### PR TITLE
Handle new prefixes in prefixed vector index update

### DIFF
--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -255,8 +255,6 @@ bool IsBuildImplTable(std::string_view tableName) {
 
 namespace NKMeans {
 
-inline constexpr TClusterId PostingParentFlag = (1ull << 63ull);
-
 bool HasPostingParentFlag(TClusterId parent) {
     return bool(parent & PostingParentFlag);
 }

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -76,6 +76,8 @@ inline constexpr const char* IdColumnSequence = "__ydb_id_sequence";
 
 inline constexpr const int DefaultKMeansRounds = 3;
 
+inline constexpr TClusterId PostingParentFlag = (1ull << 63ull);
+
 bool HasPostingParentFlag(TClusterId parent);
 void EnsureNoPostingParentFlag(TClusterId parent);
 TClusterId SetPostingParentFlag(TClusterId parent);

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -642,7 +642,6 @@ TExprBase DoRewriteTopSortOverKMeansTree(
     YQL_ENSURE(levelTableDesc->Metadata->Name.EndsWith(NTableIndex::NKMeans::LevelTable));
     YQL_ENSURE(postingTableDesc->Metadata->Name.EndsWith(NTableIndex::NKMeans::PostingTable));
 
-    // TODO(mbkkt) It's kind of strange that almost everything here have same position
     const auto pos = match.Pos();
 
     const auto levelTable = BuildTableMeta(*levelTableDesc->Metadata, pos, ctx);
@@ -717,6 +716,33 @@ TExprBase DoRewriteTopSortOverKMeansTree(
     return TExprBase{read};
 }
 
+template<typename T>
+TExprBase FilterLeafRows(const TExprBase& read, TExprContext& ctx, TPositionHandle pos) {
+    auto leafFlag = Build<TCoUint64>(ctx, pos)
+        .Literal()
+            .Value(std::to_string(NTableIndex::NKMeans::PostingParentFlag)) // "9223372036854775808"
+            .Build()
+        .Done();
+    auto prefixRowArg = ctx.NewArgument(pos, "prefixRow");
+    auto prefixCluster = Build<TCoMember>(ctx, pos)
+        .Struct(prefixRowArg)
+        .Name().Build(NTableIndex::NKMeans::ParentColumn)
+        .Done();
+    return Build<TCoFlatMap>(ctx, pos)
+        .Input(read)
+        .Lambda()
+            .Args({prefixRowArg})
+            .Body<TCoOptionalIf>()
+                .Predicate<T>()
+                    .Left(prefixCluster)
+                    .Right(leafFlag)
+                    .Build()
+                .Value(prefixRowArg)
+                .Build()
+            .Build()
+        .Done();
+}
+
 TExprBase DoRewriteTopSortOverPrefixedKMeansTree(
     const TReadMatch& match, const TCoFlatMap& flatMap, const TExprBase& lambdaArgs, const TExprBase& lambdaBody, const TCoTopBase& top,
     TExprContext& ctx, const TKqpOptimizeContext& kqpCtx,
@@ -732,7 +758,6 @@ TExprBase DoRewriteTopSortOverPrefixedKMeansTree(
     YQL_ENSURE(postingTableDesc->Metadata->Name.EndsWith(NTableIndex::NKMeans::PostingTable));
     YQL_ENSURE(prefixTableDesc->Metadata->Name.EndsWith(NTableIndex::NKMeans::PrefixTable));
 
-    // TODO(mbkkt) It's kind of strange that almost everything here have same position
     const auto pos = match.Pos();
 
     const auto levelTable = BuildTableMeta(*levelTableDesc->Metadata, pos, ctx);
@@ -776,18 +801,29 @@ TExprBase DoRewriteTopSortOverPrefixedKMeansTree(
         .Lambda(prefixLambda)
     .Done().Ptr();
 
+    read = Build<TDqPrecompute>(ctx, pos)
+        .Input(read)
+    .Done().Ptr();
+
     RemapIdToParent(ctx, pos, read);
+
+    auto prefixLeafRows = FilterLeafRows<TCoCmpGreaterOrEqual>(TExprBase(read), ctx, pos);
+    auto prefixRootRows = FilterLeafRows<TCoCmpLess>(TExprBase(read), ctx, pos);
 
     TKqpStreamLookupSettings settings;
     settings.Strategy = EStreamLookupStrategyType::LookupRows;
-    read = Build<TKqlStreamLookupTable>(ctx, pos)
+    auto levelRows = Build<TKqlStreamLookupTable>(ctx, pos)
         .Table(levelTable)
-        .LookupKeys(read)
+        .LookupKeys(prefixRootRows)
         .Columns(levelColumns)
         .Settings(settings.BuildNode(ctx, pos))
-    .Done().Ptr();
+        .Done().Ptr();
+    VectorReadLevel(indexDesc, ctx, pos, kqpCtx, levelLambda, top, levelTable, levelColumns, levelRows);
 
-    VectorReadLevel(indexDesc, ctx, pos, kqpCtx, levelLambda, top, levelTable, levelColumns, read);
+    read = Build<TCoUnionAll>(ctx, pos)
+        .Add(levelRows)
+        .Add(prefixLeafRows)
+        .Done().Ptr();
 
     VectorReadMain(ctx, pos, postingTable, postingTableDesc->Metadata, mainTable, tableDesc.Metadata, mainColumns, read);
 

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
@@ -113,4 +113,9 @@ NYql::NNodes::TExprBase BuildVectorIndexPrefixRows(const NYql::TKikimrTableDescr
     bool withData, const NYql::TIndexDescription* indexDesc, const NYql::NNodes::TExprBase& inputRows,
     TVector<TStringBuf>& indexTableColumns, NYql::TPositionHandle pos, NYql::TExprContext& ctx);
 
+std::pair<NYql::NNodes::TExprBase, NYql::NNodes::TExprBase> BuildVectorIndexPrefixRowsWithNew(
+    const NYql::TKikimrTableDescription& table, const NYql::TKikimrTableDescription& prefixTable,
+    const NYql::TIndexDescription* indexDesc, const NYql::NNodes::TExprBase& inputRows,
+    TVector<TStringBuf>& indexTableColumns, NYql::TPositionHandle pos, NYql::TExprContext& ctx);
+
 } // NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
@@ -920,7 +920,14 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
 
             if (indexDesc->Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
                 if (indexDesc->KeyColumns.size() > 1) {
-                    upsertIndexRows = BuildVectorIndexPrefixRows(table, *prefixTable, true, indexDesc, upsertIndexRows, indexTableColumns, pos, ctx);
+                    if (prefixTable->Metadata->Columns.at(NTableIndex::NKMeans::IdColumn).DefaultKind == NKikimrKqp::TKqpColumnMetadataProto::DEFAULT_KIND_SEQUENCE) {
+                        auto res = BuildVectorIndexPrefixRowsWithNew(table, *prefixTable, indexDesc, upsertIndexRows, indexTableColumns, pos, ctx);
+                        upsertIndexRows = std::move(res.first);
+                        effects.emplace_back(std::move(res.second));
+                    } else {
+                        // Handle old prefixed vector index tables without the sequence
+                        upsertIndexRows = BuildVectorIndexPrefixRows(table, *prefixTable, true, indexDesc, upsertIndexRows, indexTableColumns, pos, ctx);
+                    }
                 }
 
                 upsertIndexRows = BuildVectorIndexPostingRows(table, mainTableNode,

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_vector_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_vector_index.cpp
@@ -143,15 +143,31 @@ TVector<TExprBase> MakeColumnGetters(const TExprBase& rowArgument, const TVector
     return columnGetters;
 }
 
-TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const TKikimrTableDescription& prefixTable,
-    bool withData, const TIndexDescription* indexDesc, const TExprBase& inputRows,
-    TVector<TStringBuf>& indexTableColumns, TPositionHandle pos, TExprContext& ctx)
-{
-    // This whole method does a very simple thing:
-    // SELECT i.<indexColumns>, p.__ydb_id AS __ydb_parent FROM <inputRows> i INNER JOIN prefixTable p ON p.<prefixColumns>=i.<prefixColumns>
-    // To implement it, we use a StreamLookup in Join mode.
-    // It takes <lookup key, left row> tuples as input and returns <left row, right row, cookie> tuples as output ("cookie" contains read stats).
+TExprBase BuildNth(const TExprBase& lookupArg, const char *n, TPositionHandle pos, TExprContext& ctx) {
+    return Build<TCoNth>(ctx, pos)
+        .Tuple(lookupArg)
+        .Index().Value(n).Build()
+        .Done();
+};
 
+struct TVectorIndexPrefixLookup {
+    TExprBase Node;
+    TKqpTable PrefixTableNode;
+    TVector<TStringBuf> PrefixColumns;
+    const TStructExprType* PrefixType;
+    TVector<TStringBuf> PostingColumns;
+
+    TVectorIndexPrefixLookup(TExprBase&& node, TKqpTable&& prefixTableNode):
+        Node(std::move(node)),
+        PrefixTableNode(std::move(prefixTableNode)) {
+    }
+};
+
+TVectorIndexPrefixLookup BuildVectorIndexPrefixLookup(
+    const TKikimrTableDescription& table, const TKikimrTableDescription& prefixTable,
+    bool withData, bool withNulls, const TIndexDescription* indexDesc, const TExprBase& inputRows,
+    TPositionHandle pos, TExprContext& ctx)
+{
     TVector<TStringBuf> prefixColumns(indexDesc->KeyColumns.begin(), indexDesc->KeyColumns.end()-1);
     THashSet<TStringBuf> postingColumnsSet;
     TVector<TStringBuf> postingColumns;
@@ -172,7 +188,15 @@ TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const
     }
 
     TKqpStreamLookupSettings streamLookupSettings;
-    streamLookupSettings.Strategy = EStreamLookupStrategyType::LookupJoinRows;
+    streamLookupSettings.Strategy = EStreamLookupStrategyType::LookupSemiJoinRows;
+    TVector<TStringBuf> leftColumns = postingColumns;
+    if (withNulls) {
+        for (const auto& column : prefixColumns) {
+            if (postingColumnsSet.emplace(column).second) {
+                leftColumns.emplace_back(column);
+            }
+        }
+    }
 
     TVector<const TItemExprType*> prefixItems;
     for (auto& column : prefixColumns) {
@@ -183,17 +207,17 @@ TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const
     }
     auto prefixType = ctx.MakeType<TStructExprType>(prefixItems);
 
-    TVector<const TItemExprType*> postingItems;
-    for (auto& column : postingColumns) {
+    TVector<const TItemExprType*> leftItems;
+    for (auto& column : leftColumns) {
         auto type = table.GetColumnType(TString(column));
         YQL_ENSURE(type, "No index column: " << column);
         auto itemType = ctx.MakeType<TItemExprType>(column, type);
-        postingItems.push_back(itemType);
+        leftItems.push_back(itemType);
     }
-    auto postingType = ctx.MakeType<TStructExprType>(postingItems);
+    auto leftType = ctx.MakeType<TStructExprType>(leftItems);
 
     TVector<const TTypeAnnotationNode*> joinItemItems;
-    joinItemItems.push_back(postingType);
+    joinItemItems.push_back(leftType);
     joinItemItems.push_back(ctx.MakeType<TOptionalExprType>(prefixType));
     auto joinItemType = ctx.MakeType<TTupleExprType>(joinItemItems);
     auto joinInputType = ctx.MakeType<TListExprType>(joinItemType);
@@ -226,7 +250,7 @@ TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const
                                 // Join StreamLookup takes <left row, key> tuples as input - build them
                                 .Body<TExprList>()
                                     .Add<TCoAsStruct>()
-                                        .Add(MakeColumnGetters(rowArg, postingColumns, pos, ctx))
+                                        .Add(MakeColumnGetters(rowArg, leftColumns, pos, ctx))
                                         .Build()
                                     .Add<TCoJust>()
                                         .Input<TCoAsStruct>()
@@ -248,28 +272,49 @@ TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const
         .Settings(streamLookupSettings.BuildNode(ctx, pos))
         .Done();
 
+    TVectorIndexPrefixLookup res(std::move(lookup), std::move(prefixTableNode));
+    res.PrefixColumns = std::move(prefixColumns);
+    res.PrefixType = prefixType;
+    res.PostingColumns = std::move(postingColumns);
+    return res;
+}
+
+TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const TKikimrTableDescription& prefixTable,
+    bool withData, const TIndexDescription* indexDesc, const TExprBase& inputRows,
+    TVector<TStringBuf>& indexTableColumns, TPositionHandle pos, TExprContext& ctx)
+{
+    // This whole method does a very simple thing:
+    // SELECT i.<indexColumns>, p.__ydb_id AS __ydb_parent FROM <inputRows> i INNER JOIN prefixTable p ON p.<prefixColumns>=i.<prefixColumns>
+    // To implement it, we use a StreamLookup in Join mode.
+    // It takes <lookup key, left row> tuples as input and returns <left row, right row, cookie> tuples as output ("cookie" contains read stats).
+
+    TVectorIndexPrefixLookup lookup = BuildVectorIndexPrefixLookup(table, prefixTable, withData, false, indexDesc, inputRows, pos, ctx);
+
     // Join StreamLookup returns <left row, right row, cookie> tuples as output
     // But we need left row + 1 field of the right row - build it using TCoMap
 
     const auto lookupArg = Build<TCoArgument>(ctx, pos).Name("lookupRow").Done();
-    const auto leftRow = Build<TCoNth>(ctx, pos)
-        .Tuple(lookupArg)
-        .Index().Value("0").Build()
-        .Done();
-    const auto rightRow = Build<TCoNth>(ctx, pos)
-        .Tuple(lookupArg)
-        .Index().Value("1").Build()
-        .Done();
+    const auto leftRow = BuildNth(lookupArg, "0", pos, ctx);
+    const auto rightRow = BuildNth(lookupArg, "1", pos, ctx);
+
+    // Filter rows where rightRow is null
 
     auto mapLambda = Build<TCoLambda>(ctx, pos)
         .Args({lookupArg})
-        .Body<TCoAsStruct>()
-            .Add(MakeColumnGetters(leftRow, postingColumns, pos, ctx))
-            .Add<TCoNameValueTuple>()
-                .Name().Build(NTableIndex::NKMeans::ParentColumn)
-                .template Value<TCoMember>()
-                    .Struct<TCoUnwrap>().Optional(rightRow).Build()
-                    .Name().Build(NTableIndex::NKMeans::IdColumn)
+        .Body<TCoFlatOptionalIf>()
+            .Predicate<TCoExists>()
+                .Optional(rightRow)
+                .Build()
+            .Value<TCoJust>()
+                .Input<TCoAsStruct>()
+                    .Add(MakeColumnGetters(leftRow, lookup.PostingColumns, pos, ctx))
+                    .Add<TCoNameValueTuple>()
+                        .Name().Build(NTableIndex::NKMeans::ParentColumn)
+                        .template Value<TCoMember>()
+                            .Struct<TCoUnwrap>().Optional(rightRow).Build()
+                            .Name().Build(NTableIndex::NKMeans::IdColumn)
+                            .Build()
+                        .Build()
                     .Build()
                 .Build()
             .Build()
@@ -277,12 +322,12 @@ TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const
 
     auto mapStage = Build<TDqStage>(ctx, pos)
         .Inputs()
-            .Add(lookup)
+            .Add(lookup.Node)
             .Build()
         .Program()
             .Args({"rows"})
             .Body<TCoToStream>()
-                .Input<TCoMap>()
+                .Input<TCoFlatMap>()
                     .Input("rows")
                     .Lambda(mapLambda)
                     .Build()
@@ -291,8 +336,8 @@ TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const
         .Settings().Build()
         .Done();
 
-    postingColumns.push_back(NTableIndex::NKMeans::ParentColumn);
-    indexTableColumns = std::move(postingColumns);
+    indexTableColumns = std::move(lookup.PostingColumns);
+    indexTableColumns.push_back(NTableIndex::NKMeans::ParentColumn);
 
     return Build<TDqCnUnionAll>(ctx, pos)
         .Output()
@@ -300,6 +345,270 @@ TExprBase BuildVectorIndexPrefixRows(const TKikimrTableDescription& table, const
             .Index().Build(0)
             .Build()
         .Done();
+}
+
+std::pair<TExprBase, TExprBase> BuildVectorIndexPrefixRowsWithNew(
+    const TKikimrTableDescription& table, const TKikimrTableDescription& prefixTable,
+    const TIndexDescription* indexDesc, const TExprBase& inputRows,
+    TVector<TStringBuf>& indexTableColumns, TPositionHandle pos, TExprContext& ctx)
+{
+    // This method is similar to the previous one, but also handles unknown prefixes.
+    // StreamLookupJoin is executed in SemiJoin mode in this case, so <right row> may
+    // be null for prefixes missing from the prefix table.
+    // We feed such rows to KqpCnSequencer, replicate their IDs to the output stream,
+    // and also separately insert them into the prefix table.
+
+    TVectorIndexPrefixLookup lookup = BuildVectorIndexPrefixLookup(table, prefixTable, true, true, indexDesc, inputRows, pos, ctx);
+
+    const auto lookupArg = Build<TCoArgument>(ctx, pos).Name("lookupRow").Done();
+    const auto leftRow = BuildNth(lookupArg, "0", pos, ctx);
+    const auto rightRow = BuildNth(lookupArg, "1", pos, ctx);
+
+    const auto newRowsArg = Build<TCoArgument>(ctx, pos).Name("rows").Done();
+    auto newPrefixStream = Build<TCoFlatMap>(ctx, pos)
+        .Input(newRowsArg)
+        .Lambda()
+            .Args({lookupArg})
+            .Body<TCoOptionalIf>()
+                .Predicate<TCoNot>()
+                    .Value<TCoExists>()
+                        .Optional(rightRow)
+                        .Build()
+                    .Build()
+                .Value(leftRow)
+                .Build()
+            .Build()
+        .Done();
+
+    const auto keyArg = Build<TCoArgument>(ctx, pos).Name("keyArg").Done();
+    const auto payloadArg = Build<TCoArgument>(ctx, pos).Name("payloadArg").Done();
+    auto newPrefixDict = Build<TCoSqueezeToDict>(ctx, pos)
+        .Stream(newPrefixStream)
+        .KeySelector<TCoLambda>()
+            .Args(keyArg)
+            .Body<TCoAsStruct>()
+                .Add(MakeColumnGetters(keyArg, lookup.PrefixColumns, pos, ctx))
+                .Build()
+            .Build()
+        .PayloadSelector<TCoLambda>()
+            .Args(payloadArg)
+            .Body<TCoVoid>()
+                .Build()
+            .Build()
+        .Settings()
+            .Add().Build("One")
+            .Add().Build("Hashed")
+            .Build()
+        .Done();
+
+    auto newPrefixDictPrecompute = Build<TDqPhyPrecompute>(ctx, pos)
+        .Connection<TDqCnValue>()
+            .Output()
+                .Stage<TDqStage>()
+                    .Inputs()
+                        .Add(lookup.Node)
+                        .Build()
+                    .Program()
+                        .Args({newRowsArg})
+                        .Body(newPrefixDict)
+                        .Build()
+                    .Settings().Build()
+                    .Build()
+                .Index().Build(0)
+                .Build()
+            .Build()
+        .Done();
+
+    // Feed newPrefixes from dict to KqpCnSequencer
+
+    const auto dictArg = Build<TCoArgument>(ctx, pos).Name("dict").Done();
+    auto newPrefixesStage = Build<TDqStage>(ctx, pos)
+        .Inputs()
+            .Add(newPrefixDictPrecompute)
+            .Build()
+        .Program()
+            .Args({dictArg})
+            .Body<TCoToStream>()
+                .Input<TCoDictKeys>()
+                    .Dict(dictArg)
+                    .Build()
+                .Build()
+            .Build()
+        .Settings().Build()
+        .Done();
+
+    auto listPrefixType = ctx.MakeType<TListExprType>(lookup.PrefixType);
+    auto fullPrefixColumns = lookup.PrefixColumns;
+    fullPrefixColumns.push_back(NTableIndex::NKMeans::IdColumn);
+    auto fullPrefixColumnList = BuildColumnsList(fullPrefixColumns, pos, ctx);
+
+    auto cnSequencer = Build<TKqpCnSequencer>(ctx, pos)
+        .Output()
+            .Stage(newPrefixesStage)
+            .Index().Build(0)
+            .Build()
+        .Table(lookup.PrefixTableNode)
+        .Columns(fullPrefixColumnList)
+        .DefaultConstraintColumns<TCoAtomList>()
+            .Add(ctx.NewAtom(pos, NTableIndex::NKMeans::IdColumn))
+            .Build()
+        .InputItemType(ExpandType(pos, *listPrefixType, ctx))
+        .Done();
+
+    auto sequencerPrecompute = Build<TDqPhyPrecompute>(ctx, pos)
+        .Connection<TDqCnUnionAll>()
+            .Output()
+                .Stage<TDqStage>()
+                    .Inputs()
+                        .Add(cnSequencer)
+                        .Build()
+                    .Program()
+                        .Args({"rows"})
+                        .Body<TCoToStream>()
+                            .Input("rows")
+                            .Build()
+                        .Build()
+                    .Settings().Build()
+                    .Build()
+                .Index().Build(0)
+                .Build()
+            .Build()
+        .Done();
+
+    const auto sequencerArg = Build<TCoArgument>(ctx, pos).Name("seqRows").Done();
+    const auto seqKeyArg = Build<TCoArgument>(ctx, pos).Name("seqKey").Done();
+    const auto seqValueArg = Build<TCoArgument>(ctx, pos).Name("seqValue").Done();
+    auto sequencerDict = Build<TCoToDict>(ctx, pos)
+        .List(sequencerArg)
+        .KeySelector<TCoLambda>()
+            .Args({seqKeyArg})
+            .Body<TCoAsStruct>()
+                .Add(MakeColumnGetters(seqKeyArg, lookup.PrefixColumns, pos, ctx))
+                .Build()
+            .Build()
+        .PayloadSelector<TCoLambda>()
+            .Args({seqValueArg})
+            .Body<TCoMember>()
+                .Struct(seqValueArg)
+                .Name().Build(NTableIndex::NKMeans::IdColumn)
+                .Build()
+            .Build()
+        .Settings()
+            .Add().Build("One")
+            .Add().Build("Hashed")
+            .Build()
+        .Done();
+
+    auto sequencerDictPrecompute = Build<TDqPhyPrecompute>(ctx, pos)
+        .Connection<TDqCnValue>()
+            .Output()
+                .Stage<TDqStage>()
+                    .Inputs()
+                        .Add(sequencerPrecompute)
+                        .Build()
+                    .Program()
+                        .Args({sequencerArg})
+                        .Body<TCoToStream>()
+                            .Input<TCoAsList>()
+                                .Add(sequencerDict)
+                                .Build()
+                            .Build()
+                        .Build()
+                    .Settings().Build()
+                    .Build()
+                .Index().Build(0)
+                .Build()
+            .Build()
+        .Done();
+
+    // Take output and remap it to the input using a dictionary
+
+    const auto sequencerDictArg = Build<TCoArgument>(ctx, pos).Name("dict").Done();
+    const auto origArg = Build<TCoArgument>(ctx, pos).Name("origRows").Done();
+    const auto fillRowArg = Build<TCoArgument>(ctx, pos).Name("fillRow").Done();
+    const auto leftFillRow = BuildNth(fillRowArg, "0", pos, ctx);
+    const auto rightFillRow = BuildNth(fillRowArg, "1", pos, ctx);
+    auto mapLambda = Build<TCoLambda>(ctx, pos)
+        .Args({fillRowArg})
+        .Body<TCoAsStruct>()
+            .Add(MakeColumnGetters(leftFillRow, lookup.PostingColumns, pos, ctx))
+            .Add<TCoNameValueTuple>()
+                .Name().Build(NTableIndex::NKMeans::ParentColumn)
+                .template Value<TCoIf>()
+                    .Predicate<TCoExists>()
+                        .Optional(rightFillRow)
+                        .Build()
+                    .ThenValue<TCoMember>()
+                        .Struct<TCoUnwrap>().Optional(rightFillRow).Build()
+                        .Name().Build(NTableIndex::NKMeans::IdColumn)
+                        .Build()
+                    .ElseValue<TCoUnwrap>()
+                        .Optional<TCoLookup>()
+                            .Collection(sequencerDictArg)
+                            .Lookup<TCoAsStruct>()
+                                .Add(MakeColumnGetters(leftFillRow, lookup.PrefixColumns, pos, ctx))
+                                .Build()
+                            .Build()
+                        .Build()
+                    .Build()
+                .Build()
+            .Build()
+        .Done();
+
+    auto mapStage = Build<TDqStage>(ctx, pos)
+        .Inputs()
+            .Add(lookup.Node)
+            .Add(sequencerDictPrecompute)
+            .Build()
+        .Program()
+            .Args({origArg, sequencerDictArg})
+            .Body<TCoToStream>()
+                .Input<TCoMap>()
+                    .Input(origArg)
+                    .Lambda(mapLambda)
+                    .Build()
+                .Build()
+            .Build()
+        .Settings().Build()
+        .Done();
+
+    indexTableColumns = std::move(lookup.PostingColumns);
+    indexTableColumns.push_back(NTableIndex::NKMeans::ParentColumn);
+
+    auto mappedRows = Build<TDqCnUnionAll>(ctx, pos)
+        .Output()
+            .Stage(mapStage)
+            .Index().Build(0)
+            .Build()
+        .Done();
+
+    auto upsertPrefixStage = Build<TDqStage>(ctx, pos)
+        .Inputs()
+            .Add(sequencerPrecompute)
+            .Build()
+        .Program()
+            .Args({"rows"})
+            .Body<TCoToStream>()
+                .Input("rows")
+                .Build()
+            .Build()
+        .Settings().Build()
+        .Done();
+
+    auto upsertPrefix = Build<TKqlUpsertRows>(ctx, pos)
+        .Table(lookup.PrefixTableNode)
+        .Input<TDqCnUnionAll>()
+            .Output()
+                .Stage(upsertPrefixStage)
+                .Index().Build(0)
+                .Build()
+            .Build()
+        .Columns(fullPrefixColumnList)
+        .ReturningColumns<TCoAtomList>().Build()
+        .IsBatch(ctx.NewAtom(pos, "false"))
+        .Done();
+
+    return std::make_pair((TExprBase)mappedRows, (TExprBase)upsertPrefix);
 }
 
 } // namespace NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -257,6 +257,10 @@ struct TIndexDescription {
             case EType::GlobalAsync:
                 return false;
             case EType::GlobalSyncVectorKMeansTree:
+                if (State != EIndexState::Ready) {
+                    // Do not try to update vector indexes until their build is finished
+                    return false;
+                }
                 return true;
             case EType::GlobalFulltext:
                 return true;

--- a/ydb/core/kqp/runtime/kqp_vector_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_vector_actor.cpp
@@ -185,9 +185,12 @@ private:
                         for (size_t i = 0; i < PendingRows.size(); i++) {
                             auto rootClusterId = (ui64)PendingRows[i].GetElement(Settings.GetRootClusterColumnIndex()).GetInt128();
                             PrevClusters.push_back(rootClusterId);
-                            LevelClusters.insert(rootClusterId);
+                            if (!NKikimr::NTableIndex::NKMeans::HasPostingParentFlag(rootClusterId)) {
+                                LevelClusters.insert(rootClusterId);
+                            }
                         }
                     } else {
+                        PrevClusters.resize(PendingRows.size());
                         LevelClusters.insert(0);
                     }
                 } else {
@@ -202,8 +205,7 @@ private:
                     LevelsFinished = true;
                     break;
                 }
-                NextClusters.clear();
-                NextClusters.resize(PendingRows.size());
+                NextClusters = PrevClusters;
                 CurClusters.reset();
             }
             while (LevelClusters.size() > 0) {


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Для поддержки вставки новых префиксов:
- В алгоритм поиска по префиксному векторному индексу добавлен пропуск таблицы level в том случае, когда ID кластера в таблице prefix является сразу листовым. Производительность проверил с помощью workload - накладные расходы на это, вроде бы, минимальны, в пределах погрешности (условно 1690 tps vs 1720 tps в 10 потоков).
- В алгоритм построения префиксного векторного индекса добавлено создание sequence в таблице prefix и его привязка к колонке __ydb_id.
- В алгоритм обновления добавлена обработка новых префиксов, их прогон через KqpCnSequencer для генерации ID и их вставка в prefix таблицу.
- В VectorResolveActor добавлен пропуск вычисления кластеров, когда на входе для префиксного индекса в качестве корневого кластера передан листовой ID.
- Для старых префиксных индексов без sequence новый алгоритм пропускается и всё работает как раньше, без обработки неизвестных префиксов.

Таким образом, даже при вставке новых префиксов в индекс таблица level всегда остаётся по-настоящему иммутабельной.