### PR TITLE
Less branches in nightly tests

### DIFF
--- a/.github/config/stable_tests_branches.json
+++ b/.github/config/stable_tests_branches.json
@@ -1,9 +1,6 @@
 [
     "main",
-    "stable-25-1",
-    "stable-25-2",
     "stable-25-2-1",
-    "stable-25-3",
     "stable-25-3-1",
     "stream-nb-25-1"
 ]


### PR DESCRIPTION
Because consumption is very high for every sanitizer