### PR TITLE
Automatic checksumming decision for DSProxy/VDisk interaction

### DIFF
--- a/ydb/core/blobstorage/backpressure/queue_backpressure_client.h
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_client.h
@@ -17,14 +17,16 @@ namespace NKikimr {
         NKikimrBlobStorage::EVDiskQueueId QueueId;
         bool IsConnected;
         bool ExtraBlockChecksSupport;
+        bool Checksumming;
         std::shared_ptr<const TCostModel> CostModel;
 
         TEvProxyQueueState(const TVDiskID &vDiskId, NKikimrBlobStorage::EVDiskQueueId queueId, bool isConnected,
-                bool extraBlockChecksSupport, std::shared_ptr<const TCostModel> costModel)
+                bool extraBlockChecksSupport, bool checksumming, std::shared_ptr<const TCostModel> costModel)
             : VDiskId(vDiskId)
             , QueueId(queueId)
             , IsConnected(isConnected)
             , ExtraBlockChecksSupport(extraBlockChecksSupport)
+            , Checksumming(checksumming)
             , CostModel(std::move(costModel))
         {}
 
@@ -34,6 +36,7 @@ namespace NKikimr {
             str << " QueueId# " << static_cast<ui32>(QueueId);
             str << " IsConnected# " << (IsConnected ? "true" : "false");
             str << " ExtraBlockChecksSupport# " << (ExtraBlockChecksSupport ? "true" : "false");
+            str << " Checksumming# " << (Checksumming ? "true" : "false");
             if (CostModel) {
                 str << " CostModel# " << CostModel->ToString();
             }

--- a/ydb/core/blobstorage/backpressure/ut_client/loader.h
+++ b/ydb/core/blobstorage/backpressure/ut_client/loader.h
@@ -54,7 +54,7 @@ public:
             LOG_DEBUG(*TlsActivationContext, NActorsServices::TEST, "%s %s", ClientId.ToString().data(),
                 blobId.ToString().data());
             Send(QueueId, new TEvBlobStorage::TEvVPut(blobId, TRope(Buffer), VDiskId, false, nullptr, TInstant::Max(),
-                NKikimrBlobStorage::EPutHandleClass::TabletLog));
+                NKikimrBlobStorage::EPutHandleClass::TabletLog, false));
             RequestQ.push_back(blobId);
             --InFlightRemain;
         }

--- a/ydb/core/blobstorage/backpressure/ut_client/skeleton_front_mock.h
+++ b/ydb/core/blobstorage/backpressure/ut_client/skeleton_front_mock.h
@@ -55,7 +55,7 @@ public:
         if (!Ready && record.GetNotifyIfNotReady()) {
             Notify.insert(ev->Sender);
         }
-        Reply(*ev, new TEvBlobStorage::TEvVCheckReadinessResult(Ready ? NKikimrProto::OK : NKikimrProto::NOTREADY));
+        Reply(*ev, new TEvBlobStorage::TEvVCheckReadinessResult(Ready ? NKikimrProto::OK : NKikimrProto::NOTREADY, false));
     }
 
     void Handle(TEvBlobStorage::TEvVStatus::TPtr ev) {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_blackboard.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_blackboard.h
@@ -184,7 +184,7 @@ struct TBlackboard {
     TBlobStates DoneBlobStates;
     TGroupDiskRequests GroupDiskRequests;
     TIntrusivePtr<TBlobStorageGroupInfo> Info;
-    TIntrusivePtr<TGroupQueues> GroupQueues; // To obtain FlowRecords only
+    TIntrusivePtr<TGroupQueues> GroupQueues;
     EAccelerationMode AccelerationMode;
     const NKikimrBlobStorage::EPutHandleClass PutHandleClass;
     const NKikimrBlobStorage::EGetHandleClass GetHandleClass;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
@@ -295,8 +295,10 @@ void TGetImpl::PrepareVPuts(TLogContext &logCtx, TDeque<std::unique_ptr<TEvBlobS
         const TVDiskID vdiskId = Info->GetVDiskId(put.OrderNumber);
         Y_DEBUG_ABORT_UNLESS(Info->Type.GetErasure() != TBlobStorageGroupType::ErasureMirror3of4 ||
             put.Id.PartId() != 3 || put.Buffer.IsEmpty());
+        const bool checksumming = Blackboard.GroupQueues->ChecksumExpected(Info->GetTopology(), vdiskId,
+            TGroupQueues::TVDisk::TQueues::VDiskQueueId(Blackboard.PutHandleClass));
         auto vput = std::make_unique<TEvBlobStorage::TEvVPut>(put.Id, put.Buffer, vdiskId, true, nullptr, Deadline,
-            Blackboard.PutHandleClass);
+            Blackboard.PutHandleClass, checksumming);
         DSP_LOG_DEBUG_SX(logCtx, "BPG15", "Send put to orderNumber# " << put.OrderNumber << " vput# " << vput->ToString());
         History.AddVPutToWaitingList(put.Id.PartId(), 1, put.OrderNumber);
         outVPuts.push_back(std::move(vput));

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
@@ -238,11 +238,15 @@ public:
             auto [begin, end] = puts.equal_range(it->first);
             Y_ABORT_UNLESS(it == begin);
 
+            const TVDiskID vdiskId = Info->GetVDiskId(it->first);
+            const bool checksumming = Blackboard.GroupQueues->ChecksumExpected(Info->GetTopology(), vdiskId,
+                TGroupQueues::TVDisk::TQueues::VDiskQueueId(Blackboard.PutHandleClass));
+
             if (std::next(it) == end) { // TEvVPut
                 auto [orderNumber, ptr] = *it++;
                 TBlobInfo& blob = Blobs[ptr->BlobIdx];
-                auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(ptr->Id, ptr->Buffer, Info->GetVDiskId(orderNumber),
-                    false, nullptr, blob.Deadline, Blackboard.PutHandleClass);
+                auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(ptr->Id, ptr->Buffer, vdiskId, false, nullptr,
+                    blob.Deadline, Blackboard.PutHandleClass, checksumming);
 
                 auto& record = ev->Record;
                 for (const auto& [tabletId, generation] : blob.ExtraBlockChecks) {
@@ -267,8 +271,8 @@ public:
                     auto [orderNumber, ptr] = *temp;
                     deadline = Max(deadline, Blobs[ptr->BlobIdx].Deadline);
                 }
-                auto ev = std::make_unique<TEvBlobStorage::TEvVMultiPut>(Info->GetVDiskId(it->first), deadline,
-                    Blackboard.PutHandleClass, false);
+                auto ev = std::make_unique<TEvBlobStorage::TEvVMultiPut>(vdiskId, deadline, Blackboard.PutHandleClass,
+                    false);
 
                 ui8 firstPartId = it->second->Id.PartId();
                 ui8 orderNumber = it->first;
@@ -276,7 +280,7 @@ public:
                     auto [orderNumber, ptr] = *it++;
                     TBlobInfo& blob = Blobs[ptr->BlobIdx];
                     ev->AddVPut(ptr->Id, TRcBuf(ptr->Buffer), nullptr, blob.IssueKeepFlag, blob.IgnoreBlock,
-                        &blob.ExtraBlockChecks, blob.Span.GetTraceId());
+                        &blob.ExtraBlockChecks, blob.Span.GetTraceId(), checksumming);
                     HandoffPartsSent += ptr->IsHandoff;
                 }
                 History.AddVPutToWaitingList(firstPartId, ev->Record.ItemsSize(), orderNumber);

--- a/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
@@ -236,7 +236,7 @@ namespace NKikimr {
         auto *msg = ev->Get();
         Y_ABORT_UNLESS(Topology);
         Sessions->QueueConnectUpdate(Topology->GetOrderNumber(msg->VDiskId), msg->QueueId, msg->IsConnected,
-            msg->ExtraBlockChecksSupport, msg->CostModel, *Topology);
+            msg->ExtraBlockChecksSupport, msg->Checksumming, msg->CostModel, *Topology);
         MinHugeBlobInBytes = Sessions->GetMinHugeBlobInBytes();
         if (msg->IsConnected && (CurrentStateFunc() == &TThis::StateEstablishingSessions ||
                 CurrentStateFunc() == &TThis::StateEstablishingSessionsTimeout)) {

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_env_mock_ut.h
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_env_mock_ut.h
@@ -237,7 +237,7 @@ inline void SetupRuntime(TTestActorRuntime& runtime) {
     runtime.SetEventFilter([](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev) {
         if (ev->GetTypeRewrite() == TEvBlobStorage::EvVCheckReadiness) {
             runtime.Send(new IEventHandle(
-                    ev->Sender, ev->Recipient, new TEvBlobStorage::TEvVCheckReadinessResult(NKikimrProto::OK), 0,
+                    ev->Sender, ev->Recipient, new TEvBlobStorage::TEvVCheckReadinessResult(NKikimrProto::OK, false), 0,
                     ev->Cookie), 0, true);
             return true;
         }

--- a/ydb/core/blobstorage/dsproxy/ut_fat/dsproxy_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut_fat/dsproxy_ut.cpp
@@ -1431,7 +1431,7 @@ class TTestBlobStorageProxyVPutVGet : public TTestBlobStorageProxy {
 
                 TAutoPtr<TEvBlobStorage::TEvVPut> vPut(
                    new TEvBlobStorage::TEvVPut(logoblobid, partSet.Parts[0].OwnedString, vDiskId, false,
-                                               nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob));
+                                               nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob, false));
                 ctx.Send(Env->VDisks[vDiskIdx], vPut.Release());
                 break;
             }
@@ -1521,7 +1521,7 @@ class TTestBlobStorageProxyVPutVGetLimit : public TTestBlobStorageProxy {
 
                     TAutoPtr<TEvBlobStorage::TEvVPut> vPut(
                         new TEvBlobStorage::TEvVPut(id, partSet.Parts[partIdx].OwnedString, vDiskId, false,
-                        nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob));
+                        nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob, false));
                     auto& msgId = *vPut->Record.MutableMsgQoS()->MutableMsgId();
                     msgId.SetMsgId(i);
                     msgId.SetSequenceId(1);
@@ -1660,7 +1660,7 @@ private:
 
                 TAutoPtr<TEvBlobStorage::TEvVPut> vPut(
                         new TEvBlobStorage::TEvVPut(logoblobid, partSet.Parts[parametrs.PartId-1].OwnedString, *vDiskId,
-                            false, nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob));
+                            false, nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob, false));
                 ctx.Send(Env->VDisks[realVDiskIdx], vPut.Release());
                 break;
             }
@@ -1890,7 +1890,7 @@ class TTestBlobStorageProxyVBlockVPutVGet : public TTestBlobStorageProxy {
 
                 TAutoPtr<TEvBlobStorage::TEvVPut> x(
                     new TEvBlobStorage::TEvVPut(logoblobid, partSet.Parts[0].OwnedString, vDiskId, false,
-                        nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob));
+                        nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob, false));
                 auto& msgId = *x->Record.MutableMsgQoS()->MutableMsgId();
                 msgId.SetMsgId(0);
                 msgId.SetSequenceId(1);
@@ -2647,7 +2647,7 @@ class TTestBlobStorageProxyLongTailDiscoverPut : public TTestBlobStorageProxy {
 
                 TAutoPtr<TEvBlobStorage::TEvVPut> vPut(
                     new TEvBlobStorage::TEvVPut(from, partSet.Parts[0].OwnedString, vDiskId, false, nullptr,
-                                                TInstant::Max(), NKikimrBlobStorage::TabletLog));
+                                                TInstant::Max(), NKikimrBlobStorage::TabletLog, false));
                 auto& msgId = *vPut->Record.MutableMsgQoS()->MutableMsgId();
                 msgId.SetMsgId(MsgIdx);
                 msgId.SetSequenceId(9990);
@@ -2685,7 +2685,7 @@ class TTestBlobStorageProxyLongTailDiscoverPut : public TTestBlobStorageProxy {
 
                 TAutoPtr<TEvBlobStorage::TEvVPut> vPut(
                     new TEvBlobStorage::TEvVPut(from, partSet.Parts[0].OwnedString, vDiskId, false, nullptr,
-                                                TInstant::Max(), NKikimrBlobStorage::TabletLog));
+                                                TInstant::Max(), NKikimrBlobStorage::TabletLog, false));
                 auto& msgId = *vPut->Record.MutableMsgQoS()->MutableMsgId();
                 msgId.SetMsgId(MsgIdx);
                 msgId.SetSequenceId(9990);
@@ -3311,7 +3311,7 @@ class TTestBlobStorageProxyVPutVCollectVGetRace : public TTestBlobStorageProxy {
 
                 TAutoPtr<TEvBlobStorage::TEvVPut> x(
                     new TEvBlobStorage::TEvVPut(logoblobid, partSet.Parts[0].OwnedString, vDiskId, false,
-                        nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob));
+                        nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob, false));
                 auto& msgId = *x->Record.MutableMsgQoS()->MutableMsgId();
                 msgId.SetMsgId(0);
                 msgId.SetSequenceId(1);

--- a/ydb/core/blobstorage/dsproxy/ut_ftol/dsproxy_fault_tolerance_ut_base.h
+++ b/ydb/core/blobstorage/dsproxy/ut_ftol/dsproxy_fault_tolerance_ut_base.h
@@ -106,7 +106,7 @@ public:
 
     NKikimrProto::EReplyStatus PutToVDisk(ui32 vdiskOrderNum, const TLogoBlobID& id, const TString& part) {
         Send(Info->GetActorId(vdiskOrderNum), new TEvBlobStorage::TEvVPut(id, TRope(part), Info->GetVDiskId(vdiskOrderNum),
-            false, nullptr, TInstant::Max(), NKikimrBlobStorage::TabletLog));
+            false, nullptr, TInstant::Max(), NKikimrBlobStorage::TabletLog, false));
         auto ev = WaitForSpecificEvent<TEvBlobStorage::TEvVPutResult>(&TFaultToleranceTestBase::ProcessUnexpectedEvent);
         return ev->Get()->Record.GetStatus();
     }

--- a/ydb/core/blobstorage/ut_blobstorage/assimilation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/assimilation.cpp
@@ -254,7 +254,8 @@ void RunVDiskIterationTest(bool reverse) {
             }
             Cerr << "putting " << id << " partId# " << partId << Endl;
             runtime->Send(new IEventHandle(putQueueId, edge, new TEvBlobStorage::TEvVPut(TLogoBlobID(id, partId),
-                TRope(data), vdiskId, false, nullptr, TInstant::Max(), NKikimrBlobStorage::TabletLog)), edge.NodeId());
+                TRope(data), vdiskId, false, nullptr, TInstant::Max(), NKikimrBlobStorage::TabletLog, false)),
+                edge.NodeId());
             auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVPutResult>(edge, false);
             UNIT_ASSERT_VALUES_EQUAL(res->Get()->Record.GetStatus(), NKikimrProto::OK);
             blobs[id] |= TIngress::CreateIngressWithLocal(&info->GetTopology(), vdiskId, TLogoBlobID(id, partId))->Raw();

--- a/ydb/core/blobstorage/ut_blobstorage/huge.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/huge.cpp
@@ -60,8 +60,8 @@ namespace {
             auto edge = Runtime.AllocateEdgeActor(queueActorId.NodeId(), __FILE__, __LINE__);
             const TLogoBlobID putId(BlobId, partIdx + 1);
             Runtime.Send(new IEventHandle(queueActorId, edge, new TEvBlobStorage::TEvVPut(putId, Parts[partIdx],
-                VDiskIds[subgroupNodeId], false, nullptr, TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::TabletLog)),
-                queueActorId.NodeId());
+                VDiskIds[subgroupNodeId], false, nullptr, TInstant::Max(),
+                NKikimrBlobStorage::EPutHandleClass::TabletLog, false)), queueActorId.NodeId());
             auto res = Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVPutResult>(edge);
             auto& record = res->Get()->Record;
             UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrProto::OK);

--- a/ydb/core/blobstorage/ut_blobstorage/incorrect_queries.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/incorrect_queries.cpp
@@ -12,8 +12,9 @@ Y_UNIT_TEST_SUITE(IncorrectQueries) {
     void SendPut(TEnvironmentSetup& env, TTestInfo& test,
                 const TLogoBlobID& blobId, NKikimrProto::EReplyStatus status, ui32 blob_size, bool isEmptyObject = false, bool isEmptyMeta = false) {
         const TString data(blob_size, 'a');
-        std::unique_ptr<IEventBase> ev = std::make_unique<TEvBlobStorage::TEvVPut>(blobId, TRope(data), test.Info->GetVDiskInSubgroup(0, blobId.Hash()),
-                                 false, nullptr, TInstant::Max(), NKikimrBlobStorage::AsyncBlob);
+        std::unique_ptr<IEventBase> ev = std::make_unique<TEvBlobStorage::TEvVPut>(blobId, TRope(data),
+            test.Info->GetVDiskInSubgroup(0, blobId.Hash()), false, nullptr, TInstant::Max(),
+            NKikimrBlobStorage::AsyncBlob, false);
 
         if (isEmptyObject) {
             if (isEmptyMeta) {
@@ -81,7 +82,7 @@ Y_UNIT_TEST_SUITE(IncorrectQueries) {
 
         for(auto [blob, data, status] : blobs) {
             static_cast<TEvBlobStorage::TEvVMultiPut*>(ev.get())->AddVPut(blob, TRcBuf(data), nullptr, false, false,
-                nullptr, NWilson::TTraceId());
+                nullptr, NWilson::TTraceId(), false);
         }
 
         static_cast<TEvBlobStorage::TEvVMultiPut*>(ev.get())->Record = proto;
@@ -107,7 +108,7 @@ Y_UNIT_TEST_SUITE(IncorrectQueries) {
 
         for(auto [blob, data, status] : blobs) {
             static_cast<TEvBlobStorage::TEvVMultiPut*>(ev.get())->AddVPut(blob, TRcBuf(data), nullptr, false, false,
-                nullptr, NWilson::TTraceId());
+                nullptr, NWilson::TTraceId(), false);
         }
 
         env.WithQueueId(test.Info->GetVDiskInSubgroup(0, blobs[0].BlobId.Hash()), NKikimrBlobStorage::EVDiskQueueId::PutTabletLog, [&](TActorId queueId) {
@@ -519,7 +520,7 @@ Y_UNIT_TEST_SUITE(IncorrectQueries) {
                 ++goodCount;
                 TLogoBlobID blob(i, 1, 0, 0, blobSize, 0, 1);
                 static_cast<TEvBlobStorage::TEvVMultiPut*>(events[i].get())->AddVPut(blob, TRcBuf(data), nullptr, false,
-                    false, nullptr, NWilson::TTraceId());
+                    false, nullptr, NWilson::TTraceId(), false);
             }
         }
 

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -913,7 +913,7 @@ config:
         WithQueueId(vdiskId, NKikimrBlobStorage::EVDiskQueueId::PutTabletLog, [&](TActorId queueId) {
             const TActorId& edge = Runtime->AllocateEdgeActor(queueId.NodeId(), __FILE__, __LINE__);
             Runtime->Send(new IEventHandle(queueId, edge, new TEvBlobStorage::TEvVPut(blobId, TRope(part), vdiskId, false, nullptr,
-                TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::TabletLog)), queueId.NodeId());
+                TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::TabletLog, false)), queueId.NodeId());
             auto r = WaitForEdgeActorEvent<TEvBlobStorage::TEvVPutResult>(edge);
 
             auto& record = r->Get()->Record;

--- a/ydb/core/blobstorage/ut_blobstorage/osiris.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/osiris.cpp
@@ -47,7 +47,7 @@ bool DoTestCase(TBlobStorageGroupType::EErasureSpecies erasure, const std::set<s
         const TLogoBlobID blobId(id, partIdx + 1);
         TRope buffer = type.PartSize(blobId) ? parts.Parts[partIdx].OwnedString : TRope(TString());
         env.Runtime->Send(new IEventHandle(queueId, sender, new TEvBlobStorage::TEvVPut(blobId, buffer,
-            info->GetVDiskId(orderNum), false, nullptr, TInstant::Max(), NKikimrBlobStorage::TabletLog)),
+            info->GetVDiskId(orderNum), false, nullptr, TInstant::Max(), NKikimrBlobStorage::TabletLog, false)),
             sender.NodeId());
         auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVPutResult>(sender);
         Y_ABORT_UNLESS(res->Get()->Record.GetStatus() == NKikimrProto::OK);

--- a/ydb/core/blobstorage/ut_blobstorage/snapshots.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/snapshots.cpp
@@ -35,7 +35,7 @@ Y_UNIT_TEST_SUITE(SnapshotTesting) {
                 TString data = env.GenerateRandomString(len);
                 const TLogoBlobID id(tabletId, generation, step, channel, len, 0, 1);
                 auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(id, TRope(data), vdiskId, false, nullptr, TInstant::Max(),
-                    NKikimrBlobStorage::EPutHandleClass::TabletLog);
+                    NKikimrBlobStorage::EPutHandleClass::TabletLog, false);
                 runtime->Send(new IEventHandle(queue, edge, ev.release()), queue.NodeId());
                 if (putToBlobs) {
                     blobs.emplace(id, std::move(data));

--- a/ydb/core/blobstorage/ut_blobstorage/validation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/validation.cpp
@@ -66,7 +66,7 @@ Y_UNIT_TEST_SUITE(RequestValidation) {
         TLogoBlobID partId(100, 1, 1, 0, /*blobSize=*/0, 0, /*partId=*/1);
         TString data;
         auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(partId, TRope(data), ctx.VDiskId, false, nullptr, TInstant::Max(),
-                    NKikimrBlobStorage::EPutHandleClass::TabletLog);
+            NKikimrBlobStorage::EPutHandleClass::TabletLog, false);
         ctx.Env->Runtime->Send(new IEventHandle(ctx.VDiskActorId, ctx.Edge, ev.release()), ctx.VDiskActorId.NodeId());
 
         auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvVPutResult>(ctx.Edge, false, TInstant::Max());
@@ -84,7 +84,7 @@ Y_UNIT_TEST_SUITE(RequestValidation) {
         for (ui32 i = 0; i < vputsCount; ++i) {
             TLogoBlobID partId(100, 1, 1, 0, /*blobSize=*/0, i, /*partId=*/1);
             TString data;
-            ev->AddVPut(partId, TRcBuf(data), nullptr, false, false, nullptr, {});
+            ev->AddVPut(partId, TRcBuf(data), nullptr, false, false, nullptr, {}, false);
         }
         ctx.Env->Runtime->Send(new IEventHandle(ctx.VDiskActorId, ctx.Edge, ev.release()), ctx.VDiskActorId.NodeId());
 

--- a/ydb/core/blobstorage/ut_mirror3of4/main.cpp
+++ b/ydb/core/blobstorage/ut_mirror3of4/main.cpp
@@ -185,7 +185,7 @@ public:
             TRcBuf dataWithHeadroom(TRcBuf::Uninitialized(data.size(), 32));
             std::memcpy(dataWithHeadroom.UnsafeGetDataMut(), data.data(), data.size());
             Send(GetBackpressureFor(Info->GetOrderNumber(vdiskId)), new TEvBlobStorage::TEvVPut(blobId, TRope(dataWithHeadroom), vdiskId,
-                false, nullptr, TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::TabletLog));
+                false, nullptr, TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::TabletLog, false));
             auto ev = WaitForSpecificEvent<TEvBlobStorage::TEvVPutResult>(&TCoro::ProcessUnexpectedEvent);
             auto& record = ev->Get()->Record;
             UNIT_ASSERT_VALUES_EQUAL(vdiskId, VDiskIDFromVDiskID(record.GetVDiskID()));

--- a/ydb/core/blobstorage/ut_vdisk/lib/helpers.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/helpers.cpp
@@ -262,7 +262,7 @@ class TManyPuts : public TActorBootstrapped<TManyPuts> {
                 const TInstant deadline = noTimeout ? TInstant::Max() : TInstant::Now() + RequestTimeout;
                 ctx.Send(QueueActorId,
                          new TEvBlobStorage::TEvVPut(logoBlobID, TRope(put.Data), VDiskInfo.VDiskID, false,
-                                                     nullptr, deadline, HandleClassGen->GetHandleClass()));
+                                                     nullptr, deadline, HandleClassGen->GetHandleClass(), false));
                 return;
             } else {
                 BadSteps->insert(put.Step);
@@ -451,7 +451,7 @@ class TManyMultiPuts : public TActorBootstrapped<TManyMultiPuts> {
             TVDiskIdShort mainVDiskId = TIngress::GetMainReplica(&Conf->GroupInfo->GetTopology(), logoBlobID);
             if (mainVDiskId == VDiskInfo.VDiskID) {
                 ui64 cookieValue = Step;
-                vMultiPut->AddVPut(logoBlobID, TRcBuf(MsgData), &cookieValue, false, false, nullptr, NWilson::TTraceId());
+                vMultiPut->AddVPut(logoBlobID, TRcBuf(MsgData), &cookieValue, false, false, nullptr, NWilson::TTraceId(), false);
                 putCount++;
 
                 Step++;
@@ -1398,7 +1398,7 @@ NActors::IActor *PutGCToCorrespondingVDisks(const NActors::TActorId &notifyID, T
 void PutLogoBlobToVDisk(const TActorContext &ctx, const TActorId &actorID, const TVDiskID &vdiskID,
                         const TLogoBlobID &id, const TString &data, NKikimrBlobStorage::EPutHandleClass cls) {
     LOG_DEBUG(ctx, NActorsServices::TEST, "  Sending TEvPut: id=%s data='%s'", id.ToString().data(), LimitData(data).data());
-    ctx.Send(actorID, new TEvBlobStorage::TEvVPut(id, TRope(data), vdiskID, false, nullptr, TInstant::Max(), cls));
+    ctx.Send(actorID, new TEvBlobStorage::TEvVPut(id, TRope(data), vdiskID, false, nullptr, TInstant::Max(), cls, false));
 }
 
 // returns number of messages sent

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_bad_blobid.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_bad_blobid.cpp
@@ -29,7 +29,7 @@ public:
         for (auto it = DataSetPtr->First(); it->IsValid(); it->Next()) {
             const auto &x = *it->Get();
             ctx.Send(VDiskInfo.ActorID, new TEvBlobStorage::TEvVPut(x.Id, TRope(x.Data),
-                    VDiskInfo.VDiskID, false, nullptr, TInstant::Max(), x.HandleClass));
+                    VDiskInfo.VDiskID, false, nullptr, TInstant::Max(), x.HandleClass, false));
         }
         Become(&TThis::StateFunc);
     }

--- a/ydb/core/blobstorage/ut_vdisk/lib/vdisk_mock.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/vdisk_mock.cpp
@@ -420,7 +420,7 @@ public:
     }
 
     void Handle(TEvBlobStorage::TEvVCheckReadiness::TPtr& ev, const TActorContext& ctx) {
-        ctx.Send(ev->Sender, new TEvBlobStorage::TEvVCheckReadinessResult(NKikimrProto::OK), 0, ev->Cookie);
+        ctx.Send(ev->Sender, new TEvBlobStorage::TEvVCheckReadinessResult(NKikimrProto::OK, false), 0, ev->Cookie);
     }
 
     void Handle(TEvVMockCtlRequest::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/blobstorage/ut_vdisk2/env.h
+++ b/ydb/core/blobstorage/ut_vdisk2/env.h
@@ -95,7 +95,7 @@ namespace NKikimr {
         NKikimrBlobStorage::TEvVPutResult Put(const TLogoBlobID& id, TString buffer,
                 NKikimrBlobStorage::EPutHandleClass prio = NKikimrBlobStorage::EPutHandleClass::TabletLog) {
             return ExecuteQuery<TEvBlobStorage::TEvVPutResult>(std::make_unique<TEvBlobStorage::TEvVPut>(id, TRope(buffer),
-                VDiskId, false, nullptr, TInstant::Max(), prio), GetQueueId(prio));
+                VDiskId, false, nullptr, TInstant::Max(), prio, false), GetQueueId(prio));
         }
 
         NKikimrBlobStorage::TEvVGetResult Get(const TLogoBlobID& id,

--- a/ydb/core/blobstorage/vdisk/balance/sender.cpp
+++ b/ydb/core/blobstorage/vdisk/balance/sender.cpp
@@ -157,10 +157,12 @@ namespace {
                     auto vDiskId = GetMainReplicaVDiskId(*GInfo, key);
 
                     if (Ctx->HugeBlobCtx->IsHugeBlob(GInfo->GetTopology().GType, part.Key, Ctx->MinHugeBlobInBytes)) {
+                        // TODO(alexvru): checksumming here
                         auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(
                             key, std::move(data), vDiskId,
                             true, nullptr,
-                            TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::AsyncBlob
+                            TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::AsyncBlob,
+                            false
                         );
                         SendRequest(TVDiskIdShort(vDiskId), selfId, ev.release(), dataSize);
                     } else {
@@ -172,7 +174,8 @@ namespace {
                             ev = std::make_unique<TEvBlobStorage::TEvVMultiPut>(vDiskId, TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::AsyncBlob, true, nullptr);
                         }
 
-                        ev->AddVPut(key, TRcBuf(std::move(data)), nullptr, false, false, {}, NWilson::TTraceId());
+                        // TODO(alexvru): checksumming here
+                        ev->AddVPut(key, TRcBuf(std::move(data)), nullptr, false, false, {}, NWilson::TTraceId(), false);
                     }
                 }
             }

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.cpp
@@ -36,14 +36,19 @@ namespace NKikimr {
         }
     }
 
-    void TEvBlobStorage::TEvVPut::StorePayload(TRope&& buffer) {
-        Record.SetChecksum(TDiskBlob::CalculateChecksum(buffer));
+    void TEvBlobStorage::TEvVPut::StorePayload(TRope&& buffer, bool checksumming) {
+        if (checksumming) {
+            Record.SetChecksum(TDiskBlob::CalculateChecksum(buffer));
+        }
         AddPayload(std::move(buffer));
     }
 
-    void TEvBlobStorage::TEvVMultiPut::StorePayload(const TRcBuf& buffer, NKikimrBlobStorage::TVMultiPutItem *item) {
+    void TEvBlobStorage::TEvVMultiPut::StorePayload(const TRcBuf& buffer, NKikimrBlobStorage::TVMultiPutItem *item,
+            bool checksumming) {
         TRope rope(buffer);
-        item->SetChecksum(TDiskBlob::CalculateChecksum(rope));
+        if (checksumming) {
+            item->SetChecksum(TDiskBlob::CalculateChecksum(rope));
+        }
         AddPayload(std::move(rope));
         Y_DEBUG_ABORT_UNLESS(Record.ItemsSize() == GetPayloadCount());
     }

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -593,10 +593,10 @@ namespace NKikimr {
 
         TEvVPut(const TLogoBlobID &logoBlobId, TRope buffer, const TVDiskID &vdisk,
                 const bool ignoreBlock, const ui64 *cookie, TInstant deadline,
-                NKikimrBlobStorage::EPutHandleClass cls)
+                NKikimrBlobStorage::EPutHandleClass cls, bool checksumming)
         {
             InitWithoutBuffer(logoBlobId, vdisk, ignoreBlock, cookie, deadline, cls);
-            StorePayload(std::move(buffer));
+            StorePayload(std::move(buffer), checksumming);
         }
 
         void InitWithoutBuffer(const TLogoBlobID &logoBlobId, const TVDiskID &vdisk, const bool ignoreBlock,
@@ -633,7 +633,7 @@ namespace NKikimr {
             return Record.HasBuffer() ? TRope(Record.GetBuffer()) : GetPayload(0);
         }
 
-        void StorePayload(TRope&& buffer);
+        void StorePayload(TRope&& buffer, bool checksumming);
 
         ui64 GetBufferBytes() const {
             ui64 sizeBytes = 0;
@@ -883,16 +883,16 @@ namespace NKikimr {
             return sum;
         }
 
-        void StorePayload(const TRcBuf &buffer, NKikimrBlobStorage::TVMultiPutItem *item);
+        void StorePayload(const TRcBuf &buffer, NKikimrBlobStorage::TVMultiPutItem *item, bool checksumming);
 
         TRope GetItemBuffer(ui64 itemIdx) const;
 
         void AddVPut(const TLogoBlobID &logoBlobId, const TRcBuf &buffer, ui64 *cookie, bool issueKeepFlag, bool ignoreBlock,
-                std::vector<std::pair<ui64, ui32>> *extraBlockChecks, NWilson::TTraceId traceId) {
+                std::vector<std::pair<ui64, ui32>> *extraBlockChecks, NWilson::TTraceId traceId, bool checksumming) {
             NKikimrBlobStorage::TVMultiPutItem *item = Record.AddItems();
             LogoBlobIDFromLogoBlobID(logoBlobId, item->MutableBlobID());
             item->SetFullDataSize(logoBlobId.BlobSize());
-            StorePayload(buffer, item);
+            StorePayload(buffer, item, checksumming);
             item->SetFullDataSize(logoBlobId.BlobSize());
             if (cookie) {
                 item->SetCookie(*cookie);
@@ -2583,9 +2583,10 @@ namespace NKikimr {
     {
         TEvVCheckReadinessResult() = default;
 
-        TEvVCheckReadinessResult(NKikimrProto::EReplyStatus status) {
+        TEvVCheckReadinessResult(NKikimrProto::EReplyStatus status, bool checksumming) {
             Record.SetStatus(status);
             Record.SetExtraBlockChecksSupport(true);
+            Record.SetChecksumming(checksumming);
         }
     };
 

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
@@ -166,7 +166,8 @@ namespace NKikimr {
                 << rec.LogoBlobId << " from Location# " << rec.OldDiskPart);
 
             auto writeEvent = std::make_unique<TEvBlobStorage::TEvVPut>(rec.LogoBlobId, std::move(rope),
-                    SelfVDiskId, true, nullptr, TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::AsyncBlob);
+                SelfVDiskId, true, nullptr, TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::AsyncBlob,
+                DCtx->VCfg->BlobHeaderMode == EBlobHeaderMode::XXH3_64BIT_HEADER);
             writeEvent->RewriteBlob = true;
             Send(DCtx->SkeletonId, writeEvent.release());
         }

--- a/ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.h
+++ b/ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.h
@@ -50,6 +50,6 @@ namespace NKikimr {
 
     IActor *CreateRestoreCorruptedBlobActor(TActorId skeletonId, TEvRestoreCorruptedBlob::TPtr& ev,
         TIntrusivePtr<TBlobStorageGroupInfo> info, TIntrusivePtr<TVDiskContext> vctx,
-        TPDiskCtxPtr pdiskCtx);
+        TPDiskCtxPtr pdiskCtx, TIntrusivePtr<TVDiskConfig> vcfg);
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -2569,7 +2569,7 @@ namespace NKikimr {
         }
 
         void Handle(TEvRestoreCorruptedBlob::TPtr ev, const TActorContext& ctx) {
-            ctx.Register(CreateRestoreCorruptedBlobActor(SelfId(), ev, GInfo, VCtx, PDiskCtx));
+            ctx.Register(CreateRestoreCorruptedBlobActor(SelfId(), ev, GInfo, VCtx, PDiskCtx, Config));
         }
 
         void Handle(TEvBlobStorage::TEvCaptureVDiskLayout::TPtr ev, const TActorContext& ctx) {

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -1603,7 +1603,8 @@ namespace NKikimr {
                 NKikimrProto::EReplyStatus status, const TString& /*errorReason*/, TInstant /*now*/,
                 const std::optional<NBackpressure::TMessageId>& expectedMsgId = std::nullopt) {
             const ui32 flags = IEventHandle::MakeFlags(ev->GetChannel(), 0);
-            auto res = std::make_unique<TEvBlobStorage::TEvVCheckReadinessResult>(status);
+            auto res = std::make_unique<TEvBlobStorage::TEvVCheckReadinessResult>(status,
+                Config->BlobHeaderMode == EBlobHeaderMode::XXH3_64BIT_HEADER);
             auto& record = res->Record;
             SetRacingGroupInfo(ev->Get()->Record, record, GInfo);
             if (expectedMsgId) {

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor.cpp
@@ -501,8 +501,9 @@ namespace NKikimr::NPrivate {
                     (ReceivedXorDiffs, ReceivedXorDiffCount),
                     (ExpectedXorDiffs, WaitedXorDiffCount));
             ui64 cookie = OriginalBlobId.Hash();
+            // TODO(alexvru): checksumming here
             std::unique_ptr<IEventBase> put = std::make_unique<TEvBlobStorage::TEvVPut>(TLogoBlobID(PatchedBlobId, PatchedPartId),
-                    Buffer, VDiskId, false, &cookie, Deadline, NKikimrBlobStorage::AsyncBlob);
+                    Buffer, VDiskId, false, &cookie, Deadline, NKikimrBlobStorage::AsyncBlob, false);
             AddMark("Send vPut");
             Send(LeaderId, put.release());
         }

--- a/ydb/core/load_test/vdisk_write.cpp
+++ b/ydb/core/load_test/vdisk_write.cpp
@@ -191,7 +191,8 @@ namespace NKikimr {
                 TDataPartSet parts;
                 GType.SplitData((TErasureType::ECrcMode)logoBlobId.CrcMode(), whole, parts);
                 auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(logoBlobId,
-                        parts.Parts[logoBlobId.PartId() - 1].OwnedString, VDiskId, true, &cookie, TInstant::Max(), PutHandleClass);
+                    parts.Parts[logoBlobId.PartId() - 1].OwnedString, VDiskId, true, &cookie, TInstant::Max(),
+                    PutHandleClass, false);
                 ctx.Send(QueueActorId, ev.release());
                 ++TEvVPutsSent;
             }

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -665,6 +665,7 @@ message TEvVCheckReadinessResult {
     optional TMessageId ExpectedMsgId = 3;
     optional TVDiskCostSettings CostSettings = 4;
     optional bool ExtraBlockChecksSupport = 5;
+    optional bool Checksumming = 6;
     optional NKikimrBlobStorage.TGroupInfo RecentGroup = 100; // filled in by VDisk on RACE when VDisk has newer generation
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Automatic checksumming decision for DSProxy/VDisk interaction

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch makes DS proxy calculate blob checksums only when VDisks report this feature turned on.
