### PR TITLE
EXT-1333 Refactor Discovery service using standard macro

### DIFF
--- a/ydb/services/local_discovery/grpc_func_call.h
+++ b/ydb/services/local_discovery/grpc_func_call.h
@@ -8,22 +8,22 @@ namespace NGRpcService {
 
 using TFuncCallback = std::function<void(std::unique_ptr<IRequestOpCtx>, const IFacilityProvider&)>;
 
-template <typename TReq, typename TResp>
+template <typename TReq, typename TResp, NRuntimeEvents::EType RuntimeEventType = NRuntimeEvents::EType::COMMON>
 class TGrpcRequestFunctionCall
     : public std::conditional_t<TProtoHasValidate<TReq>::Value,
             TGRpcRequestValidationWrapperImpl<
-                TRpcServices::EvGrpcRuntimeRequest, TReq, TResp, true, TGrpcRequestFunctionCall<TReq, TResp>>,
+                TRpcServices::EvGrpcRuntimeRequest, TReq, TResp, true, TGrpcRequestFunctionCall<TReq, TResp, RuntimeEventType>, RuntimeEventType>,
             TGRpcRequestWrapperImpl<
-                TRpcServices::EvGrpcRuntimeRequest, TReq, TResp, true, TGrpcRequestFunctionCall<TReq, TResp>>>
+                TRpcServices::EvGrpcRuntimeRequest, TReq, TResp, true, TGrpcRequestFunctionCall<TReq, TResp, RuntimeEventType>, RuntimeEventType>>
     {
 public:
     static constexpr bool IsOp = true;
     static IActor* CreateRpcActor(IRequestOpCtx* msg);
     using TBase = std::conditional_t<TProtoHasValidate<TReq>::Value,
             TGRpcRequestValidationWrapperImpl<
-                TRpcServices::EvGrpcRuntimeRequest, TReq, TResp, true, TGrpcRequestFunctionCall<TReq, TResp>>,
+                TRpcServices::EvGrpcRuntimeRequest, TReq, TResp, true, TGrpcRequestFunctionCall<TReq, TResp, RuntimeEventType>, RuntimeEventType>,
             TGRpcRequestWrapperImpl<
-                TRpcServices::EvGrpcRuntimeRequest, TReq, TResp, true, TGrpcRequestFunctionCall<TReq, TResp>>>;
+                TRpcServices::EvGrpcRuntimeRequest, TReq, TResp, true, TGrpcRequestFunctionCall<TReq, TResp, RuntimeEventType>, RuntimeEventType>>;
 
     TGrpcRequestFunctionCall(NYdbGrpc::IRequestContextBase* ctx,
         TFuncCallback cb, TRequestAuxSettings auxSettings = {})


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h