### PR TITLE
EXT-1333 Refactor common grpc macros

### DIFF
--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -354,7 +354,7 @@ enum class TRateLimiterMode : ui8 {
 };
 
 #define RLSWITCH(mode) \
-    IsRlAllowed() ? mode : TRateLimiterMode::Off
+    IsRlAllowed() ? ::NKikimr::NGRpcService::TRateLimiterMode::mode : ::NKikimr::NGRpcService::TRateLimiterMode::Off
 
 struct TAuditMode {
     using TLogClassConfig = NKikimrConfig::TAuditConfig::TLogClassConfig;

--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -353,8 +353,11 @@ enum class TRateLimiterMode : ui8 {
     RuTopic = 5,
 };
 
+#define RLMODE(mode) \
+    ::NKikimr::NGRpcService::TRateLimiterMode::mode
+
 #define RLSWITCH(mode) \
-    IsRlAllowed() ? ::NKikimr::NGRpcService::TRateLimiterMode::mode : ::NKikimr::NGRpcService::TRateLimiterMode::Off
+    IsRlAllowed() ? RLMODE(mode) : RLMODE(Off)
 
 struct TAuditMode {
     using TLogClassConfig = NKikimrConfig::TAuditConfig::TLogClassConfig;

--- a/ydb/library/grpc/server/grpc_method_setup.h
+++ b/ydb/library/grpc/server/grpc_method_setup.h
@@ -17,9 +17,10 @@
 // Implies using namespace for request/response types
 #define YDB_API_DEFAULT_REQUEST_TYPE(methodName) Y_CAT(methodName, Request)
 #define YDB_API_DEFAULT_RESPONSE_TYPE(methodName) Y_CAT(methodName, Response)
+#define YDB_API_DEFAULT_COUNTER_BLOCK(counterName, methodName) getCounterBlock(Y_STRINGIZE(counterName), Y_STRINGIZE(methodName))
 
 // Implies usage from inside grpc service class, derived from TGrpcServiceBase
-#define SETUP_RUNTIME_EVENT_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, counterName, auditMode, runtimeEventType, operationCallClass, grpcProxyId) \
+#define SETUP_RUNTIME_EVENT_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, counterBlock, auditMode, runtimeEventType, operationCallClass, grpcProxyId) \
     MakeIntrusive<::NKikimr::NGRpcService::TGRpcRequest<                                                  \
         inputType,                                                                                        \
         outputType,                                                                                       \
@@ -43,7 +44,7 @@
         &TGrpcAsyncService::Y_CAT(Request, methodName),                                                   \
         Y_STRINGIZE(methodName),                                                                          \
         logger,                                                                                           \
-        getCounterBlock(Y_STRINGIZE(counterName), Y_STRINGIZE(methodName))                                \
+        counterBlock                                                                                      \
     )->Run()
 
 
@@ -55,7 +56,7 @@
         methodCallback, \
         rlMode, \
         requestType, \
-        counterName, \
+        YDB_API_DEFAULT_COUNTER_BLOCK(counterName, methodName), \
         auditMode, \
         COMMON, \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall, \

--- a/ydb/library/grpc/server/grpc_method_setup.h
+++ b/ydb/library/grpc/server/grpc_method_setup.h
@@ -1,10 +1,17 @@
 #ifndef GRPC_METHOD_SETUP_H
 #define GRPC_METHOD_SETUP_H
 
-#include <memory>
-#include <string>
+#include <ydb/core/grpc_services/base/base.h>
+#include <ydb/core/grpc_services/grpc_mon.h>
+#include <ydb/core/jaeger_tracing/request_discriminator.h>
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/grpc/server/grpc_request.h>
+#include <ydb/library/grpc/server/grpc_request_base.h>
+
 #include <grpcpp/grpcpp.h>
 
+#include <memory>
+#include <string>
 #include <type_traits>
 
 // Implies using namespace for request/response types
@@ -13,35 +20,45 @@
 
 // Implies usage from inside grpc service class, derived from TGrpcServiceBase
 #define SETUP_RUNTIME_EVENT_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, counterName, auditMode, runtimeEventType, operationCallClass, grpcProxyId) \
-    MakeIntrusive<NGRpcService::TGRpcRequest<                                                         \
-        inputType,                                                                                    \
-        outputType,                                                                                   \
-        std::remove_reference_t<decltype(*this)>>>                                                    \
-    (                                                                                                 \
-        this,                                                                                         \
-        &Service_,                                                                                    \
-        CQ_,                                                                                          \
-        [this, proxyId = grpcProxyId](NYdbGrpc::IRequestContextBase* reqCtx) {                        \
-            NGRpcService::ReportGrpcReqToMon(*ActorSystem_, reqCtx->GetPeer());                       \
-            ActorSystem_->Send(proxyId, new operationCallClass<                                       \
-                inputType,                                                                            \
-                outputType,                                                                           \
-                NRuntimeEvents::EType::runtimeEventType>(reqCtx, methodCallback,                      \
-                    TRequestAuxSettings {                                                             \
-                        .RlMode = TRateLimiterMode::rlMode,                                           \
-                        .AuditMode = auditMode,                                                       \
-                        .RequestType = NJaegerTracing::ERequestType::requestType,                     \
-                    }));                                                                              \
-        },                                                                                            \
-        &TGrpcAsyncService::Y_CAT(Request, methodName),                                               \
-        Y_STRINGIZE(methodName),                                                                      \
-        logger,                                                                                       \
-        getCounterBlock(Y_STRINGIZE(counterName), Y_STRINGIZE(methodName))                            \
+    MakeIntrusive<::NKikimr::NGRpcService::TGRpcRequest<                                                  \
+        inputType,                                                                                        \
+        outputType,                                                                                       \
+        std::remove_reference_t<decltype(*this)>>>                                                        \
+    (                                                                                                     \
+        this,                                                                                             \
+        &Service_,                                                                                        \
+        CQ_,                                                                                              \
+        [this, proxyId = grpcProxyId](::NYdbGrpc::IRequestContextBase* reqCtx) {                          \
+            ::NKikimr::NGRpcService::ReportGrpcReqToMon(*ActorSystem_, reqCtx->GetPeer());                \
+            ActorSystem_->Send(proxyId, new operationCallClass<                                           \
+                inputType,                                                                                \
+                outputType,                                                                               \
+                ::NKikimr::NGRpcService::NRuntimeEvents::EType::runtimeEventType>(reqCtx, methodCallback, \
+                    ::NKikimr::NGRpcService::TRequestAuxSettings {                                        \
+                        .RlMode = ::NKikimr::NGRpcService::TRateLimiterMode::rlMode,                      \
+                        .AuditMode = auditMode,                                                           \
+                        .RequestType = ::NKikimr::NJaegerTracing::ERequestType::requestType,              \
+                    }));                                                                                  \
+        },                                                                                                \
+        &TGrpcAsyncService::Y_CAT(Request, methodName),                                                   \
+        Y_STRINGIZE(methodName),                                                                          \
+        logger,                                                                                           \
+        getCounterBlock(Y_STRINGIZE(counterName), Y_STRINGIZE(methodName))                                \
     )->Run()
 
 
 // Common macro for gRPC methods setup
-#define SETUP_METHOD(methodName, methodCallback, rlMode, requestType, counterName, auditMode)    \
-    SETUP_RUNTIME_EVENT_METHOD(methodName, YDB_API_DEFAULT_REQUEST_TYPE(methodName), YDB_API_DEFAULT_RESPONSE_TYPE(methodName), methodCallback, rlMode, requestType, counterName, auditMode, COMMON, TGrpcRequestOperationCall, GRpcRequestProxyId_)
+#define SETUP_METHOD(methodName, methodCallback, rlMode, requestType, counterName, auditMode) \
+    SETUP_RUNTIME_EVENT_METHOD(methodName, \
+        YDB_API_DEFAULT_REQUEST_TYPE(methodName), \
+        YDB_API_DEFAULT_RESPONSE_TYPE(methodName), \
+        methodCallback, \
+        rlMode, \
+        requestType, \
+        counterName, \
+        auditMode, \
+        COMMON, \
+        ::NKikimr::NGRpcService::TGrpcRequestOperationCall, \
+        GRpcRequestProxyId_)
 
 #endif // GRPC_METHOD_SETUP_H

--- a/ydb/library/grpc/server/grpc_method_setup.h
+++ b/ydb/library/grpc/server/grpc_method_setup.h
@@ -40,7 +40,7 @@
     )->Run()
 
 
-// Общий макрос для настройки методов gRPC
+// Common macro for gRPC methods setup
 #define SETUP_METHOD(methodName, methodCallback, rlMode, requestType, counterName, auditMode)    \
     SETUP_RUNTIME_EVENT_METHOD(methodName, YDB_API_DEFAULT_REQUEST_TYPE(methodName), YDB_API_DEFAULT_RESPONSE_TYPE(methodName), methodCallback, rlMode, requestType, counterName, auditMode, COMMON, TGrpcRequestOperationCall, GRpcRequestProxyId_)
 

--- a/ydb/library/grpc/server/grpc_method_setup.h
+++ b/ydb/library/grpc/server/grpc_method_setup.h
@@ -36,7 +36,7 @@
                 outputType,                                                                               \
                 ::NKikimr::NGRpcService::NRuntimeEvents::EType::runtimeEventType>(reqCtx, methodCallback, \
                     ::NKikimr::NGRpcService::TRequestAuxSettings {                                        \
-                        .RlMode = ::NKikimr::NGRpcService::TRateLimiterMode::rlMode,                      \
+                        .RlMode = rlMode,                                                                 \
                         .AuditMode = auditMode,                                                           \
                         .RequestType = ::NKikimr::NJaegerTracing::ERequestType::requestType,              \
                     }));                                                                                  \
@@ -47,8 +47,8 @@
         counterBlock                                                                                      \
     )->Run()
 
-
 // Common macro for gRPC methods setup
+// Use RLSWITCH or RLMODE macro for rlMode
 #define SETUP_METHOD(methodName, methodCallback, rlMode, requestType, counterName, auditMode) \
     SETUP_RUNTIME_EVENT_METHOD(methodName, \
         YDB_API_DEFAULT_REQUEST_TYPE(methodName), \

--- a/ydb/library/grpc/server/grpc_method_setup.h
+++ b/ydb/library/grpc/server/grpc_method_setup.h
@@ -20,7 +20,7 @@
 #define YDB_API_DEFAULT_COUNTER_BLOCK(counterName, methodName) getCounterBlock(Y_STRINGIZE(counterName), Y_STRINGIZE(methodName))
 
 // Implies usage from inside grpc service class, derived from TGrpcServiceBase
-#define SETUP_RUNTIME_EVENT_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, counterBlock, auditMode, runtimeEventType, operationCallClass, grpcProxyId, cq, limiter) \
+#define SETUP_RUNTIME_EVENT_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, counterBlock, auditMode, runtimeEventType, operationCallClass, grpcProxyId, cq, limiter, customAttributeProcessorCallback) \
     MakeIntrusive<::NKikimr::NGRpcService::TGRpcRequest<                                                  \
         inputType,                                                                                        \
         outputType,                                                                                       \
@@ -37,6 +37,7 @@
                 ::NKikimr::NGRpcService::NRuntimeEvents::EType::runtimeEventType>(reqCtx, methodCallback, \
                     ::NKikimr::NGRpcService::TRequestAuxSettings {                                        \
                         .RlMode = rlMode,                                                                 \
+                        .CustomAttributeProcessor = customAttributeProcessorCallback,                     \
                         .AuditMode = auditMode,                                                           \
                         .RequestType = ::NKikimr::NJaegerTracing::ERequestType::requestType,              \
                     }));                                                                                  \
@@ -63,6 +64,7 @@
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                                               \
         GRpcRequestProxyId_,                                                                              \
         CQ_,                                                                                              \
+        nullptr,                                                                                          \
         nullptr)
 
 #endif // GRPC_METHOD_SETUP_H

--- a/ydb/library/grpc/server/grpc_method_setup.h
+++ b/ydb/library/grpc/server/grpc_method_setup.h
@@ -30,7 +30,10 @@
         &Service_,                                                                                        \
         cq,                                                                                               \
         [this, proxyId = grpcProxyId](::NYdbGrpc::IRequestContextBase* reqCtx) {                          \
-            ::NKikimr::NGRpcService::ReportGrpcReqToMon(*ActorSystem_, reqCtx->GetPeer());                \
+            ::NKikimr::NGRpcService::ReportGrpcReqToMon(                                                  \
+                *ActorSystem_,                                                                            \
+                reqCtx->GetPeer(),                                                                        \
+                GetSdkBuildInfoIfNeeded(reqCtx));                                                         \
             ActorSystem_->Send(proxyId, new operationCallClass<                                           \
                 inputType,                                                                                \
                 outputType,                                                                               \

--- a/ydb/library/grpc/server/grpc_request.h
+++ b/ydb/library/grpc/server/grpc_request.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ydb/library/protobuf_printer/security_printer.h>
+
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/arena.h>
 #include <google/protobuf/message.h>
@@ -582,7 +584,7 @@ private:
     std::atomic<bool> ClientLost_ = false;
 };
 
-template<typename TIn, typename TOut, typename TService, typename TInProtoPrinter=google::protobuf::TextFormat::Printer, typename TOutProtoPrinter=google::protobuf::TextFormat::Printer>
+template<typename TIn, typename TOut, typename TService, typename TInProtoPrinter = ::NKikimr::TSecurityTextFormatPrinter<TIn>, typename TOutProtoPrinter = ::NKikimr::TSecurityTextFormatPrinter<TOut>>
 class TGRpcRequest: public TGRpcRequestImpl<TIn, TOut, TService, TInProtoPrinter, TOutProtoPrinter> {
     using TBase = TGRpcRequestImpl<TIn, TOut, TService, TInProtoPrinter, TOutProtoPrinter>;
 public:

--- a/ydb/library/grpc/server/grpc_server.h
+++ b/ydb/library/grpc/server/grpc_server.h
@@ -3,6 +3,7 @@
 #include "grpc_request_base.h"
 #include "logger.h"
 
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/resources/ydb_resources.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/grpc_common/constants.h>
 #include <library/cpp/threading/future/future.h>
 
@@ -319,6 +320,21 @@ public:
         return NeedAuth_;
     }
 
+    void ReportSdkBuildInfo() {
+        ReportSdkBuildInfo_ = true;
+    }
+
+    TString GetSdkBuildInfoIfNeeded(NYdbGrpc::IRequestContextBase* reqCtx) const {
+        TString result;
+        if (ReportSdkBuildInfo_) {
+            const auto& res = reqCtx->GetPeerMetaValues(NYdb::YDB_SDK_BUILD_INFO_HEADER);
+            if (!res.empty()) {
+                result = res[0];
+            }
+        }
+        return result;
+    }
+
 private:
     TAtomic ShuttingDown_ = 0;
     TAtomic GuardCount_ = 0;
@@ -337,6 +353,7 @@ private:
     std::atomic<size_t> NextShard_{ 0 };
 
     NYdbGrpc::TGlobalLimiter* Limiter_ = nullptr;
+    bool ReportSdkBuildInfo_ = false;
 };
 
 template<typename T>

--- a/ydb/services/bridge/grpc_service.cpp
+++ b/ydb/services/bridge/grpc_service.cpp
@@ -27,8 +27,8 @@ void TBridgeGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 
     using namespace Ydb::Bridge;
 
-    #define SETUP_BRIDGE_METHOD(methodName, method, rlMode, requestType, auditModeFlags) \
-        SETUP_METHOD(methodName, method, rlMode, requestType, config, auditModeFlags)
+    #define SETUP_BRIDGE_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
+        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditModeFlags)
 
     SETUP_BRIDGE_METHOD(GetClusterState, DoGetClusterState, Rps, BRIDGE_GETCLUSTERSTATE, TAuditMode::NonModifying());
     SETUP_BRIDGE_METHOD(UpdateClusterState, DoUpdateClusterState, Rps, BRIDGE_UPDATECLUSTERSTATE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/services/bridge/grpc_service.cpp
+++ b/ydb/services/bridge/grpc_service.cpp
@@ -23,17 +23,16 @@ void TBridgeGRpcService::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::
 }
 
 void TBridgeGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+    using namespace Ydb::Bridge;
     auto getCounterBlock = NGRpcService::CreateCounterCb(Counters_, ActorSystem_);
 
-    using namespace Ydb::Bridge;
-
-    #define SETUP_BRIDGE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
+#define SETUP_BRIDGE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
 
     SETUP_BRIDGE_METHOD(GetClusterState, DoGetClusterState, RLMODE(Rps), BRIDGE_GETCLUSTERSTATE, TAuditMode::NonModifying());
     SETUP_BRIDGE_METHOD(UpdateClusterState, DoUpdateClusterState, RLMODE(Rps), BRIDGE_UPDATECLUSTERSTATE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
 
-    #undef SETUP_BRIDGE_METHOD
+#undef SETUP_BRIDGE_METHOD
 }
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/services/bridge/grpc_service.cpp
+++ b/ydb/services/bridge/grpc_service.cpp
@@ -30,8 +30,8 @@ void TBridgeGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     #define SETUP_BRIDGE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
         SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
 
-    SETUP_BRIDGE_METHOD(GetClusterState, DoGetClusterState, Rps, BRIDGE_GETCLUSTERSTATE, TAuditMode::NonModifying());
-    SETUP_BRIDGE_METHOD(UpdateClusterState, DoUpdateClusterState, Rps, BRIDGE_UPDATECLUSTERSTATE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_BRIDGE_METHOD(GetClusterState, DoGetClusterState, RLMODE(Rps), BRIDGE_GETCLUSTERSTATE, TAuditMode::NonModifying());
+    SETUP_BRIDGE_METHOD(UpdateClusterState, DoUpdateClusterState, RLMODE(Rps), BRIDGE_UPDATECLUSTERSTATE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
 
     #undef SETUP_BRIDGE_METHOD
 }

--- a/ydb/services/bridge/grpc_service.cpp
+++ b/ydb/services/bridge/grpc_service.cpp
@@ -24,10 +24,14 @@ void TBridgeGRpcService::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::
 
 void TBridgeGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     using namespace Ydb::Bridge;
-    auto getCounterBlock = NGRpcService::CreateCounterCb(Counters_, ActorSystem_);
+    auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
+
+#ifdef SETUP_BRIDGE_METHOD
+#error SETUP_BRIDGE_METHOD macro already defined
+#endif
 
 #define SETUP_BRIDGE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, bridge, auditMode)
 
     SETUP_BRIDGE_METHOD(GetClusterState, DoGetClusterState, RLMODE(Rps), BRIDGE_GETCLUSTERSTATE, TAuditMode::NonModifying());
     SETUP_BRIDGE_METHOD(UpdateClusterState, DoUpdateClusterState, RLMODE(Rps), BRIDGE_UPDATECLUSTERSTATE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/services/bridge/grpc_service.cpp
+++ b/ydb/services/bridge/grpc_service.cpp
@@ -27,8 +27,8 @@ void TBridgeGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 
     using namespace Ydb::Bridge;
 
-    #define SETUP_BRIDGE_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
-        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditModeFlags)
+    #define SETUP_BRIDGE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
 
     SETUP_BRIDGE_METHOD(GetClusterState, DoGetClusterState, Rps, BRIDGE_GETCLUSTERSTATE, TAuditMode::NonModifying());
     SETUP_BRIDGE_METHOD(UpdateClusterState, DoUpdateClusterState, Rps, BRIDGE_UPDATECLUSTERSTATE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/services/bridge/grpc_service.cpp
+++ b/ydb/services/bridge/grpc_service.cpp
@@ -4,7 +4,7 @@
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/service_bridge.h>
 #include <ydb/core/jaeger_tracing/request_discriminator.h>
-#include "ydb/library/grpc/server/grpc_method_setup.h"
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr::NGRpcService {
 

--- a/ydb/services/bridge/grpc_service.h
+++ b/ydb/services/bridge/grpc_service.h
@@ -23,11 +23,11 @@ private:
     void SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger);
 
 private:
-    NActors::TActorSystem* ActorSystem = nullptr;
-    TIntrusivePtr<NMonitoring::TDynamicCounters> Counters;
-    NActors::TActorId GRpcRequestProxyId;
+    NActors::TActorSystem* ActorSystem_ = nullptr;
+    TIntrusivePtr<NMonitoring::TDynamicCounters> Counters_;
+    NActors::TActorId GRpcRequestProxyId_;
 
-    grpc::ServerCompletionQueue* CQ = nullptr;
+    grpc::ServerCompletionQueue* CQ_ = nullptr;
 };
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/services/cms/grpc_service.cpp
+++ b/ydb/services/cms/grpc_service.cpp
@@ -21,7 +21,7 @@ void TGRpcCmsService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                                         \
                     new TCALL<Cms::NAME##Request, Cms::NAME##Response>                                          \
-                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, AUDIT_MODE})); \
+                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE})); \
             }, &Cms::V1::CmsService::AsyncService::Request ## NAME,                                             \
             #NAME, logger, getCounterBlock("cms", #NAME))->Run();
 

--- a/ydb/services/config/grpc_service.cpp
+++ b/ydb/services/config/grpc_service.cpp
@@ -47,7 +47,9 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             auditMode, \
             BOOTSTRAP_CLUSTER, \
             TGrpcRequestOperationCall, \
-            GRpcRequestProxyId_)
+            GRpcRequestProxyId_, \
+            CQ_, \
+            nullptr)
 
     SETUP_BOOTSTRAP_CLUSTER_METHOD(BootstrapCluster, DoBootstrapCluster, RLMODE(Rps), CONFIG_BOOTSTRAP, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
 

--- a/ydb/services/config/grpc_service.cpp
+++ b/ydb/services/config/grpc_service.cpp
@@ -24,7 +24,15 @@ void TConfigGRpcService::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::
 
 void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     using namespace Ydb::Config;
-    auto getCounterBlock = NGRpcService::CreateCounterCb(Counters_, ActorSystem_);
+    auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
+
+#ifdef SETUP_BS_METHOD
+#error SETUP_BS_METHOD macro already defined
+#endif
+
+#ifdef SETUP_BOOTSTRAP_CLUSTER_METHOD
+#error SETUP_BOOTSTRAP_CLUSTER_METHOD macro already defined
+#endif
 
 #define SETUP_BS_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
     SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
@@ -50,7 +58,7 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     SETUP_BOOTSTRAP_CLUSTER_METHOD(BootstrapCluster, DoBootstrapCluster, RLMODE(Rps), CONFIG_BOOTSTRAP, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
 
 #undef SETUP_BS_METHOD
-#undef SETUP_BS_METHOD_WITH_TYPE
+#undef SETUP_BOOTSTRAP_CLUSTER_METHOD
 }
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/services/config/grpc_service.cpp
+++ b/ydb/services/config/grpc_service.cpp
@@ -27,8 +27,8 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 
     using namespace Ydb::Config;
 
-    #define SETUP_BS_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
-        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditModeFlags)
+    #define SETUP_BS_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
 
     SETUP_BS_METHOD(ReplaceConfig, DoReplaceConfig, Rps, CONFIG_REPLACECONFIG, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
     SETUP_BS_METHOD(FetchConfig, DoFetchConfig, Rps, CONFIG_FETCHCONFIG, TAuditMode::NonModifying());
@@ -36,8 +36,18 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     #undef SETUP_BS_METHOD
 
 
-    #define SETUP_BOOTSTRAP_CLUSTER_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
-        SETUP_RUNTIME_EVENT_METHOD(methodName, YDB_API_DEFAULT_REQUEST_TYPE(methodName), YDB_API_DEFAULT_RESPONSE_TYPE(methodName), methodCallback, rlMode, requestType, config, auditModeFlags, BOOTSTRAP_CLUSTER, TGrpcRequestOperationCall, GRpcRequestProxyId_)
+    #define SETUP_BOOTSTRAP_CLUSTER_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+        SETUP_RUNTIME_EVENT_METHOD(methodName, \
+            YDB_API_DEFAULT_REQUEST_TYPE(methodName), \
+            YDB_API_DEFAULT_RESPONSE_TYPE(methodName), \
+            methodCallback, \
+            rlMode, \
+            requestType, \
+            YDB_API_DEFAULT_COUNTER_BLOCK(config, methodName), \
+            auditMode, \
+            BOOTSTRAP_CLUSTER, \
+            TGrpcRequestOperationCall, \
+            GRpcRequestProxyId_)
 
     SETUP_BOOTSTRAP_CLUSTER_METHOD(BootstrapCluster, DoBootstrapCluster, Rps, CONFIG_BOOTSTRAP, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
 

--- a/ydb/services/config/grpc_service.cpp
+++ b/ydb/services/config/grpc_service.cpp
@@ -27,8 +27,8 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 
     using namespace Ydb::Config;
 
-    #define SETUP_BS_METHOD(methodName, method, rlMode, requestType, auditModeFlags) \
-        SETUP_METHOD(methodName, method, rlMode, requestType, config, auditModeFlags)
+    #define SETUP_BS_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
+        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditModeFlags)
 
     SETUP_BS_METHOD(ReplaceConfig, DoReplaceConfig, Rps, CONFIG_REPLACECONFIG, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
     SETUP_BS_METHOD(FetchConfig, DoFetchConfig, Rps, CONFIG_FETCHCONFIG, TAuditMode::NonModifying());
@@ -36,8 +36,8 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     #undef SETUP_BS_METHOD
 
 
-    #define SETUP_BOOTSTRAP_CLUSTER_METHOD(methodName, method, rlMode, requestType, auditModeFlags) \
-        SETUP_RUNTIME_EVENT_METHOD(methodName, YDB_API_DEFAULT_REQUEST_TYPE(methodName), YDB_API_DEFAULT_RESPONSE_TYPE(methodName), method, rlMode, requestType, config, auditModeFlags, BOOTSTRAP_CLUSTER, TGrpcRequestOperationCall, GRpcRequestProxyId_)
+    #define SETUP_BOOTSTRAP_CLUSTER_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
+        SETUP_RUNTIME_EVENT_METHOD(methodName, YDB_API_DEFAULT_REQUEST_TYPE(methodName), YDB_API_DEFAULT_RESPONSE_TYPE(methodName), methodCallback, rlMode, requestType, config, auditModeFlags, BOOTSTRAP_CLUSTER, TGrpcRequestOperationCall, GRpcRequestProxyId_)
 
     SETUP_BOOTSTRAP_CLUSTER_METHOD(BootstrapCluster, DoBootstrapCluster, Rps, CONFIG_BOOTSTRAP, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
 

--- a/ydb/services/config/grpc_service.cpp
+++ b/ydb/services/config/grpc_service.cpp
@@ -30,8 +30,8 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     #define SETUP_BS_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
         SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
 
-    SETUP_BS_METHOD(ReplaceConfig, DoReplaceConfig, Rps, CONFIG_REPLACECONFIG, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
-    SETUP_BS_METHOD(FetchConfig, DoFetchConfig, Rps, CONFIG_FETCHCONFIG, TAuditMode::NonModifying());
+    SETUP_BS_METHOD(ReplaceConfig, DoReplaceConfig, RLMODE(Rps), CONFIG_REPLACECONFIG, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_BS_METHOD(FetchConfig, DoFetchConfig, RLMODE(Rps), CONFIG_FETCHCONFIG, TAuditMode::NonModifying());
 
     #undef SETUP_BS_METHOD
 
@@ -49,7 +49,7 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             TGrpcRequestOperationCall, \
             GRpcRequestProxyId_)
 
-    SETUP_BOOTSTRAP_CLUSTER_METHOD(BootstrapCluster, DoBootstrapCluster, Rps, CONFIG_BOOTSTRAP, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_BOOTSTRAP_CLUSTER_METHOD(BootstrapCluster, DoBootstrapCluster, RLMODE(Rps), CONFIG_BOOTSTRAP, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
 
     #undef SETUP_BS_METHOD_WITH_TYPE
 }

--- a/ydb/services/config/grpc_service.cpp
+++ b/ydb/services/config/grpc_service.cpp
@@ -4,7 +4,7 @@
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/service_config.h>
 #include <ydb/core/jaeger_tracing/request_discriminator.h>
-#include "ydb/library/grpc/server/grpc_method_setup.h"
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr::NGRpcService {
 

--- a/ydb/services/config/grpc_service.cpp
+++ b/ydb/services/config/grpc_service.cpp
@@ -37,7 +37,7 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 
 
     #define SETUP_BOOTSTRAP_CLUSTER_METHOD(methodName, method, rlMode, requestType, auditModeFlags) \
-        SETUP_RUNTIME_EVENT_METHOD(methodName, YDB_API_DEFAULT_REQUEST_TYPE(methodName), YDB_API_DEFAULT_RESPONSE_TYPE(methodName), method, rlMode, requestType, config, auditModeFlags, BOOTSTRAP_CLUSTER)
+        SETUP_RUNTIME_EVENT_METHOD(methodName, YDB_API_DEFAULT_REQUEST_TYPE(methodName), YDB_API_DEFAULT_RESPONSE_TYPE(methodName), method, rlMode, requestType, config, auditModeFlags, BOOTSTRAP_CLUSTER, TGrpcRequestOperationCall, GRpcRequestProxyId_)
 
     SETUP_BOOTSTRAP_CLUSTER_METHOD(BootstrapCluster, DoBootstrapCluster, Rps, CONFIG_BOOTSTRAP, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
 

--- a/ydb/services/config/grpc_service.h
+++ b/ydb/services/config/grpc_service.h
@@ -22,11 +22,11 @@ private:
     void SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger);
 
 private:
-    NActors::TActorSystem* ActorSystem = nullptr;
-    TIntrusivePtr<NMonitoring::TDynamicCounters> Counters;
-    NActors::TActorId GRpcRequestProxyId;
+    NActors::TActorSystem* ActorSystem_ = nullptr;
+    TIntrusivePtr<NMonitoring::TDynamicCounters> Counters_;
+    NActors::TActorId GRpcRequestProxyId_;
 
-    grpc::ServerCompletionQueue* CQ = nullptr;
+    grpc::ServerCompletionQueue* CQ_ = nullptr;
 };
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/services/datastreams/grpc_service.cpp
+++ b/ydb/services/datastreams/grpc_service.cpp
@@ -49,7 +49,7 @@ void TGRpcDataStreamsService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                                    \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                                                             \
                     new TGrpcRequestOperationCall<Ydb::DataStreams::V1::NAME##Request, Ydb::DataStreams::V1::NAME##Response>        \
-                        (ctx, CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::LIMIT_TYPE), ATTR, AUDIT_MODE}));                  \
+                        (ctx, CB, TRequestAuxSettings{RLSWITCH(LIMIT_TYPE), ATTR, AUDIT_MODE}));                  \
             }, &Ydb::DataStreams::V1::DataStreamsService::AsyncService::Request ## NAME,                                            \
             #NAME, logger, getCounterBlock("data_streams", #NAME))->Run();
 

--- a/ydb/services/discovery/grpc_service.cpp
+++ b/ydb/services/discovery/grpc_service.cpp
@@ -29,7 +29,7 @@ void TGRpcDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer(), GetSdkBuildInfo(ctx));          \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                                         \
                     new TGrpcRequestOperationCall<Discovery::NAME##Request, Discovery::NAME##Response>          \
-                        (ctx, CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, AUDIT_MODE}));  \
+                        (ctx, CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE}));  \
             }, &Ydb::Discovery::V1::DiscoveryService::AsyncService::Request ## NAME,                            \
             #NAME, logger, getCounterBlock("discovery", #NAME))->Run();
 

--- a/ydb/services/dynamic_config/grpc_service.cpp
+++ b/ydb/services/dynamic_config/grpc_service.cpp
@@ -21,7 +21,7 @@ void TGRpcDynamicConfigService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logge
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                        \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                                                 \
                     new TGrpcRequestOperationCall<DynamicConfig::NAME##Request, DynamicConfig::NAME##Response>          \
-                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, AUDIT_MODE}));         \
+                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE}));         \
             }, &DynamicConfig::V1::DynamicConfigService::AsyncService::Request ## NAME,                                 \
             #NAME, logger, getCounterBlock("console", #NAME))->Run();
 

--- a/ydb/services/kesus/grpc_service.cpp
+++ b/ydb/services/kesus/grpc_service.cpp
@@ -651,7 +651,7 @@ void TKesusGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, reqCtx->GetPeer()); \
                 ActorSystem_->Send(GRpcRequestProxyId_, \
                     new NGRpcService::TGrpcRequestOperationCall<Ydb::Coordination::IN, Ydb::Coordination::OUT> \
-                        (reqCtx, &CB, NGRpcService::TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, AUDIT_MODE})); \
+                        (reqCtx, &CB, NGRpcService::TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE})); \
             }, \
             &Ydb::Coordination::V1::CoordinationService::AsyncService::Request ## NAME, \
             #NAME,  \

--- a/ydb/services/keyvalue/grpc_service.cpp
+++ b/ydb/services/keyvalue/grpc_service.cpp
@@ -23,19 +23,18 @@ void TKeyValueGRpcService::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc
 }
 
 void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
-    auto getCounterBlock = NGRpcService::CreateCounterCb(Counters_, ActorSystem_);
-
     using namespace Ydb::KeyValue;
+    auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 
-    #define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-        SETUP_METHOD( \
-            methodName, \
-            methodCallback, \
-            rlMode, \
-            requestType, \
-            keyvalue, \
-            auditMode \
-        )
+#define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD( \
+        methodName, \
+        methodCallback, \
+        rlMode, \
+        requestType, \
+        keyvalue, \
+        auditMode \
+    )
 
     SETUP_KV_METHOD(CreateVolume, DoCreateVolumeKeyValue, RLMODE(Rps), KEYVALUE_CREATEVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_KV_METHOD(DropVolume, DoDropVolumeKeyValue, RLMODE(Rps), KEYVALUE_DROPVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
@@ -50,7 +49,7 @@ void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     SETUP_KV_METHOD(ListRange, DoListRangeKeyValue, RLMODE(Rps), KEYVALUE_LISTRANGE, TAuditMode::NonModifying());
     SETUP_KV_METHOD(GetStorageChannelStatus, DoGetStorageChannelStatusKeyValue, RLMODE(Rps), KEYVALUE_GETSTORAGECHANNELSTATUS, TAuditMode::NonModifying());
 
-    #undef SETUP_KV_METHOD
+#undef SETUP_KV_METHOD
 }
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/services/keyvalue/grpc_service.cpp
+++ b/ydb/services/keyvalue/grpc_service.cpp
@@ -37,18 +37,18 @@ void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             auditMode \
         )
 
-    SETUP_KV_METHOD(CreateVolume, DoCreateVolumeKeyValue, Rps, KEYVALUE_CREATEVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-    SETUP_KV_METHOD(DropVolume, DoDropVolumeKeyValue, Rps, KEYVALUE_DROPVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-    SETUP_KV_METHOD(AlterVolume, DoAlterVolumeKeyValue, Rps, KEYVALUE_ALTERVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-    SETUP_KV_METHOD(DescribeVolume, DoDescribeVolumeKeyValue, Rps, KEYVALUE_DESCRIBEVOLUME, TAuditMode::NonModifying());
-    SETUP_KV_METHOD(ListLocalPartitions, DoListLocalPartitionsKeyValue, Rps, KEYVALUE_LISTLOCALPARTITIONS, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(CreateVolume, DoCreateVolumeKeyValue, RLMODE(Rps), KEYVALUE_CREATEVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_KV_METHOD(DropVolume, DoDropVolumeKeyValue, RLMODE(Rps), KEYVALUE_DROPVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_KV_METHOD(AlterVolume, DoAlterVolumeKeyValue, RLMODE(Rps), KEYVALUE_ALTERVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_KV_METHOD(DescribeVolume, DoDescribeVolumeKeyValue, RLMODE(Rps), KEYVALUE_DESCRIBEVOLUME, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(ListLocalPartitions, DoListLocalPartitionsKeyValue, RLMODE(Rps), KEYVALUE_LISTLOCALPARTITIONS, TAuditMode::NonModifying());
 
-    SETUP_KV_METHOD(AcquireLock, DoAcquireLockKeyValue, Rps, KEYVALUE_ACQUIRELOCK, TAuditMode::NonModifying());
-    SETUP_KV_METHOD(ExecuteTransaction, DoExecuteTransactionKeyValue, Rps, KEYVALUE_EXECUTETRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
-    SETUP_KV_METHOD(Read, DoReadKeyValue, Rps, KEYVALUE_READ, TAuditMode::NonModifying());
-    SETUP_KV_METHOD(ReadRange, DoReadRangeKeyValue, Rps, KEYVALUE_READRANGE, TAuditMode::NonModifying());
-    SETUP_KV_METHOD(ListRange, DoListRangeKeyValue, Rps, KEYVALUE_LISTRANGE, TAuditMode::NonModifying());
-    SETUP_KV_METHOD(GetStorageChannelStatus, DoGetStorageChannelStatusKeyValue, Rps, KEYVALUE_GETSTORAGECHANNELSTATUS, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(AcquireLock, DoAcquireLockKeyValue, RLMODE(Rps), KEYVALUE_ACQUIRELOCK, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(ExecuteTransaction, DoExecuteTransactionKeyValue, RLMODE(Rps), KEYVALUE_EXECUTETRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_KV_METHOD(Read, DoReadKeyValue, RLMODE(Rps), KEYVALUE_READ, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(ReadRange, DoReadRangeKeyValue, RLMODE(Rps), KEYVALUE_READRANGE, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(ListRange, DoListRangeKeyValue, RLMODE(Rps), KEYVALUE_LISTRANGE, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(GetStorageChannelStatus, DoGetStorageChannelStatusKeyValue, RLMODE(Rps), KEYVALUE_GETSTORAGECHANNELSTATUS, TAuditMode::NonModifying());
 
     #undef SETUP_KV_METHOD
 }

--- a/ydb/services/keyvalue/grpc_service.cpp
+++ b/ydb/services/keyvalue/grpc_service.cpp
@@ -4,7 +4,7 @@
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/service_keyvalue.h>
 #include <ydb/core/jaeger_tracing/request_discriminator.h>
-#include "ydb/library/grpc/server/grpc_method_setup.h"
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr::NGRpcService {
 

--- a/ydb/services/keyvalue/grpc_service.cpp
+++ b/ydb/services/keyvalue/grpc_service.cpp
@@ -27,10 +27,10 @@ void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 
     using namespace Ydb::KeyValue;
 
-    #define SETUP_KV_METHOD(methodName, method, rlMode, requestType, auditModeFlags) \
+    #define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
         SETUP_METHOD( \
             methodName, \
-            method, \
+            methodCallback, \
             rlMode, \
             requestType, \
             keyvalue, \

--- a/ydb/services/keyvalue/grpc_service.cpp
+++ b/ydb/services/keyvalue/grpc_service.cpp
@@ -9,21 +9,23 @@
 namespace NKikimr::NGRpcService {
 
 TKeyValueGRpcService::TKeyValueGRpcService(NActors::TActorSystem* actorSystem, TIntrusivePtr<NMonitoring::TDynamicCounters> counters, NActors::TActorId grpcRequestProxyId)
-    : ActorSystem(actorSystem)
-    , Counters(std::move(counters))
-    , GRpcRequestProxyId(grpcRequestProxyId)
+    : ActorSystem_(actorSystem)
+    , Counters_(std::move(counters))
+    , GRpcRequestProxyId_(grpcRequestProxyId)
 {
 }
 
 TKeyValueGRpcService::~TKeyValueGRpcService() = default;
 
 void TKeyValueGRpcService::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::TLoggerPtr logger) {
-    CQ = cq;
+    CQ_ = cq;
     SetupIncomingRequests(std::move(logger));
 }
 
 void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
-    auto getCounterBlock = NGRpcService::CreateCounterCb(Counters, ActorSystem);
+    auto getCounterBlock = NGRpcService::CreateCounterCb(Counters_, ActorSystem_);
+
+    using namespace Ydb::KeyValue;
 
     #define SETUP_KV_METHOD(methodName, method, rlMode, requestType, auditModeFlags) \
         SETUP_METHOD( \
@@ -31,7 +33,6 @@ void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             method, \
             rlMode, \
             requestType, \
-            KeyValue, \
             keyvalue, \
             auditModeFlags \
         )

--- a/ydb/services/keyvalue/grpc_service.cpp
+++ b/ydb/services/keyvalue/grpc_service.cpp
@@ -27,14 +27,14 @@ void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 
     using namespace Ydb::KeyValue;
 
-    #define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
+    #define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
         SETUP_METHOD( \
             methodName, \
             methodCallback, \
             rlMode, \
             requestType, \
             keyvalue, \
-            auditModeFlags \
+            auditMode \
         )
 
     SETUP_KV_METHOD(CreateVolume, DoCreateVolumeKeyValue, Rps, KEYVALUE_CREATEVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));

--- a/ydb/services/keyvalue/grpc_service.cpp
+++ b/ydb/services/keyvalue/grpc_service.cpp
@@ -26,15 +26,12 @@ void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     using namespace Ydb::KeyValue;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 
+#ifdef SETUP_KV_METHOD
+#error SETUP_KV_METHOD macro already defined
+#endif
+
 #define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD( \
-        methodName, \
-        methodCallback, \
-        rlMode, \
-        requestType, \
-        keyvalue, \
-        auditMode \
-    )
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, keyvalue, auditMode)
 
     SETUP_KV_METHOD(CreateVolume, DoCreateVolumeKeyValue, RLMODE(Rps), KEYVALUE_CREATEVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_KV_METHOD(DropVolume, DoDropVolumeKeyValue, RLMODE(Rps), KEYVALUE_DROPVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));

--- a/ydb/services/keyvalue/grpc_service.h
+++ b/ydb/services/keyvalue/grpc_service.h
@@ -22,11 +22,11 @@ private:
     void SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger);
 
 private:
-    NActors::TActorSystem* ActorSystem = nullptr;
-    TIntrusivePtr<NMonitoring::TDynamicCounters> Counters;
-    NActors::TActorId GRpcRequestProxyId;
+    NActors::TActorSystem* ActorSystem_ = nullptr;
+    TIntrusivePtr<NMonitoring::TDynamicCounters> Counters_;
+    NActors::TActorId GRpcRequestProxyId_;
 
-    grpc::ServerCompletionQueue* CQ = nullptr;
+    grpc::ServerCompletionQueue* CQ_ = nullptr;
 };
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/services/maintenance/grpc_service.cpp
+++ b/ydb/services/maintenance/grpc_service.cpp
@@ -25,7 +25,7 @@ void TGRpcMaintenanceService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                                         \
                     new TGrpcRequestOperationCall<Maintenance::REQUEST, Maintenance::RESPONSE>                  \
-                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, AUDIT_MODE})); \
+                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE})); \
             }, &Maintenance::V1::MaintenanceService::AsyncService::Request ## NAME,                             \
             #NAME, logger, getCounterBlock("maintenance", #NAME))->Run();
 

--- a/ydb/services/persqueue_v1/persqueue.cpp
+++ b/ydb/services/persqueue_v1/persqueue.cpp
@@ -87,33 +87,33 @@ void TGRpcPersQueueService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         #NAME, logger, getCounterBlock("persistent_queue", #NAME))->Run();
 
     ADD_REQUEST(GetReadSessionsInfo, PersQueueService, ReadInfoRequest, ReadInfoResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQReadInfoRequest(ctx, &DoPQReadInfoRequest, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::NonModifying()}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQReadInfoRequest(ctx, &DoPQReadInfoRequest, TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::NonModifying()}));
     })
 
     ADD_REQUEST(DropTopic, PersQueueService, DropTopicRequest, DropTopicResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQDropTopicRequest(ctx, &DoPQDropTopicRequest, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl)}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQDropTopicRequest(ctx, &DoPQDropTopicRequest, TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl)}));
     })
 
     ADD_REQUEST(CreateTopic, PersQueueService, CreateTopicRequest, CreateTopicResponse, {
         auto clusterCfg = ClustersCfgProvider->GetCfg();
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQCreateTopicRequest(ctx, std::bind(DoPQCreateTopicRequest, _1, _2, clusterCfg), TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl) }));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQCreateTopicRequest(ctx, std::bind(DoPQCreateTopicRequest, _1, _2, clusterCfg), TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl) }));
     })
 
     ADD_REQUEST(AlterTopic, PersQueueService, AlterTopicRequest, AlterTopicResponse, {
         auto clusterCfg = ClustersCfgProvider->GetCfg();
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQAlterTopicRequest(ctx, std::bind(DoPQAlterTopicRequest, _1, _2, clusterCfg), TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl)}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQAlterTopicRequest(ctx, std::bind(DoPQAlterTopicRequest, _1, _2, clusterCfg), TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl)}));
     })
 
     ADD_REQUEST(DescribeTopic, PersQueueService, DescribeTopicRequest, DescribeTopicResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQDescribeTopicRequest(ctx, &DoPQDescribeTopicRequest, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::NonModifying()}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQDescribeTopicRequest(ctx, &DoPQDescribeTopicRequest, TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::NonModifying()}));
     })
 
     ADD_REQUEST(AddReadRule, PersQueueService, AddReadRuleRequest, AddReadRuleResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQAddReadRuleRequest(ctx, &DoPQAddReadRuleRequest, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl)}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQAddReadRuleRequest(ctx, &DoPQAddReadRuleRequest, TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl)}));
     })
 
     ADD_REQUEST(RemoveReadRule, PersQueueService, RemoveReadRuleRequest, RemoveReadRuleResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQRemoveReadRuleRequest(ctx, &DoPQRemoveReadRuleRequest, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl)}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvPQRemoveReadRuleRequest(ctx, &DoPQRemoveReadRuleRequest, TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl)}));
     })
 
 #undef ADD_REQUEST

--- a/ydb/services/persqueue_v1/topic.cpp
+++ b/ydb/services/persqueue_v1/topic.cpp
@@ -85,7 +85,7 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                     [this](TIntrusivePtr<TStreamGRpcRequest::IContext> context) {
                         ActorSystem_->Send(GRpcRequestProxyId_, new NKikimr::NGRpcService::TEvStreamTopicWriteRequest(context,
                             TRequestAuxSettings{
-                                .RlMode = RLSWITCH(TRateLimiterMode::RuTopic),
+                                .RlMode = RLSWITCH(RuTopic),
                                 .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml),
                                 .RequestType = NJaegerTracing::ERequestType::TOPIC_STREAMWRITE,
                             }));
@@ -110,7 +110,7 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                     [this](TIntrusivePtr<TStreamGRpcRequest::IContext> context) {
                         ActorSystem_->Send(GRpcRequestProxyId_, new NKikimr::NGRpcService::TEvStreamTopicReadRequest(context,
                             TRequestAuxSettings{
-                                .RlMode = RLSWITCH(TRateLimiterMode::RuTopic),
+                                .RlMode = RLSWITCH(RuTopic),
                                 .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml),
                                 .RequestType = NJaegerTracing::ERequestType::TOPIC_STREAMREAD,
                             }));
@@ -135,7 +135,7 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                     [this](TIntrusivePtr<TStreamGRpcRequest::IContext> context) {
                         ActorSystem_->Send(GRpcRequestProxyId_, new NKikimr::NGRpcService::TEvStreamTopicDirectReadRequest(context,
                             TRequestAuxSettings{
-                                .RlMode = RLSWITCH(TRateLimiterMode::RuTopic),
+                                .RlMode = RLSWITCH(RuTopic),
                                 .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml),
                                 .RequestType = NJaegerTracing::ERequestType::TOPIC_STREAMDIRECTREAD,
                             }));
@@ -157,32 +157,32 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         #NAME, logger, getCounterBlock("topic", #NAME))->Run();
 
     ADD_REQUEST(CommitOffset, TopicService, CommitOffsetRequest, CommitOffsetResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new NGRpcService::TEvCommitOffsetRequest(ctx, &DoCommitOffsetRequest, TRequestAuxSettings{.RlMode = RLSWITCH(TRateLimiterMode::Rps), .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml), .RequestType =  NJaegerTracing::ERequestType::TOPIC_COMMITOFFSET}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new NGRpcService::TEvCommitOffsetRequest(ctx, &DoCommitOffsetRequest, TRequestAuxSettings{.RlMode = RLSWITCH(Rps), .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml), .RequestType =  NJaegerTracing::ERequestType::TOPIC_COMMITOFFSET}));
     })
 
     ADD_REQUEST(DropTopic, TopicService, DropTopicRequest, DropTopicResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvDropTopicRequest(ctx, &DoDropTopicRequest, TRequestAuxSettings{.RlMode = RLSWITCH(TRateLimiterMode::Rps), .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), .RequestType = NJaegerTracing::ERequestType::TOPIC_DROPTOPIC}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvDropTopicRequest(ctx, &DoDropTopicRequest, TRequestAuxSettings{.RlMode = RLSWITCH(Rps), .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), .RequestType = NJaegerTracing::ERequestType::TOPIC_DROPTOPIC}));
     })
 
     ADD_REQUEST(CreateTopic, TopicService, CreateTopicRequest, CreateTopicResponse, {
         auto clusterCfg = ClustersCfgProvider->GetCfg();
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvCreateTopicRequest(ctx, std::bind(DoCreateTopicRequest, _1, _2, clusterCfg), TRequestAuxSettings{.RlMode = RLSWITCH(TRateLimiterMode::Rps), .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), .RequestType = NJaegerTracing::ERequestType::TOPIC_CREATETOPIC}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvCreateTopicRequest(ctx, std::bind(DoCreateTopicRequest, _1, _2, clusterCfg), TRequestAuxSettings{.RlMode = RLSWITCH(Rps), .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), .RequestType = NJaegerTracing::ERequestType::TOPIC_CREATETOPIC}));
     })
 
     ADD_REQUEST(AlterTopic, TopicService, AlterTopicRequest, AlterTopicResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvAlterTopicRequest(ctx, &DoAlterTopicRequest, TRequestAuxSettings{.RlMode = RLSWITCH(TRateLimiterMode::Rps), .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), .RequestType = NJaegerTracing::ERequestType::TOPIC_ALTERTOPIC}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvAlterTopicRequest(ctx, &DoAlterTopicRequest, TRequestAuxSettings{.RlMode = RLSWITCH(Rps), .AuditMode = TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), .RequestType = NJaegerTracing::ERequestType::TOPIC_ALTERTOPIC}));
     })
 
     ADD_REQUEST(DescribeTopic, TopicService, DescribeTopicRequest, DescribeTopicResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvDescribeTopicRequest(ctx, &DoDescribeTopicRequest, TRequestAuxSettings{.RlMode = RLSWITCH(TRateLimiterMode::Rps), .AuditMode = TAuditMode::NonModifying(), .RequestType = NJaegerTracing::ERequestType::TOPIC_DESCRIBETOPIC}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvDescribeTopicRequest(ctx, &DoDescribeTopicRequest, TRequestAuxSettings{.RlMode = RLSWITCH(Rps), .AuditMode = TAuditMode::NonModifying(), .RequestType = NJaegerTracing::ERequestType::TOPIC_DESCRIBETOPIC}));
     })
 
     ADD_REQUEST(DescribeConsumer, TopicService, DescribeConsumerRequest, DescribeConsumerResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvDescribeConsumerRequest(ctx, &DoDescribeConsumerRequest, TRequestAuxSettings{.RlMode = RLSWITCH(TRateLimiterMode::Rps), .AuditMode = TAuditMode::NonModifying(), .RequestType = NJaegerTracing::ERequestType::TOPIC_DESCRIBECONSUMER}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvDescribeConsumerRequest(ctx, &DoDescribeConsumerRequest, TRequestAuxSettings{.RlMode = RLSWITCH(Rps), .AuditMode = TAuditMode::NonModifying(), .RequestType = NJaegerTracing::ERequestType::TOPIC_DESCRIBECONSUMER}));
     })
 
     ADD_REQUEST(DescribePartition, TopicService, DescribePartitionRequest, DescribePartitionResponse, {
-        ActorSystem_->Send(GRpcRequestProxyId_, new TEvDescribePartitionRequest(ctx, &DoDescribePartitionRequest, TRequestAuxSettings{.RlMode = RLSWITCH(TRateLimiterMode::Rps), .CustomAttributeProcessor = YdsProcessAttr, .AuditMode = TAuditMode::NonModifying(), .RequestType = NJaegerTracing::ERequestType::TOPIC_DESCRIBEPARTITION}));
+        ActorSystem_->Send(GRpcRequestProxyId_, new TEvDescribePartitionRequest(ctx, &DoDescribePartitionRequest, TRequestAuxSettings{.RlMode = RLSWITCH(Rps), .CustomAttributeProcessor = YdsProcessAttr, .AuditMode = TAuditMode::NonModifying(), .RequestType = NJaegerTracing::ERequestType::TOPIC_DESCRIBEPARTITION}));
     })
 #undef ADD_REQUEST
 

--- a/ydb/services/rate_limiter/grpc_service.cpp
+++ b/ydb/services/rate_limiter/grpc_service.cpp
@@ -30,8 +30,8 @@ void TRateLimiterGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
     using namespace Ydb::RateLimiter;
     using namespace NGRpcService;
 
-    #define SETUP_RL_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
-        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditModeFlags)
+    #define SETUP_RL_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditMode)
 
     SETUP_RL_METHOD(CreateResource, DoCreateRateLimiterResource, Rps, RATELIMITER_CREATE_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_RL_METHOD(AlterResource, DoAlterRateLimiterResource, Rps, RATELIMITER_ALTER_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));

--- a/ydb/services/rate_limiter/grpc_service.cpp
+++ b/ydb/services/rate_limiter/grpc_service.cpp
@@ -25,13 +25,12 @@ void TRateLimiterGRpcService::InitService(grpc::ServerCompletionQueue* cq, NYdbG
 }
 
 void TRateLimiterGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
-    auto getCounterBlock = NGRpcService::CreateCounterCb(Counters_, ActorSystem_);
-
     using namespace Ydb::RateLimiter;
     using namespace NGRpcService;
+    auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 
-    #define SETUP_RL_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditMode)
+#define SETUP_RL_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditMode)
 
     SETUP_RL_METHOD(CreateResource, DoCreateRateLimiterResource, RLMODE(Rps), RATELIMITER_CREATE_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_RL_METHOD(AlterResource, DoAlterRateLimiterResource, RLMODE(Rps), RATELIMITER_ALTER_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
@@ -40,7 +39,7 @@ void TRateLimiterGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
     SETUP_RL_METHOD(DescribeResource, DoDescribeRateLimiterResource, RLMODE(Rps), RATELIMITER_DESCRIBE_RESOURCE, TAuditMode::NonModifying());
     SETUP_RL_METHOD(AcquireResource, DoAcquireRateLimiterResource, RLMODE(Off), RATELIMITER_ACQUIRE_RESOURCE, TAuditMode::NonModifying());
 
-    #undef SETUP_RL_METHOD
+#undef SETUP_RL_METHOD
 }
 
 } // namespace NKikimr::NQuoter

--- a/ydb/services/rate_limiter/grpc_service.cpp
+++ b/ydb/services/rate_limiter/grpc_service.cpp
@@ -33,12 +33,12 @@ void TRateLimiterGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
     #define SETUP_RL_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
         SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditMode)
 
-    SETUP_RL_METHOD(CreateResource, DoCreateRateLimiterResource, Rps, RATELIMITER_CREATE_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-    SETUP_RL_METHOD(AlterResource, DoAlterRateLimiterResource, Rps, RATELIMITER_ALTER_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-    SETUP_RL_METHOD(DropResource, DoDropRateLimiterResource, Rps, RATELIMITER_DROP_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-    SETUP_RL_METHOD(ListResources, DoListRateLimiterResources, Rps, RATELIMITER_LIST_RESOURCES, TAuditMode::NonModifying());
-    SETUP_RL_METHOD(DescribeResource, DoDescribeRateLimiterResource, Rps, RATELIMITER_DESCRIBE_RESOURCE, TAuditMode::NonModifying());
-    SETUP_RL_METHOD(AcquireResource, DoAcquireRateLimiterResource, Off, RATELIMITER_ACQUIRE_RESOURCE, TAuditMode::NonModifying());
+    SETUP_RL_METHOD(CreateResource, DoCreateRateLimiterResource, RLMODE(Rps), RATELIMITER_CREATE_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_RL_METHOD(AlterResource, DoAlterRateLimiterResource, RLMODE(Rps), RATELIMITER_ALTER_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_RL_METHOD(DropResource, DoDropRateLimiterResource, RLMODE(Rps), RATELIMITER_DROP_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_RL_METHOD(ListResources, DoListRateLimiterResources, RLMODE(Rps), RATELIMITER_LIST_RESOURCES, TAuditMode::NonModifying());
+    SETUP_RL_METHOD(DescribeResource, DoDescribeRateLimiterResource, RLMODE(Rps), RATELIMITER_DESCRIBE_RESOURCE, TAuditMode::NonModifying());
+    SETUP_RL_METHOD(AcquireResource, DoAcquireRateLimiterResource, RLMODE(Off), RATELIMITER_ACQUIRE_RESOURCE, TAuditMode::NonModifying());
 
     #undef SETUP_RL_METHOD
 }

--- a/ydb/services/rate_limiter/grpc_service.cpp
+++ b/ydb/services/rate_limiter/grpc_service.cpp
@@ -3,7 +3,7 @@
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/service_ratelimiter.h>
-#include "ydb/library/grpc/server/grpc_method_setup.h"
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr::NQuoter {
 

--- a/ydb/services/rate_limiter/grpc_service.cpp
+++ b/ydb/services/rate_limiter/grpc_service.cpp
@@ -29,6 +29,10 @@ void TRateLimiterGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
     using namespace NGRpcService;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 
+#ifdef SETUP_RL_METHOD
+#error SETUP_RL_METHOD macro already defined
+#endif
+
 #define SETUP_RL_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
     SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditMode)
 

--- a/ydb/services/rate_limiter/grpc_service.cpp
+++ b/ydb/services/rate_limiter/grpc_service.cpp
@@ -30,8 +30,8 @@ void TRateLimiterGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
     using namespace Ydb::RateLimiter;
     using namespace NGRpcService;
 
-    #define SETUP_RL_METHOD(methodName, method, rlMode, requestType, auditModeFlags) \
-        SETUP_METHOD(methodName, method, rlMode, requestType, rate_limiter, auditModeFlags)
+    #define SETUP_RL_METHOD(methodName, methodCallback, rlMode, requestType, auditModeFlags) \
+        SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditModeFlags)
 
     SETUP_RL_METHOD(CreateResource, DoCreateRateLimiterResource, Rps, RATELIMITER_CREATE_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_RL_METHOD(AlterResource, DoAlterRateLimiterResource, Rps, RATELIMITER_ALTER_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));

--- a/ydb/services/rate_limiter/grpc_service.h
+++ b/ydb/services/rate_limiter/grpc_service.h
@@ -20,11 +20,11 @@ private:
     void SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger);
 
 private:
-    NActors::TActorSystem* ActorSystem = nullptr;
-    TIntrusivePtr<::NMonitoring::TDynamicCounters> Counters;
-    NActors::TActorId GRpcRequestProxyId;
+    NActors::TActorSystem* ActorSystem_ = nullptr;
+    TIntrusivePtr<::NMonitoring::TDynamicCounters> Counters_;
+    NActors::TActorId GRpcRequestProxyId_;
 
-    grpc::ServerCompletionQueue* CQ = nullptr;
+    grpc::ServerCompletionQueue* CQ_ = nullptr;
 };
 
 } // namespace NKikimr::NQuoter

--- a/ydb/services/replication/grpc_service.cpp
+++ b/ydb/services/replication/grpc_service.cpp
@@ -25,7 +25,7 @@ void TGRpcReplicationService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                      \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                               \
                     new TGrpcRequestOperationCall<Replication::REQUEST, Replication::RESPONSE>        \
-                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr}));   \
+                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr}));   \
             }, &Replication::V1::ReplicationService::AsyncService::Request ## NAME,                   \
             #NAME, logger, getCounterBlock("replication", #NAME))->Run();
 

--- a/ydb/services/tablet/ydb_tablet.cpp
+++ b/ydb/services/tablet/ydb_tablet.cpp
@@ -36,7 +36,7 @@ void TGRpcYdbTabletService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                         ActorSystem_->Send(proxy,                                                                       \
                             new TGrpcRequestNoOperationCall<Ydb::Tablet::NAME##Request, Ydb::Tablet::NAME##Response>    \
                                 (ctx, &CB, TRequestAuxSettings {                                                        \
-                                    .RlMode = RLSWITCH(TRateLimiterMode::LIMIT_TYPE),                                   \
+                                    .RlMode = RLSWITCH(LIMIT_TYPE),                                   \
                                     .AuditMode = AUDIT_MODE,                                                            \
                                 }));                                                                                    \
                     }, &Ydb::Tablet::V1::TabletService::AsyncService::Request ## NAME,                                  \

--- a/ydb/services/view/grpc_service.cpp
+++ b/ydb/services/view/grpc_service.cpp
@@ -22,7 +22,7 @@ void TGRpcViewService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 new TGrpcRequestOperationCall<DescribeViewRequest,
                                               DescribeViewResponse>(
                     ctx, &DoDescribeView,
-                    TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr}
+                    TRequestAuxSettings{RLSWITCH(Rps), nullptr}
                 )
             );
         },

--- a/ydb/services/ydb/ydb_clickhouse_internal.cpp
+++ b/ydb/services/ydb/ydb_clickhouse_internal.cpp
@@ -39,7 +39,7 @@ void TGRpcYdbClickhouseInternalService::SetupIncomingRequests(NYdbGrpc::TLoggerP
             NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer()); \
             ActorSystem_->Send(GRpcRequestProxyId_, \
                 new NGRpcService::TGrpcRequestOperationCall<Ydb::ClickhouseInternal::IN, Ydb::ClickhouseInternal::OUT> \
-                    (ctx, &CB, NGRpcService::TRequestAuxSettings{RLSWITCH(NGRpcService::TRateLimiterMode::Rps), nullptr, AUDIT_MODE})); \
+                    (ctx, &CB, NGRpcService::TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE})); \
         }, &Ydb::ClickhouseInternal::V1::ClickhouseInternalService::AsyncService::Request ## NAME, \
         #NAME, logger, getCounterBlock("clickhouse_internal", #NAME), \
         GET_LIMITER_BY_PATH(GRpcControls.RequestConfigs.ClickhouseInternal_##NAME.MaxInFlight))->Run();

--- a/ydb/services/ydb/ydb_debug.cpp
+++ b/ydb/services/ydb/ydb_debug.cpp
@@ -59,7 +59,7 @@ void TGRpcYdbDebugService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                     ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()], \
                         new TGrpcRequestNoOperationCall<IN, OUT> \
                             (ctx, &CB, TRequestAuxSettings { \
-                                .RlMode = RLSWITCH(TRateLimiterMode::Rps), \
+                                .RlMode = RLSWITCH(Rps), \
                                 .AuditMode = AUDIT_MODE, \
                                 .RequestType = NJaegerTracing::ERequestType::PING_##REQUEST_TYPE, \
                             })); \

--- a/ydb/services/ydb/ydb_operation.cpp
+++ b/ydb/services/ydb/ydb_operation.cpp
@@ -22,7 +22,7 @@ void TGRpcOperationService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                                         \
                     new TCALL<Operations::NAME##Request, Operations::NAME##Response>                            \
-                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, AUDIT_MODE})); \
+                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE})); \
             }, &Operation::V1::OperationService::AsyncService::Request ## NAME,                                 \
             #NAME, logger, getCounterBlock("operation", #NAME))->Run();
 

--- a/ydb/services/ydb/ydb_query.cpp
+++ b/ydb/services/ydb/ydb_query.cpp
@@ -46,7 +46,7 @@ void TGRpcYdbQueryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                     ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()], \
                         new TGrpcRequestNoOperationCall<IN, OUT> \
                             (ctx, &CB, TRequestAuxSettings { \
-                                .RlMode = RLSWITCH(TRateLimiterMode::Rps), \
+                                .RlMode = RLSWITCH(Rps), \
                                 .AuditMode = AUDIT_MODE, \
                                 .RequestType = NJaegerTracing::ERequestType::QUERY_##REQUEST_TYPE, \
                             })); \

--- a/ydb/services/ydb/ydb_scheme.cpp
+++ b/ydb/services/ydb/ydb_scheme.cpp
@@ -21,7 +21,7 @@ void TGRpcYdbSchemeService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                 \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                                          \
                     new TGrpcRequestOperationCall<Ydb::Scheme::NAME##Request, Ydb::Scheme::NAME##Response>       \
-                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, AUDIT_MODE}));  \
+                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE}));  \
             }, &Ydb::Scheme::V1::SchemeService::AsyncService::Request ## NAME,                                   \
             #NAME, logger, getCounterBlock("scheme", #NAME))->Run();
 

--- a/ydb/services/ydb/ydb_scripting.cpp
+++ b/ydb/services/ydb/ydb_scripting.cpp
@@ -31,19 +31,19 @@ void TGRpcYdbScriptingService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger
     ADD_REQUEST(ExecuteYql, ExecuteYqlRequest, ExecuteYqlResponse, {
         ActorSystem_->Send(GRpcRequestProxyId_,
             new TGrpcRequestOperationCall<ExecuteYqlRequest, ExecuteYqlResponse>
-                (ctx, &DoExecuteYqlScript, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Ru), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml)}));
+                (ctx, &DoExecuteYqlScript, TRequestAuxSettings{RLSWITCH(Ru), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml)}));
     })
 
     ADD_REQUEST(StreamExecuteYql, ExecuteYqlRequest, ExecuteYqlPartialResponse, {
         ActorSystem_->Send(GRpcRequestProxyId_,
             new TGrpcRequestNoOperationCall<ExecuteYqlRequest, ExecuteYqlPartialResponse>
-                (ctx, &DoStreamExecuteYqlScript, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml)}));
+                (ctx, &DoStreamExecuteYqlScript, TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml)}));
     })
 
     ADD_REQUEST(ExplainYql, ExplainYqlRequest, ExplainYqlResponse, {
         ActorSystem_->Send(GRpcRequestProxyId_,
             new TGrpcRequestOperationCall<ExplainYqlRequest, ExplainYqlResponse>
-                (ctx, &DoExplainYqlScript, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::Rps), nullptr, TAuditMode::NonModifying()}));
+                (ctx, &DoExplainYqlScript, TRequestAuxSettings{RLSWITCH(Rps), nullptr, TAuditMode::NonModifying()}));
     })
 #undef ADD_REQUEST
 }

--- a/ydb/services/ydb/ydb_table.cpp
+++ b/ydb/services/ydb/ydb_table.cpp
@@ -61,7 +61,7 @@ void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                         ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()],                          \
                             new TGrpcRequestOperationCall<Ydb::Table::NAME##Request, Ydb::Table::NAME##Response>      \
                                 (ctx, &CB, TRequestAuxSettings {                                                      \
-                                    .RlMode = RLSWITCH(TRateLimiterMode::LIMIT_TYPE),                                 \
+                                    .RlMode = RLSWITCH(LIMIT_TYPE),                                 \
                                     .AuditMode = AUDIT_MODE,                                                          \
                                     .RequestType = NJaegerTracing::ERequestType::TABLE_##REQUEST_TYPE,                \
                                 }));                                                                                  \
@@ -87,7 +87,7 @@ void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                         ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()],                                            \
                             new TGrpcRequestNoOperationCall<Ydb::Table::IN, Ydb::Table::OUT>                                            \
                                 (ctx, &CB, TRequestAuxSettings {                                                                        \
-                                    .RlMode = RLSWITCH(TRateLimiterMode::LIMIT_TYPE),                                                   \
+                                    .RlMode = RLSWITCH(LIMIT_TYPE),                                                   \
                                     .AuditMode = AUDIT_MODE,                                                                            \
                                     .RequestType = NJaegerTracing::ERequestType::TABLE_##REQUEST_TYPE,                                  \
                                 }));                                                                                                    \

--- a/ydb/services/ymq/grpc_service.cpp
+++ b/ydb/services/ymq/grpc_service.cpp
@@ -28,7 +28,7 @@ void TGRpcYmqService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
                 NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                                    \
                 ActorSystem_->Send(GRpcRequestProxyId_,                                                                             \
                     new TGrpcRequestOperationCall<Ydb::Ymq::V1::NAME##Request, Ydb::Ymq::V1::NAME##Response>        \
-                        (ctx, CB, TRequestAuxSettings{RLSWITCH(TRateLimiterMode::LIMIT_TYPE), ATTR}));                              \
+                        (ctx, CB, TRequestAuxSettings{RLSWITCH(LIMIT_TYPE), ATTR}));                              \
             }, &Ydb::Ymq::V1::YmqService::AsyncService::RequestYmq ## NAME,                                            \
             #NAME, logger, getCounterBlock("ymq", #NAME))->Run();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Refactor common macros for registration of YDB grpc methods in order to use them in YDB services. It allows to use standard code for all services and not to miss all the settings (like audit settings, rate limiter and tracing).
