### PR TITLE
Watermarks: show important hopping stats

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_stats.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_stats.cpp
@@ -92,13 +92,18 @@ void FillTaskRunnerStats(ui64 taskId, ui32 stageId, const TDqTaskRunnerStats& ta
                     protoBucket->SetValue(snapshot->Value(i));
                 }
             }
+        }
 
-            for (const auto& stat : taskStats.MkqlStats) {
-                auto* s = protoTask->MutableMkqlStats()->Add();
-                s->SetName(TString(stat.Key.GetName()));
-                s->SetValue(stat.Value);
-                s->SetDeriv(stat.Key.IsDeriv());
+        for (const auto& stat : taskStats.MkqlStats) {
+            if (!StatsLevelCollectProfile(level) &&
+                "MultiHop_EarlyThrownEventsCount" != stat.Key.GetName() &&
+                "MultiHop_LateThrownEventsCount"  != stat.Key.GetName()) {
+                continue;
             }
+            auto* s = protoTask->MutableMkqlStats()->Add();
+            s->SetName(TString(stat.Key.GetName()));
+            s->SetValue(stat.Value);
+            s->SetDeriv(stat.Key.IsDeriv());
         }
 
         for (const auto& opStat : taskStats.OperatorStat) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Show hopping stats in full stats mode

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Show number of thrown events in full stats mode. It helps debugging problems related to watermarks. Those stats are enabled by default in profile stats mode, but this mode sends too much info to metrics