### PR TITLE
EXT-1333 Refactor Backup service using standard macro

### DIFF
--- a/ydb/services/backup/grpc_service.cpp
+++ b/ydb/services/backup/grpc_service.cpp
@@ -3,36 +3,31 @@
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/service_backup.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/resources/ydb_resources.h>
 
 namespace NKikimr {
 namespace NGRpcService {
 
 void TGRpcBackupService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+    using namespace Ydb::Backup;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 
-#ifdef ADD_REQUEST
-#error ADD_REQUEST macro already defined
+#ifdef SETUP_BACKUP_METHOD
+#error SETUP_BACKUP_METHOD macro already defined
 #endif
-#define ADD_REQUEST(NAME, IN, OUT, CB, AUDIT_MODE) \
-    MakeIntrusive<TGRpcRequest<Ydb::Backup::IN, Ydb::Backup::OUT, TGRpcBackupService>>(this, &Service_, CQ_, \
-        [this](NYdbGrpc::IRequestContextBase *ctx) { \
-            NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer()); \
-            ActorSystem_->Send(GRpcRequestProxyId_, \
-                new NGRpcService::TGrpcRequestOperationCall<Ydb::Backup::IN, Ydb::Backup::OUT> \
-                    (ctx, &CB, NGRpcService::TRequestAuxSettings{NGRpcService::TRateLimiterMode::Off, nullptr, AUDIT_MODE})); \
-        }, &Ydb::Backup::V1::BackupService::AsyncService::Request ## NAME, \
-        #NAME, logger, getCounterBlock("backup", #NAME))->Run();
 
-    ADD_REQUEST(FetchBackupCollections, FetchBackupCollectionsRequest, FetchBackupCollectionsResponse, DoFetchBackupCollectionsRequest, TAuditMode::NonModifying());
-    ADD_REQUEST(ListBackupCollections, ListBackupCollectionsRequest, ListBackupCollectionsResponse, DoListBackupCollectionsRequest, TAuditMode::NonModifying());
-    ADD_REQUEST(CreateBackupCollection, CreateBackupCollectionRequest, CreateBackupCollectionResponse, DoCreateBackupCollectionRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::DatabaseAdmin));
-    ADD_REQUEST(ReadBackupCollection, ReadBackupCollectionRequest, ReadBackupCollectionResponse, DoReadBackupCollectionRequest, TAuditMode::NonModifying());
-    ADD_REQUEST(UpdateBackupCollection, UpdateBackupCollectionRequest, UpdateBackupCollectionResponse, DoUpdateBackupCollectionRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::DatabaseAdmin));
-    ADD_REQUEST(DeleteBackupCollection, DeleteBackupCollectionRequest, DeleteBackupCollectionResponse, DoDeleteBackupCollectionRequest, TAuditMode::Modifying(TAuditMode::TLogClassConfig::DatabaseAdmin));
+#define SETUP_BACKUP_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, backup, auditMode)
 
-#undef ADD_REQUEST
+    SETUP_BACKUP_METHOD(FetchBackupCollections, DoFetchBackupCollectionsRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_BACKUP_METHOD(ListBackupCollections, DoListBackupCollectionsRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_BACKUP_METHOD(CreateBackupCollection, DoCreateBackupCollectionRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::DatabaseAdmin));
+    SETUP_BACKUP_METHOD(ReadBackupCollection, DoReadBackupCollectionRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_BACKUP_METHOD(UpdateBackupCollection, DoUpdateBackupCollectionRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::DatabaseAdmin));
+    SETUP_BACKUP_METHOD(DeleteBackupCollection, DoDeleteBackupCollectionRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::DatabaseAdmin));
 
+#undef SETUP_BACKUP_METHOD
 }
 
 } // namespace NGRpcService


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h