### PR TITLE
Add disable version checks command info on error while getting version

### DIFF
--- a/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
+++ b/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
@@ -207,7 +207,8 @@ bool TYdbUpdater::GetLatestVersion() {
         SetConfigValue("last_check", TInstant::Now().Seconds());
         return true;
     }
-    Cerr << "(!) Couldn't get latest version from url \"" << versionUrl << "\". " << curlCmd.GetError() << Endl;
+    Cerr << "(!) Couldn't get latest version from url \"" << versionUrl << "\". " << curlCmd.GetError() << Endl
+        << "You can disable further version checks with 'ydb version --disable-checks' command." << Endl;
     return false;
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

To make errors like this more informative:
```
$ ydb config profile list 
(!) Couldn't get latest version from url "https://storage.yandexcloud.net/yandexcloud-ydb/release/stable".
```
