### PR TITLE
Fix RegisterNode request race

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -2,7 +2,6 @@ ydb/core/blobstorage/dsproxy/ut TDSProxyPutTest.TestBlock42PutStatusErrorWith_1_
 ydb/core/blobstorage/dsproxy/ut TDSProxyPutTest.TestBlock42PutStatusOkWith_1_1_VdiskErrors
 ydb/core/blobstorage/dsproxy/ut TDSProxyPutTest.TestBlock42PutStatusOkWith_2_0_VdiskErrors
 ydb/core/blobstorage/pdisk/ut TPDiskFailureInjection.TestSilentWriteFailPDisk
-ydb/core/blobstorage/ut_blobstorage BlobPatching.PatchBlock42
 ydb/core/blobstorage/ut_blobstorage unittest.[*/*] chunk
 ydb/core/blobstorage/ut_blobstorage/ut_huge HugeBlobOnlineSizeChange.Compaction
 ydb/core/blobstorage/ut_blobstorage/ut_huge unittest.[*/*] chunk

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -401,12 +401,16 @@ public:
 
     void Complete(const TActorContext&) override {
         if (Response) {
-            auto *node = Self->FindNode(Request->Sender.NodeId());
-            Y_ABORT_UNLESS(node);
-            Y_ABORT_UNLESS(!node->Registered);
-            node->Registered = true;
-            Self->SendInReply(*Request, std::move(Response));
-            Self->Execute(new TTxUpdateNodeDrives(std::move(UpdateNodeDrivesRecord), Self));
+            if (const auto it = Self->PipeServerToNode.find(Request->Recipient); it != Self->PipeServerToNode.end()) {
+                const TNodeId nodeId = Request->Sender.NodeId();
+                Y_ABORT_UNLESS(it->second == nodeId);
+                auto *node = Self->FindNode(nodeId);
+                Y_ABORT_UNLESS(node);
+                Y_ABORT_UNLESS(!node->Registered);
+                node->Registered = true;
+                Self->SendInReply(*Request, std::move(Response));
+                Self->Execute(new TTxUpdateNodeDrives(std::move(UpdateNodeDrivesRecord), Self));
+            }
         }
         Self->ShredState.OnNodeReportTxComplete();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix RegisterNode request race

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes race that can lead to incorrect assertion failure.
