### PR TITLE
Analytics: fix creating gist

### DIFF
--- a/.github/scripts/create_or_update_pr.py
+++ b/.github/scripts/create_or_update_pr.py
@@ -12,6 +12,7 @@ def read_body_from_file(file_path):
 def create_gist_for_large_content(content, github_token, title="PR Body Content"):
     """Creates a GitHub gist for large content and returns the gist URL."""
     from github import Github
+    from github.InputFileContent import InputFileContent
     
     g = Github(github_token)
     
@@ -19,9 +20,7 @@ def create_gist_for_large_content(content, github_token, title="PR Body Content"
     gist = g.get_user().create_gist(
         public=False,
         files={
-            f"{title}.md": {
-                "content": content
-            }
+            f"{title}.md": InputFileContent(content)
         },
         description=f"Large content for {title}"
     )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR fixes a bug in the GitHub gist creation functionality by properly using the PyGithub library's `InputFileContent` class instead of a raw dictionary structure.

- Adds the missing import for `InputFileContent` from the PyGithub library
- Updates the gist file creation to use the proper `InputFileContent` object instead of a dictionary with a "content" key



### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
