### PR TITLE
Change ResolveAll to ResolveUniqueDocs for memory saving

### DIFF
--- a/ydb/core/cms/console/console_configs_manager.cpp
+++ b/ydb/core/cms/console/console_configs_manager.cpp
@@ -78,8 +78,6 @@ void TConfigsManager::ValidateMainConfig(TUpdateConfigOpContext& opCtx) {
     try {
         if (opCtx.UpdatedConfig != MainYamlConfig || YamlDropped) {
             auto tree = NFyaml::TDocument::Parse(opCtx.UpdatedConfig);
-            auto resolved = NYamlConfig::ResolveUniqueDocs(tree);
-
             if (ClusterName != opCtx.Cluster) {
                 ythrow yexception() << "ClusterName mismatch"
                     << " expected " << ClusterName
@@ -95,17 +93,19 @@ void TConfigsManager::ValidateMainConfig(TUpdateConfigOpContext& opCtx) {
             TSimpleSharedPtr<NYamlConfig::TBasicUnknownFieldsCollector> unknownFieldsCollector = new NYamlConfig::TBasicUnknownFieldsCollector;
 
             std::vector<TString> errors;
-            for (auto& config : resolved) {
-                auto cfg = NYamlConfig::YamlToProto(
-                    config.second,
-                    true,
-                    true,
-                    unknownFieldsCollector);
-                NKikimr::NConfig::EValidationResult result = NKikimr::NConfig::ValidateConfig(cfg, errors);
-                if (result == NKikimr::NConfig::EValidationResult::Error) {
-                    ythrow yexception() << errors.front();
-                }
-            }
+            NYamlConfig::ResolveUniqueDocs(
+                tree,
+                [&](NYamlConfig::TDocumentConfig&& config) {
+                    auto cfg = NYamlConfig::YamlToProto(
+                        config.second,
+                        true,
+                        true,
+                        unknownFieldsCollector);
+                    NKikimr::NConfig::EValidationResult result = NKikimr::NConfig::ValidateConfig(cfg, errors);
+                    if (result == NKikimr::NConfig::EValidationResult::Error) {
+                        ythrow yexception() << errors.front();
+                    }
+                });
 
             const auto& deprecatedPaths = NKikimrConfig::TAppConfig::GetReservedChildrenPaths();
 
@@ -177,25 +177,25 @@ void TConfigsManager::ValidateDatabaseConfig(TUpdateDatabaseConfigOpContext& opC
 
             auto tree = NFyaml::TDocument::Parse(MainYamlConfig);
             NYamlConfig::AppendDatabaseConfig(tree, databaseTree);
-            auto resolved = NYamlConfig::ResolveUniqueDocs(tree);
-
             errors.clear();
 
             auto* csk = AppData()->ConfigSwissKnife;
 
-            for (auto& config : resolved) {
-                auto cfg = NYamlConfig::YamlToProto(
-                    config.second,
-                    true,
-                    true,
-                    unknownFieldsCollector);
-                if (csk) {
-                    auto result = csk->ValidateConfig(cfg, errors);
-                    if (result == NYamlConfig::EValidationResult::Error) {
-                        ythrow yexception() << errors.front();
+            NYamlConfig::ResolveUniqueDocs(
+                tree,
+                [&](NYamlConfig::TDocumentConfig&& config) {
+                    auto cfg = NYamlConfig::YamlToProto(
+                        config.second,
+                        true,
+                        true,
+                        unknownFieldsCollector);
+                    if (csk) {
+                        auto result = csk->ValidateConfig(cfg, errors);
+                        if (result == NYamlConfig::EValidationResult::Error) {
+                            ythrow yexception() << errors.front();
+                        }
                     }
-                }
-            }
+                });
 
             const auto& deprecatedPaths = NKikimrConfig::TAppConfig::GetReservedChildrenPaths();
 

--- a/ydb/core/cms/console/console_configs_manager.cpp
+++ b/ydb/core/cms/console/console_configs_manager.cpp
@@ -78,7 +78,7 @@ void TConfigsManager::ValidateMainConfig(TUpdateConfigOpContext& opCtx) {
     try {
         if (opCtx.UpdatedConfig != MainYamlConfig || YamlDropped) {
             auto tree = NFyaml::TDocument::Parse(opCtx.UpdatedConfig);
-            auto resolved = NYamlConfig::ResolveAll(tree);
+            auto resolved = NYamlConfig::ResolveUniqueDocs(tree);
 
             if (ClusterName != opCtx.Cluster) {
                 ythrow yexception() << "ClusterName mismatch"
@@ -95,7 +95,7 @@ void TConfigsManager::ValidateMainConfig(TUpdateConfigOpContext& opCtx) {
             TSimpleSharedPtr<NYamlConfig::TBasicUnknownFieldsCollector> unknownFieldsCollector = new NYamlConfig::TBasicUnknownFieldsCollector;
 
             std::vector<TString> errors;
-            for (auto& [_, config] : resolved.Configs) {
+            for (auto& config : resolved) {
                 auto cfg = NYamlConfig::YamlToProto(
                     config.second,
                     true,
@@ -177,13 +177,13 @@ void TConfigsManager::ValidateDatabaseConfig(TUpdateDatabaseConfigOpContext& opC
 
             auto tree = NFyaml::TDocument::Parse(MainYamlConfig);
             NYamlConfig::AppendDatabaseConfig(tree, databaseTree);
-            auto resolved = NYamlConfig::ResolveAll(tree);
+            auto resolved = NYamlConfig::ResolveUniqueDocs(tree);
 
             errors.clear();
 
             auto* csk = AppData()->ConfigSwissKnife;
 
-            for (auto& [_, config] : resolved.Configs) {
+            for (auto& config : resolved) {
                 auto cfg = NYamlConfig::YamlToProto(
                     config.second,
                     true,

--- a/ydb/library/yaml_config/public/yaml_config.h
+++ b/ydb/library/yaml_config/public/yaml_config.h
@@ -5,6 +5,8 @@
 
 #include <openssl/sha.h>
 
+#include <functional>
+
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 #include <util/generic/set.h>
@@ -195,7 +197,9 @@ TResolvedConfig ResolveAll(NFyaml::TDocument& doc);
 /**
  * Generates unique resolved documents without materializing label combinations
  */
-TVector<TDocumentConfig> ResolveUniqueDocs(NFyaml::TDocument& doc);
+void ResolveUniqueDocs(
+    NFyaml::TDocument& doc,
+    const std::function<void(TDocumentConfig&&)>& onDocument);
 
 /**
  * Calculates hash of resolved config

--- a/ydb/library/yaml_config/public/yaml_config.h
+++ b/ydb/library/yaml_config/public/yaml_config.h
@@ -193,6 +193,11 @@ struct TResolvedConfig {
 TResolvedConfig ResolveAll(NFyaml::TDocument& doc);
 
 /**
+ * Generates unique resolved documents without materializing label combinations
+ */
+TVector<TDocumentConfig> ResolveUniqueDocs(NFyaml::TDocument& doc);
+
+/**
  * Calculates hash of resolved config
  * Used to ensure that cli resolves config the same as a server
  */

--- a/ydb/library/yaml_config/public/yaml_config.h
+++ b/ydb/library/yaml_config/public/yaml_config.h
@@ -144,6 +144,8 @@ public:
     size_t GetRuleCount() const { return RulesByName.size(); }
     size_t GetDisabledCount() const { return DisabledRules.size(); }
 
+    bool HasRules() const { return !RulesByName.empty() || !DisabledRules.empty(); }
+
 private:
     TMap<TString, TIncompatibilityRule> RulesByName;
     THashSet<TString> DisabledRules;

--- a/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
@@ -278,8 +278,8 @@ void TCommandConfigReplace::Parse(TConfig& config) {
     if (!IgnoreCheck) {
         NYamlConfig::GetMainMetadata(configStr);
         auto tree = NFyaml::TDocument::Parse(configStr);
-        const auto resolved = NYamlConfig::ResolveAll(tree);
-        Y_UNUSED(resolved); // we can't check it better without ydbd
+
+        NYamlConfig::ResolveUniqueDocs(tree, [](NYamlConfig::TDocumentConfig&&) {});
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add ResolveAll to ResolveUniqueDocs for memory saving and streaming combination generation for both of them. 
We can use ResolveUniqueDocs for validation, because we don't need map of all combinations to the configs - we just need to validate unique configs, and we can do it one by one.

Let:

M — total number of label combinations (which can be millions)
L — number of labels per combination
U — number of unique resolved documents
|doc| — memory size of a single document
S — number of selectors in configuration

Before (with ResolveAll):

Memory: O(M * L + U * |doc|)

After (with ResolveUniqueDocs):

Memory: O(S · |doc| + U)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
