### PR TITLE
Reuse common space checks for S3 upload rows

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -4471,25 +4471,6 @@ void TDataShard::Handle(TEvDataShard::TEvStoreS3DownloadInfo::TPtr& ev, const TA
     Execute(new TTxStoreS3DownloadInfo(this, ev), ctx);
 }
 
-void TDataShard::Handle(TEvDataShard::TEvS3UploadRowsRequest::TPtr& ev, const TActorContext& ctx)
-{
-    if (ShouldDelayOperation(ev)) {
-        return;
-    }
-
-    const float rejectProbabilty = Executor()->GetRejectProbability();
-    if (rejectProbabilty > 0) {
-        const float rnd = AppData(ctx)->RandomProvider->GenRandReal2();
-        if (rnd < rejectProbabilty) {
-            DelayedS3UploadRows.emplace_back().Reset(ev.Release());
-            IncCounter(COUNTER_BULK_UPSERT_OVERLOADED);
-            return;
-        }
-    }
-
-    Execute(new TTxS3UploadRows(this, ev), ctx);
-}
-
 void TDataShard::ScanComplete(NTable::EStatus,
                                      TAutoPtr<IDestructable> prod,
                                      ui64 cookie,

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -920,6 +920,15 @@ namespace TEvDataShard {
             Record.SetTabletID(tabletId);
             Record.SetStatus(status);
         }
+
+        bool IsRetriableError() const {
+            Y_ASSERT(Record.GetStatus() != NKikimrTxDataShard::TError::OK);
+            return
+                Record.GetStatus() == NKikimrTxDataShard::TError::WRONG_SHARD_STATE // = Ydb::StatusIds::OVERLOADED
+                || Record.GetStatus() == NKikimrTxDataShard::TError::SHARD_IS_BLOCKED // = Ydb::StatusIds::OVERLOADED
+                || Record.GetStatus() == NKikimrTxDataShard::TError::SCHEME_CHANGED // Ydb::StatusIds::GENERIC_ERROR
+            ;
+        }
     };
 
     struct TEvOverloadReady
@@ -1432,6 +1441,13 @@ namespace TEvDataShard {
         explicit TEvS3UploadRowsResponse(ui64 tabletId, ui32 status = NKikimrTxDataShard::TError::OK) {
             Record.SetTabletID(tabletId);
             Record.SetStatus(status);
+        }
+
+        TEvS3UploadRowsResponse() {}
+
+        bool IsRetriableError() const {
+            return TEvUploadRowsResponse(Record.GetTabletID(), Record.GetStatus())
+                .IsRetriableError();
         }
 
         TString ToString() const override {

--- a/ydb/core/tx/datashard/datashard__op_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__op_rows.cpp
@@ -1,5 +1,6 @@
 #include "datashard_impl.h"
 #include "datashard_direct_transaction.h"
+#include "datashard_txs.h"
 
 namespace NKikimr {
 namespace NDataShard {
@@ -112,48 +113,90 @@ public:
     TTxType GetTxType() const override { return TXTYPE_ERASE_ROWS; }
 };
 
-static void OutOfSpace(NKikimrTxDataShard::TEvUploadRowsResponse& response) {
-    response.SetStatus(NKikimrTxDataShard::TError::OUT_OF_SPACE);
+static void OutOfSpace(TEvDataShard::TEvUploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::OUT_OF_SPACE);
 }
 
-static void DiskSpaceExhausted(NKikimrTxDataShard::TEvUploadRowsResponse& response) {
-    response.SetStatus(NKikimrTxDataShard::TError::DISK_SPACE_EXHAUSTED);
+static void DiskSpaceExhausted(TEvDataShard::TEvUploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::DISK_SPACE_EXHAUSTED);
 }
 
-static void WrongShardState(NKikimrTxDataShard::TEvUploadRowsResponse& response) {
-    response.SetStatus(NKikimrTxDataShard::TError::WRONG_SHARD_STATE);
+static void WrongShardState(TEvDataShard::TEvUploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::WRONG_SHARD_STATE);
 }
 
-static void Replicated(NKikimrTxDataShard::TEvUploadRowsResponse& response) {
-    response.SetStatus(NKikimrTxDataShard::TError::READONLY);
+static void Replicated(TEvDataShard::TEvUploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::READONLY);
 }
 
-static void Overloaded(NKikimrTxDataShard::TEvUploadRowsResponse& response) {
-    response.SetStatus(NKikimrTxDataShard::TError::SHARD_IS_BLOCKED);
+static void Overloaded(TEvDataShard::TEvUploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::SHARD_IS_BLOCKED);
 }
 
 ECumulativeCounters OverloadedCounter(TEvDataShard::TEvUploadRowsRequest::TPtr&) {
     return COUNTER_BULK_UPSERT_OVERLOADED;
 }
 
-static void WrongShardState(NKikimrTxDataShard::TEvEraseRowsResponse& response) {
-    response.SetStatus(NKikimrTxDataShard::TEvEraseRowsResponse::WRONG_SHARD_STATE);
+static bool TryDelayS3UploadRows(TDataShard*, TEvDataShard::TEvUploadRowsRequest::TPtr&, ERejectReasons) {
+    // not a S3 upload rows
+    return false;
 }
 
-static void Replicated(NKikimrTxDataShard::TEvEraseRowsResponse& response) {
-    response.SetStatus(NKikimrTxDataShard::TEvEraseRowsResponse::EXEC_ERROR);
+static void OutOfSpace(TEvDataShard::TEvS3UploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::OUT_OF_SPACE);
 }
 
-static void Overloaded(NKikimrTxDataShard::TEvEraseRowsResponse& response) {
-    response.SetStatus(NKikimrTxDataShard::TEvEraseRowsResponse::SHARD_OVERLOADED);
+static void DiskSpaceExhausted(TEvDataShard::TEvS3UploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::DISK_SPACE_EXHAUSTED);
+}
+
+static void WrongShardState(TEvDataShard::TEvS3UploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::WRONG_SHARD_STATE);
+}
+
+static void Replicated(TEvDataShard::TEvS3UploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::READONLY);
+}
+
+static void Overloaded(TEvDataShard::TEvS3UploadRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TError::SHARD_IS_BLOCKED);
+}
+
+ECumulativeCounters OverloadedCounter(TEvDataShard::TEvS3UploadRowsRequest::TPtr&) {
+    return COUNTER_BULK_UPSERT_OVERLOADED;
+}
+
+static bool TryDelayS3UploadRows(TDataShard* self, TEvDataShard::TEvS3UploadRowsRequest::TPtr& ev, ERejectReasons rejectReasons) {
+    if (rejectReasons == ERejectReasons::OverloadByProbability) {
+        self->DelayS3UploadRows(ev);
+        return true;
+    }
+    return false;
+}
+
+static void WrongShardState(TEvDataShard::TEvEraseRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TEvEraseRowsResponse::WRONG_SHARD_STATE);
+}
+
+static void Replicated(TEvDataShard::TEvEraseRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TEvEraseRowsResponse::EXEC_ERROR);
+}
+
+static void Overloaded(TEvDataShard::TEvEraseRowsResponse& response) {
+    response.Record.SetStatus(NKikimrTxDataShard::TEvEraseRowsResponse::SHARD_OVERLOADED);
 }
 
 ECumulativeCounters OverloadedCounter(TEvDataShard::TEvEraseRowsRequest::TPtr&) {
     return COUNTER_ERASE_ROWS_OVERLOADED;
 }
 
+static bool TryDelayS3UploadRows(TDataShard*, TEvDataShard::TEvEraseRowsRequest::TPtr&, ERejectReasons) {
+    // not a S3 upload rows
+    return false;
+}
+
 template <typename TEvResponse>
-using TSetStatusFunc = void(*)(typename TEvResponse::ProtoRecordType&);
+using TSetStatusFunc = void(*)(TEvResponse&);
 
 template <typename TEvResponse, typename TEvRequest>
 static void Reject(TDataShard* self, TEvRequest& ev, const TString& txDesc,
@@ -166,7 +209,7 @@ static void Reject(TDataShard* self, TEvRequest& ev, const TString& txDesc,
         << ", error# " << rejectDescription);
 
     auto response = MakeHolder<TEvResponse>();
-    setStatusFunc(response->Record);
+    setStatusFunc(*response);
     response->Record.SetTabletID(self->TabletID());
     response->Record.SetErrorDescription(rejectDescription);
 
@@ -191,6 +234,13 @@ static bool MaybeReject(TDataShard* self, TEvRequest& ev, const TActorContext& c
     NKikimrTxDataShard::TEvProposeTransactionResult::EStatus rejectStatus;
     if (self->CheckDataTxReject(txDesc, ctx, rejectStatus, rejectReasons, rejectDescription)) {
         self->IncCounter(OverloadedCounter(ev));
+
+        // FIXME: it seems that s3 upload should work via TUploadRowsInternal
+        // this will deduplicate code and support overload subscribed
+        if (TryDelayS3UploadRows(self, ev, rejectReasons)) {
+            return true;
+        }
+
         Reject<TEvResponse, TEvRequest>(self, ev, txDesc, rejectReasons, rejectDescription, &WrongShardState, ctx, logThrottlerType);
         return true;
     }
@@ -229,6 +279,16 @@ void TDataShard::Handle(TEvDataShard::TEvUploadRowsRequest::TPtr& ev, const TAct
     
     if (!MaybeReject<TEvDataShard::TEvUploadRowsResponse, true>(this, ev, ctx, "bulk upsert", TDataShard::ELogThrottlerType::UploadRows_Reject)) {
         Executor()->Execute(new TTxUploadRows(this, ev), ctx);
+    }
+}
+
+void TDataShard::Handle(TEvDataShard::TEvS3UploadRowsRequest::TPtr& ev, const TActorContext& ctx) {
+    if (ShouldDelayOperation(ev)) {
+        return;
+    }
+
+    if (!MaybeReject<TEvDataShard::TEvS3UploadRowsResponse, true>(this, ev, ctx, "s3 bulk upsert", TDataShard::ELogThrottlerType::S3UploadRows_Reject)) {
+        Executor()->Execute(new TTxS3UploadRows(this, ev), ctx);
     }
 }
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1838,6 +1838,7 @@ public:
     void ScanComplete(NTable::EStatus status, TAutoPtr<IDestructable> prod, ui64 cookie, const TActorContext &ctx) override;
     bool ReassignChannelsEnabled() const override;
     void OnYellowChannelsChanged() override;
+    void DelayS3UploadRows(TEvDataShard::TEvS3UploadRowsRequest::TPtr& ev);
     void OnRejectProbabilityRelaxed() override;
     void OnFollowersCountChanged() override;
     ui64 GetMemoryUsage() const override;
@@ -2189,6 +2190,7 @@ public:
         FinishProposeUnit_UpdateCounters,
         UploadRows_Reject,
         EraseRows_Reject,
+        S3UploadRows_Reject,
 
         LAST
     };

--- a/ydb/core/tx/datashard/datashard_overload.cpp
+++ b/ydb/core/tx/datashard/datashard_overload.cpp
@@ -8,6 +8,10 @@ void TDataShard::OnYellowChannelsChanged() {
     }
 }
 
+void TDataShard::DelayS3UploadRows(TEvDataShard::TEvS3UploadRowsRequest::TPtr& ev) {
+    DelayedS3UploadRows.emplace_back().Reset(ev.Release());
+}
+
 void TDataShard::OnRejectProbabilityRelaxed() {
     NotifyOverloadSubscribers(ERejectReason::OverloadByProbability);
     for (auto& ev : DelayedS3UploadRows) {

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -2375,7 +2375,7 @@ value {
         env.TestWaitNotification(runtime, txId);
 
         const ui32 expected = data.Data.size() / batchSize + ui32(bool(data.Data.size() % batchSize));
-        UNIT_ASSERT(requests > expected);
+        UNIT_ASSERT_C(requests > expected, TStringBuilder() << "Expected to get more than " << expected << " requests, but got only " << requests);
         UNIT_ASSERT_VALUES_EQUAL(responses, expected);
 
         auto content = ReadTable(runtime, TTestTxConfig::FakeHiveTablets, "Table", {"key"}, {"key", "value"});

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -1262,11 +1262,7 @@ private:
                 }
             }
 
-            bool isRetryableError = shardResponse.GetStatus() == NKikimrTxDataShard::TError::WRONG_SHARD_STATE ||
-                shardResponse.GetStatus() == NKikimrTxDataShard::TError::SHARD_IS_BLOCKED ||
-                shardResponse.GetStatus() == NKikimrTxDataShard::TError::SCHEME_CHANGED;
-
-            if (!isRetryableError || !Backoff.HasMore()) {
+            if (!ev->Get()->IsRetriableError() || !Backoff.HasMore()) {
                 return ReplyWithError(
                     TUploadStatus(static_cast<NKikimrTxDataShard::TError::EKind>(shardResponse.GetStatus()),
                     shardResponse.GetErrorDescription()), ctx);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Overall, it seems that having a separate S3 upload rows is a mistake because it doesn't handle overload subscribed (and before this PR hasn't handled replicated and out of space), but it requires a huge refactoring I'm not going to do right now.
