### PR TITLE
merge to stable-25-3 YQ-4312 features and fixes for streaming 3

### DIFF
--- a/ydb/core/fq/libs/checkpoint_storage/storage_proxy.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/storage_proxy.cpp
@@ -1,6 +1,9 @@
 #include "storage_proxy.h"
 
 #include "gc.h"
+
+#include <ydb/core/base/appdata_fwd.h>
+
 #include <ydb/core/fq/libs/config/protos/storage.pb.h>
 #include <ydb/core/fq/libs/control_plane_storage/util.h>
 #include "ydb_checkpoint_storage.h"
@@ -22,6 +25,8 @@
 #include <util/string/join.h>
 #include <util/string/strip.h>
 
+#include <library/cpp/retry/retry_policy.h>
+
 namespace NFq {
 
 using namespace NActors;
@@ -29,6 +34,8 @@ using namespace NActors;
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
+
+constexpr char CHECKPOINTS_TABLE_PREFIX[] = ".metadata/streaming/checkpoints";
 
 struct TStorageProxyMetrics : public TThrRefBase {
     explicit TStorageProxyMetrics(const ::NMonitoring::TDynamicCounterPtr& counters)
@@ -65,7 +72,32 @@ struct TRequestContext : public TThrRefBase {
     }
 };
 
+struct TEvPrivate {
+    // Event ids
+    enum EEv : ui32 {
+        EvBegin = EventSpaceBegin(TEvents::ES_PRIVATE),
+        EvInitResult = EvBegin,
+        EvInitialize,
+        EvEnd
+    };
+    static_assert(EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE)");
+
+    // Events
+    struct TEvInitResult : public TEventLocal<TEvInitResult, EvInitResult> {
+        TEvInitResult(const NYql::TIssues& storageIssues, const NYql::TIssues& stateIssues)
+            : StorageIssues(storageIssues)
+            , StateIssues(stateIssues) {}
+        NYql::TIssues StorageIssues;
+        NYql::TIssues StateIssues;
+    };
+    struct TEvInitialize : public TEventLocal<TEvInitialize, EvInitialize> {
+    };
+};
+
 class TStorageProxy : public TActorBootstrapped<TStorageProxy> {
+private:
+    using IRetryPolicy = IRetryPolicy<>;
+
     TCheckpointStorageSettings Config;
     TString IdsPrefix;
     TExternalStorageSettings StorageConfig;
@@ -75,7 +107,8 @@ class TStorageProxy : public TActorBootstrapped<TStorageProxy> {
     NKikimr::TYdbCredentialsProviderFactory CredentialsProviderFactory;
     NYdb::TDriver Driver;
     const TStorageProxyMetricsPtr Metrics;
-    bool Initialized = false;
+    const IRetryPolicy::TPtr RetryPolicy;
+    IRetryPolicy::IRetryState::TPtr RetryState;
 
 public:
     explicit TStorageProxy(
@@ -101,6 +134,8 @@ private:
 
         hFunc(NYql::NDq::TEvDqCompute::TEvSaveTaskState, Handle);
         hFunc(NYql::NDq::TEvDqCompute::TEvGetTaskState, Handle);
+        hFunc(TEvPrivate::TEvInitResult, Handle);
+        hFunc(TEvPrivate::TEvInitialize, Handle);
     )
 
     void Handle(TEvCheckpointStorage::TEvRegisterCoordinatorRequest::TPtr& ev);
@@ -114,6 +149,8 @@ private:
 
     void Handle(NYql::NDq::TEvDqCompute::TEvSaveTaskState::TPtr& ev);
     void Handle(NYql::NDq::TEvDqCompute::TEvGetTaskState::TPtr& ev);
+    void Handle(TEvPrivate::TEvInitResult::TPtr& ev);
+    void Handle(TEvPrivate::TEvInitialize::TPtr& ev);
 };
 
 static void FillDefaultParameters(TCheckpointStorageSettings& checkpointCoordinatorConfig, TExternalStorageSettings& ydbStorageConfig) {
@@ -137,15 +174,29 @@ TStorageProxy::TStorageProxy(
     , StorageConfig(Config.GetExternalStorage())
     , CredentialsProviderFactory(credentialsProviderFactory)
     , Driver(std::move(driver))
-    , Metrics(MakeIntrusive<TStorageProxyMetrics>(counters)) {
+    , Metrics(MakeIntrusive<TStorageProxyMetrics>(counters))
+    , RetryPolicy(IRetryPolicy::GetExponentialBackoffPolicy(
+        [](){return ERetryErrorClass::LongRetry;},
+        TDuration::MilliSeconds(100), 
+        TDuration::MilliSeconds(100),
+        TDuration::Seconds(10)
+        )) {
     FillDefaultParameters(Config, StorageConfig);
 }
 
 void TStorageProxy::Bootstrap() {
     LOG_STREAMS_STORAGE_SERVICE_INFO("Bootstrap");
-    auto ydbConnectionPtr = NewYdbConnection(Config.GetExternalStorage(), CredentialsProviderFactory, Driver);
-    CheckpointStorage = NewYdbCheckpointStorage(StorageConfig, CreateEntityIdGenerator(IdsPrefix), ydbConnectionPtr);
-    StateStorage = NewYdbStateStorage(Config, ydbConnectionPtr);
+    IYdbConnection::TPtr ydbConnection;
+    if (!StorageConfig.GetEndpoint().empty()) {
+        LOG_STREAMS_STORAGE_SERVICE_INFO("Create sdk ydb connection");
+        ydbConnection = CreateSdkYdbConnection(StorageConfig, CredentialsProviderFactory, Driver);
+    } else {
+        LOG_STREAMS_STORAGE_SERVICE_INFO("Create local ydb connection");
+        ydbConnection = CreateLocalYdbConnection(NKikimr::AppData()->TenantName, CHECKPOINTS_TABLE_PREFIX);
+    }
+    CheckpointStorage = NewYdbCheckpointStorage(StorageConfig, CreateEntityIdGenerator(IdsPrefix), ydbConnection);
+    StateStorage = NewYdbStateStorage(Config, ydbConnection);
+
     if (Config.GetCheckpointGarbageConfig().GetEnabled()) {
         const auto& gcConfig = Config.GetCheckpointGarbageConfig();
         ActorGC = Register(NewGC(gcConfig, CheckpointStorage, StateStorage).release());
@@ -159,27 +210,19 @@ void TStorageProxy::Bootstrap() {
 }
 
 void TStorageProxy::Initialize() {
-    if (Initialized) {
-        return;
-    }
-    LOG_STREAMS_STORAGE_SERVICE_INFO("Initialize");
-    Initialized = true;
-    
-    auto issues = CheckpointStorage->Init().GetValueSync();
-    if (!issues.Empty()) {
-        LOG_STREAMS_STORAGE_SERVICE_ERROR("Failed to init checkpoint storage: " << issues.ToOneLineString());
-        Initialized = false;
-    }
-    
-    issues = StateStorage->Init().GetValueSync();
-    if (!issues.Empty()) {
-        LOG_STREAMS_STORAGE_SERVICE_ERROR("Failed to init checkpoint state storage: " << issues.ToOneLineString());
-        Initialized = false;
-    }
+    LOG_STREAMS_STORAGE_SERVICE_TRACE("Initialize");
+
+    auto storageInitFuture = CheckpointStorage->Init();
+    auto stateInitFuture = StateStorage->Init();
+
+    std::vector<NThreading::TFuture<NYql::TIssues>> futures{storageInitFuture, stateInitFuture};
+    auto voidFuture = NThreading::WaitAll(futures);
+    voidFuture.Subscribe([futures = std::move(futures), actorId = this->SelfId(), actorSystem = TActivationContext::ActorSystem()](const auto& ) mutable {
+            actorSystem->Send(actorId, new TEvPrivate::TEvInitResult(futures[0].GetValue(), futures[1].GetValue()));
+        });
 }
 
 void TStorageProxy::Handle(TEvCheckpointStorage::TEvRegisterCoordinatorRequest::TPtr& ev) {
-    Initialize();
     auto context = MakeIntrusive<TRequestContext>(Metrics);
 
     const auto* event = ev->Get();
@@ -433,6 +476,31 @@ void TStorageProxy::Handle(NYql::NDq::TEvDqCompute::TEvGetTaskState::TPtr& ev) {
             LOG_STREAMS_STORAGE_SERVICE_AS_DEBUG(*actorSystem, "[" << graphId << "] [" << checkpointId << "] Send TEvGetTaskStateResult: tasks: {" << JoinSeq(", ", taskIds) << "}");
             actorSystem->Send(sender, response.release(), 0, cookie);
         });
+}
+
+void TStorageProxy::Handle(TEvPrivate::TEvInitResult::TPtr& ev) {
+    const auto* event = ev->Get();
+    if (!event->StorageIssues.Empty()) {
+        LOG_STREAMS_STORAGE_SERVICE_ERROR("Failed to init checkpoint storage: " << event->StorageIssues.ToOneLineString());
+    }
+    if (!event->StateIssues.Empty()) {
+        LOG_STREAMS_STORAGE_SERVICE_ERROR("Failed to init state storage: " << event->StateIssues.ToOneLineString());
+    }
+    if (!event->StorageIssues.Empty() || !event->StateIssues.Empty()) {
+        if (RetryState == nullptr) {
+            RetryState = RetryPolicy->CreateRetryState();
+        }
+        if (auto delay = RetryState->GetNextRetryDelay()) {
+            LOG_STREAMS_STORAGE_SERVICE_INFO("Schedule init retry after " << delay);
+            Schedule(*delay, new TEvPrivate::TEvInitialize());
+        }
+        return;
+    }
+    LOG_STREAMS_STORAGE_SERVICE_INFO("Checkpoint storage and state storage were successfully inited");
+}
+
+void TStorageProxy::Handle(TEvPrivate::TEvInitialize::TPtr& /*ev*/) {
+    Initialize();
 }
 
 } // namespace

--- a/ydb/core/fq/libs/checkpoint_storage/ut/gc_ut.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ut/gc_ut.cpp
@@ -18,9 +18,10 @@
 #include <library/cpp/retry/retry.h>
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <ydb/core/testlib/actor_helpers.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/testlib/tablet_helpers.h>
-#include <ydb/core/testlib/actor_helpers.h>
+#include <ydb/core/testlib/test_client.h>
 
 #include <util/system/env.h>
 
@@ -30,6 +31,18 @@ using namespace NActors;
 using namespace NKikimr;
 
 namespace {
+
+template<typename TValue>
+class TProxyActor : public TActorBootstrapped<TProxyActor<TValue>> {
+public:
+    TProxyActor(NThreading::TPromise<TValue> p, std::function<TValue()> operation)
+        : Promise(p)
+        , Operation(operation) { }
+
+    void Bootstrap() { Promise.SetValue(Operation()); }
+    NThreading::TPromise<TValue> Promise;
+    std::function<TValue()> Operation;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -59,83 +72,106 @@ NYql::NDq::TComputeActorState MakeStateFromBlob(size_t blobSize, bool isIncremen
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TTestRuntime {
-    std::unique_ptr<TTestActorRuntime> Runtime;
-    TCheckpointStoragePtr CheckpointStorage;
-    TStateStoragePtr StateStorage;
-    TActorId ActorGC;
-    TString TablePrefix;
-    TString YdbEndpoint;
-    TString YdbDatabase;
-    std::unique_ptr<NYdb::TDriver> YdbDriver;
-    std::unique_ptr<NYdb::NTable::TTableClient> YdbTableClient;
-    NKikimr::TActorSystemStub ActorSystemStub;
+template<bool UseYdbSdk>
+class TGcTestBase: public NUnitTest::TTestBase {
+    using TSelf = TGcTestBase<UseYdbSdk>;
+    
+    IYdbConnection::TPtr Connection;
 
-    TTestRuntime(const char* tablePrefix)
-        : TablePrefix(tablePrefix)
-        , YdbEndpoint(GetEnv("YDB_ENDPOINT"))
-        , YdbDatabase(GetEnv("YDB_DATABASE"))
-    {
-        Runtime.reset(new TTestBasicRuntime(1));
+    void SetUp() override {
+        
+        TablePrefix = CreateGuidAsString();
+        if constexpr (!UseYdbSdk) {
+            InitTestServer();
+        }
+        Connection = MakeConnection();
+        Init();
+    }
+
+    IYdbConnection::TPtr MakeConnection() {
+        YdbEndpoint = GetEnv("YDB_ENDPOINT");
+        YdbDatabase = UseYdbSdk ? GetEnv("YDB_DATABASE") : Server->GetRuntime()->GetAppData().TenantName;
+
+        Runtime = std::make_unique<TTestBasicRuntime>(1, true);
         Runtime->SetLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NLog::PRI_DEBUG);
-        TAppPrepare app;
-        SetupTabletServices(*Runtime, &app, true);
+        SetupTabletServices(*Runtime);
 
         NConfig::TCheckpointCoordinatorConfig config;
-        auto& storageConfig = *config.MutableStorage();
+        auto& storageConfig = *Config.MutableStorage();
         storageConfig.SetEndpoint(YdbEndpoint);
         storageConfig.SetDatabase(YdbDatabase);
         storageConfig.SetToken("");
         storageConfig.SetTablePrefix(TablePrefix);
 
-        auto credFactory = NKikimr::CreateYdbCredentialsProviderFactory;
-        NYdb::TDriver driver(NYdb::TDriverConfig{});
-        auto ydbConnectionPtr = NewYdbConnection(config.GetStorage(), credFactory, driver);
-        CheckpointStorage = NewYdbCheckpointStorage(storageConfig, CreateEntityIdGenerator("id"), ydbConnectionPtr);
-        auto issues = CheckpointStorage->Init().GetValueSync();
+        NYdb::TDriver driver({});
+        if (UseYdbSdk) {
+            return CreateSdkYdbConnection(storageConfig, NKikimr::CreateYdbCredentialsProviderFactory, driver);
+        } else {
+            return CreateLocalYdbConnection(YdbDatabase, TablePrefix);
+        }
+    }
+
+    TTestActorRuntime* GetRuntime() {
+        if constexpr (UseYdbSdk) {
+            return Runtime.get();
+        } else {
+            return Server->GetRuntime();
+        }
+    }
+
+    void Init() {
+        CheckpointStorage = NewYdbCheckpointStorage(Config.GetStorage(), CreateEntityIdGenerator("id"), Connection);
+        auto issues = Call<NThreading::TFuture<NYql::TIssues>>([&](){ return CheckpointStorage->Init(); }).GetValueSync();
         UNIT_ASSERT_C(issues.Empty(), issues.ToString());
 
-        StateStorage = NewYdbStateStorage(config, ydbConnectionPtr);
-        issues = StateStorage->Init().GetValueSync();
+        StateStorage = NewYdbStateStorage(Config, Connection);
+        issues = Call<NThreading::TFuture<NYql::TIssues>>([&](){ return StateStorage->Init();}).GetValueSync();
         UNIT_ASSERT_C(issues.Empty(), issues.ToString());
 
         Fill();
 
-        NConfig::TCheckpointGcConfig gcConfig;
+        TCheckpointStorageSettings::TGcSettings gcConfig;
         auto gc = NewGC(gcConfig, CheckpointStorage, StateStorage);
-        ActorGC = Runtime->Register(gc.release());
-
+        ActorGC = GetRuntime()->Register(gc.release());
         Runtime->DispatchEvents({}, TDuration::Zero());
+    }
 
-        YdbDriver = std::make_unique<NYdb::TDriver>(NYdb::TDriverConfig().SetEndpoint(YdbEndpoint).SetDatabase(YdbDatabase));
-        YdbTableClient = std::make_unique<NYdb::NTable::TTableClient>(*YdbDriver);
+    void InitTestServer() {
+        MsgBusPort = PortManager.GetPort(2134);
+        NKikimrProto::TAuthConfig authConfig;
+        ServerSettings = MakeHolder<Tests::TServerSettings>(MsgBusPort, authConfig);
+        ServerSettings->NodeCount = 1;
+        Server = MakeHolder<Tests::TServer>(*ServerSettings);
+        Client = MakeHolder<Tests::TClient>(*ServerSettings);
+        Server->GetRuntime()->SetLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NActors::NLog::PRI_DEBUG);
+        Client->InitRootScheme();
     }
 
     void SaveCheckpoint(const TCoordinatorId& coordinator, const TCheckpointId& checkpointId, bool isIncrement) {
-        auto createCheckpointResult = CheckpointStorage->CreateCheckpoint(coordinator, checkpointId, NProto::TCheckpointGraphDescription(), ECheckpointStatus::Pending).GetValueSync();
+        auto createCheckpointResult = Call<NThreading::TFuture<ICheckpointStorage::TCreateCheckpointResult>>([&](){ return CheckpointStorage->CreateCheckpoint(coordinator, checkpointId, NProto::TCheckpointGraphDescription(), ECheckpointStatus::Pending); }).GetValueSync();
         UNIT_ASSERT_C(createCheckpointResult.second.Empty(), createCheckpointResult.second.ToString());
 
-        StateStorage->SaveState(1, "graph", checkpointId, MakeStateFromBlob(4, isIncrement)).GetValueSync();
-        StateStorage->SaveState(2, "graph", checkpointId, MakeStateFromBlob(4, isIncrement)).GetValueSync();
+        Call<NThreading::TFuture<IStateStorage::TSaveStateResult>>([&](){ return StateStorage->SaveState(1, "graph", checkpointId, MakeStateFromBlob(4, isIncrement)); }).GetValueSync();
+        Call<NThreading::TFuture<IStateStorage::TSaveStateResult>>([&](){ return StateStorage->SaveState(2, "graph", checkpointId, MakeStateFromBlob(4, isIncrement)); }).GetValueSync();
 
-        CheckpointStorage->UpdateCheckpointStatus(
+        Call<NThreading::TFuture<NYql::TIssues>>([&]() { return CheckpointStorage->UpdateCheckpointStatus(
             coordinator,
             checkpointId,
             ECheckpointStatus::PendingCommit,
             ECheckpointStatus::Pending,
-            100).GetValueSync();
+            100); }).GetValueSync();
 
-        CheckpointStorage->UpdateCheckpointStatus(
+        Call<NThreading::TFuture<NYql::TIssues>>([&]() { return CheckpointStorage->UpdateCheckpointStatus(
             coordinator,
             checkpointId,
             ECheckpointStatus::Completed,
             ECheckpointStatus::PendingCommit,
-            100).GetValueSync();
+            100); }).GetValueSync();
     }
 
     void Fill() {
         TCoordinatorId coordinator("graph", 11);
-        auto issues = CheckpointStorage->RegisterGraphCoordinator(coordinator).GetValueSync();
+        auto issues = Call<NThreading::TFuture<NYql::TIssues>>([&](){ return CheckpointStorage->RegisterGraphCoordinator(coordinator); }).GetValueSync();
         UNIT_ASSERT_C(issues.Empty(), issues.ToString());
 
         TCheckpointId checkpointId1(11, 1);
@@ -149,7 +185,7 @@ struct TTestRuntime {
     }
 
     void CheckpointSucceeded(const TCheckpointId& checkpointUpperBound, NYql::NDqProto::ECheckpointType type = NYql::NDqProto::CHECKPOINT_TYPE_SNAPSHOT) {
-        TActorId sender = Runtime->AllocateEdgeActor();
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
 
         TCoordinatorId coordinator("graph", 11);
 
@@ -159,43 +195,81 @@ struct TTestRuntime {
             type);
 
         auto handle = MakeHolder<IEventHandle>(ActorGC, sender, request.release());
-        Runtime->Send(handle.Release());
+        GetRuntime()->Send(handle.Release());
     }
 
     size_t CountGraphDescriptions() {
-        auto session = YdbTableClient->CreateSession().GetValueSync();
-        UNIT_ASSERT(session.IsSuccess());
         TStringBuilder query;
         query << "--!syntax_v1" << Endl;
         query << "PRAGMA TablePathPrefix(\"" << NFq::JoinPath(YdbDatabase, TablePrefix) << "\");" << Endl;
         query << "SELECT * FROM checkpoints_graphs_description;" << Endl;
         Cerr << "Count graph descriptions query:\n" << query << Endl;
-        auto queryResult = session.GetSession().ExecuteDataQuery(query, NYdb::NTable::TTxControl::BeginTx().CommitTx()).GetValueSync();
-        UNIT_ASSERT_C(queryResult.IsSuccess(), queryResult.GetIssues().ToString());
-        return queryResult.GetResultSet(0).RowsCount();
+        std::optional<NYdb::NTable::TDataQueryResult> result;
+        auto status = Call<NYdb::TAsyncStatus>([&]() { return Connection->GetTableClient()->RetryOperation([&](ISession::TPtr session) {
+            return session->ExecuteDataQuery(query, ISession::TTxControl::BeginAndCommitTx(), nullptr)
+                .Apply([&](const NThreading::TFuture<NYdb::NTable::TDataQueryResult>& selectResult) {
+                    NYdb::TStatus status = selectResult.GetValue();
+                    result = selectResult.GetValue();
+                    return NThreading::MakeFuture<NYdb::TStatus>(status);
+                });
+            }); }).GetValueSync();
+        UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        return result->GetResultSet(0).RowsCount();
     }
-};
 
-} // namespace
+    template<typename TValue>
+    auto Call(std::function<TValue()> operation) {
+        if (UseYdbSdk) {
+            return operation();     
+        }
+        auto promise = NThreading::NewPromise<TValue>();
+        GetRuntime()->Register(new TProxyActor<TValue>(promise, operation));
+        return promise.GetFuture().GetValueSync();
+    }
 
-////////////////////////////////////////////////////////////////////////////////
+    IStateStorage::TCountStatesResult CountStates(
+        const TString& graphId,
+        const TCheckpointId& checkpointId) {
+        return Call<NThreading::TFuture<IStateStorage::TCountStatesResult>>([&](){ 
+            return StateStorage->CountStates(graphId, checkpointId); }).GetValueSync();
+    }
 
-Y_UNIT_TEST_SUITE(TGcTest) {
-    Y_UNIT_TEST(ShouldRemovePreviousCheckpoints)
+private:
+    TPortManager PortManager;
+    ui16 MsgBusPort = 0;
+    ui16 GrpcPort = 0;
+    THolder<Tests::TServerSettings> ServerSettings;
+    THolder<Tests::TServer> Server;
+    THolder<Tests::TClient> Client;
+    NConfig::TCheckpointCoordinatorConfig Config;
+
+    TCheckpointStoragePtr CheckpointStorage;
+    TStateStoragePtr StateStorage;
+    TString TablePrefix;
+    TActorId ActorGC;
+    TString YdbEndpoint;
+    TString YdbDatabase;
+    NKikimr::TActorSystemStub ActorSystemStub;
+    std::unique_ptr<TTestActorRuntime> Runtime;
+
+    UNIT_TEST_SUITE_DEMANGLE(TSelf);
+    UNIT_TEST(ShouldRemovePreviousCheckpoints);
+    UNIT_TEST(ShouldIgnoreIncrementCheckpoint);
+    UNIT_TEST_SUITE_END();
+
+    void ShouldRemovePreviousCheckpoints()
     {
-        TTestRuntime runtime("TGcTestShouldRemovePreviousCheckpoints");
-
         TCheckpointId checkpointId1(11, 1);
         TCheckpointId checkpointId2(11, 2);
         TCheckpointId checkpointId3(11, 3);
 
-        UNIT_ASSERT_VALUES_EQUAL(runtime.CountGraphDescriptions(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(CountGraphDescriptions(), 3);
 
-        runtime.CheckpointSucceeded(checkpointId3);
+        CheckpointSucceeded(checkpointId3);
 
         ICheckpointStorage::TGetCheckpointsResult getResult;
         DoWithRetry<yexception>([&]() {
-            getResult = runtime.CheckpointStorage->GetCheckpoints("graph").GetValueSync();
+            getResult = Call<NThreading::TFuture<ICheckpointStorage::TGetCheckpointsResult>>([&](){ return CheckpointStorage->GetCheckpoints("graph"); }).GetValueSync();
             UNIT_ASSERT(getResult.second.Empty());
             if (getResult.first.size() == 3) {
                 throw yexception() << "gc not finished yet";
@@ -205,43 +279,49 @@ Y_UNIT_TEST_SUITE(TGcTest) {
         UNIT_ASSERT_VALUES_EQUAL(getResult.first.size(), 1UL);
         UNIT_ASSERT_VALUES_EQUAL(getResult.first.front().CheckpointId, checkpointId3);
 
-        UNIT_ASSERT_VALUES_EQUAL(runtime.CountGraphDescriptions(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(CountGraphDescriptions(), 1);
 
         IStateStorage::TCountStatesResult countResult;
         DoWithRetry<yexception>([&]() {
-            countResult = runtime.StateStorage->CountStates("graph", checkpointId1).GetValueSync();
+            countResult = CountStates("graph", checkpointId1);
             UNIT_ASSERT(countResult.second.Empty());
             if (countResult.first != 0) {
                 throw yexception() << "gc not finished yet";
             }
         }, TRetryOptions(100, TDuration::MilliSeconds(100)), true);
 
-        countResult = runtime.StateStorage->CountStates("graph", checkpointId2).GetValueSync();
+        countResult = CountStates("graph", checkpointId2);
         UNIT_ASSERT(countResult.second.Empty());
         UNIT_ASSERT_VALUES_EQUAL(countResult.first, 0UL);
 
-        countResult = runtime.StateStorage->CountStates("graph", checkpointId3).GetValueSync();
+        countResult = CountStates("graph", checkpointId3);
         UNIT_ASSERT(countResult.second.Empty());
         UNIT_ASSERT_VALUES_EQUAL(countResult.first, 2UL);
     }
 
-    Y_UNIT_TEST(ShouldIgnoreIncrementCheckpoint)
+    void ShouldIgnoreIncrementCheckpoint()
     {
-        TTestRuntime runtime("ShouldIgnoreIncrementCheckpoint");
-
         TCheckpointId checkpointId1(11, 1);
         TCheckpointId checkpointId2(11, 2);
         TCheckpointId checkpointId3(11, 3);
 
-        UNIT_ASSERT_VALUES_EQUAL(runtime.CountGraphDescriptions(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(CountGraphDescriptions(), 3);
 
-        runtime.CheckpointSucceeded(checkpointId3,  NYql::NDqProto::CHECKPOINT_TYPE_INCREMENT_OR_SNAPSHOT);
+        CheckpointSucceeded(checkpointId3,  NYql::NDqProto::CHECKPOINT_TYPE_INCREMENT_OR_SNAPSHOT);
 
         Sleep(TDuration::MilliSeconds(2000));
-        ICheckpointStorage::TGetCheckpointsResult getResult = runtime.CheckpointStorage->GetCheckpoints("graph").GetValueSync();
+        ICheckpointStorage::TGetCheckpointsResult getResult = Call<NThreading::TFuture<ICheckpointStorage::TGetCheckpointsResult>>([&](){ return CheckpointStorage->GetCheckpoints("graph"); }).GetValueSync();
         UNIT_ASSERT(getResult.second.Empty());
         UNIT_ASSERT(getResult.first.size() == 3);
     }
 };
+
+using TGcTest = TGcTestBase<true>;
+using TGcLocaTest = TGcTestBase<false>;
+
+UNIT_TEST_SUITE_REGISTRATION(TGcTest);
+UNIT_TEST_SUITE_REGISTRATION(TGcLocaTest);
+
+} // namespace
 
 } // namespace NFq

--- a/ydb/core/fq/libs/checkpoint_storage/ut/storage_service_ydb_ut.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ut/storage_service_ydb_ut.cpp
@@ -17,6 +17,8 @@
 
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/testlib/tablet_helpers.h>
+#include <ydb/core/testlib/test_client.h>
+
 #include <util/system/env.h>
 
 namespace NFq {
@@ -35,253 +37,348 @@ const TCheckpointId CheckpointId1(17, 1);
 const TCheckpointId CheckpointId2(17, 2);
 const TCheckpointId CheckpointId3(17, 3);
 
+constexpr TDuration TestTimeout = TDuration::Seconds(30);
+
 using TRuntimePtr = std::unique_ptr<TTestActorRuntime>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TRuntimePtr PrepareTestActorRuntime(const char* tablePrefix, bool enableGc = false) {
-    TRuntimePtr runtime(new TTestBasicRuntime(1, true));
-    runtime->SetLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NLog::PRI_DEBUG);
+template <bool UseYdbSdk>
+class TStorageServiceTest : public NUnitTest::TTestBase{
+    using TSelf = TStorageServiceTest<UseYdbSdk>;
 
-    NConfig::TCheckpointCoordinatorConfig config;
-    config.SetEnabled(true);
-    auto& checkpointConfig = *config.MutableStorage();
-    checkpointConfig.SetEndpoint(GetEnv("YDB_ENDPOINT"));
-    checkpointConfig.SetDatabase(GetEnv("YDB_DATABASE"));
-    checkpointConfig.SetToken("");
-    checkpointConfig.SetTablePrefix(tablePrefix);
-
-    auto& gcConfig = *config.MutableCheckpointGarbageConfig();
-    gcConfig.SetEnabled(enableGc);
-
-    auto driverConfig = NYdb::TDriverConfig();
-    NYdb::TDriver driver(driverConfig);
-    auto credFactory = NKikimr::CreateYdbCredentialsProviderFactory;
-    auto storageService = NewCheckpointStorageService(config, "id", credFactory, std::move(driver), MakeIntrusive<::NMonitoring::TDynamicCounters>());
-
-    runtime->AddLocalService(
-        NYql::NDq::MakeCheckpointStorageID(),
-        TActorSetupCmd(storageService.release(), TMailboxType::Simple, 0));
-
-    SetupTabletServices(*runtime);
-    runtime->DispatchEvents({}, TDuration::Zero());
-
-    return runtime;
-}
-
-void RegisterCoordinator(
-    const TRuntimePtr& runtime,
-    const TCoordinatorId& coordinatorId,
-    bool expectFailure = false)
-{
-    TActorId sender = runtime->AllocateEdgeActor();
-    auto request = std::make_unique<TEvCheckpointStorage::TEvRegisterCoordinatorRequest>(coordinatorId);
-    runtime->Send(new IEventHandle(
-        NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
-
-    TAutoPtr<IEventHandle> handle;
-    auto* event = runtime->GrabEdgeEvent<TEvCheckpointStorage::TEvRegisterCoordinatorResponse>(handle);
-    UNIT_ASSERT(event);
-
-    if (expectFailure) {
-        UNIT_ASSERT(!event->Issues.Empty());
-    } else {
-        UNIT_ASSERT(event->Issues.Empty());
+public:
+    void SetUp() override {
+        Init();
     }
-}
 
-void RegisterDefaultCoordinator(const TRuntimePtr& runtime) {
-    TCoordinatorId coordinatorId(GraphId, Generation);
-    RegisterCoordinator(runtime, coordinatorId);
-}
-
-template <class TResponse>
-void CheckCheckpointResponse(
-    const TRuntimePtr& runtime,
-    const TCheckpointId& checkpointId,
-    bool expectFailure = false)
-{
-    TAutoPtr<IEventHandle> handle;
-    auto* event = runtime->GrabEdgeEvent<TResponse>(handle);
-    UNIT_ASSERT(event);
-
-    if (expectFailure) {
-        UNIT_ASSERT(!event->Issues.Empty());
-    } else {
-        UNIT_ASSERT(event->Issues.Empty());
-        UNIT_ASSERT_VALUES_EQUAL(event->CheckpointId, checkpointId);
+    void Init(bool enableGc = false) {
+        if constexpr (UseYdbSdk) {
+            InitSdkConnection(enableGc);
+        } else {
+            InitLocalConnection();
+        }
+        WaitBootstrapped();
+        Cerr << "\n--------------------------- INIT FINISHED ---------------------------\n";
     }
-}
 
-void CreateCheckpoint(
-    const TRuntimePtr& runtime,
-    const TString& graphId,
-    ui64 generation,
-    const TCheckpointId& checkpointId,
-    bool expectFailure = false)
-{
-    TActorId sender = runtime->AllocateEdgeActor();
+    void InitSdkConnection(bool enableGc) {
+        Runtime = std::make_unique<TTestBasicRuntime>(1, true);
+        Runtime->SetLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NLog::PRI_DEBUG);
 
-    TCoordinatorId coordinatorId(graphId, generation);
-    auto request = std::make_unique<TEvCheckpointStorage::TEvCreateCheckpointRequest>(coordinatorId, checkpointId, 0, NProto::TCheckpointGraphDescription());
-    runtime->Send(new IEventHandle(
-        NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+        NConfig::TCheckpointCoordinatorConfig config;
+        config.SetEnabled(true);
+        auto& storageConfig = *config.MutableStorage();
+        storageConfig.SetEndpoint(GetEnv("YDB_ENDPOINT"));
+        storageConfig.SetDatabase(GetEnv("YDB_DATABASE"));
+        storageConfig.SetToken("");
+        storageConfig.SetTablePrefix(CreateGuidAsString());
 
-    CheckCheckpointResponse<TEvCheckpointStorage::TEvCreateCheckpointResponse>(
-        runtime,
-        checkpointId,
-        expectFailure);
-}
+        auto& gcConfig = *config.MutableCheckpointGarbageConfig();
+        gcConfig.SetEnabled(enableGc);
 
-void AbortCheckpoint(
-    const TRuntimePtr& runtime,
-    const TString& graphId,
-    ui64 generation,
-    const TCheckpointId& checkpointId,
-    bool expectFailure = false)
-{
-    TActorId sender = runtime->AllocateEdgeActor();
+        auto driverConfig = NYdb::TDriverConfig();
+        NYdb::TDriver driver(driverConfig);
+        auto credFactory = NKikimr::CreateYdbCredentialsProviderFactory;
+        auto storageService = NewCheckpointStorageService(config, "id", credFactory, std::move(driver), MakeIntrusive<::NMonitoring::TDynamicCounters>());
 
-    TCoordinatorId coordinatorId(graphId, generation);
-    auto request = std::make_unique<TEvCheckpointStorage::TEvAbortCheckpointRequest>(coordinatorId, checkpointId, "test reason");
-    runtime->Send(new IEventHandle(
-        NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+        Runtime->AddLocalService(
+            NYql::NDq::MakeCheckpointStorageID(),
+            TActorSetupCmd(storageService.release(), TMailboxType::Simple, 0));
 
-    CheckCheckpointResponse<TEvCheckpointStorage::TEvAbortCheckpointResponse>(
-        runtime,
-        checkpointId,
-        expectFailure);
-}
+        SetupTabletServices(*Runtime);
+        Runtime->DispatchEvents({}, TDuration::Zero());
+    }
 
-template <class TRequest, class TResponse>
-void CheckpointOperation(
-    const TRuntimePtr& runtime,
-    const TString& graphId,
-    ui64 generation,
-    const TCheckpointId& checkpointId,
-    bool expectFailure = false)
-{
-    TActorId sender = runtime->AllocateEdgeActor();
+    void InitLocalConnection() {
+        MsgBusPort = PortManager.GetPort(2134);
+        GrpcPort = PortManager.GetPort(2135);
+        NKikimrProto::TAuthConfig authConfig;
+        authConfig.SetUseBuiltinDomain(true);
+        ServerSettings = MakeHolder<Tests::TServerSettings>(MsgBusPort, authConfig);
+        ServerSettings->AppConfig->MutableFeatureFlags()->SetEnableStreamingQueries(true);
 
-    TCoordinatorId coordinatorId(graphId, generation);
-    std::unique_ptr<TRequest> request;
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableStreamingQueries(true);
+        ServerSettings->SetFeatureFlags(featureFlags);
 
-    if constexpr (std::is_same_v<TRequest, TEvCheckpointStorage::TEvCompleteCheckpointRequest>)
-        request = std::make_unique<TRequest>(coordinatorId, checkpointId, 100, NYql::NDqProto::CHECKPOINT_TYPE_SNAPSHOT);
-    else
-        request = std::make_unique<TRequest>(coordinatorId, checkpointId, 100);
-    runtime->Send(new IEventHandle(
-        NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+        ServerSettings->SetEnableScriptExecutionOperations(true);
+        ServerSettings->SetInitializeFederatedQuerySetupFactory(true);
+        ServerSettings->SetGrpcPort(GrpcPort);
+        ServerSettings->NodeCount = 1;
+        Server = MakeHolder<Tests::TServer>(*ServerSettings);
+        Client = MakeHolder<Tests::TClient>(*ServerSettings);
+        GetRuntime()->SetLogPriority(NKikimrServices::KQP_PROXY, NActors::NLog::PRI_DEBUG);
+        GetRuntime()->SetLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NActors::NLog::PRI_DEBUG);
+        GetRuntime()->SetDispatchTimeout(TestTimeout);
+        Server->EnableGRpc(GrpcPort);
+        Client->InitRootScheme();
+    }
 
-    CheckCheckpointResponse<TResponse>(
-        runtime,
-        checkpointId,
-        expectFailure);
-}
+    void WaitBootstrapped() {
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
+        while (true) {
+            try {
+                auto request = std::make_unique<TEvCheckpointStorage::TEvGetCheckpointsMetadataRequest>("aaa");
+                GetRuntime()->Send(new IEventHandle(NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+                const auto event = GetRuntime()->template GrabEdgeEvent<TEvCheckpointStorage::TEvGetCheckpointsMetadataResponse>(sender, TDuration::Seconds(1));
+                 if (event && event->Get()->Issues.Empty()) {
+                    break;
+                }
+            } catch (TEmptyEventQueueException&) {
+            }
+        }
 
-auto PendingCommitCheckpoint = CheckpointOperation<TEvCheckpointStorage::TEvSetCheckpointPendingCommitStatusRequest, TEvCheckpointStorage::TEvSetCheckpointPendingCommitStatusResponse>;
-auto CompleteCheckpoint = CheckpointOperation<TEvCheckpointStorage::TEvCompleteCheckpointRequest, TEvCheckpointStorage::TEvCompleteCheckpointResponse>;
+        while (true) {
+            try {
+                auto request = std::make_unique<TEvCheckpointStorage::TEvRegisterCoordinatorRequest>(TCoordinatorId{"test", 777});
+                GetRuntime()->Send(new IEventHandle(NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+                const auto event = GetRuntime()->template GrabEdgeEvent<TEvCheckpointStorage::TEvRegisterCoordinatorResponse>(sender, TDuration::Seconds(1));
+                 if (event && event->Get()->Issues.Empty()) {
+                    break;
+                }
+            } catch (TEmptyEventQueueException&) {
+            }
+        }
+    }
 
-TCheckpoints GetCheckpoints(
-    const TRuntimePtr& runtime,
-    const TString& graphId)
-{
-    TActorId sender = runtime->AllocateEdgeActor();
+    TTestActorRuntime* GetRuntime() {
+        if constexpr (UseYdbSdk) {
+            return Runtime.get();
+        } else {
+            return Server->GetRuntime();
+        }
+    }
 
-    auto request = std::make_unique<TEvCheckpointStorage::TEvGetCheckpointsMetadataRequest>(graphId);
-    runtime->Send(new IEventHandle(
-        NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
-
-    TAutoPtr<IEventHandle> handle;
-    auto* event = runtime->GrabEdgeEvent<TEvCheckpointStorage::TEvGetCheckpointsMetadataResponse>(handle);
-    UNIT_ASSERT(event);
-    UNIT_ASSERT(event->Issues.Empty());
-
-    return event->Checkpoints;
-}
-
-void SaveState(
-    const TRuntimePtr& runtime,
-    ui64 taskId,
-    const TCheckpointId& checkpointId,
-    const TString& blob)
-{
-    TActorId sender = runtime->AllocateEdgeActor();
-
-    TCoordinatorId coordinatorId(GraphId, Generation);
-
-    // XXX use proper checkpointId
-    auto checkpoint = NYql::NDqProto::TCheckpoint();
-    checkpoint.SetGeneration(checkpointId.CoordinatorGeneration);
-    checkpoint.SetId(checkpointId.SeqNo);
-    auto request = std::make_unique<NYql::NDq::TEvDqCompute::TEvSaveTaskState>(GraphId, taskId, checkpoint);
-    request->State.MiniKqlProgram.ConstructInPlace().Data.Blob = blob;
-    runtime->Send(new IEventHandle(NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
-
-    TAutoPtr<IEventHandle> handle;
-    auto* event = runtime->GrabEdgeEvent<NYql::NDq::TEvDqCompute::TEvSaveTaskStateResult>(handle);
-    UNIT_ASSERT(event);
-    UNIT_ASSERT_C(event->Record.GetStatus() == NYql::NDqProto::TEvSaveTaskStateResult::OK, event->Record.DebugString());
-}
-
-TString GetState(
-    const TRuntimePtr& runtime,
-    ui64 taskId,
-    const TString& graphId,
-    const TCheckpointId& checkpointId)
-{
-    TActorId sender = runtime->AllocateEdgeActor();
-
-    auto checkpoint = NYql::NDqProto::TCheckpoint();
-    checkpoint.SetGeneration(checkpointId.CoordinatorGeneration);
-    checkpoint.SetId(checkpointId.SeqNo);
-    auto request = std::make_unique<NYql::NDq::TEvDqCompute::TEvGetTaskState>(graphId, std::vector{taskId}, checkpoint, Generation);
-    runtime->Send(new IEventHandle(
-        NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
-
-    TAutoPtr<IEventHandle> handle;
-    auto* event = runtime->GrabEdgeEvent<NYql::NDq::TEvDqCompute::TEvGetTaskStateResult>(handle);
-    UNIT_ASSERT(event);
-    UNIT_ASSERT(event->Issues.Empty());
-    UNIT_ASSERT(!event->States.empty());
-
-    return event->States[0].MiniKqlProgram->Data.Blob;
-}
-
-void CreateCompletedCheckpoint(
-    const TRuntimePtr& runtime,
-    const TString& graphId,
-    ui64 generation,
-    const TCheckpointId& checkpointId)
-{
-    CreateCheckpoint(runtime, graphId, generation, checkpointId, false);
-    PendingCommitCheckpoint(runtime, graphId, generation, checkpointId, false);
-    CompleteCheckpoint(runtime, graphId, generation, checkpointId, false);
-}
-
-TString MakeState(const TString& value) {
-    TString nodesState;
-    auto mkqlState = NKikimr::NMiniKQL::TOutputSerializer::MakeSimpleBlobState(value, 0);
-    NKikimr::NMiniKQL::TNodeStateHelper::AddNodeState(nodesState, mkqlState.AsStringRef());
-    return nodesState;
-}
-
-} // namespace
-
-////////////////////////////////////////////////////////////////////////////////
-
-Y_UNIT_TEST_SUITE(TStorageServiceTest) {
-    Y_UNIT_TEST(ShouldRegister)
+    void RegisterCoordinator(
+        const TCoordinatorId& coordinatorId,
+        bool expectFailure = false)
     {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldRegister");
-        RegisterDefaultCoordinator(runtime);
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
+        auto request = std::make_unique<TEvCheckpointStorage::TEvRegisterCoordinatorRequest>(coordinatorId);
+                
+        GetRuntime()->Send(new IEventHandle(
+            NYql::NDq::MakeCheckpointStorageID(), sender, request.release(), IEventHandle::FlagTrackDelivery));
+
+        TAutoPtr<IEventHandle> handle;
+
+        auto* event = GetRuntime()->template GrabEdgeEvent<TEvCheckpointStorage::TEvRegisterCoordinatorResponse>(handle);
+        UNIT_ASSERT(event);
+
+        if (expectFailure) {
+            UNIT_ASSERT(!event->Issues.Empty());
+        } else {
+            UNIT_ASSERT_C(event->Issues.Empty(), event->Issues.ToOneLineString());
+        }
     }
 
-/*
+    void RegisterDefaultCoordinator() {
+        TCoordinatorId coordinatorId(GraphId, Generation);
+        RegisterCoordinator(coordinatorId);
+    }
+
+    template <class TResponse>
+    void CheckCheckpointResponse(
+        const TCheckpointId& checkpointId,
+        bool expectFailure = false)
+    {
+        TAutoPtr<IEventHandle> handle;
+        auto* event = GetRuntime()->template GrabEdgeEvent<TResponse>(handle);
+        UNIT_ASSERT(event);
+
+        if (expectFailure) {
+            UNIT_ASSERT(!event->Issues.Empty());
+        } else {
+            UNIT_ASSERT_C(event->Issues.Empty(), event->Issues.ToOneLineString());
+            UNIT_ASSERT_VALUES_EQUAL(event->CheckpointId, checkpointId);
+        }
+    }
+
+    void CreateCheckpoint(
+        const TString& graphId,
+        ui64 generation,
+        const TCheckpointId& checkpointId,
+        bool expectFailure = false)
+    {
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
+
+        TCoordinatorId coordinatorId(graphId, generation);
+        auto request = std::make_unique<TEvCheckpointStorage::TEvCreateCheckpointRequest>(coordinatorId, checkpointId, 0, NProto::TCheckpointGraphDescription());
+        GetRuntime()->Send(new IEventHandle(
+            NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+
+        CheckCheckpointResponse<TEvCheckpointStorage::TEvCreateCheckpointResponse>(
+            checkpointId,
+            expectFailure);
+    }
+
+    void AbortCheckpoint(
+        const TString& graphId,
+        ui64 generation,
+        const TCheckpointId& checkpointId,
+        bool expectFailure = false)
+    {
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
+
+        TCoordinatorId coordinatorId(graphId, generation);
+        auto request = std::make_unique<TEvCheckpointStorage::TEvAbortCheckpointRequest>(coordinatorId, checkpointId, "test reason");
+        GetRuntime()->Send(new IEventHandle(
+            NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+
+        CheckCheckpointResponse<TEvCheckpointStorage::TEvAbortCheckpointResponse>(
+            checkpointId,
+            expectFailure);
+    }
+
+    template <class TRequest, class TResponse>
+    void CheckpointOperation(
+        const TString& graphId,
+        ui64 generation,
+        const TCheckpointId& checkpointId,
+        bool expectFailure = false)
+    {
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
+
+        TCoordinatorId coordinatorId(graphId, generation);
+        std::unique_ptr<TRequest> request;
+
+        if constexpr (std::is_same_v<TRequest, TEvCheckpointStorage::TEvCompleteCheckpointRequest>)
+            request = std::make_unique<TRequest>(coordinatorId, checkpointId, 100, NYql::NDqProto::CHECKPOINT_TYPE_SNAPSHOT);
+        else
+            request = std::make_unique<TRequest>(coordinatorId, checkpointId, 100);
+        GetRuntime()->Send(new IEventHandle(
+            NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+
+        CheckCheckpointResponse<TResponse>(
+            checkpointId,
+            expectFailure);
+    }
+
+    void PendingCommitCheckpoint(
+        const TString& graphId,
+        ui64 generation,
+        const TCheckpointId& checkpointId,
+        bool expectFailure = false) {
+        CheckpointOperation<TEvCheckpointStorage::TEvSetCheckpointPendingCommitStatusRequest, TEvCheckpointStorage::TEvSetCheckpointPendingCommitStatusResponse>(
+            graphId, generation, checkpointId, expectFailure);
+    }
+    void CompleteCheckpoint(
+        const TString& graphId,
+        ui64 generation,
+        const TCheckpointId& checkpointId,
+        bool expectFailure = false) {
+        CheckpointOperation<TEvCheckpointStorage::TEvCompleteCheckpointRequest, TEvCheckpointStorage::TEvCompleteCheckpointResponse>(
+            graphId, generation, checkpointId, expectFailure);
+    }
+
+    TCheckpoints GetCheckpoints(
+        const TString& graphId)
+    {
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
+        auto request = std::make_unique<TEvCheckpointStorage::TEvGetCheckpointsMetadataRequest>(graphId);
+        GetRuntime()->Send(new IEventHandle(
+            NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+
+        TAutoPtr<IEventHandle> handle;
+        auto* event = GetRuntime()->template GrabEdgeEvent<TEvCheckpointStorage::TEvGetCheckpointsMetadataResponse>(handle);
+        UNIT_ASSERT(event);
+        UNIT_ASSERT(event->Issues.Empty());
+        return event->Checkpoints;
+    }
+
+    void SaveState(
+        ui64 taskId,
+        const TCheckpointId& checkpointId,
+        const TString& blob)
+    {
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
+        TCoordinatorId coordinatorId(GraphId, Generation);
+
+        // XXX use proper checkpointId
+        auto checkpoint = NYql::NDqProto::TCheckpoint();
+        checkpoint.SetGeneration(checkpointId.CoordinatorGeneration);
+        checkpoint.SetId(checkpointId.SeqNo);
+        auto request = std::make_unique<NYql::NDq::TEvDqCompute::TEvSaveTaskState>(GraphId, taskId, checkpoint);
+        request->State.MiniKqlProgram.ConstructInPlace().Data.Blob = blob;
+        GetRuntime()->Send(new IEventHandle(NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+
+        TAutoPtr<IEventHandle> handle;
+        auto* event = GetRuntime()->template GrabEdgeEvent<NYql::NDq::TEvDqCompute::TEvSaveTaskStateResult>(handle);
+        UNIT_ASSERT(event);
+        UNIT_ASSERT_C(event->Record.GetStatus() == NYql::NDqProto::TEvSaveTaskStateResult::OK, event->Record.DebugString());
+    }
+
+    TString GetState(
+        ui64 taskId,
+        const TString& graphId,
+        const TCheckpointId& checkpointId)
+    {
+        TActorId sender = GetRuntime()->AllocateEdgeActor();
+
+        auto checkpoint = NYql::NDqProto::TCheckpoint();
+        checkpoint.SetGeneration(checkpointId.CoordinatorGeneration);
+        checkpoint.SetId(checkpointId.SeqNo);
+        auto request = std::make_unique<NYql::NDq::TEvDqCompute::TEvGetTaskState>(graphId, std::vector{taskId}, checkpoint, Generation);
+        GetRuntime()->Send(new IEventHandle(
+            NYql::NDq::MakeCheckpointStorageID(), sender, request.release()));
+
+        TAutoPtr<IEventHandle> handle;
+        auto* event = GetRuntime()->template GrabEdgeEvent<NYql::NDq::TEvDqCompute::TEvGetTaskStateResult>(handle);
+        UNIT_ASSERT(event);
+        UNIT_ASSERT(event->Issues.Empty());
+        UNIT_ASSERT(!event->States.empty());
+
+        return event->States[0].MiniKqlProgram->Data.Blob;
+    }
+
+    void CreateCompletedCheckpoint(
+        const TString& graphId,
+        ui64 generation,
+        const TCheckpointId& checkpointId)
+    {
+        CreateCheckpoint(graphId, generation, checkpointId, false);
+        PendingCommitCheckpoint(graphId, generation, checkpointId, false);
+        CompleteCheckpoint(graphId, generation, checkpointId, false);
+    }
+
+    TString MakeState(const TString& value) {
+        TString nodesState;
+        auto mkqlState = NKikimr::NMiniKQL::TOutputSerializer::MakeSimpleBlobState(value, 0);
+        NKikimr::NMiniKQL::TNodeStateHelper::AddNodeState(nodesState, mkqlState.AsStringRef());
+        return nodesState;
+    }
+
+    UNIT_TEST_SUITE_DEMANGLE(TSelf);
+    UNIT_TEST(ShouldRegister);
+    UNIT_TEST(ShouldNotRegisterPrevGeneration);
+    UNIT_TEST(ShouldRegisterNextGeneration);
+    UNIT_TEST(ShouldCreateCheckpoint);
+    UNIT_TEST(ShouldNotCreateCheckpointWhenUnregistered);
+    UNIT_TEST(ShouldNotCreateCheckpointTwice);
+    UNIT_TEST(ShouldNotCreateCheckpointAfterGenerationChanged);
+    UNIT_TEST(ShouldGetCheckpoints);
+    UNIT_TEST(ShouldPendingAndCompleteCheckpoint);
+    UNIT_TEST(ShouldAbortCheckpoint);
+    UNIT_TEST(ShouldNotPendingCheckpointWithoutCreation);
+    UNIT_TEST(ShouldNotCompleteCheckpointWithoutCreation);
+    UNIT_TEST(ShouldNotAbortCheckpointWithoutCreation);
+    UNIT_TEST(ShouldNotCompleteCheckpointWithoutPending);
+    UNIT_TEST(ShouldNotPendingCheckpointGenerationChanged);
+    UNIT_TEST(ShouldNotCompleteCheckpointGenerationChanged);
+    UNIT_TEST(ShouldSaveState);
+    UNIT_TEST(ShouldGetState);
+    UNIT_TEST(ShouldUseGc);
+    UNIT_TEST_SUITE_END();
+
+    void ShouldRegister() {
+        RegisterDefaultCoordinator();
+    }
+
+    /*
  *  We weakened registration condition at while, registration with the same generation
  *  is not possible
  *
-    Y_UNIT_TEST(ShouldNotRegisterSameTwice)
+    Y_UNIT_TEST_F(ShouldNotRegisterSameTwice)
     {
         auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotRegisterSameTwice");
 
@@ -290,80 +387,60 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest) {
         RegisterCoordinator(runtime, coordinator1, true);
     }
 */
-    Y_UNIT_TEST(ShouldNotRegisterPrevGeneration)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotRegisterPrevGeneration");
 
+    void ShouldNotRegisterPrevGeneration() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
+        RegisterCoordinator(coordinator1);
 
         TCoordinatorId coordinator2(GraphId, Generation - 1);
-        RegisterCoordinator(runtime, coordinator2, true);
+        RegisterCoordinator(coordinator2, true);
     }
 
-    Y_UNIT_TEST(ShouldRegisterNextGeneration)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldRegisterNextGeneration");
-
+    void ShouldRegisterNextGeneration() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
+        RegisterCoordinator(coordinator1);
 
         TCoordinatorId coordinator2(GraphId, Generation + 1);
-        RegisterCoordinator(runtime, coordinator2);
+        RegisterCoordinator(coordinator2);
 
         // try register prev generation again
-        RegisterCoordinator(runtime, coordinator1, true);
+        RegisterCoordinator(coordinator1, true);
     }
 
-    Y_UNIT_TEST(ShouldCreateCheckpoint)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldCreateCheckpoint");
-
-        RegisterDefaultCoordinator(runtime);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+    void ShouldCreateCheckpoint() {
+        RegisterDefaultCoordinator();
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
     }
 
-    Y_UNIT_TEST(ShouldNotCreateCheckpointWhenUnregistered)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotCreateCheckpointWhenUnregistered");
-
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, true);
+    void ShouldNotCreateCheckpointWhenUnregistered() {
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, true);
     }
 
-    Y_UNIT_TEST(ShouldNotCreateCheckpointTwice)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotCreateCheckpointTwice");
-
-        RegisterDefaultCoordinator(runtime);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, true);
+    void ShouldNotCreateCheckpointTwice() {
+        RegisterDefaultCoordinator();
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, true);
     }
 
-    Y_UNIT_TEST(ShouldNotCreateCheckpointAfterGenerationChanged)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotCreateCheckpointAfterGenerationChanged");
-
+    void ShouldNotCreateCheckpointAfterGenerationChanged() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+        RegisterCoordinator(coordinator1);
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
 
         TCoordinatorId coordinator2(GraphId, Generation + 1);
-        RegisterCoordinator(runtime, coordinator2);
+        RegisterCoordinator(coordinator2);
 
         // second checkpoint, but with previous generation
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId2, true);
+        CreateCheckpoint(GraphId, Generation, CheckpointId2, true);
     }
 
-    Y_UNIT_TEST(ShouldGetCheckpoints)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldGetCheckpoints");
+    void ShouldGetCheckpoints() {
+        RegisterDefaultCoordinator();
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
+        CreateCheckpoint(GraphId, Generation, CheckpointId2, false);
+        CreateCheckpoint(GraphId, Generation, CheckpointId3, false);
 
-        RegisterDefaultCoordinator(runtime);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId2, false);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId3, false);
-
-        auto checkpoints = GetCheckpoints(runtime, GraphId);
+        auto checkpoints = GetCheckpoints(GraphId);
         UNIT_ASSERT_VALUES_EQUAL(checkpoints.size(), 3UL);
 
         THashSet<TCheckpointId, TCheckpointIdHash> checkpoinIds;
@@ -377,19 +454,16 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest) {
         UNIT_ASSERT(checkpoinIds.contains(CheckpointId3));
     }
 
-    Y_UNIT_TEST(ShouldPendingAndCompleteCheckpoint)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldPendingAndCompleteCheckpoint");
+    void ShouldPendingAndCompleteCheckpoint() {
+        RegisterDefaultCoordinator();
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
+        PendingCommitCheckpoint(GraphId, Generation, CheckpointId1, false);
 
-        RegisterDefaultCoordinator(runtime);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
-        PendingCommitCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+        CreateCheckpoint(GraphId, Generation, CheckpointId2, false);
+        PendingCommitCheckpoint(GraphId, Generation, CheckpointId2, false);
+        CompleteCheckpoint(GraphId, Generation, CheckpointId2, false);
 
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId2, false);
-        PendingCommitCheckpoint(runtime, GraphId, Generation, CheckpointId2, false);
-        CompleteCheckpoint(runtime, GraphId, Generation, CheckpointId2, false);
-
-        auto checkpoints = GetCheckpoints(runtime, GraphId);
+        auto checkpoints = GetCheckpoints(GraphId);
         UNIT_ASSERT_VALUES_EQUAL(checkpoints.size(), 2UL);
 
         for (const auto& checkpoint: checkpoints) {
@@ -403,22 +477,19 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest) {
         }
     }
 
-    Y_UNIT_TEST(ShouldAbortCheckpoint)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldPendingAndCompleteCheckpoint");
+    void ShouldAbortCheckpoint() {
+        RegisterDefaultCoordinator();
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
+        PendingCommitCheckpoint(GraphId, Generation, CheckpointId1, false);
 
-        RegisterDefaultCoordinator(runtime);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
-        PendingCommitCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+        CreateCheckpoint(GraphId, Generation, CheckpointId2, false);
+        PendingCommitCheckpoint(GraphId, Generation, CheckpointId2, false);
+        CompleteCheckpoint(GraphId, Generation, CheckpointId2, false);
 
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId2, false);
-        PendingCommitCheckpoint(runtime, GraphId, Generation, CheckpointId2, false);
-        CompleteCheckpoint(runtime, GraphId, Generation, CheckpointId2, false);
+        AbortCheckpoint(GraphId, Generation, CheckpointId1, false);
+        AbortCheckpoint(GraphId, Generation, CheckpointId2, false);
 
-        AbortCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
-        AbortCheckpoint(runtime, GraphId, Generation, CheckpointId2, false);
-
-        auto checkpoints = GetCheckpoints(runtime, GraphId);
+        auto checkpoints = GetCheckpoints(GraphId);
         UNIT_ASSERT_VALUES_EQUAL(checkpoints.size(), 2UL);
 
         for (const auto& checkpoint: checkpoints) {
@@ -426,121 +497,119 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest) {
         }
     }
 
-    Y_UNIT_TEST(ShouldNotPendingCheckpointWithoutCreation)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotPendingCheckpointWithoutCreation");
-
+    void ShouldNotPendingCheckpointWithoutCreation() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
+        RegisterCoordinator(coordinator1);
 
-        PendingCommitCheckpoint(runtime, GraphId, Generation, CheckpointId1, true);
+        PendingCommitCheckpoint(GraphId, Generation, CheckpointId1, true);
     }
 
-    Y_UNIT_TEST(ShouldNotCompleteCheckpointWithoutCreation)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotCompleteCheckpointWithoutCreation");
-
+    void ShouldNotCompleteCheckpointWithoutCreation() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
+        RegisterCoordinator(coordinator1);
 
-        CompleteCheckpoint(runtime, GraphId, Generation, CheckpointId1, true);
+        CompleteCheckpoint(GraphId, Generation, CheckpointId1, true);
     }
 
-    Y_UNIT_TEST(ShouldNotAbortCheckpointWithoutCreation)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotPendingCheckpointWithoutCreation");
-
+    void ShouldNotAbortCheckpointWithoutCreation() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
+        RegisterCoordinator(coordinator1);
 
-        AbortCheckpoint(runtime, GraphId, Generation, CheckpointId1, true);
+        AbortCheckpoint(GraphId, Generation, CheckpointId1, true);
     }
 
-    Y_UNIT_TEST(ShouldNotCompleteCheckpointWithoutPending)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotCompleteCheckpointWithoutPending");
-
+    void ShouldNotCompleteCheckpointWithoutPending() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+        RegisterCoordinator(coordinator1);
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
 
-        CompleteCheckpoint(runtime, GraphId, Generation, CheckpointId1, true);
+        CompleteCheckpoint(GraphId, Generation, CheckpointId1, true);
     }
 
-    Y_UNIT_TEST(ShouldNotPendingCheckpointGenerationChanged)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotPendingCheckpointGenerationChanged");
-
+    void ShouldNotPendingCheckpointGenerationChanged() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+        RegisterCoordinator(coordinator1);
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
 
         auto nextGen = Generation + 1;
         TCoordinatorId coordinator2(GraphId, nextGen);
-        RegisterCoordinator(runtime, coordinator2);
+        RegisterCoordinator(coordinator2);
 
-        PendingCommitCheckpoint(runtime, GraphId, Generation, CheckpointId1, true);
+        PendingCommitCheckpoint(GraphId, Generation, CheckpointId1, true);
     }
 
-    Y_UNIT_TEST(ShouldNotCompleteCheckpointGenerationChanged)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldNotPendingCheckpointGenerationChanged");
-
+    void ShouldNotCompleteCheckpointGenerationChanged() {
         TCoordinatorId coordinator1(GraphId, Generation);
-        RegisterCoordinator(runtime, coordinator1);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
-        PendingCommitCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+        RegisterCoordinator(coordinator1);
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
+        PendingCommitCheckpoint(GraphId, Generation, CheckpointId1, false);
 
         auto nextGen = Generation + 1;
         TCoordinatorId coordinator2(GraphId, nextGen);
-        RegisterCoordinator(runtime, coordinator2);
+        RegisterCoordinator(coordinator2);
 
-        CompleteCheckpoint(runtime, GraphId, Generation, CheckpointId1, true);
+        CompleteCheckpoint(GraphId, Generation, CheckpointId1, true);
     }
 
-    Y_UNIT_TEST(ShouldSaveState)
-    {
+    void ShouldSaveState() {
         NKikimr::NMiniKQL::TScopedAlloc Alloc(__LOCATION__);
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldSaveState");
 
-        RegisterDefaultCoordinator(runtime);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+        RegisterDefaultCoordinator();
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
 
-        SaveState(runtime, 1317, CheckpointId1, MakeState("some random state"));
+        SaveState(1317, CheckpointId1, MakeState("some random state"));
     }
 
-    Y_UNIT_TEST(ShouldGetState)
-    {
+    void ShouldGetState() {
         NKikimr::NMiniKQL::TScopedAlloc Alloc(__LOCATION__);
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldGetState");
 
-        RegisterDefaultCoordinator(runtime);
-        CreateCheckpoint(runtime, GraphId, Generation, CheckpointId1, false);
+        RegisterDefaultCoordinator();
+        CreateCheckpoint(GraphId, Generation, CheckpointId1, false);
         auto state = MakeState("some random state");
-        SaveState(runtime, 1317, CheckpointId1, state);
+        SaveState(1317, CheckpointId1, state);
 
-        auto actual = GetState(runtime, 1317, GraphId, CheckpointId1);
+        auto actual = GetState(1317, GraphId, CheckpointId1);
         UNIT_ASSERT_VALUES_EQUAL(state, actual);
     }
 
-    Y_UNIT_TEST(ShouldUseGc)
-    {
-        auto runtime = PrepareTestActorRuntime("TStorageServiceTestShouldUseGc", true);
-
-        RegisterDefaultCoordinator(runtime);
-        CreateCompletedCheckpoint(runtime, GraphId, Generation, CheckpointId1);
-        CreateCompletedCheckpoint(runtime, GraphId, Generation, CheckpointId2);
-        CreateCompletedCheckpoint(runtime, GraphId, Generation, CheckpointId3);
+    void ShouldUseGc() {
+        Init(true);
+        RegisterDefaultCoordinator();
+        CreateCompletedCheckpoint(GraphId, Generation, CheckpointId1);
+        CreateCompletedCheckpoint(GraphId, Generation, CheckpointId2);
+        CreateCompletedCheckpoint(GraphId, Generation, CheckpointId3);
 
         TCheckpoints checkpoints;
-
         DoWithRetry<yexception>([&]() {
-            checkpoints = GetCheckpoints(runtime, GraphId);
+            checkpoints = GetCheckpoints(GraphId);
             if (checkpoints.size() != 1) {
                 throw yexception() << "gc not finished yet";
             }
         }, TRetryOptions(100, TDuration::MilliSeconds(100)), true);
     }
+
+private:
+    TPortManager PortManager;
+    ui16 MsgBusPort = 0;
+    ui16 GrpcPort = 0;
+    THolder<Tests::TServerSettings> ServerSettings;
+    THolder<Tests::TServer> Server;
+    THolder<Tests::TClient> Client;
+    THolder<NYdb::TDriver> YdbDriver;
+    THolder<NYdb::NTable::TTableClient> TableClient;
+    THolder<NYdb::NTable::TSession> TableClientSession;
+
+    TRuntimePtr Runtime;
 };
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TStorageServiceSdkTest = TStorageServiceTest<true>; 
+using TStorageServiceLocalTest = TStorageServiceTest<false>;
+
+UNIT_TEST_SUITE_REGISTRATION(TStorageServiceSdkTest);
+UNIT_TEST_SUITE_REGISTRATION(TStorageServiceLocalTest);
 
 } // namespace NFq

--- a/ydb/core/fq/libs/checkpoint_storage/ut/ya.make
+++ b/ydb/core/fq/libs/checkpoint_storage/ut/ya.make
@@ -9,6 +9,7 @@ PEERDIR(
     library/cpp/testing/unittest
     ydb/core/fq/libs/actors/logging
     ydb/core/fq/libs/checkpoint_storage/events
+    ydb/core/testlib
     ydb/core/testlib/default
     ydb/library/security
     ydb/public/sdk/cpp/src/client/table

--- a/ydb/core/fq/libs/checkpoint_storage/ut/ydb_state_storage_ut.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ut/ydb_state_storage_ut.cpp
@@ -46,7 +46,7 @@ public:
         stateStorageLimits.SetMaxRowSizeBytes(YdbRowSizeLimit);
 
         NYdb::TDriver driver(NYdb::TDriverConfig{});
-        auto ydbConnectionPtr = NewYdbConnection(config.GetStorage(), NKikimr::CreateYdbCredentialsProviderFactory, driver);
+        auto ydbConnectionPtr = CreateSdkYdbConnection(config.GetStorage(), NKikimr::CreateYdbCredentialsProviderFactory, driver);
         auto storage = NewYdbStateStorage(config, ydbConnectionPtr);
         storage->Init().GetValueSync();
         return storage;

--- a/ydb/core/fq/libs/checkpoint_storage/ydb_checkpoint_storage.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ydb_checkpoint_storage.cpp
@@ -19,6 +19,7 @@ using namespace NYdb;
 using namespace NYdb::NTable;
 
 using NYql::TIssues;
+using TTxControl = NFq::ISession::TTxControl;
 
 namespace {
 
@@ -109,9 +110,11 @@ TFuture<TDataQueryResult> SelectGraphCoordinators(const TGenerationContextPtr& c
         FROM %s;
     )", context->TablePathPrefix.c_str(), CoordinatorsSyncTable);
 
-    return context->Session.ExecuteDataQuery(
+    auto params = std::make_shared<NYdb::TParamsBuilder>();
+    return context->Session->ExecuteDataQuery(
         query,
-        TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
+        TTxControl::BeginAndCommitTx(),
+        params,
         context->ExecDataQuerySettings);
 }
 
@@ -164,9 +167,9 @@ TFuture<TStatus> CreateCheckpoint(const TCheckpointContextPtr& context) {
 
     query << firstPart;
 
-    NYdb::TParamsBuilder params;
-    params
-        .AddParam("$graph_id")
+    auto params = std::make_shared<NYdb::TParamsBuilder>();
+    params->
+         AddParam("$graph_id")
             .String(generationContext->PrimaryKey)
             .Build()
         .AddParam("$graph_desc_id")
@@ -203,8 +206,8 @@ TFuture<TStatus> CreateCheckpoint(const TCheckpointContextPtr& context) {
             return MakeFuture(TStatus(EStatus::BAD_REQUEST, std::move(issues)));
         }
 
-        params
-            .AddParam("$graph_description")
+        params->
+            AddParam("$graph_description")
                 .String(serializedGraphDescription)
                 .Build();
     } else {
@@ -219,8 +222,8 @@ TFuture<TStatus> CreateCheckpoint(const TCheckpointContextPtr& context) {
         query << graphDescriptionPart;
     }
 
-    auto ttxControl = TTxControl::Tx(*generationContext->Transaction).CommitTx();
-    return generationContext->Session.ExecuteDataQuery(query, ttxControl, params.Build(), generationContext->ExecDataQuerySettings).Apply(
+    auto ttxControl = TTxControl::ContinueAndCommitTx();
+    return generationContext->Session->ExecuteDataQuery(query, ttxControl, std::move(params), generationContext->ExecDataQuerySettings).Apply(
         [] (const TFuture<TDataQueryResult>& future) {
             TStatus status = future.GetValue();
             return status;
@@ -248,9 +251,9 @@ TFuture<TStatus> UpdateCheckpoint(const TCheckpointContextPtr& context) {
     )", generationContext->TablePathPrefix.c_str(),
         CheckpointsMetadataTable);
 
-    NYdb::TParamsBuilder params;
-    params
-        .AddParam("$graph_id")
+    auto params = std::make_shared<NYdb::TParamsBuilder>();
+    params->
+         AddParam("$graph_id")
             .String(generationContext->PrimaryKey)
             .Build()
         .AddParam("$coordinator_generation")
@@ -269,8 +272,8 @@ TFuture<TStatus> UpdateCheckpoint(const TCheckpointContextPtr& context) {
             .Timestamp(TInstant::Now())
             .Build();
 
-    auto ttxControl = TTxControl::Tx(*generationContext->Transaction).CommitTx();
-    return generationContext->Session.ExecuteDataQuery(query, ttxControl, params.Build(), generationContext->ExecDataQuerySettings).Apply(
+    auto ttxControl = TTxControl::ContinueAndCommitTx();
+    return generationContext->Session->ExecuteDataQuery(query, ttxControl, std::move(params), generationContext->ExecDataQuerySettings).Apply(
         [] (const TFuture<TDataQueryResult>& future) {
             TStatus status = future.GetValue();
             return status;
@@ -291,13 +294,17 @@ TFuture<TDataQueryResult> SelectGraphDescId(const TCheckpointContextPtr& context
         WHERE id = $graph_desc_id;
     )", generationContext->TablePathPrefix.c_str(),
         CheckpointsGraphsDescriptionTable);
-    NYdb::TParamsBuilder params;
-    params
-        .AddParam("$graph_desc_id")
+    auto params = std::make_shared<NYdb::TParamsBuilder>();
+    params->
+         AddParam("$graph_desc_id")
             .String(graphDescContext->GraphDescId)
             .Build();
 
-    return generationContext->Session.ExecuteDataQuery(query, TTxControl::Tx(*generationContext->Transaction), params.Build(), generationContext->ExecDataQuerySettings);
+    return generationContext->Session->ExecuteDataQuery(
+        query,
+        TTxControl::ContinueTx(),
+        std::move(params),
+        generationContext->ExecDataQuerySettings);
 }
 
 bool GraphDescIdExists(const TFuture<TDataQueryResult>& result) {
@@ -351,21 +358,19 @@ TFuture<TStatus> CreateCheckpointWrapper(
 
 TFuture<TDataQueryResult> SelectGraphCheckpoints(const TGenerationContextPtr& context, const TVector<ECheckpointStatus>& statuses, ui64 limit, bool loadGraphDescription)
 {
-    NYdb::TParamsBuilder paramsBuilder;
+    auto paramsBuilder = std::make_shared<NYdb::TParamsBuilder>();
     if (statuses) {
-        auto& statusesParam = paramsBuilder.AddParam("$statuses").BeginList();
+        auto& statusesParam = paramsBuilder->AddParam("$statuses").BeginList();
         for (const auto& status : statuses) {
             statusesParam.AddListItem().Uint8(static_cast<ui8>(status));
         }
         statusesParam.EndList().Build();
     }
 
-    paramsBuilder.AddParam("$graph_id").String(context->PrimaryKey).Build();
+    paramsBuilder->AddParam("$graph_id").String(context->PrimaryKey).Build();
     if (limit < std::numeric_limits<ui64>::max()) {
-        paramsBuilder.AddParam("$limit").Uint64(limit).Build();
+        paramsBuilder->AddParam("$limit").Uint64(limit).Build();
     }
-
-    auto params = paramsBuilder.Build();
 
     using namespace fmt::literals;
     TString join;
@@ -411,10 +416,10 @@ TFuture<TDataQueryResult> SelectGraphCheckpoints(const TGenerationContextPtr& co
     "join"_a = join
     );
 
-    return context->Session.ExecuteDataQuery(
+    return context->Session->ExecuteDataQuery(
         query,
-        TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-        params,
+        TTxControl::BeginAndCommitTx(),
+        std::move(paramsBuilder),
         context->ExecDataQuerySettings);
 }
 
@@ -479,9 +484,9 @@ TFuture<TDataQueryResult> SelectCheckpoint(const TCheckpointContextPtr& context)
     )", generationContext->TablePathPrefix.c_str(),
         CheckpointsMetadataTable);
 
-    NYdb::TParamsBuilder params;
-    params
-        .AddParam("$graph_id")
+    auto params = std::make_shared<NYdb::TParamsBuilder>();
+    params->
+         AddParam("$graph_id")
             .String(generationContext->PrimaryKey)
             .Build()
         .AddParam("$coordinator_generation")
@@ -491,10 +496,10 @@ TFuture<TDataQueryResult> SelectCheckpoint(const TCheckpointContextPtr& context)
             .Uint64(context->CheckpointId.SeqNo)
             .Build();
 
-    return generationContext->Session.ExecuteDataQuery(
+    return generationContext->Session->ExecuteDataQuery(
         query,
-        TTxControl::Tx(*generationContext->Transaction),
-        params.Build(),
+        TTxControl::ContinueTx(),
+        std::move(params),
         generationContext->ExecDataQuerySettings);
 }
 
@@ -588,14 +593,14 @@ TFuture<TStatus> UpdateCheckpointWithCheckWrapper(
 ////////////////////////////////////////////////////////////////////////////////
 
 class TCheckpointStorage : public ICheckpointStorage {
-    TYdbConnectionPtr YdbConnection;
+    IYdbConnection::TPtr YdbConnection;
     const TExternalStorageSettings Config;
 
 public:
     explicit TCheckpointStorage(
         const TExternalStorageSettings& config,
         const IEntityIdGenerator::TPtr& entityIdGenerator,
-        const TYdbConnectionPtr& ydbConnection);
+        const IYdbConnection::TPtr& ydbConnection);
 
     ~TCheckpointStorage() = default;
 
@@ -660,7 +665,7 @@ private:
 TCheckpointStorage::TCheckpointStorage(
     const TExternalStorageSettings& config,
     const IEntityIdGenerator::TPtr& entityIdGenerator,
-    const TYdbConnectionPtr& ydbConnection)
+    const IYdbConnection::TPtr& ydbConnection)
     : YdbConnection(ydbConnection)
     , Config(config)
     , EntityIdGenerator(entityIdGenerator)
@@ -669,53 +674,13 @@ TCheckpointStorage::TCheckpointStorage(
 
 TFuture<TIssues> TCheckpointStorage::Init()
 {
-    TIssues issues;
-
-    // TODO: list at first?
-    if (YdbConnection->DB != YdbConnection->TablePathPrefix) {
-        auto status = YdbConnection->SchemeClient.MakeDirectory(YdbConnection->TablePathPrefix).GetValueSync();
-        if (!status.IsSuccess() && status.GetStatus() != EStatus::ALREADY_EXISTS) {
-            TStringStream ss;
-            ss << "Failed to create path '" << YdbConnection->TablePathPrefix << "'";
-            NYql::TIssue issue(ss.Str());
-            auto issues = NYdb::NAdapters::ToYqlIssues(status.GetIssues());
-            if (issues) {
-                for (const NYql::TIssue& i : issues) {
-                    issue.AddSubIssue(MakeIntrusive<NYql::TIssue>(i));
-                }
-            }
-            return MakeFuture(NYql::TIssues{issue});
-        }
-    }
-
-#define RUN_CREATE_TABLE(tableName, desc)                           \
-    {                                                               \
-        auto status = CreateTable(YdbConnection,                    \
-                                  tableName,                        \
-                                  std::move(desc)).GetValueSync();  \
-        if (!IsTableCreated(status)) {                              \
-            issues = NYdb::NAdapters::ToYqlIssues(status.GetIssues());                            \
-                                                                    \
-            TStringStream ss;                                       \
-            ss << "Failed to create " << tableName                  \
-               << " table: " << status.GetStatus();                 \
-            if (issues) {                                           \
-                ss << ", issues: ";                                 \
-                issues.PrintTo(ss);                                 \
-            }                                                       \
-                                                                    \
-            return MakeFuture(std::move(issues));                   \
-        }                                                           \
-    }
-
     auto graphDesc = TTableBuilder()
         .AddNullableColumn("graph_id", EPrimitiveType::String)
         .AddNullableColumn("generation", EPrimitiveType::Uint64)
         .SetPrimaryKeyColumn("graph_id")
         .Build();
-
-    RUN_CREATE_TABLE(CoordinatorsSyncTable, graphDesc);
-
+    auto f1 = CreateTable(YdbConnection, CoordinatorsSyncTable, std::move(graphDesc));
+    
     // TODO: graph_id could be just secondary index, but API forbids it,
     // so we set it primary key column to have index
     auto checkpointDesc = TTableBuilder()
@@ -729,8 +694,7 @@ TFuture<TIssues> TCheckpointStorage::Init()
         .AddNullableColumn("graph_description_id", EPrimitiveType::String)
         .SetPrimaryKeyColumns({"graph_id", "coordinator_generation", "seq_no"})
         .Build();
-
-    RUN_CREATE_TABLE(CheckpointsMetadataTable, checkpointDesc);
+    auto f2 = CreateTable(YdbConnection, CheckpointsMetadataTable, std::move(checkpointDesc));
 
     auto checkpointGraphsDescDesc = TTableBuilder()
         .AddNullableColumn("id", EPrimitiveType::String)
@@ -738,19 +702,40 @@ TFuture<TIssues> TCheckpointStorage::Init()
         .AddNullableColumn("graph_description", EPrimitiveType::String)
         .SetPrimaryKeyColumn("id")
         .Build();
+    auto f3 = CreateTable(YdbConnection, CheckpointsGraphsDescriptionTable, std::move(checkpointGraphsDescDesc));
 
-    RUN_CREATE_TABLE(CheckpointsGraphsDescriptionTable, checkpointGraphsDescDesc);
+    std::vector<NThreading::TFuture<NYdb::TStatus>> futures{f1, f2, f3};
 
-#undef RUN_CREATE_TABLE
-
-    return MakeFuture(std::move(issues));
+    auto promise = NThreading::NewPromise<TIssues>();
+    auto voidFuture = NThreading::WaitAll(futures);
+    
+    return voidFuture.Apply([futures = std::move(futures), promise](const auto& ) mutable {
+        TIssues issues;
+        auto check = [&issues] (const NYdb::TStatus& status) {
+            if (IsTableCreated(status)) {
+                return;
+            }
+            issues = NYdb::NAdapters::ToYqlIssues(status.GetIssues());
+            TStringStream ss;
+            ss << "Failed to create table: " << status.GetStatus();
+            if (issues) {
+                ss << ", issues: ";
+                issues.PrintTo(ss);
+            }
+        };
+        check(futures[0].GetValue());
+        check(futures[1].GetValue());
+        check(futures[2].GetValue());
+        return NThreading::MakeFuture(issues);
+    });
 }
 
 TFuture<TIssues> TCheckpointStorage::RegisterGraphCoordinator(const TCoordinatorId& coordinator)
 {
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, coordinator,
-         execDataQuerySettings = DefaultExecDataQuerySettings()] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), coordinator,
+         execDataQuerySettings = DefaultExecDataQuerySettings()] (ISession::TPtr session) {
+
             auto context = MakeIntrusive<TGenerationContext>(
                 session,
                 true,
@@ -771,8 +756,8 @@ TFuture<TIssues> TCheckpointStorage::RegisterGraphCoordinator(const TCoordinator
 TFuture<ICheckpointStorage::TGetCoordinatorsResult> TCheckpointStorage::GetCoordinators() {
     auto getContext = MakeIntrusive<TGetCoordinatorsContext>();
 
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, getContext, execDataQuerySettings = DefaultExecDataQuerySettings()] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), getContext, execDataQuerySettings = DefaultExecDataQuerySettings()] (ISession::TPtr session) {
             auto generationContext = MakeIntrusive<TGenerationContext>(
                 session,
                 false,
@@ -826,8 +811,8 @@ TFuture<ICheckpointStorage::TCreateCheckpointResult> TCheckpointStorage::CreateC
 
 TFuture<ICheckpointStorage::TCreateCheckpointResult> TCheckpointStorage::CreateCheckpointImpl(const TCoordinatorId& coordinator, const TCheckpointContextPtr& checkpointContext) {
     Y_ABORT_UNLESS(checkpointContext->CheckpointGraphDescriptionContext->GraphDescId || checkpointContext->EntityIdGenerator);
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, coordinator, checkpointContext, execDataQuerySettings = DefaultExecDataQuerySettings()] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), coordinator, checkpointContext, execDataQuerySettings = DefaultExecDataQuerySettings()] (ISession::TPtr session) {
             auto generationContext = MakeIntrusive<TGenerationContext>(
                 session,
                 false,
@@ -861,8 +846,8 @@ TFuture<TIssues> TCheckpointStorage::UpdateCheckpointStatus(
     ui64 stateSizeBytes)
 {
     auto checkpointContext = MakeIntrusive<TCheckpointContext>(checkpointId, newStatus, prevStatus, stateSizeBytes);
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, coordinator, checkpointContext, execDataQuerySettings = DefaultExecDataQuerySettings()] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), coordinator, checkpointContext, execDataQuerySettings = DefaultExecDataQuerySettings()] (ISession::TPtr session) {
             auto generationContext = MakeIntrusive<TGenerationContext>(
                 session,
                 false,
@@ -888,8 +873,8 @@ TFuture<TIssues> TCheckpointStorage::AbortCheckpoint(
     const TCheckpointId& checkpointId)
 {
     auto checkpointContext = MakeIntrusive<TCheckpointContext>(checkpointId, ECheckpointStatus::Aborted, ECheckpointStatus::Pending, 0ul);
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, coordinator, checkpointContext, execDataQuerySettings = DefaultExecDataQuerySettings()] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), coordinator, checkpointContext, execDataQuerySettings = DefaultExecDataQuerySettings()] (ISession::TPtr session) {
             auto generationContext = MakeIntrusive<TGenerationContext>(
                 session,
                 false,
@@ -919,8 +904,8 @@ TFuture<ICheckpointStorage::TGetCheckpointsResult> TCheckpointStorage::GetCheckp
 {
     auto getContext = MakeIntrusive<TGetCheckpointsContext>();
 
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, graph, getContext, statuses, limit, loadGraphDescription, execDataQuerySettings = DefaultExecDataQuerySettings()] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), graph, getContext, statuses, limit, loadGraphDescription, execDataQuerySettings = DefaultExecDataQuerySettings()] (ISession::TPtr session) {
             auto generationContext = MakeIntrusive<TGenerationContext>(
                 session,
                 false,
@@ -947,8 +932,8 @@ TFuture<ICheckpointStorage::TGetCheckpointsResult> TCheckpointStorage::GetCheckp
 }
 
 TFuture<TIssues> TCheckpointStorage::DeleteGraph(const TString& graphId) {
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, graphId, settings = DefaultExecDataQuerySettings()] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), graphId, settings = DefaultExecDataQuerySettings()] (ISession::TPtr session) {
             // TODO: use prepared queries
             auto query = Sprintf(R"(
                 --!syntax_v1
@@ -966,16 +951,16 @@ TFuture<TIssues> TCheckpointStorage::DeleteGraph(const TString& graphId) {
                 CoordinatorsSyncTable,
                 CheckpointsMetadataTable);
 
-            NYdb::TParamsBuilder params;
-            params
-                .AddParam("$graph_id")
+            auto params = std::make_shared<NYdb::TParamsBuilder>();
+            params->
+                 AddParam("$graph_id")
                     .String(graphId)
                     .Build();
 
-            auto future = session.ExecuteDataQuery(
+            auto future = session->ExecuteDataQuery(
                 query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-                params.Build(),
+                TTxControl::BeginAndCommitTx(),
+                std::move(params),
                 settings);
 
             return future.Apply(
@@ -992,8 +977,8 @@ TFuture<TIssues> TCheckpointStorage::MarkCheckpointsGC(
     const TString& graphId,
     const TCheckpointId& checkpointUpperBound)
 {
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, graphId, checkpointUpperBound, thisPtr = TIntrusivePtr(this)] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), graphId, checkpointUpperBound, thisPtr = TIntrusivePtr(this)] (ISession::TPtr session) {
             // TODO: use prepared queries
             auto query = Sprintf(R"(
                 --!syntax_v1
@@ -1012,9 +997,9 @@ TFuture<TIssues> TCheckpointStorage::MarkCheckpointsGC(
             )", prefix.c_str(),
                 CheckpointsMetadataTable);
 
-    NYdb::TParamsBuilder params;
-    params
-        .AddParam("$graph_id")
+    auto params = std::make_shared<NYdb::TParamsBuilder>();
+    params->
+         AddParam("$graph_id")
             .String(graphId)
             .Build()
         .AddParam("$coordinator_generation")
@@ -1030,10 +1015,10 @@ TFuture<TIssues> TCheckpointStorage::MarkCheckpointsGC(
             .Timestamp(TInstant::Now())
             .Build();
 
-            auto future = session.ExecuteDataQuery(
+            auto future = session->ExecuteDataQuery(
                 query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-                params.Build(),
+                TTxControl::BeginAndCommitTx(),
+                std::move(params),
                 thisPtr->DefaultExecDataQuerySettings());
 
             return future.Apply(
@@ -1050,8 +1035,8 @@ TFuture<TIssues> TCheckpointStorage::DeleteMarkedCheckpoints(
     const TString& graphId,
     const TCheckpointId& checkpointUpperBound)
 {
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, graphId, checkpointUpperBound, settings = DefaultExecDataQuerySettings()] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), graphId, checkpointUpperBound, settings = DefaultExecDataQuerySettings()] (ISession::TPtr session) {
             // TODO: use prepared queries
             using namespace fmt::literals;
             const TString query = fmt::format(R"sql(
@@ -1096,9 +1081,9 @@ TFuture<TIssues> TCheckpointStorage::DeleteMarkedCheckpoints(
             "gc_status"_a = static_cast<ui32>(ECheckpointStatus::GC)
             );
 
-            NYdb::TParamsBuilder params;
-            params
-                .AddParam("$graph_id")
+            auto params = std::make_shared<NYdb::TParamsBuilder>();
+            params->
+                 AddParam("$graph_id")
                     .String(graphId)
                     .Build()
                 .AddParam("$coordinator_generation")
@@ -1108,9 +1093,11 @@ TFuture<TIssues> TCheckpointStorage::DeleteMarkedCheckpoints(
                     .Uint64(checkpointUpperBound.SeqNo)
                     .Build();
 
-            auto future = session.ExecuteDataQuery(
+            auto future = session->ExecuteDataQuery(
                 query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(), params.Build(), settings);
+                TTxControl::BeginAndCommitTx(),
+                std::move(params),
+                settings);
 
             return future.Apply(
                 [] (const TFuture<TDataQueryResult>& future) {
@@ -1124,14 +1111,14 @@ TFuture<TIssues> TCheckpointStorage::DeleteMarkedCheckpoints(
 
 TFuture<ICheckpointStorage::TGetTotalCheckpointsStateSizeResult> TCheckpointStorage::GetTotalCheckpointsStateSize(const TString& graphId) {
     auto result = MakeIntrusive<TGetTotalCheckpointsStateSizeContext>();
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, graphId, thisPtr = TIntrusivePtr(this), result,
-         actorSystem = NActors::TActivationContext::ActorSystem()](TSession session) {
-          NYdb::TParamsBuilder paramsBuilder;
-          paramsBuilder.AddParam("$graph_id").String(graphId).Build();
-          auto params = paramsBuilder.Build();
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), graphId, thisPtr = TIntrusivePtr(this), result,
+         actorSystem = NActors::TActivationContext::ActorSystem()](ISession::TPtr session) {
 
-          auto query = Sprintf(R"(
+            auto paramsBuilder = std::make_shared<NYdb::TParamsBuilder>();
+            paramsBuilder->AddParam("$graph_id").String(graphId).Build();
+
+            auto query = Sprintf(R"(
                 --!syntax_v1
                 PRAGMA TablePathPrefix("%s");
 
@@ -1142,11 +1129,11 @@ TFuture<ICheckpointStorage::TGetTotalCheckpointsStateSizeResult> TCheckpointStor
                 WHERE graph_id = $graph_id
             )", prefix.c_str(), CheckpointsMetadataTable);
 
-          return session.ExecuteDataQuery(
-                  query,
-                  TTxControl::BeginTx(TTxSettings::OnlineRO()).CommitTx(),
-                  params,
-                  thisPtr->DefaultExecDataQuerySettings())
+            return session->ExecuteDataQuery(
+                query,
+                TTxControl::BeginAndCommitTx(true),
+                std::move(paramsBuilder),
+                thisPtr->DefaultExecDataQuerySettings())
               .Apply(
                   [graphId, result, actorSystem](const TFuture<TDataQueryResult>& future) {
                         const auto& queryResult = future.GetValue();
@@ -1187,7 +1174,7 @@ TExecDataQuerySettings TCheckpointStorage::DefaultExecDataQuerySettings() {
 TCheckpointStoragePtr NewYdbCheckpointStorage(
     const TExternalStorageSettings& config,
     const IEntityIdGenerator::TPtr& entityIdGenerator,
-    const TYdbConnectionPtr& ydbConnection)
+    const IYdbConnection::TPtr& ydbConnection)
 {
     Y_ABORT_UNLESS(entityIdGenerator);
     return new TCheckpointStorage(config, entityIdGenerator, ydbConnection);

--- a/ydb/core/fq/libs/checkpoint_storage/ydb_checkpoint_storage.h
+++ b/ydb/core/fq/libs/checkpoint_storage/ydb_checkpoint_storage.h
@@ -4,7 +4,6 @@
 
 #include <ydb/core/fq/libs/common/entity_id.h>
 #include <ydb/core/fq/libs/ydb/ydb.h>
-#include <ydb/library/security/ydb_credentials_provider_factory.h>
 
 namespace NFq {
 
@@ -13,6 +12,6 @@ namespace NFq {
 TCheckpointStoragePtr NewYdbCheckpointStorage(
     const TExternalStorageSettings& config,
     const IEntityIdGenerator::TPtr& entityIdGenerator,
-    const TYdbConnectionPtr& ydbConnection);
+    const IYdbConnection::TPtr& ydbConnection);
 
 } // namespace NFq

--- a/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
@@ -17,6 +17,7 @@ namespace NFq {
 using namespace NThreading;
 using namespace NYdb;
 using namespace NYdb::NTable;
+using TTxControl = NFq::ISession::TTxControl;
 
 using NYql::TIssues;
 
@@ -172,7 +173,7 @@ struct TContext : public TThrRefBase {
     const TString TablePathPrefix;
     const TString GraphId;
     const TCheckpointId CheckpointId;
-    TMaybe<TSession> Session;
+    TMaybe<ISession::TPtr> Session;
     size_t CurrentProcessingTaskIndex = 0;
     std::vector<TaskInfo> Tasks;
     std::function<void(TFuture<TStatus>)> Callback;    
@@ -183,7 +184,7 @@ struct TContext : public TThrRefBase {
         const std::vector<ui64>& taskIds,
         TString graphId,
         const TCheckpointId& checkpointId,
-        TMaybe<TSession> session = {})
+        TMaybe<ISession::TPtr> session = {})
         : ActorSystem(actorSystem)
         , TablePathPrefix(tablePathPrefix)
         , GraphId(std::move(graphId))
@@ -201,7 +202,7 @@ struct TContext : public TThrRefBase {
         ui64 taskId,
         TString graphId,
         const TCheckpointId& checkpointId,
-        TMaybe<TSession> session = {},
+        TMaybe<ISession::TPtr> session = {},
         const std::list<TString>& rows = {},
         EStateType type = EStateType::Snapshot)
         : TContext(actorSystem, tablePathPrefix, std::vector{taskId}, std::move(graphId), checkpointId, std::move(session))
@@ -283,14 +284,15 @@ TStatus ProcessRowState(
 ////////////////////////////////////////////////////////////////////////////////
 
 class TStateStorage : public IStateStorage {
-    TYdbConnectionPtr YdbConnection;
+    IYdbConnection::TPtr YdbConnection;
     const TExternalStorageSettings StorageConfig;
     const TCheckpointStorageSettings Config;
 
 public:
     explicit TStateStorage(
         const TCheckpointStorageSettings& config,
-        const TYdbConnectionPtr& ydbConnection);
+        const IYdbConnection::TPtr& ydbConnection);
+
     ~TStateStorage() = default;
 
     TFuture<TIssues> Init() override;
@@ -356,7 +358,7 @@ private:
 
 TStateStorage::TStateStorage(
     const TCheckpointStorageSettings& config,
-    const TYdbConnectionPtr& ydbConnection)
+    const IYdbConnection::TPtr& ydbConnection)
     : YdbConnection(ydbConnection)
     , StorageConfig(config.GetExternalStorage())
     , Config(config)
@@ -364,27 +366,6 @@ TStateStorage::TStateStorage(
 }
 
 TFuture<TIssues> TStateStorage::Init() {
-    TIssues issues;
-
-    // TODO: list at first?
-    if (YdbConnection->DB != YdbConnection->TablePathPrefix) {
-        //LOG_STREAMS_STORAGE_SERVICE_INFO("Creating directory: " << YdbConnection->TablePathPrefix);
-        auto status = YdbConnection->SchemeClient.MakeDirectory(YdbConnection->TablePathPrefix).GetValueSync();
-        if (!status.IsSuccess() && status.GetStatus() != EStatus::ALREADY_EXISTS) {
-            issues = NYdb::NAdapters::ToYqlIssues(status.GetIssues());
-
-            TStringStream ss;
-            ss << "Failed to create path '" << YdbConnection->TablePathPrefix << "': " << status.GetStatus();
-            if (issues) {
-                ss << ", issues: ";
-                issues.PrintTo(ss);
-            }
-
-            //LOG_STREAMS_STORAGE_SERVICE_DEBUG(ss.Str());
-            return MakeFuture(std::move(issues));
-        }
-    }
-
     auto stateDesc = TTableBuilder()
         .AddNullableColumn("graph_id", EPrimitiveType::String)
         .AddNullableColumn("task_id", EPrimitiveType::Uint64)
@@ -396,19 +377,25 @@ TFuture<TIssues> TStateStorage::Init() {
         .SetPrimaryKeyColumns({"graph_id", "task_id", "coordinator_generation", "seq_no", "blob_seq_num"})
         .Build();
 
-    auto status = CreateTable(YdbConnection, StatesTable, std::move(stateDesc)).GetValueSync();
-    if (!IsTableCreated(status)) {
-        issues = NYdb::NAdapters::ToYqlIssues(status.GetIssues());
+    auto promise = NThreading::NewPromise<TIssues>();
 
-        TStringStream ss;
-        ss << "Failed to create " << StatesTable << " table: " << status.GetStatus();
-        if (issues) {
-            ss << ", issues: ";
-            issues.PrintTo(ss);
-        }
-    }
-
-    return MakeFuture(std::move(issues));
+    CreateTable(YdbConnection, StatesTable, std::move(stateDesc))
+        .Subscribe([promise](const auto& f) mutable {
+            auto status = f.GetValue();
+            if (!IsTableCreated(status)) {
+                auto issues = NYdb::NAdapters::ToYqlIssues(status.GetIssues());
+                TStringStream ss;
+                ss << "Failed to create " << StatesTable << " table: " << status.GetStatus();
+                if (issues) {
+                    ss << ", issues: ";
+                    issues.PrintTo(ss);
+                }
+                promise.SetValue(std::move(issues));
+                return;
+            }
+            promise.SetValue(TIssues());
+        });
+    return promise.GetFuture();
 }
 
 EStateType TStateStorage::DeserializeState(const TContextPtr& context, TContext::TaskInfo& taskInfo) {
@@ -472,11 +459,11 @@ TFuture<IStateStorage::TSaveStateResult> TStateStorage::SaveState(
 
     auto context = MakeIntrusive<TContext>(
         NActors::TActivationContext::ActorSystem(),
-        YdbConnection->TablePathPrefix,
+        YdbConnection->GetTablePathPrefix(),
         taskId,
         graphId,
         checkpointId,
-        TMaybe<TSession>(), 
+        TMaybe<ISession::TPtr>(), 
         serializedState,
         type);
 
@@ -524,7 +511,7 @@ TFuture<IStateStorage::TGetStateResult> TStateStorage::GetState(
 
     auto context = MakeIntrusive<TContext>(
         NActors::TActivationContext::ActorSystem(),
-        YdbConnection->TablePathPrefix,
+        YdbConnection->GetTablePathPrefix(),
         taskIds,
         graphId,
         checkpointId);
@@ -561,16 +548,16 @@ TFuture<IStateStorage::TCountStatesResult> TStateStorage::CountStates(
     const TCheckpointId& checkpointId) {
     auto context = MakeIntrusive<TCountStateContext>();
 
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, graphId, checkpointId, context, thisPtr = TIntrusivePtr(this)] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), graphId, checkpointId, context, thisPtr = TIntrusivePtr(this)] (ISession::TPtr session) {
 
             // publish nodes
-            NYdb::TParamsBuilder paramsBuilder;
-            paramsBuilder.AddParam("$graph_id").String(graphId).Build();
-            paramsBuilder.AddParam("$coordinator_generation").Uint64(checkpointId.CoordinatorGeneration).Build();
-            paramsBuilder.AddParam("$seq_no").Uint64(checkpointId.SeqNo).Build();
+            auto paramsBuilder = std::make_shared<NYdb::TParamsBuilder>();
 
-            auto params = paramsBuilder.Build();
+            paramsBuilder->AddParam("$graph_id").String(graphId).Build();
+            paramsBuilder->AddParam("$coordinator_generation").Uint64(checkpointId.CoordinatorGeneration).Build();
+            paramsBuilder->AddParam("$seq_no").Uint64(checkpointId.SeqNo).Build();
+
             auto query = Sprintf(R"(
                 --!syntax_v1
                 PRAGMA TablePathPrefix("%s");
@@ -586,10 +573,10 @@ TFuture<IStateStorage::TCountStatesResult> TStateStorage::CountStates(
                 SELECT COUNT(*) as cnt FROM $tasks;
             )", prefix.c_str(), StatesTable);
 
-            auto future = session.ExecuteDataQuery(
+            auto future = session->ExecuteDataQuery(
                 query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-                params,
+                TTxControl::BeginAndCommitTx(),
+                paramsBuilder,
                 thisPtr->GetExecDataQuerySettings());
 
             return future.Apply(
@@ -615,24 +602,24 @@ TFuture<IStateStorage::TCountStatesResult> TStateStorage::CountStates(
 }
 
 TFuture<TStatus> TStateStorage::ListStates(const TContextPtr& context) {
-    return YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, context, thisPtr = TIntrusivePtr(this)] (TSession session) {
-            NYdb::TParamsBuilder paramsBuilder;
-            paramsBuilder.AddParam("$graph_id").String(context->GraphId).Build();
-            paramsBuilder.AddParam("$coordinator_generation").Uint64(context->CheckpointId.CoordinatorGeneration).Build();
-            paramsBuilder.AddParam("$seq_no").Uint64(context->CheckpointId.SeqNo).Build();
+    return YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), context, thisPtr = TIntrusivePtr(this)] (ISession::TPtr session) {
+            auto paramsBuilder = std::make_shared<NYdb::TParamsBuilder>();
+
+            paramsBuilder->AddParam("$graph_id").String(context->GraphId).Build();
+            paramsBuilder->AddParam("$coordinator_generation").Uint64(context->CheckpointId.CoordinatorGeneration).Build();
+            paramsBuilder->AddParam("$seq_no").Uint64(context->CheckpointId.SeqNo).Build();
 
             if (context->Tasks.size() == 1) {
-                paramsBuilder.AddParam("$task_id").Uint64(context->Tasks[0].TaskId).Build();
+                paramsBuilder->AddParam("$task_id").Uint64(context->Tasks[0].TaskId).Build();
             } else {
-                auto& taskIdsParam = paramsBuilder.AddParam("$task_ids").BeginList();
+                auto& taskIdsParam = paramsBuilder->AddParam("$task_ids").BeginList();
                 for (const auto& taskInfo : context->Tasks) {
                     taskIdsParam.AddListItem().Uint64(taskInfo.TaskId);
                 }
                 taskIdsParam.EndList().Build();
             }
 
-            auto params = paramsBuilder.Build();
             auto query = Sprintf(R"(
                 --!syntax_v1
                 PRAGMA AnsiInForEmptyOrNullableItemsCollections;
@@ -651,10 +638,10 @@ TFuture<TStatus> TStateStorage::ListStates(const TContextPtr& context) {
                 StatesTable,
                 context->Tasks.size() == 1 ? "task_id = $task_id" : "task_id IN $task_ids");
 
-            auto future = session.ExecuteDataQuery(
+            auto future = session->ExecuteDataQuery(
                 query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-                params,
+                TTxControl::BeginAndCommitTx(),
+                paramsBuilder,
                 thisPtr->GetExecDataQuerySettings());
 
             return future.Apply(
@@ -705,14 +692,12 @@ TExecDataQuerySettings TStateStorage::GetExecDataQuerySettings(ui64 multiplier) 
 }
 
 TFuture<TIssues> TStateStorage::DeleteGraph(const TString& graphId) {
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, graphId, thisPtr = TIntrusivePtr(this)] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), graphId, thisPtr = TIntrusivePtr(this)] (ISession::TPtr session) {
 
             // publish nodes
-            NYdb::TParamsBuilder paramsBuilder;
-            paramsBuilder.AddParam("$graph_id").String(graphId).Build();
-
-            auto params = paramsBuilder.Build();
+            auto paramsBuilder = std::make_shared<NYdb::TParamsBuilder>();
+            paramsBuilder->AddParam("$graph_id").String(graphId).Build();
 
             auto query = Sprintf(R"(
                 --!syntax_v1
@@ -725,10 +710,10 @@ TFuture<TIssues> TStateStorage::DeleteGraph(const TString& graphId) {
                 WHERE graph_id = $graph_id;
             )", prefix.c_str(), StatesTable);
 
-            auto future = session.ExecuteDataQuery(
+            auto future = session->ExecuteDataQuery(
                 query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-                params,
+                TTxControl::BeginAndCommitTx(),
+                paramsBuilder,
                 thisPtr->GetExecDataQuerySettings(DeleteStateTimeoutMultiplier));
 
             return future.Apply(
@@ -744,16 +729,14 @@ TFuture<TIssues> TStateStorage::DeleteGraph(const TString& graphId) {
 TFuture<TIssues> TStateStorage::DeleteCheckpoints(
     const TString& graphId,
     const TCheckpointId& checkpointUpperBound) {
-    auto future = YdbConnection->TableClient.RetryOperation(
-        [prefix = YdbConnection->TablePathPrefix, graphId, checkpointUpperBound, thisPtr = TIntrusivePtr(this)] (TSession session) {
+    auto future = YdbConnection->GetTableClient()->RetryOperation(
+        [prefix = YdbConnection->GetTablePathPrefix(), graphId, checkpointUpperBound, thisPtr = TIntrusivePtr(this)] (ISession::TPtr session) {
 
             // publish nodes
-            NYdb::TParamsBuilder paramsBuilder;
-            paramsBuilder.AddParam("$graph_id").String(graphId).Build();
-            paramsBuilder.AddParam("$coordinator_generation").Uint64(checkpointUpperBound.CoordinatorGeneration).Build();
-            paramsBuilder.AddParam("$seq_no").Uint64(checkpointUpperBound.SeqNo).Build();
-
-            auto params = paramsBuilder.Build();
+            auto paramsBuilder = std::make_shared<NYdb::TParamsBuilder>();
+            paramsBuilder->AddParam("$graph_id").String(graphId).Build();
+            paramsBuilder->AddParam("$coordinator_generation").Uint64(checkpointUpperBound.CoordinatorGeneration).Build();
+            paramsBuilder->AddParam("$seq_no").Uint64(checkpointUpperBound.SeqNo).Build();
 
             auto query = Sprintf(R"(
                 --!syntax_v1
@@ -770,10 +753,10 @@ TFuture<TIssues> TStateStorage::DeleteCheckpoints(
                         (coordinator_generation = $coordinator_generation AND seq_no < $seq_no));
             )", prefix.c_str(), StatesTable);
 
-            auto future = session.ExecuteDataQuery(
+            auto future = session->ExecuteDataQuery(
                 query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-                params,
+                TTxControl::BeginAndCommitTx(),
+                paramsBuilder,
                 thisPtr->GetExecDataQuerySettings(DeleteStateTimeoutMultiplier));
 
             return future.Apply(
@@ -787,8 +770,8 @@ TFuture<TIssues> TStateStorage::DeleteCheckpoints(
 }
 
 TFuture<TStatus> TStateStorage::SelectRowState(const TContextPtr& context) {
-    return YdbConnection->TableClient.RetryOperation(
-        [context, this] (TSession session) {
+    return YdbConnection->GetTableClient()->RetryOperation(
+        [context, this] (ISession::TPtr session) {
             context->Session = session;
             auto future = SelectState(context);
             return future.Apply(
@@ -804,19 +787,18 @@ TFuture<TStatus> TStateStorage::SelectRowState(const TContextPtr& context) {
 }
 
 TFuture<TDataQueryResult> TStateStorage::SelectState(const TContextPtr& context) {
-    NYdb::TParamsBuilder paramsBuilder;
+    auto paramsBuilder = std::make_shared<NYdb::TParamsBuilder>();
+
     Y_ENSURE(!context->Tasks.empty(), "Tasks is empty");
     auto& taskInfo = context->Tasks[context->CurrentProcessingTaskIndex];
 
     LOG_STORAGE_DEBUG(context, "SelectState: task_id " << taskInfo.TaskId << ", seq_no " 
         << taskInfo.ListOfStatesForReading.front().CheckpointId.SeqNo << ", blob_seq_num " << taskInfo.CurrentProcessingRow);
-    paramsBuilder.AddParam("$task_id").Uint64(taskInfo.TaskId).Build();
-    paramsBuilder.AddParam("$graph_id").String(context->GraphId).Build();
-    paramsBuilder.AddParam("$coordinator_generation").Uint64(taskInfo.ListOfStatesForReading.front().CheckpointId.CoordinatorGeneration).Build();
-    paramsBuilder.AddParam("$seq_no").Uint64(taskInfo.ListOfStatesForReading.front().CheckpointId.SeqNo).Build();
-    paramsBuilder.AddParam("$blob_seq_num").Uint64(taskInfo.CurrentProcessingRow).Build();
-
-    auto params = paramsBuilder.Build();
+    paramsBuilder->AddParam("$task_id").Uint64(taskInfo.TaskId).Build();
+    paramsBuilder->AddParam("$graph_id").String(context->GraphId).Build();
+    paramsBuilder->AddParam("$coordinator_generation").Uint64(taskInfo.ListOfStatesForReading.front().CheckpointId.CoordinatorGeneration).Build();
+    paramsBuilder->AddParam("$seq_no").Uint64(taskInfo.ListOfStatesForReading.front().CheckpointId.SeqNo).Build();
+    paramsBuilder->AddParam("$blob_seq_num").Uint64(taskInfo.CurrentProcessingRow).Build();
 
     auto query = Sprintf(R"(
         --!syntax_v1
@@ -838,32 +820,31 @@ TFuture<TDataQueryResult> TStateStorage::SelectState(const TContextPtr& context)
         (taskInfo.CurrentProcessingRow == 0) ? " OR blob_seq_num is NULL" : "");
 
     Y_ENSURE(context->Session, "Session is empty");
-    return context->Session->ExecuteDataQuery(
+    return (*context->Session)->ExecuteDataQuery(
         query,
-        TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-        params,
+        TTxControl::BeginAndCommitTx(),
+        paramsBuilder,
         GetExecDataQuerySettings());
 }
 
 TFuture<TStatus> TStateStorage::UpsertRow(const TContextPtr& context) {
 
-    return YdbConnection->TableClient.RetryOperation(
-        [context, thisPtr = TIntrusivePtr(this)] (TSession session) {
+    return YdbConnection->GetTableClient()->RetryOperation(
+        [context, thisPtr = TIntrusivePtr(this)] (ISession::TPtr session) {
             context->Session = session;
             // publish nodes
-            NYdb::TParamsBuilder paramsBuilder;
+            auto paramsBuilder = std::make_shared<NYdb::TParamsBuilder>();
+
             Y_ENSURE(context->Tasks.size() == 1, "Tasks size != 1");
             auto& taskInfo = context->Tasks[context->CurrentProcessingTaskIndex];
 
-            paramsBuilder.AddParam("$task_id").Uint64(taskInfo.TaskId).Build();
-            paramsBuilder.AddParam("$graph_id").String(context->GraphId).Build();
-            paramsBuilder.AddParam("$coordinator_generation").Uint64(context->CheckpointId.CoordinatorGeneration).Build();
-            paramsBuilder.AddParam("$seq_no").Uint64(context->CheckpointId.SeqNo).Build();
-            paramsBuilder.AddParam("$blob").String(taskInfo.Rows.front()).Build();
-            paramsBuilder.AddParam("$blob_seq_num").Uint64(taskInfo.CurrentProcessingRow).Build();
-            paramsBuilder.AddParam("$type").Uint8(static_cast<ui8>(taskInfo.Type)).Build();
-
-            auto params = paramsBuilder.Build();
+            paramsBuilder->AddParam("$task_id").Uint64(taskInfo.TaskId).Build();
+            paramsBuilder->AddParam("$graph_id").String(context->GraphId).Build();
+            paramsBuilder->AddParam("$coordinator_generation").Uint64(context->CheckpointId.CoordinatorGeneration).Build();
+            paramsBuilder->AddParam("$seq_no").Uint64(context->CheckpointId.SeqNo).Build();
+            paramsBuilder->AddParam("$blob").String(taskInfo.Rows.front()).Build();
+            paramsBuilder->AddParam("$blob_seq_num").Uint64(taskInfo.CurrentProcessingRow).Build();
+            paramsBuilder->AddParam("$type").Uint8(static_cast<ui8>(taskInfo.Type)).Build();
 
             auto query = Sprintf(R"(
                 --!syntax_v1
@@ -883,10 +864,10 @@ TFuture<TStatus> TStateStorage::UpsertRow(const TContextPtr& context) {
 
             Y_ENSURE(context->Session, "Session is empty");
 
-            auto future = context->Session->ExecuteDataQuery(
+            auto future = (*context->Session)->ExecuteDataQuery(
                 query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
-                params,
+                TTxControl::BeginAndCommitTx(),
+                paramsBuilder,
                 thisPtr->GetExecDataQuerySettings());
 
             return future.Apply(
@@ -1001,7 +982,7 @@ std::vector<NYql::NDq::TComputeActorState> TStateStorage::ApplyIncrements(
 
 TStateStoragePtr NewYdbStateStorage(
     const TCheckpointStorageSettings& config,
-    const TYdbConnectionPtr& ydbConnection) {
+    const IYdbConnection::TPtr& ydbConnection) {
     return new TStateStorage(config, ydbConnection);
 }
 

--- a/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.h
+++ b/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.h
@@ -4,7 +4,6 @@
 #include "storage_settings.h"
 
 #include <ydb/core/fq/libs/ydb/ydb.h>
-#include <ydb/library/security/ydb_credentials_provider_factory.h>
 
 namespace NFq {
 
@@ -12,6 +11,6 @@ namespace NFq {
 
 TStateStoragePtr NewYdbStateStorage(
     const TCheckpointStorageSettings& config,
-    const TYdbConnectionPtr& ydbConnection);
+    const IYdbConnection::TPtr& ydbConnection);
 
 } // namespace NFq

--- a/ydb/core/fq/libs/checkpointing/checkpoint_coordinator.cpp
+++ b/ydb/core/fq/libs/checkpointing/checkpoint_coordinator.cpp
@@ -9,6 +9,7 @@
 #include <ydb/library/yql/dq/state/dq_state_load_plan.h>
 
 #include <util/string/builder.h>
+#include <util/system/env.h>
 
 #include <utility>
 
@@ -24,6 +25,16 @@
 namespace NFq {
 
 using namespace NActors;
+
+TCheckpointCoordinatorSettings::TCheckpointCoordinatorSettings() {
+    ui64 ms = 0;
+    if (!TryFromString<ui64>(GetEnv("YDB_TEST_DEFAULT_CHECKPOINTING_PERIOD_MS"), ms)) {
+        return;
+    }
+    if (ms) {
+        CheckpointingPeriod = TDuration::MilliSeconds(ms);
+    }
+}
 
 TCheckpointCoordinatorSettings::TCheckpointCoordinatorSettings(const NFq::NConfig::TCheckpointCoordinatorConfig& config)
     : CheckpointingPeriod(TDuration::MilliSeconds(config.GetCheckpointingPeriodMillis() ? config.GetCheckpointingPeriodMillis() : 30'000))
@@ -54,7 +65,9 @@ TCheckpointCoordinator::TCheckpointCoordinator(TCoordinatorId coordinatorId,
 }
 
 void TCheckpointCoordinator::Handle(NFq::TEvCheckpointCoordinator::TEvReadyState::TPtr& ev) {
-    CC_LOG_D("TEvReadyState, streaming disposition " << StreamingDisposition << ", state load mode " << FederatedQuery::StateLoadMode_Name(StateLoadMode));
+    CC_LOG_D("TEvReadyState, streaming disposition " << StreamingDisposition 
+        << ", state load mode " << FederatedQuery::StateLoadMode_Name(StateLoadMode)
+        << ", checkpointing period " << Settings.GetCheckpointingPeriod());
     ControlId = ev->Sender;
 
     for (const auto& task : ev->Get()->Tasks) {

--- a/ydb/core/fq/libs/checkpointing/checkpoint_coordinator.h
+++ b/ydb/core/fq/libs/checkpointing/checkpoint_coordinator.h
@@ -24,7 +24,7 @@ class TCheckpointCoordinatorSettings {
 public:
     inline static TDuration DefaultCheckpointingPeriod = TDuration::Seconds(30);
 
-    TCheckpointCoordinatorSettings() = default;
+    TCheckpointCoordinatorSettings();
     TCheckpointCoordinatorSettings(const NFq::NConfig::TCheckpointCoordinatorConfig& config);
 
 private:

--- a/ydb/core/fq/libs/config/protos/row_dispatcher.proto
+++ b/ydb/core/fq/libs/config/protos/row_dispatcher.proto
@@ -23,6 +23,7 @@ message TJsonParserConfig {
     uint64 BatchSizeBytes = 1;  // default 1 MiB
     uint64 BatchCreationTimeoutMs = 2;
     uint64 BufferCellCount = 3;  // (number rows) * (number columns) limit, default 10^6
+    bool SkipErrors = 4;
 }
 
 message TCompileServiceConfig {

--- a/ydb/core/fq/libs/quota_manager/ya.make
+++ b/ydb/core/fq/libs/quota_manager/ya.make
@@ -11,7 +11,9 @@ PEERDIR(
     ydb/core/fq/libs/control_plane_storage/proto
     ydb/core/fq/libs/quota_manager/events
     ydb/core/fq/libs/shared_resources
+    ydb/core/grpc_services/local_rpc
     ydb/core/protos
+    ydb/library/aclib/protos
     ydb/public/api/grpc/draft
     ydb/public/sdk/cpp/src/client/table
 )

--- a/ydb/core/fq/libs/row_dispatcher/common/row_dispatcher_settings.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/common/row_dispatcher_settings.cpp
@@ -9,6 +9,7 @@ namespace NFq {
 
 TRowDispatcherSettings::TJsonParserSettings::TJsonParserSettings(const NConfig::TJsonParserConfig& config)
     : BatchCreationTimeout(TDuration::MilliSeconds(config.GetBatchCreationTimeoutMs()))
+    , SkipErrors(config.GetSkipErrors())
 {
     if (config.GetBatchSizeBytes()) {
         BatchSizeBytes = config.GetBatchSizeBytes();

--- a/ydb/core/fq/libs/row_dispatcher/common/row_dispatcher_settings.h
+++ b/ydb/core/fq/libs/row_dispatcher/common/row_dispatcher_settings.h
@@ -33,6 +33,7 @@ public:
         YDB_ACCESSOR(ui64, BatchSizeBytes, 1_MB);
         YDB_ACCESSOR(TDuration, BatchCreationTimeout, TDuration::Seconds(1));
         YDB_ACCESSOR(ui64, BufferCellCount, 1000'000);
+        YDB_ACCESSOR(bool, SkipErrors, false);
     };
 
     class TCompileServiceSettings {

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -26,7 +26,8 @@ struct TJsonParserBuffer {
     ui16 NumberValues = 0;
     bool Finished = false;
     TInstant CreationStartTime = TInstant::Now();
-    TVector<ui64> Offsets = {};
+    TVector<ui64> Offsets = {};             // Offsets in topics (seqno).
+    TVector<ui32> MessageOffsets = {};      // Message positions in Values.
 
     bool IsReady() const {
         return !Finished && NumberValues > 0;
@@ -38,6 +39,7 @@ struct TJsonParserBuffer {
 
     void Reserve(size_t size, size_t numberValues) {
         Values.reserve(size + simdjson::SIMDJSON_PADDING);
+        MessageOffsets.reserve(numberValues);
         Offsets.reserve(numberValues);
     }
 
@@ -50,6 +52,7 @@ struct TJsonParserBuffer {
         }
 
         NumberValues++;
+        MessageOffsets.emplace_back(Values.size());
         Values << message.GetData();
         Offsets.emplace_back(offset);
     }
@@ -68,6 +71,7 @@ struct TJsonParserBuffer {
         CreationStartTime = TInstant::Now();
         Values.clear();
         Offsets.clear();
+        MessageOffsets.clear();
     }
 
 private:
@@ -81,14 +85,19 @@ public:
     TString TypeYson;
 
 public:
-    TStatus InitParser(const TString& name, const TString& typeYson, std::span<ui16> parsedRows, const NKikimr::NMiniKQL::TType* typeMkql) {
+    TStatus InitParser(const TString& name, const TString& typeYson, std::span<ui16> parsedRows, const NKikimr::NMiniKQL::TType* typeMkql, bool skipErrors) {
         Name = name;
         TypeYson = typeYson;
         IsOptional = false;
+        SkipErrors = skipErrors;
         Status = TStatus::Success();
         ParsedRowsCount = 0;
         ParsedRows = parsedRows;
         return Status = ExtractDataSlot(typeMkql);
+    }
+
+    bool GetIsOptional() {
+        return IsOptional;
     }
 
     ui16 GetParsedRowsCount() const {
@@ -103,9 +112,9 @@ public:
         return Status;
     }
 
-    void ParseJsonValue(ui64 offset, ui16 rowId, simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue) {
-        if (Y_UNLIKELY(Status.IsFail())) {
-            return;
+    bool ParseJsonValue(ui64 offset, ui16 rowId, simdjson::builtin::ondemand::value jsonValue, NYql::NUdf::TUnboxedValue& resultValue) {
+        if (Y_UNLIKELY(!SkipErrors && Status.IsFail())) {
+            return false;
         }
         ParsedRows[ParsedRowsCount++] = rowId;
 
@@ -119,9 +128,10 @@ public:
             resultValue = resultValue.MakeOptional();
         }
 
-        if (Y_UNLIKELY(Status.IsFail())) {
+        if (Y_UNLIKELY(!SkipErrors && Status.IsFail())) {
             Status.AddParentIssue(TStringBuilder() << "Failed to parse json string at offset " << offset << ", got parsing error for column '" << Name << "' with type " << TypeYson);
         }
+        return resultValue.HasValue();
     }
 
     void ValidateNumberValues(ui16 expectedNumberValues, const TVector<ui64>& offsets) {
@@ -315,6 +325,7 @@ private:
     NYql::NUdf::EDataSlot DataSlot;
     TString DataTypeName;
     bool IsOptional = false;
+    bool SkipErrors = false;
 
     ui16 ParsedRowsCount = 0;
     std::span<ui16> ParsedRows;
@@ -335,11 +346,13 @@ public:
         , Config(config)
         , MaxNumberRows(CalculateMaxNumberRows())
         , LogPrefix("TJsonParser: ")
+        , Counters(counters.CountersSubgroup)
+        , ParsingErrors(Counters->GetCounter("ParsingErrors", true))
     {
         FillColumnsBuffers();
         Buffer.Reserve(Config.BatchSize, MaxNumberRows);
 
-        LOG_ROW_DISPATCHER_INFO("Simdjson active implementation " << simdjson::get_active_implementation()->name());
+        LOG_ROW_DISPATCHER_INFO("Simdjson active implementation " << simdjson::get_active_implementation()->name() << " (" << simdjson::get_active_implementation()->description() << "), error skip mode: " << Config.SkipErrors);
         Parser.threaded = false;
     }
 
@@ -349,6 +362,7 @@ public:
         ParsedRowsIdxBuffer.resize(consumerColumns.size() * MaxNumberRows);
         const std::span parsedRowsIdxSpan(ParsedRowsIdxBuffer);
 
+        NonOptionalColumnsCount = 0;
         Columns.resize(consumerColumns.size());
         for (ui64 i = 0; i < consumerColumns.size(); ++i) {
             const auto& name = consumerColumns[i].Name;
@@ -358,8 +372,11 @@ public:
                 return TStatus(typeStatus).AddParentIssue(TStringBuilder() << "Failed to parse column '" << name << "' type " << typeYson);
             }
 
-            if (auto status = Columns[i].InitParser(name, typeYson, parsedRowsIdxSpan.subspan(i * MaxNumberRows, MaxNumberRows), typeStatus.DetachResult()); status.IsFail()) {
+            if (auto status = Columns[i].InitParser(name, typeYson, parsedRowsIdxSpan.subspan(i * MaxNumberRows, MaxNumberRows), typeStatus.DetachResult(), Config.SkipErrors); status.IsFail()) {
                 return status.AddParentIssue(TStringBuilder() << "Failed to create parser for column '" << name << "' with type " << typeYson);
+            }
+            if (!Columns[i].GetIsOptional()) {
+                ++NonOptionalColumnsCount;
             }
         }
 
@@ -417,11 +434,11 @@ public:
     }
 
     const TVector<ui64>& GetOffsets() const override {
-        return Buffer.Offsets;
+        return !ParsingFailedRowCount ? Buffer.Offsets : OutputOffsets;
     }
 
     TValueStatus<std::span<NYql::NUdf::TUnboxedValue>> GetParsedColumn(ui64 columnId) override {
-        if (auto status = Columns[columnId].GetStatus(); status.IsFail()) {
+        if (auto status = Columns[columnId].GetStatus(); !Config.SkipErrors && status.IsFail()) {
             return status;
         }
         return ParsedValues[columnId];
@@ -432,61 +449,45 @@ protected:
         Y_ENSURE(Buffer.IsReady(), "Nothing to parse");
         Y_ENSURE(Buffer.NumberValues <= MaxNumberRows, "Too many values to parse");
 
-        const auto [values, size] = Buffer.Finish();
+        auto [values, size] = Buffer.Finish();
+        OutputOffsets.resize(Buffer.Offsets.size());
         LOG_ROW_DISPATCHER_TRACE("Do parsing, first offset: " << Buffer.Offsets.front() << ", values:\n" << values);
 
-        /*
-           Batch size must be at least maximum of document size.
-           Since we are merging several messages before feeding them to
-           `simdjson::iterate_many`, we must specify Buffer.GetSize() as batch
-           size.
-           Suppose we batched two rows:
-           '{"a":"bbbbbbbbbbb"'
-           ',"c":"d"}{"e":"f"}'
-           (both 18 byte size) into buffer
-           '{"a":"bbbbbbbbbbb","c":"d"}{"e":"f"}'
-           Then, after parsing maximum document size will be 27 bytes.
-        */
-        simdjson::ondemand::document_stream documents;
-        CHECK_JSON_ERROR(Parser.iterate_many(values, size, size).get(documents)) {
-            return TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse message batch from offset " << Buffer.Offsets.front() << ", json documents was corrupted: " << simdjson::error_message(error) << " Current data batch: " << TruncateString(std::string_view(values, size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
+         if (Config.SkipErrors) {
+            OutputOffsets = Buffer.Offsets;
+        }
+        TParsingState state{.InitialBufferPtr = values, .CurrentBufferPtr = values, .Size = size, .SkipErrors = Config.SkipErrors, .Status = TStatus::Success()};
+
+        while (true) {
+            auto status = ParseRows(state);
+            if (status == EParsingStatus::Finish) {
+                break;
+            }
+            size_t inputRowId = state.OutputRowId + state.ErrorsCount; 
+            if (inputRowId < Buffer.MessageOffsets.size()) {
+                auto nextJsonOffset = Buffer.MessageOffsets[inputRowId];
+                state.CurrentBufferPtr = values + nextJsonOffset;
+                state.Size = size - nextJsonOffset;
+            } else {
+                break;
+            }
+        };
+        if (!state.Status.IsSuccess()) {
+            return state.Status;
         }
 
-        ui16 rowId = 0;
-        for (auto document : documents) {
-            if (Y_UNLIKELY(rowId >= Buffer.NumberValues)) {
-                return TStatus::Fail(EStatusId::INTERNAL_ERROR, TStringBuilder() << "Failed to parse json messages, expected " << Buffer.NumberValues << " json rows from offset " << Buffer.Offsets.front() << " but got " << rowId + 1 << " (expected one json row for each offset from topic API in json each row format, maybe initial data was corrupted or messages is not in json format), current data batch: " << TruncateString(std::string_view(values, size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
-            }
-
-            const ui64 offset = Buffer.Offsets[rowId];
-            CHECK_JSON_ERROR(document.error()) {
-                return TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse json message for offset " << offset << ", json document was corrupted: " << simdjson::error_message(error) << " Current data batch: " << TruncateString(std::string_view(values, size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
-            }
-
-            for (auto item : document.get_object()) {
-                CHECK_JSON_ERROR(item.error()) {
-                    return TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse json message for offset " << offset << ", json item was corrupted: " << simdjson::error_message(error) << " Current data batch: " << TruncateString(std::string_view(values, size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
-                }
-
-                const auto it = ColumnsIndex.find(item.escaped_key().value());
-                if (it == ColumnsIndex.end()) {
-                    continue;
-                }
-
-                const size_t columnId = it->second;
-                Columns[columnId].ParseJsonValue(offset, rowId, item.value(), ParsedValues[columnId][rowId]);
-            }
-            rowId++;
+        ParsingFailedRowCount = state.ErrorsCount;
+        if (Y_UNLIKELY(!Config.SkipErrors && state.OutputRowId != Buffer.NumberValues)) {
+            return TStatus::Fail(EStatusId::INTERNAL_ERROR, TStringBuilder() << "Failed to parse json messages, expected " << Buffer.NumberValues << " json rows from offset " << Buffer.Offsets.front() << " but got " << state.OutputRowId << " (expected one json row for each offset from topic API in json each row format, maybe initial data was corrupted or messages is not in json format), current data batch: " << TruncateString(std::string_view(values, size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
         }
 
-        if (Y_UNLIKELY(rowId != Buffer.NumberValues)) {
-            return TStatus::Fail(EStatusId::INTERNAL_ERROR, TStringBuilder() << "Failed to parse json messages, expected " << Buffer.NumberValues << " json rows from offset " << Buffer.Offsets.front() << " but got " << rowId << " (expected one json row for each offset from topic API in json each row format, maybe initial data was corrupted or messages is not in json format), current data batch: " << TruncateString(std::string_view(values, size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
+        if (ParsingFailedRowCount) {
+            ParsingErrors->Add(ParsingFailedRowCount);
+            OutputOffsets.resize(Buffer.Offsets.size() - ParsingFailedRowCount);
         }
-
         for (auto& column : Columns) {
-            column.ValidateNumberValues(rowId, GetOffsets());
+            column.ValidateNumberValues(state.OutputRowId, GetOffsets());
         }
-
         return TStatus::Success();
     }
 
@@ -505,9 +506,179 @@ protected:
         }
 
         Buffer.Clear();
+        ParsingFailedRowCount = 0;
     }
 
+private: 
+    struct TParsingState {
+        const char* InitialBufferPtr;
+        const char* CurrentBufferPtr;
+        size_t Size;
+        bool SkipErrors = false;
+        TStatus Status;
+        ui16 OutputRowId = 0;
+        ui16 ErrorsCount = 0;
+    };
+
+    enum class EParsingStatus {
+        Finish,
+        RepeatFromNextJson,
+    };
+
 private:
+
+    bool TryParseOneJson(TParsingState& state) {
+        size_t inputRowId = state.OutputRowId + state.ErrorsCount;
+
+        if (inputRowId >= Buffer.MessageOffsets.size() - 1) {
+            return false;
+        }
+
+        auto currentJsonOffset = Buffer.MessageOffsets[inputRowId];
+        auto nextJsonOffset = Buffer.MessageOffsets[inputRowId + 1];        
+        ui16 parsedNonOptional = 0;
+        auto len = nextJsonOffset - currentJsonOffset;
+
+        simdjson::padded_string_view view{state.InitialBufferPtr + currentJsonOffset, len, len + simdjson::SIMDJSON_PADDING}; // SIMDJSON_PADDING already was added to Buffer
+        simdjson::ondemand::document document;
+        CHECK_JSON_ERROR(Parser.iterate(view).get(document)) {
+            return false;
+        }
+        for (auto item : document.get_object()) {
+            CHECK_JSON_ERROR(item.error()) {
+                return false;
+            }
+            const auto it = ColumnsIndex.find(item.escaped_key().value());
+            if (it == ColumnsIndex.end()) {
+                continue;
+            }
+
+            const size_t columnId = it->second;
+            auto& column = Columns[columnId];
+            const ui64 offset = Buffer.Offsets[inputRowId];
+            bool success = column.ParseJsonValue(offset, state.OutputRowId, item.value(), ParsedValues[columnId][state.OutputRowId]);
+            if (NonOptionalColumnsCount && !column.GetIsOptional()) {
+                ++parsedNonOptional;
+            }
+            if (!success) {
+                return false;
+            }
+        }
+        if (NonOptionalColumnsCount && parsedNonOptional != NonOptionalColumnsCount) {
+            ClearRowBuffer(state.OutputRowId);
+            return false;
+        }
+        return true;
+    }
+
+    EParsingStatus TryToParseOneJson(TParsingState& state, const TStatus& status) {
+        if (!state.SkipErrors) {
+            state.Status = status;
+            return EParsingStatus::Finish;
+        }
+        ClearRowBuffer(state.OutputRowId);
+        if (TryParseOneJson(state)) {
+            state.OutputRowId++;
+            return EParsingStatus::RepeatFromNextJson;
+        }
+        ClearRowBuffer(state.OutputRowId);
+        ++state.ErrorsCount;
+        return EParsingStatus::RepeatFromNextJson;
+    };
+
+    EParsingStatus ParseRows(TParsingState& state) {
+        LOG_ROW_DISPATCHER_TRACE("Init parser, skipped " << state.ErrorsCount << ", outputRowId " << state.OutputRowId << " size " << state.Size);
+
+        /*
+           Batch size must be at least maximum of document size.
+           Since we are merging several messages before feeding them to
+           `simdjson::iterate_many`, we must specify Buffer.GetSize() as batch
+           size.
+           Suppose we batched two rows:
+           '{"a":"bbbbbbbbbbb"'
+           ',"c":"d"}{"e":"f"}'
+           (both 18 byte size) into buffer
+           '{"a":"bbbbbbbbbbb","c":"d"}{"e":"f"}'
+           Then, after parsing maximum document size will be 27 bytes.
+        */
+        simdjson::ondemand::document_stream documents;
+        CHECK_JSON_ERROR(Parser.iterate_many(state.CurrentBufferPtr, state.Size, state.Size).get(documents)) {
+            auto status =  TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse message batch from offset " << Buffer.Offsets.front() << ", json documents was corrupted: " << simdjson::error_message(error) << " Current data batch: " << TruncateString(std::string_view(state.CurrentBufferPtr, state.Size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
+            return TryToParseOneJson(state, status);
+        }
+
+        for (auto document : documents) {
+            size_t inputRowId = state.OutputRowId + state.ErrorsCount;
+            if (Y_UNLIKELY(inputRowId >= Buffer.NumberValues)) {
+                auto status = TStatus::Fail(EStatusId::INTERNAL_ERROR, TStringBuilder() << "Failed to parse json messages, expected " << Buffer.NumberValues << " json rows from offset " << Buffer.Offsets.front() << " but got " << inputRowId + 1 << " (expected one json row for each offset from topic API in json each row format, maybe initial data was corrupted or messages is not in json format), current data batch: " << TruncateString(std::string_view(state.CurrentBufferPtr, state.Size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
+                if (!state.SkipErrors) {
+                    state.Status = status;
+                }
+                return EParsingStatus::Finish;
+            }
+
+            if (state.SkipErrors) {
+                OutputOffsets[state.OutputRowId] = Buffer.Offsets[inputRowId];
+            }
+
+            const ui64 offset = Buffer.Offsets[inputRowId];
+            CHECK_JSON_ERROR(document.error()) {
+                auto status = TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse json message for offset " << offset << ", json document was corrupted: " << simdjson::error_message(error) << " Current data batch: " << TruncateString(std::string_view(state.CurrentBufferPtr, state.Size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
+                return TryToParseOneJson(state, status);
+            }
+
+            ui16 parsedNonOptional = 0;
+            for (auto item : document.get_object()) {
+                CHECK_JSON_ERROR(item.error()) {
+                    auto status =  TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse json message for offset " << offset << ", json item was corrupted: " << simdjson::error_message(error) << " Current data batch: " << TruncateString(std::string_view(state.CurrentBufferPtr, state.Size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
+                    return TryToParseOneJson(state, status);
+                }
+
+                const auto it = ColumnsIndex.find(item.escaped_key().value());
+                if (it == ColumnsIndex.end()) {
+                    continue;
+                }
+
+                const size_t columnId = it->second;
+                auto& column = Columns[columnId];
+                bool success = column.ParseJsonValue(offset, state.OutputRowId, item.value(), ParsedValues[columnId][state.OutputRowId]);
+                if (NonOptionalColumnsCount && !column.GetIsOptional()) {
+                    ++parsedNonOptional;
+                }
+                if (Config.SkipErrors && !success) {
+                    auto status = column.GetStatus();
+                    return TryToParseOneJson(state, status);
+                }
+            }
+
+            if (Config.SkipErrors && NonOptionalColumnsCount && parsedNonOptional != NonOptionalColumnsCount) {
+                ClearRowBuffer(state.OutputRowId);
+                ++state.ErrorsCount;
+                continue;
+            }
+            state.OutputRowId++;
+        }
+
+        if (state.SkipErrors && (state.OutputRowId + state.ErrorsCount < Buffer.NumberValues)) {
+            if (documents.truncated_bytes()) {
+                size_t inputRowId = state.OutputRowId + state.ErrorsCount;
+                const ui64 offset = Buffer.Offsets[inputRowId];
+                auto status =  TStatus::Fail(EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse json message for offset " << offset << ", json batch truncated bytes, size " << documents.truncated_bytes() << ". Current data batch: " << TruncateString(std::string_view(state.CurrentBufferPtr, state.Size)) << ", buffered offsets: " << JoinSeq(' ', GetOffsets()));
+                return TryToParseOneJson(state, status);
+            } else {
+                state.ErrorsCount = Buffer.NumberValues - state.OutputRowId;
+                return EParsingStatus::Finish;
+            }
+        }
+        return EParsingStatus::Finish;
+    }
+
+    void ClearRowBuffer(ui16 outputRowId) {
+        for (size_t columnId = 0; columnId < Columns.size(); ++columnId) {
+            ParsedValues[columnId][outputRowId].Clear();
+        }
+    }
+
     void FillColumnsBuffers() {
         const auto& consumerColumns = Consumer->GetColumns();
 
@@ -538,6 +709,7 @@ private:
     ui16 MaxNumberRows = 0;
     const TString LogPrefix;
 
+    TVector<ui64> OutputOffsets = {};
     TVector<TColumnParser> Columns;
     TVector<ui16> ParsedRowsIdxBuffer;
     absl::flat_hash_map<std::string_view, size_t> ColumnsIndex;
@@ -546,6 +718,10 @@ private:
     simdjson::ondemand::parser Parser;
     TVector<NYql::NUdf::TUnboxedValue> ParsedValuesBuffer;
     TVector<std::span<NYql::NUdf::TUnboxedValue>> ParsedValues;
+    NMonitoring::TDynamicCounterPtr Counters;
+    NMonitoring::TDynamicCounters::TCounterPtr ParsingErrors;
+    ui64 ParsingFailedRowCount = 0;
+    ui64 NonOptionalColumnsCount = 0;
 };
 
 }  // anonymous namespace
@@ -565,6 +741,7 @@ TJsonParserConfig CreateJsonParserConfig(const TRowDispatcherSettings::TJsonPars
         .BatchSize = parserConfig.GetBatchSizeBytes(),
         .LatencyLimit = parserConfig.GetBatchCreationTimeout(),
         .BufferCellCount = parserConfig.GetBufferCellCount(),
+        .SkipErrors = parserConfig.GetSkipErrors()
     };
 }
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.h
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.h
@@ -17,6 +17,7 @@ struct TJsonParserConfig {
     ui64 BatchSize = 1_MB;
     TDuration LatencyLimit;
     ui64 BufferCellCount = 1000000;  // (number rows) * (number columns) limit
+    bool SkipErrors = false;
 };
 
 TValueStatus<ITopicParser::TPtr> CreateJsonParser(IParsedDataConsumer::TPtr consumer, const TJsonParserConfig& config, const TCountersDesc& counters);

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/ut/common/ut_common.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/ut/common/ut_common.cpp
@@ -247,7 +247,7 @@ void CheckSuccess(const TStatus& status) {
 }
 
 void CheckError(const TStatus& status, TStatusCode expectedStatusCode, const TString& expectedMessage) {
-    UNIT_ASSERT_C(status.GetStatus() == expectedStatusCode, "Expected error status " << NYql::NDqProto::StatusIds_StatusCode_Name(expectedStatusCode) << ", but got: " << status.GetErrorMessage());
+    UNIT_ASSERT_C(status.GetStatus() == expectedStatusCode, "Expected error status " << NYql::NDqProto::StatusIds_StatusCode_Name(expectedStatusCode) << ", but got: " << NYql::NDqProto::StatusIds_StatusCode_Name(status.GetStatus()) << " ("<< status.GetErrorMessage() << ")");
     UNIT_ASSERT_STRING_CONTAINS_C(status.GetErrorMessage(), expectedMessage, "Unexpected error message, Status: " << NYql::NDqProto::StatusIds_StatusCode_Name(status.GetStatus()));
 }
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/ut/topic_parser_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/ut/topic_parser_ut.cpp
@@ -18,10 +18,11 @@ public:
         using TPtr = TIntrusivePtr<TParsedDataConsumer>;
 
     public:
-        TParsedDataConsumer(const TBaseParserFixture& self, const TVector<TSchemaColumn>& columns, TCallback callback)
+        TParsedDataConsumer(const TBaseParserFixture& self, const TVector<TSchemaColumn>& columns, TCallback callback, bool checkOffsets = true)
             : Self(self)
             , Columns(columns)
             , Callback(callback)
+            , CheckOffsets(checkOffsets)
         {}
 
         void ExpectColumnError(ui64 columnId, TStatusCode statusCode, const TString& message) {
@@ -55,9 +56,11 @@ public:
 
             const auto& offsets = Self.Parser->GetOffsets();
             UNIT_ASSERT_VALUES_EQUAL_C(offsets.size(), numberRows, "Unexpected offsets size");
-            for (const ui64 offset : offsets) {
-                UNIT_ASSERT_VALUES_EQUAL_C(offset, CurrentOffset, "Unexpected offset");
-                CurrentOffset++;
+            if (CheckOffsets) {
+                for (const ui64 offset : offsets) {
+                    UNIT_ASSERT_VALUES_EQUAL_C(offset, CurrentOffset, "Unexpected offset");
+                    CurrentOffset++;
+                }
             }
 
             TVector<std::span<NYql::NUdf::TUnboxedValue>> result(Columns.size());
@@ -80,6 +83,7 @@ public:
         const TBaseParserFixture& Self;
         const TVector<TSchemaColumn> Columns;
         const TCallback Callback;
+        const bool CheckOffsets;
 
         std::optional<std::pair<TStatusCode, TString>> ExpectedCommonError;
         std::unordered_map<ui64, std::pair<TStatusCode, TString>> ExpectedErrors;
@@ -97,8 +101,8 @@ public:
     }
 
 public:
-    TStatus MakeParser(TVector<TSchemaColumn> columns, TCallback callback) {
-        ParserHandler = MakeIntrusive<TParsedDataConsumer>(*this, columns, callback);
+    TStatus MakeParser(TVector<TSchemaColumn> columns, TCallback callback, bool checkOffsets = true) {
+        ParserHandler = MakeIntrusive<TParsedDataConsumer>(*this, columns, callback, checkOffsets);
 
         auto parserStatus = CreateParser();
         if (parserStatus.IsFail()) {
@@ -109,12 +113,12 @@ public:
         return TStatus::Success();
     }
 
-    TStatus MakeParser(TVector<TString> columnNames, TString columnType, TCallback callback) {
+    TStatus MakeParser(TVector<TString> columnNames, TString columnType, TCallback callback, bool checkOffsets = true) {
         TVector<TSchemaColumn> columns;
         for (const auto& columnName : columnNames) {
             columns.push_back({.Name = columnName, .TypeYson = columnType});
         }
-        return MakeParser(columns, callback);
+        return MakeParser(columns, callback, checkOffsets);
     }
 
     TStatus MakeParser(TVector<TString> columnNames, TString columnType) {
@@ -151,17 +155,19 @@ public:
     ui64 ExpectedBatches = 0;
 };
 
-class TJsonParserFixture : public TBaseParserFixture {
+template<bool SkipErrors = false>
+class TJsonParserBaseFixture : public TBaseParserFixture {
     using TBase = TBaseParserFixture;
 
 public:
-    TJsonParserFixture()
+    TJsonParserBaseFixture()
         : TBase()
         , Config({
             .FunctionRegistry = FunctionRegistry,
             .BatchSize = 1_MB,
             .LatencyLimit = TDuration::Zero(),
-            .BufferCellCount = 1000
+            .BufferCellCount = 1000,
+            .SkipErrors = SkipErrors
         })
     {}
 
@@ -173,6 +179,9 @@ protected:
 public:
     TJsonParserConfig Config;
 };
+
+using TJsonParserFixture = TJsonParserBaseFixture<false>;
+using TJsonParserFixtureSkipErrors = TJsonParserBaseFixture<true>;
 
 class TRawParserFixture : public TBaseParserFixture {
 protected:
@@ -475,6 +484,85 @@ Y_UNIT_TEST_SUITE(TestJsonParser) {
         CheckBatchError(R"({"a1": "st""r"})", EStatusId::BAD_REQUEST, TStringBuilder() << "Failed to parse json message for offset " << FIRST_OFFSET + 1 << ", json item was corrupted: TAPE_ERROR: The JSON document has an improper structure");
         CheckBatchError(R"({"a1": "x"} {"a1": "y"})", EStatusId::INTERNAL_ERROR, TStringBuilder() << "Failed to parse json messages, expected 1 json rows from offset " << FIRST_OFFSET + 2 << " but got 2 (expected one json row for each offset from topic API in json each row format, maybe initial data was corrupted or messages is not in json format), current data batch: {\"a1\": \"x\"} {\"a1\": \"y\"}");
         CheckBatchError(R"({)", EStatusId::INTERNAL_ERROR, TStringBuilder() << "Failed to parse json messages, expected 1 json rows from offset " << FIRST_OFFSET + 3 << " but got 0 (expected one json row for each offset from topic API in json each row format, maybe initial data was corrupted or messages is not in json format), current data batch: {");
+    }
+
+    Y_UNIT_TEST_F(SkipErrors_Simple1, TJsonParserFixtureSkipErrors) {
+        CheckSuccess(MakeParser({{"a1", "[DataType; String]"}, {"a2", "[OptionalType; [DataType; Uint64]]"}}, [](ui64 numberRows, TVector<std::span<NYql::NUdf::TUnboxedValue>> result) {
+            UNIT_ASSERT_VALUES_EQUAL(1, numberRows);
+            UNIT_ASSERT_VALUES_EQUAL(2, result.size());
+            UNIT_ASSERT_VALUES_EQUAL("hello1", TString(result[0][0].AsStringRef()));
+            UNIT_ASSERT_VALUES_EQUAL(101, result[1][0].GetOptionalValue().Get<ui64>());
+        }));
+        PushToParser(FIRST_OFFSET, R"({"a1": "hello1", "a2": 101, "event": "event1"})");
+    }
+
+    Y_UNIT_TEST_F(SkipErrors_StringValidation, TJsonParserFixtureSkipErrors) {
+        ExpectedBatches = 1;
+        CheckSuccess(MakeParser({"a1", "a2"}, "[DataType; String]", [&](ui64 numberRows, TVector<std::span<NYql::NUdf::TUnboxedValue>> result) {
+            UNIT_ASSERT_VALUES_EQUAL(2, numberRows);
+            UNIT_ASSERT_VALUES_EQUAL(2, result.size());
+            for (size_t i = 0; i < numberRows; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C("hello1", TString(result[0][i].AsStringRef()), i);
+                UNIT_ASSERT_VALUES_EQUAL_C("101", TString(result[1][i].AsStringRef()), i);
+            }
+        }, false));
+
+        Parser->ParseMessages({
+            GetMessage(FIRST_OFFSET, R"({"a1": "hello1", "a2": "101", "event": "event1"})"),
+            GetMessage(FIRST_OFFSET + 1, R"({"a1": "hello1", "a2": 999, "event": "event2"})"),
+            GetMessage(FIRST_OFFSET + 2, R"({"a2": "101", "a1": "hello1", "event": "event3"})")
+        });
+    }
+
+    Y_UNIT_TEST_F(SkipErrors_NoField, TJsonParserFixtureSkipErrors) {
+        ExpectedBatches = 1;
+        CheckSuccess(MakeParser({"a1", "a2"}, "[DataType; String]", [&](ui64 numberRows, TVector<std::span<NYql::NUdf::TUnboxedValue>> result) {
+            UNIT_ASSERT_VALUES_EQUAL(1, numberRows);
+            UNIT_ASSERT_VALUES_EQUAL(2, result.size());
+            for (size_t i = 0; i < numberRows; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C("hello1", TString(result[0][i].AsStringRef()), i);
+                UNIT_ASSERT_VALUES_EQUAL_C("101", TString(result[1][i].AsStringRef()), i);
+            }
+        }, false));
+
+        Parser->ParseMessages({
+            GetMessage(FIRST_OFFSET, R"({"a1": "hello1", "event": "event1"})"),
+            GetMessage(FIRST_OFFSET + 1, R"({"a1": "hello1", "a2": "101", "event": "event2"})")
+        });
+    }
+
+    Y_UNIT_TEST_F(SkipErrors_NoJson, TJsonParserFixtureSkipErrors) {
+        ExpectedBatches = 1;
+        CheckSuccess(MakeParser({"a1", "a2"}, "[DataType; String]", [&](ui64 numberRows, TVector<std::span<NYql::NUdf::TUnboxedValue>> /*result*/) {
+            UNIT_ASSERT_VALUES_EQUAL(2, numberRows);
+        }, false));
+
+        Parser->ParseMessages({
+            GetMessage(FIRST_OFFSET,     R"({"a1": "hello0", "a2": "100"})"),
+            GetMessage(FIRST_OFFSET + 1, "\x80"),
+            GetMessage(FIRST_OFFSET + 2, R"(})"),
+            GetMessage(FIRST_OFFSET + 3, R"(lalala)"),
+            GetMessage(FIRST_OFFSET + 4, R"({"a2": "hello2", "a2": "102"})"),
+            GetMessage(FIRST_OFFSET + 5, "\x80"),
+        });
+    }
+    
+    Y_UNIT_TEST_F(SkipErrors_Optional, TJsonParserFixtureSkipErrors) {
+        ExpectedBatches = 1;
+        CheckSuccess(MakeParser({{"a1", "[OptionalType; [DataType; String]]"}, {"a2", "[OptionalType; [DataType; String]]"}}, [&](ui64 numberRows, TVector<std::span<NYql::NUdf::TUnboxedValue>> result) {
+            UNIT_ASSERT_VALUES_EQUAL(2, numberRows);
+            UNIT_ASSERT_VALUES_EQUAL(2, result.size());
+            UNIT_ASSERT_VALUES_EQUAL("hello0", TString(result[0][0].AsStringRef()));
+            UNIT_ASSERT_VALUES_EQUAL("100", TString(result[1][0].AsStringRef()));
+            UNIT_ASSERT(!result[0][1]);
+            UNIT_ASSERT_VALUES_EQUAL("102", TString(result[1][1].AsStringRef()));
+        }, false));
+
+        Parser->ParseMessages({
+            GetMessage(FIRST_OFFSET,     R"({"a1": "hello0", "a2": "100"})"),
+            GetMessage(FIRST_OFFSET + 1, R"({"a1": "hello1", "a2": 101})"),
+            GetMessage(FIRST_OFFSET + 2, R"({"a2": "102"})")
+        });
     }
 }
 

--- a/ydb/core/fq/libs/row_dispatcher/leader_election.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/leader_election.cpp
@@ -228,7 +228,8 @@ void TLeaderElection::Bootstrap() {
 
     LogPrefix = "TLeaderElection " + SelfId().ToString() + " ";
     LOG_ROW_DISPATCHER_DEBUG("Successfully bootstrapped, local coordinator id " << CoordinatorId.ToString()
-         << ", tenant id " << TenantId << ", local mode " << Config.GetLocalMode() << ", coordination node path " << CoordinationNodePath);
+         << ", tenant id " << TenantId << ", local mode " << Config.GetLocalMode() << ", coordination node path " << CoordinationNodePath
+         << ", endpoint " << Config.GetDatabase().GetEndpoint());
     if (Config.GetLocalMode()) {
         TActivationContext::ActorSystem()->Send(ParentId, new NFq::TEvRowDispatcher::TEvCoordinatorChanged(CoordinatorId, 0));
         return;

--- a/ydb/core/fq/libs/row_dispatcher/ut/topic_session_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/ut/topic_session_ut.cpp
@@ -49,12 +49,14 @@ public:
         RowDispatcherActorId = Runtime.AllocateEdgeActor();
     }
 
-    void Init(const TString& topicPath, ui64 maxSessionUsedMemory = std::numeric_limits<ui64>::max()) {
+    void Init(const TString& topicPath, ui64 maxSessionUsedMemory = std::numeric_limits<ui64>::max(), bool skipErrors = false) {
         TopicPath = topicPath;
         Config.SetTimeoutBeforeStartSessionSec(TimeoutBeforeStartSessionSec);
         Config.SetMaxSessionUsedMemory(maxSessionUsedMemory);
         Config.SetSendStatusPeriodSec(2);
         Config.SetWithoutConsumer(false);
+        Config.MutableJsonParser()->SetSkipErrors(skipErrors);
+        Config.MutableJsonParser()->SetBatchCreationTimeoutMs(100);
 
         auto credFactory = NKikimr::CreateYdbCredentialsProviderFactory;
         auto yqSharedResources = NFq::TYqSharedResources::Cast(NFq::CreateYqSharedResourcesImpl({}, credFactory, MakeIntrusive<NMonitoring::TDynamicCounters>()));
@@ -146,7 +148,7 @@ public:
         Runtime.Send(new IEventHandle(TopicSession, readActorId, event.release()));
     }
 
-    void ExpectMessageBatch(NActors::TActorId readActorId, const TBatch& expected) {
+    void ExpectMessageBatch(NActors::TActorId readActorId, const TBatch& expected, const std::vector<ui64>& expectedLastOffset = {}) {
         Runtime.Send(new IEventHandle(TopicSession, readActorId, new TEvRowDispatcher::TEvGetNextBatch()));
 
         auto eventHolder = Runtime.GrabEdgeEvent<TEvRowDispatcher::TEvMessageBatch>(RowDispatcherActorId, TDuration::Seconds(GrabTimeoutSec));
@@ -156,6 +158,12 @@ public:
 
         NFq::NRowDispatcherProto::TEvMessage message = eventHolder->Get()->Record.GetMessages(0);
         UNIT_ASSERT_VALUES_EQUAL(message.OffsetsSize(), expected.Rows.size());
+        if (!expectedLastOffset.empty()) {
+            UNIT_ASSERT_VALUES_EQUAL(expectedLastOffset.size(), message.OffsetsSize());
+            for (size_t i =0; i < expectedLastOffset.size(); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(expectedLastOffset[i], message.GetOffsets().Get(i));
+            }
+        }
         CheckMessageBatch(eventHolder->Get()->GetPayload(message.GetPayloadId()), expected);
     }
 
@@ -620,6 +628,58 @@ Y_UNIT_TEST_SUITE(TopicSessionTests) {
 
     //     PassAway();
     // }
+
+    Y_UNIT_TEST_F(WrongJson, TRealTopicFixture) {
+        const TString topicName = "wrong_json";
+        PQCreateStream(topicName);
+        Init(topicName, std::numeric_limits<ui64>::max(), true);
+        auto source = BuildSource();
+        StartSession(ReadActorId1, source);
+        
+        auto writeRead = [&](const std::vector<TString>& input, const TBatch& output) {
+            PQWrite(input);
+            if (output.Rows.empty()) {
+                return;
+            }
+            ExpectNewDataArrived({ReadActorId1});
+            ExpectMessageBatch(ReadActorId1, output);
+        };
+        
+        auto test = [&](const TString& wrongJson) {
+            writeRead({ wrongJson }, { });
+            Sleep(TDuration::MilliSeconds(100));
+            writeRead({ Json1, wrongJson, Json3 }, { JsonMessage(1), JsonMessage(3) });
+            writeRead({ wrongJson, Json2, Json3 }, { JsonMessage(2), JsonMessage(3) });
+            writeRead({ Json1, Json2 , wrongJson }, { JsonMessage(1), JsonMessage(2) });
+            writeRead({ Json1, wrongJson, wrongJson, Json3 }, { JsonMessage(1), JsonMessage(3) });
+        };
+
+        test("wrong");                      // not json
+        test("{\"dt\":100,\"value\"}");     // empty value
+        test("{\"dt\":100}");               // no field
+        test("{\"dt\":400,\"value\":777}"); // wrong value type
+        test("{}\x80");
+        test("}");
+        test("{");
+        writeRead({ "{\"dt\":100}", "{}\x80", Json3 }, { JsonMessage(3) });
+        writeRead({Json1 + Json1, Json3 }, { JsonMessage(1), JsonMessage(1) });  // not checked 
+        writeRead({Json1.substr(0, 3), Json1.substr(3), Json2, Json3 }, { JsonMessage(1), JsonMessage(2), JsonMessage(3) });
+        PassAway();
+    }
+
+    Y_UNIT_TEST_F(WrongJsonOffset, TRealTopicFixture) {
+        const TString topicName = "wrong_json_offset";
+        PQCreateStream(topicName);
+        Init(topicName, std::numeric_limits<ui64>::max(), true);
+        auto source = BuildSource();
+        StartSession(ReadActorId1, source);
+
+        TString wrongJson{"wrong"};
+        PQWrite({ Json1, wrongJson, wrongJson, Json3 });
+        ExpectNewDataArrived({ReadActorId1});
+        ExpectMessageBatch(ReadActorId1, { JsonMessage(1), JsonMessage(3) }, {0, 3});
+        PassAway();
+    }
 }
 
 }  // namespace NFq::NRowDispatcher::NTests

--- a/ydb/core/fq/libs/ydb/local_session.cpp
+++ b/ydb/core/fq/libs/ydb/local_session.cpp
@@ -1,0 +1,161 @@
+#include <ydb/core/fq/libs/ydb/local_session.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <library/cpp/threading/future/core/future.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+
+#include <ydb/core/fq/libs/ydb/query_actor.h>
+
+#include <ydb/library/table_creator/table_creator.h>
+#include <ydb/core/fq/libs/actors/logging/log.h>
+
+namespace NFq {
+
+namespace {
+
+class TTableCreator : public NActors::TActorBootstrapped<TTableCreator> {
+public:
+    TTableCreator(
+        const std::string& db,
+        const std::string& path,
+        NYdb::NTable::TTableDescription&& tableDesc,
+        NThreading::TPromise<NYdb::TStatus> promise)
+        : Db(db)
+        , Path(path)
+        , TableDesc(std::move(tableDesc))
+        , Promise(promise) {
+    }
+
+    void Bootstrap() {
+        Become(&TTableCreator::StateFunc);
+
+        TVector<TString> keyColumns;
+        for (const auto& key : TableDesc.GetPrimaryKeyColumns()) {
+            keyColumns.push_back(key.c_str());
+        }
+        TVector<TString> pathComponents;
+        pathComponents.push_back(Path.c_str());
+
+        TVector<NKikimrSchemeOp::TColumnDescription> columns;
+        for (const auto& column : TableDesc.GetTableColumns()) {
+            NKikimrSchemeOp::TColumnDescription desc;
+            desc.SetName(column.Name.c_str());
+            bool optional = false;
+            TString type;
+            NYdb::TTypeParser typeParser{column.Type};
+            if (typeParser.GetKind() == NYdb::TTypeParser::ETypeKind::Optional) {
+                optional = true;
+                typeParser.OpenOptional();
+            }
+            if (typeParser.GetKind() == NYdb::TTypeParser::ETypeKind::Primitive) {
+                type = (TStringBuilder() << typeParser.GetPrimitive());
+            } else {
+                Y_ABORT("not primitive type %s not suported yet", ToString(typeParser.GetPrimitive()).c_str());
+            }
+            desc.SetType(type);
+            desc.SetNotNull(!optional); 
+            columns.push_back(desc);
+        }
+        Register(
+            NKikimr::CreateTableCreator(
+                pathComponents,
+                columns,
+                keyColumns,
+                NKikimrServices::STREAMS_STORAGE_SERVICE,
+                Nothing(),
+                Db.c_str()
+            )
+        );
+    }
+
+private:
+    void Handle(NKikimr::TEvTableCreator::TEvCreateTableResponse::TPtr& ev) {
+        if (ev->Get()->Success) {
+            Promise.SetValue(NYdb::TStatus(NYdb::EStatus::SUCCESS, {}));
+        } else {
+            Promise.SetValue(NYdb::TStatus(NYdb::EStatus::INTERNAL_ERROR, NYdb::NAdapters::ToSdkIssues(ev->Get()->Issues)));
+        }
+        PassAway();
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(NKikimr::TEvTableCreator::TEvCreateTableResponse, Handle);
+    )
+
+private:
+    const std::string Db;
+    const std::string Path;
+    const NYdb::NTable::TTableDescription TableDesc;
+    NThreading::TPromise<NYdb::TStatus> Promise;
+};
+
+struct TLocalSession : public ISession { 
+
+    TLocalSession()
+        : ActorSystem(NActors::TActivationContext::ActorSystem())
+        , QuerySessionId(NActors::TActivationContext::AsActorContext().RegisterWithSameMailbox(MakeQuerySession().release())) {
+    }
+
+    ~TLocalSession() {
+        ActorSystem->Send(QuerySessionId, new NActors::TEvents::TEvPoison());
+    }
+
+    NThreading::TFuture<NYdb::NTable::TDataQueryResult> ExecuteDataQuery(
+        const TString& sql,
+        NFq::ISession::TTxControl txControl,
+        std::shared_ptr<NYdb::TParamsBuilder> params,
+        const NYdb::NTable::TExecDataQuerySettings& execDataQuerySettings = {}) override {
+        auto promise = NThreading::NewPromise<NYdb::NTable::TDataQueryResult>();
+        ActorSystem->Send(QuerySessionId, new TEvQuerySession::TEvExecuteDataQuery(
+            sql,
+            params,
+            TEvQuerySession::TTxControl{txControl.Begin_, txControl.Commit_, txControl.Continue_, txControl.SnapshotRead_},
+            execDataQuerySettings,
+            promise));
+
+        if (txControl.Begin_) {
+            HasTransaction = true;
+        } else if (txControl.Commit_) {
+            HasTransaction = false;
+        }
+        return promise.GetFuture();
+    }
+
+    NYdb::TAsyncStatus Rollback() override {
+        ActorSystem->Send(QuerySessionId, new TEvQuerySession::TEvRollbackTransaction());
+        HasTransaction = false;
+        return NThreading::MakeFuture(NYdb::TStatus{NYdb::EStatus::SUCCESS, {}});
+    }
+
+    NYdb::TAsyncStatus CreateTable(const TString& db, const TString& path, NYdb::NTable::TTableDescription&& tableDesc) override {
+        auto promise = NThreading::NewPromise<NYdb::TStatus>();
+        NActors::TActivationContext::Register(new TTableCreator(db, path, std::move(tableDesc), promise));
+        return promise.GetFuture();
+    }
+
+    NYdb::TAsyncStatus DropTable( const TString& /*path*/) override {
+        Y_ABORT("Not implemented");
+        return NYdb::TAsyncStatus();
+    }
+
+    void UpdateTransaction(std::optional<NYdb::NTable::TTransaction> /*transaction*/) override {
+        // nothing
+    }
+    
+    bool HasActiveTransaction() const override {
+        return HasTransaction;
+    }
+
+private:
+    NActors::TActorSystem* ActorSystem = nullptr;
+    NActors::TActorId QuerySessionId;
+    bool HasTransaction = false;
+};
+
+} // namespace
+
+ISession::TPtr CreateLocalSession() {
+    return MakeIntrusive<TLocalSession>();
+}
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/local_session.h
+++ b/ydb/core/fq/libs/ydb/local_session.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ydb/core/fq/libs/ydb/session.h>
+
+namespace NFq {
+
+ISession::TPtr CreateLocalSession();
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/local_table_client.cpp
+++ b/ydb/core/fq/libs/ydb/local_table_client.cpp
@@ -1,0 +1,163 @@
+#include <ydb/core/fq/libs/ydb/local_table_client.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <library/cpp/threading/future/core/future.h>
+#include <ydb/core/fq/libs/ydb/local_session.h>
+#include <library/cpp/retry/retry_policy.h>
+
+#include <ydb/core/fq/libs/ydb/table_client.h>
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+
+namespace NFq {
+
+namespace {
+
+class TRetryOperationActor : public NActors::TActorBootstrapped<TRetryOperationActor> {
+
+    using IRetryPolicy = IRetryPolicy<const NYdb::TStatus&>;
+
+    struct TEvPrivate {
+        // Event ids
+        enum EEv : ui32 {
+            EvResult = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+            EvEnd
+        };
+        static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
+        struct TEvResult : NActors::TEventLocal<TEvResult, EvResult> {
+            explicit TEvResult(const NYdb::TStatus& status) 
+                : Status(status) {
+            }
+            NYdb::TStatus Status;
+        };
+    };
+
+public:
+    TRetryOperationActor(
+        NThreading::TPromise<NYdb::TStatus> promise,
+        TOperationFunc&& operation,
+        const NYdb::NRetry::TRetryOperationSettings& settings)
+        : Promise(promise)
+        , RetryPolicy(IRetryPolicy::GetExponentialBackoffPolicy(
+            Retryable, TDuration::MilliSeconds(10), 
+            TDuration::MilliSeconds(200),
+            settings.MaxTimeout_,
+            settings.MaxRetries_, settings.MaxTimeout_
+        ))
+        , Operation(operation) {
+    }
+
+    ~TRetryOperationActor() override {
+        if (!Promise.HasValue()) {
+            auto status = NYdb::TStatus(NYdb::EStatus::INTERNAL_ERROR,
+                NYdb::NIssue::TIssues({NYdb::NIssue::TIssue("Destructor calling")}));
+            Promise.SetValue(status);
+        }
+    }
+
+    void Bootstrap() {
+        Become(&TRetryOperationActor::StateFunc);
+        StartOperation();
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(NActors::TEvents::TEvWakeup, Wakeup);
+        hFunc(TEvPrivate::TEvResult, Handle);
+    )
+
+private:
+    void Wakeup(NActors::TEvents::TEvWakeup::TPtr&) {
+        StartOperation();
+    }
+
+    void Handle(TEvPrivate::TEvResult::TPtr& ev) {
+        const auto& status = ev->Get()->Status;
+        if (!status.IsSuccess()) {
+            ScheduleRetry(status);
+        } else {
+            Promise.SetValue(status);
+            PassAway();
+        }
+    }
+
+    void StartOperation() {        
+        auto session = CreateLocalSession();
+        auto future = Operation(session);
+        future.Subscribe([selfId = SelfId(), actorSystem =  NActors::TActivationContext::ActorSystem()](const NYdb::TAsyncStatus& result){
+            actorSystem->Send(selfId, new TEvPrivate::TEvResult(result.GetValue()));
+        });
+    }
+
+    void ScheduleRetry(const NYdb::TStatus& status) {
+        if (RetryState == nullptr) {
+            RetryState = RetryPolicy->CreateRetryState();
+        }
+        if (auto delay = RetryState->GetNextRetryDelay(status)) {
+            Schedule(*delay, new NActors::TEvents::TEvWakeup());
+        } else {
+            NYdb::NIssue::TIssues issues;
+            NYdb::NIssue::TIssue issue("MaxRetries is reached");
+            for (const auto& i : status.GetIssues()) {
+                issue.AddSubIssue(MakeIntrusive<NYdb::NIssue::TIssue>(i));
+            }
+            issues.AddIssue(std::move(issue));
+            Promise.SetValue(NYdb::TStatus(NYdb::EStatus::INTERNAL_ERROR, std::move(issues)));
+            PassAway();
+        }
+    }
+
+    static ERetryErrorClass Retryable(const NYdb::TStatus& status) {
+        if (status.IsSuccess()) {
+            return ERetryErrorClass::NoRetry;
+        }
+
+        if (status.IsTransportError()) {
+            return ERetryErrorClass::ShortRetry;
+        }
+
+        const NYdb::EStatus st = status.GetStatus();
+        if (st == NYdb::EStatus::INTERNAL_ERROR
+            || st == NYdb::EStatus::UNAVAILABLE
+            || st == NYdb::EStatus::TIMEOUT
+            || st == NYdb::EStatus::BAD_SESSION
+            || st == NYdb::EStatus::SESSION_EXPIRED
+            || st == NYdb::EStatus::SESSION_BUSY
+            || st == NYdb::EStatus::ABORTED) {
+            return ERetryErrorClass::ShortRetry;
+        }
+
+        if (st == NYdb::EStatus::OVERLOADED) {
+            return ERetryErrorClass::LongRetry;
+        }
+
+        return ERetryErrorClass::NoRetry;
+    }
+
+private:
+    NThreading::TPromise<NYdb::TStatus> Promise;
+    const IRetryPolicy::TPtr RetryPolicy;
+    IRetryPolicy::IRetryState::TPtr RetryState;
+    TOperationFunc Operation;
+};
+
+struct TLocalYdbTableClient : public IYdbTableClient {
+
+    NYdb::TAsyncStatus RetryOperation(
+        TOperationFunc&& operation,
+        const NYdb::NRetry::TRetryOperationSettings& settings = NYdb::NRetry::TRetryOperationSettings()) override {
+        auto promise = NThreading::NewPromise<NYdb::TStatus>();
+        NActors::TActivationContext::Register(new TRetryOperationActor(promise, std::move(operation), settings));
+        return promise.GetFuture();
+    }
+};
+
+} // namespace
+
+IYdbTableClient::TPtr CreateLocalTableClient() {
+    return MakeIntrusive<TLocalYdbTableClient>();
+}
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/local_table_client.h
+++ b/ydb/core/fq/libs/ydb/local_table_client.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ydb/core/fq/libs/ydb/table_client.h>
+
+namespace NFq {
+
+IYdbTableClient::TPtr CreateLocalTableClient();
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/query_actor.cpp
+++ b/ydb/core/fq/libs/ydb/query_actor.cpp
@@ -1,0 +1,143 @@
+#include <ydb/core/fq/libs/ydb/query_actor.h>
+#include <ydb/core/fq/libs/actors/logging/log.h>
+
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/query_actor/query_actor.h>
+
+#include <ydb/public/api/protos/ydb_status_codes.pb.h>
+#include <yql/essentials/public/issue/yql_issue.h>
+#include <library/cpp/threading/future/core/future.h>
+
+#define LOG_T(stream) LOG_TRACE_S(*NActors::TlsActivationContext, LogComponent, LogPrefix() << stream)
+
+namespace NFq {
+
+namespace {
+
+class TQuerySession final : public NKikimr::TQueryBase {
+    using TBase = NKikimr::TQueryBase;
+
+    struct TDataQuery {
+        TString Sql;
+        std::shared_ptr<NYdb::TParamsBuilder> Params;
+        TEvQuerySession::TTxControl TxControl;
+        NThreading::TPromise<NYdb::NTable::TDataQueryResult> Promise;
+    };
+
+public:
+    TQuerySession()
+        : NKikimr::TQueryBase(NKikimrServices::STREAMS_STORAGE_SERVICE, {}, {}, false, true) {
+    }
+
+private:
+
+    TString LogPrefix() const {
+        return "TQuerySession: ";
+    }
+
+    TAutoPtr<NActors::IEventHandle> AfterRegister(const NActors::TActorId &self, const NActors::TActorId& parentId) override {
+        Y_UNUSED(parentId);
+        Become(&TQuerySession::StateWork);
+        return new NActors::IEventHandle(self, self, new NActors::TEvents::TEvBootstrap());
+    }
+    
+    STATEFN(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            cFunc(NActors::TEvents::TEvBootstrap::EventType, DoBootstrap);
+            hFunc(TEvQuerySession::TEvExecuteDataQuery, Handle);
+            hFunc(TEvQuerySession::TEvRollbackTransaction, Handle);
+            sFunc(NActors::TEvents::TEvPoison, DoPassAway);
+            default:
+                TBase::StateFunc(ev);
+        }
+    }
+    
+    void DoBootstrap() {
+        TBase::Bootstrap();
+        Become(&TQuerySession::StateWork);
+    }
+
+    void Handle(TEvQuerySession::TEvExecuteDataQuery::TPtr& ev) {
+        Y_ABORT_UNLESS(!IsExecuting);
+        Y_ABORT_UNLESS(!DataQuery);
+
+        DataQuery = TDataQuery{ev->Get()->Sql, ev->Get()->Params, ev->Get()->TxControl, ev->Get()->Promise};
+        ProcessQueries();
+    }
+
+    void Handle(TEvQuerySession::TEvRollbackTransaction::TPtr& /*ev*/) {
+        Y_ABORT_UNLESS(!DataQuery);
+        Finish(Ydb::StatusIds::INTERNAL_ERROR, "Rollback transaction", true);
+    }
+
+    void OnRunQuery() final {
+        ReadyToExecute = true;
+        ProcessQueries();
+    }
+
+    void OnQueryResult() final {
+        Y_ABORT_UNLESS(IsExecuting);
+        auto promise = DataQuery->Promise;
+        DataQuery = std::nullopt;
+        auto status = NYdb::TStatus(NYdb::EStatus::SUCCESS, NYdb::NIssue::TIssues());
+        
+        IsExecuting = false;
+        promise.SetValue(NYdb::NTable::TDataQueryResult(std::move(status), std::move(ResultSets), std::nullopt, std::nullopt, false, std::nullopt));
+        if (IsFinishing) {
+            Finish();
+        }
+    }
+
+    void OnFinish(Ydb::StatusIds::StatusCode statusCode, NYql::TIssues&& issues) final {
+        if (DataQuery) {          
+            NYdb::TStatus status(static_cast<NYdb::EStatus>(statusCode), NYdb::NAdapters::ToSdkIssues(issues));
+            DataQuery->Promise.SetValue(NYdb::NTable::TDataQueryResult(std::move(status), std::move(ResultSets), std::nullopt, std::nullopt, false, std::nullopt));
+        }
+        DataQuery = std::nullopt;
+    }
+
+    void ProcessQueries() {
+        if (IsExecuting || !ReadyToExecute || !DataQuery) {
+            return;
+        }
+        IsExecuting = true;
+
+        TQueryBase::TTxControl tx;
+        if (DataQuery->TxControl.Begin) {
+            tx.Begin(true);
+        }
+        if (DataQuery->TxControl.Commit) {
+            tx.Commit(true);
+        }
+        if (DataQuery->TxControl.Continue) {
+            tx.Continue(true);
+        }
+        if (DataQuery->TxControl.SnapshotRead) {
+            tx.SnapshotRead(true);
+        }
+        LOG_T("Run query " << DataQuery->Sql << " commit " << tx.Commit_);
+        RunDataQuery(DataQuery->Sql, DataQuery->Params.get(), tx);
+    }
+
+    void DoPassAway() {
+        if (DataQuery) {
+            IsFinishing = true;
+            return;
+        }
+        Finish();
+    }
+
+private:
+    std::optional<TDataQuery> DataQuery;
+    bool IsExecuting = false;
+    bool ReadyToExecute = false;
+    bool IsFinishing = false;
+};
+
+} // namespace
+
+std::unique_ptr<NActors::IActor> MakeQuerySession() {
+    return std::unique_ptr<NActors::IActor>(new TQuerySession());
+}
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/query_actor.h
+++ b/ydb/core/fq/libs/ydb/query_actor.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/events.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <ydb/public/sdk/cpp/adapters/issue/issue.h>
+
+namespace NFq {
+
+struct TEvQuerySession {
+    // Event ids
+    enum EEv : ui32 {
+        EvBegin = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+        EvExecuteDataQuery = EvBegin + 20,
+        EvRollback,
+        EvEnd
+    };
+
+    struct TTxControl {
+        bool Begin = false;
+        bool Commit = false;
+        bool Continue = false;
+        bool SnapshotRead = false;
+    };
+
+    static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
+    struct TEvExecuteDataQuery : NActors::TEventLocal<TEvExecuteDataQuery, EvExecuteDataQuery> {
+        TEvExecuteDataQuery(
+            const TString& sql,
+            std::shared_ptr<NYdb::TParamsBuilder> params,
+            const TTxControl& txControl,
+            const NYdb::NTable::TExecDataQuerySettings& execDataQuerySettings,
+            NThreading::TPromise<NYdb::NTable::TDataQueryResult> promise)
+            : Sql(sql)
+            , Params(params)
+            , TxControl(txControl)
+            , ExecDataQuerySettings(execDataQuerySettings)
+            , Promise(promise)
+        {}
+        const TString Sql;
+        std::shared_ptr<NYdb::TParamsBuilder> Params;
+        TTxControl TxControl;
+        NYdb::NTable::TExecDataQuerySettings ExecDataQuerySettings;
+        NThreading::TPromise<NYdb::NTable::TDataQueryResult> Promise;
+    };
+    struct TEvRollbackTransaction : public NActors::TEventLocal<TEvRollbackTransaction, EvRollback> {
+    };
+};
+
+std::unique_ptr<NActors::IActor> MakeQuerySession();
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/sdk_session.cpp
+++ b/ydb/core/fq/libs/ydb/sdk_session.cpp
@@ -1,0 +1,77 @@
+#include <ydb/core/fq/libs/ydb/sdk_session.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <library/cpp/threading/future/core/future.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+
+#include <ydb/core/fq/libs/ydb/session.h>
+#include <ydb/core/fq/libs/ydb/query_actor.h>
+
+#include <ydb/library/table_creator/table_creator.h>
+
+namespace NFq {
+
+namespace {
+
+struct TSdkSession : public ISession { 
+
+    explicit TSdkSession(NYdb::NTable::TSession session)
+        : Session(session) {
+    }
+
+    NThreading::TFuture<NYdb::NTable::TDataQueryResult> ExecuteDataQuery(
+        const TString& sql,
+        NFq::ISession::TTxControl txControl,
+        std::shared_ptr<NYdb::TParamsBuilder> paramsBuilder,
+        const NYdb::NTable::TExecDataQuerySettings& execDataQuerySettings = {}) override {
+        NYdb::NTable::TTxControl tx = NYdb::NTable::TTxControl::BeginTx(NYdb::NTable::TTxSettings::SerializableRW());
+        if (txControl.SnapshotRead_) {
+            tx = NYdb::NTable::TTxControl::BeginTx(NYdb::NTable::TTxSettings::SnapshotRO());
+        }
+        if (txControl.Continue_) {
+            tx = NYdb::NTable::TTxControl::Tx(*Transaction);
+        }
+        if (txControl.Commit_) {
+            tx = tx.CommitTx();
+        }
+        if (paramsBuilder) {
+            return Session.ExecuteDataQuery(sql, tx, paramsBuilder->Build(), execDataQuerySettings);
+        } else {
+            return Session.ExecuteDataQuery(sql, tx, execDataQuerySettings);
+        }
+    }
+
+    NYdb::TAsyncStatus Rollback() override {
+        auto future = Transaction->Rollback();
+        Transaction = std::nullopt;
+        return future;
+    }
+
+    NYdb::TAsyncStatus CreateTable(const TString& /*db*/, const TString& path, NYdb::NTable::TTableDescription&& tableDesc) override {
+        return Session.CreateTable(path, std::move(tableDesc));
+    }
+
+    NYdb::TAsyncStatus DropTable( const TString& path) override {
+        return Session.DropTable(path);
+    }
+
+    void UpdateTransaction(std::optional<NYdb::NTable::TTransaction> transaction) override {
+        Transaction = transaction;
+    }
+
+    bool HasActiveTransaction() const override {
+        return Transaction && Transaction->IsActive();
+    }
+
+private: 
+    NYdb::NTable::TSession Session;
+    std::optional<NYdb::NTable::TTransaction> Transaction;
+};
+
+} // namespace
+
+ISession::TPtr CreateSdkSession(NYdb::NTable::TSession session) {
+    return MakeIntrusive<TSdkSession>(session);
+}
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/sdk_session.h
+++ b/ydb/core/fq/libs/ydb/sdk_session.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ydb/core/fq/libs/ydb/session.h>
+
+namespace NFq {
+
+ISession::TPtr CreateSdkSession(NYdb::NTable::TSession session);
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/sdk_table_client.cpp
+++ b/ydb/core/fq/libs/ydb/sdk_table_client.cpp
@@ -1,0 +1,40 @@
+#include <ydb/core/fq/libs/ydb/sdk_table_client.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <library/cpp/threading/future/core/future.h>
+#include <ydb/core/fq/libs/ydb/table_client.h>
+#include <ydb/core/fq/libs/ydb/sdk_session.h>
+
+namespace NFq {
+
+namespace {
+
+struct TSdkYdbTableClient : public IYdbTableClient {
+
+    TSdkYdbTableClient(
+        const NYdb::TDriver& driver,
+        const NYdb::NTable::TClientSettings& settings)
+        : TableClient(driver, settings) {
+    }
+
+    NYdb::TAsyncStatus RetryOperation(TOperationFunc&& operation,
+        const NYdb::NRetry::TRetryOperationSettings& settings = NYdb::NRetry::TRetryOperationSettings()) override {
+        return TableClient.RetryOperation([operation](NYdb::NTable::TSession s) {
+            auto session = CreateSdkSession(s);
+            return operation(session);
+        }, settings);
+    }
+
+private:
+    NYdb::NTable::TTableClient TableClient;
+};
+
+} // namespace
+
+IYdbTableClient::TPtr CreateSdkTableClient(
+    const NYdb::TDriver& driver,
+    const NYdb::NTable::TClientSettings& settings) {
+    return MakeIntrusive<TSdkYdbTableClient>(driver, settings);
+}
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/sdk_table_client.h
+++ b/ydb/core/fq/libs/ydb/sdk_table_client.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <ydb/core/fq/libs/ydb/table_client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
+
+namespace NFq {
+
+IYdbTableClient::TPtr CreateSdkTableClient(
+    const NYdb::TDriver& driver,
+    const NYdb::NTable::TClientSettings& settings);
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/session.h
+++ b/ydb/core/fq/libs/ydb/session.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <library/cpp/threading/future/core/future.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/fluent_settings_helpers.h>
+
+namespace NFq {
+
+struct ISession : public TThrRefBase{
+
+    using TPtr = TIntrusivePtr<ISession>;
+
+    struct TTxControl {
+        using TSelf = TTxControl;
+
+        static TTxControl CommitTx() {return TTxControl().Commit(true);}
+        static TTxControl BeginTx(bool snapshotRead = false) {return TTxControl().Begin(true).SnapshotRead(snapshotRead);}
+        static TTxControl BeginAndCommitTx(bool snapshotRead = false) {return BeginTx(snapshotRead).Commit(true);}
+        static TTxControl ContinueTx() {return TTxControl().Continue(true);}
+        static TTxControl ContinueAndCommitTx() {return ContinueTx().Commit(true); }
+
+        FLUENT_SETTING_DEFAULT(bool, Begin, false);
+        FLUENT_SETTING_DEFAULT(bool, Commit, false);
+        FLUENT_SETTING_DEFAULT(bool, Continue, false);
+        FLUENT_SETTING_DEFAULT(bool, SnapshotRead, false);
+    };
+
+    virtual NThreading::TFuture<NYdb::NTable::TDataQueryResult> ExecuteDataQuery(
+        const TString& sql,
+        TTxControl txControl,
+        std::shared_ptr<NYdb::TParamsBuilder> params,
+        const NYdb::NTable::TExecDataQuerySettings& execDataQuerySettings = {}) = 0;
+    
+    virtual NYdb::TAsyncStatus Rollback() = 0;
+
+    virtual NYdb::TAsyncStatus CreateTable(const TString& db, const TString& path, NYdb::NTable::TTableDescription&& tableDesc) = 0;
+    
+    virtual NYdb::TAsyncStatus DropTable(const TString& path) = 0;
+
+    virtual void UpdateTransaction(std::optional<NYdb::NTable::TTransaction> transaction) = 0;
+
+    virtual bool HasActiveTransaction() const = 0 ;
+};
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/table_client.h
+++ b/ydb/core/fq/libs/ydb/table_client.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <library/cpp/threading/future/core/future.h>
+#include <ydb/core/fq/libs/ydb/session.h>
+
+namespace NFq {
+
+using TOperationFunc = std::function<NYdb::TAsyncStatus(ISession::TPtr)>;
+
+struct IYdbTableClient : public TThrRefBase {
+
+    using TPtr = TIntrusivePtr<IYdbTableClient>;
+
+    virtual NYdb::TAsyncStatus RetryOperation(
+        TOperationFunc&& operation,
+        const NYdb::NRetry::TRetryOperationSettings& settings = NYdb::NRetry::TRetryOperationSettings()) = 0;
+};
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/ut/ya.make
+++ b/ydb/core/fq/libs/ydb/ut/ya.make
@@ -11,6 +11,8 @@ PEERDIR(
     ydb/library/security
 )
 
+YQL_LAST_ABI_VERSION()
+
 INCLUDE(${ARCADIA_ROOT}/ydb/public/tools/ydb_recipe/recipe.inc)
 
 END()

--- a/ydb/core/fq/libs/ydb/ya.make
+++ b/ydb/core/fq/libs/ydb/ya.make
@@ -1,8 +1,15 @@
 LIBRARY()
 
 SRCS(
+    local_session.cpp
+    local_table_client.cpp
+    query_actor.cpp
     schema.cpp
+    sdk_session.cpp
+    sdk_table_client.cpp
     util.cpp
+    ydb_local_connection.cpp
+    ydb_sdk_connection.cpp
     ydb.cpp
 )
 
@@ -18,6 +25,9 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/rate_limiter
     ydb/public/sdk/cpp/src/client/scheme
     ydb/public/sdk/cpp/src/client/table
+    ydb/library/query_actor
+    ydb/core/base/generated
+    ydb/library/aclib/protos
 )
 
 GENERATE_ENUM_SERIALIZATION(ydb.h)

--- a/ydb/core/fq/libs/ydb/ydb.cpp
+++ b/ydb/core/fq/libs/ydb/ydb.cpp
@@ -12,6 +12,7 @@ namespace NFq {
 using namespace NThreading;
 using namespace NYdb;
 using namespace NYdb::NTable;
+using TTxControl = NFq::ISession::TTxControl;
 
 using NYql::TIssues;
 
@@ -36,18 +37,18 @@ TFuture<TDataQueryResult> SelectGeneration(const TGenerationContextPtr& context)
         context->Table.c_str(),
         context->PrimaryKeyColumn.c_str());
 
-    NYdb::TParamsBuilder params;
-    params
-        .AddParam("$pk")
+    auto params = std::make_unique<NYdb::TParamsBuilder>();
+    params->
+         AddParam("$pk")
         .String(context->PrimaryKey)
         .Build();
 
-    auto ttxControl = TTxControl::BeginTx(TTxSettings::SerializableRW());
+    auto ttxControl = TTxControl::BeginTx();
     if (context->OperationType == TGenerationContext::Check && context->CommitTx) {
         ttxControl.CommitTx();
     }
 
-    return context->Session.ExecuteDataQuery(query, ttxControl, params.Build(), context->ExecDataQuerySettings);
+    return context->Session->ExecuteDataQuery(query, ttxControl, std::move(params));
 }
 
 TFuture<TStatus> CheckGeneration(
@@ -57,7 +58,6 @@ TFuture<TStatus> CheckGeneration(
     if (!selectResult.IsSuccess()) {
         return MakeFuture<TStatus>(selectResult);
     }
-
 
     TResultSetParser parser(selectResult.GetResultSet(0));
     if (parser.TryNextRow()) {
@@ -89,7 +89,7 @@ TFuture<TStatus> CheckGeneration(
     }
     }
 
-    context->Transaction = selectResult.GetTransaction();
+    context->Session->UpdateTransaction(selectResult.GetTransaction());
     selectResult.GetTransaction().reset();
 
     if (!isOk) {
@@ -105,7 +105,7 @@ TFuture<TStatus> CheckGeneration(
         return MakeFuture(MakeErrorStatus(EStatus::ALREADY_EXISTS, ss.Str()));
     }
 
-    if (requiresTransaction && !context->Transaction) {
+    if (requiresTransaction && !context->Session->HasActiveTransaction()) {
         // just sanity check, normally should not happen.
         // note that we use retriable error
         TStringStream ss;
@@ -143,22 +143,26 @@ TFuture<TStatus> UpsertGeneration(const TGenerationContextPtr& context) {
         context->PrimaryKeyColumn.c_str(),
         context->GenerationColumn.c_str());
 
-    NYdb::TParamsBuilder params;
-    params
-        .AddParam("$pk")
+    auto params = std::make_unique<NYdb::TParamsBuilder>();
+    params->
+         AddParam("$pk")
         .String(context->PrimaryKey)
         .Build()
         .AddParam("$generation")
         .Uint64(context->Generation)
         .Build();
 
-    auto ttxControl = TTxControl::Tx(*context->Transaction);
+    auto ttxControl = TTxControl::ContinueTx();
     if (context->CommitTx) {
-        ttxControl.CommitTx();
-        context->Transaction.reset();
+        ttxControl = TTxControl::ContinueAndCommitTx();
     }
 
-    return context->Session.ExecuteDataQuery(query, ttxControl, params.Build(), context->ExecDataQuerySettings).Apply(
+    auto f = context->Session->ExecuteDataQuery(query, ttxControl, std::move(params), context->ExecDataQuerySettings);
+    if (context->CommitTx) {
+        context->Session->UpdateTransaction(std::nullopt);
+    }
+
+    return f.Apply(
         [] (const TFuture<TDataQueryResult>& future) {
             TStatus status = future.GetValue();
             return status;
@@ -294,6 +298,18 @@ TFuture<TStatus> CreateTable(
         });
 }
 
+TFuture<TStatus> CreateTable(
+    const IYdbConnection::TPtr& ydbConnection,
+    const TString& name,
+    TTableDescription&& description)
+{
+    auto tablePath = JoinPath(ydbConnection->GetTablePathPrefixWithoutDb(), name.c_str());
+    return ydbConnection->GetTableClient()->RetryOperation(
+        [db = ydbConnection->GetDb(), tablePath = std::move(tablePath), description = std::move(description)] (ISession::TPtr session) mutable {
+            return session->CreateTable(db, tablePath, TTableDescription(description));
+        });
+}
+
 bool IsTableCreated(const NYdb::TStatus& status) {
     return status.IsSuccess() ||
         status.GetStatus() == NYdb::EStatus::ALREADY_EXISTS ||
@@ -353,13 +369,13 @@ TFuture<TStatus> CheckGeneration(const TGenerationContextPtr& context) {
 }
 
 TFuture<TStatus> RollbackTransaction(const TGenerationContextPtr& context) {
-    if (!context->Transaction || !context->Transaction->IsActive()) {
+
+    if (!context->Session->HasActiveTransaction()) {
         auto status = MakeErrorStatus(EStatus::INTERNAL_ERROR, "trying to rollback non-active transaction");
         return MakeFuture(status);
     }
 
-    auto future = context->Transaction->Rollback();
-    context->Transaction.reset();
+    auto future = context->Session->Rollback();
     return future;
 }
 

--- a/ydb/core/fq/libs/ydb/ydb_local_connection.cpp
+++ b/ydb/core/fq/libs/ydb/ydb_local_connection.cpp
@@ -1,0 +1,43 @@
+#include <ydb/core/fq/libs/ydb/ydb.h>
+#include <ydb/core/fq/libs/ydb/local_table_client.h>
+#include <ydb/core/fq/libs/ydb/util.h>
+
+namespace NFq {
+
+namespace {
+
+struct TLocalYdbConnection : public IYdbConnection {
+
+    TLocalYdbConnection(const TString& db, const TString& tablePathPrefix)
+        : TablePathPrefix(tablePathPrefix)
+        , Db(db)
+        , TableClient(CreateLocalTableClient()) {
+    }
+
+    IYdbTableClient::TPtr GetTableClient() const override {
+        return TableClient;
+    }
+    TString GetTablePathPrefix() const override {
+        return JoinPath(Db, TablePathPrefix);
+    }
+    TString GetDb()const override {
+        return Db;
+    }
+
+    TString GetTablePathPrefixWithoutDb() const override {
+        return TablePathPrefix;
+    }
+
+private:
+    const TString TablePathPrefix;
+    const TString Db;
+    IYdbTableClient::TPtr TableClient;
+};
+
+} // namespace
+
+IYdbConnection::TPtr CreateLocalYdbConnection(const TString& db, const TString& tablePathPrefix) {
+    return MakeIntrusive<TLocalYdbConnection>(db, tablePathPrefix);
+}
+
+} // namespace NFq

--- a/ydb/core/fq/libs/ydb/ydb_sdk_connection.cpp
+++ b/ydb/core/fq/libs/ydb/ydb_sdk_connection.cpp
@@ -1,0 +1,54 @@
+#include <ydb/core/fq/libs/ydb/sdk_table_client.h>
+#include <ydb/library/security/ydb_credentials_provider_factory.h>
+#include <ydb/core/fq/libs/ydb/ydb.h>
+#include <ydb/core/fq/libs/ydb/util.h>
+
+namespace NFq {
+
+namespace {
+
+struct TSdkYdbConnection : public IYdbConnection {
+
+    TSdkYdbConnection(
+        const TExternalStorageSettings& config,
+        const NKikimr::TYdbCredentialsProviderFactory& credProviderFactory,
+        const NYdb::TDriver& driver)
+        : Driver(driver)
+        , TableClient(CreateSdkTableClient(driver, GetClientSettings<NYdb::NTable::TClientSettings>(config, credProviderFactory)))
+        , Db(config.GetDatabase())
+        , TablePathPrefix(JoinPath(Db, config.GetPathPrefix())) {
+    }
+
+    IYdbTableClient::TPtr GetTableClient() const override {
+        return TableClient;
+    }
+
+    TString GetTablePathPrefix() const override {
+        return TablePathPrefix;
+    }
+
+    TString GetDb() const override {
+        return Db;
+    }
+
+    TString GetTablePathPrefixWithoutDb() const override {
+        return TablePathPrefix;
+    }
+
+private:
+    NYdb::TDriver Driver;
+    IYdbTableClient::TPtr TableClient;
+    const TString Db;
+    const TString TablePathPrefix;
+};
+
+} // namespace
+
+IYdbConnection::TPtr CreateSdkYdbConnection(
+    const TExternalStorageSettings& config,
+    const NKikimr::TYdbCredentialsProviderFactory& credProviderFactory,
+    const NYdb::TDriver& driver) {
+    return MakeIntrusive<TSdkYdbConnection>(config, credProviderFactory, driver);
+}
+
+} // namespace NFq

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2860,8 +2860,7 @@ private:
 
     void StartCheckpointCoordinator() {
         const auto context = TasksGraph.GetMeta().UserRequestContext;
-        bool enableCheckpointCoordinator = QueryServiceConfig.HasStreamingQueries()
-            && QueryServiceConfig.GetStreamingQueries().HasExternalStorage()
+        bool enableCheckpointCoordinator = AppData()->FeatureFlags.GetEnableStreamingQueries()
             && (Request.SaveQueryPhysicalGraph || Request.QueryPhysicalGraph != nullptr)
             && context && context->CheckpointId;
         if (!enableCheckpointCoordinator) {

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -1966,9 +1966,14 @@ private:
             }
         }
 
-        size_t sourceScanPartitionsCount = TasksGraph.BuildAllTasks(false, TasksGraph.GetMeta().StreamResult || EnableReadsMerge, {},
-            Request.Transactions, ResourcesSnapshot, CollectProfileStats(Request.StatsMode), Stats.get(),
-            std::max<ui32>(ShardsOnNode.size(), ResourcesSnapshot.size()), &ShardsWithEffects);
+        size_t sourceScanPartitionsCount = 0;
+
+        if (!graphRestored) {
+            sourceScanPartitionsCount = TasksGraph.BuildAllTasks(false, TasksGraph.GetMeta().StreamResult || EnableReadsMerge, {},
+                Request.Transactions, ResourcesSnapshot, CollectProfileStats(Request.StatsMode), Stats.get(),
+                std::max<ui32>(ShardsOnNode.size(), ResourcesSnapshot.size()), &ShardsWithEffects);
+        }
+
         OnEmptyResult();
 
         TIssue validateIssue;

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1265,7 +1265,7 @@ protected:
 
     bool RestoreTasksGraph() {
         if (Request.QueryPhysicalGraph) {
-            TasksGraph.RestoreTasksGraphInfo(ResourcesSnapshot, *Request.QueryPhysicalGraph);
+            TasksGraph.RestoreTasksGraphInfo(Request.Transactions, ResourcesSnapshot, *Request.QueryPhysicalGraph);
         }
 
         return TasksGraph.GetMeta().IsRestored;

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1265,7 +1265,7 @@ protected:
 
     bool RestoreTasksGraph() {
         if (Request.QueryPhysicalGraph) {
-            TasksGraph.RestoreTasksGraphInfo(*Request.QueryPhysicalGraph);
+            TasksGraph.RestoreTasksGraphInfo(ResourcesSnapshot, *Request.QueryPhysicalGraph);
         }
 
         return TasksGraph.GetMeta().IsRestored;

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -1557,7 +1557,7 @@ void TKqpTasksGraph::PersistTasksGraphInfo(NKikimrKqp::TQueryPhysicalGraph& resu
     }
 }
 
-void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeResources>& resourcesSnapshot, const NKikimrKqp::TQueryPhysicalGraph& graphInfo) {
+void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<IKqpGateway::TPhysicalTxData>& transactions, const TVector<NKikimrKqp::TKqpNodeResources>& resourcesSnapshot, const NKikimrKqp::TQueryPhysicalGraph& graphInfo) {
     GetMeta().IsRestored = true;
     GetMeta().AllowWithSpilling = false;
 
@@ -1743,8 +1743,8 @@ void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeRes
         YQL_ENSURE(id == newChannel.Id);
     }
 
-    for (ui64 txIdx = 0; txIdx < Transactions.size(); ++txIdx) {
-        const auto& tx = Transactions.at(txIdx);
+    for (ui64 txIdx = 0; txIdx < transactions.size(); ++txIdx) {
+        const auto& tx = transactions.at(txIdx);
         const auto scheduledTaskCount = ScheduleByCost(tx, resourcesSnapshot);
 
         for (ui64 stageIdx = 0; stageIdx < tx.Body->StagesSize(); ++stageIdx) {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -393,7 +393,7 @@ public:
 
     NYql::NDqProto::TDqTask* ArenaSerializeTaskToProto(const TTask& task, bool serializeAsyncIoSettings);
     void PersistTasksGraphInfo(NKikimrKqp::TQueryPhysicalGraph& result) const;
-    void RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeResources>& resourcesSnapshot, const NKikimrKqp::TQueryPhysicalGraph& graphInfo);
+    void RestoreTasksGraphInfo(const TVector<IKqpGateway::TPhysicalTxData>& transactions, const TVector<NKikimrKqp::TKqpNodeResources>& resourcesSnapshot, const NKikimrKqp::TQueryPhysicalGraph& graphInfo);
 
     void FillChannelDesc(NYql::NDqProto::TChannel& channelDesc, const NYql::NDq::TChannel& channel,
         const NKikimrConfig::TTableServiceConfig::EChannelTransportVersion chanTransportVersion, bool enableSpilling) const;

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -393,7 +393,7 @@ public:
 
     NYql::NDqProto::TDqTask* ArenaSerializeTaskToProto(const TTask& task, bool serializeAsyncIoSettings);
     void PersistTasksGraphInfo(NKikimrKqp::TQueryPhysicalGraph& result) const;
-    void RestoreTasksGraphInfo(const NKikimrKqp::TQueryPhysicalGraph& graphInfo);
+    void RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeResources>& resourcesSnapshot, const NKikimrKqp::TQueryPhysicalGraph& graphInfo);
 
     void FillChannelDesc(NYql::NDqProto::TChannel& channelDesc, const NYql::NDq::TChannel& channel,
         const NKikimrConfig::TTableServiceConfig::EChannelTransportVersion chanTransportVersion, bool enableSpilling) const;

--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
@@ -372,9 +372,11 @@ namespace {
         const TString& structuredTokenJson,
         const TString& path) {
 
-        if (!federatedQuerySetup || !federatedQuerySetup->Driver) {
-            return NThreading::MakeFuture<TGetSchemeEntryResult>(); 
+        if (!federatedQuerySetup || !federatedQuerySetup->Driver || !endpoint || !database) {
+            LOG_NOTICE_S(*NActors::TActivationContext::ActorSystem(), NKikimrServices::KQP_GATEWAY, "Skipped describe for path '" << path << "' in external YDB database '" << database << "' with endpoint '" << endpoint << "'");
+            return NThreading::MakeFuture<TGetSchemeEntryResult>(TGetSchemeEntryResult{.EntryType = NYdb::NScheme::ESchemeEntryType::Table}); 
         }
+
         std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory = NYql::CreateCredentialsProviderFactoryForStructuredToken(nullptr, structuredTokenJson, false);
         auto driver = federatedQuerySetup->Driver;
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -2523,7 +2523,10 @@ private:
         CHECK_STATUS(validator.SaveRequired(ESqlSettings::QUERY_TEXT_FEATURE, &TPropertyValidator::ValidateNotEmpty));
         CHECK_STATUS(validator.SaveDefault(EName::Run, "true", &TPropertyValidator::ValidateBool));
         CHECK_STATUS(validator.SaveDefault(EName::ResourcePool, NResourcePool::DEFAULT_POOL_ID));
-        CHECK_STATUS(validator.Save(EName::QueryTextRevision, ToString(1)));
+        CHECK_STATUS(validator.Save(
+            EName::QueryTextRevision,
+            ToString(SchemeInfo ? TStreamingQuerySettings().FromProto(SchemeInfo->Properties).QueryTextRevision + 1 : 1)
+        ));
 
         return validator.Finish();
     }

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1757,6 +1757,12 @@ private:
         ev->Generation = PreviousGeneration + 1;
         ev->CheckpointId = State.GetCheckpointId();
 
+        if (const auto statsPeriod = AppData()->QueryServiceConfig.GetProgressStatsPeriodMs()) {
+            ev->ProgressStatsPeriod = TDuration::MilliSeconds(statsPeriod);
+        } else {
+            ev->ProgressStatsPeriod = TDuration::Seconds(1);
+        }
+
         auto& record = ev->Record;
         record.SetTraceId(TStringBuilder() << "streaming-query-" << QueryPath << "-" << State.GetCurrentExecutionId());
         if (const auto& token = Context.GetUserToken()) {

--- a/ydb/core/kqp/opt/kqp_query_blocks_transformer.cpp
+++ b/ydb/core/kqp/opt/kqp_query_blocks_transformer.cpp
@@ -85,7 +85,9 @@ public:
     }
 
     TStatus DoApplyAsyncChanges(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) override {
-        return QueryBlockTransformer->ApplyAsyncChanges(input, output, ctx);
+        YQL_ENSURE(CurrentBlock < input->ChildrenSize());
+        output = input;
+        return QueryBlockTransformer->ApplyAsyncChanges(input->Child(CurrentBlock), output->ChildRef(CurrentBlock), ctx);
     }
 
 private:

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -1780,13 +1780,12 @@ private:
     }
 
     void InitCheckpointStorage() {
-        const auto& streamingQueries = QueryServiceConfig.GetStreamingQueries();
-        if (!streamingQueries.HasExternalStorage() || !FederatedQuerySetup) {
+        if (!FederatedQuerySetup || !AppData()->FeatureFlags.GetEnableStreamingQueries()) {
             return;
         }
 
         auto service = NFq::NewCheckpointStorageService(
-            streamingQueries.GetExternalStorage(),
+            {},
             "cs",
             NKikimr::CreateYdbCredentialsProviderFactory,
             *FederatedQuerySetup->Driver,

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -32,6 +32,7 @@
 #include <library/cpp/protobuf/json/proto2json.h>
 #include <library/cpp/retry/retry_policy.h>
 
+#include <util/system/env.h>
 #include <util/generic/guid.h>
 #include <util/generic/utility.h>
 
@@ -4871,7 +4872,12 @@ private:
 } // anonymous namespace
 
 IActor* CreateScriptExecutionCreatorActor(TEvKqp::TEvScriptRequest::TPtr&& ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, TDuration maxRunTime) {
-    return new TCreateScriptExecutionActor(std::move(ev), queryServiceConfig, counters, maxRunTime, LEASE_DURATION);
+    TDuration leaseDuration = LEASE_DURATION;
+    ui64 seconds = 0;
+    if (TryFromString<ui64>(GetEnv("YDB_TEST_LEASE_DURATION_SEC"), seconds) && seconds) {
+        leaseDuration = TDuration::Seconds(seconds);
+    }
+    return new TCreateScriptExecutionActor(std::move(ev), queryServiceConfig, counters, maxRunTime, leaseDuration);
 }
 
 IActor* CreateScriptExecutionsTablesCreator(const NKikimrConfig::TFeatureFlags& featureFlags) {

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2405,7 +2405,10 @@ public:
             }
         }
 
-        LOG_W("ReplyQueryCompileError, status " << QueryState->CompileResult->Status << " remove tx with tx_id: " << txId.GetHumanStr());
+        LOG_W("ReplyQueryCompileError, status: " << QueryState->CompileResult->Status
+            << ", issues: " << Join(", ", QueryResponse->Record.GetResponse().GetQueryIssues())
+            << ", remove tx with tx_id: " << txId.GetHumanStr());
+
         if (auto ctx = Transactions.ReleaseTransaction(txId)) {
             ctx->Invalidate();
             if (!ctx->BufferActorId) {
@@ -2840,7 +2843,8 @@ public:
     void ReplyQueryError(Ydb::StatusIds::StatusCode ydbStatus,
         const TString& message, std::optional<google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage>> issues = {})
     {
-        LOG_W("Create QueryResponse for error on request, msg: " << message);
+        LOG_W("Create QueryResponse for error on request, msg: " << message << ", status: " << ydbStatus
+            << (issues ? TStringBuilder() << ", issues: " << Join(", ", *issues) : TStringBuilder()));
 
         QueryResponse = std::make_unique<TEvKqp::TEvQueryResponse>();
         QueryResponse->Record.SetYdbStatus(ydbStatus);

--- a/ydb/core/kqp/ut/common/kqp_ut_common.cpp
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.cpp
@@ -176,9 +176,12 @@ TKikimrRunner::TKikimrRunner(const TKikimrSettings& settings) {
     if (settings.EnableStorageProxy) {
         NFq::TCheckpointCoordinatorSettings::DefaultCheckpointingPeriod = settings.CheckpointPeriod;
 
-        auto& checkpoints = *appConfig.MutableQueryServiceConfig()->MutableStreamingQueries()->MutableExternalStorage()->MutableDatabaseConnection();
-        checkpoints.SetEndpoint(GetEnv("YDB_ENDPOINT"));
-        checkpoints.SetDatabase(GetEnv("YDB_DATABASE"));
+        auto* streamingQueries = appConfig.MutableQueryServiceConfig()->MutableStreamingQueries();
+        if (!settings.UseLocalCheckpointsInStreamingQueries) {
+            auto& checkpoints = *streamingQueries->MutableExternalStorage()->MutableDatabaseConnection();
+            checkpoints.SetEndpoint(GetEnv("YDB_ENDPOINT"));
+            checkpoints.SetDatabase(GetEnv("YDB_DATABASE"));
+        }
     }
     if (!appConfig.GetQueryServiceConfig().HasAllExternalDataSourcesAreAvailable()) {
         appConfig.MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(true);

--- a/ydb/core/kqp/ut/common/kqp_ut_common.h
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.h
@@ -95,6 +95,7 @@ public:
     NKikimrConfig::TImmediateControlsConfig Controls;
     TMaybe<NYdbGrpc::TServerOptions> GrpcServerOptions;
     bool EnableStorageProxy = false;
+    bool UseLocalCheckpointsInStreamingQueries = false;
     TDuration CheckpointPeriod = TDuration::MilliSeconds(200);
     std::optional<TTestLogSettings> LogSettings;
 
@@ -136,6 +137,7 @@ public:
     }
     TKikimrSettings& SetGrpcServerOptions(const NYdbGrpc::TServerOptions& grpcServerOptions) { GrpcServerOptions = grpcServerOptions; return *this; };
     TKikimrSettings& SetEnableStorageProxy(bool value) { EnableStorageProxy = value; return *this; };
+    TKikimrSettings& SetUseLocalCheckpointsInStreamingQueries(bool value) { UseLocalCheckpointsInStreamingQueries = value; return *this; };
     TKikimrSettings& SetCheckpointPeriod(TDuration value) { CheckpointPeriod = value; return *this; };
     TKikimrSettings& SetLogSettings(TTestLogSettings value) { LogSettings = value; return *this; };
 };

--- a/ydb/core/kqp/ut/common/kqp_ut_common.h
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.h
@@ -180,11 +180,14 @@ public:
     NYdb::TDriver* GetDriverMut() { return Driver.Get(); }
     const TString& GetEndpoint() const { return Endpoint; }
     const NYdb::TDriver& GetDriver() const { return *Driver; }
-    NYdb::NScheme::TSchemeClient GetSchemeClient() const { return NYdb::NScheme::TSchemeClient(*Driver); }
     Tests::TClient& GetTestClient() const { return *Client; }
     Tests::TServer& GetTestServer() const { return *Server; }
 
     NYdb::TDriverConfig GetDriverConfig() const { return DriverConfig; }
+
+    NYdb::NScheme::TSchemeClient GetSchemeClient(NYdb::TCommonClientSettings settings = NYdb::TCommonClientSettings()) const {
+        return NYdb::NScheme::TSchemeClient(*Driver, settings);
+    }
 
     NYdb::NTable::TTableClient GetTableClient(
         NYdb::NTable::TClientSettings settings = NYdb::NTable::TClientSettings()) const {

--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -137,6 +137,7 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
             .SetNodeCount(options.NodeCount)
             .SetEnableStorageProxy(true)
             .SetCheckpointPeriod(options.CheckpointPeriod)
+            .SetUseLocalCheckpointsInStreamingQueries(options.UseLocalCheckpointsInStreamingQueries)
             .SetLogSettings(std::move(logSettings));
 
         settings.EnableScriptExecutionBackgroundChecks = options.EnableScriptExecutionBackgroundChecks;

--- a/ydb/core/kqp/ut/federated_query/common/common.h
+++ b/ydb/core/kqp/ut/federated_query/common/common.h
@@ -27,6 +27,7 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
         TIntrusivePtr<NYql::IPqGateway> PqGateway;
         TDuration CheckpointPeriod = TDuration::MilliSeconds(200);
         TTestLogSettings LogSettings;
+        bool UseLocalCheckpointsInStreamingQueries = false;
     };
 
     std::shared_ptr<TKikimrRunner> MakeKikimrRunner(

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -761,6 +761,7 @@ public:
     inline static constexpr char INPUT_TOPIC_NAME[] = "sysViewInput";
     inline static constexpr char OUTPUT_TOPIC_NAME[] = "sysViewOutput";
     inline static constexpr char PQ_SOURCE[] = "sysViewSourceName";
+    inline static constexpr TDuration STATS_WAIT_DURATION = TDuration::Seconds(2);
 
 public:
     void Setup() {
@@ -3027,7 +3028,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesSysView) {
         StartQuery("C");
         StartQuery("D");
         StartQuery("E");
-        Sleep(TDuration::Seconds(1));
+        Sleep(STATS_WAIT_DURATION);
 
         CheckSysView({
             {"A"}, {"B"}, {"C"}, {"D"}, {"E"}
@@ -3069,6 +3070,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesSysView) {
         StartQuery("B");
         StartQuery("C");
         StartQuery("D");
+        Sleep(STATS_WAIT_DURATION);
 
         CheckSysView({
             {"A"}, {"B"}, {"C"}, {"D"}
@@ -3122,7 +3124,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesSysView) {
         pqGateway->WaitWriteSession(OutputTopic)->ExpectMessage("test0");
 
         {
-            Sleep(TDuration::Seconds(1));
+            Sleep(STATS_WAIT_DURATION);
             const auto result = CheckSysView({{
                 .Name = queryName,
                 .Status = "RUNNING",
@@ -3418,6 +3420,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesSysView) {
             return count == 0;
         });
 
+        Sleep(STATS_WAIT_DURATION);
         CheckSysView(rows);
     }
 }

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -1083,6 +1083,32 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         }
     }
 
+    Y_UNIT_TEST_F(ExplainReadTopicBasic, TStreamingTestFixture) {
+        const TString sourceName = "sourceName";
+        const TString topicName = "topicName";
+        CreateTopic(topicName);
+
+        CreatePqSourceBasicAuth(sourceName);
+
+        const auto result = GetQueryClient()->ExecuteQuery(fmt::format(
+            "SELECT * FROM `{source}`.`{topic}`",
+            "source"_a=sourceName,
+            "topic"_a=topicName
+        ), TTxControl::NoTx(), TExecuteQuerySettings().ExecMode(EExecMode::Explain)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+
+        const auto& stats = result.GetStats();
+        UNIT_ASSERT(stats);
+
+        const auto& plan = stats->GetPlan();
+        UNIT_ASSERT(plan);
+        UNIT_ASSERT_STRING_CONTAINS(*plan, sourceName);
+
+        const auto& ast = stats->GetAst();
+        UNIT_ASSERT(ast);
+        UNIT_ASSERT_STRING_CONTAINS(*ast, sourceName);
+    }
+
     Y_UNIT_TEST_F(InsertTopicBasic, TStreamingTestFixture) {
         TString sourceName = "sourceName";
         TString inputTopicName = "inputTopicName";

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -2931,7 +2931,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
                 .TableName = ydbTable,
                 .Columns = columns,
                 .DescribeCount = 2,
-                .ListSplitsCount = 5,
+                .ListSplitsCount = 4,
                 .ValidateListSplitsArgs = false
             });
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -663,11 +663,14 @@ public:
             .TypeMappingSettings(typeMappingSettings);
 
         auto listSplitsBuilder = mockClient->ExpectListSplits();
-        listSplitsBuilder
+        auto fillListSplitExpectation = listSplitsBuilder
             .ValidateArgs(settings.ValidateListSplitsArgs)
             .Select()
                 .DataSourceInstance(GetMockConnectorSourceInstance())
-                .Table(settings.TableName);
+                .Table(settings.TableName)
+                .What();
+
+        FillMockConnectorRequestColumns(fillListSplitExpectation, settings.Columns);
 
         for (ui64 i = 0; i < settings.DescribeCount; ++i) {
             auto responseBuilder = describeTableBuilder.Response();
@@ -2077,6 +2080,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
         ));
 
         {   // Prepare connector mock
+
             const std::vector<TColumn> columns = {
                 {"fqdn", Ydb::Type::STRING},
                 {"payload", Ydb::Type::STRING}
@@ -2085,7 +2089,10 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
                 .TableName = ydbTable,
                 .Columns = columns,
                 .DescribeCount = 2,
-                .ListSplitsCount = 2
+                // For stream queries type annotation is executed twice, but
+                // now List Split is done after type annotation optimization.
+                // That is why only single call to List Split is expected.
+                .ListSplitsCount = 1
             });
 
             const std::vector<std::string> fqdnColumn = {"host1.example.com", "host2.example.com", "host3.example.com"};
@@ -2186,7 +2193,9 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
                 .TableName = ydbTable,
                 .Columns = columns,
                 .DescribeCount = 2,
-                .ListSplitsCount = 5,
+                // Now List Split is done after type annotation, that is the
+                // reason why this value equal to 4 not 5
+                .ListSplitsCount = 4,
                 .ValidateListSplitsArgs = false
             });
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -116,7 +116,6 @@ public:
 
             auto& queryServiceConfig = *AppConfig->MutableQueryServiceConfig();
             queryServiceConfig.SetEnableMatchRecognize(true);
-            queryServiceConfig.SetProgressStatsPeriodMs(1000);
 
             LogSettings
                 .AddLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NLog::PRI_DEBUG)
@@ -1110,6 +1109,8 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
     }
 
     Y_UNIT_TEST_F(InsertTopicBasic, TStreamingTestFixture) {
+        SetupAppConfig().MutableQueryServiceConfig()->SetProgressStatsPeriodMs(1000);
+
         TString sourceName = "sourceName";
         TString inputTopicName = "inputTopicName";
         TString outputTopicName = "outputTopicName";
@@ -2292,6 +2293,8 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
     }
 
     Y_UNIT_TEST_F(StreamingQueryWithStreamLookupJoin, TStreamingTestFixture) {
+        SetupAppConfig().MutableQueryServiceConfig()->SetProgressStatsPeriodMs(0);
+
         const auto connectorClient = SetupMockConnectorClient();
         const auto pqGateway = SetupMockPqGateway();
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -665,7 +665,7 @@ public:
 
         auto listSplitsBuilder = mockClient->ExpectListSplits();
         auto fillListSplitExpectation = listSplitsBuilder
-            .ValidateArgs(settings.ValidateListSplitsArgs)
+            .ValidateArgs(settings.ValidateListSplitsArgs ? TConnectorClientMock::EArgsValidation::Strict : TConnectorClientMock::EArgsValidation::DataSourceInstance)
             .Select()
                 .DataSourceInstance(GetMockConnectorSourceInstance())
                 .Table(settings.TableName)
@@ -696,7 +696,7 @@ public:
         {
             auto columnsBuilder = readSplitsBuilder
                 .Filtering(TReadSplitsRequest::FILTERING_OPTIONAL)
-                .ValidateArgs(settings.ValidateReadSplitsArgs)
+                .ValidateArgs(settings.ValidateReadSplitsArgs ? TConnectorClientMock::EArgsValidation::Strict : TConnectorClientMock::EArgsValidation::DataSourceInstance)
                 .Split()
                     .Description("some binary description")
                     .Select()

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -1004,7 +1004,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         UNIT_ASSERT_VALUES_EQUAL_C(scriptExecutionOperation.Status().GetStatus(), EStatus::GENERIC_ERROR, status.GetIssues().ToOneLineString());
         const auto& issues = status.GetIssues().ToString();
         UNIT_ASSERT_STRING_CONTAINS(issues, "Couldn't determine external YDB entity type");
-        UNIT_ASSERT_STRING_CONTAINS(issues, "Describe path 'local/topicName' in external YDB database 'local'");
+        UNIT_ASSERT_STRING_CONTAINS(issues, "Describe path 'local/topicName' in external YDB database '/local'");
     }
 
     Y_UNIT_TEST_F(ReadTopic, TStreamingTestFixture) {

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -1898,6 +1898,111 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
         ReadTopicMessage(outputTopicName, "test message");
     }
 
+    Y_UNIT_TEST_F(StreamingQueryTextChangeWithCreateOrReplace, TStreamingTestFixture) {
+        constexpr char inputTopicName[] = "createAndReplaceStreamingQueryInputTopic";
+        constexpr char outputTopicName[] = "createAndReplaceStreamingQueryOutputTopic";
+        CreateTopic(inputTopicName);
+        CreateTopic(outputTopicName);
+
+        constexpr char pqSourceName[] = "sourceName";
+        CreatePqSource(pqSourceName);
+
+        constexpr char queryName[] = "streamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}`
+                SELECT key || value FROM `{pq_source}`.`{input_topic}` WITH (
+                    FORMAT = "json_each_row",
+                    SCHEMA (
+                        key String NOT NULL,
+                        value String NOT NULL
+                    )
+                )
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        WriteTopicMessage(inputTopicName, R"({"key": "key1", "value": "value1"})");
+        ReadTopicMessages(outputTopicName, {"key1value1"});
+
+        ExecQuery(fmt::format(R"(
+            CREATE OR REPLACE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}`
+                SELECT value || key FROM `{pq_source}`.`{input_topic}` WITH (
+                    FORMAT = "json_each_row",
+                    SCHEMA (
+                        key String NOT NULL,
+                        value String NOT NULL
+                    )
+                )
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(2, 1);
+        Sleep(TDuration::Seconds(1));
+
+        WriteTopicMessage(inputTopicName, R"({"key": "key2", "value": "value2"})");
+        ReadTopicMessages(outputTopicName, {"key1value1", "value2key2"});
+    }
+
+    Y_UNIT_TEST_F(StreamingQueryCreateOrReplaceFailure, TStreamingTestFixture) {
+        constexpr char inputTopicName[] = "createOrReplaceStreamingQueryFailInputTopic";
+        constexpr char outputTopicName[] = "createOrReplaceStreamingQueryFailOutputTopic";
+        CreateTopic(inputTopicName);
+        CreateTopic(outputTopicName);
+
+        constexpr char pqSourceName[] = "sourceName";
+        CreatePqSource(pqSourceName);
+
+        constexpr char queryName[] = "streamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}`
+                SELECT * FROM `{pq_source}`.`{input_topic}`
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        WriteTopicMessage(inputTopicName, "key1value1");
+        ReadTopicMessages(outputTopicName, {"key1value1"});
+
+        ExecQuery(fmt::format(R"(
+            CREATE OR REPLACE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                PRAGMA ydb.OverridePlanner = @@ [
+                    {{ "tx": 0, "stage": 10, "tasks": 1 }}
+                ] @@;
+                INSERT INTO `{pq_source}`.`{output_topic}`
+                SELECT * FROM `{pq_source}`.`{input_topic}`
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ), EStatus::GENERIC_ERROR, "Invalid override planner settings");
+
+        CheckScriptExecutionsCount(2, 0);
+    }
+
     Y_UNIT_TEST_F(StreamingQueryWithSolomonInsert, TStreamingTestFixture) {
         const auto pqGateway = SetupMockPqGateway();
 
@@ -2616,6 +2721,45 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
         ExecQuery(fmt::format(R"(
             ALTER STREAMING QUERY `{query_name}` SET (
                 FORCE = TRUE,
+                RUN = FALSE
+            ) AS
+            DO BEGIN
+                /* some comment */
+                {text}
+            END DO;)",
+            "query_name"_a = info.QueryName,
+            "text"_a = info.QueryText
+        ));
+        CheckScriptExecutionsCount(1, 0);
+
+        Sleep(TDuration::Seconds(1));
+        WriteTopicMessage(info.InputTopicName, R"({"time": "2025-08-25T00:00:00.000000Z", "event": "B"})");
+        const auto readDisposition = TInstant::Now();
+
+        ExecQuery(fmt::format(R"(
+            ALTER STREAMING QUERY `{query_name}` SET (
+                RUN = TRUE
+            );)",
+            "query_name"_a = info.QueryName
+        ));
+        CheckScriptExecutionsCount(2, 1);
+        Sleep(TDuration::Seconds(1));
+
+        WriteTopicMessage(info.InputTopicName, R"({"time": "2025-08-26T00:00:00.000000Z", "event": "A"})");
+        ReadTopicMessage(info.OutputTopicName, "B-2025-08-25T00:00:00.000000Z-1", readDisposition);
+    }
+
+    Y_UNIT_TEST_F(OffsetsRecoveryOnQueryTextChangeCreateOrReplace, TStreamingTestFixture) {
+        const auto info = SetupCheckpointRecoveryTest(*this);
+
+        WriteTopicMessages(info.InputTopicName, {
+            R"({"time": "2025-08-24T00:00:00.000000Z", "event": "A"})",
+            R"({"time": "2025-08-25T00:00:00.000000Z", "event": "A"})",
+        });
+        ReadTopicMessage(info.OutputTopicName, "A-2025-08-24T00:00:00.000000Z-1");
+
+        ExecQuery(fmt::format(R"(
+            CREATE OR REPLACE STREAMING QUERY `{query_name}` WITH (
                 RUN = FALSE
             ) AS
             DO BEGIN

--- a/ydb/core/kqp/ut/federated_query/generic_ut/kqp_generic_provider_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/generic_ut/kqp_generic_provider_ut.cpp
@@ -146,6 +146,65 @@ namespace NKikimr::NKqp {
         return databaseAsyncResolverMock;
     }
 
+    ///
+    /// Fixture that prepares mocks and services for a provider.
+    ///
+    /// TODO:
+    /// Make it reusable, currently it fails if multiple
+    /// expects are applied to mock
+    ///
+    class TQueryExecutorFixture : public NUnitTest::TBaseFixture {
+    public:
+        TQueryExecutorFixture(EProviderType providerType)
+            : DataSourceInstance(MakeDataSourceInstance(providerType))
+            , ClientMock(std::make_shared<TConnectorClientMock>())
+        {
+            auto databaseAsyncResolverMock = MakeDatabaseAsyncResolver(providerType);
+            auto appConfig = CreateDefaultAppConfig();
+            auto s3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
+
+            Kikimr = MakeKikimrRunner(
+                false,
+                ClientMock,
+                databaseAsyncResolverMock,
+                appConfig,
+                s3ActorsFactory,
+                {.CredentialsFactory = CreateCredentialsFactory()}
+            );
+
+            CreateExternalDataSource(providerType, Kikimr);
+            QueryClient = Kikimr->GetQueryClient();
+        }
+
+        TQueryClient GetQueryClient() {
+            return *QueryClient;
+        }
+
+        TAsyncExecuteQueryResult ExecuteQuery(const TString& query) {
+            return GetQueryClient()
+                .ExecuteQuery(query, TTxControl::BeginTx().CommitTx(), TExecuteQuerySettings());
+        }
+
+        NThreading::TFuture<TScriptExecutionOperation> ExecuteScript(const TString& script) {
+            return GetQueryClient()
+                .ExecuteScript(script);
+        }
+
+        TConnectorClientMock::TSelectBuilder<> GetSelectBuilder() {
+            TConnectorClientMock::TSelectBuilder<> builder;
+            builder.DataSourceInstance(DataSourceInstance);
+            return builder;
+        }
+
+    public:
+        const NYql::TGenericDataSourceInstance DataSourceInstance;
+        std::shared_ptr<TConnectorClientMock> ClientMock;
+
+    protected:
+        std::shared_ptr<TKikimrRunner> Kikimr;
+        std::optional<TQueryClient> QueryClient;
+    };
+
     Y_UNIT_TEST_SUITE(GenericFederatedQuery) {
         void TestSelectAllFields(EProviderType providerType) {
             // prepare mock
@@ -164,6 +223,9 @@ namespace NKikimr::NKqp {
             clientMock->ExpectListSplits()
                 .Select()
                     .DataSourceInstance(dataSourceInstance)
+                    .What()
+                        .Column("col1", Ydb::Type::UINT16)
+                        .Done()
                     .Done()
                 .Result()
                     .AddResponse(NewSuccess())
@@ -285,6 +347,8 @@ namespace NKikimr::NKqp {
             clientMock->ExpectListSplits()
                 .Select()
                     .DataSourceInstance(dataSourceInstance)
+                    .What()
+                        .Done()
                     .Done()
                 .Result()
                     .AddResponse(NewSuccess())
@@ -400,6 +464,8 @@ namespace NKikimr::NKqp {
             clientMock->ExpectListSplits()
                 .Select()
                     .DataSourceInstance(dataSourceInstance)
+                    .What()
+                        .Done()
                     .Done()
                 .Result()
                     .AddResponse(NewSuccess())
@@ -490,104 +556,122 @@ namespace NKikimr::NKqp {
             TestSelectCount(EProviderType::IcebergHadoopToken);
         }
 
-        void TestFilterPushdown(EProviderType providerType) {
-            // prepare mock
-            auto clientMock = std::make_shared<TConnectorClientMock>();
-
-            const NYql::TGenericDataSourceInstance dataSourceInstance = MakeDataSourceInstance(providerType);
-
-            // clang-format off
-            const NApi::TSelect selectInListSplits = TConnectorClientMock::TSelectBuilder<>()
-                .DataSourceInstance(dataSourceInstance).GetResult();
-
-            const NApi::TSelect selectInReadSplits = TConnectorClientMock::TSelectBuilder<>()
-                .DataSourceInstance(dataSourceInstance)
+        ///
+        /// Test a filter pushdown for a provider
+        ///
+        /// @param[in] providerType     Provider's type
+        /// @param[in] where            Where clause that will be appended to a sql query
+        /// @param[in] expectedWhere    Where clause that will be expected in a list split and read split requests
+        ///
+        void TestFilterPushdown(EProviderType providerType, const TString& where, NApi::TSelect::TWhere& expectedWhere) {
+            auto f = std::make_shared<TQueryExecutorFixture>(providerType);
+            auto expectedSelect = f->GetSelectBuilder()
                 .What()
-                    .NullableColumn("data_column", Ydb::Type::STRING)
-                    .NullableColumn("filtered_column", Ydb::Type::INT32)
+                    .NullableColumn("colDate", Ydb::Type::DATE)
+                    .NullableColumn("colInt32", Ydb::Type::INT32)
+                    .NullableColumn("colString", Ydb::Type::STRING)
                     .Done()
-                .Where()
-                    .Filter()
-                        .Equal()
-                            .Column("filtered_column")
-                            .Value<i32>(42)
-                            .Done()
-                        .Done()
-                    .Done()
+                .Where(expectedWhere)
                 .GetResult();
-            // clang-format on
 
             // step 1: DescribeTable
-            // clang-format off
-            clientMock->ExpectDescribeTable()
-                .DataSourceInstance(dataSourceInstance)
+            f->ClientMock->ExpectDescribeTable()
+                .DataSourceInstance(f->DataSourceInstance)
                 .TypeMappingSettings(MakeTypeMappingSettings(NYql::NConnector::NApi::STRING_FORMAT))
                 .Response()
-                    .NullableColumn("filtered_column", Ydb::Type::INT32)
-                    .NullableColumn("data_column", Ydb::Type::STRING);
-            // clang-format on
+                    .NullableColumn("colDate", Ydb::Type::DATE)
+                    .NullableColumn("colInt32", Ydb::Type::INT32)
+                    .NullableColumn("colString", Ydb::Type::STRING);
 
             // step 2: ListSplits
-            // clang-format off
-            clientMock->ExpectListSplits()
-                .Select(selectInListSplits)
+            f->ClientMock->ExpectListSplits()
+                .Select(expectedSelect)
                 .Result()
                     .AddResponse(NewSuccess())
                         .Description("some binary description")
-                        .Select(selectInReadSplits);
-            // clang-format on
+                        .Select(expectedSelect);
 
             // step 3: ReadSplits
-            // Return data such that it contains values not satisfying the filter conditions.
-            // Then check that, despite that connector reads additional data,
-            // our generic provider then filters it out.
-            std::vector<std::string> colData = {"Filtered text", "Text"};
-            std::vector<i32> filterColumnData = {42, 24};
-            // clang-format off
-            clientMock->ExpectReadSplits()
+            std::vector<std::string> colString = {"Filtered text", "Text"};
+            std::vector<ui16> colDate = {20326, 20329};
+            std::vector<i32> colInt32 = {42, 24};
+
+            f->ClientMock->ExpectReadSplits()
                 .Filtering(NYql::NConnector::NApi::TReadSplitsRequest::FILTERING_OPTIONAL)
                 .Split()
                     .Description("some binary description")
-                    .Select(selectInReadSplits)
+                    .Select(expectedSelect)
                     .Done()
                 .Result()
                     .AddResponse(MakeRecordBatch(
-                        MakeArray<arrow::BinaryBuilder>("data_column", colData, arrow::binary()),
-                        MakeArray<arrow::Int32Builder>("filtered_column", filterColumnData, arrow::int32())),
+                        MakeArray<arrow::UInt16Builder>("colDate", colDate, arrow::uint16()),
+                        MakeArray<arrow::Int32Builder>("colInt32", colInt32, arrow::int32()),
+                        MakeArray<arrow::BinaryBuilder>("colString", colString, arrow::binary())),
                         NewSuccess());
-            // clang-format on
-
-            // prepare database resolver mock
-            auto databaseAsyncResolverMock = MakeDatabaseAsyncResolver(providerType);
-
-            // run test
-            auto appConfig = CreateDefaultAppConfig();
-            auto s3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
-            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory,
-                {.CredentialsFactory = CreateCredentialsFactory()});
-
-            CreateExternalDataSource(providerType, kikimr);
 
             const TString query = fmt::format(
                 R"(
                 PRAGMA generic.UsePredicatePushdown="true";
-                SELECT data_column FROM {data_source_name}.{table_name} WHERE filtered_column = 42;
+                SELECT colDate, colInt32, colString FROM {data_source_name}.{table_name} WHERE {table_where};
             )",
                 "data_source_name"_a = DEFAULT_DATA_SOURCE_NAME,
-                "table_name"_a = DEFAULT_TABLE);
+                "table_name"_a = DEFAULT_TABLE,
+                "table_where"_a = where
+            );
 
-            auto db = kikimr->GetQueryClient();
-            auto queryResult = db.ExecuteQuery(query, TTxControl::BeginTx().CommitTx(), TExecuteQuerySettings()).ExtractValueSync();
+            auto queryResult = f->ExecuteQuery(query).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(queryResult.GetStatus(), EStatus::SUCCESS, queryResult.GetIssues().ToString());
 
+            // Check a query result
             TResultSetParser resultSet(queryResult.GetResultSetParser(0));
-            UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnsCount(), 3);
             UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 1);
 
-            // check every row
-            // Check that, despite returning nonfiltered data in connector, response will be correct
-            std::vector<TMaybe<TString>> result = {"Filtered text"}; // Only data satisfying filter conditions
-            MATCH_RESULT_WITH_INPUT(result, resultSet, GetOptionalString);
+            // Check values for the query result
+            std::vector<std::optional<TInstant>> colDateResults = {TInstant::Days(20326)};
+            std::vector<std::optional<int>> colInt32Result = {42};
+            std::vector<std::optional<TString>> colStringResult = {"Filtered text"};
+
+            for (size_t i = 0; i < colDateResults.size(); ++i) {
+                resultSet.TryNextRow();
+
+                MATCH_OPT_RESULT_WITH_VAL_IDX(colDateResults[i], resultSet, GetOptionalDate, 0);
+                MATCH_OPT_RESULT_WITH_VAL_IDX(colInt32Result[i], resultSet, GetOptionalInt32, 1);
+                MATCH_OPT_RESULT_WITH_VAL_IDX(colStringResult[i], resultSet, GetOptionalString, 2);
+            }
+        }
+
+        ///
+        /// Test a filter pushdown for a provider
+        ///
+        /// @param[in] providerType Provider's type
+        ///
+        void TestFilterPushdown(EProviderType providerType) {
+            using namespace NYql::NConnector::NTest;
+
+            auto expectedWhereInt = TConnectorClientMock::TWhereBuilder<>()
+                .Filter().Equal()
+                    .Column("colInt32")
+                    .Value<i32>(42)
+                    .Done()
+                .Done()
+                .GetResult();
+
+            TestFilterPushdown(providerType, "colInt32 = 42", expectedWhereInt);
+            TestFilterPushdown(providerType, "colInt32 = EvaluateExpr(44 - 2)", expectedWhereInt);
+            TestFilterPushdown(providerType, "colInt32 = 44 - 2", expectedWhereInt);
+
+            auto expectedWhereDate = TConnectorClientMock::TWhereBuilder<>()
+                .Filter().Equal()
+                    .Column("colDate")
+                    .Value<ui32>(20326, ::Ydb::Type::DATE)
+                    .Done()
+                .Done()
+                .GetResult();
+
+            TestFilterPushdown(providerType, "colDate = Date('2025-08-26')", expectedWhereDate);
+            TestFilterPushdown(providerType, "colDate = EvaluateExpr(Date('2025-08-27') - Interval(\"P1D\"))", expectedWhereDate);
+            TestFilterPushdown(providerType, "colDate = Date('2025-08-27') - Interval(\"P1D\")", expectedWhereDate);
         }
 
         Y_UNIT_TEST(PostgreSQLFilterPushdown) {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12743,6 +12743,16 @@ END DO)",
         }
 
         {
+            auto schemeClient = kikimr->GetSchemeClient(TCommonClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+            const auto result = schemeClient.DescribePath("/Root/MyFolder/MyStreamingQuery").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+            const auto& entry = result.GetEntry();
+            UNIT_ASSERT_VALUES_EQUAL(entry.Name, "MyStreamingQuery");
+            UNIT_ASSERT_VALUES_EQUAL(entry.Owner, BUILTIN_ACL_ROOT);
+            UNIT_ASSERT_VALUES_EQUAL(entry.Type, NYdb::NScheme::ESchemeEntryType::StreamingQuery);
+        }
+
+        {
             const auto result = db.ExecuteQuery(R"(
                 CREATE OR REPLACE STREAMING QUERY `MyFolder/MyStreamingQuery` WITH (
                     RUN = FALSE

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12560,7 +12560,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             .SetEnableResourcePools(true)
             .SetInitFederatedQuerySetupFactory(true));
 
-        const auto result = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT)).ExecuteQuery(fmt::format(R"(
+        const auto result = kikimr->GetQueryClient().ExecuteQuery(fmt::format(R"(
             CREATE TOPIC MyTopic;
             CREATE EXTERNAL DATA SOURCE MySource WITH (
                 SOURCE_TYPE = "Ydb",
@@ -12577,7 +12577,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
     Y_UNIT_TEST(DisableStreamingQueries) {
         auto kikimr = SetupStreamingSource(/* enableStreamingQueries */ false);
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         auto checkQuery = [&db](const TString& query, EStatus status, const TString& error) {
             Cerr << "Check query:\n" << query << "\n";
@@ -12611,7 +12611,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
     Y_UNIT_TEST(StreamingQueriesValidation) {
         auto kikimr = SetupStreamingSource();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         // Test create
 
@@ -12720,7 +12720,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
     Y_UNIT_TEST(CreateStreamingQueryBasic) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(TStringBuilder() << R"(
@@ -12800,7 +12800,7 @@ END DO)",
     }
 
     void CheckStreamingQueryBodyValidation(TKikimrRunner& kikimr, const TString& prefix) {
-        auto db = kikimr.GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr.GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(TStringBuilder() << prefix << R"(
@@ -12890,7 +12890,7 @@ END DO)",
     Y_UNIT_TEST(CreateStreamingQueryErrors) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(R"(
@@ -12952,7 +12952,7 @@ END DO)",
 
     Y_UNIT_TEST(ParallelCreateStreamingQuery) {
         auto kikimr = SetupStreamingSource();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         constexpr ui64 PARALLEL_QUERIES = 100;
         std::vector<NQuery::TAsyncExecuteQueryResult> results;
@@ -12999,7 +12999,7 @@ END DO)",
     Y_UNIT_TEST(AlterStreamingQueryBasic) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(TStringBuilder() << R"(
@@ -13072,7 +13072,7 @@ END DO)",
     Y_UNIT_TEST(AlterStreamingQueryErrors) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(R"(
@@ -13128,7 +13128,7 @@ END DO)",
     Y_UNIT_TEST(ParallelAlterStreamingQuery) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(R"(
@@ -13185,7 +13185,7 @@ END DO)",
     Y_UNIT_TEST(DropStreamingQueryBasic) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(R"(
@@ -13220,7 +13220,7 @@ END DO)",
     Y_UNIT_TEST(DropStreamingQueryErrors) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(R"(
@@ -13262,7 +13262,7 @@ END DO)",
     Y_UNIT_TEST(ParallelDropStreamingQuery) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = db.ExecuteQuery(R"(
@@ -13313,7 +13313,7 @@ END DO)",
     Y_UNIT_TEST(StreamingQueriesWithResourcePools) {
         auto kikimr = SetupStreamingSource();
         auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         {
             const auto result = kikimr->GetQueryClient().ExecuteQuery(R"(
@@ -13362,7 +13362,7 @@ END DO)",
 
     Y_UNIT_TEST(StreamingQueriesAclValidation) {
         auto kikimr = SetupStreamingSource();
-        auto db = kikimr->GetQueryClient(NQuery::TClientSettings().AuthToken(BUILTIN_ACL_ROOT));
+        auto db = kikimr->GetQueryClient();
 
         constexpr char createUser[] = "create@builtin";
         constexpr char removeUser[] = "remove@builtin";

--- a/ydb/library/query_actor/query_actor.cpp
+++ b/ydb/library/query_actor/query_actor.cpp
@@ -99,11 +99,12 @@ TQueryBase::TEvQueryBasePrivate::TEvCommitTransactionResponse::TEvCommitTransact
 
 //// TQueryBase
 
-TQueryBase::TQueryBase(ui64 logComponent, TString sessionId, TString database, bool isSystemUser)
+TQueryBase::TQueryBase(ui64 logComponent, TString sessionId, TString database, bool isSystemUser, bool isStreamingMode)
     : LogComponent(logComponent)
     , Database(std::move(database))
     , SessionId(std::move(sessionId))
     , IsSystemUser(isSystemUser)
+    , IsStreamingMode(isStreamingMode)
 {}
 
 void TQueryBase::Registered(NActors::TActorSystem* sys, const NActors::TActorId& owner) {
@@ -156,7 +157,7 @@ void TQueryBase::Handle(TEvQueryBasePrivate::TEvCreateSessionResult::TPtr& ev) {
 
         DeleteSession = true;
         RunQuery();
-        Y_ABORT_UNLESS(Finished || RunningQuery);
+        Y_ABORT_UNLESS(Finished || RunningQuery || IsStreamingMode);
     } else {
         LOG_W("Failed to create session: " << ev->Get()->Status << ". Issues: " << ev->Get()->Issues.ToOneLineString());
         Finish(ev->Get()->Status, std::move(ev->Get()->Issues));
@@ -253,7 +254,7 @@ void TQueryBase::Handle(TEvQueryBasePrivate::TEvDataQueryResult::TPtr& ev) {
         } catch (const std::exception& ex) {
             Finish(StatusIds::INTERNAL_ERROR, ex.what());
         }
-        Y_ABORT_UNLESS(Finished || RunningQuery || RunningCommit);
+        Y_ABORT_UNLESS(Finished || RunningQuery || RunningCommit || IsStreamingMode);
     } else {
         Finish(ev->Get()->Status, std::move(ev->Get()->Issues));
     }

--- a/ydb/library/query_actor/query_actor.h
+++ b/ydb/library/query_actor/query_actor.h
@@ -115,7 +115,7 @@ private:
 public:
     static constexpr char ActorName[] = "SQL_QUERY";
 
-    explicit TQueryBase(ui64 logComponent, TString sessionId = {}, TString database = {}, bool isSystemUser = false);
+    explicit TQueryBase(ui64 logComponent, TString sessionId = {}, TString database = {}, bool isSystemUser = false, bool isStreamingMode = false);
 
     void Bootstrap();
 
@@ -157,6 +157,8 @@ protected:
 
     TString LogPrefix() const;
 
+    STFUNC(StateFunc);
+
 private:
     // Methods for implementing in derived classes.
     virtual void OnRunQuery() = 0;
@@ -180,8 +182,6 @@ private:
             actorSystem->Send(selfId, new TEvent(std::move(result)));
         };
     }
-
-    STFUNC(StateFunc);
 
     void RunCreateSession() const;
     void Handle(TEvQueryBasePrivate::TEvCreateSessionResult::TPtr& ev);
@@ -208,6 +208,7 @@ protected:
     TString Database;
     TString SessionId;
     bool IsSystemUser = false;
+    bool IsStreamingMode = false;
     TString TxId;
     bool DeleteSession = false;
     bool RunningQuery = false;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -1160,7 +1160,12 @@ protected:
                 break;
             }
             default: {
-                CA_LOG_C("Handle unexpected event undelivery: " << lostEventType);
+                if (Checkpoints) {
+                    TAutoPtr<NActors::IEventHandle> iev(ev.Release());
+                    Checkpoints->Receive(iev);
+                } else {
+                    CA_LOG_C("Handle unexpected event undelivery: " << lostEventType);
+                }
             }
         }
     }

--- a/ydb/library/yql/providers/common/pushdown/collection.cpp
+++ b/ydb/library/yql/providers/common/pushdown/collection.cpp
@@ -201,6 +201,9 @@ private:
             node.Maybe<TCoUint64>()) {
             return true;
         }
+        if (Settings.IsEnabled(EFlag::DateCtor) && node.Maybe<TCoDate>()) {
+            return true;
+        }
         if (Settings.IsEnabled(EFlag::TimestampCtor) && node.Maybe<TCoTimestamp>()) {
             return true;
         }

--- a/ydb/library/yql/providers/common/pushdown/settings.h
+++ b/ydb/library/yql/providers/common/pushdown/settings.h
@@ -46,6 +46,7 @@ struct TSettings {
         MinMax = 1 << 27,
         NonDeterministic = 1 << 28,
         DecimalCtor = 1 << 29, 
+        DateCtor = 1 << 30,
     };
 
     explicit TSettings(NLog::EComponent logComponent)

--- a/ydb/library/yql/providers/generic/actors/ut/ya.make
+++ b/ydb/library/yql/providers/generic/actors/ut/ya.make
@@ -1,10 +1,11 @@
 UNITTEST_FOR(ydb/library/yql/providers/generic/actors)
 
 PEERDIR(
-    yql/essentials/sql/pg_dummy
-    ydb/library/yql/providers/generic/connector/libcpp/ut_helpers
-    ydb/library/actors/testlib
     library/cpp/testing/unittest
+    ydb/core/kqp/ut/federated_query/common
+    ydb/library/actors/testlib
+    ydb/library/yql/providers/generic/connector/libcpp/ut_helpers
+    yql/essentials/sql/pg_dummy
 )
 
 SRCS(

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -6,6 +6,7 @@
 
 #include <ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.h>
 
+#include <ydb/core/kqp/ut/federated_query/common/common.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
 #include <ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h>
 #include <ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/test_creds.h>
@@ -90,7 +91,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         dsi.set_protocol(::NYql::EGenericProtocol::NATIVE);
         auto token = dsi.mutable_credentials()->mutable_token();
         token->Settype("IAM");
-        token->Setvalue("TEST_TOKEN");
+        token->Setvalue("token_value");
 
         auto connectorMock = std::make_shared<NYql::NConnector::NTest::TConnectorClientMock>();
 
@@ -163,8 +164,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         NYql::Generic::TLookupSource lookupSourceSettings;
         *lookupSourceSettings.mutable_data_source_instance() = dsi;
         lookupSourceSettings.Settable("lookup_test");
-        lookupSourceSettings.SetServiceAccountId("testsaid");
-        lookupSourceSettings.SetServiceAccountIdSignature("fake_signature");
+        lookupSourceSettings.SetTokenName("test_token");   
 
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
@@ -180,7 +180,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
         auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
             connectorMock,
-            std::make_shared<NYql::NTestCreds::TSecuredServiceAccountCredentialsFactory>(),
+            NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
             edge,
             nullptr,
             alloc,
@@ -191,7 +191,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             typeEnv,
             holderFactory,
             1'000'000,
-            {});
+            {{"test_token", "{\"token\": \"token_value\"}"}});
         auto lookupActor = runtime.Register(actor);
 
         auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
@@ -257,7 +257,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         dsi.set_protocol(::NYql::EGenericProtocol::NATIVE);
         auto token = dsi.mutable_credentials()->mutable_token();
         token->Settype("IAM");
-        token->Setvalue("TEST_TOKEN");
+        token->Setvalue("token_value");
 
         auto connectorMock = std::make_shared<NYql::NConnector::NTest::TConnectorClientMock>();
 
@@ -355,8 +355,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         NYql::Generic::TLookupSource lookupSourceSettings;
         *lookupSourceSettings.mutable_data_source_instance() = dsi;
         lookupSourceSettings.Settable("lookup_test");
-        lookupSourceSettings.SetServiceAccountId("testsaid");
-        lookupSourceSettings.SetServiceAccountIdSignature("fake_signature");
+        lookupSourceSettings.SetTokenName("test_token");   
 
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
@@ -372,7 +371,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
         auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
             connectorMock,
-            std::make_shared<NYql::NTestCreds::TSecuredServiceAccountCredentialsFactory>(),
+            NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
             edge,
             nullptr,
             alloc,
@@ -383,7 +382,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             typeEnv,
             holderFactory,
             1'000'000,
-            {});
+            {{"test_token", "{\"token\": \"token_value\"}"}});
         auto lookupActor = runtime.Register(actor);
 
         auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());

--- a/ydb/library/yql/providers/generic/actors/yql_generic_credentials_provider.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_credentials_provider.cpp
@@ -5,43 +5,20 @@
 #include <yql/essentials/utils/log/log.h>
 
 namespace NYql::NDq {
-    TGenericCredentialsProvider::TGenericCredentialsProvider(const TString& staticIamToken)
-        : StaticIAMToken_(staticIamToken)
-    {
-    }
-
-    TGenericCredentialsProvider::TGenericCredentialsProvider(
-        const TString& serviceAccountId,
-        const TString& serviceAccountIdSignature,
-        const ISecuredServiceAccountCredentialsFactory::TPtr& credentialsFactory) {
-        Y_ENSURE(!serviceAccountId.empty(), "No service account provided");
-        Y_ENSURE(!serviceAccountIdSignature.empty(), "No service account signature provided");
-        Y_ENSURE(credentialsFactory, "CredentialsFactory is not initialized");
-
-        auto structuredTokenJSON =
-            TStructuredTokenBuilder().SetServiceAccountIdAuth(serviceAccountId, serviceAccountIdSignature).ToJson();
-
-        Y_ENSURE(structuredTokenJSON, "empty structured token");
-
-        auto credentialsProviderFactory =
-            CreateCredentialsProviderFactoryForStructuredToken(credentialsFactory, structuredTokenJSON, false);
-        CredentialsProvider_ = credentialsProviderFactory->CreateProvider();
-    }
-
     TGenericCredentialsProvider::TGenericCredentialsProvider(
         const TString& structuredTokenJSON,
         const ISecuredServiceAccountCredentialsFactory::TPtr& credentialsFactory) {
-        Y_ENSURE(!structuredTokenJSON.empty(), "empty structured token");
         Y_ENSURE(credentialsFactory, "CredentialsFactory is not initialized");
 
-        NYql::TStructuredTokenParser parser = NYql::CreateStructuredTokenParser(structuredTokenJSON);
-
-        if (parser.HasBasicAuth()) {
-            TString login;
-            TString password;
-            parser.GetBasicAuth(login, password);
-            BasicAuthCredentials_ = {login, password};
-            return;
+        if (IsStructuredTokenJson(structuredTokenJSON)) {
+            TStructuredTokenParser parser = CreateStructuredTokenParser(structuredTokenJSON);
+            if (parser.HasBasicAuth()) {
+                TString login;
+                TString password;
+                parser.GetBasicAuth(login, password);
+                BasicAuthCredentials_ = {login, password};
+                return;
+            }
         }
 
         auto credentialsProviderFactory = CreateCredentialsProviderFactoryForStructuredToken(
@@ -52,7 +29,7 @@ namespace NYql::NDq {
         CredentialsProvider_ = credentialsProviderFactory->CreateProvider();
     }
 
-    TString TGenericCredentialsProvider::FillCredentials(NYql::TGenericDataSourceInstance& dsi) const {
+    TString TGenericCredentialsProvider::FillCredentials(TGenericDataSourceInstance& dsi) const {
         // 1. If basic auth creds have been provided, use it
         if (BasicAuthCredentials_) {
             auto basic = dsi.mutable_credentials()->mutable_basic();
@@ -62,12 +39,6 @@ namespace NYql::NDq {
         }
 
         *dsi.mutable_credentials()->mutable_token()->mutable_type() = "IAM";
-
-        // 2. If static IAM-token has been provided, use it
-        if (StaticIAMToken_) {
-            *dsi.mutable_credentials()->mutable_token()->mutable_value() = *StaticIAMToken_;
-            return {};
-        }
 
         // 3. Otherwise use credentials provider to get token from Token Accessor
         Y_ENSURE(CredentialsProvider_, "CredentialsProvider is not initialized");
@@ -80,27 +51,13 @@ namespace NYql::NDq {
             return TString(e.what());
         }
 
-        Y_ENSURE(!iamToken.empty(), "CredentialsProvider returned empty IAM token");
-
         *dsi.mutable_credentials()->mutable_token()->mutable_value() = std::move(iamToken);
         return {};
     }
 
     TGenericCredentialsProvider::TPtr
     CreateGenericCredentialsProvider(const TString& structuredTokenJSON,
-                                     /*[[deprecated]]*/ const TString& staticIamToken,
-                                     /*[[deprecated]]*/ const TString& serviceAccountId,
-                                     /*[[deprecated]]*/ const TString& serviceAccountIdSignature,
                                      const ISecuredServiceAccountCredentialsFactory::TPtr& credentialsFactory) {
-        if (!structuredTokenJSON.empty()) {
-            return std::make_unique<TGenericCredentialsProvider>(structuredTokenJSON, credentialsFactory);
-        }
-        if (!staticIamToken.empty()) {
-            return std::make_unique<TGenericCredentialsProvider>(staticIamToken);
-        }
-        if (!serviceAccountId.empty() && !serviceAccountIdSignature.empty()) {
-            return std::make_unique<TGenericCredentialsProvider>(serviceAccountId, serviceAccountIdSignature, credentialsFactory);
-        }
-        return std::make_unique<TGenericCredentialsProvider>();
+        return std::make_unique<TGenericCredentialsProvider>(structuredTokenJSON, credentialsFactory);
     }
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/generic/actors/yql_generic_credentials_provider.h
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_credentials_provider.h
@@ -9,21 +9,10 @@ namespace NYql {
 }
 
 namespace NYql::NDq {
-    // When accessing the external data sources, there are several options for authentication:
-    //
-    // 1. Use static IAM-token provided by user (especially useful during debugging).
-    // 2. Use service account credentials in order to get (and refresh) IAM-token by demand.
-    // 3. Use login + password for basic auth.
     class TGenericCredentialsProvider {
     public:
         using TPtr = std::unique_ptr<TGenericCredentialsProvider>;
-        TGenericCredentialsProvider() = default; // No auth required
-        TGenericCredentialsProvider(const TString& staticIamToken);
-        // Remove this constructor as soon as the first part of YQ-4730 is merged
-        TGenericCredentialsProvider(
-            const TString& serviceAccountId,
-            const TString& ServiceAccountIdSignature,
-            const ISecuredServiceAccountCredentialsFactory::TPtr& credentialsFactory);
+
         TGenericCredentialsProvider(
             const TString& structuredToken,
             const ISecuredServiceAccountCredentialsFactory::TPtr& credentialsFactory);
@@ -34,8 +23,6 @@ namespace NYql::NDq {
         TString FillCredentials(NYql::TGenericDataSourceInstance& dsi) const;
 
     private:
-        std::optional<TString> StaticIAMToken_;
-
         struct BasicAuthCredentials {
             TString Username;
             TString Password;
@@ -48,8 +35,5 @@ namespace NYql::NDq {
     TGenericCredentialsProvider::TPtr
     CreateGenericCredentialsProvider(
         const TString& structuredTokenJSON,
-        /*[[deprecated]]*/ const TString& staticIamToken,
-        /*[[deprecated]]*/ const TString& serviceAccountId,
-        /*[[deprecated]]*/ const TString& serviceAccountIdSignature,
         const ISecuredServiceAccountCredentialsFactory::TPtr& credentialsFactory);
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -174,16 +174,18 @@ namespace NYql::NDq {
         }
 
     private: // events
-        STRICT_STFUNC(StateFunc,
-                      hFunc(TEvLookupRequest, Handle);
-                      hFunc(TEvListSplitsIterator, Handle);
-                      hFunc(TEvListSplitsPart, Handle);
-                      hFunc(TEvReadSplitsIterator, Handle);
-                      hFunc(TEvReadSplitsPart, Handle);
-                      hFunc(TEvReadSplitsFinished, Handle);
-                      hFunc(TEvError, Handle);
-                      hFunc(TEvLookupRetry, Handle);
-                      hFunc(NActors::TEvents::TEvPoison, Handle);)
+        STRICT_STFUNC_EXC(StateFunc,
+            hFunc(TEvLookupRequest, Handle)
+            hFunc(TEvListSplitsIterator, Handle)
+            hFunc(TEvListSplitsPart, Handle)
+            hFunc(TEvReadSplitsIterator, Handle)
+            hFunc(TEvReadSplitsPart, Handle)
+            hFunc(TEvReadSplitsFinished, Handle)
+            hFunc(TEvError, Handle)
+            hFunc(TEvLookupRetry, Handle)
+            hFunc(NActors::TEvents::TEvPoison, Handle)
+            , ExceptionFunc(std::exception, HandleException)
+        )
 
         void Handle(TEvListSplitsIterator::TPtr ev) {
             auto& iterator = ev->Get()->Iterator;
@@ -252,13 +254,17 @@ namespace NYql::NDq {
         }
 
         void Handle(TEvError::TPtr ev) {
-            auto actorSystem = TActivationContext::ActorSystem();
-            auto error = ev->Get()->Error;
-            auto errEv = std::make_unique<IDqComputeActorAsyncInput::TEvAsyncInputError>(
-                                  -1,
-                                  NConnector::ErrorToIssues(error),
-                                  NConnector::ErrorToDqStatus(error));
-            actorSystem->Send(new NActors::IEventHandle(ParentId, SelfId(), errEv.release()));
+            const auto error = ev->Get()->Error;
+            auto issues = NConnector::ErrorToIssues(error);
+            auto fatalCode = NDqProto::StatusIds::INTERNAL_ERROR;
+
+            try {
+                fatalCode = NConnector::ErrorToDqStatus(error);
+            } catch (const std::exception& e) {
+                issues.AddIssue(TStringBuilder() << "Failed to convert YDB status code: " << e.what());
+            }
+
+            Send(ParentId, new IDqComputeActorAsyncInput::TEvAsyncInputError(-1, std::move(issues), fatalCode));
         }
 
         void Handle(TEvLookupRetry::TPtr) {
@@ -273,6 +279,11 @@ namespace NYql::NDq {
         void Handle(TEvLookupRequest::TPtr ev) {
             auto guard = Guard(*Alloc);
             CreateRequest(ev->Get()->Request.lock());
+        }
+
+        void HandleException(const std::exception& e) {
+            YQL_CLOG(ERROR, ProviderGeneric) << "ActorId=" << SelfId() << " Got unexpected exception: " << e.what();
+            SendError(TActivationContext::ActorSystem(), SelfId(), TStringBuilder() << "Internal error. Got unexpected exception: " << e.what());
         }
 
     private:
@@ -413,7 +424,7 @@ namespace NYql::NDq {
         }
 
         static void SendError(NActors::TActorSystem* actorSystem, const NActors::TActorId& selfId, const NConnector::NApi::TError& error) {
-            YQL_CLOG(ERROR, ProviderGeneric) << "ActorId=" << selfId << " Got GrpcError from Connector:" << error.Getmessage();
+            YQL_CLOG(ERROR, ProviderGeneric) << "ActorId=" << selfId << " Got GrpcError from Connector: " << error.Getmessage();
             actorSystem->Send(
                 selfId,
                 new TEvError(std::move(error)));
@@ -432,6 +443,7 @@ namespace NYql::NDq {
         static void SendError(NActors::TActorSystem* actorSystem, const NActors::TActorId& selfId, TString error) {
             NConnector::NApi::TError dst;
             *dst.mutable_message() = error;
+            dst.set_status(Ydb::StatusIds::INTERNAL_ERROR);
             SendError(actorSystem, selfId, std::move(dst));
         }
 
@@ -555,9 +567,6 @@ namespace NYql::NDq {
     {
         auto credentialsProvider = NYql::NDq::CreateGenericCredentialsProvider(
             secureParams.Value(lookupSource.GetTokenName(), TString()),
-            lookupSource.GetToken(),
-            lookupSource.GetServiceAccountId(),
-            lookupSource.GetServiceAccountIdSignature(),
             securedServiceAccountCredentialsFactory);
         auto guard = Guard(*alloc);
         const auto actor = new TGenericLookupActor(

--- a/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.cpp
@@ -449,9 +449,6 @@ namespace NYql::NDq {
 
         auto tokenProvider = CreateGenericCredentialsProvider(
             secureParams.Value(source.GetTokenName(), ""),
-            source.GetToken(),
-            source.GetServiceAccountId(),
-            source.GetServiceAccountIdSignature(),
             credentialsFactory);
 
         const auto actor = new TGenericReadActor(

--- a/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.cpp
+++ b/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.cpp
@@ -29,6 +29,12 @@ namespace NYql::NConnector::NTest {
     DEFINE_SIMPLE_TYPE_SETTER(i64, INT64, int64_value);
     DEFINE_SIMPLE_TYPE_SETTER(ui64, UINT64, uint64_value);
 
+    template <>
+    void SetValue(const ui32& value, Ydb::TypedValue* proto, const ::Ydb::Type::PrimitiveTypeId& typeId, bool optional) {
+        *proto->mutable_type() = MakeYdbType(typeId, optional);
+        proto->mutable_value()->Y_CAT(set_, uint32_value)(value);
+    }
+
     void CreatePostgreSQLExternalDataSource(
         const std::shared_ptr<NKikimr::NKqp::TKikimrRunner>& kikimr,
         const TString& dataSourceName,

--- a/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h
+++ b/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h
@@ -62,15 +62,16 @@ namespace NYql::NConnector::NTest {
             static_cast<TBuilder*>(this));                                          \
     }
 
-    MATCHER_P(ProtobufRequestMatcher, expected, "request does not match") {
+    template <typename TProto>
+    bool MatchProtos(const TProto& expected, const TProto& actual) {
         Cerr << "GENERIC-CONNECTOR-MOCK Expected: " << expected.DebugString() << Endl;
-        Cerr << "GENERIC-CONNECTOR-MOCK Actual: " << arg.DebugString() << Endl;
+        Cerr << "GENERIC-CONNECTOR-MOCK Actual: " << actual.DebugString() << Endl;
 
         google::protobuf::util::MessageDifferencer differencer;
         TString differences;
         differencer.ReportDifferencesToString(&differences);
 
-        bool result = differencer.Compare(arg, expected);
+        bool result = differencer.Compare(actual, expected);
 
         if (!result) {
             Cerr << "GENERIC-CONNECTOR-MOCK Differences:" << Endl << differences << Endl;
@@ -79,9 +80,12 @@ namespace NYql::NConnector::NTest {
         return result;
     }
 
-    MATCHER_P(RequestRelaxedMatcher, expected, "") {
-        Y_UNUSED(arg);
-        return true;
+    MATCHER_P(ProtobufRequestMatcher, expected, "request does not match") {
+        return MatchProtos(expected, arg);
+    }
+
+    MATCHER_P(RequestRelaxedMatcher, checker, "request does not match") {
+        return checker(arg);
     }
 
 #define MATCH_OPT_RESULT_WITH_VAL_IDX(VAL, RESULT_SET, GETTER, INDEX)               \
@@ -258,6 +262,12 @@ namespace NYql::NConnector::NTest {
         //
         // Expectation helpers
         //
+
+        enum class EArgsValidation {
+            Strict,
+            DataSourceInstance,
+            Off,
+        };
 
         template <class TDerived, class TParent = void /* no parent by default */>
         struct TBaseDataSourceInstanceBuilder: public TProtoBuilder<TParent, NYql::TGenericDataSourceInstance> {
@@ -741,8 +751,8 @@ namespace NYql::NConnector::NTest {
                 return *this;
             }
 
-            auto& ValidateArgs(bool validate) {
-                ValidateArgs_ = validate;
+            auto& ValidateArgs(EArgsValidation validateCase) {
+                ValidateArgs_ = validateCase;
                 return *this;
             }
 
@@ -752,12 +762,31 @@ namespace NYql::NConnector::NTest {
                     Result();
                 }
 
-                auto& expectBuilder = ValidateArgs_
-                    ? EXPECT_CALL(*Mock_, ListSplitsImpl(ProtobufRequestMatcher(*Result_)))
-                    : EXPECT_CALL(*Mock_, ListSplitsImpl(RequestRelaxedMatcher(*Result_)));
+                const auto setupResponse = [&](auto& expectBuilder) {
+                    for (auto response : ResponseResults_) {
+                        expectBuilder.WillOnce(Return(TIteratorResult<IListSplitsStreamIterator>{ResponseStatus_, response}));
+                    }
+                };
 
-                for (auto response : ResponseResults_) {
-                    expectBuilder.WillOnce(Return(TIteratorResult<IListSplitsStreamIterator>{ResponseStatus_, response}));
+                switch (ValidateArgs_) {
+                    case EArgsValidation::Strict:
+                        setupResponse(EXPECT_CALL(*Mock_, ListSplitsImpl(ProtobufRequestMatcher(*Result_))));
+                        break;
+                    case EArgsValidation::DataSourceInstance:
+                        if (!Result_->selects().empty()) {
+                            setupResponse(EXPECT_CALL(*Mock_, ListSplitsImpl(RequestRelaxedMatcher([expected = Result_->selects(0).data_source_instance()](const NConnector::NApi::TListSplitsRequest& actual) {
+                                for (const auto& select : actual.selects()) {
+                                    if (!MatchProtos(expected, select.data_source_instance())) {
+                                        return false;
+                                    }
+                                }
+                                return true;
+                            }))));
+                            break;
+                        }
+                    case EArgsValidation::Off:
+                        setupResponse(EXPECT_CALL(*Mock_, ListSplitsImpl(RequestRelaxedMatcher([](const auto&) { return true; }))));
+                        break;
                 }
             }
 
@@ -765,7 +794,7 @@ namespace NYql::NConnector::NTest {
             TConnectorClientMock* Mock_ = nullptr;
             std::vector<TListSplitsStreamIteratorMock::TPtr> ResponseResults_;
             NYdbGrpc::TGrpcStatus ResponseStatus_ {};
-            bool ValidateArgs_ = true;
+            EArgsValidation ValidateArgs_ = EArgsValidation::Strict;
         };
 
         template <class TParent = void /* no parent by default */>
@@ -828,8 +857,8 @@ namespace NYql::NConnector::NTest {
                 return *this;
             }
 
-            auto& ValidateArgs(bool validate) {
-                ValidateArgs_ = validate;
+            auto& ValidateArgs(EArgsValidation validateCase) {
+                ValidateArgs_ = validateCase;
                 return *this;
             }
 
@@ -843,12 +872,31 @@ namespace NYql::NConnector::NTest {
                     Result();
                 }
 
-                auto& expectBuilder = ValidateArgs_
-                    ? EXPECT_CALL(*Mock_, ReadSplitsImpl(ProtobufRequestMatcher(*Result_)))
-                    : EXPECT_CALL(*Mock_, ReadSplitsImpl(RequestRelaxedMatcher(*Result_)));
+                const auto setupResponse = [&](auto& expectBuilder) {
+                    for (auto response : ResponseResults_) {
+                        expectBuilder.WillOnce(Return(TIteratorResult<IReadSplitsStreamIterator>{ResponseStatus_, response}));
+                    }
+                };
 
-                for (auto response : ResponseResults_) {
-                    expectBuilder.WillOnce(Return(TIteratorResult<IReadSplitsStreamIterator>{ResponseStatus_, response}));
+                switch (ValidateArgs_) {
+                    case EArgsValidation::Strict:
+                        setupResponse(EXPECT_CALL(*Mock_, ReadSplitsImpl(ProtobufRequestMatcher(*Result_))));
+                        break;
+                    case EArgsValidation::DataSourceInstance:
+                        if (!Result_->splits().empty()) {
+                            setupResponse(EXPECT_CALL(*Mock_, ReadSplitsImpl(RequestRelaxedMatcher([expected = Result_->splits(0).select().data_source_instance()](const NConnector::NApi::TReadSplitsRequest& actual) {
+                                for (const auto& split : actual.splits()) {
+                                    if (!MatchProtos(expected, split.select().data_source_instance())) {
+                                        return false;
+                                    }
+                                }
+                                return true;
+                            }))));
+                            break;
+                        }
+                    case EArgsValidation::Off:
+                        setupResponse(EXPECT_CALL(*Mock_, ReadSplitsImpl(RequestRelaxedMatcher([](const auto&) { return true; }))));
+                        break;
                 }
             }
 
@@ -856,7 +904,7 @@ namespace NYql::NConnector::NTest {
             TConnectorClientMock* Mock_ = nullptr;
             std::vector<TReadSplitsStreamIteratorMock::TPtr> ResponseResults_;
             NYdbGrpc::TGrpcStatus ResponseStatus_ {};
-            bool ValidateArgs_ = true;
+            EArgsValidation ValidateArgs_ = EArgsValidation::Strict;
         };
 
         TDescribeTableExpectationBuilder ExpectDescribeTable() {

--- a/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h
+++ b/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h
@@ -63,9 +63,20 @@ namespace NYql::NConnector::NTest {
     }
 
     MATCHER_P(ProtobufRequestMatcher, expected, "request does not match") {
-        Cerr << "CRAB Expected: " << expected.DebugString() << Endl;
-        Cerr << "CRAB Actual: " << arg.DebugString() << Endl;
-        return google::protobuf::util::MessageDifferencer::Equals(arg, expected);
+        Cerr << "GENERIC-CONNECTOR-MOCK Expected: " << expected.DebugString() << Endl;
+        Cerr << "GENERIC-CONNECTOR-MOCK Actual: " << arg.DebugString() << Endl;
+
+        google::protobuf::util::MessageDifferencer differencer;
+        TString differences;
+        differencer.ReportDifferencesToString(&differences);
+
+        bool result = differencer.Compare(arg, expected);
+
+        if (!result) {
+            Cerr << "GENERIC-CONNECTOR-MOCK Differences:" << Endl << differences << Endl;
+        }
+
+        return result;
     }
 
     MATCHER_P(RequestRelaxedMatcher, expected, "") {
@@ -73,13 +84,25 @@ namespace NYql::NConnector::NTest {
         return true;
     }
 
-#define MATCH_RESULT_WITH_INPUT(INPUT, RESULT_SET, GETTER)                      \
-    {                                                                           \
-        for (const auto& val : INPUT) {                                         \
-            UNIT_ASSERT(RESULT_SET.TryNextRow());                               \
-            UNIT_ASSERT_VALUES_EQUAL(RESULT_SET.ColumnParser(0).GETTER(), val); \
-        }                                                                       \
+#define MATCH_OPT_RESULT_WITH_VAL_IDX(VAL, RESULT_SET, GETTER, INDEX)               \
+    {                                                                               \
+            auto r = RESULT_SET.ColumnParser(INDEX).GETTER();                       \
+            UNIT_ASSERT_VALUES_EQUAL(r.has_value(), VAL.has_value());               \
+            if (r.has_value()) {                                                    \
+                UNIT_ASSERT_VALUES_EQUAL(*r, *VAL);                                 \
+            }                                                                       \
     }
+
+#define MATCH_RESULT_WITH_INPUT_IDX(INPUT, RESULT_SET, GETTER, INDEX)               \
+    {                                                                               \
+        for (const auto& val : INPUT) {                                             \
+            UNIT_ASSERT(RESULT_SET.TryNextRow());                                   \
+            UNIT_ASSERT_VALUES_EQUAL(RESULT_SET.ColumnParser(INDEX).GETTER(), val); \
+        }                                                                           \
+    }
+
+#define MATCH_RESULT_WITH_INPUT(INPUT, RESULT_SET, GETTER)\
+    MATCH_RESULT_WITH_INPUT_IDX(INPUT, RESULT_SET, GETTER, 0)
 
     // Make arrow array for one column.
     // Returns field for schema and array with data.
@@ -128,6 +151,10 @@ namespace NYql::NConnector::NTest {
 
     template <class T>
     void SetSimpleValue(const T& value, Ydb::TypedValue* proto, bool optional = false);
+
+    template <class T>
+    void SetValue(const T& value, Ydb::TypedValue* proto,
+        const ::Ydb::Type::PrimitiveTypeId& typeId, bool optional = false);
 
     template <class TParent>
     struct TWithParentBuilder {
@@ -426,8 +453,20 @@ namespace NYql::NConnector::NTest {
             }
 
             template <class T>
+            TBuilder& Value(const T& value, const ::Ydb::Type::PrimitiveTypeId& typeId) {
+                SetValue(value, this->Result_->mutable_typed_value(), typeId);
+                return *this;
+            }
+
+            template <class T>
             TBuilder& OptionalValue(const T& value) {
                 SetSimpleValue(value, this->Result_->mutable_typed_value(), true);
+                return *this;
+            }
+
+            template <class T>
+            TBuilder& OptionalValue(const T& value, const ::Ydb::Type::PrimitiveTypeId& typeId) {
+                SetValue(value, this->Result_->mutable_typed_value(), typeId, true);
                 return *this;
             }
 
@@ -481,8 +520,16 @@ namespace NYql::NConnector::NTest {
                 return Arg().Value(value).Done();
             }
 
+            TBuilder& Value(const auto& value, const ::Ydb::Type::PrimitiveTypeId& typeId) {
+                return Arg().Value(value, typeId).Done();
+            }
+
             TBuilder& OptionalValue(const auto& value) {
                 return Arg().OptionalValue(value).Done();
+            }
+
+            TBuilder& OptionalValue(const auto& value, const ::Ydb::Type::PrimitiveTypeId& typeId) {
+                return Arg().OptionalValue(value, typeId).Done();
             }
 
             void FillWithDefaults() {

--- a/ydb/library/yql/providers/generic/connector/libcpp/utils.cpp
+++ b/ydb/library/yql/providers/generic/connector/libcpp/utils.cpp
@@ -110,4 +110,5 @@ namespace NYql::NConnector {
 
         return res->type();
     }
+
 } // namespace NYql::NConnector

--- a/ydb/library/yql/providers/generic/connector/libcpp/utils.h
+++ b/ydb/library/yql/providers/generic/connector/libcpp/utils.h
@@ -13,5 +13,4 @@ namespace NYql::NConnector {
 
     std::shared_ptr<arrow::RecordBatch> ReadSplitsResponseToArrowRecordBatch(const NApi::TReadSplitsResponse& resp);
     Ydb::Type GetColumnTypeByName(const NApi::TSchema& schema, const TString& name);
-
 } // namespace NYql::NConnector

--- a/ydb/library/yql/providers/generic/proto/source.proto
+++ b/ydb/library/yql/providers/generic/proto/source.proto
@@ -12,36 +12,21 @@ message TSource {
     // Prepared Select expression
     NYql.NConnector.NApi.TSelect select = 2;
 
-    // Credentials used to access managed databases APIs.
-    // When working with external data source instances deployed in clouds,
-    // one should either set (ServiceAccountId, ServiceAccountIdSignature) pair 
-    // that will be resolved into IAM Token via Token Accessor, 
-    // or provide IAM Token directly.
-    string ServiceAccountId = 4 [deprecated = true];
-    string ServiceAccountIdSignature = 5 [deprecated = true];
-    string Token = 6 [deprecated = true];
-
     // TokenName is used during query execution phase.
     // It's used to obtain appropriate structured token from `secureParams` map.
     string TokenName = 7;
 
-    reserved 1, 3;
+    reserved 1, 3, 4, 5, 6;
 }
 
 //TODO(YQ-3093) move SA creds to some common message
 message TLookupSource {
     NYql.TGenericDataSourceInstance data_source_instance = 1;
     string table = 2;
-    // Credentials used to access managed databases APIs.
-    // When working with external data source instances deployed in clouds,
-    // one should either set (ServiceAccountId, ServiceAccountIdSignature) pair 
-    // that will be resolved into IAM Token via Token Accessor, 
-    // or provide IAM Token directly.
-    string ServiceAccountId = 4 [deprecated = true];
-    string ServiceAccountIdSignature = 5 [deprecated = true];
-    string Token = 6 [deprecated = true];
 
     // TokenName is used during query execution phase.
     // It's used to obtain appropriate structured token from `secureParams` map.
     string TokenName = 7;
+
+    reserved 4, 5, 6;
 }

--- a/ydb/library/yql/providers/generic/provider/ya.make
+++ b/ydb/library/yql/providers/generic/provider/ya.make
@@ -7,8 +7,12 @@ SRCS(
     yql_generic_datasink_type_ann.cpp
     yql_generic_datasource.cpp
     yql_generic_datasource_type_ann.cpp
+    yql_generic_describe_table.cpp
+    yql_generic_describe_table.h
     yql_generic_dq_integration.cpp
     yql_generic_io_discovery.cpp
+    yql_generic_list_splits.cpp
+    yql_generic_list_splits.h
     yql_generic_load_meta.cpp
     yql_generic_logical_opt.cpp
     yql_generic_mkql_compiler.cpp

--- a/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp
@@ -1,0 +1,616 @@
+#include "yql_generic_describe_table.h"
+
+#include <yql/essentials/utils/log/log.h>
+#include <yql/essentials/providers/common/structured_token/yql_token_builder.h>
+#include <yql/essentials/providers/common/provider/yql_provider.h>
+#include <yql/essentials/providers/common/provider/yql_provider_names.h>
+#include <yql/essentials/minikql/mkql_type_ops.h>
+#include <yql/essentials/minikql/mkql_program_builder.h>
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/minikql/computation/mkql_computation_node.h>
+#include <yql/essentials/minikql/comp_nodes/mkql_factories.h>
+#include <yql/essentials/core/yql_graph_transformer.h>
+#include <yql/essentials/core/yql_expr_optimize.h>
+#include <yql/essentials/core/type_ann/type_ann_expr.h>
+#include <yql/essentials/core/expr_nodes/yql_expr_nodes.h>
+#include <yql/essentials/ast/yql_type_string.h>
+#include <yql/essentials/ast/yql_expr.h>
+#include <ydb/library/yql/providers/generic/expr_nodes/yql_generic_expr_nodes.h>
+#include <ydb/library/yql/providers/generic/connector/libcpp/error.h>
+#include <ydb/library/yql/providers/generic/connector/libcpp/client.h>
+#include <ydb/core/fq/libs/result_formatter/result_formatter.h>
+#include <ydb/core/external_sources/iceberg_fields.h>
+#include <library/cpp/json/json_reader.h>
+
+namespace NYql {
+
+using namespace NNodes;
+using namespace NKikimr;
+using namespace NKikimr::NMiniKQL;
+
+class TGenericDescribeTableTransformer : public TGraphTransformerBase {
+    struct TTableDescription {
+        using TPtr = std::shared_ptr<TTableDescription>;
+
+        NYql::TGenericDataSourceInstance DataSourceInstance;
+        std::optional<NConnector::NApi::TSchema> Schema;
+        // Issues that could occur at any phase of network interaction with Connector
+        TIssues Issues;
+    };
+
+    using TTableDescriptionMap =
+        std::unordered_map<TGenericState::TTableAddress, TTableDescription::TPtr, THash<TGenericState::TTableAddress>>;
+
+public:
+    explicit TGenericDescribeTableTransformer(TGenericState::TPtr state);
+
+public:
+    TStatus DoTransform(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) final;
+
+    NThreading::TFuture<void> DoGetAsyncFuture(const TExprNode&) final {
+        return AsyncFuture_;
+    }
+
+    TStatus DoApplyAsyncChanges(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) final;
+
+    void Rewind() final;
+
+private:
+    TIssues DescribeTableFromConnector(const TGenericState::TTableAddress& tableAddress,
+                                       std::vector<NThreading::TFuture<void>>& handles);
+
+    TIssues FillDescribeTableRequest(NConnector::NApi::TDescribeTableRequest& request,
+                                    const TGenericClusterConfig& clusterConfig, const TString& tablePath);
+
+    void FillCredentials(NConnector::NApi::TDescribeTableRequest& request,
+                        const TGenericClusterConfig& clusterConfig);
+
+    void FillTypeMappingSettings(NConnector::NApi::TDescribeTableRequest& request);
+
+private:
+    const TGenericState::TPtr State_;
+    TTableDescriptionMap TableDescriptions_;
+    NThreading::TFuture<void> AsyncFuture_;
+};
+
+TGenericDescribeTableTransformer::TGenericDescribeTableTransformer(TGenericState::TPtr state)
+    : State_(std::move(state))
+{ }
+
+void TGenericDescribeTableTransformer::FillCredentials(NConnector::NApi::TDescribeTableRequest& request,
+                                                       const TGenericClusterConfig& clusterConfig) {
+    auto dsi = request.mutable_data_source_instance();
+
+    // If login/password is provided, just copy them into request:
+    // connector will use Basic Auth to access external data sources.
+    if (clusterConfig.GetCredentials().Hasbasic()) {
+        *dsi->mutable_credentials() = clusterConfig.GetCredentials();
+        return;
+    }
+
+    // If there are no Basic Auth parameters, two options can be considered:
+    // 1. Client provided own IAM-token to access external data source
+    auto iamToken = State_->Types->Credentials->FindCredentialContent(
+        "default_" + clusterConfig.name(), "default_generic", clusterConfig.GetToken());
+    if (iamToken) {
+        *dsi->mutable_credentials()->mutable_token()->mutable_value() = iamToken;
+        *dsi->mutable_credentials()->mutable_token()->mutable_type() = "IAM";
+        return;
+    }
+
+    // 2. Client provided service account creds that must be converted into IAM-token
+    Y_ENSURE(State_->CredentialsFactory, "CredentialsFactory is not initialized");
+    auto structuredTokenJSON = TStructuredTokenBuilder()
+                                   .SetServiceAccountIdAuth(clusterConfig.GetServiceAccountId(),
+                                                            clusterConfig.GetServiceAccountIdSignature())
+                                   .ToJson();
+    Y_ENSURE(structuredTokenJSON, "empty structured token");
+
+    // Create provider or get existing one.
+    // It's crucial to reuse providers because their construction implies synchronous IO.
+    auto providersIt = State_->CredentialProviders.find(clusterConfig.name());
+    if (providersIt == State_->CredentialProviders.end()) {
+        auto credentialsProviderFactory = CreateCredentialsProviderFactoryForStructuredToken(
+            State_->CredentialsFactory, structuredTokenJSON, false);
+
+        providersIt =
+            State_->CredentialProviders
+                .emplace(clusterConfig.name(), credentialsProviderFactory->CreateProvider())
+                .first;
+    }
+
+    iamToken = providersIt->second->GetAuthInfo();
+    Y_ENSURE(iamToken, "empty IAM token");
+    *dsi->mutable_credentials()->mutable_token()->mutable_value() = iamToken;
+    *dsi->mutable_credentials()->mutable_token()->mutable_type() = "IAM";
+}
+
+template <typename T>
+void SetSchema(T& request, const TGenericClusterConfig& clusterConfig) {
+    TString schema;
+    const auto it = clusterConfig.GetDataSourceOptions().find("schema");
+    if (it != clusterConfig.GetDataSourceOptions().end()) {
+        schema = it->second;
+    }
+    if (!schema) {
+        schema = "public";
+    }
+    request.set_schema(schema);
+}
+
+void SetOracleServiceName(NYql::TOracleDataSourceOptions& options, const TGenericClusterConfig& clusterConfig) {
+    const auto it = clusterConfig.GetDataSourceOptions().find("service_name");
+    if (it != clusterConfig.GetDataSourceOptions().end()) {
+        options.set_service_name(it->second);
+    }
+}
+
+void SetLoggingFolderId(NYql::TLoggingDataSourceOptions& options, const TGenericClusterConfig& clusterConfig) {
+    const auto it = clusterConfig.GetDataSourceOptions().find("folder_id");
+    if (it != clusterConfig.GetDataSourceOptions().end()) {
+        options.set_folder_id(it->second);
+    }
+}
+
+TString GetIcebergOptionValue(const ::google::protobuf::Map<TProtoStringType,
+                             TProtoStringType>& options, TString option) {
+    auto it = options.find(option);
+    if (options.end() == it) {
+        throw yexception()
+            << "Cluster config for an Iceberg data source"
+            << " is missing option: "
+            << option;
+    }
+    return it->second;
+}
+
+///
+/// Fill options into DatSourceOptions specific for an iceberg data type
+///
+void SetIcebergOptions(NYql::TIcebergDataSourceOptions& dataSourceOptions, const TGenericClusterConfig& clusterConfig) {
+    using namespace NKikimr::NExternalSource::NIceberg;
+    const auto& clusterOptions = clusterConfig.GetDataSourceOptions();
+    auto warehouseType = GetIcebergOptionValue(clusterOptions, WAREHOUSE_TYPE);
+
+    if (VALUE_S3 != warehouseType) {
+        throw yexception() << "Unexpected warehouse type: " << warehouseType;
+    }
+
+    auto endpoint = GetIcebergOptionValue(clusterOptions, WAREHOUSE_S3_ENDPOINT);
+    auto region = GetIcebergOptionValue(clusterOptions, WAREHOUSE_S3_REGION);
+    auto uri = GetIcebergOptionValue(clusterOptions, WAREHOUSE_S3_URI);
+    auto& s3 = *dataSourceOptions.mutable_warehouse()->mutable_s3();
+
+    s3.set_endpoint(endpoint);
+    s3.set_region(region);
+    s3.set_uri(uri);
+
+    auto catalogType = GetIcebergOptionValue(clusterOptions, CATALOG_TYPE);
+    auto& catalog = *dataSourceOptions.mutable_catalog();
+
+    // set catalog options
+    if (VALUE_HADOOP == catalogType) {
+        // hadoop nothing yet
+        catalog.mutable_hadoop();
+    } else if (VALUE_HIVE_METASTORE == catalogType) {
+        auto uri = GetIcebergOptionValue(clusterOptions, CATALOG_HIVE_METASTORE_URI);
+         catalog.mutable_hive_metastore()->set_uri(uri);
+    } else {
+        throw yexception() << "Unexpected catalog type: " << catalogType;
+    }
+}
+
+TIssues SetMongoDBOptions(NYql::TMongoDbDataSourceOptions& options, const TGenericClusterConfig& clusterConfig) {
+    TIssues issues;
+    auto it = clusterConfig.GetDataSourceOptions().find("reading_mode");
+
+    if (it != clusterConfig.GetDataSourceOptions().end()) {
+        TMongoDbDataSourceOptions_EReadingMode value = TMongoDbDataSourceOptions::READING_MODE_UNSPECIFIED;
+        if (!TMongoDbDataSourceOptions_EReadingMode_Parse(it->second, &value)) {
+            issues.AddIssue(TIssue(TStringBuilder() << "Failed to parse MongoDB reading_mode: " << it->second));
+        }
+        options.set_reading_mode(value);
+    }
+
+    it = clusterConfig.GetDataSourceOptions().find("unexpected_type_display_mode");
+
+    if (it != clusterConfig.GetDataSourceOptions().end()) {
+        TMongoDbDataSourceOptions_EUnexpectedTypeDisplayMode value = TMongoDbDataSourceOptions::UNEXPECTED_UNSPECIFIED;
+        if (!TMongoDbDataSourceOptions_EUnexpectedTypeDisplayMode_Parse(it->second, &value)) {
+            issues.AddIssue(TIssue(TStringBuilder() << "Failed to parse MongoDB unexpected_type_display_mode: " << it->second));
+        }
+        options.set_unexpected_type_display_mode(value);
+    }
+
+    it = clusterConfig.GetDataSourceOptions().find("unsupported_type_display_mode");
+
+    if (it != clusterConfig.GetDataSourceOptions().end()) {
+        TMongoDbDataSourceOptions_EUnsupportedTypeDisplayMode value = TMongoDbDataSourceOptions::UNSUPPORTED_UNSPECIFIED;
+        if (!TMongoDbDataSourceOptions_EUnsupportedTypeDisplayMode_Parse(it->second, &value)) {
+            issues.AddIssue(TIssue(TStringBuilder() << "Failed to parse MongoDB unsupported_type_display_mode: " << it->second));
+        }
+        options.set_unsupported_type_display_mode(value);
+    }
+
+    return issues;
+}
+
+TIssues FillDataSourceOptions(NConnector::NApi::TDescribeTableRequest& request,
+                              const TGenericClusterConfig& clusterConfig) {
+    const auto dataSourceKind = clusterConfig.GetKind();
+
+    switch (dataSourceKind) {
+        case NYql::EGenericDataSourceKind::CLICKHOUSE:
+            break;
+        case NYql::EGenericDataSourceKind::YDB:
+            break;
+        case NYql::EGenericDataSourceKind::MYSQL:
+            break;
+        case NYql::EGenericDataSourceKind::GREENPLUM: {
+            auto* options = request.mutable_data_source_instance()->mutable_gp_options();
+            SetSchema(*options, clusterConfig);
+        } break;
+        case NYql::EGenericDataSourceKind::MS_SQL_SERVER:
+            break;
+        case NYql::EGenericDataSourceKind::POSTGRESQL: {
+            auto* options = request.mutable_data_source_instance()->mutable_pg_options();
+            SetSchema(*options, clusterConfig);
+        } break;
+        case NYql::EGenericDataSourceKind::ORACLE: {
+            auto* options = request.mutable_data_source_instance()->mutable_oracle_options();
+            SetOracleServiceName(*options, clusterConfig);
+        } break;
+        case NYql::EGenericDataSourceKind::LOGGING: {
+            auto* options = request.mutable_data_source_instance()->mutable_logging_options();
+            SetLoggingFolderId(*options, clusterConfig);
+        } break;
+        case NYql::EGenericDataSourceKind::ICEBERG: {
+            auto* options = request.mutable_data_source_instance()->mutable_iceberg_options();
+            SetIcebergOptions(*options, clusterConfig);
+        } break;
+        case NYql::EGenericDataSourceKind::REDIS:
+            break;
+        case NYql::EGenericDataSourceKind::PROMETHEUS:
+            break;
+        case NYql::EGenericDataSourceKind::MONGO_DB: {
+            auto* options = request.mutable_data_source_instance()->mutable_mongodb_options();
+            return SetMongoDBOptions(*options, clusterConfig);
+        } break;
+        case NYql::EGenericDataSourceKind::OPENSEARCH:
+            break; 
+        default:
+            throw yexception() << "Unexpected data source kind: '"
+                               << NYql::EGenericDataSourceKind_Name(dataSourceKind) << "'";
+    }
+
+    return TIssues{};
+}
+
+void FillTablePath(NConnector::NApi::TDescribeTableRequest& request, const TGenericClusterConfig& clusterConfig,
+                   const TString& tablePath) {
+    request.mutable_data_source_instance()->set_database(clusterConfig.GetDatabaseName());
+    request.set_table(tablePath);
+}
+
+void TGenericDescribeTableTransformer::FillTypeMappingSettings(NConnector::NApi::TDescribeTableRequest& request) {
+    const TString dateTimeFormat =
+        State_->Configuration->DateTimeFormat.Get().GetOrElse(TGenericSettings::TDefault::DateTimeFormat);
+
+    if (dateTimeFormat == "string") {
+        request.mutable_type_mapping_settings()->set_date_time_format(NConnector::NApi::STRING_FORMAT);
+    } else if (dateTimeFormat == "YQL") {
+        request.mutable_type_mapping_settings()->set_date_time_format(NConnector::NApi::YQL_FORMAT);
+    } else {
+        throw yexception() << "Unexpected date/time format: '" << dateTimeFormat << "'";
+    }
+}
+
+IGraphTransformer::TStatus TGenericDescribeTableTransformer::DoTransform(TExprNode::TPtr input,
+                                                                         TExprNode::TPtr& output,
+                                                                         TExprContext& ctx) {
+    output = input;
+
+    if (ctx.Step.IsDone(TExprStep::LoadTablesMetadata)) {
+        return TStatus::Ok;
+    }
+
+    const auto& reads = FindNodes(input, [&](const TExprNode::TPtr& node) {
+        if (const auto maybeRead = TMaybeNode<TGenRead>(node)) {
+            return maybeRead.Cast().DataSource().Category().Value() == GenericProviderName;
+        }
+        return false;
+    });
+
+    if (reads.empty()) {
+        return TStatus::Ok;
+    }
+
+    std::unordered_set<TTableDescriptionMap::key_type, TTableDescriptionMap::hasher> pendingRequests;
+
+    // Iterate over all read table queries in the input expression,
+    // create Describe requests for unique tables
+    for (const auto& r : reads) {
+        const TGenRead read(r);
+
+        if (!read.FreeArgs().Get(2).Ref().IsCallable("MrTableConcat")) {
+            ctx.AddError(TIssue(ctx.GetPosition(read.FreeArgs().Get(0).Pos()), "Expected key"));
+            return TStatus::Error;
+        }
+
+        const auto maybeKey = TExprBase(read.FreeArgs().Get(2).Ref().HeadPtr()).Maybe<TCoKey>();
+
+        if (!maybeKey) {
+            ctx.AddError(TIssue(ctx.GetPosition(read.FreeArgs().Get(0).Pos()), "Expected key"));
+            return TStatus::Error;
+        }
+
+        const auto& keyArg = maybeKey.Cast().Ref().Head();
+
+        if (!keyArg.IsList() || keyArg.ChildrenSize() != 2U || !keyArg.Head().IsAtom("table") ||
+            !keyArg.Tail().IsCallable(TCoString::CallableName())) {
+            ctx.AddError(TIssue(ctx.GetPosition(keyArg.Pos()), "Expected single table name"));
+            return TStatus::Error;
+        }
+
+        const auto clusterName = read.DataSource().Cluster().StringValue();
+        const auto tableName = TString(keyArg.Tail().Head().Content());
+        auto tableAddress = TGenericState::TTableAddress(clusterName, tableName);
+
+        // Table meta has already been acquired
+        if (State_->HasTable(tableAddress)) {
+            continue;
+        }
+
+        if (pendingRequests.insert(tableAddress).second) {
+            YQL_CLOG(INFO, ProviderGeneric) << "Describe table for: `" << tableAddress.ToString() << "`";
+        }
+    }
+
+    if (pendingRequests.empty()) {
+        return TStatus::Ok;
+    }
+
+    std::vector<NThreading::TFuture<void>> handles;
+    handles.reserve(pendingRequests.size());
+    TableDescriptions_.reserve(pendingRequests.size());
+
+    for (const auto& tableAddress : pendingRequests) {
+        auto tIssues = DescribeTableFromConnector(tableAddress, handles);
+
+        if (!tIssues.Empty()) {
+            ctx.AddError(TIssue(tIssues.ToString()));
+            return TStatus::Error;
+        }
+    }
+
+    if (handles.empty()) {
+        return TStatus::Ok;
+    }
+
+    AsyncFuture_ = NThreading::WaitExceptionOrAll(handles);
+    return TStatus::Async;
+}
+
+TIssues TGenericDescribeTableTransformer::DescribeTableFromConnector(const TGenericState::TTableAddress& tableAddress,
+                                                                     std::vector<NThreading::TFuture<void>>& handles) {
+    const auto it = State_->Configuration->ClusterNamesToClusterConfigs.find(tableAddress.ClusterName);
+
+    YQL_ENSURE(
+        State_->Configuration->ClusterNamesToClusterConfigs.cend() != it,
+        "cluster not found: " << tableAddress.ClusterName
+    );
+
+    // Preserve data source instance for the further usage
+    auto emplaceIt = TableDescriptions_.emplace(tableAddress, std::make_shared<TTableDescription>());
+    auto desc = emplaceIt.first->second;   
+    NConnector::NApi::TDescribeTableRequest request;
+    auto issues = FillDescribeTableRequest(request, it->second, tableAddress.TableName);
+
+    if (!issues.Empty()) {
+        return issues;
+    }
+
+    auto promise = NThreading::NewPromise();
+    handles.emplace_back(promise.GetFuture());
+    desc->DataSourceInstance = request.data_source_instance();
+
+    Y_ENSURE(State_->GenericClient);
+
+    State_->GenericClient->DescribeTable(request, State_->Configuration->DescribeTableTimeout).Subscribe(
+    [desc, tableAddress, promise, client = State_->GenericClient](const NConnector::TDescribeTableAsyncResult& f1) mutable {
+        NConnector::TDescribeTableAsyncResult f2(f1);
+        auto result = f2.ExtractValueSync();
+
+        // Check transport error
+        if (!result.Status.Ok()) {
+            desc->Issues.AddIssue(TStringBuilder()
+                << "Call DescribeTable for table " << tableAddress.ToString() << ": "
+                << result.Status.ToDebugString());
+            promise.SetValue();
+            return;
+        }
+
+        // Check logical error
+        if (!NConnector::IsSuccess(*result.Response)) {
+            desc->Issues.AddIssues(NConnector::ErrorToIssues(
+                result.Response->error(),
+                TStringBuilder() << "Call DescribeTable for table " << tableAddress.ToString() << ": "));
+            promise.SetValue();
+            return;
+        }
+
+        // Preserve schema for the further usage
+        desc->Schema = result.Response->schema();
+        promise.SetValue();
+    });
+
+    return {};
+}
+
+TIssues TGenericDescribeTableTransformer::FillDescribeTableRequest(NConnector::NApi::TDescribeTableRequest& request,
+                                                                   const TGenericClusterConfig& clusterConfig,
+                                                                   const TString& tablePath) {
+    const auto dataSourceKind = clusterConfig.GetKind();
+    auto dsi = request.mutable_data_source_instance();
+
+    *dsi->mutable_endpoint() = clusterConfig.GetEndpoint();
+    dsi->set_kind(dataSourceKind);
+    dsi->set_use_tls(clusterConfig.GetUseSsl());
+    dsi->set_protocol(clusterConfig.GetProtocol());
+
+    FillCredentials(request, clusterConfig);
+    FillTypeMappingSettings(request);
+
+    auto issues = FillDataSourceOptions(request, clusterConfig);
+
+    if (!issues.Empty()) {
+        return issues;
+    }
+
+    FillTablePath(request, clusterConfig, tablePath);
+    return {};
+}
+
+TIssues ParseTableMeta(
+    TExprContext& ctx,
+    const TPosition& pos,
+    const TGenericState::TTableAddress& tableAddress,
+    TGenericState::TTableMeta& tableMeta
+) try {
+    TVector<const TItemExprType*> items;
+
+    const auto& columns = tableMeta.Schema.columns();
+
+    if (columns.empty()) {
+        TIssues issues;
+        issues.AddIssue(TIssue(pos, TStringBuilder() << "Table " << tableAddress.ToString() << " doesn't exist."));
+        return issues;
+    }
+
+    for (const auto& column : columns) {
+        // Make type annotation
+        NYdb::TTypeParser parser(column.type());
+        auto typeAnnotation = NFq::MakeType(parser, ctx);
+
+        // Create items from graph
+        items.emplace_back(ctx.MakeType<TItemExprType>(column.name(), typeAnnotation));
+        tableMeta.ColumnOrder.emplace_back(column.name());
+    }
+
+    tableMeta.ItemType = ctx.MakeType<TStructExprType>(items);
+    return TIssues{};
+} catch (std::exception&) {
+    TIssues issues;
+    issues.AddIssue(TIssue(pos, TStringBuilder() << "Failed to parse table metadata: " << CurrentExceptionMessage()));
+    return issues;
+}
+
+TExprNode::TPtr MakeTableMetaNode(
+    TExprContext& ctx,
+    const TGenRead& read,
+    const TString& tableName
+) {
+    // clang-format off
+    auto row = Build<TCoArgument>(ctx, read.Pos())
+        .Name("row")
+        .Done();
+
+    auto emptyPredicate = Build<TCoLambda>(ctx, read.Pos())
+        .Args({row})
+        .Body<TCoBool>()
+            .Literal().Build("true")
+            .Build()
+        .Done().Ptr();
+
+    auto table = Build<TGenTable>(ctx, read.Pos())
+        .Name().Value(tableName).Build()
+        .Done();
+
+    return Build<TGenReadTable>(ctx, read.Pos())
+        .World(read.World())
+        .DataSource(read.DataSource())
+        .Table(table)
+        .Columns<TCoVoid>().Build()
+        .FilterPredicate(emptyPredicate)
+    .Done().Ptr();
+    // clang-format on
+}
+
+IGraphTransformer::TStatus TGenericDescribeTableTransformer::DoApplyAsyncChanges(TExprNode::TPtr input,
+                                                                                 TExprNode::TPtr& output,
+                                                                                 TExprContext& ctx) {
+    AsyncFuture_.GetValue();
+
+    const auto& reads = FindNodes(input, [&](const TExprNode::TPtr& node) {
+        if (const auto maybeRead = TMaybeNode<TGenRead>(node)) {
+            return maybeRead.Cast().DataSource().Category().Value() == GenericProviderName;
+        }
+        return false;
+    });
+
+    if (!reads.size()) {
+        return TStatus::Ok;
+    }
+
+    TNodeOnNodeOwnedMap replaces(reads.size());
+
+    // Iterate over all read table queries, check Connector responses
+    for (const auto& r : reads) {
+        const TGenRead genRead(r);
+        const auto clusterName = genRead.DataSource().Cluster().StringValue();
+        const auto& keyArg = TExprBase(genRead.FreeArgs().Get(2).Ref().HeadPtr()).Cast<TCoKey>().Ref().Head();
+        const auto tableName = TString(keyArg.Tail().Head().Content());
+        const TGenericState::TTableAddress tableAddress{clusterName, tableName};
+
+        // Find appropriate response
+        auto iter = TableDescriptions_.find(tableAddress);
+        if (iter == TableDescriptions_.end()) {
+            ctx.AddError(TIssue(ctx.GetPosition(genRead.Pos()), TStringBuilder()
+                << "Connector response not found for table "
+                << tableAddress.ToString()));
+
+            return TStatus::Error;
+        }
+
+        auto& result = iter->second;
+
+        // If errors occurred during network interaction with Connector, return them
+        if (result->Issues) {
+            for (const auto& issue : result->Issues) {
+                ctx.AddError(issue);
+            }
+
+            return TStatus::Error;
+        }
+
+        Y_ENSURE(result->Schema);
+
+        TGenericState::TTableMeta tableMeta;
+        tableMeta.Schema = *result->Schema;
+        tableMeta.DataSourceInstance = result->DataSourceInstance;
+
+        // Parse table schema
+        ParseTableMeta(ctx, ctx.GetPosition(genRead.Pos()), tableAddress, tableMeta);
+
+        // Fill AST for a table
+        if (const auto ins = replaces.emplace(genRead.Raw(), TExprNode::TPtr()); ins.second) {
+            ins.first->second = MakeTableMetaNode(ctx, genRead, tableName);
+        }
+
+        // Save table metadata into provider state
+        State_->AddTable(tableAddress, std::move(tableMeta));
+    }
+
+    return RemapExpr(input, output, replaces, ctx, TOptimizeExprSettings(nullptr));
+}
+
+void TGenericDescribeTableTransformer::Rewind() {
+    TableDescriptions_.clear();
+    AsyncFuture_ = {};
+}
+
+THolder<IGraphTransformer> CreateGenericDescribeTableTransformer(TGenericState::TPtr state) {
+    return MakeHolder<TGenericDescribeTableTransformer>(std::move(state));
+}
+
+} // NYql

--- a/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.h
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <yql/essentials/core/yql_graph_transformer.h>
+#include "yql_generic_state.h"
+
+namespace NYql {
+
+THolder<IGraphTransformer> CreateGenericDescribeTableTransformer(TGenericState::TPtr state);
+
+} // namespace NYql

--- a/ydb/library/yql/providers/generic/provider/yql_generic_dq_integration.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_dq_integration.cpp
@@ -239,20 +239,6 @@ namespace NYql {
                 auto select = source.mutable_select();
                 FillSelect(*select, dqSource, ctx);
                 
-                // TODO: remove this block as soon as the first part YQ-4730 is deployed
-                //
-                // Iceberg/Managed YDB (including YDB underlying Logging) supports access via IAM token.
-                // If exists, copy service account creds to obtain tokens during request execution phase.
-                // If exists, copy previously created token.
-                if (IsIn({NYql::EGenericDataSourceKind::YDB, NYql::EGenericDataSourceKind::LOGGING, NYql::EGenericDataSourceKind::ICEBERG}, clusterConfig.kind())) {
-                    source.SetServiceAccountId(clusterConfig.GetServiceAccountId());
-                    source.SetServiceAccountIdSignature(clusterConfig.GetServiceAccountIdSignature());
-                    source.SetToken(State_->Types->Credentials->FindCredentialContent(
-                    "default_" + clusterConfig.name(),
-                    "default_generic",
-                    clusterConfig.GetToken()));
-                }
-
                 // We set token name to the protobuf message that will be received
                 // by the read actor during the execution phase.
                 // It will use token name to extract credentials from the secureParams.
@@ -384,20 +370,6 @@ namespace NYql {
                 Generic::TLookupSource source;
                 source.set_table(tableName);
                 *source.mutable_data_source_instance() = tableMeta->DataSourceInstance;
-
-                // TODO: remove this block as soon as first part YQ-4730 is deployed
-                //
-                // Managed YDB supports access via IAM token.
-                // If exist, copy service account creds to obtain tokens during request execution phase.
-                // If exists, copy previously created token.
-                if (clusterConfig.kind() == NYql::EGenericDataSourceKind::YDB) {
-                    source.SetServiceAccountId(clusterConfig.GetServiceAccountId());
-                    source.SetServiceAccountIdSignature(clusterConfig.GetServiceAccountIdSignature());
-                    source.SetToken(State_->Types->Credentials->FindCredentialContent(
-                        "default_" + clusterConfig.name(),
-                        "default_generic",
-                        clusterConfig.GetToken()));
-                }
 
                 // We set token name to the protobuf message that will be received
                 // by the lookup actor during the execution phase.

--- a/ydb/library/yql/providers/generic/provider/yql_generic_list_splits.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_list_splits.cpp
@@ -1,0 +1,342 @@
+#include "yql_generic_list_splits.h"
+
+#include <yql/essentials/utils/log/log.h>
+#include <yql/essentials/providers/common/structured_token/yql_token_builder.h>
+#include <yql/essentials/providers/common/provider/yql_provider.h>
+#include <yql/essentials/providers/common/provider/yql_provider_names.h>
+#include <yql/essentials/minikql/mkql_type_ops.h>
+#include <yql/essentials/minikql/mkql_program_builder.h>
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/minikql/computation/mkql_computation_node.h>
+#include <yql/essentials/minikql/comp_nodes/mkql_factories.h>
+#include <yql/essentials/core/yql_graph_transformer.h>
+#include <yql/essentials/core/yql_expr_optimize.h>
+#include <yql/essentials/core/type_ann/type_ann_expr.h>
+#include <yql/essentials/core/expr_nodes/yql_expr_nodes.h>
+#include <yql/essentials/ast/yql_type_string.h>
+#include <yql/essentials/ast/yql_expr.h>
+#include <ydb/library/yql/providers/generic/provider/yql_generic_utils.h>
+#include <ydb/library/yql/providers/generic/provider/yql_generic_predicate_pushdown.h>
+#include <ydb/library/yql/providers/generic/expr_nodes/yql_generic_expr_nodes.h>
+#include <ydb/library/yql/providers/generic/connector/libcpp/error.h>
+#include <ydb/library/yql/providers/generic/connector/libcpp/client.h>
+#include <ydb/library/yql/dq/expr_nodes/dq_expr_nodes.h>
+#include <ydb/core/fq/libs/result_formatter/result_formatter.h>
+#include <ydb/core/external_sources/iceberg_fields.h>
+#include <library/cpp/json/json_reader.h>
+
+namespace NYql {
+
+using namespace NNodes;
+using namespace NKikimr;
+using namespace NKikimr::NMiniKQL;
+
+///
+/// Optimization process contains several transformers in a pipeline which are called
+/// consequently. If a DoTransform returns repeat, e.g. it changes expression, the process
+/// is starting again from the very begining, but with a new input. That is why transformer
+/// can be called multiple times. The purpose of this transformer is to find TGenSourceSettings
+/// nodes which were created during previous transformations and perform ListSplit request.
+/// ListSplit transformer has to work after where clause has been pushed; otherwise
+/// in a ReadSplit request, which ultimately occurs after pushdown, connector could receive
+/// where clause that is differ from ListSplit's.
+///
+/// The order of transformations calls:
+///
+/// 1. TGenericPhysicalOptProposalTransformer::PushFilterToReadTable pushdowns predicate into
+///    a TGenReadTable node.
+///
+/// 2. TKqpConstantFoldingTransformer folds const expression in a pushdown predicate.
+///
+/// 3. TGenericListSplitTransformer performs a ListSplit request on a TGenSourceSettings node.
+///
+class TGenericListSplitTransformer : public TGraphTransformerBase {
+    struct TListSplitRequestData {
+        TSelectKey Key;
+        NConnector::NApi::TSelect Select;
+        TGenericState::TTableAddress TableAddress;
+    };
+
+    struct TListResponse {
+        using TPtr = std::shared_ptr<TListResponse>;
+
+        std::vector<NConnector::NApi::TSplit> Splits;
+        TIssues Issues;
+    };
+
+    using TListResponseMap =
+        std::unordered_map<TSelectKey, TListResponse::TPtr, TSelectKeyHash>;
+
+public:
+    explicit TGenericListSplitTransformer(TGenericState::TPtr state);
+
+public:
+    TStatus DoTransform(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) final;
+
+    NThreading::TFuture<void> DoGetAsyncFuture(const TExprNode&) final {
+        return AsyncFuture_;
+    }
+
+    TStatus DoApplyAsyncChanges(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) final;
+
+    void Rewind() final;
+
+private:
+    TIssues ListSplitsFromConnector(const TListSplitRequestData& data, std::vector<NThreading::TFuture<void>>& handles);
+
+private:
+    const TGenericState::TPtr State_;
+    TListResponseMap ListResponses_;
+    NThreading::TFuture<void> AsyncFuture_;
+};
+
+TGenericListSplitTransformer::TGenericListSplitTransformer(TGenericState::TPtr state)
+    : State_(std::move(state))
+{ }
+
+IGraphTransformer::TStatus TGenericListSplitTransformer::DoTransform(TExprNode::TPtr input,
+                                                                     TExprNode::TPtr& output,
+                                                                     TExprContext& ctx) {
+    output = input;
+
+    const auto& readsSettings = FindNodes(input, [&](const TExprNode::TPtr& node) {
+        if (const auto maybeSettings = TMaybeNode<TGenSourceSettings>(node)) {
+            return true;
+        }
+        
+        return false;
+    });
+
+    if (readsSettings.empty()) {
+        return TStatus::Ok;
+    }
+
+    std::unordered_map<TSelectKey, TListSplitRequestData, TSelectKeyHash> pendingRequests;
+
+    // Iterate over all settings in the input expression, create ListSplit request if needed
+    for (const auto& r : readsSettings) {
+        const TGenSourceSettings settings(r);
+
+        const auto& tableName = settings.Table().StringValue();
+        const auto& clusterName = settings.Cluster().StringValue();
+
+        auto tableAddress = TGenericState::TTableAddress(clusterName, tableName);
+        auto table = State_->GetTable(tableAddress);
+
+        if (!table.first) {
+            ctx.AddError(TIssue(table.second.ToString()));
+            return TStatus::Error;
+        }
+
+        // Grab select from a read table query
+        NConnector::NApi::TSelect select;
+        FillSelectFromGenSourceSettings(select, settings, ctx, table.first);
+
+        auto selectKey = tableAddress.MakeKeyFor(select);
+
+        // The one sql query could contain multiple selects, e.g.
+        // join, subquery etc. If splits has been already acquired for a
+        // select, skip it
+        if (table.first->HasSplitsForSelect(selectKey)) {
+            continue;
+        }
+
+        auto v = TListSplitRequestData{selectKey, std::move(select), tableAddress};
+        pendingRequests.emplace(selectKey, v);
+    }
+
+    if (pendingRequests.empty()) {
+        return TStatus::Ok;
+    }
+
+    std::vector<NThreading::TFuture<void>> handles;
+    handles.reserve(pendingRequests.size());
+    ListResponses_.reserve(pendingRequests.size());
+
+    for (auto& k : pendingRequests) {
+        auto tIssues = ListSplitsFromConnector(k.second, handles);
+        if (!tIssues.Empty()) {
+            ctx.AddError(TIssue(tIssues.ToString()));
+            return TStatus::Error;
+        }
+    }
+
+    if (handles.empty()) {
+        return TStatus::Ok;
+    }
+
+    AsyncFuture_ = NThreading::WaitExceptionOrAll(handles);
+    return TStatus::Async;
+}
+
+TIssues TGenericListSplitTransformer::ListSplitsFromConnector(const TListSplitRequestData& data,
+                                                              std::vector<NThreading::TFuture<void>>& handles) {
+    auto table = State_->GetTable(data.TableAddress);
+
+    if (!table.first) {
+        return table.second;
+    }
+
+    // Preserve data source instance for the further usage
+    auto emplaceIt = ListResponses_.emplace(data.Key, std::make_shared<TListResponse>());
+    auto desc = emplaceIt.first->second;
+
+    // Call ListSplits
+    NConnector::NApi::TListSplitsRequest request;
+    *request.mutable_selects()->Add() = data.Select;
+
+    auto promise = NThreading::NewPromise();
+    handles.emplace_back(promise.GetFuture());
+
+    Y_ENSURE(State_->GenericClient);
+
+    State_->GenericClient->ListSplits(request).Subscribe([desc, promise, data]
+        (const NConnector::TListSplitsStreamIteratorAsyncResult f3) mutable {
+        NConnector::TListSplitsStreamIteratorAsyncResult f4(f3);
+        auto streamIterResult = f4.ExtractValueSync();
+
+        // Check transport error
+        if (!streamIterResult.Status.Ok()) {
+            desc->Issues.AddIssue(TStringBuilder()
+                << "Call ListSplits for table: " << data.TableAddress.ToString()
+                << " with select: " << streamIterResult.Status.ToDebugString());
+            promise.SetValue();
+            return;
+        }
+
+        Y_ENSURE(streamIterResult.Iterator);
+
+        auto drainer =
+            NConnector::MakeListSplitsStreamIteratorDrainer(std::move(streamIterResult.Iterator));
+
+        // Pass drainer to the callback because we want him to stay alive until the callback is called
+        drainer->Run().Subscribe([desc, promise, data, drainer]
+            (const NThreading::TFuture<NConnector::TListSplitsStreamIteratorDrainer::TBuffer>& f5) mutable {
+            NThreading::TFuture<NConnector::TListSplitsStreamIteratorDrainer::TBuffer> f6(f5);
+            auto drainerResult = f6.ExtractValueSync();
+
+            // check transport and logical errors
+            if (drainerResult.Issues) {
+                auto msg = TStringBuilder()
+                    << "Call ListSplits for table: " << data.TableAddress.ToString() << " with select: "
+                    << data.Select.what().DebugString()
+                    << data.Select.from().DebugString()
+                    << data.Select.where().DebugString();
+
+                TIssue dstIssue(msg);
+
+                for (const auto& srcIssue : drainerResult.Issues) {
+                    dstIssue.AddSubIssue(MakeIntrusive<TIssue>(srcIssue));
+                }
+
+                desc->Issues.AddIssue(std::move(dstIssue));
+                promise.SetValue();
+                return;
+            }
+
+            // Collect all the splits from every response into a single vector
+            for (auto&& response : drainerResult.Responses) {
+                std::transform(std::make_move_iterator(response.mutable_splits()->begin()),
+                               std::make_move_iterator(response.mutable_splits()->end()),
+                               std::back_inserter(desc->Splits),
+                               [](auto&& split) { return std::move(split); });
+            }
+
+            promise.SetValue();
+        });
+    });
+
+    return TIssues();
+}
+
+IGraphTransformer::TStatus TGenericListSplitTransformer::DoApplyAsyncChanges(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) {
+    AsyncFuture_.GetValue();
+    output = input;
+
+    /* 
+     * Search for a TGenSourceSettings. TGenSourceSettings contains the same data as during
+     * DoTransform method call
+     */
+    const auto& readsSettings = FindNodes(input, [&](const TExprNode::TPtr& node) {
+        if (const auto maybeSettings = TMaybeNode<TGenSourceSettings>(node)) {
+            return true;
+        }
+
+        return false;
+    });
+
+    if (readsSettings.empty()) {
+        return TStatus::Ok;
+    }
+
+    // Iterate over all settings in the input expression, check Connector responses
+    for (const auto& r : readsSettings) {
+        const TGenSourceSettings settings(r);
+
+        const auto& tableName = settings.Table().StringValue();
+        const auto& clusterName = settings.Cluster().StringValue();
+
+        auto tableAddress = TGenericState::TTableAddress(clusterName, tableName);
+        auto table = State_->GetTable(tableAddress);
+
+        if (!table.first) {
+            ctx.AddError(TIssue(table.second.ToString()));
+            return TStatus::Error;
+        }
+
+        // Grab select from a read table query
+        NConnector::NApi::TSelect select;
+        FillSelectFromGenSourceSettings(select, settings, ctx, table.first);
+        auto selectKey = tableAddress.MakeKeyFor(select);
+
+        // If splits for a similar select for this table was created skip it
+        if (table.first->HasSplitsForSelect(selectKey)) {
+            continue;
+        }
+
+        // Find appropriate response
+        auto iter = ListResponses_.find(selectKey);
+
+        if (iter == ListResponses_.end()) {
+            auto msg = TStringBuilder()
+                << "Connector response not found for table: " << tableAddress.ToString() << " and select: "
+                << select.what().DebugString()
+                << select.from().DebugString()
+                << select.where().DebugString();
+
+            ctx.AddError(TIssue(ctx.GetPosition(settings.Pos()), msg));
+            return TStatus::Error;
+        }
+
+        auto& result = iter->second;
+
+        // If errors occurred during network interaction with Connector, return them
+        if (result->Issues) {
+            for (const auto& issue : result->Issues) {
+                ctx.AddError(issue);
+            }
+
+            return TStatus::Error;
+        }
+
+        Y_ENSURE(!result->Splits.empty());
+
+        if (auto issue = State_->AttachSplitsToTable(tableAddress, selectKey, result->Splits); issue) {
+            ctx.AddError(*issue);
+            return TStatus::Error;
+        }
+    }
+
+    return TStatus::Ok;
+}
+
+void TGenericListSplitTransformer::Rewind() {
+    ListResponses_.clear();
+    AsyncFuture_ = {};
+}
+
+THolder<TGraphTransformerBase> CreateGenericListSplitTransformer(TGenericState::TPtr state) {
+    return MakeHolder<TGenericListSplitTransformer>(std::move(state));
+}
+
+} // NYql

--- a/ydb/library/yql/providers/generic/provider/yql_generic_list_splits.h
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_list_splits.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <yql/essentials/core/yql_graph_transformer.h>
+#include "yql_generic_state.h"
+
+namespace NYql {
+
+THolder<TGraphTransformerBase> CreateGenericListSplitTransformer(TGenericState::TPtr state);
+
+} // NYql

--- a/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
@@ -1,5 +1,6 @@
 // clang-format off
 #include "yql_generic_provider_impl.h"
+#include "yql_generic_describe_table.h"
 
 #include <library/cpp/json/json_reader.h>
 #include <ydb/core/fq/libs/result_formatter/result_formatter.h>
@@ -27,7 +28,7 @@ namespace NYql {
     using namespace NKikimr;
     using namespace NKikimr::NMiniKQL;
 
-    class TGenericLoadTableMetadataTransformer: public TGraphTransformerBase {
+    class [[deprecated("Now this transformer is represented by two transformers, it will be removed in the next version")]] TGenericLoadTableMetadataTransformer: public TGraphTransformerBase {
         struct TTableDescription {
             using TPtr = std::shared_ptr<TTableDescription>;
 
@@ -635,7 +636,7 @@ namespace NYql {
     };
 
     THolder<IGraphTransformer> CreateGenericLoadTableMetadataTransformer(TGenericState::TPtr state) {
-        return MakeHolder<TGenericLoadTableMetadataTransformer>(std::move(state));
+        return CreateGenericDescribeTableTransformer(state);
     }
 
 } // namespace NYql

--- a/ydb/library/yql/providers/generic/provider/yql_generic_state.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_state.cpp
@@ -1,12 +1,87 @@
 #include "yql_generic_state.h"
+#include <ydb/library/yql/providers/generic/connector/libcpp/utils.h>
+#include <ydb/library/yql/providers/generic/provider/yql_generic_utils.h>
 
 namespace NYql {
+    std::vector<TString> GetColumns(const NConnector::NApi::TSelect& select) {
+        std::vector<TString> columns;
+
+        if (select.has_what() && !select.what().items().empty()) {
+            columns.reserve(select.what().items().size());
+
+            for (const auto& item : select.what().items()) {
+                if (!item.column().name().empty()) {
+                    columns.push_back(item.column().name());
+                }
+            }
+
+            std::sort(columns.begin(), columns.end());
+        }
+
+        return columns;
+    }
+
+    TSelectKey::TSelectKey(const TString& cluster, const NConnector::NApi::TSelect& select)
+        : Cluster(cluster)
+        , Table(select.has_from() ? select.from().table() : "")
+        , Columns(GetColumns(select))
+        , Where(select.has_where() && select.where().has_filter_typed() ?
+            select.where().filter_typed().SerializeAsString() : "")
+        , Hash(CalculateHash())
+    { }
+
+    size_t TSelectKey::CalculateHash() const {
+        auto hash = CombineHashes(std::hash<TString>()(Cluster), std::hash<TString>()(Table));
+        hash = CombineHashes(hash, std::hash<TString>()(Where));
+
+        for (const auto& col : Columns) {
+            hash = CombineHashes(hash, std::hash<TString>()(col));
+        }
+
+        return hash;
+    }
+
+    TGenericState::TTableAddress::operator size_t() const {
+        return CombineHashes(std::hash<TString>()(ClusterName), std::hash<TString>()(TableName));
+    }
+
+    TSelectKey TGenericState::TTableAddress::MakeKeyFor(const NConnector::NApi::TSelect& select) const {
+        return TSelectKey(ClusterName, select);
+    }
+
+    bool TGenericState::TTableMeta::HasSplitsForSelect(const TSelectKey& key) const {
+        return SelectSplits.contains(key);
+    }
+
+    void TGenericState::TTableMeta::AttachSplitsForSelect(const TSelectKey& key, std::vector<NYql::NConnector::NApi::TSplit>& splits) {
+        Y_ENSURE(splits.size());
+        Y_ENSURE(SelectSplits.emplace(key, std::move(splits)).second);
+    }
+
+    const std::vector<NYql::NConnector::NApi::TSplit>& TGenericState::TTableMeta::GetSplitsForSelect(
+        const TSelectKey& key) const {
+        const auto it = SelectSplits.find(key);
+
+        if (it == SelectSplits.end()) {
+            throw yexception()
+                << "Table metadata does not contain splits for a select from the table: " << key.Table
+                << " with where:" << key.Where;
+        }
+
+        return it->second;
+    }
+
+    bool TGenericState::HasTable(const TTableAddress& tableAddress) {
+        return Tables_.contains(tableAddress);
+    }
+
     void TGenericState::AddTable(const TTableAddress& tableAddress, TTableMeta&& tableMeta) {
         Tables_.emplace(tableAddress, std::move(tableMeta));
     }
 
     TGenericState::TGetTableResult TGenericState::GetTable(const TTableAddress& tableAddress) const {
         auto result = Tables_.FindPtr(tableAddress);
+
         if (result) {
             return std::make_pair(result, TIssues{});
         }
@@ -15,6 +90,19 @@ namespace NYql {
         issues.AddIssue(TIssue(TStringBuilder() << "no metadata for table " << tableAddress.ToString()));
 
         return std::make_pair<TTableMeta*, TIssues>(nullptr, std::move(issues));
+    }
+
+    std::optional<TIssue> TGenericState::AttachSplitsToTable(const TTableAddress& tableAddress,
+                                                             const TSelectKey& key,
+                                                             std::vector<NYql::NConnector::NApi::TSplit>& splits) {
+        auto result = Tables_.FindPtr(tableAddress);
+
+        if (!result) {
+            return {TIssue(TStringBuilder() << "no metadata for table " << tableAddress.ToString())};
+        }
+
+        result->AttachSplitsForSelect(key, splits);
+        return std::nullopt;
     }
 
 } // namespace NYql

--- a/ydb/library/yql/providers/generic/provider/yql_generic_utils.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_utils.cpp
@@ -1,6 +1,8 @@
 #include "yql_generic_utils.h"
 
 #include <util/string/builder.h>
+#include <ydb/library/yql/providers/generic/connector/libcpp/utils.h>
+#include <ydb/library/yql/providers/generic/provider/yql_generic_predicate_pushdown.h>
 
 namespace NYql {
     TString DumpGenericClusterConfig(const TGenericClusterConfig& clusterConfig) {
@@ -19,4 +21,40 @@ namespace NYql {
 
         return sb;
     }
+
+    ///
+    /// Fill a select from a TGenSourceSettings
+    ///
+    void FillSelectFromGenSourceSettings(NConnector::NApi::TSelect& select,
+                                         const NNodes::TGenSourceSettings& settings,
+                                         TExprContext& ctx,
+                                         const TGenericState::TTableMeta* tableMeta) {
+        const auto& tableName = settings.Table().StringValue();
+
+        select.mutable_from()->set_table(TString(tableName));
+        *select.mutable_data_source_instance() = tableMeta->DataSourceInstance;
+
+        const auto& columns = settings.Columns();
+        auto items = select.mutable_what()->mutable_items();
+
+        for (size_t i = 0; i < columns.Size(); i++) {
+            // assign column name
+            auto column = items->Add()->mutable_column();
+            auto columnName = columns.Item(i).StringValue();
+            column->mutable_name()->assign(columnName);
+
+            // assign column type
+            auto type = NConnector::GetColumnTypeByName(tableMeta->Schema, columnName);
+            *column->mutable_type() = type;
+        }
+
+        if (auto predicate = settings.FilterPredicate(); !IsEmptyFilterPredicate(predicate)) {
+            TStringBuilder err;
+
+            if (!SerializeFilterPredicate(ctx, predicate, select.mutable_where()->mutable_filter_typed(), err)) {
+                throw yexception() << "Failed to serialize filter predicate for source: " << err;
+            }
+        }
+    }
+
 } // namespace NYql

--- a/ydb/library/yql/providers/generic/provider/yql_generic_utils.h
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_utils.h
@@ -1,8 +1,16 @@
 #pragma once
 
-#include <yql/essentials/providers/common/proto/gateways_config.pb.h>
-#include <yql/essentials/providers/common/proto/gateways_config.pb.h>
+#include <ydb/library/yql/providers/generic/expr_nodes/yql_generic_expr_nodes.h>
+#include <ydb/library/yql/providers/generic/provider/yql_generic_state.h>
 
 namespace NYql {
     TString DumpGenericClusterConfig(const TGenericClusterConfig& clusterConfig);
+
+    ///
+    /// Fill a select from a TGenSourceSettings
+    ///
+    void FillSelectFromGenSourceSettings(NConnector::NApi::TSelect& select,
+                                         const NNodes::TGenSourceSettings& settings,
+                                         TExprContext& ctx,
+                                         const TGenericState::TTableMeta* tableMeta);
 } // namespace NYql

--- a/ydb/public/api/protos/ydb_scheme.proto
+++ b/ydb/public/api/protos/ydb_scheme.proto
@@ -68,7 +68,7 @@ message Entry {
         RESOURCE_POOL = 21;
         TRANSFER = 23;
         SYS_VIEW = 24;
-        STREAMING_QUERY = 25;
+        STREAMING_QUERY = 26;
     }
 
     // Name of scheme entry (dir2 of /dir1/dir2)

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
@@ -13,6 +13,8 @@ using namespace NScheme;
 using namespace NTable;
 using namespace NTopic;
 
+namespace {
+
 TStatus RemoveDirectory(TSchemeClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
     return RetryFunction([&]() -> TStatus {
         return client.RemoveDirectory(path, settings).ExtractValueSync();
@@ -79,11 +81,17 @@ TStatus RemoveReplication(NQuery::TQueryClient& client, const TString& path, con
     return DropSchemeObject("ASYNC REPLICATION", client, path, settings);
 }
 
+TStatus RemoveStreamingQuery(NQuery::TQueryClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
+    return DropSchemeObject("STREAMING QUERY", client, path, settings);
+}
+
 NYdb::NIssue::TIssues MakeIssues(const TString& error) {
     NYdb::NIssue::TIssues issues;
     issues.AddIssue(NYdb::NIssue::TIssue(error));
     return issues;
 }
+
+} // anonymous namespace
 
 bool Prompt(const TString& path, ESchemeEntryType type) {
     Cout << "Remove " << to_lower(ToString(type)) << " '" << path << "' (y/n)? ";
@@ -167,6 +175,8 @@ TStatus Remove(
         return TStatus(EStatus::SUCCESS, {});
     case ESchemeEntryType::Replication:
         return Remove(&RemoveReplication, schemeClient, queryClient, type, path, prompt, settings);
+    case ESchemeEntryType::StreamingQuery:
+        return Remove(&RemoveStreamingQuery, schemeClient, queryClient, type, path, prompt, settings);
 
     default:
         return TStatus(EStatus::UNSUPPORTED, MakeIssues(TStringBuilder()

--- a/ydb/tests/fq/streaming/conftest.py
+++ b/ydb/tests/fq/streaming/conftest.py
@@ -1,11 +1,13 @@
 import os
 import logging
 
+from ydb.tests.library.common.types import Erasure
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 import ydb
 import yatest.common
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -30,33 +32,32 @@ class YdbClient:
         return self.session_pool.execute_with_retries_async(statement)
 
 
-class StreamingImportTestBase(object):
-    @classmethod
-    def setup_class(cls):
-        cls._setup_ydb()
+@pytest.fixture(scope="function")
+def kikimr(request):
 
-    @classmethod
-    def teardown_class(cls):
-        cls.ydb_client.stop()
-        cls.cluster.stop()
+    class Kikimr:
+        def __init__(self, client, cluster):
+            self.YdbClient = client
+            self.Cluster = cluster
 
-    @classmethod
-    def _get_ydb_config(cls):
+    def get_ydb_config():
         config = KikimrConfigGenerator(
+            erasure=Erasure.MIRROR_3_DC,
             extra_feature_flags={
                 "enable_external_data_sources": True,
                 "enable_streaming_queries": True
             },
             query_service_config={"available_external_data_sources": ["Ydb"]},
             table_service_config={},
-            nodes=2,
-            default_clusteradmin="root@builtin"
+            default_clusteradmin="root@builtin",
+            use_in_memory_pdisks=False
         )
 
         config.yaml_config["log_config"]["default_level"] = 8
 
         query_service_config = config.yaml_config.setdefault("query_service_config", {})
         query_service_config["available_external_data_sources"] = ["ObjectStorage", "Ydb", "YdbTopics"]
+        query_service_config["enable_match_recognize"] = True
 
         database_connection = query_service_config.setdefault("streaming_queries", {}).setdefault("external_storage", {}).setdefault("database_connection", {})
         database_connection["endpoint"] = os.getenv("YDB_ENDPOINT")
@@ -64,18 +65,23 @@ class StreamingImportTestBase(object):
 
         return config
 
-    @classmethod
-    def _setup_ydb(cls):
-        ydb_path = yatest.common.build_path(os.environ.get("YDB_DRIVER_BINARY"))
-        logger.info(yatest.common.execute([ydb_path, "-V"], wait=True).stdout.decode("utf-8"))
+    ydb_path = yatest.common.build_path(os.environ.get("YDB_DRIVER_BINARY"))
+    logger.info(yatest.common.execute([ydb_path, "-V"], wait=True).stdout.decode("utf-8"))
 
-        config = cls._get_ydb_config()
-        cls.cluster = KiKiMR(config)
-        cls.cluster.start()
+    os.environ["YDB_TEST_DEFAULT_CHECKPOINTING_PERIOD_MS"] = "200"
+    os.environ["YDB_TEST_LEASE_DURATION_SEC"] = "5"
 
-        node = cls.cluster.nodes[1]
-        cls.ydb_client = YdbClient(
-            database=f"/{config.domain_name}",
-            endpoint=f"grpc://{node.host}:{node.port}"
-        )
-        cls.ydb_client.wait_connection()
+    config = get_ydb_config()
+    cluster = KiKiMR(config)
+    cluster.start()
+
+    node = cluster.nodes[1]
+    ydb_client = YdbClient(
+        database=f"/{config.domain_name}",
+        endpoint=f"grpc://{node.host}:{node.port}"
+    )
+    ydb_client.wait_connection()
+
+    yield Kikimr(ydb_client, cluster)
+    ydb_client.stop()
+    cluster.stop()

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -1,59 +1,105 @@
 import logging
 import os
 import time
+import random
+import string
 
-from ydb.tests.fq.streaming.base import StreamingImportTestBase
+from ydb.tests.tools.fq_runner.kikimr_runner import plain_or_under_sanitizer_wrapper
+
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
+from ydb.tests.tools.fq_runner.kikimr_metrics import load_metrics
 
 logger = logging.getLogger(__name__)
 
 
-class TestStreamingInYdb(StreamingImportTestBase, TestYdsBase):
+class TestStreamingInYdb(TestYdsBase):
 
-    def test_read_topic(self):
-        self.init_topics("test_read_topic", create_output=False)
-
-        self.ydb_client.query(f"""
-            CREATE EXTERNAL DATA SOURCE `sourceName1` WITH (
+    def create_source(self, kikimr, sourceName, shared=False):
+        kikimr.YdbClient.query(f"""
+            CREATE EXTERNAL DATA SOURCE `{sourceName}` WITH (
                 SOURCE_TYPE="Ydb",
                 LOCATION="{os.getenv("YDB_ENDPOINT")}",
                 DATABASE_NAME="{os.getenv("YDB_DATABASE")}",
-                SHARED_READING="FALSE",
+                SHARED_READING="{shared}",
                 AUTH_METHOD="NONE");""")
 
-        sql = f"""SELECT time FROM sourceName1.`{self.input_topic}`
+    def monitoring_endpoint(self, kikimr, node_id=None):
+        node = kikimr.Cluster.nodes[node_id]
+        return f"http://localhost:{node.mon_port}"
+
+    def get_sensors(self, kikimr, node_id, counters):
+        url = self.monitoring_endpoint(kikimr, node_id) + "/counters/counters={}/json".format(counters)
+        return load_metrics(url)
+
+    def get_checkpoint_coordinator_metric(self, kikimr, query_id, metric_name, expect_counters_exist=False):
+        sum = 0
+        found = False
+        for node_id in kikimr.Cluster.nodes:
+            sensor = self.get_sensors(kikimr, node_id, "kqp").find_sensor(
+                {
+                    # "query_id": query_id,  # TODO
+                    "subsystem": "checkpoint_coordinator",
+                    "sensor": metric_name
+                }
+            )
+            if sensor is not None:
+                found = True
+                sum += sensor
+        assert found or not expect_counters_exist
+        return sum
+
+    def get_completed_checkpoints(self, kikimr, query_id):
+        return self.get_checkpoint_coordinator_metric(kikimr, query_id, "CompletedCheckpoints")
+
+    def wait_completed_checkpoints(self, kikimr, query_id,
+                                   timeout=plain_or_under_sanitizer_wrapper(120, 150)):
+        current = self.get_checkpoint_coordinator_metric(kikimr, query_id, "CompletedCheckpoints")
+        checkpoints_count = current + 2
+        deadline = time.time() + timeout
+        while True:
+            completed = self.get_completed_checkpoints(kikimr, query_id)
+            if completed >= checkpoints_count:
+                break
+            assert time.time() < deadline, "Wait checkpoint failed, actual completed: " + str(completed)
+            time.sleep(plain_or_under_sanitizer_wrapper(0.5, 2))
+
+    def get_actor_count(self, kikimr, node_id, activity):
+        result = self.get_sensors(kikimr, node_id, "utils").find_sensor(
+            {"activity": activity, "sensor": "ActorsAliveByActivity", "execpool": "User"})
+        return result if result is not None else 0
+
+    def test_read_topic(self, kikimr):
+        sourceName = "test_read_topic" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        self.init_topics(sourceName, create_output=False)
+
+        self.create_source(kikimr, sourceName, False)
+        sql = f"""SELECT time FROM {sourceName}.`{self.input_topic}`
             WITH (
                 FORMAT="json_each_row",
                 SCHEMA=(time String NOT NULL))
             LIMIT 1"""
 
-        future = self.ydb_client.query_async(sql)
+        future = kikimr.YdbClient.query_async(sql)
         time.sleep(1)
         data = ['{"time": "lunch time"}']
         self.write_stream(data)
         result_sets = future.result()
         assert result_sets[0].rows[0]['time'] == b'lunch time'
 
-    def test_read_topic_shared_reading_limit(self):
-        self.init_topics("test_read_topic_shared_reading", create_output=False, partitions_count=10)
+    def test_read_topic_shared_reading_limit(self, kikimr):
+        sourceName = "test_read_topic_shared_reading_limit" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        self.init_topics(sourceName, create_output=False, partitions_count=10)
 
-        self.ydb_client.query(f"""
-            CREATE EXTERNAL DATA SOURCE `sourceName2` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION="{os.getenv("YDB_ENDPOINT")}",
-                DATABASE_NAME="{os.getenv("YDB_DATABASE")}",
-                SHARED_READING="TRUE",
-                AUTH_METHOD="NONE");""")
-
-        sql = f"""SELECT time FROM sourceName2.`{self.input_topic}`
+        self.create_source(kikimr, sourceName, True)
+        sql = f"""SELECT time FROM {sourceName}.`{self.input_topic}`
             WITH (
                 FORMAT="json_each_row",
                 SCHEMA=(time String NOT NULL))
             WHERE time like "%lunch%"
             LIMIT 1"""
 
-        future1 = self.ydb_client.query_async(sql)
-        future2 = self.ydb_client.query_async(sql)
+        future1 = kikimr.YdbClient.query_async(sql)
+        future2 = kikimr.YdbClient.query_async(sql)
         time.sleep(3)
         data = ['{"time": "lunch time"}']
         self.write_stream(data)
@@ -62,16 +108,50 @@ class TestStreamingInYdb(StreamingImportTestBase, TestYdsBase):
         assert result_sets1[0].rows[0]['time'] == b'lunch time'
         assert result_sets2[0].rows[0]['time'] == b'lunch time'
 
-    def test_read_topic_shared_reading_insert_to_topic(self):
-        sourceName = "source3"
+    def test_restart_query(self, kikimr):
+        sourceName = "test_restart_query" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
         self.init_topics(sourceName, partitions_count=10)
-        self.ydb_client.query(f"""
-            CREATE EXTERNAL DATA SOURCE `{sourceName}` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION="{os.getenv("YDB_ENDPOINT")}",
-                DATABASE_NAME="{os.getenv("YDB_DATABASE")}",
-                SHARED_READING="TRUE",
-                AUTH_METHOD="NONE");""")
+        self.create_source(kikimr, sourceName, False)
+
+        name = "query1"
+        sql = R'''
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                $in = SELECT time FROM {source_name}.`{input_topic}`
+                WITH (
+                    FORMAT="json_each_row",
+                    SCHEMA=(time String NOT NULL))
+                WHERE time like "%lunch%";
+                INSERT INTO {source_name}.`{output_topic}` SELECT time FROM $in;
+            END DO;'''
+
+        query_id = "query_id"  # TODO
+        kikimr.YdbClient.query(sql.format(query_name=name, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+        data = ['{"time": "lunch time"}']
+        expected_data = ['lunch time']
+        self.write_stream(data)
+
+        assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+        kikimr.YdbClient.query(f"ALTER STREAMING QUERY `{name}` SET (RUN = FALSE);")
+        time.sleep(0.5)
+
+        data = ['{"time": "next lunch time"}']
+        expected_data = ['next lunch time']
+        self.write_stream(data)
+
+        kikimr.YdbClient.query(f"ALTER STREAMING QUERY `{name}` SET (RUN = TRUE);")
+        assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
+
+        kikimr.YdbClient.query(f"DROP STREAMING QUERY `{name}`;")
+
+    def test_read_topic_shared_reading_insert_to_topic(self, kikimr):
+        sourceName = "source3_" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        self.init_topics(sourceName, partitions_count=10)
+        self.create_source(kikimr, sourceName, True)
 
         sql = R'''
             CREATE STREAMING QUERY `{query_name}` AS
@@ -84,14 +164,134 @@ class TestStreamingInYdb(StreamingImportTestBase, TestYdsBase):
                 INSERT INTO {source_name}.`{output_topic}` SELECT time FROM $in;
             END DO;'''
 
-        self.ydb_client.query(sql.format(query_name="query1", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-        self.ydb_client.query(sql.format(query_name="query2", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-        time.sleep(3)
+        kikimr.YdbClient.query(sql.format(query_name="query1", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        kikimr.YdbClient.query(sql.format(query_name="query2", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+
+        query_id = "query_id"  # TODO
+        self.wait_completed_checkpoints(kikimr, query_id)
+
         data = ['{"time": "lunch time"}']
         expected_data = ['lunch time', 'lunch time']
         self.write_stream(data)
         assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+        sql = R'''ALTER STREAMING QUERY `{query_name}` SET (RUN = FALSE);'''
+        kikimr.YdbClient.query(sql.format(query_name="query1"))
+        kikimr.YdbClient.query(sql.format(query_name="query2"))
+
+        time.sleep(1)
+
+        data = ['{"time": "next lunch time"}']
+        expected_data = ['next lunch time', 'next lunch time']
+        self.write_stream(data)
+
+        sql = R'''ALTER STREAMING QUERY `{query_name}` SET (RUN = TRUE);'''
+        kikimr.YdbClient.query(sql.format(query_name="query1"))
+        kikimr.YdbClient.query(sql.format(query_name="query2"))
+        assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
 
         sql = R'''DROP STREAMING QUERY `{query_name}`;'''
-        self.ydb_client.query(sql.format(query_name="query1"))
-        self.ydb_client.query(sql.format(query_name="query2"))
+        kikimr.YdbClient.query(sql.format(query_name="query1"))
+        kikimr.YdbClient.query(sql.format(query_name="query2"))
+
+    def test_read_topic_shared_reading_restart_nodes(self, kikimr):
+        sourceName = "source_" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        self.init_topics(sourceName, partitions_count=1)
+        self.create_source(kikimr, sourceName, True)
+
+        sql = R'''
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                $in = SELECT value FROM {source_name}.`{input_topic}`
+                WITH (
+                    FORMAT="json_each_row",
+                    SCHEMA=(value String NOT NULL))
+                WHERE value like "%value%";
+                INSERT INTO {source_name}.`{output_topic}` SELECT value FROM $in;
+            END DO;'''
+
+        kikimr.YdbClient.query(sql.format(query_name="query1", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        query_id = "query_id"  # TODO
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+        self.write_stream(['{"value": "value1"}'])
+        expected_data = ['value1']
+        assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+        restart_node_id = None
+        for node_id in kikimr.Cluster.nodes:
+            count = self.get_actor_count(kikimr, node_id, "DQ_PQ_READ_ACTOR")
+            if count:
+                restart_node_id = node_id
+
+        logging.debug(f"Restart node {restart_node_id}")
+        node = kikimr.Cluster.nodes[restart_node_id]
+        node.stop()
+        node.start()
+
+        self.write_stream(['{"value": "value2"}'])
+        expected_data = ['value2']
+        assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+    def test_read_topic_restore_state(self, kikimr):
+        sourceName = "source4_" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        self.init_topics(sourceName, partitions_count=1)
+        self.create_source(kikimr, sourceName, True)
+        sql = R'''
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                pragma FeatureR010="prototype";
+                PRAGMA DisableAnsiInForEmptyOrNullableItemsCollections;
+
+                $in = SELECT * FROM {source_name}.`{input_topic}`
+                    WITH (
+                        FORMAT="json_each_row",
+                        SCHEMA=(dt UINT64, str STRING));
+                $mr = SELECT * FROM $in
+                    MATCH_RECOGNIZE(
+                        MEASURES
+                        LAST(A.dt) as a_time,
+                        LAST(B.dt) as b_time,
+                        LAST(C.dt) as c_time
+                        ONE ROW PER MATCH
+                        AFTER MATCH SKIP TO NEXT ROW
+                        PATTERN ( ( A | B ) ( B | C ) )
+                        DEFINE
+                            A as A.str='A',
+                            B as B.str='B',
+                            C as C.str='C');
+                INSERT INTO {source_name}.`{output_topic}`
+                    SELECT ToBytes(Unwrap(Json::SerializeJson(Yson::From(TableRow())))) FROM $mr;
+            END DO;'''
+
+        kikimr.YdbClient.query(sql.format(query_name="query1", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        query_id = "query_id"  # TODO
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+        data = [
+            '{"dt": 1696849942000001, "str": "A" }',
+            '{"dt": 1696849942500001, "str": "B" }'
+        ]
+        self.write_stream(data)
+        expected_data = ['{"a_time":1696849942000001,"b_time":1696849942500001,"c_time":null}']
+        assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+        restart_node_id = None
+        for node_id in kikimr.Cluster.nodes:
+            count = self.get_actor_count(kikimr, node_id, "DQ_PQ_READ_ACTOR")
+            if count:
+                restart_node_id = node_id
+
+        logging.debug(f"Restart node {restart_node_id}")
+        node = kikimr.Cluster.nodes[restart_node_id]
+        node.stop()
+        node.start()
+
+        data = ['{"dt": 1696849943000001, "str": "C" }']
+        self.write_stream(data)
+        expected_data = ['{"a_time":null,"b_time":1696849942500001,"c_time":1696849943000001}']
+        assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data

--- a/ydb/tests/fq/streaming/ya.make
+++ b/ydb/tests/fq/streaming/ya.make
@@ -7,7 +7,7 @@ TEST_SRCS(
 )
 
 PY_SRCS(
-    base.py
+    conftest.py
 )
 
 SIZE(MEDIUM)

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -560,11 +560,14 @@ private:
 private:
     void FillQueryRequest(const TRequestOptions& query, NKikimrKqp::EQueryType type, ui32 targetNodeIndex, NKikimrKqp::TEvQueryRequest& event) {
         event.SetTraceId(query.TraceId);
-        event.SetUserToken(NACLib::TUserToken(
-            Settings_.YqlToken,
-            query.UserSID,
-            query.GroupSIDs ? *query.GroupSIDs : TVector<NACLib::TSID>{GetRuntime()->GetAppData(targetNodeIndex).AllAuthenticatedUsers}
-        ).SerializeAsString());
+
+        if (query.UserSID) {
+            event.SetUserToken(NACLib::TUserToken(
+                Settings_.YqlToken,
+                query.UserSID,
+                query.GroupSIDs ? *query.GroupSIDs : TVector<NACLib::TSID>{GetRuntime()->GetAppData(targetNodeIndex).AllAuthenticatedUsers}
+            ).SerializeAsString());
+        }
 
         const auto& database = GetDatabasePath(query.Database);
         auto request = event.MutableRequest();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Features and fixes for streaming 3

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

* YQ-4859 fixed streaming queries creation without user token (#28193)
* YQ-4852 fixed token passing for SLJ (#28157)
* YQ-4411 Streaming queries: local checkpoints (#26749)
* YQ-4853 fixed checkpoints event undelivery logging (#28170)
* YQ-4856 added default stats refresh period  for streaming queries (#28173)
* YQ-4854 fixed streaming query not changed after create or replace (#28171)
* YQ-4855 improved session actor logs on query fail (#28172)
* YQ-4847 fixed uncaught exception in external sources explain (#28099)
* YDB FQ: avoid storing secrets in proto messages (#27762)
* Move listsplit after physical opt (#22085)
* YQ-4844 supported recursive drop of directory with stream queries (#28059)
* YQ-4735  Shared reading: skipping json errors (#27401)
* YQ-4534 Fix describe federated logbroker (#26327)
* YQ-4824 fixed external entity check by database id (#27654)
