### PR TITLE
Use TDeque instead of TVector

### DIFF
--- a/ydb/core/mon/audit/audit_ut.cpp
+++ b/ydb/core/mon/audit/audit_ut.cpp
@@ -8,7 +8,7 @@ using namespace NMonitoring::NAudit;
 namespace {
 
 NHttp::THttpIncomingRequestPtr MakeRequest(TString method, TString url) {
-    static TVector<TString> Storage;
+    static TDeque<TString> Storage;
 
     auto request = MakeIntrusive<NHttp::THttpIncomingRequest>();
     Storage.emplace_back(std::move(method));


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

On TVector resize, all TStringBuf referring to its elements become dangling pointers. Changed to TDeque
