### PR TITLE
Invalid OverridePlanner now raises an error

### DIFF
--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -649,6 +649,7 @@ public:
                     rootIssue.AddSubIssue(MakeIntrusive<NYql::TIssue>(issue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO)));
                 }
                 ctx.AddError(rootIssue);
+                return false;
             }
         }
 


### PR DESCRIPTION
Error in OverridePlanner pragma parsing is now shown to the user and not suspended