### PR TITLE
Gwp asan example

### DIFF
--- a/junk/iddqd/gwpasan/main.cpp
+++ b/junk/iddqd/gwpasan/main.cpp
@@ -1,25 +1,43 @@
 #include <cstdlib>
-//#include <util/generic/string.h>
 #include <util/generic/strbuf.h>
 #include <util/stream/output.h>
+#include <iostream>
 #include <string>
 #include <string_view>
+#include <string_view>
+#include <contrib/libs/tcmalloc/tcmalloc/malloc_extension.h>
 
-int main(int argc, char** argv) {
+int test(int argc, char** argv) {
     for(size_t i = 0; i < 100000; ++i) {
         if (argc > 1 && TStringBuf(argv[1]) ==  "use-after-free") {
-            int* a = new int;
-            delete a;
-            *a = 1;
+            size_t s = 31;
+            volatile int* a = new int[s];
+            delete[] a;
+            for (size_t i = 0; i != s; ++i){
+                volatile int val = a[i];
+            }
         } else if (argc > 1 && TStringBuf(argv[1]) ==  "bounds") {
-            auto b = new int[1000];
-            b[1000] = 2;
-            delete b;
-        } else {
-            std::string s = "Hellooooooooooooooo ";
-            std::string_view sv = s + "World\n";
-            Cout << sv << Endl;
+            volatile int* b = new int[128];
+            for (size_t i = 0; i != 129; ++i)
+                volatile int val = b[i];
+            delete[] b;
         }
     }
     return 0;
 }
+
+int main(int argc, char** argv) {
+    std::cout << "W/o GWP-ASan" << std::endl;
+    test(argc, argv);
+    std::cout << "OK\n\n" << std::endl;
+
+    tcmalloc::MallocExtension::SetProfileSamplingInterval(1);
+    tcmalloc::MallocExtension::SetGuardedSamplingInterval(1);
+    tcmalloc::MallocExtension::ActivateGuardedSampling();
+    tcmalloc::MallocExtension::SetBackgroundReleaseRate(tcmalloc::MallocExtension::BytesPerSecond{1});
+
+    std::cout << "With GWP-ASan" << std::endl; 
+    test(argc, argv);
+    std::cout << "OK\n\n" << std::endl;
+}
+

--- a/junk/iddqd/gwpasan/main.cpp
+++ b/junk/iddqd/gwpasan/main.cpp
@@ -1,0 +1,25 @@
+#include <cstdlib>
+//#include <util/generic/string.h>
+#include <util/generic/strbuf.h>
+#include <util/stream/output.h>
+#include <string>
+#include <string_view>
+
+int main(int argc, char** argv) {
+    for(size_t i = 0; i < 100000; ++i) {
+        if (argc > 1 && TStringBuf(argv[1]) ==  "use-after-free") {
+            int* a = new int;
+            delete a;
+            *a = 1;
+        } else if (argc > 1 && TStringBuf(argv[1]) ==  "bounds") {
+            auto b = new int[1000];
+            b[1000] = 2;
+            delete b;
+        } else {
+            std::string s = "Hellooooooooooooooo ";
+            std::string_view sv = s + "World\n";
+            Cout << sv << Endl;
+        }
+    }
+    return 0;
+}

--- a/junk/iddqd/gwpasan/main.cpp
+++ b/junk/iddqd/gwpasan/main.cpp
@@ -34,7 +34,6 @@ int main(int argc, char** argv) {
     tcmalloc::MallocExtension::SetProfileSamplingInterval(1);
     tcmalloc::MallocExtension::SetGuardedSamplingInterval(1);
     tcmalloc::MallocExtension::ActivateGuardedSampling();
-    tcmalloc::MallocExtension::SetBackgroundReleaseRate(tcmalloc::MallocExtension::BytesPerSecond{1});
 
     std::cout << "With GWP-ASan" << std::endl; 
     test(argc, argv);

--- a/junk/iddqd/gwpasan/run.sh
+++ b/junk/iddqd/gwpasan/run.sh
@@ -1,0 +1,9 @@
+ya make -r . 
+echo "### "
+echo "### use-after-free"
+echo "### "
+./gwpasan use-after-free
+echo "### "
+echo "### bounds"
+echo "### "
+./gwpasan bounds

--- a/junk/iddqd/gwpasan/ya.make
+++ b/junk/iddqd/gwpasan/ya.make
@@ -1,0 +1,20 @@
+PROGRAM()
+
+SRCS(
+    main.cpp
+)
+CFLAGS(
+    -DGWP_ASAN_HOOKS=1
+    -DSCUDO_ENABLE_HOOKS=1
+)
+PEERDIR(
+#    ydb/core/driver_lib/gwp_asan_init
+    contrib/libs/clang18-rt/lib/scudo_standalone
+    contrib/libs/clang18-rt/lib/scudo_standalone_cxx
+)
+
+NO_COMPILER_WARNINGS()
+
+ALLOCATOR(SYSTEM)
+
+END()

--- a/junk/iddqd/gwpasan/ya.make
+++ b/junk/iddqd/gwpasan/ya.make
@@ -3,18 +3,9 @@ PROGRAM()
 SRCS(
     main.cpp
 )
-CFLAGS(
-    -DGWP_ASAN_HOOKS=1
-    -DSCUDO_ENABLE_HOOKS=1
-)
-PEERDIR(
-#    ydb/core/driver_lib/gwp_asan_init
-    contrib/libs/clang18-rt/lib/scudo_standalone
-    contrib/libs/clang18-rt/lib/scudo_standalone_cxx
-)
 
 NO_COMPILER_WARNINGS()
 
-ALLOCATOR(SYSTEM)
+ALLOCATOR(TCMALLOC_256K)
 
 END()


### PR DESCRIPTION
use run.sh

```
### 
### use-after-free
### 
W/o GWP-ASan
OK


With GWP-ASan
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:168] *** GWP-ASan (https://google.github.io/tcmalloc/gwp-asan.html) has detected a memory error ***
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:169] >>> Access at offset 0 into buffer of length 124
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:171] Error originates from memory allocated in thread 1089044 at:
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x4e7277
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x4d6b8f
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x35e1c0
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x35e508
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x7f526d430d90
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:178] The memory was freed in thread 1089044 at:
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x4d2db7
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x35e1cb
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x35e508
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x7f526d430d90
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:181] Use-after-free (read) occurs in thread 1089044 at:
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x513f72
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x513fbb
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x7f526d449520
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x35e508
1089044 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x7f526d430d90
./run.sh: line 5: 1089044 Segmentation fault      ./gwpasan use-after-free
### 
### bounds
### 
W/o GWP-ASan
OK


With GWP-ASan
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:168] *** GWP-ASan (https://google.github.io/tcmalloc/gwp-asan.html) has detected a memory error ***
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:169] >>> Access at offset 512 into buffer of length 512
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:171] Error originates from memory allocated in thread 1089045 at:
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x4e7277
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x4d6b8f
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x35e31e
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x35e508
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x7feac68dfd90
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/segv_handler.cc:195] Buffer overflow (read) occurs in thread 1089045 at:
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x513f72
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x513fbb
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x7feac68f8520
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x35e508
1089045 /home/maxim-yurchuk/ydb/contrib/libs/tcmalloc/tcmalloc/internal/logging.cc:193]   @  0x7feac68dfd90
./run.sh: line 9: 1089045 Segmentation fault      ./gwpasan bounds

```
