### PR TITLE
Fix data race on Checksumming field in TGroupSessions

### DIFF
--- a/ydb/core/blobstorage/dsproxy/group_sessions.cpp
+++ b/ydb/core/blobstorage/dsproxy/group_sessions.cpp
@@ -129,7 +129,7 @@ void TGroupSessions::QueueConnectUpdate(ui32 orderNumber, NKikimrBlobStorage::EV
     if (connected) {
         ConnectedQueuesMask[orderNumber] |= 1 << queueId;
         q.ExtraBlockChecksSupport = extraGroupChecksSupport;
-        q.Checksumming = checksumming;
+        q.Checksumming.store(checksumming);
         Y_ABORT_UNLESS(costModel);
         if (!q.CostModel || *q.CostModel != *costModel) {
             updated = true;
@@ -138,7 +138,7 @@ void TGroupSessions::QueueConnectUpdate(ui32 orderNumber, NKikimrBlobStorage::EV
     } else {
         ConnectedQueuesMask[orderNumber] &= ~(1 << queueId);
         q.ExtraBlockChecksSupport.reset();
-        q.Checksumming.reset();
+        q.Checksumming.store(false);
         if (q.CostModel) {
             updated = true;
             q.CostModel = nullptr;

--- a/ydb/core/blobstorage/dsproxy/group_sessions.cpp
+++ b/ydb/core/blobstorage/dsproxy/group_sessions.cpp
@@ -85,7 +85,7 @@ TGroupSessions::TGroupSessions(const TIntrusivePtr<TBlobStorageGroupInfo>& info,
             auto& q = stateVDisk.Queues.GetQueue(queueId);
             q.ActorId = queue;
             q.FlowRecord = std::move(flowRecord);
-            q.ExtraBlockChecksSupport.reset();
+            q.ExtraBlockChecksSupport.store(false);
         }
     }
 }
@@ -128,7 +128,7 @@ void TGroupSessions::QueueConnectUpdate(ui32 orderNumber, NKikimrBlobStorage::EV
 
     if (connected) {
         ConnectedQueuesMask[orderNumber] |= 1 << queueId;
-        q.ExtraBlockChecksSupport = extraGroupChecksSupport;
+        q.ExtraBlockChecksSupport.store(extraGroupChecksSupport);
         q.Checksumming.store(checksumming);
         Y_ABORT_UNLESS(costModel);
         if (!q.CostModel || *q.CostModel != *costModel) {
@@ -137,7 +137,7 @@ void TGroupSessions::QueueConnectUpdate(ui32 orderNumber, NKikimrBlobStorage::EV
         }
     } else {
         ConnectedQueuesMask[orderNumber] &= ~(1 << queueId);
-        q.ExtraBlockChecksSupport.reset();
+        q.ExtraBlockChecksSupport.store(false);
         q.Checksumming.store(false);
         if (q.CostModel) {
             updated = true;

--- a/ydb/core/blobstorage/dsproxy/group_sessions.h
+++ b/ydb/core/blobstorage/dsproxy/group_sessions.h
@@ -21,8 +21,20 @@ namespace NKikimr {
                 struct TQueue {
                     TActorId ActorId;
                     TIntrusivePtr<NBackpressure::TFlowRecord> FlowRecord;
-                    std::optional<bool> ExtraBlockChecksSupport;
-                    std::atomic<bool> Checksumming;
+                    struct AtomicParameter : public std::atomic<bool> {
+                        AtomicParameter& operator=(const AtomicParameter& other) {
+                            store(other.load());
+                            return *this;
+                        }
+
+                        AtomicParameter(const AtomicParameter& other) {
+                            store(other.load());
+                        }
+
+                        AtomicParameter() {
+                            store(false);
+                        }
+                    } ExtraBlockChecksSupport, Checksumming;
                     std::shared_ptr<const TCostModel> CostModel = nullptr;
                     volatile bool IsConnected = false;
                 };

--- a/ydb/core/blobstorage/dsproxy/group_sessions.h
+++ b/ydb/core/blobstorage/dsproxy/group_sessions.h
@@ -22,7 +22,7 @@ namespace NKikimr {
                     TActorId ActorId;
                     TIntrusivePtr<NBackpressure::TFlowRecord> FlowRecord;
                     std::optional<bool> ExtraBlockChecksSupport;
-                    std::optional<bool> Checksumming;
+                    std::atomic<bool> Checksumming;
                     std::shared_ptr<const TCostModel> CostModel = nullptr;
                     volatile bool IsConnected = false;
                 };
@@ -190,7 +190,7 @@ namespace NKikimr {
                 .Queues
                 .GetQueue(queueId)
                 .Checksumming
-                .value_or(false);
+                .load();
         }
 
         ui64 GetPredictedDelayNsByOrderNumber(ui32 orderNumber, NKikimrBlobStorage::EVDiskQueueId queueId) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes https://github.com/ydb-platform/ydb/issues/26059

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Checksumming field may be accessed from different threads, so we make it atomic.
