### PR TITLE
Autopartitioning of the topic by written bytes

### DIFF
--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -1152,6 +1152,8 @@ struct TEvPQ {
 
         NPQ::TSourceIdMap SrcIdInfo;
         std::deque<NPQ::TDataKey> BodyKeys;
+        // SourceId->WritenBytes
+        std::vector<std::pair<TString, ui64>> WrittenBytes;
 
         ui64 BytesWrittenTotal;
         ui64 BytesWrittenGrpc;

--- a/ydb/core/persqueue/pqrb/mirror_describer.cpp
+++ b/ydb/core/persqueue/pqrb/mirror_describer.cpp
@@ -45,9 +45,7 @@ void TMirrorDescriber::HandleChangeConfig(TEvPQ::TEvChangePartitionConfig::TPtr&
         ev->Get()->Config.GetPartitionConfig().GetMirrorFrom()
     );
     LOG_D("got new config, equal with previous: " << equalConfigs);
-    if (equalConfigs) {
-        DescribeTopic(ctx);
-    } else {
+    if (!equalConfigs) {
         Config = ev->Get()->Config.GetPartitionConfig().GetMirrorFrom();
         LOG_I("changing config");
         StartInit(ctx);

--- a/ydb/core/persqueue/pqrb/mirror_describer.cpp
+++ b/ydb/core/persqueue/pqrb/mirror_describer.cpp
@@ -45,7 +45,9 @@ void TMirrorDescriber::HandleChangeConfig(TEvPQ::TEvChangePartitionConfig::TPtr&
         ev->Get()->Config.GetPartitionConfig().GetMirrorFrom()
     );
     LOG_D("got new config, equal with previous: " << equalConfigs);
-    if (!equalConfigs) {
+    if (equalConfigs) {
+        DescribeTopic(ctx);
+    } else {
         Config = ev->Get()->Config.GetPartitionConfig().GetMirrorFrom();
         LOG_I("changing config");
         StartInit(ctx);

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.h
@@ -49,6 +49,7 @@ private:
     struct TPartitionScaleOperationInfo {
         ui32 PartitionId{};
         TMaybe<NKikimrPQ::TPartitionScaleParticipants> PartitionScaleParticipants;
+        TMaybe<TString> SplitBoundary;
     };
 
     struct TBuildSplitScaleRequestResult;
@@ -58,7 +59,10 @@ public:
         const NKikimrPQ::TPQTabletConfig& config, const TPartitionGraph& partitionGraph);
 
 public:
-    void HandleScaleStatusChange(const ui32 partition, NKikimrPQ::EScaleStatus scaleStatus, TMaybe<NKikimrPQ::TPartitionScaleParticipants> participants, const TActorContext& ctx);
+    void HandleScaleStatusChange(const ui32 partition, NKikimrPQ::EScaleStatus scaleStatus,
+        TMaybe<NKikimrPQ::TPartitionScaleParticipants> participants,
+        TMaybe<TString> splitBoundary,
+        const TActorContext& ctx);
     void HandleScaleRequestResult(TPartitionScaleRequest::TEvPartitionScaleRequestDone::TPtr& ev, const TActorContext& ctx);
     std::expected<void, std::string> HandleMirrorTopicDescriptionResult(TEvPQ::TEvMirrorTopicDescription::TPtr& ev, const TActorContext& ctx);
 

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.h
@@ -10,6 +10,7 @@
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
+#include <ydb/core/util/backoff.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 
 #include <util/system/types.h>
@@ -112,14 +113,12 @@ public:
     static const ui64 TRY_SCALE_REQUEST_WAKE_UP_TAG = 10;
 
 private:
-    static const ui32 MIN_SCALE_REQUEST_REPEAT_SECONDS_TIMEOUT = 10;
-    static const ui32 MAX_SCALE_REQUEST_REPEAT_SECONDS_TIMEOUT = 1000;
-
     const TString TopicName;
     const TString TopicPath;
     TString DatabasePath = "";
     TActorId CurrentScaleRequest;
-    TDuration RequestTimeout = TDuration::MilliSeconds(0);
+    TBackoff Backoff = TBackoff(TDuration::Seconds(1), TDuration::Minutes(15));
+    TDuration RequestTimeout;
     TInstant LastResponseTime = TInstant::Zero();
 
     TPartitionsToSplitMap PartitionsToSplit;

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -448,8 +448,7 @@ void TPersQueueReadBalancer::RequestTabletIfNeeded(const ui64 tabletId, const TA
             AggregatedStats.Cookies[tabletId] = cookie;
         }
 
-        PQ_LOG_D(
-            TStringBuilder() << "Send TEvPersQueue::TEvStatus TabletId: " << tabletId << " Cookie: " << cookie);
+        PQ_LOG_D("Send TEvPersQueue::TEvStatus TabletId: " << tabletId << " Cookie: " << cookie);
         NTabletPipe::SendData(ctx, pipeClient, new TEvPersQueue::TEvStatus("", true), cookie);
     }
 }
@@ -1016,6 +1015,7 @@ void TPersQueueReadBalancer::Handle(TPartitionScaleRequest::TEvPartitionScaleReq
 }
 
 void TPersQueueReadBalancer::Handle(TEvPQ::TEvMirrorTopicDescription::TPtr& ev, const TActorContext& ctx) {
+    PQ_LOG_D("Received TEvMirrorTopicDescription");
     if (!MirroringEnabled(TabletConfig)) {
         return;
     }

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -477,6 +477,7 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvStatusResponse::TPtr& ev, c
                 partitionId,
                 partRes.GetScaleStatus(),
                 partRes.HasScaleParticipatingPartitions() ? MakeMaybe(partRes.GetScaleParticipatingPartitions()) : Nothing(),
+                partRes.HasSplitBoundary() ? MakeMaybe(partRes.GetSplitBoundary()) : Nothing(),
                 ctx
             );
         }
@@ -997,6 +998,7 @@ void TPersQueueReadBalancer::Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr&
             record.GetPartitionId(),
             record.GetScaleStatus(),
             record.HasParticipatingPartitions() ? MakeMaybe(record.GetParticipatingPartitions()) : Nothing(),
+            record.HasSplitBoundary() ? MakeMaybe(record.GetSplitBoundary()) : Nothing(),
             ctx
         );
     } else {

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -151,7 +151,7 @@ public:
     }
 
     void RecreateSumWrittenBytes() {
-        SumWrittenBytes = std::move(TSlidingWindow(TDuration::Seconds(Config.GetPartitionStrategy().GetScaleThresholdSeconds()), Precision));
+        SumWrittenBytes.ConstructInPlace(TDuration::Seconds(Config.GetPartitionStrategy().GetScaleThresholdSeconds()), Precision);
     }
 
 private:

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -42,8 +42,8 @@ public:
         return std::nullopt;
     }
 
-    NKikimrPQ::EScaleStatus GetScaleStatus() override {
-        return NKikimrPQ::EScaleStatus::NORMAL;
+    NKikimrPQ::EScaleStatus GetScaleStatus(NKikimrPQ::EScaleStatus currentState) override {
+        return currentState;
     }
 
     void UpdateConfig(const NKikimrPQ::TPQTabletConfig& config) override {
@@ -82,7 +82,7 @@ public:
         return std::nullopt;
     }
 
-    NKikimrPQ::EScaleStatus GetScaleStatus() override {
+    NKikimrPQ::EScaleStatus GetScaleStatus(NKikimrPQ::EScaleStatus /*currentState*/) override {
         return NKikimrPQ::EScaleStatus::NORMAL;
     }
 
@@ -210,7 +210,7 @@ public:
         return MiddleOf(*lastLeft, *lastRight);
     }
 
-    NKikimrPQ::EScaleStatus GetScaleStatus() override {
+    NKikimrPQ::EScaleStatus GetScaleStatus(NKikimrPQ::EScaleStatus /*currentState*/) override {
         const auto writeSpeedUsagePercent = SumWrittenBytes->GetValue() * 100.0 / Config.GetPartitionStrategy().GetScaleThresholdSeconds() / Config.GetPartitionConfig().GetWriteSpeedInBytesPerSecond();
         const auto sourceIdWindow = TDuration::Seconds(std::min<ui32>(5, Config.GetPartitionStrategy().GetScaleThresholdSeconds()));
         const auto sourceIdCount = SourceIdCounter.Count(TInstant::Now() - sourceIdWindow);

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -157,6 +157,9 @@ public:
         });
 
         auto inRange = [&](const TString& sourceIdHash) {
+            if (sourceIdHash.empty()) {
+                return false;
+            }
             if (partition->GetKeyRange().HasFromBound() && sourceIdHash < partition->GetKeyRange().GetFromBound()) {
                 return false;
             }

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -100,7 +100,9 @@ public:
 
         SumWrittenBytes->Update(size, now);
 
-        TString sourceIdHash = AsKeyBound(Hash(NSourceIdEncoding::Decode(sourceId)));
+        TString sourceIdHash = sourceId // Kinesis protocol use empty sourceId
+            ? AsKeyBound(Hash(NSourceIdEncoding::Decode(sourceId)))
+            : sourceId;
 
         auto it = WrittenBytes.find(sourceIdHash);
         if (it == WrittenBytes.end()) {

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -13,12 +13,14 @@ namespace {
     void DoCleanUp(std::unordered_map<TString, TSlidingWindow>& writtenBytes) {
         auto now = TInstant::Now();
 
-        for (auto it = writtenBytes.begin(); it != writtenBytes.end(); ++it) {
+        for (auto it = writtenBytes.begin(); it != writtenBytes.end();) {
             auto& counter = it->second;
             counter.Update(now);
 
             if (0 == counter.GetValue()) {
                 it = writtenBytes.erase(it);
+            } else {
+                 ++it;
             }
         }
     }

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -19,8 +19,7 @@ public:
         return std::nullopt;
     }
 
-    NKikimrPQ::EScaleStatus GetScaleStatus(const NActors::TActorContext& ctx) override {
-        Y_UNUSED(ctx);
+    NKikimrPQ::EScaleStatus GetScaleStatus() override {
         return NKikimrPQ::EScaleStatus::NORMAL;
     }
 
@@ -119,10 +118,10 @@ public:
         return MiddleOf(*lastLeft, *lastRight);
     }
 
-    NKikimrPQ::EScaleStatus GetScaleStatus(const NActors::TActorContext& ctx) override {
+    NKikimrPQ::EScaleStatus GetScaleStatus() override {
         const auto writeSpeedUsagePercent = SumWrittenBytes->GetValue() * 100.0 / Config.GetPartitionStrategy().GetScaleThresholdSeconds() / Config.GetPartitionConfig().GetWriteSpeedInBytesPerSecond();
         const auto sourceIdWindow = TDuration::Seconds(std::min<ui32>(5, Config.GetPartitionStrategy().GetScaleThresholdSeconds()));
-        const auto sourceIdCount = SourceIdCounter.Count(ctx.Now() - sourceIdWindow);
+        const auto sourceIdCount = SourceIdCounter.Count(TInstant::Now() - sourceIdWindow);
         const auto canSplit = sourceIdCount > 1 || (sourceIdCount == 1 && SourceIdCounter.LastValue().empty() /* kinesis */);
 
         // LOG_D("TPartition::CheckScaleStatus"

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -188,7 +188,7 @@ public:
             }
         } while (i < j);
 
-        if (oWrittenBytes >= lWrittenBytes / 2 || oWrittenBytes >= rWrittenBytes / 2) {
+        if (oWrittenBytes >= lWrittenBytes || oWrittenBytes >= rWrittenBytes) {
             // The volume of entries in the partition with the SourceID manually linked to the partition is significant.
             //  We divide the partition in half.
             return MiddleOf(partition->GetKeyRange().GetFromBound(), partition->GetKeyRange().GetToBound());

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -186,7 +186,7 @@ public:
                 --j;
                 lastRight = &rhs.first;
             }
-        } while (i < j);
+        } while (i <= j);
 
         if (oWrittenBytes >= lWrittenBytes || oWrittenBytes >= rWrittenBytes) {
             // The volume of entries in the partition with the SourceID manually linked to the partition is significant.

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.cpp
@@ -1,0 +1,174 @@
+#include "autopartitioning_manager.h"
+
+#include <ydb/core/persqueue/public/partition_key_range/partition_key_range.h>
+#include <ydb/core/persqueue/public/utils.h>
+
+namespace NKikimr::NPQ {
+
+class TNoneAutopartitioningManager : public IAutopartitioningManager {
+public:
+    TNoneAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config) {
+        Y_UNUSED(config);
+    }
+
+    void OnWrite(const TString& sourceId, ui64 size) override {
+        Y_UNUSED(sourceId);
+        Y_UNUSED(size);
+    }
+    std::optional<TString> SplitBoundary() override {
+        return std::nullopt;
+    }
+
+    NKikimrPQ::EScaleStatus GetScaleStatus(const NActors::TActorContext& ctx) override {
+        Y_UNUSED(ctx);
+        return NKikimrPQ::EScaleStatus::NORMAL;
+    }
+
+    void UpdateConfig(const NKikimrPQ::TPQTabletConfig& config) override {
+        Y_UNUSED(config);
+    }
+};
+
+class TAutopartitioningManager : public IAutopartitioningManager {
+    using TSlidingWindow = NSlidingWindow::TSlidingWindow<NSlidingWindow::TSumOperation<ui64>>;
+
+    static constexpr size_t Precision = 100;
+public:
+    TAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config)
+        : Config(config)
+    {
+        RecreateSumWrittenBytes();
+    }
+
+    void OnWrite(const TString& sourceId, ui64 size) override  {
+        auto now = TInstant::Now();
+
+        SumWrittenBytes->Update(size, now);
+
+        /* TODO hash of sourceId*/
+        TString sourceIdHash = sourceId;
+        auto it = WrittenBytes.find(sourceIdHash);
+        if (it == WrittenBytes.end()) {
+            auto [i,_] = WrittenBytes.emplace(sourceIdHash, TSlidingWindow(TDuration::Minutes(1), 6));
+            it = i;
+        }
+
+        auto& counter = it->second;
+        counter.Update(size, now);
+
+        SourceIdCounter.Use(sourceIdHash, now);
+    }
+
+    void CleanUp() {
+        auto now = TInstant::Now();
+        for (auto it = WrittenBytes.begin(); it != WrittenBytes.end(); ++it) {
+            auto& counter = it->second;
+            counter.Update(now);
+
+            if (0 == counter.GetValue()) {
+            it = WrittenBytes.erase(it);
+            }
+        }
+    }
+
+
+    std::optional<TString> SplitBoundary() override {
+        CleanUp();
+
+        if (WrittenBytes.size() < 2) {
+            return std::nullopt;
+        }
+
+        std::vector<std::pair<TString, ui64>> sorted;
+        sorted.reserve(WrittenBytes.size());
+        for (const auto& [sourceIdHash, counter] : WrittenBytes) {
+            sorted.emplace_back(sourceIdHash, counter.GetValue());
+        }
+
+        std::sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) {
+            return lhs < rhs;
+        });
+
+        ui64 lWrittenBytes = 0, rWrittenBytes = 0;
+        size_t i = 0, j = sorted.size() - 1;
+        bool lastIsLeft = false;
+        TString* lastLeft, *lastRight;
+        while (i < j) {
+            auto& lhs = sorted[i];
+            auto& rhs = sorted[j];
+
+            if (lWrittenBytes < rWrittenBytes) {
+                lWrittenBytes += lhs.second;
+                ++i;
+                lastIsLeft = true;
+                lastLeft = &lhs.first;
+            } else {
+                rWrittenBytes += rhs.second;
+                --j;
+                lastIsLeft = false;
+                lastRight = &rhs.first;
+            }
+        }
+
+        return MiddleOf(*lastLeft, *lastRight);
+    }
+
+    NKikimrPQ::EScaleStatus GetScaleStatus(const NActors::TActorContext& ctx) override {
+        const auto writeSpeedUsagePercent = SumWrittenBytes->GetValue() * 100.0 / Config.GetPartitionStrategy().GetScaleThresholdSeconds() / Config.GetPartitionConfig().GetWriteSpeedInBytesPerSecond();
+        const auto sourceIdWindow = TDuration::Seconds(std::min<ui32>(5, Config.GetPartitionStrategy().GetScaleThresholdSeconds()));
+        const auto sourceIdCount = SourceIdCounter.Count(ctx.Now() - sourceIdWindow);
+        const auto canSplit = sourceIdCount > 1 || (sourceIdCount == 1 && SourceIdCounter.LastValue().empty() /* kinesis */);
+
+        LOG_D("TPartition::CheckScaleStatus"
+                << " splitMergeAvgWriteBytes# " << SumWrittenBytes->GetValue()
+                << " writeSpeedUsagePercent# " << writeSpeedUsagePercent
+                << " scaleThresholdSeconds# " << Config.GetPartitionStrategy().GetScaleThresholdSeconds()
+                << " totalPartitionWriteSpeed# " << Config.GetPartitionConfig().GetWriteSpeedInBytesPerSecond()
+                << " sourceIdCount=" << sourceIdCount
+                << " canSplit=" << canSplit
+        );
+
+        auto splitEnabled = Config.GetPartitionStrategy().GetPartitionStrategyType() == ::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT
+            || Config.GetPartitionStrategy().GetPartitionStrategyType() == ::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE;
+
+        auto mergeEnabled = Config.GetPartitionStrategy().GetPartitionStrategyType() == ::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE;
+
+        if (splitEnabled && canSplit && writeSpeedUsagePercent >= Config.GetPartitionStrategy().GetScaleUpPartitionWriteSpeedThresholdPercent()) {
+            LOG_D("TPartition::CheckScaleStatus NEED_SPLIT.");
+            return NKikimrPQ::EScaleStatus::NEED_SPLIT;
+        } else if (mergeEnabled && writeSpeedUsagePercent <= Config.GetPartitionStrategy().GetScaleDownPartitionWriteSpeedThresholdPercent()) {
+            LOG_D("TPartition::CheckScaleStatus NEED_MERGE."
+                    << " writeSpeedUsagePercent: " << writeSpeedUsagePercent);
+            return NKikimrPQ::EScaleStatus::NEED_MERGE;
+        }
+        return NKikimrPQ::EScaleStatus::NORMAL;
+    }
+
+    void UpdateConfig(const NKikimrPQ::TPQTabletConfig& config) override {
+        if (config.GetPartitionStrategy().GetScaleThresholdSeconds() != SumWrittenBytes->GetDuration().Seconds()) {
+            RecreateSumWrittenBytes();
+        }
+    }
+
+    void RecreateSumWrittenBytes() {
+        SumWrittenBytes = std::move(TSlidingWindow(TDuration::Seconds(Config.GetPartitionStrategy().GetScaleThresholdSeconds()), Precision));
+    }
+
+private:
+    const NKikimrPQ::TPQTabletConfig& Config;
+
+    TMaybe<TSlidingWindow> SumWrittenBytes;
+    // SoureIdHash -> SlidingWindow
+    std::unordered_map<TString, TSlidingWindow> WrittenBytes;
+    TLastCounter SourceIdCounter;
+
+};
+
+IAutopartitioningManager* CreateAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config) {
+    return new TAutopartitioningManager(config);
+}
+IAutopartitioningManager* CreateNoneAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config) {
+    return new TNoneAutopartitioningManager(config);
+}
+
+}

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
@@ -24,7 +24,6 @@ public:
     virtual void UpdateConfig(const NKikimrPQ::TPQTabletConfig& config) = 0;
 };
 
-IAutopartitioningManager* CreateAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config);
-IAutopartitioningManager* CreateNoneAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config);
+IAutopartitioningManager* CreateAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config, bool supportive);
 
 }

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
@@ -18,7 +18,7 @@ public:
 
     virtual void OnWrite(const TString& sourceId, ui64 size) = 0;
 
-    virtual NKikimrPQ::EScaleStatus GetScaleStatus(const NActors::TActorContext& ctx) = 0;
+    virtual NKikimrPQ::EScaleStatus GetScaleStatus() = 0;
     virtual std::optional<TString> SplitBoundary() = 0;
 
     virtual void UpdateConfig(const NKikimrPQ::TPQTabletConfig& config) = 0;

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
@@ -21,7 +21,7 @@ public:
     virtual void OnWrite(const TString& sourceId, ui64 size) = 0;
     virtual void CleanUp() = 0;
 
-    virtual NKikimrPQ::EScaleStatus GetScaleStatus() = 0;
+    virtual NKikimrPQ::EScaleStatus GetScaleStatus(NKikimrPQ::EScaleStatus currentState) = 0;
     virtual std::optional<TString> SplitBoundary() = 0;
     virtual std::vector<std::pair<TString, ui64>> GetWrittenBytes() = 0;
 

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
@@ -19,6 +19,7 @@ public:
     virtual ~IAutopartitioningManager() = default;
 
     virtual void OnWrite(const TString& sourceId, ui64 size) = 0;
+    virtual void CleanUp() = 0;
 
     virtual NKikimrPQ::EScaleStatus GetScaleStatus() = 0;
     virtual std::optional<TString> SplitBoundary() = 0;

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
@@ -20,6 +20,7 @@ public:
 
     virtual NKikimrPQ::EScaleStatus GetScaleStatus() = 0;
     virtual std::optional<TString> SplitBoundary() = 0;
+    virtual std::vector<std::pair<TString, ui64>> GetWrittenBytes() = 0;
 
     virtual void UpdateConfig(const NKikimrPQ::TPQTabletConfig& config) = 0;
 };

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
@@ -12,6 +12,8 @@
 
 namespace NKikimr::NPQ {
 
+class TPartitionId;
+
 class IAutopartitioningManager {
 public:
     virtual ~IAutopartitioningManager() = default;
@@ -25,6 +27,6 @@ public:
     virtual void UpdateConfig(const NKikimrPQ::TPQTabletConfig& config) = 0;
 };
 
-IAutopartitioningManager* CreateAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config, bool supportive);
+IAutopartitioningManager* CreateAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config, const TPartitionId& partitionId);
 
 }

--- a/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
+++ b/ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <ydb/core/persqueue/public/config.h>
+#include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+
+#include <library/cpp/sliding_window/sliding_window.h>
+
+#include <util/generic/fwd.h>
+
+
+
+namespace NKikimr::NPQ {
+
+class IAutopartitioningManager {
+public:
+    virtual ~IAutopartitioningManager() = default;
+
+    virtual void OnWrite(const TString& sourceId, ui64 size) = 0;
+
+    virtual NKikimrPQ::EScaleStatus GetScaleStatus(const NActors::TActorContext& ctx) = 0;
+    virtual std::optional<TString> SplitBoundary() = 0;
+
+    virtual void UpdateConfig(const NKikimrPQ::TPQTabletConfig& config) = 0;
+};
+
+IAutopartitioningManager* CreateAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config);
+IAutopartitioningManager* CreateNoneAutopartitioningManager(const NKikimrPQ::TPQTabletConfig& config);
+
+}

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -347,6 +347,7 @@ TPartition::TPartition(ui64 tabletId, const TPartitionId& partition, const TActo
     , AvgWriteBytes{{TDuration::Seconds(1), 1000}, {TDuration::Minutes(1), 1000}, {TDuration::Hours(1), 2000}, {TDuration::Days(1), 2000}}
     , AvgReadBytes(TDuration::Minutes(1), 1000)
     , AvgQuotaBytes{{TDuration::Seconds(1), 1000}, {TDuration::Minutes(1), 1000}, {TDuration::Hours(1), 2000}, {TDuration::Days(1), 2000}}
+    , AutopartitioningManager(CreateAutopartitioningManager(Config, IsSupportive()))
     , ReservedSize(0)
     , Channel(0)
     , NumChannels(numChannels)

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -478,6 +478,8 @@ void TPartition::HandleWakeup(const TActorContext& ctx) {
     UpdateCompactionCounters();
 
     TryRunCompaction();
+
+    AutopartitioningManager->CleanUp();
 }
 
 void TPartition::AddMetaKey(TEvKeyValue::TEvRequest* request) {

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -3160,7 +3160,7 @@ void TPartition::EndChangePartitionConfig(NKikimrPQ::TPQTabletConfig&& config,
     PQ_ENSURE(Config.GetPartitionConfig().GetTotalPartitions() > 0);
 
     if (autopartitioningChanged) {
-        AutopartitioningManager.reset(CreateAutopartitioningManager(Config, IsSupportive()));
+        AutopartitioningManager.reset(CreateAutopartitioningManager(Config, Partition));
     } else {
         AutopartitioningManager->UpdateConfig(Config);
     }

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1018,6 +1018,9 @@ void TPartition::Handle(TEvPQ::TEvPartitionStatus::TPtr& ev, const TActorContext
         if (PartitionScaleParticipants.Defined()) {
             result.MutableScaleParticipatingPartitions()->CopyFrom(*PartitionScaleParticipants);
         }
+        if (SplitBoundary.Defined()) {
+            result.SetSplitBoundary(*SplitBoundary);
+        }
         result.SetScaleStatus(ScaleStatus);
     } else {
         result.SetScaleStatus(NKikimrPQ::EScaleStatus::NORMAL);

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -13,6 +13,7 @@
 #include <ydb/core/persqueue/pqtablet/common/event_helpers.h>
 #include <ydb/core/persqueue/pqtablet/common/logging.h>
 #include <ydb/core/persqueue/pqtablet/common/tracing_support.h>
+#include <ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h>
 #include <ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer_factory.h>
 #include <ydb/core/persqueue/writer/source_id_encoding.h>
 #include <ydb/core/protos/counters_pq.pb.h>
@@ -3148,9 +3149,7 @@ void TPartition::EndChangePartitionConfig(NKikimrPQ::TPQTabletConfig&& config,
 
     PQ_ENSURE(Config.GetPartitionConfig().GetTotalPartitions() > 0);
 
-    if (Config.GetPartitionStrategy().GetScaleThresholdSeconds() != SplitMergeAvgWriteBytes->GetDuration().Seconds()) {
-        InitSplitMergeSlidingWindow();
-    }
+    AutopartitioningManager->UpdateConfig(Config); // TODO enabled or disabled autopartitioning
 
     Send(ReadQuotaTrackerActor, new TEvPQ::TEvChangePartitionConfig(TopicConverter, Config));
     Send(WriteQuotaTrackerActor, new TEvPQ::TEvChangePartitionConfig(TopicConverter, Config));

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -347,7 +347,6 @@ TPartition::TPartition(ui64 tabletId, const TPartitionId& partition, const TActo
     , AvgWriteBytes{{TDuration::Seconds(1), 1000}, {TDuration::Minutes(1), 1000}, {TDuration::Hours(1), 2000}, {TDuration::Days(1), 2000}}
     , AvgReadBytes(TDuration::Minutes(1), 1000)
     , AvgQuotaBytes{{TDuration::Seconds(1), 1000}, {TDuration::Minutes(1), 1000}, {TDuration::Hours(1), 2000}, {TDuration::Days(1), 2000}}
-    , AutopartitioningManager(CreateAutopartitioningManager(Config, IsSupportive()))
     , ReservedSize(0)
     , Channel(0)
     , NumChannels(numChannels)

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -947,6 +947,7 @@ private:
     std::unique_ptr<IAutopartitioningManager> AutopartitioningManager;
     TInstant LastScaleRequestTime = TInstant::Zero();
     TMaybe<NKikimrPQ::TPartitionScaleParticipants> PartitionScaleParticipants;
+    TMaybe<TString> SplitBoundary;
     NKikimrPQ::EScaleStatus ScaleStatus = NKikimrPQ::EScaleStatus::NORMAL;
 
     ui64 ReservedSize;

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -49,6 +49,7 @@ enum class ECommitState {
 };
 
 
+class IAutopartitioningManager;
 class TPartitionCompaction;
 
 struct TTransaction {
@@ -134,6 +135,7 @@ class TPartition : public TBaseActor<TPartition> {
     friend TInitDataRangeStep;
     friend TInitDataStep;
     friend TInitEndWriteTimestampStep;
+    friend TInitFieldsStep;
 
     friend TPartitionSourceManager;
 
@@ -449,8 +451,6 @@ private:
                                                 const TActorContext& ctx);
 
     void Initialize(const TActorContext& ctx);
-    void InitSplitMergeSlidingWindow();
-
     template <typename T>
     void EmplacePendingRequest(T&& body, NWilson::TSpan&& span, const TActorContext& ctx) {
         const auto now = ctx.Now();
@@ -479,7 +479,6 @@ private:
 
     void Handle(TEvPQ::TEvCheckPartitionStatusRequest::TPtr& ev, const TActorContext& ctx);
 
-    NKikimrPQ::EScaleStatus CheckScaleStatus(const TActorContext& ctx);
     void ChangeScaleStatusIfNeeded(NKikimrPQ::EScaleStatus scaleStatus);
     void Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx);
 
@@ -945,7 +944,7 @@ private:
     NSlidingWindow::TSlidingWindow<NSlidingWindow::TSumOperation<ui64>> AvgReadBytes;
     TVector<NSlidingWindow::TSlidingWindow<NSlidingWindow::TSumOperation<ui64>>> AvgQuotaBytes;
 
-    std::unique_ptr<NSlidingWindow::TSlidingWindow<NSlidingWindow::TSumOperation<ui64>>> SplitMergeAvgWriteBytes;
+    std::unique_ptr<IAutopartitioningManager> AutopartitioningManager;
     TInstant LastScaleRequestTime = TInstant::Zero();
     TMaybe<NKikimrPQ::TPartitionScaleParticipants> PartitionScaleParticipants;
     NKikimrPQ::EScaleStatus ScaleStatus = NKikimrPQ::EScaleStatus::NORMAL;
@@ -1032,8 +1031,6 @@ private:
     void ProcessPendingEvents(const TActorContext& ctx);
 
     TRowVersion LastEmittedHeartbeat;
-
-    TLastCounter SourceIdCounter;
 
     const NKikimrPQ::TPQTabletConfig::TPartition* GetPartitionConfig(const NKikimrPQ::TPQTabletConfig& config);
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -895,7 +895,7 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
                 return;
             case NKikimrProto::ERROR:
                 PQ_LOG_ERROR("tablet " << Partition()->TabletId << " HandleOnInit ReadResult "
-                        << i << " status NKikimrProto::ERROR result message: \"" << read.GetMessage()
+                        << i << " sta // TODO enabled or disabled autopartitioningtus NKikimrProto::ERROR result message: \"" << read.GetMessage()
                         << " \" errorReason: \"" << response.GetErrorReason() << "\""
                 );
                 PoisonPill(ctx);
@@ -954,10 +954,7 @@ TInitFieldsStep::TInitFieldsStep(TInitializer* initializer)
 void TInitFieldsStep::Execute(const TActorContext &ctx) {
     auto& config = Partition()->Config;
 
-    IAutopartitioningManager* autopartitioningManager = SplitMergeEnabled(config) && !Partition()->IsSupportive() && !MirroringEnabled(config)
-        ? CreateAutopartitioningManager(config)
-        : CreateNoneAutopartitioningManager(config);
-    Partition()->AutopartitioningManager.reset(autopartitioningManager);
+    Partition()->AutopartitioningManager.reset(CreateAutopartitioningManager(config, Partition()->IsSupportive()));
 
     return Done(ctx);
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1,3 +1,4 @@
+#include "autopartitioning_manager.h"
 #include "offload_actor.h"
 #include "partition.h"
 #include "partition_compactification.h"
@@ -34,6 +35,7 @@ TInitializer::TInitializer(TPartition* partition)
     Steps.push_back(MakeHolder<TInitDataRangeStep>(this));
     Steps.push_back(MakeHolder<TInitDataStep>(this));
     Steps.push_back(MakeHolder<TInitEndWriteTimestampStep>(this));
+    Steps.push_back(MakeHolder<TInitFieldsStep>(this));
 
     CurrentStep = Steps.begin();
 }
@@ -374,7 +376,7 @@ void TInitMetaStep::LoadMeta(const NKikimrClient::TResponse& kvResponse, const T
 
 
 //
-// TInitInfoRangeStep
+// TInitInfoRangeStep!IsSupportive() && !MirroringEnabled(Config)
 //
 
 TInitInfoRangeStep::TInitInfoRangeStep(TInitializer* initializer)
@@ -942,6 +944,25 @@ void TInitEndWriteTimestampStep::Execute(const TActorContext &ctx) {
 }
 
 //
+// TInitFieldsStep
+//
+
+TInitFieldsStep::TInitFieldsStep(TInitializer* initializer)
+    : TInitializerStep(initializer, "TInitFieldsStep", true) {
+}
+
+void TInitFieldsStep::Execute(const TActorContext &ctx) {
+    auto& config = Partition()->Config;
+
+    IAutopartitioningManager* autopartitioningManager = SplitMergeEnabled(config) && !Partition()->IsSupportive() && !MirroringEnabled(config)
+        ? CreateAutopartitioningManager(config)
+        : CreateNoneAutopartitioningManager(config);
+    Partition()->AutopartitioningManager.reset(autopartitioningManager);
+
+    return Done(ctx);
+}
+
+//
 // TPartition
 //
 
@@ -975,8 +996,6 @@ void TPartition::Initialize(const TActorContext& ctx) {
     WriteTimestamp = ctx.Now();
     LastUsedStorageMeterTimestamp = ctx.Now();
     WriteTimestampEstimate = ManageWriteTimestampEstimate ? ctx.Now() : TInstant::Zero();
-
-    InitSplitMergeSlidingWindow();
 
     CloudId = Config.GetYcCloudId();
     DbId = Config.GetYdbDatabaseId();
@@ -1273,11 +1292,6 @@ void TPartition::SetupStreamCounters(const TActorContext& ctx) {
                             {1000, "1000"}, {2500, "2500"}, {5000, "5000"},
                             {10'000, "10000"}, {9'999'999, "999999"}}, true)
     );
-}
-
-void TPartition::InitSplitMergeSlidingWindow() {
-    using Tui64SumSlidingWindow = NSlidingWindow::TSlidingWindow<NSlidingWindow::TSumOperation<ui64>>;
-    SplitMergeAvgWriteBytes = std::make_unique<Tui64SumSlidingWindow>(TDuration::Seconds(Config.GetPartitionStrategy().GetScaleThresholdSeconds()), 1000);
 }
 
 void TPartition::CreateCompacter() {

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -895,7 +895,7 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
                 return;
             case NKikimrProto::ERROR:
                 PQ_LOG_ERROR("tablet " << Partition()->TabletId << " HandleOnInit ReadResult "
-                        << i << " sta // TODO enabled or disabled autopartitioningtus NKikimrProto::ERROR result message: \"" << read.GetMessage()
+                        << i << " status NKikimrProto::ERROR result message: \"" << read.GetMessage()
                         << " \" errorReason: \"" << response.GetErrorReason() << "\""
                 );
                 PoisonPill(ctx);

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -948,7 +948,7 @@ void TInitEndWriteTimestampStep::Execute(const TActorContext &ctx) {
 //
 
 TInitFieldsStep::TInitFieldsStep(TInitializer* initializer)
-    : TInitializerStep(initializer, "TInitFieldsStep", true) {
+    : TInitializerStep(initializer, "TInitFieldsStep", false) {
 }
 
 void TInitFieldsStep::Execute(const TActorContext &ctx) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -376,7 +376,7 @@ void TInitMetaStep::LoadMeta(const NKikimrClient::TResponse& kvResponse, const T
 
 
 //
-// TInitInfoRangeStep!IsSupportive() && !MirroringEnabled(Config)
+// TInitInfoRangeStep
 //
 
 TInitInfoRangeStep::TInitInfoRangeStep(TInitializer* initializer)

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -954,7 +954,7 @@ TInitFieldsStep::TInitFieldsStep(TInitializer* initializer)
 void TInitFieldsStep::Execute(const TActorContext &ctx) {
     auto& config = Partition()->Config;
 
-    Partition()->AutopartitioningManager.reset(CreateAutopartitioningManager(config, Partition()->IsSupportive()));
+    Partition()->AutopartitioningManager.reset(CreateAutopartitioningManager(config, Partition()->Partition));
 
     return Done(ctx);
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.h
@@ -171,4 +171,11 @@ public:
     void Execute(const TActorContext& ctx) override;
 };
 
+class TInitFieldsStep: public TInitializerStep {
+public:
+    TInitFieldsStep(TInitializer* initializer);
+
+    void Execute(const TActorContext& ctx) override;
+};
+
 } // NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -611,6 +611,7 @@ void TPartition::ChangeScaleStatusIfNeeded(NKikimrPQ::EScaleStatus scaleStatus) 
     }
 
     ScaleStatus = scaleStatus;
+    SplitBoundary.Clear();
     LastScaleRequestTime = now;
 
     auto ev = MakeHolder<TEvPQ::TEvPartitionScaleStatusChanged>(Partition.OriginalPartitionId, ScaleStatus);
@@ -618,6 +619,7 @@ void TPartition::ChangeScaleStatusIfNeeded(NKikimrPQ::EScaleStatus scaleStatus) 
         auto splitBoundary = AutopartitioningManager->SplitBoundary();
         if (splitBoundary) {
             ev->Record.SetSplitBoundary(*splitBoundary);
+            SplitBoundary = *splitBoundary;
         }
     }
     Send(TabletActorId, std::move(ev));

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -1,4 +1,4 @@
-#include "autopartitioning_maanager.h"
+#include "autopartitioning_manager.h"
 #include "partition_util.h"
 #include "partition.h"
 
@@ -300,7 +300,7 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
 
             bool already = false;
 
-            SourceIdCounter.Use(s, now);
+            // SourceIdCounter.Use(s, now); TODO
             auto it = SourceIdStorage.GetInMemorySourceIds().find(s);
 
             ui64 maxSeqNo = 0;
@@ -524,7 +524,7 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
             ui64 seqNo = std::max(info.SeqNo, it->second.SeqNo);
             SourceIdStorage.RegisterSourceId(sourceId, it->second.Updated(seqNo, info.Offset, now, info.KafkaProducerEpoch));
         }
-        SourceIdCounter.Use(sourceId, now);
+        // SourceIdCounter.Use(sourceId, now); TODO
     }
     TxSourceIdForPostPersist.clear();
     TxInflightMaxSeqNoPerSourceId.clear();

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -571,7 +571,7 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
         SupportivePartitionTimeLag->UpdateTimestamp(now.MilliSeconds());
     }
 
-    auto writeNewSizeFull = WriteNewSizeFull + WriteNewSizeFromSupportivePartitions;
+    //auto writeNewSizeFull = WriteNewSizeFull + WriteNewSizeFromSupportivePartitions;
 
     WriteCycleSize = 0;
     WriteNewSize = 0;
@@ -588,7 +588,7 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
     SyncMemoryStateWithKVState(ctx);
 
     if (SplitMergeEnabled(Config) && !IsSupportive() && !MirroringEnabled(Config)) {
-        AutopartitioningManager->OnWrite();
+        //AutopartitioningManager->OnWrite(); TODO
         //SplitMergeAvgWriteBytes->Update(writeNewSizeFull, now);
         auto needScaling = AutopartitioningManager->GetScaleStatus(ctx);
         ChangeScaleStatusIfNeeded(needScaling);

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -583,7 +583,7 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
     AnswerCurrentWrites(ctx);
     SyncMemoryStateWithKVState(ctx);
 
-    ChangeScaleStatusIfNeeded(AutopartitioningManager->GetScaleStatus());
+    ChangeScaleStatusIfNeeded(AutopartitioningManager->GetScaleStatus(ScaleStatus));
 
     //if EndOffset changed there could be subscriptions witch could be completed
     TVector<std::pair<TReadInfo, ui64>> reads = Subscriber.GetReads(BlobEncoder.EndOffset);

--- a/ydb/core/persqueue/pqtablet/partition/ya.make
+++ b/ydb/core/persqueue/pqtablet/partition/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     account_read_quoter.cpp
+    autopartitioning_manager.cpp
     offload_actor.cpp
     ownerinfo.cpp
     partition.cpp

--- a/ydb/core/persqueue/public/partition_key_range/partition_key_range.cpp
+++ b/ydb/core/persqueue/public/partition_key_range/partition_key_range.cpp
@@ -11,7 +11,7 @@ namespace NKikimr {
 namespace NPQ {
 
 TString MiddleOf(const TString& from, const TString& to) {
-    AFL_ENSURE(to.empty() || from < to)("from", from)("to", to);
+    AFL_ENSURE(to.empty() || from < to);
 
     auto GetChar = [](const TString& str, size_t i, unsigned char defaultValue) {
         if (i >= str.size()) {

--- a/ydb/core/persqueue/public/partition_key_range/partition_key_range.cpp
+++ b/ydb/core/persqueue/public/partition_key_range/partition_key_range.cpp
@@ -2,12 +2,16 @@
 
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/library/actors/core/log.h>
+#include <ydb/services/lib/sharding/sharding.h>
+
+#include <library/cpp/digest/md5/md5.h>
+
 
 namespace NKikimr {
 namespace NPQ {
 
 TString MiddleOf(const TString& from, const TString& to) {
-    AFL_ENSURE(to.empty() || from < to);
+    AFL_ENSURE(to.empty() || from < to)("from", from)("to", to);
 
     auto GetChar = [](const TString& str, size_t i, unsigned char defaultValue) {
         if (i >= str.size()) {
@@ -110,6 +114,10 @@ TString MiddleOf(const TString& from, const TString& to) {
     }
 
     return result;
+}
+
+NYql::NDecimal::TUint128 Hash(const TString& sourceId) {
+    return NKikimr::NDataStreams::V1::HexBytesToDecimal(MD5::Calc(sourceId));
 }
 
 TPartitionKeyRange TPartitionKeyRange::Parse(const NKikimrPQ::TPartitionKeyRange& proto) {

--- a/ydb/core/persqueue/public/partition_key_range/partition_key_range.h
+++ b/ydb/core/persqueue/public/partition_key_range/partition_key_range.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/scheme/scheme_tablecell.h>
+#include <yql/essentials/public/decimal/yql_decimal.h>
 #include <yql/essentials/public/decimal/yql_wide_int.h>
 
 #include <util/generic/maybe.h>
@@ -120,6 +121,8 @@ inline NYql::TWide<ui16> AsInt<NYql::TWide<ui16>>(const TString& bound) {
 }
 
 TString MiddleOf(const TString& fromBound, const TString& toBound);
+
+NYql::NDecimal::TUint128 Hash(const TString& sourceId);
 
 
 struct TPartitionKeyRange {

--- a/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
@@ -878,11 +878,11 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
             UNIT_ASSERT(writeSession_2->Write(Msg(msg, 6)));
             Sleep(TDuration::Seconds(15));
             auto describe = client.DescribeTopic(TEST_TOPIC).GetValueSync();
-            UNIT_ASSERT_EQUAL(describe.GetTopicDescription().GetPartitions().size(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(describe.GetTopicDescription().GetPartitions().size(), 3);
         }
 
-        auto writeSession2_1 = CreateWriteSession(client, "producer-1", 1, TString{TEST_TOPIC}, false);
-        auto writeSession2_2 = CreateWriteSession(client, "producer-2", 1, TString{TEST_TOPIC}, false);
+        auto writeSession2_1 = CreateWriteSession(client, "producer-2", 1, TString{TEST_TOPIC}, false);
+        auto writeSession2_2 = CreateWriteSession(client, "producer-3", 1, TString{TEST_TOPIC}, false);
 
         {
             UNIT_ASSERT(writeSession2_1->Write(Msg(msg, 7)));
@@ -891,7 +891,7 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
             UNIT_ASSERT(writeSession2_2->Write(Msg(msg, 10)));
             Sleep(TDuration::Seconds(5));
             auto describe2 = client.DescribeTopic(TEST_TOPIC).GetValueSync();
-            UNIT_ASSERT_EQUAL(describe2.GetTopicDescription().GetPartitions().size(), 5);
+            UNIT_ASSERT_VALUES_EQUAL(describe2.GetTopicDescription().GetPartitions().size(), 5);
         }
     }
 

--- a/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
@@ -943,8 +943,8 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
             UNIT_ASSERT_EQUAL(describe.GetTopicDescription().GetPartitions().size(), 3);
         }
 
-        auto writeSession2_1 = CreateWriteSession(client, "producer-1", 1, TString{TEST_TOPIC}, false);
-        auto writeSession2_2 = CreateWriteSession(client, "producer-2", 1, TString{TEST_TOPIC}, false);
+        auto writeSession2_1 = CreateWriteSession(client, "producer-2", 1, TString{TEST_TOPIC}, false);
+        auto writeSession2_2 = CreateWriteSession(client, "producer-3", 1, TString{TEST_TOPIC}, false);
 
         {
             UNIT_ASSERT(writeSession2_1->Write(Msg(msg, 7)));

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_autoscaling_ut.cpp
@@ -962,6 +962,7 @@ namespace NKikimr::NPersQueueTests {
                 SplitPartition(txId++, srcTopicFullName, partitionId, bound, *ctx.Runtime(), TDuration::Zero());
             }
 
+            TInstant end = TDuration::Minutes(1).ToDeadLine();
             while (true) {
                 const auto srcStat = CountPartitionsByStatus(srcTopicFullName, server);
                 const auto dstStat = CountPartitionsByStatus(dstTopicFullName, server);
@@ -970,8 +971,12 @@ namespace NKikimr::NPersQueueTests {
                     PrintTopicDescription(name, "WAIT", server);
                 }
 
+                Cerr << "Wait partition count equals: " << srcStat.Partitions << " == " << dstStat.Partitions << Endl;
                 if (srcStat.Partitions == dstStat.Partitions) {
                     break;
+                }
+                if (end < TInstant::Now()) {
+                    UNIT_ASSERT_VALUES_EQUAL(srcStat.Partitions, dstStat.Partitions);
                 }
                 Sleep(TDuration::MilliSeconds(1000));
             }

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_autoscaling_ut.cpp
@@ -321,7 +321,7 @@ namespace NKikimr::NPersQueueTests {
                     Server.CleverServer->GetRuntime()->GetAppData(nodeId).PersQueueMirrorReaderFactory = Fabric.get();
                 }
 
-                Server.EnableLogs({NKikimrServices::PQ_READ_PROXY});
+                Server.EnableLogs({NKikimrServices::PQ_READ_PROXY, NKikimrServices::PERSQUEUE_READ_BALANCER, NKikimrServices::FLAT_TX_SCHEMESHARD});
                 Server.EnableLogs({NKikimrServices::PQ_MIRRORER, NKikimrServices::PQ_MIRROR_DESCRIBER}, NActors::NLog::PRI_TRACE);
                 Server.AnnoyingClient->CreateConsumer("user");
             }
@@ -563,17 +563,6 @@ namespace NKikimr::NPersQueueTests {
                 messagesPerPartition[wc.Partiton] += written;
             }
 
-            auto createReader = [&](const TString& topic, ui32 partition) {
-                auto settings =
-                    NYdb::NTopic::TReadSessionSettings()
-                        .AppendTopics(NYdb::NTopic::TTopicReadSettings(topic)
-                                          .AppendPartitionIds(partition))
-                        .WithoutConsumer()
-                        .Decompress(true);
-
-                return topicClient.CreateReadSession(settings);
-            };
-
             UNIT_ASSERT_VALUES_EQUAL(CountPartitionsByStatus(srcTopicFullName, server).Active, 3);
             UNIT_ASSERT_VALUES_EQUAL(CountPartitionsByStatus(dstTopicFullName, server).Active, 2); // not splitted yet
 
@@ -605,6 +594,18 @@ namespace NKikimr::NPersQueueTests {
                 Cerr << "Waiting for partitions to be splitted\n";
                 Sleep(TDuration::Seconds(1));
             }
+
+            auto createReader = [&](const TString& topic, ui32 partition) {
+                auto settings =
+                    NYdb::NTopic::TReadSessionSettings()
+                        .AppendTopics(NYdb::NTopic::TTopicReadSettings(topic)
+                                          .AppendPartitionIds(partition))
+                        .WithoutConsumer()
+                        .Decompress(true);
+
+                return topicClient.CreateReadSession(settings);
+            };
+
             const TInstant deadline = TDuration::Seconds(65).ToDeadLine();
             for (ui32 partition = 0; partition < finalPartitionsCount; ++partition) {
                 ComparePartitions(createReader(srcTopicFullName, partition), createReader(dstTopicFullName, partition), TStringBuilder() << "stage=2 " << LabeledOutput(partition), deadline, messagesPerPartition.Value(partition, 0), false);

--- a/ydb/core/persqueue/writer/partition_chooser_impl.cpp
+++ b/ydb/core/persqueue/writer/partition_chooser_impl.cpp
@@ -1,16 +1,11 @@
 #include "partition_chooser_impl.h"
 
-#include <library/cpp/digest/md5/md5.h>
 #include <ydb/core/persqueue/public/partition_key_range/partition_key_range.h>
 #include <ydb/core/persqueue/public/utils.h>
 #include <ydb/services/lib/sharding/sharding.h>
 
 namespace NKikimr::NPQ {
 namespace NPartitionChooser {
-
-NYql::NDecimal::TUint128 Hash(const TString& sourceId) {
-    return NKikimr::NDataStreams::V1::HexBytesToDecimal(MD5::Calc(sourceId));
-}
 
 ui32 TAsIsSharder::operator()(const TString& sourceId, ui32 totalShards) const {
     return NKikimr::NDataStreams::V1::ShardFromDecimal(AsInt<NYql::NDecimal::TUint128>(sourceId), totalShards);

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -816,6 +816,7 @@ message TStatusResponse {
 
         optional EScaleStatus ScaleStatus = 35;
         optional TPartitionScaleParticipants ScaleParticipatingPartitions = 36;
+        optional string SplitBoundary = 37;
     }
 
     message TConsumerResult {

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -1097,6 +1097,7 @@ message TEvPartitionScaleStatusChanged {
     required uint32 PartitionId = 1;
     required EScaleStatus ScaleStatus = 2;
     optional TPartitionScaleParticipants ParticipatingPartitions = 3;
+    optional string SplitBoundary = 4;
 };
 
 message TPartitions {

--- a/ydb/library/actors/core/actorsystem_fwd.h
+++ b/ydb/library/actors/core/actorsystem_fwd.h
@@ -6,4 +6,7 @@ class TActorSystem;
 class IActor;
 struct TActorId;
 
+struct TActivationContext;
+struct TActorContext;
+
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Сейчас при автопартициронировании топиков учитывается скорость записи различными producer-ами: партиция делится не пополам, а стараемся разделить партицию таким образом, что бы producer-ы распределились по новым партициям равномерно с учетом скорости записи.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
