### PR TITLE
ydb_cli: add an option to specify the memory usage limit for the topic workload scenarios, and lower the default read buffer size because it discards all incomming data anyway

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -249,7 +249,8 @@ void TTopicOperationsScenario::StartConsumerThreads(std::vector<std::future<void
                 .ReadWithoutCommit = ReadWithoutCommit,
                 .ReadWithoutConsumer = ReadWithoutConsumer,
                 .CommitPeriodMs = TxCommitIntervalMs != 0 ? TxCommitIntervalMs : CommitPeriodSeconds * 1000, // seconds to ms conversion,
-                .CommitMessages = CommitMessages
+                .CommitMessages = CommitMessages,
+                .MaxMemoryUsageBytes = ConsumerMaxMemoryUsageBytes,
             };
 
             threads.push_back(std::async([readerParams = std::move(readerParams)]() { TTopicWorkloadReader::RetryableReaderLoop(readerParams); }));
@@ -303,6 +304,7 @@ void TTopicOperationsScenario::StartProducerThreads(std::vector<std::future<void
             .KeyPrefix = KeyPrefix,
             .KeyCount = KeyCount,
             .KeySeed = writerIdx,
+            .MaxMemoryUsageBytes = ProducerMaxMemoryUsageBytes,
         };
 
         threads.push_back(std::async([writerParams = std::move(writerParams)]() { TTopicWorkloadWriterWorker::RetryableWriterLoop(writerParams); }));

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -86,8 +86,8 @@ public:
     TMaybe<TString> KeyPrefix;
     ui32 KeyCount = 0;
     bool CleanupPolicyCompact = false;
-    size_t ConsumerMaxMemoryUsageBytes = 15'000'000;
-    size_t ProducerMaxMemoryUsageBytes = 15'000'000;
+    size_t ConsumerMaxMemoryUsageBytes = 100'000'000;
+    size_t ProducerMaxMemoryUsageBytes = 20'000'000;
 
 protected:
     void CreateTopic(const TString& database,

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -86,8 +86,8 @@ public:
     TMaybe<TString> KeyPrefix;
     ui32 KeyCount = 0;
     bool CleanupPolicyCompact = false;
-    size_t ConsumerMaxMemoryUsageBytes = 100'000'000;
-    size_t ProducerMaxMemoryUsageBytes = 20'000'000;
+    std::optional<size_t> ConsumerMaxMemoryUsageBytes;
+    std::optional<size_t> ProducerMaxMemoryUsageBytes;
 
 protected:
     void CreateTopic(const TString& database,

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -86,6 +86,8 @@ public:
     TMaybe<TString> KeyPrefix;
     ui32 KeyCount = 0;
     bool CleanupPolicyCompact = false;
+    size_t ConsumerMaxMemoryUsageBytes = 15'000'000;
+    size_t ProducerMaxMemoryUsageBytes = 15'000'000;
 
 protected:
     void CreateTopic(const TString& database,

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
@@ -28,7 +28,9 @@ void TTopicWorkloadReader::ReaderLoop(const TTopicWorkloadReaderParams& params, 
     auto describeTopicResult = TCommandWorkloadTopicDescribe::DescribeTopic(params.Database, params.TopicName, params.Driver);
     NYdb::NTopic::TReadSessionSettings settings;
     settings.AutoPartitioningSupport(true);
-    settings.MaxMemoryUsageBytes(params.MaxMemoryUsageBytes);
+    if (params.MaxMemoryUsageBytes.has_value()) {
+        settings.MaxMemoryUsageBytes(params.MaxMemoryUsageBytes.value());
+    }
     //settings.MaxLag(TDuration::Seconds(30));
 
     if (!params.ReadWithoutConsumer) {

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
@@ -28,6 +28,7 @@ void TTopicWorkloadReader::ReaderLoop(const TTopicWorkloadReaderParams& params, 
     auto describeTopicResult = TCommandWorkloadTopicDescribe::DescribeTopic(params.Database, params.TopicName, params.Driver);
     NYdb::NTopic::TReadSessionSettings settings;
     settings.AutoPartitioningSupport(true);
+    settings.MaxMemoryUsageBytes(params.MaxMemoryUsageBytes);
     //settings.MaxLag(TDuration::Seconds(30));
 
     if (!params.ReadWithoutConsumer) {

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h
@@ -35,6 +35,7 @@ namespace NYdb {
             bool ReadWithoutConsumer = false;
             size_t CommitPeriodMs = 15'000;
             size_t CommitMessages = 1'000'000;
+            size_t MaxMemoryUsageBytes = 15_MB;
         };
 
         class TTransactionSupport;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h
@@ -35,7 +35,7 @@ namespace NYdb {
             bool ReadWithoutConsumer = false;
             size_t CommitPeriodMs = 15'000;
             size_t CommitMessages = 1'000'000;
-            size_t MaxMemoryUsageBytes = 15_MB;
+            std::optional<size_t> MaxMemoryUsageBytes = 15_MB;
         };
 
         class TTransactionSupport;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -3,7 +3,8 @@
 #include "topic_workload_params.h"
 
 #include <ydb/public/lib/ydb_cli/commands/ydb_service_topic.h>
-#include <library/cpp/string_utils/parse_size/parse_size.h>
+#include <ydb/library/backup/util.h>
+#include <util/stream/format.h>
 
 using namespace NYdb::NConsoleClient;
 
@@ -114,12 +115,12 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
         .DefaultValue(false)
         .Hidden()
         .StoreTrue(&Scenario.UseTableSelect);
-    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes. Should be more than '1M'.")
-        .DefaultValue(15_MB)
-        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NSize::ParseSize);
+    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes. Should be more than '1MiB'.")
+        .DefaultValue(HumanReadableSize(15_MB, SF_BYTES))
+        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NYdb::SizeFromString);
     config.Opts->AddLongOption("max-memory-usage-per-producer", "Max memory usage per producer in bytes.")
-        .DefaultValue(15_MB)
-        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NSize::ParseSize);
+        .DefaultValue(HumanReadableSize(15_MB, SF_BYTES))
+        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NYdb::SizeFromString);
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -3,6 +3,7 @@
 #include "topic_workload_params.h"
 
 #include <ydb/public/lib/ydb_cli/commands/ydb_service_topic.h>
+#include <library/cpp/string_utils/parse_size/parse_size.h>
 
 using namespace NYdb::NConsoleClient;
 
@@ -113,7 +114,14 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
         .DefaultValue(false)
         .Hidden()
         .StoreTrue(&Scenario.UseTableSelect);
-
+    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes.")
+        .DefaultValue(Scenario.ConsumerMaxMemoryUsageBytes)
+        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NSize::ParseSize)
+        .Hidden();
+    config.Opts->AddLongOption("max-memory-usage-per-producer", "Max memory usage per producer in bytes.")
+        .DefaultValue(Scenario.ProducerMaxMemoryUsageBytes)
+        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NSize::ParseSize)
+        .Hidden();
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -114,14 +114,12 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
         .DefaultValue(false)
         .Hidden()
         .StoreTrue(&Scenario.UseTableSelect);
-    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes.")
-        .DefaultValue(Scenario.ConsumerMaxMemoryUsageBytes)
-        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NSize::ParseSize)
-        .Hidden();
+    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes. Should be more than '1M'.")
+        .DefaultValue(15_MB)
+        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NSize::ParseSize);
     config.Opts->AddLongOption("max-memory-usage-per-producer", "Max memory usage per producer in bytes.")
-        .DefaultValue(Scenario.ProducerMaxMemoryUsageBytes)
-        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NSize::ParseSize)
-        .Hidden();
+        .DefaultValue(15_MB)
+        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NSize::ParseSize);
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
@@ -58,7 +58,7 @@ void TCommandWorkloadTopicRunRead::Config(TConfig& config)
     config.Opts->AddLongOption('t', "threads", "Number of consumer threads.")
         .DefaultValue(1)
         .StoreResult(&Scenario.ConsumerThreadCount);
-    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes. Should be more than '1M'.")
+    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes. Should be more than '1MiB'.")
         .DefaultValue(HumanReadableSize(15_MB, SF_BYTES))
         .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NYdb::SizeFromString);
     config.IsNetworkIntensive = true;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
@@ -56,10 +56,9 @@ void TCommandWorkloadTopicRunRead::Config(TConfig& config)
     config.Opts->AddLongOption('t', "threads", "Number of consumer threads.")
         .DefaultValue(1)
         .StoreResult(&Scenario.ConsumerThreadCount);
-    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes.")
-        .DefaultValue(Scenario.ConsumerMaxMemoryUsageBytes)
-        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NSize::ParseSize)
-        .Hidden();
+    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes. Should be more than '1M'.")
+        .DefaultValue(15_MB)
+        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NSize::ParseSize);
 
     config.IsNetworkIntensive = true;
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
@@ -1,6 +1,8 @@
 #include "topic_workload_run_read.h"
 #include "topic_workload_defines.h"
 
+#include <library/cpp/string_utils/parse_size/parse_size.h>
+
 using namespace NYdb::NConsoleClient;
 
 TCommandWorkloadTopicRunRead::TCommandWorkloadTopicRunRead()
@@ -54,6 +56,10 @@ void TCommandWorkloadTopicRunRead::Config(TConfig& config)
     config.Opts->AddLongOption('t', "threads", "Number of consumer threads.")
         .DefaultValue(1)
         .StoreResult(&Scenario.ConsumerThreadCount);
+    config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes.")
+        .DefaultValue(Scenario.ConsumerMaxMemoryUsageBytes)
+        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NSize::ParseSize)
+        .Hidden();
 
     config.IsNetworkIntensive = true;
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
@@ -1,7 +1,9 @@
 #include "topic_workload_run_read.h"
 #include "topic_workload_defines.h"
 
-#include <library/cpp/string_utils/parse_size/parse_size.h>
+#include <ydb/library/backup/util.h>
+#include <util/stream/format.h>
+
 
 using namespace NYdb::NConsoleClient;
 
@@ -57,9 +59,8 @@ void TCommandWorkloadTopicRunRead::Config(TConfig& config)
         .DefaultValue(1)
         .StoreResult(&Scenario.ConsumerThreadCount);
     config.Opts->AddLongOption("max-memory-usage-per-consumer", "Max memory usage per consumer in bytes. Should be more than '1M'.")
-        .DefaultValue(15_MB)
-        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NSize::ParseSize);
-
+        .DefaultValue(HumanReadableSize(15_MB, SF_BYTES))
+        .StoreMappedResult(&Scenario.ConsumerMaxMemoryUsageBytes, NYdb::SizeFromString);
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -106,9 +106,8 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .DefaultValue(1'000'000)
         .StoreResult(&Scenario.CommitMessages);
     config.Opts->AddLongOption("max-memory-usage-per-producer", "Max memory usage per producer in bytes.")
-        .DefaultValue(Scenario.ProducerMaxMemoryUsageBytes)
-        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NSize::ParseSize)
-        .Hidden();
+        .DefaultValue(15_MB)
+        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NSize::ParseSize);
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -3,7 +3,8 @@
 #include "topic_workload_params.h"
 
 #include <ydb/public/lib/ydb_cli/commands/ydb_service_topic.h>
-#include <library/cpp/string_utils/parse_size/parse_size.h>
+#include <ydb/library/backup/util.h>
+#include <util/stream/format.h>
 
 using namespace NYdb::NConsoleClient;
 
@@ -106,8 +107,8 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .DefaultValue(1'000'000)
         .StoreResult(&Scenario.CommitMessages);
     config.Opts->AddLongOption("max-memory-usage-per-producer", "Max memory usage per producer in bytes.")
-        .DefaultValue(15_MB)
-        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NSize::ParseSize);
+        .DefaultValue(HumanReadableSize(15_MB, SF_BYTES))
+        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NYdb::SizeFromString);
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -3,6 +3,7 @@
 #include "topic_workload_params.h"
 
 #include <ydb/public/lib/ydb_cli/commands/ydb_service_topic.h>
+#include <library/cpp/string_utils/parse_size/parse_size.h>
 
 using namespace NYdb::NConsoleClient;
 
@@ -104,7 +105,10 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
                                                             " Both tx-commit-messages and tx-commit-interval can trigger transaction commit.")
         .DefaultValue(1'000'000)
         .StoreResult(&Scenario.CommitMessages);
-
+    config.Opts->AddLongOption("max-memory-usage-per-producer", "Max memory usage per producer in bytes.")
+        .DefaultValue(Scenario.ProducerMaxMemoryUsageBytes)
+        .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NSize::ParseSize)
+        .Hidden();
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -173,7 +173,9 @@ std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::Create
     settings.Codec((NYdb::NTopic::ECodec) Params.Codec);
     settings.Path(Params.TopicName);
     settings.ProducerId(producerId);
-    settings.MaxMemoryUsage(Params.MaxMemoryUsageBytes);
+    if (Params.MaxMemoryUsageBytes.has_value()) {
+        settings.MaxMemoryUsage(Params.MaxMemoryUsageBytes.value());
+    }
 
     NYdb::NTopic::TWriteSessionSettings::TEventHandlers eventHandlers;
     eventHandlers.AcksHandler(

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -173,6 +173,7 @@ std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::Create
     settings.Codec((NYdb::NTopic::ECodec) Params.Codec);
     settings.Path(Params.TopicName);
     settings.ProducerId(producerId);
+    settings.MaxMemoryUsage(Params.MaxMemoryUsageBytes);
 
     NYdb::NTopic::TWriteSessionSettings::TEventHandlers eventHandlers;
     eventHandlers.AcksHandler(

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -41,7 +41,7 @@ namespace NYdb {
             TMaybe<TString> KeyPrefix;
             ui32 KeyCount = 0;
             ui32 KeySeed = 0;
-            size_t MaxMemoryUsageBytes = 15_MB;
+            std::optional<size_t> MaxMemoryUsageBytes = 15_MB;
         };
 
         class TTopicWorkloadWriterProducer;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -41,6 +41,7 @@ namespace NYdb {
             TMaybe<TString> KeyPrefix;
             ui32 KeyCount = 0;
             ui32 KeySeed = 0;
+            size_t MaxMemoryUsageBytes = 15_MB;
         };
 
         class TTopicWorkloadWriterProducer;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
@@ -32,6 +32,7 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/types/operation
     ydb/public/sdk/cpp/src/client/types/status
     library/cpp/containers/concurrent_hash
+    library/cpp/string_utils/parse_size
     library/cpp/unified_agent_client
     library/cpp/histogram/hdr
 )

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
@@ -35,6 +35,7 @@ PEERDIR(
     library/cpp/string_utils/parse_size
     library/cpp/unified_agent_client
     library/cpp/histogram/hdr
+    ydb/library/backup
 )
 
 END()

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
@@ -20,6 +20,7 @@ SRCS(
 PEERDIR(
     yql/essentials/public/issue
     yql/essentials/public/issue/protos
+    ydb/library/backup
     ydb/public/api/grpc
     ydb/public/api/protos
     ydb/public/api/protos/annotations
@@ -32,10 +33,8 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/types/operation
     ydb/public/sdk/cpp/src/client/types/status
     library/cpp/containers/concurrent_hash
-    library/cpp/string_utils/parse_size
     library/cpp/unified_agent_client
     library/cpp/histogram/hdr
-    ydb/library/backup
 )
 
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

[LOGBROKER-9919](https://st.yandex-team.ru/LOGBROKER-9919)
