### PR TITLE
Optimizing the calculation of the transaction predicate

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -27,7 +27,6 @@
 #include <util/folder/path.h>
 #include <util/string/escape.h>
 #include <util/system/byteorder.h>
-//#include <ydb/library/dbgtrace/debug_trace.h>
 
 namespace NKafka {
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1671,6 +1671,8 @@ void TPartition::Handle(TEvPQ::TEvGetWriteInfoError::TPtr& ev, const TActorConte
 void TPartition::ReplyToProposeOrPredicate(TSimpleSharedPtr<TTransaction>& tx, bool isPredicate) {
 
     if (isPredicate) {
+        TabletCounters.Percentile()[COUNTER_LATENCY_PQ_TXCALCPREDICATE].IncrementFor((Now() - tx->CalcPredicateTimestamp).MilliSeconds());
+
         tx->CalcPredicateSpan.End();
         tx->CalcPredicateSpan = {};
 
@@ -2203,7 +2205,7 @@ void TPartition::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
 
 void TPartition::PushBackDistrTx(TSimpleSharedPtr<TEvPQ::TEvTxCalcPredicate> event)
 {
-    UserActionAndTransactionEvents.emplace_back(MakeSimpleShared<TTransaction>(std::move(event)));
+    UserActionAndTransactionEvents.emplace_back(MakeSimpleShared<TTransaction>(std::move(event), Now()));
     RequestWriteInfoIfRequired();
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -27,6 +27,7 @@
 #include <util/folder/path.h>
 #include <util/string/escape.h>
 #include <util/system/byteorder.h>
+//#include <ydb/library/dbgtrace/debug_trace.h>
 
 namespace NKafka {
 
@@ -1549,7 +1550,9 @@ void TPartition::WriteInfoResponseHandler(
     ProcessTxsAndUserActs(ctx);
 }
 
-TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) {
+TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx,
+                                                              TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
+{
     bool isImmediate = (tx.ProposeTransaction != nullptr);
     PQ_ENSURE(tx.WriteInfo);
     PQ_ENSURE(!tx.WriteInfoApplied);
@@ -1568,22 +1571,23 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
 
     EProcessResult ret = EProcessResult::Continue;
     const auto& knownSourceIds = SourceIdStorage.GetInMemorySourceIds();
-    THashSet<TString> txSourceIds;
-    for (auto& s : srcIdInfo) {
+    TVector<TString> txSourceIds;
+    for (const auto& s : srcIdInfo) {
         if (TxAffectedSourcesIds.contains(s.first)) {
             PQ_LOG_TX_D("TxAffectedSourcesIds contains SourceId " << s.first << ". TxId " << tx.GetTxId());
             ret = EProcessResult::Blocked;
             break;
         }
         if (isImmediate) {
-            WriteAffectedSourcesIds.insert(s.first);
+            txSourceIds.push_back(s.first);
+            LOG_D("TxId " << tx.GetTxId() << " affect SourceId " << s.first);
         } else {
             if (WriteAffectedSourcesIds.contains(s.first)) {
                 PQ_LOG_TX_D("WriteAffectedSourcesIds contains SourceId " << s.first << ". TxId " << tx.GetTxId());
                 ret = EProcessResult::Blocked;
                 break;
             }
-            txSourceIds.insert(s.first);
+            txSourceIds.push_back(s.first);
             LOG_D("TxId " << tx.GetTxId() << " affect SourceId " << s.first);
         }
 
@@ -1617,12 +1621,16 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
             }
         }
     }
+
     if (ret == EProcessResult::Continue && tx.Predicate.GetOrElse(true)) {
-        TxAffectedSourcesIds.insert(txSourceIds.begin(), txSourceIds.end());
+        auto& sourceIds =
+            (isImmediate ? affectedSourceIdsAndConsumers.WriteSourcesIds : affectedSourceIdsAndConsumers.TxWriteSourcesIds);
+        sourceIds = std::move(txSourceIds);
 
         tx.WriteInfoApplied = true;
-        WriteKeysSizeEstimate += tx.WriteInfo->BodyKeys.size();
-        WriteKeysSizeEstimate += tx.WriteInfo->SrcIdInfo.size();
+
+        affectedSourceIdsAndConsumers.WriteKeysSize += tx.WriteInfo->BodyKeys.size();
+        affectedSourceIdsAndConsumers.WriteKeysSize += tx.WriteInfo->SrcIdInfo.size();
     }
 
     return ret;
@@ -2262,7 +2270,64 @@ size_t TPartition::GetUserActCount(const TString& consumer) const
     }
 }
 
-void TPartition::ProcessTxsAndUserActs(const TActorContext& ctx)
+//
+// TODO(abcdef): переименовать в ProcessUserActionAndTxs
+//
+void TPartition::ProcessTxsAndUserActs(const TActorContext&)
+{
+    if (KVWriteInProgress) {
+        LOG_D("Writing. Can't process user action and tx events");
+        return;
+    }
+
+    if (DeletePartitionState == DELETION_INITED) {
+        if (!PersistRequest) {
+            PersistRequest = MakeHolder<TEvKeyValue::TEvRequest>();
+        }
+
+        ScheduleNegativeReplies();
+        ScheduleDeletePartitionDone();
+
+        AddCmdDeleteRangeForAllKeys(*PersistRequest);
+
+        Send(BlobCache, PersistRequest.Release(), 0, 0, PersistRequestSpan.GetTraceId());
+        PersistRequest = nullptr;
+        CurrentPersistRequestSpan = std::move(PersistRequestSpan);
+        PersistRequestSpan = NWilson::TSpan();
+        DeletePartitionState = DELETION_IN_PROCESS;
+        KVWriteInProgress = true;
+
+        return;
+    }
+
+    LOG_D("Process user action and tx events");
+    ProcessUserActionAndTxEvents();
+    DumpTheSizeOfInternalQueues();
+    if (!UserActionAndTxPendingWrite.empty()) {
+        LOG_D("Waiting for the batch to finish");
+        return;
+    }
+
+    LOG_D("Process user action and tx pending commits");
+    ProcessUserActionAndTxPendingCommits();
+    DumpTheSizeOfInternalQueues();
+
+    if (CurrentBatchSize > 0) {
+        LOG_D("Batch completed (" << CurrentBatchSize << ")");
+        Send(SelfId(), new TEvPQ::TEvTxBatchComplete(CurrentBatchSize));
+    }
+    CurrentBatchSize = 0;
+
+    //if (UserActionAndTxPendingWrite.empty()) {
+    //    LOG_D("Waiting for the commits to arrive");
+    //    return;
+    //}
+
+    LOG_D("Try persist");
+    RunPersist();
+}
+
+void TPartition::ProcessTxsAndUserActsOriginal(const TActorContext& ctx)
 {
     if (KVWriteInProgress) {
         LOG_D("Writing. Can't process transactions and user actions");
@@ -2328,6 +2393,135 @@ bool TPartition::CanProcessUserActionAndTransactionEvents() const
     return (BatchingState == ETxBatchingState::PreProcessing);
 }
 
+void TPartition::ProcessUserActionAndTxEvents()
+{
+    while (!UserActionAndTransactionEvents.empty()) {
+        if (ChangingConfig) {
+            BatchingState = ETxBatchingState::Finishing;
+            break;
+        }
+
+        auto& front = UserActionAndTransactionEvents.front();
+        if (TMessage* msg = std::get_if<TMessage>(&front.Event); msg && msg->WaitPreviousWriteSpan) {
+            msg->WaitPreviousWriteSpan.End();
+        }
+
+        auto visitor = [this, &front](auto& event) {
+            return this->ProcessUserActionAndTxEvent(event, front.AffectedSourceIdsAndConsumers);
+        };
+        switch (std::visit(visitor, front.Event)) {
+            case EProcessResult::Continue:
+                MoveUserActionAndTxToPendingCommitQueue();
+                FirstEvent = false;
+                break;
+            case EProcessResult::ContinueDrop:
+                UserActionAndTransactionEvents.pop_front();
+                break;
+            case EProcessResult::Break:
+                MoveUserActionAndTxToPendingCommitQueue();
+                BatchingState = ETxBatchingState::Finishing;
+                FirstEvent = false;
+                break;
+            case EProcessResult::Blocked:
+                BatchingState = ETxBatchingState::Executing;
+                return;
+            case EProcessResult::NotReady:
+                return;
+        }
+    }
+}
+
+void TPartition::DumpTheSizeOfInternalQueues() const
+{
+    LOG_D("Events: " << UserActionAndTransactionEvents.size() <<
+          ", PendingCommits: " << UserActionAndTxPendingCommit.size() <<
+          ", PendingWrites: " << UserActionAndTxPendingWrite.size());
+}
+
+auto TPartition::ProcessUserActionAndTxEvent(TSimpleSharedPtr<TEvPQ::TEvSetClientInfo>& event,
+                                             TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers) -> EProcessResult
+{
+    return PreProcessUserActionOrTransaction(event, affectedSourceIdsAndConsumers);
+}
+
+auto TPartition::ProcessUserActionAndTxEvent(TSimpleSharedPtr<TTransaction>& tx,
+                                             TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers) -> EProcessResult
+{
+    return PreProcessUserActionOrTransaction(tx, affectedSourceIdsAndConsumers);
+}
+
+auto TPartition::ProcessUserActionAndTxEvent(TMessage& msg,
+                                             TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers) -> EProcessResult
+{
+    return PreProcessUserActionOrTransaction(msg, affectedSourceIdsAndConsumers);
+}
+
+
+void TPartition::MoveUserActionAndTxToPendingCommitQueue()
+{
+    MoveUserActOrTxToCommitState();
+}
+
+void TPartition::ProcessUserActionAndTxPendingCommits() {
+    CurrentBatchSize = 0;
+
+    PQ_ENSURE(!KVWriteInProgress);
+    if (!PersistRequest) {
+        PersistRequest = MakeHolder<TEvKeyValue::TEvRequest>();
+    }
+
+    while (!UserActionAndTxPendingCommit.empty()) {
+        auto& front = UserActionAndTxPendingCommit.front();
+        auto state = ECommitState::Committed;
+
+        if (auto* tx = get_if<TSimpleSharedPtr<TTransaction>>(&front.Event)) {
+            state = tx->Get()->State;
+        }
+
+        switch (state) {
+            case ECommitState::Pending:
+                return;
+            case ECommitState::Aborted:
+                break;
+            case ECommitState::Committed:
+                break;
+        }
+
+        UserActionAndTxPendingWrite.push_back(std::move(front));
+        UserActionAndTxPendingCommit.pop_front();
+
+        auto& event = UserActionAndTxPendingWrite.back().Event;
+        auto visitor = [this, request = PersistRequest.Get()](auto& event) {
+            return this->ProcessUserActionAndTxPendingCommit(event, request);
+        };
+        std::visit(visitor, event);
+
+        ++CurrentBatchSize;
+    }
+
+    if (UserActionAndTxPendingCommit.empty()) {
+        BatchingState = ETxBatchingState::Finishing;
+    }
+}
+
+void TPartition::ProcessUserActionAndTxPendingCommit(TSimpleSharedPtr<TEvPQ::TEvSetClientInfo>& event,
+                                                     TEvKeyValue::TEvRequest* request)
+{
+    ExecUserActionOrTransaction(event, request);
+}
+
+void TPartition::ProcessUserActionAndTxPendingCommit(TSimpleSharedPtr<TTransaction>& tx,
+                                                     TEvKeyValue::TEvRequest* request)
+{
+    ExecUserActionOrTransaction(tx, request);
+}
+
+void TPartition::ProcessUserActionAndTxPendingCommit(TMessage& msg,
+                                                     TEvKeyValue::TEvRequest* request)
+{
+    ExecUserActionOrTransaction(msg, request);
+}
+
 void TPartition::ContinueProcessTxsAndUserActs(const TActorContext&)
 {
     PQ_ENSURE(!KVWriteInProgress);
@@ -2336,9 +2530,6 @@ void TPartition::ContinueProcessTxsAndUserActs(const TActorContext&)
         BatchingState = ETxBatchingState::Finishing;
         return;
     }
-    auto visitor = [this](auto& event) {
-        return this->PreProcessUserActionOrTransaction(event);
-    };
     while (CanProcessUserActionAndTransactionEvents() && !UserActionAndTransactionEvents.empty()) {
         if (ChangingConfig) {
             BatchingState = ETxBatchingState::Finishing;
@@ -2348,6 +2539,9 @@ void TPartition::ContinueProcessTxsAndUserActs(const TActorContext&)
         if (TMessage* msg = std::get_if<TMessage>(&front.Event); msg && msg->WaitPreviousWriteSpan) {
             msg->WaitPreviousWriteSpan.End();
         }
+        auto visitor = [this, &front](auto& event) {
+            return this->PreProcessUserActionOrTransaction(event, front.AffectedSourceIdsAndConsumers);
+        };
         switch (std::visit(visitor, front.Event)) {
             case EProcessResult::Continue:
                 MoveUserActOrTxToCommitState();
@@ -2376,8 +2570,82 @@ void TPartition::ContinueProcessTxsAndUserActs(const TActorContext&)
 
 }
 
+static void AppendToSet(const TVector<TString>& p, THashMap<TString, size_t>& q)
+{
+    for (const auto& s : p) {
+        ++q[s];
+    }
+}
+
+void TPartition::AppendAffectedSourceIdsAndConsumers(const TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
+{
+    AppendToSet(affectedSourceIdsAndConsumers.TxWriteSourcesIds, TxAffectedSourcesIds);
+    AppendToSet(affectedSourceIdsAndConsumers.WriteSourcesIds, WriteAffectedSourcesIds);
+    AppendToSet(affectedSourceIdsAndConsumers.TxReadConsumers, TxAffectedConsumers);
+    AppendToSet(affectedSourceIdsAndConsumers.ReadConsumers, SetOffsetAffectedConsumers);
+
+    WriteKeysSizeEstimate += affectedSourceIdsAndConsumers.WriteKeysSize;
+}
+
+void TPartition::DeleteAffectedSourceIdsAndConsumers()
+{
+    if (UserActionAndTxPendingWrite.empty()) {
+        return;
+    }
+
+    for (const auto& e : UserActionAndTxPendingWrite) {
+        DeleteAffectedSourceIdsAndConsumers(e.AffectedSourceIdsAndConsumers);
+
+        if (auto* tx = std::get_if<TSimpleSharedPtr<TTransaction>>(&e.Event); tx) {
+            if (auto txId = (*tx)->GetTxId(); txId.Defined()) {
+                TransactionsInflight.erase(*txId);
+            }
+
+            if ((*tx)->ChangeConfig || (*tx)->ProposeConfig) {
+                ChangingConfig = false;
+            }
+        }
+    }
+
+    //Y_ABORT_UNLESS(UserActionAndTxPendingCommit.empty());
+    //Y_ABORT_UNLESS(TxAffectedSourcesIds.empty());
+    //Y_ABORT_UNLESS(WriteAffectedSourcesIds.empty());
+    //Y_ABORT_UNLESS(TxAffectedConsumers.empty());
+    //Y_ABORT_UNLESS(SetOffsetAffectedConsumers.empty());
+
+    UserActionAndTxPendingWrite.clear();
+}
+
+static void DeleteFromSet(const TVector<TString>& p, THashMap<TString, size_t>& q)
+{
+    for (const auto& s : p) {
+        auto i = q.find(s);
+        Y_ABORT_UNLESS(i != q.end());
+        Y_ABORT_UNLESS(i->second > 0);
+        if (--i->second) {
+            continue;
+        }
+        q.erase(s);
+    }
+}
+
+void TPartition::DeleteAffectedSourceIdsAndConsumers(const TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
+{
+    DeleteFromSet(affectedSourceIdsAndConsumers.TxWriteSourcesIds, TxAffectedSourcesIds);
+    DeleteFromSet(affectedSourceIdsAndConsumers.WriteSourcesIds, WriteAffectedSourcesIds);
+    DeleteFromSet(affectedSourceIdsAndConsumers.TxReadConsumers, TxAffectedConsumers);
+    DeleteFromSet(affectedSourceIdsAndConsumers.ReadConsumers, SetOffsetAffectedConsumers);
+
+    Y_ABORT_UNLESS(WriteKeysSizeEstimate >= affectedSourceIdsAndConsumers.WriteKeysSize);
+    WriteKeysSizeEstimate -= affectedSourceIdsAndConsumers.WriteKeysSize;
+}
+
+//
+// TODO(abcdef) переименовать в MoveUserActionAndTxToPendingCommitQueue
+//
 void TPartition::MoveUserActOrTxToCommitState() {
     auto& front = UserActionAndTransactionEvents.front();
+    AppendAffectedSourceIdsAndConsumers(front.AffectedSourceIdsAndConsumers);
     UserActionAndTxPendingCommit.push_back(std::move(front));
     UserActionAndTransactionEvents.pop_front();
 }
@@ -2389,15 +2657,14 @@ void TPartition::ProcessCommitQueue() {
     if (!PersistRequest) {
         PersistRequest = MakeHolder<TEvKeyValue::TEvRequest>();
     }
-    auto visitor = [this, request = PersistRequest.Get()](auto& event) {
-        return this->ExecUserActionOrTransaction(event, request);
-    };
     while (!UserActionAndTxPendingCommit.empty()) {
         auto& front = UserActionAndTxPendingCommit.front();
         auto state = ECommitState::Committed;
+
         if (auto* tx = get_if<TSimpleSharedPtr<TTransaction>>(&front.Event)) {
             state = tx->Get()->State;
         }
+
         switch (state) {
             case ECommitState::Pending:
                 return;
@@ -2406,8 +2673,14 @@ void TPartition::ProcessCommitQueue() {
             case ECommitState::Committed:
                 break;
         }
-        auto event = std::move(front.Event);
+
+        UserActionAndTxPendingWrite.push_back(std::move(front));
         UserActionAndTxPendingCommit.pop_front();
+
+        auto& event = UserActionAndTxPendingWrite.back().Event;
+        auto visitor = [this, request = PersistRequest.Get()](auto& event) {
+            return this->ExecUserActionOrTransaction(event, request);
+        };
         std::visit(visitor, event);
     }
     if (UserActionAndTxPendingCommit.empty()) {
@@ -2424,9 +2697,9 @@ ui64 TPartition::NextReadCookie()
 }
 
 void TPartition::RunPersist() {
-    TransactionsInflight.clear();
+    //TransactionsInflight.clear();
 
-    PQ_ENSURE(UserActionAndTxPendingCommit.empty());
+    //PQ_ENSURE(UserActionAndTxPendingCommit.empty());
     const auto& ctx = ActorContext();
     const auto now = ctx.Now();
     if (!PersistRequest) {
@@ -2460,6 +2733,11 @@ void TPartition::RunPersist() {
     if (TryAddDeleteHeadKeysToPersistRequest()) {
         haveChanges = true;
     }
+
+    LOG_D("haveChanges=" << haveChanges <<
+          ", TxIdHasChanged=" << TxIdHasChanged <<
+          ", AffectedUsers.size=" << AffectedUsers.size() <<
+          ", ChangeConfig=" << (ChangeConfig ? 1 : 0));
 
     if (haveChanges || TxIdHasChanged || !AffectedUsers.empty() || ChangeConfig) {
         WriteCycleStartTime = now;
@@ -2569,7 +2847,7 @@ bool TPartition::TryAddDeleteHeadKeysToPersistRequest()
     return haveChanges;
 }
 
-//void TPartition::DumpKeyValueRequest(const NKikimrClient::TKeyValueRequest& request)
+//void TPartition::DumpKeyValueRequest(const NKikimrClient::TKeyValueRequest& request) const
 //{
 //    DBGTRACE_LOG("=== DumpKeyValueRequest ===");
 //    DBGTRACE_LOG("--- delete ----------------");
@@ -2637,7 +2915,8 @@ void TPartition::AnswerCurrentReplies(const TActorContext& ctx)
     Replies.clear();
 }
 
-TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t)
+TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t,
+                                                                         TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
 {
     auto span = t->CalcPredicateSpan.CreateChild(TWilsonTopic::TopicTopLevel,
                                                  "Topic.Partition.PreProcess",
@@ -2649,7 +2928,7 @@ TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimple
         return EProcessResult::NotReady;
     }
     if (t->WriteInfo && !t->WriteInfoApplied) { //Recieved write info but not applied
-        result = ApplyWriteInfoResponse(*t);
+        result = ApplyWriteInfoResponse(*t, affectedSourceIdsAndConsumers);
         if (!t->WriteInfoApplied) { // Tried to apply write info but couldn't - TX must be blocked.
             PQ_LOG_TX_D("The TxId " << t->GetTxId() << " must be blocked");
             PQ_ENSURE(result != EProcessResult::Continue);
@@ -2662,14 +2941,14 @@ TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimple
             return EProcessResult::Continue;
         }
         t->Predicate.ConstructInPlace(true);
-        return PreProcessImmediateTx(t->ProposeTransaction->GetRecord());
+        return PreProcessImmediateTx(*t, affectedSourceIdsAndConsumers);
 
     } else if (t->Tx) { // Distributed TX
         if (t->Predicate.Defined()) { // Predicate defined - either failed previously or Tx created with predicate defined.
             ReplyToProposeOrPredicate(t, true);
             return EProcessResult::Continue;
         }
-        result = BeginTransaction(*t->Tx, t->Predicate, t->Message);
+        result = BeginTransactionData(*t, affectedSourceIdsAndConsumers);
         if (t->Predicate.Defined()) {
             ReplyToProposeOrPredicate(t, true);
         }
@@ -2678,7 +2957,7 @@ TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimple
         if (!FirstEvent) {
             return EProcessResult::Blocked;
         }
-        t->Predicate = BeginTransaction(*t->ProposeConfig);
+        t->Predicate = BeginTransactionConfig(*t);
         ChangingConfig = true;
         PendingPartitionConfig = GetPartitionConfig(t->ProposeConfig->Config);
         //Y_VERIFY_DEBUG_S(PendingPartitionConfig, "Partition " << Partition << " config not found");
@@ -2700,7 +2979,8 @@ TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimple
     return result;
 }
 
-bool TPartition::ExecUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t, TEvKeyValue::TEvRequest*)
+bool TPartition::ExecUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t,
+                                             TEvKeyValue::TEvRequest*)
 {
     auto span = t->CommitSpan.CreateChild(TWilsonTopic::TopicTopLevel,
                                           "Topic.Partition.Process",
@@ -2719,13 +2999,12 @@ bool TPartition::ExecUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t, 
         case ECommitState::Committed:
             break;
     }
-    const auto& ctx = ActorContext();
     if (t->ChangeConfig) {
         PQ_ENSURE(!ChangeConfig);
         PQ_ENSURE(ChangingConfig);
         ChangeConfig = t->ChangeConfig;
         SendChangeConfigReply = t->SendReply;
-        BeginChangePartitionConfig(ChangeConfig->Config, ctx);
+        BeginChangePartitionConfig(ChangeConfig->Config);
     } else if (t->ProposeConfig) {
         PQ_ENSURE(ChangingConfig);
         ChangeConfig = MakeSimpleShared<TEvPQ::TEvChangePartitionConfig>(TopicConverter,
@@ -2737,17 +3016,21 @@ bool TPartition::ExecUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t, 
     return true;
 }
 
-TPartition::EProcessResult TPartition::BeginTransaction(const TEvPQ::TEvTxCalcPredicate& tx,
-                                                        TMaybe<bool>& predicateOut, TString& issueMsg)
+TPartition::EProcessResult TPartition::BeginTransactionData(TTransaction& t,
+                                                            TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
 {
+    const TEvPQ::TEvTxCalcPredicate& tx = *t.Tx;
+    TMaybe<bool>& predicateOut = t.Predicate;
+    TString& issueMsg = t.Message;
+
     if (tx.ForcePredicateFalse) {
         predicateOut = false;
         return EProcessResult::Continue;
     }
 
-    THashSet<TString> consumers;
+    TVector<TString> consumers;
     bool result = true;
-    for (auto& operation : tx.Operations) {
+    for (const auto& operation : tx.Operations) {
         const TString& consumer = operation.GetConsumer();
         if (TxAffectedConsumers.contains(consumer)) {
             PQ_LOG_TX_D("TxAffectedConsumers contains consumer " << consumer << ". TxId " << tx.TxId);
@@ -2832,20 +3115,22 @@ TPartition::EProcessResult TPartition::BeginTransaction(const TEvPQ::TEvTxCalcPr
                 }
                 break;
             }
-            consumers.insert(consumer);
+            consumers.push_back(consumer);
             PQ_LOG_TX_D("TxId " << tx.TxId << " affect consumer " << consumer);
         }
     }
 
     if (result) {
-        TxAffectedConsumers.insert(consumers.begin(), consumers.end());
+        affectedSourceIdsAndConsumers.TxReadConsumers = std::move(consumers);
     }
     predicateOut = result;
     return EProcessResult::Continue;
 }
 
-bool TPartition::BeginTransaction(const TEvPQ::TEvProposePartitionConfig& event)
+bool TPartition::BeginTransactionConfig(TTransaction& t)
 {
+    const TEvPQ::TEvProposePartitionConfig& event = *t.ProposeConfig;
+
     ChangeConfig =
         MakeSimpleShared<TEvPQ::TEvChangePartitionConfig>(TopicConverter,
                                                           event.Config);
@@ -2949,7 +3234,6 @@ void TPartition::CommitWriteOperations(TTransaction& t)
 
 void TPartition::CommitTransaction(TSimpleSharedPtr<TTransaction>& t)
 {
-    const auto& ctx = ActorContext();
     if (t->Tx) {
         PQ_ENSURE(t->Predicate.Defined() && *t->Predicate);
 
@@ -2994,7 +3278,7 @@ void TPartition::CommitTransaction(TSimpleSharedPtr<TTransaction>& t)
     } else if (t->ProposeConfig) {
         PQ_ENSURE(t->Predicate.Defined() && *t->Predicate);
 
-        BeginChangePartitionConfig(t->ProposeConfig->Config, ctx);
+        BeginChangePartitionConfig(t->ProposeConfig->Config);
         ExecChangePartitionConfig();
         ChangePlanStepAndTxId(t->ProposeConfig->Step, t->ProposeConfig->TxId);
 
@@ -3026,15 +3310,14 @@ void TPartition::RollbackTransaction(TSimpleSharedPtr<TTransaction>& t)
     }
 }
 
-void TPartition::BeginChangePartitionConfig(const NKikimrPQ::TPQTabletConfig& config,
-                                            const TActorContext& ctx)
+void TPartition::BeginChangePartitionConfig(const NKikimrPQ::TPQTabletConfig& config)
 {
     TSet<TString> hasReadRule;
     for (auto&& [consumer, info] : UsersInfoStorage->ViewAll()) {
         hasReadRule.insert(consumer);
     }
 
-    for (auto& consumer : config.GetConsumers()) {
+    for (const auto& consumer : config.GetConsumers()) {
         auto& userInfo = GetOrCreatePendingUser(consumer.GetName(), 0);
 
         TInstant ts = TInstant::MilliSeconds(consumer.GetReadFromTimestampsMs());
@@ -3050,21 +3333,22 @@ void TPartition::BeginChangePartitionConfig(const NKikimrPQ::TPQTabletConfig& co
             auto act = MakeHolder<TEvPQ::TEvSetClientInfo>(0, consumer.GetName(), 0, "", 0, 0, 0, TActorId{},
                                         TEvPQ::TEvSetClientInfo::ESCI_INIT_READ_RULE, rrGen);
 
-            auto res = PreProcessUserAct(*act, ctx);
-            ChangeConfigActs.emplace_back(std::move(act));
-
+            auto res = PreProcessUserAct(*act, nullptr);
             PQ_ENSURE(res == EProcessResult::Continue);
+
+            ChangeConfigActs.emplace_back(std::move(act));
         }
         hasReadRule.erase(consumer.GetName());
     }
 
-    for (auto& consumer : hasReadRule) {
+    for (const auto& consumer : hasReadRule) {
         GetOrCreatePendingUser(consumer);
         auto act = MakeHolder<TEvPQ::TEvSetClientInfo>(0, consumer, 0, "", 0, 0, 0, TActorId{},
                                     TEvPQ::TEvSetClientInfo::ESCI_DROP_READ_RULE, 0);
 
-        auto res = PreProcessUserAct(*act, ctx);
+        auto res = PreProcessUserAct(*act, nullptr);
         PQ_ENSURE(res == EProcessResult::Continue);
+
         ChangeConfigActs.emplace_back(std::move(act));
     }
 }
@@ -3078,13 +3362,14 @@ void TPartition::ExecChangePartitionConfig() {
 
 void TPartition::OnProcessTxsAndUserActsWriteComplete(const TActorContext& ctx) {
     FirstEvent = true;
-    TxAffectedConsumers.clear();
-    TxAffectedSourcesIds.clear();
-    WriteAffectedSourcesIds.clear();
-    SetOffsetAffectedConsumers.clear();
+    DeleteAffectedSourceIdsAndConsumers();
+    //TxAffectedConsumers.clear();
+    //TxAffectedSourcesIds.clear();
+    //WriteAffectedSourcesIds.clear();
+    //SetOffsetAffectedConsumers.clear();
     BatchingState = ETxBatchingState::PreProcessing;
     WriteCycleSizeEstimate = 0;
-    WriteKeysSizeEstimate = 0;
+    //WriteKeysSizeEstimate = 0;
 
     if (ChangeConfig) {
         EndChangePartitionConfig(std::move(ChangeConfig->Config),
@@ -3169,7 +3454,7 @@ void TPartition::OnProcessTxsAndUserActsWriteComplete(const TActorContext& ctx) 
         ChangeConfig = nullptr;
         PendingPartitionConfig = nullptr;
     }
-    ChangingConfig = false;
+    //ChangingConfig = false;
     BatchingState = ETxBatchingState::PreProcessing;
 }
 
@@ -3256,15 +3541,18 @@ void TPartition::ChangePlanStepAndTxId(ui64 step, ui64 txId)
     TxIdHasChanged = true;
 }
 
-TPartition::EProcessResult TPartition::PreProcessImmediateTx(const NKikimrPQ::TEvProposeTransaction& tx)
+TPartition::EProcessResult TPartition::PreProcessImmediateTx(TTransaction& t,
+                                                             TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
 {
+    const NKikimrPQ::TEvProposeTransaction& tx = t.ProposeTransaction->GetRecord();
+
     if (AffectedUsers.size() >= MAX_USERS) {
         return EProcessResult::Blocked;
     }
     PQ_ENSURE(tx.GetTxBodyCase() == NKikimrPQ::TEvProposeTransaction::kData);
     PQ_ENSURE(tx.HasData());
-    THashSet<TString> consumers;
-    for (auto& operation : tx.GetData().GetOperations()) {
+    TVector<TString> consumers;
+    for (const auto& operation : tx.GetData().GetOperations()) {
         if (!operation.HasCommitOffsetsBegin() || !operation.HasCommitOffsetsEnd() || !operation.HasConsumer()) {
             continue; //Write operation - handled separately via WriteInfo
         }
@@ -3291,10 +3579,10 @@ TPartition::EProcessResult TPartition::PreProcessImmediateTx(const NKikimrPQ::TE
             return EProcessResult::ContinueDrop;
         }
 
-        consumers.insert(user);
+        consumers.push_back(user);
     }
-    SetOffsetAffectedConsumers.insert(consumers.begin(), consumers.end());
-    WriteKeysSizeEstimate += consumers.size();
+    affectedSourceIdsAndConsumers.ReadConsumers = std::move(consumers);
+    affectedSourceIdsAndConsumers.WriteKeysSize += consumers.size();
     return EProcessResult::Continue;
 }
 
@@ -3387,22 +3675,25 @@ void TPartition::ExecImmediateTx(TTransaction& t)
     return;
 }
 
-TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimpleSharedPtr<TEvPQ::TEvSetClientInfo>& act)
+TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimpleSharedPtr<TEvPQ::TEvSetClientInfo>& act,
+                                                                         TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
 {
     if (AffectedUsers.size() >= MAX_USERS) {
         return EProcessResult::Blocked;
     }
-    return PreProcessUserAct(*act, ActorContext());
+
+    return PreProcessUserAct(*act, &affectedSourceIdsAndConsumers);
 }
 
-bool TPartition::ExecUserActionOrTransaction(
-        TSimpleSharedPtr<TEvPQ::TEvSetClientInfo>& event, TEvKeyValue::TEvRequest*
-) {
+bool TPartition::ExecUserActionOrTransaction(TSimpleSharedPtr<TEvPQ::TEvSetClientInfo>& event,
+                                             TEvKeyValue::TEvRequest*)
+{
     CommitUserAct(*event);
     return true;
 }
 
-TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TMessage& msg)
+TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TMessage& msg,
+                                                                         TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
 {
     if (WriteCycleSize >= MAX_WRITE_CYCLE_SIZE) {
         return EProcessResult::Blocked;
@@ -3410,20 +3701,22 @@ TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TMessag
 
     auto result = EProcessResult::Continue;
     if (msg.IsWrite()) {
-        result = PreProcessRequest(msg.GetWrite());
+        result = PreProcessRequest(msg.GetWrite(), affectedSourceIdsAndConsumers);
     } else if (msg.IsRegisterMessageGroup()) {
-        result = PreProcessRequest(msg.GetRegisterMessageGroup());
+        result = PreProcessRequest(msg.GetRegisterMessageGroup(), affectedSourceIdsAndConsumers);
     } else if (msg.IsDeregisterMessageGroup()) {
-        result = PreProcessRequest(msg.GetDeregisterMessageGroup());
+        result = PreProcessRequest(msg.GetDeregisterMessageGroup(), affectedSourceIdsAndConsumers);
     } else if (msg.IsSplitMessageGroup()) {
-        result = PreProcessRequest(msg.GetSplitMessageGroup());
+        result = PreProcessRequest(msg.GetSplitMessageGroup(), affectedSourceIdsAndConsumers);
     } else {
         PQ_ENSURE(msg.IsOwnership());
     }
+
     return result;
 }
 
-bool TPartition::ExecUserActionOrTransaction(TMessage& msg, TEvKeyValue::TEvRequest* request)
+bool TPartition::ExecUserActionOrTransaction(TMessage& msg,
+                                             TEvKeyValue::TEvRequest* request)
 {
     const auto& ctx = ActorContext();
     if (!HaveWriteMsg) {
@@ -3453,9 +3746,9 @@ bool TPartition::ExecUserActionOrTransaction(TMessage& msg, TEvKeyValue::TEvRequ
     return true;
 }
 
-TPartition::EProcessResult TPartition::PreProcessUserAct(
-        TEvPQ::TEvSetClientInfo& act, const TActorContext&
-) {
+TPartition::EProcessResult TPartition::PreProcessUserAct(TEvPQ::TEvSetClientInfo& act,
+                                                         TAffectedSourceIdsAndConsumers* affectedSourceIdsAndConsumers)
+{
     PQ_ENSURE(!KVWriteInProgress);
 
     const TString& user = act.ClientId;
@@ -3464,8 +3757,12 @@ TPartition::EProcessResult TPartition::PreProcessUserAct(
             return EProcessResult::Blocked;
         }
     }
-    WriteKeysSizeEstimate += 1;
-    SetOffsetAffectedConsumers.insert(user);
+
+    if (affectedSourceIdsAndConsumers) {
+        ++affectedSourceIdsAndConsumers->WriteKeysSize;
+        affectedSourceIdsAndConsumers->ReadConsumers.push_back(user);
+    }
+
     return EProcessResult::Continue;
 }
 
@@ -4413,4 +4710,5 @@ void TPartition::ResetDetailedMetrics() {
     BytesWrittenPerPartition.Reset();
     MessagesWrittenPerPartition.Reset();
 }
+
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -57,13 +57,14 @@ class IAutopartitioningManager;
 class TPartitionCompaction;
 
 struct TTransaction {
-
-    explicit TTransaction(TSimpleSharedPtr<TEvPQ::TEvTxCalcPredicate> tx,
-                          TMaybe<bool> predicate = Nothing())
+    TTransaction(TSimpleSharedPtr<TEvPQ::TEvTxCalcPredicate> tx,
+                 TInstant calcPredicateTimestamp,
+                 TMaybe<bool> predicate = Nothing())
         : Tx(tx)
         , Predicate(predicate)
         , SupportivePartitionActor(tx->SupportivePartitionActor)
         , CalcPredicateSpan(std::move(tx->Span))
+        , CalcPredicateTimestamp(calcPredicateTimestamp)
     {
         AFL_ENSURE(Tx);
     }
@@ -123,6 +124,7 @@ struct TTransaction {
     NWilson::TSpan CommitSpan;
 
     TInstant WriteInfoResponseTimestamp;
+    TInstant CalcPredicateTimestamp;
 };
 class TPartitionCompaction;
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -82,7 +82,7 @@ bool TPartition::ExecRequestForCompaction(TWriteMsg& p, TProcessParametersBase& 
     auto newWrite = CompactionBlobEncoder.PartitionedBlob.Add(std::move(blob));
 
     if (newWrite && !newWrite->Value.empty()) {
-        AddCmdWrite(newWrite, request, blobCreationUnixTime, ctx);
+        AddCmdWrite(newWrite, request, blobCreationUnixTime, ctx, false);
 
         LOG_D("Topic '" << TopicName() <<
                 "' partition " << Partition <<
@@ -400,7 +400,7 @@ void TPartition::RenameCompactedBlob(TDataKey& k,
     auto write = CompactionBlobEncoder.PartitionedBlob.Add(k.Key, size, k.Timestamp, false);
     if (write && !write->Value.empty()) {
         // надо записать содержимое головы перед первым большим блобом
-        AddCmdWrite(write, compactionRequest, k.Timestamp, ctx);
+        AddCmdWrite(write, compactionRequest, k.Timestamp, ctx, false);
         CompactionBlobEncoder.CompactedKeys.emplace_back(write->Key, write->Value.size());
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -535,10 +535,6 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
     TxSourceIdForPostPersist.clear();
     TxInflightMaxSeqNoPerSourceId.clear();
 
-    TxAffectedSourcesIds.clear();
-    WriteAffectedSourcesIds.clear();
-    TxAffectedConsumers.clear();
-    SetOffsetAffectedConsumers.clear();
     if (UserActionAndTransactionEvents.empty()) {
         WriteInfosToTx.clear();
     }
@@ -896,7 +892,9 @@ void TPartition::CancelOneWriteOnWrite(const TActorContext& ctx,
     StartProcessChangeOwnerRequests(ctx);
 }
 
-TPartition::EProcessResult TPartition::PreProcessRequest(TRegisterMessageGroupMsg& msg) {
+TPartition::EProcessResult TPartition::PreProcessRequest(TRegisterMessageGroupMsg& msg,
+                                                         TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
+{
     if (!CanWrite()) {
         ScheduleReplyError(msg.Cookie, false, InactivePartitionErrorCode,
             TStringBuilder() << "Write to inactive partition " << Partition.OriginalPartitionId);
@@ -911,7 +909,7 @@ TPartition::EProcessResult TPartition::PreProcessRequest(TRegisterMessageGroupMs
     if (TxAffectedSourcesIds.contains(msg.Body.SourceId)) {
         return EProcessResult::Blocked;
     }
-    WriteAffectedSourcesIds.insert(msg.Body.SourceId);
+    affectedSourceIdsAndConsumers.WriteSourcesIds.push_back(msg.Body.SourceId);
     return EProcessResult::Continue;
 }
 
@@ -928,7 +926,9 @@ void TPartition::ExecRequest(TRegisterMessageGroupMsg& msg, ProcessParameters& p
     parameters.SourceIdBatch.RegisterSourceId(body.SourceId, body.SeqNo, parameters.CurOffset, CurrentTimestamp, std::move(keyRange));
 }
 
-TPartition::EProcessResult TPartition::PreProcessRequest(TDeregisterMessageGroupMsg& msg) {
+TPartition::EProcessResult TPartition::PreProcessRequest(TDeregisterMessageGroupMsg& msg,
+                                                         TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
+{
     if (!CanWrite()) {
         ScheduleReplyError(msg.Cookie, false, InactivePartitionErrorCode,
             TStringBuilder() << "Write to inactive partition " << Partition.OriginalPartitionId);
@@ -942,7 +942,7 @@ TPartition::EProcessResult TPartition::PreProcessRequest(TDeregisterMessageGroup
     if (TxAffectedSourcesIds.contains(msg.Body.SourceId)) {
         return EProcessResult::Blocked;
     }
-    WriteAffectedSourcesIds.insert(msg.Body.SourceId);
+    affectedSourceIdsAndConsumers.WriteSourcesIds.push_back(msg.Body.SourceId);
     return EProcessResult::Continue;
 }
 
@@ -951,7 +951,9 @@ void TPartition::ExecRequest(TDeregisterMessageGroupMsg& msg, ProcessParameters&
 }
 
 
-TPartition::EProcessResult TPartition::PreProcessRequest(TSplitMessageGroupMsg& msg) {
+TPartition::EProcessResult TPartition::PreProcessRequest(TSplitMessageGroupMsg& msg,
+                                                         TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
+{
     if (!CanWrite()) {
         ScheduleReplyError(msg.Cookie, false, InactivePartitionErrorCode,
             TStringBuilder() << "Write to inactive partition " << Partition.OriginalPartitionId);
@@ -967,16 +969,16 @@ TPartition::EProcessResult TPartition::PreProcessRequest(TSplitMessageGroupMsg& 
         if (TxAffectedSourcesIds.contains(body.SourceId)) {
             return EProcessResult::Blocked;
         }
-        WriteAffectedSourcesIds.insert(body.SourceId);
+        affectedSourceIdsAndConsumers.WriteSourcesIds.push_back(body.SourceId);
     }
     for (auto& body : msg.Deregistrations) {
         if (TxAffectedSourcesIds.contains(body.SourceId)) {
             return EProcessResult::Blocked;
         }
-        WriteAffectedSourcesIds.insert(body.SourceId);
+        affectedSourceIdsAndConsumers.WriteSourcesIds.push_back(body.SourceId);
     }
-    return EProcessResult::Continue;
 
+    return EProcessResult::Continue;
 }
 
 
@@ -996,7 +998,9 @@ void TPartition::ExecRequest(TSplitMessageGroupMsg& msg, ProcessParameters& para
     }
 }
 
-TPartition::EProcessResult TPartition::PreProcessRequest(TWriteMsg& p) {
+TPartition::EProcessResult TPartition::PreProcessRequest(TWriteMsg& p,
+                                                         TAffectedSourceIdsAndConsumers& affectedSourceIdsAndConsumers)
+{
     if (!CanWrite()) {
         WriteInflightSize -= p.Msg.Data.size();
         ScheduleReplyError(p.Cookie, false, InactivePartitionErrorCode,
@@ -1022,7 +1026,8 @@ TPartition::EProcessResult TPartition::PreProcessRequest(TWriteMsg& p) {
             return EProcessResult::Blocked;
         }
     }
-    WriteAffectedSourcesIds.insert(p.Msg.SourceId);
+    affectedSourceIdsAndConsumers.WriteSourcesIds.push_back(p.Msg.SourceId);
+
     return EProcessResult::Continue;
 }
 

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -22,7 +22,6 @@
 #include <util/system/types.h>
 
 #include "make_config.h"
-#include <ydb/library/dbgtrace/debug_trace.h>
 
 template<>
 void Out<NKikimrPQ::TEvProposeTransactionResult_EStatus>(IOutputStream& out, NKikimrPQ::TEvProposeTransactionResult_EStatus v) {
@@ -1117,7 +1116,7 @@ TTransaction TPartitionFixture::MakeTransaction(ui64 step, ui64 txId,
     auto event = MakeSimpleShared<TEvPQ::TEvTxCalcPredicate>(step, txId);
     event->AddOperation(std::move(consumer), begin, end);
 
-    return TTransaction(event, predicate);
+    return TTransaction(event, TInstant::Now(), predicate);
 }
 
 template<class TIterable>
@@ -2189,7 +2188,6 @@ Y_UNIT_TEST_F(CommitOffsetRanges, TPartitionFixture)
 
 Y_UNIT_TEST_F(CorrectRange_Commit, TPartitionFixture)
 {
-    DBGTRACE("CorrectRange_Commit");
     const TPartitionId partition{3};
     const ui64 begin = 0;
     const ui64 end = 10;
@@ -2199,36 +2197,25 @@ Y_UNIT_TEST_F(CorrectRange_Commit, TPartitionFixture)
     const ui64 step = 12345;
     const ui64 txId = 67890;
 
-    DBGTRACE_LOG("");
     CreatePartition({.Partition=partition, .Begin=begin, .End=end, .PlanStep=step, .TxId=10000});
-    DBGTRACE_LOG("");
     CreateSession(client, session);
 
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId, client, 0, 2);
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId, .Partition=TPartitionId(partition), .Predicate=true});
 
-    DBGTRACE_LOG("");
     SendCommitTx(step, txId);
 
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=3, .PlanStep=step, .TxId=txId, .UserInfos={{1, {.Session=session, .Offset=0}}}});
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=3, .PlanStep=step, .TxId=txId, .UserInfos={{1, {.Session=session, .Offset=2}}}});
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
-    DBGTRACE_LOG("");
     WaitCommitTxDone({.TxId=txId, .Partition=TPartitionId(partition)});
 }
 
 Y_UNIT_TEST_F(CorrectRange_Multiple_Transactions, TPartitionFixture)
 {
-    DBGTRACE("CorrectRange_Multiple_Transactions");
     const TPartitionId partition{3};
     const ui64 begin = 0;
     const ui64 end = 10;
@@ -2240,51 +2227,34 @@ Y_UNIT_TEST_F(CorrectRange_Multiple_Transactions, TPartitionFixture)
     const ui64 txId_2 = 67891;
     const ui64 txId_3 = 67892;
 
-    DBGTRACE_LOG("");
     CreatePartition({.Partition=partition, .Begin=begin, .End=end, .PlanStep=step, .TxId=10000});
-    DBGTRACE_LOG("");
     CreateSession(client, session);
 
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId_1, client, 0, 1);
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId_1, .Partition=TPartitionId(partition), .Predicate=true});
 
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId_2, client, 0, 2);
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId_3, client, 0, 2);
 
-    DBGTRACE_LOG("");
     SendCommitTx(step, txId_1);
 
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=1, .PlanStep=step, .TxId=txId_1, .UserInfos={{1, {.Session=session, .Offset=1}}}});
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
-    DBGTRACE_LOG("");
     WaitCommitTxDone({.TxId=txId_1, .Partition=TPartitionId(partition)});
 
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId_2, .Partition=TPartitionId(partition), .Predicate=false});
-    DBGTRACE_LOG("");
     SendRollbackTx(step, txId_2);
 
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId_3, .Partition=TPartitionId(partition), .Predicate=false});
-    DBGTRACE_LOG("");
     SendRollbackTx(step, txId_3);
 
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=1, .PlanStep=step, .TxId=txId_3, .UserInfos={{1, {.Session=session, .Offset=1}}}});
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 }
 
 Y_UNIT_TEST_F(CorrectRange_Multiple_Consumers, TPartitionFixture)
 {
-    DBGTRACE("CorrectRange_Multiple_Consumers");
     const TPartitionId partition{3};
     const ui64 begin = 0;
     const ui64 end = 10;
@@ -2292,34 +2262,22 @@ Y_UNIT_TEST_F(CorrectRange_Multiple_Consumers, TPartitionFixture)
     const ui64 step = 12345;
     const ui64 txId = 67890;
 
-    DBGTRACE_LOG("");
     CreatePartition({.Partition=partition, .Begin=begin, .End=end});
-    DBGTRACE_LOG("");
     CreateSession("client-1", "session-1");
-    DBGTRACE_LOG("");
     CreateSession("client-2", "session-2");
 
-    DBGTRACE_LOG("");
     SendSetOffset(1, "client-1", 3, "session-1");
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId, "client-2", 0, 1);
-    DBGTRACE_LOG("");
     SendSetOffset(2, "client-1", 6, "session-1");
 
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=2, .UserInfos={{0, {.Session="session-1", .Offset=3}}}});
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
-    DBGTRACE_LOG("");
     WaitProxyResponse({.Cookie=1, .Status=NMsgBusProxy::MSTATUS_OK});
 
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId, .Partition=TPartitionId(partition), .Predicate=true});
-    DBGTRACE_LOG("");
     SendCommitTx(step, txId);
 
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=5, .UserInfos={
                  {1, {.Session="session-2", .Offset=1}},
                  {3, {.Session="session-1", .Offset=6}}
@@ -2379,7 +2337,6 @@ Y_UNIT_TEST_F(IncorrectRange, TPartitionFixture)
 
 Y_UNIT_TEST_F(CorrectRange_Rollback, TPartitionFixture)
 {
-    DBGTRACE("CorrectRange_Rollback");
     const TPartitionId partition{3};
     const ui64 begin = 0;
     const ui64 end = 10;
@@ -2390,38 +2347,26 @@ Y_UNIT_TEST_F(CorrectRange_Rollback, TPartitionFixture)
     const ui64 txId_1 = 67890;
     const ui64 txId_2 = 67891;
 
-    DBGTRACE_LOG("");
     CreatePartition({.Partition=partition, .Begin=begin, .End=end});
-    DBGTRACE_LOG("");
     CreateSession(client, session);
 
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId_1, client, 0, 2);
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId_1, .Partition=TPartitionId(partition), .Predicate=true});
 
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId_2, client, 0, 5);
-    DBGTRACE_LOG("");
     SendRollbackTx(step, txId_1);
 
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=1, .PlanStep=step, .TxId=txId_1, .UserInfos={{1, {.Consumer="client", .Session="session", .Offset=0}}}});
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=1, .PlanStep=step, .TxId=txId_1, .UserInfos={{1, {.Consumer="client", .Session="session", .Offset=0}}}});
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId_2, .Partition=TPartitionId(partition), .Predicate=true});
 }
 
 Y_UNIT_TEST_F(ChangeConfig, TPartitionFixture)
 {
-    DBGTRACE("ChangeConfig");
     const TPartitionId partition{3};
     const ui64 begin = 0;
     const ui64 end = 10;
@@ -2430,7 +2375,6 @@ Y_UNIT_TEST_F(ChangeConfig, TPartitionFixture)
     const ui64 txId_1 = 67890;
     const ui64 txId_2 = 67891;
 
-    DBGTRACE_LOG("");
     CreatePartition({
                     .Partition=partition, .Begin=begin, .End=end,
                     .Config={.Consumers={
@@ -2440,10 +2384,8 @@ Y_UNIT_TEST_F(ChangeConfig, TPartitionFixture)
                     }}
     });
 
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId_1, "client-1", 0, 2);
     Cerr << "Send change config\n";
-    DBGTRACE_LOG("");
     SendChangePartitionConfig({.Version=2,
                               .Consumers={
                               {.Consumer="client-1", .Generation=0},
@@ -2452,15 +2394,11 @@ Y_UNIT_TEST_F(ChangeConfig, TPartitionFixture)
     //
     // consumer 'client-2' will be deleted
     //
-    DBGTRACE_LOG("");
     SendCalcPredicate(step, txId_2, "client-2", 0, 2);
 
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId_1, .Partition=TPartitionId(partition), .Predicate=true});
-    DBGTRACE_LOG("");
     SendCommitTx(step, txId_1);
     Cerr << "Wait cmd write (initial)\n";
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=8,
                  .PlanStep=step, .TxId=txId_1,
                  .UserInfos={
@@ -2468,10 +2406,8 @@ Y_UNIT_TEST_F(ChangeConfig, TPartitionFixture)
                  },
                  });
 
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
     Cerr << "Wait commit 1 done\n";
-    DBGTRACE_LOG("");
     WaitCommitTxDone({.TxId=txId_1, .Partition=TPartitionId(partition)});
 
     //
@@ -2484,7 +2420,6 @@ Y_UNIT_TEST_F(ChangeConfig, TPartitionFixture)
     //              },
     // });
     Cerr << "Wait cmd write (change config)\n";
-    DBGTRACE_LOG("");
     WaitCmdWrite({.Count=8,
                  .PlanStep=step, .TxId=txId_1,
                  .UserInfos={
@@ -2494,18 +2429,14 @@ Y_UNIT_TEST_F(ChangeConfig, TPartitionFixture)
                  .DeleteRanges={
                  {0, {.Partition=3, .Consumer="client-2"}}
                  }});
-    DBGTRACE_LOG("");
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
     Cerr << "Wait config changed\n";
-    DBGTRACE_LOG("");
     WaitPartitionConfigChanged({.Partition=TPartitionId(partition)});
 
     //
     // consumer 'client-2' was deleted
     //
-    DBGTRACE_LOG("");
     WaitCalcPredicateResult({.Step=step, .TxId=txId_2, .Partition=TPartitionId(partition), .Predicate=false});
-    DBGTRACE_LOG("");
     SendRollbackTx(step, txId_2);
 }
 
@@ -2825,61 +2756,39 @@ Y_UNIT_TEST_F(ShadowPartitionCountersRestore, TPartitionFixture) {
 
 Y_UNIT_TEST_F(DataTxCalcPredicateOk, TPartitionTxTestHelper)
 {
-    DBGTRACE("DataTxCalcPredicateOk");
     Init();
-    DBGTRACE_LOG("");
     CreateSession("client", "session");
     i64 cookie = 1;
 
-    DBGTRACE_LOG("");
     auto tx1 = MakeAndSendWriteTx({});
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx1, true);
     Cerr << "Wait first predicate result " << Endl;
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx1);
 
-    DBGTRACE_LOG("");
     auto tx2 = MakeAndSendWriteTx({{"src1", {1, 10}}});
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx2, true);
-    DBGTRACE_LOG("");
     SendTxCommit(tx1);
     Cerr << "Wait second predicate result " << Endl;
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx2);
-    DBGTRACE_LOG("");
     SendTxCommit(tx2);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
 
     TString data = "data for write";
 
-    DBGTRACE_LOG("");
     SendChangeOwner(cookie, "owner1", Ctx->Edge, true);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     auto ownerEvent = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvProxyResponse>(TDuration::Seconds(1));
     UNIT_ASSERT(ownerEvent != nullptr);
-    DBGTRACE_LOG("");
     auto ownerCookie = ownerEvent->Response->GetPartitionResponse().GetCmdGetOwnershipResult().GetOwnerCookie();
 
-    DBGTRACE_LOG("");
     SendWrite(++cookie, 0, ownerCookie, 51, data, false, 5);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitProxyResponse({.Cookie=cookie});
 
     Cerr << "Wait third predicate result " << Endl;
-    DBGTRACE_LOG("");
     auto tx3 = MakeAndSendWriteTx({{"src1", {12, 20}}, {"SourceId", {6, 10}}});
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx3, true);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx3);
-    DBGTRACE_LOG("");
     SendTxCommit(tx3);
 }
 
@@ -2977,101 +2886,63 @@ Y_UNIT_TEST_F(TestTxBatchInFederation, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingActsInSeveralBatches, TPartitionTxTestHelper) {
-    DBGTRACE("ConflictingActsInSeveralBatches");
     TTxBatchingTestParams params {.WriterSessions{"src1", "src4"},.EndOffset=1};
-    DBGTRACE_LOG("");
     Init(std::move(params));
 
-    DBGTRACE_LOG("");
     auto tx1 = MakeAndSendWriteTx({{"src1", {1, 3}}});
-    DBGTRACE_LOG("");
     auto tx2 = MakeAndSendWriteTx({{"src2", {4, 6}}});
-    DBGTRACE_LOG("");
     auto tx3 = MakeAndSendWriteTx({{"src1", {4, 6}}});
 
-    DBGTRACE_LOG("");
     AddAndSendNormalWrite("src1", 7, 12);
-    DBGTRACE_LOG("");
     AddAndSendNormalWrite("src4", 1, 2);
-    DBGTRACE_LOG("");
     auto tx5 = MakeAndSendWriteTx({{"src4", {4, 5}}});
-    DBGTRACE_LOG("");
     AddAndSendNormalWrite("src4", 7, 12);
-    DBGTRACE_LOG("");
     auto immTx1 = MakeAndSendImmediateTx({{"src4", {13, 15}}});
 
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx1, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx2, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx3, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx5, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(immTx1, true);
 
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx1);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx2);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(2);
 
-    DBGTRACE_LOG("");
     SendTxCommit(tx1);
-    DBGTRACE_LOG("");
     SendTxRollback(tx2);
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
 
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx3);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     SendTxCommit(tx3);
 
     //2 Normal writes with src1 & src4
-    DBGTRACE_LOG("");
     ExpectNoTxPredicateReply();
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx1);
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx3);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx5);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(6 + 2); // Normal writes produce 1 act for each message
-    DBGTRACE_LOG("");
     SendTxCommit(tx5);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
 
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx5);
 
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1 + 6); //Normal write & immTx for src4;
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx1, true);
 }
 
@@ -3179,78 +3050,48 @@ Y_UNIT_TEST_F(ConflictingSrcIdForTxInDifferentBatches, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingSrcIdTxAndWritesDifferentBatches, TPartitionTxTestHelper) {
-    DBGTRACE("ConflictingSrcIdTxAndWritesDifferentBatches");
     TTxBatchingTestParams params {.WriterSessions{"src1"}, .EndOffset = 1};
-    DBGTRACE_LOG("");
     Init(std::move(params));
 
-    DBGTRACE_LOG("");
     auto tx1 = MakeAndSendWriteTx({{"src1", {1, 3}},});
-    DBGTRACE_LOG("");
     auto tx2 = MakeAndSendWriteTx({{"src1", {2, 4}}});
-    DBGTRACE_LOG("");
     auto tx3 = MakeAndSendWriteTx({{"src1", {4, 6}}});
-    DBGTRACE_LOG("");
     AddAndSendNormalWrite("src1", 1, 1);
-    DBGTRACE_LOG("");
     AddAndSendNormalWrite("src1", 7, 7);
-    DBGTRACE_LOG("");
     AddAndSendNormalWrite("src1", 7, 7);
 
 
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx1, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx2, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx3, true);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx1);
 
-    DBGTRACE_LOG("");
     SendTxCommit(tx1);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
 
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
 
-    DBGTRACE_LOG("");
     WaitCommitDone(tx1);
 
-    DBGTRACE_LOG("");
     WaitTxPredicateFailure(tx2);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx3);
-    DBGTRACE_LOG("");
     SendTxRollback(tx2);
-    DBGTRACE_LOG("");
     SendTxCommit(tx3);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(2); // Tx 2 & 3.
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx3);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(3);
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitProxyResponse({.AlreadyWritten=true, .SeqNo=1});
-    DBGTRACE_LOG("");
     WaitProxyResponse({.AlreadyWritten=false, .SeqNo=7});
-    DBGTRACE_LOG("");
     WaitProxyResponse({.AlreadyWritten=true, .SeqNo=7});
 }
 
@@ -3328,172 +3169,105 @@ public:
 };
 
 Y_UNIT_TEST_F(DifferentWriteTxBatchingOptions, TPartitionTxTestHelper) {
-    DBGTRACE("DifferentWriteTxBatchingOptions");
     auto wrapper = TBatchingConditionsTest(this);
 
     // 1. ImmTx -> NormWrite -> ImmTx -> NormWrite = All batched
     {
-    DBGTRACE_LOG("");
     wrapper.Start();
-    DBGTRACE_LOG("");
     wrapper.AddNormalWrite();
-    DBGTRACE_LOG("");
     auto immTx1 = wrapper.AddImmediateTx();
-    DBGTRACE_LOG("");
     wrapper.AddNormalWrite();
-    DBGTRACE_LOG("");
     auto immTx2 = wrapper.AddImmediateTx();
-    DBGTRACE_LOG("");
     wrapper.Process();
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(immTx1, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(immTx2, true);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(4 + 1);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx1, true);
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx2, true);
     }
     {
     // 2. ImmTx -> WriteTx = KVRequest
-    DBGTRACE_LOG("");
     ResetBatchCompletion();
-    DBGTRACE_LOG("");
     wrapper.Start();
-    DBGTRACE_LOG("");
     auto immTx = wrapper.AddImmediateTx();
-    DBGTRACE_LOG("");
     auto tx = wrapper.AddTx();
-    DBGTRACE_LOG("");
     wrapper.Process();
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(immTx, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx, true);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1+1);
-    DBGTRACE_LOG("");
     ExpectNoTxPredicateReply();
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx, true);
-    DBGTRACE_LOG("");
     ExpectNoCommitDone();
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx);
-    DBGTRACE_LOG("");
     SendTxCommit(tx);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx);
     }
     {
     // 3. NormWrite -> WriteTx = KVRequest
-    DBGTRACE_LOG("");
     ResetBatchCompletion();
-    DBGTRACE_LOG("");
     wrapper.Start();
-    DBGTRACE_LOG("");
     wrapper.AddNormalWrite();
-    DBGTRACE_LOG("");
     auto tx = wrapper.AddTx();
-    DBGTRACE_LOG("");
     wrapper.Process();
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx, true);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1+1);
-    DBGTRACE_LOG("");
     ExpectNoTxPredicateReply();
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx);
-    DBGTRACE_LOG("");
     SendTxCommit(tx);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx);
     }
     {
     // 4. WriteTx -> NormWrite = 2 batches
-    DBGTRACE_LOG("");
     ResetBatchCompletion();
-    DBGTRACE_LOG("");
     wrapper.Start();
-    DBGTRACE_LOG("");
     auto tx = wrapper.AddTx();
-    DBGTRACE_LOG("");
     wrapper.AddNormalWrite();
-    DBGTRACE_LOG("");
     wrapper.Process();
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx, true);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1+1);
-    DBGTRACE_LOG("");
     ExpectNoKvRequest();
-    DBGTRACE_LOG("");
     SendTxCommit(tx);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
     }
     {
     // 5. WriteTx -> ImmTx = 2 batches
-    DBGTRACE_LOG("");
     ResetBatchCompletion();
-    DBGTRACE_LOG("");
     wrapper.Start();
-    DBGTRACE_LOG("");
     auto tx = wrapper.AddTx();
-    DBGTRACE_LOG("");
     auto immTx = wrapper.AddImmediateTx();
-    DBGTRACE_LOG("");
     wrapper.Process();
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(tx, true);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(immTx, true);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1+1);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx);
-    DBGTRACE_LOG("");
     SendTxCommit(tx);
-    DBGTRACE_LOG("");
     ExpectNoCommitDone();
-    DBGTRACE_LOG("");
     EmulateKVTablet();
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     WaitCommitDone(tx);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx, true);
     }
 }
@@ -3547,167 +3321,106 @@ Y_UNIT_TEST_F(FailedTxsDontBlock, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(NonConflictingCommitsBatch, TPartitionTxTestHelper) {
-    DBGTRACE("NonConflictingCommitsBatch");
     TTxBatchingTestParams params{
         .ConsumersCount= 3,
         .ConsumerSessions={1},
         .EndOffset=50
     };
-    DBGTRACE_LOG("");
     Init(std::move(params));
 
     //Just block processing so every message arrives before batching starts
-    DBGTRACE_LOG("");
     auto txTmp = MakeAndSendWriteTx({});
-    DBGTRACE_LOG("");
     MakeAndSendNormalOffsetCommit(1, 5);
-    DBGTRACE_LOG("");
     auto tx1 = MakeAndSendTxOffsetCommit(3, 0, 5);
-    DBGTRACE_LOG("");
     auto tx2 = MakeAndSendTxOffsetCommit(2, 0, 5);
-    DBGTRACE_LOG("");
     MakeAndSendNormalOffsetCommit(1, 10);
-    DBGTRACE_LOG("");
     auto txImm1 = MakeAndSendImmediateTxOffsetCommit(1, 0, 15);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(txTmp, true);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(txTmp);
-    DBGTRACE_LOG("");
     SendTxRollback(txTmp);
 
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx1);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx2);
 
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(5 + 1 /*tmpTx*/);
-    DBGTRACE_LOG("");
     SendTxCommit(tx1);
-    DBGTRACE_LOG("");
     SendTxCommit(tx2);
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
 
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx1);
-    DBGTRACE_LOG("");
     WaitCommitDone(tx2);
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(txImm1, false);
 }
 
 Y_UNIT_TEST_F(ConflictingCommitsInSeveralBatches, TPartitionTxTestHelper) {
-    DBGTRACE("ConflictingCommitsInSeveralBatches");
     TTxBatchingTestParams params{
         .ConsumersCount= 2,
         .ConsumerSessions={1},
         .EndOffset=50
     };
-    DBGTRACE_LOG("");
     Init(std::move(params));
 
-    DBGTRACE_LOG("");
     //Just block processing so every message arrives before batching starts
     auto txTmp = MakeAndSendWriteTx({});
 
-    DBGTRACE_LOG("");
     MakeAndSendNormalOffsetCommit(1, 2); // act-1
-    DBGTRACE_LOG("");
     auto tx1 = MakeAndSendTxOffsetCommit(1, 2, 5);
-    DBGTRACE_LOG("");
     auto tx2 = MakeAndSendTxOffsetCommit(1, 5, 10);
-    DBGTRACE_LOG("");
     MakeAndSendNormalOffsetCommit(1, 20); // act-2
-    DBGTRACE_LOG("");
     ResetBatchCompletion();
 
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(txTmp, true);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(txTmp);
 
-    DBGTRACE_LOG("");
     SendTxRollback(txTmp);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(2); // txTmp + act-1
 
-    DBGTRACE_LOG("");
     ExpectNoTxPredicateReply();
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
 
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx1);
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     ExpectNoTxPredicateReply();
-    DBGTRACE_LOG("");
     SendTxCommit(tx1);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1); // tx1
 
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx2);
-    DBGTRACE_LOG("");
     SendTxCommit(tx2);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1); // tx2
 
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx1);
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx2);
 
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1); // act-2
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
 
-    DBGTRACE_LOG("");
     txTmp = MakeAndSendWriteTx({});
-    DBGTRACE_LOG("");
     auto immTx1 = MakeAndSendImmediateTxOffsetCommit(2, 0, 5);
-    DBGTRACE_LOG("");
     auto immTx2 = MakeAndSendImmediateTxOffsetCommit(2, 5, 10);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(txTmp, true);
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(txTmp);
-    DBGTRACE_LOG("");
     SendTxRollback(txTmp);
 
-    DBGTRACE_LOG("");
     WaitKvRequest();
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(3);
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx1, true);
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx2, true);
 }
 
@@ -3784,153 +3497,100 @@ Y_UNIT_TEST_F(ConflictingCommitFails, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingCommitProccesAfterRollback, TPartitionTxTestHelper) {
-    DBGTRACE("ConflictingCommitProccesAfterRollback");
     TTxBatchingTestParams params{
         .ConsumersCount = 2,
         .EndOffset=50
     };
-    DBGTRACE_LOG("");
     Init(std::move(params));
 
-    DBGTRACE_LOG("");
     auto tx1 = MakeAndSendTxOffsetCommit(1, 0, 5);
-    DBGTRACE_LOG("");
     auto tx2 = MakeAndSendTxOffsetCommit(1, 0, 3);
 
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx1);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
 
-    DBGTRACE_LOG("");
     SendTxRollback(tx1);
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
 
-    DBGTRACE_LOG("");
     WaitTxPredicateReply(tx2);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     SendTxCommit(tx2);
 
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitKvRequest();
-    DBGTRACE_LOG("");
     SendKvResponse();
-    DBGTRACE_LOG("");
     WaitCommitDone(tx2);
-    DBGTRACE_LOG("");
     ExpectNoCommitDone();
 }
 
 Y_UNIT_TEST_F(TestBatchingWithChangeConfig, TPartitionTxTestHelper) {
-    DBGTRACE("TestBatchingWithChangeConfig");
     Init({.ConsumersCount = 2});
-    DBGTRACE_LOG("");
     auto txTmp = MakeAndSendWriteTx({});
-    DBGTRACE_LOG("");
     auto immTx1 = MakeAndSendImmediateTxOffsetCommit(1, 0, 5);
-    DBGTRACE_LOG("");
     SendChangePartitionConfig({.Version=2,
                                 .Consumers={
                                 {.Consumer="client-0", .Offset=5, .Generation=0},
                                 {.Consumer="client-1", .Generation=7}
                                 }});
-    DBGTRACE_LOG("");
     auto immTx2 = MakeAndSendImmediateTxOffsetCommit(1, 5, 10);
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(txTmp, true);
-    DBGTRACE_LOG("");
     SendTxRollback(txTmp);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(2);
-    DBGTRACE_LOG("");
     ExpectNoBatchCompletion();
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx1, true);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvPartitionConfigChanged>();
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1); // immTx2
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx2, true);
 }
 
 Y_UNIT_TEST_F(TestBatchingWithProposeConfig, TPartitionTxTestHelper) {
-    DBGTRACE("TestBatchingWithProposeConfig");
     Init({.ConsumersCount = 2});
-    DBGTRACE_LOG("");
     auto txTmp = MakeAndSendWriteTx({});
-    DBGTRACE_LOG("");
     auto immTx1 = MakeAndSendImmediateTxOffsetCommit(1, 0, 5);
 
-    DBGTRACE_LOG("");
     auto proposeTxId = GetTxId();
-    DBGTRACE_LOG("");
     auto event = std::make_unique<TEvPQ::TEvProposePartitionConfig>(1, proposeTxId);
 
-    DBGTRACE_LOG("");
     event->TopicConverter = TopicConverter;
     auto copy = Config;
-    DBGTRACE_LOG("");
     copy.SetVersion(10);
-    DBGTRACE_LOG("");
     auto* newConsumer = copy.AddConsumers();
 
-    DBGTRACE_LOG("");
     newConsumer->SetName("client-0");
-    DBGTRACE_LOG("");
     newConsumer->SetGeneration(0);
 
-    DBGTRACE_LOG("");
     event->Config = std::move(copy);
-    DBGTRACE_LOG("");
     SendEvent(event.release());
-    DBGTRACE_LOG("");
     auto immTx2 = MakeAndSendImmediateTxOffsetCommit(1, 5, 10);
 
-    DBGTRACE_LOG("");
     WaitWriteInfoRequest(txTmp, true);
-    DBGTRACE_LOG("");
     SendTxRollback(txTmp);
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(2);
-    DBGTRACE_LOG("");
     ExpectNoBatchCompletion();
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx1, true);
 
-    DBGTRACE_LOG("");
     SendCommitTx(1, proposeTxId);
     //ToDo - wait propose result;
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitCommitTxDone({.TxId=proposeTxId});
     //DBGTRACE_LOG("");
     //WaitBatchCompletion(1);
-    DBGTRACE_LOG("");
     EmulateKVTablet();
-    DBGTRACE_LOG("");
     WaitImmediateTxComplete(immTx2, true);
 }
 

--- a/ydb/core/persqueue/ut/ya.make
+++ b/ydb/core/persqueue/ut/ya.make
@@ -25,7 +25,6 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
 
     ydb/core/tx/schemeshard/ut_helpers
-    ydb/library/dbgtrace
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/persqueue/ut/ya.make
+++ b/ydb/core/persqueue/ut/ya.make
@@ -25,6 +25,7 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
 
     ydb/core/tx/schemeshard/ut_helpers
+    ydb/library/dbgtrace
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/protos/counters_pq.proto
+++ b/ydb/core/protos/counters_pq.proto
@@ -141,6 +141,8 @@ enum EPercentileCounters {
     COUNTER_LATENCY_PQ_SPLIT_MESSAGE_GROUP = 19                 [(CounterOpts) = {Name: "LatencySplitMessageGroup"}];
     COUNTER_LATENCY_PQ_PUBLISH_READ = 20                        [(CounterOpts) = {Name: "LatencyPublishRead"}];
     COUNTER_LATENCY_PQ_FORGET_READ = 21                         [(CounterOpts) = {Name: "LatencyForgetRead"}];
+
+    COUNTER_LATENCY_PQ_TXCALCPREDICATE = 22                     [(CounterOpts) = {Name: "LatencyTxCalcPredicate"}];
 }
 
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

If the transaction does not conflict with other transactions, then the partition actor may not wait until the persist iteration is completed.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
