### PR TITLE
fix timestamps order of the blobs after compaction

### DIFF
--- a/ydb/core/persqueue/pqtablet/blob/blob.h
+++ b/ydb/core/persqueue/pqtablet/blob/blob.h
@@ -212,7 +212,7 @@ public:
     };
 
     std::optional<TFormedBlobInfo> Add(TClientBlob&& blob);
-    std::optional<TFormedBlobInfo> Add(const TKey& key, ui32 size);
+    std::optional<TFormedBlobInfo> Add(const TKey& key, ui32 size, TInstant timestamp);
 
     bool IsInited() const;
     bool IsComplete() const;
@@ -224,19 +224,24 @@ public:
     bool IsNextPart(const TString& sourceId, const ui64 seqNo, const ui16 partNo, TString *reason) const;
 
     struct TRenameFormedBlobInfo {
-        TRenameFormedBlobInfo() = default;
-        TRenameFormedBlobInfo(const TKey& oldKey, const TKey& newKey, ui32 size);
+        TRenameFormedBlobInfo() = delete;
+        TRenameFormedBlobInfo(const TKey& oldKey, const TKey& newKey, ui32 size, TInstant creationUnixTime);
 
         TKey OldKey;
         TKey NewKey;
         ui32 Size;
+        TInstant CreationUnixTime;
     };
 
     const std::deque<TClientBlob>& GetClientBlobs() const { return Blobs; }
     const std::deque<TRenameFormedBlobInfo>& GetFormedBlobs() const { return FormedBlobs; }
 
 private:
-    TString CompactHead(bool glueHead, THead& head, bool glueNewHead, THead& newHead, ui32 estimatedSize);
+    struct TCompactHeadResult {
+        TString ValueD;
+        TInstant EndWriteTimestamp;
+    };
+    TCompactHeadResult CompactHead(bool glueHead, THead& head, bool glueNewHead, THead& newHead, ui32 estimatedSize);
     std::optional<TFormedBlobInfo> CreateFormedBlob(ui32 size, bool useRename);
 
 private:

--- a/ydb/core/persqueue/pqtablet/cache/read.h
+++ b/ydb/core/persqueue/pqtablet/cache/read.h
@@ -304,9 +304,10 @@ namespace NPQ {
                     auto key = TKey::FromString(strKey);
 
                     const TString& value = cmd.GetValue();
-                    TRequestedBlob reqBlob(key.GetOffset(), key.GetPartNo(), key.GetCount(), key.GetInternalPartsCount(), value.size(), value, key, 0); // TODO: fill & use cmd.GetCreationUnixTime()
+                    TRequestedBlob reqBlob(key.GetOffset(), key.GetPartNo(), key.GetCount(), key.GetInternalPartsCount(), value.size(), value, key, cmd.GetCreationUnixTime());
                     kvReq.Partition = key.GetPartition();
                     kvReq.Blobs.push_back(std::move(reqBlob));
+                    Y_ASSERT(cmd.GetCreationUnixTime() != 0);
                     const TRequestedBlob& blob = kvReq.Blobs.back();
 
                     LOG_D("CacheProxy. Passthrough blob. Partition "

--- a/ydb/core/persqueue/pqtablet/cache/read.h
+++ b/ydb/core/persqueue/pqtablet/cache/read.h
@@ -307,7 +307,6 @@ namespace NPQ {
                     TRequestedBlob reqBlob(key.GetOffset(), key.GetPartNo(), key.GetCount(), key.GetInternalPartsCount(), value.size(), value, key, cmd.GetCreationUnixTime());
                     kvReq.Partition = key.GetPartition();
                     kvReq.Blobs.push_back(std::move(reqBlob));
-                    Y_ASSERT(cmd.GetCreationUnixTime() != 0);
                     const TRequestedBlob& blob = kvReq.Blobs.back();
 
                     LOG_D("CacheProxy. Passthrough blob. Partition "

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -249,13 +249,16 @@ bool TPartition::CanEnqueue() const {
 }
 
 ui64 GetOffsetEstimate(const std::deque<TDataKey>& container, TInstant timestamp, ui64 offset) {
+    return GetOffsetEstimate(container, timestamp).GetOrElse(offset);
+}
+
+TMaybe<ui64> GetOffsetEstimate(const std::deque<TDataKey>& container, TInstant timestamp) {
     if (container.empty()) {
-        return offset;
+        return Nothing();
     }
-    auto it = std::lower_bound(container.begin(), container.end(), timestamp,
-                    [](const TDataKey& p, const TInstant timestamp) { return timestamp > p.Timestamp; });
+    auto it = std::ranges::lower_bound(container, timestamp, {}, &TDataKey::Timestamp);
     if (it == container.end()) {
-        return offset;
+        return Nothing();
     } else {
         return it->Key.GetOffset();
     }

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -2880,7 +2880,7 @@ void TPartition::CommitWriteOperations(TTransaction& t)
 
         for (auto& k : t.WriteInfo->BodyKeys) {
             LOG_D("add key " << k.Key.ToString());
-            auto write = BlobEncoder.PartitionedBlob.Add(k.Key, k.Size);
+            auto write = BlobEncoder.PartitionedBlob.Add(k.Key, k.Size, k.Timestamp);
             if (write && !write->Value.empty()) {
                 AddCmdWriteWithDeferredTimestamp(write, PersistRequest.Get(), ctx);
                 BlobEncoder.CompactedKeys.emplace_back(write->Key, write->Value.size());

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -194,7 +194,7 @@ private:
     void SendReadingFinished(const TString& consumer);
 
     void AddNewFastWriteBlob(std::pair<TKey, ui32>& res, TEvKeyValue::TEvRequest* request, const TActorContext& ctx);
-    void AddNewCompactionWriteBlob(std::pair<TKey, ui32>& res, TEvKeyValue::TEvRequest* request, ui64 blobCreationUnixTime, const TActorContext& ctx);
+    void AddNewCompactionWriteBlob(std::pair<TKey, ui32>& res, TEvKeyValue::TEvRequest* request, TInstant blobCreationUnixTime, const TActorContext& ctx);
     void AnswerCurrentWrites(const TActorContext& ctx);
     void AnswerCurrentReplies(const TActorContext& ctx);
     void CancelOneWriteOnWrite(const TActorContext& ctx,
@@ -839,7 +839,7 @@ private:
     void EndHandleRequests(TEvKeyValue::TEvRequest* request, const TActorContext& ctx);
     void BeginProcessWrites(const TActorContext& ctx);
     void EndProcessWrites(TEvKeyValue::TEvRequest* request, const TActorContext& ctx);
-    void EndProcessWritesForCompaction(TEvKeyValue::TEvRequest* request, ui64 blobCreationUnixTime, const TActorContext& ctx);
+    void EndProcessWritesForCompaction(TEvKeyValue::TEvRequest* request, TInstant blobCreationUnixTime, const TActorContext& ctx);
     void BeginAppendHeadWithNewWrites(const TActorContext& ctx);
     void EndAppendHeadWithNewWrites(const TActorContext& ctx);
 
@@ -1076,7 +1076,7 @@ private:
 
     void AddCmdWrite(const std::optional<TPartitionedBlob::TFormedBlobInfo>& newWrite,
                      TEvKeyValue::TEvRequest* request,
-                     ui64 creationUnixTime,
+                     TInstant creationUnixTime,
                      const TActorContext& ctx,
                      bool includeToWriteCycle = true);
     void AddCmdWriteWithDeferredTimestamp(const std::optional<TPartitionedBlob::TFormedBlobInfo>& newWrite,
@@ -1085,7 +1085,7 @@ private:
                      bool includeToWriteCycle = true);
     void AddCmdWriteImpl(const std::optional<TPartitionedBlob::TFormedBlobInfo>& newWrite,
                      TEvKeyValue::TEvRequest* request,
-                     ui64 creationUnixTime,
+                     TInstant creationUnixTime,
                      const TActorContext& ctx,
                      bool includeToWriteCycle,
                      struct TPartitionsPrivateAddCmdWriteTag);
@@ -1115,7 +1115,7 @@ private:
     void BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& blobs);
     void BlobsForCompactionWereWrite();
     ui64 NextReadCookie();
-    bool ExecRequestForCompaction(TWriteMsg& p, TProcessParametersBase& parameters, TEvKeyValue::TEvRequest* request, ui64 blobCreationUnixTime);
+    bool ExecRequestForCompaction(TWriteMsg& p, TProcessParametersBase& parameters, TEvKeyValue::TEvRequest* request, TInstant blobCreationUnixTime);
 
     bool CompactionInProgress = false;
     size_t CompactionBlobsCount = 0;

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -37,6 +37,7 @@ static const ui32 MAX_INLINE_SIZE = 1000;
 using TPartitionLabeledCounters = TProtobufTabletLabeledCounters<EPartitionLabeledCounters_descriptor>;
 
 ui64 GetOffsetEstimate(const std::deque<TDataKey>& container, TInstant timestamp, ui64 headOffset);
+TMaybe<ui64> GetOffsetEstimate(const std::deque<TDataKey>& container, TInstant timestamp);
 
 
 class TKeyLevel;

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -347,7 +347,7 @@ void TPartitionCompaction::TCompactState::AddCmdWrite(const TKey& key, TBatch& b
     batch.SerializeTo(data);
     TClientBlob::CheckBlob(key, data);
     UpdatedKeys.emplace(key, data.size());
-    PartitionActor->AddCmdWrite(TPartitionedBlob::TFormedBlobInfo{key, data}, Request.Get(), batch.EndWriteTimestamp.Seconds(), PartitionActor->ActorContext(), false);
+    PartitionActor->AddCmdWrite(TPartitionedBlob::TFormedBlobInfo{key, data}, Request.Get(), batch.EndWriteTimestamp, PartitionActor->ActorContext(), false);
     BlobsToWriteInRequest++;
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -303,7 +303,6 @@ void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& 
                 }, std::nullopt};
                 msg.Internal = true;
 
-                Y_DEBUG_ABORT_UNLESS(blobCreationUnixTime <= blob.WriteTimestamp);
                 blobCreationUnixTime = std::max(blobCreationUnixTime, blob.WriteTimestamp);
                 ExecRequestForCompaction(msg, parameters, compactionRequest.Get(), blob.WriteTimestamp);
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -270,8 +270,7 @@ void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& 
 
     for (const auto& requestedBlob : blobs) {
         TMaybe<ui64> firstBlobOffset = requestedBlob.Offset;
-
-        blobCreationUnixTime = requestedBlob.CreationUnixTime;
+        blobCreationUnixTime = std::max(blobCreationUnixTime, requestedBlob.CreationUnixTime);
 
         for (TBlobIterator it(requestedBlob.Key, requestedBlob.Value); it.IsValid(); it.Next()) {
             TBatch batch = it.GetBatch();
@@ -514,7 +513,7 @@ void TPartition::AddNewCompactionWriteBlob(std::pair<TKey, ui32>& res, TEvKeyVal
         CompactionBlobEncoder.NewHead.PartNo = 0;
     } else {
         AFL_ENSURE(CompactionBlobEncoder.NewHeadKey.Size == 0);
-        CompactionBlobEncoder.NewHeadKey = {key, res.second, CurrentTimestamp, 0, MakeBlobKeyToken(key.ToString())};
+        CompactionBlobEncoder.NewHeadKey = {key, res.second, PendingWriteTimestamp, 0, MakeBlobKeyToken(key.ToString())};
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -304,7 +304,7 @@ void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& 
                 }, std::nullopt};
                 msg.Internal = true;
 
-                ExecRequestForCompaction(msg, parameters, compactionRequest.Get(), blobCreationUnixTime);
+                ExecRequestForCompaction(msg, parameters, compactionRequest.Get(), blob.WriteTimestamp.Seconds());
 
                 firstBlobOffset = Nothing();
             }

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -481,8 +481,8 @@ void TPartition::AddNewCompactionWriteBlob(std::pair<TKey, ui32>& res, TEvKeyVal
 {
     const auto& key = res.first;
 
-    TString valueD = CompactionBlobEncoder.SerializeForKey(key, res.second, CompactionBlobEncoder.EndOffset, PendingWriteTimestamp);
-
+    TInstant compactionWriteTimestamp;
+    TString valueD = CompactionBlobEncoder.SerializeForKey(key, res.second, CompactionBlobEncoder.EndOffset, compactionWriteTimestamp);
     auto write = request->Record.AddCmdWrite();
     write->SetKey(key.Data(), key.Size());
     write->SetValue(valueD);
@@ -515,7 +515,7 @@ void TPartition::AddNewCompactionWriteBlob(std::pair<TKey, ui32>& res, TEvKeyVal
         CompactionBlobEncoder.NewHead.PartNo = 0;
     } else {
         AFL_ENSURE(CompactionBlobEncoder.NewHeadKey.Size == 0);
-        CompactionBlobEncoder.NewHeadKey = {key, res.second, PendingWriteTimestamp, 0, MakeBlobKeyToken(key.ToString())};
+        CompactionBlobEncoder.NewHeadKey = {key, res.second, compactionWriteTimestamp, 0, MakeBlobKeyToken(key.ToString())};
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -487,7 +487,7 @@ void TPartition::AddNewCompactionWriteBlob(std::pair<TKey, ui32>& res, TEvKeyVal
     write->SetKey(key.Data(), key.Size());
     write->SetValue(valueD);
     write->SetCreationUnixTime(blobCreationUnixTime.Seconds());  // note: The time is rounded to second precision.
-    Y_ASSERT(blobCreationUnixTime.Seconds() > 0);
+    // Y_ASSERT(blobCreationUnixTime.Seconds() > 0); TODO: move fake time in tests forward and enable checking
 
     bool isInline = key.IsHead() && valueD.size() < MAX_INLINE_SIZE;
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -311,7 +311,6 @@ void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& 
             }
         }
     }
-    Y_VERIFY(blobCreationUnixTime > TInstant::Zero());
 
     if (!CompactionBlobEncoder.IsLastBatchPacked()) {
         CompactionBlobEncoder.PackLastBatch();

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -680,11 +680,6 @@ void TInitDataRangeStep::FillBlobsMetaData(const NKikimrClient::TKeyValueRespons
                                   TInstant::Seconds(pair.GetCreationUnixTime()),
                                   dataKeysBody.empty() ? 0 : dataKeysBody.back().CumulativeSize + dataKeysBody.back().Size,
                                   Partition()->MakeBlobKeyToken(k.ToString()));
-        if (dataKeysBody.size() >= 2) {
-            const auto& prev = dataKeysBody[dataKeysBody.size() - 2];
-            const auto& curr = dataKeysBody[dataKeysBody.size() - 1];
-            PQ_INIT_ENSURE(prev.Timestamp <= curr.Timestamp)("prevTimestamp", prev.Timestamp)("currTimestamp", curr.Timestamp);
-        }
     }
     CheckKeysTimestampOrder(dataKeysBody);
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -680,6 +680,11 @@ void TInitDataRangeStep::FillBlobsMetaData(const NKikimrClient::TKeyValueRespons
                                   TInstant::Seconds(pair.GetCreationUnixTime()),
                                   dataKeysBody.empty() ? 0 : dataKeysBody.back().CumulativeSize + dataKeysBody.back().Size,
                                   Partition()->MakeBlobKeyToken(k.ToString()));
+        if (dataKeysBody.size() >= 2) {
+            const auto& prev = dataKeysBody[dataKeysBody.size() - 2];
+            const auto& curr = dataKeysBody[dataKeysBody.size() - 1];
+            PQ_INIT_ENSURE(prev.Timestamp <= curr.Timestamp)("prevTimestamp", prev.Timestamp)("currTimestamp", curr.Timestamp);
+        }
     }
     CheckKeysTimestampOrder(dataKeysBody);
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -45,17 +45,19 @@ ui64 TPartition::GetReadOffset(ui64 offset, TMaybe<TInstant> readTimestamp) cons
     if (!readTimestamp) {
         return offset;
     }
-    auto estimatedOffset = GetOffsetEstimate(CompactionBlobEncoder.DataKeysBody, *readTimestamp, Max<ui64>());
-    if (estimatedOffset == Max<ui64>()) {
-        estimatedOffset = GetOffsetEstimate(BlobEncoder.DataKeysBody, *readTimestamp, Max<ui64>());
+    TMaybe<ui64> estimatedOffset = GetOffsetEstimate(CompactionBlobEncoder.DataKeysBody, *readTimestamp);
+    if (!AppData()->FeatureFlags.GetEnableSkipMessagesWithObsoleteTimestamp()) {
+        if (!estimatedOffset.Defined()) {
+            estimatedOffset = GetOffsetEstimate(CompactionBlobEncoder.HeadKeys, *readTimestamp);
+        }
+        if (!estimatedOffset.Defined()) {
+            estimatedOffset = GetOffsetEstimate(BlobEncoder.DataKeysBody, *readTimestamp);
+        }
     }
-    if (estimatedOffset == Max<ui64>() && AppData()->FeatureFlags.GetEnableSkipMessagesWithObsoleteTimestamp()) {
-        estimatedOffset = GetOffsetEstimate(CompactionBlobEncoder.HeadKeys, *readTimestamp, Max<ui64>());
+    if (!estimatedOffset.Defined()) {
+        estimatedOffset = Min(BlobEncoder.Head.Offset, BlobEncoder.EndOffset - 1);
     }
-    if (estimatedOffset == Max<ui64>()) {
-        estimatedOffset = Min(BlobEncoder.Head.Offset, GetEndOffset() - 1);
-    }
-    return Max(estimatedOffset, offset);
+    return Max(*estimatedOffset, offset);
 }
 
 void TPartition::SendReadingFinished(const TString& consumer) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -1030,7 +1030,7 @@ struct TPartitionsPrivateAddCmdWriteTag {};
 
 void TPartition::AddCmdWrite(const std::optional<TPartitionedBlob::TFormedBlobInfo>& newWrite,
                              TEvKeyValue::TEvRequest* request,
-                             ui64 creationUnixTime,
+                             TInstant creationUnixTime,
                              const TActorContext& ctx,
                              bool includeToWriteCycle) {
     // Y_ASSERT(creationUnixTime > 0);  // TODO: remove test cases from the 1970s and return check
@@ -1039,7 +1039,7 @@ void TPartition::AddCmdWrite(const std::optional<TPartitionedBlob::TFormedBlobIn
 
 void TPartition::AddCmdWriteImpl(const std::optional<TPartitionedBlob::TFormedBlobInfo>& newWrite,
                              TEvKeyValue::TEvRequest* request,
-                             ui64 creationUnixTime,
+                             TInstant creationUnixTime,
                              const TActorContext& ctx,
                              bool includeToWriteCycle,
                              TPartitionsPrivateAddCmdWriteTag)
@@ -1047,8 +1047,9 @@ void TPartition::AddCmdWriteImpl(const std::optional<TPartitionedBlob::TFormedBl
     auto write = request->Record.AddCmdWrite();
     write->SetKey(newWrite->Key.Data(), newWrite->Key.Size());
     write->SetValue(newWrite->Value);
-    if (creationUnixTime) {
-        write->SetCreationUnixTime(creationUnixTime);
+    if (creationUnixTime != TInstant::Zero()) {
+        // note: The time is rounded to second precision.
+        write->SetCreationUnixTime(creationUnixTime.Seconds());
     }
     //PQ_ENSURE(newWrite->Key.IsFastWrite());
     auto channel = GetChannel(NextChannel(newWrite->Key.HasSuffix(), newWrite->Value.size()));
@@ -1066,7 +1067,7 @@ void TPartition::AddCmdWriteWithDeferredTimestamp(const std::optional<TPartition
                              const TActorContext& ctx,
                              bool includeToWriteCycle)
 {
-    AddCmdWriteImpl(newWrite, request, 0, ctx, includeToWriteCycle, {});
+    AddCmdWriteImpl(newWrite, request, TInstant::Zero(), ctx, includeToWriteCycle, {});
 }
 
 void TPartition::RenameFormedBlobs(const std::deque<TPartitionedBlob::TRenameFormedBlobInfo>& formedBlobs,

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -1082,6 +1082,9 @@ void TPartition::RenameFormedBlobs(const std::deque<TPartitionedBlob::TRenameFor
             auto rename = request->Record.AddCmdRename();
             rename->SetOldKey(x.OldKey.ToString());
             rename->SetNewKey(x.NewKey.ToString());
+            if (x.CreationUnixTime != TInstant::Zero()) {
+                rename->SetCreationUnixTime(x.CreationUnixTime.Seconds());
+            }
         }
         if (!zone.DataKeysBody.empty() && zone.CompactedKeys.empty()) {
             PQ_ENSURE(zone.DataKeysBody.back().Key.GetOffset() + zone.DataKeysBody.back().Key.GetCount() <= x.NewKey.GetOffset())

--- a/ydb/core/persqueue/ut/ut_with_sdk/topic_timestamp_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/topic_timestamp_ut.cpp
@@ -244,7 +244,7 @@ Y_UNIT_TEST_SUITE(TopicTimestamp) {
 
             const std::tuple<bool, ui32, TString, std::vector<ETimestampFnKind>> readTimestampKinds[]{
                 {true, xfailTimestampPositionMaxError, "exact", {ETimestampFnKind::Exact,}},
-                {true, 0, "offset+middle", {ETimestampFnKind::Offset, ETimestampFnKind::Middle,}},
+                {true, xfailTimestampPositionMaxError, "offset+middle", {ETimestampFnKind::Offset, ETimestampFnKind::Middle,}},
             };
 
             const std::tuple<bool, TString, bool> restartOptions[]{

--- a/ydb/core/persqueue/ut/ut_with_sdk/topic_timestamp_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/topic_timestamp_ut.cpp
@@ -46,7 +46,7 @@ Y_UNIT_TEST_SUITE(TopicTimestamp) {
             auto setup = TTopicSdkTestSetup("TopicReadTimestamp", settings, false);
 
             setup.GetRuntime().SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-            setup.GetRuntime().SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_DEBUG);
+            setup.GetRuntime().SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_TRACE);
             setup.GetRuntime().SetLogPriority(NKikimrServices::PQ_PARTITION_CHOOSER, NActors::NLog::PRI_TRACE);
             setup.GetRuntime().SetLogPriority(NKikimrServices::PQ_READ_PROXY, NActors::NLog::PRI_TRACE);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* заполняется timestamp blob'ов, взятых из кеша;
* операция rename берёт оригинальное время блоба;
* время compaction отвязано от времени партиции (CurrentTimestamp, PendingWriteTimestamp).


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->


https://st.yandex-team.ru/LOGBROKER-9742
https://st.yandex-team.ru/LOGBROKER-9846