### PR TITLE
Add GroupIds to error messages about timeouts in DSProxy

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
@@ -229,11 +229,13 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
                 << ", dropping the queue (" << (ui64)InitQueue.size() << ")" << " Marker# DSP08");
             if (CurrentStateFunc() == &TThis::StateUnconfigured) {
                 ErrorDescription = TStringBuilder() << "Too many requests while waiting for configuration (DSPE2)."
+                        << " GroupId# " << GroupId
                         << " UnconfiguredStateTs# " << UnconfiguredStateTs
                         << " UnconfiguredStateReason " << UnconfiguredStateReasonStr(UnconfiguredStateReason);
                 SetStateUnconfiguredTimeout();
             } else if (CurrentStateFunc() == &TThis::StateEstablishingSessions) {
                 ErrorDescription = TStringBuilder() << "Too many requests while establishing sessions (DSPE5)."
+                        << " GroupId# " << GroupId
                         << " EstablishingSessionsStateTs# " << EstablishingSessionsStateTs;
                 SetStateEstablishingSessionsTimeout();
             }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
@@ -186,11 +186,12 @@ namespace NKikimr {
             return;
         }
 
-        TString details = TStringBuilder() << "UnconfiguredStateTs# " << UnconfiguredStateTs
+        TString details = TStringBuilder() << " GroupId# " << GroupId
+                << "UnconfiguredStateTs# " << UnconfiguredStateTs
                 << " UnconfiguredStateReason# " << UnconfiguredStateReasonStr(UnconfiguredStateReason);
 
-        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::BS_PROXY, "Group# " << GroupId
-                << " Unconfigured Wakeup TIMEOUT Marker# DSP05 " << details);
+        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::BS_PROXY,
+                "Unconfigured Wakeup TIMEOUT Marker# DSP05 " << details);
                 
         ErrorDescription = "Configuration timeout occured (DSPE1). " + details;
         EstablishingSessionsPutMuteChecker.Unmute();
@@ -215,10 +216,11 @@ namespace NKikimr {
         if (ev && ev->Get() != EstablishingSessionsTimeoutEv) {
             return;
         }
-        TString details = TStringBuilder() << "EstablishingSessionsStateTs# " << EstablishingSessionsStateTs
+        TString details = TStringBuilder() << " GroupId# " << GroupId
+                << "EstablishingSessionsStateTs# " << EstablishingSessionsStateTs
                 << " NumUnconnectedDisks# " << NumUnconnectedDisks;
-        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::BS_PROXY, "Group# " << GroupId
-                << " StateEstablishingSessions Wakeup TIMEOUT Marker# DSP12 " << details);
+        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::BS_PROXY,
+                "StateEstablishingSessions Wakeup TIMEOUT Marker# DSP12 " << details);
         ErrorDescription = "Timeout while establishing sessions (DSPE4). " + details;
         SetStateEstablishingSessionsTimeout();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make messages about timeouts event more elaborate.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)