### PR TITLE
The order of the keys at the start of the partition

### DIFF
--- a/ydb/core/persqueue/pqtablet/common/logging.h
+++ b/ydb/core/persqueue/pqtablet/common/logging.h
@@ -22,4 +22,6 @@ inline TString LogPrefix() { return {}; }
 #define PQ_LOG_TX_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_TX, LogPrefix() << stream)
 #define PQ_LOG_TX_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PQ_TX, LogPrefix() << stream)
 
+#define PQ_INIT_LOG_D(stream) if (NActors::TlsActivationContext) { LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/blob_key_filter.h
+++ b/ydb/core/persqueue/pqtablet/partition/blob_key_filter.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <ydb/core/persqueue/common/partition_id.h>
+#include <ydb/core/protos/msgbus_kv.pb.h>
+
+#include <util/generic/hash_set.h>
+#include <util/generic/string.h>
+
+namespace NKikimr::NPQ {
+
+THashSet<TString> FilterBlobsMetaData(const NKikimrClient::TKeyValueResponse::TReadRangeResult& range,
+                                                                            const TPartitionId& partitionId);
+
+}

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -552,7 +552,7 @@ THashSet<TString> FilterBlobsMetaData(const NKikimrClient::TKeyValueResponse::TR
     std::sort(keys.begin(), keys.end(), compare);
 
     for (size_t i = 0; i < keys.size(); ++i) {
-        PQ_LOG_D("key[" << i << "]: " << keys[i]);
+        PQ_INIT_LOG_D("key[" << i << "]: " << keys[i]);
     }
 
     TVector<TString> filtered;
@@ -560,7 +560,7 @@ THashSet<TString> FilterBlobsMetaData(const NKikimrClient::TKeyValueResponse::TR
 
     for (auto& k : keys) {
         if (filtered.empty()) {
-            PQ_LOG_D("add key " << k);
+            PQ_INIT_LOG_D("add key " << k);
             filtered.push_back(std::move(k));
             lastKey = TKey::FromString(filtered.back(), partitionId);
         } else {
@@ -568,32 +568,41 @@ THashSet<TString> FilterBlobsMetaData(const NKikimrClient::TKeyValueResponse::TR
 
             if (lastKey.GetOffset() == candidate.GetOffset()) {
                 if (lastKey.GetPartNo() == candidate.GetPartNo()) {
-                    // candidate содержит lastKey
-                    AFL_ENSURE(lastKey.GetCount() <= candidate.GetCount())
-                        ("lastKey", lastKey.ToString())("candidate", candidate.ToString().data());
                     if (lastKey.GetCount() < candidate.GetCount()) {
-                        PQ_LOG_D("replace key " << filtered.back() << " to " << k);
+                        // candidate содержит lastKey
+                        PQ_INIT_LOG_D("replace key " << filtered.back() << " to " << k);
                         filtered.back() = std::move(k);
                         lastKey = candidate;
+                    } else if (lastKey.GetCount() == candidate.GetCount()) {
+                        if (lastKey.GetInternalPartsCount() < candidate.GetInternalPartsCount()) {
+                            // candidate содержит lastKey
+                            PQ_INIT_LOG_D("replace key " << filtered.back() << " to " << k);
+                            filtered.back() = std::move(k);
+                            lastKey = candidate;
+                        } else {
+                            // lastKey содержит candidate
+                            PQ_INIT_LOG_D("ignore key " << k);
+                        }
+                    } else {
+                        // lastKey содержит candidate
+                        PQ_INIT_LOG_D("ignore key " << k);
                     }
                 } else if (lastKey.GetPartNo() > candidate.GetPartNo()) {
-                    PQ_LOG_D("ignore key " << k);
+                    // lastKey содержит candidate
+                    PQ_INIT_LOG_D("ignore key " << k);
                 } else {
                     // candidate после lastKey
-                    //PQ_INIT_ENSURE(lastKey.GetPartNo() + lastKey.GetInternalPartsCount() == candidate.GetPartNo(),
-                    //               "lastKey=%s, candidate=%s",
-                    //               lastKey.ToString().data(), candidate.ToString().data());
-                    PQ_LOG_D("add key " << k);
+                    PQ_INIT_LOG_D("add key " << k);
                     filtered.push_back(std::move(k));
                     lastKey = candidate;
                 }
             } else {
                 if (const ui64 nextOffset = lastKey.GetOffset() + lastKey.GetCount(); nextOffset > candidate.GetOffset()) {
                     // lastKey содержит candidate
-                    PQ_LOG_D("ignore key " << k);
+                    PQ_INIT_LOG_D("ignore key " << k);
                 } else {
                     // candidate после lastKey или пропуск между lastKey и candidate
-                    PQ_LOG_D("add key " << k);
+                    PQ_INIT_LOG_D("add key " << k);
                     filtered.push_back(std::move(k));
                     lastKey = candidate;
                 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue #26050

The sorting order has changed. Keys with the suffix `?` are at the end of the list. Predicate `lastKey.getCount() <= candidate.getCount()` doesn't make sense.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
