### PR TITLE
Export encryption. Use __msan_unpoison to mark initialized memory. For some reason it was not done in case when chacha20-poly1305 algorithm is used

### DIFF
--- a/ydb/core/backup/common/encryption_ut.cpp
+++ b/ydb/core/backup/common/encryption_ut.cpp
@@ -28,11 +28,14 @@ const TEncryptionKey& SelectKey(const TString& alg) {
 Y_UNIT_TEST_SUITE(EncryptedFileSerializerTest) {
     Y_UNIT_TEST(SerializeWholeFileAtATime) {
         TEncryptionIV iv = TEncryptionIV::Generate();
-        TBuffer fileData = TEncryptedFileSerializer::EncryptFullFile("aes-128_gcm", Key16, iv, "short data file");
-        TBuffer data = TEncryptedFileDeserializer::DecryptFullFile(Key16, iv, fileData);
-        TString dataStr;
-        data.AsString(dataStr);
-        UNIT_ASSERT_STRINGS_EQUAL(dataStr, "short data file");
+        TString content = "Short example text file with data that is to be encrypted and the decrypted";
+        for (const TString& alg : Algorithms) {
+            TBuffer fileData = TEncryptedFileSerializer::EncryptFullFile(alg, SelectKey(alg), iv, content);
+            TBuffer data = TEncryptedFileDeserializer::DecryptFullFile(SelectKey(alg), iv, fileData);
+            TString dataStr;
+            data.AsString(dataStr);
+            UNIT_ASSERT_STRINGS_EQUAL(dataStr, content);
+        }
     }
 
     Y_UNIT_TEST(WrongParametersForSerializer) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

https://github.com/ydb-platform/ydb/issues/24903

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix memory sanitizer issue
https://github.com/ydb-platform/ydb/issues/24903