### PR TITLE
[stable-25-2] NBS-6427 IGNIETFERRO-1843: backport openssl/grpc crash fix from trunk

### DIFF
--- a/library/cpp/openssl/init/init.cpp
+++ b/library/cpp/openssl/init/init.cpp
@@ -1,66 +1,13 @@
-#include "init.h"
-
-#include <util/generic/singleton.h>
-#include <util/generic/vector.h>
-#include <util/generic/ptr.h>
-#include <util/generic/buffer.h>
-
-#include <util/system/yassert.h>
-#include <util/system/mutex.h>
-#include <util/system/thread.h>
-
-#include <util/random/entropy.h>
-#include <util/stream/input.h>
-
-#include <openssl/bio.h>
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-#include <openssl/rand.h>
-#include <openssl/conf.h>
 #include <openssl/crypto.h>
 
 namespace {
-    struct TInitSsl {
-        struct TOpensslLocks {
-            inline TOpensslLocks()
-                : Mutexes(CRYPTO_num_locks())
-            {
-                for (auto& mpref : Mutexes) {
-                    mpref.Reset(new TMutex());
-                }
-            }
-
-            inline void LockOP(int mode, int n) {
-                auto& mutex = *Mutexes.at(n);
-
-                if (mode & CRYPTO_LOCK) {
-                    mutex.Acquire();
-                } else {
-                    mutex.Release();
-                }
-            }
-
-            TVector<TAutoPtr<TMutex>> Mutexes;
-        };
-
-        inline TInitSsl() {
-            OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, nullptr);
-        }
-
-        inline ~TInitSsl() {
-            OPENSSL_cleanup();
-        }
-
-        static void LockingFunction(int mode, int n, const char* /*file*/, int /*line*/) {
-            Singleton<TOpensslLocks>()->LockOP(mode, n);
-        }
-
-        static unsigned long ThreadIdFunction() {
-            return TThread::CurrentThreadId();
-        }
-    };
+    // Initialize OpenSSL as early as possible
+    // in order to prevent any further initializations with different flags.
+    //
+    // Initialize it with OPENSSL_INIT_NO_ATEXIT thus omitting the cleanup routine at process exit
+    // (it looks like it does nothing when openssl is linked statically).
+    [[maybe_unused]] auto _ = OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN | OPENSSL_INIT_NO_ATEXIT, nullptr);
 }
 
 void InitOpenSSL() {
-    (void)SingletonWithPriority<TInitSsl, 0>();
 }

--- a/library/cpp/openssl/init/ya.make
+++ b/library/cpp/openssl/init/ya.make
@@ -5,7 +5,7 @@ PEERDIR(
 )
 
 SRCS(
-    init.cpp
+    GLOBAL init.cpp
 )
 
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Partial backport from main. Fixed crash by grpc, that happens on application exit. Affects NBS project.

```
#0 pthread_rwlock_unlock () from /lib/x86_64-linux-gnu/libpthread.so.0
#1 CRYPTO_THREAD_unlock (lock=0x0) at  contrib/libs/openssl/crypto/threads_pthread.c +91
#2 CRYPTO_free_ex_data (class_index=9, obj=0x163c7f8084b0, ad=0x163c7f808518) at  contrib/libs/openssl/crypto/ex_data.c +342
#3 RSA_free (r=0x163c7f8084b0) at  contrib/libs/openssl/crypto/rsa/rsa_lib.c +124
#4 EVP_PKEY_free_it (x=0x163c7e95c660) at  contrib/libs/openssl/crypto/evp/p_lib.c +622
#5 EVP_PKEY_free (x=0x163c7e95c660) at  contrib/libs/openssl/crypto/evp/p_lib.c +612
#6 pubkey_cb (operation=<optimized out>, pval=0x55c90bc61da0 <do_ex_data_init_ossl_>, it=<optimized out>, exarg=<optimized out>) at  contrib/libs/openssl/crypto/x509/x_pubkey.c +34
#7 asn1_item_embed_free (pval=0x163c7f6498b0, it=0x55c922bd86c8 <v1_X509_PUBKEY_it>, embed=0) at  contrib/libs/openssl/crypto/asn1/tasn_fre.c +113
#8 asn1_template_free (pval=0x0, tt=tt@entry=0x55c922bdae50 <X509_CINF_seq_tt+240>) at  contrib/libs/openssl/crypto/asn1/tasn_fre.c +142
#9 asn1_item_embed_free (pval=0x7f17b0f250e8, it=0x55c922bdaef0 <v1_X509_CINF_it>, embed=4096) at  contrib/libs/openssl/crypto/asn1/tasn_fre.c +110
#10 asn1_template_free (pval=0x0, tt=tt@entry=0x55c922bdaf30 <X509_seq_tt>) at  contrib/libs/openssl/crypto/asn1/tasn_fre.c +142
#11 asn1_item_embed_free (pval=0x7f17b0f25180, it=0x55c922bdafd0 <v1_X509_it>, embed=0) at  contrib/libs/openssl/crypto/asn1/tasn_fre.c +110
#12 ASN1_item_free (val=0x163c7f649860, it=0x55c90bc61da0 <do_ex_data_init_ossl_>) at  contrib/libs/openssl/crypto/asn1/tasn_fre.c +20
#13 x509_object_free_internal (a=0x163c7fa0b430) at  contrib/libs/openssl/crypto/x509/x509_lu.c +438
#14 X509_OBJECT_free (a=0x163c7fa0b430) at  contrib/libs/openssl/crypto/x509/x509_lu.c +470
#15 OPENSSL_sk_pop_free (st=0x163c7e2052e0, func=0x55c90bd90670 <X509_OBJECT_free>) at  contrib/libs/openssl/crypto/stack/stack.c +368
#16 sk_X509_OBJECT_pop_free (sk=0x0, freefunc=0x55c90bc61da0 <do_ex_data_init_ossl_>) at  contrib/libs/openssl/include/openssl/x509_vfy.h +59
#17 X509_STORE_free (vfy=0x163c7fd03700) at  contrib/libs/openssl/crypto/x509/x509_lu.c +225
#18 SSL_CTX_free (a=0x163c7e8a3280) at  contrib/libs/openssl/ssl/ssl_lib.c +3360
#19 tsi_ssl_client_handshaker_factory_destroy (factory=0x163c7fcb1500) at  contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc +1749
#20 tsi_ssl_handshaker_factory_destroy (factory=0x0) at  contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc +1124
#21 tsi_ssl_handshaker_factory_unref (factory=0x0) at  contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc +1143
#22 tsi_ssl_client_handshaker_factory_unref (factory=0x0) at  contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc +1741
#23 (anonymous namespace)::grpc_ssl_channel_security_connector::~grpc_ssl_channel_security_connector (this=0x163c7f58d200) at  contrib/libs/grpc/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc +100
#24 (anonymous namespace)::grpc_ssl_channel_security_connector::~grpc_ssl_channel_security_connector (this=0x0) at  contrib/libs/grpc/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc +99
#25 grpc_core::ChannelArgs::Pointer::~Pointer (this=0x55c90bc61da0 <do_ex_data_init_ossl_>) at  contrib/libs/grpc/src/core/lib/channel/channel_args.h +245
#26 std::__y1::__variant_detail::__alt<2ul, grpc_core::ChannelArgs::Pointer>::~__alt (this=0x55c90bc61da0 <do_ex_data_init_ossl_>) at  contrib/libs/cxxsupp/libcxx/include/variant +661
#27 std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy[abi:ne190000]()::{lambda(auto:1&)#1}::operator()<std::__y1::__variant_detail::__alt<2ul, grpc_core::ChannelArgs::Pointer> >(std::__y1::__variant_detail::__alt<2ul, grpc_core::ChannelArgs::Pointer>&) const (__alt=..., this=<optimized out>) at  contrib/libs/cxxsupp/libcxx/include/variant +777
#28 std::__y1::__invoke[abi:ne190000]<std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy[abi:ne190000]()::{lambda(auto:1&)#1}, std::__y1::__variant_detail::__alt<2ul, grpc_core::ChannelArgs::Pointer>&> (__args=..., __f=...) at  contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h +150
#29 std::__y1::__variant_detail::__visitation::__base::__dispatcher<2ul>::__dispatch[abi:ne190000]<std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy[abi:ne190000]()::{lambda(auto:1&)#1}&&, std::__y1::__variant_detail::__base<(std::__y1::__variant_detail::_Trait)1, int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>&>(std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy[abi:ne190000]()::{lambda(auto:1&)#1}&&, std::__y1::__variant_detail::__base<(std::__y1::__variant_detail::_Trait)1, int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>&) (__f=..., __vs=...) at /opt/buildagent/work/4ec98910e7d
 e170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/variant +537
#30 std::__y1::__variant_detail::__visitation::__base::__visit_alt[abi:ne190000]<std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy[abi:ne190000]()::{lambda(auto:1&)#1}, std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>&>(std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy[abi:ne190000]()::{lambda(auto:1&)#1}&&, std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>
 &) (__visitor=..., __vs=...) at  contrib/libs/cxxsupp/libcxx/include/variant +505
#31 std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::__destroy[abi:ne190000]() (this=0x55c90bc61da0 <do_ex_data_init_ossl_>) at  contrib/libs/cxxsupp/libcxx/include/variant +777
#32 std::__y1::__variant_detail::__dtor<std::__y1::__variant_detail::__traits<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>, (std::__y1::__variant_detail::_Trait)1>::~__dtor (this=0x55c90bc61da0 <do_ex_data_init_ossl_>) at  contrib/libs/cxxsupp/libcxx/include/variant +777
#33 std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer>::~variant[abi:ne190000]() (this=0x55c90bc61da0 <do_ex_data_init_ossl_>) at  contrib/libs/cxxsupp/libcxx/include/variant +1212
#34 std::__y1::pair<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::~pair (this=0x163c7fb80e28) at  contrib/libs/cxxsupp/libcxx/include/__utility/pair.h +63
#35 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node::~Node (this=0x163c7fb80e18) at  contrib/libs/grpc/src/core/lib/avl/avl.h +91
#36 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy[abi:ne190000](grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node*) (__p=0x163c7fb80e18, this=<optimized out>) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h +170
#37 _ZNSt4__y116allocator_traitsINS_9allocatorIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS7_NS2_11ChannelArgs7PointerEEEEE4NodeEEEE7destroyB8ne190000ISD_TnNS_9enable_ifIXsr13__has_destroyISE_PT_EE5valueEiE4typeELi0EEEvRSE_SJ_ (__p=0x163c7fb80e18, __a=...) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h +334
#38 _ZNSt4__y120__shared_ptr_emplaceIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS6_NS1_11ChannelArgs7PointerEEEEE4NodeENS_9allocatorISC_EEE21__on_zero_shared_implB8ne190000ISE_TnNS_9enable_ifIXntsr7is_sameINT_10value_typeENS_19__for_overwrite_tagEEE5valueEiE4typeELi0EEEvv (this=0x163c7fb80e00) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +315
#39 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::__on_zero_shared (this=0x163c7fb80e00) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +318
#40 std::__y1::__shared_count::__release_shared[abi:ne190000]() (this=0x163c7fb80e00) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +171
#41 std::__y1::__shared_weak_count::__release_shared[abi:ne190000]() (this=0x163c7fb80e00) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +217
#42 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr[abi:ne190000]() (this=0x163c7fb91df8) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +682
#43 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node::~Node (this=0x163c7fb91dc8) at  contrib/libs/grpc/src/core/lib/avl/avl.h +91
#44 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy[abi:ne190000](grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node*) (__p=0x163c7fb91dc8, this=<optimized out>) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h +170
#45 _ZNSt4__y116allocator_traitsINS_9allocatorIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS7_NS2_11ChannelArgs7PointerEEEEE4NodeEEEE7destroyB8ne190000ISD_TnNS_9enable_ifIXsr13__has_destroyISE_PT_EE5valueEiE4typeELi0EEEvRSE_SJ_ (__p=0x163c7fb91dc8, __a=...) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h +334
#46 _ZNSt4__y120__shared_ptr_emplaceIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS6_NS1_11ChannelArgs7PointerEEEEE4NodeENS_9allocatorISC_EEE21__on_zero_shared_implB8ne190000ISE_TnNS_9enable_ifIXntsr7is_sameINT_10value_typeENS_19__for_overwrite_tagEEE5valueEiE4typeELi0EEEvv (this=0x163c7fb91db0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +315
#47 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::__on_zero_shared (this=0x163c7fb91db0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +318
#48 std::__y1::__shared_count::__release_shared[abi:ne190000]() (this=0x163c7fb91db0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +171
#49 std::__y1::__shared_weak_count::__release_shared[abi:ne190000]() (this=0x163c7fb91db0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +217
#50 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr[abi:ne190000]() (this=0x163c7fb8e2f8) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +682
#51 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node::~Node (this=0x163c7fb8e2b8) at  contrib/libs/grpc/src/core/lib/avl/avl.h +91
#52 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy[abi:ne190000](grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node*) (__p=0x163c7fb8e2b8, this=<optimized out>) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h +170
#53 _ZNSt4__y116allocator_traitsINS_9allocatorIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS7_NS2_11ChannelArgs7PointerEEEEE4NodeEEEE7destroyB8ne190000ISD_TnNS_9enable_ifIXsr13__has_destroyISE_PT_EE5valueEiE4typeELi0EEEvRSE_SJ_ (__p=0x163c7fb8e2b8, __a=...) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h +334
#54 _ZNSt4__y120__shared_ptr_emplaceIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS6_NS1_11ChannelArgs7PointerEEEEE4NodeENS_9allocatorISC_EEE21__on_zero_shared_implB8ne190000ISE_TnNS_9enable_ifIXntsr7is_sameINT_10value_typeENS_19__for_overwrite_tagEEE5valueEiE4typeELi0EEEvv (this=0x163c7fb8e2a0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +315
#55 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::__on_zero_shared (this=0x163c7fb8e2a0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +318
#56 std::__y1::__shared_count::__release_shared[abi:ne190000]() (this=0x163c7fb8e2a0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +171
#57 std::__y1::__shared_weak_count::__release_shared[abi:ne190000]() (this=0x163c7fb8e2a0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +217
#58 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr[abi:ne190000]() (this=0x163c7fb8f398) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +682
#59 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node::~Node (this=0x163c7fb8f358) at  contrib/libs/grpc/src/core/lib/avl/avl.h +91
#60 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy[abi:ne190000](grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node*) (__p=0x163c7fb8f358, this=<optimized out>) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h +170
#61 _ZNSt4__y116allocator_traitsINS_9allocatorIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS7_NS2_11ChannelArgs7PointerEEEEE4NodeEEEE7destroyB8ne190000ISD_TnNS_9enable_ifIXsr13__has_destroyISE_PT_EE5valueEiE4typeELi0EEEvRSE_SJ_ (__p=0x163c7fb8f358, __a=...) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h +334
#62 _ZNSt4__y120__shared_ptr_emplaceIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS6_NS1_11ChannelArgs7PointerEEEEE4NodeENS_9allocatorISC_EEE21__on_zero_shared_implB8ne190000ISE_TnNS_9enable_ifIXntsr7is_sameINT_10value_typeENS_19__for_overwrite_tagEEE5valueEiE4typeELi0EEEvv (this=0x163c7fb8f340) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +315
#63 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::__on_zero_shared (this=0x163c7fb8f340) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +318
#64 std::__y1::__shared_count::__release_shared[abi:ne190000]() (this=0x163c7fb8f340) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +171
#65 std::__y1::__shared_weak_count::__release_shared[abi:ne190000]() (this=0x163c7fb8f340) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +217
#66 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr[abi:ne190000]() (this=0x163c7fb8d788) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +682
#67 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node::~Node (this=0x163c7fb8d758) at  contrib/libs/grpc/src/core/lib/avl/avl.h +91
#68 std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::destroy[abi:ne190000](grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node*) (__p=0x163c7fb8d758, this=<optimized out>) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h +170
#69 _ZNSt4__y116allocator_traitsINS_9allocatorIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS7_NS2_11ChannelArgs7PointerEEEEE4NodeEEEE7destroyB8ne190000ISD_TnNS_9enable_ifIXsr13__has_destroyISE_PT_EE5valueEiE4typeELi0EEEvRSE_SJ_ (__p=0x163c7fb8d758, __a=...) at  contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h +334
#70 _ZNSt4__y120__shared_ptr_emplaceIN9grpc_core3AVLI12TBasicStringIcNS_11char_traitsIcEEENS_7variantIJiS6_NS1_11ChannelArgs7PointerEEEEE4NodeENS_9allocatorISC_EEE21__on_zero_shared_implB8ne190000ISE_TnNS_9enable_ifIXntsr7is_sameINT_10value_typeENS_19__for_overwrite_tagEEE5valueEiE4typeELi0EEEvv (this=0x163c7fb8d740) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +315
#71 std::__y1::__shared_ptr_emplace<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node, std::__y1::allocator<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node> >::__on_zero_shared (this=0x163c7fb8d740) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +318
#72 std::__y1::__shared_count::__release_shared[abi:ne190000]() (this=0x163c7fb8d740) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +171
#73 std::__y1::__shared_weak_count::__release_shared[abi:ne190000]() (this=0x163c7fb8d740) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +217
#74 std::__y1::shared_ptr<grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::Node>::~shared_ptr[abi:ne190000]() (this=0x163c7f9044a0) at  contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h +682
#75 grpc_core::AVL<TBasicString<char, std::__y1::char_traits<char> >, std::__y1::variant<int, TBasicString<char, std::__y1::char_traits<char> >, grpc_core::ChannelArgs::Pointer> >::~AVL (this=0x163c7f9044a0) at  contrib/libs/grpc/src/core/lib/avl/avl.h +31
#76 grpc_core::ChannelArgs::~ChannelArgs (this=0x163c7f9044a0) at  contrib/libs/grpc/src/core/lib/channel/channel_args.cc +71
#77 grpc_core::SubchannelKey::~SubchannelKey (this=0x163c7f904418) at  contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel_pool_interface.h +43
#78 grpc_core::Subchannel::~Subchannel (this=0x163c7f904400) at  contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc +651
#79 grpc_core::Subchannel::~Subchannel (this=0x0) at  contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc +640
#80 grpc_core::DualRefCounted<grpc_core::Subchannel>::WeakUnref (this=0x0) at  contrib/libs/grpc/src/core/lib/gprpp/dual_ref_counted.h +179
#81 grpc_core::WeakRefCountedPtr<grpc_core::Subchannel>::reset (this=0x163c7ec0b380, value=0x0) at  contrib/libs/grpc/src/core/lib/gprpp/ref_counted_ptr.h +254
#82 grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20240722::Status)::$_0::operator()() (this=<optimized out>) at  contrib/libs/grpc/src/core/ext/filters/client_channel/subchannel.cc +913
#83 std::__y1::__invoke[abi:ne190000]<grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20240722::Status)::$_0&> (__f=...) at  contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h +150
#84 std::__y1::invoke[abi:ne190000]<grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20240722::Status)::$_0&>(grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20240722::Status)::$_0&) (__f=...) at  contrib/libs/cxxsupp/libcxx/include/__functional/invoke.h +28
#85 y_absl::lts_y_20240722::internal_any_invocable::InvokeR<void, grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20240722::Status)::$_0&, , void>(grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20240722::Status)::$_0&) (f=...) at  contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h +132
#86 y_absl::lts_y_20240722::internal_any_invocable::LocalInvoker<false, void, grpc_core::Subchannel::OnConnectingFinishedLocked(y_absl::lts_y_20240722::Status)::$_0&>(y_absl::lts_y_20240722::internal_any_invocable::TypeErasedState*) (state=0x163c7ec0b380) at  contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h +310
#87 y_absl::lts_y_20240722::internal_any_invocable::Impl<void ()>::operator()() (this=0x163c7ec0b380) at  contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h +868
#88 grpc_event_engine::experimental::PosixEventEngine::ClosureData::Run (this=0x163c7ec0b370) at  contrib/libs/grpc/src/core/lib/event_engine/posix_engine/posix_engine.cc +413
#89 y_absl::lts_y_20240722::internal_any_invocable::Impl<void ()>::operator()() (this=0x7f17b0f25560) at  contrib/restricted/abseil-cpp-tstring/y_absl/functional/internal/any_invocable.h +868
#90 grpc_event_engine::experimental::ThreadPool::Queue::Step (this=0x163c7ec0c8e8) at  contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc +170
#91 grpc_event_engine::experimental::ThreadPool::ThreadFunc (state=...) at  contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc +140
#92 grpc_event_engine::experimental::ThreadPool::StartThread(std::__y1::shared_ptr<grpc_event_engine::experimental::ThreadPool::State>, grpc_event_engine::experimental::ThreadPool::StartThreadReason)::$_0::operator()(void*) const (arg=<optimized out>, this=<optimized out>) at  contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc +132
#93 grpc_event_engine::experimental::ThreadPool::StartThread(std::__y1::shared_ptr<grpc_event_engine::experimental::ThreadPool::State>, grpc_event_engine::experimental::ThreadPool::StartThreadReason)::$_0::__invoke(void*) (arg=<optimized out>) at  contrib/libs/grpc/src/core/lib/event_engine/thread_pool.cc +113
#94 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::operator()(void*) const (v=<optimized out>, this=<optimized out>) at  contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc +135
#95 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::{lambda(void*)#1}::__invoke(void*) (v=<optimized out>) at  contrib/libs/grpc/src/core/lib/gprpp/posix/thd.cc +117
#96 start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#97 clone () from /lib/x86_64-linux-gnu/libc.so.6
```

...
