### PR TITLE
EXT-1333 Refactor DynamicConfig service using standard macro

### DIFF
--- a/ydb/services/dynamic_config/grpc_service.cpp
+++ b/ydb/services/dynamic_config/grpc_service.cpp
@@ -3,42 +3,36 @@
 #include <ydb/core/grpc_services/service_dynamic_config.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/base/base.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr {
 namespace NGRpcService {
 
 void TGRpcDynamicConfigService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+    using namespace Ydb::DynamicConfig;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
-    using namespace Ydb;
 
-#ifdef ADD_REQUEST
-#error ADD_REQUEST macro already defined
+#ifdef SETUP_CFG_METHOD
+#error SETUP_CFG_METHOD macro already defined
 #endif
-#define ADD_REQUEST(NAME, CB, AUDIT_MODE)                                                                               \
-    MakeIntrusive<TGRpcRequest<DynamicConfig::NAME##Request, DynamicConfig::NAME##Response, TGRpcDynamicConfigService>> \
-        (this, &Service_, CQ_,                                                                                          \
-            [this](NYdbGrpc::IRequestContextBase *ctx) {                                                                \
-                NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                        \
-                ActorSystem_->Send(GRpcRequestProxyId_,                                                                 \
-                    new TGrpcRequestOperationCall<DynamicConfig::NAME##Request, DynamicConfig::NAME##Response>          \
-                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE}));         \
-            }, &DynamicConfig::V1::DynamicConfigService::AsyncService::Request ## NAME,                                 \
-            #NAME, logger, getCounterBlock("console", #NAME))->Run();
 
-    ADD_REQUEST(SetConfig, DoSetConfigRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin))
-    ADD_REQUEST(ReplaceConfig, DoReplaceConfigRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin))
-    ADD_REQUEST(DropConfig, DoDropConfigRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin))
-    ADD_REQUEST(AddVolatileConfig, DoAddVolatileConfigRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin))
-    ADD_REQUEST(RemoveVolatileConfig, DoRemoveVolatileConfigRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin))
-    ADD_REQUEST(GetConfig, DoGetConfigRequest, TAuditMode::NonModifying())
-    ADD_REQUEST(GetMetadata, DoGetMetadataRequest, TAuditMode::NonModifying())
-    ADD_REQUEST(GetNodeLabels, DoGetNodeLabelsRequest, TAuditMode::NonModifying())
-    ADD_REQUEST(ResolveConfig, DoResolveConfigRequest, TAuditMode::NonModifying())
-    ADD_REQUEST(ResolveAllConfig, DoResolveAllConfigRequest, TAuditMode::NonModifying())
-    ADD_REQUEST(FetchStartupConfig, DoFetchStartupConfigRequest, TAuditMode::NonModifying())
-    ADD_REQUEST(GetConfigurationVersion, DoGetConfigurationVersionRequest, TAuditMode::NonModifying())
+#define SETUP_CFG_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, console, auditMode)
 
-#undef ADD_REQUEST
+    SETUP_CFG_METHOD(SetConfig, DoSetConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_CFG_METHOD(ReplaceConfig, DoReplaceConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_CFG_METHOD(DropConfig, DoDropConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_CFG_METHOD(AddVolatileConfig, DoAddVolatileConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_CFG_METHOD(RemoveVolatileConfig, DoRemoveVolatileConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_CFG_METHOD(GetConfig, DoGetConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CFG_METHOD(GetMetadata, DoGetMetadataRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CFG_METHOD(GetNodeLabels, DoGetNodeLabelsRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CFG_METHOD(ResolveConfig, DoResolveConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CFG_METHOD(ResolveAllConfig, DoResolveAllConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CFG_METHOD(FetchStartupConfig, DoFetchStartupConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CFG_METHOD(GetConfigurationVersion, DoGetConfigurationVersionRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+
+#undef SETUP_CFG_METHOD
 }
 
 } // namespace NGRpcService


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h