### PR TITLE
Check file exists before reading it

### DIFF
--- a/ydb/library/pdisk_io/wcache.cpp
+++ b/ydb/library/pdisk_io/wcache.cpp
@@ -7,6 +7,7 @@
 #include <util/string/builder.h>
 #include <util/string/strip.h>
 #include <util/system/file.h>
+#include <util/system/fs.h>
 
 #ifdef _linux_
 #include <libgen.h>
@@ -670,6 +671,10 @@ static std::optional<TDriveData> GetSysfsDriveData(const TString &path, TStringS
 
 std::optional<TDriveData> GetDriveData(const TString &path, TStringStream *outDetails) {
     try {
+        if (!NFs::Exists(path)) {
+            *outDetails << "file not found";
+            return std::nullopt;
+        }
         TFile f(path, OpenExisting | RdOnly);
         TDriveData data;
         if (off64_t off = lseek64(f.GetHandle(), 0, SEEK_END); off != (off64_t)-1) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`TFile f(path, OpenExisting | RdOnly)` throws if a file doesn't exits.

That makes debug with `stop on all exceptions` hard, because it often stops here.

Safe check right before resolves this issue.