### PR TITLE
EXT-1283 Run defrag and compaction independently (#24526)

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -42,6 +42,8 @@ TNodeWarden::TNodeWarden(const TIntrusivePtr<TNodeWardenConfig> &cfg)
     , HullCompMaxInFlightReads(20, 1, 1000)
     , HullCompFullCompPeriodSec(0, 0, 7 * 24 * 60 * 60)
     , HullCompThrottlerBytesRate(0, 0, 10'000'000'000) // 10 GB/s
+    , GarbageThresholdToRunFullCompactionPerMille(0, 0, 300)
+    , DefragThrottlerBytesRate(0, 0, 10'000'000'000) // 10 GB/s
     , ThrottlingDryRun(1, 0, 1)
     , ThrottlingMinLevel0SstCount(100, 1, 100000)
     , ThrottlingMaxLevel0SstCount(250, 1, 100000)
@@ -387,6 +389,8 @@ void TNodeWarden::Bootstrap() {
         TControlBoard::RegisterSharedControl(HullCompMaxInFlightReads, icb->VDiskControls.HullCompMaxInFlightReads);
         TControlBoard::RegisterSharedControl(HullCompFullCompPeriodSec, icb->VDiskControls.HullCompFullCompPeriodSec);
         TControlBoard::RegisterSharedControl(HullCompThrottlerBytesRate, icb->VDiskControls.HullCompThrottlerBytesRate);
+        TControlBoard::RegisterSharedControl(GarbageThresholdToRunFullCompactionPerMille, icb->VDiskControls.GarbageThresholdToRunFullCompactionPerMille);
+        TControlBoard::RegisterSharedControl(DefragThrottlerBytesRate, icb->VDiskControls.DefragThrottlerBytesRate);
 
         TControlBoard::RegisterSharedControl(ThrottlingDryRun, icb->VDiskControls.ThrottlingDryRun);
         TControlBoard::RegisterSharedControl(ThrottlingMinLevel0SstCount, icb->VDiskControls.ThrottlingMinLevel0SstCount);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -217,6 +217,8 @@ namespace NKikimr::NStorage {
         TControlWrapper HullCompMaxInFlightReads;
         TControlWrapper HullCompFullCompPeriodSec;
         TControlWrapper HullCompThrottlerBytesRate;
+        TControlWrapper GarbageThresholdToRunFullCompactionPerMille;
+        TControlWrapper DefragThrottlerBytesRate;
 
         TControlWrapper ThrottlingDryRun;
         TControlWrapper ThrottlingMinLevel0SstCount;

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -204,8 +204,10 @@ namespace NKikimr::NStorage {
         vdiskConfig->HullCompMaxInFlightReads = HullCompMaxInFlightReads;
         vdiskConfig->HullCompFullCompPeriodSec = HullCompFullCompPeriodSec;
         vdiskConfig->HullCompThrottlerBytesRate = HullCompThrottlerBytesRate;
-
+        vdiskConfig->GarbageThresholdToRunFullCompactionPerMille = GarbageThresholdToRunFullCompactionPerMille;
+        vdiskConfig->DefragThrottlerBytesRate = DefragThrottlerBytesRate;
         vdiskConfig->EnableLocalSyncLogDataCutting = EnableLocalSyncLogDataCutting;
+
         if (deviceType == NPDisk::EDeviceType::DEVICE_TYPE_ROT) {
             vdiskConfig->EnableSyncLogChunkCompression = EnableSyncLogChunkCompressionHDD;
             vdiskConfig->MaxSyncLogChunksInFlight = MaxSyncLogChunksInFlightHDD;
@@ -232,8 +234,8 @@ namespace NKikimr::NStorage {
 
         vdiskConfig->FeatureFlags = Cfg->FeatureFlags;
 
-        if (StorageConfig->HasBlobStorageConfig() && StorageConfig->GetBlobStorageConfig().HasVDiskPerformanceSettings()) {
-            for (auto &type : StorageConfig->GetBlobStorageConfig().GetVDiskPerformanceSettings().GetVDiskTypes()) {
+        if (Cfg->BlobStorageConfig.HasVDiskPerformanceSettings()) {
+            for (auto &type : Cfg->BlobStorageConfig.GetVDiskPerformanceSettings().GetVDiskTypes()) {
                 if (type.HasPDiskType() && deviceType == PDiskTypeToPDiskType(type.GetPDiskType())) {
                     if (type.HasMinHugeBlobSizeInBytes()) {
                         vdiskConfig->MinHugeBlobInBytes = type.GetMinHugeBlobSizeInBytes();

--- a/ydb/core/blobstorage/ut_blobstorage/comp_defrag.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/comp_defrag.cpp
@@ -2,33 +2,43 @@
 #include <ydb/core/blobstorage/ut_blobstorage/lib/common.h>
 #include <ydb/core/load_test/service_actor.h>
 #include <ydb/core/util/lz4_data_generator.h>
+#include <ydb/core/blobstorage/vdisk/defrag/defrag_quantum.h>
 #include <ydb/core/blobstorage/vdisk/defrag/defrag_search.h>
 
 #include <library/cpp/protobuf/util/pb_io.h>
 
-struct TLsmMetrics {
+struct TMetrics {
     ui64 CompactionBytesRead = 0;
     ui64 CompactionBytesWritten = 0;
+    ui64 DefragBytesRewritten = 0;
+
+    ui64 Level0 = 0;
+    ui64 Level1 = 0;
+    ui64 Level2 = 0;
+    ui64 Level3 = 0;
+
+    ui64 HugeUsedChunks = 0;
+    ui64 HugeChunksCanBeFreed = 0;
+    ui64 HugeLockedChunks = 0;
+
+    ui64 DskSpaceCurInplacedData = 0;
+    ui64 DskUsedBytes = 0;
+    ui64 DskTotalBytes = 0;
+
+    ui64 SpaceInHugeChunksCouldBeFreedViaCompaction = 0;
 };
 
-struct TTetsEnv {
-    TTetsEnv()
-    : Env({
-        .NodeCount = 8,
-        .VDiskReplPausedAtStart = false,
-        .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
-    })
+struct TTetsEnvBase {
+    TTetsEnvBase(TEnvironmentSetup::TSettings&& settings)
+    : Env(std::move(settings))
     {
         Env.CreateBoxAndPool(1, 1);
-        Env.Sim(TDuration::Minutes(1));
 
         auto groups = Env.GetGroups();
         UNIT_ASSERT_VALUES_EQUAL(groups.size(), 1);
         GroupInfo = Env.GetGroupInfo(groups.front());
 
         VDiskActorId = GroupInfo->GetActorId(0);
-
-        DataSmall = FastGenDataForLZ4(128 * 1024, 0);
 
         Sender = Env.Runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
 
@@ -42,11 +52,10 @@ struct TTetsEnv {
         Env.Sim(TDuration::Minutes(1));
     }
 
-    std::unique_ptr<TEvBlobStorage::TEvPut> GetData(ui32 index) const {
-        ui32 tabletId = 1;
-        auto& data = DataSmall;
-        auto id = TLogoBlobID(tabletId, 1, index, 0, data.size(), 0);
-        return std::make_unique<TEvBlobStorage::TEvPut>(id, data, TInstant::Max());
+    void SetIcbControl(const TString& control, ui64 value) {
+        for (ui32 i = 1; i <= Env.Settings.NodeCount; ++i) {
+            Env.SetIcbControl(i, control, value);
+        }
     }
 
     template<class TEvent>
@@ -56,35 +65,137 @@ struct TTetsEnv {
         });
     }
 
-    ui64 AggregateVDiskCounters(const TString& subsystem, const TString& counter) {
+    ui64 AggregateVDiskCounters(const TString& subsystem, const TString& counter, std::unordered_map<TString, TString> labels = {}) {
         return Env.AggregateVDiskCounters(
             "test", Env.Settings.NodeCount,
             GroupInfo->GetTotalVDisksNum(), GroupInfo->GroupID.GetRawId(),
-            PdiskLayout, subsystem, counter
+            PdiskLayout, subsystem, counter, labels
         );
     }
 
-    TLsmMetrics GetLsmMetrics() {
-        TLsmMetrics metrics;
+    TMetrics GetMetrics() {
+        TMetrics metrics;
 
         metrics.CompactionBytesRead = AggregateVDiskCounters("lsmhull", "LsmCompactionBytesRead");
         metrics.CompactionBytesWritten = AggregateVDiskCounters("lsmhull", "LsmCompactionBytesWritten");
+        metrics.DefragBytesRewritten = AggregateVDiskCounters("defrag", "DefragBytesRewritten");
+
+        metrics.Level0 = AggregateVDiskCounters("levels", "NumItems", {{"level", "0"}});
+        metrics.Level1 = AggregateVDiskCounters("levels", "NumItems", {{"level", "1..8"}})
+                        + AggregateVDiskCounters("levels", "NumItems", {{"level", "9..16"}});
+        metrics.Level2 = AggregateVDiskCounters("levels", "NumItems", {{"level", "17"}});
+        metrics.Level3 = AggregateVDiskCounters("levels", "NumItems", {{"level", "18"}});
+
+        metrics.HugeUsedChunks = AggregateVDiskCounters("outofspace", "HugeUsedChunks");
+        metrics.HugeChunksCanBeFreed = AggregateVDiskCounters("outofspace", "HugeChunksCanBeFreed");
+        metrics.HugeLockedChunks = AggregateVDiskCounters("outofspace", "HugeLockedChunks");
+
+        metrics.DskSpaceCurInplacedData = AggregateVDiskCounters("outofspace", "DskSpaceCurInplacedData");
+        metrics.DskUsedBytes = AggregateVDiskCounters("outofspace", "DskUsedBytes");
+        metrics.DskTotalBytes = AggregateVDiskCounters("outofspace", "DskTotalBytes");
+
+        metrics.SpaceInHugeChunksCouldBeFreedViaCompaction = AggregateVDiskCounters("defrag", "SpaceInHugeChunksCouldBeFreedViaCompaction");
 
         return metrics;
+    }
+
+    TMetrics PrintMetrics() {
+        auto metrics = GetMetrics();
+        Cerr << "Compaction bytes read: " << metrics.CompactionBytesRead << Endl
+             << "Compaction bytes written: " << metrics.CompactionBytesWritten << Endl
+             << "Defrag bytes rewritten: " << metrics.DefragBytesRewritten << Endl
+             << "Level 0: " << metrics.Level0 << Endl
+             << "Level 1: " << metrics.Level1 << Endl
+             << "Level 2: " << metrics.Level2 << Endl
+             << "Level 3: " << metrics.Level3 << Endl
+             << "Huge Used Chunks: " << metrics.HugeUsedChunks << Endl
+             << "Huge Chunks Can Be Freed: " << metrics.HugeChunksCanBeFreed << Endl
+             << "Huge Locked Chunks: " << metrics.HugeLockedChunks << Endl
+             << "Dsk Space Cur Inplaced Data: " << metrics.DskSpaceCurInplacedData << Endl
+             << "Dsk Used Bytes: " << metrics.DskUsedBytes << Endl
+             << "Dsk Total Bytes: " << metrics.DskTotalBytes << Endl
+             << "Space In Huge Chunks Could Be Freed Via Compaction: " << metrics.SpaceInHugeChunksCouldBeFreedViaCompaction << Endl
+             << "=========================================================" << Endl;
+        return metrics;
+    }
+
+    std::function<bool(ui32, std::unique_ptr<IEventHandle>&)> SetFilterFunction(ui32 eventType, std::function<bool(ui32, std::unique_ptr<IEventHandle>&)> func) {
+        std::function<bool(ui32, std::unique_ptr<IEventHandle>&)> oldFunc = Filters[eventType];
+        if (func == nullptr) {
+            Filters.erase(eventType);
+        } else {
+            Filters[eventType] = std::move(func);
+        }
+        return oldFunc;
+    }
+
+    virtual std::unique_ptr<TEvBlobStorage::TEvPut> GetData(ui32 index) const = 0;
+
+    void WriteData(ui32 N, ui32 batchSize) {
+        // warm up ds proxy and bs queue
+        SendToDsProxy(GetData(0).release());
+        auto res = Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(Sender, false);
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+
+        // write data in batches
+        for (ui32 i = 0; i < N / batchSize; ++i) {
+            for (ui32 j = 0; j < batchSize; ++j) {
+                SendToDsProxy(GetData(i * batchSize + j).release());
+            }
+            for (ui32 j = 0; j < batchSize; ++j) {
+                auto res = Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(Sender, false);
+                if (res->Get()->Status != NKikimrProto::OK) {
+                    PrintMetrics();
+                }
+                UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+            }
+        }
+    }
+
+    void RunFullCompaction() {
+        Cerr << "Running full compaction" << Endl;
+        Env.Sim(TDuration::Seconds(20));
+        for (ui32 i = 0; i < GroupInfo->GetTotalVDisksNum(); ++i) {
+            const TActorId& vdiskId = GroupInfo->GetActorId(i);
+            Env.CompactVDisk(vdiskId);
+        }
+        Env.Sim(TDuration::Seconds(20));
     }
 
     TEnvironmentSetup Env;
     TIntrusivePtr<TBlobStorageGroupInfo> GroupInfo;
     TActorId VDiskActorId;
-    TString DataSmall, DataLarge;
     ui32 CollectGeneration = 0;
     TActorId Sender;
     std::vector<ui32> PdiskLayout;
+    std::unordered_map<ui32, std::function<bool(ui32, std::unique_ptr<IEventHandle>&)>> Filters;
 };
+
 
 #define UNIT_ASSERT_VALUE_IN(min, value, max) \
     UNIT_ASSERT_C((min) <= (value) && (value) <= (max), \
         "Value " << value << " is not in range [" << min << ", " << max << "]")
+
+
+struct TTetsEnvCompThrottler : TTetsEnvBase {
+    using TTetsEnvBase::TTetsEnvBase;
+    TTetsEnvCompThrottler() : TTetsEnvBase({
+        .NodeCount = 8,
+        .VDiskReplPausedAtStart = false,
+        .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+    }) {
+        Data = FastGenDataForLZ4(128 * 1024, 0);
+    }
+
+    std::unique_ptr<TEvBlobStorage::TEvPut> GetData(ui32 index) const {
+        ui32 tabletId = 1;
+        auto& data = Data;
+        auto id = TLogoBlobID(tabletId, 1, index, 0, data.size(), 0);
+        return std::make_unique<TEvBlobStorage::TEvPut>(id, data, TInstant::Max());
+    }
+
+    TString Data;
+};
 
 ui32 GetMsgSize(std::unique_ptr<IEventBase>& msg) {
     if (msg->Type() == TEvBlobStorage::EvChunkWrite) {
@@ -118,7 +229,7 @@ struct TCompStatPerNode {
     }
 };
 
-struct TCompStat { 
+struct TCompStat {
     TCompStat() {
         for (ui32 i = 1; i <= 8; i++) {
             NodeCompStats[i] = TCompStatPerNode();
@@ -169,10 +280,10 @@ void CheckCompStat(TDuration duration, TCompStatPerNode& nodeStat, ui32 rate) {
     UNIT_ASSERT(nodeStat.BytesWritten + nodeStat.BytesRead <= (duration.Seconds() + 1) * rate);
 }
 
-Y_UNIT_TEST_SUITE(CompDefrag) {
+Y_UNIT_TEST_SUITE(CompactionThrottler) {
 
     Y_UNIT_TEST(CompactionLoad) {
-        TTetsEnv env;
+        TTetsEnvCompThrottler env;
         ui32 N = 7000;
         ui32 batchSize = 1000;
 
@@ -198,48 +309,20 @@ Y_UNIT_TEST_SUITE(CompDefrag) {
             return true;
         };
 
-        { // write data
-            // warm up ds proxy and bs queue
-            env.SendToDsProxy(env.GetData(0).release());
-            auto res = env.Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(env.Sender, false);
-            UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+        env.WriteData(N, batchSize);
 
-            // write data in batches
-            for (ui32 i = 0; i < N / batchSize; ++i) {
-                for (ui32 j = 0; j < batchSize; ++j) {
-                    env.SendToDsProxy(env.GetData(i * batchSize + j).release());
-                }
-                for (ui32 j = 0; j < batchSize; ++j) {
-                    auto res = env.Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(env.Sender, false);
-                    UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
-                }
-            }
-        }
+        // run first full compaction for stabilize lsm
+        env.RunFullCompaction();
 
-        { // run first full compaction for stabilize lsm
-            env.Env.Sim(TDuration::Seconds(20));
-            for (ui32 i = 0; i < env.GroupInfo->GetTotalVDisksNum(); ++i) {
-                const TActorId& vdiskId = env.GroupInfo->GetActorId(i);
-                env.Env.CompactVDisk(vdiskId);
-            }
-            env.Env.Sim(TDuration::Seconds(20));
-        }
-
-        compactionBytesWritten = env.GetLsmMetrics().CompactionBytesWritten;
-        compactionBytesRead = env.GetLsmMetrics().CompactionBytesRead;
+        compactionBytesWritten = env.GetMetrics().CompactionBytesWritten;
+        compactionBytesRead = env.GetMetrics().CompactionBytesRead;
         compStats.Clear();
 
-        { // run 2 full compaction for calculate read and write rate without throttler
-            env.Env.Sim(TDuration::Seconds(20));
-            for (ui32 i = 0; i < env.GroupInfo->GetTotalVDisksNum(); ++i) {
-                const TActorId& vdiskId = env.GroupInfo->GetActorId(i);
-                env.Env.CompactVDisk(vdiskId);
-            }
-            env.Env.Sim(TDuration::Seconds(20));
-        }
+        // run 2 full compaction for calculate read and write rate without throttler
+        env.RunFullCompaction();
 
-        expectedCompactionBytesWritten = compactionBytesWritten = env.GetLsmMetrics().CompactionBytesWritten - compactionBytesWritten;
-        compactionBytesRead = env.GetLsmMetrics().CompactionBytesRead - compactionBytesRead;
+        expectedCompactionBytesWritten = compactionBytesWritten = env.GetMetrics().CompactionBytesWritten - compactionBytesWritten;
+        compactionBytesRead = env.GetMetrics().CompactionBytesRead - compactionBytesRead;
         UNIT_ASSERT_EQUAL(compactionBytesWritten, compStats.GetSumWrittenBytes());
         UNIT_ASSERT_EQUAL(compactionBytesRead, compStats.GetSumReadBytes());
 
@@ -289,7 +372,7 @@ Y_UNIT_TEST_SUITE(CompDefrag) {
                     // check compaction wotking time
                     if (nodeId <= 2) {
                         // nodes without rate limit
-                        UNIT_ASSERT_EQUAL(i, 1); // <= 10 sec 
+                        UNIT_ASSERT_EQUAL(i, 1); // <= 10 sec
                     } else {
                         // node with rate limit
                         UNIT_ASSERT_VALUE_IN((i - 1) * 10, expectedWorkingSeconds[nodeId], i * 10);
@@ -304,6 +387,448 @@ Y_UNIT_TEST_SUITE(CompDefrag) {
 
         UNIT_ASSERT_EQUAL(compStats.GetSumWrittenBytes(), expectedCompactionBytesWritten);
 
+    }
+
+}
+
+struct TTestEnvCompDefragIndependent : TTetsEnvBase {
+    static constexpr ui64 CHUNK_SIZE = 32_MB;
+    static constexpr ui64 MIN_HUGE_BLOB_SIZE = 128_KB;
+    static constexpr ui64 MAX_DEFRAG_INFLIGHT = 2;
+
+    using TTetsEnvBase::TTetsEnvBase;
+    TTestEnvCompDefragIndependent(double garbageThresholdToRunCompaction = 0.0)
+        : TTetsEnvBase({
+            .NodeCount = 8,
+            .VDiskReplPausedAtStart = false,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+            .DiskType = NPDisk::EDeviceType::DEVICE_TYPE_ROT,
+            .MinHugeBlobInBytes = MIN_HUGE_BLOB_SIZE,
+            .PDiskSize = 20_GB,
+            .PDiskChunkSize = CHUNK_SIZE,
+        })
+    {
+        DataSmall = FastGenDataForLZ4(32_KB, 0);
+        DataLarge = FastGenDataForLZ4(1_MB, 0);
+
+        SetIcbControl("VDiskControls.MaxChunksToDefragInflight", MAX_DEFRAG_INFLIGHT);
+        SetIcbControl("VDiskControls.DefaultHugeGarbagePerMille", 50);
+        SetIcbControl("VDiskControls.GarbageThresholdToRunFullCompactionPerMille", garbageThresholdToRunCompaction * 1000);
+        Env.Sim(TDuration::Minutes(1));
+
+        Env.Runtime->FilterFunction = [this](ui32 nodeId, std::unique_ptr<IEventHandle>& ev) {
+            auto eventType = ev->GetTypeRewrite();
+            auto it = Filters.find(eventType);
+            if (it != Filters.end()) {
+                return it->second(nodeId, ev);
+            }
+            return true;
+        };
+
+        SetFilterFunction(TEvBlobStorage::EvVPut, [this](ui32, std::unique_ptr<IEventHandle>& ev) {
+            auto put = ev->Get<TEvBlobStorage::TEvVPut>();
+            auto id = LogoBlobIDFromLogoBlobID(put->Record.GetBlobID());
+            if (!SeenParts.insert({id.Step(), id.PartId()}).second) {
+                return true; // skip duplicates;
+            }
+            ui64 bytes = put->GetBufferBytes();
+            if (bytes >= MIN_HUGE_BLOB_SIZE) {
+                BytesWrittenLarge += bytes;
+            } else {
+                BytesWrittenSmall += bytes;
+            }
+            return true;
+        });
+        SetFilterFunction(TEvBlobStorage::EvCompactVDisk, [this](ui32 nodeId, std::unique_ptr<IEventHandle>&) {
+            CompactionsPerNode[nodeId]++;
+            return true;
+        });
+        SetFilterFunction(NKikimr::TEvDefragQuantumResult::EventType, [this](ui32 nodeId, std::unique_ptr<IEventHandle>& ev) {
+            auto res = ev->Get<NKikimr::TEvDefragQuantumResult>();
+            ChunksFreedByDefragPerNode[nodeId] += res->Stat.FreedChunks.size();
+            DefragQuantumsPerNode[nodeId]++;
+            return true;
+        });
+    }
+
+    std::unique_ptr<TEvBlobStorage::TEvPut> GetData(ui32 index) const {
+        ui32 tabletId = index % 2 + 1;
+        auto& data = index % 100 < 10 ? DataLarge : DataSmall;
+        auto id = TLogoBlobID(tabletId, 1, index, 0, data.size(), 0);
+        return std::make_unique<TEvBlobStorage::TEvPut>(id, data, TInstant::Max());
+    }
+
+    TString DataSmall, DataLarge;
+
+    ui64 BytesWrittenSmall = 0, BytesWrittenLarge = 0;
+    std::unordered_map<ui32, ui32> CompactionsPerNode;
+    std::unordered_map<ui32, ui32> ChunksFreedByDefragPerNode;
+    std::unordered_map<ui32, ui32> DefragQuantumsPerNode;
+    std::unordered_set<std::pair<ui32, ui32>> SeenParts;
+};
+
+
+void DeleteHugeBlobsOfTablet(TTetsEnvBase& env, ui32 N, ui32 tabletId) {
+    auto keep = std::make_unique<TVector<TLogoBlobID>>();
+    for (ui32 i = 0; i < N; ++i) {
+        auto ev = env.GetData(i);
+        if (ev->Id.TabletID() == tabletId && ev->Buffer.size() < TTestEnvCompDefragIndependent::MIN_HUGE_BLOB_SIZE * 4) {
+            keep->push_back(ev->Id);
+        }
+    }
+    env.Env.Runtime->WrapInActorContext(env.Sender, [&] {
+        SendToBSProxy(
+            env.Sender, env.GroupInfo->GroupID,
+            new TEvBlobStorage::TEvCollectGarbage(
+                tabletId, 1, 1,
+                0, true, 1, Max<ui32>(),
+                keep.release(), nullptr, TInstant::Max(), true
+            )
+        );
+    });
+    const auto& res = env.Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvCollectGarbageResult>(env.Sender);
+    UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+}
+
+struct TEvDefragStartQuantum : TEventLocal<TEvDefragStartQuantum, TEvBlobStorage::EvDefragStartQuantum> {
+    NKikimr::TChunksToDefrag ChunksToDefrag;
+};
+
+Y_UNIT_TEST_SUITE(CompDefrag) {
+
+    Y_UNIT_TEST(DoesItWork) {
+        TTestEnvCompDefragIndependent env(0.01);
+        ui32 N = 70000;
+        ui32 batchSize = 1000;
+
+        env.WriteData(N, batchSize);
+        env.RunFullCompaction();
+        ui64 compactionBytesWritten = 0;
+        ui32 totalHugeChunks = env.GetMetrics().HugeUsedChunks;
+
+        { // check metrics
+            Cerr << "Bytes written (small): " << env.BytesWrittenSmall << Endl
+                << "Bytes written (large): " << env.BytesWrittenLarge << Endl;
+            auto metrics = env.PrintMetrics();
+            UNIT_ASSERT_VALUE_IN(N * 6, metrics.Level0 + metrics.Level1 + metrics.Level2 + metrics.Level3, N * 8);
+            UNIT_ASSERT_VALUE_IN(N * 6, metrics.Level2, N * 8); // everything should be on level 2
+            UNIT_ASSERT_VALUE_IN(env.BytesWrittenLarge / TTestEnvCompDefragIndependent::CHUNK_SIZE, metrics.HugeUsedChunks, std::ceil(env.BytesWrittenLarge * 1.125 / TTestEnvCompDefragIndependent::CHUNK_SIZE));
+
+            compactionBytesWritten = metrics.CompactionBytesWritten;
+
+            for (auto& [nodeId, count] : env.CompactionsPerNode) {
+                Cerr << "Node " << nodeId << " had " << count << " compactions" << Endl;
+                UNIT_ASSERT_GE(count, 1);
+                count = 0; // reset
+            }
+        }
+
+
+        DeleteHugeBlobsOfTablet(env, N, 1);
+        env.Env.Sim(TDuration::Minutes(30)); // defrag scheduler runs every 5-5.5 minutes
+
+
+        { // check metrics
+            auto metrics = env.PrintMetrics();
+
+            for (const auto& [nodeId, count] : env.CompactionsPerNode) {
+                ui32 chunksFreed = env.ChunksFreedByDefragPerNode[nodeId];
+                Cerr << "Node " << nodeId << " had " << count << " compactions and " << chunksFreed << " chunks freed" << Endl;
+
+                UNIT_ASSERT_VALUE_IN(1, count, chunksFreed / TTestEnvCompDefragIndependent::MAX_DEFRAG_INFLIGHT - 1);
+            }
+            Cerr << "Total compaction bytes written during deletion: " << metrics.CompactionBytesWritten - compactionBytesWritten << Endl
+                << "Amplification to lsm size: " << (metrics.CompactionBytesWritten - compactionBytesWritten) / float(metrics.DskSpaceCurInplacedData) << Endl;
+
+            UNIT_ASSERT_VALUES_EQUAL(metrics.HugeChunksCanBeFreed, 0);
+            UNIT_ASSERT_LT(env.GetMetrics().HugeUsedChunks, totalHugeChunks);
+        }
+    }
+
+    Y_UNIT_TEST(DelayedCompaction) {
+        TTestEnvCompDefragIndependent env(0.01);
+        ui32 N = 50000;
+        ui32 batchSize = 1000;
+
+        env.WriteData(N, batchSize);
+        env.RunFullCompaction();
+        // env.Env.Sim(TDuration::Minutes(10));
+        ui32 totalHugeChunks = env.GetMetrics().HugeUsedChunks;
+
+        // disable compaction to test defrag without compaction
+        TVector<std::unique_ptr<IEventHandle>> compactions;
+        auto oldCompFilter = env.SetFilterFunction(TEvBlobStorage::EvCompactVDisk, [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            compactions.push_back(std::move(ev));
+            return false; // skip compaction events
+        });
+
+        DeleteHugeBlobsOfTablet(env, N, 1);
+        // wait for defrag to free all chunks it could free
+        env.Env.Sim(TDuration::Minutes(30)); // defrag scheduler runs every 5-5.5 minutes
+        UNIT_ASSERT_VALUES_EQUAL(env.GetMetrics().HugeUsedChunks, totalHugeChunks);
+
+        // check that defrag terminating without compaction
+        env.ChunksFreedByDefragPerNode.clear();
+        env.Env.Sim(TDuration::Minutes(10));
+        UNIT_ASSERT_VALUES_EQUAL(env.GetMetrics().HugeUsedChunks, totalHugeChunks);
+        UNIT_ASSERT_VALUES_EQUAL(env.ChunksFreedByDefragPerNode.size(), 0);
+
+        env.CompactionsPerNode.clear();
+        env.SetFilterFunction(TEvBlobStorage::EvCompactVDisk, std::move(oldCompFilter));
+        for (auto& ev : compactions) {
+            env.Env.Runtime->WrapInActorContext(env.Sender, [&] {
+                TlsActivationContext->Send(ev.release());
+            });
+        }
+        env.Env.Sim(TDuration::Minutes(10));
+
+        for (const auto& [nodeId, count] : env.CompactionsPerNode) {
+            Cerr << "Node " << nodeId << " had " << count << " compactions" << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(count, 1);
+        }
+
+        auto metrics = env.PrintMetrics();
+        UNIT_ASSERT_VALUES_EQUAL(metrics.HugeChunksCanBeFreed, 0);
+        UNIT_ASSERT_LT(env.GetMetrics().HugeUsedChunks, totalHugeChunks);
+
+    }
+
+    Y_UNIT_TEST(ZeroThresholdDefragWithCompaction) {
+        TTestEnvCompDefragIndependent env(0.0); // Zero threshold - compaction should run immediately
+        ui32 N = 50000;
+        ui32 batchSize = 1000;
+
+        env.WriteData(N, batchSize);
+        env.RunFullCompaction();
+        ui32 totalHugeChunks = env.GetMetrics().HugeUsedChunks;
+
+        // Clear counters before deletion
+        env.CompactionsPerNode.clear();
+        env.DefragQuantumsPerNode.clear();
+        env.ChunksFreedByDefragPerNode.clear();
+
+        DeleteHugeBlobsOfTablet(env, N, 1);
+        env.Env.Sim(TDuration::Minutes(30)); // defrag scheduler runs every 5-5.5 minutes
+
+        // Check that defragmentation is working
+        auto metrics = env.PrintMetrics();
+        UNIT_ASSERT_LT(env.GetMetrics().HugeUsedChunks, totalHugeChunks);
+        UNIT_ASSERT_VALUES_EQUAL(metrics.HugeChunksCanBeFreed, 0);
+
+        // Verify that number of compactions equals number of defragmentation quantums
+        ui32 totalCompactions = 0;
+        ui32 totalDefragQuanta = 0;
+
+        for (const auto& [nodeId, compactions] : env.CompactionsPerNode) {
+            ui32 defragQuantums = env.DefragQuantumsPerNode[nodeId];
+            Cerr << "Node " << nodeId << " had " << compactions << " compactions and " << defragQuantums << " defrag quantums" << Endl;
+
+            totalCompactions += compactions;
+            totalDefragQuanta += defragQuantums;
+
+            // Each defrag quantum should trigger exactly one compaction with zero threshold
+            UNIT_ASSERT_VALUES_EQUAL(compactions, defragQuantums);
+        }
+
+        UNIT_ASSERT_GT(totalCompactions, 0);
+        UNIT_ASSERT_GT(totalDefragQuanta, 0);
+        UNIT_ASSERT_VALUES_EQUAL(totalCompactions, totalDefragQuanta);
+
+        Cerr << "Total compactions: " << totalCompactions << ", Total defrag quantums: " << totalDefragQuanta << Endl;
+    }
+
+    Y_UNIT_TEST(DynamicThresholdChange) {
+        TTestEnvCompDefragIndependent env(0.0); // Start with zero threshold
+        ui32 N = 75000; // Increased from 50000 to create more data
+        ui32 batchSize = 1000;
+
+        env.WriteData(N, batchSize);
+        env.RunFullCompaction();
+        ui32 totalHugeChunks = env.GetMetrics().HugeUsedChunks;
+
+        // Clear counters before deletion
+        env.CompactionsPerNode.clear();
+        env.DefragQuantumsPerNode.clear();
+        env.ChunksFreedByDefragPerNode.clear();
+
+        // Track quantums per node and threshold change status
+        std::unordered_map<ui32, ui32> quantumsBeforeThresholdChange;
+        std::unordered_set<ui32> nodesWithThresholdChanged;
+        ui32 targetQuantums = 2;
+
+        // Add filter to track defrag quantums and change threshold dynamically
+        env.SetFilterFunction(NKikimr::TEvDefragQuantumResult::EventType, [&](ui32 nodeId, std::unique_ptr<IEventHandle>& ev) {
+            auto res = ev->Get<NKikimr::TEvDefragQuantumResult>();
+            env.ChunksFreedByDefragPerNode[nodeId] += res->Stat.FreedChunks.size();
+            env.DefragQuantumsPerNode[nodeId]++;
+
+            // Check if this node has reached target quantums and threshold hasn't been changed yet
+            if (env.DefragQuantumsPerNode[nodeId] == targetQuantums && !nodesWithThresholdChanged.count(nodeId)) {
+                Cerr << "Node " << nodeId << " reached " << targetQuantums << " quantums, changing threshold to 0.01" << Endl;
+
+                // Change threshold for this specific node
+                env.Env.SetIcbControl(nodeId, "VDiskControls.GarbageThresholdToRunFullCompactionPerMille", 10); // 0.01 * 1000 = 10
+                nodesWithThresholdChanged.insert(nodeId);
+
+                // Record quantums before threshold change for this node
+                quantumsBeforeThresholdChange[nodeId] = env.DefragQuantumsPerNode[nodeId];
+            }
+
+            return true;
+        });
+
+        DeleteHugeBlobsOfTablet(env, N, 1);
+        env.Env.Sim(TDuration::Minutes(30)); // Wait for defrag to complete
+
+        // Verify results
+        ui32 totalCompactions = 0;
+        ui32 totalQuantums = 0;
+
+        for (ui32 nodeId = 1; nodeId <= env.Env.Settings.NodeCount; ++nodeId) {
+            ui32 compactions = env.CompactionsPerNode[nodeId];
+            ui32 quantums = env.DefragQuantumsPerNode[nodeId];
+            ui32 quantumsBeforeChange = quantumsBeforeThresholdChange[nodeId];
+            ui32 quantumsAfterChange = quantums - quantumsBeforeChange;
+
+            Cerr << "Node " << nodeId << " had " << compactions << " compactions and " << quantums << " defrag quantums" << Endl;
+            Cerr << "  - Before threshold change: " << quantumsBeforeChange << " quantums" << Endl;
+            Cerr << "  - After threshold change: " << quantumsAfterChange << " quantums" << Endl;
+
+            totalCompactions += compactions;
+            totalQuantums += quantums;
+
+            // Verify that with zero threshold, we have 1:1 ratio for the first 2 quantums
+            UNIT_ASSERT_GE(quantumsBeforeChange, targetQuantums);
+
+            // For quantums after threshold change, should have fewer compactions than quantums
+            if (quantumsAfterChange > 0) {
+                // With 0.01 threshold, we should have fewer compactions than total quantums
+                // but more than just the quantums before threshold change
+                UNIT_ASSERT_GT(compactions, quantumsBeforeChange); // Should have more compactions than just the first 2
+                UNIT_ASSERT_LT(compactions, quantums); // Should have fewer compactions than total quantums
+            }
+        }
+
+        UNIT_ASSERT_GT(totalCompactions, 0);
+        UNIT_ASSERT_GT(totalQuantums, 0);
+
+        Cerr << "Total compactions: " << totalCompactions << ", Total defrag quantums: " << totalQuantums << Endl;
+
+        // Verify defragmentation completed successfully
+        auto metrics = env.PrintMetrics();
+        UNIT_ASSERT_LT(env.GetMetrics().HugeUsedChunks, totalHugeChunks);
+        UNIT_ASSERT_VALUES_EQUAL(metrics.HugeChunksCanBeFreed, 0);
+    }
+
+    Y_UNIT_TEST(ChunksSoftLocking) {
+        TTestEnvCompDefragIndependent env(0.01);
+        ui32 N = 50000;
+        ui32 batchSize = 1000;
+
+        env.SetIcbControl("VDiskControls.MaxChunksToDefragInflight", 10);
+
+        env.WriteData(N, batchSize);
+        env.RunFullCompaction();
+
+        env.PrintMetrics();
+
+        // freeze defragmentation with locked chunks
+        TVector<IEventHandle*> lockChunksResponses;
+        auto oldFilter = env.SetFilterFunction(NKikimr::TEvHugeLockChunksResult::EventType, [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            auto msg = ev->Get<NKikimr::TEvHugeLockChunksResult>();
+            UNIT_ASSERT_GT(msg->LockedChunks.size(), 5);
+            lockChunksResponses.push_back(ev.release());
+            return false;
+        });
+
+        DeleteHugeBlobsOfTablet(env, N, 1);
+        env.RunFullCompaction();
+        env.Env.Sim(TDuration::Minutes(10));
+        UNIT_ASSERT_VALUES_EQUAL(lockChunksResponses.size(), env.Env.Settings.NodeCount);
+
+        ui64 hugeUsedChunksBeforeWrites = env.PrintMetrics().HugeUsedChunks;
+
+        // write more data
+        env.Sender = env.Env.Runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
+        ui32 M = N / 2; // half of the data were deleted, so we write half of the data again and expect no new chunks to be created
+        for (ui32 i = 0; i < M / batchSize; ++i) {
+            for (ui32 j = 0; j < batchSize; ++j) {
+                auto ev = env.GetData(i * batchSize + j);
+                auto nextGenId = TLogoBlobID::Make(ev->Id.TabletID(), ev->Id.Generation() + 1, ev->Id.Step(), ev->Id.Channel(), ev->Id.BlobSize(), ev->Id.Cookie(), ev->Id.CrcMode());
+                auto nextGenEv = std::make_unique<TEvBlobStorage::TEvPut>(nextGenId, TRope(ev->Buffer).ConvertToString(), TInstant::Max());
+                env.SendToDsProxy(nextGenEv.release());
+            }
+            for (ui32 j = 0; j < batchSize; ++j) {
+                auto res = env.Env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(env.Sender, false);
+                UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+            }
+        }
+        env.Env.Sim(TDuration::Minutes(10));
+
+        // check that no new chunks were created
+        UNIT_ASSERT_VALUES_EQUAL(env.PrintMetrics().HugeUsedChunks, hugeUsedChunksBeforeWrites);
+
+
+        // unfreeze defragmentation with locked chunks
+        env.SetFilterFunction(NKikimr::TEvHugeLockChunksResult::EventType, [&](ui32, std::unique_ptr<IEventHandle>&) {
+            return true;
+        });
+        for (auto& ev : lockChunksResponses) {
+            env.Env.Runtime->WrapInActorContext(ev->Sender, [&] {
+                TlsActivationContext->Send(ev);
+            });
+        }
+        env.Env.Sim(TDuration::Minutes(10));
+    }
+
+    Y_UNIT_TEST(DefragThrottling) {
+        ui64 totalBytesToDefrag = 0;
+        { // without throttling
+            TTestEnvCompDefragIndependent env(0.01);
+            ui32 N = 50000;
+            ui32 batchSize = 1000;
+            
+            env.WriteData(N, batchSize);
+            env.RunFullCompaction();
+
+            DeleteHugeBlobsOfTablet(env, N, 1);
+
+            env.Env.Sim(TDuration::Minutes(30));
+
+            totalBytesToDefrag = env.PrintMetrics().DefragBytesRewritten;
+            Cerr << "Total bytes to defrag: " << totalBytesToDefrag << Endl;
+        }
+
+        UNIT_ASSERT_GT(totalBytesToDefrag, 512_MB);
+
+        { // with throttling
+            TTestEnvCompDefragIndependent env(0.01);
+            ui32 N = 50000;
+            ui32 batchSize = 1000;
+            
+            env.WriteData(N, batchSize);
+            env.RunFullCompaction();
+
+            env.PrintMetrics();
+
+            DeleteHugeBlobsOfTablet(env, N, 1);
+
+            env.SetIcbControl("VDiskControls.DefragThrottlerBytesRate", 1_MB);
+            TDuration maxThrottlingDuration = TDuration::Minutes(6) + totalBytesToDefrag / 1_MB / 8 * TDuration::Seconds(1) * 2; // 2 is a factor of safety
+            Cerr << "Max throttling duration: " << maxThrottlingDuration.ToString() << Endl;
+
+            ui64 defragBytesRewrittenBefore = env.PrintMetrics().DefragBytesRewritten;
+            for (ui32 i = 0; i < maxThrottlingDuration.Seconds(); ++i) {
+                env.Env.Sim(TDuration::Seconds(1));
+                ui64 cur = env.GetMetrics().DefragBytesRewritten;
+                ui64 defragBytesRewritten = cur - defragBytesRewrittenBefore;
+                UNIT_ASSERT_LE(defragBytesRewritten, 1_MB * 8);
+                defragBytesRewrittenBefore = cur;
+            }
+
+            env.PrintMetrics();
+            UNIT_ASSERT_VALUE_IN(totalBytesToDefrag - totalBytesToDefrag / 100, defragBytesRewrittenBefore, totalBytesToDefrag + totalBytesToDefrag / 100);
+        }
     }
 
 }

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -547,6 +547,11 @@ config:
 
                 ADD_ICB_CONTROL(VDiskControls.EnableDeepScrubbing, false, false, true, Settings.EnableDeepScrubbing);
                 ADD_ICB_CONTROL(VDiskControls.HullCompThrottlerBytesRate, 0, 0, 10737418240, 0);
+                ADD_ICB_CONTROL(VDiskControls.DefragThrottlerBytesRate, 0, 0, 10'000'000'000, 0);
+                ADD_ICB_CONTROL(VDiskControls.MaxChunksToDefragInflight, 10, 1, 50, 10);
+                ADD_ICB_CONTROL(VDiskControls.DefaultHugeGarbagePerMille, 300, 0, 1000, 300);
+                ADD_ICB_CONTROL(VDiskControls.GarbageThresholdToRunFullCompactionPerMille, 0, 0, 300, 0);
+                
 #undef ADD_ICB_CONTROL
 
                 {
@@ -1133,7 +1138,7 @@ config:
 
     ui64 AggregateVDiskCountersBase(TString storagePool, ui32 nodesCount, ui32 groupSize, ui32 groupId,
             const std::vector<ui32>& pdiskLayout, TString subsgroupName, TString subgroupValue,
-            TString counter, bool derivative = false) {
+            TString counter, std::unordered_map<TString, TString> labels = {}, bool derivative = false) {
         ui64 ctr = 0;
 
         for (ui32 nodeId = 1; nodeId <= nodesCount; ++nodeId) {
@@ -1145,14 +1150,17 @@ config:
                 ss.Clear();
                 ss << LeftPad(pdiskLayout[i], 9, '0');
                 TString pdisk = ss.Str();
-                ctr += GetServiceCounters(appData->Counters, "vdisks")->
+                auto cntr = GetServiceCounters(appData->Counters, "vdisks")->
                         GetSubgroup("storagePool", storagePool)->
                         GetSubgroup("group", std::to_string(groupId))->
                         GetSubgroup("orderNumber", orderNumber)->
                         GetSubgroup("pdisk", pdisk)->
                         GetSubgroup("media", "rot")->
-                        GetSubgroup(subsgroupName, subgroupValue)->
-                        GetCounter(counter, derivative)->Val();
+                        GetSubgroup(subsgroupName, subgroupValue);
+                for (const auto& [label, value] : labels) {
+                    cntr = cntr->GetSubgroup(label, value);
+                }
+                ctr += cntr->GetCounter(counter, derivative)->Val();
             }
         }
         return ctr;
@@ -1184,15 +1192,15 @@ config:
     }
 
     ui64 AggregateVDiskCounters(TString storagePool, ui32 nodesCount, ui32 groupSize, ui32 groupId,
-        const std::vector<ui32>& pdiskLayout, TString subsystem, TString counter, bool derivative = false) {
+        const std::vector<ui32>& pdiskLayout, TString subsystem, TString counter, std::unordered_map<TString, TString> labels = {}, bool derivative = false) {
         return AggregateVDiskCountersBase(storagePool, nodesCount, groupSize, groupId, pdiskLayout,
-            "subsystem", subsystem, counter, derivative);
+            "subsystem", subsystem, counter, labels, derivative);
     }
 
     ui64 AggregateVDiskCountersWithHandleClass(TString storagePool, ui32 nodesCount, ui32 groupSize, ui32 groupId,
-        const std::vector<ui32>& pdiskLayout, TString handleclass, TString counter) {
+        const std::vector<ui32>& pdiskLayout, TString handleclass, TString counter, std::unordered_map<TString, TString> labels = {}) {
         return AggregateVDiskCountersBase(storagePool, nodesCount, groupSize, groupId, pdiskLayout,
-            "handleclass", handleclass, counter);
+            "handleclass", handleclass, counter, labels);
     }
 
     void SetIcbControl(ui32 nodeId, TString controlName, ui64 value) {

--- a/ydb/core/blobstorage/ut_blobstorage/replication.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/replication.cpp
@@ -246,7 +246,7 @@ TString DoTestCase(TBlobStorageGroupType::EErasureSpecies erasure, const std::ve
 
     if (detainReplication) {
         ui64 vdisksWithStuckRepl = env.AggregateVDiskCounters(env.StoragePoolName, nodeCount, nodeCount,
-                groupId, pdiskLayout, "repl", "ReplMadeNoProgress", false);
+                groupId, pdiskLayout, "repl", "ReplMadeNoProgress", {}, false);
         UNIT_ASSERT_VALUES_UNEQUAL(vdisksWithStuckRepl, 0);
         env.Runtime->FilterFunction = {};
         for (auto& [nodeId, ev] : detainedMsgs) {
@@ -255,7 +255,7 @@ TString DoTestCase(TBlobStorageGroupType::EErasureSpecies erasure, const std::ve
         checkBlob();
         env.Sim(TDuration::Minutes(360));
         vdisksWithStuckRepl = env.AggregateVDiskCounters(env.StoragePoolName, nodeCount, nodeCount,
-                groupId, pdiskLayout, "repl", "ReplMadeNoProgress", false);
+                groupId, pdiskLayout, "repl", "ReplMadeNoProgress", {}, false);
         UNIT_ASSERT_VALUES_EQUAL(vdisksWithStuckRepl, 0);
     }
 

--- a/ydb/core/blobstorage/ut_blobstorage/ut_comp_defrag/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_comp_defrag/ya.make
@@ -1,8 +1,11 @@
 UNITTEST_FOR(ydb/core/blobstorage/ut_blobstorage)
 
-    SIZE(MEDIUM)
+    IF (SANITIZER_TYPE OR WITH_VALGRIND)
+        FORK_SUBTESTS()
+    ENDIF()
 
-    TIMEOUT(300)
+    SIZE(MEDIUM)
+    TIMEOUT(600)
 
     SRCS(
         comp_defrag.cpp

--- a/ydb/core/blobstorage/ut_vdisk/lib/helpers.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/helpers.cpp
@@ -4,6 +4,7 @@
 #include <util/random/shuffle.h>
 
 #include <ydb/core/blobstorage/base/blobstorage_events.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_private_events.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogreader.h>
 #include <ydb/core/blobstorage/backpressure/queue_backpressure_client.h>
@@ -885,7 +886,7 @@ NActors::IActor *CreatePutGC(const NActors::TActorId &notifyID, const TAllVDisks
 class TWaitForCompactionOneDisk : public TActorBootstrapped<TWaitForCompactionOneDisk> {
     TActorId NotifyID;
     const TAllVDisks::TVDiskInstance VDiskInfo;
-
+    const bool Sync;
     friend class TActorBootstrapped<TWaitForCompactionOneDisk>;
 
     void Bootstrap(const TActorContext&) {
@@ -903,12 +904,22 @@ class TWaitForCompactionOneDisk : public TActorBootstrapped<TWaitForCompactionOn
     }
 
     void SendVCompact() {
-        Send(VDiskInfo.ActorID, new TEvBlobStorage::TEvVCompact(VDiskInfo.VDiskID,
-                NKikimrBlobStorage::TEvVCompact::ASYNC), IEventHandle::FlagTrackDelivery);
+        if (Sync) {
+            Send(VDiskInfo.ActorID, TEvCompactVDisk::Create(EHullDbType::LogoBlobs,
+                TEvCompactVDisk::EMode::FULL, false));
+        } else {
+            Send(VDiskInfo.ActorID, new TEvBlobStorage::TEvVCompact(VDiskInfo.VDiskID,
+                    NKikimrBlobStorage::TEvVCompact::ASYNC), IEventHandle::FlagTrackDelivery);
+        }
     }
 
     void SendVStatus() {
         Send(VDiskInfo.ActorID, new TEvBlobStorage::TEvVStatus(VDiskInfo.VDiskID), IEventHandle::FlagTrackDelivery);
+    }
+
+    void Handle(TEvCompactVDiskResult::TPtr&, const TActorContext& ctx) {
+        ctx.Send(NotifyID, new TEvents::TEvCompleted());
+        Die(ctx);
     }
 
     void Handle(TEvBlobStorage::TEvVStatusResult::TPtr &ev) {
@@ -932,6 +943,7 @@ class TWaitForCompactionOneDisk : public TActorBootstrapped<TWaitForCompactionOn
     STRICT_STFUNC(StateSchedule,
         hFunc(TEvBlobStorage::TEvVCompactResult, Handle);
         cFunc(TEvents::TEvUndelivered::EventType, SendVCompact)
+        HFunc(TEvCompactVDiskResult, Handle);
     )
 
     STRICT_STFUNC(StateWait,
@@ -940,15 +952,16 @@ class TWaitForCompactionOneDisk : public TActorBootstrapped<TWaitForCompactionOn
     )
 
 public:
-    TWaitForCompactionOneDisk(const TActorId &notifyID, const TAllVDisks::TVDiskInstance &vdiskInfo)
+    TWaitForCompactionOneDisk(const TActorId &notifyID, const TAllVDisks::TVDiskInstance &vdiskInfo, bool sync)
         : TActorBootstrapped<TWaitForCompactionOneDisk>()
         , NotifyID(notifyID)
         , VDiskInfo(vdiskInfo)
+        , Sync(sync)
     {}
 };
 
-NActors::IActor *CreateWaitForCompaction(const NActors::TActorId &notifyID, const TAllVDisks::TVDiskInstance &vdiskInfo) {
-    return new TWaitForCompactionOneDisk(notifyID, vdiskInfo);
+NActors::IActor *CreateWaitForCompaction(const NActors::TActorId &notifyID, const TAllVDisks::TVDiskInstance &vdiskInfo, bool sync) {
+    return new TWaitForCompactionOneDisk(notifyID, vdiskInfo, sync);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -956,7 +969,7 @@ class TWaitForCompaction : public TActorBootstrapped<TWaitForCompaction> {
     TActorId NotifyID;
     TConfiguration *Conf;
     ui32 Counter;
-
+    bool Sync;
     friend class TActorBootstrapped<TWaitForCompaction>;
 
     void Bootstrap(const TActorContext &ctx) {
@@ -965,7 +978,7 @@ class TWaitForCompaction : public TActorBootstrapped<TWaitForCompaction> {
         ui32 total = Conf->GroupInfo->GetTotalVDisksNum();
         for (ui32 i = 0; i < total; i++) {
             TAllVDisks::TVDiskInstance &instance = Conf->VDisks->Get(i);
-            ctx.RegisterWithSameMailbox(CreateWaitForCompaction(ctx.SelfID, instance));
+            ctx.RegisterWithSameMailbox(CreateWaitForCompaction(ctx.SelfID, instance, Sync));
             Counter++;
         }
     }
@@ -984,16 +997,17 @@ class TWaitForCompaction : public TActorBootstrapped<TWaitForCompaction> {
     )
 
 public:
-    TWaitForCompaction(const TActorId &notifyID, TConfiguration *conf)
+    TWaitForCompaction(const TActorId &notifyID, TConfiguration *conf, bool sync)
         : TActorBootstrapped<TWaitForCompaction>()
         , NotifyID(notifyID)
         , Conf(conf)
         , Counter(0)
+        , Sync(sync)
     {}
 };
 
-NActors::IActor *CreateWaitForCompaction(const NActors::TActorId &notifyID, TConfiguration *conf) {
-    return new TWaitForCompaction(notifyID, conf);
+NActors::IActor *CreateWaitForCompaction(const NActors::TActorId &notifyID, TConfiguration *conf, bool sync) {
+    return new TWaitForCompaction(notifyID, conf, sync);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/ut_vdisk/lib/helpers.h
+++ b/ydb/core/blobstorage/ut_vdisk/lib/helpers.h
@@ -125,8 +125,8 @@ NActors::IActor *CreatePutGC(const NActors::TActorId &notifyID, const TAllVDisks
                              ui32 collectStep, TAutoPtr<TVector<NKikimr::TLogoBlobID>> keep,
                              TAutoPtr<TVector<NKikimr::TLogoBlobID>> doNotKeep);
 
-NActors::IActor *CreateWaitForCompaction(const NActors::TActorId &notifyID, const TAllVDisks::TVDiskInstance &vdiskInfo);
-NActors::IActor *CreateWaitForCompaction(const NActors::TActorId &notifyID, TConfiguration *conf);
+NActors::IActor *CreateWaitForCompaction(const NActors::TActorId &notifyID, const TAllVDisks::TVDiskInstance &vdiskInfo, bool sync=false);
+NActors::IActor *CreateWaitForCompaction(const NActors::TActorId &notifyID, TConfiguration *conf, bool sync=false);
 NActors::IActor *CreateWaitForSync(const NActors::TActorId &notifyID, TConfiguration *conf);
 NActors::IActor *CreateCheckDbEmptyness(const NActors::TActorId &notifyID, const TAllVDisks::TVDiskInstance &vdiskInfo,
                                         bool expectEmpty);

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_defrag.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_defrag.cpp
@@ -83,8 +83,13 @@ virtual void Scenario(const TActorContext &ctx) {
             << " FreedChunks# " << FormatList(rec.GetFreedChunks()) << "\n";
     };
 
-    // now defrag only one disk
     TAllVDisks::TVDiskInstance &instance = Conf->VDisks->Get(0);
+
+    // wait for compaction
+    SyncRunner->Run(ctx, CreateWaitForCompaction(SyncRunner->NotifyID(), instance, true));
+    LOG_NOTICE(ctx, NActorsServices::TEST, "  COMPACTION done");
+
+    // now defrag only one disk
     TAutoPtr<IActor> defragCmd(CreateDefrag(SyncRunner->NotifyID(), instance, true, check));
     SyncRunner->Run(ctx, defragCmd);
     LOG_NOTICE(ctx, NActorsServices::TEST, "  Defrag completed");
@@ -100,7 +105,7 @@ virtual void Scenario(const TActorContext &ctx) {
     LOG_NOTICE(ctx, NActorsServices::TEST, "  Defrag completed");
 
     // check actually freed chunks
-    UNIT_ASSERT_VALUES_EQUAL(freedChunks.size(), 4);
+    UNIT_ASSERT_VALUES_EQUAL(freedChunks.size(), 3);
 }
 SYNC_TEST_END(TDefrag50PercentGarbage, TSyncTestBase)
 

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_huge.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_huge.cpp
@@ -155,6 +155,7 @@ class THugeModuleRecoveryActor : public TActorBootstrapped<THugeModuleRecoveryAc
                         HmCtx->Config->HugeBlobStepsBetweenPowersOf2,
                         false,
                         HmCtx->Config->HugeBlobsFreeChunkReservation,
+                        false,
                         logFunc);
         } else {
             // read existing one
@@ -175,7 +176,7 @@ class THugeModuleRecoveryActor : public TActorBootstrapped<THugeModuleRecoveryAc
                         HmCtx->Config->HugeBlobStepsBetweenPowersOf2,
                         false,
                         HmCtx->Config->HugeBlobsFreeChunkReservation,
-                        lsn, entryPoint, logFunc);
+                        lsn, entryPoint, false, logFunc);
         }
 
         return true;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
@@ -45,6 +45,7 @@ namespace NKikimr {
         HullCompMaxInFlightReads = 20;
         HullCompFullCompPeriodSec = 0;
         HullCompThrottlerBytesRate = 0;
+        DefragThrottlerBytesRate = 0;
         HullCompReadBatchEfficiencyThreshold = 0.5;  // don't issue reads if there are more gaps than the useful data
         AnubisOsirisMaxInFly = 1000;
         BlobHeaderMode = EBlobHeaderMode::OLD_HEADER;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -134,6 +134,7 @@ namespace NKikimr {
         TControlWrapper HullCompMaxInFlightReads;
         TControlWrapper HullCompFullCompPeriodSec;
         TControlWrapper HullCompThrottlerBytesRate;
+        TControlWrapper DefragThrottlerBytesRate;
         double HullCompReadBatchEfficiencyThreshold;
         ui64 AnubisOsirisMaxInFly;
         EBlobHeaderMode BlobHeaderMode;
@@ -251,6 +252,7 @@ namespace NKikimr {
         TControlWrapper DefaultHugeGarbagePerMille = 300;
         TControlWrapper HugeDefragFreeSpaceBorderPerMille = 260;
         TControlWrapper MaxChunksToDefragInflight = 10;
+        TControlWrapper GarbageThresholdToRunFullCompactionPerMille = 0;
 
         ///////////// COST METRICS SETTINGS ////////////////
         bool UseCostTracker = true;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
@@ -607,10 +607,12 @@ public:                                                                         
             {
                 COUNTER_INIT_IF_EXTENDED(DefragBytesRewritten, true);
                 COUNTER_INIT_IF_EXTENDED(DefragThreshold, false);
+                COUNTER_INIT_IF_EXTENDED(SpaceInHugeChunksCouldBeFreedViaCompaction, false);
             }
 
             COUNTER_DEF(DefragBytesRewritten);
             COUNTER_DEF(DefragThreshold);
+            COUNTER_DEF(SpaceInHugeChunksCouldBeFreedViaCompaction);
         };
 
         ///////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/common/vdisk_outofspace.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_outofspace.h
@@ -62,6 +62,10 @@ namespace NKikimr {
             AtomicSet(LocalUsedChunks, static_cast<TAtomicBase>(usedChunks));
         }
 
+        void UpdateLocalTotalChunks(ui32 totalChunks) {
+            AtomicSet(LocalTotalChunks, static_cast<TAtomicBase>(totalChunks));
+        }
+
         NPDisk::TStatusFlags GetLocalStatusFlags() const {
             return static_cast<NPDisk::TStatusFlags>(AtomicGet(AllVDiskFlags[SelfOrderNum]));
         }
@@ -87,6 +91,10 @@ namespace NKikimr {
             return static_cast<ui32>(AtomicGet(LocalUsedChunks));
         }
 
+        ui32 GetLocalTotalChunks() const {
+            return static_cast<ui32>(AtomicGet(LocalTotalChunks));
+        }
+
     private:
         // Log space flags.
         TAtomic LogFlags = 0;
@@ -104,6 +112,8 @@ namespace NKikimr {
         const ui32 SelfOrderNum;
         // Chunks used locally by VDisk
         TAtomic LocalUsedChunks = 0;
+        // VDisk chunks limit in shared free space mode
+        TAtomic LocalTotalChunks = 0;
     };
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_actor.h
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_actor.h
@@ -25,6 +25,7 @@ namespace NKikimr {
         const TActorId HugeKeeperId;
         NMonGroup::TDefragGroup DefragMonGroup;
         bool RunDefragBySchedule;
+        std::shared_ptr<TEventsQuoter> Throttler;
 
         TDefragCtx(
                 const TIntrusivePtr<TVDiskContext> &vctx,

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_quantum.cpp
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_quantum.cpp
@@ -178,22 +178,24 @@ namespace NKikimr {
                     }
                 }
 
-                // scan index again to find tables we have to compact
-                for (findRecords.StartFindingTablesToCompact(); findRecords.Scan(NDefrag::WorkQuantum, GetSnapshot()); Yield()) {}
-                if (auto records = findRecords.GetRecordsToRewrite(); !records.empty()) {
-                    for (const auto& item : records) {
-                        STLOG(PRI_WARN, BS_VDISK_DEFRAG, BSVDD16, DCtx->VCtx->VDiskLogPrefix
-                            << "blob found again after rewriting", (ActorId, SelfActorId), (Id, item.LogoBlobId),
-                            (Location, item.OldDiskPart));
+                if (DCtx->VCfg->GarbageThresholdToRunFullCompactionPerMille == 0) {
+                    // scan index again to find tables we have to compact
+                    for (findRecords.StartFindingTablesToCompact(); findRecords.Scan(NDefrag::WorkQuantum, GetSnapshot()); Yield()) {}
+                    if (auto records = findRecords.GetRecordsToRewrite(); !records.empty()) {
+                        for (const auto& item : records) {
+                            STLOG(PRI_WARN, BS_VDISK_DEFRAG, BSVDD16, DCtx->VCtx->VDiskLogPrefix
+                                << "blob found again after rewriting", (ActorId, SelfActorId), (Id, item.LogoBlobId),
+                                (Location, item.OldDiskPart));
+                        }
                     }
-                }
 
-                auto tablesToCompact = findRecords.GetTablesToCompact();
-                const bool needsFreshCompaction = findRecords.GetNeedsFreshCompaction();
-                STLOG(PRI_DEBUG, BS_VDISK_DEFRAG, BSVDD13, DCtx->VCtx->VDiskLogPrefix << "compacting",
-                    (ActorId, SelfActorId), (TablesToCompact, tablesToCompact),
-                    (NeedsFreshCompaction, needsFreshCompaction));
-                Compact(std::move(tablesToCompact), needsFreshCompaction);
+                    auto tablesToCompact = findRecords.GetTablesToCompact();
+                    const bool needsFreshCompaction = findRecords.GetNeedsFreshCompaction();
+                    STLOG(PRI_DEBUG, BS_VDISK_DEFRAG, BSVDD13, DCtx->VCtx->VDiskLogPrefix << "compacting",
+                        (ActorId, SelfActorId), (TablesToCompact, tablesToCompact),
+                        (NeedsFreshCompaction, needsFreshCompaction));
+                    Compact(std::move(tablesToCompact), needsFreshCompaction);
+                }
             }
 
             STLOG(PRI_DEBUG, BS_VDISK_DEFRAG, BSVDD15, DCtx->VCtx->VDiskLogPrefix << "quantum finished",

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge_ut.cpp
@@ -30,7 +30,7 @@ namespace NKikimr {
             std::unique_ptr<THullHugeKeeperPersState> state(
                     new THullHugeKeeperPersState(vctx, chunkSize, appendBlockSize,
                         appendBlockSize, milestoneHugeBlobInBytes, maxBlobInBytes,
-                        overhead, 0, false, freeChunksReservation, logf));
+                        overhead, 0, false, freeChunksReservation, false, logf));
 
             state->LogPos = THullHugeRecoveryLogPos(0, 0, 100500, 50000, 70000, 56789, 39482);
 

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap.h
@@ -5,6 +5,7 @@
 
 #include <ydb/core/blobstorage/vdisk/common/vdisk_log.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_hugeblobctx.h>
+#include <ydb/core/control/lib/immediate_control_board_wrapper.h>
 #include <ydb/core/util/bits.h>
 #include <util/generic/set.h>
 #include <util/ysaveload.h>
@@ -138,6 +139,7 @@ namespace NKikimr {
             static constexpr ui32 MaxNumberOfSlots = 32768; // it's not a good idea to have more slots than this
             TString VDiskLogPrefix;
             TMask ConstMask; // mask of 'all slots are free'
+            TControlWrapper ChunksSoftLocking;
             TFreeSpace FreeSpace;
             TFreeSpace LockedChunks;
             ui32 AllocatedSlots = 0;
@@ -151,9 +153,10 @@ namespace NKikimr {
             static TMask BuildConstMask(const TString &prefix, ui32 slotsInChunk);
 
         public:
-            TChain(TString vdiskLogPrefix, ui32 slotsInChunk, ui32 slotSize)
+            TChain(TString vdiskLogPrefix, ui32 slotsInChunk, ui32 slotSize, TControlWrapper chunksSoftLocking)
                 : VDiskLogPrefix(std::move(vdiskLogPrefix))
                 , ConstMask(BuildConstMask(vdiskLogPrefix, slotsInChunk))
+                , ChunksSoftLocking(chunksSoftLocking)
                 , SlotsInChunk(slotsInChunk)
                 , SlotSize(slotSize)
             {}
@@ -193,7 +196,7 @@ namespace NKikimr {
             void ShredNotify(const std::vector<ui32>& chunksToShred);
             void ListChunks(const THashSet<TChunkIdx>& chunksOfInterest, THashSet<TChunkIdx>& chunks);
 
-            static TChain Load(IInputStream *s, TString vdiskLogPrefix, ui32 appendBlockSize, ui32 blocksInChunk);
+            static TChain Load(IInputStream *s, TString vdiskLogPrefix, ui32 appendBlockSize, ui32 blocksInChunk, TControlWrapper chunksSoftLocking);
 
             template<typename T>
             void ForEachFreeSpaceChunk(T&& callback) const {
@@ -228,7 +231,8 @@ namespace NKikimr {
                 ui32 maxHugeBlobInBytes,
                 ui32 overhead,
                 ui32 stepsBetweenPowersOf2,
-                bool useBucketsV2);
+                bool useBucketsV2,
+                TControlWrapper chunksSoftLocking);
 
             TAllChains(const TString& vdiskLogPrefix, const NKikimrVDiskData::THugeKeeperHeap& heap);
 
@@ -274,6 +278,7 @@ namespace NKikimr {
             TDynBitMap DeserializedChains; // a bit mask of chains that were deserialized from the origin stream
             std::vector<TChain> Chains;
             std::vector<ui16> SearchTable; // (NumFullBlocks - 1) -> Chain index
+            TControlWrapper ChunksSoftLocking;
         };
 
 
@@ -310,7 +315,8 @@ namespace NKikimr {
                 // new bucket scheme
                 ui32 stepsBetweenPowersOf2,
                 bool useBucketsV2,
-                ui32 freeChunksReservation);
+                ui32 freeChunksReservation,
+                TControlWrapper chunksSoftLocking);
 
             THeap(const TString& vdiskLogPrefix, const NKikimrVDiskData::THugeKeeperHeap& heap);
 

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap_ctx_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap_ctx_ut.cpp
@@ -33,6 +33,7 @@ namespace NKikimr {
                     cfg.HugeBlobStepsBetweenPowersOf2,
                     false,
                     cfg.HugeBlobsFreeChunkReservation,
+                    cfg.GarbageThresholdToRunFullCompactionPerMille,
                     logFunc);
 
             return std::make_shared<THugeBlobCtx>("",

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap_ut.cpp
@@ -52,7 +52,7 @@ namespace NKikimr {
         }
 
         void AllocFreeOneChunk(ui32 slotsInChunk) {
-            TChain chain("vdisk", slotsInChunk, 1);
+            TChain chain("vdisk", slotsInChunk, 1, false);
             TVector<NPrivate::TChunkSlot> arr;
             AllocateScenaryOneChunk(chain, arr, slotsInChunk);
             FreeScenaryOneChunk(chain, arr, slotsInChunk);
@@ -129,7 +129,7 @@ namespace NKikimr {
         }
 
         void AllocFreeAlloc(ui32 slotsInChunk) {
-            TChain chain("vdisk", slotsInChunk, 1);
+            TChain chain("vdisk", slotsInChunk, 1, false);
             TVector<NPrivate::TChunkSlot> arr;
             TVector<ui32> chunks;
 
@@ -144,13 +144,13 @@ namespace NKikimr {
 
             TStringStream serialized;
 
-            TChain chain("vdisk", slotsInChunk, 1);
+            TChain chain("vdisk", slotsInChunk, 1, false);
             PreliminaryAllocate(24, chain, arr);
             FreeChunksScenary(chain, arr, chunks);
             chain.Save(&serialized);
 
             TStringInput str(serialized.Str());
-            TChain chain2 = TChain::Load(&str, "vdisk", 1 /*appendBlockSize*/, slotsInChunk);
+            TChain chain2 = TChain::Load(&str, "vdisk", 1 /*appendBlockSize*/, slotsInChunk, false);
         }
 
         Y_UNIT_TEST(AllocFreeAllocTest) {
@@ -263,7 +263,7 @@ namespace NKikimr {
                 ui32 freeChunksReservation = 0;
 
                 THeap heap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, mileStoneBlobInBytes,
-                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                 heap.FinishRecovery();
                 ui32 hugeBlobSize = 6u << 20u;
 
@@ -288,7 +288,7 @@ namespace NKikimr {
                 // just serialize/deserialize
                 TString serialized = heap.Serialize();
                 THeap newHeap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, mileStoneBlobInBytes,
-                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                 newHeap.ParseFromString(serialized);
                 newHeap.FinishRecovery();
             }
@@ -336,7 +336,7 @@ namespace NKikimr {
                 ui32 freeChunksReservation = 0;
 
                 THeap heap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, minHugeBlobInBytes,
-                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                 heap.FinishRecovery();
                 TVector<THugeSlot> arr;
 
@@ -357,7 +357,7 @@ namespace NKikimr {
                 ui32 freeChunksReservation = 0;
 
                 THeap heap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, minHugeBlobInBytes,
-                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                 heap.FinishRecovery();
                 TVector<THugeSlot> arr;
 
@@ -379,7 +379,7 @@ namespace NKikimr {
                     UNIT_ASSERT(THeap::CheckEntryPoint(serialized));
 
                     THeap newHeap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, minHugeBlobInBytes,
-                            maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                            maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                     newHeap.ParseFromString(serialized);
                     newHeap.FinishRecovery();
 
@@ -401,7 +401,7 @@ namespace NKikimr {
                 ui32 freeChunksReservation = 0;
 
                 THeap heap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, minHugeBlobInBytes,
-                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                 heap.FinishRecovery();
 
                 heap.RecoveryModeAddChunk(2);
@@ -435,7 +435,7 @@ namespace NKikimr {
                 ui32 freeChunksReservation = 1;
 
                 THeap heap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, minHugeBlobInBytes,
-                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                 heap.FinishRecovery();
 
                 THugeSlot hugeSlot;
@@ -461,7 +461,7 @@ namespace NKikimr {
                 ui32 freeChunksReservation = 0;
 
                 THeap oldHeap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, mileStoneBlobInBytes,
-                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                        maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                 oldHeap.FinishRecovery();
                 TVector<THugeSlot> arr;
 
@@ -480,7 +480,7 @@ namespace NKikimr {
                     FreeScenary(toHeap, arr);
                 } else {
                     THeap fromHeap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, mileStoneBlobInBytes,
-                            maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                            maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                     fromHeap.ParseFromString(oldHeap.Serialize());
                     fromHeap.FinishRecovery();
 
@@ -489,10 +489,60 @@ namespace NKikimr {
                     UNIT_ASSERT(THeap::CheckEntryPoint(serialized));
 
                     THeap toHeap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, mileStoneBlobInBytes,
-                            maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation);
+                            maxBlobInBytes, overhead, stepsBetweenPowersOf2, useBucketsV2, freeChunksReservation, false);
                     toHeap.ParseFromString(serialized);
                     toHeap.FinishRecovery();
                     FreeScenary(toHeap, arr);
+                }
+            }
+        }
+
+        Y_UNIT_TEST(LockChunks) {
+            ui32 chunkSize = 134274560u;
+            ui32 appendBlockSize = 56896u;
+            ui32 minHugeBlobInBytes = 56u << 10u;
+            ui32 milestoneBlobInBytes = 512u << 10u;
+            ui32 maxBlobInBytes = 10u << 20u;
+            ui32 overhead = 8;
+            ui32 freeChunksReservation = 0;
+            ui32 hugeBlobSize = 6u << 20u;
+
+            for (bool chunksSoftLocking: {false, true}) {
+                THeap heap("vdisk", chunkSize, appendBlockSize, minHugeBlobInBytes, milestoneBlobInBytes,
+                    maxBlobInBytes, overhead, 0, false, freeChunksReservation, chunksSoftLocking);
+                heap.FinishRecovery();
+                heap.AddChunk(5);
+                heap.AddChunk(3);
+
+                THugeSlot slot1, slot2;
+                ui32 slotSize;
+                ui32 lockedChunkId;
+
+                // fill 1 chunk
+                for (ui32 i = 0; i < heap.SlotNumberOfThisSize(hugeBlobSize); i++) {
+                    UNIT_ASSERT(heap.Allocate(hugeBlobSize, &slot1, &slotSize));
+                }
+
+                // allocate 1 slot from another chunk and lock it
+                UNIT_ASSERT(heap.Allocate(hugeBlobSize, &slot2, &slotSize));
+                lockedChunkId = slot2.GetChunkId();
+                heap.LockChunkForAllocation(lockedChunkId, slotSize);
+
+                // free one slot from the first chunk
+                heap.Free(slot1.GetDiskPart());
+
+                // allocate new slot, it should not be from the locked chunk, because we have free slot in the first chunk
+                THugeSlot slot;
+                UNIT_ASSERT(heap.Allocate(hugeBlobSize, &slot, &slotSize));
+                UNIT_ASSERT_VALUES_UNEQUAL(slot.GetChunkId(), lockedChunkId);
+
+                if (!chunksSoftLocking) {
+                    // we have no more free slots in first chunk, second chunk is locked, so we can't allocate
+                    UNIT_ASSERT(!heap.Allocate(hugeBlobSize, &slot, &slotSize));
+                } else {
+                    // allocate another slot, it should be from the locked chunk, because we have no free slots in the first chunk
+                    UNIT_ASSERT(heap.Allocate(hugeBlobSize, &slot, &slotSize));
+                    UNIT_ASSERT_VALUES_EQUAL(slot.GetChunkId(), lockedChunkId);
                 }
             }
         }

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.cpp
@@ -79,12 +79,13 @@ namespace NKikimr {
                                                            const ui32 stepsBetweenPowersOf2,
                                                            const bool enableTinyDisks,
                                                            const ui32 freeChunksReservation,
+                                                           TControlWrapper chunksSoftLocking,
                                                            std::function<void(const TString&)> logFunc)
             : VCtx(std::move(vctx))
             , Heap(new NHuge::THeap(VCtx->VDiskLogPrefix, chunkSize, appendBlockSize,
                                     minHugeBlobInBytes, milestoneHugeBlobInBytes,
                                     maxBlobInBytes, overhead, stepsBetweenPowersOf2,
-                                    enableTinyDisks, freeChunksReservation))
+                                    enableTinyDisks, freeChunksReservation, chunksSoftLocking))
             , Guid(TAppData::RandomProvider->GenRand64())
             , EnableTinyDisks(enableTinyDisks)
         {
@@ -106,12 +107,13 @@ namespace NKikimr {
                                                            const ui32 freeChunksReservation,
                                                            const ui64 entryPointLsn,
                                                            const TContiguousSpan &entryPointData,
+                                                           TControlWrapper chunksSoftLocking,
                                                            std::function<void(const TString&)> logFunc)
             : VCtx(std::move(vctx))
             , Heap(new NHuge::THeap(VCtx->VDiskLogPrefix, chunkSize, appendBlockSize,
                                     minHugeBlobInBytes, milestoneHugeBlobInBytes,
                                     maxBlobInBytes, overhead, stepsBetweenPowersOf2,
-                                    false, freeChunksReservation))
+                                    false, freeChunksReservation, chunksSoftLocking))
             , Guid(TAppData::RandomProvider->GenRand64())
             , PersistentLsn(entryPointLsn)
             , EnableTinyDisks(enableTinyDisks)

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.h
@@ -101,6 +101,7 @@ namespace NKikimr {
                                      const ui32 stepsBetweenPowersOf2,
                                      const bool enableTinyDisks,
                                      const ui32 freeChunksReservation,
+                                     TControlWrapper chunksSoftLocking,
                                      std::function<void(const TString&)> logFunc);
 
             THullHugeKeeperPersState(TIntrusivePtr<TVDiskContext> vctx,
@@ -115,6 +116,7 @@ namespace NKikimr {
                                      const ui32 freeChunksReservation,
                                      const ui64 entryPointLsn,
                                      const TContiguousSpan &entryPointData,
+                                     TControlWrapper chunksSoftLocking,
                                      std::function<void(const TString&)> logFunc);
 
             ~THullHugeKeeperPersState();

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
@@ -518,6 +518,7 @@ namespace NKikimr {
                             stepsBetweenPowersOf2,
                             enableTinyDisks,
                             Config->HugeBlobsFreeChunkReservation,
+                            Config->GarbageThresholdToRunFullCompactionPerMille,
                             logFunc);
             } else {
                 // read existing one
@@ -541,7 +542,10 @@ namespace NKikimr {
                             stepsBetweenPowersOf2,
                             enableTinyDisks,
                             Config->HugeBlobsFreeChunkReservation,
-                            lsn, entryPoint, logFunc);
+                            lsn,
+                            entryPoint,
+                            Config->GarbageThresholdToRunFullCompactionPerMille,
+                            logFunc);
             }
             HugeBlobCtx = std::make_shared<THugeBlobCtx>(LocRecCtx->VCtx->VDiskLogPrefix,
                 LocRecCtx->RepairedHuge->Heap->BuildHugeSlotsMap(), Config->BlobHeaderMode);

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_tracker.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_tracker.cpp
@@ -92,6 +92,7 @@ namespace NKikimr {
             VCtx->OutOfSpaceState.UpdateLocalLog(msg->LogStatusFlags);
             VCtx->OutOfSpaceState.UpdateLocalFreeSpaceShare(ui64(1 << 24) * (1.0 - msg->Occupancy));
             VCtx->OutOfSpaceState.UpdateLocalUsedChunks(msg->UsedChunks);
+            VCtx->OutOfSpaceState.UpdateLocalTotalChunks(msg->TotalChunks);
             MonGroup.DskTotalBytes() = msg->TotalChunks * PDiskCtx->Dsk->ChunkSize;
             MonGroup.DskFreeBytes() = msg->FreeChunks * PDiskCtx->Dsk->ChunkSize;
             MonGroup.DskUsedBytes() = msg->UsedChunks * PDiskCtx->Dsk->ChunkSize;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1667,6 +1667,11 @@ message TImmediateControlsConfig {
             MinValue: 1,
             MaxValue: 50,
             DefaultValue: 10 }];
+        optional uint64 GarbageThresholdToRunFullCompactionPerMille = 36 [(ControlOptions) = {
+            Description: "Maximal allowed fraction from vdisk fare share of garbage before compaction would be triggered. If value = 0 - compaction would run after every defragmentation quantum",
+            MinValue: 0,
+            MaxValue: 300,
+            DefaultValue: 0 }];
 
         reserved 14;
         optional uint64 ThrottlingDryRun = 26 [(ControlOptions) = {
@@ -1771,6 +1776,12 @@ message TImmediateControlsConfig {
 
         optional uint64 HullCompThrottlerBytesRate = 35 [(ControlOptions) = {
             Description: "Rate bytes in 1 second for requests (sum of write and read) in compaction throttler",
+            MinValue: 0,
+            MaxValue: 10000000000, // 10 GB/s
+            DefaultValue: 0 }];
+
+        optional uint64 DefragThrottlerBytesRate = 37 [(ControlOptions) = {
+            Description: "Rate bytes in 1 second for requests (sum of write and read) in defragmentation throttler",
             MinValue: 0,
             MaxValue: 10000000000, // 10 GB/s
             DefaultValue: 0 }];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added 2 new defragmentation settings: garbage_threshold_to_run_full_compaction_per_mille - makes compaction and defragmentation independent, and defrag_throttler_bytes_rate - limit defragmentation rate

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Current behavior:** When the percentage of space that can be freed in huge chunks exceeds the threshold HugeDefragFreeSpaceBorderPerMille, defragmentation is triggered. It operates in quanta, processing up to MaxChunksToDefragInflight chunks at a time. At the beginning of each quantum, the least filled chunks are selected and locked so that no new slots can be allocated from them. Then, all data from these chunks is rewritten into other chunks. After that, a compaction process is started, which removes references to these chunks from the LSM.

**Problem:** The amount of compaction work is often much greater than the amount of data being defragmented, which significantly slows down defragmentation and increases system load.

**Solution:** Instead of running compaction after every defragmentation quantum, it is now triggered only when the amount of space that can be freed by compaction exceeds a certain percentage of the vdisks fair share — GarbageThresholdToRunFullCompactionPerMille (if this value is set to zero, the old behavior is preserved). However, this approach can cause some chunks to remain locked for a long time, which may lead to increased space usage. To mitigate this, a soft lock mechanism was introduced, allowing writes to a locked chunk if no free chunks are available. Additionally, since this change significantly increased the system load caused by defragmentation, a new setting DefragThrottlerBytesRate was added to limit the defragmentation throughput per vdisk.

**Configuration example:**
```
immediate_controls_config:
  vdisk_controls:
    garbage_threshold_to_run_full_compaction_per_mille: 20
    defrag_throttler_bytes_rate: 5000000
```
