### PR TITLE
Fix flaky KMeans tests 

### DIFF
--- a/ydb/core/tx/datashard/build_index/ut/ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_local_kmeans.cpp
@@ -161,7 +161,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
     static void DropTable(Tests::TServer::TPtr server, TActorId sender, const TString& name)
     {
         ui64 txId = AsyncDropTable(server, sender, "/Root", name);
-        WaitTxNotification(server, sender, txId);
+        WaitTxNotification(server, txId);
     }
 
     static void CreateMainTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options)

--- a/ydb/core/tx/datashard/build_index/ut/ut_prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_prefix_kmeans.cpp
@@ -163,7 +163,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
     static void DropTable(Tests::TServer::TPtr server, TActorId sender, const TString& name)
     {
         ui64 txId = AsyncDropTable(server, sender, "/Root", name);
-        WaitTxNotification(server, sender, txId);
+        WaitTxNotification(server, txId);
     }
 
     static void CreatePrefixTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options)

--- a/ydb/core/tx/datashard/build_index/ut/ut_reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_reshuffle_kmeans.cpp
@@ -145,7 +145,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardReshuffleKMeansScan) {
     static void DropTable(Tests::TServer::TPtr server, TActorId sender, const char* name)
     {
         ui64 txId = AsyncDropTable(server, sender, "/Root", name);
-        WaitTxNotification(server, sender, txId);
+        WaitTxNotification(server, txId);
     }
 
     static void CreateMainTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This version allocates a fresh edge actor for each wait operation, ensuring proper isolation of transaction completion notifications.
Previously there could be event queue conflicts when dropping multiple tables in a loop.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Closes: #28002