### PR TITLE
fix data race in the `ydb workload topic run`: do not initialize the test mock on the production code path

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -156,9 +156,6 @@ void TTopicWorkloadWriterWorker::Process(TInstant endTime) {
 
 std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::CreateProducer(ui64 partitionId) {
     auto clock = NUnifiedAgent::TClock();
-    if (!clock.Configured()) {
-        clock.Configure();
-    }
     auto producerId = TGUID::CreateTimebased().AsGuidString();
 
     auto producer = std::make_shared<TTopicWorkloadWriterProducer>(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-9919