### PR TITLE
Switch to HASH_V1 in stable

### DIFF
--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -408,7 +408,7 @@ message TTableServiceConfig {
         HASH_V2 = 1;
     }
 
-    optional EHashKind DefaultHashShuffleFuncType = 93 [ default = HASH_V2 ];
+    optional EHashKind DefaultHashShuffleFuncType = 93 [ default = HASH_V1 ];
 
     optional bool EnableParallelUnionAllConnectionsForExtend = 94  [ default = true ];
 

--- a/ydb/tests/functional/canonical/canondata/test_sql.TestCanonicalFolder1.test_case_join_group_by_lookup.script-script_/join_group_by_lookup.script.plan
+++ b/ydb/tests/functional/canonical/canondata/test_sql.TestCanonicalFolder1.test_case_join_group_by_lookup.script-script_/join_group_by_lookup.script.plan
@@ -176,7 +176,7 @@
                                                 "PlanNodeId": 4,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "Group"
                                                         ],

--- a/ydb/tests/functional/canonical/canondata/test_sql.TestCanonicalFolder1.test_case_write_write_group_by.script-script_/write_write_group_by.script.plan
+++ b/ydb/tests/functional/canonical/canondata/test_sql.TestCanonicalFolder1.test_case_write_write_group_by.script-script_/write_write_group_by.script.plan
@@ -140,7 +140,7 @@
                                                 "PlanNodeId": 4,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "Group"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-10
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-10
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 5,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "MobilePhoneModel"
                                                         ],
@@ -95,7 +95,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "MobilePhoneModel",
                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-11
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-11
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 5,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "MobilePhone",
                                                             "MobilePhoneModel"
@@ -96,7 +96,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "MobilePhone",
                                                                             "MobilePhoneModel",

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-12
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-12
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-13
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-13
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 5,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],
@@ -95,7 +95,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "SearchPhrase",
                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-14
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-14
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchEngineID",
                                                             "SearchPhrase"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-15
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-15
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "UserID"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-16
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-16
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase",
                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-17
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-17
@@ -59,7 +59,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase",
                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-18
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-18
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase",
                                                             "UserID",

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-21
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-21
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-22
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-22
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 8,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],
@@ -328,7 +328,7 @@
                                                                                 "Plans": [
                                                                                     {
                                                                                         "CTE Name": "Filter-TableFullScan_9",
-                                                                                        "HashFunc": "HashV2",
+                                                                                        "HashFunc": "HashV1",
                                                                                         "KeyColumns": [
                                                                                             "SearchPhrase",
                                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-27
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-27
@@ -75,7 +75,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "CounterID"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-28
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-28
@@ -78,7 +78,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "key"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-30
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-30
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "ClientIP",
                                                             "SearchEngineID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-31
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-31
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "ClientIP",
                                                             "WatchID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-32
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-32
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "ClientIP",
                                                             "WatchID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-33
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-33
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "URL"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-34
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-34
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "URL",
                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-35
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-35
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "ClientIP",
                                                             "group0",

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-36
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-36
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "URL"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-37
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-37
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "Title"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-38
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-38
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "URL"
                                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-39
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-39
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "AdvEngineID",
                                                                             "Dst",

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-4
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-4
@@ -97,7 +97,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "UserID"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-40
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-40
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "EventDate",
                                                                             "URLHash"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-41
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-41
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "WindowClientHeight",
                                                                             "WindowClientWidth"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-42
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-42
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "Minute"
                                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-5
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-5
@@ -97,7 +97,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-7
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-7
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "AdvEngineID"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-8
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-8
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 5,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "RegionID"
                                                         ],
@@ -95,7 +95,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "RegionID",
                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-9
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-9
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 8,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "RegionID"
                                                         ],
@@ -175,7 +175,7 @@
                                                                                 "Plans": [
                                                                                     {
                                                                                         "CTE Name": "TableFullScan_9",
-                                                                                        "HashFunc": "HashV2",
+                                                                                        "HashFunc": "HashV1",
                                                                                         "KeyColumns": [
                                                                                             "RegionID",
                                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-10
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-10
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 5,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "MobilePhoneModel"
                                                         ],
@@ -95,7 +95,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "MobilePhoneModel",
                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-11
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-11
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 5,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "MobilePhone",
                                                             "MobilePhoneModel"
@@ -96,7 +96,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "MobilePhone",
                                                                             "MobilePhoneModel",

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-12
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-12
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-13
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-13
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 5,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],
@@ -95,7 +95,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "SearchPhrase",
                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-14
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-14
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchEngineID",
                                                             "SearchPhrase"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-15
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-15
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "UserID"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-16
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-16
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase",
                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-17
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-17
@@ -59,7 +59,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase",
                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-18
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-18
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase",
                                                             "UserID",

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-21
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-21
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-22
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-22
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 8,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],
@@ -162,7 +162,7 @@
                                                                                 "Plans": [
                                                                                     {
                                                                                         "CTE Name": "Filter-TableFullScan_9",
-                                                                                        "HashFunc": "HashV2",
+                                                                                        "HashFunc": "HashV1",
                                                                                         "KeyColumns": [
                                                                                             "SearchPhrase",
                                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-27
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-27
@@ -75,7 +75,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "CounterID"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-28
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-28
@@ -78,7 +78,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "key"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-30
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-30
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "ClientIP",
                                                             "SearchEngineID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-31
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-31
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "ClientIP",
                                                             "WatchID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-32
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-32
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "ClientIP",
                                                             "WatchID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-33
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-33
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "URL"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-34
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-34
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "URL",
                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-35
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-35
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "ClientIP",
                                                             "group0",

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-36
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-36
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "URL"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-37
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-37
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "Title"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-38
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-38
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "URL"
                                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-39
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-39
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "AdvEngineID",
                                                                             "Dst",

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-4
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-4
@@ -97,7 +97,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "UserID"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-40
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-40
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "EventDate",
                                                                             "URLHash"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-41
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-41
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "WindowClientHeight",
                                                                             "WindowClientWidth"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-42
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-42
@@ -89,7 +89,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "Minute"
                                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-5
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-5
@@ -97,7 +97,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "SearchPhrase"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-7
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-7
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 3,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "AdvEngineID"
                                                         ],

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-8
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-8
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 5,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "RegionID"
                                                         ],
@@ -95,7 +95,7 @@
                                                                 "PlanNodeId": 3,
                                                                 "Plans": [
                                                                     {
-                                                                        "HashFunc": "HashV2",
+                                                                        "HashFunc": "HashV1",
                                                                         "KeyColumns": [
                                                                             "RegionID",
                                                                             "UserID"

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-9
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_row_/queries-original-plan-row-9
@@ -60,7 +60,7 @@
                                                 "PlanNodeId": 8,
                                                 "Plans": [
                                                     {
-                                                        "HashFunc": "HashV2",
+                                                        "HashFunc": "HashV1",
                                                         "KeyColumns": [
                                                             "RegionID"
                                                         ],
@@ -153,7 +153,7 @@
                                                                                 "Plans": [
                                                                                     {
                                                                                         "CTE Name": "TableFullScan_9",
-                                                                                        "HashFunc": "HashV2",
+                                                                                        "HashFunc": "HashV1",
                                                                                         "KeyColumns": [
                                                                                             "RegionID",
                                                                                             "UserID"

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join-group-by-with-null.test_/query_2.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join-group-by-with-null.test_/query_2.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 11,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "t1.q2"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join-group-by-with-null.test_/query_3.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join-group-by-with-null.test_/query_3.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 11,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "t1.q2"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join-group-by-with-null.test_/query_4.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join-group-by-with-null.test_/query_4.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 11,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "t1.q2"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join-group-by-with-null.test_/query_5.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join-group-by-with-null.test_/query_5.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 9,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "t1.q2"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join0.test_/query_14.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join0.test_/query_14.plan
@@ -75,7 +75,7 @@
                                                         "PlanNodeId": 6,
                                                         "Plans": [
                                                             {
-                                                                "HashFunc": "HashV2",
+                                                                "HashFunc": "HashV1",
                                                                 "KeyColumns": [
                                                                     "unique1"
                                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join0.test_/query_16.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join0.test_/query_16.plan
@@ -78,7 +78,7 @@
                                         "PlanNodeId": 11,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "unique2"
                                                 ],
@@ -129,7 +129,7 @@
                                                 ]
                                             },
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "unique2"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join0.test_/query_5.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join0.test_/query_5.plan
@@ -88,7 +88,7 @@
                                                         "PlanNodeId": 14,
                                                         "Plans": [
                                                             {
-                                                                "HashFunc": "HashV2",
+                                                                "HashFunc": "HashV1",
                                                                 "KeyColumns": [
                                                                     "qq"
                                                                 ],
@@ -139,7 +139,7 @@
                                                                 ]
                                                             },
                                                             {
-                                                                "HashFunc": "HashV2",
+                                                                "HashFunc": "HashV1",
                                                                 "KeyColumns": [
                                                                     "qq"
                                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join1.test_/query_11.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join1.test_/query_11.plan
@@ -56,7 +56,7 @@
                                         "PlanNodeId": 11,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "i"
                                                 ],
@@ -108,7 +108,7 @@
                                                 ]
                                             },
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "i"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join1.test_/query_12.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join1.test_/query_12.plan
@@ -56,7 +56,7 @@
                                         "PlanNodeId": 11,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "i"
                                                 ],
@@ -108,7 +108,7 @@
                                                 ]
                                             },
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "i"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join2.test_/query_1.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join2.test_/query_1.plan
@@ -71,7 +71,7 @@
                                         "PlanNodeId": 20,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "name"
                                                 ],
@@ -122,7 +122,7 @@
                                                 ]
                                             },
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "name"
                                                 ],
@@ -157,7 +157,7 @@
                                                                         "PlanNodeId": 11,
                                                                         "Plans": [
                                                                             {
-                                                                                "HashFunc": "HashV2",
+                                                                                "HashFunc": "HashV1",
                                                                                 "KeyColumns": [
                                                                                     "name"
                                                                                 ],
@@ -208,7 +208,7 @@
                                                                                 ]
                                                                             },
                                                                             {
-                                                                                "HashFunc": "HashV2",
+                                                                                "HashFunc": "HashV1",
                                                                                 "KeyColumns": [
                                                                                     "name"
                                                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join2.test_/query_4.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join2.test_/query_4.plan
@@ -68,7 +68,7 @@
                                         "PlanNodeId": 11,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "name"
                                                 ],
@@ -119,7 +119,7 @@
                                                 ]
                                             },
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "name"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join4.test_/query_4.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-jointest_join4.test_/query_4.plan
@@ -168,7 +168,7 @@
                                                                         "PlanNodeId": 4,
                                                                         "Plans": [
                                                                             {
-                                                                                "HashFunc": "HashV2",
+                                                                                "HashFunc": "HashV1",
                                                                                 "KeyColumns": [
                                                                                     "a"
                                                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_1.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_1.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "two"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_2.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_2.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "ten"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_3.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_3.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "string4"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_4.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_4.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "string4",
                                                     "ten",

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_5.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-select_distinct.test_/query_5.plan
@@ -71,7 +71,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "four",
                                                     "two"

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_1.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_1.plan
@@ -54,7 +54,7 @@
                                         "PlanNodeId": 6,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "depname"
                                                 ],
@@ -78,7 +78,7 @@
                                                         "PlanNodeId": 4,
                                                         "Plans": [
                                                             {
-                                                                "HashFunc": "HashV2",
+                                                                "HashFunc": "HashV1",
                                                                 "KeyColumns": [
                                                                     "depname"
                                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_2.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_2.plan
@@ -63,7 +63,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "depname"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_3.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_3.plan
@@ -63,7 +63,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "depname"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_4.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_4.plan
@@ -63,7 +63,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "depname"
                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_5.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_5.plan
@@ -103,7 +103,7 @@
                                                                         "PlanNodeId": 4,
                                                                         "Plans": [
                                                                             {
-                                                                                "HashFunc": "HashV2",
+                                                                                "HashFunc": "HashV1",
                                                                                 "KeyColumns": [
                                                                                     "depname"
                                                                                 ],

--- a/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_7.plan
+++ b/ydb/tests/functional/suite_tests/canondata/test_postgres.TestPGSQL.test_sql_suite_plan-window.test_/query_7.plan
@@ -53,7 +53,7 @@
                                         "PlanNodeId": 4,
                                         "Plans": [
                                             {
-                                                "HashFunc": "HashV2",
+                                                "HashFunc": "HashV1",
                                                 "KeyColumns": [
                                                     "depname"
                                                 ],


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
* Not for changelog (changelog entry is not required)
### Description for reviewers <!-- (optional) description for those who read this PR -->

HashV2 is new Hash Shuffle algo, is tested in main by default, but is incompatible with stable.

For compatibility reasons we should use HashV1 everywhere where version below 25-3 (i.e. 25-2) is possible.

After irreversible upgrade to 25-3 we can change default to HashV2

...
