### PR TITLE
Request full (and same) permissions set for all requests

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -123,7 +123,9 @@ public:
         return NKikimrServices::TActivity::GRPC_REQ_AUTH;
     }
 
-    static const TVector<TString>& GetPermissions();
+    static const TVector<TString>& GetPermissions() {
+        return NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::DEFAULT>::Get();
+    }
 
     void InitializeAttributesFromSchema(const TSchemeBoardEvents::TDescribeSchemeResult& schemeData, const TVector<std::pair<TString, TString>>& rootAttributes) {
         CheckedDatabaseName_ = CanonizePath(schemeData.GetPath());
@@ -689,24 +691,6 @@ void TGrpcRequestCheckActor<TEvent>::InitializeAttributes(const TSchemeBoardEven
         Attributes_.emplace_back(std::make_pair(attr.GetKey(), attr.GetValue()));
     }
     InitializeAttributesFromSchema(schemeData, rootAttributes);
-}
-
-template<typename T>
-inline constexpr bool IsStreamWrite = (
-    std::is_same_v<T, TEvStreamPQWriteRequest>
-    || std::is_same_v<T, TEvStreamTopicWriteRequest>
-    || std::is_same_v<T, TRefreshTokenStreamWriteSpecificRequest>
-);
-
-template <typename TEvent>
-const TVector<TString>& TGrpcRequestCheckActor<TEvent>::GetPermissions() {
-    if constexpr (IsStreamWrite<TEvent>) {
-        // extended permissions for stream write request family
-        return NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::STREAM>::Get();
-    } else {
-        // default permissions
-        return NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::DEFAULT>::Get();
-    }
 }
 
 template <typename TEvent>

--- a/ydb/library/cloud_permissions/cloud_permissions.h
+++ b/ydb/library/cloud_permissions/cloud_permissions.h
@@ -7,7 +7,6 @@ namespace NCloudPermissions {
 
 enum class EType {
     DEFAULT,
-    STREAM,
 };
 
 template<EType Type>
@@ -15,21 +14,6 @@ struct TCloudPermissions;
 
 template<>
 struct TCloudPermissions<EType::DEFAULT> {
-    static const TVector<TString>& Get() {
-        static TVector<TString> permissions {
-            "ydb.databases.list",
-            "ydb.databases.create",
-            "ydb.databases.connect",
-            "ydb.tables.select",
-            "ydb.tables.write",
-            "ydb.schemas.getMetadata"
-        };
-        return permissions;
-    }
-};
-
-template<>
-struct TCloudPermissions<EType::STREAM> {
     static const TVector<TString>& Get() {
         static TVector<TString> permissions {
             "ydb.databases.list",

--- a/ydb/services/datastreams/grpc_service.cpp
+++ b/ydb/services/datastreams/grpc_service.cpp
@@ -25,7 +25,7 @@ void YdsProcessAttr(const TSchemeBoardEvents::TDescribeSchemeResult& schemeData,
     }
     if (!attributes.empty()) {
         //full list of permissions for compatibility. remove old permissions later.
-        checker->SetEntries({{NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::STREAM>::Get(), attributes}});
+        checker->SetEntries({{NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::DEFAULT>::Get(), attributes}});
     }
 }
 

--- a/ydb/services/persqueue_v1/actors/persqueue_utils.h
+++ b/ydb/services/persqueue_v1/actors/persqueue_utils.h
@@ -79,7 +79,7 @@ static inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry>  GetTicketPar
     if (!dbId.empty()) attributes.push_back({"database_id", dbId});
     if (!folderId.empty()) attributes.push_back({"folder_id", folderId});
     if (!attributes.empty()) {
-        return {{NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::STREAM>::Get(), attributes}};
+        return {{NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::DEFAULT>::Get(), attributes}};
     }
     return {};
 }

--- a/ydb/services/persqueue_v1/topic.cpp
+++ b/ydb/services/persqueue_v1/topic.cpp
@@ -58,7 +58,7 @@ void YdsProcessAttr(const TSchemeBoardEvents::TDescribeSchemeResult& schemeData,
     }
     if (!attributes.empty()) {
         //full list of permissions for compatibility. remove old permissions later.
-        checker->SetEntries({{NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::STREAM>::Get(), attributes}});
+        checker->SetEntries({{NCloudPermissions::TCloudPermissions<NCloudPermissions::EType::DEFAULT>::Get(), attributes}});
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

There was a difference between topic requests and other requests, but actually there is no sense to make such a difference, because:
1. Additional permission don't bother others
2. We have a style that we ask for all the permissions even if we doesn't need them all, so there is no reason not to ask also for `ydb.streams.write`
