### PR TITLE
Bring fixes for serializable transactions in Column Shards to stable-25-3

### DIFF
--- a/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
@@ -76,6 +76,371 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
 //         tester.Execute();
 //     }
 
+    class TDirtyReads : public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            auto client = Kikimr->GetQueryClient();
+
+            auto session1 = client.GetSession().GetValueSync().GetSession();
+            auto session2 = client.GetSession().GetValueSync().GetSession();
+
+            // given a row (0, 0)
+            auto result = session1.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (0u, "0");
+                )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            // tx1 writes (1, 1)
+            result = session1.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (1u, "1");
+                )"), TTxControl::BeginTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            auto tx1 = result.GetTransaction();
+
+            // tx1 updates (0, 0) to (0, 1)
+            result = session1.ExecuteQuery(Q1_(R"(
+                update KV2 set Value = "1" where Key = 0u;
+                )"), TTxControl::Tx(*tx1)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            tx1 = result.GetTransaction();
+
+            // tx2 reads all the KV, it should see (0, 0)
+            result = session2.ExecuteQuery(Q1_(R"(
+                select * from KV2;
+                )"), TTxControl::BeginTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[0u;["0"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            auto tx2 = result.GetTransaction();
+
+            // bonus checks 1: tx1's reads do not affect the visibility of its writes to other concurrent txs
+            
+            // tx1 sees (0, 1), (1, 1)
+            result = session1.ExecuteQuery(Q1_(R"(
+                select * from KV2 order by Key;
+                )"), TTxControl::Tx(*tx1)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[0u;["1"]];[1u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            tx1 = result.GetTransaction();
+
+            // tx2 sees (0, 0)
+            result = session2.ExecuteQuery(Q1_(R"(
+                select * from KV2;
+                )"), TTxControl::Tx(*tx2)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[0u;["0"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            tx2 = result.GetTransaction();
+
+            // bonus checks 2: tx2's own writes do not affect what it sees from the other concurrent txs
+
+            // tx2 writes (2, 2)
+            result = session2.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (2u, "2");
+                )"), TTxControl::Tx(*tx2)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            // tx2 sees (0, 0), (2, 2)
+            result = session2.ExecuteQuery(Q1_(R"(
+                select * from KV2 order by Key;
+                )"), TTxControl::Tx(*tx2)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[0u;["0"]];[2u;["2"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            tx2 = result.GetTransaction();
+
+            // we do not check conflicts on commit in this test,
+            // so just rollback both txs
+            result = tx1->Rollback().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            result = tx2->Rollback().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+    };
+
+    Y_UNIT_TEST_TWIN(DirtyReads, IsOlap) {
+        TDirtyReads tester;
+        tester.SetIsOlap(IsOlap);
+        tester.Execute();
+    }
+
+    class TChangeFromTheFuture : public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            auto client = Kikimr->GetQueryClient();
+
+            // there is a business rule, 2 may be = 2, only if there is no 1
+
+            auto session1 = client.GetSession().GetValueSync().GetSession();
+            auto session2 = client.GetSession().GetValueSync().GetSession();
+
+            // tx1 upserts 1 = 1
+            auto result = session1.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (1u, "1");
+                )"), TTxControl::BeginTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            auto tx1 = result.GetTransaction();
+
+            // tx2 upserts 2 = 2
+            result = session2.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (2u, "2");
+                )"),
+                TTxControl::BeginTx()
+            ).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            auto tx2 = result.GetTransaction();
+
+            // tx1 commits
+            result = tx1->Commit().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            // a sneaky read checks the condition after the write - never underestimate the creativity of the users.
+            // tx2 sees no 1, because it was committed later (snapshot-wise) than tx1 started.
+            result = session2.ExecuteQuery(Q1_(R"(
+                select * from KV2 where Key = 1u;
+                )"), TTxControl::Tx(*tx2)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([])", FormatResultSetYson(result.GetResultSet(0)));
+            tx2 = result.GetTransaction();
+
+            // tx2 fails to commit
+            result = tx2->Commit().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());
+            UNIT_ASSERT_C(HasIssue(result.GetIssues(), NYql::TIssuesIds::KIKIMR_LOCKS_INVALIDATED), result.GetIssues().ToString());
+        }
+    };
+
+    Y_UNIT_TEST_TWIN(ChangeFromTheFuture, IsOlap) {
+        TChangeFromTheFuture tester;
+        tester.SetIsOlap(IsOlap);
+        tester.Execute();
+    }
+
+    class TLostUpdate : public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            if (GetIsOlap()) {
+                // will be fixed in https://github.com/ydb-platform/ydb/issues/25654
+                return;
+            }
+
+            auto client = Kikimr->GetQueryClient();
+
+            // classic lost update
+
+            auto session1 = client.GetSession().GetValueSync().GetSession();
+            auto session2 = client.GetSession().GetValueSync().GetSession();
+
+            // there is (1, 1) in the database
+            auto result = session1.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (1u, "1");
+                )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            // tx1 reads (1, 1)
+            result = session1.ExecuteQuery(Q1_(R"(
+                select * from KV2 where Key = 1u;
+                )"), TTxControl::BeginTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[1u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            auto tx1 = result.GetTransaction();
+
+            // tx1 increments the value and writes (1, 2)
+            result = session1.ExecuteQuery(Q1_(R"(
+                update KV2 set Value = "2" where Key = 1u;
+                )"), TTxControl::Tx(*tx1)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            tx1 = result.GetTransaction();
+
+            // tx2 reads (1, 1)
+            result = session2.ExecuteQuery(Q1_(R"(
+                select * from KV2 where Key = 1u;
+                )"),
+                TTxControl::BeginTx()
+            ).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[1u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            auto tx2 = result.GetTransaction();
+
+            // tx2 increments the value and writes (1, 2)
+            result = session2.ExecuteQuery(Q1_(R"(
+                update KV2 set Value = "2" where Key = 1u;
+                )"), TTxControl::Tx(*tx2)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            tx2 = result.GetTransaction();
+
+            // tx1 commits
+            result = tx1->Commit().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            // tx2 tries to commit and fails
+            result = tx2->Commit().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());
+            UNIT_ASSERT_C(HasIssue(result.GetIssues(), NYql::TIssuesIds::KIKIMR_LOCKS_INVALIDATED), result.GetIssues().ToString());
+
+            // there is (1, 2) in the database
+            result = session1.ExecuteQuery(Q1_(R"(
+                select * from KV2 where Key = 1u;
+                )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[1u;["2"]]])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    };
+
+    Y_UNIT_TEST_TWIN(LostUpdate, IsOlap) {
+        TLostUpdate tester;
+        tester.SetIsOlap(IsOlap);
+        tester.Execute();
+    }
+
+    class TTransactionFailsAsSoonAsItIsClearItCannotCommit : public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            if (GetIsOlap()) {
+                // will be fixed in https://github.com/ydb-platform/ydb/issues/25661
+                return;
+            }
+
+            auto client = Kikimr->GetQueryClient();
+
+            auto session1 = client.GetSession().GetValueSync().GetSession();
+            auto session2 = client.GetSession().GetValueSync().GetSession();
+
+            // tx1 acquires a snapshot reading from another table
+            auto result = session1.ExecuteQuery(Q1_(R"(
+                select * from KV;
+                )"), TTxControl::BeginTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            auto tx1 = result.GetTransaction();
+
+            // tx2 writes (2, 2) commits
+            result = session2.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (2u, "2");
+                )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            // tx1 reads all the KV2 and understands that there are new data
+            // in the range it reads, so it will not be able to write anything.
+            // If there is a write on the way, tx1 must fail right away not waiting for the commit.
+            result = session1.ExecuteQuery(Q1_(R"(
+                select * from KV2;
+                )"), TTxControl::Tx(*tx1)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([])", FormatResultSetYson(result.GetResultSet(0)));
+            tx1 = result.GetTransaction();
+
+            // tx1 tries to write (1, 1) and fails
+            result = session1.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (1u, "1");
+                )"), TTxControl::Tx(*tx1)).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());
+            UNIT_ASSERT_C(HasIssue(result.GetIssues(), NYql::TIssuesIds::KIKIMR_LOCKS_INVALIDATED), result.GetIssues().ToString());
+            tx1 = result.GetTransaction();
+            UNIT_ASSERT_C(!tx1.has_value(), "Transaction must be aborted");
+        }
+    };
+
+    Y_UNIT_TEST_TWIN(TransactionFailsAsSoonAsItIsClearItCannotCommit, IsOlap) {
+        TTransactionFailsAsSoonAsItIsClearItCannotCommit tester;
+        tester.SetIsOlap(IsOlap);
+        tester.Execute();
+    }
+
+    class TWriteSkew : public TTableDataModificationTester {
+        YDB_ACCESSOR(TString, WriteOp, "replace");
+    protected:
+        void DoExecute() override {
+            if (GetIsOlap()) {
+                // will be fixed in https://github.com/ydb-platform/ydb/issues/25654
+                return;
+            }
+
+            auto client = Kikimr->GetQueryClient();
+
+            // classic write skew
+            // there is a business rule: sum of values must be <= 3
+
+            auto session1 = client.GetSession().GetValueSync().GetSession();
+            auto session2 = client.GetSession().GetValueSync().GetSession();
+
+            // there is (1, 1) and (2, 1) in the database, so sum = 2
+            auto result = session1.ExecuteQuery(Q1_(R"(
+                upsert into KV2 (Key, Value) values (1u, "1");
+                upsert into KV2 (Key, Value) values (2u, "1");
+                )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            // tx1 reads (1, 1) and (2, 1)
+            result = session1.ExecuteQuery(Q1_(R"(
+                select * from KV2 order by Key;
+                )"), TTxControl::BeginTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[1u;["1"]];[2u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            auto tx1 = result.GetTransaction();
+            
+            // tx1 writes (3, 1), so the sum = 3, which is ok
+            result = session1.ExecuteQuery(
+                GetWriteOp() + " into KV2 (Key, Value) values (3u, \"1\");",
+                TTxControl::Tx(*tx1)
+            ).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            tx1 = result.GetTransaction();
+
+            // tx2 reads (1, 1) and (2, 1)
+            result = session2.ExecuteQuery(Q1_(R"(
+                select * from KV2 order by Key;
+                )"), TTxControl::BeginTx()
+            ).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[1u;["1"]];[2u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            auto tx2 = result.GetTransaction();
+
+            // tx2 writes (4, 1), so the sum = 3, which is ok
+            result = session2.ExecuteQuery(
+                GetWriteOp() + " into KV2 (Key, Value) values (4u, \"1\");",
+                TTxControl::Tx(*tx2)
+            ).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            tx2 = result.GetTransaction();
+
+            // tx1 commits
+            // now there are (1, 1), (2, 1) and (3, 1) in the database
+            // sum = 3, which is ok
+            result = tx1->Commit().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            // tx2 tries to commit and fails, because that would have made the sum = 4, which is not ok
+            result = tx2->Commit().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());
+            UNIT_ASSERT_C(HasIssue(result.GetIssues(), NYql::TIssuesIds::KIKIMR_LOCKS_INVALIDATED), result.GetIssues().ToString());
+
+            // check the database, there are (1, 1), (2, 1) and (3, 1)
+            result = session1.ExecuteQuery(Q1_(R"(
+                select * from KV2 order by Key;
+                )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            CompareYson(R"([[1u;["1"]];[2u;["1"]];[3u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    };
+
+    Y_UNIT_TEST_TWIN(WriteSkewInsert, IsOlap) {
+        TWriteSkew tester;
+        tester.SetIsOlap(IsOlap);
+        tester.SetWriteOp("insert");
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST_TWIN(WriteSkewUpsert, IsOlap) {
+        TWriteSkew tester;
+        tester.SetIsOlap(IsOlap);
+        tester.SetWriteOp("upsert");
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST_TWIN(WriteSkewReplace, IsOlap) {
+        TWriteSkew tester;
+        tester.SetIsOlap(IsOlap);
+        tester.SetWriteOp("replace");
+        tester.Execute();
+    }
+    
     class TReadOnlyTxCommitsOnConcurrentWrite : public TTableDataModificationTester {
     protected:
         void DoExecute() override {

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
@@ -118,6 +118,7 @@ void TTxBlobsWritingFinished::DoComplete(const TActorContext& ctx) {
         pathIds.emplace(op->GetPathId().InternalPathId);
         if (op->GetBehaviour() == EOperationBehaviour::WriteWithLock || op->GetBehaviour() == EOperationBehaviour::NoTxWrite) {
             if (op->GetBehaviour() != EOperationBehaviour::NoTxWrite || Self->GetOperationsManager().HasReadLocks(writeMeta.GetPathId().InternalPathId)) {
+                // detect active reads which the given tx has conflicts with
                 auto evWrite = std::make_shared<NOlap::NTxInteractions::TEvWriteWriter>(
                     writeMeta.GetPathId().InternalPathId, writeResult.GetPKBatchVerified(), Self->GetIndexOptional()->GetVersionedIndex().GetPrimaryKey());
                 Self->GetOperationsManager().AddEventForLock(*Self, op->GetLockId(), evWrite);
@@ -127,9 +128,11 @@ void TTxBlobsWritingFinished::DoComplete(const TActorContext& ctx) {
     auto& index = Self->MutableIndexAs<NOlap::TColumnEngineForLogs>();
     auto& granule = index.MutableGranuleVerified(Pack.GetPathId());
     for (auto&& portion : Pack.GetPortions()) {
+        // make the portions visible as uncommitted for reads
         granule.InsertPortionOnComplete(portion.GetPortionInfoPtr(), index);
     }
     if (PackBehaviour == EOperationBehaviour::NoTxWrite) {
+        // make the portions visible as committed for reads
         for (auto&& i : InsertWriteIds) {
             granule.CommitPortionOnComplete(i, index);
         }
@@ -139,7 +142,10 @@ void TTxBlobsWritingFinished::DoComplete(const TActorContext& ctx) {
         auto op = Self->GetOperationsManager().GetOperationVerified((TOperationWriteId)writeMeta.GetWriteId());
         if (op->GetBehaviour() == EOperationBehaviour::NoTxWrite) {
             AFL_VERIFY(CommitSnapshot);
+            // No tx writes (bulk upsert) must break decent/proper txs.
+            // Decent/proper txs asked for serializable, so we have to give them serializable. 
             Self->OperationsManager->AddTemporaryTxLink(op->GetLockId());
+            Self->OperationsManager->BreakConflictingTxs(op->GetLockId());
             Self->OperationsManager->CommitTransactionOnComplete(*Self, op->GetLockId(), *CommitSnapshot);
             Self->Counters.GetTabletCounters()->IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
         }

--- a/ydb/core/tx/columnshard/columnshard__statistics.cpp
+++ b/ydb/core/tx/columnshard/columnshard__statistics.cpp
@@ -314,7 +314,7 @@ void TColumnShard::Handle(NStat::TEvStatistics::TEvStatisticsRequest::TPtr& ev, 
         StoragesManager, resultAccumulator, 1000, columnTagsRequested, versionedIndex, DataAccessorsManager.GetObjectPtrVerified());
 
     for (const auto& [_, portionInfo] : spg->GetPortions()) {
-        if (!portionInfo->IsVisible(GetMaxReadVersion(), true)) {
+        if (!portionInfo->IsVisible(GetMaxReadVersion())) {
             continue;
         }
         portionsPack.AddTask(portionInfo);

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -176,15 +176,14 @@ NOlap::TSnapshot TColumnShard::GetMaxReadVersion() const {
     auto plannedTx = ProgressTxController->GetPlannedTx();
     if (plannedTx) {
         // We may only read just before the first transaction in the queue
-        auto maxReadVersion = TRowVersion(plannedTx->Step, plannedTx->TxId).Prev();
-        return NOlap::TSnapshot(maxReadVersion.Step, maxReadVersion.TxId);
+        auto firstPlannedSnapshot = NOlap::TSnapshot(plannedTx->Step, plannedTx->TxId);
+        return firstPlannedSnapshot.GetPreviousSnapshot();
+    } else {
+        // the same snapshot is used by bulk upsert and aborts
+        // aborts are fine, but be careful with bulk upsert,
+        // it must correctly break conflicting serializable txs
+        return GetCurrentSnapshotForInternalModification();
     }
-    ui64 step = LastPlannedStep;
-    if (MediatorTimeCastEntry) {
-        ui64 mediatorStep = MediatorTimeCastEntry->Get(TabletID());
-        step = Max(step, mediatorStep);
-    }
-    return NOlap::TSnapshot(step, Max<ui64>());
 }
 
 ui64 TColumnShard::GetOutdatedStep() const {

--- a/ydb/core/tx/columnshard/common/snapshot.h
+++ b/ydb/core/tx/columnshard/common/snapshot.h
@@ -50,7 +50,7 @@ public:
     }
 
     constexpr bool Valid() const noexcept {
-        return PlanStep && TxId;
+        return PlanStep != 0 && TxId != 0;
     }
 
     static constexpr TSnapshot Zero() noexcept {
@@ -105,6 +105,15 @@ public:
 
     explicit operator size_t() const {
         return CombineHashes(PlanStep, TxId);
+    }
+
+    TSnapshot GetPreviousSnapshot() const {
+        AFL_VERIFY(Valid());
+        if (TxId == 0) {
+            return TSnapshot(PlanStep - 1, ::Max<ui64>());
+        } else {
+            return TSnapshot(PlanStep, TxId - 1);
+        }
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/metadata_accessor.cpp
+++ b/ydb/core/tx/columnshard/engines/metadata_accessor.cpp
@@ -8,7 +8,6 @@
 #include <ydb/core/formats/arrow/accessor/abstract/accessor.h>
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
-#include <ydb/core/tx/columnshard/engines/portions/written.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/formats/arrow/simple_arrays_cache.h>
@@ -32,42 +31,23 @@ TUserTableAccessor::TUserTableAccessor(const TString& tableName, const NColumnSh
 }
 
 std::unique_ptr<NReader::NCommon::ISourcesConstructor> TUserTableAccessor::SelectMetadata(const TSelectMetadataContext& context,
-    const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver, const bool isPlain) const {
+    const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const {
     AFL_VERIFY(readDescription.PKRangesFilter);
     std::vector<std::shared_ptr<TPortionInfo>> portions =
-        context.GetEngine().Select(PathId.InternalPathId, readDescription.GetSnapshot(), *readDescription.PKRangesFilter, !!readDescription.LockId);
-    std::vector<TInsertWriteId> uncommitted;
-    if (readDescription.LockId) {
-        std::vector<std::shared_ptr<TPortionInfo>> visible;
-        for (auto&& portion: portions) {
-            if (portion->IsCommitted()) {
-                visible.emplace_back(std::move(portion));
-            } else {
-                AFL_VERIFY(portion->GetPortionType() == EPortionType::Written);
-                auto* written = static_cast<NKikimr::NOlap::TWrittenPortionInfo*>(portion.get());
-                const auto& insertWriteId = written->GetInsertWriteId();
-                uncommitted.emplace_back(insertWriteId);
-                if (const auto& lockId = resolver.ResolveWriteIdToLockId(insertWriteId); lockId == readDescription.LockId) {
-                    visible.emplace_back(std::move(portion));
-                }
-            }
-        }
-        portions.swap(visible);
-    }
+        context.GetEngine().Select(PathId.InternalPathId, readDescription.GetSnapshot(), *readDescription.PKRangesFilter, withUncommitted);
     if (!isPlain) {
         std::deque<NReader::NSimple::TSourceConstructor> sources;
         for (auto&& i : portions) {
             sources.emplace_back(NReader::NSimple::TSourceConstructor(std::move(i), readDescription.GetSorting()));
         }
-        return std::make_unique<NReader::NSimple::TPortionsSources>(std::move(sources), readDescription.GetSorting(), std::move(uncommitted));
+        return std::make_unique<NReader::NSimple::TPortionsSources>(std::move(sources), readDescription.GetSorting());
     } else {
-        return std::make_unique<NReader::NPlain::TPortionSources>(std::move(portions), std::move(uncommitted));
+        return std::make_unique<NReader::NPlain::TPortionSources>(std::move(portions));
     }
 }
 
 std::unique_ptr<NReader::NCommon::ISourcesConstructor> TAbsentTableAccessor::SelectMetadata(const TSelectMetadataContext& /*context*/,
-    const NReader::TReadDescription& /*readDescription*/, const NColumnShard::IResolveWriteIdToLockId& /*resolver*/,
-    const bool /*isPlain*/) const {
+    const NReader::TReadDescription& /*readDescription*/, const bool /*withUncommitted*/, const bool /*isPlain*/) const {
     return NReader::NSimple::TPortionsSources::BuildEmpty();
 }
 

--- a/ydb/core/tx/columnshard/engines/metadata_accessor.h
+++ b/ydb/core/tx/columnshard/engines/metadata_accessor.h
@@ -5,7 +5,6 @@
 
 #include <ydb/core/tx/columnshard/common/path_id.h>
 #include <ydb/core/tx/columnshard/common/snapshot.h>
-#include <ydb/core/tx/columnshard/operations/manager.h>
 
 #include <ydb/library/accessor/accessor.h>
 
@@ -81,7 +80,7 @@ public:
     };
 
     virtual std::unique_ptr<NReader::NCommon::ISourcesConstructor> SelectMetadata(const TSelectMetadataContext& context,
-        const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver, const bool isPlain) const = 0;
+        const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const = 0;
     virtual std::optional<TGranuleShardingInfo> GetShardingInfo(
         const std::shared_ptr<const TVersionedIndex>& indexVersionsPointer, const NOlap::TSnapshot& ss) const = 0;
 };
@@ -107,8 +106,7 @@ public:
     }
 
     virtual std::unique_ptr<NReader::NCommon::ISourcesConstructor> SelectMetadata(const TSelectMetadataContext& context,
-        const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver,
-        const bool isPlain) const override;
+        const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const override;
     virtual std::optional<TGranuleShardingInfo> GetShardingInfo(
         const std::shared_ptr<const TVersionedIndex>& indexVersionsPointer, const NOlap::TSnapshot& ss) const override {
         return indexVersionsPointer->GetShardingInfoOptional(PathId.GetInternalPathId(), ss);
@@ -144,8 +142,7 @@ public:
         return std::nullopt;
     }
     virtual std::unique_ptr<NReader::NCommon::ISourcesConstructor> SelectMetadata(const TSelectMetadataContext& context,
-        const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver,
-        const bool isPlain) const override;
+        const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const override;
 };
 
 }   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/engines/portions/written.h
+++ b/ydb/core/tx/columnshard/engines/portions/written.h
@@ -36,10 +36,6 @@ private:
         return sb;
     }
 
-    virtual bool IsCommitted() const override {
-        return !!CommitSnapshot;
-    }
-
 public:
     virtual void FillDefaultColumn(NAssembling::TColumnAssemblingInfo& column, const std::optional<TSnapshot>& defaultSnapshot) const override;
 
@@ -73,6 +69,11 @@ public:
     bool HasCommitSnapshot() const {
         return !!CommitSnapshot;
     }
+
+    virtual bool IsCommitted() const override {
+        return !!CommitSnapshot;
+    }
+
     const TSnapshot& GetCommitSnapshotVerified() const {
         AFL_VERIFY(!!CommitSnapshot);
         return *CommitSnapshot;

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
@@ -34,7 +34,7 @@ TConclusionStatus TReadMetadata::Init(const NColumnShard::TColumnShard* owner, c
             auto op = owner->GetOperationsManager().GetOperationByInsertWriteIdVerified(i);
             // we do not need to check our own uncommitted writes
             if (op->GetLockId() != *LockId) {
-                AddWriteIdToCheck(i, op->GetLockId());
+                AddMaybeConflictingWrite(i, op->GetLockId());
             }
         }
     }
@@ -88,12 +88,13 @@ void TReadMetadata::DoOnReadFinished(NColumnShard::TColumnShard& owner) const {
         return;
     }
     const ui64 lock = *GetLockId();
-    if (GetBrokenWithCommitted()) {
+    if (GetBreakLockOnReadFinished()) {
         owner.GetOperationsManager().GetLockVerified(lock).SetBroken();
     } else {
         NOlap::NTxInteractions::TTxConflicts conflicts;
-        for (auto&& i : GetConflictableLockIds()) {
-            conflicts.Add(i, lock);
+        for (auto&& lockIdToCommit : GetConflictingLockIds()) {
+            // if lockIdToCommit commits, lock must be broken
+            conflicts.Add(lockIdToCommit, lock);
         }
         if (!conflicts.IsEmpty()) {
             auto writer =
@@ -108,7 +109,7 @@ void TReadMetadata::DoOnBeforeStartReading(NColumnShard::TColumnShard& owner) co
         return;
     }
     auto evWriter = std::make_shared<NOlap::NTxInteractions::TEvReadStartWriter>(TableMetadataAccessor->GetPathIdVerified(),
-        GetResultSchema()->GetIndexInfo().GetPrimaryKey(), GetPKRangesFilterPtr(), GetConflictableLockIds());
+        GetResultSchema()->GetIndexInfo().GetPrimaryKey(), GetPKRangesFilterPtr(), GetMaybeConflictingLockIds());
     owner.GetOperationsManager().AddEventForLock(owner, *LockId, evWriter);
 }
 

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
@@ -25,7 +25,7 @@ TConclusionStatus TReadMetadata::Init(const NColumnShard::TColumnShard* owner, c
     }
 
     ITableMetadataAccessor::TSelectMetadataContext context(owner->GetTablesManager(), owner->GetIndexVerified());
-    SourcesConstructor = readDescription.TableMetadataAccessor->SelectMetadata(context, readDescription, owner->GetOperationsManager(), isPlain);
+    SourcesConstructor = readDescription.TableMetadataAccessor->SelectMetadata(context, readDescription, !!LockId, isPlain);
     if (!SourcesConstructor) {
         return TConclusionStatus::Fail("cannot build sources constructor for " + readDescription.TableMetadataAccessor->GetTablePath());
     }

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
@@ -81,7 +81,7 @@ class TReadMetadata: public TReadMetadataBase {
     using TBase = TReadMetadataBase;
 
 private:
-    std::shared_ptr<TAtomicCounter> BrokenWithCommitted = std::make_shared<TAtomicCounter>();
+    mutable TAtomicCounter BreakLockOnReadFinished = TAtomicCounter();
     std::shared_ptr<NColumnShard::TLockSharingInfo> LockSharingInfo;
 
     class TWriteIdInfo {
@@ -99,17 +99,17 @@ private:
             return LockId;
         }
 
-        void MarkAsConflictable() const {
+        void MarkAsConflicting() const {
             Conflicts->Inc();
         }
 
-        bool IsConflictable() const {
+        bool IsConflicting() const {
             return Conflicts->Val();
         }
     };
 
     THashMap<ui64, std::shared_ptr<TAtomicCounter>> LockConflictCounters;
-    THashMap<TInsertWriteId, TWriteIdInfo> ConflictedWriteIds;
+    THashMap<TInsertWriteId, TWriteIdInfo> ConflictingWrites;
 
     virtual void DoOnReadFinished(NColumnShard::TColumnShard& owner) const override;
     virtual void DoOnBeforeStartReading(NColumnShard::TColumnShard& owner) const override;
@@ -132,51 +132,48 @@ public:
         return std::move(SourcesConstructor);
     }
 
-    bool GetBrokenWithCommitted() const {
-        return BrokenWithCommitted->Val();
+    bool GetBreakLockOnReadFinished() const {
+        return BreakLockOnReadFinished.Val();
     }
-    THashSet<ui64> GetConflictableLockIds() const {
+
+    void SetBreakLockOnReadFinished() const {
+        BreakLockOnReadFinished.Inc();
+    }
+
+    THashSet<ui64> GetConflictingLockIds() const {
         THashSet<ui64> result;
-        for (auto&& i : ConflictedWriteIds) {
-            if (i.second.IsConflictable()) {
-                result.emplace(i.second.GetLockId());
+        for (auto& [_, writeIdInfo] : ConflictingWrites) {
+            if (writeIdInfo.IsConflicting()) {
+                result.emplace(writeIdInfo.GetLockId());
             }
         }
         return result;
     }
 
-    bool IsLockConflictable(const ui64 lockId) const {
-        auto it = LockConflictCounters.find(lockId);
-        AFL_VERIFY(it != LockConflictCounters.end());
-        return it->second->Val();
-    }
-
-    bool IsWriteConflictable(const TInsertWriteId writeId) const {
-        auto it = ConflictedWriteIds.find(writeId);
-        AFL_VERIFY(it != ConflictedWriteIds.end());
-        return it->second.IsConflictable();
+    THashSet<ui64> GetMaybeConflictingLockIds() const {
+        THashSet<ui64> result;
+        for (auto& [_, writeInfo] : ConflictingWrites) {
+            result.emplace(writeInfo.GetLockId());
+        }
+        return result;
     }
 
     bool MayWriteBeConflicting(const TInsertWriteId writeId) const {
-        return ConflictedWriteIds.contains(writeId);
+        return ConflictingWrites.contains(writeId);
     }
 
-    void AddWriteIdToCheck(const TInsertWriteId writeId, const ui64 lockId) {
+    void AddMaybeConflictingWrite(const TInsertWriteId writeId, const ui64 lockId) {
         auto it = LockConflictCounters.find(lockId);
         if (it == LockConflictCounters.end()) {
             it = LockConflictCounters.emplace(lockId, std::make_shared<TAtomicCounter>()).first;
         }
-        AFL_VERIFY(ConflictedWriteIds.emplace(writeId, TWriteIdInfo(lockId, it->second)).second);
+        AFL_VERIFY(ConflictingWrites.emplace(writeId, TWriteIdInfo(lockId, it->second)).second);
     }
 
-    void SetConflictedWriteId(const TInsertWriteId writeId) const {
-        auto it = ConflictedWriteIds.find(writeId);
-        AFL_VERIFY(it != ConflictedWriteIds.end());
-        it->second.MarkAsConflictable();
-    }
-
-    void SetBrokenWithCommitted() const {
-        BrokenWithCommitted->Inc();
+    void SetWriteConflicting(const TInsertWriteId writeId) const {
+        auto it = ConflictingWrites.find(writeId);
+        AFL_VERIFY(it != ConflictingWrites.end());
+        it->second.MarkAsConflicting();
     }
 
     NArrow::NMerger::TSortableBatchPosition BuildSortedPosition(const NArrow::TSimpleRow& key) const;
@@ -191,6 +188,9 @@ public:
     std::shared_ptr<TReadStats> ReadStats;
 
     TReadMetadata(const std::shared_ptr<const TVersionedIndex>& schemaIndex, const TReadDescription& read);
+
+    TReadMetadata(const TReadMetadata&) = delete;
+    TReadMetadata& operator=(const TReadMetadata&) = delete;
 
     virtual std::vector<TNameTypeInfo> GetKeyYqlSchema() const override {
         return GetResultSchema()->GetIndexInfo().GetPrimaryKeyColumns();

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
@@ -157,6 +157,10 @@ public:
         return it->second.IsConflictable();
     }
 
+    bool MayWriteBeConflicting(const TInsertWriteId writeId) const {
+        return ConflictedWriteIds.contains(writeId);
+    }
+
     void AddWriteIdToCheck(const TInsertWriteId writeId, const ui64 lockId) {
         auto it = LockConflictCounters.find(lockId);
         if (it == LockConflictCounters.end()) {
@@ -164,8 +168,6 @@ public:
         }
         AFL_VERIFY(ConflictedWriteIds.emplace(writeId, TWriteIdInfo(lockId, it->second)).second);
     }
-
-    [[nodiscard]] bool IsMyUncommitted(const TInsertWriteId writeId) const;
 
     void SetConflictedWriteId(const TInsertWriteId writeId) const {
         auto it = ConflictedWriteIds.find(writeId);

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/context.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/context.h
@@ -11,6 +11,13 @@ namespace NKikimr::NOlap::NReader::NCommon {
 class TFetchingScript;
 class IDataSource;
 
+enum class EPortionCommitStatus {
+    Unknown,
+    Committed,
+    OwnUncommitted,
+    UncommittedByAnotherTx
+};
+
 class TSpecialReadContext {
 private:
     YDB_READONLY_DEF(std::shared_ptr<TReadContext>, CommonContext);
@@ -53,6 +60,8 @@ public:
     const TReadMetadata::TConstPtr& GetReadMetadata() const {
         return ReadMetadata;
     }
+
+    EPortionCommitStatus GetPortionCommitStatus(const TPortionInfo& portionInfo) const;
 
     template <class T>
     std::shared_ptr<T> GetReadMetadataVerifiedAs() const {

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
@@ -447,6 +447,7 @@ public:
             return false;
         }
         if (DoAddTxConflict()) {
+            StageData->Clear();
             StageData->Abort();
             return true;
         }

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/constructors.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/constructors.cpp
@@ -13,7 +13,15 @@ std::shared_ptr<NCommon::IDataSource> TPortionSources::DoTryExtractNext(
 }
 
 std::vector<TInsertWriteId> TPortionSources::GetUncommittedWriteIds() const {
-    return Uncommitted;
+    std::vector<TInsertWriteId> result;
+    for (auto&& i : Sources) {
+        if (!i->IsCommitted()) {
+            AFL_VERIFY(i->GetPortionType() == EPortionType::Written);
+            auto* written = static_cast<const TWrittenPortionInfo*>(i.get());
+            result.emplace_back(written->GetInsertWriteId());
+        }
+    }
+    return result;
 }
 
 }   // namespace NKikimr::NOlap::NReader::NPlain

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/constructors.h
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/constructors.h
@@ -13,7 +13,6 @@ class TPortionSources: public NCommon::ISourcesConstructor {
 private:
     std::deque<std::shared_ptr<TPortionInfo>> Sources;
     ui32 SourceIdx = 0;
-    std::vector<TInsertWriteId> Uncommitted;
 
     virtual void DoFillReadStats(TReadStats& stats) const override {
         ui64 compactedPortionsBytes = 0;
@@ -54,10 +53,8 @@ private:
         const std::shared_ptr<NCommon::TSpecialReadContext>& context, const ui32 inFlightCurrentLimit) override;
 
 public:
-    TPortionSources(std::vector<std::shared_ptr<TPortionInfo>>&& sources, std::vector<TInsertWriteId>&& uncommitted)
-        : Sources(sources.begin(), sources.end())
-        , Uncommitted(std::move(uncommitted))
-    {
+    TPortionSources(std::vector<std::shared_ptr<TPortionInfo>>&& sources)
+        : Sources(sources.begin(), sources.end()) {
     }
 
     virtual std::vector<TInsertWriteId> GetUncommittedWriteIds() const override;

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.cpp
@@ -177,11 +177,11 @@ bool TPortionDataSource::DoStartFetchingAccessor(const std::shared_ptr<NCommon::
 bool TPortionDataSource::DoAddTxConflict() {
     auto state = GetContext()->GetPortionStateAtScanStart(this->GetPortionInfo());
     if (state.Committed) {
-        GetContext()->GetReadMetadata()->SetBrokenWithCommitted();
+        GetContext()->GetReadMetadata()->SetBreakLockOnReadFinished();
         return true;
     } else if (!state.IsMyUncommitted()) {
         const auto* wPortion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
+        GetContext()->GetReadMetadata()->SetWriteConflicting(wPortion->GetInsertWriteId());
         return true;
     }
     return false;

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.cpp
@@ -147,9 +147,10 @@ void TPortionDataSource::DoAssembleColumns(const std::shared_ptr<TColumnsSet>& c
     std::optional<TSnapshot> ss;
     if (Portion->GetPortionType() == EPortionType::Written) {
         const auto* portion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        if (portion->HasCommitSnapshot()) {
-            ss = portion->GetCommitSnapshotVerified();
-        } else if (GetContext()->GetReadMetadata()->IsMyUncommitted(portion->GetInsertWriteId())) {
+        auto state = GetContext()->GetPortionStateAtScanStart(*portion);
+        if (state.Committed) {
+            ss = state.MaxRecordSnapshot;
+        } else if (state.IsMyUncommitted()) {
             ss = GetContext()->GetReadMetadata()->GetRequestSnapshot();
         }
     }
@@ -174,15 +175,14 @@ bool TPortionDataSource::DoStartFetchingAccessor(const std::shared_ptr<NCommon::
 }
 
 bool TPortionDataSource::DoAddTxConflict() {
-    if (Portion->IsCommitted()) {
+    auto state = GetContext()->GetPortionStateAtScanStart(this->GetPortionInfo());
+    if (state.Committed) {
         GetContext()->GetReadMetadata()->SetBrokenWithCommitted();
         return true;
-    } else {
+    } else if (!state.IsMyUncommitted()) {
         const auto* wPortion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        if (!GetContext()->GetReadMetadata()->IsMyUncommitted(wPortion->GetInsertWriteId())) {
-            GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
-            return true;
-        }
+        GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
+        return true;
     }
     return false;
 }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.cpp
@@ -187,7 +187,7 @@ public:
 #define LOCAL_LOG_TRACE \
     AFL_TRACE(NKikimrServices::TX_COLUMNSHARD_SCAN)("component", "duplicates_manager")("self", TActivationContext::AsActorContext().SelfID)
 
-TDuplicateManager::TDuplicateManager(const TSpecialReadContext& context, const std::deque<NSimple::TSourceConstructor>& portions)
+TDuplicateManager::TDuplicateManager(const TSpecialReadContext& context, const std::deque<std::shared_ptr<TPortionInfo>>& portions)
     : TActor(&TDuplicateManager::StateMain)
     , LastSchema(context.GetCommonContext()->GetReadMetadata()->GetIndexVersions().GetLastSchema())
     , PKColumns(context.GetPKColumns())

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.h
@@ -8,6 +8,7 @@
 #include <ydb/core/tx/columnshard/blobs_reader/actor.h>
 #include <ydb/core/tx/columnshard/counters/duplicate_filtering.h>
 #include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
+#include <ydb/core/tx/columnshard/engines/portions/written.h>
 #include <ydb/core/tx/columnshard/engines/reader/common_reader/iterator/default_fetching.h>
 #include <ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.h>
 
@@ -74,11 +75,11 @@ private:
     ui64 ExpectedIntersectionCount = 0;
 
 private:
-    static TPortionIntervalTree MakeIntervalTree(const std::deque<NSimple::TSourceConstructor>& portions) {
+    static TPortionIntervalTree MakeIntervalTree(const std::deque<std::shared_ptr<TPortionInfo>>& portions) {
         TPortionIntervalTree intervals;
         for (const auto& portion : portions) {
-            intervals.AddRange(TPortionIntervalTree::TOwnedRange(portion.GetPortion()->IndexKeyStart(), true,
-                                   portion.GetPortion()->IndexKeyEnd(), true), portion.GetPortion());
+            intervals.AddRange(TPortionIntervalTree::TOwnedRange(portion->IndexKeyStart(), true,
+                                   portion->IndexKeyEnd(), true), portion);
         }
         return intervals;
     }
@@ -155,7 +156,7 @@ private:
         THashSet<ui64>& portionIdsToFetch, std::vector<TIntervalInfo>& intervalsToBuild);
 
 public:
-    TDuplicateManager(const TSpecialReadContext& context, const std::deque<NSimple::TSourceConstructor>& portions);
+    TDuplicateManager(const TSpecialReadContext& context, const std::deque<std::shared_ptr<TPortionInfo>>& portions);
 };
 
 }   // namespace NKikimr::NOlap::NReader::NSimple::NDuplicateFiltering

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.cpp
@@ -22,7 +22,15 @@ void TPortionsSources::DoInitCursor(const std::shared_ptr<IScanCursor>& cursor) 
 }
 
 std::vector<TInsertWriteId> TPortionsSources::GetUncommittedWriteIds() const {
-    return Uncommitted;
+    std::vector<TInsertWriteId> result;
+    for (auto&& i : TBase::GetConstructors()) {
+        if (!i.GetPortion()->IsCommitted()) {
+            AFL_VERIFY(i.GetPortion()->GetPortionType() == EPortionType::Written);
+            auto* written = static_cast<const TWrittenPortionInfo*>(i.GetPortion().get());
+            result.emplace_back(written->GetInsertWriteId());
+        }
+    }
+    return result;
 }
 
 std::shared_ptr<TPortionDataSource> TSourceConstructor::Construct(

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.h
@@ -15,7 +15,7 @@ namespace NKikimr::NOlap::NReader::NSimple {
 class TSourceConstructor: public ICursorEntity, public TMoveOnly {
 private:
     TCompareKeyForScanSequence Start;
-    YDB_READONLY(ui32, SourceId, 0);
+    YDB_READONLY(ui64, SourceId, 0);
     YDB_READONLY_DEF(std::shared_ptr<TPortionInfo>, Portion);
     ui32 RecordsCount = 0;
     bool IsStartedByCursorFlag = false;
@@ -44,8 +44,10 @@ public:
         return Start;
     }
 
-    TSourceConstructor(const std::shared_ptr<TPortionInfo>&& portion, const NReader::ERequestSorting sorting)
-        : Start(TReplaceKeyAdapter((sorting == NReader::ERequestSorting::DESC) ? portion->IndexKeyEnd() : portion->IndexKeyStart(),
+    TSourceConstructor(
+        const std::shared_ptr<TPortionInfo>&& portion, 
+        const NReader::ERequestSorting sorting
+    ) : Start(TReplaceKeyAdapter((sorting == NReader::ERequestSorting::DESC) ? portion->IndexKeyEnd() : portion->IndexKeyStart(),
                     sorting == NReader::ERequestSorting::DESC),
               portion->GetPortionId())
         , SourceId(portion->GetPortionId())

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.h
@@ -75,7 +75,6 @@ class TPortionsSources: public NCommon::TSourcesConstructorWithAccessors<TSource
 private:
     using TBase = NCommon::TSourcesConstructorWithAccessors<TSourceConstructor>;
     ui32 CurrentSourceIdx = 0;
-    std::vector<TInsertWriteId> Uncommitted;    
 
     virtual void DoFillReadStats(TReadStats& stats) const override {
         ui64 compactedPortionsBytes = 0;
@@ -108,15 +107,14 @@ private:
     }
 
 public:
-    TPortionsSources(std::deque<TSourceConstructor>&& sources, const ERequestSorting sorting, std::vector<TInsertWriteId>&& uncommitted)
-        : TBase(sorting)
-        , Uncommitted(std::move(uncommitted))
-    {
+    TPortionsSources(std::deque<TSourceConstructor>&& sources, const ERequestSorting sorting)
+        : TBase(sorting) {
         InitializeConstructors(std::move(sources));
     }
 
     static std::unique_ptr<TPortionsSources> BuildEmpty() {
-        return std::make_unique<TPortionsSources>(std::deque<TSourceConstructor>{}, ERequestSorting::NONE, std::vector<TInsertWriteId>{});
+        std::deque<TSourceConstructor> sources;
+        return std::make_unique<TPortionsSources>(std::move(sources), ERequestSorting::NONE);
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
@@ -90,9 +90,6 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(c
         if (partialUsageByPredicate) {
             acc.AddFetchingStep(*GetPredicateColumns(), NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter);
         }
-        if (needConflictDetector || GetFFColumns()->Cross(*GetSpecColumns())) {
-            acc.AddFetchingStep(*GetSpecColumns(), NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter);
-        }
         if (needFilterDeletion) {
             acc.AddAssembleStep(*GetDeletionColumns(), "SPEC_DELETION", NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter, false);
             acc.AddStep(std::make_shared<TDeletionFilter>());
@@ -101,8 +98,7 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(c
             acc.AddAssembleStep(*GetPredicateColumns(), "PREDICATE", NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter, false);
             acc.AddStep(std::make_shared<TPredicateFilter>());
         }
-        if (needConflictDetector || GetFFColumns()->Cross(*GetSpecColumns())) {
-            acc.AddAssembleStep(*GetSpecColumns(), "SPEC", NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter, false);
+        if (needConflictDetector) {
             acc.AddStep(std::make_shared<TConflictDetector>());
         }
         if (preventDuplicates) {

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
@@ -30,14 +30,17 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
 
     const auto* source = sourceExt->GetAs<IDataSource>();
 
-    NCommon::EPortionCommitStatus portionCommitStatus = NCommon::EPortionCommitStatus::Unknown;
+    NCommon::TPortionStateAtScanStart portionState = NCommon::TPortionStateAtScanStart{
+        .Committed = true,
+        .Conflicting = false,
+        .MaxRecordSnapshot = source->GetRecordSnapshotMax()
+    };
     if (source->GetType() == NCommon::IDataSource::EType::SimplePortion) {
         const auto* portion = static_cast<const TPortionDataSource*>(source);
-        portionCommitStatus = GetPortionCommitStatus(portion->GetPortionInfo());
+        portionState = GetPortionStateAtScanStart(portion->GetPortionInfo());
     }
 
-    // snapshot filters will filter the uncommitted changes by other txs and mark conflicts
-    const bool needSnapshots = GetReadMetadata()->GetRequestSnapshot() < source->GetRecordSnapshotMax() || portionCommitStatus == NCommon::EPortionCommitStatus::UncommittedByAnotherTx;
+    const bool needSnapshots = GetReadMetadata()->GetRequestSnapshot() < portionState.MaxRecordSnapshot || portionState.Conflicting;
 
     const bool useIndexes = false;
     const bool hasDeletions = source->GetHasDeletions();
@@ -49,8 +52,7 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
         }
     }
 
-    // we exclude uncommitted changes by other txs from the duplicate filter because those changes are not visible for the given tx
-    const bool preventDuplicates = NeedDuplicateFiltering() && portionCommitStatus != NCommon::EPortionCommitStatus::UncommittedByAnotherTx;
+    const bool preventDuplicates = NeedDuplicateFiltering() && !portionState.Conflicting;
     {
         auto& result = CacheFetchingScripts[needSnapshots ? 1 : 0][partialUsageByPK ? 1 : 0][useIndexes ? 1 : 0][needShardingFilter ? 1 : 0]
                                            [hasDeletions ? 1 : 0][preventDuplicates ? 1 : 0];
@@ -124,11 +126,12 @@ void TSpecialReadContext::RegisterActors(const NCommon::ISourcesConstructor& sou
     if (NeedDuplicateFiltering()) {
         const auto* casted_sources = dynamic_cast<const NCommon::TSourcesConstructorWithAccessors<TSourceConstructor>*>(&sources);
         AFL_VERIFY(casted_sources);
-        // we do not pass uncommitted portions of concurrent txs to the duplicate filter because they are invisible for the given tx
+        // we do not pass conflicting portions of concurrent txs to the duplicate filter because they are invisible for the given tx
         std::deque<std::shared_ptr<TPortionInfo>> portionsToDuplicateFilter;
         for (auto&& constructor : casted_sources->GetConstructors()) {
             const auto info = constructor.GetPortion();
-            if (GetPortionCommitStatus(*info) != NCommon::EPortionCommitStatus::UncommittedByAnotherTx) {
+            auto state = GetPortionStateAtScanStart(*info);
+            if (!state.Conflicting) {
                 portionsToDuplicateFilter.emplace_back(std::move(info));
             }
         }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.h>
 #include <ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/constructors.h>
 #include <ydb/core/tx/limiter/grouped_memory/usage/service.h>
+#include <ydb/core/tx/columnshard/engines/portions/written.h>
 
 namespace NKikimr::NOlap::NReader::NSimple {
 
@@ -26,8 +27,17 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
         }
         return false;
     }();
+
     const auto* source = sourceExt->GetAs<IDataSource>();
-    const bool needSnapshots = GetReadMetadata()->GetRequestSnapshot() < source->GetRecordSnapshotMax();
+
+    NCommon::EPortionCommitStatus portionCommitStatus = NCommon::EPortionCommitStatus::Unknown;
+    if (source->GetType() == NCommon::IDataSource::EType::SimplePortion) {
+        const auto* portion = static_cast<const TPortionDataSource*>(source);
+        portionCommitStatus = GetPortionCommitStatus(portion->GetPortionInfo());
+    }
+
+    // snapshot filters will filter the uncommitted changes by other txs and mark conflicts
+    const bool needSnapshots = GetReadMetadata()->GetRequestSnapshot() < source->GetRecordSnapshotMax() || portionCommitStatus == NCommon::EPortionCommitStatus::UncommittedByAnotherTx;
 
     const bool useIndexes = false;
     const bool hasDeletions = source->GetHasDeletions();
@@ -38,7 +48,9 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(
             needShardingFilter = true;
         }
     }
-    const bool preventDuplicates = NeedDuplicateFiltering();
+
+    // we exclude uncommitted changes by other txs from the duplicate filter because those changes are not visible for the given tx
+    const bool preventDuplicates = NeedDuplicateFiltering() && portionCommitStatus != NCommon::EPortionCommitStatus::UncommittedByAnotherTx;
     {
         auto& result = CacheFetchingScripts[needSnapshots ? 1 : 0][partialUsageByPK ? 1 : 0][useIndexes ? 1 : 0][needShardingFilter ? 1 : 0]
                                            [hasDeletions ? 1 : 0][preventDuplicates ? 1 : 0];
@@ -110,9 +122,17 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(c
 void TSpecialReadContext::RegisterActors(const NCommon::ISourcesConstructor& sources) {
     AFL_VERIFY(!DuplicatesManager);
     if (NeedDuplicateFiltering()) {
-        const auto* portions = dynamic_cast<const NCommon::TSourcesConstructorWithAccessors<TSourceConstructor>*>(&sources);
-        AFL_VERIFY(portions);
-        DuplicatesManager = NActors::TActivationContext::Register(new NDuplicateFiltering::TDuplicateManager(*this, portions->GetConstructors()));
+        const auto* casted_sources = dynamic_cast<const NCommon::TSourcesConstructorWithAccessors<TSourceConstructor>*>(&sources);
+        AFL_VERIFY(casted_sources);
+        // we do not pass uncommitted portions of concurrent txs to the duplicate filter because they are invisible for the given tx
+        std::deque<std::shared_ptr<TPortionInfo>> portionsToDuplicateFilter;
+        for (auto&& constructor : casted_sources->GetConstructors()) {
+            const auto info = constructor.GetPortion();
+            if (GetPortionCommitStatus(*info) != NCommon::EPortionCommitStatus::UncommittedByAnotherTx) {
+                portionsToDuplicateFilter.emplace_back(std::move(info));
+            }
+        }
+        DuplicatesManager = NActors::TActivationContext::Register(new NDuplicateFiltering::TDuplicateManager(*this, portionsToDuplicateFilter));
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
@@ -3,6 +3,7 @@
 #include "source.h"
 
 #include <ydb/core/tx/columnshard/engines/filter.h>
+#include <ydb/core/tx/columnshard/engines/portions/written.h>
 #include <ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/events.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
 #include <ydb/core/tx/limiter/grouped_memory/usage/service.h>
@@ -18,6 +19,48 @@ TConclusion<bool> TPredicateFilter::DoExecuteInplace(const std::shared_ptr<NComm
                 source->GetContext()->GetReadMetadata()->GetResultSchema()->GetIndexInfo()),
             true));
     source->MutableStageData().AddFilter(filter);
+    return true;
+}
+
+void VerifyConflictingPortion(const std::shared_ptr<NCommon::IDataSource>& source) {
+    // the portion must be a simple portion
+    AFL_VERIFY(source->GetType() == IDataSource::EType::SimplePortion);
+    auto* portionSource = static_cast<TPortionDataSource*>(source.get());
+    auto& info = portionSource->GetPortionInfo();
+    auto status = portionSource->GetContext()->GetPortionStateAtScanStart(info);
+
+    // let's check that the portion state is ok
+    // we may have here only written portions (not compacted)
+    AFL_VERIFY(info.GetPortionType() == EPortionType::Written);
+    const auto& wPortionInfo = static_cast<const TWrittenPortionInfo&>(info);
+    // we may have here only conflicting portions
+    AFL_VERIFY(status.Conflicting);
+    const auto& requestSnapshot = source->GetContext()->GetReadMetadata()->GetRequestSnapshot();
+    // if portion was already committed at the scan start, it must have commit snapshot greater than the request snapshot
+    if (status.Committed) {
+        AFL_VERIFY(wPortionInfo.GetCommitSnapshotVerified() > requestSnapshot)("error", "portion was committed and conflicting at the scan start, but has commit snapshot less than the request snapshot")("portion_info", wPortionInfo.DebugString())("request_snapshot", requestSnapshot.DebugString());
+    } else {
+        // if the portion was not committed it means now it may be:
+        // 1. still not committed
+        if (!wPortionInfo.IsCommitted()) {
+            // do nothing, it is just fine
+        // 2. committed and removed, in this case its snapshot must be greater or equal to the request snapshot
+        } else if (wPortionInfo.HasRemoveSnapshot()) {
+            AFL_VERIFY(wPortionInfo.GetCommitSnapshotVerified() >= requestSnapshot)("error", "portion was committed and conflicting at the scan start, but now it is removed and committed and has commit snapshot less than the request snapshot")("portion_info", wPortionInfo.DebugString())("request_snapshot", requestSnapshot.DebugString());
+        // 3. committed and not removed, in this case its snapshot must be greater than the request snapshot
+        } else {
+            AFL_VERIFY(wPortionInfo.GetCommitSnapshotVerified() > requestSnapshot)("error", "portion was committed and conflicting at the scan start, but now it is committed and has commit snapshot less than the request snapshot")("portion_info", wPortionInfo.DebugString())("request_snapshot", requestSnapshot.DebugString());
+        }
+    }
+    // source must not be empty, we will mark it as conflicting
+    AFL_VERIFY(source->GetRecordsCount() > 0)("error", "source has no records");
+}
+
+TConclusion<bool> TConflictDetector::DoExecuteInplace(
+    const std::shared_ptr<NCommon::IDataSource>& source, const TFetchingScriptCursor& /*step*/) const {
+    VerifyConflictingPortion(source);
+    // it is not empty (not filtered everything out by other filters) and conflicting, so we must mark the conflict here
+    AFL_VERIFY(source->AddTxConflict());
     return true;
 }
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.h
@@ -212,6 +212,18 @@ public:
     }
 };
 
+class TConflictDetector: public IFetchingStep {
+private:
+    using TBase = IFetchingStep;
+
+public:
+    virtual TConclusion<bool> DoExecuteInplace(
+        const std::shared_ptr<NCommon::IDataSource>& source, const TFetchingScriptCursor& step) const override;
+    TConflictDetector()
+        : TBase("CONFLICT_DETECTOR") {
+    }
+};
+
 class TSnapshotFilter: public IFetchingStep {
 private:
     using TBase = IFetchingStep;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.cpp
@@ -369,9 +369,10 @@ void TPortionDataSource::DoAssembleColumns(const std::shared_ptr<TColumnsSet>& c
     std::optional<TSnapshot> ss;
     if (Portion->GetPortionType() == EPortionType::Written) {
         const auto* portion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        if (portion->HasCommitSnapshot()) {
-            ss = portion->GetCommitSnapshotVerified();
-        } else if (GetContext()->GetReadMetadata()->IsMyUncommitted(portion->GetInsertWriteId())) {
+        auto state = GetContext()->GetPortionStateAtScanStart(*portion);
+        if (state.Committed) {
+            ss = state.MaxRecordSnapshot;
+        } else if (state.IsMyUncommitted()) {
             ss = GetContext()->GetReadMetadata()->GetRequestSnapshot();
         }
     }
@@ -462,15 +463,14 @@ TConclusion<bool> TPortionDataSource::DoStartReserveMemory(const NArrow::NSSA::T
 }
 
 bool TPortionDataSource::DoAddTxConflict() {
-    if (Portion->IsCommitted()) {
+    auto state = GetContext()->GetPortionStateAtScanStart(this->GetPortionInfo());
+    if (state.Committed) {
         GetContext()->GetReadMetadata()->SetBrokenWithCommitted();
         return true;
-    } else {
+    } else if (!state.IsMyUncommitted()) {
         const auto* wPortion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        if (!GetContext()->GetReadMetadata()->IsMyUncommitted(wPortion->GetInsertWriteId())) {
-            GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
-            return true;
-        }
+        GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
+        return true;
     }
     return false;
 }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.cpp
@@ -465,11 +465,11 @@ TConclusion<bool> TPortionDataSource::DoStartReserveMemory(const NArrow::NSSA::T
 bool TPortionDataSource::DoAddTxConflict() {
     auto state = GetContext()->GetPortionStateAtScanStart(this->GetPortionInfo());
     if (state.Committed) {
-        GetContext()->GetReadMetadata()->SetBrokenWithCommitted();
+        GetContext()->GetReadMetadata()->SetBreakLockOnReadFinished();
         return true;
     } else if (!state.IsMyUncommitted()) {
         const auto* wPortion = static_cast<const TWrittenPortionInfo*>(Portion.get());
-        GetContext()->GetReadMetadata()->SetConflictedWriteId(wPortion->GetInsertWriteId());
+        GetContext()->GetReadMetadata()->SetWriteConflicting(wPortion->GetInsertWriteId());
         return true;
     }
     return false;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/chunks/metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/chunks/metadata.cpp
@@ -9,7 +9,7 @@ TAccessor::TAccessor(const TString& tablePath, const NColumnShard::TUnifiedOptio
 }
 
 std::unique_ptr<NCommon::ISourcesConstructor> TAccessor::SelectMetadata(const TSelectMetadataContext& context,
-    const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& /*resolver*/, const bool isPlain) const {
+    const NReader::TReadDescription& readDescription, const bool /*withUncommitted*/, const bool isPlain) const {
     AFL_VERIFY(!isPlain);
     return std::make_unique<TConstructor>(context.GetPathIdTranslator(), context.GetEngine(), readDescription.GetTabletId(),
         GetTableFilterPathId(), readDescription.GetSnapshot(), readDescription.PKRangesFilter, readDescription.GetSorting());

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/chunks/metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/chunks/metadata.h
@@ -15,8 +15,7 @@ private:
 public:
     TAccessor(const TString& tableName, const NColumnShard::TUnifiedOptionalPathId pathId);
     virtual std::unique_ptr<NReader::NCommon::ISourcesConstructor> SelectMetadata(const TSelectMetadataContext& context,
-        const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver,
-        const bool isPlain) const override;
+        const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const override;
     virtual std::optional<TGranuleShardingInfo> GetShardingInfo(
         const std::shared_ptr<const TVersionedIndex>& /*indexVersionsPointer*/, const NOlap::TSnapshot& /*ss*/) const override {
         return std::nullopt;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/granules/metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/granules/metadata.cpp
@@ -11,7 +11,7 @@ TAccessor::TAccessor(const TString& tablePath, const NColumnShard::TUnifiedOptio
 }
 
 std::unique_ptr<NReader::NCommon::ISourcesConstructor> TAccessor::SelectMetadata(const TSelectMetadataContext& context,
-    const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& /*resolver*/, const bool isPlain) const {
+    const NReader::TReadDescription& readDescription, const bool /*withUncommitted*/, const bool isPlain) const {
     AFL_VERIFY(!isPlain);
     return std::make_unique<TConstructor>(context.GetPathIdTranslator(), context.GetEngine(), readDescription.GetTabletId(),
         GetTableFilterPathId(), readDescription.PKRangesFilter, readDescription.GetSorting());

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/granules/metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/granules/metadata.h
@@ -16,8 +16,7 @@ private:
 public:
     TAccessor(const TString& tableName, const NColumnShard::TUnifiedOptionalPathId pathId);
     virtual std::unique_ptr<NReader::NCommon::ISourcesConstructor> SelectMetadata(const TSelectMetadataContext& context,
-        const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver,
-        const bool isPlain) const override;
+        const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const override;
     virtual std::optional<TGranuleShardingInfo> GetShardingInfo(
         const std::shared_ptr<const TVersionedIndex>& /*indexVersionsPointer*/, const NOlap::TSnapshot& /*ss*/) const override {
         return std::nullopt;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/optimizer/metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/optimizer/metadata.cpp
@@ -11,7 +11,7 @@ TAccessor::TAccessor(const TString& tablePath, const NColumnShard::TUnifiedOptio
 }
 
 std::unique_ptr<NReader::NCommon::ISourcesConstructor> TAccessor::SelectMetadata(const TSelectMetadataContext& context,
-    const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& /*resolver*/, const bool isPlain) const {
+    const NReader::TReadDescription& readDescription, const bool /*withUncommitted*/, const bool isPlain) const {
     AFL_VERIFY(!isPlain);
     return std::make_unique<TConstructor>(context.GetPathIdTranslator(), context.GetEngine(), readDescription.GetTabletId(),
         GetTableFilterPathId(), readDescription.PKRangesFilter, readDescription.GetSorting());

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/optimizer/metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/optimizer/metadata.h
@@ -16,8 +16,7 @@ private:
 public:
     TAccessor(const TString& tableName, const NColumnShard::TUnifiedOptionalPathId pathId);
     virtual std::unique_ptr<NReader::NCommon::ISourcesConstructor> SelectMetadata(const TSelectMetadataContext& context,
-        const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver,
-        const bool isPlain) const override;
+        const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const override;
     virtual std::optional<TGranuleShardingInfo> GetShardingInfo(
         const std::shared_ptr<const TVersionedIndex>& /*indexVersionsPointer*/, const NOlap::TSnapshot& /*ss*/) const override {
         return std::nullopt;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/portions/metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/portions/metadata.cpp
@@ -11,7 +11,7 @@ TAccessor::TAccessor(const TString& tablePath, const NColumnShard::TUnifiedOptio
 }
 
 std::unique_ptr<NReader::NCommon::ISourcesConstructor> TAccessor::SelectMetadata(const TSelectMetadataContext& context,
-    const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& /*resolver*/, const bool isPlain) const {
+    const NReader::TReadDescription& readDescription, const bool /*withUncommitted*/, const bool isPlain) const {
     AFL_VERIFY(!isPlain);
     return std::make_unique<TConstructor>(context.GetPathIdTranslator(), context.GetEngine(), readDescription.GetTabletId(),
         GetTableFilterPathId(), readDescription.GetSnapshot(), readDescription.PKRangesFilter, readDescription.GetSorting());

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/portions/metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/portions/metadata.h
@@ -16,8 +16,7 @@ private:
 public:
     TAccessor(const TString& tableName, const NColumnShard::TUnifiedOptionalPathId pathId);
     virtual std::unique_ptr<NReader::NCommon::ISourcesConstructor> SelectMetadata(const TSelectMetadataContext& context,
-        const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver,
-        const bool isPlain) const override;
+        const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const override;
     virtual std::optional<TGranuleShardingInfo> GetShardingInfo(
         const std::shared_ptr<const TVersionedIndex>& /*indexVersionsPointer*/, const NOlap::TSnapshot& /*ss*/) const override {
         return std::nullopt;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/schemas/metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/schemas/metadata.cpp
@@ -11,7 +11,7 @@ TAccessor::TAccessor(const TString& tablePath, const NColumnShard::TUnifiedOptio
 }
 
 std::unique_ptr<NReader::NCommon::ISourcesConstructor> TAccessor::SelectMetadata(const TSelectMetadataContext& context,
-    const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& /*resolver*/, const bool isPlain) const {
+    const NReader::TReadDescription& readDescription, const bool /*withUncommitted*/, const bool isPlain) const {
     AFL_VERIFY(!isPlain);
     return std::make_unique<TConstructor>(
         context.GetEngine(), readDescription.GetTabletId(), readDescription.PKRangesFilter, readDescription.GetSorting());

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/schemas/metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sys_view/schemas/metadata.h
@@ -16,8 +16,7 @@ private:
 public:
     TAccessor(const TString& tableName, const NColumnShard::TUnifiedOptionalPathId pathId);
     virtual std::unique_ptr<NReader::NCommon::ISourcesConstructor> SelectMetadata(const TSelectMetadataContext& context,
-        const NReader::TReadDescription& readDescription, const NColumnShard::IResolveWriteIdToLockId& resolver,
-        const bool isPlain) const override;
+        const NReader::TReadDescription& readDescription, const bool withUncommitted, const bool isPlain) const override;
     virtual std::optional<TGranuleShardingInfo> GetShardingInfo(
         const std::shared_ptr<const TVersionedIndex>& /*indexVersionsPointer*/, const NOlap::TSnapshot& /*ss*/) const override {
         return std::nullopt;

--- a/ydb/core/tx/columnshard/engines/storage/granule/granule.h
+++ b/ydb/core/tx/columnshard/engines/storage/granule/granule.h
@@ -225,8 +225,14 @@ public:
         auto it = InsertedPortions.find(insertWriteId);
         AFL_VERIFY(it != InsertedPortions.end());
         AFL_VERIFY(InsertedPortionsById.contains(it->second->GetPortionId()));
-        it->second->SetCommitSnapshot(ssRemove);
+        // it is better to set remove snapshot before the commit snapshot
+        // because otherwise concurrent readers may see the portion as just committed while
+        // the commit snapshot is already set, but the remove snapshot is not set yet.
+        // this problem should be addressed properly by a synchronized (or atomic) access
+        // to this part of the portion info state https://github.com/ydb-platform/ydb/issues/27205.
+        // until then, this workaround is better than nothing.
         it->second->SetRemoveSnapshot(ssRemove);
+        it->second->SetCommitSnapshot(ssRemove);
         TDbWrapper wrapper(txc.DB, nullptr);
         it->second->CommitToDatabase(wrapper);
     }

--- a/ydb/core/tx/columnshard/operations/manager.cpp
+++ b/ydb/core/tx/columnshard/operations/manager.cpp
@@ -95,6 +95,9 @@ void TOperationsManager::CommitTransactionOnExecute(
     auto& lock = GetLockFeaturesForTxVerified(txId);
     TLogContextGuard gLogging(
         NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_TX)("commit_tx_id", txId)("commit_lock_id", lock.GetLockId()));
+    if (lock.GetWriteOperations().size() > 0) {
+        AFL_VERIFY(!lock.IsBroken())("error", "the tx has writes, it is broken, and we are committing it")("writes_count", lock.GetWriteOperations().size());
+    }
     TVector<TWriteOperation::TPtr> commited;
     for (auto&& opPtr : lock.GetWriteOperations()) {
         opPtr->CommitOnExecute(owner, txc, snapshot);

--- a/ydb/core/tx/columnshard/operations/manager.cpp
+++ b/ydb/core/tx/columnshard/operations/manager.cpp
@@ -72,15 +72,15 @@ bool TOperationsManager::Load(NTabletFlatExecutor::TTransactionContext& txc) {
 }
 
 void TOperationsManager::BreakConflictingTxs(const TLockFeatures& lock) {
-    for (auto&& i : lock.GetBrokeOnCommit()) {
-        if (auto lockNotify = GetLockOptional(i)) {
-            AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("broken_lock_id", i);
-            lockNotify->SetBroken();
+    for (auto&& lockIdToBreak : lock.GetBreakOnCommit()) {
+        if (auto lockToBreak = GetLockOptional(lockIdToBreak)) {
+            AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("broken_lock_id", lockIdToBreak);
+            lockToBreak->SetBroken();
         }
     }
-    for (auto&& i : lock.GetNotifyOnCommit()) {
-        if (auto lockNotify = GetLockOptional(i)) {
-            lockNotify->AddNotifyCommit(lock.GetLockId());
+    for (auto&& lockIdToNotify : lock.GetNotifyOnCommit()) {
+        if (auto lockToNotify = GetLockOptional(lockIdToNotify)) {
+            lockToNotify->NotifyAboutCommit(lock.GetLockId());
         }
     }
 }
@@ -298,16 +298,17 @@ void TOperationsManager::AddEventForLock(
     auto& txLock = GetLockVerified(lockId);
     writer->CheckInteraction(lockId, InteractionsContext, txConflicts, txNotifications);
     for (auto& [commitLockId, breakLockIds] : txConflicts) {
+        // if commitLockId not found, it means the conflicting tx is already committed or aborted
         if (GetLockOptional(commitLockId)) {
-            GetLockVerified(commitLockId).AddBrokeOnCommit(breakLockIds);
-        // if txId not found, it means the conflicting tx is already committed or aborted
-        } else if (txLock.IsCommitted(commitLockId)) {
-            // if the conflicting tx is already committed, we cannot commit the given tx, so break its lock
+            GetLockVerified(commitLockId).AddBreakOnCommit(breakLockIds);
+        } 
+        // if the conflicting tx is already committed, we cannot commit the given tx, so break its lock
+        if (txLock.IsCommitted(commitLockId)) {
             txLock.SetBroken();
         }
     }
-    for (auto&& i : txNotifications) {
-        GetLockVerified(i.first).AddNotificationsOnCommit(i.second);
+    for (auto& [commitLockId, lockIdsToNotify] : txNotifications) {
+        GetLockVerified(commitLockId).AddNotifyOnCommit(lockIdsToNotify);
     }
     if (auto txEvent = writer->BuildEvent()) {
         NOlap::NTxInteractions::TTxEventContainer container(lockId, txEvent);

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -185,6 +185,9 @@ public:
     void AbortTransactionOnExecute(TColumnShard& owner, const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc);
     void AbortTransactionOnComplete(TColumnShard& owner, const ui64 txId);
 
+    void BreakConflictingTxs(const TLockFeatures& lock);
+    void BreakConflictingTxs(const ui64 txId);
+
     std::optional<ui64> GetLockForTx(const ui64 txId) const;
     std::optional<ui64> GetLockForTxOptional(const ui64 txId) const {
         return GetLockForTx(txId);

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -124,16 +124,7 @@ public:
     }
 };
 
-class IResolveWriteIdToLockId {
-protected:
-    virtual ~IResolveWriteIdToLockId() {
-    }
-
-public:
-    virtual std::optional<ui64> ResolveWriteIdToLockId(const TInsertWriteId& writeId) const = 0;
-};
-
-class TOperationsManager: public IResolveWriteIdToLockId {
+class TOperationsManager {
     NOlap::NTxInteractions::TInteractionsContext InteractionsContext;
 
     THashMap<ui64, ui64> Tx2Lock;
@@ -141,16 +132,6 @@ class TOperationsManager: public IResolveWriteIdToLockId {
     THashMap<ui64, TLockFeatures> LockFeatures;
     THashMap<TOperationWriteId, TWriteOperation::TPtr> Operations;
     TOperationWriteId LastWriteId = TOperationWriteId(0);
-
-public:   //IResolveWriteIdToLockId
-    virtual std::optional<ui64> ResolveWriteIdToLockId(const TInsertWriteId& writeId) const override {
-        if (const auto operationWriteId = InsertWriteIdToOpWriteId.FindPtr(writeId)) {
-            if (const auto* operation = Operations.FindPtr(*operationWriteId)) {
-                return (*operation)->GetLockId();
-            }
-        }
-        return std::nullopt;
-    }
 
 public:
 

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -57,7 +57,7 @@ private:
     YDB_READONLY_DEF(std::vector<NOlap::NTxInteractions::TTxEventContainer>, Events);
     std::shared_ptr<TLockSharingInfo> SharingInfo;
 
-    YDB_READONLY_DEF(THashSet<ui64>, BrokeOnCommit);
+    YDB_READONLY_DEF(THashSet<ui64>, BreakOnCommit);
     YDB_READONLY_DEF(THashSet<ui64>, NotifyOnCommit);
     YDB_READONLY_DEF(THashSet<ui64>, Committed);
 
@@ -100,16 +100,18 @@ public:
         return Committed.contains(lockId);
     }
 
-    void AddNotifyCommit(const ui64 lockId) {
-        AFL_VERIFY(NotifyOnCommit.erase(lockId));
+    /*
+    Let the given `TLockFeatures` know that the transaction with `lockId` has committed
+    */
+    void NotifyAboutCommit(const ui64 lockId) {
         Committed.emplace(lockId);
     }
 
-    void AddBrokeOnCommit(const THashSet<ui64>& lockIds) {
-        BrokeOnCommit.insert(lockIds.begin(), lockIds.end());
+    void AddBreakOnCommit(const THashSet<ui64>& lockIds) {
+        BreakOnCommit.insert(lockIds.begin(), lockIds.end());
     }
 
-    void AddNotificationsOnCommit(const THashSet<ui64>& lockIds) {
+    void AddNotifyOnCommit(const THashSet<ui64>& lockIds) {
         NotifyOnCommit.insert(lockIds.begin(), lockIds.end());
     }
 

--- a/ydb/core/tx/columnshard/operations/write.cpp
+++ b/ydb/core/tx/columnshard/operations/write.cpp
@@ -126,9 +126,10 @@ void TWriteOperation::AbortOnExecute(TColumnShard& owner, NTabletFlatExecutor::T
     TBlobGroupSelector dsGroupSelector(owner.Info());
     NOlap::TDbWrapper dbTable(txc.DB, &dsGroupSelector);
 
+    auto abortSnapshot = owner.GetCurrentSnapshotForInternalModification();
     for (auto&& i : InsertWriteIds) {
         owner.MutableIndexAs<NOlap::TColumnEngineForLogs>().MutableGranuleVerified(PathId.InternalPathId).AbortPortionOnExecute(
-            txc, i, owner.GetCurrentSnapshotForInternalModification());
+            txc, i, abortSnapshot);
     }
 }
 

--- a/ydb/core/tx/columnshard/transactions/locks/read_finished.h
+++ b/ydb/core/tx/columnshard/transactions/locks/read_finished.h
@@ -10,7 +10,7 @@ private:
     TTxConflicts Conflicts;
 
     virtual bool DoCheckInteraction(
-        const ui64 /*selfTxId*/, TInteractionsContext& /*context*/, TTxConflicts& conflicts, TTxConflicts& /*notifications*/) const override {
+        const ui64 /*selfLockId*/, TInteractionsContext& /*context*/, TTxConflicts& conflicts, TTxConflicts& /*notifications*/) const override {
         conflicts = Conflicts;
         return true;
     }

--- a/ydb/core/tx/columnshard/transactions/locks/read_start.cpp
+++ b/ydb/core/tx/columnshard/transactions/locks/read_start.cpp
@@ -32,15 +32,15 @@ void TEvReadStart::DoSerializeToProto(NKikimrColumnShardTxProto::TEvent& proto) 
     *proto.MutableRead()->MutableSchema() = NArrow::SerializeSchema(*Schema);
 }
 
-void TEvReadStart::DoAddToInteraction(const ui64 txId, TInteractionsContext& context) const {
+void TEvReadStart::DoAddToInteraction(const ui64 lockId, TInteractionsContext& context) const {
     for (auto&& i : *Filter) {
-        context.AddInterval(txId, PathId.InternalPathId, TIntervalPoint::From(i.GetPredicateFrom(), Schema), TIntervalPoint::To(i.GetPredicateTo(), Schema));
+        context.AddInterval(lockId, PathId.InternalPathId, TIntervalPoint::From(i.GetPredicateFrom(), Schema), TIntervalPoint::To(i.GetPredicateTo(), Schema));
     }
 }
 
-void TEvReadStart::DoRemoveFromInteraction(const ui64 txId, TInteractionsContext& context) const {
+void TEvReadStart::DoRemoveFromInteraction(const ui64 lockId, TInteractionsContext& context) const {
     for (auto&& i : *Filter) {
-        context.RemoveInterval(txId, PathId.InternalPathId, TIntervalPoint::From(i.GetPredicateFrom(), Schema), TIntervalPoint::To(i.GetPredicateTo(), Schema));
+        context.RemoveInterval(lockId, PathId.InternalPathId, TIntervalPoint::From(i.GetPredicateFrom(), Schema), TIntervalPoint::To(i.GetPredicateTo(), Schema));
     }
 }
 

--- a/ydb/core/tx/columnshard/transactions/locks/read_start.h
+++ b/ydb/core/tx/columnshard/transactions/locks/read_start.h
@@ -13,9 +13,10 @@ private:
     YDB_READONLY_DEF(THashSet<ui64>, LockIdsForCheck);
 
     virtual bool DoCheckInteraction(
-        const ui64 selfTxId, TInteractionsContext& /*context*/, TTxConflicts& /*conflicts*/, TTxConflicts& notifications) const override {
-        for (auto&& i : LockIdsForCheck) {
-            notifications.Add(i, selfTxId);
+        const ui64 selfLockId, TInteractionsContext& /*context*/, TTxConflicts& /*conflicts*/, TTxConflicts& notifications) const override {
+        for (auto& lockIdToCommit : LockIdsForCheck) {
+            // when lockIdToCommit commits, selfLockId will be notified
+            notifications.Add(lockIdToCommit, selfLockId);
         }
         return true;
     }
@@ -49,8 +50,8 @@ private:
 
     virtual bool DoDeserializeFromProto(const NKikimrColumnShardTxProto::TEvent& proto) override;
     virtual void DoSerializeToProto(NKikimrColumnShardTxProto::TEvent& proto) const override;
-    virtual void DoAddToInteraction(const ui64 txId, TInteractionsContext& context) const override;
-    virtual void DoRemoveFromInteraction(const ui64 txId, TInteractionsContext& context) const override;
+    virtual void DoAddToInteraction(const ui64 lockId, TInteractionsContext& context) const override;
+    virtual void DoRemoveFromInteraction(const ui64 lockId, TInteractionsContext& context) const override;
     static inline const TFactory::TRegistrator<TEvReadStart> Registrator = TFactory::TRegistrator<TEvReadStart>(GetClassNameStatic());
 
 public:


### PR DESCRIPTION
Here we bring a bunch of fixes for serializable transactions in Column Shards to stable-25-3.

The fixes were made in the scope of making the jepsen test pass for Column Shards. It does not pass yet but not due to known anomalies.

With these fixes there are no known ways at the moment how one can get anomalies in Column Shards using serializable transactions.

Here is the BIG jepsen issue (the work goes in sub-issues under it) https://github.com/ydb-platform/ydb/issues/22259

The fixes are related to the following sub-issues:
- https://github.com/ydb-platform/ydb/issues/25654
- https://github.com/ydb-platform/ydb/issues/25656
- https://github.com/ydb-platform/ydb/issues/26726
- https://github.com/ydb-platform/ydb/issues/26463
- https://github.com/ydb-platform/ydb/issues/26727
- https://github.com/ydb-platform/ydb/issues/28075