### PR TITLE
Fix PDisk handling EvChangeExpectedSlotCount in StateInit

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -706,7 +706,9 @@ public:
 
     void InitHandle(NPDisk::TEvChangeExpectedSlotCount::TPtr &ev) {
         PDisk->Mon.ChangeExpectedSlotCount.CountRequest();
-        Send(ev->Sender, new NPDisk::TEvChangeExpectedSlotCountResult(NKikimrProto::CORRUPTED, StateErrorReason));
+        TStringStream str;
+        str << PCtx->PDiskLogPrefix << "is still initializing, please wait";
+        Send(ev->Sender, new NPDisk::TEvChangeExpectedSlotCountResult(NKikimrProto::NOTREADY, str.Str()));
         PDisk->Mon.ChangeExpectedSlotCount.CountResponse();
     }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This affects error message logged in NodeWarden only

- Fixup for https://github.com/ydb-platform/ydb/pull/25676