### PR TITLE
streamlookup: split sensors by task id

### DIFF
--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -1079,6 +1079,10 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
         lookupPayloadColumns,
         inputColumns
     );
+    auto taskCounters = args.TaskCounters;
+    if (taskCounters) {
+        taskCounters = taskCounters->GetSubgroup("task_id", ToString(args.TaskId))->GetSubgroup("input", ToString(args.InputIndex));
+    }
     if (settings.GetIsMultiget()) {
         auto actor = isWide ?
             (TInputTransformStreamMultiLookupBase*)new TInputTransformStreamMultiLookupWide(
@@ -1088,7 +1092,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
                 args.InputIndex,
                 args.TransformInput,
                 args.ComputeActorId,
-                args.TaskCounters,
+                taskCounters,
                 factory,
                 std::move(settings),
                 std::move(lookupKeyInputIndexes),
@@ -1110,7 +1114,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
                 args.InputIndex,
                 args.TransformInput,
                 args.ComputeActorId,
-                args.TaskCounters,
+                taskCounters,
                 factory,
                 std::move(settings),
                 std::move(lookupKeyInputIndexes),
@@ -1135,7 +1139,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
             args.InputIndex,
             args.TransformInput,
             args.ComputeActorId,
-            args.TaskCounters,
+            taskCounters,
             factory,
             std::move(settings),
             std::move(lookupKeyInputIndexes),
@@ -1157,7 +1161,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
             args.InputIndex,
             args.TransformInput,
             args.ComputeActorId,
-            args.TaskCounters,
+            taskCounters,
             factory,
             std::move(settings),
             std::move(lookupKeyInputIndexes),


### PR DESCRIPTION
there can be several lookups inside one query, avoid mixing up their sensors (and, in theory, there can be separate input transforms on different inputs)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

[q] Why task_id and not stage_id?
[a] task ids are usually stable, stage_id always changes from one restart to another and will blow up counter numbers
[q] Won't MaxTasksPerStage blow up counter number?
[a] Currently, no; one slj is one task; potentially -- yes (there are uncertain plans for parallelized slj), by then it may require redesign