### PR TITLE
Make scalar hash join unit tests correct

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/dq_hash_join_table.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_join_table.h
@@ -32,7 +32,6 @@ class TStdJoinTable {
     }
 
     void Lookup(TTuple key, std::function<void(TTuple)> produce) const {
-        Y_ABORT_IF(BuiltTable.empty(), "call Build first");
         auto it = BuiltTable.find(key);
         if (it != BuiltTable.end()) {
             std::ranges::for_each(it->second, produce);

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_join_table.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_join_table.h
@@ -14,7 +14,7 @@ class TStdJoinTable {
 
     void Add(std::span<NYql::NUdf::TUnboxedValue> tuple) {
         Y_ABORT_UNLESS(BuiltTable.empty(), "JoinTable is built already");
-        Y_ABORT_UNLESS(std::ssize(tuple) == TupleSize, "tuple size promise vs actual mismatch");
+        MKQL_ENSURE(std::ssize(tuple) == TupleSize, "tuple size promise vs actual mismatch");
         for (int idx = 0; idx < TupleSize; ++idx) {
             Tuples.push_back(tuple[idx]);
         }

--- a/ydb/library/yql/dq/comp_nodes/dq_scalar_hash_join.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_scalar_hash_join.cpp
@@ -48,7 +48,6 @@ public:
     ,   LogComponent_(logComponent)
     ,   KeyTypes_(KeyTypesFromColumns(leftColumnTypes))
     ,   Table_(std::ssize(leftColumnTypes), TWideUnboxedEqual{KeyTypes_}, TWideUnboxedHasher{KeyTypes_})
-    
     ,   Values_(rightColumnTypes.size())
     ,   Pointers_()
     ,   Output_()

--- a/ydb/library/yql/dq/comp_nodes/ut/dq_scalar_hash_join_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/ut/dq_scalar_hash_join_ut.cpp
@@ -14,7 +14,7 @@ namespace NMiniKQL {
 
 namespace {
 
-NUdf::TUnboxedValue DoTestDqScalarHashJoin(
+THolder<IComputationGraph> DoTestDqScalarHashJoin(
     TDqSetup<false>& setup,
     TType* leftType, NUdf::TUnboxedValue&& leftListValue, const TVector<ui32>& leftKeyColumns,
     TType* rightType, NUdf::TUnboxedValue&& rightListValue, const TVector<ui32>& rightKeyColumns,
@@ -44,14 +44,14 @@ NUdf::TUnboxedValue DoTestDqScalarHashJoin(
     
     const auto joinNode = pb.DqScalarHashJoin(leftFlow, rightFlow, joinKind, leftKeyColumns, rightKeyColumns, resultFlowType);
     
-    const auto resultNode = FromWideFlow(pb, joinNode);
+    const auto resultNode = FromWideStreamToTupleStream(pb, pb.FromFlow(joinNode));
 
-    const auto graph = setup.BuildGraph(resultNode, {leftList.GetNode(), rightList.GetNode()});
+    auto graph = setup.BuildGraph(resultNode, {leftList.GetNode(), rightList.GetNode()});
     auto& ctx = graph->GetContext();
 
     graph->GetEntryPoint(0, true)->SetValue(ctx, std::move(leftListValue));
     graph->GetEntryPoint(1, true)->SetValue(ctx, std::move(rightListValue));
-    return graph->GetValue();
+    return graph;
 }
 
 void RunTestDqScalarHashJoin(
@@ -60,15 +60,14 @@ void RunTestDqScalarHashJoin(
     TType* leftType, NUdf::TUnboxedValue&& leftListValue, const TVector<ui32>& leftKeyColumns,
     TType* rightType, NUdf::TUnboxedValue&& rightListValue, const TVector<ui32>& rightKeyColumns
 ) {
-    const auto got = DoTestDqScalarHashJoin(
+    auto got = DoTestDqScalarHashJoin(
         setup,
         leftType, std::move(leftListValue), leftKeyColumns,
         rightType, std::move(rightListValue), rightKeyColumns,
         joinKind
     );
     
-    UNIT_ASSERT(got.HasValue());
-    CompareListsIgnoringOrder(expectedType, expected, got);
+    CompareListAndStreamIgnoringOrder(expectedType, expected, *got);
 }
 
 } // namespace
@@ -80,12 +79,12 @@ Y_UNIT_TEST_SUITE(TDqScalarHashJoinBasicTest) {
         
         TVector<ui64> leftKeys = {1, 2, 3, 4, 5};
         TVector<TString> leftValues = {"a", "b", "c", "d", "e"};
-        
-        TVector<ui64> rightKeys = {2, 3, 4, 6, 7};
-        TVector<TString> rightValues = {"x", "y", "z", "u", "v"};
 
-        TVector<ui64> expectedKeys = {1, 2, 3, 4, 5, 2, 3, 4, 6, 7};
-        TVector<TString> expectedValues = {"a", "b", "c", "d", "e", "x", "y", "z", "u", "v"};
+        TVector<ui64> rightKeys = {2, 3, 4, 5, 6};
+        TVector<TString> rightValues = {"b", "c", "d", "e", "f"};
+
+        TVector<ui64> expectedKeys = {2, 3, 4, 5};
+        TVector<TString> expectedValues = {"b", "c", "d", "e"};
 
         auto [leftType, leftList] = ConvertVectorsToTuples(setup, leftKeys, leftValues);
         auto [rightType, rightList] = ConvertVectorsToTuples(setup, rightKeys, rightValues);
@@ -126,8 +125,8 @@ Y_UNIT_TEST_SUITE(TDqScalarHashJoinBasicTest) {
         TVector<ui64> rightKeys = {1, 2, 3};
         TVector<TString> rightValues = {"x", "y", "z"};
 
-        TVector<ui64> expectedKeys = {1, 2, 3};
-        TVector<TString> expectedValues = {"x", "y", "z"};
+        TVector<ui64> expectedKeys;
+        TVector<TString> expectedValues;
 
         auto [leftType, leftList] = ConvertVectorsToTuples(setup, emptyKeys, emptyValues);
         auto [rightType, rightList] = ConvertVectorsToTuples(setup, rightKeys, rightValues);
@@ -150,8 +149,8 @@ Y_UNIT_TEST_SUITE(TDqScalarHashJoinBasicTest) {
         TVector<ui64> emptyKeys;
         TVector<TString> emptyValues;
 
-        TVector<ui64> expectedKeys = {1, 2, 3};
-        TVector<TString> expectedValues = {"a", "b", "c"};
+        TVector<ui64> expectedKeys;
+        TVector<TString> expectedValues;
 
         auto [leftType, leftList] = ConvertVectorsToTuples(setup, leftKeys, leftValues);
         auto [rightType, rightList] = ConvertVectorsToTuples(setup, emptyKeys, emptyValues);

--- a/ydb/library/yql/dq/comp_nodes/ut/dq_scalar_hash_join_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/ut/dq_scalar_hash_join_ut.cpp
@@ -84,12 +84,12 @@ Y_UNIT_TEST_SUITE(TDqScalarHashJoinBasicTest) {
         TVector<TString> rightValues = {"b2", "c2", "d2", "e2", "f"};
 
         TVector<ui64> expectedKeys = {2, 3, 4, 5};
-        TVector<TString> expectedValues1 = {"b1", "c1", "d1", "e1"};
-        TVector<TString> expectedValues2 = {"b2", "c2", "d2", "e2"};
+        TVector<TString> expectedValuesLeft = {"b1", "c1", "d1", "e1"};
+        TVector<TString> expectedValuesRight = {"b2", "c2", "d2", "e2"};
 
         auto [leftType, leftList] = ConvertVectorsToTuples(setup, leftKeys, leftValues);
         auto [rightType, rightList] = ConvertVectorsToTuples(setup, rightKeys, rightValues);
-        auto [expectedType, expected] = ConvertVectorsToTuples(setup, expectedKeys, expectedValues1, expectedValues2);
+        auto [expectedType, expected] = ConvertVectorsToTuples(setup, expectedKeys, expectedValuesLeft, expectedValuesRight);
 
         RunTestDqScalarHashJoin(
             setup, EJoinKind::Inner,

--- a/ydb/library/yql/dq/comp_nodes/ut/dq_scalar_hash_join_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/ut/dq_scalar_hash_join_ut.cpp
@@ -78,17 +78,18 @@ Y_UNIT_TEST_SUITE(TDqScalarHashJoinBasicTest) {
         TDqSetup<false> setup(GetDqNodeFactory());
         
         TVector<ui64> leftKeys = {1, 2, 3, 4, 5};
-        TVector<TString> leftValues = {"a", "b", "c", "d", "e"};
+        TVector<TString> leftValues = {"a", "b1", "c1", "d1", "e1"};
 
         TVector<ui64> rightKeys = {2, 3, 4, 5, 6};
-        TVector<TString> rightValues = {"b", "c", "d", "e", "f"};
+        TVector<TString> rightValues = {"b2", "c2", "d2", "e2", "f"};
 
         TVector<ui64> expectedKeys = {2, 3, 4, 5};
-        TVector<TString> expectedValues = {"b", "c", "d", "e"};
+        TVector<TString> expectedValues1 = {"b1", "c1", "d1", "e1"};
+        TVector<TString> expectedValues2 = {"b2", "c2", "d2", "e2"};
 
         auto [leftType, leftList] = ConvertVectorsToTuples(setup, leftKeys, leftValues);
         auto [rightType, rightList] = ConvertVectorsToTuples(setup, rightKeys, rightValues);
-        auto [expectedType, expected] = ConvertVectorsToTuples(setup, expectedKeys, expectedValues);
+        auto [expectedType, expected] = ConvertVectorsToTuples(setup, expectedKeys, expectedValues1, expectedValues2);
 
         RunTestDqScalarHashJoin(
             setup, EJoinKind::Inner,

--- a/ydb/library/yql/dq/comp_nodes/ut/utils/utils.h
+++ b/ydb/library/yql/dq/comp_nodes/ut/utils/utils.h
@@ -34,9 +34,17 @@ TRuntimeNode ToWideFlow(TProgramBuilder& pgmBuilder, TRuntimeNode list);
 // WideFlow -> List<Tuple<...>>
 TRuntimeNode FromWideFlow(TProgramBuilder& pgmBuilder, TRuntimeNode wideFlow);
 
+// Stream<Multi<...>> -> Stream<Tuple<...>>
+TRuntimeNode FromWideStreamToTupleStream(TProgramBuilder& pgmBuilder, TRuntimeNode stream);
+
 TVector<NUdf::TUnboxedValue> ConvertListToVector(const NUdf::TUnboxedValue& list); 
 
-void CompareListsIgnoringOrder(const TType* type, const NUdf::TUnboxedValue& expected, const NUdf::TUnboxedValue& got);
+TVector<NUdf::TUnboxedValue> ConvertStreamToVector(IComputationGraph& tupleStream);
+
+void CompareListsIgnoringOrder(const TType* type, const NUdf::TUnboxedValue& expected,
+                               const NUdf::TUnboxedValue& gotList);
+void CompareListAndStreamIgnoringOrder(const TType* type, const NUdf::TUnboxedValue& expected,
+                                       IComputationGraph& gotStream);
 template<typename Type>
 const TVector<const TRuntimeNode> BuildListNodes(TProgramBuilder& pb,
     const TVector<Type>& vector


### PR DESCRIPTION
Fixes: #25782
...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Before this pr join unit tests were not correct, because join just concatenated 2 tables and unit tests were verifying this fact.

This pr make unit tests correct, and fix scalar hash hoin accordingly

This scalar hash join implementation doesnt support larger-than-memory right table, is very bad performance-wise, does only support inner join and doesnt support renames.

todo: add tests for different join types and renames
...
