### PR TITLE
Fix huge blob scrubbing logic

### DIFF
--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_huge.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_huge.cpp
@@ -14,7 +14,7 @@ namespace NKikimr {
                 (Id, id));
             heapIt.Seek(id);
             if (heapIt.Valid() && heapIt.GetCurKey() == id) {
-                heapIt.Prev();
+                heapIt.Prev(); // skip already processed blob
             }
         } else {
             STLOGX(GetActorContext(), PRI_INFO, BS_VDISK_SCRUB, VDS20, VDISKP(LogPrefix, "starting huge blob scrubbing"));
@@ -33,31 +33,31 @@ namespace NKikimr {
         THugeBlobAndIndexMerger merger(LogPrefix, Info->Type, readHugeBlob, this);
 
         const TInstant startTime = TActorCoroImpl::Now();
-        if (heapIt.Valid()) {
-            auto callback = [&] (TKeyLogoBlob key, auto* merger) -> bool {
-                auto status = essence->Keep(key, merger->GetMemRec(), {}, Snap->HullCtx->AllowKeepFlags,
-                    true /*allowGarbageCollection*/);
-                const TLogoBlobID& id = key.LogoBlobID();
-                if (status.KeepData) {
-                    if (ScrubCtx->EnableDeepScrubbing) {
-                        CheckIntegrity(id, true);
-                    } else {
-                        const NMatrix::TVectorType needed = merger->GetPartsToRestore();
-                        UpdateUnreadableParts(id, needed, merger->GetCorruptedPart());
-                        if (!needed.Empty()) {
-                            Checkpoints |= TEvScrubNotify::HUGE_BLOB_SCRUBBED;
-                        }
-                    }
-                } else {
-                    DropGarbageBlob(id);
+        bool timeout = false;
+        heapIt.Walk(std::nullopt, &merger, [&](TKeyLogoBlob key, auto *merger) -> bool {
+            const auto status = essence->Keep(key, merger->GetMemRec(), {}, Snap->HullCtx->AllowKeepFlags,
+                true /*allowGarbageCollection*/);
+            const TLogoBlobID& id = key.LogoBlobID();
+            LogoBlobIDFromLogoBlobID(id, State->MutableBlobId()); // remember last processed blob
+            if (status.KeepData) {
+                if (ScrubCtx->EnableDeepScrubbing) {
+                    EnqueueCheckIntegrity(id, true);
                 }
-                return TActorCoroImpl::Now() < startTime + TDuration::Seconds(5);
-            };
-            heapIt.Walk(std::nullopt, &merger, callback);
-        }
-        if (heapIt.Valid()) {
-            LogoBlobIDFromLogoBlobID(heapIt.GetCurKey().LogoBlobID(), State->MutableBlobId());
-        } else {
+                const NMatrix::TVectorType needed = merger->GetPartsToRestore();
+                UpdateUnreadableParts(id, needed, merger->GetCorruptedPart());
+                if (!needed.Empty()) {
+                    Checkpoints |= TEvScrubNotify::HUGE_BLOB_SCRUBBED;
+                }
+            } else {
+                DropGarbageBlob(id);
+            }
+            if (TActorCoroImpl::Now() < startTime + TDuration::Seconds(5)) {
+                return true;
+            }
+            timeout = true;
+            return false;
+        });
+        if (!timeout) { // we have finished walking without premature exit, so we have processed all the blobs
             State->ClearBlobId();
         }
     }

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_impl.h
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_impl.h
@@ -155,6 +155,10 @@ namespace NKikimr {
         // DEEP SCRUBBING
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+        std::vector<std::tuple<TLogoBlobID, bool>> CheckIntegrityPending;
+
+        void EnqueueCheckIntegrity(const TLogoBlobID& blobId, bool isHuge);
+        void CheckIntegrity();
         void CheckIntegrity(const TLogoBlobID& blobId, bool isHuge);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_sst.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_sst.cpp
@@ -180,28 +180,24 @@ namespace NKikimr {
                 }
                 pendingBlobs.clear();
             };
-            if (ScrubCtx->EnableDeepScrubbing) {
-                for (TBlobOnDisk *blob : blobs) {
-                    CheckIntegrity(blob->Id, false);
-                    UpdateReadableParts(blob->Id, blob->Local);
+            for (TBlobOnDisk *blob : blobs) {
+                if (ScrubCtx->EnableDeepScrubbing) {
+                    EnqueueCheckIntegrity(blob->Id, false);
                 }
-            } else {
-                for (TBlobOnDisk *blob : blobs) {
-                    const TDiskPart& part = blob->Part;
-                    const ui32 end = part.Offset + part.Size;
-                    Y_VERIFY_S(part.ChunkIdx == chunkIdx, LogPrefix);
-                    if (interval == TDiskPart()) {
-                        interval = blob->Part;
-                    } else if (end - interval.Offset <= ScrubCtx->PDiskCtx->Dsk->ReadBlockSize) {
-                        interval.Size = end - interval.Offset;
-                    } else {
-                        doCheck();
-                        interval = blob->Part;
-                    }
-                    pendingBlobs.push_back(blob);
+                const TDiskPart& part = blob->Part;
+                const ui32 end = part.Offset + part.Size;
+                Y_VERIFY_S(part.ChunkIdx == chunkIdx, LogPrefix);
+                if (interval == TDiskPart()) {
+                    interval = blob->Part;
+                } else if (end - interval.Offset <= ScrubCtx->PDiskCtx->Dsk->ReadBlockSize) {
+                    interval.Size = end - interval.Offset;
+                } else {
+                    doCheck();
+                    interval = blob->Part;
                 }
-                doCheck();
+                pendingBlobs.push_back(blob);
             }
+            doCheck();
         }
 
         if (blobsToCheck.empty()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix huge blob scrubbing logic

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes scrubbing logic bug leading to a skipped scrubbed huge blob. Also it moves CheckIntegrity out of the snapshot processing logic, preventing log cutting stall.
