### PR TITLE
Impl compatibility tests for parametrized writes and reads

### DIFF
--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -1,11 +1,20 @@
 import pytest
 import math
 
+from decimal import Decimal
 from datetime import datetime, timedelta
 from ydb.tests.library.compatibility.fixtures import RestartToAnotherVersionFixture
 from ydb.tests.oss.ydb_sdk_import import ydb
 from ydb.tests.datashard.lib.create_table import create_table_sql_request
-from ydb.tests.datashard.lib.types_of_variables import pk_types, non_pk_types, cleanup_type_name, format_sql_value, types_not_supported_yet_in_columnshard
+from ydb.tests.datashard.lib.types_of_variables import (
+    pk_types,
+    non_pk_types,
+    cleanup_type_name,
+    format_sql_value,
+    types_not_supported_yet_in_columnshard,
+    non_comparable_types,
+    primitive_type,
+)
 
 
 class TestDataType(RestartToAnotherVersionFixture):
@@ -159,6 +168,90 @@ class TestDataType(RestartToAnotherVersionFixture):
             for query in querys:
                 session_pool.execute_with_retries(query)
 
+    def create_typed_value(self, type_name, value):
+        if "Decimal" in type_name:
+            prec, scale = type_name.replace("Decimal(", "").replace(")", "").split(",")
+            return ydb.TypedValue(Decimal(value), ydb.DecimalType(int(prec), int(scale)))
+        if type_name == "String" or type_name == "Yson":
+            return ydb.TypedValue(value.encode(), primitive_type[type_name])
+        if type_name == "DyNumber":
+            return ydb.TypedValue(str(value), primitive_type[type_name])
+        if type_name == "Datetime64" or type_name == "Datetime":
+            return ydb.TypedValue(int(value.timestamp()), primitive_type[type_name])
+        return ydb.TypedValue(value, primitive_type[type_name])
+
+    def parametrized_write_data(self):
+        queries_with_parameters = []
+
+        for i in range(self.count_table):
+            query = f"""
+                {";".join([f"DECLARE $pk_{cleanup_type_name(name)} AS {name}" for name in self.pk_types[i].keys()])};
+                {";".join([f"DECLARE $col_{cleanup_type_name(name)} AS {name}" for name in self.all_types.keys()])};
+
+                UPSERT INTO {self.table_names[i]} (
+                    {", ".join([f"pk_{cleanup_type_name(name)}" for name in self.pk_types[i].keys()])},
+                    {", ".join([f"col_{cleanup_type_name(name)}" for name in self.all_types.keys()])}
+                )
+                VALUES (
+                    {", ".join([f"$pk_{cleanup_type_name(name)}" for name in self.pk_types[i].keys()])},
+                    {", ".join([f"$col_{cleanup_type_name(name)}" for name in self.all_types.keys()])}
+                );
+            """
+
+            for row in range(1, self.count_rows + 1):
+                parameters = {}
+                for idx, (type_name, lamb) in enumerate(self.pk_types[i].items()):
+                    parameters[f"$pk_{cleanup_type_name(type_name)}"] = self.create_typed_value(type_name, lamb(row))
+                for idx, (type_name, lamb) in enumerate(self.all_types.items()):
+                    parameters[f"$col_{cleanup_type_name(type_name)}"] = self.create_typed_value(type_name, lamb(row))
+                queries_with_parameters.append((query, parameters))
+
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            for query, parameters in queries_with_parameters:
+                session_pool.execute_with_retries(query, parameters)
+
+    def parametrized_check_table(self):
+        queries_with_parameters = []
+        comparable_types = [(type_name, lamb) for type_name, lamb in self.all_types.items() if type_name not in non_comparable_types]
+
+        for i in range(self.count_table):
+            query = f"""
+                {";".join([f"DECLARE $pk_{cleanup_type_name(name)} AS {name}" for name in self.pk_types[i].keys()])};
+                {";".join([f"DECLARE $col_{cleanup_type_name(name)} AS {name}" for name, _ in comparable_types])};
+
+                SELECT * FROM {self.table_names[i]} WHERE 
+                {" AND ".join([f"pk_{cleanup_type_name(name)} = $pk_{cleanup_type_name(name)}" for name in self.pk_types[i].keys()])}
+                {" AND " if len(comparable_types) != 0 else ""}
+                {" AND ".join([f"col_{cleanup_type_name(name)} = $col_{cleanup_type_name(name)}" for name, _ in comparable_types])}
+            """
+
+            for row in range(1, self.count_rows + 1):
+                parameters = {}
+                for idx, (type_name, lamb) in enumerate(self.pk_types[i].items()):
+                    parameters[f"$pk_{cleanup_type_name(type_name)}"] = self.create_typed_value(type_name, lamb(row))
+                for idx, (type_name, lamb) in enumerate(comparable_types):
+                    parameters[f"$col_{cleanup_type_name(type_name)}"] = self.create_typed_value(type_name, lamb(row))
+                queries_with_parameters.append((query, parameters))
+
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            for query_index, (query, parameters) in enumerate(queries_with_parameters):
+                table_index = query_index // self.count_rows
+                row_num = (query_index % self.count_rows) + 1
+
+                result_rows = []
+
+                result_sets = session_pool.execute_with_retries(query, parameters)
+                for result_set in result_sets:
+                    for row in result_set.rows:
+                        result_rows.append(row)
+
+                assert len(result_rows) == 1
+
+                for row in result_rows:
+                    for prefix in self.columns[table_index].keys():
+                        for type_name in self.columns[table_index][prefix]:
+                            self.assert_type(type_name, row_num, row[f"{prefix}{cleanup_type_name(type_name)}"])
+
     @pytest.mark.parametrize("store_type", ["ROW", "COLUMN"], indirect=True)
     def test_data_type(self):
         if any("Decimal" in type_name for type_name in self.all_types.keys()) and self.store_type == "COLUMN":
@@ -175,3 +268,20 @@ class TestDataType(RestartToAnotherVersionFixture):
         self.check_table()
         self.write_data()
         self.check_table()
+
+    @pytest.mark.parametrize("store_type", ["ROW", "COLUMN"], indirect=True)
+    def test_parametrized_data_type(self):
+        if any("Decimal" in type_name for type_name in self.all_types.keys()) and self.store_type == "COLUMN":
+            if (min(self.versions) < (25, 1)):
+                pytest.skip("Decimal types are not supported in columnshard in this version")
+
+        self.create_table()
+
+        self.parametrized_write_data()
+        self.parametrized_check_table()
+
+        self.change_cluster_version()
+
+        self.parametrized_check_table()
+        self.parametrized_write_data()
+        self.parametrized_check_table()

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -200,9 +200,9 @@ class TestDataType(RestartToAnotherVersionFixture):
 
             for row in range(1, self.count_rows + 1):
                 parameters = {}
-                for idx, (type_name, lamb) in enumerate(self.pk_types[i].items()):
+                for type_name, lamb in self.pk_types[i].items():
                     parameters[f"$pk_{cleanup_type_name(type_name)}"] = self.create_typed_value(type_name, lamb(row))
-                for idx, (type_name, lamb) in enumerate(self.all_types.items()):
+                for type_name, lamb in self.all_types.items():
                     parameters[f"$col_{cleanup_type_name(type_name)}"] = self.create_typed_value(type_name, lamb(row))
                 queries_with_parameters.append((query, parameters))
 
@@ -221,15 +221,15 @@ class TestDataType(RestartToAnotherVersionFixture):
 
                 SELECT * FROM {self.table_names[i]} WHERE 
                 {" AND ".join([f"pk_{cleanup_type_name(name)} = $pk_{cleanup_type_name(name)}" for name in self.pk_types[i].keys()])}
-                {" AND " if len(comparable_types) != 0 else ""}
+                {" AND " if len(comparable_types) > 0 else ""}
                 {" AND ".join([f"col_{cleanup_type_name(name)} = $col_{cleanup_type_name(name)}" for name, _ in comparable_types])}
             """
 
             for row in range(1, self.count_rows + 1):
                 parameters = {}
-                for idx, (type_name, lamb) in enumerate(self.pk_types[i].items()):
+                for type_name, lamb in self.pk_types[i].items():
                     parameters[f"$pk_{cleanup_type_name(type_name)}"] = self.create_typed_value(type_name, lamb(row))
-                for idx, (type_name, lamb) in enumerate(comparable_types):
+                for type_name, lamb in comparable_types:
                     parameters[f"$col_{cleanup_type_name(type_name)}"] = self.create_typed_value(type_name, lamb(row))
                 queries_with_parameters.append((query, parameters))
 

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from datetime import datetime
+import ydb
 
 
 def format_sql_value(value, type_name, unwrap_after_cast: bool = False):
@@ -253,4 +254,39 @@ types_not_supported_yet_in_columnshard = {
     "DyNumber",
     "UUID",
     "Interval"
+}
+
+non_comparable_types = {
+    "Yson",
+    "Json",
+    "JsonDocument",
+}
+
+primitive_type = {
+    "Int64": ydb.PrimitiveType.Int64,
+    "Uint64": ydb.PrimitiveType.Uint64,
+    "Int32": ydb.PrimitiveType.Int32,
+    "Uint32": ydb.PrimitiveType.Uint32,
+    "Int16": ydb.PrimitiveType.Int16,
+    "Uint16": ydb.PrimitiveType.Uint16,
+    "Int8": ydb.PrimitiveType.Int8,
+    "Uint8": ydb.PrimitiveType.Uint8,
+    "Bool": ydb.PrimitiveType.Bool,
+    "DyNumber": ydb.PrimitiveType.DyNumber,
+    "String": ydb.PrimitiveType.String,
+    "Utf8": ydb.PrimitiveType.Utf8,
+    "UUID": ydb.PrimitiveType.UUID,
+    "Date": ydb.PrimitiveType.Date,
+    "Datetime": ydb.PrimitiveType.Datetime,
+    "Timestamp": ydb.PrimitiveType.Timestamp,
+    "Interval": ydb.PrimitiveType.Interval,
+    "Float": ydb.PrimitiveType.Float,
+    "Double": ydb.PrimitiveType.Double,
+    "Json": ydb.PrimitiveType.Json,
+    "JsonDocument": ydb.PrimitiveType.JsonDocument,
+    "Yson": ydb.PrimitiveType.Yson,
+    "Date32": ydb.PrimitiveType.Date32,
+    "Datetime64": ydb.PrimitiveType.Datetime64,
+    "Timestamp64": ydb.PrimitiveType.Timestamp64,
+    "Interval64": ydb.PrimitiveType.Interval64,
 }

--- a/ydb/tests/datashard/parametrized_queries/test_parametrized_queries.py
+++ b/ydb/tests/datashard/parametrized_queries/test_parametrized_queries.py
@@ -17,6 +17,7 @@ from ydb.tests.datashard.lib.types_of_variables import (
     index_three_sync_not_Bool,
     index_four_sync,
     index_zero_sync,
+    primitive_type,
 )
 
 # https://github.com/ydb-platform/ydb/issues/17178
@@ -29,36 +30,6 @@ unsupported_types = [
 
 def filter_unsupported(type_map):
     return {k: v for k, v in type_map.items() if k not in unsupported_types}
-
-
-primitive_type = {
-    "Int64": ydb.PrimitiveType.Int64,
-    "Uint64": ydb.PrimitiveType.Uint64,
-    "Int32": ydb.PrimitiveType.Int32,
-    "Uint32": ydb.PrimitiveType.Uint32,
-    "Int16": ydb.PrimitiveType.Int16,
-    "Uint16": ydb.PrimitiveType.Uint16,
-    "Int8": ydb.PrimitiveType.Int8,
-    "Uint8": ydb.PrimitiveType.Uint8,
-    "Bool": ydb.PrimitiveType.Bool,
-    "DyNumber": ydb.PrimitiveType.DyNumber,
-    "String": ydb.PrimitiveType.String,
-    "Utf8": ydb.PrimitiveType.Utf8,
-    "UUID": ydb.PrimitiveType.UUID,
-    "Date": ydb.PrimitiveType.Date,
-    "Datetime": ydb.PrimitiveType.Datetime,
-    "Timestamp": ydb.PrimitiveType.Timestamp,
-    "Interval": ydb.PrimitiveType.Interval,
-    "Float": ydb.PrimitiveType.Float,
-    "Double": ydb.PrimitiveType.Double,
-    "Json": ydb.PrimitiveType.Json,
-    "JsonDocument": ydb.PrimitiveType.JsonDocument,
-    "Yson": ydb.PrimitiveType.Yson,
-    "Date32": ydb.PrimitiveType.Date32,
-    "Datetime64": ydb.PrimitiveType.Datetime64,
-    "Timestamp64": ydb.PrimitiveType.Timestamp64,
-    "Interval64": ydb.PrimitiveType.Interval64,
-}
 
 
 class TestParametrizedQueries(TestBase):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added new test for parametrized writes and reads for any comparable type (DS and CS, without `Yson`, `Json` and `JsonDocument`).
- Parametrized (with parameters) write example: `INSERT INTO test (V1, V2) VALUES ($p1, $p2);` 
- Parametrized (with parameters) read example: `SELECT * FROM test WHERE V1 = $p1 AND V2 = $p2;`

...
