### PR TITLE
Tests TxUsage::Sinks_*_WriteToTopicAndTable_*

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/topic_to_table_ut.cpp
@@ -484,25 +484,33 @@ std::vector<TResultSet> TFixture::TTableSession::Execute(const std::string& quer
                                                          bool commit,
                                                          const TParams& params)
 {
-    auto txTable = dynamic_cast<NTable::TTransaction*>(tx);
-    auto txControl = NTable::TTxControl::Tx(*txTable).CommitTx(commit);
+    while (true) {
+        auto txTable = dynamic_cast<NTable::TTransaction*>(tx);
+        auto txControl = NTable::TTxControl::Tx(*txTable).CommitTx(commit);
 
-    auto result = Session_.ExecuteDataQuery(query, txControl, params).GetValueSync();
-    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-
-    return std::move(result).ExtractResultSets();
+        auto result = Session_.ExecuteDataQuery(query, txControl, params).GetValueSync();
+        if (result.GetStatus() != EStatus::SESSION_BUSY) {
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            return std::move(result).ExtractResultSets();
+        }
+        std::this_thread::sleep_for(100ms);
+    }
 }
 
 TFixture::ISession::TExecuteInTxResult TFixture::TTableSession::ExecuteInTx(const std::string& query,
                                                                             bool commit,
                                                                             const TParams& params)
 {
-    auto txControl = NTable::TTxControl::BeginTx().CommitTx(commit);
+    while (true) {
+        auto txControl = NTable::TTxControl::BeginTx().CommitTx(commit);
 
-    auto result = Session_.ExecuteDataQuery(query, txControl, params).GetValueSync();
-    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-
-    return {std::move(result).ExtractResultSets(), std::make_unique<NTable::TTransaction>(*result.GetTransaction())};
+        auto result = Session_.ExecuteDataQuery(query, txControl, params).GetValueSync();
+        if (result.GetStatus() != EStatus::SESSION_BUSY) {
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            return {std::move(result).ExtractResultSets(), std::make_unique<NTable::TTransaction>(*result.GetTransaction())};
+        }
+        std::this_thread::sleep_for(100ms);
+    }
 }
 
 std::unique_ptr<TTransactionBase> TFixture::TTableSession::BeginTx()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The logs of the failed tests contain the error message `Pending previous query completion`. It looks like they forgot to process SESSION_BUSY somewhere.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
