### PR TITLE
MUTE RULES: mute after 2=>3 fails

### DIFF
--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -3,8 +3,8 @@
 ---
 
 ### Mute a test if in the last 4 days:
-- **2 or more failures**
-- **OR** 1 failure and runs (pass + fail) not more than 10
+- **3 or more failures AND runs (pass + fail) more than 10**
+- **OR** 2 or more failures AND runs (pass + fail) not more than 10
 
 ### Unmute a test if in the last 7 days:
 - **Runs (pass + fail + mute) >= 4**
@@ -24,6 +24,7 @@
 ---
 
 **Example:**
+- If a test ran 15 times in 3 days with 3 failures — the test will be muted.
 - If a test ran 5 times in 3 days with 2 failures — the test will be muted.
 - If a test ran 4 times in 7 days and all passed successfully — the test will be unmuted.
 - If a test didn't run at all in 7 days — it will be removed from mute.
@@ -87,7 +88,7 @@ For analyzing test status, finding mute/unmute candidates, and tracking stabilit
 
 ### 🔇 [to_mute.txt](mute_update/to_mute.txt)
 **Content:** Mute candidates by new rules  
-**Rules:** In 4 days ≥2 failures **OR** (≥1 failure and runs ≤10)  
+**Rules:** In 4 days (≥3 failures **AND** runs >10) **OR** (≥2 failures **AND** runs ≤10)  
 **Usage:** Main file for mute decisions
 
 ### 🔊 [to_unmute.txt](mute_update/to_unmute.txt)

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -360,7 +360,7 @@ def is_flaky_test(test, aggregated_data):
         return False
     
     total_runs = test_data['pass_count'] + test_data['fail_count']
-    return (test_data['fail_count'] >= 2) or (test_data['fail_count'] >= 1 and total_runs <= 10)
+    return (test_data['fail_count'] >= 3 and total_runs > 10) or (test_data['fail_count'] >= 2 and total_runs <= 10)
 
 def is_unmute_candidate(test, aggregated_data):
     """Проверяет, является ли тест кандидатом на размьют за указанный период"""


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Почему правлю mute rules
- туда сейчас много пападют timeout тестов, которые успешно проходят на retry
- в идеале такие штуки как-то отдельно отслеживать
- повышение порога 2->3 падения будет показывать менее стабильные тесты 

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
