### PR TITLE
EXT-1548 Add ReplicationAwareness and PreferLessOccupiedRack parameters to automatic cluster balancing and self-heal

### DIFF
--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -842,6 +842,8 @@ void TBlobStorageController::SetHostRecords(THostRecordMap hostRecords) {
         }
     }
     Y_ABORT_UNLESS(!SelfHealId);
+
+    SelfHealSettings = ParseSelfHealSettings(StorageConfig);
     SelfHealId = Register(CreateSelfHealActor());
 
     ClusterBalancingSettings = ParseClusterBalancingSettings(StorageConfig);

--- a/ydb/core/mind/bscontroller/cluster_balancing.cpp
+++ b/ydb/core/mind/bscontroller/cluster_balancing.cpp
@@ -177,6 +177,8 @@ namespace NKikimr::NBsController {
             cmd->SetFailDomainIdx(vslot->GetFailDomainIdx());
             cmd->SetVDiskIdx(vslot->GetVDiskIdx());
             cmd->SetOnlyToLessOccupiedPDisk(true);
+            cmd->SetPreferLessOccupiedRack(Settings.PreferLessOccupiedRack);
+            cmd->SetWithAttentionToReplication(Settings.WithAttentionToReplication);
 
             return ev;
         }
@@ -375,6 +377,12 @@ namespace NKikimr::NBsController {
         }
         if (clusterBalancingSettings.HasMaxReplicatingVDisks()) {
             settings.MaxReplicatingVDisks = clusterBalancingSettings.GetMaxReplicatingVDisks();
+        }
+        if (clusterBalancingSettings.HasPreferLessOccupiedRack()) {
+            settings.PreferLessOccupiedRack = clusterBalancingSettings.GetPreferLessOccupiedRack();
+        }
+        if (clusterBalancingSettings.HasWithAttentionToReplication()) {
+            settings.WithAttentionToReplication = clusterBalancingSettings.GetWithAttentionToReplication();
         }
 
         return settings;

--- a/ydb/core/mind/bscontroller/cluster_balancing.h
+++ b/ydb/core/mind/bscontroller/cluster_balancing.h
@@ -15,6 +15,8 @@ struct TClusterBalancingSettings {
     ui32 MaxReplicatingPDisks = 5;
     ui32 MaxReplicatingVDisks = 40;
     ui32 IterationIntervalMs = 5000;
+    bool PreferLessOccupiedRack = false;
+    bool WithAttentionToReplication = false;
 };
 
 TClusterBalancingSettings ParseClusterBalancingSettings(const std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> storageConfig);

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1543,6 +1543,8 @@ private:
     NKikimrBlobStorage::TPDiskSpaceColor::E PDiskSpaceColorBorder
             = NKikimrBlobStorage::TPDiskSpaceColor::GREEN;
 
+    TSelfHealSettings SelfHealSettings;
+    
     TClusterBalancingSettings ClusterBalancingSettings;
 
     TActorId SystemViewsCollectorId;

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -45,6 +45,8 @@ namespace NKikimr::NBsController {
         const bool IsSelfHealReasonDecommit;
         const bool IgnoreDegradedGroupsChecks;
         const bool DonorMode;
+        const bool PreferLessOccupiedRack;
+        const bool WithAttentionToReplication;
         THashSet<TVDiskID> PendingVDisks;
         THashMap<TActorId, TVDiskID> ActorToDiskMap;
         THashMap<TNodeId, TVector<TVDiskID>> NodeToDiskMap;
@@ -52,7 +54,8 @@ namespace NKikimr::NBsController {
     public:
         TReassignerActor(TActorId controllerId, TGroupId groupId, TEvControllerUpdateSelfHealInfo::TGroupContent group,
                 std::optional<TVDiskID> vdiskToReplace, std::shared_ptr<TBlobStorageGroupInfo::TTopology> topology,
-                bool isSelfHealReasonDecommit, bool ignoreDegradedGroupsChecks, bool donorMode)
+                bool isSelfHealReasonDecommit, bool ignoreDegradedGroupsChecks, bool donorMode, bool preferLessOccupiedRack,
+                bool withAttentionToReplication)
             : ControllerId(controllerId)
             , GroupId(groupId)
             , Group(std::move(group))
@@ -62,6 +65,8 @@ namespace NKikimr::NBsController {
             , IsSelfHealReasonDecommit(isSelfHealReasonDecommit)
             , IgnoreDegradedGroupsChecks(ignoreDegradedGroupsChecks)
             , DonorMode(donorMode)
+            , PreferLessOccupiedRack(preferLessOccupiedRack)
+            , WithAttentionToReplication(withAttentionToReplication)
         {}
 
         void Bootstrap(const TActorId& parent) {
@@ -181,6 +186,8 @@ namespace NKikimr::NBsController {
                 cmd->SetFailRealmIdx(VDiskToReplace->FailRealm);
                 cmd->SetFailDomainIdx(VDiskToReplace->FailDomain);
                 cmd->SetVDiskIdx(VDiskToReplace->VDisk);
+                cmd->SetPreferLessOccupiedRack(PreferLessOccupiedRack);
+                cmd->SetWithAttentionToReplication(WithAttentionToReplication);
             } else {
                 ev->GroupLayoutSanitizer = true;
                 auto *cmd = request->AddCommand()->MutableSanitizeGroup();
@@ -293,6 +300,7 @@ namespace NKikimr::NBsController {
         THostRecordMap HostRecords;
         std::shared_ptr<TControlWrapper> EnableSelfHealWithDegraded;
         std::shared_ptr<std::atomic_uint64_t> GroupsWithInvalidLayoutCounter;
+        const TSelfHealSettings SelfHealSettings;
 
         using TTopologyDescr = std::tuple<TBlobStorageGroupType::EErasureSpecies, ui32, ui32, ui32>;
         THashMap<TTopologyDescr, std::shared_ptr<TBlobStorageGroupInfo::TTopology>> Topologies;
@@ -310,7 +318,8 @@ namespace NKikimr::NBsController {
         TSelfHealActor(ui64 tabletId, std::shared_ptr<std::atomic_uint64_t> unreassignableGroups, THostRecordMap hostRecords,
                 bool groupLayoutSanitizerEnabled, bool allowMultipleRealmsOccupation, bool donorMode,
                 std::shared_ptr<TControlWrapper> enableSelfHealWithDegraded,
-                std::shared_ptr<std::atomic_uint64_t> groupsWithInvalidLayoutCounter)
+                std::shared_ptr<std::atomic_uint64_t> groupsWithInvalidLayoutCounter,
+                const TSelfHealSettings& selfHealSettings)
             : TabletId(tabletId)
             , UnreassignableGroupsCount(std::move(unreassignableGroups))
             , GroupLayoutSanitizerEnabled(groupLayoutSanitizerEnabled)
@@ -319,6 +328,7 @@ namespace NKikimr::NBsController {
             , HostRecords(std::move(hostRecords))
             , EnableSelfHealWithDegraded(std::move(enableSelfHealWithDegraded))
             , GroupsWithInvalidLayoutCounter(std::move(groupsWithInvalidLayoutCounter))
+            , SelfHealSettings(selfHealSettings)
         {}
 
         void Bootstrap(const TActorId& parentId) {
@@ -717,7 +727,8 @@ namespace NKikimr::NBsController {
             group.ReassignStatus = EReassignStatus::Active;
             Y_ABORT_UNLESS(!ActiveReassignerActorId);
             ActiveReassignerActorId = Register(new TReassignerActor(ControllerId, group.GroupId, group.Content,
-                    vdiskId, group.Topology, isSelfHealReasonDecommit, ignoreDegradedGroupsChecks, DonorMode));
+                    vdiskId, group.Topology, isSelfHealReasonDecommit, ignoreDegradedGroupsChecks, DonorMode,
+                    SelfHealSettings.PreferLessOccupiedRack, SelfHealSettings.WithAttentionToReplication));
         }
 
         void EnqueueReassign(TGroupRecord& group, EGroupRepairOperation operation) {
@@ -984,7 +995,7 @@ namespace NKikimr::NBsController {
     IActor *TBlobStorageController::CreateSelfHealActor() {
         Y_ABORT_UNLESS(HostRecords);
         return new TSelfHealActor(TabletID(), SelfHealUnreassignableGroups, HostRecords, GroupLayoutSanitizerEnabled,
-            AllowMultipleRealmsOccupation, DonorMode, EnableSelfHealWithDegraded, GroupLayoutSanitizerInvalidGroups);
+            AllowMultipleRealmsOccupation, DonorMode, EnableSelfHealWithDegraded, GroupLayoutSanitizerInvalidGroups, SelfHealSettings);
     }
 
     void TBlobStorageController::InitializeSelfHealState() {
@@ -1253,6 +1264,37 @@ namespace NKikimr::NBsController {
         TabletCounters->Simple()[NBlobStorageController::COUNTER_GROUP_LAYOUT_SANITIZER_INVALID_GROUPS] = GroupLayoutSanitizerInvalidGroups->load();
 
         Schedule(TDuration::Seconds(15), new TEvPrivate::TEvUpdateSelfHealCounters);
+    }
+
+    TSelfHealSettings ParseSelfHealSettings(const std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> storageConfig) {
+        TSelfHealSettings settings;
+
+        if (!storageConfig->HasBlobStorageConfig()) {
+            return settings;
+        }
+
+        const auto& bsConfig = storageConfig->GetBlobStorageConfig();
+
+        if (!bsConfig.HasBscSettings()) {
+            return settings;
+        }
+
+        const auto& bscSettings = bsConfig.GetBscSettings();
+
+        if (!bscSettings.HasSelfHealSettings()) {
+            return settings;
+        }
+
+        const auto& selfHealSettings = bscSettings.GetSelfHealSettings();
+
+        if (selfHealSettings.HasPreferLessOccupiedRack()) {
+            settings.PreferLessOccupiedRack = selfHealSettings.GetPreferLessOccupiedRack();
+        }
+        if (selfHealSettings.HasWithAttentionToReplication()) {
+            settings.WithAttentionToReplication = selfHealSettings.GetWithAttentionToReplication();
+        }
+
+        return settings;
     }
 
 } // NKikimr::NBsController

--- a/ydb/core/mind/bscontroller/self_heal.h
+++ b/ydb/core/mind/bscontroller/self_heal.h
@@ -8,6 +8,11 @@ namespace NKikimr::NBsController {
 
     class TGroupGeometryInfo;
 
+    struct TSelfHealSettings {
+        bool PreferLessOccupiedRack = false;
+        bool WithAttentionToReplication = false;
+    };
+
     struct TEvControllerUpdateSelfHealInfo : TEventLocal<TEvControllerUpdateSelfHealInfo, TEvBlobStorage::EvControllerUpdateSelfHealInfo> {
         struct TGroupContent {
             struct TVDiskInfo {
@@ -48,5 +53,7 @@ namespace NKikimr::NBsController {
             : VDiskStatusUpdate(std::move(updates))
         {}
     };
+
+    TSelfHealSettings ParseSelfHealSettings(const std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> storageConfig);
 
 } // NKikimr::NBsController

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -502,6 +502,13 @@ message TClusterBalancingSettings {
     optional uint64 IterationIntervalMs = 2;
     optional uint32 MaxReplicatingPDisks = 3;
     optional uint32 MaxReplicatingVDisks = 4;
+    optional bool PreferLessOccupiedRack = 5;
+    optional bool WithAttentionToReplication = 6;
+}
+
+message TSelfHealSettings {
+    optional bool PreferLessOccupiedRack = 1;
+    optional bool WithAttentionToReplication = 2;
 }
 
 message TUpdateSettings {
@@ -541,6 +548,7 @@ message TBscConfig {
     optional bool UseSelfHealLocalPolicy = 13;
     optional bool TryToRelocateBrokenDisksLocallyFirst = 14;
     optional TClusterBalancingSettings ClusterBalancingSettings = 15;
+    optional TSelfHealSettings SelfHealSettings = 16;
 }
 
 message TBoxStoragePoolId {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add ReplicationAwareness and PreferLessOccupiedRack parameters to automatic cluster balancing and self-heal

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
