### PR TITLE
Option `init-seqno-timeout`

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -1006,6 +1006,7 @@ namespace NYdb::NConsoleClient {
             .StoreResult(&MessageGroupId_);
         config.Opts->AddLongOption("init-seqno-timeout", "Max wait duration for initial seqno")
             .Optional()
+            .Hidden()
             .StoreResult(&MessagesWaitTimeoutSeconds_);
 
         AddTransform(config);

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -1007,7 +1007,7 @@ namespace NYdb::NConsoleClient {
         config.Opts->AddLongOption("init-seqno-timeout", "Max wait duration for initial seqno")
             .Optional()
             .Hidden()
-            .StoreResult(&MessagesWaitTimeoutSeconds_);
+            .Handler([this](const TString& arg) { MessagesWaitTimeout_ = TDuration::Seconds(FromString<ui8>(arg)); });
 
         AddTransform(config);
     }
@@ -1053,13 +1053,6 @@ namespace NYdb::NConsoleClient {
         return settings;
     }
 
-    TMaybe<TDuration> TCommandTopicWrite::GetMessagesWaitTimeout() const {
-        if (MessagesWaitTimeoutSeconds_.Defined()) {
-            return TDuration::Seconds(*MessagesWaitTimeoutSeconds_);
-        }
-        return Nothing();
-    }
-
     int TCommandTopicWrite::Run(TConfig& config) {
         SetInterruptHandlers();
 
@@ -1072,7 +1065,7 @@ namespace NYdb::NConsoleClient {
             auto writer =
                 TTopicWriter(writeSession, std::move(TTopicWriterParams(MessagingFormat, Delimiter_, MessageSizeLimit_, BatchDuration_,
                                                                         BatchSize_, BatchMessagesCount_, GetTransform(),
-                                                                        GetMessagesWaitTimeout())));
+                                                                        MessagesWaitTimeout_)));
 
             if (int status = writer.Init(); status) {
                 return status;

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.h
@@ -258,7 +258,7 @@ namespace NYdb::NConsoleClient {
         TMaybe<ui64> BatchSize_;
         TMaybe<ui64> BatchMessagesCount_;
         TMaybe<TString> MessageGroupId_;
-        TMaybe<ui32> MessagesWaitTimeoutSeconds_;
+        TMaybe<TDuration> MessagesWaitTimeout_;
 
         ui64 MessageSizeLimit_ = 0;
         void ParseMessageSizeLimit();
@@ -266,6 +266,5 @@ namespace NYdb::NConsoleClient {
 
     private:
         NTopic::TWriteSessionSettings PrepareWriteSessionSettings();
-        TMaybe<TDuration> GetMessagesWaitTimeout() const;
     };
 } // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.h
@@ -258,6 +258,7 @@ namespace NYdb::NConsoleClient {
         TMaybe<ui64> BatchSize_;
         TMaybe<ui64> BatchMessagesCount_;
         TMaybe<TString> MessageGroupId_;
+        TMaybe<ui32> MessagesWaitTimeoutSeconds_;
 
         ui64 MessageSizeLimit_ = 0;
         void ParseMessageSizeLimit();
@@ -265,5 +266,6 @@ namespace NYdb::NConsoleClient {
 
     private:
         NTopic::TWriteSessionSettings PrepareWriteSessionSettings();
+        TMaybe<TDuration> GetMessagesWaitTimeout() const;
     };
 } // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/topic/topic_write.h
+++ b/ydb/public/lib/ydb_cli/topic/topic_write.h
@@ -18,7 +18,8 @@ namespace NYdb::NConsoleClient {
         TTopicWriterParams(EMessagingFormat inputFormat, TMaybe<TString> delimiter,
                            ui64 messageSizeLimit, TMaybe<TDuration> batchDuration,
                            TMaybe<ui64> batchSize, TMaybe<ui64> batchMessagesCount,
-                           ETransformBody transform);
+                           ETransformBody transform,
+                           TMaybe<TDuration> messagesWaitTimeout);
         TTopicWriterParams(const TTopicWriterParams&) = default;
         TTopicWriterParams(TTopicWriterParams&&) = default;
 
@@ -30,6 +31,7 @@ namespace NYdb::NConsoleClient {
         GETTER(EMessagingFormat, MessagingFormat);
         GETTER(NTopic::ECodec, Codec);
         GETTER(ETransformBody, Transform);
+        GETTER(TMaybe<TDuration>, MessagesWaitTimeout);
 
     private:
         TMaybe<TString> File_;
@@ -42,6 +44,7 @@ namespace NYdb::NConsoleClient {
         TMaybe<ui64> BatchMessagesCount_;
         NTopic::ECodec Codec_ = NTopic::ECodec::RAW;
         ETransformBody Transform_ = ETransformBody::None;
+        TMaybe<TDuration> MessagesWaitTimeout_;
 
         ui64 MessageSizeLimit_ = 0;
     };

--- a/ydb/public/lib/ydb_cli/topic/topic_write_ut.cpp
+++ b/ydb/public/lib/ydb_cli/topic/topic_write_ut.cpp
@@ -40,7 +40,7 @@ namespace NYdb::NConsoleClient {
 
         void TestEnterMessage_OnlyDelimiters() {
             TStringStream str = TString("\n") * 6;
-            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, "\n", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None));
+            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, "\n", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing()));
             TMessages got = EnterMessageHelper(wr, str);
             AssertMessagesEqual({
                                     {
@@ -101,7 +101,7 @@ namespace NYdb::NConsoleClient {
 
         void TestEnterMessage_1KiB_Newline_Delimiter() {
             TStringStream str = TString("a") * 512 + "\n" + TString("b") * 512;
-            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, "\n", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None));
+            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, "\n", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing()));
             TMessages got = EnterMessageHelper(wr, str);
             AssertMessagesEqual({
                                     {
@@ -126,7 +126,7 @@ namespace NYdb::NConsoleClient {
         void TestEnterMessage_1KiB_Newline_Delimited_With_Two_Delimiters_In_A_Row() {
             TStringStream str = TString("a") * 512 + "\n\n" + TString("b") * 512;
             TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::NewlineDelimited, Nothing(), 0, Nothing(), Nothing(), Nothing(),
-                                                        ETransformBody::None));
+                                                        ETransformBody::None, Nothing()));
             TMessages got = EnterMessageHelper(wr, str);
             AssertMessagesEqual({
                                     {
@@ -170,7 +170,7 @@ namespace NYdb::NConsoleClient {
         void TestEnterMessage_ZeroSymbol_Delimited() {
             auto& s = "\0\0\0\0\n\nprivet";
             TStringStream str = TString(std::begin(s), std::end(s));
-            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, "\0", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None));
+            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, "\0", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing()));
             TMessages got = EnterMessageHelper(wr, str);
             AssertMessagesEqual({
                                     {
@@ -209,7 +209,7 @@ namespace NYdb::NConsoleClient {
 
         void TestEnterMessage_Custom_Delimiter_Delimited() {
             TStringStream str = TString("privet_vasya_kak_dela?");
-            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, "_", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None));
+            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, "_", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing()));
             TMessages got = EnterMessageHelper(wr, str);
             AssertMessagesEqual({
                                     {
@@ -243,7 +243,7 @@ namespace NYdb::NConsoleClient {
 
         void TestEnterMessage_No_Base64_Transform() {
             TStringStream str = TString("privet_vasya_kak_dela?");
-            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::None));
+            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing()));
             TMessages got = EnterMessageHelper(wr, str);
 
             AssertMessagesEqual({
@@ -257,13 +257,13 @@ namespace NYdb::NConsoleClient {
 
         void TestEnterMessage_With_Base64_Transform_Invalid_Encode() {
             TStringStream str = TString("cHJpdmV0X3Zhc3lhX2tha19kZWxPw==");
-            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::Base64));
+            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::Base64, Nothing()));
             UNIT_ASSERT_EXCEPTION(EnterMessageHelper(wr, str), yexception);
         }
 
         void TestEnterMessage_With_Base64_Transform() {
             TStringStream str = TString("cHJpdmV0X3Zhc3lhX2tha19kZWxhPw==");
-            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::Base64));
+            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::SingleMessage, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::Base64, Nothing()));
             TMessages got = EnterMessageHelper(wr, str);
 
             AssertMessagesEqual(
@@ -279,7 +279,7 @@ namespace NYdb::NConsoleClient {
 
         void TestEnterMessage_With_Base64_Transform_NewlineDelimited() {
             TStringStream str = TString("aG93IGRvIHlvdSBkbw==\ncHJpdmV0X3Zhc3lhX2tha19kZWxhPw==");
-            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::NewlineDelimited, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::Base64));
+            TTopicWriter wr(nullptr, TTopicWriterParams(EMessagingFormat::NewlineDelimited, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::Base64, Nothing()));
             TMessages got = EnterMessageHelper(wr, str);
 
             AssertMessagesEqual(
@@ -304,25 +304,25 @@ namespace NYdb::NConsoleClient {
         }
 
         void TestTopicWriterParams_Format_NewlineDelimited() {
-            TTopicWriterParams p = TTopicWriterParams(EMessagingFormat::NewlineDelimited, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::None);
+            TTopicWriterParams p = TTopicWriterParams(EMessagingFormat::NewlineDelimited, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing());
             UNIT_ASSERT_VALUES_EQUAL(p.MessagingFormat(), EMessagingFormat::NewlineDelimited);
             UNIT_ASSERT_VALUES_EQUAL(p.Delimiter(), '\n');
         }
 
         void TestTopicWriterParams_Format_Concatenated() {
-            TTopicWriterParams p = TTopicWriterParams(EMessagingFormat::Concatenated, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::None);
+            TTopicWriterParams p = TTopicWriterParams(EMessagingFormat::Concatenated, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing());
             UNIT_ASSERT_VALUES_EQUAL(p.MessagingFormat(), EMessagingFormat::Concatenated);
             UNIT_ASSERT_VALUES_EQUAL(p.Delimiter(), '\n');
         }
 
         void TestTopicWriterParams_No_Delimiter() {
-            TTopicWriterParams p = TTopicWriterParams(EMessagingFormat::SingleMessage, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::None);
+            TTopicWriterParams p = TTopicWriterParams(EMessagingFormat::SingleMessage, Nothing(), 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing());
             UNIT_ASSERT_VALUES_EQUAL(p.MessagingFormat(), EMessagingFormat::SingleMessage);
             UNIT_ASSERT_VALUES_EQUAL(p.Delimiter(), Nothing());
         }
 
         void TestTopicWriterParams_InvalidDelimiter() {
-            UNIT_ASSERT_EXCEPTION(TTopicWriterParams(EMessagingFormat::SingleMessage, "invalid", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None), yexception);
+            UNIT_ASSERT_EXCEPTION(TTopicWriterParams(EMessagingFormat::SingleMessage, "invalid", 0, Nothing(), Nothing(), Nothing(), ETransformBody::None, Nothing()), yexception);
         }
 
     private:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The program waits initial seqno for 1 second. Sometimes it's not enough.

- Wait 5 seconds by default.
- Hidden option `init-seqno-timeout` for waiting time.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
