### PR TITLE
Fix ydb update timeout

### DIFF
--- a/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
+++ b/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
@@ -86,7 +86,7 @@ int TYdbUpdater::Update(bool forceUpdate) {
     const TString downloadUrl = TStringBuilder() << StorageUrl << '/' << LatestVersion << '/' << osVersion
         << '/' << osArch << '/' << binaryName;
     Cout << "Downloading binary from url " << downloadUrl << Endl;
-    TShellCommand curlCmd(TStringBuilder() << "curl --max-time 60 " << downloadUrl << " -o " << tmpPathToBinary.GetPath());
+    TShellCommand curlCmd(TStringBuilder() << "curl --connect-timeout 60 " << downloadUrl << " -o " << tmpPathToBinary.GetPath());
     curlCmd.Run().Wait();
     if (curlCmd.GetExitCode() != 0) {
         Cerr << "Failed to download from url \"" << downloadUrl << "\". " << curlCmd.GetError() << Endl;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This timeout was added to prevent infinite update in some cases. But now there is another problem: users with slow internet connection can not download the binary within 60sec timeout.
The correct solution should probably be to set timeout on connection, not on downloading time.
