### PR TITLE
Blob compaction stops after TEvGetWriteInfo

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1476,6 +1476,13 @@ void TPartition::Handle(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TActorCon
                                      "Topic.Partition.GetWriteInfo",
                                      NWilson::EFlags::AUTO_END);
 
+    StopCompaction = true;
+    if (CompactionInProgress) {
+        LOG_D("Event TEvPQ::TEvGetWriteInfoRequest will be processed later");
+        PendingGetWriteInfoRequest.reset(ev->Release().Release());
+        return;
+    }
+
     ProcessPendingEvent(ev, ctx);
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -1164,6 +1164,11 @@ private:
     bool WasTheLastBlobBig = true;
 
     void DumpKeysForBlobsCompaction() const;
+
+    void TryProcessGetWriteInfoRequest(const TActorContext& ctx);
+
+    std::unique_ptr<TEvPQ::TEvGetWriteInfoRequest> PendingGetWriteInfoRequest;
+    bool StopCompaction = false;
 };
 
 inline ui64 TPartition::GetStartOffset() const {

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -163,6 +163,11 @@ void TPartition::DumpKeysForBlobsCompaction() const
 
 void TPartition::TryRunCompaction()
 {
+    if (StopCompaction) {
+        LOG_D("Blobs compaction is stopped");
+        return;
+    }
+
     if (CompactionInProgress) {
         LOG_D("Blobs compaction in progress");
         return;
@@ -499,8 +504,18 @@ void TPartition::BlobsForCompactionWereWrite()
     KeysForCompaction.clear();
     CompactionBlobsCount = 0;
 
+    TryProcessGetWriteInfoRequest(ctx);
+
     ProcessTxsAndUserActs(ctx); // Now you can delete unnecessary keys.
     TryRunCompaction();
+}
+
+void TPartition::TryProcessGetWriteInfoRequest(const TActorContext& ctx)
+{
+    if (PendingGetWriteInfoRequest) {
+        ProcessPendingEvent(std::move(PendingGetWriteInfoRequest), ctx);
+        PendingGetWriteInfoRequest = nullptr;
+    }
 }
 
 void TPartition::EndProcessWritesForCompaction(TEvKeyValue::TEvRequest* request, const TInstant blobCreationUnixTime, const TActorContext& ctx)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Blob compaction stops after TEvGetWriteInfo. TEvGetWriteInfo processing is suspended until the next iteration of the blob compaction is completed.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
