### PR TITLE
Some fixes in Bridge GRPC disconnect

### DIFF
--- a/ydb/core/driver_lib/run/grpc_servers_manager.h
+++ b/ydb/core/driver_lib/run/grpc_servers_manager.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <ydb/core/base/defs.h>
+#include <ydb/core/base/appdata.h>
+#include <ydb/library/actors/core/event_local.h>
+
+namespace NKikimr {
+
+struct TEvGRpcServersManager {
+    enum EEv {
+        EvDisconnectRequestStarted = EventSpaceBegin(TEvents::ES_PRIVATE) + 10000,
+        EvDisconnectRequestFinished,
+    };
+
+    struct TEvDisconnectRequestStarted : public TEventLocal<TEvDisconnectRequestStarted, EvDisconnectRequestStarted> {
+    };
+
+    struct TEvDisconnectRequestFinished : public TEventLocal<TEvDisconnectRequestFinished, EvDisconnectRequestFinished> {
+    };
+};
+
+inline TActorId MakeGRpcServersManagerId(ui32 nodeId) {
+    char x[12] = {'g','r','p','c','s','r','v','r','m','n','g','r'};
+    return TActorId(nodeId, TStringBuf(x, 12));
+}
+
+} // namespace NKikimr
+

--- a/ydb/core/driver_lib/run/ya.make
+++ b/ydb/core/driver_lib/run/ya.make
@@ -14,6 +14,7 @@ SRCS(
     driver.h
     factories.h
     factories.cpp
+    grpc_servers_manager.h
     kikimr_services_initializers.cpp
     kikimr_services_initializers.h
     main.h

--- a/ydb/tests/functional/bridge/test_bridge.py
+++ b/ydb/tests/functional/bridge/test_bridge.py
@@ -30,12 +30,6 @@ class TestBridgeBasic(BridgeKiKiMRTest):
         self.update_cluster_state(self.bridge_client, updates)
         self.wait_for_cluster_state(self.secondary_bridge_client, {"r1": PileState.DISCONNECTED, "r2": PileState.PRIMARY})
 
-        updates = [
-            PileState(pile_name="r1", state=PileState.NOT_SYNCHRONIZED),
-        ]
-        self.update_cluster_state(self.secondary_bridge_client, updates)
-        self.wait_for_cluster_state(self.secondary_bridge_client, {"r1": PileState.SYNCHRONIZED, "r2": PileState.PRIMARY}, timeout_seconds=50)
-
     def test_takedown(self):
         initial_result = self.get_cluster_state(self.bridge_client)
         self.check_states(initial_result, {"r1": PileState.PRIMARY, "r2": PileState.SYNCHRONIZED})
@@ -44,11 +38,6 @@ class TestBridgeBasic(BridgeKiKiMRTest):
         ]
         self.update_cluster_state(self.bridge_client, updates)
         self.wait_for_cluster_state(self.bridge_client, {"r1": PileState.PRIMARY, "r2": PileState.DISCONNECTED})
-        updates = [
-            PileState(pile_name="r2", state=PileState.NOT_SYNCHRONIZED),
-        ]
-        self.update_cluster_state(self.bridge_client, updates)
-        self.wait_for_cluster_state(self.bridge_client, {"r1": PileState.PRIMARY, "r2": PileState.SYNCHRONIZED}, timeout_seconds=50)
 
     def test_rejoin(self):
         initial_result = self.get_cluster_state(self.bridge_client)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Some fixes in Bridge grpc disconnect

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When the UpdateBridgeCluster request with `DISCONNECTED` or `SUSPENDED` state was sent to disconnected/suspended pile, GRPC immediately responses ERROR, even though, the request was successfully completed. This PR fixes this problem: we're waiting for response and only then shutting down grpc port
