### PR TITLE
Incompatibility between versions 24-4-4 and 25-1-4

### DIFF
--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -1141,9 +1141,9 @@ message TTransaction {
 
     optional TWriteId WriteId = 15;
 
-    optional NActorsProto.TTraceId ExecuteTraceId = 16;
-    optional NActorsProto.TTraceId WaitRSTraceId = 17;
-    optional NActorsProto.TTraceId WaitRSAcksTraceId = 18;
+    optional NActorsProto.TTraceId ExecuteTraceId = 17;
+    optional NActorsProto.TTraceId WaitRSTraceId = 18;
+    optional NActorsProto.TTraceId WaitRSAcksTraceId = 19;
 };
 
 message TTabletTxInfo {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The field IDs correspond to version 25-1-4.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
