### PR TITLE
Hash join utils: hash tables

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
@@ -9,8 +9,6 @@
 
 #include <util/generic/buffer.h>
 
-#include <ydb/library/yql/utils/simd/simd.h>
-
 #include "tuple.h"
 
 namespace NKikimr {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h
@@ -1,0 +1,533 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_value.h>
+
+#include <yql/essentials/utils/prefetch.h>
+
+#include <util/generic/buffer.h>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+/*
+ * Class TNeumannHashTable provides hash table implementation for packed tuples.
+ *
+ * TNeumannHashTable has the following layout:
+ * HashTable:    [[Directory 1][Directory 2]...[Directory N]]
+ * Directory:    [[Buffer Index][Bloom Filter]]
+ * Buffer:       [[Tuple 1][Tuple 2]...[Tuple M]]
+ */
+
+template <class T> class TBloomFilterMasks {
+
+    static consteval size_t BinomCoeff(size_t n, size_t k) noexcept {
+        return k == 0 ? 1 : BinomCoeff(n - 1, k - 1) * n / k;
+    }
+
+    static consteval size_t Pow2Round(size_t n) {
+        return n == 0 ? 0
+                      : 1ul << (sizeof(size_t) * 8 - std::countl_zero(n - 1));
+    }
+
+    template <size_t N, size_t K>
+    static consteval size_t GenRec(auto &arr, T mask, size_t i, size_t j) {
+        if constexpr (K == 0) {
+            arr[i] = mask;
+            return i + 1;
+        } else {
+            for (size_t ind = j; ind <= N - K; ++ind) {
+                i = GenRec<N, K - 1>(arr, mask | (T(1) << ind), i, ind + 1);
+            }
+            return i;
+        }
+    }
+
+  public:
+    template <unsigned BloomBits, unsigned BloomMaskBits>
+    static consteval auto Gen() {
+        constexpr size_t BloomMasksNum = BinomCoeff(BloomBits, BloomMaskBits);
+        constexpr size_t BloomMasksNumRounded = Pow2Round(BloomMasksNum);
+
+        auto result = std::array<T, BloomMasksNumRounded>{};
+        GenRec<BloomBits, BloomMaskBits>(result, 0, 0, 0);
+        std::copy(result.data(),
+                  result.data() + BloomMasksNumRounded - BloomMasksNum,
+                  result.data() + BloomMasksNum);
+
+        return result;
+    }
+};
+
+template <bool ConsecutiveDuplicates = false, bool Prefetch = true,
+          typename TAllocator = TMKQLAllocator<ui8>>
+class TNeumannHashTable {
+    /// hash = [...] [directory_bits] [...] [bloom_filter_bits]
+    using Hash = ui32;
+    using TBloom = ui16;
+
+    static constexpr unsigned kBloomBits = 16;
+    static constexpr unsigned kBloomMaskBits = 4;
+
+    alignas(64) static constexpr auto kBloomTags =
+        TBloomFilterMasks<TBloom>::template Gen<kBloomBits, kBloomMaskBits>();
+    static constexpr unsigned kBloomHashBits =
+        std::countr_zero(kBloomTags.size());
+
+    static_assert(kBloomBits != 0 && kBloomMaskBits != 0 &&
+                  kBloomMaskBits < kBloomBits &&
+                  kBloomBits <= sizeof(TBloom) * 8);
+
+    struct TDirectory {
+        using T = ui64;
+
+        T &operator*() { return reinterpret_cast<T &>(*this); }
+        const T &operator*() const {
+            return reinterpret_cast<const T &>(*this);
+        }
+
+        static constexpr size_t kBufferSlotShift = kBloomBits;
+
+        T BloomFilter : kBloomBits = 0;
+        T BufferSlot : sizeof(T) * 8 - kBloomBits = 0;
+    };
+    static_assert(sizeof(TDirectory) == sizeof(typename TDirectory::T));
+
+    struct THash {
+        using T = Hash;
+
+        T &operator*() { return reinterpret_cast<T &>(*this); }
+        const T &operator*() const {
+            return reinterpret_cast<const T &>(*this);
+        }
+
+        T BloomTagSlot : kBloomHashBits;
+        T DirSlotHash : sizeof(T) * 8 - kBloomHashBits;
+    };
+    static_assert(sizeof(THash) == sizeof(typename THash::T));
+
+    Hash getDirectorySlot(THash thash) const {
+        return (*thash >> DirectoryHashShift_) & DirectoryHashMask_;
+    }
+
+    static constexpr ui32 kEmbeddedSize = 16;
+
+    template <bool>
+    struct TOutplaceImpl {
+        Hash Hash;
+        ui32 Index;
+    };
+    template <>
+    struct TOutplaceImpl<true> : TOutplaceImpl<false> {
+    };
+
+    using TOutplace = TOutplaceImpl<ConsecutiveDuplicates>;
+    static_assert(sizeof(TOutplace) <= kEmbeddedSize);
+
+
+    template<bool> struct TIteratorImpl;
+    template<> struct TIteratorImpl<false> {
+        friend TNeumannHashTable;
+
+      public:
+        TIteratorImpl(): It_(nullptr), End_(nullptr) {}
+
+      private:
+        const ui8 *Row_;
+        const ui8 *It_;
+        const ui8 *End_;
+    };
+    template<> struct TIteratorImpl<true> {
+        friend TNeumannHashTable;
+
+      public:
+        TIteratorImpl(): It_(nullptr), Len_(0) {}
+
+      private:
+        const ui8 *It_;
+        ui32 Len_;
+    };
+
+
+  public:
+    using TIterator = TIteratorImpl<ConsecutiveDuplicates>;
+  
+    TNeumannHashTable()
+        : DirectoriesData_(Allocator_)
+        , Buffer_(Allocator_) 
+    {}
+
+    explicit TNeumannHashTable(const TTupleLayout *layout): TNeumannHashTable() {
+        SetTupleLayout(layout);
+    }
+
+    void SetTupleLayout(const TTupleLayout *layout) {
+        Clear();
+
+        Layout_ = layout;
+        IsInplace_ = layout->TotalRowSize <= kEmbeddedSize;
+        RowIndexSize_ = IsInplace_ ? layout->TotalRowSize : sizeof(TOutplace);
+        BufferSlotSize_ = RowIndexSize_;
+        if constexpr (ConsecutiveDuplicates) {
+            BufferSlotSize_ += sizeof(ui32);
+        }
+    }
+
+    TNeumannHashTable(const TNeumannHashTable &) = delete;
+    TNeumannHashTable &operator=(const TNeumannHashTable &) = delete;
+
+    void Build(const ui8 *const tuples, const ui8 *const overflow, ui32 nItems,
+               ui32 estimatedLogSize = 0) {
+        Y_ASSERT(Layout_ != nullptr);
+        Y_ASSERT(Directories_.empty() && Buffer_.empty() &&
+                 Tuples_ == nullptr && Overflow_ == nullptr);
+
+        if (estimatedLogSize == 0) {
+            estimatedLogSize = 32 - std::countl_zero<ui32>(nItems);
+            estimatedLogSize = estimatedLogSize > 2 ? estimatedLogSize - 2 : estimatedLogSize;
+        }
+        estimatedLogSize = std::max(1u, std::min(24u, estimatedLogSize));
+
+        Tuples_ = tuples;
+        Overflow_ = overflow;
+
+        DirectoryHashBits_ = estimatedLogSize;
+        DirectoryHashShift_ = sizeof(Hash) * 8 - kBloomHashBits >= DirectoryHashBits_
+                                ? kBloomHashBits
+                                : sizeof(Hash) * 8 - DirectoryHashBits_;
+        DirectoryHashMask_ = (1ul << DirectoryHashBits_) - 1;
+        
+        const ui32 dirsSize = (1ul << DirectoryHashBits_) + 1;
+        DirectoriesData_.resize(dirsSize * sizeof(TDirectory));
+        Directories_ = std::span((TDirectory *)DirectoriesData_.data(), dirsSize);
+        for (auto& directory : Directories_) {
+            directory = {};
+        }
+
+        for (ui32 ind = 0; ind != nItems; ++ind) {
+            const THash thash =
+                ReadUnaligned<THash>(tuples + Layout_->TotalRowSize * ind);
+            auto &dir = *Directories_[getDirectorySlot(thash)];
+            dir += 1ul << TDirectory::kBufferSlotShift;
+            dir |= kBloomTags[thash.BloomTagSlot];
+        }
+
+        {
+            ui32 accum = 0;
+            for (auto &directory : Directories_) {
+                accum += directory.BufferSlot;
+                directory.BufferSlot = accum;
+
+                directory.BloomFilter = ~directory.BloomFilter;
+            }
+        }
+
+        Buffer_.resize(BufferSlotSize_ * nItems);
+
+        constexpr ui32 prefetchInAdvance = 16;
+
+        if constexpr (Prefetch) {
+            for (ui32 ind = 0; ind != std::min(prefetchInAdvance, nItems); ++ind) {
+                const ui8 *row = tuples + Layout_->TotalRowSize * ind;
+                const THash thash = ReadUnaligned<THash>(row);
+                auto &dir = *Directories_[getDirectorySlot(thash)];
+                const ui32 dataSlot = (dir >> TDirectory::kBufferSlotShift) - 1;
+                ui8 *const ptr = Buffer_.data() + BufferSlotSize_ * dataSlot;
+                NYql::PrefetchForWrite(ptr);
+            }
+        }
+
+        const ui8 *row = tuples;
+        for (ui32 ind = 0; ind != nItems; ++ind, row += Layout_->TotalRowSize) {
+            if constexpr (Prefetch) {
+                const ui8 *prow = row + Layout_->TotalRowSize * prefetchInAdvance;
+                const THash thash = ReadUnaligned<THash>(prow);
+                auto &dir = *Directories_[getDirectorySlot(thash)];
+                const ui32 dataSlot = (dir >> TDirectory::kBufferSlotShift) - 1;
+                ui8 *const ptr = Buffer_.data() + BufferSlotSize_ * dataSlot;
+                NYql::PrefetchForWrite(ptr);
+            }
+    
+            const THash thash = ReadUnaligned<THash>(row);
+
+            auto &dir = *Directories_[getDirectorySlot(thash)];
+            dir -= 1ul << TDirectory::kBufferSlotShift;
+            const ui32 dataSlot = dir >> TDirectory::kBufferSlotShift;
+            ui8 *const bufRow = Buffer_.data() + BufferSlotSize_ * dataSlot;
+
+            if (IsInplace_) {
+                std::memcpy(bufRow, row,
+                            RowIndexSize_);
+            } else {
+                auto *const outRow = reinterpret_cast<TOutplace *>(bufRow);
+                outRow->Hash = *thash;
+                outRow->Index = ind;
+            }
+            
+            if constexpr (ConsecutiveDuplicates) {
+                WriteUnaligned<ui32>(bufRow + RowIndexSize_, 0); 
+            }
+        }
+
+        if constexpr (ConsecutiveDuplicates) {
+            for (size_t dirSlot = 0; dirSlot != Directories_.size() - 1; ++dirSlot) {
+                ui8 *begin = Buffer_.data() + BufferSlotSize_ * Directories_[dirSlot].BufferSlot;
+                ui8 *const end = Buffer_.data() + BufferSlotSize_ * Directories_[dirSlot + 1].BufferSlot;
+                const ui8* matchedRow;
+
+                while (begin != end) {
+                    const ui8 *const row = GetRow(begin);
+
+                    ui8 *left = begin + BufferSlotSize_;
+                    ui8 *right = end;
+                    ui32 size = 1;
+
+                    bool checkLeft = true;
+                    while (left != right) {
+                        while (left != right && checkLeft && GetRowMatch(left, row, overflow, &matchedRow)) {
+                            ++size;
+                            left += BufferSlotSize_;
+                        }
+                        checkLeft = false;
+
+                        if (left == right) {
+                            break;
+                        }
+                        right -= BufferSlotSize_;
+
+                        if (GetRowMatch(right, row, overflow, &matchedRow)) {
+                            ui8 buf[kEmbeddedSize];
+                            std::memcpy(buf, left, RowIndexSize_);
+                            std::memcpy(left, right, RowIndexSize_);
+                            std::memcpy(right, buf, RowIndexSize_);
+
+                            ++size;
+                            left += BufferSlotSize_;
+                            checkLeft = true;
+                        }
+                    }
+    
+                    WriteUnaligned<ui32>(begin + RowIndexSize_, size);
+                    begin = left;
+                }
+            }
+        }
+    }
+
+    Y_FORCE_INLINE const ui8 *NextMatch(TIterator &iter, const ui8 *overflow) const {
+        const ui8 *result = nullptr;
+
+        if constexpr (ConsecutiveDuplicates) {
+            if (iter.Len_) { /// allow multiple false calls
+                result = GetRow(iter.It_);
+                iter.It_ += BufferSlotSize_;
+                iter.Len_--;
+            }
+        } else {
+            for (auto& it = iter.It_; it != iter.End_; it += BufferSlotSize_) { /// allow multiple false calls
+                if (GetRowMatch(it, iter.Row_, overflow, &result)) {
+                    it += BufferSlotSize_;
+                    break;
+                }
+                result = nullptr;
+            }
+        }
+
+        return result;
+    }
+
+    TIterator Find(const ui8 *const row, const ui8 *const overflow) const {
+        Y_ASSERT(Layout_ != nullptr);
+        Y_ASSERT(!Directories_.empty() && Tuples_ != nullptr);
+
+        TIterator iter;
+
+        const THash &thash = reinterpret_cast<const THash &>(row[0]);
+        const TBloom hashBloomTag = kBloomTags[thash.BloomTagSlot];
+
+        const Hash dirSlot = getDirectorySlot(thash);
+        const TDirectory dir = Directories_[dirSlot];
+        const TBloom dirBloomFilter = dir.BloomFilter;
+
+        if (hashBloomTag & dirBloomFilter) {
+            return iter;
+        }
+
+        const ui8 *const begin =
+            Buffer_.data() + BufferSlotSize_ * dir.BufferSlot;
+        const ui8 *const end =
+            Buffer_.data() +
+            BufferSlotSize_ * Directories_[dirSlot + 1].BufferSlot;
+
+        if constexpr (!ConsecutiveDuplicates) {
+            iter.Row_ = row;
+            iter.It_ = begin;
+            iter.End_ = end;
+        } else {
+            for (auto it = begin; it != end; ) {
+                const ui8 *matchedRow;
+                auto size  = ReadUnaligned<ui32>(it + RowIndexSize_);
+
+                if (GetRowMatch(it, row, overflow, &matchedRow)) {
+                    iter.It_ = it;
+                    iter.Len_ = size;
+                    break;
+                } else {
+                    it += size * BufferSlotSize_;
+                }
+            }
+        }
+
+        return iter;
+    }
+
+    template <size_t Size>
+    std::array<TIterator, Size> FindBatch(const std::array<const ui8 *, Size> &rows,
+                                          const ui8 *const overflow) const {
+        if constexpr (Prefetch) {
+            if (Directories_.size_bytes() > 1024 * 1024) {
+                for (ui32 index = 0; index < Size && rows[index]; ++index) {
+                    const THash &thash = reinterpret_cast<const THash &>(rows[index][0]);
+                    const Hash dirSlot = getDirectorySlot(thash);
+                    NYql::PrefetchForRead(&Directories_[dirSlot]);
+                }    
+            } else {
+                for (ui32 index = 0; index < Size && rows[index]; ++index) {
+                    const THash &thash = reinterpret_cast<const THash &>(rows[index][0]);
+                    const Hash dirSlot = getDirectorySlot(thash);
+                    const TDirectory dir = Directories_[dirSlot]; 
+                    const ui8 *ptr = Buffer_.data() + BufferSlotSize_ * dir.BufferSlot;
+                    NYql::PrefetchForRead(ptr);
+                }
+            }
+        }
+
+        std::array<TIterator, Size> iters;
+        for (ui32 index = 0; index < Size && rows[index]; ++index) {
+            iters[index] = Find(rows[index], overflow);
+        }
+
+        return iters;
+    }
+
+    void Apply(const ui8 *const row, const ui8 *const overflow,
+               auto &&onMatch) {
+        Y_ASSERT(Layout_ != nullptr);
+        Y_ASSERT(!Directories_.empty() && Tuples_ != nullptr);
+
+        const THash &thash = reinterpret_cast<const THash &>(row[0]);
+        const TBloom hashBloomTag = kBloomTags[thash.BloomTagSlot];
+
+        const Hash dirSlot = getDirectorySlot(thash);
+        const TDirectory dir = Directories_[dirSlot];
+        const TBloom dirBloomFilter = dir.BloomFilter;
+
+        if (hashBloomTag & dirBloomFilter) {
+            return;
+        }
+
+        const ui8 *const begin =
+            Buffer_.data() + BufferSlotSize_ * dir.BufferSlot;
+        const ui8 *const end =
+            Buffer_.data() +
+            BufferSlotSize_ * Directories_[dirSlot + 1].BufferSlot;
+
+        const ui8 *matchedRow;
+
+        if constexpr (!ConsecutiveDuplicates) {
+            for (auto it = begin; it != end; it += BufferSlotSize_) {
+                if (GetRowMatch(it, row, overflow, &matchedRow)) {
+                    onMatch(matchedRow);
+                }
+            }
+        } else {
+            ui32 size = 0;
+            for (auto it = begin; it != end; it += size * BufferSlotSize_) {
+                size = ReadUnaligned<ui32>(it + RowIndexSize_);
+                if (!GetRowMatch(it, row, overflow, &matchedRow)) {
+                    continue;
+                }
+
+                for (; size; --size, it += BufferSlotSize_) {
+                    onMatch(it);
+                }
+                break;
+            }
+        }
+    }
+
+    void Clear() {
+        Directories_ = {};
+        DirectoriesData_.clear();
+        Buffer_.clear();
+
+        Tuples_ = nullptr;
+        Overflow_ = nullptr;
+    }
+
+  private:
+    const ui8* GetRow(const ui8* it) const {
+        if (IsInplace_) {
+            return it;
+        } else {
+            const auto *const outRow =
+                reinterpret_cast<const TOutplace *>(it);
+            it = Tuples_ + Layout_->TotalRowSize * outRow->Index;
+            return it;
+        }
+    } 
+
+    bool GetRowMatch(const ui8 *const it, const ui8 *const row, const ui8 *const overflow, const ui8 **matchedRow) const {
+        const THash &thash = reinterpret_cast<const THash &>(row[0]);
+
+        if (IsInplace_) {
+            const Hash matchRowHash = ReadUnaligned<Hash>(it);
+            if (matchRowHash != *thash) {
+                return false;
+            }
+            *matchedRow = it;
+        } else {
+            const auto *const outRow =
+                reinterpret_cast<const TOutplace *>(it);
+            if (outRow->Hash != *thash) {
+                return false;
+            }
+            *matchedRow = Tuples_ + Layout_->TotalRowSize * outRow->Index;
+        }
+
+        if (Layout_->KeysEqual(row, overflow, *matchedRow, Overflow_)) {
+            return true;
+        }
+        return false;
+    }
+
+  private:
+    const TTupleLayout * Layout_ = nullptr;
+
+    const ui8 *Tuples_ = nullptr;
+    const ui8 *Overflow_ = nullptr;
+
+    bool IsInplace_;
+    ui32 BufferSlotSize_;
+    ui32 RowIndexSize_;
+
+    unsigned DirectoryHashBits_;
+    unsigned DirectoryHashShift_;
+    Hash DirectoryHashMask_;
+
+    TAllocator Allocator_;
+    std::span<TDirectory> Directories_;
+    std::vector<ui8, TAllocator> DirectoriesData_;
+    std::vector<ui8, TAllocator> Buffer_;
+};
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.cpp
@@ -1,0 +1,205 @@
+#include "page_hash_table.h"
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+#include <arrow/util/bit_util.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+// -----------------------------------------------------------------
+THolder<TPageHashTable> TPageHashTable::Create(const TTupleLayout* layout, ui32) {
+    if (NX86::HaveAVX2()) {
+        return MakeHolder<TPageHashTableImpl<NSimd::TSimdAVX2Traits>>(layout);
+    }
+
+    if (NX86::HaveSSE42()) {
+        return MakeHolder<TPageHashTableImpl<NSimd::TSimdSSE42Traits>>(layout);
+    }
+
+    return MakeHolder<TPageHashTableImpl<NSimd::TSimdFallbackTraits>>(layout);
+}
+
+
+// -----------------------------------------------------------------
+template <typename TTraits, bool Prefetch>
+void TPageHashTableImpl<TTraits, Prefetch>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems) {
+    TotalPages_ = (nItems * SlotSize_ * 3 / 2 + PageSize_ - 1) / PageSize_;
+    const ui32 logTotalPages = arrow::BitUtil::NumRequiredBits(TotalPages_ - 1);
+    TotalPages_ = 1ul << logTotalPages;    
+    ProbeByteIndex_ = std::min<ui32>(32 - 8, logTotalPages);
+
+    Data_.assign(TotalPages_ * PageSize_, 0);
+
+    OriginalData_ = data;
+    OriginalOverflow_ = overflow;
+
+    constexpr ui32 prefetchInAdvance = 16;
+
+    if constexpr (Prefetch) {
+        for (ui32 i = 0; i < std::min<ui32>(prefetchInAdvance, nItems); i++) {
+            const ui8* tuple = OriginalData_ + i * TupleSize_;
+            ui32 hash = ReadUnaligned<ui32>(tuple);
+            ui64 pageNum = PageNum(hash);
+    
+            ui64 pagePos = pageNum * PageSize_;
+            ui8* pageAddr = Data_.data() + pagePos;
+
+            NYql::PrefetchForWrite(pageAddr);
+        }
+    }
+
+    for (ui32 i = 0; i < nItems; i++) {
+        if constexpr (Prefetch) {
+            if (i + prefetchInAdvance < nItems) {
+                const ui8* tuple = OriginalData_ + (i + prefetchInAdvance) * TupleSize_;
+                ui32 hash = ReadUnaligned<ui32>(tuple);
+                ui64 pageNum = PageNum(hash);
+        
+                ui64 pagePos = pageNum * PageSize_;
+                ui8* pageAddr = Data_.data() + pagePos;
+                
+                NYql::PrefetchForWrite(pageAddr);
+            }
+        }    
+
+        const ui8* tuple = OriginalData_ + i * TupleSize_;
+        ui32 hash = ReadUnaligned<ui32>(tuple);
+        ui64 pageNum = PageNum(hash);
+
+        ui64 pagePos = pageNum * PageSize_;
+        ui8* pageAddr = Data_.data() + pagePos;
+        ui8 filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+
+        while (filledSlotsCounter >= SlotsCount_) { // while page is completely filled
+            pageAddr += PageSize_;
+
+            if (pageAddr >= Data_.end()) { // cyclic buffer
+                pageAddr = Data_.data();
+            }
+
+            filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+        }
+
+        // found page with empty slot
+        pageAddr[filledSlotsCounter + 1] = (hash >> ProbeByteIndex_) & 0xFF;
+        pageAddr[0] = filledSlotsCounter + 1;
+
+        if (!IsEmbedded_) {
+            // put index to original buffer into slot
+            WriteUnaligned<ui32>(pageAddr + PageHeaderSize_ + SlotSize_ * filledSlotsCounter, i);
+        } else {
+            // copy tuple from original buffer into slot
+            std::memcpy(pageAddr + PageHeaderSize_ + SlotSize_ * filledSlotsCounter, tuple, TupleSize_);
+        }
+    }
+}
+
+template void TPageHashTableImpl<NSimd::TSimdFallbackTraits, false>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template __attribute__((target("avx2"))) void
+TPageHashTableImpl<NSimd::TSimdAVX2Traits, false>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template __attribute__((target("sse4.2"))) void
+TPageHashTableImpl<NSimd::TSimdSSE42Traits, false>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template void TPageHashTableImpl<NSimd::TSimdFallbackTraits, true>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template __attribute__((target("avx2"))) void
+TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+template __attribute__((target("sse4.2"))) void
+TPageHashTableImpl<NSimd::TSimdSSE42Traits, true>::Build(const ui8* data, const ui8 *const overflow, ui32 nItems);
+
+
+// -----------------------------------------------------------------
+template <typename TTraits, bool Prefetch>
+ui32 TPageHashTableImpl<TTraits, Prefetch>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems) {
+    Y_ASSERT(OriginalData_ != nullptr); // Build was called before Apply
+    using TSimd8 = typename TTraits:: template TSimd8<ui8>;
+
+    ui64 found = 0;
+
+    for (ui32 i = 0; i < nItems; i++) {
+        const ui8* tupleToFind = data + layout->TotalRowSize * i;
+        ui32 hash = ReadUnaligned<ui32>(tupleToFind);
+
+        ui64 pageNum = PageNum(hash);
+        ui64 pagePos = pageNum * PageSize_;
+        ui8* pageAddr = Data_.data() + pagePos;
+
+        while (true) { // Check all possible pages in collisions cycle
+            ui8 filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+            TSimd8 headerReg = TSimd8(reinterpret_cast<const ui8*>(pageAddr + 1));            // [<Probe byte 1> ... <Probe byte K>]
+            TSimd8 hashPartReg = TSimd8(static_cast<ui8>((hash >> ProbeByteIndex_) & 0xFF)); // [< Hash byte  > ... < Hash byte  >]
+            ui32 foundBitMask = (headerReg == hashPartReg).ToBitMask() & ((1ULL << filledSlotsCounter) - 1); // get all possible positions where desired tuples could be stored
+
+            ui32 nextSetPos = 0;
+            while (foundBitMask != 0) { // Check all possible matches in single page
+                ui32 moveMask = foundBitMask & -foundBitMask; // find least significant not null bit
+                nextSetPos = __builtin_ctzl(foundBitMask); // find position of least significant not null bit
+                foundBitMask ^= moveMask; // remove least significant not null bit
+
+                if (nextSetPos >= filledSlotsCounter) {
+                    break;
+                }
+
+                const ui8* tupleAddr;
+                // get address of tuple if it is embedded or if it is lays in original buffer
+                if (!IsEmbedded_) {
+                    ui32 index = ReadUnaligned<ui32>(pageAddr + PageHeaderSize_ + SlotSize_ * nextSetPos);
+                    tupleAddr = OriginalData_ + index * TupleSize_;
+                } else {
+                    tupleAddr = pageAddr + PageHeaderSize_ + SlotSize_ * nextSetPos;
+                }
+
+                if (Layout_->KeysEqual(tupleAddr, OriginalOverflow_, tupleToFind, overflow.data())) {
+                    found++;
+                }
+            }
+
+            if (filledSlotsCounter < SlotsCount_) { // Page has empty slots, i.e. there will definitely be no further occurrences
+                break;
+            }
+
+            pageAddr += PageSize_;
+            if (pageAddr >= Data_.end()) { // cyclic buffer
+                pageAddr = Data_.data();
+            }
+        }
+    }
+
+    return found;
+}
+
+template ui32 TPageHashTableImpl<NSimd::TSimdFallbackTraits, false>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template __attribute__((target("avx2"))) ui32
+TPageHashTableImpl<NSimd::TSimdAVX2Traits, false>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template __attribute__((target("sse4.2"))) ui32
+TPageHashTableImpl<NSimd::TSimdSSE42Traits, false>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template ui32 TPageHashTableImpl<NSimd::TSimdFallbackTraits, true>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template __attribute__((target("avx2"))) ui32
+TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+template __attribute__((target("sse4.2"))) ui32
+TPageHashTableImpl<NSimd::TSimdSSE42Traits, true>::FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems);
+
+// -----------------------------------------------------------------
+template <typename TTraits, bool Prefetch>
+void TPageHashTableImpl<TTraits, Prefetch>::Clear() {
+    if (OriginalData_ == nullptr) {
+        return;
+    }
+
+    OriginalData_ = nullptr;
+    for (ui32 i = 0; i < TotalPages_; i++) {
+        ui8* pageAddr = Data_.data() + i * PageSize_;
+        std::memset(pageAddr, 0, PageHeaderSize_);
+    }
+}
+
+template void TPageHashTableImpl<NSimd::TSimdFallbackTraits, false>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdSSE42Traits, false>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdAVX2Traits, false>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdFallbackTraits, true>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdSSE42Traits, true>::Clear();
+template void TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>::Clear();
+
+}
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.cpp
@@ -1,7 +1,5 @@
 #include "page_hash_table.h"
 
-#include <ydb/library/yql/utils/simd/simd.h>
-
 #include <arrow/util/bit_util.h>
 
 namespace NKikimr {

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.h
@@ -1,0 +1,296 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/public/udf/udf_value.h>
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+#include <yql/essentials/utils/prefetch.h>
+
+#include <util/generic/buffer.h>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+
+/*
+* Class TPageHashTable provides open address hash table implementation for packed tuples.
+*
+* TPageHashTable has the following layout:
+* HashTable:    [Page 1][Page 2]...[Page N]
+* Page:         [<Header> <Slot 1> <Slot 2> ... <Slot K>]
+* Header:       [<Filled slots counter (1 byte)> <Probe byte 1> ... <Probe byte K>]
+*/
+class TPageHashTable {
+public:
+    class TIterator;
+
+protected:
+    struct TIteratorImpl {
+        static TIteratorImpl& UpCast(TIterator& iter) {
+            return static_cast<TIteratorImpl&>(iter);
+        }
+        TIterator& DownCast() {
+            return static_cast<TIterator&>(*this);
+        }
+        
+        TIteratorImpl(): PageAddr_(nullptr) {}
+
+    public:
+        const ui8* Row_;
+        const ui8* PageAddr_;
+        ui32 FoundBitMask_; 
+        ui8 HashByte_;
+    };
+
+public:
+    class TIterator : private TIteratorImpl {
+        friend TIteratorImpl;
+
+    public:
+        TIterator() = default;
+        TIterator(const TIterator&) = default;
+        TIterator& operator=(const TIterator&) = default;
+    };
+
+    virtual ~TPageHashTable() {};
+
+    // Creates hash table for given layout with given capacity
+    static THolder<TPageHashTable> Create(const TTupleLayout* layout, ui32 capacity);
+
+    // Build new hash table on passed data.
+    // Data must be presented as a TupleLayout.
+    virtual void Build(const ui8* data, const ui8 *const overflow, ui32 nItems) = 0;
+
+    // Finds matches in hash table
+    // This method is temporary. It is expected that this method will return a batch of found tuples
+    virtual ui32 FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems) = 0;
+
+    // Clears hash table content
+    virtual void Clear() = 0;
+};
+
+
+// -----------------------------------------------------------------
+template <typename TTraits, bool Prefetch = true>
+class TPageHashTableImpl: public TPageHashTable {
+public:
+    TPageHashTableImpl() = default;
+
+    explicit TPageHashTableImpl(const TTupleLayout* layout) {
+        SetTupleLayout(layout);
+    }
+
+    void SetTupleLayout(const TTupleLayout *layout) {
+        Clear();
+
+        TupleSize_ = layout->TotalRowSize;
+        Layout_ = layout;
+
+        IsEmbedded_ = TupleSize_ <= SlotSize_; // this flag used to dispatch where to store tuple
+    }
+
+    TPageHashTableImpl(const TPageHashTableImpl &) = delete;
+    void operator=(const TPageHashTableImpl &) = delete;
+
+    void Build(const ui8* data, const ui8 *const overflow, ui32 nItems) override;
+
+    ui32 FindMatches(const TTupleLayout* layout, const ui8* data, const std::vector<ui8, TMKQLAllocator<ui8>>& overflow, ui32 nItems) override;
+    void Apply(const ui8 *const row, const ui8 *const overflow, auto &&onMatch);
+
+    void Clear() override;
+
+    Y_FORCE_INLINE const ui8 *NextMatch(TPageHashTable::TIterator &iter, const ui8 *overflow) const;
+    TIterator Find(const ui8 *const row, const ui8 *const overflow) const;
+
+    template <size_t Size>
+    std::array<TIterator, Size>
+    FindBatch(const std::array<const ui8 *, Size> &rows,
+              const ui8 *const overflow) const;
+
+private:
+    ui64 PageNum(ui64 hash) const {
+        return hash & (TotalPages_ - 1);
+    }
+
+private:
+    static constexpr ui32 SlotSize_{16};              // Amount of memory allocated per one slot
+    static constexpr ui32 SlotsCount_{TTraits::Size}; // Count of slots per page
+    static constexpr ui32 PageHeaderSize_{SlotsCount_ + 1};  // Size in bytes of the hash table page header. Page consists of header plus slots
+    static constexpr ui32 PageSize_{PageHeaderSize_ + SlotSize_ * SlotsCount_};  // Page size in bytes
+
+    ui32    TupleSize_{0};              // Amount of memory allocated per one tuple
+    bool    IsEmbedded_{false};
+    ui32    TotalPages_{0};             // Total number of pages in hash table
+    ui32    ProbeByteIndex_{0};
+
+    const TTupleLayout*                     Layout_{nullptr};   // Tuple layout description
+    std::vector<ui8, TMKQLAllocator<ui8>>   Data_;              // Place to store hash table data
+    const ui8*                              OriginalData_{nullptr};     // Data passed to build method
+    const ui8*                              OriginalOverflow_{nullptr}; // Overflow data passed to build method
+};
+
+template <typename TTraits, bool Prefetch>
+void TPageHashTableImpl<TTraits, Prefetch>::Apply(const ui8 *const row, const ui8 *const overflow, auto &&onMatch) {
+    Y_ASSERT(OriginalData_ != nullptr); // Build was called before Apply
+    using TSimd8 = typename TTraits:: template TSimd8<ui8>;
+    
+    ui32 hash = ReadUnaligned<ui32>(row);
+
+    ui64 pageNum = PageNum(hash);
+    ui64 pagePos = pageNum * PageSize_;
+    ui8* pageAddr = Data_.data() + pagePos;
+
+    while (true) { // Check all possible pages in collisions cycle
+        ui8 filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+        TSimd8 headerReg = TSimd8(reinterpret_cast<const ui8*>(pageAddr + 1));            // [<Probe byte 1> ... <Probe byte K>]
+        TSimd8 hashPartReg = TSimd8(static_cast<ui8>((hash >> ProbeByteIndex_) & 0xFF)); // [< Hash byte  > ... < Hash byte  >]
+        ui32 foundBitMask = (headerReg == hashPartReg).ToBitMask() & ((1ULL << filledSlotsCounter) - 1); // get all possible positions where desired tuples could be stored
+
+        ui32 nextSetPos = 0;
+        while (foundBitMask != 0) { // Check all possible matches in single page
+            ui32 moveMask = foundBitMask & -foundBitMask; // find least significant not null bit
+            nextSetPos = __builtin_ctzl(foundBitMask); // find position of least significant not null bit
+            foundBitMask ^= moveMask; // remove least significant not null bit
+
+            if (nextSetPos >= filledSlotsCounter) {
+                break;
+            }
+
+            const ui8* tupleAddr;
+            // get address of tuple if it is embedded or if it is lays in original buffer
+            if (!IsEmbedded_) {
+                ui32 index = ReadUnaligned<ui32>(pageAddr + PageHeaderSize_ + SlotSize_ * nextSetPos);
+                tupleAddr = OriginalData_ + index * TupleSize_;
+            } else {
+                tupleAddr = pageAddr + PageHeaderSize_ + SlotSize_ * nextSetPos;
+            }
+
+            // compare keys
+            if (Layout_->KeysEqual(tupleAddr, OriginalOverflow_, row, overflow)) {
+                onMatch(tupleAddr);
+            }            
+        }
+
+        if (filledSlotsCounter < SlotsCount_) { // Page has empty slots, i.e. there will definitely be no further occurrences
+            break;
+        }
+
+        pageAddr += PageSize_;
+        if (pageAddr >= Data_.end()) { // cyclic buffer
+            pageAddr = Data_.data();
+        }
+    }
+}
+
+template <typename TTraits, bool Prefetch>
+const ui8 *TPageHashTableImpl<TTraits, Prefetch>::NextMatch(TPageHashTable::TIterator &it, const ui8 *overflow) const {
+    using TSimd8 = typename TTraits:: template TSimd8<ui8>;
+
+    auto &iter = TIteratorImpl::UpCast(it);
+    if (iter.PageAddr_ == nullptr) {
+        return nullptr;
+    }
+
+    for (;;) { // Check all possible pages in collisions cycle
+        const ui8 filledSlotsCounter = ReadUnaligned<ui8>(iter.PageAddr_);
+
+        ui32 nextSetPos = 0;
+        while (iter.FoundBitMask_ != 0) { // Check all possible matches in single page
+            ui32 moveMask = iter.FoundBitMask_ & -iter.FoundBitMask_; // find least significant not null bit
+            nextSetPos = __builtin_ctzl(iter.FoundBitMask_); // find position of least significant not null bit
+            iter.FoundBitMask_ ^= moveMask; // remove least significant not null bit
+
+            if (nextSetPos >= filledSlotsCounter) {
+                break;
+            }
+
+            const ui8* tupleAddr;
+            // get address of tuple if it is embedded or if it is lays in original buffer
+            if (!IsEmbedded_) {
+                ui32 index = ReadUnaligned<ui32>(iter.PageAddr_ + PageHeaderSize_ + SlotSize_ * nextSetPos);
+                tupleAddr = OriginalData_ + index * TupleSize_;
+            } else {
+                tupleAddr = iter.PageAddr_ + PageHeaderSize_ + SlotSize_ * nextSetPos;
+            }
+
+            if (Layout_->KeysEqual(tupleAddr, OriginalOverflow_, iter.Row_, overflow)) {
+                return tupleAddr;
+            }
+        }
+
+        if (filledSlotsCounter < SlotsCount_) { // Page has empty slots, i.e. there will definitely be no further occurrences
+            iter = {};
+            break;
+        }
+
+        iter.PageAddr_ += PageSize_;
+        if (iter.PageAddr_ >= Data_.end()) { // cyclic buffer
+            iter.PageAddr_ = Data_.data();
+        }
+
+        const TSimd8 headerReg = TSimd8(reinterpret_cast<const ui8*>(iter.PageAddr_ + 1)); // [<Probe byte 1> ... <Probe byte K>]
+        const TSimd8 hashPartReg = TSimd8(iter.HashByte_); // [< Hash byte  > ... < Hash byte  >]
+        iter.FoundBitMask_ = (headerReg == hashPartReg).ToBitMask() & ((1ULL << filledSlotsCounter) - 1); // get all possible positions where desired tuples could be stored
+    }
+
+    return nullptr;
+}
+
+template <typename TTraits, bool Prefetch>
+typename TPageHashTableImpl<TTraits, Prefetch>::TIterator
+TPageHashTableImpl<TTraits, Prefetch>::Find(const ui8 *const row,
+                                            const ui8 *const /*overflow*/) const {
+    using TSimd8 = typename TTraits:: template TSimd8<ui8>;
+
+    const ui32 hash = ReadUnaligned<ui32>(row);
+    const ui64 pageNum = PageNum(hash);
+    const ui64 pagePos = pageNum * PageSize_;
+    const ui8 *const pageAddr = Data_.data() + pagePos;
+    const ui8 filledSlotsCounter = ReadUnaligned<ui8>(pageAddr);
+    const TSimd8 headerReg = TSimd8(reinterpret_cast<const ui8*>(pageAddr + 1));            // [<Probe byte 1> ... <Probe byte K>]
+    const TSimd8 hashPartReg = TSimd8(static_cast<ui8>((hash >> ProbeByteIndex_) & 0xFF)); // [< Hash byte  > ... < Hash byte  >]
+    const ui32 foundBitMask = (headerReg == hashPartReg).ToBitMask() & ((1ULL << filledSlotsCounter) - 1);
+    const ui8 hashByte = (hash >> ProbeByteIndex_) & 0xFF;
+
+    TIteratorImpl iter;
+    iter.Row_ = row;
+    iter.PageAddr_ = pageAddr;
+    iter.FoundBitMask_ = foundBitMask;
+    iter.HashByte_ = hashByte;
+
+    return iter.DownCast();
+}
+
+template <typename TTraits, bool Prefetch>
+template <size_t Size>
+std::array<typename TPageHashTableImpl<TTraits, Prefetch>::TIterator, Size>
+TPageHashTableImpl<TTraits, Prefetch>::FindBatch(
+    const std::array<const ui8 *, Size> &rows,
+    const ui8 *const overflow) const {
+    if constexpr (Prefetch) {
+        for (ui32 i = 0; i < Size && rows[i]; i++) {
+            const ui32 hash = ReadUnaligned<ui32>(rows[i]);
+            const ui64 pageNum = PageNum(hash);
+            const ui64 pagePos = pageNum * PageSize_;
+            const ui8 *const pageAddr = Data_.data() + pagePos;;
+            NYql::PrefetchForRead(pageAddr);
+        }
+    }
+
+    std::array<TIterator, Size> iters;
+    for (ui32 i = 0; i < Size && rows[i]; i++) {
+        iters[i] = Find(rows[i], overflow);
+    }
+
+    return iters;
+}
+
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.h
@@ -8,7 +8,7 @@
 
 #include <util/generic/buffer.h>
 
-#include <ydb/library/yql/utils/simd/simd.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/simd/simd.h>
 
 #include "tuple.h"
 

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/robin_hood_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/robin_hood_table.h
@@ -1,0 +1,657 @@
+#pragma once
+
+#include <util/generic/bitops.h>
+#include <util/generic/yexception.h>
+#include <util/system/compiler.h>
+#include <util/system/types.h>
+
+#include <yql/essentials/minikql/mkql_rh_hash_utils.h>
+#include <yql/essentials/utils/prefetch.h>
+
+#include <ydb/library/yql/utils/simd/simd.h>
+
+#include <util/digest/city.h>
+#include <util/generic/scope.h>
+
+#include "tuple.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+struct TTupleEqual {
+    bool operator()(const TTupleLayout *layout, const ui8 *lhsRow,
+                    const ui8 *lhsOverflow, const ui8 *rhsRow,
+                    const ui8 *rhsOverflow) const {
+        return layout->KeysEqual(lhsRow, lhsOverflow, rhsRow, rhsOverflow);
+    }
+};
+
+struct TTupleHash {
+    ui32 operator()(const TTupleLayout * /*layout*/, const ui8 *tuple,
+                    const ui8 * /*overflow*/) const {
+        return ((const ui32 *)tuple)[0];
+    }
+};
+
+template <bool ConsecutiveDuplicates = true, bool Prefetch = true,
+          typename TAllocator = TMKQLAllocator<ui8>>
+class TRobinHoodHashBase {
+    using TEqual = TTupleEqual;
+    using THash = TTupleHash;
+
+    struct TCellStatus {
+        /// TODO: default: ui32
+        ///       ui16 for testing embedded case of map[ui32] -> ui32
+        using T = ui16; 
+
+        static constexpr T kInvalid = 0;
+        static constexpr T kStart = 2;
+
+        bool IsValid() const { return value; }
+        bool IsList() const { return value & 1; }
+        void ToList() { value = value | 1; }
+        void operator++() { value += 2; }
+        bool operator<(TCellStatus rhs) const { return value < rhs.value; }
+
+      public:
+      T value = kStart;
+    };
+
+    struct TPSLStorage {
+        TCellStatus CellStatus;
+
+        TPSLStorage() = default;
+        TPSLStorage(ui32 /*hash*/) : CellStatus(TCellStatus::kStart) {}
+    };
+
+    struct TPSLOutStorage : TPSLStorage, TIndexedTuple {
+        ui32 DupIndex;
+
+        TPSLOutStorage() = default;
+        TPSLOutStorage(ui32 hash, ui32 outIndex)
+            : TPSLStorage(hash), TIndexedTuple{hash, outIndex} {}
+    };
+
+    static constexpr ui32 kEmbeddedSize = 16;
+    static_assert(sizeof(TPSLOutStorage) <= kEmbeddedSize);
+
+    static constexpr ui32 RoundUp(ui32 n, ui32 r) {
+        return ((n + r - 1) / r) * r;
+    }
+
+  public:
+    struct TIterator {
+        friend TRobinHoodHashBase;
+
+      public:
+        TIterator(): Matched_(nullptr), Len_(0) {}
+
+      private:
+        const ui8 *Matched_;
+        ui32 Len_;
+    };
+
+  public:
+    TRobinHoodHashBase() : SelfHash_(GetSelfHash(this)), DupSeq_(Allocator_) {
+        // Init(256);
+    }
+
+    explicit TRobinHoodHashBase(const TTupleLayout *layout)
+        : TRobinHoodHashBase() {
+        SetTupleLayout(layout);
+    }
+
+    ~TRobinHoodHashBase() {
+        if (Data_) {
+            Allocator_.deallocate(Data_, DataEnd_ - Data_);
+        }
+    }
+
+    void SetTupleLayout(const TTupleLayout *layout) {
+        Clear();
+
+        Layout_ = layout;
+        /// whole tuple and tuple key with index can be embedded
+        IsInplace_ = sizeof(TPSLStorage) + layout->TotalRowSize <= kEmbeddedSize && 
+                     sizeof(TPSLStorage) + layout->PayloadOffset + sizeof(ui32) <= kEmbeddedSize;
+        // CellSize_ = IsInplace_
+        //     ? RoundUp(sizeof(TPSLStorage) + std::max<ui32>(layout->TotalRowSize,
+        //                                                    layout->PayloadOffset + sizeof(ui32)),
+        //               sizeof(ui32))
+        //     : sizeof(TPSLOutStorage);
+        DupPayloadSize_ = IsInplace_ ? Layout_->TotalRowSize : sizeof(ui32);
+
+        /// size may be stored in dup cell
+        Y_ASSERT(DupPayloadSize_ >= sizeof(ui32));
+    }
+
+    TRobinHoodHashBase(const TRobinHoodHashBase &) = delete;
+    TRobinHoodHashBase(TRobinHoodHashBase &&) = delete;
+    void operator=(const TRobinHoodHashBase &) = delete;
+    void operator=(TRobinHoodHashBase &&) = delete;
+
+    Y_FORCE_INLINE const ui8 *NextMatch(TIterator &iter, const ui8 * /*overflow*/) const {
+        const ui8 *result = nullptr;
+
+        if constexpr (ConsecutiveDuplicates) {
+            if (iter.Len_) { /// allow multiple false calls
+                result = iter.Matched_;
+                iter.Matched_ += DupPayloadSize_;
+                iter.Len_--;
+            }
+        } else {
+            if (iter.Matched_) { /// allow multiple false calls
+                result = iter.Matched_;
+                if (!iter.Len_) {
+                    iter.Matched_ = nullptr;
+                } else {
+                    ui32 dupIndex = ReadUnaligned<ui32>(iter.Matched_ + DupPayloadSize_);
+                    iter.Matched_ = dupIndex == -1u
+                                    ? nullptr
+                                    : &DupSeq_[dupIndex * (DupPayloadSize_ + sizeof(ui32))];
+                }
+            }
+        }
+
+        if (!IsInplace_ && result) {
+            result = GetTupleOut(ReadUnaligned<ui32>(result));
+        }
+
+        return result;
+    }
+
+    Y_FORCE_INLINE TIterator Find(const ui8 *const tuple, const ui8 *const overflow) const {
+        const ui32 hash = TupleHash_(Layout_, tuple, overflow);
+        auto ptr = GetPtr(hash, Data_, CapacityShift_);
+        return FindImpl(hash, ptr, tuple, overflow);
+    }
+
+    template <size_t Size>
+    Y_FORCE_INLINE std::array<TIterator, Size>
+    FindBatch(const std::array<const ui8 *, Size> &tuples,
+              const ui8 *const overflow) const {
+        if constexpr (Prefetch) {
+            for (ui32 index = 0; index < Size && tuples[index]; ++index) {
+                const ui32 hash = TupleHash_(Layout_, tuples[index], overflow);
+                auto ptr = GetPtr(hash, Data_, CapacityShift_);
+                NYql::PrefetchForRead(ptr);
+            }
+        }
+
+        std::array<TIterator, Size> iters;
+        for (ui32 index = 0; index < Size && tuples[index]; ++index) {
+            iters[index] = Find(tuples[index], overflow);
+        }
+
+        return iters;
+    }
+
+    Y_FORCE_INLINE void Apply(const ui8 *const tuple, const ui8 *const overflow,
+                              auto &&onMatch) {
+        auto iter = Find(tuple, overflow);
+        while (auto matched = NextMatch(iter, overflow)) {
+            onMatch(matched);
+        }
+    }
+
+    void Build(const ui8 *const tuples, const ui8 *const overflow,
+               ui32 nItems) {
+        Y_ASSERT(Size_ == 0 && Listed_ == 0 && ListedUnique_ == 0);
+
+        Tuples_ = tuples;
+        Overflow_ = overflow;
+
+        /// heuristic to decrease number of growths
+        constexpr ui32 preallocFactor = 16;
+        if (RHHashTableNeedsGrow(nItems / preallocFactor, Capacity_)) {
+            Grow(nItems / preallocFactor);
+        }
+
+        auto duplicates = TVector<ui8, TAllocator>(Allocator_);
+
+        constexpr ui32 prefetchInAdvance = 16;
+
+        if constexpr (Prefetch) {
+            for (ui32 index = 0; index < std::min(prefetchInAdvance, nItems); ++index) {
+                const ui8 *const tuple = Tuples_ + index * Layout_->TotalRowSize;
+                const auto hash = TupleHash_(Layout_, tuple, Overflow_);
+                const auto ptr = GetPtr(hash, Data_, CapacityShift_);
+                NYql::PrefetchForWrite(ptr);
+            }
+        }
+
+        for (ui32 index = 0; index < nItems; ++index) {
+            if (RHHashTableNeedsGrow(Size_, Capacity_)) {
+                Grow(Size_);
+            }
+
+            if constexpr (Prefetch) {
+                if (index + prefetchInAdvance < nItems) {
+                    const ui8 *const tuple = Tuples_ + (index + prefetchInAdvance) * Layout_->TotalRowSize;
+                    const auto hash = TupleHash_(Layout_, tuple, Overflow_);
+                    const auto ptr = GetPtr(hash, Data_, CapacityShift_);
+                    NYql::PrefetchForWrite(ptr);
+                }
+            }    
+
+            const ui8 *const tuple = Tuples_ + index * Layout_->TotalRowSize;
+            const auto hash = TupleHash_(Layout_, tuple, Overflow_);
+            const auto ptr = GetPtr(hash, Data_, CapacityShift_);
+
+            ui8 cell[kEmbeddedSize];
+            if (IsInplace_) {
+                new (cell) TPSLStorage(hash);
+                std::memcpy(GetTuple(cell), tuple, Layout_->TotalRowSize);
+            } else {
+                new (cell) TPSLOutStorage(hash, index);
+            }
+
+            Size_ += InsertImpl(cell, hash, ptr, Data_, DataEnd_, duplicates,
+                               EqualInsertHandler);
+        }
+
+        if (Listed_ == 0) {
+            return;
+        }
+
+        if constexpr (!ConsecutiveDuplicates) {
+            DupSeq_ = std::move(duplicates);
+            return;
+        }
+
+        DupSeq_.resize((Listed_ + ListedUnique_) * DupPayloadSize_);
+        ui32 dupSeqIndex = 0;
+
+        for (auto ptr = Data_; ptr != DataEnd_; ptr += CellSize_) {
+            auto &ptrPsl = GetPSL(ptr);
+            if (!ptrPsl.CellStatus.IsValid() || !ptrPsl.CellStatus.IsList()) {
+                continue;
+            }
+            
+            ui32 &ptrDupIndex = IsInplace_ ? GetDupIndex(ptr) : GetPSLOut(ptr).DupIndex;
+            ui32 dupIndex = ptrDupIndex; 
+            ptrDupIndex = dupSeqIndex;
+
+            ui32 &ptrSize = *(ui32 *)(DupSeq_.data() + dupSeqIndex * DupPayloadSize_);
+            ptrSize = 0;
+            ui8 *ptrDupSeq = DupSeq_.data() + (dupSeqIndex + 1) * DupPayloadSize_;
+            ++dupSeqIndex;
+
+            while (dupIndex != -1u) {
+                const auto *const ptrDup =
+                    &duplicates[dupIndex * (DupPayloadSize_ + sizeof(ui32))];
+                std::memcpy(ptrDupSeq, ptrDup, DupPayloadSize_);
+                
+                ptrDupSeq += DupPayloadSize_;
+                ++ptrSize;
+                dupIndex = ReadUnaligned<ui32>(ptrDup + DupPayloadSize_);
+                ++dupSeqIndex;
+            }
+        }
+    }
+
+    void Clear() {
+        if (Size_ != 0) {
+            ui8 *ptr = Data_;
+            for (ui64 i = 0; i < Capacity_; ++i, ptr += CellSize_) {
+                GetPSL(ptr).CellStatus.value = TCellStatus::kInvalid;
+            }
+        }
+
+        Size_ = 0;
+        Listed_ = 0;
+        ListedUnique_ = 0;
+
+        Tuples_ = nullptr;
+        Overflow_ = nullptr;
+    }
+
+  private:
+    ui8 *GetPtr(const ui64 hash, ui8 *data, ui64 capacityShift) const {
+        // https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
+        ui64 bucket = ((SelfHash_ ^ hash) * 11400714819323198485llu) >> capacityShift;
+        ui8 *ptr = data + CellSize_ * bucket;
+        return ptr;
+    }
+
+    static ui8 *GetTuple(ui8 *ptr) { return ptr + sizeof(TPSLStorage); }
+
+    const ui8 *GetTupleOut(ui32 index) const {
+        return Tuples_ + index * Layout_->TotalRowSize;
+    }
+
+    static TPSLStorage &GetPSL(ui8 *ptr) { return *(TPSLStorage *)ptr; }
+
+    static TPSLOutStorage &GetPSLOut(ui8 *ptr) {
+        return *(TPSLOutStorage *)ptr;
+    }
+
+    ui32 &GetDupIndex(ui8 *ptr) const {
+        return *(ui32 *)(ptr + CellSize_ - sizeof(ui32));
+    }
+
+    void CopyCell(ui8 *dst, const ui8 *src) {
+        std::memcpy(dst, src, CellSize_);
+    }
+
+    void SwapCells(ui8 *lhs, ui8 *rhs) {
+        ui8 buf[kEmbeddedSize];
+        std::memcpy(buf, lhs, CellSize_);
+        std::memcpy(lhs, rhs, CellSize_);
+        std::memcpy(rhs, buf, CellSize_);
+    }
+
+    Y_FORCE_INLINE TIterator FindImpl(ui32 hash, ui8* ptr, const ui8 *const tuple, const ui8 *const overflow) const {
+        TCellStatus currCellStatus;
+        TIterator iter;
+
+        for (;;) {
+            auto &ptrPsl = GetPSL(ptr);
+            if (ptrPsl.CellStatus < currCellStatus) {
+                return iter;
+            }
+
+            auto onCell = [&](const ui8 *matched) { 
+                iter.Matched_ = matched;
+                if constexpr (ConsecutiveDuplicates) {
+                    iter.Len_ = 1;
+                }
+            };
+            auto onList = [&](const ui8 *matched) {
+                if constexpr (ConsecutiveDuplicates) {
+                    iter.Len_ = ReadUnaligned<ui32>(matched);
+                    iter.Matched_ = matched + DupPayloadSize_;
+                    if constexpr (Prefetch) {
+                        NYql::PrefetchForRead(iter.Matched_);
+                    }
+                } else {
+                    iter.Len_ = true; /// used as flag
+                    iter.Matched_ = matched;
+                }
+            };
+
+            if (OnEqual<!ConsecutiveDuplicates>(
+                    hash, ptr, DupSeq_, tuple, overflow,
+                    onCell, onList, onCell, onList)) {
+                return iter;
+            }
+
+            ++currCellStatus;
+            AdvancePointer(ptr, Data_, DataEnd_);
+        }
+    }
+
+    template <bool Offseted>
+    Y_FORCE_INLINE bool
+    OnEqual(ui32 hash, ui8 *ptr, const TVector<ui8, TAllocator> &duplicates,
+            const ui8 *tuple, const ui8 *overflow, auto FInplaceCell,
+            auto FInplaceList, auto FOutplaceCell, auto FOutplaceList) const {
+        static constexpr ui32 dupOffset = Offseted ? sizeof(ui32) : 0;
+
+        auto &ptrPsl = GetPSL(ptr);
+
+        if (IsInplace_) {
+            auto *const ptrTuple = GetTuple(ptr);
+
+            if (TuplesEqual_(Layout_, ptrTuple, Overflow_, tuple, overflow)) {
+                if (!ptrPsl.CellStatus.IsList()) {
+                    FInplaceCell(ptrTuple);
+                } else {
+                    const ui32 dupIndex = GetDupIndex(ptr);
+                    auto *const ptrDup =
+                        &duplicates[dupIndex * (DupPayloadSize_ + dupOffset)];
+                    FInplaceList(ptrDup);
+                }
+
+                return true;
+            }
+        } else {
+            auto &ptrPsl = GetPSLOut(ptr);
+            auto *const ptrTuple = GetTupleOut(ptrPsl.Index);
+
+            if (ptrPsl.Hash != hash) {
+                return false;
+            }
+
+            if (TuplesEqual_(Layout_, ptrTuple, Overflow_, tuple, overflow)) {
+                if (!ptrPsl.CellStatus.IsList()) {
+                    FOutplaceCell((ui8 *)&ptrPsl.Index);
+                } else {
+                    auto *const ptrDup =
+                        &duplicates[ptrPsl.DupIndex * (DupPayloadSize_ + dupOffset)];
+                    FOutplaceList(ptrDup);
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    Y_FORCE_INLINE bool InsertImpl(ui8 *const newRow, const ui32 hash, ui8 *ptr,
+                                   ui8 *const data, ui8 *const dataEnd,
+                                   TVector<ui8, TAllocator> &duplicates,
+                                   auto EqualHandler) {
+        auto &psl = GetPSL(newRow);
+
+        for (;;) {
+            auto &ptrPsl = GetPSL(ptr);
+            if (!ptrPsl.CellStatus.IsValid()) {
+                CopyCell(ptr, newRow);
+                return true;
+            }
+
+            if (EqualHandler(*this, newRow, hash, ptr, duplicates)) {
+                return false;
+            }
+
+            if (ptrPsl.CellStatus < psl.CellStatus) {
+                SwapCells(ptr, newRow);
+                ++psl.CellStatus;
+                AdvancePointer(ptr, data, dataEnd);
+                break;
+            }
+
+            ++psl.CellStatus;
+            AdvancePointer(ptr, data, dataEnd);
+        }
+
+        for (;;) {
+            auto &ptrPsl = GetPSL(ptr);
+            if (!ptrPsl.CellStatus.IsValid()) {
+                CopyCell(ptr, newRow);
+                return true;
+            }
+
+            if (ptrPsl.CellStatus < psl.CellStatus) {
+                SwapCells(ptr, newRow);
+            }
+
+            ++psl.CellStatus;
+            AdvancePointer(ptr, data, dataEnd);
+        }
+
+        return true;
+    }
+
+    Y_FORCE_INLINE static bool
+    EqualInsertHandler(TRobinHoodHashBase &self, ui8 *const newRow,
+                       const ui32 hash, ui8 *ptr,
+                       TVector<ui8, TAllocator> &duplicates) {
+        const ui8 *const tuple =
+            self.IsInplace_ ? GetTuple(newRow)
+                            : self.GetTupleOut(GetPSLOut(newRow).Index);
+
+        return self.OnEqual<true>(
+            hash, ptr, duplicates, tuple, self.Overflow_,
+            [&](const ui8 * /*matched*/) {
+                ui8 *ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                std::memcpy(ptrDup, GetTuple(ptr), self.DupPayloadSize_);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, -1u);
+
+                ++self.Listed_;
+
+                ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                std::memcpy(ptrDup, tuple, self.DupPayloadSize_);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, self.Listed_ - 1);
+
+                auto &ptrPsl = GetPSL(ptr);
+                self.GetDupIndex(ptr) = self.Listed_;
+                ptrPsl.CellStatus.ToList();
+
+                ++self.Listed_;
+                ++self.ListedUnique_;
+            },
+            [&](const ui8 * /*matched*/) {
+                auto &dupIndex = self.GetDupIndex(ptr);
+
+                ui8 *ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                std::memcpy(ptrDup, tuple, self.DupPayloadSize_);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, dupIndex);
+
+                dupIndex = self.Listed_;
+
+                ++self.Listed_;
+            },
+            [&](const ui8 * /*matched*/) {
+                auto &ptrPsl = GetPSLOut(ptr);
+
+                ui8 *ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                WriteUnaligned<ui32>(ptrDup, ptrPsl.Index);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, -1u);
+
+                ++self.Listed_;
+
+                ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                WriteUnaligned<ui32>(ptrDup, GetPSLOut(newRow).Index);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, self.Listed_ - 1);
+
+                ptrPsl.DupIndex = self.Listed_;
+                ptrPsl.CellStatus.ToList();
+
+                ++self.Listed_;
+                ++self.ListedUnique_;
+            },
+            [&](const ui8 * /*matched*/) {
+                auto &ptrPsl = GetPSLOut(ptr);
+
+                ui8 *ptrDup = self.GetDuplicatesData(duplicates, self.Listed_);
+                WriteUnaligned<ui32>(ptrDup, GetPSLOut(newRow).Index);
+                WriteUnaligned<ui32>(ptrDup + self.DupPayloadSize_, ptrPsl.DupIndex);
+
+                ptrPsl.DupIndex = self.Listed_;
+
+                ++self.Listed_;
+            });
+    }
+
+    Y_FORCE_INLINE ui8 *GetDuplicatesData(TVector<ui8, TAllocator> &duplicates, ui32 ind) {
+        const ui32 dupCellSize = DupPayloadSize_ + sizeof(ui32);
+        if (duplicates.size() <= ind * dupCellSize) {
+            duplicates.resize_uninitialized(
+                std::max(64ul * dupCellSize, duplicates.size() * 2));
+        }
+
+        return duplicates.data() + ind * dupCellSize;
+    }
+
+    Y_FORCE_INLINE void AdvancePointer(ui8 *&ptr, ui8 *begin, ui8 *end) const {
+        ptr += CellSize_;
+        ptr = (ptr == end) ? begin : ptr;
+    }
+
+    static ui64 GetSelfHash(void *self) {
+        char buf[sizeof(void *)];
+        *(void **)buf = self;
+        return CityHash64(buf, sizeof(buf));
+    }
+
+    void Init(ui64 capacity) {
+        Y_ASSERT((capacity & (capacity - 1)) == 0);
+        Capacity_ = capacity;
+        CapacityShift_ = 64 - MostSignificantBit(capacity);
+        Allocate(Capacity_, Data_, DataEnd_);
+    }
+
+    void Grow(ui64 size) {
+        auto newCapacity = CalculateRHHashTableCapacity(size);
+        Y_ASSERT((newCapacity & (newCapacity - 1)) == 0);
+        auto newCapacityShift = 64 - MostSignificantBit(newCapacity);
+        ui8 *newData, *newDataEnd;
+        Allocate(newCapacity, newData, newDataEnd);
+
+        for (auto cell = Data_; cell != DataEnd_; cell += CellSize_) {
+            auto &psl = GetPSL(cell);
+            if (!psl.CellStatus.IsValid()) {
+                continue;
+            }
+
+            const ui32 hash =
+                IsInplace_ ? TupleHash_(Layout_, GetTuple(cell), Overflow_)
+                           : GetPSLOut(cell).Hash;
+            const auto ptr = GetPtr(hash, newData, newCapacityShift);
+
+            if (psl.CellStatus.IsList()) {
+                psl.CellStatus.value = TCellStatus::kStart;
+                psl.CellStatus.ToList();
+            } else {
+                psl.CellStatus.value = TCellStatus::kStart;
+            }
+
+            InsertImpl(cell, hash, ptr, newData, newDataEnd, DupSeq_,
+                       [](auto &&...) { return false; });
+        }
+
+        Capacity_ = newCapacity;
+        CapacityShift_ = newCapacityShift;
+        std::swap(Data_, newData);
+        std::swap(DataEnd_, newDataEnd);
+        if (newData) {
+            Allocator_.deallocate(newData, newDataEnd - newData);
+        }
+    }
+
+    void Allocate(ui64 capacity, ui8 *&data, ui8 *&dataEnd) {
+        ui64 bytes = capacity * CellSize_;
+        data = Allocator_.allocate(bytes);
+        dataEnd = data + bytes;
+        ui8 *ptr = data;
+        for (ui64 i = 0; i < capacity; ++i) {
+            GetPSL(ptr).CellStatus.value = TCellStatus::kInvalid;
+            ptr += CellSize_;
+        }
+    }
+
+  private:
+    static constexpr ui32 CellSize_ = kEmbeddedSize;
+
+    const ui64 SelfHash_;
+
+    THash TupleHash_;
+    TEqual TuplesEqual_;
+
+    const TTupleLayout * Layout_ = nullptr;
+
+    const ui8 *Tuples_ = nullptr;
+    const ui8 *Overflow_ = nullptr;
+
+    bool IsInplace_;
+    ui32 DupPayloadSize_;
+
+    ui64 Size_ = 0;
+    ui64 Listed_ = 0;
+    ui64 ListedUnique_ = 0;
+    ui64 Capacity_ = 0;
+    ui64 CapacityShift_;
+
+    TAllocator Allocator_;
+    ui8 *Data_ = nullptr;
+    ui8 *DataEnd_ = nullptr;
+    TVector<ui8, TAllocator> DupSeq_;
+};
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/robin_hood_table.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/robin_hood_table.h
@@ -8,8 +8,6 @@
 #include <yql/essentials/minikql/mkql_rh_hash_utils.h>
 #include <yql/essentials/utils/prefetch.h>
 
-#include <ydb/library/yql/utils/simd/simd.h>
-
 #include <util/digest/city.h>
 #include <util/generic/scope.h>
 

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/hash_table_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/hash_table_ut.cpp
@@ -1,0 +1,533 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <chrono>
+#include <random>
+#include <vector>
+#include <fstream>
+
+#include <util/stream/null.h>
+#include <util/system/compiler.h>
+#include <util/system/fs.h>
+#include <util/system/mem_info.h>
+
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/neumann_hash_table.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/page_hash_table.h>
+#include <ydb/library/yql/dq/comp_nodes/hash_join_utils/robin_hood_table.h>
+
+#include <cxxabi.h> // demangled names
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NPackedTuple {
+
+using namespace std::chrono_literals;
+
+static volatile bool IsVerbose = false;
+#define CTEST (IsVerbose ? Cerr : Cnull)
+
+namespace {
+
+class IDistribution {
+  public:
+    virtual ui32 operator()(std::mt19937 &gen) = 0;
+    virtual ui32 Min() const = 0;
+    virtual ui32 Max() const = 0;
+};
+
+class TSingleValueDistribution : public IDistribution {
+  public:
+    TSingleValueDistribution(ui32 a) : Value_(a) {}
+
+    virtual ui32 operator()(std::mt19937 &) override { return Value_; }
+    virtual ui32 Min() const override { return Value_; }
+    virtual ui32 Max() const override { return Value_; }
+
+  private:
+    const ui32 Value_;
+};
+
+class TUniformDistribution : public IDistribution {
+  public:
+    TUniformDistribution(ui32 a, ui32 b) : Distribution_(a, b) {}
+
+    virtual ui32 operator()(std::mt19937 &gen) override {
+        return Distribution_(gen);
+    }
+    virtual ui32 Min() const override { return Distribution_.min(); }
+    virtual ui32 Max() const override { return Distribution_.max(); }
+
+  private:
+    std::uniform_int_distribution<ui32> Distribution_;
+};
+
+class TNormalDistribution : public IDistribution {
+  public:
+    TNormalDistribution(ui32 mean, ui32 std)
+        : Distribution_(mean, std), Min_{mean > 3 * std ? mean - 3 * std : 0},
+          Max_{mean + 3 * std} {}
+
+    virtual ui32 operator()(std::mt19937 &gen) override {
+        return std::max(Min_,
+                        std::min(Max_, ui32(std::lround(Distribution_(gen)))));
+    }
+    virtual ui32 Min() const override { return Min_; }
+    virtual ui32 Max() const override { return Max_; }
+
+  private:
+    std::normal_distribution<double> Distribution_;
+    ui32 Min_;
+    ui32 Max_;
+};
+
+class TMixtureDistribution : public IDistribution {
+  public:
+    TMixtureDistribution(IDistribution &left, IDistribution &right, float pLeft)
+        : Left_(left), Right_(right), PLeft_(pLeft) {}
+
+    virtual ui32 operator()(std::mt19937 &gen) override {
+        return PLeft_(gen) ? Left_(gen) : Right_(gen);
+    }
+    virtual ui32 Min() const override {
+        return std::min(Left_.Min(), Right_.Min());
+    }
+    virtual ui32 Max() const override {
+        return std::max(Left_.Max(), Right_.Max());
+    }
+
+  private:
+    IDistribution &Left_;
+    IDistribution &Right_;
+    std::bernoulli_distribution PLeft_;
+};
+
+class TRepeatDistribution : public IDistribution {
+  public:
+    TRepeatDistribution(IDistribution &distribution, ui32 repeatNum)
+        : Distribution_(distribution), RepeatNum_(std::max(1u, repeatNum)), Cnt_(0) {}
+
+    virtual ui32 operator()(std::mt19937 &gen) override {
+        if (Cnt_ == 0) {
+            Cnt_ = RepeatNum_;
+            Val_ = Distribution_(gen);
+        }
+        --Cnt_;
+        return Val_;
+    }
+    virtual ui32 Min() const override {
+        return Distribution_.Min();
+    }
+    virtual ui32 Max() const override {
+        return Distribution_.Max();
+    }
+
+  private:
+    IDistribution &Distribution_;
+    const ui32 RepeatNum_;
+    ui32 Val_;
+    ui32 Cnt_;
+};
+
+} // namespace
+
+namespace {
+
+template <size_t Batch, typename... Args> class TBenchmark {
+    struct TResult {
+        ui64 coldBuildTime = 0;
+        ui64 warmBuildTime = 0;
+        ui64 lookupTime = 0;
+        ui64 batchedLookupTime = 0;
+        ui64 memUsed = 0;
+    };
+
+    friend std::ostream &operator<<(std::ostream &out, TResult res) {
+        out << res.coldBuildTime << ',' << res.warmBuildTime << ','
+            << res.lookupTime << ',' << res.batchedLookupTime
+            << ',' << res.memUsed;
+        return out;
+    }
+
+    struct TInfo {
+        ui64 uniqueMatches = 0;
+        ui64 totalMatches = 0;
+        ui32 checksum = 0;
+    };
+
+    static constexpr auto kBuildLookupSize = std::array{
+        std::pair<ui32, ui32>{10000, 200000},
+        std::pair<ui32, ui32>{40000, 200000},
+        std::pair<ui32, ui32>{100000, 200000},
+    };
+    static constexpr ui32 kIters = 3;
+
+  public:
+    struct TConfig {
+        TString name;
+        IDistribution &buildKeyDistribution;
+        IDistribution &lookupKeyDistribution;
+    };
+
+    TBenchmark(ui32 payloadSize, const char *benchName)
+        : Alloc_(__LOCATION__), PayloadSize_(payloadSize),
+          BenchName_(benchName) {
+        UNIT_ASSERT(payloadSize != 0);
+        Init();
+    }
+
+    void Register(TConfig config) { Configs_.emplace_back(std::move(config)); }
+
+    void Run(bool toCSV = false) {
+        CTEST << "================================\n";
+        CTEST << "======== " << BenchName_ << "\n";
+        CTEST << "Hash tables being benchmarked:\n";
+        ApplyNumbered([&]<class Arg, size_t Ind> {
+            PrintArg<Arg>("  (" + std::to_string(Ind) + ") ",
+                          "(" + std::to_string(PayloadSize_) + ")\n");
+        });
+        CTEST << Endl;
+
+        for (const auto &config : Configs_) {
+            CTEST << "--------------------------------\n";
+
+            std::ofstream out;
+            if (toCSV) {
+                const auto dir = std::filesystem::path(__FILE__).parent_path() /= "results";
+                std::filesystem::create_directory(dir);
+                out = std::ofstream(dir.string() + "/" + BenchName_ + "_" + config.name + ".csv");
+            }
+    
+            for (const auto [buildSize, lookupSize] : kBuildLookupSize) {
+                auto [buildKeys, buildOverflow] =
+                    GenData(buildSize, config.buildKeyDistribution);
+                auto [lookupKeys, lookupOverflow] =
+                    GenData(lookupSize, config.lookupKeyDistribution);
+                const auto info =
+                    GetInfo(config.buildKeyDistribution.Max(), buildKeys.data(),
+                            buildSize, lookupKeys.data(), lookupSize);
+
+                const auto results = RunTest(config, info, buildKeys.data(), buildOverflow.data(),
+                        buildSize, lookupKeys.data(), lookupOverflow.data(),
+                        lookupSize);
+
+                if (toCSV) {
+                    out << buildSize << ',' << lookupSize << ',';
+                    for (size_t ind = 0; ind != results.size(); ++ind) {
+                        out << results[ind] << (ind + 1 == results.size() ? '\n' : ',');
+                    }
+                    out << std::flush;
+                }
+            }
+        }
+    }
+
+  private:
+    void Init() {
+        TColumnDesc kc1, pc1;
+
+        kc1.Role = EColumnRole::Key;
+        kc1.DataSize = 4;
+
+        pc1.Role = EColumnRole::Payload;
+        pc1.DataSize = PayloadSize_;
+
+        std::vector<TColumnDesc> columns{kc1, pc1};
+        Layout_ = TTupleLayout::Create(columns);
+    }
+
+    auto GenData(ui32 size, IDistribution &distribution) {
+        std::mt19937 gen(11);
+
+        std::vector<ui32> col1(size);
+        std::vector<ui8> col2(size * PayloadSize_);
+
+        for (ui32 i = 0; i < size; ++i) {
+            col1[i] = distribution(gen);
+            col2[i * PayloadSize_] = 1;
+        }
+
+        const ui8 *cols[2];
+        cols[0] = (ui8 *)col1.data();
+        cols[1] = (ui8 *)col2.data();
+
+        std::vector<ui8> colValid1((size + 7) / 8, ~0);
+        std::vector<ui8> colValid2((size + 7) / 8, ~0);
+        const ui8 *colsValid[2] = {
+            colValid1.data(),
+            colValid2.data(),
+        };
+
+        const ui64 DataSize = Layout_->TotalRowSize * size;
+        auto result = std::make_pair(std::vector<ui8>(DataSize + 64, 0),
+                                     std::vector<ui8, TMKQLAllocator<ui8>>{});
+        Layout_->Pack(cols, colsValid, result.first.data(), result.second, 0,
+                      size);
+
+        return result;
+    }
+
+    TInfo GetInfo(ui32 maxKey, ui8 *leftData, ui32 leftSize, ui8 *rightData,
+                  ui32 rightSize) {
+        std::vector<bool> keyFound(maxKey + 1, 0);
+        std::vector<ui32> keyCount(maxKey + 1, 0);
+
+        for (ui32 ind = 0; ind != leftSize; ++ind) {
+            const ui32 key =
+                ReadUnaligned<ui32>(leftData + ind * Layout_->TotalRowSize +
+                                    Layout_->KeyColumnsOffset);
+            ++keyCount[key];
+        }
+
+        TInfo result;
+        for (ui32 ind = 0; ind != rightSize; ++ind) {
+            const ui32 hash =
+                ReadUnaligned<ui32>(rightData + ind * Layout_->TotalRowSize);
+            const ui32 key =
+                ReadUnaligned<ui32>(rightData + ind * Layout_->TotalRowSize +
+                                    Layout_->KeyColumnsOffset);
+
+            if (maxKey < key) {
+                continue;
+            }
+            if (keyCount[key] && !keyFound[key]) {
+                keyFound[key] = true;
+                result.uniqueMatches++;
+            }
+            result.totalMatches += keyCount[key];
+            result.checksum += keyCount[key] * hash;
+        }
+
+        return result;
+    }
+
+    auto RunTest(const TConfig &config, const TInfo info, ui8 *buildKeys,
+                 ui8 *buildOverflow, ui32 buildSize, ui8 *lookupKeys,
+                 ui8 *lookupOverflow, ui32 lookupSize) {
+        std::array<TResult, sizeof...(Args)> results;
+        ApplyNumbered([&]<class Arg, size_t Ind> {
+            results[Ind] =
+                RunArgTest<Arg>(buildKeys, buildOverflow, buildSize, lookupKeys,
+                                lookupOverflow, lookupSize, info);
+        });
+
+        CTEST << "--------" << Endl;
+        CTEST << "Params\t" << " config: " << config.name
+              << ", keys: " << buildSize << ", lookups: " << lookupSize << Endl;
+        CTEST << "Info\t" << " unique matches: " << info.uniqueMatches
+              << ", total matches: " << info.totalMatches << Endl;
+        CTEST << "\nTime measurements (us):" << Endl;
+        PrintResult("1st build", results,
+                    [](TResult arg) { return arg.coldBuildTime; });
+        PrintResult("2nd build", results,
+                    [](TResult arg) { return arg.warmBuildTime; });
+        PrintResult("lookups", results,
+                    [](TResult arg) { return arg.lookupTime; });
+        if constexpr (Batch > 1) {
+            PrintResult("batch " + std::to_string(Batch), results,
+                [](TResult arg) { return arg.batchedLookupTime; });
+        }
+        CTEST << "\nMemory measurements (KiB):" << Endl;
+        PrintResult("used by ht", results,
+                    [](TResult arg) { return arg.memUsed; });
+
+        return results;
+    }
+
+    void PrintResult(const std::string &name,
+                     const std::array<TResult, sizeof...(Args)> &results,
+                     auto getter) {
+        const size_t minInd =
+            std::min_element(
+                results.begin(), results.end(),
+                [&](auto lhs, auto rhs) { return getter(lhs) < getter(rhs); }) -
+            results.begin();
+
+        CTEST << "  " << name << ":\t";
+        for (size_t ind = 0; ind != sizeof...(Args); ++ind) {
+            if (ind == minInd) {
+                CTEST << "> (" << ind << ") " << getter(results[ind]) << " <\t";
+            } else {
+                CTEST << "  (" << ind << ") " << getter(results[ind]) << "  \t";
+            }
+        }
+        CTEST << Endl;
+    }
+
+    template <typename Arg>
+    TResult RunArgTest(ui8 *buildKeys, ui8 *buildOverflow, ui32 buildSize,
+                       ui8 *lookupKeys, ui8 *lookupOverflow, ui32 lookupSize,
+                       TInfo info) {
+        TResult result;
+
+        for (ui32 iter = 0; iter != kIters; ++iter) {
+            UNIT_ASSERT_LE(Alloc_.GetUsed(), 1024);
+
+            Arg arg(Layout_.Get());
+
+            result.coldBuildTime += Measure(
+                [&] { arg.Build(buildKeys, buildOverflow, buildSize); });
+            arg.Clear();
+            result.warmBuildTime += Measure(
+                [&] { arg.Build(buildKeys, buildOverflow, buildSize); });
+            result.memUsed = Alloc_.GetUsed() / 1024;
+
+            ui64 matches = 0;
+            ui32 checksum = 0;
+            result.lookupTime += Measure([&] {
+                ui8 *const end =
+                    lookupKeys + Layout_->TotalRowSize * lookupSize;
+                for (ui8 *it = lookupKeys; it != end; it += Layout_->TotalRowSize) {
+                    arg.Apply(it, lookupOverflow, [&](const ui8 *const row) {
+                        checksum += ReadUnaligned<ui32>(it);
+                        matches += 
+                            ReadUnaligned<ui8>(row + 2 * sizeof(ui32) + (1 + 7) / 8);
+                    });
+                }
+            });
+            UNIT_ASSERT_EQUAL(matches, info.totalMatches);
+            UNIT_ASSERT_EQUAL(checksum, info.checksum);
+
+            if constexpr (Batch > 1) {
+                matches = 0;
+                checksum = 0;
+                result.batchedLookupTime += Measure([&] {
+                    ui8 *it = lookupKeys;
+                    for (size_t batchInd = 0; batchInd < lookupSize; batchInd += Batch) {
+                        std::array<const ui8 *, Batch> rows;
+                        for (size_t i = 0; i < Batch && batchInd + i < lookupSize; ++i) {
+                            rows[i] = it;
+                            it += Layout_->TotalRowSize;
+                        }
+
+                        std::array<typename Arg::TIterator, Batch> iters =
+                            arg.FindBatch(rows, lookupOverflow);
+                        for (size_t i = 0; i < Batch && batchInd + i < lookupSize; ++i) {
+                            while (auto match = arg.NextMatch(iters[i], lookupOverflow)) {
+                                checksum += ReadUnaligned<ui32>(rows[i]);
+                                matches +=
+                                    ReadUnaligned<ui8>(match + 2 * sizeof(ui32) + (1 + 7) / 8);    
+                            }
+                        }
+                    }
+                });
+                UNIT_ASSERT_EQUAL(matches, info.totalMatches);
+                UNIT_ASSERT_EQUAL(checksum, info.checksum);
+            }
+
+            arg.Clear();
+        }
+
+        result.coldBuildTime /= kIters;
+        result.warmBuildTime /= kIters;
+        result.lookupTime /= kIters;
+        result.batchedLookupTime /= kIters;
+
+        return result;
+    }
+
+    void ApplyNumbered(auto f) {
+        [&]<size_t... Inds>(std::index_sequence<Inds...>) {
+            (f.template operator()<Args, Inds>(), ...);
+        }(std::make_index_sequence<sizeof...(Args)>{});
+    }
+
+    template <typename Arg>
+    void PrintArg(std::string prefix, std::string suffix) {
+        int status;
+        CTEST << prefix
+              << abi::__cxa_demangle(typeid(Arg).name(), 0, 0, &status)
+              << suffix;
+    }
+
+    ui64 Measure(auto f) {
+        const auto begin = std::chrono::steady_clock::now();
+        f();
+        const auto end = std::chrono::steady_clock::now();
+
+        ui64 us =
+            std::chrono::duration_cast<std::chrono::microseconds>(end - begin)
+                .count();
+        us = (us == 0 ? 1 : us);
+        return us;
+    }
+
+  private:
+    TScopedAlloc Alloc_;
+
+    ui32 PayloadSize_;
+    const char *BenchName_;
+
+    THolder<TTupleLayout> Layout_;
+
+    std::vector<TConfig> Configs_;
+};
+
+} // namespace
+
+// -----------------------------------------------------------------
+
+using TRobinHoodTable = TRobinHoodHashBase<false, false>;
+using TRobinHoodTableSeq = TRobinHoodHashBase<true, false>;
+using TRobinHoodTableSeqPref = TRobinHoodHashBase<true, true>;
+
+using TNeumannTable = TNeumannHashTable<false, false>;
+using TNeumannTableSeq = TNeumannHashTable<true, false>;
+
+using TNeumannTablePref = TNeumannHashTable<false, true>;
+using TNeumannTableSeqPref = TNeumannHashTable<true, true>;
+
+using TPageTableSSE = TPageHashTableImpl<NSimd::TSimdSSE42Traits, false>;
+using TPageTableSSEPref = TPageHashTableImpl<NSimd::TSimdSSE42Traits, true>;
+
+using TPageTableAVX2 = TPageHashTableImpl<NSimd::TSimdAVX2Traits, false>;
+using TPageTableAVX2Pref = TPageHashTableImpl<NSimd::TSimdAVX2Traits, true>;
+
+// -----------------------------------------------------------------
+
+template <typename... Args> struct TTablesCase {
+    template <size_t Batch> using TBenchmark = TBenchmark<Batch, Args...>;
+};
+using TTablesBenchmark =
+    TTablesCase<TPageTableSSEPref, TRobinHoodTableSeqPref, TNeumannTablePref>;
+
+// -----------------------------------------------------------------
+
+Y_UNIT_TEST_SUITE(HashTablesBenchmark) {
+
+    static constexpr size_t batchSize = 16;
+    static constexpr bool toCSV = false;
+
+    Y_UNIT_TEST(Uniform) {
+        TUniformDistribution uni1M(0, 1e6 - 1);
+
+        auto benchmark = TTablesBenchmark::TBenchmark<batchSize>(4, Name_);
+
+        benchmark.Register({"uniform 1M", uni1M, uni1M});
+
+        benchmark.Run(toCSV);
+    }
+
+    Y_UNIT_TEST(UniformPayloaded) {
+        TUniformDistribution uni1M(0, 1e6 - 1);
+
+        auto benchmark = TTablesBenchmark::TBenchmark<batchSize>(21, Name_);
+
+        benchmark.Register({"uniform 1M", uni1M, uni1M});
+
+        benchmark.Run(toCSV);
+    }
+
+    Y_UNIT_TEST(NormalPayloaded) {
+        TNormalDistribution norm1M(1000000 / 2, 1000000 / 6);
+
+        auto benchmark = TTablesBenchmark::TBenchmark<batchSize>(21, Name_);
+
+        benchmark.Register({"norm 1M", norm1M, norm1M});
+
+        benchmark.Run(toCSV);
+    }
+
+} // Y_UNIT_TEST_SUITE(RobinHoodCheck)
+
+} // namespace NPackedTuple
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ut/ya.make
@@ -13,9 +13,10 @@ ENDIF()
 
 
 SRCS(
-    packed_tuple_ut.cpp
     accumulator_ut.cpp
     block_layout_converter_ut.cpp
+    hash_table_ut.cpp
+    packed_tuple_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/ya.make
@@ -19,6 +19,7 @@ SRCS(
     tuple.cpp
     accumulator.cpp
     block_layout_converter.cpp
+    page_hash_table.cpp
 )
 
 CFLAGS(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Block Hash Hoin utils: add hash tables for tuple layout rows.

### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR represents different approaches for indexing tuple layout rows using hash tables.

Main changes:

- Add hash tables adapted for tuple layout: RobinHood, Neumann, Page