### PR TITLE
25-2: DataShard: don't leave processed checkpoints in the buffer

### DIFF
--- a/ydb/core/tx/datashard/memory_state_migration.cpp
+++ b/ydb/core/tx/datashard/memory_state_migration.cpp
@@ -91,6 +91,9 @@ private:
             Buffer.Insert(Buffer.End(), std::move(payload));
         }
 
+        // We must not have any checkpoints in the buffer yet
+        Y_ENSURE(Checkpoints.empty());
+
         size_t lastOffset = 0;
         for (size_t offset : msg->Record.GetSerializedStateCheckpoints()) {
             // These offsets are relative to the start of the new chunk, we make
@@ -207,6 +210,8 @@ private:
 
             Arena.Reset();
         }
+
+        Checkpoints.clear();
 
         if (msg->Record.HasContinuationToken()) {
             // Request the next data chunk


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Don't leave processed checkpoints in the buffer. Fixes #24779.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

