### PR TITLE
Mute broken test TBsLocalRecovery::WriteRestartReadHugeDecreased

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -3,6 +3,7 @@ ydb/core/blobstorage/ut_blobstorage BlobPatching.PatchBlock42
 ydb/core/blobstorage/ut_blobstorage unittest.[*/*] chunk
 ydb/core/blobstorage/ut_blobstorage/ut_huge HugeBlobOnlineSizeChange.Compaction
 ydb/core/blobstorage/ut_blobstorage/ut_huge unittest.[*/*] chunk
+ydb/core/blobstorage/ut_vdisk TBsLocalRecovery.WriteRestartReadHugeDecreased
 ydb/core/client/ut TObjectStorageListingTest.TestSkipShards
 ydb/core/cms/ut_sentinel_unstable TSentinelUnstableTests.BSControllerCantChangeStatus
 ydb/core/fq/libs/row_dispatcher/format_handler/ut TestFormatHandler.ManyRawClients


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Mute again the broken test that was mistakingly unmuted in https://github.com/ydb-platform/ydb/pull/26602
Erroneous output: https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/18351902604/ya-x86-64/try_1/artifacts/logs/ydb/core/blobstorage/ut_vdisk/test-results/unittest/testing_out_stuff/TBsLocalRecovery.WriteRestartReadHugeDecreased.err

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)