### PR TITLE
Use explicit MutRef instead of explicit

### DIFF
--- a/ydb/core/grpc_services/rpc_kqp_base.h
+++ b/ydb/core/grpc_services/rpc_kqp_base.h
@@ -30,7 +30,7 @@ inline TString DecodePreparedQueryId(const TString& in) {
             << "got empty preparedQueryId message";
     }
     TString decodedStr;
-    bool decoded = NOperationId::DecodePreparedQueryIdCompat(in, decodedStr);
+    bool decoded = NOperationId::DecodePreparedQueryIdCompat(in, decodedStr.MutRef());
     if (decoded) {
         return decodedStr;
     } else {

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
@@ -324,7 +324,7 @@ TExprNode::TPtr RewritePgSelect(const TExprNode::TPtr &node, TExprContext &ctx, 
                     }
 
                     auto joinKind = TString(joinType);
-                    ToCamelCase(joinKind);
+                    ToCamelCase(joinKind.MutRef());
 
                     // clang-format off
                     joinExpr = Build<TKqpOpJoin>(ctx, node->Pos())


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

http://st/IGNIETFERRO-2155

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implicit `operator std::string&` could cause data races in some cases. We are trying to remove usages of this operator
