### PR TITLE
EXT-1426 Add grpc_method to audit log for grpc requests

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -96,6 +96,9 @@ class TGrpcRequestCheckActor
     using TSelf = TGrpcRequestCheckActor<TEvent>;
     using TBase = TActorBootstrappedSecureRequest<TGrpcRequestCheckActor>;
 
+    static constexpr bool IsHttpRequest = std::is_same_v<TEvent, TEvRequestAuthAndCheck>;
+    static constexpr bool IsGrpcRequest = !IsHttpRequest;
+
 public:
     void OnAccessDenied(const TEvTicketParser::TError& error, const TActorContext& ctx) {
         LOG_INFO(ctx, NKikimrServices::GRPC_SERVER, error.ToString());
@@ -504,8 +507,13 @@ private:
             auditEnabledReceived |= AppData()->AuditConfig.EnableLogging(auditMode.LogClass, NKikimrConfig::TAuditConfig::TLogClassConfig::Received, subjectType);
         }
 
-        const TString sanitizedToken = TBase::GetSanitizedToken();
         if (auditEnabledReceived || auditEnabledCompleted) {
+            if constexpr (IsGrpcRequest) {
+                if (const auto* reqCtx = dynamic_cast<const IRequestCtx*>(requestBaseCtx)) {
+                    requestBaseCtx->AddAuditLogPart("grpc_method", reqCtx->GetRpcMethodName());
+                }
+            }
+            const TString sanitizedToken = TBase::GetSanitizedToken();
             AuditContextStart(requestBaseCtx, databaseName, userSID, sanitizedToken, Attributes_);
             if (auditEnabledReceived) {
                 AuditLog(std::nullopt, requestBaseCtx->GetAuditLogParts());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add a new field `grpc.method` for grpc requests to audit logs.
An example for export request:
```json
{
    "component": "grpc-proxy",
    "operation": "ExportToS3Request", // old field, not touched
    "grpc.method": "Ydb.Export.V1.ExportService/ExportToS3", // new field
    ... // other fields
}
```
