### PR TITLE
Add new parameter InferPDiskSlotCountMax

### DIFF
--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -266,7 +266,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
     ui32 CreatePDisk(TTestActorRuntime &runtime, ui32 nodeIdx, TString path, ui64 guid, ui32 pdiskId, ui64 pDiskCategory,
             const NKikimrBlobStorage::TPDiskConfig* pdiskConfig = nullptr, ui64 inferPDiskSlotCountFromUnitSize = 0,
-            TActorId nodeWarden = {}) {
+            ui32 inferPDiskSlotCountMax = 0, TActorId nodeWarden = {}) {
         VERBOSE_COUT(" Creating pdisk");
 
         ui32 nodeId = runtime.GetNodeId(nodeIdx);
@@ -284,6 +284,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         }
         if (inferPDiskSlotCountFromUnitSize != 0) {
             pdisk->SetInferPDiskSlotCountFromUnitSize(inferPDiskSlotCountFromUnitSize);
+            pdisk->SetInferPDiskSlotCountMax(inferPDiskSlotCountMax);
         }
 
         if (!nodeWarden) {
@@ -942,11 +943,11 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         UNIT_ASSERT_EQUAL(pdiskId, restartPDiskEv->PDiskId);
     }
 
-    void TestInferPDiskSlotCount(ui64 driveSize, ui64 unitSizeInBytes,
+    void TestInferPDiskSlotCount(ui64 driveSize, ui64 unitSizeInBytes, ui32 maxSlots,
             ui64 expectedSlotCount, ui32 expectedSlotSizeInUnits, double expectedRelativeError = 0) {
         TIntrusivePtr<TPDiskConfig> pdiskConfig = new TPDiskConfig("fake_drive", 0, 0, 0);
 
-        NStorage::TNodeWarden::InferPDiskSlotCount(pdiskConfig, driveSize, unitSizeInBytes);
+        NStorage::TNodeWarden::InferPDiskSlotCount(pdiskConfig, driveSize, unitSizeInBytes, maxSlots);
 
         double unitSizeCalculated = double(driveSize) / pdiskConfig->ExpectedSlotCount / pdiskConfig->SlotSizeInUnits;
         double unitSizeRelativeError =  (unitSizeCalculated - unitSizeInBytes) / unitSizeInBytes;
@@ -954,6 +955,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         VERBOSE_COUT(""
             << " driveSize# " << driveSize
             << " unitSizeInBytes# " << unitSizeInBytes
+            << " maxSlots# " << maxSlots
             << " ->"
             << " ExpectedSlotCount# " << pdiskConfig->ExpectedSlotCount
             << " SlotSizeInUnits# " << pdiskConfig->SlotSizeInUnits
@@ -975,30 +977,38 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
     }
 
     CUSTOM_UNIT_TEST(TestInferPDiskSlotCountPureFunction) {
-        TestInferPDiskSlotCount(7900, 1000, 8, 1u, 0.0125);
-        TestInferPDiskSlotCount(8000, 1000, 8, 1u, std::numeric_limits<double>::epsilon());
-        TestInferPDiskSlotCount(8100, 1000, 8, 1u, 0.0125);
-        TestInferPDiskSlotCount(16000, 1000, 16, 1u, std::numeric_limits<double>::epsilon());
-        TestInferPDiskSlotCount(24000, 1000, 12, 2u, std::numeric_limits<double>::epsilon());
-        TestInferPDiskSlotCount(31000, 1000, 16, 2u, 0.032);
-        TestInferPDiskSlotCount(50000, 1000, 13, 4u, 0.039);
-        TestInferPDiskSlotCount(50000, 100, 16, 32u, 0.024);
-        TestInferPDiskSlotCount(18000, 200, 11, 8u, 0.023);
+        TestInferPDiskSlotCount(7900, 1000, 16, 8, 1u, 0.0125);
+        TestInferPDiskSlotCount(8000, 1000, 16, 8, 1u, std::numeric_limits<double>::epsilon());
+        TestInferPDiskSlotCount(8100, 1000, 16, 8, 1u, 0.0125);
+        TestInferPDiskSlotCount(16000, 1000, 16, 16, 1u, std::numeric_limits<double>::epsilon());
+        TestInferPDiskSlotCount(24000, 1000, 16, 12, 2u, std::numeric_limits<double>::epsilon());
+        TestInferPDiskSlotCount(31000, 1000, 16, 16, 2u, 0.032);
+        TestInferPDiskSlotCount(50000, 1000, 16, 13, 4u, 0.039);
+        TestInferPDiskSlotCount(50000, 100, 16, 16, 32u, 0.024);
+        TestInferPDiskSlotCount(18000, 200, 16, 11, 8u, 0.023);
 
-        for (ui64 i=1; i<=1024; i++) {
-            // In all cases the relative error doesn't exceed 1/maxSlotCount
-            TestInferPDiskSlotCount(i, 1, 0, 0, 1./16);
+        for (ui32 maxSlots = 1; maxSlots <= 24; maxSlots++) {
+            for (ui64 i = 1; i <= 1024; i++) {
+                // In all cases the relative error doesn't exceed 1/maxSlots
+                TestInferPDiskSlotCount(i, 1, maxSlots, 0, 0, 1./maxSlots);
+            }
         }
 
+        const size_t c_160GB = 160'000'000'000;
         const size_t c_200GB = 200'000'000'000;
         const size_t c_2000GB = 2000'000'000'000;
 
         // Some real-world examples
-        TestInferPDiskSlotCount(1919'366'987'776, c_200GB, 10, 1u, 0.041); // "Micron_5200_MTFDDAK1T9TDD"
-        TestInferPDiskSlotCount(3199'243'124'736, c_200GB, 16, 1u, 0.001); // "SAMSUNG MZWLR3T8HBLS-00007"
-        TestInferPDiskSlotCount(6400'161'873'920, c_200GB, 16, 2u, 0.001); // "INTEL SSDPE2KE064T8"
-        TestInferPDiskSlotCount(6398'611'030'016, c_200GB, 16, 2u, 0.001); // "INTEL SSDPF2KX076T1"
-        TestInferPDiskSlotCount(17999'117'418'496, c_2000GB, 9, 1u, 0.001); // "WDC  WUH721818ALE6L4"
+        TestInferPDiskSlotCount(1919'366'987'776, c_200GB, 16, 10, 1u, 0.041); // "Micron_5200_MTFDDAK1T9TDD"
+        TestInferPDiskSlotCount(3199'243'124'736, c_200GB, 16, 16, 1u, 0.001); // "SAMSUNG MZWLR3T8HBLS-00007"
+        TestInferPDiskSlotCount(6400'161'873'920, c_200GB, 16, 16, 2u, 0.001); // "INTEL SSDPE2KE064T8"
+        TestInferPDiskSlotCount(6398'611'030'016, c_200GB, 16, 16, 2u, 0.001); // "INTEL SSDPF2KX076T1"
+        TestInferPDiskSlotCount(17999'117'418'496, c_2000GB, 16, 9, 1u, 0.001); // "WDC  WUH721818ALE6L4"
+
+        // Another real-world case
+        TestInferPDiskSlotCount(3199'556'648'960, c_160GB, 24, 20, 1u, 0.001);
+        TestInferPDiskSlotCount(6399'968'935'936, c_160GB, 24, 20, 2u, 0.001);
+        TestInferPDiskSlotCount(17999'117'418'496, c_2000GB, 24, 9, 1u, 0.001);
     }
 
     void CheckInferredPDiskSettings(TTestBasicRuntime& runtime, TActorId fakeWhiteboard, TActorId fakeNodeWarden,
@@ -1084,7 +1094,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         NKikimrBlobStorage::TPDiskConfig pdiskConfig;
         pdiskConfig.SetExpectedSlotCount(13);
         CreatePDisk(runtime, 0, pdiskPath, 0, pdiskId, 0,
-            &pdiskConfig, inferPDiskSlotCountFromUnitSize, realNodeWarden);
+            &pdiskConfig, inferPDiskSlotCountFromUnitSize, 16, realNodeWarden);
         CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
             pdiskId, 13, 0u);
     }
@@ -1105,7 +1115,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
         NKikimrBlobStorage::TPDiskConfig pdiskConfig;
         CreatePDisk(runtime, 0, pdiskPath, 0, pdiskId, 0,
-            &pdiskConfig, inferPDiskSlotCountFromUnitSize, realNodeWarden);
+            &pdiskConfig, inferPDiskSlotCountFromUnitSize, 16, realNodeWarden);
         CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
             pdiskId, 12, 2u);
     }

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -247,7 +247,7 @@ namespace NKikimr::NStorage {
         TControlWrapper PredictedDelayMultiplier;
         TControlWrapper PredictedDelayMultiplierHDD;
         TControlWrapper PredictedDelayMultiplierSSD;
-    
+
         TControlWrapper MaxNumOfSlowDisks;
         TControlWrapper MaxNumOfSlowDisksHDD;
         TControlWrapper MaxNumOfSlowDisksSSD;
@@ -275,7 +275,7 @@ namespace NKikimr::NStorage {
         }
 
         TIntrusivePtr<TPDiskConfig> CreatePDiskConfig(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk);
-        static void InferPDiskSlotCount(TIntrusivePtr<TPDiskConfig> pdiskConfig, ui64 driveSize, ui64 unitSizeInBytes);
+        static void InferPDiskSlotCount(TIntrusivePtr<TPDiskConfig> pdiskConfig, ui64 driveSize, ui64 unitSizeInBytes, ui32 maxSlots);
         void StartLocalPDisk(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk, bool temporary);
         void AskBSCToRestartPDisk(ui32 pdiskId, bool ignoreDegradedGroups, ui64 requestCookie);
         void OnPDiskRestartFinished(ui32 pdiskId, NKikimrProto::EReplyStatus status);

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -16,15 +16,15 @@ namespace NKikimr::NStorage {
         {NPDisk::DEVICE_TYPE_NVME, 300000000},
     };
 
-    void TNodeWarden::InferPDiskSlotCount(TIntrusivePtr<TPDiskConfig> pdiskConfig, ui64 driveSize, ui64 unitSizeInBytes) {
+    void TNodeWarden::InferPDiskSlotCount(TIntrusivePtr<TPDiskConfig> pdiskConfig, ui64 driveSize, ui64 unitSizeInBytes, ui32 maxSlots) {
         Y_ABORT_UNLESS(driveSize);
         Y_ABORT_UNLESS(unitSizeInBytes);
 
         const double slotCount = lround(double(driveSize) / unitSizeInBytes);
         ui32 slotSizeInUnits = 1u;
 
-        constexpr long MaxSlots = 16;
-        while (lround(slotCount/slotSizeInUnits) > MaxSlots) {
+        maxSlots = maxSlots ? maxSlots : 16;
+        while (lround(slotCount/slotSizeInUnits) > maxSlots) {
             slotSizeInUnits *= 2;
         }
 
@@ -153,7 +153,8 @@ namespace NKikimr::NStorage {
                 STLOG(PRI_ERROR, BS_NODE, NW96, "Unable to determine drive size for inferring PDisk slot count",
                     (Path, path), (Details, outDetails.Str()));
             } else {
-                InferPDiskSlotCount(pdiskConfig, driveSize, unitSizeInBytes);
+                ui32 maxSlots = pdisk.GetInferPDiskSlotCountMax();
+                InferPDiskSlotCount(pdiskConfig, driveSize, unitSizeInBytes, maxSlots);
             }
         }
 

--- a/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
@@ -26,6 +26,7 @@ namespace NKikimr {
             TPDiskCategory PDiskCategory = {};
             TString PDiskConfig;
             ui64 InferPDiskSlotCountFromUnitSize = 0;
+            ui32 InferPDiskSlotCountMax = 0;
 
             TDiskId GetId() const {
                 return {NodeId, Path};
@@ -74,7 +75,8 @@ namespace NKikimr {
                 pdiskInfo->ReadCentric != disk.ReadCentric ||
                 pdiskInfo->BoxId != disk.BoxId ||
                 pdiskInfo->PDiskConfig != disk.PDiskConfig ||
-                pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize)
+                pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize ||
+                pdiskInfo->InferPDiskSlotCountMax != disk.InferPDiskSlotCountMax)
             {
                 // update PDisk configuration
                 auto pdiskInfo = state.PDisks.FindForUpdate(pdiskId);
@@ -84,15 +86,18 @@ namespace NKikimr {
                 pdiskInfo->ReadCentric = disk.ReadCentric;
                 pdiskInfo->BoxId = disk.BoxId;
                 if (pdiskInfo->PDiskConfig != disk.PDiskConfig
-                        || pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize) {
+                        || pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize
+                        || pdiskInfo->InferPDiskSlotCountMax != disk.InferPDiskSlotCountMax) {
                     const std::optional<TBlobStorageController::TStaticPDiskInfo> staticPDisk = FindStaticPDisk(disk, state).transform(
                         [&](TPDiskId id) {return state.StaticPDisks.at(id);});
                     if (staticPDisk && (staticPDisk->PDiskConfig != disk.PDiskConfig
-                            || staticPDisk->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize)) {
+                            || staticPDisk->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize
+                            || staticPDisk->InferPDiskSlotCountMax != disk.InferPDiskSlotCountMax)) {
                         throw TExError() << "PDiskConfig mismatch for static disk" << TErrorParams::NodeId(disk.NodeId) << TErrorParams::Path(disk.Path);
                     } else {
                         pdiskInfo->PDiskConfig = disk.PDiskConfig;
                         pdiskInfo->InferPDiskSlotCountFromUnitSize = disk.InferPDiskSlotCountFromUnitSize;
+                        pdiskInfo->InferPDiskSlotCountMax = disk.InferPDiskSlotCountMax;
                     }
                 }
                 // run ExtractConfig as the very last step
@@ -338,7 +343,8 @@ namespace NKikimr {
                             disk.Serial, disk.LastSeenSerial, disk.LastSeenPath, staticSlotUsage,
                             true /* assume shred completed for this disk */,
                             NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST,
-                            disk.InferPDiskSlotCountFromUnitSize);
+                            disk.InferPDiskSlotCountFromUnitSize,
+                            disk.InferPDiskSlotCountMax);
 
                     // Set PDiskId and Guid in DrivesSerials
                     if (auto info = state.DrivesSerials.FindForUpdate(disk.Serial)) {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -352,6 +352,7 @@ public:
         ui32 NumActiveSlots = 0; // sum of owners weights allocated on this PDisk
         ui32 SlotSizeInUnits = 0;
         ui64 InferPDiskSlotCountFromUnitSize = 0;
+        ui32 InferPDiskSlotCountMax = 0;
         TMap<Schema::VSlot::VSlotID::Type, TIndirectReferable<TVSlotInfo>::TPtr> VSlotsOnPDisk; // vslots over this PDisk
 
         bool Operational = false; // set to true when both containing node is connected and Operational is reported in Metrics
@@ -391,7 +392,8 @@ public:
                     Table::DecommitStatus,
                     Table::ShredComplete,
                     Table::MaintenanceStatus,
-                    Table::InferPDiskSlotCountFromUnitSize
+                    Table::InferPDiskSlotCountFromUnitSize,
+                    Table::InferPDiskSlotCountMax
                 > adapter(
                     &TPDiskInfo::Path,
                     &TPDiskInfo::Kind,
@@ -409,7 +411,8 @@ public:
                     &TPDiskInfo::DecommitStatus,
                     &TPDiskInfo::ShredComplete,
                     &TPDiskInfo::MaintenanceStatus,
-                    &TPDiskInfo::InferPDiskSlotCountFromUnitSize
+                    &TPDiskInfo::InferPDiskSlotCountFromUnitSize,
+                    &TPDiskInfo::InferPDiskSlotCountMax
                 );
             callback(&adapter);
         }
@@ -434,7 +437,8 @@ public:
                    ui32 staticSlotUsage,
                    bool shredComplete,
                    NKikimrBlobStorage::TMaintenanceStatus::E maintenanceStatus,
-                   ui64 inferPDiskSlotCountFromUnitSize)
+                   ui64 inferPDiskSlotCountFromUnitSize,
+                   ui32 inferPDiskSlotCountMax)
             : HostId(hostId)
             , Path(path)
             , Kind(kind)
@@ -446,6 +450,7 @@ public:
             , ShredComplete(shredComplete)
             , BoxId(boxId)
             , InferPDiskSlotCountFromUnitSize(inferPDiskSlotCountFromUnitSize)
+            , InferPDiskSlotCountMax(inferPDiskSlotCountMax)
             , Status(status)
             , StatusTimestamp(statusTimestamp)
             , DecommitStatus(decommitStatus)
@@ -969,6 +974,7 @@ public:
             Table::Kind::Type Kind;
             TMaybe<Table::PDiskConfig::Type> PDiskConfig;
             Table::InferPDiskSlotCountFromUnitSize::Type InferPDiskSlotCountFromUnitSize;
+            Table::InferPDiskSlotCountMax::Type InferPDiskSlotCountMax;
 
             template<typename T>
             static void Apply(TBlobStorageController* /*controller*/, T&& callback) {
@@ -978,14 +984,16 @@ public:
                         Table::ReadCentric,
                         Table::Kind,
                         Table::PDiskConfig,
-                        Table::InferPDiskSlotCountFromUnitSize
+                        Table::InferPDiskSlotCountFromUnitSize,
+                        Table::InferPDiskSlotCountMax
                     > adapter(
                         &TDriveInfo::Type,
                         &TDriveInfo::SharedWithOs,
                         &TDriveInfo::ReadCentric,
                         &TDriveInfo::Kind,
                         &TDriveInfo::PDiskConfig,
-                        &TDriveInfo::InferPDiskSlotCountFromUnitSize
+                        &TDriveInfo::InferPDiskSlotCountFromUnitSize,
+                        &TDriveInfo::InferPDiskSlotCountMax
                     );
                 callback(&adapter);
             }
@@ -2484,6 +2492,7 @@ public:
         Schema::PDisk::PDiskConfig::Type PDiskConfig;
         ui32 ExpectedSlotCount = 0;
         ui64 InferPDiskSlotCountFromUnitSize = 0;
+        ui32 InferPDiskSlotCountMax = 0;
 
         // runtime info
         ui32 StaticSlotUsage = 0;
@@ -2497,6 +2506,7 @@ public:
             , Category(pdisk.GetPDiskCategory())
             , Guid(pdisk.GetPDiskGuid())
             , InferPDiskSlotCountFromUnitSize(pdisk.GetInferPDiskSlotCountFromUnitSize())
+            , InferPDiskSlotCountMax(pdisk.GetInferPDiskSlotCountMax())
         {
             if (pdisk.HasPDiskConfig()) {
                 const auto& cfg = pdisk.GetPDiskConfig();

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -354,7 +354,8 @@ public:
                     disks.GetValue<T::DecommitStatus>(), disks.GetValue<T::Mood>(), disks.GetValue<T::ExpectedSerial>(),
                     disks.GetValue<T::LastSeenSerial>(), disks.GetValue<T::LastSeenPath>(), staticSlotUsage,
                     disks.GetValueOrDefault<T::ShredComplete>(), disks.GetValueOrDefault<T::MaintenanceStatus>(),
-                    disks.GetValueOrDefault<T::InferPDiskSlotCountFromUnitSize>());
+                    disks.GetValueOrDefault<T::InferPDiskSlotCountFromUnitSize>(),
+                    disks.GetValueOrDefault<T::InferPDiskSlotCountMax>());
 
                 if (!disks.Next())
                     return false;

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -46,11 +46,12 @@ struct Schema : NIceDb::Schema {
         struct ShredComplete : Column<19, NScheme::NTypeIds::Bool> { static constexpr Type Default = true; };
         struct MaintenanceStatus : Column<20, NScheme::NTypeIds::Uint8> { using Type = NKikimrBlobStorage::TMaintenanceStatus::E; static constexpr Type Default = NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST; };
         struct InferPDiskSlotCountFromUnitSize : Column<21, NScheme::NTypeIds::Uint64> { static constexpr Type Default = 0; };
+        struct InferPDiskSlotCountMax : Column<22, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
 
         using TKey = TableKey<NodeID, PDiskID>; // order is important
         using TColumns = TableColumns<NodeID, PDiskID, Path, Category, Guid, SharedWithOs, ReadCentric, NextVSlotId,
               Status, Timestamp, PDiskConfig, ExpectedSerial, LastSeenSerial, LastSeenPath, DecommitStatus, Mood,
-              ShredComplete, MaintenanceStatus, InferPDiskSlotCountFromUnitSize>;
+              ShredComplete, MaintenanceStatus, InferPDiskSlotCountFromUnitSize, InferPDiskSlotCountMax>;
     };
 
     struct Group : Table<4> {
@@ -248,9 +249,11 @@ struct Schema : NIceDb::Schema {
         struct Kind : Column<6, NScheme::NTypeIds::Uint64> {};
         struct PDiskConfig : Column<7, NScheme::NTypeIds::String> {};
         struct InferPDiskSlotCountFromUnitSize : Column<8, NScheme::NTypeIds::Uint64> { static constexpr Type Default = 0; };
+        struct InferPDiskSlotCountMax : Column<9, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
 
         using TKey = TableKey<HostConfigId, Path>;
-        using TColumns = TableColumns<HostConfigId, Path, TypeCol, SharedWithOs, ReadCentric, Kind, PDiskConfig, InferPDiskSlotCountFromUnitSize>;
+        using TColumns = TableColumns<HostConfigId, Path, TypeCol, SharedWithOs, ReadCentric, Kind, PDiskConfig, InferPDiskSlotCountFromUnitSize,
+            InferPDiskSlotCountMax>;
     };
 
     struct BoxHostV2 : Table<105> {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1000,9 +1000,11 @@ message TNodeWardenServiceSet {
         optional bool ReadOnly = 14;
         optional bool Stop = 15;
 
-        // If not zero, NodeWarded infers PDiskConfig ExpectedSlotCount and SlotSizeInUnits (if unset)
-        // from drive size and this value
+        // If not zero, NodeWarded infers PDiskConfig ExpectedSlotCount and SlotSizeInUnits (if unset) by the formula
+        // ExpectedSlotCount * SlotSizeInUnits = TotalSize / InferPDiskSlotCountFromUnitSize
+        // where SlotSizeInUnits = 2^N is chosen to meet ExpectedSlotCount <= InferPDiskSlotCountMax
         optional uint64 InferPDiskSlotCountFromUnitSize = 16;
+        optional uint32 InferPDiskSlotCountMax = 17;
     }
 
     message TVDisk {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -25,6 +25,7 @@ message THostConfigDrive {
     // optional PDisk config for these drives; if not set, default configuration is applied; overrides host-wide default
     NKikimrBlobStorage.TPDiskConfig PDiskConfig = 6;
     uint64 InferPDiskSlotCountFromUnitSize = 7;
+    uint32 InferPDiskSlotCountMax = 8;
 }
 
 // Command used to define typical host configuration. It it used while defining new typical host configurations and as
@@ -719,6 +720,7 @@ message TBaseConfig {
         bool ReadOnly = 19;
         TMaintenanceStatus.E MaintenanceStatus = 20;
         uint64 InferPDiskSlotCountFromUnitSize = 21;
+        uint32 InferPDiskSlotCountMax = 22;
     }
     message TVSlot {
         message TDonorDisk {

--- a/ydb/library/yaml_config/protos/config.proto
+++ b/ydb/library/yaml_config/protos/config.proto
@@ -76,11 +76,17 @@ message TExtendedHostConfigDrive {
     optional uint64 ExpectedSlotCount = 7;
     optional uint32 SlotSizeInUnits = 8;
     optional uint64 InferPDiskSlotCountFromUnitSize = 9 [(NMarkers.CopyTo) = "THostConfigDrive"];
+    optional uint32 InferPDiskSlotCountMax = 10 [(NMarkers.CopyTo) = "THostConfigDrive"];
 }
 
 message TInferPDiskSlotCountFromUnitSize {
     optional uint64 Rot = 1;
     optional uint64 Ssd = 2; // Implies both ssd and nvme
+}
+
+message TInferPDiskSlotCountMax {
+    optional uint32 Rot = 1;
+    optional uint32 Ssd = 2; // Implies both ssd and nvme
 }
 
 message THosts {
@@ -149,6 +155,7 @@ message TExtendedDefineHostConfig {
     repeated string Nvme = 7 [(NMarkers.CopyTo) = "TDefineHostConfig"];
 
     optional TInferPDiskSlotCountFromUnitSize InferPDiskSlotCountFromUnitSize = 8;
+    optional TInferPDiskSlotCountMax InferPDiskSlotCountMax = 9;
 
     optional uint64 ItemConfigGeneration = 100 [(NMarkers.CopyTo) = "TDefineHostConfig"];
 }

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
@@ -351,6 +351,11 @@
                 "ColumnId": 21,
                 "ColumnName": "InferPDiskSlotCountFromUnitSize",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 22,
+                "ColumnName": "InferPDiskSlotCountMax",
+                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
@@ -375,7 +380,8 @@
                     18,
                     19,
                     20,
-                    21
+                    21,
+                    22
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -1940,6 +1946,11 @@
                 "ColumnId": 8,
                 "ColumnName": "InferPDiskSlotCountFromUnitSize",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 9,
+                "ColumnName": "InferPDiskSlotCountMax",
+                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
@@ -1953,7 +1964,8 @@
                     5,
                     6,
                     7,
-                    8
+                    8,
+                    9
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog category 

* Not for changelog (changelog entry is not required)

### Description for reviewers 

Новый параметр InferPDiskSlotCountMax дополняет собой InferPDiskSlotCountFromUnitSize и определяет максимальное количество слотов, после которого диски становятся двойными. 

> `ExpectedSlotCount * SlotSizeInUnits = TotalSize / InferPDiskSlotCountFromUnitSize`
> where `SlotSizeInUnits = 2^N` is chosen to meet `ExpectedSlotCount <= InferPDiskSlotCountMax`
 
Это нужно для prestable, где традиционно количество слотов 24. В текущей версии была захардкожена константа 16.

- Follow-up for https://github.com/ydb-platform/ydb/pull/20966, https://github.com/ydb-platform/ydb/issues/19709 