### PR TITLE
Fix unmute tests rules (4 days thresholds -> 7 days)

### DIFF
--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -6,10 +6,9 @@
 - **2 or more failures**
 - **OR** 1 failure and runs (pass + fail) not more than 10
 
-### Unmute a test if in the last 4 days:
-- **Runs (pass + fail + mute) > 4**
+### Unmute a test if in the last 7 days:
+- **Runs (pass + fail + mute) >= 4**
 - **AND no failures (fail + mute = 0)**
-- **AND no `no_runs` states in history** (test ran consistently)
 
 ### Remove from mute if in the last 7 days:
 - **No runs at all** (pass + fail + mute + skip = 0)
@@ -17,7 +16,7 @@
 ---
 
 ### Notes
-- For all rules, only the last N days are considered (N=3 for mute, N=4 for unmute, N=7 for delete), including the current day.
+- For all rules, only the last N days are considered (N=4 for mute, N=7 for unmute, N=7 for delete), including the current day.
 - A "run" is any test execution with result pass, fail, or mute.
 - A "failure" is a test execution with result fail or mute.
 - Statistics aggregation is done by key (test_name, suite_folder, full_name, build_type, branch).
@@ -26,8 +25,7 @@
 
 **Example:**
 - If a test ran 5 times in 3 days with 2 failures — the test will be muted.
-- If a test ran 5 times in 4 days and all passed successfully, and there were no days without runs — the test will be unmuted.
-- If a test ran 5 times in 4 days and all passed successfully, but there was a day without runs (`no_runs`) — the test will NOT be unmuted.
+- If a test ran 4 times in 7 days and all passed successfully — the test will be unmuted.
 - If a test didn't run at all in 7 days — it will be removed from mute.
 
 ## 🔄 Automated Workflow
@@ -94,7 +92,7 @@ For analyzing test status, finding mute/unmute candidates, and tracking stabilit
 
 ### 🔊 [to_unmute.txt](mute_update/to_unmute.txt)
 **Content:** Unmute candidates by new rules  
-**Rules:** In 4 days >4 runs (pass+fail+mute), no failures (fail+mute=0), and no `no_runs` states  
+**Rules:** In 7 days ≥4 runs (pass+fail+mute), no failures (fail+mute=0)  
 **Usage:** Main file for unmute decisions
 
 ### 🗑️ [to_remove_from_mute.txt](mute_update/to_remove_from_mute.txt)
@@ -162,7 +160,7 @@ This table shows all files created by the mute logic script, with descriptions o
 | File | Description | Rules | Usage |
 |------|----------|---------|---------------|
 | `to_mute.txt` | Mute candidates | In 4 days ≥2 failures **OR** (≥1 failure and runs ≤10) | Main file for mute decisions |
-| `to_unmute.txt` | Unmute candidates | In 4 days >4 runs (pass+fail+mute), no failures (fail+mute=0), and no `no_runs` states | Main file for unmute decisions |
+| `to_unmute.txt` | Unmute candidates | In 7 days ≥4 runs (pass+fail+mute), no failures (fail+mute=0) | Main file for unmute decisions |
 | `to_remove_from_mute.txt` | Tests to remove from mute | No runs in 7 days | Main file for removal from mute |
 
 ## 📊 Additional analysis files

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -36,7 +36,7 @@ DATABASE_PATH = config["QA_DB"]["DATABASE_PATH"]
 
 # Константы для временных окон mute-логики
 MUTE_DAYS = 4
-UNMUTE_DAYS = 4
+UNMUTE_DAYS = 7
 DELETE_DAYS = 7
 
 def is_chunk_test(test):
@@ -384,16 +384,11 @@ def is_unmute_candidate(test, aggregated_data):
     total_runs = test_data['pass_count'] + test_data['fail_count'] + test_data['mute_count']
     total_fails = test_data['fail_count'] + test_data['mute_count']
     
-    # Проверяем, что не было состояний no_runs в истории
-    state_history = test_data.get('state', [])
-    if 'no_runs' in state_history:
-        return False
-    
-    result = total_runs > 4 and total_fails == 0
+    result = total_runs >= 4 and total_fails == 0
     
     # Добавляем детальное логирование для диагностики
     if test_data.get('is_muted', False):  # Логируем только для замьюченных тестов
-        logging.debug(f"UNMUTE_CHECK: {test.get('full_name')} - runs:{total_runs}, fails:{total_fails}, muted:{test_data.get('is_muted')}, result:{result}")
+        logging.debug(f"UNMUTE_CHECK: {test.get('full_name')} - runs:{total_runs}, fails:{total_fails}, mute_count:{test_data['mute_count']}, state:{test_data.get('state')}, muted:{test_data.get('is_muted')}, result:{result}")
     
     return result
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

# Без этих изменений приводило что large тесты выполняющиеся успешно (1 раз в день) не набирали **больше** 4х запусков за 4 дня => оставались замьюченными

## 🔧 Улучшение логики размьюта тестов

### 📋 Изменения в коде:
- Увеличено временное окно для размьюта с **4 до 7 дней** (`UNMUTE_DAYS = 7`)
- Изменено условие размьюта с `> 4` на `>= 4` запуска
- Убрана избыточная проверка состояний `no_runs` (дублировала проверку количества запусков)
- Добавлено `state` в debug-логирование для лучшей диагностики

### 📖 Обновлена документация:
- Актуализированы правила размьюта в `mute_rules.md`
- Обновлены примеры и описания файлов
- Упрощены условия без потери функциональности

### 🎯 Результат:
- **Более справедливые условия:** тесты с 4+ стабильными запусками за 7 дней будут размьючиваться
- **Упрощенная логика:** фокус на реальной стабильности вместо формальных ограничений
- **Лучшая диагностика:** больше информации в логах для отладки

### ✅ Финальные правила размьюта:
- ≥4 запуска за последние 7 дней
- 0 неудач (fail + mute = 0)
### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
