### PR TITLE
Enabled by default EnableSystemViews flag in all tests and deprecated it

### DIFF
--- a/ydb/core/base/generated/runtime_feature_flags_ut.cpp
+++ b/ydb/core/base/generated/runtime_feature_flags_ut.cpp
@@ -16,7 +16,6 @@ Y_UNIT_TEST_SUITE(RuntimeFeatureFlags) {
         NKikimrConfig::TFeatureFlags proto;
 
         // Check some known defaults (both true and false)
-        CHECK_FLAG_MATCHES(flags, proto, EnableSystemViews);
         CHECK_FLAG_MATCHES(flags, proto, TrimEntireDeviceOnStartup);
         CHECK_FLAG_MATCHES(flags, proto, EnableFailureInjectionTermination);
     }

--- a/ydb/core/client/flat_ut.cpp
+++ b/ydb/core/client/flat_ut.cpp
@@ -926,7 +926,7 @@ Y_UNIT_TEST_SUITE(TFlatTest) {
     Y_UNIT_TEST(Ls) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port).SetEnableSystemViews(false));
+        TServer cleverServer = TServer(TServerSettings(port).SetEnableRealSystemViewPaths(true));
 
         TFlatMsgBusClient annoyingClient(port);
         annoyingClient.InitRoot();
@@ -937,20 +937,20 @@ Y_UNIT_TEST_SUITE(TFlatTest) {
         TestLsUknownPath(annoyingClient, "//");
 
         TestLsSuccess(annoyingClient, "/", {"dc-1"});
-        TestLsSuccess(annoyingClient, "/dc-1", {});
+        TestLsSuccess(annoyingClient, "/dc-1", {".sys"});
         TestLsUknownPath(annoyingClient, "/dc-11");
         TestLsUknownPath(annoyingClient, "/dc-2");
 
         annoyingClient.MkDir("/dc-1", "Berkanavt");
         TestLsSuccess(annoyingClient, "/", {"dc-1"});
-        TestLsSuccess(annoyingClient, "/dc-1", {"Berkanavt"});
+        TestLsSuccess(annoyingClient, "/dc-1", {".sys", "Berkanavt"});
         TestLsSuccess(annoyingClient, "/dc-1/Berkanavt", {});
         annoyingClient.MkDir("/dc-1", "Berkanavt");
-        TestLsSuccess(annoyingClient, "/dc-1", {"Berkanavt"});
+        TestLsSuccess(annoyingClient, "/dc-1", {".sys", "Berkanavt"});
 
         TestLsUknownPath(annoyingClient, "/dc-1/arcadia");
         annoyingClient.MkDir("/dc-1", "arcadia");
-        TestLsSuccess(annoyingClient, "/dc-1", {"Berkanavt", "arcadia"});
+        TestLsSuccess(annoyingClient, "/dc-1", {".sys", "Berkanavt", "arcadia"});
         TestLsSuccess(annoyingClient, "/dc-1/arcadia", {});
     }
 
@@ -1019,7 +1019,7 @@ Y_UNIT_TEST_SUITE(TFlatTest) {
     Y_UNIT_TEST(PathSorting) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port).SetEnableSystemViews(false));
+        TServer cleverServer = TServer(TServerSettings(port).SetEnableRealSystemViewPaths(true));
 
         TFlatMsgBusClient annoyingClient(port);
 
@@ -1030,7 +1030,7 @@ Y_UNIT_TEST_SUITE(TFlatTest) {
         annoyingClient.MkDir("/dc-1", "Dir4");
         annoyingClient.MkDir("/dc-1", "Dir2");
         annoyingClient.MkDir("/dc-1", "A");
-        TestLsSuccess(annoyingClient, "/dc-1", {"A", "B", "Dir1", "Dir2", "Dir3", "Dir4"});
+        TestLsSuccess(annoyingClient, "/dc-1", {".sys", "A", "B", "Dir1", "Dir2", "Dir3", "Dir4"});
     }
 
     void TestLsPathIdSuccess(TFlatMsgBusClient& annoyingClient, ui64 schemeshardId, ui64 pathId, const TString& selfName, const TVector<TString>& children) {
@@ -1065,7 +1065,7 @@ Y_UNIT_TEST_SUITE(TFlatTest) {
     Y_UNIT_TEST(LsPathId) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port).SetEnableSystemViews(false));
+        TServer cleverServer = TServer(TServerSettings(port));
 
         TFlatMsgBusClient annoyingClient(port);
 
@@ -1073,14 +1073,14 @@ Y_UNIT_TEST_SUITE(TFlatTest) {
         ui64 schemeshardId = res->Record.GetPathDescription().GetChildren(0).GetSchemeshardId();
 
         annoyingClient.InitRoot();
-        TestLsPathIdSuccess(annoyingClient, schemeshardId, 1, "dc-1", {});
+        TestLsPathIdSuccess(annoyingClient, schemeshardId, 1, "dc-1", {".sys"});
         TestLsUknownPathId(annoyingClient, schemeshardId, 2);
         annoyingClient.MkDir("/dc-1", "Berkanavt");
-        TestLsPathIdSuccess(annoyingClient, schemeshardId, 1, "dc-1", {"Berkanavt"});
+        TestLsPathIdSuccess(annoyingClient, schemeshardId, 1, "dc-1", {".sys", "Berkanavt"});
         TestLsPathIdSuccess(annoyingClient, schemeshardId, 2, "Berkanavt", {});
         TestLsUknownPathId(annoyingClient, schemeshardId, 3);
         annoyingClient.MkDir("/dc-1", "arcadia");
-        TestLsPathIdSuccess(annoyingClient, schemeshardId, 1, "dc-1", {"Berkanavt", "arcadia"});
+        TestLsPathIdSuccess(annoyingClient, schemeshardId, 1, "dc-1", {".sys", "Berkanavt", "arcadia"});
         TestLsPathIdSuccess(annoyingClient, schemeshardId, 3, "arcadia", {});
     }
 

--- a/ydb/core/cms/console/console__create_tenant.cpp
+++ b/ydb/core/cms/console/console__create_tenant.cpp
@@ -127,7 +127,7 @@ public:
 
         Tenant->IsExternalSubdomain = Self->FeatureFlags.GetEnableExternalSubdomains();
         Tenant->IsExternalHive = Self->FeatureFlags.GetEnableExternalHive();
-        Tenant->IsExternalSysViewProcessor = Self->FeatureFlags.GetEnableSystemViews();
+        Tenant->IsExternalSysViewProcessor = true;
         Tenant->IsExternalStatisticsAggregator = Self->FeatureFlags.GetEnableStatistics();
         Tenant->IsExternalBackupController = Self->FeatureFlags.GetEnableBackupService();
         Tenant->IsGraphShardEnabled = Self->FeatureFlags.GetEnableGraphShard();

--- a/ydb/core/kqp/session_actor/kqp_query_stats.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_stats.cpp
@@ -34,10 +34,6 @@ void CollectQueryStatsImpl(const TActorContext& ctx, const T* queryStats,
     const TString& userSID, ui64 parametersSize, const TString& database,
     const NKikimrKqp::EQueryType type, ui64 requestUnits)
 {
-    if (!AppData()->FeatureFlags.GetEnableSystemViews()) {
-        return;
-    }
-
     auto collectEv = MakeHolder<NSysView::TEvSysView::TEvCollectQueryStats>();
     collectEv->Database = database;
 

--- a/ydb/core/mind/bscontroller/sys_view.cpp
+++ b/ydb/core/mind/bscontroller/sys_view.cpp
@@ -464,10 +464,6 @@ void CopyInfo(TDstMap& dst, TDeletedSet& deleted, const TSrcMap& src, TChangedSe
 }
 
 void TBlobStorageController::UpdateSystemViews() {
-    if (!AppData()->FeatureFlags.GetEnableSystemViews()) {
-        return;
-    }
-
     const TMonotonic now = TActivationContext::Monotonic();
     const TDuration expiration = TDuration::Seconds(15);
     for (auto& [key, value] : VSlots) {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -34,7 +34,7 @@ message TFeatureFlags {
     optional bool AllowHugeKeyValueDeletes = 13 [default = true]; // delete when all clients limit deletes per request
     optional bool SendSchemaVersionToDatashard = 14 [default = true]; // deprecated: always true
     optional bool EnableSchemeBoardCache = 15 [default = true]; // deprecated: always true
-    optional bool EnableSystemViews = 16 [default = true, (RequireRestart) = true];
+    optional bool EnableSystemViews = 16 [default = true]; // deprecated: always true
     optional bool EnableExternalHive = 17 [default = true];
     optional bool UseSchemeBoardCacheForSchemeRequests = 18 [default = true]; // deprecated: always true
     optional bool CompileMinikqlWithVersion = 19 [default = true]; // deprecated: always true

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -18,7 +18,6 @@ public:
         }
 
     FEATURE_FLAG_SETTER(AllowYdbRequestsWithoutDatabase)
-    FEATURE_FLAG_SETTER(EnableSystemViews)
     FEATURE_FLAG_SETTER(EnablePersistentQueryStats)
     FEATURE_FLAG_SETTER(EnablePersistentPartitionStats)
     FEATURE_FLAG_SETTER(AllowUpdateChannelsBindingOfSolomonPartitions)

--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -2798,8 +2798,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 };
 
                 NSysView::ISystemViewResolver::TSystemViewPath sysViewPath;
-                if (AppData()->FeatureFlags.GetEnableSystemViews() &&
-                    SystemViewResolver->IsSystemViewPath(entry.Path, sysViewPath)) {
+                if (SystemViewResolver->IsSystemViewPath(entry.Path, sysViewPath)) {
                     auto& fallbackEntryInfo = context->EntriesFallbackInfo[i];
                     context->HasSysViewEntries = true;
                     if (fallbackEntryInfo.IsImplicit) {

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
@@ -430,16 +430,14 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
 
         Self->PersistTablePartitionCondErase(db, tableId, partitionIdx, tableInfo);
 
-        if (AppData(ctx)->FeatureFlags.GetEnableSystemViews()) {
-            StatsCollectorEv = MakeHolder<NSysView::TEvSysView::TEvUpdateTtlStats>(
-                Self->GetDomainKey(tableId), tableId, std::make_pair(ui64(shardIdx.GetOwnerId()), ui64(shardIdx.GetLocalId()))
-            );
+        StatsCollectorEv = MakeHolder<NSysView::TEvSysView::TEvUpdateTtlStats>(
+            Self->GetDomainKey(tableId), tableId, std::make_pair(ui64(shardIdx.GetOwnerId()), ui64(shardIdx.GetLocalId()))
+        );
 
-            auto& stats = StatsCollectorEv->Stats;
-            stats.SetLastRunTime(now.MilliSeconds());
-            stats.SetLastRowsProcessed(record.GetStats().GetRowsProcessed());
-            stats.SetLastRowsErased(record.GetStats().GetRowsErased());
-        }
+        auto& stats = StatsCollectorEv->Stats;
+        stats.SetLastRunTime(now.MilliSeconds());
+        stats.SetLastRowsProcessed(record.GetStats().GetRowsProcessed());
+        stats.SetLastRowsErased(record.GetStats().GetRowsErased());
 
         Y_ABORT_UNLESS(lag.Defined());
         Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -298,20 +298,18 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
     TPartitionStats newAggrStats;
     bool updateSubdomainInfo = false;
 
-    if (AppData(ctx)->FeatureFlags.GetEnableSystemViews()) {
-        TMaybe<ui32> nodeId;
-        if (rec.HasNodeId()) {
-            nodeId = rec.GetNodeId();
-        }
-        TMaybe<ui64> startTime;
-        if (rec.HasStartTime()) {
-            startTime = rec.GetStartTime();
-        }
-
-        PendingMessages.emplace_back(
-            Self->SysPartitionStatsCollector,
-            Self->BuildStatsForCollector(pathId, shardIdx, datashardId, followerId, nodeId, startTime, newStats, ctx).Release());
+    TMaybe<ui32> nodeId;
+    if (rec.HasNodeId()) {
+        nodeId = rec.GetNodeId();
     }
+    TMaybe<ui64> startTime;
+    if (rec.HasStartTime()) {
+        startTime = rec.GetStartTime();
+    }
+
+    PendingMessages.emplace_back(
+        Self->SysPartitionStatsCollector,
+        Self->BuildStatsForCollector(pathId, shardIdx, datashardId, followerId, nodeId, startTime, newStats, ctx).Release());
 
     // Skip statistics from follower
     if (followerId) {

--- a/ydb/core/tx/schemeshard/schemeshard_system_names.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_system_names.cpp
@@ -19,7 +19,6 @@ const TVector<TString> ReservedNames = {
     ".metadata",
 
     // Database has this place for the system views.
-    // (Feature flag EnableSystemViews manages it's use.)
     ".sys",
 
     // Database has this directory for keeping kqp-session bound temporary objects (tables etc)

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -582,7 +582,6 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     TAppPrepare app(dsExportFactory ? dsExportFactory : static_cast<std::shared_ptr<NKikimr::NDataShard::IExportFactory>>(std::make_shared<TDataShardExportFactory>()));
 
     app.SetEnableDataColumnForIndexTable(true);
-    app.SetEnableSystemViews(opts.EnableSystemViews_);
     app.SetEnablePersistentQueryStats(opts.EnablePersistentQueryStats_);
     app.SetEnablePersistentPartitionStats(opts.EnablePersistentPartitionStats_);
     app.SetAllowUpdateChannelsBindingOfSolomonPartitions(opts.AllowUpdateChannelsBindingOfSolomonPartitions_);

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -40,7 +40,6 @@ namespace NSchemeShardUT_Private {
         OPTION(bool, EnablePipeRetries, true);
         OPTION(bool, RunFakeConfigDispatcher, false);
         OPTION(bool, InitYdbDriver, false);
-        OPTION(std::optional<bool>, EnableSystemViews, std::nullopt);
         OPTION(std::optional<bool>, EnablePersistentQueryStats, std::nullopt);
         OPTION(std::optional<bool>, EnablePersistentPartitionStats, std::nullopt);
         OPTION(std::optional<bool>, AllowUpdateChannelsBindingOfSolomonPartitions, std::nullopt);

--- a/ydb/core/tx/tx_proxy/describe.cpp
+++ b/ydb/core/tx/tx_proxy/describe.cpp
@@ -450,8 +450,7 @@ void TDescribeReq::Handle(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult:
 
     TxProxyMon->NavigateLatency->Collect((ctx.Now() - WallClockStarted).MilliSeconds());
 
-    if (AppData()->FeatureFlags.GetEnableSystemViews() &&
-        ev->Get()->GetRecord().GetStatus() == NKikimrScheme::StatusSuccess) {
+    if (ev->Get()->GetRecord().GetStatus() == NKikimrScheme::StatusSuccess) {
         const auto& pathDescription = ev->Get()->GetRecord().GetPathDescription();
         const auto& self = pathDescription.GetSelf();
 

--- a/ydb/core/tx/tx_proxy/proxy_ext_tenant_ut.cpp
+++ b/ydb/core/tx/tx_proxy/proxy_ext_tenant_ut.cpp
@@ -230,7 +230,7 @@ void CreateTableInsideThenStopTenantAndForceDeleteSubDomain(TTestEnvWithPoolsSup
             NTestLs::IsUnavailable(ls);  // extsubdomain is not ready yet
 
             ls = env.GetClient().Ls("/dc-1");
-            NTestLs::ChildrenCount(ls, 1);
+            NTestLs::ChildrenCount(ls, 2);
             NTestLs::HasChild(ls, "USER_0", NKikimrSchemeOp::EPathTypeExtSubDomain);
         }
 
@@ -278,7 +278,7 @@ void CreateTableInsideThenStopTenantAndForceDeleteSubDomain(TTestEnvWithPoolsSup
 
 
             ls = env.GetClient().Ls("/dc-1");
-            NTestLs::ChildrenCount(ls, 1);
+            NTestLs::ChildrenCount(ls, 2);
             NTestLs::HasChild(ls, "USER_0", NKikimrSchemeOp::EPathTypeExtSubDomain);
         }
 
@@ -495,7 +495,7 @@ void CreateTableInsideAndAlterDomainAndTable(TTestEnvWithPoolsSupport& env) {
             NTestLs::IsUnavailable(ls);  // extsubdomain is not ready yet
 
             ls = env.GetClient().Ls("/dc-1");
-            NTestLs::ChildrenCount(ls, 1);
+            NTestLs::ChildrenCount(ls, 2);
             NTestLs::HasChild(ls, "USER_0", NKikimrSchemeOp::EPathTypeExtSubDomain);
         }
 

--- a/ydb/core/tx/tx_proxy/proxy_ut_helpers.h
+++ b/ydb/core/tx/tx_proxy/proxy_ut_helpers.h
@@ -218,7 +218,6 @@ public:
         GetSettings().SetNodeCount(staticNodes);
         GetSettings().SetDynamicNodeCount(dynamicNodes);
         GetSettings().SetEnableAlterDatabaseCreateHiveFirst(enableAlterDatabaseCreateHiveFirst);
-        GetSettings().SetEnableSystemViews(false);
 
         for (ui32 poolNum = 1; poolNum <= poolsCount; ++poolNum) {
             GetSettings().AddStoragePoolType("storage-pool-number-" + ToString(poolNum));

--- a/ydb/services/config/bsconfig_ut.cpp
+++ b/ydb/services/config/bsconfig_ut.cpp
@@ -33,7 +33,6 @@ struct TKikimrTestSettings {
     static constexpr bool SSL = false;
     static constexpr bool AUTH = false;
     static constexpr bool PrecreatePools = true;
-    static constexpr bool EnableSystemViews = true;
 };
 
 struct TKikimrTestWithAuth : TKikimrTestSettings {
@@ -42,10 +41,6 @@ struct TKikimrTestWithAuth : TKikimrTestSettings {
 
 struct TKikimrTestWithAuthAndSsl : TKikimrTestWithAuth {
     static constexpr bool SSL = true;
-};
-
-struct TKikimrTestNoSystemViews : TKikimrTestSettings {
-    static constexpr bool EnableSystemViews = false;
 };
 
 template <typename TestSettings = TKikimrTestSettings>
@@ -163,7 +158,7 @@ TString NormalizeYaml(const TString& yaml) {
 Y_UNIT_TEST_SUITE(ConfigGRPCService) {
 
     template <typename TCtx>
-    void AdjustCtxForDB(TCtx &ctx) {    
+    void AdjustCtxForDB(TCtx &ctx) {
         ctx.AddMetadata(NYdb::YDB_AUTH_TICKET_HEADER, "root@builtin");
     }
 
@@ -258,7 +253,7 @@ Y_UNIT_TEST_SUITE(ConfigGRPCService) {
 
         mainConfig = rcvMainConfig;
         storageConfig = rcvStorageConfig;
-    }   
+    }
 
     Y_UNIT_TEST(ReplaceConfig) {
         TKikimrWithGrpcAndRootSchema server;

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -2575,7 +2575,6 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
 
     Y_UNIT_TEST(SetupWriteSession) {
         NPersQueue::TTestServer server{PQSettings(0, 2), false};
-        server.ServerSettings.SetEnableSystemViews(false);
         server.StartServer();
 
         server.EnableLogs({ NKikimrServices::PERSQUEUE }, NActors::NLog::PRI_INFO);

--- a/ydb/services/ydb/ydb_common_ut.h
+++ b/ydb/services/ydb/ydb_common_ut.h
@@ -28,7 +28,6 @@ struct TKikimrTestSettings {
     static constexpr bool SSL = false;
     static constexpr bool AUTH = false;
     static constexpr bool PrecreatePools = true;
-    static constexpr bool EnableSystemViews = true;
 
     static TString GetCaCrt() { return NYdbSslTestData::CaCrt; }
     static TString GetServerCrt() { return NYdbSslTestData::ServerCrt; }
@@ -69,10 +68,6 @@ struct TKikimrTestWithServerCert : TKikimrTestWithAuthAndSsl {
     static TString GetServerKey() {
         return GetServerCert().PrivateKey.c_str();
     }
-};
-
-struct TKikimrTestNoSystemViews : TKikimrTestSettings {
-    static constexpr bool EnableSystemViews = false;
 };
 
 template <typename TestSettings = TKikimrTestSettings>
@@ -116,7 +111,6 @@ public:
         ServerSettings->SetEnableDataColumnForIndexTable(true);
         ServerSettings->SetEnableNotNullColumns(true);
         ServerSettings->SetEnableParameterizedDecimal(true);
-        ServerSettings->SetEnableSystemViews(TestSettings::EnableSystemViews);
         ServerSettings->SetEnableYq(enableYq);
         ServerSettings->Formats = new TFormatFactory;
         ServerSettings->PQConfig = appConfig.GetPQConfig();
@@ -369,7 +363,6 @@ struct TTestOlap {
 using TKikimrWithGrpcAndRootSchema = TBasicKikimrWithGrpcAndRootSchema<TKikimrTestSettings>;
 using TKikimrWithGrpcAndRootSchemaWithAuth = TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth>;
 using TKikimrWithGrpcAndRootSchemaWithAuthAndSsl = TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuthAndSsl>;
-using TKikimrWithGrpcAndRootSchemaNoSystemViews = TBasicKikimrWithGrpcAndRootSchema<TKikimrTestNoSystemViews>;
 
 Ydb::StatusIds::StatusCode WaitForStatus(
     std::shared_ptr<grpc::Channel> channel, const TString& opId,

--- a/ydb/services/ydb/ydb_table_ut.cpp
+++ b/ydb/services/ydb/ydb_table_ut.cpp
@@ -3019,7 +3019,7 @@ R"___(<main>: Error: Transaction not found: , code: 2015
     }
 
     Y_UNIT_TEST(CopyTables) {
-        TKikimrWithGrpcAndRootSchemaNoSystemViews server;
+        TKikimrWithGrpcAndRootSchema server;
         server.Server_->GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_NOTICE);
 
         auto connection = NYdb::TDriver(
@@ -3039,85 +3039,85 @@ R"___(<main>: Error: Transaction not found: , code: 2015
                 .AddNullableColumn("Value", EPrimitiveType::Utf8);
             tableBuilder.SetPrimaryKeyColumn("Key");
 
-            auto result = session.CreateTable("/Root/Table-1", tableBuilder.Build()).ExtractValueSync();
+            auto result = session.CreateTable("/Root/Dir/Table-1", tableBuilder.Build()).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
-            auto result = session.CopyTables({{"/Root/Table-1", "/Root/Table-2"}}).ExtractValueSync();
-            UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
-            UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
-        }
-
-        {
-            auto result = session.CopyTables(
-                                     { {"/Root/Table-1", "/Root/Table-3"}
-                                     , {"/Root/Table-2", "/Root/Table-4"}}
-                                     ).ExtractValueSync();
+            auto result = session.CopyTables({{"/Root/Dir/Table-1", "/Root/Dir/Table-2"}}).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.CopyTables(
-                                     { {"/Root/Table-1", "/Root/Table-5"}
-                                     , {"/Root/Table-2", "/Root/Table-6"}
-                                     , {"/Root/Table-3", "/Root/Table-7"}
-                                     , {"/Root/Table-4", "/Root/Table-8"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-3"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-4"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.CopyTables(
-                                     { }).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-5"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-6"}
+                                    , {"/Root/Dir/Table-3", "/Root/Dir/Table-7"}
+                                    , {"/Root/Dir/Table-4", "/Root/Dir/Table-8"}}
+                                    ).ExtractValueSync();
+            UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
+            UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+        }
+
+        {
+            auto result = session.CopyTables(
+                                    { }).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
 
         {
             auto result = session.CopyTables(
-                                     { {"/Root/Table-1", "/Root/Table-1"}
-                                     , {"/Root/Table-2", "/Root/Table-9"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-1"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-9"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
 
         {
             auto result = session.CopyTables(
-                                     { {"/Root/Table-1", "/Root/dir_no_exist/Table-1"}
-                                     , {"/Root/Table-2", "/Root/Table-9"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/dir_no_exist/Table-1"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-9"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
 
         {
             auto result = session.CopyTables(
-                                     { {"/Root/Table-1", "/Root/Table-2"}
-                                     , {"/Root/Table-2", "/Root/Table-9"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-2"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-9"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
 
         {
             auto result = session.CopyTables(
-                                     { {"/Root/Table-1", "/Root/Table-9"}
-                                     , {"/Root/Table-1", "/Root/Table-10"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-9"}
+                                    , {"/Root/Dir/Table-1", "/Root/Dir/Table-10"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetStatus());
         }
 
         {
             auto result = session.CopyTables(
-                                     { {"/Root/Table-1", "/Root/Table-3"}
-                                     , {"/Root/Table-2", "/Root/Table-4"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-3"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-4"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus()); // do not fail on exist
         }
@@ -3130,63 +3130,60 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             tableBuilder.SetPrimaryKeyColumn("Key");
             tableBuilder.AddSecondaryIndex("user-index", "Value");
 
-            auto result = session.CreateTable("/Root/Indexed-Table-1", tableBuilder.Build()).ExtractValueSync();
+            auto result = session.CreateTable("/Root/Dir/Indexed-Table-1", tableBuilder.Build()).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.CopyTables(
-                                     {NYdb::NTable::TCopyItem("/Root/Indexed-Table-1", "/Root/Indexed-Table-2")})
-                              .ExtractValueSync();
+                                    {{"/Root/Dir/Indexed-Table-1", "/Root/Dir/Indexed-Table-2"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.CopyTables(
-                                     {NYdb::NTable::TCopyItem("/Root/Indexed-Table-1", "/Root/Omited-Indexes-Table-3").SetOmitIndexes()})
-                              .ExtractValueSync();
+                                    {NYdb::NTable::TCopyItem("/Root/Dir/Indexed-Table-1", "/Root/Dir/Omited-Indexes-Table-3").SetOmitIndexes()}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.CopyTables(
-                                     {NYdb::NTable::TCopyItem("/Root/Indexed-Table-1", "/Root/Omited-Indexes-Table-4").SetOmitIndexes(),
-                                      NYdb::NTable::TCopyItem("/Root/Indexed-Table-2", "/Root/Omited-Indexes-Table-5").SetOmitIndexes(),
-                                      NYdb::NTable::TCopyItem("/Root/Omited-Indexes-Table-3", "/Root/Omited-Indexes-Table-6").SetOmitIndexes()
-                                      })
-                              .ExtractValueSync();
+                                    { NYdb::NTable::TCopyItem("/Root/Dir/Indexed-Table-1", "/Root/Dir/Omited-Indexes-Table-4").SetOmitIndexes()
+                                    , NYdb::NTable::TCopyItem("/Root/Dir/Indexed-Table-2", "/Root/Dir/Omited-Indexes-Table-5").SetOmitIndexes()
+                                    , NYdb::NTable::TCopyItem("/Root/Dir/Omited-Indexes-Table-3", "/Root/Dir/Omited-Indexes-Table-6").SetOmitIndexes()}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.CopyTables(
-                                     {NYdb::NTable::TCopyItem("/Root/Indexed-Table-1", "/Root/Indexed-Table-7"),
-                                      NYdb::NTable::TCopyItem("/Root/Indexed-Table-2", "/Root/Omited-Indexes-Table-8").SetOmitIndexes()
-                                     })
-                              .ExtractValueSync();
+                                    { NYdb::NTable::TCopyItem("/Root/Dir/Indexed-Table-1", "/Root/Dir/Indexed-Table-7")
+                                    , NYdb::NTable::TCopyItem("/Root/Dir/Indexed-Table-2", "/Root/Dir/Omited-Indexes-Table-8").SetOmitIndexes()}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
-
         {
-            auto asyncDescDir = NYdb::NScheme::TSchemeClient(connection).ListDirectory("/Root");
+            auto asyncDescDir = NYdb::NScheme::TSchemeClient(connection).ListDirectory("/Root/Dir");
             asyncDescDir.Wait();
             const auto& val = asyncDescDir.GetValue();
             auto entry = val.GetEntry();
-            UNIT_ASSERT_EQUAL(entry.Name, "Root");
+            UNIT_ASSERT_EQUAL(entry.Name, "Dir");
             UNIT_ASSERT_EQUAL(entry.Type, NYdb::NScheme::ESchemeEntryType::Directory);
 
             auto children = val.GetChildren();
-            UNIT_ASSERT_EQUAL(children.size(), 16);
+            UNIT_ASSERT_VALUES_EQUAL(children.size(), 16);
             for (const auto& child: children) {
                 UNIT_ASSERT_EQUAL(child.Type, NYdb::NScheme::ESchemeEntryType::Table);
 
-                auto result = session.DropTable(TStringBuilder() << "Root" << "/" <<  child.Name).ExtractValueSync();
+                auto result = session.DropTable(TStringBuilder() << "Root/Dir" << "/" <<  child.Name).ExtractValueSync();
                 UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
                 UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
             }
@@ -3194,7 +3191,7 @@ R"___(<main>: Error: Transaction not found: , code: 2015
     }
 
     Y_UNIT_TEST(RenameTables) {
-        TKikimrWithGrpcAndRootSchemaNoSystemViews server;
+        TKikimrWithGrpcAndRootSchema server;
         server.Server_->GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_NOTICE);
         server.Server_->GetRuntime()->SetLogPriority(NKikimrServices::GRPC_SERVER, NActors::NLog::PRI_DEBUG);
         server.Server_->GetRuntime()->SetLogPriority(NKikimrServices::TX_PROXY, NActors::NLog::PRI_DEBUG);
@@ -3216,79 +3213,79 @@ R"___(<main>: Error: Transaction not found: , code: 2015
                 .AddNullableColumn("Value", EPrimitiveType::Utf8);
             tableBuilder.SetPrimaryKeyColumn("Key");
 
-            auto result = session.CreateTable("/Root/Table-1", tableBuilder.Build()).ExtractValueSync();
+            auto result = session.CreateTable("/Root/Dir/Table-1", tableBuilder.Build()).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
-            auto result = session.RenameTables({{"/Root/Table-1", "/Root/Table-2"}}).ExtractValueSync();
+            auto result = session.RenameTables({{"/Root/Dir/Table-1", "/Root/Dir/Table-2"}}).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
-            auto result = session.CopyTables({{"/Root/Table-2", "/Root/Table-1"}}).ExtractValueSync();
+            auto result = session.CopyTables({{"/Root/Dir/Table-2", "/Root/Dir/Table-1"}}).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.RenameTables(
-                                     { {"/Root/Table-1", "/Root/Table-2"} }
-                                     ).ExtractValueSync();
+                                    {{"/Root/Dir/Table-1", "/Root/Dir/Table-2"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
 
         {
             auto result = session.RenameTables(
-                                     { {"/Root/Table-1", "/Root/Table-3"}
-                                     , {"/Root/Table-2", "/Root/Table-4"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-3"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-4"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.RenameTables(
-                                     { }).ExtractValueSync();
+                                    { }).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetStatus());
         }
 
         {
             auto result = session.RenameTables(
-                                     { {"/Root/Table-1", "/Root/Table-1"}
-                                     , {"/Root/Table-2", "/Root/Table-9"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-1"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-9"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
 
         {
             auto result = session.RenameTables(
-                                     { {"/Root/Table-1", "/Root/dir_no_exist/Table-1"}
-                                     , {"/Root/Table-2", "/Root/Table-9"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/dir_no_exist/Table-1"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-9"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
 
         {
             auto result = session.RenameTables(
-                                     { {"/Root/Table-1", "/Root/Table-2"}
-                                     , {"/Root/Table-2", "/Root/Table-9"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-2"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-9"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
 
         {
             auto result = session.RenameTables(
-                                     { {"/Root/Table-1", "/Root/Table-9"}
-                                     , {"/Root/Table-1", "/Root/Table-10"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-9"}
+                                    , {"/Root/Dir/Table-1", "/Root/Dir/Table-10"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus());
         }
@@ -3296,62 +3293,62 @@ R"___(<main>: Error: Transaction not found: , code: 2015
 
         {
             auto result = session.RenameTables(
-                                     { {"/Root/Table-1", "/Root/Table-3"}
-                                     , {"/Root/Table-2", "/Root/Table-4"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-3"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-4"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus()); // do not fail on exist
         }
 
         {
             auto result = session.CopyTables(
-                                     { {"/Root/Table-3", "/Root/Table-1"}
-                                     , {"/Root/Table-4", "/Root/Table-2"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-3", "/Root/Dir/Table-1"}
+                                    , {"/Root/Dir/Table-4", "/Root/Dir/Table-2"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.RenameTables(
-                                     { {"/Root/Table-1", "/Root/Table-3"}
-                                     , {"/Root/Table-2", "/Root/Table-4"}}
-                                     ).ExtractValueSync();
+                                    { {"/Root/Dir/Table-1", "/Root/Dir/Table-3"}
+                                    , {"/Root/Dir/Table-2", "/Root/Dir/Table-4"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetStatus()); // do not fail on exist
         }
 
         {
             auto result = session.RenameTables(
-                                     {NYdb::NTable::TRenameItem("/Root/Table-4", "/Root/Table-1").SetReplaceDestination()})
-                              .ExtractValueSync();
+                                    {NYdb::NTable::TRenameItem("/Root/Dir/Table-4", "/Root/Dir/Table-1").SetReplaceDestination()}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
             auto result = session.RenameTables(
-                                     {NYdb::NTable::TRenameItem("/Root/Table-2", "/Root/Table-1").SetReplaceDestination(),
-                                     {"/Root/Table-3", "/Root/Table-2"}})
-                              .ExtractValueSync();
+                                    { NYdb::NTable::TRenameItem("/Root/Dir/Table-2", "/Root/Dir/Table-1").SetReplaceDestination()
+                                    , {"/Root/Dir/Table-3", "/Root/Dir/Table-2"}}
+                                    ).ExtractValueSync();
             UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
         }
 
         {
-            auto asyncDescDir = NYdb::NScheme::TSchemeClient(connection).ListDirectory("/Root");
+            auto asyncDescDir = NYdb::NScheme::TSchemeClient(connection).ListDirectory("/Root/Dir");
             asyncDescDir.Wait();
             const auto& val = asyncDescDir.GetValue();
             auto entry = val.GetEntry();
-            UNIT_ASSERT_EQUAL(entry.Name, "Root");
+            UNIT_ASSERT_EQUAL(entry.Name, "Dir");
             UNIT_ASSERT_EQUAL(entry.Type, NYdb::NScheme::ESchemeEntryType::Directory);
 
             auto children = val.GetChildren();
-            UNIT_ASSERT_EQUAL_C(children.size(), 2, children.size());
+            UNIT_ASSERT_VALUES_EQUAL(children.size(), 2);
             for (const auto& child: children) {
                 UNIT_ASSERT_EQUAL(child.Type, NYdb::NScheme::ESchemeEntryType::Table);
 
-                auto result = session.DropTable(TStringBuilder() << "Root" << "/" <<  child.Name).ExtractValueSync();
+                auto result = session.DropTable(TStringBuilder() << "Root/Dir" << "/" <<  child.Name).ExtractValueSync();
                 UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
                 UNIT_ASSERT_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetStatus());
             }


### PR DESCRIPTION
To avoid checking chained feature flags in the code I've decided to deprecate a feature flag corresponded to System views. This feature was enabled 5 years ago and it's about time to remove this flag from the code and update all dependent tests.
