### PR TITLE
VIEW: ignore case when searching for TablePathPrefix on restoration

### DIFF
--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -74,11 +74,11 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
         return true;
     }
 
+    restorePathPrefix = RewriteAbsolutePath(backupPathPrefix, backupRoot, restoreRoot);
+
     if (backupRoot == restoreRoot) {
         return true;
     }
-
-    restorePathPrefix = RewriteAbsolutePath(backupPathPrefix, backupRoot, restoreRoot);
 
     if (!re2::RE2::Replace(&query, pattern,
         std::format(R"(PRAGMA TablePathPrefix = '{}';)", restorePathPrefix.c_str())

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -51,7 +51,11 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
 ) {
     restorePathPrefix = restoreRoot;
 
-    if (!re2::RE2::PartialMatch(query, R"(PRAGMA TablePathPrefix = '(\S+)';)", &backupPathPrefix)) {
+    re2::RE2::Options options;
+    options.set_case_sensitive(false);
+    re2::RE2 pattern(R"(PRAGMA TablePathPrefix = '(\S+)';)", options);
+
+    if (!re2::RE2::PartialMatch(query, pattern, &backupPathPrefix)) {
         if (!restoreRootIsDatabase) {
             // Initially, the view relied on the implicit table path prefix;
             // however, this approach is now incorrect because the requested restore root differs from the database root.
@@ -76,12 +80,11 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
 
     restorePathPrefix = RewriteAbsolutePath(backupPathPrefix, backupRoot, restoreRoot);
 
-    constexpr TStringBuf pattern = R"(PRAGMA TablePathPrefix = '\S+';)";
     if (!re2::RE2::Replace(&query, pattern,
         std::format(R"(PRAGMA TablePathPrefix = '{}';)", restorePathPrefix.c_str())
     )) {
         issues.AddIssue(TStringBuilder() << "query: " << query.Quote()
-            << " does not contain the pattern: \"" << pattern << "\""
+            << " does not contain the pattern: \"" << pattern.pattern() << "\""
         );
         return false;
     }

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -204,11 +204,12 @@ TDataQueryResult GetTableContent(TSession& session, const char* table,
 }
 
 NQuery::TExecuteQueryResult GetTableContent(NQuery::TSession& session, const char* table,
-    const char* keyColumn = "Key"
+    const char* keyColumn = "Key", const TMaybe<TString>& pathPrefix = Nothing()
 ) {
     return ExecuteQuery(session, Sprintf(R"(
+            %s
             SELECT * FROM `%s` ORDER BY %s;
-        )", table, keyColumn
+        )", pathPrefix.GetOrElse("").c_str(), table, keyColumn
     ));
 }
 
@@ -898,18 +899,20 @@ void TestViewDependentOnAnotherViewIsRestored(
 
 void TestViewRelativeReferencesArePreserved(
     const char* view, const char* table, const char* restoredView, NQuery::TSession& session,
-    TBackupFunction&& backup, TRestoreFunction&& restore
+    TBackupFunction&& backup, TRestoreFunction&& restore, const TMaybe<TString>& pathPrefix = Nothing()
 ) {
     ExecuteQuery(session, Sprintf(R"(
+                %s
                 CREATE TABLE `%s` (
                     Key Uint32,
                     Value Utf8,
                     PRIMARY KEY (Key)
                 );
-            )", table
+            )", pathPrefix.GetOrElse("").c_str(), table
         ), true
     );
     ExecuteQuery(session, Sprintf(R"(
+            %s
             UPSERT INTO `%s` (
                 Key,
                 Value
@@ -918,8 +921,7 @@ void TestViewRelativeReferencesArePreserved(
                 (1, "one"),
                 (2, "two"),
                 (3, "three");
-        )",
-        table
+        )", pathPrefix.GetOrElse("").c_str(), table
     ));
 
     const TString viewQuery = Sprintf(R"(
@@ -927,22 +929,25 @@ void TestViewRelativeReferencesArePreserved(
         )", table
     );
     ExecuteQuery(session, Sprintf(R"(
+                %s
                 CREATE VIEW `%s` WITH security_invoker = TRUE AS %s;
-            )", view, viewQuery.c_str()
+            )", pathPrefix.GetOrElse("").c_str(), view, viewQuery.c_str()
         ), true
     );
-    const auto originalContent = GetTableContent(session, view);
+    const auto originalContent = GetTableContent(session, view, "Key", pathPrefix);
 
     backup();
 
     ExecuteQuery(session, Sprintf(R"(
+                %s
                 DROP VIEW `%s`;
-            )", view
+            )", pathPrefix.GetOrElse("").c_str(), view
         ), true
     );
     ExecuteQuery(session, Sprintf(R"(
+                %s
                 DROP TABLE `%s`;
-            )", table
+            )", pathPrefix.GetOrElse("").c_str(), table
         ), true
     );
 
@@ -2050,6 +2055,52 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
             session,
             CreateBackupLambda(driver, pathToBackup, "/Root/a/b/c"),
             CreateRestoreLambda(driver, pathToBackup, "/Root/restore/point")
+        );
+    }
+
+    Y_UNIT_TEST(RestoreViewTablePathPrefix) {
+        TKikimrWithGrpcAndRootSchema server;
+        auto driver = TDriver(TDriverConfig().SetEndpoint(Sprintf("localhost:%u", server.GetPort())).SetDatabase("/Root"));
+        NQuery::TQueryClient queryClient(driver);
+        auto session = CreateSession(queryClient);
+        TTempDir tempDir;
+        const auto& pathToBackup = tempDir.Path();
+
+        constexpr const char* view = "view";
+        constexpr const char* table = "table";
+        constexpr const char* restoredView = "restore/point/a/b/c/view";
+
+        TestViewRelativeReferencesArePreserved(
+            view,
+            table,
+            restoredView,
+            session,
+            CreateBackupLambda(driver, pathToBackup),
+            CreateRestoreLambda(driver, pathToBackup, "/Root/restore/point"),
+            "PRAGMA TablePathPrefix = '/Root/a/b/c';\n"
+        );
+    }
+
+    Y_UNIT_TEST(RestoreViewTablePathPrefixLowercase) {
+        TKikimrWithGrpcAndRootSchema server;
+        auto driver = TDriver(TDriverConfig().SetEndpoint(Sprintf("localhost:%u", server.GetPort())).SetDatabase("/Root"));
+        NQuery::TQueryClient queryClient(driver);
+        auto session = CreateSession(queryClient);
+        TTempDir tempDir;
+        const auto& pathToBackup = tempDir.Path();
+
+        constexpr const char* view = "view";
+        constexpr const char* table = "table";
+        constexpr const char* restoredView = "restore/point/a/b/c/view";
+
+        TestViewRelativeReferencesArePreserved(
+            view,
+            table,
+            restoredView,
+            session,
+            CreateBackupLambda(driver, pathToBackup),
+            CreateRestoreLambda(driver, pathToBackup, "/Root/restore/point"),
+            "pragma tablepathprefix = '/Root/a/b/c';\n" // note the lowercase
         );
     }
 
@@ -3193,6 +3244,39 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
         );
     }
 
+    Y_UNIT_TEST(RestoreViewTablePathPrefix) {
+        TS3TestEnv testEnv;
+        constexpr const char* view = "view";
+        constexpr const char* table = "table";
+        constexpr const char* restoredView = "a/b/c/view";
+
+        TestViewRelativeReferencesArePreserved(
+            view,
+            table,
+            restoredView,
+            testEnv.GetQuerySession(),
+            CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
+            CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "a/b/c/view", "a/b/c/table" }),
+            "PRAGMA TablePathPrefix = '/Root/a/b/c';\n"
+        );
+    }
+
+    Y_UNIT_TEST(RestoreViewTablePathPrefixLowercase) {
+        TS3TestEnv testEnv;
+        constexpr const char* view = "view";
+        constexpr const char* table = "table";
+        constexpr const char* restoredView = "a/b/c/view";
+
+        TestViewRelativeReferencesArePreserved(
+            view,
+            table,
+            restoredView,
+            testEnv.GetQuerySession(),
+            CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
+            CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "a/b/c/view", "a/b/c/table" }),
+            "pragma tablepathprefix = '/Root/a/b/c';\n" // note the lowercase
+        );
+    }
 
     // TO DO: test view restoration to a different database
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Bugfix: correctly handle TablePathPrefix on view restoration even if written in lowercase.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Issues:
- https://github.com/ydb-platform/ydb/issues/26568
