### PR TITLE
Split ydb/library/yql/dq/comp_nodes into llvm16 and no_llvm forks

### DIFF
--- a/ydb/core/fq/libs/init/ya.make
+++ b/ydb/core/fq/libs/init/ya.make
@@ -34,7 +34,6 @@ PEERDIR(
     ydb/library/security
     ydb/library/yql/dq/actors/compute
     ydb/library/yql/dq/actors/input_transforms
-    ydb/library/yql/dq/comp_nodes
     ydb/library/yql/dq/transform
     yql/essentials/minikql/comp_nodes
     yql/essentials/providers/common/comp_nodes

--- a/ydb/library/yql/dq/actors/compute/ut/ya.make
+++ b/ydb/library/yql/dq/actors/compute/ut/ya.make
@@ -25,7 +25,7 @@ PEERDIR(
     ydb/library/yql/dq/actors/compute/ut/proto
     ydb/library/yql/dq/actors/input_transforms
     ydb/library/yql/dq/actors/task_runner
-    ydb/library/yql/dq/comp_nodes
+    ydb/library/yql/dq/comp_nodes/no_llvm
     ydb/library/yql/dq/tasks
     ydb/library/yql/dq/transform
     ydb/library/yql/providers/dq/task_runner

--- a/ydb/library/yql/dq/comp_nodes/llvm16/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/llvm16/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+INCLUDE(../ya.make.inc)
+
+PEERDIR(
+    yql/essentials/minikql/comp_nodes/llvm16
+    yql/essentials/minikql/computation/llvm16
+    yql/essentials/minikql/codegen/llvm16
+    yql/essentials/minikql/invoke_builtins/llvm16
+)
+
+END()

--- a/ydb/library/yql/dq/comp_nodes/no_llvm/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/no_llvm/ya.make
@@ -1,0 +1,14 @@
+LIBRARY()
+
+CXXFLAGS(-DMKQL_DISABLE_CODEGEN)
+
+INCLUDE(../ya.make.inc)
+
+PEERDIR(
+    yql/essentials/minikql/comp_nodes/no_llvm
+    yql/essentials/minikql/computation/no_llvm
+    yql/essentials/minikql/codegen/no_llvm
+    yql/essentials/minikql/invoke_builtins/no_llvm
+)
+
+END()

--- a/ydb/library/yql/dq/comp_nodes/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS()
 
+# TODO: Migrate all dependents to explicit llvm16/no_llvm and remove this peerdir
 PEERDIR(
     ydb/library/yql/dq/comp_nodes/llvm16
 )

--- a/ydb/library/yql/dq/comp_nodes/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/ya.make
@@ -1,31 +1,16 @@
 LIBRARY()
 
+SRCS()
+
 PEERDIR(
-    ydb/library/actors/core
-    ydb/library/yql/dq/actors/compute
-    ydb/library/yql/dq/comp_nodes/hash_join_utils
-    ydb/library/yql/dq/runtime
-    yql/essentials/minikql/comp_nodes
-    yql/essentials/minikql/computation
-    yql/essentials/utils
+    ydb/library/yql/dq/comp_nodes/llvm16
 )
-
-SRCS(
-    yql_common_dq_factory.cpp
-    dq_hash_aggregate.cpp
-    dq_hash_combine.cpp
-    dq_hash_operator_common.cpp
-    dq_hash_operator_serdes.cpp
-    dq_program_builder.cpp
-    dq_block_hash_join.cpp
-    dq_scalar_hash_join.cpp
-)
-
-
-YQL_LAST_ABI_VERSION()
-
 
 END()
+
+RECURSE(
+    llvm16
+)
 
 RECURSE_FOR_TESTS(
     ut

--- a/ydb/library/yql/dq/comp_nodes/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/ya.make
@@ -10,6 +10,7 @@ END()
 
 RECURSE(
     llvm16
+    no_llvm
 )
 
 RECURSE_FOR_TESTS(

--- a/ydb/library/yql/dq/comp_nodes/ya.make.inc
+++ b/ydb/library/yql/dq/comp_nodes/ya.make.inc
@@ -1,0 +1,41 @@
+INCLUDE(${ARCADIA_ROOT}/yql/essentials/minikql/computation/header.ya.make.inc)
+
+PEERDIR(
+    ydb/library/actors/core
+    ydb/library/yql/dq/actors/compute
+    ydb/library/yql/dq/comp_nodes/hash_join_utils
+    ydb/library/yql/dq/runtime
+    yql/essentials/minikql/comp_nodes
+    yql/essentials/minikql/computation
+    yql/essentials/minikql/invoke_builtins
+    yql/essentials/utils
+)
+
+SET(ORIG_SRC_DIR ${ARCADIA_ROOT}/ydb/library/yql/dq/comp_nodes)
+
+SET(ORIG_SOURCES
+    yql_common_dq_factory.cpp
+    dq_hash_aggregate.cpp
+    dq_hash_combine.cpp
+    dq_hash_operator_common.cpp
+    dq_hash_operator_serdes.cpp
+    dq_program_builder.cpp
+    dq_block_hash_join.cpp
+    dq_scalar_hash_join.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+ADDINCL(
+    ${ORIG_SRC_DIR}
+)
+
+COPY(
+    WITH_CONTEXT
+    AUTO
+    FROM ${ORIG_SRC_DIR}
+    ${ORIG_SOURCES}
+    OUTPUT_INCLUDES
+       ${BINDIR}/yql/essentials/minikql/computation/mkql_computation_node_codegen.h
+       ${BINDIR}/yql/essentials/minikql/computation/mkql_llvm_base.h
+)

--- a/ydb/library/yql/dq/comp_nodes/ya.make.inc
+++ b/ydb/library/yql/dq/comp_nodes/ya.make.inc
@@ -39,3 +39,5 @@ COPY(
        ${BINDIR}/yql/essentials/minikql/computation/mkql_computation_node_codegen.h
        ${BINDIR}/yql/essentials/minikql/computation/mkql_llvm_base.h
 )
+
+PROVIDES(YDB_DQ_COMP_NODES)

--- a/ydb/library/yql/providers/dq/local_gateway/ut/ya.make
+++ b/ydb/library/yql/providers/dq/local_gateway/ut/ya.make
@@ -7,7 +7,7 @@ SRCS(
 PEERDIR(
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy
-    ydb/library/yql/dq/comp_nodes
+    ydb/library/yql/dq/comp_nodes/no_llvm
     ydb/library/yql/dq/runtime
     ydb/library/yql/providers/dq/local_gateway
     ydb/library/yql/dq/transform

--- a/ydb/library/yql/tools/dqrun/lib/ya.make
+++ b/ydb/library/yql/tools/dqrun/lib/ya.make
@@ -67,7 +67,6 @@ PEERDIR(
     ydb/library/yql/providers/common/http_gateway
     ydb/library/yql/providers/common/db_id_async_resolver
 
-    ydb/library/yql/dq/comp_nodes
     ydb/library/yql/dq/opt
     ydb/library/yql/dq/transform
     ydb/library/yql/dq/actors/compute

--- a/ydb/library/yql/tools/dqrun/ya.make
+++ b/ydb/library/yql/tools/dqrun/ya.make
@@ -36,6 +36,7 @@ IF (NOT OS_WINDOWS)
         library/cpp/lfalloc/alloc_profiler
 
         ydb/library/yql/udfs/common/clickhouse/client
+        ydb/library/yql/dq/comp_nodes/llvm16
         ydb/public/sdk/cpp/src/client/persqueue_public/codecs
     )
 

--- a/ydb/tools/query_replay/common_deps.inc
+++ b/ydb/tools/query_replay/common_deps.inc
@@ -62,6 +62,7 @@ SET(YDB_REPLAY_PEERDIRS
     ydb/services/persqueue_v1
     ydb/services/rate_limiter
     ydb/services/ydb
+    ydb/library/yql/dq/comp_nodes/llvm16
     ydb/library/yql/udfs/common/clickhouse/client
     ydb/library/yql/udfs/common/datetime
     yql/essentials/udfs/common/datetime2


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This is a pre-requisite for LLVM codegen in DQ nodes.

The library is cloned into two implementations - one is linked with LLVM, the other is not, following the convention set in yql/essentials/minikql/comp_nodes/{llvm16,no_llvm}/ya.make

NB: llvm16 is in PEERDIR by default for most of the existing uses, I'll update dependents and remove the default PEERDIR in a separate PR.