### PR TITLE
merge to stable-25-3 YQ-4312 features and fixes for streaming 4

### DIFF
--- a/ydb/core/external_sources/object_storage.cpp
+++ b/ydb/core/external_sources/object_storage.cpp
@@ -272,6 +272,10 @@ struct TObjectStorageExternalSource : public IExternalSource {
                 continue;
             }
 
+            if (key == "skip.json.errors"sv) {
+                continue;
+            }
+
             if (matchAllSettings) {
                 issues.AddIssue(MakeErrorIssue(Ydb::StatusIds::BAD_REQUEST, "unknown format setting " + key));
             }

--- a/ydb/core/fq/libs/config/protos/row_dispatcher.proto
+++ b/ydb/core/fq/libs/config/protos/row_dispatcher.proto
@@ -23,7 +23,6 @@ message TJsonParserConfig {
     uint64 BatchSizeBytes = 1;  // default 1 MiB
     uint64 BatchCreationTimeoutMs = 2;
     uint64 BufferCellCount = 3;  // (number rows) * (number columns) limit, default 10^6
-    bool SkipErrors = 4;
 }
 
 message TCompileServiceConfig {

--- a/ydb/core/fq/libs/row_dispatcher/common/row_dispatcher_settings.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/common/row_dispatcher_settings.cpp
@@ -9,7 +9,6 @@ namespace NFq {
 
 TRowDispatcherSettings::TJsonParserSettings::TJsonParserSettings(const NConfig::TJsonParserConfig& config)
     : BatchCreationTimeout(TDuration::MilliSeconds(config.GetBatchCreationTimeoutMs()))
-    , SkipErrors(config.GetSkipErrors())
 {
     if (config.GetBatchSizeBytes()) {
         BatchSizeBytes = config.GetBatchSizeBytes();

--- a/ydb/core/fq/libs/row_dispatcher/common/row_dispatcher_settings.h
+++ b/ydb/core/fq/libs/row_dispatcher/common/row_dispatcher_settings.h
@@ -33,7 +33,6 @@ public:
         YDB_ACCESSOR(ui64, BatchSizeBytes, 1_MB);
         YDB_ACCESSOR(TDuration, BatchCreationTimeout, TDuration::Seconds(1));
         YDB_ACCESSOR(ui64, BufferCellCount, 1000'000);
-        YDB_ACCESSOR(bool, SkipErrors, false);
     };
 
     class TCompileServiceSettings {

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
@@ -678,10 +678,10 @@ ITopicFormatHandler::TPtr CreateTopicFormatHandler(const NActors::TActorContext&
     return ITopicFormatHandler::TPtr(handler);
 }
 
-TFormatHandlerConfig CreateFormatHandlerConfig(const TRowDispatcherSettings& rowDispatcherConfig, const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry, NActors::TActorId compileServiceId) {
+TFormatHandlerConfig CreateFormatHandlerConfig(const TRowDispatcherSettings& rowDispatcherConfig, const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry, NActors::TActorId compileServiceId, bool skipJsonErrors) {
     return {
         .FunctionRegistry = functionRegistry,
-        .JsonParserConfig = CreateJsonParserConfig(rowDispatcherConfig.GetJsonParser(), functionRegistry),
+        .JsonParserConfig = CreateJsonParserConfig(rowDispatcherConfig.GetJsonParser(), functionRegistry, skipJsonErrors),
         .FiltersConfig = {
             .CompileServiceId = compileServiceId
         }

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.h
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.h
@@ -78,7 +78,7 @@ struct TFormatHandlerConfig {
 };
 
 ITopicFormatHandler::TPtr CreateTopicFormatHandler(const NActors::TActorContext& owner, const TFormatHandlerConfig& config, const ITopicFormatHandler::TSettings& settings, const TCountersDesc& counters);
-TFormatHandlerConfig CreateFormatHandlerConfig(const TRowDispatcherSettings& rowDispatcherConfig, const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry, NActors::TActorId compileServiceId);
+TFormatHandlerConfig CreateFormatHandlerConfig(const TRowDispatcherSettings& rowDispatcherConfig, const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry, NActors::TActorId compileServiceId, bool skipJsonErrors);
 
 namespace NTests {
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.cpp
@@ -735,13 +735,13 @@ TValueStatus<ITopicParser::TPtr> CreateJsonParser(IParsedDataConsumer::TPtr cons
     return ITopicParser::TPtr(parser);
 }
 
-TJsonParserConfig CreateJsonParserConfig(const TRowDispatcherSettings::TJsonParserSettings& parserConfig, const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry) {
+TJsonParserConfig CreateJsonParserConfig(const TRowDispatcherSettings::TJsonParserSettings& parserConfig, const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry, bool skipErrors) {
     return {
         .FunctionRegistry = functionRegistry,
         .BatchSize = parserConfig.GetBatchSizeBytes(),
         .LatencyLimit = parserConfig.GetBatchCreationTimeout(),
         .BufferCellCount = parserConfig.GetBufferCellCount(),
-        .SkipErrors = parserConfig.GetSkipErrors()
+        .SkipErrors = skipErrors
     };
 }
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.h
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/parsers/json_parser.h
@@ -21,6 +21,6 @@ struct TJsonParserConfig {
 };
 
 TValueStatus<ITopicParser::TPtr> CreateJsonParser(IParsedDataConsumer::TPtr consumer, const TJsonParserConfig& config, const TCountersDesc& counters);
-TJsonParserConfig CreateJsonParserConfig(const TRowDispatcherSettings::TJsonParserSettings& parserConfig, const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry);
+TJsonParserConfig CreateJsonParserConfig(const TRowDispatcherSettings::TJsonParserSettings& parserConfig, const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry, bool skipErrors);
 
 }  // namespace NFq::NRowDispatcher

--- a/ydb/core/fq/libs/row_dispatcher/ut/topic_session_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/ut/topic_session_ut.cpp
@@ -49,13 +49,12 @@ public:
         RowDispatcherActorId = Runtime.AllocateEdgeActor();
     }
 
-    void Init(const TString& topicPath, ui64 maxSessionUsedMemory = std::numeric_limits<ui64>::max(), bool skipErrors = false) {
+    void Init(const TString& topicPath, ui64 maxSessionUsedMemory = std::numeric_limits<ui64>::max()) {
         TopicPath = topicPath;
         Config.SetTimeoutBeforeStartSessionSec(TimeoutBeforeStartSessionSec);
         Config.SetMaxSessionUsedMemory(maxSessionUsedMemory);
         Config.SetSendStatusPeriodSec(2);
         Config.SetWithoutConsumer(false);
-        Config.MutableJsonParser()->SetSkipErrors(skipErrors);
         Config.MutableJsonParser()->SetBatchCreationTimeoutMs(100);
 
         auto credFactory = NKikimr::CreateYdbCredentialsProviderFactory;
@@ -124,7 +123,7 @@ public:
         }
     }
 
-    NYql::NPq::NProto::TDqPqTopicSource BuildSource(bool emptyPredicate = false, const TString& consumer = DefaultPqConsumer) {
+    NYql::NPq::NProto::TDqPqTopicSource BuildSource(bool emptyPredicate = false, const TString& consumer = DefaultPqConsumer, bool skipErrors = false) {
         NYql::NPq::NProto::TDqPqTopicSource settings;
         settings.SetEndpoint(GetDefaultPqEndpoint());
         settings.SetTopicPath(TopicPath);
@@ -139,6 +138,7 @@ public:
         if (!emptyPredicate) {
             settings.SetPredicate("WHERE true");
         }
+        settings.SetSkipJsonErrors(skipErrors);
         return settings;
     }
 
@@ -632,8 +632,8 @@ Y_UNIT_TEST_SUITE(TopicSessionTests) {
     Y_UNIT_TEST_F(WrongJson, TRealTopicFixture) {
         const TString topicName = "wrong_json";
         PQCreateStream(topicName);
-        Init(topicName, std::numeric_limits<ui64>::max(), true);
-        auto source = BuildSource();
+        Init(topicName);
+        auto source = BuildSource(false, DefaultPqConsumer, true);
         StartSession(ReadActorId1, source);
         
         auto writeRead = [&](const std::vector<TString>& input, const TBatch& output) {
@@ -670,8 +670,8 @@ Y_UNIT_TEST_SUITE(TopicSessionTests) {
     Y_UNIT_TEST_F(WrongJsonOffset, TRealTopicFixture) {
         const TString topicName = "wrong_json_offset";
         PQCreateStream(topicName);
-        Init(topicName, std::numeric_limits<ui64>::max(), true);
-        auto source = BuildSource();
+        Init(topicName);
+        auto source = BuildSource(false, DefaultPqConsumer, true);
         StartSession(ReadActorId1, source);
 
         TString wrongJson{"wrong"};

--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -342,7 +342,21 @@ struct TEvSaveScriptPhysicalGraphResponse : public TEventLocal<TEvSaveScriptPhys
     NYql::TIssues Issues;
 };
 
+struct TEvGetScriptExecutionPhysicalGraph : public TEventWithDatabaseId<TEvGetScriptExecutionPhysicalGraph, TKqpScriptExecutionEvents::EvGetScriptExecutionPhysicalGraph> {
+    TEvGetScriptExecutionPhysicalGraph(const TString& database, const TString& executionId)
+        : TEventWithDatabaseId(database)
+        , ExecutionId(executionId)
+    {}
+
+    const TString ExecutionId;
+};
+
 struct TEvGetScriptPhysicalGraphResponse : public TEventLocal<TEvGetScriptPhysicalGraphResponse, TKqpScriptExecutionEvents::EvGetScriptPhysicalGraphResponse> {
+    TEvGetScriptPhysicalGraphResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+        : Status(status)
+        , Issues(std::move(issues))
+    {}
+
     TEvGetScriptPhysicalGraphResponse(Ydb::StatusIds::StatusCode status, NKikimrKqp::TQueryPhysicalGraph&& physicalGraph, i64 generation, NYql::TIssues issues)
         : Status(status)
         , PhysicalGraph(std::move(physicalGraph))

--- a/ydb/core/kqp/common/simple/kqp_event_ids.h
+++ b/ydb/core/kqp/common/simple/kqp_event_ids.h
@@ -176,6 +176,7 @@ struct TKqpScriptExecutionEvents {
         EvGetScriptPhysicalGraphResponse,
         EvSaveScriptProgressResponse,
         EvResetScriptExecutionRetriesResponse,
+        EvGetScriptExecutionPhysicalGraph,
     };
 };
 

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -1932,11 +1932,6 @@ private:
                 const auto& stage = tx.Body->GetStages(stageIdx);
                 const auto& stageInfo = TasksGraph.GetStageInfo(TStageId(txIdx, stageIdx));
 
-                if (graphRestored && (stageInfo.Meta.ShardOperations || stageInfo.Meta.ShardKind != NSchemeCache::ETableKind::KindUnknown)) {
-                    ReplyErrorAndDie(Ydb::StatusIds::INTERNAL_ERROR, YqlIssue({}, NYql::TIssuesIds::KIKIMR_INTERNAL_ERROR, "Restore is not supported for table operations"));
-                    return;
-                }
-
                 if (stageInfo.Meta.ShardKind == NSchemeCache::ETableKind::KindAsyncIndexTable) {
                     TMaybe<TString> error;
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/behaviour.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/behaviour.cpp
@@ -14,7 +14,7 @@ NMetadata::NInitializer::IInitializationBehaviour::TPtr TStreamingQueryBehaviour
 }
 
 TString TStreamingQueryBehaviour::GetInternalStorageTablePath() const {
-    return "streaming/queries";
+    return TStreamingQueryConfig::InternalTablesPath;
 }
 
 NMetadata::NModifications::IOperationsManager::TPtr TStreamingQueryBehaviour::ConstructOperationsManager() const {

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.cpp
@@ -1,10 +1,15 @@
 #include "utils.h"
 
+#include <ydb/core/base/path.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 
 #include <yql/essentials/sql/v1/node.h>
 
 namespace NKikimr::NKqp {
+
+TString TStreamingQueryMeta::GetTablesPath() {
+    return JoinPath({".metadata", InternalTablesPath});
+}
 
 TStreamingQuerySettings& TStreamingQuerySettings::FromProto(const NKikimrSchemeOp::TStreamingQueryProperties& info) {
     for (const auto& [name, value] : info.GetProperties()) {

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.h
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.h
@@ -31,6 +31,10 @@ public:
         // Internal query info
         static inline constexpr char QueryTextRevision[] = "__query_text_revision";
     };
+
+    static inline constexpr char InternalTablesPath[] = "streaming/queries";
+
+    static TString GetTablesPath();
 };
 
 // Used for properties parsing after describing streaming query

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/common/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/common/ya.make
@@ -5,6 +5,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/base
     ydb/core/protos
     yql/essentials/sql/v1
 )

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/initializer.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/initializer.cpp
@@ -1,40 +1,81 @@
 #include "initializer.h"
 #include "object.h"
 
+#include <ydb/library/table_creator/table_creator.h>
+
 namespace NKikimr::NKqp {
 
 namespace {
 
-void AddColumn(Ydb::Table::CreateTableRequest& request, const TString& name, Ydb::Type::PrimitiveTypeId type, bool primary = false) {
-    if (primary) {
-        request.add_primary_key(name);
+using namespace NMetadata::NInitializer;
+
+class TStreamingQueriesTablesCreator final : public NTableCreator::TMultiTableCreator {
+    using TBase = NTableCreator::TMultiTableCreator;
+
+public:
+    TStreamingQueriesTablesCreator(const TString& modificationId, IModifierExternalController::TPtr externalController)
+        : TBase({GetStreamingQueriesCreator()})
+        , ModificationId(modificationId)
+        , ExternalController(externalController)
+    {}
+
+protected:
+    static IActor* GetStreamingQueriesCreator() {
+        NACLib::TDiffACL acl;
+        acl.ClearAccess();
+        acl.SetInterruptInheritance(AppData()->FeatureFlags.GetEnableSecureScriptExecutions());
+
+        return CreateTableCreator(
+            SplitPath(TStreamingQueryConfig::GetTablesPath()),
+            {
+                Col(TStreamingQueryConfig::TColumns::DatabaseId, NScheme::NTypeIds::Utf8),
+                Col(TStreamingQueryConfig::TColumns::QueryPath, NScheme::NTypeIds::Utf8),
+                Col(TStreamingQueryConfig::TColumns::State, NScheme::NTypeIds::Json),
+            },
+            { TStreamingQueryConfig::TColumns::DatabaseId, TStreamingQueryConfig::TColumns::QueryPath },
+            NKikimrServices::KQP_PROXY,
+            {},
+            {},
+            /* isSystemUser */ true,
+            Nothing(),
+            acl
+        );
     }
 
-    auto& column = *request.add_columns();
-    column.set_name(name);
-    column.mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(type);
-}
+    void OnTablesCreated(bool success, NYql::TIssues issues) final {
+        if (success) {
+            ExternalController->OnModificationFinished(ModificationId);
+        } else {
+            ExternalController->OnModificationFailed(Ydb::StatusIds::INTERNAL_ERROR, issues.ToString(), ModificationId);
+        }
+    }
+
+private:
+    const TString ModificationId;
+    const IModifierExternalController::TPtr ExternalController;
+};
+
+class TStreamingQueriesTablesInitializer final : public ITableModifier {
+    static constexpr char MODIFICATION_ID[] = "create-generic";
+
+public:
+    TStreamingQueriesTablesInitializer()
+        : ITableModifier(MODIFICATION_ID, /* supportDbCache */ false)
+    {}
+
+protected:
+    bool DoExecute(IModifierExternalController::TPtr externalController, const NMetadata::NRequest::TConfig& config) const final {
+        Y_UNUSED(config);
+
+        TActivationContext::Register(new TStreamingQueriesTablesCreator(MODIFICATION_ID, externalController));
+        return true;
+    }
+};
 
 }  // anonymous namespace
 
-void TStreamingQueryInitializer::DoPrepare(NMetadata::NInitializer::IInitializerInput::TPtr controller) const {
-    TVector<NMetadata::NInitializer::ITableModifier::TPtr> result;
-    {
-        Ydb::Table::CreateTableRequest request;
-        request.set_path(TStreamingQueryConfig::GetBehaviour()->GetStorageTablePath());
-        AddColumn(request, TStreamingQueryConfig::TColumns::DatabaseId, Ydb::Type::UTF8, true);
-        AddColumn(request, TStreamingQueryConfig::TColumns::QueryPath, Ydb::Type::UTF8, true);
-        AddColumn(request, TStreamingQueryConfig::TColumns::State, Ydb::Type::JSON);
-        result.emplace_back(std::make_shared<NMetadata::NInitializer::TGenericTableModifier<NMetadata::NRequest::TDialogCreateTable>>(request, "create"));
-    }
-
-    if (AppData()->FeatureFlags.GetEnableSecureScriptExecutions()) {
-        result.emplace_back(NMetadata::NInitializer::TACLModifierConstructor::GetNoAccessModifier(TStreamingQueryConfig::GetBehaviour()->GetStorageTablePath(), "acl"));
-    } else {
-        result.emplace_back(NMetadata::NInitializer::TACLModifierConstructor::GetReadOnlyModifier(TStreamingQueryConfig::GetBehaviour()->GetStorageTablePath(), "acl"));
-    }
-
-    controller->OnPreparationFinished(result);
+void TStreamingQueryInitializer::DoPrepare(IInitializerInput::TPtr controller) const {
+    controller->OnPreparationFinished({std::make_shared<TStreamingQueriesTablesInitializer>()});
 }
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -2182,7 +2182,7 @@ public:
     {}
 
     void Bootstrap() {
-        LOG_D("Bootstrap. Fetch config");
+        LOG_D("Bootstrap");
 
         TBase::Become(&TDerived::StateFunc);
         DescribeQuery("start handling");

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -13,7 +13,6 @@
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/core/kqp/provider/yql_kikimr_gateway.h>
-#include <ydb/core/kqp/proxy_service/kqp_script_executions.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/resource_pools/resource_pool_settings.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
@@ -1704,8 +1703,8 @@ private:
         if (!State.GetPreviousExecutionIds().empty() && !StateLoaded) {
             StateLoaded = true;
             const auto& executionId = *State.GetPreviousExecutionIds().rbegin();
-            const auto& fetcherId = Register(CreateGetScriptExecutionPhysicalGraphActor(SelfId(), Context.GetDatabase(), executionId));
-            LOG_D("Load previous query state from execution: " << executionId << " with fetcher " << fetcherId);
+            SendToKqpProxy(std::make_unique<TEvGetScriptExecutionPhysicalGraph>(Context.GetDatabase(), executionId));
+            LOG_D("Load previous query state from execution: " << executionId);
             return;
         }
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/ya.make
@@ -20,7 +20,6 @@ PEERDIR(
     ydb/core/kqp/gateway/behaviour/streaming_query/common
     ydb/core/kqp/gateway/utils
     ydb/core/kqp/provider
-    ydb/core/kqp/proxy_service
     ydb/core/protos
     ydb/core/protos/schemeshard
     ydb/core/resource_pools
@@ -29,6 +28,7 @@ PEERDIR(
     ydb/core/tx/tx_proxy
     ydb/library/conclusion
     ydb/library/query_actor
+    ydb/library/table_creator
     ydb/services/metadata
     ydb/services/metadata/abstract
     ydb/services/metadata/manager

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -462,12 +462,22 @@ TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCache
 
 TTableMetadataResult EnrichExternalTable(const TTableMetadataResult& externalTable, const TTableMetadataResult& externalDataSource) {
     TTableMetadataResult result;
+
     if (!externalTable.Success()) {
         result.AddIssues(externalTable.Issues());
         return result;
     }
+
     if (!externalDataSource.Success()) {
         result.AddIssues(externalDataSource.Issues());
+        return result;
+    }
+
+    if (externalTable.Metadata->ExternalSource.Type != externalDataSource.Metadata->ExternalSource.Type) {
+        result.AddIssue(YqlIssue({}, TIssuesIds::KIKIMR_INTERNAL_ERROR, TStringBuilder()
+            << "Internal error. External table type mismatch, expected: " << externalTable.Metadata->ExternalSource.Type
+            << ", but underlying external data source has type: " << externalDataSource.Metadata->ExternalSource.Type
+        ));
         return result;
     }
 
@@ -885,7 +895,8 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
     // In the case of reading from an external data source,
     // we have a construction of the form: `/Root/external_data_source`.`/path_in_external_system` WITH (...)
     // In this syntax, information about path_in_external_system is already known and we only need information about external_data_source.
-    // To do this, we go to the DefaultCluster and get information about external_data_source from scheme shard
+    // To do this, we go to the DefaultCluster and get information about external_data_source from scheme shard.
+    // In case of external data source `cluster` = "/Root/external_data_source" and `id` = "/path_in_external_system"
     const bool resolveEntityInsideDataSource = (cluster != Cluster);
     TMaybe<TString> externalPath;
     TPath entityName = id;

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -490,6 +490,7 @@ TTableMetadataResult EnrichExternalTable(const TTableMetadataResult& externalTab
     tableMeta->ExternalSource.ServiceAccountIdSignature = externalDataSource.Metadata->ExternalSource.ServiceAccountIdSignature;
     tableMeta->ExternalSource.AwsAccessKeyId = externalDataSource.Metadata->ExternalSource.AwsAccessKeyId;
     tableMeta->ExternalSource.AwsSecretAccessKey = externalDataSource.Metadata->ExternalSource.AwsSecretAccessKey;
+    tableMeta->ExternalSource.UnderlyingExternalSourceMetadata = externalDataSource.Metadata;
     return result;
 }
 

--- a/ydb/core/kqp/host/kqp_runner.cpp
+++ b/ydb/core/kqp/host/kqp_runner.cpp
@@ -80,7 +80,7 @@ public:
             TKqpPhysicalQuery physicalQuery(input);
 
             YQL_ENSURE(TransformCtx.DataQueryBlocks);
-            auto compiler = CreateKqpQueryCompiler(Cluster, OptimizeCtx.Tables, FuncRegistry, TypesCtx, Config);
+            auto compiler = CreateKqpQueryCompiler(Cluster, FuncRegistry, TypesCtx, OptimizeCtx, Config);
             auto ret = compiler->CompilePhysicalQuery(physicalQuery, *TransformCtx.DataQueryBlocks, *preparedQuery.MutablePhysicalQuery(), ctx);
             if (!ret) {
                 ctx.AddError(TIssue(ctx.GetPosition(input->Pos()), "Failed to compile physical query."));

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -318,7 +318,7 @@ TExprBase BuildFillTable(const TKiWriteTable& write, TExprContext& ctx)
 
 TExprBase BuildUpsertTable(const TKiWriteTable& write, const TCoAtomList& inputColumns,
     const TCoAtomList& autoincrement, const bool isSink,
-    const TKikimrTableDescription& table, TExprContext& ctx)
+    const TKikimrTableDescription& table, TExprContext& ctx, TKqpOptimizeContext& kqpCtx)
 {
     auto generateColumnsIfInsertNode = GetSetting(write.Settings().Ref(), "generate_columns_if_insert");
     YQL_ENSURE(generateColumnsIfInsertNode);
@@ -328,6 +328,11 @@ TExprBase BuildUpsertTable(const TKiWriteTable& write, const TCoAtomList& inputC
     generateColumnsIfInsert = ExtendGenerateOnInsertColumnsList(write, generateColumnsIfInsert, inputColumns, autoincrement, ctx);
 
     settings = AddSetting(*settings, write.Pos(), "Mode", Build<TCoAtom>(ctx, write.Pos()).Value("upsert").Done().Ptr(), ctx);
+
+    if (const auto requestContext = kqpCtx.UserRequestContext; requestContext && requestContext->IsStreamingQuery) {
+        settings = AddSetting(*settings, write.Pos(), "AllowInconsistentWrites", nullptr, ctx);
+    }
+
     const auto [input, columns] = BuildWriteInput(write, table, inputColumns, autoincrement, isSink, write.Pos(), ctx);
     if (generateColumnsIfInsert.Ref().ChildrenSize() > 0) {
         return Build<TKqlInsertOnConflictUpdateRows>(ctx, write.Pos())
@@ -853,13 +858,13 @@ TExprNode::TPtr HandleReadTable(const TKiReadTable& read, TExprContext& ctx, con
 
 TExprBase WriteTableSimple(const TKiWriteTable& write, const TCoAtomList& inputColumns,
     const TCoAtomList& autoincrement,
-    const TKikimrTableDescription& tableData, TExprContext& ctx, const bool isSink)
+    const TKikimrTableDescription& tableData, TExprContext& ctx, TKqpOptimizeContext& kqpCtx, const bool isSink)
 {
     Y_UNUSED(isSink);
     auto op = GetTableOp(write);
     switch (op) {
         case TYdbOperation::Upsert:
-            return BuildUpsertTable(write, inputColumns, autoincrement, isSink, tableData, ctx);
+            return BuildUpsertTable(write, inputColumns, autoincrement, isSink, tableData, ctx, kqpCtx);
         case TYdbOperation::Replace:
             return BuildReplaceTable(write, inputColumns, autoincrement, isSink, tableData, ctx);
         case TYdbOperation::InsertAbort:
@@ -952,7 +957,7 @@ TExprNode::TPtr HandleWriteTable(const TKiWriteTable& write, TExprContext& ctx, 
     if (HasIndexesToWrite(tableData)) {
         return WriteTableWithIndexUpdate(write, inputColumns, defaultConstraintColumns, tableData, ctx, isSink).Ptr();
     } else {
-        return WriteTableSimple(write, inputColumns, defaultConstraintColumns, tableData, ctx, isSink).Ptr();
+        return WriteTableSimple(write, inputColumns, defaultConstraintColumns, tableData, ctx, kqpCtx, isSink).Ptr();
     }
 }
 

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -454,6 +454,9 @@ enum class ESourceType : ui32 {
     ExternalDataSource = 2
 };
 
+struct TKikimrTableMetadata;
+typedef TIntrusivePtr<TKikimrTableMetadata> TKikimrTableMetadataPtr;
+
 struct TExternalSource {
     ESourceType SourceType = ESourceType::Unknown;
     TString Type;
@@ -469,6 +472,7 @@ struct TExternalSource {
     TString Token;
     NKikimrSchemeOp::TAuth DataSourceAuth;
     NKikimrSchemeOp::TExternalDataSourceProperties Properties;
+    TKikimrTableMetadataPtr UnderlyingExternalSourceMetadata;
 };
 
 enum EMetaSerializationType : ui64 {
@@ -1046,8 +1050,6 @@ struct TKikimrListPathItem {
     TString Name;
     bool IsDirectory;
 };
-
-typedef TIntrusivePtr<TKikimrTableMetadata> TKikimrTableMetadataPtr;
 
 template<typename TResult>
 class IKikimrAsyncResult : public TThrRefBase {

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -2,51 +2,52 @@
 #include "kqp_proxy_service_impl.h"
 #include "kqp_script_executions.h"
 
+#include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/base/appdata.h>
-#include <ydb/core/base/path.h>
-#include <ydb/core/base/location.h>
 #include <ydb/core/base/feature_flags.h>
+#include <ydb/core/base/location.h>
+#include <ydb/core/base/path.h>
 #include <ydb/core/base/statestorage.h>
 #include <ydb/core/cms/console/configs_dispatcher.h>
 #include <ydb/core/cms/console/console.h>
-#include <ydb/core/kqp/counters/kqp_counters.h>
+#include <ydb/core/fq/libs/checkpoint_storage/storage_service.h>
+#include <ydb/core/fq/libs/row_dispatcher/events/data_plane.h>
+#include <ydb/core/fq/libs/row_dispatcher/row_dispatcher_service.h>
 #include <ydb/core/kqp/common/events/script_executions.h>
 #include <ydb/core/kqp/common/events/workload_service.h>
 #include <ydb/core/kqp/common/kqp_lwtrace_probes.h>
 #include <ydb/core/kqp/common/kqp_timeouts.h>
 #include <ydb/core/kqp/compile_service/kqp_compile_service.h>
-#include <ydb/core/kqp/executer_actor/kqp_executer.h>
-#include <ydb/core/kqp/session_actor/kqp_worker_common.h>
-#include <ydb/core/kqp/node_service/kqp_node_service.h>
-#include <ydb/core/kqp/workload_service/kqp_workload_service.h>
-#include <ydb/core/resource_pools/resource_pool_settings.h>
-#include <ydb/core/tx/schemeshard/schemeshard.h>
-#include <ydb/library/yql/dq/actors/compute/dq_checkpoints.h>
-#include <ydb/library/yql/dq/actors/spilling/spilling_file.h>
-#include <ydb/library/yql/dq/actors/spilling/spilling.h>
-#include <ydb/core/actorlib_impl/long_timer.h>
-#include <ydb/public/sdk/cpp/src/library/operation_id/protos/operation_id.pb.h>
-#include <ydb/core/node_whiteboard/node_whiteboard.h>
-#include <ydb/core/ydb_convert/ydb_convert.h>
 #include <ydb/core/kqp/compute_actor/kqp_compute_actor.h>
+#include <ydb/core/kqp/counters/kqp_counters.h>
+#include <ydb/core/kqp/executer_actor/kqp_executer.h>
+#include <ydb/core/kqp/gateway/behaviour/streaming_query/behaviour.h>
+#include <ydb/core/kqp/node_service/kqp_node_service.h>
+#include <ydb/core/kqp/session_actor/kqp_worker_common.h>
+#include <ydb/core/kqp/workload_service/kqp_workload_service.h>
 #include <ydb/core/mon/mon.h>
-#include <ydb/library/ydb_issue/issue_helpers.h>
+#include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/protos/workload_manager_config.pb.h>
+#include <ydb/core/resource_pools/resource_pool_settings.h>
 #include <ydb/core/sys_view/common/registry.h>
-#include <ydb/core/fq/libs/checkpoint_storage/storage_service.h>
-#include <ydb/core/fq/libs/row_dispatcher/events/data_plane.h>
-#include <ydb/core/fq/libs/row_dispatcher/row_dispatcher_service.h>
-
-#include <ydb/library/yql/utils/actor_log/log.h>
-#include <yql/essentials/core/services/mounts/yql_mounts.h>
-#include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
-
+#include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/ydb_convert/ydb_convert.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/interconnect.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
+#include <ydb/library/ydb_issue/issue_helpers.h>
+#include <ydb/library/yql/dq/actors/compute/dq_checkpoints.h>
+#include <ydb/library/yql/dq/actors/spilling/spilling_file.h>
+#include <ydb/library/yql/dq/actors/spilling/spilling.h>
+#include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
+#include <ydb/library/yql/utils/actor_log/log.h>
+#include <ydb/public/sdk/cpp/src/library/operation_id/protos/operation_id.pb.h>
+
+#include <yql/essentials/core/services/mounts/yql_mounts.h>
+
 #include <library/cpp/lwtrace/mon/mon_lwtrace.h>
 #include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/resource/resource.h>
@@ -174,6 +175,7 @@ class TKqpProxyService : public TActorBootstrapped<TKqpProxyService> {
         GetScriptExecutionOperation,
         ListScriptExecutionOperations,
         CancelScriptExecutionOperation,
+        GetScriptExecutionPhysicalGraph,
     };
 
 public:
@@ -447,7 +449,13 @@ public:
         LogConfig.Swap(event.MutableConfig()->MutableLogConfig());
         UpdateYqlLogLevels();
 
-        FeatureFlags.Swap(event.MutableConfig()->MutableFeatureFlags());
+        auto* newFeatureFlags = event.MutableConfig()->MutableFeatureFlags();
+        if (newFeatureFlags->GetEnableSecureScriptExecutions() != FeatureFlags.GetEnableSecureScriptExecutions()) {
+            ScriptExecutionsCreationStatus = EScriptExecutionsCreationStatus::NotStarted;
+            Send(NMetadata::NProvider::MakeServiceId(SelfId().NodeId()), new NMetadata::NProvider::TEvResetManagerRegistration(TStreamingQueryBehaviour::GetInstance()));
+        }
+
+        FeatureFlags.Swap(newFeatureFlags);
         WorkloadManagerConfig.Swap(event.MutableConfig()->MutableWorkloadManagerConfig());
         ResourcePoolsCache.UpdateConfig(FeatureFlags, WorkloadManagerConfig, ActorContext());
 
@@ -1247,6 +1255,7 @@ public:
             hFunc(NKqp::TEvGetScriptExecutionOperation, Handle);
             hFunc(NKqp::TEvListScriptExecutionOperations, Handle);
             hFunc(NKqp::TEvCancelScriptExecutionOperation, Handle);
+            hFunc(NKqp::TEvGetScriptExecutionPhysicalGraph, Handle);
             hFunc(TEvInterconnect::TEvNodeConnected, Handle);
             hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
             hFunc(TEvKqp::TEvListSessionsRequest, Handle);
@@ -1549,6 +1558,10 @@ private:
             case EDelayedRequestType::CancelScriptExecutionOperation:
                 HandleDelayedScriptRequestError<TEvCancelScriptExecutionOperationResponse>(std::move(requestEvent), status, std::move(issues));
                 break;
+
+            case EDelayedRequestType::GetScriptExecutionPhysicalGraph:
+                HandleDelayedScriptRequestError<TEvGetScriptPhysicalGraphResponse>(std::move(requestEvent), status, std::move(issues));
+                break;
         }
     }
 
@@ -1557,9 +1570,14 @@ private:
         Send(requestEvent->Sender, new TResponse(status, std::move(issues)), 0, requestEvent->Cookie);
     }
 
+    void StartScriptExecutionsTablesCreation() {
+        ScriptExecutionsCreationStatus = EScriptExecutionsCreationStatus::Pending;
+        Register(CreateScriptExecutionsTablesCreator(FeatureFlags), TMailboxType::HTSwap, AppData()->SystemPoolId);
+    }
+
     template<typename TEvent>
     bool CheckScriptExecutionsTablesReady(TEvent& ev, EDelayedRequestType requestType) {
-        if (!AppData()->FeatureFlags.GetEnableScriptExecutionOperations()) {
+        if (!FeatureFlags.GetEnableScriptExecutionOperations()) {
             NYql::TIssues issues;
             issues.AddIssue("ExecuteScript feature is not enabled");
             HandleDelayedRequestError(requestType, std::move(ev), Ydb::StatusIds::UNSUPPORTED, std::move(issues));
@@ -1574,8 +1592,7 @@ private:
 
         switch (ScriptExecutionsCreationStatus) {
             case EScriptExecutionsCreationStatus::NotStarted:
-                ScriptExecutionsCreationStatus = EScriptExecutionsCreationStatus::Pending;
-                Register(CreateScriptExecutionsTablesCreator(FeatureFlags), TMailboxType::HTSwap, AppData()->SystemPoolId);
+                StartScriptExecutionsTablesCreation();
                 [[fallthrough]];
             case EScriptExecutionsCreationStatus::Pending:
                 if (DelayedEventsQueue.size() < 10000) {
@@ -1595,6 +1612,11 @@ private:
     }
 
     void Handle(TEvScriptExecutionsTablesCreationFinished::TPtr& ev) {
+        if (ScriptExecutionsCreationStatus == EScriptExecutionsCreationStatus::NotStarted) {
+            StartScriptExecutionsTablesCreation();
+            return;
+        }
+
         ScriptExecutionsCreationStatus = EScriptExecutionsCreationStatus::Finished;
 
         NYql::TIssue rootIssue;
@@ -1638,6 +1660,12 @@ private:
     void Handle(NKqp::TEvCancelScriptExecutionOperation::TPtr& ev) {
         if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::CancelScriptExecutionOperation)) {
             Register(CreateCancelScriptExecutionOperationActor(std::move(ev), QueryServiceConfig, Counters), TMailboxType::HTSwap, AppData()->SystemPoolId);
+        }
+    }
+
+    void Handle(TEvGetScriptExecutionPhysicalGraph::TPtr& ev) {
+        if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::GetScriptExecutionPhysicalGraph)) {
+            Register(CreateGetScriptExecutionPhysicalGraphActor(ev->Sender, ev->Get()->Database, ev->Get()->ExecutionId));
         }
     }
 
@@ -1867,7 +1895,7 @@ private:
     }
 };
 
-} // namespace
+} // anonymous namespace
 
 IActor* CreateKqpProxyService(const NKikimrConfig::TLogConfig& logConfig,
     const NKikimrConfig::TTableServiceConfig& tableServiceConfig,

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -195,13 +195,9 @@ public:
 
 private:
     static TMaybe<NACLib::TDiffACL> GetTableACL(const NKikimrConfig::TFeatureFlags& featureFlags) {
-        if (!featureFlags.GetEnableSecureScriptExecutions()) {
-            return Nothing();
-        }
-
         NACLib::TDiffACL acl;
         acl.ClearAccess();
-        acl.SetInterruptInheritance(true);
+        acl.SetInterruptInheritance(featureFlags.GetEnableSecureScriptExecutions());
         return acl;
     }
 

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -2,6 +2,7 @@
 #include "kqp_script_executions_impl.h"
 
 #include <ydb/core/base/backtrace.h>
+#include <ydb/core/cms/console/console.h>
 #include <ydb/core/kqp/common/kqp_script_executions.h>
 #include <ydb/core/kqp/finalize_script_service/kqp_finalize_script_service.h>
 #include <ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_retries.h>
@@ -91,6 +92,9 @@ struct TScriptExecutionsYdbSetup {
             signal(sig, &TScriptExecutionsYdbSetup::BackTraceSignalHandler);
         }
 
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSecureScriptExecutions(secureScriptExecutions);
+
         MsgBusPort = PortManager.GetPort(2134);
         GrpcPort = PortManager.GetPort(2135);
         ServerSettings = MakeHolder<Tests::TServerSettings>(MsgBusPort);
@@ -99,6 +103,7 @@ struct TScriptExecutionsYdbSetup {
         ServerSettings->SetEnableDataShardCreateTableAs(true);
         ServerSettings->SetEnableSecureScriptExecutions(secureScriptExecutions);
         ServerSettings->SetGrpcPort(GrpcPort);
+        ServerSettings->SetAppConfig(appConfig);
         Server = MakeHolder<Tests::TServer>(*ServerSettings);
         Client = MakeHolder<Tests::TClient>(*ServerSettings);
 
@@ -196,50 +201,78 @@ struct TScriptExecutionsYdbSetup {
     }
 
     void CreateTableInDbSync(TVector<NKikimrSchemeOp::TColumnDescription> columns = DEFAULT_COLUMNS, i32 numberOfRequests = 1, TVector<TString> pathComponents = TEST_TABLE_PATH, TVector<TString> keyColumns = TEST_KEY_COLUMNS,
-                             TMaybe<NKikimrSchemeOp::TTTLSettings> ttlSettings = Nothing()) {
-
+        TMaybe<NKikimrSchemeOp::TTTLSettings> ttlSettings = Nothing(), bool isSystemUser = false, TMaybe<NACLib::TDiffACL> tableAclDiff = Nothing())
+    {
         TVector<TActorId> edgeActors;
         for (i32 i = 0; i < numberOfRequests; ++i) {
-            edgeActors.push_back(CreateTableInDbAsync(columns, pathComponents, keyColumns, ttlSettings));
+            edgeActors.push_back(CreateTableInDbAsync(columns, pathComponents, keyColumns, ttlSettings, isSystemUser, tableAclDiff));
         }
         WaitTableCreation(std::move(edgeActors));
     }
 
     TActorId CreateTableInDbAsync(TVector<NKikimrSchemeOp::TColumnDescription> columns = DEFAULT_COLUMNS, TVector<TString> pathComponents = TEST_TABLE_PATH, TVector<TString> keyColumns = TEST_KEY_COLUMNS,
-                             TMaybe<NKikimrSchemeOp::TTTLSettings> ttlSettings = Nothing()) {
-        const ui32 node = 0;
-        TActorId edgeActor = GetRuntime()->AllocateEdgeActor(node);
-        GetRuntime()->Register(CreateTableCreator(std::move(pathComponents), std::move(columns), std::move(keyColumns),
-            NKikimrServices::KQP_PROXY, std::move(ttlSettings)), 0, 0, TMailboxType::Simple, 0, edgeActor);
+        TMaybe<NKikimrSchemeOp::TTTLSettings> ttlSettings = Nothing(), bool isSystemUser = false, TMaybe<NACLib::TDiffACL> tableAclDiff = Nothing())
+    {
+        TActorId edgeActor = GetRuntime()->AllocateEdgeActor();
+        GetRuntime()->Register(CreateTableCreator(
+            std::move(pathComponents),
+            std::move(columns),
+            std::move(keyColumns),
+            NKikimrServices::KQP_PROXY,
+            std::move(ttlSettings),
+            {},
+            isSystemUser,
+            {},
+            std::move(tableAclDiff)
+        ), 0, 0, TMailboxType::Simple, 0, edgeActor);
         return edgeActor;
     }
 
     void WaitTableCreation(TVector<TActorId> edgeActors) {
-        for (const auto& actor: edgeActors) {
-            GetRuntime()->GrabEdgeEvent<TEvTableCreator::TEvCreateTableResponse>(actor, TestTimeout);
+        for (const auto& actor : edgeActors) {
+            const auto reply = GetRuntime()->GrabEdgeEvent<TEvTableCreator::TEvCreateTableResponse>(actor, TestTimeout);
+            UNIT_ASSERT_C(reply, "CreateTable response is empty");
+            UNIT_ASSERT_C(reply->Get()->Success, reply->Get()->Issues.ToOneLineString());
         }
     }
 
-    void VerifyColumnsList( TVector<TString> pathComponents = TEST_TABLE_PATH, TVector<NKikimrSchemeOp::TColumnDescription> columns = DEFAULT_COLUMNS) {
-        TStringBuilder path;
-        path << "/dc-1/";
-        for (size_t i = 0; i < pathComponents.size() - 1; ++i) {
-            path << pathComponents[i] << "/";
-        }
-        path << pathComponents.back();
+    void VerifyColumnsList(TVector<TString> pathComponents = TEST_TABLE_PATH, TVector<NKikimrSchemeOp::TColumnDescription> columns = DEFAULT_COLUMNS,
+        bool isSystemUser = false, const std::optional<std::vector<NYdb::NScheme::TPermissions>>& effectivePermissions = std::nullopt)
+    {
+        NYdb::NTable::TTableClient client(*YdbDriver, NYdb::NTable::TClientSettings().AuthToken(""));
+        const auto sessionResult = client.CreateSession().ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(sessionResult.GetStatus(), NYdb::EStatus::SUCCESS, sessionResult.GetIssues().ToOneLineString());
+        const auto result = sessionResult.GetSession().DescribeTable(JoinPath({"dc-1", JoinPath(pathComponents)})).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToOneLineString());
 
-        auto result = TableClientSession->DescribeTable(path).ExtractValueSync();
-        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        const auto&  existingColumns = result.GetTableDescription().GetColumns();
-        UNIT_ASSERT_C(existingColumns.size() == columns.size(), "Expected size: " << columns.size() << ", actual size: " << existingColumns.size());
+        const auto& tableDesc = result.GetTableDescription();
+        const auto& existingColumns = tableDesc.GetColumns();
+        UNIT_ASSERT_VALUES_EQUAL(existingColumns.size(), columns.size());
 
         THashSet<TString> existingNames;
-        for (const auto& col: existingColumns) {
+        existingNames.reserve(existingColumns.size());
+        for (const auto& col : existingColumns) {
             existingNames.emplace(col.Name);
         }
 
-        for (const auto& col: columns) {
+        for (const auto& col : columns) {
             UNIT_ASSERT_C(existingNames.contains(col.GetName()), "Column \"" << col.GetName() << "\" is not present" );
+        }
+
+        if (effectivePermissions) {
+            const auto& existingPermissions = tableDesc.GetEffectivePermissions();
+            UNIT_ASSERT_VALUES_EQUAL(existingPermissions.size(), effectivePermissions->size());
+
+            for (ui64 i = 0; i < existingPermissions.size(); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(existingPermissions[i].Subject, effectivePermissions->at(i).Subject);
+                UNIT_ASSERT_VALUES_EQUAL(existingPermissions[i].PermissionNames, effectivePermissions->at(i).PermissionNames);
+            }
+        }
+
+        if (isSystemUser) {
+            UNIT_ASSERT_VALUES_EQUAL(tableDesc.GetOwner(), BUILTIN_ACL_METADATA);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(tableDesc.GetOwner(), BUILTIN_ACL_ROOT);
         }
     }
 
@@ -647,18 +680,60 @@ Y_UNIT_TEST_SUITE(ScriptExecutionsTest) {
         TScriptExecutionsYdbSetup ydb(false, /* secureScriptExecutions */ true);
         ydb.CreateQueryInDb();
 
-        for (const auto& table : {"script_executions", "script_execution_leases", "result_sets"}) {
-            const TString sql = fmt::format(R"(
-                SELECT
-                    COUNT(*)
-                FROM `.metadata/{table}`
-            )", "table"_a = table);
+        const auto result = ydb.TableClientSession->ExecuteSchemeQuery(fmt::format(R"(
+                GRANT ALL ON `/dc-1/.metadata` TO `{user}`;
+            )", "user"_a = BUILTIN_ACL_ROOT
+        )).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToOneLineString());
 
-            const auto result = ydb.TableClientSession->ExecuteDataQuery(sql, NYdb::NTable::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
-            const auto& issues = result.GetIssues().ToString();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SCHEME_ERROR, issues);
-            UNIT_ASSERT_STRING_CONTAINS(issues, "Cannot find table");
-        }
+        const std::vector<TString> tables = {"script_executions", "script_execution_leases", "result_sets"};
+        const auto testNoAccess = [&]() {
+            for (const auto& table : tables) {
+                const TString sql = fmt::format(R"(
+                    SELECT
+                        COUNT(*)
+                    FROM `.metadata/{table}`
+                )", "table"_a = table);
+
+                const auto result = ydb.TableClientSession->ExecuteDataQuery(sql, NYdb::NTable::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+                const auto& issues = result.GetIssues().ToString();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SCHEME_ERROR, issues);
+                UNIT_ASSERT_STRING_CONTAINS(issues, "Cannot find table");
+            }
+        };
+        const auto testAccessAllowed = [&]() {
+            for (const auto& table : tables) {
+                const TString sql = fmt::format(R"(
+                    SELECT
+                        COUNT(*)
+                    FROM `.metadata/{table}`
+                )", "table"_a = table);
+
+                const auto result = ydb.TableClientSession->ExecuteDataQuery(sql, NYdb::NTable::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+            }
+        };
+        const auto switchAccess = [&](bool allowed) {
+            auto ev = std::make_unique<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+            ev->Record.MutableConfig()->MutableFeatureFlags()->SetEnableSecureScriptExecutions(!allowed);
+
+            auto& runtime = *ydb.GetRuntime();
+            const auto edgeActor = runtime.AllocateEdgeActor();
+            runtime.Send(MakeKqpProxyID(runtime.GetNodeId()), edgeActor, ev.release());
+            const auto response = runtime.GrabEdgeEvent<NConsole::TEvConsole::TEvConfigNotificationResponse>(edgeActor, TDuration::Seconds(10));
+            UNIT_ASSERT(response);
+
+            ydb.RunSelect42Script();
+            Sleep(TDuration::Seconds(1));
+        };
+
+        testNoAccess();
+
+        switchAccess(/* allowed */ true);
+        testAccessAllowed();
+
+        switchAccess(/* allowed */ false);
+        testNoAccess();
     }
 }
 
@@ -738,12 +813,22 @@ Y_UNIT_TEST_SUITE(TestScriptExecutionsUtils) {
 }
 
 Y_UNIT_TEST_SUITE(TableCreation) {
-
     Y_UNIT_TEST(SimpleTableCreation) {
         TScriptExecutionsYdbSetup ydb;
 
         ydb.CreateTableInDbSync();
-        ydb.VerifyColumnsList();
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, DEFAULT_COLUMNS, false, std::vector<NYdb::NScheme::TPermissions>{NYdb::NScheme::TPermissions(BUILTIN_ACL_ROOT, {"ydb.generic.full"})});
+    }
+
+    Y_UNIT_TEST(TableCreationWithAcl) {
+        TScriptExecutionsYdbSetup ydb;
+
+        NACLib::TDiffACL acl;
+        acl.ClearAccess();
+        acl.SetInterruptInheritance(true);
+
+        ydb.CreateTableInDbSync(DEFAULT_COLUMNS, 1, TEST_TABLE_PATH, TEST_KEY_COLUMNS, {}, true, acl);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, DEFAULT_COLUMNS, true, std::vector<NYdb::NScheme::TPermissions>());
     }
 
     Y_UNIT_TEST(ConcurrentTableCreation) {
@@ -821,6 +906,70 @@ Y_UNIT_TEST_SUITE(TableCreation) {
         ydb.VerifyColumnsList(TEST_TABLE_PATH, EXTENDED_COLUMNS);
     }
 
+    Y_UNIT_TEST(UpdateTableWithAclModification) {
+        TScriptExecutionsYdbSetup ydb;
+
+        ydb.CreateTableInDbSync(DEFAULT_COLUMNS);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, DEFAULT_COLUMNS, false, std::vector<NYdb::NScheme::TPermissions>{NYdb::NScheme::TPermissions(BUILTIN_ACL_ROOT, {"ydb.generic.full"})});
+
+        NACLib::TDiffACL acl;
+        acl.ClearAccess();
+        acl.SetInterruptInheritance(true);
+
+        ydb.CreateTableInDbSync(EXTENDED_COLUMNS, 1, TEST_TABLE_PATH, TEST_KEY_COLUMNS, {}, true, acl);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, EXTENDED_COLUMNS, true, std::vector<NYdb::NScheme::TPermissions>());
+    }
+
+    Y_UNIT_TEST(UpdateTableWithAclRollback) {
+        TScriptExecutionsYdbSetup ydb;
+
+        NACLib::TDiffACL aclInterrupt;
+        aclInterrupt.ClearAccess();
+        aclInterrupt.SetInterruptInheritance(true);
+
+        ydb.CreateTableInDbSync(DEFAULT_COLUMNS, 1, TEST_TABLE_PATH, TEST_KEY_COLUMNS, {}, true, aclInterrupt);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, DEFAULT_COLUMNS, true, std::vector<NYdb::NScheme::TPermissions>());
+
+        NACLib::TDiffACL aclRollback;
+        aclRollback.ClearAccess();
+        aclRollback.SetInterruptInheritance(false);
+
+        ydb.CreateTableInDbSync(EXTENDED_COLUMNS, 1, TEST_TABLE_PATH, TEST_KEY_COLUMNS, {}, false, aclRollback);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, EXTENDED_COLUMNS, true, std::vector<NYdb::NScheme::TPermissions>{NYdb::NScheme::TPermissions(BUILTIN_ACL_ROOT, {"ydb.generic.full"})});
+    }
+
+    Y_UNIT_TEST(UpdateTableAcl) {
+        TScriptExecutionsYdbSetup ydb;
+
+        ydb.CreateTableInDbSync(DEFAULT_COLUMNS);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, DEFAULT_COLUMNS, false, std::vector<NYdb::NScheme::TPermissions>{NYdb::NScheme::TPermissions(BUILTIN_ACL_ROOT, {"ydb.generic.full"})});
+
+        NACLib::TDiffACL acl;
+        acl.ClearAccess();
+        acl.SetInterruptInheritance(true);
+
+        ydb.CreateTableInDbSync(DEFAULT_COLUMNS, 1, TEST_TABLE_PATH, TEST_KEY_COLUMNS, {}, true, acl);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, DEFAULT_COLUMNS, true, std::vector<NYdb::NScheme::TPermissions>());
+    }
+
+    Y_UNIT_TEST(RollbackTableAcl) {
+        TScriptExecutionsYdbSetup ydb;
+
+        NACLib::TDiffACL aclInterrupt;
+        aclInterrupt.ClearAccess();
+        aclInterrupt.SetInterruptInheritance(true);
+
+        ydb.CreateTableInDbSync(DEFAULT_COLUMNS, 1, TEST_TABLE_PATH, TEST_KEY_COLUMNS, {}, true, aclInterrupt);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, DEFAULT_COLUMNS, true, std::vector<NYdb::NScheme::TPermissions>());
+
+        NACLib::TDiffACL aclRollback;
+        aclRollback.ClearAccess();
+        aclRollback.SetInterruptInheritance(false);
+
+        ydb.CreateTableInDbSync(DEFAULT_COLUMNS, 1, TEST_TABLE_PATH, TEST_KEY_COLUMNS, {}, false, aclRollback);
+        ydb.VerifyColumnsList(TEST_TABLE_PATH, DEFAULT_COLUMNS, true, std::vector<NYdb::NScheme::TPermissions>{NYdb::NScheme::TPermissions(BUILTIN_ACL_ROOT, {"ydb.generic.full"})});
+    }
+
     Y_UNIT_TEST(ConcurrentUpdateTable) {
         TScriptExecutionsYdbSetup ydb;
 
@@ -839,7 +988,6 @@ Y_UNIT_TEST_SUITE(TableCreation) {
         ydb.CreateTableInDbSync(DEFAULT_COLUMNS);
         ydb.VerifyColumnsList(TEST_TABLE_PATH, EXTENDED_COLUMNS);
     }
-
 }
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -94,6 +94,8 @@ struct TScriptExecutionsYdbSetup {
 
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableFeatureFlags()->SetEnableSecureScriptExecutions(secureScriptExecutions);
+        appConfig.MutableTableServiceConfig()->SetEnableOltpSink(true);
+        appConfig.MutableTableServiceConfig()->SetEnableDataShardCreateTableAs(true);
 
         MsgBusPort = PortManager.GetPort(2134);
         GrpcPort = PortManager.GetPort(2135);

--- a/ydb/core/kqp/proxy_service/ya.make
+++ b/ydb/core/kqp/proxy_service/ya.make
@@ -9,8 +9,6 @@ SRCS(
 )
 
 PEERDIR(
-    ydb/library/actors/core
-    ydb/library/actors/http
     library/cpp/protobuf/interop
     library/cpp/protobuf/json
     ydb/core/actorlib_impl
@@ -20,27 +18,30 @@ PEERDIR(
     ydb/core/kqp/common/events
     ydb/core/kqp/counters
     ydb/core/kqp/gateway/behaviour/resource_pool_classifier
+    ydb/core/kqp/gateway/behaviour/streaming_query
     ydb/core/kqp/proxy_service/proto
     ydb/core/kqp/proxy_service/script_executions_utils
     ydb/core/kqp/run_script_actor
     ydb/core/kqp/workload_service
     ydb/core/mind
+    ydb/core/mon
     ydb/core/protos
-    ydb/core/tx/tx_proxy
     ydb/core/tx/scheme_cache
     ydb/core/tx/schemeshard
-    ydb/core/mon
+    ydb/core/tx/tx_proxy
+    ydb/library/actors/core
+    ydb/library/actors/http
     ydb/library/query_actor
     ydb/library/table_creator
-    ydb/library/yql/providers/common/http_gateway
-    yql/essentials/providers/common/proto
-    ydb/library/yql/providers/s3/actors_factory
-    yql/essentials/public/issue
     ydb/library/yql/dq/actors/spilling
+    ydb/library/yql/providers/common/http_gateway
+    ydb/library/yql/providers/s3/actors_factory
     ydb/public/api/protos
-    ydb/public/sdk/cpp/src/library/operation_id
     ydb/public/lib/scheme_types
     ydb/public/sdk/cpp/src/client/params
+    ydb/public/sdk/cpp/src/library/operation_id
+    yql/essentials/providers/common/proto
+    yql/essentials/public/issue
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -609,11 +609,11 @@ TStringBuf RemoveJoinAliases(TStringBuf keyName) {
 
 class TKqpQueryCompiler : public IKqpQueryCompiler {
 public:
-    TKqpQueryCompiler(const TString& cluster, const TString& database, const TIntrusivePtr<TKikimrTablesData> tablesData,
-        const NMiniKQL::IFunctionRegistry& funcRegistry, TTypeAnnotationContext& typesCtx, NYql::TKikimrConfiguration::TPtr config)
+    TKqpQueryCompiler(const TString& cluster,
+        const NMiniKQL::IFunctionRegistry& funcRegistry, TTypeAnnotationContext& typesCtx,
+        NOpt::TKqpOptimizeContext& optimizeCtx, NYql::TKikimrConfiguration::TPtr config)
         : Cluster(cluster)
-        , Database(database)
-        , TablesData(tablesData)
+        , TablesData(optimizeCtx.Tables)
         , FuncRegistry(funcRegistry)
         , Alloc(__LOCATION__, TAlignedPagePoolCounters(), funcRegistry.SupportsSizedAllocators())
         , TypeEnv(Alloc)
@@ -1933,11 +1933,11 @@ private:
 
 } // namespace
 
-TIntrusivePtr<IKqpQueryCompiler> CreateKqpQueryCompiler(const TString& cluster, const TString& database,
-    const TIntrusivePtr<TKikimrTablesData> tablesData, const IFunctionRegistry& funcRegistry,
-    TTypeAnnotationContext& typesCtx, NYql::TKikimrConfiguration::TPtr config)
+TIntrusivePtr<IKqpQueryCompiler> CreateKqpQueryCompiler(const TString& cluster,
+    const IFunctionRegistry& funcRegistry, TTypeAnnotationContext& typesCtx,
+    NOpt::TKqpOptimizeContext& optimizeCtx, NYql::TKikimrConfiguration::TPtr config)
 {
-    return MakeIntrusive<TKqpQueryCompiler>(cluster, database, tablesData, funcRegistry, typesCtx, config);
+    return MakeIntrusive<TKqpQueryCompiler>(cluster, funcRegistry, typesCtx, optimizeCtx, config);
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.h
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <ydb/core/kqp/expr_nodes/kqp_expr_nodes.h>
+#include <ydb/core/kqp/opt/kqp_opt.h>
 #include <ydb/core/kqp/provider/yql_kikimr_expr_nodes.h>
+#include <ydb/core/kqp/provider/yql_kikimr_provider.h>
 #include <ydb/core/kqp/provider/yql_kikimr_settings.h>
 #include <ydb/core/protos/kqp_physical.pb.h>
-
-#include <ydb/core/kqp/provider/yql_kikimr_provider.h>
 
 namespace NKikimr {
 namespace NKqp {
@@ -18,8 +18,8 @@ public:
 };
 
 TIntrusivePtr<IKqpQueryCompiler> CreateKqpQueryCompiler(const TString& cluster,
-    const TIntrusivePtr<NYql::TKikimrTablesData> tablesData, const NMiniKQL::IFunctionRegistry& funcRegistry,
-    NYql::TTypeAnnotationContext& typesCtx, NYql::TKikimrConfiguration::TPtr config);
+    const NMiniKQL::IFunctionRegistry& funcRegistry, NYql::TTypeAnnotationContext& typesCtx,
+    NOpt::TKqpOptimizeContext& optimizeCtx, NYql::TKikimrConfiguration::TPtr config);
 
 } // namespace NKqp
 } // namespace NKikimr

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -1865,21 +1865,21 @@ private:
         return result;
     }
 
-    void SendData(NMiniKQL::TUnboxedValueBatch&& data, i64 size, const TMaybe<NYql::NDqProto::TCheckpoint>&, bool finished) final {
+    void SendData(NMiniKQL::TUnboxedValueBatch&& data, i64 size, const TMaybe<NYql::NDqProto::TCheckpoint>& checkpoint, bool finished) final {
         YQL_ENSURE(!data.IsWide(), "Wide stream is not supported yet");
-        YQL_ENSURE(!Closed);
+        YQL_ENSURE(!Closed || data.empty());
         Closed = finished;
         EgressStats.Resume();
         Y_UNUSED(size);
 
         try {
-            Batcher->AddData(data);
-            YQL_ENSURE(WriteTableActor);
-            WriteTableActor->Write(WriteToken, GetOperation(Settings.GetType()), Batcher->Build());
-            if (Closed) {
-                WriteTableActor->Close(WriteToken);
-                WriteTableActor->FlushBuffers();
-                WriteTableActor->Close();
+            if (!data.empty()) {
+                Batcher->AddData(data);
+                DataBuffer.emplace(Batcher->Build());
+            }
+
+            if (checkpoint) {
+                DataBuffer.emplace(*checkpoint);
             }
         } catch (const TMemoryLimitExceededException&) {
             RuntimeError(
@@ -1903,6 +1903,32 @@ private:
 
     void Process() {
         try {
+            YQL_ENSURE(WriteTableActor);
+            if (CheckpointInProgress && WriteTableActor->IsEmpty()) {
+                DoCheckpoint();
+            }
+
+            while (!DataBuffer.empty() && !CheckpointInProgress) {
+                auto variant = std::move(DataBuffer.front());
+                DataBuffer.pop();
+
+                if (std::holds_alternative<IDataBatchPtr>(variant)) {
+                    WriteTableActor->Write(WriteToken, GetOperation(Settings.GetType()), std::get<IDataBatchPtr>(std::move(variant)));
+                } else if (std::holds_alternative<NYql::NDqProto::TCheckpoint>(variant)) {
+                    CheckpointInProgress = std::get<NYql::NDqProto::TCheckpoint>(std::move(variant));
+                    WriteTableActor->FlushBuffers();
+                    if (WriteTableActor->IsEmpty()) {
+                        DoCheckpoint();
+                    }
+                }
+            }
+
+            if (Closed && DataBuffer.empty() && !WriteTableActor->IsClosed()) {
+                WriteTableActor->Close(WriteToken);
+                WriteTableActor->FlushBuffers();
+                WriteTableActor->Close();
+            }
+
             const bool outOfMemory = GetFreeSpace() <= 0;
             if (outOfMemory) {
                 WaitingForTableActor = true;
@@ -1924,7 +1950,7 @@ private:
                 WriteTableActor->FlushBuffers();
             }
 
-            if (Closed || outOfMemory) {
+            if (Closed || outOfMemory || CheckpointInProgress) {
                 if (!WriteTableActor->FlushToShards()) {
                     return;
                 }
@@ -2020,6 +2046,12 @@ private:
         }
     }
 
+    void DoCheckpoint() {
+        YQL_ENSURE(CheckpointInProgress);
+        Callbacks->OnAsyncOutputStateSaved({}, OutputIndex, *CheckpointInProgress);
+        CheckpointInProgress = std::nullopt;
+    }
+
     TString LogPrefix;
     const NKikimrKqp::TKqpTableSinkSettings Settings;
     TWriteActorSettings MessageSettings;
@@ -2036,6 +2068,8 @@ private:
     TActorId WriteTableActorId;
 
     TKqpTableWriteActor::TWriteToken WriteToken = 0;
+    std::queue<std::variant<IDataBatchPtr, NYql::NDqProto::TCheckpoint>> DataBuffer;
+    std::optional<NYql::NDqProto::TCheckpoint> CheckpointInProgress;
 
     bool Closed = false;
     bool WaitingForTableActor = false;

--- a/ydb/core/kqp/runtime/kqp_write_table.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_table.cpp
@@ -707,7 +707,7 @@ public:
             return res;
         }
 
-        auto poolAlloc = CreateOffloadedPoolAllocator(std::move(Alloc));
+        auto poolAlloc = CreateOffloadedPoolAllocator(Alloc);
         return MakeIntrusive<TRowBatch>(TOwnedCellVecBatch(poolAlloc->CreateMemoryPool()), poolAlloc);
     }
 
@@ -719,7 +719,7 @@ public:
         if (Batches.empty() || (MaxBytesPerBatch && newMemorySerialized + Batches.back()->GetMemorySerialized() > *MaxBytesPerBatch)) {
             Batches.emplace_back(std::make_unique<TBatch>(Alloc));
         }
-        
+
         AFL_ENSURE(newMemory == Batches.back()->AddRow(std::move(row)));
         Memory += newMemory;
     }
@@ -1182,8 +1182,9 @@ class TShardsInfo {
 public:
     class TShardInfo {
         friend class TShardsInfo;
-        TShardInfo(i64& memory, ui64& nextCookie, bool& closed)
+        TShardInfo(i64& memory, ui64& pendingBatches, ui64& nextCookie, bool& closed)
             : Memory(memory)
+            , PendingBatches(pendingBatches)
             , NextCookie(nextCookie)
             , Cookie(NextCookie++)
             , Closed(closed) {
@@ -1238,6 +1239,7 @@ public:
                     const i64 batchMemory = Batches.front().GetMemory();
                     result.DataSize += batchMemory;
                     Memory -= batchMemory;
+                    PendingBatches--;
                     Batches.pop_front();
                 }
 
@@ -1254,6 +1256,7 @@ public:
             AFL_ENSURE(!IsClosed());
             Batches.emplace_back(std::move(batch));
             Memory += Batches.back().GetMemory();
+            PendingBatches++;
             HasReadInBatch |= Batches.back().HasRead;
         }
 
@@ -1292,6 +1295,7 @@ public:
     private:
         std::deque<TBatchWithMetadata> Batches;
         i64& Memory;
+        ui64& PendingBatches;
         bool HasReadInBatch = false;
 
         ui64& NextCookie;
@@ -1310,7 +1314,7 @@ public:
             return it->second;
         }
 
-        auto [insertIt, _] = ShardsInfo.emplace(shard, TShardInfo(Memory, NextCookie, Closed));
+        auto [insertIt, _] = ShardsInfo.emplace(shard, TShardInfo(Memory, PendingBatches, NextCookie, Closed));
         return insertIt->second;
     }
 
@@ -1330,12 +1334,7 @@ public:
     }
 
     bool IsEmpty() const {
-        for (const auto& [_, shard] : ShardsInfo) {
-            if (!shard.IsEmpty()) {
-                return false;
-            }
-        }
-        return true;
+        return PendingBatches == 0;
     }
 
     bool IsFinished() const {
@@ -1373,6 +1372,7 @@ private:
     THashMap<ui64, TShardInfo> ShardsInfo;
     i64 Memory = 0;
     ui64 NextCookie = 1;
+    ui64 PendingBatches = 0;
     bool Closed = false;
 };
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1312,9 +1312,21 @@ public:
         }
 
         const auto& txCtx = *QueryState->TxCtx;
-        if (txCtx.HasTableRead || txCtx.HasTableWrite || txCtx.TopicOperations.GetSize() != 0) {
-            ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, "Save state of query is not supported for table and topic operations");
+        if (txCtx.HasTableRead || txCtx.TopicOperations.GetSize() != 0) {
+            ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, "Save state of query is not supported for table reads and topic operations");
             return false;
+        }
+
+        if (txCtx.HasTableWrite) {
+            if (txCtx.HasOlapTable && !txCtx.EnableOlapSink.value_or(false)) {
+                ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, "Save state of query is not supported for column table writes without enabled olap sink");
+                return false;
+            }
+
+            if (txCtx.HasOltpTable && !txCtx.EnableOltpSink.value_or(false)) {
+                ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, "Save state of query is not supported for row table writes without enabled oltp sink");
+                return false;
+            }
         }
 
         if (!tx) {

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/cms/console/console.h>
 #include <ydb/core/external_sources/external_source.h>
 #include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/kqp_script_executions.h>
@@ -566,7 +567,7 @@ public:
         const auto edgeActor = runtime.AllocateEdgeActor();
         runtime.Register(CreateGetScriptExecutionPhysicalGraphActor(edgeActor, TEST_DATABASE, executionId));
 
-        const auto graph = runtime.GrabEdgeEvent<TEvGetScriptPhysicalGraphResponse>(edgeActor, TDuration::Seconds(10));
+        const auto graph = runtime.GrabEdgeEvent<TEvGetScriptPhysicalGraphResponse>(edgeActor, TEST_OPERATION_TIMEOUT);
         UNIT_ASSERT_C(graph, "Empty graph response");
         UNIT_ASSERT_VALUES_EQUAL_C(graph->Get()->Status, Ydb::StatusIds::SUCCESS, graph->Get()->Issues.ToOneLineString());
 
@@ -2424,7 +2425,8 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
     }
 
     Y_UNIT_TEST_F(StreamingQueryUnderSecureScriptExecutions, TStreamingTestFixture) {
-        SetupAppConfig().MutableFeatureFlags()->SetEnableSecureScriptExecutions(true);
+        auto& appConfig = SetupAppConfig();
+        appConfig.MutableFeatureFlags()->SetEnableSecureScriptExecutions(true);
         GetRuntime().GetAppData().FeatureFlags.SetEnableSecureScriptExecutions(true);
 
         constexpr char inputTopicName[] = "streamingQueryUnderSecureScriptExecutionsInputTopic";
@@ -2487,7 +2489,50 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             UNIT_ASSERT_VALUES_EQUAL(result.GetList().size(), 0);
         }
 
-        ExecQuery("SELECT COUNT(*) FROM `.metadata/streaming/queries`", EStatus::SCHEME_ERROR, "Cannot find table");
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+        ExecQuery("GRANT ALL ON `/Root/.metadata` TO `" BUILTIN_ACL_ROOT "`");
+        ExecQuery("GRANT ALL ON `/Root/.metadata/streaming` TO `" BUILTIN_ACL_ROOT "`");
+
+        const auto testNoAccess = [&]() {
+            ExecQuery("SELECT COUNT(*) FROM `.metadata/streaming/queries`", EStatus::SCHEME_ERROR, "Cannot find table");
+        };
+        const auto testAccessAllowed = [&]() {
+            const auto& result = ExecQuery("SELECT COUNT(*) FROM `.metadata/streaming/queries`");
+            UNIT_ASSERT_VALUES_EQUAL(result.size(), 1);
+
+            CheckScriptResult(result[0], 1, 1, [](TResultSetParser& parser) {
+                UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(0).GetUint64(), 1);
+            });
+        };
+        const auto switchAccess = [&](bool allowed) {
+            auto& runtime = GetRuntime();
+            runtime.GetAppData().FeatureFlags.SetEnableSecureScriptExecutions(!allowed);
+
+            auto ev = std::make_unique<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+            appConfig.MutableFeatureFlags()->SetEnableSecureScriptExecutions(!allowed);
+            *ev->Record.MutableConfig() = appConfig;
+
+            const auto edgeActor = runtime.AllocateEdgeActor();
+            runtime.Send(MakeKqpProxyID(runtime.GetNodeId()), edgeActor, ev.release());
+            const auto response = runtime.GrabEdgeEvent<NConsole::TEvConsole::TEvConfigNotificationResponse>(edgeActor, TEST_OPERATION_TIMEOUT);
+            UNIT_ASSERT(response);
+            Sleep(TDuration::Seconds(1));
+
+            ExecQuery(fmt::format(R"(
+                ALTER STREAMING QUERY `{query_name}` SET (
+                    RUN = FALSE
+                ))",
+                "query_name"_a = queryName
+            ));
+        };
+
+        testNoAccess();
+
+        switchAccess(/* allowed */ true);
+        testAccessAllowed();
+
+        switchAccess(/* allowed */ false);
+        testNoAccess();
     }
 
     Y_UNIT_TEST_F(OffsetsAndStateRecoveryOnInternalRetry, TStreamingTestFixture) {

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -118,6 +118,8 @@ public:
             auto& queryServiceConfig = *AppConfig->MutableQueryServiceConfig();
             queryServiceConfig.SetEnableMatchRecognize(true);
 
+            AppConfig->MutableTableServiceConfig()->SetEnableOltpSink(true);
+
             LogSettings
                 .AddLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NLog::PRI_DEBUG)
                 .AddLogPriority(NKikimrServices::STREAMS_CHECKPOINT_COORDINATOR, NLog::PRI_DEBUG)

--- a/ydb/core/kqp/ut/federated_query/datastreams/ya.make
+++ b/ydb/core/kqp/ut/federated_query/datastreams/ya.make
@@ -11,6 +11,7 @@ SRCS(
 
 PEERDIR(
     library/cpp/threading/local_executor
+    ydb/core/cms/console
     ydb/core/kqp
     ydb/core/kqp/ut/common
     ydb/core/kqp/ut/federated_query/common

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12869,7 +12869,18 @@ END DO)",
                 END DO)",
                 NQuery::TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToOneLineString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Streaming query with more than one streaming write to topic is not supported now");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Streaming query with more than one write is not supported now");
+        }
+
+        {
+            const auto result = db.ExecuteQuery(TStringBuilder() << prefix << R"(
+                AS DO BEGIN
+                    INSERT INTO MySource.MyTopic SELECT * FROM MySource.MyTopic;
+                    UPSERT INTO `MyFolder/MyTable` (Key) VALUES ("1");
+                END DO)",
+                NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToOneLineString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Streaming query with more than one write is not supported now");
         }
 
         {
@@ -12899,7 +12910,7 @@ END DO)",
                 END DO)",
                 NQuery::TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToOneLineString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Writing into YDB tables is not supported now for streaming queries");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Only UPSERT writing mode is supported for YDB writes inside streaming queries, got mode: INSERT_ABORT");
         }
 
         {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -8228,6 +8228,19 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             const auto& externalDataSource = externalDataSourceDesc->ResultSet.at(0);
             UNIT_ASSERT_VALUES_EQUAL(externalDataSource.ExternalDataSourceInfo->Description.GetLocation(), "other-bucket");
         }
+
+        {
+            const auto result = queryClient.ExecuteQuery(fmt::format(R"(
+                CREATE OR REPLACE EXTERNAL DATA SOURCE `{external_source}` WITH (
+                    SOURCE_TYPE="YT",
+                    LOCATION="other-bucket",
+                    AUTH_METHOD="NONE"
+                );)",
+                "external_source"_a = externalDataSourceName
+            ), NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToOneLineString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Changing external data source type is not allowed");
+        }
     }
 
     Y_UNIT_TEST(CreateExternalDataSourceWithSa) {
@@ -8560,6 +8573,19 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             const auto& externalTable = externalTableDesc->ResultSet.at(0);
             UNIT_ASSERT_VALUES_EQUAL(externalTable.ExternalTableInfo->Description.GetLocation(), "/other/location/");
         }
+
+        {
+            const auto result = queryClient.ExecuteQuery(fmt::format(R"(
+                CREATE OR REPLACE EXTERNAL DATA SOURCE `{external_source}` WITH (
+                    SOURCE_TYPE="YT",
+                    LOCATION="other-bucket",
+                    AUTH_METHOD="NONE"
+                );)",
+                "external_source"_a = externalDataSourceName
+            ), NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToOneLineString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Changing external data source type is not allowed");
+        }
     }
 
     Y_UNIT_TEST(DisableCreateExternalTable) {
@@ -8865,6 +8891,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         NKikimrConfig::TAppConfig config;
         config.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
         config.MutableQueryServiceConfig()->MutableS3()->SetGeneratorPathsLimit(50000);
+        config.MutableFeatureFlags()->SetEnableReplaceIfExistsForExternalEntities(true);
         TKikimrRunner kikimr{ NKqp::TKikimrSettings(config) };
 
         kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.SetEnableExternalDataSources(true);
@@ -8904,6 +8931,28 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             auto query = TStringBuilder() << R"( DROP EXTERNAL DATA SOURCE `)" << externalDataSourceName << "`";
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Other entities depend on this data source, please remove them at the beginning: /Root/ExternalTable", result.GetIssues().ToString());
+        }
+
+        auto queryClient = kikimr.GetQueryClient();
+        {
+            const auto result = queryClient.ExecuteQuery(fmt::format(R"(
+                CREATE OR REPLACE EXTERNAL DATA SOURCE `{external_source}` WITH (
+                    SOURCE_TYPE="ObjectStorage",
+                    LOCATION="other-bucket",
+                    AUTH_METHOD="NONE"
+                );)",
+                "external_source"_a = externalDataSourceName
+            ), NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+        }
+
+        {
+            const auto result = session.ExecuteSchemeQuery(fmt::format(
+                "DROP EXTERNAL DATA SOURCE `{external_source}`",
+                "external_source"_a = externalDataSourceName
+            )).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToOneLineString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Other entities depend on this data source, please remove them at the beginning: /Root/ExternalTable");
         }
     }
 

--- a/ydb/core/sys_view/streaming_queries/streaming_queries.cpp
+++ b/ydb/core/sys_view/streaming_queries/streaming_queries.cpp
@@ -26,8 +26,6 @@ namespace {
 
 using namespace fmt::literals;
 
-constexpr char STREAMING_QUERIES_TABLE[] = ".metadata/streaming/queries";
-
 struct TEvPrivate {
     // Event ids
     enum EEv : ui32 {
@@ -176,7 +174,7 @@ private:
                 ORDER BY database_id, query_path {order}
                 LIMIT $limit;
             )",
-            "table"_a = STREAMING_QUERIES_TABLE,
+            "table"_a = NKqp::TStreamingQueryMeta::GetTablesPath(),
             "params_decl"_a = paramsDecl,
             "range_filter"_a = rangeFilter,
             "order"_a = Settings.Reverse ? "DESC" : "ASC"
@@ -447,7 +445,7 @@ class TStreamingQueriesTablesCheckerActor final : public TSchemeDescribeActorBas
 
 public:
     TStreamingQueriesTablesCheckerActor(const TString& database)
-        : TBase(__func__, database, {JoinPath({database, STREAMING_QUERIES_TABLE})}, MakeIntrusive<NACLib::TUserToken>(BUILTIN_ACL_METADATA, TVector<NACLib::TSID>{}))
+        : TBase(__func__, database, {JoinPath({database, NKqp::TStreamingQueryMeta::GetTablesPath()})}, MakeIntrusive<NACLib::TUserToken>(BUILTIN_ACL_METADATA, TVector<NACLib::TSID>{}))
     {}
 
 protected:

--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -1637,10 +1637,12 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 break;
             case NKikimrSchemeOp::EPathTypeExternalTable:
                 Kind = TNavigate::KindExternalTable;
+                SchemaVersion = entryDesc.HasVersion() ? entryDesc.GetVersion().GetExternalTableVersion() : 0;
                 FillInfo(Kind, ExternalTableInfo, std::move(*pathDesc.MutableExternalTableDescription()));
                 break;
             case NKikimrSchemeOp::EPathTypeExternalDataSource:
                 Kind = TNavigate::KindExternalDataSource;
+                SchemaVersion = entryDesc.HasVersion() ? entryDesc.GetVersion().GetExternalDataSourceVersion() : 0;
                 FillInfo(Kind, ExternalDataSourceInfo, std::move(*pathDesc.MutableExternalDataSourceDescription()));
                 break;
             case NKikimrSchemeOp::EPathTypeBlockStoreVolume:

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
@@ -7,10 +7,9 @@
 
 #include <utility>
 
-namespace {
+namespace NKikimr::NSchemeShard {
 
-using namespace NKikimr;
-using namespace NSchemeShard;
+namespace {
 
 class TPropose: public TSubOperationState {
 private:
@@ -194,10 +193,9 @@ public:
     THolder<TProposeResponse> Propose(const TString& owner,
                                       TOperationContext& context) override {
         Y_UNUSED(owner);
-        const auto ssId              = context.SS->SelfTabletId();
+        const auto ssId = context.SS->SelfTabletId();
         const TString& parentPathStr = Transaction.GetWorkingDir();
-        const auto& externalDataSourceDescription =
-            Transaction.GetCreateExternalDataSource();
+        const auto& externalDataSourceDescription = Transaction.GetCreateExternalDataSource();
         const TString& name = externalDataSourceDescription.GetName();
 
         LOG_N("TAlterExternalDataSource Propose"
@@ -215,8 +213,7 @@ public:
         }
 
         const TPath parentPath = TPath::Resolve(parentPathStr, context.SS);
-        RETURN_RESULT_UNLESS(NExternalDataSource::IsParentPathValid(
-            result, parentPath, Transaction, /* isCreate */ false));
+        RETURN_RESULT_UNLESS(NExternalDataSource::IsParentPathValid(result, parentPath, Transaction, /* isCreate */ false));
 
         const TPath dstPath = parentPath.Child(name);
 
@@ -224,13 +221,14 @@ public:
         RETURN_RESULT_UNLESS(IsApplyIfChecksPassed(result, context));
         RETURN_RESULT_UNLESS(IsDescriptionValid(result, externalDataSourceDescription, context.SS->ExternalSourceFactory));
 
-        const auto oldExternalDataSourceInfo =
-        context.SS->ExternalDataSources.Value(dstPath->PathId, nullptr);
+        const auto oldExternalDataSourceInfo = context.SS->ExternalDataSources.Value(dstPath->PathId, nullptr);
         Y_ABORT_UNLESS(oldExternalDataSourceInfo);
-        const TExternalDataSourceInfo::TPtr externalDataSourceInfo =
-            NExternalDataSource::CreateExternalDataSource(externalDataSourceDescription,
-                                     oldExternalDataSourceInfo->AlterVersion + 1);
+        const TExternalDataSourceInfo::TPtr externalDataSourceInfo = NExternalDataSource::CreateExternalDataSource(
+            externalDataSourceDescription,
+            oldExternalDataSourceInfo->AlterVersion + 1
+        );
         Y_ABORT_UNLESS(externalDataSourceInfo);
+        externalDataSourceInfo->ExternalTableReferences = oldExternalDataSourceInfo->ExternalTableReferences;
 
         {
             bool isTieredStorage = false;
@@ -250,9 +248,13 @@ public:
             }
         }
 
+        if (oldExternalDataSourceInfo->SourceType != externalDataSourceInfo->SourceType) {
+            result->SetError(NKikimrScheme::StatusSchemeError, "Changing external data source type is not allowed");
+            return result;
+        }
+
         AddPathInSchemeShard(result, dstPath);
-        const TPathElement::TPtr externalDataSource =
-            ReplaceExternalDataSourcePathElement(dstPath);
+        const TPathElement::TPtr externalDataSource = ReplaceExternalDataSourcePathElement(dstPath);
         CreateTransaction(context, externalDataSource->PathId);
 
         NIceDb::TNiceDb db(context.GetDB());
@@ -261,8 +263,7 @@ public:
 
         AdvanceTransactionStateToPropose(context, db);
 
-        PersistExternalDataSource(
-            context, db, externalDataSource, externalDataSourceInfo);
+        PersistExternalDataSource(context, db, externalDataSource, externalDataSourceInfo);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,
@@ -286,9 +287,7 @@ public:
     }
 };
 
-} // namespace
-
-namespace NKikimr::NSchemeShard {
+} // anonymous namespace
 
 ISubOperation::TPtr CreateAlterExternalDataSource(TOperationId id, const TTxTransaction& tx) {
     return MakeSubOperation<TAlterExternalDataSource>(id, tx);
@@ -299,4 +298,4 @@ ISubOperation::TPtr CreateAlterExternalDataSource(TOperationId id, TTxState::ETx
     return MakeSubOperation<TAlterExternalDataSource>(id, state);
 }
 
-}
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.cpp
@@ -105,16 +105,15 @@ bool Validate(const NKikimrSchemeOp::TExternalDataSourceDescription& desc,
     }
 }
 
-TExternalDataSourceInfo::TPtr CreateExternalDataSource(
-    const NKikimrSchemeOp::TExternalDataSourceDescription& desc, ui64 alterVersion) {
-    TExternalDataSourceInfo::TPtr externalDataSoureInfo = new TExternalDataSourceInfo;
-    externalDataSoureInfo->SourceType                   = desc.GetSourceType();
-    externalDataSoureInfo->Location                     = desc.GetLocation();
-    externalDataSoureInfo->Installation                 = desc.GetInstallation();
-    externalDataSoureInfo->AlterVersion                 = alterVersion;
-    externalDataSoureInfo->Auth.CopyFrom(desc.GetAuth());
-    externalDataSoureInfo->Properties.CopyFrom(desc.GetProperties());
-    return externalDataSoureInfo;
+TExternalDataSourceInfo::TPtr CreateExternalDataSource(const NKikimrSchemeOp::TExternalDataSourceDescription& desc, ui64 alterVersion) {
+    auto externalDataSourceInfo = MakeIntrusive<TExternalDataSourceInfo>();
+    externalDataSourceInfo->SourceType = desc.GetSourceType();
+    externalDataSourceInfo->Location = desc.GetLocation();
+    externalDataSourceInfo->Installation = desc.GetInstallation();
+    externalDataSourceInfo->AlterVersion = alterVersion;
+    externalDataSourceInfo->Auth = desc.GetAuth();
+    externalDataSourceInfo->Properties = desc.GetProperties();
+    return externalDataSourceInfo;
 }
 
 } // namespace NKikimr::NSchemeShard::NExternalDataSource

--- a/ydb/library/table_creator/table_creator.h
+++ b/ydb/library/table_creator/table_creator.h
@@ -80,6 +80,6 @@ NActors::IActor* CreateTableCreator(
     const TString& database = {},
     bool isSystemUser = false,
     TMaybe<NKikimrSchemeOp::TPartitioningPolicy> partitioningPolicy = Nothing(),
-    TMaybe<NACLib::TDiffACL> newTableAcl = Nothing());
+    TMaybe<NACLib::TDiffACL> tableAclDiff = Nothing());
 
 } // namespace NKikimr

--- a/ydb/library/yql/providers/generic/actors/yql_generic_credentials_provider.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_credentials_provider.cpp
@@ -8,8 +8,6 @@ namespace NYql::NDq {
     TGenericCredentialsProvider::TGenericCredentialsProvider(
         const TString& structuredTokenJSON,
         const ISecuredServiceAccountCredentialsFactory::TPtr& credentialsFactory) {
-        Y_ENSURE(credentialsFactory, "CredentialsFactory is not initialized");
-
         if (IsStructuredTokenJson(structuredTokenJSON)) {
             TStructuredTokenParser parser = CreateStructuredTokenParser(structuredTokenJSON);
             if (parser.HasBasicAuth()) {

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -532,9 +532,8 @@ TDqPqRdReadActor::TDqPqRdReadActor(
         , CredentialsProviderFactory(std::move(credentialsProviderFactory))
         , MaxBufferSize(bufferSize)
 {
-
     SRC_LOG_I("Start read actor, local row dispatcher " << LocalRowDispatcherActorId.ToString() << ", metadatafields: " << JoinSeq(',', SourceParams.GetMetadataFields())
-        << ", partitions: " << JoinSeq(',', GetPartitionsToRead()));
+        << ", partitions: " << JoinSeq(',', GetPartitionsToRead()) << ", skip json errors: " << SourceParams.GetSkipJsonErrors());
     if (Parent != this) {
         return;
     }

--- a/ydb/library/yql/providers/pq/common/yql_names.h
+++ b/ydb/library/yql/providers/pq/common/yql_names.h
@@ -18,5 +18,6 @@ constexpr TStringBuf WatermarksLateArrivalDelayUsSetting = "WatermarksLateArriva
 constexpr TStringBuf WatermarksIdlePartitionsSetting = "WatermarksIdlePartitions";
 constexpr TStringBuf ReconnectPeriod = "ReconnectPeriod";
 constexpr TStringBuf ReadGroup = "ReadGroup";
+constexpr TStringBuf SkipJsonErrors = "SkipJsonErrors";
 
 } // namespace NYql

--- a/ydb/library/yql/providers/pq/proto/dq_io.proto
+++ b/ydb/library/yql/providers/pq/proto/dq_io.proto
@@ -91,6 +91,7 @@ message TDqPqTopicSource {
     string WatermarkExpr = 24;
     repeated uint64 NodeIds = 25;
     bool UseActorSystemThreadsInTopicClient = 26;
+    bool SkipJsonErrors = 27;
 }
 
 message TDqPqTopicSink {

--- a/ydb/library/yql/providers/pq/provider/yql_pq_datasource.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_datasource.cpp
@@ -184,6 +184,10 @@ public:
             settings.Add(topicKeyParser.GetDateFormat());
         }
 
+        if (topicKeyParser.GetSkipJsonErrors()) {
+            settings.Add(topicKeyParser.GetSkipJsonErrors());
+        }
+
         auto builder = Build<TPqReadTopic>(ctx, read.Pos())
             .World(read.World())
             .DataSource(read.DataSource())

--- a/ydb/library/yql/providers/pq/provider/yql_pq_datasource_type_ann.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_datasource_type_ann.cpp
@@ -298,6 +298,19 @@ public:
             }
         }
 
+        if (const auto maybeSkipJsonErrorsSetting = FindSetting(settings, SkipJsonErrors)) {
+            const auto value = maybeSkipJsonErrorsSetting.Cast().Ptr();
+            if (!EnsureAtom(*value, ctx)) {
+                return TStatus::Error;
+            }
+            bool skipJsonErrorsSetting;
+            if (!TryFromString<bool>(value->Content(), skipJsonErrorsSetting)) {
+                ctx.AddError(TIssue(ctx.GetPosition(settings->Pos()), TStringBuilder()
+                    << "Expected bool, but got: " << value->Content()));
+                return TStatus::Error;
+            }
+        }
+
         if (const auto maybeSharedReadingSetting = FindSetting(settings, SharedReading)) {
             const auto value = maybeSharedReadingSetting.Cast().Ptr();
             if (!EnsureAtom(*value, ctx)) {

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -116,13 +116,32 @@ public:
                 }
             }
 
+            bool skipJsonErrors = false;
+            if (auto settingsList = pqReadTopic.Settings().Maybe<TExprList>()) {
+                for (const TExprNode::TPtr& s : pqReadTopic.Settings().Raw()->Children()) {
+                    if (s->ChildrenSize() >= 2 && s->Child(0)->Content() == "skip.json.errors"sv) {
+                        if (!TryFromString<bool>(s->Child(1)->Content(), skipJsonErrors)) {
+                            ctx.AddError(TIssue(ctx.GetPosition(pqReadTopic.Pos()), R"("skip.json.errors" must be boolean type))"));
+                            return {};
+                        }
+                    }
+                }
+            }
+
+            if (skipJsonErrors) {
+                auto clusterConfiguration = GetClusterConfiguration(clusterName);
+                if (!UseSharedReading(clusterConfiguration, format) ) {
+                    ctx.AddError(TIssue(ctx.GetPosition(pqReadTopic.Pos()), R"("skip.json.errors" is supported only in shared reading mode))"));
+                    return {};
+                }
+            }
 
             return Build<TDqSourceWrap>(ctx, pos)
                 .Input<TDqPqTopicSource>()
                     .World(pqReadTopic.World())
                     .Topic(pqReadTopic.Topic())
                     .Columns(std::move(columnNames))
-                    .Settings(BuildTopicReadSettings(clusterName, wrSettings, pos, format, ctx))
+                    .Settings(BuildTopicReadSettings(clusterName, wrSettings, pos, format, skipJsonErrors, ctx))
                     .Token<TCoSecureParam>()
                         .Name().Build(token)
                         .Build()
@@ -218,6 +237,7 @@ public:
                 }
 
                 bool sharedReading = false;
+                bool skipErrors = false;
                 TString format;
                 size_t const settingsCount = topicSource.Settings().Size();
                 for (size_t i = 0; i < settingsCount; ++i) {
@@ -247,6 +267,8 @@ public:
                         srcDesc.MutableWatermarks()->SetLateArrivalDelayUs(FromString<ui64>(Value(setting)));
                     } else if (name == WatermarksIdlePartitionsSetting) {
                         srcDesc.MutableWatermarks()->SetIdlePartitionsEnabled(true);
+                    } else if (name == SkipJsonErrors) {
+                        skipErrors = FromString<bool>(Value(setting));
                     }
                 }
 
@@ -296,6 +318,8 @@ public:
                     srcDesc.SetPredicate(predicateSql);
                     srcDesc.SetSharedReading(true);
                 }
+                srcDesc.SetSkipJsonErrors(skipErrors);
+
                 *srcDesc.MutableDisposition() = State_->Disposition;
 
                 for (const auto& [label, value] : State_->TaskSensorLabels) {
@@ -390,6 +414,7 @@ public:
         const IDqIntegration::TWrapReadSettings& wrSettings,
         TPositionHandle pos,
         std::string_view format,
+        bool skipJsonErrors,
         TExprContext& ctx) const
     {
         TVector<TCoNameValueTuple> props;
@@ -408,6 +433,9 @@ public:
         Add(props, ReconnectPeriod, ToString(clusterConfiguration->ReconnectPeriod), pos, ctx);
         Add(props, Format, format, pos, ctx);
         Add(props, ReadGroup, clusterConfiguration->ReadGroup, pos, ctx);
+        if (skipJsonErrors) {
+            Add(props, SkipJsonErrors, ToString(skipJsonErrors), pos, ctx);
+        }
 
         if (clusterConfiguration->UseSsl) {
             Add(props, UseSslSetting, "1", pos, ctx);

--- a/ydb/library/yql/providers/pq/provider/yql_pq_topic_key_parser.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_topic_key_parser.cpp
@@ -75,6 +75,10 @@ bool TTopicKeyParser::Parse(const TExprNode& expr, TExprNode::TPtr readSettings,
                 Watermark = readSettings->Child(i)->ChildPtr(1);
                 continue;
             }
+            if (readSettings->Child(i)->Head().IsAtom("skip.json.errors")) {
+                SkipJsonErrors = readSettings->Child(i);
+                continue;
+            }
         }
     }
 

--- a/ydb/library/yql/providers/pq/provider/yql_pq_topic_key_parser.h
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_topic_key_parser.h
@@ -54,6 +54,10 @@ public:
         return Watermark;
     }
 
+    TExprNode::TPtr GetSkipJsonErrors() const {
+        return SkipJsonErrors;
+    }
+
     bool Parse(const TExprNode& expr, TExprNode::TPtr readSettings, TExprContext& ctx);
 
 private:
@@ -72,6 +76,7 @@ private:
     TExprNode::TPtr UserSchema;
     TExprNode::TPtr ColumnOrder;
     TExprNode::TPtr Watermark;
+    TExprNode::TPtr SkipJsonErrors;
 };
 
 } // namespace NYql

--- a/ydb/services/metadata/abstract/events.h
+++ b/ydb/services/metadata/abstract/events.h
@@ -30,6 +30,7 @@ enum EEvents {
     EvStartMetadataService,
     EvStartRegistration,
     EvRecheckExistence,
+    EvResetManagerRegistration,
     EvEnd
 };
 

--- a/ydb/services/metadata/ds_table/service.h
+++ b/ydb/services/metadata/ds_table/service.h
@@ -29,6 +29,7 @@ private:
     void Handle(TEvSubscribeExternal::TPtr& ev);
     void Handle(TEvUnsubscribeExternal::TPtr& ev);
     void Handle(TEvObjectsOperation::TPtr& ev);
+    void Handle(TEvResetManagerRegistration::TPtr& ev);
 
     void PrepareManagers(std::vector<IClassBehaviour::TPtr> managers, TAutoPtr<IEventBase> ev, const NActors::TActorId& sender);
     void Activate();
@@ -55,6 +56,7 @@ public:
             hFunc(TEvPrepareManager, Handle);
             hFunc(TEvSubscribeExternal, Handle);
             hFunc(TEvUnsubscribeExternal, Handle);
+            hFunc(TEvResetManagerRegistration, Handle);
 
             default:
                 Y_ABORT_UNLESS(false);
@@ -69,4 +71,4 @@ public:
 
 NActors::IActor* CreateService(const TConfig& config);
 
-}
+} // namespace NKikimr::NMetadata::NProvider

--- a/ydb/services/metadata/initializer/accessor_init.cpp
+++ b/ydb/services/metadata/initializer/accessor_init.cpp
@@ -12,7 +12,7 @@ namespace NKikimr::NMetadata::NInitializer {
 
 void TDSAccessorInitialized::DoNextModifier(const bool doPop) {
     if (InitializationSnapshotOwner->HasInitializationSnapshot() && !doPop) {
-        while (Modifiers.size() && !doPop) {
+        while (Modifiers.size() && Modifiers.front()->GetSupportDbCache() && !doPop) {
             if (InitializationSnapshotOwner->HasModification(ComponentId, Modifiers.front()->GetModificationId())) {
                 Modifiers.pop_front();
             } else {

--- a/ydb/services/metadata/initializer/common.h
+++ b/ydb/services/metadata/initializer/common.h
@@ -17,17 +17,20 @@ public:
 class ITableModifier {
 private:
     YDB_READONLY_DEF(TString, ModificationId);
+    YDB_READONLY_DEF(bool, SupportDbCache);
+
 protected:
     virtual bool DoExecute(IModifierExternalController::TPtr externalController, const NRequest::TConfig& config) const = 0;
+
 public:
     using TPtr = std::shared_ptr<ITableModifier>;
+
     virtual ~ITableModifier() = default;
 
-    ITableModifier(const TString& modificationId)
+    explicit ITableModifier(const TString& modificationId, bool supportDbCache = true)
         : ModificationId(modificationId)
-    {
-
-    }
+        , SupportDbCache(supportDbCache)
+    {}
 
     bool Execute(IModifierExternalController::TPtr externalController, const NRequest::TConfig& config) const {
         return DoExecute(externalController, config);

--- a/ydb/services/metadata/service.h
+++ b/ydb/services/metadata/service.h
@@ -66,6 +66,18 @@ public:
     }
 };
 
+class TEvResetManagerRegistration : public TEventLocal<TEvResetManagerRegistration, EEvents::EvResetManagerRegistration> {
+private:
+    YDB_READONLY_DEF(IClassBehaviour::TPtr, Manager);
+
+public:
+    explicit TEvResetManagerRegistration(IClassBehaviour::TPtr manager)
+        : Manager(std::move(manager))
+    {
+        Y_ABORT_UNLESS(!!Manager);
+    }
+};
+
 NActors::TActorId MakeServiceId(const ui32 node);
 
 class TConfig;
@@ -82,4 +94,4 @@ public:
     static TString GetPath();
 };
 
-}
+} // namespace NKikimr::NMetadata::NProvider

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -295,3 +295,34 @@ class TestStreamingInYdb(TestYdsBase):
         self.write_stream(data)
         expected_data = ['{"a_time":null,"b_time":1696849942500001,"c_time":1696849943000001}']
         assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
+
+    def test_json_errors(self, kikimr):
+        sourceName = "test_json_errors" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        self.init_topics(sourceName, partitions_count=10)
+        self.create_source(kikimr, sourceName, True)
+
+        name = "query1"
+        sql = R'''
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                $in = SELECT data FROM {source_name}.`{input_topic}`
+                WITH (
+                    FORMAT="json_each_row",
+                    `skip.json.errors` = "true",
+                    SCHEMA=(time UINT32 NOT NULL, data String NOT NULL));
+                INSERT INTO {source_name}.`{output_topic}` SELECT data FROM $in;
+            END DO;'''
+
+        query_id = "query_id"  # TODO
+        kikimr.YdbClient.query(sql.format(query_name=name, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        self.wait_completed_checkpoints(kikimr, query_id)
+
+        data = [
+            '{"time": 101, "data": "hello1"}',
+            '{"time": 102, "data": 7777}',
+            '{"time": 103, "data": "hello2"}'
+        ]
+        self.write_stream(data, partition_key="key")
+
+        expected = ['hello1', 'hello2']
+        assert self.read_stream(len(expected), topic_path=self.output_topic) == expected

--- a/ydb/tests/fq/yds/test_row_dispatcher.py
+++ b/ydb/tests/fq/yds/test_row_dispatcher.py
@@ -19,18 +19,11 @@ from ydb.tests.tools.datastreams_helpers.control_plane import create_stream, cre
 from ydb.tests.tools.datastreams_helpers.data_plane import read_stream, write_stream
 from ydb.tests.tools.fq_runner.fq_client import StreamingDisposition
 
+import ydb.public.api.protos.ydb_value_pb2 as ydb_value
 import ydb.public.api.protos.draft.fq_pb2 as fq
 
 YDS_CONNECTION = "yds"
 COMPUTE_NODE_COUNT = 3
-
-
-class Param(object):
-    def __init__(
-        self,
-        skip_errors=False,
-    ):
-        self.skip_errors = skip_errors
 
 
 @pytest.fixture
@@ -43,10 +36,6 @@ def kikimr(request):
     kikimr.compute_plane.fq_config['row_dispatcher']['without_consumer'] = True
     kikimr.compute_plane.fq_config['row_dispatcher']['json_parser'] = {}
 
-    skip_errors = False
-    if hasattr(request, "param") and isinstance(request.param, Param):
-        skip_errors = request.param.skip_errors
-    kikimr.compute_plane.fq_config['row_dispatcher']['json_parser']['skip_errors'] = skip_errors
     kikimr.start_mvp_mock_server()
     kikimr.start()
     yield kikimr
@@ -1191,15 +1180,33 @@ class TestPqRowDispatcher(TestYdsBase):
         assert received == expected
 
     @yq_v1
-    @pytest.mark.parametrize(
-        "kikimr", [Param(skip_errors=True)], indirect=["kikimr"]
-    )
-    def test_json_errors(self, kikimr, client):
-        self.init(client, "test_json_errors")
-        sql = Rf'''
-            INSERT INTO {YDS_CONNECTION}.`{self.output_topic}`
-            SELECT data FROM {YDS_CONNECTION}.`{self.input_topic}`
-                WITH (format=json_each_row, SCHEMA (time Int32 NOT NULL, data String NOT NULL));'''
+    @pytest.mark.parametrize("use_binding", [False, True], ids=["with_option", "bindings"])
+    def test_json_errors(self, kikimr, client, use_binding):
+        connection_response = client.create_yds_connection(YDS_CONNECTION, os.getenv("YDB_DATABASE"), os.getenv("YDB_ENDPOINT"), shared_reading=True)
+        self.init_topics("test_json_errors", create_input=True, create_output=True, partitions_count=1)
+
+        time_type = ydb_value.Column(name="time", type=ydb_value.Type(type_id=ydb_value.Type.PrimitiveTypeId.INT32))
+        data_type = ydb_value.Column(name="data", type=ydb_value.Type(type_id=ydb_value.Type.PrimitiveTypeId.STRING))
+
+        if use_binding:
+            client.create_yds_binding(
+                name="my_binding",
+                stream=self.input_topic,
+                format="json_each_row",
+                connection_id=connection_response.result.connection_id,
+                columns=[time_type, data_type],
+                format_setting={"skip.json.errors": "true"},
+            )
+
+        if use_binding:
+            sql = Rf'''
+                INSERT INTO {YDS_CONNECTION}.`{self.output_topic}`
+                SELECT data FROM bindings.`my_binding`;'''
+        else:
+            sql = Rf'''
+                INSERT INTO {YDS_CONNECTION}.`{self.output_topic}`
+                SELECT data FROM {YDS_CONNECTION}.`{self.input_topic}`
+                    WITH (format=json_each_row, `skip.json.errors` = "true", SCHEMA (time Int32 NOT NULL, data String NOT NULL));'''
 
         query_id = start_yds_query(kikimr, client, sql)
         wait_actor_count(kikimr, "FQ_ROW_DISPATCHER_SESSION", 1)
@@ -1210,7 +1217,7 @@ class TestPqRowDispatcher(TestYdsBase):
             '{"time": 103, "data": "hello2"}'
         ]
 
-        self.write_stream(data)
+        self.write_stream(data, partition_key="key")
         expected = ['hello1', 'hello2']
         assert self.read_stream(len(expected), topic_path=self.output_topic) == expected
 

--- a/ydb/tests/tools/datastreams_helpers/test_yds_base.py
+++ b/ydb/tests/tools/datastreams_helpers/test_yds_base.py
@@ -21,9 +21,9 @@ class TestYdsBase(object):
             create_stream(self.output_topic, partitions_count=partitions_count)
             create_read_rule(self.output_topic, self.consumer_name)
 
-    def write_stream(self, data, topic_path=None):
+    def write_stream(self, data, topic_path=None, partition_key=None):
         topic = topic_path if topic_path else self.input_topic
-        write_stream(topic, data)
+        write_stream(topic, data, partition_key=partition_key)
 
     def read_stream(self, messages_count, commit_after_processing=True, topic_path=None):
         topic = topic_path if topic_path else self.output_topic

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -578,6 +578,7 @@ private:
         request->SetDatabase(database);
         request->SetPoolId(query.PoolId);
         request->MutableYdbParameters()->insert(query.Params.begin(), query.Params.end());
+        request->MutableQueryCachePolicy()->set_keep_in_cache(IsIn({NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY}, type));
 
         if (query.Timeout) {
             request->SetTimeoutMs(query.Timeout.MilliSeconds());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Features and fixes for streaming 3

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

* YQ-4735 Json format settings / skip jsons errors (#28329)
* YQ-4860 supported automatic access revert after secure FF disabled (#28202)
* YQ-4593 supported table writing in streaming queries (#28220)
* YQ-4868 fixed token auth for YDB external data source (#28330)
* YQ-4858 fixed cache invalidation for external sources (#28186)
* YQ-4857 forbidden change of external data source type (#28183)