### PR TITLE
[NEW RBO] Added support for scalar context

### DIFF
--- a/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
+++ b/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
@@ -926,6 +926,14 @@
                 {"Index": 1, "Name": "AggregationTraitsList", "Type": "TKqpOpAggregationTraitsList"},
                 {"Index": 2, "Name": "KeyColumns", "Type": "TCoAtomList"}
             ]
+        },
+        {
+            "Name": "TKqpPgExprSublink",
+            "Base": "TExprBase",
+            "Match" : {"Type": "Callable", "Name": "KqpPgExprSublink"},
+            "Children": [
+                {"Index": 0, "Name": "Expr", "Type": "TExprBase"}
+            ]
         }
     ]
 }

--- a/ydb/core/kqp/opt/rbo/kqp_convert_to_physical.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_convert_to_physical.cpp
@@ -165,27 +165,31 @@ TExprNode::TPtr BuildCrossJoin(TOpJoin &join, TExprNode::TPtr leftInput, TExprNo
 
     TVector<TExprNode::TPtr> keys;
     for (auto iu : join.GetLeftInput()->GetOutputIUs()) {
-        // clang-format off
-                auto keyPtr = Build<TCoNameValueTuple>(ctx, pos)
-                    .Name().Build(iu.GetFullName())
-                    .Value<TCoMember>()
-                        .Struct(leftArg)
-                        .Name().Build(iu.GetFullName())
-                    .Build()
-                .Done().Ptr();
-                // clang-forat on
-                keys.push_back(keyPtr);
-            }
+        YQL_CLOG(TRACE, CoreDq) << "Converting Cross Join, left key: " << iu.GetFullName();
 
-            for (auto iu : join.GetRightInput()->GetOutputIUs()) {
-                // clang-format off
-                auto keyPtr = Build<TCoNameValueTuple>(ctx, pos)
-                    .Name().Build(iu.GetFullName())
-                    .Value<TCoMember>()
-                    .Struct(rightArg)
-                        .Name().Build(iu.GetFullName())
-                    .Build()
-                .Done().Ptr();
+        // clang-format off
+        auto keyPtr = Build<TCoNameValueTuple>(ctx, pos)
+            .Name().Build(iu.GetFullName())
+            .Value<TCoMember>()
+                .Struct(leftArg)
+                .Name().Build(iu.GetFullName())
+            .Build()
+            .Done().Ptr();
+        // clang-format on
+        keys.push_back(keyPtr);
+    }
+
+    for (auto iu : join.GetRightInput()->GetOutputIUs()) {
+        YQL_CLOG(TRACE, CoreDq) << "Converting Cross Join, right key: " << iu.GetFullName();
+
+        // clang-format off
+        auto keyPtr = Build<TCoNameValueTuple>(ctx, pos)
+            .Name().Build(iu.GetFullName())
+            .Value<TCoMember>()
+                .Struct(rightArg)
+                .Name().Build(iu.GetFullName())
+            .Build()
+            .Done().Ptr();
         // clang-format on
         keys.push_back(keyPtr);
     }
@@ -193,58 +197,58 @@ TExprNode::TPtr BuildCrossJoin(TOpJoin &join, TExprNode::TPtr leftInput, TExprNo
     // clang-format off
     // We have to `Condense` right input as single-element stream of lists (single list of all elements from the right),
     // because stream supports single iteration only
-            auto itemArg = Build<TCoArgument>(ctx, pos).Name("item").Done();
-            auto rightAsStreamOfLists = Build<TCoCondense1>(ctx, pos)
-                .Input<TCoToFlow>()
-                    .Input(rightInput)
-                    .Build()
-                .InitHandler()
-                    .Args({itemArg})
-                    .Body<TCoAsList>()
-                        .Add(itemArg)
-                        .Build()
-                    .Build()
-                .SwitchHandler()
-                    .Args({"item", "state"})
-                    .Body<TCoBool>()
-                        .Literal().Build("false")
-                        .Build()
-                    .Build()
-                .UpdateHandler()
-                    .Args({"item", "state"})
-                    .Body<TCoAppend>()
-                        .List("state")
-                        .Item("item")
-                    .Build()
+    auto itemArg = Build<TCoArgument>(ctx, pos).Name("item").Done();
+    auto rightAsStreamOfLists = Build<TCoCondense1>(ctx, pos)
+        .Input<TCoToFlow>()
+            .Input(rightInput)
+            .Build()
+        .InitHandler()
+            .Args({itemArg})
+            .Body<TCoAsList>()
+                .Add(itemArg)
                 .Build()
-            .Done();
+            .Build()
+        .SwitchHandler()
+            .Args({"item", "state"})
+            .Body<TCoBool>()
+                .Literal().Build("false")
+                .Build()
+            .Build()
+        .UpdateHandler()
+            .Args({"item", "state"})
+            .Body<TCoAppend>()
+                .List("state")
+                .Item("item")
+            .Build()
+        .Build()
+    .Done();
 
-            auto flatMap = Build<TCoFlatMap>(ctx, pos)
-                .Input(rightAsStreamOfLists)
+    auto flatMap = Build<TCoFlatMap>(ctx, pos)
+        .Input(rightAsStreamOfLists)
+        .Lambda()
+            .Args({"rightAsList"})
+            .Body<TCoFlatMap>()
+                .Input(leftInput)
                 .Lambda()
-                    .Args({"rightAsList"})
-                    .Body<TCoFlatMap>()
-                        .Input(leftInput)
+                    .Args({leftArg})
+                    .Body<TCoMap>()
+                        // here we have `List`, so we can iterate over it many times (for every `leftArg`)
+                        .Input("rightAsList")
                         .Lambda()
-                            .Args({leftArg})
-                            .Body<TCoMap>()
-                                // here we have `List`, so we can iterate over it many times (for every `leftArg`)
-                                .Input("rightAsList")
-                                .Lambda()
-                                    .Args({rightArg})
-                                    .Body<TCoAsStruct>()
-                                        .Add(keys)
-                                    .Build()
-                                .Build()
+                            .Args({rightArg})
+                            .Body<TCoAsStruct>()
+                                .Add(keys)
                             .Build()
                         .Build()
                     .Build()
                 .Build()
-            .Done().Ptr();
+            .Build()
+        .Build()
+    .Done().Ptr();
 
-            return Build<TCoFromFlow>(ctx, pos)
-                .Input(flatMap)
-            .Done().Ptr();
+    return Build<TCoFromFlow>(ctx, pos)
+        .Input(flatMap)
+    .Done().Ptr();
     // clang-format on
 }
 
@@ -1053,11 +1057,20 @@ TExprNode::TPtr ConvertToPhysical(TOpRoot &root, TRBOContext& rboCtx, TAutoPtr<I
             stageArgs[opStageId].push_back(rightArg);
             TVector<TExprNode::TPtr> extendArgs{leftArg, rightArg};
 
-            // clang-format off
-            currentStageBody = Build<TCoExtend>(ctx, op->Pos)
-                .Add(extendArgs)
-            .Done().Ptr();
-            // clang-format on
+            if (unionAll->Ordered) {
+                // clang-format off
+                currentStageBody = Build<TCoOrderedExtend>(ctx, op->Pos)
+                    .Add(extendArgs)
+                .Done().Ptr();
+                // clang-format on
+            }
+            else {
+                // clang-format off
+                currentStageBody = Build<TCoExtend>(ctx, op->Pos)
+                    .Add(extendArgs)
+                .Done().Ptr();
+                // clang-format on
+            }
 
             stages[opStageId] = currentStageBody;
             stagePos[opStageId] = op->Pos;

--- a/ydb/core/kqp/opt/rbo/kqp_operator.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_operator.cpp
@@ -150,9 +150,13 @@ namespace NKqp {
 using namespace NYql;
 using namespace NNodes;
 
+/**
+ * Scan expression and retrieve all members
+ */
 void GetAllMembers(TExprNode::TPtr node, TVector<TInfoUnit> &IUs) {
     if (node->IsCallable("Member")) {
         auto member = TCoMember(node);
+        auto iu = TInfoUnit(member.Name().StringValue());
         IUs.push_back(TInfoUnit(member.Name().StringValue()));
         return;
     }
@@ -162,7 +166,32 @@ void GetAllMembers(TExprNode::TPtr node, TVector<TInfoUnit> &IUs) {
     }
 }
 
-TInfoUnit::TInfoUnit(TString name) {
+/**
+ * Scan expression and retrieve all members while respecting scalar context variables:
+ *   If `withScalarContext` is true - retrieve all members including all scalar context IUs
+ */
+void GetAllMembers(TExprNode::TPtr node, TVector<TInfoUnit> &IUs, TPlanProps& props, bool withScalarContext) {
+    if (node->IsCallable("Member")) {
+        auto member = TCoMember(node);
+        auto iu = TInfoUnit(member.Name().StringValue());
+        if (props.ScalarSubplans.PlanMap.contains(iu)){
+            if (withScalarContext) {
+                iu.ScalarContext = true;
+                IUs.push_back(iu);
+            }
+        }
+        else {
+            IUs.push_back(iu);
+        }
+        return;
+    }
+
+    for (auto c : node->Children()) {
+        GetAllMembers(c, IUs, props, withScalarContext);
+    }
+}
+
+TInfoUnit::TInfoUnit(TString name, bool scalarContext) : ScalarContext(scalarContext) {
     if (auto idx = name.find('.'); idx != TString::npos) {
         Alias = name.substr(0, idx);
         if (Alias.StartsWith("_alias_")) {
@@ -364,6 +393,11 @@ void IOperator::RenameIUs(const THashMap<TInfoUnit, TInfoUnit, TInfoUnit::THashF
     Y_UNUSED(ctx);
 }
 
+const TTypeAnnotationNode* IOperator::GetIUType(TInfoUnit iu) {
+    auto structType = Type->Cast<TListExprType>()->GetItemType()->Cast<TStructExprType>();
+    return structType->FindItemType(iu.GetFullName());
+}
+
 TString TOpEmptySource::ToString(TExprContext& ctx) {
     Y_UNUSED(ctx); 
     return "EmptySource"; 
@@ -419,6 +453,26 @@ TVector<TInfoUnit> TOpMap::GetOutputIUs() {
         res.push_back(k);
     }
 
+    return res;
+}
+
+TVector<TInfoUnit> TOpMap::GetScalarSubplanIUs(TPlanProps& props) {
+    TVector<TInfoUnit> allVars;
+    TVector<TInfoUnit> res;
+
+    for (auto &[ui, body] : MapElements) {
+        if (std::holds_alternative<TExprNode::TPtr>(body)) {
+            auto lambda = std::get<TExprNode::TPtr>(body);
+            auto lambdaBody = TCoLambda(lambda).Body();
+            GetAllMembers(lambdaBody.Ptr(), allVars, props, true);
+        }
+    }
+
+    for ( auto iu : allVars) {
+        if (iu.ScalarContext) {
+            res.push_back(iu);
+        }
+    }
     return res;
 }
 
@@ -539,15 +593,25 @@ void TOpFilter::RenameIUs(const THashMap<TInfoUnit, TInfoUnit, TInfoUnit::THashF
     FilterLambda = RenameMembers(FilterLambda, renameMap, ctx);
 }
 
-TVector<TInfoUnit> TOpFilter::GetFilterIUs() const {
+TVector<TInfoUnit> TOpFilter::GetFilterIUs(TPlanProps& props) const {
     TVector<TInfoUnit> res;
 
     auto lambdaBody = TCoLambda(FilterLambda).Body();
-    GetAllMembers(lambdaBody.Ptr(), res);
+    GetAllMembers(lambdaBody.Ptr(), res, props, true);
     return res;
 }
 
-TConjunctInfo TOpFilter::GetConjunctInfo() const {
+TVector<TInfoUnit> TOpFilter::GetScalarSubplanIUs(TPlanProps& props) {
+    TVector<TInfoUnit> res;
+    for (auto iu : GetFilterIUs(props)) {
+        if (iu.ScalarContext) {
+            res.push_back(iu);
+        }
+    }
+    return res;
+}
+
+TConjunctInfo TOpFilter::GetConjunctInfo(TPlanProps& props) const {
     TConjunctInfo res;
 
     auto lambdaBody = TCoLambda(FilterLambda).Body().Ptr();
@@ -568,27 +632,30 @@ TConjunctInfo TOpFilter::GetConjunctInfo() const {
             if (conjObj->IsCallable("PgResolvedOp") && conjObj->Child(0)->Content() == "=") {
                 auto leftArg = conjObj->Child(2);
                 auto rightArg = conjObj->Child(3);
+                TVector<TInfoUnit> conjIUs;
+                GetAllMembers(conj, conjIUs, props);
 
-                if (!leftArg->IsCallable("Member") || !rightArg->IsCallable("Member")) {
+                if (leftArg->IsCallable("Member") && rightArg->IsCallable("Member") && conjIUs.size() >= 2) {
+                    TVector<TInfoUnit> leftIUs;
+                    TVector<TInfoUnit> rightIUs;
+                    GetAllMembers(leftArg, leftIUs, props);
+                    GetAllMembers(rightArg, rightIUs, props);
+                    res.JoinConditions.push_back(TJoinConditionInfo(conjObj, leftIUs[0], rightIUs[0]));
+                }
+                else {
                     TVector<TInfoUnit> conjIUs;
                     GetAllMembers(conj, conjIUs);
                     res.Filters.push_back(TFilterInfo(conj, conjIUs, fromPg));
-                } else {
-                    TVector<TInfoUnit> leftIUs;
-                    TVector<TInfoUnit> rightIUs;
-                    GetAllMembers(leftArg, leftIUs);
-                    GetAllMembers(rightArg, rightIUs);
-                    res.JoinConditions.push_back(TJoinConditionInfo(conjObj, leftIUs[0], rightIUs[0]));
                 }
             } else {
                 TVector<TInfoUnit> conjIUs;
-                GetAllMembers(conj, conjIUs);
+                GetAllMembers(conj, conjIUs, props);
                 res.Filters.push_back(TFilterInfo(conj, conjIUs, fromPg));
             }
         }
     } else {
         TVector<TInfoUnit> filterIUs;
-        GetAllMembers(lambdaBody, filterIUs);
+        GetAllMembers(lambdaBody, filterIUs, props);
         res.Filters.push_back(TFilterInfo(lambdaBody, filterIUs));
     }
 
@@ -639,15 +706,11 @@ TString TOpJoin::ToString(TExprContext& ctx) {
     return res;
 }
 
-TOpUnionAll::TOpUnionAll(std::shared_ptr<IOperator> leftInput, std::shared_ptr<IOperator> rightInput, TPositionHandle pos)
-    : IBinaryOperator(EOperator::UnionAll, pos, leftInput, rightInput) {}
+TOpUnionAll::TOpUnionAll(std::shared_ptr<IOperator> leftInput, std::shared_ptr<IOperator> rightInput, TPositionHandle pos, bool ordered)
+    : IBinaryOperator(EOperator::UnionAll, pos, leftInput, rightInput), Ordered(ordered) {}
 
 TVector<TInfoUnit> TOpUnionAll::GetOutputIUs() {
-    auto res = GetLeftInput()->GetOutputIUs();
-    auto rightInputIUs = GetRightInput()->GetOutputIUs();
-
-    res.insert(res.end(), rightInputIUs.begin(), rightInputIUs.end());
-    return res;
+    return GetLeftInput()->GetOutputIUs();
 }
 
 TString TOpUnionAll::ToString(TExprContext& ctx) {
@@ -733,6 +796,10 @@ void TOpRoot::ComputeParents() {
     }
     std::shared_ptr<TOpRoot> noParent;
     ComputeParentsRec(GetInput(), noParent);
+
+    for (auto subplan : PlanProps.ScalarSubplans.Get()) {
+        ComputeParentsRec(subplan, noParent);
+    }
 }
 
 TString TOpRoot::ToString(TExprContext& ctx) {

--- a/ydb/core/kqp/opt/rbo/kqp_operator.h
+++ b/ydb/core/kqp/opt/rbo/kqp_operator.h
@@ -22,14 +22,19 @@ enum EAggregationPhase : ui32 {Intermediate, Final};
  * Currently we only record the name and alias of the column, but we will extend it in the future
  */
 struct TInfoUnit {
-    TInfoUnit(TString alias, TString column) : Alias(alias), ColumnName(column) {}
-    TInfoUnit(TString name);
+    TInfoUnit(TString alias, TString column, bool scalarContext=false) : 
+        Alias(alias), 
+        ColumnName(column), 
+        ScalarContext(scalarContext) {}
+
+    TInfoUnit(TString name, bool scalarContext=false);
     TInfoUnit() {}
 
     TString GetFullName() const { return ((Alias != "") ? ("_alias_" + Alias + ".") : "") + ColumnName; }
 
     TString Alias;
     TString ColumnName;
+    bool ScalarContext = false;
 
     bool operator==(const TInfoUnit &other) const { return Alias == other.Alias && ColumnName == other.ColumnName; }
 
@@ -37,11 +42,6 @@ struct TInfoUnit {
         size_t operator()(const TInfoUnit &c) const { return THash<TString>{}(c.Alias) ^ THash<TString>{}(c.ColumnName); }
     };
 };
-
-/**
- * Extract all into units from an expression in YQL
- */
-void GetAllMembers(TExprNode::TPtr node, TVector<TInfoUnit> &IUs);
 
 /**
  * The following structures are used to extract filter information in convenient form from a filter expression
@@ -93,6 +93,7 @@ struct TPhysicalOpProps {
     std::optional<int> StageId;
     std::optional<TString> Algorithm;
     std::optional<TOrderEnforcer> OrderEnforcer;
+    bool EnsureAtMostOne = false;
 };
 
 /**
@@ -200,13 +201,47 @@ struct TStageGraph {
     void TopologicalSort();
 };
 
+class IOperator;
+
+struct TScalarSubplans {
+
+    void Add(TInfoUnit iu, std::shared_ptr<IOperator> op) {
+        OrderedList.push_back(iu);
+        PlanMap[iu] = op;
+    }
+
+    TVector<std::shared_ptr<IOperator>> Get() {
+        TVector<std::shared_ptr<IOperator>> result;
+        for (auto iu : OrderedList) {
+            result.push_back(PlanMap.at(iu));
+        }
+        return result;
+    }
+
+    void Remove(TInfoUnit iu) {
+        std::erase(OrderedList, iu);
+        PlanMap.erase(iu);
+    }
+
+    THashMap<TInfoUnit, std::shared_ptr<IOperator>, TInfoUnit::THashFunction> PlanMap;
+    TVector<TInfoUnit> OrderedList;
+};
+
 /**
  * Global plan properties
  */
 struct TPlanProps {
     TStageGraph StageGraph;
     int InternalVarIdx = 1;
+    TScalarSubplans ScalarSubplans;
 };
+
+
+/**
+ * Extract all into units from an expression in YQL
+ */
+void GetAllMembers(TExprNode::TPtr node, TVector<TInfoUnit> &IUs);
+void GetAllMembers(TExprNode::TPtr node, TVector<TInfoUnit> &IUs, TPlanProps& props, bool withScalarContext=false);
 
 /**
  * Interface for the operator
@@ -227,6 +262,10 @@ class IOperator {
      * TODO: Add caching with the ability to invalidate
      */
     virtual TVector<TInfoUnit> GetOutputIUs() = 0;
+
+    virtual TVector<TInfoUnit> GetScalarSubplanIUs(TPlanProps& props) { Y_UNUSED(props); return {}; }
+
+    const TTypeAnnotationNode* GetIUType(TInfoUnit iu);
 
     /***
      * Rename information units of this operator using a specified mapping
@@ -301,6 +340,8 @@ class TOpMap : public IUnaryOperator {
     TOpMap(std::shared_ptr<IOperator> input, TPositionHandle pos, TVector<std::pair<TInfoUnit, std::variant<TInfoUnit, TExprNode::TPtr>>> mapElements,
            bool project);
     virtual TVector<TInfoUnit> GetOutputIUs() override;
+    virtual TVector<TInfoUnit> GetScalarSubplanIUs(TPlanProps& props) override;
+
     bool HasRenames() const;
     bool HasLambdas() const;
     TVector<std::pair<TInfoUnit, TInfoUnit>> GetRenames() const;
@@ -351,10 +392,11 @@ class TOpFilter : public IUnaryOperator {
   public:
     TOpFilter(std::shared_ptr<IOperator> input, TPositionHandle pos, TExprNode::TPtr filterLambda);
     virtual TVector<TInfoUnit> GetOutputIUs() override;
+    virtual TVector<TInfoUnit> GetScalarSubplanIUs(TPlanProps& props) override;
     virtual TString ToString(TExprContext& ctx) override;
 
-    TVector<TInfoUnit> GetFilterIUs() const;
-    TConjunctInfo GetConjunctInfo() const;
+    TVector<TInfoUnit> GetFilterIUs(TPlanProps& props) const;
+    TConjunctInfo GetConjunctInfo(TPlanProps& props) const;
     void RenameIUs(const THashMap<TInfoUnit, TInfoUnit, TInfoUnit::THashFunction> &renameMap, TExprContext &ctx) override;
 
     TExprNode::TPtr FilterLambda;
@@ -374,9 +416,11 @@ class TOpJoin : public IBinaryOperator {
 
 class TOpUnionAll : public IBinaryOperator {
   public:
-    TOpUnionAll(std::shared_ptr<IOperator> leftArg, std::shared_ptr<IOperator> rightArg, TPositionHandle pos);
+    TOpUnionAll(std::shared_ptr<IOperator> leftArg, std::shared_ptr<IOperator> rightArg, TPositionHandle pos, bool ordered = false);
     virtual TVector<TInfoUnit> GetOutputIUs() override;
     virtual TString ToString(TExprContext& ctx) override;
+
+    bool Ordered;
 };
 
 class TOpLimit : public IUnaryOperator {
@@ -422,9 +466,13 @@ class TOpRoot : public IUnaryOperator {
                 CurrElement = -1;
                 return;
             }
+            Root = ptr;
 
-            auto child = ptr->Children[0];
             std::unordered_set<std::shared_ptr<IOperator>> visited;
+            for (auto scalarSubplan : Root->PlanProps.ScalarSubplans.Get()) {
+                BuildDfsList(scalarSubplan, {}, size_t(0), visited);
+            }
+            auto child = ptr->Children[0];
             BuildDfsList(child, {}, size_t(0), visited);
             CurrElement = 0;
         }
@@ -465,6 +513,7 @@ class TOpRoot : public IUnaryOperator {
         }
         TVector<IteratorItem> DfsList;
         size_t CurrElement;
+        TOpRoot *Root;
     };
 
     Iterator begin() { return Iterator(this); }

--- a/ydb/core/kqp/opt/rbo/kqp_plan_conversion_utils.h
+++ b/ydb/core/kqp/opt/rbo/kqp_plan_conversion_utils.h
@@ -16,6 +16,8 @@ struct TIOperatorSharedPtrHash {
 
 class PlanConverter {
   public:
+    PlanConverter(TTypeAnnotationContext &typeCtx, TExprContext &ctx) : TypeCtx(typeCtx), Ctx(ctx) {}
+
     TOpRoot ConvertRoot(TExprNode::TPtr node);
     std::shared_ptr<IOperator> ExprNodeToOperator(TExprNode::TPtr node);
 
@@ -28,8 +30,13 @@ class PlanConverter {
     std::shared_ptr<IOperator> ConvertTKqpOpSort(TExprNode::TPtr node);
     std::shared_ptr<IOperator> ConvertTKqpOpAggregate(TExprNode::TPtr node);
 
+    TExprNode::TPtr RemoveScalarSubplans(TExprNode::TPtr lambda);
+
+    TTypeAnnotationContext &TypeCtx;
+    TExprContext &Ctx;
     THashMap<TExprNode*, std::shared_ptr<IOperator>> Converted;
     TPlanProps PlanProps;
+
 };
 
 } // namespace NKqp

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_rules.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_rules.cpp
@@ -142,7 +142,7 @@ bool TExtractJoinExpressionsRule::TestAndApply(std::shared_ptr<IOperator> &input
     }
 
     auto filter = CastOperator<TOpFilter>(input);
-    auto conjInfo = filter->GetConjunctInfo();
+    auto conjInfo = filter->GetConjunctInfo(props);
 
     TVector<std::pair<int, TExprNode::TPtr>> matchedConjuncts;
 
@@ -169,8 +169,8 @@ bool TExtractJoinExpressionsRule::TestAndApply(std::shared_ptr<IOperator> &input
 
                 TVector<TInfoUnit> leftIUs;
                 TVector<TInfoUnit> rightIUs;
-                GetAllMembers(leftSide, leftIUs);
-                GetAllMembers(rightSide, rightIUs);
+                GetAllMembers(leftSide, leftIUs, props);
+                GetAllMembers(rightSide, rightIUs, props);
 
                 if (leftIUs.size() == 1 && rightIUs.size() == 1) {
                     matchedConjuncts.push_back(std::make_pair(idx, f.FilterBody));
@@ -253,7 +253,62 @@ bool TExtractJoinExpressionsRule::TestAndApply(std::shared_ptr<IOperator> &input
     return false;
 }
 
-// Currently we push map operator
+// Rewrite a single scalar subplan into a cross-join
+
+bool TInlineScalarSubplanRule::TestAndApply(std::shared_ptr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
+    auto scalarIUs = input->GetScalarSubplanIUs(props);
+    if (scalarIUs.empty()) {
+        return false;
+    }
+
+    auto scalarIU = scalarIUs[0];
+    auto subplan = props.ScalarSubplans.PlanMap.at(scalarIU);
+    auto subplanResIU = subplan->GetOutputIUs()[0];
+    auto subplanResType = subplan->GetIUType(subplanResIU);
+
+    auto unaryOp = std::dynamic_pointer_cast<IUnaryOperator>(input);
+    Y_ENSURE(unaryOp);
+
+    auto child = unaryOp->GetInput();
+
+    auto emptySource = std::make_shared<TOpEmptySource>(subplan->Pos);
+
+    // FIXME: This works only for postgres types, because they are null-compatible
+    // For YQL types we will need to handle optionality
+    auto nullExpr = ctx.ExprCtx.NewCallable(subplan->Pos, "Nothing", {ExpandType(subplan->Pos, *subplanResType, ctx.ExprCtx)});
+
+    // clang-format off
+    auto mapLambda = Build<TCoLambda>(ctx.ExprCtx, subplan->Pos)
+                    .Args({"arg"})
+                    .Body(nullExpr)
+                    .Done().Ptr();
+    // clang-format on
+
+    TVector<std::pair<TInfoUnit, std::variant<TInfoUnit, TExprNode::TPtr>>> mapElements = {std::make_pair(scalarIU, mapLambda)};
+    auto map = std::make_shared<TOpMap>(emptySource, subplan->Pos, mapElements, true);
+
+    TVector<std::pair<TInfoUnit, std::variant<TInfoUnit, TExprNode::TPtr>>> renameElements = {std::make_pair(scalarIU, subplanResIU)};
+    auto rename = std::make_shared<TOpMap>(subplan, subplan->Pos, renameElements, true);
+    rename->Props.EnsureAtMostOne = true;
+
+    auto unionAll = std::make_shared<TOpUnionAll>(rename, map, subplan->Pos, true);
+
+    auto limitExpr = ctx.ExprCtx.NewCallable(subplan->Pos, "Uint64", {ctx.ExprCtx.NewAtom(subplan->Pos, "1")});
+    auto limit = std::make_shared<TOpLimit>(unionAll, subplan->Pos, limitExpr);
+
+    TVector<std::pair<TInfoUnit,TInfoUnit>> joinKeys;
+    auto cross = std::make_shared<TOpJoin>(child, limit, subplan->Pos, "Cross", joinKeys);
+    unaryOp->Children[0] = cross;
+
+    props.ScalarSubplans.Remove(scalarIU);
+
+    return true;
+}
+
+// We push the map operator only below join right now
+// We only push a non-projecting map operator, and there are some limitations to where we can push:
+//  - we cannot push the right side of left join for example or left side of right join
+
 std::shared_ptr<IOperator> TPushMapRule::SimpleTestAndApply(const std::shared_ptr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);
@@ -279,6 +334,8 @@ std::shared_ptr<IOperator> TPushMapRule::SimpleTestAndApply(const std::shared_pt
     }
 
     auto join = CastOperator<TOpJoin>(map->GetInput());
+    bool canPushRight = join->JoinKind != "Left" && join->JoinKind != "LeftOnly";
+    bool canPushLeft = join->JoinKind != "Right" && join->JoinKind != "RightOnly";
 
     // Make sure the join and its inputs are single consumer
     if (!join->IsSingleConsumer() || !join->GetLeftInput()->IsSingleConsumer() || !join->GetRightInput()->IsSingleConsumer()) {
@@ -295,11 +352,11 @@ std::shared_ptr<IOperator> TPushMapRule::SimpleTestAndApply(const std::shared_pt
         auto mapElement = map->MapElements[i];
 
         TVector<TInfoUnit> mapElIUs;
-        GetAllMembers(std::get<TExprNode::TPtr>(mapElement.second), mapElIUs);
+        GetAllMembers(std::get<TExprNode::TPtr>(mapElement.second), mapElIUs, props);
 
-        if (!IUSetDiff(mapElIUs, join->GetLeftInput()->GetOutputIUs()).size()) {
+        if (!IUSetDiff(mapElIUs, join->GetLeftInput()->GetOutputIUs()).size() && canPushLeft) {
             leftMapElements.push_back(mapElement);
-        } else if (!IUSetDiff(mapElIUs, join->GetRightInput()->GetOutputIUs()).size()) {
+        } else if (!IUSetDiff(mapElIUs, join->GetRightInput()->GetOutputIUs()).size() && canPushRight) {
             rightMapElements.push_back(mapElement);
         } else {
             topMapElements.push_back(mapElement);
@@ -335,6 +392,7 @@ std::shared_ptr<IOperator> TPushMapRule::SimpleTestAndApply(const std::shared_pt
     return output;
 }
 
+// FIXME: We currently support pushing filter into Inner, Cross and Left Join
 std::shared_ptr<IOperator> TPushFilterRule::SimpleTestAndApply(const std::shared_ptr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
 
     Y_UNUSED(props);
@@ -356,7 +414,7 @@ std::shared_ptr<IOperator> TPushFilterRule::SimpleTestAndApply(const std::shared
         return input;
     }
 
-    if (join->JoinKind != "Inner" && join->JoinKind != "Cross" && to_lower(join->JoinKind) != "left") {
+    if (join->JoinKind != "Inner" && join->JoinKind != "Cross" && join->JoinKind != "Left") {
         YQL_CLOG(TRACE, CoreDq) << "Wrong join type " << join->JoinKind << Endl;
         return input;
     }
@@ -370,7 +428,7 @@ std::shared_ptr<IOperator> TPushFilterRule::SimpleTestAndApply(const std::shared
     // Join conditions can be pushed into the join operator and conjucts can either be pushed
     // or left on top of the join
 
-    auto conjunctInfo = filter->GetConjunctInfo();
+    auto conjunctInfo = filter->GetConjunctInfo(props);
 
     // Check if we need a top level filter
     TVector<TFilterInfo> topLevelPreds;
@@ -840,7 +898,12 @@ void TRenameStage::RunStage(TOpRoot &root, TRBOContext &ctx) {
 }
 
 TRuleBasedStage RuleStage1 = TRuleBasedStage(
-    {std::make_shared<TExtractJoinExpressionsRule>(), std::make_shared<TPushMapRule>(), std::make_shared<TPushFilterRule>()});
+    {
+        std::make_shared<TInlineScalarSubplanRule>(),
+        std::make_shared<TExtractJoinExpressionsRule>(), 
+        std::make_shared<TPushMapRule>(), 
+        std::make_shared<TPushFilterRule>()
+    });
 TRuleBasedStage RuleStage2 = TRuleBasedStage({std::make_shared<TAssignStagesRule>()});
 
 } // namespace NKqp

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
@@ -23,6 +23,16 @@ class TExtractJoinExpressionsRule : public IRule {
 };
 
 /**
+ * Rewrites scalar subplans into cross join plans
+ */
+class TInlineScalarSubplanRule : public IRule {
+  public:
+    TInlineScalarSubplanRule() : IRule("Inline scalar subplan") {}
+
+    virtual bool TestAndApply(std::shared_ptr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
+};
+
+/**
  * Push down a non-projecting map operator
  * Currently only pushes below joins that are immediately below
  */

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_type_ann.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_type_ann.cpp
@@ -76,11 +76,43 @@ TStatus ComputeTypes(std::shared_ptr<TOpEmptySource> emptySource, TRBOContext & 
     return TStatus::Ok;
 }
 
-TStatus ComputeTypes(std::shared_ptr<TOpFilter> filter, TRBOContext & ctx) {
+const TStructExprType* AddScalarTypes(const TStructExprType* itemType, TVector<TInfoUnit> scalarContextIUs, TRBOContext & ctx, TPlanProps& props) {
+    TVector<const TItemExprType*> structItemTypes;
+    for (auto t : itemType->GetItems()) {
+        structItemTypes.push_back(t);
+    }
+
+    for (auto iu : scalarContextIUs) {
+        auto subplan = props.ScalarSubplans.PlanMap.at(iu);
+        auto subplanType = subplan->Type->Cast<TListExprType>()->GetItemType()->Cast<TStructExprType>();
+        auto scalarExprType = subplanType->GetItems()[0];
+
+        auto newType = ctx.ExprCtx.MakeType<TItemExprType>(iu.GetFullName(), scalarExprType->GetItemType());
+        structItemTypes.push_back(newType);
+    }
+
+    return ctx.ExprCtx.MakeType<TStructExprType>(structItemTypes);
+}
+
+TStatus ComputeTypes(std::shared_ptr<TOpFilter> filter, TRBOContext & ctx, TPlanProps& props) {
     const TTypeAnnotationNode* inputType = filter->GetInput()->Type;
     YQL_CLOG(TRACE, CoreDq) << "Type annotation for Filter, inputType: " << *inputType;
 
-    auto itemType = inputType->Cast<TListExprType>()->GetItemType();
+    auto itemType = inputType->Cast<TListExprType>()->GetItemType()->Cast<TStructExprType>();
+    YQL_CLOG(TRACE, CoreDq) << "Type annotation for Filter, itemType: " << *(TTypeAnnotationNode*)itemType;
+
+    auto filterIUs = filter->GetFilterIUs(props);
+    TVector<TInfoUnit> scalarContextIUs;
+    for (auto iu : filterIUs ) {
+        if (iu.ScalarContext) {
+            scalarContextIUs.push_back(iu);
+        }
+    }
+    if (!scalarContextIUs.empty()) {
+        itemType = AddScalarTypes(itemType, scalarContextIUs, ctx, props);
+    }
+    YQL_CLOG(TRACE, CoreDq) << "Type annotation for Filter, itemType after scalars: " << *(TTypeAnnotationNode*)itemType;
+
 
     auto& lambda = filter->FilterLambda;
 
@@ -248,7 +280,7 @@ TStatus ComputeTypes(std::shared_ptr<TOpLimit> limit, TRBOContext & ctx) {
     return TStatus::Ok;
 }
 
-TStatus ComputeTypes(std::shared_ptr<IOperator> op, TRBOContext & ctx) {
+TStatus ComputeTypes(std::shared_ptr<IOperator> op, TRBOContext & ctx, TPlanProps& props) {
     if (MatchOperator<TOpEmptySource>(op)) {
         return ComputeTypes(CastOperator<TOpEmptySource>(op), ctx);
     }
@@ -256,7 +288,7 @@ TStatus ComputeTypes(std::shared_ptr<IOperator> op, TRBOContext & ctx) {
         return ComputeTypes(CastOperator<TOpRead>(op), ctx);
     }
     else if(MatchOperator<TOpFilter>(op)) {
-        return ComputeTypes(CastOperator<TOpFilter>(op), ctx);
+        return ComputeTypes(CastOperator<TOpFilter>(op), ctx, props);
     }
     else if(MatchOperator<TOpMap>(op)) {
         return ComputeTypes(CastOperator<TOpMap>(op), ctx);
@@ -285,7 +317,7 @@ namespace NKqp {
 
 TStatus TOpRoot::ComputeTypes(TRBOContext & ctx) {
     for (auto it = begin(); it != end(); it++) {
-        auto status = ::ComputeTypes((*it).Current, ctx);
+        auto status = ::ComputeTypes((*it).Current, ctx, PlanProps);
         if (status != TStatus::Ok) {
             return status;
         }

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_ut.cpp
@@ -154,6 +154,79 @@ Y_UNIT_TEST_SUITE(KqpRbo) {
         }
     }
 
+    Y_UNIT_TEST(ScalarSubquery) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        TKikimrRunner kikimr(NKqp::TKikimrSettings(appConfig).SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/foo` (
+                id	Int64	NOT NULL,	
+	            name	String,
+                primary key(id)	
+            );
+
+            CREATE TABLE `/Root/bar` (
+                id	Int64	NOT NULL,	
+	            lastname	String,
+                primary key(id)	
+            );
+        )").GetValueSync();
+
+        NYdb::TValueBuilder rowsTableFoo;
+        rowsTableFoo.BeginList();
+        for (size_t i = 0; i < 1; ++i) {
+            rowsTableFoo.AddListItem()
+                .BeginStruct()
+                .AddMember("id").Int64(i)
+                .AddMember("name").String(std::to_string(i) + "_name")
+                .EndStruct();
+        }
+        rowsTableFoo.EndList();
+
+        auto resultUpsert = db.BulkUpsert("/Root/foo", rowsTableFoo.Build()).GetValueSync();
+        UNIT_ASSERT_C(resultUpsert.IsSuccess(), resultUpsert.GetIssues().ToString());
+
+        NYdb::TValueBuilder rowsTableBar;
+        rowsTableBar.BeginList();
+        for (size_t i = 0; i < 4; ++i) {
+            rowsTableBar.AddListItem()
+                .BeginStruct()
+                .AddMember("id").Int64(i)
+                .AddMember("lastname").String(std::to_string(i) + "_name")
+                .EndStruct();
+        }
+        rowsTableBar.EndList();
+
+        resultUpsert = db.BulkUpsert("/Root/bar", rowsTableBar.Build()).GetValueSync();
+        UNIT_ASSERT_C(resultUpsert.IsSuccess(), resultUpsert.GetIssues().ToString());
+
+        db = kikimr.GetTableClient();
+        auto session2 = db.CreateSession().GetValueSync().GetSession();
+
+        std::vector<std::string> queries = {
+            R"(
+                --!syntax_pg
+                SET TablePathPrefix = "/Root/";
+                SELECT bar.id FROM bar where bar.id = (SELECT id FROM foo);
+            )"
+        };
+
+        // TODO: The order of result is not defined, we need order by to add more interesting tests.
+        std::vector<std::string> results = {
+            R"([["0"]])",
+        };
+
+        for (ui32 i = 0; i < queries.size(); ++i) {
+            const auto &query = queries[i];
+            auto result = session2.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(FormatResultSetYson(result.GetResultSet(0)), results[i]);
+        }
+    }
+
     Y_UNIT_TEST(CrossInnerJoin) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Two known limitations:

- If the scalar subplan produces more than 1 tuple, we'll currently get an incorrect result
- Works with subplans with pgtypes, might not work with yql types