### PR TITLE
schemeshard: fix stats processing opt 1

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -156,11 +156,14 @@ TPartitionStats TTxStoreTableStats::PrepareStats(const T& rec,
     Y_UNUSED(pools);
 
     for (const auto& channelStats : tableStats.GetChannels()) {
-        const auto& channelBind = bindings[channelStats.GetChannel()];
-        const auto& poolKind = channelBind.GetStoragePoolKind();
-        auto& [dataSize, indexSize] = newStats.StoragePoolsStats[poolKind];
-        dataSize += channelStats.GetDataSize();
-        indexSize += channelStats.GetIndexSize();
+        const ui32 channel = channelStats.GetChannel();
+        if (channel < bindings.size()) {
+            const auto& channelBind = bindings[channel];
+            const auto& poolKind = channelBind.GetStoragePoolKind();
+            auto& [dataSize, indexSize] = newStats.StoragePoolsStats[poolKind];
+            dataSize += channelStats.GetDataSize();
+            indexSize += channelStats.GetIndexSize();
+        }
     }
 
     newStats.ImmediateTxCompleted = tableStats.GetImmediateTxCompleted();


### PR DESCRIPTION
Fix-up to:
- https://github.com/ydb-platform/ydb/pull/27165

Protect shard statistics processing from missing channel binding information on table shards for old clusters or old databases still served by the root schemeshard.
