### PR TITLE
Fix bug when importing a table with a non Uint primary key and a changefeed

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -25,23 +25,6 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTablePropose(
     const auto& item = importInfo.Items.at(itemIdx);
     Y_ABORT_UNLESS(item.Table);
 
-    // const auto& pk0 = item.Table->primary_key()[0];
-    // const auto& columns = item.Table->columns();
-    // ::Ydb::Table::ColumnMeta pkColumn;
-
-    // for (const auto& column : columns) {
-    //     if (column.name() == pk0) {
-    //         pkColumn = column;
-    //         break;
-    //     }
-    // }
-
-    // if (pkColumn.type().has_type_id() 
-    //     && pkColumn.type().type_id() != ::Ydb::Type_PrimitiveTypeId_UINT32
-    //     && && pkColumn.type().type_id() != ::Ydb::Type_PrimitiveTypeId_UINT64) {
-
-    // }
-
     auto propose = MakeModifySchemeTransaction(ss, txId, importInfo);
     auto& record = propose->Record;
 

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -290,17 +290,17 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateChangefeedPropose(
 
     auto tableDesc = GetTableDescription(ss, dstPath->PathId);
     const auto& keyIds = tableDesc.GetKeyColumnIds()[0];
-    bool isPartitioningAvaliable = false;
+    bool isPartitioningAvailable = false;
     
     // ydb.tech/docs/ru/concepts/cdc#topic-partitions
     for (const auto& column : tableDesc.GetColumns()) {
         if (column.GetId() == keyIds) {
-            isPartitioningAvaliable = column.GetType() == "Uint32" || column.GetType() == "Uint64";
+            isPartitioningAvailable = column.GetType() == "Uint32" || column.GetType() == "Uint64";
             break;
         }
     }
 
-    if (topic.has_partitioning_settings() && isPartitioningAvaliable) {
+    if (topic.has_partitioning_settings() && isPartitioningAvailable) {
         i64 minActivePartitions =
             topic.partitioning_settings().min_active_partitions();
         if (minActivePartitions < 0) {

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -25,6 +25,23 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTablePropose(
     const auto& item = importInfo.Items.at(itemIdx);
     Y_ABORT_UNLESS(item.Table);
 
+    // const auto& pk0 = item.Table->primary_key()[0];
+    // const auto& columns = item.Table->columns();
+    // ::Ydb::Table::ColumnMeta pkColumn;
+
+    // for (const auto& column : columns) {
+    //     if (column.name() == pk0) {
+    //         pkColumn = column;
+    //         break;
+    //     }
+    // }
+
+    // if (pkColumn.type().has_type_id() 
+    //     && pkColumn.type().type_id() != ::Ydb::Type_PrimitiveTypeId_UINT32
+    //     && && pkColumn.type().type_id() != ::Ydb::Type_PrimitiveTypeId_UINT64) {
+
+    // }
+
     auto propose = MakeModifySchemeTransaction(ss, txId, importInfo);
     auto& record = propose->Record;
 

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -292,6 +292,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateChangefeedPropose(
     const auto& keyIds = tableDesc.GetKeyColumnIds()[0];
     bool isPartitioningAvaliable = false;
     
+    // ydb.tech/docs/ru/concepts/cdc#topic-partitions
     for (const auto& column : tableDesc.GetColumns()) {
         if (column.GetId() == keyIds) {
             isPartitioningAvaliable = column.GetType() == "Uint32" || column.GetType() == "Uint64";

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -1145,6 +1145,34 @@ void NoMaxPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) 
     UNIT_ASSERT(!record.GetPathDescription().GetTable().GetPartitionConfig().GetPartitioningPolicy().HasMaxPartitionsCount());
 }
 
+TCheckFunc MinTopicPartitionsCountEqual(ui32 count) {
+    return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
+        UNIT_ASSERT_VALUES_EQUAL(record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().GetMinPartitionCount(), count);
+    };
+}
+
+void HasMinTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) {
+    UNIT_ASSERT(record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().HasMinPartitionCount());
+}
+
+void NoMinTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) {
+    UNIT_ASSERT(!record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().HasMinPartitionCount());
+}
+
+TCheckFunc MaxTopicPartitionsCountEqual(ui32 count) {
+    return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
+        UNIT_ASSERT_VALUES_EQUAL(record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().GetMaxPartitionCount(), count);
+    };
+}
+
+void HasMaxTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) {
+    UNIT_ASSERT(record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().HasMaxPartitionCount());
+}
+
+void NoMaxTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) {
+    UNIT_ASSERT(!record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().HasMaxPartitionCount());
+}
+
 TCheckFunc PartitioningByLoadStatus(bool status) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
         UNIT_ASSERT_VALUES_EQUAL(record.GetPathDescription().GetTable().GetPartitionConfig().GetPartitioningPolicy().GetSplitByLoadSettings().GetEnabled(), status);

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -1151,26 +1151,10 @@ TCheckFunc MinTopicPartitionsCountEqual(ui32 count) {
     };
 }
 
-void HasMinTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) {
-    UNIT_ASSERT(record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().HasMinPartitionCount());
-}
-
-void NoMinTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) {
-    UNIT_ASSERT(!record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().HasMinPartitionCount());
-}
-
 TCheckFunc MaxTopicPartitionsCountEqual(ui32 count) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
         UNIT_ASSERT_VALUES_EQUAL(record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().GetMaxPartitionCount(), count);
     };
-}
-
-void HasMaxTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) {
-    UNIT_ASSERT(record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().HasMaxPartitionCount());
-}
-
-void NoMaxTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record) {
-    UNIT_ASSERT(!record.GetPathDescription().GetPersQueueGroup().GetPQTabletConfig().GetPartitionStrategy().HasMaxPartitionCount());
 }
 
 TCheckFunc PartitioningByLoadStatus(bool status) {

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
@@ -139,11 +139,7 @@ namespace NLs {
     void HasMaxPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void NoMaxPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
     TCheckFunc MinTopicPartitionsCountEqual(ui32 count);
-    void HasMinTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
-    void NoMinTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
     TCheckFunc MaxTopicPartitionsCountEqual(ui32 count);
-    void HasMaxTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
-    void NoMaxTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
     TCheckFunc PartitioningByLoadStatus(bool status);
     TCheckFunc ColumnFamiliesCount(ui32 size);
     TCheckFunc ColumnFamiliesHas(ui32 familyId);

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
@@ -138,6 +138,12 @@ namespace NLs {
     TCheckFunc MaxPartitionsCountEqual(ui32 count);
     void HasMaxPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void NoMaxPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
+    TCheckFunc MinTopicPartitionsCountEqual(ui32 count);
+    void HasMinTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
+    void NoMinTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
+    TCheckFunc MaxTopicPartitionsCountEqual(ui32 count);
+    void HasMaxTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
+    void NoMaxTopicPartitionsCount(const NKikimrScheme::TEvDescribeSchemeResult& record);
     TCheckFunc PartitioningByLoadStatus(bool status);
     TCheckFunc ColumnFamiliesCount(ui32 size);
     TCheckFunc ColumnFamiliesHas(ui32 familyId);

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5445,6 +5445,7 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         TestImportChangefeeds(1, AddedScheme);
     }
 
+    // ydb.tech/docs/ru/concepts/cdc#topic-partitions
     Y_UNIT_TEST(ChangefeedWithPartitioning) {
         TestImportChangefeeds(1, AddedScheme, "UINT32");
     }

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5238,7 +5238,7 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         std::function<void(TTestBasicRuntime&)> Checker;
     };
 
-    TGeneratedChangefeed GenChangefeed(ui64 num = 1, bool isPartitioningAvaliable = true) {
+    TGeneratedChangefeed GenChangefeed(ui64 num = 1, bool isPartitioningAvailable = true) {
         const TString changefeedName = TStringBuilder() << "updates_feed" << num;
         const auto changefeedPath = TStringBuilder() << "/" << changefeedName;
 
@@ -5303,7 +5303,7 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         attr.emplace(NAttr::EKeys::TOPIC_DESCRIPTION, topicDesc);
         return {
             {changefeedPath, GenerateTestData({EPathTypeCdcStream, changefeedDesc, std::move(attr)})},
-            [changefeedPath = TString(changefeedPath), isPartitioningAvaliable](TTestBasicRuntime& runtime) {
+            [changefeedPath = TString(changefeedPath), isPartitioningAvailable](TTestBasicRuntime& runtime) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Table" + changefeedPath, false, false, true), {
                     NLs::PathExist,
                 });
@@ -5311,7 +5311,7 @@ Y_UNIT_TEST_SUITE(TImportTests) {
                 TestDescribeResult(topicDesc, {
                     NLs::ConsumerExist("my_consumer"),
                 });
-                if (isPartitioningAvaliable) {
+                if (isPartitioningAvailable) {
                     TestDescribeResult(topicDesc, {
                         NLs::MinTopicPartitionsCountEqual(2),
                         NLs::MaxTopicPartitionsCountEqual(3),
@@ -5327,12 +5327,12 @@ Y_UNIT_TEST_SUITE(TImportTests) {
     TVector<std::function<void(TTestBasicRuntime&)>> GenChangefeeds(
         THashMap<TString, TTestDataWithScheme>& bucketContent, 
         ui64 count = 1, 
-        bool isPartitioningAvaliable = true) 
+        bool isPartitioningAvailable = true) 
     {
         TVector<std::function<void(TTestBasicRuntime&)>> checkers;
         checkers.reserve(count);
         for (ui64 i = 1; i <= count; ++i) {
-            auto genChangefeed = GenChangefeed(i, isPartitioningAvaliable);
+            auto genChangefeed = GenChangefeed(i, isPartitioningAvailable);
             bucketContent.emplace(genChangefeed.Changefeed);
             checkers.push_back(genChangefeed.Checker);
         }

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5251,8 +5251,8 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
         const auto topicDesc = R"(
             partitioning_settings {
-                min_active_partitions: 1
-                max_active_partitions: 1
+                min_active_partitions: 2
+                max_active_partitions: 2
                 auto_partitioning_settings {
                     strategy: AUTO_PARTITIONING_STRATEGY_DISABLED
                     partition_write_speed {
@@ -5385,18 +5385,6 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         ui64 txId = 100;
         runtime.GetAppData().FeatureFlags.SetEnableChangefeedsImport(true);
         runtime.SetLogPriority(NKikimrServices::IMPORT, NActors::NLog::PRI_TRACE);
-
-        const auto data = GenerateTestData(R"(
-            columns {
-              name: "key"
-              type { optional_type { item { type_id: UTF8 } } }
-            }
-            columns {
-              name: "value"
-              type { optional_type { item { type_id: UTF8 } } }
-            }
-            primary_key: "key"
-        )");
 
         THashMap<TString, TTestDataWithScheme> bucketContent(countChangefeed + 1);
 

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5238,7 +5238,7 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         std::function<void(TTestBasicRuntime&)> Checker;
     };
 
-    TGeneratedChangefeed GenChangefeed(ui64 num = 1) {
+    TGeneratedChangefeed GenChangefeed(ui64 num = 1, bool isPartitioningAvaliable = true) {
         const TString changefeedName = TStringBuilder() << "updates_feed" << num;
         const auto changefeedPath = TStringBuilder() << "/" << changefeedName;
 
@@ -5252,9 +5252,9 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         const auto topicDesc = R"(
             partitioning_settings {
                 min_active_partitions: 2
-                max_active_partitions: 2
+                max_active_partitions: 3
                 auto_partitioning_settings {
-                    strategy: AUTO_PARTITIONING_STRATEGY_DISABLED
+                    strategy: AUTO_PARTITIONING_STRATEGY_SCALE_UP
                     partition_write_speed {
                         stabilization_window {
                             seconds: 300
@@ -5303,40 +5303,60 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         attr.emplace(NAttr::EKeys::TOPIC_DESCRIPTION, topicDesc);
         return {
             {changefeedPath, GenerateTestData({EPathTypeCdcStream, changefeedDesc, std::move(attr)})},
-            [changefeedPath = TString(changefeedPath)](TTestBasicRuntime& runtime) {
+            [changefeedPath = TString(changefeedPath), isPartitioningAvaliable](TTestBasicRuntime& runtime) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Table" + changefeedPath, false, false, true), {
                     NLs::PathExist,
                 });
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/Table" + changefeedPath + "/streamImpl", false, false, true), {
-                    NLs::ConsumerExist("my_consumer")
+                const auto topicDesc = DescribePath(runtime, "/MyRoot/Table" + changefeedPath + "/streamImpl", false, false, true);
+                TestDescribeResult(topicDesc, {
+                    NLs::ConsumerExist("my_consumer"),
                 });
+                if (isPartitioningAvaliable) {
+                    TestDescribeResult(topicDesc, {
+                        NLs::MinTopicPartitionsCountEqual(2),
+                        NLs::MaxTopicPartitionsCountEqual(3),
+                    });
+                } else {
+                    NLs::NoMinTopicPartitionsCount(topicDesc);
+                    NLs::NoMaxTopicPartitionsCount(topicDesc);
+                }
             }
         };
     }
 
-    TVector<std::function<void(TTestBasicRuntime&)>> GenChangefeeds(THashMap<TString, TTestDataWithScheme>& bucketContent, ui64 count = 1) {
+    TVector<std::function<void(TTestBasicRuntime&)>> GenChangefeeds(
+        THashMap<TString, TTestDataWithScheme>& bucketContent, 
+        ui64 count = 1, 
+        bool isPartitioningAvaliable = true) 
+    {
         TVector<std::function<void(TTestBasicRuntime&)>> checkers;
         checkers.reserve(count);
         for (ui64 i = 1; i <= count; ++i) {
-            auto genChangefeed = GenChangefeed(i);
+            auto genChangefeed = GenChangefeed(i, isPartitioningAvaliable);
             bucketContent.emplace(genChangefeed.Changefeed);
             checkers.push_back(genChangefeed.Checker);
         }
         return checkers;
     }
 
-    std::function<void(TTestBasicRuntime&)> AddedSchemeCommon(THashMap<TString, TTestDataWithScheme>& bucketContent, const TString& permissions) {
-        const auto data = GenerateTestData(R"(
+    std::function<void(TTestBasicRuntime&)> AddedSchemeCommon(
+        THashMap<TString, TTestDataWithScheme>& bucketContent,
+        const TString& permissions,
+        const TString& pkType)
+    {
+        const TString shardConfUTF8 = "a";
+
+        const auto data = GenerateTestData(Sprintf(R"(
             columns {
               name: "key"
-              type { optional_type { item { type_id: UTF8 } } }
+              type { optional_type { item { type_id: %s } } }
             }
             columns {
               name: "value"
               type { optional_type { item { type_id: UTF8 } } }
             }
             primary_key: "key"
-        )", {{"a", 1}}, permissions);
+        )", pkType.c_str()), {{pkType == "UTF8" ? shardConfUTF8 : "", 1}}, permissions);
 
         bucketContent.emplace("", data);
         return [](TTestBasicRuntime& runtime) {
@@ -5346,11 +5366,17 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         };
     }
 
-    std::function<void(TTestBasicRuntime&)> AddedScheme(THashMap<TString, TTestDataWithScheme>& bucketContent) {
-        return AddedSchemeCommon(bucketContent, "");
+    std::function<void(TTestBasicRuntime&)> AddedScheme(
+        THashMap<TString, TTestDataWithScheme>& bucketContent,
+        const TString& pkType)
+    {
+        return AddedSchemeCommon(bucketContent, "", pkType);
     }
 
-    std::function<void(TTestBasicRuntime&)> AddedSchemeWithPermissions(THashMap<TString, TTestDataWithScheme>& bucketContent) {
+    std::function<void(TTestBasicRuntime&)> AddedSchemeWithPermissions(
+        THashMap<TString, TTestDataWithScheme>& bucketContent,
+        const TString& pkType) 
+    {
         const auto permissions = R"(
             actions {
               change_owner: "eve"
@@ -5374,12 +5400,12 @@ Y_UNIT_TEST_SUITE(TImportTests) {
               }
             }
         )";
-        return AddedSchemeCommon(bucketContent, permissions);
+        return AddedSchemeCommon(bucketContent, permissions, pkType);
     }
 
-    using SchemeFunction = std::function<std::function<void(TTestBasicRuntime&)>(THashMap<TString, TTestDataWithScheme>&)>;
+    using SchemeFunction = std::function<std::function<void(TTestBasicRuntime&)>(THashMap<TString, TTestDataWithScheme>&, const TString&)>;
 
-    void TestImportChangefeeds(ui64 countChangefeed, SchemeFunction addedScheme) {
+    void TestImportChangefeeds(ui64 countChangefeed, SchemeFunction addedScheme, const TString& pkType = "UTF8") {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         ui64 txId = 100;
@@ -5388,8 +5414,8 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
         THashMap<TString, TTestDataWithScheme> bucketContent(countChangefeed + 1);
 
-        auto checkerTable = addedScheme(bucketContent);
-        auto checkersChangefeeds = GenChangefeeds(bucketContent, countChangefeed);
+        auto checkerTable = addedScheme(bucketContent, pkType);
+        auto checkersChangefeeds = GenChangefeeds(bucketContent, countChangefeed, pkType == "UINT32" || pkType == "UINT64");
 
         TPortManager portManager;
         const ui16 port = portManager.GetPort();
@@ -5417,6 +5443,14 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(Changefeed) {
         TestImportChangefeeds(1, AddedScheme);
+    }
+
+    Y_UNIT_TEST(ChangefeedWithPartitioning) {
+        TestImportChangefeeds(1, AddedScheme, "UINT32");
+    }
+
+    Y_UNIT_TEST(ChangefeedsWithPartitioning) {
+        TestImportChangefeeds(3, AddedScheme, "UINT64");
     }
 
     Y_UNIT_TEST(Changefeeds) {

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5344,8 +5344,6 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         const TString& permissions,
         const TString& pkType)
     {
-        const TString shardConfUTF8 = "a";
-
         const auto data = GenerateTestData(Sprintf(R"(
             columns {
               name: "key"
@@ -5356,7 +5354,7 @@ Y_UNIT_TEST_SUITE(TImportTests) {
               type { optional_type { item { type_id: UTF8 } } }
             }
             primary_key: "key"
-        )", pkType.c_str()), {{pkType == "UTF8" ? shardConfUTF8 : "", 1}}, permissions);
+        )", pkType.c_str()), {{pkType == "UTF8" ? "a" : "", 1}}, permissions);
 
         bucketContent.emplace("", data);
         return [](TTestBasicRuntime& runtime) {

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5307,19 +5307,11 @@ Y_UNIT_TEST_SUITE(TImportTests) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Table" + changefeedPath, false, false, true), {
                     NLs::PathExist,
                 });
-                const auto topicDesc = DescribePath(runtime, "/MyRoot/Table" + changefeedPath + "/streamImpl", false, false, true);
-                TestDescribeResult(topicDesc, {
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/Table" + changefeedPath + "/streamImpl", false, false, true), {
                     NLs::ConsumerExist("my_consumer"),
+                    NLs::MinTopicPartitionsCountEqual(isPartitioningAvailable ? 2 : 1),
+                    NLs::MaxTopicPartitionsCountEqual(3),
                 });
-                if (isPartitioningAvailable) {
-                    TestDescribeResult(topicDesc, {
-                        NLs::MinTopicPartitionsCountEqual(2),
-                        NLs::MaxTopicPartitionsCountEqual(3),
-                    });
-                } else {
-                    NLs::NoMinTopicPartitionsCount(topicDesc);
-                    NLs::NoMaxTopicPartitionsCount(topicDesc);
-                }
             }
         };
     }
@@ -5443,7 +5435,9 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         TestImportChangefeeds(1, AddedScheme);
     }
 
-    // ydb.tech/docs/ru/concepts/cdc#topic-partitions
+    // Explicit specification of the number of partitions when creating CDC
+    // is possible only if the first component of the primary key 
+    // of the source table is Uint32 or Uint64 
     Y_UNIT_TEST(ChangefeedWithPartitioning) {
         TestImportChangefeeds(1, AddedScheme, "UINT32");
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

https://github.com/ydb-platform/ydb/issues/25524

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

При создании changefeed проверяетеся первый компонент первичного ключа, если он не Uint32 или Uint64, то настройки партиционирования не заполняются
