### PR TITLE
Enable VIEW export by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -186,7 +186,7 @@ message TFeatureFlags {
     optional bool DisableLocalDBEraseCache = 161 [default = false];
     optional bool EnableChecksumsExport = 162 [default = false];
     optional bool EnableTopicTransfer = 163 [default = true];
-    optional bool EnableViewExport = 164 [default = false];
+    optional bool EnableViewExport = 164 [default = true];
     optional bool EnableColumnStore = 165 [default = false];
     optional bool EnableStrictAclCheck = 166 [default = false];
     optional bool DatabaseYamlConfigAllowed = 167 [default = false];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Enable the feature flag `EnableViewExport` by default.

Issue:
- https://github.com/ydb-platform/ydb/issues/12724
