### PR TITLE
Integer division error in Fair share calculation fix

### DIFF
--- a/ydb/core/kqp/runtime/scheduler/tree/snapshot.cpp
+++ b/ydb/core/kqp/runtime/scheduler/tree/snapshot.cpp
@@ -59,6 +59,7 @@ void TTreeElement::UpdateTopDown(bool allowFairShareOverlimit) {
     if (!IsLeaf()) {
         ui64 totalWeightedDemand = 0;
         std::vector<ui64> weightedDemand;
+        ui64 undistributedFairShare = FairShare;
 
         weightedDemand.resize(ChildrenSize());
         ForEachChild<TTreeElement>([&](TTreeElement* child, size_t i) {
@@ -74,6 +75,31 @@ void TTreeElement::UpdateTopDown(bool allowFairShareOverlimit) {
             }
 
             child->UpdateTopDown(allowFairShareOverlimit);
+        });
+        ForEachChild<TTreeElement>([&](TTreeElement* child, size_t i) {
+            if (totalWeightedDemand > 0) {
+                // TODO: distribute the resources lost cause of integer division.
+                ui64 givenFairShare = weightedDemand.at(i) * FairShare / totalWeightedDemand;
+                child->FairShare = givenFairShare;
+                undistributedFairShare -= givenFairShare;
+            } else {
+                child->FairShare = 0;
+            }
+
+            if (i != 0) {
+                child->UpdateTopDown(allowFairShareOverlimit);
+            }
+        });
+        ForEachChild<TTreeElement>([&](TTreeElement* child, size_t) {
+            if (totalWeightedDemand > 0) {
+                // give all undistributed fair-share to the first child
+                child->FairShare += undistributedFairShare;
+            } else {
+                child->FairShare = 0;
+            }
+
+            child->UpdateTopDown(allowFairShareOverlimit);
+            return true;
         });
     }
     // FIFO variant (when children are queries)


### PR DESCRIPTION
All undistributed fair share is given to the first child