### PR TITLE
more parallel tsan and msan

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -133,10 +133,10 @@ jobs:
             echo "threads_count=20" >> $GITHUB_ENV
             echo "timeout=1200" >> $GITHUB_ENV
           elif [[ "${{ inputs.build_preset }}" == "release-msan" ]]; then
-            echo "threads_count=5" >> $GITHUB_ENV
+            echo "threads_count=18" >> $GITHUB_ENV
             echo "timeout=1200" >> $GITHUB_ENV
           elif [[ "${{ inputs.build_preset }}" == "release-tsan" ]]; then
-            echo "threads_count=10" >> $GITHUB_ENV
+            echo "threads_count=18" >> $GITHUB_ENV
             echo "timeout=1200" >> $GITHUB_ENV
           else
             echo "Unknown build_preset value."


### PR DESCRIPTION
Because they are too slow

Some random test ram usage:

relwithdebinfo
ydb/tests/functional/encryption sole chunk 5.78 GiB

asan
ydb/tests/functional/encryption sole chunk 22.63 GiB

tsan
ydb/tests/functional/encryption sole chunk 16.06 GiB

msan
ydb/tests/functional/encryption sole chunk 14.21 GiB