### PR TITLE
[25-3-1] Ignore TEvNewAsyncInputDataArrived in TKqpVectorResolveActor when reading is already finished (fix #27095)

### DIFF
--- a/ydb/core/kqp/runtime/kqp_vector_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_vector_actor.cpp
@@ -323,6 +323,9 @@ private:
     }
 
     void HandleRead(TEvNewAsyncInputDataArrived::TPtr) {
+        if (!ReadActorInput) {
+            return;
+        }
         TMaybe<TInstant> watermark;
         ui64 freeSpace = 32*1024*1024; // FIXME The value doesn't really matter, but where to take it from?
         NKikimr::NMiniKQL::TUnboxedValueBatch rows;


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Cherry-pick of #27155, fix crash from #27095
