### PR TITLE
Implement a test for splitting shards by the follower load

### DIFF
--- a/ydb/core/testlib/tablet_helpers.h
+++ b/ydb/core/testlib/tablet_helpers.h
@@ -149,6 +149,7 @@ namespace NKikimr {
         const TTabletTypes::EType Type;
         const ui64 TabletId;
         TActorId BootstrapperActorId;
+        TVector<TActorId> FollowerActorIds;
         ETabletState State = ETabletState::Unknown;
         TSubDomainKey ObjectDomain;  // what subdomain tablet belongs to
 

--- a/ydb/core/testlib/tablet_helpers.h
+++ b/ydb/core/testlib/tablet_helpers.h
@@ -149,7 +149,7 @@ namespace NKikimr {
         const TTabletTypes::EType Type;
         const ui64 TabletId;
         TActorId BootstrapperActorId;
-        TVector<TActorId> FollowerActorIds;
+        TMap<ui32, TActorId> FollowerLaunchers; // keyed by followerId
         ETabletState State = ETabletState::Unknown;
         TSubDomainKey ObjectDomain;  // what subdomain tablet belongs to
 


### PR DESCRIPTION
### Changelog entry

Add a new test to verify splitting shards by the follower load

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Added a new test `TSchemeShardSplitByLoad::TableSplitsByFollowerLoad`, which is supposed to verify that a shard splits, when one of the followers is overloaded. Since splitting by the follower load is not implemented yet, this test is essentially reversed - it verifies that no splitting happens in this case.

**NOTE:** Once this new feature is implemented, this test will be updated to verify the new behavior.
