### PR TITLE
`ydb import s3 --exclude`

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added a new `--exclude` option to the `ydb import s3` command, allowing objects to be excluded from the operation if their names match a pattern.
 * Added a new `ydb admin cluster state fetch` command to collect information about cluster nodes state and metrics.
 * Fixed a bug with no consumer creation for transfers with absolute topic paths when no CONNECTION_STRING is provided.
 * Added transfer objects support to the `ydb tools dump` and `ydb tools restore` commands.

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
@@ -2,6 +2,7 @@
 
 #include "ydb_common.h"
 
+#include <ydb/public/lib/ydb_cli/common/exclude_item.h>
 #include <ydb/public/lib/ydb_cli/common/interactive.h>
 #include <ydb/public/lib/ydb_cli/common/normalize_path.h>
 #include <ydb/public/lib/ydb_cli/common/pretty_table.h>
@@ -82,6 +83,11 @@ void TCommandImportFromS3::Config(TConfig& config) {
 
     config.Opts->AddLongOption("include", "Schema objects to be included in the import. Directories are traversed recursively. The option can be used multiple times")
         .RequiredArgument("PATH").AppendTo(&IncludePaths);
+
+    config.Opts->AddLongOption("exclude", "Pattern (PCRE) for paths excluded from import operation")
+        .RequiredArgument("STRING").Handler([this](const TString& arg) {
+            ExclusionPatterns.emplace_back(TRegExMatch(arg));
+        });
 
     config.Opts->AddLongOption("item", TItem::FormatHelp("Item specification", config.HelpCommandVerbosiltyLevel, 2))
         .RequiredArgument("PROPERTY=VALUE,...");
@@ -170,6 +176,8 @@ void TCommandImportFromS3::FillItems(NYdb::NImport::TImportFromS3Settings& setti
     } else {
         FillItemsFromIncludeParam(settings);
     }
+
+    ExcludeItems(settings, ExclusionPatterns);
 }
 
 void TCommandImportFromS3::FillItemsFromItemParam(NYdb::NImport::TImportFromS3Settings& settings) const {

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.h
@@ -9,6 +9,8 @@
 #include <ydb/public/lib/ydb_cli/common/parseable_struct.h>
 #include <ydb/public/lib/ydb_cli/import/import.h>
 
+#include <library/cpp/regex/pcre/regexp.h>
+
 namespace NYdb::NConsoleClient {
 
 class TCommandImport : public TClientCommandTree {
@@ -43,6 +45,7 @@ private:
     ES3Scheme AwsScheme = ES3Scheme::HTTPS;
     TString AwsBucket;
     TVector<TItem> Items;
+    TVector<TRegExMatch> ExclusionPatterns;
     TVector<TString> IncludePaths;
     TString Description;
     ui32 NumberOfRetries = 10;

--- a/ydb/public/lib/ydb_cli/common/exclude_item.h
+++ b/ydb/public/lib/ydb_cli/common/exclude_item.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <library/cpp/regex/pcre/regexp.h>
+
+#include <util/generic/vector.h>
+
+#include <string>
+
+namespace NYdb::NConsoleClient {
+
+inline bool IsExcluded(const char* str, const TVector<TRegExMatch>& exclusionPatterns) {
+    for (const auto& pattern : exclusionPatterns) {
+        if (pattern.Match(str)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+inline bool IsExcluded(const std::string& str, const TVector<TRegExMatch>& exclusionPatterns) {
+    return IsExcluded(str.c_str(), exclusionPatterns);
+}
+
+template <typename TSettings>
+void ExcludeItems(TSettings& settings, const TVector<TRegExMatch>& exclusionPatterns) {
+    auto items(std::move(settings.Item_));
+    for (const auto& item : items) {
+        if (IsExcluded(item.Src, exclusionPatterns)) {
+            continue;
+        }
+
+        settings.AppendItem({item.Src, item.Dst});
+    }
+}
+
+}

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -40,8 +40,9 @@ PEERDIR(
     contrib/libs/openssl
     library/cpp/getopt
     library/cpp/json/writer
-    library/cpp/yaml/as
+    library/cpp/regex/pcre
     library/cpp/string_utils/csv
+    library/cpp/yaml/as
     ydb/public/lib/json_value
     ydb/public/sdk/cpp/src/library/operation_id
     ydb/public/lib/yson_value


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added a new `--exclude` option to the `ydb import s3` command, allowing objects to be excluded from the operation if their names match a pattern.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
