### PR TITLE
YQ-4782 support checkpointing on streaming query restart

### DIFF
--- a/ydb/core/actorlib_impl/ut/ya.make
+++ b/ydb/core/actorlib_impl/ut/ya.make
@@ -19,8 +19,8 @@ PEERDIR(
     ydb/library/actors/core
     ydb/library/actors/interconnect
     yql/essentials/minikql/comp_nodes/llvm16
-    yt/yql/providers/yt/comp_nodes/llvm16
     yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 SRCS(

--- a/ydb/core/actorlib_impl/ut/ya.make
+++ b/ydb/core/actorlib_impl/ut/ya.make
@@ -11,14 +11,16 @@ ELSE()
 ENDIF()
 
 PEERDIR(
-    ydb/apps/version
-    ydb/library/actors/core
-    ydb/library/actors/interconnect
     library/cpp/getopt
     library/cpp/svnversion
+    ydb/apps/version
     ydb/core/testlib/actors
     ydb/core/testlib/basics/default
+    ydb/library/actors/core
+    ydb/library/actors/interconnect
     yql/essentials/minikql/comp_nodes/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
 )
 
 SRCS(

--- a/ydb/core/actorlib_impl/ut/ya.make
+++ b/ydb/core/actorlib_impl/ut/ya.make
@@ -11,16 +11,14 @@ ELSE()
 ENDIF()
 
 PEERDIR(
-    library/cpp/getopt
-    library/cpp/svnversion
     ydb/apps/version
-    ydb/core/testlib/actors
-    ydb/core/testlib/basics/default
     ydb/library/actors/core
     ydb/library/actors/interconnect
+    library/cpp/getopt
+    library/cpp/svnversion
+    ydb/core/testlib/actors
+    ydb/core/testlib/basics/default
     yql/essentials/minikql/comp_nodes/llvm16
-    yt/yql/providers/yt/comp_nodes/dq/llvm16
-    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 SRCS(

--- a/ydb/core/blobstorage/ut_blobstorage/lib/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/ya.make
@@ -37,10 +37,12 @@ PEERDIR(
     ydb/core/tx/coordinator
     ydb/core/tx/scheme_board
     ydb/core/util
+    ydb/core/util/actorsys_test
     yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/public/udf/service/exception_policy
     yql/essentials/sql/pg_dummy
-    ydb/core/util/actorsys_test
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 END()

--- a/ydb/core/control/ut/ya.make
+++ b/ydb/core/control/ut/ya.make
@@ -18,8 +18,8 @@ PEERDIR(
     yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/public/udf/service/exception_policy
     yql/essentials/sql/pg_dummy
-    yt/yql/providers/yt/comp_nodes/llvm16
     yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 SRCS(

--- a/ydb/core/control/ut/ya.make
+++ b/ydb/core/control/ut/ya.make
@@ -5,20 +5,21 @@ FORK_SUBTESTS()
 SIZE(MEDIUM)
 
 PEERDIR(
-    ydb/library/actors/core
-    ydb/library/actors/interconnect
     library/cpp/testing/unittest
-    util
     ydb/core/base
     ydb/core/mind
     ydb/core/mon
-    yql/essentials/sql/pg_dummy
-    ydb/services/ydb
-    ydb/services/persqueue_v1
+    ydb/library/actors/core
+    ydb/library/actors/interconnect
     ydb/services/kesus
     ydb/services/persqueue_cluster_discovery
+    ydb/services/persqueue_v1
+    ydb/services/ydb
     yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/public/udf/service/exception_policy
+    yql/essentials/sql/pg_dummy
+    yt/yql/providers/yt/comp_nodes/llvm16
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
 )
 
 SRCS(

--- a/ydb/core/fq/libs/checkpointing/checkpoint_coordinator.cpp
+++ b/ydb/core/fq/libs/checkpointing/checkpoint_coordinator.cpp
@@ -237,6 +237,8 @@ void TCheckpointCoordinator::TryToRestoreOffsetsFromForeignCheckpoint(const TChe
         Send(RunActorId, new NFq::TEvCheckpointCoordinator::TEvRaiseTransientIssues(std::move(issues)));
     }
 
+    CC_LOG_I("Going to restore offsets from foreign checkpoint " << checkpoint.CheckpointId << " for tasks #" << plan.size());
+
     PendingRestoreCheckpoint = TPendingRestoreCheckpoint(checkpoint.CheckpointId, false, ActorsToWaitForSet);
     ++*Metrics.RestoredStreamingOffsetsFromCheckpoint;
     for (const auto& [taskId, taskPlan] : plan) {
@@ -249,6 +251,7 @@ void TCheckpointCoordinator::TryToRestoreOffsetsFromForeignCheckpoint(const TChe
         }
         const auto transportIt = ActorsToWaitFor.find(actorIdIt->second);
         if (transportIt != ActorsToWaitFor.end()) {
+            CC_LOG_D("Restore offsets from foreign checkpoint " << checkpoint.CheckpointId << " for task " << taskId);
             transportIt->second->EventsQueue.Send(
                 new NYql::NDq::TEvDqCompute::TEvRestoreFromCheckpoint(
                     checkpoint.CheckpointId.SeqNo,

--- a/ydb/core/fq/libs/checkpointing/ut/ya.make
+++ b/ydb/core/fq/libs/checkpointing/ut/ya.make
@@ -9,8 +9,6 @@ PEERDIR(
     ydb/core/fq/libs/checkpointing
     ydb/core/testlib/actors
     ydb/core/testlib/basics/default
-    yt/yql/providers/yt/comp_nodes/dq/llvm16
-    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 SIZE(MEDIUM)

--- a/ydb/core/fq/libs/checkpointing/ut/ya.make
+++ b/ydb/core/fq/libs/checkpointing/ut/ya.make
@@ -9,6 +9,8 @@ PEERDIR(
     ydb/core/fq/libs/checkpointing
     ydb/core/testlib/actors
     ydb/core/testlib/basics/default
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 SIZE(MEDIUM)

--- a/ydb/core/kqp/common/events/events.h
+++ b/ydb/core/kqp/common/events/events.h
@@ -138,6 +138,8 @@ struct TEvKqp {
         std::optional<NKikimrKqp::TQueryPhysicalGraph> QueryPhysicalGraph;
         std::optional<TString> ExecutionId;
         bool DisableDefaultTimeout = false;
+        i64 Generation = 1;
+        TString CheckpointId;
     };
 
     struct TEvScriptResponse : public TEventLocal<TEvScriptResponse, TKqpEvents::EvScriptResponse> {

--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -343,14 +343,16 @@ struct TEvSaveScriptPhysicalGraphResponse : public TEventLocal<TEvSaveScriptPhys
 };
 
 struct TEvGetScriptPhysicalGraphResponse : public TEventLocal<TEvGetScriptPhysicalGraphResponse, TKqpScriptExecutionEvents::EvGetScriptPhysicalGraphResponse> {
-    TEvGetScriptPhysicalGraphResponse(Ydb::StatusIds::StatusCode status, NKikimrKqp::TQueryPhysicalGraph&& physicalGraph, NYql::TIssues issues)
+    TEvGetScriptPhysicalGraphResponse(Ydb::StatusIds::StatusCode status, NKikimrKqp::TQueryPhysicalGraph&& physicalGraph, i64 generation, NYql::TIssues issues)
         : Status(status)
         , PhysicalGraph(std::move(physicalGraph))
+        , Generation(generation)
         , Issues(std::move(issues))
     {}
 
     Ydb::StatusIds::StatusCode Status;
     NKikimrKqp::TQueryPhysicalGraph PhysicalGraph;
+    i64 Generation = 0;
     NYql::TIssues Issues;
 };
 

--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -325,7 +325,7 @@ struct TEvSaveScriptExternalEffectResponse : public TEventLocal<TEvSaveScriptExt
 };
 
 struct TEvSaveScriptPhysicalGraphRequest : public TEventLocal<TEvSaveScriptPhysicalGraphRequest, TKqpScriptExecutionEvents::EvSaveScriptPhysicalGraphRequest> {
-    explicit TEvSaveScriptPhysicalGraphRequest(NKikimrKqp::TQueryPhysicalGraph&& physicalGraph)
+    explicit TEvSaveScriptPhysicalGraphRequest(NKikimrKqp::TQueryPhysicalGraph physicalGraph)
         : PhysicalGraph(std::move(physicalGraph))
     {}
 

--- a/ydb/core/kqp/common/kqp_user_request_context.cpp
+++ b/ydb/core/kqp/common/kqp_user_request_context.cpp
@@ -14,6 +14,9 @@ namespace NKikimr::NKqp {
             o << ", CurrentExecutionId: " << CurrentExecutionId;
             o << ", RunScriptActorId: " << RunScriptActorId.ToString();
         }
+        if (CheckpointId) {
+            o << ", CheckpointId: " << CheckpointId;
+        }
         o << "}";
     }
 
@@ -26,5 +29,6 @@ namespace NKikimr::NKqp {
         resultMap["CustomerSuppliedId"] = ctx.CustomerSuppliedId;
         resultMap["PoolId"] = ctx.PoolId;
         resultMap["RunScriptActorId"] = ctx.RunScriptActorId.ToString();  // Only for logging
+        resultMap["CheckpointId"] = ctx.CheckpointId;
     }
 }

--- a/ydb/core/kqp/common/kqp_user_request_context.h
+++ b/ydb/core/kqp/common/kqp_user_request_context.h
@@ -20,6 +20,7 @@ namespace NKikimr::NKqp {
         TString PoolId;
         std::optional<NResourcePool::TPoolSettings> PoolConfig;
         bool IsStreamingQuery = false;
+        TString CheckpointId;
 
         TUserRequestContext() = default;
 

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2891,9 +2891,9 @@ private:
             graphParams,
             stateLoadMode,
             streamingDisposition).Release());
-        LOG_D("Created new CheckpointCoordinator (" << CheckpointCoordinatorId << "), execution id "
-            << context->CurrentExecutionId << ", checkpoint id "
-            << checkpointId << ", generation " << Generation
+        LOG_D("Created new CheckpointCoordinator (" << CheckpointCoordinatorId << ")"
+            << ", execution id " << context->CurrentExecutionId
+            << ", checkpoint id " << checkpointId << ", generation " << Generation
             << ", state load mode " << FederatedQuery::StateLoadMode_Name(stateLoadMode)
             << ", streaming disposition " << streamingDisposition.ShortDebugString());
     }

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.cpp
@@ -14,6 +14,8 @@ TStreamingQuerySettings& TStreamingQuerySettings::FromProto(const NKikimrSchemeO
             Run = value == "true";
         } else if (name == TStreamingQueryMeta::TProperties::ResourcePool) {
             ResourcePool = value;
+        } else if (name == TStreamingQueryMeta::TProperties::QueryTextRevision) {
+            QueryTextRevision = TryFromString<ui64>(value).GetOrElse(0);
         }
     }
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.h
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.h
@@ -27,6 +27,9 @@ public:
         static inline constexpr char Run[] = "run";
         static inline constexpr char ResourcePool[] = "resource_pool";
         static inline constexpr char Force[] = "force";
+
+        // Internal query info
+        static inline constexpr char QueryTextRevision[] = "__query_text_revision";
     };
 };
 
@@ -39,6 +42,7 @@ public:
     TString QueryText;
     bool Run = false;
     TString ResourcePool;
+    ui64 QueryTextRevision = 0;
 };
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/ya.make
@@ -20,6 +20,7 @@ PEERDIR(
     ydb/core/kqp/gateway/behaviour/streaming_query/common
     ydb/core/kqp/gateway/utils
     ydb/core/kqp/provider
+    ydb/core/kqp/proxy_service
     ydb/core/protos
     ydb/core/protos/schemeshard
     ydb/core/resource_pools

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -4930,7 +4930,7 @@ IActor* CreateRefreshScriptExecutionLeasesActor(const TActorId& replyActorId, co
     return new TRefreshScriptExecutionLeasesActor(replyActorId, queryServiceConfig, counters);
 }
 
-IActor* CreateSaveScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId, NKikimrKqp::TQueryPhysicalGraph&& physicalGraph, i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig) {
+IActor* CreateSaveScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId, NKikimrKqp::TQueryPhysicalGraph physicalGraph, i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig) {
     return new TSaveScriptExecutionPhysicalGraphActor::TRetry(replyActorId, database, executionId, std::move(physicalGraph), leaseGeneration, queryServiceConfig);
 }
 

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.h
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.h
@@ -41,7 +41,7 @@ IActor* CreateScriptProgressActor(const TString& executionId, const TString& dat
 IActor* CreateRefreshScriptExecutionLeasesActor(const TActorId& replyActorId, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters);
 
 // Script execution physical graph management
-IActor* CreateSaveScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId, NKikimrKqp::TQueryPhysicalGraph&& physicalGraph, i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig);
+IActor* CreateSaveScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId, NKikimrKqp::TQueryPhysicalGraph physicalGraph, i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig);
 IActor* CreateGetScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId);
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -124,6 +124,7 @@ public:
         , QueryServiceConfig(std::move(queryServiceConfig))
         , SaveQueryPhysicalGraph(settings.SaveQueryPhysicalGraph)
         , DisableDefaultTimeout(settings.DisableDefaultTimeout)
+        , CheckpointId(settings.CheckpointId)
         , PhysicalGraph(std::move(settings.PhysicalGraph))
         , Counters(settings.Counters)
     {}
@@ -141,6 +142,7 @@ public:
             SelfId()
         );
         UserRequestContext->IsStreamingQuery = SaveQueryPhysicalGraph;
+        UserRequestContext->CheckpointId = CheckpointId;
 
         LOG_I("Bootstrap");
 
@@ -920,6 +922,7 @@ private:
     const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
     const bool SaveQueryPhysicalGraph = false;
     const bool DisableDefaultTimeout = false;
+    const TString CheckpointId;
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     std::optional<TActorId> PhysicalGraphSender;
     TIntrusivePtr<TKqpCounters> Counters;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -1,5 +1,6 @@
 #include "kqp_run_script_actor.h"
 
+#include <ydb/core/fq/libs/checkpointing/events/events.h>
 #include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/kqp.h>
 #include <ydb/core/kqp/common/kqp_script_executions.h>
@@ -158,6 +159,7 @@ private:
         hFunc(TEvSaveScriptExternalEffectRequest, Handle);
         hFunc(TEvSaveScriptPhysicalGraphRequest, Handle);
         hFunc(TEvSaveScriptPhysicalGraphResponse, Handle);
+        hFunc(NFq::TEvCheckpointCoordinator::TEvZeroCheckpointDone, Handle);
         hFunc(TEvKqp::TEvQueryResponse, Handle);
         hFunc(TEvKqp::TEvCreateSessionResponse, Handle);
         IgnoreFunc(TEvKqp::TEvCloseSessionResponse);
@@ -265,6 +267,7 @@ private:
             ast = std::nullopt;
         }
 
+        SavedRunningStatus = true;
         const auto& updaterId = Register(CreateScriptProgressActor(ExecutionId, Database, plan, LeaseGeneration, ast, QueryServiceConfig));
         LOG_T("Start TScriptProgressActor " << updaterId);
     }
@@ -608,17 +611,59 @@ private:
             return;
         }
 
+        if (PhysicalGraph) {
+            ev->Get()->PhysicalGraph.SetZeroCheckpointSaved(PhysicalGraph->GetZeroCheckpointSaved());
+        } else {
+            PhysicalGraph = ev->Get()->PhysicalGraph;
+        }
+
         PhysicalGraphSender = ev->Sender;
         const auto& saverId = Register(CreateSaveScriptExecutionPhysicalGraphActor(SelfId(), Database, ExecutionId, std::move(ev->Get()->PhysicalGraph), LeaseGeneration, QueryServiceConfig));
         LOG_D("Save script physical graph, saver id: " << saverId);
+        SaveScriptPhysicalGraphInflight++;
     }
 
     void Handle(TEvSaveScriptPhysicalGraphResponse::TPtr& ev) {
+        SaveScriptPhysicalGraphInflight--;
         LOG_D("Script physical graph saved " << ev->Sender << ", Status: " << ev->Get()->Status << ", Issues: " << ev->Get()->Issues.ToOneLineString());
 
-        Y_ABORT_UNLESS(PhysicalGraphSender);
-        Forward(ev, *PhysicalGraphSender);
-        UpdateScriptProgress("{}");
+        if (PhysicalGraphSender) {
+            Forward(ev, *PhysicalGraphSender);
+            PhysicalGraphSender = {};
+        } else if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
+            Issues.AddIssue("Internal error. Failed to update query physical graph");
+            if (IsExecuting()) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR);
+            }
+        }
+
+        if (!SavedRunningStatus) {
+            UpdateScriptProgress("{}");
+        }
+
+        CheckInflight();
+    }
+
+    void Handle(NFq::TEvCheckpointCoordinator::TEvZeroCheckpointDone::TPtr& ev) {
+        LOG_I("Zero checkpoint saved by " << ev->Sender);
+
+        if (RunState != ERunState::Running) {
+            LOG_N("Zero checkpoint saved after finalization");
+            return;
+        }
+
+        if (!PhysicalGraph) {
+            Issues.AddIssue("Internal error. Zero checkpoint saved before physical graph saved");
+            Finish(Ydb::StatusIds::INTERNAL_ERROR);
+            return;
+        }
+
+        if (!PhysicalGraph->GetZeroCheckpointSaved()) {
+            PhysicalGraph->SetZeroCheckpointSaved(true);
+            const auto& saverId = Register(CreateSaveScriptExecutionPhysicalGraphActor(SelfId(), Database, ExecutionId, *PhysicalGraph, LeaseGeneration, QueryServiceConfig));
+            LOG_D("Save script physical graph after zero checkpoint saved, saver id: " << saverId);
+            SaveScriptPhysicalGraphInflight++;
+        }
     }
 
     void Handle(TEvKqp::TEvQueryResponse::TPtr& ev) {
@@ -845,7 +890,7 @@ private:
     }
 
     void CheckInflight() {
-        if (SaveResultMetaInflight || SaveResultInflight) {
+        if (SaveResultMetaInflight || SaveResultInflight || SaveScriptPhysicalGraphInflight) {
             return;
         }
 
@@ -932,6 +977,7 @@ private:
     bool FinalStatusIsSaved = false;
     bool FinishAfterLeaseUpdate = false;
     bool WaitFinalizationRequest = false;
+    bool SavedRunningStatus = false;
     ERunState RunState = ERunState::Created;
     std::forward_list<TEvKqp::TEvCancelScriptExecutionRequest::TPtr> CancelRequests;
     ui64 CancelRequestsCount = 0;
@@ -945,6 +991,7 @@ private:
     std::vector<TResultSetInfo> ResultSetInfos;
     TMap<ui64, TProducerState> StreamChannels;
     std::optional<TInstant> ExpireAt;
+    ui32 SaveScriptPhysicalGraphInflight = 0;
     ui32 SaveResultInflight = 0;
     ui64 SaveResultInflightBytes = 0;
     ui32 SaveResultMetaInflight = 0;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
@@ -24,6 +24,7 @@ struct TKqpRunScriptActorSettings {
     bool SaveQueryPhysicalGraph = false;
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     bool DisableDefaultTimeout = false;
+    TString CheckpointId;
 };
 
 NActors::IActor* CreateRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig queryServiceConfig);

--- a/ydb/core/kqp/run_script_actor/ya.make
+++ b/ydb/core/kqp/run_script_actor/ya.make
@@ -7,6 +7,7 @@ SRCS(
 PEERDIR(
     library/cpp/protobuf/json
     ydb/core/base
+    ydb/core/fq/libs/checkpointing/events
     ydb/core/kqp/common/events
     ydb/core/kqp/executer_actor
     ydb/core/kqp/proxy_service/proto

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -250,7 +250,7 @@ public:
         ReadTopicMessages(topicName, {expectedMessage}, disposition, sort);
     }
 
-    void ReadTopicMessages(const TString& topicName, const TVector<TString>& expectedMessages, TInstant disposition = TInstant::Now() - TDuration::Seconds(100), bool sort = false) {
+    void ReadTopicMessages(const TString& topicName, TVector<TString> expectedMessages, TInstant disposition = TInstant::Now() - TDuration::Seconds(100), bool sort = false) {
         NTopic::TReadSessionSettings readSettings;
         readSettings
             .WithoutConsumer()
@@ -294,6 +294,7 @@ public:
         });
 
         if (sort) {
+            std::sort(expectedMessages.begin(), expectedMessages.end());
             std::sort(received.begin(), received.end());
         }
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -297,8 +297,8 @@ public:
         });
 
         if (sort) {
-            std::sort(expectedMessages.begin(), expectedMessages.end());
-            std::sort(received.begin(), received.end());
+            Sort(expectedMessages);
+            Sort(received);
         }
 
         UNIT_ASSERT_VALUES_EQUAL(received.size(), expectedMessages.size());

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -2567,7 +2567,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
                 .TableName = ydbTable,
                 .Columns = columns,
                 .DescribeCount = 2,
-                .ListSplitsCount = 5,
+                .ListSplitsCount = 4,
                 .ValidateListSplitsArgs = false
             });
 

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -973,6 +973,7 @@ message TQueryPhysicalGraph {
 
     optional TPreparedQuery PreparedQuery = 1;
     repeated TTask Tasks = 2;
+    optional bool ZeroCheckpointSaved = 3;
 }
 
 /// KQP workload manager Events

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -938,6 +938,7 @@ message TScriptExecutionOperationMeta {
     optional TRlPath RlPath = 11;
     optional bool SaveQueryPhysicalGraph = 12;
     optional bool DisableDefaultTimeout = 13;
+    optional string CheckpointId = 14;
 }
 
 // stored in column "retry_state" of .metadata/script_executions table
@@ -1005,6 +1006,7 @@ message TStreamingQueryState {
     optional EStatus Status = 1;
     optional string CurrentExecutionId = 2;
     repeated string PreviousExecutionIds = 3;
+    optional string CheckpointId = 11;
 
     // Inflight streaming query operation info
     optional string OperationName = 4;
@@ -1016,4 +1018,5 @@ message TStreamingQueryState {
     optional string QueryText = 8;
     optional bool Run = 9;
     optional string ResourcePool = 10;
+    optional uint64 QueryTextRevision = 12;
 }

--- a/ydb/core/public_http/ut/ya.make
+++ b/ydb/core/public_http/ut/ya.make
@@ -7,11 +7,13 @@ SRCS(
 )
 
 PEERDIR(
-    yql/essentials/public/udf/service/exception_policy
-    yql/essentials/sql/pg_dummy
     ydb/services/kesus
     ydb/services/persqueue_cluster_discovery
     yql/essentials/minikql/comp_nodes/llvm16
+    yql/essentials/public/udf/service/exception_policy
+    yql/essentials/sql/pg_dummy
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/testlib/basics/ya.make
+++ b/ydb/core/testlib/basics/ya.make
@@ -10,7 +10,6 @@ SRCS(
 PEERDIR(
     library/cpp/regex/pcre
     library/cpp/testing/unittest
-    ydb/library/actors/dnsresolver
     ydb/core/base
     ydb/core/blobstorage
     ydb/core/blobstorage/crypto
@@ -29,6 +28,7 @@ PEERDIR(
     ydb/core/tx/scheme_board
     ydb/core/tx/schemeshard
     ydb/core/util
+    ydb/library/actors/dnsresolver
     ydb/library/keys
     ydb/services/kesus
     ydb/services/persqueue_cluster_discovery

--- a/ydb/core/testlib/basics/ya.make
+++ b/ydb/core/testlib/basics/ya.make
@@ -8,9 +8,9 @@ SRCS(
 )
 
 PEERDIR(
-    ydb/library/actors/dnsresolver
     library/cpp/regex/pcre
     library/cpp/testing/unittest
+    ydb/library/actors/dnsresolver
     ydb/core/base
     ydb/core/blobstorage
     ydb/core/blobstorage/crypto
@@ -29,12 +29,14 @@ PEERDIR(
     ydb/core/tx/scheme_board
     ydb/core/tx/schemeshard
     ydb/core/util
-    yql/essentials/minikql/invoke_builtins/llvm16
-    yql/essentials/public/udf/service/exception_policy
     ydb/library/keys
     ydb/services/kesus
     ydb/services/persqueue_cluster_discovery
     ydb/services/ydb
+    yql/essentials/minikql/invoke_builtins/llvm16
+    yql/essentials/public/udf/service/exception_policy
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/tx/columnshard/splitter/ut/ya.make
+++ b/ydb/core/tx/columnshard/splitter/ut/ya.make
@@ -27,8 +27,8 @@ PEERDIR(
     yql/essentials/public/udf
     yql/essentials/public/udf/service/exception_policy
     yql/essentials/sql/pg
-    yt/yql/providers/yt/comp_nodes/llvm16
     yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 ADDINCL(

--- a/ydb/core/tx/columnshard/splitter/ut/ya.make
+++ b/ydb/core/tx/columnshard/splitter/ut/ya.make
@@ -4,30 +4,31 @@ SIZE(SMALL)
 
 PEERDIR(
     contrib/libs/apache/arrow
-    ydb/library/arrow_kernels
-
+    ydb/core/kqp/common
+    ydb/core/kqp/session_actor
+    ydb/core/mind
+    ydb/core/tx
     ydb/core/tx/columnshard/counters
     ydb/core/tx/columnshard/engines/portions
     ydb/core/tx/columnshard/common
     ydb/core/tx/columnshard/blobs_action
     ydb/core/tx/columnshard/data_sharing
-    ydb/core/kqp/common
-    yql/essentials/parser/pg_wrapper
-    yql/essentials/public/udf
-    ydb/core/kqp/session_actor
-    ydb/core/tx/tx_proxy
     ydb/core/tx/columnshard/engines/storage/chunks
     ydb/core/tx/columnshard/engines/storage/indexes/max
     ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch
     ydb/core/tx/columnshard/data_accessor
-    ydb/core/tx
-    ydb/core/mind
-    yql/essentials/minikql/comp_nodes/llvm16
-    yql/essentials/public/udf/service/exception_policy
-    yql/essentials/sql/pg
+    ydb/core/tx/tx_proxy
+    ydb/library/arrow_kernels
     ydb/services/kesus
     ydb/services/persqueue_cluster_discovery
     ydb/services/ydb
+    yql/essentials/minikql/comp_nodes/llvm16
+    yql/essentials/parser/pg_wrapper
+    yql/essentials/public/udf
+    yql/essentials/public/udf/service/exception_policy
+    yql/essentials/sql/pg
+    yt/yql/providers/yt/comp_nodes/llvm16
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
 )
 
 ADDINCL(

--- a/ydb/core/tx/schemeshard/ut_ru_calculator/ya.make
+++ b/ydb/core/tx/schemeshard/ut_ru_calculator/ya.make
@@ -3,14 +3,14 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 PEERDIR(
     library/cpp/testing/unittest
     ydb/core/tx/tx_proxy
-    yql/essentials/public/udf/service/stub
-    yql/essentials/sql/pg_dummy
     ydb/services/ydb
-
     ydb/services/kesus
     ydb/services/persqueue_cluster_discovery
     yql/essentials/minikql/comp_nodes/llvm16
-
+    yql/essentials/public/udf/service/stub
+    yql/essentials/sql/pg_dummy
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 SRCS(

--- a/ydb/core/wrappers/ut/ya.make
+++ b/ydb/core/wrappers/ut/ya.make
@@ -6,14 +6,16 @@ SPLIT_FACTOR(20)
 
 IF (NOT OS_WINDOWS)
     PEERDIR(
-        ydb/library/actors/core
         library/cpp/digest/md5
         library/cpp/testing/unittest
         ydb/core/protos
         ydb/core/testlib/basics/default
         ydb/core/util
         ydb/core/wrappers/ut_helpers
+        ydb/library/actors/core
         yql/essentials/minikql/comp_nodes/llvm16
+        yt/yql/providers/yt/comp_nodes/dq/llvm16
+        yt/yql/providers/yt/comp_nodes/llvm16
     )
     SRCS(
         s3_wrapper_ut.cpp

--- a/ydb/core/wrappers/ut/ya.make
+++ b/ydb/core/wrappers/ut/ya.make
@@ -6,16 +6,14 @@ SPLIT_FACTOR(20)
 
 IF (NOT OS_WINDOWS)
     PEERDIR(
+        ydb/library/actors/core
         library/cpp/digest/md5
         library/cpp/testing/unittest
         ydb/core/protos
         ydb/core/testlib/basics/default
         ydb/core/util
         ydb/core/wrappers/ut_helpers
-        ydb/library/actors/core
         yql/essentials/minikql/comp_nodes/llvm16
-        yt/yql/providers/yt/comp_nodes/dq/llvm16
-        yt/yql/providers/yt/comp_nodes/llvm16
     )
     SRCS(
         s3_wrapper_ut.cpp

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.cpp
@@ -587,6 +587,9 @@ NDqProto::ECheckpointingMode GetTaskCheckpointingMode(const TDqTaskSettings& tas
 
 bool IsIngress(const TDqTaskSettings& task) {
     // No inputs at all or there is no input channels with checkpoints.
+    // We don't want to inject checkpoint into tasks that has checkpointed input channels,
+    // otherwise task can be checkpointed twice;
+    // once checkpoint will arrive from channels, it will pause reading from sources too.
 
     const auto& inputs = task.GetInputs();
     if (inputs.empty()) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -1493,7 +1493,7 @@ protected:
         }
 
         // Don't produce any input from sources if we're about to save checkpoint.
-        if ((Checkpoints && Checkpoints->HasPendingCheckpoint() && !Checkpoints->ComputeActorStateSaved())) {
+        if (Checkpoints && Checkpoints->HasPendingCheckpoint() && !Checkpoints->ComputeActorStateSaved()) {
             CA_LOG_T("Skip polling sources because of pending checkpoint");
             return pollResult;
         }

--- a/ydb/library/yql/dq/tasks/dq_tasks_graph.h
+++ b/ydb/library/yql/dq/tasks/dq_tasks_graph.h
@@ -326,6 +326,9 @@ public:
 
     bool IsIngress(const TTaskType& task) const {
         // No inputs at all or there is no input channels with checkpoints.
+        // We don't want to inject checkpoint into tasks that has checkpointed input channels,
+        // otherwise task can be checkpointed twice;
+        // once checkpoint will arrive from channels, it will pause reading from sources too.
 
         if (!task.Inputs) {
             return true;

--- a/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h
+++ b/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h
@@ -895,12 +895,43 @@ namespace NYql::NConnector::NTest {
         }
 
         TReadSplitsStreamIteratorAsyncResult ReadSplits(const NApi::TReadSplitsRequest& request, TDuration = {}) override {
-            Cerr << "Call ReadSplits.\n"
-                 << request.Utf8DebugString() << Endl;
+            Cerr << "Call ReadSplits.\n" << request.Utf8DebugString() << Endl;
+            auto resultPromise = NThreading::NewPromise<TIteratorResult<IReadSplitsStreamIterator>>();
+
+            with_lock (Mutex_) {
+                if (ReadingLocked_) {
+                    Cerr << "Delay ReadSplits." << Endl;
+                    PendingReadSplits.push_back({request, resultPromise});
+                    return resultPromise.GetFuture();
+                }
+            }
+
+            ProcessReadSplits(request, resultPromise);
+            return resultPromise.GetFuture();
+        }
+
+        void LockReading() {
+            with_lock (Mutex_) {
+                ReadingLocked_ = true;
+            }
+        }
+
+        void UnlockReading() {
+            with_lock (Mutex_) {
+                ReadingLocked_ = false;
+                for (auto& pending : PendingReadSplits) {
+                    Cerr << "Process pending ReadSplits." << Endl;
+                    ProcessReadSplits(pending.Request, pending.ResultPromise);
+                }
+                PendingReadSplits.clear();
+            }
+        }
+
+    private:
+        void ProcessReadSplits(const NApi::TReadSplitsRequest& request, NThreading::TPromise<TIteratorResult<IReadSplitsStreamIterator>>& resultPromise) {
             auto result = ReadSplitsImpl(request);
-            Cerr << "ReadSplits result.\n"
-                 << StatusToDebugString(result.Status) << Endl;
-            return NThreading::MakeFuture(std::move(result));
+            Cerr << "ReadSplits result.\n" << StatusToDebugString(result.Status) << Endl;
+            resultPromise.SetValue(std::move(result));
         }
 
     protected:
@@ -918,5 +949,15 @@ namespace NYql::NConnector::NTest {
             }
             return std::move(s);
         }
+
+        template <typename TRequest, typename TResult>
+        struct TPendingResult {
+            TRequest Request;
+            NThreading::TPromise<TResult> ResultPromise;
+        };
+
+        std::vector<TPendingResult<NApi::TReadSplitsRequest, TIteratorResult<IReadSplitsStreamIterator>>> PendingReadSplits;
+        bool ReadingLocked_ = false;
+        TMutex Mutex_;
     };
 } // namespace NYql::NConnector::NTest

--- a/ydb/library/yql/providers/pq/task_meta/task_meta.h
+++ b/ydb/library/yql/providers/pq/task_meta/task_meta.h
@@ -1,9 +1,18 @@
 #pragma once
+
 #include <google/protobuf/any.pb.h>
 
 #include <util/generic/maybe.h>
 
-namespace NYql::NPq {
+namespace NYql {
+
+namespace NDqProto {
+
+class TDqTask;
+
+} // namespace NDqProto
+
+namespace NPq {
 
 // Partitioning parameters for topic
 struct TTopicPartitionsSet {
@@ -18,4 +27,8 @@ struct TTopicPartitionsSet {
 
 TMaybe<TTopicPartitionsSet> GetTopicPartitionsSet(const google::protobuf::Any& dqTaskMeta);
 
-} // namespace NYql::NPq
+std::vector<TTopicPartitionsSet> GetTopicPartitionsSets(const NDqProto::TDqTask& dqTask);
+
+} // namespace NPq
+
+} // namespace NYql

--- a/ydb/tools/query_replay/common_deps.inc
+++ b/ydb/tools/query_replay/common_deps.inc
@@ -7,11 +7,7 @@ SET(YDB_REPLAY_SRCS
 )
 
 SET(YDB_REPLAY_PEERDIRS
-    ydb/library/actors/core
-    ydb/library/actors/interconnect
     library/cpp/getopt
-    ydb/public/sdk/cpp/src/library/grpc/client
-    ydb/library/grpc/server
     library/cpp/regex/pcre
     ydb/core/actorlib_impl
     ydb/core/base
@@ -45,15 +41,16 @@ SET(YDB_REPLAY_PEERDIRS
     ydb/core/tx/mediator
     ydb/core/tx/time_cast
     ydb/core/tx/tx_proxy
-    yql/essentials/core/services/mounts
-    yql/essentials/minikql/comp_nodes/llvm16
-    yt/yql/providers/yt/codec/codegen
-    yt/yql/providers/yt/comp_nodes/llvm16
-    yql/essentials/public/udf/service/exception_policy
+    ydb/library/actors/core
+    ydb/library/actors/interconnect
+    ydb/library/grpc/server
+    ydb/library/yql/dq/comp_nodes/llvm16
+    ydb/library/yql/udfs/common/clickhouse/client
     ydb/public/api/protos
     ydb/public/lib/base
     ydb/public/lib/deprecated/kicli
     ydb/public/sdk/cpp/src/client/table
+    ydb/public/sdk/cpp/src/library/grpc/client
     ydb/services/cms
     ydb/services/datastreams
     ydb/services/discovery
@@ -62,8 +59,10 @@ SET(YDB_REPLAY_PEERDIRS
     ydb/services/persqueue_v1
     ydb/services/rate_limiter
     ydb/services/ydb
-    ydb/library/yql/dq/comp_nodes/llvm16
-    ydb/library/yql/udfs/common/clickhouse/client
+    yql/essentials/core/services/mounts
+    yql/essentials/minikql/comp_nodes/llvm16
+    yql/essentials/public/udf/service/exception_policy
+    yql/essentials/sql/pg_dummy
     yql/essentials/udfs/common/datetime2
     yql/essentials/udfs/common/digest
     yql/essentials/udfs/common/histogram
@@ -81,5 +80,7 @@ SET(YDB_REPLAY_PEERDIRS
     yql/essentials/udfs/common/topfreq
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/logs/dsv
-    yql/essentials/sql/pg_dummy
+    yt/yql/providers/yt/codec/codegen
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )

--- a/ydb/tools/query_replay_yt/common_deps.inc
+++ b/ydb/tools/query_replay_yt/common_deps.inc
@@ -6,11 +6,7 @@ SET(YDB_REPLAY_SRCS
 )
 
 SET(YDB_REPLAY_PEERDIRS
-    ydb/library/actors/core
-    ydb/library/actors/interconnect
     library/cpp/getopt
-    ydb/public/sdk/cpp/src/library/grpc/client
-    ydb/library/grpc/server
     library/cpp/regex/pcre
     ydb/core/actorlib_impl
     ydb/core/base
@@ -44,15 +40,17 @@ SET(YDB_REPLAY_PEERDIRS
     ydb/core/tx/mediator
     ydb/core/tx/time_cast
     ydb/core/tx/tx_proxy
-    yql/essentials/core/services/mounts
-    yql/essentials/minikql/comp_nodes/llvm16
-    yt/yql/providers/yt/codec/codegen
-    yt/yql/providers/yt/comp_nodes/llvm16
-    yql/essentials/public/udf/service/exception_policy
+    ydb/library/actors/core
+    ydb/library/actors/interconnect
+    ydb/library/grpc/server
+    ydb/library/yql/udfs/common/clickhouse/client
+    ydb/library/yql/udfs/common/knn
+    ydb/library/yql/udfs/common/roaring
     ydb/public/api/protos
     ydb/public/lib/base
     ydb/public/lib/deprecated/kicli
     ydb/public/sdk/cpp/src/client/table
+    ydb/public/sdk/cpp/src/library/grpc/client
     ydb/services/cms
     ydb/services/datastreams
     ydb/services/discovery
@@ -61,9 +59,11 @@ SET(YDB_REPLAY_PEERDIRS
     ydb/services/persqueue_v1
     ydb/services/rate_limiter
     ydb/services/ydb
-    ydb/library/yql/udfs/common/clickhouse/client
-    ydb/library/yql/udfs/common/knn
-    ydb/library/yql/udfs/common/roaring
+    yql/essentials/core/services/mounts
+    yql/essentials/minikql/comp_nodes/llvm16
+    yql/essentials/parser/pg_wrapper
+    yql/essentials/public/udf/service/exception_policy
+    yql/essentials/sql/pg
     yql/essentials/udfs/common/compress_base
     yql/essentials/udfs/common/datetime2
     yql/essentials/udfs/common/digest
@@ -87,6 +87,7 @@ SET(YDB_REPLAY_PEERDIRS
     yql/essentials/udfs/common/url_base
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/logs/dsv
-    yql/essentials/sql/pg
-    yql/essentials/parser/pg_wrapper
+    yt/yql/providers/yt/codec/codegen
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )

--- a/ydb/tools/stress_tool/ut/ya.make
+++ b/ydb/tools/stress_tool/ut/ya.make
@@ -16,6 +16,8 @@ PEERDIR(
     yql/essentials/parser/pg_wrapper
     yql/essentials/sql/pg
     yql/essentials/minikql/comp_nodes/llvm16
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 END()

--- a/ydb/tools/stress_tool/ya.make
+++ b/ydb/tools/stress_tool/ya.make
@@ -17,8 +17,8 @@ PEERDIR(
     yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/parser/pg_wrapper
     yql/essentials/sql/pg
-    yt/yql/providers/yt/comp_nodes/llvm16
     yt/yql/providers/yt/comp_nodes/dq/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
 )
 
 SRCS(

--- a/ydb/tools/stress_tool/ya.make
+++ b/ydb/tools/stress_tool/ya.make
@@ -12,11 +12,13 @@ PEERDIR(
     ydb/core/node_whiteboard
     ydb/core/tablet
     ydb/library/pdisk_io
-    yql/essentials/parser/pg_wrapper
-    yql/essentials/sql/pg
-    yql/essentials/minikql/comp_nodes/llvm16
     ydb/tools/stress_tool/lib
     ydb/tools/stress_tool/proto
+    yql/essentials/minikql/comp_nodes/llvm16
+    yql/essentials/parser/pg_wrapper
+    yql/essentials/sql/pg
+    yt/yql/providers/yt/comp_nodes/llvm16
+    yt/yql/providers/yt/comp_nodes/dq/llvm16
 )
 
 SRCS(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support passing checkpoint on streaming query manual restart (before it checkpoint always was lost when called `ALTER STREAMING QUERY`)

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Also fixed SLJ checkpoint waiting 
