### PR TITLE
fq row_dispatcher: remove unnecessary UseAntlr4

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/purecalc_compilation/compile_service.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/purecalc_compilation/compile_service.cpp
@@ -187,7 +187,6 @@ private:
         }
         auto options = NYql::NPureCalc::TProgramFactoryOptions();
         options.SetLLVMSettings(settings.EnabledLLVM ? "ON" : "OFF");
-        options.UseAntlr4 = true;
         return ProgramFactories.emplace(settings, NYql::NPureCalc::MakeProgramFactory(options)).first->second;
     }
 


### PR DESCRIPTION
Antlr4 is always used

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
