### PR TITLE
Add a way to disable CMS

### DIFF
--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1664,10 +1664,6 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvPermissionRequest::TPtr &ev, const 
 {
     auto &rec = ev->Get()->Record;
 
-    if (!CheckEnabled(ev, ctx)) {
-        return;
-    }
-
     if (!rec.GetUser()) {
         return ReplyWithError<TEvCms::TEvPermissionResponse>(
             ev, TStatus::WRONG_REQUEST, "Missing user in request", ctx);
@@ -1708,10 +1704,6 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvCheckRequest::TPtr &ev, const TActo
 {
     auto &rec = ev->Get()->Record;
 
-    if (!CheckEnabled(ev, ctx)) {
-        return;
-    }
-
     if (!rec.GetUser()) {
         return ReplyWithError<TEvCms::TEvPermissionResponse>(
             ev, TStatus::WRONG_REQUEST, "Missing user in request", ctx);
@@ -1733,20 +1725,12 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvCheckRequest::TPtr &ev, const TActo
 
 void TCms::CheckAndEnqueueRequest(TEvCms::TEvConditionalPermissionRequest::TPtr &ev, const TActorContext &ctx)
 {
-    if (!CheckEnabled(ev, ctx)) {
-        return;
-    }
-
     ReplyWithError<TEvCms::TEvPermissionResponse>(ev, TStatus::ERROR, "Not supported", ctx);
 }
 
 void TCms::CheckAndEnqueueRequest(TEvCms::TEvNotification::TPtr &ev, const TActorContext &ctx)
 {
     auto &rec = ev->Get()->Record;
-
-    if (!CheckEnabled(ev, ctx)) {
-        return;
-    }
 
     if (!rec.GetUser()) {
         return ReplyWithError<TEvCms::TEvNotificationResponse>(

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1660,13 +1660,21 @@ void TCms::StartCollecting()
     Register(collector);
 }
 
+template<typename TEvRequestPtr>
+bool TCms::CheckEnabled(TEvRequestPtr &ev, const TActorContext &ctx)
+{
+    if (!State->Config.Enable) {
+        ReplyWithError<TEvCms::TEvPermissionResponse>(ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    }
+    return State->Config.Enable;
+}
+
 void TCms::CheckAndEnqueueRequest(TEvCms::TEvPermissionRequest::TPtr &ev, const TActorContext &ctx)
 {
     auto &rec = ev->Get()->Record;
 
-    if (!State->Config.Enable) {
-        return ReplyWithError<TEvCms::TEvPermissionResponse>(
-            ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    if (!CheckEnabled(ev, ctx)) {
+        return;
     }
 
     if (!rec.GetUser()) {
@@ -1709,9 +1717,8 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvCheckRequest::TPtr &ev, const TActo
 {
     auto &rec = ev->Get()->Record;
 
-    if (!State->Config.Enable) {
-        return ReplyWithError<TEvCms::TEvPermissionResponse>(
-            ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    if (!CheckEnabled(ev, ctx)) {
+        return;
     }
 
     if (!rec.GetUser()) {
@@ -1735,9 +1742,8 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvCheckRequest::TPtr &ev, const TActo
 
 void TCms::CheckAndEnqueueRequest(TEvCms::TEvConditionalPermissionRequest::TPtr &ev, const TActorContext &ctx)
 {
-    if (!State->Config.Enable) {
-        return ReplyWithError<TEvCms::TEvPermissionResponse>(
-            ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    if (!CheckEnabled(ev, ctx)) {
+        return;
     }
 
     ReplyWithError<TEvCms::TEvPermissionResponse>(ev, TStatus::ERROR, "Not supported", ctx);
@@ -1747,9 +1753,8 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvNotification::TPtr &ev, const TActo
 {
     auto &rec = ev->Get()->Record;
 
-    if (!State->Config.Enable) {
-        return ReplyWithError<TEvCms::TEvPermissionResponse>(
-            ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    if (!CheckEnabled(ev, ctx)) {
+        return;
     }
 
     if (!rec.GetUser()) {

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1664,6 +1664,11 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvPermissionRequest::TPtr &ev, const 
 {
     auto &rec = ev->Get()->Record;
 
+    if (!State->Config.Enable) {
+        return ReplyWithError<TEvCms::TEvPermissionResponse>(
+            ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    }
+
     if (!rec.GetUser()) {
         return ReplyWithError<TEvCms::TEvPermissionResponse>(
             ev, TStatus::WRONG_REQUEST, "Missing user in request", ctx);
@@ -1704,6 +1709,11 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvCheckRequest::TPtr &ev, const TActo
 {
     auto &rec = ev->Get()->Record;
 
+    if (!State->Config.Enable) {
+        return ReplyWithError<TEvCms::TEvPermissionResponse>(
+            ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    }
+
     if (!rec.GetUser()) {
         return ReplyWithError<TEvCms::TEvPermissionResponse>(
             ev, TStatus::WRONG_REQUEST, "Missing user in request", ctx);
@@ -1725,12 +1735,22 @@ void TCms::CheckAndEnqueueRequest(TEvCms::TEvCheckRequest::TPtr &ev, const TActo
 
 void TCms::CheckAndEnqueueRequest(TEvCms::TEvConditionalPermissionRequest::TPtr &ev, const TActorContext &ctx)
 {
+    if (!State->Config.Enable) {
+        return ReplyWithError<TEvCms::TEvPermissionResponse>(
+            ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    }
+
     ReplyWithError<TEvCms::TEvPermissionResponse>(ev, TStatus::ERROR, "Not supported", ctx);
 }
 
 void TCms::CheckAndEnqueueRequest(TEvCms::TEvNotification::TPtr &ev, const TActorContext &ctx)
 {
     auto &rec = ev->Get()->Record;
+
+    if (!State->Config.Enable) {
+        return ReplyWithError<TEvCms::TEvPermissionResponse>(
+            ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+    }
 
     if (!rec.GetUser()) {
         return ReplyWithError<TEvCms::TEvNotificationResponse>(

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1660,15 +1660,6 @@ void TCms::StartCollecting()
     Register(collector);
 }
 
-template<typename TEvRequestPtr>
-bool TCms::CheckEnabled(TEvRequestPtr &ev, const TActorContext &ctx)
-{
-    if (!State->Config.Enable) {
-        ReplyWithError<TEvCms::TEvPermissionResponse>(ev, TStatus::ERROR_TEMP, "CMS is disabled", ctx);
-    }
-    return State->Config.Enable;
-}
-
 void TCms::CheckAndEnqueueRequest(TEvCms::TEvPermissionRequest::TPtr &ev, const TActorContext &ctx)
 {
     auto &rec = ev->Get()->Record;

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -389,7 +389,7 @@ private:
     bool RemoveNotification(const TString &id, const TString &user, bool remove, TErrorInfo &error);
 
     template<typename TEvRequestPtr>
-    bool CheckEnabled(TEvRequestPtr &ev, const TActorContext &ctx) {
+    bool CheckEnabled(TEvRequestPtr &ev, const TActorContext &ctx) const {
         if (!State->Config.Enable) {
             ReplyWithError<TEvCms::TEvPermissionResponse>(ev, NKikimrCms::TStatus::ERROR_TEMP, "CMS is disabled", ctx);
         }

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -388,9 +388,15 @@ private:
     void GetNotifications(TEvCms::TEvManageNotificationRequest::TPtr &ev, bool all, const TActorContext &ctx);
     bool RemoveNotification(const TString &id, const TString &user, bool remove, TErrorInfo &error);
 
-    void EnqueueRequest(TAutoPtr<IEventHandle> ev, const TActorContext &ctx);
     template<typename TEvRequestPtr>
-    bool CheckEnabled(TEvRequestPtr &ev, const TActorContext &ctx);
+    bool CheckEnabled(TEvRequestPtr &ev, const TActorContext &ctx) {
+        if (!State->Config.Enable) {
+            ReplyWithError<TEvCms::TEvPermissionResponse>(ev, NKikimrCms::TStatus::ERROR_TEMP, "CMS is disabled", ctx);
+        }
+        return State->Config.Enable;
+    }
+
+    void EnqueueRequest(TAutoPtr<IEventHandle> ev, const TActorContext &ctx);
     void CheckAndEnqueueRequest(TEvCms::TEvPermissionRequest::TPtr &ev, const TActorContext &ctx);
     void CheckAndEnqueueRequest(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx);
     void CheckAndEnqueueRequest(TEvCms::TEvConditionalPermissionRequest::TPtr &ev, const TActorContext &ctx);

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -232,7 +232,7 @@ private:
                 ReplyWithError<TEvCms::TEvPermissionResponse>(*x, NKikimrCms::TStatus::ERROR_TEMP, "CMS is disabled", this->ActorContext()); \
             } \
             break; \
-        } \
+        } Y_SEMICOLON_GUARD
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -389,6 +389,8 @@ private:
     bool RemoveNotification(const TString &id, const TString &user, bool remove, TErrorInfo &error);
 
     void EnqueueRequest(TAutoPtr<IEventHandle> ev, const TActorContext &ctx);
+    template<typename TEvRequestPtr>
+    bool CheckEnabled(TEvRequestPtr &ev, const TActorContext &ctx);
     void CheckAndEnqueueRequest(TEvCms::TEvPermissionRequest::TPtr &ev, const TActorContext &ctx);
     void CheckAndEnqueueRequest(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx);
     void CheckAndEnqueueRequest(TEvCms::TEvConditionalPermissionRequest::TPtr &ev, const TActorContext &ctx);

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -2773,7 +2773,68 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         // tablet 'FLAT_BS_CONTROLLER' has too many unavailable nodes.
         env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(4), 60000000, "storage"));
-        
+    }
+
+    Y_UNIT_TEST(DisableCMS){
+        TCmsTestEnv env(16);
+
+        auto r1 = env.CheckPermissionRequest("user", false, false, true, true, TStatus::ALLOW,
+                                             MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000));
+        UNIT_ASSERT_VALUES_EQUAL(r1.PermissionsSize(), 1);
+
+        // Scheduled request
+        auto r2 = env.CheckPermissionRequest("user", false, false, /* scheduled */ true, true, TStatus::DISALLOW_TEMP,
+                                             MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000));
+
+        // Disable CMS
+        NKikimrCms::TCmsConfig config;
+        config.SetEnable(false);
+        env.SetCmsConfig(config);
+
+        env.CheckDonePermission("user", r1.GetPermissions(0).GetId());
+
+        // Requests should fail
+        env.CheckPermissionRequest("user", false, false, true, true, TStatus::ERROR_TEMP,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(9), 60000000));
+        env.CheckRequest("user", r2.GetRequestId(), true, TStatus::ERROR_TEMP);
+
+        // Enable CMS back
+        config.SetEnable(true);
+        env.SetCmsConfig(config);
+
+        // Requests should be ok
+        auto r3 = env.CheckPermissionRequest("user", false, false, true, true, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(9), 60000000));
+        UNIT_ASSERT_VALUES_EQUAL(r3.PermissionsSize(), 1);
+        env.CheckRequest("user", r2.GetRequestId(), true, TStatus::ALLOW, 1);
+    }
+
+    Y_UNIT_TEST(WalleDisableCMS){
+        TCmsTestEnv env(16);
+
+        env.CheckWalleCreateTask("task-1", "reboot", false, TStatus::ALLOW, env.GetNodeId(0));
+
+        // Scheduled request
+        env.CheckWalleCreateTask("task-2", "reboot", false, TStatus::DISALLOW_TEMP, env.GetNodeId(0));
+
+        // Disable CMS
+        NKikimrCms::TCmsConfig config;
+        config.SetEnable(false);
+        env.SetCmsConfig(config);
+
+        env.CheckWalleRemoveTask("task-1");
+
+        // Requests should fail
+        env.CheckWalleCreateTask("task-3", "reboot", false, TStatus::ERROR_TEMP, env.GetNodeId(9));
+        env.CheckWalleCheckTask("task-2", TStatus::ERROR_TEMP);
+
+        // Enable CMS back
+        config.SetEnable(true);
+        env.SetCmsConfig(config);
+
+        // Requests should be ok
+        env.CheckWalleCreateTask("task-3", "reboot", false, TStatus::ALLOW, env.GetNodeId(9));
+        env.CheckWalleCheckTask("task-2", TStatus::ALLOW);
     }
 }
 

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -506,6 +506,24 @@ public:
         return CheckMaintenanceTaskCreate(taskUid, code, Ydb::Maintenance::AVAILABILITY_MODE_STRONG, actionGroups...);
     }
 
+    Ydb::Maintenance::ManageActionResult CheckCompleteAction(
+        const Ydb::Maintenance::ActionUid &actionUid,
+        Ydb::StatusIds::StatusCode code)
+    {
+        auto ev = std::make_unique<NCms::TEvCms::TEvCompleteActionRequest>();
+
+        auto *req = ev->Record.MutableRequest();
+        req->mutable_action_uids()->Add()->CopyFrom(actionUid);
+
+        SendToPipe(CmsId, Sender, ev.release(), 0, GetPipeConfigWithRetries());
+        TAutoPtr<IEventHandle> handle;
+        auto reply = GrabEdgeEventRethrow<NCms::TEvCms::TEvManageActionResponse>(handle);
+
+        const auto &rec = reply->Record;
+        UNIT_ASSERT_VALUES_EQUAL(rec.GetStatus(), code);
+        return rec.GetResult();
+    }
+
     void EnableBSBaseConfig();
     void DisableBSBaseConfig();
 

--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -257,6 +257,7 @@ struct TCmsLogConfig {
 };
 
 struct TCmsConfig {
+    bool Enable = true;
     TDuration DefaultRetryTime;
     TDuration DefaultPermissionDuration;
     TDuration DefaultWalleCleanupPeriod = TDuration::Minutes(1);
@@ -275,6 +276,7 @@ struct TCmsConfig {
     }
 
     void Serialize(NKikimrCms::TCmsConfig &config) const {
+        config.SetEnable(Enable);
         config.SetDefaultRetryTime(DefaultRetryTime.GetValue());
         config.SetDefaultPermissionDuration(DefaultPermissionDuration.GetValue());
         config.SetInfoCollectionTimeout(InfoCollectionTimeout.GetValue());
@@ -285,6 +287,7 @@ struct TCmsConfig {
     }
 
     void Deserialize(const NKikimrCms::TCmsConfig &config) {
+        Enable = config.GetEnable();
         DefaultRetryTime = TDuration::MicroSeconds(config.GetDefaultRetryTime());
         DefaultPermissionDuration = TDuration::MicroSeconds(config.GetDefaultPermissionDuration());
         InfoCollectionTimeout = TDuration::MicroSeconds(config.GetInfoCollectionTimeout());

--- a/ydb/core/cms/walle_api_handler.cpp
+++ b/ydb/core/cms/walle_api_handler.cpp
@@ -277,6 +277,12 @@ private:
             return false;
         }
 
+        if (status.GetCode() == TStatus::ERROR_TEMP) {
+            auto err = Sprintf("HTTP/1.1 503 Service Unavailable\r\n\r\n%s", status.GetReason().data());
+            ReplyWithError(err, ctx);
+            return false;
+        }
+
         auto err = Sprintf("HTTP/1.1 500 Internal Server Error\r\n\r\n%s", status.GetReason().data());
         ReplyWithError(err, ctx);
         return false;

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -514,6 +514,7 @@ message TCmsConfig {
     optional uint64 InfoCollectionTimeout = 6 [default = 15000000];
     optional TLogConfig LogConfig = 7;
     optional TSentinelConfig SentinelConfig = 8;
+    optional bool Enable = 9 [default = true];
 }
 
 message TPDiskID {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds functionality to enable/disable the CMS (Cluster Management System) through a configuration flag

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

When disabled, CMS rejects incoming maintenance requests with a temporary error status, allowing operators to temporarily suspend cluster maintenance operations.

- Adds an `Enable` boolean flag to the CMS configuration
- Implements request rejection logic that returns `ERROR_TEMP` status when CMS is disabled
- Maps `ERROR_TEMP` status to `HTTP 503 (Service Unavailable)` for Walle API endpoints