### PR TITLE
fix race between switch drain and node status

### DIFF
--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -1235,6 +1235,68 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         UNIT_ASSERT(!isNodeEmpty(nodeId));
     }
 
+    Y_UNIT_TEST(TestDrainAndReconnect) {
+        const int NUM_TABLETS = 5;
+        TTestBasicRuntime runtime(2, false);
+        TBlockEvents<NNodeWhiteboard::TEvWhiteboard::TEvSystemStateResponse> blockSystemState(runtime);
+        Setup(runtime, true, 2);
+        const ui64 hiveTablet = MakeDefaultHiveID();
+        const ui64 testerTablet = MakeTabletID(false, 1);
+        const TActorId hiveActor = CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
+        runtime.EnableScheduleForActor(hiveActor);
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvStatus, 2);
+            runtime.DispatchEvents(options);
+        }
+        TTabletTypes::EType tabletType = TTabletTypes::Dummy;
+        std::unordered_set<TTabletId> tablets;
+        TActorId senderA = runtime.AllocateEdgeActor(0);
+        for (int i = 0; i < NUM_TABLETS; ++i) {
+            THolder<TEvHive::TEvCreateTablet> ev(new TEvHive::TEvCreateTablet(testerTablet, 100500 + tablets.size(), tabletType, BINDED_CHANNELS));
+            runtime.SendToPipe(hiveTablet, senderA, ev.Release(), 0, GetPipeConfigWithRetries());
+            TAutoPtr<IEventHandle> handle;
+            auto createTabletReply = runtime.GrabEdgeEventRethrow<TEvHive::TEvCreateTabletReply>(handle);
+            ui64 tabletId = createTabletReply->Record.GetTabletID();
+            tablets.insert(tabletId);
+        }
+        NTabletPipe::TClientConfig pipeConfig;
+        pipeConfig.RetryPolicy = NTabletPipe::TClientRetryPolicy::WithRetries();
+        for (TTabletId tabletId : tablets) {
+            MakeSureTabletIsUp(runtime, tabletId, 0, &pipeConfig);
+        }
+
+        ui32 nodeIdx = 0;
+        ui32 nodeId = runtime.GetNodeId(nodeIdx);
+        TBlockEvents<TEvTablet::TEvCommit> blockCommit(runtime);
+
+        runtime.SendToPipe(hiveTablet, senderA, new TEvHive::TEvDrainNode(nodeId));
+
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(500));
+
+        // This causes local to send TEvStatus
+        for (auto& ev : blockSystemState) {
+            auto& record = ev->Get()->Record;
+            if (record.SystemStateInfoSize() == 0) {
+                record.AddSystemStateInfo();
+            }
+            record.MutableSystemStateInfo(0)->SetMemoryLimit(20'000'000'000ull);
+        }
+        blockSystemState.Stop().Unblock();
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvStatus);
+            runtime.DispatchEvents(options);
+        }
+
+        blockCommit.Stop().Unblock();
+
+        TAutoPtr<IEventHandle> handle;
+        auto drainResponse = runtime.GrabEdgeEventRethrow<TEvHive::TEvDrainNodeResult>(handle, TDuration::Seconds(30));
+        UNIT_ASSERT_VALUES_EQUAL(drainResponse->Record.GetStatus(), NKikimrProto::EReplyStatus::OK);
+    }
+
     Y_UNIT_TEST(TestCreateSubHiveCreateTablet) {
         TTestBasicRuntime runtime(1, false);
         Setup(runtime, true);

--- a/ydb/core/mind/hive/tx__status.cpp
+++ b/ydb/core/mind/hive/tx__status.cpp
@@ -48,7 +48,7 @@ public:
             }
             Self->ProcessWaitQueue(); // new node connected
             if (node.Drain && Self->BalancerNodes.count(nodeId) == 0) {
-                BLOG_D("THive::TTxStatus(" << nodeId << ")::Complete - continuing node drain");
+                BLOG_D("THive::TTxStatus(" << nodeId << ") - continuing node drain");
                 Y_DEBUG_ABORT_UNLESS(node.DrainActor == nullptr);
                 node.DrainActor = Self->StartHiveDrain(nodeId, {.Persist = true, .DownPolicy = NKikimrHive::EDrainDownPolicy::DRAIN_POLICY_NO_DOWN});
             }

--- a/ydb/core/mind/hive/tx__switch_drain.cpp
+++ b/ydb/core/mind/hive/tx__switch_drain.cpp
@@ -11,7 +11,7 @@ class TTxSwitchDrainOn : public TTransactionBase<THive> {
     TActorId Initiator;
     NKikimrProto::EReplyStatus Status = NKikimrProto::UNKNOWN;
     ui64 SeqNo;
-    bool ShouldStartDrain = true;
+    bool StartingDrain = true;
     ui64 Cookie;
 
 public:
@@ -32,11 +32,11 @@ public:
         if (node != nullptr) {
             if (!(node->Drain) && (Self->BalancerNodes.count(NodeId) != 0 || (SeqNo != 0 && SeqNo <= node->DrainSeqNo))) {
                 Status = NKikimrProto::ALREADY;
-                ShouldStartDrain = false;
+                StartingDrain = false;
             } else {
                 Status = NKikimrProto::OK;
                 if (node->Drain) {
-                    ShouldStartDrain = false;
+                    StartingDrain = false;
                 }
                 node->Drain = true;
                 node->DrainInitiators.emplace_back(Initiator);
@@ -60,27 +60,22 @@ public:
                         }
                     }
                 }
+                Y_DEBUG_ABORT_UNLESS(node->DrainActor == nullptr);
+                node->DrainActor = Self->StartHiveDrain(NodeId, std::move(Settings));
             }
         } else {
             Status = NKikimrProto::ERROR;
-            ShouldStartDrain = false;
+            StartingDrain = false;
         }
         return true;
     }
 
     void Complete(const TActorContext&) override {
         BLOG_D("THive::TTxSwitchDrainOn::Complete NodeId: " << NodeId << " Status: " << Status);
-        if (ShouldStartDrain) {
-            auto* node = Self->FindNode(NodeId);
-            if (node) {
-                Y_DEBUG_ABORT_UNLESS(node->DrainActor == nullptr);
-                node->DrainActor = Self->StartHiveDrain(NodeId, std::move(Settings));
-            }
-            if (Initiator) {
+        if (Initiator) {
+            if (StartingDrain) {
                 Self->Send(Initiator, new TEvHive::TEvDrainNodeAck(SeqNo), 0, Cookie);
-            }
-        } else {
-            if (Initiator) {
+            } else {
                 Self->Send(Initiator, new TEvHive::TEvDrainNodeResult(Status), 0, Cookie);
             }
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Получалось два запуска дрейна, если TEvStatus прилетал между Execute и Complete у TxSwitchDrainOn. Лечится переносом запуска дрейна в Execute (когда-то раньше [так и было](https://github.com/ydb-platform/ydb/pull/14125), потом я в какой-то момент решил, что типа логичнее запуски иметь в Complete - ну и зря).
