### PR TITLE
prestable-25-4: MKQL_RUNTIME_VERSION=67u

### DIFF
--- a/yql/essentials/minikql/mkql_runtime_version.h
+++ b/yql/essentials/minikql/mkql_runtime_version.h
@@ -24,7 +24,7 @@ namespace NMiniKQL {
 // 1. Bump this version every time incompatible runtime nodes are introduced.
 // 2. Make sure you provide runtime node generation for previous runtime versions.
 #ifndef MKQL_RUNTIME_VERSION
-#define MKQL_RUNTIME_VERSION 59U
+#define MKQL_RUNTIME_VERSION 67U
 #endif
 
 // History:


### PR DESCRIPTION
As it was in main before stable-25-3 branching