### PR TITLE
[Backport stable-25-2] Use default value of BufferPageAllocSize from proto

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -221,6 +221,9 @@ std::unique_ptr<TEvKqpNode::TEvStartKqpTasksRequest> TKqpPlanner::SerializeReque
         if (ArrayBufferMinFillPercentage) {
             serializedTask->SetArrayBufferMinFillPercentage(*ArrayBufferMinFillPercentage);
         }
+        if (BufferPageAllocSize) {
+            serializedTask->SetBufferPageAllocSize(*BufferPageAllocSize);
+        }
         request.AddTasks()->Swap(serializedTask);
     }
 


### PR DESCRIPTION
# Description

Backport of https://github.com/ydb-platform/ydb/pull/28237 to stable-25-2.