### PR TITLE
Add timeout for GroupLayoutSanitizer.Stress* tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -3,7 +3,6 @@ ydb/core/blobstorage/pdisk/ut TPDiskTest.FailedToFormatDiskInfoUpdate
 ydb/core/blobstorage/pdisk/ut TPDiskTest.PDiskSlotSizeInUnits
 ydb/core/blobstorage/ut_blobstorage BlobPatching.PatchBlock42
 ydb/core/blobstorage/ut_blobstorage Defragmentation.CorruptedReadHandling
-ydb/core/blobstorage/ut_blobstorage GroupLayoutSanitizer.StressMirror3of4
 ydb/core/blobstorage/ut_blobstorage GroupReconfiguration.BsControllerDoesNotDisableGroup
 ydb/core/blobstorage/ut_blobstorage GroupReconfiguration.BsControllerDoesNotDisableGroupNoRequestsToNodesWVDisks
 ydb/core/blobstorage/ut_blobstorage NodeDisconnected.BsQueueRetries

--- a/ydb/core/blobstorage/ut_blobstorage/sanitize_groups.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/sanitize_groups.cpp
@@ -244,7 +244,9 @@ Y_UNIT_TEST_SUITE(GroupLayoutSanitizer) {
     }
 
     void StressTest(TBlobStorageGroupType groupType, ui32 dcs, ui32 racks, ui32 units) {
+        const TDuration timeLimit = TDuration::Seconds(60);
         const ui32 steps = 100;
+        THPTimer timer;
         std::vector<TNodeLocation> locations;
 
         MakeLocations(locations, dcs, racks, units, LocationGenerator);
@@ -322,6 +324,9 @@ Y_UNIT_TEST_SUITE(GroupLayoutSanitizer) {
         bool groupLayoutSanitizer = false;
 
         for (ui32 i = 0; i < steps; ++i) {
+            if (TDuration::Seconds(timer.Passed()) > timeLimit) {
+                Cerr << "Test terminated prematurely due to timeout, steps processed# " << i << Endl;
+            }
             switch (act.GetRandom()) {
                 case EActions::SHUFFLE_LOCATIONS:
                     shuffleLocations();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix UT timeout failure by adding premature test termination after 60 seconds of work.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)