### PR TITLE
[ICRDMA] Fix link manager crash in case of missed library.

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -64,22 +64,6 @@ ydb/core/viewer/tests test.py.test_topic_data_cdc
 ydb/core/viewer/ut Viewer.TabletMerging
 ydb/library/actors/core/ut_fat HeavyActorBenchmark.SendActivateReceiveCSV_10Pairs_LONG
 ydb/library/actors/core/ut_fat unittest.[*/*] chunk
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite.AllocMemoryManually
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.AllocMemoryWithMemPool/DummyMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.AllocMemoryWithMemPool/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.AllocMemoryWithMemPoolAsync/DummyMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.AllocMemoryWithMemPoolAsync/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.AllocMemoryWithMemPoolAsyncRandomOrderDealloc/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.FullChunkAllocationMultiThread/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.MemRegRcBuf/DummyMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.MemRegRcBuf/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.MemRegRcBufSubstr/DummyMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.MemRegRcBufSubstr/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.MemRegRope/DummyMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.MemRegRope/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.PageAlligned/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.SmallAllocationMultiThread/SlotMemPool
-ydb/library/actors/interconnect/rdma/ut TAllocatorSuite/WithAllPools.ThreadsDestroy/SlotMemPool
 ydb/library/actors/interconnect/ut_fat InterconnectUnstableConnection.InterconnectTestWithProxyTlsReestablishWithXdc
 ydb/library/actors/interconnect/ut_fat InterconnectZcLocalOp.ZcDisabledAfterHiddenCopy
 ydb/library/actors/interconnect/ut_fat InterconnectZcLocalOp.ZcIsDisabledByDefault

--- a/ydb/library/actors/interconnect/rdma/ctx.h
+++ b/ydb/library/actors/interconnect/rdma/ctx.h
@@ -20,6 +20,10 @@ namespace NLinkMgr {
     class TRdmaLinkManager;
 }
 
+// Open ibdrvlib. Throw exception in case of absent library, or other dlopen errors.
+// Is used to check the library is present.
+void IbvDlOpen();
+
 struct TDeviceCtx : public NNonCopyable::TNonCopyable {
     TDeviceCtx(ibv_context* ctx, ibv_pd* pd);
 

--- a/ydb/library/actors/interconnect/rdma/ctx_open.cpp
+++ b/ydb/library/actors/interconnect/rdma/ctx_open.cpp
@@ -1,0 +1,8 @@
+#include <contrib/libs/ibdrv/symbols.h>
+
+// symbols.h and verbs.h can't be used in one cpp file
+namespace NInterconnect::NRdma {
+    void IbvDlOpen() {
+        IBSym();
+    }
+}

--- a/ydb/library/actors/interconnect/rdma/link_manager.cpp
+++ b/ydb/library/actors/interconnect/rdma/link_manager.cpp
@@ -54,6 +54,13 @@ public:
     }
 
     TRdmaLinkManager() {
+        // Make sure libibverbs.so is present
+        try {
+            IbvDlOpen();
+        } catch (std::exception& ex) {
+            Cerr << "Unalbe to load ibverbs library: " << ex.what() << Endl;
+            return;
+        }
         ScanDevices();
     }
 private:

--- a/ydb/library/actors/interconnect/rdma/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     ctx.cpp
+    ctx_open.cpp
     link_manager.cpp
     mem_pool.cpp
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

ibdrv wrapper performs dlopen during first call of ib* "C" function. But in case of missed library will throw exception. To prevent cross language exception we will try to open the library before first ibv* call and check is ibverbs present.

https://github.com/ydb-platform/ydb/issues/26673

### Changelog category <!-- remove all except one -->


* Bugfix 



### Description for reviewers <!-- (optional) description for those who read this PR -->

...
