### PR TITLE
http_gateway: use correct enum (backport q-25-1 #28315) / wake up poll when we released inflight buffers (backport q-25-1 #28390)

### DIFF
--- a/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
@@ -758,7 +758,7 @@ private:
                         curl_easy_pause(streamHandle, CURLPAUSE_RECV_CONT);
                         break;
                     case TEasyCurlStream::EAction::Stop:
-                        curl_easy_pause(streamHandle, CURL_WRITEFUNC_PAUSE);
+                        curl_easy_pause(streamHandle, CURLPAUSE_RECV);
                         break;
                     case TEasyCurlStream::EAction::Drop:
                         curl_multi_remove_handle(Handle, streamHandle);

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h
@@ -101,7 +101,7 @@ public:
 
     class TCountedContent : public TContentBase {
     public:
-        TCountedContent(TString&& data, const std::shared_ptr<std::atomic_size_t>& counter, const ::NMonitoring::TDynamicCounters::TCounterPtr& inflightCounter);
+        TCountedContent(TString&& data, const std::shared_ptr<std::atomic_size_t>& counter, const ::NMonitoring::TDynamicCounters::TCounterPtr& inflightCounter, std::weak_ptr<CURLM> handle, size_t threshold);
         ~TCountedContent();
 
         TCountedContent(TCountedContent&&) = default;
@@ -109,8 +109,12 @@ public:
 
         TString Extract();
     private:
+        void BeforeRelease();
+
         const std::shared_ptr<std::atomic_size_t> Counter;
         const ::NMonitoring::TDynamicCounters::TCounterPtr InflightCounter;
+        std::weak_ptr<CURLM> Handle;
+        const size_t Threshold;
     };
 
     using TOnDownloadStart = std::function<void(CURLcode, long)>; // http code.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
