### PR TITLE
Fix stucking SelfHealNodesStateUpdate cmd

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
@@ -113,6 +113,8 @@ namespace NKikimr::NStorage {
         }
         if (cmd.GetEnableSelfHealStateStorage()) {
             SelfHealStateStorage(cmd.GetWaitForConfigStep(), true, cmd.GetPileupReplicas(), cmd.GetOverrideReplicasInRingCount(), cmd.GetOverrideRingsCount(), cmd.GetReplicasSpecificVolume());
+        } else {
+            Finish(TResult::OK, std::nullopt);
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix stucking SelfHealNodesStateUpdate cmd

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixed stucking command leading to impossibility to execute further distconf transactions.
