### PR TITLE
[ICRDMA] Move iterconnect_address in to separate lib EXT-1068

### DIFF
--- a/ydb/core/mind/dynamic_nameserver_impl.h
+++ b/ydb/core/mind/dynamic_nameserver_impl.h
@@ -6,7 +6,7 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/interconnect/events_local.h>
 #include <ydb/library/actors/interconnect/interconnect_impl.h>
-#include <ydb/library/actors/interconnect/interconnect_address.h>
+#include <ydb/library/actors/interconnect/address/interconnect_address.h>
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/cms/console/configs_dispatcher.h>
 #include <ydb/core/cms/console/console.h>

--- a/ydb/library/actors/interconnect/address/interconnect_address.cpp
+++ b/ydb/library/actors/interconnect/address/interconnect_address.cpp
@@ -19,21 +19,21 @@
 #endif
 
 namespace NInterconnect {
-    TAddress::TAddress() {
+    TAddress::TAddress() noexcept {
         memset(&Addr, 0, sizeof(Addr));
     }
 
-    TAddress::TAddress(NAddr::IRemoteAddr& addr) {
+    TAddress::TAddress(NAddr::IRemoteAddr& addr) noexcept {
         socklen_t len = addr.Len();
         Y_ABORT_UNLESS(len <= sizeof(Addr));
         memcpy(&Addr.Generic, addr.Addr(), len);
     }
 
-    int TAddress::GetFamily() const {
+    int TAddress::GetFamily() const noexcept {
         return Addr.Generic.sa_family;
     }
 
-    socklen_t TAddress::Size() const {
+    socklen_t TAddress::Size() const noexcept {
         switch (Addr.Generic.sa_family) {
             case AF_INET6:
                 return sizeof(sockaddr_in6);
@@ -44,15 +44,15 @@ namespace NInterconnect {
         }
     }
 
-    sockaddr* TAddress::SockAddr() {
+    sockaddr* TAddress::SockAddr() noexcept {
         return &Addr.Generic;
     }
 
-    const sockaddr* TAddress::SockAddr() const {
+    const sockaddr* TAddress::SockAddr() const noexcept {
         return &Addr.Generic;
     }
 
-    ui16 TAddress::GetPort() const {
+    ui16 TAddress::GetPort() const noexcept {
         switch (Addr.Generic.sa_family) {
             case AF_INET6:
                 return ntohs(Addr.Ipv6.sin6_port);
@@ -67,7 +67,7 @@ namespace NInterconnect {
         return GetAddress() + ":" + ::ToString(GetPort());
     }
 
-    TAddress::TAddress(const char* addr, ui16 port) {
+    TAddress::TAddress(const char* addr, ui16 port) noexcept {
         memset(&Addr, 0, sizeof(Addr));
         if (inet_pton(Addr.Ipv6.sin6_family = AF_INET6, addr, &Addr.Ipv6.sin6_addr) > 0) {
             Addr.Ipv6.sin6_port = htons(port);
@@ -76,17 +76,17 @@ namespace NInterconnect {
         }
     }
 
-    TAddress::TAddress(const TString& addr, ui16 port)
+    TAddress::TAddress(const TString& addr, ui16 port) noexcept
         : TAddress(addr.data(), port)
     {}
 
-    TAddress::TAddress(in_addr addr, ui16 port) {
+    TAddress::TAddress(in_addr addr, ui16 port) noexcept {
         Addr.Ipv4.sin_family = AF_INET;
         Addr.Ipv4.sin_port = htons(port);
         Addr.Ipv4.sin_addr = addr;
     }
 
-    TAddress::TAddress(in6_addr addr, ui16 port) {
+    TAddress::TAddress(in6_addr addr, ui16 port) noexcept {
         Addr.Ipv6.sin6_family = AF_INET6;
         Addr.Ipv6.sin6_port = htons(port);
         Addr.Ipv6.sin6_addr = addr;

--- a/ydb/library/actors/interconnect/address/interconnect_address.h
+++ b/ydb/library/actors/interconnect/address/interconnect_address.h
@@ -15,21 +15,21 @@ namespace NInterconnect {
         } Addr;
 
         using TV6Addr = in6_addr;
-        TAddress();
-        TAddress(const char* addr, ui16 port);
-        TAddress(const TString& addr, ui16 port);
-        TAddress(in_addr addr, ui16 port);
-        TAddress(in6_addr addr, ui16 port);
-        TAddress(NAddr::IRemoteAddr& addr);
-        int GetFamily() const;
-        socklen_t Size() const;
-        ::sockaddr* SockAddr();
-        const ::sockaddr* SockAddr() const;
-        ui16 GetPort() const;
+        TAddress() noexcept;
+        TAddress(const char* addr, ui16 port) noexcept;
+        TAddress(const TString& addr, ui16 port) noexcept;
+        TAddress(in_addr addr, ui16 port) noexcept;
+        TAddress(in6_addr addr, ui16 port) noexcept;
+        TAddress(NAddr::IRemoteAddr& addr) noexcept;
+        int GetFamily() const noexcept;
+        socklen_t Size() const noexcept;
+        ::sockaddr* SockAddr() noexcept;
+        const ::sockaddr* SockAddr() const noexcept;
+        ui16 GetPort() const noexcept;
         TString GetAddress() const;
         TString ToString() const;
 
-        static TAddress AnyIPv4(ui16 port) {
+        static TAddress AnyIPv4(ui16 port) noexcept {
             TAddress res;
             res.Addr.Ipv4.sin_family = AF_INET;
             res.Addr.Ipv4.sin_port = htons(port);
@@ -37,7 +37,7 @@ namespace NInterconnect {
             return res;
         }
 
-        static TAddress AnyIPv6(ui16 port) {
+        static TAddress AnyIPv6(ui16 port) noexcept {
             TAddress res;
             res.Addr.Ipv6.sin6_family = AF_INET6;
             res.Addr.Ipv6.sin6_port = htons(port);

--- a/ydb/library/actors/interconnect/address/ya.make
+++ b/ydb/library/actors/interconnect/address/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+SRCS(
+    interconnect_address.cpp
+    interconnect_address.h
+)
+
+PEERDIR(
+    contrib/libs/libc_compat
+)
+
+END()

--- a/ydb/library/actors/interconnect/interconnect_nameserver_base.h
+++ b/ydb/library/actors/interconnect/interconnect_nameserver_base.h
@@ -1,6 +1,5 @@
 #include "interconnect.h"
 #include "interconnect_impl.h"
-#include "interconnect_address.h"
 #include "events_local.h"
 
 #include <ydb/library/actors/core/hfunc.h>

--- a/ydb/library/actors/interconnect/interconnect_nameserver_dynamic.cpp
+++ b/ydb/library/actors/interconnect/interconnect_nameserver_dynamic.cpp
@@ -1,6 +1,5 @@
 #include "interconnect.h"
 #include "interconnect_impl.h"
-#include "interconnect_address.h"
 #include "interconnect_nameserver_base.h"
 #include "events_local.h"
 

--- a/ydb/library/actors/interconnect/interconnect_nameserver_table.cpp
+++ b/ydb/library/actors/interconnect/interconnect_nameserver_table.cpp
@@ -1,6 +1,5 @@
 #include "interconnect.h"
 #include "interconnect_impl.h"
-#include "interconnect_address.h"
 #include "interconnect_nameserver_base.h"
 #include "interconnect_stream.h"
 #include "events_local.h"

--- a/ydb/library/actors/interconnect/interconnect_resolve.cpp
+++ b/ydb/library/actors/interconnect/interconnect_resolve.cpp
@@ -1,5 +1,4 @@
 #include "interconnect.h"
-#include "interconnect_address.h"
 #include "events_local.h"
 
 #include <ydb/library/actors/interconnect/logging/logging.h>

--- a/ydb/library/actors/interconnect/interconnect_stream.h
+++ b/ydb/library/actors/interconnect/interconnect_stream.h
@@ -6,9 +6,8 @@
 #include <util/network/init.h>
 #include <util/system/defaults.h>
 
+#include <ydb/library/actors/interconnect/address/interconnect_address.h>
 #include <ydb/library/actors/interconnect/poller/poller.h>
-
-#include "interconnect_address.h"
 
 #include <memory>
 

--- a/ydb/library/actors/interconnect/rdma/ut/rdma_low_ut.cpp
+++ b/ydb/library/actors/interconnect/rdma/ut/rdma_low_ut.cpp
@@ -6,7 +6,7 @@
 #include <ydb/library/actors/interconnect/rdma/events.h>
 #include <ydb/library/actors/interconnect/rdma/rdma.h>
 #include <ydb/library/actors/interconnect/rdma/mem_pool.h>
-#include <ydb/library/actors/interconnect/interconnect_address.h>
+#include <ydb/library/actors/interconnect/address/interconnect_address.h>
 #include <ydb/library/actors/interconnect/poller/poller_actor.h>
 
 #include <library/cpp/testing/gtest/gtest.h>

--- a/ydb/library/actors/interconnect/rdma/ut/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ut/ya.make
@@ -20,6 +20,7 @@ PEERDIR(
     contrib/libs/ibdrv
     ydb/library/actors/core
     ydb/library/actors/interconnect
+    ydb/library/actors/interconnect/address
     ydb/library/actors/interconnect/rdma
     ydb/library/actors/interconnect/rdma/cq_actor
     ydb/library/actors/testlib

--- a/ydb/library/actors/interconnect/ya.make
+++ b/ydb/library/actors/interconnect/ya.make
@@ -16,8 +16,6 @@ SRCS(
     event_filter.h
     event_holder_pool.h
     events_local.h
-    interconnect_address.cpp
-    interconnect_address.h
     interconnect_channel.cpp
     interconnect_channel.h
     interconnect_common.cpp
@@ -66,6 +64,7 @@ PEERDIR(
     ydb/library/actors/dnscachelib
     ydb/library/actors/dnsresolver
     ydb/library/actors/helpers
+    ydb/library/actors/interconnect/address
     ydb/library/actors/interconnect/poller
     ydb/library/actors/prof
     ydb/library/actors/protos

--- a/ydb/library/yql/providers/dq/actors/dynamic_nameserver.cpp
+++ b/ydb/library/yql/providers/dq/actors/dynamic_nameserver.cpp
@@ -4,7 +4,7 @@
 
 #include <ydb/library/actors/interconnect/interconnect.h>
 #include <ydb/library/actors/interconnect/interconnect_impl.h>
-#include <ydb/library/actors/interconnect/interconnect_address.h>
+#include <ydb/library/actors/interconnect/address/interconnect_address.h>
 #include <ydb/library/actors/interconnect/events_local.h>
 
 #include <ydb/library/actors/core/hfunc.h>


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Move iterconnect_address in to separate lib.
The NInterconnect::TAddress code is used inside RDMA code. We need to move it in to separate library to prevent cycle dependence interconnect -> rdma -> interconnect 

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
