### PR TITLE
SET NOT NULL in SchemeShard

### DIFF
--- a/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
+++ b/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
@@ -914,7 +914,7 @@ public:
         return tablePromise.GetFuture();
     }
 
-    TFuture<TGenericResult> SetConstraint(const TString&, TVector<NYql::TSetColumnConstraintSettings>&&) override {
+    TFuture<TGenericResult> SetColumnConstraints(const TString&, TVector<NYql::TSetColumnConstraintSettings>&&) override {
         return NotImplemented<TGenericResult>();
     }
 

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -659,7 +659,7 @@ public:
         return Gateway->LoadTableMetadata(cluster, table, settings);
     }
 
-    TFuture<TGenericResult> SetConstraint(const TString& tablePath, TVector<TSetColumnConstraintSettings>&& settings) override {
+    TFuture<TGenericResult> SetColumnConstraints(const TString& tablePath, TVector<TSetColumnConstraintSettings>&& settings) override {
         try {
             auto [dirname, tableName] = NSchemeHelpers::SplitPathByDirAndBaseNames(tablePath);
 
@@ -682,7 +682,7 @@ public:
             NKikimrSchemeOp::TModifyScheme modifyScheme;
             *modifyScheme.MutableSetColumnConstraintsInitiate() = std::move(setColumnConstraintsInitiate);
             modifyScheme.SetWorkingDir(std::move(dirname));
-            modifyScheme.SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraintInitiate);
+            modifyScheme.SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsInitiate);
 
             return Gateway->ModifyScheme(std::move(modifyScheme));
         }

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -1843,7 +1843,7 @@ public:
                             if (value == "drop_not_null") {
                                 alter_columns->set_not_null(false);
                             } else if (value == "set_not_null") {
-                                if (!SessionCtx->Config().FeatureFlags.GetEnableSetColumnConstraint()) {
+                                if (!SessionCtx->Config().FeatureFlags.GetEnableSetColumnConstraints()) {
                                     ctx.AddError(TIssue(ctx.GetPosition(constraintsList.Pos()), TStringBuilder()
                                         << "SET NOT NULL is currently not supported."));
                                     return SyncError();
@@ -2393,10 +2393,10 @@ public:
             NThreading::TFuture<IKikimrGateway::TGenericResult> future;
             bool isTableStore = (table.Metadata->TableType == ETableType::TableStore);  // Doesn't set, so always false
             bool isColumn = (table.Metadata->StoreType == EStoreType::Column);
-            bool isSetConstraint = (!constraintSetObjects.empty());
+            bool isSetColumnConstraints = (!constraintSetObjects.empty());
 
-            if (isSetConstraint) {
-                future = Gateway->SetConstraint(table.Metadata->Name, std::move(constraintSetObjects));
+            if (isSetColumnConstraints) {
+                future = Gateway->SetColumnConstraints(table.Metadata->Name, std::move(constraintSetObjects));
             } else if (isTableStore) {
                 AFL_VERIFY(false);
                 if (!isColumn) {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -1252,7 +1252,7 @@ public:
     virtual NThreading::TFuture<TTableMetadataResult> LoadTableMetadata(
         const TString& cluster, const TString& table, TLoadTableMetadataSettings settings) = 0;
 
-    virtual NThreading::TFuture<TGenericResult> SetConstraint(const TString& tableName, TVector<TSetColumnConstraintSettings>&& settings) = 0;
+    virtual NThreading::TFuture<TGenericResult> SetColumnConstraints(const TString& tableName, TVector<TSetColumnConstraintSettings>&& settings) = 0;
 
     virtual NThreading::TFuture<TGenericResult> AlterDatabase(const TString& cluster, const TAlterDatabaseSettings& settings) = 0;
 

--- a/ydb/core/kqp/ut/service/kqp_qs_queries_ut.cpp
+++ b/ydb/core/kqp/ut/service/kqp_qs_queries_ut.cpp
@@ -5480,7 +5480,7 @@ Y_UNIT_TEST_SUITE(KqpQueryService) {
     // TODO: flown4qqqq
     Y_UNIT_TEST(AlterTable_SetNotNull_Invalid) {
         NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableSetColumnConstraint(true);
+        featureFlags.SetEnableSetColumnConstraints(true);
         auto settings = TKikimrSettings().SetFeatureFlags(featureFlags).SetWithSampleTables(false);
         TKikimrRunner kikimr(settings);
 
@@ -5522,7 +5522,7 @@ Y_UNIT_TEST_SUITE(KqpQueryService) {
             )sql", NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_C(!setNotNull.IsSuccess(), setNotNull.GetIssues().ToString());
             UNIT_ASSERT_VALUES_EQUAL_C(setNotNull.GetStatus(), EStatus::PRECONDITION_FAILED, setNotNull.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(setNotNull.GetIssues().ToString(), "CreateSetConstraintInitiate is not implemented. TablePath = '/Root/test/alterNotNull'");
+            UNIT_ASSERT_STRING_CONTAINS(setNotNull.GetIssues().ToString(), "CreateSetColumnConstraintsLock is not implemented");
         }
 
         // {
@@ -5549,7 +5549,7 @@ Y_UNIT_TEST_SUITE(KqpQueryService) {
     // TODO: flown4qqqq
     Y_UNIT_TEST(AlterTable_SetNotNull_Valid) {
         NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableSetColumnConstraint(true);
+        featureFlags.SetEnableSetColumnConstraints(true);
         auto settings = TKikimrSettings().SetFeatureFlags(featureFlags).SetWithSampleTables(false);
         TKikimrRunner kikimr(settings);
 
@@ -5591,7 +5591,7 @@ Y_UNIT_TEST_SUITE(KqpQueryService) {
             )sql", NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_C(!setNotNull.IsSuccess(), setNotNull.GetIssues().ToString());
             UNIT_ASSERT_VALUES_EQUAL_C(setNotNull.GetStatus(), EStatus::PRECONDITION_FAILED, setNotNull.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(setNotNull.GetIssues().ToString(), "CreateSetConstraintInitiate is not implemented. TablePath = '/Root/test/alterNotNull'");
+            UNIT_ASSERT_STRING_CONTAINS(setNotNull.GetIssues().ToString(), "CreateSetColumnConstraintsLock is not implemented");
         }
 
         // {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -225,7 +225,7 @@ message TFeatureFlags {
     optional bool EnableDataShardWriteAlwaysVolatile = 199 [default = true];
     optional bool EnableMirroredTopicSplitMerge = 200 [default = false];
     optional bool EnableFulltextIndex = 201 [default = false];
-    optional bool EnableSetColumnConstraint = 202 [default = false];
+    optional bool EnableSetColumnConstraints = 202 [default = false];
     optional bool EnableSchemaSecrets = 203 [default = false];
     optional bool EnableTableCacheModes = 204 [default = false];
     optional bool EnableSkipMessagesWithObsoleteTimestamp = 205 [default = false];

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1781,14 +1781,8 @@ message TSetColumnConstraintsCheck {
 }
 
 message TSetColumnConstraintsFinalize {
-    enum EStatus {
-        SUCCESS = 0;
-        COLUMN_CONSTRAINT_VIOLATION = 1;
-    }
-
     optional string TableName = 1;
     repeated TSetColumnConstraintSettings ConstraintSettings = 2;
-    optional EStatus Status = 3;
 }
 
 // End Set Column Constraints
@@ -1909,13 +1903,16 @@ message TModifyScheme {
 
     optional TCreateLongIncrementalBackupOp CreateLongIncrementalBackupOp = 85;
 
-    optional TSetColumnConstraintsInitiate SetColumnConstraintsInitiate = 87;
-
     // Secret
     optional TSecretSchemaOp CreateSecret = 88;
     optional TSecretSchemaOp AlterSecret = 89;
 
     optional TStreamingQueryDescription CreateStreamingQuery = 90;
+
+    optional TSetColumnConstraintsInitiate SetColumnConstraintsInitiate = 87;
+    optional TSetColumnConstraintsLock SetColumnConstraintsLock = 92;
+    optional TSetColumnConstraintsCheck SetColumnConstraintsCheck = 93;
+    optional TSetColumnConstraintsFinalize SetColumnConstraintsFinalize = 94;
 
     // Some entries are grouped by semantics, so are out of order
 }

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -528,7 +528,7 @@ message TKqpSchemeOperation {
         NKikimrSchemeOp.TModifyScheme AlterTransfer = 52;
         NKikimrSchemeOp.TModifyScheme DropTransfer = 53;
         NKikimrSchemeOp.TModifyScheme AlterDatabase = 54;
-        NKikimrSchemeOp.TModifyScheme SetConstraint = 55;
+        NKikimrSchemeOp.TModifyScheme SetColumnConstraint = 55;
         NKikimrSchemeOp.TModifyScheme CreateStreamingQuery = 56;
         NKikimrSchemeOp.TModifyScheme AlterStreamingQuery = 57;
         NKikimrSchemeOp.TModifyScheme DropStreamingQuery = 58;

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -528,7 +528,7 @@ message TKqpSchemeOperation {
         NKikimrSchemeOp.TModifyScheme AlterTransfer = 52;
         NKikimrSchemeOp.TModifyScheme DropTransfer = 53;
         NKikimrSchemeOp.TModifyScheme AlterDatabase = 54;
-        NKikimrSchemeOp.TModifyScheme SetColumnConstraint = 55;
+        NKikimrSchemeOp.TModifyScheme SetColumnConstraints = 55;
         NKikimrSchemeOp.TModifyScheme CreateStreamingQuery = 56;
         NKikimrSchemeOp.TModifyScheme AlterStreamingQuery = 57;
         NKikimrSchemeOp.TModifyScheme DropStreamingQuery = 58;

--- a/ydb/core/protos/schemeshard/operations.proto
+++ b/ydb/core/protos/schemeshard/operations.proto
@@ -195,9 +195,6 @@ enum EOperationType {
     // Long Incremental Backup
     ESchemeOpCreateLongIncrementalBackupOp = 124;
 
-    // Alter Table Alter Column Set
-    ESchemeOpCreateSetColumnConstraintInitiate = 126;
-
     // Secret
     ESchemeOpCreateSecret = 127;
     ESchemeOpAlterSecret = 128;
@@ -207,6 +204,13 @@ enum EOperationType {
     ESchemeOpCreateStreamingQuery = 130;
     ESchemeOpDropStreamingQuery = 131;
     ESchemeOpAlterStreamingQuery = 132;
+
+
+    // Alter Table Alter Column Set
+    ESchemeOpCreateSetColumnConstraintsInitiate = 126;
+    ESchemeOpCreateSetColumnConstraintsLock = 133;
+    ESchemeOpCreateSetColumnConstraintsCheck = 134;
+    ESchemeOpCreateSetColumnConstraintsFinalize = 135;
 
     // Some entries are grouped by semantics, so are out of order
 }

--- a/ydb/core/protos/schemeshard/operations.proto
+++ b/ydb/core/protos/schemeshard/operations.proto
@@ -196,7 +196,7 @@ enum EOperationType {
     ESchemeOpCreateLongIncrementalBackupOp = 124;
 
     // Alter Table Alter Column Set
-    ESchemeOpCreateSetConstraintInitiate = 126;
+    ESchemeOpCreateSetColumnConstraintInitiate = 126;
 
     // Secret
     ESchemeOpCreateSecret = 127;

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
@@ -154,7 +154,10 @@ EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
         case NKikimrSchemeOp::EOperationType::ESchemeOpCreateLongIncrementalBackupOp:
         case NKikimrSchemeOp::EOperationType::ESchemeOpChangePathState:
         case NKikimrSchemeOp::EOperationType::ESchemeOpIncrementalRestoreFinalize:
-        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraintInitiate:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsInitiate:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsLock:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsCheck:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsFinalize:
             return EOperationClass::Other;
 
         // intentionally no default -- to trigger [-Werror,-Wswitch] compile error on any new entry not handled here

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1425,8 +1425,14 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
         return CreateBuildColumn(op.NextPartId(), tx, context);
     case NKikimrSchemeOp::EOperationType::ESchemeOpDropColumnBuild:
         return {DropBuildColumn(op.NextPartId(), tx, context)};
-    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraintInitiate:
-        return CreateSetConstraintInitiate(op.NextPartId(), tx, context);
+
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsInitiate:
+        return CreateSetColumnConstraintsInitiate(op.NextPartId(), tx, context);
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsLock:
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsCheck:
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsFinalize:
+        Y_ABORT("multipart operations are handled before, also they require transaction details");
+
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateIndexBuild:
         return CreateBuildIndex(op.NextPartId(), tx, context);
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateLock:

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -146,7 +146,7 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
         .EnableTablePgTypes = AppData()->FeatureFlags.GetEnableTablePgTypes(),
         .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
         .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
-        .EnableSetColumnConstraint = AppData()->FeatureFlags.GetEnableSetColumnConstraint(),
+        .EnableSetColumnConstraints = AppData()->FeatureFlags.GetEnableSetColumnConstraints(),
     };
 
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint.cpp
@@ -8,12 +8,100 @@
 
 namespace NKikimr::NSchemeShard {
 
-TVector<ISubOperation::TPtr> CreateSetConstraintInitiate(TOperationId opId, const TTxTransaction& tx, TOperationContext& context) {
-    Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraintInitiate);
+TVector<ISubOperation::TPtr> CreateSetColumnConstraintsInitiate(TOperationId opId, const TTxTransaction& tx, TOperationContext& context) {
+    Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsInitiate);
     Y_UNUSED(context);
-    auto tablePath = NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetSetColumnConstraintsInitiate().GetTableName()});
-    TString error = "CreateSetConstraintInitiate is not implemented. TablePath = '" + tablePath + "'";
-    return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, std::move(error))};
+    auto tablePathStr = NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetSetColumnConstraintsInitiate().GetTableName()});
+
+    if (!context.SS->EnableSetColumnConstraints) {
+        TString error = "CreateSetColumnConstraintsInitiate is not implemented. TablePath = '" + tablePathStr + "'";
+        return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, std::move(error))};
+    }
+
+    const auto tablePath = TPath::Resolve(tablePathStr, context.SS);
+
+    {
+        TPath::TChecker checks = tablePath.Check();
+        checks
+            .NotEmpty()
+            .NotUnderDomainUpgrade()
+            .IsAtLocalSchemeShard()
+            .IsResolved()
+            .NotDeleted()
+            .IsTable()
+            .NotUnderOperation();
+
+        if (!checks) {
+            return {CreateReject(opId, checks.GetStatus(), checks.GetError())};
+        }
+    }
+
+    const auto& op = tx.GetSetColumnConstraintsInitiate();
+
+    TTableInfo::TPtr table = context.SS->Tables.at(tablePath.Base()->PathId);
+    std::vector<TString> tableColumns;
+    tableColumns.reserve(table->Columns.size());
+    {
+        for (const auto& [colId, colInfo] : table->Columns) {
+            Y_ENSURE(colId == colInfo.Id);
+
+            if (colInfo.IsDropped()) {
+                continue;
+            }
+
+            tableColumns.push_back(colInfo.Name);
+        }
+    }
+
+    // check column's existence in O((|tableColumns| + |ConstraintSettings|) * log(|tableColumns|))
+    std::sort(tableColumns.begin(), tableColumns.end());
+    for (const auto& constraint : op.GetConstraintSettings()) {
+        const auto& col = constraint.GetColumnName();
+
+        if (auto it = std::lower_bound(tableColumns.begin(), tableColumns.end(), col); it == tableColumns.end() || *it != col) {
+            TString error = "Table '" + tablePathStr + "' " + "does not have column '" + col + "'";
+            return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, std::move(error))};
+        }
+    }
+
+    TVector<ISubOperation::TPtr> result;
+
+    {
+        auto outTx = TransactionTemplate(tablePath.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsLock);
+        *outTx.MutableLockGuard() = tx.GetLockGuard();
+
+        outTx.MutableSetColumnConstraintsLock()->SetTableName(op.GetTableName());
+        outTx.MutableSetColumnConstraintsLock()->MutableConstraintSettings()->CopyFrom(op.GetConstraintSettings());
+
+        outTx.SetInternal(true);
+
+        result.push_back(CreateSetColumnConstraintsLock(NextPartId(opId, result), outTx));
+    }
+
+    {
+        auto outTx = TransactionTemplate(tablePath.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsCheck);
+        *outTx.MutableLockGuard() = tx.GetLockGuard();
+
+        outTx.MutableSetColumnConstraintsCheck()->SetTableName(op.GetTableName());
+        outTx.MutableSetColumnConstraintsCheck()->MutableConstraintSettings()->CopyFrom(op.GetConstraintSettings());
+
+        outTx.SetInternal(true);
+
+        result.push_back(CreateSetColumnConstraintsCheck(NextPartId(opId, result), outTx));
+    }
+
+    {
+        auto outTx = TransactionTemplate(tablePath.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsFinalize);
+
+        outTx.MutableSetColumnConstraintsFinalize()->SetTableName(op.GetTableName());
+        outTx.MutableSetColumnConstraintsFinalize()->MutableConstraintSettings()->CopyFrom(op.GetConstraintSettings());
+
+        outTx.SetInternal(true);
+
+        result.push_back(CreateSetColumnConstraintsFinalize(NextPartId(opId, result), outTx));
+    }
+
+    return result;
 }
 
 } // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_check.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_check.cpp
@@ -8,11 +8,10 @@
 
 namespace NKikimr::NSchemeShard {
 
-ISubOperation::TPtr CreateSetConstraintCheck(TOperationId opId, const TTxTransaction& tx) {
-    // Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraint);
-    Y_UNUSED(opId);
-    Y_UNUSED(tx);
-    return {};
+ISubOperation::TPtr CreateSetColumnConstraintsCheck(TOperationId opId, const TTxTransaction& tx) {
+    Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsCheck);
+    TString error = "CreateSetColumnConstraintsCheck is not implemented";
+    return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, std::move(error))};
 }
 
 } // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_finalize.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_finalize.cpp
@@ -8,11 +8,10 @@
 
 namespace NKikimr::NSchemeShard {
 
-ISubOperation::TPtr CreateSetConstraintFinalize(TOperationId opId, const TTxTransaction& tx) {
-    // Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraint);
-    Y_UNUSED(opId);
-    Y_UNUSED(tx);
-    return {};
+ISubOperation::TPtr CreateSetColumnConstraintsFinalize(TOperationId opId, const TTxTransaction& tx) {
+    Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsFinalize);
+    TString error = "CreateSetColumnConstraintsFinalize is not implemented.";
+    return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, std::move(error))};
 }
 
 } // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_lock.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_lock.cpp
@@ -8,11 +8,10 @@
 
 namespace NKikimr::NSchemeShard {
 
-ISubOperation::TPtr CreateSetConstraintLock(TOperationId opId, const TTxTransaction& tx) {
-    // Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraint);
-    Y_UNUSED(opId);
-    Y_UNUSED(tx);
-    return {};
+ISubOperation::TPtr CreateSetColumnConstraintsLock(TOperationId opId, const TTxTransaction& tx) {
+    Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsLock);
+    TString error = "CreateSetColumnConstraintsLock is not implemented";
+    return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, std::move(error))};
 }
 
 } // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__operation_part.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_part.h
@@ -405,10 +405,10 @@ ISubOperation::TPtr CreateUpdateMainTableOnIndexMove(TOperationId id, const TTxT
 ISubOperation::TPtr CreateUpdateMainTableOnIndexMove(TOperationId id, TTxState::ETxState state);
 
 
-TVector<ISubOperation::TPtr> CreateSetConstraintInitiate(TOperationId, const TTxTransaction&, TOperationContext&);
-ISubOperation::TPtr CreateSetConstraintLock(TOperationId, const TTxTransaction&);
-ISubOperation::TPtr CreateSetConstraintCheck(TOperationId, const TTxTransaction&);
-ISubOperation::TPtr CreateSetConstraintFinalize(TOperationId, const TTxTransaction&);
+TVector<ISubOperation::TPtr> CreateSetColumnConstraintsInitiate(TOperationId, const TTxTransaction&, TOperationContext&);
+ISubOperation::TPtr CreateSetColumnConstraintsLock(TOperationId, const TTxTransaction&);
+ISubOperation::TPtr CreateSetColumnConstraintsCheck(TOperationId, const TTxTransaction&);
+ISubOperation::TPtr CreateSetColumnConstraintsFinalize(TOperationId, const TTxTransaction&);
 
 // External Table
 // Create

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -292,8 +292,16 @@ TString DefineUserOperationName(const NKikimrSchemeOp::TModifyScheme& tx) {
         return "CHANGE PATH STATE";
     case NKikimrSchemeOp::EOperationType::ESchemeOpIncrementalRestoreFinalize:
         return "RESTORE INCREMENTAL FINALIZE";
-    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraintInitiate:
-        return "SET CONSTRAINT";
+
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsInitiate:
+        return "SET CONSTRAINT INITIATE";
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsLock:
+        return "SET CONSTRAINT LOCK";
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsCheck:
+        return "SET CONSTRAINT CHECK";
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsFinalize:
+        return "SET CONSTRAINT FINALIZE";
+
     // secret
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret:
         return "CREATE SECRET";
@@ -685,8 +693,17 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
         // For incremental restore finalization, we don't have a specific path in the message
         // since it operates on paths determined at runtime
         break;
-    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraintInitiate:
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsInitiate:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetSetColumnConstraintsInitiate().GetTableName()}));
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsLock:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetSetColumnConstraintsLock().GetTableName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsCheck:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetSetColumnConstraintsCheck().GetTableName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetColumnConstraintsFinalize:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetSetColumnConstraintsFinalize().GetTableName()}));
+        break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetCreateSecret().GetName()}));
         break;

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5090,6 +5090,7 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     EnableInitialUniqueIndex = appData->FeatureFlags.GetEnableUniqConstraint();
     EnableAddUniqueIndex = appData->FeatureFlags.GetEnableAddUniqueIndex();
     EnableFulltextIndex = appData->FeatureFlags.GetEnableFulltextIndex();
+    EnableSetColumnConstraints = appData->FeatureFlags.GetEnableSetColumnConstraints();
     EnableResourcePoolsOnServerless = appData->FeatureFlags.GetEnableResourcePoolsOnServerless();
     EnableExternalDataSourcesOnServerless = appData->FeatureFlags.GetEnableExternalDataSourcesOnServerless();
     EnableShred = appData->FeatureFlags.GetEnableDataErasure();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -364,6 +364,7 @@ public:
     bool EnableShred = false;
     bool EnableExternalSourceSchemaInference = false;
     bool EnableMoveColumnTable = false;
+    bool EnableSetColumnConstraints = false;
 
     TShardDeleter ShardDeleter;
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -452,8 +452,8 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
 
             if (isChangeNotNullConstraint) {
                 if (col.GetNotNull()) { // SET NOT NULL
-                    if (!featureFlags.EnableSetColumnConstraint) {
-                        errStr = Sprintf("Type '%s' specified for column '%s', but support for SET NOT NULL is disabled (EnableSetColumnConstraint feature flag is off)", col.GetType().data(), colName.data());
+                    if (!featureFlags.EnableSetColumnConstraints) {
+                        errStr = Sprintf("Type '%s' specified for column '%s', but support for SET NOT NULL is disabled (EnableSetColumnConstraints feature flag is off)", col.GetType().data(), colName.data());
                         return nullptr;
                     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -595,7 +595,7 @@ public:
         bool EnableTablePgTypes;
         bool EnableTableDatetime64;
         bool EnableParameterizedDecimal;
-        bool EnableSetColumnConstraint = false; // This flag is used in alter table operation only
+        bool EnableSetColumnConstraints = false; // This flag is used in alter table operation only
     };
 
     static TAlterDataPtr CreateAlterData(

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
@@ -581,7 +581,10 @@ ETxType ConvertToTxType(NKikimrSchemeOp::EOperationType opType) {
         case NKikimrSchemeOp::ESchemeOpRestoreMultipleIncrementalBackups:
         case NKikimrSchemeOp::ESchemeOpCreateColumnBuild:
         case NKikimrSchemeOp::ESchemeOpDropColumnBuild:
-        case NKikimrSchemeOp::ESchemeOpCreateSetConstraintInitiate: // TODO flown4qqqq
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsInitiate: // TODO flown4qqqq
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsLock: // TODO flown4qqqq
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsCheck: // TODO flown4qqqq
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsFinalize: // TODO flown4qqqq
             return TxInvalid;
 
         //NOTE: intentionally no default: case

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -234,8 +234,17 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpUpgradeSubDomainDecision:
             return *modifyScheme.MutableUpgradeSubDomain()->MutableName();
 
-        case NKikimrSchemeOp::ESchemeOpCreateSetConstraintInitiate:
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsInitiate:
             return *modifyScheme.MutableSetColumnConstraintsInitiate()->MutableTableName();
+
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsLock:
+            Y_ABORT("no implementation for ESchemeOpCreateSetColumnConstraintsLock");
+
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsCheck:
+            Y_ABORT("no implementation for ESchemeOpCreateSetColumnConstraintsCheck");
+
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsFinalize:
+            Y_ABORT("no implementation for ESchemeOpCreateSetColumnConstraintsFinalize");
 
         case NKikimrSchemeOp::ESchemeOpCreateColumnBuild:
             Y_ABORT("no implementation for ESchemeOpCreateColumnBuild");
@@ -1076,13 +1085,16 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpDropSysView:
             return false;
         case NKikimrSchemeOp::ESchemeOpChangePathState: {
-        case NKikimrSchemeOp::ESchemeOpCreateSetConstraintInitiate:
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsInitiate:
             auto toResolve = TPathToResolve(pbModifyScheme);
             toResolve.Path = Merge(workingDir, SplitPath(GetPathNameForScheme(pbModifyScheme)));
             toResolve.RequireAccess = NACLib::EAccessRights::AlterSchema | accessToUserAttrs;
             ResolveForACL.push_back(toResolve);
             break;
         }
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsLock:
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsCheck:
+        case NKikimrSchemeOp::ESchemeOpCreateSetColumnConstraintsFinalize:
         case NKikimrSchemeOp::ESchemeOpCreateTableIndex:
         case NKikimrSchemeOp::ESchemeOpDropTableIndex:
         case NKikimrSchemeOp::ESchemeOp_DEPRECATED_35:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR adds new feature: setting constraint NOT NULL on column. At this moment, only in [row-oriented](https://ydb.tech/docs/en/concepts/datamodel/table#row-oriented-tables) tables.

Please note that code which implements setting constraint NOT NULL can be reused for setting other constraints.

This is second part of implementation setting NOT NULL. There will be four parts in total:

0. YQL (too old PR).
1.  KQP (https://github.com/ydb-platform/ydb/pull/22406).
2. SchemeShard (this PR).
3. DataShards (in future).

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
