### PR TITLE
YDBOPS-12504: use_auth_token_file options for configurator

### DIFF
--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -70,10 +70,13 @@ class StaticConfigGenerator(object):
         self._enable_modules = template.get("enable_modules", enable_modules)
 
         self.__cluster_details = base.ClusterDetailsProvider(template, host_info_provider, validator=schema_validator, database=database, enable_modules=self._enable_modules)
+        self.__use_auth_token_file = template.get("use_auth_token_file", False)
         if self.__cluster_details.use_k8s_api:
             self._host_info_provider._init_k8s_labels(self.__cluster_details.k8s_rack_label, self.__cluster_details.k8s_dc_label)
 
         self._yaml_config_enabled = template.get("yaml_config_enabled", False)
+        # New option: whether to include kikimr_auth_token_file in generated configs
+        self._use_auth_token_file = template.get("use_auth_token_file", False)
         self.__is_dynamic_node = True if database is not None else False
         self._database = database
         self._skip_location = skip_location
@@ -369,6 +372,7 @@ class StaticConfigGenerator(object):
                 metering_txt_enabled=self.metering_txt_enabled,
                 audit_txt_enabled=self.audit_txt_enabled,
                 fq_txt_enabled=self.fq_txt_enabled,
+                use_auth_token_file=self._use_auth_token_file,
             )
 
         if self.__cluster_details.use_new_style_kikimr_cfg:
@@ -381,6 +385,7 @@ class StaticConfigGenerator(object):
                 kikimr_home=self.__kikimr_home,
                 cert_params=self.__cluster_details.ic_cert_params,
                 mbus_enabled=self.mbus_enabled,
+                use_auth_token_file=self._use_auth_token_file,
             )
 
         return kikimr_cfg_for_static_node(
@@ -398,6 +403,7 @@ class StaticConfigGenerator(object):
             audit_txt_enabled=self.audit_txt_enabled,
             fq_txt_enabled=self.fq_txt_enabled,
             mbus_enabled=self.mbus_enabled,
+            use_auth_token_file=self._use_auth_token_file,
         )
 
     def get_all_configs(self):
@@ -1692,7 +1698,7 @@ class StaticConfigGenerator(object):
     @property
     def dynamic_server_common_args(self):
         if self.__cluster_details.use_new_style_kikimr_cfg:
-            return dynamic_cfg_new_style(self._enable_cores)
+            return dynamic_cfg_new_style(self._enable_cores, use_auth_token_file=self.__use_auth_token_file)
         return kikimr_cfg_for_dynamic_slot(
             self._enable_cores, cert_params=self.__cluster_details.ic_cert_params
         )

--- a/ydb/tools/cfg/templates.py
+++ b/ydb/tools/cfg/templates.py
@@ -18,7 +18,6 @@ BASE_VARS = [
     ("kikimr_udfs_dir", "${kikimr_binaries_base_path}/libs"),
     ("kikimr_key_file", "${kikimr_config}/key.txt"),
     ("kikimr_auth_file", "${kikimr_config}/auth.txt"),
-    ("kikimr_auth_token_file", "${kikimr_home}/token/kikimr.token"),
     ("kikimr_dyn_ns_file", "${kikimr_config}/dyn_ns.txt"),
     ("kikimr_tracing_file", "${kikimr_config}/tracing.txt"),
     ("kikimr_pdisk_key_file", "${kikimr_config}/pdisk_key.txt"),
@@ -39,9 +38,8 @@ if [ -z "$kikimr_system_file" ]; then
 fi
 """
 
-NEW_STYLE_CONFIG = """kikimr_auth_token_file="${kikimr_home}/token/kikimr.token"
+NEW_STYLE_CONFIG = """
 kikimr_config="${kikimr_home}/cfg"
-kikimr_auth_token_file="${kikimr_home}/token/kikimr.token"
 kikimr_key_file="${kikimr_config}/key.txt"
 
 kikimr_arg="${kikimr_arg} server --yaml-config ${kikimr_config}/config.yaml --node static"
@@ -56,9 +54,7 @@ else
     echo "Monitoring address is not defined."
 fi
 
-if [ -f "${kikimr_auth_token_file}" ]; then
-    kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
-fi
+kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
 
 if [ -f "${kikimr_key_file}" ]; then
     kikimr_arg="${kikimr_arg}${kikimr_key_file:+ --key-file ${kikimr_key_file}}"
@@ -70,9 +66,8 @@ kikimr_arg="${kikimr_arg}${kikimr_ca:+ --ca=${kikimr_ca}}${kikimr_cert:+ --cert=
 """
 
 
-CONFIG_V2 = """kikimr_auth_token_file="${kikimr_home}/token/kikimr.token"
+CONFIG_V2 = """
 kikimr_config="${kikimr_home}/cfg"
-kikimr_auth_token_file="${kikimr_home}/token/kikimr.token"
 kikimr_key_file="${kikimr_config}/key.txt"
 
 kikimr_arg="${kikimr_arg} server --config-dir ${kikimr_config} --node static"
@@ -87,9 +82,7 @@ else
     echo "Monitoring address is not defined."
 fi
 
-if [ -f "${kikimr_auth_token_file}" ]; then
-    kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
-fi
+kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
 
 if [ -f "${kikimr_key_file}" ]; then
     kikimr_arg="${kikimr_arg}${kikimr_key_file:+ --key-file ${kikimr_key_file}}"
@@ -111,7 +104,6 @@ kikimr_node_broker_port="2135"
 kikimr_syslog_service_tag="${kikimr_syslog_service_tag:? expected not empty var}"
 kikimr_tenant="${kikimr_tenant:? expected not empty var}"
 kikimr_config="${kikimr_home}/cfg"
-kikimr_auth_token_file="${kikimr_home}/token/kikimr.token"
 kikimr_key_file="${kikimr_config}/key.txt"
 
 #Custom config
@@ -124,9 +116,7 @@ kikimr_arg="${kikimr_arg}${kikimr_ic_port:+ --ic-port ${kikimr_ic_port}}"
 kikimr_arg="${kikimr_arg}${kikimr_node_broker_port:+ --node-broker-port ${kikimr_node_broker_port}}"
 kikimr_arg="${kikimr_arg}${kikimr_syslog_service_tag:+ --syslog-service-tag ${kikimr_syslog_service_tag}}"
 
-if [ -f "${kikimr_auth_token_file}" ]; then
-    kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
-fi
+kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
 
 if [ ! -z "${kikimr_kafka_port}" ]; then
     kikimr_arg="${kikimr_arg}${kikimr_kafka_port:+ --kafka-port ${kikimr_kafka_port}}"
@@ -162,7 +152,6 @@ kikimr_node_broker_port="2135"
 kikimr_syslog_service_tag="${kikimr_syslog_service_tag:? expected not empty var}"
 kikimr_tenant="${kikimr_tenant:? expected not empty var}"
 kikimr_config="${kikimr_home}/cfg"
-kikimr_auth_token_file="${kikimr_home}/token/kikimr.token"
 
 #Custom config
 [ -s /etc/default/kikimr.custom ] && . /etc/default/kikimr.custom
@@ -174,9 +163,7 @@ kikimr_arg="${kikimr_arg}${kikimr_ic_port:+ --ic-port ${kikimr_ic_port}}"
 kikimr_arg="${kikimr_arg}${kikimr_node_broker_port:+ --node-broker-port ${kikimr_node_broker_port}}"
 kikimr_arg="${kikimr_arg}${kikimr_syslog_service_tag:+ --syslog-service-tag ${kikimr_syslog_service_tag}}"
 
-if [ -f "${kikimr_auth_token_file}" ]; then
-    kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
-fi
+kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
 
 if [ ! -z "${kikimr_kafka_port}" ]; then
     kikimr_arg="${kikimr_arg}${kikimr_kafka_port:+ --kafka-port ${kikimr_kafka_port}}"
@@ -238,9 +225,7 @@ fi
 if [ -f "${kikimr_auth_file}" ]; then
     kikimr_arg="${kikimr_arg}${kikimr_auth_file:+ --auth-file ${kikimr_auth_file}}"
 fi
-if [ -f "${kikimr_auth_token_file}" ]; then
-    kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
-fi
+kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
 
 if [ -f "${kikimr_dyn_ns_file}" ]; then
     kikimr_arg="${kikimr_arg}${kikimr_dyn_ns_file:+ --dyn-nodes-file ${kikimr_dyn_ns_file}}"
@@ -293,6 +278,7 @@ def local_vars(
     fq_txt_enabled=False,
     new_style_kikimr_cfg=False,
     mbus_enabled=False,
+    use_auth_token_file=False,
 ):
     cur_vars = []
     if enable_cores:
@@ -338,6 +324,9 @@ def local_vars(
 
     if not new_style_kikimr_cfg:
         cur_vars.extend(BASE_VARS)
+
+    if use_auth_token_file:
+        cur_vars.append(("kikimr_auth_token_file", "${kikimr_home}/token/kikimr.token"))
 
     if pq_enable:
         cur_vars.append(("kikimr_pq_file", "${kikimr_config}/pq.txt"))
@@ -457,10 +446,12 @@ def ydbd_extra_args(extra_args: str = ""):
 def dynamic_cfg_new_style(
     enable_cores=False,
     extra_args="",
+    use_auth_token_file=False
 ):
     return "\n".join(
         [
             "kikimr_coregen=\"--core\"" if enable_cores else "",
+            "kikimr_auth_token_file=${kikimr_home}/token/kikimr.token" if use_auth_token_file else "",
             NEW_STYLE_DYNAMIC_CFG,
         ]
         + ydbd_extra_args(extra_args)
@@ -469,9 +460,11 @@ def dynamic_cfg_new_style(
 
 def dynamic_cfg_new_style_v2(
     extra_args="",
+    use_auth_token_file=False,
 ):
     return "\n".join(
         [
+            "kikimr_auth_token_file=${kikimr_home}/token/kikimr.token" if use_auth_token_file else "",
             DYNAMIC_CFG_V2,
         ]
         + ydbd_extra_args(extra_args)
@@ -490,6 +483,7 @@ def kikimr_cfg_for_static_node_new_style(
     new_style_kikimr_cfg=True,
     mbus_enabled=False,
     pq_enable=True,
+    use_auth_token_file=False,
 ):
     return "\n".join(
         [
@@ -507,6 +501,7 @@ def kikimr_cfg_for_static_node_new_style(
                 new_style_kikimr_cfg=new_style_kikimr_cfg,
                 mbus_enabled=mbus_enabled,
                 pq_enable=pq_enable,
+                use_auth_token_file=use_auth_token_file,
             ),
             NEW_STYLE_CONFIG,
         ]
@@ -526,6 +521,7 @@ def kikimr_cfg_for_static_node_new_style_v2(
     new_style_kikimr_cfg=True,
     mbus_enabled=False,
     pq_enable=True,
+    use_auth_token_file=False,
 ):
     return "\n".join(
         [
@@ -542,6 +538,7 @@ def kikimr_cfg_for_static_node_new_style_v2(
                 new_style_kikimr_cfg=new_style_kikimr_cfg,
                 mbus_enabled=mbus_enabled,
                 pq_enable=pq_enable,
+                use_auth_token_file=use_auth_token_file,
             ),
             CONFIG_V2,
         ]
@@ -566,6 +563,7 @@ def kikimr_cfg_for_static_node(
     yql_txt_enabled=False,
     fq_txt_enabled=False,
     mbus_enabled=False,
+    use_auth_token_file=False,
 ):
     return '\n'.join(
         [
@@ -586,10 +584,10 @@ def kikimr_cfg_for_static_node(
                 yql_txt_enabled=yql_txt_enabled,
                 fq_txt_enabled=fq_txt_enabled,
                 mbus_enabled=mbus_enabled,
+                use_auth_token_file=use_auth_token_file,
             ),
             NODE_ID_LOCAL_VAR,
             CUSTOM_CONFIG_INJECTOR,
-            # arguments
             DEFAULT_ARGUMENTS_SET,
             NODE_ID_ARGUMENT,
             tenant_argument(tenant),
@@ -621,6 +619,7 @@ def kikimr_cfg_for_dynamic_node(
     audit_txt_enabled=False,
     yql_txt_enabled=False,
     fq_txt_enabled=False,
+    use_auth_token_file=False,
 ):
     return "\n".join(
         [
@@ -642,9 +641,9 @@ def kikimr_cfg_for_dynamic_node(
                 audit_txt_enabled=audit_txt_enabled,
                 yql_txt_enabled=yql_txt_enabled,
                 fq_txt_enabled=fq_txt_enabled,
+                use_auth_token_file=use_auth_token_file,
             ),
             CUSTOM_CONFIG_INJECTOR,
-            # arguments
             DEFAULT_ARGUMENTS_SET,
             NODE_BROKER_ARGUMENT,
             tenant_argument(tenant),
@@ -702,7 +701,6 @@ def kikimr_cfg_for_dynamic_slot(
         + [
             CUSTOM_CONFIG_INJECTOR,
             CUSTOM_SYS_CONFIG_INJECTOR,
-            # arguments
             DEFAULT_ARGUMENTS_SET,
             NODE_BROKER_ARGUMENT,
             SYS_LOG_SERVICE_TAG,


### PR DESCRIPTION
### Changelog entry 

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers 

Added [use_auth_token_file](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (default False) to the generator/templates so kikimr_auth_token_file is injected only when enabled and templates use ${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}} (no -f checks).