### PR TITLE
Set and show pdisk maintenance status in dstool

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_pdisk_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pdisk_list.py
@@ -26,6 +26,7 @@ def do(args):
         'Type',
         'Status',
         'DecommitStatus',
+        'MaintenanceStatus',
         'Kind',
         'BoxId',
         'Guid',
@@ -49,6 +50,7 @@ def do(args):
         'Type',
         'Status',
         'DecommitStatus',
+        'MaintenanceStatus',
     ]
     col_units = {
         'Usage': '%',
@@ -84,6 +86,7 @@ def do(args):
         row['Path'] = pdisk.Path
         row['Status'] = kikimr_bsconfig.EDriveStatus.Name(pdisk.DriveStatus)
         row['DecommitStatus'] = kikimr_bsconfig.EDecommitStatus.Name(pdisk.DecommitStatus)
+        row['MaintenanceStatus'] = kikimr_bsconfig.TMaintenanceStatus.E.Name(pdisk.MaintenanceStatus)
         row['Type'] = common.EPDiskType.Name(pdisk.Type)
         row['BoxId'] = pdisk.BoxId
         row['Kind'] = pdisk.Kind

--- a/ydb/apps/dstool/lib/dstool_cmd_pdisk_set.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pdisk_set.py
@@ -12,6 +12,8 @@ def add_options(p):
     g.add_argument('--status', type=str, choices=statuses, help='Set status')
     decommit_statuses = kikimr_bsconfig.EDecommitStatus.keys()
     g.add_argument('--decommit-status', type=str, choices=decommit_statuses, help='Set decomission status')
+    maintenance_statuses = kikimr_bsconfig.TMaintenanceStatus.E.keys()
+    g.add_argument('--maintenance-status', type=str, choices=maintenance_statuses, help='Set maintenance status')
     common.add_allow_unusable_pdisks_option(p)
     p.add_argument('--allow-working-disks', action='store_true', help='Allow settlement even if any of enlisted PDisks is still working')
     common.add_ignore_degraded_group_check_option(p)
@@ -34,6 +36,8 @@ def create_request(args, pdisks, node_id_to_host):
             cmd.Status = kikimr_bsconfig.EDriveStatus.Value(args.status)
         if args.decommit_status is not None:
             cmd.DecommitStatus = kikimr_bsconfig.EDecommitStatus.Value(args.decommit_status)
+        if args.maintenance_status is not None:
+            cmd.MaintenanceStatus = kikimr_bsconfig.TMaintenanceStatus.E.Value(args.maintenance_status)
 
     return request
 

--- a/ydb/core/mind/bscontroller/monitoring.cpp
+++ b/ydb/core/mind/bscontroller/monitoring.cpp
@@ -1136,6 +1136,8 @@ void TBlobStorageController::RenderInternalTables(IOutputStream& out, const TStr
                         TABLEH() { out << "Total Size"; }
                         TABLEH() { out << "Status"; }
                         TABLEH() { out << "State"; }
+                        TABLEH() { out << "Decommit status"; }
+                        TABLEH() { out << "Maintenance status"; }
                         TABLEH() { out << "ExpectedSerial"; }
                         TABLEH() { out << "LastSeenSerial"; }
                         TABLEH() { out << "LastSeenPath"; }
@@ -1159,6 +1161,8 @@ void TBlobStorageController::RenderInternalTables(IOutputStream& out, const TStr
                                     out << NKikimrBlobStorage::TPDiskState::E_Name(m.GetState());
                                 }
                             }
+                            TABLED() { out << NKikimrBlobStorage::EDecommitStatus_Name(pdisk->DecommitStatus); }
+                            TABLED() { out << NKikimrBlobStorage::TMaintenanceStatus::E_Name(pdisk->MaintenanceStatus); }
                             TABLED() { out << pdisk->ExpectedSerial.Quote(); }
                             TABLED() {
                                 TString color = pdisk->ExpectedSerial == pdisk->LastSeenSerial ? "green" : "red";

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -235,7 +235,7 @@ message TMaintenanceStatus {
     enum E {
         NOT_SET = 0;                        // unset status, default value
         NO_REQUEST = 1;                     // no active maintenance request
-        LONG_TERM_MAINTENANCE_PLANNED = 2;  // maintence requested, VDisks should be moved asynchronously from PDisk
+        LONG_TERM_MAINTENANCE_PLANNED = 2;  // maintenance requested, VDisks should be moved asynchronously from PDisk
         NO_NEW_VDISKS = 3;                  // no new VDisks should be allocated on this PDisk, but existing ones are not moved
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Set and show pdisk maintenance status in dstool. Show maintenance and decommit status in blobstorage controller internal table.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
