### PR TITLE
Extend support of multiple columns in fulltext index

### DIFF
--- a/ydb/core/base/fulltext.h
+++ b/ydb/core/base/fulltext.h
@@ -9,6 +9,7 @@ namespace NKikimr::NFulltext {
 TVector<TString> Analyze(const TString& text, const Ydb::Table::FulltextIndexSettings::Analyzers& settings);
 
 bool ValidateSettings(const NProtoBuf::RepeatedPtrField<TString>& keyColumns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
+bool ValidateSettings(const TVector<TString>& keyColumns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
 Ydb::Table::FulltextIndexSettings FillSettings(const TString& keyColumn, const TVector<std::pair<TString, TString>>& values, TString& error);
 
 }

--- a/ydb/core/base/fulltext.h
+++ b/ydb/core/base/fulltext.h
@@ -8,8 +8,10 @@ namespace NKikimr::NFulltext {
 
 TVector<TString> Analyze(const TString& text, const Ydb::Table::FulltextIndexSettings::Analyzers& settings);
 
-bool ValidateSettings(const NProtoBuf::RepeatedPtrField<TString>& keyColumns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
-bool ValidateSettings(const TVector<TString>& keyColumns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
+bool ValidateColumnsMatches(const NProtoBuf::RepeatedPtrField<TString>& columns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
+bool ValidateColumnsMatches(const TVector<TString>& columns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
+
+bool ValidateSettings(const Ydb::Table::FulltextIndexSettings& settings, TString& error);
 Ydb::Table::FulltextIndexSettings FillSettings(const TString& keyColumn, const TVector<std::pair<TString, TString>>& values, TString& error);
 
 }

--- a/ydb/core/base/ut/fulltext_ut.cpp
+++ b/ydb/core/base/ut/fulltext_ut.cpp
@@ -6,50 +6,54 @@ namespace NKikimr::NFulltext {
 
 Y_UNIT_TEST_SUITE(NFulltext) {
 
+    Y_UNIT_TEST(ValidateColumnsMatches) {
+        TString error;
+        
+        Ydb::Table::FulltextIndexSettings settings;
+        settings.add_columns()->set_column("column1");
+        settings.add_columns()->set_column("column2");
+
+        UNIT_ASSERT(!ValidateColumnsMatches(TVector<TString>{"column2"}, settings, error));
+        UNIT_ASSERT_VALUES_EQUAL(error, "columns [ column1 column2 ] should be [ column2 ]");
+
+        UNIT_ASSERT(!ValidateColumnsMatches(TVector<TString>{"column2", "column1"}, settings, error));
+        UNIT_ASSERT_VALUES_EQUAL(error, "columns [ column1 column2 ] should be [ column2 column1 ]");
+
+        UNIT_ASSERT(ValidateColumnsMatches(TVector<TString>{"column1", "column2"}, settings, error));
+        UNIT_ASSERT_VALUES_EQUAL(error, "");
+    }
+
     Y_UNIT_TEST(ValidateSettings) {
         Ydb::Table::FulltextIndexSettings settings;
         TString error;
 
-        UNIT_ASSERT(!ValidateSettings(TVector<TString>{"text"}, settings, error));
+        UNIT_ASSERT(!ValidateSettings(settings, error));
         UNIT_ASSERT_VALUES_EQUAL(error, "layout should be set");
         settings.set_layout(Ydb::Table::FulltextIndexSettings::FLAT);
 
-        UNIT_ASSERT(!ValidateSettings(TVector<TString>{"text"}, settings, error));
-        UNIT_ASSERT_VALUES_EQUAL(error, "settings columns should be set");
+        UNIT_ASSERT(!ValidateSettings(settings, error));
+        UNIT_ASSERT_VALUES_EQUAL(error, "columns should be set");
         auto columnSettings = settings.add_columns();
 
-        UNIT_ASSERT(!ValidateSettings(TVector<TString>{"text"}, settings, error));
-        UNIT_ASSERT_VALUES_EQUAL(error, "settings should have a column name");
+        UNIT_ASSERT(!ValidateSettings(settings, error));
+        UNIT_ASSERT_VALUES_EQUAL(error, "column name should be set");
         columnSettings->set_column("text");
 
-        UNIT_ASSERT(!ValidateSettings(TVector<TString>{"text"}, settings, error));
-        UNIT_ASSERT_VALUES_EQUAL(error, "settings columns should have a single fulltext column");
+        UNIT_ASSERT(!ValidateSettings(settings, error));
+        UNIT_ASSERT_VALUES_EQUAL(error, "column analyzers should be set");
         auto columnAnalyzers = columnSettings->mutable_analyzers();
 
-        UNIT_ASSERT(!ValidateSettings(TVector<TString>{"text"}, settings, error));
+        UNIT_ASSERT(!ValidateSettings(settings, error));
         UNIT_ASSERT_VALUES_EQUAL(error, "tokenizer should be set");
         columnAnalyzers->set_tokenizer(Ydb::Table::FulltextIndexSettings::STANDARD);
 
-        // success:
-        UNIT_ASSERT_C(ValidateSettings(TVector<TString>{"text"}, settings, error), error);
+        UNIT_ASSERT_C(ValidateSettings(settings, error), error);
         UNIT_ASSERT_VALUES_EQUAL(error, "");
-
-        UNIT_ASSERT_C(!ValidateSettings(TVector<TString>{}, settings, error), error);
-        UNIT_ASSERT_VALUES_EQUAL(error, "key columns should be set");
-
-        UNIT_ASSERT_C(!ValidateSettings(TVector<TString>{"text2"}, settings, error), error);
-        UNIT_ASSERT_VALUES_EQUAL(error, "settings should have matching key columns and fulltext columns but [ text2 ] not equal to [ text ]");
-
-        UNIT_ASSERT_C(!ValidateSettings(TVector<TString>{"text", "text2"}, settings, error), error);
-        UNIT_ASSERT_VALUES_EQUAL(error, "settings should have matching key columns and fulltext columns but [ text text2 ] not equal to [ text ]");
 
         columnSettings = settings.add_columns();
         columnSettings->set_column("text2");
-        UNIT_ASSERT_C(!ValidateSettings(TVector<TString>{"text"}, settings, error), error);
-        UNIT_ASSERT_VALUES_EQUAL(error, "settings should have matching key columns and fulltext columns but [ text ] not equal to [ text text2 ]");
-
-        UNIT_ASSERT_C(!ValidateSettings(TVector<TString>{"text", "text2"}, settings, error), error);
-        UNIT_ASSERT_VALUES_EQUAL(error, "settings columns should have a single fulltext column");
+        UNIT_ASSERT_C(!ValidateSettings(settings, error), error);
+        UNIT_ASSERT_VALUES_EQUAL(error, "columns should have a single value");
     }
 
     Y_UNIT_TEST(FillSettings) {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1799,14 +1799,12 @@ message TEvBuildFulltextIndexRequest {
     optional uint64 SeqNoGeneration = 6;
     optional uint64 SeqNoRound = 7;
 
-    optional Ydb.Table.FulltextIndexSettings Settings = 8;
+    optional string IndexName = 8;
 
-    optional string IndexName = 9;
+    optional Ydb.Table.FulltextIndexSettings Settings = 9; // also has key columns
+    repeated string DataColumns = 10;
 
-    repeated string KeyColumns = 10;
-    repeated string DataColumns = 11;
-
-    optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 12;
+    optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 11;
 }
 
 message TEvBuildFulltextIndexResponse {

--- a/ydb/core/tx/datashard/build_index/fulltext.cpp
+++ b/ydb/core/tx/datashard/build_index/fulltext.cpp
@@ -390,12 +390,8 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildFulltextIndexRequest::TPtr& ev
         if (!request.HasSettings()) {
             badRequest(TStringBuilder() << "Missing fulltext index settings");
         } else {
-            TVector<TString> keyColumns(::Reserve(request.GetSettings().columns().size()));
-            for (auto column : request.GetSettings().columns()) {
-                keyColumns.push_back(column.column());
-            }
             TString error;
-            if (!NKikimr::NFulltext::ValidateSettings(keyColumns, request.GetSettings(), error)) {
+            if (!NKikimr::NFulltext::ValidateSettings(request.GetSettings(), error)) {
                 badRequest(error);
             }
         }

--- a/ydb/core/tx/datashard/build_index/ut/ut_fulltext.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_fulltext.cpp
@@ -54,8 +54,6 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
 
         request.SetIndexName(kIndexTable);
 
-        request.AddKeyColumns("text");
-
         setupRequest(request);
 
         return datashards[0];
@@ -176,24 +174,17 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
         }, "{ <main>: Error: Missing fulltext index settings }");
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
             request.MutableSettings()->clear_columns();
-        }, "{ <main>: Error: fulltext index should have a single text key column settings but have 0 of them }");
+        }, "{ <main>: Error: settings columns should be set }");
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
             request.MutableSettings()->mutable_columns()->at(0).mutable_analyzers()->clear_tokenizer();
         }, "{ <main>: Error: tokenizer should be set }");
-        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
-            request.MutableSettings()->mutable_columns()->at(0).set_column("data");
-        }, "{ <main>: Error: fulltext index should have a single text key column text settings but have data }");
 
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
             request.ClearIndexName();
         }, "{ <main>: Error: Empty index table name }");
 
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
-            request.ClearKeyColumns();
-        }, "{ <main>: Error: fulltext index should have a single text key column but have 0 of them }");
-        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
-            request.ClearKeyColumns();
-            request.AddKeyColumns("some");
+            request.MutableSettings()->mutable_columns()->at(0).set_column("some");
         }, "{ <main>: Error: Unknown key column: some }");
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
             request.AddDataColumns("some");
@@ -202,9 +193,8 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
         // test multiple issues:
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
             request.ClearIndexName();
-            request.ClearKeyColumns();
-            request.AddKeyColumns("some");
-        }, "[ { <main>: Error: Empty index table name } { <main>: Error: Unknown key column: some } ]");
+            request.AddDataColumns("some");
+        }, "[ { <main>: Error: Empty index table name } { <main>: Error: Unknown data column: some } ]");
     }
 
     Y_UNIT_TEST(Build) {

--- a/ydb/core/tx/datashard/build_index/ut/ut_fulltext.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_fulltext.cpp
@@ -174,7 +174,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
         }, "{ <main>: Error: Missing fulltext index settings }");
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
             request.MutableSettings()->clear_columns();
-        }, "{ <main>: Error: settings columns should be set }");
+        }, "{ <main>: Error: columns should be set }");
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
             request.MutableSettings()->mutable_columns()->at(0).mutable_analyzers()->clear_tokenizer();
         }, "{ <main>: Error: tokenizer should be set }");

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -153,7 +153,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     return {CreateReject(nextId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Fulltext index support is disabled")};
                 }
                 TString msg;
-                if (!NKikimr::NFulltext::ValidateSettings(indexDescription.keycolumnnames(), indexDescription.GetFulltextIndexDescription().GetSettings(), msg)) {
+                if (!NKikimr::NFulltext::ValidateSettings(indexDescription.GetFulltextIndexDescription().GetSettings(), msg)) {
                     return {CreateReject(nextId, NKikimrScheme::EStatus::StatusInvalidParameter, msg)};
                 }
                 break;

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -282,7 +282,7 @@ private:
             buildInfo.IndexType = NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltext;
             NKikimrSchemeOp::TFulltextIndexDescription fulltextIndexDescription;
             *fulltextIndexDescription.MutableSettings() = index.global_fulltext_index().fulltext_settings();
-            if (!NKikimr::NFulltext::ValidateSettings(index.index_columns(), fulltextIndexDescription.GetSettings(), explain)) {
+            if (!NKikimr::NFulltext::ValidateSettings(fulltextIndexDescription.GetSettings(), explain)) {
                 return false;
             }
             buildInfo.SpecializedIndexDescription = fulltextIndexDescription;

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -243,9 +243,10 @@ message FulltextIndexSettings {
     // See Layout enum
     optional Layout layout = 1;
 
-    // List of columns and their fulltext settings
-    // Currently, this list should contain a single entry
-    // And provided column should be the only one in the TableIndex.index_columns list
+    // List of columns and their full-text search settings
+    // Currently, this list should contain a single entry with specified analyzers
+    // This list must always match TableIndex.index_columns
+    // Some columns may not use analyzers and will be indexed as-is
     repeated ColumnAnalyzers columns = 2;
 }
 

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -243,10 +243,10 @@ message FulltextIndexSettings {
     // See Layout enum
     optional Layout layout = 1;
 
-    // List of columns and their full-text search settings
+    // List of columns and their fulltext settings
     // Currently, this list should contain a single entry with specified analyzers
+    // Later, some columns may not use analyzers and will be indexed as-is
     // This list must always match TableIndex.index_columns
-    // Some columns may not use analyzers and will be indexed as-is
     repeated ColumnAnalyzers columns = 2;
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

In addition to #24439.

I've realized, that some text columns may be simultaniously used as fulltext and as keys (for example git/arcradia branches).

So, I've propose to transform `FulltextIndexSettings.columns` list into all index key columns, not only fulltext ones.

This allows us to make this syntax work (`title` column is indexed in two ways):

```
INDEX my_index GLOBAL SYNC USING fulltext ON (
    title WITH (tokenizer = "standard", language = "russian"),
    title,
    content WITH (tokenizer = "keyword", language = "english")
) 
WITH (layout = "flat")
```

Also separated columns list validation for better readability.