### PR TITLE
Fix DoLockRowTx build

### DIFF
--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -478,6 +478,11 @@ public:
         // ignore
     }
 
+    void DoLockRowTx(ui32, ELockMode, TKeys, ui64)
+    {
+        // ignore
+    }
+
     void Finalize()
     {
         if (HasChanges) {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
In file included from /home/vladilenmuz/ydbwork/ydb/ydb/core/tablet_flat/flat_executor_backup.cpp:5:
/home/vladilenmuz/ydbwork/ydb/ydb/core/tablet_flat/flat_redo_player.h:229:22: error: no member named 'DoLockRowTx' in 'NKikimr::NTabletFlatExecutor::NBackup::TChangelogSerializer'
  229 |                 Base.DoLockRowTx(ev->Table, ev->Mode, KeyVec, ev->TxId);
      |                 ~~~~ ^
/home/vladilenmuz/ydbwork/ydb/ydb/core/tablet_flat/flat_redo_player.h:82:28: note: in instantiation of member function 'NKikimr::NTable::NRedo::TPlayer<NKikimr::NTabletFlatExecutor::NBackup::TChangelogSerializer>::DoLockRowTx' requested here
   82 |                     return DoLockRowTx(chunk);
      |                            ^
/home/vladilenmuz/ydbwork/ydb/ydb/core/tablet_flat/flat_redo_player.h:52:21: note: in instantiation of member function 'NKikimr::NTable::NRedo::TPlayer<NKikimr::NTabletFlatExecutor::NBackup::TChangelogSerializer>::Handle' requested here
   52 |                     Handle(label, chunk);
      |                     ^
/home/vladilenmuz/ydbwork/ydb/ydb/core/tablet_flat/flat_executor_backup.cpp:626:28: note: in instantiation of member function 'NKikimr::NTable::NRedo::TPlayer<NKikimr::NTabletFlatExecutor::NBackup::TChangelogSerializer>::Replay' requested here
  626 |                 redoPlayer.Replay(dataUpdate);
      |                            ^
1 error generated.
Failed
```