### PR TITLE
Order by PK + limit full fix

### DIFF
--- a/ydb/core/kqp/ut/olap/aggregations_ut.cpp
+++ b/ydb/core/kqp/ut/olap/aggregations_ut.cpp
@@ -488,8 +488,7 @@ Y_UNIT_TEST_SUITE(KqpOlapAggregations) {
                 LIMIT 2
             )")
             .AddExpectedPlanOptions("KqpOlapFilter")
-            .MutableLimitChecker().SetExpectedLimit(2)
-            .SetExpectedResultCount(400); // FIXME (delete this line)
+            .MutableLimitChecker().SetExpectedLimit(2);
         TestAggregations({ testCase });
     }
 
@@ -504,8 +503,7 @@ Y_UNIT_TEST_SUITE(KqpOlapAggregations) {
                 LIMIT 2
             )")
             .AddExpectedPlanOptions("KqpOlapFilter")
-            .MutableLimitChecker().SetExpectedLimit(2)
-            .SetExpectedResultCount(400); // FIXME (delete this line)
+            .MutableLimitChecker().SetExpectedLimit(2);
         TestAggregations({ testCase });
     }
 
@@ -520,8 +518,7 @@ Y_UNIT_TEST_SUITE(KqpOlapAggregations) {
             )")
             .AddExpectedPlanOptions("KqpOlapFilter")
             .AddExpectedPlanOptions("KqpOlapExtractMembers")
-            .MutableLimitChecker().SetExpectedLimit(2)
-            .SetExpectedResultCount(400); // FIXME (delete this line)
+            .MutableLimitChecker().SetExpectedLimit(2);
         TestAggregations({ testCase });
     }
 
@@ -537,8 +534,7 @@ Y_UNIT_TEST_SUITE(KqpOlapAggregations) {
             )")
             .AddExpectedPlanOptions("KqpOlapFilter")
             .AddExpectedPlanOptions("KqpOlapExtractMembers")
-            .MutableLimitChecker().SetExpectedLimit(2)
-            .SetExpectedResultCount(400); // FIXME (delete this line)
+            .MutableLimitChecker().SetExpectedLimit(2);
         TestAggregations({ testCase });
     }
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sync_points/limit.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sync_points/limit.cpp
@@ -17,11 +17,8 @@ bool TSyncPointLimitControl::DrainToLimit() {
     if (Collection->GetNextSource()) {
         nextInHeap = TSourceIterator(Collection->GetNextSource());
     }
-    if (Iterators.empty() || (nextInHeap && Iterators.front() < *nextInHeap)) {
-        return false;
-    }
 
-    while (Iterators.size()) {
+    while (Iterators.size() && (!nextInHeap || !(Iterators.front() < *nextInHeap))) {
         if (!Iterators.front().IsFilled()) {
             return false;
         }

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
@@ -46,9 +46,7 @@ void TTxScan::Complete(const TActorContext& ctx) {
             return TReadMetadataBase::ESorting::NONE;
         }
     }();
-    /* FIXME: #22992 */
-    const auto useLimit = request.HasItemsLimit() && (sorting == ERequestSorting::NONE || !deduplicationEnabled);
-    TScannerConstructorContext context(snapshot, useLimit ? request.GetItemsLimit() : 0, sorting);
+    TScannerConstructorContext context(snapshot, request.HasItemsLimit() ? request.GetItemsLimit() : 0, sorting);
     const auto scanId = request.GetScanId();
     const ui64 txId = request.GetTxId();
     const ui32 scanGen = request.GetGeneration();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Some time ago order by PK + limit requests work incorrectly, so I made a tmp fix. This PR fixes the issue completely and removes tmp fix
...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
