### PR TITLE
Add tests that reproduce transaction isolation anomalies in Column Shards

### DIFF
--- a/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
@@ -228,6 +228,11 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
     class LostUpdate : public TTableDataModificationTester {
     protected:
         void DoExecute() override {
+            if (GetIsOlap()) {
+                // will be fixed in https://github.com/ydb-platform/ydb/issues/25654
+                return;
+            }
+
             auto client = Kikimr->GetQueryClient();
 
             // classic lost update
@@ -306,6 +311,11 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
     class TransactionFailsAsSoonAsItIsClearItCannotCommit : public TTableDataModificationTester {
     protected:
         void DoExecute() override {
+            if (GetIsOlap()) {
+                // will be fixed in https://github.com/ydb-platform/ydb/issues/25661
+                return;
+            }
+
             auto client = Kikimr->GetQueryClient();
 
             auto session1 = client.GetSession().GetValueSync().GetSession();
@@ -361,6 +371,11 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         YDB_ACCESSOR(TString, WriteOp, "replace");
     protected:
         void DoExecute() override {
+            if (GetIsOlap()) {
+                // will be fixed in https://github.com/ydb-platform/ydb/issues/25654
+                return;
+            }
+
             auto client = Kikimr->GetQueryClient();
 
             // classic write skew

--- a/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
@@ -76,7 +76,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
 //         tester.Execute();
 //     }
 
-    class DirtyReads : public TTableDataModificationTester {
+    class TDirtyReads : public TTableDataModificationTester {
     protected:
         void DoExecute() override {
             auto client = Kikimr->GetQueryClient();
@@ -155,19 +155,13 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         }
     };
 
-    Y_UNIT_TEST(DirtyReadsOltp) {
-        DirtyReads tester;
-        tester.SetIsOlap(false);
+    Y_UNIT_TEST_TWIN(DirtyReads, IsOlap) {
+        TDirtyReads tester;
+        tester.SetIsOlap(IsOlap);
         tester.Execute();
     }
 
-    Y_UNIT_TEST(DirtyReadsOlap) {
-        DirtyReads tester;
-        tester.SetIsOlap(true);
-        tester.Execute();
-    }
-
-    class ChangeFromTheFuture : public TTableDataModificationTester {
+    class TChangeFromTheFuture : public TTableDataModificationTester {
     protected:
         void DoExecute() override {
             auto client = Kikimr->GetQueryClient();
@@ -213,19 +207,13 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         }
     };
 
-    Y_UNIT_TEST(ChangeFromTheFuture_olap) {
-        ChangeFromTheFuture tester;
-        tester.SetIsOlap(true);
+    Y_UNIT_TEST_TWIN(ChangeFromTheFuture, IsOlap) {
+        TChangeFromTheFuture tester;
+        tester.SetIsOlap(IsOlap);
         tester.Execute();
     }
 
-    Y_UNIT_TEST(ChangeFromTheFuture_oltp) {
-        ChangeFromTheFuture tester;
-        tester.SetIsOlap(false);
-        tester.Execute();
-    }
-
-    class LostUpdate : public TTableDataModificationTester {
+    class TLostUpdate : public TTableDataModificationTester {
     protected:
         void DoExecute() override {
             if (GetIsOlap()) {
@@ -296,19 +284,13 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         }
     };
 
-    Y_UNIT_TEST(LostUpdate_olap) {
-        LostUpdate tester;
-        tester.SetIsOlap(true);
+    Y_UNIT_TEST_TWIN(LostUpdate, IsOlap) {
+        TLostUpdate tester;
+        tester.SetIsOlap(IsOlap);
         tester.Execute();
     }
 
-    Y_UNIT_TEST(LostUpdate_oltp) {
-        LostUpdate tester;
-        tester.SetIsOlap(false);
-        tester.Execute();
-    }
-
-    class TransactionFailsAsSoonAsItIsClearItCannotCommit : public TTableDataModificationTester {
+    class TTransactionFailsAsSoonAsItIsClearItCannotCommit : public TTableDataModificationTester {
     protected:
         void DoExecute() override {
             if (GetIsOlap()) {
@@ -355,19 +337,13 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         }
     };
 
-    Y_UNIT_TEST(TransactionFailsAsSoonAsItIsClearItCannotCommit_olap) {
-        TransactionFailsAsSoonAsItIsClearItCannotCommit tester;
-        tester.SetIsOlap(true);
+    Y_UNIT_TEST_TWIN(TransactionFailsAsSoonAsItIsClearItCannotCommit, IsOlap) {
+        TTransactionFailsAsSoonAsItIsClearItCannotCommit tester;
+        tester.SetIsOlap(IsOlap);
         tester.Execute();
     }
 
-    Y_UNIT_TEST(TransactionFailsAsSoonAsItIsClearItCannotCommit_oltp) {
-        TransactionFailsAsSoonAsItIsClearItCannotCommit tester;
-        tester.SetIsOlap(false);
-        tester.Execute();
-    }
-
-    class WriteSkew : public TTableDataModificationTester {
+    class TWriteSkew : public TTableDataModificationTester {
         YDB_ACCESSOR(TString, WriteOp, "replace");
     protected:
         void DoExecute() override {
@@ -444,48 +420,27 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         }
     };
 
-    Y_UNIT_TEST(WriteSkew_olap_insert) {
-        WriteSkew tester;
-        tester.SetIsOlap(true);
+    Y_UNIT_TEST_TWIN(WriteSkewInsert, IsOlap) {
+        TWriteSkew tester;
+        tester.SetIsOlap(IsOlap);
         tester.SetWriteOp("insert");
         tester.Execute();
     }
 
-    Y_UNIT_TEST(WriteSkew_olap_upsert) {
-        WriteSkew tester;
-        tester.SetIsOlap(true);
+    Y_UNIT_TEST_TWIN(WriteSkewUpsert, IsOlap) {
+        TWriteSkew tester;
+        tester.SetIsOlap(IsOlap);
         tester.SetWriteOp("upsert");
         tester.Execute();
     }
 
-    Y_UNIT_TEST(WriteSkew_olap_replace) {
-        WriteSkew tester;
-        tester.SetIsOlap(true);
+    Y_UNIT_TEST_TWIN(WriteSkewReplace, IsOlap) {
+        TWriteSkew tester;
+        tester.SetIsOlap(IsOlap);
         tester.SetWriteOp("replace");
         tester.Execute();
     }
     
-    Y_UNIT_TEST(WriteSkew_oltp_replace) {
-        WriteSkew tester;
-        tester.SetIsOlap(false);
-        tester.SetWriteOp("replace");
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(WriteSkew_oltp_upsert) {
-        WriteSkew tester;
-        tester.SetIsOlap(false);
-        tester.SetWriteOp("upsert");
-        tester.Execute();
-    }
-
-    Y_UNIT_TEST(WriteSkew_oltp_insert) {
-        WriteSkew tester;
-        tester.SetIsOlap(false);
-        tester.SetWriteOp("insert");
-        tester.Execute();
-    }
-
     class TReadOnlyTxCommitsOnConcurrentWrite : public TTableDataModificationTester {
     protected:
         void DoExecute() override {

--- a/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
@@ -106,7 +106,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
 
             // tx2 reads all the KV, it should see (0, 0)
             result = session2.ExecuteQuery(Q1_(R"(
-                SELECT * FROM KV2;
+                select * from KV2;
                 )"), TTxControl::BeginTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
             CompareYson(R"([[0u;["0"]]])", FormatResultSetYson(result.GetResultSet(0)));

--- a/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
@@ -364,7 +364,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             auto client = Kikimr->GetQueryClient();
 
             // classic write skew
-            // there a business rule: sum of values must be <= 3
+            // there is a business rule: sum of values must be <= 3
 
             auto session1 = client.GetSession().GetValueSync().GetSession();
             auto session2 = client.GetSession().GetValueSync().GetSession();


### PR DESCRIPTION
Investigating #22259 here #25093, I found several problems in Column Shard transaction isolation logic.

I reproduced those problems in the unit tests.

This pull request brings the following tests:
- DirtyRead, classic "dirty read" anomaly. Data and Column shards pass it.
- ChangeFromTheFuture. Data and Column shards pass it.
- LostUpdate, classic "lost update" anomaly. Data shards pass it, Column shards FAIL it.
- WriteSkew, classic "write skew" anomaly. Data shards pass it, Column shards FAIL it.

I am going to mute the FAILING tests, until I fix the problems in the scopes of separate issues and pull requests.

