### PR TITLE
Fixed response code for kafka fetch request

### DIFF
--- a/ydb/core/kafka_proxy/actors/actors.h
+++ b/ydb/core/kafka_proxy/actors/actors.h
@@ -120,6 +120,10 @@ inline EKafkaErrors ConvertErrorCode(NPersQueue::NErrorCode::EErrorCode code) {
             return EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION;
         case NPersQueue::NErrorCode::EErrorCode::READ_TIMEOUT:
             return EKafkaErrors::REQUEST_TIMED_OUT;
+        case NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE:
+            return EKafkaErrors::NONE_ERROR;
+        case NPersQueue::NErrorCode::EErrorCode::TABLET_PIPE_DISCONNECTED:
+            return EKafkaErrors::NOT_LEADER_OR_FOLLOWER;
         default:
             return EKafkaErrors::UNKNOWN_SERVER_ERROR;
     }

--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -35,7 +35,18 @@ void TKafkaFetchActor::SendFetchRequests(const TActorContext& ctx) {
         TVector<NKikimr::NPQ::TPartitionFetchRequest> partPQRequests;
         PrepareFetchRequestData(topicIndex, partPQRequests);
         auto ruPerRequest = topicIndex == 0 && Context->Config.GetMeteringV2Enabled();
-        NKikimr::NPQ::TFetchRequestSettings request(Context->DatabasePath, partPQRequests, FetchRequestData->MaxWaitMs, FetchRequestData->MaxBytes, Context->RlContext, Context->UserToken, 0, ruPerRequest);
+        auto consumer = Context->GroupId.empty() ? NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER : Context->GroupId;
+        NKikimr::NPQ::TFetchRequestSettings request {
+            .Database = Context->DatabasePath,
+            .Consumer = consumer,
+            .Partitions = partPQRequests,
+            .MaxWaitTimeMs = FetchRequestData->MaxWaitMs < 0 ? 1000u : FetchRequestData->MaxWaitMs,
+            .TotalMaxBytes = FetchRequestData->MaxBytes < 0 ? 8_MB : FetchRequestData->MaxBytes,
+            .RuPerRequest = ruPerRequest,
+            .RequestId = 0,
+            .RlCtx = Context->RlContext,
+            .UserToken = Context->UserToken
+        };
         auto fetchActor = NKikimr::NPQ::CreatePQFetchRequestActor(request, NKikimr::MakeSchemeCacheID(), ctx.SelfID);
         auto actorId = ctx.Register(fetchActor);
         PendingResponses++;
@@ -62,7 +73,6 @@ void TKafkaFetchActor::PrepareFetchRequestData(const size_t topicIndex, TVector<
         partPQRequest.Partition = partKafkaRequest.Partition;
         partPQRequest.Offset = partKafkaRequest.FetchOffset;
         partPQRequest.MaxBytes = partKafkaRequest.PartitionMaxBytes;
-        partPQRequest.ClientId = Context->GroupId.empty() ? NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER : Context->GroupId;
     }
 }
 

--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.h
@@ -9,10 +9,12 @@
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/library/aclib/aclib.h>
 
-
 namespace NKafka {
 
+struct TestAccessor;    
+
 class TKafkaFetchActor: public NActors::TActorBootstrapped<TKafkaFetchActor> {
+    friend struct TestAccessor;
 public:
     TKafkaFetchActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TFetchRequestData>& message)
         : Context(context)

--- a/ydb/core/kafka_proxy/ut/actors_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/actors_ut.cpp
@@ -7,8 +7,9 @@
 #include <ydb/core/base/statestorage.h>
 #include <ydb/core/kafka_proxy/kafka_messages.h>
 #include <ydb/core/kafka_proxy/actors/actors.h>
-#include <ydb/core/kafka_proxy/actors/kafka_metadata_actor.h>
 #include <ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.h>
+#include <ydb/core/kafka_proxy/actors/kafka_fetch_actor.h>
+#include <ydb/core/kafka_proxy/actors/kafka_metadata_actor.h>
 #include <ydb/core/discovery/discovery.h>
 
 
@@ -87,11 +88,22 @@ TMetarequestTestParams SetupServer(const TString shortTopicName, bool serverless
             serverSettings.AppConfig->MutableKafkaProxyConfig()->MutableProxy()->SetPort(FAKE_SERVERLESS_KAFKA_PROXY_PORT);
     }
     NPersQueue::TTestServer server(serverSettings, true, {}, NActors::NLog::PRI_INFO, pm);
+    server.EnableLogs({NKikimrServices::PERSQUEUE, NKikimrServices::PQ_FETCH_REQUEST});
 
     server.AnnoyingClient->CreateTopic(fullTopicName, 1);
     server.WaitInit(shortTopicName);
 
     return {std::move(server), kafkaPort, serverSettings.AppConfig->GetKafkaProxyConfig(), fullTopicName};
+}
+
+namespace NKafka {
+
+struct TestAccessor {
+    static std::unordered_map<TActorId, size_t> GetTopicIndexes(TKafkaFetchActor* actor) {
+        return actor->TopicIndexes;
+    }
+};
+
 }
 
 namespace NKafka::NTests {
@@ -276,7 +288,6 @@ namespace NKafka::NTests {
 
             CheckKafkaMetaResponse(runtime, kafkaPort);
         }
-
 
         Y_UNIT_TEST(DiscoveryResponsesWithError) {
             auto [server, kafkaPort, config, topicName] = SetupServer("topic1");
@@ -464,6 +475,77 @@ namespace NKafka::NTests {
             CreateMetarequestActor(edge, {path, path}, runtime, config);
 
             CheckKafkaMetaResponse(runtime, kafkaPort, false, 2);
+        }
+    }
+
+    Y_UNIT_TEST_SUITE(FetchActorTests) {
+        std::pair<TActorId, NKafka::TKafkaFetchActor*>  CreateFetchActor(
+                const TActorId& edge, const TString& topic, auto* runtime, const auto& kafkaConfig
+        ) {
+            TFetchRequestData::TPtr request = std::make_shared<TFetchRequestData>();
+            request->MaxBytes = 10000;
+            request->MaxWaitMs = 1000;
+            request->Topics.resize(1);
+            request->Topics[0].Topic = topic;
+            request->Topics[0].Partitions.resize(1);
+            request->Topics[0].Partitions[0].Partition = 0;
+            request->Topics[0].Partitions[0].PartitionMaxBytes = 10000;
+
+            auto context = std::make_shared<TContext>(kafkaConfig);
+            context->ConnectionId = edge;
+            context->DatabasePath = "/Root";
+            context->ResourceDatabasePath = "/Root";
+            context->UserToken = new NACLib::TUserToken("root@builtin", {});
+
+            auto* actor = new NKafka::TKafkaFetchActor(context, 1, TMessagePtr<TFetchRequestData>(std::make_shared<TBuffer>(), request));
+            TActorId actorId = runtime->Register(actor);
+            runtime->EnableScheduleForActor(actorId);
+            return {actorId, actor};
+        }
+
+        Y_UNIT_TEST(FetchWithNoneData) {
+            auto [server, kafkaPort, config, topicName] = SetupServer("topic1");
+
+            auto* runtime = server.GetRuntime();
+            auto edge = runtime->AllocateEdgeActor();
+
+            CreateFetchActor(edge, {NKikimr::JoinPath({"/Root/PQ/", topicName})}, runtime, config);
+
+            TAutoPtr<IEventHandle> handle;
+            auto* ev = runtime->GrabEdgeEvent<TEvKafka::TEvResponse>(handle);
+            UNIT_ASSERT(ev);
+            auto response = dynamic_cast<TFetchResponseData*>(ev->Response.get());
+
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            UNIT_ASSERT_VALUES_EQUAL(response->Responses.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(response->Responses[0].Partitions.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(response->Responses[0].Partitions[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        }
+
+        Y_UNIT_TEST(FetchWithTimeout) {
+            auto [server, kafkaPort, config, topicName] = SetupServer("topic1");
+
+            auto* runtime = server.GetRuntime();
+            auto edge = runtime->AllocateEdgeActor();
+
+            auto [actorId, actor] = CreateFetchActor(edge, {NKikimr::JoinPath({"/Root/PQ/", topicName})}, runtime, config);
+            Sleep(TDuration::MilliSeconds(100)); // wait actor willbe created
+
+            // emulate pipe error
+            auto topicIndexes = TestAccessor::GetTopicIndexes(actor);
+            UNIT_ASSERT(topicIndexes.size() == 1);
+            auto fetchActorId = topicIndexes.begin()->first;
+            runtime->Send(fetchActorId, fetchActorId, new TEvents::TEvWakeup(1000));
+
+            TAutoPtr<IEventHandle> handle;
+            auto* ev = runtime->GrabEdgeEvent<TEvKafka::TEvResponse>(handle);
+            UNIT_ASSERT(ev);
+            auto response = dynamic_cast<TFetchResponseData*>(ev->Response.get());
+
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            UNIT_ASSERT_VALUES_EQUAL(response->Responses.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(response->Responses[0].Partitions.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(response->Responses[0].Partitions[0].ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
         }
     }
 

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -12,6 +12,7 @@
 #include <ydb/core/kafka_proxy/kafka_constants.h>
 #include <ydb/core/kafka_proxy/actors/actors.h>
 #include <ydb/core/kafka_proxy/kafka_transactional_producers_initializers.h>
+#include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/constants.h>
 #include <ydb/services/ydb/ydb_common_ut.h>
 #include <ydb/services/ydb/ydb_keys_ut.h>
@@ -1348,6 +1349,35 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions[0].Records->Records.size(), 1);
         }
     } // Y_UNIT_TEST(FetchScenarioWithJoinGroup)
+
+    Y_UNIT_TEST(FetchEmptyTopicScenario) {
+        TInsecureTestServer testServer("FetchEmptyTopicScenario");
+
+        TString protocolName = "roundrobin";
+
+        TString topicName = "/Root/topic-0-test";
+        TString group = "group-0-test";
+
+
+          NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
+        CreateTopic(pqClient, topicName, 1, { group });
+
+        TKafkaTestClient client(testServer.Port);
+
+        client.AuthenticateToKafka();
+
+        {
+            // Check FETCH
+            std::vector<std::pair<TString, std::vector<i32>>> topics {{topicName, {0}}};
+            auto msg = client.Fetch(topics);
+            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            UNIT_ASSERT_VALUES_EQUAL(msg->Responses.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions.size(), 1);
+            // To protect the clients from failing due to null records,
+            // Java SDK always convert null records to MemoryRecords.EMPTY
+            UNIT_ASSERT_VALUES_EQUAL(msg->Responses[0].Partitions[0].Records.has_value(), false);
+        }
+    } // Y_UNIT_TEST(FetchEmptyTopicScenario)
 
     void RunBalanceScenarionTest(bool forFederation) {
         TString protocolName = "roundrobin";
@@ -3091,7 +3121,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             auto alteredTopic = TTopicConfig(
                     shortTopic0Name,
                     1,
-                    std::to_string(365 * 24 * 60 * 60 * 1000ul),
+                    std::to_string(TDuration::Days(365).MilliSeconds()),
                     std::nullopt
             );
             auto msg = client.AlterConfigs({alteredTopic});

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -1,27 +1,15 @@
 #include "fetch_request_actor.h"
 
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/interconnect.h>
-#include <ydb/core/protos/msgbus_pq.pb.h>
-#include <ydb/core/protos/msgbus.pb.h>
-
 #include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/client/server/msgbus_server_pq_metacache.h>
-#include <ydb/core/grpc_services/service_scheme.h>
-#include <ydb/core/grpc_services/service_topic.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/events/internal.h>
-#include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/pq_rl_helpers.h>
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/tx/replication/ydb_proxy/ydb_proxy.h>
-#include <ydb/core/tx/replication/ydb_proxy/local_proxy/local_proxy.h>
-#include <ydb/core/tx/replication/ydb_proxy/local_proxy/local_proxy_request.h>
-#include <ydb/core/kafka_proxy/actors/actors.h>
-#include <ydb/core/kafka_proxy/actors/kafka_topic_group_path_struct.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
-#include <ydb/public/lib/base/msgbus_status.h>
 
 #define LOG_PREFIX "[" << NActors::TlsActivationContext->AsActorContext().SelfID << "] "
 #define LOG_E(stream) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
@@ -65,11 +53,11 @@ class TPQFetchRequestActor : public TActorBootstrapped<TPQFetchRequestActor>
 private:
     TFetchRequestSettings Settings;
 
-    ui32 FetchRequestReadsDone;
+    size_t FetchRequestCurrentPartitionIndex;
     ui64 FetchRequestCurrentReadTablet;
-    ui64 CurrentCookie;
     ui32 PendingAlterTopicResponses = 0;
     ui32 FetchRequestBytesLeft;
+    bool ProcessingFinished = false;
     THolder<TEvPQ::TEvFetchResponse> Response;
     const TActorId SchemeCache;
 
@@ -77,8 +65,6 @@ private:
     THashMap<TString, TTopicInfo> TopicInfo;
     // TabletId -> TabletInfo
     THashMap<ui64, TTabletInfo> TabletInfo;
-    // PartitionIndex
-    std::deque<ui64> PartitionsWithData;
 
     TActorId RequesterId;
     ui64 PendingQuotaAmount;
@@ -106,15 +92,13 @@ public:
     TPQFetchRequestActor(const TFetchRequestSettings& settings, const TActorId& schemeCacheId, const TActorId& requesterId)
         : TRlHelpers({}, settings.RlCtx, 8_KB, false, TDuration::Seconds(1))
         , Settings(settings)
-        , FetchRequestReadsDone(0)
+        , FetchRequestCurrentPartitionIndex(0)
         , FetchRequestCurrentReadTablet(0)
-        , CurrentCookie(1)
-        , FetchRequestBytesLeft(0)
+        , FetchRequestBytesLeft(Settings.TotalMaxBytes)
         , SchemeCache(schemeCacheId)
         , RequesterId(requesterId)
     {
         ui64 deadline = TAppData::TimeProvider->Now().MilliSeconds() + Min<ui64>(Settings.MaxWaitTimeMs, MaxTimeout.MilliSeconds());
-        FetchRequestBytesLeft = Settings.TotalMaxBytes;
 
         PartitionStatus.resize(Settings.Partitions.size());
 
@@ -146,9 +130,9 @@ public:
 
     void Handle(TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx) {
         if (ev->Get()->Tag == TimeoutWakeupTag) {
-            HandleTimeout(ctx);
-            return;
+            return FinishProcessing(ctx);
         }
+
         const auto tag = static_cast<EWakeupTag>(ev->Get()->Tag);
         OnWakeup(tag);
         switch (tag) {
@@ -179,7 +163,7 @@ public:
             new IEventHandle(ctx.SelfID, ctx.SelfID, new TEvents::TEvWakeup(TimeoutWakeupTag)));
 
         SendSchemeCacheRequest(ctx);
-        Become(&TPQFetchRequestActor::StateFunc);
+        Become(&TPQFetchRequestActor::StateDescribe);
     }
 
     void SendSchemeCacheRequest(const TActorContext& ctx) {
@@ -292,6 +276,13 @@ public:
         OnMetadataReceived(ctx);
     }
 
+    STRICT_STFUNC(StateDescribe,
+        HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleSchemeCacheResponse);
+        HFunc(TEvents::TEvWakeup, Handle);
+        CFunc(NActors::TEvents::TSystem::Poison, Die);
+    )
+
+
     void OnMetadataReceived(const TActorContext& ctx) {
         if (!AppData(ctx)->KafkaProxyConfig.GetAutoCreateConsumersEnable()) {
             return OnTopicAltered(ctx);
@@ -320,6 +311,8 @@ public:
         if (PendingAlterTopicResponses == 0) {
             return OnTopicAltered(ctx);
         }
+
+        Become(&TPQFetchRequestActor::StateAlterTopics);
     }
 
     void Handle(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse::TPtr& ev, const TActorContext& ctx) {
@@ -333,50 +326,18 @@ public:
         }
     }
 
+    STRICT_STFUNC(StateAlterTopics,
+        HFunc(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse, Handle);
+        HFunc(TEvents::TEvWakeup, Handle);
+        CFunc(NActors::TEvents::TSystem::Poison, Die);
+    )
+
     void OnTopicAltered(const TActorContext& ctx) {
         for (auto& [name, info]: TopicInfo) {
             ProcessTopicMetadata(name, info, ctx);
         }
-    }
 
-    void Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx) {
-        return ProcessFetchRequestResult(ev, ctx);
-    }
-
-    void Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, const TActorContext& ctx) {
-        auto& record = ev->Get()->Record;
-        auto partitionIndex = record.GetCookie();
-        LOG_D("Handle TEvPersQueue::TEvHasDataInfoResponse " << record.ShortDebugString());
-        if (partitionIndex >= PartitionStatus.size()) {
-            Y_VERIFY_DEBUG(partitionIndex < PartitionStatus.size());
-            return;
-        }
-        auto& status = PartitionStatus[partitionIndex];
-        if (status != EPartitionStatus::HasDataRequested) {
-            // On timeout we resend send HasData
-            return;
-        }
-
-        status = EPartitionStatus::HasDataReceived;
-
-        auto& partition = Settings.Partitions[partitionIndex];
-        if (record.GetEndOffset() < partition.Offset) {
-            AddResult(partitionIndex, NPersQueue::NErrorCode::EErrorCode::READ_ERROR_TOO_BIG_OFFSET);
-        } else if (record.GetEndOffset() == partition.Offset) {
-            AddResult(partitionIndex, NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE);
-        } else {
-            PartitionsWithData.push_back(partitionIndex);
-        }
-
-        ProceedFetchRequest(ctx);
-    }
-
-    TActorId CreatePipe(ui64 tabletId, const TActorContext& ctx) {
-        auto retryPolicy = NTabletPipe::TClientRetryPolicy::WithRetries();
-        retryPolicy.RetryLimitCount = 5;
-        NTabletPipe::TClientConfig clientConfig(retryPolicy);
-
-        return ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, tabletId, clientConfig));
+        Become(&TPQFetchRequestActor::StateWork);
     }
 
     void ProcessTopicMetadata(const TString& name, TTopicInfo& topicInfo, const TActorContext& ctx) {
@@ -416,139 +377,41 @@ public:
         AFL_ENSURE(!TabletInfo.empty()); // if TabletInfo is empty - topic is empty
     }
 
-    void AddResult(size_t partitionIndex, NPersQueue::NErrorCode::EErrorCode errorCode) {
-        EnsureResponse();
-
-        PartitionStatus[partitionIndex] = EPartitionStatus::DataReceived;
-
-        const auto& req = Settings.Partitions[partitionIndex];
-
-        auto* res = Response->Response.MutablePartResult(partitionIndex);
-        res->SetTopic(req.Topic);
-        res->SetPartition(req.Partition);
-        auto* read = res->MutableReadResult();
-        read->SetErrorCode(errorCode);
-
-        ++FetchRequestReadsDone;
-    }
-
-    void HandlePipeError(const ui64 tabletId, const TActorContext& ctx) {
-        auto it = TabletInfo.find(tabletId);
-        // All pipes openned for tablets from the TabletInfo
-        AFL_ENSURE(it != TabletInfo.end())("tabletId", tabletId);
-        auto& pipeInfo = it->second;
-
-        pipeInfo.BrokenPipe = true;
-
-        for (const auto partitionIndex : pipeInfo.PartitionIndexes) {
-            if (PartitionStatus[partitionIndex] != EPartitionStatus::DataReceived) {
-                AddResult(partitionIndex, NPersQueue::NErrorCode::EErrorCode::TABLET_PIPE_DISCONNECTED);
-            }
-        }
-
-        if (FetchRequestCurrentReadTablet == tabletId) {
-            FetchRequestCurrentReadTablet = 0;
-            ProceedFetchRequest(ctx);
-        }
-    }
-
-    void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx) {
-        TEvTabletPipe::TEvClientConnected *msg = ev->Get();
-        if (msg->Status != NKikimrProto::OK) {
-            HandlePipeError(ev->Get()->TabletId, ctx);
-        }
-    }
-
-    void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx) {
-        HandlePipeError(ev->Get()->TabletId, ctx);
-    }
-
-    void HandleTimeout(const TActorContext& ctx) {
-        for (size_t i = 0; i < PartitionStatus.size(); ++i) {
-            if (PartitionStatus[i] == EPartitionStatus::HasDataRequested) { // rerequest HasData without timeout
-                auto& p = Settings.Partitions[i];
-                auto [topic, topicInfo] = GetTopicInfo(p.Topic);
-
-                auto fetchInfo = std::make_unique<TEvPersQueue::TEvHasDataInfo>();
-                fetchInfo->Record.SetPartition(p.Partition);
-                fetchInfo->Record.SetOffset(p.Offset);
-                fetchInfo->Record.SetCookie(i);
-
-                auto tabletId = topicInfo.PartitionToTablet[p.Partition];
-                NTabletPipe::SendData(ctx, TabletInfo[tabletId].PipeClient, fetchInfo.release());
-            }
-        }
-    }
-
-    void Die(const TActorContext& ctx) override {
-        for (auto& [_, tabletInfo]: TabletInfo) {
-            if (!tabletInfo.BrokenPipe) {
-                NTabletPipe::CloseClient(ctx, tabletInfo.PipeClient);
-            }
-        }
-        if (YdbProxy) {
-            Send(YdbProxy, new TEvents::TEvPoison());
-        }
-        if (LongTimer) {
-            Send(LongTimer, new TEvents::TEvPoison());
-        }
-        TRlHelpers::PassAway(SelfId());
-        TActorBootstrapped<TPQFetchRequestActor>::Die(ctx);
-    }
-
-    std::optional<size_t> NextPartition() {
-        if (PartitionsWithData.empty()) {
-            return std::nullopt;
-        }
-        size_t i = RandomNumber<size_t>(PartitionsWithData.size());
-        if (i == 0) {
-            auto partitionIndex = std::move(PartitionsWithData.front());
-            PartitionsWithData.pop_front();
-            return partitionIndex;
-        }
-
-        ui64 result = PartitionsWithData[i];
-        PartitionsWithData[i] = PartitionsWithData.front();
-        PartitionsWithData.pop_front();
-
-        return result;
-    }
-
-    std::pair<const TString&, TTopicInfo&> GetTopicInfo(const TString& topicPath) {
-        auto* topic = &topicPath;
-        auto cdcTopicNameIt = CdcPathToPrivateTopicPath.find(*topic);
-        if (cdcTopicNameIt != CdcPathToPrivateTopicPath.end()) {
-            topic = &cdcTopicNameIt->second;
-        }
-
-        auto it = TopicInfo.find(CanonizePath(*topic));
-        AFL_ENSURE(it != TopicInfo.end())("topic", *topic);
-
-        return {*topic, it->second};
-    }
-
     void ProceedFetchRequest(const TActorContext& ctx) {
         if (FetchRequestCurrentReadTablet) { //already got active read request
+            LOG_D("Fetch request is pending. TabletId=" << FetchRequestCurrentReadTablet
+                << " partitionIndex=" << FetchRequestCurrentPartitionIndex << "/" << Settings.Partitions.size());
             return;
         }
 
-        if (FetchRequestReadsDone == Settings.Partitions.size()) {
-            CreateOkResponse();
-            return SendReplyAndDie(std::move(Response), ctx);
-        }
-        AFL_ENSURE(FetchRequestReadsDone < Settings.Partitions.size())
-            ("l", FetchRequestReadsDone)
+        AFL_ENSURE(FetchRequestCurrentPartitionIndex <= Settings.Partitions.size())
+            ("l", FetchRequestCurrentPartitionIndex)
             ("r", Settings.Partitions.size());
 
         while (true) {
-            auto partitionIndex = NextPartition();
-            if (!partitionIndex) {
+            LOG_D("Processing " << FetchRequestCurrentPartitionIndex << "/" << Settings.Partitions.size());
+            if (FetchRequestCurrentPartitionIndex == Settings.Partitions.size()) {
+                CreateOkResponse();
+                return SendReplyAndDie(std::move(Response), ctx);
+            }
+
+            auto& status = PartitionStatus[FetchRequestCurrentPartitionIndex];
+            if (status == EPartitionStatus::DataReceived) {
+                LOG_D("Skip partition " << FetchRequestCurrentPartitionIndex << " because status is DataReceived");
+                ++FetchRequestCurrentPartitionIndex;
+                continue;
+            }
+
+            if (FetchRequestBytesLeft == 0) {
+                LOG_D("Partition " << FetchRequestCurrentPartitionIndex << " status is " << (int)status << " bytesLeft=" << FetchRequestBytesLeft);
+                if (status == EPartitionStatus::HasDataReceived) {
+                    ++FetchRequestCurrentPartitionIndex;
+                    continue;
+                }
                 return;
             }
 
-            CurrentCookie = *partitionIndex;
-
-            auto& req = Settings.Partitions[*partitionIndex];
+            auto& req = Settings.Partitions[FetchRequestCurrentPartitionIndex];
             auto [topic, topicInfo] = GetTopicInfo(req.Topic);
 
             auto partitionId = req.Partition;
@@ -565,13 +428,10 @@ public:
                 ("partition", partitionId)
                 ("tabletId", tabletId);
             auto& tabletInfo = jt->second;
-
-            if (tabletInfo.BrokenPipe) {
-                continue;
-            }
+            AFL_ENSURE(!tabletInfo.BrokenPipe); // If pipe is broken, than partition status is DataReceived. It is verified early.
 
             FetchRequestCurrentReadTablet = tabletId;
-            PartitionStatus[*partitionIndex] = EPartitionStatus::DataRequested;
+            PartitionStatus[FetchRequestCurrentPartitionIndex] = EPartitionStatus::DataRequested;
 
             //Form read request
             auto request = CreateReadRequest(topic, req);
@@ -582,12 +442,195 @@ public:
         }
     }
 
+    void Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, const TActorContext& ctx) {
+        auto& record = ev->Get()->Record;
+        auto partitionIndex = record.GetCookie();
+        LOG_D("Handle TEvPersQueue::TEvHasDataInfoResponse " << record.ShortDebugString());
+        if (partitionIndex >= PartitionStatus.size()) {
+            Y_VERIFY_DEBUG(partitionIndex < PartitionStatus.size());
+            return;
+        }
+        auto& status = PartitionStatus[partitionIndex];
+        LOG_D("Partition " << partitionIndex << " status is " << (int)status);
+        if (status != EPartitionStatus::HasDataRequested) {
+            // On timeout we resend send HasData
+            return;
+        }
+
+        status = EPartitionStatus::HasDataReceived;
+
+        auto& partition = Settings.Partitions[partitionIndex];
+        if (record.GetEndOffset() < partition.Offset) {
+            AddResult(partitionIndex, EPartitionStatus::DataReceived, NPersQueue::NErrorCode::EErrorCode::READ_ERROR_TOO_BIG_OFFSET, record.GetEndOffset());
+        } else if (record.GetEndOffset() == partition.Offset) {
+            AddResult(partitionIndex, EPartitionStatus::DataReceived, NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE, record.GetEndOffset());
+        } else {
+            AddResult(partitionIndex, EPartitionStatus::HasDataReceived, NPersQueue::NErrorCode::EErrorCode::OK, record.GetEndOffset());
+        }
+
+        ProceedFetchRequest(ctx);
+    }
+
+    void Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx) {
+        auto& record = ev->Get()->Record;
+        LOG_D("Handle TEvPersQueue::TEvRespons " << record.ShortDebugString());
+        AFL_ENSURE(record.HasPartitionResponse());
+
+        if (record.GetPartitionResponse().GetCookie() != FetchRequestCurrentPartitionIndex || FetchRequestCurrentReadTablet == 0) {
+            LOG_W("proxy fetch error: got response from tablet " << record.GetPartitionResponse().GetCookie()
+                                << " while waiting from " << FetchRequestCurrentPartitionIndex << " and requested tablet is " << FetchRequestCurrentReadTablet);
+            return;
+        }
+
+        if (FetchRequestBytesLeft >= (ui32)record.ByteSize()) {
+            FetchRequestBytesLeft -= (ui32)record.ByteSize();
+        } else {
+            FetchRequestBytesLeft = 0;
+        }
+        FetchRequestCurrentReadTablet = 0;
+        EnsureResponse();
+
+        AFL_ENSURE(FetchRequestCurrentPartitionIndex < Settings.Partitions.size());
+        PartitionStatus[FetchRequestCurrentPartitionIndex] = EPartitionStatus::DataReceived;
+
+        const auto& req = Settings.Partitions[FetchRequestCurrentPartitionIndex];
+        const auto& partitionId = req.Partition;
+
+        auto res = Response->Response.MutablePartResult(FetchRequestCurrentPartitionIndex);
+        res->SetTopic(req.Topic);
+        res->SetPartition(partitionId);
+        auto read = res->MutableReadResult();
+        if (record.HasPartitionResponse() && record.GetPartitionResponse().HasCmdReadResult()) {
+            read->CopyFrom(record.GetPartitionResponse().GetCmdReadResult());
+        }
+        if (record.HasErrorCode()) {
+            read->SetErrorCode(record.GetErrorCode());
+        }
+        if (record.HasErrorReason()) {
+            read->SetErrorReason(record.GetErrorReason());
+        }
+
+        ++FetchRequestCurrentPartitionIndex;
+
+        auto [_, topicInfo] = GetTopicInfo(req.Topic);
+
+        SetMeteringMode(topicInfo.PQInfo->Description.GetPQTabletConfig().GetMeteringMode());
+
+        LOG_D("After processing result FetchRequestBytesLeft=" << FetchRequestBytesLeft);
+        if (FetchRequestBytesLeft == 0) {
+            FinishProcessing(ctx);
+        } else if (IsQuotaRequired()) {
+            PendingQuotaAmount = CalcRuConsumption(GetPayloadSize(record)) + (Settings.RuPerRequest ? 1 : 0);
+            Settings.RuPerRequest = false;
+            RequestDataQuota(PendingQuotaAmount, ctx);
+        } else {
+            ProceedFetchRequest(ctx);
+        }
+    }
+
+    TActorId CreatePipe(ui64 tabletId, const TActorContext& ctx) {
+        auto retryPolicy = NTabletPipe::TClientRetryPolicy::WithRetries();
+        retryPolicy.RetryLimitCount = 5;
+        NTabletPipe::TClientConfig clientConfig(retryPolicy);
+
+        return ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, tabletId, clientConfig));
+    }
+
+    void AddResult(size_t partitionIndex, EPartitionStatus status, NPersQueue::NErrorCode::EErrorCode errorCode, std::optional<ui64> maxOffset = std::nullopt) {
+        EnsureResponse();
+
+        PartitionStatus[partitionIndex] = status;
+
+        const auto& req = Settings.Partitions[partitionIndex];
+
+        auto* res = Response->Response.MutablePartResult(partitionIndex);
+        res->SetTopic(req.Topic);
+        res->SetPartition(req.Partition);
+        auto* read = res->MutableReadResult();
+        read->SetErrorCode(errorCode);
+        if (maxOffset) {
+            read->SetMaxOffset(*maxOffset);
+        }
+    }
+
+    void HandlePipeError(const ui64 tabletId, const TActorContext& ctx) {
+        auto it = TabletInfo.find(tabletId);
+        // All pipes openned for tablets from the TabletInfo
+        AFL_ENSURE(it != TabletInfo.end())("tabletId", tabletId);
+        auto& pipeInfo = it->second;
+
+        pipeInfo.BrokenPipe = true;
+
+        for (const auto partitionIndex : pipeInfo.PartitionIndexes) {
+            if (PartitionStatus[partitionIndex] != EPartitionStatus::DataReceived) {
+                AddResult(partitionIndex, EPartitionStatus::DataReceived, NPersQueue::NErrorCode::EErrorCode::TABLET_PIPE_DISCONNECTED);
+            }
+        }
+
+        if (FetchRequestCurrentReadTablet == tabletId) {
+            FetchRequestCurrentReadTablet = 0;
+        }
+
+        ProceedFetchRequest(ctx);
+    }
+
+    void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx) {
+        TEvTabletPipe::TEvClientConnected *msg = ev->Get();
+        if (msg->Status != NKikimrProto::OK) {
+            HandlePipeError(ev->Get()->TabletId, ctx);
+        }
+    }
+
+    void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx) {
+        HandlePipeError(ev->Get()->TabletId, ctx);
+    }
+
+    void FinishProcessing(const TActorContext& ctx) {
+        if (ProcessingFinished) {
+            return;
+        }
+        ProcessingFinished = true;
+
+        for (size_t i = 0; i < PartitionStatus.size(); ++i) {
+            if (PartitionStatus[i] == EPartitionStatus::HasDataRequested) { // rerequest HasData without timeout
+                auto& p = Settings.Partitions[i];
+                auto [topic, topicInfo] = GetTopicInfo(p.Topic);
+
+                auto fetchInfo = std::make_unique<TEvPersQueue::TEvHasDataInfo>();
+                fetchInfo->Record.SetPartition(p.Partition);
+                fetchInfo->Record.SetOffset(p.Offset);
+                fetchInfo->Record.SetCookie(i);
+                fetchInfo->Record.SetDeadline(0);
+
+                auto tabletId = topicInfo.PartitionToTablet[p.Partition];
+                LOG_D("Sending TEvPersQueue::TEvHasDataInfo " << fetchInfo->Record.ShortDebugString());
+                NTabletPipe::SendData(ctx, TabletInfo[tabletId].PipeClient, fetchInfo.release());
+            }
+        }
+
+        FetchRequestBytesLeft = 0;
+        ProceedFetchRequest(ctx);
+    }
+
+    std::pair<const TString&, TTopicInfo&> GetTopicInfo(const TString& topicPath) {
+        auto* topic = &topicPath;
+        auto cdcTopicNameIt = CdcPathToPrivateTopicPath.find(*topic);
+        if (cdcTopicNameIt != CdcPathToPrivateTopicPath.end()) {
+            topic = &cdcTopicNameIt->second;
+        }
+
+        auto it = TopicInfo.find(CanonizePath(*topic));
+        AFL_ENSURE(it != TopicInfo.end())("topic", *topic);
+
+        return {*topic, it->second};
+    }
+
     std::unique_ptr<TEvPersQueue::TEvRequest> CreateReadRequest(const TString& topic, const TPartitionFetchRequest& fetchRequest) {
         auto request = std::make_unique<TEvPersQueue::TEvRequest>();
-        request->Record.SetRequestId(TStringBuilder() << "request" << "-id-" << FetchRequestReadsDone << "-" << Settings.Partitions.size());
+        request->Record.SetRequestId(TStringBuilder() << "request" << "-id-" << FetchRequestCurrentPartitionIndex << "-" << Settings.Partitions.size());
 
         auto* partitionRequest = request->Record.MutablePartitionRequest();
-        partitionRequest->SetCookie(CurrentCookie);
+        partitionRequest->SetCookie(FetchRequestCurrentPartitionIndex);
         partitionRequest->SetTopic(topic);
         partitionRequest->SetPartition(fetchRequest.Partition);
 
@@ -601,58 +644,6 @@ public:
         read->SetExternalOperation(true);
 
         return request;
-    }
-
-    void ProcessFetchRequestResult(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx) {
-        auto& record = ev->Get()->Record;
-        AFL_ENSURE(record.HasPartitionResponse());
-
-        if (record.GetPartitionResponse().GetCookie() != CurrentCookie || FetchRequestCurrentReadTablet == 0) {
-            LOG_W("proxy fetch error: got response from tablet " << record.GetPartitionResponse().GetCookie()
-                                << " while waiting from " << CurrentCookie << " and requested tablet is " << FetchRequestCurrentReadTablet);
-            return;
-        }
-
-        if (FetchRequestBytesLeft >= (ui32)record.ByteSize()) {
-            FetchRequestBytesLeft -= (ui32)record.ByteSize();
-        } else {
-            FetchRequestBytesLeft = 0;
-        }
-        FetchRequestCurrentReadTablet = 0;
-        EnsureResponse();
-
-        PartitionStatus[CurrentCookie] = EPartitionStatus::DataReceived;
-
-        AFL_ENSURE(FetchRequestReadsDone < Settings.Partitions.size());
-        const auto& req = Settings.Partitions[CurrentCookie];
-        const auto& partitionId = req.Partition;
-
-        auto res = Response->Response.MutablePartResult(CurrentCookie);
-        res->SetTopic(req.Topic);
-        res->SetPartition(partitionId);
-        auto read = res->MutableReadResult();
-        if (record.HasPartitionResponse() && record.GetPartitionResponse().HasCmdReadResult())
-            read->CopyFrom(record.GetPartitionResponse().GetCmdReadResult());
-        if (record.HasErrorCode())
-            read->SetErrorCode(record.GetErrorCode());
-        if (record.HasErrorReason())
-            read->SetErrorReason(record.GetErrorReason());
-
-        ++FetchRequestReadsDone;
-
-        auto [_, topicInfo] = GetTopicInfo(req.Topic);
-
-        SetMeteringMode(topicInfo.PQInfo->Description.GetPQTabletConfig().GetMeteringMode());
-
-        if (FetchRequestBytesLeft == 0) {
-            SendReplyOnDoneAndDie(ctx);
-        } else if (IsQuotaRequired()) {
-            PendingQuotaAmount = CalcRuConsumption(GetPayloadSize(record)) + (Settings.RuPerRequest ? 1 : 0);
-            Settings.RuPerRequest = false;
-            RequestDataQuota(PendingQuotaAmount, ctx);
-        } else {
-            ProceedFetchRequest(ctx);
-        }
     }
 
     ui64 GetPayloadSize(const NKikimrClient::TResponse& record) const {
@@ -675,19 +666,8 @@ public:
         return access.CheckAccess(NACLib::EAccessRights::SelectRow, *Settings.UserToken);
     }
 
-    void SendReplyOnDoneAndDie(const TActorContext& ctx) {
-        CreateOkResponse();
-
-        for (size_t i = 0; i < PartitionStatus.size(); ++i) {
-            if (PartitionStatus[i] != EPartitionStatus::DataReceived) {
-                AddResult(i, NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE);
-            }
-        }
-
-        SendReplyAndDie(std::move(Response), ctx);
-    }
-
-     void SendReplyAndDie(THolder<TEvPQ::TEvFetchResponse> event, const TActorContext& ctx) {
+    void SendReplyAndDie(THolder<TEvPQ::TEvFetchResponse> event, const TActorContext& ctx) {
+        LOG_D("Reply to " << RequesterId << ": " << event->Response.ShortDebugString());
         ctx.Send(RequesterId, event.Release());
         Die(ctx);
     }
@@ -720,20 +700,32 @@ public:
         }
     }
 
-    STRICT_STFUNC(StateFunc,
-            HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleSchemeCacheResponse);
-            HFunc(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse, Handle);
+    STRICT_STFUNC(StateWork,
+        HFunc(TEvPersQueue::TEvHasDataInfoResponse, Handle);
+        HFunc(TEvPersQueue::TEvResponse, Handle);
 
-            HFunc(TEvPersQueue::TEvHasDataInfoResponse, Handle);
-            HFunc(TEvPersQueue::TEvResponse, Handle);
+        HFunc(TEvTabletPipe::TEvClientDestroyed, Handle);
+        HFunc(TEvTabletPipe::TEvClientConnected, Handle);
 
-            HFunc(TEvTabletPipe::TEvClientDestroyed, Handle);
-            HFunc(TEvTabletPipe::TEvClientConnected, Handle);
-
-            HFunc(TEvents::TEvWakeup, Handle);
-
-            CFunc(NActors::TEvents::TSystem::PoisonPill, Die);
+        HFunc(TEvents::TEvWakeup, Handle);
+        CFunc(NActors::TEvents::TSystem::PoisonPill, Die);
     )
+
+    void Die(const TActorContext& ctx) override {
+        for (auto& [_, tabletInfo]: TabletInfo) {
+            if (!tabletInfo.BrokenPipe) {
+                NTabletPipe::CloseClient(ctx, tabletInfo.PipeClient);
+            }
+        }
+        if (YdbProxy) {
+            Send(YdbProxy, new TEvents::TEvPoison());
+        }
+        if (LongTimer) {
+            Send(LongTimer, new TEvents::TEvPoison());
+        }
+        TRlHelpers::PassAway(SelfId());
+        TActorBootstrapped<TPQFetchRequestActor>::Die(ctx);
+    }
 };
 
 NActors::IActor* CreatePQFetchRequestActor(

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -4,6 +4,8 @@
 #include <ydb/library/actors/core/interconnect.h>
 #include <ydb/core/protos/msgbus_pq.pb.h>
 #include <ydb/core/protos/msgbus.pb.h>
+
+#include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/client/server/msgbus_server_pq_metacache.h>
 #include <ydb/core/grpc_services/service_scheme.h>
@@ -21,9 +23,12 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/public/lib/base/msgbus_status.h>
 
-#define LOG_E(stream) LOG_ERROR_S(ctx, NKikimrServices::PQ_FETCH_REQUEST, stream)
-#define LOG_I(stream) LOG_INFO_S(ctx, NKikimrServices::PQ_FETCH_REQUEST, stream)
-#define LOG_D(stream) LOG_DEBUG_S(ctx, NKikimrServices::PQ_FETCH_REQUEST, stream)
+#define LOG_PREFIX "[" << NActors::TlsActivationContext->AsActorContext().SelfID << "] "
+#define LOG_E(stream) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
+#define LOG_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
+#define LOG_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
+#define LOG_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
+#define LOG(level, stream) LOG_LOG_S(*NActors::TlsActivationContext, level, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
 
 namespace NKikimr::NPQ {
 
@@ -32,32 +37,24 @@ using namespace NSchemeCache;
 
 
 namespace {
-    static constexpr TDuration DefaultTimeout = TDuration::MilliSeconds(30000);
+    static constexpr TDuration MaxTimeout = TDuration::Seconds(30);
+    static constexpr ui64 TimeoutWakeupTag = 1000;
 }
 
-struct TTabletInfo { // ToDo !! remove
-    ui32 NodeId = 0;
-    TString Topic;
+struct TTabletInfo {
     TActorId PipeClient;
     bool BrokenPipe = false;
-    bool IsBalancer = false;
-    TVector<NKikimrPQ::TOffsetsResponse::TPartResult> OffsetResponses;
-    TVector<NKikimrPQ::TStatusResponse::TPartResult> StatusResponses;
+    std::vector<size_t> PartitionIndexes;
 };
 
 struct TTopicInfo {
-    TVector<ui64> Tablets;
     THashMap<ui32, ui64> PartitionToTablet;
-    ui64 BalancerTabletId = 0;
 
-    NKikimrPQ::TPQTabletConfig Config;
     TIntrusiveConstPtr<TSchemeCacheNavigate::TPQGroupInfo> PQInfo;
-    NPersQueue::TDiscoveryConverterPtr Converter;
-    ui32 NumParts = 0;
     THashSet<ui32> PartitionsToRequest;
 
     //fetchRequest part
-    THashMap<ui32, TAutoPtr<TEvPersQueue::TEvHasDataInfo>> FetchInfo;
+    THashMap<ui32, TAutoPtr<TEvPersQueue::TEvHasDataInfo>> HasDataRequests;
 };
 
 
@@ -65,51 +62,41 @@ using namespace NActors;
 
 class TPQFetchRequestActor : public TActorBootstrapped<TPQFetchRequestActor>
                            , private TRlHelpers {
-
-struct TEvPrivate {
-    enum EEv {
-        EvTimeout = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
-        EvEnd
-    };
-
-    static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
-
-    struct TEvTimeout : NActors::TEventLocal<TEvTimeout, EvTimeout> {
-    };
-
-};
-
 private:
     TFetchRequestSettings Settings;
 
-    bool CanProcessFetchRequest; //any partitions answered that it has data or WaitMs timeout occured
     ui32 FetchRequestReadsDone;
     ui64 FetchRequestCurrentReadTablet;
     ui64 CurrentCookie;
-    ui32 AlterTopicCookie = 0;
     ui32 PendingAlterTopicResponses = 0;
     ui32 FetchRequestBytesLeft;
     THolder<TEvPQ::TEvFetchResponse> Response;
-    TVector<TActorId> PQClient;
     const TActorId SchemeCache;
 
+    // TopicPath -> TopicInfo
     THashMap<TString, TTopicInfo> TopicInfo;
+    // TabletId -> TabletInfo
     THashMap<ui64, TTabletInfo> TabletInfo;
+    // PartitionIndex
+    std::deque<ui64> PartitionsWithData;
 
-    std::unordered_map<ui32, TString> AlterTopicCookieToName;
-    std::unordered_set<NKafka::TTopicGroupIdAndPath, NKafka::TTopicGroupIdAndPathHash> ConsumerTopicAlterRequestAttempts;
-
-    ui32 TopicsAnswered;
-    THashSet<ui64> TabletsDiscovered;
-    THashSet<ui64> TabletsAnswered;
-    ui32 PartTabletsRequested;
-    TString ErrorReason;
     TActorId RequesterId;
     ui64 PendingQuotaAmount;
     bool AnyCdcTopicInRequest = false;
 
-    std::unordered_map<TString, TString> PrivateTopicPathToCdcPath;
+    TActorId YdbProxy;
+    TActorId LongTimer;
+
     std::unordered_map<TString, TString> CdcPathToPrivateTopicPath;
+
+    enum class EPartitionStatus {
+        DataRequested,
+        DataReceived,
+        HasDataRequested,
+        HasDataReceived,
+        Unprocessed
+    };
+    std::vector<EPartitionStatus> PartitionStatus;
 
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -119,19 +106,20 @@ public:
     TPQFetchRequestActor(const TFetchRequestSettings& settings, const TActorId& schemeCacheId, const TActorId& requesterId)
         : TRlHelpers({}, settings.RlCtx, 8_KB, false, TDuration::Seconds(1))
         , Settings(settings)
-        , CanProcessFetchRequest(false)
         , FetchRequestReadsDone(0)
         , FetchRequestCurrentReadTablet(0)
         , CurrentCookie(1)
         , FetchRequestBytesLeft(0)
         , SchemeCache(schemeCacheId)
-        , TopicsAnswered(0)
-        , PartTabletsRequested(0)
         , RequesterId(requesterId)
     {
-        ui64 deadline = TAppData::TimeProvider->Now().MilliSeconds() + Min<ui32>(Settings.MaxWaitTimeMs, 30000);
+        ui64 deadline = TAppData::TimeProvider->Now().MilliSeconds() + Min<ui64>(Settings.MaxWaitTimeMs, MaxTimeout.MilliSeconds());
         FetchRequestBytesLeft = Settings.TotalMaxBytes;
-        for (const auto& p : Settings.Partitions) {
+
+        PartitionStatus.resize(Settings.Partitions.size());
+
+        for (size_t i = 0; i < Settings.Partitions.size(); ++i) {
+            const auto& p = Settings.Partitions[i];
             if (p.Topic.empty()) {
                 Response = CreateErrorReply(Ydb::StatusIds::BAD_REQUEST, "Empty topic in fetch request");
                 return;
@@ -139,8 +127,8 @@ public:
                 Response = CreateErrorReply(Ydb::StatusIds::BAD_REQUEST, "No maxBytes for partition in fetch request");
                 return;
             }
-            auto path = CanonizePath(p.Topic);
-            bool res = TopicInfo[path].PartitionsToRequest.insert(p.Partition).second;
+            auto topicPath = CanonizePath(p.Topic);
+            bool res = TopicInfo[topicPath].PartitionsToRequest.insert(p.Partition).second;
             if (!res) {
                 Response = CreateErrorReply(Ydb::StatusIds::BAD_REQUEST, "Some partition specified multiple times in fetch request");
                 return;
@@ -149,11 +137,18 @@ public:
             fetchInfo->Record.SetPartition(p.Partition);
             fetchInfo->Record.SetOffset(p.Offset);
             fetchInfo->Record.SetDeadline(deadline);
-            TopicInfo[path].FetchInfo[p.Partition] = fetchInfo;
+            fetchInfo->Record.SetCookie(i);
+            TopicInfo[topicPath].HasDataRequests[p.Partition] = fetchInfo;
+
+            PartitionStatus[i] = EPartitionStatus::Unprocessed;
         }
     }
 
     void Handle(TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx) {
+        if (ev->Get()->Tag == TimeoutWakeupTag) {
+            HandleTimeout(ctx);
+            return;
+        }
         const auto tag = static_cast<EWakeupTag>(ev->Get()->Tag);
         OnWakeup(tag);
         switch (tag) {
@@ -179,11 +174,11 @@ public:
         if (Response) {
             return SendReplyAndDie(std::move(Response), ctx);
         }
-        LOG_D("scheduling HasDataInfoResponse in " << Settings.MaxWaitTimeMs);
-        ctx.Schedule(TDuration::MilliSeconds(Min<ui32>(Settings.MaxWaitTimeMs, 30000)), new TEvPersQueue::TEvHasDataInfoResponse);
+
+        LongTimer = CreateLongTimer(Min<TDuration>(MaxTimeout, TDuration::MilliSeconds(Settings.MaxWaitTimeMs)),
+            new IEventHandle(ctx.SelfID, ctx.SelfID, new TEvents::TEvWakeup(TimeoutWakeupTag)));
 
         SendSchemeCacheRequest(ctx);
-        Schedule(DefaultTimeout, new TEvPrivate::TEvTimeout());
         Become(&TPQFetchRequestActor::StateFunc);
     }
 
@@ -194,14 +189,13 @@ public:
         schemeCacheRequest->DatabaseName = Settings.Database;
 
         THashSet<TString> topicsRequested;
-
-        if (PrivateTopicPathToCdcPath.empty()) {
+        if (CdcPathToPrivateTopicPath.empty()) {
             for (const auto& part : Settings.Partitions) {
                 topicsRequested.insert(part.Topic);
             }
         } else {
-            for (const auto& [key, value] : PrivateTopicPathToCdcPath) {
-                topicsRequested.insert(key);
+            for (const auto& [_, topicPath] : CdcPathToPrivateTopicPath) {
+                topicsRequested.insert(topicPath);
             }
         }
 
@@ -250,9 +244,8 @@ public:
                 AnyCdcTopicInRequest = true;
                 AFL_ENSURE(entry.ListNodeEntry->Children.size() == 1);
                 auto privateTopicPath = CanonizePath(JoinPath(ChildPath(NKikimr::SplitPath(path), entry.ListNodeEntry->Children.at(0).Name)));
-                PrivateTopicPathToCdcPath[privateTopicPath] = path;
                 CdcPathToPrivateTopicPath[path] = privateTopicPath;
-                TopicInfo[privateTopicPath] = TopicInfo[path];
+                TopicInfo[privateTopicPath] = std::move(TopicInfo[path]);
                 TopicInfo.erase(path);
                 continue;
             }
@@ -288,93 +281,61 @@ public:
                 );;
             }
 
-            auto& description = entry.PQGroupInfo->Description;
             auto& topicInfo = TopicInfo[path];
-            topicInfo.BalancerTabletId = description.GetBalancerTabletID();
             topicInfo.PQInfo = entry.PQGroupInfo;
+        }
 
-            const auto &config = description.GetPQTabletConfig();
-            const auto &consumers = config.GetConsumers();
-            TString groupId = Settings.Partitions[0].ClientId;
-            if (groupId != NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER) {
-                bool consumerIsAdded = false;
-                for (const auto& consumer : consumers) {
-                    TString consumerName = consumer.GetName();
-                    if (consumerName == groupId) {
-                        consumerIsAdded = true;
-                    }
-                }
-                TAppData* appData = AppData(ctx);
-                if (!consumerIsAdded && appData->KafkaProxyConfig.GetAutoCreateConsumersEnable()) {
-                    CreateConsumerGroupIfNecessary(entry.Path.back(), path, groupId);
-                }
+        if (AnyCdcTopicInRequest) {
+            return SendSchemeCacheRequest(ctx);
+        }
+
+        OnMetadataReceived(ctx);
+    }
+
+    void OnMetadataReceived(const TActorContext& ctx) {
+        if (!AppData(ctx)->KafkaProxyConfig.GetAutoCreateConsumersEnable()) {
+            return OnTopicAltered(ctx);
+        }
+
+        if (Settings.Consumer == NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER) {
+            return OnTopicAltered(ctx);
+        }
+
+        for (auto& [topicPath, info]: TopicInfo) {
+            if (HasConsumer(info.PQInfo->Description.GetPQTabletConfig(), Settings.Consumer)) {
+                continue;
             }
+
+            EnsureYdbProxy();
+
+            const auto settings = NYdb::NTopic::TAlterTopicSettings()
+                .BeginAddConsumer()
+                    .ConsumerName(Settings.Consumer)
+                .EndAddConsumer();
+
+            Send(YdbProxy, new NReplication::TEvYdbProxy::TEvAlterTopicRequest(topicPath, settings));
+            ++PendingAlterTopicResponses;
         }
 
         if (PendingAlterTopicResponses == 0) {
-            if (AnyCdcTopicInRequest) {
-                SendSchemeCacheRequest(ctx);
-                return;
-            }
-
-            for (auto& p: TopicInfo) {
-                ProcessMetadata(p.first, p.second, ctx);
-            }
+            return OnTopicAltered(ctx);
         }
-
-    }
-
-    void CreateConsumerGroupIfNecessary(const TString& topicName,
-                                    const TString& topicPath,
-                                    const TString& groupId) {
-        NKafka::TTopicGroupIdAndPath consumerTopicRequest = NKafka::TTopicGroupIdAndPath{groupId, topicPath};
-        if (ConsumerTopicAlterRequestAttempts.find(consumerTopicRequest) == ConsumerTopicAlterRequestAttempts.end()) {
-            ConsumerTopicAlterRequestAttempts.insert(consumerTopicRequest);
-        } else {
-            // it is enough to send a consumer addition request only once for a particular topic
-            return;
-        }
-        PendingAlterTopicResponses++;
-
-        auto request = std::make_unique<Ydb::Topic::AlterTopicRequest>();
-        request.get()->set_path(topicPath);
-        auto* consumer = request->add_add_consumers();
-        consumer->set_name(groupId);
-        AlterTopicCookie++;
-        AlterTopicCookieToName[AlterTopicCookie] = topicName;
-        auto callback = [replyTo = SelfId(), cookie = AlterTopicCookie, path = topicName, this]
-            (Ydb::StatusIds::StatusCode statusCode, const google::protobuf::Message*) {
-            NYdb::NIssue::TIssues issues;
-            NYdb::TStatus status(static_cast<NYdb::EStatus>(statusCode), std::move(issues));
-            Send(replyTo,
-                new NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse(std::move(status)),
-                0,
-                cookie);
-        };
-        NKikimr::NGRpcService::DoAlterTopicRequest(
-            std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
-            topicName, Settings.Database, std::move(request), callback),
-            NKikimr::NReplication::TLocalProxyActor(Settings.Database));
-
     }
 
     void Handle(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse::TPtr& ev, const TActorContext& ctx) {
         NYdb::TStatus& result = ev->Get()->Result;
-        if (result.GetStatus() == NYdb::EStatus::SUCCESS) {
-            LOG_DEBUG_S(ctx, NKikimrServices::PQ_FETCH_REQUEST, "Handling TEvAlterTopicResponse. Status: " << result.GetStatus() << "\n");
-        } else {
-            LOG_INFO_S(ctx, NKikimrServices::PQ_FETCH_REQUEST, "Handling TEvAlterTopicResponse. Status: " << result.GetStatus() << "\n");
-        }
-        PendingAlterTopicResponses--;
-        if (PendingAlterTopicResponses == 0) {
-            if (AnyCdcTopicInRequest) {
-                SendSchemeCacheRequest(ctx);
-                return;
-            }
+        auto logLevel = result.GetStatus() == NYdb::EStatus::SUCCESS ? NActors::NLog::PRI_DEBUG :NActors::NLog::PRI_INFO;
+        LOG(logLevel, "Handling TEvAlterTopicResponse. Status: " << result.GetStatus());
 
-            for (auto& p: TopicInfo) {
-                ProcessMetadata(p.first, p.second, ctx);
-            }
+        --PendingAlterTopicResponses;
+        if (PendingAlterTopicResponses == 0) {
+            OnTopicAltered(ctx);
+        }
+    }
+
+    void OnTopicAltered(const TActorContext& ctx) {
+        for (auto& [name, info]: TopicInfo) {
+            ProcessTopicMetadata(name, info, ctx);
         }
     }
 
@@ -382,219 +343,293 @@ public:
         return ProcessFetchRequestResult(ev, ctx);
     }
 
-    void Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr&, const TActorContext& ctx) {
-        LOG_D("got HasDatainfoResponse");
+    void Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, const TActorContext& ctx) {
+        auto& record = ev->Get()->Record;
+        auto partitionIndex = record.GetCookie();
+        LOG_D("Handle TEvPersQueue::TEvHasDataInfoResponse " << record.ShortDebugString());
+        if (partitionIndex >= PartitionStatus.size()) {
+            Y_VERIFY_DEBUG(partitionIndex < PartitionStatus.size());
+            return;
+        }
+        auto& status = PartitionStatus[partitionIndex];
+        if (status != EPartitionStatus::HasDataRequested) {
+            // On timeout we resend send HasData
+            return;
+        }
+
+        status = EPartitionStatus::HasDataReceived;
+
+        auto& partition = Settings.Partitions[partitionIndex];
+        if (record.GetEndOffset() < partition.Offset) {
+            AddResult(partitionIndex, NPersQueue::NErrorCode::EErrorCode::READ_ERROR_TOO_BIG_OFFSET);
+        } else if (record.GetEndOffset() == partition.Offset) {
+            AddResult(partitionIndex, NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE);
+        } else {
+            PartitionsWithData.push_back(partitionIndex);
+        }
+
         ProceedFetchRequest(ctx);
     }
 
-    void ProcessMetadata(const TString& name, TTopicInfo& info, const TActorContext& ctx) {
-        const auto& pqDescr = info.PQInfo->Description;
+    TActorId CreatePipe(ui64 tabletId, const TActorContext& ctx) {
+        auto retryPolicy = NTabletPipe::TClientRetryPolicy::WithRetries();
+        retryPolicy.RetryLimitCount = 5;
+        NTabletPipe::TClientConfig clientConfig(retryPolicy);
 
-        ++TopicsAnswered;
-        auto it = TopicInfo.find(name);
-        AFL_ENSURE(it != TopicInfo.end())("topic", name);
-        it->second.Config = pqDescr.GetPQTabletConfig();
-        it->second.Config.SetVersion(pqDescr.GetAlterVersion());
-        it->second.NumParts = pqDescr.PartitionsSize();
-        AFL_ENSURE(it->second.BalancerTabletId);
+        return ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, tabletId, clientConfig));
+    }
 
-        for (ui32 i = 0; i < pqDescr.PartitionsSize(); ++i) {
-            ui32 part = pqDescr.GetPartitions(i).GetPartitionId();
-            ui64 tabletId = pqDescr.GetPartitions(i).GetTabletId();
-            if (!it->second.PartitionsToRequest.contains(part)) {
+    void ProcessTopicMetadata(const TString& name, TTopicInfo& topicInfo, const TActorContext& ctx) {
+        const auto& pqDescr = topicInfo.PQInfo->Description;
+
+        for (const auto& partition : pqDescr.GetPartitions()) {
+            ui32 partitionId = partition.GetPartitionId();
+            ui64 tabletId = partition.GetTabletId();
+            if (!topicInfo.PartitionsToRequest.contains(partitionId)) {
                 continue;
             }
-            bool res = it->second.PartitionToTablet.insert({part, tabletId}).second;
-            AFL_ENSURE(res);
+
+            bool res = topicInfo.PartitionToTablet.insert({partitionId, tabletId}).second;
+            AFL_ENSURE(res)("partitionId", partitionId);
+
             if (TabletInfo.find(tabletId) == TabletInfo.end()) {
                 auto& tabletInfo = TabletInfo[tabletId];
-                tabletInfo.Topic = name;
-                it->second.Tablets.push_back(tabletId);
-                    // Tablet node resolution relies on opening a pipe
 
-                auto retryPolicy = NTabletPipe::TClientRetryPolicy::WithRetries();
-                retryPolicy.RetryLimitCount = 5;
-                NTabletPipe::TClientConfig clientConfig(retryPolicy);
-
-                TActorId pipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, tabletId, clientConfig));
-                tabletInfo.PipeClient = pipeClient;
-                PQClient.push_back(pipeClient);
-                ++PartTabletsRequested;
+                // Tablet node resolution relies on opening a pipe
+                tabletInfo.PipeClient = CreatePipe(tabletId, ctx);
             }
-            if (CanProcessFetchRequest) {
-                ProceedFetchRequest(ctx);
-            } else {
-                const auto& tabletInfo = TabletInfo[tabletId];
-                auto& fetchInfo = it->second.FetchInfo[part];
-                LOG_D("sending HasDataInfoResponse " << fetchInfo->Record.DebugString());
 
-                NTabletPipe::SendData(ctx, tabletInfo.PipeClient, it->second.FetchInfo[part].Release());
-                ++PartTabletsRequested;
-            }
+            auto& tabletInfo = TabletInfo[tabletId];
+            auto& fetchInfo = topicInfo.HasDataRequests[partitionId];
+            const auto partitionIndex = fetchInfo->Record.GetCookie();
+            tabletInfo.PartitionIndexes.push_back(partitionIndex);
+            LOG_D("Sending TEvPersQueue::TEvHasDataInfo " << fetchInfo->Record.ShortDebugString());
+            NTabletPipe::SendData(ctx, tabletInfo.PipeClient, fetchInfo.Release());
+            PartitionStatus[partitionIndex] = EPartitionStatus::HasDataRequested;
         }
-        if (!it->second.PartitionsToRequest.empty() && it->second.PartitionsToRequest.size() != it->second.PartitionToTablet.size()) {
+
+        if (!topicInfo.PartitionsToRequest.empty() && topicInfo.PartitionsToRequest.size() != topicInfo.PartitionToTablet.size()) {
             auto reason = TStringBuilder() << "no one of requested partitions in topic " << name << ", Marker# PQ12";
             return SendReplyAndDie(CreateErrorReply(Ydb::StatusIds::BAD_REQUEST, reason), ctx);
         }
+
         AFL_ENSURE(!TabletInfo.empty()); // if TabletInfo is empty - topic is empty
     }
 
-    bool HandlePipeError(const ui64 tabletId, const TActorContext& ctx)
-    {
+    void AddResult(size_t partitionIndex, NPersQueue::NErrorCode::EErrorCode errorCode) {
+        EnsureResponse();
+
+        PartitionStatus[partitionIndex] = EPartitionStatus::DataReceived;
+
+        const auto& req = Settings.Partitions[partitionIndex];
+
+        auto* res = Response->Response.MutablePartResult(partitionIndex);
+        res->SetTopic(req.Topic);
+        res->SetPartition(req.Partition);
+        auto* read = res->MutableReadResult();
+        read->SetErrorCode(errorCode);
+
+        ++FetchRequestReadsDone;
+    }
+
+    void HandlePipeError(const ui64 tabletId, const TActorContext& ctx) {
         auto it = TabletInfo.find(tabletId);
-        if (it != TabletInfo.end()) {
-            it->second.BrokenPipe = true;
-            if (FetchRequestCurrentReadTablet == tabletId) {
-                //fail current read
-                ctx.Send(ctx.SelfID, FormEmptyCurrentRead(CurrentCookie).Release());
+        // All pipes openned for tablets from the TabletInfo
+        AFL_ENSURE(it != TabletInfo.end())("tabletId", tabletId);
+        auto& pipeInfo = it->second;
+
+        pipeInfo.BrokenPipe = true;
+
+        for (const auto partitionIndex : pipeInfo.PartitionIndexes) {
+            if (PartitionStatus[partitionIndex] != EPartitionStatus::DataReceived) {
+                AddResult(partitionIndex, NPersQueue::NErrorCode::EErrorCode::TABLET_PIPE_DISCONNECTED);
             }
-            return true;
         }
-        return false;
+
+        if (FetchRequestCurrentReadTablet == tabletId) {
+            FetchRequestCurrentReadTablet = 0;
+            ProceedFetchRequest(ctx);
+        }
     }
 
     void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx) {
         TEvTabletPipe::TEvClientConnected *msg = ev->Get();
-        const ui64 tabletId = ev->Get()->TabletId;
         if (msg->Status != NKikimrProto::OK) {
-
-            if (HandlePipeError(tabletId, ctx))
-                return;
-
-            auto reason = TStringBuilder() << "Client pipe to " << tabletId << " connection error, Status"
-                                                           << NKikimrProto::EReplyStatus_Name(msg->Status).data()
-                                                           << ", Marker# PQ6";
-            return SendReplyAndDie(CreateErrorReply(Ydb::StatusIds::INTERNAL_ERROR, reason), ctx);
+            HandlePipeError(ev->Get()->TabletId, ctx);
         }
     }
 
     void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx) {
-        ui64 tabletId = ev->Get()->TabletId;
-        if (HandlePipeError(tabletId, ctx))
-            return;
-
-        auto reason = TStringBuilder() << "Client pipe to " << tabletId << " destroyed (connection lost), Marker# PQ7";
-        SendReplyAndDie(CreateErrorReply(Ydb::StatusIds::INTERNAL_ERROR, reason), ctx);
+        HandlePipeError(ev->Get()->TabletId, ctx);
     }
 
     void HandleTimeout(const TActorContext& ctx) {
-        TString reason = "Timeout while waiting for response, may be just slow, Marker# PQ11";
-        return SendReplyAndDie(CreateErrorReply(Ydb::StatusIds::GENERIC_ERROR, reason), ctx);
+        for (size_t i = 0; i < PartitionStatus.size(); ++i) {
+            if (PartitionStatus[i] == EPartitionStatus::HasDataRequested) { // rerequest HasData without timeout
+                auto& p = Settings.Partitions[i];
+                auto [topic, topicInfo] = GetTopicInfo(p.Topic);
+
+                auto fetchInfo = std::make_unique<TEvPersQueue::TEvHasDataInfo>();
+                fetchInfo->Record.SetPartition(p.Partition);
+                fetchInfo->Record.SetOffset(p.Offset);
+                fetchInfo->Record.SetCookie(i);
+
+                auto tabletId = topicInfo.PartitionToTablet[p.Partition];
+                NTabletPipe::SendData(ctx, TabletInfo[tabletId].PipeClient, fetchInfo.release());
+            }
+        }
     }
 
     void Die(const TActorContext& ctx) override {
-        for (auto& actor: PQClient) {
-            NTabletPipe::CloseClient(ctx, actor);
+        for (auto& [_, tabletInfo]: TabletInfo) {
+            if (!tabletInfo.BrokenPipe) {
+                NTabletPipe::CloseClient(ctx, tabletInfo.PipeClient);
+            }
+        }
+        if (YdbProxy) {
+            Send(YdbProxy, new TEvents::TEvPoison());
+        }
+        if (LongTimer) {
+            Send(LongTimer, new TEvents::TEvPoison());
         }
         TRlHelpers::PassAway(SelfId());
         TActorBootstrapped<TPQFetchRequestActor>::Die(ctx);
     }
 
-    TAutoPtr<TEvPersQueue::TEvResponse> FormEmptyCurrentRead(ui64 cookie) {
-        TAutoPtr<TEvPersQueue::TEvResponse> req(new TEvPersQueue::TEvResponse);
-        auto read = req->Record.MutablePartitionResponse()->MutableCmdReadResult();
-        req->Record.MutablePartitionResponse()->SetCookie(cookie);
-        read->SetErrorCode(NPersQueue::NErrorCode::READ_NOT_DONE);
-        return req.Release();
+    std::optional<size_t> NextPartition() {
+        if (PartitionsWithData.empty()) {
+            return std::nullopt;
+        }
+        size_t i = RandomNumber<size_t>(PartitionsWithData.size());
+        if (i == 0) {
+            auto partitionIndex = std::move(PartitionsWithData.front());
+            PartitionsWithData.pop_front();
+            return partitionIndex;
+        }
+
+        ui64 result = PartitionsWithData[i];
+        PartitionsWithData[i] = PartitionsWithData.front();
+        PartitionsWithData.pop_front();
+
+        return result;
+    }
+
+    std::pair<const TString&, TTopicInfo&> GetTopicInfo(const TString& topicPath) {
+        auto* topic = &topicPath;
+        auto cdcTopicNameIt = CdcPathToPrivateTopicPath.find(*topic);
+        if (cdcTopicNameIt != CdcPathToPrivateTopicPath.end()) {
+            topic = &cdcTopicNameIt->second;
+        }
+
+        auto it = TopicInfo.find(CanonizePath(*topic));
+        AFL_ENSURE(it != TopicInfo.end())("topic", *topic);
+
+        return {*topic, it->second};
     }
 
     void ProceedFetchRequest(const TActorContext& ctx) {
         if (FetchRequestCurrentReadTablet) { //already got active read request
             return;
         }
-        CanProcessFetchRequest = true;
 
         if (FetchRequestReadsDone == Settings.Partitions.size()) {
             CreateOkResponse();
             return SendReplyAndDie(std::move(Response), ctx);
         }
-        AFL_ENSURE(FetchRequestReadsDone < Settings.Partitions.size());
-        auto& req = Settings.Partitions[FetchRequestReadsDone];
+        AFL_ENSURE(FetchRequestReadsDone < Settings.Partitions.size())
+            ("l", FetchRequestReadsDone)
+            ("r", Settings.Partitions.size());
 
-        auto& topic = req.Topic;
+        while (true) {
+            auto partitionIndex = NextPartition();
+            if (!partitionIndex) {
+                return;
+            }
 
-        auto cdcToPrivateIt = CdcPathToPrivateTopicPath.find(req.Topic);
-        if (cdcToPrivateIt != CdcPathToPrivateTopicPath.end()) {
-            topic = cdcToPrivateIt->second;
+            CurrentCookie = *partitionIndex;
+
+            auto& req = Settings.Partitions[*partitionIndex];
+            auto [topic, topicInfo] = GetTopicInfo(req.Topic);
+
+            auto partitionId = req.Partition;
+
+            ui64 tabletId = topicInfo.PartitionToTablet[partitionId];
+            AFL_ENSURE(tabletId)
+                ("topic", topic)
+                ("partition", partitionId)
+                ("tabletId", tabletId);
+
+            auto jt = TabletInfo.find(tabletId);
+            AFL_ENSURE(jt != TabletInfo.end())
+                ("topic", topic)
+                ("partition", partitionId)
+                ("tabletId", tabletId);
+            auto& tabletInfo = jt->second;
+
+            if (tabletInfo.BrokenPipe) {
+                continue;
+            }
+
+            FetchRequestCurrentReadTablet = tabletId;
+            PartitionStatus[*partitionIndex] = EPartitionStatus::DataRequested;
+
+            //Form read request
+            auto request = CreateReadRequest(topic, req);
+            LOG_D("Sending request: " << request->Record.ShortDebugString());
+            NTabletPipe::SendData(ctx, tabletInfo.PipeClient, request.release());
+
+            break;
         }
+    }
 
-        const auto& offset = req.Offset;
-        const auto& part = req.Partition;
-        const auto& maxBytes = req.MaxBytes;
-        const auto& readTimestampMs = req.ReadTimestampMs;
-        const auto& clientId = req.ClientId;
-        auto it = TopicInfo.find(CanonizePath(topic));
-        AFL_ENSURE(it != TopicInfo.end());
-        if (it->second.PartitionToTablet.find(part) == it->second.PartitionToTablet.end()) {
-            return;
-        }
-        ui64 tabletId = it->second.PartitionToTablet[part];
-        AFL_ENSURE(tabletId);
-        FetchRequestCurrentReadTablet = tabletId;
-        ++CurrentCookie;
-        auto jt = TabletInfo.find(tabletId);
-        AFL_ENSURE(jt != TabletInfo.end());
-        if (jt->second.BrokenPipe || FetchRequestBytesLeft == 0) { //answer right now
-            ctx.Send(ctx.SelfID, FormEmptyCurrentRead(CurrentCookie).Release());
-            return;
-        }
+    std::unique_ptr<TEvPersQueue::TEvRequest> CreateReadRequest(const TString& topic, const TPartitionFetchRequest& fetchRequest) {
+        auto request = std::make_unique<TEvPersQueue::TEvRequest>();
+        request->Record.SetRequestId(TStringBuilder() << "request" << "-id-" << FetchRequestReadsDone << "-" << Settings.Partitions.size());
 
-        LOG_D("Send request. Topic " << topic << " partition " << part << " offset " << offset
-            << " clientId " << clientId << " tabletId " << tabletId);
+        auto* partitionRequest = request->Record.MutablePartitionRequest();
+        partitionRequest->SetCookie(CurrentCookie);
+        partitionRequest->SetTopic(topic);
+        partitionRequest->SetPartition(fetchRequest.Partition);
 
-        //Form read request
-        TAutoPtr<TEvPersQueue::TEvRequest> preq(new TEvPersQueue::TEvRequest);
-        TStringBuilder reqId;
-        reqId << "request" << "-id-" << FetchRequestReadsDone << "-" << Settings.Partitions.size();
-        preq->Record.SetRequestId(reqId);
-        auto partReq = preq->Record.MutablePartitionRequest();
-        partReq->SetCookie(CurrentCookie);
-
-        partReq->SetTopic(topic);
-        partReq->SetPartition(part);
-        auto read = partReq->MutableCmdRead();
-        read->SetClientId(clientId);
-        read->SetOffset(offset);
+        auto read = partitionRequest->MutableCmdRead();
+        read->SetClientId(Settings.Consumer);
+        read->SetOffset(fetchRequest.Offset);
         read->SetCount(1000000);
         read->SetTimeoutMs(0);
-        read->SetBytes(Min<ui32>(maxBytes, FetchRequestBytesLeft));
-        read->SetReadTimestampMs(readTimestampMs);
+        read->SetBytes(Min<ui32>(fetchRequest.MaxBytes, FetchRequestBytesLeft));
+        read->SetReadTimestampMs(fetchRequest.ReadTimestampMs);
         read->SetExternalOperation(true);
-        NTabletPipe::SendData(ctx, jt->second.PipeClient, preq.Release());
+
+        return request;
     }
 
     void ProcessFetchRequestResult(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx) {
         auto& record = ev->Get()->Record;
         AFL_ENSURE(record.HasPartitionResponse());
+
         if (record.GetPartitionResponse().GetCookie() != CurrentCookie || FetchRequestCurrentReadTablet == 0) {
-            LOG_E("proxy fetch error: got response from tablet " << record.GetPartitionResponse().GetCookie()
+            LOG_W("proxy fetch error: got response from tablet " << record.GetPartitionResponse().GetCookie()
                                 << " while waiting from " << CurrentCookie << " and requested tablet is " << FetchRequestCurrentReadTablet);
             return;
         }
 
-        if (FetchRequestBytesLeft >= (ui32)record.ByteSize())
+        if (FetchRequestBytesLeft >= (ui32)record.ByteSize()) {
             FetchRequestBytesLeft -= (ui32)record.ByteSize();
-        else
-            FetchRequestBytesLeft = 0;
-        FetchRequestCurrentReadTablet = 0;
-        if (!Response) {
-            Response = MakeHolder<TEvPQ::TEvFetchResponse>();
-        }
-
-        auto res = Response->Response.AddPartResult();
-        AFL_ENSURE(FetchRequestReadsDone < Settings.Partitions.size());
-        const auto& req = Settings.Partitions[FetchRequestReadsDone];
-        const auto& topic = req.Topic;
-        const auto& part = req.Partition;
-
-        auto privateTopicToCdcIt = PrivateTopicPathToCdcPath.find(topic);
-        if (privateTopicToCdcIt == PrivateTopicPathToCdcPath.end()) {
-            res->SetTopic(topic);
         } else {
-            res->SetTopic(PrivateTopicPathToCdcPath[topic]);
+            FetchRequestBytesLeft = 0;
         }
+        FetchRequestCurrentReadTablet = 0;
+        EnsureResponse();
 
-        res->SetPartition(part);
+        PartitionStatus[CurrentCookie] = EPartitionStatus::DataReceived;
+
+        AFL_ENSURE(FetchRequestReadsDone < Settings.Partitions.size());
+        const auto& req = Settings.Partitions[CurrentCookie];
+        const auto& partitionId = req.Partition;
+
+        auto res = Response->Response.MutablePartResult(CurrentCookie);
+        res->SetTopic(req.Topic);
+        res->SetPartition(partitionId);
         auto read = res->MutableReadResult();
         if (record.HasPartitionResponse() && record.GetPartitionResponse().HasCmdReadResult())
             read->CopyFrom(record.GetPartitionResponse().GetCmdReadResult());
@@ -605,19 +640,19 @@ public:
 
         ++FetchRequestReadsDone;
 
-        auto it = TopicInfo.find(CanonizePath(topic));
-        AFL_ENSURE(it != TopicInfo.end());
+        auto [_, topicInfo] = GetTopicInfo(req.Topic);
 
-        SetMeteringMode(it->second.PQInfo->Description.GetPQTabletConfig().GetMeteringMode());
+        SetMeteringMode(topicInfo.PQInfo->Description.GetPQTabletConfig().GetMeteringMode());
 
-        if (IsQuotaRequired()) {
+        if (FetchRequestBytesLeft == 0) {
+            SendReplyOnDoneAndDie(ctx);
+        } else if (IsQuotaRequired()) {
             PendingQuotaAmount = CalcRuConsumption(GetPayloadSize(record)) + (Settings.RuPerRequest ? 1 : 0);
             Settings.RuPerRequest = false;
             RequestDataQuota(PendingQuotaAmount, ctx);
         } else {
             ProceedFetchRequest(ctx);
         }
-
     }
 
     ui64 GetPayloadSize(const NKikimrClient::TResponse& record) const {
@@ -634,14 +669,26 @@ public:
     }
 
     bool CheckAccess(const TSecurityObject& access) {
-        if (Settings.User == nullptr)
+        if (Settings.UserToken == nullptr) {
             return true;
-        return access.CheckAccess(NACLib::EAccessRights::SelectRow, *Settings.User);
+        }
+        return access.CheckAccess(NACLib::EAccessRights::SelectRow, *Settings.UserToken);
+    }
+
+    void SendReplyOnDoneAndDie(const TActorContext& ctx) {
+        CreateOkResponse();
+
+        for (size_t i = 0; i < PartitionStatus.size(); ++i) {
+            if (PartitionStatus[i] != EPartitionStatus::DataReceived) {
+                AddResult(i, NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE);
+            }
+        }
+
+        SendReplyAndDie(std::move(Response), ctx);
     }
 
      void SendReplyAndDie(THolder<TEvPQ::TEvFetchResponse> event, const TActorContext& ctx) {
         ctx.Send(RequesterId, event.Release());
-
         Die(ctx);
     }
 
@@ -652,28 +699,47 @@ public:
         return response;
     }
 
-    void CreateOkResponse() {
+    void EnsureResponse() {
         if (!Response) {
             Response = MakeHolder<TEvPQ::TEvFetchResponse>();
+
+            for (size_t i = 0; i < PartitionStatus.size(); ++i) {
+                Response->Response.AddPartResult();
+            }
         }
+    }
+
+    void CreateOkResponse() {
+        EnsureResponse();
         Response->Status = Ydb::StatusIds::SUCCESS;
     }
 
+    void EnsureYdbProxy() {
+        if (!YdbProxy) {
+            YdbProxy = RegisterWithSameMailbox(NReplication::CreateLocalYdbProxy(Settings.Database));
+        }
+    }
+
     STRICT_STFUNC(StateFunc,
-            HFunc(TEvTabletPipe::TEvClientDestroyed, Handle);
-            HFunc(TEvTabletPipe::TEvClientConnected, Handle);
-            HFunc(TEvPersQueue::TEvResponse, Handle);
-            HFunc(TEvents::TEvWakeup, Handle);
             HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleSchemeCacheResponse);
             HFunc(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse, Handle);
+
             HFunc(TEvPersQueue::TEvHasDataInfoResponse, Handle);
-            CFunc(TEvPrivate::EvTimeout, HandleTimeout);
+            HFunc(TEvPersQueue::TEvResponse, Handle);
+
+            HFunc(TEvTabletPipe::TEvClientDestroyed, Handle);
+            HFunc(TEvTabletPipe::TEvClientConnected, Handle);
+
+            HFunc(TEvents::TEvWakeup, Handle);
+
             CFunc(NActors::TEvents::TSystem::PoisonPill, Die);
     )
 };
 
 NActors::IActor* CreatePQFetchRequestActor(
-        const TFetchRequestSettings& settings, const TActorId& schemeCache, const TActorId& requester
+    const TFetchRequestSettings& settings,
+    const TActorId& schemeCache,
+    const TActorId& requester
 ) {
     return new TPQFetchRequestActor(settings, schemeCache, requester);
 }

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.h
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.h
@@ -29,8 +29,8 @@ struct TFetchRequestSettings {
     TString Database;
     TString Consumer;
     TVector<TPartitionFetchRequest> Partitions;
-    ui64 MaxWaitTimeMs;
-    ui64 TotalMaxBytes;
+    ui64 MaxWaitTimeMs = 0;
+    ui64 TotalMaxBytes = 0;
 
     bool RuPerRequest = false;
     ui64 RequestId = 0;

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.h
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.h
@@ -2,8 +2,6 @@
 
 #include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/pq_rl_helpers.h>
-#include <ydb/core/tx/replication/ydb_proxy/local_proxy/local_proxy.h>
-#include <ydb/core/tx/replication/ydb_proxy/local_proxy/local_proxy_request.h>
 #include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/aclib/aclib.h>
 
@@ -11,15 +9,13 @@ namespace NKikimr::NPQ {
 
 struct TPartitionFetchRequest {
     TString Topic;
-    TString ClientId;
     ui32 Partition;
     ui64 Offset;
     ui64 MaxBytes;
     ui64 ReadTimestampMs;
 
-    TPartitionFetchRequest(const TString& topic, ui32 partition, ui64 offset, ui64 maxBytes, ui64 readTimestampMs = 0, const TString& clientId = NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER)
+    TPartitionFetchRequest(const TString& topic, ui32 partition, ui64 offset, ui64 maxBytes, ui64 readTimestampMs = 0)
         : Topic(topic)
-        , ClientId(clientId)
         , Partition(partition)
         , Offset(offset)
         , MaxBytes(maxBytes)
@@ -31,27 +27,16 @@ struct TPartitionFetchRequest {
 
 struct TFetchRequestSettings {
     TString Database;
+    TString Consumer;
     TVector<TPartitionFetchRequest> Partitions;
-    TIntrusiveConstPtr<NACLib::TUserToken> User;
     ui64 MaxWaitTimeMs;
     ui64 TotalMaxBytes;
-    TRlContext RlCtx;
-    bool RuPerRequest;
 
+    bool RuPerRequest = false;
     ui64 RequestId = 0;
-    TFetchRequestSettings(
-            const TString& database, const TVector<TPartitionFetchRequest>& partitions, ui64 maxWaitTimeMs, ui64 totalMaxBytes, TRlContext rlCtx,
-            TIntrusiveConstPtr<NACLib::TUserToken> user = {}, ui64 requestId = 0, bool ruPerRequest = false
-    )
-        : Database(database)
-        , Partitions(partitions)
-        , User(user)
-        , MaxWaitTimeMs(maxWaitTimeMs)
-        , TotalMaxBytes(totalMaxBytes)
-        , RlCtx(rlCtx)
-        , RuPerRequest(ruPerRequest)
-        , RequestId(requestId)
-    {}
+
+    TRlContext RlCtx = {};
+    TIntrusiveConstPtr<NACLib::TUserToken> UserToken = {};
 };
 
 NActors::IActor* CreatePQFetchRequestActor(const TFetchRequestSettings& settings, const NActors::TActorId& schemeCache,

--- a/ydb/core/persqueue/public/fetcher/fetch_request_ut.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_ut.cpp
@@ -4,12 +4,12 @@
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/testlib/tenant_runtime.h>
 #include <ydb/core/tx/scheme_board/cache.h>
-#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/ut_utils.h>
+#include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
 
 namespace NKikimr::NPQ {
 using namespace NPersQueue;
 //using namespace NYdb::NTopic;
-using namespace NYdb::NPersQueue::NTests;
+using namespace NYdb::NTopic::NTests;
 
 
 Y_UNIT_TEST_SUITE(TFetchRequestTests) {
@@ -26,7 +26,7 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
     }
 
     Y_UNIT_TEST(HappyWay) {
-        auto setup = std::make_shared<TPersQueueYdbSdkTestSetup>(TEST_CASE_NAME);
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         setup->GetServer().EnableLogs(
                 { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_FETCH_REQUEST },
                 NActors::NLog::PRI_DEBUG
@@ -36,28 +36,18 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
 
         ui32 totalPartitions = 5;
         setup->CreateTopic("topic1", "dc1", totalPartitions);
+        setup->Write("/Root/topic1", "Data 1-1", 1);
+        setup->Write("/Root/topic1", "Data 1-2", 1);
+        setup->Write("/Root/topic1", "Data 1-3", 1);
+
         setup->CreateTopic("topic2", "dc1", totalPartitions);
-        auto pqClient = setup->GetPersQueueClient();
-        auto settings1 = TWriteSessionSettings().Path("topic1").MessageGroupId("src-id").PartitionGroupId(2);
-        auto settings2 = TWriteSessionSettings().Path("topic2").MessageGroupId("src-id").PartitionGroupId(4);
-        auto ws1 = pqClient.CreateSimpleBlockingWriteSession(settings1);
-        auto ws2 = pqClient.CreateSimpleBlockingWriteSession(settings2);
-        
-        ws1->Write("Data 1-1");
-        ws1->Write("Data 1-2");
-        ws1->Write("Data 1-3");
-        
-        ws2->Write("Data 2-1");
-        ws2->Write("Data 2-2");
-
-        ws1->Close();
-        ws2->Close();
-
+        setup->Write("/Root/topic1", "Data 2-1", 3);
+        setup->Write("/Root/topic1", "Data 2-2", 3);
 
         auto edgeId = runtime.AllocateEdgeActor();
-        TPartitionFetchRequest p1{"Root/PQ/rt3.dc1--topic1", 1, 1, 10000};
-        TPartitionFetchRequest p2{"Root/PQ/rt3.dc1--topic2", 3, 0, 10000};
-        TPartitionFetchRequest pbad{"Root/PQ/rt3.dc1--topic2", 2, 1, 10000};
+        TPartitionFetchRequest p1{"/Root/topic1", 1, 1, 10000};
+        TPartitionFetchRequest p2{"/Root/topic2", 3, 0, 10000};
+        TPartitionFetchRequest pbad{"/Root/topic2", 2, 1, 10000};
 
         TFetchRequestSettings settings{{}, NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER, {p1, p2, pbad}, 1000, 1000};
         auto fetchId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
@@ -68,25 +58,143 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
         UNIT_ASSERT_C(ev->Status == Ydb::StatusIds::SUCCESS, ev->Message);
         Cerr << "Got event: " << ev->Response.DebugString() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(ev->Response.PartResultSize(), 3);
-        for (const auto& part : ev->Response.GetPartResult()) {
-            if (part.GetTopic().Contains("topic1")) {
-                UNIT_ASSERT(part.GetReadResult().GetErrorCode() == NPersQueue::NErrorCode::EErrorCode::OK);
-                UNIT_ASSERT_VALUES_EQUAL(part.GetPartition(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(part.GetReadResult().GetResult(0).GetOffset(), 1);
-            } else {
-                UNIT_ASSERT(part.GetTopic().Contains("topic2"));
-                if (part.GetPartition() == 2) {
-                    UNIT_ASSERT(part.GetReadResult().GetErrorCode() != NPersQueue::NErrorCode::EErrorCode::OK);
-                } else {
-                    UNIT_ASSERT_VALUES_EQUAL(part.GetPartition(), 3);
-                    UNIT_ASSERT_VALUES_EQUAL(part.GetReadResult().GetResult(0).GetOffset(), 0);
-                }
-            }
+
+        {
+            auto& result = ev->Response.GetPartResult(0);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetTopic(), "/Root/topic1");
+            UNIT_ASSERT_VALUES_EQUAL(result.GetPartition(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(NPersQueue::NErrorCode::EErrorCode_Name(result.GetReadResult().GetErrorCode()),
+                NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::EErrorCode::OK));
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().GetMaxOffset(), 3);
+        }
+
+        {
+            auto& result = ev->Response.GetPartResult(1);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetTopic(), "/Root/topic2");
+            UNIT_ASSERT_VALUES_EQUAL(result.GetPartition(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(NPersQueue::NErrorCode::EErrorCode_Name(result.GetReadResult().GetErrorCode()),
+                NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::EErrorCode::OK));
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().GetMaxOffset(), 0);
+        }
+
+        {
+            auto& result = ev->Response.GetPartResult(2);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetTopic(), "/Root/topic2");
+            UNIT_ASSERT_VALUES_EQUAL(result.GetPartition(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(NPersQueue::NErrorCode::EErrorCode_Name(result.GetReadResult().GetErrorCode()),
+                NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::EErrorCode::READ_ERROR_TOO_BIG_OFFSET));
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().GetMaxOffset(), 0);
+        }
+    }
+
+    Y_UNIT_TEST(SmallBytesRead) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        setup->GetServer().EnableLogs(
+                { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_FETCH_REQUEST },
+                NActors::NLog::PRI_DEBUG
+        );
+        auto& runtime = setup->GetRuntime();
+        StartSchemeCache(runtime);
+
+        setup->CreateTopic("topic1", "dc1", 2);
+        setup->Write("/Root/topic1", TString(2_KB, 'a'), 0);
+
+        TPartitionFetchRequest p1 {"/Root/topic1", 0, 0, 1_KB};
+        TPartitionFetchRequest p2 {"/Root/topic1", 1, 0, 1_KB};
+
+        TFetchRequestSettings settings{
+            .Database = {},
+            .Consumer = NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER,
+            .Partitions = {p1, p2},
+            .MaxWaitTimeMs = 1000,
+            .TotalMaxBytes = 100
+        };
+
+        auto edgeId = runtime.AllocateEdgeActor();
+        auto fetchActorId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
+        runtime.EnableScheduleForActor(fetchActorId);
+        runtime.DispatchEvents();
+        
+        auto ev = runtime.GrabEdgeEvent<TEvPQ::TEvFetchResponse>();
+        Cerr << ev->Response.DebugString() << Endl;
+        UNIT_ASSERT_C(ev->Status == Ydb::StatusIds::SUCCESS, ev->Message);
+
+        UNIT_ASSERT_VALUES_EQUAL(ev->Response.PartResultSize(), 2);
+
+        {
+            auto& result = ev->Response.GetPartResult(0);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetPartition(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(NPersQueue::NErrorCode::EErrorCode_Name(result.GetReadResult().GetErrorCode()),
+                NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::EErrorCode::OK));
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().GetMaxOffset(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().ResultSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().GetResult(0).GetUncompressedSize(), 2_KB);
+        }
+
+        {
+            auto& result = ev->Response.GetPartResult(1);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetPartition(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(NPersQueue::NErrorCode::EErrorCode_Name(result.GetReadResult().GetErrorCode()),
+                NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE));
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().GetMaxOffset(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().ResultSize(), 0);
+        }
+    }
+
+    Y_UNIT_TEST(EmptyTopic) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        setup->GetServer().EnableLogs(
+                { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_FETCH_REQUEST },
+                NActors::NLog::PRI_DEBUG
+        );
+        auto& runtime = setup->GetRuntime();
+        StartSchemeCache(runtime);
+
+        setup->CreateTopic("topic1", "dc1", 2);
+
+        TPartitionFetchRequest p1 {"/Root/topic1", 0, 0, 1_KB};
+        TPartitionFetchRequest p2 {"/Root/topic1", 1, 0, 1_KB};
+
+        TFetchRequestSettings settings{
+            .Database = {},
+            .Consumer = NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER,
+            .Partitions = {p1, p2},
+            .MaxWaitTimeMs = 100,
+            .TotalMaxBytes = 100
+        };
+
+        auto edgeId = runtime.AllocateEdgeActor();
+        auto fetchActorId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
+        runtime.EnableScheduleForActor(fetchActorId);
+        runtime.DispatchEvents();
+
+        auto ev = runtime.GrabEdgeEvent<TEvPQ::TEvFetchResponse>();
+        Cerr << ev->Response.DebugString() << Endl;
+        UNIT_ASSERT_C(ev->Status == Ydb::StatusIds::SUCCESS, ev->Message);
+
+        UNIT_ASSERT_VALUES_EQUAL(ev->Response.PartResultSize(), 2);
+
+        {
+            auto& result = ev->Response.GetPartResult(0);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetPartition(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(NPersQueue::NErrorCode::EErrorCode_Name(result.GetReadResult().GetErrorCode()),
+                NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE));
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().GetMaxOffset(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().ResultSize(), 0);
+        }
+
+        {
+            auto& result = ev->Response.GetPartResult(1);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetPartition(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(NPersQueue::NErrorCode::EErrorCode_Name(result.GetReadResult().GetErrorCode()),
+                NPersQueue::NErrorCode::EErrorCode_Name(NPersQueue::NErrorCode::EErrorCode::READ_NOT_DONE));
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().GetMaxOffset(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetReadResult().ResultSize(), 0);
         }
     }
 
     Y_UNIT_TEST(BadTopicName) {
-        auto setup = std::make_shared<TPersQueueYdbSdkTestSetup>(TEST_CASE_NAME);
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         auto& runtime = setup->GetRuntime();
         StartSchemeCache(runtime);
 
@@ -96,8 +204,8 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
         setup->CreateTopic("topic1", "dc1", totalPartitions);
 
         auto edgeId = runtime.AllocateEdgeActor();
-        TPartitionFetchRequest p1{"Root/PQ/rt3.dc1--topic1", 1, 1, 10000};
-        TPartitionFetchRequest p2{"Root/PQ/rt3.dc1--topic2", 3, 0, 10000};
+        TPartitionFetchRequest p1{"/Root/topic1", 1, 1, 10000};
+        TPartitionFetchRequest p2{"/Root/topic2", 3, 0, 10000};
 
         TFetchRequestSettings settings{{}, NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER, {p1, p2}, 1000, 1000};
         auto fetchId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
@@ -108,7 +216,7 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
     }
 
     Y_UNIT_TEST(CheckAccess) {
-        auto setup = std::make_shared<TPersQueueYdbSdkTestSetup>(TEST_CASE_NAME);
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         auto& runtime = setup->GetRuntime();
         runtime.SetLogPriority(NKikimrServices::PQ_FETCH_REQUEST, NActors::NLog::EPriority::PRI_DEBUG);
         StartSchemeCache(runtime);
@@ -117,12 +225,12 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
         setup->CreateTopic("topic1", "dc1", totalPartitions);
 
         auto edgeId = runtime.AllocateEdgeActor();
-        TPartitionFetchRequest p1{"Root/PQ/rt3.dc1--topic1", 1, 1, 10000};
+        TPartitionFetchRequest p1{"/Root/topic1", 1, 1, 10000};
 
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "user1@staff");
-            setup->GetServer().AnnoyingClient->ModifyACL("/Root/PQ", "rt3.dc1--topic1", acl.SerializeAsString());
+            setup->GetServer().AnnoyingClient->ModifyACL("/Root", "topic1", acl.SerializeAsString());
 
             auto goodToken = MakeIntrusiveConst<NACLib::TUserToken>("user1@staff", TVector<TString>{});
             TFetchRequestSettings settings{

--- a/ydb/core/persqueue/public/fetcher/fetch_request_ut.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_ut.cpp
@@ -59,7 +59,7 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
         TPartitionFetchRequest p2{"Root/PQ/rt3.dc1--topic2", 3, 0, 10000};
         TPartitionFetchRequest pbad{"Root/PQ/rt3.dc1--topic2", 2, 1, 10000};
 
-        TFetchRequestSettings settings{{}, {p1, p2, pbad}, 10000, 10000, {}};
+        TFetchRequestSettings settings{{}, NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER, {p1, p2, pbad}, 1000, 1000};
         auto fetchId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
         runtime.EnableScheduleForActor(fetchId);
         runtime.DispatchEvents();
@@ -99,7 +99,7 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
         TPartitionFetchRequest p1{"Root/PQ/rt3.dc1--topic1", 1, 1, 10000};
         TPartitionFetchRequest p2{"Root/PQ/rt3.dc1--topic2", 3, 0, 10000};
 
-        TFetchRequestSettings settings{{}, {p1, p2}, 10000, 10000, {}};
+        TFetchRequestSettings settings{{}, NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER, {p1, p2}, 1000, 1000};
         auto fetchId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
         runtime.EnableScheduleForActor(fetchId);
         
@@ -110,32 +110,56 @@ Y_UNIT_TEST_SUITE(TFetchRequestTests) {
     Y_UNIT_TEST(CheckAccess) {
         auto setup = std::make_shared<TPersQueueYdbSdkTestSetup>(TEST_CASE_NAME);
         auto& runtime = setup->GetRuntime();
+        runtime.SetLogPriority(NKikimrServices::PQ_FETCH_REQUEST, NActors::NLog::EPriority::PRI_DEBUG);
         StartSchemeCache(runtime);
 
         ui32 totalPartitions = 5;
         setup->CreateTopic("topic1", "dc1", totalPartitions);
-        NACLib::TDiffACL acl;
-        acl.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "user1@staff");
-        setup->GetServer().AnnoyingClient->ModifyACL("/Root/PQ", "rt3.dc1--topic1", acl.SerializeAsString());
 
         auto edgeId = runtime.AllocateEdgeActor();
         TPartitionFetchRequest p1{"Root/PQ/rt3.dc1--topic1", 1, 1, 10000};
-        auto goodToken = MakeIntrusiveConst<NACLib::TUserToken>("user1@staff", TVector<TString>{});
-        auto badToken = MakeIntrusiveConst<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
-        TFetchRequestSettings settings{{}, {p1}, 10000, 10000, {}, goodToken};
-        auto fetchId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
-        runtime.EnableScheduleForActor(fetchId);
-        
-        auto ev = runtime.GrabEdgeEvent<TEvPQ::TEvFetchResponse>();
-        UNIT_ASSERT_C(ev->Status == Ydb::StatusIds::SUCCESS, ev->Message);
-        settings.User = badToken;
 
-        fetchId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
-        runtime.EnableScheduleForActor(fetchId);
-        
-        ev = runtime.GrabEdgeEvent<TEvPQ::TEvFetchResponse>();
-        UNIT_ASSERT_C(ev->Status == Ydb::StatusIds::UNAUTHORIZED, ev->Message);
+        {
+            NACLib::TDiffACL acl;
+            acl.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "user1@staff");
+            setup->GetServer().AnnoyingClient->ModifyACL("/Root/PQ", "rt3.dc1--topic1", acl.SerializeAsString());
 
+            auto goodToken = MakeIntrusiveConst<NACLib::TUserToken>("user1@staff", TVector<TString>{});
+            TFetchRequestSettings settings{
+                .Database = {},
+                .Consumer = NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER,
+                .Partitions = {p1},
+                .MaxWaitTimeMs = 100,
+                .TotalMaxBytes = 10000,
+                .RuPerRequest = false,
+                .UserToken = goodToken
+            };
+
+            auto fetchId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
+            runtime.EnableScheduleForActor(fetchId);
+
+            auto ev = runtime.GrabEdgeEvent<TEvPQ::TEvFetchResponse>();
+            UNIT_ASSERT_C(ev->Status == Ydb::StatusIds::SUCCESS, ev->Message);
+        }
+        
+        {
+            auto badToken = MakeIntrusiveConst<NACLib::TUserToken>("bad-user@staff", TVector<TString>{});
+            TFetchRequestSettings settings{
+                .Database = {},
+                .Consumer = NKikimr::NPQ::CLIENTID_WITHOUT_CONSUMER,
+                .Partitions = {p1},
+                .MaxWaitTimeMs = 100,
+                .TotalMaxBytes = 10000,
+                .RuPerRequest = false,
+                .UserToken = badToken
+            };
+
+            auto fetchId = runtime.Register(CreatePQFetchRequestActor(settings, MakeSchemeCacheID(), edgeId));
+            runtime.EnableScheduleForActor(fetchId);
+            
+            auto ev = runtime.GrabEdgeEvent<TEvPQ::TEvFetchResponse>();
+            UNIT_ASSERT_C(ev->Status == Ydb::StatusIds::UNAUTHORIZED, ev->Message);
+        }
     }
 };
 

--- a/ydb/core/persqueue/public/fetcher/ut/ya.make
+++ b/ydb/core/persqueue/public/fetcher/ut/ya.make
@@ -9,6 +9,7 @@ SRCS(
 PEERDIR(
     library/cpp/testing/unittest
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
+    ydb/public/sdk/cpp/src/client/topic/ut/ut_utils
 
 )
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/ut_utils.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/ut_utils.h
@@ -97,6 +97,19 @@ public:
                 .ClusterDiscoveryMode(EClusterDiscoveryMode::On);
         return settings;
     }
+
+    void Write(const TString& topic, ui32 partitionId, const TString& data) {
+        auto settings = TWriteSessionSettings()
+            .Path(topic)
+            .MessageGroupId("src-id")
+            .PartitionGroupId(partitionId)
+            .Codec(ECodec::RAW);
+        auto writeSession = GetPersQueueClient().CreateSimpleBlockingWriteSession(settings);
+        
+        writeSession->Write(data);
+
+        writeSession->Close();
+    }
 };
 
 struct TYDBClientEventLoop : public ::NPersQueue::IClientEventLoop {

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.cpp
@@ -56,10 +56,16 @@ TConsumerDescription TTopicSdkTestSetup::DescribeConsumer(const std::string& nam
 void TTopicSdkTestSetup::Write(const std::string& message, std::uint32_t partitionId,
                                const std::optional<std::string> producer,
                                std::optional<std::uint64_t> seqNo) {
+    Write(GetTopicPath(), message, partitionId, producer, seqNo);
+}
+
+void TTopicSdkTestSetup::Write(const std::string& topic, const std::string& message, std::uint32_t partitionId,
+                               const std::optional<std::string> producer,
+                               std::optional<std::uint64_t> seqNo) {                            
     TTopicClient client(MakeDriver());
 
     TWriteSessionSettings settings;
-    settings.Path(GetTopicPath());
+    settings.Path(topic);
     settings.PartitionId(partitionId);
     settings.DeduplicationEnabled(producer.has_value());
     if (producer) {

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h
@@ -32,6 +32,10 @@ public:
                const std::optional<std::string> producer = std::nullopt,
                std::optional<std::uint64_t> seqNo = std::nullopt);
 
+    void Write(const std::string& topic, const std::string& message, std::uint32_t partitionId = 0,
+               const std::optional<std::string> producer = std::nullopt,
+               std::optional<std::uint64_t> seqNo = std::nullopt);
+
     struct TReadResult {
         std::shared_ptr<IReadSession> Reader;
         bool Timeout;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Исправлен код ответа для чтения из партиции по кафка протоколу (fetch). Раньше в некоторых случаях могли отвечать UNKNOWN_SERVER_ERROR, в то время как обработка этих партиций завершилась успешно.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://st.yandex-team.ru/LOGBROKER-9991
