### PR TITLE
Add IC queue time metric. EXT-1612

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -71,6 +71,8 @@ namespace NActors {
             switch (State) {
                 case EState::INITIAL:
                     event.InitChecksum();
+                    task.UpdateIcQueueDuration(event);
+                    event.Span && event.Span.Event("FeedBuf:INITIAL");
                     if (event.Buffer) {
                         State = EState::BODY;
                         Iter = event.Buffer->GetBeginIter();

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -71,7 +71,10 @@ namespace NActors {
             switch (State) {
                 case EState::INITIAL:
                     event.InitChecksum();
-                    task.UpdateIcQueueDuration(event);
+                    if (event.EnqueueTime) {
+                        TDuration duration = NActors::TlsActivationContext->Now() - event.EnqueueTime;
+                        Metrics->UpdateIcQueueTimeHistogram(duration.MicroSeconds());
+                    }
                     event.Span && event.Span.Event("FeedBuf:INITIAL");
                     if (event.Buffer) {
                         State = EState::BODY;

--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -77,9 +77,9 @@ namespace NActors {
         ~TEventOutputChannel() {
         }
 
-        std::pair<ui32, TEventHolder*> Push(IEventHandle& ev, TEventHolderPool& pool) {
+        std::pair<ui32, TEventHolder*> Push(IEventHandle& ev, TEventHolderPool& pool, TInstant now) {
             TEventHolder& event = pool.Allocate(Queue);
-            const ui32 bytes = event.Fill(ev) + sizeof(TEventDescr2);
+            const ui32 bytes = event.Fill(ev, now) + sizeof(TEventDescr2);
             OutputQueueSize += bytes;
             if (event.Span = NWilson::TSpan(15 /*max verbosity*/, NWilson::TTraceId(ev.TraceId), "Interconnect.Queue")) {
                 event.Span

--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -236,6 +236,10 @@ namespace {
             PingTimeHistogram->Collect(value);
         }
 
+        void UpdateIcQueueTimeHistogram(ui64 value) override {
+            InterconnectQueueTimeHistogram->Collect(value);
+        }
+
         void UpdateOutputChannelTraffic(ui16 channel, ui64 value) override {
             auto& ch = GetOutputChannel(channel);
             if (ch.OutgoingTraffic) {
@@ -317,6 +321,8 @@ namespace {
 
                 PingTimeHistogram = AdaptiveCounters->GetHistogram(
                     "PingTimeUs", NMonitoring::ExponentialHistogram(18, 2, 125));
+                InterconnectQueueTimeHistogram = AdaptiveCounters->GetHistogram(
+                    "InterconnectQueueTimeHistogramUs", NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
             }
 
             if (updateGlobal) {
@@ -379,6 +385,7 @@ namespace {
         NMonitoring::TDynamicCounters::TCounterPtr UsefulWriteWakeups;
         NMonitoring::TDynamicCounters::TCounterPtr SpuriousWriteWakeups;
         NMonitoring::THistogramPtr PingTimeHistogram;
+        NMonitoring::THistogramPtr InterconnectQueueTimeHistogram;
 
         std::unordered_map<ui16, TOutputChannel> OutputChannels;
         TOutputChannel OtherOutputChannel;
@@ -580,6 +587,10 @@ namespace {
             PingTimeHistogram_->Record(value);
         }
 
+        void UpdateIcQueueTimeHistogram(ui64 value) override {
+            InterconnectQueueTimeHistogram_->Record(value);
+        }
+
         void UpdateOutputChannelTraffic(ui16 channel, ui64 value) override {
             auto& ch = GetOutputChannel(channel);
             if (ch.OutgoingTraffic) {
@@ -672,6 +683,8 @@ namespace {
                 InflightDataAmount_ = createRate(AdaptiveMetrics_, "interconnect.inflight_data");
                 PingTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ping_time_us"}}), NMonitoring::ExponentialHistogram(18, 2, 125));
+                InterconnectQueueTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
+                        NMonitoring::MakeLabels({{"sensor", "interconnect.ic_queue_time_us"}}), NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
             }
 
             if (updateGlobal) {
@@ -756,6 +769,7 @@ namespace {
         NMonitoring::IIntGauge* ClockSkewMicrosec_;
 
         NMonitoring::IHistogram* PingTimeHistogram_;
+        NMonitoring::IHistogram* InterconnectQueueTimeHistogram_;
 
         THashMap<ui16, TOutputChannel> OutputChannels_;
         TOutputChannel OtherOutputChannel_;

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -41,6 +41,7 @@ public:
     virtual void IncRecvSyscalls(ui64 ns) = 0;
     virtual void AddTotalBytesRead(ui64 value) = 0;
     virtual void UpdatePingTimeHistogram(ui64 value) = 0;
+    virtual void UpdateIcQueueTimeHistogram(ui64 value) = 0;
     virtual void UpdateOutputChannelTraffic(ui16 channel, ui64 value) = 0;
     virtual void UpdateOutputChannelEvents(ui16 channel) = 0;
     virtual void SetUtilization(ui32 total, ui32 starvation) = 0;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -153,7 +153,9 @@ namespace NActors {
         auto& oChannel = ChannelScheduler->GetOutputChannel(evChannel);
         const bool wasWorking = oChannel.IsWorking();
 
-        const auto [dataSize, event] = oChannel.Push(*ev, *Pool);
+        TInstant now = TlsActivationContext->Now();
+
+        const auto [dataSize, event] = oChannel.Push(*ev, *Pool, now);
         LWTRACK(ForwardEvent, event->Orbit, Proxy->PeerNodeId, event->Descr.Type, event->Descr.Flags, LWACTORID(event->Descr.Recipient), LWACTORID(event->Descr.Sender), event->Descr.Cookie, event->EventSerializedSize);
 
         TotalOutputQueueSize += dataSize;
@@ -871,7 +873,7 @@ namespace NActors {
         stream.Align();
         XdcStream.Align();
 
-        TTcpPacketOutTask packet(Params, stream, XdcStream);
+        TTcpPacketOutTask packet(Params, stream, XdcStream, Proxy->Metrics.get());
         ui64 serial = 0;
 
         if (data) {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -873,7 +873,7 @@ namespace NActors {
         stream.Align();
         XdcStream.Align();
 
-        TTcpPacketOutTask packet(Params, stream, XdcStream, Proxy->Metrics.get());
+        TTcpPacketOutTask packet(Params, stream, XdcStream);
         ui64 serial = 0;
 
         if (data) {

--- a/ydb/library/actors/interconnect/packet.cpp
+++ b/ydb/library/actors/interconnect/packet.cpp
@@ -8,20 +8,12 @@
 LWTRACE_USING(ACTORLIB_PROVIDER);
 
 TTcpPacketOutTask::TTcpPacketOutTask(const TSessionParams& params, NInterconnect::TOutgoingStream& outgoingStream,
-    NInterconnect::TOutgoingStream& xdcStream, NActors::IInterconnectMetrics* metrics)
+    NInterconnect::TOutgoingStream& xdcStream)
     : Params(params)
     , OutgoingStream(outgoingStream)
     , XdcStream(xdcStream)
     , HeaderBookmark(OutgoingStream.Bookmark(sizeof(TTcpPacketHeader_v2)))
-    , Metrics(metrics)
 {}
-
-void TTcpPacketOutTask::UpdateIcQueueDuration(const TEventHolder& event) {
-    if (event.EnqueueTime) {
-        TDuration duration = NActors::TlsActivationContext->Now() - event.EnqueueTime;
-        Metrics->UpdateIcQueueTimeHistogram(duration.MicroSeconds());
-    }
-}
 
 ui32 TEventHolder::Fill(IEventHandle& ev) {
     Serial = 0;

--- a/ydb/library/actors/interconnect/packet.cpp
+++ b/ydb/library/actors/interconnect/packet.cpp
@@ -1,10 +1,27 @@
 #include "packet.h"
+#include "interconnect_counters.h"
 
 #include <ydb/library/actors/core/probes.h>
 
 #include <util/system/datetime.h>
 
 LWTRACE_USING(ACTORLIB_PROVIDER);
+
+TTcpPacketOutTask::TTcpPacketOutTask(const TSessionParams& params, NInterconnect::TOutgoingStream& outgoingStream,
+    NInterconnect::TOutgoingStream& xdcStream, NActors::IInterconnectMetrics* metrics)
+    : Params(params)
+    , OutgoingStream(outgoingStream)
+    , XdcStream(xdcStream)
+    , HeaderBookmark(OutgoingStream.Bookmark(sizeof(TTcpPacketHeader_v2)))
+    , Metrics(metrics)
+{}
+
+void TTcpPacketOutTask::UpdateIcQueueDuration(const TEventHolder& event) {
+    if (event.EnqueueTime) {
+        TDuration duration = NActors::TlsActivationContext->Now() - event.EnqueueTime;
+        Metrics->UpdateIcQueueTimeHistogram(duration.MicroSeconds());
+    }
+}
 
 ui32 TEventHolder::Fill(IEventHandle& ev) {
     Serial = 0;
@@ -30,4 +47,9 @@ ui32 TEventHolder::Fill(IEventHandle& ev) {
     }
 
     return EventSerializedSize;
+}
+
+ui32 TEventHolder::Fill(IEventHandle& ev, TInstant now) {
+    EnqueueTime = now;
+    return Fill(ev);
 }

--- a/ydb/library/actors/interconnect/packet.h
+++ b/ydb/library/actors/interconnect/packet.h
@@ -145,7 +145,6 @@ struct TTcpPacketOutTask : TNonCopyable {
     NInterconnect::TOutgoingStream& OutgoingStream;
     NInterconnect::TOutgoingStream& XdcStream;
     NInterconnect::TOutgoingStream::TBookmark HeaderBookmark;
-    NActors::IInterconnectMetrics* Metrics;
 
     ui32 InternalSize = 0;
     ui32 ExternalSize = 0;
@@ -158,9 +157,7 @@ struct TTcpPacketOutTask : TNonCopyable {
     ui32 ExternalChecksum = 0;
 
     TTcpPacketOutTask(const TSessionParams& params, NInterconnect::TOutgoingStream& outgoingStream,
-        NInterconnect::TOutgoingStream& xdcStream, NActors::IInterconnectMetrics* metrics);
-
-    void UpdateIcQueueDuration(const TEventHolder& event);
+        NInterconnect::TOutgoingStream& xdcStream);
 
     // Preallocate some space to fill it later.
     NInterconnect::TOutgoingStream::TBookmark Bookmark(size_t len) {

--- a/ydb/library/actors/interconnect/ut/channel_scheduler_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/channel_scheduler_ut.cpp
@@ -23,7 +23,7 @@ Y_UNIT_TEST_SUITE(ChannelScheduler) {
             auto ev = MakeHolder<IEventHandle>(1, 0, TActorId(), TActorId(), MakeIntrusive<TEventSerializedData>(payload, TEventSerializationInfo{}), 0);
             auto& ch = scheduler.GetOutputChannel(channel);
             const bool wasWorking = ch.IsWorking();
-            ch.Push(*ev, pool);
+            ch.Push(*ev, pool, TInstant::Zero()/*Do not account time outside AS*/);
             if (!wasWorking) {
                 scheduler.AddToHeap(ch, 0);
             }
@@ -46,7 +46,7 @@ Y_UNIT_TEST_SUITE(ChannelScheduler) {
         NInterconnect::TOutgoingStream stream;
 
         for (; numEvents; ++step) {
-            TTcpPacketOutTask task(p, stream, stream);
+            TTcpPacketOutTask task(p, stream, stream, ctr.get());
 
             if (step == 100) {
                 for (ui32 i = 0; i < 200; ++i) {

--- a/ydb/library/actors/interconnect/ut/channel_scheduler_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/channel_scheduler_ut.cpp
@@ -46,7 +46,7 @@ Y_UNIT_TEST_SUITE(ChannelScheduler) {
         NInterconnect::TOutgoingStream stream;
 
         for (; numEvents; ++step) {
-            TTcpPacketOutTask task(p, stream, stream, ctr.get());
+            TTcpPacketOutTask task(p, stream, stream);
 
             if (step == 100) {
                 for (ui32 i = 0; i < 200; ++i) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add IC queue time metric. Time spend in the interconnect queue does not report in any existed counter, but the time spend in this queue important for performance analysis.


### Changelog category <!-- remove all except one -->


* Improvement


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
