### PR TITLE
YQ-4686 fixed multipart uploading in s3 provider

### DIFF
--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -2558,6 +2558,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
         auto db = kikimr->GetQueryClient();
         {
             const TString query = R"(
+                PRAGMA s3.AtomicUploadCommit = "true";
                 INSERT INTO test_bucket.`test-inset-splitting/` WITH (FORMAT = "parquet")
                 SELECT Random(data) AS data FROM AS_TABLE(ListReplicate(
                     <|data: "x"|>,
@@ -2567,12 +2568,16 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
 
             // Create two large parquet files
             {
-                const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
-                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+                const auto result = db.ExecuteScript(query).GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.Status().GetStatus(), EStatus::SUCCESS, result.Status().GetIssues().ToString());
+                const auto readyOp = WaitScriptExecutionOperation(result.Id(), kikimr->GetDriver());
+                UNIT_ASSERT_EQUAL_C(readyOp.Status().GetStatus(), EStatus::SUCCESS, readyOp.Status().GetIssues().ToString());
             }
             {
-                const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
-                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+                const auto result = db.ExecuteScript(query).GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.Status().GetStatus(), EStatus::SUCCESS, result.Status().GetIssues().ToString());
+                const auto readyOp = WaitScriptExecutionOperation(result.Id(), kikimr->GetDriver());
+                UNIT_ASSERT_EQUAL_C(readyOp.Status().GetStatus(), EStatus::SUCCESS, readyOp.Status().GetIssues().ToString());
             }
         }
 
@@ -2581,6 +2586,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
             // write tasks will be scheduled locally
             // so one of the channels is remote
             const TString query = R"(
+                PRAGMA s3.AtomicUploadCommit = "true";
                 PRAGMA s3.UseRuntimeListing = "false";
                 PRAGMA ydb.OverridePlanner = @@ [
                     { "tx": 0, "stage": 0, "tasks": 2 }
@@ -2594,8 +2600,10 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
                     )
                 )
             )";
-            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            const auto result = db.ExecuteScript(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.Status().GetStatus(), EStatus::SUCCESS, result.Status().GetIssues().ToString());
+            const auto readyOp = WaitScriptExecutionOperation(result.Id(), kikimr->GetDriver());
+            UNIT_ASSERT_EQUAL_C(readyOp.Status().GetStatus(), EStatus::SUCCESS, readyOp.Status().GetIssues().ToString());
         }
 
         const TString query = R"(

--- a/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
@@ -387,12 +387,13 @@ private:
     }
 
     void StartUploadParts() {
-        while (auto part = Parts->Pop()) {
+        for (auto part = Parts->Pop(); part || (!SentCount && Parts->IsSealed()); part = Parts->Pop()) {
             const auto size = part.size();
             const auto index = Tags.size();
             Tags.emplace_back();
             InFlight += size;
             SentSize += size;
+            SentCount++;
             auto authInfo = Credentials.GetAuthInfo();
             Gateway->Upload(Url + "?partNumber=" + std::to_string(index + 1) + "&uploadId=" + UploadId,
                 IHTTPGateway::MakeYcHeaders(RequestId, authInfo.GetToken(), {}, authInfo.GetAwsUserPwd(), authInfo.GetAwsSigV4()),
@@ -460,6 +461,7 @@ private:
 
     size_t InFlight = 0ULL;
     size_t SentSize = 0ULL;
+    size_t SentCount = 0ULL;
 
     const TTxId TxId;
     const IHTTPGateway::TPtr Gateway;

--- a/ydb/library/yql/providers/s3/compressors/factory.cpp
+++ b/ydb/library/yql/providers/s3/compressors/factory.cpp
@@ -55,10 +55,10 @@ IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& compression) {
         return NBrotli::MakeCompressor();
     }
     if ("zstd" == compression) {
-        return  NZstd::MakeCompressor();
+        return NZstd::MakeCompressor();
     }
     if ("bzip2" == compression) {
-        return  NBzip2::MakeCompressor();
+        return NBzip2::MakeCompressor();
     }
     if ("xz" == compression) {
         return NXz::MakeCompressor();

--- a/ydb/library/yql/providers/s3/compressors/output_queue_impl.h
+++ b/ydb/library/yql/providers/s3/compressors/output_queue_impl.h
@@ -27,24 +27,25 @@ public:
                     if (Queue.back().size() + item.size() > MaxItemSize) {
                         const auto sizeToAdd = MaxItemSize - Queue.back().size();
                         Queue.back().append(item.substr(0U, sizeToAdd));
-                        item = item.substr(item.size() - sizeToAdd);
+                        item = item.substr(sizeToAdd);
                     } else {
-                        Queue.back().append(std::move(item));
+                        Queue.back().append(item);
                         item.clear();
                     }
                 } else {
-                    Queue.back().append(std::move(item));
+                    Queue.back().append(item);
                     item.clear();
                 }
             }
         }
 
-        if (!item.empty()) {
+        if (item) {
             if constexpr (MaxItemSize > 0ULL) {
-                while (item.size() > MaxItemSize) {
-                    Queue.emplace_back(item.substr(0U, MaxItemSize));
-                    item = item.substr(MaxItemSize);
+                ui64 i = 0;
+                for (; i + MaxItemSize < item.size(); i += MaxItemSize) {
+                    Queue.emplace_back(item.substr(i, MaxItemSize));
                 }
+                item = item.substr(i);
             }
 
             Queue.emplace_back(std::move(item));
@@ -75,7 +76,7 @@ public:
             if constexpr (MaxItemSize > 0ULL) {
                 const auto endSize = Queue.back().size();
                 if (endSize + lastItem.size() <= MaxItemSize) {
-                    Queue.back().append(std::move(lastItem));
+                    Queue.back().append(lastItem);
                     return;
                 }
 
@@ -89,7 +90,7 @@ public:
 
                 Queue.push_back(std::move(lastItem));
             } else {
-                Queue.back().append(std::move(lastItem));
+                Queue.back().append(lastItem);
             }
         }
     }

--- a/ydb/library/yql/providers/s3/compressors/ut/output_queue_ut.cpp
+++ b/ydb/library/yql/providers/s3/compressors/ut/output_queue_ut.cpp
@@ -1,0 +1,157 @@
+#include <ydb/library/yql/providers/s3/compressors/output_queue_impl.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYql {
+
+Y_UNIT_TEST_SUITE(TOutputQueueTests) {
+    Y_UNIT_TEST(TestOutputQueueBasic) {
+        TOutputQueue<0> queue;
+
+        queue.Push("");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 0);
+
+        queue.Push("A");
+        queue.Push("BB");
+        queue.Push("CCC");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Volume(), 6);
+        UNIT_ASSERT(!queue.Empty());
+        UNIT_ASSERT(!queue.IsSealed());
+
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "A");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Volume(), 5);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "BB");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Volume(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        UNIT_ASSERT(!queue.Empty());
+
+        queue.Seal();
+        UNIT_ASSERT(queue.IsSealed());
+
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "CCC");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Volume(), 0);
+        UNIT_ASSERT(queue.Empty());
+
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "");
+    }
+
+    Y_UNIT_TEST(TestOutputQueueWithMaxItemSize) {
+        TOutputQueue<0, 3> queue;
+
+        queue.Push("A");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        queue.Push("XYZ");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+        queue.Push("hello world");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 6);
+        queue.Push("XYZXYZ");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 8);
+
+        queue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "A");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "XYZ");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "hel");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "lo ");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "wor");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "ld");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "XYZ");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "XYZ");
+        UNIT_ASSERT(queue.Empty());
+    }
+
+    Y_UNIT_TEST(TestOutputQueueWithMinItemSize) {
+        TOutputQueue<3, 0> queue;
+
+        queue.Push("XYZ");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        queue.Push("A");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+        queue.Push("hello world");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+
+        queue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "XYZ");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "Ahello world");
+
+        queue = TOutputQueue<3, 0>();
+        queue.Push("A");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        queue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "A");
+
+        queue = TOutputQueue<3, 0>();
+        queue.Push("hello world");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        queue.Push("A");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+        queue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "hello worldA");
+    }
+
+    Y_UNIT_TEST(TestOutputQueueWithMinMaxItemSize) {
+        TOutputQueue<3, 6> queue;
+
+        queue.Push("AB");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        queue.Push("BCCD");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        queue.Push("XY");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+        queue.Push("hello world !");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 4);
+
+        queue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "ABBCCD");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "XYhell");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "o worl");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "d !");
+
+        queue = TOutputQueue<3, 6>();
+        queue.Push("ABC");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        queue.Push("D");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+        queue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "ABCD");
+
+        TOutputQueue<4, 5> smallQueue;
+        smallQueue.Push("ABCD");
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Size(), 1);
+        smallQueue.Push("XYZ");
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Size(), 2);
+        smallQueue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Pop(), "ABCD");
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Pop(), "XYZ");
+
+        smallQueue = TOutputQueue<4, 5>();
+        smallQueue.Push("ABCDE");
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Size(), 1);
+        smallQueue.Push("X");
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Size(), 2);
+        smallQueue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Pop(), "ABCD");
+        UNIT_ASSERT_VALUES_EQUAL(smallQueue.Pop(), "EX");
+
+        queue = TOutputQueue<3, 6>();
+        queue.Push("ABCDEF");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 1);
+        queue.Push("A");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+        queue.Seal();
+        UNIT_ASSERT_VALUES_EQUAL(queue.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "ABCD");
+        UNIT_ASSERT_VALUES_EQUAL(queue.Pop(), "EFA");
+    }
+}
+
+} // namespace NYql

--- a/ydb/library/yql/providers/s3/compressors/ut/ya.make
+++ b/ydb/library/yql/providers/s3/compressors/ut/ya.make
@@ -4,12 +4,13 @@ UNITTEST_FOR(ydb/library/yql/providers/s3/compressors)
 
 SRCS(
     decompressor_ut.cpp
+    output_queue_ut.cpp
 )
 
 PEERDIR(
     library/cpp/scheme
-    yql/essentials/public/udf/service/stub
     ydb/library/yql/udfs/common/clickhouse/client
+    yql/essentials/public/udf/service/stub
 )
 
 ADDINCL(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed multipart uploading in s3 provider

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Fixed bug in S3 write actor when used multipart upload with empty raw data
* Fixed data loss in TOutputQueue when `MaxItemSize` is not zero (in case of lz4 compression)
* Fixed data compaction in TOutputQueue for last part in case of multipart upload
* Fixed pragmas keys_count_limit, total_size_limit, block_size_limit
