### PR TITLE
Fix test harness compatibility with stable-25-2

### DIFF
--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -251,7 +251,8 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
                 "--data-center=%s" % self.data_center
             )
 
-        if self.module is not None:
+        # The --module option was added after stable-25-3-1, check if binary supports it
+        if self.module is not None and self.__binary_supports_module_option():
             command.append(
                 "--module=%s" % self.module
             )
@@ -322,6 +323,14 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
                 break
             version_info.append(line)
         return '\n'.join(version_info)
+
+    def __binary_supports_module_option(self):
+        try:
+            help_output = yatest.common.execute([self.binary_path, 'server', '--help']).std_out.decode('utf-8')
+            return '--module' in help_output
+        except Exception:
+            # If we can't check, assume it doesn't support it (safer for old binaries)
+            return False
 
     def enable_config_dir(self):
         self.__use_config_store = True


### PR DESCRIPTION
### Changelog category 

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Fixup for https://github.com/ydb-platform/ydb/pull/26884

The previous commit broke many compatibility tests:

https://github.com/ydb-platform/ydb/actions/runs/18667366766 (FAILED: 209) 

```
E   (NLastGetopt::TUsageException) unknown option 'module' in '--module=7'
E   Try 'server --help' for more information.
E   Daemon failed with message: Unexpectedly finished before stop.
E   Process exit_code = 1.
```
