### PR TITLE
Use self-hosted runner for check-running-allowed

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   check-running-allowed:
     if: ${{vars.CHECKS_SWITCH != '' && fromJSON(vars.CHECKS_SWITCH).pr_check == true}}
-    runs-on: [self-hosted, auto-provisioned, build-preset-analytic-node]
+    runs-on: [self-hosted, auto-provisioned, tiny-worker]
     timeout-minutes: 600
     outputs:
       result: ${{ steps.check-ownership-membership.outputs.result == 'true' && steps.check-is-mergeable.outputs.result == 'true' }}

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   check-running-allowed:
     if: ${{vars.CHECKS_SWITCH != '' && fromJSON(vars.CHECKS_SWITCH).pr_check == true}}
-    runs-on: [self-hosted, auto-provisioned, tiny-worker]
+    runs-on: [self-hosted, tiny-worker]
     timeout-minutes: 600
     outputs:
       result: ${{ steps.check-ownership-membership.outputs.result == 'true' && steps.check-is-mergeable.outputs.result == 'true' }}

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   check-running-allowed:
     if: ${{vars.CHECKS_SWITCH != '' && fromJSON(vars.CHECKS_SWITCH).pr_check == true}}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, auto-provisioned, build-preset-analytic-node]
     timeout-minutes: 600
     outputs:
       result: ${{ steps.check-ownership-membership.outputs.result == 'true' && steps.check-is-mergeable.outputs.result == 'true' }}


### PR DESCRIPTION
Because ubuntu-latest (not self-hosted) sometimes waits a lot in a queue

Check here: https://github.com/ydb-platform/ydb/pull/24385