### PR TITLE
[ICRDMA] Fix windows build. Peerdir to "contrib/libs/ibdrv" should be present in any case

### DIFF
--- a/ydb/library/actors/interconnect/rdma/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ya.make
@@ -10,11 +10,6 @@ IF (OS_LINUX)
         rdma.h
     )
 
-    PEERDIR(
-        contrib/libs/ibdrv
-        contrib/libs/protobuf
-    )
-
 ELSE()
     CXXFLAGS(-DMEM_POOL_DISABLE_RDMA_SUPPORT)
     SRCS(
@@ -23,11 +18,12 @@ ELSE()
         rdma.h
     )
 
-    PEERDIR(
-        contrib/libs/protobuf
-    )
-
 ENDIF()
+
+PEERDIR(
+    contrib/libs/ibdrv
+    contrib/libs/protobuf
+)
 
 END()
 


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix windows build. The ibverbs header should be reachable. 

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
