### PR TITLE
Fix race condition in login authentication

### DIFF
--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -874,7 +874,7 @@ private:
                     BLOG_TRACE("CanInitLoginToken, database " << database << ", login state is not available yet, deffer token (" << MaskTicket(record.Ticket) << ")");
                     return true;
                 }
-                BLOG_TRACE("CanInitLoginToken, database " << database << ", A5 error");
+                BLOG_TRACE("CanInitLoginToken, database " << database << ", A6 error");
             }
         }
         return false;
@@ -2342,7 +2342,7 @@ void TTicketParserImpl<TDerived>::RefreshDeferredLoginTokens(const TInstant& now
     deferredLoginTokensMessage << "Finish waiting for login providers for " << finishWaitingForLoginProviders.size() << " databases: ";
     for (size_t i = 0; i < finishWaitingForLoginProviders.size() && i < FINISH_WAITING_FOR_LOGIN_PROVIDERS_NUM; ++i) {
         const TString& key = finishWaitingForLoginProviders[i];
-        deferredLoginTokensMessage << key;
+        deferredLoginTokensMessage << key << ", ";
         DeferredLoginTokens.erase(key);
     }
     if (!finishWaitingForLoginProviders.empty()) {

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -858,7 +858,7 @@ private:
                     auto it = DeferredLoginTokens.find(database);
                     if (it != DeferredLoginTokens.end()) {
                         auto& tokenKeys = it->second.second;
-                        static constexpr ui64 MAX_NUMBER_DEFERRED_TOKENS = 1'000'000;
+                        static constexpr ui64 MAX_NUMBER_DEFERRED_TOKENS = 100'000;
                         if (tokenKeys.size() < MAX_NUMBER_DEFERRED_TOKENS) {
                             tokenKeys.insert(key);
                         } else {

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -166,6 +166,56 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT(result->Token->IsExist("group1"));
     }
 
+    Y_UNIT_TEST(LoginGoodWithDelayUpdateSecurityState) {
+        using namespace Tests;
+        TPortManager tp;
+        ui16 kikimrPort = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        NKikimrProto::TAuthConfig authConfig;
+        authConfig.SetUseBlackBox(false);
+        authConfig.SetUseLoginProvider(true);
+        auto settings = TServerSettings(kikimrPort, authConfig);
+        settings.SetDomainName("Root");
+        settings.CreateTicketParser = NKikimr::CreateTicketParser;
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::TICKET_PARSER, NLog::PRI_TRACE);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
+        TClient client(settings);
+        NClient::TKikimr kikimr(client.GetClientConfig());
+        client.InitRootScheme();
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        NLogin::TLoginProvider provider;
+
+        provider.Audience = "/Root";
+        provider.RotateKeys();
+
+        TActorId sender = runtime->AllocateEdgeActor();
+
+        provider.CreateGroup({.Group = "group1"});
+        provider.CreateUser({.User = "user1", .Password = "password1"});
+        provider.AddGroupMembership({.Group = "group1", .Member = "user1"});
+
+
+        auto loginResponse = provider.LoginUser({.User = "user1", .Password = "password1"});
+
+        UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
+
+        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(loginResponse.Token)), 0);
+        Sleep(TDuration::Seconds(1));
+        // Send update security state in 1 second after send TEvAuthorizeTicket
+        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(provider.GetSecurityState())), 0);
+
+        TAutoPtr<IEventHandle> handle;
+
+        TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(result->Token != nullptr);
+        UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
+        UNIT_ASSERT(result->Token->IsExist("group1"));
+    }
+
     Y_UNIT_TEST(LoginBad) {
         using namespace Tests;
         TPortManager tp;

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -174,6 +174,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         NKikimrProto::TAuthConfig authConfig;
         authConfig.SetUseBlackBox(false);
         authConfig.SetUseLoginProvider(true);
+        authConfig.SetDomainLoginOnly(false);
         auto settings = TServerSettings(kikimrPort, authConfig);
         settings.SetDomainName("Root");
         settings.CreateTicketParser = NKikimr::CreateTicketParser;
@@ -186,35 +187,119 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         client.InitRootScheme();
         TTestActorRuntime* runtime = server.GetRuntime();
 
-        NLogin::TLoginProvider provider;
+        {
+            NLogin::TLoginProvider loginProviderDb1;
+            loginProviderDb1.Audience = "/Root/Db1";
+            loginProviderDb1.RotateKeys();
 
-        provider.Audience = "/Root";
-        provider.RotateKeys();
+            TActorId sender = runtime->AllocateEdgeActor();
+
+            loginProviderDb1.CreateGroup({.Group = "group1"});
+            loginProviderDb1.CreateUser({.User = "user1", .Password = "password1"});
+            loginProviderDb1.AddGroupMembership({.Group = "group1", .Member = "user1"});
+
+
+            auto loginResponse = loginProviderDb1.LoginUser({.User = "user1", .Password = "password1"});
+
+            UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
+
+            // Send token without type
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Ticket = loginResponse.Token, .Database = "/Root/Db1"})), 0);
+            Sleep(TDuration::Seconds(1));
+            // Send update security state in 1 second after send TEvAuthorizeTicket
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb1.GetSecurityState())), 0);
+
+            TAutoPtr<IEventHandle> handle;
+
+            TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+            UNIT_ASSERT(result->Error.empty());
+            UNIT_ASSERT(result->Token != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
+            UNIT_ASSERT(result->Token->IsExist("group1"));
+        }
+
+        {
+            NLogin::TLoginProvider loginProviderDb2;
+            loginProviderDb2.Audience = "/Root/Db2";
+            loginProviderDb2.RotateKeys();
+
+            TActorId sender = runtime->AllocateEdgeActor();
+
+            loginProviderDb2.CreateGroup({.Group = "group1"});
+            loginProviderDb2.CreateUser({.User = "user1", .Password = "password1"});
+            loginProviderDb2.AddGroupMembership({.Group = "group1", .Member = "user1"});
+
+
+            auto loginResponse = loginProviderDb2.LoginUser({.User = "user1", .Password = "password1"});
+
+            UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
+
+            // Send token with type Login
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Ticket = "Login " + loginResponse.Token, .Database = "/Root/Db2"})), 0);
+            Sleep(TDuration::Seconds(1));
+            // Send update security state in 1 second after send TEvAuthorizeTicket
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb2.GetSecurityState())), 0);
+
+            TAutoPtr<IEventHandle> handle;
+
+            TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+            UNIT_ASSERT(result->Error.empty());
+            UNIT_ASSERT(result->Token != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
+            UNIT_ASSERT(result->Token->IsExist("group1"));
+        }
+    }
+
+    Y_UNIT_TEST(CanGetErrorIfAppropriateLoginProviderIsAbsent) {
+        using namespace Tests;
+        TPortManager tp;
+        ui16 kikimrPort = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        NKikimrProto::TAuthConfig authConfig;
+        authConfig.SetUseBlackBox(false);
+        authConfig.SetUseLoginProvider(true);
+        authConfig.SetDomainLoginOnly(false);
+        auto settings = TServerSettings(kikimrPort, authConfig);
+        settings.SetDomainName("Root");
+        settings.CreateTicketParser = NKikimr::CreateTicketParser;
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::TICKET_PARSER, NLog::PRI_TRACE);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
+        TClient client(settings);
+        NClient::TKikimr kikimr(client.GetClientConfig());
+        client.InitRootScheme();
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        NLogin::TLoginProvider loginProviderDb1;
+        loginProviderDb1.Audience = "/Root/Db1";
+        loginProviderDb1.RotateKeys();
 
         TActorId sender = runtime->AllocateEdgeActor();
 
-        provider.CreateGroup({.Group = "group1"});
-        provider.CreateUser({.User = "user1", .Password = "password1"});
-        provider.AddGroupMembership({.Group = "group1", .Member = "user1"});
+        loginProviderDb1.CreateGroup({.Group = "group1"});
+        loginProviderDb1.CreateUser({.User = "user1", .Password = "password1"});
+        loginProviderDb1.AddGroupMembership({.Group = "group1", .Member = "user1"});
 
 
-        auto loginResponse = provider.LoginUser({.User = "user1", .Password = "password1"});
+        auto loginResponse = loginProviderDb1.LoginUser({.User = "user1", .Password = "password1"});
 
         UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
 
-        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(loginResponse.Token)), 0);
-        Sleep(TDuration::Seconds(1));
-        // Send update security state in 1 second after send TEvAuthorizeTicket
-        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(provider.GetSecurityState())), 0);
+        // Send token without type
+        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Ticket = loginResponse.Token, .Database = "/Root/Db1"})), 0);
+        // Do no send update security state
+        // runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb1.GetSecurityState())), 0);
 
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
-        UNIT_ASSERT(result->Token != nullptr);
-        UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
-        UNIT_ASSERT(result->Token->IsExist("group1"));
+        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->Token == nullptr);
+        UNIT_ASSERT_EQUAL_C(result->Error.Message, "Login state is not available", result->Error);
+        UNIT_ASSERT_EQUAL_C(result->Error.Retryable, false, result->Error.Retryable);
     }
+
 
     Y_UNIT_TEST(LoginBad) {
         using namespace Tests;

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -709,6 +709,16 @@ TLoginProvider::TValidateTokenResponse TLoginProvider::ValidateToken(const TVali
     }
     return response;
 }
+bool TLoginProvider::CanDecodeToken(const TString& token) {
+    try {
+        jwt::decoded_jwt decoded_token = jwt::decode(token);
+    } catch (const std::invalid_argument& e) {
+        return false;
+    } catch (const std::runtime_error& e) {
+        return false;
+    }
+    return true;
+}
 
 TString TLoginProvider::GetTokenAudience(const TString& token) {
     try {

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -253,6 +253,7 @@ public:
     ~TLoginProvider();
 
     std::vector<TString> GetGroupsMembership(const TString& member) const;
+    static bool CanDecodeToken(const TString& token);
     static TString GetTokenAudience(const TString& token);
     static std::chrono::system_clock::time_point GetTokenExpiresAt(const TString& token);
     static TString SanitizeJwtToken(const TString& token);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes race condition where clients receive "Could not find correct token validator" error when
using newly issued tokens before LoginProvider state is updated.
https://github.com/ydb-platform/ydb/issues/28510

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Add structure for deferred tokens
* When loginProvider is absent do not return error immediate, defer parsing of token when security state will be updated
* Process deferred tokens when UpdateSecurityState arrives
* Return error for deferred tokens when delay will expired
* Add count send requests to LDAP provider in order to do not response to client before get response from LDAP provider
