### PR TITLE
Docs: TxCompleteLag in partition_stats

### DIFF
--- a/ydb/docs/en/core/dev/system-views.md
+++ b/ydb/docs/en/core/dev/system-views.md
@@ -47,6 +47,7 @@ Table structure:
 | `CoordinatedTxCompleted` | Number of completed [distributed transactions](../concepts/glossary.md#transactions). | `Uint64` | Cumulative |
 | `TxRejectedByOverload` | Number of transactions cancelled due to [overload](../troubleshooting/performance/queries/overloaded-errors.md). | `Uint64` | Cumulative |
 | `TxRejectedByOutOfStorage` | Number of transactions cancelled due to lack of storage space. | `Uint64` | Cumulative |
+| `TxCompleteLag` | Transaction execution delay (how much transactions lag behind their scheduled time). | `Interval` | Instant |
 | `LastTtlRunTime` | Launch time of the last TTL erasure procedure | `Timestamp` | Instant |
 | `LastTtlRowsProcessed` | Number of rows checked during the last TTL erasure procedure | `Uint64` | Instant |
 | `LastTtlRowsErased` | Number of rows deleted during the last TTL erasure procedure | `Uint64` | Instant |

--- a/ydb/docs/ru/core/dev/system-views.md
+++ b/ydb/docs/ru/core/dev/system-views.md
@@ -47,6 +47,7 @@
 | `CoordinatedTxCompleted` | Количество завершившихся [распределенных транзакций](../concepts/glossary.md#transactions). | `Uint64` | Кумулятивная |
 | `TxRejectedByOverload` | Количество транзакций, отменённых по причине [высокой нагрузки](../troubleshooting/performance/queries/overloaded-errors.md). | `Uint64` | Кумулятивная |
 | `TxRejectedByOutOfStorage` | Количество транзакций, отменённых из-за нехватки места в хранилище. | `Uint64` | Кумулятивная |
+| `TxCompleteLag` | Задержка выполнения транзакций (насколько транзакции отстают от запланированного времени). | `Interval` | Моментальная |
 | `LastTtlRunTime` | Последний момент запуска очистки партиции по TTL | `Timestamp` | Моментальная |
 | `LastTtlRowsProcessed` | Количество проверенных строк партиции при последней очистке по TTL | `Uint64` | Моментальная |
 | `LastTtlRowsErased` | Количество удалённых строк партиции при последней очистке по TTL | `Uint64` | Моментальная |


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

New column `TxCompleteLag` in system view `partition_stats`

### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

#28281