### PR TITLE
YQ-4594 fixes for kqprun and fqrun

### DIFF
--- a/ydb/tests/fq/control_plane_storage/in_memory_control_plane_storage_ut.cpp
+++ b/ydb/tests/fq/control_plane_storage/in_memory_control_plane_storage_ut.cpp
@@ -39,7 +39,7 @@ public:
         EnableYDBBacktraceFormat();
 
         TFqSetupSettings settings;
-        settings.VerboseLevel = TFqSetupSettings::EVerbose::Max;
+        settings.VerbosityLevel = TFqSetupSettings::EVerbosity::InitLogs;
         settings.EnableYdbCompute = true;
 
         auto& logConfig = *settings.AppConfig.MutableLogConfig();

--- a/ydb/tests/tools/fqrun/configuration/app_config.conf
+++ b/ydb/tests/tools/fqrun/configuration/app_config.conf
@@ -104,6 +104,7 @@ FederatedQueryConfig {
     StreamingRetryCounterUpdateTime: "1d"
     TaskLeaseTtl: "30s"
     DisableCurrentIam: false
+    ResultSetsTtl: "365d"
 
     AvailableConnection: "OBJECT_STORAGE"
     AvailableConnection: "DATA_STREAMS"

--- a/ydb/tests/tools/fqrun/fqrun.cpp
+++ b/ydb/tests/tools/fqrun/fqrun.cpp
@@ -603,12 +603,12 @@ protected:
 
         fqConfig.MutablePendingFetcher()->SetPendingFetchPeriodMs(RunnerOptions.PingPeriod.MilliSeconds());
 
-        SetupLogsConfig(*appConfig.MutableLogConfig());
-
         if (!DefaultLogPriority) {
             DefaultLogPriority = DefaultLogPriorityFromVerbosity(RunnerOptions.FqSettings.VerbosityLevel);
         }
-        SetupActorSystemConfig(*appConfig.MutableActorSystemConfig());
+        SetupLogsConfig(*appConfig.MutableLogConfig());
+
+        SetupActorSystemConfig(appConfig);
 
         if (!PqFilesMapping.empty()) {
             auto fileGateway = MakeIntrusive<NYql::TDummyPqGateway>();

--- a/ydb/tests/tools/fqrun/fqrun.cpp
+++ b/ydb/tests/tools/fqrun/fqrun.cpp
@@ -536,7 +536,7 @@ protected:
                 }
             });
 
-        options.AddLongOption("single-compute-db", "Enable single compute database for analytics queries (will use local database by default), token variable YDB_COMPUTE_TOKEN")
+        auto& singleComputeOpt = options.AddLongOption("single-compute-db", "Enable single compute database for analytics queries (will use local database by default), token variable YDB_COMPUTE_TOKEN")
             .OptionalArgument("database@endpoint")
             .Handler1([this](const NLastGetopt::TOptsParser* option) {
                 RunnerOptions.FqSettings.EnableYdbCompute = true;
@@ -545,13 +545,13 @@ protected:
                 }
             });
 
-        options.AddLongOption("shared-compute-db", "Add shared compute database for analytics queries, token variable YDB_COMPUTE_TOKEN")
+        auto& sharedComputeOpt = options.AddLongOption("shared-compute-db", "Add shared compute database for analytics queries, token variable YDB_COMPUTE_TOKEN")
             .RequiredArgument("database@endpoint")
             .Handler1([this](const NLastGetopt::TOptsParser* option) {
                 RunnerOptions.FqSettings.EnableYdbCompute = true;
                 RunnerOptions.FqSettings.SharedComputeDatabases.emplace_back(TExternalDatabase::Parse(option->CurVal(), "YDB_COMPUTE_TOKEN"));
             });
-        options.MutuallyExclusive("single-compute-db", "shared-compute-db");
+        options.MutuallyExclusiveOpt(singleComputeOpt, sharedComputeOpt);
 
         options.AddLongOption("hold", "Hold fqrun process after finishing all queries")
             .NoArgument()

--- a/ydb/tests/tools/fqrun/fqrun.cpp
+++ b/ydb/tests/tools/fqrun/fqrun.cpp
@@ -592,7 +592,8 @@ protected:
         RunnerOptions.FqSettings.YqlToken = YqlToken;
         RunnerOptions.FqSettings.FunctionRegistry = CreateFunctionRegistry().Get();
 
-        auto& fqConfig = *RunnerOptions.FqSettings.AppConfig.MutableFederatedQueryConfig();
+        auto& appConfig = RunnerOptions.FqSettings.AppConfig;
+        auto& fqConfig = *appConfig.MutableFederatedQueryConfig();
         auto& gatewayConfig = *fqConfig.mutable_gateways();
         FillTokens(gatewayConfig.mutable_pq());
         FillTokens(gatewayConfig.mutable_s3());
@@ -603,6 +604,7 @@ protected:
         fqConfig.MutablePendingFetcher()->SetPendingFetchPeriodMs(RunnerOptions.PingPeriod.MilliSeconds());
 
         SetupLogsConfig();
+        SetupActorSystemConfig(*appConfig.MutableActorSystemConfig());
 
         if (!PqFilesMapping.empty()) {
             auto fileGateway = MakeIntrusive<NYql::TDummyPqGateway>();

--- a/ydb/tests/tools/fqrun/fqrun.cpp
+++ b/ydb/tests/tools/fqrun/fqrun.cpp
@@ -431,7 +431,7 @@ protected:
             .DefaultValue(0)
             .StoreResult(&RunnerOptions.FqSettings.AsyncQueriesSettings.InFlightLimit);
 
-        options.AddLongOption("verbosity", TStringBuilder() << "Common verbosity level (max level " << static_cast<ui32>(EVerbosity::Max) - 1 << ")")
+        options.AddLongOption("verbosity", TStringBuilder() << "Common verbosity level (min level 0, max level " << static_cast<ui32>(EVerbosity::Max) - 1 << ")")
             .RequiredArgument("uint")
             .DefaultValue(static_cast<ui8>(EVerbosity::Info))
             .StoreMappedResultT<ui8>(&RunnerOptions.FqSettings.VerbosityLevel, [](ui8 value) {

--- a/ydb/tests/tools/fqrun/fqrun.cpp
+++ b/ydb/tests/tools/fqrun/fqrun.cpp
@@ -293,7 +293,7 @@ void RunScript(const TExecutionOptions& executionOptions, const TRunnerOptions& 
 
 class TMain : public TMainBase {
     using TBase = TMainBase;
-    using EVerbose = TFqSetupSettings::EVerbose;
+    using EVerbosity = TFqSetupSettings::EVerbosity;
 
 protected:
     void RegisterOptions(NLastGetopt::TOpts& options) override {
@@ -431,22 +431,22 @@ protected:
             .DefaultValue(0)
             .StoreResult(&RunnerOptions.FqSettings.AsyncQueriesSettings.InFlightLimit);
 
-        options.AddLongOption("verbose", TStringBuilder() << "Common verbose level (max level " << static_cast<ui32>(EVerbose::Max) - 1 << ")")
+        options.AddLongOption("verbosity", TStringBuilder() << "Common verbosity level (max level " << static_cast<ui32>(EVerbosity::Max) - 1 << ")")
             .RequiredArgument("uint")
-            .DefaultValue(static_cast<ui8>(EVerbose::Info))
-            .StoreMappedResultT<ui8>(&RunnerOptions.FqSettings.VerboseLevel, [](ui8 value) {
-                return static_cast<EVerbose>(std::min(value, static_cast<ui8>(EVerbose::Max)));
+            .DefaultValue(static_cast<ui8>(EVerbosity::Info))
+            .StoreMappedResultT<ui8>(&RunnerOptions.FqSettings.VerbosityLevel, [](ui8 value) {
+                return static_cast<EVerbosity>(std::min(value, static_cast<ui8>(EVerbosity::Max)));
             });
 
-        TChoices<TAsyncQueriesSettings::EVerbose> verbose({
-            {"each-query", TAsyncQueriesSettings::EVerbose::EachQuery},
-            {"final", TAsyncQueriesSettings::EVerbose::Final}
+        TChoices<TAsyncQueriesSettings::EVerbosity> verbosity({
+            {"each-query", TAsyncQueriesSettings::EVerbosity::EachQuery},
+            {"final", TAsyncQueriesSettings::EVerbosity::Final}
         });
-        options.AddLongOption("async-verbose", "Verbose type for async queries")
+        options.AddLongOption("async-verbosity", "Verbosity type for async queries")
             .RequiredArgument("type")
             .DefaultValue("each-query")
-            .Choices(verbose.GetChoices())
-            .StoreMappedResultT<TString>(&RunnerOptions.FqSettings.AsyncQueriesSettings.Verbose, verbose);
+            .Choices(verbosity.GetChoices())
+            .StoreMappedResultT<TString>(&RunnerOptions.FqSettings.AsyncQueriesSettings.Verbosity, verbosity);
 
         options.AddLongOption("ping-period", "Query ping period in milliseconds")
             .RequiredArgument("uint")
@@ -606,7 +606,7 @@ protected:
         SetupLogsConfig(*appConfig.MutableLogConfig());
 
         if (!DefaultLogPriority) {
-            DefaultLogPriority = DefaultLogPriorityFromVerbose(RunnerOptions.FqSettings.VerboseLevel);
+            DefaultLogPriority = DefaultLogPriorityFromVerbosity(RunnerOptions.FqSettings.VerbosityLevel);
         }
         SetupActorSystemConfig(*appConfig.MutableActorSystemConfig());
 
@@ -626,7 +626,7 @@ protected:
         }
 
 #ifdef PROFILE_MEMORY_ALLOCATIONS
-        if (RunnerOptions.FqSettings.VerboseLevel >= EVerbose::Info) {
+        if (RunnerOptions.FqSettings.VerbosityLevel >= EVerbosity::Info) {
             Cout << CoutColors.Cyan() << "Starting profile memory allocations" << CoutColors.Default() << Endl;
         }
         NAllocProfiler::StartAllocationSampling(true);
@@ -639,7 +639,7 @@ protected:
         RunScript(ExecutionOptions, RunnerOptions);
 
 #ifdef PROFILE_MEMORY_ALLOCATIONS
-        if (RunnerOptions.FqSettings.VerboseLevel >= EVerbose::Info) {
+        if (RunnerOptions.FqSettings.VerbosityLevel >= EVerbosity::Info) {
             Cout << CoutColors.Cyan() << "Finishing profile memory allocations" << CoutColors.Default() << Endl;
         }
         FinishProfileMemoryAllocations();

--- a/ydb/tests/tools/fqrun/fqrun.cpp
+++ b/ydb/tests/tools/fqrun/fqrun.cpp
@@ -604,6 +604,10 @@ protected:
         fqConfig.MutablePendingFetcher()->SetPendingFetchPeriodMs(RunnerOptions.PingPeriod.MilliSeconds());
 
         SetupLogsConfig(*appConfig.MutableLogConfig());
+
+        if (!DefaultLogPriority) {
+            DefaultLogPriority = DefaultLogPriorityFromVerbose(RunnerOptions.FqSettings.VerboseLevel);
+        }
         SetupActorSystemConfig(*appConfig.MutableActorSystemConfig());
 
         if (!PqFilesMapping.empty()) {

--- a/ydb/tests/tools/fqrun/src/common.h
+++ b/ydb/tests/tools/fqrun/src/common.h
@@ -79,6 +79,7 @@ struct TRequestOptions {
     FederatedQuery::ExecuteMode Action = FederatedQuery::ExecuteMode::RUN;
     FederatedQuery::QueryContent::QueryType Type = FederatedQuery::QueryContent::STREAMING;
     ui64 QueryId = 0;
+    TDuration Timeout;
     TFqOptions FqOptions;
 };
 

--- a/ydb/tests/tools/fqrun/src/common.h
+++ b/ydb/tests/tools/fqrun/src/common.h
@@ -25,8 +25,14 @@ struct TFqSetupSettings : public NKikimrRun::TServerSettings {
     enum class EVerbose {
         None,
         Info,
+        LogDefaultError,
         QueriesText,
+        LogDefaultWarn,
         InitLogs,
+        LogDefaultNotice,
+        LogDefaultInfo,
+        LogDefaultDebug,
+        LogDefaultTrace,
         Max
     };
 

--- a/ydb/tests/tools/fqrun/src/common.h
+++ b/ydb/tests/tools/fqrun/src/common.h
@@ -22,7 +22,7 @@ struct TExternalDatabase {
 };
 
 struct TFqSetupSettings : public NKikimrRun::TServerSettings {
-    enum class EVerbose {
+    enum class EVerbosity {
         None,
         Info,
         LogDefaultError,
@@ -55,7 +55,7 @@ struct TFqSetupSettings : public NKikimrRun::TServerSettings {
     std::optional<TExternalDatabase> SingleComputeDatabase;
     std::vector<TExternalDatabase> SharedComputeDatabases;
 
-    EVerbose VerboseLevel = EVerbose::Info;
+    EVerbosity VerbosityLevel = EVerbosity::Info;
     NYql::IPqGatewayFactory::TPtr PqGatewayFactory;
     NKikimrRun::TAsyncQueriesSettings AsyncQueriesSettings;
 };

--- a/ydb/tests/tools/fqrun/src/fq_runner.cpp
+++ b/ydb/tests/tools/fqrun/src/fq_runner.cpp
@@ -36,12 +36,12 @@ TString CanonizeAstLogicalId(TString ast) {
 }  // anonymous namespace
 
 class TFqRunner::TImpl {
-    using EVerbose = TFqSetupSettings::EVerbose;
+    using EVerbosity = TFqSetupSettings::EVerbosity;
 
 public:
     explicit TImpl(const TRunnerOptions& options)
         : Options(options)
-        , VerboseLevel(options.FqSettings.VerboseLevel)
+        , VerbosityLevel(options.FqSettings.VerbosityLevel)
         , FqSetup(options.FqSettings)
         , CerrColors(NColorizer::AutoColors(Cerr))
         , CoutColors(NColorizer::AutoColors(Cout))
@@ -50,7 +50,7 @@ public:
     bool ExecuteQuery(const TRequestOptions& query) {
         StartTraceOpt(query.QueryId);
 
-        if (VerboseLevel >= EVerbose::QueriesText) {
+        if (VerbosityLevel >= EVerbosity::QueriesText) {
             Cout << CoutColors.Cyan() << "Starting " << FederatedQuery::QueryContent::QueryType_Name(query.Type) << " request:\n" << CoutColors.Default() << query.Query << Endl;
         }
 
@@ -88,7 +88,7 @@ public:
         if (Options.ResultOutput) {
             Cout << CoutColors.Yellow() << TInstant::Now().ToIsoStringLocal() << " Writing query results..." << CoutColors.Default() << Endl;
             for (size_t i = 0; i < ResultSets.size(); ++i) {
-                if (ResultSets.size() > 1 && VerboseLevel >= EVerbose::Info) {
+                if (ResultSets.size() > 1 && VerbosityLevel >= EVerbosity::Info) {
                     *Options.ResultOutput << CoutColors.Cyan() << "Result set " << i + 1 << ":" << CoutColors.Default() << Endl;
                 }
                 PrintResultSet(Options.ResultOutputFormat, *Options.ResultOutput, ResultSets[i]);
@@ -98,7 +98,7 @@ public:
 
     bool CreateConnections(const std::vector<FederatedQuery::ConnectionContent>& connections, const TFqOptions& options) {
         for (const auto& connection : connections) {
-            if (VerboseLevel >= EVerbose::QueriesText) {
+            if (VerbosityLevel >= EVerbosity::QueriesText) {
                 Cout << CoutColors.Cyan() << "Creating connection:\n" << CoutColors.Default() << Endl << connection.DebugString() << Endl;
             }
 
@@ -121,7 +121,7 @@ public:
 
     bool CreateBindings(const std::vector<FederatedQuery::BindingContent>& bindings, const TFqOptions& options) const {
         for (auto binding : bindings) {
-            if (VerboseLevel >= EVerbose::QueriesText) {
+            if (VerbosityLevel >= EVerbosity::QueriesText) {
                 Cout << CoutColors.Cyan() << "Creating binding:\n" << CoutColors.Default() << Endl << binding.DebugString() << Endl;
             }
 
@@ -146,7 +146,7 @@ public:
     void ExecuteQueryAsync(const TRequestOptions& query) const {
         StartTraceOpt(query.QueryId);
 
-        if (VerboseLevel >= EVerbose::QueriesText) {
+        if (VerbosityLevel >= EVerbosity::QueriesText) {
             Cout << CoutColors.Cyan() << "Starting async " << FederatedQuery::QueryContent::QueryType_Name(query.Type) << " request:\n" << CoutColors.Default() << query.Query << Endl;
         }
 
@@ -179,7 +179,7 @@ private:
             TExecutionMeta meta;
             const TRequestResult status = FqSetup.DescribeQuery(QueryId, CurrentOptions, meta);
 
-            if (const auto newIssues = meta.TransientIssues.ToString(); newIssues && previousIssues != newIssues && VerboseLevel >= EVerbose::Info) {
+            if (const auto newIssues = meta.TransientIssues.ToString(); newIssues && previousIssues != newIssues && VerbosityLevel >= EVerbosity::Info) {
                 previousIssues = newIssues;
                 Cerr << CerrColors.Red() << "Query transient issues updated:" << CerrColors.Default() << Endl << newIssues << Endl;
             }
@@ -199,7 +199,7 @@ private:
         }
 
         printStats(ExecutionMeta, true);
-        if (VerboseLevel >= EVerbose::Info) {
+        if (VerbosityLevel >= EVerbosity::Info) {
             Cout << CoutColors.Cyan() << "Query finished. Duration: " << TInstant::Now() - StartTime << CoutColors.Default() << Endl;
         }
 
@@ -228,7 +228,7 @@ private:
         }
 
         return TCachedPrinter(astOutput, [this](TString ast, IOutputStream& output) {
-            if (VerboseLevel >= EVerbose::Info) {
+            if (VerbosityLevel >= EVerbosity::Info) {
                 Cout << CoutColors.Cyan() << "Writing query ast" << CoutColors.Default() << Endl;
             }
             if (Options.CanonicalOutput) {
@@ -246,7 +246,7 @@ private:
         }
 
         return TCachedPrinter(planOutput, [this](TString plan, IOutputStream& output) {
-            if (VerboseLevel >= EVerbose::Info) {
+            if (VerbosityLevel >= EVerbosity::Info) {
                 Cout << CoutColors.Cyan() << "Writing query plan" << CoutColors.Default() << Endl;
             }
             if (!plan) {
@@ -279,7 +279,7 @@ private:
 
 private:
     const TRunnerOptions Options;
-    const EVerbose VerboseLevel;
+    const EVerbosity VerbosityLevel;
     const TFqSetup FqSetup;
     const NColorizer::TColors CerrColors;
     const NColorizer::TColors CoutColors;

--- a/ydb/tests/tools/fqrun/src/fq_setup.cpp
+++ b/ydb/tests/tools/fqrun/src/fq_setup.cpp
@@ -30,11 +30,11 @@ TRequestResult GetStatus(const NYql::TIssues& issues) {
 
 class TFqSetup::TImpl : public TKikimrSetupBase {
     using TBase = TKikimrSetupBase;
-    using EVerbose = TFqSetupSettings::EVerbose;
+    using EVerbosity = TFqSetupSettings::EVerbosity;
 
 private:
     NKikimr::Tests::TServerSettings GetServerSettings(ui32 grpcPort) {
-        auto serverSettings = TBase::GetServerSettings(Settings, grpcPort, Settings.VerboseLevel >= EVerbose::InitLogs);
+        auto serverSettings = TBase::GetServerSettings(Settings, grpcPort, Settings.VerbosityLevel >= EVerbosity::InitLogs);
 
         serverSettings.SetEnableYqGrpc(true);
 
@@ -147,7 +147,7 @@ private:
 
     void InitializeFqProxy(ui32 grpcPort) {
         const auto& fqConfig = GetFqProxyConfig(grpcPort);
-        if (Settings.VerboseLevel >= EVerbose::InitLogs) {
+        if (Settings.VerbosityLevel >= EVerbosity::InitLogs) {
             Cout << "FQ config:\n" << fqConfig.DebugString() << Endl;
         }
 
@@ -184,7 +184,7 @@ public:
         : Settings(settings)
     {
         const ui32 grpcPort = Settings.FirstGrpcPort ? Settings.FirstGrpcPort : PortManager.GetPort();
-        if (Settings.GrpcEnabled && Settings.VerboseLevel >= EVerbose::Info) {
+        if (Settings.GrpcEnabled && Settings.VerbosityLevel >= EVerbosity::Info) {
             Cout << CoutColors.Cyan() << "Domain gRPC port: " << CoutColors.Default() << grpcPort << Endl;
         }
 
@@ -194,7 +194,7 @@ public:
         InitializeServer(grpcPort);
         InitializeFqProxy(grpcPort);
 
-        if (Settings.MonitoringEnabled && Settings.VerboseLevel >= EVerbose::Info) {
+        if (Settings.MonitoringEnabled && Settings.VerbosityLevel >= EVerbosity::Info) {
             Cout << CoutColors.Cyan() << "Monitoring port: " << CoutColors.Default() << GetRuntime()->GetMonPort() << Endl;
         }
     }

--- a/ydb/tests/tools/fqrun/src/fq_setup.cpp
+++ b/ydb/tests/tools/fqrun/src/fq_setup.cpp
@@ -2,6 +2,7 @@
 #include "actors.h"
 
 #include <library/cpp/colorizer/colors.h>
+#include <library/cpp/protobuf/interop/cast.h>
 #include <library/cpp/testing/unittest/tests_data.h>
 
 #include <ydb/core/fq/libs/control_plane_proxy/events/events.h>
@@ -291,6 +292,10 @@ private:
         content.set_type(query.Type);
         content.set_text(query.Query);
         SetupAcl(content.mutable_acl());
+
+        if (const auto timeout = query.Timeout) {
+            *content.mutable_limits()->mutable_execution_deadline() = NProtoInterop::CastToProto(TInstant::Now() + timeout);
+        }
 
         return request;
     }

--- a/ydb/tests/tools/fqrun/src/ya.make
+++ b/ydb/tests/tools/fqrun/src/ya.make
@@ -9,6 +9,7 @@ SRCS(
 
 PEERDIR(
     library/cpp/colorizer
+    library/cpp/protobuf/interop
     library/cpp/testing/unittest
     ydb/core/fq/libs/config/protos
     ydb/core/fq/libs/control_plane_proxy/events

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -324,7 +324,7 @@ void RunArgumentQuery(size_t index, size_t loopId, size_t queryId, TInstant star
 }
 
 
-void RunArgumentQueries(const TExecutionOptions& executionOptions, TKqpRunner& runner) {
+void RunArgumentQueries(const TExecutionOptions& executionOptions, TKqpRunner& runner, TYdbSetupSettings::EVerbose verboseLevel) {
     NColorizer::TColors colors = NColorizer::AutoColors(Cout);
 
     if (executionOptions.SchemeQuery) {
@@ -386,10 +386,10 @@ void RunArgumentQueries(const TExecutionOptions& executionOptions, TKqpRunner& r
         }
     }
 
-    if (durations.size() > 1) {
-        auto gmean = pow(std::accumulate(durations.begin(), durations.end(), 1.0, std::multiplies<double>()), 1.0 / durations.size());
+    if (durations.size() > 1 && verboseLevel >= TYdbSetupSettings::EVerbose::Info) {
+        auto gMean = pow(std::accumulate(durations.begin(), durations.end(), 1.0, std::multiplies<double>()), 1.0 / durations.size());
         Cout << colors.Cyan()
-             << "Geometric mean of " << durations.size() << " best iterations: " << TDuration::MicroSeconds(static_cast<ui64>(gmean * 1000000.0))
+             << "Geometric mean of " << durations.size() << " best iterations: " << TDuration::MicroSeconds(static_cast<ui64>(gMean * 1000000.0))
              << colors.Default() << Endl;
     }
 

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -931,6 +931,10 @@ protected:
         queryService.SetProgressStatsPeriodMs(PingPeriod.MilliSeconds());
 
         SetupActorSystemConfig(*appConfig.MutableActorSystemConfig());
+
+        if (!DefaultLogPriority) {
+            DefaultLogPriority = DefaultLogPriorityFromVerbose(RunnerOptions.YdbSettings.VerboseLevel);
+        }
         SetupLogsConfig(*appConfig.MutableLogConfig());
 
         if (EmulateYt) {

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -931,7 +931,7 @@ protected:
         queryService.SetProgressStatsPeriodMs(PingPeriod.MilliSeconds());
 
         SetupActorSystemConfig(*appConfig.MutableActorSystemConfig());
-        SetupLogsConfig();
+        SetupLogsConfig(*appConfig.MutableLogConfig());
 
         if (EmulateYt) {
             const auto& fileStorageConfig = appConfig.GetQueryServiceConfig().GetFileStorage();
@@ -989,14 +989,6 @@ private:
         if (ExecutionOptions.UseTemplates) {
             ReplaceYqlTokenTemplate(sql);
         }
-    }
-
-    void SetupLogsConfig() {
-        auto& logConfig = *RunnerOptions.YdbSettings.AppConfig.MutableLogConfig();
-        if (DefaultLogPriority) {
-            logConfig.SetDefaultLevel(*DefaultLogPriority);
-        }
-        ModifyLogPriorities(LogPriorities, logConfig);
     }
 };
 

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -422,7 +422,7 @@ void RunScript(const TExecutionOptions& executionOptions, const TRunnerOptions& 
     TKqpRunner runner(runnerOptions);
 
     try {
-        RunArgumentQueries(executionOptions, runner);
+        RunArgumentQueries(executionOptions, runner, runnerOptions.YdbSettings.VerboseLevel);
     } catch (const yexception& exception) {
         if (runnerOptions.YdbSettings.MonitoringEnabled) {
             Cerr << colors.Red() <<  CurrentExceptionMessage() << colors.Default() << Endl;
@@ -446,7 +446,6 @@ class TMain : public TMainBase {
     TDuration PingPeriod;
     TExecutionOptions ExecutionOptions;
     TRunnerOptions RunnerOptions;
-    std::optional<ui64> UserPoolSize;
 
     std::unordered_map<TString, TString> Templates;
     THashMap<TString, TString> TablesMapping;
@@ -807,15 +806,6 @@ protected:
 
         // Cluster settings
 
-        options.AddLongOption("threads", "User pool size for each node (also scaled system, batch and IC pools in proportion: system / user / batch / IC = 1 / 10 / 1 / 1)")
-            .RequiredArgument("uint")
-            .StoreMappedResultT<ui32>(&UserPoolSize, [](ui32 threadsCount) {
-                if (threadsCount < 1) {
-                    ythrow yexception() << "Number of threads less than one";
-                }
-                return threadsCount;
-            });
-
         options.AddLongOption('N', "node-count", "Number of nodes to create")
             .RequiredArgument("uint")
             .DefaultValue(RunnerOptions.YdbSettings.NodeCount)
@@ -940,7 +930,7 @@ protected:
         }
         queryService.SetProgressStatsPeriodMs(PingPeriod.MilliSeconds());
 
-        SetupActorSystemConfig();
+        SetupActorSystemConfig(*appConfig.MutableActorSystemConfig());
         SetupLogsConfig();
 
         if (EmulateYt) {
@@ -1007,61 +997,6 @@ private:
             logConfig.SetDefaultLevel(*DefaultLogPriority);
         }
         ModifyLogPriorities(LogPriorities, logConfig);
-    }
-
-    void SetupActorSystemConfig() {
-        if (!UserPoolSize) {
-            return;
-        }
-
-        auto& asConfig = *RunnerOptions.YdbSettings.AppConfig.MutableActorSystemConfig();
-
-        if (!asConfig.HasScheduler()) {
-            auto& scheduler = *asConfig.MutableScheduler();
-            scheduler.SetResolution(64);
-            scheduler.SetSpinThreshold(0);
-            scheduler.SetProgressThreshold(10000);
-        }
-
-        asConfig.ClearExecutor();
-
-        const auto addExecutor = [&asConfig](const TString& name, ui64 threads, NKikimrConfig::TActorSystemConfig::TExecutor::EType type, std::optional<ui64> spinThreshold = std::nullopt) {
-            auto& executor = *asConfig.AddExecutor();
-            executor.SetName(name);
-            executor.SetThreads(threads);
-            executor.SetType(type);
-            if (spinThreshold) {
-                executor.SetSpinThreshold(*spinThreshold);
-            }
-            return executor;
-        };
-
-        const auto divideThreads = [](ui64 threads, ui64 divisor) {
-            if (threads < 1) {
-                ythrow yexception() << "Threads must be greater than 0";
-            }
-            return (threads - 1) / divisor + 1;
-        };
-
-        addExecutor("System", divideThreads(*UserPoolSize, 10), NKikimrConfig::TActorSystemConfig::TExecutor::BASIC, 10);
-        asConfig.SetSysExecutor(0);
-
-        addExecutor("User", *UserPoolSize, NKikimrConfig::TActorSystemConfig::TExecutor::BASIC, 1);
-        asConfig.SetUserExecutor(1);
-
-        addExecutor("Batch", divideThreads(*UserPoolSize, 10), NKikimrConfig::TActorSystemConfig::TExecutor::BASIC, 1);
-        asConfig.SetBatchExecutor(2);
-
-        addExecutor("IO", 1, NKikimrConfig::TActorSystemConfig::TExecutor::IO);
-        asConfig.SetIoExecutor(3);
-
-        addExecutor("IC", divideThreads(*UserPoolSize, 10), NKikimrConfig::TActorSystemConfig::TExecutor::BASIC, 10)
-            .SetTimePerMailboxMicroSecs(100);
-        auto& serviceExecutors = *asConfig.MutableServiceExecutor();
-        serviceExecutors.Clear();
-        auto& serviceExecutor = *serviceExecutors.Add();
-        serviceExecutor.SetServiceName("Interconnect");
-        serviceExecutor.SetExecutorId(4);
     }
 };
 

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -930,11 +930,11 @@ protected:
         }
         queryService.SetProgressStatsPeriodMs(PingPeriod.MilliSeconds());
 
-        SetupActorSystemConfig(*appConfig.MutableActorSystemConfig());
-
         if (!DefaultLogPriority) {
             DefaultLogPriority = DefaultLogPriorityFromVerbosity(RunnerOptions.YdbSettings.VerbosityLevel);
         }
+        SetupActorSystemConfig(appConfig);
+
         SetupLogsConfig(*appConfig.MutableLogConfig());
 
         if (EmulateYt) {

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -701,7 +701,7 @@ protected:
             .DefaultValue(0)
             .StoreResult(&RunnerOptions.YdbSettings.AsyncQueriesSettings.InFlightLimit);
 
-        options.AddLongOption("verbosity", TStringBuilder() << "Common verbosity level (max level " << static_cast<ui32>(EVerbosity::Max) - 1 << ")")
+        options.AddLongOption("verbosity", TStringBuilder() << "Common verbosity level (min level 0, max level " << static_cast<ui32>(EVerbosity::Max) - 1 << ")")
             .RequiredArgument("uint")
             .DefaultValue(static_cast<ui8>(EVerbosity::Info))
             .StoreMappedResultT<ui8>(&RunnerOptions.YdbSettings.VerbosityLevel, [](ui8 value) {

--- a/ydb/tests/tools/kqprun/runlib/actors.h
+++ b/ydb/tests/tools/kqprun/runlib/actors.h
@@ -95,7 +95,7 @@ public:
 
         if (response.IsSuccess()) {
             Completed_++;
-            if (Settings_.Verbose == TAsyncQueriesSettings::EVerbose::EachQuery) {
+            if (Settings_.Verbosity == TAsyncQueriesSettings::EVerbosity::EachQuery) {
                 Cout << CoutColors_.Green() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " completed. " << CoutColors_.Yellow() << GetInfoString() << CoutColors_.Default() << Endl;
             }
         } else {
@@ -103,7 +103,7 @@ public:
             Cout << CoutColors_.Red() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " failed " << response.GetStatus() << ". " << CoutColors_.Yellow() << GetInfoString() << "\n" << CoutColors_.Red() << "Issues:\n" << response.GetError() << CoutColors_.Default();
         }
 
-        if (Settings_.Verbose == TAsyncQueriesSettings::EVerbose::Final && TInstant::Now() - LastReportTime_ > TDuration::Seconds(1)) {
+        if (Settings_.Verbosity == TAsyncQueriesSettings::EVerbosity::Final && TInstant::Now() - LastReportTime_ > TDuration::Seconds(1)) {
             Cout << CoutColors_.Green() << TInstant::Now().ToIsoStringLocal() << " Finished " << Failed_ + Completed_ << " requests. " << CoutColors_.Yellow() << GetInfoString() << CoutColors_.Default() << Endl;
             LastReportTime_ = TInstant::Now();
         }
@@ -138,7 +138,7 @@ private:
             };
 
             MaxInFlight_ = std::max(MaxInFlight_, RunningRequests_.size());
-            if (Settings_.Verbose == TAsyncQueriesSettings::EVerbose::EachQuery) {
+            if (Settings_.Verbosity == TAsyncQueriesSettings::EVerbosity::EachQuery) {
                 Cout << CoutColors_.Cyan() << TInstant::Now().ToIsoStringLocal() << " Request #" << RequestId_ << " started. " << CoutColors_.Yellow() << GetInfoString() << CoutColors_.Default() << "\n";
             }
 
@@ -152,7 +152,7 @@ private:
             return false;
         }
 
-        if (Settings_.Verbose == TAsyncQueriesSettings::EVerbose::Final) {
+        if (Settings_.Verbosity == TAsyncQueriesSettings::EVerbosity::Final) {
             Cout << CoutColors_.Cyan() << TInstant::Now().ToIsoStringLocal() << " All async requests finished. " << CoutColors_.Yellow() << GetInfoString() << CoutColors_.Default() << "\n";
         }
 

--- a/ydb/tests/tools/kqprun/runlib/application.cpp
+++ b/ydb/tests/tools/kqprun/runlib/application.cpp
@@ -128,7 +128,7 @@ void TMainBase::RegisterKikimrOptions(NLastGetopt::TOpts& options, TServerSettin
 }
 
 void TMainBase::RegisterLogOptions(NLastGetopt::TOpts& options) {
-    options.AddLongOption("log-default", "Default log priority")
+    options.AddLongOption("log-default", "Default log priority (allowed log priorities: trace, debug, info, notice, warn, error, crit, alert, emerg)")
         .RequiredArgument("priority")
         .StoreMappedResultT<TString>(&DefaultLogPriority, GetLogPrioritiesMap("log-default"));
 

--- a/ydb/tests/tools/kqprun/runlib/application.cpp
+++ b/ydb/tests/tools/kqprun/runlib/application.cpp
@@ -275,10 +275,10 @@ void TMainBase::SetupLogsConfig(NKikimrConfig::TLogConfig& config) const {
         const auto descriptor = NKikimrServices::EServiceKikimr_descriptor();
         for (int i = 0; i < descriptor->value_count(); ++i) {
             const auto service = static_cast<NKikimrServices::EServiceKikimr>(descriptor->value(i)->number());
-            const auto& servicceStr = NKikimrServices::EServiceKikimr_Name(service);
+            const auto& serviceStr = NKikimrServices::EServiceKikimr_Name(service);
 
             for (const auto& prefix : prefixes) {
-                if (servicceStr.StartsWith(prefix)) {
+                if (serviceStr.StartsWith(prefix)) {
                     logPriorities.emplace(service, *priority);
                     break;
                 }

--- a/ydb/tests/tools/kqprun/runlib/application.h
+++ b/ydb/tests/tools/kqprun/runlib/application.h
@@ -35,6 +35,8 @@ protected:
 
     void ReplaceYqlTokenTemplate(TString& text) const;
 
+    void SetupActorSystemConfig(NKikimrConfig::TActorSystemConfig& config) const;
+
 protected:
     inline static NColorizer::TColors CoutColors = NColorizer::AutoColors(Cout);
     inline static IOutputStream* ProfileAllocationsOutput = nullptr;
@@ -49,6 +51,7 @@ private:
     TString UdfsDirectory;
     TVector<TString> UdfsPaths;
     bool ExcludeLinkedUdfs;
+    std::optional<ui64> UserPoolSize;
 };
 
 }  // namespace NKikimrRun

--- a/ydb/tests/tools/kqprun/runlib/application.h
+++ b/ydb/tests/tools/kqprun/runlib/application.h
@@ -35,7 +35,7 @@ protected:
 
     void ReplaceYqlTokenTemplate(TString& text) const;
 
-    void SetupActorSystemConfig(NKikimrConfig::TActorSystemConfig& config) const;
+    void SetupActorSystemConfig(NKikimrConfig::TAppConfig& config) const;
 
     void SetupLogsConfig(NKikimrConfig::TLogConfig& config) const;
 

--- a/ydb/tests/tools/kqprun/runlib/application.h
+++ b/ydb/tests/tools/kqprun/runlib/application.h
@@ -37,6 +37,8 @@ protected:
 
     void SetupActorSystemConfig(NKikimrConfig::TActorSystemConfig& config) const;
 
+    void SetupLogsConfig(NKikimrConfig::TLogConfig& config) const;
+
 protected:
     inline static NColorizer::TColors CoutColors = NColorizer::AutoColors(Cout);
     inline static IOutputStream* ProfileAllocationsOutput = nullptr;
@@ -44,6 +46,12 @@ protected:
 
     std::optional<NActors::NLog::EPriority> DefaultLogPriority;
     std::unordered_map<NKikimrServices::EServiceKikimr, NActors::NLog::EPriority> LogPriorities;
+    std::optional<NActors::NLog::EPriority> FqLogPriority;
+    std::optional<NActors::NLog::EPriority> KqpLogPriority;
+    std::optional<NActors::NLog::EPriority> RuntimeLogPriority;
+    std::optional<NActors::NLog::EPriority> TabletsLogPriority;
+    std::optional<NActors::NLog::EPriority> BsLogPriority;
+    std::optional<NActors::NLog::EPriority> ServerIoLogPriority;
 
 private:
     inline static std::vector<std::unique_ptr<TFileOutput>> FileHolders;

--- a/ydb/tests/tools/kqprun/runlib/kikimr_setup.cpp
+++ b/ydb/tests/tools/kqprun/runlib/kikimr_setup.cpp
@@ -108,6 +108,23 @@ NKikimr::Tests::TServerSettings TKikimrSetupBase::GetServerSettings(const TServe
     return serverSettings;
 }
 
+std::optional<NKikimrWhiteboard::TSystemStateInfo> TKikimrSetupBase::GetSystemStateInfo(TIntrusivePtr<NKikimr::NMemory::IProcessMemoryInfoProvider> memoryInfoProvider) {
+    if (!memoryInfoProvider) {
+        return std::nullopt;
+    }
+
+    NKikimrWhiteboard::TSystemStateInfo systemStateInfo;
+
+    const auto& memInfo = memoryInfoProvider->Get();
+    if (memInfo.CGroupLimit) {
+        systemStateInfo.SetMemoryLimit(*memInfo.CGroupLimit);
+    } else if (memInfo.MemTotal) {
+        systemStateInfo.SetMemoryLimit(*memInfo.MemTotal);
+    }
+
+    return systemStateInfo;
+}
+
 void TKikimrSetupBase::SetLoggerSettings(const TServerSettings& settings, NKikimr::Tests::TServerSettings& serverSettings) const {
     auto loggerInitializer = [this, settings](NActors::TTestActorRuntime& runtime) {
         InitLogSettings(settings.AppConfig.GetLogConfig(), runtime);

--- a/ydb/tests/tools/kqprun/runlib/kikimr_setup.cpp
+++ b/ydb/tests/tools/kqprun/runlib/kikimr_setup.cpp
@@ -66,7 +66,7 @@ TAutoPtr<TLogBackend> TKikimrSetupBase::CreateLogBackend(const TServerSettings& 
     }
 }
 
-NKikimr::Tests::TServerSettings TKikimrSetupBase::GetServerSettings(const TServerSettings& settings, ui32 grpcPort, bool verbose) {
+NKikimr::Tests::TServerSettings TKikimrSetupBase::GetServerSettings(const TServerSettings& settings, ui32 grpcPort, bool verbosity) {
     const ui32 msgBusPort = PortManager.GetPort();
 
     NKikimr::Tests::TServerSettings serverSettings(msgBusPort, settings.AppConfig.GetAuthConfig(), settings.AppConfig.GetPQConfig());
@@ -89,7 +89,7 @@ NKikimr::Tests::TServerSettings TKikimrSetupBase::GetServerSettings(const TServe
     serverSettings.S3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
     serverSettings.SetDqTaskTransformFactory(NYql::CreateYtDqTaskTransformFactory(true));
     serverSettings.SetInitializeFederatedQuerySetupFactory(true);
-    serverSettings.SetVerbose(verbose);
+    serverSettings.SetVerbose(verbosity);
     serverSettings.SetNeedStatsCollectors(true);
     serverSettings.SetEnableStorageProxy(settings.AppConfig.GetQueryServiceConfig().GetCheckpointsConfig().GetEnabled());
 

--- a/ydb/tests/tools/kqprun/runlib/kikimr_setup.h
+++ b/ydb/tests/tools/kqprun/runlib/kikimr_setup.h
@@ -4,6 +4,7 @@
 
 #include <library/cpp/logger/backend.h>
 
+#include <ydb/core/protos/node_whiteboard.pb.h>
 #include <ydb/core/testlib/test_client.h>
 
 namespace NKikimrRun {
@@ -15,6 +16,8 @@ public:
     TAutoPtr<TLogBackend> CreateLogBackend(const TServerSettings& settings) const;
 
     NKikimr::Tests::TServerSettings GetServerSettings(const TServerSettings& settings, ui32 grpcPort, bool verbosity);
+
+    static std::optional<NKikimrWhiteboard::TSystemStateInfo> GetSystemStateInfo(TIntrusivePtr<NKikimr::NMemory::IProcessMemoryInfoProvider> memoryInfoProvider);
 
 private:
     void SetLoggerSettings(const TServerSettings& settings, NKikimr::Tests::TServerSettings& serverSettings) const;

--- a/ydb/tests/tools/kqprun/runlib/kikimr_setup.h
+++ b/ydb/tests/tools/kqprun/runlib/kikimr_setup.h
@@ -14,7 +14,7 @@ public:
 
     TAutoPtr<TLogBackend> CreateLogBackend(const TServerSettings& settings) const;
 
-    NKikimr::Tests::TServerSettings GetServerSettings(const TServerSettings& settings, ui32 grpcPort, bool verbose);
+    NKikimr::Tests::TServerSettings GetServerSettings(const TServerSettings& settings, ui32 grpcPort, bool verbosity);
 
 private:
     void SetLoggerSettings(const TServerSettings& settings, NKikimr::Tests::TServerSettings& serverSettings) const;

--- a/ydb/tests/tools/kqprun/runlib/settings.h
+++ b/ydb/tests/tools/kqprun/runlib/settings.h
@@ -14,13 +14,13 @@ namespace NKikimrRun {
 constexpr char YQL_TOKEN_VARIABLE[] = "YQL_TOKEN";
 
 struct TAsyncQueriesSettings {
-    enum class EVerbose {
+    enum class EVerbosity {
         EachQuery,
         Final,
     };
 
     ui64 InFlightLimit = 0;
-    EVerbose Verbose = EVerbose::EachQuery;
+    EVerbosity Verbosity = EVerbosity::EachQuery;
 };
 
 struct TServerSettings {

--- a/ydb/tests/tools/kqprun/runlib/utils.cpp
+++ b/ydb/tests/tools/kqprun/runlib/utils.cpp
@@ -121,14 +121,11 @@ void TStatsPrinter::PrintInProgressStatistics(const TString& plan, IOutputStream
         auto publicStat = StatProcessor->GetPublicStat(fullStat);
 
         output << "\nCPU usage: " << cpuUsage << Endl;
-        PrintStatistics(fullStat, flatStat, publicStat, output);
+        PrintStatistics(fullStat, flatStat, publicStat, convertedPlan, output);
     } catch (const NJson::TJsonException& ex) {
         output << "Error stat conversion: " << ex.what() << Endl;
         return;
     }
-
-    output << "\nPlan visualization:" << Endl;
-    PrintPlan(convertedPlan, output);
 }
 
 void TStatsPrinter::PrintTimeline(const TString& plan, IOutputStream& output) {
@@ -137,7 +134,7 @@ void TStatsPrinter::PrintTimeline(const TString& plan, IOutputStream& output) {
     output.Write(planVisualizer.PrintSvg());
 }
 
-void TStatsPrinter::PrintStatistics(const TString& fullStat, const THashMap<TString, i64>& flatStat, const NFq::TPublicStat& publicStat, IOutputStream& output) {
+void TStatsPrinter::PrintStatistics(const TString& fullStat, const THashMap<TString, i64>& flatStat, const NFq::TPublicStat& publicStat, const TString& plan, IOutputStream& output) const {
     output << "\nFlat statistics:" << Endl;
     for (const auto& [propery, value] : flatStat) {
         TString valueString = ToString(value);
@@ -175,6 +172,9 @@ void TStatsPrinter::PrintStatistics(const TString& fullStat, const THashMap<TStr
     if (auto runningTasks = publicStat.RunningTasks) {
         output << "RunningTasks = " << FormatNumber(*runningTasks) << Endl;
     }
+
+    output << "\nPlan visualization:" << Endl;
+    PrintPlan(plan, output);
 
     output << "\nFull statistics:" << Endl;
     NJson::TJsonValue statsJson;

--- a/ydb/tests/tools/kqprun/runlib/utils.h
+++ b/ydb/tests/tools/kqprun/runlib/utils.h
@@ -133,24 +133,24 @@ TValue GetValue(size_t index, const std::vector<TValue>& values, TValue defaultV
     return values[std::min(index, values.size() - 1)];
 }
 
-template <typename EVerbose>
-std::optional<NActors::NLog::EPriority> DefaultLogPriorityFromVerbose(EVerbose verbose) {
-    if (verbose >= EVerbose::LogDefaultTrace) {
+template <typename EVerbosity>
+std::optional<NActors::NLog::EPriority> DefaultLogPriorityFromVerbosity(EVerbosity verbosity) {
+    if (verbosity >= EVerbosity::LogDefaultTrace) {
         return NActors::NLog::EPriority::PRI_TRACE;
     }
-    if (verbose >= EVerbose::LogDefaultDebug) {
+    if (verbosity >= EVerbosity::LogDefaultDebug) {
         return NActors::NLog::EPriority::PRI_DEBUG;
     }
-    if (verbose >= EVerbose::LogDefaultInfo) {
+    if (verbosity >= EVerbosity::LogDefaultInfo) {
         return NActors::NLog::EPriority::PRI_INFO;
     }
-    if (verbose >= EVerbose::LogDefaultNotice) {
+    if (verbosity >= EVerbosity::LogDefaultNotice) {
         return NActors::NLog::EPriority::PRI_NOTICE;
     }
-    if (verbose >= EVerbose::LogDefaultWarn) {
+    if (verbosity >= EVerbosity::LogDefaultWarn) {
         return NActors::NLog::EPriority::PRI_WARN;
     }
-    if (verbose >= EVerbose::LogDefaultError) {
+    if (verbosity >= EVerbosity::LogDefaultError) {
         return NActors::NLog::EPriority::PRI_ERROR;
     }
     return std::nullopt;

--- a/ydb/tests/tools/kqprun/runlib/utils.h
+++ b/ydb/tests/tools/kqprun/runlib/utils.h
@@ -85,7 +85,7 @@ public:
 
     static void PrintTimeline(const TString& plan, IOutputStream& output);
 
-    static void PrintStatistics(const TString& fullStat, const THashMap<TString, i64>& flatStat, const NFq::TPublicStat& publicStat, IOutputStream& output);
+    void PrintStatistics(const TString& fullStat, const THashMap<TString, i64>& flatStat, const NFq::TPublicStat& publicStat, const TString& plan, IOutputStream& output) const;
 
     // Function adds thousands separators
     // 123456789 -> 123.456.789

--- a/ydb/tests/tools/kqprun/runlib/utils.h
+++ b/ydb/tests/tools/kqprun/runlib/utils.h
@@ -133,4 +133,27 @@ TValue GetValue(size_t index, const std::vector<TValue>& values, TValue defaultV
     return values[std::min(index, values.size() - 1)];
 }
 
+template <typename EVerbose>
+std::optional<NActors::NLog::EPriority> DefaultLogPriorityFromVerbose(EVerbose verbose) {
+    if (verbose >= EVerbose::LogDefaultTrace) {
+        return NActors::NLog::EPriority::PRI_TRACE;
+    }
+    if (verbose >= EVerbose::LogDefaultDebug) {
+        return NActors::NLog::EPriority::PRI_DEBUG;
+    }
+    if (verbose >= EVerbose::LogDefaultInfo) {
+        return NActors::NLog::EPriority::PRI_INFO;
+    }
+    if (verbose >= EVerbose::LogDefaultNotice) {
+        return NActors::NLog::EPriority::PRI_NOTICE;
+    }
+    if (verbose >= EVerbose::LogDefaultWarn) {
+        return NActors::NLog::EPriority::PRI_WARN;
+    }
+    if (verbose >= EVerbose::LogDefaultError) {
+        return NActors::NLog::EPriority::PRI_ERROR;
+    }
+    return std::nullopt;
+}
+
 }  // namespace NKikimrRun

--- a/ydb/tests/tools/kqprun/scripts/flame_graph.sh
+++ b/ydb/tests/tools/kqprun/scripts/flame_graph.sh
@@ -8,7 +8,7 @@ if [ $# -gt 3 ]; then
 fi
 
 COLLECTION_TIME=${1:-'30'}
-echo "Flame graph collection will be finished after $COLLECTION_TIME seconds or by ^C"
+echo "Flame graph collection will be finished in $COLLECTION_TIME seconds or by ^C"
 
 SUDO=""
 

--- a/ydb/tests/tools/kqprun/scripts/flame_graph.sh
+++ b/ydb/tests/tools/kqprun/scripts/flame_graph.sh
@@ -17,7 +17,8 @@ if (( ${2:-''} )); then
 fi
 
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
-FLAME_GRAPH_TOOL="$SCRIPT_DIR/../../../../../contrib/tools/flame-graph/"
+ROOT_DIR=$(cd $SCRIPT_DIR && git rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR/../../../../../..")
+FLAME_GRAPH_TOOL="$ROOT_DIR/contrib/tools/flame-graph/"
 
 TARGET_PID=$(pgrep -u $USER ${3:-'kqprun'})
 

--- a/ydb/tests/tools/kqprun/src/actors.cpp
+++ b/ydb/tests/tools/kqprun/src/actors.cpp
@@ -124,7 +124,7 @@ protected:
 
 class TResourcesWaiterActor : public NActors::TActorBootstrapped<TResourcesWaiterActor> {
     using IRetryPolicy = IRetryPolicy<bool>;
-    using EVerbose = TYdbSetupSettings::EVerbose;
+    using EVerbosity = TYdbSetupSettings::EVerbosity;
     using EHealthCheck = TYdbSetupSettings::EHealthCheck;
 
     static constexpr TDuration REFRESH_PERIOD = TDuration::MilliSeconds(10);
@@ -251,7 +251,7 @@ private:
         }
 
         if (auto delay = RetryState_->GetNextRetryDelay(shortRetry)) {
-            if (Settings_.VerboseLevel >= EVerbose::InitLogs) {
+            if (Settings_.VerbosityLevel >= EVerbosity::InitLogs) {
                 const TString str = TStringBuilder() << CoutColors_.Cyan() << "Retry for database '" << Settings_.Database << "' in " << *delay << " " << message << CoutColors_.Default();
                 Cout << str << Endl;
             }
@@ -267,7 +267,7 @@ private:
     }
 
     void FailTimeout() {
-        Fail(TStringBuilder() << "Health check timeout " << Settings_.HealthCheckTimeout << " exceeded for database '" << Settings_.Database << "', use --health-check-timeout for increasing it or check out health check logs by using --verbose " << static_cast<ui32>(EVerbose::InitLogs));
+        Fail(TStringBuilder() << "Health check timeout " << Settings_.HealthCheckTimeout << " exceeded for database '" << Settings_.Database << "', use --health-check-timeout for increasing it or check out health check logs by using --verbosity " << static_cast<ui32>(EVerbosity::InitLogs));
     }
 
     void Fail(const TString& error) {
@@ -292,13 +292,13 @@ private:
 };
 
 class TSessionHolderActor : public NActors::TActorBootstrapped<TSessionHolderActor> {
-    using EVerbose = TYdbSetupSettings::EVerbose;
+    using EVerbosity = TYdbSetupSettings::EVerbosity;
 
 public:
     TSessionHolderActor(TCreateSessionRequest request, NThreading::TPromise<TString> openPromise, NThreading::TPromise<void> closePromise)
         : TargetNode_(request.TargetNode)
         , TraceId_(request.Event->Record.GetTraceId())
-        , VerboseLevel_(request.VerboseLevel)
+        , VerbosityLevel_(request.VerbosityLevel)
         , Request_(std::move(request.Event))
         , OpenPromise_(openPromise)
         , ClosePromise_(closePromise)
@@ -317,7 +317,7 @@ public:
         }
 
         SessionId_ = response.GetResponse().GetSessionId();
-        if (VerboseLevel_ >= EVerbose::Info) {
+        if (VerbosityLevel_ >= EVerbosity::Info) {
             Cout << CoutColors_.Cyan() << "Created new session on node " << TargetNode_ << " with id " << SessionId_ << "\n";
         }
 
@@ -395,7 +395,7 @@ private:
 private:
     const ui32 TargetNode_;
     const TString TraceId_;
-    const EVerbose VerboseLevel_;
+    const EVerbosity VerbosityLevel_;
     const NColorizer::TColors CoutColors_ = NColorizer::AutoColors(Cout);
 
     std::unique_ptr<NKikimr::NKqp::TEvKqp::TEvCreateSessionRequest> Request_;

--- a/ydb/tests/tools/kqprun/src/actors.h
+++ b/ydb/tests/tools/kqprun/src/actors.h
@@ -28,14 +28,14 @@ struct TQueryRequest {
 struct TCreateSessionRequest {
     std::unique_ptr<NKikimr::NKqp::TEvKqp::TEvCreateSessionRequest> Event;
     ui32 TargetNode;
-    TYdbSetupSettings::EVerbose VerboseLevel;
+    TYdbSetupSettings::EVerbosity VerbosityLevel;
 };
 
 struct TWaitResourcesSettings {
     i32 ExpectedNodeCount;
     TYdbSetupSettings::EHealthCheck HealthCheckLevel;
     TDuration HealthCheckTimeout;
-    TYdbSetupSettings::EVerbose VerboseLevel;
+    TYdbSetupSettings::EVerbosity VerbosityLevel;
     TString Database;
 };
 

--- a/ydb/tests/tools/kqprun/src/common.h
+++ b/ydb/tests/tools/kqprun/src/common.h
@@ -20,8 +20,14 @@ struct TYdbSetupSettings : public NKikimrRun::TServerSettings {
     enum class EVerbose {
         None,
         Info,
+        LogDefaultError,
         QueriesText,
+        LogDefaultWarn,
         InitLogs,
+        LogDefaultNotice,
+        LogDefaultInfo,
+        LogDefaultDebug,
+        LogDefaultTrace,
         Max
     };
 

--- a/ydb/tests/tools/kqprun/src/common.h
+++ b/ydb/tests/tools/kqprun/src/common.h
@@ -17,7 +17,7 @@ constexpr ui64 DEFAULT_STORAGE_SIZE = 32_GB;
 constexpr TDuration TENANT_CREATION_TIMEOUT = TDuration::Seconds(30);
 
 struct TYdbSetupSettings : public NKikimrRun::TServerSettings {
-    enum class EVerbose {
+    enum class EVerbosity {
         None,
         Info,
         LogDefaultError,
@@ -51,7 +51,7 @@ struct TYdbSetupSettings : public NKikimrRun::TServerSettings {
     std::optional<ui64> DiskSize;
 
     bool TraceOptEnabled = false;
-    EVerbose VerboseLevel = EVerbose::Info;
+    EVerbosity VerbosityLevel = EVerbosity::Info;
     NKikimrRun::TAsyncQueriesSettings AsyncQueriesSettings;
 
     NYql::IPqGateway::TPtr PqGateway;

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -365,17 +365,7 @@ private:
     }
 
     void InitializeTenants(TPortGenerator& grpcPortGen) const {
-        std::optional<NKikimrWhiteboard::TSystemStateInfo> systemStateInfo;
-        if (const auto memoryInfoProvider = Server_->GetProcessMemoryInfoProvider()) {
-            systemStateInfo = NKikimrWhiteboard::TSystemStateInfo();
-
-            const auto& memInfo = memoryInfoProvider->Get();
-            if (memInfo.CGroupLimit) {
-                systemStateInfo->SetMemoryLimit(*memInfo.CGroupLimit);
-            } else if (memInfo.MemTotal) {
-                systemStateInfo->SetMemoryLimit(*memInfo.MemTotal);
-            }
-        }
+        const auto& systemStateInfo = GetSystemStateInfo(Server_->GetProcessMemoryInfoProvider());
 
         std::vector<NThreading::TFuture<void>> futures(1, InitializeTenantNodes(Settings_.DomainName, systemStateInfo, grpcPortGen));
         futures.reserve(StorageMeta_.GetTenants().size() + 1);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* Added `threads` flag for fqrun
* Added `timeout` flag for fqrun
* Flame graph now stops also by ^C
* Fixed flame graph script run from arcadia
* Added log settings for large components (FQ / KQP / DQ & MKQL / Tablets / Blob Storage / Server IO)
* Now `--verbosity` flag also increase default log priority 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->