### PR TITLE
Shared ownership of DeletedKeys

### DIFF
--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -746,7 +746,7 @@ private:
     TMessageQueue PendingRequests;
     TMessageQueue QuotaWaitingRequests;
 
-    std::deque<TString> DeletedKeys;
+    std::shared_ptr<std::deque<TString>> DeletedKeys;
     std::deque<TBlobKeyTokenPtr> DefferedKeysForDeletion;
 
     THead Head;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The DeletedKeys queue is used by the token partitioners and destructors. They have different lifetimes. Joint ownership is needed.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required) 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
