### PR TITLE
MUTE: Remove deprecated branches from workflow inputs

### DIFF
--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -8,7 +8,7 @@ on:
       branches:
         description: 'Comma-separated list of branches to process'
         required: false
-        default: 'main,stable-25-1,stable-25-1-4,stable-25-2,stable-25-2-1,stable-25-3,stable-25-3-1,stream-nb-25-1'
+        default: 'main,stable-25-2,stable-25-2-1,stable-25-3,stable-25-3-1,stream-nb-25-1'
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "branches=$(echo '${{ github.event.inputs.branches }}' | jq -R -s -c 'split(",")')" >> $GITHUB_OUTPUT
           else
-            echo "branches=$(echo '["main","stable-25-1","stable-25-1-4","stable-25-2","stable-25-2-1","stable-25-3","stable-25-3-1","stream-nb-25-1"]' | jq -c .)" >> $GITHUB_OUTPUT
+            echo "branches=$(echo '["main","stable-25-2","stable-25-2-1","stable-25-3","stable-25-3-1","stream-nb-25-1"]' | jq -c .)" >> $GITHUB_OUTPUT
           fi
 
   update-muted-tests:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
