### PR TITLE
EXT-1333 Refactor ClickhouseInternal service using standard macro

### DIFF
--- a/ydb/services/ydb/ydb_clickhouse_internal.cpp
+++ b/ydb/services/ydb/ydb_clickhouse_internal.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/grpc_services/service_chinternal.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/base/base.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr {
 namespace NGRpcService {
@@ -18,39 +19,47 @@ TGRpcYdbClickhouseInternalService::TGRpcYdbClickhouseInternalService(NActors::TA
 {}
 
 void TGRpcYdbClickhouseInternalService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+    using namespace Ydb::ClickhouseInternal;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
     auto getLimiter = CreateLimiterCb(LimiterRegistry_);
     auto& icb = *ActorSystem_->AppData<TAppData>()->Icb;
 
-#ifdef ADD_REQUEST
-#error ADD_REQUEST macro already defined
+#ifdef SETUP_CH_METHOD
+#error SETUP_CH_METHOD macro already defined
 #endif
 
 #ifdef GET_LIMITER_BY_PATH
 #error GET_LIMITER_BY_PATH macro already defined
 #endif
 
-#define GET_LIMITER_BY_PATH(ICB_PATH)\
+#define GET_LIMITER_BY_PATH(ICB_PATH) \
     getLimiter(#ICB_PATH, icb.ICB_PATH, DEFAULT_MAX_IN_FLIGHT)
 
-#define ADD_REQUEST(NAME, IN, OUT, CB, AUDIT_MODE) \
-    MakeIntrusive<TGRpcRequest<Ydb::ClickhouseInternal::IN, Ydb::ClickhouseInternal::OUT, TGRpcYdbClickhouseInternalService>>(this, &Service_, CQ_, \
-        [this](NYdbGrpc::IRequestContextBase *ctx) { \
-            NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer()); \
-            ActorSystem_->Send(GRpcRequestProxyId_, \
-                new NGRpcService::TGrpcRequestOperationCall<Ydb::ClickhouseInternal::IN, Ydb::ClickhouseInternal::OUT> \
-                    (ctx, &CB, NGRpcService::TRequestAuxSettings{RLSWITCH(Rps), nullptr, AUDIT_MODE})); \
-        }, &Ydb::ClickhouseInternal::V1::ClickhouseInternalService::AsyncService::Request ## NAME, \
-        #NAME, logger, getCounterBlock("clickhouse_internal", #NAME), \
-        GET_LIMITER_BY_PATH(GRpcControls.RequestConfigs.ClickhouseInternal_##NAME.MaxInFlight))->Run();
+#define SETUP_CH_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_RUNTIME_EVENT_METHOD(methodName,                                          \
+        YDB_API_DEFAULT_REQUEST_TYPE(methodName),                                   \
+        YDB_API_DEFAULT_RESPONSE_TYPE(methodName),                                  \
+        methodCallback,                                                             \
+        rlMode,                                                                     \
+        requestType,                                                                \
+        YDB_API_DEFAULT_COUNTER_BLOCK(clickhouse_internal, methodName),             \
+        auditMode,                                                                  \
+        COMMON,                                                                     \
+        ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                         \
+        GRpcRequestProxyId_,                                                        \
+        CQ_,                                                                        \
+        GET_LIMITER_BY_PATH(GRpcControls.RequestConfigs.ClickhouseInternal_##methodName.MaxInFlight), \
+        nullptr)
 
-    ADD_REQUEST(Scan, ScanRequest, ScanResponse, DoReadColumnsRequest, TAuditMode::NonModifying());
-    ADD_REQUEST(GetShardLocations, GetShardLocationsRequest, GetShardLocationsResponse, DoGetShardLocationsRequest, TAuditMode::NonModifying());
-    ADD_REQUEST(DescribeTable, DescribeTableRequest, DescribeTableResponse, DoKikhouseDescribeTableRequest, TAuditMode::NonModifying());
-    ADD_REQUEST(CreateSnapshot, CreateSnapshotRequest, CreateSnapshotResponse, DoKikhouseCreateSnapshotRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-    ADD_REQUEST(RefreshSnapshot, RefreshSnapshotRequest, RefreshSnapshotResponse, DoKikhouseRefreshSnapshotRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-    ADD_REQUEST(DiscardSnapshot, DiscardSnapshotRequest, DiscardSnapshotResponse, DoKikhouseDiscardSnapshotRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
-#undef ADD_REQUEST
+    SETUP_CH_METHOD(Scan, DoReadColumnsRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CH_METHOD(GetShardLocations, DoGetShardLocationsRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CH_METHOD(DescribeTable, DoKikhouseDescribeTableRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_CH_METHOD(CreateSnapshot, DoKikhouseCreateSnapshotRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_CH_METHOD(RefreshSnapshot, DoKikhouseRefreshSnapshotRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_CH_METHOD(DiscardSnapshot, DoKikhouseDiscardSnapshotRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+
+#undef GET_LIMITER_BY_PATH
+#undef SETUP_CH_METHOD
 }
 
 } // namespace NGRpcService


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h