### PR TITLE
EXT-1546 Fix monitoring race between shutdown and pages registration

### DIFF
--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1459,7 +1459,6 @@ std::future<void> TMon::Start(TActorSystem* actorSystem) {
 void TMon::Stop() {
     TGuard<TMutex> g(Mutex);
     if (ActorSystem) {
-        TGuard<TMutex> g(Mutex);
         for (const auto& [path, actorId] : ActorServices) {
             ActorSystem->Send(actorId, new TEvents::TEvPoisonPill);
         }

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1211,7 +1211,7 @@ public:
 // receives everyhing not related to actor communcation, converts them to request-actors
 class THttpMonIndexService : public TActor<THttpMonIndexService> {
 public:
-    THttpMonIndexService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring::TIndexMonPage> indexMonPage, 
+    THttpMonIndexService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring::TIndexMonPage> indexMonPage,
                          TMon::TRequestAuthorizer authorizer, const TString& redirectRoot = {}, bool needMonLegacyAudit = true)
         : TActor(&THttpMonIndexService::StateWork)
         , HttpProxyActorId(httpProxyActorId)
@@ -1345,6 +1345,10 @@ TMon::TMon(TConfig config)
 {
 }
 
+TMon::~TMon() {
+    IndexMonPage->ClearPages(); // it's required to avoid loop-reference
+}
+
 void TMon::RegisterLwtrace() {
     NLwTraceMonPage::RegisterPages(IndexMonPage.Get());
     NLwTraceMonPage::ProbeRegistry().AddProbesList(LWTRACE_GET_PROBES(ACTORLIB_PROVIDER));
@@ -1453,7 +1457,7 @@ std::future<void> TMon::Start(TActorSystem* actorSystem) {
 }
 
 void TMon::Stop() {
-    IndexMonPage->ClearPages(); // it's required to avoid loop-reference
+    TGuard<TMutex> g(Mutex);
     if (ActorSystem) {
         TGuard<TMutex> g(Mutex);
         for (const auto& [path, actorId] : ActorServices) {

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -42,7 +42,7 @@ public:
     };
 
     TMon(TConfig config);
-    virtual ~TMon() = default;
+    virtual ~TMon();
 
     std::future<void> Start(TActorSystem* actorSystem); // signals when monitoring is ready
     void Stop();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix race and use after free: https://github.com/ydb-platform/ydb/issues/25045

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

According to the stacks provided in issue https://github.com/ydb-platform/ydb/issues/25045
There was a parallel shutdown process and actor page registration.
Interconnect attempted to register its pages here: https://github.com/ydb-platform/ydb/blob/4f80ca1c62a8ca3646195341cae23f0704b28dd5/ydb/core/driver_lib/run/kikimr_services_initializers.cpp#L691 and we see that it allocates new pages through `TMon` and `TIndexMonPage` interfaces and assumes that the pages allocated by it are pointing to valid objects.

At the same time a ydbd process already stops here: https://github.com/ydb-platform/ydb/blob/4f80ca1c62a8ca3646195341cae23f0704b28dd5/ydb/core/driver_lib/run/run.cpp#L2008
It managed to clear the pages allocated by the interconnect actors here: https://github.com/ydb-platform/ydb/blob/4f80ca1c62a8ca3646195341cae23f0704b28dd5/ydb/core/mon/mon.cpp#L1462, so these pointers point to the freed objects.
