### PR TITLE
merge to stable-25-3 YQ-4312 fixes for streaming queries

### DIFF
--- a/ydb/core/kqp/common/events/events.h
+++ b/ydb/core/kqp/common/events/events.h
@@ -140,6 +140,7 @@ struct TEvKqp {
         bool DisableDefaultTimeout = false;
         i64 Generation = 1;
         TString CheckpointId;
+        TString StreamingQueryPath;
     };
 
     struct TEvScriptResponse : public TEventLocal<TEvScriptResponse, TKqpEvents::EvScriptResponse> {

--- a/ydb/core/kqp/common/kqp_user_request_context.h
+++ b/ydb/core/kqp/common/kqp_user_request_context.h
@@ -21,6 +21,7 @@ namespace NKikimr::NKqp {
         std::optional<NResourcePool::TPoolSettings> PoolConfig;
         bool IsStreamingQuery = false;
         TString CheckpointId;
+        TString StreamingQueryPath;
 
         TUserRequestContext() = default;
 

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2887,7 +2887,7 @@ private:
             NYql::NDq::MakeCheckpointStorageID(),
             SelfId(),
             {},
-            Counters->Counters->GetKqpCounters(),
+            Counters->Counters->GetKqpCounters()->GetSubgroup("path", context->StreamingQueryPath),
             graphParams,
             stateLoadMode,
             streamingDisposition).Release());

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -1559,7 +1559,6 @@ void TKqpTasksGraph::PersistTasksGraphInfo(NKikimrKqp::TQueryPhysicalGraph& resu
 
 void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<IKqpGateway::TPhysicalTxData>& transactions, const TVector<NKikimrKqp::TKqpNodeResources>& resourcesSnapshot, const NKikimrKqp::TQueryPhysicalGraph& graphInfo) {
     GetMeta().IsRestored = true;
-    GetMeta().AllowWithSpilling = false;
 
     const auto restoreDqTransform = [](const auto& protoInfo) -> TMaybe<TTransform> {
         if (!protoInfo.HasTransform()) {
@@ -1755,6 +1754,8 @@ void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<IKqpGateway::TPhysicalT
                 const auto it = scheduledTaskCount.find(stageIdx);
                 BuildReadTasksFromSource(stageInfo, resourcesSnapshot, it != scheduledTaskCount.end() ? it->second.TaskCount : 0);
             }
+
+            GetMeta().AllowWithSpilling |= stage.GetAllowWithSpilling();
         }
     }
 }

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1746,6 +1746,7 @@ private:
         ev->ForgetAfter = TDuration::Max();
         ev->Generation = PreviousGeneration + 1;
         ev->CheckpointId = State.GetCheckpointId();
+        ev->StreamingQueryPath = QueryPath;
 
         if (const auto statsPeriod = AppData()->QueryServiceConfig.GetProgressStatsPeriodMs()) {
             ev->ProgressStatsPeriod = TDuration::MilliSeconds(statsPeriod);

--- a/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
@@ -116,9 +116,9 @@ private:
         TExprBase currentNode(node);
         if (auto maybeReadTable = currentNode.Maybe<TKiReadTable>()) {
             auto readTable = maybeReadTable.Cast();
-            for (auto setting : readTable.Settings()) {
-                auto name = setting.Name().Value();
-                if (name == "sysViewRewritten") {
+            for (auto setting : readTable.Settings().Ref().ChildrenList()) {
+                auto maybeTuple = TMaybeNode<TCoNameValueTuple>(setting);
+                if (maybeTuple && maybeTuple.Cast().Name().Value() == "sysViewRewritten"sv) {
                     sysViewRewritten = true;
                 }
             }

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -562,6 +562,7 @@ public:
             .PhysicalGraph = ev.QueryPhysicalGraph,
             .DisableDefaultTimeout = ev.DisableDefaultTimeout,
             .CheckpointId = ev.CheckpointId,
+            .StreamingQueryPath = ev.StreamingQueryPath
         }, QueryServiceConfig));
 
         const auto& creatorId = Register(new TCreateScriptOperationQuery(ExecutionId, RunScriptActorId, ev.Record, meta, MaxRunTime, GetRetryState(), ev.QueryPhysicalGraph, QueryServiceConfig, ev.Generation));
@@ -615,6 +616,7 @@ private:
         meta.SetTraceId(eventProto.GetTraceId());
         meta.SetResourcePoolId(request.GetPoolId());
         meta.SetCheckpointId(ev.CheckpointId);
+        meta.SetStreamingQueryPath(ev.StreamingQueryPath);
         meta.SetClientAddress(request.GetClientAddress());
         meta.SetCollectStats(request.GetCollectStats());
         meta.SetSaveQueryPhysicalGraph(ev.SaveQueryPhysicalGraph);
@@ -1092,6 +1094,7 @@ public:
             .PhysicalGraph = std::move(physicalGraph),
             .DisableDefaultTimeout = meta.GetDisableDefaultTimeout(),
             .CheckpointId = meta.GetCheckpointId(),
+            .StreamingQueryPath = meta.GetStreamingQueryPath()
         }, QueryServiceConfig));
 
         KQP_PROXY_LOG_D("Restart with RunScriptActorId: " << RunScriptActorId << ", has PhysicalGraph: " << hasPhysicalGraph);

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -127,6 +127,7 @@ public:
         , DisableDefaultTimeout(settings.DisableDefaultTimeout)
         , CheckpointId(settings.CheckpointId)
         , PhysicalGraph(std::move(settings.PhysicalGraph))
+        , StreamingQueryPath(settings.StreamingQueryPath)
         , Counters(settings.Counters)
     {}
 
@@ -144,6 +145,7 @@ public:
         );
         UserRequestContext->IsStreamingQuery = SaveQueryPhysicalGraph;
         UserRequestContext->CheckpointId = CheckpointId;
+        UserRequestContext->StreamingQueryPath = StreamingQueryPath;
 
         LOG_I("Bootstrap");
 
@@ -969,6 +971,7 @@ private:
     const bool DisableDefaultTimeout = false;
     const TString CheckpointId;
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
+    const TString StreamingQueryPath;
     std::optional<TActorId> PhysicalGraphSender;
     TIntrusivePtr<TKqpCounters> Counters;
     TString SessionId;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
@@ -25,6 +25,7 @@ struct TKqpRunScriptActorSettings {
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     bool DisableDefaultTimeout = false;
     TString CheckpointId;
+    TString StreamingQueryPath;
 };
 
 NActors::IActor* CreateRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig queryServiceConfig);

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -660,35 +660,39 @@ public:
         TTypeMappingSettings typeMappingSettings;
         typeMappingSettings.set_date_time_format(STRING_FORMAT);
 
-        auto describeTableBuilder = mockClient->ExpectDescribeTable();
-        describeTableBuilder
-            .Table(settings.TableName)
-            .DataSourceInstance(GetMockConnectorSourceInstance())
-            .TypeMappingSettings(typeMappingSettings);
-
-        auto listSplitsBuilder = mockClient->ExpectListSplits();
-        auto fillListSplitExpectation = listSplitsBuilder
-            .ValidateArgs(settings.ValidateListSplitsArgs ? TConnectorClientMock::EArgsValidation::Strict : TConnectorClientMock::EArgsValidation::DataSourceInstance)
-            .Select()
-                .DataSourceInstance(GetMockConnectorSourceInstance())
+        if (settings.DescribeCount) {
+            auto describeTableBuilder = mockClient->ExpectDescribeTable();
+            describeTableBuilder
                 .Table(settings.TableName)
-                .What();
+                .DataSourceInstance(GetMockConnectorSourceInstance())
+                .TypeMappingSettings(typeMappingSettings);
 
-        FillMockConnectorRequestColumns(fillListSplitExpectation, settings.Columns);
-
-        for (ui64 i = 0; i < settings.DescribeCount; ++i) {
-            auto responseBuilder = describeTableBuilder.Response();
-            FillMockConnectorRequestColumns(responseBuilder, settings.Columns);
+            for (ui64 i = 0; i < settings.DescribeCount; ++i) {
+                auto responseBuilder = describeTableBuilder.Response();
+                FillMockConnectorRequestColumns(responseBuilder, settings.Columns);
+            }
         }
 
-        for (ui64 i = 0; i < settings.ListSplitsCount; ++i) {
-            auto responseBuilder = listSplitsBuilder.Result()
-                .AddResponse(NYql::NConnector::NewSuccess())
-                    .Description("some binary description")
-                    .Select()
-                        .DataSourceInstance(GetMockConnectorSourceInstance())
-                        .What();
-            FillMockConnectorRequestColumns(responseBuilder, settings.Columns);
+        if (settings.ListSplitsCount) {
+            auto listSplitsBuilder = mockClient->ExpectListSplits();
+            auto fillListSplitExpectation = listSplitsBuilder
+                .ValidateArgs(settings.ValidateListSplitsArgs ? TConnectorClientMock::EArgsValidation::Strict : TConnectorClientMock::EArgsValidation::DataSourceInstance)
+                .Select()
+                    .DataSourceInstance(GetMockConnectorSourceInstance())
+                    .Table(settings.TableName)
+                    .What();
+
+            FillMockConnectorRequestColumns(fillListSplitExpectation, settings.Columns);
+
+            for (ui64 i = 0; i < settings.ListSplitsCount; ++i) {
+                auto responseBuilder = listSplitsBuilder.Result()
+                    .AddResponse(NYql::NConnector::NewSuccess())
+                        .Description("some binary description")
+                        .Select()
+                            .DataSourceInstance(GetMockConnectorSourceInstance())
+                            .What();
+                FillMockConnectorRequestColumns(responseBuilder, settings.Columns);
+            }
         }
     }
 
@@ -1560,6 +1564,51 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         const auto& readyOp = WaitScriptExecution(operationId);
         UNIT_ASSERT_STRING_CONTAINS(readyOp.Status().GetIssues().ToString(), "Runtime listing is not supported for streaming queries, pragma value was ignored");
         UNIT_ASSERT_VALUES_EQUAL(GetAllObjects(sourceBucket), "{\"data\":\"x\"}\n{\"data\": \"x\"}");
+    }
+
+    Y_UNIT_TEST_F(CrossJoinWithNotExistingDataSource, TStreamingTestFixture) {
+        const auto connectorClient = SetupMockConnectorClient();
+
+        constexpr char ydbSourceName[] = "ydbSourceName";
+        CreateYdbSource(ydbSourceName);
+
+        constexpr char ydbTable[] = "unknownSourceLookup";
+        ExecExternalQuery(fmt::format(R"(
+            CREATE TABLE `{table}` (
+                fqdn String,
+                payload String,
+                PRIMARY KEY (fqdn)
+            ))",
+            "table"_a = ydbTable
+        ));
+
+        {   // Prepare connector mock
+            const std::vector<TColumn> columns = {
+                {"fqdn", Ydb::Type::STRING},
+                {"payload", Ydb::Type::STRING}
+            };
+            SetupMockConnectorTableDescription(connectorClient, {
+                .TableName = ydbTable,
+                .Columns = columns,
+                .DescribeCount = 1,
+                .ListSplitsCount = 0
+            });
+        }
+
+        ExecQuery(fmt::format(R"(
+                SELECT
+                    *
+                FROM `unknown-datasource`.`unknown-topic` WITH (
+                    FORMAT = raw,
+                    SCHEMA (Data String NOT NULL)
+                ) AS p
+                CROSS JOIN (
+                    SELECT * FROM `{ydb_source}`.`{table}`
+                ) AS l
+            )",
+            "ydb_source"_a = ydbSourceName,
+            "table"_a = ydbTable
+        ), EStatus::SCHEME_ERROR, "Cannot find table '/Root/unknown-datasource.[unknown-topic]' because it does not exist or you do not have access permissions");
     }
 }
 

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -925,6 +925,7 @@ message TScriptExecutionOperationMeta {
     optional bool SaveQueryPhysicalGraph = 12;
     optional bool DisableDefaultTimeout = 13;
     optional string CheckpointId = 14;
+    optional string StreamingQueryPath = 15;
 }
 
 // stored in column "retry_state" of .metadata/script_executions table

--- a/ydb/tests/fq/streaming/conftest.py
+++ b/ydb/tests/fq/streaming/conftest.py
@@ -32,7 +32,7 @@ class YdbClient:
         return self.session_pool.execute_with_retries_async(statement)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def kikimr(request):
 
     class Kikimr:

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -31,13 +31,13 @@ class TestStreamingInYdb(TestYdsBase):
         url = self.monitoring_endpoint(kikimr, node_id) + "/counters/counters={}/json".format(counters)
         return load_metrics(url)
 
-    def get_checkpoint_coordinator_metric(self, kikimr, query_id, metric_name, expect_counters_exist=False):
+    def get_checkpoint_coordinator_metric(self, kikimr, path, metric_name, expect_counters_exist=False):
         sum = 0
         found = False
         for node_id in kikimr.Cluster.nodes:
             sensor = self.get_sensors(kikimr, node_id, "kqp").find_sensor(
                 {
-                    # "query_id": query_id,  # TODO
+                    "path": path,
                     "subsystem": "checkpoint_coordinator",
                     "sensor": metric_name
                 }
@@ -48,16 +48,16 @@ class TestStreamingInYdb(TestYdsBase):
         assert found or not expect_counters_exist
         return sum
 
-    def get_completed_checkpoints(self, kikimr, query_id):
-        return self.get_checkpoint_coordinator_metric(kikimr, query_id, "CompletedCheckpoints")
+    def get_completed_checkpoints(self, kikimr, path):
+        return self.get_checkpoint_coordinator_metric(kikimr, path, "CompletedCheckpoints")
 
-    def wait_completed_checkpoints(self, kikimr, query_id,
+    def wait_completed_checkpoints(self, kikimr, path,
                                    timeout=plain_or_under_sanitizer_wrapper(120, 150)):
-        current = self.get_checkpoint_coordinator_metric(kikimr, query_id, "CompletedCheckpoints")
+        current = self.get_checkpoint_coordinator_metric(kikimr, path, "CompletedCheckpoints")
         checkpoints_count = current + 2
         deadline = time.time() + timeout
         while True:
-            completed = self.get_completed_checkpoints(kikimr, query_id)
+            completed = self.get_completed_checkpoints(kikimr, path)
             if completed >= checkpoints_count:
                 break
             assert time.time() < deadline, "Wait checkpoint failed, actual completed: " + str(completed)
@@ -125,16 +125,16 @@ class TestStreamingInYdb(TestYdsBase):
                 INSERT INTO {source_name}.`{output_topic}` SELECT time FROM $in;
             END DO;'''
 
-        query_id = "query_id"  # TODO
+        path = f"/Root/{name}"
         kikimr.YdbClient.query(sql.format(query_name=name, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path)
 
         data = ['{"time": "lunch time"}']
         expected_data = ['lunch time']
         self.write_stream(data)
 
         assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path)
 
         kikimr.YdbClient.query(f"ALTER STREAMING QUERY `{name}` SET (RUN = FALSE);")
         time.sleep(0.5)
@@ -164,21 +164,22 @@ class TestStreamingInYdb(TestYdsBase):
                 INSERT INTO {source_name}.`{output_topic}` SELECT time FROM $in;
             END DO;'''
 
-        kikimr.YdbClient.query(sql.format(query_name="query1", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-        kikimr.YdbClient.query(sql.format(query_name="query2", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-
-        query_id = "query_id"  # TODO
-        self.wait_completed_checkpoints(kikimr, query_id)
+        query_name1 = "test_read_topic_shared_reading_insert_to_topic1"
+        query_name2 = "test_read_topic_shared_reading_insert_to_topic2"
+        kikimr.YdbClient.query(sql.format(query_name=query_name1, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        kikimr.YdbClient.query(sql.format(query_name=query_name2, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        path1 = f"/Root/{query_name1}"
+        self.wait_completed_checkpoints(kikimr, path1)
 
         data = ['{"time": "lunch time"}']
         expected_data = ['lunch time', 'lunch time']
         self.write_stream(data)
         assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path1)
 
         sql = R'''ALTER STREAMING QUERY `{query_name}` SET (RUN = FALSE);'''
-        kikimr.YdbClient.query(sql.format(query_name="query1"))
-        kikimr.YdbClient.query(sql.format(query_name="query2"))
+        kikimr.YdbClient.query(sql.format(query_name=query_name1))
+        kikimr.YdbClient.query(sql.format(query_name=query_name2))
 
         time.sleep(1)
 
@@ -187,13 +188,13 @@ class TestStreamingInYdb(TestYdsBase):
         self.write_stream(data)
 
         sql = R'''ALTER STREAMING QUERY `{query_name}` SET (RUN = TRUE);'''
-        kikimr.YdbClient.query(sql.format(query_name="query1"))
-        kikimr.YdbClient.query(sql.format(query_name="query2"))
+        kikimr.YdbClient.query(sql.format(query_name=query_name1))
+        kikimr.YdbClient.query(sql.format(query_name=query_name2))
         assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
 
         sql = R'''DROP STREAMING QUERY `{query_name}`;'''
-        kikimr.YdbClient.query(sql.format(query_name="query1"))
-        kikimr.YdbClient.query(sql.format(query_name="query2"))
+        kikimr.YdbClient.query(sql.format(query_name=query_name1))
+        kikimr.YdbClient.query(sql.format(query_name=query_name2))
 
     def test_read_topic_shared_reading_restart_nodes(self, kikimr):
         sourceName = "source_" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
@@ -211,14 +212,15 @@ class TestStreamingInYdb(TestYdsBase):
                 INSERT INTO {source_name}.`{output_topic}` SELECT value FROM $in;
             END DO;'''
 
-        kikimr.YdbClient.query(sql.format(query_name="query1", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-        query_id = "query_id"  # TODO
-        self.wait_completed_checkpoints(kikimr, query_id)
+        query_name = "test_read_topic_shared_reading_restart_nodes"
+        kikimr.YdbClient.query(sql.format(query_name=query_name, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        path = f"/Root/{query_name}"
+        self.wait_completed_checkpoints(kikimr, path)
 
         self.write_stream(['{"value": "value1"}'])
         expected_data = ['value1']
         assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path)
 
         restart_node_id = None
         for node_id in kikimr.Cluster.nodes:
@@ -234,7 +236,7 @@ class TestStreamingInYdb(TestYdsBase):
         self.write_stream(['{"value": "value2"}'])
         expected_data = ['value2']
         assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path)
 
     def test_read_topic_restore_state(self, kikimr):
         sourceName = "source4_" + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
@@ -267,9 +269,10 @@ class TestStreamingInYdb(TestYdsBase):
                     SELECT ToBytes(Unwrap(Json::SerializeJson(Yson::From(TableRow())))) FROM $mr;
             END DO;'''
 
-        kikimr.YdbClient.query(sql.format(query_name="query1", source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-        query_id = "query_id"  # TODO
-        self.wait_completed_checkpoints(kikimr, query_id)
+        query_name = "test_read_topic_restore_state"
+        kikimr.YdbClient.query(sql.format(query_name=query_name, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
+        path = f"/Root/{query_name}"
+        self.wait_completed_checkpoints(kikimr, path)
 
         data = [
             '{"dt": 1696849942000001, "str": "A" }',
@@ -278,7 +281,7 @@ class TestStreamingInYdb(TestYdsBase):
         self.write_stream(data)
         expected_data = ['{"a_time":1696849942000001,"b_time":1696849942500001,"c_time":null}']
         assert self.read_stream(len(expected_data), topic_path=self.output_topic) == expected_data
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path)
 
         restart_node_id = None
         for node_id in kikimr.Cluster.nodes:
@@ -313,9 +316,9 @@ class TestStreamingInYdb(TestYdsBase):
                 INSERT INTO {source_name}.`{output_topic}` SELECT data FROM $in;
             END DO;'''
 
-        query_id = "query_id"  # TODO
+        path = f"/Root/{name}"
         kikimr.YdbClient.query(sql.format(query_name=name, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path)
 
         data = [
             '{"time": 101, "data": "hello1"}',
@@ -328,7 +331,7 @@ class TestStreamingInYdb(TestYdsBase):
         assert self.read_stream(len(expected), topic_path=self.output_topic) == expected
 
     def test_restart_query_by_rescaling(self, kikimr):
-        sourceName = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        sourceName = 'source' + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
         self.init_topics(sourceName, partitions_count=10)
         self.create_source(kikimr, sourceName, True)
 
@@ -347,15 +350,15 @@ class TestStreamingInYdb(TestYdsBase):
                 INSERT INTO `{source_name}`.`{output_topic}` SELECT time FROM $in;
             END DO;'''
 
-        query_id = "query_id"  # TODO
+        path = f"/Root/{name}"
         kikimr.YdbClient.query(sql.format(query_name=name, source_name=sourceName, input_topic=self.input_topic, output_topic=self.output_topic))
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path)
 
         message_count = 20
         for i in range(message_count):
             self.write_stream(['{"time": "time to do it"}'], topic_path=None, partition_key=(''.join(random.choices(string.digits, k=8))))
         assert self.read_stream(message_count, topic_path=self.output_topic) == ["time to do it" for i in range(message_count)]
-        self.wait_completed_checkpoints(kikimr, query_id)
+        self.wait_completed_checkpoints(kikimr, path)
 
         logging.debug(f"stopping query {name}")
         kikimr.YdbClient.query(f"ALTER STREAMING QUERY `{name}` SET (RUN = FALSE);")

--- a/ydb/tests/fq/yds/test_row_dispatcher.py
+++ b/ydb/tests/fq/yds/test_row_dispatcher.py
@@ -15,7 +15,7 @@ from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
 from ydb.tests.tools.fq_runner.kikimr_runner import TenantConfig
 
 from ydb.tests.tools.datastreams_helpers.control_plane import list_read_rules
-from ydb.tests.tools.datastreams_helpers.control_plane import create_stream, create_read_rule
+from ydb.tests.tools.datastreams_helpers.control_plane import create_stream, create_read_rule, delete_stream
 from ydb.tests.tools.datastreams_helpers.data_plane import read_stream, write_stream
 from ydb.tests.tools.fq_runner.fq_client import StreamingDisposition
 
@@ -1233,3 +1233,52 @@ class TestPqRowDispatcher(TestYdsBase):
             assert time.time() < deadline, f"Waiting sensor ParsingErrors value failed, current count {count}"
             time.sleep(1)
         stop_yds_query(client, query_id)
+
+    @yq_v1
+    def test_delete_topic(self, kikimr, client):
+        self.init(client, "test_delete_topic")
+
+        sql = Rf'''
+            INSERT INTO {YDS_CONNECTION}.`{self.output_topic}`
+            SELECT Cast(time as String) FROM {YDS_CONNECTION}.`{self.input_topic}`
+                WITH (format=json_each_row, SCHEMA (time Int32 NOT NULL, data String NOT NULL));'''
+
+        query_id = start_yds_query(kikimr, client, sql)
+        wait_actor_count(kikimr, "FQ_ROW_DISPATCHER_SESSION", 1)
+
+        data = [
+            '{"time": 101, "data": "hello1", "event": "event1"}',
+            '{"time": 102, "data": "hello2", "event": "event2"}',
+            '{"time": 103, "data": "hello3", "event": "event3"}',
+        ]
+
+        self.write_stream(data)
+        expected = ['101', '102', '103']
+        assert self.read_stream(len(expected), topic_path=self.output_topic) == expected
+        kikimr.compute_plane.wait_completed_checkpoints(
+            query_id, kikimr.compute_plane.get_completed_checkpoints(query_id) + 2
+        )
+        stop_yds_query(client, query_id)
+
+        delete_stream(self.input_topic)
+        create_stream(self.input_topic)
+
+        client.modify_query(
+            query_id,
+            "simple",
+            sql,
+            type=fq.QueryContent.QueryType.STREAMING,
+            state_load_mode=fq.StateLoadMode.EMPTY,
+            streaming_disposition=StreamingDisposition.from_last_checkpoint(),
+        )
+
+        data = [
+            '{"time": 101, "data": "hello1", "event": "event1"}',
+            '{"time": 102, "data": "hello2", "event": "event2"}',
+            '{"time": 103, "data": "hello3", "event": "event3"}',
+            '{"time": 104, "data": "hello4", "event": "event4"}',
+        ]
+
+        self.write_stream(data)
+        expected = ['104']
+        assert self.read_stream(len(expected), topic_path=self.output_topic) == expected


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes for streaming queries

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

* YQ-4867 Add streaming query name to checkpoint metrics (#28519)
* YQ-4535 Streaming queries: add rescaling test (#28122)
* YQ-4555 fixed streaming query recovery with spilling (#28764)
* YQ-4882 fixed internal error in CROS join between PQ and external YDB (#28688)
