### PR TITLE
Добавление примера с столбцом-автоинкрементом типа Serial

### DIFF
--- a/ydb/docs/ru/core/dev/yql-tutorial/create_demo_tables.md
+++ b/ydb/docs/ru/core/dev/yql-tutorial/create_demo_tables.md
@@ -46,6 +46,16 @@
         air_date Uint64,
         PRIMARY KEY (series_id, season_id, episode_id)
     );
+
+    CREATE TABLE games
+    (
+        id Serial,                         -- Столбец с типом Serial автоматически получает уникальное значение при каждой вставке строки.
+                                           -- Это аналог автоинкремента в других базах данных.
+                                           -- Такой столбец обязательно должен быть частью первичного ключа.
+        datetime_start Timestamp,
+        datetime_end Timestamp,
+        PRIMARY KEY (id)
+    );
     ```
 
 - Создание колоночных таблиц


### PR DESCRIPTION
Данный пример нужен для того, чтобы дать понять, что существует возможность сделать столбец с автоматически генерируемым id. А также данный пример требуется для того, чтобы показать в статье с добавлением новой строчки, что существует в таких таблицах возможность делать returning id, о чём не говорится ни в каком месте в документации, хотя такая возможность поддерживается