### PR TITLE
Temporary disable rdma for win

### DIFF
--- a/ydb/library/actors/interconnect/ya.make
+++ b/ydb/library/actors/interconnect/ya.make
@@ -99,9 +99,11 @@ PEERDIR(
 
 END()
 
-RECURSE(
-    rdma
-)
+IF (OS_LINUX)
+    RECURSE(
+        rdma
+    )
+ENDIF()
 
 RECURSE_FOR_TESTS(
     ut


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

verbs.h from contrib includes linux/types.h so it breaks win build. Temporary allow rdma build for linux only.  

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
