### PR TITLE
Typo in RandomPointsAndRanges  test

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_order.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_order.cpp
@@ -942,7 +942,7 @@ public:
         }
 
         Ranges.reserve(numRanges);
-        for (ui32 i = 0; i < numPoints; ++i) {
+        for (ui32 i = 0; i < numRanges; ++i) {
             ui32 from = RandomNumber<ui32>(max);
             Ranges.emplace_back(TSimpleRange(from, from + 1 + RandomNumber<ui32>(maxRange-1)));
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The test was calling Generate(numWrites, numReads, numRanges) with parameters up to (50, 50, 50), and the bug caused it to generate numPoints (numReads) ranges instead of numRanges ranges. This meant that instead of generating the intended number of ranges, it was generating ranges based on the second parameter. In worst-case test variants like {400, 50, 50, 50}, this could create significantly more database operations per transaction, causing the test to exceed the 600-second timeout.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
