### PR TITLE
SchemeShard: allow default column family altering for indexImplTable

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -43,6 +43,20 @@ bool CheckAllowedFields(const TMessage& message, THashSet<TString>&& allowedFiel
     return true;
 }
 
+bool CheckDefaultColumnFamilies(const NKikimrSchemeOp::TPartitionConfig& partitionConfig) {
+    // checks that partitionConfig contains only default column families
+    for (const auto& family : partitionConfig.GetColumnFamilies()) {
+        const bool isDefaultFamily = (
+            (!family.HasId() && !family.HasName()) ||
+            (family.HasId() && family.GetId() == 0) ||
+            (family.HasName() && family.GetName() == "default"));
+        if (!isDefaultFamily) {
+            return false;
+        }
+    }
+    return true;
+}
+
 TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table, const NKikimrSchemeOp::TTableDescription& alter,
                                       const bool shadowDataAllowed, const THashSet<TString>& localSequences,
                                       TString& errStr, NKikimrScheme::EStatus& status, TOperationContext& context) {
@@ -750,8 +764,9 @@ TVector<ISubOperation::TPtr> CreateConsistentAlterTable(TOperationId id, const T
     if (!(IsAdministrator(AppData(), context.UserToken.Get()) && !AppData()->AdministrationAllowedSIDs.empty())
         && (!CheckAllowedFields(alter, {"Name", "PathId", "PartitionConfig", "ReplicationConfig", "IncrementalBackupConfig"})
             || (alter.HasPartitionConfig()
-                && !CheckAllowedFields(alter.GetPartitionConfig(), {"PartitioningPolicy", "FollowerCount", "FollowerGroups"})
+                && !CheckAllowedFields(alter.GetPartitionConfig(), {"PartitioningPolicy", "FollowerCount", "FollowerGroups", "ColumnFamilies"})
             )
+            || !CheckDefaultColumnFamilies(alter.GetPartitionConfig())
         )
     ) {
         return {CreateAlterTable(id, tx)};


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This allows setting  family parameters for index tables, such as CACHE_MODE, along with already allowed partitioning parameters.
