### PR TITLE
Add SIMD-based pack/unpack implementation

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/packing.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/packing.h
@@ -5,7 +5,6 @@ namespace NKikimr {
 namespace NMiniKQL {
 namespace NPackedTuple {
 
-[[maybe_unused]]
 static void
 PackTupleFallbackRowImpl(const ui8 *const src_cols[], ui8 *const dst_rows,
                          const size_t cols, const size_t size,
@@ -43,7 +42,6 @@ PackTupleFallbackRowImpl(const ui8 *const src_cols[], ui8 *const dst_rows,
     }
 }
 
-[[maybe_unused]]
 static void
 UnpackTupleFallbackRowImpl(const ui8 *const src_rows, ui8 *const dst_cols[],
                            const size_t cols, const size_t size,
@@ -279,6 +277,459 @@ UnpackTupleFallbackColImpl(const ui8 *const src_rows, ui8 *const dst_cols[],
                                start + block_size * block_rows);
 }
 
+template <class TTraits> struct SIMDPack {
+    template <class T> using TSimd = typename TTraits::template TSimd8<T>;
+
+    /// [8,16,32,64]-bits iters
+    static const ui8 BaseIters = 4;
+
+    /// 128-bit lane iters
+    static const ui8 LaneIters = [] {
+        if constexpr (std::is_same_v<TTraits, NSimd::TSimdAVX2Traits>) {
+            return 1;
+        }
+        return 0;
+    }();
+
+    static const ui8 TransposeIters = BaseIters + LaneIters;
+
+    /// bits reversed
+    static constexpr ui8 TransposeRevInd[BaseIters][1 << BaseIters] = {
+        {
+            0x0,
+            0x8,
+            0x4,
+            0xc,
+            0x2,
+            0xa,
+            0x6,
+            0xe,
+            0x1,
+            0x9,
+            0x5,
+            0xd,
+            0x3,
+            0xb,
+            0x7,
+            0xf,
+        },
+        {
+            0x0,
+            0x4,
+            0x2,
+            0x6,
+            0x1,
+            0x5,
+            0x3,
+            0x7,
+        },
+        {
+            0x0,
+            0x2,
+            0x1,
+            0x3,
+        },
+        {
+            0x0,
+            0x1,
+        },
+    };
+
+    template <ui8 Cols, ui8 LogIter>
+    static void Transpose(TSimd<ui8> (&regs)[2][Cols]) {
+        /// iterative transposition, starting from ColSize:
+        ///     ui8 -> ui16 -> ui32 -> ui64 -> 128bit-lane
+        /// smth like fourier butterfly
+
+#define TRANSPOSE_ITER(iter, bits)                                             \
+    if constexpr (LogIter <= iter) {                                           \
+        constexpr bool from = iter % 2;                                        \
+        constexpr bool to = from ^ 1;                                          \
+                                                                               \
+        constexpr ui8 log = iter - LogIter;                                    \
+        constexpr ui8 exp = 1u << log;                                         \
+                                                                               \
+        for (ui8 col = 0; col != Cols; ++col) {                                \
+            switch ((col & exp) >> log) {                                      \
+            case 0: {                                                          \
+                regs[to][col] = TSimd<ui8>::UnpackLaneLo##bits(                \
+                    regs[from][col & ~exp], regs[from][col | exp]);            \
+                break;                                                         \
+            }                                                                  \
+            case 1: {                                                          \
+                regs[to][col] = TSimd<ui8>::UnpackLaneHi##bits(                \
+                    regs[from][col & ~exp], regs[from][col | exp]);            \
+                break;                                                         \
+            }                                                                  \
+            default:;                                                          \
+            }                                                                  \
+        }                                                                      \
+    }
+
+        TRANSPOSE_ITER(0, 8);
+        TRANSPOSE_ITER(1, 16);
+        TRANSPOSE_ITER(2, 32);
+        TRANSPOSE_ITER(3, 64);
+    
+#undef TRANSPOSE_ITER
+
+        if constexpr (LaneIters == 1) {
+            constexpr auto iter = BaseIters;
+
+            constexpr bool from = iter % 2;
+            constexpr bool to = from ^ 1;
+
+            constexpr ui8 log = iter - LogIter;
+            constexpr ui8 exp = 1u << log;
+
+            for (ui8 col = 0; col != Cols; ++col) {
+                switch ((col & exp) >> log) {
+                case 0: {
+                    regs[to][col] =
+                        TSimd<ui8>::template PermuteLanes<0 + 2 * 16>(
+                            regs[from][col & ~exp], regs[from][col | exp]);
+                    break;
+                }
+                case 1: {
+                    regs[to][col] =
+                        TSimd<ui8>::template PermuteLanes<1 + 3 * 16>(
+                            regs[from][col & ~exp], regs[from][col | exp]);
+                    break;
+                }
+                }
+            }
+        } else if constexpr (LaneIters) {
+            static_assert(!LaneIters, "Not implemented");
+        }
+    }
+
+    template <ui8 ColSize>
+    static void PackColSizeImpl(const ui8 *const src_cols[],
+                                ui8 *const dst_rows, const size_t size,
+                                const size_t cols_num, const size_t padded_size,
+                                const size_t start = 0) {
+        static constexpr ui8 Cols = TSimd<ui8>::SIZE / ColSize;
+        static constexpr ui8 LogIter = std::countr_zero(ColSize);
+        static constexpr std::array<size_t, Cols> ColSizes = [] {
+            std::array<size_t, Cols> offsets;
+            for (size_t ind = 0; ind != Cols; ++ind) {
+                offsets[ind] = ColSize;
+            }
+            return offsets;
+        }();
+        static constexpr std::array<size_t, Cols> Offsets = [] {
+            std::array<size_t, Cols> offsets;
+            for (size_t ind = 0; ind != Cols; ++ind) {
+                offsets[ind] = ind * ColSize;
+            }
+            return offsets;
+        }();
+
+        const size_t simd_iters = size / Cols;
+
+        TSimd<ui8> regs[2][Cols];
+
+        for (size_t cols_group = 0; cols_group < cols_num; cols_group += Cols) {
+            const ui8 *srcs[Cols];
+            std::memcpy(srcs, src_cols + cols_group, sizeof(srcs));
+            for (ui8 col = 0; col != Cols; ++col) {
+                srcs[col] += ColSize * start;
+            }
+
+            auto dst = dst_rows + cols_group * ColSize;
+            ui8 *const end = dst + simd_iters * Cols * padded_size;
+
+            while (dst != end) {
+                for (ui8 col = 0; col != Cols; ++col) {
+                    regs[LogIter % 2][col] = TSimd<ui8>(srcs[col]);
+                    srcs[col] += TSimd<ui8>::SIZE;
+                }
+
+                Transpose<Cols, LogIter>(regs);
+
+                const bool res = TransposeIters % 2;
+                for (ui8 col = 0; col != Cols; ++col) {
+                    if constexpr (LaneIters) {
+                        const ui8 half_ind = col % (Cols / 2);
+                        const ui8 half_shift = col & (Cols / 2);
+                        regs[res]
+                            [TransposeRevInd[LogIter][half_ind] + half_shift]
+                                .Store(dst);
+                        dst += padded_size;
+                    } else {
+                        regs[res][TransposeRevInd[LogIter][col]].Store(dst);
+                        dst += padded_size;
+                    }
+                }
+            }
+
+            PackTupleFallbackRowImpl(srcs, dst, Cols, size - simd_iters * Cols,
+                                     ColSizes.data(), Offsets.data(),
+                                     padded_size);
+        }
+    }
+
+    template <ui8 ColSize>
+    static void
+    UnpackColSizeImpl(const ui8 *const src_rows, ui8 *const dst_cols[],
+                      size_t size, const size_t cols_num,
+                      const size_t padded_size, const size_t start = 0) {
+        static constexpr ui8 Cols = TSimd<ui8>::SIZE / ColSize;
+        static constexpr ui8 LogIter = std::countr_zero(ColSize);
+        static constexpr std::array<size_t, Cols> ColSizes = [] {
+            std::array<size_t, Cols> offsets;
+            for (size_t ind = 0; ind != Cols; ++ind) {
+                offsets[ind] = ColSize;
+            }
+            return offsets;
+        }();
+        static constexpr std::array<size_t, Cols> Offsets = [] {
+            std::array<size_t, Cols> offsets;
+            for (size_t ind = 0; ind != Cols; ++ind) {
+                offsets[ind] = ind * ColSize;
+            }
+            return offsets;
+        }();
+
+        const size_t simd_iters = size / Cols;
+
+        TSimd<ui8> regs[2][Cols];
+
+        for (size_t cols_group = 0; cols_group < cols_num; cols_group += Cols) {
+            auto src = src_rows + cols_group * ColSize;
+            const ui8 *const end = src + simd_iters * Cols * padded_size;
+
+            ui8 *dsts[Cols];
+            std::memcpy(dsts, dst_cols + cols_group, sizeof(dsts));
+            for (ui8 col = 0; col != Cols; ++col) {
+                dsts[col] += ColSize * start;
+            }
+
+            while (src != end) {
+                for (ui8 iter = 0; iter != Cols; ++iter) {
+                    regs[LogIter % 2][iter] = TSimd<ui8>(src);
+                    src += padded_size;
+                }
+
+                Transpose<Cols, LogIter>(regs);
+
+                const bool res = TransposeIters % 2;
+                for (ui8 col = 0; col != Cols; ++col) {
+                    if constexpr (LaneIters) {
+                        const ui8 half_ind = col % (Cols / 2);
+                        const ui8 half_shift = col & (Cols / 2);
+                        regs[res]
+                            [TransposeRevInd[LogIter][half_ind] + half_shift]
+                                .Store(dsts[col]);
+                        dsts[col] += TSimd<ui8>::SIZE;
+                    } else {
+                        regs[res][TransposeRevInd[LogIter][col]].Store(
+                            dsts[col]);
+                        dsts[col] += TSimd<ui8>::SIZE;
+                    }
+                }
+            }
+
+            UnpackTupleFallbackRowImpl(
+                src, dsts, Cols, size - simd_iters * Cols, ColSizes.data(),
+                Offsets.data(), padded_size);
+        }
+    }
+
+    static void PackColSize(const ui8 *const src_cols[], ui8 *const dst_rows,
+                            const size_t size, const size_t col_size,
+                            const size_t cols_num, const size_t padded_size,
+                            const size_t start = 0) {
+        switch (col_size) {
+        case 1:
+            PackColSizeImpl<1>(src_cols, dst_rows, size, cols_num, padded_size,
+                               start);
+            break;
+        case 2:
+            PackColSizeImpl<2>(src_cols, dst_rows, size, cols_num, padded_size,
+                               start);
+            break;
+        case 4:
+            PackColSizeImpl<4>(src_cols, dst_rows, size, cols_num, padded_size,
+                               start);
+            break;
+        case 8:
+            PackColSizeImpl<8>(src_cols, dst_rows, size, cols_num, padded_size,
+                               start);
+            break;
+        default:
+            throw std::runtime_error("What? Unexpected pack switch case " +
+                                     std::to_string(col_size));
+        }
+    }
+
+    static void UnpackColSize(const ui8 *const src_rows, ui8 *const dst_cols[],
+                              const size_t size, const size_t col_size,
+                              const size_t cols_num, const size_t padded_size,
+                              const size_t start = 0) {
+        switch (col_size) {
+        case 1:
+            UnpackColSizeImpl<1>(src_rows, dst_cols, size, cols_num,
+                                 padded_size, start);
+            break;
+        case 2:
+            UnpackColSizeImpl<2>(src_rows, dst_cols, size, cols_num,
+                                 padded_size, start);
+            break;
+        case 4:
+            UnpackColSizeImpl<4>(src_rows, dst_cols, size, cols_num,
+                                 padded_size, start);
+            break;
+        case 8:
+            UnpackColSizeImpl<8>(src_rows, dst_cols, size, cols_num,
+                                 padded_size, start);
+            break;
+        default:
+            throw std::runtime_error("What? Unexpected unpack switch case " +
+                                     std::to_string(col_size));
+        }
+    }
+
+    static TSimd<ui8> BuildTuplePerm(size_t col_size, size_t col_pad,
+                                     size_t tuple_size, ui8 offset, ui8 ind,
+                                     bool packing) {
+        ui8 perm[TSimd<ui8>::SIZE];
+        std::memset(perm, 0x80, TSimd<ui8>::SIZE);
+
+        size_t iters = std::max(1ul, 1 + (TSimd<ui8>::SIZE - tuple_size) /
+                                             (col_size + col_pad));
+        while (iters--) {
+            for (size_t it = col_size; it; --it, ++offset, ++ind) {
+                if (packing) {
+                    perm[offset] = ind;
+                } else {
+                    perm[ind] = offset;
+                }
+            }
+            offset += col_pad;
+        }
+
+        return TSimd<ui8>{perm};
+    }
+
+    template <ui8 TupleSize> static TSimd<ui8> TupleOr(TSimd<ui8> vec[]) {
+        return TupleOrImpl<TupleSize>(vec);
+    }
+
+    template <ui8 TupleSize> static TSimd<ui8> TupleOrImpl(TSimd<ui8> vec[]) {
+        static constexpr ui8 Left = TupleSize / 2;
+        static constexpr ui8 Right = TupleSize - Left;
+
+        return TupleOrImpl<Left>(vec) | TupleOrImpl<Right>(vec + Left);
+    }
+
+    template <> TSimd<ui8> TupleOrImpl<0>(TSimd<ui8>[]) { std::abort(); }
+
+    template <> TSimd<ui8> TupleOrImpl<1>(TSimd<ui8> vec[]) { return vec[0]; }
+
+    template <> TSimd<ui8> TupleOrImpl<2>(TSimd<ui8> vec[]) {
+        return vec[0] | vec[1];
+    }
+
+    template <ui8 StoresPerLoad, ui8 Cols>
+    static void PackTupleOr(const ui8 *const src_cols[], ui8 *const dst_rows,
+                            const size_t size, const size_t col_sizes[],
+                            const size_t offsets[], const size_t tuple_size,
+                            const size_t padded_size, const TSimd<ui8> perms[],
+                            const size_t start = 0) {
+        static constexpr size_t kSIMD_Rem = sizeof(TSimd<ui8>) - StoresPerLoad;
+        const ui8 tuples_per_store =
+            std::max(1ul, 1 + (TSimd<ui8>::SIZE - tuple_size) / padded_size);
+        const size_t simd_iters = (size > kSIMD_Rem ? size - kSIMD_Rem : 0) /
+                                  (tuples_per_store * StoresPerLoad);
+
+        TSimd<ui8> src_regs[Cols];
+        TSimd<ui8> perm_regs[Cols];
+
+        const ui8 *srcs[Cols];
+        std::memcpy(srcs, src_cols, sizeof(srcs));
+        for (ui8 col = 0; col != Cols; ++col) {
+            srcs[col] += col_sizes[col] * start;
+        }
+
+        auto dst = dst_rows;
+        ui8 *const end = dst_rows + simd_iters * tuples_per_store *
+                                        StoresPerLoad * padded_size;
+        while (dst != end) {
+            for (ui8 col = 0; col != Cols; ++col) {
+                src_regs[col] = TSimd<ui8>(srcs[col]);
+                srcs[col] += col_sizes[col] * tuples_per_store * StoresPerLoad;
+            }
+
+            for (ui8 iter = 0; iter != StoresPerLoad; ++iter) {
+                // shuffling each col bytes to the right positions
+                // then blending them together with 'or'
+                for (ui8 col = 0; col != Cols; ++col) {
+                    perm_regs[col] = src_regs[col].Shuffle(
+                        perms[col * StoresPerLoad + iter]);
+                }
+
+                TupleOr<Cols>(perm_regs).Store(dst);
+                dst += padded_size * tuples_per_store;
+            }
+        }
+
+        PackTupleFallbackRowImpl(srcs, dst, Cols,
+                                 size - simd_iters * tuples_per_store *
+                                            StoresPerLoad,
+                                 col_sizes, offsets, padded_size);
+    }
+
+    template <ui8 LoadsPerStore, ui8 Cols>
+    static void
+    UnpackTupleOr(const ui8 *const src_rows, ui8 *const dst_cols[], size_t size,
+                  const size_t col_sizes[], const size_t offsets[],
+                  const size_t tuple_size, const size_t padded_size,
+                  const TSimd<ui8> perms[], const size_t start = 0) {
+        static constexpr size_t kSIMD_Rem = sizeof(TSimd<ui8>) - LoadsPerStore;
+        const ui8 tuples_per_load =
+            std::max(1ul, 1 + (TSimd<ui8>::SIZE - tuple_size) / padded_size);
+        const size_t simd_iters = (size > kSIMD_Rem ? size - kSIMD_Rem : 0) /
+                                  (tuples_per_load * LoadsPerStore);
+
+        TSimd<ui8> src_regs[LoadsPerStore];
+        TSimd<ui8> perm_regs[LoadsPerStore];
+
+        auto src = src_rows;
+        const ui8 *const end = src_rows + simd_iters * tuples_per_load *
+                                              LoadsPerStore * padded_size;
+
+        ui8 *dsts[Cols];
+        std::memcpy(dsts, dst_cols, sizeof(dsts));
+        for (ui8 col = 0; col != Cols; ++col) {
+            dsts[col] += col_sizes[col] * start;
+        }
+
+        while (src != end) {
+            for (ui8 iter = 0; iter != LoadsPerStore; ++iter) {
+                src_regs[iter] = TSimd<ui8>(src);
+                src += padded_size * tuples_per_load;
+            }
+
+            for (ui8 col = 0; col != Cols; ++col) {
+                // shuffling each col bytes to the right positions
+                // then blending them together with 'or'
+                for (ui8 iter = 0; iter != LoadsPerStore; ++iter) {
+                    perm_regs[iter] = src_regs[iter].Shuffle(
+                        perms[col * LoadsPerStore + iter]);
+                }
+
+                TupleOr<LoadsPerStore>(perm_regs).Store(dsts[col]);
+                dsts[col] += col_sizes[col] * tuples_per_load * LoadsPerStore;
+            }
+        }
+
+        UnpackTupleFallbackRowImpl(src, dsts, Cols,
+                                   size - simd_iters * tuples_per_load *
+                                              LoadsPerStore,
+                                   col_sizes, offsets, padded_size);
+    }
+};
 
 } // namespace NPackedTuple
 } // namespace NMiniKQL

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <queue>
 
 #include <yql/essentials/minikql/mkql_alloc.h>
 #include <yql/essentials/public/udf/udf_data_type.h>
@@ -60,6 +61,34 @@ Y_FORCE_INLINE ui64 transposeBitmatrix(ui64 x) {
          << 28);
 
     return x;
+}
+
+void transposeBitmatrix(ui8 dst[], const ui8 *src[], const size_t row_size) {
+    ui64 x = 0;
+    for (size_t ind = 0; ind != 8; ++ind) {
+        x |= ui64(*src[ind]) << (ind * 8);
+    }
+
+    x = transposeBitmatrix(x);
+
+    for (size_t ind = 0; ind != 8; ++ind) {
+        dst[ind * row_size] = x;
+        x >>= 8;
+    }
+}
+
+void transposeBitmatrix(ui8 *dst[], const ui8 src[], const size_t row_size) {
+    ui64 x = 0;
+    for (size_t ind = 0; ind != 8; ++ind) {
+        x |= ui64(src[ind * row_size]) << (ind * 8);
+    }
+
+    x = transposeBitmatrix(x);
+
+    for (size_t ind = 0; ind != 8; ++ind) {
+        *dst[ind] = x;
+        x >>= 8;
+    }
 }
 
 } // namespace
@@ -189,6 +218,15 @@ bool TTupleLayout::KeysLess(const ui8 *lhsRow, const ui8 *lhsOverflow,
 
 THolder<TTupleLayout>
 TTupleLayout::Create(const std::vector<TColumnDesc> &columns) {
+
+    if (NX86::HaveAVX2())
+        return MakeHolder<TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>>(
+            columns);
+
+    if (NX86::HaveSSE42())
+        return MakeHolder<TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>>(
+            columns);
+
     return MakeHolder<TTupleLayoutFallback>(
         columns);
 }
@@ -310,6 +348,194 @@ TTupleLayoutFallback::TTupleLayoutFallback(
     }
 }
 
+template <typename TTraits>
+TTupleLayoutSIMD<TTraits>::TTupleLayoutSIMD(
+    const std::vector<TColumnDesc> &columns)
+    : TTupleLayoutFallback(columns) {
+    BlockRows_ = 128 * std::max(1ul, 128ul / TotalRowSize);
+    const bool use_simd = true;
+
+    // pack optimization for small tuple
+    const size_t max_simd_tuple_size =
+        use_simd && TSimd<ui8>::SIZE > TotalRowSize
+            ? TSimd<ui8>::SIZE - TotalRowSize
+            : 0;
+
+    std::vector<const TColumnDesc *> fallback_cols;
+    std::queue<const TColumnDesc *> next_cols;
+
+    size_t fixed_cols_left =
+        KeyColumnsFixedNum +
+        std::accumulate(PayloadColumns.begin(), PayloadColumns.end(), 0ul,
+                        [](size_t prev, const auto &col) {
+                            return prev +
+                                   (col.SizeType == EColumnSizeType::Fixed);
+                        });
+
+    const auto small_tuple_packing = [&](const std::vector<TColumnDesc>
+                                             &columns) {
+        for (const auto &col : columns) {
+            if (col.SizeType != EColumnSizeType::Fixed) {
+                break;
+            }
+            --fixed_cols_left;
+
+            size_t tuple_size = next_cols.empty()
+                                    ? 0
+                                    : next_cols.back()->DataSize +
+                                          next_cols.back()->Offset -
+                                          next_cols.front()->Offset;
+            const size_t tuple_size_with_col =
+                next_cols.empty()
+                    ? col.DataSize
+                    : col.DataSize + col.Offset - next_cols.front()->Offset;
+
+            const bool col_pushed = tuple_size_with_col <= max_simd_tuple_size;
+            if (col_pushed) {
+                next_cols.push(&col);
+                tuple_size = tuple_size_with_col;
+            }
+
+            if (!SIMDSmallTuple_.Cols && next_cols.size() > 1 &&
+                tuple_size <= max_simd_tuple_size &&
+                (!col_pushed || !fixed_cols_left)) {
+                SIMDSmallTupleDesc simd_desc;
+                simd_desc.Cols = next_cols.size();
+                simd_desc.RowOffset = next_cols.front()->Offset;
+                simd_desc.SmallTupleSize = tuple_size;
+
+                const TColumnDesc *col_descs[kSIMDMaxCols];
+                ui32 col_max_size = 0;
+                for (ui8 col_ind = 0; col_ind != simd_desc.Cols; ++col_ind) {
+                    col_descs[col_ind] = next_cols.front();
+                    col_max_size =
+                        std::max(col_max_size, col_descs[col_ind]->DataSize);
+                    next_cols.pop();
+                }
+
+                const auto tuples_per_register = std::max(
+                    1ul, 1ul + (TSimd<ui8>::SIZE - tuple_size) / TotalRowSize);
+
+                simd_desc.InnerLoopIters = std::min(
+                    size_t(kSIMDMaxInnerLoopSize),
+                    (TSimd<ui8>::SIZE / col_max_size) / tuples_per_register);
+
+                for (ui8 col_ind = 0; col_ind != simd_desc.Cols; ++col_ind) {
+                    const auto &col_desc = col_descs[col_ind];
+                    const size_t offset =
+                        col_desc->Offset - simd_desc.RowOffset;
+
+                    BlockColsOffsets_.push_back(offset);
+                    BlockFixedColsSizes_.push_back(col_desc->DataSize);
+                    BlockColumnsOrigInds_.push_back(col_desc->OriginalIndex);
+                }
+
+                for (size_t packing_flag = 1; packing_flag != 3;
+                     ++packing_flag) {
+                    for (ui8 col_ind = 0; col_ind != simd_desc.Cols;
+                         ++col_ind) {
+                        const auto col_desc = col_descs[col_ind];
+                        const size_t offset =
+                            col_desc->Offset - simd_desc.RowOffset;
+
+                        for (ui8 ind = 0; ind != simd_desc.InnerLoopIters;
+                             ++ind) {
+                            auto perm = SIMDPack<TTraits>::BuildTuplePerm(
+                                col_desc->DataSize,
+                                TotalRowSize - col_desc->DataSize, tuple_size,
+                                offset,
+                                ind * col_desc->DataSize * tuples_per_register,
+                                packing_flag % 2);
+                            SIMDPermMasks_.push_back(perm);
+                        }
+                    }
+                }
+
+                SIMDSmallTuple_ = simd_desc;
+            }
+
+            if (!col_pushed) {
+                next_cols.push(&col);
+            }
+        }
+    };
+
+    const auto transpose_packing = [&](const std::vector<TColumnDesc> &columns,
+                                       bool payload) {
+        ui32 colsize = 0;
+
+        for (const auto &col : columns) {
+            if (col.SizeType != EColumnSizeType::Fixed) {
+                break;
+            }
+
+            if (colsize != col.DataSize) {
+                while (!next_cols.empty()) {
+                    fallback_cols.push_back(next_cols.front());
+                    next_cols.pop();
+                }
+
+                if (use_simd && std::find(SIMDTranspositionsColSizes_.begin(),
+                                          SIMDTranspositionsColSizes_.end(),
+                                          col.DataSize) !=
+                                    SIMDTranspositionsColSizes_.end()) {
+                    colsize = col.DataSize;
+                }
+            }
+
+            if (colsize == col.DataSize) {
+                next_cols.push(&col);
+                if (next_cols.size() * colsize == TSimd<ui8>::SIZE) {
+                    const auto ind =
+                        payload * SIMDTranspositionsColSizes_.size() +
+                        std::find(SIMDTranspositionsColSizes_.begin(),
+                                  SIMDTranspositionsColSizes_.end(), colsize) -
+                        SIMDTranspositionsColSizes_.begin();
+                    if (SIMDTranspositions_[ind].Cols == 0) {
+                        SIMDTranspositions_[ind].RowOffset =
+                            next_cols.front()->Offset;
+                    }
+                    SIMDTranspositions_[ind].Cols += next_cols.size();
+
+                    while (!next_cols.empty()) {
+                        const auto col_desc = next_cols.front();
+                        BlockColsOffsets_.push_back(col_desc->Offset);
+                        BlockFixedColsSizes_.push_back(col_desc->DataSize);
+                        BlockColumnsOrigInds_.push_back(
+                            col_desc->OriginalIndex);
+                        next_cols.pop();
+                    }
+                }
+            } else {
+                fallback_cols.push_back(&col);
+            }
+        }
+
+        while (!next_cols.empty()) {
+            fallback_cols.push_back(next_cols.front());
+            next_cols.pop();
+        }
+    };
+
+    if (max_simd_tuple_size) {
+        small_tuple_packing(KeyColumns);
+        small_tuple_packing(PayloadColumns);
+
+        while (!next_cols.empty()) {
+            fallback_cols.push_back(next_cols.front());
+            next_cols.pop();
+        }
+    } else {
+        transpose_packing(KeyColumns, 0);
+        transpose_packing(PayloadColumns, 1);
+    }
+
+    for (const auto col_desc_p : fallback_cols) {
+        BlockColsOffsets_.push_back(col_desc_p->Offset);
+        BlockFixedColsSizes_.push_back(col_desc_p->DataSize);
+        BlockColumnsOrigInds_.push_back(col_desc_p->OriginalIndex);
+    }
+}
 
 // Columns (SoA) format:
 //   for fixed size: packed data
@@ -587,6 +813,388 @@ void TTupleLayoutFallback::Unpack(
         }
     }
 }
+
+#define MULTI_8_I(C, i) C(i, 0) C(i, 1) C(i, 2) C(i, 3)
+#define MULTI_8(C, A) C(A, 0) C(A, 1) C(A, 2) C(A, 3)
+
+template <typename TTraits>
+void TTupleLayoutSIMD<TTraits>::Pack(
+    const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+    std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const {
+    std::vector<const ui8 *> block_columns;
+    for (const auto col_ind : BlockColumnsOrigInds_) {
+        block_columns.push_back(columns[col_ind]);
+    }
+
+    for (size_t row_ind = 0; row_ind < count; row_ind += BlockRows_) {
+        const size_t cur_block_size = std::min(count - row_ind, BlockRows_);
+        size_t cols_past = 0;
+
+        if (SIMDSmallTuple_.Cols) {
+
+#define CASE(i, j)                                                             \
+    case i *kSIMDMaxCols + j:                                                  \
+        SIMDPack<TTraits>::template PackTupleOr<i + 1, j + 1>(                 \
+            block_columns.data() + cols_past, res + SIMDSmallTuple_.RowOffset, \
+            cur_block_size, BlockFixedColsSizes_.data() + cols_past,           \
+            BlockColsOffsets_.data() + cols_past,                              \
+            SIMDSmallTuple_.SmallTupleSize, TotalRowSize,                      \
+            SIMDPermMasks_.data(), start);                                     \
+        break;
+
+            switch ((SIMDSmallTuple_.InnerLoopIters - 1) * kSIMDMaxCols +
+                    SIMDSmallTuple_.Cols - 1) {
+                MULTI_8(MULTI_8_I, CASE)
+
+            default:
+                std::abort();
+            }
+
+#undef CASE
+
+            cols_past += SIMDSmallTuple_.Cols;
+        }
+
+        for (size_t trnsps_ind = 0; trnsps_ind != SIMDTranspositions_.size();
+             ++trnsps_ind) {
+            if (SIMDTranspositions_[trnsps_ind].Cols) {
+                SIMDPack<TTraits>::PackColSize(
+                    block_columns.data() + cols_past,
+                    res + SIMDTranspositions_[trnsps_ind].RowOffset,
+                    cur_block_size,
+                    SIMDTranspositionsColSizes_
+                        [trnsps_ind % SIMDTranspositionsColSizes_.size()],
+                    SIMDTranspositions_[trnsps_ind].Cols, TotalRowSize, start);
+                cols_past += SIMDTranspositions_[trnsps_ind].Cols;
+            }
+        }
+
+        PackTupleFallbackColImpl(
+            block_columns.data() + cols_past, res,
+            BlockColsOffsets_.size() - cols_past, cur_block_size,
+            BlockFixedColsSizes_.data() + cols_past,
+            BlockColsOffsets_.data() + cols_past, TotalRowSize, start);
+
+        for (ui32 cols_ind = 0; cols_ind < Columns.size(); cols_ind += 8) {
+            const size_t cols = std::min<size_t>(8ul, Columns.size() - cols_ind);
+            const ui8 ones_byte = 0xFF;  // dereferencable + all-ones fast path
+            const ui8 *bitmasks[8];
+
+            for (size_t ind = 0; ind != cols; ++ind) {
+                const auto &col = Columns[cols_ind + ind];
+                bitmasks[ind] = 
+                    isValidBitmask[col.OriginalIndex]
+                    ? isValidBitmask[col.OriginalIndex] + start / 8
+                    : &ones_byte;
+            }
+            for (size_t ind = cols; ind != 8; ++ind) {
+                bitmasks[ind] = &ones_byte;
+            }
+
+            const auto advance_masks = [&] {
+                for (size_t ind = 0; ind != 8; ++ind) {
+                    if (bitmasks[ind] != &ones_byte) {
+                        ++bitmasks[ind];
+                    }
+                }
+            };
+
+            const size_t first_full_byte =
+                std::min<size_t>((8ul - start) & 7, cur_block_size);
+            size_t block_row_ind = 0;
+
+            const auto edge_mask_transpose = [&](const size_t until) {
+                for (; block_row_ind < until; ++block_row_ind) {
+                    const auto shift = (start + block_row_ind) % 8;
+
+                    const auto new_res = res + block_row_ind * TotalRowSize;
+                    const auto res = new_res;
+
+                    res[BitmaskOffset + cols_ind / 8] = 0;
+                    for (size_t col_ind = 0; col_ind != 8; ++col_ind) {
+                        res[BitmaskOffset + cols_ind / 8] |=
+                            ((bitmasks[col_ind][0] >> shift) & 1u) << col_ind;
+                    }
+                }
+            };
+
+            edge_mask_transpose(first_full_byte);
+            if (first_full_byte) {
+                advance_masks();
+            }
+
+            for (; block_row_ind + 7 < cur_block_size; block_row_ind += 8) {
+                transposeBitmatrix(res + block_row_ind * TotalRowSize +
+                                       BitmaskOffset + cols_ind / 8,
+                                   bitmasks, TotalRowSize);
+                advance_masks();
+            }
+
+            edge_mask_transpose(cur_block_size);
+        }
+
+        for (size_t block_row_ind = 0; block_row_ind != cur_block_size;
+             ++block_row_ind) {
+
+            const auto new_start = start + block_row_ind;
+            const auto start = new_start;
+
+            const auto new_res = res + block_row_ind * TotalRowSize;
+            const auto res = new_res;
+
+            ui32 hash = CalculateCRC32<TTraits>(
+                res + KeyColumnsOffset, KeyColumnsFixedEnd - KeyColumnsOffset);
+
+            for (ui32 i = KeyColumnsFixedNum; i < KeyColumns.size(); ++i) {
+                auto &col = KeyColumns[i];
+                auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto nextOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+                auto size = nextOffset - dataOffset;
+                auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+                // hash = CalculateCRC32<TTraits>((ui8 *)&size, sizeof(size), hash);
+                hash = CalculateCRC32<TTraits>(data, size, hash);
+            }
+
+            // isValid bitmap is NOT included into hashed data
+            WriteUnaligned<ui32>(res, hash);
+
+            for (auto &col : VariableColumns) {
+                auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto nextOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+                auto size = nextOffset - dataOffset;
+                auto data = columns[col.OriginalIndex + 1] + dataOffset;
+                if (size >= col.DataSize) {
+                    res[col.Offset] = 255;
+
+                    auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                    auto overflowSize = size - prefixSize;
+                    auto overflowOffset = overflow.size();
+
+                    overflow.resize(overflowOffset + overflowSize);
+
+                    WriteUnaligned<ui32>(res + col.Offset + 1 +
+                                             0 * sizeof(ui32),
+                                         overflowOffset);
+                    WriteUnaligned<ui32>(
+                        res + col.Offset + 1 + 1 * sizeof(ui32), overflowSize);
+                    std::memcpy(res + col.Offset + 1 + 2 * sizeof(ui32), data,
+                                prefixSize);
+                    std::memcpy(overflow.data() + overflowOffset,
+                                data + prefixSize, overflowSize);
+                } else {
+                    Y_DEBUG_ABORT_UNLESS(size < 255);
+                    res[col.Offset] = size;
+                    std::memcpy(res + col.Offset + 1, data, size);
+                    std::memset(res + col.Offset + 1 + size, 0,
+                                col.DataSize - (size + 1));
+                }
+            }
+        }
+
+        start += cur_block_size;
+        res += cur_block_size * TotalRowSize;
+    }
+}
+
+template <typename TTraits>
+void TTupleLayoutSIMD<TTraits>::Unpack(
+    ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+    const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const {
+    std::vector<ui8 *> block_columns;
+    for (const auto col_ind : BlockColumnsOrigInds_) {
+        block_columns.push_back(columns[col_ind]);
+    }
+
+    for (size_t row_ind = 0; row_ind < count; row_ind += BlockRows_) {
+        const size_t cur_block_size = std::min(count - row_ind, BlockRows_);
+        size_t cols_past = 0;
+
+        if (SIMDSmallTuple_.Cols) {
+
+#define CASE(i, j)                                                             \
+    case i *kSIMDMaxCols + j:                                                  \
+        SIMDPack<TTraits>::template UnpackTupleOr<i + 1, j + 1>(               \
+            res + SIMDSmallTuple_.RowOffset, block_columns.data() + cols_past, \
+            cur_block_size, BlockFixedColsSizes_.data() + cols_past,           \
+            BlockColsOffsets_.data() + cols_past,                              \
+            SIMDSmallTuple_.SmallTupleSize, TotalRowSize,                      \
+            SIMDPermMasks_.data() + (i + 1) * (j + 1), start);                 \
+        break;
+
+            switch ((SIMDSmallTuple_.InnerLoopIters - 1) * kSIMDMaxCols +
+                    SIMDSmallTuple_.Cols - 1) {
+                MULTI_8(MULTI_8_I, CASE)
+
+            default:
+                std::abort();
+            }
+
+#undef CASE
+
+            cols_past += SIMDSmallTuple_.Cols;
+        }
+
+        for (size_t trnsps_ind = 0; trnsps_ind != SIMDTranspositions_.size();
+             ++trnsps_ind) {
+            if (SIMDTranspositions_[trnsps_ind].Cols) {
+                SIMDPack<TTraits>::UnpackColSize(
+                    res + SIMDTranspositions_[trnsps_ind].RowOffset,
+                    block_columns.data() + cols_past, cur_block_size,
+                    SIMDTranspositionsColSizes_
+                        [trnsps_ind % SIMDTranspositionsColSizes_.size()],
+                    SIMDTranspositions_[trnsps_ind].Cols, TotalRowSize, start);
+                cols_past += SIMDTranspositions_[trnsps_ind].Cols;
+            }
+        }
+
+        UnpackTupleFallbackColImpl(
+            res, block_columns.data() + cols_past,
+            BlockColsOffsets_.size() - cols_past, cur_block_size,
+            BlockFixedColsSizes_.data() + cols_past,
+            BlockColsOffsets_.data() + cols_past, TotalRowSize, start);
+
+        for (ui32 cols_ind = 0; cols_ind < Columns.size(); cols_ind += 8) {
+            const size_t cols = std::min<size_t>(8ul, Columns.size() - cols_ind);
+            ui8 *bitmasks[8];
+            ui8 trash_byte;  // dereferencable
+
+            for (size_t ind = 0; ind != cols; ++ind) {
+                const auto &col = Columns[cols_ind + ind];
+                bitmasks[ind] =
+                    isValidBitmask[col.OriginalIndex]
+                        ? isValidBitmask[col.OriginalIndex] + start / 8
+                        : &trash_byte;
+            }
+            for (size_t ind = cols; ind != 8; ++ind) {
+                bitmasks[ind] = &trash_byte;
+            }
+
+            const auto advance_masks = [&] {
+                for (size_t ind = 0; ind != 8; ++ind) {
+                    if (bitmasks[ind] != &trash_byte) {
+                        ++bitmasks[ind];
+                    }
+                }
+            };
+
+            const size_t first_full_byte =
+                std::min<size_t>((8ul - start) & 7, cur_block_size);
+            size_t block_row_ind = 0;
+
+            const auto edge_mask_transpose = [&](const size_t until) {
+                for (size_t col_ind = 0;
+                     block_row_ind != until && col_ind != cols; ++col_ind) {
+                    auto bitmask =
+                        bitmasks[col_ind][0] & ~((0xFF << (block_row_ind & 7)) ^
+                                                 (0xFF << (until & 7)));
+
+                    for (size_t row_ind = block_row_ind; row_ind < until;
+                         ++row_ind) {
+                        const auto shift = (start + row_ind) % 8;
+
+                        const auto new_res = res + row_ind * TotalRowSize;
+                        const auto res = new_res;
+
+                        bitmask |=
+                            ((res[BitmaskOffset + cols_ind / 8] >> col_ind) &
+                             1u)
+                            << shift;
+                    }
+
+                    bitmasks[col_ind][0] = bitmask;
+                }
+                block_row_ind = until;
+            };
+
+            edge_mask_transpose(first_full_byte);
+            if (first_full_byte) {
+                advance_masks();
+            }
+
+            for (; block_row_ind + 7 < cur_block_size; block_row_ind += 8) {
+                transposeBitmatrix(bitmasks,
+                                   res + block_row_ind * TotalRowSize +
+                                       BitmaskOffset + cols_ind / 8,
+                                   TotalRowSize);
+                advance_masks();
+            }
+
+            edge_mask_transpose(cur_block_size);
+        }
+
+        for (size_t block_row_ind = 0; block_row_ind != cur_block_size;
+             ++block_row_ind) {
+
+            const auto new_start = start + block_row_ind;
+            const auto start = new_start;
+
+            const auto new_res = res + block_row_ind * TotalRowSize;
+            const auto res = new_res;
+
+            for (auto &col : VariableColumns) {
+                const auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto *const data = columns[col.OriginalIndex + 1] + dataOffset;
+
+                ui32 size = ReadUnaligned<ui8>(res + col.Offset);
+
+                if (size < 255) { // embedded str
+                    std::memcpy(data, res + col.Offset + 1, size);
+                } else { // overflow buffer used
+                    const auto prefixSize =
+                        (col.DataSize - 1 - 2 * sizeof(ui32));
+                    const auto overflowOffset = ReadUnaligned<ui32>(
+                        res + col.Offset + 1 + 0 * sizeof(ui32));
+                    const auto overflowSize = ReadUnaligned<ui32>(
+                        res + col.Offset + 1 + 1 * sizeof(ui32));
+
+                    std::memcpy(data, res + col.Offset + 1 + 2 * sizeof(ui32),
+                                prefixSize);
+                    std::memcpy(data + prefixSize,
+                                overflow.data() + overflowOffset, overflowSize);
+
+                    size = prefixSize + overflowSize;
+                }
+
+                WriteUnaligned<ui32>(columns[col.OriginalIndex] +
+                                         sizeof(ui32) * (start + 1),
+                                     dataOffset + size);
+            }
+        }
+
+        start += cur_block_size;
+        res += cur_block_size * TotalRowSize;
+    }
+}
+
+template __attribute__((target("avx2"))) void
+TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>::Pack(
+    const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+    std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const;
+template __attribute__((target("sse4.2"))) void
+TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>::Pack(
+    const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+    std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const;
+
+template __attribute__((target("avx2"))) void
+TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>::Unpack(
+    ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+    const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const;
+template __attribute__((target("sse4.2"))) void
+TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>::Unpack(
+    ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+    const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+    ui32 count) const;
 
 void TTupleLayout::CalculateColumnSizes(
     const ui8 *res, ui32 count,

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
@@ -193,7 +193,7 @@ struct TTupleLayout {
         ui32 dstCount,
         const ui8 *src, const ui8 *srcOverflow, ui32 srcCount, ui32 srcOverflowSize) const;
 
-        ui32 GetTupleVarSize(const ui8* inTuple) const;
+    ui32 GetTupleVarSize(const ui8* inTuple) const;
 
     bool KeysEqual(const ui8 *lhsRow, const ui8 *lhsOverflow, const ui8 *rhsRow, const ui8 *rhsOverflow) const;
     bool KeysLess(const ui8 *lhsRow, const ui8 *lhsOverflow, const ui8 *rhsRow, const ui8 *rhsOverflow) const;
@@ -218,6 +218,49 @@ struct TTupleLayoutFallback : public TTupleLayout {
     std::vector<TColumnDesc> FixedNPOTColumns_; // Remaining fixed-size columns
 };
 
+
+template <typename TTraits> struct TTupleLayoutSIMD : public TTupleLayoutFallback {
+
+    explicit TTupleLayoutSIMD(const std::vector<TColumnDesc> &columns);
+
+    void Pack(const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
+        std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
+        ui32 count) const override;
+
+    void Unpack(ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
+            const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
+            ui32 start, ui32 count) const override;
+
+  private:
+    using TSimdI8 = typename TTraits::TSimdI8;
+    template <class T> using TSimd = typename TTraits::template TSimd8<T>;
+
+    static constexpr ui8 kSIMDMaxCols = 4;
+    static constexpr ui8 kSIMDMaxInnerLoopSize = 4;
+
+    size_t BlockRows_; // Estimated rows per cache block
+    std::vector<size_t> BlockColsOffsets_;
+    std::vector<size_t> BlockFixedColsSizes_;
+    std::vector<size_t> BlockColumnsOrigInds_;
+
+    struct SIMDSmallTupleDesc {
+        ui8 Cols = 0;
+        ui8 InnerLoopIters;
+        size_t SmallTupleSize;
+        size_t RowOffset;
+    };
+    SIMDSmallTupleDesc SIMDSmallTuple_;
+    std::vector<TSimd<ui8>> SIMDPermMasks_; // small tuple precomputed masks
+
+    struct SIMDTransposeDesc {
+        ui8 Cols = 0;
+        size_t RowOffset;
+    };
+    // [1, 2, 4, 8] bytes x [Key, Payload]
+    std::array<SIMDTransposeDesc, 8> SIMDTranspositions_;
+    static constexpr std::array<size_t, 4> SIMDTranspositionsColSizes_ = {1, 2,
+                                                                          4, 8};
+};
 
 bool TupleKeysEqual(const TTupleLayout *layout,
     const ui8 *lhsRow, const ui8 *lhsOverflow,

--- a/ydb/library/yql/utils/simd/simd_avx2.h
+++ b/ydb/library/yql/utils/simd/simd_avx2.h
@@ -111,7 +111,7 @@ struct TSimd8 {
     }
 
     static Y_FORCE_INLINE TSimd8<T> LoadStream(const T values[32]) {
-        return _mm256_stream_load_si256(reinterpret_cast<__m256i *>(values));
+        return _mm256_stream_load_si256(reinterpret_cast<const __m256i *>(values));
     }
 
     Y_FORCE_INLINE void Store(T dst[32]) const {
@@ -127,7 +127,7 @@ struct TSimd8 {
     }
 
     Y_FORCE_INLINE void StoreMasked(void* dst, const TSimd8<T>& mask) const {
-        _mm_maskmoveu_si128(_mm256_castsi256_si128(this->Value), _mm256_castsi256_si128(mask.Value), (char*) dst);
+        _mm_maskmoveu_si128(_mm256_castsi256_si128(this->Value), _mm256_castsi256_si128(mask.Value), dst);
         _mm_maskmoveu_si128(_mm256_extracti128_si256(this->Value, 1), _mm256_extracti128_si256(mask.Value, 1), (char*) dst);
     }
 
@@ -283,6 +283,43 @@ struct TSimd8 {
             return Shuffle(TSimd8<T>(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15,
                                      A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31));
         }
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo8(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpacklo_epi8(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi8(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpackhi_epi8(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo16(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpacklo_epi16(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi16(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpackhi_epi16(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo32(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpacklo_epi32(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi32(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpackhi_epi32(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo64(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpacklo_epi64(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi64(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_unpackhi_epi64(lhs.Value, rhs.Value);
+    }
+
+    template <int N>
+    static Y_FORCE_INLINE TSimd8<T> PermuteLanes(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm256_permute2x128_si256(lhs.Value, rhs.Value, N);
     }
 
     static Y_FORCE_INLINE TSimd8<T> Repeat16(

--- a/ydb/library/yql/utils/simd/simd_fallback.h
+++ b/ydb/library/yql/utils/simd/simd_fallback.h
@@ -158,7 +158,21 @@ struct TBase8: TBase<TSimd8<T>> {
     }
 
     friend inline Mask operator==(const TSimd8<T> lhs, const TSimd8<T> rhs) {
-        return lhs.Value == rhs.Value;
+        ui64 diff = lhs.Value ^ rhs.Value;
+        ui64 result = 0;
+
+        #define ComparisonResultByte(i) ((diff >> (i * 8)) & 0xFF) ? 0 : 0x80ULL << (i * 8);
+        result |= ComparisonResultByte(0);
+        result |= ComparisonResultByte(1);
+        result |= ComparisonResultByte(2);
+        result |= ComparisonResultByte(3);
+        result |= ComparisonResultByte(4);
+        result |= ComparisonResultByte(5);
+        result |= ComparisonResultByte(6);
+        result |= ComparisonResultByte(7);
+        #undef ComparisonResultByte
+        
+        return result;
     }
 
     static const int SIZE = sizeof(TBase<T>::Value);

--- a/ydb/library/yql/utils/simd/simd_fallback.h
+++ b/ydb/library/yql/utils/simd/simd_fallback.h
@@ -161,7 +161,7 @@ struct TBase8: TBase<TSimd8<T>> {
         ui64 diff = lhs.Value ^ rhs.Value;
         ui64 result = 0;
 
-        #define ComparisonResultByte(i) ((diff >> (i * 8)) & 0xFF) ? 0 : 0x80ULL << (i * 8);
+        #define ComparisonResultByte(i) ((diff >> (i * 8)) & 0xFF) ? 0 : 0xFFULL << (i * 8);
         result |= ComparisonResultByte(0);
         result |= ComparisonResultByte(1);
         result |= ComparisonResultByte(2);

--- a/ydb/library/yql/utils/simd/simd_sse42.h
+++ b/ydb/library/yql/utils/simd/simd_sse42.h
@@ -107,8 +107,8 @@ struct TSimd8 {
         return _mm_load_si128(reinterpret_cast<const __m128i *>(values));
     }
 
-    static Y_FORCE_INLINE TSimd8<T> LoadStream(T dst[16]) {
-        return _mm_stream_load_si128(reinterpret_cast<__m128i *>(dst));
+    static Y_FORCE_INLINE TSimd8<T> LoadStream(const T values[16]) {
+        return _mm_stream_load_si128(reinterpret_cast<const __m128i *>(values));
     }
 
     Y_FORCE_INLINE void Store(T dst[16]) const {
@@ -124,7 +124,7 @@ struct TSimd8 {
     }
 
     Y_FORCE_INLINE void StoreMasked(void* dst, const TSimd8<T>& mask) const {
-        _mm_maskmoveu_si128(this->Value, mask.Value, (char*)dst);
+        _mm_maskmoveu_si128(this->Value, mask.Value, dst);
     }
 
     template<bool CanBeNegative = true>
@@ -198,6 +198,38 @@ struct TSimd8 {
     template<int N>
     Y_FORCE_INLINE TSimd8<T> Rotate() const {
         return Rotate128<N>();
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo8(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpacklo_epi8(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi8(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpackhi_epi8(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo16(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpacklo_epi16(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi16(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpackhi_epi16(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo32(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpacklo_epi32(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi32(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpackhi_epi32(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneLo64(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpacklo_epi64(lhs.Value, rhs.Value);
+    }
+
+    static Y_FORCE_INLINE TSimd8<T> UnpackLaneHi64(const TSimd8<T>& lhs, const TSimd8<T>& rhs) {
+        return _mm_unpackhi_epi64(lhs.Value, rhs.Value);
     }
 
     static Y_FORCE_INLINE TSimd8<T> Repeat16(


### PR DESCRIPTION
### Changelog entry

Add SIMD-based implementation of TTupleLayout interface.

### Changelog category

* Experimental feature

### Description for reviewers

This PR represents an improved implementation using vector instructions.

Main changes:
- Add SIMD-based AoS <-> SoA formats conversion for AVX2 and SSE42
- Fix some issues in SIMD library
