### PR TITLE
fix(viewer): add missing tablet status

### DIFF
--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -972,6 +972,7 @@ NKikimrViewer::EFlag GetFlagFromTabletState(NKikimrWhiteboard::TTabletStateInfo:
     case NKikimrWhiteboard::TTabletStateInfo::Lock:
     case NKikimrWhiteboard::TTabletStateInfo::RebuildGraph:
     case NKikimrWhiteboard::TTabletStateInfo::ResolveLeader:
+    case NKikimrWhiteboard::TTabletStateInfo::Terminating:
         flag = NKikimrViewer::EFlag::Yellow;
         break;
     case NKikimrWhiteboard::TTabletStateInfo::Deleted:


### PR DESCRIPTION
### Changelog entry
Add missing tablet status `Terminating` to properly calculate flag

...

### Changelog category
* Not for changelog (changelog entry is not required)