### PR TITLE
EXT-1430 Fix race in resource manager

### DIFF
--- a/ydb/core/kqp/rm_service/kqp_resource_info_exchanger.cpp
+++ b/ydb/core/kqp/rm_service/kqp_resource_info_exchanger.cpp
@@ -316,19 +316,18 @@ private:
             Schedule(at - now, new TEvPrivate::TEvUpdateSnapshotState);
             return;
         }
-        TVector<NKikimrKqp::TKqpNodeResources> resources;
-        resources.reserve(NodesState.size());
+        std::shared_ptr<TVector<NKikimrKqp::TKqpNodeResources>> resources = std::make_shared<TVector<NKikimrKqp::TKqpNodeResources>>();
+        resources->reserve(NodesState.size());
 
         for (const auto& [nodeId, state] : NodesState) {
             const auto& currentResources = state.NodeData.GetResources();
             if (currentResources.HasNodeId()) {
-                resources.push_back(std::move(currentResources));
+                resources->push_back(std::move(currentResources));
             }
         }
 
         with_lock (ResourceSnapshotState->Lock) {
-            ResourceSnapshotState->Snapshot =
-                std::make_shared<TVector<NKikimrKqp::TKqpNodeResources>>(std::move(resources));
+            ResourceSnapshotState->Snapshot = std::move(resources);
         }
 
         ResourceSnapshotRetryState.LastRetryAt = now;

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -171,7 +171,7 @@ public:
         SetConfigValues(config);
     }
 
-    void Bootstrap(NKikimrConfig::TTableServiceConfig::TResourceManager& config, TActorSystem* actorSystem, TActorId selfId) {
+    void Registered(NKikimrConfig::TTableServiceConfig::TResourceManager& config, TActorSystem* actorSystem, TActorId selfId) {
         ActorSystem = actorSystem;
         SelfId = selfId;
         if (!Counters) {
@@ -593,15 +593,16 @@ public:
     // Is called right after service registration
     // and before any usual actor can try to get ResourceManager
     void Registered(TActorSystem* sys, const TActorId& owner) override {
-        ResourceManager->Bootstrap(Config, sys, SelfId());
+        TActorBootstrapped::Registered(sys, owner);
+
+        ResourceManager->Registered(Config, sys, SelfId());
+
         with_lock (ResourceManagers.Lock) {
             if (ResourceManagers.Default.expired()) { // There can be several managers in tests
                 ResourceManagers.Default = ResourceManager;
             }
             ResourceManagers.ByNodeId[NodeId] = ResourceManager;
         }
-
-        TActorBootstrapped::Registered(sys, owner);
     }
 
     void Bootstrap() {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

https://github.com/ydb-platform/ydb/issues/23180

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

I was fixing the problem in issue https://github.com/ydb-platform/ydb/issues/23180 and found this problem

1. `NRm::ResourceManagers.Default` is first set and after that is initialized in Bootstrap()
2. `NRm::ResourceManagers.Default` is written and read in parallel