### PR TITLE
Fix NeedToUseAutoConfig function

### DIFF
--- a/ydb/core/driver_lib/run/auto_config_initializer.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer.cpp
@@ -411,8 +411,10 @@ namespace NKikimr::NAutoConfigInitializer {
 
 namespace NKikimr {
     bool NeedToUseAutoConfig(const NKikimrConfig::TActorSystemConfig& config) {
+        bool hasSpecialFields = config.HasNodeType() || config.HasCpuCount();
+        if (!config.HasUseAutoConfig() && hasSpecialFields) {
+            return true;
+        }
         return config.GetUseAutoConfig()
-            || config.HasNodeType()
-            || config.HasCpuCount();
     }
 }

--- a/ydb/core/driver_lib/run/auto_config_initializer.cpp
+++ b/ydb/core/driver_lib/run/auto_config_initializer.cpp
@@ -415,6 +415,6 @@ namespace NKikimr {
         if (!config.HasUseAutoConfig() && hasSpecialFields) {
             return true;
         }
-        return config.GetUseAutoConfig()
+        return config.GetUseAutoConfig();
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixed the NeedToUseAutoConfig function. Previously, the function would return true even when UseAutoConfig was set to false if additional fields were present. This pull request corrects that bug: now, whenever UseAutoConfig is false, the function will always return false.
