### PR TITLE
The ability to specify UA config inside AuditConfig

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2071,7 +2071,7 @@ message TAuditConfig {
         optional EFormat Format = 1 [default = JSON];
         optional string LogName = 2;
         optional string LogJsonEnvelope = 3; // Json template with text field containing %message% placeholder. For example {"my_enveloped_message": "%message%"}. %message% will be replaced with real audit log message
-        optional TUAClientConfig UAClientConfig = 4; // If not specified, the configuration is taken from logconfig
+        optional TUAClientConfig UAClientConfig = 4; // If not specified, the configuration is taken from common TLogConfig section
     }
 
     message TLogClassConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2071,6 +2071,7 @@ message TAuditConfig {
         optional EFormat Format = 1 [default = JSON];
         optional string LogName = 2;
         optional string LogJsonEnvelope = 3; // Json template with text field containing %message% placeholder. For example {"my_enveloped_message": "%message%"}. %message% will be replaced with real audit log message
+        optional TUAClientConfig UAClientConfig = 4; // If not specified, the configuration is taken from logconfig
     }
 
     message TLogClassConfig {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Previously, it was not possible to specify the unified agent configuration for the audit configuration. Instead, the configuration audit used the Unified Agent settings that were specified in the LogConfig section.

This was required in order to be able to separate the flows of audit and regular logging, including at the Unified Agent configuration level.

### Changelog category <!-- remove all except one -->

* New feature