### PR TITLE
Added wide dates and decimals support for s3:parquet (#25186)

### DIFF
--- a/ydb/library/yql/providers/s3/actors/ya.make
+++ b/ydb/library/yql/providers/s3/actors/ya.make
@@ -29,11 +29,9 @@ PEERDIR(
     ydb/core/base
     ydb/core/fq/libs/events
     ydb/library/yql/dq/actors/compute
-    yql/essentials/minikql/computation
     ydb/library/yql/providers/common/arrow
     ydb/library/yql/providers/common/arrow/interface
     ydb/library/yql/providers/common/http_gateway
-    yql/essentials/providers/common/schema/mkql
     ydb/library/yql/providers/common/token_accessor/client
     ydb/library/yql/providers/generic/pushdown
     ydb/library/yql/providers/s3/actors_factory
@@ -44,9 +42,12 @@ PEERDIR(
     ydb/library/yql/providers/s3/object_listers
     ydb/library/yql/providers/s3/proto
     ydb/library/yql/providers/s3/range_helpers
+    ydb/library/yql/udfs/common/clickhouse/client
+    yql/essentials/minikql
+    yql/essentials/minikql/computation
+    yql/essentials/providers/common/schema/mkql
     yql/essentials/public/issue
     yql/essentials/public/types
-    ydb/library/yql/udfs/common/clickhouse/client
     yql/essentials/utils
 )
 

--- a/ydb/library/yql/providers/s3/actors/yql_arrow_column_converters.h
+++ b/ydb/library/yql/providers/s3/actors/yql_arrow_column_converters.h
@@ -35,7 +35,7 @@ std::shared_ptr<arrow::RecordBatch> ConvertArrowColumns(
     std::shared_ptr<arrow::RecordBatch> batch,
     std::vector<TColumnConverter>& columnConverters);
 
-bool S3ConvertArrowOutputType(NUdf::EDataSlot slot, std::shared_ptr<arrow::DataType>& type);
+bool S3ConvertArrowOutputType(NUdf::EDataSlot slot, std::shared_ptr<arrow::DataType>& type, NKikimr::NMiniKQL::TType* itemType = nullptr);
 bool S3ConvertArrowOutputType(NKikimr::NMiniKQL::TType* itemType, std::shared_ptr<arrow::DataType>& type);
 
 void BuildOutputColumnConverters(

--- a/ydb/library/yql/providers/s3/common/util.cpp
+++ b/ydb/library/yql/providers/s3/common/util.cpp
@@ -34,6 +34,20 @@ struct TTypeError {
     TString Error = "unsupported type";
 };
 
+std::optional<TTypeError> ValidateIoDataType(const TDataExprType* type, std::vector<EDataSlot> extraTypes = {}) {
+    const auto dataSlot = type->GetSlot();
+    if (IsDataTypeBigDate(dataSlot)) {
+        return TTypeError{type, "big dates is not supported"};
+    }
+    if (IsDataTypeNumeric(dataSlot) || IsDataTypeDateOrTzDate(dataSlot)) {
+        return std::nullopt;
+    }
+    if (IsIn({EDataSlot::Bool, EDataSlot::String, EDataSlot::Utf8, EDataSlot::Json, EDataSlot::Uuid}, dataSlot) || IsIn(extraTypes, dataSlot)) {
+        return std::nullopt;
+    }
+    return TTypeError{type};
+}
+
 // Type compatible with Yson2.From and Yson2.ConvertTo udfs
 std::optional<TTypeError> ValidateJsonListIoType(const TTypeAnnotationNode* type) {
     switch (type->GetKind()) {
@@ -99,18 +113,53 @@ std::optional<TTypeError> ValidateJsonListIoType(const TTypeAnnotationNode* type
     return TTypeError{type};
 }
 
-std::optional<TTypeError> ValidateIoDataType(const TDataExprType* type, std::vector<EDataSlot> extraTypes = {}) {
-    const auto dataSlot = type->GetSlot();
-    if (IsDataTypeBigDate(dataSlot)) {
-        return TTypeError{type, "big dates is not supported"};
-    }
-    if (IsDataTypeNumeric(dataSlot) || IsDataTypeDateOrTzDate(dataSlot)) {
-        return std::nullopt;
-    }
-    if (IsIn({EDataSlot::Bool, EDataSlot::String, EDataSlot::Utf8, EDataSlot::Json, EDataSlot::Uuid}, dataSlot) || IsIn(extraTypes, dataSlot)) {
-        return std::nullopt;
+std::optional<TTypeError> ValidateParquetIoType(const TTypeAnnotationNode* type, bool underOptional = false) {
+    switch (type->GetKind()) {
+        case ETypeAnnotationKind::Data: {
+            const auto dataSlot = type->Cast<TDataExprType>()->GetSlot();
+            if (IsDataTypeNumeric(dataSlot) || IsDataTypeDateOrTzDate(dataSlot) || IsDataTypeDecimal(dataSlot) || IsDataTypeBigDate(dataSlot)) {
+                return std::nullopt;
+            }
+            if (IsIn({EDataSlot::Bool, EDataSlot::String, EDataSlot::Utf8, EDataSlot::Json, EDataSlot::Uuid}, dataSlot)) {
+                return std::nullopt;
+            }
+            return TTypeError{type};
+        }
+        case ETypeAnnotationKind::Optional: {
+            if (underOptional) {
+                return TTypeError{type, "double optional is not supported"};
+            }
+            return ValidateParquetIoType(type->Cast<TOptionalExprType>()->GetItemType(), true);
+        }
+        case ETypeAnnotationKind::List: {
+            if (underOptional) {
+                return TTypeError{type, "list under optional is not supported"};
+            }
+            return ValidateIoDataType(type->Cast<TDataExprType>());
+        }
+        case ETypeAnnotationKind::Tuple: {
+            if (underOptional) {
+                return TTypeError{type, "tuple under optional is not supported"};
+            }
+            for (const auto* item : type->Cast<TTupleExprType>()->GetItems()) {
+                if (const auto error = ValidateIoDataType(item->Cast<TDataExprType>())) {
+                    return error;
+                }
+            }
+            return std::nullopt;
+        }
+        case ETypeAnnotationKind::Pg: {
+            return std::nullopt;
+        }
+        default: {
+            break;
+        }
     }
     return TTypeError{type};
+}
+
+std::optional<TTypeError> ValidateParquetOutputType(const TTypeAnnotationNode* type) {
+    return ValidateParquetIoType(type);
 }
 
 // Data type compatible with ClickHouseClient.ParseBlocks udf and S3 coro read actor
@@ -225,6 +274,10 @@ bool ValidateS3WriteSchema(TPositionHandle pos, std::string_view format, const T
 
     if (format == "json_list"sv) {
         return ValidateIoSchema(pos, schemaStructRowType, "S3 json_list output format", ctx, &ValidateJsonListIoType);
+    }
+
+    if (format == "parquet"sv) {
+        return ValidateIoSchema(pos, schemaStructRowType, "S3 parquet output format", ctx, &ValidateParquetOutputType);
     }
 
     return ValidateIoSchema(pos, schemaStructRowType, TStringBuilder() << "S3 " << format << " output format", ctx, [](const TTypeAnnotationNode* type) {

--- a/ydb/tests/fq/s3/test_format_setting.py
+++ b/ydb/tests/fq/s3/test_format_setting.py
@@ -1680,10 +1680,12 @@ Pear;15;33'''
             '''
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
-        client.wait_query_status(query_id, fq.QueryMeta.FAILED)
-        describe_result = client.describe_query(query_id).result
-        issues = describe_result.query.issue
-        assert "millisecond accuracy does not fit into the datetime" in str(issues)
+        client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
+        data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
+        assert len(rows) == 1, "invalid count rows"
+        assert rows[0].items[0].text_value == "apple"
+        assert rows[0].items[1].bytes_value == b"2024-04-02T12:01:00Z"
 
         # timestamp[us] -> Timestamp
 
@@ -1698,10 +1700,12 @@ Pear;15;33'''
         s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
-        client.wait_query_status(query_id, fq.QueryMeta.FAILED)
-        describe_result = client.describe_query(query_id).result
-        issues = describe_result.query.issue
-        assert "microsecond accuracy does not fit into the datetime" in str(issues)
+        client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
+        data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
+        assert len(rows) == 1, "invalid count rows"
+        assert rows[0].items[0].text_value == "apple"
+        assert rows[0].items[1].bytes_value == b"2024-04-02T12:01:00Z"
 
         # timestamp[s] -> Timestamp
 
@@ -1716,10 +1720,12 @@ Pear;15;33'''
         s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
-        client.wait_query_status(query_id, fq.QueryMeta.FAILED)
-        describe_result = client.describe_query(query_id).result
-        issues = describe_result.query.issue
-        assert "millisecond accuracy does not fit into the datetime" in str(issues)
+        client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
+        data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
+        assert len(rows) == 1, "invalid count rows"
+        assert rows[0].items[0].text_value == "apple"
+        assert rows[0].items[1].bytes_value == b"2024-04-02T12:01:00Z"
 
         # timestamp[ns] -> Timestamp
 
@@ -1734,10 +1740,12 @@ Pear;15;33'''
         s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
-        client.wait_query_status(query_id, fq.QueryMeta.FAILED)
-        describe_result = client.describe_query(query_id).result
-        issues = describe_result.query.issue
-        assert "microsecond accuracy does not fit into the datetime" in str(issues)
+        client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
+        data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
+        assert len(rows) == 1, "invalid count rows"
+        assert rows[0].items[0].text_value == "apple"
+        assert rows[0].items[1].bytes_value == b"2024-04-02T12:01:00Z"
 
         # date64 -> Timestamp
 
@@ -1774,13 +1782,14 @@ Pear;15;33'''
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
         data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
         assert len(rows) == 1, "invalid count rows"
         assert rows[0].items[0].text_value == "apple"
         assert rows[0].items[1].bytes_value == b"2024-04-02T00:00:00Z"
 
         # int32 -> Timestamp
 
-        # 2024-04-02T00:00:00.000Z
+        # 2024-04-02T12:01:00.000Z
         data = [['apple'], [1712059260]]
 
         # Define the schema for the data
@@ -1793,9 +1802,10 @@ Pear;15;33'''
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
         data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
         assert len(rows) == 1, "invalid count rows"
         assert rows[0].items[0].text_value == "apple"
-        assert rows[0].items[1].bytes_value == b"2024-04-02T00:00:00Z"
+        assert rows[0].items[1].bytes_value == b"2024-04-02T12:01:00Z"
 
         # int64 -> Timestamp
 
@@ -1816,7 +1826,7 @@ Pear;15;33'''
 
         # uint32 -> Timestamp
 
-        # 2024-04-02T00:00:00.000Z
+        # 2024-04-02T12:01:00.000Z
         data = [['apple'], [1712059260]]
 
         # Define the schema for the data
@@ -1829,13 +1839,14 @@ Pear;15;33'''
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
         data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
         assert len(rows) == 1, "invalid count rows"
         assert rows[0].items[0].text_value == "apple"
-        assert rows[0].items[1].bytes_value == b"2024-04-02T00:00:00Z"
+        assert rows[0].items[1].bytes_value == b"2024-04-02T12:01:00Z"
 
         # uint64 -> Timestamp
 
-        # 2024-04-02T00:00:00.000Z
+        # 2024-04-02T12:01:00.000Z
         data = [['apple'], [1712059260]]
 
         # Define the schema for the data
@@ -1848,9 +1859,10 @@ Pear;15;33'''
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
         data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
         assert len(rows) == 1, "invalid count rows"
         assert rows[0].items[0].text_value == "apple"
-        assert rows[0].items[1].bytes_value == b"2024-04-02T00:00:00Z"
+        assert rows[0].items[1].bytes_value == b"2024-04-02T12:01:00Z"
 
         # uint16 [default] -> Timestamp
 
@@ -1867,6 +1879,7 @@ Pear;15;33'''
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
         data = client.get_result_data(query_id, limit=50)
+        rows = data.result.result_set.rows
         rows = data.result.result_set.rows
         assert len(rows) == 1, "invalid count rows"
         assert rows[0].items[0].text_value == "apple"

--- a/ydb/tests/olap/common/s3_client.py
+++ b/ydb/tests/olap/common/s3_client.py
@@ -1,0 +1,83 @@
+import logging
+import requests
+from typing import Tuple, Optional
+
+import boto3
+import yatest.common
+from library.recipes import common as recipes_common
+
+
+class S3Mock:
+    def __init__(self, moto_server_path: str):
+        self.moto_server_path = moto_server_path
+        self.s3_pid_file = "s3.pid"
+        self.port_manager = yatest.common.network.PortManager()
+
+        self.endpoint: Optional[str] = None
+        self.s3_pid: Optional[int] = None
+
+    def __is_s3_ready(self):
+        assert self.endpoint is not None, "expected filled endpoint"
+
+        try:
+            response = requests.get(self.endpoint)
+            response.raise_for_status()
+            return True
+        except requests.RequestException as err:
+            logging.debug(err)
+            return False
+
+    def start(self):
+        assert self.s3_pid is None, "s3 already started"
+
+        port = self.port_manager.get_port()
+        self.endpoint = f"http://localhost:{port}"
+        command = [self.moto_server_path, "s3", "--port", str(port)]
+
+        recipes_common.start_daemon(
+            command=command, environment=None, is_alive_check=self.__is_s3_ready, pid_file_name=self.s3_pid_file
+        )
+
+        with open(self.s3_pid_file, 'r') as s3_pid_file:
+            self.s3_pid = int(s3_pid_file.read())
+
+    def stop(self):
+        assert self.s3_pid is not None, "s3 is not started"
+        recipes_common.stop_daemon(self.s3_pid)
+        self.s3_pid = None
+
+
+class S3Client:
+    def __init__(self, endpoint: str, region: str = "us-east-1", key_id: str = "fake_key_id", key_secret: str = "fake_key_secret"):
+        self.endpoint = endpoint
+        self.region = region
+        self.key_id = key_id
+        self.key_secret = key_secret
+
+        session = boto3.session.Session()
+        self.s3 = session.resource(
+            service_name="s3",
+            aws_access_key_id=key_id,
+            aws_secret_access_key=key_secret,
+            region_name=region,
+            endpoint_url=endpoint
+        )
+        self.client = session.client(
+            service_name="s3",
+            aws_access_key_id=key_id,
+            aws_secret_access_key=key_secret,
+            region_name=region,
+            endpoint_url=endpoint
+        )
+
+    def create_bucket(self, name: str):
+        self.client.create_bucket(Bucket=name)
+
+    def get_bucket_stat(self, bucket_name: str) -> Tuple[int, int]:
+        bucket = self.s3.Bucket(bucket_name)
+        count = 0
+        size = 0
+        for obj in bucket.objects.all():
+            count += 1
+            size += obj.size
+        return (count, size)

--- a/ydb/tests/olap/common/ya.make
+++ b/ydb/tests/olap/common/ya.make
@@ -1,0 +1,15 @@
+PY3_LIBRARY()
+
+PY_SRCS (
+    s3_client.py
+    ydb_client.py
+)
+
+PEERDIR(
+    contrib/python/boto3
+    contrib/python/requests
+    library/recipes/common
+    ydb/public/sdk/python
+)
+
+END()

--- a/ydb/tests/olap/common/ydb_client.py
+++ b/ydb/tests/olap/common/ydb_client.py
@@ -1,0 +1,39 @@
+from typing import List, Optional
+
+import ydb
+import yatest.common
+
+
+class YdbClient:
+    def __init__(self, endpoint: str, database: str, ydb_cli_path: Optional[str] = None):
+        self.endpoint = endpoint
+        self.database = database
+        self.ydb_cli_path = ydb_cli_path
+
+        self.driver = ydb.Driver(endpoint=endpoint, database=database, oauth=None)
+        self.session_pool = ydb.QuerySessionPool(self.driver)
+
+    def stop(self):
+        self.session_pool.stop()
+        self.driver.stop()
+
+    def wait_connection(self, timeout=5):
+        self.driver.wait(timeout, fail_fast=True)
+
+    def query(self, statement):
+        return self.session_pool.execute_with_retries(statement)
+
+    def bulk_upsert(self, table_path, column_types: ydb.BulkUpsertColumns, data_slice):
+        self.driver.table_client.bulk_upsert(
+            table_path,
+            data_slice,
+            column_types
+        )
+
+    def run_cli_comand(self, cmd: List[str]):
+        assert self.ydb_cli_path is not None, "ydb CLI path is not specified"
+
+        cmd = [self.ydb_cli_path, '-e', self.endpoint, '-d', self.database] + cmd
+        process = yatest.common.process.execute(cmd, check_exit_code=False)
+        if process.exit_code != 0:
+            assert False, f'Command\n{cmd}\n finished with exit code {process.exit_code}, stderr:\n\n{process.std_err}\n\nstdout:\n{process.std_out}'

--- a/ydb/tests/olap/s3_import/base.py
+++ b/ydb/tests/olap/s3_import/base.py
@@ -1,0 +1,65 @@
+import os
+import logging
+
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.olap.common.s3_client import S3Mock, S3Client
+from ydb.tests.olap.common.ydb_client import YdbClient
+
+import yatest.common
+
+logger = logging.getLogger(__name__)
+
+
+class S3ImportTestBase(object):
+    @classmethod
+    def setup_class(cls):
+        cls._setup_ydb()
+        cls._setup_s3()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.s3_mock.stop()
+        cls.ydb_client.stop()
+        cls.cluster.stop()
+
+    @classmethod
+    def _get_ydb_config(cls):
+        config = KikimrConfigGenerator(
+            extra_feature_flags={
+                "enable_external_data_sources": True,
+                "enable_move_column_table": True
+            },
+            query_service_config={"available_external_data_sources": ["ObjectStorage"]},
+            table_service_config={}
+        )
+        config.yaml_config["query_service_config"] = {}
+        config.yaml_config["query_service_config"]["available_external_data_sources"] = ["ObjectStorage"]
+        config.yaml_config["table_service_config"]["resource_manager"] = {"query_memory_limit": 64424509440}
+        config.yaml_config["resource_broker_config"] = {}
+        config.yaml_config["resource_broker_config"]["queues"] = [{"limit": {"memory": 64424509440}, "weight": 30, "name": "queue_kqp_resource_manager"}]
+        config.yaml_config["resource_broker_config"]["resource_limit"] = {"memory": 64424509440}
+        return config
+
+    @classmethod
+    def _setup_ydb(cls):
+        ydb_path = yatest.common.build_path(os.environ.get("YDB_DRIVER_BINARY"))
+        logger.info(yatest.common.execute([ydb_path, "-V"], wait=True).stdout.decode("utf-8"))
+
+        config = cls._get_ydb_config()
+        cls.cluster = KiKiMR(config)
+        cls.cluster.start()
+
+        node = cls.cluster.nodes[1]
+        cls.ydb_client = YdbClient(
+            database=f"/{config.domain_name}",
+            endpoint=f"grpc://{node.host}:{node.port}",
+            ydb_cli_path=yatest.common.build_path(os.environ.get("YDB_CLI_BINARY"))
+        )
+        cls.ydb_client.wait_connection()
+
+    @classmethod
+    def _setup_s3(cls):
+        cls.s3_mock = S3Mock(yatest.common.binary_path(os.environ["MOTO_SERVER_PATH"]))
+        cls.s3_mock.start()
+        cls.s3_client = S3Client(cls.s3_mock.endpoint)

--- a/ydb/tests/olap/s3_import/test_types_and_formats.py
+++ b/ydb/tests/olap/s3_import/test_types_and_formats.py
@@ -1,0 +1,288 @@
+import logging
+import pytest
+
+from ydb.tests.library.test_meta import link_test_case
+from ydb.tests.olap.s3_import.base import S3ImportTestBase
+
+logger = logging.getLogger(__name__)
+
+
+class TestTypesAndFormats(S3ImportTestBase):
+    def _check_tables_hash(self, original_table_name, exported_table_name):
+        result_sets = self.ydb_client.query(f"""
+            SELECT
+                String::Hex(Sum(Digest::MurMurHash32(Pickle(TableRow())))) AS check_hash,
+                COUNT(*) AS check_size
+            FROM {exported_table_name};
+
+            SELECT
+                String::Hex(Sum(Digest::MurMurHash32(Pickle(TableRow())))) AS olap_hash,
+                COUNT(*) AS olap_size
+            FROM {original_table_name};
+        """)
+
+        check_result = result_sets[0].rows[0]
+        assert check_result.check_size > 0
+
+        original_table_result = result_sets[1].rows[0]
+        assert check_result.check_size == original_table_result.olap_size
+        assert check_result.check_hash == original_table_result.olap_hash
+
+    @link_test_case("#18784")
+    @pytest.mark.parametrize(
+        "format",
+        [
+            "csv_with_names",
+            "tsv_with_names",
+            "json_each_row"
+        ]
+    )
+    @pytest.mark.parametrize(
+        "compression",
+        [
+            "gzip",
+            "zstd",
+            "lz4",
+            "brotli",
+            "bzip2",
+            "xz"
+        ]
+    )
+    def test_different_types_and_formats(self, format, compression):
+        olap_table_name = f"olap_table_{format}_{compression}"
+        s3_source_name = f"s3_source_{format}_{compression}"
+        s3_table_name = f"s3_table_{format}_{compression}"
+        from_s3_table_name = f"from_s3_{format}_{compression}"
+
+        table_schema = """
+            c_int8 Int8,
+            c_int16 Int16,
+            c_int32 Int32 NOT NULL,
+            c_int64 Int64,
+            c_uint8 Uint8,
+            c_uint16 Uint16,
+            c_uint32 Uint32,
+            c_uint64 Uint64,
+            c_float Float,
+            c_double Double,
+            c_string String,
+            c_utf8 Utf8,
+            c_json Json,
+            c_date Date,
+            c_datetime Datetime,
+            c_timestamp Timestamp
+        """
+
+        self.ydb_client.query(f"""
+            CREATE TABLE {olap_table_name} (
+                {table_schema},
+                PRIMARY KEY (c_int32)
+            ) WITH (
+                STORE = COLUMN
+            );
+        """)
+
+        self.ydb_client.query(f"""
+            UPSERT INTO {olap_table_name} (
+                c_int8, c_int16, c_int32, c_int64, c_uint8, c_uint16, c_uint32, c_uint64, c_float, c_double, c_string, c_utf8, c_json, c_date, c_datetime, c_timestamp
+            ) VALUES
+                (1, 1, 1, 1, 1, 1, 1, 1, Float("0.5"), Double("-0.5"), "hello", "world", Json("[10, 20, 30]"), Date("2025-08-25"), Datetime("2025-08-25T10:00:00Z"), Timestamp("2025-08-25T10:00:00Z")),
+                (NULL, NULL, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        """)
+
+        test_bucket = f"{format}_{compression}_bucket"
+        self.s3_client.create_bucket(test_bucket)
+
+        access_key_id_secret_name = f"{test_bucket}_key_id"
+        access_key_secret_secret_name = f"{test_bucket}_key_secret"
+        self.ydb_client.query(f"CREATE OBJECT {access_key_id_secret_name} (TYPE SECRET) WITH value='{self.s3_client.key_id}'")
+        self.ydb_client.query(f"CREATE OBJECT {access_key_secret_secret_name} (TYPE SECRET) WITH value='{self.s3_client.key_secret}'")
+
+        self.ydb_client.query(f"""
+            CREATE EXTERNAL DATA SOURCE {s3_source_name} WITH (
+                SOURCE_TYPE = "ObjectStorage",
+                LOCATION = "{self.s3_mock.endpoint}/{test_bucket}",
+                AUTH_METHOD="AWS",
+                AWS_ACCESS_KEY_ID_SECRET_NAME="{access_key_id_secret_name}",
+                AWS_SECRET_ACCESS_KEY_SECRET_NAME="{access_key_secret_secret_name}",
+                AWS_REGION="{self.s3_client.region}"
+            );
+
+            CREATE EXTERNAL TABLE {s3_table_name} (
+                {table_schema}
+            ) WITH (
+                DATA_SOURCE="{s3_source_name}",
+                LOCATION="/test_folder/",
+                FORMAT="{format}",
+                COMPRESSION="{compression}"
+            );
+        """)
+
+        logger.info("Exporting into s3...")
+        self.ydb_client.query(f"INSERT INTO {s3_table_name} SELECT * FROM {olap_table_name}")
+        logger.info(f"Exporting finished, bucket stats: {self.s3_client.get_bucket_stat(test_bucket)}")
+
+        logger.info("Importing into ydb...")
+        self.ydb_client.query(f"""
+            CREATE TABLE {from_s3_table_name} (
+                PRIMARY KEY (c_int32)
+            ) WITH (
+                STORE = COLUMN
+            ) AS SELECT * FROM {s3_table_name}
+        """)
+
+        self._check_tables_hash(olap_table_name, from_s3_table_name)
+
+    @link_test_case("#18784")
+    def test_parquet_format(self):
+        olap_table_name = "olap_table"
+        s3_source_name = "s3_source"
+        s3_table_name = "s3_table"
+        from_s3_table_name = "from_s3"
+
+        table_schema = """
+            c_int8 Int8,
+            c_int16 Int16,
+            c_int32 Int32 NOT NULL,
+            c_int64 Int64,
+            c_uint8 Uint8,
+            c_uint16 Uint16,
+            c_uint32 Uint32,
+            c_uint64 Uint64,
+            c_float Float,
+            c_double Double,
+            c_string String,
+            c_utf8 Utf8,
+            c_json Json,
+            c_date Date,
+            c_date32 Date32,
+            c_datetime Datetime,
+            c_datetime64 Datetime64,
+            c_timestamp Timestamp,
+            c_timestamp64 Timestamp64,
+            c_decimal Decimal(22, 9)
+        """
+
+        self.ydb_client.query(f"""
+            CREATE TABLE {olap_table_name} (
+                {table_schema},
+                PRIMARY KEY (c_int32)
+            ) WITH (
+                STORE = COLUMN
+            );
+        """)
+
+        self.ydb_client.query(f"""
+            UPSERT INTO {olap_table_name} (
+                c_int8,
+                c_int16,
+                c_int32,
+                c_int64,
+                c_uint8,
+                c_uint16,
+                c_uint32,
+                c_uint64,
+                c_float,
+                c_double,
+                c_string,
+                c_utf8,
+                c_json,
+                c_date,
+                c_date32,
+                c_datetime,
+                c_datetime64,
+                c_timestamp,
+                c_timestamp64,
+                c_decimal
+            ) VALUES
+                (
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    Float("0.5"),
+                    Double("-0.5"),
+                    "hello",
+                    "world",
+                    Json("[10, 20, 30]"),
+                    Date("2025-08-25"),
+                    Date32("2025-08-25"),
+                    Datetime("2025-08-25T10:00:00Z"),
+                    Datetime64("2025-08-25T10:00:00Z"),
+                    Timestamp("2025-08-25T10:00:00Z"),
+                    Timestamp64("2025-08-25T10:00:00Z"),
+                    CAST("12.34" AS Decimal(22, 9))
+                ),
+                (
+                    NULL,
+                    NULL,
+                    2,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL
+                )
+        """)
+
+        test_bucket = "parquet_bucket"
+        self.s3_client.create_bucket(test_bucket)
+
+        access_key_id_secret_name = f"{test_bucket}_key_id"
+        access_key_secret_secret_name = f"{test_bucket}_key_secret"
+        self.ydb_client.query(f"CREATE OBJECT {access_key_id_secret_name} (TYPE SECRET) WITH value='{self.s3_client.key_id}'")
+        self.ydb_client.query(f"CREATE OBJECT {access_key_secret_secret_name} (TYPE SECRET) WITH value='{self.s3_client.key_secret}'")
+
+        self.ydb_client.query(f"""
+            CREATE EXTERNAL DATA SOURCE {s3_source_name} WITH (
+                SOURCE_TYPE = "ObjectStorage",
+                LOCATION = "{self.s3_mock.endpoint}/{test_bucket}",
+                AUTH_METHOD="AWS",
+                AWS_ACCESS_KEY_ID_SECRET_NAME="{access_key_id_secret_name}",
+                AWS_SECRET_ACCESS_KEY_SECRET_NAME="{access_key_secret_secret_name}",
+                AWS_REGION="{self.s3_client.region}"
+            );
+
+            CREATE EXTERNAL TABLE {s3_table_name} (
+                {table_schema}
+            ) WITH (
+                DATA_SOURCE="{s3_source_name}",
+                LOCATION="/test_folder/",
+                FORMAT="parquet"
+            );
+        """)
+
+        logger.info("Exporting into s3...")
+        self.ydb_client.query(f"""
+            PRAGMA s3.UseBlocksSink = "true";
+
+            INSERT INTO {s3_table_name} SELECT * FROM {olap_table_name};
+        """)
+        logger.info(f"Exporting finished, bucket stats: {self.s3_client.get_bucket_stat(test_bucket)}")
+
+        logger.info("Importing into ydb...")
+        self.ydb_client.query(f"""
+            CREATE TABLE {from_s3_table_name} (
+                PRIMARY KEY (c_int32)
+            ) WITH (
+                STORE = COLUMN
+            ) AS SELECT * FROM {s3_table_name}
+        """)
+
+        self._check_tables_hash(olap_table_name, from_s3_table_name)

--- a/ydb/tests/olap/s3_import/ya.make
+++ b/ydb/tests/olap/s3_import/ya.make
@@ -1,0 +1,32 @@
+PY3TEST()
+
+ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
+ENV(MOTO_SERVER_PATH="contrib/python/moto/bin/moto_server")
+
+TEST_SRCS(
+    test_types_and_formats.py
+)
+
+PY_SRCS(
+    base.py
+)
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    ydb/tests/library
+    ydb/tests/library/test_meta
+    ydb/public/sdk/python
+    ydb/public/sdk/python/enable_v3_new_behavior
+    contrib/python/boto3
+    library/recipes/common
+    ydb/tests/olap/common
+)
+
+DEPENDS(
+    ydb/apps/ydb
+    contrib/python/moto/bin
+)
+
+END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

added support to read/write `Date32`, `Datetime64`, `Timestamp64` and `Decimal(n, m)` from/to external data sources with "ObjectStorage" source type and "parquet" format

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

fix for [YQ-4663](https://st.yandex-team.ru/YQ-4663)
