### PR TITLE
Get rid of expected status checking in BSC

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -1022,7 +1022,6 @@ config:
         if (force) {
             request.SetIgnoreGroupFailModelChecks(true);
             request.SetIgnoreDegradedGroupsChecks(true);
-            request.SetIgnoreDisintegratedGroupsChecks(true);
             request.SetIgnoreGroupSanityChecks(true);
         }
         auto *cmd = request.AddCommand();
@@ -1067,7 +1066,6 @@ config:
         NKikimrBlobStorage::TConfigRequest request;
         request.SetIgnoreGroupFailModelChecks(true);
         request.SetIgnoreDegradedGroupsChecks(true);
-        request.SetIgnoreDisintegratedGroupsChecks(true);
         auto *cmd = request.AddCommand();
         auto *wipe = cmd->MutableWipeVDisk();
         auto *vslot = wipe->MutableVSlotId();

--- a/ydb/core/blobstorage/ut_blobstorage/move_pdisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/move_pdisk.cpp
@@ -81,7 +81,6 @@ Y_UNIT_TEST_SUITE(BSCMovePDisk) {
                 }
                 NKikimrBlobStorage::TConfigRequest request;
                 auto *cmd = request.AddCommand()->MutableReassignGroupDisk();
-                request.SetIgnoreDisintegratedGroupsChecks(true);
                 request.SetIgnoreDegradedGroupsChecks(true);
                 request.SetIgnoreGroupFailModelChecks(true);
                 cmd->SetGroupId(vslot.GetGroupId());

--- a/ydb/core/blobstorage/ut_blobstorage/sanitize_groups.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/sanitize_groups.cpp
@@ -276,7 +276,6 @@ Y_UNIT_TEST_SUITE(GroupLayoutSanitizer) {
             request.SetIgnoreGroupFailModelChecks(true);
             request.SetIgnoreGroupSanityChecks(true);
             request.SetIgnoreDegradedGroupsChecks(true);
-            request.SetIgnoreDisintegratedGroupsChecks(true);
             for (ui32 i = 0; i < drives; ++i) {
                 auto* cmd = request.AddCommand();
                 auto* drive = cmd->MutableUpdateDriveStatus();

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -18,7 +18,7 @@ SRCS(
     assimilation.cpp
     backpressure.cpp
     block_race.cpp
-    bsc_cache.cpp
+    bsc.cpp
     counting_events.cpp
     deadlines.cpp
     decommit_3dc.cpp

--- a/ydb/core/mind/bscontroller/bridge.cpp
+++ b/ydb/core/mind/bscontroller/bridge.cpp
@@ -61,7 +61,7 @@ public:
             }
         }
 
-        if (TString error; State->Changed() && !Self->CommitConfigUpdates(*State, true, true, true, txc, &error)) {
+        if (TString error; State->Changed() && !Self->CommitConfigUpdates(*State, true, true, txc, &error)) {
             State->Rollback();
             State.reset();
         }
@@ -113,7 +113,7 @@ public:
             State->GroupContentChanged.insert(GroupId);
         }
 
-        if (TString error; State->Changed() && !Self->CommitConfigUpdates(*State, true, true, true, txc, &error)) {
+        if (TString error; State->Changed() && !Self->CommitConfigUpdates(*State, true, true, txc, &error)) {
             State->Rollback();
             State.reset();
         }

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -603,9 +603,6 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerConfigResponse:
             for (const auto& group : resp.GetGroupsGetDisintegrated()) {
                 s << " GroupGetDisintegrated# " << group;
             }
-            for (const auto& group : resp.GetGroupsGetDisintegratedByExpectedStatus()) {
-                s << " GroupGetDisintegratedByExpectedStatus# " << group;
-            }
             errorReason = s.Str();
         }
 

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -330,8 +330,8 @@ namespace NKikimr::NBsController {
         };
 
         bool TBlobStorageController::CommitConfigUpdates(TConfigState& state, bool suppressFailModelChecking,
-                bool suppressDegradedGroupsChecking, bool suppressDisintegratedGroupsChecking,
-                TTransactionContext& txc, TString *errorDescription, NKikimrBlobStorage::TConfigResponse *response) {
+                bool suppressDegradedGroupsChecking, TTransactionContext& txc, TString *errorDescription,
+                NKikimrBlobStorage::TConfigResponse *response) {
             NIceDb::TNiceDb db(txc.DB);
 
             // when bridged non-proxy groups get updated, we update parent group too
@@ -395,23 +395,8 @@ namespace NKikimr::NBsController {
             }
 
             bool errors = false;
-            std::vector<TGroupId> disintegratedByExpectedStatus;
             std::vector<TGroupId> disintegrated;
             std::vector<TGroupId> degraded;
-
-            if (!suppressDisintegratedGroupsChecking) {
-                for (auto&& [base, overlay] : state.Groups.Diff()) {
-                    if (base && overlay->second) {
-                        const TGroupInfo::TGroupStatus& prev = base->second->Status;
-                        const TGroupInfo::TGroupStatus& status = overlay->second->Status;
-                        if (status.ExpectedStatus == NKikimrBlobStorage::TGroupStatus::DISINTEGRATED &&
-                                status.ExpectedStatus != prev.ExpectedStatus) { // status did really change
-                            disintegratedByExpectedStatus.push_back(overlay->first);
-                            errors = true;
-                        }
-                    }
-                }
-            }
 
             // check that group modification would not degrade failure model
             if (!suppressFailModelChecking) {
@@ -476,14 +461,6 @@ namespace NKikimr::NBsController {
                     if (response) {
                         for (const auto& id: disintegrated) {
                             response->MutableGroupsGetDisintegrated()->Add(id.GetRawId());
-                        }
-                    }
-                }
-                if (!disintegratedByExpectedStatus.empty()) {
-                    msg << "DisintegratedByExpectedStatus GroupIds# " << FormatList(disintegratedByExpectedStatus) << ' ';
-                    if (response) {
-                        for (const auto& id: disintegratedByExpectedStatus) {
-                            response->MutableGroupsGetDisintegratedByExpectedStatus()->Add(id.GetRawId());
                         }
                     }
                 }

--- a/ydb/core/mind/bscontroller/config_cmd.cpp
+++ b/ydb/core/mind/bscontroller/config_cmd.cpp
@@ -272,8 +272,7 @@ namespace NKikimr::NBsController {
 
                 const bool doLogCommand = Success && State->Changed();
                 Success = Success && Self->CommitConfigUpdates(*State, Cmd.GetIgnoreGroupFailModelChecks(),
-                    Cmd.GetIgnoreDegradedGroupsChecks(), Cmd.GetIgnoreDisintegratedGroupsChecks(), txc, &Error,
-                    Response);
+                    Cmd.GetIgnoreDegradedGroupsChecks(), txc, &Error, Response);
 
                 Finish();
                 if (doLogCommand) {

--- a/ydb/core/mind/bscontroller/drop_donor.cpp
+++ b/ydb/core/mind/bscontroller/drop_donor.cpp
@@ -28,7 +28,7 @@ public:
         }
         State->CheckConsistency();
         TString error;
-        if (State->Changed() && !Self->CommitConfigUpdates(*State, false, false, false, txc, &error)) {
+        if (State->Changed() && !Self->CommitConfigUpdates(*State, false, false, txc, &error)) {
             State->Rollback();
             State.reset();
         }

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1595,8 +1595,7 @@ private:
     void UpdateSystemViews();
 
     bool CommitConfigUpdates(TConfigState& state, bool suppressFailModelChecking, bool suppressDegradedGroupsChecking,
-        bool suppressDisintegratedGroupsChecking, TTransactionContext& txc, TString *errorDescription,
-        NKikimrBlobStorage::TConfigResponse *response = nullptr);
+        TTransactionContext& txc, TString *errorDescription, NKikimrBlobStorage::TConfigResponse *response = nullptr);
 
     void CommitSelfHealUpdates(TConfigState& state);
     void CommitScrubUpdates(TConfigState& state, TTransactionContext& txc);

--- a/ydb/core/mind/bscontroller/node_report.cpp
+++ b/ydb/core/mind/bscontroller/node_report.cpp
@@ -121,7 +121,7 @@ public:
 
         State->CheckConsistency();
         TString error;
-        if (State->Changed() && !Self->CommitConfigUpdates(*State, false, false, false, txc, &error)) {
+        if (State->Changed() && !Self->CommitConfigUpdates(*State, false, false, txc, &error)) {
             State->Rollback();
             State.reset();
         }

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -176,7 +176,7 @@ public:
         }
 
         TString error;
-        if (!updateIsSuccessful || (State->Changed() && !Self->CommitConfigUpdates(*State, false, false, false, txc, &error))) {
+        if (!updateIsSuccessful || (State->Changed() && !Self->CommitConfigUpdates(*State, false, false, txc, &error))) {
             State->Rollback();
             State.reset();
         }

--- a/ydb/core/mind/bscontroller/virtual_group.cpp
+++ b/ydb/core/mind/bscontroller/virtual_group.cpp
@@ -270,7 +270,7 @@ namespace NKikimr::NBsController {
                     return TGroupGeometryInfo();
                 });
                 TString error;
-                if (State->Changed() && !Self->CommitConfigUpdates(*State, true, true, true, txc, &error)) {
+                if (State->Changed() && !Self->CommitConfigUpdates(*State, true, true, txc, &error)) {
                     STLOG(PRI_ERROR, BS_CONTROLLER, BSCVG08, "failed to commit update", (VirtualGroupId, GroupId), (Error, error));
                     State->Rollback();
                     State.reset();
@@ -312,7 +312,7 @@ namespace NKikimr::NBsController {
                 const size_t n = State->BlobDepotDeleteQueue.Unshare().erase(GroupId);
                 Y_ABORT_UNLESS(n == 1);
                 TString error;
-                if (State->Changed() && !Self->CommitConfigUpdates(*State, true, true, true, txc, &error)) {
+                if (State->Changed() && !Self->CommitConfigUpdates(*State, true, true, txc, &error)) {
                     STLOG(PRI_ERROR, BS_CONTROLLER, BSCVG17, "failed to commit update", (VirtualGroupId, GroupId), (Error, error));
                     State->Rollback();
                     State.reset();
@@ -914,7 +914,7 @@ namespace NKikimr::NBsController {
                 State.emplace(*Self, Self->HostRecords, TActivationContext::Now(), TActivationContext::Monotonic());
                 Action(*State);
                 TString error;
-                if (State->Changed() && !Self->CommitConfigUpdates(*State, true, true, true, txc, &error)) {
+                if (State->Changed() && !Self->CommitConfigUpdates(*State, true, true, txc, &error)) {
                     STLOG(PRI_INFO, BS_CONTROLLER, BSCVG09, "failed to commit update", (Error, error));
                     State->Rollback();
                     State.reset();

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -669,7 +669,7 @@ message TConfigRequest {
     bool IgnoreDegradedGroupsChecks = 8;
 
     // ignore disintegrated groups checking
-    bool IgnoreDisintegratedGroupsChecks = 11;
+    bool IgnoreDisintegratedGroupsChecks = 11; // for compatibility only, modern BSC doesn't use it
 
     // do not settle slots over non-operating PDisks
     bool SettleOnlyOnOperationalDisks = 9;
@@ -887,6 +887,6 @@ message TConfigResponse {
     uint64 ConfigTxSeqNo = 4;
     repeated uint32 GroupsGetDegraded = 5;
     repeated uint32 GroupsGetDisintegrated = 6;
-    repeated uint32 GroupsGetDisintegratedByExpectedStatus = 7;
+    repeated uint32 GroupsGetDisintegratedByExpectedStatus = 7; // for compatibility only, modern BSC doesn't use it
     bool RollbackSuccess = 8;
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Get rid of expected status checking in BSC

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch removes failures when changing PDisk status to INACTIVE/FAULTY.
