### PR TITLE
EXT-1662 Add feature flag to use PutUserData for external blobs

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -238,5 +238,6 @@ message TFeatureFlags {
     optional bool EnableTopicMessageLevelParallelism = 212 [default = false];
     optional bool EnableOlapRejectProbability = 213 [default = false];
     optional bool EnablePDiskLogForSmallDisks = 214 [default = false];
-    optional bool DisableMissingDefaultColumnsInBulkUpsert = 215 [default = true];
+    optional bool DisableMissingDefaultColumnsInBulkUpsert = 215 [default = false];
+    optional bool EnableExternalBlobPutUserDataHandleClass = 216 [default = false];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -238,6 +238,6 @@ message TFeatureFlags {
     optional bool EnableTopicMessageLevelParallelism = 212 [default = false];
     optional bool EnableOlapRejectProbability = 213 [default = false];
     optional bool EnablePDiskLogForSmallDisks = 214 [default = false];
-    optional bool DisableMissingDefaultColumnsInBulkUpsert = 215 [default = false];
+    optional bool DisableMissingDefaultColumnsInBulkUpsert = 215 [default = true];
     optional bool EnableExternalBlobPutUserDataHandleClass = 216 [default = false];
 }

--- a/ydb/core/tablet/tablet_req_writelog.cpp
+++ b/ydb/core/tablet/tablet_req_writelog.cpp
@@ -1,5 +1,6 @@
 #include "tablet_impl.h"
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/base/feature_flags.h>
 #include <ydb/core/tablet/tablet_metrics.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
@@ -171,7 +172,8 @@ public:
         // todo: adaptive save-with-retry and timeouts
         // todo: cancelation
 
-        const auto handleClass = NKikimrBlobStorage::TabletLog;
+        const auto handleClass = AppData()->FeatureFlags.GetEnableExternalBlobPutUserDataHandleClass() ? NKikimrBlobStorage::UserData : NKikimrBlobStorage::TabletLog;
+    
         for (const auto &ref : References) {
             NWilson::TTraceId innerTraceId;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Add `EnableExternalBlobPutUserDataHandleClass` to use PutUserData for external blobs

### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
