### PR TITLE
Added code ownership rules for sys_view registry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,7 +73,7 @@
 /ydb/tests/functional/tenants/test_dynamic_tenants.py @ydb-platform/schemeshard
 /ydb/core/tx/tx_proxy/schemereq.cpp @ydb-platform/schemeshard
 
-/ydb/core/scheme @ydb-platform/datashard 
+/ydb/core/scheme @ydb-platform/datashard
 /ydb/core/tablet_flat @ydb-platform/datashard
 /ydb/core/tx/datashard @ydb-platform/datashard
 /ydb/core/tx/coordinator @ydb-platform/datashard
@@ -91,3 +91,7 @@
 /ydb/library/aclib @ydb-platform/Security
 /ydb/services/ydb/ydb_ldap_login_ut.cpp @ydb-platform/Security
 /ydb/services/ydb/ydb_register_node_ut.cpp @ydb-platform/Security
+/ydb/core/sys_view/common/registry.h @ydb-platform/Security
+/ydb/core/sys_view/common/registry.cpp @ydb-platform/Security
+/ydb/core/sys_view/ut_registry.cpp @ydb-platform/Security
+/ydb/tests/compatibility/test_system_views.py @ydb-platform/Security

--- a/ydb/tests/compatibility/test_system_views.py
+++ b/ydb/tests/compatibility/test_system_views.py
@@ -48,37 +48,34 @@ class TestSystemViewsRegistry(RestartToAnotherVersionFixture):
             if min(self.versions) < (25, 1, 4) and sysview_name in ["resource_pools", "resource_pool_classifiers"]:
                 continue
             if sysview_name not in dict_after:
-                logger.debug(f"sysview '{sysview_name}' was deleted")
-                return False
+                return False, f"sysview '{sysview_name}' was deleted"
 
             columns_before = sysview_descr['columns']
             columns_after = dict_after[sysview_name]['columns']
 
             for col_name, col_type in columns_before.items():
                 if col_name not in columns_after:
-                    logger.debug(f"column '{col_name}' was deleted from sysview '{sysview_name}'")
-                    return False
+                    return False, f"column '{col_name}' was deleted from sysview '{sysview_name}'"
 
                 if col_type != columns_after[col_name]:
-                    logger.debug(f"column '{col_name}' changed type in sysview '{sysview_name}'")
-                    return False
+                    return False, f"column '{col_name}' changed type in sysview '{sysview_name}'"
 
             primary_key_before = sysview_descr['primary_key']
             primary_key_after = dict_after[sysview_name]['primary_key']
 
             for i, primary_key_col in enumerate(primary_key_before):
                 if primary_key_col != primary_key_after[i]:
-                    logger.debug(f"column '{primary_key_col}' was deleted from sysview '{sysview_name}' primary key")
-                    return False
+                    return False, f"column '{primary_key_col}' was deleted from sysview '{sysview_name}' primary key"
 
-        return True
+        return True, ''
 
     def test_domain_sys_dir(self):
         sysview_folder_content_before = self.collect_sysviews()
         self.change_cluster_version()
         sysview_folder_content_after = self.collect_sysviews()
 
-        assert self.compare_sysviews_dicts(sysview_folder_content_before, sysview_folder_content_after)
+        result, debug_compare_string = self.compare_sysviews_dicts(sysview_folder_content_before, sysview_folder_content_after)
+        assert result, debug_compare_string
 
 
 class TestSystemViewsRollingUpgrade(RollingUpgradeAndDowngradeFixture):


### PR DESCRIPTION
## Add Security team code ownership and improve system views test debugging

### Changes

- Security and Code Ownership
Add Security team ownership rules for sys_view registry files in CODEOWNERS to ensure proper review of critical system views components to support compatible local backups.

- Testing Improvements  
Enhance debugging capabilities in system views compatibility tests to improve diagnostic information when test failures occur.
