### PR TITLE
Retry NotifyBridgeSyncFinished command when racing

### DIFF
--- a/ydb/core/blobstorage/bridge/syncer/syncer.cpp
+++ b/ydb/core/blobstorage/bridge/syncer/syncer.cpp
@@ -90,6 +90,7 @@ namespace NKikimr::NBridge {
     }
 
     void TSyncerActor::PassAway() {
+        STLOG(PRI_DEBUG, BS_BRIDGE_SYNC, BRSS15, "PassAway", (LogId, LogId));
         TActorBootstrapped::PassAway();
     }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
@@ -351,6 +351,13 @@ namespace NKikimr::NStorage {
 
         for (const TWorkingSyncer& syncer : toStop) {
             if (syncer.ActorId) {
+                STLOG(PRI_DEBUG, BS_NODE, NW65, "ApplyWorkingSyncers: stopping",
+                    (BridgeProxyGroupId, syncer.BridgeProxyGroupId),
+                    (BridgeProxyGroupGeneration, syncer.BridgeProxyGroupGeneration),
+                    (SourceGroupId, syncer.SourceGroupId),
+                    (TargetGroupId, syncer.TargetGroupId),
+                    (PendingBridgeProxyGroupGeneration, syncer.PendingBridgeProxyGroupGeneration),
+                    (ActorId, syncer.ActorId));
                 TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, syncer.ActorId, {}, nullptr, 0));
             }
             WorkingSyncers.erase(syncer);
@@ -358,14 +365,24 @@ namespace NKikimr::NStorage {
     }
 
     void TNodeWarden::StartSyncerIfNeeded(TWorkingSyncer& syncer) {
-        if (syncer.BridgeProxyGroupGeneration < syncer.PendingBridgeProxyGroupGeneration && syncer.ActorId) {
+        auto& group = Groups[syncer.BridgeProxyGroupId.GetRawId()];
+
+        const bool stopCurrent = syncer.BridgeProxyGroupGeneration < syncer.PendingBridgeProxyGroupGeneration
+            && syncer.ActorId;
+        const bool startNew = (stopCurrent || !syncer.ActorId)
+            && group.Info
+            && group.Info->GroupGeneration == syncer.PendingBridgeProxyGroupGeneration;
+
+        const ui32 prevBridgeProxyGroupGeneration = syncer.BridgeProxyGroupGeneration;
+        const TActorId prevActorId = syncer.ActorId;
+
+        if (stopCurrent) {
             // we've got already running syncer, but group generation gets changed, we need to restart it
             TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, syncer.ActorId, {}, nullptr, 0));
             syncer.ActorId = {};
             ++syncer.NumStop;
         }
-        auto& group = Groups[syncer.BridgeProxyGroupId.GetRawId()];
-        if (!syncer.ActorId && group.Info && group.Info->GroupGeneration == syncer.PendingBridgeProxyGroupGeneration) {
+        if (startNew) {
             syncer.BridgeProxyGroupGeneration = syncer.PendingBridgeProxyGroupGeneration;
             syncer.SyncerDataStats = std::make_unique<NBridge::TSyncerDataStats>();
 
@@ -381,6 +398,21 @@ namespace NKikimr::NStorage {
             syncer.Finished = false;
             syncer.ErrorReason.reset();
             ++syncer.NumStart;
+        }
+        if (stopCurrent || startNew) {
+            STLOG(PRI_DEBUG, BS_NODE, NW64, "StartSyncerIfNeeded",
+                (BridgeProxyGroupId, syncer.BridgeProxyGroupId),
+                (PrevBridgeProxyGroupGeneration, prevBridgeProxyGroupGeneration),
+                (BridgeProxyGroupGeneration, syncer.BridgeProxyGroupGeneration),
+                (SourceGroupId, syncer.SourceGroupId),
+                (TargetGroupId, syncer.TargetGroupId),
+                (PendingBridgeProxyGroupGeneration, syncer.PendingBridgeProxyGroupGeneration),
+                (PrevActorId, prevActorId),
+                (ActorId, syncer.ActorId),
+                (HasGroupInfo, static_cast<bool>(group.Info)),
+                (GroupInfoGeneration, group.Info ? std::make_optional(group.Info->GroupGeneration) : std::nullopt),
+                (StopCurrent, stopCurrent),
+                (StartNew, startNew));
         }
     }
 
@@ -412,11 +444,9 @@ namespace NKikimr::NStorage {
 
     bool TNodeWarden::FillInWorkingSyncer(NKikimrBlobStorage::TEvControllerUpdateSyncerState *update,
             TWorkingSyncer& syncer, bool forceProgress) {
-        auto res = false;
-
         auto *item = update->AddSyncers();
         syncer.BridgeProxyGroupId.CopyToProto(item, &std::decay_t<decltype(*item)>::SetBridgeProxyGroupId);
-        item->SetBridgeProxyGroupGeneration(syncer.BridgeProxyGroupGeneration);
+        item->SetBridgeProxyGroupGeneration(syncer.PendingBridgeProxyGroupGeneration);
         syncer.SourceGroupId.CopyToProto(item, &std::decay_t<decltype(*item)>::SetSourceGroupId);
         syncer.TargetGroupId.CopyToProto(item, &std::decay_t<decltype(*item)>::SetTargetGroupId);
         if (syncer.Finished) {
@@ -426,8 +456,13 @@ namespace NKikimr::NStorage {
             item->SetErrorReason(*syncer.ErrorReason);
         }
 
+        if (!syncer.SyncerDataStats) {
+            return false; // hasn't started yet (maybe waiting for correct group infos)
+        }
+
         // report syncer progress
         auto& stats = *syncer.SyncerDataStats;
+        auto res = false;
 
 #define ISSUE_METRIC(NAME) \
         const ui64 current##NAME = stats.NAME; \

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -699,9 +699,14 @@ void TNodeWarden::PersistConfig(std::optional<TString> mainYaml, ui64 mainYamlVe
         return;
     }
 
+    auto escape = [&](auto& value) { return value ? std::make_optional('"' + EscapeC(*value) + '"') : std::nullopt; };
+
     STLOG(PRI_DEBUG, BS_NODE, NW63, "persisting new configurations",
-        (MainYaml, mainYaml), (MainYamlVersion, mainYamlVersion), (StorageYaml, storageYaml),
-        (StorageYamlVersion, storageYamlVersion), (YamlConfig, YamlConfig));
+        (MainYaml, escape(mainYaml)),
+        (MainYamlVersion, mainYamlVersion),
+        (StorageYaml, escape(storageYaml)),
+        (StorageYamlVersion, storageYamlVersion),
+        (YamlConfig, YamlConfig));
 
     const bool updateMain = mainYaml && (!YamlConfig || !YamlConfig->HasMainConfigVersion() ||
         YamlConfig->GetMainConfigVersion() < mainYamlVersion);

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -299,7 +299,7 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
     const bool isFirstStorageConfig = !StorageConfig;
     Y_DEBUG_ABORT_UNLESS(!isFirstStorageConfig || CurrentStateFunc() == &TThis::StateInit);
 
-    StorageConfig = std::move(ev->Get()->Config);
+    auto prevStorageConfig = std::exchange(StorageConfig, std::move(ev->Get()->Config));
     auto prevBridgeInfo = std::exchange(BridgeInfo, std::move(ev->Get()->BridgeInfo));
     SelfManagementEnabled = ev->Get()->SelfManagementEnabled;
 
@@ -397,6 +397,13 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
 
     ApplyStaticGroupUpdateForSyncers(prevStaticGroups);
     UpdateWaitingGroups(groupsToCheck);
+
+    if (Loaded && BridgeInfo && (!prevStorageConfig || prevStorageConfig->GetClusterState().GetGeneration() <
+            StorageConfig->GetClusterState().GetGeneration())) {
+        // cluster state has changed -- we need to recheck groups
+        RecheckUnsyncedBridgePiles = true;
+        CheckUnsyncedBridgePiles();
+    }
 }
 
 void TBlobStorageController::Handle(TEvents::TEvUndelivered::TPtr ev) {
@@ -493,7 +500,6 @@ void TBlobStorageController::ApplyBscSettings(const NKikimrConfig::TBlobStorageC
 
 std::unique_ptr<TEvBlobStorage::TEvControllerConfigRequest> TBlobStorageController::BuildConfigRequestFromStorageConfig(
         const NKikimrBlobStorage::TStorageConfig& storageConfig, const THostRecordMap& hostRecords, bool validationMode) {
-
     if (Boxes.size() > 1 || !storageConfig.HasBlobStorageConfig()) {
         return nullptr;
     }
@@ -603,8 +609,6 @@ std::unique_ptr<TEvBlobStorage::TEvControllerConfigRequest> TBlobStorageControll
 }
 
 void TBlobStorageController::ApplyStorageConfig(bool ignoreDistconf) {
-    CheckUnsyncedBridgePiles();
-
     if (!StorageConfig->HasBlobStorageConfig()) {
         return;
     }
@@ -1006,6 +1010,9 @@ STFUNC(TBlobStorageController::StateWork) {
             }
         break;
     }
+
+    // start any pending bridge syncers
+    ProcessSyncers();
 
     if (const TDuration time = TDuration::Seconds(timer.Passed()); time >= TDuration::MilliSeconds(100)) {
         STLOG(PRI_ERROR, BS_CONTROLLER, BSC00, "StateWork event processing took too much time", (Type, type),

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -2030,6 +2030,11 @@ private:
     std::set<std::tuple<TNodeId, TSyncerState*>> NodeToSyncerState;
     TIntrusiveList<TSyncerState, TSyncersRequiringAction> SyncersRequiringAction;
 
+    bool CheckingUnsyncedBridgePiles = false;
+    bool NotifyBridgeSyncFinishedErrors = false;
+    bool RecheckUnsyncedBridgePiles = false;
+    ui32 NumPendingBridgeSyncFinishedResponses = 0;
+
     void CheckUnsyncedBridgePiles();
 
     void ApplySyncerState(TNodeId nodeId, const NKikimrBlobStorage::TEvControllerUpdateSyncerState& update,
@@ -2037,7 +2042,7 @@ private:
 
     void CheckSyncerDisconnectedNodes();
 
-    bool ProcessSyncers(TNodeId nodeId = 0);
+    void ProcessSyncers(THashSet<TNodeId> nodesToUpdate = {});
 
     void SerializeSyncers(TNodeId nodeId, NKikimrBlobStorage::TEvControllerNodeServiceSetUpdate *update,
         TSet<ui32>& groupIdsToRead);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Retry NotifyBridgeSyncFinished command when racing

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch makes BSC retry NotifyBridgeSyncFinished command when it is racing with newer configuration.
