### PR TITLE
Make sure that index type is valid as soon as possible

### DIFF
--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -85,6 +85,10 @@ TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType type, const T
     return result;
 }
 
+TString InvalidIndexType(NKikimrSchemeOp::EIndexType type) {
+    return TStringBuilder() << "Invalid index type " << static_cast<int>(type);
+}
+
 bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType indexType, const TTableColumns& table, const TIndexColumns& index, TString& explain) {
     if (const auto* broken = IsContains(table.Keys, table.Columns)) {
         explain = TStringBuilder()

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -41,6 +41,8 @@ inline constexpr const char* ImplTable = "indexImplTable";
 bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index, TString& explain);
 TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index);
 
+TString InvalidIndexType(NKikimrSchemeOp::EIndexType type);
+
 std::span<const std::string_view> GetImplTables(NKikimrSchemeOp::EIndexType indexType, std::span<const TString> indexKeys);
 bool IsImplTable(std::string_view tableName);
 bool IsBuildImplTable(std::string_view tableName);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -57,7 +57,6 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Vector index support is disabled")};
             }
             break;
-        // no default section because proto2 enum can only have a valid value
     }
 
     const auto table = TPath::Resolve(op.GetTable(), context.SS);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -41,8 +41,6 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
     const auto& indexDesc = op.GetIndex();
 
     switch (indexDesc.GetType()) {
-        case NKikimrSchemeOp::EIndexTypeInvalid:
-            return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Invalid index type")};
         case NKikimrSchemeOp::EIndexTypeGlobal:
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
             // no feature flag, everything is fine
@@ -57,6 +55,8 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Vector index support is disabled")};
             }
             break;
+        default:
+            return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, InvalidIndexType(indexDesc.GetType()))};
     }
 
     const auto table = TPath::Resolve(op.GetTable(), context.SS);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -145,7 +145,6 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     return {CreateReject(nextId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Vector index support is disabled")};
                 }
                 break;
-            // no default section because proto2 enum can only have a valid value
         }
 
         bool uniformIndexTable = false;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -129,8 +129,6 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
         const auto& indexName = indexDescription.GetName();
         
         switch (indexDescription.GetType()) {
-            case NKikimrSchemeOp::EIndexTypeInvalid:
-                return {CreateReject(nextId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Invalid index type")};
             case NKikimrSchemeOp::EIndexTypeGlobal:
             case NKikimrSchemeOp::EIndexTypeGlobalAsync:
                 // no feature flag, everything is fine
@@ -145,6 +143,8 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     return {CreateReject(nextId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Vector index support is disabled")};
                 }
                 break;
+            default:
+                return {CreateReject(nextId, NKikimrScheme::EStatus::StatusPreconditionFailed, InvalidIndexType(indexDescription.GetType()))};
         }
 
         bool uniformIndexTable = false;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Make index types checks as soon as possible to prevent unsupported index from being handled (for example in `CommonCheck` or table manipulations)

Also I propose to delete 

```
const NKikimrSchemeOp::EIndexType indexType = indexDesc.HasType() 
    ? indexDesc.GetType() 
    : NKikimrSchemeOp::EIndexTypeGlobal;
```

logic, because it's hard to keep in mind that we should always consider empty index type as `EIndexTypeGlobal` (for example, also in `CommonCheck`).

Unknown values in proto2 are ignored, so we could create a global index by mistake, instead of rejecting a request with unknown enum value.

Hope that making index type mandatory won't break anything (but we can easily fix it later if needed by explicitly filling it in requests). Added a few SQL/SDK tests to make sure they still work when using a short form statements.

Move invalid index handle to `default` case for better readability.