### PR TITLE
Do not run rdma ut with msan due to no support in the verbs *.so library

### DIFF
--- a/ydb/library/actors/interconnect/rdma/ut/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ut/ya.make
@@ -1,6 +1,6 @@
 UNITTEST()
 
-IF (OS_LINUX)
+IF (OS_LINUX AND SANITIZER_TYPE != "memory")
 
 SRCS(
     ibv_ut.cpp


### PR DESCRIPTION
### Changelog entry

verbs library is external *.so library and does not have support for memory sanitiser. 


### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)


