### PR TITLE
Add TDescribeSchemaSecretsService to KQP

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -82,6 +82,7 @@
 #include <ydb/core/kqp/proxy_service/kqp_proxy_service.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
 #include <ydb/core/kqp/finalize_script_service/kqp_finalize_script_service.h>
+#include <ydb/core/kqp/federated_query/kqp_federated_query_actors.h>
 
 #include <ydb/core/load_test/service_actor.h>
 
@@ -2262,6 +2263,13 @@ void TKqpServiceInitializer::InitializeServices(NActors::TActorSystemSetup* setu
         setup->LocalServices.push_back(std::make_pair(
             NKqp::MakeKqpFinalizeScriptServiceId(NodeId),
             TActorSetupCmd(finalize, TMailboxType::HTSwap, appData->UserPoolId)));
+
+        if (appData->FeatureFlags.GetEnableSchemaSecrets()) {
+            auto describeSchemaSecretsService = NKqp::CreateDescribeSchemaSecretsService();
+            setup->LocalServices.push_back(std::make_pair(
+                NKqp::MakeKqpDescribeSchemaSecretServiceId(NodeId),
+                TActorSetupCmd(describeSchemaSecretsService, TMailboxType::HTSwap, appData->UserPoolId)));
+        }
     }
 }
 

--- a/ydb/core/kqp/common/simple/services.h
+++ b/ydb/core/kqp/common/simple/services.h
@@ -51,4 +51,9 @@ inline NActors::TActorId MakeKqpSchedulerServiceId(ui32 nodeId) {
     return NActors::TActorId(nodeId, TStringBuf(name, 12));
 }
 
+inline NActors::TActorId MakeKqpDescribeSchemaSecretServiceId(ui32 nodeId) {
+    const char name[12] = "kqp_dsc_sec";
+    return NActors::TActorId(nodeId, TStringBuf(name, 12));
+}
+
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -61,9 +61,15 @@ public:
     }
 
 private:
+    struct TVersionedSecret {
+        ui64 Version;
+        TString Value;
+    };
+
     ui64 LastCookie = 0;
     THashMap<ui64, NThreading::TPromise<TEvDescribeSecretsResponse::TDescription>> ResolveInFlight;
     THashMap<ui64, TString> SecretNameInFlight;
+    THashMap<TString, TVersionedSecret> SecretNameToValue;
 };
 
 IActor* CreateDescribeSecretsActor(const TString& ownerUserId, const std::vector<TString>& secretIds, NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> promise);

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -4,16 +4,74 @@
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 
 #include <ydb/library/actors/core/actor.h>
-
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/aclib/aclib.h>
 #include <library/cpp/threading/future/future.h>
 
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/core/tx/schemeshard/schemeshard.h>
 
 namespace NKikimr::NKqp {
+
+class TDescribeSchemaSecretsService: public NActors::TActorBootstrapped<TDescribeSchemaSecretsService> {
+public:
+    enum ESecretEvents {
+        EvResolveSecret = EventSpaceBegin(TKikimrEvents::ES_PRIVATE),
+        EvEnd,
+    };
+
+    struct TEvResolveSecret : public NActors::TEventLocal<TEvResolveSecret, EvResolveSecret> {
+    public:
+        TEvResolveSecret(
+            const TString& ownerUserId,
+            const TString& secretName,
+            NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> promise
+        )
+            : UserToken(NACLib::TUserToken{ownerUserId, TVector<NACLib::TSID>{}})
+            , SecretName(secretName)
+            , Promise(promise)
+        {
+        }
+
+    public:
+        const NACLib::TUserToken UserToken;
+        const TString SecretName;
+        NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> Promise;
+    };
+
+private:
+    STRICT_STFUNC(StateWait,
+        hFunc(TEvResolveSecret, Handle);
+        hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
+        hFunc(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult, Handle);
+        cFunc(NActors::TEvents::TEvPoison::EventType, PassAway);
+    )
+
+    void Handle(TEvResolveSecret::TPtr& ev);
+    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
+    void Handle(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev);
+    void FillResponse(const ui64 requestId, const TEvDescribeSecretsResponse::TDescription& response);
+
+public:
+    TDescribeSchemaSecretsService() = default;
+
+    void Bootstrap() {
+        Become(&TDescribeSchemaSecretsService::StateWait);
+    }
+
+private:
+    ui64 LastCookie = 0;
+    THashMap<ui64, NThreading::TPromise<TEvDescribeSecretsResponse::TDescription>> ResolveInFlight;
+    THashMap<ui64, TString> SecretNameInFlight;
+};
 
 IActor* CreateDescribeSecretsActor(const TString& ownerUserId, const std::vector<TString>& secretIds, NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> promise);
 
 void RegisterDescribeSecretsActor(const TActorId& replyActorId, const TString& ownerUserId, const std::vector<TString>& secretIds, TActorSystem* actorSystem);
 
 NThreading::TFuture<TEvDescribeSecretsResponse::TDescription> DescribeExternalDataSourceSecrets(const NKikimrSchemeOp::TAuth& authDescription, const TString& ownerUserId, TActorSystem* actorSystem);
+
+IActor* CreateDescribeSchemaSecretsService();
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -52,6 +52,8 @@ private:
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
     void Handle(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev);
     void FillResponse(const ui64 requestId, const TEvDescribeSecretsResponse::TDescription& response);
+    void SaveIncomingRequestInfo(const TEvResolveSecret& req);
+    void SendSchemeCacheRequest(const TString& secretName);
 
 public:
     TDescribeSchemaSecretsService() = default;

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -56,9 +56,7 @@ private:
 public:
     TDescribeSchemaSecretsService() = default;
 
-    void Bootstrap() {
-        Become(&TDescribeSchemaSecretsService::StateWait);
-    }
+    void Bootstrap();
 
 private:
     struct TVersionedSecret {

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors_ut.cpp
@@ -1,0 +1,129 @@
+#include "kqp_federated_query_actors.h"
+#include <library/cpp/testing/unittest/registar.h>
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/kqp/common/simple/services.h>
+
+namespace NYql {
+
+namespace {
+    void CreateSchemaSecret(const TString& secretName, const TString& secretValue, NYdb::NTable::TSession& session) {
+        auto createSecretQuery = "CREATE SECRET `" + secretName + "` WITH (value = \"" + secretValue + "\");";
+        auto createSecretQueryResult = session.ExecuteSchemeQuery(createSecretQuery).GetValueSync();
+        UNIT_ASSERT_C(createSecretQueryResult.GetStatus() == NYdb::EStatus::SUCCESS, createSecretQueryResult.GetIssues().ToString());
+    }
+
+    void AlterSchemaSecret(const TString& secretName, const TString& secretValue, NYdb::NTable::TSession& session) {
+        auto createSecretQuery = "ALTER  SECRET `" + secretName + "` WITH (value = \"" + secretValue + "\");";
+        auto createSecretQueryResult = session.ExecuteSchemeQuery(createSecretQuery).GetValueSync();
+        UNIT_ASSERT_C(createSecretQueryResult.GetStatus() == NYdb::EStatus::SUCCESS, createSecretQueryResult.GetIssues().ToString());
+    }
+
+    NThreading::TPromise<NKikimr::NKqp::TEvDescribeSecretsResponse::TDescription>
+    ResolveSecret(const TString& userId, const TString& secretName, NKikimr::NKqp::TKikimrRunner& kikimr) {
+        auto promise = NThreading::NewPromise<NKikimr::NKqp::TEvDescribeSecretsResponse::TDescription>();
+        const auto evResolveSecret = new NKikimr::NKqp::TDescribeSchemaSecretsService::TEvResolveSecret(userId,secretName, promise);
+        auto actorSystem = kikimr.GetTestServer().GetRuntime()->GetActorSystem(0);
+        actorSystem->Send(NKikimr::NKqp::MakeKqpDescribeSchemaSecretServiceId(actorSystem->NodeId), evResolveSecret);
+        return promise;
+    }
+}
+
+Y_UNIT_TEST_SUITE(DescribeSchemaSecretsService) {
+    Y_UNIT_TEST(GetNewValue) {
+        NKikimrConfig::TAppConfig appCfg;
+        appCfg.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
+        NKikimr::NKqp::TKikimrRunner kikimr{ NKikimr::NKqp::TKikimrSettings(appCfg) };
+        kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.SetEnableSchemaSecrets(true);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        TString secretName = "/Root/secret-name";
+        TString secretValue = "secret-value";
+        CreateSchemaSecret(secretName, secretValue, session);
+
+        auto promise = ResolveSecret("ownerId", "/Root/secret-name", kikimr);
+
+        UNIT_ASSERT_VALUES_EQUAL(secretValue, promise.GetFuture().GetValueSync().SecretValues[0]);
+    }
+
+    Y_UNIT_TEST(GetUpdatedValue) {
+        NKikimrConfig::TAppConfig appCfg;
+        appCfg.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
+        NKikimr::NKqp::TKikimrRunner kikimr{ NKikimr::NKqp::TKikimrSettings(appCfg) };
+        kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.SetEnableSchemaSecrets(true);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        TString secretName = "/Root/secret-name";
+        TString secretValue = "secret-value";
+        CreateSchemaSecret(secretName, secretValue, session);
+
+        {
+            auto promise = ResolveSecret("ownerId", "/Root/secret-name", kikimr);
+            UNIT_ASSERT_VALUES_EQUAL(secretValue, promise.GetFuture().GetValueSync().SecretValues[0]);
+        }
+
+        TString newSecretValue = "new-secret-value";
+        AlterSchemaSecret(secretName, newSecretValue, session);
+
+        {
+            auto promise = ResolveSecret("ownerId", "/Root/secret-name", kikimr);
+            UNIT_ASSERT_VALUES_EQUAL(newSecretValue, promise.GetFuture().GetValueSync().SecretValues[0]);
+        }
+    }
+
+    Y_UNIT_TEST(GetUnexistingValue) {
+        NKikimrConfig::TAppConfig appCfg;
+        appCfg.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
+        NKikimr::NKqp::TKikimrRunner kikimr{ NKikimr::NKqp::TKikimrSettings(appCfg) };
+        kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.SetEnableSchemaSecrets(true);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto promise = ResolveSecret("ownerId", "/Root/secret-not-exist", kikimr);
+
+        UNIT_ASSERT_VALUES_EQUAL(Ydb::StatusIds::BAD_REQUEST, promise.GetFuture().GetValueSync().Status);
+    }
+
+    Y_UNIT_TEST(GetInParallel) {
+        static const int SECRETS_CNT = 5;
+        NKikimrConfig::TAppConfig appCfg;
+        appCfg.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
+        NKikimr::NKqp::TKikimrRunner kikimr{ NKikimr::NKqp::TKikimrSettings(appCfg) };
+        kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.SetEnableSchemaSecrets(true);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        // new values
+        std::vector<std::pair<TString, TString>> secrets;
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            secrets.push_back({"/Root/secret-name-" + ToString(i), "secret-value-" + ToString(i)});
+            CreateSchemaSecret(secrets.back().first, secrets.back().second, session);
+        }
+        std::vector<NThreading::TPromise<NKikimr::NKqp::TEvDescribeSecretsResponse::TDescription>> promises;
+        for (const auto& [secretName, secretValue] : secrets) {
+            promises.push_back(ResolveSecret("ownerId", secretName, kikimr));
+        }
+
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(secrets[i].second, promises[i].GetFuture().GetValueSync().SecretValues[0]);
+        }
+
+        // altered values
+        promises.clear();
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            secrets[i].second += "-new";
+            AlterSchemaSecret(secrets[i].first, secrets[i].second, session);
+        }
+        for (const auto& [secretName, secretValue] : secrets) {
+            promises.push_back(ResolveSecret("ownerId", secretName, kikimr));
+        }
+
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(secrets[i].second, promises[i].GetFuture().GetValueSync().SecretValues[0]);
+        }
+    }
+}
+
+}

--- a/ydb/core/kqp/federated_query/ut_service/ya.make
+++ b/ydb/core/kqp/federated_query/ut_service/ya.make
@@ -1,0 +1,15 @@
+UNITTEST_FOR(ydb/core/kqp/federated_query)
+
+PEERDIR(
+    ydb/core/kqp/federated_query
+    ydb/core/kqp/ut/common
+    yql/essentials/sql/pg_dummy
+)
+
+SRCS(
+    kqp_federated_query_actors_ut.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/federated_query/ya.make
+++ b/ydb/core/kqp/federated_query/ya.make
@@ -31,4 +31,5 @@ END()
 
 RECURSE_FOR_TESTS(
     ut
+    ut_service
 )

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1,5 +1,6 @@
 #include "test_client.h"
 
+#include <ydb/core/kqp/federated_query/kqp_federated_query_actors.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/base/appdata.h>
@@ -1281,6 +1282,11 @@ namespace Tests {
             IActor* metadataCache = CreateDatabaseMetadataCache(appData.TenantName, appData.Counters).release();
             TActorId metadataCacheId = Runtime->Register(metadataCache, nodeIdx, userPoolId);
             Runtime->RegisterService(MakeDatabaseMetadataCacheId(Runtime->GetNodeId(nodeIdx)), metadataCacheId, nodeIdx);
+        }
+        {
+            IActor* describeSchemaSecretsService = NKqp::CreateDescribeSchemaSecretsService();
+            TActorId describeSchemaSecretsServiceId = Runtime->Register(describeSchemaSecretsService, nodeIdx, userPoolId);
+            Runtime->RegisterService(NKqp::MakeKqpDescribeSchemaSecretServiceId(Runtime->GetNodeId(nodeIdx)), describeSchemaSecretsServiceId, nodeIdx);
         }
         {
             auto kqpProxySharedResources = std::make_shared<NKqp::TKqpProxySharedResources>();

--- a/ydb/library/services/services.proto
+++ b/ydb/library/services/services.proto
@@ -439,6 +439,8 @@ enum EServiceKikimr {
     TOKEN_MANAGER = 3600;
 
     LOCAL_DB_BACKUP = 3700;
+
+    SCHEMA_SECRET_CACHE = 3800;
 };
 
 message TActivity {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Not for changelog

### Description for reviewers
Пока скорее демо. Проблемы
1. В некоторых сценариях федеративные запросы резолвят два секрета, а схемшард из коробки такое не поддерживает. Это буду делать отдельно.

2. Сейчас использовать секрет могут все, а не только нет, кто грант имеет. Это починю следом.

3. Секрет приезжает в схемный кеш целиком, а не должен. Это делается тут https://github.com/ydb-platform/ydb/pull/25478.
