### PR TITLE
Fix the notify about commit logic in Column Shards

### DIFF
--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
@@ -110,7 +110,6 @@ void TReadMetadata::DoOnBeforeStartReading(NColumnShard::TColumnShard& owner) co
     }
     auto evWriter = std::make_shared<NOlap::NTxInteractions::TEvReadStartWriter>(TableMetadataAccessor->GetPathIdVerified(),
         GetResultSchema()->GetIndexInfo().GetPrimaryKey(), GetPKRangesFilterPtr(), GetMaybeConflictingLockIds());
-    // AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("opca", "DoOnBeforeStartReading")("lock_id", *LockId)("conflictable_lock_ids", JoinSeq(", ", GetMaybeConflictableLockIds()));
     owner.GetOperationsManager().AddEventForLock(owner, *LockId, evWriter);
 }
 

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
@@ -81,7 +81,7 @@ class TReadMetadata: public TReadMetadataBase {
     using TBase = TReadMetadataBase;
 
 private:
-    std::shared_ptr<TAtomicCounter> BrokenWithCommitted = std::make_shared<TAtomicCounter>();
+    mutable TAtomicCounter BreakLockOnReadFinished = TAtomicCounter();
     std::shared_ptr<NColumnShard::TLockSharingInfo> LockSharingInfo;
 
     class TWriteIdInfo {
@@ -99,17 +99,17 @@ private:
             return LockId;
         }
 
-        void MarkAsConflictable() const {
+        void MarkAsConflicting() const {
             Conflicts->Inc();
         }
 
-        bool IsConflictable() const {
+        bool IsConflicting() const {
             return Conflicts->Val();
         }
     };
 
     THashMap<ui64, std::shared_ptr<TAtomicCounter>> LockConflictCounters;
-    THashMap<TInsertWriteId, TWriteIdInfo> ConflictedWriteIds;
+    THashMap<TInsertWriteId, TWriteIdInfo> ConflictingWrites;
 
     virtual void DoOnReadFinished(NColumnShard::TColumnShard& owner) const override;
     virtual void DoOnBeforeStartReading(NColumnShard::TColumnShard& owner) const override;
@@ -132,51 +132,48 @@ public:
         return std::move(SourcesConstructor);
     }
 
-    bool GetBrokenWithCommitted() const {
-        return BrokenWithCommitted->Val();
+    bool GetBreakLockOnReadFinished() const {
+        return BreakLockOnReadFinished.Val();
     }
-    THashSet<ui64> GetConflictableLockIds() const {
+
+    void SetBreakLockOnReadFinished() const {
+        BreakLockOnReadFinished.Inc();
+    }
+
+    THashSet<ui64> GetConflictingLockIds() const {
         THashSet<ui64> result;
-        for (auto&& i : ConflictedWriteIds) {
-            if (i.second.IsConflictable()) {
-                result.emplace(i.second.GetLockId());
+        for (auto& [_, writeIdInfo] : ConflictingWrites) {
+            if (writeIdInfo.IsConflicting()) {
+                result.emplace(writeIdInfo.GetLockId());
             }
         }
         return result;
     }
 
-    bool IsLockConflictable(const ui64 lockId) const {
-        auto it = LockConflictCounters.find(lockId);
-        AFL_VERIFY(it != LockConflictCounters.end());
-        return it->second->Val();
-    }
-
-    bool IsWriteConflictable(const TInsertWriteId writeId) const {
-        auto it = ConflictedWriteIds.find(writeId);
-        AFL_VERIFY(it != ConflictedWriteIds.end());
-        return it->second.IsConflictable();
+    THashSet<ui64> GetMaybeConflictingLockIds() const {
+        THashSet<ui64> result;
+        for (auto& [_, writeInfo] : ConflictingWrites) {
+            result.emplace(writeInfo.GetLockId());
+        }
+        return result;
     }
 
     bool MayWriteBeConflicting(const TInsertWriteId writeId) const {
-        return ConflictedWriteIds.contains(writeId);
+        return ConflictingWrites.contains(writeId);
     }
 
-    void AddWriteIdToCheck(const TInsertWriteId writeId, const ui64 lockId) {
+    void AddMaybeConflictingWrite(const TInsertWriteId writeId, const ui64 lockId) {
         auto it = LockConflictCounters.find(lockId);
         if (it == LockConflictCounters.end()) {
             it = LockConflictCounters.emplace(lockId, std::make_shared<TAtomicCounter>()).first;
         }
-        AFL_VERIFY(ConflictedWriteIds.emplace(writeId, TWriteIdInfo(lockId, it->second)).second);
+        AFL_VERIFY(ConflictingWrites.emplace(writeId, TWriteIdInfo(lockId, it->second)).second);
     }
 
-    void SetConflictedWriteId(const TInsertWriteId writeId) const {
-        auto it = ConflictedWriteIds.find(writeId);
-        AFL_VERIFY(it != ConflictedWriteIds.end());
-        it->second.MarkAsConflictable();
-    }
-
-    void SetBrokenWithCommitted() const {
-        BrokenWithCommitted->Inc();
+    void SetWriteConflicting(const TInsertWriteId writeId) const {
+        auto it = ConflictingWrites.find(writeId);
+        AFL_VERIFY(it != ConflictingWrites.end());
+        it->second.MarkAsConflicting();
     }
 
     NArrow::NMerger::TSortableBatchPosition BuildSortedPosition(const NArrow::TSimpleRow& key) const;

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
@@ -189,6 +189,9 @@ public:
 
     TReadMetadata(const std::shared_ptr<const TVersionedIndex>& schemaIndex, const TReadDescription& read);
 
+    TReadMetadata(const TReadMetadata&) = delete;
+    TReadMetadata& operator=(const TReadMetadata&) = delete;
+
     virtual std::vector<TNameTypeInfo> GetKeyYqlSchema() const override {
         return GetResultSchema()->GetIndexInfo().GetPrimaryKeyColumns();
     }

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.cpp
@@ -177,11 +177,11 @@ bool TPortionDataSource::DoStartFetchingAccessor(const std::shared_ptr<NCommon::
 bool TPortionDataSource::DoAddTxConflict() {
     auto state = GetContext()->GetPortionStateAtScanStart(this->GetPortionInfo());
     if (state.Committed) {
-        GetContext()->GetReadMetadata()->SetBrokenWithCommitted();
+        GetContext()->GetReadMetadata()->SetBreakLockOnReadFinished();
         return true;
     } else if (!state.IsMyUncommitted()) {
         const auto* wPortion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
+        GetContext()->GetReadMetadata()->SetWriteConflicting(wPortion->GetInsertWriteId());
         return true;
     }
     return false;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.cpp
@@ -465,11 +465,11 @@ TConclusion<bool> TPortionDataSource::DoStartReserveMemory(const NArrow::NSSA::T
 bool TPortionDataSource::DoAddTxConflict() {
     auto state = GetContext()->GetPortionStateAtScanStart(this->GetPortionInfo());
     if (state.Committed) {
-        GetContext()->GetReadMetadata()->SetBrokenWithCommitted();
+        GetContext()->GetReadMetadata()->SetBreakLockOnReadFinished();
         return true;
     } else if (!state.IsMyUncommitted()) {
         const auto* wPortion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
+        GetContext()->GetReadMetadata()->SetWriteConflicting(wPortion->GetInsertWriteId());
         return true;
     }
     return false;

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -72,7 +72,7 @@ private:
     YDB_READONLY_DEF(std::vector<NOlap::NTxInteractions::TTxEventContainer>, Events);
     std::shared_ptr<TLockSharingInfo> SharingInfo;
 
-    YDB_READONLY_DEF(THashSet<ui64>, BrokeOnCommit);
+    YDB_READONLY_DEF(THashSet<ui64>, BreakOnCommit);
     YDB_READONLY_DEF(THashSet<ui64>, NotifyOnCommit);
     YDB_READONLY_DEF(THashSet<ui64>, Committed);
     YDB_READONLY_DEF(TPositiveControlInteger, OperationsInProgress);
@@ -146,16 +146,18 @@ public:
         return Committed.contains(lockId);
     }
 
-    void AddNotifyCommit(const ui64 lockId) {
-        AFL_VERIFY(NotifyOnCommit.erase(lockId));
+    /*
+    Let the given `TLockFeatures` know that the transaction with `lockId` has committed
+    */
+    void NotifyAboutCommit(const ui64 lockId) {
         Committed.emplace(lockId);
     }
 
-    void AddBrokeOnCommit(const THashSet<ui64>& lockIds) {
-        BrokeOnCommit.insert(lockIds.begin(), lockIds.end());
+    void AddBreakOnCommit(const THashSet<ui64>& lockIds) {
+        BreakOnCommit.insert(lockIds.begin(), lockIds.end());
     }
 
-    void AddNotificationsOnCommit(const THashSet<ui64>& lockIds) {
+    void AddNotifyOnCommit(const THashSet<ui64>& lockIds) {
         NotifyOnCommit.insert(lockIds.begin(), lockIds.end());
     }
 

--- a/ydb/core/tx/columnshard/transactions/locks/abstract.h
+++ b/ydb/core/tx/columnshard/transactions/locks/abstract.h
@@ -43,57 +43,57 @@ public:
         DoSerializeToProto(proto);
     }
 
-    void AddToInteraction(const ui64 txId, TInteractionsContext& context) const {
-        return DoAddToInteraction(txId, context);
+    void AddToInteraction(const ui64 lockId, TInteractionsContext& context) const {
+        return DoAddToInteraction(lockId, context);
     }
 
-    void RemoveFromInteraction(const ui64 txId, TInteractionsContext& context) const {
-        return DoRemoveFromInteraction(txId, context);
+    void RemoveFromInteraction(const ui64 lockId, TInteractionsContext& context) const {
+        return DoRemoveFromInteraction(lockId, context);
     }
 };
 
 class TTxEventContainer: public NBackgroundTasks::TInterfaceProtoContainer<ITxEvent> {
 private:
     using TBase = NBackgroundTasks::TInterfaceProtoContainer<ITxEvent>;
-    YDB_READONLY(ui64, TxId, 0);
+    YDB_READONLY(ui64, LockId, 0);
 
 public:
     void AddToInteraction(TInteractionsContext& context) const {
-        return GetObjectVerified().AddToInteraction(TxId, context);
+        return GetObjectVerified().AddToInteraction(LockId, context);
     }
 
     void RemoveFromInteraction(TInteractionsContext& context) const {
-        return GetObjectVerified().RemoveFromInteraction(TxId, context);
+        return GetObjectVerified().RemoveFromInteraction(LockId, context);
     }
 
-    TTxEventContainer(const ui64 txId, const std::shared_ptr<ITxEvent>& txEvent)
+    TTxEventContainer(const ui64 lockId, const std::shared_ptr<ITxEvent>& txEvent)
         : TBase(txEvent)
-        , TxId(txId) {
+        , LockId(lockId) {
     }
 
-    TTxEventContainer(const ui64 txId)
-        : TxId(txId) {
+    TTxEventContainer(const ui64 lockId)
+        : LockId(lockId) {
     }
 
     bool operator<(const TTxEventContainer& item) const {
-        return TxId < item.TxId;
+        return LockId < item.LockId;
     }
 };
 
 class ITxEventWriter {
 protected:
     virtual bool DoCheckInteraction(
-        const ui64 selfTxId, TInteractionsContext& context, TTxConflicts& conflicts, TTxConflicts& notifications) const = 0;
+        const ui64 selfLockId, TInteractionsContext& context, TTxConflicts& conflicts, TTxConflicts& notifications) const = 0;
     virtual std::shared_ptr<ITxEvent> DoBuildEvent() = 0;
 
 public:
     ITxEventWriter() = default;
     virtual ~ITxEventWriter() = default;
 
-    bool CheckInteraction(const ui64 selfTxId, TInteractionsContext& context, TTxConflicts& conflicts, TTxConflicts& notifications) const {
+    bool CheckInteraction(const ui64 selfLockId, TInteractionsContext& context, TTxConflicts& conflicts, TTxConflicts& notifications) const {
         TTxConflicts conflictsResult;
         TTxConflicts notificationsResult;
-        const bool result = DoCheckInteraction(selfTxId, context, conflictsResult, notificationsResult);
+        const bool result = DoCheckInteraction(selfLockId, context, conflictsResult, notificationsResult);
         std::swap(conflictsResult, conflicts);
         std::swap(notificationsResult, notifications);
         return result;

--- a/ydb/core/tx/columnshard/transactions/locks/abstract.h
+++ b/ydb/core/tx/columnshard/transactions/locks/abstract.h
@@ -22,8 +22,8 @@ public:
     using TProto = NKikimrColumnShardTxProto::TEvent;
 
 protected:
-    virtual void DoAddToInteraction(const ui64 txId, TInteractionsContext& context) const = 0;
-    virtual void DoRemoveFromInteraction(const ui64 txId, TInteractionsContext& context) const = 0;
+    virtual void DoAddToInteraction(const ui64 lockId, TInteractionsContext& context) const = 0;
+    virtual void DoRemoveFromInteraction(const ui64 lockId, TInteractionsContext& context) const = 0;
     virtual bool DoDeserializeFromProto(const NKikimrColumnShardTxProto::TEvent& proto) = 0;
     virtual void DoSerializeToProto(NKikimrColumnShardTxProto::TEvent& proto) const = 0;
 

--- a/ydb/core/tx/columnshard/transactions/locks/read_finished.h
+++ b/ydb/core/tx/columnshard/transactions/locks/read_finished.h
@@ -10,7 +10,7 @@ private:
     TTxConflicts Conflicts;
 
     virtual bool DoCheckInteraction(
-        const ui64 /*selfTxId*/, TInteractionsContext& /*context*/, TTxConflicts& conflicts, TTxConflicts& /*notifications*/) const override {
+        const ui64 /*selfLockId*/, TInteractionsContext& /*context*/, TTxConflicts& conflicts, TTxConflicts& /*notifications*/) const override {
         conflicts = Conflicts;
         return true;
     }

--- a/ydb/core/tx/columnshard/transactions/locks/read_start.cpp
+++ b/ydb/core/tx/columnshard/transactions/locks/read_start.cpp
@@ -32,15 +32,15 @@ void TEvReadStart::DoSerializeToProto(NKikimrColumnShardTxProto::TEvent& proto) 
     *proto.MutableRead()->MutableSchema() = NArrow::SerializeSchema(*Schema);
 }
 
-void TEvReadStart::DoAddToInteraction(const ui64 txId, TInteractionsContext& context) const {
+void TEvReadStart::DoAddToInteraction(const ui64 lockId, TInteractionsContext& context) const {
     for (auto&& i : *Filter) {
-        context.AddInterval(txId, PathId.InternalPathId, TIntervalPoint::From(i.GetPredicateFrom(), Schema), TIntervalPoint::To(i.GetPredicateTo(), Schema));
+        context.AddInterval(lockId, PathId.InternalPathId, TIntervalPoint::From(i.GetPredicateFrom(), Schema), TIntervalPoint::To(i.GetPredicateTo(), Schema));
     }
 }
 
-void TEvReadStart::DoRemoveFromInteraction(const ui64 txId, TInteractionsContext& context) const {
+void TEvReadStart::DoRemoveFromInteraction(const ui64 lockId, TInteractionsContext& context) const {
     for (auto&& i : *Filter) {
-        context.RemoveInterval(txId, PathId.InternalPathId, TIntervalPoint::From(i.GetPredicateFrom(), Schema), TIntervalPoint::To(i.GetPredicateTo(), Schema));
+        context.RemoveInterval(lockId, PathId.InternalPathId, TIntervalPoint::From(i.GetPredicateFrom(), Schema), TIntervalPoint::To(i.GetPredicateTo(), Schema));
     }
 }
 

--- a/ydb/core/tx/columnshard/transactions/locks/read_start.h
+++ b/ydb/core/tx/columnshard/transactions/locks/read_start.h
@@ -13,9 +13,10 @@ private:
     YDB_READONLY_DEF(THashSet<ui64>, LockIdsForCheck);
 
     virtual bool DoCheckInteraction(
-        const ui64 selfTxId, TInteractionsContext& /*context*/, TTxConflicts& /*conflicts*/, TTxConflicts& notifications) const override {
-        for (auto&& i : LockIdsForCheck) {
-            notifications.Add(i, selfTxId);
+        const ui64 selfLockId, TInteractionsContext& /*context*/, TTxConflicts& /*conflicts*/, TTxConflicts& notifications) const override {
+        for (auto& lockIdToCommit : LockIdsForCheck) {
+            // when lockIdToCommit commits, selfLockId will be notified
+            notifications.Add(lockIdToCommit, selfLockId);
         }
         return true;
     }
@@ -49,8 +50,8 @@ private:
 
     virtual bool DoDeserializeFromProto(const NKikimrColumnShardTxProto::TEvent& proto) override;
     virtual void DoSerializeToProto(NKikimrColumnShardTxProto::TEvent& proto) const override;
-    virtual void DoAddToInteraction(const ui64 txId, TInteractionsContext& context) const override;
-    virtual void DoRemoveFromInteraction(const ui64 txId, TInteractionsContext& context) const override;
+    virtual void DoAddToInteraction(const ui64 lockId, TInteractionsContext& context) const override;
+    virtual void DoRemoveFromInteraction(const ui64 lockId, TInteractionsContext& context) const override;
     static inline const TFactory::TRegistrator<TEvReadStart> Registrator = TFactory::TRegistrator<TEvReadStart>(GetClassNameStatic());
 
 public:


### PR DESCRIPTION
Fixes #26463

There is some renaming. It does not fixes the logic but makes it much easier to understand and harder to make a mistake.

The actual fix is in:
- TReadMetadata, I added clear separation between "maybe conflicting writes" (writes that we may be conflicting but we have not checked for sure yet) and "conflicting writes" (writes that we have checked and found out they are conflicting). Previously, there was no way to get "maybe conflicting writes" but they are crucial for the notify about commit logic.
-  TOperationsManager::AddEventForLock(), there were a tricky bug. We check if there is a lock for conflicting tx and "tell" it to break the current tx, when it commits. If the lock was present, we did not check if it is committed already. And that was a mistake, because the lock may be present and its tx may be already committed. Now we check whether the conflicting tx is committed or not always.
-  TReadMetadata::DoOnBeforeStartReading(). Here we must pass "maybe conflicting writes" to evWriter and "ask" all the maybe conflicting txs to notify the given tx when they commit. We do not now which are really conflicting so we have to "ask" all of them.

