### PR TITLE
[ICRDMA] Temporary disable verbs device scan and ut

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -3035,7 +3035,7 @@ Y_UNIT_TEST_SUITE(TPDiskPrefailureDiskTest) {
         pdt.Run();
     }
 }
-
+/*
 Y_UNIT_TEST_SUITE(RDMA) {
     void TestChunkReadWithRdmaAllocator(bool plainDataChunks) {
         TActorTestContext testCtx({
@@ -3117,5 +3117,5 @@ Y_UNIT_TEST_SUITE(RDMA) {
         buf2.RawDataPtr(0, totalSize);
     }
 }
-
+*/
 } // namespace NKikimr

--- a/ydb/core/blobstorage/ut_blobstorage/get.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/get.cpp
@@ -111,7 +111,7 @@ Y_UNIT_TEST_SUITE(Get) {
         SendGet(test, originalBlobId, data, NKikimrProto::BLOCKED, TEvBlobStorage::TEvGet::TReaderTabletData(tabletId, tabletGeneration));
     }
 
-    Y_UNIT_TEST(TestRdmaRegiseredMemory) {
+/*    Y_UNIT_TEST(TestRdmaRegiseredMemory) {
         TEnvironmentSetup env(true);
         TTestInfo test = InitTest(env);
 
@@ -160,4 +160,5 @@ Y_UNIT_TEST_SUITE(Get) {
 
         SendGet(test, originalBlobId, data, NKikimrProto::OK, TEvBlobStorage::TEvGet::TReaderTabletData(tabletId, tabletGeneration));
     }
+*/
 }

--- a/ydb/library/actors/interconnect/rdma/link_manager.cpp
+++ b/ydb/library/actors/interconnect/rdma/link_manager.cpp
@@ -59,7 +59,6 @@ public:
         } catch (std::exception& ex) {
             return;
         }
-        ScanDevices();
     }
 private:
     TCtxsMap CtxMap;

--- a/ydb/library/actors/interconnect/rdma/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ya.make
@@ -35,6 +35,6 @@ RECURSE(
     cq_actor
 )
 
-RECURSE_FOR_TESTS(
-    ut
-)
+#RECURSE_FOR_TESTS(
+#    ut
+#)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

[ICRDMA] Temporary disable verbs device scan and ut

The scan during static global initialisation is wrong due to msan errors for whole project. 

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
