### PR TITLE
EXT-1423 audit trace merge stream-nb-25-1

### DIFF
--- a/ydb/core/mon/audit/audit.cpp
+++ b/ydb/core/mon/audit/audit.cpp
@@ -108,7 +108,11 @@ bool TAuditCtx::AuditableRequest(const NHttp::THttpIncomingRequestPtr& request) 
     return true;
 }
 
-void TAuditCtx::InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev) {
+void TAuditCtx::InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev, bool needAudit) {
+    if (!(Auditable = needAudit)) {
+        return;
+    }
+
     const auto& request = ev->Get()->Request;
     const TString method(request->Method);
     const TString url(request->URL.Before('?'));

--- a/ydb/core/mon/audit/audit.h
+++ b/ydb/core/mon/audit/audit.h
@@ -22,7 +22,7 @@ enum ERequestStatus {
 
 class TAuditCtx {
 public:
-    void InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev);
+    void InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev, bool needAudit = true);
     void AddAuditLogParts(const TAuditParts& parts); // TODO: pass request context instead of audit log parts
     void LogAudit(ERequestStatus status, const TString& reason, NKikimrConfig::TAuditConfig::TLogClassConfig::ELogPhase logPhase);
     void LogOnReceived();

--- a/ydb/core/mon/events_internal.h
+++ b/ydb/core/mon/events_internal.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <ydb/core/protos/mon.pb.h>
+
+namespace NMonitoring::NPrivate {
+
+struct TEvMon {
+    enum {
+        EvBegin = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+
+        EvMonitoringRequest = EvBegin,
+        EvMonitoringResponse,
+        EvRegisterHandler,
+        EvMonitoringCancelRequest,
+        EvCleanupProxy,
+
+        End
+    };
+
+    static_assert(End < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect End < EventSpaceEnd(TEvents::ES_PRIVATE)");
+
+    struct TEvMonitoringRequest : NActors::TEventPB<TEvMonitoringRequest, NKikimrMonProto::TEvMonitoringRequest, EvMonitoringRequest> {
+        TEvMonitoringRequest() = default;
+    };
+
+    struct TEvMonitoringResponse : NActors::TEventPB<TEvMonitoringResponse, NKikimrMonProto::TEvMonitoringResponse, EvMonitoringResponse> {
+        TEvMonitoringResponse() = default;
+    };
+
+    struct TEvRegisterHandler : NActors::TEventLocal<TEvRegisterHandler, EvRegisterHandler> {
+        NActors::TMon::TRegisterHandlerFields Fields;
+
+        TEvRegisterHandler(const NActors::TMon::TRegisterHandlerFields& fields)
+            : Fields(fields)
+        {}
+    };
+
+    struct TEvMonitoringCancelRequest : NActors::TEventPB<TEvMonitoringCancelRequest, NKikimrMonProto::TEvMonitoringCancelRequest, EvMonitoringCancelRequest> {
+        TEvMonitoringCancelRequest() = default;
+    };
+
+    struct TEvCleanupProxy : NActors::TEventLocal<TEvCleanupProxy, EvCleanupProxy> {
+        TString Address;
+
+        TEvCleanupProxy(const TString& address)
+            : Address(address)
+        {}
+    };
+};
+
+} // namespace NMonitoring::NPrivate

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -51,6 +51,7 @@ public:
 
     void Register(NMonitoring::IMonPage* page);
     NMonitoring::TIndexMonPage* RegisterIndexPage(const TString& path, const TString& title);
+    void RegisterLwtrace();
 
     struct TRegisterActorPageFields {
         TString Title;
@@ -97,6 +98,7 @@ protected:
     TActorSystem* ActorSystem = {};
     TActorId HttpProxyActorId;
     TActorId HttpMonServiceActorId;
+    TActorId HttpAuthMonServiceActorId;
     TActorId NodeProxyServiceActorId;
 
     struct TActorMonPageInfo {

--- a/ydb/core/mon/mon_ut.cpp
+++ b/ydb/core/mon/mon_ut.cpp
@@ -1,0 +1,353 @@
+#include <ydb/core/mon/mon.h>
+#include <ydb/core/mon/ut_utils/ut_utils.h>
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/testlib/test_client.h>
+
+#include <library/cpp/http/misc/httpcodes.h>
+#include <library/cpp/http/simple/http_client.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NMonitoring::NTests {
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::Tests;
+
+void GrantConnect(Tests::TClient& client) {
+    client.CreateUser("/Root", "username", "password");
+    client.GrantConnect("username");
+
+    const auto alterAttrsStatus = client.AlterUserAttributes("/", "Root", {
+        { "folder_id", "test_folder_id" },
+        { "database_id", "test_database_id" },
+    });
+    UNIT_ASSERT_EQUAL(alterAttrsStatus, NMsgBusProxy::MSTATUS_OK);
+}
+
+struct THttpMonTestEnvOptions {
+    enum class ERegKind {
+        None,
+        ActorPage,
+        ActorHandler,
+        MonPage,
+    };
+
+    ERegKind RegKind = ERegKind::None;
+    TVector<TString> ActorAllowedSIDs;
+    TVector<TString> TicketParserGroupSIDs = DEFAULT_TICKET_PARSER_GROUPS;
+    bool UseAuth = true;
+};
+
+class THttpMonTestEnv {
+public:
+    THttpMonTestEnv(const THttpMonTestEnvOptions& options = {})
+        : Port(PortManager.GetPort(2134))
+        , GrpcPort(PortManager.GetPort(2135))
+        , MonPort(PortManager.GetPort(8765))
+        , Settings(Port)
+        , Options(std::move(options))
+    {
+        Settings.InitKikimrRunConfig()
+            .SetNodeCount(1)
+            .SetUseRealThreads(true)
+            .SetDomainName("Root")
+            .SetUseSectorMap(true)
+            .SetMonitoringPortOffset(MonPort, true);
+
+        auto& securityConfig = *Settings.AppConfig->MutableDomainsConfig()->MutableSecurityConfig();
+        securityConfig.SetEnforceUserTokenCheckRequirement(true);
+        securityConfig.MutableMonitoringAllowedSIDs()->Add("ydb.clusters.monitor@as");
+
+        Settings.CreateTicketParser = [&](const TTicketParserSettings&) -> NActors::IActor* {
+            return TicketParser = new TFakeTicketParserActor(Options.TicketParserGroupSIDs);
+        };
+
+        Server = std::make_unique<TServer>(Settings);
+        Server->EnableGRpc(GrpcPort);
+        Client = std::make_unique<TClient>(Settings);
+        Client->InitRootScheme();
+        GrantConnect(*Client);
+
+        Runtime = Server->GetRuntime();
+
+        TMon* mon = Runtime->GetAppData().Mon;
+        UNIT_ASSERT(mon != nullptr);
+
+        switch (Options.RegKind) {
+            case THttpMonTestEnvOptions::ERegKind::None:
+                break;
+            case THttpMonTestEnvOptions::ERegKind::ActorPage: {
+                TestActorPage = new TTestActorPage();
+                TestActorId = Runtime->Register(TestActorPage);
+                mon->RegisterActorPage({
+                    .RelPath = TEST_MON_PATH,
+                    .ActorSystem = Runtime->GetActorSystem(0),
+                    .ActorId = TestActorId,
+                    .UseAuth = Options.UseAuth,
+                    .AllowedSIDs = Options.ActorAllowedSIDs,
+                });
+                break;
+            }
+            case THttpMonTestEnvOptions::ERegKind::ActorHandler: {
+                TestActorHandler = new TTestActorHandler();
+                TestActorId = Runtime->Register(TestActorHandler);
+                mon->RegisterActorHandler({
+                    .Path = MakeDefaultUrl(),
+                    .Handler = TestActorId,
+                    .UseAuth = Options.UseAuth,
+                    .AllowedSIDs = Options.ActorAllowedSIDs,
+                });
+                break;
+            }
+            case THttpMonTestEnvOptions::ERegKind::MonPage: {
+                mon->Register(new TTestMonPage());
+                break;
+            }
+        }
+
+        HttpClient = std::make_unique<TKeepAliveHttpClient>("localhost", MonPort);
+    }
+
+    TKeepAliveHttpClient::THeaders MakeAuthHeaders(const TString& token = VALID_TOKEN) const {
+        TKeepAliveHttpClient::THeaders headers;
+        headers[AUTHORIZATION_HEADER] = token;
+        return headers;
+    }
+
+    TString MakeDefaultUrl() const {
+        TStringBuilder url;
+        url << "/" << TEST_MON_PATH;
+        return url;
+    }
+
+    TFakeTicketParserActor* GetTicketParser() const {
+        UNIT_ASSERT(TicketParser);
+        return TicketParser;
+    }
+
+    TKeepAliveHttpClient& GetHttpClient() const {
+        return *HttpClient;
+    }
+
+private:
+    TPortManager PortManager;
+    ui16 Port;
+    ui16 GrpcPort;
+    ui16 MonPort;
+    TServerSettings Settings;
+    std::unique_ptr<TServer> Server;
+    std::unique_ptr<TClient> Client;
+    TTestActorRuntime* Runtime = nullptr;
+    TTestActorPage* TestActorPage = nullptr;
+    TTestActorHandler* TestActorHandler = nullptr;
+    TActorId TestActorId;
+    TFakeTicketParserActor* TicketParser = nullptr;
+    std::unique_ptr<TKeepAliveHttpClient> HttpClient;
+    THttpMonTestEnvOptions Options;
+};
+
+Y_UNIT_TEST_SUITE(ActorPage) {
+    Y_UNIT_TEST(HttpOk) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorPage,
+            .ActorAllowedSIDs = {"valid_group"},
+            .TicketParserGroupSIDs = {"valid_group"},
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders());
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_OK);
+
+        const TString response = responseStream.ReadAll();
+        UNIT_ASSERT_STRING_CONTAINS(response, TEST_RESPONSE);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 0);
+    }
+
+    Y_UNIT_TEST(NoValidGroupForbidden) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorPage,
+            .ActorAllowedSIDs = {"valid_group"},
+            .TicketParserGroupSIDs = {"wrong_group"},
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders());
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_FORBIDDEN);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 0);
+    }
+
+    Y_UNIT_TEST(InvalidTokenForbidden) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorPage,
+        });
+
+        TStringStream responseStream;
+        const TString invalidToken = TString("Bearer invalid");
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders(invalidToken));
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_FORBIDDEN);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 1);
+    }
+
+    Y_UNIT_TEST(NoUseAuthOk) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorPage,
+            .UseAuth = false,
+        });
+
+        TStringStream responseStream;
+        const TString invalidToken = TString("Bearer invalid");
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders(invalidToken));
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_OK);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 0);
+    }
+
+    Y_UNIT_TEST(OptionsNoContent) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorPage,
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoRequest("OPTIONS", env.MakeDefaultUrl(), "", &responseStream);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_NO_CONTENT);
+    }
+}
+
+Y_UNIT_TEST_SUITE(ActorHandler) {
+    Y_UNIT_TEST(HttpOk) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorHandler,
+            .ActorAllowedSIDs = {"valid_group"},
+            .TicketParserGroupSIDs = {"valid_group"},
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders());
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_OK);
+
+        const TString response = responseStream.ReadAll();
+        UNIT_ASSERT_STRING_CONTAINS(response, TEST_RESPONSE);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 0);
+    }
+
+    Y_UNIT_TEST(NoValidGroupForbidden) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorHandler,
+            .ActorAllowedSIDs = {"valid_group"},
+            .TicketParserGroupSIDs = {"wrong_group"},
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders());
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_FORBIDDEN);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 0);
+    }
+
+    Y_UNIT_TEST(InvalidTokenForbidden) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorHandler,
+        });
+
+        TStringStream responseStream;
+        const TString invalidToken = TString("Bearer invalid");
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders(invalidToken));
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_FORBIDDEN);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 1);
+    }
+
+    Y_UNIT_TEST(NoUseAuthOk) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorHandler,
+            .UseAuth = false,
+        });
+
+        TStringStream responseStream;
+        const TString invalidToken = TString("Bearer invalid");
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders(invalidToken));
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_OK);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 0);
+    }
+
+    Y_UNIT_TEST(OptionsNoContent) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::ActorHandler,
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoRequest("OPTIONS", env.MakeDefaultUrl(), "", &responseStream);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_NO_CONTENT);
+    }
+}
+
+Y_UNIT_TEST_SUITE(MonPage) {
+    Y_UNIT_TEST(HttpOk) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoGet(env.MakeDefaultUrl(), &responseStream, env.MakeAuthHeaders());
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_OK);
+
+        const TString response = responseStream.ReadAll();
+        UNIT_ASSERT_STRING_CONTAINS(response, TEST_RESPONSE);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 0);
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 0);
+    }
+
+    Y_UNIT_TEST(OptionsNoContent) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoRequest("OPTIONS", env.MakeDefaultUrl(), "", &responseStream);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_NO_CONTENT);
+    }
+}
+
+Y_UNIT_TEST_SUITE(Other) {
+    Y_UNIT_TEST(UnknownPathNotFound) {
+        THttpMonTestEnv env;
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoGet("/wrong_path", &responseStream, env.MakeAuthHeaders());
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_NOT_FOUND);
+    }
+}
+
+} // namespace NMonitoring::NTests

--- a/ydb/core/mon/ut/ya.make
+++ b/ydb/core/mon/ut/ya.make
@@ -1,0 +1,21 @@
+UNITTEST_FOR(ydb/core/mon)
+
+FORK_SUBTESTS()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    ydb/core/mon
+    ydb/core/mon/ut_utils
+    ydb/core/testlib/default
+    ydb/library/aclib
+    ydb/library/actors/core
+)
+
+SRCS(
+    mon_ut.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/mon/ut_utils/ut_utils.cpp
+++ b/ydb/core/mon/ut_utils/ut_utils.cpp
@@ -1,0 +1,133 @@
+#include "ut_utils.h"
+
+#include <library/cpp/http/misc/httpcodes.h>
+
+namespace NMonitoring::NTests {
+
+using namespace NActors;
+using namespace NKikimr;
+
+const TString TEST_MON_PATH = "test_mon";
+const TString TEST_RESPONSE = "Test actor";
+const TString AUTHORIZATION_HEADER = "Authorization";
+const TString VALID_TOKEN = "Bearer token";
+const TVector<TString> DEFAULT_TICKET_PARSER_GROUPS = {"group_name"};
+
+void TTestActorPage::Bootstrap() {
+    Become(&TTestActorPage::StateWork);
+}
+
+void TTestActorPage::Handle(NMon::TEvHttpInfo::TPtr& ev) {
+    TStringBuilder body;
+    body << "<html><body><p>" << TEST_RESPONSE << "</p></body></html>";
+    Send(ev->Sender, new NMon::TEvHttpInfoRes(body));
+}
+
+void TTestActorHandler::Bootstrap() {
+    Become(&TTestActorHandler::StateWork);
+}
+
+void TTestActorHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev) {
+    TStringBuilder body;
+    body << "<html><body><p>" << TEST_RESPONSE << "</p></body></html>";
+
+    TStringBuilder response;
+    response << "HTTP/1.1 200 OK\r\n"
+                << "Content-Type: text/html\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "Connection: Close\r\n\r\n"
+                << body;
+
+    Send(ev->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(
+        ev->Get()->Request->CreateResponseString(response)));
+}
+
+TTestMonPage::TTestMonPage()
+    : NMonitoring::IMonPage(TEST_MON_PATH, TString("Test Page"))
+{
+}
+
+void TTestMonPage::Output(NMonitoring::IMonHttpRequest& request) {
+    const TStringBuf pathInfo = request.GetPathInfo();
+    if (!pathInfo.empty() && pathInfo != TStringBuf("/")) {
+        request.Output() << NMonitoring::HTTPNOTFOUND;
+        return;
+    }
+
+    auto& out = request.Output();
+    out << NMonitoring::HTTPOKHTML;
+    out << "<html><body><p>" << TEST_RESPONSE << "</p></body></html>";
+}
+
+TFakeTicketParserActor::TFakeTicketParserActor(TVector<TString> groupSIDs)
+    : TActor<TFakeTicketParserActor>(&TFakeTicketParserActor::StateFunc)
+    , GroupSIDs(std::move(groupSIDs))
+{}
+
+void TFakeTicketParserActor::Handle(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
+    LOG_INFO_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, "Ticket parser: got TEvAuthorizeTicket event: " << ev->Get()->Ticket << " " << ev->Get()->Database << " " << ev->Get()->Entries.size());
+    ++AuthorizeTicketRequests;
+
+    if (ev->Get()->Database != "/Root") {
+        Fail(ev, TStringBuilder() << "Incorrect database " << ev->Get()->Database);
+        return;
+    }
+
+    if (ev->Get()->Ticket != VALID_TOKEN) {
+        Fail(ev, TStringBuilder() << "Incorrect token " << ev->Get()->Ticket);
+        return;
+    }
+
+    bool databaseIdFound = false;
+    bool folderIdFound = false;
+    for (const TEvTicketParser::TEvAuthorizeTicket::TEntry& entry : ev->Get()->Entries) {
+        for (const std::pair<TString, TString>& attr : entry.Attributes) {
+            if (attr.first == "database_id") {
+                databaseIdFound = true;
+                if (attr.second != "test_database_id") {
+                    Fail(ev, TStringBuilder() << "Incorrect database_id " << attr.second);
+                    return;
+                }
+            } else if (attr.first == "folder_id") {
+                folderIdFound = true;
+                if (attr.second != "test_folder_id") {
+                    Fail(ev, TStringBuilder() << "Incorrect folder_id " << attr.second);
+                    return;
+                }
+            }
+        }
+    }
+    if (!databaseIdFound) {
+        Fail(ev, "database_id not found");
+        return;
+    }
+    if (!folderIdFound) {
+        Fail(ev, "folder_id not found");
+        return;
+    }
+
+    Success(ev);
+}
+
+void TFakeTicketParserActor::Fail(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev, const TString& message) {
+    ++AuthorizeTicketFails;
+    TEvTicketParser::TError err;
+    err.Retryable = false;
+    err.Message = message ? message : "Test error";
+    LOG_INFO_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER,
+        "Send TEvAuthorizeTicketResult: " << err.Message);
+    Send(ev->Sender, new TEvTicketParser::TEvAuthorizeTicketResult(ev->Get()->Ticket, err));
+}
+
+void TFakeTicketParserActor::Success(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
+    ++AuthorizeTicketSuccesses;
+    NACLib::TUserToken::TUserTokenInitFields args;
+    args.UserSID = "username";
+    args.GroupSIDs = GroupSIDs;
+    TIntrusivePtr<NACLib::TUserToken> userToken = MakeIntrusive<NACLib::TUserToken>(args);
+    LOG_INFO_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER,
+        "Send TEvAuthorizeTicketResult success");
+    Send(ev->Sender, new TEvTicketParser::TEvAuthorizeTicketResult(ev->Get()->Ticket, userToken));
+}
+
+} // namespace NMonitoring::NTests

--- a/ydb/core/mon/ut_utils/ut_utils.h
+++ b/ydb/core/mon/ut_utils/ut_utils.h
@@ -1,0 +1,74 @@
+#include <ydb/core/base/ticket_parser.h>
+#include <ydb/core/security/ticket_parser_settings.h>
+
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/http/http_proxy.h>
+
+namespace NMonitoring::NTests {
+
+using namespace NActors;
+using namespace NKikimr;
+
+extern const TString TEST_MON_PATH;
+extern const TString TEST_RESPONSE;
+extern const TString AUTHORIZATION_HEADER;
+extern const TString VALID_TOKEN;
+extern const TVector<TString> DEFAULT_TICKET_PARSER_GROUPS;
+
+class TTestActorPage : public TActorBootstrapped<TTestActorPage> {
+public:
+    void Bootstrap();
+
+private:
+    void Handle(NMon::TEvHttpInfo::TPtr& ev);
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NMon::TEvHttpInfo, Handle);
+        }
+    }
+};
+
+class TTestActorHandler : public TActorBootstrapped<TTestActorHandler> {
+public:
+    void Bootstrap();
+
+private:
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev);
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+        }
+    }
+};
+
+class TTestMonPage : public NMonitoring::IMonPage {
+public:
+    TTestMonPage();
+    void Output(NMonitoring::IMonHttpRequest& request) override;
+};
+
+struct TFakeTicketParserActor : public TActor<TFakeTicketParserActor> {
+    TFakeTicketParserActor(TVector<TString> groupSIDs);
+    void Handle(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev);
+    void Fail(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev, const TString& message);
+    void Success(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev);
+
+    size_t AuthorizeTicketRequests = 0;
+    size_t AuthorizeTicketSuccesses = 0;
+    size_t AuthorizeTicketFails = 0;
+    TVector<TString> GroupSIDs;
+
+    STFUNC(StateFunc) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvTicketParser::TEvAuthorizeTicket, Handle);
+            default:
+                break;
+        }
+    }
+};
+
+} // namespace NMonitoring::NTests

--- a/ydb/core/mon/ut_utils/ya.make
+++ b/ydb/core/mon/ut_utils/ya.make
@@ -1,0 +1,14 @@
+LIBRARY()
+
+SRCS(
+    ut_utils.cpp
+)
+
+PEERDIR(
+    ydb/core/protos
+    ydb/library/aclib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/mon/ya.make
+++ b/ydb/core/mon/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    events_internal.h
     mon.cpp
     mon.h
     crossref.cpp
@@ -25,3 +26,12 @@ PEERDIR(
 )
 
 END()
+
+RECURSE(
+    audit
+    ut_utils
+)
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/core/viewer/ut/ya.make
+++ b/ydb/core/viewer/ut/ya.make
@@ -16,6 +16,8 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/mon
+    ydb/core/mon/ut_utils
     library/cpp/http/misc
     library/cpp/http/simple
     ydb/core/testlib/default

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1,4 +1,6 @@
 #include "ut/ut_utils.h"
+#include <ydb/core/mon/ut_utils/ut_utils.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/testing/unittest/tests_data.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
@@ -35,6 +37,7 @@ using namespace NKikimrWhiteboard;
 using namespace NSchemeShard;
 using namespace Tests;
 using namespace NMonitoring;
+using namespace NMonitoring::NTests;
 using namespace NKikimr::NViewerTests;
 using TNavigate = NSchemeCache::TSchemeCacheNavigate;
 
@@ -420,90 +423,9 @@ Y_UNIT_TEST_SUITE(Viewer) {
 #endif
     }
 
-    struct TFakeTicketParserActor : public TActor<TFakeTicketParserActor> {
-        TFakeTicketParserActor()
-            : TActor<TFakeTicketParserActor>(&TFakeTicketParserActor::StFunc)
-        {}
-
-        STFUNC(StFunc) {
-            switch (ev->GetTypeRewrite()) {
-                hFunc(TEvTicketParser::TEvAuthorizeTicket, Handle);
-                default:
-                    break;
-            }
-        }
-
-        void Handle(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
-            LOG_INFO_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, "Ticket parser: got TEvAuthorizeTicket event: " << ev->Get()->Ticket << " " << ev->Get()->Database << " " << ev->Get()->Entries.size());
-            ++AuthorizeTicketRequests;
-
-            if (ev->Get()->Database != "/Root") {
-                Fail(ev, TStringBuilder() << "Incorrect database " << ev->Get()->Database);
-                return;
-            }
-
-            if (ev->Get()->Ticket != "test_ydb_token") {
-                Fail(ev, TStringBuilder() << "Incorrect token " << ev->Get()->Ticket);
-                return;
-            }
-
-            bool databaseIdFound = false;
-            bool folderIdFound = false;
-            for (const TEvTicketParser::TEvAuthorizeTicket::TEntry& entry : ev->Get()->Entries) {
-                for (const std::pair<TString, TString>& attr : entry.Attributes) {
-                    if (attr.first == "database_id") {
-                        databaseIdFound = true;
-                        if (attr.second != "test_database_id") {
-                            Fail(ev, TStringBuilder() << "Incorrect database_id " << attr.second);
-                            return;
-                        }
-                    } else if (attr.first == "folder_id") {
-                        folderIdFound = true;
-                        if (attr.second != "test_folder_id") {
-                            Fail(ev, TStringBuilder() << "Incorrect folder_id " << attr.second);
-                            return;
-                        }
-                    }
-                }
-            }
-            if (!databaseIdFound) {
-                Fail(ev, "database_id not found");
-                return;
-            }
-            if (!folderIdFound) {
-                Fail(ev, "folder_id not found");
-                return;
-            }
-
-            Success(ev);
-        }
-
-        void Fail(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev, const TString& message) {
-            ++AuthorizeTicketFails;
-            TEvTicketParser::TError err;
-            err.Retryable = false;
-            err.Message = message ? message : "Test error";
-            LOG_INFO_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, "Send TEvAuthorizeTicketResult: " << err.Message);
-            Send(ev->Sender, new TEvTicketParser::TEvAuthorizeTicketResult(ev->Get()->Ticket, err));
-        }
-
-        void Success(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
-            ++AuthorizeTicketSuccesses;
-            NACLib::TUserToken::TUserTokenInitFields args;
-            args.UserSID = "username";
-            args.GroupSIDs.push_back("group_name");
-            TIntrusivePtr<NACLib::TUserToken> userToken = MakeIntrusive<NACLib::TUserToken>(args);
-            LOG_INFO_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, "Send TEvAuthorizeTicketResult success");
-            Send(ev->Sender, new TEvTicketParser::TEvAuthorizeTicketResult(ev->Get()->Ticket, userToken));
-        }
-
-        size_t AuthorizeTicketRequests = 0;
-        size_t AuthorizeTicketSuccesses = 0;
-        size_t AuthorizeTicketFails = 0;
-    };
 
     IActor* CreateFakeTicketParser(const TTicketParserSettings&) {
-        return new TFakeTicketParserActor();
+        return new TFakeTicketParserActor({"group_name"});
     }
 
     struct TPostQueryArguments {
@@ -537,7 +459,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoPost("/viewer/query?timeout=600000", NJson::WriteJson(jsonRequest, false), &responseStream, headers);
         UNIT_ASSERT_EQUAL(statusCode, HTTP_OK);
         return NJson::ReadJsonTree(&responseStream, /* throwOnError = */ true);
@@ -1712,7 +1634,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         TString requestBody = R"json({
             "query": "SELECT cast('311111111113.222222223' as Double);",
             "database": "/Root",
@@ -1756,8 +1678,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
 
         TFakeTicketParserActor* ticketParser = nullptr;
         settings.CreateTicketParser = [&](const TTicketParserSettings&) -> IActor* {
-            ticketParser = new TFakeTicketParserActor();
-            return ticketParser;
+            return ticketParser = new TFakeTicketParserActor({"group_name"});
         };
 
         TServer server(settings);
@@ -1775,7 +1696,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         TString requestBody = R"json({
             "query": "SELECT 42;",
             "database": "/Root",
@@ -1838,7 +1759,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoPost(TStringBuilder()
                                                             << "/query/script/execute?timeout=600000"
                                                             << "&database=%2FRoot", requestBody.Str(), &responseStream, headers);
@@ -1852,7 +1773,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         id = std::regex_replace(id.c_str(), std::regex("/"), "%2F");
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoGet(TStringBuilder()
                                                             << "/operation/get?timeout=600000&id=" << id
@@ -1868,7 +1789,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoGet(TStringBuilder()
                                                             << "/operation/list?timeout=600000&kind=scriptexec"
                                                             << "&database=%2FRoot", &responseStream, headers);
@@ -1883,7 +1804,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         id = std::regex_replace(id.c_str(), std::regex("/"), "%2F");
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoGet(TStringBuilder()
                                                             << "/query/script/fetch?timeout=600000&operation_id=" << id
@@ -2001,7 +1922,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoPost("/viewer/plan2svg", tinyPlan, &responseStream, headers);
         const TString response = responseStream.ReadAll();
         UNIT_ASSERT_EQUAL_C(statusCode, HTTP_OK, statusCode << ": " << response);
@@ -2055,7 +1976,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["Authorization"] = "test_ydb_token";
+        headers["Authorization"] = VALID_TOKEN;
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoPost("/viewer/plan2svg", brokenPlan, &responseStream, headers);
         const TString response = responseStream.ReadAll();
         UNIT_ASSERT_EQUAL_C(statusCode, HTTP_BAD_REQUEST, statusCode << ": " << response);


### PR DESCRIPTION
- EXT-1540 added basic monitoring tests (#25538)
- EXT-1423 added auth lwtrace (#25924)

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Problem**
The `lwtrace` endpoints currently requires no authorization.
The `lwtrace` interface is available through the Developer UI, which is not available for users without `MonitoringAllowedSIDs` list.
The issue was discovered while adding audit logs. Noticed that we don't populate `subject` field with the `userSID` for `/trace` endpoint.

**Limitations of lwtrace**
The `/trace` page is registered as an index page by calling `NLwTraceMonPage::RegisterPages(IndexMonPage.Get())`. Currently each type of endpoint has its own authorization with significant duplication, but index pages no authorization mechanism, and you cannot assign access rights during registration.

**Solution: Adding an index-paged service with handler authorization**
New instance of `THttpMonIndexService` service has been added. It is used to handle index pages that require authorization.
An index page path can be registered as an actor handler with the required permissions specified (currently added only for lwtrace). After authorization, the index page will be processed as before.

**Scope**
The changes affect only `/trace` handler and `/ydb/core/mon` service. 

<details><summary>audit log example</summary>
<p>

```
2025-09-17T16:58:41.309491Z: {"reason":"Execute","params":"mode=probes","sanitized_token":"ne1CvkBCh5hY2Nlc3N0b2tlbi1lMHRoMDNicjJ5a2pzYWo4OWMSIXVzZXJhY2NvdW50LWUwdHI3OGJjZ2Z6bng0eTQwOXM1Nhp_ChpzZXNzaW9uLWUwdHh6a3RrNzc3MnBudHl6MxAEGl8KGnNlc3Npb24tZTB0bm45YndhbnRrNjV0am1xEAQaPwoZc2VydmljZWFjY291bnQtZTB0aWFtLWNwbBADGiAKHHB1YmxpY2tleS1lMHRwdGNyMjNmMzR2aGdna3gQASoQbXZwLW9pZGMtdGVzdGluZzIMCMHRq8YGELHolZEBOgwIzYmtxgYQxPCOtQFIAloDZTB0.**","remote_address":"2a13:5947:111:20::cc7c:545b","method":"GET","status":"IN-PROCESS","subject":"tenantuseraccount-e0tg829s16770fh6qkha6@as","operation":"HTTP REQUEST","folder_id":"ydbui-e0tydb-testing-nebius-dev-container","url":"/trace","component":"monitoring"}
2025-09-17T16:58:41.322365Z: {"reason":"200 Ok","params":"mode=probes","sanitized_token":"ne1CvkBCh5hY2Nlc3N0b2tlbi1lMHRoMDNicjJ5a2pzYWo4OWMSIXVzZXJhY2NvdW50LWUwdHI3OGJjZ2Z6bng0eTQwOXM1Nhp_ChpzZXNzaW9uLWUwdHh6a3RrNzc3MnBudHl6MxAEGl8KGnNlc3Npb24tZTB0bm45YndhbnRrNjV0am1xEAQaPwoZc2VydmljZWFjY291bnQtZTB0aWFtLWNwbBADGiAKHHB1YmxpY2tleS1lMHRwdGNyMjNmMzR2aGdna3gQASoQbXZwLW9pZGMtdGVzdGluZzIMCMHRq8YGELHolZEBOgwIzYmtxgYQxPCOtQFIAloDZTB0.**","remote_address":"2a13:5947:111:20::cc7c:545b","method":"GET","status":"SUCCESS","subject":"tenantuseraccount-e0tg829s16770fh6qkha6@as","operation":"HTTP REQUEST","folder_id":"ydbui-e0tydb-testing-nebius-dev-container","url":"/trace","component":"monitoring"}
```

</p>
</details> 
