### PR TITLE
explicitly call TString::MutRef in the conversion to std::string IGNIETFERRO-2155

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/issue/yql_issue.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/issue/yql_issue.h
@@ -3,7 +3,6 @@
 #include <util/generic/ptr.h>
 #include <util/generic/yexception.h>
 #include <util/stream/output.h>
-#include <util/stream/str.h>
 #include <util/system/types.h>
 #include <util/str_stl.h>
 
@@ -183,11 +182,7 @@ public:
 
     void PrintTo(IOutputStream& out, bool oneLine = false) const;
 
-    std::string ToString(bool oneLine = false) const {
-        TStringStream out;
-        PrintTo(out, oneLine);
-        return out.Str();
-    }
+    std::string ToString(bool oneLine = false) const;
 
     // Unsafe method. Doesn't call SanitizeNonAscii(Message)
     std::string* MutableMessage() {
@@ -295,11 +290,7 @@ public:
             const std::string& programFilename,
             const std::string& programText) const;
 
-    inline std::string ToString(bool oneLine = false) const {
-        TStringStream out;
-        PrintTo(out, oneLine);
-        return out.Str();
-    }
+    std::string ToString(bool oneLine = false) const;
 
     std::string ToOneLineString() const {
         return ToString(true);

--- a/ydb/public/sdk/cpp/src/library/issue/yql_issue.cpp
+++ b/ydb/public/sdk/cpp/src/library/issue/yql_issue.cpp
@@ -7,6 +7,7 @@
 #include <library/cpp/colorizer/output.h>
 
 #include <util/charset/utf8.h>
+#include <util/stream/str.h>
 #include <util/string/ascii.h>
 #include <util/string/split.h>
 #include <util/string/strip.h>
@@ -77,6 +78,12 @@ void TIssue::PrintTo(IOutputStream& out, bool oneLine) const {
     if (GetCode()) {
         out << ", code: " << GetCode();
     }
+}
+
+std::string TIssue::ToString(bool oneLine) const {
+    TStringStream out;
+    PrintTo(out, oneLine);
+    return std::move(out.Str().MutRef());
 }
 
 void WalkThroughIssues(const TIssue& topIssue, bool leafOnly, std::function<void(const TIssue&, uint16_t level)> fn, std::function<void(const TIssue&, uint16_t level)> afterChildrenFn) {
@@ -222,6 +229,12 @@ void TIssues::PrintWithProgramTo(
             out << Endl;
         });
     }
+}
+
+std::string TIssues::ToString(bool oneLine) const {
+    TStringStream out;
+    PrintTo(out, oneLine);
+    return std::move(out.Str().MutRef());
 }
 
 TIssue ExceptionToIssue(const std::exception& e, const TPosition& pos) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Moving strings is usually faster.

And there is no good reason to keep the method's definition in the header file, so move it to the source file.

Also fixes: https://nda.ya.ru/t/R7P7HqPW7MRMSz


