### PR TITLE
EXT-1333 Refactor LogStore service using standard macro

### DIFF
--- a/ydb/services/ydb/ydb_logstore.cpp
+++ b/ydb/services/ydb/ydb_logstore.cpp
@@ -2,39 +2,33 @@
 
 #include <ydb/core/grpc_services/service_logstore.h>
 #include <ydb/core/grpc_services/base/base.h>
-
 #include <ydb/core/grpc_services/grpc_helper.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr::NGRpcService {
 
 void TGRpcYdbLogStoreService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
-    using namespace Ydb;
+    using namespace Ydb::LogStore;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 
-#ifdef ADD_REQUEST
-#error ADD_REQUEST macro already defined
+#ifdef SETUP_LOGSTORE_METHOD
+#error SETUP_LOGSTORE_METHOD macro already defined
 #endif
-#define ADD_REQUEST(NAME, CB, AUDIT_MODE)                                                                   \
-    MakeIntrusive<TGRpcRequest<LogStore::NAME##Request, LogStore::NAME##Response, TGRpcYdbLogStoreService>> \
-        (this, &Service_, CQ_, [this](NYdbGrpc::IRequestContextBase *ctx) {                                 \
-            NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                \
-            ActorSystem_->Send(GRpcRequestProxyId_,                                                         \
-                new TGrpcRequestOperationCall<LogStore::NAME##Request, LogStore::NAME##Response>            \
-                    (ctx, &CB, TRequestAuxSettings{.AuditMode = AUDIT_MODE}));                              \
-        }, &Ydb::LogStore::V1::LogStoreService::AsyncService::Request ## NAME,                              \
-        #NAME, logger, getCounterBlock("logstore", #NAME))->Run();
 
-    ADD_REQUEST(CreateLogStore, DoCreateLogStoreRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST(DescribeLogStore, DoDescribeLogStoreRequest, TAuditMode::NonModifying())
-    ADD_REQUEST(DropLogStore, DoDropLogStoreRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST(AlterLogStore, DoAlterLogStoreRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
+#define SETUP_LOGSTORE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, logstore, auditMode)
 
-    ADD_REQUEST(CreateLogTable, DoCreateLogTableRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST(DescribeLogTable, DoDescribeLogTableRequest, TAuditMode::NonModifying())
-    ADD_REQUEST(DropLogTable, DoDropLogTableRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST(AlterLogTable, DoAlterLogTableRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
+    SETUP_LOGSTORE_METHOD(CreateLogStore, DoCreateLogStoreRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_LOGSTORE_METHOD(DescribeLogStore, DoDescribeLogStoreRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_LOGSTORE_METHOD(DropLogStore, DoDropLogStoreRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_LOGSTORE_METHOD(AlterLogStore, DoAlterLogStoreRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
 
-#undef ADD_REQUEST
+    SETUP_LOGSTORE_METHOD(CreateLogTable, DoCreateLogTableRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_LOGSTORE_METHOD(DescribeLogTable, DoDescribeLogTableRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_LOGSTORE_METHOD(DropLogTable, DoDropLogTableRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_LOGSTORE_METHOD(AlterLogTable, DoAlterLogTableRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+
+#undef SETUP_LOGSTORE_METHOD
 }
 
 }


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h