### PR TITLE
merge to stable-25-3 YQ-4312 streaming in ydb fixes and features

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
@@ -437,7 +437,7 @@ public:
 
         if (const auto clientOffset = client->GetNextMessageOffset()) {
             if (Parser && CurrentOffset && *CurrentOffset > *clientOffset) {
-                LOG_ROW_DISPATCHER_DEBUG("Parser was flushed due to new historical offset " << *clientOffset << "(previous parser offset: " << *CurrentOffset << ")");
+                LOG_ROW_DISPATCHER_DEBUG("Parser was flushed due to new historical offset " << *clientOffset << " (previous parser offset: " << *CurrentOffset << ")");
                 Parser->Refresh(true);
             }
         }

--- a/ydb/core/fq/libs/row_dispatcher/leader_election.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/leader_election.cpp
@@ -9,9 +9,12 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/protos/actors.pb.h>
+#include <ydb/library/logger/actor.h>
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/config.pb.h>
+
+#include <memory>
 
 namespace NFq {
 
@@ -83,7 +86,11 @@ struct TLeaderElectionMetrics {
     ::NMonitoring::TDynamicCounters::TCounterPtr LeaderChanged;
 };
 
-class TLeaderElection: public TActorBootstrapped<TLeaderElection> {
+struct TActorSystemPtrMixin {
+    NKikimr::TDeferredActorLogBackend::TSharedAtomicActorSystemPtr ActorSystemPtr = std::make_shared<NKikimr::TDeferredActorLogBackend::TAtomicActorSystemPtr>(nullptr);
+};
+
+class TLeaderElection: public TActorBootstrapped<TLeaderElection>, public TActorSystemPtrMixin {
 
     enum class EState {
         Init,
@@ -93,8 +100,8 @@ class TLeaderElection: public TActorBootstrapped<TLeaderElection> {
         Started
     };
     NKikimrConfig::TSharedReadingConfig::TCoordinatorConfig Config;
-    const NKikimr::TYdbCredentialsProviderFactory& CredentialsProviderFactory;
-    NYdb::TDriver Driver;
+    NKikimr::TYdbCredentialsProviderFactory CredentialsProviderFactory;
+    std::unique_ptr<NYdb::TDriver> Driver;
     TYdbConnectionPtr YdbConnection;
     TString TablePathPrefix;
     const TString TenantId;
@@ -165,6 +172,7 @@ private:
     void ProcessState();
     void ResetState();
     void SetTimeout();
+    NYdb::TDriverConfig GetYdbDriverConfig() const;
 };
 
 TLeaderElection::TLeaderElection(
@@ -172,13 +180,11 @@ TLeaderElection::TLeaderElection(
     NActors::TActorId coordinatorId,
     const NKikimrConfig::TSharedReadingConfig::TCoordinatorConfig& config,
     const NKikimr::TYdbCredentialsProviderFactory& credentialsProviderFactory,
-    NYdb::TDriver driver,
+    NYdb::TDriver /*driver*/,
     const TString& tenant,
     const ::NMonitoring::TDynamicCounterPtr& counters)
     : Config(config)
     , CredentialsProviderFactory(credentialsProviderFactory)
-    , Driver(driver)
-    , YdbConnection(config.GetLocalMode() ? nullptr : NewYdbConnection(config.GetDatabase(), credentialsProviderFactory, Driver))
     , TablePathPrefix(JoinPath(config.GetDatabase().GetDatabase(), config.GetCoordinationNodePath()))
     , TenantId(JoinSeq(":", NKikimr::SplitPath(tenant)))
     , CoordinationNodePath(JoinPath(TablePathPrefix, TenantId))
@@ -218,6 +224,9 @@ TYdbSdkRetryPolicy::TPtr MakeSchemaRetryPolicy() {
 
 void TLeaderElection::Bootstrap() {
     Become(&TLeaderElection::StateFunc);
+    Y_ABORT_UNLESS(!ActorSystemPtr->load(std::memory_order_relaxed), "Double ActorSystemPtr init");
+    ActorSystemPtr->store(TActivationContext::ActorSystem(), std::memory_order_relaxed);
+
     LogPrefix = "TLeaderElection " + SelfId().ToString() + " ";
     LOG_ROW_DISPATCHER_DEBUG("Successfully bootstrapped, local coordinator id " << CoordinatorId.ToString()
          << ", tenant id " << TenantId << ", local mode " << Config.GetLocalMode() << ", coordination node path " << CoordinationNodePath);
@@ -225,6 +234,9 @@ void TLeaderElection::Bootstrap() {
         TActivationContext::ActorSystem()->Send(ParentId, new NFq::TEvRowDispatcher::TEvCoordinatorChanged(CoordinatorId, 0));
         return;
     }
+
+    Driver = std::make_unique<NYdb::TDriver>(GetYdbDriverConfig());
+    YdbConnection = NewYdbConnection(Config.GetDatabase(), CredentialsProviderFactory, *Driver);
     ProcessState();
 }
 
@@ -467,6 +479,13 @@ void TLeaderElection::HandleException(const std::exception& e) {
     LOG_ROW_DISPATCHER_ERROR("Internal error: exception:" << e.what());
     Metrics.Errors->Inc();
     ResetState();
+}
+
+NYdb::TDriverConfig TLeaderElection::GetYdbDriverConfig() const {
+    NYdb::TDriverConfig cfg;
+    cfg.SetDiscoveryMode(NYdb::EDiscoveryMode::Async);
+    cfg.SetLog(std::make_unique<NKikimr::TDeferredActorLogBackend>(ActorSystemPtr, NKikimrServices::EServiceKikimr::YDB_SDK));
+    return cfg;
 }
 
 } // anonymous namespace

--- a/ydb/core/fq/libs/row_dispatcher/topic_session.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/topic_session.cpp
@@ -427,6 +427,7 @@ void TTopicSession::PassAway() {
 
 void TTopicSession::SubscribeOnNextEvent() {
     if (!ReadSession || IsWaitingEvents) {
+        LOG_ROW_DISPATCHER_TRACE("Skip SubscribeOnNextEvent, has ReadSession: " << (ReadSession ? "true" : "false") << ", IsWaitingEvents: " << IsWaitingEvents);
         return;
     }
 

--- a/ydb/core/fq/libs/row_dispatcher/topic_session.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/topic_session.cpp
@@ -5,13 +5,11 @@
 #include <ydb/core/fq/libs/row_dispatcher/events/data_plane.h>
 #include <ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.h>
 #include <ydb/core/protos/config.pb.h>
-
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/yql/dq/actors/dq.h>
-
+#include <ydb/library/yql/providers/pq/common/pq_events_processor.h>
 #include <ydb/public/sdk/cpp/adapters/issue/issue.h>
-
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 
 #include <util/generic/queue.h>
@@ -62,6 +60,7 @@ struct TEvPrivate {
         EvCreateSession,
         EvSendStatistic,
         EvReconnectSession,
+        EvExecuteTopicEvent,
         EvEnd
     };
     static_assert(EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE)");
@@ -71,13 +70,16 @@ struct TEvPrivate {
     struct TEvCreateSession : public TEventLocal<TEvCreateSession, EvCreateSession> {};
     struct TEvSendStatistic : public TEventLocal<TEvSendStatistic, EvSendStatistic> {};
     struct TEvReconnectSession : public TEventLocal<TEvReconnectSession, EvReconnectSession> {};
+    struct TEvExecuteTopicEvent : public NYql::TTopicEventBase<TEvExecuteTopicEvent, EvExecuteTopicEvent> {
+        using TTopicEventBase::TTopicEventBase;
+    };
 };
 
 constexpr ui64 SendStatisticPeriodSec = 2;
 constexpr ui64 MaxHandledEventsCount = 1000;
 constexpr ui64 MaxHandledEventsSize = 1000000;
 
-class TTopicSession : public TActorBootstrapped<TTopicSession> {
+class TTopicSession : public TActorBootstrapped<TTopicSession>, NYql::TTopicEventProcessor<TEvPrivate::TEvExecuteTopicEvent> {
 private:
     using TBase = TActorBootstrapped<TTopicSession>;
 
@@ -315,7 +317,7 @@ public:
     [[maybe_unused]] static constexpr char ActorName[] = "FQ_ROW_DISPATCHER_SESSION";
 
 private:
-    NYdb::NTopic::TTopicClientSettings GetTopicClientSettings(bool useSsl) const;
+    NYdb::NTopic::TTopicClientSettings GetTopicClientSettings(bool useSsl);
     NYql::ITopicClient& GetTopicClient(bool useSsl);
     NYdb::NTopic::TReadSessionSettings GetReadSessionSettings(const TString& consumerName) const;
     void CreateTopicSession();
@@ -351,6 +353,7 @@ private:
 private:
 
     STRICT_STFUNC_EXC(StateFunc,
+        hFunc(TEvPrivate::TEvExecuteTopicEvent, HandleTopicEvent);
         hFunc(NFq::TEvPrivate::TEvPqEventsReady, Handle);
         hFunc(NFq::TEvPrivate::TEvCreateSession, Handle);
         hFunc(NFq::TEvPrivate::TEvSendStatistic, Handle);
@@ -364,6 +367,7 @@ private:
 
     STRICT_STFUNC_EXC(ErrorState,
         cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
+        hFunc(TEvPrivate::TEvExecuteTopicEvent, HandleTopicEvent);
         IgnoreFunc(NFq::TEvPrivate::TEvPqEventsReady);
         IgnoreFunc(NFq::TEvPrivate::TEvCreateSession);
         IgnoreFunc(TEvRowDispatcher::TEvGetNextBatch);
@@ -446,12 +450,16 @@ void TTopicSession::SubscribeOnNextEvent() {
     });
 }
 
-NYdb::NTopic::TTopicClientSettings TTopicSession::GetTopicClientSettings(bool useSsl) const {
-    return PqGateway->GetTopicClientSettings()
-        .Database(Database)
+NYdb::NTopic::TTopicClientSettings TTopicSession::GetTopicClientSettings(bool useSsl) {
+    auto opts = PqGateway->GetTopicClientSettings();
+    SetupTopicClientSettings(ActorContext().ActorSystem(), SelfId(), opts);
+
+    opts.Database(Database)
         .DiscoveryEndpoint(Endpoint)
         .SslCredentials(NYdb::TSslCredentials(useSsl))
         .CredentialsProviderFactory(CredentialsProviderFactory);
+
+    return opts;
 }
 
 NYql::ITopicClient& TTopicSession::GetTopicClient(bool useSsl) {
@@ -983,7 +991,7 @@ void TTopicSession::RefreshParsers() {
     }
 }
 
-}  // anonymous namespace
+} // anonymous namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1006,4 +1014,4 @@ std::unique_ptr<IActor> NewTopicSession(
     return std::unique_ptr<IActor>(new TTopicSession(readGroup, topicPath, endpoint, database, config, functionRegistry, rowDispatcherActorId, compileServiceActorId, partitionId, std::move(driver), credentialsProviderFactory, counters, countersRoot, pqGateway, maxBufferSize));
 }
 
-}  // namespace NFq
+} // namespace NFq

--- a/ydb/core/fq/libs/row_dispatcher/ut/topic_session_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/ut/topic_session_ut.cpp
@@ -30,7 +30,7 @@ constexpr ui64 TimeoutBeforeStartSessionSec = 3;
 constexpr ui64 GrabTimeoutSec = 4 * TimeoutBeforeStartSessionSec;
 static_assert(GrabTimeoutSec <= WAIT_TIMEOUT.Seconds());
 
-template<bool MockTopicSession>
+template <bool MockTopicSession>
 class TFixture : public NTests::TBaseFixture {
 public:
     using TBase = NTests::TBaseFixture;
@@ -69,7 +69,7 @@ public:
         CompileNotifier = Runtime.AllocateEdgeActor();
         const auto compileServiceActorId = Runtime.Register(CreatePurecalcCompileServiceMock(CompileNotifier));
 
-        if (MockTopicSession) {
+        if constexpr (MockTopicSession) {
             PqGatewayNotifier = Runtime.AllocateEdgeActor();
             MockPqGateway = CreateMockPqGateway({.Runtime = &Runtime, .Notifier = PqGatewayNotifier});
         }
@@ -115,9 +115,10 @@ public:
             UNIT_ASSERT_C(ping, "Compilation is not performed for predicate: " << predicate);
         }
 
-        if (MockTopicSession) {
+        if constexpr (MockTopicSession) {
             Runtime.GrabEdgeEvent<TEvMockPqEvents::TEvCreateSession>(PqGatewayNotifier, TDuration::Seconds(GrabTimeoutSec));
-            MockPqGateway->AddEvent(TopicPath, NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent(nullptr, 0, 0), 0);
+            MockReadSession = MockPqGateway->ExtractReadSession(TopicPath);
+            MockReadSession->AddStartSessionEvent();
         }
     }
 
@@ -223,40 +224,18 @@ public:
         return TRow().AddUint64(100 * index).AddString(TStringBuilder() << "value" << index);
     }
 
-    using TMessageInformation = NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TMessageInformation;
-    using TMessage = NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TMessage;
-
-    TMessageInformation MakeNextMessageInformation(size_t offset, size_t uncompressedSize) {
-        auto now = TInstant::Now();
-        TMessageInformation msgInfo(
-            offset,
-            "ProducerId",
-            0,
-            now,
-            now,
-            MakeIntrusive<NYdb::NTopic::TWriteSessionMeta>(),
-            MakeIntrusive<NYdb::NTopic::TMessageMeta>(),
-            uncompressedSize,
-            "messageGroupId"
-        );
-        return msgInfo;
-    }
-
     void PQWrite(
         const std::vector<TString>& sequence,
         ui64 firstMessageOffset = 0) {
-        if (!MockTopicSession) {
+        if constexpr (!MockTopicSession) {
             NYql::NDq::PQWrite(sequence, TopicPath, GetDefaultPqEndpoint());
         } else {
             ui64 offset = firstMessageOffset;
-            TVector<TMessage> msgs;
-            size_t size = 0;
+            TVector<IMockPqReadSession::TMessage> msgs;
             for (const auto& s : sequence) {
-                TMessage msg(s, nullptr, MakeNextMessageInformation(offset++, s.size()), CreatePartitionSession());
-                msgs.emplace_back(msg);
-                size += s.size();
+                msgs.push_back({.Offset = offset++, .Data = s});
             }
-            MockPqGateway->AddEvent(TopicPath, NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent(msgs, {}, CreatePartitionSession()), size);
+            MockReadSession->AddDataReceivedEvent(msgs);
         }
     }
 
@@ -280,6 +259,7 @@ public:
     ui32 PartitionId = 0;
     NKikimrConfig::TSharedReadingConfig Config;
     TIntrusivePtr<IMockPqGateway> MockPqGateway;
+    IMockPqReadSession::TPtr MockReadSession;
 
     const TString Json1 = "{\"dt\":100,\"value\":\"value1\"}";
     const TString Json2 = "{\"dt\":200,\"value\":\"value2\"}";
@@ -628,7 +608,8 @@ Y_UNIT_TEST_SUITE(TopicSessionTests) {
 
         StopSession(ReadActorId2, source);
         Runtime.GrabEdgeEvent<TEvMockPqEvents::TEvCreateSession>(PqGatewayNotifier, TDuration::Seconds(GrabTimeoutSec));
-        MockPqGateway->AddEvent(TopicPath, NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent(nullptr, 0, 0), 0);
+        MockReadSession = MockPqGateway->ExtractReadSession(TopicPath);
+        MockReadSession->AddStartSessionEvent();
 
         std::vector<TString> data3 = { Json4 };
         PQWrite(data3, 4);

--- a/ydb/core/fq/libs/row_dispatcher/ya.make
+++ b/ydb/core/fq/libs/row_dispatcher/ya.make
@@ -29,6 +29,7 @@ PEERDIR(
     ydb/library/yql/dq/actors/common
     ydb/library/yql/dq/actors/compute
     ydb/library/yql/dq/proto
+    ydb/library/yql/providers/pq/common
     ydb/library/yql/providers/pq/provider
 
     ydb/public/sdk/cpp/adapters/issue

--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
@@ -122,6 +122,9 @@ namespace {
         return allTypes.contains(type);
     }
 
+    void IKqpFederatedQuerySetupFactory::Cleanup() {
+    }
+
     // TKqpFederatedQuerySetupFactoryDefault contains network clients and service actors necessary
     // for federated queries. HTTP Gateway (required by S3 provider) is run by default even without
     // explicit configuration. Token Accessor and Connector Client are run only if config is provided.
@@ -232,6 +235,11 @@ namespace {
         }
 
         return result;
+    }
+
+    void TKqpFederatedQuerySetupFactoryDefault::Cleanup() {
+        HttpGateway.reset();
+        PqGateway.Reset();
     }
 
     IKqpFederatedQuerySetupFactory::TPtr MakeKqpFederatedQuerySetupFactory(

--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.h
@@ -62,6 +62,7 @@ namespace NKikimr::NKqp {
 
     struct IKqpFederatedQuerySetupFactory {
         using TPtr = std::shared_ptr<IKqpFederatedQuerySetupFactory>;
+        virtual void Cleanup();
         virtual std::optional<TKqpFederatedQuerySetup> Make(NActors::TActorSystem* actorSystem) = 0;
         virtual ~IKqpFederatedQuerySetupFactory() = default;
     };
@@ -81,6 +82,8 @@ namespace NKikimr::NKqp {
             const NKikimrConfig::TAppConfig& appConfig);
 
         std::optional<TKqpFederatedQuerySetup> Make(NActors::TActorSystem* actorSystem) override;
+
+        void Cleanup() override;
 
     private:
         NYql::THttpGatewayConfig HttpGatewayConfig;
@@ -151,6 +154,11 @@ namespace NKikimr::NKqp {
                 YtGatewayConfig, YtGateway, SolomonGatewayConfig,
                 SolomonGateway, ComputationFactory, S3ReadActorFactoryConfig,
                 DqTaskTransformFactory, PqGatewayConfig, PqGateway, ActorSystemPtr, Driver};
+        }
+
+        void Cleanup() override {
+            HttpGateway.reset();
+            PqGateway.Reset();
         }
 
     private:

--- a/ydb/core/kqp/ut/common/kqp_ut_common.cpp
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.cpp
@@ -165,11 +165,13 @@ TKikimrRunner::TKikimrRunner(const TKikimrSettings& settings) {
     appConfig.MutableColumnShardConfig()->SetDisabledOnSchemeShard(false);
     appConfig.MutableTableServiceConfig()->SetEnableRowsDuplicationCheck(true);
     if (settings.EnableStorageProxy) {
-        appConfig.MutableQueryServiceConfig()->MutableCheckpointsConfig()->SetEnabled(true);
-        appConfig.MutableQueryServiceConfig()->MutableCheckpointsConfig()->SetCheckpointingPeriodMillis(200);
-        appConfig.MutableQueryServiceConfig()->MutableCheckpointsConfig()->SetMaxInflight(1);
-        appConfig.MutableQueryServiceConfig()->MutableCheckpointsConfig()->MutableExternalStorage()->SetEndpoint(GetEnv("YDB_ENDPOINT"));
-        appConfig.MutableQueryServiceConfig()->MutableCheckpointsConfig()->MutableExternalStorage()->SetDatabase(GetEnv("YDB_DATABASE"));
+        auto& checkpoints = *appConfig.MutableQueryServiceConfig()->MutableCheckpointsConfig();
+        checkpoints.SetEnabled(true);
+        checkpoints.SetCheckpointingPeriodMillis(settings.CheckpointPeriod.MilliSeconds());
+        checkpoints.SetMaxInflight(1);
+        checkpoints.MutableExternalStorage()->SetEndpoint(GetEnv("YDB_ENDPOINT"));
+        checkpoints.MutableExternalStorage()->SetDatabase(GetEnv("YDB_DATABASE"));
+        checkpoints.MutableCheckpointGarbageConfig()->SetEnabled(true);
     }
     if (!appConfig.GetQueryServiceConfig().HasAllExternalDataSourcesAreAvailable()) {
         appConfig.MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(true);

--- a/ydb/core/kqp/ut/common/kqp_ut_common.h
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.h
@@ -86,6 +86,7 @@ public:
     NKikimrConfig::TImmediateControlsConfig Controls;
     TMaybe<NYdbGrpc::TServerOptions> GrpcServerOptions;
     bool EnableStorageProxy = false;
+    TDuration CheckpointPeriod = TDuration::MilliSeconds(200);
 
     TKikimrSettings() {
         InitDefaultConfig();
@@ -124,6 +125,7 @@ public:
     }
     TKikimrSettings& SetGrpcServerOptions(const NYdbGrpc::TServerOptions& grpcServerOptions) { GrpcServerOptions = grpcServerOptions; return *this; };
     TKikimrSettings& SetEnableStorageProxy(bool value) { EnableStorageProxy = value; return *this; };
+    TKikimrSettings& SetCheckpointPeriod(TDuration value) { CheckpointPeriod = value; return *this; };
 };
 
 class TKikimrRunner {

--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -118,7 +118,8 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
             .SetWithSampleTables(false)
             .SetDomainRoot(options.DomainRoot)
             .SetNodeCount(options.NodeCount)
-            .SetEnableStorageProxy(true);
+            .SetEnableStorageProxy(true)
+            .SetCheckpointPeriod(options.CheckpointPeriod);
 
         settings.EnableScriptExecutionBackgroundChecks = options.EnableScriptExecutionBackgroundChecks;
 

--- a/ydb/core/kqp/ut/federated_query/common/common.h
+++ b/ydb/core/kqp/ut/federated_query/common/common.h
@@ -23,6 +23,7 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
         NYql::ISecuredServiceAccountCredentialsFactory::TPtr CredentialsFactory;
         bool EnableScriptExecutionBackgroundChecks = true;
         TIntrusivePtr<NYql::IPqGateway> PqGateway;
+        TDuration CheckpointPeriod = TDuration::MilliSeconds(200);
     };
 
     std::shared_ptr<TKikimrRunner> MakeKikimrRunner(

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -33,6 +33,8 @@ struct TScriptQuerySettings {
 };
 
 class TStreamingTestFixture : public NUnitTest::TBaseFixture {
+    using TBase = NUnitTest::TBaseFixture;
+
 public:
     // External YDB recipe
     inline static const TString YDB_ENDPOINT = GetEnv("YDB_ENDPOINT");
@@ -78,7 +80,8 @@ public:
             queryServiceConfig.SetProgressStatsPeriodMs(1000);
 
             Kikimr = MakeKikimrRunner(true, nullptr, nullptr, AppConfig, NYql::NDq::CreateS3ActorsFactory(), {
-                .PqGateway = PqGateway
+                .PqGateway = PqGateway,
+                .CheckpointPeriod = CheckpointPeriod,
             });
 
             if (GetTestParam("DEFAULT_LOG", "enabled") == "enabled") {
@@ -161,6 +164,22 @@ public:
         return TopicClient;
     }
 
+    std::shared_ptr<TQueryClient> GetExternalQueryClient() {
+        if (!ExternalQueryClient) {
+            ExternalQueryClient = std::make_shared<TQueryClient>(*GetExternalDriver(), TClientSettings()
+                .DiscoveryEndpoint(YDB_ENDPOINT)
+                .Database(YDB_DATABASE));
+        }
+
+        return ExternalQueryClient;
+    }
+
+    std::vector<TResultSet> ExecExternalQuery(const TString& query, EStatus expectedStatus = EStatus::SUCCESS) {
+        auto result = GetExternalQueryClient()->ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToOneLineString());
+        return result.GetResultSets();
+    }
+
     // Topic client SDK (external YDB recipe)
 
     void CreateTopic(const TString& topicName, std::optional<NTopic::TCreateTopicSettings> settings = std::nullopt) {
@@ -186,6 +205,10 @@ public:
         for (const auto& message : messages) {
             WriteTopicMessage(topicName, message, partition);
         }
+    }
+
+    void ReadTopicMessage(const TString& topicName, const TString& expectedMessage, TDuration disposition = TDuration::Seconds(100)) {
+        ReadTopicMessages(topicName, {expectedMessage}, disposition);
     }
 
     void ReadTopicMessages(const TString& topicName, const TVector<TString>& expectedMessages, TDuration disposition = TDuration::Seconds(100)) {
@@ -471,7 +494,82 @@ public:
         });
     }
 
+    void WaitCheckpointUpdate(const TString& executionId) {
+        std::optional<uint64_t> minSeqNo;
+        WaitFor(TEST_OPERATION_TIMEOUT, "checkpoint update", [&](TString& error) {
+            const auto& result = ExecExternalQuery(fmt::format(R"(
+                SELECT MIN(seq_no) AS seq_no FROM checkpoints_metadata
+                WHERE graph_id = "{execution_id}";
+            )", "execution_id"_a = executionId));
+            UNIT_ASSERT_VALUES_EQUAL(result.size(), 1);
+
+            std::optional<uint64_t> seqNo;
+            CheckScriptResult(result[0], 1, 1, [&seqNo](TResultSetParser& resultSet) {
+                seqNo = resultSet.ColumnParser(0).GetOptionalUint64();
+            });
+
+            if (!seqNo) {
+                error = "seq_no is null";
+                return false;
+            }
+
+            if (!minSeqNo) {
+                minSeqNo = *seqNo;
+                error = TStringBuilder() << "found initial seq_no: " << *minSeqNo;
+                return false;
+            }
+
+            if (*minSeqNo != *seqNo) {
+                return true;
+            }
+
+            error = TStringBuilder() << "seq_no is not changed from: " << *minSeqNo;
+            return false;
+        });
+    }
+
     // Utils
+
+    static IMockPqReadSession::TPtr WaitMockPqReadSession(IMockPqGateway::TPtr gateway, const TString& topic) {
+        return WaitForPqMockSession<IMockPqReadSession>(TEST_OPERATION_TIMEOUT, "read", [gateway, topic]() {
+            return gateway->ExtractReadSession(topic);
+        });
+    }
+
+    static IMockPqWriteSession::TPtr WaitMockPqWriteSession(IMockPqGateway::TPtr gateway, const TString& topic) {
+        return WaitForPqMockSession<IMockPqWriteSession>(TEST_OPERATION_TIMEOUT, "write", [gateway, topic]() {
+            return gateway->ExtractWriteSession(topic);
+        });
+    }
+
+    template <typename TSession>
+    static TSession::TPtr WaitForPqMockSession(TDuration timeout, const TString& info, std::function<typename TSession::TPtr()> sessionExtractor) {
+        typename TSession::TPtr session;
+        WaitFor(timeout, TStringBuilder() << info << " session from mock pq gateway", [&](TString& errorString) {
+            if (session = sessionExtractor()) {
+                return true;
+            }
+
+            errorString = "Session is not ready";
+            return false;
+        });
+
+        return session;
+    }
+
+    static void ReadMockPqMessage(IMockPqWriteSession::TPtr session, const TString& message) {
+        WaitFor(TEST_OPERATION_TIMEOUT, "read message from mock pq gateway", [&](TString& errorString) {
+            const auto data = session->ExtractData();
+            if (!data.empty()) {
+                UNIT_ASSERT_VALUES_EQUAL(data.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(data[0], message);
+                return true;
+            }
+
+            errorString = "no messages found";
+            return false;
+        });
+    }
 
     static void WaitFor(TDuration timeout, const TString& description, std::function<bool(TString&)> callback) {
         TInstant start = TInstant::Now();
@@ -493,6 +591,14 @@ private:
         UNIT_ASSERT_C(!Kikimr, "Kikimr runner is already initialized, can not setup " << info);
     }
 
+    void TearDown(NUnitTest::TTestContext& context) final {
+        PqGateway.Reset();
+        TBase::TearDown(context);
+    }
+
+protected:
+    TDuration CheckpointPeriod = TDuration::MilliSeconds(200);
+
 private:
     std::optional<NKikimrConfig::TAppConfig> AppConfig;
     TIntrusivePtr<NYql::IPqGateway> PqGateway;
@@ -507,6 +613,7 @@ private:
     // Attached to database from recipe (YDB_ENDPOINT / YDB_DATABASE)
     std::shared_ptr<TDriver> ExternalDriver;
     std::shared_ptr<NTopic::TTopicClient> TopicClient;
+    std::shared_ptr<TQueryClient> ExternalQueryClient;
 };
 
 } // anonymous namespace
@@ -684,7 +791,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         ));
 
         WriteTopicMessage(inputTopicName, R"({"key": "key1", "value": "value1"})");
-        ReadTopicMessages(outputTopicName, {"key1value1"});
+        ReadTopicMessage(outputTopicName, "key1value1");
 
         WaitFor(TDuration::Seconds(5), "operation AST", [&](TString& error) {
             const auto& operation = GetScriptExecutionOperation(scriptExecutionOperation);
@@ -885,17 +992,6 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         constexpr char s3SinkName[] = "s3Sink";
         CreateS3Source(writeBucket, s3SinkName);
 
-        size_t numberEvents = 0;
-        pqGateway->AddEventProvider(topicName, [&](TMockPqSession meta) -> NTopic::TReadSessionEvent::TEvent {
-            numberEvents++;
-
-            if (numberEvents == 1) {
-                return NTopic::TSessionClosedEvent(EStatus::UNAVAILABLE, {NIssue::TIssue("Test pq session failure")});
-            }
-
-            return MakePqMessage(numberEvents, R"({"key": "key1", "value": "value1"})", meta);
-        });
-
         const auto& [_, operationId] = ExecScriptNative(fmt::format(R"(
             PRAGMA s3.AtomicUploadCommit = "true";
 
@@ -913,8 +1009,9 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         ), {
             .SaveState = true,
             .RetryMapping = CreateRetryMapping({Ydb::StatusIds::BAD_REQUEST})
-        }, false);
+        });
 
+        WaitMockPqReadSession(pqGateway, topicName)->AddCloseSessionEvent(EStatus::UNAVAILABLE, {NIssue::TIssue("Test pq session failure")});
         WaitScriptExecution(operationId, EExecStatus::Failed, true);
 
         ExecQuery(fmt::format(R"(
@@ -924,6 +1021,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
             "pq_source"_a = pqSourceName
         ));
 
+        WaitMockPqReadSession(pqGateway, topicName)->AddDataReceivedEvent(1, R"({"key": "key1", "value": "value1"})");
         WaitScriptExecution(operationId);
 
         UNIT_ASSERT_VALUES_EQUAL(GetAllObjects(writeBucket), "{\"key\":\"key1\",\"value\":\"value1\"}\n");
@@ -938,14 +1036,10 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         constexpr char outputTopicName[] = "outputTopicName";
         CreateTopic(outputTopicName);
 
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, std::nullopt, NYql::NDq::CreateS3ActorsFactory(), {
-            .PqGateway = pqGateway
-        });
-
         constexpr char sourceName[] = "sourceName";
         CreatePqSource(sourceName);
 
-        const auto& [_, operationId] = ExecScriptNative(fmt::format(R"(
+        const auto& [executionId, operationId] = ExecScriptNative(fmt::format(R"(
                 $input = SELECT key, value FROM `{source}`.`{input_topic}`
                 WITH (
                     FORMAT="json_each_row",
@@ -961,34 +1055,120 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
             ), {
                 .SaveState = true,
                 .RetryMapping = CreateRetryMapping({Ydb::StatusIds::BAD_REQUEST})
-            }, false);
+            });
 
-        Sleep(TDuration::MilliSeconds(3000));
+        WaitCheckpointUpdate(executionId);
 
-        pqGateway->AddEvent(inputTopicName, MakePqMessage(1, R"({"key": "key1", "value": "value1"})", {.Session = CreatePartitionSession()}));
-        pqGateway->AddEvent(inputTopicName, MakePqMessage(2, R"({"key": "key2", "value": "value2"})", {.Session = CreatePartitionSession()}));
-        pqGateway->AddEvent(inputTopicName, MakePqMessage(3, R"({"key": "key3", "value": "value3"})", {.Session = CreatePartitionSession()}));
-        Sleep(TDuration::MilliSeconds(1000));
-        pqGateway->AddEvent(inputTopicName, NTopic::TSessionClosedEvent(EStatus::UNAVAILABLE, {NIssue::TIssue("Test pq session failure")}));
+        auto readSession = WaitMockPqReadSession(pqGateway, inputTopicName);
+        readSession->AddDataReceivedEvent(1, R"({"key": "key1", "value": "value1"})");
+        readSession->AddDataReceivedEvent(2, R"({"key": "key2", "value": "value2"})");
+        readSession->AddDataReceivedEvent(3, R"({"key": "key3", "value": "value3"})");
+        WaitCheckpointUpdate(executionId);
+        readSession->AddCloseSessionEvent(EStatus::UNAVAILABLE, {NIssue::TIssue("Test pq session failure")});
 
-        Sleep(TDuration::MilliSeconds(10000));
-        pqGateway->AddEvent(inputTopicName, MakePqMessage(4, R"({"key": "key4", "value": "value4"})", {.Session = CreatePartitionSession()}));
+        WaitScriptExecution(operationId, EExecStatus::Failed, true);
+        WaitCheckpointUpdate(executionId);
 
-        bool success = false;
-        while (true) {
-            auto writeResult = pqGateway->GetWriteSessionData(outputTopicName);
-            for (auto& w : writeResult) {
-                if (w == "key4value4") {
-                    success = true;
-                    break;
-                }
-            }
-            if (success) {
-                break;
-            }
-            Sleep(TDuration::MilliSeconds(100));
-        }
+        WaitMockPqReadSession(pqGateway, inputTopicName)->AddDataReceivedEvent(4, R"({"key": "key4", "value": "value4"})");
+        ReadMockPqMessage(WaitMockPqWriteSession(pqGateway, outputTopicName), "key4value4");
+
         CancelScriptExecution(operationId);
+    }
+
+    Y_UNIT_TEST_F(CheckpointsPropagationWithGroupByHop, TStreamingTestFixture) {
+        CheckpointPeriod = TDuration::Seconds(5);
+
+        constexpr char inputTopicName[] = "inputTopicName";
+        constexpr char outputTopicName[] = "outputTopicName";
+        CreateTopic(inputTopicName);
+        CreateTopic(outputTopicName);
+
+        constexpr char sourceName[] = "sourceName";
+        CreatePqSource(sourceName);
+
+        const auto& [executionId, operationId] = ExecScriptNative(fmt::format(R"(
+            INSERT INTO `{source}`.`{output_topic}`
+            SELECT event FROM `{source}`.`{input_topic}` WITH (
+                FORMAT = "json_each_row",
+                SCHEMA (
+                    time String,
+                    event String NOT NULL
+                )
+            )
+            GROUP BY HOP (CAST(time AS Timestamp), "PT1H", "PT1H", "PT0H"), event;)",
+            "source"_a = sourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ), {
+            .SaveState = true
+        });
+
+        WriteTopicMessages(inputTopicName, {
+            R"({"time": "2025-08-24T00:00:00.000000Z", "event": "A"})",
+            R"({"time": "2025-08-25T00:00:00.000000Z", "event": "B"})"
+        });
+        ReadTopicMessage(outputTopicName, "A");
+        WaitCheckpointUpdate(executionId);
+
+        const auto& result = ExecExternalQuery(fmt::format(R"(
+            SELECT COUNT(*) AS states_count FROM (
+                SELECT DISTINCT task_id FROM states
+                WHERE graph_id = "{execution_id}"
+            )
+        )", "execution_id"_a = executionId));
+        UNIT_ASSERT_VALUES_EQUAL(result.size(), 1);
+
+        CheckScriptResult(result[0], 1, 1, [](TResultSetParser& resultSet) {
+            UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser(0).GetUint64(), 2);
+        });
+    }
+
+    Y_UNIT_TEST_F(CheckpointsOnNotDrainedChannels, TStreamingTestFixture) {
+        CheckpointPeriod = TDuration::Seconds(3);
+        const auto pqGateway = SetupMockPqGateway();
+
+        constexpr char inputTopicName[] = "inputTopicName";
+        constexpr char outputTopicName[] = "outputTopicName";
+        CreateTopic(inputTopicName);
+        CreateTopic(outputTopicName);
+
+        constexpr char sourceName[] = "sourceName";
+        CreatePqSource(sourceName);
+
+        const auto& [executionId, operationId] = ExecScriptNative(fmt::format(R"(
+            INSERT INTO `{source}`.`{output_topic}`
+            SELECT event FROM `{source}`.`{input_topic}` WITH (
+                FORMAT = "json_each_row",
+                SCHEMA (
+                    time String,
+                    event String NOT NULL
+                )
+            )
+            GROUP BY HOP (CAST(time AS Timestamp), "PT1H", "PT1H", "PT0H"), event;)",
+            "source"_a = sourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ), {
+            .SaveState = true
+        });
+
+        auto writeSession = WaitMockPqWriteSession(pqGateway, outputTopicName);
+        WaitCheckpointUpdate(executionId);
+        writeSession->Lock();
+
+        auto readSession = WaitMockPqReadSession(pqGateway, inputTopicName);
+        const TString value(1_KB, 'x');
+        TInstant time = TInstant::Now();
+        for (ui64 i = 0; i < 100000; ++i, time += TDuration::Hours(2)) {
+            readSession->AddDataReceivedEvent(i, TStringBuilder() << R"({"time": ")" << time.ToString() << R"(", "event": ")" << value << R"("})");
+        }
+
+        Sleep(TDuration::Seconds(6));
+        writeSession->Unlock();
+
+        for (ui64 i = 0; i < 3; ++i) {
+            WaitCheckpointUpdate(executionId);
+        }
     }
 }
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -359,7 +359,7 @@ public:
             }
 
             const auto& status = operation->Status();
-            UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::SUCCESS, status.GetIssues().ToOneLineString());
+            UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::SUCCESS, TStringBuilder() << "Status: " << execStatus << ", Issues: " << status.GetIssues().ToOneLineString());
             UNIT_ASSERT_C(!operation->Ready(), "Operation unexpectedly ready in status " << execStatus << " (expected status " << finalStatus << ")");
 
             error = TStringBuilder() << "operation status: " << execStatus << ", ready: " << operation->Ready();
@@ -378,7 +378,7 @@ public:
     }
 
     void ExecAndWaitScript(const TString& query, EExecStatus finalStatus = EExecStatus::Completed, std::optional<TExecuteScriptSettings> settings = std::nullopt) {
-        WaitScriptExecution(ExecScript(query, settings), finalStatus, false);
+        WaitScriptExecution(ExecScript(query, settings, /* waitRunning */ false), finalStatus, false);
     }
 
     TResultSet FetchScriptResult(const TOperation::TOperationId& operationId, ui64 resultSetId = 0) {

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1799,6 +1799,10 @@ namespace Tests {
             YqSharedResources->Stop();
         }
 
+        if (Settings->FederatedQuerySetupFactory) {
+            Settings->FederatedQuerySetupFactory->Cleanup();
+        }
+
         if (Runtime) {
             WaitFinalization();
             SysViewsRosterUpdateObserver.Remove();

--- a/ydb/library/testlib/pq_helpers/mock_pq_gateway.cpp
+++ b/ydb/library/testlib/pq_helpers/mock_pq_gateway.cpp
@@ -1,269 +1,382 @@
 #include "mock_pq_gateway.h"
 
+#include <ydb/library/yql/providers/pq/gateway/dummy/yql_pq_blocking_queue.h>
+
 #include <library/cpp/threading/future/async.h>
 
-#include <ydb/library/yql/providers/pq/gateway/dummy/yql_pq_blocking_queue.h>
+#include <util/string/join.h>
 
 namespace NTestUtils {
 
 namespace {
 
-using TQueue = NYql::TBlockingEQueue<NYdb::NTopic::TReadSessionEvent::TEvent>;
+class TMockSessionBase {
+protected:
+    NThreading::TFuture<void> GetFuture() const {
+        return Promise.GetFuture();
+    }
 
-class TMockTopicReadSession : public NYdb::NTopic::IReadSession {
-public:
-    struct TSettings {
-        IMockPqGateway::TEvGen EvGen;
-        NYdb::NTopic::TPartitionSession::TPtr Session;
+    void FillPromise() {
+        if (!Promise.HasValue()) {
+            Promise.SetValue();
+        }
+    }
+
+    void ClearPromise() {
+        if (Promise.HasValue()) {
+            Promise = NThreading::NewPromise();
+        }
+    }
+
+    TGuard<TMutex> Guard() const {
+        return ::Guard(Mutex);
+    }
+
+    TInverseGuard<TMutex> Unguard() const {
+        return ::Unguard(Mutex);
+    }
+
+private:
+    TMutex Mutex;
+    NThreading::TPromise<void> Promise = NThreading::NewPromise();
+};
+
+class TMockPqReadSession final : private TMockSessionBase, public IMockPqReadSession, public NYdb::NTopic::IReadSession {
+    struct TMockPartitionSession final : public NYdb::NTopic::TPartitionSession {
+        explicit TMockPartitionSession(const TString& topicPath) {
+            PartitionSessionId = 0;
+            TopicPath = topicPath;
+            ReadSessionId = TStringBuilder() << "mock-session-to-" << topicPath;
+            PartitionId = 0;
+        }
+
+        void RequestStatus() final {
+            Y_ENSURE(false, "Not implemented");
+        }
     };
 
-    TMockTopicReadSession(std::shared_ptr<TQueue> queue, const TSettings& settings)
-        : Settings(settings)
-        , MaxBatchSize(Settings.EvGen ? 1 : std::numeric_limits<size_t>::max())
-        , Queue(queue)
-    {
-        if (Queue->IsStopped()) {
-            Queue->~TBlockingEQueue();
-            new (Queue.get()) TQueue(4_MB);
-        }
-        ThreadPool.Start(1);
+public:
+    explicit TMockPqReadSession(const TString& topicPath)
+        : PartitionSession(MakeIntrusive<TMockPartitionSession>(topicPath))
+    {}
+
+    ~TMockPqReadSession() {
+        Close(TDuration::Max());
     }
 
-    ~TMockTopicReadSession() {
-        Close(TDuration::Zero());
+    //// IReadSession interface implementation
+
+    NThreading::TFuture<void> WaitEvent() final {
+        return GetFuture();
     }
 
-    NThreading::TFuture<void> WaitEvent() override {
-        return Settings.EvGen
-            ? NThreading::MakeFuture()
-            : NThreading::Async([&] () {
-                Queue->BlockUntilEvent();
-                return NThreading::MakeFuture();
-            }, ThreadPool);
-    }
-
-    std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvents(bool block, std::optional<size_t> maxEventsCount, size_t maxByteSize) override {
-        const auto maxEvents = std::min(MaxBatchSize, maxEventsCount.value_or(std::numeric_limits<size_t>::max()));
-
-        std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> res;
-        while (res.size() < maxEvents) {
+    std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvents(bool block, std::optional<size_t> maxEventsCount, size_t maxByteSize) final {
+        std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> result;
+        while (!maxEventsCount || result.size() < *maxEventsCount) {
             if (auto event = GetEvent(block, maxByteSize)) {
-                res.push_back(std::move(*event));
+                result.emplace_back(std::move(*event));
                 block = false;
+            } else {
+                break;
+            }
+
+            if (const auto lock = Guard(); result.size() >= MaxEventsBatchSize) {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvents(const NYdb::NTopic::TReadSessionGetEventSettings& settings) final {
+        return GetEvents(settings.Block_, settings.MaxEventsCount_, settings.MaxByteSize_);
+    }
+
+    std::optional<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvent(bool block, size_t /*maxByteSize*/) final {
+        const auto lock = Guard();
+
+        if (Events.empty() && !EvGen) {
+            if (!block) {
+                return std::nullopt;
+            }
+
+            const auto unlock = Unguard();
+            GetFuture().Wait();
+        }
+
+        if (EvGen) {
+            const auto unlock = Unguard();
+            return EvGen();
+        }
+
+        Y_ENSURE(!Events.empty());
+        auto result = std::move(Events.front());
+        Events.pop();
+        if (Events.empty()) {
+            ClearPromise();
+        }
+
+        return std::move(result);
+    }
+
+    std::optional<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvent(const NYdb::NTopic::TReadSessionGetEventSettings& settings) final {
+        return GetEvent(settings.Block_, settings.MaxByteSize_);
+    }
+
+    bool Close(TDuration /*timeout*/) final {
+        FillPromise();
+        return true;
+    }
+
+    NYdb::NTopic::TReaderCounters::TPtr GetCounters() const final {
+        auto result = MakeIntrusive<NYdb::NTopic::TReaderCounters>();
+        NYdb::NTopic::MakeCountersNotNull(*result);
+        return result;
+    }
+
+    std::string GetSessionId() const final {
+        return PartitionSession->GetReadSessionId();
+    }
+
+    //// Mock API implementation
+
+    NYdb::NTopic::TPartitionSession::TPtr GetPartitionSession() const final {
+        return PartitionSession;
+    }
+
+    void SetEventProvider(TEvGen evGen) final {
+        const auto lock = Guard();
+
+        EvGen = evGen;
+        MaxEventsBatchSize = EvGen ? 1 : std::numeric_limits<size_t>::max();
+        FillPromise();
+    }
+
+    void AddEvent(NYdb::NTopic::TReadSessionEvent::TEvent&& ev) final {
+        const auto lock = Guard();
+
+        Events.emplace(std::move(ev));
+        FillPromise();
+    }
+
+    void AddStartSessionEvent() final {
+        AddEvent(NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent(nullptr, 0, 0));
+    }
+
+    void AddDataReceivedEvent(ui64 offset, const TString& data) final {
+        AddDataReceivedEvent({{.Offset = offset, .Data = data}});
+    }
+
+    void AddDataReceivedEvent(const std::vector<TMessage>& messages) final {
+        const auto now = TInstant::Now();
+
+        std::vector<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TMessage> topicMessages;
+        topicMessages.reserve(messages.size());
+        for (const auto& message : messages) {
+            topicMessages.push_back({
+                message.Data,
+                nullptr,
+                NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TMessageInformation(
+                    message.Offset,
+                    "",
+                    0,
+                    now,
+                    now,
+                    MakeIntrusive<NYdb::NTopic::TWriteSessionMeta>(),
+                    MakeIntrusive<NYdb::NTopic::TMessageMeta>(),
+                    message.Data.size(),
+                    ""
+                ),
+                PartitionSession
+            });
+        }
+
+        AddEvent(NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent(std::move(topicMessages), {}, PartitionSession));
+    }
+
+    void AddCloseSessionEvent(NYdb::EStatus status, NYdb::NIssue::TIssues issues) final {
+        AddEvent(NYdb::NTopic::TSessionClosedEvent(status, std::move(issues)));
+    }
+
+private:
+    const NYdb::NTopic::TPartitionSession::TPtr PartitionSession;
+    TEvGen EvGen;
+    size_t MaxEventsBatchSize = std::numeric_limits<size_t>::max();
+    std::queue<NYdb::NTopic::TReadSessionEvent::TEvent> Events;
+};
+
+class TMockPqWriteSession final : private TMockSessionBase, private NYdb::NTopic::TContinuationTokenIssuer, public IMockPqWriteSession, public NYdb::NTopic::IWriteSession {
+public:
+    TMockPqWriteSession() {
+        Events.emplace(NYdb::NTopic::TWriteSessionEvent::TReadyToAcceptEvent(std::move(IssueContinuationToken())));
+        FillPromise();
+    }
+
+    //// IReadSession interface implementation
+
+    NThreading::TFuture<void> WaitEvent() final {
+        return GetFuture();
+    }
+
+    std::optional<NYdb::NTopic::TWriteSessionEvent::TEvent> GetEvent(bool block) final {
+        const auto lock = Guard();
+
+        if (Events.empty() || Locked) {
+            if (!block) {
+                return std::nullopt;
+            }
+
+            const auto unlock = Unguard();
+            GetFuture().Wait();
+        }
+
+        Y_ENSURE(!Events.empty() && !Locked);
+        auto result = std::move(Events.front());
+        Events.pop();
+        if (Events.empty()) {
+            ClearPromise();
+        }
+
+        return std::move(result);
+    }
+
+    std::vector<NYdb::NTopic::TWriteSessionEvent::TEvent> GetEvents(bool block, std::optional<size_t> maxEventsCount) final {
+        std::vector<NYdb::NTopic::TWriteSessionEvent::TEvent> result;
+        while (!maxEventsCount || result.size() < *maxEventsCount) {
+            if (auto event = GetEvent(block)) {
+                result.emplace_back(std::move(*event));
             } else {
                 break;
             }
         }
 
-        return res;
-    }
-
-    std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvents(const NYdb::NTopic::TReadSessionGetEventSettings& settings) override {
-        return GetEvents(settings.Block_, settings.MaxEventsCount_, settings.MaxByteSize_);
-    }
-
-    std::optional<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvent(bool block, size_t /*maxByteSize*/) override {
-        if (auto event = Queue->Pop(block)) {
-            return std::move(*event);
-        } else if (Settings.EvGen) {
-            return Settings.EvGen({
-                .Session = Settings.Session
-            });
-        }
-        return std::nullopt;
-    }
-
-    std::optional<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvent(const NYdb::NTopic::TReadSessionGetEventSettings& settings) override {
-        return GetEvent(settings.Block_, settings.MaxByteSize_);
-    }
-
-    bool Close(TDuration /*timeout*/) override {
-        if (Closed) {
-            return true;
-        }
-        Queue->Stop();
-        ThreadPool.Stop();
-        Closed = true;
-        return true;
-    }
-
-    NYdb::NTopic::TReaderCounters::TPtr GetCounters() const override {
-        const auto result = MakeIntrusive<NYdb::NTopic::TReaderCounters>();
-        NYdb::NTopic::MakeCountersNotNull(*result);
         return result;
     }
 
-    std::string GetSessionId() const override {
-        return "0";
+    NThreading::TFuture<uint64_t> GetInitSeqNo() final {
+        return NThreading::MakeFuture<uint64_t>(0);
+    }
+
+    void Write(NYdb::NTopic::TContinuationToken&& continuationToken, NYdb::NTopic::TWriteMessage&& message, NYdb::TTransactionBase* /*tx*/) final {
+        Write(std::move(continuationToken), message.Data, message.SeqNo_, message.CreateTimestamp_);
+    }
+
+    void Write(NYdb::NTopic::TContinuationToken&& continuationToken, std::string_view data, std::optional<uint64_t> seqNo, std::optional<TInstant> /*createTimestamp*/) final {
+        const auto lock = Guard();
+
+        if (seqNo) {
+            Events.emplace(NYdb::NTopic::TWriteSessionEvent::TAcksEvent{.Acks = {NYdb::NTopic::TWriteSessionEvent::TWriteAck{
+                .SeqNo = *seqNo,
+                .State = NYdb::NTopic::TWriteSessionEvent::TWriteAck::EES_WRITTEN,
+            }}});
+        }
+
+        Events.emplace(NYdb::NTopic::TWriteSessionEvent::TReadyToAcceptEvent(std::move(continuationToken)));
+
+        if (!Locked) {
+            FillPromise();
+        }
+
+        Data.emplace_back(data);
+    }
+
+    void WriteEncoded(NYdb::NTopic::TContinuationToken&& continuationToken, NYdb::NTopic::TWriteMessage&& params, NYdb::TTransactionBase* tx) final {
+        Write(std::move(continuationToken), std::move(params), tx);
+    }
+
+    void WriteEncoded(NYdb::NTopic::TContinuationToken&& continuationToken, std::string_view data, NYdb::NTopic::ECodec /*codec*/, uint32_t /*originalSize*/, std::optional<uint64_t> seqNo, std::optional<TInstant> createTimestamp) final {
+        Write(std::move(continuationToken), data, seqNo, createTimestamp);
+    }
+
+    bool Close(TDuration /*closeTimeout*/) final {
+        return true;
+    }
+
+    NYdb::NTopic::TWriterCounters::TPtr GetCounters() final {
+        return MakeIntrusive<NYdb::NTopic::TWriterCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
+    }
+
+    //// Mock API implementation
+
+    std::vector<TString> ExtractData() final {
+        const auto lock = Guard();
+
+        std::vector<TString> result = std::move(Data);
+        Data.clear();
+        return result;
+    }
+
+    void Lock() final {
+        const auto lock = Guard();
+
+        Locked = true;
+        ClearPromise();
+    }
+
+    void Unlock() final {
+        const auto lock = Guard();
+
+        Locked = false;
+        if (!Events.empty()) {
+            FillPromise();
+        }
     }
 
 private:
-    TThreadPool ThreadPool;
-    const TSettings Settings;
-    const ui64 MaxBatchSize = std::numeric_limits<size_t>::max();
-    std::shared_ptr<TQueue> Queue;
-    bool Closed = false;
+    std::vector<TString> Data;
+    bool Locked = false;
+    std::queue<NYdb::NTopic::TWriteSessionEvent::TEvent> Events;
 };
 
-struct TMockPartitionSession : public NYdb::NTopic::TPartitionSession {
-    explicit TMockPartitionSession(const TString& topicPath) {
-        PartitionSessionId = 0;
-        TopicPath = topicPath;
-        PartitionId = 0;
-    }
-
-    void RequestStatus() override {
-        Y_ENSURE(false, "Not implemented");
-    }
-};
-
-class TMockPqGateway : public IMockPqGateway {
-
-    class TMockTopicWriteSession : public NYdb::NTopic::IWriteSession, private NYdb::NTopic::TContinuationTokenIssuer {
+class TMockPqGateway final : public IMockPqGateway {
+    class TMockTopicClient final : public NYql::ITopicClient {
     public:
-        TMockTopicWriteSession(TMockPqGateway* self, const TString& topic)
-            : Topic(topic)
-            , Self(self) {
-            Events.emplace_back(NYdb::NTopic::TWriteSessionEvent::TReadyToAcceptEvent(std::move(IssueContinuationToken())));
-        }
-
-        NThreading::TFuture<void> WaitEvent() override {
-            if (FirstEvent) {
-                FirstEvent = false;
-                return NThreading::MakeFuture();
-            }
-            return Promise.GetFuture();
-        }
-
-        std::optional<NYdb::NTopic::TWriteSessionEvent::TEvent> GetEvent(bool /*block*/ = false) override {
-            return std::nullopt;
-        }
-
-        std::vector<NYdb::NTopic::TWriteSessionEvent::TEvent> GetEvents(bool /*block*/ = false, std::optional<size_t> /*maxEventsCount*/ = std::nullopt) override {
-            return std::move(Events);
-        }
-
-        NThreading::TFuture<uint64_t> GetInitSeqNo() override {
-            return NThreading::MakeFuture<uint64_t>(0);
-        }
-
-        void Write(NYdb::NTopic::TContinuationToken&& /*continuationToken*/, NYdb::NTopic::TWriteMessage&& /*message*/,
-            NYdb::TTransactionBase* /*tx*/ = nullptr) override {
-        }
-
-        void Write(NYdb::NTopic::TContinuationToken&& continuationToken, std::string_view data, std::optional<uint64_t> seqNo = std::nullopt,
-            std::optional<TInstant> /*createTimestamp*/ = std::nullopt) override {
-            std::vector<NYdb::NTopic::TWriteSessionEvent::TWriteAck> acks;
-            NYdb::NTopic::TWriteSessionEvent::TWriteAck ack;
-            ack.State = NYdb::NTopic::TWriteSessionEvent::TWriteAck::EES_WRITTEN;
-            ack.SeqNo = *seqNo;
-            acks.push_back(ack);
-            Events.emplace_back(NYdb::NTopic::TWriteSessionEvent::TAcksEvent{.Acks = acks});
-            Events.emplace_back(NYdb::NTopic::TWriteSessionEvent::TReadyToAcceptEvent(std::move(continuationToken)));
-            if (!Promise.HasValue()) {
-                Promise.SetValue();
-            }
-            auto& info = Self->GetTopicInfo(Topic);
-            with_lock (info.Mutex) {
-                info.WriteSessionData.push_back(TString(data));
-            }
-        }
-
-        void WriteEncoded(NYdb::NTopic::TContinuationToken&& /*continuationToken*/, NYdb::NTopic::TWriteMessage&& /*params*/,
-            NYdb::TTransactionBase* /*tx*/ = nullptr) override {
-        }
-
-        void WriteEncoded(NYdb::NTopic::TContinuationToken&& /*continuationToken*/, std::string_view /*data*/, NYdb::NTopic::ECodec /*codec*/, uint32_t /*originalSize*/,
-            std::optional<uint64_t> /*seqNo*/ = std::nullopt, std::optional<TInstant> /*createTimestamp*/ = std::nullopt) override {
-        }
-
-        bool Close(TDuration /*closeTimeout*/ = TDuration::Max()) override {
-            return true;
-        }
-
-        NYdb::NTopic::TWriterCounters::TPtr GetCounters() override {
-            return nullptr;
-        }
-    private:
-        NThreading::TPromise<void> Promise = NThreading::NewPromise();
-        bool FirstEvent = true;
-        std::vector<NYdb::NTopic::TWriteSessionEvent::TEvent> Events;
-        TString Topic;
-        TMockPqGateway* Self;
-    };
-
-    struct TTopicInfo {
-        TTopicInfo()
-            : Queue(std::make_shared<TQueue>(4_MB))
-        {}
-
-        std::shared_ptr<TQueue> Queue;
-        TEvGen EvGen;
-        std::shared_ptr<TMockTopicWriteSession> WriteSession;
-        std::vector<TString> WriteSessionData;
-        TMutex Mutex;
-    };
-
-    struct TMockTopicClient : public NYql::ITopicClient {
         explicit TMockTopicClient(TMockPqGateway* self)
             : Self(self)
         {}
 
-        NYdb::TAsyncStatus CreateTopic(const TString& /*path*/, const NYdb::NTopic::TCreateTopicSettings& /*settings*/ = {}) override {
+        NYdb::TAsyncStatus CreateTopic(const TString& /*path*/, const NYdb::NTopic::TCreateTopicSettings& /*settings*/) final {
             Y_ENSURE(false, "Not implemented");
         }
 
-        NYdb::TAsyncStatus AlterTopic(const TString& /*path*/, const NYdb::NTopic::TAlterTopicSettings& /*settings*/ = {}) override {
+        NYdb::TAsyncStatus AlterTopic(const TString& /*path*/, const NYdb::NTopic::TAlterTopicSettings& /*settings*/) final {
             Y_ENSURE(false, "Not implemented");
         }
 
-        NYdb::TAsyncStatus DropTopic(const TString& /*path*/, const NYdb::NTopic::TDropTopicSettings& /*settings*/ = {}) override {
+        NYdb::TAsyncStatus DropTopic(const TString& /*path*/, const NYdb::NTopic::TDropTopicSettings& /*settings*/) final {
             Y_ENSURE(false, "Not implemented");
         }
 
-        NYdb::NTopic::TAsyncDescribeTopicResult DescribeTopic(const TString& /*path*/, const NYdb::NTopic::TDescribeTopicSettings& /*settings*/ = {}) override {
+        NYdb::NTopic::TAsyncDescribeTopicResult DescribeTopic(const TString& /*path*/, const NYdb::NTopic::TDescribeTopicSettings& /*settings*/) final {
             Ydb::Topic::DescribeTopicResult describe;
             describe.add_partitions();
             return NThreading::MakeFuture(NYdb::NTopic::TDescribeTopicResult(NYdb::TStatus(NYdb::EStatus::SUCCESS, {}), std::move(describe)));
         }
 
-        NYdb::NTopic::TAsyncDescribeConsumerResult DescribeConsumer(const TString& /*path*/, const TString& /*consumer*/, const NYdb::NTopic::TDescribeConsumerSettings& /*settings*/ = {}) override {
+        NYdb::NTopic::TAsyncDescribeConsumerResult DescribeConsumer(const TString& /*path*/, const TString& /*consumer*/, const NYdb::NTopic::TDescribeConsumerSettings& /*settings*/) final {
             Y_ENSURE(false, "Not implemented");
         }
 
-        NYdb::NTopic::TAsyncDescribePartitionResult DescribePartition(const TString& /*path*/, i64 /*partitionId*/, const NYdb::NTopic::TDescribePartitionSettings& /*settings*/ = {}) override {
+        NYdb::NTopic::TAsyncDescribePartitionResult DescribePartition(const TString& /*path*/, i64 /*partitionId*/, const NYdb::NTopic::TDescribePartitionSettings& /*settings*/) final {
             Y_ENSURE(false, "Not implemented");
         }
 
-        std::shared_ptr<NYdb::NTopic::IReadSession> CreateReadSession(const NYdb::NTopic::TReadSessionSettings& settings) override {
+        std::shared_ptr<NYdb::NTopic::IReadSession> CreateReadSession(const NYdb::NTopic::TReadSessionSettings& settings) final {
             Y_ENSURE(settings.Topics_.size() == 1, "Expected only one topic to read, but got " << settings.Topics_.size());
             const auto& topic = settings.Topics_.front();
             Y_ENSURE(topic.PartitionIds_.size() == 1, "Expected only one partition to read, but got " << topic.PartitionIds_.size());
-
-            if (Self->Runtime) {
-                Self->Runtime->Send(new NActors::IEventHandle(Self->Notifier, NActors::TActorId(), new TEvMockPqEvents::TEvCreateSession()));
-            }
-
-            const auto& path = TString(topic.Path_);
-            const auto& topicInfo = Self->GetTopicInfo(path);
-            return std::make_shared<TMockTopicReadSession>(topicInfo.Queue, TMockTopicReadSession::TSettings{
-                .EvGen = topicInfo.EvGen,
-                .Session = MakeIntrusive<TMockPartitionSession>(path),
-            });
+            return Self->CreateReadSession(topic.Path_);
         }
 
-        std::shared_ptr<NYdb::NTopic::ISimpleBlockingWriteSession> CreateSimpleBlockingWriteSession(const NYdb::NTopic::TWriteSessionSettings& /*settings*/) override {
+        std::shared_ptr<NYdb::NTopic::ISimpleBlockingWriteSession> CreateSimpleBlockingWriteSession(const NYdb::NTopic::TWriteSessionSettings& /*settings*/) final {
             Y_ENSURE(false, "Not implemented");
         }
 
-        std::shared_ptr<NYdb::NTopic::IWriteSession> CreateWriteSession(const NYdb::NTopic::TWriteSessionSettings& settings) override {
-            const auto& path = TString(settings.Path_);
-            auto& topicInfo = Self->GetTopicInfo(path);
-            topicInfo.WriteSession = std::make_shared<TMockTopicWriteSession>(Self, path);
-            return topicInfo.WriteSession;
+        std::shared_ptr<NYdb::NTopic::IWriteSession> CreateWriteSession(const NYdb::NTopic::TWriteSessionSettings& settings) final {
+            return Self->CreateWriteSession(settings.Path_);
         }
 
-        NYdb::TAsyncStatus CommitOffset(const TString& /*path*/, ui64 /*partitionId*/, const TString& /*consumerName*/, ui64 /*offset*/, const NYdb::NTopic::TCommitOffsetSettings& /*settings*/ = {}) override {
+        NYdb::TAsyncStatus CommitOffset(const TString& /*path*/, ui64 /*partitionId*/, const TString& /*consumerName*/, ui64 /*offset*/, const NYdb::NTopic::TCommitOffsetSettings& /*settings*/) final {
             Y_ENSURE(false, "Not implemented");
         }
 
@@ -271,33 +384,41 @@ class TMockPqGateway : public IMockPqGateway {
         TMockPqGateway* Self;
     };
 
-    struct TMockFederatedTopicClient : public NYql::IFederatedTopicClient {
+    class TMockFederatedTopicClient final : public NYql::IFederatedTopicClient {
+    public:
         explicit TMockFederatedTopicClient(TMockPqGateway* self)
             : Self(self)
         {}
 
-        NThreading::TFuture<std::vector<NYdb::NFederatedTopic::TFederatedTopicClient::TClusterInfo>> GetAllTopicClusters() override {
+        NThreading::TFuture<std::vector<NYdb::NFederatedTopic::TFederatedTopicClient::TClusterInfo>> GetAllTopicClusters() final {
             std::vector<NYdb::NFederatedTopic::TFederatedTopicClient::TClusterInfo> dbInfo;
-            dbInfo.reserve(Self->Topics.size());
-            for (const auto& [topic, _] : Self->Topics) {
-                dbInfo.push_back({
-                    .Name = topic,
-                    .Endpoint = "",
-                    .Path = topic,
-                    .Status = NYdb::NFederatedTopic::TFederatedTopicClient::TClusterInfo::EStatus::AVAILABLE
-                });
+
+            with_lock (Self->Mutex) {
+                dbInfo.reserve(Self->Topics.size());
+                for (const auto& [topic, _] : Self->Topics) {
+                    dbInfo.push_back({
+                        .Name = topic,
+                        .Endpoint = "",
+                        .Path = topic,
+                        .Status = NYdb::NFederatedTopic::TFederatedTopicClient::TClusterInfo::EStatus::AVAILABLE
+                    });
+                }
             }
 
             return NThreading::MakeFuture(std::move(dbInfo));
         }
 
-        std::shared_ptr<NYdb::NTopic::IWriteSession> CreateWriteSession(const NYdb::NFederatedTopic::TFederatedWriteSessionSettings& settings) override {
-            const auto& path = TString(settings.Path_);
-            return std::make_shared<TMockTopicWriteSession>(Self, path);
+        std::shared_ptr<NYdb::NTopic::IWriteSession> CreateWriteSession(const NYdb::NFederatedTopic::TFederatedWriteSessionSettings& settings) final {
+            return Self->CreateWriteSession(settings.Path_);
         }
 
     private:
         TMockPqGateway* Self;
+    };
+
+    struct TTopicInfo {
+        IMockPqReadSession::TPtr ReadSession;
+        IMockPqWriteSession::TPtr WriteSession;
     };
 
 public:
@@ -306,77 +427,96 @@ public:
         , Notifier(settings.Notifier)
     {}
 
-    ~TMockPqGateway() {
-    }
+    //// IPqGateway interface implementation
 
-    NThreading::TFuture<void> OpenSession(const TString& sessionId, const TString& /*username*/) override {
+    NThreading::TFuture<void> OpenSession(const TString& sessionId, const TString& /*username*/) final {
         with_lock (Mutex) {
             Y_ENSURE(Sessions.emplace(sessionId).second, "Session " << sessionId << " is already opened in pq gateway");
         }
         return NThreading::MakeFuture();
     }
 
-    NThreading::TFuture<void> CloseSession(const TString& sessionId) override {
+    NThreading::TFuture<void> CloseSession(const TString& sessionId) final {
         with_lock (Mutex) {
             Y_ENSURE(Sessions.erase(sessionId), "Session " << sessionId << " is not opened in pq gateway");
         }
         return NThreading::MakeFuture();
     }
 
-    NPq::NConfigurationManager::TAsyncDescribePathResult DescribePath(const TString& /*sessionId*/, const TString& /*cluster*/, const TString& /*database*/, const TString& path, const TString& /*token*/) override {
+    NPq::NConfigurationManager::TAsyncDescribePathResult DescribePath(const TString& /*sessionId*/, const TString& /*cluster*/, const TString& /*database*/, const TString& path, const TString& /*token*/) final {
         NPq::NConfigurationManager::TTopicDescription result(path);
         result.PartitionsCount = 1;
         return NThreading::MakeFuture<NPq::NConfigurationManager::TDescribePathResult>(NPq::NConfigurationManager::TDescribePathResult::Make<NPq::NConfigurationManager::TTopicDescription>(result));
     }
 
-    NThreading::TFuture<TListStreams> ListStreams(const TString& /*sessionId*/, const TString& /*cluster*/, const TString& /*database*/, const TString& /*token*/, ui32 /*limit*/, const TString& /*exclusiveStartStreamName*/ = {}) override {
-        Y_ENSURE(false, "Not implemented");
+    NThreading::TFuture<TListStreams> ListStreams(const TString& /*sessionId*/, const TString& /*cluster*/, const TString& /*database*/, const TString& /*token*/, ui32 /*limit*/, const TString& /*exclusiveStartStreamName*/) final {
+        TListStreams streams;
+
+        with_lock (Mutex) {
+            streams.Names.reserve(Topics.size());
+            for (const auto& [name, _] : Topics) {
+                streams.Names.emplace_back(name);
+            }
+        }
+
+        return NThreading::MakeFuture<TListStreams>(std::move(streams));
     }
 
-    IPqGateway::TAsyncDescribeFederatedTopicResult DescribeFederatedTopic(const TString& /*sessionId*/, const TString& /*cluster*/, const TString& /*database*/, const TString& /*path*/, const TString& /*token*/) override {
+    IPqGateway::TAsyncDescribeFederatedTopicResult DescribeFederatedTopic(const TString& /*sessionId*/, const TString& /*cluster*/, const TString& /*database*/, const TString& /*path*/, const TString& /*token*/) final {
         return NThreading::MakeFuture<TDescribeFederatedTopicResult>(IPqGateway::TDescribeFederatedTopicResult{{
             .PartitionsCount = 1,
         }});
     }
 
-    void UpdateClusterConfigs(const TString& /*clusterName*/, const TString& /*endpoint*/, const TString& /*database*/, bool /*secure*/) override {
+    void UpdateClusterConfigs(const TString& /*clusterName*/, const TString& /*endpoint*/, const TString& /*database*/, bool /*secure*/) final {
     }
 
-    void UpdateClusterConfigs(const NYql::TPqGatewayConfigPtr& /*config*/) override {
+    void UpdateClusterConfigs(const NYql::TPqGatewayConfigPtr& /*config*/) final {
     }
 
-    NYql::ITopicClient::TPtr GetTopicClient(const NYdb::TDriver& /*driver*/, const NYdb::NTopic::TTopicClientSettings& /*settings*/) override {
+    NYql::ITopicClient::TPtr GetTopicClient(const NYdb::TDriver& /*driver*/, const NYdb::NTopic::TTopicClientSettings& /*settings*/) final {
         return MakeIntrusive<TMockTopicClient>(this);
     }
 
-    NYql::IFederatedTopicClient::TPtr GetFederatedTopicClient(const NYdb::TDriver& /*driver*/, const NYdb::NFederatedTopic::TFederatedTopicClientSettings& /*settings*/) override {
+    NYql::IFederatedTopicClient::TPtr GetFederatedTopicClient(const NYdb::TDriver& /*driver*/, const NYdb::NFederatedTopic::TFederatedTopicClientSettings& /*settings*/) final {
         return MakeIntrusive<TMockFederatedTopicClient>(this);
     }
 
-    NYdb::NFederatedTopic::TFederatedTopicClientSettings GetFederatedTopicClientSettings() const override {
+    NYdb::NFederatedTopic::TFederatedTopicClientSettings GetFederatedTopicClientSettings() const final {
         return NYdb::NFederatedTopic::TFederatedTopicClientSettings();
     }
 
-    NYdb::NTopic::TTopicClientSettings GetTopicClientSettings() const override {
+    NYdb::NTopic::TTopicClientSettings GetTopicClientSettings() const final {
         return NYdb::NTopic::TTopicClientSettings();
     }
 
-    void AddCluster(const NYql::TPqClusterConfig& /*cluster*/) override {
+    void AddCluster(const NYql::TPqClusterConfig& /*cluster*/) final {
     }
 
-    void AddEvent(const TString& topic, NYdb::NTopic::TReadSessionEvent::TEvent&& e, size_t size) override {
-        GetTopicInfo(topic).Queue->Push(std::move(e), size);
-    }
+    //// Mock API implementation
 
-    void AddEventProvider(const TString& topic, TEvGen evGen) override {
-        GetTopicInfo(topic).EvGen = evGen;
-    }
-
-    TWriteResult GetWriteSessionData(const TString& topic) override {
+    IMockPqReadSession::TPtr ExtractReadSession(const TString& topic) final {
         auto& info = GetTopicInfo(topic);
-        with_lock (info.Mutex) {
-            return std::move(info.WriteSessionData);
+        IMockPqReadSession::TPtr session;
+
+        with_lock (Mutex) {
+            session = info.ReadSession;
+            info.ReadSession = nullptr;
         }
+
+        return session;
+    }
+
+    IMockPqWriteSession::TPtr ExtractWriteSession(const TString& topic) final {
+        auto& info = GetTopicInfo(topic);
+        IMockPqWriteSession::TPtr session;
+
+        with_lock (Mutex) {
+            session = info.WriteSession;
+            info.WriteSession = nullptr;
+        }
+
+        return session;
     }
 
 private:
@@ -386,45 +526,45 @@ private:
         }
     }
 
+    std::shared_ptr<NYdb::NTopic::IReadSession> CreateReadSession(const std::string& topic) {
+        if (Runtime && Notifier) {
+            Runtime->Send(Notifier, NActors::TActorId(), new TEvMockPqEvents::TEvCreateSession());
+        }
+
+        const TString path(topic);
+        auto& info = GetTopicInfo(path);
+        auto session = std::make_shared<TMockPqReadSession>(path);
+
+        with_lock (Mutex) {
+            info.ReadSession = session;
+        }
+
+        return session;
+    }
+
+    std::shared_ptr<NYdb::NTopic::IWriteSession> CreateWriteSession(const std::string& topic) {
+        auto& info = GetTopicInfo(TString(topic));
+        auto session = std::make_shared<TMockPqWriteSession>();
+
+        with_lock (Mutex) {
+            info.WriteSession = session;
+        }
+
+        return session;
+    }
+
 private:
+    NActors::TTestActorRuntime* Runtime = nullptr;
+    const NActors::TActorId Notifier;
     TMutex Mutex;
     std::unordered_set<TString> Sessions;
     std::unordered_map<TString, TTopicInfo> Topics;
-    NActors::TTestActorRuntime* Runtime;
-    const NActors::TActorId Notifier;
 };
 
 }  // anonymous namespace
 
-NYdb::NTopic::TPartitionSession::TPtr CreatePartitionSession(const TString& path) {
-    return MakeIntrusive<TMockPartitionSession>(path);
-}
-
 TIntrusivePtr<IMockPqGateway> CreateMockPqGateway(const TMockPqGatewaySettings& settings) {
     return MakeIntrusive<TMockPqGateway>(settings);
-}
-
-NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent MakePqMessage(ui64 offset, const TString& data, const TMockPqSession& meta) {
-    const auto now = TInstant::Now();
-
-    return NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent({
-        NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TMessage(
-            data,
-            nullptr,
-            NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TMessageInformation(
-                offset,
-                "",
-                0,
-                now,
-                now,
-                MakeIntrusive<NYdb::NTopic::TWriteSessionMeta>(),
-                MakeIntrusive<NYdb::NTopic::TMessageMeta>(),
-                data.size(),
-                ""
-            ),
-            meta.Session
-        )
-    }, {}, meta.Session);
 }
 
 }  // namespace NTestUtils

--- a/ydb/library/testlib/pq_helpers/mock_pq_gateway.h
+++ b/ydb/library/testlib/pq_helpers/mock_pq_gateway.h
@@ -17,8 +17,58 @@ struct TEvMockPqEvents {
     struct TEvCreateSession : public NActors::TEventLocal<TEvCreateSession, EvCreateSession> {};
 };
 
-struct TMockPqSession {
-    NYdb::NTopic::TPartitionSession::TPtr Session;
+class IMockPqReadSession {
+public:
+    using TPtr = std::shared_ptr<IMockPqReadSession>;
+    using TEvGen = std::function<NYdb::NTopic::TReadSessionEvent::TEvent()>;
+
+    struct TMessage {
+        ui64 Offset;
+        TString Data;
+    };
+
+    virtual ~IMockPqReadSession() = default;
+
+    virtual NYdb::NTopic::TPartitionSession::TPtr GetPartitionSession() const = 0;
+
+    virtual void SetEventProvider(TEvGen evGen) = 0;
+
+    virtual void AddEvent(NYdb::NTopic::TReadSessionEvent::TEvent&& ev) = 0;
+
+    virtual void AddStartSessionEvent() = 0;
+
+    virtual void AddDataReceivedEvent(ui64 offset, const TString& data) = 0;
+
+    virtual void AddDataReceivedEvent(const std::vector<TMessage>& messages) = 0;
+
+    virtual void AddCloseSessionEvent(NYdb::EStatus status, NYdb::NIssue::TIssues issues = {}) = 0;
+};
+
+class IMockPqWriteSession {
+public:
+    using TPtr = std::shared_ptr<IMockPqWriteSession>;
+
+    virtual ~IMockPqWriteSession() = default;
+
+    virtual std::vector<TString> ExtractData() = 0;
+
+    virtual void Lock() = 0;
+
+    virtual void Unlock() = 0;
+};
+
+// Limitations:
+// - There is should be at most one query in flight for each topic
+// - Supported only single partition topics
+class IMockPqGateway : public NYql::IPqGateway {
+public:
+    using TPtr = TIntrusivePtr<IMockPqGateway>;
+
+    // Extract last created partition read session
+    virtual IMockPqReadSession::TPtr ExtractReadSession(const TString& topic) = 0;
+
+    // Extract last created partition write session
+    virtual IMockPqWriteSession::TPtr ExtractWriteSession(const TString& topic) = 0;
 };
 
 struct TMockPqGatewaySettings {
@@ -26,22 +76,6 @@ struct TMockPqGatewaySettings {
     NActors::TActorId Notifier;
 };
 
-class IMockPqGateway : public NYql::IPqGateway {
-public:
-    using TEvGen = std::function<NYdb::NTopic::TReadSessionEvent::TEvent(TMockPqSession)>;
-    using TWriteResult = std::vector<TString>;
-
-    virtual void AddEvent(const TString& topic, NYdb::NTopic::TReadSessionEvent::TEvent&& e, size_t size = 0) = 0;
-
-    virtual void AddEventProvider(const TString& topic, TEvGen evGen) = 0;
-
-    virtual TWriteResult GetWriteSessionData(const TString& topic) = 0;
-};
-
-NYdb::NTopic::TPartitionSession::TPtr CreatePartitionSession(const TString& path = "fake/path");
-
 TIntrusivePtr<IMockPqGateway> CreateMockPqGateway(const TMockPqGatewaySettings& settings = {});
-
-NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent MakePqMessage(ui64 offset, const TString& data, const TMockPqSession& meta);
 
 }  // namespace NTestUtils

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -113,6 +113,7 @@ protected: //TDqComputeActorChannels::ICalbacks
             Y_ABORT_UNLESS(inputChannel->CheckpointingMode != NDqProto::CHECKPOINTING_MODE_DISABLED);
             Y_ABORT_UNLESS(this->Checkpoints);
             const auto& checkpoint = channelData.Proto.GetCheckpoint();
+            auto guard = TBase::BindAllocator();
             inputChannel->Pause(checkpoint);
             this->Checkpoints->RegisterCheckpoint(checkpoint, channelData.Proto.GetChannelId());
         }

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_write_actor.cpp
@@ -1,27 +1,27 @@
 #include "dq_pq_write_actor.h"
 #include "probes.h"
 
-#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h>
-#include <ydb/library/yql/dq/actors/protos/dq_events.pb.h>
-#include <ydb/library/yql/dq/common/dq_common.h>
-#include <ydb/library/yql/dq/actors/compute/dq_checkpoints_states.h>
-
-#include <yql/essentials/utils/log/log.h>
-#include <yql/essentials/minikql/comp_nodes/mkql_saveload.h>
-#include <yql/essentials/minikql/mkql_alloc.h>
-#include <yql/essentials/minikql/mkql_string_util.h>
-#include <ydb/library/yql/providers/pq/proto/dq_io_state.pb.h>
-#include <yql/essentials/utils/yql_panic.h>
-
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/federated_topic/federated_topic.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h>
-
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
+#include <ydb/library/yql/dq/actors/compute/dq_checkpoints_states.h>
+#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h>
+#include <ydb/library/yql/dq/actors/protos/dq_events.pb.h>
+#include <ydb/library/yql/dq/common/dq_common.h>
+#include <ydb/library/yql/providers/pq/common/pq_events_processor.h>
+#include <ydb/library/yql/providers/pq/proto/dq_io_state.pb.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/federated_topic/federated_topic.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h>
+
+#include <yql/essentials/minikql/comp_nodes/mkql_saveload.h>
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/minikql/mkql_string_util.h>
+#include <yql/essentials/utils/log/log.h>
+#include <yql/essentials/utils/yql_panic.h>
+
 #include <library/cpp/lwtrace/mon/mon_lwtrace.h>
 
 #include <util/generic/algorithm.h>
@@ -78,6 +78,7 @@ struct TEvPrivate {
         EvBegin = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
 
         EvPqEventsReady = EvBegin,
+        EvExecuteTopicEvent,
 
         EvEnd
     };
@@ -87,15 +88,19 @@ struct TEvPrivate {
     // Events
 
     struct TEvPqEventsReady : public TEventLocal<TEvPqEventsReady, EvPqEventsReady> {};
+
+    struct TEvExecuteTopicEvent : public TTopicEventBase<TEvExecuteTopicEvent, EvExecuteTopicEvent> {
+        using TTopicEventBase::TTopicEventBase;
+    };
 };
 
 TString MakeStringForLog(const NDqProto::TCheckpoint& checkpoint) {
     return TStringBuilder() << "[Checkpoint " << checkpoint.GetGeneration() << "." << checkpoint.GetId() << "] ";
 }
 
-} // namespace
+} // anonymous namespace
 
-class TDqPqWriteActor : public NActors::TActor<TDqPqWriteActor>, public IDqComputeActorAsyncOutput {
+class TDqPqWriteActor : public NActors::TActor<TDqPqWriteActor>, public IDqComputeActorAsyncOutput, TTopicEventProcessor<TEvPrivate::TEvExecuteTopicEvent> {
     struct TMetrics {
         TMetrics(const TTxId& txId, ui64 taskId, const ::NMonitoring::TDynamicCounterPtr& counters)
             : TxId(std::visit([](auto arg) { return ToString(arg); }, txId))
@@ -282,6 +287,7 @@ public:
 private:
     STRICT_STFUNC(StateFunc,
         hFunc(TEvPrivate::TEvPqEventsReady, Handle);
+        hFunc(TEvPrivate::TEvExecuteTopicEvent, HandleTopicEvent);
     )
 
     void Handle(TEvPrivate::TEvPqEventsReady::TPtr&) {
@@ -329,8 +335,10 @@ private:
         return *FederatedTopicClient;
     }
 
-    NYdb::NFederatedTopic::TFederatedTopicClientSettings GetFederatedTopicClientSettings() const {
+    NYdb::NFederatedTopic::TFederatedTopicClientSettings GetFederatedTopicClientSettings() {
         NYdb::NFederatedTopic::TFederatedTopicClientSettings opts = PqGateway->GetFederatedTopicClientSettings();
+        SetupTopicClientSettings(ActorContext().ActorSystem(), SelfId(), opts);
+
         opts.Database(SinkParams.GetDatabase())
             .DiscoveryEndpoint(SinkParams.GetEndpoint())
             .SslCredentials(NYdb::TSslCredentials(SinkParams.GetUseSsl()))

--- a/ydb/library/yql/providers/pq/common/pq_events_processor.h
+++ b/ydb/library/yql/providers/pq/common/pq_events_processor.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/executor.h>
+
+namespace NYql {
+
+template <typename TEv, ui32 TEventType>
+class TTopicEventBase : public NActors::TEventLocal<TEv, TEventType> {
+public:
+    explicit TTopicEventBase(NYdb::NTopic::IExecutor::TFunction&& f)
+        : Function(std::move(f))
+    {}
+
+    void Execute() {
+        Function();
+    }
+
+private:
+    NYdb::NTopic::IExecutor::TFunction Function;
+};
+
+template <typename TTopicEvent>
+class TTopicEventProcessor {
+    class TEventProxy final : public NYdb::NTopic::IExecutor {
+    public:
+        TEventProxy(NActors::TActorSystem* actorSystem, const NActors::TActorId& executerId)
+            : ActorSystem(actorSystem)
+            , ExecuterId(executerId)
+        {
+            Y_ENSURE(actorSystem);
+        }
+
+        bool IsAsync() const final {
+            return true;
+        }
+
+        void Post(TFunction&& f) final {
+            ActorSystem->Send(ExecuterId, new TTopicEvent(std::move(f)));
+        }
+
+    private:
+        void DoStart() final {
+        }
+
+    private:
+        NActors::TActorSystem* ActorSystem = nullptr;
+        const NActors::TActorId ExecuterId;
+    };
+
+public:
+    template <typename TSettings>
+    void SetupTopicClientSettings(NActors::TActorSystem* actorSystem, const NActors::TActorId& selfId, TSettings& settings) {
+        if (!ExecuterProxy) {
+            ExecuterProxy = MakeIntrusive<TEventProxy>(actorSystem, selfId);
+        }
+
+        settings.DefaultHandlersExecutor(ExecuterProxy);
+        settings.DefaultCompressionExecutor(ExecuterProxy);
+    }
+
+protected:
+    void HandleTopicEvent(TTopicEvent::TPtr& event) {
+        event->Get()->Execute();
+    }
+
+private:
+    NYdb::NTopic::IExecutor::TPtr ExecuterProxy;
+};
+
+} // namespace NYql

--- a/ydb/library/yql/providers/pq/common/ya.make
+++ b/ydb/library/yql/providers/pq/common/ya.make
@@ -7,6 +7,8 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/library/actors/core
+    ydb/public/sdk/cpp/src/client/topic
     yql/essentials/public/types
 )
 

--- a/ydb/tests/tools/kqprun/configuration/app_config.conf
+++ b/ydb/tests/tools/kqprun/configuration/app_config.conf
@@ -215,8 +215,7 @@ QueryServiceConfig {
     ExternalStorage {
       Endpoint: "localhost:12345"
       Database: "/Root"
-      TablePrefix: "prefix"
-      UseSsl: true
+      TablePrefix: ".metadata/streaming/checkpoints"
       ClientTimeoutSec: 10
       OperationTimeoutSec: 10
       CancelAfterSec: 10
@@ -256,7 +255,7 @@ QueryServiceConfig {
         Endpoint: "localhost:12345"
         Database: "/Root"
       }
-      CoordinationNodePath: "coordinator"
+      CoordinationNodePath: ".metadata/streaming/row_dispatcher"
       LocalMode: true
     }
   }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Streaming in ydb fixes and features

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

* YQ-4682 fixed fault for checkpoint on not drained channels (#25515)
* YQ-4711 fixed test ReadTopicFailedWithoutAvailableExternalDataSourcesYdbTopics (#25619)
* YQ-4723 Use own driver in leader election (#25770)
* YQ-4664 used AS threads in topic sdk IO operations (#25668)

