### PR TITLE
[YDB Topics] Enable compaction by key by default in 25.2

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -210,7 +210,7 @@ message TFeatureFlags {
     optional bool EnableCSSchemasCollapsing = 192 [default = false];
     optional bool EnableMoveColumnTable = 193 [default = true];
     optional bool EnableCSOverloadsSubscriptionRetries = 195 [default = false];
-    optional bool EnableTopicCompactificationByKey = 196 [default = false];
+    optional bool EnableTopicCompactificationByKey = 196 [default = true];
     optional bool EnableCompactionOverloadDetection = 197 [default = true];
     reserved 198; // DisableColumnShardBulkUpsertRequireAllColumns
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Enables EnableTopicCompactificationByKey feature flag by default

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
