### PR TITLE
25-3: Renamed table should be present in partiton_stats (#28331)

### DIFF
--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -30,6 +30,17 @@ using namespace NTestUtils;
 
 namespace {
 
+void FillRootTable(TTestEnv& env, ui16 tableNum = 0) {
+    TTableClient client(env.GetDriver());
+    auto session = client.CreateSession().GetValueSync().GetSession();
+    NKqp::AssertSuccessResult(session.ExecuteDataQuery(Sprintf(R"(
+        REPLACE INTO `Root/Table%u` (Key, Value) VALUES
+            (0u, "X"),
+            (1u, "Y"),
+            (2u, "Z");
+    )", tableNum), TTxControl::BeginTx().CommitTx()).GetValueSync());
+}
+
 void CreateRootTable(TTestEnv& env, ui64 partitionCount = 1, bool fillTable = false, ui16 tableNum = 0) {
     env.GetClient().CreateTable("/Root", Sprintf(R"(
         Name: "Table%u"
@@ -39,16 +50,23 @@ void CreateRootTable(TTestEnv& env, ui64 partitionCount = 1, bool fillTable = fa
         UniformPartitionsCount: %lu
     )", tableNum, partitionCount));
 
-    if (fillTable) {
-        TTableClient client(env.GetDriver());
-        auto session = client.CreateSession().GetValueSync().GetSession();
-        NKqp::AssertSuccessResult(session.ExecuteDataQuery(R"(
-            REPLACE INTO `Root/Table0` (Key, Value) VALUES
-                (0u, "X"),
-                (1u, "Y"),
-                (2u, "Z");
-        )", TTxControl::BeginTx().CommitTx()).GetValueSync());
-    }
+    if (fillTable)
+        FillRootTable(env, tableNum);
+}
+
+void CreateRootColumnTable(TTestEnv& env, ui64 partitionCount = 1, bool fillTable = false, ui16 tableNum = 0) {
+    NQuery::TQueryClient client(env.GetDriver());
+    auto result = client.ExecuteQuery(Sprintf(R"(
+        CREATE TABLE `/Root/Table%u` (
+            Key Int32 NOT NULL,
+            Value Utf8,
+            PRIMARY KEY(Key)
+        ) WITH (STORE=COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %lu);
+    )", tableNum, partitionCount), NQuery::TTxControl::NoTx()).GetValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+    if (fillTable)
+        FillRootTable(env, tableNum);
 }
 
 void BreakLock(TSession& session, const TString& tableName) {
@@ -2646,68 +2664,27 @@ R"(CREATE TABLE `test_show_create` (
         check.Uint64(1u); // LastTtlRowsProcessed
         check.Uint64(1u); // LastTtlRowsErased
     }
-    
-    Y_UNIT_TEST(PartitionStatsAfterRemoveColumnTable) {
-        TTestEnv env;
-        NQuery::TQueryClient client(env.GetDriver());
-        
-        {
-            auto result = client.ExecuteQuery(R"(
-                CREATE TABLE `/Root/test_table` (
-                    key int not null,
-                    value utf8,
-                    PRIMARY KEY(key)
-                ) WITH (STORE=COLUMN);
-            )", NQuery::TTxControl::NoTx()).GetValueSync();
-            
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        }
-        
-        {
-            auto result = client.ExecuteQuery(R"(
-                SELECT Path FROM `/Root/.sys/partition_stats`
-                GROUP BY Path;
-            )", NQuery::TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-            auto parser = result.GetResultSetParser(0);
-            bool existsPath = false;
-            while (parser.TryNextRow()) {
-                auto path = parser.ColumnParser("Path").GetOptionalUtf8();
-                UNIT_ASSERT(path);
-                if (*path == "/Root/test_table") {
-                    existsPath = true;
-                    break;
-                }
-            }
-            UNIT_ASSERT_C(existsPath, "Path /Root/test_table not found");
-        }
-        
-        {
-            auto result = client.ExecuteQuery(R"(
-                DROP TABLE `/Root/test_table`
-            )", NQuery::TTxControl::NoTx()).GetValueSync();
-            
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        }
-        
-        {
-            auto result = client.ExecuteQuery(R"(
-                SELECT Path FROM `/Root/.sys/partition_stats`
-                GROUP BY Path;
-            )", NQuery::TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-            auto parser = result.GetResultSetParser(0);
-            bool existsPath = false;
-            while (parser.TryNextRow()) {
-                auto path = parser.ColumnParser("Path").GetOptionalUtf8();
-                UNIT_ASSERT(path);
-                if (*path == "/Root/test_table") {
-                    existsPath = true;
-                    break;
-                }
-            }
-            UNIT_ASSERT_C(!existsPath, "Path /Root/test_table found");
-        }
+
+    Y_UNIT_TEST_TWIN(PartitionStatsAfterDropTable, UseColumnTable) {
+        TTestEnv env({.DataShardStatsReportIntervalSeconds = 0});
+        if (UseColumnTable)
+            CreateRootColumnTable(env);
+        else
+            CreateRootTable(env);
+
+        TTableClient client(env.GetDriver());
+
+        WaitForStats(client, "/Root/.sys/partition_stats", "Path = '/Root/Table0'");
+
+        auto session = client.CreateSession().GetValueSync().GetSession();
+        auto result = session.ExecuteSchemeQuery(R"(
+            DROP TABLE `Root/Table0`;
+        )").GetValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+        // Verify Table0 is removed from partition_stats
+        auto table0Count = GetRowCount(client, "/Root/.sys/partition_stats", "Path = '/Root/Table0'");
+        UNIT_ASSERT_VALUES_EQUAL(table0Count, 0);
     }
 
     Y_UNIT_TEST(PartitionStatsLocksFields) {
@@ -2736,6 +2713,34 @@ R"(CREATE TABLE `test_show_create` (
         check.Uint64(1); // LocksAcquired
         check.Uint64(0); // LocksWholeShard
         check.Uint64(1); // LocksBroken
+    }
+
+    Y_UNIT_TEST_TWIN(PartitionStatsAfterRenameTable, UseColumnTable) {
+        TTestEnv env({.DataShardStatsReportIntervalSeconds = 0});
+        if (UseColumnTable)
+            CreateRootColumnTable(env);
+        else
+            CreateRootTable(env);
+
+        TTableClient client(env.GetDriver());
+        auto session = client.CreateSession().GetValueSync().GetSession();
+
+        WaitForStats(client, "/Root/.sys/partition_stats", "Path = '/Root/Table0'");
+
+        auto result = session.ExecuteSchemeQuery(R"(
+            ALTER TABLE `Root/Table0` RENAME TO `Root/Table1`;
+        )").GetValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+        WaitForStats(client, "/Root/.sys/partition_stats", "Path = '/Root/Table1'");
+
+        // Verify Table0 is no longer in partition_stats
+        auto table0Count = GetRowCount(client, "/Root/.sys/partition_stats", "Path = '/Root/Table0'");
+        UNIT_ASSERT_VALUES_EQUAL(table0Count, 0);
+
+        // Verify Table1 exists in partition_stats
+        auto table1Count = GetRowCount(client, "/Root/.sys/partition_stats", "Path = '/Root/Table1'");
+        UNIT_ASSERT_VALUES_EQUAL(table1Count, 1);
     }
 
     Y_UNIT_TEST(PartitionStatsFields) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -184,7 +184,7 @@ void MarkSrcDropped(NIceDb::TNiceDb& db,
         context.SS->Tables.at(srcPath->PathId)->DetachShardsStats();
         context.SS->PersistRemoveTable(db, srcPath->PathId, context.Ctx);
     } else if (srcPath->IsColumnTable()) {
-        context.SS->PersistColumnTableRemove(db, srcPath->PathId, context.Ctx);
+        context.SS->PersistColumnTableRemove(db, srcPath->PathId);
     }
     context.SS->PersistUserAttributes(db, srcPath->PathId, srcPath->UserAttrs, nullptr);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Create table
```
CREATE TABLE table1
SELECT * FROM `.sys/partition_stats` WHERE Path like '%table1' -- is OK.
```
Rename table
```
ALTER TABLE table1 RENAME TO table2
SELECT * FROM `.sys/partition_stats` WHERE Path like '%table2' -- is empty. But should be OK
```

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

#28331
