### PR TITLE
Added a muted test that causes a crash in ColumnShard

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -66,7 +66,6 @@ ydb/core/kqp/ut/service KqpService.TwoNodeOneShuttingDown
 ydb/core/kqp/ut/service unittest.[*/*] chunk
 ydb/core/kqp/ut/yql KqpScripting.StreamExecuteYqlScriptScanClientTimeoutBruteForce
 ydb/core/kqp/ut/yql KqpScripting.StreamExecuteYqlScriptScanOperationTmeoutBruteForce
-ydb/core/kqp/ut/tx KqpRollback.DoubleUpdate
 ydb/core/kqp/workload_service/ut DefaultPoolSettings.TestResourcePoolsSysViewFilters
 ydb/core/kqp/workload_service/ut KqpWorkloadServiceDistributed.TestDistributedLargeConcurrentQueryLimit
 ydb/core/mind/hive/ut THiveTest.TestCreateSubHiveCreateManyTablets

--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -66,6 +66,7 @@ ydb/core/kqp/ut/service KqpService.TwoNodeOneShuttingDown
 ydb/core/kqp/ut/service unittest.[*/*] chunk
 ydb/core/kqp/ut/yql KqpScripting.StreamExecuteYqlScriptScanClientTimeoutBruteForce
 ydb/core/kqp/ut/yql KqpScripting.StreamExecuteYqlScriptScanOperationTmeoutBruteForce
+ydb/core/kqp/ut/tx KqpRollback.DoubleUpdate
 ydb/core/kqp/workload_service/ut DefaultPoolSettings.TestResourcePoolsSysViewFilters
 ydb/core/kqp/workload_service/ut KqpWorkloadServiceDistributed.TestDistributedLargeConcurrentQueryLimit
 ydb/core/mind/hive/ut THiveTest.TestCreateSubHiveCreateManyTablets

--- a/ydb/core/formats/arrow/rows/view.cpp
+++ b/ydb/core/formats/arrow/rows/view.cpp
@@ -38,7 +38,7 @@ std::partial_ordering TSimpleRow::ComparePartNotNull(const TSimpleRow& item, con
 }
 
 std::partial_ordering TSimpleRow::CompareNotNull(const TSimpleRow& item) const {
-    AFL_VERIFY_DEBUG(Schema->Equals(*item.Schema));
+    AFL_VERIFY_DEBUG(Schema->Equals(*item.Schema))("rowSchema", Schema->ToString(true))("itemSchema", item.Schema->ToString(true));
     AFL_VERIFY(GetColumnsCount() <= item.GetColumnsCount());
     return TSimpleRowViewV0(Data).Compare(TSimpleRowViewV0(item.Data), Schema).GetResult();
 }

--- a/ydb/core/kqp/ut/tx/kqp_rollback.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_rollback.cpp
@@ -9,6 +9,10 @@ using namespace NYdb::NTable;
 Y_UNIT_TEST_SUITE(KqpRollback) {
     Y_UNIT_TEST(DoubleUpdate) {
 
+        // TODO fix crash
+        // https://github.com/ydb-platform/ydb/issues/25336
+        return;
+
         // Given
         TKikimrSettings sts;
         sts.SetWithSampleTables(false);

--- a/ydb/core/kqp/ut/tx/kqp_rollback.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_rollback.cpp
@@ -1,0 +1,75 @@
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+
+namespace NKikimr {
+namespace NKqp {
+
+using namespace NYdb;
+using namespace NYdb::NTable;
+
+Y_UNIT_TEST_SUITE(KqpRollback) {
+    Y_UNIT_TEST(DoubleUpdate) {
+
+        // Given
+        TKikimrSettings sts;
+        sts.SetWithSampleTables(false);
+        sts.SetColumnShardReaderClassName("SIMPLE");
+        sts.AppConfig.MutableTableServiceConfig()->SetAllowOlapDataQuery(true);        
+        TKikimrRunner kikimr(sts);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/KVR` (
+                id Uint64 NOT NULL,
+                vn Int32,
+                vs String,
+                PRIMARY KEY (id)
+            )
+            WITH (
+                STORE = COLUMN
+            );
+        )").GetValueSync());
+
+
+        auto rowsBuilder = NYdb::TValueBuilder();
+        rowsBuilder.BeginList();
+        for (ui32 i = 0; i < 100; ++i) {
+            rowsBuilder.AddListItem()
+                .BeginStruct()
+                .AddMember("id")
+                    .Uint64(i)
+                .AddMember("vn")
+                    .Int32(i)
+                .AddMember("vs")
+                    .String(TString(3, '0' + i % 10))
+                .EndStruct();
+        }
+        rowsBuilder.EndList();
+
+        auto buRes = db.BulkUpsert("/Root/KVR", rowsBuilder.Build()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(buRes.GetStatus(), NYdb::EStatus::SUCCESS, buRes.GetIssues().ToString());
+
+        // When 0
+        auto result = session.ExecuteDataQuery(Q_(R"(
+            UPDATE `/Root/KVR` SET vs = 'whatever' WHERE id = 2u;
+        )"), TTxControl::BeginTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        auto tx1 = result.GetTransaction();
+        auto rollbackResult = tx1->Rollback().GetValueSync();
+        // Then 0
+        UNIT_ASSERT_VALUES_EQUAL_C(rollbackResult.GetStatus(), EStatus::SUCCESS, rollbackResult.GetIssues().ToString());
+
+        // When 1
+        result = session.ExecuteDataQuery(Q_(R"(
+            UPDATE `/Root/KVR` SET vs = 'xyz';
+        )"), TTxControl::BeginTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        auto tx2 = result.GetTransaction();
+        rollbackResult = tx2->Rollback().GetValueSync();
+        // Then 1
+        UNIT_ASSERT_VALUES_EQUAL_C(rollbackResult.GetStatus(), EStatus::SUCCESS, rollbackResult.GetIssues().ToString());
+    }
+}
+
+} // namespace NKqp
+} // namespace NKikimr

--- a/ydb/core/kqp/ut/tx/ya.make
+++ b/ydb/core/kqp/ut/tx/ya.make
@@ -19,6 +19,7 @@ SRCS(
     kqp_sink_tx_ut.cpp
     kqp_snapshot_isolation_ut.cpp
     kqp_tx_ut.cpp
+    kqp_rollback.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry

C++ version of test https://github.com/ydb-platform/ydb/pull/25078/files#r2358892394 to reproduce the crash from
https://github.com/ydb-platform/ydb/issues/25336


### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Creating a table with 3 columns  (not reproduced with 2 column tables)
Performing two updates with rollbacks after each
Crash on second rollback
