### PR TITLE
Check src stage to be WideChannel-enabled for block propagation

### DIFF
--- a/ydb/core/kqp/opt/peephole/kqp_opt_peephole.cpp
+++ b/ydb/core/kqp/opt/peephole/kqp_opt_peephole.cpp
@@ -299,7 +299,6 @@ bool IsCompatibleWithBlocks(TPositionHandle pos, const TStructExprType& type, TE
 bool CanPropagateWideBlockThroughChannel(
     const TDqOutput& output,
     const THashMap<ui64, TKqpProgram>& programs,
-    const TDqStageSettings& stageSettings,
     TExprContext& ctx,
     TTypeAnnotationContext& typesCtx)
 {
@@ -310,6 +309,8 @@ bool CanPropagateWideBlockThroughChannel(
         // stage has multiple outputs
         return false;
     }
+
+    auto stageSettings = TDqStageSettings::Parse(output.Stage());
 
     if (!stageSettings.WideChannels) {
         return false;
@@ -380,7 +381,7 @@ TMaybeNode<TKqpPhysicalTx> PeepholeOptimize(const TKqpPhysicalTx& tx, TExprConte
                 newArgs.emplace_back(newArg);
 
                 if (auto connection = stage.Inputs().Item(i).Maybe<TDqConnection>(); scalarHashShuffleCount <= 1 && connection &&
-                    CanPropagateWideBlockThroughChannel(connection.Cast().Output(), programs, TDqStageSettings::Parse(stage), ctx, typesCtx))
+                    CanPropagateWideBlockThroughChannel(connection.Cast().Output(), programs, ctx, typesCtx))
                 {
                     TExprNode::TPtr newArgNode = ctx.Builder(oldArg.Pos())
                         .Callable("WideFromBlocks")

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -1150,7 +1150,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
         auto tableClient = kikimr.GetTableClient();
 
-        // TODO: Add support for DqPhyPrecompute push-down: Cast((2+2) as Uint64) 
+        // TODO: Add support for DqPhyPrecompute push-down: Cast((2+2) as Uint64)
         // - this is not needed because constant folding eliminates this now
         std::vector<TString> testData = {
             R"(`resource_id` = `uid`)",
@@ -1489,7 +1489,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         auto session = queryClient.GetSession().GetValueSync().GetSession();
         {
             const auto res = session.ExecuteQuery(R"(
-                INSERT INTO `/Root/foo` (id, str, u_str) VALUES 
+                INSERT INTO `/Root/foo` (id, str, u_str) VALUES
                     (1, "hello", "hello")
             )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
             UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues());
@@ -1543,7 +1543,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
             const auto& query = TString(R"(
                 PRAGMA OptimizeSimpleILike;
                 PRAGMA AnsiLike;
-                SELECT id FROM `/Root/foo` WHERE 
+                SELECT id FROM `/Root/foo` WHERE
                 )") + predicates[i];
             Cerr
                 << "QUERY " << i << Endl
@@ -1838,7 +1838,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
                 ts64    Timestamp64,
                 --inter  Interval, -- NOT SUPPORTED?
                 inter64  Interval64,
-                primary key(id)	
+                primary key(id)
             )
             PARTITION BY HASH(id)
             WITH (STORE = COLUMN);
@@ -1846,12 +1846,12 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         UNIT_ASSERT(res.IsSuccess());
 
         auto insertRes = session2.ExecuteQuery(R"(
-            INSERT INTO `/Root/foo` (id, dt, dt32, dtm, dtm64, ts, ts64, inter64) 
-            VALUES (1, 
-                CAST('1998-12-01' AS Date), 
-                CAST('1998-12-01' AS Date32), 
-                CAST('1998-12-01' AS DateTime), 
-                CAST('1998-12-01' AS DateTime64), 
+            INSERT INTO `/Root/foo` (id, dt, dt32, dtm, dtm64, ts, ts64, inter64)
+            VALUES (1,
+                CAST('1998-12-01' AS Date),
+                CAST('1998-12-01' AS Date32),
+                CAST('1998-12-01' AS DateTime),
+                CAST('1998-12-01' AS DateTime64),
                 CAST('1998-12-01' AS Timestamp),
                 CAST('1998-12-01' AS Timestamp64),
                 CAST('1D' AS Interval64));
@@ -1862,26 +1862,26 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
             // TPC-H Datetime predicates. Commented out predicates currently fail, need to be fixed
             // TPCH Q1:
             R"(CAST(dt AS Timestamp) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
-            R"(CAST(dt AS Timestamp64) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))", 
+            R"(CAST(dt AS Timestamp64) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
 
-            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))", 
-            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date32) - Interval("P100D")))", 
-            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))", 
-            R"(CAST(dt32 AS Timestamp64) <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))", 
+            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
+            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date32) - Interval("P100D")))",
+            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))",
+            R"(CAST(dt32 AS Timestamp64) <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))",
 
             // TPCH Q6:
             R"(cast(dt as Timestamp) < (Date("1995-01-01") + Interval("P365D")))",
 
             // Other tests:
 
-            R"(dt <= (CAST('1998-12-01' AS Date) - Interval("P100D")))", 
-            R"(dt32 <= (CAST('1998-12-01' AS Date) - Interval("P100D")))", 
-            R"(dt <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))", 
+            R"(dt <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
+            R"(dt32 <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
+            R"(dt <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))",
 
             R"(CAST(dt as Timestamp) <= dt - inter64)",
             R"(CAST(dt as Timestamp64) <= dt - inter64)",
             R"(CAST(dt as Timestamp64) <= dt32 - inter64)",
-            R"(dt <= dt - inter64)", 
+            R"(dt <= dt - inter64)",
             R"(dt32 <= dt - inter64)",
             R"(CAST(dt32 as Date) <= dt - inter64)",
             R"(dt <= dt - CAST(inter64 as Interval))",
@@ -1968,7 +1968,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
             TString plan = *result.GetStats()->GetPlan();
             auto ast = *result.GetStats()->GetAst();
-    
+
             UNIT_ASSERT_C(ast.find("KqpOlapFilter") != std::string::npos,
                               TStringBuilder() << "Predicate not pushed down. Query: " << query);
             //if (ast.find("KqpOlapFilter") != std::string::npos) {
@@ -2083,7 +2083,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
                 ts64    Timestamp64,
                 --inter  Interval, -- NOT SUPPORTED?
                 inter64  Interval64,
-                primary key(id)	
+                primary key(id)
             )
             PARTITION BY HASH(id)
             WITH (STORE = COLUMN);
@@ -2091,42 +2091,42 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         UNIT_ASSERT(res.IsSuccess());
 
         auto insertRes = queryClient.ExecuteQuery(R"(
-            INSERT INTO `/Root/foo` (id, dt, dt32, dtm, dtm64, ts, ts64, inter64) 
-            VALUES (1, 
-                CAST('1998-12-01' AS Date), 
-                CAST('1998-12-01' AS Date32), 
-                CAST('1998-12-01' AS DateTime), 
-                CAST('1998-12-01' AS DateTime64), 
+            INSERT INTO `/Root/foo` (id, dt, dt32, dtm, dtm64, ts, ts64, inter64)
+            VALUES (1,
+                CAST('1998-12-01' AS Date),
+                CAST('1998-12-01' AS Date32),
+                CAST('1998-12-01' AS DateTime),
+                CAST('1998-12-01' AS DateTime64),
                 CAST('1998-12-01' AS Timestamp),
                 CAST('1998-12-01' AS Timestamp64),
                 CAST('1D' AS Interval64));
             )", NYdb::NQuery::TTxControl::NoTx(), NYdb::NQuery::TExecuteQuerySettings()).GetValueSync();
-        UNIT_ASSERT(insertRes.IsSuccess());    
-        
+        UNIT_ASSERT(insertRes.IsSuccess());
+
         std::vector<TString> testData = {
             // TPC-H Datetime predicates. Commented out predicates currently fail, need to be fixed
             // TPCH Q1:
             R"(CAST(dt AS Timestamp) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
-            R"(CAST(dt AS Timestamp64) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))", 
+            R"(CAST(dt AS Timestamp64) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
 
-            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))", 
-            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date32) - Interval("P100D")))", 
-            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))", 
-            R"(CAST(dt32 AS Timestamp64) <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))", 
+            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
+            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date32) - Interval("P100D")))",
+            R"(CAST(dt32 AS Timestamp) <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))",
+            R"(CAST(dt32 AS Timestamp64) <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))",
 
             // TPCH Q6:
             R"(cast(dt as Timestamp) < (Date("1995-01-01") + Interval("P365D")))",
 
             // Other tests:
 
-            R"(dt <= (CAST('1998-12-01' AS Date) - Interval("P100D")))", 
-            R"(dt32 <= (CAST('1998-12-01' AS Date) - Interval("P100D")))", 
-            R"(dt <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))", 
+            R"(dt <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
+            R"(dt32 <= (CAST('1998-12-01' AS Date) - Interval("P100D")))",
+            R"(dt <= (CAST('1998-12-01' AS Date32) - Interval64("P100D")))",
 
             R"(CAST(dt as Timestamp) <= dt - inter64)",
             R"(CAST(dt as Timestamp64) <= dt - inter64)",
             R"(CAST(dt as Timestamp64) <= dt32 - inter64)",
-            R"(dt <= dt - inter64)", 
+            R"(dt <= dt - inter64)",
             R"(dt32 <= dt - inter64)",
             R"(CAST(dt32 as Date) <= dt - inter64)",
             R"(dt <= dt - CAST(inter64 as Interval))",
@@ -2151,7 +2151,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
             auto result = CollectStreamResult(it);
             auto ast = result.QueryStats->Getquery_ast();
-    
+
             UNIT_ASSERT_C(ast.find("KqpOlapFilter") != std::string::npos,
                               TStringBuilder() << "Predicate not pushed down. Query: " << query);
 
@@ -3451,19 +3451,21 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
         auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
 
-        const TString query = R"(
-            CREATE TABLE `/Root/ColumnShard` (
-                a Uint64 NOT NULL,
-                b Int32,
-                c Int64,
-                PRIMARY KEY (a)
-            )
-            PARTITION BY HASH(a)
-            WITH (STORE = COLUMN, PARTITION_COUNT = 4);
-        )";
+        {
+            const TString query = R"(
+                CREATE TABLE `/Root/ColumnShard` (
+                    a Uint64 NOT NULL,
+                    b Int32,
+                    c Int64,
+                    PRIMARY KEY (a)
+                )
+                PARTITION BY HASH(a)
+                WITH (STORE = COLUMN, PARTITION_COUNT = 4);
+            )";
 
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
 
         auto client = kikimr.GetQueryClient();
         {
@@ -3522,60 +3524,67 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         }
 
         {
+            const TString query = R"(
+                CREATE TABLE `/Root/ColumnIsHard` (
+                    a Uint64 NOT NULL,
+                    b Int32,
+                    c Int64,
+                    PRIMARY KEY (a)
+                )
+                PARTITION BY HASH(a)
+                WITH (STORE = COLUMN, PARTITION_COUNT = 4);
+            )";
+
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto prepareResult = client.ExecuteQuery(R"(
+                REPLACE INTO `/Root/ColumnIsHard` (a, b, c) VALUES
+                    (1u, 1, 5),
+                    (2u, 2, 5),
+                    (3u, 2, 0),
+                    (4u, 2, 5);
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT(prepareResult.IsSuccess());;
+        }
+
+        {
             NYdb::NQuery::TExecuteQuerySettings scanSettings;
             scanSettings.ExecMode(NYdb::NQuery::EExecMode::Explain);
             auto it = client.StreamExecuteQuery(R"(
-                PRAGMA ydb.CostBasedOptimizationLevel='0';
+                PRAGMA ydb.OptimizerHints =
+                '
+                    JoinType(T1 T2 Shuffle)
+                ';
 
-                $select1 = (
-                    SELECT b AS a1, COUNT(*) AS b1, SUM(a) AS c1
-                    FROM `/Root/ColumnShard`
-                    WHERE c = 5
-                    GROUP BY b
-                );
-
-                $select2 = (
-                    SELECT (b1 + 1ul) AS a2, COUNT(*) AS b2, SUM(a1) AS c2
-                    FROM $select1
-                    WHERE c1 = 5
-                    GROUP BY b1
-                );
-
-                $select3 = (
-                    SELECT b1 AS a3, COUNT(*) AS b3, MAX(a1) AS c3
-                    FROM $select1
-                    WHERE b1 = 6
-                    GROUP BY b1
-                );
-
-                SELECT a2, b2
-                FROM $select2 AS table2
-                JOIN $select3 AS table3
-                ON table2.a2 = table3.a3
-                ORDER BY b2
-                LIMIT 10
+                SELECT *
+                    FROM (SELECT Just(a) as a FROM `/Root/ColumnShard`) as T1
+                    LEFT JOIN `/Root/ColumnIsHard` as T2
+                    ON T1.a = T2.a
                 ;
 
             )", NYdb::NQuery::TTxControl::BeginTx().CommitTx(), scanSettings).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
             auto plan = CollectStreamResult(it);
 
-            // auto CountSubstr = [](const TString& str, const TString& sub) -> ui64 {
-            //     ui64 count = 0;
-            //     for (auto pos = str.find(sub); pos != TString::npos; pos = str.find(sub, pos + sub.size())) {
-            //         ++count;
-            //     }
-            //     return count;
-            // };
+            auto CountSubstr = [](const TString& str, const TString& sub) -> ui64 {
+                ui64 count = 0;
+                for (auto pos = str.find(sub); pos != TString::npos; pos = str.find(sub, pos + sub.size())) {
+                    ++count;
+                }
+                return count;
+            };
 
             switch (blockChannelsMode) {
                 case NKikimrConfig::TTableServiceConfig_EBlockChannelsMode_BLOCK_CHANNELS_SCALAR:
                     // TODO: implement checks?
                     break;
                 case NKikimrConfig::TTableServiceConfig_EBlockChannelsMode_BLOCK_CHANNELS_AUTO:
-                    // TODO: test fails because of some stages don't get wide channels.
-                    // UNIT_ASSERT_EQUAL_C(CountSubstr(plan.QueryStats->Getquery_ast(), "WideFromBlocks"), 2, plan.QueryStats->Getquery_ast());
-                    // UNIT_ASSERT_C(!plan.QueryStats->Getquery_ast().Contains("WideToBlocks"), plan.QueryStats->Getquery_ast());
+                    UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("(GraceJoinCore (ToFlow (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    UNIT_ASSERT_EQUAL_C(CountSubstr(plan.QueryStats->Getquery_ast(), "(ToFlow (WideFromBlocks"), 2, plan.QueryStats->Getquery_ast());
+                    UNIT_ASSERT_C(!plan.QueryStats->Getquery_ast().Contains("WideToBlocks"), plan.QueryStats->Getquery_ast());
                     break;
                 case NKikimrConfig::TTableServiceConfig_EBlockChannelsMode_BLOCK_CHANNELS_FORCE:
                     // TODO: implement checks?
@@ -4089,8 +4098,8 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
             auto result = queryClient
                               .ExecuteQuery(R"(
                     CREATE TABLE `/Root/arrow/columns` (
-                        hash Utf8 NOT NULL, 
-                        length Int32 NOT NULL, 
+                        hash Utf8 NOT NULL,
+                        length Int32 NOT NULL,
                         PRIMARY KEY(hash)
                     )
                     WITH (STORE = COLUMN)
@@ -4181,7 +4190,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         auto settings = TKikimrSettings().SetWithSampleTables(false);
         settings.AppConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
         settings.AppConfig.MutableColumnShardConfig()->SetAllowNullableColumnsInPK(true);
-        
+
         TTestHelper testHelper(settings);
 
         TVector<TTestHelper::TColumnSchema> schema = {
@@ -4492,7 +4501,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
                 CREATE TABLE `/Root/query_stat` (
                     ts      Timestamp NOT NULL,
                     folder_id String,
-                    primary key(ts)	
+                    primary key(ts)
                 )
                 PARTITION BY HASH(ts)
                 WITH (STORE = COLUMN);
@@ -4502,7 +4511,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
         {
             auto result = querySession.ExecuteQuery(R"(
-                    INSERT INTO `/Root/query_stat` (ts, folder_id) 
+                    INSERT INTO `/Root/query_stat` (ts, folder_id)
                     VALUES (
                         CurrentUtcTimestamp(),
                         "abc"
@@ -4513,12 +4522,12 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
         {
             auto result = querySession.ExecuteQuery(R"(
-                    SELECT 
+                    SELECT
                         ts1, count(*)
-                    FROM 
-                        query_stat 
-                    where 
-                        folder_id not in [ "b1g0gammoel2iuh0hir6" ] 
+                    FROM
+                        query_stat
+                    where
+                        folder_id not in [ "b1g0gammoel2iuh0hir6" ]
                     GROUP BY DateTime::MakeDatetime(DateTime::StartOf(ts, DateTime::IntervalFromDays(1))) as ts1
                 )", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
* Not for changelog (changelog entry is not required)
### Description for reviewers <!-- (optional) description for those who read this PR -->

After this change queires like this propagate blocks channels correctly

```sql
PRAGMA ydb.OptimizerHints = 
'
    JoinType(region nation Shuffle)
';

select * from
(
    select Just(r_regionkey) as r_regionkey, r_name from region 
) as region 
left join nation on region.r_regionkey = nation.n_regionkey
```

Before:

<img width="597" height="422" alt="image" src="https://github.com/user-attachments/assets/d5319239-8543-4803-a05c-386c3dd52a29" />

After:

<img width="598" height="422" alt="image" src="https://github.com/user-attachments/assets/3c28d83a-0d90-4bff-be4f-fb1e6789f466" />


...
