### PR TITLE
The order of the keys at the start of the partition

### DIFF
--- a/ydb/core/persqueue/pqtablet/common/logging.h
+++ b/ydb/core/persqueue/pqtablet/common/logging.h
@@ -22,4 +22,6 @@ inline TString LogPrefix() { return {}; }
 #define PQ_LOG_TX_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_TX, LogPrefix() << stream)
 #define PQ_LOG_TX_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PQ_TX, LogPrefix() << stream)
 
+#define PQ_INIT_LOG_D(stream) if (NActors::TlsActivationContext) { LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+
 } // namespace NKikimr::NPQ


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Changes from #26110

The sorting order has changed. Keys with the suffix `?` are at the end of the list. Predicate `lastKey.getCount() <= candidate.getCount()` doesn't make sense.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
