### PR TITLE
VIEW backup restore: ignore pragma table path prefix case (lower must be ok)

### DIFF
--- a/ydb/core/sys_view/show_create/create_view_formatter.cpp
+++ b/ydb/core/sys_view/show_create/create_view_formatter.cpp
@@ -1,6 +1,7 @@
 #include "create_view_formatter.h"
 
 #include <ydb/public/lib/ydb_cli/dump/util/query_utils.h>
+#include <ydb/public/lib/ydb_cli/dump/util/view_utils.h>
 
 #include <yql/essentials/parser/proto_ast/gen/v1/SQLv1Lexer.h>
 #include <yql/essentials/sql/settings/translation_settings.h>
@@ -41,19 +42,6 @@ TParsers BuildParsers() {
     parsers.Antlr4 = MakeAntlr4ParserFactory();
     parsers.Antlr4Ansi = MakeAntlr4AnsiParserFactory();
     return parsers;
-}
-
-bool SplitViewQuery(const TString& query, const TLexers& lexers, const TParsers& parsers, const TTranslationSettings& translationSettings, TViewQuerySplit& split, TIssues& issues) {
-    TVector<TString> statements;
-    if (!SplitQueryToStatements(lexers, parsers, query, statements, issues, translationSettings)) {
-        return false;
-    }
-    if (statements.empty()) {
-        issues.AddIssue(TStringBuilder() << "No select statement in the view query: " << query.Quote());
-        return false;
-    }
-    split = TViewQuerySplit(statements);
-    return true;
 }
 
 struct TTokenCollector {
@@ -136,27 +124,6 @@ TString GetRelativePath(const TFsPath& prefix, const TFsPath& absolutePath) {
 
 }
 
-TViewQuerySplit::TViewQuerySplit(const TVector<TString>& statements) {
-    TStringBuilder context;
-    for (int i = 0; i < std::ssize(statements) - 1; ++i) {
-        context << statements[i] << '\n';
-    }
-    ContextRecreation = context;
-    Y_ENSURE(!statements.empty());
-    Select = statements.back();
-}
-
-bool SplitViewQuery(const TString& query, TViewQuerySplit& split, TIssues& issues) {
-    google::protobuf::Arena arena;
-    TTranslationSettings translationSettings;
-    if (!BuildTranslationSettings(query, arena, translationSettings, issues)) {
-        return false;
-    }
-    auto lexers = BuildLexers();
-    auto parsers = BuildParsers();
-    return SplitViewQuery(query, lexers, parsers, translationSettings, split, issues);
-}
-
 TFormatResult TCreateViewFormatter::Format(const TString& viewRelativePath, const TString& viewAbsolutePath, const NKikimrSchemeOp::TViewDescription& viewDesc) {
     const auto& query = viewDesc.GetQueryText();
 
@@ -169,7 +136,7 @@ TFormatResult TCreateViewFormatter::Format(const TString& viewRelativePath, cons
 
     auto lexers = BuildLexers();
     auto parsers = BuildParsers();
-    TViewQuerySplit split;
+    NYdb::NDump::TViewQuerySplit split;
     if (!SplitViewQuery(query, lexers, parsers, translationSettings, split, issues)) {
         return TFormatResult(Ydb::StatusIds::SCHEME_ERROR, issues);
     }

--- a/ydb/core/sys_view/show_create/create_view_formatter.cpp
+++ b/ydb/core/sys_view/show_create/create_view_formatter.cpp
@@ -137,7 +137,7 @@ TFormatResult TCreateViewFormatter::Format(const TString& viewRelativePath, cons
     auto lexers = BuildLexers();
     auto parsers = BuildParsers();
     NYdb::NDump::TViewQuerySplit split;
-    if (!SplitViewQuery(query, lexers, parsers, translationSettings, split, issues)) {
+    if (!SplitViewQuery(query, lexers, translationSettings, split, issues)) {
         return TFormatResult(Ydb::StatusIds::SCHEME_ERROR, issues);
     }
 

--- a/ydb/core/sys_view/show_create/create_view_formatter.h
+++ b/ydb/core/sys_view/show_create/create_view_formatter.h
@@ -8,16 +8,6 @@
 
 namespace NKikimr::NSysView {
 
-struct TViewQuerySplit {
-    TString ContextRecreation;
-    TString Select;
-
-    TViewQuerySplit() = default;
-    TViewQuerySplit(const TVector<TString>& statements);
-};
-
-bool SplitViewQuery(const TString& query, TViewQuerySplit& split, NYql::TIssues& issues);
-
 class TCreateViewFormatter {
 public:
     TFormatResult Format(const TString& viewRelativePath, const TString& viewAbsolutePath, const NKikimrSchemeOp::TViewDescription& viewDesc);

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -1,6 +1,7 @@
 #include "ut_common.h"
 
 #include <ydb/public/lib/ydb_cli/dump/util/query_utils.h>
+#include <ydb/public/lib/ydb_cli/dump/util/view_utils.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_scripting.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/value/value.h>
 
@@ -24,8 +25,9 @@ namespace NKikimr {
 namespace NSysView {
 
 using namespace NYdb;
-using namespace NYdb::NTable;
+using namespace NYdb::NDump;
 using namespace NYdb::NScheme;
+using namespace NYdb::NTable;
 
 namespace {
 
@@ -2639,11 +2641,11 @@ ALTER OBJECT `/Root/test_show_create` (TYPE TABLE) SET (ACTION = UPSERT_OPTIONS,
         check.Uint64(1u); // LastTtlRowsProcessed
         check.Uint64(1u); // LastTtlRowsErased
     }
-    
+
     Y_UNIT_TEST(PartitionStatsAfterRemoveColumnTable) {
         TTestEnv env;
         NQuery::TQueryClient client(env.GetDriver());
-        
+
         {
             auto result = client.ExecuteQuery(R"(
                 CREATE TABLE `/Root/test_table` (
@@ -2652,10 +2654,10 @@ ALTER OBJECT `/Root/test_show_create` (TYPE TABLE) SET (ACTION = UPSERT_OPTIONS,
                     PRIMARY KEY(key)
                 ) WITH (STORE=COLUMN);
             )", NQuery::TTxControl::NoTx()).GetValueSync();
-            
+
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
-        
+
         {
             auto result = client.ExecuteQuery(R"(
                 SELECT Path FROM `/Root/.sys/partition_stats`
@@ -2674,15 +2676,15 @@ ALTER OBJECT `/Root/test_show_create` (TYPE TABLE) SET (ACTION = UPSERT_OPTIONS,
             }
             UNIT_ASSERT_C(existsPath, "Path /Root/test_table not found");
         }
-        
+
         {
             auto result = client.ExecuteQuery(R"(
                 DROP TABLE `/Root/test_table`
             )", NQuery::TTxControl::NoTx()).GetValueSync();
-            
+
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
-        
+
         {
             auto result = client.ExecuteQuery(R"(
                 SELECT Path FROM `/Root/.sys/partition_stats`

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -76,11 +76,11 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
         return true;
     }
 
+    restorePathPrefix = RewriteAbsolutePath(backupPathPrefix, backupRoot, restoreRoot);
+
     if (backupRoot == restoreRoot) {
         return true;
     }
-
-    restorePathPrefix = RewriteAbsolutePath(backupPathPrefix, backupRoot, restoreRoot);
 
     if (!re2::RE2::Replace(&query, pattern,
         std::format(R"(PRAGMA TablePathPrefix = '{}';)", restorePathPrefix.c_str())

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -45,7 +45,11 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
 ) {
     restorePathPrefix = restoreRoot;
 
-    if (!re2::RE2::PartialMatch(query, R"(PRAGMA TablePathPrefix = '(\S+)';)", &backupPathPrefix)) {
+    re2::RE2::Options options;
+    options.set_case_sensitive(false);
+    re2::RE2 pattern(R"(PRAGMA TablePathPrefix = '(\S+)';)", options);
+
+    if (!re2::RE2::PartialMatch(query, pattern, &backupPathPrefix)) {
         if (!restoreRootIsDatabase) {
             // Initially, the view relied on the implicit table path prefix;
             // however, this approach is now incorrect because the requested restore root differs from the database root.
@@ -70,12 +74,11 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
 
     restorePathPrefix = RewriteAbsolutePath(backupPathPrefix, backupRoot, restoreRoot);
 
-    constexpr TStringBuf pattern = R"(PRAGMA TablePathPrefix = '\S+';)";
     if (!re2::RE2::Replace(&query, pattern,
         std::format(R"(PRAGMA TablePathPrefix = '{}';)", restorePathPrefix.c_str())
     )) {
         issues.AddIssue(TStringBuilder() << "query: " << query.Quote()
-            << " does not contain the pattern: \"" << pattern << "\""
+            << " does not contain the pattern: \"" << pattern.pattern() << "\""
         );
         return false;
     }

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.h
@@ -5,7 +5,6 @@
 
 namespace NSQLTranslationV1 {
     struct TLexers;
-    struct TParsers;
 }
 
 namespace NSQLTranslation {
@@ -28,7 +27,7 @@ struct TViewQuerySplit {
 
 bool SplitViewQuery(const TString& query, TViewQuerySplit& split, NYql::TIssues& issues);
 bool SplitViewQuery(
-    const TString& query, const NSQLTranslationV1::TLexers& lexers, const NSQLTranslationV1::TParsers& parsers, const NSQLTranslation::TTranslationSettings& translationSettings,
+    const TString& query, const NSQLTranslationV1::TLexers& lexers, const NSQLTranslation::TTranslationSettings& translationSettings,
     TViewQuerySplit& split, NYql::TIssues& issues
 );
 

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.h
@@ -3,6 +3,15 @@
 #include <util/generic/string.h>
 #include <util/stream/str.h>
 
+namespace NSQLTranslationV1 {
+    struct TLexers;
+    struct TParsers;
+}
+
+namespace NSQLTranslation {
+    struct TTranslationSettings;
+}
+
 namespace NYql {
     class TIssues;
 }
@@ -12,9 +21,16 @@ namespace NYdb::NDump {
 struct TViewQuerySplit {
     TString ContextRecreation;
     TString Select;
+
+    TViewQuerySplit() = default;
+    TViewQuerySplit(const TVector<TString>& statements);
 };
 
-TViewQuerySplit SplitViewQuery(TStringInput query);
+bool SplitViewQuery(const TString& query, TViewQuerySplit& split, NYql::TIssues& issues);
+bool SplitViewQuery(
+    const TString& query, const NSQLTranslationV1::TLexers& lexers, const NSQLTranslationV1::TParsers& parsers, const NSQLTranslation::TTranslationSettings& translationSettings,
+    TViewQuerySplit& split, NYql::TIssues& issues
+);
 
 TString BuildCreateViewQuery(
     const TString& name, const TString& dbPath, const TString& viewQuery, const TString& database, const TString& backupRoot,

--- a/ydb/public/lib/ydb_cli/dump/util/ya.make
+++ b/ydb/public/lib/ydb_cli/dump/util/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     yql/essentials/parser/proto_ast/gen/v1
     yql/essentials/parser/proto_ast/gen/v1_proto_split
     yql/essentials/sql/settings
+    yql/essentials/sql/v1
     yql/essentials/sql/v1/format
     yql/essentials/sql/v1/proto_parser
     yql/essentials/sql/v1/lexer/antlr4

--- a/ydb/public/lib/ydb_cli/dump/util/ya.make
+++ b/ydb/public/lib/ydb_cli/dump/util/ya.make
@@ -7,32 +7,21 @@ SRCS(
 )
 
 PEERDIR(
-    library/cpp/protobuf/util
     ydb/public/lib/ydb_cli/common
     ydb/public/sdk/cpp/src/client/draft
     ydb/public/sdk/cpp/src/client/scheme
     ydb/public/sdk/cpp/src/client/table
     ydb/public/sdk/cpp/src/client/types/status
-    yql/essentials/public/udf/service/exception_policy
-    yql/essentials/parser/pg_wrapper
     yql/essentials/parser/proto_ast/gen/v1
     yql/essentials/parser/proto_ast/gen/v1_proto_split
     yql/essentials/sql/settings
-    yql/essentials/sql/v1
     yql/essentials/sql/v1/format
+    yql/essentials/sql/v1/proto_parser
     yql/essentials/sql/v1/lexer/antlr4
     yql/essentials/sql/v1/lexer/antlr4_ansi
-    yql/essentials/sql/v1/proto_parser
     yql/essentials/sql/v1/proto_parser/antlr4
     yql/essentials/sql/v1/proto_parser/antlr4_ansi
+    library/cpp/protobuf/util
 )
-
-YQL_LAST_ABI_VERSION()
-
-IF (MKQL_RUNTIME_VERSION)
-    CFLAGS(
-        -DMKQL_RUNTIME_VERSION=$MKQL_RUNTIME_VERSION
-    )
-ENDIF()
 
 END()

--- a/ydb/public/lib/ydb_cli/dump/util/ya.make
+++ b/ydb/public/lib/ydb_cli/dump/util/ya.make
@@ -7,22 +7,32 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/protobuf/util
     ydb/public/lib/ydb_cli/common
     ydb/public/sdk/cpp/src/client/draft
     ydb/public/sdk/cpp/src/client/scheme
     ydb/public/sdk/cpp/src/client/table
     ydb/public/sdk/cpp/src/client/types/status
+    yql/essentials/public/udf/service/exception_policy
+    yql/essentials/parser/pg_wrapper
     yql/essentials/parser/proto_ast/gen/v1
     yql/essentials/parser/proto_ast/gen/v1_proto_split
     yql/essentials/sql/settings
     yql/essentials/sql/v1
     yql/essentials/sql/v1/format
-    yql/essentials/sql/v1/proto_parser
     yql/essentials/sql/v1/lexer/antlr4
     yql/essentials/sql/v1/lexer/antlr4_ansi
+    yql/essentials/sql/v1/proto_parser
     yql/essentials/sql/v1/proto_parser/antlr4
     yql/essentials/sql/v1/proto_parser/antlr4_ansi
-    library/cpp/protobuf/util
 )
+
+YQL_LAST_ABI_VERSION()
+
+IF (MKQL_RUNTIME_VERSION)
+    CFLAGS(
+        -DMKQL_RUNTIME_VERSION=$MKQL_RUNTIME_VERSION
+    )
+ENDIF()
 
 END()

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -3244,6 +3244,39 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
         );
     }
 
+    Y_UNIT_TEST(RestoreViewTablePathPrefix) {
+        TS3TestEnv testEnv;
+        constexpr const char* view = "view";
+        constexpr const char* table = "table";
+        constexpr const char* restoredView = "a/b/c/view";
+
+        TestViewRelativeReferencesArePreserved(
+            view,
+            table,
+            restoredView,
+            testEnv.GetQuerySession(),
+            CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
+            CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "a/b/c/view", "a/b/c/table" }),
+            "PRAGMA TablePathPrefix = '/Root/a/b/c';\n"
+        );
+    }
+
+    Y_UNIT_TEST(RestoreViewTablePathPrefixLowercase) {
+        TS3TestEnv testEnv;
+        constexpr const char* view = "view";
+        constexpr const char* table = "table";
+        constexpr const char* restoredView = "a/b/c/view";
+
+        TestViewRelativeReferencesArePreserved(
+            view,
+            table,
+            restoredView,
+            testEnv.GetQuerySession(),
+            CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
+            CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "a/b/c/view", "a/b/c/table" }),
+            "pragma tablepathprefix = '/Root/a/b/c';\n" // note the lowercase
+        );
+    }
 
     // TO DO: test view restoration to a different database
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix restoration of views defined using `PRAGMA TablePathPrefix` written in non-canonical case.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Issues:
- https://github.com/ydb-platform/ydb/issues/26568
