### PR TITLE
Eliminate GroupSizeInUnits from serialization if unset

### DIFF
--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -1051,7 +1051,9 @@ namespace NKikimr::NBsController {
             pb->SetKind(pool.Kind);
             pb->SetNumGroups(pool.NumGroups);
             pb->SetRandomizeGroupMapping(pool.RandomizeGroupMapping);
-            pb->SetDefaultGroupSizeInUnits(pool.DefaultGroupSizeInUnits);
+            if (pool.DefaultGroupSizeInUnits != 0) {
+                pb->SetDefaultGroupSizeInUnits(pool.DefaultGroupSizeInUnits);
+            }
 
             for (const auto &userId : pool.UserIds) {
                 pb->AddUserId(std::get<2>(userId));
@@ -1101,7 +1103,9 @@ namespace NKikimr::NBsController {
             pb->SetLastSeenSerial(pdisk.LastSeenSerial);
             pb->SetReadOnly(pdisk.Mood == TPDiskMood::ReadOnly);
             pb->SetMaintenanceStatus(pdisk.MaintenanceStatus);
-            pb->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
+            if (pdisk.InferPDiskSlotCountFromUnitSize) {
+                pb->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
+            }
         }
 
         void TBlobStorageController::Serialize(NKikimrBlobStorage::TVSlotId *pb, TVSlotId id) {
@@ -1158,7 +1162,9 @@ namespace NKikimr::NBsController {
             pb->SetBoxId(std::get<0>(group.StoragePoolId));
             pb->SetStoragePoolId(std::get<1>(group.StoragePoolId));
             pb->SetSeenOperational(group.SeenOperational);
-            pb->SetGroupSizeInUnits(group.GroupSizeInUnits);
+            if (group.GroupSizeInUnits != 0) {
+                pb->SetGroupSizeInUnits(group.GroupSizeInUnits);
+            }
 
             const auto& status = group.GetStatus(finder, bridgeInfo);
             pb->SetOperatingStatus(status.OperatingStatus);
@@ -1167,7 +1173,7 @@ namespace NKikimr::NBsController {
             if (group.BridgeGroupInfo) {
                 pb->SetIsProxyGroup(true);
             }
-            
+
             if (group.DecommitStatus != NKikimrBlobStorage::TGroupDecommitStatus::NONE || group.VirtualGroupState) {
                 auto *vgi = pb->MutableVirtualGroupInfo();
                 if (group.VirtualGroupState) {
@@ -1291,7 +1297,9 @@ namespace NKikimr::NBsController {
                 group->SetDecommitStatus(groupInfo.DecommitStatus);
             }
 
-            group->SetGroupSizeInUnits(groupInfo.GroupSizeInUnits);
+            if (groupInfo.GroupSizeInUnits != 0) {
+                group->SetGroupSizeInUnits(groupInfo.GroupSizeInUnits);
+            }
 
             if (groupInfo.BridgeGroupInfo) {
                 group->MergeFrom(*groupInfo.BridgeGroupInfo);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes compatibility. It's necessary to avoid producing GroupInfo protobuf with a new field with GroupGeneration unchanged. StoragePool.DefaultGroupSizeInUnits and PDisk.InferSlotCountFromUnitSize are changed as well to avoid new fields in QueryBaseConfig with the same ItemConfigGenetration 