### PR TITLE
rd + watermarks: transfer single watermark per batch (backport #25209), pq rd: get rid of New watermark (empty maybe) log spam (backport #25882) (q-stable-2025-09-25)

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/format_handler/filters/purecalc_filter.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/filters/purecalc_filter.cpp
@@ -21,6 +21,10 @@ NYT::TNode CreateTypeNode(NYT::TNode&& typeNode) {
     return CreateNamedNode("DataType", std::move(typeNode));
 }
 
+NYT::TNode CreateOptionalTypeNode(NYT::TNode&& typeNode) {
+    return CreateNamedNode("OptionalType", std::move(typeNode));
+}
+
 NYT::TNode CreateStructTypeNode(NYT::TNode&& membersNode) {
     return CreateNamedNode("StructType", std::move(membersNode));
 }
@@ -70,7 +74,7 @@ NYT::TNode MakeWatermarkOutputSchema() {
     return CreateStructTypeNode(
         NYT::TNode::CreateList()
             .Add(CreateFieldNode(OFFSET_FIELD_NAME, CreateTypeNode("Uint64")))
-            .Add(CreateFieldNode(WATERMARK_FIELD_NAME, CreateTypeNode("Timestamp")))
+            .Add(CreateFieldNode(WATERMARK_FIELD_NAME, CreateOptionalTypeNode(CreateTypeNode("Timestamp"))))
     );
 }
 
@@ -456,21 +460,10 @@ private:
 
     TStringBuilder sb;
     sb << R"(PRAGMA config.flags("LLVM", ")" << (settings.EnabledLLVM ? "ON" : "OFF") << R"(");)" << '\n';
-    sb << "$input ="
-        << " SELECT "
-            << OFFSET_FIELD_NAME << ", "
-            << watermarkExpr << " AS " << WATERMARK_FIELD_NAME
-        << " FROM Input;\n";
-    sb << "$output ="
-        << " SELECT "
-            << OFFSET_FIELD_NAME << ", "
-            << WATERMARK_FIELD_NAME
-        << " FROM $input"
-        << " WHERE " << WATERMARK_FIELD_NAME << " IS NOT NULL;\n";
     sb << "SELECT "
         << OFFSET_FIELD_NAME << ", "
-        << "Unwrap(" << WATERMARK_FIELD_NAME << ") AS " << WATERMARK_FIELD_NAME
-    << " FROM $output;\n";
+        << watermarkExpr << " AS " << WATERMARK_FIELD_NAME
+    << " FROM Input;\n";
 
     TString result = sb;
     LOG_ROW_DISPATCHER_DEBUG("Generated sql:\n" << result);

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
@@ -219,17 +219,31 @@ private:
             Client->StartClientSession();
         }
 
+    private:
+        void OnWatermark(const NYql::NUdf::TUnboxedValue& rowIdValue, const NYql::NUdf::TUnboxedValue& maybeWatermark) {
+            if (!maybeWatermark) {
+                return;
+            }
+            auto rowId = rowIdValue.Get<ui64>();
+            Offset = Self.Offsets->at(rowId);
+            auto watermark = TInstant::MicroSeconds(maybeWatermark.Get<ui64>());
+            if (Watermark < watermark) {
+                Watermark = watermark;
+            }
+            LOG_ROW_DISPATCHER_TRACE("OnWatermark, row id: " << rowId << ", watermark: " << watermark);
+        }
+
+    public:
         void OnData(const NYql::NUdf::TUnboxedValue* value) override {
             ui64 rowId;
-            TMaybe<ui64> watermarkUs;
             if (value->IsEmbedded()) {
                 rowId = value->Get<ui64>();
             } else if (value->IsBoxed()) {
                 if (value->GetListLength() == 1) {
                     rowId = value->GetElement(0).Get<ui64>();
                 } else if (value->GetListLength() == 2) {
-                    rowId = value->GetElement(0).Get<ui64>();
-                    watermarkUs = value->GetElement(1).Get<ui64>();
+                    OnWatermark(value->GetElement(0), value->GetElement(1));
+                    return;
                 } else {
                     Y_ENSURE(false, "Unexpected output schema size");
                 }
@@ -244,14 +258,6 @@ private:
             }
 
             FilteredOffsets.insert(Offset);
-            if (watermarkUs) {
-                WatermarksUs.push_back(*watermarkUs);
-
-                const auto watermark = WatermarksUs.empty() ? Nothing() : TMaybe<TInstant>{TInstant::MicroSeconds(WatermarksUs.back())};
-                LOG_ROW_DISPATCHER_TRACE("OnData, row id: " << rowId << ", offset: " << Offset << ", watermark: " << watermark);
-
-                return;
-            }
 
             Y_DEFER {
                 // Values allocated on parser allocator and should be released
@@ -270,7 +276,7 @@ private:
         }
 
         void OnBatchFinish() override {
-            if (NewNumberRows == NumberRows && NewDataPackerSize == DataPackerSize && WatermarksUs.empty()) {
+            if (NewNumberRows == NumberRows && NewDataPackerSize == DataPackerSize && !Watermark) {
                 return;
             }
             if (const auto nextOffset = Client->GetNextMessageOffset(); nextOffset && Offset < *nextOffset) {
@@ -280,11 +286,10 @@ private:
 
             const auto numberRows = NewNumberRows - NumberRows;
             const auto rowSize = NewDataPackerSize - DataPackerSize;
-            const auto watermark = WatermarksUs.empty() ? Nothing() : TMaybe<TInstant>{TInstant::MicroSeconds(WatermarksUs.back())};
 
-            LOG_ROW_DISPATCHER_TRACE("OnBatchFinish, offset: " << Offset << ", number rows: " << numberRows << ", row size: " << rowSize << ", watermark: " << watermark);
+            LOG_ROW_DISPATCHER_TRACE("OnBatchFinish, offset: " << Offset << ", number rows: " << numberRows << ", row size: " << rowSize << ", watermark: " << Watermark);
 
-            Client->AddDataToClient(Offset, numberRows, rowSize, watermark);
+            Client->AddDataToClient(Offset, numberRows, rowSize, Watermark);
 
             NumberRows = NewNumberRows;
             DataPackerSize = NewDataPackerSize;
@@ -313,15 +318,18 @@ private:
         }
 
         void FinishPacking() {
-            if (!DataPacker->IsEmpty() || !WatermarksUs.empty()) {
+            if (!DataPacker->IsEmpty() || !Watermark.Empty()) {
                 LOG_ROW_DISPATCHER_TRACE("FinishPacking, batch size: " << DataPackerSize << ", number rows: " << FilteredOffsets.size());
-                ClientData.emplace(NYql::MakeReadOnlyRope(DataPacker->Finish()), FilteredOffsets, WatermarksUs);
+                if (FilteredOffsets.empty()) {
+                    FilteredOffsets.emplace(Offset);
+                }
+                ClientData.emplace(NYql::MakeReadOnlyRope(DataPacker->Finish()), std::move(FilteredOffsets), Watermark);
                 NumberRows = 0;
                 NewNumberRows = 0;
                 DataPackerSize = 0;
                 NewDataPackerSize = 0;
                 FilteredOffsets.clear();
-                WatermarksUs.clear();
+                Watermark.Clear();
             }
         }
 
@@ -343,7 +351,7 @@ private:
         TVector<NYql::NUdf::TUnboxedValue> FilteredRow;  // Temporary value holder for DataPacket
         std::unique_ptr<NKikimr::NMiniKQL::TValuePackerTransport<true>> DataPacker;
         TSet<ui64> FilteredOffsets;  // Offsets of current batch in DataPacker
-        TVector<ui64> WatermarksUs;
+        TMaybe<TInstant> Watermark;
         TQueue<TDataBatch> ClientData;
     };
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.h
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.h
@@ -38,7 +38,7 @@ public:
 struct TDataBatch {
     TRope SerializedData;
     TSet<ui64> Offsets;
-    TVector<ui64> WatermarksUs;
+    TMaybe<TInstant> Watermark;
 };
 
 class ITopicFormatHandler : public TNonCopyable {

--- a/ydb/core/fq/libs/row_dispatcher/topic_session.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/topic_session.cpp
@@ -697,7 +697,7 @@ void TTopicSession::SendData(TClientsInfo& info) {
 
         ui64 batchSize = 0;
         while (!buffer.empty()) {
-            auto [serializedData, offsets, watermarksUs] = std::move(buffer.front());
+            auto [serializedData, offsets, watermark] = std::move(buffer.front());
             Y_ENSURE(!offsets.empty(), "Expected non empty message batch");
             buffer.pop();
 
@@ -706,7 +706,9 @@ void TTopicSession::SendData(TClientsInfo& info) {
             NFq::NRowDispatcherProto::TEvMessage message;
             message.SetPayloadId(event->AddPayload(std::move(serializedData)));
             message.MutableOffsets()->Assign(offsets.begin(), offsets.end());
-            message.MutableWatermarksUs()->Assign(watermarksUs.begin(), watermarksUs.end());
+            if (watermark) {
+                message.AddWatermarksUs(watermark->MicroSeconds());
+            }
             event->Record.AddMessages()->CopyFrom(std::move(message));
             event->Record.SetNextMessageOffset(*offsets.rbegin() + 1);
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -1144,8 +1144,10 @@ void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvMessageBatch::TPtr& ev) 
             newWatermark = *maybeNewWatermark;
         }
 
-        SRC_LOG_D("SessionId: " << GetSessionId() << " New watermark " << newWatermark << " was generated");
-        activeBatch.Watermark = newWatermark;
+        if (newWatermark) {
+            SRC_LOG_D("SessionId: " << GetSessionId() << " New watermark " << newWatermark << " was generated");
+            activeBatch.Watermark = newWatermark;
+        }
     }
 
     Parent->NotifyCA();


### PR DESCRIPTION
(cherry picked from commit 580503a145c75b341cabdd6aed063fda93f499c3)
(cherry picked from commit 3db6964e6ff0a5738b4b443bf93369ee20b6328a)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
