### PR TITLE
SharedCache: refactor page counters and persist PageCollection pointer

### DIFF
--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
@@ -1841,22 +1841,19 @@ Y_UNIT_TEST_SUITE(TSharedPageCache_Actor) {
         });
         sharedCache.Provide(sharedCache.Collection2, {0, 1, 2, 3}, TRY_KEEP_IN_MEMORY_PRELOAD_COOKIE);
         sharedCache.CheckResults({
-            TFetch{0, sharedCache.Collection2, {2, 3}}
+            TFetch{0, sharedCache.Collection2, {0, 1, 2, 3}}
         });
 
         // collection#1 pages has reads and prioritized, read collection#2 again to evict their pages
         sharedCache.Request(sharedCache.Sender1, sharedCache.Collection2, {0, 1, 2, 3});
-        sharedCache.CheckFetches({
-            TFetch{20, sharedCache.Collection2, {0, 1}}
-        });
-        sharedCache.Provide(sharedCache.Collection2, {0, 1});
+        sharedCache.CheckFetches({});
         sharedCache.CheckResults({
             TFetch{fetchNo++, sharedCache.Collection2, {0, 1, 2, 3}}
         });
         sharedCache.Wakeup();
 
-        UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->CacheHitPages->Val(), cacheHits += 2);
-        UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->CacheMissPages->Val(), cacheMisses += 2);
+        UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->CacheHitPages->Val(), cacheHits += 4);
+        UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->CacheMissPages->Val(), cacheMisses);
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->ActivePages->Val(), 0);
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->PassivePages->Val(), 2);
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->TargetInMemoryBytes->Val(), collection1TotalSize + collection2TotalSize);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- save PageCollection pointer in TCollection along with InMemoryOwners
- account `sizeof(TPage)` in  LoadInFlyBytes
- small changes in Add/Remove*Page functions
