### PR TITLE
EXT-1333 Refactor View service using standard macro

### DIFF
--- a/ydb/services/view/grpc_service.cpp
+++ b/ydb/services/view/grpc_service.cpp
@@ -3,32 +3,24 @@
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/service_view.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr::NGRpcService {
 
 void TGRpcViewService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     using namespace Ydb::View;
-
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 
-    MakeIntrusive<TGRpcRequest<DescribeViewRequest,
-                               DescribeViewResponse,
-                               TGRpcViewService>>(
-        this, &Service_, CQ_,
-        [this](NYdbGrpc::IRequestContextBase* ctx) {
-            NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());
-            ActorSystem_->Send(
-                GRpcRequestProxyId_,
-                new TGrpcRequestOperationCall<DescribeViewRequest,
-                                              DescribeViewResponse>(
-                    ctx, &DoDescribeView,
-                    TRequestAuxSettings{RLSWITCH(Rps), nullptr}
-                )
-            );
-        },
-        &V1::ViewService::AsyncService::RequestDescribeView,
-        "DescribeView", logger, getCounterBlock("view", "DescribeView")
-    )->Run();
+#ifdef SETUP_VIEW_METHOD
+#error SETUP_VIEW_METHOD macro already defined
+#endif
+
+#define SETUP_VIEW_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, view, auditMode)
+
+    SETUP_VIEW_METHOD(DescribeView, DoDescribeView, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+
+#undef SETUP_VIEW_METHOD
 }
 
 }


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h