### PR TITLE
EXT-1333 Refactor Replication service using standard macro

### DIFF
--- a/ydb/services/replication/grpc_service.cpp
+++ b/ydb/services/replication/grpc_service.cpp
@@ -5,34 +5,25 @@
 #include <ydb/core/grpc_services/grpc_request_proxy.h>
 #include <ydb/core/grpc_services/rpc_calls.h>
 #include <ydb/core/grpc_services/service_replication.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 
 namespace NKikimr::NGRpcService {
 
 void TGRpcReplicationService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
-    Y_UNUSED(logger);
-
+    using namespace Ydb::Replication;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
-    using namespace Ydb;
 
-#ifdef ADD_REQUEST
-#error ADD_REQUEST macro already defined
+#ifdef SETUP_REPLICATION_METHOD
+#error SETUP_REPLICATION_METHOD macro already defined
 #endif
 
-#define ADD_REQUEST(NAME, REQUEST, RESPONSE, CB) \
-    MakeIntrusive<TGRpcRequest<Replication::REQUEST, Replication::RESPONSE, TGRpcReplicationService>> \
-        (this, &Service_, CQ_,                                                                        \
-            [this](NYdbGrpc::IRequestContextBase *ctx) {                                              \
-                NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                      \
-                ActorSystem_->Send(GRpcRequestProxyId_,                                               \
-                    new TGrpcRequestOperationCall<Replication::REQUEST, Replication::RESPONSE>        \
-                        (ctx, &CB, TRequestAuxSettings{RLSWITCH(Rps), nullptr}));   \
-            }, &Replication::V1::ReplicationService::AsyncService::Request ## NAME,                   \
-            #NAME, logger, getCounterBlock("replication", #NAME))->Run();
+#define SETUP_REPLICATION_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, replication, auditMode)
 
-    ADD_REQUEST(DescribeReplication, DescribeReplicationRequest, DescribeReplicationResponse, DoDescribeReplication);
-    ADD_REQUEST(DescribeTransfer, DescribeTransferRequest, DescribeTransferResponse, DoDescribeTransfer);
+    SETUP_REPLICATION_METHOD(DescribeReplication, DoDescribeReplication, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_REPLICATION_METHOD(DescribeTransfer, DoDescribeTransfer, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
 
-#undef ADD_REQUEST
+#undef SETUP_REPLICATION_METHOD
 }
 
 }


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h