### PR TITLE
Add new MaintenanceStatus NO_NEW_VDISKS to PDisk

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
@@ -2,6 +2,19 @@
 #include <util/system/compiler.h>
 
 Y_UNIT_TEST_SUITE(SelfHeal) {
+    void ChangeDiskStatus(TEnvironmentSetup& env, TPDiskId pdiskId, NKikimrBlobStorage::EDriveStatus status,
+            NKikimrBlobStorage::TMaintenanceStatus::E maintenanceStatus) {
+        NKikimrBlobStorage::TConfigRequest request;
+        auto* cmd = request.AddCommand()->MutableUpdateDriveStatus();
+        cmd->MutableHostKey()->SetNodeId(pdiskId.NodeId);
+        cmd->SetPDiskId(pdiskId.PDiskId);
+        cmd->SetStatus(status);
+        cmd->SetMaintenanceStatus(maintenanceStatus);
+        auto res = env.Invoke(request);
+        UNIT_ASSERT_C(res.GetSuccess(), res.GetErrorDescription());
+        UNIT_ASSERT_C(res.GetStatus(0).GetSuccess(), res.GetStatus(0).GetErrorDescription());
+    }
+
     void TestReassignThrottling() {
         const TBlobStorageGroupType erasure = TBlobStorageGroupType::ErasureMirror3dc;
         const ui32 groupsCount = 32;
@@ -46,16 +59,8 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
 
         auto pdisk = base.GetPDisk(0);
         // set FAULTY status on the chosen PDisk
-        {
-            NKikimrBlobStorage::TConfigRequest request;
-            auto* cmd = request.AddCommand()->MutableUpdateDriveStatus();
-            cmd->MutableHostKey()->SetNodeId(pdisk.GetNodeId());
-            cmd->SetPDiskId(pdisk.GetPDiskId());
-            cmd->SetStatus(NKikimrBlobStorage::FAULTY);
-            auto res = env.Invoke(request);
-            UNIT_ASSERT_C(res.GetSuccess(), res.GetErrorDescription());
-            UNIT_ASSERT_C(res.GetStatus(0).GetSuccess(), res.GetStatus(0).GetErrorDescription());
-        }
+        ChangeDiskStatus(env, { pdisk.GetNodeId(), pdisk.GetPDiskId() }, NKikimrBlobStorage::EDriveStatus::FAULTY,
+            NKikimrBlobStorage::TMaintenanceStatus::NOT_SET);
 
         env.Sim(TDuration::Minutes(15));
 
@@ -145,15 +150,7 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
             for (ui32 orderNumber = 0; orderNumber < groupSize; ++orderNumber) {
                 TPDiskId pdiskId = orderNumberToPDiskId[orderNumber];
                 TPDiskStatus pdiskStatus = pdisks[orderNumber];
-                NKikimrBlobStorage::TConfigRequest request;
-                auto* cmd = request.AddCommand()->MutableUpdateDriveStatus();
-                cmd->MutableHostKey()->SetNodeId(pdiskId.NodeId);
-                cmd->SetPDiskId(pdiskId.PDiskId);
-                cmd->SetStatus(pdiskStatus.DriveStatus);
-                cmd->SetMaintenanceStatus(pdiskStatus.MaintenanceStatus);
-                auto res = env.Invoke(request);
-                UNIT_ASSERT_C(res.GetSuccess(), res.GetErrorDescription());
-                UNIT_ASSERT_C(res.GetStatus(0).GetSuccess(), res.GetStatus(0).GetErrorDescription());
+                ChangeDiskStatus(env, pdiskId, pdiskStatus.DriveStatus, pdiskStatus.MaintenanceStatus);
             }
         };
 
@@ -176,7 +173,7 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
         }
 
         env.UpdateSettings(true, true, false); // enable self-heal
-        env.Sim(TDuration::Minutes(180));
+        env.Sim(TDuration::Seconds(180));
 
         base = env.FetchBaseConfig();
         updateMapping(base);
@@ -231,6 +228,107 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
                     "Got DriveStatus# " << NKikimrBlobStorage::EDriveStatus_Name(driveStatus));
             UNIT_ASSERT_C(maintenanceStatus == NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST,
                     "Got MaintenanceStatus# " << NKikimrBlobStorage::TMaintenanceStatus::E_Name(maintenanceStatus));
+        }
+    }
+
+    Y_UNIT_TEST(MaintenanceStatusNoNewAllocations) {
+        const TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
+        TEnvironmentSetup env({
+            .NodeCount = erasure.BlobSubgroupSize() + 1,
+            .Erasure = erasure,
+        });
+
+        env.CreateBoxAndPool(1, 1);
+
+        env.UpdateSettings(false, true, false); // disable self-heal
+        
+        // set PDisk (9,1000) to ACTIVE + NO_NEW_ALLOCATIONS
+        ChangeDiskStatus(env, { 9, 1000 }, NKikimrBlobStorage::EDriveStatus::ACTIVE, NKikimrBlobStorage::TMaintenanceStatus::NO_NEW_ALLOCATIONS);
+    
+        // set PDisk (1,1000) to ACTIVE + LONG_TERM_MAINTENANCE_PLANNED
+        ChangeDiskStatus(env, { 1, 1000 }, NKikimrBlobStorage::EDriveStatus::ACTIVE, NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED);
+
+        TActorId reassigner;
+        bool reassignSeen = false;
+        bool seenReassignFailure = false;
+
+        auto catchReassigns = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) { 
+            if (seenReassignFailure) {
+                return true;
+            }
+            if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerConfigRequest::EventType) {
+                const auto& request = ev->Get<TEvBlobStorage::TEvControllerConfigRequest>()->Record.GetRequest();
+                for (const auto& command : request.GetCommand()) {
+                    if (command.GetCommandCase() == NKikimrBlobStorage::TConfigRequest::TCommand::kReassignGroupDisk) {
+                        reassignSeen = true;
+                        reassigner = ev->Sender;
+                    }
+                }
+            } else if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerConfigResponse::EventType) {
+                if (ev->Recipient != reassigner) {
+                    return true;
+                }
+                const auto& response = ev->Get<TEvBlobStorage::TEvControllerConfigResponse>()->Record.GetResponse();
+                auto& status = response.GetStatus(0);
+                bool succeeded = status.GetSuccess();
+                UNIT_ASSERT_C(!succeeded, "Reassign was expected to fail");
+                seenReassignFailure = true;
+            }
+            return true;
+        };
+
+        auto prevFn = env.Runtime->FilterFunction;
+        env.Runtime->FilterFunction = catchReassigns;
+
+        env.UpdateSettings(true, true, false); // enable self-heal
+        env.Sim(TDuration::Seconds(30));
+
+        {
+            auto base = env.FetchBaseConfig();
+            UNIT_ASSERT_VALUES_EQUAL(base.GroupSize(), 1);
+
+            auto& group = base.GetGroup(0);
+
+            bool diskNotMoved = false;
+
+            for (auto& slot : group.GetVSlotId()) {
+                TPDiskId pdiskId = { slot.GetNodeId(), slot.GetPDiskId() };
+                if (pdiskId == TPDiskId{9, 1000}) {
+                    UNIT_ASSERT_C(false, "Expected PDisk (9,1000) to be excluded from group");
+                }
+                if (pdiskId == TPDiskId{1, 1000}) {
+                    diskNotMoved = true;
+                }
+            }
+            UNIT_ASSERT_C(reassignSeen, "Expected to see reassign request");
+            UNIT_ASSERT_C(seenReassignFailure, "Expected to see reassign failure");
+            UNIT_ASSERT_C(diskNotMoved, "Expected PDisk (1,1000) to not be excluded from group");
+        }
+
+        env.Runtime->FilterFunction = prevFn;
+
+        // set PDisk (9,1000) to ACTIVE + NO_REQUEST
+        ChangeDiskStatus(env, { 9, 1000 }, NKikimrBlobStorage::EDriveStatus::ACTIVE, NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST);
+
+        env.Sim(TDuration::Seconds(30));
+
+        {
+            auto base = env.FetchBaseConfig();
+            UNIT_ASSERT_VALUES_EQUAL(base.GroupSize(), 1);
+
+            auto& group = base.GetGroup(0);
+
+            bool diskMoved = false;
+
+            for (auto& slot : group.GetVSlotId()) {
+                TPDiskId pdiskId = { slot.GetNodeId(), slot.GetPDiskId() };
+                if (pdiskId == TPDiskId{9, 1000}) {
+                    diskMoved = true;
+                    break;
+                }
+            }
+
+            UNIT_ASSERT_C(diskMoved, "Expected PDisk (9,1000) to be included into group");
         }
     }
 }

--- a/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
@@ -242,8 +242,8 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
 
         env.UpdateSettings(false, true, false); // disable self-heal
         
-        // set PDisk (9,1000) to ACTIVE + NO_NEW_ALLOCATIONS
-        ChangeDiskStatus(env, { 9, 1000 }, NKikimrBlobStorage::EDriveStatus::ACTIVE, NKikimrBlobStorage::TMaintenanceStatus::NO_NEW_ALLOCATIONS);
+        // set PDisk (9,1000) to ACTIVE + NO_NEW_VDISKS
+        ChangeDiskStatus(env, { 9, 1000 }, NKikimrBlobStorage::EDriveStatus::ACTIVE, NKikimrBlobStorage::TMaintenanceStatus::NO_NEW_VDISKS);
     
         // set PDisk (1,1000) to ACTIVE + LONG_TERM_MAINTENANCE_PLANNED
         ChangeDiskStatus(env, { 1, 1000 }, NKikimrBlobStorage::EDriveStatus::ACTIVE, NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED);

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -529,7 +529,7 @@ public:
         bool AcceptsNewSlots() const {
             return Status == NKikimrBlobStorage::EDriveStatus::ACTIVE
                 && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED
-                && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::NO_NEW_ALLOCATIONS;
+                && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::NO_NEW_VDISKS;
         }
 
         bool Decommitted() const {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -528,7 +528,8 @@ public:
 
         bool AcceptsNewSlots() const {
             return Status == NKikimrBlobStorage::EDriveStatus::ACTIVE
-                && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED;
+                && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED
+                && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::NO_NEW_ALLOCATIONS;
         }
 
         bool Decommitted() const {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -236,6 +236,7 @@ message TMaintenanceStatus {
         NOT_SET = 0;                        // unset status, default value
         NO_REQUEST = 1;                     // no active maintenance request
         LONG_TERM_MAINTENANCE_PLANNED = 2;  // maintence requested, VDisks should be moved asynchronously from PDisk
+        NO_NEW_ALLOCATIONS = 3;             // no new VDisks should be allocated on this PDisk, but existing ones are not moved
     }
 }
 

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -236,7 +236,7 @@ message TMaintenanceStatus {
         NOT_SET = 0;                        // unset status, default value
         NO_REQUEST = 1;                     // no active maintenance request
         LONG_TERM_MAINTENANCE_PLANNED = 2;  // maintence requested, VDisks should be moved asynchronously from PDisk
-        NO_NEW_ALLOCATIONS = 3;             // no new VDisks should be allocated on this PDisk, but existing ones are not moved
+        NO_NEW_VDISKS = 3;                  // no new VDisks should be allocated on this PDisk, but existing ones are not moved
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Add TMaintenanceStatus::NO_NEW_VDISKS to PDisk. If this status is set, PDisk will not accept new VDisks, but VDisks that are already on that PDisk will not be moved.

### Changelog category <!-- remove all except one -->

* Experimental feature