### PR TITLE
Make failures in keyvalue/ut_trace more verbose

### DIFF
--- a/ydb/core/keyvalue/keyvalue_ut_trace.cpp
+++ b/ydb/core/keyvalue/keyvalue_ut_trace.cpp
@@ -111,7 +111,7 @@ void TestOneWrite(TString value, TVector<TString> &&expectedTraceVariants) {
         }
     );
 
-    UNIT_ASSERT(oneIsGood);
+    UNIT_ASSERT_C(oneIsGood, env.WilsonUploader->PrintTraces());
 }
 
 void TestOneRead(TString value, TString expectedTrace) {
@@ -134,7 +134,8 @@ void TestOneRead(TString value, TString expectedTrace) {
             return trace.ToString() == expectedTrace;
         }
     );
-    UNIT_ASSERT(oneIsGood);
+
+    UNIT_ASSERT_C(oneIsGood, env.WilsonUploader->PrintTraces());
 }
 
 Y_UNIT_TEST_SUITE(TKeyValueTracingTest) {

--- a/ydb/library/actors/wilson/test_util/fake_wilson_uploader.h
+++ b/ydb/library/actors/wilson/test_util/fake_wilson_uploader.h
@@ -162,6 +162,14 @@ namespace NWilson {
 
     public:
         std::unordered_map<TString, Trace> Traces;
+
+        TString PrintTraces() const {
+            TStringStream str;
+            for (const auto& [_, trace] : Traces) {
+                str << "{ " << trace.ToString() << " } ";
+            }
+            return str.Str();
+        }
     };
 
 } // NWilson


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Small follow-up for https://github.com/ydb-platform/ydb/pull/26430

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
