### PR TITLE
Fix audit logging to stderr: don't add newline if input already ends on it (#23745)

### DIFF
--- a/ydb/library/actors/core/log.cpp
+++ b/ydb/library/actors/core/log.cpp
@@ -20,7 +20,9 @@ namespace {
             , Buf(rec.Len + 1)
         {
             Buf.Append(rec.Data, rec.Len);
-            *Buf.Proceed(1) = '\n';
+            if (rec.Len > 0 && rec.Data[rec.Len - 1] != '\n') {
+                *Buf.Proceed(1) = '\n';
+            }
         }
 
         operator TLogRecord() const {


### PR DESCRIPTION
(cherry picked from commit 2773f6f1fe2542fa7c18fcee5d563448c01c24a0)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
