### PR TITLE
[ICRDMA] Disable rdma allocator for testruntime in case of msan

### DIFF
--- a/ydb/core/util/actorsys_test/testactorsys.h
+++ b/ydb/core/util/actorsys_test/testactorsys.h
@@ -290,8 +290,10 @@ public:
         setup->Executors.Reset(new TAutoPtr<IExecutorPool>[setup->ExecutorsCount]);
         IExecutorPool *pool = CreateTestExecutorPool(nodeId);
         setup->Executors[0].Reset(pool);
+#if !defined(_msan_enabled_)
         auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
         setup->RcBufAllocator = std::make_shared<TRdmaAllocatorWithFallback>(memPool);
+#endif
 
         // we create this actor for correct service lookup through ActorSystem
         setup->LocalServices.emplace_back(LoggerSettings_->LoggerActorId, TActorSetupCmd(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Do not use rdma allocator for testrintime in case of msan

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
