### PR TITLE
Handle build stats messages in all datashard states

### DIFF
--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -380,7 +380,7 @@ class TDataShard
 
         struct TEvPeriodicWakeup : public TEventLocal<TEvPeriodicWakeup, EvPeriodicWakeup> {};
 
-        struct TEvAsyncTableStats : public TEventLocal<TEvAsyncTableStats, EvAsyncTableStats> {
+        struct TEvBuildTableStatsResult : public TEventLocal<TEvBuildTableStatsResult, EvAsyncTableStats> {
             ui64 TableId = -1;
             TInstant StatsUpdateTime;
             NTable::TStats Stats;
@@ -392,7 +392,7 @@ class TDataShard
             bool HasSchemaChanges = false;
         };
 
-        struct TEvTableStatsError : public TEventLocal<TEvTableStatsError, EvTableStatsError> {
+        struct TEvBuildTableStatsError : public TEventLocal<TEvBuildTableStatsError, EvTableStatsError> {
             enum class ECode {
                 FETCH_PAGE_FAILED,
                 RESOURCE_ALLOCATION_FAILED,
@@ -400,14 +400,14 @@ class TDataShard
                 UNKNOWN
             };
 
-            TEvTableStatsError(ui64 tableId, ECode code, const TString& msg)
+            TEvBuildTableStatsError(ui64 tableId, ECode code, const TString& msg)
                 : TableId(tableId)
                 , Code(code)
                 , Message(msg)
             {}
 
-            TEvTableStatsError(ui64 tableId, ECode code)
-                : TEvTableStatsError(tableId, code, "")
+            TEvBuildTableStatsError(ui64 tableId, ECode code)
+                : TEvBuildTableStatsError(tableId, code, "")
             {}
 
             const ui64 TableId;
@@ -1294,8 +1294,8 @@ class TDataShard
     void Handle(TEvDataShard::TEvSplitTransferSnapshotAck::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvSplitPartitioningChanged::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvGetTableStats::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvPrivate::TEvAsyncTableStats::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvPrivate::TEvTableStatsError::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvBuildTableStatsResult::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvBuildTableStatsError::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvKqpScan::TPtr& ev, const TActorContext& ctx);
     void HandleSafe(TEvDataShard::TEvKqpScan::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvUploadRowsRequest::TPtr& ev, const TActorContext& ctx);
@@ -3130,6 +3130,8 @@ protected:
             HFuncTraced(TEvPrivate::TEvMediatorRestoreBackup, Handle);
             HFuncTraced(TEvPrivate::TEvRemoveLockChangeRecords, Handle);
             HFuncTraced(TEvPrivate::TEvRemoveSchemaSnapshots, Handle);
+            HFunc(TEvPrivate::TEvBuildTableStatsResult, Handle);
+            HFunc(TEvPrivate::TEvBuildTableStatsError, Handle);
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
                 ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateInactive unhandled event type: " << ev->GetTypeRewrite()
@@ -3194,8 +3196,8 @@ protected:
             HFunc(TEvDataShard::TEvSplitTransferSnapshotAck, Handle);
             HFunc(TEvDataShard::TEvSplitPartitioningChanged, Handle);
             HFunc(TEvDataShard::TEvGetTableStats, Handle);
-            HFunc(TEvPrivate::TEvAsyncTableStats, Handle);
-            HFunc(TEvPrivate::TEvTableStatsError, Handle);
+            HFunc(TEvPrivate::TEvBuildTableStatsResult, Handle);
+            HFunc(TEvPrivate::TEvBuildTableStatsError, Handle);
             HFunc(TEvDataShard::TEvKqpScan, Handle);
             HFunc(TEvDataShard::TEvUploadRowsRequest, Handle);
             HFunc(TEvDataShard::TEvEraseRowsRequest, Handle);
@@ -3298,6 +3300,8 @@ protected:
             hFuncTraced(TEvDataShard::TEvReadScanStarted, Handle);
             hFuncTraced(TEvDataShard::TEvReadScanFinished, Handle);
             HFuncTraced(TEvPrivate::TEvPeriodicWakeup, DoPeriodicTasks);
+            HFunc(TEvPrivate::TEvBuildTableStatsResult, Handle);
+            HFunc(TEvPrivate::TEvBuildTableStatsError, Handle);
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
                 ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateWorkAsFollower unhandled event type: " << ev->GetTypeRewrite()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes missing data shard stats event handling that may lead to not splitting by size data shards

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Also rename events for better readability 
