### PR TITLE
25-3-1: UI-QUERY-EXCLUDE for metadata queries (#28155)

### DIFF
--- a/ydb/services/metadata/ds_table/accessor_snapshot_base.cpp
+++ b/ydb/services/metadata/ds_table/accessor_snapshot_base.cpp
@@ -126,6 +126,7 @@ void TDSAccessorBase::StartSnapshotsFetchingImpl() {
     Y_ABORT_UNLESS(managers.size());
     CurrentExistence = ExistenceChecks;
     TStringBuilder sb;
+    sb << "/*UI-QUERY-EXCLUDE*/" << Endl;
     for (auto&& i : managers) {
         auto it = CurrentExistence.find(i->GetStorageTablePath());
         Y_ABORT_UNLESS(it != CurrentExistence.end());

--- a/ydb/services/metadata/manager/table_record.cpp
+++ b/ydb/services/metadata/manager/table_record.cpp
@@ -222,6 +222,7 @@ Ydb::Table::ExecuteDataQueryRequest TTableRecords::BuildSelectQuery(const TStrin
     Ydb::Table::ExecuteDataQueryRequest result;
     TStringBuilder sb;
     sb << "--!syntax_v1\n";
+    sb << "/*UI-QUERY-EXCLUDE*/" << Endl;
     sb << "DECLARE $ids AS List<" << BuildColumnsSchemaTuple() << ">;" << Endl;
     sb << "SELECT * FROM `" + tablePath + "`" << Endl;
     if (GetColumnIds().size() > 1) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The goal is to remove spam like `SELECT * FROM .metadata/initialization/migrations` from UI Top Queries

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

#28155
