### PR TITLE
Add dead runner alert

### DIFF
--- a/.github/scripts/report_ram_analyzer.py
+++ b/.github/scripts/report_ram_analyzer.py
@@ -8,7 +8,21 @@ import subprocess
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from datetime import datetime, timezone
-from telegram.alert_queued_jobs import send_telegram_message, get_current_workflow_url, get_alert_logins
+from telegram.send_telegram_message import send_telegram_message
+
+
+def get_alert_logins() -> str:
+    logins = os.getenv('GH_ALERTS_TG_LOGINS')
+    return logins.strip() if logins else "@empEfarinov"
+
+
+def get_current_workflow_url() -> str:
+    github_repository = os.getenv('GITHUB_REPOSITORY', 'ydb-platform/ydb')
+    github_run_id = os.getenv('GITHUB_RUN_ID')
+
+    if github_run_id:
+        return f"https://github.com/{github_repository}/actions/runs/{github_run_id}"
+    return ""
 
 
 def timstamp_to_time(ts):

--- a/.github/scripts/shutdown_runner_alert.py
+++ b/.github/scripts/shutdown_runner_alert.py
@@ -73,8 +73,8 @@ def check_logs_for_shutdown_signal(owner, repo, run_id, token):
                 if log_response.status_code == 200:
                     fail = fail or ("##[error]The runner has received a shutdown signal" in log_response.text)
         return fail
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Error while log reading: {e}")
     return False
 
 
@@ -141,7 +141,7 @@ def main():
             message = "🚨 *RUNNER DIED DURING RUN*\n"
             for error in errors:
                 message += f"""
-• Workflow *{workflow['name']}* [#{error['workflow_id']}]({error['workflow_url']})
+• Workflow *{error['workflow_name']}* [#{error['workflow_id']}]({error['workflow_url']})
   Created at: {error['created_at']}"""
                 if error['pr_url']:
                     message += f"""

--- a/.github/scripts/shutdown_runner_alert.py
+++ b/.github/scripts/shutdown_runner_alert.py
@@ -58,6 +58,8 @@ def check_logs_for_shutdown_signal(owner, repo, run_id, token):
     fail = False
     try:
         for job in all_jobs:
+            if job['conclusion'] != 'cancelled':
+                continue
             url = f"https://api.github.com/repos/{owner}/{repo}/actions/jobs/{job['id']}/logs"
             headers = {
                 'Accept': 'application/vnd.github.v3+json',

--- a/.github/scripts/shutdown_runner_alert.py
+++ b/.github/scripts/shutdown_runner_alert.py
@@ -1,0 +1,156 @@
+import datetime
+import os
+import requests
+import argparse
+
+from telegram.alert_queued_jobs import send_telegram_message, get_alert_logins
+
+
+def get_workflows_from_ts(owner, repo, token, ts, max_runs=50):
+    """Get recent workflow runs filtered by status and event type."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/actions/runs"
+    workflow_runs = []
+    page_size = 25
+    while len(workflow_runs) < max_runs:
+        params = {
+            'status': 'cancelled',
+            'event': 'pull_request_target',
+            'per_page': 25,
+            'page': len(workflow_runs) // page_size + 1
+        }
+        headers = {
+            'Accept': 'application/vnd.github.v3+json',
+            'Authorization': f'token {token}'
+        }
+        response = requests.get(url, headers=headers, params=params)
+        response.raise_for_status()
+        workflow_runs += response.json()['workflow_runs']
+        if workflow_runs[-1]['created_at'] > ts:
+            break
+    return workflow_runs
+
+
+def get_workflow_jobs(owner, repo, run_id, token):
+    """Get jobs for a specific workflow run."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/actions/runs/{run_id}/jobs"
+    headers = {
+        'Accept': 'application/vnd.github.v3+json',
+        'Authorization': f'token {token}'
+    }
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()['jobs']
+
+
+def check_logs_for_shutdown_signal(owner, repo, run_id, token):
+    """Check workflow logs for the specific shutdown signal error."""
+    all_jobs = get_workflow_jobs(owner, repo, run_id, token)
+    print(len(all_jobs))
+    fail = False
+    try:
+        for job in all_jobs:
+            url = f"https://api.github.com/repos/{owner}/{repo}/actions/jobs/{job['id']}/logs"
+            headers = {
+                'Accept': 'application/vnd.github.v3+json',
+                'Authorization': f'token {token}'
+            }
+            # Get the redirect URL for logs
+            response = requests.get(url, headers=headers, allow_redirects=False)
+            if response.status_code == 302:
+                log_url = response.headers['Location']
+                log_response = requests.get(log_url)
+                if log_response.status_code == 200:
+                    fail = fail or ("##[error]The runner has received a shutdown signal" in log_response.text)
+        return fail
+    except Exception:
+        pass
+    return False
+
+
+def main():
+    """Main function to execute the workflow check."""
+    parser = argparse.ArgumentParser(
+        description='Check GitHub PR target workflows for runner shutdown errors'
+    )
+    parser.add_argument('--bot-token', help='Telegram bot token (or use TELEGRAM_BOT_TOKEN env var)')
+    parser.add_argument('--chat-id', help='Telegram chat ID')
+    parser.add_argument('--channel', help='Telegram channel ID (alternative to --chat-id)')
+    parser.add_argument('--thread-id', type=int, help='Telegram thread ID for group messages')
+
+    parser.add_argument('--owner', help='Repository owner')
+    parser.add_argument('--repo', help='Repository name')
+    parser.add_argument('--token', help='Github token')
+    parser.add_argument('--hours-delta', help='Number of hours to analyze from current timestamp', default=12)
+    parser.add_argument('--max-rows', help='Max number of workflow runs to analyze', default=100)
+    args = parser.parse_args()
+
+    # Get GitHub token from environment
+    token = args.token or os.getenv('GITHUB_TOKEN')
+    if not token:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        return
+
+    # Get repo owner/name from arguments or environment
+    repo_full_name = os.getenv('GITHUB_REPOSITORY')
+    if repo_full_name:
+        owner, repo = repo_full_name.split('/')
+    elif args.owner and args.repo:
+        owner, repo = args.owner, args.repo
+    else:
+        parser.print_help()
+        return
+
+    try:
+        # Get recent workflow runs
+        current_date = datetime.datetime.now()
+        workflows = get_workflows_from_ts(owner, repo, token, current_date.add(hours=-args.hours_delta), max_runs=args.max_rows)
+        print(f'Got {len(workflows)} workflows created from the last {args.hours_delta} hours')
+        recent_workflows = sorted(workflows, key=lambda x: x['created_at'], reverse=True)
+
+        errors = []
+        for workflow in recent_workflows:
+            print(workflow['created_at'])
+            if check_logs_for_shutdown_signal(owner, repo, workflow['id'], token):
+                print(f"\n🔴 SHUTDOWN ERROR - Workflow #{workflow['id']}")
+                print(f"Created: {workflow['created_at']}")
+                print(f"URL: {workflow['html_url']}")
+                print(f"PR: {workflow['pull_requests'][0]['url'] if workflow['pull_requests'] else 'N/A'}")
+                errors.append({
+                    "workflow_id": workflow['id'],
+                    "workflow_name": workflow['name'],
+                    "workflow_url": workflow['html_url'],
+                    "pr_url": workflow['pull_requests'][0]['url'] if workflow['pull_requests'] else 'N/A'
+                })
+
+        if len(errors) > 0:
+            bot_token = args.bot_token or os.getenv('TELEGRAM_BOT_TOKEN')
+            chat_id = args.channel or args.chat_id or os.getenv('TELEGRAM_CHAT_ID')
+            thread_id = args.thread_id or os.getenv('TELEGRAM_THREAD_ID')
+
+            message = "🚨 *RUNNER DIED DURING RUN*"
+            for error in errors:
+                message += f"""
+Created: {error['created_at']}
+Workflow {workflow['name']} [#{error['workflow_id']}]({error['workflow_url']})
+Linked PR: {error['pr_url']}"""
+            message += f"""
+
+CC {get_alert_logins()}"""
+
+            if chat_id and not chat_id.startswith('-') and len(chat_id) >= 10:
+                # Add -100 prefix for supergroup
+                chat_id = f"-100{chat_id}"
+            send_telegram_message(
+                bot_token,
+                chat_id,
+                message,
+                thread_id,
+                "MarkdownV2")
+        print(f"\nFound {len(errors)} workflows with shutdown errors out of {len(recent_workflows)} checked")
+
+    except Exception as e:
+        print(f"Error: {str(e)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/shutdown_runner_alert.py
+++ b/.github/scripts/shutdown_runner_alert.py
@@ -20,7 +20,7 @@ def get_workflows_from_ts(owner, repo, token, ts, max_runs=50):
             'status': 'cancelled',
             'event': 'pull_request_target',
             'per_page': 25,
-            'page': len(workflow_runs) // page_size + 15
+            'page': len(workflow_runs) // page_size + 1
         }
         headers = {
             'Accept': 'application/vnd.github.v3+json',

--- a/.github/scripts/shutdown_runner_alert.py
+++ b/.github/scripts/shutdown_runner_alert.py
@@ -3,7 +3,12 @@ import os
 import requests
 import argparse
 
-from telegram.alert_queued_jobs import send_telegram_message, get_alert_logins
+from telegram.send_telegram_message import send_telegram_message
+
+
+def get_alert_logins() -> str:
+    logins = os.getenv('GH_ALERTS_TG_LOGINS')
+    return logins.strip() if logins else "@empEfarinov"
 
 
 def str_to_date(str):
@@ -14,12 +19,12 @@ def get_workflows_from_ts(owner, repo, token, ts, max_runs=50):
     """Get recent workflow runs filtered by status and event type."""
     url = f"https://api.github.com/repos/{owner}/{repo}/actions/runs"
     workflow_runs = []
-    page_size = 25
+    page_size = min(100, max_runs)
     while len(workflow_runs) < max_runs:
         params = {
             'status': 'cancelled',
             'event': 'pull_request_target',
-            'per_page': 25,
+            'per_page': page_size,
             'page': len(workflow_runs) // page_size + 1
         }
         headers = {
@@ -151,8 +156,7 @@ def main():
                 bot_token,
                 chat_id,
                 message,
-                thread_id,
-                "MarkdownV2")
+                message_thread_id=thread_id)
         print(f"\nFound {len(errors)} workflows with shutdown errors out of {len(recent_workflows)} checked")
 
     except Exception as e:

--- a/.github/workflows/alert_died_runners.yml
+++ b/.github/workflows/alert_died_runners.yml
@@ -1,0 +1,37 @@
+name: Alert Died Runners
+
+on:
+  schedule:
+    # Run every 2 hours
+    - cron: '0 */2 * * *'
+  # Can also be triggered manually
+  workflow_dispatch:
+
+jobs:
+  check-queued-jobs:
+    runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+        
+    - name: Run queued jobs checker and send to Telegram
+      env:
+        TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_YDBOT_TOKEN }}
+        GH_ALERTS_TG_LOGINS: ${{ vars.GH_ALERTS_TG_LOGINS }}
+      run: |
+        python .github/scripts/shutdown_runner_alert.py \
+          --chat-id -4792293503 \
+          --token ${{ secrets.GITHUB_TOKEN }} \
+          --hours-delta 12 \
+          --max-rows 100

--- a/.github/workflows/alert_died_runners.yml
+++ b/.github/workflows/alert_died_runners.yml
@@ -31,7 +31,7 @@ jobs:
         GH_ALERTS_TG_LOGINS: ${{ vars.GH_ALERTS_TG_LOGINS }}
       run: |
         python .github/scripts/shutdown_runner_alert.py \
-          --chat-id -4792293503 \
+          --chat-id ${{ vars.GH_ALERTS_TG_CHAT }} \
           --token ${{ secrets.GITHUB_TOKEN }} \
           --hours-delta 12 \
           --max-rows 100


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Добавлен алерт на умерший раннер в процессе работы тестов

Условие по наличию `"##[error]The runner has received a shutdown signal` в отмененных прогонах с пулл реквеста

Предполагаю запускать каждые 2 часа с окном проверки - 12 часов (на случай проблем на долгих запусках)

Пример сообщения:
<img width="316" height="596" alt="image" src="https://github.com/user-attachments/assets/ee6b1de5-c3a5-44c0-891d-8d37955da712" />

