### PR TITLE
set domain for disconnecting nodes in hive info

### DIFF
--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2115,6 +2115,8 @@ void THive::Handle(TEvHive::TEvRequestHiveNodeStats::TPtr& ev) {
         nodeStats.SetNodeId(node.Id);
         if (!node.ServicedDomains.empty()) {
             nodeStats.MutableNodeDomain()->CopyFrom(node.ServicedDomains.front());
+        } else if (!node.LastSeenServicedDomains.empty()) {
+            nodeStats.MutableNodeDomain()->CopyFrom(node.LastSeenServicedDomains.front());
         }
         if (!node.Name.empty()) {
             nodeStats.SetNodeName(node.Name);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

из-за этого нода с частыми рестартами могла не попасть в хелсчек
