### PR TITLE
Compatible Scalar and Block HashV2 Shuffles

### DIFF
--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -526,7 +526,7 @@ private:
             if (hashShuffle.HashFunc().IsValid()) {
                 hashFunc = hashShuffle.HashFunc().Cast().StringValue();
             } else {
-                hashFunc = "HashV1";
+                hashFunc = ToString(SerializerCtx.Config->DefaultHashShuffleFuncType);
             }
         } else if (auto merge = connection.Maybe<TDqCnMerge>()) {
             planNode.TypeName = "Merge";

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1479,6 +1479,7 @@ private:
             for (const auto& keyColumn : shuffle.KeyColumns()) {
                 shuffleProto.AddKeyColumns(TString(keyColumn));
             }
+
             NDq::EHashShuffleFuncType hashFuncType = Config->DefaultHashShuffleFuncType;
             if (shuffle.HashFunc().IsValid()) {
                 hashFuncType = FromString<NDq::EHashShuffleFuncType>(shuffle.HashFunc().Cast().StringValue());

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1479,8 +1479,7 @@ private:
             for (const auto& keyColumn : shuffle.KeyColumns()) {
                 shuffleProto.AddKeyColumns(TString(keyColumn));
             }
-
-            NDq::EHashShuffleFuncType hashFuncType = NDq::EHashShuffleFuncType::HashV1;
+            NDq::EHashShuffleFuncType hashFuncType = Config->DefaultHashShuffleFuncType;
             if (shuffle.HashFunc().IsValid()) {
                 hashFuncType = FromString<NDq::EHashShuffleFuncType>(shuffle.HashFunc().Cast().StringValue());
             }

--- a/ydb/core/kqp/runtime/kqp_tasks_runner.cpp
+++ b/ydb/core/kqp/runtime/kqp_tasks_runner.cpp
@@ -35,7 +35,7 @@ IDqOutputConsumer::TPtr KqpBuildOutputConsumer(const NDqProto::TTaskOutput& outp
             GetColumnsInfo(type, outputDesc.GetRangePartition().GetKeyColumns(), keyColumns);
             YQL_ENSURE(!keyColumns.empty());
             for (auto& info : keyColumns) {
-                NScheme::TTypeInfo typeInfo = NScheme::TypeInfoFromMiniKQLType(info.Type);
+                NScheme::TTypeInfo typeInfo = NScheme::TypeInfoFromMiniKQLType(info.DataType);
                 keyColumnTypeInfos.emplace_back(typeInfo);
                 keyColumnIndices.emplace_back(info.Index);
             }

--- a/ydb/core/kqp/ut/runtime/kqp_hash_shuffle_ut.cpp
+++ b/ydb/core/kqp/ut/runtime/kqp_hash_shuffle_ut.cpp
@@ -1,0 +1,103 @@
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/kqp/counters/kqp_counters.h>
+
+#include <util/system/fs.h>
+
+namespace NKikimr {
+namespace NKqp {
+
+using namespace NYdb;
+using namespace NYdb::NTable;
+
+Y_UNIT_TEST_SUITE(HashShuffle) {
+
+    void RunHashShuffleCompatibility(bool shuffleElimination, bool hashV2) {
+        TKikimrSettings settings;
+
+        settings.AppConfig.MutableTableServiceConfig()->SetDefaultEnableShuffleElimination(shuffleElimination);
+        settings.AppConfig.MutableTableServiceConfig()->SetDefaultHashShuffleFuncType(
+            hashV2 ? NKikimrConfig::TTableServiceConfig_EHashKind_HASH_V2
+                   : NKikimrConfig::TTableServiceConfig_EHashKind_HASH_V1
+        );
+        settings.AppConfig.MutableTableServiceConfig()->SetAllowOlapDataQuery(true);
+        settings.AppConfig.MutableTableServiceConfig()->SetEnableSpillingNodes("All");
+        settings.AppConfig.MutableTableServiceConfig()->SetEnableQueryServiceSpilling(true);
+        settings.AppConfig.MutableTableServiceConfig()->SetBlockChannelsMode(NKikimrConfig::TTableServiceConfig_EBlockChannelsMode_BLOCK_CHANNELS_AUTO);
+
+        TKikimrRunner kikimr(settings);
+
+        // we need following:
+        //
+        // 1. hash join
+        // 2. scalar input (forced by scalar combiner) and possible block input (propagated from CS read)
+        // 3. optional field in shuffle (caused by left join)
+        //
+        // HashV1 should prevent block propagation (both inputs are scalar)
+        // HashV2 should provide correct answer in case of scalar vs block shuffles
+
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+        {
+            const TString query = R"(
+                CREATE TABLE `/Root/Table1` (
+                    k1 Uint32 NOT NULL,
+                    k2 Uint32,
+                    PRIMARY KEY (k1)
+                )
+                PARTITION BY HASH (k1)
+                WITH (STORE = COLUMN, PARTITION_COUNT = 4);
+            )";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            const TString query = R"(
+                CREATE TABLE `/Root/Table2` (
+                    k2 Uint32,
+                    k3 Uint32 NOT NULL,
+                    PRIMARY KEY (k3)
+                )
+                PARTITION BY HASH (k3)
+                WITH (STORE = COLUMN, PARTITION_COUNT = 4);
+            )";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto result = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/Table1` (k1, k2) VALUES (0, 1), (1, 1), (2, 2), (3, 2), (4, 3), (5, 3), (6, 4), (7, 5);
+            )", TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto result = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/Table2` (k2, k3) VALUES (1, 1), (2, 2), (3, 3), (5, 4), (6, 5), (7, 6);
+            )", TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            TString query = R"(
+                PRAGMA ydb.OptimizerHints = 'JoinType(t1 t2 Shuffle)';
+                SELECT SUM(t2.k3) FROM (
+                    SELECT COUNT(*) as cnt, k2 FROM `/Root/Table1` GROUP BY k1, k2
+                ) as t1 LEFT JOIN `/Root/Table2` as t2 on t1.k2 = t2.k2
+            )";
+
+            NYdb::NTable::TExecDataQuerySettings settings;
+            settings.CollectQueryStats(ECollectQueryStatsMode::Full);
+            auto result = session.ExecuteDataQuery(query, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(), settings).GetValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            Cerr << *result.GetStats()->GetAst() << Endl;
+            CompareYson(FormatResultSetYson(result.GetResultSet(0)), R"([[[16u]]])");
+        }
+    }
+
+    Y_UNIT_TEST_QUAD(Compatibility, ShuffleElimination, HashV2) {
+        RunHashShuffleCompatibility(ShuffleElimination, HashV2);
+    }
+
+
+} // suite
+
+} // namespace NKqp
+} // namespace NKikimr

--- a/ydb/core/kqp/ut/runtime/ya.make
+++ b/ydb/core/kqp/ut/runtime/ya.make
@@ -5,9 +5,10 @@ FORK_SUBTESTS()
 SIZE(MEDIUM)
 
 SRCS(
+    kqp_hash_shuffle_ut.cpp
+    kqp_re2_ut.cpp
     kqp_scan_spilling_ut.cpp
     kqp_scan_logging_ut.cpp
-    kqp_re2_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/runtime/dq_columns_resolve.cpp
+++ b/ydb/library/yql/dq/runtime/dq_columns_resolve.cpp
@@ -31,10 +31,6 @@ TMaybe<TColumnInfo> FindColumnInfo(const NKikimr::NMiniKQL::TType* type, TString
         idx = *columnIndex;
     }
 
-    if (memberType->GetKind() == TType::EKind::Optional) {
-        memberType = static_cast<TOptionalType&>(*memberType).GetItemType();
-    }
-
     return TColumnInfo{TString(columnName), idx, memberType, isScalar};
 }
 

--- a/ydb/library/yql/dq/runtime/dq_columns_resolve.h
+++ b/ydb/library/yql/dq/runtime/dq_columns_resolve.h
@@ -10,15 +10,17 @@ namespace NYql::NDq {
 struct TColumnInfo {
     TString Name;
     ui32 Index;
-    NKikimr::NMiniKQL::TType* Type;
+    NKikimr::NMiniKQL::TType* OriginalType; // may be optional
+    NKikimr::NMiniKQL::TType* DataType;     // optionality removed
     TMaybe<bool> IsScalar; // defined only on block types
 
     TColumnInfo(TString name, ui32 index, NKikimr::NMiniKQL::TType* type, TMaybe<bool> isScalar)
         : Name(name)
         , Index(index)
-        , Type(type)
+        , OriginalType(type)
         , IsScalar(isScalar)
     {
+        DataType = (type->GetKind() == NKikimr::NMiniKQL::TType::EKind::Optional) ? static_cast<NKikimr::NMiniKQL::TOptionalType&>(*type).GetItemType() : type;
     }
 
     bool IsBlockOrScalar() const {
@@ -26,8 +28,8 @@ struct TColumnInfo {
     }
 
     NUdf::TDataTypeId GetTypeId() const {
-        YQL_ENSURE(Type->GetKind() == NKikimr::NMiniKQL::TType::EKind::Data);
-        return static_cast<NKikimr::NMiniKQL::TDataType&>(*Type).GetSchemeType();
+        YQL_ENSURE(DataType->GetKind() == NKikimr::NMiniKQL::TType::EKind::Data);
+        return static_cast<NKikimr::NMiniKQL::TDataType&>(*DataType).GetSchemeType();
     }
 };
 

--- a/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
@@ -70,9 +70,17 @@ struct THashV2 : public THashBase {
         const NKikimr::NMiniKQL::TType* outputType
     )
     {
-        auto multiType = static_cast<const NMiniKQL::TMultiType*>(outputType);
-        for (const auto& column : keyColumns) {
-            Hashers.emplace_back(MakeHashImpl(multiType->GetElementType(column.Index)));
+        if (outputType->GetKind() == NKikimr::NMiniKQL::TType::EKind::Multi) {
+            auto multiType = static_cast<const NMiniKQL::TMultiType*>(outputType);
+            for (const auto& column : keyColumns) {
+                Hashers.emplace_back(MakeHashImpl(multiType->GetElementType(column.Index)));
+            }
+        } else {
+            YQL_ENSURE(outputType->GetKind() == NKikimr::NMiniKQL::TType::EKind::Struct);
+            auto structType = static_cast<const TStructType*>(outputType);
+            for (const auto& column : keyColumns) {
+                Hashers.emplace_back(MakeHashImpl(structType->GetMemberType(column.Index)));
+            }
         }
     }
 


### PR DESCRIPTION
Make Scalar and Block HashV2 Shuffles compatible in relation to Optional (NULL-able) fields

Problem was discovered in #20440

Also revert workaround in peephole optimizer and change DefaultHashShuffleFuncType config settings behaviour not to depend on Shuffle Elimination 