### PR TITLE
[COMMON] [ICRDMA] Fix unrealizable IContiguousChunk EXT-1594

### DIFF
--- a/ydb/core/blobstorage/crypto/ut/ut_helpers.h
+++ b/ydb/core/blobstorage/crypto/ut/ut_helpers.h
@@ -52,6 +52,10 @@ public:
         return BufSize;
     }
 
+    size_t GetAlign() const {
+        return Align;
+    }
+
     ~TAlignedBuf() {
         delete[] Buf;
     }
@@ -69,16 +73,18 @@ public:
         return {reinterpret_cast<const char *>(Buffer.Data()), Buffer.Size()};
     }
 
-    TMutableContiguousSpan GetDataMut() override {
-        return {reinterpret_cast<char *>(Buffer.Data()), Buffer.Size()};
-    }
-
     TMutableContiguousSpan UnsafeGetDataMut() override {
         return {reinterpret_cast<char *>(Buffer.Data()), Buffer.Size()};
     }
 
     size_t GetOccupiedMemorySize() const override {
         return Buffer.Size();
+    }
+
+    IContiguousChunk::TPtr Clone() override {
+        auto newBackend = MakeIntrusive<TRopeAlignedBufferBackend>(Buffer.Size(), Buffer.GetAlign());
+        ::memcpy(newBackend->UnsafeGetDataMut().data(), GetData().data(), GetData().size());
+        return newBackend;
     }
 };
 

--- a/ydb/core/blobstorage/vdisk/hulldb/base/hullds_arena.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/hullds_arena.h
@@ -22,12 +22,19 @@ namespace NKikimr {
             return Capacity;
         }
 
-        TMutableContiguousSpan GetDataMut() override {
+        TMutableContiguousSpan UnsafeGetDataMut() override {
             return {Data, Capacity};
         }
 
         static TIntrusivePtr<IContiguousChunk> Allocate() {
             return MakeIntrusive<TRopeArenaBackend>();
+        }
+
+        IContiguousChunk::TPtr Clone() override {
+            IContiguousChunk::TPtr buf = Allocate();
+            TContiguousSpan src = GetData();
+            ::memcpy(buf->UnsafeGetDataMut().GetData(), src.Data(), src.GetSize());
+            return buf;
         }
     };
 

--- a/ydb/core/erasure/erasure_split.cpp
+++ b/ydb/core/erasure/erasure_split.cpp
@@ -10,16 +10,16 @@ namespace NKikimr {
             return {ZeroData, sizeof(ZeroData)};
         }
 
-        TMutableContiguousSpan GetDataMut() override {
-            return {const_cast<char*>(ZeroData), sizeof(ZeroData)};
-        }
-
         TMutableContiguousSpan UnsafeGetDataMut() override {
             return {const_cast<char*>(ZeroData), sizeof(ZeroData)};
         }
 
         size_t GetOccupiedMemorySize() const override {
             return sizeof(ZeroData);
+        }
+
+        IContiguousChunk::TPtr Clone() noexcept override {
+            return this;
         }
     };
 

--- a/ydb/library/actors/interconnect/rdma/mem_pool.h
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.h
@@ -38,9 +38,10 @@ namespace NInterconnect::NRdma {
 
     public: // IContiguousChunk
         TContiguousSpan GetData() const override;
-        TMutableContiguousSpan GetDataMut() override;
+        TMutableContiguousSpan UnsafeGetDataMut() override;
         size_t GetOccupiedMemorySize() const override;
         EInnerType GetInnerType() const noexcept override;
+        IContiguousChunk::TPtr Clone() noexcept override;
     protected:
         TChunkPtr Chunk;
         const uint32_t Offset;
@@ -73,6 +74,7 @@ namespace NInterconnect::NRdma {
 
     class IMemPool {
     public:
+        // WARN: In case of addition new flags consider "Clone()" method implementation
         enum Flags : ui32 {
             EMPTY = 0,
             PAGE_ALIGNED = 1,    // Page alignment allocation

--- a/ydb/library/actors/interconnect/rdma/ut/allocator_ut.cpp
+++ b/ydb/library/actors/interconnect/rdma/ut/allocator_ut.cpp
@@ -304,6 +304,56 @@ TEST_P(WithAllPools, PageAlligned) {
     }
 }
 
+TEST_P(WithAllPools, RcBufDetach) {
+    auto memPool = GetParam();
+    TRcBuf data = memPool->AllocRcBuf(4, 0).value();
+    {
+        ::memcpy(data.UnsafeGetDataMut(), "test", 4);
+    }
+    TRcBuf data2 = data;
+    UNIT_ASSERT_EQUAL(data.GetData(), data2.GetData());
+    char* res = data2.Detach();
+    UNIT_ASSERT_UNEQUAL(data.GetData(), data2.GetData());
+    UNIT_ASSERT_EQUAL(res, data2.GetData());
+    UNIT_ASSERT_EQUAL(::memcmp(res, "test", 4), 0);
+    UNIT_ASSERT_EQUAL(::memcmp(data.GetData(), "test", 4), 0);
+}
+
+TEST_P(WithAllPools, RcBufDetachPageAlign) {
+    using namespace NInterconnect::NRdma;
+    static const ui64 pageAlign = NSystemInfo::GetPageSize() - 1;
+    auto memPool = GetParam();
+    TRcBuf data = memPool->AllocRcBuf(4, IMemPool::PAGE_ALIGNED).value();
+    {
+        ::memcpy(data.UnsafeGetDataMut(), "test", 4);
+    }
+    TRcBuf data2 = data;
+    UNIT_ASSERT_EQUAL(data.GetData(), data2.GetData());
+    UNIT_ASSERT_EQUAL((ui64)data.GetData() & pageAlign, 0ull);
+    char* res = data2.Detach();
+    UNIT_ASSERT_UNEQUAL(data.GetData(), data2.GetData());
+    UNIT_ASSERT_EQUAL((ui64)data.GetData() & pageAlign, 0ull);
+    UNIT_ASSERT_EQUAL((ui64)data2.GetData() & pageAlign, 0ull);
+    UNIT_ASSERT_EQUAL(res, data2.GetData());
+    UNIT_ASSERT_EQUAL(::memcmp(res, "test", 4), 0);
+    UNIT_ASSERT_EQUAL(::memcmp(data.GetData(), "test", 4), 0);
+}
+
+TEST_P(WithAllPools, DetachAndDestroySrc) {
+    auto memPool = GetParam();
+    TRcBuf data = memPool->AllocRcBuf(4, 0).value();
+    {
+        ::memcpy(data.UnsafeGetDataMut(), "test", 4);
+    }
+    TRcBuf data2 = data;
+    data = {};
+    UNIT_ASSERT_EQUAL(data2.GetSize(), 4u);
+    char* res = data2.Detach();
+    UNIT_ASSERT_EQUAL(data2.GetSize(), 4u);
+    UNIT_ASSERT_EQUAL(res, data2.GetData());
+    UNIT_ASSERT_EQUAL(::memcmp(res, "test", 4), 0);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     TAllocatorSuite,
     WithAllPools,

--- a/ydb/library/actors/interconnect/rdma/ut/allocator_ut.cpp
+++ b/ydb/library/actors/interconnect/rdma/ut/allocator_ut.cpp
@@ -319,6 +319,23 @@ TEST_P(WithAllPools, RcBufDetach) {
     UNIT_ASSERT_EQUAL(::memcmp(data.GetData(), "test", 4), 0);
 }
 
+TEST_P(WithAllPools, RcBufDetachAfterMut) {
+    auto memPool = GetParam();
+    TRcBuf data = memPool->AllocRcBuf(4, 0).value();
+    {
+        ::memcpy(data.UnsafeGetDataMut(), "test", 4);
+    }
+    // Check GetDataMut doesn't change backend in case of single ref
+    UNIT_ASSERT_EQUAL(data.GetData(), data.GetDataMut());
+    TRcBuf data2 = data;
+    UNIT_ASSERT_EQUAL(data.GetData(), data2.GetData());
+    char* res = data2.Detach();
+    UNIT_ASSERT_UNEQUAL(data.GetData(), data2.GetData());
+    UNIT_ASSERT_EQUAL(res, data2.GetData());
+    UNIT_ASSERT_EQUAL(::memcmp(res, "test", 4), 0);
+    UNIT_ASSERT_EQUAL(::memcmp(data.GetData(), "test", 4), 0);
+}
+
 TEST_P(WithAllPools, RcBufDetachPageAlign) {
     using namespace NInterconnect::NRdma;
     static const ui64 pageAlign = NSystemInfo::GetPageSize() - 1;

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -291,10 +291,10 @@ struct IContiguousChunk : TThrRefBase {
     virtual TMutableContiguousSpan UnsafeGetDataMut() = 0;
 
     /**
-     * Must return false if implementation shares data even if ref count for IContiguousChunk::TPtr equal to 1
+     * Must return false if the implementation shares data
      */
     virtual bool IsPrivate() const {
-        return true;
+        return RefCount() == 1;
     }
 
     virtual size_t GetOccupiedMemorySize() const = 0;
@@ -454,7 +454,7 @@ class TRcBuf {
                 } else if constexpr (std::is_same_v<T, TString>) {
                     return value.IsDetached();
                 } else if constexpr (std::is_same_v<T, IContiguousChunk::TPtr>) {
-                    return value.RefCount() == 1 && value->IsPrivate();
+                    return value->IsPrivate();
                 } else {
                     static_assert(TDependentFalse<T>);
                 }
@@ -496,7 +496,7 @@ class TRcBuf {
                     }
                     return {value.mutable_data(), value.size()};
                 } else if constexpr (std::is_same_v<T, IContiguousChunk::TPtr>) {
-                    if ((value->RefCount() != 1) || (value->IsPrivate() == false)) {
+                    if (!value->IsPrivate()) {
                         value = value->Clone();
                     }
                     return value->UnsafeGetDataMut();

--- a/ydb/library/actors/util/rc_buf_ut.cpp
+++ b/ydb/library/actors/util/rc_buf_ut.cpp
@@ -63,11 +63,23 @@ Y_UNIT_TEST_SUITE(TRcBuf) {
     Y_UNIT_TEST(Detach) {
         TRcBuf data = TRcBuf::Copy(TString("test"));
         TRcBuf data2 = data;
+        UNIT_ASSERT_EQUAL(data.GetData(), data2.GetData());
         char* res = data2.Detach();
         UNIT_ASSERT_UNEQUAL(data.GetData(), data2.GetData());
         UNIT_ASSERT_EQUAL(res, data2.GetData());
         UNIT_ASSERT_EQUAL(::memcmp(res, "test", 4), 0);
         UNIT_ASSERT_EQUAL(::memcmp(data.GetData(), "test", 4), 0);
+    }
+
+    Y_UNIT_TEST(DetachAndDestroySrc) {
+        TRcBuf data = TRcBuf::Copy(TString("test"));
+        TRcBuf data2 = data;
+        data = {};
+        UNIT_ASSERT_EQUAL(data2.GetSize(), 4);
+        char* res = data2.Detach();
+        UNIT_ASSERT_EQUAL(data2.GetSize(), 4);
+        UNIT_ASSERT_EQUAL(res, data2.GetData());
+        UNIT_ASSERT_EQUAL(::memcmp(res, "test", 4), 0);
     }
 
     Y_UNIT_TEST(Resize) {

--- a/ydb/library/actors/util/rope.h
+++ b/ydb/library/actors/util/rope.h
@@ -20,7 +20,7 @@ class TRopeAlignedBuffer : public IContiguousChunk {
     static constexpr size_t Alignment = 16;
     static constexpr size_t MallocAlignment = sizeof(size_t);
 
-    ui32 Size;
+    const ui32 Size;
     const ui32 Capacity;
     const ui32 Offset;
     alignas(Alignment) char Data[];
@@ -36,6 +36,13 @@ class TRopeAlignedBuffer : public IContiguousChunk {
 public:
     static TIntrusivePtr<TRopeAlignedBuffer> Allocate(size_t size) {
         return new(malloc(sizeof(TRopeAlignedBuffer) + size + Alignment - MallocAlignment)) TRopeAlignedBuffer(size);
+    }
+
+    IContiguousChunk::TPtr Clone() override {
+        TIntrusivePtr<TRopeAlignedBuffer> buf = Allocate(Size);
+        TContiguousSpan src = GetData();
+        ::memcpy(buf->UnsafeGetDataMut().GetData(), src.Data(), src.GetSize());
+        return buf;
     }
 
     void *operator new(size_t) {
@@ -59,7 +66,7 @@ public:
         return {Data + Offset, Size};
     }
 
-    TMutableContiguousSpan GetDataMut() override {
+    TMutableContiguousSpan UnsafeGetDataMut() override {
         return {Data + Offset, Size};
     }
 

--- a/ydb/library/actors/util/rope_ut.cpp
+++ b/ydb/library/actors/util/rope_ut.cpp
@@ -15,16 +15,18 @@ public:
         return {Buffer.data(), Buffer.size()};
     }
 
-    TMutableContiguousSpan GetDataMut() override {
-        return {Buffer.Detach(), Buffer.size()};
-    }
-
     TMutableContiguousSpan UnsafeGetDataMut() override {
         return {const_cast<char*>(Buffer.data()), Buffer.size()};
     }
 
     size_t GetOccupiedMemorySize() const override {
         return Buffer.capacity();
+    }
+
+    IContiguousChunk::TPtr Clone() override {
+        auto ptr = MakeIntrusive<TRopeStringBackend>(Buffer);
+        ptr->Buffer.Detach();
+        return ptr;
     }
 };
 

--- a/ydb/library/actors/util/shared_data_rope_backend.h
+++ b/ydb/library/actors/util/shared_data_rope_backend.h
@@ -27,7 +27,7 @@ public:
     }
 
     bool IsPrivate() const override {
-        return Buffer.IsPrivate();
+        return RefCount() == 1 && Buffer.IsPrivate();
     }
 
     size_t GetOccupiedMemorySize() const override {
@@ -36,9 +36,7 @@ public:
 
     IContiguousChunk::TPtr Clone() override {
         auto backend = MakeIntrusive<TRopeSharedDataBackend>(Buffer);
-        if (backend->Buffer.IsShared()) {
-            backend->Buffer = TSharedData::Copy(Buffer.data(), Buffer.size());
-        }
+        backend->Buffer.Detach();
         return backend;
     }
 };

--- a/ydb/library/yql/dq/common/rope_over_buffer.cpp
+++ b/ydb/library/yql/dq/common/rope_over_buffer.cpp
@@ -18,12 +18,17 @@ private:
         return Span_;
     }
 
-    TMutableContiguousSpan GetDataMut() override {
+    TMutableContiguousSpan UnsafeGetDataMut() override {
         YQL_ENSURE(false, "Payload mutation is not supported");
     }
 
     size_t GetOccupiedMemorySize() const override {
         return Span_.GetSize();
+    }
+
+    IContiguousChunk::TPtr Clone() noexcept override {
+        // Mutable call is not supported.
+        return this;
     }
 
     const std::shared_ptr<const void> Owner_;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The issue is:
1. Caller has a pointer to IContiguousChunk
2. If caller calls GetDataMut() and the object is not "private" (ref count is not equal to 1) the implementation had to perform "Detach()" and return pointer to copyed data.
3. But we have no place to store newly allocated object. Ooops...

The solution:
Replace IContiguousChunk::GetDataMut() with IContiguousChunk::Clone() + IContiguousChunk::UnsafeGetDataMut()





https://github.com/ydb-platform/ydb/issues/27372

### Changelog category <!-- remove all except one -->


* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->

probably IContiguousChunk::IsPrivate also should be removed to simplify the code...