### PR TITLE
Support in-memory migration for volatile EvWrite transactions

### DIFF
--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2358,14 +2358,13 @@ message TInMemoryLockVolatileDependency {
 }
 
 // In-memory prepared volatile transactions, i.e. those we have accepted for
-// execution and may be planned and executed later. This includes planned and
-// acknowledged transactions that haven't executed yet (including those that
-// have not been committed yet?)
+// execution and which may be planned and executed later. This includes planned
+// and acknowledged transactions that haven't executed yet.
 message TInMemoryPreparedVolatileTx {
     optional uint64 TxId = 1;
     optional NActorsProto.TActorId Source = 2;
     optional uint64 Cookie = 3;
-    optional uint64 Type = 4;
+    optional uint64 Kind = 4;
     optional bytes Body = 5;
     optional uint64 Flags = 6;
     // This is Min/Max step of a prepared transactions, mostly used for deadline cleanup
@@ -2374,6 +2373,8 @@ message TInMemoryPreparedVolatileTx {
     // Specified when the transaction has been planned already (including predictions)
     optional uint64 PredictedStep = 9;
     optional uint64 Step = 10;
+    // Auxillary state which needs to be preserved
+    optional uint64 ReceivedAt = 11; // TInstant in microseconds
 }
 
 // In-memory waiting volatile transactions, i.e. those that have not been

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -623,6 +623,14 @@ void TDataShard::SendCommittedReplies(std::vector<std::unique_ptr<IEventHandle>>
     }
 }
 
+void TDataShard::SendRestartNotification(TOperation* op) {
+    if (!op->HasFlag(TTxFlags::RestartNotificationSent)) {
+        auto notify = MakeHolder<TEvDataShard::TEvProposeTransactionRestart>(TabletID(), op->GetGlobalTxId());
+        Send(op->GetTarget(), notify.Release(), 0, op->GetCookie());
+        op->SetFlag(TTxFlags::RestartNotificationSent);
+    }
+}
+
 class TDataShard::TWaitVolatileDependencies final : public IVolatileTxCallback {
 public:
     TWaitVolatileDependencies(

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -135,8 +135,10 @@ namespace NDataShard {
             // Operation was blocked and is waiting for explicit unblock
             BlockFailPointWaiting = 1ULL << 48,
             BlockFailPointUnblocked = 1ULL << 49,
+            // Operation sent a TEvProposeTransactionRestart notification
+            RestartNotificationSent = 1ULL << 50,
 
-            LastFlag = BlockFailPointUnblocked,
+            LastFlag = RestartNotificationSent,
 
             PrivateFlagsMask = 0xFFFFFFFFFFFF0000ULL,
             PreservedPrivateFlagsMask = ReadOnly | ProposeBlocker | NeedDiagnostics | GlobalReader

--- a/ydb/core/tx/datashard/datashard__init.cpp
+++ b/ydb/core/tx/datashard/datashard__init.cpp
@@ -31,8 +31,9 @@ private:
 
 class TDataShard::TTxInitRestored : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
 public:
-    TTxInitRestored(TDataShard* self)
+    TTxInitRestored(TDataShard* self, THashMap<ui64, TOperation::TPtr> migratedTxs)
         : TTransactionBase(self)
+        , MigratedTxs(std::move(migratedTxs))
     {}
 
     TTxType GetTxType() const override { return TXTYPE_INIT_RESTORED; }
@@ -41,6 +42,7 @@ public:
     void Complete(const TActorContext& ctx) override;
 
 private:
+    THashMap<ui64, TOperation::TPtr> MigratedTxs;
     bool InMemoryStateActorStarted = false;
 };
 
@@ -92,12 +94,41 @@ void TDataShard::TTxInit::Complete(const TActorContext &ctx) {
     LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "TDataShard::TTxInit::Complete");
 }
 
-void TDataShard::OnInMemoryStateRestored() {
-    Execute(CreateTxInitRestored());
+void TDataShard::OnInMemoryStateRestored(THashMap<ui64, TOperation::TPtr> migratedTxs) {
+    Execute(CreateTxInitRestored(std::move(migratedTxs)));
 }
 
 bool TDataShard::TTxInitRestored::Execute(TTransactionContext& txc, const TActorContext& ctx) {
     LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "TDataShard::TTxInitRestored::Execute");
+
+    if (!MigratedTxs.empty()) {
+        bool wasEmpty = Self->TransQueue.GetPlan().empty();
+
+        for (auto& [txId, op] : MigratedTxs) {
+            if (op->GetStep() && op->GetStep() > Self->Pipeline.GetLastPlannedTx().Step) {
+                // When op->GetStep() > LastPlannedTx.Step it means this tx was
+                // planned by the previous generation, but commit failed. We
+                // may have other non-volatile transactions which may need to
+                // be planned before this step, so change it to a predicted
+                // step instead.
+                op->SetPredictedStep(op->GetStep());
+                op->SetStep(0);
+            }
+            if (op->OnFinishMigration(*Self, txc.DB.GetScheme())) {
+                Self->TransQueue.AddTxInFly(op);
+                if (!op->IsExecutionPlanFinished()) {
+                    Self->Pipeline.GetExecutionUnit(op->GetCurrentUnit()).AddOperation(op);
+                }
+                if (op->GetPredictedStep() && !op->GetStep()) {
+                    Self->Pipeline.AddPredictedPlan(op->GetPredictedStep(), op->GetTxId(), ctx);
+                }
+            }
+        }
+
+        if (wasEmpty && Self->TransQueue.GetPlan().size()) {
+            Self->Pipeline.AddCandidateUnit(EExecutionUnitKind::PlanQueue);
+        }
+    }
 
     InMemoryStateActorStarted = Self->StartInMemoryStateActor();
 
@@ -728,8 +759,8 @@ ITransaction* TDataShard::CreateTxInit() {
     return new TTxInit(this);
 }
 
-ITransaction* TDataShard::CreateTxInitRestored() {
-    return new TTxInitRestored(this);
+ITransaction* TDataShard::CreateTxInitRestored(THashMap<ui64, TOperation::TPtr> migratedTxs) {
+    return new TTxInitRestored(this, std::move(migratedTxs));
 }
 
 ITransaction* TDataShard::CreateTxInitSchema() {

--- a/ydb/core/tx/datashard/datashard_active_transaction.cpp
+++ b/ydb/core/tx/datashard/datashard_active_transaction.cpp
@@ -975,9 +975,7 @@ bool TActiveTransaction::OnStopping(TDataShard& self, const TActorContext& ctx) 
     } else {
         // Distributed operations send notification when proposed
         if (GetTarget() && !HasCompletedFlag()) {
-            auto notify = MakeHolder<TEvDataShard::TEvProposeTransactionRestart>(
-                self.TabletID(), GetTxId());
-            ctx.Send(GetTarget(), notify.Release(), 0, GetCookie());
+            self.SendRestartNotification(this);
         }
 
         // Distributed ops avoid doing new work when stopping

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1479,7 +1479,7 @@ class TDataShard
     bool CheckMediatorAuthorisation(ui64 mediatorId);
 
     NTabletFlatExecutor::ITransaction* CreateTxInit();
-    NTabletFlatExecutor::ITransaction* CreateTxInitRestored();
+    NTabletFlatExecutor::ITransaction* CreateTxInitRestored(THashMap<ui64, TOperation::TPtr> migratedTxs);
     NTabletFlatExecutor::ITransaction* CreateTxInitSchema();
     NTabletFlatExecutor::ITransaction* CreateTxInitSchemaDefaults();
     NTabletFlatExecutor::ITransaction* CreateTxSchemaChanged(TEvDataShard::TEvSchemaChangedResult::TPtr& ev);
@@ -1526,6 +1526,8 @@ public:
     void GetCleanupReplies(const TOperation::TPtr& op, std::vector<std::unique_ptr<IEventHandle>>& cleanupReplies);
     void SendConfirmedReplies(TMonotonic ts, std::vector<std::unique_ptr<IEventHandle>>&& replies);
     void SendCommittedReplies(std::vector<std::unique_ptr<IEventHandle>>&& replies);
+
+    void SendRestartNotification(TOperation* op);
 
     void WaitVolatileDependenciesThenSend(
             const absl::flat_hash_set<ui64>& dependencies,
@@ -2756,7 +2758,7 @@ private:
     ui64 InMemoryStatePrevGeneration = 0;
 
     void StartInMemoryRestoreActor();
-    void OnInMemoryStateRestored();
+    void OnInMemoryStateRestored(THashMap<ui64, TOperation::TPtr> migratedTxs);
     bool StartInMemoryStateActor();
 
     struct TPreservedInMemoryState {

--- a/ydb/core/tx/datashard/datashard_ut_common_kqp.h
+++ b/ydb/core/tx/datashard/datashard_ut_common_kqp.h
@@ -190,9 +190,9 @@ namespace NKqpHelpers {
         return KqpSimpleExec(runtime, query, true, database);
     }
 
-    inline auto KqpSimpleBeginSend(TTestActorRuntime& runtime, TString& sessionId, const TString& query) {
-        sessionId = CreateSessionRPC(runtime);
-        return SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, /* txId */ {}, false /* commitTx */));
+    inline auto KqpSimpleBeginSend(TTestActorRuntime& runtime, TString& sessionId, const TString& query, const TString& database = {}) {
+        sessionId = CreateSessionRPC(runtime, database);
+        return SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, /* txId */ {}, false /* commitTx */), database);
     }
 
     inline TString KqpSimpleBeginWait(TTestActorRuntime& runtime, TString& txId, NThreading::TFuture<Ydb::Table::ExecuteDataQueryResponse> future) {
@@ -207,13 +207,13 @@ namespace NKqpHelpers {
         return FormatResult(result);
     }
 
-    inline TString KqpSimpleBegin(TTestActorRuntime& runtime, TString& sessionId, TString& txId, const TString& query) {
-        return KqpSimpleBeginWait(runtime, txId, KqpSimpleBeginSend(runtime, sessionId, query));
+    inline TString KqpSimpleBegin(TTestActorRuntime& runtime, TString& sessionId, TString& txId, const TString& query, const TString& database = {}) {
+        return KqpSimpleBeginWait(runtime, txId, KqpSimpleBeginSend(runtime, sessionId, query, database));
     }
 
-    inline TString KqpSimpleContinue(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query) {
+    inline TString KqpSimpleContinue(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query, const TString& database = {}) {
         Y_ENSURE(!txId.empty(), "continue on empty transaction");
-        auto response = AwaitResponse(runtime, SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, txId, false /* commitTx */)));
+        auto response = AwaitResponse(runtime, SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, txId, false /* commitTx */), database));
         if (response.operation().status() != Ydb::StatusIds::SUCCESS) {
             return TStringBuilder() << "ERROR: " << response.operation().status();
         }
@@ -223,9 +223,9 @@ namespace NKqpHelpers {
         return FormatResult(result);
     }
 
-    inline auto KqpSimpleSendCommit(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query) {
+    inline auto KqpSimpleSendCommit(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query, const TString& database = {}) {
         Y_ENSURE(!txId.empty(), "commit on empty transaction");
-        return SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, txId, true /* commitTx */));
+        return SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, txId, true /* commitTx */), database);
     }
 
     inline TString KqpSimpleWaitCommit(TTestActorRuntime& runtime, NThreading::TFuture<Ydb::Table::ExecuteDataQueryResponse> future) {
@@ -239,8 +239,8 @@ namespace NKqpHelpers {
         return FormatResult(result);
     }
 
-    inline TString KqpSimpleCommit(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query) {
-        return KqpSimpleWaitCommit(runtime, KqpSimpleSendCommit(runtime, sessionId, txId, query));
+    inline TString KqpSimpleCommit(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query, const TString& database = {}) {
+        return KqpSimpleWaitCommit(runtime, KqpSimpleSendCommit(runtime, sessionId, txId, query, database));
     }
 
     inline Ydb::Table::ExecuteSchemeQueryRequest MakeSchemeRequestRPC(

--- a/ydb/core/tx/datashard/datashard_ut_volatile.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_volatile.cpp
@@ -204,23 +204,38 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         }
         capturedPlans.clear();
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            FormatResult(AwaitResponse(runtime, std::move(future))),
-            "ERROR: UNDETERMINED");
+        auto upsertResult = FormatResult(AwaitResponse(runtime, std::move(future)));
         Cerr << "!!! distributed write end" << Endl;
 
         runtime.GetAppData(0).FeatureFlags.ClearEnableDataShardVolatileTransactions();
 
-        // Verify transaction was not committed
-        UNIT_ASSERT_VALUES_EQUAL(
-            KqpSimpleExec(runtime, R"(
-                SELECT key, value FROM `/Root/table-1`
-                UNION ALL
-                SELECT key, value FROM `/Root/table-2`
-                ORDER BY key
-                )"),
-            "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
-            "{ items { uint32_value: 10 } items { uint32_value: 10 } }");
+        if (upsertResult == "ERROR: UNDETERMINED") {
+            // Verify transaction was not committed
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table-1`
+                    UNION ALL
+                    SELECT key, value FROM `/Root/table-2`
+                    ORDER BY key
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 10 } items { uint32_value: 10 } }");
+        } else if (upsertResult == "<empty>") {
+            // Verify transaction was fully committed
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table-1`
+                    UNION ALL
+                    SELECT key, value FROM `/Root/table-2`
+                    ORDER BY key
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 2 } items { uint32_value: 2 } }, "
+                "{ items { uint32_value: 10 } items { uint32_value: 10 } }, "
+                "{ items { uint32_value: 20 } items { uint32_value: 20 } }");
+        } else {
+            UNIT_ASSERT_C(false, "Unexpected upsert result: " << upsertResult);
+        }
     }
 
     Y_UNIT_TEST_TWIN(DistributedWriteShardRestartAfterExpectation, UseSink) {
@@ -295,23 +310,38 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         // Restart the first table shard
         RebootTablet(runtime, shard1, sender);
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            FormatResult(AwaitResponse(runtime, std::move(future))),
-            "ERROR: UNDETERMINED");
+        auto upsertResult = FormatResult(AwaitResponse(runtime, std::move(future)));
         Cerr << "!!! distributed write end" << Endl;
 
         runtime.GetAppData(0).FeatureFlags.ClearEnableDataShardVolatileTransactions();
 
-        // Verify transaction was not committed
-        UNIT_ASSERT_VALUES_EQUAL(
-            KqpSimpleExec(runtime, R"(
-                SELECT key, value FROM `/Root/table-1`
-                UNION ALL
-                SELECT key, value FROM `/Root/table-2`
-                ORDER BY key
-                )"),
-            "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
-            "{ items { uint32_value: 10 } items { uint32_value: 10 } }");
+        if (upsertResult == "ERROR: UNDETERMINED") {
+            // Verify transaction was not committed
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table-1`
+                    UNION ALL
+                    SELECT key, value FROM `/Root/table-2`
+                    ORDER BY key
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 10 } items { uint32_value: 10 } }");
+        } else if (upsertResult == "<empty>") {
+            // Verify transaction was fully committed
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table-1`
+                    UNION ALL
+                    SELECT key, value FROM `/Root/table-2`
+                    ORDER BY key
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 2 } items { uint32_value: 2 } }, "
+                "{ items { uint32_value: 10 } items { uint32_value: 10 } }, "
+                "{ items { uint32_value: 20 } items { uint32_value: 20 } }");
+        } else {
+            UNIT_ASSERT_C(false, "Unexpected upsert result: " << upsertResult);
+        }
     }
 
     Y_UNIT_TEST(DistributedWriteEarlierSnapshotNotBlocked) {
@@ -480,9 +510,10 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
             "{ items { uint32_value: 20 } items { uint32_value: 20 } }");
     }
 
-    Y_UNIT_TEST(DistributedWriteLaterSnapshotBlockedThenAbort) {
+    Y_UNIT_TEST_TWIN(DistributedWriteLaterSnapshotBlockedThenAbort, UseSink) {
         TPortManager pm;
         NKikimrConfig::TAppConfig app;
+        app.MutableTableServiceConfig()->SetEnableOltpSink(UseSink);
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root")
             .SetUseRealThreads(false)
@@ -543,11 +574,11 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         runtime.GetAppData(0).FeatureFlags.ClearEnableDataShardVolatileTransactions();
 
         // Start reading from table-2
-        TString sessionIdSnapshot = CreateSessionRPC(runtime, "/Root");
-        auto snapshotReadFuture = SendRequest(runtime, MakeSimpleRequestRPC(R"(
+        TString snapshotSessionId, snapshotTxId;
+        auto snapshotReadFuture = KqpSimpleBeginSend(runtime, snapshotSessionId, R"(
             SELECT key, value FROM `/Root/table-2`
             ORDER BY key
-        )", sessionIdSnapshot, "", false /* commitTx */), "/Root");
+        )", "/Root");
 
         // Let some virtual time pass
         SimulateSleep(runtime, TDuration::Seconds(1));
@@ -556,19 +587,34 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         UNIT_ASSERT(!snapshotReadFuture.HasValue());
         UNIT_ASSERT(!future.HasValue());
 
-        // Reboot table-1 tablet and sleep a little, this will abort the write
+        // Reboot table-1 tablet and sleep a little, this may abort the write
         RebootTablet(runtime, shard1, sender);
         SimulateSleep(runtime, TDuration::Seconds(1));
 
-        // We expect aborted commit and read without that data
+        // We expect aborted commit and read without that data, or successful commit and read with the data
         UNIT_ASSERT(snapshotReadFuture.HasValue());
         UNIT_ASSERT(future.HasValue());
-        UNIT_ASSERT_VALUES_EQUAL(
-            FormatResult(future.ExtractValue()),
-            "ERROR: UNDETERMINED");
-        UNIT_ASSERT_VALUES_EQUAL(
-            FormatResult(snapshotReadFuture.ExtractValue()),
-            "{ items { uint32_value: 10 } items { uint32_value: 10 } }");
+        auto upsertResult = FormatResult(future.ExtractValue());
+        auto readResult = KqpSimpleBeginWait(runtime, snapshotTxId, std::move(snapshotReadFuture));
+        if (upsertResult == "ERROR: UNDETERMINED") {
+            UNIT_ASSERT_VALUES_EQUAL(
+                readResult,
+                "{ items { uint32_value: 10 } items { uint32_value: 10 } }");
+        } else if (upsertResult == "<empty>") {
+            UNIT_ASSERT_VALUES_EQUAL(
+                readResult,
+                "{ items { uint32_value: 10 } items { uint32_value: 10 } }, "
+                "{ items { uint32_value: 20 } items { uint32_value: 20 } }");
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleContinue(runtime, snapshotSessionId, snapshotTxId, R"(
+                    SELECT key, value FROM `/Root/table-1`
+                    ORDER BY key
+                )", "/Root"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 2 } items { uint32_value: 2 } }");
+        } else {
+            UNIT_ASSERT_C(false, "Unexpected upsert result: " << upsertResult);
+        }
     }
 
     Y_UNIT_TEST(DistributedWriteAsymmetricExecute) {
@@ -3318,17 +3364,43 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         Cerr << "========= Restarting shard 1 =========" << Endl;
         GracefulRestartTablet(runtime, shards.at(0), sender);
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            FormatResult(runtime.WaitFuture(std::move(upsertFuture1))),
-            "ERROR: ABORTED");
+        auto upsertResult = FormatResult(runtime.WaitFuture(std::move(upsertFuture1)));
+
+        Cerr << "========= Checking table =========" << Endl;
+        if (upsertResult == "ERROR: ABORTED") {
+            // Verify transaction was not committed
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table`
+                    ORDER BY key
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 11 } items { uint32_value: 11 } }");
+        } else if (upsertResult == "<empty>") {
+            // Verify transaction was fully committed
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table`
+                    ORDER BY key
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 2 } items { uint32_value: 2 } }, "
+                "{ items { uint32_value: 11 } items { uint32_value: 11 } }, "
+                "{ items { uint32_value: 12 } items { uint32_value: 12 } }");
+        } else {
+            UNIT_ASSERT_C(false, "Unexpected upsert result: " << upsertResult);
+        }
     }
 
-    Y_UNIT_TEST(DistributedUpsertRestartAfterPlan) {
+    Y_UNIT_TEST_TWIN(DistributedUpsertRestartAfterPlan, UseSink) {
         TPortManager pm;
+        NKikimrConfig::TAppConfig app;
+        app.MutableTableServiceConfig()->SetEnableOltpSink(UseSink);
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root")
             .SetUseRealThreads(false)
-            .SetEnableDataShardVolatileTransactions(true);
+            .SetEnableDataShardVolatileTransactions(true)
+            .SetAppConfig(app);
 
         Tests::TServer::TPtr server = new TServer(serverSettings);
         auto &runtime = *server->GetRuntime();
@@ -3389,18 +3461,33 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         Cerr << "========= Restarting shard 1 =========" << Endl;
         GracefulRestartTablet(runtime, shards.at(0), sender);
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            FormatResult(runtime.WaitFuture(std::move(upsertFuture1))),
-            "ERROR: ABORTED");
+        auto upsertResult = FormatResult(runtime.WaitFuture(std::move(upsertFuture1)));
 
         Cerr << "========= Checking table =========" << Endl;
-        UNIT_ASSERT_VALUES_EQUAL(
-            KqpSimpleExec(runtime, R"(
-                SELECT key, value FROM `/Root/table`
-                ORDER BY key;
-            )"),
-            "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
-            "{ items { uint32_value: 11 } items { uint32_value: 11 } }");
+        if (upsertResult == "ERROR: ABORTED") {
+            // Verify transaction was not committed
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table`
+                    ORDER BY key
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 11 } items { uint32_value: 11 } }");
+        } else if (upsertResult == "<empty>") {
+            // Verify transaction was fully committed
+            Cerr << "========= Checking table =========" << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table`
+                    ORDER BY key
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+                "{ items { uint32_value: 2 } items { uint32_value: 2 } }, "
+                "{ items { uint32_value: 11 } items { uint32_value: 11 } }, "
+                "{ items { uint32_value: 12 } items { uint32_value: 12 } }");
+        } else {
+            UNIT_ASSERT_C(false, "Unexpected upsert result: " << upsertResult);
+        }
     }
 
     // Regression test for KIKIMR-22506

--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -393,6 +393,7 @@ void TWriteOperation::FillTxData(TDataShard* self, const TActorId& target, const
     Y_ENSURE(!WriteRequest);
 
     Target = target;
+
     SetTxBody(txBody);
 
     if (locks.size()) {
@@ -417,7 +418,6 @@ void TWriteOperation::FillVolatileTxData(TDataShard* self)
     BuildWriteTx(self);
     Y_ENSURE(WriteTx->Ready());
 
-
     TrackMemory();
 }
 
@@ -439,21 +439,31 @@ TString TWriteOperation::GetTxBody() const {
     return str;
 }
 
-void TWriteOperation::SetTxBody(const TString& txBody) {
+bool TWriteOperation::TrySetTxBody(const TString& txBody) {
     Y_ENSURE(!WriteRequest);
 
     NKikimrTxDataShard::TSerializedEvent proto;
     const bool success = proto.ParseFromString(txBody);
-    Y_ENSURE(success);
+    if (!success) {
+        return false;
+    }
 
     TEventSerializationInfo serializationInfo;
     serializationInfo.IsExtendedFormat = proto.GetIsExtendedFormat();
 
     TEventSerializedData buffer(proto.GetEventData(), std::move(serializationInfo));
     NKikimr::NEvents::TDataEvents::TEvWrite* writeRequest = static_cast<NKikimr::NEvents::TDataEvents::TEvWrite*>(NKikimr::NEvents::TDataEvents::TEvWrite::Load(&buffer));
-    Y_ENSURE(writeRequest);
+    if (!writeRequest) {
+        return false;
+    }
 
     WriteRequest.reset(writeRequest);
+    return true;
+}
+
+void TWriteOperation::SetTxBody(const TString& txBody) {
+    const bool success = TrySetTxBody(txBody);
+    Y_ENSURE(success);
 }
 
 void TWriteOperation::ClearTxBody() {
@@ -462,13 +472,13 @@ void TWriteOperation::ClearTxBody() {
     TrackMemory();
 }
 
-TValidatedWriteTx::TPtr TWriteOperation::BuildWriteTx(TDataShard* self)
+bool TWriteOperation::BuildWriteTx(TDataShard* self)
 {
     if (!WriteTx) {
         Y_ENSURE(WriteRequest);
         WriteTx = std::make_shared<TValidatedWriteTx>(self, GetGlobalTxId(), GetReceivedAt(), *WriteRequest, IsMvccSnapshotRead());
     }
-    return WriteTx;
+    return bool(WriteTx);
 }
 
 void TWriteOperation::ReleaseTxData(NTabletFlatExecutor::TTxMemoryProviderBase& provider) {
@@ -604,12 +614,15 @@ void TWriteOperation::BuildExecutionPlan(bool loaded)
         plan.push_back(EExecutionUnitKind::FinishProposeWrite);
         plan.push_back(EExecutionUnitKind::CompletedOperations);
     } else if (HasVolatilePrepareFlag()) {
-        Y_ENSURE(!loaded);
-        plan.push_back(EExecutionUnitKind::CheckWrite);
-        plan.push_back(EExecutionUnitKind::StoreWrite);  // note: stores in memory
-        plan.push_back(EExecutionUnitKind::FinishProposeWrite);
-        Y_ENSURE(!GetStep());
-        plan.push_back(EExecutionUnitKind::WaitForPlan);
+        // Note: loaded == true when migrating from previous generations
+        if (!loaded) {
+            plan.push_back(EExecutionUnitKind::CheckWrite);
+            plan.push_back(EExecutionUnitKind::StoreWrite);  // note: stores in memory
+            plan.push_back(EExecutionUnitKind::FinishProposeWrite);
+        }
+        if (!GetStep()) {
+            plan.push_back(EExecutionUnitKind::WaitForPlan);
+        }
         plan.push_back(EExecutionUnitKind::PlanQueue);
         plan.push_back(EExecutionUnitKind::LoadWriteDetails);  // note: reloads from memory
         plan.push_back(EExecutionUnitKind::BuildAndWaitDependencies);
@@ -655,6 +668,54 @@ void TWriteOperation::BuildExecutionPlan(bool loaded)
     RewriteExecutionPlan(plan);
 }
 
+std::optional<TString> TWriteOperation::OnMigration(TDataShard& self, const TActorContext&) {
+    if (!IsImmediate() && HasVolatilePrepareFlag() && !HasCompletedFlag() && !HasResultSentFlag() && !Result()) {
+        self.SendRestartNotification(this);
+        return GetTxBody();
+    }
+
+    return std::nullopt;
+}
+
+bool TWriteOperation::OnRestoreMigrated(TDataShard&, const TString& body) {
+    if (WriteRequest || WriteTx) {
+        // Unexpected: write request already exists
+        return false;
+    }
+
+    if (!TrySetTxBody(body)) {
+        return false;
+    }
+
+    // Make sure event is tracked as soon as possible
+    TrackMemory();
+
+    return true;
+}
+
+bool TWriteOperation::OnFinishMigration(TDataShard& self, const NTable::TScheme& scheme) {
+    if (!WriteTx) {
+        if (!BuildWriteTx(&self)) {
+            return false;
+        }
+        Y_ENSURE(WriteTx);
+    }
+
+    if (!WriteTx->Ready()) {
+        return false;
+    }
+
+    WriteTx->ExtractKeys(scheme, true);
+
+    if (!WriteTx->Ready()) {
+        return false;
+    }
+
+    BuildExecutionPlan(true);
+    ClearWriteTx();
+    return true;
+}
+
 bool TWriteOperation::OnStopping(TDataShard& self, const TActorContext& ctx) {
     if (IsImmediate()) {
         // Send reject result immediately, because we cannot control when
@@ -682,28 +743,12 @@ bool TWriteOperation::OnStopping(TDataShard& self, const TActorContext& ctx) {
         // Immediate ops become ready when stopping flag is set
         return true;
     } else if (HasVolatilePrepareFlag()) {
-        // Volatile transactions may be aborted at any time unless executed
-        // Note: we need to send the result (and discard the transaction) as
-        // soon as possible, because new transactions are unlikely to execute
-        // and commits will even more likely fail.
-        if (!HasResultSentFlag() && !Result() && !HasCompletedFlag()) {
-            auto status = NKikimrDataEvents::TEvWriteResult::STATUS_ABORTED;
-            TString reason = TStringBuilder()
-                << "DataShard " << TabletId << " is restarting";
-            auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletId, GetTxId(), status, std::move(reason));
-
-            ctx.Send(GetTarget(), result.release(), 0, GetCookie());
-
-            // Make sure we also send acks and nodata readsets to expecting participants
-            std::vector<std::unique_ptr<IEventHandle>> cleanupReplies;
-            self.GetCleanupReplies(this, cleanupReplies);
-
-            for (auto& ev : cleanupReplies) {
-                TActivationContext::Send(ev.release());
-            }
-
-            SetResultSentFlag();
-            return true;
+        // Volatile transactions may be aborted at any time unless executed,
+        // but we want them to migrate and run to completion when possible.
+        if (!HasCompletedFlag() && !HasResultSentFlag() && !Result()) {
+            // It is possible this transaction already migrated or will migrate soon
+            self.SendRestartNotification(this);
+            return false;
         }
 
         // Executed transactions will have to wait until committed
@@ -712,8 +757,7 @@ bool TWriteOperation::OnStopping(TDataShard& self, const TActorContext& ctx) {
     } else {
         // Distributed operations send notification when proposed
         if (GetTarget() && !HasCompletedFlag()) {
-            auto notify = MakeHolder<TEvDataShard::TEvProposeTransactionRestart>(self.TabletID(), GetTxId());
-            ctx.Send(GetTarget(), notify.Release(), 0, GetCookie());
+            self.SendRestartNotification(this);
         }
 
         // Distributed ops avoid doing new work when stopping

--- a/ydb/core/tx/datashard/datashard_write_operation.h
+++ b/ydb/core/tx/datashard/datashard_write_operation.h
@@ -158,6 +158,7 @@ public:
     void FillVolatileTxData(TDataShard* self);
 
     TString GetTxBody() const;
+    bool TrySetTxBody(const TString& txBody);
     void SetTxBody(const TString& txBody);
     void ClearTxBody();
 
@@ -258,7 +259,7 @@ public:
     TValidatedWriteTx::TPtr& GetWriteTx() {
         return WriteTx;
     }
-    TValidatedWriteTx::TPtr BuildWriteTx(TDataShard* self);
+    bool BuildWriteTx(TDataShard* self);
 
     void ClearWriteTx() { 
         WriteTx = nullptr; 
@@ -274,6 +275,9 @@ public:
     void SetError(const NKikimrDataEvents::TEvWriteResult::EStatus& status, const TString& errorMsg);
     void SetWriteResult(std::unique_ptr<NEvents::TDataEvents::TEvWriteResult>&& writeResult);
 
+    std::optional<TString> OnMigration(TDataShard& self, const TActorContext& ctx) override;
+    bool OnRestoreMigrated(TDataShard& self, const TString& body) override;
+    bool OnFinishMigration(TDataShard& self, const NTable::TScheme& scheme) override;
     bool OnStopping(TDataShard& self, const TActorContext& ctx) override;
     void OnCleanup(TDataShard& self, std::vector<std::unique_ptr<IEventHandle>>& replies) override;
 

--- a/ydb/core/tx/datashard/memory_state_migration.cpp
+++ b/ydb/core/tx/datashard/memory_state_migration.cpp
@@ -51,20 +51,20 @@ private:
         auto* owner = Owner;
         Y_ENSURE(owner);
 
-        if (Locks) {
-            owner->SysLocks.RestoreInMemoryLocks(std::move(Locks));
-        }
-
         if (Vars) {
             owner->SnapshotManager.RestoreImmediateWriteEdge(Vars->ImmediateWriteEdge, Vars->ImmediateWriteEdgeReplied);
             owner->SnapshotManager.RestoreUnprotectedReadEdge(Vars->UnprotectedReadEdge);
             owner->InMemoryVarsRestored = true;
         }
 
+        if (Locks) {
+            owner->SysLocks.RestoreInMemoryLocks(std::move(Locks));
+        }
+
         Detach();
         PassAway();
 
-        owner->OnInMemoryStateRestored();
+        owner->OnInMemoryStateRestored(std::move(Transactions));
     }
 
     void Failed() {
@@ -205,6 +205,39 @@ private:
                 row->VolatileDependencies.push_back(protoVolatileDep.GetTxId());
             }
 
+            for (const auto& protoTx : state->GetPreparedVolatileTxs()) {
+                ui64 txId = protoTx.GetTxId();
+                EOperationKind kind = EOperationKind(protoTx.GetKind());
+                ui64 flags = protoTx.GetFlags();
+                if (flags & TTxFlags::Immediate) {
+                    // Cannot restore immediate transactions
+                    continue;
+                }
+                if (!(flags & TTxFlags::VolatilePrepare)) {
+                    // Cannot restore non-volatile transactions
+                    continue;
+                }
+                flags |= TTxFlags::Stored; // Volatile transactions also have a Stored flag (stored in memory, not on disk)
+                ui64 maxStep = protoTx.GetMaxStep();
+                ui64 receivedAt = protoTx.GetReceivedAt();
+                TBasicOpInfo info(txId, kind, flags, maxStep, TInstant::MicroSeconds(receivedAt), Owner->NextTieBreakerIndex++);
+                TOperation::TPtr op = NEvWrite::TConvertor::MakeOperation(kind, info, Owner->TabletID());
+                op->SetMinStep(protoTx.GetMinStep());
+                if (protoTx.HasStep()) {
+                    op->SetStep(protoTx.GetStep());
+                }
+                if (protoTx.HasPredictedStep()) {
+                    op->SetPredictedStep(protoTx.GetPredictedStep());
+                }
+                op->SetTarget(ActorIdFromProto(protoTx.GetSource()));
+                op->SetCookie(protoTx.GetCookie());
+                if (!op->OnRestoreMigrated(*Owner, protoTx.GetBody())) {
+                    // This transaction cannot be restored
+                    continue;
+                }
+                Transactions[txId] = std::move(op);
+            }
+
             Arena.Reset();
         }
 
@@ -256,8 +289,9 @@ private:
     TVector<size_t> Checkpoints;
 
     google::protobuf::Arena Arena;
-    THashMap<ui64, ILocksDb::TLockRow> Locks;
     std::optional<TVars> Vars;
+    THashMap<ui64, ILocksDb::TLockRow> Locks;
+    THashMap<ui64, TOperation::TPtr> Transactions;
 };
 
 void TDataShard::StartInMemoryRestoreActor() {
@@ -274,7 +308,7 @@ void TDataShard::StartInMemoryRestoreActor() {
         return;
     }
 
-    OnInMemoryStateRestored();
+    OnInMemoryStateRestored({});
 }
 
 class TDataShardInMemoryStateActor
@@ -519,6 +553,8 @@ private:
 };
 
 TDataShard::TPreservedInMemoryState TDataShard::PreserveInMemoryState() {
+    TActorContext ctx = TActivationContext::ActorContextFor(SelfId());
+
     TDataShardPreservedInMemoryStateOutputStream stream;
     TVector<size_t> checkpoints;
 
@@ -540,6 +576,9 @@ TDataShard::TPreservedInMemoryState TDataShard::PreserveInMemoryState() {
     };
 
     auto addedMessage = [&](size_t messageSize) {
+        // Note: assumes field tag is always 1 byte, which is exact as long as
+        // all field numbers are less than 15 in TInMemoryState. Checkpoints
+        // don't rely on this being exact however.
         currentStateSize += 1 + google::protobuf::io::CodedOutputStream::VarintSize32(messageSize) + messageSize;
         if (currentStateSize >= MAX_DATASHARD_STATE_CHUNK_SIZE) {
             flushState();
@@ -630,6 +669,36 @@ TDataShard::TPreservedInMemoryState TDataShard::PreserveInMemoryState() {
                 protoDep->SetTxId(txId);
                 addedMessage(protoDep->ByteSizeLong());
             });
+        maybeCheckpoint();
+    }
+
+    for (const auto& [txId, op] : TransQueue.GetTxsInFly()) {
+        if (op->IsImmediate() || !op->HasVolatilePrepareFlag()) {
+            // Non-volatile transactions don't need to be migrated
+            continue;
+        }
+        auto txBody = op->OnMigration(*this, ctx);
+        if (!txBody) {
+            // This transaction cannot be migrated
+            continue;
+        }
+        auto* protoTx = state->AddPreparedVolatileTxs();
+        protoTx->SetTxId(txId);
+        ActorIdToProto(op->GetTarget(), protoTx->MutableSource());
+        protoTx->SetCookie(op->GetCookie());
+        protoTx->SetKind(static_cast<ui64>(op->GetKind()));
+        protoTx->SetBody(std::move(*txBody));
+        protoTx->SetFlags(op->GetFlags() & (TTxFlags::PublicFlagsMask | TTxFlags::PreservedPrivateFlagsMask));
+        protoTx->SetMinStep(op->GetMinStep());
+        protoTx->SetMaxStep(op->GetMaxStep());
+        if (auto step = op->GetPredictedStep()) {
+            protoTx->SetPredictedStep(step);
+        }
+        if (auto step = op->GetStep()) {
+            protoTx->SetStep(step);
+        }
+        protoTx->SetReceivedAt(op->GetReceivedAt().MicroSeconds());
+        addedMessage(protoTx->ByteSizeLong());
         maybeCheckpoint();
     }
 

--- a/ydb/core/tx/datashard/operation.cpp
+++ b/ydb/core/tx/datashard/operation.cpp
@@ -323,6 +323,24 @@ void TOperation::SetFinishProposeTs() noexcept
     SetFinishProposeTs(AppData()->MonotonicTimeProvider->Now());
 }
 
+std::optional<TString> TOperation::OnMigration(TDataShard&, const TActorContext&)
+{
+    // By default operations cannot be migrated
+    return std::nullopt;
+}
+
+bool TOperation::OnRestoreMigrated(TDataShard&, const TString&)
+{
+    // By default operations cannot be restored
+    return false;
+}
+
+bool TOperation::OnFinishMigration(TDataShard&, const NTable::TScheme&)
+{
+    // By default operations cannot finish migration
+    return false;
+}
+
 bool TOperation::OnStopping(TDataShard&, const TActorContext&)
 {
     // By default operations don't do anything when stopping


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Serialize prepared and not-yet-executed volatile transactions are restore them by newer generations.

Related to #11561.