### PR TITLE
Добавление примера со вставкой строчки используя returning

### DIFF
--- a/ydb/docs/ru/core/dev/yql-tutorial/fill_tables_with_data.md
+++ b/ydb/docs/ru/core/dev/yql-tutorial/fill_tables_with_data.md
@@ -114,3 +114,16 @@ VALUES
     (2, 5, 7, "Initial Coin Offering", CAST(Date("2018-05-06") AS Uint64)),
     (2, 5, 8, "Fifty-One Percent", CAST(Date("2018-05-13") AS Uint64));
 ```
+
+## Вставка данных с возвратом сгенерированного ключа
+
+Если в таблице есть столбец с типом `Serial`, то его значение будет генерироваться автоматически на стороне БД.  
+Чтобы получить это значение в момент вставки, можно использовать конструкцию `RETURNING`.
+
+Пример:
+
+```yql
+INSERT INTO games (datetime_start, datetime_end)
+VALUES (CurrentUtcTimestamp(), NULL)
+RETURNING id;
+```


### PR DESCRIPTION
Очень важный пример для понимания возможностей при вставке строчек в таблицу с столбцом автоинкрементом. При вставке строчки можно не указывать значение в столбце id и использовать ключевое слово returning для возвращения значения вставленного в таблицу в столбце id