### PR TITLE
YQ-4696 fixed federated query datastreams tests

### DIFF
--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -428,12 +428,14 @@ struct TEvScriptExecutionsTablesCreationFinished : public TEventLocal<TEvScriptE
 };
 
 struct TEvScriptExecutionRestarted : public TEventLocal<TEvScriptExecutionRestarted, TKqpScriptExecutionEvents::EvScriptExecutionRestarted> {
-    TEvScriptExecutionRestarted(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+    TEvScriptExecutionRestarted(Ydb::StatusIds::StatusCode status, bool leaseGenerationChanged, NYql::TIssues issues)
         : Status(status)
+        , LeaseGenerationChanged(leaseGenerationChanged)
         , Issues(std::move(issues))
     {}
 
     const Ydb::StatusIds::StatusCode Status;
+    const bool LeaseGenerationChanged = false;
     const NYql::TIssues Issues;
 };
 

--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -122,7 +122,22 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
 
         settings.EnableScriptExecutionBackgroundChecks = options.EnableScriptExecutionBackgroundChecks;
 
-        return std::make_shared<TKikimrRunner>(settings);
+        auto kikimr = std::make_shared<TKikimrRunner>(settings);
+
+        if (GetTestParam("DEFAULT_LOG", "enabled") == "enabled") {
+            auto& runtime = *kikimr->GetTestServer().GetRuntime();
+
+            const auto descriptor = NKikimrServices::EServiceKikimr_descriptor();
+            for (i64 i = 0; i < descriptor->value_count(); ++i) {
+                runtime.SetLogPriority(static_cast<NKikimrServices::EServiceKikimr>(descriptor->value(i)->number()), NLog::PRI_NOTICE);
+            }
+
+            runtime.SetLogPriority(NKikimrServices::KQP_EXECUTER, NLog::PRI_INFO);
+            runtime.SetLogPriority(NKikimrServices::KQP_PROXY, NLog::PRI_DEBUG);
+            runtime.SetLogPriority(NKikimrServices::KQP_COMPUTE, NLog::PRI_INFO);
+        }
+
+        return kikimr;
     }
 
 } // namespace NKikimr::NKqp::NFederatedQueryTest

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -80,6 +80,12 @@ public:
             Kikimr = MakeKikimrRunner(true, nullptr, nullptr, AppConfig, NYql::NDq::CreateS3ActorsFactory(), {
                 .PqGateway = PqGateway
             });
+
+            if (GetTestParam("DEFAULT_LOG", "enabled") == "enabled") {
+                auto& runtime = *Kikimr->GetTestServer().GetRuntime();
+                runtime.SetLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NLog::PRI_DEBUG);
+                runtime.SetLogPriority(NKikimrServices::STREAMS_CHECKPOINT_COORDINATOR, NLog::PRI_DEBUG);
+            }
         }
 
         return Kikimr;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed tests:

* TestRetryLimiter 
* RestoreScriptPhysicalGraphOnRetry 
* CreateStreamingQueryMatchRecognize 

Also increased default test logs level

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Described in comments for YQ-4696

Streaming queries fixes:

* Fixed streaming queries version check
* Fixed TLI retries (+ refactored retry actor definition)
* Fixed lease version change handling 