### PR TITLE
[ICRDMA] Do not fail memory pool in case of absent ibverbs library. EXT-1506

### DIFF
--- a/ydb/library/actors/interconnect/rdma/link_manager.cpp
+++ b/ydb/library/actors/interconnect/rdma/link_manager.cpp
@@ -38,6 +38,10 @@ public:
         return CtxMap;
     }
 
+    bool IsLoadFail() const noexcept {
+        return LoadFail;
+    }
+
     TRdmaCtx* GetCtx(const ibv_gid& gid) {
         auto it = std::lower_bound(
             CtxMap.begin(), CtxMap.end(),
@@ -58,6 +62,7 @@ public:
         try {
             IbvDlOpen();
         } catch (std::exception& ex) {
+            LoadFail = true;
             return;
         }
     }
@@ -142,7 +147,7 @@ private:
     TString Err;
     std::mutex Mtx;
     bool Inited = false;
-
+    bool LoadFail = false;
 
 } RdmaLinkManager;
 
@@ -168,8 +173,12 @@ const TCtxsMap& GetAllCtxs() {
     return RdmaLinkManager.GetAllCtxs();
 }
 
-void Init() {
+bool Init() {
+    if (RdmaLinkManager.IsLoadFail()) {
+        return false;
+    }
     RdmaLinkManager.ScanDevices();
+    return true;
 }
 
 } 

--- a/ydb/library/actors/interconnect/rdma/link_manager.h
+++ b/ydb/library/actors/interconnect/rdma/link_manager.h
@@ -44,5 +44,5 @@ using TCtxsMap = std::vector<std::pair<ibv_gid, std::shared_ptr<NInterconnect::N
 TRdmaCtx* GetCtx(int sockfd);
 TRdmaCtx* GetCtx(const in6_addr& );
 const TCtxsMap& GetAllCtxs();
-void Init();
+bool Init();
 }

--- a/ydb/library/actors/interconnect/rdma/mem_pool.cpp
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.cpp
@@ -65,20 +65,7 @@ namespace NInterconnect::NRdma {
     }
 
     ~TChunk() {
-        MemPool->NotifyDealocated();
-        if (Empty()) {
-            return;
-        }
-        auto addr = MRs.front()->addr;
-#ifndef MEM_POOL_DISABLE_RDMA_SUPPORT
-        for (auto& m: MRs) {
-            ibv_dereg_mr(m);
-        }
-#else
-        free(MRs.front());
-#endif
-        freeMemory(addr);
-        MRs.clear();
+        MemPool->DealocateMr(MRs);
     }
 
     ibv_mr* GetMr(size_t deviceIndex) noexcept {
@@ -265,30 +252,36 @@ namespace NInterconnect::NRdma {
 
     std::vector<ibv_mr*> registerMemory(void* addr, size_t size, const NInterconnect::NRdma::NLinkMgr::TCtxsMap& ctxs) {
         std::vector<ibv_mr*> res;
+
+// In case of windows windows we can't use ibv_dereg_mr - compile error
+// In case of linux but absent librray we can't register memory, but we need mem pool for tests - emulate registration
 #ifndef MEM_POOL_DISABLE_RDMA_SUPPORT
-        res.reserve(ctxs.size());
-        for (const auto& [_, ctx]: ctxs) {
-            ibv_mr* mr = ibv_reg_mr(
-                ctx->GetProtDomain(), addr, size,
-                IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE
-            );
-            if (!mr) {
-                for (ibv_mr* tmp : res) {
-                    ibv_dereg_mr(tmp);
+        if (!ctxs.empty()) {
+            res.reserve(ctxs.size());
+            for (const auto& [_, ctx]: ctxs) {
+                ibv_mr* mr = ibv_reg_mr(
+                    ctx->GetProtDomain(), addr, size,
+                    IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE
+                );
+                if (!mr) {
+                    for (ibv_mr* tmp : res) {
+                        ibv_dereg_mr(tmp);
+                    }
+                    return {};
                 }
-                return {};
+                res.push_back(mr);
             }
-            res.push_back(mr);
-        }
-#else
-        Y_UNUSED(ctxs);
-        // Just emulate registration if platform is not support rdma code compilation.
-        // Probably ibdrv should be fixed to support compilation on windows 
-        struct ibv_mr* dummy = (struct ibv_mr*)calloc(1, sizeof(struct ibv_mr));
-        dummy->addr = addr;
-        dummy->length = size;
-        res.push_back(dummy);
+        } else
 #endif
+        {
+#ifdef MEM_POOL_DISABLE_RDMA_SUPPORT
+        Y_UNUSED(ctxs);
+#endif
+            struct ibv_mr* dummy = (struct ibv_mr*)calloc(1, sizeof(struct ibv_mr));
+            dummy->addr = addr;
+            dummy->length = size;
+            res.push_back(dummy);
+        }
         return res;
     }
 
@@ -361,10 +354,28 @@ namespace NInterconnect::NRdma {
             return MakeIntrusive<TChunk>(std::move(mrs), this);
         }
 
-        void NotifyDealocated() noexcept override {
-            const std::lock_guard<std::mutex> lock(Mutex);
-            AllocatedChunks--;
-            AllocatedChunksCounter->Dec();
+        void DealocateMr(std::vector<ibv_mr*>& mrs) noexcept override {
+            {
+                const std::lock_guard<std::mutex> lock(Mutex);
+                AllocatedChunks--;
+                AllocatedChunksCounter->Dec();
+            }
+            if (mrs.empty()) {
+                return;
+            }
+            auto addr = mrs.front()->addr;
+#ifndef MEM_POOL_DISABLE_RDMA_SUPPORT
+            if (!Ctxs.empty()) {
+                for (auto& m: mrs) {
+                    ibv_dereg_mr(m);
+                }
+            } else
+#endif
+            {
+                free(mrs.front());
+            }
+            freeMemory(addr);
+            mrs.clear();
         }
 
         const NInterconnect::NRdma::NLinkMgr::TCtxsMap Ctxs;

--- a/ydb/library/actors/interconnect/rdma/mem_pool.h
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.h
@@ -93,7 +93,7 @@ namespace NInterconnect::NRdma {
     protected:
         virtual TMemRegion* AllocImpl(int size, ui32 flags) noexcept = 0;
         virtual void Free(TMemRegion&& mr, TChunk& chunk) noexcept = 0;
-        virtual void NotifyDealocated() noexcept = 0;
+        virtual void DealocateMr(std::vector<ibv_mr*>& mrs) noexcept = 0;
     };
 
     std::shared_ptr<IMemPool> CreateDummyMemPool() noexcept;


### PR DESCRIPTION
The RDMA code will not work without ibverbs but we still need mem pool in this case for test purpose. So this pr emulate memory region registration if we have no ibverbs context

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The RDMA code will not work without ibverbs but we still need mem pool in this case for test purpose.
    So this pr emulate memory region registration if we have no ibverbs context

### Changelog category <!-- remove all except one -->


* Experimental feature


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
