### PR TITLE
Fix AddHeader logic in VDisk

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/defrag.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/defrag.cpp
@@ -11,7 +11,7 @@ static TIntrusivePtr<TBlobStorageGroupInfo> PrepareEnv(TEnvironmentSetup& env, T
     const TIntrusivePtr<TBlobStorageGroupInfo> info = env.GetGroupInfo(groups.front());
     env.Sim(TDuration::Minutes(5));
 
-    const ui32 dataLen = 512 * 1024;
+    const ui32 dataLen = 513 * 1024;
     const TString data(dataLen, 'x');
     ui32 index = 0;
 
@@ -283,7 +283,7 @@ Y_UNIT_TEST_SUITE(Defragmentation) {
         UNIT_ASSERT_VALUES_EQUAL(caughtDone, true);
         UNIT_ASSERT_VALUES_EQUAL(caughtRestore, true);
         UNIT_ASSERT_VALUES_EQUAL(rewrittenRecs, 20 - (9 + 1));  // // defragmentation stopping if number of can be freed chunks is 9 + 1 chunk really used
-        UNIT_ASSERT_VALUES_EQUAL(rewrittenBytes, 5767223);
+        UNIT_ASSERT(rewrittenBytes == 5778432 /*AddHeader=false*/ || rewrittenBytes == 5778487);
 
     }
 

--- a/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_blob.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_blob.h
@@ -362,6 +362,10 @@ namespace NKikimr {
             return Blob.Empty();
         }
 
+        bool ContainsMetadataPartsOnly() const {
+            return Blob.ContainsMetadataPartsOnly();
+        }
+
         TRope CreateDiskBlob(TRopeArena& arena, bool addHeader) const {
             return Blob.CreateDiskBlob(arena, addHeader);
         }

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hulldatamerger.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hulldatamerger.h
@@ -117,7 +117,17 @@ namespace NKikimr {
 
                 if (memRec.GetType() == TBlobType::DiskBlob) {
                     const TDiskPart& location = extr.SwearOne();
-                    ui32 offset = AddHeader ? TDiskBlob::HeaderSize : 0;
+
+                    // calculate total data size of parts stored within this blob
+                    ui32 totalSize = 0;
+                    for (ui8 partIdx : parts) {
+                        totalSize += GType.PartSize(TLogoBlobID(fullId, partIdx + 1));
+                    }
+
+                    // calculate initial offset of first stored part
+                    Y_ABORT_UNLESS(location.Size == totalSize || location.Size == totalSize + TDiskBlob::HeaderSize);
+                    ui32 offset = location.Size - totalSize;
+
                     for (ui8 partIdx : parts) {
                         const ui32 partSize = GType.PartSize(TLogoBlobID(fullId, partIdx + 1));
                         Y_DEBUG_ABORT_UNLESS(partIdx < Parts.size());

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
@@ -679,7 +679,8 @@ namespace NKikimr {
                         Y_VERIFY_S(writtenLocation == preallocatedLocation, HullCtx->VCtx->VDiskLogPrefix);
                     }
                 } else {
-                    Y_VERIFY_S(collectTask.BlobMerger.Empty(), HullCtx->VCtx->VDiskLogPrefix);
+                    Y_VERIFY_S(collectTask.BlobMerger.ContainsMetadataPartsOnly() || collectTask.BlobMerger.Empty(),
+                        HullCtx->VCtx->VDiskLogPrefix);
                     Y_VERIFY_S(collectTask.Reads.empty(), HullCtx->VCtx->VDiskLogPrefix);
                 }
 

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst.h
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst.h
@@ -182,8 +182,10 @@ namespace NKikimr {
             const bool success = Writer->PushIndexOnly(record.Id, memRec, &Merger, &preallocatedLocation);
             if (success) {
                 Y_VERIFY_DEBUG_S(Merger.GetCollectTask().Reads.empty(), ReplCtx->VCtx->VDiskLogPrefix);
-                const TDiskPart writtenLocation = Writer->PushDataOnly(std::move(record.Data));
-                Y_VERIFY_S(writtenLocation == preallocatedLocation, ReplCtx->VCtx->VDiskLogPrefix);
+                if (record.Data) {
+                    const TDiskPart writtenLocation = Writer->PushDataOnly(std::move(record.Data));
+                    Y_VERIFY_S(writtenLocation == preallocatedLocation, ReplCtx->VCtx->VDiskLogPrefix);
+                }
 
                 if (auto msg = Writer->GetPendingMessage()) {
                     IssueWriteCmd(std::move(msg), EOutputState::INTERMEDIATE_CHUNK);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix AddHeader logic in VDisk

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This allows enabling AddHeader=false in future release of VDisk.
