### PR TITLE
Make transaction not to see aborted changes

### DIFF
--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
@@ -16,7 +16,7 @@ bool TTxBlobsWritingFinished::DoExecute(TTransactionContext& txc, const TActorCo
     TInstant startTransactionTime = TInstant::Now();
     TMemoryProfileGuard mpg("TTxBlobsWritingFinished::Execute");
     txc.DB.NoMoreReadsForTx();
-    CommitSnapshot = Self->GetCurrentSnapshotForInternalModification().GetNextSnapshot();
+    CommitSnapshot = Self->GetCurrentSnapshotForInternalModification();
     NActors::TLogContextGuard logGuard =
         NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_BLOBS)("tablet_id", Self->TabletID())("tx_state", "execute");
     ACFL_DEBUG("event", "start_execute");

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
@@ -44,7 +44,7 @@ bool TTxBlobsWritingFinished::DoExecute(TTransactionContext& txc, const TActorCo
         InsertWriteIds.emplace_back(constructor->GetInsertWriteIdVerified());
         portion.Finalize(Self, txc);
         if (PackBehaviour == EOperationBehaviour::NoTxWrite) {
-            granule.CommitImmediateOnExecute(txc, CommitSnapshot->GetNextSnapshot(), portion.GetPortionInfo(), firstPKColumnId);
+            granule.CommitImmediateOnExecute(txc, *CommitSnapshot, portion.GetPortionInfo(), firstPKColumnId);
         } else {
             granule.InsertPortionOnExecute(txc, portion.GetPortionInfoPtr(), firstPKColumnId);
         }

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -179,9 +179,9 @@ NOlap::TSnapshot TColumnShard::GetMaxReadVersion() const {
         auto firstPlannedSnapshot = NOlap::TSnapshot(plannedTx->Step, plannedTx->TxId);
         return firstPlannedSnapshot.GetPreviousSnapshot();
     } else {
-        // If we use the current snapshot for internal modification, the scan will see portions that are committed with the same snapshot.
-        // So we should use the previous snapshot to avoid this.
-        // Internal modification are, for example, the abort of a transaction and no tx writes (bulk upsert).
+        // the same snapshot is used by bulk upsert and aborts
+        // aborts are fine, but be careful with bulk upsert,
+        // it must correctly break conflicting serializable txs
         return GetCurrentSnapshotForInternalModification();
     }
 }

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -182,7 +182,7 @@ NOlap::TSnapshot TColumnShard::GetMaxReadVersion() const {
         // If we use the current snapshot for internal modification, the scan will see portions that are committed with the same snapshot.
         // So we should use the previous snapshot to avoid this.
         // Internal modification are, for example, the abort of a transaction and no tx writes (bulk upsert).
-        return GetCurrentSnapshotForInternalModification().GetPreviousSnapshot();
+        return GetCurrentSnapshotForInternalModification();
     }
 }
 

--- a/ydb/core/tx/columnshard/common/snapshot.h
+++ b/ydb/core/tx/columnshard/common/snapshot.h
@@ -114,14 +114,6 @@ public:
             return TSnapshot(PlanStep, TxId - 1);
         }
     }
-
-    TSnapshot GetNextSnapshot() const {
-        if (TxId == ::Max<ui64>()) {
-            return TSnapshot(PlanStep + 1, 0);
-        } else {
-            return TSnapshot(PlanStep, TxId + 1);
-        }
-    }
 };
 
 } // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/common/snapshot.h
+++ b/ydb/core/tx/columnshard/common/snapshot.h
@@ -108,6 +108,7 @@ public:
     }
 
     TSnapshot GetPreviousSnapshot() const {
+        AFL_VERIFY(Valid());
         if (TxId == 0) {
             return TSnapshot(PlanStep - 1, ::Max<ui64>());
         } else {

--- a/ydb/core/tx/columnshard/common/snapshot.h
+++ b/ydb/core/tx/columnshard/common/snapshot.h
@@ -50,7 +50,7 @@ public:
     }
 
     constexpr bool Valid() const noexcept {
-        return PlanStep;
+        return PlanStep != 0 && TxId != 0;
     }
 
     static constexpr TSnapshot Zero() noexcept {

--- a/ydb/core/tx/columnshard/common/snapshot.h
+++ b/ydb/core/tx/columnshard/common/snapshot.h
@@ -50,7 +50,7 @@ public:
     }
 
     constexpr bool Valid() const noexcept {
-        return PlanStep && TxId;
+        return PlanStep;
     }
 
     static constexpr TSnapshot Zero() noexcept {

--- a/ydb/core/tx/columnshard/common/snapshot.h
+++ b/ydb/core/tx/columnshard/common/snapshot.h
@@ -106,6 +106,22 @@ public:
     explicit operator size_t() const {
         return CombineHashes(PlanStep, TxId);
     }
+
+    TSnapshot GetPreviousSnapshot() const {
+        if (TxId == 0) {
+            return TSnapshot(PlanStep - 1, ::Max<ui64>());
+        } else {
+            return TSnapshot(PlanStep, TxId - 1);
+        }
+    }
+
+    TSnapshot GetNextSnapshot() const {
+        if (TxId == ::Max<ui64>()) {
+            return TSnapshot(PlanStep + 1, 0);
+        } else {
+            return TSnapshot(PlanStep, TxId + 1);
+        }
+    }
 };
 
 } // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
@@ -447,6 +447,7 @@ public:
             return false;
         }
         if (DoAddTxConflict()) {
+            StageData->Clear();
             StageData->Abort();
             return true;
         }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
         portionState = GetPortionStateAtScanStart(portion->GetPortionInfo());
     }
 
-    const bool needSnapshots = GetReadMetadata()->GetRequestSnapshot() < portionState.MaxRecordSnapshot || portionState.Conflicting;
+    const bool needConflictDetector = portionState.Conflicting;
 
     const bool useIndexes = false;
     const bool hasDeletions = source->GetHasDeletions();
@@ -54,13 +54,13 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
 
     const bool preventDuplicates = NeedDuplicateFiltering() && !portionState.Conflicting;
     {
-        auto& result = CacheFetchingScripts[needSnapshots ? 1 : 0][partialUsageByPK ? 1 : 0][useIndexes ? 1 : 0][needShardingFilter ? 1 : 0]
+        auto& result = CacheFetchingScripts[needConflictDetector ? 1 : 0][partialUsageByPK ? 1 : 0][useIndexes ? 1 : 0][needShardingFilter ? 1 : 0]
                                            [hasDeletions ? 1 : 0][preventDuplicates ? 1 : 0];
         if (result.NeedInitialization()) {
             TGuard<TMutex> g(Mutex);
             if (auto gInit = result.StartInitialization()) {
                 gInit->InitializationFinished(BuildColumnsFetchingPlan(
-                    needSnapshots, partialUsageByPK, useIndexes, needShardingFilter, hasDeletions, preventDuplicates, isFinalSyncPoint));
+                    needConflictDetector, partialUsageByPK, useIndexes, needShardingFilter, hasDeletions, preventDuplicates, isFinalSyncPoint));
             }
             AFL_VERIFY(!result.NeedInitialization());
         }
@@ -68,7 +68,7 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
     }
 }
 
-std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(const bool needSnapshots, const bool partialUsageByPredicateExt,
+std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(const bool needConflictDetector, const bool partialUsageByPredicateExt,
     const bool /*useIndexes*/, const bool needFilterSharding, const bool needFilterDeletion, const bool preventDuplicates,
     const bool isFinalSyncPoint) const {
     const bool partialUsageByPredicate = partialUsageByPredicateExt && GetPredicateColumns()->GetColumnsCount();
@@ -90,7 +90,7 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(c
         if (partialUsageByPredicate) {
             acc.AddFetchingStep(*GetPredicateColumns(), NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter);
         }
-        if (needSnapshots || GetFFColumns()->Cross(*GetSpecColumns())) {
+        if (needConflictDetector || GetFFColumns()->Cross(*GetSpecColumns())) {
             acc.AddFetchingStep(*GetSpecColumns(), NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter);
         }
         if (needFilterDeletion) {
@@ -101,7 +101,7 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(c
             acc.AddAssembleStep(*GetPredicateColumns(), "PREDICATE", NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter, false);
             acc.AddStep(std::make_shared<TPredicateFilter>());
         }
-        if (needSnapshots || GetFFColumns()->Cross(*GetSpecColumns())) {
+        if (needConflictDetector || GetFFColumns()->Cross(*GetSpecColumns())) {
             acc.AddAssembleStep(*GetSpecColumns(), "SPEC", NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter, false);
             acc.AddStep(std::make_shared<TSnapshotFilter>());
         }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
@@ -103,7 +103,7 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(c
         }
         if (needConflictDetector || GetFFColumns()->Cross(*GetSpecColumns())) {
             acc.AddAssembleStep(*GetSpecColumns(), "SPEC", NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter, false);
-            acc.AddStep(std::make_shared<TSnapshotFilter>());
+            acc.AddStep(std::make_shared<TConflictDetector>());
         }
         if (preventDuplicates) {
             acc.AddStep(std::make_shared<TDuplicateFilter>());

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
@@ -58,7 +58,6 @@ void VerifyConflictingPortion(const std::shared_ptr<NCommon::IDataSource>& sourc
 
 TConclusion<bool> TConflictDetector::DoExecuteInplace(
     const std::shared_ptr<NCommon::IDataSource>& source, const TFetchingScriptCursor& /*step*/) const {
-    
     VerifyConflictingPortion(source);
     // it is not empty (not filtered everything out by other filters) and conflicting, so we must mark the conflict here
     AFL_VERIFY(source->AddTxConflict());

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
@@ -67,7 +67,6 @@ TConclusion<bool> TConflictDetector::DoExecuteInplace(
 
 TConclusion<bool> TSnapshotFilter::DoExecuteInplace(
     const std::shared_ptr<NCommon::IDataSource>& source, const TFetchingScriptCursor& /*step*/) const {
-
     auto filter =
         MakeSnapshotFilter(source->GetStageData().GetTable().ToTable(
                                std::set<ui32>({ (ui32)IIndexInfo::ESpecialColumn::PLAN_STEP, (ui32)IIndexInfo::ESpecialColumn::TX_ID }),
@@ -78,7 +77,6 @@ TConclusion<bool> TSnapshotFilter::DoExecuteInplace(
             return true;
         }
     }
-    
     source->MutableStageData().AddFilter(filter);
     return true;
 }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
@@ -32,33 +32,8 @@ TConclusion<bool> TSnapshotFilter::DoExecuteInplace(
     source->AddTxConflict();
     return true;
 
-    // If we have only conflicting portions
 
     
-    auto filter =
-        MakeSnapshotFilter(source->GetStageData().GetTable().ToTable(
-                               std::set<ui32>({ (ui32)IIndexInfo::ESpecialColumn::PLAN_STEP, (ui32)IIndexInfo::ESpecialColumn::TX_ID }),
-                               source->GetContext()->GetCommonContext()->GetResolver()),
-            source->GetContext()->GetReadMetadata()->GetRequestSnapshot());
-    if (filter.GetFilteredCount().value_or(source->GetRecordsCount()) != source->GetRecordsCount()) {
-        if (source->AddTxConflict()) {
-            return true;
-        }
-    }
-    
-    AFL_VERIFY(false)("fuck me", "we must not get here")("info", portionSource->GetPortionInfo().DebugString())("conflicting", status.Conflicting)("committed", status.Committed)("read snapshot", source->GetContext()->GetReadMetadata()->GetRequestSnapshot().DebugString());
-    // source->MutableStageData().Clear();
-    // source->MutableStageData().Abort();
-    // return true;
-    // total deny is 0
-    // cast to TPortionDataSource
-    // auto* portionSource = static_cast<TPortionDataSource*>(source.get());
-    // auto state = portionSource->GetContext()->GetPortionStateAtScanStart(portionSource->GetPortionInfo());
-    // auto count = filter.GetFilteredCount().value_or(0);
-    // // we must not have here a single row
-    // AFL_VERIFY(count == 0)("count", count)("source.record_count", source->GetRecordsCount())("filter", filter.DebugString())("portion", portionSource->GetPortionInfo().DebugString())("request_snapshot", source->GetContext()->GetReadMetadata()->GetRequestSnapshot().DebugString())("state.conflicting", ToString(state.Conflicting))("state.committed", ToString(state.Committed));
-    source->MutableStageData().AddFilter(filter);
-    return true;
 }
 
 TConclusion<bool> TDeletionFilter::DoExecuteInplace(

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.h
@@ -212,6 +212,18 @@ public:
     }
 };
 
+class TConflictDetector: public IFetchingStep {
+private:
+    using TBase = IFetchingStep;
+
+public:
+    virtual TConclusion<bool> DoExecuteInplace(
+        const std::shared_ptr<NCommon::IDataSource>& source, const TFetchingScriptCursor& step) const override;
+    TConflictDetector()
+        : TBase("CONFLICT_DETECTOR") {
+    }
+};
+
 class TSnapshotFilter: public IFetchingStep {
 private:
     using TBase = IFetchingStep;

--- a/ydb/core/tx/columnshard/engines/storage/granule/granule.h
+++ b/ydb/core/tx/columnshard/engines/storage/granule/granule.h
@@ -225,8 +225,14 @@ public:
         auto it = InsertedPortions.find(insertWriteId);
         AFL_VERIFY(it != InsertedPortions.end());
         AFL_VERIFY(InsertedPortionsById.contains(it->second->GetPortionId()));
-        it->second->SetCommitSnapshot(ssRemove);
+        // it is better to set remove snapshot before the commit snapshot
+        // because otherwise concurrent readers may see the portion as just committed while
+        // the commit snapshot is already set, but the remove snapshot is not set yet.
+        // this problem should be addressed properly by a synchronized (or atomic) access
+        // to this part of the portion info state https://github.com/ydb-platform/ydb/issues/27205.
+        // until then, this workaround is better than nothing.
         it->second->SetRemoveSnapshot(ssRemove);
+        it->second->SetCommitSnapshot(ssRemove);
         TDbWrapper wrapper(txc.DB, nullptr);
         it->second->CommitToDatabase(wrapper);
     }

--- a/ydb/core/tx/columnshard/operations/write.cpp
+++ b/ydb/core/tx/columnshard/operations/write.cpp
@@ -126,7 +126,7 @@ void TWriteOperation::AbortOnExecute(TColumnShard& owner, NTabletFlatExecutor::T
     TBlobGroupSelector dsGroupSelector(owner.Info());
     NOlap::TDbWrapper dbTable(txc.DB, &dsGroupSelector);
 
-    auto abortSnapshot = owner.GetCurrentSnapshotForInternalModification().GetNextSnapshot();
+    auto abortSnapshot = owner.GetCurrentSnapshotForInternalModification();
     for (auto&& i : InsertWriteIds) {
         owner.MutableIndexAs<NOlap::TColumnEngineForLogs>().MutableGranuleVerified(PathId.InternalPathId).AbortPortionOnExecute(
             txc, i, abortSnapshot);

--- a/ydb/core/tx/columnshard/operations/write.cpp
+++ b/ydb/core/tx/columnshard/operations/write.cpp
@@ -126,9 +126,10 @@ void TWriteOperation::AbortOnExecute(TColumnShard& owner, NTabletFlatExecutor::T
     TBlobGroupSelector dsGroupSelector(owner.Info());
     NOlap::TDbWrapper dbTable(txc.DB, &dsGroupSelector);
 
+    auto abortSnapshot = owner.GetCurrentSnapshotForInternalModification().GetNextSnapshot();
     for (auto&& i : InsertWriteIds) {
         owner.MutableIndexAs<NOlap::TColumnEngineForLogs>().MutableGranuleVerified(PathId.InternalPathId).AbortPortionOnExecute(
-            txc, i, owner.GetCurrentSnapshotForInternalModification());
+            txc, i, abortSnapshot);
     }
 }
 


### PR DESCRIPTION
fixes #26727,  #26207

Here we get rid of the SnapshotFilter in SimpleReader completely. We use ConflictDetector instead.

The fix relies on the fact that we take to the scan only compacted portions with appearance snapshot <= scan snapshot. In fact, the current logic relies on this too. So we just do not need a snapshot filter.

Only conflicting portions may reach the conflict detector, so there is no need to read anything from the disk. If the portion reaches the conflict detector, the portion is definitely conflicting.

Here is how we write the appearance snapshot to the local db (see we check that it is not 0,0) https://github.com/ydb-platform/ydb/blob/0c1e09afcb1bf802381666fcbd353bf80c601704/ydb/core/tx/columnshard/engines/portions/compacted.cpp#L11

Here is how we read the appearance snapshot from the local db (see we require it to be present) https://github.com/ydb-platform/ydb/blob/0c1e09afcb1bf802381666fcbd353bf80c601704/ydb/core/tx/columnshard/engines/db_wrapper.cpp#L145

Small but pleasant performance benefit is here too. Instead of actually reading the data the disk (snapshot filter, O(rows_number)), we just look at the remaining number of rows in the portion (conflict detector, O(1)).

