### PR TITLE
Add changelog to system tablet backup

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -602,6 +602,7 @@ class TExecutor
     void Handle(TEvBlobStorage::TEvGetResult::TPtr&, const TActorContext&);
     void Handle(TEvTablet::TEvGcForStepAckResponse::TPtr &ev);
     void Handle(NBackup::TEvSnapshotCompleted::TPtr &ev);
+    void Handle(NBackup::TEvChangelogFailed::TPtr &ev);
 
     void UpdateUsedTabletMemory();
     void UpdateCounters(const TActorContext &ctx);

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -1,7 +1,14 @@
+#include "flat_boot_cookie.h"
+#include "flat_dbase_apply.h"
 #include "flat_dbase_scheme.h"
 #include "flat_executor_backup.h"
+#include "flat_redo_player.h"
 #include "flat_row_state.h"
+#include "flat_sausage_slicer.h"
+#include "flat_update_op.h"
+#include "util_deref.h"
 
+#include <ydb/core/util/pb.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
@@ -40,6 +47,95 @@ EScanStatus ToScanStatus(EStatus status) {
     return EScanStatus::InProgress;
 }
 
+void WriteColumnToJson(const TString& columnName, NScheme::TTypeId columnType,
+                       const TCell& columnData, NJsonWriter::TBuf& writer)
+{
+    if (columnData.IsNull()) {
+        writer.WriteKey(columnName).WriteNull();
+        return;
+    }
+
+    switch (columnType) {
+    case NScheme::NTypeIds::Int32:
+        writer.WriteKey(columnName).WriteInt(columnData.AsValue<i32>());
+        break;
+    case NScheme::NTypeIds::Uint32:
+        writer.WriteKey(columnName).WriteULongLong(columnData.AsValue<ui32>());
+        break;
+    case NScheme::NTypeIds::Int64:
+        writer.WriteKey(columnName).WriteLongLong(columnData.AsValue<i64>());
+        break;
+    case NScheme::NTypeIds::Uint64:
+        writer.WriteKey(columnName).WriteULongLong(columnData.AsValue<ui64>());
+        break;
+    case NScheme::NTypeIds::Uint8:
+        writer.WriteKey(columnName).WriteULongLong(columnData.AsValue<ui8>());
+        break;
+    case NScheme::NTypeIds::Int8:
+        writer.WriteKey(columnName).WriteInt(columnData.AsValue<i8>());
+        break;
+    case NScheme::NTypeIds::Int16:
+        writer.WriteKey(columnName).WriteInt(columnData.AsValue<i16>());
+        break;
+    case NScheme::NTypeIds::Uint16:
+        writer.WriteKey(columnName).WriteULongLong(columnData.AsValue<ui16>());
+        break;
+    case NScheme::NTypeIds::Bool:
+        writer.WriteKey(columnName).WriteBool(columnData.AsValue<bool>());
+        break;
+    case NScheme::NTypeIds::Double:
+        writer.WriteKey(columnName).WriteDouble(columnData.AsValue<double>());
+        break;
+    case NScheme::NTypeIds::Float:
+        writer.WriteKey(columnName).WriteFloat(columnData.AsValue<float>());
+        break;
+    case NScheme::NTypeIds::Date:
+        writer.WriteKey(columnName).WriteULongLong(columnData.AsValue<ui16>());
+        break;
+    case NScheme::NTypeIds::Datetime:
+        writer.WriteKey(columnName).WriteULongLong(columnData.AsValue<ui32>());
+        break;
+    case NScheme::NTypeIds::Timestamp:
+        writer.WriteKey(columnName).WriteULongLong(columnData.AsValue<ui64>());
+        break;
+    case NScheme::NTypeIds::Interval:
+        writer.WriteKey(columnName).WriteLongLong(columnData.AsValue<i64>());
+        break;
+    case NScheme::NTypeIds::Date32:
+        writer.WriteKey(columnName).WriteInt(columnData.AsValue<i32>());
+        break;
+    case NScheme::NTypeIds::Datetime64:
+    case NScheme::NTypeIds::Timestamp64:
+    case NScheme::NTypeIds::Interval64:
+        writer.WriteKey(columnName).WriteLongLong(columnData.AsValue<i64>());
+        break;
+    case NScheme::NTypeIds::Utf8:
+    case NScheme::NTypeIds::Json:
+        writer.WriteKey(columnName).WriteString(columnData.AsBuf());
+        break;
+    case NScheme::NTypeIds::JsonDocument:
+        writer.WriteKey(columnName).WriteString(Base64Encode(NBinaryJson::SerializeToJson(columnData.AsBuf())));
+        break;
+    case NScheme::NTypeIds::PairUi64Ui64: {
+        auto pair = columnData.AsValue<std::pair<ui64, ui64>>();
+        writer.WriteKey(columnName)
+            .BeginList()
+            .WriteULongLong(pair.first)
+            .WriteULongLong(pair.second)
+            .EndList();
+        break;
+    }
+    case NScheme::NTypeIds::ActorId: {
+        auto actorId = columnData.AsValue<TActorId>();
+        writer.WriteKey(columnName).WriteString(actorId.ToString());
+        break;
+    }
+    default:
+        writer.WriteKey(columnName).WriteString(Base64Encode(columnData.AsBuf()));
+        break;
+    }
+}
+
 }
 
 class TSnapshotWriter : public TActorBootstrapped<TSnapshotWriter> {
@@ -51,11 +147,11 @@ public:
         TFile File;
     };
 
-    TSnapshotWriter(const TFsPath& path, TActorId owner,
+    TSnapshotWriter(TActorId owner, const TFsPath& path,
                     const THashMap<ui32, TScheme::TTableInfo>& tables,
-                    TAutoPtr<NTable::TSchemeChanges> schema)
-        : SnapshotPath(path.Child("snapshot"))
-        , Owner(owner)
+                    TAutoPtr<TSchemeChanges> schema)
+        : Owner(owner)
+        , SnapshotPath(path.Child("snapshot"))
         , Schema(schema)
     {
         for (const auto& [tableId, table] : tables) {
@@ -175,14 +271,15 @@ public:
     }
 
 private:
-    TFsPath SnapshotPath;
     TActorId Owner;
+
+    TFsPath SnapshotPath;
 
     THashMap<ui32, TTableFile> Tables;
     THashSet<ui32> DoneTables;
 
     TFile SchemaFile;
-    TAutoPtr<NTable::TSchemeChanges> Schema;
+    TAutoPtr<TSchemeChanges> Schema;
 };
 
 class TBackupSnapshotScan : public IScan, public TActor<TBackupSnapshotScan> {
@@ -220,91 +317,8 @@ public:
 
         for (const auto& info : Scheme->Cols) {
             const auto& cell = row.Get(info.Pos);
-
-            if (cell.IsNull()) {
-                b.WriteKey(Columns.at(info.Tag).Name).WriteNull();
-                continue;
-            }
-
-            switch (info.TypeInfo.GetTypeId()) {
-            case NScheme::NTypeIds::Int32:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteInt(cell.AsValue<i32>());
-                break;
-            case NScheme::NTypeIds::Uint32:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteULongLong(cell.AsValue<ui32>());
-                break;
-            case NScheme::NTypeIds::Int64:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteLongLong(cell.AsValue<i64>());
-                break;
-            case NScheme::NTypeIds::Uint64:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteULongLong(cell.AsValue<ui64>());
-                break;
-            case NScheme::NTypeIds::Uint8:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteULongLong(cell.AsValue<ui8>());
-                break;
-            case NScheme::NTypeIds::Int8:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteInt(cell.AsValue<i8>());
-                break;
-            case NScheme::NTypeIds::Int16:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteInt(cell.AsValue<i16>());
-                break;
-            case NScheme::NTypeIds::Uint16:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteULongLong(cell.AsValue<ui16>());
-                break;
-            case NScheme::NTypeIds::Bool:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteBool(cell.AsValue<bool>());
-                break;
-            case NScheme::NTypeIds::Double:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteDouble(cell.AsValue<double>());
-                break;
-            case NScheme::NTypeIds::Float:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteFloat(cell.AsValue<float>());
-                break;
-            case NScheme::NTypeIds::Date:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteULongLong(cell.AsValue<ui16>());
-                break;
-            case NScheme::NTypeIds::Datetime:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteULongLong(cell.AsValue<ui32>());
-                break;
-            case NScheme::NTypeIds::Timestamp:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteULongLong(cell.AsValue<ui64>());
-                break;
-            case NScheme::NTypeIds::Interval:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteLongLong(cell.AsValue<i64>());
-                break;
-            case NScheme::NTypeIds::Date32:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteInt(cell.AsValue<i32>());
-                break;
-            case NScheme::NTypeIds::Datetime64:
-            case NScheme::NTypeIds::Timestamp64:
-            case NScheme::NTypeIds::Interval64:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteLongLong(cell.AsValue<i64>());
-                break;
-            case NScheme::NTypeIds::Utf8:
-            case NScheme::NTypeIds::Json:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteString(cell.AsBuf());
-                break;
-            case NScheme::NTypeIds::JsonDocument:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteString(Base64Encode(NBinaryJson::SerializeToJson(cell.AsBuf())));
-                break;
-            case NScheme::NTypeIds::PairUi64Ui64: {
-                auto pair = cell.AsValue<std::pair<ui64, ui64>>();
-                b.WriteKey(Columns.at(info.Tag).Name)
-                    .BeginList()
-                    .WriteULongLong(pair.first)
-                    .WriteULongLong(pair.second)
-                    .EndList();
-                break;
-            }
-            case NScheme::NTypeIds::ActorId: {
-                auto actorId = cell.AsValue<TActorId>();
-                b.WriteKey(Columns.at(info.Tag).Name).WriteString(actorId.ToString());
-                break;
-            }
-            default:
-                b.WriteKey(Columns.at(info.Tag).Name).WriteString(Base64Encode(cell.AsBuf()));
-                break;
-            }
+            const auto& column = Columns.at(info.Tag);
+            WriteColumnToJson(column.Name, column.PType.GetTypeId(), cell, b);
         }
 
         b.EndObject();
@@ -363,10 +377,309 @@ private:
     bool InFlight = false;
 };
 
+class TChangelogSerializer {
+public:
+    using TKeys = TArrayRef<const TRawTypeValue>;
+    using TOps = TArrayRef<const TUpdateOp>;
+
+    TChangelogSerializer(NJsonWriter::TBuf& writer, TScheme& schema)
+        : Writer(writer)
+        , Schema(schema)
+    {}
+
+    bool NeedIn(ui32) noexcept
+    {
+        return true;
+    }
+
+    void DoBegin(ui32, ui32, ui64, ui64)
+    {
+        // ignore
+    }
+
+    void DoAnnex(TArrayRef<const TStdPad<NPageCollection::TGlobId>>)
+    {
+        Y_TABLET_ERROR("Annex is unsupported");
+    }
+
+    void DoUpdate(ui32 tid, ERowOp rop, TKeys key, TOps ops, TRowVersion)
+    {
+        Writer.BeginObject();
+
+        Writer.WriteKey("table");
+
+        auto* table = Schema.GetTableInfo(tid);
+        Writer.WriteString(table->Name);
+
+        Writer.WriteKey("op");
+        switch (rop) {
+            case ERowOp::Absent:
+                Y_TABLET_ERROR("Row op is absent");
+                break;
+            case ERowOp::Upsert:
+                Writer.WriteString("upsert");
+                break;
+            case ERowOp::Erase:
+                Writer.WriteString("erase");
+                break;
+            case ERowOp::Reset:
+                Writer.WriteString("replace");
+                break;
+        }
+
+        for (size_t i = 0; i < table->KeyColumns.size(); ++i) {
+            ui32 columnId = table->KeyColumns[i];
+            const auto& column = table->Columns.at(columnId);
+            WriteColumnToJson(column.Name, column.PType.GetTypeId(), key[i].AsRef(), Writer);
+        }
+
+        for (const auto& op : ops) {
+            const auto& column = table->Columns.at(op.Tag);
+            switch (ECellOp(op.Op)) {
+                case ECellOp::Empty:
+                    Y_TABLET_ERROR("Cell op is empty");
+                    break;
+                case ECellOp::Set:
+                    WriteColumnToJson(column.Name, column.PType.GetTypeId(), op.AsCell(), Writer);
+                    break;
+                case ECellOp::Null:
+                case ECellOp::Reset:
+                    WriteColumnToJson(column.Name, column.PType.GetTypeId(), column.Null, Writer);
+                    break;
+            }
+        }
+
+        Writer.EndObject();
+    }
+
+    void DoUpdateTx(ui32, ERowOp, TKeys, TOps, ui64)
+    {
+        Y_TABLET_ERROR("UpdateTx is unsupported");
+    }
+
+    void DoCommitTx(ui32, ui64, TRowVersion)
+    {
+        Y_TABLET_ERROR("CommitTx is unsupported");
+    }
+
+    void DoRemoveTx(ui32, ui64)
+    {
+        Y_TABLET_ERROR("RemoveTx is unsupported");
+    }
+
+    void DoFlush(ui32, ui64, TEpoch)
+    {
+        Y_TABLET_ERROR("Flush is unsupported");
+    }
+
+private:
+    NJsonWriter::TBuf& Writer;
+    TScheme& Schema;
+};
+
+class TChangelogWriter : public TActorBootstrapped<TChangelogWriter> {
+    struct TEvPrivate {
+        enum EEv {
+            EvMailboxCleaned = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+            EvFlush,
+            EvEnd
+        };
+
+        static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE));
+
+        struct TEvMailboxCleaned : TEventLocal<TEvMailboxCleaned, EvMailboxCleaned> {};
+        struct TEvFlush : TEventLocal<TEvFlush, EvFlush> {
+            TEvFlush(ui64 cookie)
+                : Cookie(cookie)
+            {}
+
+            ui64 Cookie;
+        };
+    };
+public:
+    TChangelogWriter(TActorId owner, const TFsPath& path, const TScheme& schema)
+        : Owner(owner)
+        , ChangelogPath(path.Child("changelog.json"))
+        , Schema(schema)
+    {}
+
+    void Bootstrap() {
+        LOG_D("Bootstrap for " << ChangelogPath);
+
+        try {
+            ChangelogPath.Parent().MkDirs();
+            ChangelogFile = TFile(ChangelogPath, EOpenModeFlag::CreateNew | EOpenModeFlag::WrOnly);
+        } catch (const TIoException& e) {
+            return ReplyAndDie(TStringBuilder() << "Failed to create changelog file " << ChangelogPath << ": " << e.what());
+        }
+
+        Become(&TThis::StateWork);
+        Schedule(TDuration::Seconds(5), new TEvPrivate::TEvFlush(++ExpectedFlushCookie));
+    }
+
+    STATEFN(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvWriteChangelog, Handle);
+            hFunc(TEvPrivate::TEvFlush, Handle);
+            cFunc(TEvents::TEvPoisonPill::EventType, CleanMailbox);
+            cFunc(TEvPrivate::TEvMailboxCleaned::EventType, FlushAndDie);
+        }
+    }
+
+    void Handle(TEvWriteChangelog::TPtr& ev) {
+        LOG_D("Handle " << ev->ToString());
+
+        TBufferOutput out(Buffer);
+        NJsonWriter::TBuf b(NJsonWriter::HEM_RELAXED, &out);
+
+        const auto* msg = ev->Get();
+
+        TString dataUpdate;
+        TString schemeUpdate;
+
+        if (!msg->EmbeddedLogBody.empty()) {
+            if (!msg->References.empty()) {
+                return ReplyAndDie("There are both embedded log body and references");
+            }
+            dataUpdate = msg->EmbeddedLogBody;
+        } else {
+            for (const auto& ref : msg->References) {
+                const TLogoBlobID& id = ref.Id;
+                const TString& body = ref.Buffer;
+
+                const NBoot::TCookie cookie(id.Cookie());
+                if (cookie.Type() != NBoot::TCookie::EType::Log) {
+                    return ReplyAndDie("Cookie type is not log");
+                }
+
+                switch (cookie.Index()) {
+                case NBoot::TCookie::EIdx::RedoLz4:
+                    if (dataUpdate)
+                        dataUpdate.append(body);
+                    else
+                        dataUpdate = body;
+                    break;
+                case NBoot::TCookie::EIdx::Alter:
+                    if (schemeUpdate)
+                        schemeUpdate.append(body);
+                    else
+                        schemeUpdate = body;
+                    break;
+                default:
+                    return ReplyAndDie("Unsupported blob kind");
+                }
+            }
+        }
+
+        if (schemeUpdate.empty() && dataUpdate.empty()) {
+            return;
+        }
+
+        b.BeginObject();
+        b.WriteKey("step");
+        b.WriteULongLong(msg->Step);
+
+        if (schemeUpdate) {
+            TSchemeChanges changes;
+            bool parseOk = ParseFromStringNoSizeLimit(changes, schemeUpdate);
+            if (!parseOk) {
+                return ReplyAndDie("Can't parse scheme update from proto");
+            }
+
+            TSchemeModifier modifier(Schema);
+            modifier.Apply(changes);
+
+            b.WriteKey("schema_changes");
+            b.BeginList();
+
+            for (const auto& rec : changes.GetDelta()) {
+                NJson::TJsonValue value;
+                NProtobufJson::Proto2Json(rec, value, {
+                    .EnumMode = NProtobufJson::TProto2JsonConfig::EnumName,
+                    .FieldNameMode = NProtobufJson::TProto2JsonConfig::FieldNameSnakeCaseDense,
+                    .MapAsObject = true,
+                });
+                b.WriteJsonValue(&value);
+            }
+            b.EndList();
+        }
+
+        if (dataUpdate) {
+            dataUpdate = NPageCollection::TSlicer::Lz4()->Decode(dataUpdate);
+
+            b.WriteKey("data_changes");
+            b.BeginList();
+
+            try {
+                TChangelogSerializer serializer(b, Schema);
+                NRedo::TPlayer<TChangelogSerializer> redoPlayer(serializer);
+                redoPlayer.Replay(dataUpdate);
+            } catch (const std::exception& e) {
+                return ReplyAndDie(TStringBuilder() << "Failed to serialize commit data: " << e.what());
+            }
+
+            b.EndList();
+        }
+
+        b.EndObject();
+        out << '\n';
+
+        if (Buffer.Size() >= 1_MB) {
+            Flush();
+        }
+    }
+
+    void Handle(TEvPrivate::TEvFlush::TPtr& ev) {
+        LOG_D("Handle " << ev->ToString());
+
+        if (ev->Get()->Cookie == ExpectedFlushCookie) {
+            Flush();
+        }
+    }
+
+    void Flush() {
+        if (!Buffer.Empty()) {
+            try {
+                ChangelogFile.Write(Buffer.data(), Buffer.size());
+                ChangelogFile.Flush(); // TODO(pixcc): fsync on parent folder?
+            } catch (const TIoException& e) {
+                return ReplyAndDie(TStringBuilder() << "Failed to write changelog data " << ChangelogFile.GetName() << ": " << e.what());
+            }
+            Buffer.Clear();
+        }
+        Schedule(TDuration::Seconds(5), new TEvPrivate::TEvFlush(++ExpectedFlushCookie));
+    }
+
+    void CleanMailbox() {
+        Send(SelfId(), new TEvPrivate::TEvMailboxCleaned());
+    }
+
+    void FlushAndDie() {
+        Flush();
+        PassAway();
+    }
+
+    void ReplyAndDie(const TString& error) {
+        Send(Owner, new TEvChangelogFailed(error));
+        PassAway();
+    }
+
+private:
+    TActorId Owner;
+
+    TFsPath ChangelogPath;
+    TFile ChangelogFile;
+
+    TScheme Schema;
+
+    TBuffer Buffer;
+    ui64 ExpectedFlushCookie = 0;
+};
+
 IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                              const THashMap<ui32, TScheme::TTableInfo>& tables,
                              TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation,
-                             TAutoPtr<NTable::TSchemeChanges> schema)
+                             TAutoPtr<TSchemeChanges> schema)
 {
     if (config.HasFilesystem()) {
         TString tabletTypeName = TTabletTypes::EType_Name(tabletType);
@@ -376,7 +689,7 @@ IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletB
             .Child(tabletTypeName)
             .Child(ToString(tabletId))
             .Child("gen_" + ToString(generation));
-        return new TSnapshotWriter(path, owner, tables, schema);
+        return new TSnapshotWriter(owner, path, tables, schema);
     } else {
         return nullptr;
     }
@@ -384,6 +697,24 @@ IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletB
 
 IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<ui32, TColumn>& columns) {
     return new TBackupSnapshotScan(snapshotWriter, tableId, columns);
+}
+
+IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
+                              TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation,
+                              const TScheme& schema)
+{
+    if (config.HasFilesystem()) {
+        TString tabletTypeName = TTabletTypes::EType_Name(tabletType);
+        NProtobufJson::ToSnakeCaseDense(&tabletTypeName);
+
+        auto path = TFsPath(config.GetFilesystem().GetPath())
+            .Child(tabletTypeName)
+            .Child(ToString(tabletId))
+            .Child("gen_" + ToString(generation));
+        return new TChangelogWriter(owner, path, schema);
+    } else {
+        return nullptr;
+    }
 }
 
 } // NKikimr::NTabletFlatExecutor::NBackup

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -549,7 +549,7 @@ public:
 
                 const NBoot::TCookie cookie(id.Cookie());
                 if (cookie.Type() != NBoot::TCookie::EType::Log) {
-                    return ReplyAndDie("Cookie type is not log");
+                    continue; // skip
                 }
 
                 switch (cookie.Index()) {
@@ -566,7 +566,7 @@ public:
                         schemeUpdate = body;
                     break;
                 default:
-                    return ReplyAndDie("Unsupported blob kind");
+                    continue; // skip
                 }
             }
         }
@@ -605,12 +605,11 @@ public:
         }
 
         if (dataUpdate) {
-            dataUpdate = NPageCollection::TSlicer::Lz4()->Decode(dataUpdate);
-
             b.WriteKey("data_changes");
             b.BeginList();
 
             try {
+                dataUpdate = NPageCollection::TSlicer::Lz4()->Decode(dataUpdate);
                 TChangelogSerializer serializer(b, Schema);
                 NRedo::TPlayer<TChangelogSerializer> redoPlayer(serializer);
                 redoPlayer.Replay(dataUpdate);

--- a/ydb/core/tablet_flat/flat_executor_backup.h
+++ b/ydb/core/tablet_flat/flat_executor_backup.h
@@ -4,6 +4,7 @@
 #include "flat_scan_iface.h"
 #include "flat_dbase_scheme.h"
 
+#include <ydb/core/base/tablet.h>
 #include <ydb/core/base/tablet_types.h>
 #include <ydb/core/protos/config.pb.h>
 
@@ -16,10 +17,13 @@ enum EEv {
     EvWriteSnapshotAck,
     EvSnapshotCompleted,
 
+    EvWriteChangelog,
+    EvChangelogFailed,
+
     EvEnd
 };
 
-static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_FLAT_EXECUTOR), "");
+static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_FLAT_EXECUTOR));
 
 struct TEvSnapshotCompleted : public TEventLocal<TEvSnapshotCompleted, EvSnapshotCompleted> {
     TEvSnapshotCompleted(bool success, const TString& error = "")
@@ -54,10 +58,33 @@ struct TEvWriteSnapshot : public TEventLocal<TEvWriteSnapshot, EvWriteSnapshot> 
 
 struct TEvWriteSnapshotAck : public TEventLocal<TEvWriteSnapshotAck, EvWriteSnapshotAck> {};
 
+struct TEvWriteChangelog : public TEventLocal<TEvWriteChangelog, EvWriteChangelog> {
+    TEvWriteChangelog(ui32 step, const TString& logBody, const TVector<TEvTablet::TLogEntryReference>& references)
+        : Step(step)
+        , EmbeddedLogBody(logBody)
+        , References(references)
+    {}
+
+    ui32 Step;
+    TString EmbeddedLogBody;
+    TVector<TEvTablet::TLogEntryReference> References;
+};
+
+struct TEvChangelogFailed : public TEventLocal<TEvChangelogFailed, EvChangelogFailed> {
+    TEvChangelogFailed(const TString& error)
+        : Error(error)
+    {}
+
+    TString Error;
+};
+
 IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                              const THashMap<ui32, NTable::TScheme::TTableInfo>& tables,
                              TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation,
                              TAutoPtr<NTable::TSchemeChanges> schema);
 NTable::IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<ui32, NTable::TColumn>& columns);
 
+IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
+                              TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation,
+                              const NTable::TScheme& schema);
 } // NKikimr::NTabletFlatExecutor::NBackup

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -3,6 +3,8 @@
 
 #include <ydb/core/testlib/actors/block_events.h>
 
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/writer/json_value.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NKikimr::NTabletFlatExecutor::NBackup {
@@ -11,17 +13,11 @@ struct TSchema : NIceDb::Schema {
     struct Data : Table<1> {
         struct Key : Column<1, NScheme::NTypeIds::Uint64> { };
         struct Value : Column<2, NScheme::NTypeIds::Uint32> { };
+        struct BinaryValue : Column<3, NScheme::NTypeIds::String> { };
+        struct DefaultValue : Column<4, NScheme::NTypeIds::Uint32> { static constexpr ui32 Default = 42; };
 
         using TKey = TableKey<Key>;
-        using TColumns = TableColumns<Key, Value>;
-    };
-
-    struct BinaryData : Table<2> {
-        struct Key : Column<1, NScheme::NTypeIds::Uint64> { };
-        struct Value : Column<2, NScheme::NTypeIds::String> { };
-
-        using TKey = TableKey<Key>;
-        using TColumns = TableColumns<Key, Value>;
+        using TColumns = TableColumns<Key, Value, BinaryValue, DefaultValue>;
     };
 
     struct CompositePKData : Table<3> {
@@ -33,7 +29,7 @@ struct TSchema : NIceDb::Schema {
         using TColumns = TableColumns<Key, SubKey, Value>;
     };
 
-    using TTables = SchemaTables<Data, BinaryData, CompositePKData>;
+    using TTables = SchemaTables<Data, CompositePKData>;
 }; // TSchema
 
 struct TTxInitSchema : public ITransaction {
@@ -52,12 +48,32 @@ struct TTxInitSchema : public ITransaction {
     }
 }; // TTxInitSchema
 
-struct TTxWriteDataRow : public ITransaction {
+struct TTxInitSchemaWithMigration : public ITransaction {
+    const TActorId Owner;
+
+    TTxInitSchemaWithMigration(TActorId owner) : Owner(owner) {}
+
+    bool Execute(TTransactionContext &txc, const TActorContext &) override {
+        NIceDb::TNiceDb db(txc.DB);
+
+        db.Materialize<TSchema>();
+        db.Table<TSchema::Data>().Key(1)
+            .Update<TSchema::Data::Value>(42);
+
+        return true;
+    }
+
+    void Complete(const TActorContext &ctx) override {
+        ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+    }
+}; // TTxInitSchemaWithMigration
+
+struct TTxWriteValue : public ITransaction {
     const TActorId Owner;
     const ui64 Key;
     const ui32 Value;
 
-    TTxWriteDataRow(TActorId owner, ui64 key, ui32 value)
+    TTxWriteValue(TActorId owner, ui64 key, ui32 value)
         : Owner(owner)
         , Key(key)
         , Value(value)
@@ -75,15 +91,15 @@ struct TTxWriteDataRow : public ITransaction {
     void Complete(const TActorContext &ctx) override {
         ctx.Send(Owner, new NFake::TEvResult);
     }
-}; // TTxWriteDataRow
+}; // TTxWriteValue
 
-struct TTxWriteDataRange : public ITransaction {
+struct TTxWriteRange : public ITransaction {
     const TActorId Owner;
     const ui64 KeyStart;
     const ui64 KeyEnd;
     const ui32 Value;
 
-    TTxWriteDataRange(TActorId owner, ui64 keyStart, ui64 keyEnd, ui32 value)
+    TTxWriteRange(TActorId owner, ui64 keyStart, ui64 keyEnd, ui32 value)
         : Owner(owner)
         , KeyStart(keyStart)
         , KeyEnd(keyEnd)
@@ -104,14 +120,14 @@ struct TTxWriteDataRange : public ITransaction {
     void Complete(const TActorContext &ctx) override {
         ctx.Send(Owner, new NFake::TEvResult);
     }
-}; // TTxWriteDataRange
+}; // TTxWriteRange
 
-struct TTxWriteBinaryDataRow : public ITransaction {
+struct TTxWriteBinaryValue : public ITransaction {
     const TActorId Owner;
     const ui64 Key;
     const TString Value;
 
-    TTxWriteBinaryDataRow(TActorId owner, ui64 key, const TString& value)
+    TTxWriteBinaryValue(TActorId owner, ui64 key, const TString& value)
         : Owner(owner)
         , Key(key)
         , Value(value)
@@ -120,8 +136,8 @@ struct TTxWriteBinaryDataRow : public ITransaction {
     bool Execute(TTransactionContext &txc, const TActorContext &) override {
         NIceDb::TNiceDb db(txc.DB);
 
-        db.Table<TSchema::BinaryData>().Key(Key)
-            .Update<TSchema::BinaryData::Value>(Value);
+        db.Table<TSchema::Data>().Key(Key)
+            .Update<TSchema::Data::BinaryValue>(Value);
 
         return true;
     }
@@ -129,15 +145,15 @@ struct TTxWriteBinaryDataRow : public ITransaction {
     void Complete(const TActorContext &ctx) override {
         ctx.Send(Owner, new NFake::TEvResult);
     }
-}; // TTxWriteBinaryDataRow
+}; // TTxWriteBinaryValue
 
-struct TTxWriteCompositePKDataRow : public ITransaction {
+struct TTxWriteCompositePK : public ITransaction {
     const TActorId Owner;
     const ui64 Key;
     const ui64 SubKey;
     const ui32 Value;
 
-    TTxWriteCompositePKDataRow(TActorId owner, ui64 key, ui64 subKey, ui32 value)
+    TTxWriteCompositePK(TActorId owner, ui64 key, ui64 subKey, ui32 value)
         : Owner(owner)
         , Key(key)
         , SubKey(subKey)
@@ -156,7 +172,115 @@ struct TTxWriteCompositePKDataRow : public ITransaction {
     void Complete(const TActorContext &ctx) override {
         ctx.Send(Owner, new NFake::TEvResult);
     }
-}; // TTxWriteCompositePKDataRow
+}; // TTxWriteCompositePK
+
+struct TTxEraseRow : public ITransaction {
+    const TActorId Owner;
+    const ui64 Key;
+
+    TTxEraseRow(TActorId owner, ui64 key)
+        : Owner(owner)
+        , Key(key)
+    {}
+
+    bool Execute(TTransactionContext &txc, const TActorContext &) override {
+        NIceDb::TNiceDb db(txc.DB);
+
+        db.Table<TSchema::Data>().Key(Key).Delete();
+
+        return true;
+    }
+
+    void Complete(const TActorContext &ctx) override {
+        ctx.Send(Owner, new NFake::TEvResult);
+    }
+}; // TTxEraseRow
+
+struct TxWriteDefaultValue : public ITransaction {
+    const TActorId Owner;
+    const ui64 Key;
+    const std::optional<ui32> Value;
+
+    TxWriteDefaultValue(TActorId owner, ui64 key, std::optional<ui32> value)
+        : Owner(owner)
+        , Key(key)
+        , Value(value)
+    {}
+
+    bool Execute(TTransactionContext &txc, const TActorContext &) override {
+        NIceDb::TNiceDb db(txc.DB);
+
+        if (Value) {
+            db.Table<TSchema::Data>().Key(Key)
+                .Update<TSchema::Data::DefaultValue>(*Value);
+        } else {
+            db.Table<TSchema::Data>().Key(Key)
+                .UpdateToNull<TSchema::Data::DefaultValue>();
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext &ctx) override {
+        ctx.Send(Owner, new NFake::TEvResult);
+    }
+}; // TxWriteDefaultValue
+
+struct TxWriteTwoColumns : public ITransaction {
+    const TActorId Owner;
+    const ui64 Key;
+    const ui32 Value;
+    const TString BinaryValue;
+
+    TxWriteTwoColumns(TActorId owner, ui64 key, ui32 value, const TString& binaryValue)
+        : Owner(owner)
+        , Key(key)
+        , Value(value)
+        , BinaryValue(binaryValue)
+    {}
+
+    bool Execute(TTransactionContext &txc, const TActorContext &) override {
+        NIceDb::TNiceDb db(txc.DB);
+
+        db.Table<TSchema::Data>().Key(Key)
+            .Update<TSchema::Data::Value, TSchema::Data::BinaryValue>(Value, BinaryValue);
+
+        return true;
+    }
+
+    void Complete(const TActorContext &ctx) override {
+        ctx.Send(Owner, new NFake::TEvResult);
+    }
+}; // TxWriteTwoColumns
+
+struct TTxReplaceRow : public ITransaction {
+    const TActorId Owner;
+    const ui64 Key;
+    const ui32 Value;
+
+    TTxReplaceRow(TActorId owner, ui64 key, ui32 value)
+        : Owner(owner)
+        , Key(key)
+        , Value(value)
+    {}
+
+    bool Execute(TTransactionContext &txc, const TActorContext &) override {
+        NIceDb::TNiceDb db(txc.DB);
+
+        txc.DB.Update(
+            TSchema::Data::TableId,
+            NTable::ERowOp::Reset,
+            { NScheme::TUint64::TInstance(Key) },
+            { NIceDb::TUpdateOp(TSchema::Data::Value::ColumnId, NTable::ECellOp::Set, NScheme::TUint32::TInstance(Value)) }
+        );
+
+        return true;
+    }
+
+    void Complete(const TActorContext &ctx) override {
+        ctx.Send(Owner, new NFake::TEvResult);
+    }
+}; // TTxReplaceRow
 
 struct TEnv : public TMyEnvBase {
     TEnv()
@@ -170,24 +294,54 @@ struct TEnv : public TMyEnvBase {
         SendSync(new NFake::TEvExecute{ new TTxInitSchema(Edge) });
     }
 
-    void WriteRow(ui64 key, ui32 value) {
-        SendAsync(new NFake::TEvExecute{ new TTxWriteDataRow(Edge, key, value) });
+    void InitSchemaWithMigration() {
+        SendSync(new NFake::TEvExecute{ new TTxInitSchemaWithMigration(Edge) });
+    }
+
+    void WriteValue(ui64 key, ui32 value) {
+        SendAsync(new NFake::TEvExecute{ new TTxWriteValue(Edge, key, value) });
+        WaitFor<NFake::TEvResult>();
+    }
+
+    void EraseRow(ui64 key) {
+        SendAsync(new NFake::TEvExecute{ new TTxEraseRow(Edge, key) });
         WaitFor<NFake::TEvResult>();
     }
 
     void WriteRange(ui64 keyStart, ui64 keyEnd, ui32 value) {
-        SendAsync(new NFake::TEvExecute{ new TTxWriteDataRange(Edge, keyStart, keyEnd, value) });
+        SendAsync(new NFake::TEvExecute{ new TTxWriteRange(Edge, keyStart, keyEnd, value) });
         WaitFor<NFake::TEvResult>();
     }
 
-    void WriteBinaryRow(ui64 key, const TString& value) {
-        SendAsync(new NFake::TEvExecute{ new TTxWriteBinaryDataRow(Edge, key, value) });
+    void WriteBinaryValue(ui64 key, const TString& value) {
+        SendAsync(new NFake::TEvExecute{ new TTxWriteBinaryValue(Edge, key, value) });
         WaitFor<NFake::TEvResult>();
     }
 
-    void WriteCompositePKRow(ui64 key, ui64 subKey, ui32 value) {
-        SendAsync(new NFake::TEvExecute{ new TTxWriteCompositePKDataRow(Edge, key, subKey, value) });
+    void WriteCompositePK(ui64 key, ui64 subKey, ui32 value) {
+        SendAsync(new NFake::TEvExecute{ new TTxWriteCompositePK(Edge, key, subKey, value) });
         WaitFor<NFake::TEvResult>();
+    }
+
+    void WriteDefaultValue(ui64 key, std::optional<ui32> value) {
+        SendAsync(new NFake::TEvExecute{ new TxWriteDefaultValue(Edge, key, value) });
+        WaitFor<NFake::TEvResult>();
+    }
+
+    void WriteTwoColumns(ui64 key, ui32 value, const TString& binaryValue) {
+        SendAsync(new NFake::TEvExecute{ new TxWriteTwoColumns(Edge, key, value, binaryValue) });
+        WaitFor<NFake::TEvResult>();
+    }
+
+    void ReplaceRow(ui64 key, ui32 value) {
+        SendAsync(new NFake::TEvExecute{ new TTxReplaceRow(Edge, key, value) });
+        WaitFor<NFake::TEvResult>();
+    }
+    
+    void WaitChangelogFlush() {
+        Cerr << "...waiting changelog flush" << Endl;
+        Env.AdvanceCurrentTime(TDuration::Seconds(5));
+        Env.SimulateSleep(TDuration::Seconds(1));
     }
 
 }; // TEnv
@@ -197,30 +351,18 @@ Y_UNIT_TEST_SUITE(Backup) {
         | ui32(NFake::TDummy::EFlg::Comp)
         | ui32(NFake::TDummy::EFlg::Vac);
 
-    Y_UNIT_TEST(FileStructure) {
+    Y_UNIT_TEST(GenerationDirs) {
         TEnv env;
 
+        Cerr << "...starting tablet" << Endl;
         env.FireDummyTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
 
-        auto dummyDir = TFsPath(env->GetTempDir()).Child("dummy");
-        UNIT_ASSERT_C(dummyDir.Exists(), "Tablet type dir isn't created");
-
-        auto tabletIdDir = dummyDir.Child(ToString(env.Tablet));
-        UNIT_ASSERT_C(tabletIdDir.Exists(), "Tablet ID dir isn't created");
-
-        TVector<TFsPath> genDirs;
-        tabletIdDir.List(genDirs);
-
-        UNIT_ASSERT_C(!genDirs.empty(), "Tablet generation dir isn't created");
-    }
-
-    Y_UNIT_TEST(FileStructureAfterRestarts) {
-        TEnv env;
-
-        env.FireDummyTablet(TestTabletFlags);
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
 
+        Cerr << "...restarting tablet again" << Endl;
         env.RestartTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
 
@@ -233,27 +375,33 @@ Y_UNIT_TEST_SUITE(Backup) {
         TVector<TFsPath> genDirs;
         tabletIdDir.List(genDirs);
 
-        UNIT_ASSERT_C(genDirs.size() == 2, "Every restart must create new generation dir");
+        UNIT_ASSERT_C(genDirs.size() == 3, "Every restart must create new generation dir");
     }
 
     Y_UNIT_TEST(SnapshotIOError) {
         TEnv env;
 
-        env->GetAppData().SystemTabletBackupConfig.MutableFilesystem()->SetPath("/dev/null");
+        TFsPath(env->GetTempDir()).Child("dummy").MkDir(S_IRUSR);
         env->GetAppData().FeatureFlags.SetEnableTabletRestartOnUnhandledExceptions(true);
 
+        Cerr << "...starting tablet" << Endl;
         env.FireDummyTablet(TestTabletFlags);
 
+        Cerr << "...waiting tablet death" << Endl;
         env.WaitForGone(); // crash on IO error
     }
 
-    Y_UNIT_TEST(SnapshotEmptyData) {
+    Y_UNIT_TEST(EmptyData) {
         TEnv env;
 
+        Cerr << "...starting tablet" << Endl;
         env.FireDummyTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
         env.InitSchema();
 
+        Cerr << "...restarting tablet" << Endl;
         env.RestartTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
 
@@ -268,7 +416,7 @@ Y_UNIT_TEST_SUITE(Backup) {
             return a.Basename() < b.Basename();
         });
 
-        auto snapshotDir = genDirs.rbegin()->Child("snapshot");
+        auto snapshotDir = genDirs.back().Child("snapshot");
         UNIT_ASSERT_C(snapshotDir.Exists(), "Snapshot dir isn't created");
 
         TVector<TFsPath> tables;
@@ -278,26 +426,53 @@ Y_UNIT_TEST_SUITE(Backup) {
             return path.Basename() == "schema.json";
         });
 
-        UNIT_ASSERT(tables.size() == 3);
+        UNIT_ASSERT(tables.size() == 2);
 
         for (const auto& table : tables) {
             TString content = TFileInput(table).ReadAll();
             UNIT_ASSERT(content.empty());
         }
+
+        auto changelog = genDirs.back().Child("changelog.json");
+        UNIT_ASSERT_C(changelog.Exists(), "Changelog file isn't created");
+
+        TString content = TFileInput(changelog).ReadAll();
+        UNIT_ASSERT(content.empty());
     }
 
     Y_UNIT_TEST(SnapshotData) {
         TEnv env;
 
+        Cerr << "...starting tablet" << Endl;
         env.FireDummyTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
         env.InitSchema();
 
-        env.WriteRow(1, 10);
-        env.WriteRow(2, 11);
-        env.WriteBinaryRow(3, "abcdef");
-        env.WriteCompositePKRow(4, 5, 100);
+        Cerr << "...writing two columns" << Endl;
+        env.WriteValue(1, 10);
+        env.WriteBinaryValue(1, "abcdef");
 
+        Cerr << "...writing two columns simultaneously" << Endl;
+        env.WriteTwoColumns(2, 20, "abcdef");
+
+        Cerr << "...erasing row" << Endl;
+        env.WriteValue(3, 30);
+        env.EraseRow(3);
+
+        Cerr << "...replacing row" << Endl;
+        env.WriteDefaultValue(4, 40);
+        env.ReplaceRow(4, 40);
+
+        Cerr << "...writing different values in one column" << Endl;
+        env.WriteValue(5, 10);
+        env.WriteValue(5, 50);
+
+        Cerr << "...writing composite primary key" << Endl;
+        env.WriteCompositePK(1, 2, 10);
+
+        Cerr << "...restarting tablet" << Endl;
         env.RestartTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
 
@@ -312,7 +487,7 @@ Y_UNIT_TEST_SUITE(Backup) {
             return a.Basename() < b.Basename();
         });
 
-        auto snapshotDir = genDirs.rbegin()->Child("snapshot");
+        auto snapshotDir = genDirs.back().Child("snapshot");
         UNIT_ASSERT_C(snapshotDir.Exists(), "Snapshot dir isn't created");
 
         TVector<TFsPath> tables;
@@ -322,7 +497,7 @@ Y_UNIT_TEST_SUITE(Backup) {
             return path.Basename() == "schema.json";
         });
 
-        UNIT_ASSERT(tables.size() == 3);
+        UNIT_ASSERT(tables.size() == 2);
 
         {
             auto table = snapshotDir.Child("Data.json");
@@ -330,35 +505,35 @@ Y_UNIT_TEST_SUITE(Backup) {
             TString content = TFileInput(table).ReadAll();
             UNIT_ASSERT_VALUES_EQUAL(
                 content,
-                "{\"Key\":1,\"Value\":10}\n"
-                "{\"Key\":2,\"Value\":11}\n"
+                R"({"Key":1,"Value":10,"BinaryValue":"YWJjZGVm","DefaultValue":null})""\n"
+                R"({"Key":2,"Value":20,"BinaryValue":"YWJjZGVm","DefaultValue":null})""\n"
+                R"({"Key":4,"Value":40,"BinaryValue":null,"DefaultValue":null})""\n"
+                R"({"Key":5,"Value":50,"BinaryValue":null,"DefaultValue":null})""\n"
             );
-        }
-
-        {
-            auto table = snapshotDir.Child("BinaryData.json");
-            UNIT_ASSERT_C(table.Exists(), "BinaryData table isn't created");
-            TString content = TFileInput(table).ReadAll();
-            UNIT_ASSERT_VALUES_EQUAL(content, "{\"Key\":3,\"Value\":\"YWJjZGVm\"}\n");
         }
 
         {
             auto table = snapshotDir.Child("CompositePKData.json");
             UNIT_ASSERT_C(table.Exists(), "CompositePKData table isn't created");
             TString content = TFileInput(table).ReadAll();
-            UNIT_ASSERT_VALUES_EQUAL(content, "{\"Key\":4,\"SubKey\":5,\"Value\":100}\n");
+            UNIT_ASSERT_VALUES_EQUAL(content, R"({"Key":1,"SubKey":2,"Value":10})""\n");
         }
     }
 
     Y_UNIT_TEST(SnapshotLargeData) {
         TEnv env;
 
+        Cerr << "...starting tablet" << Endl;
         env.FireDummyTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
         env.InitSchema();
 
+        Cerr << "...writing large data" << Endl;
         env.WriteRange(0, 1'000'000, 42); // 1 million rows
 
+        Cerr << "...restarting tablet" << Endl;
         env.RestartTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
 
@@ -373,7 +548,7 @@ Y_UNIT_TEST_SUITE(Backup) {
             return a.Basename() < b.Basename();
         });
 
-        auto snapshotDir = genDirs.rbegin()->Child("snapshot");
+        auto snapshotDir = genDirs.back().Child("snapshot");
         UNIT_ASSERT_C(snapshotDir.Exists(), "Snapshot dir isn't created");
 
         auto table = snapshotDir.Child("Data.json");
@@ -387,10 +562,14 @@ Y_UNIT_TEST_SUITE(Backup) {
     Y_UNIT_TEST(SnapshotSchema) {
         TEnv env;
 
+        Cerr << "...starting tablet" << Endl;
         env.FireDummyTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
         env.InitSchema();
 
+        Cerr << "...restarting tablet" << Endl;
         env.RestartTablet(TestTabletFlags);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
 
@@ -405,7 +584,7 @@ Y_UNIT_TEST_SUITE(Backup) {
             return a.Basename() < b.Basename();
         });
 
-        auto snapshotDir = genDirs.rbegin()->Child("snapshot");
+        auto snapshotDir = genDirs.back().Child("snapshot");
         UNIT_ASSERT_C(snapshotDir.Exists(), "Snapshot dir isn't created");
 
         TVector<TFsPath> schemaFiles;
@@ -422,8 +601,232 @@ Y_UNIT_TEST_SUITE(Backup) {
 
         TString content = TFileInput(schema).ReadAll();
         UNIT_ASSERT_C(content.Contains("\"table_name\":\"Data\""), "Data table isn't in schema");
-        UNIT_ASSERT_C(content.Contains("\"table_name\":\"BinaryData\""), "BinaryData table isn't in schema");
         UNIT_ASSERT_C(content.Contains("\"table_name\":\"CompositePKData\""), "CompositePKData table isn't in schema");
+    }
+
+    Y_UNIT_TEST(ChangelogData) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...writing two columns" << Endl;
+        env.WriteValue(1, 10);
+        env.WriteBinaryValue(1, "abcdef");
+
+        Cerr << "...writing two columns simultaneously" << Endl;
+        env.WriteTwoColumns(2, 20, "abcdef");
+
+        Cerr << "...erasing row" << Endl;
+        env.WriteValue(3, 30);
+        env.EraseRow(3);
+
+        Cerr << "...replacing row" << Endl;
+        env.WriteDefaultValue(4, 40);
+        env.ReplaceRow(4, 40);
+
+        Cerr << "...writing different values in one column" << Endl;
+        env.WriteValue(5, 10);
+        env.WriteValue(5, 50);
+
+        Cerr << "...writing composite primary key" << Endl;
+        env.WriteCompositePK(1, 2, 10);
+
+        auto tabletIdDir = TFsPath(env->GetTempDir())
+            .Child("dummy")
+            .Child(ToString(env.Tablet));
+
+        TVector<TFsPath> genDirs;
+        tabletIdDir.List(genDirs);
+
+        std::sort(genDirs.begin(), genDirs.end(), [](const TFsPath& a, const TFsPath& b) {
+            return a.Basename() < b.Basename();
+        });
+
+        env.WaitChangelogFlush();
+
+        auto changelog = genDirs.back().Child("changelog.json");
+        UNIT_ASSERT_C(changelog.Exists(), "Changelog file isn't created");
+
+        TString content = TFileInput(changelog).ReadAll();
+        UNIT_ASSERT_VALUES_EQUAL(
+            content,
+            R"({"step":4,"data_changes":[{"table":"Data","op":"upsert","Key":1,"Value":10}]})""\n"
+            R"({"step":5,"data_changes":[{"table":"Data","op":"upsert","Key":1,"BinaryValue":"YWJjZGVm"}]})""\n"
+
+            R"({"step":6,"data_changes":[{"table":"Data","op":"upsert","Key":2,"Value":20,"BinaryValue":"YWJjZGVm"}]})""\n"
+
+            R"({"step":7,"data_changes":[{"table":"Data","op":"upsert","Key":3,"Value":30}]})""\n"
+            R"({"step":8,"data_changes":[{"table":"Data","op":"erase","Key":3}]})""\n"
+
+            R"({"step":9,"data_changes":[{"table":"Data","op":"upsert","Key":4,"DefaultValue":40}]})""\n"
+            R"({"step":10,"data_changes":[{"table":"Data","op":"replace","Key":4,"Value":40}]})""\n"
+
+            R"({"step":11,"data_changes":[{"table":"Data","op":"upsert","Key":5,"Value":10}]})""\n"
+            R"({"step":12,"data_changes":[{"table":"Data","op":"upsert","Key":5,"Value":50}]})""\n"
+
+            R"({"step":13,"data_changes":[{"table":"CompositePKData","op":"upsert","Key":1,"SubKey":2,"Value":10}]})""\n"
+        );
+    }
+
+    Y_UNIT_TEST(ChangelogLargeData) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...writing large data in one commit" << Endl;
+        env.WriteRange(0, 1'000'000, 42); // 1 million rows
+
+        auto tabletIdDir = TFsPath(env->GetTempDir())
+            .Child("dummy")
+            .Child(ToString(env.Tablet));
+
+        TVector<TFsPath> genDirs;
+        tabletIdDir.List(genDirs);
+
+        std::sort(genDirs.begin(), genDirs.end(), [](const TFsPath& a, const TFsPath& b) {
+            return a.Basename() < b.Basename();
+        });
+
+        env.WaitChangelogFlush();
+
+        auto changelog = genDirs.back().Child("changelog.json");
+        UNIT_ASSERT_C(changelog.Exists(), "Changelog file isn't created");
+
+        TString content = TFileInput(changelog).ReadAll();
+        NJson::TJsonValue json;
+        NJson::ReadJsonTree(content, &json);
+
+        UNIT_ASSERT_VALUES_EQUAL(json["step"].GetInteger(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(json["data_changes"].GetArray().size(), 1'000'000);
+    }
+
+    Y_UNIT_TEST(ChangelogManyCommits) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...writing data in many commits" << Endl;
+        TString data(1'000, 'a'); // make commit large enough
+        for (int i = 0; i < 1'000; ++i) {
+            env.WriteBinaryValue(i, data);
+        }
+
+        auto tabletIdDir = TFsPath(env->GetTempDir())
+            .Child("dummy")
+            .Child(ToString(env.Tablet));
+
+        TVector<TFsPath> genDirs;
+        tabletIdDir.List(genDirs);
+
+        std::sort(genDirs.begin(), genDirs.end(), [](const TFsPath& a, const TFsPath& b) {
+            return a.Basename() < b.Basename();
+        });
+
+        env.WaitChangelogFlush();
+
+        auto changelog = genDirs.back().Child("changelog.json");
+        UNIT_ASSERT_C(changelog.Exists(), "Changelog file isn't created");
+
+        TString content = TFileInput(changelog).ReadAll();
+        auto lines = StringSplitter(content).Split('\n').SkipEmpty();
+        UNIT_ASSERT_VALUES_EQUAL(lines.Count(), 1'000);
+    }
+
+    Y_UNIT_TEST(ChangelogSchema) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        auto tabletIdDir = TFsPath(env->GetTempDir())
+            .Child("dummy")
+            .Child(ToString(env.Tablet));
+
+        TVector<TFsPath> genDirs;
+        tabletIdDir.List(genDirs);
+
+        std::sort(genDirs.begin(), genDirs.end(), [](const TFsPath& a, const TFsPath& b) {
+            return a.Basename() < b.Basename();
+        });
+
+        auto changelog = genDirs.back().Child("changelog.json");
+        UNIT_ASSERT_C(changelog.Exists(), "Changelog file isn't created");
+
+        env.WaitChangelogFlush();
+
+        TString content = TFileInput(changelog).ReadAll();
+        NJson::TJsonValue json;
+        NJson::ReadJsonTree(content, &json);
+
+        UNIT_ASSERT_VALUES_EQUAL(json["step"].GetInteger(), 2);
+        UNIT_ASSERT_C(json.Has("schema_changes"), "Schema changes must be in changelog");
+        UNIT_ASSERT_C(!json.Has("data_changes"), "Unexpected data changes in changelog");
+    }
+
+    Y_UNIT_TEST(ChangelogSchemaAndData) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema with migration" << Endl;
+        env.InitSchemaWithMigration();
+
+        auto tabletIdDir = TFsPath(env->GetTempDir())
+            .Child("dummy")
+            .Child(ToString(env.Tablet));
+
+        TVector<TFsPath> genDirs;
+        tabletIdDir.List(genDirs);
+
+        std::sort(genDirs.begin(), genDirs.end(), [](const TFsPath& a, const TFsPath& b) {
+            return a.Basename() < b.Basename();
+        });
+
+        auto changelog = genDirs.back().Child("changelog.json");
+        UNIT_ASSERT_C(changelog.Exists(), "Changelog file isn't created");
+
+        env.WaitChangelogFlush();
+
+        TString content = TFileInput(changelog).ReadAll();
+        NJson::TJsonValue json;
+        NJson::ReadJsonTree(content, &json);
+
+        UNIT_ASSERT_VALUES_EQUAL(json["step"].GetInteger(), 2);
+        UNIT_ASSERT_C(json.Has("schema_changes"), "Schema changes must be in changelog");
+        UNIT_ASSERT_C(json.Has("data_changes"), "Data changes must be in changelog");
     }
 }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds changelog functionality to the system tablet backup feature. The main purpose is to enable tracking of data and schema changes during tablet operations by creating a `changelog.json` file alongside the existing snapshot backup functionality.
