### PR TITLE
Fix IC overall network utilization

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_common.cpp
+++ b/ydb/library/actors/interconnect/interconnect_common.cpp
@@ -1,0 +1,31 @@
+#include "interconnect_common.h"
+
+namespace NActors {
+
+    double TInterconnectProxyCommon::CalculateNetworkUtilization() {
+        const ui64 sessions = NumSessionsWithDataInQueue.load();
+        const ui64 ts = GetCycleCountFast();
+        const ui64 prevts = CyclesOnLastSwitch.exchange(ts);
+        const ui64 passed = ts - prevts;
+        const ui64 zero = CyclesWithZeroSessions.exchange(0) + (sessions ? 0 : passed);
+        const ui64 nonzero = CyclesWithNonzeroSessions.exchange(0) + (sessions ? passed : 0);
+        return (double)nonzero / (zero + nonzero);
+    }
+
+    void TInterconnectProxyCommon::AddSessionWithDataInQueue() {
+        if (!NumSessionsWithDataInQueue++) {
+            const ui64 ts = GetCycleCountFast();
+            const ui64 prevts = CyclesOnLastSwitch.exchange(ts);
+            CyclesWithZeroSessions += ts - prevts;
+        }
+    }
+
+    void TInterconnectProxyCommon::RemoveSessionWithDataInQueue() {
+        if (!--NumSessionsWithDataInQueue) {
+            const ui64 ts = GetCycleCountFast();
+            const ui64 prevts = CyclesOnLastSwitch.exchange(ts);
+            CyclesWithNonzeroSessions += ts - prevts;
+        }
+    }
+
+}

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -135,15 +135,9 @@ namespace NActors {
         std::atomic_uint64_t CyclesWithNonzeroSessions = 0;
         std::atomic_uint64_t CyclesWithZeroSessions = 0;
 
-        double CalculateNetworkUtilization() {
-            const ui64 sessions = NumSessionsWithDataInQueue.load();
-            const ui64 ts = GetCycleCountFast();
-            const ui64 prevts = CyclesOnLastSwitch.exchange(ts);
-            const ui64 passed = ts - prevts;
-            const ui64 zero = CyclesWithZeroSessions.exchange(0) + (sessions ? 0 : passed);
-            const ui64 nonzero = CyclesWithNonzeroSessions.exchange(0) + (sessions ? passed : 0);
-            return (double)nonzero / (zero + nonzero);
-        }
+        double CalculateNetworkUtilization();
+        void AddSessionWithDataInQueue();
+        void RemoveSessionWithDataInQueue();
 
         struct TVersionInfo {
             TString Tag; // version tag for this node

--- a/ydb/library/actors/interconnect/ya.make
+++ b/ydb/library/actors/interconnect/ya.make
@@ -20,6 +20,7 @@ SRCS(
     interconnect_address.h
     interconnect_channel.cpp
     interconnect_channel.h
+    interconnect_common.cpp
     interconnect_common.h
     interconnect_counters.cpp
     interconnect.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix IC overall network utilization

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes issue #26998 when network utilization is calculated incorrectly due to IC session actor death.
