### PR TITLE
Fixed SchemeCache navigate to other ExtSubdomain (#24747)

### DIFF
--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -270,14 +270,31 @@ namespace {
     public:
         explicit TAccessChecker(TContextPtr context)
             : Context(context)
+            , RootSchemeShard(AppData()->DomainsInfo->GetDomain()->SchemeRoot, 1)
         {
             Y_ABORT_UNLESS(!Context->WaitCounter);
         }
 
         void Bootstrap(const TActorContext&) {
             for (auto& entry : Context->Request->ResultSet) {
-                if (!IsDomain(entry) && Context->ResolvedDomainInfo && entry.DomainInfo) {
-                    // ^ It is allowed to describe subdomains by specifying root as DatabaseName
+                // Lookup path policy for DatabaseName and Path provided by SchemeCache request
+                //
+                // DatabaseName         | Path                              | Allowed
+                // ------------------------------------------------------------------
+                // Domain root path     | Domain root path                  | True
+                // Domain root path     | Regular path within domain        | True
+                // Domain root path     | Subdomain root path               | True
+                // Domain root path     | Regular path within subdomain1    | False
+                // Subdomain1 root path | Domain root path                  | False
+                // Subdomain1 root path | Regular path within domain        | False
+                // Subdomain1 root path | Subdomain1 root path              | True
+                // Subdomain1 root path | Regular path within subdomain1    | True
+                // Subdomain1 root path | Subdomain2 root path              | False
+                // Subdomain1 root path | Regular path within subdomain2    | False
+
+                if (Context->ResolvedDomainInfo && entry.DomainInfo
+                    && !(Context->ResolvedDomainInfo->DomainKey == RootSchemeShard && IsDomain(entry))
+                ) {
 
                     if (Context->ResolvedDomainInfo->DomainKey != entry.DomainInfo->DomainKey) {
                         SBC_LOG_W("Path does not belong to the specified domain"
@@ -315,6 +332,7 @@ namespace {
 
     private:
         TContextPtr Context;
+        const TPathId RootSchemeShard;
 
     }; // TAccessChecker
 

--- a/ydb/core/tx/scheme_board/cache_ut.cpp
+++ b/ydb/core/tx/scheme_board/cache_ut.cpp
@@ -956,43 +956,205 @@ void TCacheTest::WatchRoot() {
 
 void TCacheTest::PathBelongsToDomain() {
     ui64 txId = 100;
-    TestCreateSubDomain(*Context, ++txId, "/Root", "Name: \"SubDomain\"");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
-    TestMkDir(*Context, ++txId, "/Root/SubDomain", "DirA");
+    const auto rootSubscriber = CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard);
 
-    TTableId testId;
+    TestMkDir(*Context, ++txId, "/Root", "DirA");
+    TestWaitNotification(*Context, {txId}, rootSubscriber);
 
-    // ok
+    TestCreateSubDomain(*Context, ++txId, "/Root", "Name: \"SubDomain1\"");
+    TestMkDir(*Context, ++txId, "/Root/SubDomain1", "DirA");
+    TestWaitNotification(*Context, {txId - 1, txId}, rootSubscriber);
+
+    TestCreateSubDomain(*Context, ++txId, "/Root", "Name: \"SubDomain2\"");
+    TestMkDir(*Context, ++txId, "/Root/SubDomain2", "DirA");
+    TestWaitNotification(*Context, {txId - 1, txId}, rootSubscriber);
+
+    TTableId domain;
+    TTableId dirInDomain;
+    TTableId subDomain1;
+    TTableId dirInSubDomain1;
+    TTableId subDomain2;
+    TTableId dirInSubDomain2;
+
     {
-        auto request = MakeHolder<TNavigate>();
-        request->DatabaseName = "/Root/SubDomain";
-        auto& entry = request->ResultSet.emplace_back();
-        entry.Path = SplitPath("/Root/SubDomain/DirA");
-        entry.RequestType = TNavigate::TEntry::ERequestType::ByPath;
-        auto result  = TestNavigateImpl(std::move(request), TNavigate::EStatus::Ok,
-            "", TNavigate::EOp::OpPath, false, true);
-
-        testId = result.TableId;
+        const auto dirEntry = DescribePath(*Context, "/Root/SubDomain2").GetPathDescription().GetSelf();
+        subDomain2 = TTableId(dirEntry.GetSchemeshardId(), dirEntry.GetPathId());
     }
-    // error, by path
+
     {
-        auto request = MakeHolder<TNavigate>();
-        request->DatabaseName = "/Root";
-        auto& entry = request->ResultSet.emplace_back();
-        entry.Path = SplitPath("/Root/SubDomain/DirA");
-        entry.RequestType = TNavigate::TEntry::ERequestType::ByPath;
-        auto result  = TestNavigateImpl(std::move(request), TNavigate::EStatus::PathErrorUnknown,
-            "", TNavigate::EOp::OpPath, false, true);
+        const auto dirEntry = DescribePath(*Context, "/Root/SubDomain2/DirA").GetPathDescription().GetSelf();
+        dirInSubDomain2 = TTableId(dirEntry.GetSchemeshardId(), dirEntry.GetPathId());
     }
-    // error, by path id
-    {
-        auto request = MakeHolder<TNavigate>();
-        request->DatabaseName = "/Root";
-        auto& entry = request->ResultSet.emplace_back();
-        entry.TableId = testId;
-        entry.RequestType = TNavigate::TEntry::ERequestType::ByTableId;
-        auto result  = TestNavigateImpl(std::move(request), TNavigate::EStatus::PathErrorUnknown,
-            "", TNavigate::EOp::OpPath, false, true);
+
+    TVector<TNavigate::TEntry::ERequestType> requestTypes =
+        {TNavigate::TEntry::ERequestType::ByPath, TNavigate::TEntry::ERequestType::ByTableId};
+
+    for (const auto requestType : requestTypes) {
+        // Domain - Domain root path - ok
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root");
+            } else {
+                entry.TableId = domain;
+            }
+            entry.RequestType = requestType;
+            auto result = TestNavigateImpl(std::move(request), TNavigate::EStatus::Ok,
+                "", TNavigate::EOp::OpPath, false, true);
+
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                domain = result.TableId;
+            }
+        }
+
+        // Domain - Regular path within domain - ok
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root/DirA");
+            } else {
+                entry.TableId = dirInDomain;
+            }
+            entry.RequestType = requestType;
+            auto result = TestNavigateImpl(std::move(request), TNavigate::EStatus::Ok,
+                "", TNavigate::EOp::OpPath, false, true);
+
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                dirInDomain = result.TableId;
+            }
+        }
+
+        // Domain - Subdomain1 root path - ok
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root/SubDomain1");
+            } else {
+                entry.TableId = subDomain1;
+            }
+            entry.RequestType = requestType;
+            auto result = TestNavigateImpl(std::move(request), TNavigate::EStatus::Ok,
+                "", TNavigate::EOp::OpPath, false, true);
+
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                subDomain1 = result.TableId;
+            }
+        }
+
+        // Domain - Regular path within subdomain1 - error
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root/SubDomain1/DirA");
+            } else {
+                entry.TableId = dirInSubDomain1;
+            }
+            entry.RequestType = requestType;
+            auto result  = TestNavigateImpl(std::move(request), TNavigate::EStatus::PathErrorUnknown,
+                "", TNavigate::EOp::OpPath, false, true);
+        }
+
+        // Subdomain1 - Domain root path - error
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root/SubDomain1";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root");
+            } else {
+                entry.TableId = domain;
+            }
+            entry.RequestType = requestType;
+            auto result  = TestNavigateImpl(std::move(request), TNavigate::EStatus::PathErrorUnknown,
+                "", TNavigate::EOp::OpPath, false, true);
+        }
+
+        // Subdomain1 - Regular path within domain - error
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root/SubDomain1";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root/DirA");
+            } else {
+                entry.TableId = dirInDomain;
+            }
+            entry.RequestType = requestType;
+            auto result  = TestNavigateImpl(std::move(request), TNavigate::EStatus::PathErrorUnknown,
+                "", TNavigate::EOp::OpPath, false, true);
+        }
+
+        // Subdomain1 - Subdomain1 root path - ok
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root/SubDomain1";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root/SubDomain1");
+            } else {
+                entry.TableId = subDomain1;
+            }
+            entry.RequestType = requestType;
+            auto result = TestNavigateImpl(std::move(request), TNavigate::EStatus::Ok,
+                "", TNavigate::EOp::OpPath, false, true);
+        }
+
+        // Subdomain1 - Regular path within subdomain1 - ok
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root/SubDomain1";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root/SubDomain1/DirA");
+            } else {
+                entry.TableId = dirInSubDomain1;
+            }
+            entry.RequestType = requestType;
+            auto result = TestNavigateImpl(std::move(request), TNavigate::EStatus::Ok,
+                "", TNavigate::EOp::OpPath, false, true);
+
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                dirInSubDomain1 = result.TableId;
+            }
+        }
+
+        // Subdomain1 - Subdomain2 root path - error
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root/SubDomain1";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root/SubDomain2");
+            } else {
+                entry.TableId = subDomain2;
+            }
+            entry.RequestType = requestType;
+            auto result = TestNavigateImpl(std::move(request), TNavigate::EStatus::PathErrorUnknown,
+                "", TNavigate::EOp::OpPath, false, true);
+        }
+
+        // Subdomain1 - Regular path within subdomain2 - error
+        {
+            auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = "/Root/SubDomain1";
+            auto& entry = request->ResultSet.emplace_back();
+            if (requestType == TNavigate::TEntry::ERequestType::ByPath) {
+                entry.Path = SplitPath("/Root/SubDomain2/DirA");
+            } else {
+                entry.TableId = dirInSubDomain2;
+            }
+            entry.RequestType = requestType;
+            auto result = TestNavigateImpl(std::move(request), TNavigate::EStatus::PathErrorUnknown,
+                "", TNavigate::EOp::OpPath, false, true);
+        }
     }
 }
 

--- a/ydb/tests/functional/tenants/test_dynamic_tenants.py
+++ b/ydb/tests/functional/tenants/test_dynamic_tenants.py
@@ -447,7 +447,7 @@ def test_check_access(ydb_cluster):
             calling(client.list_directory).with_args(
                 user_2['path']
             ),
-            raises(ydb.Unauthorized)
+            raises(ydb.SchemeError)
         )
 
         assert_that(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Cherry Pick commit: a4ddf636069b1e75cd7fd511093cf24304c41771
When the request to SchemeCache was made within one ExtSubdomain SchemeCached allowed to get info about other ExtSubdomain.
