### PR TITLE
fix database node restrictions

### DIFF
--- a/ydb/core/viewer/pdisk_info.h
+++ b/ydb/core/viewer/pdisk_info.h
@@ -43,8 +43,8 @@ public:
     void Bootstrap() override {
         TString pDiskId = Params.Get("pdisk_id");
         if (pDiskId.Contains('-')) {
-            PDiskId = FromStringWithDefault<ui32>(TStringBuf(pDiskId).Before('-'), Max<ui32>());
-            NodeId = FromStringWithDefault<ui32>(TStringBuf(pDiskId).After('-'), 0);
+            NodeId = FromStringWithDefault<ui32>(TStringBuf(pDiskId).Before('-'), 0);
+            PDiskId = FromStringWithDefault<ui32>(TStringBuf(pDiskId).After('-'), Max<ui32>());
         } else {
             NodeId = FromStringWithDefault<ui32>(Params.Get("node_id"), 0);
             PDiskId = FromStringWithDefault<ui32>(Params.Get("pdisk_id"), Max<ui32>());

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -569,6 +569,54 @@
         "restart_pdisk_viewer": {
             "status_code": 403,
             "text": "<html><body><h1>403 Forbidden</h1></body></html>"
+        },
+        "storage_nodes_database": {
+            "FieldsAvailable": "10000000110000000000110100000011",
+            "FieldsRequired": "00000000000000000000000000000011",
+            "FoundNodes": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "NodeId": 1
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "storage_nodes_monitoring": {
+            "FieldsAvailable": "10000000110000000000110100000011",
+            "FieldsRequired": "00000000000000000000000000000011",
+            "FoundNodes": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "NodeId": 1
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "storage_nodes_root": {
+            "FieldsAvailable": "10000000110000000000110100000011",
+            "FieldsRequired": "00000000000000000000000000000011",
+            "FoundNodes": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "NodeId": 1
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "storage_nodes_viewer": {
+            "FieldsAvailable": "10000000110000000000110100000011",
+            "FieldsRequired": "00000000000000000000000000000011",
+            "FoundNodes": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "NodeId": 1
+                }
+            ],
+            "TotalNodes": "1"
         }
     },
     "test.test_storage_groups": {

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -1433,6 +1433,35 @@ def test_security():
         'Cookie': 'ydb_session_id=' + database_session_id,
     })
 
+    result['storage_nodes_root'] = get_viewer_normalized("/viewer/nodes", params={
+        'fields_required': 'NodeId',
+        'database': dedicated_db,
+        'type': 'storage',
+    }, headers={
+        'Cookie': 'ydb_session_id=' + root_session_id,
+    })
+    result['storage_nodes_monitoring'] = get_viewer_normalized("/viewer/nodes", params={
+        'fields_required': 'NodeId',
+        'database': dedicated_db,
+        'type': 'storage',
+    }, headers={
+        'Cookie': 'ydb_session_id=' + monitoring_session_id,
+    })
+    result['storage_nodes_viewer'] = get_viewer_normalized("/viewer/nodes", params={
+        'fields_required': 'NodeId',
+        'database': dedicated_db,
+        'type': 'storage',
+    }, headers={
+        'Cookie': 'ydb_session_id=' + viewer_session_id,
+    })
+    result['storage_nodes_database'] = get_viewer_normalized("/viewer/nodes", params={
+        'fields_required': 'NodeId',
+        'database': dedicated_db,
+        'type': 'storage',
+    }, headers={
+        'Cookie': 'ydb_session_id=' + database_session_id,
+    })
+
     result['down_node_root'] = get_viewer("/tablets/app", params={
         'TabletID': '72057594037968897',
         'page': 'SetDown',


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

resolves security issue with database user being able to get info about storage nodes
closes #24588
also solves small issue with incorrect pdisk id parsing.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
