### PR TITLE
Filled db names in SchemeCache requests and removed unnecessary CanonizePath

### DIFF
--- a/ydb/core/grpc_services/operation_helpers.cpp
+++ b/ydb/core/grpc_services/operation_helpers.cpp
@@ -29,19 +29,6 @@ namespace NGRpcService {
 #define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
 #define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_PROXY, LogPrefix << stream)
 
-IEventBase* CreateNavigateForPath(const TString& path) {
-    auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
-
-    request->DatabaseName = path;
-
-    auto& entry = request->ResultSet.emplace_back();
-    entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
-    entry.Path = ::NKikimr::SplitPath(path);
-    entry.RedirectRequired = false;
-
-    return new TEvTxProxySchemeCache::TEvNavigateKeySet(request.Release());
-}
-
 TActorId CreatePipeClient(ui64 id, const TActorContext& ctx) {
     NTabletPipe::TClientConfig clientConfig;
     clientConfig.RetryPolicy = {.RetryLimitCount = 3};

--- a/ydb/core/grpc_services/rpc_alter_table.cpp
+++ b/ydb/core/grpc_services/rpc_alter_table.cpp
@@ -31,29 +31,6 @@ using namespace NActors;
 using namespace NConsole;
 using namespace Ydb;
 
-static bool CheckAddIndexAccess(const NACLib::TUserToken& userToken, const NSchemeCache::TSchemeCacheNavigate* navigate) {
-    bool isDatabaseEntry = true;
-
-    using TEntry = NSchemeCache::TSchemeCacheNavigate::TEntry;
-
-    for (const TEntry& entry : navigate->ResultSet) {
-        if (!entry.SecurityObject) {
-            continue;
-        }
-        if (isDatabaseEntry) { // first entry is always database
-            isDatabaseEntry = false;
-            continue;
-        }
-
-        const ui32 access = NACLib::AlterSchema | NACLib::DescribeSchema;
-        if (!entry.SecurityObject->CheckAccess(access, userToken)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 using TEvAlterTableRequest = TGrpcRequestOperationCall<Ydb::Table::AlterTableRequest,
     Ydb::Table::AlterTableResponse>;
 
@@ -64,6 +41,7 @@ class TAlterTableRPC : public TRpcSchemeRequestActor<TAlterTableRPC, TEvAlterTab
 public:
     TAlterTableRPC(IRequestOpCtx* msg)
         : TBase(msg)
+        , DatabaseName(Request_->GetDatabaseName().GetOrElse(""))
     {}
 
     void Bootstrap(const TActorContext &ctx) {
@@ -113,7 +91,7 @@ public:
         case EOp::Attribute:
         case EOp::AddChangefeed:
         case EOp::DropChangefeed:
-            GetProxyServices();
+            Navigate(GetProtoRequest()->path());;
             break;
 
         case EOp::DropIndex:
@@ -128,8 +106,7 @@ public:
 private:
     void AlterStateWork(TAutoPtr<IEventHandle>& ev) {
         switch (ev->GetTypeRewrite()) {
-           HFunc(TEvTxUserProxy::TEvAllocateTxIdResult, Handle);
-           HFunc(TEvTxUserProxy::TEvGetProxyServicesResponse, Handle);
+           hFunc(TEvTxUserProxy::TEvAllocateTxIdResult, Handle);
            HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
            HFunc(NSchemeShard::TEvIndexBuilder::TEvCreateResponse, Handle);
            HFunc(NSchemeShard::TEvIndexBuilder::TEvGetResponse, Handle);
@@ -189,61 +166,46 @@ private:
         Send(MakeTxProxyID(), new TEvTxUserProxy::TEvAllocateTxId);
     }
 
-    void Handle(TEvTxUserProxy::TEvAllocateTxIdResult::TPtr& ev, const TActorContext& ctx) {
+    void Handle(TEvTxUserProxy::TEvAllocateTxIdResult::TPtr& ev) {
         TXLOG_D("Handle TEvTxUserProxy::TEvAllocateTxIdResult");
 
         const auto* msg = ev->Get();
         TxId = msg->TxId;
         LogPrefix = TStringBuilder() << "[AlterTableAddIndex " << SelfId() << " TxId# " << TxId << "] ";
 
-        Navigate(msg->Services.SchemeCache, ctx);
+        Navigate(GetProtoRequest()->path());
     }
 
-    void GetProxyServices() {
-        using namespace NTxProxy;
-        Send(MakeTxProxyID(), new TEvTxUserProxy::TEvGetProxyServicesRequest);
-    }
-
-    void Handle(TEvTxUserProxy::TEvGetProxyServicesResponse::TPtr& ev, const TActorContext& ctx) {
-        Navigate(ev->Get()->Services.SchemeCache, ctx);
-    }
-
-    void Navigate(const TActorId& schemeCache, const TActorContext& ctx) {
-        DatabaseName = Request_->GetDatabaseName()
-            .GetOrElse(DatabaseFromDomain(AppData()));
-
-        const auto& path = GetProtoRequest()->path();
-
-        const auto paths = NKikimr::SplitPath(path);
+    void Navigate(const TString& path) {
+        auto paths = NKikimr::SplitPath(path);
         if (paths.empty()) {
+            auto& ctx = TlsActivationContext->AsActorContext();
             TString error = TStringBuilder() << "Failed to split table path " << path;
             Request_->RaiseIssue(NYql::TIssue(error));
             return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
-        auto ev = CreateNavigateForPath(DatabaseName);
-        {
-            auto& entry = static_cast<TEvTxProxySchemeCache::TEvNavigateKeySet*>(ev)->Request->ResultSet.emplace_back();
-            entry.Path = paths;
-        }
+        auto navigate = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+        navigate->DatabaseName = DatabaseName;
 
-        Send(schemeCache, ev);
+        auto& entry = navigate->ResultSet.emplace_back();
+        entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
+        entry.Path = std::move(paths);
+
+        Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(navigate));
     }
 
-    void Navigate(const TTableId& pathId, const TActorContext& /*ctx*/) {
-        DatabaseName = Request_->GetDatabaseName()
-            .GetOrElse(DatabaseFromDomain(AppData()));
+    void Navigate(const TTableId& pathId) {
+        auto navigate = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+        navigate->DatabaseName = DatabaseName;
 
-        auto ev = CreateNavigateForPath(DatabaseName);
-        {
-            auto& entry = static_cast<TEvTxProxySchemeCache::TEvNavigateKeySet*>(ev)->Request->ResultSet.emplace_back();
-            entry.RequestType = NSchemeCache::TSchemeCacheNavigate::TEntry::ERequestType::ByTableId;
-            entry.TableId = pathId;
-            entry.ShowPrivatePath = true;
-            entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;
-        }
+        auto& entry = navigate->ResultSet.emplace_back();
+        entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;
+        entry.RequestType = NSchemeCache::TSchemeCacheNavigate::TEntry::ERequestType::ByTableId;
+        entry.TableId = pathId;
+        entry.ShowPrivatePath = true;
 
-        Send(MakeSchemeCacheID(), ev);
+        Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(navigate));
     }
 
     static bool IsChangefeedOperation(EOp type) {
@@ -278,8 +240,8 @@ private:
             return Reply(Ydb::StatusIds::SCHEME_ERROR, ctx);
         }
 
-        Y_ABORT_UNLESS(!resp->ResultSet.empty());
-        const auto& entry = resp->ResultSet.back();
+        Y_ABORT_UNLESS(resp->ResultSet.size() == 1);
+        const auto& entry = resp->ResultSet.front();
 
         switch (entry.Kind) {
         case NSchemeCache::TSchemeCacheNavigate::KindTable:
@@ -301,7 +263,7 @@ private:
 
         switch (OpType) {
         case EOp::AddIndex:
-            return AlterTableAddIndexOp(resp, ctx);
+            return AlterTableAddIndexOp(entry, ctx);
         case EOp::Attribute:
             ResolvedPathId = resp->ResultSet.back().TableId.PathId;
             return AlterTable(ctx);
@@ -317,7 +279,7 @@ private:
                 const auto& child = list->Children.at(0);
                 AlterTable(ctx, CanonizePath(ChildPath(NKikimr::SplitPath(GetProtoRequest()->path()), child.Name)));
             } else {
-                Navigate(entry.TableId, ctx);
+                Navigate(entry.TableId);
             }
             break;
         default:
@@ -326,13 +288,32 @@ private:
         }
     }
 
-    void AlterTableAddIndexOp(const NSchemeCache::TSchemeCacheNavigate* resp, const TActorContext& ctx) {
-        if (UserToken && !CheckAddIndexAccess(*UserToken, resp)) {
-            TXLOG_W("Access check failed");
-            return Reply(Ydb::StatusIds::UNAUTHORIZED, ctx);
+    bool CheckAddIndexAccess(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry, const TActorContext& ctx) {
+        if (!UserToken || !entry.SecurityObject) {
+            return true;
         }
 
-        auto domainInfo = resp->ResultSet.front().DomainInfo;
+        const ui32 access = NACLib::AlterSchema | NACLib::DescribeSchema;
+        if (entry.SecurityObject->CheckAccess(access, *UserToken)) {
+            return true;
+        }
+
+        TXLOG_W("Access check failed");
+        Reply(Ydb::StatusIds::UNAUTHORIZED,
+            TStringBuilder() << "Access denied"
+                << " for# " << UserToken->GetUserSID()
+                << ", path# " << CanonizePath(entry.Path)
+                << ", access# " << NACLib::AccessRightsToString(access),
+            NKikimrIssues::TIssuesIds::ACCESS_DENIED, ctx);
+        return false;
+    }
+
+    void AlterTableAddIndexOp(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry, const TActorContext& ctx) {
+        if (!CheckAddIndexAccess(entry, ctx)) {
+            return;
+        }
+
+        const auto& domainInfo = entry.DomainInfo;
         if (!domainInfo) {
             TXLOG_E("Got empty domain info");
             return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
@@ -416,7 +397,7 @@ private:
         Die(ctx);
     }
 
-    void AlterTable(const TActorContext &ctx, const TMaybe<TString>& overridePath = {}) { 
+    void AlterTable(const TActorContext &ctx, const TMaybe<TString>& overridePath = {}) {
         const auto req = GetProtoRequest();
         std::unique_ptr<TEvTxUserProxy::TEvProposeTransaction> proposeRequest = CreateProposeTransaction();
         auto modifyScheme = proposeRequest->Record.MutableTransaction()->MutableModifyScheme();
@@ -433,7 +414,7 @@ private:
     }
 
     ui64 TxId = 0;
-    TString DatabaseName;
+    const TString DatabaseName;
     TString LogPrefix;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     TPathId ResolvedPathId;

--- a/ydb/core/grpc_services/rpc_describe_path.cpp
+++ b/ydb/core/grpc_services/rpc_describe_path.cpp
@@ -37,7 +37,7 @@ public:
 private:
     void ResolvePath(const TActorContext& ctx) {
         auto request = MakeHolder<TSchemeCacheNavigate>();
-        request->DatabaseName = NKikimr::CanonizePath(this->Request_->GetDatabaseName().GetOrElse(""));
+        request->DatabaseName = this->Request_->GetDatabaseName().GetOrElse("");
 
         auto& entry = request->ResultSet.emplace_back();
         entry.Operation = TSchemeCacheNavigate::OpList; // we need ListNodeEntry

--- a/ydb/core/grpc_services/rpc_describe_table.cpp
+++ b/ydb/core/grpc_services/rpc_describe_table.cpp
@@ -59,7 +59,7 @@ public:
         }
 
         auto navigate = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
-        navigate->DatabaseName = CanonizePath(Request_->GetDatabaseName().GetOrElse(""));
+        navigate->DatabaseName = Request_->GetDatabaseName().GetOrElse("");
         auto& entry = navigate->ResultSet.emplace_back();
         entry.Path = paths;
         entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;

--- a/ydb/core/grpc_services/rpc_import_data.cpp
+++ b/ydb/core/grpc_services/rpc_import_data.cpp
@@ -120,7 +120,7 @@ class TImportDataRPC: public TRpcRequestActor<TImportDataRPC, TEvImportDataReque
 
     void ResolvePath() {
         auto request = MakeHolder<TNavigate>();
-        request->DatabaseName = NKikimr::CanonizePath(GetDatabaseName());
+        request->DatabaseName = GetDatabaseName();
 
         auto& entry = request->ResultSet.emplace_back();
         entry.Operation = TNavigate::OpTable;

--- a/ydb/core/grpc_services/rpc_rate_limiter_api.cpp
+++ b/ydb/core/grpc_services/rpc_rate_limiter_api.cpp
@@ -169,7 +169,7 @@ protected:
         }
 
         auto req = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
-        req->DatabaseName = this->Request_->GetDatabaseName().GetOrElse(DatabaseFromDomain(AppData()));
+        req->DatabaseName = this->Request_->GetDatabaseName().GetOrElse("");
         req->ResultSet.emplace_back();
         req->ResultSet.back().Path.swap(path);
         req->ResultSet.back().Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;

--- a/ydb/core/grpc_services/rpc_read_rows.cpp
+++ b/ydb/core/grpc_services/rpc_read_rows.cpp
@@ -266,7 +266,7 @@ public:
     }
 
     TString GetDatabase() {
-        return Request->GetDatabaseName().GetOrElse(DatabaseFromDomain(AppData()));
+        return Request->GetDatabaseName().GetOrElse("");
     }
 
     const TString& GetTable() {

--- a/ydb/core/grpc_services/rpc_request_base.h
+++ b/ydb/core/grpc_services/rpc_request_base.h
@@ -176,7 +176,7 @@ protected:
             if (name) {
                 DatabaseName_.emplace(std::move(*name));
             } else {
-                DatabaseName_.emplace(DatabaseFromDomain(AppData()));
+                DatabaseName_.emplace("");
             }
         }
         return *DatabaseName_;

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -622,7 +622,7 @@ void TKafkaProduceActor::ProcessInitializationRequests(const TActorContext& ctx)
         request->ResultSet.emplace_back(entry);
     }
 
-    request->DatabaseName = CanonizePath(Context->DatabasePath);
+    request->DatabaseName = Context->DatabasePath;
 
     ctx.Send(MakeSchemeCacheID(), MakeHolder<TEvTxProxySchemeCache::TEvNavigateKeySet>(request.release()));
 }

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -564,7 +564,7 @@ protected:
         LOG_D("Describe streaming query in database: " << Database);
 
         auto request = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
-        request->DatabaseName = CanonizePath(Database);
+        request->DatabaseName = Database;
         request->UserToken = GetUserToken();
 
         auto& entry = request->ResultSet.emplace_back();

--- a/ydb/core/statistics/service/http_request.cpp
+++ b/ydb/core/statistics/service/http_request.cpp
@@ -84,6 +84,7 @@ void THttpRequest::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& 
 
     auto navigateDomainKey = [this] (TPathId domainKey) {
         auto navigate = std::make_unique<TNavigate>();
+        navigate->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
         auto& entry = navigate->ResultSet.emplace_back();
         entry.TableId = TTableId(domainKey.OwnerId, domainKey.LocalPathId);
         entry.Operation = TNavigate::EOp::OpPath;

--- a/ydb/core/statistics/service/service_impl.cpp
+++ b/ydb/core/statistics/service/service_impl.cpp
@@ -812,6 +812,7 @@ private:
             SA_LOG_D("[TStatService::TEvNavigateKeySetResult] RequestId[ " << requestId
                 << " ] resolve DatabasePath[ " << pathId << " ]");
             auto navigateRequest = std::make_unique<TNavigate>();
+            navigateRequest->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
             AddNavigateEntry(navigateRequest->ResultSet, pathId);
 
             Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(navigateRequest.release()), 0, ev->Cookie);
@@ -883,6 +884,7 @@ private:
 
         auto navigateDomainKey = [this, cookie = ev->Cookie] (const TPathId& domainKey) {
             auto navigateRequest = std::make_unique<TNavigate>();
+            navigateRequest->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
             AddNavigateEntry(navigateRequest->ResultSet, domainKey);
             navigateRequest->Cookie = ResolveSACookie;
             Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(navigateRequest.release()));

--- a/ydb/core/sys_view/service/sysview_service.cpp
+++ b/ydb/core/sys_view/service/sysview_service.cpp
@@ -530,6 +530,7 @@ private:
     void RequestDatabaseName(TPathId pathId) {
         using TNavigate = NSchemeCache::TSchemeCacheNavigate;
         auto request = MakeHolder<TNavigate>();
+        request->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
         request->ResultSet.push_back({});
 
         auto& entry = request->ResultSet.back();

--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -128,6 +128,7 @@ namespace {
             entry.RedirectRequired = false;
 
             auto request = MakeHolder<TNavigate>();
+            request->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
             request->ResultSet.emplace_back(std::move(entry));
             request->DomainOwnerId = DomainOwnerId;
 

--- a/ydb/services/datastreams/put_records_actor.h
+++ b/ydb/services/datastreams/put_records_actor.h
@@ -312,7 +312,7 @@ namespace NKikimr::NDataStreams::V1 {
         entry.Path = NKikimr::SplitPath(this->GetTopicPath());
         entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;
         entry.SyncVersion = true;
-        schemeCacheRequest->DatabaseName = CanonizePath(this->Request_->GetDatabaseName().GetOrElse(""));
+        schemeCacheRequest->DatabaseName = this->Request_->GetDatabaseName().GetOrElse("");
         schemeCacheRequest->ResultSet.emplace_back(entry);
         ctx.Send(MakeSchemeCacheID(), MakeHolder<TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
     }

--- a/ydb/services/lib/actors/pq_schema_actor.h
+++ b/ydb/services/lib/actors/pq_schema_actor.h
@@ -142,7 +142,7 @@ namespace NKikimr::NGRpcProxy::V1 {
                 return RespondWithCode(Ydb::StatusIds::UNAUTHORIZED);
             }
 
-            navigateRequest->DatabaseName = CanonizePath(Database);
+            navigateRequest->DatabaseName = Database;
             navigateRequest->ResultSet.emplace_back(NSchemeCache::TSchemeCacheNavigate::TEntry{
                 .Path = NKikimr::SplitPath(GetTopicPath()),
                 .Access = CheckAccessWithWriteTopicPermission ? NACLib::UpdateRow : NACLib::DescribeSchema,

--- a/ydb/services/metadata/common/ss_dialog.cpp
+++ b/ydb/services/metadata/common/ss_dialog.cpp
@@ -35,7 +35,7 @@ void TSSDialogActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr
 
 void TSSDialogActor::OnBootstrap() {
     auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
-    request->DatabaseName = NKikimr::CanonizePath(AppData()->TenantName);
+    request->DatabaseName = AppData()->TenantName;
     auto& entry = request->ResultSet.emplace_back();
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
     entry.Path = NKikimr::SplitPath(request->DatabaseName);

--- a/ydb/services/metadata/ds_table/scheme_describe.cpp
+++ b/ydb/services/metadata/ds_table/scheme_describe.cpp
@@ -33,7 +33,7 @@ void TSchemeDescriptionActorImpl::Bootstrap() {
     Become(&TSchemeDescriptionActor::StateMain);
 
     auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
-    request->DatabaseName = NKikimr::CanonizePath(AppData()->TenantName);
+    request->DatabaseName = AppData()->TenantName;
     auto& entry = request->ResultSet.emplace_back();
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpTable;
     InitEntry(entry);

--- a/ydb/services/metadata/ds_table/table_exists.cpp
+++ b/ydb/services/metadata/ds_table/table_exists.cpp
@@ -42,7 +42,7 @@ void TTableExistsActor::OnBootstrap() {
     Become(&TTableExistsActor::StateMain);
 
     auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
-    request->DatabaseName = NKikimr::CanonizePath(AppData()->TenantName);
+    request->DatabaseName = AppData()->TenantName;
     auto& entry = request->ResultSet.emplace_back();
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
     entry.Path = NKikimr::SplitPath(Path);

--- a/ydb/services/ydb/ydb_common_ut.h
+++ b/ydb/services/ydb/ydb_common_ut.h
@@ -367,6 +367,7 @@ using TKikimrWithGrpcAndRootSchemaWithAuthAndSsl = TBasicKikimrWithGrpcAndRootSc
 Ydb::StatusIds::StatusCode WaitForStatus(
     std::shared_ptr<grpc::Channel> channel, const TString& opId,
     TString* error = nullptr,
+    const TString& database = "/Root",
     int retries = 10,
     TDuration sleepDuration = NYdb::ITERATION_DURATION
 );

--- a/ydb/services/ydb/ydb_import_ut.cpp
+++ b/ydb/services/ydb/ydb_import_ut.cpp
@@ -129,8 +129,11 @@ Y_UNIT_TEST_SUITE(YdbImport) {
 
     Y_UNIT_TEST(ImportFromS3ToExistingTable) {
         TKikimrWithGrpcAndRootSchema server;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(TStringBuilder()
-            << "localhost:" << server.GetPort()));
+        auto driver = TDriver(
+            TDriverConfig()
+                .SetEndpoint(TStringBuilder() << "localhost:" << server.GetPort())
+                .SetDatabase("/Root")
+            );
 
         {
             NYdb::NTable::TTableClient client(driver);

--- a/ydb/services/ydb/ydb_index_table_ut.cpp
+++ b/ydb/services/ydb/ydb_index_table_ut.cpp
@@ -48,7 +48,11 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
     Y_UNIT_TEST(AlterIndexImplBySuperUser) {
         TKikimrWithGrpcAndRootSchema server;
 
-        NYdb::TDriver driver(TDriverConfig().SetEndpoint(TStringBuilder() << "localhost:" << server.GetPort()));
+        NYdb::TDriver driver(
+            TDriverConfig()
+                .SetEndpoint(TStringBuilder() << "localhost:" << server.GetPort())
+                .SetDatabase("/Root")
+        );
         NYdb::NTable::TTableClient client(driver);
         NFlatTests::TFlatMsgBusClient oldClient(server.ServerSettings->Port);
 
@@ -65,7 +69,7 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
             auto type = TTypeBuilder().BeginOptional().Primitive(EPrimitiveType::Uint64).EndOptional().Build();
             auto alter = TAlterTableSettings().AppendAddColumns(TColumn("FinishedTimestamp", type));
 
-            auto alterResult = session.AlterTable("Root/Foo/TimestampIndex/indexImplTable", alter).GetValueSync();
+            auto alterResult = session.AlterTable("/Root/Foo/TimestampIndex/indexImplTable", alter).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(alterResult.GetStatus(), EStatus::SCHEME_ERROR,
                                        "Alter of index impl table must fail");
         }
@@ -211,7 +215,7 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
             operation.result().UnpackTo(&result);
 
             auto partitioning = result.partitioning_settings().ShortDebugString();
-            UNIT_ASSERT_STRINGS_EQUAL(partitioning, 
+            UNIT_ASSERT_STRINGS_EQUAL(partitioning,
                 "partitioning_by_size: DISABLED "
                 "partitioning_by_load: ENABLED "
                 "min_partitions_count: 5"
@@ -245,6 +249,7 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
         }
         {
             grpc::ClientContext context;
+            context.AddMetadata("x-ydb-database", "/Root");
             Ydb::Table::AlterTableRequest request;
             UNIT_ASSERT(::google::protobuf::TextFormat::ParseFromString(R"(
                 path: "/Root/TheTable"
@@ -292,7 +297,7 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
             operation.result().UnpackTo(&result);
 
             auto partitioning = result.partitioning_settings().ShortDebugString();
-            UNIT_ASSERT_STRINGS_EQUAL(partitioning, 
+            UNIT_ASSERT_STRINGS_EQUAL(partitioning,
                 "partitioning_by_size: DISABLED "
                 "partitioning_by_load: ENABLED "
                 "min_partitions_count: 5"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
1. Filled db names in remained SchemeCache requests
2. Deleted filling db name in GRPC requests with default values
3. Deleted unnecessary CanonizePath calls for db names

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
