### PR TITLE
stable-24-4-enterprise: backport view query rewrite bugfixes and improvements

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_export_scheme_uploader.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export_scheme_uploader.cpp
@@ -25,9 +25,9 @@ class TSchemeUploader: public TActorBootstrapped<TSchemeUploader> {
         Become(&TThis::StateDescribe);
     }
 
-    static TString BuildViewScheme(const TString& path, const NKikimrSchemeOp::TViewDescription& viewDescription, const TString& backupRoot, TString& error) {
+    static TString BuildViewScheme(const TString& path, const NKikimrSchemeOp::TViewDescription& viewDescription, const TString& database, const TString& backupRoot, TString& error) {
         NYql::TIssues issues;
-        auto scheme = NYdb::NDump::BuildCreateViewQuery(viewDescription.GetName(), path, viewDescription.GetQueryText(), backupRoot, issues);
+        auto scheme = NYdb::NDump::BuildCreateViewQuery(viewDescription.GetName(), path, viewDescription.GetQueryText(), database, backupRoot, issues);
         if (!scheme) {
             error = issues.ToString();
         }
@@ -38,7 +38,7 @@ class TSchemeUploader: public TActorBootstrapped<TSchemeUploader> {
         const auto pathType = describeResult.GetPathDescription().GetSelf().GetPathType();
         switch (pathType) {
             case NKikimrSchemeOp::EPathTypeView: {
-                Scheme = BuildViewScheme(describeResult.GetPath(), describeResult.GetPathDescription().GetViewDescription(), DatabaseRoot, error);
+                Scheme = BuildViewScheme(describeResult.GetPath(), describeResult.GetPathDescription().GetViewDescription(), DatabaseRoot, DatabaseRoot, error);
                 return !Scheme.empty();
             }
             default:

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -533,7 +533,7 @@ and writes it to the backup folder designated for this view.
 \param fsBackupDir the path on the file system to write the file with the CREATE VIEW statement to
 \param issues the accumulated backup issues container
 */
-void BackupView(TDriver driver, const TString& dbBackupRoot, const TString& dbPathRelativeToBackupRoot,
+void BackupView(TDriver driver, const TString& db, const TString& dbBackupRoot, const TString& dbPathRelativeToBackupRoot,
     const TFsPath& fsBackupDir, NYql::TIssues& issues
 ) {
     Y_ENSURE(!dbPathRelativeToBackupRoot.empty());
@@ -551,6 +551,7 @@ void BackupView(TDriver driver, const TString& dbBackupRoot, const TString& dbPa
         TFsPath(dbPathRelativeToBackupRoot).GetName(),
         dbPath,
         TString(viewDescription.GetQueryText()),
+        db,
         dbBackupRoot,
         issues
     );
@@ -636,7 +637,7 @@ void BackupFolderImpl(TDriver driver, const TString& dbPrefix, const TString& ba
                 }
             }
             if (dbIt.IsView()) {
-                BackupView(driver, dbIt.GetTraverseRoot(), dbIt.GetRelPath(), childFolderPath, issues);
+                BackupView(driver, database, dbIt.GetTraverseRoot(), dbIt.GetRelPath(), childFolderPath, issues);
             }
             dbIt.Next();
         }

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -593,7 +593,7 @@ static bool IsExcluded(const TString& path, const TVector<TRegExMatch>& exclusio
     return false;
 }
 
-void BackupFolderImpl(TDriver driver, const TString& dbPrefix, const TString& backupPrefix, TString path,
+void BackupFolderImpl(TDriver driver, const TString& database, const TString& dbPrefix, const TString& backupPrefix, TString path,
         const TFsPath folderPath, const TVector<TRegExMatch>& exclusionPatterns,
         bool schemaOnly, bool useConsistentCopyTable, bool avoidCopy, bool preservePoolKinds, bool ordered,
         NYql::TIssues& issues
@@ -760,7 +760,7 @@ void BackupFolder(TDriver driver, const TString& database, const TString& relDbP
         TString dbPrefix = JoinDatabasePath(database, relDbPath);
         TString path;
         NYql::TIssues issues;
-        BackupFolderImpl(driver, dbPrefix, tmpDbFolder, path, folderPath, exclusionPatterns,
+        BackupFolderImpl(driver, database, dbPrefix, tmpDbFolder, path, folderPath, exclusionPatterns,
             schemaOnly, useConsistentCopyTable, avoidCopy, preservePoolKinds, ordered, issues
         );
 

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -334,11 +334,11 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
         return true;
     }
 
+    restorePathPrefix = RewriteAbsolutePath(backupPathPrefix, backupRoot, restoreRoot);
+
     if (backupRoot == restoreRoot) {
         return true;
     }
-
-    restorePathPrefix = RewriteAbsolutePath(backupPathPrefix, backupRoot, restoreRoot);
 
     constexpr TStringBuf pattern = "PRAGMA TablePathPrefix = \"\\S+\";";
     if (!re2::RE2::Replace(&query, pattern,

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -61,7 +61,7 @@ struct TPathRewriter {
             return TString(path);
         }
 
-        return TStringBuilder() << '`' << NDump::RewriteAbsolutePath(path.Skip(1).Chop(1), BackupRoot, RestoreRoot) << '`';
+        return TStringBuilder() << '`' << ::RewriteAbsolutePath(path.Skip(1).Chop(1), BackupRoot, RestoreRoot) << '`';
     }
 
     TPathSplitUnix BuildAbsolutePath(TStringBuf path) const {
@@ -297,7 +297,7 @@ bool Format(const TString& query, TString& formattedQuery, NYql::TIssues& issues
     return formatter->Format(query, formattedQuery, issues);
 }
 
-bool RewriteTableRefs(TString& query, TStringBuf backupRoot, TStringBuf restoreRoot, TStringBuf backupPathPrefix, TStringBuf restorePathPrefix, NYql::TIssues& issues);
+bool RewriteTableRefs(TString& query, TStringBuf backupRoot, TStringBuf restoreRoot, TStringBuf backupPathPrefix, TStringBuf restorePathPrefix, NYql::TIssues& issues) {
     TRule_sql_query queryProto;
     if (!SqlToProtoAst(query, queryProto, issues)) {
         return false;

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -228,6 +228,7 @@ struct TViewQuerySplit {
     TString ContextRecreation;
     TString Select;
 
+    TViewQuerySplit() = default;
     TViewQuerySplit(const TVector<TString>& statements) {
         TStringBuilder context;
         for (int i = 0; i < std::ssize(statements) - 1; ++i) {
@@ -244,16 +245,9 @@ bool BuildTranslationSettings(const TString& query, google::protobuf::Arena& are
     return ParseTranslationSettings(query, settings, issues);
 }
 
-TLexers BuildLexers() {
-    TLexers lexers;
-    lexers.Antlr4 = MakeAntlr4LexerFactory();
-    lexers.Antlr4Ansi = MakeAntlr4AnsiLexerFactory();
-    return lexers;
-}
-
-bool SplitViewQuery(const TString& query, const TLexers& lexers, const TTranslationSettings& translationSettings, TViewQuerySplit& split, NYql::TIssues& issues) {
+bool SplitViewQuery(const TString& query, const TTranslationSettings& translationSettings, TViewQuerySplit& split, NYql::TIssues& issues) {
     TVector<TString> statements;
-    auto lexer = NSQLTranslationV1::MakeLexer(lexers, translationSettings.AnsiLexer, translationSettings.Antlr4Parser);
+    auto lexer = NSQLTranslationV1::MakeLexer(translationSettings.AnsiLexer);
     if (!SplitQueryToStatements(query, lexer, statements, issues)) {
         return false;
     }
@@ -271,8 +265,7 @@ bool SplitViewQuery(const TString& query, TViewQuerySplit& split, NYql::TIssues&
     if (!BuildTranslationSettings(query, arena, translationSettings, issues)) {
         return false;
     }
-    auto lexers = BuildLexers();
-    return SplitViewQuery(query, lexers, translationSettings, split, issues);
+    return SplitViewQuery(query, translationSettings, split, issues);
 }
 
 bool SqlToProtoAst(const TString& query, TRule_sql_query& queryProto, NYql::TIssues& issues) {

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -105,7 +105,7 @@ public:
         if (IsAbsolutePath(path)) {
             return RewriteAbsolutePath(path);
         } else if (!BackupPathPrefix.empty() && !RestorePathPrefix.empty()) {
-            return TStringBuilder() << '`' << BuildRelativePath(NDump::RewriteAbsolutePath(BuildAbsolutePath(path), BackupRoot, RestoreRoot)) << '`';
+            return TStringBuilder() << '`' << BuildRelativePath(::RewriteAbsolutePath(BuildAbsolutePath(path), BackupRoot, RestoreRoot)) << '`';
         }
 
         return path;

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.h
@@ -3,7 +3,7 @@
 namespace NYdb::NDump {
 
 TString BuildCreateViewQuery(
-    const TString& name, const TString& dbPath, const TString& viewQuery, const TString& backupRoot,
+    const TString& name, const TString& dbPath, const TString& viewQuery, const TString& database, const TString& backupRoot,
     NYql::TIssues& issues
 );
 


### PR DESCRIPTION
- **VIEW: fix folder to folder backups for relative path references (#26179)**
- **fixup**
- **compilation fixes 1**
- **compilation fix 2**
- **fixes for the tests**
- **VIEW: split view query using parser when backing-up (#26816)**
- **compilation fixes**
- **VIEW: ignore case when searching for TablePathPrefix on restoration (#26868)**

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Backport:
- (partially) 5876eb747ad78e5d96f9624205dd9201ea05bd8a
- 7c1350b9c1b6b307c52e1e71e28de79748f747ab
- ef3889c83d809188f4367d4aa97099f3809c077b
- 37977bbfea8ec787e661c9765aab16c1630519eb

