### PR TITLE
EXT-1423 added auth lwtrace

### DIFF
--- a/ydb/core/mon/audit/audit.cpp
+++ b/ydb/core/mon/audit/audit.cpp
@@ -108,7 +108,11 @@ bool TAuditCtx::AuditableRequest(const NHttp::THttpIncomingRequestPtr& request) 
     return true;
 }
 
-void TAuditCtx::InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev) {
+void TAuditCtx::InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev, bool needAudit) {
+    if (!(Auditable = needAudit)) {
+        return;
+    }
+
     const auto& request = ev->Get()->Request;
     const TString method(request->Method);
     const TString url(request->URL.Before('?'));

--- a/ydb/core/mon/audit/audit.h
+++ b/ydb/core/mon/audit/audit.h
@@ -22,7 +22,7 @@ enum ERequestStatus {
 
 class TAuditCtx {
 public:
-    void InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev);
+    void InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev, bool needAudit = true);
     void AddAuditLogParts(const TAuditParts& parts); // TODO: pass request context instead of audit log parts
     void LogAudit(ERequestStatus status, const TString& reason, NKikimrConfig::TAuditConfig::TLogClassConfig::ELogPhase logPhase);
     void LogOnReceived();

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -49,6 +49,7 @@ public:
 
     void Register(NMonitoring::IMonPage* page);
     NMonitoring::TIndexMonPage* RegisterIndexPage(const TString& path, const TString& title);
+    void RegisterLwtrace();
 
     struct TRegisterActorPageFields {
         TString Title;
@@ -95,6 +96,7 @@ protected:
     TActorSystem* ActorSystem = {};
     TActorId HttpProxyActorId;
     TActorId HttpMonServiceActorId;
+    TActorId HttpAuthMonServiceActorId;
     TActorId NodeProxyServiceActorId;
 
     struct TActorMonPageInfo {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Require `MonitoringAllowedSIDs` for the `/trace` endpoint authorization.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Problem**
The `lwtrace` endpoints currently requires no authorization.
The `lwtrace` interface is available through the Developer UI, which is not available for users without `MonitoringAllowedSIDs` list.
The issue was discovered while adding audit logs. Noticed that we don't populate `subject` field with the `userSID` for `/trace` endpoint.

**Limitations of lwtrace**
The `/trace` page is registered as an index page by calling `NLwTraceMonPage::RegisterPages(IndexMonPage.Get())`. Currently each type of endpoint has its own authorization with significant duplication, but index pages no authorization mechanism, and you cannot assign access rights during registration.

**Solution: Adding an index-paged service with handler authorization**
New instance of `THttpMonIndexService` service has been added. It is used to handle index pages that require authorization.
An index page path can be registered as an actor handler with the required permissions specified (currently added only for lwtrace). After authorization, the index page will be processed as before.

**Scope**
The changes affect only `/trace` handler and `/ydb/core/mon` service. 

<details><summary>audit log example</summary>
<p>

```
2025-09-17T16:58:41.309491Z: {"reason":"Execute","params":"mode=probes","sanitized_token":"ne1CvkBCh5hY2Nlc3N0b2tlbi1lMHRoMDNicjJ5a2pzYWo4OWMSIXVzZXJhY2NvdW50LWUwdHI3OGJjZ2Z6bng0eTQwOXM1Nhp_ChpzZXNzaW9uLWUwdHh6a3RrNzc3MnBudHl6MxAEGl8KGnNlc3Npb24tZTB0bm45YndhbnRrNjV0am1xEAQaPwoZc2VydmljZWFjY291bnQtZTB0aWFtLWNwbBADGiAKHHB1YmxpY2tleS1lMHRwdGNyMjNmMzR2aGdna3gQASoQbXZwLW9pZGMtdGVzdGluZzIMCMHRq8YGELHolZEBOgwIzYmtxgYQxPCOtQFIAloDZTB0.**","remote_address":"2a13:5947:111:20::cc7c:545b","method":"GET","status":"IN-PROCESS","subject":"tenantuseraccount-e0tg829s16770fh6qkha6@as","operation":"HTTP REQUEST","folder_id":"ydbui-e0tydb-testing-nebius-dev-container","url":"/trace","component":"monitoring"}
2025-09-17T16:58:41.322365Z: {"reason":"200 Ok","params":"mode=probes","sanitized_token":"ne1CvkBCh5hY2Nlc3N0b2tlbi1lMHRoMDNicjJ5a2pzYWo4OWMSIXVzZXJhY2NvdW50LWUwdHI3OGJjZ2Z6bng0eTQwOXM1Nhp_ChpzZXNzaW9uLWUwdHh6a3RrNzc3MnBudHl6MxAEGl8KGnNlc3Npb24tZTB0bm45YndhbnRrNjV0am1xEAQaPwoZc2VydmljZWFjY291bnQtZTB0aWFtLWNwbBADGiAKHHB1YmxpY2tleS1lMHRwdGNyMjNmMzR2aGdna3gQASoQbXZwLW9pZGMtdGVzdGluZzIMCMHRq8YGELHolZEBOgwIzYmtxgYQxPCOtQFIAloDZTB0.**","remote_address":"2a13:5947:111:20::cc7c:545b","method":"GET","status":"SUCCESS","subject":"tenantuseraccount-e0tg829s16770fh6qkha6@as","operation":"HTTP REQUEST","folder_id":"ydbui-e0tydb-testing-nebius-dev-container","url":"/trace","component":"monitoring"}
```

</p>
</details> 
