### PR TITLE
Fix state storage replicas selection

### DIFF
--- a/ydb/core/base/statestorage.cpp
+++ b/ydb/core/base/statestorage.cpp
@@ -75,9 +75,9 @@ void TStateStorageInfo::SelectReplicas(ui64 tabletId, TSelection *selection, ui3
             selection->SelectedReplicas[idx] = ringGroup.Rings[idx].SelectReplica(hash);
         }
     } else { // NToSelect < total, first - select rings with walker, then select concrete node
-        TStateStorageRingWalker walker(hash, total);
-        for (ui32 idx : xrange(ringGroup.NToSelect))
-            selection->SelectedReplicas[idx] = ringGroup.Rings[walker.Next()].SelectReplica(hash);
+        for (ui32 idx = 0; ui32 ringIdx : TStateStorageRingWalker::Select(hash, total, ringGroup.NToSelect)) {
+            selection->SelectedReplicas[idx++] = ringGroup.Rings[ringIdx].SelectReplica(hash);
+        }
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix duplicated replicas selection when bad state storage config (nToSelect = 5, ringsCount = 9) applied
[Issue](https://st.yandex-team.ru/SPI-162924)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
