### PR TITLE
Solomon data source: change solomon api methods from `get` to `post`

### DIFF
--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_config.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_config.cpp
@@ -8,10 +8,10 @@ TSolomonConfiguration::TSolomonConfiguration()
 {
     REGISTER_SETTING(*this, _EnableReading);
     REGISTER_SETTING(*this, _EnableRuntimeListing);
+    REGISTER_SETTING(*this, _EnableSolomonClientPostApi);
     REGISTER_SETTING(*this, _TruePointsFindRange);
     REGISTER_SETTING(*this, _MaxListingPageSize);
     REGISTER_SETTING(*this, MetricsQueueBatchCountLimit);
-    REGISTER_SETTING(*this, SolomonClientDefaultReplica);
     REGISTER_SETTING(*this, ComputeActorBatchSize);
     REGISTER_SETTING(*this, MaxApiInflight);
 }

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_config.h
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_config.h
@@ -14,10 +14,10 @@ private:
 public:
     NCommon::TConfSetting<bool, Static> _EnableReading;
     NCommon::TConfSetting<bool, Static> _EnableRuntimeListing;
+    NCommon::TConfSetting<bool, Static> _EnableSolomonClientPostApi;
     NCommon::TConfSetting<ui64, Static> _TruePointsFindRange;
     NCommon::TConfSetting<ui64, Static> _MaxListingPageSize;
     NCommon::TConfSetting<ui64, Static> MetricsQueueBatchCountLimit;
-    NCommon::TConfSetting<TString, Static> SolomonClientDefaultReplica;
     NCommon::TConfSetting<ui64, Static> ComputeActorBatchSize;
     NCommon::TConfSetting<ui64, Static> MaxApiInflight;
 };

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_dq_integration.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_dq_integration.cpp
@@ -368,16 +368,14 @@ public:
             source.AddRequiredLabelNames(labelAsString);
         }
 
-        auto defaultReplica = (source.GetClusterType() == NSo::NProto::CT_SOLOMON ? "sas" : "cloud-prod-a");
-
         auto& solomonConfig = State_->Configuration;
         auto& sourceSettings = *source.MutableSettings();
 
         auto metricsQueueBatchCountLimit = solomonConfig->MetricsQueueBatchCountLimit.Get().OrElse(500);
         sourceSettings.insert({"metricsQueueBatchCountLimit", ToString(metricsQueueBatchCountLimit)});
 
-        auto solomonClientDefaultReplica = solomonConfig->SolomonClientDefaultReplica.Get().OrElse(defaultReplica);
-        sourceSettings.insert({"solomonClientDefaultReplica", ToString(solomonClientDefaultReplica)});
+        auto enableSolomonClientPostApi = solomonConfig->_EnableSolomonClientPostApi.Get().OrElse(false);
+        sourceSettings.insert({"enableSolomonClientPostApi", ToString(enableSolomonClientPostApi)});
 
         auto computeActorBatchSize = solomonConfig->ComputeActorBatchSize.Get().OrElse(100);
         sourceSettings.insert({"computeActorBatchSize", ToString(computeActorBatchSize)});

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_load_meta.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_load_meta.cpp
@@ -93,10 +93,6 @@ public:
                     return TStatus::Error;
                 }
 
-                auto defaultReplica = (source.GetClusterType() == NSo::NProto::CT_SOLOMON ? "sas" : "cloud-prod-a");
-                auto solomonClientDefaultReplica = State_->Configuration->SolomonClientDefaultReplica.Get().OrElse(defaultReplica);
-                source.MutableSettings()->insert({ "solomonClientDefaultReplica", ToString(solomonClientDefaultReplica) });
-
                 auto providerFactory = CreateCredentialsProviderFactoryForStructuredToken(State_->CredentialsFactory, State_->Configuration->Tokens.at(clusterName));
                 auto credentialsProvider = providerFactory->CreateProvider();
 

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_load_meta.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_load_meta.cpp
@@ -93,6 +93,9 @@ public:
                     return TStatus::Error;
                 }
 
+                auto enableSolomonClientPostApi = State_->Configuration->_EnableSolomonClientPostApi.Get().OrElse(false);
+                source.MutableSettings()->insert({ "enableSolomonClientPostApi", ToString(enableSolomonClientPostApi) });
+
                 auto providerFactory = CreateCredentialsProviderFactoryForStructuredToken(State_->CredentialsFactory, State_->Configuration->Tokens.at(clusterName));
                 auto credentialsProvider = providerFactory->CreateProvider();
 

--- a/ydb/library/yql/providers/solomon/solomon_accessor/client/solomon_accessor_client.cpp
+++ b/ydb/library/yql/providers/solomon/solomon_accessor/client/solomon_accessor_client.cpp
@@ -728,7 +728,7 @@ private:
     }
 
 private:
-    const bool EnableSolomonClientPostApi = false;
+    const bool EnableSolomonClientPostApi;
     const ui64 MaxListingPageSize;
     const ui64 ListSizeLimit = 100 * 1024 * 1024 * 8;
     const NYql::NSo::NProto::TDqSolomonSource Settings;

--- a/ydb/library/yql/tools/solomon_emulator/lib/webapp.py
+++ b/ydb/library/yql/tools/solomon_emulator/lib/webapp.py
@@ -110,7 +110,8 @@ class SolomonEmulator(object):
         return web.json_response({"writtenMetricsCount": shard.add_metrics(metrics_json)})
 
     async def sensor_names(self, request):
-        selectors, success = _parse_selectors(request.rel_url.query["selectors"])
+        json = await request.json() 
+        selectors, success = _parse_selectors(json["selectors"])
 
         if not success:
             return web.HTTPBadRequest(text="Invalid selectors")
@@ -128,7 +129,8 @@ class SolomonEmulator(object):
         return web.json_response({"names": result})
 
     async def sensor_labels(self, request):
-        selectors, success = _parse_selectors(request.rel_url.query["selectors"])
+        json = await request.json() 
+        selectors, success = _parse_selectors(json["selectors"])
 
         if not success:
             return web.HTTPBadRequest(text="Invalid selectors")
@@ -146,7 +148,8 @@ class SolomonEmulator(object):
         return web.json_response({"labels": labels, "totalCount": totalCount})
 
     async def sensors(self, request):
-        selectors, success = _parse_selectors(request.rel_url.query["selectors"])
+        json = await request.json() 
+        selectors, success = _parse_selectors(json["selectors"])
 
         if not success:
             return web.HTTPBadRequest(text="Invalid selectors")
@@ -311,9 +314,9 @@ class DataService(DataServiceServicer):
 def create_web_app(emulator):
     webapp = web.Application(client_max_size=1024**3, handler_args={"max_line_size": 1024**3, "max_field_size": 1024**3})
     webapp.add_routes([
-        web.get("/api/v2/projects/{project}/sensors/names", emulator.sensor_names),
-        web.get("/api/v2/projects/{project}/sensors/labels", emulator.sensor_labels),
-        web.get("/api/v2/projects/{project}/sensors", emulator.sensors),
+        web.post("/api/v2/projects/{project}/sensors/names", emulator.sensor_names),
+        web.post("/api/v2/projects/{project}/sensors/labels", emulator.sensor_labels),
+        web.post("/api/v2/projects/{project}/sensors", emulator.sensors),
         web.get("/metrics/get", emulator.metrics_get),
         web.get("/ping", emulator.get_ping),
         web.post("/api/v2/push", emulator.api_v2_push),

--- a/ydb/library/yql/tools/solomon_emulator/lib/webapp.py
+++ b/ydb/library/yql/tools/solomon_emulator/lib/webapp.py
@@ -110,7 +110,7 @@ class SolomonEmulator(object):
         return web.json_response({"writtenMetricsCount": shard.add_metrics(metrics_json)})
 
     async def sensor_names(self, request):
-        json = await request.json() 
+        json = await request.json()
         selectors, success = _parse_selectors(json["selectors"])
 
         if not success:
@@ -129,7 +129,7 @@ class SolomonEmulator(object):
         return web.json_response({"names": result})
 
     async def sensor_labels(self, request):
-        json = await request.json() 
+        json = await request.json()
         selectors, success = _parse_selectors(json["selectors"])
 
         if not success:
@@ -148,7 +148,7 @@ class SolomonEmulator(object):
         return web.json_response({"labels": labels, "totalCount": totalCount})
 
     async def sensors(self, request):
-        json = await request.json() 
+        json = await request.json()
         selectors, success = _parse_selectors(json["selectors"])
 
         if not success:

--- a/ydb/library/yql/tools/solomon_emulator/lib/webapp.py
+++ b/ydb/library/yql/tools/solomon_emulator/lib/webapp.py
@@ -312,7 +312,7 @@ class DataService(DataServiceServicer):
 
 
 def create_web_app(emulator):
-    webapp = web.Application(client_max_size=1024**3, handler_args={"max_line_size": 1024**3, "max_field_size": 1024**3})
+    webapp = web.Application()
     webapp.add_routes([
         web.post("/api/v2/projects/{project}/sensors/names", emulator.sensor_names),
         web.post("/api/v2/projects/{project}/sensors/labels", emulator.sensor_labels),

--- a/ydb/tests/solomon/reading/base.py
+++ b/ydb/tests/solomon/reading/base.py
@@ -73,6 +73,10 @@ class SolomonReadingTestBase(object):
                     "value": "true"
                 },
                 {
+                    "name": "_EnableSolomonClientPostApi",
+                    "value": "true"
+                },
+                {
                     "name": "_MaxListingPageSize",
                     "value": 1000
                 },


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TSolomonAccessorClient теперь использует post версии всех ручек соломон апи
