### PR TITLE
Fix and unmute PDisk tests [stable-25-3-1]

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -1,7 +1,5 @@
 ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestDoesNotContainAHugeBlob
 ydb/core/blobstorage/pdisk/ut TPDiskTest.AllRequestsAreAnsweredOnPDiskRestart
-ydb/core/blobstorage/pdisk/ut TPDiskTest.FailedToFormatDiskInfoUpdate
-ydb/core/blobstorage/pdisk/ut TPDiskTest.PDiskSlotSizeInUnits
 ydb/core/blobstorage/pdisk/ut TPDiskTest.TestStartEncryptedOrPlainAndRestart
 ydb/core/blobstorage/ut_blobstorage BlobPatching.PatchBlock42
 ydb/core/blobstorage/ut_blobstorage Defragmentation.CorruptedReadHandling


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Close #22107
- Close #20203
- Part of #25317

Тесты предполагали, что TActorTestContext использует `NodeId# 1`, но в CI это не выполняется:

```
2025-09-23T15:50:09.821998Z node 34 :BS_PDISK NOTICE: {BPD38@blobstorage_pdisk_impl.cpp:2835}  OnDriveStartup  Path# "" PDiskId# 1
```

Внимание на `node 34`. Я правда не смог найти откуда берется 34 и как вообще из окружения на это можно влиять, если кто-то знает - просветите меня

- Cherry-picked from https://github.com/ydb-platform/ydb/pull/25696