### PR TITLE
allow evicting CS indexes with portions

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -457,6 +457,7 @@ message TOlapIndexRequested {
     optional string Name = 1;
     optional TCompressionOptions Compression = 3;
     optional string StorageId = 4;
+    optional bool InheritPortionStorage = 5;
 
     optional string ClassName = 39;
     oneof Implementation {
@@ -502,6 +503,7 @@ message TOlapIndexDescription {
     optional TCompressionOptions Compression = 3;
 
     optional string StorageId = 4;
+    optional bool InheritPortionStorage = 5;
 
     optional string ClassName = 40;
     oneof Implementation {

--- a/ydb/core/tx/columnshard/columnshard__statistics.cpp
+++ b/ydb/core/tx/columnshard/columnshard__statistics.cpp
@@ -205,7 +205,7 @@ public:
                     }
                     AFL_VERIFY(indexMeta->GetColumnIds().size() == 1);
                     indexIdToColumnId.emplace(indexMeta->GetIndexId(), columnId);
-                    if (!indexMeta->IsInplaceData()) {
+                    if (!indexMeta->IsInplaceData(portionInfo->GetPortionInfo().GetTierNameDef(NOlap::NBlobOperations::TGlobal::DefaultStorageId))) {
                         portionInfo->FillBlobRangesByStorage(rangesByColumn, portionSchema->GetIndexInfo(), { indexMeta->GetIndexId() });
                     } else {
                         const std::vector<TString> data = portionInfo->GetIndexInplaceDataOptional(indexMeta->GetIndexId());

--- a/ydb/core/tx/columnshard/columnshard_schema.h
+++ b/ydb/core/tx/columnshard/columnshard_schema.h
@@ -1126,7 +1126,8 @@ public:
     TIndexChunkLoadContext(const TSource& rowset, const IBlobGroupSelector* dsGroupSelector)
         : PathId(TInternalPathId::FromRawValue(rowset.template GetValue<NColumnShard::Schema::IndexIndexes::PathId>()))
         , PortionId(rowset.template GetValue<NColumnShard::Schema::IndexIndexes::PortionId>())
-        , Address(rowset.template GetValue<NColumnShard::Schema::IndexIndexes::IndexId>(), rowset.template GetValue<NColumnShard::Schema::IndexIndexes::ChunkIdx>())
+        , Address(rowset.template GetValue<NColumnShard::Schema::IndexIndexes::IndexId>(),
+              rowset.template GetValue<NColumnShard::Schema::IndexIndexes::ChunkIdx>())
         , RecordsCount(rowset.template GetValue<NColumnShard::Schema::IndexIndexes::RecordsCount>())
         , RawBytes(rowset.template GetValue<NColumnShard::Schema::IndexIndexes::RawBytes>())
     {

--- a/ydb/core/tx/columnshard/common/path_id.cpp
+++ b/ydb/core/tx/columnshard/common/path_id.cpp
@@ -234,7 +234,7 @@ NColumnShard::TUnifiedPathId IPathIdTranslator::GetUnifiedByInternalVerified(con
 
 NColumnShard::TSchemeShardLocalPathId IPathIdTranslator::ResolveSchemeShardLocalPathIdVerified(const TInternalPathId internalPathId) const {
     auto result = ResolveSchemeShardLocalPathId(internalPathId);
-    AFL_VERIFY(result);
+    AFL_VERIFY(result)("path_id", internalPathId.DebugString());
     return *result;
 }
 

--- a/ydb/core/tx/columnshard/data_accessor/abstract/constructor.h
+++ b/ydb/core/tx/columnshard/data_accessor/abstract/constructor.h
@@ -1,7 +1,17 @@
 #pragma once
-#include "manager.h"
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+
+#include <ydb/library/accessor/accessor.h>
+#include <ydb/library/conclusion/result.h>
+#include <ydb/services/bg_tasks/abstract/interface.h>
+
+#include <library/cpp/json/writer/json_value.h>
+#include <library/cpp/object_factory/object_factory.h>
+
+namespace NKikimr::NOlap::NDataAccessorControl {
+class IMetadataMemoryManager;
+}
 
 namespace NKikimr::NOlap::NDataAccessorControl {
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction/dictionary/logic.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/dictionary/logic.cpp
@@ -1,5 +1,6 @@
 #include "logic.h"
 
+#include <ydb/core/formats/arrow/accessor/composite/accessor.h>
 #include <ydb/core/formats/arrow/accessor/dictionary/constructor.h>
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
 #include <ydb/core/formats/arrow/arrow_filter.h>

--- a/ydb/core/tx/columnshard/engines/changes/compaction/merger.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/merger.cpp
@@ -336,10 +336,10 @@ std::vector<TWritePortionInfoWithBlobsResult> TMerger::Execute(const std::shared
         ui32 recordIdx = 0;
         for (auto&& i : packs) {
             TGeneralSerializedSlice slicePrimary(std::move(i));
-            auto dataWithSecondary =
-                resultFiltered->GetIndexInfo()
-                    .AppendIndexes(slicePrimary.GetPortionChunksToHash(), SaverContext.GetStoragesManager(), slicePrimary.GetRecordsCount())
-                    .DetachResult();
+            auto dataWithSecondary = resultFiltered->GetIndexInfo()
+                                         .AppendIndexes(slicePrimary.GetPortionChunksToHash(), SaverContext.GetStoragesManager(),
+                                             slicePrimary.GetRecordsCount(), IStoragesManager::DefaultStorageId)
+                                         .DetachResult();
             TGeneralSerializedSlice slice(dataWithSecondary.GetExternalData(), schemaDetails, Context.Counters.SplitterCounters);
 
             auto b = batchResult->Slice(recordIdx, slice.GetRecordsCount());

--- a/ydb/core/tx/columnshard/engines/changes/ttl.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/ttl.cpp
@@ -58,6 +58,9 @@ NKikimr::TConclusionStatus TTTLColumnEngineChanges::DoConstructBlobs(TConstructi
     for (auto&& info : PortionsToEvict) {
         if (auto pwb = UpdateEvictedPortion(info, Blobs, context)) {
             AddPortionToRemove(info.GetPortionInfo(), false);
+            for (const auto& x : pwb->MutableBlobs()) {
+                AFL_VERIFY(x.GetOperator()->GetStorageId() != IStoragesManager::LocalMetadataStorageId);
+            }
             AppendedPortions.emplace_back(std::move(*pwb));
         }
     }

--- a/ydb/core/tx/columnshard/engines/column_engine.h
+++ b/ydb/core/tx/columnshard/engines/column_engine.h
@@ -7,9 +7,11 @@
 #include "scheme/snapshot_scheme.h"
 #include "scheme/versions/versioned_index.h"
 
-#include <ydb/core/tx/columnshard/common/reverse_accessor.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
+#include <ydb/core/tx/columnshard/common/reverse_accessor.h>
 #include <ydb/core/tx/columnshard/counters/common_data.h>
+#include <ydb/core/tx/columnshard/data_accessor/request.h>
+#include <ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h>
 #include <ydb/core/tx/columnshard/resource_subscriber/container.h>
 #include <ydb/core/tx/columnshard/tx_reader/abstract.h>
 

--- a/ydb/core/tx/columnshard/engines/db_wrapper.h
+++ b/ydb/core/tx/columnshard/engines/db_wrapper.h
@@ -6,6 +6,7 @@
 #include <ydb/core/tx/columnshard/common/blob.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
 #include <ydb/core/tx/columnshard/common/snapshot.h>
+#include <ydb/core/tx/columnshard/engines/protos/portion_info.pb.h>
 
 namespace NKikimrTxColumnShard {
 class TIndexPortionMeta;

--- a/ydb/core/tx/columnshard/engines/portions/compacted.cpp
+++ b/ydb/core/tx/columnshard/engines/portions/compacted.cpp
@@ -51,7 +51,7 @@ const TString& TCompactedPortionInfo::GetEntityStorageId(const ui32 columnId, co
 }
 
 const TString& TCompactedPortionInfo::GetIndexStorageId(const ui32 indexId, const TIndexInfo& indexInfo) const {
-    return indexInfo.GetIndexStorageId(indexId);
+    return indexInfo.GetIndexStorageId(indexId, GetMeta().GetTierName());
 }
 
 }   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/engines/portions/data_accessor.cpp
+++ b/ydb/core/tx/columnshard/engines/portions/data_accessor.cpp
@@ -197,7 +197,7 @@ THashMap<TString, THashMap<TChunkAddress, std::shared_ptr<IPortionDataChunk>>> T
         AFL_VERIFY(result[storageId].emplace(c.GetAddress(), chunk).second);
     }
     for (auto&& c : GetIndexesVerified()) {
-        const TString& storageId = indexInfo.GetIndexStorageId(c.GetIndexId());
+        const TString& storageId = PortionInfo->GetIndexStorageId(c.GetIndexId(), indexInfo);
         const TString blobData = [&]() -> TString {
             if (auto bRange = c.GetBlobRangeOptional()) {
                 return blobs.ExtractVerified(storageId, RestoreBlobRange(*bRange));
@@ -241,7 +241,7 @@ THashMap<TChunkAddress, TString> TPortionDataAccessor::DecodeBlobAddressesImpl(
             continue;
         }
         std::optional<TString> blob =
-            blobs.ExtractOptional(indexInfo.GetIndexStorageId(record.GetIndexId()), RestoreBlobRange(record.GetBlobRangeVerified()));
+            blobs.ExtractOptional(PortionInfo->GetEntityStorageId(record.GetIndexId(), indexInfo), RestoreBlobRange(record.GetBlobRangeVerified()));
         if (blob) {
             result.emplace(record.GetAddress(), std::move(*blob));
         }

--- a/ydb/core/tx/columnshard/engines/portions/portion_info.h
+++ b/ydb/core/tx/columnshard/engines/portions/portion_info.h
@@ -63,7 +63,6 @@ public:
 
 class TPortionInfoConstructor;
 class TGranuleShardingInfo;
-class TPortionDataAccessor;
 class TCompactedPortionInfo;
 class TWrittenPortionInfo;
 

--- a/ydb/core/tx/columnshard/engines/portions/read_with_blobs.cpp
+++ b/ydb/core/tx/columnshard/engines/portions/read_with_blobs.cpp
@@ -123,10 +123,13 @@ std::optional<TWritePortionInfoWithBlobsResult> TReadPortionInfoWithBlobs::SyncP
     TIndexInfo::TSecondaryData secondaryData;
     secondaryData.MutableExternalData() = entityChunksNew;
     for (auto&& i : to->GetIndexInfo().GetIndexes()) {
-        to->GetIndexInfo().AppendIndex(entityChunksNew, i.first, storages, source.PortionInfo.GetPortionInfo().GetRecordsCount(), secondaryData).Validate();
+        to->GetIndexInfo()
+            .AppendIndex(entityChunksNew, i.first, storages, source.PortionInfo.GetPortionInfo().GetRecordsCount(), targetTier, secondaryData)
+            .Validate();
     }
 
-    const NSplitter::TEntityGroups groups = source.PortionInfo.GetPortionInfo().GetEntityGroupsByStorageId(targetTier, *storages, to->GetIndexInfo());
+    const NSplitter::TEntityGroups groups =
+        source.PortionInfo.GetPortionInfo().GetEntityGroupsByStorageId(targetTier, *storages, to->GetIndexInfo());
     auto schemaTo = std::make_shared<TDefaultSchemaDetails>(to, std::make_shared<NArrow::NSplitter::TSerializationStats>());
     TGeneralSerializedSlice slice(secondaryData.GetExternalData(), schemaTo, counters);
 

--- a/ydb/core/tx/columnshard/engines/portions/read_with_blobs.h
+++ b/ydb/core/tx/columnshard/engines/portions/read_with_blobs.h
@@ -3,6 +3,7 @@
 #include "common.h"
 #include "portion_info.h"
 
+#include <ydb/core/tx/columnshard/engines/portions/data_accessor.h>
 #include <ydb/core/tx/columnshard/splitter/abstract/chunks.h>
 
 #include <ydb/library/accessor/accessor.h>

--- a/ydb/core/tx/columnshard/engines/portions/write_with_blobs.cpp
+++ b/ydb/core/tx/columnshard/engines/portions/write_with_blobs.cpp
@@ -55,8 +55,8 @@ TWritePortionInfoWithBlobsConstructor TWritePortionInfoWithBlobsConstructor::Bui
         }
     }
     for (auto&& [_, i] : inplaceChunks) {
-        result.GetPortionConstructor().AddIndex(
-            TIndexChunk(i->GetEntityId(), i->GetChunkIdxVerified(), i->GetRecordsCountVerified(), i->GetRawBytesVerified(), i->GetData()));
+        result.GetPortionConstructor().AddIndex(TIndexChunk(
+            i->GetEntityId(), i->GetChunkIdxVerified(), i->GetRecordsCountVerified(), i->GetRawBytesVerified(), i->GetData()));
     }
 
     return result;

--- a/ydb/core/tx/columnshard/engines/portions/written.h
+++ b/ydb/core/tx/columnshard/engines/portions/written.h
@@ -46,17 +46,26 @@ public:
     void CommitToDatabase(IDbWrapper& wrapper);
 
     virtual NSplitter::TEntityGroups GetEntityGroupsByStorageId(
-        const TString& /*specialTier*/, const IStoragesManager& storages, const TIndexInfo& /*indexInfo*/) const override {
-        NSplitter::TEntityGroups groups(storages.GetDefaultOperator()->GetBlobSplitSettings(), IStoragesManager::DefaultStorageId);
+        const TString& specialTier, const IStoragesManager& storages, const TIndexInfo& /*indexInfo*/) const override {
+        const TString& storageId = [&]() {
+            if (specialTier && specialTier != IStoragesManager::DefaultStorageId) {
+                return specialTier;
+            }
+            return IStoragesManager::DefaultStorageId;
+        }();
+        NSplitter::TEntityGroups groups(storages.GetOperatorVerified(storageId)->GetBlobSplitSettings(), storageId);
         return groups;
     }
 
     virtual const TString& GetColumnStorageId(const ui32 /*columnId*/, const TIndexInfo& /*indexInfo*/) const override {
-        return { NBlobOperations::TGlobal::DefaultStorageId };
+        if (GetMeta().GetTierName()) {
+            return GetMeta().GetTierName();
+        }
+        return NBlobOperations::TGlobal::DefaultStorageId;
     }
 
-    virtual const TString& GetEntityStorageId(const ui32 /*columnId*/, const TIndexInfo& /*indexInfo*/) const override {
-        return { NBlobOperations::TGlobal::DefaultStorageId };
+    virtual const TString& GetEntityStorageId(const ui32 columnId, const TIndexInfo& indexInfo) const override {
+        return GetColumnStorageId(columnId, indexInfo);
     }
 
     virtual const TString& GetIndexStorageId(const ui32 /*indexId*/, const TIndexInfo& /*indexInfo*/) const override {

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/chunks/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/chunks/source.cpp
@@ -139,11 +139,11 @@ std::shared_ptr<arrow::Array> TSourceData::BuildArrayAccessor(const ui64 columnI
     if (columnId == NKikimr::NSysView::Schema::PrimaryIndexStats::TierName::ColumnId) {
         auto builder = NArrow::MakeBuilder(arrow::utf8());
         for (auto&& i : GetPortionAccessor().GetRecordsVerified()) {
-            const TString tierName = Schema->GetIndexInfo().GetEntityStorageId(i.GetEntityId(), Portion->GetMeta().GetTierName());
+            const TString tierName = Portion->GetEntityStorageId(i.GetEntityId(), Schema->GetIndexInfo());
             NArrow::Append<arrow::StringType>(*builder, arrow::util::string_view(tierName.data(), tierName.size()));
         }
         for (auto&& i : GetPortionAccessor().GetIndexesVerified()) {
-            const TString tierName = Schema->GetIndexInfo().GetEntityStorageId(i.GetEntityId(), Portion->GetMeta().GetTierName());
+            const TString tierName = Portion->GetEntityStorageId(i.GetEntityId(), Schema->GetIndexInfo());
             NArrow::Append<arrow::StringType>(*builder, arrow::util::string_view(tierName.data(), tierName.size()));
         }
         return NArrow::FinishBuilder(std::move(builder));

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
@@ -27,8 +27,7 @@ TConclusionStatus TIndexInfo::CheckCompatible(const TIndexInfo& other) const {
 
 ui32 TIndexInfo::GetColumnIdVerified(const std::string& name) const {
     auto id = GetColumnIdOptional(name);
-    AFL_VERIFY(!!id)("column_name", name)("idxs", JoinSeq(",", ColumnIdxSortedByName))(
-        "names", JoinSeq(",", GetColumnNames()));
+    AFL_VERIFY(!!id)("column_name", name)("idxs", JoinSeq(",", ColumnIdxSortedByName))("names", JoinSeq(",", GetColumnNames()));
     return *id;
 }
 
@@ -444,12 +443,14 @@ std::shared_ptr<arrow::Scalar> TIndexInfo::GetColumnExternalDefaultValueVerified
 }
 
 NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& originalData,
-    const ui32 indexId, const std::shared_ptr<IStoragesManager>& operators, const ui32 recordsCount, TSecondaryData& result) const {
+    const ui32 indexId, const std::shared_ptr<IStoragesManager>& operators, const ui32 recordsCount, const TString& specialTier,
+    TSecondaryData& result) const {
     auto it = Indexes.find(indexId);
     AFL_VERIFY(it != Indexes.end());
     auto& index = it->second;
     TMemoryProfileGuard mpg("IndexConstruction::" + index->GetIndexName());
-    auto indexChunkConclusion = index->BuildIndexOptional(originalData, recordsCount, *this);
+    TConclusion<std::vector<std::shared_ptr<IPortionDataChunk>>> indexChunkConclusion =
+        index->BuildIndexOptional(originalData, recordsCount, *this);
     if (indexChunkConclusion.IsFail()) {
         return indexChunkConclusion;
     }
@@ -457,7 +458,8 @@ NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vec
         return TConclusionStatus::Success();
     }
     auto chunks = indexChunkConclusion.DetachResult();
-    auto opStorage = operators->GetOperatorVerified(index->GetStorageId());
+    const TString indexStorageId = GetIndexStorageId(indexId, specialTier);
+    auto opStorage = operators->GetOperatorVerified(indexStorageId);
     for (auto&& chunk : chunks) {
         if ((i64)chunk->GetPackedSize() > opStorage->GetBlobSplitSettings().GetMaxBlobSize()) {
             return TConclusionStatus::Fail("blob size for secondary data (" + ::ToString(indexId) + ":" + ::ToString(chunk->GetPackedSize()) +
@@ -465,7 +467,7 @@ NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vec
                                            ::ToString(opStorage->GetBlobSplitSettings().GetMaxBlobSize()) + ")");
         }
     }
-    if (index->GetStorageId() == IStoragesManager::LocalMetadataStorageId) {
+    if (indexStorageId == IStoragesManager::LocalMetadataStorageId) {
         AFL_VERIFY(chunks.size() == 1);
         AFL_VERIFY(result.MutableSecondaryInplaceData().emplace(indexId, chunks.front()).second);
     } else {
@@ -536,7 +538,8 @@ std::shared_ptr<arrow::Scalar> TIndexInfo::GetColumnExternalDefaultValueByIndexV
 
 TIndexInfo::TIndexInfo(const TIndexInfo& original, const TSchemaDiffView& diff, const std::shared_ptr<IStoragesManager>& operators,
     const std::shared_ptr<TSchemaObjectsCache>& cache)
-    : PresetId(original.PresetId) {
+    : PresetId(original.PresetId)
+{
     {
         std::vector<std::shared_ptr<arrow::Field>> fields;
         const auto addFromOriginal = [&](const ui32 index) {

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.h
@@ -3,11 +3,11 @@
 #include "column_features.h"
 #include "objects_cache.h"
 #include "schema_diff.h"
-#include "tier_info.h"
 
 #include "abstract/index_info.h"
 #include "indexes/abstract/meta.h"
 
+#include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/dictionary/object.h>
 #include <ydb/core/formats/arrow/program/execution.h>
 #include <ydb/core/formats/arrow/serializer/abstract.h>
@@ -150,10 +150,13 @@ private:
     std::shared_ptr<TColumnFeatures> BuildDefaultColumnFeatures(
         const NTable::TColumn& column, const std::shared_ptr<IStoragesManager>& operators) const;
 
-    const TString& GetIndexStorageId(const ui32 indexId) const {
+    const TString& GetIndexStorageId(const ui32 indexId, const TString& specialTier) const {
         auto it = Indexes.find(indexId);
         AFL_VERIFY(it != Indexes.end());
-        return it->second->GetStorageId();
+        if (specialTier && specialTier != IStoragesManager::DefaultStorageId && it->second->GetInheritPortionStorage()) {
+            return specialTier;
+        }
+        return it->second->GetDefaultStorageId();
     }
 
     const TString& GetColumnStorageId(const ui32 columnId, const TString& specialTier) const {
@@ -174,9 +177,8 @@ private:
 
 public:
     const TString& GetEntityStorageId(const ui32 entityId, const TString& specialTier) const {
-        auto it = Indexes.find(entityId);
-        if (it != Indexes.end()) {
-            return it->second->GetStorageId();
+        if (Indexes.contains(entityId)) {
+            return GetIndexStorageId(entityId, specialTier);
         }
         return GetColumnStorageId(entityId, specialTier);
     }
@@ -359,11 +361,11 @@ public:
     };
 
     [[nodiscard]] TConclusion<TSecondaryData> AppendIndexes(const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& primaryData,
-        const std::shared_ptr<IStoragesManager>& operators, const ui32 recordsCount) const {
+        const std::shared_ptr<IStoragesManager>& operators, const ui32 recordsCount, const TString& specialTier) const {
         TSecondaryData result;
         result.MutableExternalData() = primaryData;
         for (auto&& i : Indexes) {
-            auto conclusion = AppendIndex(primaryData, i.first, operators, recordsCount, result);
+            auto conclusion = AppendIndex(primaryData, i.first, operators, recordsCount, specialTier, result);
             if (conclusion.IsFail()) {
                 return conclusion;
             }
@@ -377,7 +379,8 @@ public:
     std::shared_ptr<NIndexes::NCountMinSketch::TIndexMeta> GetIndexMetaCountMinSketch(const std::set<ui32>& columnIds) const;
 
     [[nodiscard]] TConclusionStatus AppendIndex(const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& originalData,
-        const ui32 indexId, const std::shared_ptr<IStoragesManager>& operators, const ui32 recordsCount, TSecondaryData& result) const;
+        const ui32 indexId, const std::shared_ptr<IStoragesManager>& operators, const ui32 recordsCount, const TString& specialTier,
+        TSecondaryData& result) const;
 
     /// Returns an id of the column located by name. The name should exists in the schema.
     ui32 GetColumnIdVerified(const std::string& name) const;

--- a/ydb/core/tx/columnshard/engines/scheme/indexes/abstract/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/indexes/abstract/constructor.cpp
@@ -14,6 +14,12 @@ NKikimr::TConclusionStatus IIndexMetaConstructor::DeserializeFromJson(const NJso
             return TConclusionStatus::Fail("storage_id have to been one of variant ['__LOCAL_METADATA', '__DEFAULT']");
         }
     }
+    if (jsonInfo.Has("inherit_portion_storage")) {
+        if (!jsonInfo["inherit_portion_storage"].IsBoolean()) {
+            return TConclusionStatus::Fail("incorrect inherit_portion_storage field in json index description (have to be boolean)");
+        }
+        InheritPortionStorage = jsonInfo["inherit_portion_storage"].GetBooleanSafe();
+    }
     return DoDeserializeFromJson(jsonInfo);
 }
 

--- a/ydb/core/tx/columnshard/engines/scheme/indexes/abstract/constructor.h
+++ b/ydb/core/tx/columnshard/engines/scheme/indexes/abstract/constructor.h
@@ -16,6 +16,7 @@ namespace NKikimr::NOlap::NIndexes {
 class IIndexMetaConstructor {
 private:
     YDB_READONLY_DEF(std::optional<TString>, StorageId);
+    YDB_READONLY_DEF(std::optional<bool>, InheritPortionStorage);
 
 protected:
     virtual TConclusionStatus DoDeserializeFromJson(const NJson::TJsonValue& jsonInfo) = 0;
@@ -38,12 +39,18 @@ public:
         if (proto.HasStorageId()) {
             StorageId = proto.GetStorageId();
         }
+        if (proto.HasInheritPortionStorage()) {
+            InheritPortionStorage = proto.GetInheritPortionStorage();
+        }
         return DoDeserializeFromProto(proto);
     }
 
     void SerializeToProto(NKikimrSchemeOp::TOlapIndexRequested& proto) const {
         if (StorageId) {
             proto.SetStorageId(*StorageId);
+        }
+        if (InheritPortionStorage) {
+            proto.SetInheritPortionStorage(*InheritPortionStorage);
         }
         return DoSerializeToProto(proto);
     }

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom/constructor.cpp
@@ -14,8 +14,9 @@ std::shared_ptr<IIndexMeta> TBloomIndexConstructor::DoCreateIndexMeta(
         return nullptr;
     }
     const ui32 columnId = columnInfo->GetId();
-    return std::make_shared<TBloomIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::DefaultStorageId), columnId,
-        FalsePositiveProbability, std::make_shared<TDefaultDataExtractor>(), TBase::GetBitsStorageConstructor());
+    return std::make_shared<TBloomIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::DefaultStorageId),
+        GetInheritPortionStorage().value_or(false), columnId, FalsePositiveProbability, std::make_shared<TDefaultDataExtractor>(),
+        TBase::GetBitsStorageConstructor());
 }
 
 NKikimr::TConclusionStatus TBloomIndexConstructor::DoDeserializeFromJson(const NJson::TJsonValue& jsonInfo) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.cpp
@@ -12,7 +12,8 @@
 
 namespace NKikimr::NOlap::NIndexes {
 
-std::vector<std::shared_ptr<IPortionDataChunk>> TBloomIndexMeta::DoBuildIndexImpl(TChunkedBatchReader& reader, const ui32 recordsCount) const {
+std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TBloomIndexMeta::DoBuildIndexImpl(
+    TChunkedBatchReader& reader, const ui32 recordsCount) const {
     std::deque<std::shared_ptr<NArrow::NAccessor::IChunkedArray>> dataOwners;
     ui32 indexHitsCount = 0;
     for (reader.Start(); reader.IsCorrect();) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.h
@@ -26,7 +26,7 @@ private:
 
 protected:
     virtual TConclusionStatus DoCheckModificationCompatibility(const IIndexMeta& newMeta) const override;
-    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoBuildIndexImpl(
+    virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
         TChunkedBatchReader& reader, const ui32 recordsCount) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override;
@@ -37,10 +37,12 @@ protected:
 
 public:
     TBloomIndexMeta() = default;
-    TBloomIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const ui32 columnId, const double fpProbability,
-        const TReadDataExtractorContainer& dataExtractor, const std::shared_ptr<IBitsStorageConstructor>& bitsStorageConstructor)
-        : TBase(indexId, indexName, columnId, storageId, dataExtractor, bitsStorageConstructor)
-        , FalsePositiveProbability(fpProbability) {
+    TBloomIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const bool inheritPortionStorage,
+        const ui32 columnId, const double fpProbability, const TReadDataExtractorContainer& dataExtractor,
+        const std::shared_ptr<IBitsStorageConstructor>& bitsStorageConstructor)
+        : TBase(indexId, indexName, columnId, storageId, inheritPortionStorage, dataExtractor, bitsStorageConstructor)
+        , FalsePositiveProbability(fpProbability)
+    {
         Initialize();
     }
 

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/constructor.cpp
@@ -15,8 +15,9 @@ std::shared_ptr<IIndexMeta> TIndexConstructor::DoCreateIndexMeta(
         return nullptr;
     }
     const ui32 columnId = columnInfo->GetId();
-    return std::make_shared<TIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::DefaultStorageId), columnId,
-        GetDataExtractor(), HashesCount, FilterSizeBytes, NGrammSize, RecordsCount, TBase::GetBitsStorageConstructor(), CaseSensitive);
+    return std::make_shared<TIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::DefaultStorageId),
+        GetInheritPortionStorage().value_or(false), columnId, GetDataExtractor(), HashesCount, FilterSizeBytes, NGrammSize, RecordsCount,
+        TBase::GetBitsStorageConstructor(), CaseSensitive);
 }
 
 TConclusionStatus TIndexConstructor::DoDeserializeFromJson(const NJson::TJsonValue& jsonInfo) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.cpp
@@ -277,7 +277,8 @@ public:
 };
 }   // namespace
 
-std::vector<std::shared_ptr<IPortionDataChunk>> TIndexMeta::DoBuildIndexImpl(TChunkedBatchReader& reader, const ui32 recordsCount) const {
+std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
+    TChunkedBatchReader& reader, const ui32 recordsCount) const {
     AFL_VERIFY(reader.GetColumnsCount() == 1)("count", reader.GetColumnsCount());
     TNGrammBuilder builder(HashesCount, CaseSensitive);
 

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.h
@@ -50,7 +50,7 @@ protected:
         }
         return TBase::CheckSameColumnsForModification(newMeta);
     }
-    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoBuildIndexImpl(
+    virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
         TChunkedBatchReader& reader, const ui32 recordsCount) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override {
@@ -116,15 +116,16 @@ protected:
 
 public:
     TIndexMeta() = default;
-    TIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const ui32 columnId,
+    TIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const bool inheritPortionIndex, const ui32 columnId,
         const TReadDataExtractorContainer& dataExtractor, const ui32 hashesCount, const ui32 filterSizeBytes, const ui32 nGrammSize,
         const ui32 recordsCount, const std::shared_ptr<IBitsStorageConstructor>& bitsStorageConstructor, const bool caseSensitive)
-        : TBase(indexId, indexName, columnId, storageId, dataExtractor, bitsStorageConstructor)
+        : TBase(indexId, indexName, columnId, storageId, inheritPortionIndex, dataExtractor, bitsStorageConstructor)
         , CaseSensitive(caseSensitive)
         , NGrammSize(nGrammSize)
         , FilterSizeBytes(filterSizeBytes)
         , RecordsCount(recordsCount)
-        , HashesCount(hashesCount) {
+        , HashesCount(hashesCount)
+    {
         Initialize();
     }
 

--- a/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/constructor.cpp
@@ -14,7 +14,8 @@ std::shared_ptr<IIndexMeta> TBloomIndexConstructor::DoCreateIndexMeta(
         return nullptr;
     }
     return std::make_shared<TIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::DefaultStorageId),
-        columnInfo->GetId(), FalsePositiveProbability, std::make_shared<TDefaultDataExtractor>(), TBase::GetBitsStorageConstructor());
+        GetInheritPortionStorage().value_or(false), columnInfo->GetId(), FalsePositiveProbability, std::make_shared<TDefaultDataExtractor>(),
+        TBase::GetBitsStorageConstructor());
 }
 
 NKikimr::TConclusionStatus TBloomIndexConstructor::DoDeserializeFromJson(const NJson::TJsonValue& jsonInfo) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/meta.cpp
@@ -89,8 +89,9 @@ public:
     }
 };
 
-std::vector<std::shared_ptr<IPortionDataChunk>> TIndexMeta::DoBuildIndexImpl(TChunkedBatchReader& reader, const ui32 /*recordsCount*/) const {
-    std::vector<std::shared_ptr<IPortionDataChunk>> result;
+std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
+    TChunkedBatchReader& reader, const ui32 /*recordsCount*/) const {
+    std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> result;
     ui32 chunkIdx = 0;
     for (reader.Start(); reader.IsCorrect(); reader.ReadNext(reader.begin()->GetCurrentChunk()->GetRecordsCount())) {
         std::deque<std::shared_ptr<NArrow::NAccessor::IChunkedArray>> dataOwners;

--- a/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/meta.h
@@ -47,7 +47,7 @@ protected:
         AFL_VERIFY(FalsePositiveProbability < 1 && FalsePositiveProbability >= 0.01);
         return TBase::CheckSameColumnsForModification(newMeta);
     }
-    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoBuildIndexImpl(
+    virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
         TChunkedBatchReader& reader, const ui32 recordsCount) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override;
@@ -55,9 +55,9 @@ protected:
 
 public:
     TIndexMeta() = default;
-    TIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const ui32 columnId, const double fpProbability,
+    TIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const bool inheritPortionStorage, const ui32 columnId, const double fpProbability,
         const TReadDataExtractorContainer& dataExtractor, const std::shared_ptr<IBitsStorageConstructor>& bitsStorageConstructor)
-        : TBase(indexId, indexName, columnId, storageId, dataExtractor, bitsStorageConstructor)
+        : TBase(indexId, indexName, columnId, storageId, inheritPortionStorage, dataExtractor, bitsStorageConstructor)
         , FalsePositiveProbability(fpProbability) {
         Initialize();
     }

--- a/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/constructor.cpp
@@ -21,7 +21,8 @@ std::shared_ptr<NKikimr::NOlap::NIndexes::IIndexMeta> TCountMinSketchConstructor
         AFL_VERIFY(columnIds.emplace(columnInfo->GetId()).second);
     }
     AFL_VERIFY(columnIds.size() == 1);
-    return std::make_shared<TIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::DefaultStorageId), *columnIds.begin());
+    return std::make_shared<TIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::DefaultStorageId),
+        GetInheritPortionStorage().value_or(false), *columnIds.begin());
 }
 
 NKikimr::TConclusionStatus TCountMinSketchConstructor::DoDeserializeFromJson(const NJson::TJsonValue& jsonInfo) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/meta.cpp
@@ -13,7 +13,8 @@
 
 namespace NKikimr::NOlap::NIndexes::NCountMinSketch {
 
-std::vector<std::shared_ptr<IPortionDataChunk>> TIndexMeta::DoBuildIndexImpl(TChunkedBatchReader& reader, const ui32 recordsCount) const {
+std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
+    TChunkedBatchReader& reader, const ui32 recordsCount) const {
     auto sketch = std::unique_ptr<TCountMinSketch>(TCountMinSketch::Create());
 
     for (auto& colReader : reader) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/meta.h
@@ -25,7 +25,7 @@ protected:
         return TBase::CheckSameColumnsForModification(newMeta);
     }
 
-    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoBuildIndexImpl(
+    virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
         TChunkedBatchReader& reader, const ui32 recordsCount) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override {
@@ -47,8 +47,9 @@ protected:
 
 public:
     TIndexMeta() = default;
-    TIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const ui32 columnId)
-        : TBase(indexId, indexName, columnId, storageId, std::make_shared<TDefaultDataExtractor>()) {
+    TIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const bool inheritPortionStorage, const ui32 columnId)
+        : TBase(indexId, indexName, columnId, storageId, inheritPortionStorage, std::make_shared<TDefaultDataExtractor>())
+    {
     }
 
     virtual TString GetClassName() const override {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/max/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/max/constructor.cpp
@@ -20,7 +20,8 @@ std::shared_ptr<NKikimr::NOlap::NIndexes::IIndexMeta> TIndexConstructor::DoCreat
         }
         columnId = columnInfo->GetId();
     }
-    return std::make_shared<TIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::LocalMetadataStorageId), columnId);
+    return std::make_shared<TIndexMeta>(indexId, indexName, GetStorageId().value_or(NBlobOperations::TGlobal::LocalMetadataStorageId),
+        GetInheritPortionStorage().value_or(false), columnId);
 }
 
 NKikimr::TConclusionStatus TIndexConstructor::DoDeserializeFromJson(const NJson::TJsonValue& jsonInfo) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/max/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/max/meta.cpp
@@ -11,7 +11,8 @@
 
 namespace NKikimr::NOlap::NIndexes::NMax {
 
-std::vector<std::shared_ptr<IPortionDataChunk>> TIndexMeta::DoBuildIndexImpl(TChunkedBatchReader& reader, const ui32 recordsCount) const {
+std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
+    TChunkedBatchReader& reader, const ui32 recordsCount) const {
     std::shared_ptr<arrow::Scalar> result;
     AFL_VERIFY(reader.GetColumnsCount() == 1)("count", reader.GetColumnsCount());
     {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/max/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/max/meta.h
@@ -22,7 +22,7 @@ protected:
         Y_UNUSED(newMeta);
         return TConclusionStatus::Fail("max index not modifiable");
     }
-    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoBuildIndexImpl(
+    virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
         TChunkedBatchReader& reader, const ui32 recordsCount) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override {
@@ -46,8 +46,9 @@ protected:
 
 public:
     TIndexMeta() = default;
-    TIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const ui32& columnId)
-        : TBase(indexId, indexName, columnId, storageId, std::make_shared<TDefaultDataExtractor>()) {
+    TIndexMeta(const ui32 indexId, const TString& indexName, const TString& storageId, const bool inheritPortionStorage, const ui32& columnId)
+        : TBase(indexId, indexName, columnId, storageId, inheritPortionStorage, std::make_shared<TDefaultDataExtractor>())
+    {
     }
 
     static bool IsAvailableType(const NScheme::TTypeInfo type) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/meta.cpp
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NOlap::NIndexes {
 
-TConclusion<std::vector<std::shared_ptr<IPortionDataChunk>>> TIndexByColumns::DoBuildIndexOptional(
+TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> TIndexByColumns::DoBuildIndexOptional(
     const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo) const {
     AFL_VERIFY(Serializer);
     AFL_VERIFY(data.size());
@@ -16,7 +16,7 @@ TConclusion<std::vector<std::shared_ptr<IPortionDataChunk>>> TIndexByColumns::Do
         if (it == data.end()) {
             AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "index_data_absent")("column_id", i)("index_name", GetIndexName())(
                 "index_id", GetIndexId());
-            return std::vector<std::shared_ptr<IPortionDataChunk>>();
+            return std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>();
         }
         columnReaders.emplace_back(it->second, indexInfo.GetColumnLoaderVerified(i));
     }
@@ -29,11 +29,12 @@ bool TIndexByColumns::DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDe
     return true;
 }
 
-TIndexByColumns::TIndexByColumns(
-    const ui32 indexId, const TString& indexName, const ui32 columnId, const TString& storageId, const TReadDataExtractorContainer& extractor)
-    : TBase(indexId, indexName, storageId)
+TIndexByColumns::TIndexByColumns(const ui32 indexId, const TString& indexName, const ui32 columnId, const TString& storageId,
+    const bool inheritPortionStorage, const TReadDataExtractorContainer& extractor)
+    : TBase(indexId, indexName, storageId, inheritPortionStorage)
     , DataExtractor(extractor)
-    , ColumnIds({ columnId }) {
+    , ColumnIds({ columnId })
+{
     Serializer = NArrow::NSerialization::TSerializerContainer::GetDefaultSerializer();
 }
 

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/meta.h
@@ -23,10 +23,10 @@ protected:
         return DataExtractor;
     }
 
-    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoBuildIndexImpl(
+    virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
         TChunkedBatchReader& reader, const ui32 recordsCount) const = 0;
 
-    virtual TConclusion<std::vector<std::shared_ptr<IPortionDataChunk>>> DoBuildIndexOptional(
+    virtual TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> DoBuildIndexOptional(
         const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount,
         const TIndexInfo& indexInfo) const override final;
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override;
@@ -48,8 +48,8 @@ public:
         return ColumnIds;
     }
     TIndexByColumns() = default;
-    TIndexByColumns(const ui32 indexId, const TString& indexName, const ui32 columnId, const TString& storageId,
-        const TReadDataExtractorContainer& extractor);
+    TIndexByColumns(const ui32 indexId, const TString& indexName, const ui32 columnId,
+        const TString& storageId, const bool inheritPortionStorage, const TReadDataExtractorContainer& extractor);
 };
 
 }   // namespace NKikimr::NOlap::NIndexes

--- a/ydb/core/tx/columnshard/engines/storage/indexes/skip_index/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/skip_index/meta.h
@@ -83,10 +83,12 @@ public:
     }
 
     TSkipBitmapIndex() = default;
-    TSkipBitmapIndex(const ui32 indexId, const TString& indexName, const ui32 columnId, const TString& storageId,
-        const TReadDataExtractorContainer& extractor, const std::shared_ptr<IBitsStorageConstructor>& bitsStorageConstructor)
-        : TBase(indexId, indexName, columnId, storageId, extractor)
-        , BitsStorageConstructor(bitsStorageConstructor) {
+    TSkipBitmapIndex(const ui32 indexId, const TString& indexName, const ui32 columnId,
+        const TString& storageId, const bool inheritPortionStorage, const TReadDataExtractorContainer& extractor,
+        const std::shared_ptr<IBitsStorageConstructor>& bitsStorageConstructor)
+        : TBase(indexId, indexName, columnId, storageId, inheritPortionStorage, extractor)
+        , BitsStorageConstructor(bitsStorageConstructor)
+    {
         AFL_VERIFY(!!BitsStorageConstructor);
     }
 };

--- a/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
+++ b/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
@@ -421,7 +421,7 @@ void TTestSchema::InitSchema(const std::vector<NArrow::NTest::TTestColumn>& colu
         }
         if (NOlap::NIndexes::NMax::TIndexMeta::IsAvailableType(columns[i].GetType())) {
             *schema->AddIndexes() = NOlap::NIndexes::TIndexMetaContainer(
-                std::make_shared<NOlap::NIndexes::NMax::TIndexMeta>(1000 + i, "MAX::INDEX::" + columns[i].GetName(), "__LOCAL_METADATA", i + 1))
+                std::make_shared<NOlap::NIndexes::NMax::TIndexMeta>(1000 + i, "MAX::INDEX::" + columns[i].GetName(), "__LOCAL_METADATA", false, i + 1))
                                         .SerializeToProto();
         }
     }

--- a/ydb/core/tx/schemeshard/olap/indexes/update.cpp
+++ b/ydb/core/tx/schemeshard/olap/indexes/update.cpp
@@ -7,6 +7,9 @@ void TOlapIndexUpsert::SerializeToProto(NKikimrSchemeOp::TOlapIndexRequested& re
     if (StorageId && !!*StorageId) {
         requestedProto.SetStorageId(*StorageId);
     }
+    if (!!InheritPortionStorage) {
+        requestedProto.SetInheritPortionStorage(*InheritPortionStorage);
+    }
     IndexConstructor.SerializeToProto(requestedProto);
 }
 
@@ -14,6 +17,9 @@ bool TOlapIndexUpsert::DeserializeFromProto(const NKikimrSchemeOp::TOlapIndexReq
     Name = indexSchema.GetName();
     if (!!indexSchema.GetStorageId()) {
         StorageId = indexSchema.GetStorageId();
+    }
+    if (indexSchema.HasInheritPortionStorage()) {
+        InheritPortionStorage = indexSchema.GetInheritPortionStorage();
     }
     AFL_VERIFY(IndexConstructor.DeserializeFromProto(indexSchema))("incorrect_proto", indexSchema.DebugString());
     return true;

--- a/ydb/core/tx/schemeshard/olap/indexes/update.h
+++ b/ydb/core/tx/schemeshard/olap/indexes/update.h
@@ -12,6 +12,7 @@ namespace NKikimr::NSchemeShard {
         YDB_READONLY_DEF(TString, Name);
         YDB_READONLY_DEF(TString, TypeName);
         YDB_READONLY_DEF(std::optional<TString>, StorageId);
+        YDB_READONLY_DEF(std::optional<bool>, InheritPortionStorage);
     protected:
         NBackgroundTasks::TInterfaceProtoContainer<NOlap::NIndexes::IIndexMetaConstructor> IndexConstructor;
     public:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow eviction of OLAP indexes to S3 with portions

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
