### PR TITLE
Make sure that state generation is no ahead of cluster generation (#2…

### DIFF
--- a/ydb/apps/bridge_skipper_demo/bridge.py
+++ b/ydb/apps/bridge_skipper_demo/bridge.py
@@ -460,13 +460,16 @@ class BridgeSkipper:
             self._load_state()
             # Check that loaded state generation is not ahead of what cluster reports
             if self.current_state:
-                pile_world_views = self.async_checker.get_health_state()
-                latest_generation = health.get_latest_generation_pile(pile_world_views)[0]
-                logger.info(f"Loaded state: {self.current_state}, cluster reported latest generation: {latest_generation}")
-                if self.current_state.generation and latest_generation and self.current_state.generation > latest_generation:
-                    logger.error(f"Generation {self.current_state.generation} from state file is ahead of cluster generation {latest_generation}")
-                    self.async_checker.stop(wait=True)
-                    sys.exit(1)
+                try:
+                    pile_world_views = self.async_checker.get_health_state()
+                    latest_generation = health.get_latest_generation_pile(pile_world_views)[0]
+                    logger.info(f"Loaded state: {self.current_state}, cluster reported latest generation: {latest_generation}")
+                    if self.current_state.generation and latest_generation and self.current_state.generation > latest_generation:
+                        logger.error(f"Generation {self.current_state.generation} from state file is ahead of cluster generation {latest_generation}")
+                        self.async_checker.stop(wait=True)
+                        sys.exit(1)
+                except Exception as e:
+                    logger.error(f"Failed to get health state or latest generation: {e}")
 
         except Exception as e:
             logger.debug(f"Failed to load saved state: {e}")


### PR DESCRIPTION
…3455)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
