### PR TITLE
Require admin privileges to start Scheme Board restore

### DIFF
--- a/ydb/core/tx/scheme_board/monitoring.cpp
+++ b/ydb/core/tx/scheme_board/monitoring.cpp
@@ -3,6 +3,7 @@
 #include "monitoring.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/auth.h>
 #include <ydb/core/scheme/scheme_pathid.h>
 #include <ydb/core/base/statestorage_impl.h>
 #include <ydb/core/base/tabletid.h>
@@ -1777,6 +1778,11 @@ class TMonitoring: public TActorBootstrapped<TMonitoring> {
 
         case ERequestType::Restore:
             if (params.Has("startRestore")) {
+                if (!ev->Get()->UserToken || !IsAdministrator(AppData(TlsActivationContext->AsActorContext()), ev->Get()->UserToken)) {
+                    return (void)Send(ev->Sender, new NMon::TEvHttpInfoRes(
+                        RenderRestore(false, "Unauthorized")
+                    ));
+                }
                 if (RestoreProgress.IsRunning()) {
                     return (void)Send(ev->Sender, new NMon::TEvHttpInfoRes(
                         RenderRestore(false, "Restore is already running")

--- a/ydb/core/tx/scheme_board/monitoring.cpp
+++ b/ydb/core/tx/scheme_board/monitoring.cpp
@@ -1778,7 +1778,7 @@ class TMonitoring: public TActorBootstrapped<TMonitoring> {
 
         case ERequestType::Restore:
             if (params.Has("startRestore")) {
-                if (!ev->Get()->UserToken || !IsAdministrator(AppData(TlsActivationContext->AsActorContext()), ev->Get()->UserToken)) {
+                if (!ev->Get()->UserToken || !IsAdministrator(AppData(), ev->Get()->UserToken)) {
                     return (void)Send(ev->Sender, new NMon::TEvHttpInfoRes(
                         RenderRestore(false, "Unauthorized")
                     ));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Issues:
- https://github.com/ydb-platform/ydb/issues/25729

"Admin privileges" = the user token is in administration allowed SIDs.

Test config:

```yaml
domains_config:
  security_config:
    default_users:
    - name: "root"
      password: "1234"
    - name: "daniil"
      password: "VeryLongPassword"
    - name: "ivan"
      password: "TheTerrible"
    default_user_sids:
    - "root"
    - "daniil"
    - "ivan"
    enforce_user_token_requirement: true
    monitoring_allowed_sids:
    - "root"
    - "daniil"
    - "ivan"
    - "ADMINS"
    - "DATABASE-ADMINS"
    administration_allowed_sids:
    - "root"
    - "daniil"
    - "ADMINS"
    - "DATABASE-ADMINS"
    viewer_allowed_sids:
    - "root"
    - "daniil"
    - "ivan"
    - "ADMINS"
    - "DATABASE-ADMINS"
    - "USERS"
```

User "ivan" (text in $${\color{red}red}$$ is a note written by me over the screenshot; not present in the actual web-page):

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/90ae491c-63a5-47f3-aea4-57edba0ba75d" />

User "daniil":

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/7fc85abe-fc7a-4e5f-bf19-f406a03fe0db" />

No user (log out with web UI), the "Restore" web page remained open from the previous use:

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/504d260b-02c7-4e01-8726-678b717e3120" />
