### PR TITLE
TMeteringStatsHelper.TryFixOldFormat is no longer needed

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
@@ -44,14 +44,6 @@ TMeteringStats& operator -= (TMeteringStats& value, const TMeteringStats& other)
     return value;
 }
 
-void TMeteringStatsHelper::TryFixOldFormat(TMeteringStats& value) {
-    // old format: assign upload to read
-    if (value.GetReadRows() == 0 && value.GetUploadRows() != 0) {
-        value.SetReadRows(value.GetUploadRows());
-        value.SetReadBytes(value.GetUploadBytes());
-    }
-}
-
 TMeteringStats TMeteringStatsHelper::ZeroValue() {
     // this method the only purpose is to beautifully print zero stats instead of empty protobuf or with missing fields
     TMeteringStats value;

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
@@ -13,7 +13,6 @@ TMeteringStats& operator += (TMeteringStats& value, const TMeteringStats& other)
 TMeteringStats& operator -= (TMeteringStats& value, const TMeteringStats& other);
 
 struct TMeteringStatsHelper {
-    static void TryFixOldFormat(TMeteringStats& value);
     static TMeteringStats ZeroValue();
     static bool IsZero(TMeteringStats& value);
 };

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3614,18 +3614,12 @@ public:
         indexInfo->Billed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsBilled>(0));
         indexInfo->Billed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesBilled>(0));
         indexInfo->Billed.SetCpuTimeUs(row.template GetValueOrDefault<Schema::IndexBuild::CpuTimeUsBilled>(0));
-        if (indexInfo->IsOldBuildIndex()) {
-            TMeteringStatsHelper::TryFixOldFormat(indexInfo->Billed);
-        }
 
         indexInfo->Processed.SetUploadRows(row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsProcessed>(0));
         indexInfo->Processed.SetUploadBytes(row.template GetValueOrDefault<Schema::IndexBuild::UploadBytesProcessed>(0));
         indexInfo->Processed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsProcessed>(0));
         indexInfo->Processed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesProcessed>(0));
         indexInfo->Processed.SetCpuTimeUs(row.template GetValueOrDefault<Schema::IndexBuild::CpuTimeUsProcessed>(0));
-        if (indexInfo->IsOldBuildIndex()) {
-            TMeteringStatsHelper::TryFixOldFormat(indexInfo->Processed);
-        }
 
         // Restore the operation details: ImplTableDescriptions and SpecializedIndexDescription.
         if (row.template HaveValue<Schema::IndexBuild::CreationConfig>()) {
@@ -3703,18 +3697,11 @@ public:
         shardStatus.Processed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadRowsProcessed>(0));
         shardStatus.Processed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadBytesProcessed>(0));
         shardStatus.Processed.SetCpuTimeUs(row.template GetValueOrDefault<Schema::IndexBuildShardStatus::CpuTimeUsProcessed>(0));
-        if (IsOldBuildIndex()) {
-            TMeteringStatsHelper::TryFixOldFormat(shardStatus.Processed);
-        }
         Processed += shardStatus.Processed;
     }
 
     bool IsCancellationRequested() const {
         return CancelRequested;
-    }
-
-    bool IsOldBuildIndex() const {
-        return IsBuildSecondaryIndex() || IsBuildColumns();
     }
 
     TString InvalidBuildKind() {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TMeteringStatsHelper.TryFixOldFormat was added for backward compatibilyty, but because we only bill during index build, it is no longer needed anymore

https://github.com/ydb-platform/ydb/pull/25811#discussion_r2388206369
