### PR TITLE
Impl methods to detect BulkUpsert with DEFAULT columns and a flag to disable

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -238,4 +238,5 @@ message TFeatureFlags {
     optional bool EnableTopicMessageLevelParallelism = 212 [default = false];
     optional bool EnableOlapRejectProbability = 213 [default = false];
     optional bool EnablePDiskLogForSmallDisks = 214 [default = false];
+    optional bool DisableMissingDefaultColumnsInBulkUpsert = 215 [default = false];
 }

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -83,6 +83,7 @@ public:
     FEATURE_FLAG_SETTER(EnableDataShardWriteAlwaysVolatile)
     FEATURE_FLAG_SETTER(EnableStreamingQueries)
     FEATURE_FLAG_SETTER(EnableSecureScriptExecutions)
+    FEATURE_FLAG_SETTER(DisableMissingDefaultColumnsInBulkUpsert)
 
     #undef FEATURE_FLAG_SETTER
 };

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -381,6 +381,7 @@ private:
         THashMap<TString, ui32> columnByName;
         THashSet<TString> keyColumnsLeft;
         THashSet<TString> notNullColumnsLeft = entry.NotNullColumns;
+        THashSet<TString> defaultColumnsLeft;
         SrcColumns.reserve(entry.Columns.size());
         THashSet<TString> HasInternalConversion;
 
@@ -399,6 +400,10 @@ private:
                 keyColumnIds.resize(Max<size_t>(keyColumnIds.size(), keyOrder + 1));
                 keyColumnIds[keyOrder] = id;
                 keyColumnsLeft.insert(name);
+            }
+
+            if (colInfo.IsDefaultFromLiteral()) {
+                defaultColumnsLeft.insert(name);
             }
         }
 
@@ -498,6 +503,10 @@ private:
                 NotNullColumns.emplace(ci.Name);
             }
 
+            if (defaultColumnsLeft.contains(ci.Name)) {
+                defaultColumnsLeft.erase(ci.Name);
+            }
+
             if (ci.KeyOrder != -1) {
                 KeyColumnPositions[ci.KeyOrder] = TFieldDescription{ci.Id, ci.Name, (ui32)pos, ci.PType, pgTypeMod, notNull};
                 keyColumnsLeft.erase(ci.Name);
@@ -580,6 +589,21 @@ private:
 
         if (!notNullColumnsLeft.empty()) {
             return TConclusionStatus::Fail(Sprintf("Missing not null columns: %s", JoinSeq(", ", notNullColumnsLeft).c_str()));
+        }
+
+        if (!defaultColumnsLeft.empty() && UpsertIfExists) {
+            // some default columns are not specified in the request but upsert is executed in update mode
+            // we will not change these default columns, only update the columns that are specified in the request.
+            defaultColumnsLeft.clear();
+        }
+
+        if (!defaultColumnsLeft.empty()) {
+            if (AppData(ctx)->FeatureFlags.GetDisableMissingDefaultColumnsInBulkUpsert()) {
+                return TConclusionStatus::Fail(Sprintf("Missing default columns: %s", JoinSeq(", ", defaultColumnsLeft).c_str()));
+            }
+
+            UploadCounters.OnMissingDefaultColumns();
+            LOG_WARN_S(ctx, NKikimrServices::RPC_REQUEST, "Missing default columns: " << JoinSeq(", ", defaultColumnsLeft).c_str());
         }
 
         TConclusionStatus res = TConclusionStatus::Success();

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -592,8 +592,8 @@ private:
         }
 
         if (!defaultColumnsLeft.empty() && UpsertIfExists) {
-            // some default columns are not specified in the request but upsert is executed in update mode
-            // we will not change these default columns, only update the columns that are specified in the request.
+            // some default columns are not specified in the request, but upsert will only update existing rows
+            // and only the columns specified in the request will be updated; unspecified default columns will not be changed.
             defaultColumnsLeft.clear();
         }
 

--- a/ydb/core/tx/tx_proxy/upload_rows_counters.cpp
+++ b/ydb/core/tx/tx_proxy/upload_rows_counters.cpp
@@ -99,5 +99,6 @@ TUploadCounters::TUploadCounters()
             WrittenBytes = TBase::GetDeriviative("Replies/WrittenBytes");
             FailedBytes = TBase::GetDeriviative("Replies/FailedBytes");
             RequestsBytes = TBase::GetDeriviative("Requests/Bytes");
+            MissingDefaultColumnsCount = TBase::GetDeriviative("MissingDefaultColumns/Count");
 }
 }

--- a/ydb/core/tx/tx_proxy/upload_rows_counters.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_counters.h
@@ -76,6 +76,8 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr FailedBytes;
     NMonitoring::TDynamicCounters::TCounterPtr RequestsBytes;
 
+    NMonitoring::TDynamicCounters::TCounterPtr MissingDefaultColumnsCount;
+
     THashMap<TUploadStatus, NMonitoring::TDynamicCounters::TCounterPtr, TUploadStatus::THasher> CodesCount;
 
     NMonitoring::TDynamicCounters::TCounterPtr GetCodeCounter(const TUploadStatus& status);
@@ -141,6 +143,10 @@ public:
         PackageSizeRecordsByRecords->Collect((i64)rowsCount, rowsCount);
         PackageSizeCountByRecords->Collect(rowsCount);
         RequestsBytes->Add(requestBytes);
+    }
+
+    void OnMissingDefaultColumns() {
+        MissingDefaultColumnsCount->Inc();
     }
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

New feature flag `DisableMissingDefaultColumnsInBulkUpsert`:
- `true`: BulkUpsert returns an error if the default columns were not specified for writing.
- `false`: BulkUpsert returns OK, increments `MissingDefaultColumnsCount` counter and prints LOG_WARN_S.

Add some tests to check writing with/without a column building.

...
