### PR TITLE
Do not include immediate_control_board_html_renderer in the most of compilation units

### DIFF
--- a/ydb/core/control/immediate_control_board_actor.h
+++ b/ydb/core/control/immediate_control_board_actor.h
@@ -6,7 +6,6 @@
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <ydb/library/actors/core/actor.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 
 namespace NKikimr {
 

--- a/ydb/core/control/lib/dynamic_control_board_impl.h
+++ b/ydb/core/control/lib/dynamic_control_board_impl.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include "immediate_control_board_wrapper.h"
-#include "immediate_control_board_html_renderer.h"
 
 #include <ydb/core/util/concurrent_rw_hash.h>
 
 namespace NKikimr {
+
+class TControlBoardTableHtmlRenderer;
 
 class TDynamicControlBoard : public TThrRefBase {
 private:

--- a/ydb/core/control/lib/immediate_control_board_impl.h
+++ b/ydb/core/control/lib/immediate_control_board_impl.h
@@ -1,18 +1,15 @@
 #pragma once
 
 #include "immediate_control_board_wrapper.h"
-#include "immediate_control_board_html_renderer.h"
 
 #include <ydb/core/control/lib/generated/control_board_proto.h>
 
 #include <library/cpp/threading/hot_swap/hot_swap.h>
 
-#include <util/generic/serialized_enum.h>
-
-
 namespace NKikimr {
 
 class TImmediateControlActor;
+class TControlBoardTableHtmlRenderer;
 
 class TControlBoard: public TControlBoardBase {
     friend class TImmediateControlActor;


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

appdata.h -> immediate_control_board_impl.h -> immediate_control_board_html_renderer.h but the last one actually doesn't need for most components.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
