### PR TITLE
Fix inherit_permissions=true for new secrets

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -12,11 +12,7 @@ namespace {
 using namespace NKikimr;
 using namespace NSchemeShard;
 
-TString InterruptInheritanceExceptDescribe(const TString& initialAcl, const bool inheritPermissions) {
-    if (inheritPermissions) { // don't change parent ACL
-        return initialAcl;
-    }
-
+TString InterruptInheritanceExceptDescribe(const TString& initialAcl) {
     NACLib::TACL secObj(initialAcl);
     NACLib::TACL resultSecObj;
     resultSecObj.SetInterruptInheritance(true);
@@ -255,8 +251,10 @@ public:
               * However, the DescribeSchema grant is quite harmless and allows users to view the object's ACL to request access from the owner.
               * There is also an inherit_permissions flag, which, when set, allows grant inheritance similarly to all other schema objects.
               */
-            secretPath->ACL = InterruptInheritanceExceptDescribe(dstPath.GetEffectiveACL(), createSecretProto.GetInheritPermissions());
-            secretPath->ACLVersion++;
+            if (!createSecretProto.GetInheritPermissions()) {
+                secretPath->ACL = InterruptInheritanceExceptDescribe(dstPath.GetEffectiveACL());
+                secretPath->ACLVersion++;
+            }
         }
 
         NKikimrSchemeOp::TSecretDescription secretDescription;


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Ошибок в поведении не было, но доступы дублировались: при выставленном флаге inherit_permissions=true на самом объекте появлялись такие же ACL, как на родителе, что избыточно.