### PR TITLE
Fix incorrect event response on put error

### DIFF
--- a/ydb/core/keyvalue/keyvalue_state.cpp
+++ b/ydb/core/keyvalue/keyvalue_state.cpp
@@ -3,6 +3,7 @@
 #include "keyvalue_storage_read_request.h"
 #include "keyvalue_storage_request.h"
 #include "keyvalue_trash_key_arbitrary.h"
+#include "keyvalue_utils.h"
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/protos/counters_keyvalue.pb.h>
 #include <ydb/core/protos/msgbus_kv.pb.h>
@@ -2817,21 +2818,6 @@ TPrepareResult TKeyValueState::PrepareCommands(NKikimrKeyValue::ExecuteTransacti
         intermediate->ExecuteTransactionResponse.set_status(NKikimrKeyValue::Statuses::RSTATUS_OK);
     }
     return {};
-}
-
-NKikimrKeyValue::Statuses::ReplyStatus ConvertStatus(NMsgBusProxy::EResponseStatus status) {
-    switch (status) {
-    case NMsgBusProxy::MSTATUS_ERROR:
-        return NKikimrKeyValue::Statuses::RSTATUS_ERROR;
-    case NMsgBusProxy::MSTATUS_TIMEOUT:
-        return NKikimrKeyValue::Statuses::RSTATUS_TIMEOUT;
-    case NMsgBusProxy::MSTATUS_REJECTED:
-        return NKikimrKeyValue::Statuses::RSTATUS_WRONG_LOCK_GENERATION;
-    case NMsgBusProxy::MSTATUS_INTERNALERROR:
-        return NKikimrKeyValue::Statuses::RSTATUS_INTERNAL_ERROR;
-    default:
-        return NKikimrKeyValue::Statuses::RSTATUS_INTERNAL_ERROR;
-    };
 }
 
 void TKeyValueState::ReplyError(const TActorContext &ctx, TString errorDescription,

--- a/ydb/core/keyvalue/keyvalue_utils.cpp
+++ b/ydb/core/keyvalue/keyvalue_utils.cpp
@@ -1,0 +1,72 @@
+#include <ydb/core/keyvalue/keyvalue_utils.h>
+
+namespace NKikimr {
+namespace NKeyValue {
+
+NKikimrKeyValue::Statuses::ReplyStatus ConvertStatus(NMsgBusProxy::EResponseStatus status) {
+    switch (status) {
+    case NMsgBusProxy::MSTATUS_ERROR:
+        return NKikimrKeyValue::Statuses::RSTATUS_ERROR;
+    case NMsgBusProxy::MSTATUS_TIMEOUT:
+        return NKikimrKeyValue::Statuses::RSTATUS_TIMEOUT;
+    case NMsgBusProxy::MSTATUS_REJECTED:
+        return NKikimrKeyValue::Statuses::RSTATUS_WRONG_LOCK_GENERATION;
+    case NMsgBusProxy::MSTATUS_INTERNALERROR:
+        return NKikimrKeyValue::Statuses::RSTATUS_INTERNAL_ERROR;
+    default:
+        return NKikimrKeyValue::Statuses::RSTATUS_INTERNAL_ERROR;
+    };
+}
+
+
+template <typename TEvent>
+struct THasCookie : std::true_type {};
+
+template <>
+struct THasCookie<TEvKeyValue::TEvGetStorageChannelStatusResponse> : std::false_type {};
+
+
+
+template<typename TEvent>
+std::unique_ptr<IEventBase> MakeErrorResponseImpl(const TIntermediate *intermediateResults, NKikimrKeyValue::Statuses::ReplyStatus status, TString errorDescription) {
+    std::unique_ptr<TEvent> response(new TEvent);
+    if constexpr (THasCookie<TEvent>::value) {
+        if (intermediateResults->HasCookie) {
+            response->Record.set_cookie(intermediateResults->Cookie);
+        }
+    }
+    response->Record.set_msg(errorDescription);
+    response->Record.set_status(status);
+    return response;
+}
+
+
+std::unique_ptr<IEventBase> MakeErrorResponse(const TIntermediate *intermediateResults, NMsgBusProxy::EResponseStatus status, TString errorDescription) {
+    if (intermediateResults->EvType == TEvKeyValue::TEvRequest::EventType) {
+        std::unique_ptr<TEvKeyValue::TEvResponse> response(new TEvKeyValue::TEvResponse);
+        if (intermediateResults->HasCookie) {
+            response->Record.SetCookie(intermediateResults->Cookie);
+        }
+        response->Record.SetErrorReason(errorDescription);
+        response->Record.SetStatus(status);
+        return response;
+    }
+    if (intermediateResults->EvType == TEvKeyValue::TEvRead::EventType) {
+        return MakeErrorResponseImpl<TEvKeyValue::TEvReadResponse>(intermediateResults, ConvertStatus(status), errorDescription);
+    }
+    if (intermediateResults->EvType == TEvKeyValue::TEvReadRange::EventType) {
+        return MakeErrorResponseImpl<TEvKeyValue::TEvReadRangeResponse>(intermediateResults, ConvertStatus(status), errorDescription);
+    }
+    if (intermediateResults->EvType == TEvKeyValue::TEvExecuteTransaction::EventType) {
+        return MakeErrorResponseImpl<TEvKeyValue::TEvExecuteTransactionResponse>(intermediateResults, ConvertStatus(status), errorDescription);
+    }
+    if (intermediateResults->EvType == TEvKeyValue::TEvGetStorageChannelStatus::EventType) {
+        return MakeErrorResponseImpl<TEvKeyValue::TEvGetStorageChannelStatusResponse>(intermediateResults, ConvertStatus(status), errorDescription);
+    }
+
+    return nullptr;
+}
+
+
+} // NKeyValue
+} // NKikimr

--- a/ydb/core/keyvalue/keyvalue_utils.h
+++ b/ydb/core/keyvalue/keyvalue_utils.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <ydb/core/keyvalue/keyvalue_events.h>
+
+namespace NKikimr {
+namespace NKeyValue {
+
+NMsgBusProxy::EResponseStatus ConvertStatus(NKikimrKeyValue::Statuses::ReplyStatus status);
+
+std::unique_ptr<IEventBase> MakeErrorResponse(const TIntermediate *intermediateResults, NMsgBusProxy::EResponseStatus status, TString errorDescription);
+
+} // NKeyValue
+} // NKikimr

--- a/ydb/core/keyvalue/ya.make
+++ b/ydb/core/keyvalue/ya.make
@@ -38,6 +38,8 @@ SRCS(
     keyvalue_stored_state_data.cpp
     keyvalue_stored_state_data.h
     keyvalue_trash_key_arbitrary.h
+    keyvalue_utils.cpp
+    keyvalue_utils.h
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Close [#22290](https://github.com/ydb-platform/ydb/issues/22290)

The KV tablet returned responses in the legacy format (TEvResponse) instead of the new format (TEvExecuteTransactionResponse) when a PUT operation fails. The response format is currently determined by the format of the incoming request.

### Changelog category <!-- remove all except one -->


* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
