### PR TITLE
Fix inherit_permissions flag at secret creation

### DIFF
--- a/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
@@ -31,6 +31,50 @@ namespace {
         opts.SetReturnSecretValue(true);
         return DescribePath(runtime, path, opts);
     }
+
+    void AssertHasAccess(
+        const int directoryId,
+        const ui32 inheritance,
+        const bool expectedHasAccess,
+        TTestBasicRuntime& runtime,
+        ui64& txId,
+        TTestEnv& env
+    ) {
+        /** This test
+          * - creates a new directory "/MyRoot/dir" + ToString(directoryId)
+          * - provide to the user some grants to this directory
+          * - creates a secret in the new directory with InheritPermissions=True
+          * - check grants for the secret
+          */
+        const TString user = "some-user";
+        const auto userToken = NACLib::TUserToken(NACLib::TUserToken::TUserTokenInitFields{.UserSID = user});
+        const TString& workingDir = "/MyRoot";
+
+        // create container dir
+        NACLib::TDiffACL diffACL;
+        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::DescribeSchema, user, inheritance);
+        AsyncModifyACL(runtime, ++txId, workingDir, "dir" + ToString(directoryId), diffACL.SerializeAsString(), /* newOwner */ "");
+        env.TestWaitNotification(runtime, txId);
+
+        // create secret
+        const TString workingDirPath = workingDir + "/dir" + ToString(directoryId);
+        const TString secretName = "secret-name";
+        TestCreateSecret(runtime, ++txId, workingDirPath,
+            Sprintf(R"(
+                Name: "%s"
+                Value: "test-value"
+                InheritPermissions: false
+            )", secretName.data())
+        );
+        env.TestWaitNotification(runtime, txId);
+        const TString secretPath = workingDirPath + "/" + secretName;
+        TestLs(runtime, secretPath, false, NLs::PathExist);
+
+        // assert access
+        const auto describeResult = DescribePath(runtime, secretPath).GetPathDescription().GetSelf();
+        const TSecurityObject secObj(describeResult.GetOwner(), describeResult.GetEffectiveACL(), false);
+        UNIT_ASSERT_VALUES_EQUAL(expectedHasAccess, secObj.CheckAccess(NACLib::DescribeSchema, userToken));
+    }
 }
 
 Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
@@ -286,6 +330,41 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
         const auto user2Token = NACLib::TUserToken(NACLib::TUserToken::TUserTokenInitFields{.UserSID = "user2"});
         UNIT_ASSERT_C(secObj.CheckAccess(NACLib::DescribeSchema, user1Token), "user1 should have grant (inherited from dir)");
         UNIT_ASSERT_C(!secObj.CheckAccess(NACLib::DescribeSchema, user2Token), "user2 should have no grant (inherited from subdir)");
+    }
+
+    Y_UNIT_TEST(InheritPermissionsWithDifferentInheritanceTypes) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        for (int i = 1; i <= 6; ++i) {
+            AsyncMkDir(runtime, ++txId, "/MyRoot", "dir" + ToString(i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // If a user has the DescribeSchema grant on a directory with the default inheritance type,
+        // then they will have the DescribeSchema grant on the nested secret
+        AssertHasAccess(1, NACLib::EInheritanceType::DefaultInheritanceType, /* expectedHasAccess */ true, runtime, txId, env);
+
+        // If a user has the DescribeSchema grant on a directory with inheritance type equals to InheritNone,
+        // then they will NOT have the DescribeSchema grant on the nested secret
+        AssertHasAccess(2, NACLib::EInheritanceType::InheritNone, /* expectedHasAccess */ false, runtime, txId, env);
+
+        // If a user has the DescribeSchema grant on a directory with inheritance type equals to InheritObject,
+        // then they will have the DescribeSchema grant on the nested secret (since secrets are objects)
+        AssertHasAccess(3, NACLib::EInheritanceType::InheritObject, /* expectedHasAccess */ true, runtime, txId, env);
+
+        // If a user has the DescribeSchema grant on a directory with inheritance type equals to InheritContainer,
+        // then they will NOT have the DescribeSchema grant on the nested secret (since secrets are objects, but not containers)
+        AssertHasAccess(4, NACLib::EInheritanceType::InheritContainer, /* expectedHasAccess */ false, runtime, txId, env);
+
+        // If a user has the DescribeSchema grant on a directory with inheritance type equals to InheritOnly,
+        // then they will NOT have the DescribeSchema grant on the nested secret ...
+        AssertHasAccess(5, NACLib::EInheritanceType::InheritOnly, /* expectedHasAccess */ false, runtime, txId, env);
+
+        // ... but with the InheritObject type as well, they will have the DescribeSchema grant
+        AssertHasAccess(6, NACLib::EInheritanceType::InheritOnly | NACLib::EInheritanceType::InheritObject,
+            /* expectedHasAccess */ true, runtime, txId, env);
     }
 
     Y_UNIT_TEST(AsyncCreateDifferentSecrets) {

--- a/ydb/library/aclib/aclib.cpp
+++ b/ydb/library/aclib/aclib.cpp
@@ -513,7 +513,7 @@ TString TACL::ToString(const NACLibProto::TACE& ace) {
     str << ':';
     str << ace.GetSID();
     auto inh = ace.GetInheritanceType();
-    if (inh != (EInheritanceType::InheritContainer | EInheritanceType::InheritObject)) {
+    if (inh != EInheritanceType::DefaultInheritanceType) {
         str << ':';
         if (inh == EInheritanceType::InheritNone)
             str << '-';
@@ -668,7 +668,7 @@ void TACL::FromString(NACLibProto::TACE& ace, const TString& string) {
     auto end_pos = string.find(':', start_pos);
     ace.SetSID(string.substr(start_pos, end_pos == TString::npos ? end_pos : end_pos - start_pos));
     if (end_pos == TString::npos) {
-        ace.SetInheritanceType(EInheritanceType::InheritContainer | EInheritanceType::InheritObject);
+        ace.SetInheritanceType(EInheritanceType::DefaultInheritanceType);
         return;
     }
     ui32 inheritanceType = 0;

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -66,6 +66,8 @@ enum EInheritanceType : ui32 { // bitmask
     InheritObject = 0x01, // this ACE will inherit on child objects
     InheritContainer = 0x02, // this ACE will inherit on child containers
     InheritOnly = 0x04, // this ACE will not be used for access checking but for inheritance only
+
+    DefaultInheritanceType = InheritObject | InheritContainer,
 };
 
 enum class EDiffType : ui32 {
@@ -120,8 +122,8 @@ class TACL : public NACLibProto::TACL {
 public:
     TACL() = default;
     TACL(const TString& string); // proto format
-    std::pair<ui32, ui32> AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
-    std::pair<ui32, ui32> RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
+    std::pair<ui32, ui32> AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = DefaultInheritanceType);
+    std::pair<ui32, ui32> RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = DefaultInheritanceType);
     std::pair<ui32, ui32> RemoveAccess(const NACLibProto::TACE& filter);
     bool HasAccess(const NACLib::TSID& sid);
     std::pair<ui32, ui32> ClearAccess();
@@ -142,8 +144,8 @@ class TDiffACL : public NACLibProto::TDiffACL {
 public:
     TDiffACL() = default;
     TDiffACL(const TString& string);
-    void AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
-    void RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
+    void AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = DefaultInheritanceType);
+    void RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = DefaultInheritanceType);
     void AddAccess(const NACLibProto::TACE& access);
     void RemoveAccess(const NACLibProto::TACE& access);
     void ClearAccess();
@@ -162,8 +164,8 @@ public:
     ui32 GetEffectiveAccessRights(const TUserToken& user) const;
     TSecurityObject MergeWithParent(const NACLibProto::TSecurityObject& parent) const; // returns effective ACL as result of merging parent with this
     NACLibProto::TACL GetImmediateACL() const;
-    void AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
-    void RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
+    void AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = DefaultInheritanceType);
+    void RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = DefaultInheritanceType);
     void ApplyDiff(const NACLibProto::TDiffACL& diffACL);
     void ClearAccess();
     TInstant GetExpireTime() const;


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
- При создании меняю сами права на секрет, а не от его родителя.
- В тестах понадобился "дефолтный" тип наследования. Чтобы потом это не разошлось, завёл такое значение в `EInheritanceType`