### PR TITLE
EXT-1551. Remove obsolete UsageByActivity sensor from ActorSystem

### DIFF
--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -72,62 +72,6 @@ namespace NActors {
         }
     }
 
-    template<i64 Increment>
-    static void UpdateQueueSizeAndTimestamp(TActorUsageImpl<true>& impl, ui64 time) {
-        ui64 usedTimeIncrement = 0;
-        using T = TActorUsageImpl<true>;
-
-        for (;;) {
-            uint64_t value = impl.QueueSizeAndTimestamp.load();
-            ui64 count = value >> T::TimestampBits;
-
-            count += Increment;
-            Y_ABORT_UNLESS((count & ~T::CountMask) == 0);
-
-            ui64 timestamp = value;
-            if (Increment == 1 && count == 1) {
-                timestamp = time;
-            } else if (Increment == -1 && count == 0) {
-                usedTimeIncrement = (static_cast<ui64>(time) - timestamp) & T::TimestampMask;
-                timestamp = 0; // reset timestamp to some zero value
-            }
-
-            const ui64 updated = (timestamp & T::TimestampMask) | (count << T::TimestampBits);
-            if (impl.QueueSizeAndTimestamp.compare_exchange_weak(value, updated)) {
-                break;
-            }
-        }
-
-        if (usedTimeIncrement && impl.LastUsageTimestamp <= time) {
-            impl.UsedTime += usedTimeIncrement;
-        }
-    }
-
-    void TActorUsageImpl<true>::OnEnqueueEvent(ui64 time) {
-        UpdateQueueSizeAndTimestamp<+1>(*this, time);
-    }
-
-    void TActorUsageImpl<true>::OnDequeueEvent() {
-        UpdateQueueSizeAndTimestamp<-1>(*this, GetCycleCountFast());
-    }
-
-    double TActorUsageImpl<true>::GetUsage(ui64 time) {
-        ui64 used = UsedTime.exchange(0);
-        if (const ui64 value = QueueSizeAndTimestamp.load(); value >> TimestampBits) {
-            used += (static_cast<ui64>(time) - value) & TimestampMask;
-        }
-
-        Y_ABORT_UNLESS(LastUsageTimestamp <= time);
-        ui64 passed = time - LastUsageTimestamp;
-        LastUsageTimestamp = time;
-
-        if (!passed) {
-            return 0;
-        }
-
-        return (double)Min(passed, used) / passed;
-    }
-
     void IActor::Describe(IOutputStream &out) const {
         SelfActorId.Out(out);
     }

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -323,30 +323,6 @@ namespace NActors {
 
     };
 
-    template<bool>
-    struct TActorUsageImpl {
-        void OnEnqueueEvent(ui64 /*time*/) {} // called asynchronously when event is put in the mailbox
-        void OnDequeueEvent() {} // called when processed by Executor
-        double GetUsage(ui64 /*time*/) { return 0; } // called from collector thread
-        void DoActorInit() {}
-    };
-
-    template<>
-    struct TActorUsageImpl<true> {
-        static constexpr int TimestampBits = 40;
-        static constexpr int CountBits = 24;
-        static constexpr ui64 TimestampMask = ((ui64)1 << TimestampBits) - 1;
-        static constexpr ui64 CountMask = ((ui64)1 << CountBits) - 1;
-
-        std::atomic_uint64_t QueueSizeAndTimestamp = 0;
-        std::atomic_uint64_t UsedTime = 0; // how much time did we consume since last GetUsage() call
-        ui64 LastUsageTimestamp = 0; // when GetUsage() was called the last time
-
-        void OnEnqueueEvent(ui64 time);
-        void OnDequeueEvent();
-        double GetUsage(ui64 time);
-        void DoActorInit() { LastUsageTimestamp = GetCycleCountFast(); }
-    };
 
     /**
      * Optional interface for actors with exception handling
@@ -562,7 +538,6 @@ namespace NActors {
 
     class IActor
         : protected IActorOps
-        , public TActorUsageImpl<ActorLibCollectUsageStats>
     {
     private:
         TActorIdentity SelfActorId;

--- a/ydb/library/actors/core/defs.h
+++ b/ydb/library/actors/core/defs.h
@@ -12,8 +12,6 @@
 //    event processing time histograms
 #define ACTORSLIB_COLLECT_EXEC_STATS
 
-static constexpr bool ActorLibCollectUsageStats = false;
-
 namespace NActors {
     using TPoolId = ui8;
     using TPoolsMask = ui64;

--- a/ydb/library/actors/core/executor_pool_base.cpp
+++ b/ydb/library/actors/core/executor_pool_base.cpp
@@ -14,7 +14,6 @@ namespace NActors {
 
     void DoActorInit(TActorSystem* sys, IActor* actor, const TActorId& self, const TActorId& owner) {
         actor->SelfActorId = self;
-        actor->DoActorInit();
         actor->Registered(sys, owner);
     }
 
@@ -37,17 +36,6 @@ namespace NActors {
 
         const TMonotonic now = ActorSystem->Monotonic();
 
-        for (auto& u : stats.UsageByActivity) {
-            u.fill(0);
-        }
-
-        auto accountUsage = [&](ui32 activityType, double usage) {
-            Y_ABORT_UNLESS(0 <= usage);
-            Y_ABORT_UNLESS(usage <= 1);
-            int bin = Min<int>(9, usage * 10);
-            ++stats.UsageByActivity[activityType][bin];
-        };
-
         std::fill(stats.StuckActorsByActivity.begin(), stats.StuckActorsByActivity.end(), 0);
 
         with_lock (StuckObserverMutex) {
@@ -58,12 +46,7 @@ namespace NActors {
                 if (delta > TDuration::Seconds(30)) {
                     ++stats.StuckActorsByActivity[actor->GetActivityType().GetIndex()];
                 }
-                accountUsage(actor->GetActivityType().GetIndex(), actor->GetUsage(GetCycleCountFast()));
             }
-            for (const auto& [activityType, usage] : DeadActorsUsage) {
-                accountUsage(activityType, usage);
-            }
-            DeadActorsUsage.clear();
         }
     }
 #endif

--- a/ydb/library/actors/core/executor_pool_base.h
+++ b/ydb/library/actors/core/executor_pool_base.h
@@ -27,7 +27,6 @@ namespace NActors {
         // Stuck actor monitoring
         TMutex StuckObserverMutex;
         std::vector<IActor*> Actors;
-        mutable std::vector<std::tuple<ui32, double>> DeadActorsUsage;
         friend class TExecutorThread;
         friend class TSharedExecutorThread;
         void RecalculateStuckActors(TExecutorThreadStats& stats) const;

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -103,7 +103,6 @@ namespace NActors {
                         actorPtr = pool->Actors.back();
                         actorPtr->StuckIndex = i;
                         pool->Actors.pop_back();
-                        pool->DeadActorsUsage.emplace_back(actor->GetActivityType().GetIndex(), actor->GetUsage(GetCycleCountFast()));
                     }
                 }
             }
@@ -269,8 +268,6 @@ namespace NActors {
 
                     hpnow = GetCycleCountFast();
                     hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
-
-                    actor->OnDequeueEvent();
 
                     size_t dyingActorsCnt = DyingActors.size();
                     EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "dyingActorsCnt ", dyingActorsCnt);

--- a/ydb/library/actors/core/mailbox_lockfree.cpp
+++ b/ydb/library/actors/core/mailbox_lockfree.cpp
@@ -364,18 +364,6 @@ namespace NActors {
     void TMailbox::OnPreProcessed(IEventHandle* head, IEventHandle* tail) noexcept {
         Y_DEBUG_ABORT_UNLESS(head && tail);
         Y_DEBUG_ABORT_UNLESS(GetNextPtr(tail) == nullptr);
-#ifdef ACTORSLIB_COLLECT_EXEC_STATS
-        // Mark events as enqueued when usage stats are enabled
-         if constexpr (ActorLibCollectUsageStats) {
-            for (IEventHandle* ev = head; ev; ev = GetNextPtr(ev)) {
-                if (IActor* actor = FindActor(ev->GetRecipientRewrite().LocalId())) {
-                    actor->OnEnqueueEvent(ev->SendTime);
-                } else if (/*IActor* alias = */FindAlias(ev->GetRecipientRewrite().LocalId())) {
-                    actor->OnEnqueueEvent(ev->SendTime);
-                }
-            }
-        }
-#endif
     }
 
     void TMailbox::AppendPreProcessed(IEventHandle* head, IEventHandle* tail) noexcept {
@@ -474,7 +462,7 @@ namespace NActors {
     }
 
     TAutoPtr<IEventHandle> TMailbox::Pop() noexcept {
-        if (!EventHead || ActorLibCollectUsageStats) {
+        if (!EventHead) {
             PreProcessEvents();
         }
 

--- a/ydb/library/actors/core/mon_stats.cpp
+++ b/ydb/library/actors/core/mon_stats.cpp
@@ -38,7 +38,6 @@ namespace NActors {
         , ActorsAliveByActivity(TLocalProcessKeyStateIndexLimiter::GetMaxKeysCount())
         , ScheduledEventsByActivity(TLocalProcessKeyStateIndexLimiter::GetMaxKeysCount())
         , StuckActorsByActivity(TLocalProcessKeyStateIndexLimiter::GetMaxKeysCount())
-        , UsageByActivity(TLocalProcessKeyStateIndexLimiter::GetMaxKeysCount())
     {}
 
     namespace {
@@ -93,15 +92,6 @@ namespace NActors {
         }
         if (other.AggregatedCurrentActivationTime.size()) {
             AggregatedCurrentActivationTime.insert(AggregatedCurrentActivationTime.end(), other.AggregatedCurrentActivationTime.begin(), other.AggregatedCurrentActivationTime.end());
-        }
-
-        if (UsageByActivity.size() < other.UsageByActivity.size()) {
-            UsageByActivity.resize(other.UsageByActivity.size());
-        }
-        for (size_t i = 0; i < UsageByActivity.size(); ++i) {
-            for (size_t j = 0; j < 10; ++j) {
-                UsageByActivity[i][j] += RelaxedLoad(&other.UsageByActivity[i][j]);
-            }
         }
 
         RelaxedStore(

--- a/ydb/library/actors/core/mon_stats.h
+++ b/ydb/library/actors/core/mon_stats.h
@@ -120,7 +120,6 @@ namespace NActors {
         TVector<ui64> ScheduledEventsByActivity;
         TVector<ui64> StuckActorsByActivity;
         TVector<TActivationTime> AggregatedCurrentActivationTime;
-        TVector<std::array<ui64, 10>> UsageByActivity;
         ui64 PoolActorRegistrations = 0;
         ui64 PoolDestroyedActors = 0;
         ui64 PoolAllocatedMailboxes = 0;

--- a/ydb/library/actors/helpers/collector_counters.cpp
+++ b/ydb/library/actors/helpers/collector_counters.cpp
@@ -43,7 +43,6 @@ void TActivityStats::Init(NMonitoring::TDynamicCounterPtr group) {
     ActorsAliveByActivityBuckets.resize(GetActivityTypeCount());
     ScheduledEventsByActivityBuckets.resize(GetActivityTypeCount());
     StuckActorsByActivityBuckets.resize(GetActivityTypeCount());
-    UsageByActivityBuckets.resize(GetActivityTypeCount());
 }
 
 void TActivityStats::Set(const TExecutorThreadStats& stats) {
@@ -69,12 +68,6 @@ void TActivityStats::Set(const TExecutorThreadStats& stats) {
         *ActorsAliveByActivityBuckets[i] = actors;
         *ScheduledEventsByActivityBuckets[i] = scheduled;
         *StuckActorsByActivityBuckets[i] = stuck;
-
-        if constexpr (ActorLibCollectUsageStats) {
-            for (ui32 j = 0; j < 10; ++j) {
-                *UsageByActivityBuckets[i][j] = stats.UsageByActivity[i][j];
-            }
-        }
     }
 
     auto setActivationTime = [&](TActivationTime activation) {
@@ -118,12 +111,6 @@ void TActivityStats::InitCountersForActivity(ui32 activityType) {
         Group->GetSubgroup("sensor", "ScheduledEventsByActivity")->GetNamedCounter("activity", bucketName, true);
     StuckActorsByActivityBuckets[activityType] =
         Group->GetSubgroup("sensor", "StuckActorsByActivity")->GetNamedCounter("activity", bucketName, false);
-
-     if constexpr (ActorLibCollectUsageStats) {
-        for (ui32 i = 0; i < 10; ++i) {
-            UsageByActivityBuckets[activityType][i] = Group->GetSubgroup("sensor", "UsageByActivity")->GetSubgroup("bin", ToString(i))->GetNamedCounter("activity", bucketName, false);
-        }
-    }
 }
 
 // TExecutorPoolCounters

--- a/ydb/library/actors/helpers/collector_counters.h
+++ b/ydb/library/actors/helpers/collector_counters.h
@@ -35,7 +35,6 @@ private:
     TVector<NMonitoring::TDynamicCounters::TCounterPtr> ActorsAliveByActivityBuckets;
     TVector<NMonitoring::TDynamicCounters::TCounterPtr> ScheduledEventsByActivityBuckets;
     TVector<NMonitoring::TDynamicCounters::TCounterPtr> StuckActorsByActivityBuckets;
-    TVector<std::array<NMonitoring::TDynamicCounters::TCounterPtr, 10>> UsageByActivityBuckets;
 };
 
 struct TExecutorPoolCounters {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The sensor seems to be unused for a long time and consumes approx. 25% of metrics in utils bucket.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
