### PR TITLE
Fix updating of a unique covered index when data columns are missing from the update input

### DIFF
--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
@@ -148,6 +148,13 @@ TExprBase MakeNonexistingRowsFilter(const TDqPhyPrecompute& inputRows, const TDq
         .Done();
 }
 
+// Take input rows and enrich them with data columns missing from the original update
+// - inputRows is the original input
+// - lookupDict is a dictionary with existing versions of rows from the table
+// - If opt is true: lookupDict contains <row, equal> tuples instead of just rows,
+//   and rows with equal flag == true must be filtered out from the result.
+//   This is used for the "don't update index" optimisation, i.e. when the query
+//   only changes rows not in the index.
 TExprBase MakeUpsertIndexRows(TKqpPhyUpsertIndexMode mode, const TDqPhyPrecompute& inputRows,
     const TDqPhyPrecompute& lookupDict, const THashSet<TStringBuf>& inputColumns,
     const TVector<TStringBuf>& indexColumns, const TKikimrTableDescription& table, TPositionHandle pos,
@@ -171,7 +178,7 @@ TExprBase MakeUpsertIndexRows(TKqpPhyUpsertIndexMode mode, const TDqPhyPrecomput
                 .Done());
     }
 
-    auto lookup = Build<TCoLookup>(ctx, pos)
+    TExprBase lookup = Build<TCoLookup>(ctx, pos)
         .Collection(lookupDictArg)
         .Lookup<TCoAsStruct>()
             .Add(dictLookupKeyTuples)
@@ -180,13 +187,18 @@ TExprBase MakeUpsertIndexRows(TKqpPhyUpsertIndexMode mode, const TDqPhyPrecomput
 
     // rows to be added into the index table in case if the given key hasn't been found in the main table
     TVector<TExprBase> absentKeyRow;
-    absentKeyRow.reserve(indexColumns.size());
+    if (mode != TKqpPhyUpsertIndexMode::UpdateOn) {
+        absentKeyRow.reserve(indexColumns.size());
+    }
 
     // rows to be updated in the index table in case if the given key has been found in the main table
     TVector<TExprBase> presentKeyRow;
     presentKeyRow.reserve(indexColumns.size());
 
-    auto payload = TCoArgument(ctx.NewArgument(pos, "payload"));
+    auto presentDictArg = TCoArgument(ctx.NewArgument(pos, "presentDictItem"));
+    auto presentDictItem = (mode != TKqpPhyUpsertIndexMode::UpdateOn
+        ? (TExprBase)presentDictArg
+        : (TExprBase)Build<TCoUnwrap>(ctx, pos).Optional(lookup).Done());
 
     for (const auto& column : indexColumns) {
         auto columnAtom = ctx.NewAtom(pos, column);
@@ -200,24 +212,28 @@ TExprBase MakeUpsertIndexRows(TKqpPhyUpsertIndexMode mode, const TDqPhyPrecomput
                     .Build()
                 .Done();
 
-            absentKeyRow.emplace_back(tuple);
+            if (mode != TKqpPhyUpsertIndexMode::UpdateOn) {
+                absentKeyRow.emplace_back(tuple);
+            }
             presentKeyRow.emplace_back(tuple);
         } else {
-            auto columnType = table.GetColumnType(TString(column));
-            absentKeyRow.emplace_back(
-                Build<TCoNameValueTuple>(ctx, pos)
-                    .Name(columnAtom)
-                    .Value<TCoNothing>()
-                        .OptionalType(NCommon::BuildTypeExpr(pos, *columnType, ctx))
-                        .Build()
-                    .Done()
-            );
-            TExprNode::TPtr member = payload.Ptr();
+            if (mode != TKqpPhyUpsertIndexMode::UpdateOn) {
+                auto columnType = table.GetColumnType(TString(column));
+                absentKeyRow.emplace_back(
+                    Build<TCoNameValueTuple>(ctx, pos)
+                        .Name(columnAtom)
+                        .Value<TCoNothing>()
+                            .OptionalType(NCommon::BuildTypeExpr(pos, *columnType, ctx))
+                            .Build()
+                        .Done()
+                );
+            }
+            TExprBase member = presentDictItem;
             if (opt) {
                 member = Build<TCoNth>(ctx, pos)
                     .Tuple(member)
                     .Index().Build(0)
-                    .Done().Ptr();
+                    .Done();
             }
             presentKeyRow.emplace_back(
                 Build<TCoNameValueTuple>(ctx, pos)
@@ -235,44 +251,40 @@ TExprBase MakeUpsertIndexRows(TKqpPhyUpsertIndexMode mode, const TDqPhyPrecomput
         .Add(presentKeyRow)
         .Done();
 
-    TExprNode::TPtr b;
-
-    if (opt) {
-        b = Build<TCoFlatOptionalIf>(ctx, pos)
+    TExprBase b = (opt
+        ? (TExprBase)Build<TCoFlatOptionalIf>(ctx, pos)
             .Predicate<TCoNth>()
-                .Tuple(payload)
+                .Tuple(presentDictItem)
                 .Index().Build(1)
                 .Build()
             .Value<TCoJust>()
                 .Input(presentKeyRowStruct)
                 .Build()
-            .Done().Ptr();
-    } else {
-        b = Build<TCoJust>(ctx, pos)
+            .Done()
+        : (TExprBase)Build<TCoJust>(ctx, pos)
             .Input(presentKeyRowStruct)
-            .Done().Ptr();
-    }
+            .Done());
 
-    TExprBase flatmapBody = Build<TCoIfPresent>(ctx, pos)
-        .Optional(lookup)
-        .PresentHandler<TCoLambda>()
-            .Args(payload)
-            .Body(b)
-            .Build()
-        .MissingValue<TCoJust>()
-            .Input<TCoAsStruct>()
-                .Add(absentKeyRow)
+    if (mode != TKqpPhyUpsertIndexMode::UpdateOn) {
+        b = Build<TCoIfPresent>(ctx, pos)
+            .Optional(lookup)
+            .PresentHandler<TCoLambda>()
+                .Args(presentDictArg)
+                .Body(b)
                 .Build()
-            .Build()
-        .Done();
-
-    if (mode == TKqpPhyUpsertIndexMode::UpdateOn) {
+            .MissingValue<TCoJust>()
+                .Input<TCoAsStruct>()
+                    .Add(absentKeyRow)
+                    .Build()
+                .Build()
+            .Done();
+    } else {
         // Filter non-existing rows
-        flatmapBody = Build<TCoFlatOptionalIf>(ctx, pos)
+        b = Build<TCoFlatOptionalIf>(ctx, pos)
             .Predicate<TCoExists>()
                 .Optional(lookup)
                 .Build()
-            .Value(flatmapBody)
+            .Value(b)
             .Done();
     }
 
@@ -288,7 +300,7 @@ TExprBase MakeUpsertIndexRows(TKqpPhyUpsertIndexMode mode, const TDqPhyPrecomput
                     .Input(inputRowsArg)
                     .Lambda()
                         .Args(inputRowArg)
-                        .Body(flatmapBody)
+                        .Body(b)
                         .Build()
                     .Build()
                 .Build()
@@ -790,7 +802,7 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
         auto reComputeDictStage = Build<TDqStage>(ctx, pos)
             .Inputs()
                 .Add(rowsPrecompute.Cast()) // input rows
-                .Add(lookupDict.Cast()) // dict contains loockuped from table rows
+                .Add(lookupDict.Cast()) // dict contains rows looked up from the table
                 .Build()
             .Program()
                 .Args({inputArg, lookupDictArg})


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Не работали запросы UPDATE в нетривиальном кейсе: при наличии уникального покрывающего индекса по не-nullable колонкам при условии, что в запросе обновления нет значения колонок данных.

В этом случае универсально с UPSERT (используется один и тот же участок кода) строилась конструкция в духе "если строки нет в исходной таблице, то взять вместо значений отсутствующих колонок null-ы", потом, на самом деле, эта конструкция дополнительно фильтровалась по условию "если строки нет в исходной таблице, то не брать строку вообще", но в итоге получалось значение TCoNothing не-nullable типа и оно на этом обламывалось.

Сообщение об ошибке (добавленный тест без фикса его воспроизводит):

```
    <main>:3:70: Error: At tuple, At tuple, At tuple, At function: KqlUpsertRows, At function: DqCnUnionAll, At function: TDqOutput, At function: DqStage, At lambda, At function: Iterator, At function: FlatMap, At lambda, At function: FlatOptionalIf, At function: IfPresent, At function: Just, At function: AsStruct, At tuple, At function: Nothing, At function: Nothing, At function: Nothing
        <main>:3:69: Error: Expected optional, pg type or Null type, but got: String
```