### PR TITLE
AvailabilityPeriod for topic consumers

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.cpp
@@ -1,0 +1,38 @@
+#include "consumer_offset_tracker.h"
+
+namespace NKikimr::NPQ {
+
+
+TImportantConsumerOffsetTracker::TImportantConsumerOffsetTracker(std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumersToCheck)
+    : Consumers_(std::move(consumersToCheck))
+{
+}
+
+bool TImportantConsumerOffsetTracker::ShouldKeep(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now, const TConsumerOffset& consumer) {
+    const TInstant endOfLife = currentKey.Timestamp + consumer.AvailabilityPeriod; // note: sum with saturation
+    if (endOfLife < now) {
+        // The current key is too old. It doesn't matter whether the consumer has read it or not. It can be retired.
+        return false;
+    }
+    if (consumer.Offset < nextKey.Key.GetOffset()) {
+        // The first message in the next blob was not read by an important consumer.
+        // We also save the current blob, since not all messages from it could be read.
+        return true;
+    }
+    if (consumer.Offset == nextKey.Key.GetOffset() && nextKey.Key.GetPartNo() != 0) {
+        // We save all the blobs that contain parts of the last message read by an important consumer.
+        return true;
+    }
+    return false;
+}
+
+bool TImportantConsumerOffsetTracker::ShouldKeepCurrentKey(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) const {
+    for (const auto& consumer : Consumers_) {
+        if (ShouldKeep(currentKey, nextKey, now, consumer)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.cpp
@@ -2,7 +2,7 @@
 
 namespace NKikimr::NPQ {
 
-bool ImportantConsumerNeedToKeepCurrentKey(const TDuration availabilityPeriod, ui64 offset, const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) {
+bool ImportantConsumerNeedToKeepCurrentKey(const TDuration availabilityPeriod, const ui64 offset, const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) {
     const TInstant endOfLife = currentKey.Timestamp + availabilityPeriod; // note: sum with saturation
     if (endOfLife < now) {
         // The current key is too old. It doesn't matter whether the consumer has read it or not. It can be retired.

--- a/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.cpp
@@ -2,33 +2,32 @@
 
 namespace NKikimr::NPQ {
 
-
-TImportantConsumerOffsetTracker::TImportantConsumerOffsetTracker(std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumersToCheck)
-    : Consumers_(std::move(consumersToCheck))
-{
-}
-
-bool TImportantConsumerOffsetTracker::ShouldKeep(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now, const TConsumerOffset& consumer) {
-    const TInstant endOfLife = currentKey.Timestamp + consumer.AvailabilityPeriod; // note: sum with saturation
+bool ImportantConsumerNeedToKeepCurrentKey(const TDuration availabilityPeriod, ui64 offset, const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) {
+    const TInstant endOfLife = currentKey.Timestamp + availabilityPeriod; // note: sum with saturation
     if (endOfLife < now) {
         // The current key is too old. It doesn't matter whether the consumer has read it or not. It can be retired.
         return false;
     }
-    if (consumer.Offset < nextKey.Key.GetOffset()) {
+    if (offset < nextKey.Key.GetOffset()) {
         // The first message in the next blob was not read by an important consumer.
         // We also save the current blob, since not all messages from it could be read.
         return true;
     }
-    if (consumer.Offset == nextKey.Key.GetOffset() && nextKey.Key.GetPartNo() != 0) {
+    if (offset == nextKey.Key.GetOffset() && nextKey.Key.GetPartNo() != 0) {
         // We save all the blobs that contain parts of the last message read by an important consumer.
         return true;
     }
     return false;
 }
 
+TImportantConsumerOffsetTracker::TImportantConsumerOffsetTracker(std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumersToCheck)
+    : Consumers_(std::move(consumersToCheck))
+{
+}
+
 bool TImportantConsumerOffsetTracker::ShouldKeepCurrentKey(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) const {
     for (const auto& consumer : Consumers_) {
-        if (ShouldKeep(currentKey, nextKey, now, consumer)) {
+        if (ImportantConsumerNeedToKeepCurrentKey(consumer.AvailabilityPeriod, consumer.Offset, currentKey, nextKey, now)) {
             return true;
         }
     }

--- a/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.h
+++ b/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <util/datetime/base.h>
+#include <vector>
+#include <ydb/core/persqueue/events/internal.h>
+
+namespace NKikimr::NPQ {
+
+    class TImportantConsumerOffsetTracker {
+    public:
+        struct TConsumerOffset {
+            TDuration AvailabilityPeriod = TDuration::Max();
+            ui64 Offset = 0;
+        };
+
+        explicit TImportantConsumerOffsetTracker(std::vector<TConsumerOffset> consumers);
+
+        bool ShouldKeepCurrentKey(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) const;
+
+    private:
+        static bool ShouldKeep(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now, const TConsumerOffset& consumer);
+
+    private:
+        std::vector<TConsumerOffset> Consumers_;
+    };
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.h
+++ b/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <ydb/core/persqueue/events/internal.h>
 #include <util/datetime/base.h>
 #include <vector>
-#include <ydb/core/persqueue/events/internal.h>
 
 namespace NKikimr::NPQ {
 
@@ -21,6 +21,6 @@ namespace NKikimr::NPQ {
         std::vector<TConsumerOffset> Consumers_;
     };
 
-    bool ImportantConsumerNeedToKeepCurrentKey(const TDuration availabilityPeriod, ui64 offset, const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now);
+    bool ImportantConsumerNeedToKeepCurrentKey(const TDuration availabilityPeriod, const ui64 offset, const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now);
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.h
+++ b/ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.h
@@ -18,10 +18,9 @@ namespace NKikimr::NPQ {
         bool ShouldKeepCurrentKey(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) const;
 
     private:
-        static bool ShouldKeep(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now, const TConsumerOffset& consumer);
-
-    private:
         std::vector<TConsumerOffset> Consumers_;
     };
+
+    bool ImportantConsumerNeedToKeepCurrentKey(const TDuration availabilityPeriod, ui64 offset, const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now);
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -720,6 +720,8 @@ void TPartition::InitComplete(const TActorContext& ctx) {
 
     CreateCompacter();
 
+    InitUserInfoForImportantClients(ctx);
+
     FillReadFromTimestamps(ctx);
     ProcessPendingEvents(ctx);
     ProcessTxsAndUserActs(ctx);
@@ -735,7 +737,6 @@ void TPartition::InitComplete(const TActorContext& ctx) {
     }
     ProcessHasDataRequests(ctx);
 
-    InitUserInfoForImportantClients(ctx);
 
     for (auto&& userInfoPair : UsersInfoStorage->GetAll()) {
         PQ_ENSURE(userInfoPair.second.Offset >= 0);

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -440,7 +440,7 @@ TImportantConsumerOffsetTracker TPartition::ImportantClientsMinOffset() const {
             continue;
         }
 
-        const TUserInfo* userInfo = UsersInfoStorage->GetIfExists(consumer.GetName());
+        TUserInfoViewPtr userInfo = UsersInfoStorage->GetIfExists(consumer.GetName());
         ui64 curOffset = GetStartOffset();
         if (userInfo && userInfo->Offset >= 0) //-1 means no offset
             curOffset = userInfo->Offset;
@@ -1751,13 +1751,13 @@ void TPartition::Handle(TEvPQ::TEvBlobResponse::TPtr& ev, const TActorContext& c
     TReadInfo info = std::move(it->second);
     ReadInfo.erase(it);
 
-    auto* userInfo = UsersInfoStorage->GetIfExists(info.User);
+    TUserInfoMutableViewPtr userInfo = UsersInfoStorage->GetIfExists(info.User);
     if (!userInfo) {
         ReplyError(ctx, info.Destination,  NPersQueue::NErrorCode::BAD_REQUEST, GetConsumerDeletedMessage(info.User));
         OnReadRequestFinished(info.Destination, 0, info.User, ctx);
     }
 
-    OnReadComplete(info, userInfo, ev->Get(), ctx);
+    OnReadComplete(info, userInfo.Get(), ev->Get(), ctx);
 }
 
 void TPartition::Handle(TEvPQ::TEvError::TPtr& ev, const TActorContext& ctx) {
@@ -2096,7 +2096,7 @@ void TPartition::ReportCounters(const TActorContext& ctx, bool force) {
 
 void TPartition::Handle(NReadQuoterEvents::TEvQuotaUpdated::TPtr& ev, const TActorContext&) {
     for (auto& [consumerStr, quota] : ev->Get()->UpdatedConsumerQuotas) {
-        const TUserInfo* userInfo = UsersInfoStorage->GetIfExists(consumerStr);
+        TUserInfoViewPtr userInfo = UsersInfoStorage->GetIfExists(consumerStr);
         if (userInfo) {
             userInfo->LabeledCounters->GetCounters()[METRIC_READ_QUOTA_PER_CONSUMER_BYTES].Set(quota);
         }
@@ -3130,39 +3130,39 @@ void TPartition::OnProcessTxsAndUserActsWriteComplete(const TActorContext& ctx) 
 
     for (auto& user : AffectedUsers) {
         if (auto* actual = GetPendingUserIfExists(user)) {
-            TUserInfo& userInfo = UsersInfoStorage->GetOrCreate(user, ctx);
-            bool offsetHasChanged = (userInfo.Offset != actual->Offset);
+            TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(user, ctx);
+            bool offsetHasChanged = (userInfo->Offset != actual->Offset);
 
-            userInfo.Session = actual->Session;
-            userInfo.Generation = actual->Generation;
-            userInfo.Step = actual->Step;
-            userInfo.Offset = actual->Offset;
-            userInfo.CommittedMetadata = actual->CommittedMetadata;
-            if (userInfo.Offset <= (i64)GetStartOffset()) {
-                userInfo.AnyCommits = false;
+            userInfo->Session = actual->Session;
+            userInfo->Generation = actual->Generation;
+            userInfo->Step = actual->Step;
+            userInfo->Offset = actual->Offset;
+            userInfo->CommittedMetadata = actual->CommittedMetadata;
+            if (userInfo->Offset <= (i64)GetStartOffset()) {
+                userInfo->AnyCommits = false;
             }
-            userInfo.ReadRuleGeneration = actual->ReadRuleGeneration;
-            userInfo.ReadFromTimestamp = actual->ReadFromTimestamp;
-            userInfo.HasReadRule = true;
+            userInfo->ReadRuleGeneration = actual->ReadRuleGeneration;
+            userInfo->ReadFromTimestamp = actual->ReadFromTimestamp;
+            userInfo->HasReadRule = true;
 
-            if (userInfo.Important != actual->Important || userInfo.AvailabilityPeriod != actual->AvailabilityPeriod) {
-                if (userInfo.LabeledCounters) {
-                    ScheduleDropPartitionLabeledCounters(userInfo.LabeledCounters->GetGroup());
+            if (userInfo->Important != actual->Important || userInfo->AvailabilityPeriod != actual->AvailabilityPeriod) {
+                if (userInfo->LabeledCounters) {
+                    ScheduleDropPartitionLabeledCounters(userInfo->LabeledCounters->GetGroup());
                 }
-                userInfo.SetImportant(actual->Important, actual->AvailabilityPeriod);
+                userInfo->SetImportant(actual->Important, actual->AvailabilityPeriod);
             }
-            if (ImporantOrExtendedAvailabilityPeriod(userInfo) && userInfo.Offset < (i64)GetStartOffset()) {
-                userInfo.Offset = GetStartOffset();
+            if (ImporantOrExtendedAvailabilityPeriod(*userInfo) && userInfo->Offset < (i64)GetStartOffset()) {
+                userInfo->Offset = GetStartOffset();
             }
 
-            if (offsetHasChanged && !userInfo.UpdateTimestampFromCache()) {
-                userInfo.ActualTimestamps = false;
-                ReadTimestampForOffset(user, userInfo, ctx);
+            if (offsetHasChanged && !userInfo->UpdateTimestampFromCache()) {
+                userInfo->ActualTimestamps = false;
+                ReadTimestampForOffset(user, *userInfo, ctx);
             } else {
                 TabletCounters.Cumulative()[COUNTER_PQ_WRITE_TIMESTAMP_CACHE_HIT].Increment(1);
             }
 
-            if (LastOffsetHasBeenCommited(userInfo)) {
+            if (LastOffsetHasBeenCommited(*userInfo)) {
                 SendReadingFinished(user);
             }
         } else if (user != CLIENTID_WITHOUT_CONSUMER) {
@@ -3537,7 +3537,7 @@ void TPartition::CommitUserAct(TEvPQ::TEvSetClientInfo& act) {
             && act.Generation == userInfo.Generation
             && act.Step == userInfo.Step
     ) {
-        auto* ui = UsersInfoStorage->GetIfExists(userInfo.User);
+        TUserInfoViewPtr ui = UsersInfoStorage->GetIfExists(userInfo.User);
         auto ts = ui ? GetTime(*ui, userInfo.Offset) : std::make_pair<TInstant, TInstant>(TInstant::Zero(), TInstant::Zero());
 
         userInfo.PipeClient = act.PipeClient;
@@ -3673,7 +3673,7 @@ void TPartition::EmulatePostProcessUserAct(const TEvPQ::TEvSetClientInfo& act,
         if (createSession || dropSession) {
             offset = userInfo.Offset;
 
-            auto *ui = UsersInfoStorage->GetIfExists(userInfo.User);
+            TUserInfoViewPtr ui = UsersInfoStorage->GetIfExists(userInfo.User);
             auto ts = ui ? GetTime(*ui, userInfo.Offset) : std::make_pair<TInstant, TInstant>(TInstant::Zero(), TInstant::Zero());
 
             ScheduleReplyGetClientOffsetOk(act.Cookie,
@@ -3885,7 +3885,7 @@ void TPartition::AddCmdWriteUserInfos(NKikimrClient::TKeyValueRequest& request)
         ikeyDeprecated.Append(user.c_str(), user.size());
 
         if (TUserInfoBase* userInfo = GetPendingUserIfExists(user)) {
-            auto *ui = UsersInfoStorage->GetIfExists(user);
+            TUserInfoViewPtr ui = UsersInfoStorage->GetIfExists(user);
 
             AddCmdWrite(request,
                         ikey, ikeyDeprecated,
@@ -4428,7 +4428,7 @@ void TPartition::SetupDetailedMetrics() {
     SourceIdCountPerPartition = getCounter("topic.partition.producers_count", "SourceIdCount", false);
     TimeSinceLastWriteMsPerPartition = getCounter("topic.partition.write.idle_milliseconds", "TimeSinceLastWriteMs", false);
 
-    BytesWrittenPerPartition = getCounter("topic.partition.write.bytes", "BytesWrittenPerPartition", true);
+    BytesWrittenPerPartition = getCounter("topic.partitzion.write.bytes", "BytesWrittenPerPartition", true);
     MessagesWrittenPerPartition = getCounter("topic.partition.write.messages", "MessagesWrittenPerPartition", true);
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -420,9 +420,6 @@ ui64 TPartition::GetUsedStorage(const TInstant& now) {
 }
 
 static TDuration GetAvailabilityPeriod(const TUserInfo& consumer)  {
-    if (!ImporantOrExtendedAvailabilityPeriod(consumer)) {
-        return TDuration::Zero();
-    }
     if (consumer.Important) {
         return TDuration::Max();
     }

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -3068,13 +3068,6 @@ void TPartition::BeginChangePartitionConfig(const NKikimrPQ::TPQTabletConfig& co
         hasReadRule.insert(consumer);
     }
 
-    TSet<TString> important;
-    for (const auto& consumer : config.GetConsumers()) {
-        if (consumer.GetImportant()) {
-            important.insert(consumer.GetName());
-        }
-    }
-
     for (auto& consumer : config.GetConsumers()) {
         auto& userInfo = GetOrCreatePendingUser(consumer.GetName(), 0);
 
@@ -3083,7 +3076,7 @@ void TPartition::BeginChangePartitionConfig(const NKikimrPQ::TPQTabletConfig& co
             ts += TDuration::MilliSeconds(1);
         }
         userInfo.ReadFromTimestamp = ts;
-        userInfo.Important = important.contains(consumer.GetName());
+        userInfo.Important = consumer.GetImportant();
         userInfo.AvailabilityPeriod = TDuration::MilliSeconds(consumer.GetAvailabilityPeriodMs());
 
         ui64 rrGen = consumer.GetGeneration();

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -315,6 +315,8 @@ private:
     // Removes blobs that are no longer required. Blobs are no longer required if the storage time of all messages
     // stored in this blob has expired and they have been read by all important consumers.
     bool CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorContext& ctx);
+    // Checks if any consumer has uncommited messages in their availability window
+    bool ImportantConsumersNeedToKeepCurrentKey(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) const;
     bool IsQuotingEnabled() const;
     bool WaitingForPreviousBlobQuota() const;
     bool WaitingForSubDomainQuota(const ui64 withSize = 0) const;
@@ -533,8 +535,6 @@ public:
     // The size of the storage that usud by the partition. That included combination of the reserver and realy persisted data.
     ui64 StorageSize(const TActorContext& ctx) const;
     ui64 UsedReserveSize(const TActorContext& ctx) const;
-    // Minimal offsets, the data from which cannot be deleted, because it is required by an important consumers
-    TImportantConsumerOffsetTracker ImportantClientsMinOffset() const;
 
     TInstant GetEndWriteTimestamp() const; // For tests only
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "consumer_offset_tracker.h"
 #include "partition_blob_encoder.h"
 #include "partition_compactification.h"
 #include "partition_init.h"
@@ -532,8 +533,8 @@ public:
     // The size of the storage that usud by the partition. That included combination of the reserver and realy persisted data.
     ui64 StorageSize(const TActorContext& ctx) const;
     ui64 UsedReserveSize(const TActorContext& ctx) const;
-    // Minimal offset, the data from which cannot be deleted, because it is required by an important consumer
-    ui64 ImportantClientsMinOffset() const;
+    // Minimal offsets, the data from which cannot be deleted, because it is required by an important consumers
+    TImportantConsumerOffsetTracker ImportantClientsMinOffset() const;
 
     TInstant GetEndWriteTimestamp() const; // For tests only
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -452,9 +452,6 @@ private:
                                   const TActorContext& ctx);
     TString GetKeyConfig() const;
 
-    void InitPendingUserInfoForImportantClients(const NKikimrPQ::TPQTabletConfig& config,
-                                                const TActorContext& ctx);
-
     void Initialize(const TActorContext& ctx);
     template <typename T>
     void EmplacePendingRequest(T&& body, NWilson::TSpan&& span, const TActorContext& ctx) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_common.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_common.h
@@ -24,8 +24,8 @@ std::function<void(bool, T& r)> TPartition::GetResultPostProcessor(const TString
 
             if constexpr (std::is_same<T, NKikimrClient::TCmdReadResult>::value) {
                 if (consumer) {
-                    TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(consumer, ActorContext());
-                    r.SetCommittedToEnd(LastOffsetHasBeenCommited(*userInfo));
+                    auto& userInfo = UsersInfoStorage->GetOrCreate(consumer, ActorContext());
+                    r.SetCommittedToEnd(LastOffsetHasBeenCommited(userInfo));
                 }
             }
         }

--- a/ydb/core/persqueue/pqtablet/partition/partition_common.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_common.h
@@ -24,8 +24,8 @@ std::function<void(bool, T& r)> TPartition::GetResultPostProcessor(const TString
 
             if constexpr (std::is_same<T, NKikimrClient::TCmdReadResult>::value) {
                 if (consumer) {
-                    auto& userInfo = UsersInfoStorage->GetOrCreate(consumer, ActorContext());
-                    r.SetCommittedToEnd(LastOffsetHasBeenCommited(userInfo));
+                    TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(consumer, ActorContext());
+                    r.SetCommittedToEnd(LastOffsetHasBeenCommited(*userInfo));
                 }
             }
         }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1340,8 +1340,8 @@ void TPartition::CreateCompacter() {
         return;
     }
 
-    TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(CLIENTID_COMPACTION_CONSUMER, ActorContext()); //ToDo: Fix!
-    ui64 compStartOffset = userInfo->Offset;
+    auto& userInfo = UsersInfoStorage->GetOrCreate(CLIENTID_COMPACTION_CONSUMER, ActorContext()); //ToDo: Fix!
+    ui64 compStartOffset = userInfo.Offset;
     Compacter = MakeHolder<TPartitionCompaction>(compStartOffset, ++CompacterCookie, this);
     Compacter->TryCompactionIfPossible();
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1340,8 +1340,8 @@ void TPartition::CreateCompacter() {
         return;
     }
 
-    auto& userInfo = UsersInfoStorage->GetOrCreate(CLIENTID_COMPACTION_CONSUMER, ActorContext()); //ToDo: Fix!
-    ui64 compStartOffset = userInfo.Offset;
+    TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(CLIENTID_COMPACTION_CONSUMER, ActorContext()); //ToDo: Fix!
+    ui64 compStartOffset = userInfo->Offset;
     Compacter = MakeHolder<TPartitionCompaction>(compStartOffset, ++CompacterCookie, this);
     Compacter->TryCompactionIfPossible();
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -460,7 +460,7 @@ void TInitInfoRangeStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActor
 
 void TInitInfoRangeStep::PostProcessing(const TActorContext& ctx) {
     auto& usersInfoStorage = Partition()->UsersInfoStorage;
-    for (auto& [_, userInfo] : usersInfoStorage->GetAll()) {
+    for (auto&& [_, userInfo] : usersInfoStorage->GetAll()) {
         userInfo.AnyCommits = userInfo.Offset > (i64)Partition()->BlobEncoder.StartOffset;
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_monitoring.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_monitoring.cpp
@@ -296,7 +296,7 @@ void TPartition::HandleMonitoring(TEvPQ::TEvMonRequest::TPtr& ev, const TActorCo
                             }
                         }
                         TABLEBODY() {
-                            for (auto& [user, userInfo]: UsersInfoStorage->GetAll()) {
+                            for (auto&& [user, userInfo]: UsersInfoStorage->GetAll()) {
                                 auto snapshot = CreateSnapshot(userInfo);
                                 TABLER() {
                                     TABLED() {out << EncodeHtmlPcdata(user);}

--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -82,10 +82,10 @@ void TPartition::FillReadFromTimestamps(const TActorContext& ctx) {
     }
 
     for (auto& consumer : Config.GetConsumers()) {
-        TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(consumer.GetName(), ctx, 0);
-        userInfo->HasReadRule = true;
+        auto& userInfo = UsersInfoStorage->GetOrCreate(consumer.GetName(), ctx, 0);
+        userInfo.HasReadRule = true;
 
-        if (userInfo->ReadRuleGeneration != consumer.GetGeneration()) {
+        if (userInfo.ReadRuleGeneration != consumer.GetGeneration()) {
             THolder<TEvPQ::TEvSetClientInfo> event = MakeHolder<TEvPQ::TEvSetClientInfo>(
                     0, consumer.GetName(), 0, "", 0, 0, 0, TActorId{}, TEvPQ::TEvSetClientInfo::ESCI_INIT_READ_RULE, consumer.GetGeneration()
             );
@@ -93,34 +93,34 @@ void TPartition::FillReadFromTimestamps(const TActorContext& ctx) {
             // TODO(abcdef): заменить на вызов ProcessUserAct
             //
             AddUserAct(event.Release());
-            userInfo->Session = "";
-            userInfo->Offset = 0;
-            if (ImporantOrExtendedAvailabilityPeriod(*userInfo)) {
-                userInfo->Offset = GetStartOffset();
+            userInfo.Session = "";
+            userInfo.Offset = 0;
+            if (ImporantOrExtendedAvailabilityPeriod(userInfo)) {
+                userInfo.Offset = GetStartOffset();
             }
-            userInfo->Step = userInfo->Generation = 0;
+            userInfo.Step = userInfo.Generation = 0;
         }
         hasReadRule.erase(consumer.GetName());
         TInstant ts = TInstant::MilliSeconds(consumer.GetReadFromTimestampsMs());
         if (!ts) ts += TDuration::MilliSeconds(1);
-        if (!userInfo->ReadFromTimestamp || userInfo->ReadFromTimestamp > ts)
-            userInfo->ReadFromTimestamp = ts;
+        if (!userInfo.ReadFromTimestamp || userInfo.ReadFromTimestamp > ts)
+            userInfo.ReadFromTimestamp = ts;
     }
 
     for (auto& consumer : hasReadRule) {
-        TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(consumer, ctx);
-        if (userInfo->NoConsumer) {
+        auto& userInfo = UsersInfoStorage->GetOrCreate(consumer, ctx);
+        if (userInfo.NoConsumer) {
             continue;
         }
         THolder<TEvPQ::TEvSetClientInfo> event = MakeHolder<TEvPQ::TEvSetClientInfo>(
                 0, consumer, 0, "", 0, 0, 0, TActorId{}, TEvPQ::TEvSetClientInfo::ESCI_DROP_READ_RULE, 0
         );
-        if (!ImporantOrExtendedAvailabilityPeriod(*userInfo) && userInfo->LabeledCounters) {
-            ctx.Send(TabletActorId, new TEvPQ::TEvPartitionLabeledCountersDrop(Partition, userInfo->LabeledCounters->GetGroup()));
+        if (!ImporantOrExtendedAvailabilityPeriod(userInfo) && userInfo.LabeledCounters) {
+            ctx.Send(TabletActorId, new TEvPQ::TEvPartitionLabeledCountersDrop(Partition, userInfo.LabeledCounters->GetGroup()));
         }
-        userInfo->Session = "";
-        userInfo->Offset = 0;
-        userInfo->Step = userInfo->Generation = 0;
+        userInfo.Session = "";
+        userInfo.Offset = 0;
+        userInfo.Step = userInfo.Generation = 0;
         //
         // TODO(abcdef): заменить на вызов ProcessUserAct
         //
@@ -155,8 +155,8 @@ bool TPartition::ProcessHasDataRequest(const THasDataReq& request, const TActorC
             sendResponse(0, true);
 
             auto now = ctx.Now();
-            TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(request.ClientId, ctx);
-            userInfo->UpdateReadOffset((i64)GetEndOffset() - 1, now, now, now, true);
+            auto& userInfo = UsersInfoStorage->GetOrCreate(request.ClientId, ctx);
+            userInfo.UpdateReadOffset((i64)GetEndOffset() - 1, now, now, now, true);
         }
     } else if (request.Offset < GetEndOffset()) {
         sendResponse(GetSizeLag(request.Offset), false);
@@ -176,8 +176,8 @@ void TPartition::ProcessHasDataRequests(const TActorContext& ctx) {
 
     auto forgetSubscription = [&](const TString clientId) {
         if (!clientId.empty()) {
-            TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(clientId, ctx);
-            userInfo->ForgetSubscription(GetEndOffset(), now);
+            auto& userInfo = UsersInfoStorage->GetOrCreate(clientId, ctx);
+            userInfo.ForgetSubscription(GetEndOffset(), now);
         }
     };
 
@@ -227,10 +227,10 @@ void TPartition::Handle(TEvPersQueue::TEvHasDataInfo::TPtr& ev, const TActorCont
         PQ_ENSURE(res.second);
 
         if (InitDone && record.HasClientId() && !record.GetClientId().empty()) {
-            TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(record.GetClientId(), ctx);
-            ++userInfo->Subscriptions;
-            userInfo->UpdateReadOffset((i64)GetEndOffset() - 1, now, now, now);
-            userInfo->UpdateReadingTimeAndState(GetEndOffset(), now);
+            auto& userInfo = UsersInfoStorage->GetOrCreate(record.GetClientId(), ctx);
+            ++userInfo.Subscriptions;
+            userInfo.UpdateReadOffset((i64)GetEndOffset() - 1, now, now, now);
+            userInfo.UpdateReadingTimeAndState(GetEndOffset(), now);
         }
     }
 }
@@ -248,14 +248,14 @@ void TPartition::InitUserInfoForImportantClients(const TActorContext& ctx) {
 
         important.insert(consumer.GetName());
 
-        TUserInfoMutableViewPtr userInfo = UsersInfoStorage->GetIfExists(consumer.GetName());
+        TUserInfo* userInfo = UsersInfoStorage->GetIfExists(consumer.GetName());
         if (userInfo && !ImporantOrExtendedAvailabilityPeriod(*userInfo) && userInfo->LabeledCounters) {
             ctx.Send(TabletActorId, new TEvPQ::TEvPartitionLabeledCountersDrop(Partition, userInfo->LabeledCounters->GetGroup()));
             userInfo->SetImportant(consumer.GetImportant(), TDuration::MilliSeconds(consumer.GetAvailabilityPeriodMs()));
             continue;
         }
         if (!userInfo) {
-            userInfo = UsersInfoStorage->Create(
+            userInfo = &UsersInfoStorage->Create(
                     ctx, consumer.GetName(), 0, consumer.GetImportant(), TDuration::MilliSeconds(consumer.GetAvailabilityPeriodMs()), "", 0, 0, 0, 0, 0, TInstant::Zero(), {}, false
             );
         }
@@ -283,7 +283,7 @@ void TPartition::Handle(TEvPQ::TEvPartitionOffsets::TPtr& ev, const TActorContex
     result.SetWriteTimestampEstimateMS(WriteTimestampEstimate.MilliSeconds());
 
     if (!ev->Get()->ClientId.empty()) {
-        TUserInfoViewPtr userInfo = UsersInfoStorage->GetIfExists(ev->Get()->ClientId);
+        TUserInfo* userInfo = UsersInfoStorage->GetIfExists(ev->Get()->ClientId);
         if (userInfo) {
             auto snapshot = CreateSnapshot(*userInfo);
             result.SetClientOffset(userInfo->Offset);
@@ -311,12 +311,12 @@ std::pair<TInstant, TInstant> TPartition::GetTime(const TUserInfo& userInfo, ui6
 }
 
 void TPartition::Handle(TEvPQ::TEvGetClientOffset::TPtr& ev, const TActorContext& ctx) {
-    TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(ev->Get()->ClientId, ctx);
-    PQ_ENSURE(userInfo->Offset >= -1)("Unexpected Offset", userInfo->Offset);
-    ui64 offset = Max<i64>(userInfo->Offset, 0);
-    auto ts = GetTime(*userInfo, offset);
+    auto& userInfo = UsersInfoStorage->GetOrCreate(ev->Get()->ClientId, ctx);
+    PQ_ENSURE(userInfo.Offset >= -1)("Unexpected Offset", userInfo.Offset);
+    ui64 offset = Max<i64>(userInfo.Offset, 0);
+    auto ts = GetTime(userInfo, offset);
     TabletCounters.Cumulative()[COUNTER_PQ_GET_CLIENT_OFFSET_OK].Increment(1);
-    ReplyGetClientOffsetOk(ctx, ev->Get()->Cookie, userInfo->Offset, ts.first, ts.second, userInfo->AnyCommits, userInfo->CommittedMetadata);
+    ReplyGetClientOffsetOk(ctx, ev->Get()->Cookie, userInfo.Offset, ts.first, ts.second, userInfo.AnyCommits, userInfo.CommittedMetadata);
 }
 
 void TPartition::Handle(TEvPQ::TEvSetClientInfo::TPtr& ev, const TActorContext& ctx) {
@@ -687,9 +687,9 @@ void TPartition::Handle(TEvPQ::TEvReadTimeout::TPtr& ev, const TActorContext& ct
     ctx.Send(answer.IsInternal ? SelfId() : TabletActorId, answer.Event.Release());
     LOG_D(" waiting read cookie " << ev->Get()->Cookie
         << " partition " << Partition << " read timeout for " << res->User << " offset " << res->Offset);
-    TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(res->User, ctx);
+    auto& userInfo = UsersInfoStorage->GetOrCreate(res->User, ctx);
 
-    userInfo->ForgetSubscription(GetEndOffset(), ctx.Now());
+    userInfo.ForgetSubscription(GetEndOffset(), ctx.Now());
     OnReadRequestFinished(res->Destination, answer.Size, res->User, ctx);
 }
 
@@ -803,9 +803,9 @@ void TPartition::Handle(TEvPQ::TEvRead::TPtr& ev, const TActorContext& ctx) {
     PQ_ENSURE(read->Offset <= GetEndOffset());
 
     const TString& user = read->ClientId;
-    TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(user, ctx);
-    if (!read->SessionId.empty() && !userInfo->NoConsumer) {
-        if (userInfo->Session != read->SessionId) {
+    auto& userInfo = UsersInfoStorage->GetOrCreate(user, ctx);
+    if (!read->SessionId.empty() && !userInfo.NoConsumer) {
+        if (userInfo.Session != read->SessionId) {
             TabletCounters.Cumulative()[COUNTER_PQ_READ_ERROR_NO_SESSION].Increment(1);
             TabletCounters.Percentile()[COUNTER_LATENCY_PQ_READ_ERROR].IncrementFor(0);
             ReplyError(ctx, read->Cookie, NPersQueue::NErrorCode::READ_ERROR_NO_SESSION,
@@ -813,7 +813,7 @@ void TPartition::Handle(TEvPQ::TEvRead::TPtr& ev, const TActorContext& ctx) {
             return;
         }
     }
-    userInfo->ReadsInQuotaQueue++;
+    userInfo.ReadsInQuotaQueue++;
     Send(ReadQuotaTrackerActor,
             new TEvPQ::TEvRequestQuota(ev->Get()->Cookie, IEventHandle::Upcast(std::move(ev)))
     );
@@ -1048,10 +1048,10 @@ void TPartition::ProcessRead(const TActorContext& ctx, TReadInfo&& info, const u
     ui32 size = 0;
 
     PQ_ENSURE(!info.User.empty());
-    TUserInfoMutableRef userInfo = UsersInfoStorage->GetOrCreate(info.User, ctx);
+    auto& userInfo = UsersInfoStorage->GetOrCreate(info.User, ctx);
 
     if (subscription) {
-        userInfo->ForgetSubscription(GetEndOffset(), ctx.Now());
+        userInfo.ForgetSubscription(GetEndOffset(), ctx.Now());
     }
 
     TVector<TRequestedBlob> blobs;
@@ -1080,14 +1080,14 @@ void TPartition::ProcessRead(const TActorContext& ctx, TReadInfo&& info, const u
 
     PQ_ENSURE(info.BlobKeyTokens.Size() == info.Blobs.size());
     if (info.Destination != 0) {
-        ++userInfo->ActiveReads;
-        userInfo->UpdateReadingTimeAndState(GetEndOffset(), ctx.Now());
+        ++userInfo.ActiveReads;
+        userInfo.UpdateReadingTimeAndState(GetEndOffset(), ctx.Now());
     }
 
     if (info.Blobs.empty()) { //all from head, answer right now
         LOG_D("Reading cookie " << cookie << ". All data is from uncompacted head.");
 
-        OnReadComplete(info, UsersInfoStorage->GetOrCreate(info.User, ctx).Get(), nullptr, ctx);
+        OnReadComplete(info, &UsersInfoStorage->GetOrCreate(info.User, ctx), nullptr, ctx);
         return;
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/user_info.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.cpp
@@ -309,7 +309,7 @@ void TUsersInfoStorage::ParseDeprecated(const TString& key, const TString& data,
     AFL_ENSURE(key[TKeyPrefix::MarkPosition()] == TKeyPrefix::MarkUserDeprecated);
     TString user = key.substr(TKeyPrefix::MarkedSize());
 
-    TUserInfo* userInfo = GetIfExists(user);
+    TUserInfoMutableViewPtr userInfo = GetIfExists(user);
     if (userInfo && userInfo->Parsed) {
         return;
     }
@@ -345,7 +345,7 @@ void TUsersInfoStorage::Parse(const TString& key, const TString& data, const TAc
     AFL_ENSURE(userData.GetOffset() <= (ui64)Max<i64>())("description", "Offset is too big")("offset", userData.GetOffset());
     i64 offset = static_cast<i64>(userData.GetOffset());
 
-    TUserInfo* userInfo = GetIfExists(user);
+    TUserInfoMutableViewPtr userInfo = GetIfExists(user);
     if (!userInfo) {
         Create(
             ctx, user, userData.GetReadRuleGeneration(), false, TDuration::Zero(), userData.GetSession(), userData.GetPartitionSessionId(),
@@ -372,7 +372,7 @@ void TUsersInfoStorage::Remove(const TString& user, const TActorContext&) {
     UsersInfo.erase(it);
 }
 
-TUserInfo& TUsersInfoStorage::GetOrCreate(const TString& user, const TActorContext& ctx, TMaybe<ui64> readRuleGeneration) {
+TUserInfoMutableRef TUsersInfoStorage::GetOrCreate(const TString& user, const TActorContext& ctx, TMaybe<ui64> readRuleGeneration) {
     AFL_ENSURE(!user.empty());
     auto it = UsersInfo.find(user);
     if (it == UsersInfo.end()) {
@@ -381,7 +381,7 @@ TUserInfo& TUsersInfoStorage::GetOrCreate(const TString& user, const TActorConte
                 0, 0, 0, 0, TInstant::Zero(), {}, false
         );
     }
-    return it->second;
+    return TUserInfoMutableRef{&it->second, this};
 }
 
 ::NMonitoring::TDynamicCounterPtr TUsersInfoStorage::GetPartitionCounterSubgroup(const TActorContext& ctx) const {
@@ -442,14 +442,14 @@ bool TUsersInfoStorage::DetailedMetricsAreEnabled() const {
     return AppData()->FeatureFlags.GetEnableMetricsLevel() && (Config.HasMetricsLevel() && Config.GetMetricsLevel() == Ydb::MetricsLevel::Detailed);
 }
 
-const TUserInfo* TUsersInfoStorage::GetIfExists(const TString& user) const {
-    auto it = UsersInfo.find(user);
-    return it != UsersInfo.end() ? &it->second : nullptr;
+TUserInfoViewPtr TUsersInfoStorage::GetIfExists(const TString& user) const {
+    auto p = UsersInfo.FindPtr(user);
+    return TUserInfoViewPtr(p, this);
 }
 
-TUserInfo* TUsersInfoStorage::GetIfExists(const TString& user) {
-    auto it = UsersInfo.find(user);
-    return it != UsersInfo.end() ? &it->second : nullptr;
+TUserInfoMutableViewPtr TUsersInfoStorage::GetIfExists(const TString& user) {
+    auto p = UsersInfo.FindPtr(user);
+    return TUserInfoMutableViewPtr(p, this);
 }
 
 THashMap<TString, TUserInfo>& TUsersInfoStorage::GetAll() {
@@ -493,7 +493,7 @@ TUserInfoBase TUsersInfoStorage::CreateUserInfo(const TString& user,
                           "", 0, 0, 0, false, false, TDuration::Zero(), {}, 0, {}};
 }
 
-TUserInfo& TUsersInfoStorage::Create(
+TUserInfoMutableRef TUsersInfoStorage::Create(
         const TActorContext& ctx, const TString& user, const ui64 readRuleGeneration,
         bool important, const TDuration availabilityPeriod, const TString& session,
         ui64 partitionSessionId, ui32 gen, ui32 step, i64 offset, ui64 readOffsetRewindSum,
@@ -505,7 +505,7 @@ TUserInfo& TUsersInfoStorage::Create(
                                               anyCommits, committedMetadata);
     auto result = UsersInfo.emplace(user, std::move(userInfo));
     AFL_ENSURE(result.second);
-    return result.first->second;
+    return TUserInfoMutableRef{&result.first->second, this};
 }
 
 void TUsersInfoStorage::Clear(const TActorContext&) {

--- a/ydb/core/persqueue/pqtablet/partition/user_info.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.cpp
@@ -85,7 +85,7 @@ TUserInfo::TUserInfo(
             SetupStreamCounters(streamCountersSubgroup);
         } else {
             LabeledCounters.Reset(new TUserLabeledCounters(
-                user + "/" + (important ? "1" : "0") + "/" + topicConverter->GetClientsideName(),
+                user + "/" + (ImporantOrExtendedAvailabilityPeriod(*this) ? "1" : "0") + "/" + topicConverter->GetClientsideName(),
                 partition));
 
             SetupTopicCounters(ctx, dcId, ToString<ui32>(partition));

--- a/ydb/core/persqueue/pqtablet/partition/user_info.h
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.h
@@ -223,95 +223,6 @@ struct TUserInfo: public TUserInfoBase {
     bool Parsed = false;
 };
 
-class TUsersInfoStorage;
-
-class TUserInfoMutableViewPtr: public TPointerBase<TUserInfoMutableViewPtr, TUserInfo> {
-public:
-    TUserInfoMutableViewPtr(TUserInfo* userInfo, TUsersInfoStorage* usersInfoStorage)
-        : UserInfo_(userInfo)
-        , UsersInfoStorage_(usersInfoStorage)
-    {
-        Y_ASSERT(UsersInfoStorage_);
-    }
-
-    TUserInfo* Get() const noexcept {
-        return UserInfo_;
-    }
-
-    TUsersInfoStorage* UsersInfoStorage() const noexcept {
-        Y_ASSERT(UsersInfoStorage_);
-        return UsersInfoStorage_;
-    }
-
-    explicit operator bool() const noexcept {
-        return UserInfo_ != nullptr;
-    }
-
-
-private:
-    TUserInfo* UserInfo_;
-    TUsersInfoStorage* UsersInfoStorage_;
-};
-
-
-class TUserInfoMutableRef: public TUserInfoMutableViewPtr {
-public:
-    TUserInfoMutableRef(TUserInfo* userInfo, TUsersInfoStorage* usersInfoStorage)
-        : TUserInfoMutableViewPtr(userInfo, usersInfoStorage)
-    {
-        Y_ASSERT(UserInfo_);
-        Y_ASSERT(UsersInfoStorage_);
-    }
-
-    TUserInfo* Get() const noexcept {
-        Y_ASSERT(UserInfo_);
-        return UserInfo_;
-    }
-
-    TUsersInfoStorage* UsersInfoStorage() const noexcept {
-        Y_ASSERT(UsersInfoStorage_);
-        return UsersInfoStorage_;
-    }
-
-private:
-    TUserInfo* UserInfo_;
-    TUsersInfoStorage* UsersInfoStorage_;
-};
-
-class TUserInfoViewPtr: public TPointerBase<TUserInfoMutableViewPtr, TUserInfo> {
-public:
-    TUserInfoViewPtr(const TUserInfo* userInfo, const TUsersInfoStorage* usersInfoStorage)
-        : UserInfo_(userInfo)
-        , UsersInfoStorage_(usersInfoStorage)
-    {
-        Y_ASSERT(UsersInfoStorage_);
-    }
-
-    TUserInfoViewPtr(const TUserInfoMutableViewPtr& userInfo)
-        : UserInfo_(userInfo.Get())
-        , UsersInfoStorage_(userInfo.UsersInfoStorage())
-    {
-        Y_ASSERT(UsersInfoStorage_);
-    }
-
-    const TUserInfo* Get() const noexcept {
-        return UserInfo_;
-    }
-
-    const TUsersInfoStorage* UsersInfoStorage() const noexcept {
-        Y_ASSERT(UsersInfoStorage_);
-        return UsersInfoStorage_;
-    }
-
-    explicit operator bool() const noexcept {
-        return UserInfo_ != nullptr;
-    }
-
-private:
-    const TUserInfo* UserInfo_;
-    const TUsersInfoStorage* UsersInfoStorage_;
-};
-
 class TUsersInfoStorage {
 public:
     TUsersInfoStorage(
@@ -331,15 +242,15 @@ public:
     void ParseDeprecated(const TString& key, const TString& data, const TActorContext& ctx);
     void Parse(const TString& key, const TString& data, const TActorContext& ctx);
 
-    TUserInfoMutableRef GetOrCreate(const TString& user, const TActorContext& ctx, TMaybe<ui64> readRuleGeneration = {});
-    TUserInfoViewPtr GetIfExists(const TString& user) const;
-    TUserInfoMutableViewPtr GetIfExists(const TString& user);
+    TUserInfo& GetOrCreate(const TString& user, const TActorContext& ctx, TMaybe<ui64> readRuleGeneration = {});
+    const TUserInfo* GetIfExists(const TString& user) const;
+    TUserInfo* GetIfExists(const TString& user);
 
     THashMap<TString, TUserInfo>& GetAll();
 
     TUserInfoBase CreateUserInfo(const TString& user,
                              TMaybe<ui64> readRuleGeneration = {}) const;
-    TUserInfoMutableRef Create(
+    TUserInfo& Create(
         const TActorContext& ctx,
         const TString& user, const ui64 readRuleGeneration, bool important, TDuration availabilityPeriod, const TString& session,
         ui64 partitionSessionId, ui32 gen, ui32 step, i64 offset, ui64 readOffsetRewindSum,

--- a/ydb/core/persqueue/pqtablet/partition/user_info.h
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.h
@@ -208,16 +208,19 @@ public:
     const TUserInfo* GetIfExists(const TString& user) const;
     TUserInfo* GetIfExists(const TString& user);
 
+    // iterate over a mutable list of UserInfo
     auto GetAll() {
         auto proj = [](auto& ni) -> std::pair<const TString&, TUserInfo&> { return {ni.first, *ni.second}; };
         return std::views::transform(UsersInfo, proj);
     }
 
+    // iterate over a constant list of UserInfo
     auto ViewAll() const {
         auto proj = [](auto& ni) -> std::pair<const TString&, const TUserInfo&> { return {ni.first, *ni.second}; };
         return std::views::transform(UsersInfo, proj);
     }
 
+    // iterate over a constant list of UserInfo with important flag or non-zero availability period
     auto ViewImportant() const {
         auto proj = [](auto& ni) -> std::pair<const TString&, const TUserInfo&> { return {ni.first, *ni.second}; };
         return std::views::transform(ImportantExtUsersInfoSlice, proj);

--- a/ydb/core/persqueue/pqtablet/partition/user_info.h
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.h
@@ -88,50 +88,7 @@ struct TUserInfo: public TUserInfoBase, public TAtomicRefCount<TUserInfo> {
         const ui64 readOffsetRewindSum, const TString& dcId, TInstant readFromTimestamp,
         const TString& dbPath, bool meterRead, const TActorId& pipeClient, bool anyCommits,
         const std::optional<TString>& committedMetadata = std::nullopt
-    )
-        : TUserInfoBase{user, readRuleGeneration, session, gen, step, offset, anyCommits, important, availabilityPeriod,
-                        readFromTimestamp, partitionSession, pipeClient, committedMetadata}
-        , ActualTimestamps(false)
-        , WriteTimestamp(TInstant::Zero())
-        , CreateTimestamp(TInstant::Zero())
-        , ReadTimestamp(TAppData::TimeProvider->Now())
-        , ReadOffset(-1)
-        , ReadWriteTimestamp(TInstant::Zero())
-        , ReadCreateTimestamp(TInstant::Zero())
-        , ReadOffsetRewindSum(readOffsetRewindSum)
-        , ReadScheduled(false)
-        , HasReadRule(false)
-        , TopicConverter(topicConverter)
-        , Counter(nullptr)
-        , ActiveReads(0)
-        , ReadsInQuotaQueue(0)
-        , Subscriptions(0)
-        , Partition(partition)
-        , AvgReadBytes{{TDuration::Seconds(1), 1000}, {TDuration::Minutes(1), 1000},
-                       {TDuration::Hours(1), 2000}, {TDuration::Days(1), 2000}}
-        , WriteLagMs(TDuration::Minutes(1), 100)
-        , NoConsumer(user == CLIENTID_WITHOUT_CONSUMER)
-        , MeterRead(meterRead)
-    {
-        if (AppData(ctx)->Counters) {
-            if (partitionCountersSubgroup) {
-                SetupDetailedMetrics(ctx, partitionCountersSubgroup);
-            }
-
-            if (AppData()->PQConfig.GetTopicsAreFirstClassCitizen()) {
-                LabeledCounters.Reset(new TUserLabeledCounters(
-                    EscapeBadChars(user) + "||" + EscapeBadChars(topicConverter->GetClientsideName()), partition, dbPath));
-
-                SetupStreamCounters(streamCountersSubgroup);
-            } else {
-                LabeledCounters.Reset(new TUserLabeledCounters(
-                    user + "/" + (important ? "1" : "0") + "/" + topicConverter->GetClientsideName(),
-                    partition));
-
-                SetupTopicCounters(ctx, dcId, ToString<ui32>(partition));
-            }
-        }
-    }
+    );
 
     void ForgetSubscription(i64 endOffset, const TInstant& now);
     void UpdateReadingState();

--- a/ydb/core/persqueue/pqtablet/partition/ut/consumer_offset_tracker_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/ut/consumer_offset_tracker_ut.cpp
@@ -1,0 +1,212 @@
+#include <ydb/core/persqueue/pqtablet/partition/consumer_offset_tracker.h>
+
+#include <library/cpp/testing/gtest/gtest.h>
+
+using namespace NKikimr::NPQ;
+
+static const std::vector<TDataKey> KEYS = {
+    {
+        .Key = TKey::ForBody(TKey::TypeData, TPartitionId(0), 10, 0, 0, 0),
+        .Timestamp = TInstant::Seconds(100)
+    },
+    {
+        .Key = TKey::ForBody(TKey::TypeData, TPartitionId(0), 20, 0, 0, 0),
+        .Timestamp = TInstant::Seconds(200)
+    },
+    {
+        .Key = TKey::ForBody(TKey::TypeData, TPartitionId(0), 30, 0, 0, 0),
+        .Timestamp = TInstant::Seconds(300)
+    },
+    {
+        .Key = TKey::ForBody(TKey::TypeData, TPartitionId(0), 40, 5, 0, 0),
+        .Timestamp = TInstant::Seconds(400)
+    },
+    {
+        .Key = TKey::ForBody(TKey::TypeData, TPartitionId(0), 50, 0, 0, 0),
+        .Timestamp = TInstant::Seconds(500)
+    },
+};
+
+static const TInstant NOW = TInstant::Seconds(800);
+
+static std::vector<std::tuple<size_t, TDataKey, TDataKey>> Pairs() {
+    std::vector<std::tuple<size_t, TDataKey, TDataKey>> r;
+    for (size_t i = 1; i < KEYS.size(); ++i) {
+        r.emplace_back(i, KEYS[i - 1], KEYS[i - 0]);
+    }
+    return r;
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, EmptyConsumersList) {
+    TImportantConsumerOffsetTracker tracker({});
+
+    for (const auto& [idx, currentKey, nextKey] : Pairs()) {
+        EXPECT_FALSE(tracker.ShouldKeepCurrentKey(currentKey, nextKey, NOW)) << "case=" << idx;
+    }
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, Unbound) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 35},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, Expired) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(15), .Offset = 35},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, UnboundAndExpired) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(15), .Offset = 35},
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 25},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+
+TEST(TImportantConsumerOffsetTrackerTest, ReadUnboundAndExpired) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(15), .Offset = 35},
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 75},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+
+TEST(TImportantConsumerOffsetTrackerTest, ReadUnboundAndWaiting300) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(300), .Offset = 35},
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 75},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+
+TEST(TImportantConsumerOffsetTrackerTest, ReadUnboundAndWaiting400) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(400), .Offset = 35},
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 75},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, ReadUnboundAndWaiting500) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(500), .Offset = 35},
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 75},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, Waiting400And500) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(400), .Offset = 35},
+        {.AvailabilityPeriod = TDuration::Seconds(500), .Offset = 35},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, Waiting400AndRead500) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(400), .Offset = 35},
+        {.AvailabilityPeriod = TDuration::Seconds(500), .Offset = 45},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, ExactMatchSingleConsumerMaxRetention) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 30},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, ExactMatchSingleConsumerFiniteRetention) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(500), .Offset = 30},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, ExactMatchMultipleConsumers) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(400), .Offset = 20},
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 30},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, MultipleExactMatches) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Seconds(500), .Offset = 20},
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 30},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}
+
+TEST(TImportantConsumerOffsetTrackerTest, UnboundKeepNextBlob) {
+    std::vector<TImportantConsumerOffsetTracker::TConsumerOffset> consumers{
+        {.AvailabilityPeriod = TDuration::Max(), .Offset = 40},
+    };
+    TImportantConsumerOffsetTracker tracker(std::move(consumers));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[0], KEYS[1], NOW));
+    EXPECT_FALSE(tracker.ShouldKeepCurrentKey(KEYS[1], KEYS[2], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[2], KEYS[3], NOW));
+    EXPECT_TRUE(tracker.ShouldKeepCurrentKey(KEYS[3], KEYS[4], NOW));
+}

--- a/ydb/core/persqueue/pqtablet/partition/ut/ya.make
+++ b/ydb/core/persqueue/pqtablet/partition/ut/ya.make
@@ -1,0 +1,12 @@
+GTEST()
+
+
+SRCS(
+    consumer_offset_tracker_ut.cpp
+)
+
+PEERDIR(
+    ydb/core/persqueue/pqtablet/partition
+)
+
+END()

--- a/ydb/core/persqueue/pqtablet/partition/ya.make
+++ b/ydb/core/persqueue/pqtablet/partition/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     account_read_quoter.cpp
     autopartitioning_manager.cpp
+    consumer_offset_tracker.cpp
     offload_actor.cpp
     ownerinfo.cpp
     partition.cpp
@@ -43,4 +44,5 @@ RECURSE(
 )
 
 RECURSE_FOR_TESTS(
+    ut
 )

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -376,6 +376,7 @@ message TPQTabletConfig {
         optional uint64 Version = 7 [default = 0];
         optional uint64 Generation = 8 [default = 0];
         optional bool Important = 9 [default = false];
+        optional uint64 AvailabilityPeriodMs = 10 [default = 0];
     }
 
     repeated TConsumer Consumers = 37;

--- a/ydb/core/ydb_convert/topic_description.cpp
+++ b/ydb/core/ydb_convert/topic_description.cpp
@@ -25,6 +25,10 @@ bool FillConsumer(Ydb::Topic::Consumer& out, const NKikimrPQ::TPQTabletConfig_TC
     }
 
     out.set_important(in.GetImportant());
+    if (in.has_availabilityperiodms()) {
+        out.mutable_availability_period()->set_seconds(in.availabilityperiodms() / 1000);
+        out.mutable_availability_period()->set_nanos((in.availabilityperiodms() % 1000) * 1'000'000);
+    }
     TString serviceType = "";
     if (in.HasServiceType()) {
         serviceType = in.GetServiceType();
@@ -43,7 +47,7 @@ bool FillConsumer(Ydb::Topic::Consumer& out, const NKikimrPQ::TPQTabletConfig_TC
 bool FillTopicDescription(Ydb::Topic::DescribeTopicResult& out, const NKikimrSchemeOp::TPersQueueGroupDescription& inDesc,
     const NKikimrSchemeOp::TDirEntry& inDirEntry, const TMaybe<TString>& cdcName,
     Ydb::StatusIds_StatusCode& status, TString& error) {
-    
+
     const NKikimrPQ::TPQConfig pqConfig = AppData()->PQConfig;
 
     Ydb::Scheme::Entry *selfEntry = out.mutable_self();

--- a/ydb/public/api/protos/ydb_persqueue_v1.proto
+++ b/ydb/public/api/protos/ydb_persqueue_v1.proto
@@ -1159,6 +1159,9 @@ message TopicSettings {
 
         // Client service type.
         string service_type = 7;
+
+        // Message for this consumer will not expire due to retention for at least `availability_period` if they aren't commited.
+        optional google.protobuf.Duration availability_period = 8;
     }
 
     // List of consumer read rules for this topic.

--- a/ydb/public/api/protos/ydb_topic.proto
+++ b/ydb/public/api/protos/ydb_topic.proto
@@ -6,6 +6,7 @@ import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/annotations/sensitive.proto";
 import "ydb/public/api/protos/annotations/validation.proto";
 
+import "google/protobuf/empty.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -822,6 +823,9 @@ message Consumer {
         // Bytes read statistics.
         MultipleWindowsStat bytes_read = 4;
     }
+
+    // Message for this consumer will not expire due to retention for at least `availability_period` if they aren't commited.
+    optional google.protobuf.Duration availability_period = 8;
 }
 
 // Consumer alter description.
@@ -844,6 +848,12 @@ message AlterConsumer {
     // User and server attributes of consumer. Server attributes starts from "_" and will be validated by server.
     // Leave the value blank to drop an attribute.
     map<string, string> alter_attributes = 6;
+
+    // Change message lifetime if consumer is important.
+    oneof availability_period_action {
+        google.protobuf.Duration set_availability_period = 7;
+        google.protobuf.Empty reset_availability_period = 8;
+    }
 }
 
 enum AutoPartitioningStrategy {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
@@ -42,6 +42,7 @@ public:
 
     const std::string& GetConsumerName() const;
     bool GetImportant() const;
+    TDuration GetAvailabilityPeriod() const;
     const TInstant& GetReadFrom() const;
     const std::vector<ECodec>& GetSupportedCodecs() const;
     const std::map<std::string, std::string>& GetAttributes() const;
@@ -49,6 +50,7 @@ public:
 private:
     std::string ConsumerName_;
     bool Important_;
+    TDuration AvailabilityPeriod_;
     TInstant ReadFrom_;
     std::map<std::string, std::string> Attributes_;
     std::vector<ECodec> SupportedCodecs_;
@@ -452,6 +454,7 @@ struct TConsumerSettings {
 
     FLUENT_SETTING(std::string, ConsumerName);
     FLUENT_SETTING_DEFAULT(bool, Important, false);
+    FLUENT_SETTING_DEFAULT(TDuration, AvailabilityPeriod, TDuration::Zero());
     FLUENT_SETTING_DEFAULT(TInstant, ReadFrom, TInstant::Zero());
 
     FLUENT_SETTING_VECTOR(ECodec, SupportedCodecs);
@@ -488,6 +491,11 @@ struct TConsumerSettings {
         return *this;
     }
 
+    TConsumerSettings& SetAvailiabilityPeriod(TDuration availabilityPeriod) {
+        AvailabilityPeriod_ = availabilityPeriod;
+        return *this;
+    }
+
     TSettings& EndAddConsumer() { return Parent_; };
 
 private:
@@ -504,6 +512,7 @@ struct TAlterConsumerSettings {
 
     FLUENT_SETTING(std::string, ConsumerName);
     FLUENT_SETTING_OPTIONAL(bool, SetImportant);
+    FLUENT_SETTING_OPTIONAL(TDuration, SetAvailabilityPeriod);
     FLUENT_SETTING_OPTIONAL(TInstant, SetReadFrom);
 
     FLUENT_SETTING_OPTIONAL_VECTOR(ECodec, SetSupportedCodecs);
@@ -521,6 +530,11 @@ struct TAlterConsumerSettings {
 
     TAlterConsumerSettings& SetSupportedCodecs(const std::vector<ECodec>& codecs) {
         SetSupportedCodecs_ = codecs;
+        return *this;
+    }
+
+    TAlterConsumerSettings& SetAvailabilityPeriod(TDuration availabilityPeriod) {
+        SetAvailabilityPeriod_ = availabilityPeriod;
         return *this;
     }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
@@ -11,6 +11,10 @@
 
 namespace NYdb::inline Dev::NTopic {
 
+static TDuration ConvertPositiveDuration(const google::protobuf::Duration& duration) {
+    return TDuration::Seconds(Max<i64>(duration.seconds(), 0)) + TDuration::MicroSeconds(Max<i32>(duration.nanos(), 0) / 1000);
+}
+
 TDescribeTopicResult::TDescribeTopicResult(TStatus&& status, Ydb::Topic::DescribeTopicResult&& result)
     : TStatus(std::move(status))
     , TopicDescription_(std::move(result))
@@ -88,6 +92,7 @@ TPartitionDescription::TPartitionDescription(Ydb::Topic::DescribePartitionResult
 TConsumer::TConsumer(const Ydb::Topic::Consumer& consumer)
     : ConsumerName_(consumer.name())
     , Important_(consumer.important())
+    , AvailabilityPeriod_(ConvertPositiveDuration(consumer.availability_period()))
     , ReadFrom_(TInstant::Seconds(consumer.read_from().seconds()))
 {
     for (const auto& codec : consumer.supported_codecs().codecs()) {
@@ -104,6 +109,10 @@ const std::string& TConsumer::GetConsumerName() const {
 
 bool TConsumer::GetImportant() const {
     return Important_;
+}
+
+TDuration TConsumer::GetAvailabilityPeriod() const {
+    return AvailabilityPeriod_;
 }
 
 const TInstant& TConsumer::GetReadFrom() const {
@@ -282,7 +291,7 @@ uint32_t TAutoPartitioningSettings::GetDownUtilizationPercent() const {
 TTopicStats::TTopicStats(const Ydb::Topic::DescribeTopicResult::TopicStats& topicStats)
     : StoreSizeBytes_(topicStats.store_size_bytes())
     , MinLastWriteTime_(TInstant::Seconds(topicStats.min_last_write_time().seconds()))
-    , MaxWriteTimeLag_(TDuration::Seconds(topicStats.max_write_time_lag().seconds()) + TDuration::MicroSeconds(topicStats.max_write_time_lag().nanos() / 1000))
+    , MaxWriteTimeLag_(ConvertPositiveDuration(topicStats.max_write_time_lag()))
     , BytesWrittenPerMinute_(topicStats.bytes_written().per_minute())
     , BytesWrittenPerHour_(topicStats.bytes_written().per_hour())
     , BytesWrittenPerDay_(topicStats.bytes_written().per_day())
@@ -319,7 +328,7 @@ TPartitionStats::TPartitionStats(const Ydb::Topic::PartitionStats& partitionStat
     , EndOffset_(partitionStats.partition_offsets().end())
     , StoreSizeBytes_(partitionStats.store_size_bytes())
     , LastWriteTime_(TInstant::Seconds(partitionStats.last_write_time().seconds()))
-    , MaxWriteTimeLag_(TDuration::Seconds(partitionStats.max_write_time_lag().seconds()) + TDuration::MicroSeconds(partitionStats.max_write_time_lag().nanos() / 1000))
+    , MaxWriteTimeLag_(ConvertPositiveDuration(partitionStats.max_write_time_lag()))
     , BytesWrittenPerMinute_(partitionStats.bytes_written().per_minute())
     , BytesWrittenPerHour_(partitionStats.bytes_written().per_hour())
     , BytesWrittenPerDay_(partitionStats.bytes_written().per_day())
@@ -620,6 +629,7 @@ template <typename TSettings>
 TConsumerSettings<TSettings>::TConsumerSettings(TSettings& parent, const Ydb::Topic::Consumer& proto)
     : ConsumerName_(proto.name())
     , Important_(proto.important())
+    , AvailabilityPeriod_(ConvertPositiveDuration(proto.availability_period()))
     , ReadFrom_(TInstant::Seconds(proto.read_from().seconds()))
     , SupportedCodecs_(DeserializeCodecs(proto.supported_codecs()))
     , Attributes_(DeserializeAttributes(proto.attributes()))
@@ -631,6 +641,12 @@ template <typename TSettings>
 void TConsumerSettings<TSettings>::SerializeTo(Ydb::Topic::Consumer& proto) const {
     proto.set_name(ConsumerName_);
     proto.set_important(Important_);
+    if (AvailabilityPeriod_ != TDuration::Zero()) {
+        proto.mutable_availability_period()->set_seconds(AvailabilityPeriod_.Seconds());
+        proto.mutable_availability_period()->set_nanos((AvailabilityPeriod_.MicroSeconds() % 1'000'000) * 1'000);
+    } else {
+        proto.clear_availability_period();
+    }
     proto.mutable_read_from()->set_seconds(ReadFrom_.Seconds());
     *proto.mutable_supported_codecs() = SerializeCodecs(SupportedCodecs_);
     *proto.mutable_attributes() = SerializeAttributes(Attributes_);

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.h
@@ -46,6 +46,14 @@ public:
         consumerProto.set_name(TStringType{settings.ConsumerName_});
         if (settings.SetImportant_)
             consumerProto.set_set_important(*settings.SetImportant_);
+        if (settings.SetAvailabilityPeriod_) {
+            if (settings.SetAvailabilityPeriod_ != TDuration::Zero()) {
+                consumerProto.mutable_set_availability_period()->set_seconds(settings.SetAvailabilityPeriod_->Seconds());
+                consumerProto.mutable_set_availability_period()->set_nanos((settings.SetAvailabilityPeriod_->MicroSeconds() % 1'000'000) * 1'000);
+            } else {
+                consumerProto.mutable_reset_availability_period();
+            }
+        }
         if (settings.SetReadFrom_)
             consumerProto.mutable_set_read_from()->set_seconds(settings.SetReadFrom_->Seconds());
 

--- a/ydb/services/lib/actors/pq_schema_actor.cpp
+++ b/ydb/services/lib/actors/pq_schema_actor.cpp
@@ -4,6 +4,7 @@
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 #include <ydb/core/base/feature_flags.h>
 #include <ydb/core/persqueue/public/constants.h>
+#include <ydb/core/util/proto_duration.h>
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/jwt/jwt.h>
 
@@ -14,6 +15,8 @@
 #include <util/string/vector.h>
 
 #include <library/cpp/digest/md5/md5.h>
+
+#include <expected>
 
 
 namespace NKikimr::NGRpcProxy::V1 {
@@ -56,6 +59,35 @@ namespace NKikimr::NGRpcProxy::V1 {
         }
         return serviceTypes;
     }
+
+    static std::expected<TDuration, TString> ConvertPositiveDuration(const google::protobuf::Duration& duration) {
+        if (duration.seconds() < 0) {
+            return std::unexpected(TStringBuilder() << "duration seconds cannot be negative, provided " << duration.seconds());
+        }
+        return NKikimr::GetDuration(duration);
+    }
+
+    static std::expected<TMaybe<TDuration>, TMsgPqCodes> ConvertConsumerAvailabilityPeriod(const google::protobuf::Duration& duration, bool important, std::string_view consumerName) {
+        if (auto val = ConvertPositiveDuration(duration); val.has_value()) {
+            if (val.value() == TDuration::Zero()) {
+                return Nothing();
+            } else {
+                if (val.value() != TDuration::Max() && important) {
+                    return std::unexpected(TMsgPqCodes(
+                        TStringBuilder() << "Consumer '" << consumerName << "' has important flag and limited availability_period",
+                        Ydb::PersQueue::ErrorCode::INVALID_ARGUMENT
+                    ));
+                }
+                return val.value();
+            }
+        } else {
+            return std::unexpected(TMsgPqCodes(
+                TStringBuilder() << "Invalid availability_period for consumer '" << consumerName << "': " << val.error(),
+                Ydb::PersQueue::ErrorCode::INVALID_ARGUMENT
+            ));
+        }
+    }
+
 
     TMsgPqCodes AddReadRuleToConfig(
         NKikimrPQ::TPQTabletConfig* config,
@@ -130,6 +162,15 @@ namespace NKikimr::NGRpcProxy::V1 {
         if (rr.important()) {
             consumer->SetImportant(true);
         }
+        if (auto period = ConvertConsumerAvailabilityPeriod(rr.availability_period(), rr.important(), rr.consumer_name()); period.has_value()) {
+            if (period.value().Defined()) {
+                consumer->SetAvailabilityPeriodMs(period.value()->MilliSeconds());
+            } else {
+                consumer->ClearAvailabilityPeriodMs();
+            }
+        } else {
+            return period.error();
+        }
 
         if (!rr.service_type().empty()) {
             if (!supportedClientServiceTypes.contains(rr.service_type())) {
@@ -153,7 +194,6 @@ namespace NKikimr::NGRpcProxy::V1 {
         return TMsgPqCodes("", Ydb::PersQueue::ErrorCode::OK);
     }
 
-
     void ProcessAlterConsumer(Ydb::Topic::Consumer& consumer, const Ydb::Topic::AlterConsumer& alter) {
         if (alter.has_set_important()) {
             consumer.set_important(alter.set_important());
@@ -166,6 +206,12 @@ namespace NKikimr::NGRpcProxy::V1 {
         }
         for (auto& pair : alter.alter_attributes()) {
             (*consumer.mutable_attributes())[pair.first] = pair.second;
+        }
+        if (alter.has_set_availability_period()) {
+            consumer.mutable_availability_period()->CopyFrom(alter.set_availability_period());
+        }
+        if (alter.has_reset_availability_period()) {
+            consumer.clear_availability_period();
         }
     }
 
@@ -276,6 +322,15 @@ namespace NKikimr::NGRpcProxy::V1 {
                 return TMsgPqCodes(TStringBuilder() << "important flag is forbiden for consumer " << rr.name(), Ydb::PersQueue::ErrorCode::INVALID_ARGUMENT);
             }
             consumer->SetImportant(true);
+        }
+        if (auto period = ConvertConsumerAvailabilityPeriod(rr.availability_period(), rr.important(), rr.name()); period.has_value()) {
+            if (period.value().Defined()) {
+                consumer->SetAvailabilityPeriodMs(period.value()->MilliSeconds());
+            } else {
+                consumer->ClearAvailabilityPeriodMs();
+            }
+        } else {
+            return period.error();
         }
 
         return TMsgPqCodes("", Ydb::PersQueue::ErrorCode::OK);
@@ -1298,6 +1353,10 @@ namespace NKikimr::NGRpcProxy::V1 {
             (*consumer.mutable_attributes())["_version"] = TStringBuilder() << c.GetVersion();
             for (ui32 codec : c.GetCodec().GetIds()) {
                 consumer.mutable_supported_codecs()->add_codecs(codec + 1);
+            }
+            if (ui64 ms = c.GetAvailabilityPeriodMs()) {
+                consumer.mutable_availability_period()->set_seconds(ms / 1000);
+                consumer.mutable_availability_period()->set_nanos((ms % 1000) * 1'000'000);
             }
         }
 

--- a/ydb/services/lib/actors/ya.make
+++ b/ydb/services/lib/actors/ya.make
@@ -12,6 +12,7 @@ PEERDIR(
     ydb/core/metering
     ydb/core/mind
     ydb/core/protos
+    ydb/core/util
     ydb/public/sdk/cpp/src/library/persqueue/obfuscate
     ydb/library/persqueue/topic_parser
     ydb/public/api/grpc

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -8207,5 +8207,164 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             UNIT_ASSERT_VALUES_EQUAL((ui64)group->GetNamedCounter("bin", "20480")->Val(), 1);
         }
     }
+
+    void TestConsumerAvailabilityPeriod(bool setAvailabilityPeriod) {
+        TPersQueueV1TestServer server;
+        SET_LOCALS;
+        MAKE_INSECURE_STUB(Ydb::Topic::V1::TopicService);
+        server.EnablePQLogs({ NKikimrServices::PQ_METACACHE, NKikimrServices::PQ_READ_PROXY });
+        server.EnablePQLogs({ NKikimrServices::KQP_PROXY }, NLog::EPriority::PRI_EMERG);
+        server.EnablePQLogs({ NKikimrServices::FLAT_TX_SCHEMESHARD }, NLog::EPriority::PRI_ERROR);
+        server.EnablePQLogs({ NKikimrServices::PERSQUEUE }, NLog::EPriority::PRI_DEBUG);
+
+        auto TopicStubP_ = Ydb::Topic::V1::TopicService::NewStub(Channel_);
+
+        {
+            Ydb::Topic::CreateTopicRequest request;
+            Ydb::Topic::CreateTopicResponse response;
+            request.set_path(TStringBuilder() << "/Root/PQ/rt3.dc1--acc--topic2");
+
+            request.set_retention_storage_mb(1);
+
+            request.mutable_supported_codecs()->add_codecs(Ydb::Topic::CODEC_RAW);
+            request.mutable_supported_codecs()->add_codecs(Ydb::Topic::CODEC_GZIP);
+
+            grpc::ClientContext rcontext;
+
+            auto status = TopicStubP_->CreateTopic(&rcontext, request, &response);
+
+            UNIT_ASSERT(status.ok());
+            Ydb::Topic::CreateTopicResult res;
+            response.operation().result().UnpackTo(&res);
+            Cerr << response << "\n" << res << "\n";
+            UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), Ydb::StatusIds::SUCCESS);
+
+            server.Server->AnnoyingClient->WaitTopicInit("acc/topic2");
+            server.Server->AnnoyingClient->AddTopic("acc/topic2");
+        }
+
+        {
+            using namespace NYdb::NTopic;
+            auto settings = TDescribeTopicSettings().IncludeStats(true);
+            auto client = TTopicClient(server.Server->GetDriver());
+            auto desc = client.DescribeTopic("/Root/PQ/rt3.dc1--acc--topic2", settings)
+                            .ExtractValueSync()
+                            .GetTopicDescription();
+            Cerr << ">>>Describe result: partitions count is " << desc.GetTotalPartitionsCount() << Endl;
+            for (const auto& partInfo: desc.GetPartitions()) {
+                Cerr << ">>>Describe result: partition id = " << partInfo.GetPartitionId() << ", ";
+                auto stats = partInfo.GetPartitionStats();
+                UNIT_ASSERT(stats.has_value());
+                Cerr << "offsets: [ " << stats.value().GetStartOffset() << ", " << stats.value().GetEndOffset() << " )" << Endl;
+            }
+
+            TAlterTopicSettings alterSettings;
+
+            alterSettings
+                .BeginAddConsumer("first-consumer")
+                .EndAddConsumer();
+            if (setAvailabilityPeriod) {
+                alterSettings.BeginAddConsumer("second-consumer").AvailabilityPeriod(TDuration::Hours(2)).EndAddConsumer();
+            } else {
+                alterSettings.BeginAddConsumer("second-consumer").EndAddConsumer();
+            }
+            auto res = client.AlterTopic("/Root/PQ/rt3.dc1--acc--topic2", alterSettings);
+            res.Wait();
+            Cerr << res.GetValue().IsSuccess() << " " << res.GetValue().GetIssues().ToString() << "\n";
+            UNIT_ASSERT(res.GetValue().IsSuccess());
+        }
+
+        const int nMsg = 40;
+        auto driver = pqClient->GetDriver();
+        {
+            auto writer = CreateSimpleWriter(*driver, "acc/topic2", "source", /*partitionGroup=*/{}, /*codec=*/{"raw"});
+            TString blob{1_MB, 'x'};
+            for (int i = 1; i <= nMsg; ++i) {
+                bool res = writer->Write(blob + ToString(i), i);
+                UNIT_ASSERT(res);
+            }
+
+            bool res = writer->Close(TDuration::Seconds(10));
+            UNIT_ASSERT(res);
+        }
+        {
+            using namespace NYdb::NTopic;
+            auto settings = TDescribeTopicSettings().IncludeStats(true);
+            auto client = TTopicClient(server.Server->GetDriver());
+            auto desc = client.DescribeTopic("/Root/PQ/rt3.dc1--acc--topic2", settings)
+                            .ExtractValueSync()
+                            .GetTopicDescription();
+
+            UNIT_ASSERT_VALUES_EQUAL(desc.GetConsumers().size(), 2);
+            for (const auto& consumer: desc.GetConsumers()) {
+                TDuration expected = (consumer.GetConsumerName().ends_with("second-consumer") && setAvailabilityPeriod) ? TDuration::Hours(2) : TDuration::Zero();
+                UNIT_ASSERT_VALUES_EQUAL_C(consumer.GetAvailabilityPeriod().MicroSeconds(), expected.MicroSeconds(), LabeledOutput(consumer.GetConsumerName(), setAvailabilityPeriod));
+            }
+
+            Cerr << ">>>Describe result: partitions count is " << desc.GetTotalPartitionsCount() << Endl;
+            for (const auto& partInfo: desc.GetPartitions()) {
+                Cerr << ">>>Describe result: partition id = " << partInfo.GetPartitionId() << ", ";
+                auto stats = partInfo.GetPartitionStats();
+                UNIT_ASSERT(stats.has_value());
+                Cerr << "offsets: [ " << stats.value().GetStartOffset() << ", " << stats.value().GetEndOffset() << " )" << Endl;
+
+                if (setAvailabilityPeriod) {
+                    UNIT_ASSERT_VALUES_EQUAL(stats.value().GetStartOffset(), 0);
+                    UNIT_ASSERT_VALUES_EQUAL(stats.value().GetEndOffset(), nMsg);
+                } else {
+                    UNIT_ASSERT_GT(stats.value().GetStartOffset(),  0);
+                    UNIT_ASSERT_VALUES_EQUAL(stats.value().GetEndOffset(), nMsg);
+                }
+            }
+        }
+        {
+            using namespace NYdb::NTopic;
+            auto settings = TDescribeTopicSettings().IncludeStats(true);
+            auto client = TTopicClient(server.Server->GetDriver());
+            TAlterTopicSettings alterSettings;
+
+            alterSettings
+                .BeginAlterConsumer().ConsumerName("first-consumer").SetAvailabilityPeriod(TDuration::Hours(20)).EndAlterConsumer()
+                .BeginAlterConsumer().ConsumerName("second-consumer").SetAvailabilityPeriod(TDuration::Zero()).EndAlterConsumer();
+
+            auto res = client.AlterTopic("/Root/PQ/rt3.dc1--acc--topic2", alterSettings);
+            res.Wait();
+            Cerr << res.GetValue().IsSuccess() << " " << res.GetValue().GetIssues().ToString() << "\n";
+            UNIT_ASSERT(res.GetValue().IsSuccess());
+        }
+        {
+            using namespace NYdb::NTopic;
+            auto settings = TDescribeTopicSettings().IncludeStats(true);
+            auto client = TTopicClient(server.Server->GetDriver());
+            auto desc = client.DescribeTopic("/Root/PQ/rt3.dc1--acc--topic2", settings)
+                            .ExtractValueSync()
+                            .GetTopicDescription();
+
+            UNIT_ASSERT_VALUES_EQUAL(desc.GetConsumers().size(), 2);
+            for (const auto& consumer: desc.GetConsumers()) {
+                TDuration expected = consumer.GetConsumerName().ends_with("first-consumer") ? TDuration::Hours(20) : TDuration::Zero();
+                UNIT_ASSERT_VALUES_EQUAL_C(consumer.GetAvailabilityPeriod().MicroSeconds(), expected.MicroSeconds(), LabeledOutput(consumer.GetConsumerName(), setAvailabilityPeriod));
+            }
+        }
+        {
+            using namespace NYdb::NTopic;
+            auto settings = TDescribeTopicSettings().IncludeStats(true);
+            auto client = TTopicClient(server.Server->GetDriver());
+            TAlterTopicSettings alterSettings;
+
+            alterSettings
+                .BeginAlterConsumer().ConsumerName("first-consumer").SetAvailabilityPeriod(TDuration::Hours(20)).SetImportant(true).EndAlterConsumer();
+
+            auto res = client.AlterTopic("/Root/PQ/rt3.dc1--acc--topic2", alterSettings);
+            res.Wait();
+            Cerr << res.GetValue().IsSuccess() << " " << res.GetValue().GetIssues().ToString() << "\n";
+            UNIT_ASSERT(!res.GetValue().IsSuccess());
+        }
+    }
+
+    Y_UNIT_TEST(ConsumerAvailabilityPeriod) {
+        TestConsumerAvailabilityPeriod(true);
+        TestConsumerAvailabilityPeriod(false);
+    }
 }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Introduce the `availability_period` option to extend the period for which unprocessed messages can be retained in the topic.


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

KIKIMR-24054
