### PR TITLE
Fix scaling out during rolling restart

### DIFF
--- a/ydb/core/mind/hive/domain_info.cpp
+++ b/ydb/core/mind/hive/domain_info.cpp
@@ -63,8 +63,8 @@ TString TTargetTrackingPolicy::GetLogPrefix() const {
     return TStringBuilder() << TScaleRecommenderPolicy::GetLogPrefix() << "[TargetTracking] ";
 }
 
-ui32 TTargetTrackingPolicy::MakeScaleRecommendation(ui32 readyNodesCount, const NKikimrConfig::THiveConfig& config) const {
-    ui32 recommendedNodes = readyNodesCount;
+std::optional<ui32> TTargetTrackingPolicy::MakeScaleRecommendation(ui32 readyNodesCount, const NKikimrConfig::THiveConfig& config) const {
+    std::optional<ui32> recommendedNodes;
 
     if (UsageHistory.size() >= config.GetScaleInWindowSize()) {
         auto scaleInWindowBegin = UsageHistory.end() - config.GetScaleInWindowSize();
@@ -117,7 +117,7 @@ ui32 TTargetTrackingPolicy::MakeScaleRecommendation(ui32 readyNodesCount, const 
         BLOG_TRACE("[MSR] Not enough history for scale out");
     }
 
-    return std::max(recommendedNodes, 1u);
+    return recommendedNodes ? std::max(*recommendedNodes, 1u) : recommendedNodes;
 }
 
 void TDomainInfo::SetScaleRecommenderPolicies(const NKikimrHive::TScaleRecommenderPolicies& policies) {

--- a/ydb/core/mind/hive/domain_info.h
+++ b/ydb/core/mind/hive/domain_info.h
@@ -19,7 +19,7 @@ class TScaleRecommenderPolicy {
 public:
     TScaleRecommenderPolicy(ui64 hiveId, bool dryRun);
     virtual ~TScaleRecommenderPolicy() = default;
-    virtual ui32 MakeScaleRecommendation(ui32 readyNodes, const NKikimrConfig::THiveConfig& config) const = 0;
+    virtual std::optional<ui32> MakeScaleRecommendation(ui32 readyNodes, const NKikimrConfig::THiveConfig& config) const = 0;
 
     virtual TString GetLogPrefix() const;
 private:
@@ -30,7 +30,7 @@ private:
 class TTargetTrackingPolicy : public TScaleRecommenderPolicy {
 public:
     TTargetTrackingPolicy(double target, const std::deque<double>& usageHistory, ui64 hiveId = 0, bool dryRun = false);
-    ui32 MakeScaleRecommendation(ui32 readyNodesCount, const NKikimrConfig::THiveConfig& config) const override;
+    std::optional<ui32> MakeScaleRecommendation(ui32 readyNodesCount, const NKikimrConfig::THiveConfig& config) const override;
 
     virtual TString GetLogPrefix() const override;
 private:

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -9135,9 +9135,20 @@ Y_UNIT_TEST_SUITE(TScaleRecommenderTest) {
         UNIT_ASSERT_VALUES_EQUAL(response->Record.GetStatus(), NKikimrProto::OK);
     }
 
-    void AssertScaleRecommencation(TTestBasicRuntime& runtime, ui64 hiveId, TSubDomainKey subdomainKey,
+    void RefreshScaleRecommendation(TTestBasicRuntime& runtime, ui64 hiveId) {
+        const auto sender = runtime.AllocateEdgeActor();
+        runtime.SendToPipe(hiveId, sender, new NHive::TEvPrivate::TEvRefreshScaleRecommendation());
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(NHive::TEvPrivate::EvRefreshScaleRecommendation);
+        runtime.DispatchEvents(options);
+    }
+
+    void AssertScaleRecommendation(TTestBasicRuntime& runtime, ui64 hiveId, TSubDomainKey subdomainKey,
         NKikimrProto::EReplyStatus expectedStatus, ui32 expectedNodes = 0)
     {
+        RefreshScaleRecommendation(runtime, hiveId);
+
         const auto sender = runtime.AllocateEdgeActor();
         runtime.SendToPipe(hiveId, sender, new TEvHive::TEvRequestScaleRecommendation(subdomainKey));
 
@@ -9147,15 +9158,6 @@ Y_UNIT_TEST_SUITE(TScaleRecommenderTest) {
         if (expectedNodes) {
             UNIT_ASSERT_VALUES_EQUAL(response->Record.GetRecommendedNodes(), expectedNodes);
         }
-    }
-
-    void RefreshScaleRecommendation(TTestBasicRuntime& runtime, ui64 hiveId) {
-        const auto sender = runtime.AllocateEdgeActor();
-        runtime.SendToPipe(hiveId, sender, new NHive::TEvPrivate::TEvRefreshScaleRecommendation());
-
-        TDispatchOptions options;
-        options.FinalEvents.emplace_back(NHive::TEvPrivate::EvRefreshScaleRecommendation);
-        runtime.DispatchEvents(options);
     }
 
     void SendUsage(TTestBasicRuntime& runtime, ui64 hiveId, ui64 nodeIdx, double cpuUsage) {
@@ -9169,7 +9171,7 @@ Y_UNIT_TEST_SUITE(TScaleRecommenderTest) {
         runtime.GrabEdgeEvent<TEvLocal::TEvTabletMetricsAck>(handle);
     }
 
-    std::pair<ui64,TSubDomainKey> SetupTest(TTestBasicRuntime& runtime) {
+    std::pair<ui64,TSubDomainKey> SetupTest(TTestBasicRuntime& runtime, ui32 initialNodeCount) {
         Setup(runtime, true);
 
         // Setup hive
@@ -9210,16 +9212,19 @@ Y_UNIT_TEST_SUITE(TScaleRecommenderTest) {
         createHive->Record.MutableAllowedDomains(0)->SetPathId(subdomainKey.second);
         ui64 subHiveTablet = SendCreateTestTablet(runtime, hiveTablet, testerTablet, std::move(createHive), 0, false);
 
-        TTestActorRuntime::TEventObserver prevObserverFunc;
-        prevObserverFunc = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        runtime.SetObserverFunc([=](TAutoPtr<IEventHandle>& event) {
             if (event->GetTypeRewrite() == NSchemeShard::TEvSchemeShard::EvDescribeSchemeResult) {
                 event->Get<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>()->MutableRecord()->
                 MutablePathDescription()->MutableDomainDescription()->MutableProcessingParams()->SetHive(subHiveTablet);
             }
-            return prevObserverFunc(event);
+            return TTestActorRuntime::EEventAction::PROCESS;
         });
 
-        SendKillLocal(runtime, 0);
+        for (size_t i = 0; i < runtime.GetNodeCount(); ++i) {
+            SendKillLocal(runtime, i);
+        }
+
+        // Connect hive node
         CreateLocalForTenant(runtime, 0, "/dc-1/tenant1");
         MakeSureTabletIsUp(runtime, subHiveTablet, 0); // sub hive good
 
@@ -9230,88 +9235,122 @@ Y_UNIT_TEST_SUITE(TScaleRecommenderTest) {
         ui64 tabletId = SendCreateTestTablet(runtime, subHiveTablet, testerTablet, std::move(createTablet), 0, true);
         MakeSureTabletIsUp(runtime, tabletId, 0); // dummy from sub hive also good
 
+        // Connect all other nodes
+        TBlockEvents<TEvLocal::TEvStatus> block(runtime);
+        for (size_t i = 1; i < initialNodeCount; ++i) {
+            CreateLocalForTenant(runtime, i, "/dc-1/tenant1");
+        }
+        runtime.WaitFor("nodes are connected to root hive", [&]{ return block.size() >= initialNodeCount - 1; });
+        block.Unblock();
+
+        runtime.WaitFor("nodes are connected to sub hive", [&]{ return block.size() >= initialNodeCount - 1; });
+        block.Unblock();
+        block.Stop();
+
         return {subHiveTablet, subdomainKey};
     }
 
-    constexpr double LOW_CPU_USAGE = 0.2;
+    void StartNode(TTestActorRuntime &runtime, ui32 nodeIndex) {
+        CreateLocalForTenant(runtime, nodeIndex, "/dc-1/tenant1");
+    }
+
+    void StopNode(TTestActorRuntime &runtime, ui32 nodeIndex) {
+        SendKillLocal(runtime, nodeIndex);
+    }
+
+    constexpr double LOW_CPU_USAGE = 0.3;
+    constexpr double TARGET_CPU_USAGE = 0.6;
     constexpr double HIGH_CPU_USAGE = 0.95;
 
     Y_UNIT_TEST(BasicTest) {
         // Setup test runtime
-        TTestBasicRuntime runtime(1, false);
-        const auto& [subHiveTablet, subdomainKey] = SetupTest(runtime);
-
-        // Configure target CPU usage
-        ConfigureScaleRecommender(runtime, subHiveTablet, subdomainKey, 60);
-
-        // No data yet
-        AssertScaleRecommencation(runtime, subHiveTablet, subdomainKey, NKikimrProto::NOTREADY);
-
-        // Set low CPU usage on Node
-        SendUsage(runtime, subHiveTablet, 0, LOW_CPU_USAGE);
-
-        // Refresh to calculate new scale recommendation
-        RefreshScaleRecommendation(runtime, subHiveTablet);
-
-        // Check scale recommendation for low CPU usage
-        AssertScaleRecommencation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 1);
-
-        // Set high CPU usage on Node
-        SendUsage(runtime, subHiveTablet, 0, HIGH_CPU_USAGE);
-
-        // Refresh to calculate new scale recommendation
-        RefreshScaleRecommendation(runtime, subHiveTablet);
-
-        // Check scale recommendation for high CPU usage
-        AssertScaleRecommencation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 2);
-    }
-
-    Y_UNIT_TEST(RollingRestart) {
-        // Setup test runtime
         TTestBasicRuntime runtime(2, false);
-        const auto& [subHiveTablet, subdomainKey] = SetupTest(runtime);
-
-        SendKillLocal(runtime, 1);
+        const auto& [subHiveTablet, subdomainKey] = SetupTest(runtime, 2);
 
         // Configure target CPU usage
         ConfigureScaleRecommender(runtime, subHiveTablet, subdomainKey, 60);
-
-        // No data yet
-        AssertScaleRecommencation(runtime, subHiveTablet, subdomainKey, NKikimrProto::NOTREADY);
-
-        // Set low CPU usage on node
-        SendUsage(runtime, subHiveTablet, 0, LOW_CPU_USAGE);
-
-        // Refresh to calculate new scale recommendation
-        RefreshScaleRecommendation(runtime, subHiveTablet);
-
-        // Check scale recommendation for low CPU usage
-        AssertScaleRecommencation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 1);
-
-        // Start new node during rolling restart
-        CreateLocalForTenant(runtime, 1, "/dc-1/tenant1");
 
         // Set low CPU usage on nodes
         SendUsage(runtime, subHiveTablet, 0, LOW_CPU_USAGE);
         SendUsage(runtime, subHiveTablet, 1, LOW_CPU_USAGE);
 
-        // Refresh to calculate new scale recommendation
-        RefreshScaleRecommendation(runtime, subHiveTablet);
+        // Check scale in recommendation for low CPU usage
+        AssertScaleRecommendation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 1);
 
-        // Check scale recommendation for high CPU usage
-        AssertScaleRecommencation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 1);
+        // Apply scale recommendation - stop one node
+        StopNode(runtime, 1);
 
-        // Kill node during rolling restart
-        SendKillLocal(runtime, 1);
+        // Set high CPU usage on node
+        SendUsage(runtime, subHiveTablet, 0, HIGH_CPU_USAGE);
 
-        // Set low CPU usage on node
-        SendUsage(runtime, subHiveTablet, 0, LOW_CPU_USAGE);
+        // Check scale out recommendation for high CPU usage
+        AssertScaleRecommendation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 2);
+    }
 
-        // Refresh to calculate new scale recommendation
-        RefreshScaleRecommendation(runtime, subHiveTablet);
+    Y_UNIT_TEST(RollingRestart) {
+        // Setup test runtime
+        TTestBasicRuntime runtime(3, false);
+        const auto& [subHiveTablet, subdomainKey] = SetupTest(runtime, 1);
 
-        // Check scale recommendation for low CPU usage
-        AssertScaleRecommencation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 1);
+        // Configure target CPU usage
+        ConfigureScaleRecommender(runtime, subHiveTablet, subdomainKey, 60);
+
+        // Set high CPU usage on node
+        SendUsage(runtime, subHiveTablet, 0, HIGH_CPU_USAGE);
+
+        // Recommended scale out: 1 -> 2
+        AssertScaleRecommendation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 2);
+
+        // Set target CPU usage on nodes
+        SendUsage(runtime, subHiveTablet, 0, TARGET_CPU_USAGE);
+        SendUsage(runtime, subHiveTablet, 1, TARGET_CPU_USAGE);
+
+        // Start rolling restart node
+        StartNode(runtime, 2);
+        SendUsage(runtime, subHiveTablet, 2, LOW_CPU_USAGE);
+
+        // No new scale recommended: 2 + 1 (rolling restart node) -> 2
+        AssertScaleRecommendation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 2);
+
+        // Stop rolling restart node
+        StopNode(runtime, 2);
+
+        // Set target CPU usage on nodes
+        SendUsage(runtime, subHiveTablet, 0, TARGET_CPU_USAGE);
+        SendUsage(runtime, subHiveTablet, 1, TARGET_CPU_USAGE);
+
+        // No new scale recommended: 2 -> 2
+        AssertScaleRecommendation(runtime, subHiveTablet, subdomainKey, NKikimrProto::OK, 2);
+    }
+
+    Y_UNIT_TEST(RollingRestartNoLastRecommendation) {
+        // Setup test runtime
+        TTestBasicRuntime runtime(3, false);
+        const auto& [subHiveTablet, subdomainKey] = SetupTest(runtime, 2);
+
+        // Configure target CPU usage
+        ConfigureScaleRecommender(runtime, subHiveTablet, subdomainKey, 60);
+
+        // Set target CPU usage on nodes
+        SendUsage(runtime, subHiveTablet, 0, TARGET_CPU_USAGE);
+        SendUsage(runtime, subHiveTablet, 1, TARGET_CPU_USAGE);
+
+        // Start rolling restart node
+        StartNode(runtime, 2);
+        SendUsage(runtime, subHiveTablet, 2, LOW_CPU_USAGE);
+
+        // No new scale recommended
+        AssertScaleRecommendation(runtime, subHiveTablet, subdomainKey, NKikimrProto::NOTREADY);
+
+        // Stop rolling restart node
+        StopNode(runtime, 2);
+
+        // Set target CPU usage on nodes
+        SendUsage(runtime, subHiveTablet, 0, TARGET_CPU_USAGE);
+        SendUsage(runtime, subHiveTablet, 1, TARGET_CPU_USAGE);
+
+        // No new scale recommended
+        AssertScaleRecommendation(runtime, subHiveTablet, subdomainKey, NKikimrProto::NOTREADY);
     }
 }
 

--- a/ydb/core/mind/hive/scale_recommender_policy_ut.cpp
+++ b/ydb/core/mind/hive/scale_recommender_policy_ut.cpp
@@ -17,13 +17,13 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.8 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.8, 0.8 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.8, 0.8, 0.8 };
         UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 4);
@@ -37,13 +37,13 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3, 0.3 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3, 0.3, 0.3 };
         UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 2);
@@ -57,13 +57,13 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), std::nullopt);
 
         history = { 0.8 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), std::nullopt);
 
         history = { 0.8, 0.8 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), std::nullopt);
 
         history = { 0.8, 0.8, 0.8 };
         UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), 1334);
@@ -77,13 +77,13 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), std::nullopt);
 
         history = { 0.3 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), std::nullopt);
 
         history = { 0.3, 0.3 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), std::nullopt);
 
         history = { 0.3, 0.3, 0.3 };
         UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(1000, config), 500);
@@ -97,16 +97,16 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3, };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3, 0.9 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3, 0.9, 0.3 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
     }
 
     Y_UNIT_TEST(NearTarget) {
@@ -118,16 +118,16 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.55, };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.55, 0.55 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.55, 0.55, 0.55 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
     }
 
     Y_UNIT_TEST(AtTarget) {
@@ -139,16 +139,16 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.6, };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.6, 0.6 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.6, 0.6, 0.6 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
     }
 
     void TestFluctuations(ui32 initialNodes) {
@@ -167,8 +167,11 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
                 std::deque<double> history;
                 for (size_t i = 0; i < 10; ++i) {
                     history.push_back(totalLoad / currentNodes);
-                    currentNodes = TTargetTrackingPolicy(avgTargetLoad, history).MakeScaleRecommendation(currentNodes, config);
-                    uniqueCurrentNodes.insert(currentNodes);
+                    std::optional<ui32> recommendedNodes = TTargetTrackingPolicy(avgTargetLoad, history).MakeScaleRecommendation(currentNodes, config);
+                    if (recommendedNodes) {
+                        currentNodes = *recommendedNodes;
+                        uniqueCurrentNodes.insert(currentNodes);
+                    }
                     currentNodesHistory.push_back(currentNodes);
                 }
 
@@ -229,13 +232,13 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3, };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3, 0.1 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.3, 0.1, 0.1 };
         UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 2);
@@ -249,13 +252,13 @@ Y_UNIT_TEST_SUITE(TargetTrackingScaleRecommenderPolicy) {
         std::deque<double> history;
 
         history = {};
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.01, };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.01, 0.01 };
-        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), std::nullopt);
 
         history = { 0.01, 0.01, 0.01 };
         UNIT_ASSERT_VALUES_EQUAL(TTargetTrackingPolicy(0.6, history).MakeScaleRecommendation(3, config), 1);

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2280,8 +2280,8 @@ message THiveConfig {
     optional string CutHistoryDenyList = 76 [default = "ColumnShard,KeyValue,PersQueue,BlobDepot"];
     optional string CutHistoryAllowList = 79 [default = "DataShard"];
     optional uint64 ScaleRecommendationRefreshFrequency = 80 [default = 60000]; // calculate scale recommendation every x milliseconds
-    optional uint64 ScaleOutWindowSize = 81 [default = 15]; // buckets
-    optional uint64 ScaleInWindowSize = 82 [default = 5]; // buckets
+    optional uint64 ScaleOutWindowSize = 81 [default = 10]; // buckets
+    optional uint64 ScaleInWindowSize = 82 [default = 60]; // buckets
     optional double TargetTrackingCPUMargin = 83 [default = 0.1]; // percent
     optional double DryRunTargetTrackingCPU = 84; // percent
     optional uint64 NodeRestartsForPenalty = 85 [default = 3];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes https://github.com/ydb-platform/ydb/issues/25980

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Этот PR устраняет проблему, из-за которой автоскейлер мог некорректно расширять базу во время роллинг-рестарта, так как думал, что в базе больше нод, чем в ней есть (во время роллинга в базу добавляется +1 дополнительная нода).

- Обновление рекомендации теперь происходит только в том случае, если необходимо изменить количество нод относительно текущего количества. Иначе на запросы возвращается предыдущая рекомендация или `UNAVAILABLE` в случае ее отсутствия.
- Обновлены значения по умолчанию для размеров окна масштабирования, чтобы быстрее расширять на при увеличении нагрузки и медленнее сужать базу при уменьшении нагрузки (`ScaleOutWindowSize`: 15 → 10, `ScaleInWindowSize`: 5 → 60).

