### PR TITLE
Filled RateLimiter database name in SchemeCache requests

### DIFF
--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -44,6 +44,7 @@ namespace NSchemeCache {
 
 namespace NRpcService {
     struct TRlPath {
+        TString DatabaseName;
         TString CoordinationNode;
         TString ResourcePath;
     };

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -121,6 +121,14 @@ public:
 
     void InitializeAttributesFromSchema(const TSchemeBoardEvents::TDescribeSchemeResult& schemeData, const TVector<std::pair<TString, TString>>& rootAttributes) {
         CheckedDatabaseName_ = CanonizePath(schemeData.GetPath());
+
+        const auto& domainDescription = schemeData.GetPathDescription().GetDomainDescription();
+        const auto domainKey = TPathId::FromDomainKey(domainDescription.GetDomainKey());
+        const auto resourceDomainKey = TPathId::FromDomainKey(domainDescription.GetResourcesDomainKey());
+        if (resourceDomainKey != domainKey) {
+            ResourceDomainKey = resourceDomainKey;
+        }
+
         if (!GrpcRequestBaseCtx_->TryCustomAttributeProcess(schemeData, this)) {
             ProcessCommonAttributes(schemeData, rootAttributes);
         }
@@ -248,6 +256,90 @@ public:
             AuditLogConn(GrpcRequestBaseCtx_, CheckedDatabaseName_, TBase::GetUserSID(), TBase::GetSanitizedToken());
         }
 
+        if (ResourceDomainKey) {
+            ResolveResourceDatabase();
+        } else {
+            ProcessRlconfig(ctx);
+        }
+    }
+
+    void SetTokenAndDie() {
+        if (GrpcRequestBaseCtx_->IsClientLost()) {
+            LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
+                "Client was disconnected before processing request (check actor)");
+            const NYql::TIssues issues;
+            ReplyUnavailableAndDie(issues);
+        } else {
+            GrpcRequestBaseCtx_->UpdateAuthState(NYdbGrpc::TAuthState::AS_OK);
+            GrpcRequestBaseCtx_->SetInternalToken(TBase::GetParsedToken());
+            Continue();
+        }
+    }
+
+    STATEFN(DbAccessStateFunc) {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
+            hFunc(TEvents::TEvPoisonPill, HandlePoison);
+        }
+    }
+
+    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx) {
+        auto* navigate = ev->Get()->Request.Get();
+
+        Y_ABORT_UNLESS(navigate->ResultSet.size() == 1);
+        const auto& entry = navigate->ResultSet.front();
+
+        LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
+            "Handle " << ev->Get()->ToString() << ": entry# " << entry.ToString());
+
+        switch (entry.Status) {
+        case NSchemeCache::TSchemeCacheNavigate::EStatus::Ok:
+            break;
+        default:
+            LOG_WARN_S(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
+                "Unexpected status" << ": entry# " << entry.ToString());
+            return ReplyUnauthenticatedAndDie();
+        }
+
+        ResourceDatabaseName = CanonizePath(entry.Path);
+        ProcessRlconfig(ctx);
+    }
+
+    void HandlePoison(TEvents::TEvPoisonPill::TPtr&) {
+        GrpcRequestBaseCtx_->FinishSpan();
+        PassAway();
+    }
+
+    ui64 GetChannelBufferSize() const override {
+        return FacilityProvider_->GetChannelBufferSize();
+    }
+
+    TActorId RegisterActor(IActor* actor) const override {
+        // CheckActor will die after creation rpc_ actor
+        // so we can use same mailbox
+        return this->RegisterWithSameMailbox(actor);
+    }
+
+    void PassAway() override {
+        Span_.EndOk();
+        TBase::PassAway();
+    }
+
+private:
+    void ResolveResourceDatabase() {
+        auto navigate = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+        navigate->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
+
+        auto& entry = navigate->ResultSet.emplace_back();
+        entry.RequestType = NSchemeCache::TSchemeCacheNavigate::TEntry::ERequestType::ByTableId;
+        entry.TableId = *ResourceDomainKey;
+        entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
+        entry.RedirectRequired = false;
+
+        TBase::Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(navigate));
+    }
+
+    void ProcessRlconfig(const TActorContext& ctx) {
         // Simple rps limitation
         static NRpcService::TRlConfig rpsRlConfig(
             "serverless_rt_coordination_node_path",
@@ -334,53 +426,13 @@ public:
         }
     }
 
-    void SetTokenAndDie() {
-        if (GrpcRequestBaseCtx_->IsClientLost()) {
-            LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER,
-                "Client was disconnected before processing request (check actor)");
-            const NYql::TIssues issues;
-            ReplyUnavailableAndDie(issues);
-        } else {
-            GrpcRequestBaseCtx_->UpdateAuthState(NYdbGrpc::TAuthState::AS_OK);
-            GrpcRequestBaseCtx_->SetInternalToken(TBase::GetParsedToken());
-            Continue();
-        }
-    }
-
-    STATEFN(DbAccessStateFunc) {
-        switch (ev->GetTypeRewrite()) {
-            hFunc(TEvents::TEvPoisonPill, HandlePoison);
-        }
-    }
-
-    void HandlePoison(TEvents::TEvPoisonPill::TPtr&) {
-        GrpcRequestBaseCtx_->FinishSpan();
-        PassAway();
-    }
-
-    ui64 GetChannelBufferSize() const override {
-        return FacilityProvider_->GetChannelBufferSize();
-    }
-
-    TActorId RegisterActor(IActor* actor) const override {
-        // CheckActor will die after creation rpc_ actor
-        // so we can use same mailbox
-        return this->RegisterWithSameMailbox(actor);
-    }
-
-    void PassAway() override {
-        Span_.EndOk();
-        TBase::PassAway();
-    }
-
-private:
     static NYql::TIssues GetRlIssues(const Ydb::RateLimiter::AcquireResourceResponse& resp) {
         NYql::TIssues opIssues;
         NYql::IssuesFromMessage(resp.operation().issues(), opIssues);
         return opIssues;
     }
 
-    void ProcessOnRequest(Ydb::RateLimiter::AcquireResourceRequest&& req, const TActorContext& ctx) {
+    void ProcessOnRequest(const TString& rlDatabase, Ydb::RateLimiter::AcquireResourceRequest&& req, const TActorContext& ctx) {
         auto time = TInstant::Now();
         auto cb = [this, time](Ydb::RateLimiter::AcquireResourceResponse resp) {
             TDuration delay = TInstant::Now() - time;
@@ -416,14 +468,14 @@ private:
 
         NKikimr::NRpcService::RateLimiterAcquireUseSameMailbox(
             std::move(req),
-            CheckedDatabaseName_,
+            rlDatabase,
             TBase::GetSerializedToken(),
             std::move(cb),
             ctx);
     }
 
-    TRespHook CreateRlRespHook(Ydb::RateLimiter::AcquireResourceRequest&& req) {
-        const auto& databasename = CheckedDatabaseName_;
+    TRespHook CreateRlRespHook(const TString& rlDatabase, Ydb::RateLimiter::AcquireResourceRequest&& req) {
+        const TString databasename = rlDatabase;
         auto token = TBase::GetSerializedToken();
         auto counters = Counters_;
         return [req{std::move(req)}, databasename, token, counters](TRespHookCtx::TPtr ctx) mutable {
@@ -455,7 +507,8 @@ private:
 
     void ProcessRateLimit(const THashMap<TString, TString>& attributes, const TActorContext& ctx) {
         // Match rate limit config and database attributes
-        auto rlPath = NRpcService::Match(*RlConfig, attributes);
+        const auto& rlDatabase = ResourceDomainKey ? ResourceDatabaseName : CheckedDatabaseName_;
+        auto rlPath = NRpcService::MakeRlPath(rlDatabase, *RlConfig, attributes);
         if (!rlPath) {
             return SetTokenAndDie();
         } else {
@@ -471,13 +524,13 @@ private:
                     hasOnReqAction = true;
                     break;
                 case NRpcService::Actions::OnResp:
-                    GrpcRequestBaseCtx_->SetRespHook(CreateRlRespHook(std::move(action.second)));
+                    GrpcRequestBaseCtx_->SetRespHook(CreateRlRespHook(rlDatabase, std::move(action.second)));
                     break;
                 }
             }
 
             if (hasOnReqAction) {
-                return ProcessOnRequest(std::move(req), ctx);
+                return ProcessOnRequest(rlDatabase, std::move(req), ctx);
             } else {
                 return SetTokenAndDie();
             }
@@ -553,7 +606,7 @@ private:
     }
 
     void ReplyUnauthenticatedAndDie() {
-        GrpcRequestBaseCtx_->ReplyUnauthenticated("Unknown database");
+        GrpcRequestBaseCtx_->ReplyUnauthenticated("Unknown resource database");
         GrpcRequestBaseCtx_->FinishSpan();
         PassAway();
     }
@@ -693,6 +746,8 @@ private:
     IGRpcProxyCounters::TPtr Counters_;
     TIntrusivePtr<TSecurityObject> SecurityObject_;
     TString CheckedDatabaseName_;
+    TMaybe<TPathId> ResourceDomainKey;
+    TString ResourceDatabaseName;
     IRequestProxyCtx* GrpcRequestBaseCtx_;
     NRpcService::TRlConfig* RlConfig = nullptr;
     bool SkipCheckConnectRights_ = false;

--- a/ydb/core/grpc_services/local_rate_limiter.cpp
+++ b/ydb/core/grpc_services/local_rate_limiter.cpp
@@ -96,7 +96,7 @@ TActorId RateLimiterAcquireUseSameMailbox(
         request.set_required(required);
         return RateLimiterAcquireUseSameMailbox(
             std::move(request),
-            reqCtx.GetDatabaseName().GetOrElse(""),
+            rlPath.DatabaseName,
             reqCtx.GetSerializedToken(),
             std::move(cb),
             ctx,
@@ -130,7 +130,7 @@ static void Fill(const TRlConfig::TOnRespAction&,
     res.push_back({Actions::OnResp, request});
 }
 
-TMaybe<TRlPath> Match(const TRlConfig& rlConfig, const THashMap<TString, TString>& attrs) {
+TMaybe<TRlPath> MakeRlPath(const TString& database, const TRlConfig& rlConfig, const THashMap<TString, TString>& attrs) {
     const auto coordinationNodeIt = attrs.find(rlConfig.CoordinationNodeKey);
     if (coordinationNodeIt == attrs.end()) {
         return {};
@@ -141,7 +141,7 @@ TMaybe<TRlPath> Match(const TRlConfig& rlConfig, const THashMap<TString, TString
         return {};
     }
 
-    return TRlPath{coordinationNodeIt->second, rlResourcePathIt->second};
+    return TRlPath{database, coordinationNodeIt->second, rlResourcePathIt->second};
 }
 
 TVector<std::pair<Actions, Ydb::RateLimiter::AcquireResourceRequest>> MakeRequests(

--- a/ydb/core/grpc_services/local_rate_limiter.h
+++ b/ydb/core/grpc_services/local_rate_limiter.h
@@ -86,7 +86,7 @@ enum class Actions {
     OnResp
 };
 
-TMaybe<TRlPath> Match(const TRlConfig& rlConfig, const THashMap<TString, TString>& attrs);
+TMaybe<TRlPath> MakeRlPath(const TString& database, const TRlConfig& rlConfig, const THashMap<TString, TString>& attrs);
 TVector<std::pair<Actions, Ydb::RateLimiter::AcquireResourceRequest>> MakeRequests(
     const TRlConfig& rlConfig, const TRlPath& rlPath);
 

--- a/ydb/core/grpc_services/rpc_rate_limiter_api.cpp
+++ b/ydb/core/grpc_services/rpc_rate_limiter_api.cpp
@@ -22,9 +22,8 @@ class TRateLimiterRequest : public TRpcOperationRequestActor<TDerived, TRequest>
 public:
     using TBase = TRpcOperationRequestActor<TDerived, TRequest>;
 
-    TRateLimiterRequest(IRequestOpCtx* msg, bool trusted = false)
+    TRateLimiterRequest(IRequestOpCtx* msg)
         : TBase(msg)
-        , TrustedZone(trusted)
     {}
 
     static bool ValidateMetric (const Ydb::RateLimiter::MeteringConfig::Metric& srcMetric, Ydb::StatusIds::StatusCode& status, NYql::TIssues& issues) {
@@ -100,10 +99,9 @@ public:
     }
 
     bool ValidateCoordinationNodePath(Ydb::StatusIds::StatusCode& status, NYql::TIssues& issues) {
-        auto databaseName = this->Request_->GetDatabaseName()
-            .GetOrElse(DatabaseFromDomain(AppData()));
+        const auto databaseName = this->Request_->GetDatabaseName().GetOrElse("");
 
-        if (!TrustedZone && !GetCoordinationNodePath().StartsWith(databaseName)) {
+        if (!GetCoordinationNodePath().StartsWith(databaseName)) {
             status = StatusIds::BAD_REQUEST;
             issues.AddIssue(TStringBuilder()
                 << "Coordination node path: " << GetCoordinationNodePath()
@@ -118,9 +116,6 @@ protected:
     const TString& GetCoordinationNodePath() const {
         return this->GetProtoRequest()->coordination_node_path();
     }
-
-private:
-    const bool TrustedZone;
 };
 
 template <class TEvRequest>
@@ -574,11 +569,6 @@ public:
         Ydb::StatusIds::StatusCode status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
         NYql::TIssues issues;
 
-        if (!ValidateCoordinationNodePath(status, issues)) {
-            Reply(status, issues, TActivationContext::AsActorContext());
-            return;
-        }
-
         if (!ValidateRequest(status, issues)) {
             Reply(status, issues, TActivationContext::AsActorContext());
             return;
@@ -620,9 +610,8 @@ public:
     }
 
     void SendRequest() {
+        const TString database = Request().GetDatabaseName().GetOrElse("");
         UnsafeBecome(&TAcquireRateLimiterResourceRPC::StateFunc);
-        const TString database = ""; // to allow access to shared database
-
         if (GetProtoRequest()->units_case() == Ydb::RateLimiter::AcquireResourceRequest::UnitsCase::kRequired) {
             SendLeaf(
                 TEvQuota::TResourceLeaf(database,
@@ -705,7 +694,7 @@ void DoAcquireRateLimiterResource(std::unique_ptr<IRequestOpCtx> p, const IFacil
 
 template<>
 IActor* TEvAcquireRateLimiterResource::CreateRpcActor(NKikimr::NGRpcService::IRequestOpCtx* msg) {
-    return new TAcquireRateLimiterResourceRPC(msg, true);
+    return new TAcquireRateLimiterResourceRPC(msg);
 }
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/core/scheme/scheme_pathid.cpp
+++ b/ydb/core/scheme/scheme_pathid.cpp
@@ -1,5 +1,7 @@
 #include "scheme_pathid.h"
 
+#include <ydb/core/protos/subdomains.pb.h>
+
 #include <util/stream/str.h>
 
 namespace NKikimr {
@@ -114,6 +116,10 @@ NKikimrProto::TPathID TPathId::ToProto() const {
     NKikimrProto::TPathID proto;
     ToProto(proto);
     return proto;
+}
+
+TPathId TPathId::FromDomainKey(const NKikimrSubDomains::TDomainKey& proto) {
+    return TPathId(proto.GetSchemeShard(), proto.GetPathId());
 }
 
 } // NKikimr

--- a/ydb/core/scheme/scheme_pathid.h
+++ b/ydb/core/scheme/scheme_pathid.h
@@ -2,6 +2,12 @@
 
 #include <ydb/core/scheme/protos/pathid.pb.h>
 
+namespace NKikimrSubDomains {
+
+class TDomainKey;
+
+} // NKikimrSubDomains
+
 namespace NKikimr {
 
 using TOwnerId = ui64;
@@ -48,6 +54,7 @@ struct TPathId {
     void ToProto(NKikimrProto::TPathID& proto) const;
     void ToProto(NKikimrProto::TPathID* proto) const;
     NKikimrProto::TPathID ToProto() const;
+    static TPathId FromDomainKey(const NKikimrSubDomains::TDomainKey& proto);
 
 }; // TPathId
 

--- a/ydb/core/scheme/ya.make
+++ b/ydb/core/scheme/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
     library/cpp/deprecated/enum_codegen
     library/cpp/yson
     ydb/public/api/protos
+    ydb/core/protos
     ydb/core/scheme/protos
     ydb/core/scheme_types
     ydb/library/aclib

--- a/ydb/core/tx/scheme_board/helpers.cpp
+++ b/ydb/core/tx/scheme_board/helpers.cpp
@@ -72,7 +72,7 @@ TDomainId GetDomainId(const NKikimrScheme::TEvDescribeSchemeResult &record) {
 
     const auto& domainKey = pathDescription.GetDomainDescription().GetDomainKey();
 
-    return TDomainId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+    return TDomainId::FromDomainKey(domainKey);
 }
 
 TSet<ui64> GetAbandonedSchemeShardIds(const NKikimrScheme::TEvDescribeSchemeResult &record) {

--- a/ydb/core/tx/scheme_board/subscriber_ut.cpp
+++ b/ydb/core/tx/scheme_board/subscriber_ut.cpp
@@ -319,7 +319,7 @@ void TSubscriberCombinationsTest::CombinationsRootDomain() {
                 UNIT_ASSERT_VALUES_EQUAL(argsLeft.PathId, ev->Get()->PathId);
                 const NKikimrScheme::TEvDescribeSchemeResult& descr = ev->Get()->DescribeSchemeResult;
                 const auto& domainKey = descr.GetPathDescription().GetDomainDescription().GetDomainKey();
-                UNIT_ASSERT_VALUES_EQUAL(argsLeft.DomainId, TDomainId(domainKey.GetSchemeShard(), domainKey.GetPathId()));
+                UNIT_ASSERT_VALUES_EQUAL(argsLeft.DomainId, TDomainId::FromDomainKey(domainKey));
             }
 
             context->Send(replicas[1], populatorRight, argsRight.GenerateUpdate());
@@ -343,7 +343,7 @@ void TSubscriberCombinationsTest::CombinationsRootDomain() {
                 UNIT_ASSERT_VALUES_EQUAL(argsRight.PathId, ev->Get()->PathId);
                 const NKikimrScheme::TEvDescribeSchemeResult& descr = ev->Get()->DescribeSchemeResult;
                 const auto& domainKey = descr.GetPathDescription().GetDomainDescription().GetDomainKey();
-                UNIT_ASSERT_VALUES_EQUAL(argsRight.DomainId, TDomainId(domainKey.GetSchemeShard(), domainKey.GetPathId()));
+                UNIT_ASSERT_VALUES_EQUAL(argsRight.DomainId, TDomainId::FromDomainKey(domainKey));
 
                 continue;
             }
@@ -396,7 +396,7 @@ void TSubscriberCombinationsTest::MigratedPathRecreation() {
         UNIT_ASSERT_VALUES_EQUAL(argsLeft.PathId, ev->Get()->PathId);
         const NKikimrScheme::TEvDescribeSchemeResult& descr = ev->Get()->DescribeSchemeResult;
         const auto& domainKey = descr.GetPathDescription().GetDomainDescription().GetDomainKey();
-        UNIT_ASSERT_VALUES_EQUAL(argsLeft.DomainId, TDomainId(domainKey.GetSchemeShard(), domainKey.GetPathId()));
+        UNIT_ASSERT_VALUES_EQUAL(argsLeft.DomainId, TDomainId::FromDomainKey(domainKey));
     }
 
     context->Send(replicas[1], populatorRight, argsRight.GenerateUpdate());
@@ -420,7 +420,7 @@ void TSubscriberCombinationsTest::MigratedPathRecreation() {
         UNIT_ASSERT_VALUES_EQUAL(argsRight.PathId, ev->Get()->PathId);
         const NKikimrScheme::TEvDescribeSchemeResult& descr = ev->Get()->DescribeSchemeResult;
         const auto& domainKey = descr.GetPathDescription().GetDomainDescription().GetDomainKey();
-        UNIT_ASSERT_VALUES_EQUAL(argsRight.DomainId, TDomainId(domainKey.GetSchemeShard(), domainKey.GetPathId()));
+        UNIT_ASSERT_VALUES_EQUAL(argsRight.DomainId, TDomainId::FromDomainKey(domainKey));
 
         return;
     }
@@ -467,7 +467,7 @@ void TSubscriberCombinationsTest::CombinationsMigratedPath() {
                 UNIT_ASSERT_VALUES_EQUAL(argsLeft.PathId, ev->Get()->PathId);
                 const NKikimrScheme::TEvDescribeSchemeResult& descr = ev->Get()->DescribeSchemeResult;
                 const auto& domainKey = descr.GetPathDescription().GetDomainDescription().GetDomainKey();
-                UNIT_ASSERT_VALUES_EQUAL(argsLeft.DomainId, TDomainId(domainKey.GetSchemeShard(), domainKey.GetPathId()));
+                UNIT_ASSERT_VALUES_EQUAL(argsLeft.DomainId, TDomainId::FromDomainKey(domainKey));
             }
 
             context->Send(replicas[1], populatorRight, argsRight.GenerateUpdate());
@@ -491,7 +491,7 @@ void TSubscriberCombinationsTest::CombinationsMigratedPath() {
                 UNIT_ASSERT_VALUES_EQUAL(argsRight.PathId, ev->Get()->PathId);
                 const NKikimrScheme::TEvDescribeSchemeResult& descr = ev->Get()->DescribeSchemeResult;
                 const auto& domainKey = descr.GetPathDescription().GetDomainDescription().GetDomainKey();
-                UNIT_ASSERT_VALUES_EQUAL(argsRight.DomainId, TDomainId(domainKey.GetSchemeShard(), domainKey.GetPathId()));
+                UNIT_ASSERT_VALUES_EQUAL(argsRight.DomainId, TDomainId::FromDomainKey(domainKey));
 
                 continue;
             }

--- a/ydb/core/tx/scheme_cache/scheme_cache.h
+++ b/ydb/core/tx/scheme_cache/scheme_cache.h
@@ -69,12 +69,12 @@ struct TDomainInfo : public TAtomicRefCount<TDomainInfo> {
     {}
 
     explicit TDomainInfo(const NKikimrSubDomains::TDomainDescription& descr)
-        : DomainKey(GetDomainKey(descr.GetDomainKey()))
+        : DomainKey(TPathId::FromDomainKey(descr.GetDomainKey()))
         , Params(descr.GetProcessingParams())
         , Coordinators(descr.GetProcessingParams())
     {
         if (descr.HasResourcesDomainKey()) {
-            ResourcesDomainKey = GetDomainKey(descr.GetResourcesDomainKey());
+            ResourcesDomainKey = TPathId::FromDomainKey(descr.GetResourcesDomainKey());
         } else {
             ResourcesDomainKey = DomainKey;
         }
@@ -143,11 +143,6 @@ struct TDomainInfo : public TAtomicRefCount<TDomainInfo> {
     TVector<TGroup> Groups;
 
     TString ToString() const;
-
-private:
-    inline static TPathId GetDomainKey(const NKikimrSubDomains::TDomainKey& protoKey) {
-        return TPathId(protoKey.GetSchemeShard(), protoKey.GetPathId());
-    }
 
 }; // TDomainInfo
 

--- a/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
@@ -1519,8 +1519,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardExtSubDomainTest) {
                 NLs::IsExternalSubDomain("USER_0"),
                 NLs::ExtractDomainHive(&tenantHiveId),
             });
-            TSubDomainKey subdomainKey(describe.GetPathDescription().GetDomainDescription().GetDomainKey());
-            subdomainPathId = TPathId(subdomainKey.GetSchemeShard(), subdomainKey.GetPathId());
+            const auto& domainKey = describe.GetPathDescription().GetDomainDescription().GetDomainKey();
+            subdomainPathId = TPathId::FromDomainKey(domainKey);
         }
 
         // check that there is a new path in the root schemeshard

--- a/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
@@ -126,8 +126,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                     NLs::DomainSchemeshard(0),
                     NLs::DomainHive(0)
                 });
-                TSubDomainKey subdomainKey = TSubDomainKey(describe.GetPathDescription().GetDomainDescription().GetDomainKey());
-                subdomainPathId = TPathId(subdomainKey.GetSchemeShard(), subdomainKey.GetPathId());
+                const auto& domainKey = describe.GetPathDescription().GetDomainDescription().GetDomainKey();
+                subdomainPathId = TPathId::FromDomainKey(domainKey);
                 UNIT_ASSERT_VALUES_EQUAL(subdomainPathId.LocalPathId, 3);
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"), {

--- a/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
@@ -287,7 +287,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/partition_stats");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("metadata@system")});
             ExpectEqualSysViewDescription(describeResult, "partition_stats", ESysViewType::EPartitionStats,
                                           describedPathId);
@@ -295,14 +295,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/ds_pdisks");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("metadata@system")});
             ExpectEqualSysViewDescription(describeResult, "ds_pdisks", ESysViewType::EPDisks, describedPathId);
         }
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/query_metrics_one_minute");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("metadata@system")});
             ExpectEqualSysViewDescription(describeResult, "query_metrics_one_minute", ESysViewType::EQueryMetricsOneMinute,
                                           describedPathId);
@@ -329,7 +329,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/partition_stats");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("metadata@system")});
             ExpectEqualSysViewDescription(describeResult, "partition_stats", ESysViewType::EPartitionStats,
                                           describedPathId);
@@ -337,7 +337,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/ds_pdisks");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("metadata@system")});
             ExpectEqualSysViewDescription(describeResult, "ds_pdisks", ESysViewType::EPDisks, describedPathId);
         }
@@ -359,7 +359,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("root@builtin")});
             ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EShowCreate, describedPathId);
         }
@@ -376,7 +376,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_ds_pdisks");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("metadata@system")});
             ExpectEqualSysViewDescription(describeResult, "new_ds_pdisks", ESysViewType::EPDisks, describedPathId);
         }
@@ -391,7 +391,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_partition_stats");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("root@builtin")});
             ExpectEqualSysViewDescription(describeResult, "new_partition_stats", ESysViewType::EPartitionStats,
                                           describedPathId);
@@ -405,7 +405,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/partition_stats");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("metadata@system")});
             ExpectEqualSysViewDescription(describeResult, "partition_stats", ESysViewType::EPartitionStats,
                                           describedPathId);
@@ -421,7 +421,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_partition_stats");
             const auto& domainKey = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey();
-            const auto describedPathId = TPathId(domainKey.GetSchemeShard(), domainKey.GetPathId());
+            const auto describedPathId = TPathId::FromDomainKey(domainKey);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView, NLs::HasOwner("root@builtin")});
             ExpectEqualSysViewDescription(describeResult, "new_partition_stats", ESysViewType::EPartitionStats,
                                           describedPathId);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
To make a proper request from Rate Limiter to SchemeCache describing Kesus we have to fill a corresponded database.
In case a user makes requests to his serverless database we only have database name from a user request, but Kesus belongs to a shared database.

To resolve a shared database name from a resource domain key I added an extra resolving request to SchemeCache to TCheckRequstActor for requests to a serverless database.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added resolving RateLimiter database (for Serverless databases) before sending AcquireResources request
