### PR TITLE
EXT-1620: Use getaddrinfo instead of c-ares in DnsResolver

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -555,6 +555,14 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
         resolverOptions.MonCounters = GetServiceCounters(counters, "utils")->GetSubgroup("subsystem", "dns_resolver");
         resolverOptions.ForceTcp = nsConfig.GetForceTcp();
         resolverOptions.KeepSocket = nsConfig.GetKeepSocket();
+        switch (nsConfig.GetDnsResolverType()) {
+            case NKikimrConfig::TStaticNameserviceConfig::ARES:
+                resolverOptions.Type = NDnsResolver::EDnsResolverType::Ares;
+                break;
+            case NKikimrConfig::TStaticNameserviceConfig::LIBC:
+                resolverOptions.Type = NDnsResolver::EDnsResolverType::Libc;
+                break;
+        }
         IActor *resolver = NDnsResolver::CreateOnDemandDnsResolver(resolverOptions);
 
         setup->LocalServices.emplace_back(

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -148,6 +148,11 @@ message TStaticNameserviceConfig {
         NS_EXTERNAL = 3;    // may be paired with external discovery
     }
 
+    enum EDnsResolverType {
+        ARES = 0;
+        LIBC = 1;
+    }
+
     message TEndpoint {
         optional string Name = 1;
         optional string Address = 2;
@@ -177,6 +182,7 @@ message TStaticNameserviceConfig {
     optional ENameserviceType Type = 5;
     optional bool KeepSocket = 6 [default = true];
     optional bool ForceTcp = 7 [default = false];
+    optional EDnsResolverType DnsResolverType = 8 [default = ARES];
 }
 
 message TDynamicNameserviceConfig {

--- a/ydb/library/actors/dnsresolver/dnsresolver.h
+++ b/ydb/library/actors/dnsresolver/dnsresolver.h
@@ -82,7 +82,14 @@ namespace NDnsResolver {
         };
     };
 
+    enum class EDnsResolverType {
+        Ares,
+        Libc,
+    };
+
     struct TSimpleDnsResolverOptions {
+        // Type of dns resolver to use
+        EDnsResolverType Type = EDnsResolverType::Ares;
         // Initial per-server timeout, grows exponentially with each retry
         TDuration Timeout = TDuration::Seconds(1);
         // Number of attempts per-server

--- a/ydb/library/actors/dnsresolver/dnsresolver_ut.cpp
+++ b/ydb/library/actors/dnsresolver/dnsresolver_ut.cpp
@@ -29,42 +29,51 @@ Y_UNIT_TEST_SUITE(DnsResolver) {
     };
 
     Y_UNIT_TEST(ResolveLocalHost) {
-        TTestActorRuntimeBase runtime;
-        runtime.Initialize();
-        auto sender = runtime.AllocateEdgeActor();
-        auto resolver = runtime.Register(CreateSimpleDnsResolver());
-        runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("localhost", AF_UNSPEC)),
-                0, true);
-        auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-        size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
-        UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
+            TSimpleDnsResolverOptions options { .Type = type };
+            TTestActorRuntimeBase runtime;
+            runtime.Initialize();
+            auto sender = runtime.AllocateEdgeActor();
+            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
+            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("localhost", AF_UNSPEC)),
+                    0, true);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
+            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+            size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
+            UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        }
     }
 
     Y_UNIT_TEST(ResolveYandexRu) {
-        TTestActorRuntimeBase runtime;
-        runtime.Initialize();
-        auto sender = runtime.AllocateEdgeActor();
-        auto resolver = runtime.Register(CreateSimpleDnsResolver());
-        runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("yandex.ru", AF_UNSPEC)),
-                0, true);
-        auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-        size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
-        UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
+            TSimpleDnsResolverOptions options { .Type = type }; 
+            TTestActorRuntimeBase runtime;
+            runtime.Initialize();
+            auto sender = runtime.AllocateEdgeActor();
+            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
+            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("yandex.ru", AF_UNSPEC)),
+                    0, true);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
+            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+            size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
+            UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        }
     }
 
     Y_UNIT_TEST(GetAddrYandexRu) {
-        TTestActorRuntimeBase runtime;
-        runtime.Initialize();
-        auto sender = runtime.AllocateEdgeActor();
-        auto resolver = runtime.Register(CreateSimpleDnsResolver());
+        for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
+            TSimpleDnsResolverOptions options { .Type = type };
+            TTestActorRuntimeBase runtime;
+            runtime.Initialize();
+            auto sender = runtime.AllocateEdgeActor();
+            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
 
-        runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetAddr("yandex.ru", AF_UNSPEC)),
-                0, true);
-        auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetAddrResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-        UNIT_ASSERT_C(ev->Get()->IsV4() || ev->Get()->IsV6(), "Expect v4 or v6 address");
+            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetAddr("yandex.ru", AF_UNSPEC)),
+                    0, true);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetAddrResult>(sender);
+            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+            UNIT_ASSERT_C(ev->Get()->IsV4() || ev->Get()->IsV6(), "Expect v4 or v6 address");
+        }
     }
 
     Y_UNIT_TEST(ResolveTimeout) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added DnsReslover with use libc getaddrinfo instead of c-ares

```
nameservice_config:
  dns_resolver_type: {libc/ares}
```

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

c-ares often fails with sigsegv with enabled force_tcp: true

```
Core was generated by `/opt/ydb/bin/ydbd server --mon-port 8765 --ic-port 19001 --grpcs-port 2135 --ya'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  ares_buf_fetch_be16 (buf=0x45d06fff5850, u16=u16@entry=0x7ae4b1f95e36) at /place/sandbox-data/tasks/8/5/3214975658/ydb/contrib/libs/c-ares/src/lib/str/ares_buf.c:535
 
warning: 535	/place/sandbox-data/tasks/8/5/3214975658/ydb/contrib/libs/c-ares/src/lib/str/ares_buf.c: No such file or directory
[Current thread is 1 (LWP 456)]
(gdb) bt
#0  ares_buf_fetch_be16 (buf=0x45d06fff5850, u16=u16@entry=0x7ae4b1f95e36) at /place/sandbox-data/tasks/8/5/3214975658/ydb/contrib/libs/c-ares/src/lib/str/ares_buf.c:535
#1  0x000000000c21d7e9 in read_answers (conn=0x45d070d36010, now=0x7ae4b1f95da8) at /place/sandbox-data/tasks/8/5/3214975658/ydb/contrib/libs/c-ares/src/lib/ares_process.c:557
#2  process_read (channel=0x45d07b983800, read_fd=<optimized out>, now=0x7ae4b1f95da8)
    at /place/sandbox-data/tasks/8/5/3214975658/ydb/contrib/libs/c-ares/src/lib/ares_process.c:644
#3  ares_process_fds_nolock (channel=channel@entry=0x45d07b983800, events=events@entry=0x7ae4b1f95e70, nevents=nevents@entry=1, flags=flags@entry=0)
    at /place/sandbox-data/tasks/8/5/3214975658/ydb/contrib/libs/c-ares/src/lib/ares_process.c:226
#4  0x000000000c21df2c in ares_process_fds (channel=0x45d07b983800, events=0x7ae4b1f95e70, nevents=1, flags=0)
    at /place/sandbox-data/tasks/8/5/3214975658/ydb/contrib/libs/c-ares/src/lib/ares_process.c:258
#5  ares_process_fd (channel=0x45d07b983800, read_fd=<optimized out>, write_fd=<optimized out>)
    at /place/sandbox-data/tasks/8/5/3214975658/ydb/contrib/libs/c-ares/src/lib/ares_process.c:285
#6  0x000000001630e74b in NActors::NDnsResolver::TSimpleDnsResolver::WorkerThreadLoop (this=0x45d0772c5d00)
    at /home/robdrynkin/ydbwork/ydb/ydb/library/actors/dnsresolver/dnsresolver.cpp:452
#7  0x000000001630c199 in NActors::NDnsResolver::TSimpleDnsResolver::WorkerThreadStart (arg=0x45d06fff5850)
    at /home/robdrynkin/ydbwork/ydb/ydb/library/actors/dnsresolver/dnsresolver.cpp:387
#8  0x0000000009711818 in (anonymous namespace)::TPosixThread::ThreadProxy (arg=0x45d0767d8360) at /place/sandbox-data/tasks/6/3/2964990436/ydb/util/system/thread.cpp:244
#9  0x00007ae530611ac3 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
```
