### PR TITLE
25-3: Fix datashards not resubscribing to subdomain state on some restarts

### DIFF
--- a/ydb/core/tx/datashard/datashard__init.cpp
+++ b/ydb/core/tx/datashard/datashard__init.cpp
@@ -192,7 +192,7 @@ void TDataShard::TTxInitRestored::Complete(const TActorContext& ctx) {
     }
 
     // Find subdomain path id if needed
-    if (Self->State == TShardState::Ready) {
+    if (Self->NeedToWatchSubDomainPathId()) {
         if (Self->SubDomainPathId) {
             Self->StartWatchingSubDomainPathId();
         } else {

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -2124,6 +2124,7 @@ public:
     void StopFindSubDomainPathId();
     void StartFindSubDomainPathId(bool delayFirstRequest = true);
 
+    bool NeedToWatchSubDomainPathId();
     void StopWatchingSubDomainPathId();
     void StartWatchingSubDomainPathId();
 

--- a/ydb/core/tx/datashard/datashard_ut_disk_quotas.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_disk_quotas.cpp
@@ -1,0 +1,318 @@
+#include "datashard_ut_common_kqp.h"
+
+#include <ydb/core/testlib/actors/block_events.h>
+
+namespace NKikimr {
+
+using namespace NKikimr::NDataShard;
+using namespace NKikimr::NDataShard::NKqpHelpers;
+using namespace NSchemeShard;
+using namespace Tests;
+
+Y_UNIT_TEST_SUITE(DataShardDiskQuotas) {
+
+    Y_UNIT_TEST(DiskQuotaExceeded) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            // .AddStoragePool("test", "/Root/db:test")
+            .SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
+
+        // FIXME: subdomain creation hangs waiting for coordinators
+        // Cerr << "... Creating subdomain" << Endl;
+        // ui64 txId = AsyncCreateSubDomain(server, sender, "/Root", "db", R"(
+        //         PlanResolution: 500
+        //         Coordinators: 1
+        //         Mediators: 1
+        //         TimeCastBucketsPerMediator: 2
+        //         StoragePools {
+        //             Name: "/Root/db:test"
+        //             Kind: "test"
+        //         }
+        //         DatabaseQuotas {
+        //             data_size_hard_quota: 1
+        //         }
+        //     )");
+        // WaitTxNotification(server, sender, txId);
+
+        Cerr << "... Setting hard disk quota to 1 byte" << Endl;
+        ui64 txId = AsyncAlterSubDomain(server, sender, "/", "Root", R"(
+                StoragePools {
+                    Name: "/Root:test"
+                    Kind: "test"
+                }
+                DatabaseQuotas {
+                    data_size_hard_quota: 1
+                }
+            )");
+        WaitTxNotification(server, sender, txId);
+
+        Cerr << "... Creating the table" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        size_t observedZeroStats = 0;
+        size_t observedNonZeroStats = 0;
+        auto periodicStatsObserver = runtime.AddObserver<TEvDataShard::TEvPeriodicTableStats>(
+            [&](auto& ev) {
+                auto* msg = ev->Get();
+                if (msg->Record.GetTableStats().GetDataSize() > 0) {
+                    ++observedNonZeroStats;
+                } else {
+                    ++observedZeroStats;
+                }
+            });
+
+        Cerr << "... Inserting the 1st row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (1, 1);
+                )"),
+            "<empty>");
+
+        runtime.WaitFor("non-zero stats", [&]{ return observedNonZeroStats > 0; });
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Note: this depends on schemeshard correctly bumping root path version
+        Cerr << "... Inserting the 2nd row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (2, 2);
+                )"),
+            "ERROR: UNAVAILABLE");
+    }
+
+    Y_UNIT_TEST(ShardRestartOnCreateTable) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
+
+        Cerr << "... Setting hard disk quota to 1 byte" << Endl;
+        ui64 txId = AsyncAlterSubDomain(server, sender, "/", "Root", R"(
+                StoragePools {
+                    Name: "/Root:test"
+                    Kind: "test"
+                }
+                DatabaseQuotas {
+                    data_size_hard_quota: 1
+                }
+            )");
+        WaitTxNotification(server, sender, txId);
+
+        Cerr << "... Creating the 1st table" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table1` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        size_t observedZeroStats = 0;
+        size_t observedNonZeroStats = 0;
+        auto periodicStatsObserver = runtime.AddObserver<TEvDataShard::TEvPeriodicTableStats>(
+            [&](auto& ev) {
+                auto* msg = ev->Get();
+                if (msg->Record.GetTableStats().GetDataSize() > 0) {
+                    ++observedNonZeroStats;
+                } else {
+                    ++observedZeroStats;
+                }
+            });
+
+        Cerr << "... Inserting the 1st row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table1` (key, value) VALUES (1, 1);
+                )"),
+            "<empty>");
+
+        runtime.WaitFor("non-zero stats", [&]{ return observedNonZeroStats > 0; });
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        Cerr << "... Inserting the 2nd row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table1` (key, value) VALUES (2, 2);
+                )"),
+            "ERROR: UNAVAILABLE");
+
+        Cerr << "... Creating the 2nd table" << Endl;
+        ui64 tabletId = 0;
+        auto createTabletObserver = runtime.AddObserver<TEvHive::TEvCreateTabletReply>(
+            [&](auto& ev) {
+                tabletId = ev->Get()->Record.GetTabletID();
+            });
+        TBlockEvents<TEvTxProcessing::TEvPlanStep> blockedPlan(runtime, [&](auto& ev) {
+            return ev->Get()->Record.GetTabletID() == tabletId;
+        });
+        auto createTableFuture = KqpSchemeExecSend(runtime, R"(
+            CREATE TABLE `/Root/table2` (key int, value int, PRIMARY KEY (key));
+            )");
+        runtime.WaitFor("blocked plan", [&]{ return blockedPlan.size() >= 1; });
+        blockedPlan.Stop();
+
+        Cerr << "... Restarting shard " << tabletId << Endl;
+        RebootTablet(runtime, tabletId, sender);
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExecWait(runtime, std::move(createTableFuture)),
+            "SUCCESS");
+
+        Cerr << "... Inserting the 3rd row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table2` (key, value) VALUES (3, 3);
+                )"),
+            "ERROR: UNAVAILABLE");
+
+        Cerr << "... Dropping the 1st table" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                DROP TABLE `/Root/table1`;
+            )"),
+            "SUCCESS");
+
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        Cerr << "... Inserting the 4th row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table2` (key, value) VALUES (4, 4);
+                )"),
+            "<empty>");
+    }
+
+    Y_UNIT_TEST(ShardRestartOnSplitDst) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
+
+        Cerr << "... Setting hard disk quota to 1 byte" << Endl;
+        ui64 txId = AsyncAlterSubDomain(server, sender, "/", "Root", R"(
+                StoragePools {
+                    Name: "/Root:test"
+                    Kind: "test"
+                }
+                DatabaseQuotas {
+                    data_size_hard_quota: 1
+                }
+            )");
+        WaitTxNotification(server, sender, txId);
+
+        Cerr << "... Creating tables" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table1` (key uint32, value int, PRIMARY KEY (key));
+                CREATE TABLE `/Root/table2` (key uint32, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        size_t observedZeroStats = 0;
+        size_t observedNonZeroStats = 0;
+        auto periodicStatsObserver = runtime.AddObserver<TEvDataShard::TEvPeriodicTableStats>(
+            [&](auto& ev) {
+                auto* msg = ev->Get();
+                if (msg->Record.GetTableStats().GetDataSize() > 0) {
+                    ++observedNonZeroStats;
+                } else {
+                    ++observedZeroStats;
+                }
+            });
+
+        Cerr << "... Inserting the 1st row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table1` (key, value) VALUES (1, 1);
+                )"),
+            "<empty>");
+
+        runtime.WaitFor("non-zero stats", [&]{ return observedNonZeroStats > 0; });
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        Cerr << "... Inserting the 2nd row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table2` (key, value) VALUES (2, 2);
+                )"),
+            "ERROR: UNAVAILABLE");
+
+        TVector<ui64> tabletIds;
+        auto createTabletObserver = runtime.AddObserver<TEvHive::TEvCreateTabletReply>(
+            [&](auto& ev) {
+                tabletIds.push_back(ev->Get()->Record.GetTabletID());
+            });
+
+        TBlockEvents<TEvDataShard::TEvSplitTransferSnapshot> blockedSnapshots(runtime);
+
+        Cerr << "... Splitting the 2nd table" << Endl;
+        SetSplitMergePartCountLimit(server->GetRuntime(), -1);
+        auto shards2before = GetTableShards(server, sender, "/Root/table2");
+        ui64 txId2 = AsyncSplitTable(server, sender, "/Root/table2", shards2before.at(0), 10);
+        runtime.WaitFor("blocked snapshots", [&]{ return blockedSnapshots.size() >= 2; });
+        blockedSnapshots.Stop();
+
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Reboot dst tablets
+        createTabletObserver.Remove();
+        for (ui64 tabletId : tabletIds) {
+            Cerr << "... Restarting shard " << tabletId << Endl;
+            RebootTablet(runtime, tabletId, sender);
+        }
+
+        // Wait for split to finish
+        Cerr << "... Waiting for split to finish" << Endl;
+        WaitTxNotification(server, sender, txId2);
+
+        // Shards should still be blocked from writes
+        Cerr << "... Inserting the 3rd row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table2` (key, value) VALUES (3, 3);
+                )"),
+            "ERROR: UNAVAILABLE");
+
+        Cerr << "... Dropping the 1st table" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                DROP TABLE `/Root/table1`;
+            )"),
+            "SUCCESS");
+
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        Cerr << "... Inserting the 4th row" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table2` (key, value) VALUES (4, 4);
+                )"),
+            "<empty>");
+    }
+
+} // Y_UNIT_TEST_SUITE(DataShardDiskQuotas)
+
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -2835,4 +2835,38 @@ TString ReadTable(
     return result;
 }
 
+ui64 AsyncCreateSubDomain(
+        const Tests::TServer::TPtr& server,
+        const TActorId& sender,
+        const TString& workingDir,
+        const TString& name,
+        const TString& schema)
+{
+    auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpCreateSubDomain, workingDir);
+    auto* m = request->Record.MutableTransaction()->MutableModifyScheme();
+    auto* op = m->MutableSubDomain();
+    op->SetName(name);
+    bool ok = google::protobuf::TextFormat::MergeFromString(schema, op);
+    UNIT_ASSERT_C(ok, "failed to parse schema: " << schema);
+
+    return RunSchemeTx(*server->GetRuntime(), std::move(request), sender, true);
+}
+
+ui64 AsyncAlterSubDomain(
+        const Tests::TServer::TPtr& server,
+        const TActorId& sender,
+        const TString& workingDir,
+        const TString& name,
+        const TString& schema)
+{
+    auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpAlterSubDomain, workingDir);
+    auto* m = request->Record.MutableTransaction()->MutableModifyScheme();
+    auto* op = m->MutableSubDomain();
+    op->SetName(name);
+    bool ok = google::protobuf::TextFormat::MergeFromString(schema, op);
+    UNIT_ASSERT_C(ok, "failed to parse schema: " << schema);
+
+    return RunSchemeTx(*server->GetRuntime(), std::move(request), sender, true);
+}
+
 }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -732,6 +732,20 @@ ui64 AsyncAlterRestoreMultipleIncrementalBackups(
         const TVector<TString>& srcTablePaths,
         const TString& dstTablePAth);
 
+ui64 AsyncCreateSubDomain(
+        const Tests::TServer::TPtr& server,
+        const TActorId& sender,
+        const TString& workingDir,
+        const TString& name,
+        const TString& schema);
+
+ui64 AsyncAlterSubDomain(
+        const Tests::TServer::TPtr& server,
+        const TActorId& sender,
+        const TString& workingDir,
+        const TString& name,
+        const TString& schema);
+
 struct TReadShardedTableState {
     TActorId Sender;
     TActorId Worker;

--- a/ydb/core/tx/datashard/ut_disk_quotas/ya.make
+++ b/ydb/core/tx/datashard/ut_disk_quotas/ya.make
@@ -1,0 +1,29 @@
+UNITTEST_FOR(ydb/core/tx/datashard)
+
+IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
+    SIZE(LARGE)
+    TAG(ya:fat)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+PEERDIR(
+    ydb/core/tx/datashard/ut_common
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/default
+    ydb/core/tx
+    yql/essentials/public/udf/service/exception_policy
+    ydb/public/lib/yson_value
+    ydb/public/sdk/cpp/src/client/result
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    datashard_ut_disk_quotas.cpp
+)
+
+END()

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -315,7 +315,7 @@ RECURSE_FOR_TESTS(
     ut_change_exchange
     ut_column_stats
     ut_compaction
-    ut_vacuum
+    ut_disk_quotas
     ut_erase_rows
     ut_export
     ut_external_blobs
@@ -343,6 +343,7 @@ RECURSE_FOR_TESTS(
     ut_stats
     ut_trace
     ut_upload_rows
+    ut_vacuum
     ut_volatile
     ut_write
 )

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4656,6 +4656,11 @@ NKikimrSchemeOp::TPathVersion TSchemeShard::GetPathVersion(const TPath& path) co
                     result.SetSecurityStateVersion(subDomain->GetSecurityStateVersion());
                     generalVersion += result.GetSubDomainVersion();
                     generalVersion += result.GetSecurityStateVersion();
+
+                    if (ui64 version = subDomain->GetDomainStateVersion()) {
+                        result.SetSubDomainStateVersion(version);
+                        generalVersion += version;
+                    }
                 }
                 break;
             case NKikimrSchemeOp::EPathType::EPathTypeSubDomain:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed datashards sometimes not resubscribing to database "out of disk space" state on restarts. Fixes #27335.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Tests currently alter the domain root instead of creating a new subdomain.

Disk quotas in the domain root didn't work correctly, so this PR also fixes domain state version for the domain root.