### PR TITLE
lower initial delay before sending base statistics from schemeshard to statistics aggregator

### DIFF
--- a/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
+++ b/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
@@ -17,16 +17,18 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
         ui64 schemeShardId = Record.GetSchemeShardId();
         const auto& stats = Record.GetStats();
 
+        NKikimrStat::TSchemeShardStats statRecord;
+        Y_PROTOBUF_SUPPRESS_NODISCARD statRecord.ParseFromString(stats);
+
         SA_LOG_D("[" << Self->TabletID() << "] TTxSchemeShardStats::Execute: "
-            << "schemeshard id# " << schemeShardId
-            << ", stats size# " << stats.size());
+            << "schemeshard id: " << schemeShardId
+            << ", stats byte size: " << stats.size()
+            << ", entries count: " << statRecord.GetEntries().size()
+            << ", are all stats full: " << statRecord.GetAreAllStatsFull());
 
         NIceDb::TNiceDb db(txc.DB);
 
         TSerializedBaseStats& existingStats = Self->BaseStatistics[schemeShardId];
-
-        NKikimrStat::TSchemeShardStats statRecord;
-        Y_PROTOBUF_SUPPRESS_NODISCARD statRecord.ParseFromString(stats);
 
         // if statistics is sent from schemeshard for the first time or
         // AreAllStatsFull field is not set (schemeshard is working on previous code version) or

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -8276,10 +8276,10 @@ void TSchemeShard::Handle(TEvPrivate::TEvSendBaseStatsToSA::TPtr&, const TActorC
 
 void TSchemeShard::InitializeStatistics(const TActorContext& ctx) {
     ResolveSA();
-    // since columnshard statistics is now sent once in a minute,
-    // we expect that in most cases we will gather full stats
-    // before sending them to StatisticsAggregator
-    ctx.Schedule(TDuration::Seconds(120), new TEvPrivate::TEvSendBaseStatsToSA());
+    // Give table shards some time to report statistics. This is not required for correctness,
+    // but if we tried to send the statistics right away, info for all paths would probably
+    // be incomplete.
+    ctx.Schedule(TDuration::Seconds(30), new TEvPrivate::TEvSendBaseStatsToSA());
 }
 
 void TSchemeShard::ResolveSA() {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

* lower initial delay before sending base statistics from schemeshard to statistics aggregator.
* improve logging
* add test with incomplete table base statistics after schemeshard reboot