### PR TITLE
Support for persistent row locks in LocalDB

### DIFF
--- a/ydb/core/tablet_flat/flat_abi_evol.h
+++ b/ydb/core/tablet_flat/flat_abi_evol.h
@@ -25,7 +25,7 @@ namespace NTable {
 
         Tail = 1,
         Head = 17,
-        Edge = 28,
+        Edge = 29,
     };
 
     /* Ev | Desc                                                   | Gone
@@ -91,6 +91,8 @@ namespace NTable {
        27   Parts with versioned rows and historic indexes
      ---------------------------------------------------------------------
        28   Parts with uncommitted delta rows
+     ---------------------------------------------------------------------
+       29   Parts with persistent row locks
      */
 
 }

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -367,6 +367,20 @@ void TDatabase::UpdateTx(ui32 table, ERowOp rop, TRawVals key, TArrayRef<const T
     RequireForUpdate(table)->UpdateTx(rop, key, ModifiedOps, Annex->Current(), txId);
 }
 
+void TDatabase::LockRowTx(ui32 table, ELockMode mode, TRawVals key, ui64 txId)
+{
+    Y_ENSURE(mode != ELockMode::None);
+
+    for (size_t index = 0; index < key.size(); ++index) {
+        if (auto error = NScheme::HasUnexpectedValueSize(key[index])) {
+            Y_TABLET_ERROR("Key index " << index << " validation failure: " << error);
+        }
+    }
+
+    Redo->EvLockRowTx(table, mode, key, txId);
+    RequireForUpdate(table)->LockRowTx(mode, key, txId);
+}
+
 void TDatabase::RemoveTx(ui32 table, ui64 txId)
 {
     Redo->EvRemoveTx(table, txId);

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -149,6 +149,7 @@ public:
     void Update(ui32 table, ERowOp, TRawVals key, TArrayRef<const TUpdateOp>, TRowVersion rowVersion = TRowVersion::Min());
 
     void UpdateTx(ui32 table, ERowOp, TRawVals key, TArrayRef<const TUpdateOp>, ui64 txId);
+    void LockRowTx(ui32 table, ELockMode, TRawVals key, ui64 txId);
     void RemoveTx(ui32 table, ui64 txId);
     void CommitTx(ui32 table, ui64 txId, TRowVersion rowVersion = TRowVersion::Min());
 

--- a/ydb/core/tablet_flat/flat_dbase_naked.h
+++ b/ydb/core/tablet_flat/flat_dbase_naked.h
@@ -780,6 +780,17 @@ namespace NTable {
             Stats.MemTableBytes += wrap->GetMemSize();
         }
 
+        void DoLockRowTx(ui32 tid, ELockMode mode, TKeys key, ui64 txId)
+        {
+            auto &wrap = Touch(tid);
+
+            NUtil::SubSafe(Stats.MemTableWaste, wrap->GetMemWaste());
+            NUtil::SubSafe(Stats.MemTableBytes, wrap->GetMemSize());
+            wrap->LockRowTx(mode, key, txId);
+            Stats.MemTableWaste += wrap->GetMemWaste();
+            Stats.MemTableBytes += wrap->GetMemSize();
+        }
+
         void DoFlush(ui32 tid, ui64 /* stamp */, TEpoch epoch)
         {
             auto on = Touch(tid)->Snapshot();

--- a/ydb/core/tablet_flat/flat_mem_eggs.h
+++ b/ydb/core/tablet_flat/flat_mem_eggs.h
@@ -45,7 +45,8 @@ namespace NMem {
         const TUpdate *Next;
         TRowVersion RowVersion;
         ui16 Items;
-        ERowOp Rop;
+        ERowOp Rop : 4;
+        ELockMode Lock : 4;
     };
 
     struct TTreeKey {

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -94,6 +94,7 @@ namespace NTable {
             KeyState.Written = 0;
             KeyState.Final = Final || (UnderlayMask && !UnderlayMask->HasKey(key));
             KeyState.DelayedErase = false;
+            KeyState.LockMode = ELockMode::None;
 
             if (SplitKeys && SplitKeys->ShouldSplit(key) && NextSliceFirstRowId != Max<TRowId>()) {
                 // Force a new slice on flush
@@ -107,6 +108,17 @@ namespace NTable {
                 Y_DEBUG_ABORT_UNLESS(!NextSliceForce);
                 Y_DEBUG_ABORT_UNLESS(NextSliceFirstRowId == Max<TRowId>());
             }
+        }
+
+        void AddKeyLock(ELockMode lockMode, ui64 lockTxId)
+        {
+            Y_ENSURE(KeyState.LockMode == ELockMode::None, "Cannot add multiple locks");
+            Y_ENSURE(KeyState.Written == 0, "Cannot add lock after committed versions");
+            Y_ENSURE(lockMode != ELockMode::None, "Cannot add lock with mode == None");
+            Y_ENSURE(lockTxId != 0, "Cannot add lock with txId == 0");
+
+            KeyState.LockMode = lockMode;
+            KeyState.LockTxId = lockTxId;
         }
 
         void AddKeyDelta(const TRowState& row, ui64 txId)
@@ -136,10 +148,16 @@ namespace NTable {
                 WriteRow(EraseRowState, KeyState.LastVersion, TRowVersion::Max());
                 KeyState.LastWritten = KeyState.LastVersion;
                 KeyState.DelayedErase = false;
-            } else if (KeyState.WrittenDeltas && !KeyState.Written) {
-                // We have written some deltas, but no committed versions
-                // We need to properly flush uncommitted deltas
-                FlushDeltaRows();
+            } else if (!KeyState.Written) {
+                if (KeyState.LockMode != ELockMode::None) {
+                    WriteDeltaRow(TRowState(), KeyState.LockTxId);
+                    Y_DEBUG_ABORT_UNLESS(KeyState.LockMode == ELockMode::None);
+                }
+                if (KeyState.WrittenDeltas) {
+                    // We have written some deltas, but no committed versions
+                    // We need to properly flush uncommitted deltas
+                    FlushDeltaRows();
+                }
             }
 
             return KeyState.Written + KeyState.WrittenDeltas;
@@ -186,7 +204,7 @@ namespace NTable {
                 auto& g = Groups[groupIdx];
                 // N.B. non-main groups have no key
                 TCellsRef groupKey = groupIdx == 0 ? KeyState.Key : TCellsRef{ };
-                g.NextDataSize = g.Data.CalcSize(groupKey, row, KeyState.Final, TRowVersion::Min(), TRowVersion::Max(), txId);
+                g.NextDataSize = g.Data.CalcSize(groupKey, row, KeyState.Final, TRowVersion::Min(), TRowVersion::Max(), txId, KeyState.LockMode, KeyState.LockTxId);
                 g.NextIndexSize = WriteFlatIndex ? g.FlatIndex.CalcSize(groupKey) : 0;
                 g.NextBTreeIndexSize = WriteBTreeIndex ? g.BTreeIndex.CalcSize(groupKey) : 0;
                 overheadBytes += (
@@ -204,6 +222,10 @@ namespace NTable {
                 }
             }
 
+            if (KeyState.LockMode != ELockMode::None && KeyState.LockTxId != txId) {
+                Current.TxIdStatsBuilder.AddRow(KeyState.LockTxId, sizeof(NPage::TDataPage::TLocked));
+                overheadBytes -= sizeof(NPage::TDataPage::TLocked);
+            }
             Current.TxIdStatsBuilder.AddRow(txId, overheadBytes);
             Current.DeltaRows += 1;
 
@@ -217,13 +239,18 @@ namespace NTable {
             FrameS.FlushRow();
             FrameL.FlushRow();
 
+            if (KeyState.LockMode != ELockMode::None) {
+                Current.RowLocks = true;
+            }
+
             for (size_t groupIdx : xrange(Groups.size())) {
                 auto& g = Groups[groupIdx];
                 // N.B. non-main groups have no key
                 TCellsRef groupKey = groupIdx == 0 ? KeyState.Key : TCellsRef{ };
-                g.Data.Add(g.NextDataSize, groupKey, row, *this, KeyState.Final, TRowVersion::Min(), TRowVersion::Max(), txId);
+                g.Data.Add(g.NextDataSize, groupKey, row, *this, KeyState.Final, TRowVersion::Min(), TRowVersion::Max(), txId, KeyState.LockMode, KeyState.LockTxId);
             }
 
+            KeyState.LockMode = ELockMode::None;
             ++KeyState.WrittenDeltas;
         }
 
@@ -252,7 +279,7 @@ namespace NTable {
                 auto& g = Groups[groupIdx];
                 // N.B. non-main groups have no key
                 TCellsRef groupKey = groupIdx == 0 ? KeyState.Key : TCellsRef{ };
-                g.NextDataSize = g.Data.CalcSize(groupKey, row, KeyState.Final, minVersion, maxVersion, /* txId */ 0);
+                g.NextDataSize = g.Data.CalcSize(groupKey, row, KeyState.Final, minVersion, maxVersion, /* txId */ 0, KeyState.LockMode, KeyState.LockTxId);
                 g.NextIndexSize = WriteFlatIndex ? g.FlatIndex.CalcSize(groupKey) : 0;
                 g.NextBTreeIndexSize = WriteBTreeIndex ? g.BTreeIndex.CalcSize(groupKey) : 0;
 
@@ -272,6 +299,11 @@ namespace NTable {
                 for (auto& g : Groups) {
                     g.NextDataSize.Overflow = false;
                 }
+            }
+
+            if (KeyState.LockMode != ELockMode::None) {
+                Current.TxIdStatsBuilder.AddRow(KeyState.LockTxId, sizeof(NPage::TDataPage::TLocked));
+                overheadBytes -= sizeof(NPage::TDataPage::TLocked);
             }
 
             Current.Rows += 1;
@@ -299,12 +331,22 @@ namespace NTable {
             FrameS.FlushRow();
             FrameL.FlushRow();
 
+            if (KeyState.LockMode != ELockMode::None) {
+                // This lock may end up as a lock-only delta in the future, make sure we account for version uncertainty
+                Y_DEBUG_ABORT_UNLESS(MinRowVersion == TRowVersion::Min());
+                Current.MinRowVersion = TRowVersion::Min();
+                Current.MaxRowVersion = TRowVersion::Max();
+                Current.Versioned = true;
+                Current.RowLocks = true;
+            }
+
             for (size_t groupIdx : xrange(Groups.size())) {
                 auto& g = Groups[groupIdx];
                 // N.B. non-main groups have no key
                 TCellsRef groupKey = groupIdx == 0 ? KeyState.Key : TCellsRef{ };
-                g.Data.Add(g.NextDataSize, groupKey, row, *this, KeyState.Final, minVersion, maxVersion, /* txId */ 0);
+                g.Data.Add(g.NextDataSize, groupKey, row, *this, KeyState.Final, minVersion, maxVersion, /* txId */ 0, KeyState.LockMode, KeyState.LockTxId);
             }
+            KeyState.LockMode = ELockMode::None;
 
             FinishMainKey(erased);
 
@@ -630,6 +672,9 @@ namespace NTable {
 
                 if (Current.TxIdStatsBuilder)
                     head = Max(head, ui32(28) /* Uncommitted deltas present */);
+
+                if (Current.RowLocks)
+                    head = Max(head, ui32(29) /* Persistent row locks present */);
 
                 abi->SetTail(head);
                 abi->SetHead(ui32(NTable::ECompatibility::Edge));
@@ -1113,6 +1158,8 @@ namespace NTable {
             ui32 Written = 0;
             bool Final = false;
             bool DelayedErase = false;
+            ELockMode LockMode = ELockMode::None;
+            ui64 LockTxId = 0;
         };
 
         TKeyState KeyState;
@@ -1156,6 +1203,7 @@ namespace NTable {
             ui64 DeltaRows = 0;
 
             bool Versioned = false;
+            bool RowLocks = false;
         } Current;
 
         TIntrusivePtr<TSlices> Slices;

--- a/ydb/core/tablet_flat/flat_redo_layout.h
+++ b/ydb/core/tablet_flat/flat_redo_layout.h
@@ -17,6 +17,7 @@ namespace NRedo {
         UpdateTx = 10,
         CommitTx = 11,
         RemoveTx = 12,
+        LockRowTx = 13,
     };
 
     #pragma pack(push, 1)
@@ -124,6 +125,16 @@ namespace NRedo {
         ui64 RowVersionTxId;
     } Y_PACKED;
 
+    struct TEvLockRowTx {
+        TChunk Label;
+
+        ui32 Table;
+        ELockMode Mode;
+        ui8 Pad0_;
+        ui16 Keys;
+        ui64 TxId;
+    } Y_PACKED;
+
     struct TValue {
         bool IsNull() const noexcept
         {
@@ -147,8 +158,12 @@ namespace NRedo {
     static_assert(sizeof(TEvBegin_v1) == 32, "");
     static_assert(sizeof(TEvUpdate) == 18, "");
     static_assert(sizeof(TEvUpdateV) == 16, "");
+    static_assert(sizeof(TEvUpdateTx) == 8);
     static_assert(sizeof(TEvAnnex) == 12, "");
     static_assert(sizeof(TEvFlush) == 32, "");
+    static_assert(sizeof(TEvRemoveTx) == 24);
+    static_assert(sizeof(TEvCommitTx) == 40);
+    static_assert(sizeof(TEvLockRowTx) == 24);
 
 }
 }

--- a/ydb/core/tablet_flat/flat_row_eggs.h
+++ b/ydb/core/tablet_flat/flat_row_eggs.h
@@ -39,6 +39,13 @@ namespace NTable {
         Reset   = 3,    /* Reset cell or row to default */
     };
 
+    enum class ELockMode : ui8 {
+        None = 0,
+        Shared = 1,
+        Exclusive = 2,
+        Multi = 3,
+    };
+
     enum class ECellOp : ui8 { /* cell operation code */
         Empty   = 0,    /* Cell has no any valid state  */
         Set     = 1,    /* Set cell to exact value      */
@@ -74,12 +81,14 @@ namespace NTable {
     struct TSelectRowVersionResult {
         EReady Ready;
         TRowVersion RowVersion;
+        ELockMode LockMode = ELockMode::None;
+        ui64 LockTxId = 0;
 
-        TSelectRowVersionResult(EReady ready)
+        explicit TSelectRowVersionResult(EReady ready)
             : Ready(ready)
         { }
 
-        TSelectRowVersionResult(const TRowVersion& rowVersion)
+        explicit TSelectRowVersionResult(const TRowVersion& rowVersion)
             : Ready(EReady::Data)
             , RowVersion(rowVersion)
         { }

--- a/ydb/core/tablet_flat/flat_row_state.h
+++ b/ydb/core/tablet_flat/flat_row_state.h
@@ -145,7 +145,11 @@ namespace NTable {
 
         bool IsFinalized(TPos pos) const noexcept
         {
-            return GetCellOp(pos) != ECellOp::Empty;
+            if (pos < State.size()) {
+                return GetCellOp(pos) != ECellOp::Empty;
+            } else {
+                return false;
+            }
         }
 
     private:

--- a/ydb/core/tablet_flat/flat_scan_iface.h
+++ b/ydb/core/tablet_flat/flat_scan_iface.h
@@ -160,6 +160,7 @@ namespace NTable {
         virtual EScan BeginKey(TArrayRef<const TCell>) = 0;
         virtual EScan BeginDeltas() = 0;
         virtual EScan Feed(const TRow&, ui64) = 0;
+        virtual EScan Feed(ELockMode, ui64) = 0;
         virtual EScan EndDeltas() = 0;
         virtual EScan Feed(const TRow&, TRowVersion&) = 0;
         virtual EScan EndKey() = 0;

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -172,6 +172,7 @@ public:
     void Update(ERowOp, TRawVals key, TOpsRef, TArrayRef<const TMemGlob> apart, TRowVersion rowVersion);
 
     void UpdateTx(ERowOp, TRawVals key, TOpsRef, TArrayRef<const TMemGlob> apart, ui64 txId);
+    void LockRowTx(ELockMode, TRawVals key, ui64 txId);
     void CommitTx(ui64 txId, TRowVersion rowVersion);
     void RemoveTx(ui64 txId);
 

--- a/ydb/core/tablet_flat/flat_table_observer.h
+++ b/ydb/core/tablet_flat/flat_table_observer.h
@@ -26,6 +26,14 @@ namespace NKikimr::NTable {
             TArrayRef<const TRawTypeValue> key,
             TArrayRef<const TUpdateOp> ops,
             ui64 txId) = 0;
+
+        /**
+         * Called when a new lock is added to the table
+         */
+        virtual void OnLockRowTx(
+            ELockMode mode,
+            TArrayRef<const TRawTypeValue> key,
+            ui64 txId) = 0;
     };
 
 } // namespace NKikimr::NTable

--- a/ydb/core/tablet_flat/test/libs/table/test_comp.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_comp.h
@@ -164,6 +164,16 @@ namespace NTest {
             return Failed = 0, EScan::Feed;
         }
 
+        EScan Feed(ELockMode mode, ui64 txId) override
+        {
+            if (!IsLocked) {
+                Writer->AddKeyLock(mode, txId);
+                IsLocked = true;
+            }
+
+            return Failed = 0, EScan::Feed;
+        }
+
         EScan EndDeltas() override
         {
             return Failed = 0, EScan::Feed;
@@ -183,6 +193,7 @@ namespace NTest {
         EScan EndKey() override
         {
             Writer->EndKey();
+            IsLocked = false;
 
             return Failed = 0, EScan::Feed;
         }
@@ -206,6 +217,7 @@ namespace NTest {
         TVector<ui32> Tags;
         TAutoPtr<TPartWriter> Writer;
         TRowVersionRanges::TSnapshot RemovedRowVersions;
+        bool IsLocked = false;
     };
 
 }

--- a/ydb/core/tablet_flat/test/libs/table/test_steps.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_steps.h
@@ -4,6 +4,7 @@
 #include <util/string/builder.h>
 #include <util/system/yassert.h>
 #include <util/stream/output.h>
+#include <source_location>
 
 namespace NKikimr {
 namespace NTable {
@@ -14,9 +15,28 @@ namespace NTest {
     public:
         TImpl& To(size_t seq)
         {
-            Y_ENSURE(seq >= Seq, "Invalid sequence flow");
+            if (Seq.index() == 0) {
+                Y_ENSURE(seq >= std::get<size_t>(Seq), "Invalid sequence flow");
+            }
 
             Seq = seq;
+
+            return static_cast<TImpl&>(*this);
+        }
+
+        TImpl& To(std::variant<size_t, std::source_location> seq)
+        {
+            if (Seq.index() == 0 && seq.index() == 0) {
+                Y_ENSURE(std::get<size_t>(seq) >= std::get<size_t>(Seq), "Invalid sequence flow");
+            }
+
+            Seq = seq;
+            return static_cast<TImpl&>(*this);
+        }
+
+        TImpl& ToLine(std::source_location location = std::source_location::current())
+        {
+            Seq = location;
 
             return static_cast<TImpl&>(*this);
         }
@@ -28,13 +48,29 @@ namespace NTest {
             return Cerr;
         }
 
-        size_t CurrentStep() const noexcept { return Seq; }
+        std::variant<size_t, std::source_location> CurrentStep() const noexcept { return Seq; }
 
-        TString CurrentStepStr() const { return TStringBuilder() << "On " << CurrentStep(); }
+        TString CurrentStepStr() const {
+            TStringBuilder sb;
+            switch (Seq.index()) {
+                case 0: {
+                    size_t seq = std::get<size_t>(Seq);
+                    sb << "On " << seq;
+                    break;
+                }
+                case 1: {
+                    const auto& location = std::get<std::source_location>(Seq);
+                    sb << "At " << location.file_name() << ":" << location.line();
+                    break;
+                }
+            }
+            return sb;
+        }
 
     private:
-        size_t Seq     = 0;
+        std::variant<size_t, std::source_location> Seq = size_t(0);
     };
+
 }
 }
 }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_dbase.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_dbase.h
@@ -92,6 +92,10 @@ namespace NTest {
             return Iter->Row();
         }
 
+        TRowVersion GetRowVersion() const {
+            return Iter->GetRowVersion();
+        }
+
     public:
         const TIntrusiveConstPtr<TRowScheme> Scheme;
         TDatabase &Base;

--- a/ydb/core/tablet_flat/test/tool/surg/main.cpp
+++ b/ydb/core/tablet_flat/test/tool/surg/main.cpp
@@ -32,6 +32,17 @@ namespace NTest {
 
             return ui8(rop) < names.size() ? names[ui8(rop)] : "?error";
         }
+
+        static const char* Do(ELockMode mode)
+        {
+            static const std::array<const char*, 3> names{{
+                "None",
+                "Shared",
+                "Exclusive"
+            }};
+
+            return ui8(mode) < names.size() ? names[ui8(mode)] : "?error";
+        }
     };
 
     class TDumpValue {
@@ -142,6 +153,30 @@ namespace NTest {
             }
             for (const auto& op : ops) {
                 Out << "   > col " << op.Tag << ": " << TDumpValue(op.Value) << " <" << Endl;
+            }
+        }
+
+        void DoLockRowTx(ui32 tid, ELockMode mode, TKeys key, ui64 txId)
+        {
+            ui32 keyBytes = 0;
+
+            for (const auto& one : key) {
+                keyBytes += one.Size();
+            }
+
+            Updates++;
+            KeyBytes += keyBytes;
+            KeyItems += key.size();
+
+            Out
+                << " | LockRowTx " << tid
+                << ": " << TNames::Do(mode) << "." << unsigned(mode)
+                << ", " << key.size() << " keys (" << keyBytes << "b)"
+                << " txId " << txId
+                << Endl;
+
+            for (const auto& one : key) {
+                Out << "   > key: " << TDumpValue(one) << " <" << Endl;
             }
         }
 

--- a/ydb/core/tablet_flat/ut/ut_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_charge.cpp
@@ -380,17 +380,17 @@ namespace {
 
         std::string AssertMessage(bool fail) const {
             return 
-                "Seq: " + std::to_string(CurrentStep()) + 
+                "Seq: " + CurrentStepStr() + 
                 " Fail: " + (fail ? "Yes" : "No");
         }
         std::string AssertMessage(TGroupId group) const {
             return 
-                "Seq: " + std::to_string(CurrentStep()) + 
+                "Seq: " + CurrentStepStr() + 
                 " Group: " + std::to_string(group.Index) + "," + std::to_string(group.IsHistoric());
         }
         std::string AssertMessage(TGroupId group, TPageIdFlags flags) const {
             auto result = 
-                "Seq: " + std::to_string(CurrentStep()) + 
+                "Seq: " + CurrentStepStr() + 
                 " Group: " + std::to_string(group.Index) + "," + std::to_string(group.IsHistoric());
 
             if (flags & TPageIdFlags::IfFail) {

--- a/ydb/core/tablet_flat/ut/ut_rowlocks.cpp
+++ b/ydb/core/tablet_flat/ut/ut_rowlocks.cpp
@@ -1,0 +1,592 @@
+#include <ydb/core/tablet_flat/flat_dbase_scheme.h>
+#include <ydb/core/tablet_flat/test/libs/table/test_dbase.h>
+#include <ydb/core/tablet_flat/test/libs/rows/cook.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/stream/file.h>
+
+namespace NKikimr::NTable {
+
+Y_UNIT_TEST_SUITE(DBRowLocks) {
+
+    using namespace NTest;
+
+    Y_UNIT_TEST(LockSurvivesCompactions) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(123).LockRowN(table1, ELockMode::Exclusive, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        {
+            auto r1 = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r1.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r1.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r1.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r1.LockTxId, 123u);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        {
+            auto r2 = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r2.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r2.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r2.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r2.LockTxId, 123u);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Compact(table1);
+
+        me.ToLine().Begin();
+        {
+            auto r3 = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r3.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r3.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r3.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r3.LockTxId, 123u);
+        }
+        me.ToLine().Commit();
+    }
+
+    Y_UNIT_TEST(LockOverCompactedErase) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteVer({1, 11}).EraseN(table1, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(123).LockRowN(table1, ELockMode::Exclusive, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        {
+            auto r1 = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r1.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r1.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r1.LockTxId, 123u);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Compact(table1, true);
+
+        me.ToLine().Begin();
+        {
+            auto r2 = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r2.Ready, EReady::Gone);
+            UNIT_ASSERT_VALUES_EQUAL(r2.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r2.LockTxId, 123u);
+        }
+        me.ToLine().Commit();
+    }
+
+    Y_UNIT_TEST(CommitTxAfterLockThenCompact) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(123).LockRowN(table1, ELockMode::Exclusive, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(234).PutN(table1, 1_u64, 22_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 123u);
+        }
+        me.ToLine().WriteVer({2, 22}).CommitTx(table1, 234u);
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(2, 22));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::None);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1);
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(2, 22));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::None);
+        }
+        me.ToLine().Commit();
+    }
+
+    Y_UNIT_TEST(CommitLockThenCompactRowVersion) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(123).LockRowN(table1, ELockMode::Exclusive, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        {
+            auto r1 = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r1.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r1.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r1.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r1.LockTxId, 123u);
+        }
+        me.ToLine().WriteVer({2, 22}).CommitTx(table1, 123);
+        {
+            auto r2 = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r2.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r2.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r2.LockMode, ELockMode::None);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1);
+
+        me.ToLine().Begin();
+        {
+            auto r3 = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r3.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r3.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r3.LockMode, ELockMode::None);
+        }
+        me.ToLine().Commit();
+    }
+
+    Y_UNIT_TEST(OverwriteLockThenCompact) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(123).LockRowN(table1, ELockMode::Exclusive, 1_u64);
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 123u);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(234).LockRowN(table1, ELockMode::Multi, 1_u64);
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Multi);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 234u);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Multi);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 234u);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Compact(table1);
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Multi);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 234u);
+        }
+        me.ToLine().Commit();
+    }
+
+    Y_UNIT_TEST(LockOpenTxAndTxDataAccounting) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(123).LockRowN(table1, ELockMode::Exclusive, 1_u64);
+        me.ToLine().Commit();
+
+        UNIT_ASSERT(me->HasOpenTx(table1, 123u));
+        UNIT_ASSERT(me->HasTxData(table1, 123u));
+
+        me.ToLine().Snap(table1).Compact(table1);
+
+        UNIT_ASSERT(me->HasOpenTx(table1, 123u));
+        UNIT_ASSERT(me->HasTxData(table1, 123u));
+    }
+
+    Y_UNIT_TEST(MultipleCommittedRowLocks) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(101).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().WriteTx(102).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(103).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().WriteTx(104).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(105).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().WriteTx(106).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(107).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().WriteTx(108).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1);
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Gone);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Multi);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 108u);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteVer({1, 101}).CommitTx(table1, 101);
+        me.ToLine().WriteVer({1, 102}).CommitTx(table1, 102);
+        me.ToLine().WriteVer({1, 103}).CommitTx(table1, 103);
+        me.ToLine().WriteVer({1, 104}).CommitTx(table1, 104);
+        me.ToLine().WriteVer({1, 105}).CommitTx(table1, 105);
+        me.ToLine().WriteVer({1, 106}).CommitTx(table1, 106);
+        me.ToLine().WriteVer({1, 107}).CommitTx(table1, 107);
+        me.ToLine().WriteVer({1, 108}).CommitTx(table1, 108);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Gone);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::None);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, true);
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Gone);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::None);
+        }
+        me.ToLine().Commit();
+    }
+
+    Y_UNIT_TEST(LocksCommittedRemovedIteration) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().WriteVer({1, 12}).PutN(table1, 5_u64, 13_u64, 14_u64);
+        me.ToLine().WriteVer({1, 13}).PutN(table1, 9_u64, 15_u64, 16_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(101).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().WriteTx(102).LockRowN(table1, ELockMode::Multi, 6_u64);
+        me.ToLine().WriteTx(103).LockRowN(table1, ELockMode::Multi, 9_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(104).PutN(table1, 5_u64, 17_u64, 18_u64);
+        me.ToLine().WriteTx(105).LockRowN(table1, ELockMode::Multi, 9_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(106).LockRowN(table1, ELockMode::Multi, 5_u64);
+        me.ToLine().WriteTx(107).PutN(table1, 5_u64, 19_u64, 20_u64);
+        me.ToLine().WriteTx(108).LockRowN(table1, ELockMode::Multi, 5_u64);
+        me.ToLine().WriteTx(109).PutN(table1, 5_u64, 21_u64, 22_u64);
+        me.ToLine().WriteTx(110).LockRowN(table1, ELockMode::Multi, 9_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteVer({1, 14}).CommitTx(table1, 101);
+        me.ToLine().WriteVer({1, 15}).CommitTx(table1, 102);
+        me.ToLine().WriteVer({1, 16}).CommitTx(table1, 103);
+        me.ToLine().WriteVer({1, 17}).CommitTx(table1, 104);
+        me.ToLine().WriteVer({1, 18}).CommitTx(table1, 105);
+        me.ToLine().WriteVer({1, 19}).RemoveTx(table1, 106);
+        me.ToLine().WriteVer({1, 20}).CommitTx(table1, 107);
+        me.ToLine().WriteVer({1, 21}).CommitTx(table1, 108);
+        me.ToLine().WriteVer({1, 22}).CommitTx(table1, 109);
+        me.ToLine().WriteVer({1, 23}).RemoveTx(table1, 110);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        {
+            auto it = me.ToLine().ReadVer({1, 16}).Iter(table1, false);
+            it.ToLine().Seek({ }, ESeek::Lower)
+                .IsOpN(ERowOp::Upsert, 1_u64, 11_u64, 12_u64)
+                .IsVer({1, 11});
+            it.ToLine().Next()
+                .IsOpN(ERowOp::Upsert, 5_u64, 13_u64, 14_u64)
+                .IsVer({1, 12});
+            it.ToLine().Next()
+                .IsOpN(ERowOp::Upsert, 9_u64, 15_u64, 16_u64)
+                .IsVer({1, 13});
+            it.ToLine().Next().Is(EReady::Gone);
+        }
+        {
+            auto it = me.ToLine().ReadVer({1, 21}).Iter(table1, false);
+            it.ToLine().Seek({ }, ESeek::Lower)
+                .IsOpN(ERowOp::Upsert, 1_u64, 11_u64, 12_u64)
+                .IsVer({1, 11});
+            it.ToLine().Next()
+                .IsOpN(ERowOp::Upsert, 5_u64, 19_u64, 20_u64)
+                .IsVer({1, 20});
+            it.ToLine().Next()
+                .IsOpN(ERowOp::Upsert, 9_u64, 15_u64, 16_u64)
+                .IsVer({1, 13});
+            it.ToLine().Next().Is(EReady::Gone);
+        }
+        {
+            auto it = me.ToLine().ReadVer(TRowVersion::Max()).Iter(table1, false);
+            it.ToLine().Seek({ }, ESeek::Lower)
+                .IsOpN(ERowOp::Upsert, 1_u64, 11_u64, 12_u64)
+                .IsVer({1, 11});
+            it.ToLine().Next()
+                .IsOpN(ERowOp::Upsert, 5_u64, 21_u64, 22_u64)
+                .IsVer({1, 22});
+            it.ToLine().Next()
+                .IsOpN(ERowOp::Upsert, 9_u64, 15_u64, 16_u64)
+                .IsVer({1, 13});
+            it.ToLine().Next().Is(EReady::Gone);
+        }
+        me.ToLine().Commit();
+    }
+
+    Y_UNIT_TEST(LocksReplay) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(101).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Replay(EPlay::Boot);
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Multi);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 101u);
+        }
+        me.ToLine().Commit();
+
+        me.ToLine().Replay(EPlay::Redo);
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine().SelectRowVersionN(table1, 1_u64);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Multi);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 101u);
+        }
+        me.ToLine().Commit();
+    }
+
+    Y_UNIT_TEST(LocksMvccCompact) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+                .AddTable("me_1", table1)
+                .AddColumn(table1, "key",    1, ETypes::Uint64, false)
+                .AddColumn(table1, "arg1",   4, ETypes::Uint64, false, Cimple(10004_u64))
+                .AddColumn(table1, "arg2",   5, ETypes::Uint64, false, Cimple(10005_u64))
+                .AddColumnToKey(table1, 1));
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 11_u64, 12_u64);
+        me.ToLine().WriteVer({2, 11}).PutN(table1, 1_u64, 21_u64, 22_u64);
+        me.ToLine().WriteVer({1, 12}).PutN(table1, 3_u64, 13_u64, 14_u64);
+        me.ToLine().WriteVer({2, 12}).PutN(table1, 3_u64, 23_u64, 24_u64);
+        me.ToLine().WriteVer({1, 13}).PutN(table1, 5_u64, 15_u64, 16_u64);
+        me.ToLine().WriteVer({2, 13}).PutN(table1, 5_u64, 25_u64, 26_u64);
+        me.ToLine().WriteTx(101).LockRowN(table1, ELockMode::Multi, 1_u64);
+        me.ToLine().WriteTx(102).LockRowN(table1, ELockMode::Multi, 3_u64);
+        me.ToLine().WriteTx(103).LockRowN(table1, ELockMode::Multi, 5_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        // Note: intentionally overwrite locked keys. This should force locks
+        // to become implicitly removed, and should not break full compaction
+        // later. In other words scan should not feed locks after the first
+        // committed row for a given key.
+        me.ToLine().Begin();
+        me.ToLine().WriteVer({3, 11}).PutN(table1, 1_u64, 31_u64, 32_u64);
+        me.ToLine().WriteVer({3, 12}).PutN(table1, 3_u64, 33_u64, 34_u64);
+        me.ToLine().WriteVer({3, 13}).PutN(table1, 5_u64, 35_u64, 36_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Snap(table1).Compact(table1, false);
+
+        UNIT_ASSERT(me->HasTxData(table1, 101u));
+        UNIT_ASSERT(me->HasTxData(table1, 102u));
+        UNIT_ASSERT(me->HasTxData(table1, 103u));
+
+        me.ToLine().Compact(table1, true);
+
+        UNIT_ASSERT(!me->HasTxData(table1, 101u));
+        UNIT_ASSERT(!me->HasTxData(table1, 102u));
+        UNIT_ASSERT(!me->HasTxData(table1, 103u));
+    }
+
+} // Y_UNIT_TEST_SUITE(DBRowLocks)
+
+} // namespace NKikimr::NTable

--- a/ydb/core/tablet_flat/ut/ya.make
+++ b/ydb/core/tablet_flat/ut/ya.make
@@ -49,6 +49,7 @@ SRCS(
     ut_pages.cpp
     ut_redo.cpp
     ut_rename_table_column.cpp
+    ut_rowlocks.cpp
     ut_other.cpp
     ut_forward.cpp
     ut_screen.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch makes it possible to mark keys as having row locks in LocalDB.

See #25403 for details.