### PR TITLE
Handle secrets that were removed and restored

### DIFF
--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
@@ -197,7 +197,6 @@ void TDescribeSchemaSecretsService::SendSchemeCacheRequest(const TString& secret
     NSchemeCache::TSchemeCacheNavigate::TEntry entry;
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
     entry.Path = SplitPath(secretName);
-    entry.SyncVersion = true;
     request->ResultSet.emplace_back(entry);
     // TODO(yurikiselev): Deal with UserToken [issue:25472]
 

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
@@ -101,14 +101,14 @@ private:
 
 }  // anonymous namespace
 
-void TDescribeSchemaSecretsService::Handle(TEvResolveSecret::TPtr& ev) {
+void TDescribeSchemaSecretsService::HandleIncomingRequest(TEvResolveSecret::TPtr& ev) {
     LOG_D("TEvResolveSecret: name=" << ev->Get()->SecretName << ", request cookie=" << LastCookie);
 
     SaveIncomingRequestInfo(*ev->Get());
     SendSchemeCacheRequest(ev->Get()->SecretName);
 }
 
-void TDescribeSchemaSecretsService::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+void TDescribeSchemaSecretsService::HandleSchemeCacheResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
     LOG_D("TEvNavigateKeySetResult: request cookie=" << ev->Cookie);
 
     const auto respIt = ResolveInFlight.find(ev->Cookie);
@@ -146,7 +146,7 @@ void TDescribeSchemaSecretsService::Handle(TEvTxProxySchemeCache::TEvNavigateKey
     Send(MakeTxProxyID(), req.Release(), 0, ev->Cookie);
 }
 
-void TDescribeSchemaSecretsService::Handle(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev) {
+void TDescribeSchemaSecretsService::HandleSchemeShardResponse(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev) {
     LOG_D("TEvDescribeSchemeResult: request cookie=" << ev->Cookie);
 
     const auto respIt = ResolveInFlight.find(ev->Cookie);

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
@@ -209,7 +209,7 @@ bool TDescribeSchemaSecretsService::LocalCacheHasActualVersion(const TVersionedS
 }
 
 bool TDescribeSchemaSecretsService::LocalCacheHasActualObject(const TVersionedSecret& secret, const ui64& cacheSecretPathId) {
-    // altering secret object, i.e. changing acl, should leed to secret cache update
+    // altering secret object, i.e. changing acl, should lead to secret cache update
     return secret.PathId == cacheSecretPathId;
 }
 

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -41,6 +41,14 @@ public:
     };
 
 private:
+    struct TVersionedSecret {
+        ui64 SecretVersion = 0;
+        ui64 PathId = 0;
+        TString Name;
+        TString Value;
+    };
+
+private:
     STRICT_STFUNC(StateWait,
         hFunc(TEvResolveSecret, HandleIncomingRequest);
         hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleSchemeCacheResponse);
@@ -54,6 +62,8 @@ private:
     void FillResponse(const ui64 requestId, const TEvDescribeSecretsResponse::TDescription& response);
     void SaveIncomingRequestInfo(const TEvResolveSecret& req);
     void SendSchemeCacheRequest(const TString& secretName);
+    bool LocalCacheHasActualVersion(const TVersionedSecret& secret, const ui64& cacheSecretVersion);
+    bool LocalCacheHasActualObject(const TVersionedSecret& secret, const ui64& cacheSecretPathId);
 
 public:
     TDescribeSchemaSecretsService() = default;
@@ -61,13 +71,6 @@ public:
     void Bootstrap();
 
 private:
-    struct TVersionedSecret {
-        ui64 SecretVersion = 0;
-        ui64 PathId = 0;
-        TString Name;
-        TString Value;
-    };
-
     struct TResponseContext {
         TVersionedSecret Secret;
         NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> Result;

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -42,15 +42,15 @@ public:
 
 private:
     STRICT_STFUNC(StateWait,
-        hFunc(TEvResolveSecret, Handle);
-        hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
-        hFunc(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult, Handle);
+        hFunc(TEvResolveSecret, HandleIncomingRequest);
+        hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleSchemeCacheResponse);
+        hFunc(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult, HandleSchemeShardResponse);
         cFunc(NActors::TEvents::TEvPoison::EventType, PassAway);
     )
 
-    void Handle(TEvResolveSecret::TPtr& ev);
-    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
-    void Handle(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev);
+    void HandleIncomingRequest(TEvResolveSecret::TPtr& ev);
+    void HandleSchemeCacheResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
+    void HandleSchemeShardResponse(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev);
     void FillResponse(const ui64 requestId, const TEvDescribeSecretsResponse::TDescription& response);
     void SaveIncomingRequestInfo(const TEvResolveSecret& req);
     void SendSchemeCacheRequest(const TString& secretName);

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -62,14 +62,20 @@ public:
 
 private:
     struct TVersionedSecret {
-        ui64 Version;
+        ui64 SecretVersion = 0;
+        ui64 PathId = 0;
+        TString Name;
         TString Value;
     };
 
+    struct TResponseContext {
+        TVersionedSecret Secret;
+        NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> Result;
+    };
+
     ui64 LastCookie = 0;
-    THashMap<ui64, NThreading::TPromise<TEvDescribeSecretsResponse::TDescription>> ResolveInFlight;
-    THashMap<ui64, TString> SecretNameInFlight;
-    THashMap<TString, TVersionedSecret> SecretNameToValue;
+    THashMap<ui64, TResponseContext> ResolveInFlight;
+    THashMap<TString, TVersionedSecret> VersionedSecrets;
 };
 
 IActor* CreateDescribeSecretsActor(const TString& ownerUserId, const std::vector<TString>& secretIds, NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> promise);

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors_ut.cpp
@@ -110,6 +110,12 @@ Y_UNIT_TEST_SUITE(DescribeSchemaSecretsService) {
 
         promise = ResolveSecret("ownerId", "/Root/secret-name", kikimr);
         UNIT_ASSERT_VALUES_EQUAL(Ydb::StatusIds::BAD_REQUEST, promise.GetFuture().GetValueSync().Status);
+
+        secretValue += "-updated";
+        CreateSchemaSecret(secretName, secretValue, session);
+
+        promise = ResolveSecret("ownerId", "/Root/secret-name", kikimr);
+        UNIT_ASSERT_VALUES_EQUAL(secretValue, promise.GetFuture().GetValueSync().SecretValues[0]);
     }
 
     Y_UNIT_TEST(GetInParallel) {


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
The freshness of a secret is determined by the version of its schema object (it tracks value changes) and the version of its path (it tracks schema changes)