### PR TITLE
Make NOT_SYNCHRONIZED_1 internal state treated as DISCONNECTED

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_bridge.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_bridge.cpp
@@ -191,10 +191,10 @@ namespace NKikimr::NStorage {
                         } else {
                             switch (clusterState.GetPerPileState(pileId.GetPileIndex())) {
                                 case NKikimrBridge::TClusterState::DISCONNECTED:
+                                case NKikimrBridge::TClusterState::NOT_SYNCHRONIZED_1:
                                     state = T::DISCONNECTED;
                                     break;
 
-                                case NKikimrBridge::TClusterState::NOT_SYNCHRONIZED_1:
                                 case NKikimrBridge::TClusterState::NOT_SYNCHRONIZED_2:
                                     state = T::NOT_SYNCHRONIZED;
                                     break;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make NOT\_SYNCHRONIZED\_1 internal state treated as DISCONNECTED

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes a bug when state storage and boards treat NOT\_SYNCHRONIZED\_1 state as NOT\_SYNCHRONIZED thus leading to impossibility to work then only part of unsynced pile is available.
