### PR TITLE
Fix huge blob scrubbing logic

### DIFF
--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_impl.h
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_impl.h
@@ -154,6 +154,10 @@ namespace NKikimr {
         // DEEP SCRUBBING
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+        std::vector<std::tuple<TLogoBlobID, bool>> CheckIntegrityPending;
+
+        void EnqueueCheckIntegrity(const TLogoBlobID& blobId, bool isHuge);
+        void CheckIntegrity();
         void CheckIntegrity(const TLogoBlobID& blobId, bool isHuge);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_sst.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_sst.cpp
@@ -180,28 +180,24 @@ namespace NKikimr {
                 }
                 pendingBlobs.clear();
             };
-            if (ScrubCtx->EnableDeepScrubbing) {
-                for (TBlobOnDisk *blob : blobs) {
-                    CheckIntegrity(blob->Id, false);
-                    UpdateReadableParts(blob->Id, blob->Local);
+            for (TBlobOnDisk *blob : blobs) {
+                if (ScrubCtx->EnableDeepScrubbing) {
+                    EnqueueCheckIntegrity(blob->Id, false);
                 }
-            } else {
-                for (TBlobOnDisk *blob : blobs) {
-                    const TDiskPart& part = blob->Part;
-                    const ui32 end = part.Offset + part.Size;
-                    Y_VERIFY_S(part.ChunkIdx == chunkIdx, LogPrefix);
-                    if (interval == TDiskPart()) {
-                        interval = blob->Part;
-                    } else if (end - interval.Offset <= ScrubCtx->PDiskCtx->Dsk->ReadBlockSize) {
-                        interval.Size = end - interval.Offset;
-                    } else {
-                        doCheck();
-                        interval = blob->Part;
-                    }
-                    pendingBlobs.push_back(blob);
+                const TDiskPart& part = blob->Part;
+                const ui32 end = part.Offset + part.Size;
+                Y_VERIFY_S(part.ChunkIdx == chunkIdx, LogPrefix);
+                if (interval == TDiskPart()) {
+                    interval = blob->Part;
+                } else if (end - interval.Offset <= ScrubCtx->PDiskCtx->Dsk->ReadBlockSize) {
+                    interval.Size = end - interval.Offset;
+                } else {
+                    doCheck();
+                    interval = blob->Part;
                 }
-                doCheck();
+                pendingBlobs.push_back(blob);
             }
+            doCheck();
         }
 
         if (blobsToCheck.empty()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix huge blob scrubbing logic

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes scrubbing logic bug leading to a skipped scrubbed huge blob. Also it moves CheckIntegrity out of the snapshot processing logic, preventing log cutting stall.
