### PR TITLE
Add category to the metering logs

### DIFF
--- a/ydb/core/persqueue/pqtablet/metering_sink.cpp
+++ b/ydb/core/persqueue/pqtablet/metering_sink.cpp
@@ -102,7 +102,7 @@ TString TMeteringSink::GetMeteringJson(const TMeteringSink::FlushParameters& par
     writer.OpenMap("labels");
     writer.Write("datastreams_stream_name", Parameters_.StreamName);
     writer.Write("ydb_database", Parameters_.YdbDatabaseId);
-    writer.Write("category", "Topic");
+    writer.Write("Category", "Topic");
     writer.CloseMap(); // "labels"
 
     writer.Write("version", parameters.Version);

--- a/ydb/core/persqueue/pqtablet/metering_sink.cpp
+++ b/ydb/core/persqueue/pqtablet/metering_sink.cpp
@@ -102,6 +102,7 @@ TString TMeteringSink::GetMeteringJson(const TMeteringSink::FlushParameters& par
     writer.OpenMap("labels");
     writer.Write("datastreams_stream_name", Parameters_.StreamName);
     writer.Write("ydb_database", Parameters_.YdbDatabaseId);
+    writer.Write("category", "Topic");
     writer.CloseMap(); // "labels"
 
     writer.Write("version", parameters.Version);

--- a/ydb/core/persqueue/ut/metering_sink_ut.cpp
+++ b/ydb/core/persqueue/ut/metering_sink_ut.cpp
@@ -45,7 +45,7 @@ Y_UNIT_TEST(FlushPutEventsV1) {
         ",\"unit\":\"put_events\"," <<
         "\"start\":" << emptyFlushTs / 1'000'000 << ",\"finish\":" << flushTs / 1'000'000 <<
         "},\"labels\":{\"datastreams_stream_name\":\"streamName\"," <<
-        "\"ydb_database\":\"databaseId\",\"category\":\"Topic\"},\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
+        "\"ydb_database\":\"databaseId\",\"Category\":\"Topic\"},\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
         "\"source_wt\":" << flushTs / 1'000'000 << "}\n";
 
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referencePutUnitsJson);
@@ -89,7 +89,7 @@ Y_UNIT_TEST(FlushResourcesReservedV1) {
         partitions * (flushTs - creationTs) / 1'000'000 << ",\"unit\":\"second\"," <<
         "\"start\":" << creationTs / 1'000'000 << ",\"finish\":" << flushTs / 1'000'000 <<
         "},\"labels\":{\"datastreams_stream_name\":\"streamName\"," <<
-        "\"ydb_database\":\"databaseId\",\"category\":\"Topic\"},\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
+        "\"ydb_database\":\"databaseId\",\"Category\":\"Topic\"},\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
         "\"source_wt\":" << flushTs / 1'000'000 << "}\n";
 
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referenceResourcesReservedJson);
@@ -125,7 +125,7 @@ Y_UNIT_TEST(FlushThroughputV1) {
         "{\"reserved_throughput_bps\":" << writeQuota << ",\"reserved_consumers_count\":" << 0 << "}," << "\"usage\":{\"quantity\":" <<
         partitions * (flushTs - creationTs) / 1'000'000 << ",\"unit\":\"second\"" <<
         ",\"start\":" << creationTs / 1'000'000 << ",\"finish\":" << flushTs / 1'000'000 <<
-        "},\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"category\":\"Topic\"}," <<
+        "},\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"Category\":\"Topic\"}," <<
         "\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
         "\"source_wt\":" << flushTs / 1'000'000 << "}\n";
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referenceThrougputJson);
@@ -161,7 +161,7 @@ Y_UNIT_TEST(FlushStorageV1) {
         ((flushTs - creationTs) / 1'000'000) * partitions * (reservedSpace / 1_MB) <<
         ",\"unit\":\"mbyte*second\"" <<
         ",\"start\":" << creationTs / 1'000'000 << ",\"finish\":" << flushTs / 1'000'000 <<
-        "},\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"category\":\"Topic\"}," <<
+        "},\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"Category\":\"Topic\"}," <<
         "\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
         "\"source_wt\":" << flushTs / 1'000'000 << "}\n";
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referenceStorageJson);
@@ -198,7 +198,7 @@ Y_UNIT_TEST(UsedStorageV1) {
         "\n{\"cloud_id\":\"cloudId\",\"folder_id\":\"folderId\",\"resource_id\":\"streamPath\","
         << "\"id\":\"used_storage-databaseId-tabletId-1651752943168-" << meteringSink.GetMeteringCounter() << "\","
         << "\"schema\":\"ydb.serverless.v1\",\"tags\":{\"ydb_size\":6815},\"usage\":{\"quantity\":2000,\"unit\":\"byte*second\",\"start\":1651752943,\"finish\":1651754943},"
-        << "\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"category\":\"Topic\"},\"version\":\"1.0.0\",\"source_id\":\"tabletId\",\"source_wt\":1651754943}\n";
+        << "\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"Category\":\"Topic\"},\"version\":\"1.0.0\",\"source_id\":\"tabletId\",\"source_wt\":1651754943}\n";
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referenceStorageJson);
 }
 

--- a/ydb/core/persqueue/ut/metering_sink_ut.cpp
+++ b/ydb/core/persqueue/ut/metering_sink_ut.cpp
@@ -45,7 +45,7 @@ Y_UNIT_TEST(FlushPutEventsV1) {
         ",\"unit\":\"put_events\"," <<
         "\"start\":" << emptyFlushTs / 1'000'000 << ",\"finish\":" << flushTs / 1'000'000 <<
         "},\"labels\":{\"datastreams_stream_name\":\"streamName\"," <<
-        "\"ydb_database\":\"databaseId\"},\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
+        "\"ydb_database\":\"databaseId\",\"category\":\"Topic\"},\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
         "\"source_wt\":" << flushTs / 1'000'000 << "}\n";
 
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referencePutUnitsJson);
@@ -89,7 +89,7 @@ Y_UNIT_TEST(FlushResourcesReservedV1) {
         partitions * (flushTs - creationTs) / 1'000'000 << ",\"unit\":\"second\"," <<
         "\"start\":" << creationTs / 1'000'000 << ",\"finish\":" << flushTs / 1'000'000 <<
         "},\"labels\":{\"datastreams_stream_name\":\"streamName\"," <<
-        "\"ydb_database\":\"databaseId\"},\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
+        "\"ydb_database\":\"databaseId\",\"category\":\"Topic\"},\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
         "\"source_wt\":" << flushTs / 1'000'000 << "}\n";
 
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referenceResourcesReservedJson);
@@ -125,7 +125,7 @@ Y_UNIT_TEST(FlushThroughputV1) {
         "{\"reserved_throughput_bps\":" << writeQuota << ",\"reserved_consumers_count\":" << 0 << "}," << "\"usage\":{\"quantity\":" <<
         partitions * (flushTs - creationTs) / 1'000'000 << ",\"unit\":\"second\"" <<
         ",\"start\":" << creationTs / 1'000'000 << ",\"finish\":" << flushTs / 1'000'000 <<
-        "},\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\"}," <<
+        "},\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"category\":\"Topic\"}," <<
         "\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
         "\"source_wt\":" << flushTs / 1'000'000 << "}\n";
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referenceThrougputJson);
@@ -161,7 +161,7 @@ Y_UNIT_TEST(FlushStorageV1) {
         ((flushTs - creationTs) / 1'000'000) * partitions * (reservedSpace / 1_MB) <<
         ",\"unit\":\"mbyte*second\"" <<
         ",\"start\":" << creationTs / 1'000'000 << ",\"finish\":" << flushTs / 1'000'000 <<
-        "},\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\"}," <<
+        "},\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"category\":\"Topic\"}," <<
         "\"version\":\"v1\",\"source_id\":\"tabletId\"," <<
         "\"source_wt\":" << flushTs / 1'000'000 << "}\n";
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referenceStorageJson);
@@ -198,7 +198,7 @@ Y_UNIT_TEST(UsedStorageV1) {
         "\n{\"cloud_id\":\"cloudId\",\"folder_id\":\"folderId\",\"resource_id\":\"streamPath\","
         << "\"id\":\"used_storage-databaseId-tabletId-1651752943168-" << meteringSink.GetMeteringCounter() << "\","
         << "\"schema\":\"ydb.serverless.v1\",\"tags\":{\"ydb_size\":6815},\"usage\":{\"quantity\":2000,\"unit\":\"byte*second\",\"start\":1651752943,\"finish\":1651754943},"
-        << "\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\"},\"version\":\"1.0.0\",\"source_id\":\"tabletId\",\"source_wt\":1651754943}\n";
+        << "\"labels\":{\"datastreams_stream_name\":\"streamName\",\"ydb_database\":\"databaseId\",\"category\":\"Topic\"},\"version\":\"1.0.0\",\"source_id\":\"tabletId\",\"source_wt\":1651754943}\n";
     UNIT_ASSERT_VALUES_EQUAL(fullMetering, referenceStorageJson);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__serverless_storage_billing.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__serverless_storage_billing.cpp
@@ -166,7 +166,7 @@ struct TSchemeShard::TTxServerlessStorageBilling : public TTransactionBase<TSche
                  {"finish", toBill.End.Seconds()}
              }},
              {"labels", NJson::TJsonMap {
-                 {"category", "Table"},
+                 {"Category", "Table"},
              }},
         };
 

--- a/ydb/core/tx/schemeshard/schemeshard__serverless_storage_billing.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__serverless_storage_billing.cpp
@@ -165,6 +165,9 @@ struct TSchemeShard::TTxServerlessStorageBilling : public TTransactionBase<TSche
                  {"start", toBill.Start.Seconds()},
                  {"finish", toBill.End.Seconds()}
              }},
+             {"labels", NJson::TJsonMap {
+                 {"category", "Table"},
+             }},
         };
 
         for (const auto& [k, v] : dbRootEl->UserAttrs->Attrs) {

--- a/ydb/core/tx/schemeshard/ut_serverless/ut_serverless.cpp
+++ b/ydb/core/tx/schemeshard/ut_serverless/ut_serverless.cpp
@@ -253,7 +253,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         waitMeteringMessage();
 
         {
-            TString meteringData = R"({"usage":{"start":1600452120,"quantity":59,"finish":1600452179,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":13280},"id":"72057594046678944-3-1600452120-1600452179-13280","cloud_id":"CLOUD_ID_VAL","source_wt":1600452180,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+            TString meteringData = R"({"usage":{"start":1600452120,"quantity":59,"finish":1600452179,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":13280},"labels":{"category":"Table"},"id":"72057594046678944-3-1600452120-1600452179-13280","cloud_id":"CLOUD_ID_VAL","source_wt":1600452180,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
             MeteringDataEqual(meteringMessages, meteringData);
         }
 
@@ -268,7 +268,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         waitMeteringMessage();
 
         {
-            TString meteringData = R"({"usage":{"start":1600452180,"quantity":59,"finish":1600452239,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":0},"id":"72057594046678944-3-1600452180-1600452239-0","cloud_id":"CLOUD_ID_VAL","source_wt":1600452240,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+            TString meteringData = R"({"usage":{"start":1600452180,"quantity":59,"finish":1600452239,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":0},"labels":{"category":"Table"},"id":"72057594046678944-3-1600452180-1600452239-0","cloud_id":"CLOUD_ID_VAL","source_wt":1600452240,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
             MeteringDataEqual(meteringMessages, meteringData);
         }
     }
@@ -338,7 +338,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         runtime.WaitFor("metering", [&]{ return block.size() >= 1; });
 
         const auto& jsonStr = block[0]->Get()->MeteringJson;
-        UNIT_ASSERT_C(jsonStr.Contains(R"("labels":{"k":"v"})"), jsonStr);
+        UNIT_ASSERT_C(jsonStr.Contains(R"("labels":{"category":"Table","k":"v"})"), jsonStr);
         UNIT_ASSERT_C(!jsonStr.Contains("not_a_label"), jsonStr);
     }
 

--- a/ydb/core/tx/schemeshard/ut_serverless/ut_serverless.cpp
+++ b/ydb/core/tx/schemeshard/ut_serverless/ut_serverless.cpp
@@ -253,7 +253,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         waitMeteringMessage();
 
         {
-            TString meteringData = R"({"usage":{"start":1600452120,"quantity":59,"finish":1600452179,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":13280},"labels":{"category":"Table"},"id":"72057594046678944-3-1600452120-1600452179-13280","cloud_id":"CLOUD_ID_VAL","source_wt":1600452180,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+            TString meteringData = R"({"usage":{"start":1600452120,"quantity":59,"finish":1600452179,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":13280},"labels":{"Category":"Table"},"id":"72057594046678944-3-1600452120-1600452179-13280","cloud_id":"CLOUD_ID_VAL","source_wt":1600452180,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
             MeteringDataEqual(meteringMessages, meteringData);
         }
 
@@ -268,7 +268,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         waitMeteringMessage();
 
         {
-            TString meteringData = R"({"usage":{"start":1600452180,"quantity":59,"finish":1600452239,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":0},"labels":{"category":"Table"},"id":"72057594046678944-3-1600452180-1600452239-0","cloud_id":"CLOUD_ID_VAL","source_wt":1600452240,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+            TString meteringData = R"({"usage":{"start":1600452180,"quantity":59,"finish":1600452239,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":0},"labels":{"Category":"Table"},"id":"72057594046678944-3-1600452180-1600452239-0","cloud_id":"CLOUD_ID_VAL","source_wt":1600452240,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
             MeteringDataEqual(meteringMessages, meteringData);
         }
     }
@@ -338,7 +338,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         runtime.WaitFor("metering", [&]{ return block.size() >= 1; });
 
         const auto& jsonStr = block[0]->Get()->MeteringJson;
-        UNIT_ASSERT_C(jsonStr.Contains(R"("labels":{"category":"Table","k":"v"})"), jsonStr);
+        UNIT_ASSERT_C(jsonStr.Contains(R"("labels":{"Category":"Table","k":"v"})"), jsonStr);
         UNIT_ASSERT_C(!jsonStr.Contains("not_a_label"), jsonStr);
     }
 

--- a/ydb/services/datastreams/datastreams_ut.cpp
+++ b/ydb/services/datastreams/datastreams_ut.cpp
@@ -519,11 +519,13 @@ Y_UNIT_TEST_SUITE(DataStreams) {
                             [streamName](const NJson::TJsonValue::TMapType& map) {
                                 UNIT_ASSERT(map.contains("labels"));
                                 auto& labels = map.find("labels")->second.GetMap();
-                                UNIT_ASSERT_VALUES_EQUAL(labels.size(), 2);
+                                UNIT_ASSERT_VALUES_EQUAL(labels.size(), 3);
                                 UNIT_ASSERT_VALUES_EQUAL(
                                     labels.find("datastreams_stream_name")->second.GetString(), streamName);
                                 UNIT_ASSERT_VALUES_EQUAL(
                                     labels.find("ydb_database")->second.GetString(), "root");
+                                UNIT_ASSERT_VALUES_EQUAL(
+                                    labels.find("Category")->second.GetString(), "Topic");
                             },
                             [](const NJson::TJsonValue::TMapType& map) {
                                 UNIT_ASSERT(map.contains("usage"));
@@ -561,11 +563,13 @@ Y_UNIT_TEST_SUITE(DataStreams) {
                             [streamName](const NJson::TJsonValue::TMapType& map) {
                                 UNIT_ASSERT(map.contains("labels"));
                                 auto& labels = map.find("labels")->second.GetMap();
-                                UNIT_ASSERT_VALUES_EQUAL(labels.size(), 2);
+                                UNIT_ASSERT_VALUES_EQUAL(labels.size(), 3);
                                 UNIT_ASSERT_VALUES_EQUAL(
                                     labels.find("datastreams_stream_name")->second.GetString(), streamName);
                                 UNIT_ASSERT_VALUES_EQUAL(
                                     labels.find("ydb_database")->second.GetString(), "root");
+                                UNIT_ASSERT_VALUES_EQUAL(
+                                    labels.find("Category")->second.GetString(), "Topic");
                             },
                             [](const NJson::TJsonValue::TMapType& map) {
                                 UNIT_ASSERT(map.contains("usage"));
@@ -703,11 +707,13 @@ Y_UNIT_TEST_SUITE(DataStreams) {
                             [streamName](const NJson::TJsonValue::TMapType& map) {
                                 UNIT_ASSERT(map.contains("labels"));
                                 auto& labels = map.find("labels")->second.GetMap();
-                                UNIT_ASSERT_VALUES_EQUAL(labels.size(), 2);
+                                UNIT_ASSERT_VALUES_EQUAL(labels.size(), 3);
                                 UNIT_ASSERT_VALUES_EQUAL(
                                     labels.find("datastreams_stream_name")->second.GetString(), streamName);
                                 UNIT_ASSERT_VALUES_EQUAL(
                                     labels.find("ydb_database")->second.GetString(), "root");
+                                UNIT_ASSERT_VALUES_EQUAL(
+                                    labels.find("Category")->second.GetString(), "Topic");
                             },
                             [/*storageMb*/](const NJson::TJsonValue::TMapType& map) {
                                 UNIT_ASSERT(map.contains("usage"));
@@ -743,11 +749,13 @@ Y_UNIT_TEST_SUITE(DataStreams) {
                             [streamName](const NJson::TJsonValue::TMapType& map) {
                                 UNIT_ASSERT(map.contains("labels"));
                                 auto& labels = map.find("labels")->second.GetMap();
-                                UNIT_ASSERT_VALUES_EQUAL(labels.size(), 2);
+                                UNIT_ASSERT_VALUES_EQUAL(labels.size(), 3);
                                 UNIT_ASSERT_VALUES_EQUAL(
                                     labels.find("datastreams_stream_name")->second.GetString(), streamName);
                                 UNIT_ASSERT_VALUES_EQUAL(
                                     labels.find("ydb_database")->second.GetString(), "root");
+                                UNIT_ASSERT_VALUES_EQUAL(
+                                    labels.find("Category")->second.GetString(), "Topic");
                             },
                             [](const NJson::TJsonValue::TMapType& map) {
                                 UNIT_ASSERT(map.contains("usage"));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
annotate  the `ydb_size` metric with the
`Category=Table`, `Category=Topic`
labels

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
[LOGBROKER-9955](https://st.yandex-team.ru/LOGBROKER-9955)