### PR TITLE
Don't schedule timeout for each compute actor

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -137,11 +137,6 @@ public:
                 RuntimeSettings.StatsMode, MemoryLimits.ChannelBufferSize, this, this->GetActivityType());
             this->RegisterWithSameMailbox(Channels);
 
-            if (RuntimeSettings.Timeout) {
-                CA_LOG_D("Set execution timeout " << *RuntimeSettings.Timeout);
-                this->Schedule(*RuntimeSettings.Timeout, new NActors::TEvents::TEvWakeup(EEvWakeupTag::TimeoutTag));
-            }
-
             if (auto reportStatsSettings = RuntimeSettings.ReportStatsSettings) {
                 if (reportStatsSettings->MaxInterval) {
                     CA_LOG_D("Set periodic stats " << reportStatsSettings->MaxInterval);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Don't schedule timeout for each compute actor - to prevent huge pile of unmanaged memory #27080 #27639 

### Changelog category <!-- remove all except one -->

* Bugfix