### PR TITLE
Collect cluster state change api

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added a new `--output` option to the `ydb admin cluster state fetch` command. The new option specify path to the output .tar.bz2 file.
 * Added a simple progress bar for non-interactive stderr.
 
 ## 2.27.0 ##

--- a/ydb/core/grpc_services/rpc_cluster_state.cpp
+++ b/ydb/core/grpc_services/rpc_cluster_state.cpp
@@ -246,7 +246,7 @@ public:
                 TStringBuilder sb;
                 sb << "node_" << node << "_counters_" << i << ".json";
                 counterBlock->Setname(sb);
-                block->Setcontent(Counters[node][i]);
+                counterBlock->Setcontent(Counters[node][i]);
             }
         }
         operation.mutable_result()->PackFrom(result);

--- a/ydb/public/api/protos/ydb_monitoring.proto
+++ b/ydb/public/api/protos/ydb_monitoring.proto
@@ -246,6 +246,12 @@ message ClusterStateResponse {
     Ydb.Operations.Operation operation = 1;
 }
 
+message ClusterStateResultBlock {
+    string name = 1;
+    string content = 2;
+}
+
 message ClusterStateResult {
-    string result = 1;
+    string result = 1; // deprecated
+    repeated ClusterStateResultBlock blocks = 2;
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_state.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_state.cpp
@@ -37,7 +37,7 @@ void TCommandClusterStateFetch::Config(TConfig& config) {
         "If set to zero or omitted, only a single collection is done.")
     .DefaultValue(0)
         .OptionalArgument("NUM").StoreResult(&PeriodSeconds);
-    config.Opts->AddLongOption('f', "filename", "File name to save the results in .tar.bz2 format\n")
+    config.Opts->AddLongOption('o', "output", "Path to the output .tar.bz2 file")
     .DefaultValue("out.tar.bz2")
         .OptionalArgument("PATH").StoreResult(&FileName);
     config.AllowEmptyDatabase = true;

--- a/ydb/public/lib/ydb_cli/commands/ydb_state.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_state.cpp
@@ -4,6 +4,10 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 #include <ydb/public/lib/ydb_cli/common/command_utils.h>
 
+#include <util/generic/xrange.h>
+
+#include <library/cpp/streams/bzip2/bzip2.h>
+
 namespace NYdb::NConsoleClient {
 
 TCommandClusterState::TCommandClusterState()
@@ -26,16 +30,15 @@ void TCommandClusterStateFetch::Config(TConfig& config) {
         "Total time in seconds during which metrics should be collected on the server.\n"
         "Defines how long the server-side node will keep polling other nodes. "
         "If --period is unset or zero, only one snapshot is collected and the server waits up to --duration for all responses.")
-    .DefaultValue(0)
+    .DefaultValue(60)
         .OptionalArgument("NUM").StoreResult(&DurationSeconds);
     config.Opts->AddLongOption("period",
         "Interval in seconds between metric collections during the --duration period.\n"
         "If set to zero or omitted, only a single collection is done.")
     .DefaultValue(0)
         .OptionalArgument("NUM").StoreResult(&PeriodSeconds);
-    AddOutputFormats(config, {
-        EDataFormat::Json
-    }, EDataFormat::Json);
+    config.Opts->AddLongOption('f', "filename", "File name to save the results\n")
+        .RequiredArgument("[out.tar.gz]").StoreResult(&FileName);
     config.AllowEmptyDatabase = true;
 }
 
@@ -43,6 +46,58 @@ void TCommandClusterStateFetch::Parse(TConfig& config) {
     TYdbReadOnlyCommand::Parse(config);
     ParseOutputFormats();
 }
+
+struct TARFileHeader {
+    char filename[100]; //NUL-terminated
+    char mode[8];
+    char uid[8];
+    char gid[8];
+    char fileSize[12];
+    char lastModification[12];
+    char checksum[8];
+    char typeFlag; //Also called link indicator for none-UStar format
+    char linkedFileName[100];
+    //USTar-specific fields -- NUL-filled in non-USTAR version
+    char ustarIndicator[6]; //"ustar" -- 6th character might be NUL but results show it doesn't have to
+    char ustarVersion[2]; //00
+    char ownerUserName[32];
+    char ownerGroupName[32];
+    char deviceMajorNumber[8];
+    char deviceMinorNumber[8];
+    char filenamePrefix[155];
+    char padding[12];
+
+    TARFileHeader(TString name, ui32 size) {
+        memset(this, 0, sizeof(TARFileHeader));
+        strcpy(filename, name.c_str());
+        strcpy(fileSize, ToOct(size).c_str());
+        CalcChecksum();
+    }
+
+    std::string ToOct(ui64 n){
+        std::string result;
+        std::stringstream ss;
+        ss << std::oct << n;
+        ss >> result;
+        return result;
+    }
+
+    void CalcChecksum() {
+        memset(checksum, ' ', 8);
+        ui64 unsignedSum = 0;
+        for (ui32 i = 0; i < sizeof(TARFileHeader); i++) {
+            unsignedSum += ((unsigned char*) this)[i];
+        }
+        strcpy(checksum, ToOct(unsignedSum).c_str());
+    }
+
+    void ToStream(IOutputStream& out) {
+        for (ui32 i = 0; i < sizeof(TARFileHeader); i++) {
+            out.Write(((char*) this)[i]);
+        }
+    }
+
+};
 
 int TCommandClusterStateFetch::Run(TConfig& config) {
     NMonitoring::TMonitoringClient client(CreateDriver(config));
@@ -53,7 +108,22 @@ int TCommandClusterStateFetch::Run(TConfig& config) {
     NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
     const auto& proto = NYdb::TProtoAccessor::GetProto(result);
 
-    Cout << proto.Getresult();
+    TFileOutput out(FileName);
+    TBZipCompress compress(&out);
+    TString r = proto.Getresult();
+    if (!r.empty()) {
+        TARFileHeader h("result.json", r.size());
+        h.ToStream(compress);
+        compress << r;
+    }
+    for (ui32 i : xrange(proto.blocksSize())) {
+        auto& block = proto.Getblocks(i);
+        auto& content = block.Getcontent();
+        TARFileHeader h(block.Getname(), content.size());
+        h.ToStream(compress);
+        compress << content;
+    }
+
     return EXIT_SUCCESS;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_state.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_state.cpp
@@ -48,24 +48,12 @@ void TCommandClusterStateFetch::Parse(TConfig& config) {
 }
 
 struct TARFileHeader {
-    char filename[100]; //NUL-terminated
-    char mode[8];
-    char uid[8];
-    char gid[8];
+    char filename[100];
+    char padding[24];
     char fileSize[12];
     char lastModification[12];
     char checksum[8];
-    char typeFlag; //Also called link indicator for none-UStar format
-    char linkedFileName[100];
-    //USTar-specific fields -- NUL-filled in non-USTAR version
-    char ustarIndicator[6]; //"ustar" -- 6th character might be NUL but results show it doesn't have to
-    char ustarVersion[2]; //00
-    char ownerUserName[32];
-    char ownerGroupName[32];
-    char deviceMajorNumber[8];
-    char deviceMinorNumber[8];
-    char filenamePrefix[155];
-    char padding[12];
+    char padding2[356];
 
     TARFileHeader(TString name, ui32 size) {
         memset(this, 0, sizeof(TARFileHeader));
@@ -85,14 +73,14 @@ struct TARFileHeader {
     void CalcChecksum() {
         memset(checksum, ' ', 8);
         ui64 unsignedSum = 0;
-        for (ui32 i = 0; i < sizeof(TARFileHeader); i++) {
+        for (ui32 i : xrange(sizeof(TARFileHeader))) {
             unsignedSum += ((unsigned char*) this)[i];
         }
         strcpy(checksum, ToOct(unsignedSum).c_str());
     }
 
     void ToStream(IOutputStream& out) {
-        for (ui32 i = 0; i < sizeof(TARFileHeader); i++) {
+        for (ui32 i : xrange(sizeof(TARFileHeader))) {
             out.Write(((char*) this)[i]);
         }
     }

--- a/ydb/public/lib/ydb_cli/commands/ydb_state.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_state.h
@@ -25,6 +25,7 @@ public:
 private:
     ui32 DurationSeconds = 0;
     ui32 PeriodSeconds = 0;
+    TString FileName;
 };
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Changed api for ydb admin cluster state fetch
--output option added to store the results in file
Counters are separated from cluster state in different files

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
