### PR TITLE
EXT-1634: DnsResolver Add trailing dot option

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -563,6 +563,7 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                 resolverOptions.Type = NDnsResolver::EDnsResolverType::Libc;
                 break;
         }
+        resolverOptions.AddTrailingDot = nsConfig.GetAddTrailingDot();
         IActor *resolver = NDnsResolver::CreateOnDemandDnsResolver(resolverOptions);
 
         setup->LocalServices.emplace_back(

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -183,6 +183,7 @@ message TStaticNameserviceConfig {
     optional bool KeepSocket = 6 [default = true];
     optional bool ForceTcp = 7 [default = false];
     optional EDnsResolverType DnsResolverType = 8 [default = ARES];
+    optional bool AddTrailingDot = 9 [default = false];
 }
 
 message TDynamicNameserviceConfig {

--- a/ydb/library/actors/dnsresolver/dnsresolver.cpp
+++ b/ydb/library/actors/dnsresolver/dnsresolver.cpp
@@ -130,6 +130,13 @@ namespace NDnsResolver {
         std::atomic<size_t> Activations{ 0 };
     };
 
+    static TString AddTrailingDot(TString&& name, bool addTrailingDot) noexcept {
+        if (addTrailingDot && !name.empty() && name.back() != '.') {
+            name += ".";
+        }
+        return name;
+    }
+
     class TAresDnsResolver
         : public TActor<TAresDnsResolver>
         , private TAresLibraryInitBase
@@ -290,6 +297,7 @@ namespace NDnsResolver {
             memset(&hints, 0, sizeof(hints));
             hints.ai_flags = ARES_AI_NOSORT;
             hints.ai_family = family;
+            name = AddTrailingDot(std::move(name), reqCtx->Self->Options.AddTrailingDot);
             ares_getaddrinfo(AresChannel, name.c_str(), nullptr, &hints, &TThis::GetAddrInfoAresCallback, reqCtx.Get());
         }
 
@@ -533,6 +541,7 @@ namespace NDnsResolver {
 
     private:
         std::unique_ptr<TEvDns::TEvGetHostByNameResult> GetHostByName(TString name, int family) {
+            name = AddTrailingDot(std::move(name), Options.AddTrailingDot);
             auto result = std::make_unique<TEvDns::TEvGetHostByNameResult>();
 
             struct addrinfo hints, *res;

--- a/ydb/library/actors/dnsresolver/dnsresolver.h
+++ b/ydb/library/actors/dnsresolver/dnsresolver.h
@@ -100,6 +100,8 @@ namespace NDnsResolver {
         bool KeepSocket = true;
         // Force tcp to perform dns requests
         bool ForceTcp = false;
+        // Add trailing dot to hostname
+        bool AddTrailingDot = false;
     };
 
     IActor* CreateSimpleDnsResolver(TSimpleDnsResolverOptions options = TSimpleDnsResolverOptions());

--- a/ydb/library/actors/dnsresolver/dnsresolver_ut.cpp
+++ b/ydb/library/actors/dnsresolver/dnsresolver_ut.cpp
@@ -29,50 +29,56 @@ Y_UNIT_TEST_SUITE(DnsResolver) {
     };
 
     Y_UNIT_TEST(ResolveLocalHost) {
-        for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
-            TSimpleDnsResolverOptions options { .Type = type };
-            TTestActorRuntimeBase runtime;
-            runtime.Initialize();
-            auto sender = runtime.AllocateEdgeActor();
-            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
-            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("localhost", AF_UNSPEC)),
-                    0, true);
-            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
-            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-            size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
-            UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        for (auto addTrailingDot : { true, false }) {
+            for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
+                TSimpleDnsResolverOptions options { .Type = type, .AddTrailingDot = addTrailingDot };
+                TTestActorRuntimeBase runtime;
+                runtime.Initialize();
+                auto sender = runtime.AllocateEdgeActor();
+                auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
+                runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("localhost", AF_UNSPEC)),
+                        0, true);
+                auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
+                UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+                size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
+                UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+            }
         }
     }
 
     Y_UNIT_TEST(ResolveYandexRu) {
-        for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
-            TSimpleDnsResolverOptions options { .Type = type }; 
-            TTestActorRuntimeBase runtime;
-            runtime.Initialize();
-            auto sender = runtime.AllocateEdgeActor();
-            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
-            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("yandex.ru", AF_UNSPEC)),
-                    0, true);
-            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
-            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-            size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
-            UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        for (auto addTrailingDot : { true, false }) {
+            for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
+                TSimpleDnsResolverOptions options { .Type = type, .AddTrailingDot = addTrailingDot }; 
+                TTestActorRuntimeBase runtime;
+                runtime.Initialize();
+                auto sender = runtime.AllocateEdgeActor();
+                auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
+                runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("yandex.ru", AF_UNSPEC)),
+                        0, true);
+                auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
+                UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+                size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
+                UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+            }
         }
     }
 
     Y_UNIT_TEST(GetAddrYandexRu) {
-        for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
-            TSimpleDnsResolverOptions options { .Type = type };
-            TTestActorRuntimeBase runtime;
-            runtime.Initialize();
-            auto sender = runtime.AllocateEdgeActor();
-            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
+        for (auto addTrailingDot : { true, false }) {
+            for (auto type : { EDnsResolverType::Ares, EDnsResolverType::Libc }) {
+                TSimpleDnsResolverOptions options { .Type = type, .AddTrailingDot = addTrailingDot };
+                TTestActorRuntimeBase runtime;
+                runtime.Initialize();
+                auto sender = runtime.AllocateEdgeActor();
+                auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
 
-            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetAddr("yandex.ru", AF_UNSPEC)),
-                    0, true);
-            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetAddrResult>(sender);
-            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-            UNIT_ASSERT_C(ev->Get()->IsV4() || ev->Get()->IsV6(), "Expect v4 or v6 address");
+                runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetAddr("yandex.ru", AF_UNSPEC)),
+                        0, true);
+                auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetAddrResult>(sender);
+                UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+                UNIT_ASSERT_C(ev->Get()->IsV4() || ev->Get()->IsV6(), "Expect v4 or v6 address");
+            }
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added an option to add a trailing dot to all resolving domains

```
nameservice_config:
  add_trailing_dot: true
```

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

If an FQDN doesn’t end with a dot, multiple search queries may be sent to handle the search domain configuration. This can create additional load on DNS.
