### PR TITLE
pq/watermarks: fix multiplying Schedule in pq rd read actor (and limit idleness check re-schedule)

### DIFF
--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -453,7 +453,7 @@ public:
     TSession* FindAndUpdateSession(const TEventPtr& ev);
     void SendNoSession(const NActors::TActorId& recipient, ui64 cookie);
     void NotifyCA();
-    void SchedulePartitionInlenessCheck(TInstant) override;
+    void SchedulePartitionIdlenessCheck(TInstant) override;
     void InitWatermarkTracker() override;
     void SendStartSession(TSession& sessionInfo);
     void Init();
@@ -818,7 +818,7 @@ TDuration TDqPqRdReadActor::GetCpuTime() {
     return TDuration::MicroSeconds(CpuMicrosec);
 }
 
-void TDqPqRdReadActor::SchedulePartitionInlenessCheck(TInstant at) {
+void TDqPqRdReadActor::SchedulePartitionIdlenessCheck(TInstant at) {
     Schedule(at, new TEvPrivate::TEvPartitionIdleness(at));
 }
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -119,15 +119,15 @@ struct TEvPrivate {
         EvRefreshClusters = EvBegin + 23,
         EvReceivedClusters = EvBegin + 24,
         EvDescribeTopicResult = EvBegin + 25,
-        EvWatermarkIdleness = EvBegin + 26,
+        EvPartitionIdleness = EvBegin + 26,
         EvEnd
     };
     static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
     struct TEvPrintState : public NActors::TEventLocal<TEvPrintState, EvPrintState> {};
     struct TEvProcessState : public NActors::TEventLocal<TEvProcessState, EvProcessState> {};
     struct TEvNotifyCA : public NActors::TEventLocal<TEvNotifyCA, EvNotifyCA> {};
-    struct TEvWatermarkIdleness : public NActors::TEventLocal<TEvWatermarkIdleness, EvWatermarkIdleness> {
-        explicit TEvWatermarkIdleness(TInstant notifyTime)
+    struct TEvPartitionIdleness : public NActors::TEventLocal<TEvPartitionIdleness, EvPartitionIdleness> {
+        explicit TEvPartitionIdleness(TInstant notifyTime)
             : NotifyTime(notifyTime)
         {}
         const TInstant NotifyTime;
@@ -363,7 +363,7 @@ public:
     void Handle(TEvPrivate::TEvPrintState::TPtr&);
     void Handle(TEvPrivate::TEvProcessState::TPtr&);
     void Handle(TEvPrivate::TEvNotifyCA::TPtr&);
-    void Handle(TEvPrivate::TEvWatermarkIdleness::TPtr&);
+    void Handle(TEvPrivate::TEvPartitionIdleness::TPtr&);
     void Handle(TEvPrivate::TEvRefreshClusters::TPtr&);
     void Handle(TEvPrivate::TEvReceivedClusters::TPtr&);
     void Handle(TEvPrivate::TEvDescribeTopicResult::TPtr&);
@@ -388,7 +388,7 @@ public:
         hFunc(TEvPrivate::TEvPrintState, Handle);
         hFunc(TEvPrivate::TEvProcessState, Handle);
         hFunc(TEvPrivate::TEvNotifyCA, Handle);
-        hFunc(TEvPrivate::TEvWatermarkIdleness, Handle);
+        hFunc(TEvPrivate::TEvPartitionIdleness, Handle);
         hFunc(TEvPrivate::TEvRefreshClusters, Handle);
         hFunc(TEvPrivate::TEvReceivedClusters, Handle);
         hFunc(TEvPrivate::TEvDescribeTopicResult, Handle);
@@ -417,7 +417,7 @@ public:
         hFunc(TEvPrivate::TEvPrintState, IgnoreEvent);
         hFunc(TEvPrivate::TEvProcessState, IgnoreEvent);
         hFunc(TEvPrivate::TEvNotifyCA, IgnoreEvent);
-        hFunc(TEvPrivate::TEvWatermarkIdleness, IgnoreEvent);
+        hFunc(TEvPrivate::TEvPartitionIdleness, IgnoreEvent);
         hFunc(TEvPrivate::TEvRefreshClusters, IgnoreEvent);
         hFunc(TEvPrivate::TEvReceivedClusters, IgnoreEvent);
         hFunc(TEvPrivate::TEvDescribeTopicResult, IgnoreEvent);
@@ -453,7 +453,7 @@ public:
     TSession* FindAndUpdateSession(const TEventPtr& ev);
     void SendNoSession(const NActors::TActorId& recipient, ui64 cookie);
     void NotifyCA();
-    void ScheduleSourcesCheck(TInstant) override;
+    void SchedulePartitionInlenessCheck(TInstant) override;
     void InitWatermarkTracker() override;
     void SendStartSession(TSession& sessionInfo);
     void Init();
@@ -772,7 +772,7 @@ i64 TDqPqRdReadActor::GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& b
                 ReadyBuffer.back().Watermark = *idleWatermark;
             }
         }
-        MaybeScheduleNextIdleCheck(now);
+        MaybeSchedulePartitionIdlenessCheck(now);
     }
 
     if (freeSpace == 0 || ReadyBuffer.empty()) {
@@ -818,8 +818,8 @@ TDuration TDqPqRdReadActor::GetCpuTime() {
     return TDuration::MicroSeconds(CpuMicrosec);
 }
 
-void TDqPqRdReadActor::ScheduleSourcesCheck(TInstant at) {
-    Schedule(at, new TEvPrivate::TEvWatermarkIdleness(at));
+void TDqPqRdReadActor::SchedulePartitionInlenessCheck(TInstant at) {
+    Schedule(at, new TEvPrivate::TEvPartitionIdleness(at));
 }
 
 void TDqPqRdReadActor::InitWatermarkTracker() {
@@ -1539,8 +1539,8 @@ void TDqPqRdReadActor::Handle(TEvPrivate::TEvNotifyCA::TPtr&) {
     NotifyCA();
 }
 
-void TDqPqRdReadActor::Handle(TEvPrivate::TEvWatermarkIdleness::TPtr& ev) {
-    if (RemovePendingWatermarkIdlenessCheck(ev->Get()->NotifyTime)) {
+void TDqPqRdReadActor::Handle(TEvPrivate::TEvPartitionIdleness::TPtr& ev) {
+    if (RemoveExpiredPartitionIdlenessCheck(ev->Get()->NotifyTime)) {
         NotifyCA();
     }
 }

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -1540,7 +1540,7 @@ void TDqPqRdReadActor::Handle(TEvPrivate::TEvNotifyCA::TPtr&) {
 }
 
 void TDqPqRdReadActor::Handle(TEvPrivate::TEvWatermarkIdleness::TPtr& ev) {
-    if (InflyIdlenessChecks.erase(ev->Get()->NotifyTime)) {
+    if (RemovePendingWatermarkIdlenessCheck(ev->Get()->NotifyTime)) {
         NotifyCA();
     }
 }

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -119,12 +119,19 @@ struct TEvPrivate {
         EvRefreshClusters = EvBegin + 23,
         EvReceivedClusters = EvBegin + 24,
         EvDescribeTopicResult = EvBegin + 25,
+        EvWatermarkIdleness = EvBegin + 26,
         EvEnd
     };
     static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
     struct TEvPrintState : public NActors::TEventLocal<TEvPrintState, EvPrintState> {};
     struct TEvProcessState : public NActors::TEventLocal<TEvProcessState, EvProcessState> {};
     struct TEvNotifyCA : public NActors::TEventLocal<TEvNotifyCA, EvNotifyCA> {};
+    struct TEvWatermarkIdleness : public NActors::TEventLocal<TEvWatermarkIdleness, EvWatermarkIdleness> {
+        explicit TEvWatermarkIdleness(TInstant notifyTime)
+            : NotifyTime(notifyTime)
+        {}
+        const TInstant NotifyTime;
+    };
     struct TEvRefreshClusters : public NActors::TEventLocal<TEvRefreshClusters, EvRefreshClusters> {};
     struct TEvReceivedClusters : public NActors::TEventLocal<TEvReceivedClusters, EvReceivedClusters> {
         explicit TEvReceivedClusters(
@@ -356,6 +363,7 @@ public:
     void Handle(TEvPrivate::TEvPrintState::TPtr&);
     void Handle(TEvPrivate::TEvProcessState::TPtr&);
     void Handle(TEvPrivate::TEvNotifyCA::TPtr&);
+    void Handle(TEvPrivate::TEvWatermarkIdleness::TPtr&);
     void Handle(TEvPrivate::TEvRefreshClusters::TPtr&);
     void Handle(TEvPrivate::TEvReceivedClusters::TPtr&);
     void Handle(TEvPrivate::TEvDescribeTopicResult::TPtr&);
@@ -380,6 +388,7 @@ public:
         hFunc(TEvPrivate::TEvPrintState, Handle);
         hFunc(TEvPrivate::TEvProcessState, Handle);
         hFunc(TEvPrivate::TEvNotifyCA, Handle);
+        hFunc(TEvPrivate::TEvWatermarkIdleness, Handle);
         hFunc(TEvPrivate::TEvRefreshClusters, Handle);
         hFunc(TEvPrivate::TEvReceivedClusters, Handle);
         hFunc(TEvPrivate::TEvDescribeTopicResult, Handle);
@@ -408,6 +417,7 @@ public:
         hFunc(TEvPrivate::TEvPrintState, IgnoreEvent);
         hFunc(TEvPrivate::TEvProcessState, IgnoreEvent);
         hFunc(TEvPrivate::TEvNotifyCA, IgnoreEvent);
+        hFunc(TEvPrivate::TEvWatermarkIdleness, IgnoreEvent);
         hFunc(TEvPrivate::TEvRefreshClusters, IgnoreEvent);
         hFunc(TEvPrivate::TEvReceivedClusters, IgnoreEvent);
         hFunc(TEvPrivate::TEvDescribeTopicResult, IgnoreEvent);
@@ -751,12 +761,10 @@ i64 TDqPqRdReadActor::GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& b
 
     if (WatermarkTracker) {
         const auto now = TInstant::Now();
-        MaybeScheduleNextIdleCheck(now);
-
         const auto idleWatermark = WatermarkTracker->HandleIdleness(now);
 
         if (idleWatermark) {
-            SRC_LOG_D("SessionId: " << GetSessionId() << " Fake watermark " << idleWatermark << " was produced");
+            SRC_LOG_D("SessionId: " << GetSessionId() << " Idleness watermark " << idleWatermark << " was produced");
             if (ReadyBuffer.empty()) {
                 watermark = *idleWatermark;
             } else {
@@ -764,6 +772,7 @@ i64 TDqPqRdReadActor::GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& b
                 ReadyBuffer.back().Watermark = *idleWatermark;
             }
         }
+        MaybeScheduleNextIdleCheck(now);
     }
 
     if (freeSpace == 0 || ReadyBuffer.empty()) {
@@ -810,7 +819,7 @@ TDuration TDqPqRdReadActor::GetCpuTime() {
 }
 
 void TDqPqRdReadActor::ScheduleSourcesCheck(TInstant at) {
-    Schedule(at, new TEvPrivate::TEvNotifyCA());
+    Schedule(at, new TEvPrivate::TEvWatermarkIdleness(at));
 }
 
 void TDqPqRdReadActor::InitWatermarkTracker() {
@@ -1528,6 +1537,12 @@ void TDqPqRdReadActor::Handle(TEvPrivate::TEvRefreshClusters::TPtr&) {
 void TDqPqRdReadActor::Handle(TEvPrivate::TEvNotifyCA::TPtr&) {
     Schedule(TDuration::Seconds(NotifyCAPeriodSec), new TEvPrivate::TEvNotifyCA());
     NotifyCA();
+}
+
+void TDqPqRdReadActor::Handle(TEvPrivate::TEvWatermarkIdleness::TPtr& ev) {
+    if (InflyIdlenessChecks.erase(ev->Get()->NotifyTime)) {
+        NotifyCA();
+    }
 }
 
 std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateDqPqRdReadActor(

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
@@ -623,7 +623,7 @@ private:
         TDqPqReadActorBase::InitWatermarkTracker(TDuration::MicroSeconds(lateArrivalDelayUs), TDuration::MicroSeconds(idleDelayUs));
     }
 
-    void SchedulePartitionInlenessCheck(TInstant at) override {
+    void SchedulePartitionIdlenessCheck(TInstant at) override {
         Schedule(at, new TEvPrivate::TEvPartitionIdleness(at));
     }
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
@@ -582,8 +582,7 @@ private:
             const auto watermark = WatermarkTracker->HandleIdleness(now);
 
             if (watermark) {
-                const auto t = watermark;
-                SRC_LOG_T("SessionId: " << GetSessionId() << " Idleness watermark " << t << " was produced");
+                SRC_LOG_T("SessionId: " << GetSessionId() << " Idleness watermark " << *watermark << " was produced");
                 PushWatermarkToReady(*watermark);
                 recheckBatch = true;
             }

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
@@ -370,7 +370,7 @@ private:
     }
 
     void Handle(TEvPrivate::TEvWatermarkIdleness::TPtr& ev) {
-        if (InflyIdlenessChecks.erase(ev->Get()->NotifyTime)) {
+        if (RemovePendingWatermarkIdlenessCheck(ev->Get()->NotifyTime)) {
             NotifyCA();
         }
     }

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
@@ -186,13 +186,12 @@ void TDqPqReadActorBase::MaybeScheduleNextIdleCheck(TInstant systemTime) {
 }
 
 bool TDqPqReadActorBase::RemovePendingWatermarkIdlenessCheck(TInstant notifyTime) {
-    if (InflyIdlenessChecks.empty() || InflyIdlenessChecks.front() > notifyTime) {
-        return false;
-    }
+    bool removedAny = false;
     while (!InflyIdlenessChecks.empty() && InflyIdlenessChecks.front() <= notifyTime) {
         InflyIdlenessChecks.pop_front();
+        removedAny = true;
     }
-    return true;
+    return removedAny;
 }
 
 } // namespace NYql::NDq::NInternal

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
@@ -189,7 +189,7 @@ void TDqPqReadActorBase::MaybeSchedulePartitionIdlenessCheck(TInstant systemTime
     }
     InflyIdlenessChecks.push_front(*nextIdleCheckAt);
     SRC_LOG_T("SessionId: " << GetSessionId() << " Next idleness check scheduled at " << *nextIdleCheckAt);
-    ScheduleSourcesCheck(*nextIdleCheckAt);
+    SchedulePartitionIdlenessCheck(*nextIdleCheckAt);
 }
 
 bool TDqPqReadActorBase::RemoveExpiredPartitionIdlenessCheck(TInstant notifyTime) {

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
@@ -175,9 +175,10 @@ void TDqPqReadActorBase::MaybeScheduleNextIdleCheck(TInstant systemTime) {
     }
 
     const auto nextIdleCheckAt = WatermarkTracker->GetNextIdlenessCheckAt(systemTime);
-    if (!nextIdleCheckAt || *nextIdleCheckAt <= systemTime) {
+    if (!nextIdleCheckAt) {
         return;
     }
+    Y_DEBUG_ABORT_UNLESS(*nextIdleCheckAt >= systemTime);
 
     if (InflyIdlenessChecks.empty() || *InflyIdlenessChecks.cbegin() > *nextIdleCheckAt) {
         InflyIdlenessChecks.insert(*nextIdleCheckAt);

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
@@ -41,7 +41,7 @@ public:
     ui64 GetInputIndex() const override;
     const TDqAsyncStats& GetIngressStats() const override;
 
-    virtual void SchedulePartitionInlenessCheck(TInstant) = 0;
+    virtual void SchedulePartitionIdlenessCheck(TInstant) = 0;
 
     virtual void InitWatermarkTracker() = 0;
     void InitWatermarkTracker(TDuration, TDuration);

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
@@ -52,6 +52,8 @@ public:
     virtual TString GetSessionId() const {
         return TString{"empty"};
     }
+private:
+    bool HasEarlierWatermarkIdlenessChecks(TInstant time);
 };
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
@@ -24,7 +24,6 @@ public:
     ui64 TaskId;
     TMaybe<TDqSourceWatermarkTracker<TPartitionKey>> WatermarkTracker;
     // << Initialized when watermark tracking is enabled
-    std::deque<TInstant> InflyIdlenessChecks;
 
     TDqPqReadActorBase(
         ui64 inputIndex,
@@ -42,18 +41,19 @@ public:
     ui64 GetInputIndex() const override;
     const TDqAsyncStats& GetIngressStats() const override;
 
-    virtual void ScheduleSourcesCheck(TInstant) = 0;
+    virtual void SchedulePartitionInlenessCheck(TInstant) = 0;
 
     virtual void InitWatermarkTracker() = 0;
     void InitWatermarkTracker(TDuration, TDuration);
-    void MaybeScheduleNextIdleCheck(TInstant systemTime);
-    bool RemovePendingWatermarkIdlenessCheck(TInstant notifyTime);
+    void MaybeSchedulePartitionIdlenessCheck(TInstant systemTime);
+    bool RemoveExpiredPartitionIdlenessCheck(TInstant notifyTime); // return true if any watermark check was expired
 
     virtual TString GetSessionId() const {
         return TString{"empty"};
     }
 private:
-    bool HasEarlierWatermarkIdlenessChecks(TInstant time);
+    bool HasEarlierPartitionIdlenessChecks(TInstant time);
+    std::deque<TInstant> InflyIdlenessChecks; // strictly increasing queue of scheduled idle partitions checks; normally contains at most one check; only used when idle watermarks enabled
 };
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
@@ -24,7 +24,7 @@ public:
     ui64 TaskId;
     TMaybe<TDqSourceWatermarkTracker<TPartitionKey>> WatermarkTracker;
     // << Initialized when watermark tracking is enabled
-    TSet<TInstant> InflyIdlenessChecks;
+    std::deque<TInstant> InflyIdlenessChecks;
 
     TDqPqReadActorBase(
         ui64 inputIndex,
@@ -47,6 +47,7 @@ public:
     virtual void InitWatermarkTracker() = 0;
     void InitWatermarkTracker(TDuration, TDuration);
     void MaybeScheduleNextIdleCheck(TInstant systemTime);
+    bool RemovePendingWatermarkIdlenessCheck(TInstant notifyTime);
 
     virtual TString GetSessionId() const {
         return TString{"empty"};

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
@@ -24,7 +24,7 @@ public:
     ui64 TaskId;
     TMaybe<TDqSourceWatermarkTracker<TPartitionKey>> WatermarkTracker;
     // << Initialized when watermark tracking is enabled
-    TMaybe<TInstant> NextIdlenessCheckAt;
+    TSet<TInstant> InflyIdlenessChecks;
 
     TDqPqReadActorBase(
         ui64 inputIndex,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

YQ-4820; main problem was abuse of `TEvPrivate::TEvNotifyCA` adds new `Schedule()`
