### PR TITLE
[q-stable-ydb-25-1] Solomon data source: change solomon api methods from get to post

### DIFF
--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_config.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_config.cpp
@@ -8,10 +8,10 @@ TSolomonConfiguration::TSolomonConfiguration()
 {
     REGISTER_SETTING(*this, _EnableReading);
     REGISTER_SETTING(*this, _EnableRuntimeListing);
+    REGISTER_SETTING(*this, _EnableSolomonClientPostApi);
     REGISTER_SETTING(*this, _TruePointsFindRange);
     REGISTER_SETTING(*this, _MaxListingPageSize);
     REGISTER_SETTING(*this, MetricsQueueBatchCountLimit);
-    REGISTER_SETTING(*this, SolomonClientDefaultReplica);
     REGISTER_SETTING(*this, ComputeActorBatchSize);
     REGISTER_SETTING(*this, MaxApiInflight);
 }

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_config.h
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_config.h
@@ -12,10 +12,10 @@ struct TSolomonSettings {
 
     NCommon::TConfSetting<bool, false> _EnableReading;
     NCommon::TConfSetting<bool, false> _EnableRuntimeListing;
+    NCommon::TConfSetting<bool, false> _EnableSolomonClientPostApi;
     NCommon::TConfSetting<ui64, false> _TruePointsFindRange;
     NCommon::TConfSetting<ui64, false> _MaxListingPageSize;
     NCommon::TConfSetting<ui64, false> MetricsQueueBatchCountLimit;
-    NCommon::TConfSetting<TString, false> SolomonClientDefaultReplica;
     NCommon::TConfSetting<ui64, false> ComputeActorBatchSize;
     NCommon::TConfSetting<ui64, false> MaxApiInflight;
 };

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_dq_integration.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_dq_integration.cpp
@@ -349,16 +349,14 @@ public:
             source.AddRequiredLabelNames(labelAsString);
         }
 
-        auto defaultReplica = (source.GetClusterType() == NSo::NProto::CT_SOLOMON ? "sas" : "cloud-prod-a");
-
         auto& solomonConfig = State_->Configuration;
         auto& sourceSettings = *source.MutableSettings();
 
         auto metricsQueueBatchCountLimit = solomonConfig->MetricsQueueBatchCountLimit.Get().OrElse(500);
         sourceSettings.insert({"metricsQueueBatchCountLimit", ToString(metricsQueueBatchCountLimit)});
 
-        auto solomonClientDefaultReplica = solomonConfig->SolomonClientDefaultReplica.Get().OrElse(defaultReplica);
-        sourceSettings.insert({"solomonClientDefaultReplica", ToString(solomonClientDefaultReplica)});
+        auto enableSolomonClientPostApi = solomonConfig->_EnableSolomonClientPostApi.Get().OrElse(false);
+        sourceSettings.insert({"enableSolomonClientPostApi", ToString(enableSolomonClientPostApi)});
 
         auto computeActorBatchSize = solomonConfig->ComputeActorBatchSize.Get().OrElse(100);
         sourceSettings.insert({"computeActorBatchSize", ToString(computeActorBatchSize)});

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_load_meta.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_load_meta.cpp
@@ -93,9 +93,8 @@ public:
                     return TStatus::Error;
                 }
 
-                auto defaultReplica = (source.GetClusterType() == NSo::NProto::CT_SOLOMON ? "sas" : "cloud-prod-a");
-                auto solomonClientDefaultReplica = State_->Configuration->SolomonClientDefaultReplica.Get().OrElse(defaultReplica);
-                source.MutableSettings()->insert({ "solomonClientDefaultReplica", ToString(solomonClientDefaultReplica) });
+                auto enableSolomonClientPostApi = State_->Configuration->_EnableSolomonClientPostApi.Get().OrElse(false);
+                source.MutableSettings()->insert({ "enableSolomonClientPostApi", ToString(enableSolomonClientPostApi) });
 
                 auto providerFactory = CreateCredentialsProviderFactoryForStructuredToken(State_->CredentialsFactory, State_->Configuration->Tokens.at(clusterName));
                 auto credentialsProvider = providerFactory->CreateProvider();

--- a/ydb/library/yql/providers/solomon/solomon_accessor/client/solomon_accessor_client.cpp
+++ b/ydb/library/yql/providers/solomon/solomon_accessor/client/solomon_accessor_client.cpp
@@ -302,12 +302,12 @@ TGetDataResponse ProcessGetDataResponse(NYdbGrpc::TGrpcStatus&& status, ReadResp
 class TSolomonAccessorClient : public ISolomonAccessorClient, public std::enable_shared_from_this<TSolomonAccessorClient> {
 public:
     TSolomonAccessorClient(
-        const TString& defaultReplica,
+        bool enableSolomonClientPostApi,
         ui64 maxListingPageSize,
         ui64 maxApiInflight,
         NYql::NSo::NProto::TDqSolomonSource&& settings,
         std::shared_ptr<NYdb::ICredentialsProvider> credentialsProvider)
-        : DefaultReplica(defaultReplica)
+        : EnableSolomonClientPostApi(enableSolomonClientPostApi)
         , MaxListingPageSize(maxListingPageSize)
         , Settings(std::move(settings))
         , CredentialsProvider(credentialsProvider) {
@@ -327,7 +327,7 @@ public:
 
 public:
     NThreading::TFuture<TGetLabelsResponse> GetLabelNames(const TSelectors& selectors, TInstant from, TInstant to) const override final {
-        auto url = BuildGetLabelsUrl(selectors, from, to);
+        auto [url, body] = BuildGetLabelsHttpParams(selectors, from, to);
 
         auto resultPromise = NThreading::NewPromise<TGetLabelsResponse>();
         
@@ -337,7 +337,8 @@ public:
 
         DoHttpRequest(
             std::move(cb),
-            std::move(url)
+            std::move(url),
+            std::move(body)
         );
 
         return resultPromise.GetFuture();
@@ -546,7 +547,7 @@ private:
         }
     }
 
-    TString BuildGetLabelsUrl(const TSelectors& selectors, TInstant from, TInstant to) const {
+    std::tuple<TString, TString> BuildGetLabelsHttpParams(const TSelectors& selectors, TInstant from, TInstant to) const {
         TUrlBuilder builder(GetHttpSolomonEndpoint());
 
         builder.AddPathComponent("api");
@@ -556,12 +557,23 @@ private:
         builder.AddPathComponent("sensors");
         builder.AddPathComponent("names");
 
-        builder.AddUrlParam("projectId", GetProjectId());
-        builder.AddUrlParam("selectors", BuildSelectorsProgram(selectors));
-        builder.AddUrlParam("from", from.ToString());
-        builder.AddUrlParam("to", to.ToString());
+        NJsonWriter::TBuf w;
 
-        return builder.Build();
+        if (EnableSolomonClientPostApi) {
+            w.BeginObject()
+                .UnsafeWriteKey("projectId").WriteString(GetProjectId())
+                .UnsafeWriteKey("selectors").WriteString(BuildSelectorsProgram(selectors))
+                .UnsafeWriteKey("from").WriteString(from.ToString())
+                .UnsafeWriteKey("to").WriteString(to.ToString())
+            .EndObject();
+        } else {
+            builder.AddUrlParam("projectId", GetProjectId());
+            builder.AddUrlParam("selectors", BuildSelectorsProgram(selectors));
+            builder.AddUrlParam("from", from.ToString());
+            builder.AddUrlParam("to", to.ToString());
+        }
+
+        return { builder.Build(), w.Str() };
     }
 
     std::tuple<TString, TString> BuildListMetricsHttpParams(const TSelectors& selectors, TInstant from, TInstant to) const {
@@ -573,13 +585,25 @@ private:
         builder.AddPathComponent(Settings.GetProject());
         builder.AddPathComponent("sensors");
 
-        builder.AddUrlParam("projectId", GetProjectId());
-        builder.AddUrlParam("selectors", BuildSelectorsProgram(selectors));
-        builder.AddUrlParam("from", from.ToString());
-        builder.AddUrlParam("to", to.ToString());
-        builder.AddUrlParam("pageSize", ToString(MaxListingPageSize));
+        NJsonWriter::TBuf w;
 
-        return { builder.Build(), "" };
+        if (EnableSolomonClientPostApi) {
+            w.BeginObject()
+                .UnsafeWriteKey("projectId").WriteString(GetProjectId())
+                .UnsafeWriteKey("selectors").WriteString(BuildSelectorsProgram(selectors))
+                .UnsafeWriteKey("from").WriteString(from.ToString())
+                .UnsafeWriteKey("to").WriteString(to.ToString())
+                .UnsafeWriteKey("pageSize").WriteLongLong(MaxListingPageSize)
+            .EndObject();
+        } else {
+            builder.AddUrlParam("projectId", GetProjectId());
+            builder.AddUrlParam("selectors", BuildSelectorsProgram(selectors));
+            builder.AddUrlParam("from", from.ToString());
+            builder.AddUrlParam("to", to.ToString());
+            builder.AddUrlParam("pageSize", ToString(MaxListingPageSize));
+        }
+
+        return { builder.Build(), w.Str() };
     }
 
     std::tuple<TString, TString> BuildListMetricsLabelsHttpParams(const TSelectors& selectors, TInstant from, TInstant to) const {
@@ -592,13 +616,25 @@ private:
         builder.AddPathComponent("sensors");
         builder.AddPathComponent("labels");
 
-        builder.AddUrlParam("projectId", GetProjectId());
-        builder.AddUrlParam("selectors", BuildSelectorsProgram(selectors));
-        builder.AddUrlParam("from", from.ToString());
-        builder.AddUrlParam("to", to.ToString());
-        builder.AddUrlParam("limit", "100000");
+        NJsonWriter::TBuf w;
 
-        return { builder.Build(), "" };
+        if (EnableSolomonClientPostApi) {
+            w.BeginObject()
+                .UnsafeWriteKey("projectId").WriteString(GetProjectId())
+                .UnsafeWriteKey("selectors").WriteString(BuildSelectorsProgram(selectors))
+                .UnsafeWriteKey("from").WriteString(from.ToString())
+                .UnsafeWriteKey("to").WriteString(to.ToString())
+                .UnsafeWriteKey("limit").WriteLongLong(100000)
+            .EndObject();
+        } else {
+            builder.AddUrlParam("projectId", GetProjectId());
+            builder.AddUrlParam("selectors", BuildSelectorsProgram(selectors));
+            builder.AddUrlParam("from", from.ToString());
+            builder.AddUrlParam("to", to.ToString());
+            builder.AddUrlParam("limit", "100000");
+        }
+
+        return { builder.Build(), w.Str() };
     }
 
     std::tuple<TString, TString> BuildGetPointsCountHttpParams(const TString& program, TInstant from, TInstant to) const {
@@ -692,7 +728,7 @@ private:
     }
 
 private:
-    const TString DefaultReplica;
+    const bool EnableSolomonClientPostApi;
     const ui64 MaxListingPageSize;
     const ui64 ListSizeLimit = 100 * 1024 * 1024 * 8;
     const NYql::NSo::NProto::TDqSolomonSource Settings;
@@ -713,9 +749,9 @@ ISolomonAccessorClient::Make(
     std::shared_ptr<NYdb::ICredentialsProvider> credentialsProvider) {
     const auto& settings = source.settings();
 
-    TString defaultReplica;
-    if (auto it = settings.find("solomonClientDefaultReplica"); it != settings.end()) {
-        defaultReplica = it->second;
+    bool enableSolomonClientPostApi = false;
+    if (auto it = settings.find("enableSolomonClientPostApi"); it != settings.end()) {
+        enableSolomonClientPostApi = FromString<bool>(it->second);
     }
 
     ui64 maxListingPageSize = 20000;
@@ -728,7 +764,7 @@ ISolomonAccessorClient::Make(
         maxApiInflight = FromString<ui64>(it->second);
     }
 
-    return std::make_shared<TSolomonAccessorClient>(defaultReplica, maxListingPageSize, maxApiInflight, std::move(source), credentialsProvider);
+    return std::make_shared<TSolomonAccessorClient>(enableSolomonClientPostApi, maxListingPageSize, maxApiInflight, std::move(source), credentialsProvider);
 }
 
 } // namespace NYql::NSo

--- a/ydb/library/yql/tools/solomon_emulator/lib/webapp.py
+++ b/ydb/library/yql/tools/solomon_emulator/lib/webapp.py
@@ -110,7 +110,8 @@ class SolomonEmulator(object):
         return web.json_response({"writtenMetricsCount": shard.add_metrics(metrics_json)})
 
     async def sensor_names(self, request):
-        selectors, success = _parse_selectors(request.rel_url.query["selectors"])
+        json = await request.json()
+        selectors, success = _parse_selectors(json["selectors"])
 
         if not success:
             return web.HTTPBadRequest(text="Invalid selectors")
@@ -128,7 +129,8 @@ class SolomonEmulator(object):
         return web.json_response({"names": result})
 
     async def sensor_labels(self, request):
-        selectors, success = _parse_selectors(request.rel_url.query["selectors"])
+        json = await request.json()
+        selectors, success = _parse_selectors(json["selectors"])
 
         if not success:
             return web.HTTPBadRequest(text="Invalid selectors")
@@ -146,7 +148,8 @@ class SolomonEmulator(object):
         return web.json_response({"labels": labels, "totalCount": totalCount})
 
     async def sensors(self, request):
-        selectors, success = _parse_selectors(request.rel_url.query["selectors"])
+        json = await request.json()
+        selectors, success = _parse_selectors(json["selectors"])
 
         if not success:
             return web.HTTPBadRequest(text="Invalid selectors")
@@ -309,11 +312,11 @@ class DataService(DataServiceServicer):
 
 
 def create_web_app(emulator):
-    webapp = web.Application(client_max_size=1024**3, handler_args={"max_line_size": 1024**3, "max_field_size": 1024**3})
+    webapp = web.Application()
     webapp.add_routes([
-        web.get("/api/v2/projects/{project}/sensors/names", emulator.sensor_names),
-        web.get("/api/v2/projects/{project}/sensors/labels", emulator.sensor_labels),
-        web.get("/api/v2/projects/{project}/sensors", emulator.sensors),
+        web.post("/api/v2/projects/{project}/sensors/names", emulator.sensor_names),
+        web.post("/api/v2/projects/{project}/sensors/labels", emulator.sensor_labels),
+        web.post("/api/v2/projects/{project}/sensors", emulator.sensors),
         web.get("/metrics/get", emulator.metrics_get),
         web.get("/ping", emulator.get_ping),
         web.post("/api/v2/push", emulator.api_v2_push),

--- a/ydb/tests/solomon/reading/base.py
+++ b/ydb/tests/solomon/reading/base.py
@@ -73,6 +73,10 @@ class SolomonReadingTestBase(object):
                     "value": "true"
                 },
                 {
+                    "name": "_EnableSolomonClientPostApi",
+                    "value": "true"
+                },
+                {
                     "name": "_MaxListingPageSize",
                     "value": 1000
                 },


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TSolomonAccessorClient теперь использует post версии всех ручек соломон апи
