### PR TITLE
Stop committing broken txs

### DIFF
--- a/ydb/core/tx/columnshard/operations/manager.cpp
+++ b/ydb/core/tx/columnshard/operations/manager.cpp
@@ -95,6 +95,9 @@ void TOperationsManager::CommitTransactionOnExecute(
     auto& lock = GetLockFeaturesForTxVerified(txId);
     TLogContextGuard gLogging(
         NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_TX)("commit_tx_id", txId)("commit_lock_id", lock.GetLockId()));
+    if (lock.GetWriteOperations().size() > 0) {
+        AFL_VERIFY(!lock.IsBroken())("error", "the tx has writes, it is broken, and we are committing it")("writes_count", lock.GetWriteOperations().size());
+    }
     TVector<TWriteOperation::TPtr> commited;
     for (auto&& opPtr : lock.GetWriteOperations()) {
         opPtr->CommitOnExecute(owner, txc, snapshot);

--- a/ydb/core/tx/columnshard/transactions/operators/ev_write/primary.h
+++ b/ydb/core/tx/columnshard/transactions/operators/ev_write/primary.h
@@ -172,7 +172,7 @@ private:
     }
 
     void CheckFinished(TColumnShard& owner) {
-        if (WaitShardsResultAck.empty()) {
+        if (!IsInProgress()) {
             AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "finished");
             owner.EnqueueProgressTx(NActors::TActivationContext::AsActorContext(), GetTxId());
         }
@@ -255,7 +255,7 @@ private:
     }
 
     virtual bool DoIsInProgress() const override {
-        return WaitShardsResultAck.size();
+        return WaitShardsBrokenFlags.size() || WaitShardsResultAck.size();
     }
     virtual std::unique_ptr<NTabletFlatExecutor::ITransaction> DoBuildTxPrepareForProgress(TColumnShard* owner) const override {
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "prepare_for_progress_started")("lock_id", LockId);


### PR DESCRIPTION
fixes #28075

The anomaly happened in the following case

- secondary sends ReadSet (lock is broken) to primary
- primary processes ReadSet and sets TxBroken = true
- primary executes TxStartPreparation and sets TxBroken = lock.IsBroken() (that is false)
- so primary sees that TxBroken == false and decides to commit the tx

So we committed the broken tx, that may lead to all kinds of anomalies.