### PR TITLE
Unpoison trace id to prevent false msan alert (merge from main #24282)

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -38,6 +38,7 @@ namespace NActors {
 #endif
         };
         traceId.Serialize(&descr.TraceId);
+        NSan::Unpoison(&descr.TraceId, sizeof(descr.TraceId));
 
         // and channel header before the descriptor
         TChannelPart part{


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Unpoison trace id to prevent false msan alert

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes false-positive #21513
