### PR TITLE
limit  memory in the TestYdbTopicWorkload.test  by reducing concurrency under memory sanitizer

### DIFF
--- a/ydb/tests/stress/topic/tests/test_workload_topic.py
+++ b/ydb/tests/stress/topic/tests/test_workload_topic.py
@@ -12,14 +12,20 @@ class TestYdbTopicWorkload(StressFixture):
         yield from self.setup_cluster()
 
     def test(self):
+        limit_memory_useage = os.environ.get("YDB_STRESS_TEST_LIMIT_MEMORY", "0").lower() in ['true', '1', 'y', 'yes']
+        consumers = 50
+        producers = 100
+        if limit_memory_useage:
+            consumers //= 3
+            producers //= 3
         cmd_args = [
             yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
             "--endpoint", self.endpoint,
             "--database", self.database,
             "--duration", "60",
-            "--consumers", "50",
-            "--producers", "100",
+            "--consumers", str(consumers),
+            "--producers", str(producers),
         ]
-        if os.environ.get("YDB_STRESS_TEST_LIMIT_MEMORY", "0").lower() in ['true', '1', 'y', 'yes']:
+        if limit_memory_useage:
             cmd_args.append('--limit-memory-usage')
         yatest.common.execute(cmd_args)


### PR DESCRIPTION
    LOGBROKER-9919
