### PR TITLE
Propagate StorageConfig up the distconf tree

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_cache.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_cache.cpp
@@ -48,7 +48,7 @@ namespace NKikimr::NStorage {
         }
         // propagate backwards
         for (auto& [nodeId, info] : DirectBoundNodes) {
-            auto ev = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), nullptr);
+            auto ev = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), nullptr, std::nullopt);
             info.LastReportedRootNodeId = GetRootNodeId();
             ev->Record.MutableCacheUpdate()->CopyFrom(updates);
             SendEvent(nodeId, info, std::move(ev));

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -715,7 +715,7 @@ namespace NKikimr::NStorage {
             const bool needToUpdateConfig = nodeIdsToUpdate.contains(nodeId);
             if (needToUpdateConfig || info.LastReportedRootNodeId != rootNodeId) {
                 SendEvent(nodeId, info, std::make_unique<TEvNodeConfigReversePush>(rootNodeId,
-                    needToUpdateConfig ? StorageConfig.get() : nullptr));
+                    needToUpdateConfig ? StorageConfig.get() : nullptr, std::nullopt));
                 info.LastReportedRootNodeId = GetRootNodeId();
             }
         }

--- a/ydb/core/blobstorage/nodewarden/node_warden_events.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_events.h
@@ -22,10 +22,14 @@ namespace NKikimr::NStorage {
     {
         TEvNodeConfigReversePush() = default;
 
-        TEvNodeConfigReversePush(ui32 rootNodeId, const NKikimrBlobStorage::TStorageConfig *committedConfig) {
+        TEvNodeConfigReversePush(ui32 rootNodeId, const NKikimrBlobStorage::TStorageConfig *committedConfig,
+                std::optional<ui64> requestStorageConfigGeneration) {
             Record.SetRootNodeId(rootNodeId);
             if (committedConfig) {
                 Record.MutableCommittedStorageConfig()->CopyFrom(*committedConfig);
+            }
+            if (requestStorageConfigGeneration) {
+                Record.SetRequestStorageConfigGeneration(*requestStorageConfigGeneration);
             }
         }
 

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -78,6 +78,7 @@ message TEvNodeConfigPush {
     repeated TBoundNode BoundNodes = 2; // a list of bound node updates (including itself)
     repeated TNodeIdentifier DeletedBoundNodeIds = 3; // a list of detached nodes
     TCacheUpdate CacheUpdate = 4;
+    TStorageConfig StorageConfig = 5;
 }
 
 // Used to reverse-propagate configuration and to confirm/reject initial TEvNodePushBinding query.
@@ -87,6 +88,7 @@ message TEvNodeConfigReversePush {
     TStorageConfig CommittedStorageConfig = 3; // last known committed storage configuration
     bool RecurseConfigUpdate = 4;
     TCacheUpdate CacheUpdate = 5;
+    optional uint64 RequestStorageConfigGeneration = 6;
 }
 
 // Remove node from bound list.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Propagate StorageConfig up the distconf tree

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows configuration to be propagated from the bottom node to the top.
