### PR TITLE
Add splitting tuple layout rows into buckets

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.cpp
@@ -1,0 +1,278 @@
+#include "accumulator.h"
+
+#include <cstdlib>
+
+#include <yql/essentials/utils/prefetch.h>
+
+#include <arrow/util/bit_util.h>
+
+#include "histogram.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+// -----------------------------------------------------------------------
+THolder<TAccumulator> TAccumulator::Create(
+    const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets)
+{
+    // according to https://www.cidrdb.org/cidr2019/papers/p133-zhang-cidr19.pdf
+    if (log2Buckets <= 6)
+    {
+        return MakeHolder<TAccumulatorImpl>(
+            layout, bitShift, log2Buckets, std::move(packedTupleBuckets), std::move(overflowBuckets));
+    }
+
+    if (log2Buckets <= 13 && layout->TotalRowSize <= 128 && layout->VariableColumns.empty()) // tuple is too wide SMB will not help us, because the number of tuples that fit into the buffer will be small
+    {
+        return MakeHolder<TSMBAccumulatorImpl>(
+           layout, bitShift, log2Buckets, std::move(packedTupleBuckets), std::move(overflowBuckets));
+    }
+
+    return MakeHolder<TAccumulatorImpl>(
+        layout, bitShift, log2Buckets, std::move(packedTupleBuckets), std::move(overflowBuckets));
+}
+
+THolder<TAccumulator> TAccumulator::Create(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets) {
+    // according to https://www.cidrdb.org/cidr2019/papers/p133-zhang-cidr19.pdf
+    if (log2Buckets <= 6)
+    {
+        return MakeHolder<TAccumulatorImpl>(layout, bitShift, log2Buckets);
+    }
+
+    if (log2Buckets <= 13 && layout->TotalRowSize <= 128 && layout->VariableColumns.empty()) // tuple is too wide SMB will not help us, because the number of tuples that fit into the buffer will be small
+    {
+        return MakeHolder<TSMBAccumulatorImpl>(layout, bitShift, log2Buckets);
+    }
+
+    return MakeHolder<TAccumulatorImpl>(layout, bitShift, log2Buckets);
+}
+
+// -----------------------------------------------------------------------
+TAccumulatorImpl::TAccumulatorImpl(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets)
+    : NBuckets_(1 << log2Buckets)
+    , Layout_(layout)
+    , PackedTupleBucketSizes_(NBuckets_, 0)
+    , OverflowBucketSizes_(NBuckets_, 0)
+    , PackedTupleBuckets_(NBuckets_)
+    , OverflowBuckets_(NBuckets_)
+{
+    Shift_ = sizeof(ui32) * 8 - (log2Buckets + bitShift);
+    Mask_ = (1u << log2Buckets) - 1;
+}
+
+TAccumulatorImpl::TAccumulatorImpl(
+    const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets
+)
+    : NBuckets_(1 << log2Buckets)
+    , Layout_(layout)
+    , PackedTupleBucketSizes_(NBuckets_, 0)
+    , OverflowBucketSizes_(NBuckets_, 0)
+    , NoAllocations_(true)
+    , PackedTupleBuckets_(std::move(packedTupleBuckets))
+    , OverflowBuckets_(std::move(overflowBuckets))
+{
+    Shift_ = sizeof(ui32) * 8 - (log2Buckets + bitShift);
+    Mask_ = (1u << log2Buckets) - 1;
+}
+
+void TAccumulatorImpl::AddData(const ui8* data, const ui8* overflow, ui32 nItems) {
+    const auto layoutTotalRowSize = Layout_->TotalRowSize;
+
+    if (!NoAllocations_) {
+        Histogram hist;
+        hist.AddData(Layout_, data, nItems, TAccumulator::GetBucketId, Shift_, Mask_);
+        std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(NBuckets_, {0, 0});
+        hist.EstimateSizes(sizes);
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets_[i].resize(PackedTupleBuckets_[i].size() + TLsize);
+            OverflowBuckets_[i].resize(OverflowBuckets_[i].size() + Osize);
+        }
+    }
+
+    for (ui32 i = 0; i < nItems; ++i) {
+        const ui8* tuple = data + i * layoutTotalRowSize;
+        const ui32 bucketId = GetBucketId(ReadUnaligned<ui32>(tuple), Shift_, Mask_);
+        NYql::PrefetchForRead(tuple + layoutTotalRowSize * 32);
+
+        ui8* ptStoreAddr = PackedTupleBuckets_[bucketId].data() + PackedTupleBucketSizes_[bucketId];
+        ui8* ovStoreAddr = OverflowBuckets_[bucketId].data() + OverflowBucketSizes_[bucketId];
+        NYql::PrefetchForWrite(ptStoreAddr + layoutTotalRowSize);
+
+        Layout_->TupleDeepCopy(tuple, overflow, ptStoreAddr, ovStoreAddr, OverflowBucketSizes_[bucketId]);
+        PackedTupleBucketSizes_[bucketId] += layoutTotalRowSize;
+    }
+}
+
+TAccumulatorImpl::TBucketRef TAccumulatorImpl::GetBucket(ui32 bucket) const {
+    return {
+        &PackedTupleBuckets_[bucket],
+        &OverflowBuckets_[bucket],
+        static_cast<ui32>(PackedTupleBucketSizes_[bucket] / Layout_->TotalRowSize),
+        Layout_
+    };
+}
+
+void TAccumulatorImpl::Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) {
+    buckets.clear();
+    for (size_t i = 0; i < PackedTupleBuckets_.size(); ++i) {
+        ui32 NTuples = static_cast<ui32>(PackedTupleBucketSizes_[i] / Layout_->TotalRowSize);
+        buckets.emplace_back(
+            std::move(PackedTupleBuckets_[i]), std::move(OverflowBuckets_[i]), NTuples, Layout_);
+        PackedTupleBuckets_[i].clear();
+        PackedTupleBucketSizes_[i] = 0;
+    }
+}
+
+// -----------------------------------------------------------------------
+
+static constexpr size_t kSMBSize = 2 * 1024 * 1024;
+
+TSMBAccumulatorImpl::TSMBAccumulatorImpl(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets)
+    : NBuckets_(1 << log2Buckets)
+    , Layout_(layout)
+    , PackedTupleBucketSizes_(NBuckets_, 0)
+    , OverflowBucketSizes_(NBuckets_, 0)
+    , PackedTupleBuckets_(NBuckets_)
+    , OverflowBuckets_(NBuckets_)
+    , PackedTupleSMB_(kSMBSize)
+    , OverflowSMB_(kSMBSize)
+{
+    Shift_ = sizeof(ui32) * 8 - (log2Buckets + bitShift);
+    Mask_ = (1u << log2Buckets) - 1;
+
+    std::memset(PackedTupleSMB_.data(), 0, kSMBSize);
+    std::memset(OverflowSMB_.data(), 0, kSMBSize);
+}
+
+TSMBAccumulatorImpl::TSMBAccumulatorImpl(
+    const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets
+)
+    : NBuckets_(1 << log2Buckets)
+    , Layout_(layout)
+    , PackedTupleBucketSizes_(NBuckets_, 0)
+    , OverflowBucketSizes_(NBuckets_, 0)
+    , NoAllocations_(true)
+    , PackedTupleBuckets_(std::move(packedTupleBuckets))
+    , OverflowBuckets_(std::move(overflowBuckets))
+    , PackedTupleSMB_(kSMBSize + sizeof(ui64) * NBuckets_)
+    , OverflowSMB_(kSMBSize)
+{
+    Shift_ = sizeof(ui32) * 8 - (log2Buckets + bitShift);
+    Mask_ = (1u << log2Buckets) - 1;
+
+    std::memset(PackedTupleSMB_.data(), 0, kSMBSize + sizeof(ui64) * NBuckets_);
+    std::memset(OverflowSMB_.data(), 0, kSMBSize);
+}
+
+void TSMBAccumulatorImpl::AddData(const ui8* data, const ui8* overflow, ui32 nItems) {
+    const auto layoutTotalRowSize = Layout_->TotalRowSize;
+    const ui64 maxBytesPerPartition = kSMBSize / NBuckets_; // in SMB
+    const ui64 maxTuplesPerPartition = maxBytesPerPartition / layoutTotalRowSize;
+
+    const ui8 hasVarSized = static_cast<ui8>(Layout_->VariableColumns.size() > 0);
+
+    if (!NoAllocations_) {
+        Histogram hist;
+        hist.AddData(Layout_, data, nItems, TAccumulator::GetBucketId, Shift_, Mask_);
+        std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(NBuckets_, {0, 0});
+        hist.EstimateSizes(sizes);
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets_[i].resize(PackedTupleBuckets_[i].size() + TLsize);
+            OverflowBuckets_[i].resize(OverflowBuckets_[i].size() + Osize);
+        }
+    }
+
+    ui8* ptSmbPartAddr = nullptr;
+    ui8* ovSmbPartAddr = nullptr;
+    ui8* ptStoreAddr = nullptr;
+    ui8* ovStoreAddr = nullptr;
+    for (ui32 i = 0; i < nItems; ++i) {
+        const ui8* tuple = data + i * layoutTotalRowSize;
+        const ui32 bucketId = GetBucketId(ReadUnaligned<ui32>(tuple), Shift_, Mask_);
+        NYql::PrefetchForRead(tuple + layoutTotalRowSize * 32);
+        auto [nPackedTuples, bytesOverflow] = GetCounters(bucketId, maxBytesPerPartition);
+
+        ptSmbPartAddr = PackedTupleSMB_.data() + bucketId * (maxBytesPerPartition + sizeof(ui64)) + sizeof(ui64); // take bucket in SMB
+        if (nPackedTuples == maxTuplesPerPartition) {
+            ui8* storeAddr = PackedTupleBuckets_[bucketId].data() + PackedTupleBucketSizes_[bucketId];
+            std::memcpy(storeAddr, ptSmbPartAddr, layoutTotalRowSize * nPackedTuples);
+            PackedTupleBucketSizes_[bucketId] += layoutTotalRowSize * nPackedTuples;
+            nPackedTuples = 0;
+        }
+        ptStoreAddr = ptSmbPartAddr + nPackedTuples * layoutTotalRowSize; // take last packed tuple
+
+        // WARNING: do not use SMB with var sized column, because it works slow. Code here is just for demonstration
+        if (hasVarSized) {
+            ovSmbPartAddr = OverflowSMB_.data() + bucketId * maxBytesPerPartition; // take bucket in SMB
+            if (bytesOverflow + Layout_->GetTupleVarSize(tuple) >= maxTuplesPerPartition) {
+                ui8* storeAddr = OverflowBuckets_[bucketId].data() + OverflowBucketSizes_[bucketId];
+                std::memcpy(storeAddr, ovSmbPartAddr, bytesOverflow);
+                OverflowBucketSizes_[bucketId] += bytesOverflow;
+                bytesOverflow = 0;
+            }
+            ovStoreAddr = ovSmbPartAddr + bytesOverflow; // offset
+        } else {
+            nPackedTuples++;
+            NYql::PrefetchForWrite(ptSmbPartAddr + nPackedTuples * layoutTotalRowSize);
+            Layout_->TupleDeepCopy(tuple, overflow, ptStoreAddr, ovStoreAddr, bytesOverflow);
+            WriteUnaligned<ui64>(ptSmbPartAddr - sizeof(ui64), (bytesOverflow << 32) | nPackedTuples);
+        }
+    }
+
+    // flush remaining data in SMB to buckets
+    for (ui32 bucketId = 0; bucketId < NBuckets_; ++bucketId) {
+        auto [nPackedTuples, bytesOverflow] = GetCounters(bucketId, maxBytesPerPartition);
+
+        ptSmbPartAddr = PackedTupleSMB_.data() + bucketId * (maxBytesPerPartition + sizeof(ui64)) + sizeof(ui64); // take bucket in SMB
+        ui8* storeAddr = PackedTupleBuckets_[bucketId].data() + PackedTupleBucketSizes_[bucketId];
+        std::memcpy(storeAddr, ptSmbPartAddr, layoutTotalRowSize * nPackedTuples);
+        PackedTupleBucketSizes_[bucketId] += layoutTotalRowSize * nPackedTuples;
+
+        ovSmbPartAddr = OverflowSMB_.data() + bucketId * maxBytesPerPartition; // take bucket in SMB
+        storeAddr = OverflowBuckets_[bucketId].data() + OverflowBucketSizes_[bucketId];
+        std::memcpy(storeAddr, ovSmbPartAddr, bytesOverflow);
+        OverflowBucketSizes_[bucketId] += bytesOverflow;
+
+        WriteUnaligned<ui64>(ptSmbPartAddr - sizeof(ui64), 0);
+    }
+}
+
+std::pair<ui64, ui64> TSMBAccumulatorImpl::GetCounters(ui32 bucket, ui64 maxBytesPerPartition) {
+    auto counters = ReadUnaligned<ui64>(PackedTupleSMB_.data() + bucket * (maxBytesPerPartition + sizeof(ui64)));
+    ui64 nPackedTuples = counters & 0xFFFFFFFF;
+    ui64 bytesOverflow = (counters >> 32) & 0xFFFFFFFF;
+    return {nPackedTuples, bytesOverflow};
+}
+
+TSMBAccumulatorImpl::TBucketRef TSMBAccumulatorImpl::GetBucket(ui32 bucket) const {
+    return {
+        &PackedTupleBuckets_[bucket],
+        &OverflowBuckets_[bucket],
+        static_cast<ui32>(PackedTupleBucketSizes_[bucket] / Layout_->TotalRowSize),
+        Layout_
+    };
+}
+
+void TSMBAccumulatorImpl::Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) {
+    buckets.clear();
+    for (size_t i = 0; i < PackedTupleBuckets_.size(); ++i) {
+        ui32 NTuples = static_cast<ui32>(PackedTupleBucketSizes_[i] / Layout_->TotalRowSize);
+        buckets.emplace_back(
+            std::move(PackedTupleBuckets_[i]), std::move(OverflowBuckets_[i]), NTuples, Layout_);
+        PackedTupleBuckets_[i].clear();
+        PackedTupleBucketSizes_[i] = 0;
+    }
+}
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+
+#include <util/generic/buffer.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+/*
+* Class TAccumulator is used to split provided vector of tuples to buckets using provided key hashes.
+*/
+class TAccumulator {
+public:
+    using TBuffer = std::vector<ui8, TMKQLAllocator<ui8>>;
+
+    struct TBucketRef {
+        const TBuffer*      PackedTuples;
+        const TBuffer*      Overflow;
+        ui32                NTuples;    // Count of elements in a bucket
+        const TTupleLayout* Layout;     // Layout for packed row (tuple)
+    };
+
+    struct TBucket {
+        TBuffer             PackedTuples;
+        TBuffer             Overflow;
+        ui32                NTuples;    // Count of elements in a bucket
+        const TTupleLayout* Layout;     // Layout for packed row (tuple)
+    };
+
+public:
+    virtual ~TAccumulator() = default;
+
+    // Create new accumulator for log2Buckets for given layout using given memory.
+    // Accumulator will not allocate any memory
+    static THolder<TAccumulator> Create(
+        const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets);
+
+    // Create new accumulator for log2Buckets for given layout.
+    // Accumulator will manage memory by itself
+    static THolder<TAccumulator> Create(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets);
+
+    // Add new nItems of data in TTupleLayout representation to accumulator 
+    virtual void AddData(const ui8* data, const ui8* overflow, ui32 nItems) = 0;
+
+    // Return bucket reference
+    virtual TBucketRef GetBucket(ui32 bucket) const = 0;
+
+    // Detach and return all buckets. Once this method has been called, the accumulator object can no longer be used
+    virtual void Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) = 0;
+
+    // Get bucket id
+    inline static ui32 GetBucketId(ui32 hash, ui32 shift, ui32 mask) {
+        return (hash >> shift) & mask;
+    }
+};
+
+// Simple radix partitioning algorithm using software prefetching technique to improve performance.
+// Suitable when number of buckets small (<= 32) or very big (> 1024)
+class TAccumulatorImpl: public TAccumulator {
+public:
+    TAccumulatorImpl(
+        const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets);
+
+    TAccumulatorImpl(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets);
+
+    ~TAccumulatorImpl() = default;
+
+    void AddData(const ui8* data, const ui8* overflow, ui32 nItems) override;
+
+    TBucketRef GetBucket(ui32 bucket) const override;
+
+    void Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) override;
+
+private:
+    ui32 NBuckets_{0};                                                   // Number of buckets
+    ui32 Shift_{0};                                                      // Mask used for partitioning tuples 
+    ui32 Mask_{0};                                                  // Bits count to write buckets number in binary
+    const TTupleLayout* Layout_;                                         // Tuple layout
+    std::vector<ui64, TMKQLAllocator<ui64>> PackedTupleBucketSizes_;     // Sizes for filled part of packed tuple buckets
+    std::vector<ui64, TMKQLAllocator<ui64>> OverflowBucketSizes_;        // Sizes for filled part of overflow buckets
+    bool NoAllocations_{false};                                          // Do not allocate any memory for buckets
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets_;   // Buckets for packed tuples
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets_;      // Buckets for overflow buffers
+};
+
+// Simple radix partitioning algorithm using software buffer technique to improve performance.
+class TSMBAccumulatorImpl: public TAccumulator {
+public:
+    TSMBAccumulatorImpl(
+        const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& packedTupleBuckets,
+        std::vector<TBuffer, TMKQLAllocator<TBuffer>>&& overflowBuckets);
+
+    TSMBAccumulatorImpl(const TTupleLayout* layout, ui32 bitShift, ui32 log2Buckets);
+
+    ~TSMBAccumulatorImpl() = default;
+
+    void AddData(const ui8* data, const ui8* overflow, ui32 nItems) override;
+
+    TBucketRef GetBucket(ui32 bucket) const override;
+
+    void Detach(std::vector<TBucket, TMKQLAllocator<TBucket>>& buckets) override;
+
+private:
+    using THugePageBuffer = std::vector<ui8, TMKQLHugeAllocator<ui8>>;
+
+private:
+    std::pair<ui64, ui64> GetCounters(ui32 bucket, ui64 maxBytesPerPartition);
+
+private:
+    ui32 NBuckets_{0};                                                   // Number of buckets
+    ui32 Shift_{0};                                                      // Mask used for partitioning tuples 
+    ui32 Mask_{0};                                                  // Bits count to write buckets number in binary
+    const TTupleLayout* Layout_;                                         // Tuple layout
+    std::vector<ui64, TMKQLAllocator<ui64>> PackedTupleBucketSizes_;     // Sizes for filled part of packed tuple buckets
+    std::vector<ui64, TMKQLAllocator<ui64>> OverflowBucketSizes_;        // Sizes for filled part of overflow buckets
+    bool NoAllocations_{false};                                          // Do not allocate any memory for buckets
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets_;   // Buckets for packed tuples
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets_;      // Buckets for overflow buffers
+    THugePageBuffer PackedTupleSMB_;                                     // SMB for packed tuples
+    THugePageBuffer OverflowSMB_;                                        // SMB for overflow
+};
+
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/histogram.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/histogram.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+
+#include <util/generic/buffer.h>
+#include <yql/essentials/utils/prefetch.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+class Histogram {
+public:
+    Histogram() = default;
+
+    template <typename F, typename... Args>
+    void AddData(const TTupleLayout* layout, const ui8* data, ui32 nTuples, F HashMapper, Args&&... args) {
+        const auto layoutTotalRowSize = layout->TotalRowSize;
+
+        for (ui32 i = 0; i < nTuples; i += 1 /*step*/) {
+            const ui8* tuple = data + i * layoutTotalRowSize;
+            const auto hash = ReadUnaligned<ui32>(tuple);
+            NYql::PrefetchForRead(tuple + layoutTotalRowSize * 32); // prefetch next tuples
+
+            ui64 overflowSize = 0;
+            for (const auto& col: layout->VariableColumns) {
+                ui32 size = ReadUnaligned<ui8>(tuple + col.Offset);
+                if (size == 255) { // overflow buffer used
+                    const auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                    const auto overflowSize = ReadUnaligned<ui32>(tuple + col.Offset + 1 + 1 * sizeof(ui32));
+                    size = prefixSize + overflowSize;
+                }
+                overflowSize += size;
+            }
+
+            auto key = HashMapper(hash, std::forward<Args>(args)...);
+            TuplesCountStatistics_[key]++;
+            TuplesSizeStatistics_[key] += layoutTotalRowSize;
+            OverflowSizeStatistics_[key] += overflowSize;
+        }
+    }
+
+    // hist vector must have proper size
+    void GetHistogram(std::vector<ui64, TMKQLAllocator<ui64>>& hist) {
+        for (auto [key, count]: TuplesCountStatistics_) {
+            hist[key] += count;
+        }
+    }
+
+    // sizes vector must have proper size
+    void EstimateSizes(std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>>& sizes)
+    {
+        for (auto [key, _]: TuplesSizeStatistics_) {
+            auto accTupleSize = TuplesSizeStatistics_[key];
+            auto accOverflowSize = OverflowSizeStatistics_[key];
+
+            auto& [prevTS, prevOS] = sizes[key];
+            prevTS += accTupleSize;
+            prevOS += accOverflowSize;
+        }
+    }
+
+    void Clear() {
+        TuplesCountStatistics_.clear();
+        TuplesSizeStatistics_.clear();
+        OverflowSizeStatistics_.clear();
+    }
+
+private:
+    using TMap = std::unordered_map<ui32, ui64>;
+
+private:
+    TMap TuplesCountStatistics_;
+    TMap TuplesSizeStatistics_;
+    TMap OverflowSizeStatistics_;
+};
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.cpp
@@ -814,6 +814,165 @@ void TTupleLayoutFallback::Unpack(
     }
 }
 
+void TTupleLayoutFallback::BucketPack(
+    const ui8 **columns, const ui8 **isValidBitmask,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows, ui32 start,
+    ui32 count, ui32 bucketsLogNum) const {
+    using TTraits = NSimd::TSimdFallbackTraits;
+
+    if (bucketsLogNum == 0) {
+        auto& bres = reses[0];
+        const auto size = bres.size();
+
+        bres.resize(size + count * TotalRowSize);
+        auto* const res = bres.data() + size;
+
+        Pack(columns, isValidBitmask, res, overflows[0], start, count);
+        return;
+    }
+
+    std::vector<ui8> resbuf(TotalRowSize);
+    ui8 *const res = resbuf.data();
+
+    for (ui32 bucket = 0; bucket < (1u << bucketsLogNum); ++bucket) {
+        auto &bres = reses[bucket];
+        /// memory reserve heuristic
+        bres.reserve(bres.size() + ((count >> bucketsLogNum) + 1) * 9 / 8);
+    }
+
+    const ui64 bitmaskTail =
+        BitmaskSize * 8 == OrigColumns.size()
+            ? 0
+            : ~0ull << ((OrigColumns.size() + 8 - BitmaskSize * 8) * 8);
+    std::vector<ui64> bitmaskMatrix(BitmaskSize, 0);
+    bitmaskMatrix.back() = bitmaskTail;
+
+    if (auto off = (start % 8)) {
+        auto bitmaskIdx = start / 8;
+
+        for (ui32 j = Columns.size(); j--;) {
+            const ui64 byte =
+                isValidBitmask[Columns[j].OriginalIndex]
+                    ? isValidBitmask[Columns[j].OriginalIndex][bitmaskIdx]
+                    : 0xFF;
+            bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+        }
+
+        for (auto &m : bitmaskMatrix) {
+            m = transposeBitmatrix(m);
+            m >>= off * 8;
+        }
+    }
+
+    for (; count--; ++start) {
+        auto bitmaskIdx = start / 8;
+
+        if ((start % 8) == 0) {
+            std::fill(bitmaskMatrix.begin(), bitmaskMatrix.end(), 0);
+            bitmaskMatrix.back() = bitmaskTail;
+
+            for (ui32 j = Columns.size(); j--;) {
+                const ui64 byte =
+                isValidBitmask[Columns[j].OriginalIndex]
+                    ? isValidBitmask[Columns[j].OriginalIndex][bitmaskIdx]
+                    : 0xFF;
+                bitmaskMatrix[j / 8] |= byte << ((j % 8) * 8);
+            }
+            for (auto &m : bitmaskMatrix)
+                m = transposeBitmatrix(m);
+        }
+
+        for (ui32 j = 0; j < BitmaskSize; ++j) {
+            res[BitmaskOffset + j] = ui8(bitmaskMatrix[j]);
+            bitmaskMatrix[j] >>= 8;
+        }
+
+        for (auto &col : FixedNPOTColumns_) {
+            std::memcpy(res + col.Offset,
+                        columns[col.OriginalIndex] + start * col.DataSize,
+                        col.DataSize);
+        }
+
+#define PackPOTColumn(POT)                                                     \
+    for (auto &col : FixedPOTColumns_[POT]) {                                  \
+        std::memcpy(res + col.Offset,                                          \
+                    columns[col.OriginalIndex] + start * (1u << POT),          \
+                    1u << POT);                                                \
+    }
+
+        PackPOTColumn(0);
+        PackPOTColumn(1);
+        PackPOTColumn(2);
+        PackPOTColumn(3);
+        PackPOTColumn(4);
+#undef PackPOTColumn
+
+        ui32 hash = CalculateCRC32<TTraits>(
+            res + KeyColumnsOffset, KeyColumnsFixedEnd - KeyColumnsOffset);
+
+        for (ui32 i = KeyColumnsFixedNum; i < KeyColumns.size(); ++i) {
+            auto &col = KeyColumns[i];
+            auto dataOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * start);
+            auto nextOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+            auto size = nextOffset - dataOffset;
+            auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+            // hash = CalculateCRC32<TTraits>((ui8 *)&size, sizeof(size), hash);
+            hash = CalculateCRC32<TTraits>(data, size, hash);
+        }
+
+        // isValid bitmap is NOT included into hashed data
+        WriteUnaligned<ui32>(res, hash);
+
+        /// most-significant bits of hash
+        const auto bucket = hash >> (sizeof(hash) * 8 - bucketsLogNum);
+
+        auto& overflow = overflows[bucket];
+
+        for (auto &col : VariableColumns) {
+            auto dataOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * start);
+            auto nextOffset = ReadUnaligned<ui32>(
+                columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+            auto size = nextOffset - dataOffset;
+            auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+            if (size >= col.DataSize) {
+                res[col.Offset] = 255;
+
+                auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                auto overflowSize = size - prefixSize;
+                auto overflowOffset = overflow.size();
+
+                overflow.resize(overflowOffset + overflowSize);
+
+                WriteUnaligned<ui32>(res + col.Offset + 1 +
+                                        0 * sizeof(ui32),
+                                    overflowOffset);
+                WriteUnaligned<ui32>(
+                    res + col.Offset + 1 + 1 * sizeof(ui32), overflowSize);
+                std::memcpy(res + col.Offset + 1 + 2 * sizeof(ui32), data,
+                            prefixSize);
+                std::memcpy(overflow.data() + overflowOffset,
+                            data + prefixSize, overflowSize);
+            } else {
+                Y_DEBUG_ABORT_UNLESS(size < 255);
+                res[col.Offset] = size;
+                std::memcpy(res + col.Offset + 1, data, size);
+                std::memset(res + col.Offset + 1 + size, 0,
+                            col.DataSize - (size + 1));
+            }
+        }
+
+        auto &bres = reses[bucket];
+        bres.resize_uninitialized(bres.size() + TotalRowSize);
+        std::memcpy(bres.data() + bres.size() - TotalRowSize, res, TotalRowSize);
+    }
+}
+
 #define MULTI_8_I(C, i) C(i, 0) C(i, 1) C(i, 2) C(i, 3)
 #define MULTI_8(C, A) C(A, 0) C(A, 1) C(A, 2) C(A, 3)
 
@@ -1174,6 +1333,221 @@ void TTupleLayoutSIMD<TTraits>::Unpack(
     }
 }
 
+template <typename TTraits>
+void TTupleLayoutSIMD<TTraits>::BucketPack(
+    const ui8 **columns, const ui8 **isValidBitmask,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows, ui32 start,
+    ui32 count, ui32 bucketsLogNum) const {
+    if (bucketsLogNum == 0) {
+        auto& bres = reses[0];
+        const auto size = bres.size();
+
+        bres.resize(size + count * TotalRowSize);
+        auto* const res = bres.data() + size;
+
+        Pack(columns, isValidBitmask, res, overflows[0], start, count);
+        return;
+    }
+
+    std::vector<ui8> resbuf(BlockRows_ * TotalRowSize);
+    ui8 *const res = resbuf.data();
+
+    for (ui32 bucket = 0; bucket < (1u << bucketsLogNum); ++bucket) {
+        auto &bres = reses[bucket];
+        /// memory reserve heuristic
+        bres.reserve(bres.size() + ((count >> bucketsLogNum) + 1) * 9 / 8);
+    }
+
+    std::vector<const ui8 *> block_columns;
+    for (const auto col_ind : BlockColumnsOrigInds_) {
+        block_columns.push_back(columns[col_ind]);
+    }
+
+    for (size_t row_ind = 0; row_ind < count; row_ind += BlockRows_) {
+        const size_t cur_block_size = std::min(count - row_ind, BlockRows_);
+        size_t cols_past = 0;
+
+        if (SIMDSmallTuple_.Cols) {
+
+#define CASE(i, j)                                                             \
+    case i *kSIMDMaxCols + j:                                                  \
+        SIMDPack<TTraits>::template PackTupleOr<i + 1, j + 1>(                 \
+            block_columns.data() + cols_past, res + SIMDSmallTuple_.RowOffset, \
+            cur_block_size, BlockFixedColsSizes_.data() + cols_past,           \
+            BlockColsOffsets_.data() + cols_past,                              \
+            SIMDSmallTuple_.SmallTupleSize, TotalRowSize,                      \
+            SIMDPermMasks_.data(), start);                                     \
+        break;
+
+            switch ((SIMDSmallTuple_.InnerLoopIters - 1) * kSIMDMaxCols +
+                    SIMDSmallTuple_.Cols - 1) {
+                MULTI_8(MULTI_8_I, CASE)
+
+            default:
+                std::abort();
+            }
+
+#undef CASE
+
+            cols_past += SIMDSmallTuple_.Cols;
+        }
+
+        for (size_t trnsps_ind = 0; trnsps_ind != SIMDTranspositions_.size();
+             ++trnsps_ind) {
+            if (SIMDTranspositions_[trnsps_ind].Cols) {
+                SIMDPack<TTraits>::PackColSize(
+                    block_columns.data() + cols_past,
+                    res + SIMDTranspositions_[trnsps_ind].RowOffset,
+                    cur_block_size,
+                    SIMDTranspositionsColSizes_
+                        [trnsps_ind % SIMDTranspositionsColSizes_.size()],
+                    SIMDTranspositions_[trnsps_ind].Cols, TotalRowSize, start);
+                cols_past += SIMDTranspositions_[trnsps_ind].Cols;
+            }
+        }
+
+        PackTupleFallbackColImpl(
+            block_columns.data() + cols_past, res,
+            BlockColsOffsets_.size() - cols_past, cur_block_size,
+            BlockFixedColsSizes_.data() + cols_past,
+            BlockColsOffsets_.data() + cols_past, TotalRowSize, start);
+
+        for (ui32 cols_ind = 0; cols_ind < Columns.size(); cols_ind += 8) {
+            const size_t cols = std::min<size_t>(8ul, Columns.size() - cols_ind);
+            const ui8 ones_byte = 0xFF;  // dereferencable + all-ones fast path
+            const ui8 *bitmasks[8];
+
+            for (size_t ind = 0; ind != cols; ++ind) {
+                const auto &col = Columns[cols_ind + ind];
+                bitmasks[ind] = 
+                    isValidBitmask[col.OriginalIndex]
+                    ? isValidBitmask[col.OriginalIndex] + start / 8
+                    : &ones_byte;
+            }
+            for (size_t ind = cols; ind != 8; ++ind) {
+                bitmasks[ind] = &ones_byte;
+            }
+
+            const auto advance_masks = [&] {
+                for (size_t ind = 0; ind != 8; ++ind) {
+                    if (bitmasks[ind] != &ones_byte) {
+                        ++bitmasks[ind];
+                    }
+                }
+            };
+
+            const size_t first_full_byte =
+                std::min<size_t>((8ul - start) & 7, cur_block_size);
+            size_t block_row_ind = 0;
+
+            const auto edge_mask_transpose = [&](const size_t until) {
+                for (; block_row_ind < until; ++block_row_ind) {
+                    const auto shift = (start + block_row_ind) % 8;
+
+                    const auto new_res = res + block_row_ind * TotalRowSize;
+                    const auto res = new_res;
+
+                    res[BitmaskOffset + cols_ind / 8] = 0;
+                    for (size_t col_ind = 0; col_ind != 8; ++col_ind) {
+                        res[BitmaskOffset + cols_ind / 8] |=
+                            ((bitmasks[col_ind][0] >> shift) & 1u) << col_ind;
+                    }
+                }
+            };
+
+            edge_mask_transpose(first_full_byte);
+            if (first_full_byte) {
+                advance_masks();
+            }
+
+            for (; block_row_ind + 7 < cur_block_size; block_row_ind += 8) {
+                transposeBitmatrix(res + block_row_ind * TotalRowSize +
+                                       BitmaskOffset + cols_ind / 8,
+                                   bitmasks, TotalRowSize);
+                advance_masks();
+            }
+
+            edge_mask_transpose(cur_block_size);
+        }
+
+        for (size_t block_row_ind = 0; block_row_ind != cur_block_size;
+            ++block_row_ind) {
+
+            const auto new_start = start + block_row_ind;
+            const auto start = new_start;
+
+            const auto new_res = res + block_row_ind * TotalRowSize;
+            const auto res = new_res;
+
+            ui32 hash = CalculateCRC32<TTraits>(
+                res + KeyColumnsOffset, KeyColumnsFixedEnd - KeyColumnsOffset);
+
+            for (ui32 i = KeyColumnsFixedNum; i < KeyColumns.size(); ++i) {
+                auto &col = KeyColumns[i];
+                auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto nextOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+                auto size = nextOffset - dataOffset;
+                auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+                // hash = CalculateCRC32<TTraits>((ui8 *)&size, sizeof(size), hash);
+                hash = CalculateCRC32<TTraits>(data, size, hash);
+            }
+
+            // isValid bitmap is NOT included into hashed data
+            WriteUnaligned<ui32>(res, hash);
+
+            /// most-significant bits of hash
+            const auto bucket = hash >> (sizeof(hash) * 8 - bucketsLogNum);
+
+            auto& overflow = overflows[bucket];
+
+            for (auto &col : VariableColumns) {
+                auto dataOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * start);
+                auto nextOffset = ReadUnaligned<ui32>(
+                    columns[col.OriginalIndex] + sizeof(ui32) * (start + 1));
+                auto size = nextOffset - dataOffset;
+                auto data = columns[col.OriginalIndex + 1] + dataOffset;
+
+                if (size >= col.DataSize) {
+                    res[col.Offset] = 255;
+
+                    auto prefixSize = (col.DataSize - 1 - 2 * sizeof(ui32));
+                    auto overflowSize = size - prefixSize;
+                    auto overflowOffset = overflow.size();
+
+                    overflow.resize(overflowOffset + overflowSize);
+
+                    WriteUnaligned<ui32>(res + col.Offset + 1 +
+                                            0 * sizeof(ui32),
+                                        overflowOffset);
+                    WriteUnaligned<ui32>(
+                        res + col.Offset + 1 + 1 * sizeof(ui32), overflowSize);
+                    std::memcpy(res + col.Offset + 1 + 2 * sizeof(ui32), data,
+                                prefixSize);
+                    std::memcpy(overflow.data() + overflowOffset,
+                                data + prefixSize, overflowSize);
+                } else {
+                    Y_DEBUG_ABORT_UNLESS(size < 255);
+                    res[col.Offset] = size;
+                    std::memcpy(res + col.Offset + 1, data, size);
+                    std::memset(res + col.Offset + 1 + size, 0,
+                                col.DataSize - (size + 1));
+                }
+           }
+
+            auto &bres = reses[bucket];
+            bres.resize_uninitialized(bres.size() + TotalRowSize);
+            std::memcpy(bres.data() + bres.size() - TotalRowSize, res, TotalRowSize);
+        }
+
+        start += cur_block_size;
+    }
+}
+
 template __attribute__((target("avx2"))) void
 TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>::Pack(
     const ui8 **columns, const ui8 **isValidBitmask, ui8 *res,
@@ -1195,6 +1569,19 @@ TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>::Unpack(
     ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
     const std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start,
     ui32 count) const;
+
+template __attribute__((target("avx2"))) void
+TTupleLayoutSIMD<NSimd::TSimdAVX2Traits>::BucketPack(
+    const ui8 **columns, const ui8 **isValidBitmask,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows, ui32 start,
+    ui32 count, ui32 bucketsLogNum) const;
+template __attribute__((target("sse4.2"))) void
+TTupleLayoutSIMD<NSimd::TSimdSSE42Traits>::BucketPack(
+    const ui8 **columns, const ui8 **isValidBitmask,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+    TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows, ui32 start,
+    ui32 count, ui32 bucketsLogNum) const;
 
 void TTupleLayout::CalculateColumnSizes(
     const ui8 *res, ui32 count,

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h
@@ -178,10 +178,16 @@ struct TTupleLayout {
                         const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
                         ui32 start, ui32 count) const = 0;
 
+    virtual void
+    BucketPack(const ui8 **columns, const ui8 **isValidBitmask,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows,
+                 ui32 start, ui32 count, ui32 bucketsLogNum) const = 0;
+
     // Takes packed rows,
     // outputs vector of column sizes in bytes
     void CalculateColumnSizes(
-        const ui8* res, ui32 count, std::vector<ui64, TMKQLAllocator<ui64>>& bytes) const ;
+        const ui8* res, ui32 count, std::vector<ui64, TMKQLAllocator<ui64>>& bytes) const;
 
     void TupleDeepCopy(
         const ui8* inTuple, const ui8* inOverflow,
@@ -211,6 +217,12 @@ struct TTupleLayoutFallback : public TTupleLayout {
                 const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
                 ui32 start, ui32 count) const override;
 
+    void
+    BucketPack(const ui8 **columns, const ui8 **isValidBitmask,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows,
+                 ui32 start, ui32 count, ui32 bucketsLogNum) const override;
+
   protected:
     std::array<std::vector<TColumnDesc>, 5>
         FixedPOTColumns_; // Fixed-size columns for power-of-two sizes from 1 to
@@ -230,6 +242,12 @@ template <typename TTraits> struct TTupleLayoutSIMD : public TTupleLayoutFallbac
     void Unpack(ui8 **columns, ui8 **isValidBitmask, const ui8 *res,
             const std::vector<ui8, TMKQLAllocator<ui8>> &overflow,
             ui32 start, ui32 count) const override;
+
+    void
+    BucketPack(const ui8 **columns, const ui8 **isValidBitmask,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> reses,
+                 TPaddedPtr<std::vector<ui8, TMKQLAllocator<ui8>>> overflows,
+                 ui32 start, ui32 count, ui32 bucketsLogNum) const override;
 
   private:
     using TSimdI8 = typename TTraits::TSimdI8;

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/accumulator_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/accumulator_ut.cpp
@@ -1,0 +1,613 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <chrono>
+#include <vector>
+#include <random>
+
+#include <util/system/fs.h>
+#include <util/system/compiler.h>
+#include <util/stream/null.h>
+#include <util/system/mem_info.h>
+
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/accumulator.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/histogram.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/tuple.h>
+
+#include <arrow/util/bit_util.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+using namespace std::chrono_literals;
+
+static volatile bool IsVerbose = false;
+#define CTEST (IsVerbose ? Cerr : Cnull)
+
+namespace {
+
+TVector<TString> GenerateValues(size_t level) {
+    constexpr size_t alphaSize = 'Z' - 'A' + 1;
+    if (level == 1) {
+        TVector<TString> alphabet(alphaSize);
+        std::iota(alphabet.begin(), alphabet.end(), 'A');
+        return alphabet;
+    }
+    const auto subValues = GenerateValues(level - 1);
+    TVector<TString> values;
+    values.reserve(alphaSize * subValues.size());
+    for (char ch = 'A'; ch <= 'Z'; ch++) {
+        for (const auto& tail : subValues) {
+            values.emplace_back(ch + tail);
+        }
+    }
+    return values;
+}
+
+static const TVector<TString> threeLetterValues = GenerateValues(3);
+
+bool RunFixSizedAccumulatorBench(ui64 nTuples, ui64 nCols, ui64 log2Buckets) {
+    auto nBuckets = 1 << log2Buckets;
+    CTEST << "============ BENCH BEGIN ============" << Endl;
+    CTEST << "Test config:" << Endl;
+    CTEST << ">  nTuples: " << nTuples << Endl;
+    CTEST << ">  nCols: " << nCols << Endl;
+    CTEST << ">  nBuckets: " << nBuckets << Endl;
+
+    ui64 totalTime = 0;
+
+    TScopedAlloc alloc(__LOCATION__);
+    using TBuffer = TAccumulator::TBuffer;
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns(nCols, kc);
+    auto tl = TTupleLayout::Create(columns);
+    const ui64 TuplesDataBytes = (tl->TotalRowSize) * nTuples;
+    CTEST << ">  Dataset size: " << TuplesDataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST << " " << Endl;
+
+    std::vector<ui64> col(nTuples, 0);
+    std::iota(col.begin(), col.end(), 0);
+    auto colsData = std::vector(nCols, col);
+    std::vector<const ui8*> cols(nCols);
+    for (size_t ind = 0; ind != nCols; ind++) {
+        cols[ind] = (ui8*)colsData[ind].data();
+    }
+    std::vector<ui8> colValid((nTuples + 7)/8, ~0);
+    auto colsValidData = std::vector(nCols, colValid);
+    std::vector<const ui8*> colsValid(nCols);
+    for (size_t ind = 0; ind != nCols; ind++) {
+        colsValid[ind] = (ui8*)colsValidData[ind].data();
+    }
+
+    auto resesData = std::vector<std::vector<ui8, TMKQLAllocator<ui8>>>(1u << log2Buckets);
+    std::vector<std::vector<ui8, TMKQLAllocator<ui8>>> overflowsData(1u << log2Buckets);
+
+    auto reses = TPaddedPtr(resesData.data(), sizeof(resesData[0]));
+    auto overflows = TPaddedPtr(overflowsData.data(), sizeof(overflowsData[0]));
+
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    for (auto& bres : resesData) {
+        bres.resize(0);
+    }
+
+    auto begintp = std::chrono::steady_clock::now();
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    auto endtp = std::chrono::steady_clock::now();
+    auto bucketPackTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (bucketPackTime == 0) bucketPackTime = 1;
+
+    CTEST << "Bucket pack time: " << bucketPackTime  << "[microseconds]" << Endl;
+    CTEST << "Bucket pack speed: " << TuplesDataBytes / bucketPackTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    std::vector<ui8> res(TuplesDataBytes, 0);
+    for (ui32 i = 0; i < nTuples; ++i) {
+        col[i] = i;
+    }
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+
+    begintp = std::chrono::steady_clock::now();
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    endtp = std::chrono::steady_clock::now();
+    auto packTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (packTime == 0) packTime = 1;
+    totalTime += packTime;
+
+    CTEST << "Pack time: " << packTime  << "[microseconds]" << Endl;
+    CTEST << "Pack speed: " << TuplesDataBytes / packTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
+    ui32 shift = 32 - bitsCount;
+    ui32 mask = (1 << bitsCount) - 1;
+
+    std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(nBuckets, {0, 0});
+
+    {
+        // std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        Histogram hist;
+        hist.AddData(tl.Get(), res.data(), nTuples, TAccumulator::GetBucketId, shift, mask);
+        hist.EstimateSizes(sizes);
+
+        // std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        // ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        // if (microseconds == 0) microseconds = 1;
+        // // totalTime += microseconds;
+
+        // CTEST << "Histogram build time: " << microseconds  << "[microseconds]" << Endl;
+        // CTEST << "Histogram build speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        // CTEST << " " << Endl;
+    }
+
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets(nBuckets);
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets(nBuckets);
+
+    {
+        // std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets[i].resize(TLsize);
+            std::memset(PackedTupleBuckets[i].data(), 0, TLsize);
+            OverflowBuckets[i].resize(Osize);
+            std::memset(OverflowBuckets[i].data(), 0, Osize);
+        }
+
+        // std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        // ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        // if (microseconds == 0) microseconds = 1;
+        // // totalTime += microseconds;
+
+        // CTEST << "Memory allocation time: " << microseconds  << "[microseconds]" << Endl;
+        // CTEST << "Memory allocation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        // CTEST << " " << Endl;
+    }
+
+    std::array<THolder<TAccumulator>, 2> accums;
+    accums[0] = MakeHolder<TAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+    accums[1] = MakeHolder<TSMBAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+
+    for (auto &accum : accums)
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        accum->AddData(res.data(), overflow.data(), nTuples);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+    
+        CTEST << "------------------" << Endl << " " << Endl;
+
+        CTEST << "Accumulation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Accumulation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+
+        CTEST << "Total time: " << totalTime + microseconds  << "[microseconds]" << Endl;
+        CTEST << "Resulting speed: " << TuplesDataBytes / (totalTime + microseconds) << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    CTEST << "============= BENCH END =============" << Endl << " " << Endl;
+
+    return accums[0]->GetBucket(0).NTuples > 0;
+}
+
+bool RunVarSizedAccumulatorBench(ui64 nTuples, ui64 nCols, ui64 log2Buckets) {
+    auto nBuckets = 1 << log2Buckets;
+    TScopedAlloc alloc(__LOCATION__);
+    using TBuffer = TAccumulator::TBuffer;
+
+    ui64 totalTime = 0;
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.SizeType = EColumnSizeType::Variable;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns(nCols, kc);
+    auto tl = TTupleLayout::Create(columns);
+    ui64 TuplesDataBytes = tl->TotalRowSize * nTuples;
+
+    std::vector<ui32> col(1, 0);
+    std::vector<ui8> colData;
+
+    for (ui64 i = 0; i < nTuples; ++i) {
+        const auto& str = threeLetterValues[i % threeLetterValues.size()];
+        for (ui8 k = 0; k < 6; ++k) {
+            for (auto c: str) {
+                colData.push_back(c);
+            }
+        }
+        col.push_back(colData.size());
+    }
+
+    std::vector<const ui8*> cols(2 * nCols);
+    for (ui64 i = 0; i < nCols; i++) {
+        cols[2 * i] = (ui8*) col.data();
+        cols[2 * i + 1] = (ui8*) colData.data();
+    }
+
+    std::vector<ui8> colValid((nTuples + 7)/8, ~0);
+    std::vector<const ui8*> colsValid(2 * nCols);
+    for (ui64 i = 0; i < nCols; i++) {
+        colsValid[2 * i] = colValid.data();
+        colsValid[2 * i + 1] = nullptr;
+    }
+
+    std::vector<ui8> res(TuplesDataBytes, 0);
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    TuplesDataBytes += overflow.size();
+    overflow.resize(0);
+
+    CTEST << "============ BENCH BEGIN ============" << Endl;
+    CTEST << "Test config:" << Endl;
+    CTEST << ">  nTuples: " << nTuples << Endl;
+    CTEST << ">  nCols: " << nCols << Endl;
+    CTEST << ">  nBuckets: " << nBuckets << Endl;
+    CTEST << ">  Dataset size: " << TuplesDataBytes / (1024 * 1024) << "[MB]" << Endl;
+    CTEST << " " << Endl;
+
+    auto resesData = std::vector<std::vector<ui8, TMKQLAllocator<ui8>>>(1u << log2Buckets);
+    std::vector<std::vector<ui8, TMKQLAllocator<ui8>>> overflowsData(1u << log2Buckets);
+
+    auto reses = TPaddedPtr(resesData.data(), sizeof(resesData[0]));
+    auto overflows = TPaddedPtr(overflowsData.data(), sizeof(overflowsData[0]));
+    
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    for (auto& bres : resesData) {
+        bres.resize(0);
+    }
+    for (auto& boverflow : overflowsData) {
+        boverflow.resize(0);
+    }
+
+    auto begintp = std::chrono::steady_clock::now();
+    tl->BucketPack(cols.data(), colsValid.data(), reses, overflows, 0, nTuples, log2Buckets);
+    auto endtp = std::chrono::steady_clock::now();
+    auto bucketPackTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (bucketPackTime == 0) bucketPackTime = 1;
+
+    CTEST << "Bucket pack time: " << bucketPackTime  << "[microseconds]" << Endl;
+    CTEST << "Bucket pack speed: " << TuplesDataBytes / bucketPackTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    begintp = std::chrono::steady_clock::now();
+    tl->Pack(cols.data(), colsValid.data(), res.data(), overflow, 0, nTuples);
+    endtp = std::chrono::steady_clock::now();
+    auto packTime = std::chrono::duration_cast<std::chrono::microseconds>(endtp - begintp).count();
+    if (packTime == 0) packTime = 1;
+    totalTime += packTime;
+
+    CTEST << "Pack time: " << packTime  << "[microseconds]" << Endl;
+    CTEST << "Pack speed: " << TuplesDataBytes / packTime << "[MB/sec]" << Endl;
+    CTEST << " " << Endl;
+
+    ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
+    ui32 shift = 32 - bitsCount;
+    ui32 mask = (1 << bitsCount) - 1;
+
+    std::vector<std::pair<ui64, ui64>, TMKQLAllocator<std::pair<ui64, ui64>>> sizes(nBuckets, {0, 0});
+
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        Histogram hist;
+        hist.AddData(tl.Get(), res.data(), nTuples, TAccumulator::GetBucketId, shift, mask);
+        hist.EstimateSizes(sizes);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+
+        CTEST << "Histogram build time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Histogram build speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> PackedTupleBuckets(nBuckets);
+    std::vector<TBuffer, TMKQLAllocator<TBuffer>> OverflowBuckets(nBuckets);
+
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        for (ui32 i = 0; i < sizes.size(); ++i) {
+            auto [TLsize, Osize] = sizes[i];
+            PackedTupleBuckets[i].resize(TLsize);
+            std::memset(PackedTupleBuckets[i].data(), 0, TLsize);
+            OverflowBuckets[i].resize(Osize);
+            std::memset(OverflowBuckets[i].data(), 0, Osize);
+        }
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+
+        CTEST << "Memory allocation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Memory allocation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    std::array<THolder<TAccumulator>, 2> accums;
+    accums[0] = MakeHolder<TAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+    accums[1] = MakeHolder<TSMBAccumulatorImpl>(
+        tl.Get(), 0, log2Buckets, std::vector(PackedTupleBuckets), std::vector(OverflowBuckets));
+
+    for (auto &accum : accums)
+    {
+        std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+
+        accum->AddData(res.data(), overflow.data(), nTuples);
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        ui64 microseconds = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        if (microseconds == 0) microseconds = 1;
+        // totalTime += microseconds;
+    
+        CTEST << "------------------" << Endl << " " << Endl;
+
+        CTEST << "Accumulation time: " << microseconds  << "[microseconds]" << Endl;
+        CTEST << "Accumulation speed: " << TuplesDataBytes / microseconds << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+
+        CTEST << "Total time: " << totalTime + microseconds  << "[microseconds]" << Endl;
+        CTEST << "Resulting speed: " << TuplesDataBytes / (totalTime + microseconds) << "[MB/sec]" << Endl;
+        CTEST << " " << Endl;
+    }
+
+    CTEST << "============= BENCH END =============" << Endl << " " << Endl;
+
+    return accums[0]->GetBucket(0).NTuples > 0;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(Accumulator) {
+
+Y_UNIT_TEST(CreateAccumulator) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc1, kc2, pc1, pc2, pc3;
+
+    kc1.Role = EColumnRole::Key;
+    kc1.DataSize = 8;
+
+    kc2.Role = EColumnRole::Key;
+    kc2.DataSize = 4;
+
+    pc1.Role = EColumnRole::Payload;
+    pc1.DataSize = 16;
+
+    pc2.Role = EColumnRole::Payload;
+    pc2.DataSize = 4;
+
+    pc3.Role = EColumnRole::Payload;
+    pc3.DataSize = 8;
+
+    std::vector<TColumnDesc> columns{kc1, kc2, pc1, pc2, pc3};
+    auto tl = TTupleLayout::Create(columns);
+
+    auto accum = TAccumulator::Create(tl.Get(), 0, 1);
+    auto info = accum->GetBucket(0);
+
+    UNIT_ASSERT(info.NTuples == 0);
+    CTEST << "";
+} // Y_UNIT_TEST(CreateAccumulator)
+
+Y_UNIT_TEST(MultipleAddToAccumulator) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns{kc};
+    auto tl = TTupleLayout::Create(columns);
+    const ui64 NTuples = 1000;
+    const ui64 TuplesDataBytes = (tl->TotalRowSize) * NTuples;
+
+    std::vector<ui64> col(NTuples, 0);
+    std::vector<ui8> res(TuplesDataBytes, 0);
+    for (ui32 i = 0; i < NTuples; ++i) {
+        col[i] = i;
+    }
+    const ui8* cols[1];
+    cols[0] = (ui8*) col.data();
+
+    std::vector<ui8> colValid((NTuples + 7)/8, ~0);
+    const ui8 *colsValid[] = {
+        colValid.data(),
+    };
+
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples);
+
+    auto accum = TAccumulator::Create(tl.Get(), 0, 3);
+
+    for (int i = 0; i < 2; ++i) {
+        accum->AddData(res.data(), overflow.data(), NTuples); // + 1000 elements
+    }
+
+    ui32 totalCount = 0;
+    for (ui32 i = 0; i < 8; ++i) {
+        auto info = accum->GetBucket(i);
+        totalCount += info.NTuples;
+        UNIT_ASSERT(info.NTuples > 0);
+    }
+
+    UNIT_ASSERT(totalCount == 2 * NTuples);
+} // Y_UNIT_TEST(MultipleAddToAccumulator)
+
+Y_UNIT_TEST(AddVarSizedDataToAccumulator) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    TColumnDesc kc;
+    kc.Role = EColumnRole::Key;
+    kc.SizeType = EColumnSizeType::Variable;
+    kc.DataSize = 8;
+
+    std::vector<TColumnDesc> columns{kc};
+    auto tl = TTupleLayout::Create(columns);
+    const ui64 NTuples = 2;
+    const ui64 TuplesDataBytes = (tl->TotalRowSize) * NTuples;
+    std::vector<ui8> res(TuplesDataBytes, 0);
+
+    std::vector<ui32> col(1, 0);
+    std::vector<ui8> colData;
+    std::vector<TString> strs{
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    };
+
+    for (const auto& str: strs) {
+        for (auto c: str) {
+            colData.push_back(c);
+        }
+        col.push_back(colData.size());
+    }
+    UNIT_ASSERT_VALUES_EQUAL(col.size(), NTuples + 1);
+
+    const ui8* cols[2];
+    cols[0] = (ui8*) col.data();
+    cols[1] = (ui8*) colData.data();
+
+    std::vector<ui8> colValid((NTuples + 7)/8, ~0);
+    const ui8 *colsValid[] = {
+        colValid.data(),
+        nullptr,
+    };
+
+    std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+    tl->Pack(cols, colsValid, res.data(), overflow, 0, NTuples);
+
+    auto accum = TAccumulator::Create(tl.Get(), 0, 5);
+    accum->AddData(res.data(), overflow.data(), NTuples);
+
+    ui32 total = 0;
+    for (ui32 i = 0; i < 32; ++i) {
+        auto info = accum->GetBucket(i);
+        UNIT_ASSERT(info.NTuples <= 1);
+        total += info.NTuples;
+    }
+    UNIT_ASSERT(total == 2);
+} // Y_UNIT_TEST(AddVarSizedDataToAccumulator)
+
+Y_UNIT_TEST(AccumulatorFuzz) {
+    TScopedAlloc alloc(__LOCATION__);
+
+    std::mt19937 rng; // fixed-seed (0) prng
+    std::vector<TColumnDesc> columns;
+    std::vector<std::vector<ui8>> colsdata;
+    std::vector<const ui8*> colsptr;
+    std::vector<std::vector<ui8>> isValidData;
+    std::vector<const ui8*> isValidPtr;
+
+    for (ui32 test = 0; test < 10; ++test) {
+        ui32 rows = 1 + (rng() % 100);
+        ui32 cols = 1 + (rng() % 20);
+        columns.resize(cols);
+        colsdata.resize(cols);
+        colsptr.resize(cols);
+        isValidData.resize(cols);
+        isValidPtr.resize(cols);
+        ui32 isValidSize = (rows + 7)/8;
+        for (ui32 j = 0; j < cols; ++j) {
+            auto &col = columns[j];
+            col.Role = (rng() % 10 < 1) ? EColumnRole::Key : EColumnRole::Payload;
+            col.DataSize = 1u << (rng() % 10);
+            col.SizeType = EColumnSizeType::Fixed;
+            colsdata[j].resize(rows*col.DataSize);
+            colsptr[j] = colsdata[j].data();
+            isValidData[j].resize(isValidSize);
+            isValidPtr[j] = isValidData[j].data();
+            std::generate(isValidData[j].begin(), isValidData[j].end(), rng);
+        }
+        auto tl = TTupleLayout::Create(columns);
+        std::vector<ui8> res;
+        for (ui32 subtest = 0; subtest < 10; ++subtest) {
+            ui32 log2Buckets = rng() % 11;
+            ui32 nBuckets = (1 << log2Buckets);
+            ui32 bitsCount = arrow::BitUtil::NumRequiredBits(nBuckets - 1);
+            ui32 shift = 32 - bitsCount;
+            ui32 mask = (1 << bitsCount) - 1;
+            ui32 subRows = 1 + (rows ? rng() % (rows - 1) : 0);
+            ui32 off = subRows != rows ? rng() % (rows - subRows) : 0;
+            std::vector<ui8, TMKQLAllocator<ui8>> overflow;
+            res.resize(subRows*tl->TotalRowSize);
+            tl->Pack(colsptr.data(), isValidPtr.data(), res.data(), overflow, off, subRows);
+
+            auto accum = TAccumulator::Create(tl.Get(), 0, log2Buckets);
+            accum->AddData(res.data(), overflow.data(), subRows);
+
+            ui32 totalCount = 0;
+            for (ui32 i = 0; i < nBuckets; ++i) {
+                auto info = accum->GetBucket(i);
+                const ui8* Bucket = info.PackedTuples->data();
+
+                ui32 offset = 0;
+                if (info.NTuples > 0) {
+                    UNIT_ASSERT(info.PackedTuples->size() > 0);
+                    UNIT_ASSERT(info.PackedTuples->size() / tl->TotalRowSize == info.NTuples);
+                    for (ui32 count = 0; count < info.NTuples; ++count) {
+                        auto maskedHash = TAccumulator::GetBucketId(ReadUnaligned<ui32>(Bucket + offset), shift, mask);
+                        UNIT_ASSERT(maskedHash == i);
+                        offset += info.Layout->TotalRowSize;
+                        totalCount++;
+                    }
+                }
+            }
+            UNIT_ASSERT_VALUES_EQUAL(totalCount, subRows);
+        }
+    }
+} // Y_UNIT_TEST(AccumulatorFuzz)
+
+Y_UNIT_TEST(BenchAccumulator_VariateNTuples) {
+    CTEST << ">>> BenchAccumulator_VariateNTuples <<<" << Endl;
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e5, 2, 3));
+} // Y_UNIT_TEST(BenchAccumulator_VariateNTuples)
+
+Y_UNIT_TEST(BenchAccumulator_VariateNColumns) {
+    CTEST << ">>> BenchAccumulator_VariateNColumns <<<" << Endl;
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e5,  2, 4));
+} // Y_UNIT_TEST(BenchAccumulator_VariateNColumns)
+
+Y_UNIT_TEST(BenchAccumulator_VariateNBuckets) {
+    CTEST << ">>> BenchAccumulator_VariateNBuckets <<<" << Endl;
+    UNIT_ASSERT(RunFixSizedAccumulatorBench(1e5, 4,  2));
+} // Y_UNIT_TEST(BenchAccumulator_VariateNBuckets)
+
+Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNTuples) {
+    CTEST << ">>> VarSized_BenchAccumulator_VariateNTuples <<<" << Endl;
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e5, 2, 3));
+} // Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNTuples)
+
+Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNColumns) {
+    CTEST << ">>> VarSized_BenchAccumulator_VariateNColumns <<<" << Endl;
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e5,  2, 4));
+} // Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNColumns)
+
+Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNBuckets) {
+    CTEST << ">>> VarSized_BenchAccumulator_VariateNBuckets <<<" << Endl;
+    UNIT_ASSERT(RunVarSizedAccumulatorBench(1e5, 2,  4));
+} // Y_UNIT_TEST(VarSized_BenchAccumulator_VariateNBuckets)
+
+} // Y_UNIT_TEST_SUITE(Accumulator)
+
+
+}
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/packed_tuple_ut.cpp
@@ -1,10 +1,7 @@
-// #include <yql/essentials/minikql/mkql_runtime_version.h>
-// #include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <chrono>
 #include <vector>
-#include <set>
 #include <random>
 
 #include <util/system/fs.h>

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
@@ -14,6 +14,7 @@ ENDIF()
 
 SRCS(
     packed_tuple_ut.cpp
+    accumulator_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
@@ -1,5 +1,10 @@
 LIBRARY()
 
+SRCS(
+    tuple.cpp
+    accumulator.cpp
+)
+
 PEERDIR(
     contrib/libs/apache/arrow
     yql/essentials/types/binary_json
@@ -13,10 +18,6 @@ IF (ARCH_X86_64 AND OS_LINUX)
 
 PEERDIR(
     ydb/library/yql/dq/comp_nodes/hash_join_utils/simd
-)
-
-SRCS(
-    tuple.cpp
 )
 
 CFLAGS(


### PR DESCRIPTION
### Changelog entry

Block Hash Hoin utils: add splitting of tuple layout rows into buckets.

### Changelog category

* Experimental feature

### Description for reviewers

This PR represents different approaches for splitting tuple rows.

Main changes:
- Add bucket splitting