### PR TITLE
Fix UMU in TStateStorageRingGroupProxyRequest

### DIFF
--- a/ydb/core/base/statestorage_proxy.cpp
+++ b/ydb/core/base/statestorage_proxy.cpp
@@ -794,6 +794,12 @@ public:
     TStateStorageRingGroupProxyRequest(TIntrusivePtr<TStateStorageInfo> info)
         : Info(info)
         , RingGroupPassAwayCounter(0)
+        , TabletID(0)
+        , Cookie(0)
+        , CurrentGeneration(0)
+        , CurrentStep(0)
+        , Locked(false)
+        , LockedFor(0)
     {
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

When TStateStorageRingGroupProxyRequest reply ERROR TEvInfo contains uninitialized fields which is used in log and tracing before message status checked

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
