### PR TITLE
Relaxed config quorum for distconf

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_common.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_common.cpp
@@ -239,7 +239,7 @@ namespace NKikimr::NStorage {
     void TInvokeRequestHandlerActor::StartProposition(NKikimrBlobStorage::TStorageConfig *config, bool acceptLocalQuorum,
             bool requireScepter, bool mindPrev, const NKikimrBlobStorage::TStorageConfig *propositionBase,
             bool fromBootstrap) {
-        if (!Self->HasConnectedNodeQuorum(mindPrev && config->HasPrevConfig() ? config->GetPrevConfig() : *config, acceptLocalQuorum)) {
+        if (!Self->HasConnectedNodeQuorum(*config, acceptLocalQuorum)) {
             throw TExError() << "No quorum to start propose/commit configuration";
         } else if (requireScepter && !Self->Scepter) {
             throw TExError() << "No scepter";

--- a/ydb/core/blobstorage/nodewarden/distconf_quorum.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_quorum.h
@@ -9,17 +9,10 @@ namespace NKikimr::NStorage {
             const THashSet<TBridgePileId>& pileIdQuorumOverride);
 
     bool HasNodeQuorum(const NKikimrBlobStorage::TStorageConfig& config, std::span<TNodeIdentifier> successful,
-        const THashMap<TString, TBridgePileId>& bridgePileNameMap, TBridgePileId singleBridgePileId, TStringStream *out);
+        const THashMap<TString, TBridgePileId>& bridgePileNameMap, TBridgePileId singleBridgePileId,
+        const TNodeWardenConfig& nwConfig, TStringStream *out, bool allowConfigQuorum = false);
 
     using TSuccessfulDisk = std::tuple<TNodeIdentifier, TString, std::optional<ui64>>;
-
-    bool HasDiskQuorum(const NKikimrBlobStorage::TStorageConfig& config, std::span<TSuccessfulDisk> successful,
-        const THashMap<TString, TBridgePileId>& bridgePileNameMap, TBridgePileId singleBridgePileId, IOutputStream *out,
-        const char *name);
-
-    std::optional<bool> HasStorageQuorum(const NKikimrBlobStorage::TStorageConfig& config, std::span<TSuccessfulDisk> successful,
-        const THashMap<TString, TBridgePileId>& bridgePileNameMap, TBridgePileId singleBridgePileId,
-        const TNodeWardenConfig& nwConfig, bool allowUnformatted, IOutputStream *out, const char *name);
 
     // Ensure configuration has quorum in both disk and storage ways for current and previous configuration.
     bool HasConfigQuorum(const NKikimrBlobStorage::TStorageConfig& config, std::span<TSuccessfulDisk> successful,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Relaxed config quorum for distconf

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch changes the way distconf calculates quorum for scepter operations: now it is based on static groups too.
