### PR TITLE
Fix flaky TPDiskTest::TestStartEncryptedOrPlainAndRestart

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion_impl.cpp
@@ -104,6 +104,7 @@ void TCompletionLogWrite::Release(TActorSystem *actorSystem) {
         auto res = MakeHolder<TEvLogResult>(NKikimrProto::CORRUPTED,
             NKikimrBlobStorage::StatusIsValid, ErrorReason, PDisk->Keeper.GetLogChunkCount());
         logWrite->Replied = true;
+        res->Results.emplace_back(logWrite->Lsn, logWrite->Cookie);
         actorSystem->Send(logWrite->Sender, res.Release());
         PDisk->Mon.WriteLog.CountResponse();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Changelog entry isn't necessary because the bug couldn't affect users, just the test was flaky  

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Close #25426

The flaky test revealed a bug which couldn't affect users though, just the test was flaky.

The test expects that after a PDisk restart, all previously sent TEvLog events will be answered with either ok or with error. The check is based on counting `TEvLogResult.Results.size()` ([permalink](https://github.com/ydb-platform/ydb/blob/cab7c1767896e1aa8325d322491dce3e262608c1/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp#L1743-L1746)). The TEvLogResult (CORRUPTED) can be sent from 2 places: `TLogWrite::Abort` ([permalink](https://github.com/ydb-platform/ydb/blob/cab7c1767896e1aa8325d322491dce3e262608c1/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h#L364-L370)) that is fine, and from `TCompletionLogWrite::Release` ([permalink](https://github.com/ydb-platform/ydb/blob/8d87a49baafead7a160a178465cc48d4e6e8cf2d/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion_impl.cpp#L102-L112)) which is missing Results field. The flakiness appeared because the second case is reproduced infrequently.

