### PR TITLE
Make combinations for ResolveAll with labels, only used in selectors

### DIFF
--- a/ydb/library/yaml_config/public/yaml_config.cpp
+++ b/ydb/library/yaml_config/public/yaml_config.cpp
@@ -434,9 +434,18 @@ TResolvedConfig ResolveAll(NFyaml::TDocument& doc)
     TVector<std::pair<TString, TSet<TLabel>>> labels;
 
     auto config = ParseConfig(doc);
+    THashSet<TString> usedNames;
+    usedNames.reserve(config.Selectors.size() * 2);
+    for (const auto& selectorModel : config.Selectors) {
+        for (const auto& [label, _] : selectorModel.Selector.In) usedNames.insert(label);
+        for (const auto& [label, _] : selectorModel.Selector.NotIn) usedNames.insert(label);
+    }
     auto namedLabels = CollectLabels(doc);
 
     for (auto& [name, values]: namedLabels) {
+        if (!usedNames.contains(name)) {
+            continue;
+        }
         TSet<TLabel> set;
         if (values.Class == EYamlConfigLabelTypeClass::Open) {
             set.insert(TLabel{TLabel::EType::Negative, {}});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make combinations for resolve only with used in selectors labels

Let:
$d_k$ - branching per label
M = $\prod d_k$ - all combinations for labels
S - selectors
K - average number of in/not_in conditions in each selector
F - average time for Value.Contains() for `TSet<TString>`

Complexity: O(M * S * K * F)

With this improvement we reducing M, removing unused label from product, which give us exponential improvement in theory

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
