### PR TITLE
EXT-1486 Heartbeat setting for audit logging

### DIFF
--- a/ydb/core/audit/audit_log.h
+++ b/ydb/core/audit/audit_log.h
@@ -22,7 +22,7 @@
 #define AUDIT_PART_NO_COND(key, value) AUDIT_PART_COND(key, value, true)
 #define AUDIT_PART_COND(key, value, condition)                                                                                    \
     do {                                                                                                                          \
-        if (condition && !value.empty()) {                                                                                        \
+        if (condition && !TStringBuf(value).empty()) {                                                                            \
             auditParts.emplace_back(key, value);                                                                                  \
         }                                                                                                                         \
     } while (0);

--- a/ydb/core/audit/audit_log_impl.cpp
+++ b/ydb/core/audit/audit_log_impl.cpp
@@ -214,10 +214,10 @@ void SendAuditLog(const NActors::TActorSystem* sys, TAuditLogParts&& parts)
 // Service interface implementation
 //
 
-THolder<NActors::IActor> CreateAuditWriter(TAuditLogBackends&& logBackends)
+std::unique_ptr<NActors::IActor> CreateAuditWriter(TAuditLogBackends&& logBackends)
 {
     AUDIT_LOG_ENABLED.store(true);
-    return MakeHolder<TAuditLogActor>(std::move(logBackends));
+    return std::make_unique<TAuditLogActor>(std::move(logBackends));
 }
 
 static void EscapeNonUtf8(TString& s) {

--- a/ydb/core/audit/audit_log_service.h
+++ b/ydb/core/audit/audit_log_service.h
@@ -5,6 +5,8 @@
 #include <ydb/library/actors/core/actorid.h>
 #include <ydb/core/protos/config.pb.h>
 
+#include <memory>
+
 class TLogBackend;
 
 namespace NActors {
@@ -19,6 +21,6 @@ inline NActors::TActorId MakeAuditServiceID() {
 
 using TAuditLogBackends = TMap<NKikimrConfig::TAuditConfig::EFormat, TVector<THolder<TLogBackend>>>;
 
-THolder<NActors::IActor> CreateAuditWriter(TAuditLogBackends&& logBackends);
+std::unique_ptr<NActors::IActor> CreateAuditWriter(TAuditLogBackends&& logBackends);
 
 }   // namespace NKikimr::NAudit

--- a/ydb/core/audit/audit_log_service_ut.cpp
+++ b/ydb/core/audit/audit_log_service_ut.cpp
@@ -176,7 +176,7 @@ Y_UNIT_TEST_SUITE(AuditLogHeartbeatTest) {
 
         auto waitAndCheckLog = [&]() {
             const TString log = test.WaitAuditLog();
-            UNIT_ASSERT_STRING_CONTAINS(log, "component=audit, subject=metadata@system, operation=HEARTBEAT");
+            UNIT_ASSERT_STRING_CONTAINS(log, "component=audit, subject=metadata@system, sanitized_token={none}, operation=HEARTBEAT, status=SUCCESS");
         };
 
         waitAndCheckLog();

--- a/ydb/core/audit/heartbeat_actor/heartbeat_actor.cpp
+++ b/ydb/core/audit/heartbeat_actor/heartbeat_actor.cpp
@@ -31,6 +31,8 @@ public:
         Become(&THeartbeatActor::StateFunc);
         if (HeartbeatInterval) {
             PerformHeartbeat();
+        } else {
+            PassAway();
         }
     }
 

--- a/ydb/core/audit/heartbeat_actor/heartbeat_actor.cpp
+++ b/ydb/core/audit/heartbeat_actor/heartbeat_actor.cpp
@@ -27,7 +27,9 @@ public:
         AUDIT_LOG(
             AUDIT_PART("component", "audit")
             AUDIT_PART("subject", "metadata@system")
+            AUDIT_PART("sanitized_token", "{none}")
             AUDIT_PART("operation", "HEARTBEAT")
+            AUDIT_PART("status", "SUCCESS")
         );
     }
 

--- a/ydb/core/audit/heartbeat_actor/heartbeat_actor.h
+++ b/ydb/core/audit/heartbeat_actor/heartbeat_actor.h
@@ -10,6 +10,8 @@ class IActor;
 
 namespace NKikimr::NAudit {
 
-std::unique_ptr<NActors::IActor> CreateHeartbeatActor(TDuration heartbeatInterval);
+class TAuditConfig;
+
+std::unique_ptr<NActors::IActor> CreateHeartbeatActor(const TAuditConfig& auditConfig);
 
 }   // namespace NKikimr::NAudit

--- a/ydb/core/audit/heartbeat_actor/heartbeat_actor.h
+++ b/ydb/core/audit/heartbeat_actor/heartbeat_actor.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <util/datetime/base.h>
+
+#include <memory>
+
+namespace NActors {
+class IActor;
+}
+
+namespace NKikimr::NAudit {
+
+std::unique_ptr<NActors::IActor> CreateHeartbeatActor(TDuration heartbeatInterval);
+
+}   // namespace NKikimr::NAudit

--- a/ydb/core/audit/heartbeat_actor/ya.make
+++ b/ydb/core/audit/heartbeat_actor/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+SRCS(
+    heartbeat_actor.cpp
+)
+
+PEERDIR(
+    ydb/core/audit
+    ydb/library/actors/core
+)
+
+END()

--- a/ydb/core/audit/ut/ya.make
+++ b/ydb/core/audit/ut/ya.make
@@ -2,6 +2,7 @@ UNITTEST_FOR(ydb/core/audit)
 
 PEERDIR(
     ydb/library/actors/testlib
+    ydb/core/audit/heartbeat_actor
 )
 
 SRCS(

--- a/ydb/core/audit/ya.make
+++ b/ydb/core/audit/ya.make
@@ -18,6 +18,7 @@ END()
 
 RECURSE(
     audit_config
+    heartbeat_actor
 )
 
 RECURSE_FOR_TESTS(

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -2866,7 +2866,7 @@ void TAuditWriterInitializer::InitializeServices(TActorSystemSetup* setup, const
         NAudit::MakeAuditServiceID(),
         TActorSetupCmd(std::move(actor), TMailboxType::HTSwap, appData->IOPoolId));
 
-    if (appData->AuditConfig.HasHeartbeat()) {
+    if (appData->AuditConfig.GetHeartbeat().GetIntervalSeconds()) {
         auto heartbeatActor = NAudit::CreateHeartbeatActor(appData->AuditConfig);
         setup->LocalServices.emplace_back(
             NActors::TActorId(), // We don't need external communication with this actor

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -2866,8 +2866,8 @@ void TAuditWriterInitializer::InitializeServices(TActorSystemSetup* setup, const
         NAudit::MakeAuditServiceID(),
         TActorSetupCmd(std::move(actor), TMailboxType::HTSwap, appData->IOPoolId));
 
-    if (appData->AuditConfig.GetHeartbeatIntervalSeconds()) {
-        auto heartbeatActor = NAudit::CreateHeartbeatActor(TDuration::Seconds(appData->AuditConfig.GetHeartbeatIntervalSeconds()));
+    if (appData->AuditConfig.HasHeartbeat()) {
+        auto heartbeatActor = NAudit::CreateHeartbeatActor(appData->AuditConfig);
         setup->LocalServices.emplace_back(
             NActors::TActorId(), // We don't need external communication with this actor
             TActorSetupCmd(std::move(heartbeatActor), TMailboxType::HTSwap, appData->UserPoolId));

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -6,7 +6,9 @@
 
 #include <ydb/core/actorlib_impl/destruct_actor.h>
 
-#include "ydb/core/audit/audit_log_service.h"
+#include <ydb/core/audit/audit_log_service.h>
+#include <ydb/core/audit/audit_config/audit_config.h>
+#include <ydb/core/audit/heartbeat_actor/heartbeat_actor.h>
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/config_units.h>
@@ -2860,9 +2862,16 @@ void TAuditWriterInitializer::InitializeServices(TActorSystemSetup* setup, const
 
     auto actor = NAudit::CreateAuditWriter(std::move(logBackends));
 
-    setup->LocalServices.push_back(std::pair<TActorId, TActorSetupCmd>(
+    setup->LocalServices.emplace_back(
         NAudit::MakeAuditServiceID(),
-        TActorSetupCmd(actor.Release(), TMailboxType::HTSwap, appData->IOPoolId)));
+        TActorSetupCmd(std::move(actor), TMailboxType::HTSwap, appData->IOPoolId));
+
+    if (appData->AuditConfig.GetHeartbeatIntervalSeconds()) {
+        auto heartbeatActor = NAudit::CreateHeartbeatActor(TDuration::Seconds(appData->AuditConfig.GetHeartbeatIntervalSeconds()));
+        setup->LocalServices.emplace_back(
+            NActors::TActorId(), // We don't need external communication with this actor
+            TActorSetupCmd(std::move(heartbeatActor), TMailboxType::HTSwap, appData->UserPoolId));
+    }
 }
 
 TSchemeBoardMonitoringInitializer::TSchemeBoardMonitoringInitializer(const TKikimrRunConfig &runConfig)

--- a/ydb/core/driver_lib/run/ya.make
+++ b/ydb/core/driver_lib/run/ya.make
@@ -38,6 +38,7 @@ PEERDIR(
     ydb/core/actorlib_impl
     ydb/core/audit
     ydb/core/audit/audit_config
+    ydb/core/audit/heartbeat_actor
     ydb/core/backup/controller
     ydb/core/base
     ydb/core/blob_depot

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1851,6 +1851,7 @@ message TAuditConfig {
             Operations = 7; // Operations API. See ydb/public/api/grpc/ydb_operation_v1.proto
             ExportImport = 8;
             Acl = 9;
+            AuditHeartbeat = 10;
             Default = 1000; // For default settings for all other nonconfigured log classes
         }
 
@@ -1872,11 +1873,20 @@ message TAuditConfig {
         repeated ELogPhase LogPhase = 4; // The phases of requests execution where audit log records are written
     }
 
+    // Settings for heartbeat audit messages
+    // Heartbeat messages are messages that are written in
+    // a time interval that is set up in this config.
+    // Audit messages are written from AuditHeartbeat log class
+    // and Anonymous account type and also can be set up using its setting
+    message THeartbeatSettings {
+        optional uint32 IntervalSeconds = 5; // Make heartbeat records to audit log every HeartbeatInterval seconds. 0 means that heartbeat is disabled
+    }
+
     optional TStderrBackend StderrBackend = 1;
     optional TFileBackend FileBackend = 2;
     optional TUnifiedAgentBackend UnifiedAgentBackend = 3;
     repeated TLogClassConfig LogClassConfig = 4;
-    optional uint32 HeartbeatIntervalSeconds = 5; // Make heartbeat records to audit log every HeartbeatInterval seconds. 0 means that heartbeat is disabled
+    optional THeartbeatSettings Heartbeat = 5;
 };
 
 message THiveTabletLimit {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1876,6 +1876,7 @@ message TAuditConfig {
     optional TFileBackend FileBackend = 2;
     optional TUnifiedAgentBackend UnifiedAgentBackend = 3;
     repeated TLogClassConfig LogClassConfig = 4;
+    optional uint32 HeartbeatIntervalSeconds = 5; // Make heartbeat records to audit log every HeartbeatInterval seconds. 0 means that heartbeat is disabled
 };
 
 message THiveTabletLimit {

--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -126,7 +126,7 @@ namespace NActors {
             AddLocalService(
                 NKikimr::NAudit::MakeAuditServiceID(),
                 TActorSetupCmd(
-                    NKikimr::NAudit::CreateAuditWriter(std::move(AuditLogBackends)).Release(),
+                    NKikimr::NAudit::CreateAuditWriter(std::move(AuditLogBackends)),
                     TMailboxType::HTSwap,
                     0
                 ),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

We need to know if something goes wrong with audit events process - for example, if someone (occasionally or on their purpose) disabled audit logging. At the same time, it can be normal that for some cluster there are no records for a long time. With this setting we can setup alerts on audit and not to get false positive on them.