### PR TITLE
Fix source location regex in audit test

### DIFF
--- a/ydb/tests/functional/audit/helpers.py
+++ b/ydb/tests/functional/audit/helpers.py
@@ -144,7 +144,7 @@ class CanonicalCaptureAuditFileOutput:
         self.__canonize_apply_regex(json_record, r'Host: \"[^\"]+\"', 'Host: \"<canonized_host_name>\"')
         self.__canonize_apply_regex(json_record, r'RestartTabletID=\d+', 'RestartTabletID=<canonized_tablet_id>')
         # source_location is used only in debug builds like relwithdebinfo and debug
-        self.__canonize_apply_regex(json_record, r', source_location: [A-Za-z0-9_/.]+\.(cpp|h):\d+', '')
+        self.__canonize_apply_regex(json_record, r', source_location: [A-Za-z0-9_\-/.]+\.(cpp|h):\d+', '')
         return json.dumps(json_record, sort_keys=True) + '\n'
 
     def __validate_field(self, json_record, field_name):

--- a/ydb/tests/functional/audit/helpers.py
+++ b/ydb/tests/functional/audit/helpers.py
@@ -144,7 +144,7 @@ class CanonicalCaptureAuditFileOutput:
         self.__canonize_apply_regex(json_record, r'Host: \"[^\"]+\"', 'Host: \"<canonized_host_name>\"')
         self.__canonize_apply_regex(json_record, r'RestartTabletID=\d+', 'RestartTabletID=<canonized_tablet_id>')
         # source_location is used only in debug builds like relwithdebinfo and debug
-        self.__canonize_apply_regex(json_record, r', source_location: [A-Za-z0-9_\-/.]+\.(cpp|h):\d+', '')
+        self.__canonize_apply_regex(json_record, r', source_location: [A-Za-z0-9_\-\\/.]+\.(cpp|h):\d+', '')
         return json.dumps(json_record, sort_keys=True) + '\n'
 
     def __validate_field(self, json_record, field_name):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The test removes source_location from audit fields. Add forgotten "-" symbol to the removing regex.
