### PR TITLE
EXT-1333 Refactor Query/Table services using standard macro

### DIFF
--- a/ydb/services/ydb/ydb_query.cpp
+++ b/ydb/services/ydb/ydb_query.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/grpc_services/counters/counters.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/query/service_query.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr::NGRpcService {
 
@@ -30,43 +31,47 @@ TGRpcYdbQueryService::TGRpcYdbQueryService(NActors::TActorSystem *system,
 void TGRpcYdbQueryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     using namespace Ydb::Query;
     using namespace NQuery;
-
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
     size_t proxyCounter = 0;
 
-#ifdef ADD_REQUEST
-#error ADD_REQUEST macro already defined
+#ifdef SETUP_QUERY_METHOD
+#error SETUP_QUERY_METHOD macro already defined
 #endif
-#define ADD_REQUEST(NAME, IN, OUT, CB, REQUEST_TYPE, AUDIT_MODE) \
-    for (size_t i = 0; i < HandlersPerCompletionQueue; ++i) {  \
-        for (auto* cq: CQS) { \
-            MakeIntrusive<TGRpcRequest<IN, OUT, TGRpcYdbQueryService>>(this, &Service_, cq, \
-                [this, proxyCounter](NYdbGrpc::IRequestContextBase* ctx) { \
-                    NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer()); \
-                    ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()], \
-                        new TGrpcRequestNoOperationCall<IN, OUT> \
-                            (ctx, &CB, TRequestAuxSettings { \
-                                .RlMode = RLSWITCH(Rps), \
-                                .AuditMode = AUDIT_MODE, \
-                                .RequestType = NJaegerTracing::ERequestType::QUERY_##REQUEST_TYPE, \
-                            })); \
-                }, &Ydb::Query::V1::QueryService::AsyncService::Request ## NAME, \
-                #NAME, logger, getCounterBlock("query", #NAME))->Run(); \
-            ++proxyCounter; \
-        }  \
+
+#define SETUP_QUERY_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, auditMode) \
+    for (size_t i = 0; i < HandlersPerCompletionQueue; ++i) {                          \
+        for (auto* cq: CQS) {                                                          \
+            SETUP_RUNTIME_EVENT_METHOD(                                                \
+                methodName,                                                            \
+                inputType,                                                             \
+                outputType,                                                            \
+                methodCallback,                                                        \
+                rlMode,                                                                \
+                requestType,                                                           \
+                YDB_API_DEFAULT_COUNTER_BLOCK(query, methodName),                      \
+                auditMode,                                                             \
+                COMMON,                                                                \
+                ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                  \
+                GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \
+                cq,                                                                    \
+                nullptr,                                                               \
+                nullptr                                                                \
+            );                                                                         \
+            ++proxyCounter;                                                            \
+        }                                                                              \
     }
 
-    ADD_REQUEST(ExecuteQuery, ExecuteQueryRequest, ExecuteQueryResponsePart, DoExecuteQuery, EXECUTEQUERY, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
-    ADD_REQUEST(ExecuteScript, ExecuteScriptRequest, Ydb::Operations::Operation, DoExecuteScript, EXECUTESCRIPT, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
-    ADD_REQUEST(FetchScriptResults, FetchScriptResultsRequest, FetchScriptResultsResponse, DoFetchScriptResults, FETCHSCRIPTRESULTS, TAuditMode::NonModifying());
-    ADD_REQUEST(CreateSession, CreateSessionRequest, CreateSessionResponse, DoCreateSession, CREATESESSION, TAuditMode::NonModifying());
-    ADD_REQUEST(DeleteSession, DeleteSessionRequest, DeleteSessionResponse, DoDeleteSession, DELETESESSION, TAuditMode::NonModifying());
-    ADD_REQUEST(AttachSession, AttachSessionRequest, SessionState, DoAttachSession, ATTACHSESSION, TAuditMode::NonModifying());
-    ADD_REQUEST(BeginTransaction, BeginTransactionRequest, BeginTransactionResponse, DoBeginTransaction, BEGINTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
-    ADD_REQUEST(CommitTransaction, CommitTransactionRequest, CommitTransactionResponse, DoCommitTransaction, COMMITTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
-    ADD_REQUEST(RollbackTransaction, RollbackTransactionRequest, RollbackTransactionResponse, DoRollbackTransaction, ROLLBACKTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_QUERY_METHOD(ExecuteQuery, ExecuteQueryRequest, ExecuteQueryResponsePart, DoExecuteQuery, RLSWITCH(Rps), QUERY_EXECUTEQUERY, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_QUERY_METHOD(ExecuteScript, ExecuteScriptRequest, Ydb::Operations::Operation, DoExecuteScript, RLSWITCH(Rps), QUERY_EXECUTESCRIPT, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_QUERY_METHOD(FetchScriptResults, FetchScriptResultsRequest, FetchScriptResultsResponse, DoFetchScriptResults, RLSWITCH(Rps), QUERY_FETCHSCRIPTRESULTS, TAuditMode::NonModifying());
+    SETUP_QUERY_METHOD(CreateSession, CreateSessionRequest, CreateSessionResponse, DoCreateSession, RLSWITCH(Rps), QUERY_CREATESESSION, TAuditMode::NonModifying());
+    SETUP_QUERY_METHOD(DeleteSession, DeleteSessionRequest, DeleteSessionResponse, DoDeleteSession, RLSWITCH(Rps), QUERY_DELETESESSION, TAuditMode::NonModifying());
+    SETUP_QUERY_METHOD(AttachSession, AttachSessionRequest, SessionState, DoAttachSession, RLSWITCH(Rps), QUERY_ATTACHSESSION, TAuditMode::NonModifying());
+    SETUP_QUERY_METHOD(BeginTransaction, BeginTransactionRequest, BeginTransactionResponse, DoBeginTransaction, RLSWITCH(Rps), QUERY_BEGINTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_QUERY_METHOD(CommitTransaction, CommitTransactionRequest, CommitTransactionResponse, DoCommitTransaction, RLSWITCH(Rps), QUERY_COMMITTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_QUERY_METHOD(RollbackTransaction, RollbackTransactionRequest, RollbackTransactionResponse, DoRollbackTransaction, RLSWITCH(Rps), QUERY_ROLLBACKTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
 
-#undef ADD_REQUEST
+#undef SETUP_QUERY_METHOD
 }
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/services/ydb/ydb_table.cpp
+++ b/ydb/services/ydb/ydb_table.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/grpc_services/service_table.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/base/base.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr {
 namespace NGRpcService {
@@ -34,102 +35,105 @@ TGRpcYdbTableService::TGRpcYdbTableService(NActors::TActorSystem *system,
 }
 
 void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+    using namespace Ydb::Table;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
     auto getLimiter = CreateLimiterCb(LimiterRegistry_);
-
+    auto& icb = *ActorSystem_->AppData<TAppData>()->Icb;
     size_t proxyCounter = 0;
 
-#ifdef ADD_REQUEST_LIMIT
-#error ADD_REQUEST_LIMIT macro already defined
+#ifdef SETUP_TABLE_METHOD
+#error SETUP_TABLE_METHOD macro already defined
 #endif
 
-#ifdef ADD_STREAM_REQUEST_LIMIT
-#error ADD_STREAM_REQUEST_LIMIT macro already defined
+#ifdef SETUP_TABLE_STREAM_METHOD
+#error SETUP_TABLE_STREAM_METHOD macro already defined
 #endif
 
 #ifdef GET_LIMITER_BY_PATH
 #error GET_LIMITER_BY_PATH macro already defined
 #endif
 
-#define ADD_REQUEST_LIMIT(NAME, CB, LIMIT_TYPE, REQUEST_TYPE, AUDIT_MODE)                                             \
-    for (size_t i = 0; i < HandlersPerCompletionQueue; ++i) {                                                         \
-        for (auto* cq: CQS) {                                                                                         \
-            MakeIntrusive<TGRpcRequest<Ydb::Table::NAME##Request, Ydb::Table::NAME##Response, TGRpcYdbTableService>>  \
-                (this, &Service_, cq,                                                                                 \
-                    [this, proxyCounter](NYdbGrpc::IRequestContextBase *ctx) {                                        \
-                        NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                              \
-                        ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()],                          \
-                            new TGrpcRequestOperationCall<Ydb::Table::NAME##Request, Ydb::Table::NAME##Response>      \
-                                (ctx, &CB, TRequestAuxSettings {                                                      \
-                                    .RlMode = RLSWITCH(LIMIT_TYPE),                                 \
-                                    .AuditMode = AUDIT_MODE,                                                          \
-                                    .RequestType = NJaegerTracing::ERequestType::TABLE_##REQUEST_TYPE,                \
-                                }));                                                                                  \
-                    }, &Ydb::Table::V1::TableService::AsyncService::Request ## NAME,                                  \
-                    #NAME, logger, getCounterBlock("table", #NAME))->Run();                                           \
-            ++proxyCounter;                                                                                           \
-        }                                                                                                             \
+#define SETUP_TABLE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    for (size_t i = 0; i < HandlersPerCompletionQueue; ++i) {                          \
+        for (auto* cq: CQS) {                                                          \
+            SETUP_RUNTIME_EVENT_METHOD(                                                \
+                methodName,                                                            \
+                YDB_API_DEFAULT_REQUEST_TYPE(methodName),                              \
+                YDB_API_DEFAULT_RESPONSE_TYPE(methodName),                             \
+                methodCallback,                                                        \
+                rlMode,                                                                \
+                requestType,                                                           \
+                YDB_API_DEFAULT_COUNTER_BLOCK(table, methodName),                      \
+                auditMode,                                                             \
+                COMMON,                                                                \
+                ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                    \
+                GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \
+                cq,                                                                    \
+                nullptr,                                                               \
+                nullptr                                                                \
+            );                                                                         \
+            ++proxyCounter;                                                            \
+        }                                                                              \
     }
-
-    auto& icb = *ActorSystem_->AppData<TAppData>()->Icb;
 
 #define GET_LIMITER_BY_PATH(ICB_PATH)\
     getLimiter(#ICB_PATH, icb.ICB_PATH, UNLIMITED_INFLIGHT)
 
+#define SETUP_TABLE_STREAM_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, auditMode, limiter) \
+    for (size_t i = 0; i < HandlersPerCompletionQueue; ++i) {                                                                 \
+        for (auto* cq: CQS) {                                                                                                 \
+            SETUP_RUNTIME_EVENT_METHOD(                                                                                       \
+                methodName,                                                                                                   \
+                inputType,                                                                                                    \
+                outputType,                                                                                                   \
+                methodCallback,                                                                                               \
+                rlMode,                                                                                                       \
+                requestType,                                                                                                  \
+                YDB_API_DEFAULT_COUNTER_BLOCK(table, methodName),                                                             \
+                auditMode,                                                                                                    \
+                COMMON,                                                                                                       \
+                ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                                                         \
+                GRpcProxies_[proxyCounter % GRpcProxies_.size()],                                                             \
+                cq,                                                                                                           \
+                limiter,                                                                                                      \
+                nullptr                                                                                                       \
+            );                                                                                                                \
+            ++proxyCounter;                                                                                                   \
+        }                                                                                                                     \
+    }
 
-#define ADD_STREAM_REQUEST_LIMIT(NAME, IN, OUT, CB, LIMIT_TYPE, REQUEST_TYPE, USE_LIMITER, AUDIT_MODE)                                  \
-    for (size_t i = 0; i < HandlersPerCompletionQueue; ++i) {                                                                           \
-        for (auto* cq: CQS) {                                                                                                           \
-            MakeIntrusive<TGRpcRequest<Ydb::Table::IN, Ydb::Table::OUT, TGRpcYdbTableService>>                                          \
-                (this, &Service_, cq,                                                                                                   \
-                    [this, proxyCounter](NYdbGrpc::IRequestContextBase *ctx) {                                                          \
-                        NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                                \
-                        ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()],                                            \
-                            new TGrpcRequestNoOperationCall<Ydb::Table::IN, Ydb::Table::OUT>                                            \
-                                (ctx, &CB, TRequestAuxSettings {                                                                        \
-                                    .RlMode = RLSWITCH(LIMIT_TYPE),                                                   \
-                                    .AuditMode = AUDIT_MODE,                                                                            \
-                                    .RequestType = NJaegerTracing::ERequestType::TABLE_##REQUEST_TYPE,                                  \
-                                }));                                                                                                    \
-                    }, &Ydb::Table::V1::TableService::AsyncService::Request ## NAME,                                                    \
-                    #NAME, logger, getCounterBlock("table", #NAME),                                                                     \
-                    (USE_LIMITER ? GET_LIMITER_BY_PATH(GRpcControls.RequestConfigs.TableService_##NAME.MaxInFlight) : nullptr))->Run(); \
-        ++proxyCounter;                                                                                                                 \
-    }                                                                                                                                   \
-    }                                                                                                                                   \
+    SETUP_TABLE_METHOD(CreateSession, DoCreateSessionRequest, RLSWITCH(Rps), TABLE_CREATESESSION, TAuditMode::NonModifying());
+    SETUP_TABLE_METHOD(KeepAlive, DoKeepAliveRequest, RLSWITCH(Rps), TABLE_KEEPALIVE, TAuditMode::NonModifying());
+    SETUP_TABLE_METHOD(AlterTable, DoAlterTableRequest, RLSWITCH(Rps), TABLE_ALTERTABLE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_TABLE_METHOD(CreateTable, DoCreateTableRequest, RLSWITCH(Rps), TABLE_CREATETABLE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_TABLE_METHOD(DropTable, DoDropTableRequest, RLSWITCH(Rps), TABLE_DROPTABLE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_TABLE_METHOD(DescribeTable, DoDescribeTableRequest, RLSWITCH(Rps), TABLE_DESCRIBETABLE, TAuditMode::NonModifying());
+    SETUP_TABLE_METHOD(DescribeExternalDataSource, DoDescribeExternalDataSourceRequest, RLSWITCH(Rps), TABLE_DESCRIBEEXTERNALDATASOURCE, TAuditMode::NonModifying());
+    SETUP_TABLE_METHOD(DescribeExternalTable, DoDescribeExternalTableRequest, RLSWITCH(Rps), TABLE_DESCRIBEEXTERNALTABLE, TAuditMode::NonModifying());
+    SETUP_TABLE_METHOD(DescribeSystemView, DoDescribeSystemViewRequest, RLSWITCH(Rps), TABLE_DESCRIBESYSTEMVIEW, TAuditMode::NonModifying());
+    SETUP_TABLE_METHOD(CopyTable, DoCopyTableRequest, RLSWITCH(Rps), TABLE_COPYTABLE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_TABLE_METHOD(CopyTables, DoCopyTablesRequest, RLSWITCH(Rps), TABLE_COPYTABLES, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_TABLE_METHOD(RenameTables, DoRenameTablesRequest, RLSWITCH(Rps), TABLE_RENAMETABLES, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_TABLE_METHOD(ExplainDataQuery, DoExplainDataQueryRequest, RLSWITCH(Rps), TABLE_EXPLAINDATAQUERY, TAuditMode::NonModifying());
+    SETUP_TABLE_METHOD(ExecuteSchemeQuery, DoExecuteSchemeQueryRequest, RLSWITCH(Rps), TABLE_EXECUTESCHEMEQUERY, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
+    SETUP_TABLE_METHOD(BeginTransaction, DoBeginTransactionRequest, RLSWITCH(Rps), TABLE_BEGINTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_TABLE_METHOD(DescribeTableOptions, DoDescribeTableOptionsRequest, RLSWITCH(Rps), TABLE_DESCRIBETABLEOPTIONS, TAuditMode::NonModifying());
 
-    ADD_REQUEST_LIMIT(CreateSession, DoCreateSessionRequest, Rps, CREATESESSION, TAuditMode::NonModifying())
-    ADD_REQUEST_LIMIT(KeepAlive, DoKeepAliveRequest, Rps, KEEPALIVE, TAuditMode::NonModifying())
-    ADD_REQUEST_LIMIT(AlterTable, DoAlterTableRequest, Rps, ALTERTABLE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST_LIMIT(CreateTable, DoCreateTableRequest, Rps, CREATETABLE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST_LIMIT(DropTable, DoDropTableRequest, Rps, DROPTABLE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST_LIMIT(DescribeTable, DoDescribeTableRequest, Rps, DESCRIBETABLE, TAuditMode::NonModifying())
-    ADD_REQUEST_LIMIT(DescribeExternalDataSource, DoDescribeExternalDataSourceRequest, Rps, DESCRIBEEXTERNALDATASOURCE, TAuditMode::NonModifying())
-    ADD_REQUEST_LIMIT(DescribeExternalTable, DoDescribeExternalTableRequest, Rps, DESCRIBEEXTERNALTABLE, TAuditMode::NonModifying())
-    ADD_REQUEST_LIMIT(DescribeSystemView, DoDescribeSystemViewRequest, Rps, DESCRIBESYSTEMVIEW, TAuditMode::NonModifying())
-    ADD_REQUEST_LIMIT(CopyTable, DoCopyTableRequest, Rps, COPYTABLE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST_LIMIT(CopyTables, DoCopyTablesRequest, Rps, COPYTABLES, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST_LIMIT(RenameTables, DoRenameTablesRequest, Rps, RENAMETABLES, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST_LIMIT(ExplainDataQuery, DoExplainDataQueryRequest, Rps, EXPLAINDATAQUERY, TAuditMode::NonModifying())
-    ADD_REQUEST_LIMIT(ExecuteSchemeQuery, DoExecuteSchemeQueryRequest, Rps, EXECUTESCHEMEQUERY, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl))
-    ADD_REQUEST_LIMIT(BeginTransaction, DoBeginTransactionRequest, Rps, BEGINTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml))
-    ADD_REQUEST_LIMIT(DescribeTableOptions, DoDescribeTableOptionsRequest, Rps, DESCRIBETABLEOPTIONS, TAuditMode::NonModifying())
+    SETUP_TABLE_METHOD(DeleteSession, DoDeleteSessionRequest, RLMODE(Off), TABLE_DELETESESSION, TAuditMode::NonModifying());
+    SETUP_TABLE_METHOD(CommitTransaction, DoCommitTransactionRequest, RLMODE(Off), TABLE_COMMITTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_TABLE_METHOD(RollbackTransaction, DoRollbackTransactionRequest, RLMODE(Off), TABLE_ROLLBACKTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
 
-    ADD_REQUEST_LIMIT(DeleteSession, DoDeleteSessionRequest, Off, DELETESESSION, TAuditMode::NonModifying())
-    ADD_REQUEST_LIMIT(CommitTransaction, DoCommitTransactionRequest, Off, COMMITTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml))
-    ADD_REQUEST_LIMIT(RollbackTransaction, DoRollbackTransactionRequest, Off, ROLLBACKTRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml))
+    SETUP_TABLE_METHOD(PrepareDataQuery, DoPrepareDataQueryRequest, RLSWITCH(Ru), TABLE_PREPAREDATAQUERY, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_TABLE_METHOD(ExecuteDataQuery, DoExecuteDataQueryRequest, RLSWITCH(Ru), TABLE_EXECUTEDATAQUERY, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_TABLE_METHOD(BulkUpsert, DoBulkUpsertRequest, RLSWITCH(Ru), TABLE_BULKUPSERT, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
 
-    ADD_REQUEST_LIMIT(PrepareDataQuery, DoPrepareDataQueryRequest, Ru, PREPAREDATAQUERY, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml))
-    ADD_REQUEST_LIMIT(ExecuteDataQuery, DoExecuteDataQueryRequest, Ru, EXECUTEDATAQUERY, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml))
-    ADD_REQUEST_LIMIT(BulkUpsert, DoBulkUpsertRequest, Ru, BULKUPSERT, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml))
-
-    ADD_STREAM_REQUEST_LIMIT(StreamExecuteScanQuery, ExecuteScanQueryRequest, ExecuteScanQueryPartialResponse, DoExecuteScanQueryRequest, RuOnProgress, STREAMEXECUTESCANQUERY, false, TAuditMode::NonModifying())
-    ADD_STREAM_REQUEST_LIMIT(StreamReadTable, ReadTableRequest, ReadTableResponse, DoReadTableRequest, RuOnProgress, STREAMREADTABLE, false, TAuditMode::NonModifying())
-    ADD_STREAM_REQUEST_LIMIT(ReadRows, ReadRowsRequest, ReadRowsResponse, DoReadRowsRequest, Ru, READROWS, true, TAuditMode::NonModifying())
+    SETUP_TABLE_STREAM_METHOD(StreamExecuteScanQuery, ExecuteScanQueryRequest, ExecuteScanQueryPartialResponse, DoExecuteScanQueryRequest, RLSWITCH(RuOnProgress), TABLE_STREAMEXECUTESCANQUERY, TAuditMode::NonModifying(), nullptr);
+    SETUP_TABLE_STREAM_METHOD(StreamReadTable, ReadTableRequest, ReadTableResponse, DoReadTableRequest, RLSWITCH(RuOnProgress), TABLE_STREAMREADTABLE, TAuditMode::NonModifying(), nullptr);
+    SETUP_TABLE_STREAM_METHOD(ReadRows, ReadRowsRequest, ReadRowsResponse, DoReadRowsRequest, RLSWITCH(Ru), TABLE_READROWS, TAuditMode::NonModifying(), GET_LIMITER_BY_PATH(GRpcControls.RequestConfigs.TableService_ReadRows.MaxInFlight));
 
 #undef GET_LIMITER_BY_PATH
-#undef ADD_REQUEST_LIMIT
-#undef ADD_STREAM_REQUEST_LIMIT
+#undef SETUP_TABLE_METHOD
+#undef SETUP_TABLE_STREAM_METHOD
 }
 
 } // namespace NGRpcService


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h