### PR TITLE
hotfix for healthcheck access rights check

### DIFF
--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -132,8 +132,7 @@ public:
                 .RelPath = "healthcheck",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = true,
-                .AllowedSIDs = databaseAllowedSIDs,
+                .UseAuth = false, // auth is checked inside handler
             });
             mon->RegisterActorPage({
                 .RelPath = "vdisk",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fixes access check restrictions, introduced in #22513
allows for prometheus metrics to be collected without access check.
closes #28021

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
