### PR TITLE
Hash join utils

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.cpp
@@ -1,0 +1,279 @@
+#include "accumulator.h"
+
+#include <cstdlib>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+#include <yql/essentials/utils/prefetch.h>
+
+#include <arrow/util/bit_util.h>
+
+#include "histogram.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+// -----------------------------------------------------------------------
+THolder<TAccumulator> TAccumulator::Create(
+    const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets)
+{
+    // according to https://www.cidrdb.org/cidr2019/papers/p133-zhang-cidr19.pdf
+    if (log2Buckets <= 6)
+    {
+        return MakeHolder<TAccumulatorImpl>(
+            layout, bitShift, log2Buckets, std::move(packedTupleBuckets), std::move(overflowBuckets));
+    }
+
+    if (log2Buckets <= 13 && layout->TotalRowSize <= 128 && layout->VariableColumns.empty()) // tuple is too wide SMB will not help us, because the number of tuples that fit into the buffer will be small
+    {
+        return MakeHolder<TSMBAccumulatorImpl>(
+           layout, bitShift, log2Buckets, std::move(packedTupleBuckets), std::move(overflowBuckets));
+    }
+
+    return MakeHolder<TAccumulatorImpl>(
+        layout, bitShift, log2Buckets, std::move(packedTupleBuckets), std::move(overflowBuckets));
+}
+
+THolder<TAccumulator> TAccumulator::Create(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets) {
+    // according to https://www.cidrdb.org/cidr2019/papers/p133-zhang-cidr19.pdf
+    if (log2Buckets <= 6)
+    {
+        return MakeHolder<TAccumulatorImpl>(layout, bitShift, log2Buckets);
+    }
+
+    if (log2Buckets <= 13 && layout->TotalRowSize <= 128 && layout->VariableColumns.empty()) // tuple is too wide SMB will not help us, because the number of tuples that fit into the buffer will be small
+    {
+        return MakeHolder<TSMBAccumulatorImpl>(layout, bitShift, log2Buckets);
+    }
+
+    return MakeHolder<TAccumulatorImpl>(layout, bitShift, log2Buckets);
+}
+
+// -----------------------------------------------------------------------
+TAccumulatorImpl::TAccumulatorImpl(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets)
+    : NBuckets_(1 << log2Buckets)
+    , Layout_(layout)
+    , PackedTupleBucketSizes_(NBuckets_, 0)
+    , OverflowBucketSizes_(NBuckets_, 0)
+    , PackedTupleBuckets_(NBuckets_)
+    , OverflowBuckets_(NBuckets_)
+{
+    Shift_ = sizeof(ui32) * 8 - (log2Buckets + bitShift);
+    Mask_ = (1u << log2Buckets) - 1;
+}
+
+TAccumulatorImpl::TAccumulatorImpl(
+    const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets
+)
+    : NBuckets_(1 << log2Buckets)
+    , Layout_(layout)
+    , PackedTupleBucketSizes_(NBuckets_, 0)
+    , OverflowBucketSizes_(NBuckets_, 0)
+    , NoAllocations_(true)
+    , PackedTupleBuckets_(std::move(packedTupleBuckets))
+    , OverflowBuckets_(std::move(overflowBuckets))
+{
+    Shift_ = sizeof(ui32) * 8 - (log2Buckets + bitShift);
+    Mask_ = (1u << log2Buckets) - 1;
+}
+
+void TAccumulatorImpl::AddData(const ui8* data, const ui8* overflow, ui32 nItems) {
+    const auto layoutTotalRowSize = Layout_->TotalRowSize;
+
+    if (!NoAllocations_) {
+        Histogram hist;
+        hist.AddData(Layout_, data, nItems, TAccumulator::GetBucketId, Shift_, Mask_);
+        std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(NBuckets_, {0, 0});
+        hist.EstimateSizes(sizes);
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets_[i].resize(PackedTupleBuckets_[i].size() + TLsize);
+            OverflowBuckets_[i].resize(OverflowBuckets_[i].size() + Osize);
+        }
+    }
+
+    for (ui32 i = 0; i < nItems; ++i) {
+        const ui8* tuple = data + i * layoutTotalRowSize;
+        const ui32 bucketId = GetBucketId(ReadUnaligned<ui32>(tuple), Shift_, Mask_);
+        NYql::PrefetchForRead(tuple + layoutTotalRowSize * 32);
+
+        ui8* ptStoreAddr = PackedTupleBuckets_[bucketId].data() + PackedTupleBucketSizes_[bucketId];
+        ui8* ovStoreAddr = OverflowBuckets_[bucketId].data() + OverflowBucketSizes_[bucketId];
+        NYql::PrefetchForWrite(ptStoreAddr + layoutTotalRowSize);
+
+        Layout_->TupleDeepCopy(tuple, overflow, ptStoreAddr, ovStoreAddr, OverflowBucketSizes_[bucketId]);
+        PackedTupleBucketSizes_[bucketId] += layoutTotalRowSize;
+    }
+}
+
+TAccumulatorImpl::TBucketRef TAccumulatorImpl::GetBucket(ui32 bucket) const {
+    return {
+        &PackedTupleBuckets_[bucket],
+        &OverflowBuckets_[bucket],
+        static_cast<ui32>(PackedTupleBucketSizes_[bucket] / Layout_->TotalRowSize),
+        Layout_
+    };
+}
+
+void TAccumulatorImpl::Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) {
+    buckets.clear();
+    for (size_t i = 0; i < PackedTupleBuckets_.size(); ++i) {
+        ui32 NTuples = static_cast<ui32>(PackedTupleBucketSizes_[i] / Layout_->TotalRowSize);
+        buckets.emplace_back(
+            std::move(PackedTupleBuckets_[i]), std::move(OverflowBuckets_[i]), NTuples, Layout_);
+        PackedTupleBuckets_[i].clear();
+        PackedTupleBucketSizes_[i] = 0;
+    }
+}
+
+// -----------------------------------------------------------------------
+
+static constexpr size_t kSMBSize = 2 * 1024 * 1024;
+
+TSMBAccumulatorImpl::TSMBAccumulatorImpl(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets)
+    : NBuckets_(1 << log2Buckets)
+    , Layout_(layout)
+    , PackedTupleBucketSizes_(NBuckets_, 0)
+    , OverflowBucketSizes_(NBuckets_, 0)
+    , PackedTupleBuckets_(NBuckets_)
+    , OverflowBuckets_(NBuckets_)
+    , PackedTupleSMB_(kSMBSize)
+    , OverflowSMB_(kSMBSize)
+{
+    Shift_ = sizeof(ui32) * 8 - (log2Buckets + bitShift);
+    Mask_ = (1u << log2Buckets) - 1;
+
+    std::memset(PackedTupleSMB_.data(), 0, kSMBSize);
+    std::memset(OverflowSMB_.data(), 0, kSMBSize);
+}
+
+TSMBAccumulatorImpl::TSMBAccumulatorImpl(
+    const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets
+)
+    : NBuckets_(1 << log2Buckets)
+    , Layout_(layout)
+    , PackedTupleBucketSizes_(NBuckets_, 0)
+    , OverflowBucketSizes_(NBuckets_, 0)
+    , NoAllocations_(true)
+    , PackedTupleBuckets_(std::move(packedTupleBuckets))
+    , OverflowBuckets_(std::move(overflowBuckets))
+    , PackedTupleSMB_(kSMBSize + sizeof(ui64) * NBuckets_)
+    , OverflowSMB_(kSMBSize)
+{
+    Shift_ = sizeof(ui32) * 8 - (log2Buckets + bitShift);
+    Mask_ = (1u << log2Buckets) - 1;
+
+    std::memset(PackedTupleSMB_.data(), 0, kSMBSize + sizeof(ui64) * NBuckets_);
+    std::memset(OverflowSMB_.data(), 0, kSMBSize);
+}
+
+void TSMBAccumulatorImpl::AddData(const ui8* data, const ui8* overflow, ui32 nItems) {
+    const auto layoutTotalRowSize = Layout_->TotalRowSize;
+    const ui64 maxBytesPerPartition = kSMBSize / NBuckets_; // in SMB
+    const ui64 maxTuplesPerPartition = maxBytesPerPartition / layoutTotalRowSize;
+
+    const ui8 hasVarSized = static_cast<ui8>(Layout_->VariableColumns.size() > 0);
+
+    if (!NoAllocations_) {
+        Histogram hist;
+        hist.AddData(Layout_, data, nItems, TAccumulator::GetBucketId, Shift_, Mask_);
+        std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(NBuckets_, {0, 0});
+        hist.EstimateSizes(sizes);
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets_[i].resize(PackedTupleBuckets_[i].size() + TLsize);
+            OverflowBuckets_[i].resize(OverflowBuckets_[i].size() + Osize);
+        }
+    }
+
+    ui8* ptSmbPartAddr = nullptr;
+    ui8* ovSmbPartAddr = nullptr;
+    ui8* ptStoreAddr = nullptr;
+    ui8* ovStoreAddr = nullptr;
+    for (ui32 i = 0; i < nItems; ++i) {
+        const ui8* tuple = data + i * layoutTotalRowSize;
+        const ui32 bucketId = GetBucketId(ReadUnaligned<ui32>(tuple), Shift_, Mask_);
+        NYql::PrefetchForRead(tuple + layoutTotalRowSize * 32);
+        auto [nPackedTuples, bytesOverflow] = GetCounters(bucketId, maxBytesPerPartition);
+
+        ptSmbPartAddr = PackedTupleSMB_.data() + bucketId * (maxBytesPerPartition + sizeof(ui64)) + sizeof(ui64); // take bucket in SMB
+        if (nPackedTuples == maxTuplesPerPartition) {
+            ui8* storeAddr = PackedTupleBuckets_[bucketId].data() + PackedTupleBucketSizes_[bucketId];
+            std::memcpy(storeAddr, ptSmbPartAddr, layoutTotalRowSize * nPackedTuples);
+            PackedTupleBucketSizes_[bucketId] += layoutTotalRowSize * nPackedTuples;
+            nPackedTuples = 0;
+        }
+        ptStoreAddr = ptSmbPartAddr + nPackedTuples * layoutTotalRowSize; // take last packed tuple
+
+        // WARNING: do not use SMB with var sized column, because it works slow. Code here is just for demonstration
+        if (hasVarSized) {
+            ovSmbPartAddr = OverflowSMB_.data() + bucketId * maxBytesPerPartition; // take bucket in SMB
+            if (bytesOverflow + Layout_->GetTupleVarSize(tuple) >= maxTuplesPerPartition) {
+                ui8* storeAddr = OverflowBuckets_[bucketId].data() + OverflowBucketSizes_[bucketId];
+                std::memcpy(storeAddr, ovSmbPartAddr, bytesOverflow);
+                OverflowBucketSizes_[bucketId] += bytesOverflow;
+                bytesOverflow = 0;
+            }
+            ovStoreAddr = ovSmbPartAddr + bytesOverflow; // offset
+        } else {
+            nPackedTuples++;
+            NYql::PrefetchForWrite(ptSmbPartAddr + nPackedTuples * layoutTotalRowSize);
+            Layout_->TupleDeepCopy(tuple, overflow, ptStoreAddr, ovStoreAddr, bytesOverflow);
+            WriteUnaligned<ui64>(ptSmbPartAddr - sizeof(ui64), (bytesOverflow << 32) | nPackedTuples);
+        }
+    }
+
+    // flush remaining data in SMB to buckets
+    for (ui32 bucketId = 0; bucketId < NBuckets_; ++bucketId) {
+        auto [nPackedTuples, bytesOverflow] = GetCounters(bucketId, maxBytesPerPartition);
+
+        ptSmbPartAddr = PackedTupleSMB_.data() + bucketId * (maxBytesPerPartition + sizeof(ui64)) + sizeof(ui64); // take bucket in SMB
+        ui8* storeAddr = PackedTupleBuckets_[bucketId].data() + PackedTupleBucketSizes_[bucketId];
+        std::memcpy(storeAddr, ptSmbPartAddr, layoutTotalRowSize * nPackedTuples);
+        PackedTupleBucketSizes_[bucketId] += layoutTotalRowSize * nPackedTuples;
+
+        ovSmbPartAddr = OverflowSMB_.data() + bucketId * maxBytesPerPartition; // take bucket in SMB
+        storeAddr = OverflowBuckets_[bucketId].data() + OverflowBucketSizes_[bucketId];
+        std::memcpy(storeAddr, ovSmbPartAddr, bytesOverflow);
+        OverflowBucketSizes_[bucketId] += bytesOverflow;
+
+        WriteUnaligned<ui64>(ptSmbPartAddr - sizeof(ui64), 0);
+    }
+}
+
+std::pair<ui64, ui64> TSMBAccumulatorImpl::GetCounters(ui32 bucket, ui64 maxBytesPerPartition) {
+    auto counters = ReadUnaligned<ui64>(PackedTupleSMB_.data() + bucket * (maxBytesPerPartition + sizeof(ui64)));
+    ui64 nPackedTuples = counters & 0xFFFFFFFF;
+    ui64 bytesOverflow = (counters >> 32) & 0xFFFFFFFF;
+    return {nPackedTuples, bytesOverflow};
+}
+
+TSMBAccumulatorImpl::TBucketRef TSMBAccumulatorImpl::GetBucket(ui32 bucket) const {
+    return {
+        &PackedTupleBuckets_[bucket],
+        &OverflowBuckets_[bucket],
+        static_cast<ui32>(PackedTupleBucketSizes_[bucket] / Layout_->TotalRowSize),
+        Layout_
+    };
+}
+
+void TSMBAccumulatorImpl::Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) {
+    buckets.clear();
+    for (size_t i = 0; i < PackedTupleBuckets_.size(); ++i) {
+        ui32 NTuples = static_cast<ui32>(PackedTupleBucketSizes_[i] / Layout_->TotalRowSize);
+        buckets.emplace_back(
+            std::move(PackedTupleBuckets_[i]), std::move(OverflowBuckets_[i]), NTuples, Layout_);
+        PackedTupleBuckets_[i].clear();
+        PackedTupleBucketSizes_[i] = 0;
+    }
+}
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+
+#include <util/generic/buffer.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+/*
+* Class TAccumulator is used to split provided vector of tuples to buckets using provided key hashes.
+*/
+class TAccumulator {
+public:
+    using TBuffer = std::vector<ui8, TMKQLAllocator<ui8>>;
+
+    struct TBucketRef {
+        const TBuffer*      PackedTuples;
+        const TBuffer*      Overflow;
+        ui32                NTuples;    // Count of elements in a bucket
+        const TTupleLayout* Layout;     // Layout for packed row (tuple)
+    };
+
+    struct TBucket {
+        TBuffer             PackedTuples;
+        TBuffer             Overflow;
+        ui32                NTuples;    // Count of elements in a bucket
+        const TTupleLayout* Layout;     // Layout for packed row (tuple)
+    };
+
+public:
+    virtual ~TAccumulator() = default;
+
+    // Create new accumulator for log2Buckets for given layout using given memory.
+    // Accumulator will not allocate any memory
+    static THolder<TAccumulator> Create(
+        const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets);
+
+    // Create new accumulator for log2Buckets for given layout.
+    // Accumulator will manage memory by itself
+    static THolder<TAccumulator> Create(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets);
+
+    // Add new nItems of data in TTupleLayout representation to accumulator 
+    virtual void AddData(const ui8* data, const ui8* overflow, ui32 nItems) = 0;
+
+    // Return bucket reference
+    virtual TBucketRef GetBucket(ui32 bucket) const = 0;
+
+    // Detach and return all buckets. Once this method has been called, the accumulator object can no longer be used
+    virtual void Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) = 0;
+
+    // Get bucket id
+    inline static ui32 GetBucketId(ui32 hash, ui32 shift, ui32 mask) {
+        return (hash >> shift) & mask;
+    }
+};
+
+// Simple radix partitioning algorithm using software prefetching technique to improve performance.
+// Suitable when number of buckets small (<= 32) or very big (> 1024)
+class TAccumulatorImpl: public TAccumulator {
+public:
+    TAccumulatorImpl(
+        const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets);
+
+    TAccumulatorImpl(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets);
+
+    ~TAccumulatorImpl() = default;
+
+    void AddData(const ui8* data, const ui8* overflow, ui32 nItems) override;
+
+    TBucketRef GetBucket(ui32 bucket) const override;
+
+    void Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) override;
+
+private:
+    ui32 NBuckets_{0};                                                   // Number of buckets
+    ui32 Shift_{0};                                                      // Mask used for partitioning tuples 
+    ui32 Mask_{0};                                                  // Bits count to write buckets number in binary
+    const TTupleLayout* Layout_;                                         // Tuple layout
+    std::vector<ui64, TMKQLAllocator<ui64>> PackedTupleBucketSizes_;     // Sizes for filled part of packed tuple buckets
+    std::vector<ui64, TMKQLAllocator<ui64>> OverflowBucketSizes_;        // Sizes for filled part of overflow buckets
+    bool NoAllocations_{false};                                          // Do not allocate any memory for buckets
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets_;   // Buckets for packed tuples
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets_;      // Buckets for overflow buffers
+};
+
+// Simple radix partitioning algorithm using software buffer technique to improve performance.
+class TSMBAccumulatorImpl: public TAccumulator {
+public:
+    TSMBAccumulatorImpl(
+        const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets);
+
+    TSMBAccumulatorImpl(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets);
+
+    ~TSMBAccumulatorImpl() = default;
+
+    void AddData(const ui8* data, const ui8* overflow, ui32 nItems) override;
+
+    TBucketRef GetBucket(ui32 bucket) const override;
+
+    void Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) override;
+
+private:
+    using THugePageBuffer = std::vector<ui8, TMKQLHugeAllocator<ui8>>;
+
+private:
+    std::pair<ui64, ui64> GetCounters(ui32 bucket, ui64 maxBytesPerPartition);
+
+private:
+    ui32 NBuckets_{0};                                                   // Number of buckets
+    ui32 Shift_{0};                                                      // Mask used for partitioning tuples 
+    ui32 Mask_{0};                                                  // Bits count to write buckets number in binary
+    const TTupleLayout* Layout_;                                         // Tuple layout
+    std::vector<ui64, TMKQLAllocator<ui64>> PackedTupleBucketSizes_;     // Sizes for filled part of packed tuple buckets
+    std::vector<ui64, TMKQLAllocator<ui64>> OverflowBucketSizes_;        // Sizes for filled part of overflow buckets
+    bool NoAllocations_{false};                                          // Do not allocate any memory for buckets
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets_;   // Buckets for packed tuples
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets_;      // Buckets for overflow buffers
+    THugePageBuffer PackedTupleSMB_;                                     // SMB for packed tuples
+    THugePageBuffer OverflowSMB_;                                        // SMB for overflow
+};
+
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.cpp
@@ -1,0 +1,604 @@
+#include "block_layout_converter.h"
+
+#include <yql/essentials/minikql/arrow/arrow_util.h>
+#include <yql/essentials/minikql/mkql_type_builder.h>
+#include <yql/essentials/public/decimal/yql_decimal.h>
+#include <yql/essentials/public/udf/arrow/defs.h>
+#include <yql/essentials/public/udf/arrow/dispatch_traits.h>
+#include <yql/essentials/public/udf/arrow/util.h>
+#include <yql/essentials/public/udf/udf_type_inspection.h>
+#include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/public/udf/udf_value_builder.h>
+#include <yql/essentials/utils/yql_panic.h>
+
+#include <arrow/array/data.h>
+#include <arrow/datum.h>
+
+#include <util/generic/vector.h>
+
+namespace NKikimr::NMiniKQL {
+
+struct IColumnDataExtractor {
+    using TPtr = std::unique_ptr<IColumnDataExtractor>;
+
+    virtual ~IColumnDataExtractor() = default;
+
+    virtual TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) = 0;
+    virtual TVector<ui8*> GetNullBitmap(std::shared_ptr<arrow::ArrayData> array) = 0;
+    virtual ui32 GetElementSize() = 0;
+    virtual NPackedTuple::EColumnSizeType GetElementSizeType() = 0;
+    virtual std::shared_ptr<arrow::ArrayData> ReserveArray(const TVector<ui64>& bytes, ui32 len, [[maybe_unused]] bool isBitmapNull = false) = 0;
+    // Ugly interface, but I dont care
+    virtual void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) = 0;
+};
+
+// ------------------------------------------------------------
+
+template <typename TLayout, bool Nullable>
+class TFixedSizeColumnDataExtractor : public IColumnDataExtractor {
+public:
+    TFixedSizeColumnDataExtractor(arrow::MemoryPool* pool, TType* type)
+        : Pool_(pool)
+        , Type_(type)
+    {}
+
+    TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() == 2);
+
+        return {array->GetMutableValues<ui8>(1)};
+    }
+
+    TVector<ui8*> GetNullBitmap(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() > 0);
+
+        return {array->GetMutableValues<ui8>(0)};
+    }
+
+    ui32 GetElementSize() override {
+        return sizeof(TLayout);
+    }
+
+    NPackedTuple::EColumnSizeType GetElementSizeType() override {
+        return NPackedTuple::EColumnSizeType::Fixed;
+    }
+
+    std::shared_ptr<arrow::ArrayData> ReserveArray(const TVector<ui64>& bytes, ui32 len, [[maybe_unused]] bool isBitmapNull = false) override {
+        Y_ENSURE(bytes.size() == 1);
+        auto bytesCount = bytes.front();
+        Y_ENSURE(bytesCount == len * GetElementSize());
+
+        std::shared_ptr<arrow::DataType> type;
+        auto isConverted = ConvertArrowType(Type_, type);
+        Y_ENSURE(isConverted);
+
+        std::shared_ptr<arrow::Buffer> nullBitmap;
+        if (!isBitmapNull) {
+            nullBitmap = NUdf::AllocateBitmapWithReserve(len, Pool_);
+        }
+        auto dataBuffer = NUdf::AllocateResizableBuffer(bytesCount, Pool_);
+
+        return arrow::ArrayData::Make(std::move(type), len, {std::move(nullBitmap), std::move(dataBuffer)});
+    }
+
+    void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) override {
+        extractors.push_back(this);
+    }
+
+protected:
+    arrow::MemoryPool* Pool_;
+    TType* Type_;
+};
+
+template <bool Nullable>
+class TResourceColumnDataExtractor : public IColumnDataExtractor {
+public:
+    TResourceColumnDataExtractor(arrow::MemoryPool* pool, TType* type)
+        : Pool_(pool)
+        , Type_(type)
+    {}
+
+    TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() == 2);
+        Y_ENSURE(array->child_data.empty());
+
+        return {array->GetMutableValues<ui8>(1)};
+    }
+
+    TVector<ui8*> GetNullBitmap(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() > 0);
+
+        return {array->GetMutableValues<ui8>(0)};
+    }
+
+    ui32 GetElementSize() override {
+        return sizeof(NUdf::TUnboxedValue);
+    }
+
+    NPackedTuple::EColumnSizeType GetElementSizeType() override {
+        return NPackedTuple::EColumnSizeType::Fixed;
+    }
+
+    std::shared_ptr<arrow::ArrayData> ReserveArray(const TVector<ui64>& bytes, ui32 len, [[maybe_unused]] bool isBitmapNull = false) override {
+        Y_ENSURE(bytes.size() == 1);
+        auto bytesCount = bytes.front();
+        Y_ENSURE(bytesCount == len * GetElementSize());
+
+        std::shared_ptr<arrow::DataType> type;
+        auto isConverted = ConvertArrowType(Type_, type);
+        Y_ENSURE(isConverted);
+
+        std::shared_ptr<arrow::Buffer> nullBitmap;
+        if (!isBitmapNull) {
+            nullBitmap = NUdf::AllocateBitmapWithReserve(len, Pool_);
+        }
+        auto dataBuffer = NUdf::AllocateResizableBuffer<NUdf::TResizableManagedBuffer<NUdf::TUnboxedValue>>(bytesCount, Pool_);
+        ARROW_OK(dataBuffer->Resize(bytesCount));
+
+        return arrow::ArrayData::Make(std::move(type), len, {std::move(nullBitmap), std::move(dataBuffer)});
+    }
+
+    void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) override {
+        extractors.push_back(this);
+    }
+
+protected:
+    arrow::MemoryPool* Pool_;
+    TType* Type_;
+};
+
+class TSingularColumnDataExtractor : public IColumnDataExtractor {
+public:
+    TSingularColumnDataExtractor(arrow::MemoryPool* pool, TType* type) {
+        Y_UNUSED(pool, type);
+    }
+
+    TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) override {
+        return {array->GetMutableValues<ui8>(0)}; // nullptr
+    }
+
+    TVector<ui8*> GetNullBitmap(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_UNUSED(array);
+        return {nullptr};
+    }
+
+    ui32 GetElementSize() override {
+        return 1; // or 0?
+    }
+
+    NPackedTuple::EColumnSizeType GetElementSizeType() override {
+        return NPackedTuple::EColumnSizeType::Fixed;
+    }
+
+    std::shared_ptr<arrow::ArrayData> ReserveArray(const TVector<ui64>& bytes, ui32 len, [[maybe_unused]] bool isBitmapNull = false) override {
+        Y_UNUSED(bytes);
+        return arrow::ArrayData::Make(arrow::null(), len, {nullptr}, len);
+    }
+
+    void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) override {
+        extractors.push_back(this);
+    }
+};
+
+template <typename TStringType, bool Nullable>
+class TStringColumnDataExtractor : public IColumnDataExtractor {
+    using TOffset = typename TStringType::offset_type;
+
+public:
+    TStringColumnDataExtractor(arrow::MemoryPool* pool, TType* type)
+        : Pool_(pool)
+        , Type_(type)
+    {}
+
+    TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() == 3);
+        Y_ENSURE(array->child_data.empty());
+
+        return {array->GetMutableValues<ui8>(1), array->GetMutableValues<ui8>(2)};
+    }
+
+    TVector<ui8*> GetNullBitmap(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() > 0);
+
+        return {array->GetMutableValues<ui8>(0), nullptr};
+    }
+
+    ui32 GetElementSize() override {
+        return 16; // for now threshold for variable sized types is 16 bytes
+    }
+
+    NPackedTuple::EColumnSizeType GetElementSizeType() override {
+        return NPackedTuple::EColumnSizeType::Variable;
+    }
+
+    std::shared_ptr<arrow::ArrayData> ReserveArray(const TVector<ui64>& bytes, ui32 len, [[maybe_unused]] bool isBitmapNull = false) override {
+        Y_ENSURE(bytes.size() == 1);
+        auto bytesCount = bytes.front();
+
+        std::shared_ptr<arrow::DataType> type;
+        auto isConverted = ConvertArrowType(Type_, type);
+        Y_ENSURE(isConverted);
+
+        std::shared_ptr<arrow::Buffer> nullBitmap;
+        if (!isBitmapNull) {
+            nullBitmap = NUdf::AllocateBitmapWithReserve(len, Pool_);
+        }
+        auto offsetBuffer = NUdf::AllocateResizableBuffer(sizeof(TOffset) * (len + 1), Pool_);
+        // zeroize offsets buffer, or your code will die
+        // low-level unpack expects that first offset is set to null
+        std::memset(offsetBuffer->mutable_data(), 0, sizeof(TOffset) * (len + 1));
+        auto dataBuffer = NUdf::AllocateResizableBuffer(bytesCount, Pool_);
+
+        return arrow::ArrayData::Make(std::move(type), len, {std::move(nullBitmap), std::move(offsetBuffer), std::move(dataBuffer)});
+    }
+
+    void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) override {
+        extractors.push_back(this);
+    }
+
+protected:
+    arrow::MemoryPool* Pool_;
+    TType* Type_;
+};
+
+template <bool Nullable>
+class TTupleColumnDataExtractor : public IColumnDataExtractor {
+public:
+    TTupleColumnDataExtractor(
+        std::vector<IColumnDataExtractor::TPtr> children, arrow::MemoryPool* pool, TType* type
+    )
+        : Children_(std::move(children))
+        , Pool_(pool)
+        , Type_(type)
+    {}
+
+    TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() == 1);
+
+        TVector<ui8*> childrenData;
+        Y_ENSURE(array->child_data.size() == Children_.size());
+
+        for (size_t i = 0; i < Children_.size(); i++) {
+            auto data = Children_[i]->GetColumnsData(array->child_data[i]);
+            childrenData.insert(childrenData.end(), data.begin(), data.end());
+        }
+
+        return childrenData;
+    }
+
+    TVector<ui8*> GetNullBitmap(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() == 1);
+
+        TVector<ui8*> childrenData;
+        Y_ENSURE(array->child_data.size() == Children_.size());
+
+        for (size_t i = 0; i < Children_.size(); i++) {
+            auto data = Children_[i]->GetNullBitmap(array->child_data[i]);
+            childrenData.insert(childrenData.end(), data.begin(), data.end());
+        }
+
+        return childrenData;
+    }
+
+    ui32 GetElementSize() override {
+        THROW yexception() << "Do not call GetElementSize on tuples";
+    }
+
+    NPackedTuple::EColumnSizeType GetElementSizeType() override {
+        THROW yexception() << "Do not call GetElementSizeType on tuples";
+    }
+
+    std::shared_ptr<arrow::ArrayData> ReserveArray(const TVector<ui64>& bytes, ui32 len, [[maybe_unused]] bool isBitmapNull = false) override {
+        std::shared_ptr<arrow::DataType> type;
+        auto isConverted = ConvertArrowType(Type_, type);
+        Y_ENSURE(isConverted);
+
+        std::shared_ptr<arrow::Buffer> nullBitmap;
+        if (!isBitmapNull) {
+            nullBitmap = NUdf::AllocateBitmapWithReserve(len, Pool_);
+        }
+        std::vector<std::shared_ptr<arrow::ArrayData>> reservedChildren;
+        for (size_t i = 0; i < Children_.size(); i++) {
+            reservedChildren.push_back(Children_[i]->ReserveArray({bytes[i]}, len)); // TODO: handle recursive tuple, only one level of nesting is available now
+        }
+
+        return arrow::ArrayData::Make(std::move(type), len, {std::move(nullBitmap)}, std::move(reservedChildren));
+    }
+
+    void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) override {
+        for (auto& child: Children_) {
+            child->AppendInnerExtractors(extractors);
+        }
+    }
+
+protected:
+    TTupleColumnDataExtractor() = default;
+
+protected:
+    std::vector<IColumnDataExtractor::TPtr> Children_;
+    arrow::MemoryPool* Pool_;
+    TType* Type_;
+};
+
+template<typename TDate, bool Nullable>
+class TTzDateColumnDataExtractor : public TTupleColumnDataExtractor<Nullable> {
+    using TBase = TTupleColumnDataExtractor<Nullable>;
+    using TDateLayout = typename NUdf::TDataType<TDate>::TLayout;
+
+public:
+    TTzDateColumnDataExtractor(arrow::MemoryPool* pool, TType* type) {
+        this->Pool_ = pool;
+        this->Type_ = type;
+        this->Children_.push_back(std::make_unique<TFixedSizeColumnDataExtractor<TDateLayout, false>>(pool, type));
+        this->Children_.push_back(std::make_unique<TFixedSizeColumnDataExtractor<ui16, false>>(pool, type));
+    }
+};
+
+// TODO: Doesn't supported yet, use nullable parameter in type instead
+class TExternalOptionalColumnDataExtractor : public IColumnDataExtractor {
+public:
+    TExternalOptionalColumnDataExtractor(
+        IColumnDataExtractor::TPtr inner, arrow::MemoryPool* pool, TType* type
+    )
+        : Inner_(std::move(inner))
+        , Pool_(pool)
+        , Type_(type)
+    {}
+
+    TVector<ui8*> GetColumnsData(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() == 1);
+        Y_ENSURE(array->child_data.size() == 1);
+
+        return Inner_->GetColumnsData(array->child_data[0]);
+    }
+
+    TVector<ui8*> GetNullBitmap(std::shared_ptr<arrow::ArrayData> array) override {
+        Y_ENSURE(array->buffers.size() > 0);
+
+        return Inner_->GetNullBitmap(array);
+    }
+
+    ui32 GetElementSize() override {
+        return Inner_->GetElementSize();
+    }
+
+    NPackedTuple::EColumnSizeType GetElementSizeType() override {
+        return Inner_->GetElementSizeType();
+    }
+
+    std::shared_ptr<arrow::ArrayData> ReserveArray(const TVector<ui64>& bytes, ui32 len, [[maybe_unused]] bool isBitmapNull = false) override {
+        std::shared_ptr<arrow::DataType> type;
+        auto isConverted = ConvertArrowType(Type_, type);
+        Y_ENSURE(isConverted);
+
+        std::shared_ptr<arrow::Buffer> nullBitmap;
+        if (!isBitmapNull) {
+            nullBitmap = NUdf::AllocateBitmapWithReserve(len, Pool_);
+        }
+        auto reservedInner = Inner_->ReserveArray(bytes, len);
+
+        return arrow::ArrayData::Make(std::move(type), len, {std::move(nullBitmap)}, {std::move(reservedInner)});
+    }
+
+    void AppendInnerExtractors(std::vector<IColumnDataExtractor*>& extractors) override {
+        extractors.push_back(this);
+    }
+
+private:
+    IColumnDataExtractor::TPtr Inner_;
+    arrow::MemoryPool* Pool_;
+    TType* Type_;
+};
+
+// ------------------------------------------------------------
+
+struct TColumnDataExtractorTraits {
+    using TResult = IColumnDataExtractor;
+    template <bool Nullable>
+    using TTuple = TTupleColumnDataExtractor<Nullable>;
+    template <typename T, bool Nullable>
+    using TFixedSize = TFixedSizeColumnDataExtractor<T, Nullable>;
+    template <typename TStringType, bool Nullable, NKikimr::NUdf::EDataSlot>
+    using TStrings = TStringColumnDataExtractor<TStringType, Nullable>;
+    using TExtOptional = TExternalOptionalColumnDataExtractor;
+    template<bool Nullable>
+    using TResource = TResourceColumnDataExtractor<Nullable>;
+    template<typename TTzDate, bool Nullable>
+    using TTzDateReader = TTzDateColumnDataExtractor<TTzDate, Nullable>;
+    using TSingular = TSingularColumnDataExtractor;
+
+    constexpr static bool PassType = false;
+
+    static TResult::TPtr MakePg(const NUdf::TPgTypeDescription& desc, const NUdf::IPgBuilder* pgBuilder, arrow::MemoryPool* pool, TType* type) {
+        Y_UNUSED(pgBuilder);
+        if (desc.PassByValue) {
+            return std::make_unique<TFixedSize<ui64, true>>(pool, type);
+        } else {
+            return std::make_unique<TStrings<arrow::BinaryType, true, NKikimr::NUdf::EDataSlot::String>>(pool, type);
+        }
+    }
+
+    static TResult::TPtr MakeSingular(arrow::MemoryPool* pool, TType* type) {
+        return std::make_unique<TSingular>(pool, type);
+    }
+
+    static TResult::TPtr MakeResource(bool isOptional, arrow::MemoryPool* pool, TType* type) {
+        if (isOptional) {
+            return std::make_unique<TResource<true>>(pool, type);
+        } else {
+            return std::make_unique<TResource<false>>(pool, type);
+        }
+    }
+
+    template<typename TTzDate>
+    static TResult::TPtr MakeTzDate(bool isOptional, arrow::MemoryPool* pool, TType* type) {
+        if (isOptional) {
+            return std::make_unique<TTzDateReader<TTzDate, true>>(pool, type);
+        } else {
+            return std::make_unique<TTzDateReader<TTzDate, false>>(pool, type);
+        }
+    }
+};
+
+// ------------------------------------------------------------
+
+class TBlockLayoutConverter : public IBlockLayoutConverter {
+    auto GetColumns_(const TVector<arrow::Datum>& columns) {
+        Y_ENSURE(columns.size() == Extractors_.size());
+
+        std::fill(IsBitmapNull_.begin(), IsBitmapNull_.end(), false);
+        TVector<const ui8*> columnsData;
+        TVector<const ui8*> columnsNullBitmap;
+
+        for (size_t i = 0; i < columns.size(); ++i) {
+            const auto& column = columns[i];
+
+            auto data = Extractors_[i]->GetColumnsData(column.array());
+            columnsData.insert(columnsData.end(), data.begin(), data.end());
+
+            auto nullBitmap = Extractors_[i]->GetNullBitmap(column.array());
+            columnsNullBitmap.insert(columnsNullBitmap.end(), nullBitmap.begin(), nullBitmap.end());
+            if (nullBitmap.front() == nullptr) {
+                IsBitmapNull_[i] = true;
+            }
+        }
+
+        return std::pair{std::move(columnsData), std::move(columnsNullBitmap)};
+    }
+
+public:
+    TBlockLayoutConverter(
+        TVector<IColumnDataExtractor::TPtr>&& extractors,
+        const TVector<NPackedTuple::EColumnRole>& roles,
+        bool rememberNullBitmaps = true // remember bitmaps which are equal to nullptr to not allocate memory for them in unpack
+    )
+        : Extractors_(std::move(extractors))
+        , InnerMapping_(Extractors_.size())
+        , RememberNullBitmaps_(rememberNullBitmaps)
+        , IsBitmapNull_(Extractors_.size(), false)
+    {
+        Y_ENSURE(roles.size() == Extractors_.size());
+
+        ui32 colCounter = 0;
+        TVector<NPackedTuple::TColumnDesc> columnDescrs;
+        for (size_t i = 0; i < Extractors_.size(); ++i) {
+            auto& extractor = Extractors_[i];
+            auto& mapping = InnerMapping_[i];
+            auto prevSize = InnerExtractors_.size();
+            extractor->AppendInnerExtractors(InnerExtractors_);
+
+            for (size_t j = 0; j < InnerExtractors_.size() - prevSize; ++j) {
+                NPackedTuple::TColumnDesc descr;
+                descr.Role = roles[i];
+                columnDescrs.push_back(descr);
+                mapping.push_back(colCounter);
+                colCounter++;
+            }
+        }
+
+        for (size_t i = 0; i < columnDescrs.size(); ++i) {
+            auto& descr = columnDescrs[i];
+            descr.DataSize = InnerExtractors_[i]->GetElementSize();
+            descr.SizeType = InnerExtractors_[i]->GetElementSizeType();
+        }
+
+        TupleLayout_ = NPackedTuple::TTupleLayout::Create(columnDescrs);
+    }
+
+    void Pack(const TVector<arrow::Datum>& columns, TPackResult& packed) override {
+        auto [columnsData, columnsNullBitmap] = GetColumns_(columns);
+
+        auto& packedTuples = packed.PackedTuples;
+        auto& overflow = packed.Overflow;
+        auto& nTuples = packed.NTuples;
+
+        auto currentSize = (TupleLayout_->TotalRowSize) * nTuples;
+        auto tuplesToPack = columns.front().array()->length;
+        nTuples += tuplesToPack;
+        auto newSize = (TupleLayout_->TotalRowSize) * nTuples;
+        packedTuples.resize(newSize, 0);
+
+        TupleLayout_->Pack(
+            columnsData.data(), columnsNullBitmap.data(),
+            packedTuples.data() + currentSize, overflow, 0, tuplesToPack);
+    }
+
+    void BucketPack(const TVector<arrow::Datum>& columns, TPaddedPtr<TPackResult> packs, ui32 bucketsLogNum) override {
+        auto [columnsData, columnsNullBitmap] = GetColumns_(columns);
+        auto tuplesToPack = columns.front().array()->length;
+
+        const auto reses = TPaddedPtr(&packs[0].PackedTuples, packs.Step());
+        const auto overflows = TPaddedPtr(&packs[0].Overflow, packs.Step());
+
+        TupleLayout_->BucketPack(
+            columnsData.data(), columnsNullBitmap.data(),
+            reses, overflows, 0, tuplesToPack, bucketsLogNum);
+
+        for (ui32 bucket = 0; bucket < (1u << bucketsLogNum); ++bucket) {
+            auto& pack = packs[bucket];
+            pack.NTuples = pack.PackedTuples.size() / TupleLayout_->TotalRowSize;
+        }
+    }
+
+    void Unpack(const TPackResult& packed, TVector<arrow::Datum>& columns) override {
+        columns.resize(Extractors_.size());
+
+        std::vector<ui64, TMKQLAllocator<ui64>> bytesPerColumn;
+        TupleLayout_->CalculateColumnSizes(
+            packed.PackedTuples.data(), packed.NTuples, bytesPerColumn);
+
+        TVector<ui8*> columnsData;
+        TVector<ui8*> columnsNullBitmap;
+        for (size_t i = 0; i < columns.size(); ++i) {
+            const auto& mapping = InnerMapping_[i];
+            TVector<ui64> bytesCount;
+            for (auto idx: mapping) {
+                bytesCount.push_back(bytesPerColumn[idx]);
+            }
+
+            bool isBitmapNull = false;
+            if (RememberNullBitmaps_) {
+                isBitmapNull = IsBitmapNull_[i];
+            }
+            columns[i] = Extractors_[i]->ReserveArray(bytesCount, packed.NTuples, isBitmapNull);
+
+            auto data = Extractors_[i]->GetColumnsData(columns[i].array());
+            columnsData.insert(columnsData.end(), data.begin(), data.end());
+
+            auto nullBitmap = Extractors_[i]->GetNullBitmap(columns[i].array());
+            columnsNullBitmap.insert(columnsNullBitmap.end(), nullBitmap.begin(), nullBitmap.end());
+        }
+
+        TupleLayout_->Unpack(
+            columnsData.data(), columnsNullBitmap.data(),
+            packed.PackedTuples.data(), packed.Overflow, 0, packed.NTuples);
+    }
+
+    const NPackedTuple::TTupleLayout* GetTupleLayout() const override {
+        return TupleLayout_.get();
+    }
+
+private:
+    TVector<IColumnDataExtractor::TPtr> Extractors_;
+    std::vector<IColumnDataExtractor*> InnerExtractors_;
+    TVector<TVector<ui32>> InnerMapping_;
+    THolder<NPackedTuple::TTupleLayout> TupleLayout_;
+    bool RememberNullBitmaps_;
+    TVector<bool> IsBitmapNull_;
+};
+
+// ------------------------------------------------------------
+
+IBlockLayoutConverter::TPtr MakeBlockLayoutConverter(
+    const NUdf::ITypeInfoHelper& typeInfoHelper, const TVector<TType*>& types,
+    const TVector<NPackedTuple::EColumnRole>& roles, arrow::MemoryPool* pool)
+{
+    TVector<IColumnDataExtractor::TPtr> extractors;
+
+    for (auto type: types) {
+        extractors.emplace_back(DispatchByArrowTraits<TColumnDataExtractorTraits>(typeInfoHelper, type, nullptr, pool, type));
+    }
+
+    return std::make_unique<TBlockLayoutConverter>(std::move(extractors), roles);
+}
+
+} // namespace NKikimr::NMiniKQL

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <util/generic/noncopyable.h>
+#include <yql/essentials/public/udf/udf_types.h>
+
+#include <arrow/type.h>
+
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h>
+
+namespace NKikimr::NMiniKQL {
+
+class IBlockLayoutConverter : private TNonCopyable {
+public:
+    struct TPackResult {
+        std::vector<ui8, TMKQLAllocator<ui8>> PackedTuples;
+        std::vector<ui8, TMKQLAllocator<ui8>> Overflow;
+        ui32 NTuples{0};
+    };
+
+    using TPackedTuple = std::vector<ui8, TMKQLAllocator<ui8>>;
+    using TOverflow = std::vector<ui8, TMKQLAllocator<ui8>>;
+
+public:
+    using TPtr = std::unique_ptr<IBlockLayoutConverter>;
+
+public:
+    virtual ~IBlockLayoutConverter() = default;
+
+    // Can be called multiple times to accumulate packed data in one storage
+    virtual void Pack(const TVector<arrow::Datum>& columns, TPackResult& packed) = 0;
+    virtual void BucketPack(const TVector<arrow::Datum>& columns, TPaddedPtr<TPackResult> packs, ui32 bucketsLogNum) = 0;
+    // Can not be called multiple times due to immutability of arrow arrays
+    virtual void Unpack(const TPackResult& packed, TVector<arrow::Datum>& columns) = 0;
+    virtual const NPackedTuple::TTupleLayout* GetTupleLayout() const = 0;
+};
+
+IBlockLayoutConverter::TPtr MakeBlockLayoutConverter(
+    const NUdf::ITypeInfoHelper& typeInfoHelper, const TVector<TType*>& types,
+    const TVector<NPackedTuple::EColumnRole>& roles, arrow::MemoryPool* pool);
+
+}

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <util/generic/noncopyable.h>
+#include <yql/essentials/minikql/mkql_node.h>
 #include <yql/essentials/public/udf/udf_types.h>
 
 #include <arrow/type.h>
@@ -37,5 +37,4 @@ public:
 IBlockLayoutConverter::TPtr MakeBlockLayoutConverter(
     const NUdf::ITypeInfoHelper& typeInfoHelper, const TVector<TType*>& types,
     const TVector<NPackedTuple::EColumnRole>& roles, arrow::MemoryPool* pool);
-
 }

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/hashes_calc.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/hashes_calc.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <util/system/unaligned_mem.h>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+template <typename TTraits>
+inline ui32 CalculateCRC32(const ui8 * data, ui32 size, ui32 hash = 0 ) {
+    using TSimdI8 = typename TTraits::TSimdI8;
+
+    while (size >= 8) {
+        hash = TSimdI8::CRC32u64(hash, ReadUnaligned<ui64>(data));
+        size -= 8;
+        data += 8;
+    }
+
+    switch(size) {
+        case 7:
+            hash = TSimdI8::CRC32u32(hash, ReadUnaligned<ui32>(data));
+            data += 4;
+            [[fallthrough]];
+        case 3:
+            hash = TSimdI8::CRC32u16(hash, ReadUnaligned<ui16>(data));
+            data += 2;
+            [[fallthrough]];
+        case 1:
+            hash = TSimdI8::CRC32u8(hash, ReadUnaligned<ui8>(data));
+            break;
+        case 6:
+            hash = TSimdI8::CRC32u32(hash, ReadUnaligned<ui32>(data));
+            data += 4;
+            [[fallthrough]];
+        case 2:
+            hash = TSimdI8::CRC32u16(hash, ReadUnaligned<ui16>(data));
+            break;
+        case 5:
+            hash = TSimdI8::CRC32u32(hash, ReadUnaligned<ui32>(data));
+            data += 4;
+            hash = TSimdI8::CRC32u8(hash, ReadUnaligned<ui8>(data));
+            break;
+        case 4:
+            hash = TSimdI8::CRC32u32(hash, ReadUnaligned<ui32>(data));
+            break;
+        case 0:
+            break;
+    }
+    return hash;
+
+}
+
+template
+__attribute__((target("avx2")))
+ui32 CalculateCRC32<NSimd::TSimdAVX2Traits>(const ui8 * data, ui32 size, ui32 hash = 0 );
+template
+__attribute__((target("sse4.2")))
+ui32 CalculateCRC32<NSimd::TSimdSSE42Traits>(const ui8 * data, ui32 size, ui32 hash = 0 );
+
+}
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/histogram.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/histogram.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+
+#include <util/generic/buffer.h>
+#include <yql/essentials/utils/prefetch.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+class Histogram {
+public:
+    Histogram() = default;
+
+    template <typename F, typename... Args>
+    void AddData(const TTupleLayout* layout, const ui8* data, ui32 nTuples, F HashMapper, Args&&... args) {
+        const auto layoutTotalRowSize = layout->TotalRowSize;
+
+        for (ui32 i = 0; i < nTuples; i += 1 /*step*/) {
+            const ui8* tuple = data + i * layoutTotalRowSize;
+            const auto hash = ReadUnaligned<ui32>(tuple);
+            NYql::PrefetchForRead(tuple + layoutTotalRowSize * 32); // prefetch next tuples
+
+            ui64 overflowSize = 0;
+            for (const auto& col: layout->VariableColumns) {
+                ui32 size = ReadUnaligned<ui8>(tuple + col.Offset);
+                if (size == 255) { // overflow buffer used
+                    const auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                    const auto overflowSize = ReadUnaligned<ui32>(tuple + col.Offset + 1 + 1 * sizeof(ui32));
+                    size = prefixSize + overflowSize;
+                }
+                overflowSize += size;
+            }
+
+            auto key = HashMapper(hash, std::forward<Args>(args)...);
+            TuplesCountStatistics_[key]++;
+            TuplesSizeStatistics_[key] += layoutTotalRowSize;
+            OverflowSizeStatistics_[key] += overflowSize;
+        }
+    }
+
+    // hist vector must have proper size
+    void GetHistogram(std::vector<ui64, TMKQLAllocator<ui64>>& hist) {
+        for (auto [key, count]: TuplesCountStatistics_) {
+            hist[key] += count;
+        }
+    }
+
+    // sizes vector must have proper size
+    void EstimateSizes(std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>>& sizes)
+    {
+        for (auto [key, _]: TuplesSizeStatistics_) {
+            auto accTupleSize = TuplesSizeStatistics_[key];
+            auto accOverflowSize = OverflowSizeStatistics_[key];
+
+            auto& [prevTS, prevOS] = sizes[key];
+            prevTS += accTupleSize;
+            prevOS += accOverflowSize;
+        }
+    }
+
+    void Clear() {
+        TuplesCountStatistics_.clear();
+        TuplesSizeStatistics_.clear();
+        OverflowSizeStatistics_.clear();
+    }
+
+private:
+    using TMap = std::unordered_map<ui32, ui64>;
+
+private:
+    TMap TuplesCountStatistics_;
+    TMap TuplesSizeStatistics_;
+    TMap OverflowSizeStatistics_;
+};
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
@@ -1,0 +1,533 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_value.h>
+
+#include <yql/essentials/utils/prefetch.h>
+
+#include <util/generic/buffer.h>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+/*
+ * Class TNeumannHashTable provides hash table implementation for packed tuples.
+ *
+ * TNeumannHashTable has the following layout:
+ * HashTable:    [[Directory 1][Directory 2]...[Directory N]]
+ * Directory:    [[Buffer Index][Bloom Filter]]
+ * Buffer:       [[Tuple 1][Tuple 2]...[Tuple M]]
+ */
+
+template <class T> class TBloomFilterMasks {
+
+    static consteval size_t BinomCoeff(size_t n, size_t k) noexcept {
+        return k == 0 ? 1 : BinomCoeff(n - 1, k - 1) * n / k;
+    }
+
+    static consteval size_t Pow2Round(size_t n) {
+        return n == 0 ? 0
+                      : 1ul << (sizeof(size_t) * 8 - std::countl_zero(n - 1));
+    }
+
+    template <size_t N, size_t K>
+    static consteval size_t GenRec(auto &arr, T mask, size_t i, size_t j) {
+        if constexpr (K == 0) {
+            arr[i] = mask;
+            return i + 1;
+        } else {
+            for (size_t ind = j; ind <= N - K; ++ind) {
+                i = GenRec<N, K - 1>(arr, mask | (T(1) << ind), i, ind + 1);
+            }
+            return i;
+        }
+    }
+
+  public:
+    template <unsigned BloomBits, unsigned BloomMaskBits>
+    static consteval auto Gen() {
+        constexpr size_t BloomMasksNum = BinomCoeff(BloomBits, BloomMaskBits);
+        constexpr size_t BloomMasksNumRounded = Pow2Round(BloomMasksNum);
+
+        auto result = std::array<T, BloomMasksNumRounded>{};
+        GenRec<BloomBits, BloomMaskBits>(result, 0, 0, 0);
+        std::copy(result.data(),
+                  result.data() + BloomMasksNumRounded - BloomMasksNum,
+                  result.data() + BloomMasksNum);
+
+        return result;
+    }
+};
+
+template <bool ConsecutiveDuplicates = false, bool Prefetch = true,
+          typename TAllocator = TMKQLAllocator<ui8>>
+class TNeumannHashTable {
+    /// hash = [...] [directory_bits] [...] [bloom_filter_bits]
+    using Hash = ui32;
+    using TBloom = ui16;
+
+    static constexpr unsigned kBloomBits = 16;
+    static constexpr unsigned kBloomMaskBits = 4;
+
+    alignas(64) static constexpr auto kBloomTags =
+        TBloomFilterMasks<TBloom>::template Gen<kBloomBits, kBloomMaskBits>();
+    static constexpr unsigned kBloomHashBits =
+        std::countr_zero(kBloomTags.size());
+
+    static_assert(kBloomBits != 0 && kBloomMaskBits != 0 &&
+                  kBloomMaskBits < kBloomBits &&
+                  kBloomBits <= sizeof(TBloom) * 8);
+
+    struct TDirectory {
+        using T = ui64;
+
+        T &operator*() { return reinterpret_cast<T &>(*this); }
+        const T &operator*() const {
+            return reinterpret_cast<const T &>(*this);
+        }
+
+        static constexpr size_t kBufferSlotShift = kBloomBits;
+
+        T BloomFilter : kBloomBits = 0;
+        T BufferSlot : sizeof(T) * 8 - kBloomBits = 0;
+    };
+    static_assert(sizeof(TDirectory) == sizeof(typename TDirectory::T));
+
+    struct THash {
+        using T = Hash;
+
+        T &operator*() { return reinterpret_cast<T &>(*this); }
+        const T &operator*() const {
+            return reinterpret_cast<const T &>(*this);
+        }
+
+        T BloomTagSlot : kBloomHashBits;
+        T DirSlotHash : sizeof(T) * 8 - kBloomHashBits;
+    };
+    static_assert(sizeof(THash) == sizeof(typename THash::T));
+
+    Hash getDirectorySlot(THash thash) const {
+        return (*thash >> DirectoryHashShift_) & DirectoryHashMask_;
+    }
+
+    static constexpr ui32 kEmbeddedSize = 16;
+
+    template <bool>
+    struct TOutplaceImpl {
+        Hash Hash;
+        ui32 Index;
+    };
+    template <>
+    struct TOutplaceImpl<true> : TOutplaceImpl<false> {
+    };
+
+    using TOutplace = TOutplaceImpl<ConsecutiveDuplicates>;
+    static_assert(sizeof(TOutplace) <= kEmbeddedSize);
+
+
+    template<bool> struct TIteratorImpl;
+    template<> struct TIteratorImpl<false> {
+        friend TNeumannHashTable;
+
+      public:
+        TIteratorImpl(): It_(nullptr), End_(nullptr) {}
+
+      private:
+        const ui8 *Row_;
+        const ui8 *It_;
+        const ui8 *End_;
+    };
+    template<> struct TIteratorImpl<true> {
+        friend TNeumannHashTable;
+
+      public:
+        TIteratorImpl(): It_(nullptr), Len_(0) {}
+
+      private:
+        const ui8 *It_;
+        ui32 Len_;
+    };
+
+
+  public:
+    using TIterator = TIteratorImpl<ConsecutiveDuplicates>;
+  
+    TNeumannHashTable()
+        : DirectoriesData_(Allocator_)
+        , Buffer_(Allocator_) 
+    {}
+
+    explicit TNeumannHashTable(const TTupleLayout *layout): TNeumannHashTable() {
+        SetTupleLayout(layout);
+    }
+
+    void SetTupleLayout(const TTupleLayout *layout) {
+        Clear();
+
+        Layout_ = layout;
+        IsInplace_ = layout->TotalRowSize <= kEmbeddedSize;
+        RowIndexSize_ = IsInplace_ ? layout->TotalRowSize : sizeof(TOutplace);
+        BufferSlotSize_ = RowIndexSize_;
+        if constexpr (ConsecutiveDuplicates) {
+            BufferSlotSize_ += sizeof(ui32);
+        }
+    }
+
+    TNeumannHashTable(const TNeumannHashTable &) = delete;
+    TNeumannHashTable &operator=(const TNeumannHashTable &) = delete;
+
+    void Build(const ui8 *const tuples, const ui8 *const overflow, ui32 nItems,
+               ui32 estimatedLogSize = 0) {
+        Y_ASSERT(Layout_ != nullptr);
+        Y_ASSERT(Directories_.empty() && Buffer_.empty() &&
+                 Tuples_ == nullptr && Overflow_ == nullptr);
+
+        if (estimatedLogSize == 0) {
+            estimatedLogSize = 32 - std::countl_zero<ui32>(nItems);
+            estimatedLogSize = estimatedLogSize > 2 ? estimatedLogSize - 2 : estimatedLogSize;
+        }
+        estimatedLogSize = std::max(1u, std::min(24u, estimatedLogSize));
+
+        Tuples_ = tuples;
+        Overflow_ = overflow;
+
+        DirectoryHashBits_ = estimatedLogSize;
+        DirectoryHashShift_ = sizeof(Hash) * 8 - kBloomHashBits >= DirectoryHashBits_
+                                ? kBloomHashBits
+                                : sizeof(Hash) * 8 - DirectoryHashBits_;
+        DirectoryHashMask_ = (1ul << DirectoryHashBits_) - 1;
+        
+        const ui32 dirsSize = (1ul << DirectoryHashBits_) + 1;
+        DirectoriesData_.resize(dirsSize * sizeof(TDirectory));
+        Directories_ = std::span((TDirectory *)DirectoriesData_.data(), dirsSize);
+        for (auto& directory : Directories_) {
+            directory = {};
+        }
+
+        for (ui32 ind = 0; ind != nItems; ++ind) {
+            const THash thash =
+                ReadUnaligned<THash>(tuples + Layout_->TotalRowSize * ind);
+            auto &dir = *Directories_[getDirectorySlot(thash)];
+            dir += 1ul << TDirectory::kBufferSlotShift;
+            dir |= kBloomTags[thash.BloomTagSlot];
+        }
+
+        {
+            ui32 accum = 0;
+            for (auto &directory : Directories_) {
+                accum += directory.BufferSlot;
+                directory.BufferSlot = accum;
+
+                directory.BloomFilter = ~directory.BloomFilter;
+            }
+        }
+
+        Buffer_.resize(BufferSlotSize_ * nItems);
+
+        constexpr ui32 prefetchInAdvance = 16;
+
+        if constexpr (Prefetch) {
+            for (ui32 ind = 0; ind != std::min(prefetchInAdvance, nItems); ++ind) {
+                const ui8 *row = tuples + Layout_->TotalRowSize * ind;
+                const THash thash = ReadUnaligned<THash>(row);
+                auto &dir = *Directories_[getDirectorySlot(thash)];
+                const ui32 dataSlot = (dir >> TDirectory::kBufferSlotShift) - 1;
+                ui8 *const ptr = Buffer_.data() + BufferSlotSize_ * dataSlot;
+                NYql::PrefetchForWrite(ptr);
+            }
+        }
+
+        const ui8 *row = tuples;
+        for (ui32 ind = 0; ind != nItems; ++ind, row += Layout_->TotalRowSize) {
+            if constexpr (Prefetch) {
+                const ui8 *prow = row + Layout_->TotalRowSize * prefetchInAdvance;
+                const THash thash = ReadUnaligned<THash>(prow);
+                auto &dir = *Directories_[getDirectorySlot(thash)];
+                const ui32 dataSlot = (dir >> TDirectory::kBufferSlotShift) - 1;
+                ui8 *const ptr = Buffer_.data() + BufferSlotSize_ * dataSlot;
+                NYql::PrefetchForWrite(ptr);
+            }
+    
+            const THash thash = ReadUnaligned<THash>(row);
+
+            auto &dir = *Directories_[getDirectorySlot(thash)];
+            dir -= 1ul << TDirectory::kBufferSlotShift;
+            const ui32 dataSlot = dir >> TDirectory::kBufferSlotShift;
+            ui8 *const bufRow = Buffer_.data() + BufferSlotSize_ * dataSlot;
+
+            if (IsInplace_) {
+                std::memcpy(bufRow, row,
+                            RowIndexSize_);
+            } else {
+                auto *const outRow = reinterpret_cast<TOutplace *>(bufRow);
+                outRow->Hash = *thash;
+                outRow->Index = ind;
+            }
+            
+            if constexpr (ConsecutiveDuplicates) {
+                WriteUnaligned<ui32>(bufRow + RowIndexSize_, 0); 
+            }
+        }
+
+        if constexpr (ConsecutiveDuplicates) {
+            for (size_t dirSlot = 0; dirSlot != Directories_.size() - 1; ++dirSlot) {
+                ui8 *begin = Buffer_.data() + BufferSlotSize_ * Directories_[dirSlot].BufferSlot;
+                ui8 *const end = Buffer_.data() + BufferSlotSize_ * Directories_[dirSlot + 1].BufferSlot;
+                const ui8* matchedRow;
+
+                while (begin != end) {
+                    const ui8 *const row = GetRow(begin);
+
+                    ui8 *left = begin + BufferSlotSize_;
+                    ui8 *right = end;
+                    ui32 size = 1;
+
+                    bool checkLeft = true;
+                    while (left != right) {
+                        while (left != right && checkLeft && GetRowMatch(left, row, overflow, &matchedRow)) {
+                            ++size;
+                            left += BufferSlotSize_;
+                        }
+                        checkLeft = false;
+
+                        if (left == right) {
+                            break;
+                        }
+                        right -= BufferSlotSize_;
+
+                        if (GetRowMatch(right, row, overflow, &matchedRow)) {
+                            ui8 buf[kEmbeddedSize];
+                            std::memcpy(buf, left, RowIndexSize_);
+                            std::memcpy(left, right, RowIndexSize_);
+                            std::memcpy(right, buf, RowIndexSize_);
+
+                            ++size;
+                            left += BufferSlotSize_;
+                            checkLeft = true;
+                        }
+                    }
+    
+                    WriteUnaligned<ui32>(begin + RowIndexSize_, size);
+                    begin = left;
+                }
+            }
+        }
+    }
+
+    Y_FORCE_INLINE const ui8 *NextMatch(TIterator &iter, const ui8 *overflow) const {
+        const ui8 *result = nullptr;
+
+        if constexpr (ConsecutiveDuplicates) {
+            if (iter.Len_) { /// allow multiple false calls
+                result = GetRow(iter.It_);
+                iter.It_ += BufferSlotSize_;
+                iter.Len_--;
+            }
+        } else {
+            for (auto& it = iter.It_; it != iter.End_; it += BufferSlotSize_) { /// allow multiple false calls
+                if (GetRowMatch(it, iter.Row_, overflow, &result)) {
+                    it += BufferSlotSize_;
+                    break;
+                }
+                result = nullptr;
+            }
+        }
+
+        return result;
+    }
+
+    TIterator Find(const ui8 *const row, const ui8 *const overflow) const {
+        Y_ASSERT(Layout_ != nullptr);
+        Y_ASSERT(!Directories_.empty() && Tuples_ != nullptr);
+
+        TIterator iter;
+
+        const THash &thash = reinterpret_cast<const THash &>(row[0]);
+        const TBloom hashBloomTag = kBloomTags[thash.BloomTagSlot];
+
+        const Hash dirSlot = getDirectorySlot(thash);
+        const TDirectory dir = Directories_[dirSlot];
+        const TBloom dirBloomFilter = dir.BloomFilter;
+
+        if (hashBloomTag & dirBloomFilter) {
+            return iter;
+        }
+
+        const ui8 *const begin =
+            Buffer_.data() + BufferSlotSize_ * dir.BufferSlot;
+        const ui8 *const end =
+            Buffer_.data() +
+            BufferSlotSize_ * Directories_[dirSlot + 1].BufferSlot;
+
+        if constexpr (!ConsecutiveDuplicates) {
+            iter.Row_ = row;
+            iter.It_ = begin;
+            iter.End_ = end;
+        } else {
+            for (auto it = begin; it != end; ) {
+                const ui8 *matchedRow;
+                auto size  = ReadUnaligned<ui32>(it + RowIndexSize_);
+
+                if (GetRowMatch(it, row, overflow, &matchedRow)) {
+                    iter.It_ = it;
+                    iter.Len_ = size;
+                    break;
+                } else {
+                    it += size * BufferSlotSize_;
+                }
+            }
+        }
+
+        return iter;
+    }
+
+    template <size_t Size>
+    std::array<TIterator, Size> FindBatch(const std::array<const ui8 *, Size> &rows,
+                                          const ui8 *const overflow) const {
+        if constexpr (Prefetch) {
+            if (Directories_.size_bytes() > 1024 * 1024) {
+                for (ui32 index = 0; index < Size && rows[index]; ++index) {
+                    const THash &thash = reinterpret_cast<const THash &>(rows[index][0]);
+                    const Hash dirSlot = getDirectorySlot(thash);
+                    NYql::PrefetchForRead(&Directories_[dirSlot]);
+                }    
+            } else {
+                for (ui32 index = 0; index < Size && rows[index]; ++index) {
+                    const THash &thash = reinterpret_cast<const THash &>(rows[index][0]);
+                    const Hash dirSlot = getDirectorySlot(thash);
+                    const TDirectory dir = Directories_[dirSlot]; 
+                    const ui8 *ptr = Buffer_.data() + BufferSlotSize_ * dir.BufferSlot;
+                    NYql::PrefetchForRead(ptr);
+                }
+            }
+        }
+
+        std::array<TIterator, Size> iters;
+        for (ui32 index = 0; index < Size && rows[index]; ++index) {
+            iters[index] = Find(rows[index], overflow);
+        }
+
+        return iters;
+    }
+
+    void Apply(const ui8 *const row, const ui8 *const overflow,
+               auto &&onMatch) {
+        Y_ASSERT(Layout_ != nullptr);
+        Y_ASSERT(!Directories_.empty() && Tuples_ != nullptr);
+
+        const THash &thash = reinterpret_cast<const THash &>(row[0]);
+        const TBloom hashBloomTag = kBloomTags[thash.BloomTagSlot];
+
+        const Hash dirSlot = getDirectorySlot(thash);
+        const TDirectory dir = Directories_[dirSlot];
+        const TBloom dirBloomFilter = dir.BloomFilter;
+
+        if (hashBloomTag & dirBloomFilter) {
+            return;
+        }
+
+        const ui8 *const begin =
+            Buffer_.data() + BufferSlotSize_ * dir.BufferSlot;
+        const ui8 *const end =
+            Buffer_.data() +
+            BufferSlotSize_ * Directories_[dirSlot + 1].BufferSlot;
+
+        const ui8 *matchedRow;
+
+        if constexpr (!ConsecutiveDuplicates) {
+            for (auto it = begin; it != end; it += BufferSlotSize_) {
+                if (GetRowMatch(it, row, overflow, &matchedRow)) {
+                    onMatch(matchedRow);
+                }
+            }
+        } else {
+            ui32 size = 0;
+            for (auto it = begin; it != end; it += size * BufferSlotSize_) {
+                size = ReadUnaligned<ui32>(it + RowIndexSize_);
+                if (!GetRowMatch(it, row, overflow, &matchedRow)) {
+                    continue;
+                }
+
+                for (; size; --size, it += BufferSlotSize_) {
+                    onMatch(it);
+                }
+                break;
+            }
+        }
+    }
+
+    void Clear() {
+        Directories_ = {};
+        DirectoriesData_.clear();
+        Buffer_.clear();
+
+        Tuples_ = nullptr;
+        Overflow_ = nullptr;
+    }
+
+  private:
+    const ui8* GetRow(const ui8* it) const {
+        if (IsInplace_) {
+            return it;
+        } else {
+            const auto *const outRow =
+                reinterpret_cast<const TOutplace *>(it);
+            it = Tuples_ + Layout_->TotalRowSize * outRow->Index;
+            return it;
+        }
+    } 
+
+    bool GetRowMatch(const ui8 *const it, const ui8 *const row, const ui8 *const overflow, const ui8 **matchedRow) const {
+        const THash &thash = reinterpret_cast<const THash &>(row[0]);
+
+        if (IsInplace_) {
+            const Hash matchRowHash = ReadUnaligned<Hash>(it);
+            if (matchRowHash != *thash) {
+                return false;
+            }
+            *matchedRow = it;
+        } else {
+            const auto *const outRow =
+                reinterpret_cast<const TOutplace *>(it);
+            if (outRow->Hash != *thash) {
+                return false;
+            }
+            *matchedRow = Tuples_ + Layout_->TotalRowSize * outRow->Index;
+        }
+
+        if (Layout_->KeysEqual(row, overflow, *matchedRow, Overflow_)) {
+            return true;
+        }
+        return false;
+    }
+
+  private:
+    const TTupleLayout * Layout_ = nullptr;
+
+    const ui8 *Tuples_ = nullptr;
+    const ui8 *Overflow_ = nullptr;
+
+    bool IsInplace_;
+    ui32 BufferSlotSize_;
+    ui32 RowIndexSize_;
+
+    unsigned DirectoryHashBits_;
+    unsigned DirectoryHashShift_;
+    Hash DirectoryHashMask_;
+
+    TAllocator Allocator_;
+    std::span<TDirectory> Directories_;
+    std::vector<ui8, TAllocator> DirectoriesData_;
+    std::vector<ui8, TAllocator> Buffer_;
+};
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/packing.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/packing.h
@@ -5,7 +5,6 @@ namespace NKikimr {
 namespace NMiniKQL {
 namespace NPackedTuple {
 
-[[maybe_unused]]
 static void
 PackTupleFallbackRowImpl(const ui8 *const src_cols[], ui8 *const dst_rows,
                          const size_t cols, const size_t size,
@@ -43,7 +42,6 @@ PackTupleFallbackRowImpl(const ui8 *const src_cols[], ui8 *const dst_rows,
     }
 }
 
-[[maybe_unused]]
 static void
 UnpackTupleFallbackRowImpl(const ui8 *const src_rows, ui8 *const dst_cols[],
                            const size_t cols, const size_t size,
@@ -279,6 +277,459 @@ UnpackTupleFallbackColImpl(const ui8 *const src_rows, ui8 *const dst_cols[],
                                start + block_size * block_rows);
 }
 
+template <class TTraits> struct SIMDPack {
+    template <class T> using TSimd = typename TTraits::template TSimd8<T>;
+
+    /// [8,16,32,64]-bits iters
+    static const ui8 BaseIters = 4;
+
+    /// 128-bit lane iters
+    static const ui8 LaneIters = [] {
+        if constexpr (std::is_same_v<TTraits, NSimd::TSimdAVX2Traits>) {
+            return 1;
+        }
+        return 0;
+    }();
+
+    static const ui8 TransposeIters = BaseIters + LaneIters;
+
+    /// bits reversed
+    static constexpr ui8 TransposeRevInd[BaseIters][1 << BaseIters] = {
+        {
+            0x0,
+            0x8,
+            0x4,
+            0xc,
+            0x2,
+            0xa,
+            0x6,
+            0xe,
+            0x1,
+            0x9,
+            0x5,
+            0xd,
+            0x3,
+            0xb,
+            0x7,
+            0xf,
+        },
+        {
+            0x0,
+            0x4,
+            0x2,
+            0x6,
+            0x1,
+            0x5,
+            0x3,
+            0x7,
+        },
+        {
+            0x0,
+            0x2,
+            0x1,
+            0x3,
+        },
+        {
+            0x0,
+            0x1,
+        },
+    };
+
+    template <ui8 Cols, ui8 LogIter>
+    static void Transpose(TSimd<ui8> (&regs)[2][Cols]) {
+        /// iterative transposition, starting from ColSize:
+        ///     ui8 -> ui16 -> ui32 -> ui64 -> 128bit-lane
+        /// smth like fourier butterfly
+
+#define TRANSPOSE_ITER(iter, bits)                                             \
+    if constexpr (LogIter <= iter) {                                           \
+        constexpr bool from = iter % 2;                                        \
+        constexpr bool to = from ^ 1;                                          \
+                                                                               \
+        constexpr ui8 log = iter - LogIter;                                    \
+        constexpr ui8 exp = 1u << log;                                         \
+                                                                               \
+        for (ui8 col = 0; col != Cols; ++col) {                                \
+            switch ((col & exp) >> log) {                                      \
+            case 0: {                                                          \
+                regs[to][col] = TSimd<ui8>::UnpackLaneLo##bits(                \
+                    regs[from][col & ~exp], regs[from][col | exp]);            \
+                break;                                                         \
+            }                                                                  \
+            case 1: {                                                          \
+                regs[to][col] = TSimd<ui8>::UnpackLaneHi##bits(                \
+                    regs[from][col & ~exp], regs[from][col | exp]);            \
+                break;                                                         \
+            }                                                                  \
+            default:;                                                          \
+            }                                                                  \
+        }                                                                      \
+    }
+
+        TRANSPOSE_ITER(0, 8);
+        TRANSPOSE_ITER(1, 16);
+        TRANSPOSE_ITER(2, 32);
+        TRANSPOSE_ITER(3, 64);
+    
+#undef TRANSPOSE_ITER
+
+        if constexpr (LaneIters == 1) {
+            constexpr auto iter = BaseIters;
+
+            constexpr bool from = iter % 2;
+            constexpr bool to = from ^ 1;
+
+            constexpr ui8 log = iter - LogIter;
+            constexpr ui8 exp = 1u << log;
+
+            for (ui8 col = 0; col != Cols; ++col) {
+                switch ((col & exp) >> log) {
+                case 0: {
+                    regs[to][col] =
+                        TSimd<ui8>::template PermuteLanes<0 + 2 * 16>(
+                            regs[from][col & ~exp], regs[from][col | exp]);
+                    break;
+                }
+                case 1: {
+                    regs[to][col] =
+                        TSimd<ui8>::template PermuteLanes<1 + 3 * 16>(
+                            regs[from][col & ~exp], regs[from][col | exp]);
+                    break;
+                }
+                }
+            }
+        } else if constexpr (LaneIters) {
+            static_assert(!LaneIters, "Not implemented");
+        }
+    }
+
+    template <ui8 ColSize>
+    static void PackColSizeImpl(const ui8 *const src_cols[],
+                                ui8 *const dst_rows, const size_t size,
+                                const size_t cols_num, const size_t padded_size,
+                                const size_t start = 0) {
+        static constexpr ui8 Cols = TSimd<ui8>::SIZE / ColSize;
+        static constexpr ui8 LogIter = std::countr_zero(ColSize);
+        static constexpr std::array<size_t, Cols> ColSizes = [] {
+            std::array<size_t, Cols> offsets;
+            for (size_t ind = 0; ind != Cols; ++ind) {
+                offsets[ind] = ColSize;
+            }
+            return offsets;
+        }();
+        static constexpr std::array<size_t, Cols> Offsets = [] {
+            std::array<size_t, Cols> offsets;
+            for (size_t ind = 0; ind != Cols; ++ind) {
+                offsets[ind] = ind * ColSize;
+            }
+            return offsets;
+        }();
+
+        const size_t simd_iters = size / Cols;
+
+        TSimd<ui8> regs[2][Cols];
+
+        for (size_t cols_group = 0; cols_group < cols_num; cols_group += Cols) {
+            const ui8 *srcs[Cols];
+            std::memcpy(srcs, src_cols + cols_group, sizeof(srcs));
+            for (ui8 col = 0; col != Cols; ++col) {
+                srcs[col] += ColSize * start;
+            }
+
+            auto dst = dst_rows + cols_group * ColSize;
+            ui8 *const end = dst + simd_iters * Cols * padded_size;
+
+            while (dst != end) {
+                for (ui8 col = 0; col != Cols; ++col) {
+                    regs[LogIter % 2][col] = TSimd<ui8>(srcs[col]);
+                    srcs[col] += TSimd<ui8>::SIZE;
+                }
+
+                Transpose<Cols, LogIter>(regs);
+
+                const bool res = TransposeIters % 2;
+                for (ui8 col = 0; col != Cols; ++col) {
+                    if constexpr (LaneIters) {
+                        const ui8 half_ind = col % (Cols / 2);
+                        const ui8 half_shift = col & (Cols / 2);
+                        regs[res]
+                            [TransposeRevInd[LogIter][half_ind] + half_shift]
+                                .Store(dst);
+                        dst += padded_size;
+                    } else {
+                        regs[res][TransposeRevInd[LogIter][col]].Store(dst);
+                        dst += padded_size;
+                    }
+                }
+            }
+
+            PackTupleFallbackRowImpl(srcs, dst, Cols, size - simd_iters * Cols,
+                                     ColSizes.data(), Offsets.data(),
+                                     padded_size);
+        }
+    }
+
+    template <ui8 ColSize>
+    static void
+    UnpackColSizeImpl(const ui8 *const src_rows, ui8 *const dst_cols[],
+                      size_t size, const size_t cols_num,
+                      const size_t padded_size, const size_t start = 0) {
+        static constexpr ui8 Cols = TSimd<ui8>::SIZE / ColSize;
+        static constexpr ui8 LogIter = std::countr_zero(ColSize);
+        static constexpr std::array<size_t, Cols> ColSizes = [] {
+            std::array<size_t, Cols> offsets;
+            for (size_t ind = 0; ind != Cols; ++ind) {
+                offsets[ind] = ColSize;
+            }
+            return offsets;
+        }();
+        static constexpr std::array<size_t, Cols> Offsets = [] {
+            std::array<size_t, Cols> offsets;
+            for (size_t ind = 0; ind != Cols; ++ind) {
+                offsets[ind] = ind * ColSize;
+            }
+            return offsets;
+        }();
+
+        const size_t simd_iters = size / Cols;
+
+        TSimd<ui8> regs[2][Cols];
+
+        for (size_t cols_group = 0; cols_group < cols_num; cols_group += Cols) {
+            auto src = src_rows + cols_group * ColSize;
+            const ui8 *const end = src + simd_iters * Cols * padded_size;
+
+            ui8 *dsts[Cols];
+            std::memcpy(dsts, dst_cols + cols_group, sizeof(dsts));
+            for (ui8 col = 0; col != Cols; ++col) {
+                dsts[col] += ColSize * start;
+            }
+
+            while (src != end) {
+                for (ui8 iter = 0; iter != Cols; ++iter) {
+                    regs[LogIter % 2][iter] = TSimd<ui8>(src);
+                    src += padded_size;
+                }
+
+                Transpose<Cols, LogIter>(regs);
+
+                const bool res = TransposeIters % 2;
+                for (ui8 col = 0; col != Cols; ++col) {
+                    if constexpr (LaneIters) {
+                        const ui8 half_ind = col % (Cols / 2);
+                        const ui8 half_shift = col & (Cols / 2);
+                        regs[res]
+                            [TransposeRevInd[LogIter][half_ind] + half_shift]
+                                .Store(dsts[col]);
+                        dsts[col] += TSimd<ui8>::SIZE;
+                    } else {
+                        regs[res][TransposeRevInd[LogIter][col]].Store(
+                            dsts[col]);
+                        dsts[col] += TSimd<ui8>::SIZE;
+                    }
+                }
+            }
+
+            UnpackTupleFallbackRowImpl(
+                src, dsts, Cols, size - simd_iters * Cols, ColSizes.data(),
+                Offsets.data(), padded_size);
+        }
+    }
+
+    static void PackColSize(const ui8 *const src_cols[], ui8 *const dst_rows,
+                            const size_t size, const size_t col_size,
+                            const size_t cols_num, const size_t padded_size,
+                            const size_t start = 0) {
+        switch (col_size) {
+        case 1:
+            PackColSizeImpl<1>(src_cols, dst_rows, size, cols_num, padded_size,
+                               start);
+            break;
+        case 2:
+            PackColSizeImpl<2>(src_cols, dst_rows, size, cols_num, padded_size,
+                               start);
+            break;
+        case 4:
+            PackColSizeImpl<4>(src_cols, dst_rows, size, cols_num, padded_size,
+                               start);
+            break;
+        case 8:
+            PackColSizeImpl<8>(src_cols, dst_rows, size, cols_num, padded_size,
+                               start);
+            break;
+        default:
+            throw std::runtime_error("What? Unexpected pack switch case " +
+                                     std::to_string(col_size));
+        }
+    }
+
+    static void UnpackColSize(const ui8 *const src_rows, ui8 *const dst_cols[],
+                              const size_t size, const size_t col_size,
+                              const size_t cols_num, const size_t padded_size,
+                              const size_t start = 0) {
+        switch (col_size) {
+        case 1:
+            UnpackColSizeImpl<1>(src_rows, dst_cols, size, cols_num,
+                                 padded_size, start);
+            break;
+        case 2:
+            UnpackColSizeImpl<2>(src_rows, dst_cols, size, cols_num,
+                                 padded_size, start);
+            break;
+        case 4:
+            UnpackColSizeImpl<4>(src_rows, dst_cols, size, cols_num,
+                                 padded_size, start);
+            break;
+        case 8:
+            UnpackColSizeImpl<8>(src_rows, dst_cols, size, cols_num,
+                                 padded_size, start);
+            break;
+        default:
+            throw std::runtime_error("What? Unexpected unpack switch case " +
+                                     std::to_string(col_size));
+        }
+    }
+
+    static TSimd<ui8> BuildTuplePerm(size_t col_size, size_t col_pad,
+                                     size_t tuple_size, ui8 offset, ui8 ind,
+                                     bool packing) {
+        ui8 perm[TSimd<ui8>::SIZE];
+        std::memset(perm, 0x80, TSimd<ui8>::SIZE);
+
+        size_t iters = std::max(1ul, 1 + (TSimd<ui8>::SIZE - tuple_size) /
+                                             (col_size + col_pad));
+        while (iters--) {
+            for (size_t it = col_size; it; --it, ++offset, ++ind) {
+                if (packing) {
+                    perm[offset] = ind;
+                } else {
+                    perm[ind] = offset;
+                }
+            }
+            offset += col_pad;
+        }
+
+        return TSimd<ui8>{perm};
+    }
+
+    template <ui8 TupleSize> static TSimd<ui8> TupleOr(TSimd<ui8> vec[]) {
+        return TupleOrImpl<TupleSize>(vec);
+    }
+
+    template <ui8 TupleSize> static TSimd<ui8> TupleOrImpl(TSimd<ui8> vec[]) {
+        static constexpr ui8 Left = TupleSize / 2;
+        static constexpr ui8 Right = TupleSize - Left;
+
+        return TupleOrImpl<Left>(vec) | TupleOrImpl<Right>(vec + Left);
+    }
+
+    template <> TSimd<ui8> TupleOrImpl<0>(TSimd<ui8>[]) { std::abort(); }
+
+    template <> TSimd<ui8> TupleOrImpl<1>(TSimd<ui8> vec[]) { return vec[0]; }
+
+    template <> TSimd<ui8> TupleOrImpl<2>(TSimd<ui8> vec[]) {
+        return vec[0] | vec[1];
+    }
+
+    template <ui8 StoresPerLoad, ui8 Cols>
+    static void PackTupleOr(const ui8 *const src_cols[], ui8 *const dst_rows,
+                            const size_t size, const size_t col_sizes[],
+                            const size_t offsets[], const size_t tuple_size,
+                            const size_t padded_size, const TSimd<ui8> perms[],
+                            const size_t start = 0) {
+        static constexpr size_t kSIMD_Rem = sizeof(TSimd<ui8>) - StoresPerLoad;
+        const ui8 tuples_per_store =
+            std::max(1ul, 1 + (TSimd<ui8>::SIZE - tuple_size) / padded_size);
+        const size_t simd_iters = (size > kSIMD_Rem ? size - kSIMD_Rem : 0) /
+                                  (tuples_per_store * StoresPerLoad);
+
+        TSimd<ui8> src_regs[Cols];
+        TSimd<ui8> perm_regs[Cols];
+
+        const ui8 *srcs[Cols];
+        std::memcpy(srcs, src_cols, sizeof(srcs));
+        for (ui8 col = 0; col != Cols; ++col) {
+            srcs[col] += col_sizes[col] * start;
+        }
+
+        auto dst = dst_rows;
+        ui8 *const end = dst_rows + simd_iters * tuples_per_store *
+                                        StoresPerLoad * padded_size;
+        while (dst != end) {
+            for (ui8 col = 0; col != Cols; ++col) {
+                src_regs[col] = TSimd<ui8>(srcs[col]);
+                srcs[col] += col_sizes[col] * tuples_per_store * StoresPerLoad;
+            }
+
+            for (ui8 iter = 0; iter != StoresPerLoad; ++iter) {
+                // shuffling each col bytes to the right positions
+                // then blending them together with 'or'
+                for (ui8 col = 0; col != Cols; ++col) {
+                    perm_regs[col] = src_regs[col].Shuffle(
+                        perms[col * StoresPerLoad + iter]);
+                }
+
+                TupleOr<Cols>(perm_regs).Store(dst);
+                dst += padded_size * tuples_per_store;
+            }
+        }
+
+        PackTupleFallbackRowImpl(srcs, dst, Cols,
+                                 size - simd_iters * tuples_per_store *
+                                            StoresPerLoad,
+                                 col_sizes, offsets, padded_size);
+    }
+
+    template <ui8 LoadsPerStore, ui8 Cols>
+    static void
+    UnpackTupleOr(const ui8 *const src_rows, ui8 *const dst_cols[], size_t size,
+                  const size_t col_sizes[], const size_t offsets[],
+                  const size_t tuple_size, const size_t padded_size,
+                  const TSimd<ui8> perms[], const size_t start = 0) {
+        static constexpr size_t kSIMD_Rem = sizeof(TSimd<ui8>) - LoadsPerStore;
+        const ui8 tuples_per_load =
+            std::max(1ul, 1 + (TSimd<ui8>::SIZE - tuple_size) / padded_size);
+        const size_t simd_iters = (size > kSIMD_Rem ? size - kSIMD_Rem : 0) /
+                                  (tuples_per_load * LoadsPerStore);
+
+        TSimd<ui8> src_regs[LoadsPerStore];
+        TSimd<ui8> perm_regs[LoadsPerStore];
+
+        auto src = src_rows;
+        const ui8 *const end = src_rows + simd_iters * tuples_per_load *
+                                              LoadsPerStore * padded_size;
+
+        ui8 *dsts[Cols];
+        std::memcpy(dsts, dst_cols, sizeof(dsts));
+        for (ui8 col = 0; col != Cols; ++col) {
+            dsts[col] += col_sizes[col] * start;
+        }
+
+        while (src != end) {
+            for (ui8 iter = 0; iter != LoadsPerStore; ++iter) {
+                src_regs[iter] = TSimd<ui8>(src);
+                src += padded_size * tuples_per_load;
+            }
+
+            for (ui8 col = 0; col != Cols; ++col) {
+                // shuffling each col bytes to the right positions
+                // then blending them together with 'or'
+                for (ui8 iter = 0; iter != LoadsPerStore; ++iter) {
+                    perm_regs[iter] = src_regs[iter].Shuffle(
+                        perms[col * LoadsPerStore + iter]);
+                }
+
+                TupleOr<LoadsPerStore>(perm_regs).Store(dsts[col]);
+                dsts[col] += col_sizes[col] * tuples_per_load * LoadsPerStore;
+            }
+        }
+
+        UnpackTupleFallbackRowImpl(src, dsts, Cols,
+                                   size - simd_iters * tuples_per_load *
+                                              LoadsPerStore,
+                                   col_sizes, offsets, padded_size);
+    }
+};
 
 } // namespace NPackedTuple
 } // namespace NMiniKQL

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/packing.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/packing.h
@@ -1,0 +1,285 @@
+#include <util/system/unaligned_mem.h>
+#include <ydb/library/yql/utils/simd/simd.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+[[maybe_unused]]
+static void
+PackTupleFallbackRowImpl(const ui8 *const src_cols[], ui8 *const dst_rows,
+                         const size_t cols, const size_t size,
+                         const size_t col_sizes[], const size_t offsets[],
+                         const size_t padded_size, const size_t start = 0) {
+    for (size_t row = 0; row != size; ++row) {
+        for (size_t col = 0; col != cols; ++col) {
+            switch (col_sizes[col] * 8) {
+
+#define MULTY_8x4(...)                                                         \
+    __VA_ARGS__(8);                                                            \
+    __VA_ARGS__(16);                                                           \
+    __VA_ARGS__(32);                                                           \
+    __VA_ARGS__(64)
+
+#define CASE(bits)                                                             \
+    case bits:                                                                 \
+        *reinterpret_cast<ui##bits *>(dst_rows + row * padded_size +           \
+                                      offsets[col]) =                          \
+            *reinterpret_cast<const ui##bits *>(src_cols[col] +                \
+                                                (start + row) * (bits / 8));   \
+        break
+
+                MULTY_8x4(CASE);
+
+#undef CASE
+#undef MULTY_8x4
+
+            default:
+                memcpy(dst_rows + row * padded_size + offsets[col],
+                       src_cols[col] + (start + row) * col_sizes[col],
+                       col_sizes[col]);
+            }
+        }
+    }
+}
+
+[[maybe_unused]]
+static void
+UnpackTupleFallbackRowImpl(const ui8 *const src_rows, ui8 *const dst_cols[],
+                           const size_t cols, const size_t size,
+                           const size_t col_sizes[], const size_t offsets[],
+                           const size_t padded_size, const size_t start = 0) {
+    for (size_t row = 0; row != size; ++row) {
+        for (size_t col = 0; col != cols; ++col) {
+            switch (col_sizes[col] * 8) {
+
+#define MULTY_8x4(...)                                                         \
+    __VA_ARGS__(8);                                                            \
+    __VA_ARGS__(16);                                                           \
+    __VA_ARGS__(32);                                                           \
+    __VA_ARGS__(64)
+
+#define CASE(bits)                                                             \
+    case bits:                                                                 \
+        *reinterpret_cast<ui##bits *>(dst_cols[col] +                          \
+                                      (start + row) * (bits / 8)) =            \
+            *reinterpret_cast<const ui##bits *>(src_rows + row * padded_size + \
+                                                offsets[col]);                 \
+        break
+
+                MULTY_8x4(CASE);
+
+#undef CASE
+#undef MULTY_8x4
+
+            default:
+                memcpy(dst_cols[col] + (start + row) * col_sizes[col],
+                       src_rows + row * padded_size + offsets[col],
+                       col_sizes[col]);
+            }
+        }
+    }
+}
+
+template <class ByteType>
+Y_FORCE_INLINE static void
+PackTupleFallbackTypedColImpl(const ui8 *const src_col, ui8 *const dst_rows,
+                              const size_t size, const size_t padded_size,
+                              const size_t start = 0) {
+    static constexpr size_t BYTES = sizeof(ByteType);
+    for (size_t row = 0; row != size; ++row) {
+        WriteUnaligned<ByteType>(
+            dst_rows + row * padded_size,
+            ReadUnaligned<ByteType>(src_col + (start + row) * BYTES));
+    }
+}
+
+template <class ByteType>
+Y_FORCE_INLINE static void
+UnpackTupleFallbackTypedColImpl(const ui8 *const src_rows, ui8 *const dst_col,
+                                const size_t size, const size_t padded_size,
+                                const size_t start = 0) {
+    static constexpr size_t BYTES = sizeof(ByteType);
+    for (size_t row = 0; row != size; ++row) {
+        WriteUnaligned<ByteType>(
+            dst_col + (start + row) * BYTES,
+            ReadUnaligned<ByteType>(src_rows + row * padded_size));
+    }
+}
+
+static void
+PackTupleFallbackColImpl(const ui8 *const src_cols[], ui8 *const dst_rows,
+                         const size_t cols, const size_t size,
+                         const size_t col_sizes[], const size_t offsets[],
+                         const size_t padded_size, const size_t start = 0) {
+    for (size_t col = 0; col != cols; ++col) {
+        switch (col_sizes[col] * 8) {
+
+#define MULTY_8x4(...)                                                         \
+    __VA_ARGS__(8);                                                            \
+    __VA_ARGS__(16);                                                           \
+    __VA_ARGS__(32);                                                           \
+    __VA_ARGS__(64)
+
+#define CASE(bits)                                                             \
+    case bits:                                                                 \
+        PackTupleFallbackTypedColImpl<ui##bits>(                               \
+            src_cols[col], dst_rows + offsets[col], size, padded_size, start); \
+        break
+
+            MULTY_8x4(CASE);
+
+#undef CASE
+#undef MULTY_8x4
+
+        default:
+            for (size_t row = 0; row != size; ++row) {
+                memcpy(dst_rows + row * padded_size + offsets[col],
+                       src_cols[col] + (start + row) * col_sizes[col],
+                       col_sizes[col]);
+            }
+        }
+    }
+}
+
+static void
+UnpackTupleFallbackColImpl(const ui8 *const src_rows, ui8 *const dst_cols[],
+                           const size_t cols, const size_t size,
+                           const size_t col_sizes[], const size_t offsets[],
+                           const size_t padded_size, const size_t start = 0) {
+    for (size_t col = 0; col != cols; ++col) {
+        switch (col_sizes[col] * 8) {
+
+#define MULTY_8x4(...)                                                         \
+    __VA_ARGS__(8);                                                            \
+    __VA_ARGS__(16);                                                           \
+    __VA_ARGS__(32);                                                           \
+    __VA_ARGS__(64)
+
+#define CASE(bits)                                                             \
+    case bits:                                                                 \
+        UnpackTupleFallbackTypedColImpl<ui##bits>(                             \
+            src_rows + offsets[col], dst_cols[col], size, padded_size, start); \
+        break
+
+            MULTY_8x4(CASE);
+
+#undef CASE
+#undef MULTY_8x4
+
+        default:
+            for (size_t row = 0; row != size; ++row) {
+                memcpy(dst_cols[col] + (start + row) * col_sizes[col],
+                       src_rows + row * padded_size + offsets[col],
+                       col_sizes[col]);
+            }
+        }
+    }
+}
+
+[[maybe_unused]] static void PackTupleFallbackBlockImpl(
+    const ui8 *const src_cols[], ui8 *const dst_rows, const size_t cols,
+    const size_t size, const size_t col_sizes[], const size_t offsets[],
+    const size_t padded_size, const size_t block_rows, const size_t start = 0) {
+
+    const size_t block_size = size / block_rows;
+    for (size_t block = 0; block != block_size; ++block) {
+        for (size_t col = 0; col != cols; ++col) {
+            switch (col_sizes[col] * 8) {
+
+#define BLOCK_LOOP(...)                                                        \
+    for (size_t block_i = 0; block_i != block_rows; ++block_i) {               \
+        const size_t row = block_rows * block + block_i;                       \
+        __VA_ARGS__                                                            \
+    }
+
+#define MULTY_8x4(...)                                                         \
+    __VA_ARGS__(8);                                                            \
+    __VA_ARGS__(16);                                                           \
+    __VA_ARGS__(32);                                                           \
+    __VA_ARGS__(64)
+
+#define CASE(bits)                                                             \
+    case bits:                                                                 \
+        PackTupleFallbackTypedColImpl<ui##bits>(                               \
+            src_cols[col],                                                     \
+            dst_rows + block * block_rows * padded_size + offsets[col],        \
+            block_rows, padded_size, start + block * block_rows);              \
+        break
+
+                MULTY_8x4(CASE);
+
+            default:
+                BLOCK_LOOP(
+                    memcpy(dst_rows + row * padded_size + offsets[col],
+                           src_cols[col] + (start + row) * col_sizes[col],
+                           col_sizes[col]);)
+
+#undef CASE
+#undef MULTY_8x4
+#undef BLOCK_LOOP
+            }
+        }
+    }
+
+    PackTupleFallbackColImpl(
+        src_cols, dst_rows + block_size * block_rows * padded_size, cols,
+        size - block_size * block_rows, col_sizes, offsets, padded_size,
+        start + block_size * block_rows);
+}
+
+[[maybe_unused]] static void UnpackTupleFallbackBlockImpl(
+    const ui8 *const src_rows, ui8 *const dst_cols[], const size_t cols,
+    const size_t size, const size_t col_sizes[], const size_t offsets[],
+    const size_t padded_size, const size_t block_rows, const size_t start = 0) {
+
+    const size_t block_size = size / block_rows;
+    for (size_t block = 0; block != block_size; ++block) {
+        for (size_t col = 0; col != cols; ++col) {
+            switch (col_sizes[col] * 8) {
+
+#define BLOCK_LOOP(...)                                                        \
+    for (size_t block_i = 0; block_i != block_rows; ++block_i) {               \
+        const size_t row = block_rows * block + block_i;                       \
+        __VA_ARGS__                                                            \
+    }
+
+#define MULTY_8x4(...)                                                         \
+    __VA_ARGS__(8);                                                            \
+    __VA_ARGS__(16);                                                           \
+    __VA_ARGS__(32);                                                           \
+    __VA_ARGS__(64)
+
+#define CASE(bits)                                                             \
+    case bits:                                                                 \
+        UnpackTupleFallbackTypedColImpl<ui##bits>(                             \
+            src_rows + block * block_rows * padded_size + offsets[col],        \
+            dst_cols[col], block_rows, padded_size,                            \
+            start + block * block_rows);                                       \
+        break
+
+                MULTY_8x4(CASE);
+
+            default:
+                BLOCK_LOOP(
+                    memcpy(dst_cols[col] + (start + row) * col_sizes[col],
+                           src_rows + row * padded_size + offsets[col],
+                           col_sizes[col]);)
+
+#undef CASE
+#undef MULTY_8x4
+#undef BLOCK_LOOP
+            }
+        }
+    }
+
+    UnpackTupleFallbackColImpl(src_rows + block_size * block_rows * padded_size,
+                               dst_cols, cols, size - block_size * block_rows,
+                               col_sizes, offsets, padded_size,
+                               start + block_size * block_rows);
+}
+
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.cpp
@@ -1,0 +1,205 @@
+#include "page_hash_table.h"
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+#include <arrow/util/bit_util.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+// -----------------------------------------------------------------
+THolder<TPageHashTable> TPageHashTable::Create(const TTupleLayout* layout, ui32) {
+    if (NX86::HaveAVX2()) {
+        return MakeHolder<TPageHashTableImpl<NSimd::TSimdAVX2Traits>>(layout);
+    }
+
+    if (NX86::HaveSSE42()) {
+        return MakeHolder<TPageHashTableImpl<NSimd::TSimdSSE42Traits>>(layout);
+    }
+
+    return MakeHolder<TPageHashTableImpl<NSimd::TSimdFallbackTraits>>(layout);
+}
+
+
+// -----------------------------------------------------------------
+template <typename TTraits, bool Prefetch>
+void TPageHashTableImpl<TTraits, Prefetch>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems) {
+    TotalPages_ = (nItems * SlotSize_ * 3 / 2 + PageSize_ - 1) / PageSize_;
+    const ui32 logTotalPages = arrow::BitUtil::NumRequiredBits(TotalPages_ - 1);
+    TotalPages_ = 1ul << logTotalPages;    
+    ProbeByteIndex_ = std::min<ui32>(32 - 8, logTotalPages);
+
+    Data_.assign(TotalPages_ * PageSize_, 0);
+
+    OriginalData_ = data;
+    OriginalOverflow_ = overflow;
+
+    constexpr ui32 prefetchInAdvance = 16;
+
+    if constexpr (Prefetch) {
+        for (ui32 i = 0; i < std::min<ui32>(prefetchInAdvance, nItems); i++) {
+            const ui8* tuple = OriginalData_ + i * TupleSize_;
+            ui32 hash = ReadUnaligned<ui32>(tuple);
+            ui64 pageNum = PageNum(hash);
+    
+            ui64 pagePos = pageNum * PageSize_;
+            ui8* pageAddr = Data_.data() + pagePos;
+
+            NYql::PrefetchForWrite(pageAddr);
+        }
+    }
+
+    for (ui32 i = 0; i < nItems; i++) {
+        if constexpr (Prefetch) {
+            if (i + prefetchInAdvance < nItems) {
+                const ui8* tuple = OriginalData_ + (i + prefetchInAdvance) * TupleSize_;
+                ui32 hash = ReadUnaligned<ui32>(tuple);
+                ui64 pageNum = PageNum(hash);
+        
+                ui64 pagePos = pageNum * PageSize_;
+                ui8* pageAddr = Data_.data() + pagePos;
+                
+                NYql::PrefetchForWrite(pageAddr);
+            }
+        }    
+
+        const ui8* tuple = OriginalData_ + i * TupleSize_;
+        ui32 hash = ReadUnaligned<ui32>(tuple);
+        ui64 pageNum = PageNum(hash);
+
+        ui64 pagePos = pageNum * PageSize_;
+        ui8* pageAddr = Data_.data() + pagePos;
+        ui8 filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+
+        while (filledSlotsCounter >= SlotsCount_) { // while page is completely filled
+            pageAddr += PageSize_;
+
+            if (pageAddr >= Data_.end()) { // cyclic buffer
+                pageAddr = Data_.data();
+            }
+
+            filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+        }
+
+        // found page with empty slot
+        pageAddr[filledSlotsCounter + 1] = (hash >> ProbeByteIndex_) & 0xFF;
+        pageAddr[0] = filledSlotsCounter + 1;
+
+        if (!IsEmbedded_) {
+            // put index to original buffer into slot
+            WriteUnaligned<ui32>(pageAddr + PageHeaderSize_ + SlotSize_ * filledSlotsCounter, i);
+        } else {
+            // copy tuple from original buffer into slot
+            std::memcpy(pageAddr + PageHeaderSize_ + SlotSize_ * filledSlotsCounter, tuple, TupleSize_);
+        }
+    }
+}
+
+template void TPageHashTableImpl<NSimd::TSimdFallbackTraits, false>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template __attribute__((target("avx2"))) void
+TPageHashTableImpl<NSimd::TSimdAVX2Traits, false>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template __attribute__((target("sse4.2"))) void
+TPageHashTableImpl<NSimd::TSimdSSE42Traits, false>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template void TPageHashTableImpl<NSimd::TSimdFallbackTraits, true>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template __attribute__((target("avx2"))) void
+TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template __attribute__((target("sse4.2"))) void
+TPageHashTableImpl<NSimd::TSimdSSE42Traits, true>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+
+
+// -----------------------------------------------------------------
+template <typename TTraits, bool Prefetch>
+ui32 TPageHashTableImpl<TTraits, Prefetch>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems) {
+    Y_ASSERT(OriginalData_ != nullptr); // Build was called before Apply
+    using TSimd8 = typename TTraits:: template TSimd8<ui8>;
+
+    ui64 found = 0;
+
+    for (ui32 i = 0; i < nItems; i++) {
+        const ui8* tupleToFind = data + layout->TotalRowSize * i;
+        ui32 hash = ReadUnaligned<ui32>(tupleToFind);
+
+        ui64 pageNum = PageNum(hash);
+        ui64 pagePos = pageNum * PageSize_;
+        ui8* pageAddr = Data_.data() + pagePos;
+
+        while (true) { // Check all possible pages in collisions cycle
+            ui8 filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+            TSimd8 headerReg = TSimd8(reinterpret_cast<const ui8*>(pageAddr + 1));            // [<Probe byte 1> ... <Probe byte K>]
+            TSimd8 hashPartReg = TSimd8(static_cast<ui8>((hash >> ProbeByteIndex_) & 0xFF)); // [< Hash byte  > ... < Hash byte  >]
+            ui32 foundBitMask = (headerReg == hashPartReg).ToBitMask() & ((1ULL << filledSlotsCounter) - 1); // get all possible positions where desired tuples could be stored
+
+            ui32 nextSetPos = 0;
+            while (foundBitMask != 0) { // Check all possible matches in single page
+                ui32 moveMask = foundBitMask & -foundBitMask; // find least significant not null bit
+                nextSetPos = __builtin_ctzl(foundBitMask); // find position of least significant not null bit
+                foundBitMask ^= moveMask; // remove least significant not null bit
+
+                if (nextSetPos >= filledSlotsCounter) {
+                    break;
+                }
+
+                const ui8* tupleAddr;
+                // get address of tuple if it is embedded or if it is lays in original buffer
+                if (!IsEmbedded_) {
+                    ui32 index = ReadUnaligned<ui32>(pageAddr + PageHeaderSize_ + SlotSize_ * nextSetPos);
+                    tupleAddr = OriginalData_ + index * TupleSize_;
+                } else {
+                    tupleAddr = pageAddr + PageHeaderSize_ + SlotSize_ * nextSetPos;
+                }
+
+                if (Layout_->KeysEqual(tupleAddr, OriginalOverflow_, tupleToFind, overflow.data())) {
+                    found++;
+                }
+            }
+
+            if (filledSlotsCounter < SlotsCount_) { // Page has empty slots, i.e. there will definitely be no further occurrences
+                break;
+            }
+
+            pageAddr += PageSize_;
+            if (pageAddr >= Data_.end()) { // cyclic buffer
+                pageAddr = Data_.data();
+            }
+        }
+    }
+
+    return found;
+}
+
+template ui32 TPageHashTableImpl<NSimd::TSimdFallbackTraits, false>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template __attribute__((target("avx2"))) ui32
+TPageHashTableImpl<NSimd::TSimdAVX2Traits, false>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template __attribute__((target("sse4.2"))) ui32
+TPageHashTableImpl<NSimd::TSimdSSE42Traits, false>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template ui32 TPageHashTableImpl<NSimd::TSimdFallbackTraits, true>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template __attribute__((target("avx2"))) ui32
+TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template __attribute__((target("sse4.2"))) ui32
+TPageHashTableImpl<NSimd::TSimdSSE42Traits, true>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+
+// -----------------------------------------------------------------
+template <typename TTraits, bool Prefetch>
+void TPageHashTableImpl<TTraits, Prefetch>::Clear() {
+    if (OriginalData_ == nullptr) {
+        return;
+    }
+
+    OriginalData_ = nullptr;
+    for (ui32 i = 0; i < TotalPages_; i++) {
+        ui8* pageAddr = Data_.data() + i * PageSize_;
+        std::memset(pageAddr, 0, PageHeaderSize_);
+    }
+}
+
+template void TPageHashTableImpl<NSimd::TSimdFallbackTraits, false>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdSSE42Traits, false>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdAVX2Traits, false>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdFallbackTraits, true>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdSSE42Traits, true>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>::Clear();
+
+}
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.h
@@ -1,0 +1,296 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+#include <yql/essentials/utils/prefetch.h>
+
+#include <util/generic/buffer.h>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+
+/*
+* Class TPageHashTable provides open address hash table implementation for packed tuples.
+*
+* TPageHashTable has the following layout:
+* HashTable:    [Page 1][Page 2]...[Page N]
+* Page:         [<Header> <Slot 1> <Slot 2> ... <Slot K>]
+* Header:       [<Filled slots counter (1 byte)> <Probe byte 1> ... <Probe byte K>]
+*/
+class TPageHashTable {
+public:
+    class TIterator;
+
+protected:
+    struct TIteratorImpl {
+        static TIteratorImpl& UpCast(TIterator& iter) {
+            return static_cast<TIteratorImpl&>(iter);
+        }
+        TIterator& DownCast() {
+            return static_cast<TIterator&>(*this);
+        }
+        
+        TIteratorImpl(): PageAddr_(nullptr) {}
+
+    public:
+        const ui8* Row_;
+        const ui8* PageAddr_;
+        ui32 FoundBitMask_; 
+        ui8 HashByte_;
+    };
+
+public:
+    class TIterator : private TIteratorImpl {
+        friend TIteratorImpl;
+
+    public:
+        TIterator() = default;
+        TIterator(const TIterator&) = default;
+        TIterator& operator=(const TIterator&) = default;
+    };
+
+    virtual ~TPageHashTable() {};
+
+    // Creates hash table for given layout with given capacity
+    static THolder<TPageHashTable> Create(const TTupleLayout* layout, ui32 capacity);
+
+    // Build new hash table on passed data.
+    // Data must be presented as a TupleLayout.
+    virtual void Build(const ui8* data, const ui8 *const overflow, ui32 nItems) = 0;
+
+    // Finds matches in hash table
+    // This method is temporary. It is expected that this method will return a batch of found tuples
+    virtual ui32 FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems) = 0;
+
+    // Clears hash table content
+    virtual void Clear() = 0;
+};
+
+
+// -----------------------------------------------------------------
+template <typename TTraits, bool Prefetch = true>
+class TPageHashTableImpl: public TPageHashTable {
+public:
+    TPageHashTableImpl() = default;
+
+    explicit TPageHashTableImpl(const TTupleLayout* layout) {
+        SetTupleLayout(layout);
+    }
+
+    void SetTupleLayout(const TTupleLayout *layout) {
+        Clear();
+
+        TupleSize_ = layout->TotalRowSize;
+        Layout_ = layout;
+
+        IsEmbedded_ = TupleSize_ <= SlotSize_; // this flag used to dispatch where to store tuple
+    }
+
+    TPageHashTableImpl(const TPageHashTableImpl &) = delete;
+    void operator=(const TPageHashTableImpl &) = delete;
+
+    void Build(const ui8* data, const ui8 *const overflow, ui32 nItems) override;
+
+    ui32 FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems) override;
+    void Apply(const ui8 *const row, const ui8 *const overflow, auto &&onMatch);
+
+    void Clear() override;
+
+    Y_FORCE_INLINE const ui8 *NextMatch(TPageHashTable::TIterator &iter, const ui8 *overflow) const;
+    TIterator Find(const ui8 *const row, const ui8 *const overflow) const;
+
+    template <size_t Size>
+    std::array<TIterator, Size>
+    FindBatch(const std::array<const ui8 *, Size> &rows,
+              const ui8 *const overflow) const;
+
+private:
+    ui64 PageNum(ui64 hash) const {
+        return hash & (TotalPages_ - 1);
+    }
+
+private:
+    static constexpr ui32 SlotSize_{16};              // Amount of memory allocated per one slot
+    static constexpr ui32 SlotsCount_{TTraits::Size}; // Count of slots per page
+    static constexpr ui32 PageHeaderSize_{SlotsCount_ + 1};  // Size in bytes of the hash table page header. Page consists of header plus slots
+    static constexpr ui32 PageSize_{PageHeaderSize_ + SlotSize_ * SlotsCount_};  // Page size in bytes
+
+    ui32    TupleSize_{0};              // Amount of memory allocated per one tuple
+    bool    IsEmbedded_{false};
+    ui32    TotalPages_{0};             // Total number of pages in hash table
+    ui32    ProbeByteIndex_{0};
+
+    const TTupleLayout*                     Layout_{nullptr};   // Tuple layout description
+    std::vector<ui8, TMKQLAllocator<ui8>>   Data_;              // Place to store hash table data
+    const ui8*                              OriginalData_{nullptr};     // Data passed to build method
+    const ui8*                              OriginalOverflow_{nullptr}; // Overflow data passed to build method
+};
+
+template <typename TTraits, bool Prefetch>
+void TPageHashTableImpl<TTraits, Prefetch>::Apply(const ui8 *const row, const ui8 *const overflow, auto &&onMatch) {
+    Y_ASSERT(OriginalData_ != nullptr); // Build was called before Apply
+    using TSimd8 = typename TTraits:: template TSimd8<ui8>;
+    
+    ui32 hash = ReadUnaligned<ui32>(row);
+
+    ui64 pageNum = PageNum(hash);
+    ui64 pagePos = pageNum * PageSize_;
+    ui8* pageAddr = Data_.data() + pagePos;
+
+    while (true) { // Check all possible pages in collisions cycle
+        ui8 filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+        TSimd8 headerReg = TSimd8(reinterpret_cast<const ui8*>(pageAddr + 1));            // [<Probe byte 1> ... <Probe byte K>]
+        TSimd8 hashPartReg = TSimd8(static_cast<ui8>((hash >> ProbeByteIndex_) & 0xFF)); // [< Hash byte  > ... < Hash byte  >]
+        ui32 foundBitMask = (headerReg == hashPartReg).ToBitMask() & ((1ULL << filledSlotsCounter) - 1); // get all possible positions where desired tuples could be stored
+
+        ui32 nextSetPos = 0;
+        while (foundBitMask != 0) { // Check all possible matches in single page
+            ui32 moveMask = foundBitMask & -foundBitMask; // find least significant not null bit
+            nextSetPos = __builtin_ctzl(foundBitMask); // find position of least significant not null bit
+            foundBitMask ^= moveMask; // remove least significant not null bit
+
+            if (nextSetPos >= filledSlotsCounter) {
+                break;
+            }
+
+            const ui8* tupleAddr;
+            // get address of tuple if it is embedded or if it is lays in original buffer
+            if (!IsEmbedded_) {
+                ui32 index = ReadUnaligned<ui32>(pageAddr + PageHeaderSize_ + SlotSize_ * nextSetPos);
+                tupleAddr = OriginalData_ + index * TupleSize_;
+            } else {
+                tupleAddr = pageAddr + PageHeaderSize_ + SlotSize_ * nextSetPos;
+            }
+
+            // compare keys
+            if (Layout_->KeysEqual(tupleAddr, OriginalOverflow_, row, overflow)) {
+                onMatch(tupleAddr);
+            }            
+        }
+
+        if (filledSlotsCounter < SlotsCount_) { // Page has empty slots, i.e. there will definitely be no further occurrences
+            break;
+        }
+
+        pageAddr += PageSize_;
+        if (pageAddr >= Data_.end()) { // cyclic buffer
+            pageAddr = Data_.data();
+        }
+    }
+}
+
+template <typename TTraits, bool Prefetch>
+const ui8 *TPageHashTableImpl<TTraits, Prefetch>::NextMatch(TPageHashTable::TIterator &it, const ui8 *overflow) const {
+    using TSimd8 = typename TTraits:: template TSimd8<ui8>;
+
+    auto &iter = TIteratorImpl::UpCast(it);
+    if (iter.PageAddr_ == nullptr) {
+        return nullptr;
+    }
+
+    for (;;) { // Check all possible pages in collisions cycle
+        const ui8 filledSlotsCounter = ReadUnaligned<ui8>(iter.PageAddr_);
+
+        ui32 nextSetPos = 0;
+        while (iter.FoundBitMask_ != 0) { // Check all possible matches in single page
+            ui32 moveMask = iter.FoundBitMask_ & -iter.FoundBitMask_; // find least significant not null bit
+            nextSetPos = __builtin_ctzl(iter.FoundBitMask_); // find position of least significant not null bit
+            iter.FoundBitMask_ ^= moveMask; // remove least significant not null bit
+
+            if (nextSetPos >= filledSlotsCounter) {
+                break;
+            }
+
+            const ui8* tupleAddr;
+            // get address of tuple if it is embedded or if it is lays in original buffer
+            if (!IsEmbedded_) {
+                ui32 index = ReadUnaligned<ui32>(iter.PageAddr_ + PageHeaderSize_ + SlotSize_ * nextSetPos);
+                tupleAddr = OriginalData_ + index * TupleSize_;
+            } else {
+                tupleAddr = iter.PageAddr_ + PageHeaderSize_ + SlotSize_ * nextSetPos;
+            }
+
+            if (Layout_->KeysEqual(tupleAddr, OriginalOverflow_, iter.Row_, overflow)) {
+                return tupleAddr;
+            }
+        }
+
+        if (filledSlotsCounter < SlotsCount_) { // Page has empty slots, i.e. there will definitely be no further occurrences
+            iter = {};
+            break;
+        }
+
+        iter.PageAddr_ += PageSize_;
+        if (iter.PageAddr_ >= Data_.end()) { // cyclic buffer
+            iter.PageAddr_ = Data_.data();
+        }
+
+        const TSimd8 headerReg = TSimd8(reinterpret_cast<const ui8*>(iter.PageAddr_ + 1)); // [<Probe byte 1> ... <Probe byte K>]
+        const TSimd8 hashPartReg = TSimd8(iter.HashByte_); // [< Hash byte  > ... < Hash byte  >]
+        iter.FoundBitMask_ = (headerReg == hashPartReg).ToBitMask() & ((1ULL << filledSlotsCounter) - 1); // get all possible positions where desired tuples could be stored
+    }
+
+    return nullptr;
+}
+
+template <typename TTraits, bool Prefetch>
+typename TPageHashTableImpl<TTraits, Prefetch>::TIterator
+TPageHashTableImpl<TTraits, Prefetch>::Find(const ui8 *const row,
+                                            const ui8 *const /*overflow*/) const {
+    using TSimd8 = typename TTraits:: template TSimd8<ui8>;
+
+    const ui32 hash = ReadUnaligned<ui32>(row);
+    const ui64 pageNum = PageNum(hash);
+    const ui64 pagePos = pageNum * PageSize_;
+    const ui8 *const pageAddr = Data_.data() + pagePos;
+    const ui8 filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+    const TSimd8 headerReg = TSimd8(reinterpret_cast<const ui8*>(pageAddr + 1));            // [<Probe byte 1> ... <Probe byte K>]
+    const TSimd8 hashPartReg = TSimd8(static_cast<ui8>((hash >> ProbeByteIndex_) & 0xFF)); // [< Hash byte  > ... < Hash byte  >]
+    const ui32 foundBitMask = (headerReg == hashPartReg).ToBitMask() & ((1ULL << filledSlotsCounter) - 1);
+    const ui8 hashByte = (hash >> ProbeByteIndex_) & 0xFF;
+
+    TIteratorImpl iter;
+    iter.Row_ = row;
+    iter.PageAddr_ = pageAddr;
+    iter.FoundBitMask_ = foundBitMask;
+    iter.HashByte_ = hashByte;
+
+    return iter.DownCast();
+}
+
+template <typename TTraits, bool Prefetch>
+template <size_t Size>
+std::array<typename TPageHashTableImpl<TTraits, Prefetch>::TIterator, Size>
+TPageHashTableImpl<TTraits, Prefetch>::FindBatch(
+    const std::array<const ui8 *, Size> &rows,
+    const ui8 *const overflow) const {
+    if constexpr (Prefetch) {
+        for (ui32 i = 0; i < Size && rows[i]; i++) {
+            const ui32 hash = ReadUnaligned<ui32>(rows[i]);
+            const ui64 pageNum = PageNum(hash);
+            const ui64 pagePos = pageNum * PageSize_;
+            const ui8 *const pageAddr = Data_.data() + pagePos;;
+            NYql::PrefetchForRead(pageAddr);
+        }
+    }
+
+    std::array<TIterator, Size> iters;
+    for (ui32 i = 0; i < Size && rows[i]; i++) {
+        iters[i] = Find(rows[i], overflow);
+    }
+
+    return iters;
+}
+
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/robin_hood_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/robin_hood_table.h
@@ -1,0 +1,657 @@
+#pragma once
+
+#include <util/generic/bitops.h>
+#include <util/generic/yexception.h>
+#include <util/system/compiler.h>
+#include <util/system/types.h>
+
+#include <yql/essentials/minikql/mkql_rh_hash_utils.h>
+#include <yql/essentials/utils/prefetch.h>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+#include <util/digest/city.h>
+#include <util/generic/scope.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+struct TTupleEqual {
+    bool operator()(const TTupleLayout *layout, const ui8 *lhsRow,
+                    const ui8 *lhsOverflow, const ui8 *rhsRow,
+                    const ui8 *rhsOverflow) const {
+        return layout->KeysEqual(lhsRow, lhsOverflow, rhsRow, rhsOverflow);
+    }
+};
+
+struct TTupleHash {
+    ui32 operator()(const TTupleLayout * /*layout*/, const ui8 *tuple,
+                    const ui8 * /*overflow*/) const {
+        return ((const ui32 *)tuple)[0];
+    }
+};
+
+template <bool ConsecutiveDuplicates = true, bool Prefetch = true,
+          typename TAllocator = TMKQLAllocator<ui8>>
+class TRobinHoodHashBase {
+    using TEqual = TTupleEqual;
+    using THash = TTupleHash;
+
+    struct TCellStatus {
+        /// TODO: default: ui32
+        ///       ui16 for testing embedded case of map[ui32] -> ui32
+        using T = ui16; 
+
+        static constexpr T kInvalid = 0;
+        static constexpr T kStart = 2;
+
+        bool IsValid() const { return value; }
+        bool IsList() const { return value & 1; }
+        void ToList() { value = value | 1; }
+        void operator++() { value += 2; }
+        bool operator<(TCellStatus rhs) const { return value < rhs.value; }
+
+      public:
+      T value = kStart;
+    };
+
+    struct TPSLStorage {
+        TCellStatus CellStatus;
+
+        TPSLStorage() = default;
+        TPSLStorage(ui32 /*hash*/) : CellStatus(TCellStatus::kStart) {}
+    };
+
+    struct TPSLOutStorage : TPSLStorage, TIndexedTuple {
+        ui32 DupIndex;
+
+        TPSLOutStorage() = default;
+        TPSLOutStorage(ui32 hash, ui32 outIndex)
+            : TPSLStorage(hash), TIndexedTuple{hash, outIndex} {}
+    };
+
+    static constexpr ui32 kEmbeddedSize = 16;
+    static_assert(sizeof(TPSLOutStorage) <= kEmbeddedSize);
+
+    static constexpr ui32 RoundUp(ui32 n, ui32 r) {
+        return ((n + r - 1) / r) * r;
+    }
+
+  public:
+    struct TIterator {
+        friend TRobinHoodHashBase;
+
+      public:
+        TIterator(): Matched_(nullptr), Len_(0) {}
+
+      private:
+        const ui8 *Matched_;
+        ui32 Len_;
+    };
+
+  public:
+    TRobinHoodHashBase() : SelfHash_(GetSelfHash(this)), DupSeq_(Allocator_) {
+        // Init(256);
+    }
+
+    explicit TRobinHoodHashBase(const TTupleLayout *layout)
+        : TRobinHoodHashBase() {
+        SetTupleLayout(layout);
+    }
+
+    ~TRobinHoodHashBase() {
+        if (Data_) {
+            Allocator_.deallocate(Data_, DataEnd_ - Data_);
+        }
+    }
+
+    void SetTupleLayout(const TTupleLayout *layout) {
+        Clear();
+
+        Layout_ = layout;
+        /// whole tuple and tuple key with index can be embedded
+        IsInplace_ = sizeof(TPSLStorage) + layout->TotalRowSize <= kEmbeddedSize && 
+                     sizeof(TPSLStorage) + layout->PayloadOffset + sizeof(ui32) <= kEmbeddedSize;
+        // CellSize_ = IsInplace_
+        //     ? RoundUp(sizeof(TPSLStorage) + std::max<ui32>(layout->TotalRowSize,
+        //                                                    layout->PayloadOffset + sizeof(ui32)),
+        //               sizeof(ui32))
+        //     : sizeof(TPSLOutStorage);
+        DupPayloadSize_ = IsInplace_ ? Layout_->TotalRowSize : sizeof(ui32);
+
+        /// size may be stored in dup cell
+        Y_ASSERT(DupPayloadSize_ >= sizeof(ui32));
+    }
+
+    TRobinHoodHashBase(const TRobinHoodHashBase &) = delete;
+    TRobinHoodHashBase(TRobinHoodHashBase &&) = delete;
+    void operator=(const TRobinHoodHashBase &) = delete;
+    void operator=(TRobinHoodHashBase &&) = delete;
+
+    Y_FORCE_INLINE const ui8 *NextMatch(TIterator &iter, const ui8 * /*overflow*/) const {
+        const ui8 *result = nullptr;
+
+        if constexpr (ConsecutiveDuplicates) {
+            if (iter.Len_) { /// allow multiple false calls
+                result = iter.Matched_;
+                iter.Matched_ += DupPayloadSize_;
+                iter.Len_--;
+            }
+        } else {
+            if (iter.Matched_) { /// allow multiple false calls
+                result = iter.Matched_;
+                if (!iter.Len_) {
+                    iter.Matched_ = nullptr;
+                } else {
+                    ui32 dupIndex = ReadUnaligned<ui32>(iter.Matched_ + DupPayloadSize_);
+                    iter.Matched_ = dupIndex == -1u
+                                    ? nullptr
+                                    : &DupSeq_[dupIndex * (DupPayloadSize_ + sizeof(ui32))];
+                }
+            }
+        }
+
+        if (!IsInplace_ && result) {
+            result = GetTupleOut(ReadUnaligned<ui32>(result));
+        }
+
+        return result;
+    }
+
+    Y_FORCE_INLINE TIterator Find(const ui8 *const tuple, const ui8 *const overflow) const {
+        const ui32 hash = TupleHash_(Layout_, tuple, overflow);
+        auto ptr = GetPtr(hash, Data_, CapacityShift_);
+        return FindImpl(hash, ptr, tuple, overflow);
+    }
+
+    template <size_t Size>
+    Y_FORCE_INLINE std::array<TIterator, Size>
+    FindBatch(const std::array<const ui8 *, Size> &tuples,
+              const ui8 *const overflow) const {
+        if constexpr (Prefetch) {
+            for (ui32 index = 0; index < Size && tuples[index]; ++index) {
+                const ui32 hash = TupleHash_(Layout_, tuples[index], overflow);
+                auto ptr = GetPtr(hash, Data_, CapacityShift_);
+                NYql::PrefetchForRead(ptr);
+            }
+        }
+
+        std::array<TIterator, Size> iters;
+        for (ui32 index = 0; index < Size && tuples[index]; ++index) {
+            iters[index] = Find(tuples[index], overflow);
+        }
+
+        return iters;
+    }
+
+    Y_FORCE_INLINE void Apply(const ui8 *const tuple, const ui8 *const overflow,
+                              auto &&onMatch) {
+        auto iter = Find(tuple, overflow);
+        while (auto matched = NextMatch(iter, overflow)) {
+            onMatch(matched);
+        }
+    }
+
+    void Build(const ui8 *const tuples, const ui8 *const overflow,
+               ui32 nItems) {
+        Y_ASSERT(Size_ == 0 && Listed_ == 0 && ListedUnique_ == 0);
+
+        Tuples_ = tuples;
+        Overflow_ = overflow;
+
+        /// heuristic to decrease number of growths
+        constexpr ui32 preallocFactor = 16;
+        if (RHHashTableNeedsGrow(nItems / preallocFactor, Capacity_)) {
+            Grow(nItems / preallocFactor);
+        }
+
+        auto duplicates = TVector<ui8, TAllocator>(Allocator_);
+
+        constexpr ui32 prefetchInAdvance = 16;
+
+        if constexpr (Prefetch) {
+            for (ui32 index = 0; index < std::min(prefetchInAdvance, nItems); ++index) {
+                const ui8 *const tuple = Tuples_ + index * Layout_->TotalRowSize;
+                const auto hash = TupleHash_(Layout_, tuple, Overflow_);
+                const auto ptr = GetPtr(hash, Data_, CapacityShift_);
+                NYql::PrefetchForWrite(ptr);
+            }
+        }
+
+        for (ui32 index = 0; index < nItems; ++index) {
+            if (RHHashTableNeedsGrow(Size_, Capacity_)) {
+                Grow(Size_);
+            }
+
+            if constexpr (Prefetch) {
+                if (index + prefetchInAdvance < nItems) {
+                    const ui8 *const tuple = Tuples_ + (index + prefetchInAdvance) * Layout_->TotalRowSize;
+                    const auto hash = TupleHash_(Layout_, tuple, Overflow_);
+                    const auto ptr = GetPtr(hash, Data_, CapacityShift_);
+                    NYql::PrefetchForWrite(ptr);
+                }
+            }    
+
+            const ui8 *const tuple = Tuples_ + index * Layout_->TotalRowSize;
+            const auto hash = TupleHash_(Layout_, tuple, Overflow_);
+            const auto ptr = GetPtr(hash, Data_, CapacityShift_);
+
+            ui8 cell[kEmbeddedSize];
+            if (IsInplace_) {
+                new (cell) TPSLStorage(hash);
+                std::memcpy(GetTuple(cell), tuple, Layout_->TotalRowSize);
+            } else {
+                new (cell) TPSLOutStorage(hash, index);
+            }
+
+            Size_ += InsertImpl(cell, hash, ptr, Data_, DataEnd_, duplicates,
+                               EqualInsertHandler);
+        }
+
+        if (Listed_ == 0) {
+            return;
+        }
+
+        if constexpr (!ConsecutiveDuplicates) {
+            DupSeq_ = std::move(duplicates);
+            return;
+        }
+
+        DupSeq_.resize((Listed_ + ListedUnique_) * DupPayloadSize_);
+        ui32 dupSeqIndex = 0;
+
+        for (auto ptr = Data_; ptr != DataEnd_; ptr += CellSize_) {
+            auto &ptrPsl = GetPSL(ptr);
+            if (!ptrPsl.CellStatus.IsValid() || !ptrPsl.CellStatus.IsList()) {
+                continue;
+            }
+            
+            ui32 &ptrDupIndex = IsInplace_ ? GetDupIndex(ptr) : GetPSLOut(ptr).DupIndex;
+            ui32 dupIndex = ptrDupIndex; 
+            ptrDupIndex = dupSeqIndex;
+
+            ui32 &ptrSize = *(ui32 *)(DupSeq_.data() + dupSeqIndex * DupPayloadSize_);
+            ptrSize = 0;
+            ui8 *ptrDupSeq = DupSeq_.data() + (dupSeqIndex + 1) * DupPayloadSize_;
+            ++dupSeqIndex;
+
+            while (dupIndex != -1u) {
+                const auto *const ptrDup =
+                    &duplicates[dupIndex * (DupPayloadSize_ + sizeof(ui32))];
+                std::memcpy(ptrDupSeq, ptrDup, DupPayloadSize_);
+                
+                ptrDupSeq += DupPayloadSize_;
+                ++ptrSize;
+                dupIndex = ReadUnaligned<ui32>(ptrDup + DupPayloadSize_);
+                ++dupSeqIndex;
+            }
+        }
+    }
+
+    void Clear() {
+        if (Size_ != 0) {
+            ui8 *ptr = Data_;
+            for (ui64 i = 0; i < Capacity_; ++i, ptr += CellSize_) {
+                GetPSL(ptr).CellStatus.value = TCellStatus::kInvalid;
+            }
+        }
+
+        Size_ = 0;
+        Listed_ = 0;
+        ListedUnique_ = 0;
+
+        Tuples_ = nullptr;
+        Overflow_ = nullptr;
+    }
+
+  private:
+    ui8 *GetPtr(const ui64 hash, ui8 *data, ui64 capacityShift) const {
+        // https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
+        ui64 bucket = ((SelfHash_ ^ hash) * 11400714819323198485llu) >> capacityShift;
+        ui8 *ptr = data + CellSize_ * bucket;
+        return ptr;
+    }
+
+    static ui8 *GetTuple(ui8 *ptr) { return ptr + sizeof(TPSLStorage); }
+
+    const ui8 *GetTupleOut(ui32 index) const {
+        return Tuples_ + index * Layout_->TotalRowSize;
+    }
+
+    static TPSLStorage &GetPSL(ui8 *ptr) { return *(TPSLStorage *)ptr; }
+
+    static TPSLOutStorage &GetPSLOut(ui8 *ptr) {
+        return *(TPSLOutStorage *)ptr;
+    }
+
+    ui32 &GetDupIndex(ui8 *ptr) const {
+        return *(ui32 *)(ptr + CellSize_ - sizeof(ui32));
+    }
+
+    void CopyCell(ui8 *dst, const ui8 *src) {
+        std::memcpy(dst, src, CellSize_);
+    }
+
+    void SwapCells(ui8 *lhs, ui8 *rhs) {
+        ui8 buf[kEmbeddedSize];
+        std::memcpy(buf, lhs, CellSize_);
+        std::memcpy(lhs, rhs, CellSize_);
+        std::memcpy(rhs, buf, CellSize_);
+    }
+
+    Y_FORCE_INLINE TIterator FindImpl(ui32 hash, ui8* ptr, const ui8 *const tuple, const ui8 *const overflow) const {
+        TCellStatus currCellStatus;
+        TIterator iter;
+
+        for (;;) {
+            auto &ptrPsl = GetPSL(ptr);
+            if (ptrPsl.CellStatus < currCellStatus) {
+                return iter;
+            }
+
+            auto onCell = [&](const ui8 *matched) { 
+                iter.Matched_ = matched;
+                if constexpr (ConsecutiveDuplicates) {
+                    iter.Len_ = 1;
+                }
+            };
+            auto onList = [&](const ui8 *matched) {
+                if constexpr (ConsecutiveDuplicates) {
+                    iter.Len_ = ReadUnaligned<ui32>(matched);
+                    iter.Matched_ = matched + DupPayloadSize_;
+                    if constexpr (Prefetch) {
+                        NYql::PrefetchForRead(iter.Matched_);
+                    }
+                } else {
+                    iter.Len_ = true; /// used as flag
+                    iter.Matched_ = matched;
+                }
+            };
+
+            if (OnEqual<!ConsecutiveDuplicates>(
+                    hash, ptr, DupSeq_, tuple, overflow,
+                    onCell, onList, onCell, onList)) {
+                return iter;
+            }
+
+            ++currCellStatus;
+            AdvancePointer(ptr, Data_, DataEnd_);
+        }
+    }
+
+    template <bool Offseted>
+    Y_FORCE_INLINE bool
+    OnEqual(ui32 hash, ui8 *ptr, const TVector<ui8, TAllocator> &duplicates,
+            const ui8 *tuple, const ui8 *overflow, auto FInplaceCell,
+            auto FInplaceList, auto FOutplaceCell, auto FOutplaceList) const {
+        static constexpr ui32 dupOffset = Offseted ? sizeof(ui32) : 0;
+
+        auto &ptrPsl = GetPSL(ptr);
+
+        if (IsInplace_) {
+            auto *const ptrTuple = GetTuple(ptr);
+
+            if (TuplesEqual_(Layout_, ptrTuple, Overflow_, tuple, overflow)) {
+                if (!ptrPsl.CellStatus.IsList()) {
+                    FInplaceCell(ptrTuple);
+                } else {
+                    const ui32 dupIndex = GetDupIndex(ptr);
+                    auto *const ptrDup =
+                        &duplicates[dupIndex * (DupPayloadSize_ + dupOffset)];
+                    FInplaceList(ptrDup);
+                }
+
+                return true;
+            }
+        } else {
+            auto &ptrPsl = GetPSLOut(ptr);
+            auto *const ptrTuple = GetTupleOut(ptrPsl.Index);
+
+            if (ptrPsl.Hash != hash) {
+                return false;
+            }
+
+            if (TuplesEqual_(Layout_, ptrTuple, Overflow_, tuple, overflow)) {
+                if (!ptrPsl.CellStatus.IsList()) {
+                    FOutplaceCell((ui8 *)&ptrPsl.Index);
+                } else {
+                    auto *const ptrDup =
+                        &duplicates[ptrPsl.DupIndex * (DupPayloadSize_ + dupOffset)];
+                    FOutplaceList(ptrDup);
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    Y_FORCE_INLINE bool InsertImpl(ui8 *const newRow, const ui32 hash, ui8 *ptr,
+                                   ui8 *const data, ui8 *const dataEnd,
+                                   TVector<ui8, TAllocator> &duplicates,
+                                   auto EqualHandler) {
+        auto &psl = GetPSL(newRow);
+
+        for (;;) {
+            auto &ptrPsl = GetPSL(ptr);
+            if (!ptrPsl.CellStatus.IsValid()) {
+                CopyCell(ptr, newRow);
+                return true;
+            }
+
+            if (EqualHandler(*this, newRow, hash, ptr, duplicates)) {
+                return false;
+            }
+
+            if (ptrPsl.CellStatus < psl.CellStatus) {
+                SwapCells(ptr, newRow);
+                ++psl.CellStatus;
+                AdvancePointer(ptr, data, dataEnd);
+                break;
+            }
+
+            ++psl.CellStatus;
+            AdvancePointer(ptr, data, dataEnd);
+        }
+
+        for (;;) {
+            auto &ptrPsl = GetPSL(ptr);
+            if (!ptrPsl.CellStatus.IsValid()) {
+                CopyCell(ptr, newRow);
+                return true;
+            }
+
+            if (ptrPsl.CellStatus < psl.CellStatus) {
+                SwapCells(ptr, newRow);
+            }
+
+            ++psl.CellStatus;
+            AdvancePointer(ptr, data, dataEnd);
+        }
+
+        return true;
+    }
+
+    Y_FORCE_INLINE static bool
+    EqualInsertHandler(TRobinHoodHashBase &self, ui8 *const newRow,
+                       const ui32 hash, ui8 *ptr,
+                       TVector<ui8, TAllocator> &duplicates) {
+        const ui8 *const tuple =
+            self.IsInplace_ ? GetTuple(newRow)
+                            : self.GetTupleOut(GetPSLOut(newRow).Index);
+
+        return self.OnEqual<true>(
+            hash, ptr, duplicates, tuple, self.Overflow_,
+            [&](const ui8 * /*matched*/) {
+                ui8 *ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                std::memcpy(ptrDup, GetTuple(ptr), self.DupPayloadSize_);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, -1u);
+
+                ++self.Listed_;
+
+                ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                std::memcpy(ptrDup, tuple, self.DupPayloadSize_);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, self.Listed_ - 1);
+
+                auto &ptrPsl = GetPSL(ptr);
+                self.GetDupIndex(ptr) = self.Listed_;
+                ptrPsl.CellStatus.ToList();
+
+                ++self.Listed_;
+                ++self.ListedUnique_;
+            },
+            [&](const ui8 * /*matched*/) {
+                auto &dupIndex = self.GetDupIndex(ptr);
+
+                ui8 *ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                std::memcpy(ptrDup, tuple, self.DupPayloadSize_);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, dupIndex);
+
+                dupIndex = self.Listed_;
+
+                ++self.Listed_;
+            },
+            [&](const ui8 * /*matched*/) {
+                auto &ptrPsl = GetPSLOut(ptr);
+
+                ui8 *ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                WriteUnaligned<ui32>(ptrDup, ptrPsl.Index);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, -1u);
+
+                ++self.Listed_;
+
+                ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                WriteUnaligned<ui32>(ptrDup, GetPSLOut(newRow).Index);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, self.Listed_ - 1);
+
+                ptrPsl.DupIndex = self.Listed_;
+                ptrPsl.CellStatus.ToList();
+
+                ++self.Listed_;
+                ++self.ListedUnique_;
+            },
+            [&](const ui8 * /*matched*/) {
+                auto &ptrPsl = GetPSLOut(ptr);
+
+                ui8 *ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                WriteUnaligned<ui32>(ptrDup, GetPSLOut(newRow).Index);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, ptrPsl.DupIndex);
+
+                ptrPsl.DupIndex = self.Listed_;
+
+                ++self.Listed_;
+            });
+    }
+
+    Y_FORCE_INLINE ui8 *GetDuplicatesData(TVector<ui8, TAllocator> &duplicates, ui32 ind) {
+        const ui32 dupCellSize = DupPayloadSize_ + sizeof(ui32);
+        if (duplicates.size() <= ind * dupCellSize) {
+            duplicates.resize_uninitialized(
+                std::max(64ul * dupCellSize, duplicates.size() * 2));
+        }
+
+        return duplicates.data() + ind * dupCellSize;
+    }
+
+    Y_FORCE_INLINE void AdvancePointer(ui8 *&ptr, ui8 *begin, ui8 *end) const {
+        ptr += CellSize_;
+        ptr = (ptr == end) ? begin : ptr;
+    }
+
+    static ui64 GetSelfHash(void *self) {
+        char buf[sizeof(void *)];
+        *(void **)buf = self;
+        return CityHash64(buf, sizeof(buf));
+    }
+
+    void Init(ui64 capacity) {
+        Y_ASSERT((capacity & (capacity - 1)) == 0);
+        Capacity_ = capacity;
+        CapacityShift_ = 64 - MostSignificantBit(capacity);
+        Allocate(Capacity_, Data_, DataEnd_);
+    }
+
+    void Grow(ui64 size) {
+        auto newCapacity = CalculateRHHashTableCapacity(size);
+        Y_ASSERT((newCapacity & (newCapacity - 1)) == 0);
+        auto newCapacityShift = 64 - MostSignificantBit(newCapacity);
+        ui8 *newData, *newDataEnd;
+        Allocate(newCapacity, newData, newDataEnd);
+
+        for (auto cell = Data_; cell != DataEnd_; cell += CellSize_) {
+            auto &psl = GetPSL(cell);
+            if (!psl.CellStatus.IsValid()) {
+                continue;
+            }
+
+            const ui32 hash =
+                IsInplace_ ? TupleHash_(Layout_, GetTuple(cell), Overflow_)
+                           : GetPSLOut(cell).Hash;
+            const auto ptr = GetPtr(hash, newData, newCapacityShift);
+
+            if (psl.CellStatus.IsList()) {
+                psl.CellStatus.value = TCellStatus::kStart;
+                psl.CellStatus.ToList();
+            } else {
+                psl.CellStatus.value = TCellStatus::kStart;
+            }
+
+            InsertImpl(cell, hash, ptr, newData, newDataEnd, DupSeq_,
+                       [](auto &&...) { return false; });
+        }
+
+        Capacity_ = newCapacity;
+        CapacityShift_ = newCapacityShift;
+        std::swap(Data_, newData);
+        std::swap(DataEnd_, newDataEnd);
+        if (newData) {
+            Allocator_.deallocate(newData, newDataEnd - newData);
+        }
+    }
+
+    void Allocate(ui64 capacity, ui8 *&data, ui8 *&dataEnd) {
+        ui64 bytes = capacity * CellSize_;
+        data = Allocator_.allocate(bytes);
+        dataEnd = data + bytes;
+        ui8 *ptr = data;
+        for (ui64 i = 0; i < capacity; ++i) {
+            GetPSL(ptr).CellStatus.value = TCellStatus::kInvalid;
+            ptr += CellSize_;
+        }
+    }
+
+  private:
+    static constexpr ui32 CellSize_ = kEmbeddedSize;
+
+    const ui64 SelfHash_;
+
+    THash TupleHash_;
+    TEqual TuplesEqual_;
+
+    const TTupleLayout * Layout_ = nullptr;
+
+    const ui8 *Tuples_ = nullptr;
+    const ui8 *Overflow_ = nullptr;
+
+    bool IsInplace_;
+    ui32 DupPayloadSize_;
+
+    ui64 Size_ = 0;
+    ui64 Listed_ = 0;
+    ui64 ListedUnique_ = 0;
+    ui64 Capacity_ = 0;
+    ui64 CapacityShift_;
+
+    TAllocator Allocator_;
+    ui8 *Data_ = nullptr;
+    ui8 *DataEnd_ = nullptr;
+    TVector<ui8, TAllocator> DupSeq_;
+};
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
@@ -814,6 +814,165 @@ void TTupleLayoutFallback::Unpack(
     }
 }
 
+void TTupleLayoutFallback::BucketPack(
+    const ui8 **columns, const ui8 **isValidBitmask,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows, ui32 start,
+    ui32 count, ui32 bucketsLogNum) const {
+    using TTraits = NSimd::TSimdFallbackTraits;
+
+    if (bucketsLogNum == 0) {
+        auto& bres = reses[0];
+        const auto size = bres.size();
+
+        bres.resize(size + count * TotalRowSize);
+        auto* const res = bres.data() + size;
+
+        Pack(columns, isValidBitmask, res, overflows[0], start, count);
+        return;
+    }
+
+    std::vector<ui8> resbuf(TotalRowSize);
+    ui8 *const res = resbuf.data();
+
+    for (ui32 bucket = 0; bucket < (1u << bucketsLogNum); ++bucket) {
+        auto &bres = reses[bucket];
+        /// memory reserve heuristic
+        bres.reserve(bres.size() + ((count >> bucketsLogNum) + 1) * 9 / 8);
+    }
+
+    const ui64 bitmaskTail =
+        BitmaskSize * 8 == OrigColumns.size()
+            ? 0
+            : ~0ull << ((OrigColumns.size() + 8 - BitmaskSize * 8) * 8);
+    std::vector<ui64> bitmaskMatrix(BitmaskSize, 0);
+    bitmaskMatrix.back() = bitmaskTail;
+
+    if (auto off = (start % 8)) {
+        auto bitmaskIdx = start / 8;
+
+        for (ui32 j = Columns.size(); j--;) {
+            const ui64 byte =
+                isValidBitmask[Columns[j].OriginalIndex]
+                    ? isValidBitmask[Columns[j].OriginalIndex][bitmaskIdx]
+                    : 0xFF;
+            bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+        }
+
+        for (auto &m : bitmaskMatrix) {
+            m = transposeBitmatrix(m);
+            m >>= off * 8;
+        }
+    }
+
+    for (; count--; ++start) {
+        auto bitmaskIdx = start / 8;
+
+        if ((start % 8) == 0) {
+            std::fill(bitmaskMatrix.begin(), bitmaskMatrix.end(), 0);
+            bitmaskMatrix.back() = bitmaskTail;
+
+            for (ui32 j = Columns.size(); j--;) {
+                const ui64 byte =
+                isValidBitmask[Columns[j].OriginalIndex]
+                    ? isValidBitmask[Columns[j].OriginalIndex][bitmaskIdx]
+                    : 0xFF;
+                bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+            }
+            for (auto &m : bitmaskMatrix)
+                m = transposeBitmatrix(m);
+        }
+
+        for (ui32 j = 0; j < BitmaskSize; ++j) {
+            res[BitmaskOffset + j] = ui8(bitmaskMatrix[j]);
+            bitmaskMatrix[j] >>= 8;
+        }
+
+        for (auto &col : FixedNPOTColumns_) {
+            std::memcpy(res + col.Offset,
+                        columns[col.OriginalIndex] + start * col.DataSize,
+                        col.DataSize);
+        }
+
+#define PackPOTColumn(POT)                                                     \
+    for (auto &col : FixedPOTColumns_[POT]) {                                  \
+        std::memcpy(res + col.Offset,                                          \
+                    columns[col.OriginalIndex] + start * (1u << POT),          \
+                    1u << POT);                                                \
+    }
+
+        PackPOTColumn(0);
+        PackPOTColumn(1);
+        PackPOTColumn(2);
+        PackPOTColumn(3);
+        PackPOTColumn(4);
+#undef PackPOTColumn
+
+        ui32 hash = CalculateCRC32<TTraits>(
+            res + KeyColumnsOffset, KeyColumnsFixedEnd - KeyColumnsOffset);
+
+        for (ui32 i = KeyColumnsFixedNum; i < KeyColumns.size(); ++i) {
+            auto &col = KeyColumns[i];
+            auto dataOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * start);
+            auto nextOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+            auto size = nextOffset - dataOffset;
+            auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+            // hash = CalculateCRC32<TTraits>((ui8 *)&size, sizeof(size), hash);
+            hash = CalculateCRC32<TTraits>(data, size, hash);
+        }
+
+        // isValid bitmap is NOT included into hashed data
+        WriteUnaligned<ui32>(res, hash);
+
+        /// most-significant bits of hash
+        const auto bucket = hash >> (sizeof(hash) * 8 - bucketsLogNum);
+
+        auto& overflow = overflows[bucket];
+
+        for (auto &col : VariableColumns) {
+            auto dataOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * start);
+            auto nextOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+            auto size = nextOffset - dataOffset;
+            auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+            if (size >= col.DataSize) {
+                res[col.Offset] = 255;
+
+                auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                auto overflowSize = size - prefixSize;
+                auto overflowOffset = overflow.size();
+
+                overflow.resize(overflowOffset + overflowSize);
+
+                WriteUnaligned<ui32>(res + col.Offset + 1 +
+                                        0 * sizeof(ui32),
+                                    overflowOffset);
+                WriteUnaligned<ui32>(
+                    res + col.Offset + 1 + 1 * sizeof(ui32), overflowSize);
+                std::memcpy(res + col.Offset + 1 + 2 * sizeof(ui32), data,
+                            prefixSize);
+                std::memcpy(overflow.data() + overflowOffset,
+                            data + prefixSize, overflowSize);
+            } else {
+                Y_DEBUG_ABORT_UNLESS(size < 255);
+                res[col.Offset] = size;
+                std::memcpy(res + col.Offset + 1, data, size);
+                std::memset(res + col.Offset + 1 + size, 0,
+                            col.DataSize - (size + 1));
+            }
+        }
+
+        auto &bres = reses[bucket];
+        bres.resize_uninitialized(bres.size() + TotalRowSize);
+        std::memcpy(bres.data() + bres.size() - TotalRowSize, res, TotalRowSize);
+    }
+}
+
 #define MULTI_8_I(C, i) C(i, 0) C(i, 1) C(i, 2) C(i, 3)
 #define MULTI_8(C, A) C(A, 0) C(A, 1) C(A, 2) C(A, 3)
 
@@ -1174,6 +1333,221 @@ void TTupleLayoutSIMD<TTraits>::Unpack(
     }
 }
 
+template <typename TTraits>
+void TTupleLayoutSIMD<TTraits>::BucketPack(
+    const ui8 **columns, const ui8 **isValidBitmask,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows, ui32 start,
+    ui32 count, ui32 bucketsLogNum) const {
+    if (bucketsLogNum == 0) {
+        auto& bres = reses[0];
+        const auto size = bres.size();
+
+        bres.resize(size + count * TotalRowSize);
+        auto* const res = bres.data() + size;
+
+        Pack(columns, isValidBitmask, res, overflows[0], start, count);
+        return;
+    }
+
+    std::vector<ui8> resbuf(BlockRows_ * TotalRowSize);
+    ui8 *const res = resbuf.data();
+
+    for (ui32 bucket = 0; bucket < (1u << bucketsLogNum); ++bucket) {
+        auto &bres = reses[bucket];
+        /// memory reserve heuristic
+        bres.reserve(bres.size() + ((count >> bucketsLogNum) + 1) * 9 / 8);
+    }
+
+    std::vector<const ui8 *> block_columns;
+    for (const auto col_ind : BlockColumnsOrigInds_) {
+        block_columns.push_back(columns[col_ind]);
+    }
+
+    for (size_t row_ind = 0; row_ind < count; row_ind += BlockRows_) {
+        const size_t cur_block_size = std::min(count - row_ind, BlockRows_);
+        size_t cols_past = 0;
+
+        if (SIMDSmallTuple_.Cols) {
+
+#define CASE(i, j)                                                             \
+    case i *kSIMDMaxCols + j:                                                  \
+        SIMDPack<TTraits>::template PackTupleOr<i + 1, j + 1>(                 \
+            block_columns.data() + cols_past, res + SIMDSmallTuple_.RowOffset, \
+            cur_block_size, BlockFixedColsSizes_.data() + cols_past,           \
+            BlockColsOffsets_.data() + cols_past,                              \
+            SIMDSmallTuple_.SmallTupleSize, TotalRowSize,                      \
+            SIMDPermMasks_.data(), start);                                     \
+        break;
+
+            switch ((SIMDSmallTuple_.InnerLoopIters - 1) * kSIMDMaxCols +
+                    SIMDSmallTuple_.Cols - 1) {
+                MULTI_8(MULTI_8_I, CASE)
+
+            default:
+                std::abort();
+            }
+
+#undef CASE
+
+            cols_past += SIMDSmallTuple_.Cols;
+        }
+
+        for (size_t trnsps_ind = 0; trnsps_ind != SIMDTranspositions_.size();
+             ++trnsps_ind) {
+            if (SIMDTranspositions_[trnsps_ind].Cols) {
+                SIMDPack<TTraits>::PackColSize(
+                    block_columns.data() + cols_past,
+                    res + SIMDTranspositions_[trnsps_ind].RowOffset,
+                    cur_block_size,
+                    SIMDTranspositionsColSizes_
+                        [trnsps_ind % SIMDTranspositionsColSizes_.size()],
+                    SIMDTranspositions_[trnsps_ind].Cols, TotalRowSize, start);
+                cols_past += SIMDTranspositions_[trnsps_ind].Cols;
+            }
+        }
+
+        PackTupleFallbackColImpl(
+            block_columns.data() + cols_past, res,
+            BlockColsOffsets_.size() - cols_past, cur_block_size,
+            BlockFixedColsSizes_.data() + cols_past,
+            BlockColsOffsets_.data() + cols_past, TotalRowSize, start);
+
+        for (ui32 cols_ind = 0; cols_ind < Columns.size(); cols_ind += 8) {
+            const size_t cols = std::min<size_t>(8ul, Columns.size() - cols_ind);
+            const ui8 ones_byte = 0xFF;  // dereferencable + all-ones fast path
+            const ui8 *bitmasks[8];
+
+            for (size_t ind = 0; ind != cols; ++ind) {
+                const auto &col = Columns[cols_ind + ind];
+                bitmasks[ind] = 
+                    isValidBitmask[col.OriginalIndex]
+                    ? isValidBitmask[col.OriginalIndex] + start / 8
+                    : &ones_byte;
+            }
+            for (size_t ind = cols; ind != 8; ++ind) {
+                bitmasks[ind] = &ones_byte;
+            }
+
+            const auto advance_masks = [&] {
+                for (size_t ind = 0; ind != 8; ++ind) {
+                    if (bitmasks[ind] != &ones_byte) {
+                        ++bitmasks[ind];
+                    }
+                }
+            };
+
+            const size_t first_full_byte =
+                std::min<size_t>((8ul - start) & 7, cur_block_size);
+            size_t block_row_ind = 0;
+
+            const auto edge_mask_transpose = [&](const size_t until) {
+                for (; block_row_ind < until; ++block_row_ind) {
+                    const auto shift = (start + block_row_ind) % 8;
+
+                    const auto new_res = res + block_row_ind * TotalRowSize;
+                    const auto res = new_res;
+
+                    res[BitmaskOffset + cols_ind / 8] = 0;
+                    for (size_t col_ind = 0; col_ind != 8; ++col_ind) {
+                        res[BitmaskOffset + cols_ind / 8] |=
+                            ((bitmasks[col_ind][0] >> shift) & 1u) << col_ind;
+                    }
+                }
+            };
+
+            edge_mask_transpose(first_full_byte);
+            if (first_full_byte) {
+                advance_masks();
+            }
+
+            for (; block_row_ind + 7 < cur_block_size; block_row_ind += 8) {
+                transposeBitmatrix(res + block_row_ind * TotalRowSize +
+                                       BitmaskOffset + cols_ind / 8,
+                                   bitmasks, TotalRowSize);
+                advance_masks();
+            }
+
+            edge_mask_transpose(cur_block_size);
+        }
+
+        for (size_t block_row_ind = 0; block_row_ind != cur_block_size;
+            ++block_row_ind) {
+
+            const auto new_start = start + block_row_ind;
+            const auto start = new_start;
+
+            const auto new_res = res + block_row_ind * TotalRowSize;
+            const auto res = new_res;
+
+            ui32 hash = CalculateCRC32<TTraits>(
+                res + KeyColumnsOffset, KeyColumnsFixedEnd - KeyColumnsOffset);
+
+            for (ui32 i = KeyColumnsFixedNum; i < KeyColumns.size(); ++i) {
+                auto &col = KeyColumns[i];
+                auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto nextOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+                auto size = nextOffset - dataOffset;
+                auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+                // hash = CalculateCRC32<TTraits>((ui8 *)&size, sizeof(size), hash);
+                hash = CalculateCRC32<TTraits>(data, size, hash);
+            }
+
+            // isValid bitmap is NOT included into hashed data
+            WriteUnaligned<ui32>(res, hash);
+
+            /// most-significant bits of hash
+            const auto bucket = hash >> (sizeof(hash) * 8 - bucketsLogNum);
+
+            auto& overflow = overflows[bucket];
+
+            for (auto &col : VariableColumns) {
+                auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto nextOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+                auto size = nextOffset - dataOffset;
+                auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+                if (size >= col.DataSize) {
+                    res[col.Offset] = 255;
+
+                    auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                    auto overflowSize = size - prefixSize;
+                    auto overflowOffset = overflow.size();
+
+                    overflow.resize(overflowOffset + overflowSize);
+
+                    WriteUnaligned<ui32>(res + col.Offset + 1 +
+                                            0 * sizeof(ui32),
+                                        overflowOffset);
+                    WriteUnaligned<ui32>(
+                        res + col.Offset + 1 + 1 * sizeof(ui32), overflowSize);
+                    std::memcpy(res + col.Offset + 1 + 2 * sizeof(ui32), data,
+                                prefixSize);
+                    std::memcpy(overflow.data() + overflowOffset,
+                                data + prefixSize, overflowSize);
+                } else {
+                    Y_DEBUG_ABORT_UNLESS(size < 255);
+                    res[col.Offset] = size;
+                    std::memcpy(res + col.Offset + 1, data, size);
+                    std::memset(res + col.Offset + 1 + size, 0,
+                                col.DataSize - (size + 1));
+                }
+           }
+
+            auto &bres = reses[bucket];
+            bres.resize_uninitialized(bres.size() + TotalRowSize);
+            std::memcpy(bres.data() + bres.size() - TotalRowSize, res, TotalRowSize);
+        }
+
+        start += cur_block_size;
+    }
+}
+
 template __attribute__((target("avx2"))) void
 TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>::Pack(
     const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
@@ -1195,6 +1569,19 @@ TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>::Unpack(
     ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
     const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
     ui32 count) const;
+
+template __attribute__((target("avx2"))) void
+TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>::BucketPack(
+    const ui8 **columns, const ui8 **isValidBitmask,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows, ui32 start,
+    ui32 count, ui32 bucketsLogNum) const;
+template __attribute__((target("sse4.2"))) void
+TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>::BucketPack(
+    const ui8 **columns, const ui8 **isValidBitmask,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows, ui32 start,
+    ui32 count, ui32 bucketsLogNum) const;
 
 void TTupleLayout::CalculateColumnSizes(
     const ui8 *res, ui32 count,

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <queue>
 
 #include <yql/essentials/minikql/mkql_alloc.h>
 #include <yql/essentials/public/udf/udf_data_type.h>
@@ -60,6 +61,34 @@ Y_FORCE_INLINE ui64 transposeBitmatrix(ui64 x) {
          << 28);
 
     return x;
+}
+
+void transposeBitmatrix(ui8 dst[], const ui8 *src[], const size_t row_size) {
+    ui64 x = 0;
+    for (size_t ind = 0; ind != 8; ++ind) {
+        x |= ui64(*src[ind]) << (ind * 8);
+    }
+
+    x = transposeBitmatrix(x);
+
+    for (size_t ind = 0; ind != 8; ++ind) {
+        dst[ind * row_size] = x;
+        x >>= 8;
+    }
+}
+
+void transposeBitmatrix(ui8 *dst[], const ui8 src[], const size_t row_size) {
+    ui64 x = 0;
+    for (size_t ind = 0; ind != 8; ++ind) {
+        x |= ui64(src[ind * row_size]) << (ind * 8);
+    }
+
+    x = transposeBitmatrix(x);
+
+    for (size_t ind = 0; ind != 8; ++ind) {
+        *dst[ind] = x;
+        x >>= 8;
+    }
 }
 
 } // namespace
@@ -189,6 +218,15 @@ bool TTupleLayout::KeysLess(const ui8 *lhsRow, const ui8 *lhsOverflow,
 
 THolder<TTupleLayout>
 TTupleLayout::Create(const std::vector<TColumnDesc> &columns) {
+
+    if (NX86::HaveAVX2())
+        return MakeHolder<TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>>(
+            columns);
+
+    if (NX86::HaveSSE42())
+        return MakeHolder<TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>>(
+            columns);
+
     return MakeHolder<TTupleLayoutFallback>(
         columns);
 }
@@ -310,6 +348,194 @@ TTupleLayoutFallback::TTupleLayoutFallback(
     }
 }
 
+template <typename TTraits>
+TTupleLayoutSIMD<TTraits>::TTupleLayoutSIMD(
+    const std::vector<TColumnDesc> &columns)
+    : TTupleLayoutFallback(columns) {
+    BlockRows_ = 128 * std::max(1ul, 128ul / TotalRowSize);
+    const bool use_simd = true;
+
+    // pack optimization for small tuple
+    const size_t max_simd_tuple_size =
+        use_simd && TSimd<ui8>::SIZE > TotalRowSize
+            ? TSimd<ui8>::SIZE - TotalRowSize
+            : 0;
+
+    std::vector<const TColumnDesc *> fallback_cols;
+    std::queue<const TColumnDesc *> next_cols;
+
+    size_t fixed_cols_left =
+        KeyColumnsFixedNum +
+        std::accumulate(PayloadColumns.begin(), PayloadColumns.end(), 0ul,
+                        [](size_t prev, const auto &col) {
+                            return prev +
+                                   (col.SizeType == EColumnSizeType::Fixed);
+                        });
+
+    const auto small_tuple_packing = [&](const std::vector<TColumnDesc>
+                                             &columns) {
+        for (const auto &col : columns) {
+            if (col.SizeType != EColumnSizeType::Fixed) {
+                break;
+            }
+            --fixed_cols_left;
+
+            size_t tuple_size = next_cols.empty()
+                                    ? 0
+                                    : next_cols.back()->DataSize +
+                                          next_cols.back()->Offset -
+                                          next_cols.front()->Offset;
+            const size_t tuple_size_with_col =
+                next_cols.empty()
+                    ? col.DataSize
+                    : col.DataSize + col.Offset - next_cols.front()->Offset;
+
+            const bool col_pushed = tuple_size_with_col <= max_simd_tuple_size;
+            if (col_pushed) {
+                next_cols.push(&col);
+                tuple_size = tuple_size_with_col;
+            }
+
+            if (!SIMDSmallTuple_.Cols && next_cols.size() > 1 &&
+                tuple_size <= max_simd_tuple_size &&
+                (!col_pushed || !fixed_cols_left)) {
+                SIMDSmallTupleDesc simd_desc;
+                simd_desc.Cols = next_cols.size();
+                simd_desc.RowOffset = next_cols.front()->Offset;
+                simd_desc.SmallTupleSize = tuple_size;
+
+                const TColumnDesc *col_descs[kSIMDMaxCols];
+                ui32 col_max_size = 0;
+                for (ui8 col_ind = 0; col_ind != simd_desc.Cols; ++col_ind) {
+                    col_descs[col_ind] = next_cols.front();
+                    col_max_size =
+                        std::max(col_max_size, col_descs[col_ind]->DataSize);
+                    next_cols.pop();
+                }
+
+                const auto tuples_per_register = std::max(
+                    1ul, 1ul + (TSimd<ui8>::SIZE - tuple_size) / TotalRowSize);
+
+                simd_desc.InnerLoopIters = std::min(
+                    size_t(kSIMDMaxInnerLoopSize),
+                    (TSimd<ui8>::SIZE / col_max_size) / tuples_per_register);
+
+                for (ui8 col_ind = 0; col_ind != simd_desc.Cols; ++col_ind) {
+                    const auto &col_desc = col_descs[col_ind];
+                    const size_t offset =
+                        col_desc->Offset - simd_desc.RowOffset;
+
+                    BlockColsOffsets_.push_back(offset);
+                    BlockFixedColsSizes_.push_back(col_desc->DataSize);
+                    BlockColumnsOrigInds_.push_back(col_desc->OriginalIndex);
+                }
+
+                for (size_t packing_flag = 1; packing_flag != 3;
+                     ++packing_flag) {
+                    for (ui8 col_ind = 0; col_ind != simd_desc.Cols;
+                         ++col_ind) {
+                        const auto col_desc = col_descs[col_ind];
+                        const size_t offset =
+                            col_desc->Offset - simd_desc.RowOffset;
+
+                        for (ui8 ind = 0; ind != simd_desc.InnerLoopIters;
+                             ++ind) {
+                            auto perm = SIMDPack<TTraits>::BuildTuplePerm(
+                                col_desc->DataSize,
+                                TotalRowSize - col_desc->DataSize, tuple_size,
+                                offset,
+                                ind * col_desc->DataSize * tuples_per_register,
+                                packing_flag % 2);
+                            SIMDPermMasks_.push_back(perm);
+                        }
+                    }
+                }
+
+                SIMDSmallTuple_ = simd_desc;
+            }
+
+            if (!col_pushed) {
+                next_cols.push(&col);
+            }
+        }
+    };
+
+    const auto transpose_packing = [&](const std::vector<TColumnDesc> &columns,
+                                       bool payload) {
+        ui32 colsize = 0;
+
+        for (const auto &col : columns) {
+            if (col.SizeType != EColumnSizeType::Fixed) {
+                break;
+            }
+
+            if (colsize != col.DataSize) {
+                while (!next_cols.empty()) {
+                    fallback_cols.push_back(next_cols.front());
+                    next_cols.pop();
+                }
+
+                if (use_simd && std::find(SIMDTranspositionsColSizes_.begin(),
+                                          SIMDTranspositionsColSizes_.end(),
+                                          col.DataSize) !=
+                                    SIMDTranspositionsColSizes_.end()) {
+                    colsize = col.DataSize;
+                }
+            }
+
+            if (colsize == col.DataSize) {
+                next_cols.push(&col);
+                if (next_cols.size() * colsize == TSimd<ui8>::SIZE) {
+                    const auto ind =
+                        payload * SIMDTranspositionsColSizes_.size() +
+                        std::find(SIMDTranspositionsColSizes_.begin(),
+                                  SIMDTranspositionsColSizes_.end(), colsize) -
+                        SIMDTranspositionsColSizes_.begin();
+                    if (SIMDTranspositions_[ind].Cols == 0) {
+                        SIMDTranspositions_[ind].RowOffset =
+                            next_cols.front()->Offset;
+                    }
+                    SIMDTranspositions_[ind].Cols += next_cols.size();
+
+                    while (!next_cols.empty()) {
+                        const auto col_desc = next_cols.front();
+                        BlockColsOffsets_.push_back(col_desc->Offset);
+                        BlockFixedColsSizes_.push_back(col_desc->DataSize);
+                        BlockColumnsOrigInds_.push_back(
+                            col_desc->OriginalIndex);
+                        next_cols.pop();
+                    }
+                }
+            } else {
+                fallback_cols.push_back(&col);
+            }
+        }
+
+        while (!next_cols.empty()) {
+            fallback_cols.push_back(next_cols.front());
+            next_cols.pop();
+        }
+    };
+
+    if (max_simd_tuple_size) {
+        small_tuple_packing(KeyColumns);
+        small_tuple_packing(PayloadColumns);
+
+        while (!next_cols.empty()) {
+            fallback_cols.push_back(next_cols.front());
+            next_cols.pop();
+        }
+    } else {
+        transpose_packing(KeyColumns, 0);
+        transpose_packing(PayloadColumns, 1);
+    }
+
+    for (const auto col_desc_p : fallback_cols) {
+        BlockColsOffsets_.push_back(col_desc_p->Offset);
+        BlockFixedColsSizes_.push_back(col_desc_p->DataSize);
+        BlockColumnsOrigInds_.push_back(col_desc_p->OriginalIndex);
+    }
+}
 
 // Columns (SoA) format:
 //   for fixed size: packed data
@@ -587,6 +813,388 @@ void TTupleLayoutFallback::Unpack(
         }
     }
 }
+
+#define MULTI_8_I(C, i) C(i, 0) C(i, 1) C(i, 2) C(i, 3)
+#define MULTI_8(C, A) C(A, 0) C(A, 1) C(A, 2) C(A, 3)
+
+template <typename TTraits>
+void TTupleLayoutSIMD<TTraits>::Pack(
+    const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+    std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const {
+    std::vector<const ui8 *> block_columns;
+    for (const auto col_ind : BlockColumnsOrigInds_) {
+        block_columns.push_back(columns[col_ind]);
+    }
+
+    for (size_t row_ind = 0; row_ind < count; row_ind += BlockRows_) {
+        const size_t cur_block_size = std::min(count - row_ind, BlockRows_);
+        size_t cols_past = 0;
+
+        if (SIMDSmallTuple_.Cols) {
+
+#define CASE(i, j)                                                             \
+    case i *kSIMDMaxCols + j:                                                  \
+        SIMDPack<TTraits>::template PackTupleOr<i + 1, j + 1>(                 \
+            block_columns.data() + cols_past, res + SIMDSmallTuple_.RowOffset, \
+            cur_block_size, BlockFixedColsSizes_.data() + cols_past,           \
+            BlockColsOffsets_.data() + cols_past,                              \
+            SIMDSmallTuple_.SmallTupleSize, TotalRowSize,                      \
+            SIMDPermMasks_.data(), start);                                     \
+        break;
+
+            switch ((SIMDSmallTuple_.InnerLoopIters - 1) * kSIMDMaxCols +
+                    SIMDSmallTuple_.Cols - 1) {
+                MULTI_8(MULTI_8_I, CASE)
+
+            default:
+                std::abort();
+            }
+
+#undef CASE
+
+            cols_past += SIMDSmallTuple_.Cols;
+        }
+
+        for (size_t trnsps_ind = 0; trnsps_ind != SIMDTranspositions_.size();
+             ++trnsps_ind) {
+            if (SIMDTranspositions_[trnsps_ind].Cols) {
+                SIMDPack<TTraits>::PackColSize(
+                    block_columns.data() + cols_past,
+                    res + SIMDTranspositions_[trnsps_ind].RowOffset,
+                    cur_block_size,
+                    SIMDTranspositionsColSizes_
+                        [trnsps_ind % SIMDTranspositionsColSizes_.size()],
+                    SIMDTranspositions_[trnsps_ind].Cols, TotalRowSize, start);
+                cols_past += SIMDTranspositions_[trnsps_ind].Cols;
+            }
+        }
+
+        PackTupleFallbackColImpl(
+            block_columns.data() + cols_past, res,
+            BlockColsOffsets_.size() - cols_past, cur_block_size,
+            BlockFixedColsSizes_.data() + cols_past,
+            BlockColsOffsets_.data() + cols_past, TotalRowSize, start);
+
+        for (ui32 cols_ind = 0; cols_ind < Columns.size(); cols_ind += 8) {
+            const size_t cols = std::min<size_t>(8ul, Columns.size() - cols_ind);
+            const ui8 ones_byte = 0xFF;  // dereferencable + all-ones fast path
+            const ui8 *bitmasks[8];
+
+            for (size_t ind = 0; ind != cols; ++ind) {
+                const auto &col = Columns[cols_ind + ind];
+                bitmasks[ind] = 
+                    isValidBitmask[col.OriginalIndex]
+                    ? isValidBitmask[col.OriginalIndex] + start / 8
+                    : &ones_byte;
+            }
+            for (size_t ind = cols; ind != 8; ++ind) {
+                bitmasks[ind] = &ones_byte;
+            }
+
+            const auto advance_masks = [&] {
+                for (size_t ind = 0; ind != 8; ++ind) {
+                    if (bitmasks[ind] != &ones_byte) {
+                        ++bitmasks[ind];
+                    }
+                }
+            };
+
+            const size_t first_full_byte =
+                std::min<size_t>((8ul - start) & 7, cur_block_size);
+            size_t block_row_ind = 0;
+
+            const auto edge_mask_transpose = [&](const size_t until) {
+                for (; block_row_ind < until; ++block_row_ind) {
+                    const auto shift = (start + block_row_ind) % 8;
+
+                    const auto new_res = res + block_row_ind * TotalRowSize;
+                    const auto res = new_res;
+
+                    res[BitmaskOffset + cols_ind / 8] = 0;
+                    for (size_t col_ind = 0; col_ind != 8; ++col_ind) {
+                        res[BitmaskOffset + cols_ind / 8] |=
+                            ((bitmasks[col_ind][0] >> shift) & 1u) << col_ind;
+                    }
+                }
+            };
+
+            edge_mask_transpose(first_full_byte);
+            if (first_full_byte) {
+                advance_masks();
+            }
+
+            for (; block_row_ind + 7 < cur_block_size; block_row_ind += 8) {
+                transposeBitmatrix(res + block_row_ind * TotalRowSize +
+                                       BitmaskOffset + cols_ind / 8,
+                                   bitmasks, TotalRowSize);
+                advance_masks();
+            }
+
+            edge_mask_transpose(cur_block_size);
+        }
+
+        for (size_t block_row_ind = 0; block_row_ind != cur_block_size;
+             ++block_row_ind) {
+
+            const auto new_start = start + block_row_ind;
+            const auto start = new_start;
+
+            const auto new_res = res + block_row_ind * TotalRowSize;
+            const auto res = new_res;
+
+            ui32 hash = CalculateCRC32<TTraits>(
+                res + KeyColumnsOffset, KeyColumnsFixedEnd - KeyColumnsOffset);
+
+            for (ui32 i = KeyColumnsFixedNum; i < KeyColumns.size(); ++i) {
+                auto &col = KeyColumns[i];
+                auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto nextOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+                auto size = nextOffset - dataOffset;
+                auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+                // hash = CalculateCRC32<TTraits>((ui8 *)&size, sizeof(size), hash);
+                hash = CalculateCRC32<TTraits>(data, size, hash);
+            }
+
+            // isValid bitmap is NOT included into hashed data
+            WriteUnaligned<ui32>(res, hash);
+
+            for (auto &col : VariableColumns) {
+                auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto nextOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+                auto size = nextOffset - dataOffset;
+                auto data = columns[col.OriginalIndex + 1] + dataOffset;
+                if (size >= col.DataSize) {
+                    res[col.Offset] = 255;
+
+                    auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                    auto overflowSize = size - prefixSize;
+                    auto overflowOffset = overflow.size();
+
+                    overflow.resize(overflowOffset + overflowSize);
+
+                    WriteUnaligned<ui32>(res + col.Offset + 1 +
+                                             0 * sizeof(ui32),
+                                         overflowOffset);
+                    WriteUnaligned<ui32>(
+                        res + col.Offset + 1 + 1 * sizeof(ui32), overflowSize);
+                    std::memcpy(res + col.Offset + 1 + 2 * sizeof(ui32), data,
+                                prefixSize);
+                    std::memcpy(overflow.data() + overflowOffset,
+                                data + prefixSize, overflowSize);
+                } else {
+                    Y_DEBUG_ABORT_UNLESS(size < 255);
+                    res[col.Offset] = size;
+                    std::memcpy(res + col.Offset + 1, data, size);
+                    std::memset(res + col.Offset + 1 + size, 0,
+                                col.DataSize - (size + 1));
+                }
+            }
+        }
+
+        start += cur_block_size;
+        res += cur_block_size * TotalRowSize;
+    }
+}
+
+template <typename TTraits>
+void TTupleLayoutSIMD<TTraits>::Unpack(
+    ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+    const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const {
+    std::vector<ui8 *> block_columns;
+    for (const auto col_ind : BlockColumnsOrigInds_) {
+        block_columns.push_back(columns[col_ind]);
+    }
+
+    for (size_t row_ind = 0; row_ind < count; row_ind += BlockRows_) {
+        const size_t cur_block_size = std::min(count - row_ind, BlockRows_);
+        size_t cols_past = 0;
+
+        if (SIMDSmallTuple_.Cols) {
+
+#define CASE(i, j)                                                             \
+    case i *kSIMDMaxCols + j:                                                  \
+        SIMDPack<TTraits>::template UnpackTupleOr<i + 1, j + 1>(               \
+            res + SIMDSmallTuple_.RowOffset, block_columns.data() + cols_past, \
+            cur_block_size, BlockFixedColsSizes_.data() + cols_past,           \
+            BlockColsOffsets_.data() + cols_past,                              \
+            SIMDSmallTuple_.SmallTupleSize, TotalRowSize,                      \
+            SIMDPermMasks_.data() + (i + 1) * (j + 1), start);                 \
+        break;
+
+            switch ((SIMDSmallTuple_.InnerLoopIters - 1) * kSIMDMaxCols +
+                    SIMDSmallTuple_.Cols - 1) {
+                MULTI_8(MULTI_8_I, CASE)
+
+            default:
+                std::abort();
+            }
+
+#undef CASE
+
+            cols_past += SIMDSmallTuple_.Cols;
+        }
+
+        for (size_t trnsps_ind = 0; trnsps_ind != SIMDTranspositions_.size();
+             ++trnsps_ind) {
+            if (SIMDTranspositions_[trnsps_ind].Cols) {
+                SIMDPack<TTraits>::UnpackColSize(
+                    res + SIMDTranspositions_[trnsps_ind].RowOffset,
+                    block_columns.data() + cols_past, cur_block_size,
+                    SIMDTranspositionsColSizes_
+                        [trnsps_ind % SIMDTranspositionsColSizes_.size()],
+                    SIMDTranspositions_[trnsps_ind].Cols, TotalRowSize, start);
+                cols_past += SIMDTranspositions_[trnsps_ind].Cols;
+            }
+        }
+
+        UnpackTupleFallbackColImpl(
+            res, block_columns.data() + cols_past,
+            BlockColsOffsets_.size() - cols_past, cur_block_size,
+            BlockFixedColsSizes_.data() + cols_past,
+            BlockColsOffsets_.data() + cols_past, TotalRowSize, start);
+
+        for (ui32 cols_ind = 0; cols_ind < Columns.size(); cols_ind += 8) {
+            const size_t cols = std::min<size_t>(8ul, Columns.size() - cols_ind);
+            ui8 *bitmasks[8];
+            ui8 trash_byte;  // dereferencable
+
+            for (size_t ind = 0; ind != cols; ++ind) {
+                const auto &col = Columns[cols_ind + ind];
+                bitmasks[ind] =
+                    isValidBitmask[col.OriginalIndex]
+                        ? isValidBitmask[col.OriginalIndex] + start / 8
+                        : &trash_byte;
+            }
+            for (size_t ind = cols; ind != 8; ++ind) {
+                bitmasks[ind] = &trash_byte;
+            }
+
+            const auto advance_masks = [&] {
+                for (size_t ind = 0; ind != 8; ++ind) {
+                    if (bitmasks[ind] != &trash_byte) {
+                        ++bitmasks[ind];
+                    }
+                }
+            };
+
+            const size_t first_full_byte =
+                std::min<size_t>((8ul - start) & 7, cur_block_size);
+            size_t block_row_ind = 0;
+
+            const auto edge_mask_transpose = [&](const size_t until) {
+                for (size_t col_ind = 0;
+                     block_row_ind != until && col_ind != cols; ++col_ind) {
+                    auto bitmask =
+                        bitmasks[col_ind][0] & ~((0xFF << (block_row_ind & 7)) ^
+                                                 (0xFF << (until & 7)));
+
+                    for (size_t row_ind = block_row_ind; row_ind < until;
+                         ++row_ind) {
+                        const auto shift = (start + row_ind) % 8;
+
+                        const auto new_res = res + row_ind * TotalRowSize;
+                        const auto res = new_res;
+
+                        bitmask |=
+                            ((res[BitmaskOffset + cols_ind / 8] >> col_ind) &
+                             1u)
+                            << shift;
+                    }
+
+                    bitmasks[col_ind][0] = bitmask;
+                }
+                block_row_ind = until;
+            };
+
+            edge_mask_transpose(first_full_byte);
+            if (first_full_byte) {
+                advance_masks();
+            }
+
+            for (; block_row_ind + 7 < cur_block_size; block_row_ind += 8) {
+                transposeBitmatrix(bitmasks,
+                                   res + block_row_ind * TotalRowSize +
+                                       BitmaskOffset + cols_ind / 8,
+                                   TotalRowSize);
+                advance_masks();
+            }
+
+            edge_mask_transpose(cur_block_size);
+        }
+
+        for (size_t block_row_ind = 0; block_row_ind != cur_block_size;
+             ++block_row_ind) {
+
+            const auto new_start = start + block_row_ind;
+            const auto start = new_start;
+
+            const auto new_res = res + block_row_ind * TotalRowSize;
+            const auto res = new_res;
+
+            for (auto &col : VariableColumns) {
+                const auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto *const data = columns[col.OriginalIndex + 1] + dataOffset;
+
+                ui32 size = ReadUnaligned<ui8>(res + col.Offset);
+
+                if (size < 255) { // embedded str
+                    std::memcpy(data, res + col.Offset + 1, size);
+                } else { // overflow buffer used
+                    const auto prefixSize =
+                        (col.DataSize - 1 - 2 * sizeof(ui32));
+                    const auto overflowOffset = ReadUnaligned<ui32>(
+                        res + col.Offset + 1 + 0 * sizeof(ui32));
+                    const auto overflowSize = ReadUnaligned<ui32>(
+                        res + col.Offset + 1 + 1 * sizeof(ui32));
+
+                    std::memcpy(data, res + col.Offset + 1 + 2 * sizeof(ui32),
+                                prefixSize);
+                    std::memcpy(data + prefixSize,
+                                overflow.data() + overflowOffset, overflowSize);
+
+                    size = prefixSize + overflowSize;
+                }
+
+                WriteUnaligned<ui32>(columns[col.OriginalIndex] +
+                                         sizeof(ui32) * (start + 1),
+                                     dataOffset + size);
+            }
+        }
+
+        start += cur_block_size;
+        res += cur_block_size * TotalRowSize;
+    }
+}
+
+template __attribute__((target("avx2"))) void
+TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>::Pack(
+    const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+    std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const;
+template __attribute__((target("sse4.2"))) void
+TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>::Pack(
+    const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+    std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const;
+
+template __attribute__((target("avx2"))) void
+TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>::Unpack(
+    ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+    const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const;
+template __attribute__((target("sse4.2"))) void
+TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>::Unpack(
+    ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+    const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const;
 
 void TTupleLayout::CalculateColumnSizes(
     const ui8 *res, ui32 count,

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
@@ -1,0 +1,689 @@
+#include "tuple.h"
+
+#include <algorithm>
+#include <vector>
+
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_value.h>
+
+#include <util/generic/bitops.h>
+#include <util/generic/buffer.h>
+
+#include <arrow/util/bit_util.h>
+
+#include "hashes_calc.h"
+#include "packing.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+namespace {
+
+// Transpose 8x8 bit-matrix packed in ui64 integer
+Y_FORCE_INLINE ui64 transposeBitmatrix(ui64 x) {
+    /// fast path
+    if (x == ~0ull) {
+        return x;
+    }
+
+    /// transpose 1x1 diagonal elements in 2x2 block
+    x = ((x &
+          0b10101010'01010101'10101010'01010101'10101010'01010101'10101010'01010101ull)) |
+        ((x &
+          0b01010101'00000000'01010101'00000000'01010101'00000000'01010101'00000000ull) >>
+         7) |
+        ((x &
+          0b00000000'10101010'00000000'10101010'00000000'10101010'00000000'10101010ull)
+         << 7);
+
+    /// transpose 2x2 diagonal elements in 4x4 block
+    x = ((x &
+          0b1100110011001100'0011001100110011'1100110011001100'0011001100110011ull)) |
+        ((x &
+          0b0011001100110011'0000000000000000'0011001100110011'0000000000000000ull) >>
+         14) |
+        ((x &
+          0b0000000000000000'1100110011001100'0000000000000000'1100110011001100ull)
+         << 14);
+
+    /// transpose 4x4 diagonal elements in 8x8 block
+    x = ((x &
+          0b11110000111100001111000011110000'00001111000011110000111100001111ull)) |
+        ((x &
+          0b00001111000011110000111100001111'00000000000000000000000000000000ull) >>
+         28) |
+        ((x &
+          0b00000000000000000000000000000000'11110000111100001111000011110000ull)
+         << 28);
+
+    return x;
+}
+
+} // namespace
+
+
+bool TupleKeysEqual(const TTupleLayout *layout,
+                           const ui8 *lhsRow, const ui8 *lhsOverflow,
+                           const ui8 *rhsRow, const ui8 *rhsOverflow) {
+    if (std::memcmp(lhsRow, rhsRow, layout->KeyColumnsFixedEnd)) {
+        return false;
+    }
+
+    // TODO: better nulls detection??
+    const ui8 rem = layout->KeyColumnsNum % 8;
+    const ui8 masks[2] = {static_cast<ui8>((1 << rem) - 1), 0xFF};
+    for (i32 i = layout->KeyColumnsNum, byteN = 0; i > 0; i -= 8, byteN++) {
+        const ui8 lhsBits = ReadUnaligned<ui8>(lhsRow + layout->BitmaskOffset + byteN);
+        const ui8 rhsBits = ReadUnaligned<ui8>(rhsRow + layout->BitmaskOffset + byteN);
+        const ui8 midx = (i >= 8);
+        if (((lhsBits & masks[midx]) != masks[midx]) || (rhsBits & masks[midx]) != masks[midx]) { // if there is at least one null in key cols
+            return false;
+        }
+    }
+
+    for (auto colInd = layout->KeyColumnsFixedNum; colInd != layout->KeyColumnsNum; ++colInd) {
+        const auto &col = layout->Columns[colInd];
+
+        const auto lhsPrefSize = ReadUnaligned<ui8>(lhsRow + col.Offset);
+        const auto rhsPrefSize = ReadUnaligned<ui8>(rhsRow + col.Offset);
+        if (lhsPrefSize != rhsPrefSize) {
+            return false;
+        }
+
+        if (lhsPrefSize < 255) {
+            if (std::memcmp(lhsRow + col.Offset + 1,
+                            rhsRow + col.Offset + 1, lhsPrefSize)) {
+                return false;
+            }
+        } else {
+            const auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+            const auto lhsOverflowOffset = ReadUnaligned<ui32>(
+                lhsRow + col.Offset + 1 + 0 * sizeof(ui32));
+            const auto lhsOverflowSize = ReadUnaligned<ui32>(
+                lhsRow + col.Offset + 1 + 1 * sizeof(ui32));
+            const auto rhsOverflowOffset = ReadUnaligned<ui32>(
+                rhsRow + col.Offset + 1 + 0 * sizeof(ui32));
+            const auto rhsOverflowSize = ReadUnaligned<ui32>(
+                rhsRow + col.Offset + 1 + 1 * sizeof(ui32));
+
+            if (lhsOverflowSize != rhsOverflowSize ||
+                std::memcmp(lhsRow + col.Offset + 1 + 2 * sizeof(ui32),
+                            rhsRow + col.Offset + 1 + 2 * sizeof(ui32),
+                            prefixSize) ||
+                std::memcmp(lhsOverflow + lhsOverflowOffset,
+                            rhsOverflow + rhsOverflowOffset,
+                            lhsOverflowSize)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+/// used just for having AN order on tuples
+/// cant rely on that comparison in any other way
+bool TTupleLayout::KeysLess(const ui8 *lhsRow, const ui8 *lhsOverflow,
+                            const ui8 *rhsRow, const ui8 *rhsOverflow) const {
+    int cmpRes;
+
+    cmpRes = std::memcmp(lhsRow, rhsRow, KeyColumnsFixedEnd);
+    if (cmpRes) {
+        return cmpRes < 0;
+    }
+    cmpRes = std::memcmp(lhsRow + BitmaskOffset, rhsRow + BitmaskOffset,
+                         BitmaskSize);
+    if (cmpRes) {
+        return cmpRes < 0;
+    }
+
+    for (auto colInd = KeyColumnsFixedNum; colInd != KeyColumnsNum; ++colInd) {
+        const auto &col = Columns[colInd];
+
+        const auto lhsPrefSize = ReadUnaligned<ui8>(lhsRow + col.Offset);
+        const auto rhsPrefSize = ReadUnaligned<ui8>(rhsRow + col.Offset);
+        if (lhsPrefSize != rhsPrefSize) {
+            return lhsPrefSize < rhsPrefSize;
+        }
+
+        if (lhsPrefSize < 255) {
+            cmpRes = std::memcmp(lhsRow + col.Offset + 1,
+                                 rhsRow + col.Offset + 1, lhsPrefSize);
+            if (cmpRes) {
+                return cmpRes < 0;
+            }
+        } else {
+            const auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+            const auto lhsOverflowOffset =
+                ReadUnaligned<ui32>(lhsRow + col.Offset + 1 + 0 * sizeof(ui32));
+            const auto lhsOverflowSize =
+                ReadUnaligned<ui32>(lhsRow + col.Offset + 1 + 1 * sizeof(ui32));
+            const auto rhsOverflowOffset =
+                ReadUnaligned<ui32>(rhsRow + col.Offset + 1 + 0 * sizeof(ui32));
+            const auto rhsOverflowSize =
+                ReadUnaligned<ui32>(rhsRow + col.Offset + 1 + 1 * sizeof(ui32));
+
+            if (lhsOverflowSize != rhsOverflowSize) {
+                return lhsOverflowSize < rhsOverflowSize;
+            }
+            cmpRes = std::memcmp(lhsRow + col.Offset + 1 + 2 * sizeof(ui32),
+                                 rhsRow + col.Offset + 1 + 2 * sizeof(ui32),
+                                 prefixSize);
+            if (cmpRes) {
+                return cmpRes < 0;
+            }
+            cmpRes =
+                std::memcmp(lhsOverflow + lhsOverflowOffset,
+                            rhsOverflow + rhsOverflowOffset, lhsOverflowSize);
+            if (cmpRes) {
+                return cmpRes < 0;
+            }
+        }
+    }
+
+    return false;
+}
+
+THolder<TTupleLayout>
+TTupleLayout::Create(const std::vector<TColumnDesc> &columns) {
+    return MakeHolder<TTupleLayoutFallback>(
+        columns);
+}
+
+TTupleLayoutFallback::TTupleLayoutFallback(
+    const std::vector<TColumnDesc> &columns)
+    : TTupleLayout(columns) {
+
+    for (ui32 i = 0, idx = 0; i < OrigColumns.size(); ++i) {
+        auto &col = OrigColumns[i];
+
+        col.OriginalIndex = idx;
+        col.OriginalColumnIndex = i;
+
+        if (col.SizeType == EColumnSizeType::Variable) {
+            // we cannot handle (rare) overflow strings unless we have at least
+            // space for header; size of inlined strings is limited to 254
+            // bytes, limit maximum inline data size
+            col.DataSize = std::max<ui32>(1 + 2 * sizeof(ui32),
+                                          std::min<ui32>(255, col.DataSize));
+            idx += 2; // Variable-size takes two buffers: one for offsets, and
+                      // another for payload
+        } else {
+            idx += 1;
+        }
+
+        if (col.Role == EColumnRole::Key) {
+            KeyColumns.push_back(col);
+        } else {
+            PayloadColumns.push_back(col);
+        }
+    }
+
+    KeyColumnsNum = KeyColumns.size();
+
+    auto ColumnDescLess = [](const TColumnDesc &a, const TColumnDesc &b) {
+        if (a.SizeType != b.SizeType) // Fixed first
+            return a.SizeType == EColumnSizeType::Fixed;
+
+        if (a.DataSize == b.DataSize)
+            // relative order of (otherwise) same key columns must be preserved
+            return a.OriginalIndex < b.OriginalIndex;
+
+        return a.DataSize < b.DataSize;
+    };
+
+    std::sort(KeyColumns.begin(), KeyColumns.end(), ColumnDescLess);
+    std::sort(PayloadColumns.begin(), PayloadColumns.end(), ColumnDescLess);
+
+    KeyColumnsFixedEnd = 0;
+
+    ui32 currOffset = 4; // crc32 hash in the beginning
+    KeyColumnsOffset = currOffset;
+    KeyColumnsFixedNum = KeyColumnsNum;
+
+    for (ui32 i = 0; i < KeyColumnsNum; ++i) {
+        auto &col = KeyColumns[i];
+
+        if (col.SizeType == EColumnSizeType::Variable &&
+            KeyColumnsFixedEnd == 0) {
+            KeyColumnsFixedEnd = currOffset;
+            KeyColumnsFixedNum = i;
+        }
+
+        col.ColumnIndex = i;
+        col.Offset = currOffset;
+        Columns.push_back(col);
+        currOffset += col.DataSize;
+    }
+
+    KeyColumnsEnd = currOffset;
+
+    if (KeyColumnsFixedEnd == 0) // >= 4 if was ever assigned
+        KeyColumnsFixedEnd = KeyColumnsEnd;
+
+    KeyColumnsSize = KeyColumnsEnd - KeyColumnsOffset;
+
+    /// if layout contains varsize keys or null byte of 8 cols is not enough
+    if (KeyColumnsFixedNum != KeyColumnsNum || KeyColumnsNum > 8 ||
+        !arrow::BitUtil::IsPowerOf2(uint64_t(KeyColumnsSize)) ||
+        KeyColumnsSize > (1 << 4)) {
+        KeySizeTag_ = 5;
+    } else {
+        KeySizeTag_ = arrow::BitUtil::CountTrailingZeros(KeyColumnsSize);
+    }
+
+    BitmaskOffset = currOffset;
+
+    BitmaskSize = (OrigColumns.size() + 7) / 8;
+
+    currOffset += BitmaskSize;
+    BitmaskEnd = currOffset;
+
+    PayloadOffset = currOffset;
+
+    for (ui32 i = 0; i < PayloadColumns.size(); ++i) {
+        auto &col = PayloadColumns[i];
+        col.ColumnIndex = KeyColumnsNum + i;
+        col.Offset = currOffset;
+        Columns.push_back(col);
+        currOffset += col.DataSize;
+    }
+
+    PayloadEnd = currOffset;
+    PayloadSize = PayloadEnd - PayloadOffset;
+
+    TotalRowSize = currOffset;
+
+    for (auto &col : Columns) {
+        if (col.SizeType == EColumnSizeType::Variable) {
+            VariableColumns.push_back(col);
+        } else if (IsPowerOf2(col.DataSize) &&
+                   col.DataSize < (1u << FixedPOTColumns_.size())) {
+            FixedPOTColumns_[CountTrailingZeroBits(col.DataSize)].push_back(
+                col);
+        } else {
+            FixedNPOTColumns_.push_back(col);
+        }
+    }
+}
+
+
+// Columns (SoA) format:
+//   for fixed size: packed data
+//   for variable size: offset (ui32) into next column; size of colum is
+//   rowCount + 1
+//
+// Row (AoS) format:
+//   fixed size: packed data
+//   variable size:
+//     assumes DataSize <= 255 && DataSize >= 1 + 2*4
+//     if size of payload is less than col.DataSize:
+//       u8 one byte of size (0..254)
+//       u8 [size] data
+//       u8 [DataSize - 1 - size] padding
+//     if size of payload is greater than DataSize:
+//       u8 = 255
+//       u32 = offset in overflow buffer
+//       u32 = size
+//       u8 [DataSize - 1 - 2*4] initial bytes of data
+// Data is expected to be consistent with isValidBitmask (0 for fixed-size,
+// empty for variable-size)
+void TTupleLayoutFallback::Pack(
+    const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+    std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const {
+    using TTraits = NSimd::TSimdFallbackTraits;
+
+    const ui64 bitmaskTail =
+        BitmaskSize * 8 == OrigColumns.size()
+            ? 0
+            : ~0ull << ((OrigColumns.size() + 8 - BitmaskSize * 8) * 8);
+    std::vector<ui64> bitmaskMatrix(BitmaskSize, 0);
+    bitmaskMatrix.back() = bitmaskTail;
+
+    if (auto off = (start % 8)) {
+        auto bitmaskIdx = start / 8;
+
+        for (ui32 j = Columns.size(); j--;) {
+            const ui64 byte =
+                isValidBitmask[Columns[j].OriginalIndex]
+                    ? isValidBitmask[Columns[j].OriginalIndex][bitmaskIdx]
+                    : 0xFF;
+            bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+        }
+
+        for (auto &m : bitmaskMatrix) {
+            m = transposeBitmatrix(m);
+            m >>= off * 8;
+        }
+    }
+
+    for (; count--; ++start, res += TotalRowSize) {
+        auto bitmaskIdx = start / 8;
+
+        if ((start % 8) == 0) {
+            std::fill(bitmaskMatrix.begin(), bitmaskMatrix.end(), 0);
+            bitmaskMatrix.back() = bitmaskTail;
+
+            for (ui32 j = Columns.size(); j--;) {
+                const ui64 byte =
+                isValidBitmask[Columns[j].OriginalIndex]
+                    ? isValidBitmask[Columns[j].OriginalIndex][bitmaskIdx]
+                    : 0xFF;
+                bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+            }
+            for (auto &m : bitmaskMatrix)
+                m = transposeBitmatrix(m);
+        }
+
+        for (ui32 j = 0; j < BitmaskSize; ++j) {
+            res[BitmaskOffset + j] = ui8(bitmaskMatrix[j]);
+            bitmaskMatrix[j] >>= 8;
+        }
+
+        for (auto &col : FixedNPOTColumns_) {
+            std::memcpy(res + col.Offset,
+                        columns[col.OriginalIndex] + start * col.DataSize,
+                        col.DataSize);
+        }
+
+#define PackPOTColumn(POT)                                                     \
+    for (auto &col : FixedPOTColumns_[POT]) {                                  \
+        std::memcpy(res + col.Offset,                                          \
+                    columns[col.OriginalIndex] + start * (1u << POT),          \
+                    1u << POT);                                                \
+    }
+
+        PackPOTColumn(0);
+        PackPOTColumn(1);
+        PackPOTColumn(2);
+        PackPOTColumn(3);
+        PackPOTColumn(4);
+#undef PackPOTColumn
+
+        ui32 hash = CalculateCRC32<TTraits>(
+            res + KeyColumnsOffset, KeyColumnsFixedEnd - KeyColumnsOffset);
+
+        for (ui32 i = KeyColumnsFixedNum; i < KeyColumns.size(); ++i) {
+            auto &col = KeyColumns[i];
+            auto dataOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * start);
+            auto nextOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+            auto size = nextOffset - dataOffset;
+            auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+            // hash = CalculateCRC32<TTraits>((ui8 *)&size, sizeof(size), hash);
+            hash = CalculateCRC32<TTraits>(data, size, hash);
+        }
+
+        // isValid bitmap is NOT included into hashed data
+        WriteUnaligned<ui32>(res, hash);
+
+        for (auto &col : VariableColumns) {
+            auto dataOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * start);
+            auto nextOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+            auto size = nextOffset - dataOffset;
+            auto data = columns[col.OriginalIndex + 1] + dataOffset;
+            if (size >= col.DataSize) {
+                res[col.Offset] = 255;
+
+                auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                auto overflowSize = size - prefixSize;
+                auto overflowOffset = overflow.size();
+
+                overflow.resize(overflowOffset + overflowSize);
+
+                WriteUnaligned<ui32>(res + col.Offset + 1 +
+                                        0 * sizeof(ui32),
+                                    overflowOffset);
+                WriteUnaligned<ui32>(
+                    res + col.Offset + 1 + 1 * sizeof(ui32), overflowSize);
+                std::memcpy(res + col.Offset + 1 + 2 * sizeof(ui32), data,
+                            prefixSize);
+                std::memcpy(overflow.data() + overflowOffset,
+                            data + prefixSize, overflowSize);
+            } else {
+                Y_DEBUG_ABORT_UNLESS(size < 255);
+                res[col.Offset] = size;
+                std::memcpy(res + col.Offset + 1, data, size);
+                std::memset(res + col.Offset + 1 + size, 0,
+                            col.DataSize - (size + 1));
+            }
+        }
+    }
+}
+
+void TTupleLayoutFallback::Unpack(
+    ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+    const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const {
+    std::vector<ui64> bitmaskMatrix(BitmaskSize, 0);
+
+    {
+        const auto bitmaskIdx = start / 8;
+        const auto bitmaskShift = start % 8;
+        const auto bitmaskIdxC = (start + count) / 8;
+        const auto bitmaskShiftC = (start + count) % 8;
+
+        /// ready first bitmatrix bytes
+        for (ui32 j = Columns.size(); j--;) {
+            const ui64 byte =
+                isValidBitmask[Columns[j].OriginalIndex]
+                    ? isValidBitmask[Columns[j].OriginalIndex][bitmaskIdx] &
+                          ~(0xFF << bitmaskShift)
+                    : 0xFF;
+            bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+        }
+
+        /// ready last (which are same as above) bitmatrix bytes if needed
+        if (bitmaskIdx == bitmaskIdxC)
+            for (ui32 j = Columns.size(); j--;) {
+                const ui64 byte = isValidBitmask[Columns[j].OriginalIndex]
+                                      ? isValidBitmask[Columns[j].OriginalIndex]
+                                                      [bitmaskIdxC] &
+                                            (0xFF << bitmaskShiftC)
+                                      : 0xFF;
+                bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+            }
+
+        for (auto &m : bitmaskMatrix)
+            m = transposeBitmatrix(m);
+    }
+
+    for (auto ind = 0; ind != start % 8; ++ind) {
+        for (ui32 j = 0; j < BitmaskSize; ++j) {
+            bitmaskMatrix[j] |=
+                ui64(
+                    (res - (start % 8 - ind) * TotalRowSize)[BitmaskOffset + j])
+                << (ind * 8);
+        }
+    }
+
+    for (; count--; ++start, res += TotalRowSize) {
+        const auto bitmaskIdx = start / 8;
+        const auto bitmaskShift = start % 8;
+
+        for (ui32 j = 0; j < BitmaskSize; ++j) {
+            bitmaskMatrix[j] |= ui64(res[BitmaskOffset + j])
+                                << (bitmaskShift * 8);
+        }
+
+        if (bitmaskShift == 7 || count == 0) {
+            for (auto &m : bitmaskMatrix)
+                m = transposeBitmatrix(m);
+            for (ui32 j = Columns.size(); j--;)
+                if (isValidBitmask[Columns[j].OriginalIndex])
+                    isValidBitmask[Columns[j].OriginalIndex][bitmaskIdx] =
+                        ui8(bitmaskMatrix[j / 8] >> ((j % 8) * 8));
+            std::fill(bitmaskMatrix.begin(), bitmaskMatrix.end(), 0);
+
+            if (count && count < 8) {
+                /// ready last bitmatrix bytes
+                for (ui32 j = Columns.size(); j--;) {
+                    const ui64 byte =
+                        isValidBitmask[Columns[j].OriginalIndex]
+                            ? isValidBitmask[Columns[j].OriginalIndex]
+                                            [bitmaskIdx + 1] &
+                                  (0xFF << count)
+                            : 0xFF;
+                    bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+                }
+
+                for (auto &m : bitmaskMatrix)
+                    m = transposeBitmatrix(m);
+            }
+        }
+
+        for (auto &col : FixedNPOTColumns_) {
+            std::memcpy(columns[col.OriginalIndex] + start * col.DataSize,
+                        res + col.Offset, col.DataSize);
+        }
+
+#define PackPOTColumn(POT)                                                     \
+    for (auto &col : FixedPOTColumns_[POT]) {                                  \
+        std::memcpy(columns[col.OriginalIndex] + start * (1u << POT),          \
+                    res + col.Offset, 1u << POT);                              \
+    }
+        PackPOTColumn(0);
+        PackPOTColumn(1);
+        PackPOTColumn(2);
+        PackPOTColumn(3);
+        PackPOTColumn(4);
+#undef PackPOTColumn
+
+        for (auto &col : VariableColumns) {
+            const auto dataOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * start);
+            auto *const data = columns[col.OriginalIndex + 1] + dataOffset;
+
+            ui32 size = ReadUnaligned<ui8>(res + col.Offset);
+
+            if (size < 255) { // embedded str
+                std::memcpy(data, res + col.Offset + 1, size);
+            } else { // overflow buffer used
+                const auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                const auto overflowOffset = ReadUnaligned<ui32>(
+                    res + col.Offset + 1 + 0 * sizeof(ui32));
+                const auto overflowSize = ReadUnaligned<ui32>(
+                    res + col.Offset + 1 + 1 * sizeof(ui32));
+
+                std::memcpy(data, res + col.Offset + 1 + 2 * sizeof(ui32),
+                            prefixSize);
+                std::memcpy(data + prefixSize, overflow.data() + overflowOffset,
+                            overflowSize);
+
+                size = prefixSize + overflowSize;
+            }
+
+            WriteUnaligned<ui32>(columns[col.OriginalIndex] +
+                                     sizeof(ui32) * (start + 1),
+                                 dataOffset + size);
+        }
+    }
+}
+
+void TTupleLayout::CalculateColumnSizes(
+    const ui8 *res, ui32 count,
+    std::vector<ui64, TMKQLAllocator<ui64>> &bytes) const {
+
+    bytes.resize(Columns.size());
+
+    // handle fixed size columns
+    for (const auto& column: OrigColumns) {
+        if (column.SizeType == EColumnSizeType::Fixed) {
+            bytes[column.OriginalColumnIndex] = column.DataSize * count;
+        }
+    }
+
+    // handle variable size columns
+    for (; count--; res += TotalRowSize) {
+        for (const auto& col: VariableColumns) {
+            ui32 size = ReadUnaligned<ui8>(res + col.Offset);
+            if (size == 255) { // overflow buffer used
+                const auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                const auto overflowSize = ReadUnaligned<ui32>(res + col.Offset + 1 + 1 * sizeof(ui32));
+                size = prefixSize + overflowSize;
+            }
+            bytes[col.OriginalColumnIndex] += size;
+        }
+    }
+}
+
+void TTupleLayout::TupleDeepCopy(
+    const ui8* inTuple, const ui8* inOverflow,
+    ui8* outTuple, ui8* outOverflow, ui64& outOverflowSize) const
+{
+    std::memcpy(outTuple, inTuple, TotalRowSize);
+    for (const auto& col: VariableColumns) {
+        ui32 size = ReadUnaligned<ui8>(inTuple + col.Offset);
+        if (size == 255) { // overflow buffer used
+            auto overflowOffset = ReadUnaligned<ui32>(inTuple + col.Offset + 1 + 0 * sizeof(ui32));
+            auto overflowSize   = ReadUnaligned<ui32>(inTuple + col.Offset + 1 + 1 * sizeof(ui32));
+            std::memcpy(outOverflow, inOverflow + overflowOffset, overflowSize);
+            WriteUnaligned<ui32>(outTuple + col.Offset + 1 + 0 * sizeof(ui32), outOverflowSize);
+            outOverflowSize += overflowSize;
+        }
+    }
+}
+
+/// TODO: write unit tests
+void TTupleLayout::Concat(
+    std::vector<ui8, TMKQLAllocator<ui8>>& dst,
+        std::vector<ui8, TMKQLAllocator<ui8>>& dstOverflow,
+        ui32 dstCount,
+        const ui8 *src, const ui8 *srcOverflow, ui32 srcCount, ui32 srcOverflowSize) const 
+{
+    ui32 dstOverflowOffset = dstOverflow.size();
+    dstOverflow.resize(dstOverflow.size() + srcOverflowSize);
+    std::memcpy(dstOverflow.data() + dstOverflowOffset, srcOverflow, srcOverflowSize);
+
+    constexpr ui32 blockRows = 128;
+    dst.resize((dstCount + srcCount) * TotalRowSize);
+    ui8 *dstRow = dst.data() + dstCount * TotalRowSize;
+    ui32 blockSize;
+    
+    for (ui32 rowInd = 0; rowInd < srcCount; rowInd += blockRows, 
+                                             dstRow += blockSize * TotalRowSize,
+                                             src += blockSize * TotalRowSize) {
+        blockSize = std::min(srcCount - rowInd, blockRows);
+        std::memcpy(dstRow, src, blockSize * TotalRowSize);
+
+        ui8 *res = dstRow;
+        for (ui32 blockInd = 0; blockInd < blockSize; blockInd++,
+                                                      res += TotalRowSize) {
+            for (auto &col : VariableColumns) {
+                if (res[col.Offset] == 255) {
+                    WriteUnaligned<ui32>(res + col.Offset + 1 + 0 * sizeof(ui32),
+                                         dstOverflowOffset);
+                    dstOverflowOffset += ReadUnaligned<ui32>(
+                        res + col.Offset + 1 + 1 * sizeof(ui32));
+                }
+            }
+        }
+
+    }
+}
+
+ui32 TTupleLayout::GetTupleVarSize(const ui8* inTuple) const {
+    ui32 result = 0;
+    for (const auto& col: VariableColumns) {
+        ui32 size = ReadUnaligned<ui8>(inTuple + col.Offset);
+        if (size == 255) { // overflow buffer used
+            const auto prefixSize = col.DataSize - 1 - 2 * sizeof(ui32);
+            const auto overflowSize = ReadUnaligned<ui32>(inTuple + col.Offset + 1 + 1 * sizeof(ui32));
+            size = prefixSize + overflowSize;
+        }
+        result += size;
+    }
+    return result;
+}
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
@@ -193,7 +193,7 @@ struct TTupleLayout {
         ui32 dstCount,
         const ui8 *src, const ui8 *srcOverflow, ui32 srcCount, ui32 srcOverflowSize) const;
 
-        ui32 GetTupleVarSize(const ui8* inTuple) const;
+    ui32 GetTupleVarSize(const ui8* inTuple) const;
 
     bool KeysEqual(const ui8 *lhsRow, const ui8 *lhsOverflow, const ui8 *rhsRow, const ui8 *rhsOverflow) const;
     bool KeysLess(const ui8 *lhsRow, const ui8 *lhsOverflow, const ui8 *rhsRow, const ui8 *rhsOverflow) const;
@@ -218,6 +218,49 @@ struct TTupleLayoutFallback : public TTupleLayout {
     std::vector<TColumnDesc> FixedNPOTColumns_; // Remaining fixed-size columns
 };
 
+
+template <typename TTraits> struct TTupleLayoutSIMD : public TTupleLayoutFallback {
+
+    explicit TTupleLayoutSIMD(const std::vector<TColumnDesc> &columns);
+
+    void Pack(const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+        std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+        ui32 count) const override;
+
+    void Unpack(ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+            const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
+            ui32 start, ui32 count) const override;
+
+  private:
+    using TSimdI8 = typename TTraits::TSimdI8;
+    template <class T> using TSimd = typename TTraits::template TSimd8<T>;
+
+    static constexpr ui8 kSIMDMaxCols = 4;
+    static constexpr ui8 kSIMDMaxInnerLoopSize = 4;
+
+    size_t BlockRows_; // Estimated rows per cache block
+    std::vector<size_t> BlockColsOffsets_;
+    std::vector<size_t> BlockFixedColsSizes_;
+    std::vector<size_t> BlockColumnsOrigInds_;
+
+    struct SIMDSmallTupleDesc {
+        ui8 Cols = 0;
+        ui8 InnerLoopIters;
+        size_t SmallTupleSize;
+        size_t RowOffset;
+    };
+    SIMDSmallTupleDesc SIMDSmallTuple_;
+    std::vector<TSimd<ui8>> SIMDPermMasks_; // small tuple precomputed masks
+
+    struct SIMDTransposeDesc {
+        ui8 Cols = 0;
+        size_t RowOffset;
+    };
+    // [1, 2, 4, 8] bytes x [Key, Payload]
+    std::array<SIMDTransposeDesc, 8> SIMDTranspositions_;
+    static constexpr std::array<size_t, 4> SIMDTranspositionsColSizes_ = {1, 2,
+                                                                          4, 8};
+};
 
 bool TupleKeysEqual(const TTupleLayout *layout,
     const ui8 *lhsRow, const ui8 *lhsOverflow,

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
@@ -178,10 +178,16 @@ struct TTupleLayout {
                         const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
                         ui32 start, ui32 count) const = 0;
 
+    virtual void
+    BucketPack(const ui8 **columns, const ui8 **isValidBitmask,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows,
+                 ui32 start, ui32 count, ui32 bucketsLogNum) const = 0;
+
     // Takes packed rows,
     // outputs vector of column sizes in bytes
     void CalculateColumnSizes(
-        const ui8* res, ui32 count, std::vector<ui64, TMKQLAllocator<ui64>>& bytes) const ;
+        const ui8* res, ui32 count, std::vector<ui64, TMKQLAllocator<ui64>>& bytes) const;
 
     void TupleDeepCopy(
         const ui8* inTuple, const ui8* inOverflow,
@@ -211,6 +217,12 @@ struct TTupleLayoutFallback : public TTupleLayout {
                 const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
                 ui32 start, ui32 count) const override;
 
+    void
+    BucketPack(const ui8 **columns, const ui8 **isValidBitmask,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows,
+                 ui32 start, ui32 count, ui32 bucketsLogNum) const override;
+
   protected:
     std::array<std::vector<TColumnDesc>, 5>
         FixedPOTColumns_; // Fixed-size columns for power-of-two sizes from 1 to
@@ -230,6 +242,12 @@ template <typename TTraits> struct TTupleLayoutSIMD : public TTupleLayoutFallbac
     void Unpack(ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
             const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
             ui32 start, ui32 count) const override;
+
+    void
+    BucketPack(const ui8 **columns, const ui8 **isValidBitmask,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows,
+                 ui32 start, ui32 count, ui32 bucketsLogNum) const override;
 
   private:
     using TSimdI8 = typename TTraits::TSimdI8;

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
@@ -1,0 +1,337 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+#include <yql/essentials/public/udf/udf_types.h>
+
+#include <util/generic/buffer.h>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+template <typename TData>
+struct TCastPtrTransform {
+    using T = TData;
+    static T *ToPtr(ui8 *ptr) { return reinterpret_cast<T *>(ptr); }
+    static T &ToRef(ui8 *ptr) { return *reinterpret_cast<T *>(ptr); }
+};
+
+template <typename TData, typename TPtrTransform = TCastPtrTransform<TData>>
+class TPaddedPtr
+    : public std::iterator<std::random_access_iterator_tag,
+                           typename TPtrTransform::T, int64_t,
+                           decltype(TPtrTransform::ToPtr(nullptr)),
+                           decltype(TPtrTransform::ToRef(nullptr))> {
+    using T = std::iterator_traits<TPaddedPtr>::value_type;
+    using TPtr = std::iterator_traits<TPaddedPtr>::pointer;
+    using TRef = std::iterator_traits<TPaddedPtr>::reference;
+
+  public:
+    TPaddedPtr(TData *ptr)
+        : Ptr_(reinterpret_cast<ui8 *>(ptr)), Step_(sizeof(TData)) {}
+
+    TPaddedPtr(TData *ptr, ui32 step)
+        : Ptr_(reinterpret_cast<ui8 *>(ptr)), Step_(step) {}
+
+    TPaddedPtr(ui8 *ptr, ui32 step)
+        requires(!std::same_as<ui8, TData>)
+        : Ptr_(reinterpret_cast<ui8 *>(ptr)), Step_(step) {}
+
+    ui32 Step() const {
+        return Step_;
+    }
+
+    TRef operator[](int64_t ind) const {
+        return TPtrTransform::ToRef(Ptr_ + Step_ * ind);
+    }
+
+    TPtr operator->() const {
+        return TPtrTransform::ToPtr(Ptr_);
+    }
+
+    TRef operator*() const {
+        return TPtrTransform::ToRef(Ptr_);
+    }
+        
+    TPaddedPtr& operator+=(int64_t n) {
+        Ptr_ += n * Step_;
+        return *this;
+    }
+    TPaddedPtr& operator++() {
+        return (*this) += 1;
+    }
+    TPaddedPtr& operator-=(int64_t n) {
+        return (*this) += -n;
+    }
+    TPaddedPtr& operator--() {
+        return (*this) -= 1;
+    }
+
+    TPaddedPtr operator+(int64_t n) const {
+        auto ptr = *this;
+        ptr += n;
+        return ptr;
+    }
+    TPaddedPtr operator-(int64_t n) const {
+        return (*this) + (-n);
+    }
+
+    int64_t operator-(const TPaddedPtr& rhs) const {
+        return (Ptr_ - rhs.Ptr_) / Step_;
+    }
+
+    bool operator==(const TPaddedPtr& rhs) const {
+        return Ptr_ == rhs.Ptr_;
+    }
+    bool operator!=(const TPaddedPtr& rhs) const {
+        return Ptr_ != rhs.Ptr_;
+    }
+
+    bool operator<(const TPaddedPtr& rhs) const {
+        return Ptr_ < rhs.Ptr_;
+    }
+    bool operator<=(const TPaddedPtr& rhs) const {
+        return Ptr_ <= rhs.Ptr_;
+    }
+    bool operator>(const TPaddedPtr& rhs) const {
+        return Ptr_ > rhs.Ptr_;
+    }
+    bool operator>=(const TPaddedPtr& rhs) const {
+        return Ptr_ >= rhs.Ptr_;
+    }
+
+  private:
+    ui8* Ptr_;
+    i64 Step_;
+};
+
+namespace NPackedTuple {
+
+// Defines if data type of particular column variable or fixed
+enum class EColumnSizeType { Fixed, Variable };
+
+// Defines if particular column is key column or payload column
+enum class EColumnRole { Key, Payload };
+
+// Describes layout and size of particular column
+struct TColumnDesc {
+    ui32 ColumnIndex = 0;   // Index of the column in particular layout
+    ui32 OriginalColumnIndex = 0; // Index of the column in input representation
+    ui32 OriginalIndex = 0; // Index of the buffer in input representation
+    EColumnRole Role = EColumnRole::Payload; // Role of the particular column in
+                                             // tuple (Key or Payload)
+    EColumnSizeType SizeType =
+        EColumnSizeType::Fixed; // Fixed size or variable size column
+    ui32 DataSize = 0; // Size of the column in bytes for fixed size part
+                       // Must be same for matching key columns
+    ui32 Offset =
+        0; // Offset in bytes for column value from the beginning of tuple
+};
+
+// Defines in memory layout of tuple.
+struct TTupleLayout {
+    std::vector<TColumnDesc> OrigColumns; // Columns description and order as
+                                          // passed during layout construction
+    std::vector<TColumnDesc> Columns; // Vector describing all columns in order
+                                      // corresponding to tuple layout
+    std::vector<TColumnDesc> KeyColumns; // Vector describing key columns
+    std::vector<TColumnDesc>
+        PayloadColumns;      // Vector describing payload columns
+    std::vector<TColumnDesc> VariableColumns;  // Variable-size columns only
+    ui32 KeyColumnsNum;      // Total number of key columns
+    ui32 KeyColumnsSize;     // Total size of all key columns in bytes
+    ui32 KeyColumnsOffset;   // Start of row-packed keys data
+    ui32 KeyColumnsFixedEnd; // Offset in row-packed keys data of first variable
+                             // key (can be same as KeyColumnsEnd, if there are
+                             // none)
+    ui32 KeyColumnsFixedNum; // Number of fixed-size columns
+    ui32 KeyColumnsEnd; // First byte after key columns. Start of bitmask for
+                        // row-based columns
+    ui32 KeySizeTag_;   // Simple byte key fast path tag
+    ui32 BitmaskSize;   // Size of bitmask for null values flag in columns
+    ui32 BitmaskOffset; // Offset of nulls bitmask. = KeyColumnsEnd
+    ui32 BitmaskEnd;    // First byte after bitmask. = PayloadOffset
+    ui32 PayloadSize;   // Total size in bytes of the payload columns
+    ui32 PayloadOffset; // Offset of payload values. = BitmaskEnd.
+    ui32 PayloadEnd;    // First byte after payload
+    ui32 TotalRowSize;  // Total size of bytes for packed row
+
+    // Creates new tuple layout based on provided columns description.
+    static THolder<TTupleLayout>
+    Create(const std::vector<TColumnDesc> &columns);
+
+    TTupleLayout(const std::vector<TColumnDesc> &columns)
+        : OrigColumns(columns) {}
+    virtual ~TTupleLayout() {}
+
+    // Takes array of pointer to columns, array of validity bitmaps,
+    // outputs packed rows
+    virtual void Pack(const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+                      std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
+                      ui32 start, ui32 count) const = 0;
+
+    // Takes packed rows,
+    // outputs array of pointer to columns, array of validity bitmaps
+    virtual void Unpack(ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+                        const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
+                        ui32 start, ui32 count) const = 0;
+
+    // Takes packed rows,
+    // outputs vector of column sizes in bytes
+    void CalculateColumnSizes(
+        const ui8* res, ui32 count, std::vector<ui64, TMKQLAllocator<ui64>>& bytes) const ;
+
+    void TupleDeepCopy(
+        const ui8* inTuple, const ui8* inOverflow,
+        ui8* outTuple, ui8* outOverflow, ui64& outOverflowSize) const;
+
+    void Concat(
+        std::vector<ui8, TMKQLAllocator<ui8>>& dst,
+        std::vector<ui8, TMKQLAllocator<ui8>>& dstOverflow,
+        ui32 dstCount,
+        const ui8 *src, const ui8 *srcOverflow, ui32 srcCount, ui32 srcOverflowSize) const;
+
+        ui32 GetTupleVarSize(const ui8* inTuple) const;
+
+    bool KeysEqual(const ui8 *lhsRow, const ui8 *lhsOverflow, const ui8 *rhsRow, const ui8 *rhsOverflow) const;
+    bool KeysLess(const ui8 *lhsRow, const ui8 *lhsOverflow, const ui8 *rhsRow, const ui8 *rhsOverflow) const;
+};
+
+struct TTupleLayoutFallback : public TTupleLayout {
+
+    explicit TTupleLayoutFallback(const std::vector<TColumnDesc> &columns);
+
+    void Pack(const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+              std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+              ui32 count) const override;
+
+    void Unpack(ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+                const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
+                ui32 start, ui32 count) const override;
+
+  protected:
+    std::array<std::vector<TColumnDesc>, 5>
+        FixedPOTColumns_; // Fixed-size columns for power-of-two sizes from 1 to
+                          // 16 bytes
+    std::vector<TColumnDesc> FixedNPOTColumns_; // Remaining fixed-size columns
+};
+
+
+bool TupleKeysEqual(const TTupleLayout *layout,
+    const ui8 *lhsRow, const ui8 *lhsOverflow,
+    const ui8 *rhsRow, const ui8 *rhsOverflow);
+
+Y_FORCE_INLINE
+bool TTupleLayout::KeysEqual(const ui8 *lhsRow, const ui8 *lhsOverflow,
+                             const ui8 *rhsRow, const ui8 *rhsOverflow) const {
+    const ui8 keyNullMask = (1u << KeyColumnsNum) - 1;
+
+    switch (KeySizeTag_) {
+    case 0:
+        return ReadUnaligned<ui8>(lhsRow + KeyColumnsOffset) ==
+                   ReadUnaligned<ui8>(rhsRow + KeyColumnsOffset) &&
+               (ReadUnaligned<ui8>(lhsRow + BitmaskOffset) &
+                ReadUnaligned<ui8>(rhsRow + BitmaskOffset) & keyNullMask) ==
+                   keyNullMask;
+    case 1:
+        return ReadUnaligned<ui16>(lhsRow + KeyColumnsOffset) ==
+                   ReadUnaligned<ui16>(rhsRow + KeyColumnsOffset) &&
+               (ReadUnaligned<ui8>(lhsRow + BitmaskOffset) &
+                ReadUnaligned<ui8>(rhsRow + BitmaskOffset) & keyNullMask) ==
+                   keyNullMask;
+
+    case 2:
+        return ReadUnaligned<ui32>(lhsRow + KeyColumnsOffset) ==
+                   ReadUnaligned<ui32>(rhsRow + KeyColumnsOffset) &&
+               (ReadUnaligned<ui8>(lhsRow + BitmaskOffset) &
+                ReadUnaligned<ui8>(rhsRow + BitmaskOffset) & keyNullMask) ==
+                   keyNullMask;
+
+    case 3:
+        return ReadUnaligned<ui64>(lhsRow + KeyColumnsOffset) ==
+                   ReadUnaligned<ui64>(rhsRow + KeyColumnsOffset) &&
+               (ReadUnaligned<ui8>(lhsRow + BitmaskOffset) &
+                ReadUnaligned<ui8>(rhsRow + BitmaskOffset) & keyNullMask) ==
+                   keyNullMask;
+
+    case 4:
+        return ReadUnaligned<ui64>(lhsRow + KeyColumnsOffset) ==
+                   ReadUnaligned<ui64>(rhsRow + KeyColumnsOffset) &&
+               ReadUnaligned<ui64>(lhsRow + KeyColumnsOffset + 8) ==
+                   ReadUnaligned<ui64>(rhsRow + KeyColumnsOffset + 8) &&
+               (ReadUnaligned<ui8>(lhsRow + BitmaskOffset) &
+                ReadUnaligned<ui8>(rhsRow + BitmaskOffset) & keyNullMask) ==
+                   keyNullMask;
+
+    default:
+        return TupleKeysEqual(this, lhsRow, lhsOverflow, rhsRow, rhsOverflow);
+    }
+}
+
+template <size_t Size>
+struct TEmbeddedTupleRowRef {
+    TEmbeddedTupleRowRef(ui8* tuple): Ptr(tuple) {}
+
+    TEmbeddedTupleRowRef(const TEmbeddedTupleRowRef&) = default;
+    
+    TEmbeddedTupleRowRef& operator=(const TEmbeddedTupleRowRef& rhs) {
+        std::memcpy(Ptr, rhs.Ptr, Size);
+        return *this;
+    }
+    
+    friend void swap(TEmbeddedTupleRowRef lhs, TEmbeddedTupleRowRef rhs) {
+        ui8 buf[Size];
+        std::memcpy(buf, lhs.Ptr, Size);
+        std::memcpy(lhs.Ptr, rhs.Ptr, Size);
+        std::memcpy(rhs.Ptr, buf, Size);
+    }
+
+  public:
+    ui8* Ptr;
+};
+
+template <size_t Size>
+struct TEmbeddedTuple {
+    TEmbeddedTuple() {}
+
+    TEmbeddedTuple(const TEmbeddedTuple& row) {
+        std::memcpy(Ptr, row.Ptr, Size);
+    };
+
+    TEmbeddedTuple& operator=(const TEmbeddedTuple &rhs) {
+        std::memcpy(Ptr, rhs.Ptr, Size);
+        return *this;
+    }
+    
+  public:
+    ui8 Ptr[Size];
+};
+
+template <size_t Size = 16>
+[[maybe_unused]] void SortEmbeddedTuples(TPaddedPtr<TEmbeddedTuple<Size>> first, size_t n, const TTupleLayout* layout, const ui8* overflow) {
+    auto cmpr = [layout, overflow](const TEmbeddedTuple<Size> &lhs, const TEmbeddedTuple<Size> &rhs) {
+        return layout->KeysLess(lhs.Ptr, overflow, rhs.Ptr, overflow);
+    };
+    std::sort(first, first + n, cmpr);
+}
+
+struct TIndexedTuple {
+    ui32 Hash;
+    ui32 Index;
+};
+
+[[maybe_unused]] inline void SortIndexedTuples(TPaddedPtr<TIndexedTuple> first, size_t n, const TTupleLayout* layout, const ui8* tuples, const ui8* overflow) {
+    auto cmpr = [layout, tuples, overflow](TIndexedTuple lhs, TIndexedTuple rhs) {
+        if (lhs.Hash != rhs.Hash) {
+            return lhs.Hash < rhs.Hash;
+        }
+        return layout->KeysLess(tuples + layout->TotalRowSize * lhs.Index, overflow, tuples + layout->TotalRowSize * rhs.Index, overflow);
+    };
+    std::sort(first, first + n, cmpr);
+}
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/accumulator_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/accumulator_ut.cpp
@@ -1,0 +1,655 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <chrono>
+#include <vector>
+#include <random>
+
+#include <util/system/fs.h>
+#include <util/system/compiler.h>
+#include <util/stream/null.h>
+#include <util/system/mem_info.h>
+
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/histogram.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h>
+
+#include <arrow/util/bit_util.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+using namespace std::chrono_literals;
+
+static volatile bool IsVerbose = false;
+#define CTEST (IsVerbose ? Cerr : Cnull)
+
+namespace {
+
+TVector<TString> GenerateValues(size_t level) {
+    constexpr size_t alphaSize = 'Z' - 'A' + 1;
+    if (level == 1) {
+        TVector<TString> alphabet(alphaSize);
+        std::iota(alphabet.begin(), alphabet.end(), 'A');
+        return alphabet;
+    }
+    const auto subValues = GenerateValues(level - 1);
+    TVector<TString> values;
+    values.reserve(alphaSize * subValues.size());
+    for (char ch = 'A'; ch <= 'Z'; ch++) {
+        for (const auto& tail : subValues) {
+            values.emplace_back(ch + tail);
+        }
+    }
+    return values;
+}
+
+static const TVector<TString> threeLetterValues = GenerateValues(3);
+
+bool RunFixSizedAccumulatorBench(ui64 nTuples, ui64 nCols, ui64 log2Buckets) {
+    auto nBuckets = 1 << log2Buckets;
+    CTEST << "============ BENCH BEGIN ============" << Endl;
+    CTEST << "Test config:" << Endl;
+    CTEST << ">  nTuples: " << nTuples << Endl;
+    CTEST << ">  nCols: " << nCols << Endl;
+    CTEST << ">  nBuckets: " << nBuckets << Endl;
+
+    ui64 totalTime = 0;
+
+    TScopedAlloc alloc(__LOCATION__);
+    using TBuffer = TAccumulator::TBuffer;
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns(nCols, kc);
+    auto tl = TTupleLayout::Create(columns);
+    const ui64 TuplesDataBytes = (tl->TotalRowSize) * nTuples;
+    CTEST << ">  Dataset size: " << TuplesDataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST << " " << Endl;
+
+    std::vector<ui64> col(nTuples, 0);
+    std::iota(col.begin(), col.end(), 0);
+    auto colsData = std::vector(nCols, col);
+    std::vector<const ui8*> cols(nCols);
+    for (size_t ind = 0; ind != nCols; ind++) {
+        cols[ind] = (ui8*)colsData[ind].data();
+    }
+    std::vector<ui8> colValid((nTuples + 7)/8, ~0);
+    auto colsValidData = std::vector(nCols, colValid);
+    std::vector<const ui8*> colsValid(nCols);
+    for (size_t ind = 0; ind != nCols; ind++) {
+        colsValid[ind] = (ui8*)colsValidData[ind].data();
+    }
+
+    auto resesData = std::vector<std::vector<ui8, TMKQLAllocator<ui8>>>(1u << log2Buckets);
+    std::vector<std::vector<ui8, TMKQLAllocator<ui8>>> overflowsData(1u << log2Buckets);
+
+    auto reses = TPaddedPtr(resesData.data(), sizeof(resesData[0]));
+    auto overflows = TPaddedPtr(overflowsData.data(), sizeof(overflowsData[0]));
+
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    for (auto& bres : resesData) {
+        bres.resize(0);
+    }
+
+    auto begintp = std::chrono::steady_clock::now();
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    auto endtp = std::chrono::steady_clock::now();
+    auto bucketPackTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (bucketPackTime == 0) bucketPackTime = 1;
+
+    CTEST << "Bucket pack time: " << bucketPackTime  << "[microseconds]" << Endl;
+    CTEST << "Bucket pack speed: " << TuplesDataBytes / bucketPackTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    std::vector<ui8> res(TuplesDataBytes, 0);
+    for (ui32 i = 0; i < nTuples; ++i) {
+        col[i] = i;
+    }
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+
+    begintp = std::chrono::steady_clock::now();
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    endtp = std::chrono::steady_clock::now();
+    auto packTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (packTime == 0) packTime = 1;
+    totalTime += packTime;
+
+    CTEST << "Pack time: " << packTime  << "[microseconds]" << Endl;
+    CTEST << "Pack speed: " << TuplesDataBytes / packTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
+    ui32 shift = 32 - bitsCount;
+    ui32 mask = (1 << bitsCount) - 1;
+
+    std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(nBuckets, {0, 0});
+
+    {
+        // std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        Histogram hist;
+        hist.AddData(tl.Get(), res.data(), nTuples, TAccumulator::GetBucketId, shift, mask);
+        hist.EstimateSizes(sizes);
+
+        // std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        // ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        // if (microseconds == 0) microseconds = 1;
+        // // totalTime += microseconds;
+
+        // CTEST << "Histogram build time: " << microseconds  << "[microseconds]" << Endl;
+        // CTEST << "Histogram build speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        // CTEST << " " << Endl;
+    }
+
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets(nBuckets);
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets(nBuckets);
+
+    {
+        // std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets[i].resize(TLsize);
+            std::memset(PackedTupleBuckets[i].data(), 0, TLsize);
+            OverflowBuckets[i].resize(Osize);
+            std::memset(OverflowBuckets[i].data(), 0, Osize);
+        }
+
+        // std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        // ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        // if (microseconds == 0) microseconds = 1;
+        // // totalTime += microseconds;
+
+        // CTEST << "Memory allocation time: " << microseconds  << "[microseconds]" << Endl;
+        // CTEST << "Memory allocation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        // CTEST << " " << Endl;
+    }
+
+    std::array<THolder<TAccumulator>, 2> accums;
+    accums[0] = MakeHolder<TAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+    accums[1] = MakeHolder<TSMBAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+
+    for (auto &accum : accums)
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        accum->AddData(res.data(), overflow.data(), nTuples);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+    
+        CTEST << "------------------" << Endl << " " << Endl;
+
+        CTEST << "Accumulation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Accumulation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+
+        CTEST << "Total time: " << totalTime + microseconds  << "[microseconds]" << Endl;
+        CTEST << "Resulting speed: " << TuplesDataBytes / (totalTime + microseconds) << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    CTEST << "============= BENCH END =============" << Endl << " " << Endl;
+
+    return accums[0]->GetBucket(0).NTuples > 0;
+}
+
+bool RunVarSizedAccumulatorBench(ui64 nTuples, ui64 nCols, ui64 log2Buckets) {
+    auto nBuckets = 1 << log2Buckets;
+    TScopedAlloc alloc(__LOCATION__);
+    using TBuffer = TAccumulator::TBuffer;
+
+    ui64 totalTime = 0;
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.SizeType = EColumnSizeType::Variable;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns(nCols, kc);
+    auto tl = TTupleLayout::Create(columns);
+    ui64 TuplesDataBytes = tl->TotalRowSize * nTuples;
+
+    std::vector<ui32> col(1, 0);
+    std::vector<ui8> colData;
+
+    for (ui64 i = 0; i < nTuples; ++i) {
+        const auto& str = threeLetterValues[i % threeLetterValues.size()];
+        for (ui8 k = 0; k < 6; ++k) {
+            for (auto c: str) {
+                colData.push_back(c);
+            }
+        }
+        col.push_back(colData.size());
+    }
+
+    std::vector<const ui8*> cols(2 * nCols);
+    for (ui64 i = 0; i < nCols; i++) {
+        cols[2 * i] = (ui8*) col.data();
+        cols[2 * i + 1] = (ui8*) colData.data();
+    }
+
+    std::vector<ui8> colValid((nTuples + 7)/8, ~0);
+    std::vector<const ui8*> colsValid(2 * nCols);
+    for (ui64 i = 0; i < nCols; i++) {
+        colsValid[2 * i] = colValid.data();
+        colsValid[2 * i + 1] = nullptr;
+    }
+
+    std::vector<ui8> res(TuplesDataBytes, 0);
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    TuplesDataBytes += overflow.size();
+    overflow.resize(0);
+
+    CTEST << "============ BENCH BEGIN ============" << Endl;
+    CTEST << "Test config:" << Endl;
+    CTEST << ">  nTuples: " << nTuples << Endl;
+    CTEST << ">  nCols: " << nCols << Endl;
+    CTEST << ">  nBuckets: " << nBuckets << Endl;
+    CTEST << ">  Dataset size: " << TuplesDataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST << " " << Endl;
+
+    auto resesData = std::vector<std::vector<ui8, TMKQLAllocator<ui8>>>(1u << log2Buckets);
+    std::vector<std::vector<ui8, TMKQLAllocator<ui8>>> overflowsData(1u << log2Buckets);
+
+    auto reses = TPaddedPtr(resesData.data(), sizeof(resesData[0]));
+    auto overflows = TPaddedPtr(overflowsData.data(), sizeof(overflowsData[0]));
+    
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    for (auto& bres : resesData) {
+        bres.resize(0);
+    }
+    for (auto& boverflow : overflowsData) {
+        boverflow.resize(0);
+    }
+
+    auto begintp = std::chrono::steady_clock::now();
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    auto endtp = std::chrono::steady_clock::now();
+    auto bucketPackTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (bucketPackTime == 0) bucketPackTime = 1;
+
+    CTEST << "Bucket pack time: " << bucketPackTime  << "[microseconds]" << Endl;
+    CTEST << "Bucket pack speed: " << TuplesDataBytes / bucketPackTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    begintp = std::chrono::steady_clock::now();
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    endtp = std::chrono::steady_clock::now();
+    auto packTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (packTime == 0) packTime = 1;
+    totalTime += packTime;
+
+    CTEST << "Pack time: " << packTime  << "[microseconds]" << Endl;
+    CTEST << "Pack speed: " << TuplesDataBytes / packTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
+    ui32 shift = 32 - bitsCount;
+    ui32 mask = (1 << bitsCount) - 1;
+
+    std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(nBuckets, {0, 0});
+
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        Histogram hist;
+        hist.AddData(tl.Get(), res.data(), nTuples, TAccumulator::GetBucketId, shift, mask);
+        hist.EstimateSizes(sizes);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+
+        CTEST << "Histogram build time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Histogram build speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets(nBuckets);
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets(nBuckets);
+
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets[i].resize(TLsize);
+            std::memset(PackedTupleBuckets[i].data(), 0, TLsize);
+            OverflowBuckets[i].resize(Osize);
+            std::memset(OverflowBuckets[i].data(), 0, Osize);
+        }
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+
+        CTEST << "Memory allocation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Memory allocation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    std::array<THolder<TAccumulator>, 2> accums;
+    accums[0] = MakeHolder<TAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+    accums[1] = MakeHolder<TSMBAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+
+    for (auto &accum : accums)
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        accum->AddData(res.data(), overflow.data(), nTuples);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+    
+        CTEST << "------------------" << Endl << " " << Endl;
+
+        CTEST << "Accumulation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Accumulation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+
+        CTEST << "Total time: " << totalTime + microseconds  << "[microseconds]" << Endl;
+        CTEST << "Resulting speed: " << TuplesDataBytes / (totalTime + microseconds) << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    CTEST << "============= BENCH END =============" << Endl << " " << Endl;
+
+    return accums[0]->GetBucket(0).NTuples > 0;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(Accumulator) {
+
+Y_UNIT_TEST(CreateAccumulator) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc1, kc2, pc1, pc2, pc3;
+
+    kc1.Role = EColumnRole::Key;
+    kc1.DataSize = 8;
+
+    kc2.Role = EColumnRole::Key;
+    kc2.DataSize = 4;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 16;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    pc3.Role = EColumnRole::Payload;
+    pc3.DataSize = 8;
+
+    std::vector<TColumnDesc> columns{kc1, kc2, pc1, pc2, pc3};
+    auto tl = TTupleLayout::Create(columns);
+
+    auto accum = TAccumulator::Create(tl.Get(), 0, 1);
+    auto info = accum->GetBucket(0);
+
+    UNIT_ASSERT(info.NTuples == 0);
+    CTEST << "";
+} // Y_UNIT_TEST(CreateAccumulator)
+
+Y_UNIT_TEST(MultipleAddToAccumulator) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns{kc};
+    auto tl = TTupleLayout::Create(columns);
+    const ui64 NTuples = 1000;
+    const ui64 TuplesDataBytes = (tl->TotalRowSize) * NTuples;
+
+    std::vector<ui64> col(NTuples, 0);
+    std::vector<ui8> res(TuplesDataBytes, 0);
+    for (ui32 i = 0; i < NTuples; ++i) {
+        col[i] = i;
+    }
+    const ui8* cols[1];
+    cols[0] = (ui8*) col.data();
+
+    std::vector<ui8> colValid((NTuples + 7)/8, ~0);
+    const ui8 *colsValid[] = {
+        colValid.data(),
+    };
+
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples);
+
+    auto accum = TAccumulator::Create(tl.Get(), 0, 3);
+
+    for (int i = 0; i < 2; ++i) {
+        accum->AddData(res.data(), overflow.data(), NTuples); // + 1000 elements
+    }
+
+    ui32 totalCount = 0;
+    for (ui32 i = 0; i < 8; ++i) {
+        auto info = accum->GetBucket(i);
+        totalCount += info.NTuples;
+        UNIT_ASSERT(info.NTuples > 0);
+    }
+
+    UNIT_ASSERT(totalCount == 2 * NTuples);
+} // Y_UNIT_TEST(MultipleAddToAccumulator)
+
+Y_UNIT_TEST(AddVarSizedDataToAccumulator) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.SizeType = EColumnSizeType::Variable;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns{kc};
+    auto tl = TTupleLayout::Create(columns);
+    const ui64 NTuples = 2;
+    const ui64 TuplesDataBytes = (tl->TotalRowSize) * NTuples;
+    std::vector<ui8> res(TuplesDataBytes, 0);
+
+    std::vector<ui32> col(1, 0);
+    std::vector<ui8> colData;
+    std::vector<TString> strs{
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    };
+
+    for (const auto& str: strs) {
+        for (auto c: str) {
+            colData.push_back(c);
+        }
+        col.push_back(colData.size());
+    }
+    UNIT_ASSERT_VALUES_EQUAL(col.size(), NTuples + 1);
+
+    const ui8* cols[2];
+    cols[0] = (ui8*) col.data();
+    cols[1] = (ui8*) colData.data();
+
+    std::vector<ui8> colValid((NTuples + 7)/8, ~0);
+    const ui8 *colsValid[] = {
+        colValid.data(),
+        nullptr,
+    };
+
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples);
+
+    auto accum = TAccumulator::Create(tl.Get(), 0, 5);
+    accum->AddData(res.data(), overflow.data(), NTuples);
+
+    ui32 total = 0;
+    for (ui32 i = 0; i < 32; ++i) {
+        auto info = accum->GetBucket(i);
+        UNIT_ASSERT(info.NTuples <= 1);
+        total += info.NTuples;
+    }
+    UNIT_ASSERT(total == 2);
+} // Y_UNIT_TEST(AddVarSizedDataToAccumulator)
+
+Y_UNIT_TEST(AccumulatorFuzz) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    std::mt19937 rng; // fixed-seed (0) prng
+    std::vector<TColumnDesc> columns;
+    std::vector<std::vector<ui8>> colsdata;
+    std::vector<const ui8*> colsptr;
+    std::vector<std::vector<ui8>> isValidData;
+    std::vector<const ui8*> isValidPtr;
+
+    for (ui32 test = 0; test < 10; ++test) {
+        ui32 rows = 1 + (rng() % 1000);
+        ui32 cols = 1 + (rng() % 20);
+        columns.resize(cols);
+        colsdata.resize(cols);
+        colsptr.resize(cols);
+        isValidData.resize(cols);
+        isValidPtr.resize(cols);
+        ui32 isValidSize = (rows + 7)/8;
+        for (ui32 j = 0; j < cols; ++j) {
+            auto &col = columns[j];
+            col.Role = (rng() % 10 < 1) ? EColumnRole::Key : EColumnRole::Payload;
+            col.DataSize = 1u << (rng() % 10);
+            col.SizeType = EColumnSizeType::Fixed;
+            colsdata[j].resize(rows*col.DataSize);
+            colsptr[j] = colsdata[j].data();
+            isValidData[j].resize(isValidSize);
+            isValidPtr[j] = isValidData[j].data();
+            std::generate(isValidData[j].begin(), isValidData[j].end(), rng);
+        }
+        auto tl = TTupleLayout::Create(columns);
+        std::vector<ui8> res;
+        for (ui32 subtest = 0; subtest < 10; ++subtest) {
+            ui32 log2Buckets = rng() % 11;
+            ui32 nBuckets = (1 << log2Buckets);
+            ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
+            ui32 shift = 32 - bitsCount;
+            ui32 mask = (1 << bitsCount) - 1;
+            ui32 subRows = 1 + (rows ? rng() % (rows - 1) : 0);
+            ui32 off = subRows != rows ? rng() % (rows - subRows) : 0;
+            std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+            res.resize(subRows*tl->TotalRowSize);
+            tl->Pack(colsptr.data(), isValidPtr.data(), res.data(), overflow, off, subRows);
+
+            auto accum = TAccumulator::Create(tl.Get(), 0, log2Buckets);
+            accum->AddData(res.data(), overflow.data(), subRows);
+
+            ui32 totalCount = 0;
+            for (ui32 i = 0; i < nBuckets; ++i) {
+                auto info = accum->GetBucket(i);
+                const ui8* Bucket = info.PackedTuples->data();
+
+                ui32 offset = 0;
+                if (info.NTuples > 0) {
+                    UNIT_ASSERT(info.PackedTuples->size() > 0);
+                    UNIT_ASSERT(info.PackedTuples->size() / tl->TotalRowSize == info.NTuples);
+                    for (ui32 count = 0; count < info.NTuples; ++count) {
+                        auto maskedHash = TAccumulator::GetBucketId(ReadUnaligned<ui32>(Bucket + offset), shift, mask);
+                        UNIT_ASSERT(maskedHash == i);
+                        offset += info.Layout->TotalRowSize;
+                        totalCount++;
+                    }
+                }
+            }
+            UNIT_ASSERT_VALUES_EQUAL(totalCount, subRows);
+        }
+    }
+} // Y_UNIT_TEST(AccumulatorFuzz)
+
+Y_UNIT_TEST(BenchAccumulator_VariateNTuples) {
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>> BenchAccumulator_VariateNTuples <<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl;
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e5, 2, 3));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e6, 2, 3));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 2, 3));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e8, 2, 3));
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl << " " << Endl;
+} // Y_UNIT_TEST(BenchAccumulator_VariateNTuples)
+
+Y_UNIT_TEST(BenchAccumulator_VariateNColumns) {
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>> BenchAccumulator_VariateNColumns <<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl;
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7,  1, 4));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7,  2, 4));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7,  4, 4));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e6,  8, 4));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e6, 16, 4));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e6, 24, 4));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e6, 32, 4));
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl << " " << Endl;
+} // Y_UNIT_TEST(BenchAccumulator_VariateNColumns)
+
+Y_UNIT_TEST(BenchAccumulator_VariateNBuckets) {
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>> BenchAccumulator_VariateNBuckets <<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl;
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4,  2));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4,  3));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4,  4));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4,  5));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4,  6));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4,  7));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4,  8));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4,  9));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4, 10));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4, 11));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4, 12));
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e7, 4, 13));
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl << " " << Endl;
+} // Y_UNIT_TEST(BenchAccumulator_VariateNBuckets)
+
+Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNTuples) {
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>> VarSized_BenchAccumulator_VariateNTuples <<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl;
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e5, 2, 3));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e6, 2, 3));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2, 3));
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl << " " << Endl;
+} // Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNTuples)
+
+Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNColumns) {
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>> VarSized_BenchAccumulator_VariateNColumns <<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl;
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7,  1, 4));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7,  2, 4));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7,  4, 4));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7,  8, 4));
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl << " " << Endl;
+} // Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNColumns)
+
+Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNBuckets) {
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>> VarSized_BenchAccumulator_VariateNBuckets <<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl;
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2,  2));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2,  3));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2,  4));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2,  5));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2,  6));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2,  7));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2,  8));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2,  9));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2, 10));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2, 11));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2, 12));
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2, 13));
+    Cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl << " " << Endl;
+} // Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNBuckets)
+
+} // Y_UNIT_TEST_SUITE(Accumulator)
+
+
+}
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/accumulator_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/accumulator_ut.cpp
@@ -24,6 +24,8 @@ using namespace std::chrono_literals;
 static volatile bool IsVerbose = false;
 #define CTEST (IsVerbose ? Cerr : Cnull)
 
+#define TO_BENCH 0
+
 namespace {
 
 TVector<TString> GenerateValues(size_t level) {
@@ -45,334 +47,6 @@ TVector<TString> GenerateValues(size_t level) {
 }
 
 static const TVector<TString> threeLetterValues = GenerateValues(3);
-
-bool RunFixSizedAccumulatorBench(ui64 nTuples, ui64 nCols, ui64 log2Buckets) {
-    auto nBuckets = 1 << log2Buckets;
-    CTEST << "============ BENCH BEGIN ============" << Endl;
-    CTEST << "Test config:" << Endl;
-    CTEST << ">  nTuples: " << nTuples << Endl;
-    CTEST << ">  nCols: " << nCols << Endl;
-    CTEST << ">  nBuckets: " << nBuckets << Endl;
-
-    ui64 totalTime = 0;
-
-    TScopedAlloc alloc(__LOCATION__);
-    using TBuffer = TAccumulator::TBuffer;
-
-    TColumnDesc kc;
-    kc.Role = EColumnRole::Key;
-    kc.DataSize = 8;
-
-    std::vector<TColumnDesc> columns(nCols, kc);
-    auto tl = TTupleLayout::Create(columns);
-    const ui64 TuplesDataBytes = (tl->TotalRowSize) * nTuples;
-    CTEST << ">  Dataset size: " << TuplesDataBytes / (1024 * 1024) << "[MB]" << Endl;
-    CTEST << " " << Endl;
-
-    std::vector<ui64> col(nTuples, 0);
-    std::iota(col.begin(), col.end(), 0);
-    auto colsData = std::vector(nCols, col);
-    std::vector<const ui8*> cols(nCols);
-    for (size_t ind = 0; ind != nCols; ind++) {
-        cols[ind] = (ui8*)colsData[ind].data();
-    }
-    std::vector<ui8> colValid((nTuples + 7)/8, ~0);
-    auto colsValidData = std::vector(nCols, colValid);
-    std::vector<const ui8*> colsValid(nCols);
-    for (size_t ind = 0; ind != nCols; ind++) {
-        colsValid[ind] = (ui8*)colsValidData[ind].data();
-    }
-
-    auto resesData = std::vector<std::vector<ui8, TMKQLAllocator<ui8>>>(1u << log2Buckets);
-    std::vector<std::vector<ui8, TMKQLAllocator<ui8>>> overflowsData(1u << log2Buckets);
-
-    auto reses = TPaddedPtr(resesData.data(), sizeof(resesData[0]));
-    auto overflows = TPaddedPtr(overflowsData.data(), sizeof(overflowsData[0]));
-
-    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
-    for (auto& bres : resesData) {
-        bres.resize(0);
-    }
-
-    auto begintp = std::chrono::steady_clock::now();
-    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
-    auto endtp = std::chrono::steady_clock::now();
-    auto bucketPackTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
-    if (bucketPackTime == 0) bucketPackTime = 1;
-
-    CTEST << "Bucket pack time: " << bucketPackTime  << "[microseconds]" << Endl;
-    CTEST << "Bucket pack speed: " << TuplesDataBytes / bucketPackTime << "[MB/sec]" << Endl;
-    CTEST << " " << Endl;
-
-    std::vector<ui8> res(TuplesDataBytes, 0);
-    for (ui32 i = 0; i < nTuples; ++i) {
-        col[i] = i;
-    }
-    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
-    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
-
-    begintp = std::chrono::steady_clock::now();
-    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
-    endtp = std::chrono::steady_clock::now();
-    auto packTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
-    if (packTime == 0) packTime = 1;
-    totalTime += packTime;
-
-    CTEST << "Pack time: " << packTime  << "[microseconds]" << Endl;
-    CTEST << "Pack speed: " << TuplesDataBytes / packTime << "[MB/sec]" << Endl;
-    CTEST << " " << Endl;
-
-    ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
-    ui32 shift = 32 - bitsCount;
-    ui32 mask = (1 << bitsCount) - 1;
-
-    std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(nBuckets, {0, 0});
-
-    {
-        // std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-
-        Histogram hist;
-        hist.AddData(tl.Get(), res.data(), nTuples, TAccumulator::GetBucketId, shift, mask);
-        hist.EstimateSizes(sizes);
-
-        // std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-        // ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
-        // if (microseconds == 0) microseconds = 1;
-        // // totalTime += microseconds;
-
-        // CTEST << "Histogram build time: " << microseconds  << "[microseconds]" << Endl;
-        // CTEST << "Histogram build speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
-        // CTEST << " " << Endl;
-    }
-
-    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets(nBuckets);
-    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets(nBuckets);
-
-    {
-        // std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-
-        for (ui32 i = 0; i < sizes.size(); ++i) {
-            auto [TLsize, Osize] = sizes[i];
-            PackedTupleBuckets[i].resize(TLsize);
-            std::memset(PackedTupleBuckets[i].data(), 0, TLsize);
-            OverflowBuckets[i].resize(Osize);
-            std::memset(OverflowBuckets[i].data(), 0, Osize);
-        }
-
-        // std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-        // ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
-        // if (microseconds == 0) microseconds = 1;
-        // // totalTime += microseconds;
-
-        // CTEST << "Memory allocation time: " << microseconds  << "[microseconds]" << Endl;
-        // CTEST << "Memory allocation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
-        // CTEST << " " << Endl;
-    }
-
-    std::array<THolder<TAccumulator>, 2> accums;
-    accums[0] = MakeHolder<TAccumulatorImpl>(
-        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
-    accums[1] = MakeHolder<TSMBAccumulatorImpl>(
-        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
-
-    for (auto &accum : accums)
-    {
-        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-
-        accum->AddData(res.data(), overflow.data(), nTuples);
-
-        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
-        if (microseconds == 0) microseconds = 1;
-        // totalTime += microseconds;
-    
-        CTEST << "------------------" << Endl << " " << Endl;
-
-        CTEST << "Accumulation time: " << microseconds  << "[microseconds]" << Endl;
-        CTEST << "Accumulation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
-        CTEST << " " << Endl;
-
-        CTEST << "Total time: " << totalTime + microseconds  << "[microseconds]" << Endl;
-        CTEST << "Resulting speed: " << TuplesDataBytes / (totalTime + microseconds) << "[MB/sec]" << Endl;
-        CTEST << " " << Endl;
-    }
-
-    CTEST << "============= BENCH END =============" << Endl << " " << Endl;
-
-    return accums[0]->GetBucket(0).NTuples > 0;
-}
-
-bool RunVarSizedAccumulatorBench(ui64 nTuples, ui64 nCols, ui64 log2Buckets) {
-    auto nBuckets = 1 << log2Buckets;
-    TScopedAlloc alloc(__LOCATION__);
-    using TBuffer = TAccumulator::TBuffer;
-
-    ui64 totalTime = 0;
-
-    TColumnDesc kc;
-    kc.Role = EColumnRole::Key;
-    kc.SizeType = EColumnSizeType::Variable;
-    kc.DataSize = 8;
-
-    std::vector<TColumnDesc> columns(nCols, kc);
-    auto tl = TTupleLayout::Create(columns);
-    ui64 TuplesDataBytes = tl->TotalRowSize * nTuples;
-
-    std::vector<ui32> col(1, 0);
-    std::vector<ui8> colData;
-
-    for (ui64 i = 0; i < nTuples; ++i) {
-        const auto& str = threeLetterValues[i % threeLetterValues.size()];
-        for (ui8 k = 0; k < 6; ++k) {
-            for (auto c: str) {
-                colData.push_back(c);
-            }
-        }
-        col.push_back(colData.size());
-    }
-
-    std::vector<const ui8*> cols(2 * nCols);
-    for (ui64 i = 0; i < nCols; i++) {
-        cols[2 * i] = (ui8*) col.data();
-        cols[2 * i + 1] = (ui8*) colData.data();
-    }
-
-    std::vector<ui8> colValid((nTuples + 7)/8, ~0);
-    std::vector<const ui8*> colsValid(2 * nCols);
-    for (ui64 i = 0; i < nCols; i++) {
-        colsValid[2 * i] = colValid.data();
-        colsValid[2 * i + 1] = nullptr;
-    }
-
-    std::vector<ui8> res(TuplesDataBytes, 0);
-    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
-
-    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
-    TuplesDataBytes += overflow.size();
-    overflow.resize(0);
-
-    CTEST << "============ BENCH BEGIN ============" << Endl;
-    CTEST << "Test config:" << Endl;
-    CTEST << ">  nTuples: " << nTuples << Endl;
-    CTEST << ">  nCols: " << nCols << Endl;
-    CTEST << ">  nBuckets: " << nBuckets << Endl;
-    CTEST << ">  Dataset size: " << TuplesDataBytes / (1024 * 1024) << "[MB]" << Endl;
-    CTEST << " " << Endl;
-
-    auto resesData = std::vector<std::vector<ui8, TMKQLAllocator<ui8>>>(1u << log2Buckets);
-    std::vector<std::vector<ui8, TMKQLAllocator<ui8>>> overflowsData(1u << log2Buckets);
-
-    auto reses = TPaddedPtr(resesData.data(), sizeof(resesData[0]));
-    auto overflows = TPaddedPtr(overflowsData.data(), sizeof(overflowsData[0]));
-    
-    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
-    for (auto& bres : resesData) {
-        bres.resize(0);
-    }
-    for (auto& boverflow : overflowsData) {
-        boverflow.resize(0);
-    }
-
-    auto begintp = std::chrono::steady_clock::now();
-    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
-    auto endtp = std::chrono::steady_clock::now();
-    auto bucketPackTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
-    if (bucketPackTime == 0) bucketPackTime = 1;
-
-    CTEST << "Bucket pack time: " << bucketPackTime  << "[microseconds]" << Endl;
-    CTEST << "Bucket pack speed: " << TuplesDataBytes / bucketPackTime << "[MB/sec]" << Endl;
-    CTEST << " " << Endl;
-
-    begintp = std::chrono::steady_clock::now();
-    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
-    endtp = std::chrono::steady_clock::now();
-    auto packTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
-    if (packTime == 0) packTime = 1;
-    totalTime += packTime;
-
-    CTEST << "Pack time: " << packTime  << "[microseconds]" << Endl;
-    CTEST << "Pack speed: " << TuplesDataBytes / packTime << "[MB/sec]" << Endl;
-    CTEST << " " << Endl;
-
-    ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
-    ui32 shift = 32 - bitsCount;
-    ui32 mask = (1 << bitsCount) - 1;
-
-    std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(nBuckets, {0, 0});
-
-    {
-        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-
-        Histogram hist;
-        hist.AddData(tl.Get(), res.data(), nTuples, TAccumulator::GetBucketId, shift, mask);
-        hist.EstimateSizes(sizes);
-
-        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
-        if (microseconds == 0) microseconds = 1;
-        // totalTime += microseconds;
-
-        CTEST << "Histogram build time: " << microseconds  << "[microseconds]" << Endl;
-        CTEST << "Histogram build speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
-        CTEST << " " << Endl;
-    }
-
-    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets(nBuckets);
-    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets(nBuckets);
-
-    {
-        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-
-        for (ui32 i = 0; i < sizes.size(); ++i) {
-            auto [TLsize, Osize] = sizes[i];
-            PackedTupleBuckets[i].resize(TLsize);
-            std::memset(PackedTupleBuckets[i].data(), 0, TLsize);
-            OverflowBuckets[i].resize(Osize);
-            std::memset(OverflowBuckets[i].data(), 0, Osize);
-        }
-
-        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
-        if (microseconds == 0) microseconds = 1;
-        // totalTime += microseconds;
-
-        CTEST << "Memory allocation time: " << microseconds  << "[microseconds]" << Endl;
-        CTEST << "Memory allocation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
-        CTEST << " " << Endl;
-    }
-
-    std::array<THolder<TAccumulator>, 2> accums;
-    accums[0] = MakeHolder<TAccumulatorImpl>(
-        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
-    accums[1] = MakeHolder<TSMBAccumulatorImpl>(
-        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
-
-    for (auto &accum : accums)
-    {
-        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-
-        accum->AddData(res.data(), overflow.data(), nTuples);
-
-        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
-        if (microseconds == 0) microseconds = 1;
-        // totalTime += microseconds;
-    
-        CTEST << "------------------" << Endl << " " << Endl;
-
-        CTEST << "Accumulation time: " << microseconds  << "[microseconds]" << Endl;
-        CTEST << "Accumulation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
-        CTEST << " " << Endl;
-
-        CTEST << "Total time: " << totalTime + microseconds  << "[microseconds]" << Endl;
-        CTEST << "Resulting speed: " << TuplesDataBytes / (totalTime + microseconds) << "[MB/sec]" << Endl;
-        CTEST << " " << Endl;
-    }
-
-    CTEST << "============= BENCH END =============" << Endl << " " << Endl;
-
-    return accums[0]->GetBucket(0).NTuples > 0;
-}
 
 } // namespace
 
@@ -575,6 +249,336 @@ Y_UNIT_TEST(AccumulatorFuzz) {
     }
 } // Y_UNIT_TEST(AccumulatorFuzz)
 
+#if TO_BENCH > 0
+
+bool RunFixSizedAccumulatorBench(ui64 nTuples, ui64 nCols, ui64 log2Buckets) {
+    auto nBuckets = 1 << log2Buckets;
+    CTEST << "============ BENCH BEGIN ============" << Endl;
+    CTEST << "Test config:" << Endl;
+    CTEST << ">  nTuples: " << nTuples << Endl;
+    CTEST << ">  nCols: " << nCols << Endl;
+    CTEST << ">  nBuckets: " << nBuckets << Endl;
+
+    ui64 totalTime = 0;
+
+    TScopedAlloc alloc(__LOCATION__);
+    using TBuffer = TAccumulator::TBuffer;
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns(nCols, kc);
+    auto tl = TTupleLayout::Create(columns);
+    const ui64 TuplesDataBytes = (tl->TotalRowSize) * nTuples;
+    CTEST << ">  Dataset size: " << TuplesDataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST << " " << Endl;
+
+    std::vector<ui64> col(nTuples, 0);
+    std::iota(col.begin(), col.end(), 0);
+    auto colsData = std::vector(nCols, col);
+    std::vector<const ui8*> cols(nCols);
+    for (size_t ind = 0; ind != nCols; ind++) {
+        cols[ind] = (ui8*)colsData[ind].data();
+    }
+    std::vector<ui8> colValid((nTuples + 7)/8, ~0);
+    auto colsValidData = std::vector(nCols, colValid);
+    std::vector<const ui8*> colsValid(nCols);
+    for (size_t ind = 0; ind != nCols; ind++) {
+        colsValid[ind] = (ui8*)colsValidData[ind].data();
+    }
+
+    auto resesData = std::vector<std::vector<ui8, TMKQLAllocator<ui8>>>(1u << log2Buckets);
+    std::vector<std::vector<ui8, TMKQLAllocator<ui8>>> overflowsData(1u << log2Buckets);
+
+    auto reses = TPaddedPtr(resesData.data(), sizeof(resesData[0]));
+    auto overflows = TPaddedPtr(overflowsData.data(), sizeof(overflowsData[0]));
+
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    for (auto& bres : resesData) {
+        bres.resize(0);
+    }
+
+    auto begintp = std::chrono::steady_clock::now();
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    auto endtp = std::chrono::steady_clock::now();
+    auto bucketPackTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (bucketPackTime == 0) bucketPackTime = 1;
+
+    CTEST << "Bucket pack time: " << bucketPackTime  << "[microseconds]" << Endl;
+    CTEST << "Bucket pack speed: " << TuplesDataBytes / bucketPackTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    std::vector<ui8> res(TuplesDataBytes, 0);
+    for (ui32 i = 0; i < nTuples; ++i) {
+        col[i] = i;
+    }
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+
+    begintp = std::chrono::steady_clock::now();
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    endtp = std::chrono::steady_clock::now();
+    auto packTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (packTime == 0) packTime = 1;
+    totalTime += packTime;
+
+    CTEST << "Pack time: " << packTime  << "[microseconds]" << Endl;
+    CTEST << "Pack speed: " << TuplesDataBytes / packTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
+    ui32 shift = 32 - bitsCount;
+    ui32 mask = (1 << bitsCount) - 1;
+
+    std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(nBuckets, {0, 0});
+
+    {
+        // std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        Histogram hist;
+        hist.AddData(tl.Get(), res.data(), nTuples, TAccumulator::GetBucketId, shift, mask);
+        hist.EstimateSizes(sizes);
+
+        // std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        // ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        // if (microseconds == 0) microseconds = 1;
+        // // totalTime += microseconds;
+
+        // CTEST << "Histogram build time: " << microseconds  << "[microseconds]" << Endl;
+        // CTEST << "Histogram build speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        // CTEST << " " << Endl;
+    }
+
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets(nBuckets);
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets(nBuckets);
+
+    {
+        // std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets[i].resize(TLsize);
+            std::memset(PackedTupleBuckets[i].data(), 0, TLsize);
+            OverflowBuckets[i].resize(Osize);
+            std::memset(OverflowBuckets[i].data(), 0, Osize);
+        }
+
+        // std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        // ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        // if (microseconds == 0) microseconds = 1;
+        // // totalTime += microseconds;
+
+        // CTEST << "Memory allocation time: " << microseconds  << "[microseconds]" << Endl;
+        // CTEST << "Memory allocation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        // CTEST << " " << Endl;
+    }
+
+    std::array<THolder<TAccumulator>, 2> accums;
+    accums[0] = MakeHolder<TAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+    accums[1] = MakeHolder<TSMBAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+
+    for (auto &accum : accums)
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        accum->AddData(res.data(), overflow.data(), nTuples);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+    
+        CTEST << "------------------" << Endl << " " << Endl;
+
+        CTEST << "Accumulation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Accumulation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+
+        CTEST << "Total time: " << totalTime + microseconds  << "[microseconds]" << Endl;
+        CTEST << "Resulting speed: " << TuplesDataBytes / (totalTime + microseconds) << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    CTEST << "============= BENCH END =============" << Endl << " " << Endl;
+
+    return accums[0]->GetBucket(0).NTuples > 0;
+}
+
+static bool RunVarSizedAccumulatorBench(ui64 nTuples, ui64 nCols, ui64 log2Buckets) {
+    auto nBuckets = 1 << log2Buckets;
+    TScopedAlloc alloc(__LOCATION__);
+    using TBuffer = TAccumulator::TBuffer;
+
+    ui64 totalTime = 0;
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.SizeType = EColumnSizeType::Variable;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns(nCols, kc);
+    auto tl = TTupleLayout::Create(columns);
+    ui64 TuplesDataBytes = tl->TotalRowSize * nTuples;
+
+    std::vector<ui32> col(1, 0);
+    std::vector<ui8> colData;
+
+    for (ui64 i = 0; i < nTuples; ++i) {
+        const auto& str = threeLetterValues[i % threeLetterValues.size()];
+        for (ui8 k = 0; k < 6; ++k) {
+            for (auto c: str) {
+                colData.push_back(c);
+            }
+        }
+        col.push_back(colData.size());
+    }
+
+    std::vector<const ui8*> cols(2 * nCols);
+    for (ui64 i = 0; i < nCols; i++) {
+        cols[2 * i] = (ui8*) col.data();
+        cols[2 * i + 1] = (ui8*) colData.data();
+    }
+
+    std::vector<ui8> colValid((nTuples + 7)/8, ~0);
+    std::vector<const ui8*> colsValid(2 * nCols);
+    for (ui64 i = 0; i < nCols; i++) {
+        colsValid[2 * i] = colValid.data();
+        colsValid[2 * i + 1] = nullptr;
+    }
+
+    std::vector<ui8> res(TuplesDataBytes, 0);
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    TuplesDataBytes += overflow.size();
+    overflow.resize(0);
+
+    CTEST << "============ BENCH BEGIN ============" << Endl;
+    CTEST << "Test config:" << Endl;
+    CTEST << ">  nTuples: " << nTuples << Endl;
+    CTEST << ">  nCols: " << nCols << Endl;
+    CTEST << ">  nBuckets: " << nBuckets << Endl;
+    CTEST << ">  Dataset size: " << TuplesDataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST << " " << Endl;
+
+    auto resesData = std::vector<std::vector<ui8, TMKQLAllocator<ui8>>>(1u << log2Buckets);
+    std::vector<std::vector<ui8, TMKQLAllocator<ui8>>> overflowsData(1u << log2Buckets);
+
+    auto reses = TPaddedPtr(resesData.data(), sizeof(resesData[0]));
+    auto overflows = TPaddedPtr(overflowsData.data(), sizeof(overflowsData[0]));
+    
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    for (auto& bres : resesData) {
+        bres.resize(0);
+    }
+    for (auto& boverflow : overflowsData) {
+        boverflow.resize(0);
+    }
+
+    auto begintp = std::chrono::steady_clock::now();
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    auto endtp = std::chrono::steady_clock::now();
+    auto bucketPackTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (bucketPackTime == 0) bucketPackTime = 1;
+
+    CTEST << "Bucket pack time: " << bucketPackTime  << "[microseconds]" << Endl;
+    CTEST << "Bucket pack speed: " << TuplesDataBytes / bucketPackTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    begintp = std::chrono::steady_clock::now();
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    endtp = std::chrono::steady_clock::now();
+    auto packTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (packTime == 0) packTime = 1;
+    totalTime += packTime;
+
+    CTEST << "Pack time: " << packTime  << "[microseconds]" << Endl;
+    CTEST << "Pack speed: " << TuplesDataBytes / packTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
+    ui32 shift = 32 - bitsCount;
+    ui32 mask = (1 << bitsCount) - 1;
+
+    std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(nBuckets, {0, 0});
+
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        Histogram hist;
+        hist.AddData(tl.Get(), res.data(), nTuples, TAccumulator::GetBucketId, shift, mask);
+        hist.EstimateSizes(sizes);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+
+        CTEST << "Histogram build time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Histogram build speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets(nBuckets);
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets(nBuckets);
+
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets[i].resize(TLsize);
+            std::memset(PackedTupleBuckets[i].data(), 0, TLsize);
+            OverflowBuckets[i].resize(Osize);
+            std::memset(OverflowBuckets[i].data(), 0, Osize);
+        }
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+
+        CTEST << "Memory allocation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Memory allocation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    std::array<THolder<TAccumulator>, 2> accums;
+    accums[0] = MakeHolder<TAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+    accums[1] = MakeHolder<TSMBAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+
+    for (auto &accum : accums)
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        accum->AddData(res.data(), overflow.data(), nTuples);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+    
+        CTEST << "------------------" << Endl << " " << Endl;
+
+        CTEST << "Accumulation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Accumulation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+
+        CTEST << "Total time: " << totalTime + microseconds  << "[microseconds]" << Endl;
+        CTEST << "Resulting speed: " << TuplesDataBytes / (totalTime + microseconds) << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    CTEST << "============= BENCH END =============" << Endl << " " << Endl;
+
+    return accums[0]->GetBucket(0).NTuples > 0;
+}
+
 Y_UNIT_TEST(BenchAccumulator_VariateNTuples) {
     Cerr << ">>>>>>>>>>>>>>>>>>>>>>> BenchAccumulator_VariateNTuples <<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl;
     UNIT_ASSERT(RunFixSizedAccumulatorBench(1e5, 2, 3));
@@ -646,6 +650,8 @@ Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNBuckets) {
     UNIT_ASSERT(RunVarSizedAccumulatorBench(1e7, 2, 13));
     Cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << Endl << " " << Endl;
 } // Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNBuckets)
+
+#endif
 
 } // Y_UNIT_TEST_SUITE(Accumulator)
 

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/block_layout_converter_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/block_layout_converter_ut.cpp
@@ -1,0 +1,599 @@
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/block_layout_converter.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <yql/essentials/public/udf/arrow/block_builder.h>
+#include <yql/essentials/public/udf/arrow/block_reader.h>
+#include <yql/essentials/public/udf/arrow/memory_pool.h>
+#include <yql/essentials/minikql/mkql_type_builder.h>
+#include <yql/essentials/minikql/mkql_function_registry.h>
+#include <yql/essentials/minikql/mkql_program_builder.h>
+#include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
+
+using namespace NYql::NUdf;
+using namespace NKikimr;
+using namespace NKikimr::NMiniKQL;
+
+struct TBlockLayoutConverterTestData {
+    TBlockLayoutConverterTestData()
+        : FunctionRegistry(NMiniKQL::CreateFunctionRegistry(NMiniKQL::CreateBuiltinRegistry()))
+        , Alloc(__LOCATION__)
+        , Env(Alloc)
+        , PgmBuilder(Env, *FunctionRegistry)
+        , MemInfo("Memory")
+        , ArrowPool(GetYqlMemoryPool())
+    {
+    }
+
+    TIntrusivePtr<NMiniKQL::IFunctionRegistry> FunctionRegistry;
+    NMiniKQL::TScopedAlloc Alloc;
+    NMiniKQL::TTypeEnvironment Env;
+    NMiniKQL::TProgramBuilder PgmBuilder;
+    NMiniKQL::TMemoryUsageInfo MemInfo;
+    arrow::MemoryPool* const ArrowPool;
+};
+
+Y_UNIT_TEST_SUITE(TBlockLayoutConverterTest) {
+    Y_UNIT_TEST(TestFixedSize) {
+        TBlockLayoutConverterTestData data;
+
+        const auto int64Type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, false);
+        TVector< NKikimr::NMiniKQL::TType*> types{int64Type};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        size_t itemSize = NMiniKQL::CalcMaxBlockItemSize(int64Type);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        constexpr auto testSize = NMiniKQL::MaxBlockSizeInBytes / sizeof(i64);
+
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), int64Type, *data.ArrowPool, blockLen, nullptr);
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+
+        for (size_t i = 0; i < testSize; i++) {
+            builder->Add(TBlockItem(i));
+        }
+        auto datum = builder->Build(true);
+        Y_ENSURE(datum.is_array());
+        TVector<arrow::Datum> columns{datum};
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), 1, "Expected the one column after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        const auto& columnBefore = columns.front().array();
+        const auto& columnAfter = columnsAfterConversion.front().array();
+        auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), int64Type);
+
+        for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+            TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+            TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+            UNIT_ASSERT_VALUES_EQUAL_C(lhs.Get<i64>(), rhs.Get<i64>(), "Expected the same data after conversion");
+        }
+    }
+
+    Y_UNIT_TEST(TestMultipleFixedSize) {
+        TBlockLayoutConverterTestData data;
+
+        const auto int64Type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, false);
+        TVector< NKikimr::NMiniKQL::TType*> types{int64Type, int64Type, int64Type, int64Type};
+        TVector<NPackedTuple::EColumnRole> roles{
+            NPackedTuple::EColumnRole::Key, NPackedTuple::EColumnRole::Key,
+            NPackedTuple::EColumnRole::Payload, NPackedTuple::EColumnRole::Payload};
+
+        size_t itemSize = 4 * NMiniKQL::CalcMaxBlockItemSize(int64Type);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        constexpr auto testSize = NMiniKQL::MaxBlockSizeInBytes / (4 * sizeof(i64));
+
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+        TVector<arrow::Datum> columns;
+
+        for (size_t i = 0; i < types.size(); ++i) {
+            auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), int64Type, *data.ArrowPool, blockLen, nullptr);
+            for (size_t j = 0; j < testSize; j++) {
+                builder->Add(TBlockItem(i + j));
+            }
+            auto datum = builder->Build(true);
+            columns.emplace_back(std::move(datum));
+            Y_ENSURE(datum.is_array());
+        }
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), columns.size(), "Expected same columns count after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        for (size_t colIdx = 0; colIdx < columns.size(); ++colIdx) {
+            const auto& columnBefore = columns[colIdx].array();
+            const auto& columnAfter = columnsAfterConversion[colIdx].array();
+            auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), int64Type);
+
+            for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+                TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+                TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+                UNIT_ASSERT_VALUES_EQUAL_C(lhs.Get<i64>(), rhs.Get<i64>(), "Expected the same data after conversion");
+            }
+        }
+    }
+
+    Y_UNIT_TEST(TestString) {
+        TBlockLayoutConverterTestData data;
+
+        const auto stringType = data.PgmBuilder.NewDataType(NUdf::EDataSlot::String, false);
+        TVector< NKikimr::NMiniKQL::TType*> types{stringType};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        size_t itemSize = NMiniKQL::CalcMaxBlockItemSize(stringType);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        // To fit all strings into single block
+        constexpr auto testSize = 512;
+
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), stringType, *data.ArrowPool, blockLen, nullptr);
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+
+        std::string testString;
+        testString.resize(testSize);
+        for (size_t i = 0; i < testSize; i++) {
+            testString[i] = static_cast<char>(i);
+            if (i % 2) {
+                builder->Add(TBlockItem(TStringRef(testString.data(), i + 1)));
+            } else {
+                // Empty string
+                builder->Add(TBlockItem(TStringRef()));
+            }
+        }
+        auto datum = builder->Build(true);
+        Y_ENSURE(datum.is_array());
+        TVector<arrow::Datum> columns{datum};
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), 1, "Expected the one column after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        const auto& columnBefore = columns.front().array();
+        const auto& columnAfter = columnsAfterConversion.front().array();
+        auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), stringType);
+
+        for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+            TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+            TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+            UNIT_ASSERT_VALUES_EQUAL_C(lhs.AsStringRef(), rhs.AsStringRef(), "Expected the same data after conversion");
+        }
+    }
+
+    Y_UNIT_TEST(TestMultipleStrings) {
+        TBlockLayoutConverterTestData data;
+
+        const auto stringType = data.PgmBuilder.NewDataType(NUdf::EDataSlot::String, false);
+        TVector< NKikimr::NMiniKQL::TType*> types{stringType, stringType, stringType, stringType};
+        TVector<NPackedTuple::EColumnRole> roles{
+            NPackedTuple::EColumnRole::Key, NPackedTuple::EColumnRole::Key,
+            NPackedTuple::EColumnRole::Payload, NPackedTuple::EColumnRole::Payload};
+
+        size_t itemSize = 4 * NMiniKQL::CalcMaxBlockItemSize(stringType);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        // To fit all strings into single block
+        constexpr auto testSize = 128;
+
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+        TVector<arrow::Datum> columns;
+
+        for (size_t i = 0; i < types.size(); ++i) {
+            auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), stringType, *data.ArrowPool, blockLen, nullptr);
+            std::string testString;
+            testString.resize(testSize);
+            for (size_t j = 0; j < testSize; j++) {
+                testString[j] = static_cast<char>(j % 256);
+                if (j % 2) {
+                    builder->Add(TBlockItem(TStringRef(testString.data(), i * 2 + j / 2 + 1)));
+                } else {
+                    // Empty string
+                    builder->Add(TBlockItem(TStringRef()));
+                }
+            }
+            auto datum = builder->Build(true);
+            columns.emplace_back(std::move(datum));
+            Y_ENSURE(datum.is_array());
+        }
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), columns.size(), "Expected same columns count after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        for (size_t colIdx = 0; colIdx < columns.size(); ++colIdx) {
+            const auto& columnBefore = columns[colIdx].array();
+            const auto& columnAfter = columnsAfterConversion[colIdx].array();
+            auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), stringType);
+
+            for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+                TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+                TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+                UNIT_ASSERT_VALUES_EQUAL_C(lhs.AsStringRef(), rhs.AsStringRef(), "Expected the same data after conversion");
+            }
+        }
+    }
+
+    Y_UNIT_TEST(TestMultipleVariousTypes) {
+        TBlockLayoutConverterTestData data;
+
+        const auto int64Type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, false);
+        const auto stringType = data.PgmBuilder.NewDataType(NUdf::EDataSlot::String, false);
+
+        TVector< NKikimr::NMiniKQL::TType*> types{int64Type, stringType, int64Type, stringType};
+        TVector<NPackedTuple::EColumnRole> roles{
+            NPackedTuple::EColumnRole::Payload, NPackedTuple::EColumnRole::Key,
+            NPackedTuple::EColumnRole::Key, NPackedTuple::EColumnRole::Payload};
+
+        size_t itemSize = 2 * NMiniKQL::CalcMaxBlockItemSize(stringType) + 2 * NMiniKQL::CalcMaxBlockItemSize(int64Type);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        constexpr auto testSize = 128;
+
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+        TVector<arrow::Datum> columns;
+
+        for (size_t i = 0; i < types.size(); ++i) {
+            if (i % 2 == 0) {
+                auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), int64Type, *data.ArrowPool, blockLen, nullptr);
+                for (size_t j = 0; j < testSize; j++) {
+                    builder->Add(TBlockItem(i + j));
+                }
+                auto datum = builder->Build(true);
+                columns.emplace_back(std::move(datum));
+            } else {
+                auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), stringType, *data.ArrowPool, blockLen, nullptr);
+                std::string testString;
+                testString.resize(testSize);
+                for (size_t j = 0; j < testSize; j++) {
+                    testString[j] = static_cast<char>(j % 256);
+                    if (j % 2) {
+                        builder->Add(TBlockItem(TStringRef(testString.data(), i * 2 + j / 2 + 1)));
+                    } else {
+                        // Empty string
+                        builder->Add(TBlockItem(TStringRef()));
+                    }
+                }
+                auto datum = builder->Build(true);
+                columns.emplace_back(std::move(datum));
+            }
+        }
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), columns.size(), "Expected same columns count after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        for (size_t colIdx = 0; colIdx < columns.size(); ++colIdx) {
+            const auto& columnBefore = columns[colIdx].array();
+            const auto& columnAfter = columnsAfterConversion[colIdx].array();
+
+            if (colIdx % 2 == 0) {
+                auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), int64Type);
+                for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+                    TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+                    TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+                    UNIT_ASSERT_VALUES_EQUAL_C(lhs.Get<i64>(), rhs.Get<i64>(), "Expected the same data after conversion");
+                }
+            } else {
+                auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), stringType);
+                for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+                    TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+                    TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+                    UNIT_ASSERT_VALUES_EQUAL_C(lhs.AsStringRef(), rhs.AsStringRef(), "Expected the same data after conversion");
+                }
+            }
+        }
+    }
+
+    Y_UNIT_TEST(TestOptional) {
+        TBlockLayoutConverterTestData data;
+
+        const auto optionalInt64Type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, true);
+        TVector< NKikimr::NMiniKQL::TType*> types{optionalInt64Type};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        size_t itemSize = NMiniKQL::CalcMaxBlockItemSize(optionalInt64Type);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        constexpr auto testSize = NMiniKQL::MaxBlockSizeInBytes / sizeof(i64);
+
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), optionalInt64Type, *data.ArrowPool, blockLen, nullptr);
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+
+        for (size_t i = 0; i < testSize; i++) {
+            if (i % 2) {
+                builder->Add(TBlockItem());
+            } else {
+                builder->Add(TBlockItem(i));
+            }
+        }
+        auto datum = builder->Build(true);
+        Y_ENSURE(datum.is_array());
+        TVector<arrow::Datum> columns{datum};
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), 1, "Expected the one column after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        const auto& columnBefore = columns.front().array();
+        const auto& columnAfter = columnsAfterConversion.front().array();
+        auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), optionalInt64Type);
+
+        for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+            TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+            TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+            UNIT_ASSERT_VALUES_EQUAL_C(bool(lhs), bool(rhs), "Expected the same optionality after conversion");
+
+            if (lhs) {
+                UNIT_ASSERT_VALUES_EQUAL_C(lhs.Get<i64>(), rhs.Get<i64>(), "Expected the same data after conversion");
+            }
+        }
+    }
+
+    Y_UNIT_TEST(TestTuple) {
+        TBlockLayoutConverterTestData data;
+
+        std::vector<NMiniKQL::TType*> t;
+        t.push_back(data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64));
+        t.push_back(data.PgmBuilder.NewDataType(NUdf::EDataSlot::String));
+        t.push_back(data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, true));
+        const auto tupleType = data.PgmBuilder.NewTupleType(t);
+        TVector< NKikimr::NMiniKQL::TType*> types{tupleType};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        size_t itemSize = NMiniKQL::CalcMaxBlockItemSize(tupleType);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        constexpr auto testSize = 512;
+
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), tupleType, *data.ArrowPool, blockLen, nullptr);
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+
+        std::string testString;
+        testString.resize(testSize);
+        std::vector<TBlockItem*> testTuples(testSize);
+        for (size_t i = 0; i < testSize; i++) {
+            testString[i] = static_cast<char>(i);
+
+            TBlockItem* tupleItems = new TBlockItem[3];
+            testTuples.push_back(tupleItems);
+            tupleItems[0] = TBlockItem(i);
+            tupleItems[1] = TBlockItem(TStringRef(testString.data(), i + 1));
+            tupleItems[2] = i % 2 ? TBlockItem(i) : TBlockItem();
+
+            builder->Add(TBlockItem(tupleItems));
+        }
+        auto datum = builder->Build(true);
+        Y_ENSURE(datum.is_array());
+        TVector<arrow::Datum> columns{datum};
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), columns.size(), "Expected the one column after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        const auto& columnBefore = columns.front().array();
+        const auto& columnAfter = columnsAfterConversion.front().array();
+        auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), tupleType);
+
+        for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+            TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+            TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(lhs.GetElement(0).Get<i64>(), rhs.GetElement(0).Get<i64>(), "Expected the same data after conversion");
+            UNIT_ASSERT_VALUES_EQUAL_C(lhs.GetElement(1).AsStringRef(), rhs.GetElement(1).AsStringRef(), "Expected the same data after conversion");
+            UNIT_ASSERT_VALUES_EQUAL_C(bool(lhs.GetElement(2)), bool(rhs.GetElement(2)), "Expected the same optionality after conversion");
+            if (bool(lhs.GetElement(2))) {
+                UNIT_ASSERT_VALUES_EQUAL_C(lhs.GetElement(2).Get<i64>(), rhs.GetElement(2).Get<i64>(), "Expected the same data after conversion");
+            }
+        }
+
+        for (auto tupleItems : testTuples) {
+            delete[] tupleItems;
+        }
+    }
+
+    Y_UNIT_TEST(TestTzDate) {
+        TBlockLayoutConverterTestData data;
+        using TDtLayout = NUdf::TDataType<TTzDatetime>::TLayout;
+
+        const auto tzDatetimeType = data.PgmBuilder.NewDataType(NUdf::EDataSlot::TzDatetime, false);
+        TVector< NKikimr::NMiniKQL::TType*> types{tzDatetimeType};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        size_t itemSize = NMiniKQL::CalcMaxBlockItemSize(tzDatetimeType);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        constexpr auto testSize = NMiniKQL::MaxBlockSizeInBytes / (sizeof(TDtLayout) + sizeof(ui16));
+
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), tzDatetimeType, *data.ArrowPool, blockLen, nullptr);
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+
+        for (size_t i = 0; i < testSize; i++) {
+            TBlockItem dt = TBlockItem(i);
+            dt.SetTimezoneId(i * 2);
+            builder->Add(dt);
+        }
+        auto datum = builder->Build(true);
+        Y_ENSURE(datum.is_array());
+        TVector<arrow::Datum> columns{datum};
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), columns.size(), "Expected the one column after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        const auto& columnBefore = columns.front().array();
+        const auto& columnAfter = columnsAfterConversion.front().array();
+        auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), tzDatetimeType);
+
+        for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+            TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+            TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(lhs.Get<TDtLayout>(), rhs.Get<TDtLayout>(), "Expected the same data after conversion");
+            UNIT_ASSERT_VALUES_EQUAL_C(lhs.GetTimezoneId(), rhs.GetTimezoneId(), "Expected the same data after conversion");
+        }
+    }
+
+    #if 0
+    Y_UNIT_TEST(TestExternalOptional) {
+        TBlockLayoutConverterTestData data;
+
+        const auto doubleOptInt64Type = data.PgmBuilder.NewOptionalType(data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, true));
+        TVector< NKikimr::NMiniKQL::TType*> types{doubleOptInt64Type};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        size_t itemSize = NMiniKQL::CalcMaxBlockItemSize(doubleOptInt64Type);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        constexpr auto testSize = NMiniKQL::MaxBlockSizeInBytes / sizeof(i64);
+
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), doubleOptInt64Type, *data.ArrowPool, blockLen, nullptr);
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+
+        for (size_t i = 0; i < testSize; i++) {
+            if (i % 2) {
+                builder->Add(TBlockItem(i).MakeOptional());
+            } else if (i % 4) {
+                builder->Add(TBlockItem());
+            } else {
+                builder->Add(TBlockItem().MakeOptional());
+            }
+        }
+        auto datum = builder->Build(true);
+        Y_ENSURE(datum.is_array());
+        TVector<arrow::Datum> columns{datum};
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        TVector<arrow::Datum> columnsAfterConversion;
+        converter->Unpack(packRes, columnsAfterConversion);
+        UNIT_ASSERT_VALUES_EQUAL_C(columnsAfterConversion.size(), 1, "Expected the one column after conversion");
+        Y_ENSURE(columnsAfterConversion.front().is_array());
+
+        const auto& columnBefore = columns.front().array();
+        const auto& columnAfter = columnsAfterConversion.front().array();
+        auto reader = MakeBlockReader(NMiniKQL::TTypeInfoHelper(), doubleOptInt64Type);
+
+        for (size_t elemIdx = 0; elemIdx < testSize; elemIdx++) {
+            TBlockItem lhs = reader->GetItem(*columnBefore, elemIdx);
+            TBlockItem rhs = reader->GetItem(*columnAfter, elemIdx);
+
+            for (size_t i = 0; i < 2; i++) {
+                UNIT_ASSERT_VALUES_EQUAL_C(bool(lhs), bool(rhs), "Expected the same optionality after conversion");
+                if (!lhs) {
+                    break;
+                }
+
+                lhs = lhs.GetOptionalValue();
+                rhs = rhs.GetOptionalValue();
+            }
+
+            if (lhs) {
+                UNIT_ASSERT_VALUES_EQUAL_C(lhs.Get<i64>(), rhs.Get<i64>(), "Expected the same data after conversion");
+            }
+        }
+    }
+    #endif
+
+    Y_UNIT_TEST(TestBuckets) {
+        TBlockLayoutConverterTestData data;
+
+        const auto int64Type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, false);
+        TVector< NKikimr::NMiniKQL::TType*> types{int64Type};
+        TVector<NPackedTuple::EColumnRole> roles{NPackedTuple::EColumnRole::Key};
+
+        size_t itemSize = NMiniKQL::CalcMaxBlockItemSize(int64Type);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        constexpr auto testSize = NMiniKQL::MaxBlockSizeInBytes / sizeof(i64);
+
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), int64Type, *data.ArrowPool, blockLen, nullptr);
+        auto converter = MakeBlockLayoutConverter(NMiniKQL::TTypeInfoHelper(), types, roles, data.ArrowPool);
+
+        for (size_t i = 0; i < testSize; i++) {
+            builder->Add(TBlockItem(i));
+        }
+        auto datum = builder->Build(true);
+        Y_ENSURE(datum.is_array());
+        TVector<arrow::Datum> columns{datum};
+
+        IBlockLayoutConverter::TPackResult packRes;
+        converter->Pack(columns, packRes);
+        UNIT_ASSERT_VALUES_EQUAL_C(packRes.NTuples, testSize, "Expected the same dataset sizes after conversion");
+
+        static constexpr ui32 bucketsLogNum = 5;
+        auto packReses = std::array<IBlockLayoutConverter::TPackResult, 1u << bucketsLogNum>{};
+        converter->BucketPack(columns, packReses.data(), bucketsLogNum);
+        
+        const ui32 bucketedTuplesNum = std::accumulate(packReses.begin(), packReses.end(), 0, [](size_t lhs, const IBlockLayoutConverter::TPackResult& rhs) {
+            return lhs + rhs.NTuples;
+        });
+        UNIT_ASSERT_EQUAL(testSize, bucketedTuplesNum);
+
+        const size_t totalRowSize = converter->GetTupleLayout()->TotalRowSize;
+
+        ui32 hashsum = 0;
+        for (size_t i = 0; i < packRes.PackedTuples.size(); i += totalRowSize) {
+            hashsum += ReadUnaligned<ui32>(packRes.PackedTuples.data() + i);
+        }
+        ui32 bhashsum = 0;
+        for (const auto& packRes : packReses) {
+            for (size_t i = 0; i < packRes.PackedTuples.size(); i += totalRowSize) {
+                bhashsum += ReadUnaligned<ui32>(packRes.PackedTuples.data() + i);
+            }
+        }
+        UNIT_ASSERT_EQUAL(hashsum, bhashsum);
+    }
+}

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/hash_table_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/hash_table_ut.cpp
@@ -1,0 +1,533 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <chrono>
+#include <random>
+#include <vector>
+#include <fstream>
+
+#include <util/stream/null.h>
+#include <util/system/compiler.h>
+#include <util/system/fs.h>
+#include <util/system/mem_info.h>
+
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/robin_hood_table.h>
+
+#include <cxxabi.h> // demangled names
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+using namespace std::chrono_literals;
+
+static volatile bool IsVerbose = false;
+#define CTEST (IsVerbose ? Cerr : Cnull)
+
+namespace {
+
+class IDistribution {
+  public:
+    virtual ui32 operator()(std::mt19937 &gen) = 0;
+    virtual ui32 Min() const = 0;
+    virtual ui32 Max() const = 0;
+};
+
+class TSingleValueDistribution : public IDistribution {
+  public:
+    TSingleValueDistribution(ui32 a) : Value_(a) {}
+
+    virtual ui32 operator()(std::mt19937 &) override { return Value_; }
+    virtual ui32 Min() const override { return Value_; }
+    virtual ui32 Max() const override { return Value_; }
+
+  private:
+    const ui32 Value_;
+};
+
+class TUniformDistribution : public IDistribution {
+  public:
+    TUniformDistribution(ui32 a, ui32 b) : Distribution_(a, b) {}
+
+    virtual ui32 operator()(std::mt19937 &gen) override {
+        return Distribution_(gen);
+    }
+    virtual ui32 Min() const override { return Distribution_.min(); }
+    virtual ui32 Max() const override { return Distribution_.max(); }
+
+  private:
+    std::uniform_int_distribution<ui32> Distribution_;
+};
+
+class TNormalDistribution : public IDistribution {
+  public:
+    TNormalDistribution(ui32 mean, ui32 std)
+        : Distribution_(mean, std), Min_{mean > 3 * std ? mean - 3 * std : 0},
+          Max_{mean + 3 * std} {}
+
+    virtual ui32 operator()(std::mt19937 &gen) override {
+        return std::max(Min_,
+                        std::min(Max_, ui32(std::lround(Distribution_(gen)))));
+    }
+    virtual ui32 Min() const override { return Min_; }
+    virtual ui32 Max() const override { return Max_; }
+
+  private:
+    std::normal_distribution<double> Distribution_;
+    ui32 Min_;
+    ui32 Max_;
+};
+
+class TMixtureDistribution : public IDistribution {
+  public:
+    TMixtureDistribution(IDistribution &left, IDistribution &right, float pLeft)
+        : Left_(left), Right_(right), PLeft_(pLeft) {}
+
+    virtual ui32 operator()(std::mt19937 &gen) override {
+        return PLeft_(gen) ? Left_(gen) : Right_(gen);
+    }
+    virtual ui32 Min() const override {
+        return std::min(Left_.Min(), Right_.Min());
+    }
+    virtual ui32 Max() const override {
+        return std::max(Left_.Max(), Right_.Max());
+    }
+
+  private:
+    IDistribution &Left_;
+    IDistribution &Right_;
+    std::bernoulli_distribution PLeft_;
+};
+
+class TRepeatDistribution : public IDistribution {
+  public:
+    TRepeatDistribution(IDistribution &distribution, ui32 repeatNum)
+        : Distribution_(distribution), RepeatNum_(std::max(1u, repeatNum)), Cnt_(0) {}
+
+    virtual ui32 operator()(std::mt19937 &gen) override {
+        if (Cnt_ == 0) {
+            Cnt_ = RepeatNum_;
+            Val_ = Distribution_(gen);
+        }
+        --Cnt_;
+        return Val_;
+    }
+    virtual ui32 Min() const override {
+        return Distribution_.Min();
+    }
+    virtual ui32 Max() const override {
+        return Distribution_.Max();
+    }
+
+  private:
+    IDistribution &Distribution_;
+    const ui32 RepeatNum_;
+    ui32 Val_;
+    ui32 Cnt_;
+};
+
+} // namespace
+
+namespace {
+
+template <size_t Batch, typename... Args> class TBenchmark {
+    struct TResult {
+        ui64 coldBuildTime = 0;
+        ui64 warmBuildTime = 0;
+        ui64 lookupTime = 0;
+        ui64 batchedLookupTime = 0;
+        ui64 memUsed = 0;
+    };
+
+    friend std::ostream &operator<<(std::ostream &out, TResult res) {
+        out << res.coldBuildTime << ',' << res.warmBuildTime << ','
+            << res.lookupTime << ',' << res.batchedLookupTime
+            << ',' << res.memUsed;
+        return out;
+    }
+
+    struct TInfo {
+        ui64 uniqueMatches = 0;
+        ui64 totalMatches = 0;
+        ui32 checksum = 0;
+    };
+
+    static constexpr auto kBuildLookupSize = std::array{
+        std::pair<ui32, ui32>{10000, 200000},
+        std::pair<ui32, ui32>{40000, 200000},
+        std::pair<ui32, ui32>{100000, 200000},
+    };
+    static constexpr ui32 kIters = 3;
+
+  public:
+    struct TConfig {
+        TString name;
+        IDistribution &buildKeyDistribution;
+        IDistribution &lookupKeyDistribution;
+    };
+
+    TBenchmark(ui32 payloadSize, const char *benchName)
+        : Alloc_(__LOCATION__), PayloadSize_(payloadSize),
+          BenchName_(benchName) {
+        UNIT_ASSERT(payloadSize != 0);
+        Init();
+    }
+
+    void Register(TConfig config) { Configs_.emplace_back(std::move(config)); }
+
+    void Run(bool toCSV = false) {
+        CTEST << "================================\n";
+        CTEST << "======== " << BenchName_ << "\n";
+        CTEST << "Hash tables being benchmarked:\n";
+        ApplyNumbered([&]<class Arg, size_t Ind> {
+            PrintArg<Arg>("  (" + std::to_string(Ind) + ") ",
+                          "(" + std::to_string(PayloadSize_) + ")\n");
+        });
+        CTEST << Endl;
+
+        for (const auto &config : Configs_) {
+            CTEST << "--------------------------------\n";
+
+            std::ofstream out;
+            if (toCSV) {
+                const auto dir = std::filesystem::path(__FILE__).parent_path() /= "results";
+                std::filesystem::create_directory(dir);
+                out = std::ofstream(dir.string() + "/" + BenchName_ + "_" + config.name + ".csv");
+            }
+    
+            for (const auto [buildSize, lookupSize] : kBuildLookupSize) {
+                auto [buildKeys, buildOverflow] =
+                    GenData(buildSize, config.buildKeyDistribution);
+                auto [lookupKeys, lookupOverflow] =
+                    GenData(lookupSize, config.lookupKeyDistribution);
+                const auto info =
+                    GetInfo(config.buildKeyDistribution.Max(), buildKeys.data(),
+                            buildSize, lookupKeys.data(), lookupSize);
+
+                const auto results = RunTest(config, info, buildKeys.data(), buildOverflow.data(),
+                        buildSize, lookupKeys.data(), lookupOverflow.data(),
+                        lookupSize);
+
+                if (toCSV) {
+                    out << buildSize << ',' << lookupSize << ',';
+                    for (size_t ind = 0; ind != results.size(); ++ind) {
+                        out << results[ind] << (ind + 1 == results.size() ? '\n' : ',');
+                    }
+                    out << std::flush;
+                }
+            }
+        }
+    }
+
+  private:
+    void Init() {
+        TColumnDesc kc1, pc1;
+
+        kc1.Role = EColumnRole::Key;
+        kc1.DataSize = 4;
+
+        pc1.Role = EColumnRole::Payload;
+        pc1.DataSize = PayloadSize_;
+
+        std::vector<TColumnDesc> columns{kc1, pc1};
+        Layout_ = TTupleLayout::Create(columns);
+    }
+
+    auto GenData(ui32 size, IDistribution &distribution) {
+        std::mt19937 gen(11);
+
+        std::vector<ui32> col1(size);
+        std::vector<ui8> col2(size * PayloadSize_);
+
+        for (ui32 i = 0; i < size; ++i) {
+            col1[i] = distribution(gen);
+            col2[i * PayloadSize_] = 1;
+        }
+
+        const ui8 *cols[2];
+        cols[0] = (ui8 *)col1.data();
+        cols[1] = (ui8 *)col2.data();
+
+        std::vector<ui8> colValid1((size + 7) / 8, ~0);
+        std::vector<ui8> colValid2((size + 7) / 8, ~0);
+        const ui8 *colsValid[2] = {
+            colValid1.data(),
+            colValid2.data(),
+        };
+
+        const ui64 DataSize = Layout_->TotalRowSize * size;
+        auto result = std::make_pair(std::vector<ui8>(DataSize + 64, 0),
+                                     std::vector<ui8, TMKQLAllocator<ui8>>{});
+        Layout_->Pack(cols, colsValid, result.first.data(), result.second, 0,
+                      size);
+
+        return result;
+    }
+
+    TInfo GetInfo(ui32 maxKey, ui8 *leftData, ui32 leftSize, ui8 *rightData,
+                  ui32 rightSize) {
+        std::vector<bool> keyFound(maxKey + 1, 0);
+        std::vector<ui32> keyCount(maxKey + 1, 0);
+
+        for (ui32 ind = 0; ind != leftSize; ++ind) {
+            const ui32 key =
+                ReadUnaligned<ui32>(leftData + ind * Layout_->TotalRowSize +
+                                    Layout_->KeyColumnsOffset);
+            ++keyCount[key];
+        }
+
+        TInfo result;
+        for (ui32 ind = 0; ind != rightSize; ++ind) {
+            const ui32 hash =
+                ReadUnaligned<ui32>(rightData + ind * Layout_->TotalRowSize);
+            const ui32 key =
+                ReadUnaligned<ui32>(rightData + ind * Layout_->TotalRowSize +
+                                    Layout_->KeyColumnsOffset);
+
+            if (maxKey < key) {
+                continue;
+            }
+            if (keyCount[key] && !keyFound[key]) {
+                keyFound[key] = true;
+                result.uniqueMatches++;
+            }
+            result.totalMatches += keyCount[key];
+            result.checksum += keyCount[key] * hash;
+        }
+
+        return result;
+    }
+
+    auto RunTest(const TConfig &config, const TInfo info, ui8 *buildKeys,
+                 ui8 *buildOverflow, ui32 buildSize, ui8 *lookupKeys,
+                 ui8 *lookupOverflow, ui32 lookupSize) {
+        std::array<TResult, sizeof...(Args)> results;
+        ApplyNumbered([&]<class Arg, size_t Ind> {
+            results[Ind] =
+                RunArgTest<Arg>(buildKeys, buildOverflow, buildSize, lookupKeys,
+                                lookupOverflow, lookupSize, info);
+        });
+
+        CTEST << "--------" << Endl;
+        CTEST << "Params\t" << " config: " << config.name
+              << ", keys: " << buildSize << ", lookups: " << lookupSize << Endl;
+        CTEST << "Info\t" << " unique matches: " << info.uniqueMatches
+              << ", total matches: " << info.totalMatches << Endl;
+        CTEST << "\nTime measurements (us):" << Endl;
+        PrintResult("1st build", results,
+                    [](TResult arg) { return arg.coldBuildTime; });
+        PrintResult("2nd build", results,
+                    [](TResult arg) { return arg.warmBuildTime; });
+        PrintResult("lookups", results,
+                    [](TResult arg) { return arg.lookupTime; });
+        if constexpr (Batch > 1) {
+            PrintResult("batch " + std::to_string(Batch), results,
+                [](TResult arg) { return arg.batchedLookupTime; });
+        }
+        CTEST << "\nMemory measurements (KiB):" << Endl;
+        PrintResult("used by ht", results,
+                    [](TResult arg) { return arg.memUsed; });
+
+        return results;
+    }
+
+    void PrintResult(const std::string &name,
+                     const std::array<TResult, sizeof...(Args)> &results,
+                     auto getter) {
+        const size_t minInd =
+            std::min_element(
+                results.begin(), results.end(),
+                [&](auto lhs, auto rhs) { return getter(lhs) < getter(rhs); }) -
+            results.begin();
+
+        CTEST << "  " << name << ":\t";
+        for (size_t ind = 0; ind != sizeof...(Args); ++ind) {
+            if (ind == minInd) {
+                CTEST << "> (" << ind << ") " << getter(results[ind]) << " <\t";
+            } else {
+                CTEST << "  (" << ind << ") " << getter(results[ind]) << "  \t";
+            }
+        }
+        CTEST << Endl;
+    }
+
+    template <typename Arg>
+    TResult RunArgTest(ui8 *buildKeys, ui8 *buildOverflow, ui32 buildSize,
+                       ui8 *lookupKeys, ui8 *lookupOverflow, ui32 lookupSize,
+                       TInfo info) {
+        TResult result;
+
+        for (ui32 iter = 0; iter != kIters; ++iter) {
+            UNIT_ASSERT_LE(Alloc_.GetUsed(), 1024);
+
+            Arg arg(Layout_.Get());
+
+            result.coldBuildTime += Measure(
+                [&] { arg.Build(buildKeys, buildOverflow, buildSize); });
+            arg.Clear();
+            result.warmBuildTime += Measure(
+                [&] { arg.Build(buildKeys, buildOverflow, buildSize); });
+            result.memUsed = Alloc_.GetUsed() / 1024;
+
+            ui64 matches = 0;
+            ui32 checksum = 0;
+            result.lookupTime += Measure([&] {
+                ui8 *const end =
+                    lookupKeys + Layout_->TotalRowSize * lookupSize;
+                for (ui8 *it = lookupKeys; it != end; it += Layout_->TotalRowSize) {
+                    arg.Apply(it, lookupOverflow, [&](const ui8 *const row) {
+                        checksum += ReadUnaligned<ui32>(it);
+                        matches += 
+                            ReadUnaligned<ui8>(row + 2 * sizeof(ui32) + (1 + 7) / 8);
+                    });
+                }
+            });
+            UNIT_ASSERT_EQUAL(matches, info.totalMatches);
+            UNIT_ASSERT_EQUAL(checksum, info.checksum);
+
+            if constexpr (Batch > 1) {
+                matches = 0;
+                checksum = 0;
+                result.batchedLookupTime += Measure([&] {
+                    ui8 *it = lookupKeys;
+                    for (size_t batchInd = 0; batchInd < lookupSize; batchInd += Batch) {
+                        std::array<const ui8 *, Batch> rows;
+                        for (size_t i = 0; i < Batch && batchInd + i < lookupSize; ++i) {
+                            rows[i] = it;
+                            it += Layout_->TotalRowSize;
+                        }
+
+                        std::array<typename Arg::TIterator, Batch> iters =
+                            arg.FindBatch(rows, lookupOverflow);
+                        for (size_t i = 0; i < Batch && batchInd + i < lookupSize; ++i) {
+                            while (auto match = arg.NextMatch(iters[i], lookupOverflow)) {
+                                checksum += ReadUnaligned<ui32>(rows[i]);
+                                matches +=
+                                    ReadUnaligned<ui8>(match + 2 * sizeof(ui32) + (1 + 7) / 8);    
+                            }
+                        }
+                    }
+                });
+                UNIT_ASSERT_EQUAL(matches, info.totalMatches);
+                UNIT_ASSERT_EQUAL(checksum, info.checksum);
+            }
+
+            arg.Clear();
+        }
+
+        result.coldBuildTime /= kIters;
+        result.warmBuildTime /= kIters;
+        result.lookupTime /= kIters;
+        result.batchedLookupTime /= kIters;
+
+        return result;
+    }
+
+    void ApplyNumbered(auto f) {
+        [&]<size_t... Inds>(std::index_sequence<Inds...>) {
+            (f.template operator()<Args, Inds>(), ...);
+        }(std::make_index_sequence<sizeof...(Args)>{});
+    }
+
+    template <typename Arg>
+    void PrintArg(std::string prefix, std::string suffix) {
+        int status;
+        CTEST << prefix
+              << abi::__cxa_demangle(typeid(Arg).name(), 0, 0, &status)
+              << suffix;
+    }
+
+    ui64 Measure(auto f) {
+        const auto begin = std::chrono::steady_clock::now();
+        f();
+        const auto end = std::chrono::steady_clock::now();
+
+        ui64 us =
+            std::chrono::duration_cast<std::chrono::microseconds>(end - begin)
+                .count();
+        us = (us == 0 ? 1 : us);
+        return us;
+    }
+
+  private:
+    TScopedAlloc Alloc_;
+
+    ui32 PayloadSize_;
+    const char *BenchName_;
+
+    THolder<TTupleLayout> Layout_;
+
+    std::vector<TConfig> Configs_;
+};
+
+} // namespace
+
+// -----------------------------------------------------------------
+
+using TRobinHoodTable = TRobinHoodHashBase<false, false>;
+using TRobinHoodTableSeq = TRobinHoodHashBase<true, false>;
+using TRobinHoodTableSeqPref = TRobinHoodHashBase<true, true>;
+
+using TNeumannTable = TNeumannHashTable<false, false>;
+using TNeumannTableSeq = TNeumannHashTable<true, false>;
+
+using TNeumannTablePref = TNeumannHashTable<false, true>;
+using TNeumannTableSeqPref = TNeumannHashTable<true, true>;
+
+using TPageTableSSE = TPageHashTableImpl<NSimd::TSimdSSE42Traits, false>;
+using TPageTableSSEPref = TPageHashTableImpl<NSimd::TSimdSSE42Traits, true>;
+
+using TPageTableAVX2 = TPageHashTableImpl<NSimd::TSimdAVX2Traits, false>;
+using TPageTableAVX2Pref = TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>;
+
+// -----------------------------------------------------------------
+
+template <typename... Args> struct TTablesCase {
+    template <size_t Batch> using TBenchmark = TBenchmark<Batch, Args...>;
+};
+using TTablesBenchmark =
+    TTablesCase<TPageTableSSEPref, TRobinHoodTableSeqPref, TNeumannTablePref>;
+
+// -----------------------------------------------------------------
+
+Y_UNIT_TEST_SUITE(HashTablesBenchmark) {
+
+    static constexpr size_t batchSize = 16;
+    static constexpr bool toCSV = false;
+
+    Y_UNIT_TEST(Uniform) {
+        TUniformDistribution uni1M(0, 1e6 - 1);
+
+        auto benchmark = TTablesBenchmark::TBenchmark<batchSize>(4, Name_);
+
+        benchmark.Register({"uniform 1M", uni1M, uni1M});
+
+        benchmark.Run(toCSV);
+    }
+
+    Y_UNIT_TEST(UniformPayloaded) {
+        TUniformDistribution uni1M(0, 1e6 - 1);
+
+        auto benchmark = TTablesBenchmark::TBenchmark<batchSize>(21, Name_);
+
+        benchmark.Register({"uniform 1M", uni1M, uni1M});
+
+        benchmark.Run(toCSV);
+    }
+
+    Y_UNIT_TEST(NormalPayloaded) {
+        TNormalDistribution norm1M(1000000 / 2, 1000000 / 6);
+
+        auto benchmark = TTablesBenchmark::TBenchmark<batchSize>(21, Name_);
+
+        benchmark.Register({"norm 1M", norm1M, norm1M});
+
+        benchmark.Run(toCSV);
+    }
+
+} // Y_UNIT_TEST_SUITE(RobinHoodCheck)
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
@@ -1,10 +1,7 @@
-// #include <yql/essentials/minikql/mkql_runtime_version.h>
-// #include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <chrono>
 #include <vector>
-#include <set>
 #include <random>
 
 #include <util/system/fs.h>

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
@@ -179,7 +179,7 @@ Y_UNIT_TEST(PackMany) {
 
     constexpr size_t cols_types_num = 4;
     constexpr size_t cols_cnts[cols_types_num] = {0, 20, 10, 6}; // both Key and Payload
-    const ui64 NTuples1 = 1e6 * 2;
+    const ui64 NTuples1 = 1e5 * 2;
 
     constexpr size_t cols_sizes[cols_types_num] = {1, 2, 4, 8};
     constexpr size_t cols_num =
@@ -273,7 +273,7 @@ Y_UNIT_TEST(UnpackMany) {
 
     constexpr size_t cols_types_num = 4;
     constexpr size_t cols_cnts[cols_types_num] = {0, 20, 10, 6}; // both Key and Payload
-    const ui64 NTuples1 = 1e6 * 2;
+    const ui64 NTuples1 = 1e5 * 2;
 
     constexpr size_t cols_sizes[cols_types_num] = {1, 2, 4, 8};
     constexpr size_t cols_num =
@@ -989,8 +989,8 @@ Y_UNIT_TEST(PackIsValidFuzz) {
     ui64 totalSize = 0;
     ui64 totalRows = 0;
     for (ui32 test = 0; test < 10; ++test) {
-        ui32 rows = 1 + (rng() % 1000);
-        ui32 cols = 1 + (rng() % 100);
+        ui32 rows = 1 + (rng() % 100);
+        ui32 cols = 1 + (rng() % 10);
         columns.resize(cols);
         colsdata.resize(cols);
         colsptr.resize(cols);

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
@@ -1,0 +1,1053 @@
+// #include <yql/essentials/minikql/mkql_runtime_version.h>
+// #include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <chrono>
+#include <vector>
+#include <set>
+#include <random>
+
+#include <util/system/fs.h>
+#include <util/system/compiler.h>
+#include <util/stream/null.h>
+#include <util/system/mem_info.h>
+
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/hashes_calc.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h>
+
+#include <yql/essentials/minikql/comp_nodes/mkql_rh_hash.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+using namespace std::chrono_literals;
+
+static volatile bool IsVerbose = false;
+#define CTEST (IsVerbose ? Cerr : Cnull)
+
+namespace {
+
+template <typename TTraits>
+void TestCalculateCRC32_Impl() {
+    std::mt19937_64 rng; // fixed-seed (0) prng
+    std::vector<ui64> v(1024);
+    std::generate(v.begin(), v.end(), rng);
+
+    ui64 nanoseconds = 0;
+    ui64 totalBytes = 0;
+    ui32 hash = 0;
+    for (ui32 test = 0; test < 65535; ++test) {
+        ui32 bytes = rng() % (sizeof(v[0])*v.size());
+
+        std::chrono::steady_clock::time_point begin01 = std::chrono::steady_clock::now();
+        hash = CalculateCRC32<TTraits>((const ui8 *) v.data(), bytes, hash);
+        std::chrono::steady_clock::time_point end01 = std::chrono::steady_clock::now();
+
+        nanoseconds += std::chrono::duration_cast<std::chrono::nanoseconds>(end01 - begin01).count();
+        totalBytes += bytes;
+    }
+    CTEST << "Hash: "  << hash << Endl;
+    UNIT_ASSERT_VALUES_EQUAL(hash, 80113928);
+    CTEST << "Data Size: "  << totalBytes << Endl;
+    CTEST  << "Time for hash: " << ((nanoseconds + 999)/1000)  << "[microseconds]" << Endl;
+    CTEST  << "Calculating speed: " << totalBytes / ((nanoseconds + 999)/1000) << "MB/sec" << Endl;
+}
+}
+
+Y_UNIT_TEST_SUITE(TestHash) {
+
+Y_UNIT_TEST(TestCalculateCRC32Fallback) {
+    TestCalculateCRC32_Impl<NSimd::TSimdFallbackTraits>();
+}
+
+Y_UNIT_TEST(TestCalculateCRC32SSE42) {
+    if (NX86::HaveSSE42())
+        TestCalculateCRC32_Impl<NSimd::TSimdSSE42Traits>();
+    else
+        CTEST << "Skipped SSE42 test\n";
+}
+
+Y_UNIT_TEST(TestCalculateCRC32AVX2) {
+    if (NX86::HaveAVX2())
+        TestCalculateCRC32_Impl<NSimd::TSimdAVX2Traits>();
+    else
+        CTEST << "Skipped AVX2 test\n";
+}
+
+}
+
+Y_UNIT_TEST_SUITE(TupleLayout) {
+Y_UNIT_TEST(CreateLayout) {
+
+    TColumnDesc kc1, kc2,  pc1, pc2, pc3;
+
+    kc1.Role = EColumnRole::Key;
+    kc1.DataSize = 8;
+
+    kc2.Role = EColumnRole::Key;
+    kc2.DataSize = 4;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 16;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    pc3.Role = EColumnRole::Payload;
+    pc3.DataSize = 8;
+
+    std::vector<TColumnDesc> columns{kc1, kc2, pc1, pc2, pc3};
+
+    auto tl = TTupleLayout::Create(columns);
+    UNIT_ASSERT(tl->TotalRowSize == 45);
+}
+
+Y_UNIT_TEST(Pack) {
+
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc1, kc2,  pc1, pc2;
+
+    kc1.Role = EColumnRole::Key;
+    kc1.DataSize = 8;
+
+    kc2.Role = EColumnRole::Key;
+    kc2.DataSize = 4;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 8;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    std::vector<TColumnDesc> columns{kc1, kc2, pc1, pc2};
+
+    auto tl = TTupleLayout::Create(columns);
+    UNIT_ASSERT(tl->TotalRowSize == 29);
+
+    const ui64 NTuples1 = 10e6;
+
+    const ui64 Tuples1DataBytes = (tl->TotalRowSize) * NTuples1;
+
+    std::vector<ui64> col1(NTuples1, 0);
+    std::vector<ui32> col2(NTuples1, 0);
+    std::vector<ui64> col3(NTuples1, 0);
+    std::vector<ui32> col4(NTuples1, 0);
+
+    for (ui32 i = 0; i < NTuples1; ++i) {
+        col1[i] = i;
+        col2[i] = i;
+        col3[i] = i;
+        col4[i] = i;
+    }
+
+    const ui8* cols[4];
+
+    cols[0] = (ui8*) col1.data();
+    cols[1] = (ui8*) col2.data();
+    cols[2] = (ui8*) col3.data();
+    cols[3] = (ui8*) col4.data();
+
+    
+    std::vector<ui8> colValid1((NTuples1 + 7)/8, ~0);
+    std::vector<ui8> colValid2((NTuples1 + 7)/8, ~0);
+    std::vector<ui8> colValid3((NTuples1 + 7)/8, ~0);
+    std::vector<ui8> colValid4((NTuples1 + 7)/8, ~0);
+    const ui8 *colsValid[4] = {
+        colValid1.data(),
+        colValid2.data(),
+        colValid3.data(),
+        colValid4.data(),
+    };
+    
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+
+    std::vector<ui8> res(Tuples1DataBytes, 0);
+    std::chrono::steady_clock::time_point begintp = std::chrono::steady_clock::now();
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples1);
+    std::chrono::steady_clock::time_point endtp = std::chrono::steady_clock::now();
+    ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (microseconds == 0) microseconds = 1;
+
+    CTEST  << "Time for " << (NTuples1) << " transpose (external cycle)= " << microseconds  << "[microseconds]" << Endl;
+    CTEST  << "Data size = " << Tuples1DataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST  << "Calculating pack speed = " << Tuples1DataBytes / microseconds << "MB/sec" << Endl;
+    CTEST  << Endl;
+}
+
+Y_UNIT_TEST(PackMany) {
+
+    TScopedAlloc alloc(__LOCATION__);
+
+    constexpr size_t cols_types_num = 4;
+    constexpr size_t cols_cnts[cols_types_num] = {0, 20, 10, 6}; // both Key and Payload
+    const ui64 NTuples1 = 1e6 * 2;
+
+    constexpr size_t cols_sizes[cols_types_num] = {1, 2, 4, 8};
+    constexpr size_t cols_num =
+        2 * [&]<size_t... Is>(const std::index_sequence<Is...> &) {
+            return (... + cols_cnts[Is]);
+        }(std::make_index_sequence<cols_types_num>{});
+
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        CTEST << "Row: [crc32]";
+        ((cols_cnts[Is] ? CTEST << " [" << cols_sizes[Is] << "]x" <<  cols_cnts[Is] : CTEST), ...);
+        CTEST << " [mask byte]x" << (cols_num + 7) / 8;
+        ((cols_cnts[Is] ? CTEST << " [" << cols_sizes[Is] << "]x" <<  cols_cnts[Is] : CTEST), ...);
+        CTEST << Endl;
+    }(std::make_index_sequence<cols_types_num>{});
+    
+    std::vector<TColumnDesc> columns;
+    for (size_t ind = 0; ind != cols_types_num; ++ind) {
+        TColumnDesc desc;
+        desc.DataSize = cols_sizes[ind];
+
+        desc.Role = EColumnRole::Key;
+        for (size_t cnt = 0; cnt != cols_cnts[ind]; ++cnt) {
+            columns.push_back(desc);
+        }
+        desc.Role = EColumnRole::Payload;
+        for (size_t cnt = 0; cnt != cols_cnts[ind]; ++cnt) {
+            columns.push_back(desc);
+        }
+    }
+
+    UNIT_ASSERT_EQUAL(cols_num, columns.size());
+
+    auto tl = TTupleLayout::Create(columns);
+    CTEST << "Row size: " << tl->TotalRowSize << Endl;
+
+    const ui64 Tuples1DataBytes = (tl->TotalRowSize) * NTuples1;
+
+    std::vector<ui8> cols_vecs[cols_num];
+    for (size_t col = 0; col != cols_num; ++col) {
+        const size_t size = columns[col].DataSize * NTuples1;
+        cols_vecs[col].resize(size, 0);
+        for (ui32 i = 0; i < size; ++i) {
+            cols_vecs[col][i] = i;
+        }
+        for (ui32 i = 0; i < NTuples1; ++i) {
+            cols_vecs[col][i * columns[col].DataSize] = i;
+        }
+    }
+
+    const ui8* cols[cols_num];
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        ((cols[Is] = cols_vecs[Is].data()), ...);
+    }(std::make_index_sequence<cols_num>{});
+
+    std::vector<ui8> cols_valid_vecs[cols_num];
+    for (size_t col = 0; col != cols_num; ++col) {
+        cols_valid_vecs[col].resize((NTuples1 + 7)/8, ~0);
+    }
+
+    const ui8* cols_valid[cols_num];
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        ((cols_valid[Is] = cols_valid_vecs[Is].data()), ...);
+    }(std::make_index_sequence<cols_num>{});
+
+    std::vector<ui8> res(Tuples1DataBytes + 64, 0);
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+
+    std::chrono::steady_clock::time_point begin02 = std::chrono::steady_clock::now();
+    tl->Pack(cols, cols_valid, res.data(), overflow, 0, NTuples1);
+    std::chrono::steady_clock::time_point end02 = std::chrono::steady_clock::now();
+
+    ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end02 - begin02).count();
+    if (microseconds == 0) microseconds = 1;
+
+    for (size_t ind = 0; ind != NTuples1; ++ind) {
+        UNIT_ASSERT_EQUAL((ui8)ind, res.data()[tl->TotalRowSize * ind + 4]);
+    }
+
+    CTEST  << "Time for " << (NTuples1) << " transpose (external cycle)= " << microseconds  << "[microseconds]" << Endl;
+    CTEST  << "Data size =  " << Tuples1DataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST  << "Calculating pack-many speed = " << Tuples1DataBytes / microseconds << "[MB/sec]" << Endl;
+    CTEST  << Endl;
+
+    UNIT_ASSERT(true);
+
+}
+
+Y_UNIT_TEST(UnpackMany) {
+
+    TScopedAlloc alloc(__LOCATION__);
+
+    constexpr size_t cols_types_num = 4;
+    constexpr size_t cols_cnts[cols_types_num] = {0, 20, 10, 6}; // both Key and Payload
+    const ui64 NTuples1 = 1e6 * 2;
+
+    constexpr size_t cols_sizes[cols_types_num] = {1, 2, 4, 8};
+    constexpr size_t cols_num =
+        2 * [&]<size_t... Is>(const std::index_sequence<Is...> &) {
+            return (... + cols_cnts[Is]);
+        }(std::make_index_sequence<cols_types_num>{});
+
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        CTEST << "Row: [crc32]";
+        ((cols_cnts[Is] ? CTEST << " [" << cols_sizes[Is] << "]x" <<  cols_cnts[Is] : CTEST), ...);
+        CTEST << " [mask byte]x" << (cols_num + 7) / 8;
+        ((cols_cnts[Is] ? CTEST << " [" << cols_sizes[Is] << "]x" <<  cols_cnts[Is] : CTEST), ...);
+        CTEST << Endl;
+    }(std::make_index_sequence<cols_types_num>{});
+    
+    std::vector<TColumnDesc> columns;
+    for (size_t ind = 0; ind != cols_types_num; ++ind) {
+        TColumnDesc desc;
+        desc.DataSize = cols_sizes[ind];
+
+        desc.Role = EColumnRole::Key;
+        for (size_t cnt = 0; cnt != cols_cnts[ind]; ++cnt) {
+            columns.push_back(desc);
+        }
+        desc.Role = EColumnRole::Payload;
+        for (size_t cnt = 0; cnt != cols_cnts[ind]; ++cnt) {
+            columns.push_back(desc);
+        }
+    }
+
+    UNIT_ASSERT_EQUAL(cols_num, columns.size());
+
+    auto tl = TTupleLayout::Create(columns);
+    CTEST << "Row size: " << tl->TotalRowSize << Endl;
+
+    const ui64 Tuples1DataBytes = (tl->TotalRowSize) * NTuples1;
+
+    std::vector<ui8> cols_vecs[cols_num];
+    for (size_t col = 0; col != cols_num; ++col) {
+        const size_t size = columns[col].DataSize * NTuples1;
+        cols_vecs[col].resize(size, 0);
+        for (ui32 i = 0; i < size; ++i) {
+            cols_vecs[col][i] = i;
+        }
+    }
+
+    const ui8* cols[cols_num];
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        ((cols[Is] = cols_vecs[Is].data()), ...);
+    }(std::make_index_sequence<cols_num>{});
+
+    std::vector<ui8> cols_valid_vecs[cols_num];
+    for (size_t col = 0; col != cols_num; ++col) {
+        cols_valid_vecs[col].resize((NTuples1 + 7)/8, ~0);
+    }
+
+    const ui8* cols_valid[cols_num];
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        ((cols_valid[Is] = cols_valid_vecs[Is].data()), ...);
+    }(std::make_index_sequence<cols_num>{});
+
+    std::vector<ui8> res(Tuples1DataBytes + 64, 0);
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols, cols_valid, res.data(), overflow, 0, NTuples1);
+
+    std::vector<ui8> cols_new_vecs[cols_num];
+    for (size_t col = 0; col != cols_num; ++col) {
+        const size_t size = columns[col].DataSize * NTuples1;
+        cols_new_vecs[col].resize(size, 13);
+    }
+
+    ui8* cols_new[cols_num];
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        ((cols_new[Is] = cols_new_vecs[Is].data()), ...);
+    }(std::make_index_sequence<cols_num>{});
+
+    std::vector<ui8> cols_new_valid_vecs[cols_num];
+    for (size_t col = 0; col != cols_num; ++col) {
+        cols_new_valid_vecs[col].resize((NTuples1 + 7)/8, 13);
+    }
+
+    ui8* cols_new_valid[cols_num];
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        ((cols_new_valid[Is] = cols_new_valid_vecs[Is].data()), ...);
+    }(std::make_index_sequence<cols_num>{});
+
+
+    std::chrono::steady_clock::time_point begin02 = std::chrono::steady_clock::now();
+    tl->Unpack(cols_new, cols_new_valid, res.data(), overflow, 0, NTuples1);
+    std::chrono::steady_clock::time_point end02 = std::chrono::steady_clock::now();
+    ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end02 - begin02).count();
+
+    if (microseconds == 0) microseconds = 1;
+
+    CTEST  << "Time for " << (NTuples1) << " transpose (external cycle)= " << microseconds  << "[microseconds]" << Endl;
+    CTEST  << "Data size =  " << Tuples1DataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST  << "Calculating unpack-many speed = " << Tuples1DataBytes / microseconds << "[MB/sec]" << Endl;
+    CTEST  << Endl;
+
+    [&]<size_t... Is>(const std::index_sequence<Is...>&) {
+        const bool data_check = ((std::memcmp(cols[Is], cols_new[Is], cols_vecs[Is].size()) == 0) && ...);
+        UNIT_ASSERT(data_check);
+        const bool valid_check = ((std::memcmp(cols_valid[Is], cols_new_valid[Is], cols_valid_vecs[Is].size()) == 0) && ...);
+        UNIT_ASSERT(valid_check); 
+    }(std::make_index_sequence<cols_num>{});
+}
+
+Y_UNIT_TEST(Unpack) {
+
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc1, kc2,  pc1, pc2;
+
+    kc1.Role = EColumnRole::Key;
+    kc1.DataSize = 8;
+
+    kc2.Role = EColumnRole::Key;
+    kc2.DataSize = 4;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 8;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    std::vector<TColumnDesc> columns{kc1, kc2, pc1, pc2};
+
+    auto tl = TTupleLayout::Create(columns);
+    UNIT_ASSERT(tl->TotalRowSize == 29);
+
+    const ui64 NTuples1 = 10e6;
+
+    const ui64 Tuples1DataBytes = (tl->TotalRowSize) * NTuples1;
+
+    std::vector<ui64> col1(NTuples1, 0);
+    std::vector<ui32> col2(NTuples1, 0);
+    std::vector<ui64> col3(NTuples1, 0);
+    std::vector<ui32> col4(NTuples1, 0);
+
+    std::vector<ui8> res(Tuples1DataBytes + 64, 0);
+
+    for (ui32 i = 0; i < NTuples1; ++i) {
+        col1[i] = i;
+        col2[i] = i ^ 1;
+        col3[i] = i ^ 7;
+        col4[i] = i ^ 13;
+    }
+
+    const ui8* cols[4];
+
+    cols[0] = (ui8*) col1.data();
+    cols[1] = (ui8*) col2.data();
+    cols[2] = (ui8*) col3.data();
+    cols[3] = (ui8*) col4.data();
+
+    std::vector<ui8> colValid1((NTuples1 + 7)/8, ~0);
+    std::vector<ui8> colValid2((NTuples1 + 7)/8, ~0);
+    std::vector<ui8> colValid3((NTuples1 + 7)/8, ~0);
+    std::vector<ui8> colValid4((NTuples1 + 7)/8, ~0);
+    const ui8 *colsValid[4] = {
+            colValid1.data(),
+            colValid2.data(),
+            colValid3.data(),
+            colValid4.data(),
+    };
+
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples1);
+
+    std::vector<ui64> col1_new(NTuples1, 0);
+    std::vector<ui32> col2_new(NTuples1, 0);
+    std::vector<ui64> col3_new(NTuples1, 0);
+    std::vector<ui32> col4_new(NTuples1, 0);
+
+    ui8* cols_new[4];
+    cols_new[0] = (ui8*) col1_new.data();
+    cols_new[1] = (ui8*) col2_new.data();
+    cols_new[2] = (ui8*) col3_new.data();
+    cols_new[3] = (ui8*) col4_new.data();
+
+    std::vector<ui8> colValid1_new((NTuples1 + 7)/8, 0);
+    std::vector<ui8> colValid2_new((NTuples1 + 7)/8, 0);
+    std::vector<ui8> colValid3_new((NTuples1 + 7)/8, 0);
+    std::vector<ui8> colValid4_new((NTuples1 + 7)/8, 0);
+
+    ui8 *colsValid_new[4] = {
+        colValid1_new.data(),
+        colValid2_new.data(),
+        colValid3_new.data(),
+        colValid4_new.data(),
+    };
+
+    std::chrono::steady_clock::time_point begin02 = std::chrono::steady_clock::now();
+    tl->Unpack(cols_new, colsValid_new, res.data(), overflow, 0, NTuples1);
+    std::chrono::steady_clock::time_point end02 = std::chrono::steady_clock::now();
+    ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end02 - begin02).count();
+
+    if (microseconds == 0) microseconds = 1;
+
+    CTEST  << "Time for " << (NTuples1) << " transpose (external cycle)= " << microseconds  << "[microseconds]" << Endl;
+    CTEST  << "Data size =  " << Tuples1DataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST  << "Calculating unpack speed = " << Tuples1DataBytes / microseconds << "MB/sec" << Endl;
+    CTEST  << Endl;
+
+    UNIT_ASSERT(std::memcmp(col1.data(), col1_new.data(), sizeof(ui64) * col1.size()) == 0);
+    UNIT_ASSERT(std::memcmp(col2.data(), col2_new.data(), sizeof(ui32) * col2.size()) == 0);
+    UNIT_ASSERT(std::memcmp(col3.data(), col3_new.data(), sizeof(ui64) * col3.size()) == 0);
+    UNIT_ASSERT(std::memcmp(col4.data(), col4_new.data(), sizeof(ui32) * col4.size()) == 0);
+
+    UNIT_ASSERT(std::memcmp(colValid1.data(), colValid1_new.data(), colValid1.size()) == 0);
+    UNIT_ASSERT(std::memcmp(colValid2.data(), colValid2_new.data(), colValid2.size()) == 0);
+    UNIT_ASSERT(std::memcmp(colValid3.data(), colValid3_new.data(), colValid3.size()) == 0);
+    UNIT_ASSERT(std::memcmp(colValid4.data(), colValid4_new.data(), colValid4.size()) == 0);
+}
+
+Y_UNIT_TEST(PackVarSize) {
+
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc1, kcv1, kcv2, kc2,  pc1, pc2;
+
+    kc1.Role = EColumnRole::Key;
+    kc1.DataSize = 8;
+
+    kc2.Role = EColumnRole::Key;
+    kc2.DataSize = 4;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 8;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    kcv1.Role = EColumnRole::Key;
+    kcv1.DataSize = 8;
+    kcv1.SizeType = EColumnSizeType::Variable;
+
+    kcv2.Role = EColumnRole::Key;
+    kcv2.DataSize = 16;
+    kcv2.SizeType = EColumnSizeType::Variable;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 8;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    std::vector<TColumnDesc> columns{kc1, kc2, kcv1, kcv2, pc1, pc2};
+
+    auto tl = TTupleLayout::Create(columns);
+    CTEST << "TotalRowSize = " << tl->TotalRowSize << Endl;
+    UNIT_ASSERT_VALUES_EQUAL(tl->TotalRowSize, 54);
+
+    const ui64 NTuples1 = 3;
+
+    const ui64 Tuples1DataBytes = (tl->TotalRowSize) * NTuples1;
+
+    std::vector<ui64> col1(NTuples1, 0);
+    std::vector<ui32> col2(NTuples1, 0);
+    std::vector<ui64> col3(NTuples1, 0);
+    std::vector<ui32> col4(NTuples1, 0);
+
+    std::vector<ui32> vcol1(1, 0);
+
+    std::vector<ui8> vcol1data;
+    std::vector<ui32> vcol2(1, 0);
+    std::vector<ui8> vcol2data;
+
+    std::vector<ui8> res(Tuples1DataBytes + 64, 0);
+    std::vector<TString> vcol1str {
+        "abc",
+        "ABCDEFGHIJKLMNO",
+        "ZYXWVUTSPR"
+    };
+    std::vector<TString> vcol2str {
+        "ABC",
+        "abcdefghijklmno",
+        "zyxwvutspr"
+    };
+    for (auto &&str: vcol1str) {
+        for (auto c: str)
+            vcol1data.push_back(c);
+        vcol1.push_back(vcol1data.size());
+    }
+    UNIT_ASSERT_VALUES_EQUAL(vcol1.size(), NTuples1 + 1);
+    for (auto &&str: vcol2str) {
+        for (auto c: str)
+            vcol2data.push_back(c);
+        vcol2.push_back(vcol2data.size());
+    }
+    UNIT_ASSERT_VALUES_EQUAL(vcol2.size(), NTuples1 + 1);
+    for (ui32 i = 0; i < NTuples1; ++i) {
+        col1[i] = (1ull<<(sizeof(col1[0])*8 - 4)) + i + 1;
+        col2[i] = (2ull<<(sizeof(col2[0])*8 - 4)) + i + 1;
+        col3[i] = (3ull<<(sizeof(col3[0])*8 - 4)) + i + 1;
+        col4[i] = (4ull<<(sizeof(col4[0])*8 - 4)) + i + 1;
+    }
+
+    const ui8* cols[4 + 2*2];
+
+    cols[0] = (ui8*) col1.data();
+    cols[1] = (ui8*) col2.data();
+    cols[2] = (ui8*) vcol1.data();
+    cols[3] = (ui8*) vcol1data.data();
+    cols[4] = (ui8*) vcol2.data();
+    cols[5] = (ui8*) vcol2data.data();
+    cols[6] = (ui8*) col3.data();
+    cols[7] = (ui8*) col4.data();
+
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    std::vector<ui8> colValid((NTuples1 + 7)/8, ~0);
+    const ui8 *colsValid[8] = {
+            colValid.data(),
+            colValid.data(),
+            colValid.data(),
+            nullptr,
+            colValid.data(),
+            nullptr,
+            colValid.data(),
+            colValid.data(),
+    };
+
+    auto begintp = std::chrono::steady_clock::now();
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples1);
+    auto endtp = std::chrono::steady_clock::now();
+    ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+
+    if (microseconds == 0)
+        microseconds = 1;
+
+    CTEST  << "Time for " << (NTuples1) << " transpose (external cycle)= " << microseconds  << "[microseconds]" << Endl;
+}
+
+Y_UNIT_TEST(UnpackVarSize) {
+
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc1, kcv1, kcv2, kc2,  pc1, pc2;
+
+    kc1.Role = EColumnRole::Key;
+    kc1.DataSize = 8;
+
+    kc2.Role = EColumnRole::Key;
+    kc2.DataSize = 4;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 8;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    kcv1.Role = EColumnRole::Key;
+    kcv1.DataSize = 8;
+    kcv1.SizeType = EColumnSizeType::Variable;
+
+    kcv2.Role = EColumnRole::Key;
+    kcv2.DataSize = 16;
+    kcv2.SizeType = EColumnSizeType::Variable;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 8;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    std::vector<TColumnDesc> columns{kc1, kc2, kcv1, kcv2, pc1, pc2};
+
+    auto tl = TTupleLayout::Create(columns);
+    CTEST << "TotalRowSize = " << tl->TotalRowSize << Endl;
+    UNIT_ASSERT_VALUES_EQUAL(tl->TotalRowSize, 54);
+
+    const ui64 NTuples1 = 3;
+
+    const ui64 Tuples1DataBytes = (tl->TotalRowSize) * NTuples1;
+
+    std::vector<ui64> col1(NTuples1, 0);
+    std::vector<ui32> col2(NTuples1, 0);
+    std::vector<ui64> col3(NTuples1, 0);
+    std::vector<ui32> col4(NTuples1, 0);
+    
+    std::vector<ui32> vcol1(1, 0);
+    std::vector<ui8> vcol1data;
+    std::vector<ui32> vcol2(1, 0);
+    std::vector<ui8> vcol2data;
+
+    std::vector<ui8> res(Tuples1DataBytes + 64, 0);
+    std::vector<TString> vcol1str {
+        "abc",
+        "ABCDEFGHIJKLMNO",
+        "ZYXWVUTSPR"
+    };
+    std::vector<TString> vcol2str {
+        "ABC",
+        "abcdefghijklmno",
+        "zyxwvutspr"
+    };
+    for (auto &&str: vcol1str) {
+        for (auto c: str)
+            vcol1data.push_back(c);
+        vcol1.push_back(vcol1data.size());
+    }
+    UNIT_ASSERT_VALUES_EQUAL(vcol1.size(), NTuples1 + 1);
+    for (auto &&str: vcol2str) {
+        for (auto c: str)
+            vcol2data.push_back(c);
+        vcol2.push_back(vcol2data.size());
+    }
+    UNIT_ASSERT_VALUES_EQUAL(vcol2.size(), NTuples1 + 1);
+    for (ui32 i = 0; i < NTuples1; ++i) {
+        col1[i] = (1ull<<(sizeof(col1[0])*8 - 4)) + i + 1;
+        col2[i] = (2ull<<(sizeof(col2[0])*8 - 4)) + i + 1;
+        col3[i] = (3ull<<(sizeof(col3[0])*8 - 4)) + i + 1;
+        col4[i] = (4ull<<(sizeof(col4[0])*8 - 4)) + i + 1;
+    }
+
+    const ui8* cols[4 + 2*2];
+
+    cols[0] = (ui8*) col1.data();
+    cols[1] = (ui8*) col2.data();
+    cols[2] = (ui8*) vcol1.data();
+    cols[3] = (ui8*) vcol1data.data();
+    cols[4] = (ui8*) vcol2.data();
+    cols[5] = (ui8*) vcol2data.data();
+    cols[6] = (ui8*) col3.data();
+    cols[7] = (ui8*) col4.data();
+ 
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    std::vector<ui8> colValid((NTuples1 + 7)/8, ~0);
+    const ui8 *colsValid[8] = {
+            colValid.data(),
+            nullptr,
+            colValid.data(),
+            nullptr,
+            colValid.data(),
+            nullptr,
+            colValid.data(),
+            colValid.data(),
+    };
+
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples1);
+
+    std::vector<ui64> col1_new(NTuples1, 0);
+    std::vector<ui32> col2_new(NTuples1, 0);
+    std::vector<ui64> col3_new(NTuples1, 0);
+    std::vector<ui32> col4_new(NTuples1, 0);
+    
+    std::vector<ui32> vcol1_new(NTuples1 + 1, 0);
+    std::vector<ui8>  vcol1data_new(vcol1data.size());
+    std::vector<ui32> vcol2_new(NTuples1 + 1, 0);
+    std::vector<ui8>  vcol2data_new(vcol2data.size());
+
+    ui8* cols_new[4 + 2 * 2];
+    cols_new[0] = (ui8*) col1_new.data();
+    cols_new[1] = (ui8*) col2_new.data();
+    cols_new[2] = (ui8*) vcol1_new.data();
+    cols_new[3] = (ui8*) vcol1data_new.data();
+    cols_new[4] = (ui8*) vcol2_new.data();
+    cols_new[5] = (ui8*) vcol2data_new.data();
+    cols_new[6] = (ui8*) col3_new.data();
+    cols_new[7] = (ui8*) col4_new.data();
+
+    std::vector<ui8> colValid1_new((NTuples1 + 7)/8, 0);
+    colValid1_new.back() = ~0;
+    std::vector<ui8> colValid2_new((NTuples1 + 7)/8, 0);
+    colValid2_new.back() = ~0;
+    std::vector<ui8> colValid3_new((NTuples1 + 7)/8, 0);
+    colValid3_new.back() = ~0;
+    std::vector<ui8> colValid4_new((NTuples1 + 7)/8, 0);
+    colValid4_new.back() = ~0;
+    std::vector<ui8> colValid5_new((NTuples1 + 7)/8, 0);
+    colValid5_new.back() = ~0;
+    std::vector<ui8> colValid6_new((NTuples1 + 7)/8, 0);
+    colValid6_new.back() = ~0;
+
+    ui8 *colsValid_new[8] = {
+        colValid1_new.data(),
+        colValid2_new.data(),
+        colValid3_new.data(),
+        nullptr,
+        colValid4_new.data(),
+        nullptr,
+        colValid5_new.data(),
+        colValid6_new.data(),
+    };
+
+    std::chrono::steady_clock::time_point begin02 = std::chrono::steady_clock::now();
+    tl->Unpack(cols_new, colsValid_new, res.data(), overflow, 0, NTuples1);
+    std::chrono::steady_clock::time_point end02 = std::chrono::steady_clock::now();
+    ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end02 - begin02).count();
+
+    if (microseconds == 0)
+        microseconds = 1;
+
+    CTEST  << "Time for " << (NTuples1) << " transpose (external cycle)= " << microseconds  << "[microseconds]" << Endl;
+#ifndef NDEBUG
+    CTEST << "Result size = " << Tuples1DataBytes << Endl;
+    CTEST << "Result = ";
+    for (ui32 i = 0; i < Tuples1DataBytes; ++i)
+        CTEST << int(res[i]) << ' ';
+    CTEST << Endl;
+    CTEST << "Overflow size = " << overflow.size() << Endl;
+    CTEST << "Overflow = ";
+    for (auto c: overflow)
+        CTEST << int(c) << ' ';
+    CTEST << Endl;
+#endif
+
+    UNIT_ASSERT(std::memcmp(cols[0], cols_new[0], sizeof(ui64) * col1.size()) == 0);
+    UNIT_ASSERT(std::memcmp(cols[1], cols_new[1], sizeof(ui32) * col2.size()) == 0);
+    UNIT_ASSERT(std::memcmp(cols[2], cols_new[2], sizeof(ui32) * vcol1.size()) == 0);
+    UNIT_ASSERT(std::memcmp(cols[3], cols_new[3], vcol1data.size()) == 0);
+    UNIT_ASSERT(std::memcmp(cols[4], cols_new[4], sizeof(ui32) * vcol2.size()) == 0);
+    UNIT_ASSERT(std::memcmp(cols[5], cols_new[5], vcol1data.size()) == 0);
+    UNIT_ASSERT(std::memcmp(cols[6], cols_new[6], sizeof(ui64) * col3.size()) == 0);
+    UNIT_ASSERT(std::memcmp(cols[7], cols_new[7], sizeof(ui32) * col4.size()) == 0);
+
+    UNIT_ASSERT(std::memcmp(colValid.data(), colValid1_new.data(), colValid.size()) == 0);
+    UNIT_ASSERT(std::memcmp(colValid.data(), colValid2_new.data(), colValid.size()) == 0);
+    UNIT_ASSERT(std::memcmp(colValid.data(), colValid3_new.data(), colValid.size()) == 0);
+    UNIT_ASSERT(std::memcmp(colValid.data(), colValid4_new.data(), colValid.size()) == 0);
+    UNIT_ASSERT(std::memcmp(colValid.data(), colValid5_new.data(), colValid.size()) == 0);
+    UNIT_ASSERT(std::memcmp(colValid.data(), colValid6_new.data(), colValid.size()) == 0);
+}
+
+Y_UNIT_TEST(PackVarSizeBig) {
+
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc1, kc2, kcv1;
+
+    kc1.Role = EColumnRole::Key;
+    kc1.DataSize = 1;
+
+    kc2.Role = EColumnRole::Key;
+    kc2.DataSize = 2;
+
+    kcv1.Role = EColumnRole::Key;
+    kcv1.DataSize = 1000;
+    kcv1.SizeType = EColumnSizeType::Variable;
+
+    std::vector<TColumnDesc> columns{kc1, kc2, kcv1 };
+
+    auto tl = TTupleLayout::Create(columns);
+    //CTEST << "TotalRowSize = " << tl->TotalRowSize << Endl;
+    UNIT_ASSERT_VALUES_EQUAL(tl->TotalRowSize, 263);
+
+    const ui64 NTuples1 = 2;
+
+    const ui64 Tuples1DataBytes = (tl->TotalRowSize) * NTuples1;
+
+    std::vector<ui8> col1(NTuples1, 0);
+    std::vector<ui16> col2(NTuples1, 0);
+
+    std::vector<ui32> vcol1(1, 0);
+
+    std::vector<ui8> vcol1data;
+
+    std::vector<ui8> res(Tuples1DataBytes + 64, 0);
+    std::vector<TString> vcol1str {
+        "zaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbabcdefghijklnmorstuvwxy",
+        "zaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbrstuv",
+    };
+    for (auto &&str: vcol1str) {
+        for (auto c: str)
+            vcol1data.push_back(c);
+        vcol1.push_back(vcol1data.size());
+    }
+    UNIT_ASSERT_VALUES_EQUAL(vcol1.size(), NTuples1 + 1);
+    for (ui32 i = 0; i < NTuples1; ++i) {
+        col1[i] = (1ull<<(sizeof(col1[0])*8 - 4)) + i + 1;
+        col2[i] = (2ull<<(sizeof(col2[0])*8 - 4)) + i + 1;
+    }
+
+    const ui8* cols[2 + 1*2];
+
+    cols[0] = (ui8*) col1.data();
+    cols[1] = (ui8*) col2.data();
+    cols[2] = (ui8*) vcol1.data();
+    cols[3] = (ui8*) vcol1data.data();
+
+    std::vector<ui8> colValid((NTuples1 + 7)/8, ~0);
+    std::vector<ui8> colInvalid((NTuples1 + 7)/8, 0);
+    const ui8 *colsValid[2 + 1*2] = {
+            nullptr,
+            colInvalid.data(),
+            colValid.data(),
+            nullptr,
+    };
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+
+    std::chrono::steady_clock::time_point begin02 = std::chrono::steady_clock::now();
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples1);
+    std::chrono::steady_clock::time_point end02 = std::chrono::steady_clock::now();
+    ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end02 - begin02).count();
+
+    CTEST  << "Time for " << (NTuples1) << " transpose (external cycle)= " << microseconds  << "[microseconds]" << Endl;
+#ifndef NDEBUG
+    CTEST << "Result size = " << Tuples1DataBytes << Endl;
+    CTEST << "Result = ";
+    for (ui32 i = 0; i < Tuples1DataBytes; ++i)
+        CTEST << int(res[i]) << ' ';
+    CTEST << Endl;
+    CTEST << "Overflow size = " << overflow.size() << Endl;
+    CTEST << "Overflow = ";
+    for (auto c: overflow)
+        CTEST << int(c) << ' ';
+    CTEST << Endl;
+#endif
+    static const ui8 expected_data[263*2] = {
+            // row1
+            0x27,0xd1,0xce,0x49, // hash
+            0x11, // col1
+            0x1, 0x20, // col2
+            0xff,  0, 0, 0, 0,   0xb, 0, 0, 0, // vcol2 [ overflow offset, overflow size ]
+            0x7a, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+            0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
+            ui8(~0x2), // NULL bitmap
+            // row 2
+            0x96,0x27,0x88,0xaa, // hash
+            0x12, // col1
+            0x2, 0x20, // col2
+            0xfe, 0x7a, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
+            0x61, 0x61, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62, 0x62,
+            0x62, 0x62, 0x72, 0x73, 0x74, 0x75, 0x76,
+            ui8(~0x2), // NULLs bitmap
+    };
+    static const ui8 expected_overflow[11] = {
+            0x6e, 0x6d, 0x6f, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79,
+    };
+    UNIT_ASSERT_VALUES_EQUAL(sizeof(expected_data), tl->TotalRowSize*NTuples1);
+    UNIT_ASSERT_VALUES_EQUAL(overflow.size(), sizeof(expected_overflow));
+    for (ui32 i = 0; i < sizeof(expected_data); ++i)
+        UNIT_ASSERT_VALUES_EQUAL(expected_data[i], res[i]);
+    for (ui32 i = 0; i < sizeof(expected_overflow); ++i)
+        UNIT_ASSERT_VALUES_EQUAL(expected_overflow[i], overflow[i]);
+}
+Y_UNIT_TEST(PackIsValidFuzz) {
+
+    TScopedAlloc alloc(__LOCATION__);
+
+    std::mt19937 rng; // fixed-seed (0) prng
+    std::vector<TColumnDesc> columns;
+    std::vector<std::vector<ui8>> colsdata;
+    std::vector<const ui8*> colsptr;
+    std::vector<std::vector<ui8>> isValidData;
+    std::vector<const ui8*> isValidPtr;
+
+    ui64 totalNanoseconds = 0;
+    ui64 totalSize = 0;
+    ui64 totalRows = 0;
+    for (ui32 test = 0; test < 10; ++test) {
+        ui32 rows = 1 + (rng() % 1000);
+        ui32 cols = 1 + (rng() % 100);
+        columns.resize(cols);
+        colsdata.resize(cols);
+        colsptr.resize(cols);
+        isValidData.resize(cols);
+        isValidPtr.resize(cols);
+        ui32 isValidSize = (rows + 7)/8;
+        totalRows += rows;
+        for (ui32 j = 0; j < cols; ++j) {
+            auto &col = columns[j];
+            col.Role = (rng() % 10 < 1) ? EColumnRole::Key : EColumnRole::Payload;
+            col.DataSize = 1u <<(rng() % 16);
+            col.SizeType = EColumnSizeType::Fixed;
+            colsdata[j].resize(rows*col.DataSize);
+            colsptr[j] = colsdata[j].data();
+            isValidData[j].resize(isValidSize);
+            isValidPtr[j] = isValidData[j].data();
+            std::generate(isValidData[j].begin(), isValidData[j].end(), rng);
+        }
+        auto tl = TTupleLayout::Create(columns);
+        std::vector<ui8> res;
+        for (ui32 subtest = 0; subtest < 20; ++subtest) {
+            ui32 subRows = 1 + (rows ? rng() % (rows - 1) : 0);
+            ui32 off = subRows != rows ? rng() % (rows - subRows) : 0;
+            std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+            totalSize += subRows*tl->TotalRowSize;
+            res.resize(subRows*tl->TotalRowSize);
+
+            std::chrono::steady_clock::time_point begin01 = std::chrono::steady_clock::now();
+            tl->Pack(colsptr.data(), isValidPtr.data(), res.data(), overflow, off, subRows);
+            std::chrono::steady_clock::time_point end01 = std::chrono::steady_clock::now();
+            totalNanoseconds += std::chrono::duration_cast<std::chrono::nanoseconds>(end01 - begin01).count();
+
+            UNIT_ASSERT_VALUES_EQUAL(overflow.size(), 0);
+            auto resptr = res.data();
+            for (ui32 row = 0; row < subRows; ++row, resptr += tl->TotalRowSize) {
+                for (ui32 j = 0; j < cols; ++j) {
+                    auto &col = tl->Columns[j];
+                    UNIT_ASSERT_VALUES_EQUAL(((resptr[tl->BitmaskOffset + (j / 8)] >> (j % 8)) & 1), ((isValidData[col.OriginalIndex][(off + row) / 8] >> ((off + row) % 8)) & 1));
+                }
+            }
+        }
+    }
+
+    if (totalNanoseconds == 0) totalNanoseconds = 1;
+
+    CTEST  << "Time for " << totalRows << " transpose (external cycle)= " << (totalNanoseconds + 999)/1000  << "[microseconds]" << Endl;
+    CTEST  << "Data size =  " << totalSize / (1024 * 1024) << "[MB]" << Endl;
+    CTEST  << "Calculating speed = " << totalSize / ((totalNanoseconds + 999)/1000) << "MB/sec" << Endl;
+    CTEST  << Endl;
+}
+}
+
+
+
+}
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
@@ -14,6 +14,7 @@ ENDIF()
 
 SRCS(
     packed_tuple_ut.cpp
+    accumulator_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
@@ -1,0 +1,39 @@
+UNITTEST_FOR(ydb/library/yql/dq/comp_nodes/hash_join_utils)
+
+IF (SANITIZER_TYPE OR NOT OPENSOURCE)
+    REQUIREMENTS(ram:32)
+ENDIF()
+
+IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
+    SIZE(LARGE)
+    TAG(ya:fat)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+
+SRCS(
+    packed_tuple_ut.cpp
+)
+
+PEERDIR(
+    yql/essentials/public/udf
+    yql/essentials/public/udf/arrow
+    yql/essentials/public/udf/service/exception_policy
+    yql/essentials/sql/pg_dummy
+)
+
+CFLAGS(
+    -mavx2
+    -mprfchw
+)
+
+YQL_LAST_ABI_VERSION()
+
+IF (MKQL_RUNTIME_VERSION)
+    CFLAGS(
+        -DMKQL_RUNTIME_VERSION=$MKQL_RUNTIME_VERSION
+    )
+ENDIF()
+
+END()

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
@@ -15,6 +15,7 @@ ENDIF()
 SRCS(
     packed_tuple_ut.cpp
     accumulator_ut.cpp
+    block_layout_converter_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
@@ -13,9 +13,10 @@ ENDIF()
 
 
 SRCS(
-    packed_tuple_ut.cpp
     accumulator_ut.cpp
     block_layout_converter_ut.cpp
+    hash_table_ut.cpp
+    packed_tuple_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
@@ -22,6 +22,10 @@ PEERDIR(
     yql/essentials/public/udf
     yql/essentials/public/udf/arrow
     yql/essentials/public/udf/service/exception_policy
+    yql/essentials/minikql/comp_nodes
+    yql/essentials/minikql/comp_nodes/no_llvm
+    yql/essentials/minikql/computation
+    yql/essentials/minikql/invoke_builtins
     yql/essentials/sql/pg_dummy
 )
 

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     tuple.cpp
+    accumulator.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
@@ -1,0 +1,27 @@
+LIBRARY()
+
+SRCS(
+    tuple.cpp
+)
+
+PEERDIR(
+    contrib/libs/apache/arrow
+    yql/essentials/types/binary_json
+    yql/essentials/minikql
+    yql/essentials/utils
+    yql/essentials/utils/log
+    library/cpp/digest/crc32c
+)
+
+CFLAGS(
+    -mprfchw
+    -mavx2
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     tuple.cpp
     accumulator.cpp
+    block_layout_converter.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
@@ -1,9 +1,10 @@
 LIBRARY()
 
 SRCS(
-    tuple.cpp
     accumulator.cpp
     block_layout_converter.cpp
+    tuple.cpp
+    page_hash_table.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/comp_nodes/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 PEERDIR(
     ydb/library/actors/core
     ydb/library/yql/dq/actors/compute
+    ydb/library/yql/dq/comp_nodes/hash_join_utils
     ydb/library/yql/dq/runtime
     yql/essentials/minikql/comp_nodes
     yql/essentials/minikql/computation

--- a/ydb/library/yql/utils/simd/simd_avx2.h
+++ b/ydb/library/yql/utils/simd/simd_avx2.h
@@ -111,7 +111,7 @@ struct TSimd8 {
     }
 
     static Y_FORCE_INLINE TSimd8<T> LoadStream(const T values[32]) {
-        return _mm256_stream_load_si256(reinterpret_cast<__m256i *>(values));
+        return _mm256_stream_load_si256(reinterpret_cast<const __m256i *>(values));
     }
 
     Y_FORCE_INLINE void Store(T dst[32]) const {
@@ -127,7 +127,7 @@ struct TSimd8 {
     }
 
     Y_FORCE_INLINE void StoreMasked(void* dst, const TSimd8<T>& mask) const {
-        _mm_maskmoveu_si128(_mm256_castsi256_si128(this->Value), _mm256_castsi256_si128(mask.Value), (char*) dst);
+        _mm_maskmoveu_si128(_mm256_castsi256_si128(this->Value), _mm256_castsi256_si128(mask.Value), dst);
         _mm_maskmoveu_si128(_mm256_extracti128_si256(this->Value, 1), _mm256_extracti128_si256(mask.Value, 1), (char*) dst);
     }
 
@@ -283,6 +283,43 @@ struct TSimd8 {
             return Shuffle(TSimd8<T>(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15,
                                      A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31));
         }
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo8(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpacklo_epi8(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi8(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpackhi_epi8(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo16(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpacklo_epi16(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi16(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpackhi_epi16(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo32(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpacklo_epi32(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi32(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpackhi_epi32(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo64(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpacklo_epi64(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi64(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpackhi_epi64(lhs.Value, rhs.Value);
+    }
+
+    template <int N>
+    static Y_FORCE_INLINE TSimd8<T> PermuteLanes(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_permute2x128_si256(lhs.Value, rhs.Value, N);
     }
 
     static Y_FORCE_INLINE TSimd8<T> Repeat16(

--- a/ydb/library/yql/utils/simd/simd_fallback.h
+++ b/ydb/library/yql/utils/simd/simd_fallback.h
@@ -158,7 +158,21 @@ struct TBase8: TBase<TSimd8<T>> {
     }
 
     friend inline Mask operator==(const TSimd8<T> lhs, const TSimd8<T> rhs) {
-        return lhs.Value == rhs.Value;
+        ui64 diff = lhs.Value ^ rhs.Value;
+        ui64 result = 0;
+
+        #define ComparisonResultByte(i) ((diff >> (i * 8)) & 0xFF) ? 0 : 0x80ULL << (i * 8);
+        result |= ComparisonResultByte(0);
+        result |= ComparisonResultByte(1);
+        result |= ComparisonResultByte(2);
+        result |= ComparisonResultByte(3);
+        result |= ComparisonResultByte(4);
+        result |= ComparisonResultByte(5);
+        result |= ComparisonResultByte(6);
+        result |= ComparisonResultByte(7);
+        #undef ComparisonResultByte
+        
+        return result;
     }
 
     static const int SIZE = sizeof(TBase<T>::Value);

--- a/ydb/library/yql/utils/simd/simd_sse42.h
+++ b/ydb/library/yql/utils/simd/simd_sse42.h
@@ -107,8 +107,8 @@ struct TSimd8 {
         return _mm_load_si128(reinterpret_cast<const __m128i *>(values));
     }
 
-    static Y_FORCE_INLINE TSimd8<T> LoadStream(T dst[16]) {
-        return _mm_stream_load_si128(reinterpret_cast<__m128i *>(dst));
+    static Y_FORCE_INLINE TSimd8<T> LoadStream(const T values[16]) {
+        return _mm_stream_load_si128(reinterpret_cast<const __m128i *>(values));
     }
 
     Y_FORCE_INLINE void Store(T dst[16]) const {
@@ -124,7 +124,7 @@ struct TSimd8 {
     }
 
     Y_FORCE_INLINE void StoreMasked(void* dst, const TSimd8<T>& mask) const {
-        _mm_maskmoveu_si128(this->Value, mask.Value, (char*)dst);
+        _mm_maskmoveu_si128(this->Value, mask.Value, dst);
     }
 
     template<bool CanBeNegative = true>
@@ -198,6 +198,38 @@ struct TSimd8 {
     template<int N>
     Y_FORCE_INLINE TSimd8<T> Rotate() const {
         return Rotate128<N>();
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo8(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpacklo_epi8(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi8(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpackhi_epi8(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo16(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpacklo_epi16(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi16(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpackhi_epi16(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo32(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpacklo_epi32(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi32(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpackhi_epi32(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo64(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpacklo_epi64(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi64(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpackhi_epi64(lhs.Value, rhs.Value);
     }
 
     static Y_FORCE_INLINE TSimd8<T> Repeat16(


### PR DESCRIPTION
### Changelog entry

Block Hash Hoin utils.

### Changelog category

* Experimental feature

### Description for reviewers

This PR represents Block Hash Join utils using some experimental features such as:
- AoS <-> SoA formats conversion (with SIMD option)
- Different hash tables

Main changes:
- Add low-level tuple layout format designed for Join
- Add low-level AoS <-> SoA formats conversion
- Integrate tuple layout and conversion support into YDB
- Add three hash tables adapted for tuple layout: RH, Neumann, page
- Add low-level bucket splitter
- Add unit tests and benchmarks