### PR TITLE
EXT-1333 Refactor Auth service using standard macro

### DIFF
--- a/ydb/services/auth/grpc_service.cpp
+++ b/ydb/services/auth/grpc_service.cpp
@@ -3,18 +3,11 @@
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/service_auth.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/resources/ydb_resources.h>
 
 namespace NKikimr {
 namespace NGRpcService {
-
-static TString GetSdkBuildInfo(NYdbGrpc::IRequestContextBase* reqCtx) {
-    const auto& res = reqCtx->GetPeerMetaValues(NYdb::YDB_SDK_BUILD_INFO_HEADER);
-    if (res.empty()) {
-        return {};
-    }
-    return TString{res[0]};
-}
 
 void TGRpcAuthService::SetServerOptions(const NYdbGrpc::TServerOptions& options) {
     // !!! WARN: The login request should be available without auth token !!!
@@ -27,29 +20,20 @@ void TGRpcAuthService::SetServerOptions(const NYdbGrpc::TServerOptions& options)
 }
 
 void TGRpcAuthService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+    using namespace Ydb::Auth;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
-#ifdef ADD_REQUEST
-#error ADD_REQUEST macro already defined
+    ReportSdkBuildInfo();
+
+#ifdef SETUP_LOGIN_METHOD
+#error SETUP_LOGIN_METHOD macro already defined
 #endif
 
-#define ADD_REQUEST_LIMIT(NAME, CB, RATE_LIMITER_MODE, AUDIT_MODE)                                     \
-    MakeIntrusive<TGRpcRequest<Ydb::Auth::NAME##Request, Ydb::Auth::NAME##Response, TGRpcAuthService>> \
-        (this, this->GetService(), CQ_,                                                                \
-            [this](NYdbGrpc::IRequestContextBase *ctx) {                                               \
-                NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer(), GetSdkBuildInfo(ctx)); \
-                ActorSystem_->Send(GRpcRequestProxyId_,                                                \
-                    new TGrpcRequestOperationCall<Ydb::Auth::NAME##Request, Ydb::Auth::NAME##Response> \
-                        (ctx, &CB, TRequestAuxSettings{                                                \
-                            .RlMode = RATE_LIMITER_MODE,                                               \
-                            .AuditMode = AUDIT_MODE,                                                   \
-                        }));                                                                           \
-            }, &Ydb::Auth::V1::AuthService::AsyncService::Request ## NAME,                             \
-            #NAME, logger, getCounterBlock("login", #NAME))->Run();
+#define SETUP_LOGIN_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, login, auditMode)
 
-    ADD_REQUEST_LIMIT(Login, DoLoginRequest, TRateLimiterMode::Off, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Login));
+    SETUP_LOGIN_METHOD(Login, DoLoginRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Login));
 
-#undef ADD_REQUEST_LIMIT
-
+#undef SETUP_LOGIN_METHOD
 }
 
 } // namespace NGRpcService


### PR DESCRIPTION
Refactor grpc service to use standard macros from ydb/library/grpc/server/grpc_method_setup.h