### PR TITLE
Change expected slot count without pdisk restart

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -764,6 +764,7 @@ struct TEvBlobStorage {
         EvReleaseSyncToken,
         EvBSQueueResetConnection, // for test purposes
         EvYardResize,                                           // 268 636 340
+        EvChangeExpectedSlotCount,
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,
@@ -820,6 +821,7 @@ struct TEvBlobStorage {
         EvYardResizeResult,
         EvCommitVDiskMetadata,
         EvCommitVDiskMetadataDone,
+        EvChangeExpectedSlotCountResult,
 
         // internal proxy interface
         EvUnusedLocal1 = EvPut + 10 * 512, // Not used.    /// 268 637 184

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -116,6 +116,7 @@ STATEFN(TNodeWarden::StateOnline) {
         hFunc(NPDisk::TEvSlayResult, Handle);
         hFunc(NPDisk::TEvShredPDiskResult, Handle);
         hFunc(NPDisk::TEvShredPDisk, Handle);
+        hFunc(NPDisk::TEvChangeExpectedSlotCountResult, Handle);
 
         hFunc(TEvRegisterPDiskLoadActor, Handle);
 
@@ -626,6 +627,16 @@ void TNodeWarden::Handle(NPDisk::TEvShredPDiskResult::TPtr ev) {
     ProcessShredStatus(ev->Cookie, ev->Get()->ShredGeneration, ev->Get()->Status == NKikimrProto::OK ? std::nullopt :
         std::make_optional(TStringBuilder() << "failed to shred PDisk Status# " << NKikimrProto::EReplyStatus_Name(
         ev->Get()->Status)));
+}
+
+void TNodeWarden::Handle(NPDisk::TEvChangeExpectedSlotCountResult::TPtr ev) {
+    const NPDisk::TEvChangeExpectedSlotCountResult &msg = *ev->Get();
+    STLOG(PRI_DEBUG, BS_NODE, NW108, "Handle(NPDisk::TEvChangeExpectedSlotCountResult)", (Msg, msg.ToString()));
+
+    // For now, just log the result. In the future, we might want to track this or take action based on the result.
+    if (msg.Status != NKikimrProto::OK) {
+        STLOG(PRI_ERROR, BS_NODE, NW109, "ChangeExpectedSlotCount failed", (Status, msg.Status), (ErrorReason, msg.ErrorReason));
+    }
 }
 
 void TNodeWarden::Handle(NPDisk::TEvShredPDisk::TPtr ev) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -592,6 +592,7 @@ namespace NKikimr::NStorage {
         void Handle(NPDisk::TEvSlayResult::TPtr ev);
         void Handle(NPDisk::TEvShredPDiskResult::TPtr ev);
         void Handle(NPDisk::TEvShredPDisk::TPtr ev);
+        void Handle(NPDisk::TEvChangeExpectedSlotCountResult::TPtr ev);
         void ProcessShredStatus(ui64 cookie, ui64 generation, std::optional<TString> error);
 
         void PersistConfig(std::optional<TString> mainYaml, ui64 mainYamlVersion, std::optional<TString> storageYaml,
@@ -608,6 +609,8 @@ namespace NKikimr::NStorage {
 
         void SendPDiskReport(ui32 pdiskId, NKikimrBlobStorage::TEvControllerNodeReport::EPDiskPhase phase,
                 std::variant<std::monostate, ui64, TString> shredState = {});
+
+        void SendChangeExpectedSlotCount(ui32 pdiskId, ui64 expectedSlotCount);
 
         void Handle(TEvBlobStorage::TEvControllerUpdateDiskStatus::TPtr ev);
         void Handle(TEvBlobStorage::TEvControllerGroupMetricsExchange::TPtr ev);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -610,8 +610,6 @@ namespace NKikimr::NStorage {
         void SendPDiskReport(ui32 pdiskId, NKikimrBlobStorage::TEvControllerNodeReport::EPDiskPhase phase,
                 std::variant<std::monostate, ui64, TString> shredState = {});
 
-        void SendChangeExpectedSlotCount(ui32 pdiskId, ui64 expectedSlotCount);
-
         void Handle(TEvBlobStorage::TEvControllerUpdateDiskStatus::TPtr ev);
         void Handle(TEvBlobStorage::TEvControllerGroupMetricsExchange::TPtr ev);
         void Handle(TEvPrivate::TEvSendDiskMetrics::TPtr&);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -1422,11 +1422,11 @@ struct TEvCheckSpace : TEventLocal<TEvCheckSpace, TEvBlobStorage::EvCheckSpace> 
 struct TEvCheckSpaceResult : TEventLocal<TEvCheckSpaceResult, TEvBlobStorage::EvCheckSpaceResult> {
     NKikimrProto::EReplyStatus Status;
     TStatusFlags StatusFlags;
-    ui32 FreeChunks;
-    ui32 TotalChunks; // contains common limit in shared free space mode, Total != Free + Used
-    ui32 UsedChunks; // number of chunks allocated by requesting owner
-    ui32 NumSlots; // number of VSlots over PDisk
-    ui32 NumActiveSlots; // $ \sum_i{ceil(VSlot[i].SlotSizeInUnits / PDisk.SlotSizeInUnits)} $
+    ui32 FreeChunks; // contains SharedQuota.Free
+    ui32 TotalChunks; // contains OwnerQuota.HardLimit(owner), Total != Free + Used
+    ui32 UsedChunks; // equals OwnerQuota.Used(owner) - a number of chunks allocated by requesting owner
+    ui32 NumSlots; // number of VDisks over PDisk, not their weight
+    ui32 NumActiveSlots; // sum of VDisks weights - $ \sum_i{ceil(VSlot[i].SlotSizeInUnits / PDisk.SlotSizeInUnits)} $
     double Occupancy = 0;
     TString ErrorReason;
     TStatusFlags LogStatusFlags;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -308,6 +308,50 @@ struct TEvYardResizeResult : TEventLocal<TEvYardResizeResult, TEvBlobStorage::Ev
     }
 };
 
+struct TEvChangeExpectedSlotCount : TEventLocal<TEvChangeExpectedSlotCount, TEvBlobStorage::EvChangeExpectedSlotCount> {
+    ui64 ExpectedSlotCount;
+
+    TEvChangeExpectedSlotCount(ui64 expectedSlotCount)
+        : ExpectedSlotCount(expectedSlotCount)
+    {}
+
+    TString ToString() const {
+        return ToString(*this);
+    }
+
+    static TString ToString(const TEvChangeExpectedSlotCount& record) {
+        TStringStream str;
+        str << "{";
+        str << "EvChangeExpectedSlotCount ";
+        str << " ExpectedSlotCount# " << record.ExpectedSlotCount;
+        str << "}";
+        return str.Str();
+    }
+};
+
+struct TEvChangeExpectedSlotCountResult : TEventLocal<TEvChangeExpectedSlotCountResult, TEvBlobStorage::EvChangeExpectedSlotCountResult> {
+    NKikimrProto::EReplyStatus Status;
+    TString ErrorReason;
+
+    TEvChangeExpectedSlotCountResult(NKikimrProto::EReplyStatus status, TString errorReason)
+        : Status(status)
+        , ErrorReason(std::move(errorReason))
+    {}
+
+    TString ToString() const {
+        return ToString(*this);
+    }
+
+    static TString ToString(const TEvChangeExpectedSlotCountResult& record) {
+        TStringStream str;
+        str << "{";
+        str << "EvChangeExpectedSlotCountResult Status#" << NKikimrProto::EReplyStatus_Name(record.Status).data();
+        str << " ErrorReason# \"" << record.ErrorReason << "\"";
+        str << "}";
+        return str.Str();
+    }
+};
+
 ////////////////////////////////////////////////////////////////////////////
 // LOG
 ////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -310,9 +310,11 @@ struct TEvYardResizeResult : TEventLocal<TEvYardResizeResult, TEvBlobStorage::Ev
 
 struct TEvChangeExpectedSlotCount : TEventLocal<TEvChangeExpectedSlotCount, TEvBlobStorage::EvChangeExpectedSlotCount> {
     ui64 ExpectedSlotCount;
+    ui32 SlotSizeInUnits;
 
-    TEvChangeExpectedSlotCount(ui64 expectedSlotCount)
+    TEvChangeExpectedSlotCount(ui64 expectedSlotCount, ui32 slotSizeInUnits)
         : ExpectedSlotCount(expectedSlotCount)
+        , SlotSizeInUnits(slotSizeInUnits)
     {}
 
     TString ToString() const {
@@ -324,6 +326,7 @@ struct TEvChangeExpectedSlotCount : TEventLocal<TEvChangeExpectedSlotCount, TEvB
         str << "{";
         str << "EvChangeExpectedSlotCount ";
         str << " ExpectedSlotCount# " << record.ExpectedSlotCount;
+        str << " SlotSizeInUnits# " << record.SlotSizeInUnits;
         str << "}";
         return str.Str();
     }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -704,6 +704,12 @@ public:
         PDisk->Mon.YardResize.CountResponse();
     }
 
+    void InitHandle(NPDisk::TEvChangeExpectedSlotCount::TPtr &ev) {
+        PDisk->Mon.ChangeExpectedSlotCount.CountRequest();
+        Send(ev->Sender, new NPDisk::TEvChangeExpectedSlotCountResult(NKikimrProto::CORRUPTED, StateErrorReason));
+        PDisk->Mon.ChangeExpectedSlotCount.CountResponse();
+    }
+
     void InitHandle(NPDisk::TEvShredPDisk::TPtr &ev) {
         const NPDisk::TEvShredPDisk &evShredPDisk = *ev->Get();
         InitQueue.emplace_back(ev->Sender, evShredPDisk.ShredGeneration, ev->Cookie);
@@ -846,6 +852,12 @@ public:
         PDisk->Mon.YardResize.CountRequest();
         Send(ev->Sender, new NPDisk::TEvYardResizeResult(NKikimrProto::CORRUPTED, {}, StateErrorReason));
         PDisk->Mon.YardResize.CountResponse();
+    }
+
+    void ErrorHandle(NPDisk::TEvChangeExpectedSlotCount::TPtr &ev) {
+        PDisk->Mon.ChangeExpectedSlotCount.CountRequest();
+        Send(ev->Sender, new NPDisk::TEvChangeExpectedSlotCountResult(NKikimrProto::CORRUPTED, StateErrorReason));
+        PDisk->Mon.ChangeExpectedSlotCount.CountResponse();
     }
 
     void ErrorHandle(NPDisk::TEvChunkReserve::TPtr &ev) {
@@ -991,6 +1003,12 @@ public:
     void Handle(NPDisk::TEvYardResize::TPtr &ev) {
         PDisk->Mon.YardResize.CountRequest();
         TYardResize* request = PDisk->ReqCreator.CreateFromEv<TYardResize>(*ev->Get(), ev->Sender);
+        PDisk->InputRequest(request);
+    }
+
+    void Handle(NPDisk::TEvChangeExpectedSlotCount::TPtr &ev) {
+        PDisk->Mon.YardResize.CountRequest();
+        TChangeExpectedSlotCount* request = PDisk->ReqCreator.CreateFromEv<TChangeExpectedSlotCount>(*ev->Get(), ev->Sender);
         PDisk->InputRequest(request);
     }
 
@@ -1499,6 +1517,7 @@ public:
             hFunc(NPDisk::TEvShredVDiskResult, InitHandle);
             hFunc(NPDisk::TEvContinueShred, InitHandle);
             hFunc(NPDisk::TEvYardResize, InitHandle);
+            hFunc(NPDisk::TEvChangeExpectedSlotCount, InitHandle);
 
             hFunc(TEvReadMetadata, Handle);
             hFunc(TEvWriteMetadata, Handle);
@@ -1532,6 +1551,7 @@ public:
             hFunc(NPDisk::TEvShredVDiskResult, Handle);
             hFunc(NPDisk::TEvContinueShred, Handle);
             hFunc(NPDisk::TEvYardResize, Handle);
+            hFunc(NPDisk::TEvChangeExpectedSlotCount, Handle);
 
             cFunc(NActors::TEvents::TSystem::PoisonPill, HandlePoison);
             hFunc(NMon::TEvHttpInfo, Handle);
@@ -1569,6 +1589,7 @@ public:
             hFunc(NPDisk::TEvShredVDiskResult, ErrorHandle);
             hFunc(NPDisk::TEvContinueShred, ErrorHandle);
             hFunc(NPDisk::TEvYardResize, ErrorHandle);
+            hFunc(NPDisk::TEvChangeExpectedSlotCount, ErrorHandle);
 
             cFunc(NActors::TEvents::TSystem::PoisonPill, HandlePoison);
             hFunc(NMon::TEvHttpInfo, Handle);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
@@ -606,6 +606,10 @@ public:
             }
         }
     }
+
+    void SetExpectedOwnerCount(size_t newOwnerCount) {
+        OwnerQuota->SetExpectedOwnerCount(newOwnerCount);
+    }
 };
 
 } // NPDisk

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -2107,7 +2107,10 @@ void TPDisk::YardResize(TYardResize &ev) {
 void TPDisk::ProcessChangeExpectedSlotCount(TChangeExpectedSlotCount& request) {
     TGuard<TMutex> guard(StateMutex);
     ExpectedSlotCount = request.ExpectedSlotCount;
+    Cfg->ExpectedSlotCount = request.ExpectedSlotCount;
+    Cfg->SlotSizeInUnits = request.SlotSizeInUnits;
     Keeper.SetExpectedOwnerCount(ExpectedSlotCount);
+    // TODO: recalculate the weight of all owners
 
     auto result = std::make_unique<NPDisk::TEvChangeExpectedSlotCountResult>(NKikimrProto::OK, TString());
     Mon.ChangeExpectedSlotCount.CountResponse();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -2110,7 +2110,11 @@ void TPDisk::ProcessChangeExpectedSlotCount(TChangeExpectedSlotCount& request) {
     Cfg->ExpectedSlotCount = request.ExpectedSlotCount;
     Cfg->SlotSizeInUnits = request.SlotSizeInUnits;
     Keeper.SetExpectedOwnerCount(ExpectedSlotCount);
-    // TODO: recalculate the weight of all owners
+    for (TOwner owner = OwnerBeginUser; owner < OwnerEndUser; ++owner) {
+        if (OwnerData[owner].VDiskId != TVDiskID::InvalidId) {
+            Keeper.SetOwnerWeight(owner, Cfg->GetOwnerWeight(OwnerData[owner].GroupSizeInUnits));
+        }
+    }
 
     auto result = std::make_unique<NPDisk::TEvChangeExpectedSlotCountResult>(NKikimrProto::OK, TString());
     Mon.ChangeExpectedSlotCount.CountResponse();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -367,6 +367,7 @@ public:
     void YardInitFinish(TYardInit &evYardInit);
     bool YardInitForKnownVDisk(TYardInit &evYardInit, TOwner owner);
     void YardResize(TYardResize &evYardResize);
+    void ProcessChangeExpectedSlotCount(TChangeExpectedSlotCount& request);
 
     // Scheduler weight configuration
     void ConfigureCbs(ui32 ownerId, EGate gate, ui64 weight);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
@@ -176,6 +176,10 @@ public:
         return ChunkTracker.ColorFlagLimit(owner, color);
     }
 
+    void SetExpectedOwnerCount(size_t newOwnerCount) {
+        ChunkTracker.SetExpectedOwnerCount(newOwnerCount);
+    }
+
     //
     // GUI
     //

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
@@ -231,6 +231,7 @@ TPDiskMon::TPDiskMon(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& count
     IO_REQ_INIT_IF_EXTENDED(PDiskGroup, YardSlay, YardSlay);
     IO_REQ_INIT_IF_EXTENDED(PDiskGroup, YardControl, YardControl);
     IO_REQ_INIT_IF_EXTENDED(PDiskGroup, YardResize, YardResize);
+    IO_REQ_INIT_IF_EXTENDED(PDiskGroup, ChangeExpectedSlotCount, ChangeExpectedSlotCount);
 
     IO_REQ_INIT_IF_EXTENDED(PDiskGroup, ShredPDisk, ShredPDisk);
     IO_REQ_INIT_IF_EXTENDED(PDiskGroup, PreShredCompactVDisk, PreShredCompactVDisk);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
@@ -474,6 +474,7 @@ struct TPDiskMon {
     TReqCounters YardSlay;
     TReqCounters YardControl;
     TReqCounters YardResize;
+    TReqCounters ChangeExpectedSlotCount;
 
     TReqCounters ShredPDisk;
     TReqCounters PreShredCompactVDisk;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_req_creator.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_req_creator.h
@@ -212,7 +212,7 @@ public:
 
     template<typename TReq, typename... TArgs>
     [[nodiscard]] TReq* CreateFromArgs(TArgs&&... args) {
-        P_LOG(PRI_DEBUG, BPD01, "CreateReaFromArgs",
+        P_LOG(PRI_DEBUG, BPD01, "CreateReqFromArgs",
             (Req, TypeName<TReq>()),
             (ReqId, AtomicGet(LastReqId)));
         auto req = MakeHolder<TReq>(std::forward<TArgs>(args)..., AtomicIncrement(LastReqId));

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_request_id.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_request_id.h
@@ -98,6 +98,7 @@ struct TReqId {
         ContinueShred = 79,
         MarkDirtySysLog = 80,
         YardResize = 81,
+        ChangeExpectedSlotCount = 82,
     };
 
     // 56 bit idx, 8 bit source
@@ -168,6 +169,7 @@ enum class ERequestType {
     RequestChunkShredResult,
     RequestContinueShred,
     RequestYardResize,
+    RequestChangeExpectedSlotCount,
 };
 
 inline IOutputStream& operator <<(IOutputStream& out, const TReqId& reqId) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
@@ -1270,5 +1270,25 @@ public:
     }
 };
 
+class TChangeExpectedSlotCount : public TRequestBase {
+public:
+    ui64 ExpectedSlotCount;
+
+    TChangeExpectedSlotCount(const NPDisk::TEvChangeExpectedSlotCount &ev, const TActorId &sender, TAtomicBase reqIdx)
+        : TRequestBase(sender, TReqId(TReqId::ChangeExpectedSlotCount, reqIdx), OwnerSystem, 0, NPriInternal::Other)
+        , ExpectedSlotCount(ev.ExpectedSlotCount)
+    {}
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestChangeExpectedSlotCount;
+    }
+
+    TString ToString() const {
+        TStringStream str;
+        str << "TChangeExpectedSlotCount { ExpectedSlotCount# " << ExpectedSlotCount << " }";
+        return str.Str();
+    }
+};
+
 } // NPDisk
 } // NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
@@ -1273,10 +1273,12 @@ public:
 class TChangeExpectedSlotCount : public TRequestBase {
 public:
     ui64 ExpectedSlotCount;
+    ui32 SlotSizeInUnits;
 
     TChangeExpectedSlotCount(const NPDisk::TEvChangeExpectedSlotCount &ev, const TActorId &sender, TAtomicBase reqIdx)
         : TRequestBase(sender, TReqId(TReqId::ChangeExpectedSlotCount, reqIdx), OwnerSystem, 0, NPriInternal::Other)
         , ExpectedSlotCount(ev.ExpectedSlotCount)
+        , SlotSizeInUnits(ev.SlotSizeInUnits)
     {}
 
     ERequestType GetType() const override {
@@ -1285,7 +1287,10 @@ public:
 
     TString ToString() const {
         TStringStream str;
-        str << "TChangeExpectedSlotCount { ExpectedSlotCount# " << ExpectedSlotCount << " }";
+        str << "TChangeExpectedSlotCount {"
+            << " ExpectedSlotCount# " << ExpectedSlotCount
+            << " SlotSizeInUnits# " << SlotSizeInUnits
+            << " }";
         return str.Str();
     }
 };

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -1229,105 +1229,176 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         AwaitAndCheckEvPDiskStateUpdate(testCtx, 2u, 4);
     }
 
-    Y_UNIT_TEST(PDiskChangeExpectedSlotCount) {
-        TActorTestContext testCtx({
-            .IsBad=false,
-            .DiskSize = 1_GB,
-            .ChunkSize = 1_MB,
-        });
+    THolder<NPDisk::TEvCheckSpaceResult> CheckEvCheckSpace(
+        TActorTestContext& testCtx,
+        const TVDiskMock& vdisk,
+        ui32 expectedFreeChunks,
+        ui32 expectedTotalChunks,
+        ui32 expectedUsedChunks,
+        ui32 expectedNumSlots,
+        ui32 expectedNumActiveSlots,
+        NKikimrBlobStorage::TPDiskSpaceColor::E expectedColor
+    ) {
+        Cerr << (TStringBuilder() << "... Checking EvCheckSpace"
+            << " VDisk# " << vdisk.VDiskID
+            << " FreeChunks# " << expectedFreeChunks
+            << " TotalChunks# " << expectedTotalChunks
+            << " UsedChunks# " << expectedUsedChunks
+            << " NumSlots# " << expectedNumSlots
+            << " NumActiveSlots# " << expectedNumActiveSlots
+            << " Color# " << NKikimrBlobStorage::TPDiskSpaceColor::E_Name(expectedColor)
+            << Endl);
+        auto evCheckSpaceResult = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
+            new NPDisk::TEvCheckSpace(vdisk.PDiskParams->Owner, vdisk.PDiskParams->OwnerRound),
+            NKikimrProto::OK);
+        Cerr << (TStringBuilder() << "Got " << evCheckSpaceResult->ToString() << Endl);
+        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResult->FreeChunks, expectedFreeChunks);
+        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResult->TotalChunks, expectedTotalChunks);
+        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResult->UsedChunks, expectedUsedChunks);
+        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResult->NumSlots, expectedNumSlots);
+        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResult->NumActiveSlots, expectedNumActiveSlots);
+        UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(evCheckSpaceResult->StatusFlags), expectedColor);
+        return evCheckSpaceResult;
+    };
+
+    Y_UNIT_TEST(ChangeExpectedSlotCount) {
+        TActorTestContext testCtx({});
+        const ui32 firstNodeId = testCtx.GetRuntime()->GetFirstNodeId();
+        auto pdiskConfig = testCtx.GetPDiskConfig();
+        using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
+        pdiskConfig->SpaceColorBorder = TColor::YELLOW;
+        testCtx.UpdateConfigRecreatePDisk(pdiskConfig);
+        // The actual value of SharedQuota.HardLimit internally initialized in TActorTestContext
+        // Feel free to update if some day it changes
+        const ui32 sharedQuota = 778;
 
         // Setup receiving whiteboard state updates
         testCtx.GetRuntime()->SetDispatchTimeout(10 * TDuration::MilliSeconds(testCtx.GetPDiskConfig()->StatisticsUpdateIntervalMs));
-        testCtx.GetRuntime()->RegisterService(NNodeWhiteboard::MakeNodeWhiteboardServiceId(1), testCtx.Sender);
-        AwaitAndCheckEvPDiskStateUpdate(testCtx, 0u, 0);
+        testCtx.GetRuntime()->RegisterService(NNodeWhiteboard::MakeNodeWhiteboardServiceId(firstNodeId), testCtx.Sender);
 
-        // Setup 2 vdisks
+        // State 1:
+        // PDisk.ExpectedSlotCount: 0
+        // Owners.GroupSizeInUnits: [0u, 2u]
+        // Owners.Weight: [1, 2]
+        Cerr << (TStringBuilder() << "- State 1" << Endl);
+
+        TVDiskMock vdisk0(&testCtx);
+        vdisk0.InitFull(1u);
+        CheckEvCheckSpace(testCtx, vdisk0, sharedQuota, sharedQuota, 0, 1, 1, TColor::GREEN);
+
         TVDiskMock vdisk1(&testCtx);
-        TVDiskMock vdisk2(&testCtx);
+        vdisk1.InitFull(2u);
+        CheckEvCheckSpace(testCtx, vdisk0, sharedQuota, sharedQuota/3*1, 0, 2, 3, TColor::GREEN);
+        CheckEvCheckSpace(testCtx, vdisk1, sharedQuota, sharedQuota/3*2, 0, 2, 3, TColor::GREEN);
 
-        vdisk1.InitFull(0u);
-        vdisk2.InitFull(4u);
+        // State 2:
+        // PDisk.ExpectedSlotCount: 4
+        Cerr << (TStringBuilder() << "- State 2" << Endl);
 
-        vdisk1.ReserveChunk();
-        vdisk2.ReserveChunk();
-
-        vdisk1.CommitReservedChunks();
-        vdisk2.CommitReservedChunks();
-
-        // State:
-        // PDisk.SlotSizeUnits: 0
-        // Owners.GroupSizeInUnits: [0, 4]
-
-        // Assert NumActiveSlots == 5
-        const auto evCheckSpaceResponse1 = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
-            new NPDisk::TEvCheckSpace(vdisk1.PDiskParams->Owner, vdisk1.PDiskParams->OwnerRound),
-            NKikimrProto::OK);
-        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResponse1->NumActiveSlots, 5);
-        AwaitAndCheckEvPDiskStateUpdate(testCtx, 0u, 5);
-
-        // Set ExpectedSlotCount to 3
         testCtx.TestResponse<NPDisk::TEvChangeExpectedSlotCountResult>(
-            new NPDisk::TEvChangeExpectedSlotCount(3),
+            new NPDisk::TEvChangeExpectedSlotCount(4, 0u),
             NKikimrProto::OK);
-
-        // Check that NumActiveSlots is updated to match ExpectedSlotCount
-        const auto evCheckSpaceResponse2 = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
-            new NPDisk::TEvCheckSpace(vdisk1.PDiskParams->Owner, vdisk1.PDiskParams->OwnerRound),
-            NKikimrProto::OK);
-        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResponse2->NumActiveSlots, 3);
         AwaitAndCheckEvPDiskStateUpdate(testCtx, 0u, 3);
 
-        // Set ExpectedSlotCount to 0 (should be ignored and use actual number of slots)
+        ui32 fairQuota = sharedQuota / 4;
+        CheckEvCheckSpace(testCtx, vdisk0, sharedQuota, fairQuota, 0, 2, 3, TColor::GREEN);
+        CheckEvCheckSpace(testCtx, vdisk1, sharedQuota, fairQuota*2, 0, 2, 3, TColor::GREEN);
+
+        // State 3:
+        // vdisk0 consumes all it's fair quota (1/4 pdisk)
+        Cerr << (TStringBuilder() << "- State 3" << Endl);
+
+        ui32 vdisk0Used = fairQuota;
+        ui32 sharedFree = sharedQuota - vdisk0Used;
+        for (ui32 i = 0; i < vdisk0Used; ++i) {
+            vdisk0.ReserveChunk();
+        }
+        vdisk0.CommitReservedChunks();
+
+        CheckEvCheckSpace(testCtx, vdisk0, sharedFree, fairQuota, vdisk0Used, 2, 3, TColor::YELLOW);
+        CheckEvCheckSpace(testCtx, vdisk1, sharedFree, fairQuota*2, 0, 2, 3, TColor::GREEN);
+
+        // State 4:
+        // PDisk.ExpectedSlotCount: 2
+        // PDisk.SlotSizeInUnits: 2u
+        // Owners.GroupSizeInUnits: [0u, 2u]
+        // Owners.Weight: [1, 1]
+        Cerr << (TStringBuilder() << "- State 4" << Endl);
+
         testCtx.TestResponse<NPDisk::TEvChangeExpectedSlotCountResult>(
-            new NPDisk::TEvChangeExpectedSlotCount(0),
+            new NPDisk::TEvChangeExpectedSlotCount(2, 2u),
             NKikimrProto::OK);
+        AwaitAndCheckEvPDiskStateUpdate(testCtx, 2u, 2);
 
-        // Check that NumActiveSlots is updated to match actual number of slots
-        const auto evCheckSpaceResponse3 = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
-            new NPDisk::TEvCheckSpace(vdisk1.PDiskParams->Owner, vdisk1.PDiskParams->OwnerRound),
-            NKikimrProto::OK);
-        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResponse3->NumActiveSlots, 5);
-        AwaitAndCheckEvPDiskStateUpdate(testCtx, 0u, 5);
+        fairQuota = sharedQuota / 2;
+        UNIT_ASSERT_VALUES_EQUAL(vdisk0Used, fairQuota/2);
+        CheckEvCheckSpace(testCtx, vdisk0, sharedFree, fairQuota, vdisk0Used, 2, 2, TColor::GREEN);
+        CheckEvCheckSpace(testCtx, vdisk1, sharedFree, fairQuota, 0, 2, 2, TColor::GREEN);
 
-        // Graceful restart with same config
-        testCtx.GracefulPDiskRestart();
-        vdisk1.InitFull(0u);
-        vdisk1.SendEvLogSync();
+        // State 5:
+        // Owners.GroupSizeInUnits: [0u, 2u, 4u]
+        // Owners.GroupSizeInUnits: [1, 1, 2]
+        Cerr << (TStringBuilder() << "- State 5" << Endl);
+
+        TVDiskMock vdisk2(&testCtx);
         vdisk2.InitFull(4u);
-        vdisk2.SendEvLogSync();
 
-        // Set ExpectedSlotCount to 10
+        fairQuota = sharedQuota / 4;
+        UNIT_ASSERT_VALUES_EQUAL(vdisk0Used, fairQuota);
+        CheckEvCheckSpace(testCtx, vdisk0, sharedFree, fairQuota, vdisk0Used, 3, 4, TColor::YELLOW);
+        CheckEvCheckSpace(testCtx, vdisk1, sharedFree, fairQuota, 0, 3, 4, TColor::GREEN);
+        CheckEvCheckSpace(testCtx, vdisk2, sharedFree, fairQuota*2, 0, 3, 4, TColor::GREEN);
+
+        // State 6:
+        // Owners.GroupSizeInUnits: [0u, 2u, 1u]
+        // Owners.GroupSizeInUnits: [1, 1, 1]
+        Cerr << (TStringBuilder() << "- State 6" << Endl);
+
+        testCtx.TestResponse<NPDisk::TEvYardResizeResult>(
+            new NPDisk::TEvYardResize(vdisk2.PDiskParams->Owner, vdisk2.PDiskParams->OwnerRound, 1u),
+            NKikimrProto::OK);
+        AwaitAndCheckEvPDiskStateUpdate(testCtx, 2u, 3);
+
+        fairQuota = sharedQuota / 3;
+        CheckEvCheckSpace(testCtx, vdisk0, sharedFree, fairQuota, vdisk0Used, 3, 3, TColor::GREEN);
+        CheckEvCheckSpace(testCtx, vdisk1, sharedFree, fairQuota, 0, 3, 3, TColor::GREEN);
+        CheckEvCheckSpace(testCtx, vdisk2, sharedFree, fairQuota, 0, 3, 3, TColor::GREEN);
+
+        // State 7:
+        // PDisk.ExpectedSlotCount: 8
+        // PDisk.SlotSizeInUnits: 1u
+        // Owners.GroupSizeInUnits: [0u, 2u, 1u]
+        // Owners.Weight: [1, 2, 1]
+        Cerr << (TStringBuilder() << "- State 7" << Endl);
+
         testCtx.TestResponse<NPDisk::TEvChangeExpectedSlotCountResult>(
-            new NPDisk::TEvChangeExpectedSlotCount(10),
+            new NPDisk::TEvChangeExpectedSlotCount(8, 1u),
             NKikimrProto::OK);
+        AwaitAndCheckEvPDiskStateUpdate(testCtx, 1u, 4);
 
-        // Check that NumActiveSlots is still 5 (actual number of slots)
-        const auto evCheckSpaceResponse4 = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
-            new NPDisk::TEvCheckSpace(vdisk1.PDiskParams->Owner, vdisk1.PDiskParams->OwnerRound),
-            NKikimrProto::OK);
-        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResponse4->NumActiveSlots, 5);
-        AwaitAndCheckEvPDiskStateUpdate(testCtx, 0u, 5);
+        fairQuota = sharedQuota / 8;
+        UNIT_ASSERT_VALUES_EQUAL(vdisk0Used, fairQuota*2);
+        CheckEvCheckSpace(testCtx, vdisk0, sharedFree, fairQuota, vdisk0Used, 3, 4, TColor::YELLOW);
+        CheckEvCheckSpace(testCtx, vdisk1, sharedFree, fairQuota*2, 0, 3, 4, TColor::GREEN);
+        CheckEvCheckSpace(testCtx, vdisk2, sharedFree, fairQuota, 0, 3, 4, TColor::GREEN);
 
-        // Graceful restart with ExpectedSlotCount in config
-        auto cfg = testCtx.GetPDiskConfig();
-        cfg->ExpectedSlotCount = 8;
-        testCtx.UpdateConfigRecreatePDisk(cfg);
-        vdisk1.InitFull(0u);
-        vdisk1.SendEvLogSync();
-        vdisk2.InitFull(4u);
-        vdisk2.SendEvLogSync();
+        // State 8:
+        // vdisk1 makes the whole PDisk Red
+        Cerr << (TStringBuilder() << "- State 8" << Endl);
 
-        // Update ExpectedSlotCount again
-        testCtx.TestResponse<NPDisk::TEvChangeExpectedSlotCountResult>(
-            new NPDisk::TEvChangeExpectedSlotCount(6),
-            NKikimrProto::OK);
+        ui32 vdisk1Used = sharedFree - 3;
+        sharedFree = 3;
+        for (ui32 i = 0; i < vdisk1Used; ++i) {
+            vdisk1.ReserveChunk();
+        }
+        vdisk1.CommitReservedChunks();
 
-        // Check that NumActiveSlots is still 5 (actual number of slots)
-        const auto evCheckSpaceResponse5 = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
-            new NPDisk::TEvCheckSpace(vdisk1.PDiskParams->Owner, vdisk1.PDiskParams->OwnerRound),
-            NKikimrProto::OK);
-        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResponse5->NumActiveSlots, 5);
-        AwaitAndCheckEvPDiskStateUpdate(testCtx, 0u, 5);
+        UNIT_ASSERT_VALUES_EQUAL(vdisk0Used, fairQuota*2);
+        UNIT_ASSERT_VALUES_EQUAL(vdisk1Used, fairQuota*6-1);
+        UNIT_ASSERT_VALUES_EQUAL(vdisk0Used + vdisk1Used, sharedQuota - sharedFree);
+        CheckEvCheckSpace(testCtx, vdisk0, sharedFree, fairQuota, vdisk0Used, 3, 4, TColor::RED);
+        CheckEvCheckSpace(testCtx, vdisk1, sharedFree, fairQuota*2, vdisk1Used, 3, 4, TColor::RED);
+        CheckEvCheckSpace(testCtx, vdisk2, sharedFree, fairQuota, 0, 3, 4, TColor::RED);
     }
 
     Y_UNIT_TEST(TestChunkWriteCrossOwner) {

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -81,8 +81,11 @@ namespace NKikimr::NBsController {
             }
 
             void ApplyPDiskDiff(const TPDiskId &pdiskId, const TPDiskInfo &prev, const TPDiskInfo &cur) {
-                if (prev.Mood != cur.Mood) {
-                    // PDisk's mood has changed
+                if (prev.Mood != cur.Mood ||
+                        prev.ExpectedSlotCount != cur.ExpectedSlotCount ||
+                        prev.SlotSizeInUnits != cur.SlotSizeInUnits ||
+                        prev.InferPDiskSlotCountFromUnitSize != cur.InferPDiskSlotCountFromUnitSize ||
+                        prev.InferPDiskSlotCountMax != cur.InferPDiskSlotCountMax) {
                     CreatePDiskEntry(pdiskId, cur);
                 }
             }


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Close #21011

This PR introduces the new branch in the `DefineHostConfig` execution flow:

- When BSController handles `DefineHostConfig` command, it updates the host configuration in its state. After processing, the transaction is committed via `CommitConfigUpdates` which calls `TNodeWardenUpdateNotifier::Execute`

- The notifier checks if either of the next values (all user-defined) changes, and sends `TEvControllerNodeServiceSetUpdate` to the NodeWarden
    - ExpectedSlotCount
    - SlotSizeInUnits
    - InferPDiskSlotCountFromUnitSize
    - InferPDiskSlotCountMax

- NodeWarden handles it by calling `ApplyServiceSetPDisks` and `processDisk` lambda, which calculates new inferred values, and forwards `TEvChangeExpectedSlotCount` to the PDiskActor. It also immediately updates the NodeWarden state PDiskConfig (tested manually on dev cluster)

- New event `TEvChangeExpectedSlotCount` is sent from NodeWarden to the PDiskActor and contains `ExpectedSlotCount` and `SlotSizeInUnits`, either user-defined or inferred (tested in TPDiskTest::ChangeExpectedSlotCount)

- PDiskActor handles the event:
    - in Init and Error states it immediately replies with `Status# CORRUPTED` (tested in TPDiskTest::TestPDiskActorErrorState)
    - in Online state it forwards the request to the `TPDisk`

- TPDisk updates the following state and replies to the NodeWarden with `Status# OK`. The request is truly read-only, nothing of this is persisted (tested in ReadOnlyPDisk::ReadOnlyPDiskEvents)
    - ExpectedSlotCount
    - Cfg
    - Keeper.SetExpectedOwnerCount
    - Keeper.SetOwnerWeights

- NodeWarden handles the result by simply logging it

Other minor changes:

- Update comments about `TEvCheckSpaceResult` fields meaning

