### PR TITLE
Filled and persisted database name in replication controller

### DIFF
--- a/ydb/core/protos/counters_replication.proto
+++ b/ydb/core/protos/counters_replication.proto
@@ -17,6 +17,7 @@ enum ESimpleCounters {
     COUNTER_ASSIGNED_TX_IDS = 8 [(CounterOpts) = {Name: "AssignedTxIds"}];
     COUNTER_WORKERS_WITH_HEARTBEAT = 9 [(CounterOpts) = {Name: "WorkersWithHeartbeat"}];
     COUNTER_WORKERS_PENDING_HEARTBEAT = 10 [(CounterOpts) = {Name: "WorkersPendingHeartbeat"}];
+    COUNTER_UNRESOLVED_DATABASE_REPLICATIONS = 11 [(CounterOpts) = {Name: "UnresolvedDatabaseReplications"}];
 }
 
 enum ECumulativeCounters {
@@ -57,4 +58,5 @@ enum ETxTypes {
     TXTYPE_HEARTBEAT = 16 [(TxTypeOpts) = {Name: "TxHeartbeat"}];
     TXTYPE_COMMIT_CHANGES = 17 [(TxTypeOpts) = {Name: "TxCommitChanges"}];
     TXTYPE_RESOLVE_RESOURCE_ID_RESULT = 18 [(TxTypeOpts) = {Name: "TxResolveResourceIdResult"}];
+    TXTYPE_RESOLVE_DATABASE_RESULT = 19 [(TxTypeOpts) = {Name: "TxResolveDatabaseResult"}];
 }

--- a/ydb/core/tx/replication/controller/controller_impl.h
+++ b/ydb/core/tx/replication/controller/controller_impl.h
@@ -64,9 +64,11 @@ private:
 
     // state functions
     STFUNC(StateInit);
+    STFUNC(StateDatabaseResolve);
     STFUNC(StateWork);
 
     void Cleanup(const TActorContext& ctx);
+    void SwitchToDatabaseResolve(const TActorContext& ctx);
     void SwitchToWork(const TActorContext& ctx);
     void Reset();
 
@@ -85,6 +87,7 @@ private:
     void Handle(TEvPrivate::TEvDropDstResult::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvResolveSecretResult::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvResolveResourceIdResult::TPtr& ev, const TActorContext& ctx);
+    void HandleDatabaseResolve(TEvPrivate::TEvResolveTenantResult::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvResolveTenantResult::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvUpdateTenantNodes::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvProcessQueues::TPtr& ev, const TActorContext& ctx);
@@ -134,6 +137,7 @@ private:
     class TTxCreateDstResult;
     class TTxAlterDstResult;
     class TTxDropDstResult;
+    class TTxResolveDatabaseResult;
     class TTxResolveSecretResult;
     class TTxResolveResourceIdResult;
     class TTxWorkerError;
@@ -157,6 +161,7 @@ private:
     void RunTxCreateDstResult(TEvPrivate::TEvCreateDstResult::TPtr& ev, const TActorContext& ctx);
     void RunTxAlterDstResult(TEvPrivate::TEvAlterDstResult::TPtr& ev, const TActorContext& ctx);
     void RunTxDropDstResult(TEvPrivate::TEvDropDstResult::TPtr& ev, const TActorContext& ctx);
+    void RunTxResolveDatabaseResult(TEvPrivate::TEvResolveTenantResult::TPtr& ev, const TActorContext& ctx);
     void RunTxResolveSecretResult(TEvPrivate::TEvResolveSecretResult::TPtr& ev, const TActorContext& ctx);
     void RunTxResolveResourceIdResult(TEvPrivate::TEvResolveResourceIdResult::TPtr& ev, const TActorContext& ctx);
     void RunTxWorkerError(const TWorkerId& id, const TString& error, const TActorContext& ctx);
@@ -192,6 +197,8 @@ private:
     TSysParams SysParams;
     THashMap<ui64, TReplication::TPtr> Replications;
     THashMap<TPathId, TReplication::TPtr> ReplicationsByPathId;
+    THashMap<ui64, ui8> UnresolvedDatabaseReplications;
+    static constexpr ui8 ResolveDatabaseAttemptsLimit = 5;
 
     TActorId DiscoveryCache;
     TNodesManager NodesManager;

--- a/ydb/core/tx/replication/controller/dst_creator.h
+++ b/ydb/core/tx/replication/controller/dst_creator.h
@@ -28,10 +28,10 @@ bool CheckReplicationConfig(
     TString& error);
 
 IActor* CreateDstCreator(TReplication* replication, ui64 targetId, const TActorContext& ctx);
-IActor* CreateDstCreator(const TActorId& parent, ui64 schemeShardId, const TActorId& proxy, const TPathId& pathId,
+IActor* CreateDstCreator(const TActorId& parent, ui64 schemeShardId, const TActorId& proxy,
+    const TString& database, const TPathId& pathId,
     ui64 rid, ui64 tid, TReplication::ETargetKind kind, const TString& srcPath, const TString& dstPath,
     EReplicationMode mode = EReplicationMode::ReadOnly,
-    EConsistencyLevel consistency = EConsistencyLevel::Row,
-    const TString& database = "");
+    EConsistencyLevel consistency = EConsistencyLevel::Row);
 
 }

--- a/ydb/core/tx/replication/controller/dst_creator_ut.cpp
+++ b/ydb/core/tx/replication/controller/dst_creator_ut.cpp
@@ -57,7 +57,8 @@ Y_UNIT_TEST_SUITE(DstCreator) {
 
         env.CreateTable("/Root", *MakeTableDescription(tableDesc));
         env.GetRuntime().Register(CreateDstCreator(
-            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(), env.GetPathId("/Root"),
+            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(),
+            "/Root", env.GetPathId("/Root"),
             1 /* rid */, 1 /* tid */, TReplication::ETargetKind::Table, "/Root/Table", replicatedPath, mode, consistency
         ));
 
@@ -101,7 +102,8 @@ Y_UNIT_TEST_SUITE(DstCreator) {
         env.CreateTableWithIndex("/Root", *MakeTableDescription(tableDesc),
              indexName, TVector<TString>{"value"}, indexType);
         env.GetRuntime().Register(CreateDstCreator(
-            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(), env.GetPathId("/Root"),
+            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(),
+            "/Root", env.GetPathId("/Root"),
             1 /* rid */, 1 /* tid */, TReplication::ETargetKind::Table, "/Root/Table", replicatedPath
         ));
         {
@@ -125,7 +127,8 @@ Y_UNIT_TEST_SUITE(DstCreator) {
         }
 
         env.GetRuntime().Register(CreateDstCreator(
-            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(), env.GetPathId("/Root"),
+            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(),
+            "/Root", env.GetPathId("/Root"),
             1 /* rid */, 2 /* tid */, TReplication::ETargetKind::IndexTable,
             "/Root/Table/" + indexName + "/indexImplTable", replicatedPath + "/" + indexName + "/indexImplTable"
         ));
@@ -176,7 +179,8 @@ Y_UNIT_TEST_SUITE(DstCreator) {
         }));
 
         env.GetRuntime().Register(CreateDstCreator(
-            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(), env.GetPathId("/Root"),
+            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(),
+            "/Root", env.GetPathId("/Root"),
             1 /* rid */, 1 /* tid */, TReplication::ETargetKind::Table, "/Root/Table", "/Root/Replicated"
         ));
 
@@ -204,7 +208,8 @@ Y_UNIT_TEST_SUITE(DstCreator) {
         }));
 
         env.GetRuntime().Register(CreateDstCreator(
-            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(), env.GetPathId("/Root"),
+            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(),
+            "/Root", env.GetPathId("/Root"),
             1 /* rid */, 1 /* tid */, TReplication::ETargetKind::Table, "/Root/Table", "/Root/Replicated"
         ));
 
@@ -225,7 +230,8 @@ Y_UNIT_TEST_SUITE(DstCreator) {
         env.GetRuntime().SetLogPriority(NKikimrServices::REPLICATION_CONTROLLER, NLog::PRI_TRACE);
 
         env.GetRuntime().Register(CreateDstCreator(
-            env.GetSender(), env.GetSchemeshardId("/Root"), env.GetYdbProxy(), env.GetPathId("/Root"),
+            env.GetSender(), env.GetSchemeshardId("/Root"), env.GetYdbProxy(),
+            "/Root", env.GetPathId("/Root"),
             1 /* rid */, 1 /* tid */, TReplication::ETargetKind::Table, "/Root/Table", "/Root/Replicated"
         ));
 
@@ -254,7 +260,8 @@ Y_UNIT_TEST_SUITE(DstCreator) {
         env.CreateTable("/Root", *MakeTableDescription(mod(changeName(desc, "Dst"))));
 
         env.GetRuntime().Register(CreateDstCreator(
-            env.GetSender(), env.GetSchemeshardId("/Root"), env.GetYdbProxy(), env.GetPathId("/Root"),
+            env.GetSender(), env.GetSchemeshardId("/Root"), env.GetYdbProxy(),
+            "/Root", env.GetPathId("/Root"),
             1 /* rid */, 1 /* tid */, TReplication::ETargetKind::Table, "/Root/Src", "/Root/Dst"
         ));
 

--- a/ydb/core/tx/replication/controller/replication.cpp
+++ b/ydb/core/tx/replication/controller/replication.cpp
@@ -45,6 +45,14 @@ class TReplication::TImpl: public TLagProvider {
         SecretResolver = ctx.Register(CreateSecretResolver(ctx.SelfID, ReplicationId, PathId, secretName, ++SecretResolverCookie, Database));
     }
 
+    void ResolveDatabase(const TActorContext& ctx) {
+        if (TenantResolver) {
+            return;
+        }
+
+        TenantResolver = ctx.Register(CreateTenantResolver(ctx.SelfID, ReplicationId, PathId));
+    }
+
     ui64 GetExpectedSecretResolverCookie() const {
         return SecretResolverCookie;
     }
@@ -196,8 +204,8 @@ public:
             }
         }
 
-        if (!Tenant && !TenantResolver) {
-            TenantResolver = ctx.Register(CreateTenantResolver(ctx.SelfID, ReplicationId, PathId));
+        if (!Database) {
+            ResolveDatabase(ctx);
         }
 
         switch (State) {
@@ -265,7 +273,6 @@ public:
 private:
     const ui64 ReplicationId;
     const TPathId PathId;
-    TString Tenant;
 
     NKikimrReplication::TReplicationConfig Config;
     TString Database;
@@ -280,7 +287,7 @@ private:
     ui64 SecretResolverCookie = 0;
     TActorId ResourceIdResolver;
     TActorId YdbProxy;
-    TActorId TenantResolver;
+    TActorId TenantResolver; // TODO: Remove in next major release
     TActorId TargetDiscoverer;
 
 }; // TImpl
@@ -367,8 +374,17 @@ const NKikimrReplication::TReplicationConfig& TReplication::GetConfig() const {
     return Impl->Config;
 }
 
+void TReplication::SetDatabase(const TString& value) {
+    Impl->Database = value;
+    Impl->TenantResolver = {};
+}
+
 const TString& TReplication::GetDatabase() const {
     return Impl->Database;
+}
+
+void TReplication::ResolveDatabase(const TActorContext& ctx) {
+    Impl->ResolveDatabase(ctx);
 }
 
 void TReplication::SetState(EState state, TString issue) {
@@ -429,15 +445,6 @@ void TReplication::UpdateResourceId(const TString& value) {
     default:
         Y_ABORT("unreachable");
     }
-}
-
-void TReplication::SetTenant(const TString& value) {
-    Impl->Tenant = value;
-    Impl->TenantResolver = {};
-}
-
-const TString& TReplication::GetTenant() const {
-    return Impl->Tenant;
 }
 
 void TReplication::SetDropOp(const TActorId& sender, const std::pair<ui64, ui32>& opId) {

--- a/ydb/core/tx/replication/controller/replication.h
+++ b/ydb/core/tx/replication/controller/replication.h
@@ -141,7 +141,6 @@ public:
     void SetConfig(NKikimrReplication::TReplicationConfig&& config);
     void ResetCredentials(const TActorContext& ctx);
     const NKikimrReplication::TReplicationConfig& GetConfig() const;
-    const TString& GetDatabase() const;
     void SetState(EState state, TString issue = {});
     EState GetState() const;
     EState GetDesiredState() const;
@@ -157,8 +156,9 @@ public:
 
     void UpdateResourceId(const TString& value);
 
-    void SetTenant(const TString& value);
-    const TString& GetTenant() const;
+    void SetDatabase(const TString& value);
+    const TString& GetDatabase() const;
+    void ResolveDatabase(const TActorContext& ctx);
 
     bool CheckAlterDone() const;
 

--- a/ydb/core/tx/replication/controller/secret_resolver.cpp
+++ b/ydb/core/tx/replication/controller/secret_resolver.cpp
@@ -108,6 +108,7 @@ public:
         }
 
         auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+        request->DatabaseName = Database;
 
         auto& entry = request->ResultSet.emplace_back();
         entry.TableId = PathId;

--- a/ydb/core/tx/replication/controller/stream_creator_ut.cpp
+++ b/ydb/core/tx/replication/controller/stream_creator_ut.cpp
@@ -30,7 +30,8 @@ Y_UNIT_TEST_SUITE(StreamCreator) {
         env.CreateTable("/Root", *MakeTableDescription(tableDesc));
 
         env.GetRuntime().Register(CreateDstCreator(
-            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(), env.GetPathId("/Root"),
+            env.GetSender(), env.GetSchemeshardId("/Root/Table"), env.GetYdbProxy(),
+            "/Root", env.GetPathId("/Root"),
             1 /* rid */, 1 /* tid */, TReplication::ETargetKind::Table, "/Root/Table", "/Root/Replica"
         ));
         {

--- a/ydb/core/tx/replication/controller/tenant_resolver.cpp
+++ b/ydb/core/tx/replication/controller/tenant_resolver.cpp
@@ -13,6 +13,7 @@ namespace NKikimr::NReplication::NController {
 class TTenantResolver: public TActorBootstrapped<TTenantResolver> {
     void Resolve(const TPathId& pathId) {
         auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+        request->DatabaseName = ""; // it's intentional because TTenantResolver is deprecated
 
         auto& entry = request->ResultSet.emplace_back();
         entry.TableId = pathId;

--- a/ydb/core/tx/replication/controller/tx_create_replication.cpp
+++ b/ydb/core/tx/replication/controller/tx_create_replication.cpp
@@ -62,6 +62,13 @@ public:
         }
 
         if (Replication) {
+            const auto& tenant = Replication->GetDatabase();
+            Y_ABORT_UNLESS(tenant);
+            if (!Self->NodesManager.HasTenant(tenant)) {
+                CLOG_I(ctx, "Discover tenant nodes: tenant# " << tenant);
+                Self->NodesManager.DiscoverNodes(tenant, Self->DiscoveryCache, ctx);
+            }
+
             Replication->Progress(ctx);
         }
     }

--- a/ydb/core/tx/replication/controller/tx_resolve_database_result.cpp
+++ b/ydb/core/tx/replication/controller/tx_resolve_database_result.cpp
@@ -1,0 +1,79 @@
+#include "controller_impl.h"
+
+namespace NKikimr::NReplication::NController {
+
+class TController::TTxResolveDatabaseResult : public TTxBase {
+    const TEvPrivate::TEvResolveTenantResult::TPtr Ev;
+    TReplication::TPtr Replication;
+
+public:
+    explicit TTxResolveDatabaseResult(TController* self, TEvPrivate::TEvResolveTenantResult::TPtr& ev)
+        : TTxBase("TxResolveDatabaseResult", self)
+        , Ev(ev)
+    {
+    }
+
+    TTxType GetTxType() const override {
+        return TXTYPE_RESOLVE_DATABASE_RESULT;
+    }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        CLOG_D(ctx, "Execute: " << Ev->Get()->ToString());
+
+        const auto rid = Ev->Get()->ReplicationId;
+        const auto& tenant = Ev->Get()->Tenant;
+
+        Replication = Self->Find(rid);
+        if (!Replication) {
+            CLOG_W(ctx, "Cannot resolve database of unknown replication"
+                << ": rid# " << rid);
+            return true;
+        }
+
+        Replication->SetDatabase(tenant);
+
+        if (Ev->Get()->IsSuccess()) {
+            CLOG_N(ctx, "Database resolved"
+                << ": rid# " << rid
+                << ", database# " << tenant);
+
+            Self->UnresolvedDatabaseReplications.erase(Replication->GetId());
+        } else {
+            CLOG_E(ctx, "Resolve database error"
+                << ": rid# " << rid);
+            Y_ABORT_UNLESS(!tenant);
+
+            auto& resolveAttempts = Self->UnresolvedDatabaseReplications[rid];
+            if (resolveAttempts > 0) {
+                Replication->ResolveDatabase(ctx);
+                --resolveAttempts;
+            } else {
+                Self->UnresolvedDatabaseReplications.erase(Replication->GetId());
+            }
+        }
+
+        if (tenant) {
+            NIceDb::TNiceDb db(txc.DB);
+            db.Table<Schema::Replications>().Key(Replication->GetId()).Update(
+                NIceDb::TUpdate<Schema::Replications::Database>(tenant)
+            );
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        CLOG_D(ctx, "Complete");
+
+        if (Self->UnresolvedDatabaseReplications.empty()) {
+            Self->SwitchToWork(ctx);
+        }
+    }
+
+}; // TTxResolveDatabaseResult
+
+void TController::RunTxResolveDatabaseResult(TEvPrivate::TEvResolveTenantResult::TPtr& ev, const TActorContext& ctx) {
+    Execute(new TTxResolveDatabaseResult(this, ev), ctx);
+}
+
+}

--- a/ydb/core/tx/replication/controller/ya.make
+++ b/ydb/core/tx/replication/controller/ya.make
@@ -60,6 +60,7 @@ SRCS(
     tx_heartbeat.cpp
     tx_init.cpp
     tx_init_schema.cpp
+    tx_resolve_database_result.cpp
     tx_resolve_resource_id_result.cpp
     tx_resolve_secret_result.cpp
     tx_worker_error.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
To avoid further SchemeCache requests without DatabaseName we have needs for resolve and persist DatabaseName for existing replications
