### PR TITLE
25-1: Make it possible to backup out-of-range decimal values

### DIFF
--- a/ydb/core/tx/datashard/type_serialization.cpp
+++ b/ydb/core/tx/datashard/type_serialization.cpp
@@ -15,7 +15,10 @@ TString DecimalToString(const std::pair<ui64, i64>& loHi, const NScheme::TTypeIn
     using namespace NYql::NDecimal;
 
     TInt128 val = FromHalfs(loHi.first, loHi.second);
-    return ToString(val, typeInfo.GetDecimalType().GetPrecision(), typeInfo.GetDecimalType().GetScale());
+    const char* result = ToString(val, MaxPrecision /*typeInfo.GetDecimalType().GetPrecision()*/, typeInfo.GetDecimalType().GetScale());
+    Y_ENSURE(result);
+
+    return result;
 }
 
 TString DyNumberToString(TStringBuf data) {
@@ -36,11 +39,15 @@ TString PgToString(TStringBuf data, const NScheme::TTypeInfo& typeInfo) {
 }
 
 bool DecimalToStream(const std::pair<ui64, i64>& loHi, IOutputStream& out, TString& err, const NScheme::TTypeInfo& typeInfo) {
-    Y_UNUSED(err);
     using namespace NYql::NDecimal;
 
     TInt128 val = FromHalfs(loHi.first, loHi.second);
-    out << ToString(val, typeInfo.GetDecimalType().GetPrecision(), typeInfo.GetDecimalType().GetScale());
+    const char* result = ToString(val, MaxPrecision /*typeInfo.GetDecimalType().GetPrecision()*/, typeInfo.GetDecimalType().GetScale());
+    if (!result) [[unlikely]] {
+        err = "Invalid Decimal binary representation";
+        return false;
+    }
+    out << result;
     return true;
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix backup of out-of-range decimal values which may have been accidentally inserted into tables. Fixes #26470.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

We now use MaxPrecision when transforming binary decimal values into strings, so it does not result in unexpected `nullptr` as long as the binary value is correct (less than ±10^35 or one of special values). Also make sure to handle `nullptr` result as an error.