### PR TITLE
EXT-1552 Remove log for DS stats keys limit

### DIFF
--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -175,19 +175,6 @@ private:
             << (ev->HasSchemaChanges ? ", with schema changes" : "")
             << ", LoadedSize " << PagesSize << ", " << NFmt::Do(*Spent));
 
-        if (const auto& stats = ev->Stats; stats.DataSize.Size > 10_MB && stats.RowCount > 100
-            && Min(stats.RowCountHistogram.size(), stats.DataSizeHistogram.size()) < HistogramBucketsCount / 2)
-        {
-            LOG_ERROR_S(GetActorContext(), NKikimrServices::TABLET_STATS_BUILDER, "Stats at datashard " << TabletId << ", for tableId " << TableId
-                << " don't have enough keys: "
-                << ev->Stats.ToString()
-                << ", RowCountHistogramSize=" << stats.RowCountHistogram.size()
-                << ", DataSizeHistogramSize=" << stats.DataSizeHistogram.size()
-                << ", HistogramBucketsCount=" << HistogramBucketsCount
-                << ", MinHistogramSize=" << Min(stats.RowCountHistogram.size(), stats.DataSizeHistogram.size())
-                << ", Threshold=" << HistogramBucketsCount / 2);
-        }
-
         Send(ReplyTo, ev.Release());
 
         ReleaseResources();

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -119,7 +119,7 @@ public:
 
         ObtainResources();
         Spent->Alter(true); // resume measurement
-        
+
         for (auto& loaded : msg->Pages) {
             partPages.emplace(pageId, TPinnedPageRef(loaded.Page).GetData());
             PageRefs.emplace_back(std::move(loaded.Page));
@@ -151,21 +151,21 @@ private:
 
         BuildStats(*Subset, ev->Stats, RowCountResolution, DataSizeResolution, HistogramBucketsCount, this, [this](){
             const auto now = GetCycleCountFast();
-    
+
             if (now > CoroutineDeadline) {
                 Spent->Alter(false); // pause measurement
                 ReleaseResources();
 
                 Send(new IEventHandle(EvResume, 0, SelfActorId, {}, nullptr, 0));
-                WaitForSpecificEvent([](IEventHandle& ev) { 
-                    return ev.Type == EvResume; 
+                WaitForSpecificEvent([](IEventHandle& ev) {
+                    return ev.Type == EvResume;
                 }, &TTableStatsCoroBuilder::ProcessUnexpectedEvent);
 
                 ObtainResources();
                 Spent->Alter(true); // resume measurement
             }
         }, TStringBuilder() << "Building stats at datashard " << TabletId << ", for tableId " << TableId << ": ");
-        
+
         Y_DEBUG_ABORT_UNLESS(IndexSize == ev->Stats.IndexSize.Size);
 
         LOG_INFO_S(GetActorContext(), NKikimrServices::TABLET_STATS_BUILDER, "Stats at datashard " << TabletId << ", for tableId " << TableId << ": "
@@ -174,13 +174,18 @@ private:
             << (ev->PartOwners.size() > 1 || ev->PartOwners.size() == 1 && *ev->PartOwners.begin() != TabletId ? ", with borrowed parts" : "")
             << (ev->HasSchemaChanges ? ", with schema changes" : "")
             << ", LoadedSize " << PagesSize << ", " << NFmt::Do(*Spent));
-        
+
         if (const auto& stats = ev->Stats; stats.DataSize.Size > 10_MB && stats.RowCount > 100
             && Min(stats.RowCountHistogram.size(), stats.DataSizeHistogram.size()) < HistogramBucketsCount / 2)
         {
             LOG_ERROR_S(GetActorContext(), NKikimrServices::TABLET_STATS_BUILDER, "Stats at datashard " << TabletId << ", for tableId " << TableId
                 << " don't have enough keys: "
-                << ev->Stats.ToString());
+                << ev->Stats.ToString()
+                << ", RowCountHistogramSize=" << stats.RowCountHistogram.size()
+                << ", DataSizeHistogramSize=" << stats.DataSizeHistogram.size()
+                << ", HistogramBucketsCount=" << HistogramBucketsCount
+                << ", MinHistogramSize=" << Min(stats.RowCountHistogram.size(), stats.DataSizeHistogram.size())
+                << ", Threshold=" << HistogramBucketsCount / 2);
         }
 
         Send(ReplyTo, ev.Release());
@@ -192,7 +197,7 @@ private:
         switch (ev->GetTypeRewrite()) {
             case TEvResourceBroker::EvTaskOperationError: {
                 const auto* msg = ev->CastAsLocal<TEvResourceBroker::TEvTaskOperationError>();
-                LOG_ERROR_S(GetActorContext(), NKikimrServices::TABLET_STATS_BUILDER, "Failed to allocate resource" 
+                LOG_ERROR_S(GetActorContext(), NKikimrServices::TABLET_STATS_BUILDER, "Failed to allocate resource"
                     << " error '" << msg->Status.Message << "'"
                     << " at datashard " << TabletId << ", for tableId " << TableId);
                 throw TExTableStatsError(ECode::RESOURCE_ALLOCATION_FAILED, msg->Status.Message);
@@ -421,8 +426,8 @@ void TDataShard::Handle(TEvPrivate::TEvTableStatsError::TPtr& ev, const TActorCo
 
     auto msg = ev->Get();
 
-    LOG_ERROR_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "Stats rebuilt error '" << msg->Message 
-        << "', code: " << ui32(msg->Code) 
+    LOG_ERROR_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "Stats rebuilt error '" << msg->Message
+        << "', code: " << ui32(msg->Code)
         << " at datashard " << TabletID() << ", for tableId " << msg->TableId);
 
     auto it = TableInfos.find(msg->TableId);


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

```
Stats at datashard 72075186224423644, for tableId 14 don't have enough keys: RowCount: 367805 DataSize: 1018478341 IndexSize: 7436996 RowCountHistogram: 3 DataSizeHistogram: 97
```
During the investigation, we noticed many error logs near DS. We decided to make them more detailed because it was not clear what the problem was. One of the reviewers said the log was no longer needed, so I decided to remove it to avoid confusion.
