### PR TITLE
Local YDB: add custom init scripts support for YDB Docker container

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN ./ya make -r -T \
 
 FROM ubuntu:22.04
 RUN apt-get update  \
-    && apt-get install --no-install-recommends -y libidn12 libaio1 \
+    && apt-get install --no-install-recommends -y libidn12 libaio1 jq \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /root/ydb/bin/ \
@@ -62,4 +62,4 @@ EXPOSE ${YDB_KAFKA_PROXY_PORT:-9092}
 
 HEALTHCHECK --start-period=60s --interval=60s CMD sh /health_check
 
-CMD ["sh", "/initialize_local_ydb"]
+CMD ["bash", "/initialize_local_ydb"]

--- a/.github/docker/files/health_check
+++ b/.github/docker/files/health_check
@@ -5,5 +5,5 @@ if [ "${DEBUG}" = "true" ]; then
     set -x
 fi
 
-/ydb -e grpcs://localhost:${GRPC_TLS_PORT:-2135} --ca-file /ydb_certs/ca.pem -d /local --no-discovery monitoring healthcheck | grep -q GOOD || exit 1
-
+/ydb config profile activate local >/dev/null 2>&1 || true
+/ydb --no-discovery monitoring healthcheck | grep -q GOOD || exit 1

--- a/.github/docker/files/initialize_local_ydb
+++ b/.github/docker/files/initialize_local_ydb
@@ -14,49 +14,116 @@ export YDB_TINY_MODE="true"
 export YBD_INITSCRIPTS_DIR=${YBD_INITSCRIPTS_DIR:-/initdb.d}
 export YBD_PREINITSCRIPTS_DIR=${YBD_PREINITSCRIPTS_DIR:-/preinitdb.d}
 
+ydb_wait_ready() {
+  local max_tries=60
+  local wait_seconds=1
+  local try=0
+
+  echo "Waiting for YDB to be ready..."
+  while [ $try -lt $max_tries ]; do
+    if /ydb -e grpcs://localhost:${GRPC_TLS_PORT} --ca-file /ydb_certs/ca.pem -d /local --no-discovery monitoring healthcheck 2>/dev/null | grep -q GOOD; then
+      echo "YDB is ready!"
+      return 0
+    fi
+
+    try=$((try + 1))
+    echo "Waiting for YDB... ($try/$max_tries)"
+    sleep $wait_seconds
+  done
+
+  echo "ERROR: YDB did not become ready in time"
+  return 1
+}
+
 ydb_custom_pre_init_scripts() {
   echo "Loading custom pre-init scripts..."
   if [[ -d "$YBD_PREINITSCRIPTS_DIR" ]] && [[ -n $(find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
     echo "Loading user's custom files from $YBD_PREINITSCRIPTS_DIR ..."
-    find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+    local failed=0
+    while read -r f; do
+      local status
       if [[ -x "$f" ]]; then
         echo "Executing $f"
         "$f"
+        status=$?
       else
         echo "Sourcing $f"
         . "$f"
+        status=$?
       fi
-    done
+
+      if [[ $status -ne 0 ]]; then
+        echo "ERROR: Pre-init script $f failed with exit code $status"
+        failed=1
+        break
+      fi
+    done < <(find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort)
+
+    if [ $failed -eq 1 ]; then
+      echo "ERROR: Pre-init scripts failed"
+      exit 1
+    fi
+
+    echo "All pre-init scripts executed successfully"
   fi
 }
 
 ydb_custom_init_scripts() {
   echo "Loading custom scripts..."
-  if [[ -d "$YBD_INITSCRIPTS_DIR" ]] && [[ -n $(find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "/ydb_data/.user_scripts_initialized" ]]; then
+  if [[ -d "$YBD_INITSCRIPTS_DIR" ]] && [[ -n $(find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql\.gz\)") ]] && [[ ! -f "/ydb_data/.user_scripts_initialized" ]]; then
+    # Wait for YDB to be ready before running SQL scripts
+    if ! ydb_wait_ready; then
+      echo "ERROR: Cannot run init scripts, YDB is not ready"
+      exit 1
+    fi
+
     echo "Loading user's custom files from $YBD_INITSCRIPTS_DIR ..."
-    find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do
+
+    local failed=0
+    while read -r f; do
+      local status
       case "$f" in
       *.sh)
         if [[ -x "$f" ]]; then
           echo "Executing $f"
           "$f"
+          status=$?
         else
           echo "Sourcing $f"
           . "$f"
+          status=$?
         fi
         ;;
       *.sql)
         echo "Executing $f"
-        ydb -e grpc://localhost:${GRPC_PORT} -d /local scripting yql -f "$f"
+        ydb -e grpcs://localhost:${GRPC_TLS_PORT} --ca-file /ydb_certs/ca.pem -d /local scripting yql -f "$f"
+        status=$?
         ;;
       *.sql.gz)
         echo "Executing $f"
-        gunzip -c "$f" | ydb -e grpc://localhost:${GRPC_PORT} -d /local scripting yql -s -
+        gunzip -c "$f" | ydb -e grpcs://localhost:${GRPC_TLS_PORT} --ca-file /ydb_certs/ca.pem -d /local scripting yql -s -
+        status=$?
         ;;
-      *) echo "Ignoring $f" ;;
+      *)
+        echo "Ignoring $f"
+        continue
+        ;;
       esac
-    done
+
+      if [[ $status -ne 0 ]]; then
+        echo "ERROR: Script $f failed with exit code $status"
+        failed=1
+        break
+      fi
+    done < <(find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql\.gz\)" | sort)
+
+    if [ $failed -eq 1 ]; then
+      echo "ERROR: Init scripts failed, marker file not created"
+      exit 1
+    fi
+
     touch /ydb_data/.user_scripts_initialized
+    echo "All init scripts executed successfully"
   fi
 }
 

--- a/.github/docker/files/initialize_local_ydb
+++ b/.github/docker/files/initialize_local_ydb
@@ -1,133 +1,230 @@
 #!/bin/bash
-set -x
-
-export YDB_GRPC_ENABLE_TLS="true"
-export GRPC_TLS_PORT=${GRPC_TLS_PORT:-2135}
 export GRPC_PORT=${GRPC_PORT:-2136}
-export YDB_GRPC_TLS_DATA_PATH="/ydb_certs"
+export GRPC_TLS_PORT=${GRPC_TLS_PORT:-2135}
 export YDB_KAFKA_PROXY_PORT=${YDB_KAFKA_PROXY_PORT:-9092}
-export YDB_TINY_MODE="true"
 
-# Start local_ydb tool. Pass additional arguments for local_ydb
-/local_ydb deploy --ydb-working-dir /ydb_data --ydb-binary-path /ydbd --fixed-ports --dont-use-log-files "$@";
+export YDB_TINY_MODE=${YDB_TINY_MODE:-true}
+export YDB_WORKING_DIR=${YDB_WORKING_DIR:-/ydb_data}
 
-export YBD_INITSCRIPTS_DIR=${YBD_INITSCRIPTS_DIR:-/initdb.d}
-export YBD_PREINITSCRIPTS_DIR=${YBD_PREINITSCRIPTS_DIR:-/preinitdb.d}
+export YDB_GRPC_ENABLE_TLS=${YDB_GRPC_ENABLE_TLS:-true}
+export YDB_GRPC_TLS_DATA_PATH=${YDB_GRPC_TLS_DATA_PATH:-/ydb_certs}
+
+export PYTHONWARNINGS=ignore
+export YBD_INITSCRIPTS_DIR=${YBD_INITSCRIPTS_DIR:-/init.d}
+export YBD_PREINITSCRIPTS_DIR=${YBD_PREINITSCRIPTS_DIR:-/preinit.d}
+
+# Create and activate a YDB profile for simplified commands
+/ydb config profile create local \
+    --endpoint grpcs://localhost:${GRPC_TLS_PORT} \
+    --database /local \
+    --ca-file /ydb_certs/ca.pem
+/ydb config profile activate local >/dev/null 2>&1
+
+log() {
+    local channel="$1"
+    shift
+    printf '[ydb|%s] %s\n' "$channel" "$*" >&2
+}
+
+log_stream() {
+    local channel="$1"
+    while IFS= read -r line || [ -n "$line" ]; do
+        log "$channel" "$line"
+    done
+}
+
+log_stream_file() {
+    local node="$1"
+    local channel="$2"
+    local file="$3"
+    local is_stderr="${4:-false}"
+
+    if [ "$is_stderr" = "true" ]; then
+        (
+            tail -n +1 -F "$file" 2>/dev/null | while IFS= read -r line || [ -n "$line" ]; do
+                printf '[ydb|%s|%s] %s\n' "$node" "$channel" "$line" >&2
+            done
+        ) &
+    else
+        (
+            tail -n +1 -F "$file" 2>/dev/null | while IFS= read -r line || [ -n "$line" ]; do
+                printf '[ydb|%s|%s] %s\n' "$node" "$channel" "$line"
+            done
+        ) &
+    fi
+}
 
 ydb_wait_ready() {
-  local max_tries=60
-  local wait_seconds=1
-  local try=0
+    local max_tries=10
+    local wait_seconds=6
+    local try=0
 
-  echo "Waiting for YDB to be ready..."
-  while [ $try -lt $max_tries ]; do
-    if /ydb -e grpcs://localhost:${GRPC_TLS_PORT} --ca-file /ydb_certs/ca.pem -d /local --no-discovery monitoring healthcheck 2>/dev/null | grep -q GOOD; then
-      echo "YDB is ready!"
-      return 0
+    while [ $try -lt $max_tries ]; do
+        if /health_check >/dev/null 2>&1; then
+            log init "YDB is ready"
+            return 0
+        fi
+
+        try=$((try + 1))
+        log init "Waiting for YDB... ($try/$max_tries)"
+        sleep $wait_seconds
+    done
+
+    log init "ERROR: YDB did not become ready in time"
+    return 1
+}
+
+ydb_stream_logs() {
+    find "${YDB_WORKING_DIR}" -type f \( -name stdout -o -name stderr -o -name "logfile_*" \) 2>/dev/null | sort | while read -r log_file; do
+        if [ -n "$log_file" ]; then
+            # Extract node ID from path (e.g., /ydb_data/cluster/node_1/logfile_* -> node_1)
+            node_id=$(echo "$log_file" | awk -F'/' '{for(i=1;i<=NF;i++) if($i ~ /^node_/) print $i}')
+            case "$log_file" in
+            *logfile_*)
+                log_stream_file "${node_id:-unknown}" "log" "$log_file" "false"
+                ;;
+            *stderr)
+                log_stream_file "${node_id:-unknown}" "stderr" "$log_file" "true"
+                ;;
+            *stdout)
+                log_stream_file "${node_id:-unknown}" "stdout" "$log_file" "false"
+                ;;
+            esac
+        fi
+    done
+}
+
+ydb_monitor_process() {
+    local attempts=60
+    local ydb_pid=""
+
+    while [ $attempts -gt 0 ]; do
+        ydb_pid=$(pgrep -f '/ydbd server' | head -n 1)
+        if [ -n "$ydb_pid" ]; then
+            break
+        fi
+        sleep 1
+        attempts=$((attempts - 1))
+    done
+
+    if [ -z "$ydb_pid" ]; then
+        exit 1
     fi
 
-    try=$((try + 1))
-    echo "Waiting for YDB... ($try/$max_tries)"
-    sleep $wait_seconds
-  done
+    trap 'kill -TERM "$ydb_pid" 2>/dev/null; wait "$ydb_pid"; exit $?' TERM INT
 
-  echo "ERROR: YDB did not become ready in time"
-  return 1
+    while kill -0 "$ydb_pid" 2>/dev/null; do
+        sleep 5
+    done
+
+    wait "$ydb_pid"
+    exit $? # Exit with the same status as YDB
 }
 
 ydb_custom_pre_init_scripts() {
-  echo "Loading custom pre-init scripts..."
-  if [[ -d "$YBD_PREINITSCRIPTS_DIR" ]] && [[ -n $(find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
-    echo "Loading user's custom files from $YBD_PREINITSCRIPTS_DIR ..."
-    local failed=0
-    while read -r f; do
-      local status
-      if [[ -x "$f" ]]; then
-        echo "Executing $f"
-        "$f"
-        status=$?
-      else
-        echo "Sourcing $f"
-        . "$f"
-        status=$?
-      fi
+    if [ -d "$YBD_PREINITSCRIPTS_DIR" ] && [ -n "$(find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh")" ]; then
+        local fail_marker="${YDB_WORKING_DIR}/.pre_init_failed"
+        rm -f "$fail_marker"
+        find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+            local status
+            # Non-executable scripts are sourced to allow them to modify the environment for subsequent scripts.
+            if [ -x "$f" ]; then
+                log preinit "Running $f"
+                "$f" 1> >(log_stream preinit_script_stdout) 2> >(log_stream preinit_script_stderr)
+                status=$?
+            else
+                log preinit "Sourcing $f"
+                { . "$f"; } 1> >(log_stream preinit_script_stdout) 2> >(log_stream preinit_script_stderr)
+                status=$?
+            fi
 
-      if [[ $status -ne 0 ]]; then
-        echo "ERROR: Pre-init script $f failed with exit code $status"
-        failed=1
-        break
-      fi
-    done < <(find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort)
+            if [ $status -ne 0 ]; then
+                log preinit "ERROR: $f failed with exit code $status"
+                touch "$fail_marker"
+                break
+            fi
+        done
 
-    if [ $failed -eq 1 ]; then
-      echo "ERROR: Pre-init scripts failed"
-      exit 1
+        if [ -f "$fail_marker" ]; then
+            rm -f "$fail_marker"
+            log preinit "ERROR: Pre-init scripts failed"
+            exit 1
+        fi
     fi
-
-    echo "All pre-init scripts executed successfully"
-  fi
 }
 
 ydb_custom_init_scripts() {
-  echo "Loading custom scripts..."
-  if [[ -d "$YBD_INITSCRIPTS_DIR" ]] && [[ -n $(find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql\.gz\)") ]] && [[ ! -f "/ydb_data/.user_scripts_initialized" ]]; then
-    # Wait for YDB to be ready before running SQL scripts
-    if ! ydb_wait_ready; then
-      echo "ERROR: Cannot run init scripts, YDB is not ready"
-      exit 1
-    fi
-
-    echo "Loading user's custom files from $YBD_INITSCRIPTS_DIR ..."
-
-    local failed=0
-    while read -r f; do
-      local status
-      case "$f" in
-      *.sh)
-        if [[ -x "$f" ]]; then
-          echo "Executing $f"
-          "$f"
-          status=$?
-        else
-          echo "Sourcing $f"
-          . "$f"
-          status=$?
+    local user_scripts_initialized_file="${YDB_WORKING_DIR}/.user_scripts_initialized"
+    if [ -d "$YBD_INITSCRIPTS_DIR" ] && [ -n "$(find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql\.gz\)")" ] && [ ! -f "$user_scripts_initialized_file" ]; then
+        # YDB is started in the background by a separate process,
+        # so we need to wait for it to become ready before running init scripts.
+        if ! ydb_wait_ready; then
+            log init "ERROR: Cannot run init files, YDB did not become ready in time"
+            exit 1
         fi
-        ;;
-      *.sql)
-        echo "Executing $f"
-        ydb -e grpcs://localhost:${GRPC_TLS_PORT} --ca-file /ydb_certs/ca.pem -d /local scripting yql -f "$f"
-        status=$?
-        ;;
-      *.sql.gz)
-        echo "Executing $f"
-        gunzip -c "$f" | ydb -e grpcs://localhost:${GRPC_TLS_PORT} --ca-file /ydb_certs/ca.pem -d /local scripting yql -s -
-        status=$?
-        ;;
-      *)
-        echo "Ignoring $f"
-        continue
-        ;;
-      esac
 
-      if [[ $status -ne 0 ]]; then
-        echo "ERROR: Script $f failed with exit code $status"
-        failed=1
-        break
-      fi
-    done < <(find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql\.gz\)" | sort)
+        local fail_marker="${YDB_WORKING_DIR}/.init_failed"
+        rm -f "$fail_marker"
+        find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql\.gz\)" | sort | while read -r f; do
+            local status
+            case "$f" in
+            *.sh)
+                # Non-executable scripts are sourced to allow them to modify the environment for subsequent scripts.
+                if [ -x "$f" ]; then
+                    log init "Running $f"
+                    "$f" 1> >(log_stream init_script_stdout) 2> >(log_stream init_script_stderr)
+                    status=$?
+                else
+                    log init "Sourcing $f"
+                    { . "$f"; } 1> >(log_stream init_script_stdout) 2> >(log_stream init_script_stderr)
+                    status=$?
+                fi
+                ;;
+            *.sql)
+                log init "Executing queries from $f"
+                /ydb --no-discovery yql -f "$f" 1> >(log_stream init_sql_stdout) 2> >(log_stream init_sql_stderr)
+                status=$?
+                ;;
+            *.sql.gz)
+                log init "Executing compressed queries from $f"
+                gunzip -c "$f" | /ydb --no-discovery yql -f - 1> >(log_stream init_sql_stdout) 2> >(log_stream init_sql_stderr)
+                status=$?
+                ;;
+            *)
+                log init "Ignoring $f"
+                continue
+                ;;
+            esac
 
-    if [ $failed -eq 1 ]; then
-      echo "ERROR: Init scripts failed, marker file not created"
-      exit 1
+            if [ $status -ne 0 ]; then
+                log init "ERROR: $f failed with exit code $status"
+                touch "$fail_marker"
+                break
+            fi
+        done
+
+        if [ -f "$fail_marker" ]; then
+            rm -f "$fail_marker"
+            log init "ERROR: Init scripts failed, marker file not created"
+            exit 1
+        fi
+
+        touch "$user_scripts_initialized_file"
     fi
-
-    touch /ydb_data/.user_scripts_initialized
-    echo "All init scripts executed successfully"
-  fi
 }
 
+# Run pre-initialization scripts
 ydb_custom_pre_init_scripts
+
+# Start YDB in a background process
+log init "Starting YDB..."
+/local_ydb deploy --ydb-working-dir /ydb_data --ydb-binary-path /ydbd --fixed-ports "$@"
+
+# Stream logs to stdout
+ydb_stream_logs
+
+# Run initialization scripts after YDB is ready
 ydb_custom_init_scripts
 
-sleep infinity
+# Monitor YDB process and exit container when it stops
+ydb_monitor_process

--- a/.github/docker/files/initialize_local_ydb
+++ b/.github/docker/files/initialize_local_ydb
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -x
 
-INIT_YDB_SCRIPT=/init_ydb
-
 export YDB_GRPC_ENABLE_TLS="true"
 export GRPC_TLS_PORT=${GRPC_TLS_PORT:-2135}
 export GRPC_PORT=${GRPC_PORT:-2136}
@@ -13,8 +11,56 @@ export YDB_TINY_MODE="true"
 # Start local_ydb tool. Pass additional arguments for local_ydb
 /local_ydb deploy --ydb-working-dir /ydb_data --ydb-binary-path /ydbd --fixed-ports --dont-use-log-files "$@";
 
-if [ -f "$INIT_YDB_SCRIPT" ]; then
-  sh "$INIT_YDB_SCRIPT";
-fi
+export YBD_INITSCRIPTS_DIR=${YBD_INITSCRIPTS_DIR:-/initdb.d}
+export YBD_PREINITSCRIPTS_DIR=${YBD_PREINITSCRIPTS_DIR:-/preinitdb.d}
 
-tail -f /dev/null
+ydb_custom_pre_init_scripts() {
+  echo "Loading custom pre-init scripts..."
+  if [[ -d "$YBD_PREINITSCRIPTS_DIR" ]] && [[ -n $(find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh") ]]; then
+    echo "Loading user's custom files from $YBD_PREINITSCRIPTS_DIR ..."
+    find "$YBD_PREINITSCRIPTS_DIR/" -type f -name "*.sh" | sort | while read -r f; do
+      if [[ -x "$f" ]]; then
+        echo "Executing $f"
+        "$f"
+      else
+        echo "Sourcing $f"
+        . "$f"
+      fi
+    done
+  fi
+}
+
+ydb_custom_init_scripts() {
+  echo "Loading custom scripts..."
+  if [[ -d "$YBD_INITSCRIPTS_DIR" ]] && [[ -n $(find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "/ydb_data/.user_scripts_initialized" ]]; then
+    echo "Loading user's custom files from $YBD_INITSCRIPTS_DIR ..."
+    find "$YBD_INITSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do
+      case "$f" in
+      *.sh)
+        if [[ -x "$f" ]]; then
+          echo "Executing $f"
+          "$f"
+        else
+          echo "Sourcing $f"
+          . "$f"
+        fi
+        ;;
+      *.sql)
+        echo "Executing $f"
+        ydb -e grpc://localhost:${GRPC_PORT} -d /local scripting yql -f "$f"
+        ;;
+      *.sql.gz)
+        echo "Executing $f"
+        gunzip -c "$f" | ydb -e grpc://localhost:${GRPC_PORT} -d /local scripting yql -s -
+        ;;
+      *) echo "Ignoring $f" ;;
+      esac
+    done
+    touch /ydb_data/.user_scripts_initialized
+  fi
+}
+
+ydb_custom_pre_init_scripts
+ydb_custom_init_scripts
+
+sleep infinity


### PR DESCRIPTION
Features:
- Pre-init scripts directory (/preinit.d) for .sh files
- Init scripts directory (/init.d) for .sh, .sql, .sql.gz files
- Sorted execution order (alphabetical)
- Smart .sh handling (execute if executable, source otherwise)
- One-time initialization marker to prevent re-running
- Configurable paths via environment variables

Inspired by PostgreSQL/Bitnami initialization pattern.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added support for custom initialization scripts in YDB Docker container via /preinitdb.d and /initdb.d directories

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds PostgreSQL-style initialization script support to the YDB Docker container. Users can now place .sh, .sql, and .sql.gz files in designated directories that will be executed automatically on container startup. Pre-init scripts run on every start, while init scripts run only once (protected by a marker file). Script paths are configurable via environment variables.

# Example

<img width="523" height="110" alt="image" src="https://github.com/user-attachments/assets/b51f1635-591d-4231-8962-8212127a4a8a" />
<img width="746" height="149" alt="image" src="https://github.com/user-attachments/assets/1fc4c705-2306-4942-a731-94b81c2c6c88" />
