### PR TITLE
[stable-25-3-1] Fix actorsystem counters core_limit

### DIFF
--- a/ydb/core/sys_view/service/ext_counters.cpp
+++ b/ydb/core/sys_view/service/ext_counters.cpp
@@ -37,7 +37,7 @@ class TExtCountersUpdaterActor
     ui64 InterconnectSentBytesPrev = 0;
     ui64 InterconnectReceivedBytesPrev = 0;
     TVector<TCounterPtr> PoolElapsedMicrosec;
-    TVector<TCounterPtr> PoolCurrentThreadCount;
+    TVector<TCounterPtr> PoolPotentialMaxThreadPercent;
     TVector<ui64> PoolElapsedMicrosecPrevValue;
     TVector<ui64> ExecuteLatencyMsValues;
     TVector<ui64> ExecuteLatencyMsPrevValues;
@@ -93,13 +93,13 @@ private:
             CGroupMemLimit = utilsGroup->FindCounter("Process/CGroupMemLimit");
 
             PoolElapsedMicrosec.resize(Config.Pools.size());
-            PoolCurrentThreadCount.resize(Config.Pools.size());
+            PoolPotentialMaxThreadPercent.resize(Config.Pools.size());
             PoolElapsedMicrosecPrevValue.resize(Config.Pools.size());
             for (size_t i = 0; i < Config.Pools.size(); ++i) {
                 auto poolGroup = utilsGroup->FindSubgroup("execpool", Config.Pools[i].Name);
                 if (poolGroup) {
                     PoolElapsedMicrosec[i] = poolGroup->FindCounter("ElapsedMicrosec");
-                    PoolCurrentThreadCount[i] = poolGroup->FindCounter("CurrentThreadCount");
+                    PoolPotentialMaxThreadPercent[i] = poolGroup->FindCounter("PotentialMaxThreadCountPercent");
                     if (PoolElapsedMicrosec[i]) {
                         PoolElapsedMicrosecPrevValue[i] = PoolElapsedMicrosec[i]->Val();
                     }
@@ -161,11 +161,11 @@ private:
                     }
                     PoolElapsedMicrosecPrevValue[i] = elapsedMs;
                 }
-                if (PoolCurrentThreadCount[i] && PoolCurrentThreadCount[i]->Val()) {
-                    limitCore = PoolCurrentThreadCount[i]->Val();
-                    CpuLimitCorePercents[i]->Set(limitCore * 100);
+                if (PoolPotentialMaxThreadPercent[i] && PoolPotentialMaxThreadPercent[i]->Val()) {
+                    limitCore = PoolPotentialMaxThreadPercent[i]->Val();
+                    CpuLimitCorePercents[i]->Set(limitCore);
                 } else {
-                    limitCore = Config.Pools[i].ThreadCount * 100;
+                    limitCore = Config.Pools[i].ThreadCount;
                     CpuLimitCorePercents[i]->Set(limitCore * 100);
                 }
                 if (limitCore > 0) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a bug with the actor system counters: when shared threads were enabled in the actor system and the number of available cores was less than 1, it displayed a significantly overestimated core count.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required) 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
