### PR TITLE
merge to q-stable-ydb-25-1 YQ-4449 unmuted tests on s3 url escaping

### DIFF
--- a/ydb/library/yql/providers/s3/actors/yql_arrow_column_converters.h
+++ b/ydb/library/yql/providers/s3/actors/yql_arrow_column_converters.h
@@ -5,6 +5,7 @@
 
 namespace NDB {
 
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatSettings.h>
 struct FormatSettings;
 
 } // namespace NDB

--- a/ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.cpp
@@ -2,14 +2,13 @@
 #include "yql_s3_write_actor.h"
 #include "yql_s3_applicator_actor.h"
 
+#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h>
+
 #include <util/system/platform.h>
 #if defined(_linux_) || defined(_darwin_)
 #include "yql_s3_read_actor.h"
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/registerFormats.h>
 #endif
-
-#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h>
-
 
 namespace NYql::NDq {
 

--- a/ydb/library/yql/providers/s3/actors/yql_s3_actors_util.h
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_actors_util.h
@@ -11,6 +11,7 @@
 #include <util/generic/string.h>
 
 #include <optional>
+#include <source_location>
 
 namespace NYql::NDq {
 

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -1,41 +1,3 @@
-#include <util/system/platform.h>
-#if defined(_linux_) || defined(_darwin_)
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeArray.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDate.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDateTime64.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesDecimal.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeEnum.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNothing.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNullable.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeString.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeTuple.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeUUID.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesNumber.h>
-
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/ColumnsWithTypeAndName.h>
-
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatFactory.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/InputStreamFromInputFormat.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/Impl/ArrowBufferedStreams.h>
-
-#include <arrow/api.h>
-#include <arrow/io/api.h>
-#include <arrow/compute/cast.h>
-#include <arrow/status.h>
-#include <arrow/util/future.h>
-#include <parquet/arrow/reader.h>
-#include <parquet/file_reader.h>
-
-#include <library/cpp/protobuf/util/pb_io.h>
-#include <google/protobuf/text_format.h>
-
-#endif
-
 #include "yql_arrow_column_converters.h"
 #include "yql_arrow_push_down.h"
 #include "yql_s3_decompressor_actor.h"
@@ -96,6 +58,47 @@
 #undef THROW
 #include <library/cpp/string_utils/quote/quote.h>
 #include <library/cpp/xml/document/xml-document.h>
+
+#include <util/system/platform.h>
+#if defined(_linux_) || defined(_darwin_)
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/compute/cast.h>
+#include <arrow/status.h>
+#include <arrow/util/future.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/file_reader.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+#include <google/protobuf/text_format.h>
+
+#undef NO_SANITIZE_THREAD
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeArray.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDate.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDateTime64.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesDecimal.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeEnum.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNothing.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNullable.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeString.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeTuple.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeUUID.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesNumber.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/ColumnsWithTypeAndName.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatFactory.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/InputStreamFromInputFormat.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/Impl/ArrowBufferedStreams.h>
+
+#endif
 
 #define LOG_E(name, stream) \
     LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, name << ": " << this->SelfId() << ", TxId: " << TxId << ". " << stream)
@@ -1575,8 +1578,19 @@ private:
 
     class TReadyBlock {
     public:
-        TReadyBlock(TEvS3Provider::TEvNextBlock::TPtr& event) : PathInd(event->Get()->PathIndex) { Block.swap(event->Get()->Block); }
-        TReadyBlock(TEvS3Provider::TEvNextRecordBatch::TPtr& event) : Batch(event->Get()->Batch), PathInd(event->Get()->PathIndex) {}
+        TReadyBlock(TEvS3Provider::TEvNextBlock::TPtr& event)
+            : PathInd(event->Get()->PathIndex)
+        {
+            const auto& block = event->Get()->Block;
+            YQL_ENSURE(block);
+            Block.swap(*block);
+        }
+
+        TReadyBlock(TEvS3Provider::TEvNextRecordBatch::TPtr& event)
+            : Batch(event->Get()->Batch)
+            , PathInd(event->Get()->PathIndex)
+        {}
+
         NDB::Block Block;
         std::shared_ptr<arrow::RecordBatch> Batch;
         size_t PathInd;
@@ -1759,7 +1773,9 @@ private:
 
     void HandleNextBlock(TEvS3Provider::TEvNextBlock::TPtr& next) {
         YQL_ENSURE(!ReadSpec->Arrow);
-        auto rows = next->Get()->Block.rows();
+        const auto& block = next->Get()->Block;
+        YQL_ENSURE(block);
+        auto rows = block->rows();
         IngressStats.Bytes += next->Get()->IngressDelta;
         IngressStats.DecompressedBytes += next->Get()->IngressDecompressedDelta;
         IngressStats.Rows += rows;

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -45,28 +45,18 @@
 #include "yql_s3_source_queue.h"
 
 #include <ydb/core/base/events.h>
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/actor_coroutine.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/event_local.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/actors/util/datetime.h>
 #include <ydb/library/services/services.pb.h>
 
-#include <yql/essentials/core/yql_expr_type_annotation.h>
 #include <ydb/library/yql/dq/actors/common/retry_queue.h>
-#include <yql/essentials/minikql/mkql_string_util.h>
-#include <yql/essentials/minikql/computation/mkql_computation_node_impl.h>
-#include <yql/essentials/minikql/mkql_program_builder.h>
-#include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
-#include <yql/essentials/minikql/mkql_function_registry.h>
-#include <yql/essentials/minikql/mkql_node_cast.h>
-#include <yql/essentials/minikql/mkql_terminator.h>
-#include <yql/essentials/minikql/comp_nodes/mkql_factories.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h>
-#include <yql/essentials/providers/common/schema/mkql/yql_mkql_schema.h>
-#include <yql/essentials/public/issue/yql_issue_message.h>
-#include <yql/essentials/public/udf/arrow/block_builder.h>
-#include <yql/essentials/public/udf/arrow/block_reader.h>
-#include <yql/essentials/public/udf/arrow/util.h>
-#include <yql/essentials/utils/exceptions.h>
-#include <yql/essentials/utils/yql_panic.h>
-#include <yql/essentials/parser/pg_wrapper/interface/arrow.h>
-
 #include <ydb/library/yql/providers/s3/common/util.h>
 #include <ydb/library/yql/providers/s3/common/source_context.h>
 #include <ydb/library/yql/providers/s3/compressors/factory.h>
@@ -78,13 +68,23 @@
 #include <ydb/library/yql/providers/s3/range_helpers/path_list_reader.h>
 #include <ydb/library/yql/providers/s3/serializations/serialization_interval.h>
 
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actor_coroutine.h>
-#include <ydb/library/actors/core/events.h>
-#include <ydb/library/actors/core/event_local.h>
-#include <ydb/library/actors/core/hfunc.h>
-#include <ydb/library/actors/core/log.h>
-#include <ydb/library/actors/util/datetime.h>
+#include <yql/essentials/core/yql_expr_type_annotation.h>
+#include <yql/essentials/minikql/mkql_string_util.h>
+#include <yql/essentials/minikql/computation/mkql_computation_node_impl.h>
+#include <yql/essentials/minikql/mkql_program_builder.h>
+#include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
+#include <yql/essentials/minikql/mkql_function_registry.h>
+#include <yql/essentials/minikql/mkql_node_cast.h>
+#include <yql/essentials/minikql/mkql_terminator.h>
+#include <yql/essentials/minikql/comp_nodes/mkql_factories.h>
+#include <yql/essentials/providers/common/schema/mkql/yql_mkql_schema.h>
+#include <yql/essentials/public/issue/yql_issue_message.h>
+#include <yql/essentials/public/udf/arrow/block_builder.h>
+#include <yql/essentials/public/udf/arrow/block_reader.h>
+#include <yql/essentials/public/udf/arrow/util.h>
+#include <yql/essentials/utils/exceptions.h>
+#include <yql/essentials/utils/yql_panic.h>
+#include <yql/essentials/parser/pg_wrapper/interface/arrow.h>
 
 #include <util/generic/size_literals.h>
 #include <util/stream/format.h>
@@ -93,9 +93,7 @@
 #include <algorithm>
 #include <queue>
 
-#ifdef THROW
 #undef THROW
-#endif
 #include <library/cpp/string_utils/quote/quote.h>
 #include <library/cpp/xml/document/xml-document.h>
 
@@ -269,8 +267,10 @@ struct TParquetFileInfo {
     ui64 UncompressedSize = 0;
 };
 
-class TS3ReadCoroImpl : public TActorCoroImpl {
+class TS3ReadCoroImpl : public TActorCoroImpl, public TSourceErrorHandler {
     friend class TS3StreamReadActor;
+
+    static constexpr ui64 MAX_ERROR_TEXT_SIZE = 256_KB;
 
 public:
 
@@ -879,7 +879,7 @@ public:
         hFunc(TEvS3Provider::TEvDecompressDataFinish, Handle);
         hFunc(TEvS3Provider::TEvContinue, Handle);
         hFunc(TEvS3Provider::TEvReadResult2, Handle);
-        hFunc(NActors::TEvents::TEvPoison, Handle);
+        hFunc(TEvents::TEvPoison, Handle);
     )
 
     void ProcessOneEvent() {
@@ -891,7 +891,7 @@ public:
             }
             return;
         }
-        TAutoPtr<::NActors::IEventHandle> ev(WaitForEvent().Release());
+        TAutoPtr<IEventHandle> ev(WaitForEvent().Release());
         StateFunc(ev);
     }
 
@@ -939,10 +939,13 @@ public:
             }
         } else if (HttpResponseCode && !RetryStuff->IsCancelled() && !RetryStuff->NextRetryDelay) {
             ServerReturnedError = true;
-            if (ErrorText.size() < 256_KB)
+            if (ErrorText.size() < MAX_ERROR_TEXT_SIZE) {
                 ErrorText.append(ev->Get()->Result.Extract());
-            else if (!ErrorText.EndsWith(TruncatedSuffix))
-                ErrorText.append(TruncatedSuffix);
+                if (ErrorText.size() > MAX_ERROR_TEXT_SIZE) {
+                    ErrorText.resize(MAX_ERROR_TEXT_SIZE);
+                    ErrorText.append(TruncatedSuffix);
+                }
+            }
             LOG_CORO_W("TEvDownloadData, ERROR: " << ErrorText << ", LastOffset: " << LastOffset << ", LastData: " << GetLastDataAsText());
         }
     }
@@ -989,7 +992,7 @@ public:
             LOG_CORO_D("TEvDownloadFinish with Issues (try to retry): " << Issues.ToOneLineString());
             if (RetryStuff->NextRetryDelay) {
                 // inplace retry: report problem to TransientIssues and repeat
-                Send(ComputeActorId, new IDqComputeActorAsyncInput::TEvAsyncInputError(InputIndex, Issues, NYql::NDqProto::StatusIds::UNSPECIFIED));
+                OnRetriableError(Issues);
             } else {
                 // can't retry here: fail download
                 RetryStuff->RetryState = nullptr;
@@ -1033,7 +1036,7 @@ public:
         HandleEvent(*ev);
     }
 
-    void Handle(NActors::TEvents::TEvPoison::TPtr&) {
+    void Handle(TEvents::TEvPoison::TPtr&) {
         LOG_CORO_D("TEvPoison");
         RetryStuff->Cancel();
         FinishDecompressor(true);
@@ -1042,14 +1045,15 @@ public:
 
     void FinishDecompressor(bool force = false) {
         if (AsyncDecompressing) {
-            Send(DecompressorActorId, new NActors::TEvents::TEvPoison(), 0, force);
+            Send(DecompressorActorId, new TEvents::TEvPoison(), 0, force);
         }
     }
 
 private:
     static constexpr std::string_view TruncatedSuffix = "... [truncated]"sv;
+
 public:
-    TS3ReadCoroImpl(ui64 inputIndex, const TTxId& txId, const NActors::TActorId& computeActorId,
+    TS3ReadCoroImpl(ui64 inputIndex, const TTxId& txId, const TActorId& computeActorId,
         const TRetryStuff::TPtr& retryStuff, const TReadSpec::TPtr& readSpec, size_t pathIndex,
         const TString& path, const TString& url, std::optional<ui64> maxRows,
         const TS3ReadActorFactoryConfig& readActorFactoryCfg,
@@ -1059,13 +1063,24 @@ public:
         const ::NMonitoring::TDynamicCounters::TCounterPtr& httpDataRps,
         const ::NMonitoring::TDynamicCounters::TCounterPtr& rawInflightSize,
         bool asyncDecompressing)
-        : TActorCoroImpl(256_KB), ReadActorFactoryCfg(readActorFactoryCfg), InputIndex(inputIndex),
-        TxId(txId), RetryStuff(retryStuff), ReadSpec(readSpec), ComputeActorId(computeActorId),
-        PathIndex(pathIndex), Path(path), Url(url), RowsRemained(maxRows),
-        SourceContext(queueBufferCounter),
-        DeferredQueueSize(deferredQueueSize), HttpInflightSize(httpInflightSize),
-        HttpDataRps(httpDataRps), RawInflightSize(rawInflightSize), AsyncDecompressing(asyncDecompressing) {
-    }
+        : TActorCoroImpl(256_KB)
+        , TSourceErrorHandler(inputIndex)
+        , ReadActorFactoryCfg(readActorFactoryCfg)
+        , TxId(txId)
+        , RetryStuff(retryStuff)
+        , ReadSpec(readSpec)
+        , ComputeActorId(computeActorId)
+        , PathIndex(pathIndex)
+        , Path(path)
+        , Url(url)
+        , RowsRemained(maxRows)
+        , SourceContext(queueBufferCounter)
+        , DeferredQueueSize(deferredQueueSize)
+        , HttpInflightSize(httpInflightSize)
+        , HttpDataRps(httpDataRps)
+        , RawInflightSize(rawInflightSize)
+        , AsyncDecompressing(asyncDecompressing)
+    {}
 
     ~TS3ReadCoroImpl() override {
         if (DeferredDataParts.size() && DeferredQueueSize) {
@@ -1187,10 +1202,15 @@ private:
         CpuTime += GetCpuTimeDelta();
 
         auto issues = NS3Util::AddParentIssue(TStringBuilder{} << "Error while reading file " << Path, std::move(Issues));
-        if (issues)
-            Send(ComputeActorId, new IDqComputeActorAsyncInput::TEvAsyncInputError(InputIndex, std::move(issues), FatalCode));
-        else
+        if (issues) {
+            OnFatalError(std::move(issues), FatalCode);
+        } else {
             Send(ParentActorId, new TEvS3Provider::TEvFileFinished(PathIndex, TakeIngressDelta(), TakeCpuTimeDelta(), RetryStuff->SizeLimit));
+        }
+    }
+
+    void SendError(std::unique_ptr<IDqComputeActorAsyncInput::TEvAsyncInputError> ev) final {
+        Send(ComputeActorId, ev.release());
     }
 
     void ProcessUnexpectedEvent(TAutoPtr<IEventHandle> ev) {
@@ -1231,12 +1251,10 @@ private:
 
 private:
     const TS3ReadActorFactoryConfig ReadActorFactoryCfg;
-    const ui64 InputIndex;
     const TTxId TxId;
     const TRetryStuff::TPtr RetryStuff;
     const TReadSpec::TPtr ReadSpec;
-    const TString Format, RowType, Compression;
-    const NActors::TActorId ComputeActorId;
+    const TActorId ComputeActorId;
     const size_t PathIndex;
     const TString Path;
     const TString Url;
@@ -1250,7 +1268,7 @@ private:
     TIssues Issues;
     NYql::NDqProto::StatusIds::StatusCode FatalCode;
 
-    NActors::TActorId DecompressorActorId;
+    TActorId DecompressorActorId;
     std::size_t LastOffset = 0;
     TString LastData;
     ui64 IngressBytes = 0;
@@ -1281,7 +1299,7 @@ private:
     }
 };
 
-class TS3StreamReadActor : public TActorBootstrapped<TS3StreamReadActor>, public IDqComputeActorAsyncInput {
+class TS3StreamReadActor : public TActorBootstrapped<TS3StreamReadActor>, public IDqComputeActorAsyncInput, public TSourceErrorHandler {
 public:
     TS3StreamReadActor(
         ui64 inputIndex,
@@ -1296,7 +1314,7 @@ public:
         TPathList&& paths,
         bool addPathIndex,
         const TReadSpec::TPtr& readSpec,
-        const NActors::TActorId& computeActorId,
+        const TActorId& computeActorId,
         const IHTTPGateway::TRetryPolicy::TPtr& retryPolicy,
         const TS3ReadActorFactoryConfig& readActorFactoryCfg,
         ::NMonitoring::TDynamicCounterPtr counters,
@@ -1312,11 +1330,11 @@ public:
         ui64 fileQueueConsumersCountDelta,
         bool asyncDecoding,
         bool asyncDecompressing,
-        bool allowLocalFiles
-    )   : ReadActorFactoryCfg(readActorFactoryCfg)
+        bool allowLocalFiles)
+        : TSourceErrorHandler(inputIndex)
+        , ReadActorFactoryCfg(readActorFactoryCfg)
         , Gateway(std::move(gateway))
         , HolderFactory(holderFactory)
-        , InputIndex(inputIndex)
         , TxId(txId)
         , ComputeActorId(computeActorId)
         , RetryPolicy(retryPolicy)
@@ -1374,7 +1392,7 @@ public:
         if (!MemoryQuotaManager->AllocateQuota(ReadActorFactoryCfg.DataInflight)) {
             TIssues issues;
             issues.AddIssue(TIssue{TStringBuilder() << "OutOfMemory - can't allocate " << ReadActorFactoryCfg.DataInflight << "b read buffer"});
-            Send(ComputeActorId, new TEvAsyncInputError(InputIndex, std::move(issues), NYql::NDqProto::StatusIds::OVERLOADED));
+            OnFatalError(std::move(issues), NYql::NDqProto::StatusIds::OVERLOADED);
             return;
         }
 
@@ -1592,7 +1610,6 @@ private:
             NUdf::TUnboxedValue value;
             if (ReadSpec->Arrow) {
                 const auto& batch = *Blocks.front().Batch;
-// Cerr << "ASYNC batch with COLS=" << batch.num_columns() << " and ROWS=" << batch.num_rows() << Endl;
                 NUdf::TUnboxedValue* structItems = nullptr;
                 auto structObj = ArrowRowContainerCache.NewArray(HolderFactory, 1 + batch.num_columns(), structItems);
                 for (int i = 0; i < batch.num_columns(); ++i) {
@@ -1651,7 +1668,7 @@ private:
             SourceContext.reset();
 
             for (const auto actorId : CoroActors) {
-                Send(actorId, new NActors::TEvents::TEvPoison());
+                Send(actorId, new TEvents::TEvPoison());
             }
             LOG_T("TS3StreamReadActor", "PassAway FileQueue RemoveConfirmedEvents=" << FileQueueEvents.RemoveConfirmedEvents());
             FileQueueEvents.Unsubscribe();
@@ -1678,13 +1695,13 @@ private:
         hFunc(TEvS3Provider::TEvObjectPathBatch, HandleObjectPathBatch);
         hFunc(TEvS3Provider::TEvObjectPathReadError, HandleObjectPathReadError);
         hFunc(NYql::NDq::TEvRetryQueuePrivate::TEvRetry, Handle);
-        hFunc(NActors::TEvInterconnect::TEvNodeDisconnected, Handle);
-        hFunc(NActors::TEvInterconnect::TEvNodeConnected, Handle);
-        hFunc(NActors::TEvents::TEvUndelivered, Handle);
+        hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
+        hFunc(TEvInterconnect::TEvNodeConnected, Handle);
+        hFunc(TEvents::TEvUndelivered, Handle);
         hFunc(IDqComputeActorAsyncInput::TEvAsyncInputError, Handle);
         , catch (const std::exception& e) {
             TIssues issues{TIssue{TStringBuilder() << "An unknown exception has occurred: '" << e.what() << "'"}};
-            Send(ComputeActorId, new TEvAsyncInputError(InputIndex, issues, NYql::NDqProto::StatusIds::INTERNAL_ERROR));
+            OnFatalError(std::move(issues), NYql::NDqProto::StatusIds::INTERNAL_ERROR);
         }
     )
 
@@ -1733,7 +1750,7 @@ private:
         IssuesFromMessage(result->Get()->Record.GetIssues(), issues);
         LOG_W("TS3StreamReadActor", "Error while object listing, details: TEvObjectPathReadError: " << issues.ToOneLineString());
         issues = NS3Util::AddParentIssue(TStringBuilder{} << "Error while object listing", std::move(issues));
-        Send(ComputeActorId, new TEvAsyncInputError(InputIndex, std::move(issues), result->Get()->Record.GetFatalCode()));
+        OnFatalError(std::move(issues), result->Get()->Record.GetFatalCode());
     }
 
     void HandleRetry(TEvS3Provider::TEvRetryEventFunc::TPtr& retry) {
@@ -1819,21 +1836,21 @@ private:
         FileQueueEvents.Retry();
     }
 
-    void Handle(NActors::TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
+    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
         LOG_T("TS3StreamReadActor", "Handle disconnected FileQueue " << ev->Get()->NodeId);
         FileQueueEvents.HandleNodeDisconnected(ev->Get()->NodeId);
     }
 
-    void Handle(NActors::TEvInterconnect::TEvNodeConnected::TPtr& ev) {
+    void Handle(TEvInterconnect::TEvNodeConnected::TPtr& ev) {
         LOG_T("TS3StreamReadActor", "Handle connected FileQueue " << ev->Get()->NodeId);
         FileQueueEvents.HandleNodeConnected(ev->Get()->NodeId);
     }
 
-    void Handle(NActors::TEvents::TEvUndelivered::TPtr& ev) {
+    void Handle(TEvents::TEvUndelivered::TPtr& ev) {
         LOG_T("TS3StreamReadActor", "Handle undelivered FileQueue ");
         if (FileQueueEvents.HandleUndelivered(ev) != NYql::NDq::TRetryEventsQueue::ESessionState::WrongSession) {
             TIssues issues{TIssue{TStringBuilder() << "FileQueue was lost"}};
-            Send(ComputeActorId, new TEvAsyncInputError(InputIndex, issues, NYql::NDqProto::StatusIds::UNAVAILABLE));
+            OnFatalError(std::move(issues), NYql::NDqProto::StatusIds::UNAVAILABLE);
         }
     }
 
@@ -1854,13 +1871,17 @@ private:
         if (*RowsRemained == 0) {
             LOG_T("TS3StreamReadActor", "StopLoadsIfEnough(consumedRows = " << consumedRows << ") sends poison");
             for (const auto actorId : CoroActors) {
-                Send(actorId, new NActors::TEvents::TEvPoison());
+                Send(actorId, new TEvents::TEvPoison());
             }
         }
     }
 
     bool ConsumedEnoughRows() const noexcept {
         return RowsRemained && *RowsRemained == 0;
+    }
+
+    void SendError(std::unique_ptr<IDqComputeActorAsyncInput::TEvAsyncInputError> ev) final {
+        Send(ComputeActorId, ev.release());
     }
 
     const TS3ReadActorFactoryConfig ReadActorFactoryCfg;
@@ -1870,10 +1891,9 @@ private:
     TPlainContainerCache ArrowTupleContainerCache;
     TPlainContainerCache ArrowRowContainerCache;
 
-    const ui64 InputIndex;
     TDqAsyncStats IngressStats;
     const TTxId TxId;
-    const NActors::TActorId ComputeActorId;
+    const TActorId ComputeActorId;
     const IHTTPGateway::TRetryPolicy::TPtr RetryPolicy;
 
     const TString Url;
@@ -1909,8 +1929,8 @@ private:
     ::NMonitoring::TDynamicCounterPtr Counters;
     ::NMonitoring::TDynamicCounterPtr TaskCounters;
     ui64 DownloadSize = 0;
-    std::set<NActors::TActorId> CoroActors;
-    NActors::TActorId FileQueueActor;
+    std::set<TActorId> CoroActors;
+    TActorId FileQueueActor;
     const ui64 FileSizeLimit;
     const ui64 ReadLimit;
     bool Bootstrapped = false;
@@ -2064,9 +2084,7 @@ NDB::FormatSettings::TimestampFormat ToTimestampFormat(const TString& formatName
     return NDB::FormatSettings::TimestampFormat::Unspecified;
 }
 
-
-
-} // namespace
+} // anonymous namespace
 
 std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
     const TTypeEnvironment& typeEnv,
@@ -2079,7 +2097,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
     const THashMap<TString, TString>& secureParams,
     const THashMap<TString, TString>& taskParams,
     const TVector<TString>& readRanges,
-    const NActors::TActorId& computeActorId,
+    const TActorId& computeActorId,
     ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory,
     const IHTTPGateway::TRetryPolicy::TPtr& retryPolicy,
     const TS3ReadActorFactoryConfig& cfg,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_source_queue.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_source_queue.cpp
@@ -1,43 +1,3 @@
-#include <util/system/platform.h>
-#if defined(_linux_) || defined(_darwin_)
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeArray.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDate.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDateTime64.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesDecimal.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeEnum.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNothing.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNullable.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeString.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeTuple.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeUUID.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesNumber.h>
-
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/ColumnsWithTypeAndName.h>
-
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatFactory.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/InputStreamFromInputFormat.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/Impl/ArrowBufferedStreams.h>
-
-#include <arrow/api.h>
-#include <arrow/io/api.h>
-#include <arrow/compute/cast.h>
-#include <arrow/status.h>
-#include <arrow/util/future.h>
-#include <parquet/arrow/reader.h>
-#include <parquet/file_reader.h>
-
-#include <library/cpp/protobuf/util/pb_io.h>
-#include <google/protobuf/text_format.h>
-
-#endif
-
-#include "yql_arrow_column_converters.h"
-#include "yql_s3_actors_util.h"
 #include "yql_s3_read_actor.h"
 #include "yql_s3_source_queue.h"
 
@@ -87,13 +47,53 @@
 #include <util/system/fstat.h>
 
 #include <algorithm>
-#include <queue>
 
 #ifdef THROW
 #undef THROW
 #endif
 #include <library/cpp/string_utils/quote/quote.h>
 #include <library/cpp/xml/document/xml-document.h>
+
+#include <util/system/platform.h>
+#if defined(_linux_) || defined(_darwin_)
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/compute/cast.h>
+#include <arrow/status.h>
+#include <arrow/util/future.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/file_reader.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+#include <google/protobuf/text_format.h>
+
+#undef NO_SANITIZE_THREAD
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeArray.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDate.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDateTime64.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesDecimal.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeEnum.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNothing.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNullable.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeString.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeTuple.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeUUID.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesNumber.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/ColumnsWithTypeAndName.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatFactory.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/InputStreamFromInputFormat.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/Impl/ArrowBufferedStreams.h>
+
+#endif
 
 #define LOG_E(name, stream) \
     LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, name << ": " << this->SelfId() << ", TxId: " << TxId << ". " << stream)

--- a/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
@@ -11,8 +11,6 @@
 #include <parquet/arrow/writer.h>
 #include <util/generic/size_literals.h>
 
-#include <ydb/library/yql/providers/s3/compressors/factory.h>  // defines NO_SANITIZE_THREAD
-
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/event_local.h>
@@ -22,6 +20,7 @@
 #include <ydb/library/services/services.pb.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h>
 #include <ydb/library/yql/providers/s3/common/util.h>
+#include <ydb/library/yql/providers/s3/compressors/factory.h>
 #include <ydb/library/yql/providers/s3/credentials/credentials.h>
 
 #include <yql/essentials/minikql/mkql_program_builder.h>

--- a/ydb/library/yql/providers/s3/common/source_context.h
+++ b/ydb/library/yql/providers/s3/common/source_context.h
@@ -4,13 +4,10 @@
 #include <memory>
 #include <mutex>
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatSettings.h>
-#include <ydb/library/yql/providers/s3/events/events.h>
-
 #include <ydb/library/actors/core/actorsystem.h>
-
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h>
+#include <ydb/library/yql/providers/s3/events/events.h>
 
 namespace NYql::NDq {
 

--- a/ydb/library/yql/providers/s3/common/util.cpp
+++ b/ydb/library/yql/providers/s3/common/util.cpp
@@ -1,8 +1,9 @@
 #include "util.h"
 
-#include <library/cpp/string_utils/quote/quote.h>
 #include <yql/essentials/core/yql_expr_type_annotation.h>
 #include <yql/essentials/minikql/dom/node.h>
+
+#include <library/cpp/string_utils/quote/quote.h>
 
 namespace NYql::NS3Util {
 
@@ -14,7 +15,7 @@ inline char d2x(unsigned x) {
 
 char* UrlEscape(char* to, const char* from) {
     while (*from) {
-        if (*from == '%' || *from == '#' || *from == '?' || (unsigned char)*from <= ' ' || (unsigned char)*from > '~') {
+        if (IsIn({'%', '#', '?', ';'}, *from) || (unsigned char)*from <= ' ' || (unsigned char)*from > '~') {
             *to++ = '%';
             *to++ = d2x((unsigned char)*from >> 4);
             *to++ = d2x((unsigned char)*from & 0xF);
@@ -188,7 +189,7 @@ bool ValidateIoSchema(TPositionHandle pos, const TStructExprType* schemaStructRo
     return !hasErrors;
 }
 
-}
+} // anonymous namespace
 
 TIssues AddParentIssue(const TString& prefix, TIssues&& issues) {
     if (!issues) {
@@ -281,4 +282,4 @@ TString TUrlBuilder::Build() const {
     return std::move(result);
 }
 
-}
+} // namespace NYql::NS3Util

--- a/ydb/library/yql/providers/s3/common/util_ut.cpp
+++ b/ydb/library/yql/providers/s3/common/util_ut.cpp
@@ -3,7 +3,6 @@
 #include <library/cpp/string_utils/quote/quote.h>
 #include <library/cpp/testing/unittest/registar.h>
 
-
 namespace NYql::NS3Util {
 
 Y_UNIT_TEST_SUITE(TestS3UrlEscape) {
@@ -24,9 +23,9 @@ Y_UNIT_TEST_SUITE(TestS3UrlEscape) {
 
     // Test additional symbols escape
     Y_UNIT_TEST(EscapeAdditionalSymbols) {
-        TString s = "hello#?world";
+        TString s = "hello#?wor;ld";
 
-        UNIT_ASSERT_VALUES_EQUAL(NS3Util::UrlEscapeRet(s), "hello%23%3Fworld");
+        UNIT_ASSERT_VALUES_EQUAL(NS3Util::UrlEscapeRet(s), "hello%23%3Fwor%3Bld");
     }
 }
 

--- a/ydb/library/yql/providers/s3/compressors/brotli.cpp
+++ b/ydb/library/yql/providers/s3/compressors/brotli.cpp
@@ -1,28 +1,52 @@
 #include "brotli.h"
 #include "output_queue_impl.h"
 
-#include <util/generic/size_literals.h>
-#include <yql/essentials/utils/exceptions.h>
-#include <yql/essentials/utils/yql_panic.h>
+#include <contrib/libs/brotli/include/brotli/decode.h>
 #include <contrib/libs/brotli/include/brotli/encode.h>
+
+#include <util/generic/size_literals.h>
+
 #include <ydb/library/yql/dq/actors/protos/dq_status_codes.pb.h>
 
-namespace NYql {
+#include <yql/essentials/utils/exceptions.h>
+#include <yql/essentials/utils/yql_panic.h>
 
-namespace NBrotli {
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+
+namespace NYql::NBrotli {
 
 namespace {
-    struct TAllocator {
-        static void* Allocate(void* /* opaque */, size_t size) {
-            return ::operator new(size);
-        }
 
-        static void Deallocate(void* /* opaque */, void* ptr) noexcept {
-            ::operator delete(ptr);
-        }
-    };
+struct TAllocator {
+    static void* Allocate(void* /* opaque */, size_t size) {
+        return ::operator new(size);
+    }
 
-}
+    static void Deallocate(void* /* opaque */, void* ptr) noexcept {
+        ::operator delete(ptr);
+    }
+};
+
+class TReadBuffer : public NDB::ReadBuffer {
+public:
+    TReadBuffer(NDB::ReadBuffer& source);
+    ~TReadBuffer();
+private:
+    bool nextImpl() final;
+
+    NDB::ReadBuffer& Source_;
+    std::vector<char> InBuffer, OutBuffer;
+
+    BrotliDecoderState* DecoderState_;
+
+    bool SubstreamFinished_ = false;
+    bool InputExhausted_ = false;
+    size_t InputAvailable_ = 0;
+    size_t InputSize_ = 0;
+
+    void InitDecoder();
+    void FreeDecoder();
+};
 
 TReadBuffer::TReadBuffer(NDB::ReadBuffer& source)
     : NDB::ReadBuffer(nullptr, 0ULL), Source_(source)
@@ -107,8 +131,6 @@ void TReadBuffer::FreeDecoder() {
     BrotliDecoderDestroyInstance(DecoderState_);
 }
 
-namespace {
-
 class TCompressor : public TOutputQueue<> {
 public:
     TCompressor(int quiality)
@@ -188,11 +210,14 @@ private:
     bool IsFirstBlock = true;
 };
 
+} // anonymous namespace
+
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source) {
+    return std::make_unique<TReadBuffer>(source);
 }
+
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel) {
     return std::make_unique<TCompressor>(cLevel.value_or(BROTLI_DEFAULT_QUALITY));
 }
 
-}
-
-}
+} // namespace NYql::NBrotli

--- a/ydb/library/yql/providers/s3/compressors/brotli.h
+++ b/ydb/library/yql/providers/s3/compressors/brotli.h
@@ -1,36 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <contrib/libs/brotli/include/brotli/decode.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NBrotli {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
+namespace NYql::NBrotli {
 
-    BrotliDecoderState* DecoderState_;
-
-    bool SubstreamFinished_ = false;
-    bool InputExhausted_ = false;
-    size_t InputAvailable_ = 0;
-    size_t InputSize_ = 0;
-
-    void InitDecoder();
-    void FreeDecoder();
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
+} // namespace NYql::NBrotli

--- a/ydb/library/yql/providers/s3/compressors/bzip2.cpp
+++ b/ydb/library/yql/providers/s3/compressors/bzip2.cpp
@@ -1,14 +1,36 @@
 #include "bzip2.h"
-
-#include <util/generic/size_literals.h>
-#include <yql/essentials/utils/exceptions.h>
-#include <yql/essentials/utils/yql_panic.h>
-#include <ydb/library/yql/dq/actors/protos/dq_status_codes.pb.h>
 #include "output_queue_impl.h"
 
-namespace NYql {
+#include <contrib/libs/libbz2/bzlib.h>
 
-namespace NBzip2 {
+#include <util/generic/size_literals.h>
+
+#include <ydb/library/yql/dq/actors/protos/dq_status_codes.pb.h>
+
+#include <yql/essentials/utils/exceptions.h>
+#include <yql/essentials/utils/yql_panic.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+
+namespace NYql::NBzip2 {
+
+namespace {
+
+class TReadBuffer : public NDB::ReadBuffer {
+public:
+    TReadBuffer(NDB::ReadBuffer& source);
+    ~TReadBuffer();
+private:
+    bool nextImpl() final;
+
+    NDB::ReadBuffer& Source_;
+    std::vector<char> InBuffer, OutBuffer;
+
+    bz_stream BzStream_;
+
+    void InitDecoder();
+    void FreeDecoder();
+};
 
 TReadBuffer::TReadBuffer(NDB::ReadBuffer& source)
     : NDB::ReadBuffer(nullptr, 0ULL), Source_(source)
@@ -63,8 +85,6 @@ bool TReadBuffer::nextImpl() {
         }
     }
 }
-
-namespace {
 
 class TCompressor : public TOutputQueue<> {
 public:
@@ -134,12 +154,14 @@ private:
     TOutputQueue<0> InputQueue;
 };
 
+} // anonymous namespace
+
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source) {
+    return std::make_unique<TReadBuffer>(source);
 }
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> blockSize100k) {
     return std::make_unique<TCompressor>(blockSize100k.value_or(9));
 }
 
-}
-
-}
+} // namespace NYql::NBzip2

--- a/ydb/library/yql/providers/s3/compressors/bzip2.h
+++ b/ydb/library/yql/providers/s3/compressors/bzip2.h
@@ -1,32 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <contrib/libs/libbz2/bzlib.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NBzip2 {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
+namespace NYql::NBzip2 {
 
-    bz_stream BzStream_;
-
-    void InitDecoder();
-    void FreeDecoder();
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> blockSize100k = {});
 
-}
-
-}
-
+} // namespace NYql::NBzip2

--- a/ydb/library/yql/providers/s3/compressors/factory.cpp
+++ b/ydb/library/yql/providers/s3/compressors/factory.cpp
@@ -1,13 +1,15 @@
 #include "factory.h"
 
 #if defined(_win_)
+
 namespace NYql {
 
 IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& /*compression*/) {
     return {};
 }
 
-}
+} // namespace NYql
+
 #else
 
 #include "lz4io.h"
@@ -18,44 +20,59 @@ IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& /*compression*/) 
 #include "gz.h"
 #include "output_queue_impl.h"
 
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+
 namespace NYql {
 
 std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& input, const std::string_view& compression) {
-    if ("lz4" == compression)
-        return std::make_unique<NLz4::TReadBuffer>(input);
-    if ("brotli" == compression)
-        return std::make_unique<NBrotli::TReadBuffer>(input);
-    if ("zstd" == compression)
-        return std::make_unique<NZstd::TReadBuffer>(input);
-    if ("bzip2" == compression)
-        return std::make_unique<NBzip2::TReadBuffer>(input);
-    if ("xz" == compression)
-        return std::make_unique<NXz::TReadBuffer>(input);
-    if ("gzip" == compression)
-        return std::make_unique<NGz::TReadBuffer>(input);
+    if ("lz4" == compression) {
+        return NLz4::MakeDecompressor(input);
+    }
+    if ("brotli" == compression) {
+        return NBrotli::MakeDecompressor(input);
+    }
+    if ("zstd" == compression) {
+        return NZstd::MakeDecompressor(input);
+    }
+    if ("bzip2" == compression) {
+        return NBzip2::MakeDecompressor(input);
+    }
+    if ("xz" == compression) {
+        return NXz::MakeDecompressor(input);
+    }
+    if ("gzip" == compression) {
+        return NGz::MakeDecompressor(input);
+    }
 
     return nullptr;
 }
 
 IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& compression) {
-    if ("lz4" == compression)
+    if ("lz4" == compression) {
         return NLz4::MakeCompressor();
-    if ("brotli" == compression)
+    }
+    if ("brotli" == compression) {
         return NBrotli::MakeCompressor();
-    if ("zstd" == compression)
+    }
+    if ("zstd" == compression) {
         return  NZstd::MakeCompressor();
-    if ("bzip2" == compression)
+    }
+    if ("bzip2" == compression) {
         return  NBzip2::MakeCompressor();
-    if ("xz" == compression)
+    }
+    if ("xz" == compression) {
         return NXz::MakeCompressor();
-    if ("gzip" == compression)
+    }
+    if ("gzip" == compression) {
         return NGz::MakeCompressor();
-
-    if (compression.empty())
+    }
+    if (compression.empty()) {
         return std::make_unique<TOutputQueue<5_MB>>();
+    }
 
     return {};
 }
 
-}
+} // namespace NYql
+
 #endif

--- a/ydb/library/yql/providers/s3/compressors/factory.h
+++ b/ydb/library/yql/providers/s3/compressors/factory.h
@@ -1,15 +1,23 @@
 #pragma once
+
 #include "output_queue.h"
 
 #if defined(_win_)
+
 namespace NYql {
 
 IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& compression);
 
-}
+} // namespace NYql
+
 #else
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+namespace NDB {
+
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
+
+} // namespace NDB
 
 namespace NYql {
 
@@ -17,5 +25,6 @@ std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& input, const 
 
 IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& compression);
 
-}
+} // namespace NYql
+
 #endif

--- a/ydb/library/yql/providers/s3/compressors/gz.h
+++ b/ydb/library/yql/providers/s3/compressors/gz.h
@@ -1,29 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <zlib.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NGz {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
+namespace NYql::NGz {
 
-    z_stream Z_;
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
-
+} // namespace NYql::NGz

--- a/ydb/library/yql/providers/s3/compressors/lz4io.h
+++ b/ydb/library/yql/providers/s3/compressors/lz4io.h
@@ -1,42 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#define LZ4F_STATIC_LINKING_ONLY
-#include <contrib/libs/lz4/lz4frame.h>
-
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NLz4 {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-enum class EStreamType {
-    Unknown = 0,
-    Frame,
-    Legacy
-};
+} // namespace NDB
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+namespace NYql::NLz4 {
 
-    size_t DecompressFrame();
-    size_t DecompressLegacy();
-
-    NDB::ReadBuffer& Source;
-    const EStreamType StreamType;
-    std::vector<char> InBuffer, OutBuffer;
-
-    LZ4F_decompressionContext_t Ctx;
-    LZ4F_errorCode_t NextToLoad;
-    size_t Pos, Remaining;
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
+} // namespace NYql::NLz4

--- a/ydb/library/yql/providers/s3/compressors/ut/decompressor_ut.cpp
+++ b/ydb/library/yql/providers/s3/compressors/ut/decompressor_ut.cpp
@@ -1,9 +1,10 @@
 #include <ydb/library/yql/providers/s3/compressors/lz4io.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
 
 #include <library/cpp/scheme/scheme.h>
 #include <library/cpp/testing/common/env.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
 
 namespace NYql::NCompressors {
 
@@ -16,7 +17,7 @@ namespace {
 Y_UNIT_TEST_SUITE(TCompressorTests) {
     Y_UNIT_TEST(SuccessLz4) {
         NDB::ReadBufferFromFile buffer(GetResourcePath("test.json.lz4"));
-        auto decompressorBuffer = std::make_unique<NLz4::TReadBuffer>(buffer);
+        auto decompressorBuffer = NLz4::MakeDecompressor(buffer);
 
         char str[256] = {};
         decompressorBuffer->read(str, 256);
@@ -31,12 +32,12 @@ Y_UNIT_TEST_SUITE(TCompressorTests) {
 
     Y_UNIT_TEST(WrongMagicLz4) {
         NDB::ReadBufferFromFile buffer(GetResourcePath("test.json"));
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::make_unique<NLz4::TReadBuffer>(buffer), yexception, "Wrong magic.");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(NLz4::MakeDecompressor(buffer), yexception, "Wrong magic.");
     }
 
     Y_UNIT_TEST(ErrorLz4) {
         NDB::ReadBufferFromFile buffer(GetResourcePath("test.broken.lz4"));
-        auto decompressorBuffer = std::make_unique<NLz4::TReadBuffer>(buffer);
+        auto decompressorBuffer = NLz4::MakeDecompressor(buffer);
         char str[256] = {};
         UNIT_ASSERT_EXCEPTION_CONTAINS(decompressorBuffer->read(str, 256), yexception, "Decompression error: ERROR_reservedFlag_set");
     }

--- a/ydb/library/yql/providers/s3/compressors/xz.h
+++ b/ydb/library/yql/providers/s3/compressors/xz.h
@@ -1,32 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <contrib/libs/lzma/liblzma/api/lzma.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NXz {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
+namespace NYql::NXz {
 
-    lzma_stream Strm_;
-
-    bool IsInFinished_ = false;
-    bool IsOutFinished_ = false;
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
-
+} // namespace NYql::NXz

--- a/ydb/library/yql/providers/s3/compressors/ya.make
+++ b/ydb/library/yql/providers/s3/compressors/ya.make
@@ -1,4 +1,5 @@
 LIBRARY()
+
 PEERDIR(
     contrib/libs/fmt
     contrib/libs/poco/Util

--- a/ydb/library/yql/providers/s3/compressors/zstd.h
+++ b/ydb/library/yql/providers/s3/compressors/zstd.h
@@ -1,31 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#define ZSTD_STATIC_LINKING_ONLY
-#include <contrib/libs/zstd/include/zstd.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NZstd {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
-    ::ZSTD_DStream *const ZCtx_;
-    size_t Offset_;
-    size_t Size_;
-    bool Finished_ = false;
-};
+namespace NYql::NZstd {
+
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
+} // namespace NYql::NZstd

--- a/ydb/library/yql/providers/s3/events/events.cpp
+++ b/ydb/library/yql/providers/s3/events/events.cpp
@@ -1,1 +1,17 @@
 #include "events.h"
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
+
+namespace NYql::NDq {
+
+TEvS3Provider::TEvNextBlock::TEvNextBlock(NDB::Block& block, size_t pathInd, ui64 ingressDelta, TDuration cpuTimeDelta, ui64 ingressDecompressedDelta)
+    : Block(std::make_unique<NDB::Block>())
+    , PathIndex(pathInd)
+    , IngressDelta(ingressDelta)
+    , CpuTimeDelta(cpuTimeDelta)
+    , IngressDecompressedDelta(ingressDecompressedDelta)
+{
+    Block->swap(block);
+}
+
+} // namespace NYql::NDq

--- a/ydb/library/yql/providers/s3/events/events.h
+++ b/ydb/library/yql/providers/s3/events/events.h
@@ -10,9 +10,14 @@
 #include <yql/essentials/public/issue/yql_issue_message.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
-
 #include <arrow/api.h>
+
+namespace NDB {
+
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
+class Block;
+
+} // namespace NDB
 
 namespace NYql::NDq {
 
@@ -176,11 +181,9 @@ struct TEvS3Provider {
     };
 
     struct TEvNextBlock : public NActors::TEventLocal<TEvNextBlock, EvNextBlock> {
-        TEvNextBlock(NDB::Block& block, size_t pathInd, ui64 ingressDelta, TDuration cpuTimeDelta, ui64 ingressDecompressedDelta = 0)
-            : PathIndex(pathInd), IngressDelta(ingressDelta), CpuTimeDelta(cpuTimeDelta), IngressDecompressedDelta(ingressDecompressedDelta) {
-            Block.swap(block);
-        }
-        NDB::Block Block;
+        TEvNextBlock(NDB::Block& block, size_t pathInd, ui64 ingressDelta, TDuration cpuTimeDelta, ui64 ingressDecompressedDelta = 0);
+
+        std::unique_ptr<NDB::Block> Block;
         const size_t PathIndex;
         const ui64 IngressDelta;
         const TDuration CpuTimeDelta;

--- a/ydb/library/yql/providers/s3/serializations/serialization_interval.cpp
+++ b/ydb/library/yql/providers/s3/serializations/serialization_interval.cpp
@@ -1,13 +1,13 @@
 #include "serialization_interval.h"
 
+#include <util/generic/serialized_enum.h>
+
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/Serializations/SerializationNumber.h>
 
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadHelpers.h>
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/WriteHelpers.h>
-
-#include <util/generic/serialized_enum.h>
 
 namespace NYql::NSerialization {
 

--- a/ydb/library/yql/udfs/common/clickhouse/client/base/common/defines.h
+++ b/ydb/library/yql/udfs/common/clickhouse/client/base/common/defines.h
@@ -46,45 +46,45 @@
 #endif
 
 /// Check for presence of address sanitizer
-#if !defined(ADDRESS_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(address_sanitizer)
-#            define ADDRESS_SANITIZER 1
-#        endif
-#    elif defined(__SANITIZE_ADDRESS__)
-#        define ADDRESS_SANITIZER 1
-#    endif
-#endif
+// #if !defined(ADDRESS_SANITIZER)
+// #    if defined(ch_has_feature)
+// #        if ch_has_feature(address_sanitizer)
+// #            define ADDRESS_SANITIZER 1
+// #        endif
+// #    elif defined(__SANITIZE_ADDRESS__)
+// #        define ADDRESS_SANITIZER 1
+// #    endif
+// #endif
 
-#if !defined(THREAD_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(thread_sanitizer)
-#            define THREAD_SANITIZER 1
-#        endif
-#    elif defined(__SANITIZE_THREAD__)
-#        define THREAD_SANITIZER 1
-#    endif
-#endif
+// #if !defined(THREAD_SANITIZER)
+// #    if defined(ch_has_feature)
+// #        if ch_has_feature(thread_sanitizer)
+// #            define THREAD_SANITIZER 1
+// #        endif
+// #    elif defined(__SANITIZE_THREAD__)
+// #        define THREAD_SANITIZER 1
+// #    endif
+// #endif
 
-#if !defined(MEMORY_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(memory_sanitizer)
-#            define MEMORY_SANITIZER 1
-#        endif
-#    elif defined(__MEMORY_SANITIZER__)
-#        define MEMORY_SANITIZER 1
-#    endif
-#endif
+// #if !defined(MEMORY_SANITIZER)
+// #    if defined(ch_has_feature)
+// #        if ch_has_feature(memory_sanitizer)
+// #            define MEMORY_SANITIZER 1
+// #        endif
+// #    elif defined(__MEMORY_SANITIZER__)
+// #        define MEMORY_SANITIZER 1
+// #    endif
+// #endif
 
-#if !defined(UNDEFINED_BEHAVIOR_SANITIZER)
-#    if defined(__has_feature)
-#        if __has_feature(undefined_behavior_sanitizer)
-#            define UNDEFINED_BEHAVIOR_SANITIZER 1
-#        endif
-#    elif defined(__UNDEFINED_BEHAVIOR_SANITIZER__)
-#        define UNDEFINED_BEHAVIOR_SANITIZER 1
-#    endif
-#endif
+// #if !defined(UNDEFINED_BEHAVIOR_SANITIZER)
+// #    if defined(__has_feature)
+// #        if __has_feature(undefined_behavior_sanitizer)
+// #            define UNDEFINED_BEHAVIOR_SANITIZER 1
+// #        endif
+// #    elif defined(__UNDEFINED_BEHAVIOR_SANITIZER__)
+// #        define UNDEFINED_BEHAVIOR_SANITIZER 1
+// #    endif
+// #endif
 
 #if defined(ADDRESS_SANITIZER)
 #    define BOOST_USE_ASAN 1

--- a/ydb/tests/tools/s3_recipe/.gitignore
+++ b/ydb/tests/tools/s3_recipe/.gitignore
@@ -1,0 +1,3 @@
+*.json
+*.log
+*.pid


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Unmuted tests ExecuteScriptWithExternalTableResolve and ExecuteScriptWithExternalTableResolveCheckPartitionedBy on s3 url escaping

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->
