### PR TITLE
Make metadata response be sent after topic response is received

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -53,6 +53,7 @@ void TKafkaMetadataActor::Bootstrap(const TActorContext& ctx) {
     }
 
     Become(&TKafkaMetadataActor::StateWork);
+    RespondIfRequired(ctx);
 }
 
 void TKafkaMetadataActor::SendDiscoveryRequest() {
@@ -342,9 +343,6 @@ void TKafkaMetadataActor::AddBroker(ui64 nodeId, const TString& host, ui64 port)
 }
 
 void TKafkaMetadataActor::RespondIfRequired(const TActorContext& ctx) {
-    if (InflyCreateTopics != 0) {
-        return;
-    }
     auto Respond = [&] {
         Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, Response, ErrorCode));
         Die(ctx);
@@ -358,7 +356,7 @@ void TKafkaMetadataActor::RespondIfRequired(const TActorContext& ctx) {
         Respond();
         return;
     }
-    if (PendingResponses != 0) {
+    if (PendingResponses != 0 || InflyCreateTopics != 0) {
         return;
     }
 

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -53,7 +53,6 @@ void TKafkaMetadataActor::Bootstrap(const TActorContext& ctx) {
     }
 
     Become(&TKafkaMetadataActor::StateWork);
-    RespondIfRequired(ctx);
 }
 
 void TKafkaMetadataActor::SendDiscoveryRequest() {
@@ -279,6 +278,7 @@ void TKafkaMetadataActor::HandleLocationResponse(TEvLocationResponse::TPtr ev, c
                 << locationResponse->Status << ", Issues=" << locationResponse->Issues.ToOneLineString());
             AddTopicError(topic, ConvertErrorCode(locationResponse->Status));
         } else if (status == Ydb::StatusIds::SCHEME_ERROR && TopicСreationAttempts.find(*topic.Name) == TopicСreationAttempts.end()) {
+            KAFKA_LOG_D("Sending create topic'" << topic.Name << "' request");
             TopicСreationAttempts.insert(*topic.Name);
             SendCreateTopicsRequest(*topic.Name, index, ctx);
         }
@@ -342,6 +342,9 @@ void TKafkaMetadataActor::AddBroker(ui64 nodeId, const TString& host, ui64 port)
 }
 
 void TKafkaMetadataActor::RespondIfRequired(const TActorContext& ctx) {
+    if (InflyCreateTopics != 0) {
+        return;
+    }
     auto Respond = [&] {
         Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, Response, ErrorCode));
         Die(ctx);

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -281,6 +281,7 @@ void TKafkaMetadataActor::HandleLocationResponse(TEvLocationResponse::TPtr ev, c
         } else if (status == Ydb::StatusIds::SCHEME_ERROR && TopicСreationAttempts.find(*topic.Name) == TopicСreationAttempts.end()) {
             KAFKA_LOG_D("Sending create topic'" << topic.Name << "' request");
             TopicСreationAttempts.insert(*topic.Name);
+            PendingResponses++;
             SendCreateTopicsRequest(*topic.Name, index, ctx);
         }
     }
@@ -296,6 +297,7 @@ void TKafkaMetadataActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const TA
     const TString& topicName = topicNameToIndex.TopicName;
     const ui32& topicIndex = topicNameToIndex.TopicIndex;
     InflyCreateTopics--;
+    PendingResponses--;
     EKafkaErrors errorCode = ev->Get()->ErrorCode;
     if (errorCode == EKafkaErrors::NONE_ERROR) {
         TActorId child = SendTopicRequest(topicName);
@@ -356,7 +358,7 @@ void TKafkaMetadataActor::RespondIfRequired(const TActorContext& ctx) {
         Respond();
         return;
     }
-    if (PendingResponses != 0 || InflyCreateTopics != 0) {
+    if (PendingResponses != 0) {
         return;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Resolve error with flapping test because of responses' race
Pr to main: https://github.com/ydb-platform/ydb/pull/23797

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
