### PR TITLE
Revert parallel union all scheduling changes due to regression on low cardinality keys

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1635,6 +1635,7 @@ protected:
         ui32 inputTasks = 0;
         bool isShuffle = false;
         bool forceMapTasks = false;
+        bool isParallelUnionAll = false;
         ui32 mapCnt = 0;
 
 
@@ -1683,7 +1684,8 @@ protected:
                     break;
                 }
                 case NKqpProto::TKqpPhyConnection::kParallelUnionAll: {
-                    partitionsCount = std::max<ui64>(partitionsCount, originStageInfo.Tasks.size());
+                    inputTasks += originStageInfo.Tasks.size();
+                    isParallelUnionAll = true;
                     break;
                 }
                 case NKqpProto::TKqpPhyConnection::kVectorResolve: {
@@ -1700,7 +1702,7 @@ protected:
 
         Y_ENSURE(mapCnt < 2, "There can be only < 2 'Map' connections");
 
-        if (isShuffle && !forceMapTasks) {
+        if ((isShuffle || isParallelUnionAll) && !forceMapTasks) {
             if (stage.GetTaskCount()) {
                 partitionsCount = stage.GetTaskCount();
                 intros.push_back("Manually overridden - " + ToString(partitionsCount));


### PR DESCRIPTION
Revert some changes from #23010 until #24757 is implemented