### PR TITLE
Prevent more than 32768 partitions during vector index build

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -36,7 +36,7 @@ static std::tuple<NTableIndex::NKMeans::TClusterId, NTableIndex::NKMeans::TClust
     if (!buildInfo.KMeans.NeedsAnotherLevel() || count <= 1 || shards <= 1) {
         return {1, 1, 1};
     }
-    for (; 2 * shards <= parts; parts = (parts + 1) / 2) {
+    for (; 2 * shards <= parts || parts > 32768; parts = (parts + 1) / 2) {
         step *= 2;
     }
     return {count, parts, step};


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Не уверен, что на это легко тест написать, но кейс по сути следующий - если в первой же build таблице внезапно оказалось очень много партиций (ну например она очень большая и сильно насплитилась в процессе построения), то условие не срабатывало и step оказывался 1. И если например childCount = 200*200, то есть 40000 - получалось 40000 партиций при создании следующей билд таблицы...