### PR TITLE
temporary disable timestamp check at partition_init stage

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -612,14 +612,12 @@ static void CheckKeysTimestampOrder(const std::deque<TDataKey>& keys) {
     auto curr = std::next(prev);
     while (curr != keys.end()) {
         if (curr->Timestamp < prev->Timestamp) {
-            Y_DEBUG_ABORT("Data keys have misarranged timestamps:%s", (
-                TStringBuilder()
+            PQ_LOG_ERROR("Data keys have misarranged timestamps:"
                     << " prev_timestamp=" << prev->Timestamp
                     << " curr_timestamp=" << curr->Timestamp
                     << " prev_key=" << prev->Key.ToString()
                     << " curr_key=" << curr->Key.ToString()
                     << " index=" << std::distance(keys.begin(), curr)
-                ).c_str()
             );
         }
         prev = curr++;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->



### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Это баг, но он мешает стартавать dev-slice'aм.
Надо запускать проверку только в тестах