### PR TITLE
EXT-1623 Fix AdministrationAllowedSIDs check: call SetInternalToken for all template specialisations of TMessageBusSecureRequest (#27611)

### DIFF
--- a/ydb/core/client/server/msgbus_securereq.h
+++ b/ydb/core/client/server/msgbus_securereq.h
@@ -67,7 +67,9 @@ public:
           TMessageBusSimpleTabletRequest<TDerived, TTabletReplyEvent, Activity>,
           TMessageBusSecureRequest<TMessageBusSimpleTabletRequest<TDerived, TTabletReplyEvent, Activity>>,
           TMessageBusSimpleTabletRequest<TDerived, TTabletReplyEvent, Activity>>(std::forward<Args>(args)...)
-    {}
+    {
+        this->SetInternalToken(this->GetInternalToken()); // No effect if token is nullptr
+    }
 };
 
 template <typename TDerived, typename TTabletReplyEvent>
@@ -106,7 +108,9 @@ public:
           TMessageBusTabletRequest<TDerived, TTabletReplyEvent>,
           TMessageBusSecureRequest<TMessageBusTabletRequest<TDerived, TTabletReplyEvent>>,
           TMessageBusTabletRequest<TDerived, TTabletReplyEvent>>(std::forward<Args>(args)...)
-    {}
+    {
+        this->SetInternalToken(this->GetInternalToken()); // No effect if token is nullptr
+    }
 };
 
 }


### PR DESCRIPTION
(cherry picked from commit fd2cb7bd7d7256158095d1e0698510bf6e71ed0f)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
