### PR TITLE
Filled database name in Scheme Cache P.3

### DIFF
--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -161,6 +161,7 @@ public:
         : TBase(std::make_shared<TVector<std::pair<TSerializedCellVec, TString>>>(), GetDuration(GetProtoRequest(request)->operation_params().operation_timeout()), diskQuotaExceeded,
                 NWilson::TSpan(TWilsonKqp::BulkUpsertActor, request->GetWilsonTraceId(), name))
         , Request(request)
+        , Database(Request->GetDatabaseName().GetOrElse(""))
     {
     }
 
@@ -184,11 +185,11 @@ private:
         NKikimr::NGRpcService::AuditContextAppend(Request.get(), *GetProtoRequest(Request.get()));
     }
 
-    TString GetDatabase() override {
-        return Request->GetDatabaseName().GetOrElse(DatabaseFromDomain(AppData()));
+    const TString& GetDatabase() const override {
+        return Database;
     }
 
-    const TString& GetTable() override {
+    const TString& GetTable() const override {
         return GetProtoRequest(Request.get())->table();
     }
 
@@ -307,6 +308,7 @@ private:
 
 private:
     std::unique_ptr<IRequestOpCtx> Request;
+    const TString Database;
 };
 
 class TUploadColumnsRPCPublic : public NTxProxy::TUploadRowsBase<NKikimrServices::TActivity::GRPC_REQ> {
@@ -315,6 +317,7 @@ public:
     explicit TUploadColumnsRPCPublic(IRequestOpCtx* request, bool diskQuotaExceeded)
         : TBase(std::make_shared<TVector<std::pair<TSerializedCellVec, TString>>>(), GetDuration(GetProtoRequest(request)->operation_params().operation_timeout()), diskQuotaExceeded)
         , Request(request)
+        , Database(Request->GetDatabaseName().GetOrElse(""))
     {
     }
 
@@ -349,11 +352,11 @@ private:
         NKikimr::NGRpcService::AuditContextAppend(Request.get(), *GetProtoRequest(Request.get()));
     }
 
-    TString GetDatabase() override {
-        return Request->GetDatabaseName().GetOrElse(DatabaseFromDomain(AppData()));
+    const TString& GetDatabase() const override {
+        return Database;
     }
 
-    const TString& GetTable() override {
+    const TString& GetTable() const override {
         return GetProtoRequest(Request.get())->table();
     }
 
@@ -512,6 +515,7 @@ private:
 
 private:
     std::unique_ptr<IRequestOpCtx> Request;
+    const TString Database;
 
     const Ydb::Formats::CsvSettings& GetCsvSettings() const {
         return GetProtoRequest(Request.get())->csv_settings();

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1445,6 +1445,7 @@ message TEvConditionalEraseRowsRequest {
     optional uint64 SchemaVersion = 3;
     repeated TIndexDescription Indexes = 4;
     optional TLimits Limits = 5;
+    optional string DatabaseName = 6;
 
     oneof Condition {
         TExpirationCondition Expiration = 2;
@@ -1501,6 +1502,8 @@ message TEvBuildIndexCreateRequest {
     optional NKikimrIndexBuilder.TColumnBuildSettings ColumnBuildSettings = 16;
 
     optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 17;
+
+    optional string DatabaseName = 18;
 }
 
 message TEvBuildIndexProgressResponse {
@@ -1611,6 +1614,8 @@ message TEvLocalKMeansRequest {
     repeated string DataColumns = 20;
 
     optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 22;
+
+    optional string DatabaseName = 23;
 }
 
 message TEvLocalKMeansResponse {
@@ -1659,6 +1664,8 @@ message TEvReshuffleKMeansRequest {
     repeated string DataColumns = 15;
 
     optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 16;
+
+    optional string DatabaseName = 17;
 }
 
 message TEvReshuffleKMeansResponse {
@@ -1725,7 +1732,7 @@ message TEvIncrementalRestoreResponse {
         RETRY = 1;
         ERROR = 2;
     }
-    
+
     optional uint64 TxId = 1;
     optional uint64 TableId = 2;
     optional uint64 OperationId = 3;
@@ -1770,6 +1777,8 @@ message TEvPrefixKMeansRequest {
     optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 18;
 
     repeated string SourcePrimaryKeyColumns = 19;
+
+    optional string DatabaseName = 20;
 }
 
 message TEvPrefixKMeansResponse {
@@ -1806,6 +1815,8 @@ message TEvBuildFulltextIndexRequest {
     repeated string DataColumns = 10;
 
     optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 11;
+
+    optional string DatabaseName = 12;
 }
 
 message TEvBuildFulltextIndexResponse {

--- a/ydb/core/transfer/table_kind_state.h
+++ b/ydb/core/transfer/table_kind_state.h
@@ -10,8 +10,9 @@ class ITableKindState {
 public:
     using TPtr = std::unique_ptr<ITableKindState>;
 
-    ITableKindState(const TActorId& selfId, const TAutoPtr<NSchemeCache::TSchemeCacheNavigate>& result)
+    ITableKindState(const TActorId& selfId, const TString& database, const TAutoPtr<NSchemeCache::TSchemeCacheNavigate>& result)
         : SelfId(selfId)
+        , Database(database)
         , Scheme(BuildScheme(result))
     {}
 
@@ -55,6 +56,7 @@ public:
 
 protected:
     const TActorId SelfId;
+    const TString Database;
     const TScheme::TPtr Scheme;
 
     std::map<TString, NKqp::IDataBatcherPtr> Batchers;
@@ -62,7 +64,7 @@ protected:
 };
 
 
-std::unique_ptr<ITableKindState> CreateColumnTableState(const TActorId& selfId, TAutoPtr<NSchemeCache::TSchemeCacheNavigate>& result);
-std::unique_ptr<ITableKindState> CreateRowTableState(const TActorId& selfId, TAutoPtr<NSchemeCache::TSchemeCacheNavigate>& result);
+std::unique_ptr<ITableKindState> CreateColumnTableState(const TActorId& selfId, const TString& database, TAutoPtr<NSchemeCache::TSchemeCacheNavigate>& result);
+std::unique_ptr<ITableKindState> CreateRowTableState(const TActorId& selfId, const TString& database, TAutoPtr<NSchemeCache::TSchemeCacheNavigate>& result);
 
 }

--- a/ydb/core/transfer/transfer_writer.cpp
+++ b/ydb/core/transfer/transfer_writer.cpp
@@ -51,6 +51,7 @@ private:
         Become(&TThis::StateGetTableScheme);
 
         auto request = MakeHolder<TNavigate>();
+        request->DatabaseName = Database;
         request->ResultSet.emplace_back(MakeNavigateEntry(TablePathId, TNavigate::OpTable));
         Send(MakeSchemeCacheID(), new TEvNavigate(request.Release()));
     }
@@ -137,9 +138,9 @@ private:
         DefaultTablePath = JoinPath(entry.Path);
 
         if (entry.Kind == TNavigate::KindColumnTable) {
-            TableState = CreateColumnTableState(SelfId(), result);
+            TableState = CreateColumnTableState(SelfId(), Database, result);
         } else {
-            TableState = CreateRowTableState(SelfId(), result);
+            TableState = CreateRowTableState(SelfId(), Database, result);
         }
 
         CompileTransferLambda();

--- a/ydb/core/tx/datashard/build_index/common_helper.h
+++ b/ydb/core/tx/datashard/build_index/common_helper.h
@@ -29,8 +29,9 @@ class TBatchRowsUploader
     };
 
 public:
-    TBatchRowsUploader(const TIndexBuildScanSettings& scanSettings)
-        : ScanSettings(scanSettings)
+    TBatchRowsUploader(const TString& database, const TIndexBuildScanSettings& scanSettings)
+        : Database(database)
+        , ScanSettings(scanSettings)
     {}
 
     TBufferData* AddDestination(TString table, std::shared_ptr<NTxProxy::TUploadTypes> types) {
@@ -208,7 +209,7 @@ private:
         Y_ENSURE(!UploaderId);
         Y_ENSURE(Owner);
         auto actor = NTxProxy::CreateUploadRowsInternal(
-            Owner, Uploading.Table, Uploading.Types, Uploading.Buffer.GetRowsData(),
+            Owner, Database, Uploading.Table, Uploading.Types, Uploading.Buffer.GetRowsData(),
             NTxProxy::EUploadRowsMode::WriteToTableShadow,
             true /*writeToPrivateTable*/,
             true /*writeToIndexImplTable*/);
@@ -217,6 +218,7 @@ private:
     }
 
 private:
+    const TString Database;
     const TIndexBuildScanSettings ScanSettings;
     TActorId Owner;
 

--- a/ydb/core/tx/datashard/build_index/fulltext.cpp
+++ b/ydb/core/tx/datashard/build_index/fulltext.cpp
@@ -55,7 +55,7 @@ public:
         : TActor{&TThis::StateWork}
         , TabletId(tabletId)
         , BuildId{request.GetId()}
-        , Uploader(request.GetScanSettings())
+        , Uploader(request.GetDatabaseName(), request.GetScanSettings())
         , Request(std::move(request))
         , ResponseActorId{responseActorId}
         , Response{std::move(response)}
@@ -140,14 +140,14 @@ public:
 
         TVector<TCell> uploadKey(::Reserve(key.size() + 1));
         TVector<TCell> uploadValue(::Reserve(Request.GetDataColumns().size()));
-        
+
         TString text((*row).at(0).AsBuf());
         auto tokens = Analyze(text, TextAnalyzers);
         for (const auto& token : tokens) {
             uploadKey.clear();
             uploadKey.push_back(TCell(token));
             uploadKey.insert(uploadKey.end(), key.begin(), key.end());
-            
+
             uploadValue.clear();
             size_t index = 1; // skip text column
             for (auto dataColumn : Request.GetDataColumns()) {

--- a/ydb/core/tx/datashard/build_index/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/local_kmeans.cpp
@@ -123,7 +123,7 @@ public:
         , Lead{std::move(lead)}
         , TabletId(tabletId)
         , BuildId{request.GetId()}
-        , Uploader(request.GetScanSettings())
+        , Uploader(request.GetDatabaseName(), request.GetScanSettings())
         , Dimensions(request.GetSettings().vector_dimension())
         , K(request.GetK())
         , ScanSettings(request.GetScanSettings())

--- a/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
@@ -123,7 +123,7 @@ public:
         , Sampler(request.GetK(), request.GetSeed())
         , TabletId(tabletId)
         , BuildId{request.GetId()}
-        , Uploader(request.GetScanSettings())
+        , Uploader(request.GetDatabaseName(), request.GetScanSettings())
         , Dimensions(request.GetSettings().vector_dimension())
         , K(request.GetK())
         , ScanSettings(request.GetScanSettings())

--- a/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
@@ -105,7 +105,7 @@ public:
         , Lead(std::move(lead))
         , TabletId(tabletId)
         , BuildId(request.GetId())
-        , Uploader(request.GetScanSettings())
+        , Uploader(request.GetDatabaseName(), request.GetScanSettings())
         , Dimensions(request.GetSettings().vector_dimension())
         , ScanSettings(request.GetScanSettings())
         , ResponseActorId(responseActorId)

--- a/ydb/core/tx/datashard/build_index/ut/ut_fulltext.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_fulltext.cpp
@@ -18,13 +18,14 @@ using Ydb::Table::FulltextIndexSettings;
 using namespace NTableIndex::NFulltext;
 
 static std::atomic<ui64> sId = 1;
+static const TString kDatabaseName = "/Root";
 static const TString kMainTable = "/Root/table-main";
 static const TString kIndexTable = "/Root/table-index";
 
 Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
 
     ui64 FillRequest(Tests::TServer::TPtr server, TActorId sender,
-        NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request, 
+        NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request,
         std::function<void(NKikimrTxDataShard::TEvBuildFulltextIndexRequest&)> setupRequest)
     {
         auto id = sId.fetch_add(1, std::memory_order_relaxed);
@@ -52,6 +53,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
         column->mutable_analyzers()->set_tokenizer(FulltextIndexSettings::WHITESPACE);
         *request.MutableSettings() = settings;
 
+        request.SetDatabaseName(kDatabaseName);
         request.SetIndexName(kIndexTable);
 
         setupRequest(request);
@@ -206,7 +208,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
         auto sender = server->GetRuntime()->AllocateEdgeActor();
 
         Setup(server, sender);
-        
+
         auto result = DoBuild(server, sender, [](auto&){});
 
         UNIT_ASSERT_VALUES_EQUAL(result, R"(__ydb_token = apple, key = 1, data = (empty maybe)
@@ -229,7 +231,7 @@ __ydb_token = yellow, key = 3, data = (empty maybe)
         auto sender = server->GetRuntime()->AllocateEdgeActor();
 
         Setup(server, sender);
-        
+
         auto result = DoBuild(server, sender, [](auto& request) {
             request.AddDataColumns("data");
         });
@@ -271,7 +273,7 @@ __ydb_token = yellow, key = 3, data = three
             });
             CreateShardedTable(server, sender, "/Root", "table-index", options);
         }
-        
+
         auto result = DoBuild(server, sender, [](auto& request) {
             request.AddDataColumns("text");
             request.AddDataColumns("data");
@@ -337,7 +339,7 @@ __ydb_token = yellow, key = 3, text = yellow apple, data = three
             });
             CreateShardedTable(server, sender, "/Root", "table-index", options);
         }
-        
+
         auto result = DoBuild(server, sender, [](auto& request) {
             request.AddDataColumns("data");
         });

--- a/ydb/core/tx/datashard/build_index/ut/ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_local_kmeans.cpp
@@ -18,6 +18,7 @@ using Ydb::Table::VectorIndexSettings;
 using namespace NTableIndex::NKMeans;
 
 static std::atomic<ui64> sId = 1;
+static const TString kDatabaseName = "/Root";
 static const TString kMainTable = "/Root/table-main";
 static const TString kLevelTable = "/Root/table-level";
 static const TString kPostingTable = "/Root/table-posting";
@@ -69,6 +70,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
 
         rec.SetEmbeddingColumn("embedding");
 
+        rec.SetDatabaseName(kDatabaseName);
         rec.SetLevelName(kLevelTable);
         rec.SetOutputName(kPostingTable);
 
@@ -126,6 +128,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
                 rec.SetEmbeddingColumn("embedding");
                 rec.AddDataColumns("data");
 
+                rec.SetDatabaseName(kDatabaseName);
                 rec.SetLevelName(kLevelTable);
                 rec.SetOutputName(kPostingTable);
 

--- a/ydb/core/tx/datashard/build_index/ut/ut_prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_prefix_kmeans.cpp
@@ -18,6 +18,7 @@ using Ydb::Table::VectorIndexSettings;
 using namespace NTableIndex::NKMeans;
 
 static std::atomic<ui64> sId = 1;
+static const TString kDatabaseName = "/Root";
 static const TString kMainTable = "/Root/table-main";
 static const TString kPrefixTable = "/Root/table-prefix";
 static const TString kLevelTable = "/Root/table-level";
@@ -70,6 +71,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
 
         rec.SetPrefixName(kPrefixTable);
 
+        rec.SetDatabaseName(kDatabaseName);
         rec.SetLevelName(kLevelTable);
         rec.SetOutputName(kPostingTable);
         rec.SetPrefixName(kPrefixTable);
@@ -124,6 +126,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
                 rec.SetPrefixColumns(1);
                 rec.AddSourcePrimaryKeyColumns("key");
 
+                rec.SetDatabaseName(kDatabaseName);
                 rec.SetPrefixName(kPrefixTable);
                 rec.SetLevelName(kLevelTable);
                 rec.SetOutputName(kPostingTable);

--- a/ydb/core/tx/datashard/build_index/ut/ut_reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_reshuffle_kmeans.cpp
@@ -18,6 +18,7 @@ using Ydb::Table::VectorIndexSettings;
 using namespace NTableIndex::NKMeans;
 
 static std::atomic<ui64> sId = 1;
+static constexpr const char* kDatabaseName = "/Root";
 static constexpr const char* kMainTable = "/Root/table-main";
 static constexpr const char* kPostingTable = "/Root/table-posting";
 
@@ -64,6 +65,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardReshuffleKMeansScan) {
 
         rec.SetEmbeddingColumn("embedding");
 
+        rec.SetDatabaseName(kDatabaseName);
         rec.SetOutputName(kPostingTable);
 
         setupRequest(rec);
@@ -116,6 +118,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardReshuffleKMeansScan) {
                 rec.SetEmbeddingColumn("embedding");
                 rec.AddDataColumns("data");
 
+                rec.SetDatabaseName(kDatabaseName);
                 rec.SetOutputName(kPostingTable);
             };
             fill(ev1);

--- a/ydb/core/tx/datashard/build_index/ut/ut_secondary_index.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_secondary_index.cpp
@@ -15,6 +15,7 @@ using namespace NKikimr::NDataShard::NKqpHelpers;
 using namespace NSchemeShard;
 using namespace Tests;
 
+static const TString kDatabaseName = "/Root";
 static const TString kMainTable = "/Root/table-1";
 static const TString kIndexTable = "/Root/table-2";
 
@@ -38,6 +39,7 @@ static void DoBadRequest(Tests::TServer::TPtr server, TActorId sender,
     rec.SetOwnerId(tableId.PathId.OwnerId);
     rec.SetPathId(tableId.PathId.LocalPathId);
 
+    rec.SetDatabaseName(kDatabaseName);
     rec.SetTargetName(kIndexTable);
     rec.AddIndexColumns("value");
     rec.AddIndexColumns("key");
@@ -52,7 +54,7 @@ static void DoBadRequest(Tests::TServer::TPtr server, TActorId sender,
 
 Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
     static void DoBuildIndex(Tests::TServer::TPtr server, TActorId sender,
-                             const TString& tableFrom, const TString& tableTo,
+                             const TString& database, const TString& tableFrom, const TString& tableTo,
                              const TRowVersion& snapshot,
                              const NKikimrIndexBuilder::EBuildStatus& expected) {
         auto &runtime = *server->GetRuntime();
@@ -68,6 +70,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
             rec.SetOwnerId(tableId.PathId.OwnerId);
             rec.SetPathId(tableId.PathId.LocalPathId);
 
+            rec.SetDatabaseName(database);
             rec.SetTargetName(tableTo);
             rec.AddIndexColumns("value");
             rec.AddIndexColumns("key");
@@ -201,7 +204,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
 
         auto snapshot = CreateVolatileSnapshot(server, { kMainTable });
 
-        DoBuildIndex(server, sender, kMainTable, kIndexTable, snapshot, NKikimrIndexBuilder::EBuildStatus::DONE);
+        DoBuildIndex(server, sender, kDatabaseName, kMainTable, kIndexTable, snapshot, NKikimrIndexBuilder::EBuildStatus::DONE);
 
         // Writes to shadow data should not be visible yet
         auto data = ReadShardedTable(server, kIndexTable);
@@ -254,7 +257,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
 
         auto snapshot = CreateVolatileSnapshot(server, { kMainTable });
 
-        DoBuildIndex(server, sender, kMainTable, kIndexTable, snapshot, NKikimrIndexBuilder::EBuildStatus::DONE);
+        DoBuildIndex(server, sender, kDatabaseName, kMainTable, kIndexTable, snapshot, NKikimrIndexBuilder::EBuildStatus::DONE);
 
         // Writes to shadow data should not be visible yet
         auto data = ReadShardedTable(server, kIndexTable);

--- a/ydb/core/tx/datashard/datashard_distributed_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_distributed_erase.cpp
@@ -339,6 +339,7 @@ class TDistEraser: public TActorBootstrapped<TDistEraser> {
             << ": txId# " << TxId);
 
         auto request = MakeHolder<TNavigate>();
+        request->DatabaseName = DatabaseName;
         request->ResultSet.emplace_back(MakeNavigateEntry(MainTableId));
         for (const auto& [tableId, _] : Indexes) {
             request->ResultSet.emplace_back(MakeNavigateEntry(tableId));
@@ -494,6 +495,8 @@ class TDistEraser: public TActorBootstrapped<TDistEraser> {
         Y_ENSURE(!TableInfos.empty());
 
         auto request = MakeHolder<TResolve>();
+        request->DatabaseName = DatabaseName;
+
         for (auto& [_, info] : TableInfos) {
             auto& entry = request->ResultSet.emplace_back(info.TakeKeyDesc());
             entry.Access = NACLib::EAccessRights::EraseRow;
@@ -1053,8 +1056,9 @@ public:
         return NKikimrServices::TActivity::DISTRIBUTED_ERASE_ROWS_ACTOR;
     }
 
-    TDistEraser(const TActorId& replyTo, const TTableId& mainTableId, const TIndexes& indexes)
+    TDistEraser(const TActorId& replyTo, const TString& databaseName, const TTableId& mainTableId, const TIndexes& indexes)
         : ReplyTo(replyTo)
+        , DatabaseName(databaseName)
         , MainTableId(mainTableId)
         , Indexes(indexes)
         , Cancelled(false)
@@ -1086,6 +1090,7 @@ public:
 
 private:
     const TActorId ReplyTo;
+    const TString DatabaseName;
     const TTableId MainTableId;
     const TIndexes Indexes;
 
@@ -1109,8 +1114,9 @@ private:
 
 }; // TDistEraser
 
-IActor* CreateDistributedEraser(const TActorId& replyTo, const TTableId& mainTableId, const TIndexes& indexes) {
-    return new TDistEraser(replyTo, mainTableId, indexes);
+IActor* CreateDistributedEraser(const TActorId& replyTo, const TString& databaseName,
+    const TTableId& mainTableId, const TIndexes& indexes) {
+    return new TDistEraser(replyTo, databaseName, mainTableId, indexes);
 }
 
 } // NDataShard

--- a/ydb/core/tx/datashard/datashard_distributed_erase.h
+++ b/ydb/core/tx/datashard/datashard_distributed_erase.h
@@ -14,7 +14,8 @@ namespace NDataShard {
 using TKeyMap = TVector<std::pair<ui32, ui32>>; // index to main
 using TIndexes = THashMap<TTableId, TKeyMap>;
 
-IActor* CreateDistributedEraser(const TActorId& replyTo, const TTableId& mainTableId, const TIndexes& indexes);
+IActor* CreateDistributedEraser(const TActorId& replyTo, const TString& databaseName,
+    const TTableId& mainTableId, const TIndexes& indexes);
 
 template <typename TBitMapType>
 static TString SerializeBitMap(const TBitMapType& bitmap) {

--- a/ydb/core/tx/datashard/datashard_ut_erase_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_erase_rows.cpp
@@ -1434,7 +1434,7 @@ tkey = 100, key = 4
                 return TTestActorRuntime::EEventAction::PROCESS;
             });
 
-            const auto eraser = runtime.Register(NDataShard::CreateDistributedEraser(sender, tableId, indexes));
+            const auto eraser = runtime.Register(NDataShard::CreateDistributedEraser(sender, "/Root", tableId, indexes));
             auto ev = runtime.GrabEdgeEventRethrow<TEvResponse>(sender);
             UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetStatus(), status);
             UNIT_ASSERT_STRING_CONTAINS(ev->Get()->Record.GetErrorDescription(), error);
@@ -1549,7 +1549,7 @@ tkey = 100, key = 4
 
         using TRequestMaker = std::function<IEventBase*(void)>;
         auto badRequest = [&](TEvResponse::ProtoRecordType::EStatus status, const TString& error, TRequestMaker maker) {
-            const auto eraser = runtime.Register(NDataShard::CreateDistributedEraser(sender, tableId, indexes));
+            const auto eraser = runtime.Register(NDataShard::CreateDistributedEraser(sender, "/Root", tableId, indexes));
 
             runtime.Send(new IEventHandle(eraser, sender, maker()), 0, true);
             auto ev = runtime.GrabEdgeEventRethrow<TEvResponse>(sender);

--- a/ydb/core/tx/datashard/datashard_ut_read_table.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_table.cpp
@@ -587,7 +587,7 @@ Y_UNIT_TEST_SUITE(DataShardReadTableSnapshots) {
             }));
 
         // Write bad DyNumber
-        UploadRows(runtime, "/Root/Table", 
+        UploadRows(runtime, "/Root", "/Root/Table",
             {{"key", Ydb::Type::UINT32}, {"value", Ydb::Type::DYNUMBER}},
             {TCell::Make(ui32(1))}, {TCell::Make(ui32(55555))}
             );

--- a/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
@@ -2279,7 +2279,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
             rows->emplace_back(serializedKey, serializedValues);
 
             auto upsertSender = runtime.AllocateEdgeActor();
-            auto actor = NTxProxy::CreateUploadRowsInternal(upsertSender, "/Root/table-1", types, rows);
+            auto actor = NTxProxy::CreateUploadRowsInternal(upsertSender, "/Root", "/Root/table-1", types, rows);
             runtime.Register(actor);
 
             auto ev = runtime.GrabEdgeEventRethrow<TEvTxUserProxy::TEvUploadRowsResponse>(upsertSender);

--- a/ydb/core/tx/datashard/datashard_ut_upload_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_upload_rows.cpp
@@ -24,6 +24,7 @@ using TRowTypes = TVector<std::pair<TString, Ydb::Type>>;
 static void DoStartUploadTestRows(
         const Tests::TServer::TPtr& server,
         const TActorId& sender,
+        const TString& database,
         const TString& tableName,
         Ydb::Type::PrimitiveTypeId typeId,
         TBackoff backoff = TBackoff(0))
@@ -44,7 +45,7 @@ static void DoStartUploadTestRows(
         rows->emplace_back(serializedKey, serializedValue);
     }
 
-    auto actor = NTxProxy::CreateUploadRowsInternal(sender, tableName, types, rows, NTxProxy::EUploadRowsMode::Normal, false, false, 0, backoff);
+    auto actor = NTxProxy::CreateUploadRowsInternal(sender, database, tableName, types, rows, NTxProxy::EUploadRowsMode::Normal, false, false, 0, backoff);
     runtime.Register(actor);
 }
 
@@ -60,15 +61,16 @@ static void DoWaitUploadTestRows(
 }
 
 static void DoUploadTestRows(Tests::TServer::TPtr server, const TActorId& sender,
-                             const TString& tableName, Ydb::Type::PrimitiveTypeId typeId,
-                             Ydb::StatusIds::StatusCode expected)
+                             const TString& database, const TString& tableName,
+                             Ydb::Type::PrimitiveTypeId typeId, Ydb::StatusIds::StatusCode expected)
 {
-    DoStartUploadTestRows(server, sender, tableName, typeId);
+    DoStartUploadTestRows(server, sender, database, tableName, typeId);
     DoWaitUploadTestRows(server, sender, expected);
 }
 
 static TActorId DoStartUploadRows(
         TTestActorRuntime& runtime,
+        const TString& database,
         const TString& tableName,
         const std::vector<std::pair<ui32, ui32>>& data,
         NTxProxy::EUploadRowsMode mode = NTxProxy::EUploadRowsMode::Normal)
@@ -92,6 +94,7 @@ static TActorId DoStartUploadRows(
 
     auto actor = NTxProxy::CreateUploadRowsInternal(
             sender,
+            database,
             tableName,
             std::move(types),
             std::move(rows),
@@ -112,12 +115,13 @@ static void DoWaitUploadRows(
 
 static void DoUploadRows(
         TTestActorRuntime& runtime,
+        const TString& database,
         const TString& tableName,
         const std::vector<std::pair<ui32, ui32>>& data,
         NTxProxy::EUploadRowsMode mode = NTxProxy::EUploadRowsMode::Normal,
         Ydb::StatusIds::StatusCode expected = Ydb::StatusIds::SUCCESS)
 {
-    auto sender = DoStartUploadRows(runtime, tableName, data, mode);
+    auto sender = DoStartUploadRows(runtime, database, tableName, data, mode);
     DoWaitUploadRows(runtime, sender, expected);
 }
 
@@ -141,11 +145,11 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
 
         CreateShardedTable(server, sender, "/Root", "table-1", 4, false);
 
-        DoUploadTestRows(server, sender, "/Root/table-1", Ydb::Type::UINT32, Ydb::StatusIds::SUCCESS);
+        DoUploadTestRows(server, sender, "/Root", "/Root/table-1", Ydb::Type::UINT32, Ydb::StatusIds::SUCCESS);
 
-        DoUploadTestRows(server, sender, "/Root/table-doesnt-exist", Ydb::Type::UINT32, Ydb::StatusIds::SCHEME_ERROR);
+        DoUploadTestRows(server, sender, "/Root", "/Root/table-doesnt-exist", Ydb::Type::UINT32, Ydb::StatusIds::SCHEME_ERROR);
 
-        DoUploadTestRows(server, sender, "/Root/table-1", Ydb::Type::INT32, Ydb::StatusIds::SCHEME_ERROR);
+        DoUploadTestRows(server, sender, "/Root", "/Root/table-1", Ydb::Type::INT32, Ydb::StatusIds::SCHEME_ERROR);
     }
 
     Y_UNIT_TEST(TestUploadRowsDropColumnRace) {
@@ -184,7 +188,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
             uploadRequests.emplace_back(ev.Release());
         });
 
-        DoStartUploadTestRows(server, sender, "/Root/table-1", Ydb::Type::UINT32);
+        DoStartUploadTestRows(server, sender, "/Root", "/Root/table-1", Ydb::Type::UINT32);
 
         waitFor([&]{ return uploadRequests.size() >= 3; }, "TEvUploadRowsRequest");
         observerHolder.Remove();
@@ -232,7 +236,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
         }
 
         // Do some upserts using UploadRows (overwrites key 3)
-        DoUploadRows(runtime, "/Root/table-1", {
+        DoUploadRows(runtime, "/Root", "/Root/table-1", {
             { 2, 20 },
             { 3, 30 },
             { 4, 40 },
@@ -288,6 +292,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
             }
             auto actor = NTxProxy::CreateUploadRowsInternal(
                     sender,
+                    "/Root",
                     "/Root/table-1",
                     std::move(types),
                     rows,
@@ -353,6 +358,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
             }
             auto actor = NTxProxy::CreateUploadRowsInternal(
                     sender,
+                    "/Root",
                     "/Root/table-1",
                     std::move(types),
                     std::move(rows),
@@ -433,6 +439,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
             }
             auto actor = NTxProxy::CreateUploadRowsInternal(
                     sender,
+                    "/Root",
                     "/Root/table-1",
                     std::move(types),
                     std::move(rows),
@@ -531,6 +538,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
             }
             auto actor = NTxProxy::CreateUploadRowsInternal(
                     sender,
+                    "/Root",
                     "/Root/table-1",
                     std::move(types),
                     std::move(rows),
@@ -632,6 +640,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
             }
             auto actor = NTxProxy::CreateUploadRowsInternal(
                     sender,
+                    "/Root",
                     "/Root/table-1",
                     std::move(types),
                     std::move(rows),
@@ -684,6 +693,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
             }
             auto actor = NTxProxy::CreateUploadRowsInternal(
                     sender,
+                    "/Root",
                     "/Root/table-1",
                     std::move(types),
                     std::move(rows),
@@ -734,7 +744,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
         InitRoot(server, sender);
         CreateShardedTable(server, sender, "/Root", "table-1", TShardedTableOptions().Replicated(true));
 
-        DoUploadTestRows(server, sender, "/Root/table-1", Ydb::Type::UINT32, Ydb::StatusIds::GENERIC_ERROR);
+        DoUploadTestRows(server, sender, "/Root", "/Root/table-1", Ydb::Type::UINT32, Ydb::StatusIds::GENERIC_ERROR);
     }
 
     Y_UNIT_TEST(RetryUploadRowsToShard) {
@@ -781,7 +791,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
         };
 
 
-        DoStartUploadTestRows(server, sender, "/Root/table-1", Ydb::Type::UINT32, TBackoff(5));
+        DoStartUploadTestRows(server, sender, "/Root", "/Root/table-1", Ydb::Type::UINT32, TBackoff(5));
 
         splitShard(0, 5);
 
@@ -855,14 +865,14 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
             return TTestActorRuntime::EEventAction::PROCESS;
         });
 
-        DoUploadTestRows(server, sender, "/Root/table-1", Ydb::Type::UINT32, Ydb::StatusIds::SUCCESS);
+        DoUploadTestRows(server, sender, "/Root", "/Root/table-1", Ydb::Type::UINT32, Ydb::StatusIds::SUCCESS);
 
         UNIT_ASSERT(!observedUploadStatus.empty());
         UNIT_ASSERT(observedUploadStatus.back() == NKikimrTxDataShard::TError::OK);
         observedUploadStatus.clear();
 
         if (!overloadSubscribe && !withBackoff) {
-            DoUploadTestRows(server, sender, "/Root/table-1", Ydb::Type::UINT32, Ydb::StatusIds::OVERLOADED);
+            DoUploadTestRows(server, sender, "/Root", "/Root/table-1", Ydb::Type::UINT32, Ydb::StatusIds::OVERLOADED);
             return;
         }
 
@@ -878,7 +888,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardUploadRows) {
         }));
 
         TBackoff backoff = withBackoff ? TBackoff(3, TDuration::Seconds(1)) : TBackoff(0);
-        DoStartUploadTestRows(server, responseAwaiter, "/Root/table-1", Ydb::Type::UINT32, backoff);
+        DoStartUploadTestRows(server, responseAwaiter, "/Root", "/Root/table-1", Ydb::Type::UINT32, backoff);
 
         runtime.SimulateSleep(TDuration::Seconds(1));
         UNIT_ASSERT(!blockedEnqueueRecords.empty());

--- a/ydb/core/tx/datashard/datashard_ut_vacuum.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_vacuum.cpp
@@ -43,19 +43,19 @@ Y_UNIT_TEST_SUITE(Vacuum) {
             });
         auto [shards, tableId] = CreateShardedTable(server, sender, "/Root", "table-1", opts);
 
-        UploadRows(runtime, "/Root/table-1",
+        UploadRows(runtime, "/Root", "/Root/table-1",
             {{"key", Ydb::Type::UINT32}, {"subkey", Ydb::Type::STRING}, {"value", Ydb::Type::UTF8}},
             {TCell::Make(ui32(1)), TCell(DeletedSubkey1)}, {TCell(DeletedShortValue1)}
         );
-        UploadRows(runtime, "/Root/table-1",
+        UploadRows(runtime, "/Root", "/Root/table-1",
             {{"key", Ydb::Type::UINT32}, {"subkey", Ydb::Type::STRING}, {"value", Ydb::Type::UTF8}},
             {TCell::Make(ui32(2)), TCell(PresentSubkey2)}, {TCell(PresentLongValue2)}
         );
-        UploadRows(runtime, "/Root/table-1",
+        UploadRows(runtime, "/Root", "/Root/table-1",
             {{"key", Ydb::Type::UINT32}, {"subkey", Ydb::Type::STRING}, {"value", Ydb::Type::UTF8}},
             {TCell::Make(ui32(3)), TCell(PresentSubkey3)}, {TCell(PresentShortValue3)}
         );
-        UploadRows(runtime, "/Root/table-1",
+        UploadRows(runtime, "/Root", "/Root/table-1",
             {{"key", Ydb::Type::UINT32}, {"subkey", Ydb::Type::STRING}, {"value", Ydb::Type::UTF8}},
             {TCell::Make(ui32(4)), TCell(DeletedSubkey4)}, {TCell(DeletedLongValue4)}
         );

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -1690,7 +1690,7 @@ ui64 AsyncSetColumnFamily(
     auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpAlterTable, workingDir);
     auto& desc = *request->Record.MutableTransaction()->MutableModifyScheme()->MutableAlterTable();
     desc.SetName(name);
-    
+
     auto col = desc.AddColumns();
     col->SetName(colName);
     col->SetFamilyName(family.Name);
@@ -1967,7 +1967,7 @@ void WaitTxNotification(Tests::TServer::TPtr server, ui64 txId) {
     WaitTxNotification(server, sender, txId);
 }
 
-void WaitTableStatsImpl(TTestActorRuntime& runtime, 
+void WaitTableStatsImpl(TTestActorRuntime& runtime,
     std::function<void(typename TEvDataShard::TEvPeriodicTableStats::TPtr&)> observerFunc,
     bool& captured) {
 
@@ -1984,8 +1984,8 @@ void WaitTableStatsImpl(TTestActorRuntime& runtime,
     UNIT_ASSERT(captured);
 }
 
-NKikimrTxDataShard::TEvPeriodicTableStats WaitTableFollowerStats(TTestActorRuntime& runtime, ui64 datashardId, 
-    std::function<bool(const NKikimrTableStats::TTableStats& stats)> condition) 
+NKikimrTxDataShard::TEvPeriodicTableStats WaitTableFollowerStats(TTestActorRuntime& runtime, ui64 datashardId,
+    std::function<bool(const NKikimrTableStats::TTableStats& stats)> condition)
 {
     NKikimrTxDataShard::TEvPeriodicTableStats stats;
     bool captured = false;
@@ -1999,7 +1999,7 @@ NKikimrTxDataShard::TEvPeriodicTableStats WaitTableFollowerStats(TTestActorRunti
 
         if (record.GetDatashardId() != datashardId)
             return;
-        
+
         if (!condition(record.GetTableStats()))
             return;
 
@@ -2013,7 +2013,7 @@ NKikimrTxDataShard::TEvPeriodicTableStats WaitTableFollowerStats(TTestActorRunti
 
 
 NKikimrTxDataShard::TEvPeriodicTableStats WaitTableStats(TTestActorRuntime& runtime, ui64 datashardId,
-    std::function<bool(const NKikimrTableStats::TTableStats& stats)> condition) 
+    std::function<bool(const NKikimrTableStats::TTableStats& stats)> condition)
 {
     NKikimrTxDataShard::TEvPeriodicTableStats stats;
     bool captured = false;
@@ -2027,7 +2027,7 @@ NKikimrTxDataShard::TEvPeriodicTableStats WaitTableStats(TTestActorRuntime& runt
 
         if (record.GetDatashardId() != datashardId)
             return;
-        
+
         if (!condition(record.GetTableStats()))
             return;
 
@@ -2339,7 +2339,7 @@ NKikimrDataEvents::TEvWriteResult WaitForWriteCompleted(TTestActorRuntime& runti
     return resultRecord;
 }
 
-void UploadRows(TTestActorRuntime& runtime, const TString& tablePath, const TVector<std::pair<TString, Ydb::Type_PrimitiveTypeId>>& types, const TVector<TCell>& keys, const TVector<TCell>& values)
+void UploadRows(TTestActorRuntime& runtime, const TString& database, const TString& tablePath, const TVector<std::pair<TString, Ydb::Type_PrimitiveTypeId>>& types, const TVector<TCell>& keys, const TVector<TCell>& values)
 {
     auto txTypes = std::make_shared<NTxProxy::TUploadTypes>();
     std::transform(types.cbegin(), types.cend(), std::back_inserter(*txTypes), [](const auto& iter) {
@@ -2355,7 +2355,7 @@ void UploadRows(TTestActorRuntime& runtime, const TString& tablePath, const TVec
     txRows->emplace_back(serializedKey, serializedValues);
 
     auto uploadSender = runtime.AllocateEdgeActor();
-    auto actor = NTxProxy::CreateUploadRowsInternal(uploadSender, tablePath, txTypes, txRows);
+    auto actor = NTxProxy::CreateUploadRowsInternal(uploadSender, database, tablePath, txTypes, txRows);
     runtime.Register(actor);
 
     auto ev = runtime.GrabEdgeEventRethrow<TEvTxUserProxy::TEvUploadRowsResponse>(uploadSender);

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -852,7 +852,7 @@ class TEvWriteRows : public std::vector<TEvWriteRow> {
     }
 };
 
-void UploadRows(TTestActorRuntime& runtime, const TString& tablePath, const TVector<std::pair<TString, Ydb::Type_PrimitiveTypeId>>& types, const TVector<TCell>& keys, const TVector<TCell>& values);
+void UploadRows(TTestActorRuntime& runtime, const TString& database, const TString& tablePath, const TVector<std::pair<TString, Ydb::Type_PrimitiveTypeId>>& types, const TVector<TCell>& keys, const TVector<TCell>& values);
 
 struct TSendProposeToCoordinatorOptions {
     const ui64 TxId;

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
@@ -155,6 +155,7 @@ struct TSchemeShard::TTxRunConditionalErase: public TSchemeShard::TRwTxBase {
         const TInstant wallClock = ctx.Now() - *expireAfter;
 
         NKikimrTxDataShard::TEvConditionalEraseRowsRequest request;
+        request.SetDatabaseName(CanonizePath(Self->RootPathElements));
         request.SetTableId(shardInfo.PathId.LocalPathId);
         request.SetSchemaVersion(tableInfo->AlterVersion);
 
@@ -208,7 +209,6 @@ struct TSchemeShard::TTxRunConditionalErase: public TSchemeShard::TRwTxBase {
 
             auto ev = MakeHolder<TEvDataShard::TEvConditionalEraseRowsRequest>();
             ev->Record = std::move(request);
-
             LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Run conditional erase"
                 << ", tabletId: " << tabletId
                 << ", request: " << ev->Record.ShortDebugString()

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -48,6 +48,7 @@ class TUploadSampleK: public TActorBootstrapped<TUploadSampleK> {
 
 protected:
     TString LogPrefix;
+    const TString DatabaseName;
     const TString TargetTable;
     const bool IsPostingLevel;
 
@@ -71,7 +72,8 @@ protected:
     NDataShard::TUploadStatus UploadStatus;
 
 public:
-    TUploadSampleK(TString targetTable,
+    TUploadSampleK(const TString& databaseName,
+                   const TString& targetTable,
                    bool isPostingLevel,
                    const NKikimrIndexBuilder::TIndexBuildScanSettings& scanSettings,
                    const TActorId& responseActorId,
@@ -81,7 +83,8 @@ public:
                    NTableIndex::NKMeans::TClusterId child,
                    const TString& emptyVector,
                    ui32 emptyLevels)
-        : TargetTable(std::move(targetTable))
+        : DatabaseName(databaseName)
+        , TargetTable(targetTable)
         , IsPostingLevel(isPostingLevel)
         , ScanSettings(scanSettings)
         , ResponseActorId(responseActorId)
@@ -226,6 +229,7 @@ private:
 
         auto actor = NTxProxy::CreateUploadRowsInternal(
             SelfId(),
+            DatabaseName,
             TargetTable,
             Types,
             UploadRows,
@@ -712,6 +716,7 @@ private:
             *clusters.Add() = TSerializedCellVec::ExtractCell(row, 0).AsBuf();
         }
 
+        ev->Record.SetDatabaseName(CanonizePath(Self->RootPathElements));
         ev->Record.SetOutputName(path.Dive(buildInfo.KMeans.WriteTo()).PathString());
 
         ev->Record.SetEmbeddingColumn(buildInfo.IndexColumns.back());
@@ -790,6 +795,7 @@ private:
             ev->Record.SetChild(childBegin);
         }
 
+        ev->Record.SetDatabaseName(CanonizePath(Self->RootPathElements));
         ev->Record.SetOutputName(path.Dive(buildInfo.KMeans.WriteTo()).PathString());
         path.Rise().Dive(NTableIndex::NKMeans::LevelTable);
         ev->Record.SetLevelName(path.PathString());
@@ -828,6 +834,7 @@ private:
         // about 2 * TableSize see comment in PrefixIndexDone
         ev->Record.SetChild(buildInfo.KMeans.ChildBegin + (2 * buildInfo.KMeans.TableSize) * shardIndex);
 
+        ev->Record.SetDatabaseName(CanonizePath(Self->RootPathElements));
         ev->Record.SetOutputName(path.Dive(buildInfo.KMeans.WriteTo()).PathString());
         path.Rise().Dive(NTableIndex::NKMeans::LevelTable);
         ev->Record.SetLevelName(path.PathString());
@@ -879,6 +886,7 @@ private:
             };
         }
 
+        ev->Record.SetDatabaseName(CanonizePath(Self->RootPathElements));
         ev->Record.SetTargetName(buildInfo.TargetName);
 
         auto shardId = FillScanRequestCommon(ev->Record, shardIdx, buildInfo);
@@ -922,7 +930,8 @@ private:
         buildInfo.Sample.MakeStrictTop(buildInfo.KMeans.K);
         auto path = GetBuildPath(Self, buildInfo, NTableIndex::NKMeans::LevelTable);
         Y_ENSURE(buildInfo.Sample.Rows.size() <= buildInfo.KMeans.K);
-        auto actor = new TUploadSampleK(path.PathString(), !buildInfo.KMeans.NeedsAnotherLevel(),
+        auto actor = new TUploadSampleK(CanonizePath(Self->RootPathElements), path.PathString(),
+            !buildInfo.KMeans.NeedsAnotherLevel(),
             buildInfo.ScanSettings, Self->SelfId(), BuildId,
             buildInfo.Sample.Rows, buildInfo.KMeans.Parent, buildInfo.KMeans.Child,
             buildInfo.KMeans.IsEmpty ? buildInfo.Clusters->GetEmptyRow() : "",
@@ -946,6 +955,7 @@ private:
             const auto& implTableInfo = Self->Tables.at(implTable.Base()->PathId);
             FillBuildInfoColumns(buildInfo, NTableIndex::ExtractInfo(implTableInfo));
         }
+        ev->Record.SetDatabaseName(CanonizePath(Self->RootPathElements));
         ev->Record.SetIndexName(buildInfo.TargetName);
         *ev->Record.MutableSettings() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(
             buildInfo.SpecializedIndexDescription).GetSettings();
@@ -1873,7 +1883,7 @@ public:
         }
         Y_ENSURE(path.LockedBy() == buildInfo.LockTxId);
 
-        TTableInfo::TPtr table = Self->Tables.at(path->PathId);        
+        TTableInfo::TPtr table = Self->Tables.at(path->PathId);
 
         auto tableColumns = NTableIndex::ExtractInfo(table); // skip dropped columns
         // In case of unique index validation the real range will arrive after index validation for each shard:

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4096,7 +4096,7 @@ void TSchemeShard::PersistColumnTableRemove(NIceDb::TNiceDb& db, TPathId pathId,
         storeInfo->ColumnTablesUnderOperation.erase(pathId);
         storeInfo->ColumnTables.erase(pathId);
     }
-    
+
     UpdateDiskSpaceUsage(db, pathId, TPartitionStats(), tableInfo.GetStats().Aggregated, ctx);
 
     db.Table<Schema::ColumnTables>().Key(pathId.LocalPathId).Delete();
@@ -8289,6 +8289,7 @@ void TSchemeShard::ResolveSA() {
 
         using TNavigate = NSchemeCache::TSchemeCacheNavigate;
         auto navigate = std::make_unique<TNavigate>();
+        navigate->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
         auto& entry = navigate->ResultSet.emplace_back();
         entry.TableId = TTableId(resourcesDomainId.OwnerId, resourcesDomainId.LocalPathId);
         entry.Operation = TNavigate::EOp::OpPath;

--- a/ydb/core/tx/tx_proxy/rpc_long_tx.cpp
+++ b/ydb/core/tx/tx_proxy/rpc_long_tx.cpp
@@ -95,7 +95,7 @@ protected:
         }
         if (NCSIndex::TServiceOperator::IsEnabled()) {
             TBase::Send(
-                NCSIndex::MakeServiceId(TBase::SelfId().NodeId()), new NCSIndex::TEvAddData(accessor->GetDeserializedBatch(), Path,
+                NCSIndex::MakeServiceId(TBase::SelfId().NodeId()), new NCSIndex::TEvAddData(accessor->GetDeserializedBatch(), DatabaseName, Path,
                                                                        std::make_shared<NCSIndex::TNaiveDataUpsertController>(TBase::SelfId())));
         } else {
             IndexReady = true;

--- a/ydb/core/tx/tx_proxy/upload_columns.cpp
+++ b/ydb/core/tx/tx_proxy/upload_columns.cpp
@@ -10,12 +10,14 @@ class TUploadColumnsInternal : public TUploadRowsBase<NKikimrServices::TActivity
 public:
     TUploadColumnsInternal(
         TActorId sender,
+        const TString& database,
         const TString& table,
         std::shared_ptr<TUploadTypes>& types,
         std::shared_ptr<arrow::RecordBatch>& data,
         ui64 cookie)
         : TUploadRowsBase(std::make_shared<TVector<std::pair<TSerializedCellVec, TString>>>())
         , Sender(sender)
+        , Database(database)
         , Table(table)
         , ColumnTypes(types)
         , Data(data)
@@ -24,11 +26,11 @@ public:
     }
 
 private:
-    TString GetDatabase() override {
-        return TString();
+    const TString& GetDatabase() const override {
+        return Database;
     }
 
-    const TString& GetTable() override {
+    const TString& GetTable() const override {
         return Table;
     }
 
@@ -68,6 +70,7 @@ private:
 
 private:
     const TActorId Sender;
+    const TString Database;
     const TString Table;
     const std::shared_ptr<TVector<std::pair<TString, Ydb::Type>>> ColumnTypes;
     const std::shared_ptr<arrow::RecordBatch> Data;
@@ -77,11 +80,12 @@ private:
 };
 
 IActor* CreateUploadColumnsInternal(const TActorId& sender,
+                                    const TString& database,
                                     const TString& table,
                                     std::shared_ptr<TUploadTypes> types,
                                     std::shared_ptr<arrow::RecordBatch> data,
                                     ui64 cookie = 0) {
-    return new TUploadColumnsInternal(sender, table, types, data, cookie);
+    return new TUploadColumnsInternal(sender, database, table, types, data, cookie);
 }
 
 

--- a/ydb/core/tx/tx_proxy/upload_columns.h
+++ b/ydb/core/tx/tx_proxy/upload_columns.h
@@ -14,6 +14,7 @@ namespace NKikimr::NTxProxy {
 using TUploadTypes = TVector<std::pair<TString, Ydb::Type>>;
 
 IActor* CreateUploadColumnsInternal(const TActorId& sender,
+                                    const TString& database,
                                     const TString& table,
                                     std::shared_ptr<TUploadTypes> types,
                                     std::shared_ptr<arrow::RecordBatch> data,

--- a/ydb/core/tx/tx_proxy/upload_rows.cpp
+++ b/ydb/core/tx/tx_proxy/upload_rows.cpp
@@ -10,6 +10,7 @@ class TUploadRowsInternal : public TUploadRowsBase<NKikimrServices::TActivity::U
 public:
     TUploadRowsInternal(
         TActorId sender,
+        const TString& database,
         const TString& table,
         std::shared_ptr<const TVector<std::pair<TString, Ydb::Type>>> types,
         std::shared_ptr<const TVector<std::pair<TSerializedCellVec, TString>>>&& rows,
@@ -20,6 +21,7 @@ public:
         TBackoff backoff)
         : TUploadRowsBase(std::move(rows))
         , Sender(sender)
+        , Database(database)
         , Table(table)
         , ColumnTypes(types)
         , Cookie(cookie)
@@ -43,11 +45,11 @@ public:
     }
 
 private:
-    TString GetDatabase()override {
-        return TString();
+    const TString& GetDatabase() const override {
+        return Database;
     }
 
-    const TString& GetTable() override {
+    const TString& GetTable() const override {
         return Table;
     }
 
@@ -87,6 +89,7 @@ private:
 
 private:
     const TActorId Sender;
+    const TString Database;
     const TString Table;
     const std::shared_ptr<const TVector<std::pair<TString, Ydb::Type>>> ColumnTypes;
     const ui64 Cookie;
@@ -95,6 +98,7 @@ private:
 };
 
 IActor* CreateUploadRowsInternal(const TActorId& sender,
+    const TString& database,
     const TString& table,
     std::shared_ptr<const TVector<std::pair<TString, Ydb::Type>>> types,
     std::shared_ptr<const TVector<std::pair<TSerializedCellVec, TString>>> rows,
@@ -105,6 +109,7 @@ IActor* CreateUploadRowsInternal(const TActorId& sender,
     TBackoff backoff)
 {
     return new TUploadRowsInternal(sender,
+        database,
         table,
         types,
         std::move(rows),

--- a/ydb/core/tx/tx_proxy/upload_rows.h
+++ b/ydb/core/tx/tx_proxy/upload_rows.h
@@ -23,6 +23,7 @@ using TUploadTypes = TVector<std::pair<TString, Ydb::Type>>;
 using TUploadRows = TVector<std::pair<TSerializedCellVec, TString>>;
 
 IActor* CreateUploadRowsInternal(const TActorId& sender,
+                                 const TString& database,
                                  const TString& table,
                                  std::shared_ptr<const TUploadTypes> types,
                                  std::shared_ptr<const TUploadRows> rows,

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -280,8 +280,8 @@ private:
         // nothing by default
     }
 
-    virtual TString GetDatabase() = 0;
-    virtual const TString& GetTable() = 0;
+    virtual const TString& GetDatabase() const = 0;
+    virtual const TString& GetTable() const = 0;
     virtual bool CheckAccess(TString& errorMessage) = 0;
     virtual TConclusion<TVector<std::pair<TString, Ydb::Type>>> GetRequestColumns() const = 0;
     virtual bool ExtractRows(TString& errorMessage) = 0;
@@ -599,6 +599,8 @@ private:
         AuditContextStart();
 
         TAutoPtr<NSchemeCache::TSchemeCacheNavigate> request(new NSchemeCache::TSchemeCacheNavigate());
+        request->DatabaseName = std::move(GetDatabase());
+
         NSchemeCache::TSchemeCacheNavigate::TEntry entry;
         entry.Path = ::NKikimr::SplitPath(table);
         if (entry.Path.empty()) {

--- a/ydb/services/ext_index/common/service.h
+++ b/ydb/services/ext_index/common/service.h
@@ -19,11 +19,16 @@ public:
 class TEvAddData: public NActors::TEventLocal<TEvAddData, EEvents::EvAddData> {
 private:
     YDB_READONLY_DEF(std::shared_ptr<arrow::RecordBatch>, Data);
+    YDB_READONLY_DEF(TString, DatabaseName);
     YDB_READONLY_DEF(TString, TablePath);
     YDB_READONLY_DEF(IDataUpsertController::TPtr, ExternalController);
 public:
-    TEvAddData(std::shared_ptr<arrow::RecordBatch> data, const TString& tablePath, IDataUpsertController::TPtr externalController)
+    TEvAddData(std::shared_ptr<arrow::RecordBatch> data,
+        const TString& databaseName, const TString& tablePath,
+        IDataUpsertController::TPtr externalController
+    )
         : Data(data)
+        , DatabaseName(databaseName)
         , TablePath(tablePath)
         , ExternalController(externalController)
     {

--- a/ydb/services/ext_index/service/add_data.cpp
+++ b/ydb/services/ext_index/service/add_data.cpp
@@ -14,7 +14,7 @@ void TDataUpserter::OnDescriptionSuccess(NMetadata::NProvider::TTableInfo&& resu
         } else {
             ALS_DEBUG(NKikimrServices::EXT_INDEX) << "add data";
             AtomicCounter.Inc();
-            TActivationContext::ActorSystem()->Register(new TIndexUpsertActor(Data, i, pkFields, i.GetIndexTablePath(), SelfContainer));
+            TActivationContext::ActorSystem()->Register(new TIndexUpsertActor(Data, i, pkFields, DatabaseName, i.GetIndexTablePath(), SelfContainer));
         }
     }
     OnIndexUpserted();

--- a/ydb/services/ext_index/service/add_data.h
+++ b/ydb/services/ext_index/service/add_data.h
@@ -13,14 +13,18 @@ class TDataUpserter:
     public NMetadata::NProvider::ISchemeDescribeController {
 private:
     mutable std::shared_ptr<TDataUpserter> SelfContainer;
+    const TString DatabaseName;
     std::vector<NMetadata::NCSIndex::TObject> Indexes;
     mutable TAtomicCounter AtomicCounter = 0;
     IDataUpsertController::TPtr ExternalController;
     std::shared_ptr<arrow::RecordBatch> Data;
 public:
-    TDataUpserter(std::vector<NMetadata::NCSIndex::TObject>&& indexes,
+    TDataUpserter(
+        const TString& databaseName,
+        std::vector<NMetadata::NCSIndex::TObject>&& indexes,
         IDataUpsertController::TPtr externalController, std::shared_ptr<arrow::RecordBatch> data)
-        : Indexes(std::move(indexes))
+        : DatabaseName(databaseName)
+        , Indexes(std::move(indexes))
         , ExternalController(externalController)
         , Data(data)
     {

--- a/ydb/services/ext_index/service/add_index.cpp
+++ b/ydb/services/ext_index/service/add_index.cpp
@@ -90,7 +90,7 @@ void TIndexUpsertActor::Bootstrap() {
         i.first = "pk_" + i.first;
     }
     types->insert(types->begin(), std::make_pair("index_hash", NMetadata::NInternal::TYDBType::Primitive(Ydb::Type::UINT64)));
-    auto actor = NTxProxy::CreateUploadRowsInternal(SelfId(), IndexTablePath, types, writer.GetRows());
+    auto actor = NTxProxy::CreateUploadRowsInternal(SelfId(), DatabaseName, IndexTablePath, types, writer.GetRows());
     Become(&TIndexUpsertActor::StateMain);
     Register(actor);
 }

--- a/ydb/services/ext_index/service/add_index.h
+++ b/ydb/services/ext_index/service/add_index.h
@@ -19,6 +19,7 @@ private:
     std::shared_ptr<arrow::RecordBatch> Data;
     const NMetadata::NCSIndex::TObject IndexInfo;
     std::vector<TString> PKFields;
+    const TString DatabaseName;
     TString IndexTablePath;
     IIndexUpsertController::TPtr ExternalController;
 protected:
@@ -36,10 +37,14 @@ public:
     void Bootstrap();
 
     TIndexUpsertActor(const std::shared_ptr<arrow::RecordBatch>& data, const NMetadata::NCSIndex::TObject& indexInfo,
-        const std::vector<TString>& pKFields, const TString& indexTablePath, IIndexUpsertController::TPtr externalController)
+        const std::vector<TString>& pKFields,
+        const TString& databaseName, const TString& indexTablePath,
+        IIndexUpsertController::TPtr externalController
+    )
         : Data(data)
         , IndexInfo(indexInfo)
         , PKFields(pKFields)
+        , DatabaseName(databaseName)
         , IndexTablePath(indexTablePath)
         , ExternalController(externalController)
     {

--- a/ydb/services/ext_index/service/executor.cpp
+++ b/ydb/services/ext_index/service/executor.cpp
@@ -15,7 +15,7 @@ void TExecutor::Handle(TEvAddData::TPtr& ev) {
         if (indexes.empty()) {
             ev->Get()->GetExternalController()->OnAllIndexesUpserted();
         } else {
-            std::shared_ptr<TDataUpserter> upserter = std::make_shared<TDataUpserter>(std::move(indexes), ev->Get()->GetExternalController(), ev->Get()->GetData());
+            auto upserter = std::make_shared<TDataUpserter>(ev->Get()->GetDatabaseName(), std::move(indexes), ev->Get()->GetExternalController(), ev->Get()->GetData());
             upserter->Start(upserter);
         }
     } else {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
To increase isolation of different databases and prevent lookups from one to another we have to fill database name in SchemeCache.
Therefore I added passing database name through Datashard batch upload requests.

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

