### PR TITLE
Revert "[ICRDMA] Enable RDMA allocator ut"

### DIFF
--- a/ydb/library/actors/interconnect/rdma/ut/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ut/ya.make
@@ -3,7 +3,6 @@ GTEST()
 IF (OS_LINUX AND SANITIZER_TYPE != "memory")
 
 SRCS(
-    allocator_ut.cpp
     ibv_ut.cpp
     utils.cpp
 )


### PR DESCRIPTION
Reverts ydb-platform/ydb#26564

```
serg-belyakov@mr-nvme-testing-11:~/ydbwork/ydb/ydb/library/actors/interconnect/rdma/ut$ ya make --build=relwithdebinfo -tt
------- [TS] ydb/library/actors/interconnect/rdma/ut/gtest
Test command err:
Ut test failed with exit code -6 while listing tests.
Process stderr:
Terminating due to uncaught exception 0x70003fa40410    what() -> "contrib/libs/ibdrv/symbols.cpp:40: Cannot open any shared library. Reasons:
Path: /usr/lib/libibverbs.so Reason: util/system/dynlib.cpp:58: /usr/lib/libibverbs.so: cannot open shared object file: No such file or directory
Path: libibverbs.so Reason: util/system/dynlib.cpp:58: libibverbs.so: cannot open shared object file: No such file or directory
Path: libibverbs.so.1 Reason: util/system/dynlib.cpp:58: libibverbs.so.1: cannot open shared object file: No such file or directory
"
 of type yexception

ydb/library/actors/interconnect/rdma/ut <gtest>
------ sole chunk ran 0 tests (total:0.53s - test:0.51s)
Ut test failed with exit code -6 while listing tests.
Process stderr:
Terminating due to uncaught exception 0x70003fa40410    what() -> "contrib/libs/ibdrv/symbols.cpp:40: Cannot open any shared library. Reasons:
Path: /usr/lib/libibverbs.so Reason: util/system/dynlib.cpp:58: /usr/lib/libibverbs.so: cannot open shared object file: No such file or directory
Path: libibverbs.so Reason: util/system/dynlib.cpp:58: libibverbs.so: cannot open shared object file: No such file or directory
Path: libibverbs.so.1 Reason: util/system/dynlib.cpp:58: libibverbs.so.1: cannot open shared object file: No such file or directory
"
 of type yexception
Log: /home/serg-belyakov/ydbwork/ydb/ydb/library/actors/interconnect/rdma/ut/test-results/gtest/run_test.log
Logsdir: /home/serg-belyakov/ydbwork/ydb/ydb/library/actors/interconnect/rdma/ut/test-results/gtest/testing_out_stuff
Stderr: /home/serg-belyakov/ydbwork/ydb/ydb/library/actors/interconnect/rdma/ut/test-results/gtest/testing_out_stuff/stderr
------ FAIL ydb/library/actors/interconnect/rdma/ut

Total 1 suite:
        1 - FAIL
Total 0 tests
Failed
```