### PR TITLE
25-2-1: Don't allow SetActivityType after actor registration

### DIFF
--- a/ydb/core/client/server/msgbus_server_pq_metarequest_ut.cpp
+++ b/ydb/core/client/server/msgbus_server_pq_metarequest_ut.cpp
@@ -393,7 +393,7 @@ protected:
         for (const TActorId& actorId : TestActors) {
             IActor* actor = Runtime->FindActor(actorId);
             if (actor != nullptr) {
-                const bool isPipe = actor->ActivityType == NKikimrServices::TActivity::TABLET_PIPE_CLIENT;
+                const bool isPipe = actor->GetActivityType() == NKikimrServices::TActivity::TABLET_PIPE_CLIENT;
                 if (isPipe) {
                     UNIT_ASSERT_C(IsIn(destroyedActors, actorId),
                                   "Pipe client was not destroyed after test actor worked. Pipe client actor id: " << actorId);

--- a/ydb/core/keyvalue/keyvalue_flat_impl.h
+++ b/ydb/core/keyvalue/keyvalue_flat_impl.h
@@ -378,7 +378,6 @@ protected:
     }
 
     void Enqueue(STFUNC_SIG) override {
-        SetActivityType(NKikimrServices::TActivity::KEYVALUE_ACTOR);
         ALOG_DEBUG(NKikimrServices::KEYVALUE,
                 "KeyValue# " << TabletID()
                 << " Enqueue, event type# " << (ui32)ev->GetTypeRewrite()
@@ -544,10 +543,6 @@ protected:
         ctx.Send(Tablet(), new TEvents::TEvPoisonPill);
     }
 
-    void RestoreActorActivity() {
-        SetActivityType(NKikimrServices::TActivity::KEYVALUE_ACTOR);
-    }
-
     void Handle(TEvKeyValue::TEvCleanUpDataRequest::TPtr &ev) {
         ALOG_DEBUG(NKikimrServices::KEYVALUE, "KeyValue# " << TabletID()
                 << " Handle TEvCleanUpDataRequest " << ev->Get()->ToString());
@@ -616,7 +611,6 @@ public:
     }
 
     STFUNC(StateInit) {
-        RestoreActorActivity();
         ALOG_DEBUG(NKikimrServices::KEYVALUE, "KeyValue# " << TabletID()
                 << " StateInit flat event type# " << (ui32)ev->GetTypeRewrite()
                 << " event# " << ev->ToString());
@@ -626,7 +620,6 @@ public:
     STFUNC(StateWork) {
         if (HandleHook(ev))
             return;
-        RestoreActorActivity();
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvKeyValue::TEvRead, Handle);
             hFunc(TEvKeyValue::TEvReadRange, Handle);
@@ -657,7 +650,6 @@ public:
     }
 
     STFUNC(StateBroken) {
-        RestoreActorActivity();
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvTablet::TEvTabletDead, HandleTabletDead)
 

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -3160,6 +3160,9 @@ TPersQueue::TPersQueue(const TActorId& tablet, TTabletStorageInfo *info)
     , NextResponseCookie(0)
     , ResourceMetrics(nullptr)
 {
+    // Override to persqueue activity type
+    SetActivityType(ActorActivityType());
+
     InitPipeClientCache();
 
     typedef TProtobufTabletCounters<
@@ -5527,7 +5530,6 @@ void TPersQueue::ProcessPendingEvents()
 
 bool TPersQueue::HandleHook(STFUNC_SIG)
 {
-    SetActivityType(NKikimrServices::TActivity::PERSQUEUE_ACTOR);
     TRACE_EVENT(NKikimrServices::PERSQUEUE);
     switch(ev->GetTypeRewrite())
     {

--- a/ydb/core/test_tablet/test_shard_impl.h
+++ b/ydb/core/test_tablet/test_shard_impl.h
@@ -36,6 +36,8 @@ namespace NKikimr::NTestShard {
         TTestShard(const TActorId& tablet, TTabletStorageInfo *info)
             : TKeyValueFlat(tablet, info)
         {
+            SetActivityType(ActorActivityType());
+
             using TKeyValueCounters = TProtobufTabletCounters<
                 NKeyValue::ESimpleCounters_descriptor,
                 NKeyValue::ECumulativeCounters_descriptor,
@@ -62,7 +64,6 @@ namespace NKikimr::NTestShard {
         }
 
         bool HandleHook(STFUNC_SIG) override {
-            SetActivityType(NKikimrServices::TActivity::TEST_SHARD_ACTOR);
             switch (ev->GetTypeRewrite()) {
                 HFunc(TEvControlRequest, Handle);
                 HFunc(TEvSwitchMode, Handle);

--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -294,6 +294,11 @@ namespace NActors {
         }
     }
 
+    void IActor::SetActivityType(TActorActivityType activityType) {
+        Y_DEBUG_ABORT_UNLESS(!SelfActorId, "Cannot change activity type for registered actors");
+        ActivityType = activityType;
+    }
+
     template bool TExecutorThread::Send<ESendingType::Common>(TAutoPtr<IEventHandle> ev);
     template bool TExecutorThread::Send<ESendingType::Lazy>(TAutoPtr<IEventHandle> ev);
     template bool TExecutorThread::Send<ESendingType::Tail>(TAutoPtr<IEventHandle> ev);

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -436,6 +436,8 @@ namespace NActors {
         /// @sa services.proto NKikimrServices::TActivity::EType
         using EActorActivity = EInternalActorType;
         using EActivityType = EActorActivity;
+
+    private:
         TActorActivityType ActivityType;
 
     protected:
@@ -515,17 +517,15 @@ namespace NActors {
         virtual void PassAway();
 
     protected:
-        void SetActivityType(TActorActivityType activityType) {
-            ActivityType = activityType;
-        }
+        void SetActivityType(TActorActivityType activityType);
 
         template <typename EEnum>
         void SetActivityType(EEnum activityType) requires (std::is_enum_v<EEnum>) {
-            ActivityType = TActorActivityType::FromEnum(activityType);
+            SetActivityType(TActorActivityType::FromEnum(activityType));
         }
 
         void SetActivityType(TStringBuf activityName) {
-            ActivityType = TActorActivityType::FromName(activityName);
+            SetActivityType(TActorActivityType::FromName(activityName));
         }
 
     public:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Changing actor activity type after registration is unsafe, since during registration it is used for counter increments, and when actor is destroyed it is used for decrements. Changing activity type after registration makes some counters unexpectedly negative. Moreover, current uses are incorrect, since calling SetActivityType in an event handler doesn't affect the current event, and may cause the next event to be attributed to the wrong activity as well.