### PR TITLE
Filled DatabaseName in LoadTest while sending TEvNavigate events

### DIFF
--- a/ydb/core/load_test/ycsb/kqp_select.cpp
+++ b/ydb/core/load_test/ycsb/kqp_select.cpp
@@ -329,6 +329,7 @@ private:
     void DescribePath(const TActorContext& ctx) {
         TString path = Target.GetWorkingDir() + "/" + Target.GetTableName();
         auto request = std::make_unique<TEvTxUserProxy::TEvNavigate>();
+        request->Record.SetDatabaseName(Target.GetWorkingDir());
         request->Record.MutableDescribePath()->SetPath(path);
         ctx.Send(MakeTxProxyID(), request.release());
     }

--- a/ydb/core/load_test/ycsb/test_load_actor.cpp
+++ b/ydb/core/load_test/ycsb/test_load_actor.cpp
@@ -270,6 +270,7 @@ public:
         TString path = setup.GetWorkingDir() + "/" + setup.GetTableName();
 
         auto request = std::make_unique<TEvTxUserProxy::TEvNavigate>();
+        request->Record.SetDatabaseName(Request.GetTableSetup().GetWorkingDir());
         request->Record.MutableDescribePath()->SetPath(path);
 
         ctx.Send(MakeTxProxyID(), request.release());

--- a/ydb/core/load_test/ycsb/test_load_read_iterator.cpp
+++ b/ydb/core/load_test/ycsb/test_load_read_iterator.cpp
@@ -359,6 +359,7 @@ private:
     void DescribePath(const TActorContext& ctx) {
         TString path = Target.GetWorkingDir() + "/" + Target.GetTableName();
         auto request = std::make_unique<TEvTxUserProxy::TEvNavigate>();
+        request->Record.SetDatabaseName(Target.GetWorkingDir());
         request->Record.MutableDescribePath()->SetPath(path);
         ctx.Send(MakeTxProxyID(), request.release());
     }


### PR DESCRIPTION
Improve isolation of Describe path requests in Load tests