### PR TITLE
[q-stable-only] collect/report all non-zero MultiHop sensors on full stats mode

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_stats.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_stats.cpp
@@ -90,8 +90,7 @@ void FillTaskRunnerStats(ui64 taskId, ui32 stageId, const TDqTaskRunnerStats& ta
 
         for (const auto& stat : taskStats.MkqlStats) {
             if (!StatsLevelCollectProfile(level) &&
-                "MultiHop_EarlyThrownEventsCount" != stat.Key.GetName() &&
-                "MultiHop_LateThrownEventsCount"  != stat.Key.GetName()) {
+                !(stat.Value != 0 && stat.Key.GetName().starts_with("MultiHop_"sv))) {
                 continue;
             }
             auto* s = protoTask->MutableMkqlStats()->Add();


### PR DESCRIPTION
this reduces amount of collected sensors overall, adds more useful data, and less fragile wrt future changes.

TODO we need something more flexible, tunable in configuration or, better, runtime

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
