### PR TITLE
Fix setting InferPDiskSlotCountMax value in BSC (merge from main #25680)

### DIFF
--- a/ydb/core/mind/bscontroller/cmds_host_config.cpp
+++ b/ydb/core/mind/bscontroller/cmds_host_config.cpp
@@ -24,6 +24,7 @@ namespace NKikimr::NBsController {
             driveInfo.ReadCentric = drive.GetReadCentric();
             driveInfo.Kind = drive.GetKind();
             driveInfo.InferPDiskSlotCountFromUnitSize = drive.GetInferPDiskSlotCountFromUnitSize();
+            driveInfo.InferPDiskSlotCountMax = drive.GetInferPDiskSlotCountMax();
 
             if (drive.HasPDiskConfig()) {
                 TString config;
@@ -48,6 +49,7 @@ namespace NKikimr::NBsController {
             driveInfo.ReadCentric = false;
             driveInfo.Kind = 0;
             driveInfo.InferPDiskSlotCountFromUnitSize = 0;
+            driveInfo.InferPDiskSlotCountMax = 0;
             driveInfo.PDiskConfig = defaultPDiskConfig;
 
             for (const auto& path : field) {

--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -609,6 +609,7 @@ namespace NKikimr::NBsController {
                 x->SetExpectedSlotCount(pdisk.ExpectedSlotCount);
                 x->SetDecommitStatus(NKikimrBlobStorage::EDecommitStatus::DECOMMIT_NONE);
                 x->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
+                x->SetInferPDiskSlotCountMax(pdisk.InferPDiskSlotCountMax);
                 if (pdisk.PDiskMetrics) {
                     x->MutablePDiskMetrics()->CopyFrom(*pdisk.PDiskMetrics);
                     x->MutablePDiskMetrics()->ClearPDiskId();

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -116,6 +116,7 @@ namespace NKikimr::NBsController {
                 pdisk->SetExpectedSerial(pdiskInfo.ExpectedSerial);
                 pdisk->SetManagementStage(Self->SerialManagementStage);
                 pdisk->SetInferPDiskSlotCountFromUnitSize(pdiskInfo.InferPDiskSlotCountFromUnitSize);
+                pdisk->SetInferPDiskSlotCountMax(pdiskInfo.InferPDiskSlotCountMax);
                 if (pdiskInfo.PDiskConfig && !pdisk->MutablePDiskConfig()->ParseFromString(pdiskInfo.PDiskConfig)) {
                     // TODO(alexvru): report this somehow
                 }
@@ -973,6 +974,7 @@ namespace NKikimr::NBsController {
                 drive.SetReadCentric(value.ReadCentric);
                 drive.SetKind(value.Kind);
                 drive.SetInferPDiskSlotCountFromUnitSize(value.InferPDiskSlotCountFromUnitSize);
+                drive.SetInferPDiskSlotCountMax(value.InferPDiskSlotCountMax);
 
                 if (const auto& config = value.PDiskConfig) {
                     NKikimrBlobStorage::TPDiskConfig& pb = *drive.MutablePDiskConfig();
@@ -1113,6 +1115,9 @@ namespace NKikimr::NBsController {
             pb->SetMaintenanceStatus(pdisk.MaintenanceStatus);
             if (pdisk.InferPDiskSlotCountFromUnitSize) {
                 pb->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
+            }
+            if (pdisk.InferPDiskSlotCountMax) {
+                pb->SetInferPDiskSlotCountMax(pdisk.InferPDiskSlotCountMax);
             }
         }
 

--- a/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
@@ -191,6 +191,7 @@ namespace NKikimr {
                         disk.Serial = serial;
                         disk.SharedWithOs = driveInfo.SharedWithOs;
                         disk.InferPDiskSlotCountFromUnitSize = driveInfo.InferPDiskSlotCountFromUnitSize;
+                        disk.InferPDiskSlotCountMax = driveInfo.InferPDiskSlotCountMax;
 
                         auto diskId = disk.GetId();
                         auto [_, inserted] = disks.try_emplace(diskId, std::move(disk));

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -490,6 +490,9 @@ void TBlobStorageController::ReadPDisk(const TPDiskId& pdiskId, const TPDiskInfo
         if (pdisk.InferPDiskSlotCountFromUnitSize) {
             pDisk->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
         }
+        if (pdisk.InferPDiskSlotCountMax) {
+            pDisk->SetInferPDiskSlotCountMax(pdisk.InferPDiskSlotCountMax);
+        }
     }
     pDisk->SetExpectedSerial(pdisk.ExpectedSerial);
     pDisk->SetManagementStage(SerialManagementStage);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix setting InferPDiskSlotCountMax value in BSC

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes msan failure and provides correct setting value throughout the system.

The bug was introduced in https://github.com/ydb-platform/ydb/pull/24627 
