### PR TITLE
Add replicas specific volume option

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -472,6 +472,7 @@ namespace NKikimr::NStorage {
             , const NKikimrConfig::TDomainsConfig::TStateStorage& oldConfig = {}
             , ui32 overrideReplicasInRingCount = 0
             , ui32 overrideRingsCount = 0
+            , ui32 replicasDensity = 200
         );
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -472,7 +472,7 @@ namespace NKikimr::NStorage {
             , const NKikimrConfig::TDomainsConfig::TStateStorage& oldConfig = {}
             , ui32 overrideReplicasInRingCount = 0
             , ui32 overrideRingsCount = 0
-            , ui32 replicasDensity = 200
+            , ui32 replicasSpecificVolume = 200
         );
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
@@ -586,7 +586,7 @@ namespace NKikimr::NStorage {
             , const NKikimrConfig::TDomainsConfig::TStateStorage& oldConfig
             , ui32 overrideReplicasInRingCount
             , ui32 overrideRingsCount
-            , ui32 replicasDensity
+            , ui32 replicasSpecificVolume
         ) {
         std::map<TBridgePileId, THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>> nodes;
         bool goodConfig = true;
@@ -596,7 +596,7 @@ namespace NKikimr::NStorage {
             nodes[pileId][location.GetDataCenterId()].emplace_back(node.GetNodeId(), location);
         }
         for (auto& [pileId, nodesByDataCenter] : nodes) {
-            TStateStoragePerPileGenerator generator(nodesByDataCenter, SelfHealNodesState, pileId, usedNodes, oldConfig, overrideReplicasInRingCount, overrideRingsCount, replicasDensity);
+            TStateStoragePerPileGenerator generator(nodesByDataCenter, SelfHealNodesState, pileId, usedNodes, oldConfig, overrideReplicasInRingCount, overrideRingsCount, replicasSpecificVolume);
             generator.AddRingGroup(ss);
             goodConfig &= generator.IsGoodConfig();
         }

--- a/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
@@ -586,6 +586,7 @@ namespace NKikimr::NStorage {
             , const NKikimrConfig::TDomainsConfig::TStateStorage& oldConfig
             , ui32 overrideReplicasInRingCount
             , ui32 overrideRingsCount
+            , ui32 replicasDensity
         ) {
         std::map<TBridgePileId, THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>> nodes;
         bool goodConfig = true;
@@ -595,7 +596,7 @@ namespace NKikimr::NStorage {
             nodes[pileId][location.GetDataCenterId()].emplace_back(node.GetNodeId(), location);
         }
         for (auto& [pileId, nodesByDataCenter] : nodes) {
-            TStateStoragePerPileGenerator generator(nodesByDataCenter, SelfHealNodesState, pileId, usedNodes, oldConfig, overrideReplicasInRingCount, overrideRingsCount);
+            TStateStoragePerPileGenerator generator(nodesByDataCenter, SelfHealNodesState, pileId, usedNodes, oldConfig, overrideReplicasInRingCount, overrideRingsCount, replicasDensity);
             generator.AddRingGroup(ss);
             goodConfig &= generator.IsGoodConfig();
         }

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -107,12 +107,12 @@ namespace NKikimr::NStorage {
         void ReassignStateStorageNode(const TQuery::TReassignStateStorageNode& cmd);
         void ReconfigStateStorage(const NKikimrBlobStorage::TStateStorageConfig& cmd);
         void SelfHealStateStorage(const TQuery::TSelfHealStateStorage& cmd);
-        void SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount);
+        void SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasDensity);
         void SelfHealNodesStateUpdate(const TQuery::TSelfHealNodesStateUpdate& cmd);
         void GetStateStorageConfig(const TQuery::TGetStateStorageConfig& cmd);
 
         void GetCurrentStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool getNodesState);
-        bool GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount);
+        bool GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasDensity);
         void AdjustRingGroupActorIdOffsetInRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig);
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Storage configuration YAML manipulation

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -107,12 +107,12 @@ namespace NKikimr::NStorage {
         void ReassignStateStorageNode(const TQuery::TReassignStateStorageNode& cmd);
         void ReconfigStateStorage(const NKikimrBlobStorage::TStateStorageConfig& cmd);
         void SelfHealStateStorage(const TQuery::TSelfHealStateStorage& cmd);
-        void SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasDensity);
+        void SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasSpecificVolume);
         void SelfHealNodesStateUpdate(const TQuery::TSelfHealNodesStateUpdate& cmd);
         void GetStateStorageConfig(const TQuery::TGetStateStorageConfig& cmd);
 
         void GetCurrentStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool getNodesState);
-        bool GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasDensity);
+        bool GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasSpecificVolume);
         void AdjustRingGroupActorIdOffsetInRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig);
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Storage configuration YAML manipulation

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
@@ -9,19 +9,19 @@ namespace NKikimr::NStorage {
 
     using TInvokeRequestHandlerActor = TDistributedConfigKeeper::TInvokeRequestHandlerActor;
 
-    bool TInvokeRequestHandlerActor::GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasDensity) {
+    bool TInvokeRequestHandlerActor::GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasSpecificVolume) {
         const NKikimrBlobStorage::TStorageConfig& config = *Self->StorageConfig;
         bool result = true;
         std::unordered_set<ui32> usedNodes;
-        result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageConfig(), config, usedNodes, config.GetStateStorageConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasDensity);
+        result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageConfig(), config, usedNodes, config.GetStateStorageConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasSpecificVolume);
         if (pileupReplicas) {
             usedNodes.clear();
         }
-        result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageBoardConfig(), config, usedNodes, config.GetStateStorageBoardConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasDensity);
+        result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageBoardConfig(), config, usedNodes, config.GetStateStorageBoardConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasSpecificVolume);
         if (pileupReplicas) {
             usedNodes.clear();
         }
-        result &= Self->GenerateStateStorageConfig(currentConfig->MutableSchemeBoardConfig(), config, usedNodes, config.GetSchemeBoardConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasDensity);
+        result &= Self->GenerateStateStorageConfig(currentConfig->MutableSchemeBoardConfig(), config, usedNodes, config.GetSchemeBoardConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasSpecificVolume);
         return result;
     }
 
@@ -97,7 +97,7 @@ namespace NKikimr::NStorage {
             auto* currentConfig = record->MutableStateStorageConfig();
 
             if (cmd.GetRecommended()) {
-                GetRecommendedStateStorageConfig(currentConfig, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasDensity());
+                GetRecommendedStateStorageConfig(currentConfig, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasSpecificVolume());
                 AdjustRingGroupActorIdOffsetInRecommendedStateStorageConfig(currentConfig);
             } else {
                 GetCurrentStateStorageConfig(currentConfig, cmd.GetNodesState());
@@ -112,20 +112,20 @@ namespace NKikimr::NStorage {
             Self->SelfHealNodesState[node.GetNodeId()] = node.GetState();
         }
         if (cmd.GetEnableSelfHealStateStorage()) {
-            SelfHealStateStorage(cmd.GetWaitForConfigStep(), true, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasDensity());
+            SelfHealStateStorage(cmd.GetWaitForConfigStep(), true, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasSpecificVolume());
         }
     }
 
     void TInvokeRequestHandlerActor::SelfHealStateStorage(const TQuery::TSelfHealStateStorage& cmd) {
-        SelfHealStateStorage(cmd.GetWaitForConfigStep(), cmd.GetForceHeal(), cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasDensity());
+        SelfHealStateStorage(cmd.GetWaitForConfigStep(), cmd.GetForceHeal(), cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasSpecificVolume());
     }
 
-    void TInvokeRequestHandlerActor::SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasDensity) {
+    void TInvokeRequestHandlerActor::SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasSpecificVolume) {
         RunCommonChecks();
         STLOG(PRI_DEBUG, BS_NODE, NW105, "TInvokeRequestHandlerActor::SelfHealStateStorage", (waitForConfigStep, waitForConfigStep),
-            (forceHeal, forceHeal), (pileupReplicas, pileupReplicas), (overrideReplicasInRingCount, overrideReplicasInRingCount), (overrideRingsCount, overrideRingsCount), (replicasDensity, replicasDensity));
+            (forceHeal, forceHeal), (pileupReplicas, pileupReplicas), (overrideReplicasInRingCount, overrideReplicasInRingCount), (overrideRingsCount, overrideRingsCount), (replicasSpecificVolume, replicasSpecificVolume));
         NKikimrBlobStorage::TStateStorageConfig targetConfig;
-        if (!GetRecommendedStateStorageConfig(&targetConfig, pileupReplicas, overrideReplicasInRingCount, overrideRingsCount, replicasDensity) && !forceHeal) {
+        if (!GetRecommendedStateStorageConfig(&targetConfig, pileupReplicas, overrideReplicasInRingCount, overrideRingsCount, replicasSpecificVolume) && !forceHeal) {
             throw TExError() << "Recommended configuration has faulty nodes and can not be applyed";
         }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
@@ -9,19 +9,19 @@ namespace NKikimr::NStorage {
 
     using TInvokeRequestHandlerActor = TDistributedConfigKeeper::TInvokeRequestHandlerActor;
 
-    bool TInvokeRequestHandlerActor::GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount) {
+    bool TInvokeRequestHandlerActor::GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasDensity) {
         const NKikimrBlobStorage::TStorageConfig& config = *Self->StorageConfig;
         bool result = true;
         std::unordered_set<ui32> usedNodes;
-        result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageConfig(), config, usedNodes, config.GetStateStorageConfig(), overrideReplicasInRingCount, overrideRingsCount);
+        result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageConfig(), config, usedNodes, config.GetStateStorageConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasDensity);
         if (pileupReplicas) {
             usedNodes.clear();
         }
-        result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageBoardConfig(), config, usedNodes, config.GetStateStorageBoardConfig(), overrideReplicasInRingCount, overrideRingsCount);
+        result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageBoardConfig(), config, usedNodes, config.GetStateStorageBoardConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasDensity);
         if (pileupReplicas) {
             usedNodes.clear();
         }
-        result &= Self->GenerateStateStorageConfig(currentConfig->MutableSchemeBoardConfig(), config, usedNodes, config.GetSchemeBoardConfig(), overrideReplicasInRingCount, overrideRingsCount);
+        result &= Self->GenerateStateStorageConfig(currentConfig->MutableSchemeBoardConfig(), config, usedNodes, config.GetSchemeBoardConfig(), overrideReplicasInRingCount, overrideRingsCount, replicasDensity);
         return result;
     }
 
@@ -97,7 +97,7 @@ namespace NKikimr::NStorage {
             auto* currentConfig = record->MutableStateStorageConfig();
 
             if (cmd.GetRecommended()) {
-                GetRecommendedStateStorageConfig(currentConfig, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount());
+                GetRecommendedStateStorageConfig(currentConfig, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasDensity());
                 AdjustRingGroupActorIdOffsetInRecommendedStateStorageConfig(currentConfig);
             } else {
                 GetCurrentStateStorageConfig(currentConfig, cmd.GetNodesState());
@@ -112,20 +112,20 @@ namespace NKikimr::NStorage {
             Self->SelfHealNodesState[node.GetNodeId()] = node.GetState();
         }
         if (cmd.GetEnableSelfHealStateStorage()) {
-            SelfHealStateStorage(cmd.GetWaitForConfigStep(), true, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount());
+            SelfHealStateStorage(cmd.GetWaitForConfigStep(), true, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasDensity());
         }
     }
 
     void TInvokeRequestHandlerActor::SelfHealStateStorage(const TQuery::TSelfHealStateStorage& cmd) {
-        SelfHealStateStorage(cmd.GetWaitForConfigStep(), cmd.GetForceHeal(), cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount());
+        SelfHealStateStorage(cmd.GetWaitForConfigStep(), cmd.GetForceHeal(), cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasDensity());
     }
 
-    void TInvokeRequestHandlerActor::SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount) {
+    void TInvokeRequestHandlerActor::SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasDensity) {
         RunCommonChecks();
         STLOG(PRI_DEBUG, BS_NODE, NW105, "TInvokeRequestHandlerActor::SelfHealStateStorage", (waitForConfigStep, waitForConfigStep),
-            (forceHeal, forceHeal), (pileupReplicas, pileupReplicas), (overrideReplicasInRingCount, overrideReplicasInRingCount), (overrideRingsCount, overrideRingsCount));
+            (forceHeal, forceHeal), (pileupReplicas, pileupReplicas), (overrideReplicasInRingCount, overrideReplicasInRingCount), (overrideRingsCount, overrideRingsCount), (replicasDensity, replicasDensity));
         NKikimrBlobStorage::TStateStorageConfig targetConfig;
-        if (!GetRecommendedStateStorageConfig(&targetConfig, pileupReplicas, overrideReplicasInRingCount, overrideRingsCount) && !forceHeal) {
+        if (!GetRecommendedStateStorageConfig(&targetConfig, pileupReplicas, overrideReplicasInRingCount, overrideRingsCount, replicasDensity) && !forceHeal) {
             throw TExError() << "Recommended configuration has faulty nodes and can not be applyed";
         }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
@@ -9,7 +9,7 @@
 #include <library/cpp/streams/zstd/zstd.h>
 
 namespace NKikimr::NStorage {
-    constexpr ui32 defaultReplicasDensity = 200;
+    constexpr ui32 defaultReplicasSpecificVolume = 200;
 
     TStateStoragePerPileGenerator::TStateStoragePerPileGenerator(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes
         , const std::unordered_map<ui32, ui32>& selfHealNodesState
@@ -18,7 +18,7 @@ namespace NKikimr::NStorage {
         , const NKikimrConfig::TDomainsConfig::TStateStorage& oldConfig
         , ui32 overrideReplicasInRingCount
         , ui32 overrideRingsCount
-        , ui32 replicasDensity
+        , ui32 replicasSpecificVolume
     )
         : PileId(pileId)
         , SelfHealNodesState(selfHealNodesState)
@@ -26,7 +26,7 @@ namespace NKikimr::NStorage {
         , OldConfig(oldConfig)
         , OverrideReplicasInRingCount(overrideReplicasInRingCount)
         , OverrideRingsCount(overrideRingsCount)
-        , ReplicasDensity(replicasDensity == 0 ? defaultReplicasDensity : replicasDensity)
+        , ReplicasSpecificVolume(replicasSpecificVolume == 0 ? defaultReplicasSpecificVolume : replicasSpecificVolume)
     {
         FillNodeGroups(nodes);
         CalculateRingsParameters();
@@ -70,7 +70,7 @@ namespace NKikimr::NStorage {
                 RingsInGroupCount = minNodesInGroup;
             }
             NToSelect = RingsInGroupCount < 3 ? 1 : (RingsInGroupCount < 5 ? 3 : 5);
-            ReplicasInRingCount = OverrideReplicasInRingCount > 0 ? OverrideReplicasInRingCount : (1 + minNodesInGroup / ReplicasDensity);
+            ReplicasInRingCount = OverrideReplicasInRingCount > 0 ? OverrideReplicasInRingCount : (1 + minNodesInGroup / ReplicasSpecificVolume);
         } else {
             if (OverrideRingsCount == 3 || OverrideRingsCount == 9) {
                 RingsInGroupCount = OverrideRingsCount / 3;
@@ -82,7 +82,7 @@ namespace NKikimr::NStorage {
             for (auto& n : NodeGroups) {
                 nodesCnt += n.Nodes.size();
             }
-            ReplicasInRingCount = OverrideReplicasInRingCount > 0 ? OverrideReplicasInRingCount : (1 + nodesCnt / ReplicasDensity);
+            ReplicasInRingCount = OverrideReplicasInRingCount > 0 ? OverrideReplicasInRingCount : (1 + nodesCnt / ReplicasSpecificVolume);
         }
         if (ReplicasInRingCount * RingsInGroupCount > minNodesInGroup) {
             ReplicasInRingCount = 1;

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
@@ -9,6 +9,7 @@
 #include <library/cpp/streams/zstd/zstd.h>
 
 namespace NKikimr::NStorage {
+    constexpr ui32 defaultReplicasDensity = 200;
 
     TStateStoragePerPileGenerator::TStateStoragePerPileGenerator(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes
         , const std::unordered_map<ui32, ui32>& selfHealNodesState
@@ -17,6 +18,7 @@ namespace NKikimr::NStorage {
         , const NKikimrConfig::TDomainsConfig::TStateStorage& oldConfig
         , ui32 overrideReplicasInRingCount
         , ui32 overrideRingsCount
+        , ui32 replicasDensity
     )
         : PileId(pileId)
         , SelfHealNodesState(selfHealNodesState)
@@ -24,6 +26,7 @@ namespace NKikimr::NStorage {
         , OldConfig(oldConfig)
         , OverrideReplicasInRingCount(overrideReplicasInRingCount)
         , OverrideRingsCount(overrideRingsCount)
+        , ReplicasDensity(replicasDensity == 0 ? defaultReplicasDensity : replicasDensity)
     {
         FillNodeGroups(nodes);
         CalculateRingsParameters();
@@ -67,7 +70,7 @@ namespace NKikimr::NStorage {
                 RingsInGroupCount = minNodesInGroup;
             }
             NToSelect = RingsInGroupCount < 3 ? 1 : (RingsInGroupCount < 5 ? 3 : 5);
-            ReplicasInRingCount = OverrideReplicasInRingCount > 0 ? OverrideReplicasInRingCount : (1 + minNodesInGroup / 1000);
+            ReplicasInRingCount = OverrideReplicasInRingCount > 0 ? OverrideReplicasInRingCount : (1 + minNodesInGroup / ReplicasDensity);
         } else {
             if (OverrideRingsCount == 3 || OverrideRingsCount == 9) {
                 RingsInGroupCount = OverrideRingsCount / 3;
@@ -79,7 +82,7 @@ namespace NKikimr::NStorage {
             for (auto& n : NodeGroups) {
                 nodesCnt += n.Nodes.size();
             }
-            ReplicasInRingCount = OverrideReplicasInRingCount > 0 ? OverrideReplicasInRingCount : (1 + nodesCnt / 1000);
+            ReplicasInRingCount = OverrideReplicasInRingCount > 0 ? OverrideReplicasInRingCount : (1 + nodesCnt / ReplicasDensity);
         }
         if (ReplicasInRingCount * RingsInGroupCount > minNodesInGroup) {
             ReplicasInRingCount = 1;

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
@@ -14,7 +14,8 @@ namespace NKikimr::NStorage {
             std::unordered_set<ui32>& usedNodes,
             const NKikimrConfig::TDomainsConfig::TStateStorage& oldConfig,
             ui32 overrideReplicasInRingCount,
-            ui32 overrideRingsCount
+            ui32 overrideRingsCount,
+            ui32 replicasDensity
         );
         bool IsGoodConfig() const;
         void AddRingGroup(NKikimrConfig::TDomainsConfig::TStateStorage *ss);
@@ -46,5 +47,6 @@ namespace NKikimr::NStorage {
         ui32 NToSelect = 1;
         ui32 OverrideReplicasInRingCount = 0;
         ui32 OverrideRingsCount = 0;
+        ui32 ReplicasDensity = 200;
     };
 }

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
@@ -15,7 +15,7 @@ namespace NKikimr::NStorage {
             const NKikimrConfig::TDomainsConfig::TStateStorage& oldConfig,
             ui32 overrideReplicasInRingCount,
             ui32 overrideRingsCount,
-            ui32 replicasDensity
+            ui32 replicasSpecificVolume
         );
         bool IsGoodConfig() const;
         void AddRingGroup(NKikimrConfig::TDomainsConfig::TStateStorage *ss);
@@ -47,6 +47,6 @@ namespace NKikimr::NStorage {
         ui32 NToSelect = 1;
         ui32 OverrideReplicasInRingCount = 0;
         ui32 OverrideRingsCount = 0;
-        ui32 ReplicasDensity = 200;
+        ui32 ReplicasSpecificVolume = 200;
     };
 }

--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -23,6 +23,7 @@ struct TCmsSentinelConfig {
         bool PileupReplicas;
         ui32 OverrideReplicasInRingCount;
         ui32 OverrideRingsCount;
+        ui32 ReplicasDensity;
 
         void Serialize(NKikimrCms::TCmsConfig::TSentinelConfig::TStateStorageSelfHealConfig &config) const {
             config.SetEnable(Enable);
@@ -34,6 +35,7 @@ struct TCmsSentinelConfig {
             config.SetPileupReplicas(PileupReplicas);
             config.SetOverrideReplicasInRingCount(OverrideReplicasInRingCount);
             config.SetOverrideRingsCount(OverrideRingsCount);
+            config.SetReplicasDensity(ReplicasDensity);
         }
 
         void Deserialize(const NKikimrCms::TCmsConfig::TSentinelConfig::TStateStorageSelfHealConfig &config) {
@@ -46,6 +48,7 @@ struct TCmsSentinelConfig {
             PileupReplicas = config.GetPileupReplicas();
             OverrideReplicasInRingCount = config.GetOverrideReplicasInRingCount();
             OverrideRingsCount = config.GetOverrideRingsCount();
+            ReplicasDensity = config.GetReplicasDensity();
         }
     };
 

--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -23,7 +23,7 @@ struct TCmsSentinelConfig {
         bool PileupReplicas;
         ui32 OverrideReplicasInRingCount;
         ui32 OverrideRingsCount;
-        ui32 ReplicasDensity;
+        ui32 ReplicasSpecificVolume;
 
         void Serialize(NKikimrCms::TCmsConfig::TSentinelConfig::TStateStorageSelfHealConfig &config) const {
             config.SetEnable(Enable);
@@ -35,7 +35,7 @@ struct TCmsSentinelConfig {
             config.SetPileupReplicas(PileupReplicas);
             config.SetOverrideReplicasInRingCount(OverrideReplicasInRingCount);
             config.SetOverrideRingsCount(OverrideRingsCount);
-            config.SetReplicasDensity(ReplicasDensity);
+            config.SetReplicasSpecificVolume(ReplicasSpecificVolume);
         }
 
         void Deserialize(const NKikimrCms::TCmsConfig::TSentinelConfig::TStateStorageSelfHealConfig &config) {
@@ -48,7 +48,7 @@ struct TCmsSentinelConfig {
             PileupReplicas = config.GetPileupReplicas();
             OverrideReplicasInRingCount = config.GetOverrideReplicasInRingCount();
             OverrideRingsCount = config.GetOverrideRingsCount();
-            ReplicasDensity = config.GetReplicasDensity();
+            ReplicasSpecificVolume = config.GetReplicasSpecificVolume();
         }
     };
 

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -1153,6 +1153,7 @@ class TSentinel: public TActorBootstrapped<TSentinel> {
         updateRequest->SetPileupReplicas(Config.StateStorageSelfHealConfig.PileupReplicas);
         updateRequest->SetOverrideReplicasInRingCount(Config.StateStorageSelfHealConfig.OverrideReplicasInRingCount);
         updateRequest->SetOverrideRingsCount(Config.StateStorageSelfHealConfig.OverrideRingsCount);
+        updateRequest->SetReplicasDensity(Config.StateStorageSelfHealConfig.ReplicasDensity);
         for (auto& [nodeId, node] : SentinelState->Nodes) {
             SentinelState->NeedSelfHealStateStorage |= node.Compute();
             auto* nodeState = updateRequest->AddNodesState();

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -1153,7 +1153,7 @@ class TSentinel: public TActorBootstrapped<TSentinel> {
         updateRequest->SetPileupReplicas(Config.StateStorageSelfHealConfig.PileupReplicas);
         updateRequest->SetOverrideReplicasInRingCount(Config.StateStorageSelfHealConfig.OverrideReplicasInRingCount);
         updateRequest->SetOverrideRingsCount(Config.StateStorageSelfHealConfig.OverrideRingsCount);
-        updateRequest->SetReplicasDensity(Config.StateStorageSelfHealConfig.ReplicasDensity);
+        updateRequest->SetReplicasSpecificVolume(Config.StateStorageSelfHealConfig.ReplicasSpecificVolume);
         for (auto& [nodeId, node] : SentinelState->Nodes) {
             SentinelState->NeedSelfHealStateStorage |= node.Compute();
             auto* nodeState = updateRequest->AddNodesState();

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -227,7 +227,7 @@ message TEvNodeConfigInvokeOnRoot {
         optional bool NodesState = 3;
         optional uint32 OverrideReplicasInRingCount = 4;
         optional uint32 OverrideRingsCount = 5;
-        optional uint32 ReplicasDensity = 6;
+        optional uint32 ReplicasSpecificVolume = 6;
     }
 
     message TSelfHealStateStorage {
@@ -236,7 +236,7 @@ message TEvNodeConfigInvokeOnRoot {
         optional bool PileupReplicas = 3;
         optional uint32 OverrideReplicasInRingCount = 4;
         optional uint32 OverrideRingsCount = 5;
-        optional uint32 ReplicasDensity = 6;
+        optional uint32 ReplicasSpecificVolume = 6;
     }
 
     message TSelfHealNodesStateUpdate {
@@ -250,7 +250,7 @@ message TEvNodeConfigInvokeOnRoot {
         optional bool PileupReplicas = 4;
         optional uint32 OverrideReplicasInRingCount = 5;
         optional uint32 OverrideRingsCount = 6;
-        optional uint32 ReplicasDensity = 7;
+        optional uint32 ReplicasSpecificVolume = 7;
     }
 
     message TAdvanceGeneration

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -227,6 +227,7 @@ message TEvNodeConfigInvokeOnRoot {
         optional bool NodesState = 3;
         optional uint32 OverrideReplicasInRingCount = 4;
         optional uint32 OverrideRingsCount = 5;
+        optional uint32 ReplicasDensity = 6;
     }
 
     message TSelfHealStateStorage {
@@ -235,6 +236,7 @@ message TEvNodeConfigInvokeOnRoot {
         optional bool PileupReplicas = 3;
         optional uint32 OverrideReplicasInRingCount = 4;
         optional uint32 OverrideRingsCount = 5;
+        optional uint32 ReplicasDensity = 6;
     }
 
     message TSelfHealNodesStateUpdate {
@@ -248,6 +250,7 @@ message TEvNodeConfigInvokeOnRoot {
         optional bool PileupReplicas = 4;
         optional uint32 OverrideReplicasInRingCount = 5;
         optional uint32 OverrideRingsCount = 6;
+        optional uint32 ReplicasDensity = 7;
     }
 
     message TAdvanceGeneration

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -441,7 +441,7 @@ message TCmsConfig {
             optional bool PileupReplicas = 7 [default = false];
             optional uint32 OverrideReplicasInRingCount = 8 [default = 0];
             optional uint32 OverrideRingsCount = 9 [default = 0];
-            optional uint32 ReplicasDensity = 10 [default = 200]; // 1 additional replica in ring per ReplicasDensity nodes in cluster
+            optional uint32 ReplicasSpecificVolume = 10 [default = 200]; // 1 additional replica in ring per ReplicasSpecificVolume nodes in cluster
         }
 
         message TStateLimit {

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -441,6 +441,7 @@ message TCmsConfig {
             optional bool PileupReplicas = 7 [default = false];
             optional uint32 OverrideReplicasInRingCount = 8 [default = 0];
             optional uint32 OverrideRingsCount = 9 [default = 0];
+            optional uint32 ReplicasDensity = 10 [default = 200]; // 1 additional replica in ring per ReplicasDensity nodes in cluster
         }
 
         message TStateLimit {

--- a/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
+++ b/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
@@ -39,6 +39,7 @@ class KiKiMRDistConfNodeStatusTest(object):
     n_to_select = None
     override_rings_count = 0
     override_replicas_in_ring_count = 0
+    replicas_density = 200
     metadata_section = {
         "kind": "MainConfig",
         "version": 0,
@@ -58,6 +59,7 @@ class KiKiMRDistConfNodeStatusTest(object):
                 "pileup_replicas": cls.pileup_replicas,
                 "override_rings_count": cls.override_rings_count,
                 "override_replicas_in_ring_count": cls.override_replicas_in_ring_count
+                "replicas_density": cls.replicas_density,
             },
             "default_state_limit": 2,
             "update_config_interval": 2000000,
@@ -264,3 +266,17 @@ class TestKiKiMRDistConfSelfHealOverrides(KiKiMRDistConfNodeStatusTest):
         assert_eq(rg2["NToSelect"], 3)
         assert_eq(len(rg2["Ring"]), 3)
         assert_eq(len(rg2["Ring"][0]["Node"]), 2)
+
+
+class TestKiKiMRDistConfSelfHealReplicasDensity(KiKiMRDistConfNodeStatusTest):
+    erasure = Erasure.MIRROR_3_DC
+    nodes_count = 12
+    override_rings_count = 3
+    replicas_density = 4
+
+    def do_test(self, configName):
+        time.sleep(25)
+        rg2 = get_ring_group(self.do_request_config(), configName)
+        assert_eq(rg2["NToSelect"], 3)
+        assert_eq(len(rg2["Ring"]), 3)
+        assert_eq(len(rg2["Ring"][0]["Node"]), 4)

--- a/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
+++ b/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
@@ -39,7 +39,7 @@ class KiKiMRDistConfNodeStatusTest(object):
     n_to_select = None
     override_rings_count = 0
     override_replicas_in_ring_count = 0
-    replicas_density = 200
+    replicas_specific_volume = 200
     metadata_section = {
         "kind": "MainConfig",
         "version": 0,
@@ -58,8 +58,8 @@ class KiKiMRDistConfNodeStatusTest(object):
                 "relax_time": 10000000,
                 "pileup_replicas": cls.pileup_replicas,
                 "override_rings_count": cls.override_rings_count,
-                "override_replicas_in_ring_count": cls.override_replicas_in_ring_count
-                "replicas_density": cls.replicas_density,
+                "override_replicas_in_ring_count": cls.override_replicas_in_ring_count,
+                "replicas_specific_volume": cls.replicas_specific_volume,
             },
             "default_state_limit": 2,
             "update_config_interval": 2000000,
@@ -268,11 +268,11 @@ class TestKiKiMRDistConfSelfHealOverrides(KiKiMRDistConfNodeStatusTest):
         assert_eq(len(rg2["Ring"][0]["Node"]), 2)
 
 
-class TestKiKiMRDistConfSelfHealReplicasDensity(KiKiMRDistConfNodeStatusTest):
+class TestKiKiMRDistConfSelfHealReplicasSpecificVolume(KiKiMRDistConfNodeStatusTest):
     erasure = Erasure.MIRROR_3_DC
     nodes_count = 12
     override_rings_count = 3
-    replicas_density = 4
+    replicas_specific_volume = 4
 
     def do_test(self, configName):
         time.sleep(25)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added ReplicasSpecificVolume option in Sentinel options.
It allows to change number of replicas in rings in state storage depending on nodes count. Default is 1 additional replica per every 200 static nodes in cluster.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
