### PR TITLE
Use latest step from timecast instead of local time when possible

### DIFF
--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -1184,6 +1184,19 @@ ui64 TPipeline::OutdatedCleanupStep() const
     return LastPlannedTx.Step;
 }
 
+ui64 TPipeline::AllowedDataStep() const
+{
+    ui64 latestStep = 0;
+    if (Self->MediatorTimeCastEntry) {
+        // This could be zero when still initializing
+        latestStep = Self->MediatorTimeCastEntry->GetLatestStep();
+    }
+
+    return Max(
+        LastPlannedTx.Step + 1,
+        latestStep ? latestStep + 1 : TAppData::TimeProvider->Now().MilliSeconds());
+}
+
 ui64 TPipeline::GetTxCompleteLag(EOperationKind kind, ui64 timecastStep) const
 {
     auto &plan = Self->TransQueue.GetPlan(kind);

--- a/ydb/core/tx/datashard/datashard_pipeline.h
+++ b/ydb/core/tx/datashard/datashard_pipeline.h
@@ -141,7 +141,7 @@ public:
     bool AssignPlanInterval(TOperation::TPtr op);
     ui64 OutdatedReadSetStep() const;
     ui64 OutdatedCleanupStep() const;
-    ui64 AllowedDataStep() const { return Max(LastPlannedTx.Step + 1, TAppData::TimeProvider->Now().MilliSeconds()); }
+    ui64 AllowedDataStep() const;
     ui64 AllowedSchemaStep() const { return LastPlannedTx.Step + 1; }
     ui64 VacantSchemaStep() const { return KeepSchemaStep + 1; }
 

--- a/ydb/core/tx/time_cast/time_cast.cpp
+++ b/ydb/core/tx/time_cast/time_cast.cpp
@@ -56,6 +56,12 @@ void TMediatorTimecastEntry::SetFrozenStep(ui64 step) noexcept {
     FrozenStep.store(step, std::memory_order_relaxed);
 }
 
+ui64 TMediatorTimecastEntry::GetLatestStep() const noexcept {
+    ui64 latest = LatestStep->Get();
+    ui64 safe = SafeStep->Get();
+    return Max(latest, safe);
+}
+
 class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
     struct TEvPrivate {
         enum EEv {

--- a/ydb/core/tx/time_cast/time_cast.h
+++ b/ydb/core/tx/time_cast/time_cast.h
@@ -43,6 +43,8 @@ public:
     ui64 GetFrozenStep() const noexcept;
     void SetFrozenStep(ui64 step) noexcept;
 
+    ui64 GetLatestStep() const noexcept;
+
 private:
     const TMediatorTimecastSharedEntry::TCPtr SafeStep;
     const TMediatorTimecastSharedEntry::TCPtr LatestStep;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Local time might be too far in the future due to ntp sync problems, so it's preferrable to use latest timecast step when available. Since this is used for calculating min/max step to have a roughly 30 seconds timeout on abandoned transactions, we don't need this timestamp precise, and it's preferrable to have it as close to the latest coordinator step as possible.

Fixes #25185.