### PR TITLE
Fix segfault when handling ChangeGroupSizeInUnits during VDisk LocalRecovery

### DIFF
--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -7,10 +7,13 @@
 #include <ydb/core/blobstorage/base/blobstorage_events.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_http_request.h>
+#include <ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
 #include <ydb/core/mind/bscontroller/bsc.h>
 #include <ydb/core/util/actorsys_test/testactorsys.h>
 
 #include <ydb/library/pdisk_io/sector_map.h>
+#include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/util/random.h>
 
 #include <google/protobuf/text_format.h>
@@ -1130,6 +1133,79 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
             pdiskId, 12, 2u);
     }
+
+    void ChangeGroupSizeInUnits(TTestBasicRuntime& runtime, TString poolName, ui32 groupId, ui32 groupSizeInUnits) {
+        TActorId edge = runtime.AllocateEdgeActor();
+
+        auto storagePool = DescribeStoragePool(runtime, poolName);
+        auto request = std::make_unique<TEvBlobStorage::TEvControllerConfigRequest>();
+        auto& cmd = *request->Record.MutableRequest()->AddCommand()->MutableChangeGroupSizeInUnits();
+        cmd.SetBoxId(storagePool.GetBoxId());
+        cmd.SetItemConfigGeneration(storagePool.GetItemConfigGeneration());
+        cmd.SetStoragePoolId(storagePool.GetStoragePoolId());
+        cmd.AddGroupId(groupId);
+        cmd.SetSizeInUnits(groupSizeInUnits);
+
+        NTabletPipe::TClientConfig pipeConfig;
+        pipeConfig.RetryPolicy = NTabletPipe::TClientRetryPolicy::WithRetries();
+        runtime.SendToPipe(MakeBSControllerID(), edge, request.release(), 0, pipeConfig);
+
+        auto reply = runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvControllerConfigResponse>(edge);
+        VERBOSE_COUT("TEvControllerConfigResponse# " << reply->ToString());
+        UNIT_ASSERT_VALUES_EQUAL(reply->Get()->Record.GetResponse().GetSuccess(), true);
+    }
+
+    void CheckVDiskStateUpdate(TTestBasicRuntime& runtime, TActorId fakeWhiteboard, ui32 groupId,
+            ui32 expectedGroupGeneration, ui32 expectedGroupSizeInUnits,
+            TDuration simTimeout = TDuration::Seconds(10)) {
+        TInstant deadline = runtime.GetCurrentTime() + simTimeout;
+        while (true) {
+            UNIT_ASSERT_LT(runtime.GetCurrentTime(), deadline);
+
+            const auto ev = runtime.GrabEdgeEventRethrow<NNodeWhiteboard::TEvWhiteboard::TEvVDiskStateUpdate>(fakeWhiteboard, deadline - runtime.GetCurrentTime());
+            VERBOSE_COUT(" Got TEvVDiskStateUpdate# " << ev->ToString());
+
+            NKikimrWhiteboard::TVDiskStateInfo vdiskInfo = ev->Get()->Record;
+            if (vdiskInfo.GetVDiskId().GetGroupID() != groupId || !vdiskInfo.HasGroupSizeInUnits()) {
+                continue;
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(vdiskInfo.GetVDiskId().GetGroupGeneration(), expectedGroupGeneration);
+            UNIT_ASSERT_VALUES_EQUAL(vdiskInfo.GetGroupSizeInUnits(), expectedGroupSizeInUnits);
+            break;
+        }
+    }
+
+    CUSTOM_UNIT_TEST(TestEvVGenerationChangeRace) {
+        TTestBasicRuntime runtime(1, false);
+        Setup(runtime, "", nullptr);
+        runtime.SetLogPriority(NKikimrServices::BS_PROXY, NLog::PRI_ERROR);
+        runtime.SetLogPriority(NKikimrServices::BS_PROXY_PUT, NLog::PRI_ERROR);
+        runtime.SetLogPriority(NKikimrServices::BS_PROXY_BLOCK, NLog::PRI_ERROR);
+        runtime.SetLogPriority(NKikimrServices::BS_SKELETON, NLog::PRI_INFO);
+        runtime.SetLogPriority(NKikimrServices::BS_LOCALRECOVERY, NLog::PRI_INFO);
+        runtime.SetLogPriority(NKikimrServices::BS_NODE, NLog::PRI_INFO);
+        runtime.SetLogPriority(NKikimrServices::BS_CONTROLLER, NLog::PRI_INFO);
+
+        const ui32 nodeId = runtime.GetNodeId(0);
+        TActorId fakeWhiteboard = runtime.AllocateEdgeActor();
+        runtime.RegisterService(NNodeWhiteboard::MakeNodeWhiteboardServiceId(nodeId), fakeWhiteboard);
+
+        VERBOSE_COUT(" Starting test");
+
+        TBlockEvents<TEvBlobStorage::TEvLocalRecoveryDone> block(runtime);
+
+        const TString poolName = "testEvVGenerationChangeRace";
+        CreateStoragePool(runtime, poolName, "pool-kind-1");
+        ui32 groupId = GetGroupFromPool(runtime, poolName);
+
+        CheckVDiskStateUpdate(runtime, fakeWhiteboard, groupId, 1, 0u);
+        ChangeGroupSizeInUnits(runtime, poolName, groupId, 2u);
+        CheckVDiskStateUpdate(runtime, fakeWhiteboard, groupId, 1, 0u);
+        block.Stop().Unblock();
+        CheckVDiskStateUpdate(runtime, fakeWhiteboard, groupId, 2, 2u);
+    }
+
 }
 
 } // namespace NBlobStorageNodeWardenTest

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -1931,6 +1931,17 @@ namespace NKikimr {
             ApplyHugeBlobSize(Config->MinHugeBlobInBytes);
             Y_VERIFY_S(MinHugeBlobInBytes, VCtx->VDiskLogPrefix);
 
+            if (Config->GroupSizeInUnits != GInfo->GroupSizeInUnits) {
+                Config->GroupSizeInUnits = GInfo->GroupSizeInUnits;
+                Y_VERIFY(PDiskCtx);
+                Y_VERIFY(PDiskCtx->Dsk);
+                ctx.Send(PDiskCtx->PDiskId,
+                    new NPDisk::TEvYardResize(
+                        PDiskCtx->Dsk->Owner,
+                        PDiskCtx->Dsk->OwnerRound,
+                        Config->GroupSizeInUnits));
+            }
+
             // handle special case when donor disk starts and finds out that it has been wiped out
             if (ev->Get()->LsnMngr->GetOriginallyRecoveredLsn() == 0 && Config->BaseInfo.DonorMode) {
                 // send drop donor cmd to NodeWarden
@@ -2448,10 +2459,11 @@ namespace NKikimr {
             GInfo = msg->NewInfo;
             SelfVDiskId = msg->NewVDiskId;
 
-            if (Config->GroupSizeInUnits != GInfo->GroupSizeInUnits) {
+            if (PDiskCtx && Config->GroupSizeInUnits != GInfo->GroupSizeInUnits) {
                 Config->GroupSizeInUnits = GInfo->GroupSizeInUnits;
                 UpdateWhiteboard(ctx);
 
+                Y_VERIFY(PDiskCtx->Dsk);
                 ctx.Send(PDiskCtx->PDiskId,
                     new NPDisk::TEvYardResize(
                         PDiskCtx->Dsk->Owner,

--- a/ydb/tests/compatibility/test_infer_pdisk_expected_slot_count.py
+++ b/ydb/tests/compatibility/test_infer_pdisk_expected_slot_count.py
@@ -8,7 +8,6 @@ from ydb.tests.library.compatibility.fixtures import init_stable_binary_path, in
 from ydb.tests.library.compatibility.fixtures import inter_stable_binary_path, inter_stable_name
 from ydb.tests.library.compatibility.fixtures import current_binary_path, current_name
 from ydb.tests.library.common.types import Erasure
-import ydb.core.protos.msgbus_pb2 as msgbus
 import ydb.core.protos.blobstorage_config_pb2 as blobstorage_config_pb2
 
 logger = logging.getLogger(__name__)
@@ -43,96 +42,18 @@ class TestUpgradeThenRollback(RestartToAnotherVersionFixture):
             use_in_memory_pdisks=False)
         next(cluster_generator)
 
-        host_configs = self.read_host_configs()
+        host_configs = self.cluster.client.read_host_configs()
         for host_config in host_configs:
             drive = host_config.Drive.add()
             drive.Path = CONST_PDISK_PATH
             drive.PDiskConfig.ExpectedSlotCount = CONST_EXPECTED_SLOT_COUNT
-        self.define_host_configs(host_configs)
+        self.cluster.client.define_host_configs(host_configs)
 
         yield
 
-    def read_host_configs(self):
-        request = msgbus.TBlobStorageConfigRequest()
-        request.Domain = 1
-        request.Request.Command.add().ReadHostConfig.SetInParent()
-
-        response = self.cluster.client.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
-        logger.info(f"read_host_config response: {response}")
-        if not response.Success:
-            raise RuntimeError('read_host_config request failed: %s' % response.ErrorDescription)
-        status = response.Status[0]
-        if not status.Success:
-            raise RuntimeError('read_host_config has failed status: %s' % status.ErrorDescription)
-
-        return status.HostConfig
-
-    def define_host_configs(self, host_configs):
-        """Define host configuration with specified host config"""
-        request = msgbus.TBlobStorageConfigRequest()
-        request.Domain = 1
-        for host_config in host_configs:
-            request.Request.Command.add().DefineHostConfig.MergeFrom(host_config)
-
-        logger.info(f"define_host_config request: {request}")
-        response = self.cluster.client.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
-        logger.info(f"define_host_config responce: {response}")
-        if not response.Success:
-            raise RuntimeError('define_host_config request failed: %s' % response.ErrorDescription)
-        for i, status in enumerate(response.Status):
-            if not status.Success:
-                raise RuntimeError('define_host_config has failed status[%d]: %s' % (i, status))
-
-    def pdisk_set_all_active(self):
-        """Update all drive statuses to ACTIVE. Equivalent to
-            `dstool pdisk set --status=ACTIVE --pdisk-ids <pdisks>`
-        """
-        base_config = self.query_base_config()
-
-        request = msgbus.TBlobStorageConfigRequest()
-        request.Domain = 1
-
-        for pdisk in base_config.BaseConfig.PDisk:
-            if pdisk.Path != CONST_PDISK_PATH:
-                continue
-            cmd = request.Request.Command.add().UpdateDriveStatus
-            cmd.HostKey.NodeId = pdisk.NodeId
-            cmd.PDiskId = pdisk.PDiskId
-            cmd.Status = blobstorage_config_pb2.EDriveStatus.ACTIVE
-
-        logger.info(f"update_all_drive_status_active request: {request}")
-        response = self.cluster.client.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
-        logger.info(f"update_all_drive_status_active response: {response}")
-
-        if not response.Success:
-            raise RuntimeError('update_all_drive_status_active request failed: %s' % response.ErrorDescription)
-        for i, status in enumerate(response.Status):
-            if not status.Success:
-                raise RuntimeError('update_all_drive_status_active has failed status[%d]: %s' % (i, status))
-
-    def query_base_config(self):
-        request = msgbus.TBlobStorageConfigRequest()
-        request.Domain = 1
-
-        # Add QueryBaseConfig command
-        command = request.Request.Command.add()
-        command.QueryBaseConfig.RetrieveDevices = True
-        command.QueryBaseConfig.VirtualGroupsOnly = False
-
-        # Send the request
-        response = self.cluster.client.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
-        if not response.Success:
-            raise RuntimeError('query_base_config failed: %s' % response.ErrorDescription)
-
-        status = response.Status[0]
-        if not status.Success:
-            raise RuntimeError('query_base_config failed: %s' % status.ErrorDescription)
-
-        return status
-
     def pdisk_list(self):
         """Equivalent to `dstool pdisk list`"""
-        base_config = self.query_base_config()
+        base_config = self.cluster.client.query_base_config()
 
         # Collect PDisk information
         pdisks_info = []
@@ -156,7 +77,7 @@ class TestUpgradeThenRollback(RestartToAnotherVersionFixture):
                 else:
                     time.sleep(delay)
 
-    def test_infer_pdisk_expected_slot_count(self):
+    def test(self):
         assert self.current_binary_paths_index == 0
         logger.info(f"Test started on {self.versions[0]} {time.time()=}")
         #################################################################
@@ -187,7 +108,7 @@ class TestUpgradeThenRollback(RestartToAnotherVersionFixture):
         ######################################################################
 
         t2 = time.time()
-        host_configs = self.read_host_configs()
+        host_configs = self.cluster.client.read_host_configs()
         for host_config in host_configs:
             drive = host_config.Drive[1]
             assert drive.Path == CONST_PDISK_PATH
@@ -195,10 +116,10 @@ class TestUpgradeThenRollback(RestartToAnotherVersionFixture):
             drive.PDiskConfig.SetInParent()
             drive.InferPDiskSlotCountFromUnitSize = CONST_10_GB
             drive.InferPDiskSlotCountMax = 32
-        self.define_host_configs(host_configs)
+        self.cluster.client.define_host_configs(host_configs)
         logger.info(f"Inferred PDisk setting applied {time.time()=}")
 
-        self.pdisk_set_all_active()
+        self.cluster.client.pdisk_set_all_active(pdisk_path=CONST_PDISK_PATH)
         logger.info(f"Drives activated {time.time()=}")
 
         deadline = time.time() + timeout
@@ -224,7 +145,7 @@ class TestUpgradeThenRollback(RestartToAnotherVersionFixture):
         logger.info(f"Restarted back on version {self.versions[0]} {time.time()=}")
         ###########################################################################
 
-        self.pdisk_set_all_active()
+        self.cluster.client.pdisk_set_all_active(pdisk_path=CONST_PDISK_PATH)
         logger.info(f"Drives activated {time.time()=}")
 
         deadline = time.time() + timeout

--- a/ydb/tests/compatibility/test_infer_pdisk_expected_slot_count.py
+++ b/ydb/tests/compatibility/test_infer_pdisk_expected_slot_count.py
@@ -8,7 +8,7 @@ from ydb.tests.library.compatibility.fixtures import init_stable_binary_path, in
 from ydb.tests.library.compatibility.fixtures import inter_stable_binary_path, inter_stable_name
 from ydb.tests.library.compatibility.fixtures import current_binary_path, current_name
 from ydb.tests.library.common.types import Erasure
-import ydb.core.protos.blobstorage_config_pb2 as blobstorage_config_pb2
+from ydb.core.protos import blobstorage_config_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ class TestUpgradeThenRollback(RestartToAnotherVersionFixture):
             except AssertionError as e:
                 if time.time() > deadline:
                     logger.warning(f"pdisk_list incorrect: {pdisks}")
-                    raise e from e
+                    raise e
                 else:
                     time.sleep(delay)
 

--- a/ydb/tests/functional/blobstorage/test_pdisk_slot_size_in_units.py
+++ b/ydb/tests/functional/blobstorage/test_pdisk_slot_size_in_units.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import time
+import logging
+import pytest
+import requests
+import json
+
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.common.types import Erasure
+from ydb.tests.library.harness.util import LogLevels
+from ydb.core.protos import msgbus_pb2
+
+logger = logging.getLogger(__name__)
+
+CONST_64_GB = 64 * 1024**3
+
+
+class TestPDiskSlotSizeInUnits(object):
+    erasure = Erasure.NONE
+    pool_name = 'test:1'
+    nodes_count = 1
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        log_configs = {
+            'BS_NODE': LogLevels.DEBUG,
+            'BS_CONTROLLER': LogLevels.DEBUG,
+            'BS_SKELETON': LogLevels.DEBUG,
+            'BS_PDISK': LogLevels.DEBUG,
+        }
+
+        configurator = KikimrConfigGenerator(
+            erasure=self.erasure,
+            nodes=self.nodes_count,
+            use_in_memory_pdisks=False,
+            static_pdisk_size=CONST_64_GB,
+            dynamic_pdisks=[{'disk_size': CONST_64_GB, 'user_kind': 1}],
+            dynamic_pdisks_config=dict(expected_slot_count=4),
+            dynamic_storage_pools=[dict(name=self.pool_name, kind="hdd", pdisk_user_kind=1)],
+            additional_log_configs=log_configs
+        )
+
+        assert len(configurator.pdisks_info) == 2
+        self.cluster = KiKiMR(configurator)
+        self.cluster.start()
+
+        host_config = self.cluster.client.read_host_configs()[0]
+        assert len(host_config.Drive) == 2
+        assert host_config.Drive[1].PDiskConfig.ExpectedSlotCount == 4
+
+        base_config = self.cluster.client.query_base_config().BaseConfig
+        logger.info(f"{base_config=}")
+
+        self.pdisk_id = base_config.PDisk[1].PDiskId
+        self.groups = [group for group in base_config.Group if group.StoragePoolId == 1]
+        assert len(self.groups) == 2
+        for g in self.groups:
+            assert len(g.VSlotId) == 1
+            assert g.VSlotId[0].PDiskId == self.pdisk_id
+
+        yield
+        self.cluster.stop()
+
+    def change_group_size_in_units(self, new_size, group_id=None):
+        storage_pool = self.cluster.client.read_storage_pools()[0]
+
+        request = msgbus_pb2.TBlobStorageConfigRequest()
+        request.Domain = 1
+
+        cmd = request.Request.Command.add().ChangeGroupSizeInUnits
+        cmd.BoxId = storage_pool.BoxId
+        cmd.StoragePoolId = storage_pool.StoragePoolId
+        cmd.SizeInUnits = new_size
+        if group_id:
+            cmd.GroupId.append(group_id)
+        cmd.ItemConfigGeneration = storage_pool.ItemConfigGeneration
+
+        logger.info(f"change_group_size_in_units request: {request}")
+        response = self.cluster.client.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        logger.info(f"change_group_size_in_units response: {response}")
+
+        if not response.Success:
+            raise RuntimeError(f'change_group_size_in_units request failed: {response.ErrorDescription}')
+
+        for i, status in enumerate(response.Status):
+            if not status.Success:
+                raise RuntimeError(f'change_group_size_in_units has failed status[{i}]: {status.ErrorDescription}')
+
+    def change_pdisk_slot_size_in_units(self, slot_size_in_units):
+        host_config = self.cluster.client.read_host_configs()[0]
+        host_config.Drive[1].PDiskConfig.SlotSizeInUnits = slot_size_in_units
+        self.cluster.client.define_host_configs([host_config])
+
+    def retriable(self, check_fn, timeout=30, delay=1):
+        deadline = time.time() + timeout
+
+        while True:
+            try:
+                return check_fn()
+            except AssertionError as e:
+                logger.info(str(e))
+                if time.time() > deadline:
+                    raise e
+                else:
+                    time.sleep(delay)
+
+    def http_get(self, url):
+        host = self.cluster.nodes[1].host
+        port = self.cluster.nodes[1].mon_port
+        return requests.get("http://%s:%s%s" % (host, port, url))
+
+    def get_storage_groups(self):
+        response = self.http_get('/storage/groups?fields_required=all&with=all').json()
+        groups = [group for group in response['StorageGroups'] if group['PoolName'] == self.pool_name]
+        assert len(groups) == 2
+        for group in groups:
+            vdisk = group['VDisks'][0]
+            assert vdisk['Whiteboard'].get('VDiskState') == 'OK'
+            assert vdisk['PDisk']['Whiteboard'].get('State') == 'Normal'
+        return groups
+
+    def get_pdisk_info(self):
+        response = self.http_get('/pdisk/info?node_id=1&pdisk_id=%s' % self.pdisk_id).json()
+        return response
+
+    def check_group(self, group, expected_vdisk_weight, expected_num_active_slots):
+        vdisk = group['VDisks'][0]
+        assert vdisk['PDisk']['Whiteboard']['NumActiveSlots'] == expected_num_active_slots
+        assert int(vdisk['Whiteboard']['AllocatedSize']) + int(vdisk['Whiteboard']['AvailableSize']) == \
+            expected_vdisk_weight * int(vdisk['PDisk']['Whiteboard']['EnforcedDynamicSlotSize'])
+
+    def check_pdisk(self, pdisk, expected_num_active_slots=None, expected_slot_size_in_units=None):
+        if expected_num_active_slots is not None:
+            assert pdisk['NumActiveSlots'] == expected_num_active_slots
+        if expected_slot_size_in_units is not None:
+            assert pdisk['SlotSizeInUnits'] == expected_slot_size_in_units
+
+    def test_change_group_size_in_units(self):
+        self.change_group_size_in_units(new_size=2, group_id=self.groups[0].GroupId)
+
+        def wait_whiteboard_updated():
+            groups = self.get_storage_groups()
+            logger.info(json.dumps(groups, indent=2))
+            self.check_group(groups[0], expected_vdisk_weight=2, expected_num_active_slots=3)
+            self.check_group(groups[1], expected_vdisk_weight=1, expected_num_active_slots=3)
+        self.retriable(wait_whiteboard_updated)
+
+        pdisk_info = self.get_pdisk_info()
+        logger.info(json.dumps(pdisk_info, indent=2))
+
+        self.check_pdisk(pdisk_info['Whiteboard']['PDisk'], expected_num_active_slots=3)
+        self.check_pdisk(pdisk_info['BSC']['PDisk'], expected_num_active_slots=3, expected_slot_size_in_units=0)
+
+    def test_change_pdisk_slot_size_in_units(self):
+        self.change_pdisk_slot_size_in_units(slot_size_in_units=2)
+        self.change_group_size_in_units(new_size=4, group_id=self.groups[1].GroupId)
+
+        def wait_whiteboard_updated():
+            groups = self.get_storage_groups()
+            logger.info(json.dumps(groups, indent=2))
+            self.check_group(groups[0], expected_vdisk_weight=1, expected_num_active_slots=3)
+            self.check_group(groups[1], expected_vdisk_weight=2, expected_num_active_slots=3)
+        self.retriable(wait_whiteboard_updated)
+
+        pdisk_info = self.get_pdisk_info()
+        logger.info(json.dumps(pdisk_info, indent=2))
+
+        self.check_pdisk(pdisk_info['Whiteboard']['PDisk'], expected_num_active_slots=3)
+        self.check_pdisk(pdisk_info['BSC']['PDisk'], expected_num_active_slots=3, expected_slot_size_in_units=2)

--- a/ydb/tests/functional/blobstorage/ya.make
+++ b/ydb/tests/functional/blobstorage/ya.make
@@ -3,6 +3,7 @@ PY3TEST()
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 TEST_SRCS(
     test_pdisk_format_info.py
+    test_pdisk_slot_size_in_units.py
     test_replication.py
     test_self_heal.py
     test_tablet_channel_migration.py

--- a/ydb/tests/library/clients/kikimr_client.py
+++ b/ydb/tests/library/clients/kikimr_client.py
@@ -326,6 +326,22 @@ class KiKiMRMessageBusClient(object):
             if not status.Success:
                 raise RuntimeError(f'define_host_config has failed status[{i}]: {status}')
 
+    def read_storage_pools(self, domain=1):
+        request = msgbus.TBlobStorageConfigRequest()
+        request.Domain = domain
+        cmd = request.Request.Command.add().ReadStoragePool
+        cmd.BoxId = 0xFFFFFFFFFFFFFFFF
+
+        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        if not response.Success:
+            raise RuntimeError(f'read_storage_pools request failed: {response.ErrorDescription}')
+
+        status = response.Status[0]
+        if not status.Success:
+            raise RuntimeError(f'read_storage_pools has failed status: {status.ErrorDescription}')
+
+        return status.StoragePool
+
     def pdisk_set_all_active(self, pdisk_path=None, domain=1):
         """Equivalent to `dstool pdisk set --status=ACTIVE --pdisk-ids <pdisks>`"""
         base_config = self.query_base_config(domain=domain)
@@ -366,7 +382,6 @@ class KiKiMRMessageBusClient(object):
             raise RuntimeError(f'query_base_config failed: {status.ErrorDescription}')
 
         return status
-
 
     def __del__(self):
         self.close()

--- a/ydb/tests/library/clients/kikimr_client.py
+++ b/ydb/tests/library/clients/kikimr_client.py
@@ -299,5 +299,74 @@ class KiKiMRMessageBusClient(object):
         request.Alive = True
         return self.invoke(request, 'TabletStateRequest')
 
+    def read_host_configs(self, domain=1):
+        request = msgbus.TBlobStorageConfigRequest()
+        request.Domain = domain
+        request.Request.Command.add().ReadHostConfig.SetInParent()
+
+        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        if not response.Success:
+            raise RuntimeError(f'read_host_config request failed: {response.ErrorDescription}')
+        status = response.Status[0]
+        if not status.Success:
+            raise RuntimeError(f'read_host_config has failed status: {status.ErrorDescription}')
+
+        return status.HostConfig
+
+    def define_host_configs(self, host_configs, domain=1):
+        request = msgbus.TBlobStorageConfigRequest()
+        request.Domain = domain
+        for host_config in host_configs:
+            request.Request.Command.add().DefineHostConfig.MergeFrom(host_config)
+
+        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        if not response.Success:
+            raise RuntimeError(f'define_host_config request failed: {response.ErrorDescription}')
+        for i, status in enumerate(response.Status):
+            if not status.Success:
+                raise RuntimeError(f'define_host_config has failed status[{i}]: {status}')
+
+    def pdisk_set_all_active(self, pdisk_path=None, domain=1):
+        """Equivalent to `dstool pdisk set --status=ACTIVE --pdisk-ids <pdisks>`"""
+        base_config = self.query_base_config(domain=domain)
+
+        request = msgbus.TBlobStorageConfigRequest()
+        request.Domain = domain
+
+        for pdisk in base_config.BaseConfig.PDisk:
+            if pdisk_path is not None and pdisk.Path != pdisk_path:
+                continue
+            cmd = request.Request.Command.add().UpdateDriveStatus
+            cmd.HostKey.NodeId = pdisk.NodeId
+            cmd.PDiskId = pdisk.PDiskId
+            cmd.Status = blobstorage_config_pb2.EDriveStatus.ACTIVE
+
+        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+
+        if not response.Success:
+            raise RuntimeError(f'update_all_drive_status_active request failed: {response.ErrorDescription}')
+        for i, status in enumerate(response.Status):
+            if not status.Success:
+                raise RuntimeError(f'update_all_drive_status_active has failed status[{i}]: {status}')
+
+    def query_base_config(self, domain=1):
+        request = msgbus.TBlobStorageConfigRequest()
+        request.Domain = domain
+
+        command = request.Request.Command.add()
+        command.QueryBaseConfig.RetrieveDevices = True
+        command.QueryBaseConfig.VirtualGroupsOnly = False
+
+        response = self.send(request, 'BlobStorageConfig').BlobStorageConfigResponse
+        if not response.Success:
+            raise RuntimeError(f'query_base_config failed: {response.ErrorDescription}')
+
+        status = response.Status[0]
+        if not status.Success:
+            raise RuntimeError(f'query_base_config failed: {status.ErrorDescription}')
+
+        return status
+
+
     def __del__(self):
         self.close()

--- a/ydb/tests/library/clients/kikimr_http_client.py
+++ b/ydb/tests/library/clients/kikimr_http_client.py
@@ -177,3 +177,13 @@ class SwaggerClient(object):
         return self.__http_get_and_parse_json(
             "/json/nodes", timeout=self.__timeout
         )
+
+    def storage_groups(self, **kwargs):
+        return self.__http_get_and_parse_json(
+            "/storage/groups", timeout=self.__timeout, **kwargs
+        )
+
+    def pdisk_info_detailed(self, node_id, pdisk_id):
+        return self.__http_get_and_parse_json(
+            "/pdisk/info", node_id=str(node_id), pdisk_id=str(pdisk_id), timeout=self.__timeout
+        )

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -808,6 +808,12 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
                 drive_proto.Kind = drive['pdisk_user_kind']
                 drive_proto.Type = drive.get('pdisk_type', 0)
 
+                for key, value in drive.get('pdisk_config', {}).items():
+                    if key == 'expected_slot_count':
+                        drive_proto.PDiskConfig.ExpectedSlotCount = value
+                    else:
+                        raise KeyError(f"unknown pdisk_config option {key}")
+
         cmd = request.Command.add()
         cmd.DefineBox.BoxId = 1
         for node_id, node in self.nodes.items():


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Add tests for https://github.com/ydb-platform/ydb/issues/21011
- Follow-up for https://github.com/ydb-platform/ydb/pull/19198

The test revealed the bug. During VDisk LocalRecovery the `PDiskCtx` is nullptr, which resulted in a segmentation fault when handling `TEvVGenerationChange`. The `PDiskCtx` is initialized wen handling `TEvLocalRecoveryDone`.


