### PR TITLE
Disable bulk upserts without specified DEFAULT columns

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -238,5 +238,5 @@ message TFeatureFlags {
     optional bool EnableTopicMessageLevelParallelism = 212 [default = false];
     optional bool EnableOlapRejectProbability = 213 [default = false];
     optional bool EnablePDiskLogForSmallDisks = 214 [default = false];
-    optional bool DisableMissingDefaultColumnsInBulkUpsert = 215 [default = false];
+    optional bool DisableMissingDefaultColumnsInBulkUpsert = 215 [default = true];
 }

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -602,6 +602,7 @@ private:
                 return TConclusionStatus::Fail(Sprintf("Missing default columns: %s", JoinSeq(", ", defaultColumnsLeft).c_str()));
             }
 
+            // TODO: Unreachable, delete "MissingDefaultColumns/Count" counter
             UploadCounters.OnMissingDefaultColumns();
             LOG_WARN_S(ctx, NKikimrServices::RPC_REQUEST, "Missing default columns: " << JoinSeq(", ", defaultColumnsLeft).c_str());
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Flag `DisableMissingDefaultColumnsInBulkUpsert` is enabled.
Reason: https://nda.ya.ru/t/2D4PQ8xu7MTQkS

...
