### PR TITLE
Let the scan see stable state of portions during the whole scan in Column Shards

### DIFF
--- a/ydb/core/tx/columnshard/engines/portions/written.h
+++ b/ydb/core/tx/columnshard/engines/portions/written.h
@@ -36,10 +36,6 @@ private:
         return sb;
     }
 
-    virtual bool IsCommitted() const override {
-        return !!CommitSnapshot;
-    }
-
 public:
     virtual void FillDefaultColumn(NAssembling::TColumnAssemblingInfo& column, const std::optional<TSnapshot>& defaultSnapshot) const override;
 
@@ -73,6 +69,11 @@ public:
     bool HasCommitSnapshot() const {
         return !!CommitSnapshot;
     }
+
+    virtual bool IsCommitted() const override {
+        return !!CommitSnapshot;
+    }
+
     const TSnapshot& GetCommitSnapshotVerified() const {
         AFL_VERIFY(!!CommitSnapshot);
         return *CommitSnapshot;

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
@@ -157,6 +157,10 @@ public:
         return it->second.IsConflictable();
     }
 
+    bool MayWriteBeConflicting(const TInsertWriteId writeId) const {
+        return ConflictedWriteIds.contains(writeId);
+    }
+
     void AddWriteIdToCheck(const TInsertWriteId writeId, const ui64 lockId) {
         auto it = LockConflictCounters.find(lockId);
         if (it == LockConflictCounters.end()) {
@@ -164,8 +168,6 @@ public:
         }
         AFL_VERIFY(ConflictedWriteIds.emplace(writeId, TWriteIdInfo(lockId, it->second)).second);
     }
-
-    [[nodiscard]] bool IsMyUncommitted(const TInsertWriteId writeId) const;
 
     void SetConflictedWriteId(const TInsertWriteId writeId) const {
         auto it = ConflictedWriteIds.find(writeId);

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/context.cpp
@@ -108,17 +108,53 @@ TString TSpecialReadContext::DebugString() const {
     return sb;
 }
 
-EPortionCommitStatus TSpecialReadContext::GetPortionCommitStatus(const TPortionInfo& portionInfo) const {
-    if (portionInfo.IsCommitted()) {
-        return EPortionCommitStatus::Committed;
+/*
+Returns the portion state at the moment of the scan planning on the column shard.
+
+Scan reads portions in separate actors from the column shard, so the portions state may
+be changed during the scan. To avoid anomalies caused by the fact that scan may see different
+portion states, we need a way to get a stable portion state during the whole scan. Here it is.
+*/
+TPortionStateAtScanStart TSpecialReadContext::GetPortionStateAtScanStart(const TPortionInfo& portionInfo) const {
+    bool committed = false;
+    bool conflicting = false;
+    TSnapshot maxRecordSnapshot = TSnapshot::Zero();
+    if (portionInfo.GetPortionType() == EPortionType::Compacted) {
+        // compacted portions are stable and not conflicting,
+        // they have max snapshot less or equal to the request snapshot
+        committed = true;
+        conflicting = false;
+        maxRecordSnapshot = portionInfo.RecordSnapshotMax();
     } else {
         const auto& wPortionInfo = static_cast<const TWrittenPortionInfo&>(portionInfo);
-        if (GetReadMetadata()->IsMyUncommitted(wPortionInfo.GetInsertWriteId())) {
-            return EPortionCommitStatus::OwnUncommitted;
+        auto maybeConflicting = GetReadMetadata()->MayWriteBeConflicting(wPortionInfo.GetInsertWriteId());
+        if (maybeConflicting) {
+            // uncommitted portions by other txs
+            committed = false;
+            conflicting = true;
+        } else if (!wPortionInfo.IsCommitted()) {
+            // uncommitted portions by the current tx
+            committed = false;
+            conflicting = false;
+        } else if (wPortionInfo.RecordSnapshotMax() > GetReadMetadata()->GetRequestSnapshot()) {
+            // portions that were committed at the moment of the scan start
+            // but have snapshot greater than the request snapshot, so the current tx
+            // does not see them and may conflict with them
+            committed = true;
+            conflicting = true;
+            maxRecordSnapshot = wPortionInfo.RecordSnapshotMax();
         } else {
-            return EPortionCommitStatus::UncommittedByAnotherTx;
+            // committed, not yet compacted portions, visible to the current tx
+            committed = true;
+            conflicting = false;
+            maxRecordSnapshot = wPortionInfo.RecordSnapshotMax();
         }
     }
+    return TPortionStateAtScanStart {
+        .Committed = committed,
+        .Conflicting = conflicting,
+        .MaxRecordSnapshot = maxRecordSnapshot
+    };
 }
 
 }   // namespace NKikimr::NOlap::NReader::NCommon

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/context.cpp
@@ -122,6 +122,7 @@ TPortionStateAtScanStart TSpecialReadContext::GetPortionStateAtScanStart(const T
     if (portionInfo.GetPortionType() == EPortionType::Compacted) {
         // compacted portions are stable and not conflicting,
         // they have max snapshot less or equal to the request snapshot
+        AFL_VERIFY(portionInfo.RecordSnapshotMax() <= GetReadMetadata()->GetRequestSnapshot())("portion_info", portionInfo.DebugString())("request_snapshot", GetReadMetadata()->GetRequestSnapshot().DebugString());
         committed = true;
         conflicting = false;
         maxRecordSnapshot = portionInfo.RecordSnapshotMax();

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.cpp
@@ -147,9 +147,10 @@ void TPortionDataSource::DoAssembleColumns(const std::shared_ptr<TColumnsSet>& c
     std::optional<TSnapshot> ss;
     if (Portion->GetPortionType() == EPortionType::Written) {
         const auto* portion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        if (portion->HasCommitSnapshot()) {
-            ss = portion->GetCommitSnapshotVerified();
-        } else if (GetContext()->GetReadMetadata()->IsMyUncommitted(portion->GetInsertWriteId())) {
+        auto state = GetContext()->GetPortionStateAtScanStart(*portion);
+        if (state.Committed) {
+            ss = state.MaxRecordSnapshot;
+        } else if (state.IsMyUncommitted()) {
             ss = GetContext()->GetReadMetadata()->GetRequestSnapshot();
         }
     }
@@ -174,15 +175,14 @@ bool TPortionDataSource::DoStartFetchingAccessor(const std::shared_ptr<NCommon::
 }
 
 bool TPortionDataSource::DoAddTxConflict() {
-    if (Portion->IsCommitted()) {
+    auto state = GetContext()->GetPortionStateAtScanStart(this->GetPortionInfo());
+    if (state.Committed) {
         GetContext()->GetReadMetadata()->SetBrokenWithCommitted();
         return true;
-    } else {
+    } else if (!state.IsMyUncommitted()) {
         const auto* wPortion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        if (!GetContext()->GetReadMetadata()->IsMyUncommitted(wPortion->GetInsertWriteId())) {
-            GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
-            return true;
-        }
+        GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
+        return true;
     }
     return false;
 }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.h
@@ -15,7 +15,7 @@ namespace NKikimr::NOlap::NReader::NSimple {
 class TSourceConstructor: public ICursorEntity, public TMoveOnly {
 private:
     TCompareKeyForScanSequence Start;
-    YDB_READONLY(ui32, SourceId, 0);
+    YDB_READONLY(ui64, SourceId, 0);
     YDB_READONLY_DEF(std::shared_ptr<TPortionInfo>, Portion);
     ui32 RecordsCount = 0;
     bool IsStartedByCursorFlag = false;
@@ -44,8 +44,10 @@ public:
         return Start;
     }
 
-    TSourceConstructor(const std::shared_ptr<TPortionInfo>&& portion, const NReader::ERequestSorting sorting)
-        : Start(TReplaceKeyAdapter((sorting == NReader::ERequestSorting::DESC) ? portion->IndexKeyEnd() : portion->IndexKeyStart(),
+    TSourceConstructor(
+        const std::shared_ptr<TPortionInfo>&& portion, 
+        const NReader::ERequestSorting sorting
+    ) : Start(TReplaceKeyAdapter((sorting == NReader::ERequestSorting::DESC) ? portion->IndexKeyEnd() : portion->IndexKeyStart(),
                     sorting == NReader::ERequestSorting::DESC),
               portion->GetPortionId())
         , SourceId(portion->GetPortionId())

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
@@ -30,14 +30,17 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
 
     const auto* source = sourceExt->GetAs<IDataSource>();
 
-    NCommon::EPortionCommitStatus portionCommitStatus = NCommon::EPortionCommitStatus::Unknown;
+    NCommon::TPortionStateAtScanStart portionState = NCommon::TPortionStateAtScanStart{
+        .Committed = true,
+        .Conflicting = false,
+        .MaxRecordSnapshot = source->GetRecordSnapshotMax()
+    };
     if (source->GetType() == NCommon::IDataSource::EType::SimplePortion) {
         const auto* portion = static_cast<const TPortionDataSource*>(source);
-        portionCommitStatus = GetPortionCommitStatus(portion->GetPortionInfo());
+        portionState = GetPortionStateAtScanStart(portion->GetPortionInfo());
     }
 
-    // snapshot filters will filter the uncommitted changes by other txs and mark conflicts
-    const bool needSnapshots = GetReadMetadata()->GetRequestSnapshot() < source->GetRecordSnapshotMax() || portionCommitStatus == NCommon::EPortionCommitStatus::UncommittedByAnotherTx;
+    const bool needSnapshots = GetReadMetadata()->GetRequestSnapshot() < portionState.MaxRecordSnapshot || portionState.Conflicting;
 
     const bool useIndexes = false;
     const bool hasDeletions = source->GetHasDeletions();
@@ -49,8 +52,7 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
         }
     }
 
-    // we exclude uncommitted changes by other txs from the duplicate filter because those changes are not visible for the given tx
-    const bool preventDuplicates = NeedDuplicateFiltering() && portionCommitStatus != NCommon::EPortionCommitStatus::UncommittedByAnotherTx;
+    const bool preventDuplicates = NeedDuplicateFiltering() && !portionState.Conflicting;
     {
         auto& result = CacheFetchingScripts[needSnapshots ? 1 : 0][partialUsageByPK ? 1 : 0][useIndexes ? 1 : 0][needShardingFilter ? 1 : 0]
                                            [hasDeletions ? 1 : 0][preventDuplicates ? 1 : 0];
@@ -124,11 +126,12 @@ void TSpecialReadContext::RegisterActors(const NCommon::ISourcesConstructor& sou
     if (NeedDuplicateFiltering()) {
         const auto* casted_sources = dynamic_cast<const NCommon::TSourcesConstructorWithAccessors<TSourceConstructor>*>(&sources);
         AFL_VERIFY(casted_sources);
-        // we do not pass uncommitted portions of concurrent txs to the duplicate filter because they are invisible for the given tx
+        // we do not pass conflicting portions of concurrent txs to the duplicate filter because they are invisible for the given tx
         std::deque<std::shared_ptr<TPortionInfo>> portionsToDuplicateFilter;
         for (auto&& constructor : casted_sources->GetConstructors()) {
             const auto info = constructor.GetPortion();
-            if (GetPortionCommitStatus(*info) != NCommon::EPortionCommitStatus::UncommittedByAnotherTx) {
+            auto state = GetPortionStateAtScanStart(*info);
+            if (!state.Conflicting) {
                 portionsToDuplicateFilter.emplace_back(std::move(info));
             }
         }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.cpp
@@ -369,9 +369,10 @@ void TPortionDataSource::DoAssembleColumns(const std::shared_ptr<TColumnsSet>& c
     std::optional<TSnapshot> ss;
     if (Portion->GetPortionType() == EPortionType::Written) {
         const auto* portion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        if (portion->HasCommitSnapshot()) {
-            ss = portion->GetCommitSnapshotVerified();
-        } else if (GetContext()->GetReadMetadata()->IsMyUncommitted(portion->GetInsertWriteId())) {
+        auto state = GetContext()->GetPortionStateAtScanStart(*portion);
+        if (state.Committed) {
+            ss = state.MaxRecordSnapshot;
+        } else if (state.IsMyUncommitted()) {
             ss = GetContext()->GetReadMetadata()->GetRequestSnapshot();
         }
     }
@@ -462,15 +463,14 @@ TConclusion<bool> TPortionDataSource::DoStartReserveMemory(const NArrow::NSSA::T
 }
 
 bool TPortionDataSource::DoAddTxConflict() {
-    if (Portion->IsCommitted()) {
+    auto state = GetContext()->GetPortionStateAtScanStart(this->GetPortionInfo());
+    if (state.Committed) {
         GetContext()->GetReadMetadata()->SetBrokenWithCommitted();
         return true;
-    } else {
+    } else if (!state.IsMyUncommitted()) {
         const auto* wPortion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        if (!GetContext()->GetReadMetadata()->IsMyUncommitted(wPortion->GetInsertWriteId())) {
-            GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
-            return true;
-        }
+        GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
fixes #26726

Here we reuse the existing way of understanding if a portion is conflicting with the current tx, and build the stable meaningful state that the scan logic uses.

Also noticed that TSourceConstructor.SourceId field is ui32, but we pass there ui64 value (portionId). So I fixed that as well.