### PR TITLE
Do not allow non-bootstrap command as first config-changing for cluster

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -419,6 +419,7 @@ namespace NKikimr::NStorage {
             bool IsDistconfDisabledQuorum = false;
             std::optional<NKikimrBlobStorage::TStorageConfig> PropositionBase;
             std::optional<NKikimrBlobStorage::TStorageConfig> ConfigToPropose;
+            bool AutomaticBootstrap = false;
         };
         TProcessCollectConfigsResult ProcessCollectConfigs(TEvGather::TCollectConfigs *res,
             std::optional<TStringBuf> selfAssemblyUUID);

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -407,6 +407,8 @@ namespace NKikimr::NStorage {
             (ProposedConfig, proposedConfig),
             (CanPropose, canPropose));
 
+        bool automaticBootstrap = false;
+
         if (!canPropose) {
             // we can't propose any configuration here, just ignore
         } else if (proposedConfig) { // we have proposition in progress, resume
@@ -434,6 +436,7 @@ namespace NKikimr::NStorage {
                     return {.ErrorReason = *error};
                 }
                 configToPropose = baseConfig;
+                automaticBootstrap = true;
             }
         }
 
@@ -441,6 +444,7 @@ namespace NKikimr::NStorage {
             return {
                 .PropositionBase = std::move(propositionBase),
                 .ConfigToPropose = *configToPropose,
+                .AutomaticBootstrap = automaticBootstrap,
             };
         }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -24,6 +24,7 @@ namespace NKikimr::NStorage {
         std::shared_ptr<TLifetimeToken> RequestHandlerToken = std::make_shared<TLifetimeToken>();
 
         bool InvokedWithoutScepter = false;
+        bool EnablingDistconf = false;
 
     public: // Error handling
         struct TExError : yexception {
@@ -160,7 +161,7 @@ namespace NKikimr::NStorage {
         void AdvanceGeneration();
         void StartProposition(NKikimrBlobStorage::TStorageConfig *config, bool acceptLocalQuorum = false,
             bool requireScepter = true, bool mindPrev = true,
-            const NKikimrBlobStorage::TStorageConfig *propositionBase = nullptr);
+            const NKikimrBlobStorage::TStorageConfig *propositionBase = nullptr, bool fromBootstrap = false);
         void Handle(TEvPrivate::TEvConfigProposed::TPtr ev);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_common.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_common.cpp
@@ -184,7 +184,7 @@ namespace NKikimr::NStorage {
                     } else if (r.ConfigToPropose) {
                         StartProposition(&r.ConfigToPropose.value(), /*acceptLocalQuorum=*/ true,
                             /*requireScepter=*/ false, /*mindPrev=*/ true,
-                            r.PropositionBase ? &r.PropositionBase.value() : nullptr);
+                            r.PropositionBase ? &r.PropositionBase.value() : nullptr, r.AutomaticBootstrap);
                     } else {
                         Finish(TResult::OK, std::nullopt);
                     }
@@ -234,7 +234,8 @@ namespace NKikimr::NStorage {
     }
 
     void TInvokeRequestHandlerActor::StartProposition(NKikimrBlobStorage::TStorageConfig *config, bool acceptLocalQuorum,
-            bool requireScepter, bool mindPrev, const NKikimrBlobStorage::TStorageConfig *propositionBase) {
+            bool requireScepter, bool mindPrev, const NKikimrBlobStorage::TStorageConfig *propositionBase,
+            bool fromBootstrap) {
         if (!Self->HasConnectedNodeQuorum(*config, acceptLocalQuorum)) {
             throw TExError() << "No quorum to start propose/commit configuration";
         } else if (requireScepter && !Self->Scepter) {
@@ -283,6 +284,10 @@ namespace NKikimr::NStorage {
 
         if (!propositionBase) {
             propositionBase = Self->StorageConfig.get();
+        }
+
+        if (propositionBase && !propositionBase->GetGeneration() && !fromBootstrap) {
+            throw TExError() << "First distconf config-changing command has to be BootstrapCluster";
         }
 
         Y_ABORT_UNLESS(InvokePipelineGeneration == Self->InvokePipelineGeneration);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Do not allow non-bootstrap command as first config-changing for cluster

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch makes it impossible to execute any config-changing command as first for the cluster.
