### PR TITLE
Disable new schema secrets by default and forbid old secrets creation under the new `EnableSchemaSecrets` flag

### DIFF
--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -1842,6 +1842,12 @@ public:
     TFuture<TGenericResult> CreateObject(const TString& cluster, const TCreateObjectSettings& settings) override {
         CHECK_PREPARED_DDL(CreateObject);
 
+        if (AppData()->FeatureFlags.GetEnableSchemaSecrets() && to_lower(settings.GetTypeId()) == "secret") {
+            return MakeErrorFuture<IKikimrGateway::TGenericResult>(
+                std::make_exception_ptr(yexception() << "Old secrets creation syntax is disabled now. Please use the new one")
+            );
+        }
+
         if (IsPrepare()) {
             return MakeFuture(PrepareObjectOperation(cluster, settings, &NMetadata::NModifications::IOperationsManager::PrepareCreateObjectSchemeOperation));
         } else {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -13874,6 +13874,7 @@ END DO)",
         auto db = kikimr.GetTableClient();
         auto session = db.CreateSession().GetValueSync().GetSession();
 
+        // new schema secrets
         { // create
             static const auto query = R"sql(
                 CREATE SECRET `/Root/secret-name-1` WITH (value = "secret-value");
@@ -13893,6 +13894,40 @@ END DO)",
                 DROP SECRET `/Root/secret-name-1`;
             )sql";
             const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // old secrets
+        { // create
+            static const auto query = R"sql(
+                CREATE OBJECT SecretName (TYPE SECRET) WITH value="secret-value";
+            )sql";
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::INTERNAL_ERROR, result.GetIssues().ToString());
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                result.GetIssues().ToString(),
+                "Old secrets creation syntax is disabled now. Please use the new one",
+                result.GetIssues().ToString());
+        }
+        { // alter
+            static const auto query = R"sql(
+                ALTER OBJECT SecretName (TYPE SECRET) SET value="secret-value";
+            )sql";
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                result.GetIssues().ToString(),
+                "preparation problem: secret SecretName not found for alter",
+                result.GetIssues().ToString());
+        }
+        { // drop
+            static const auto query = R"sql(
+                DROP OBJECT SecretName (TYPE SECRET);
+            )sql";
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            // old secrets pretend that removing non existent secret is fine and succeeded
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
         }
     }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -13837,40 +13837,8 @@ END DO)",
         }
     }
 
-    Y_UNIT_TEST(SecretsEnabledByDefault) {
+    Y_UNIT_TEST(SecretsDisabledByDefault) {
         TKikimrRunner kikimr;
-        auto db = kikimr.GetTableClient();
-        auto session = db.CreateSession().GetValueSync().GetSession();
-
-        { // create
-            static const auto query = R"sql(
-                CREATE SECRET `/Root/secret-name-1` WITH (value = "secret-value");
-            )sql";
-            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        }
-        { // alter
-            static const auto query = R"sql(
-                ALTER SECRET `/Root/secret-name-1` WITH (value = "secret-value");
-            )sql";
-            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        }
-        { // drop
-            static const auto query = R"sql(
-                DROP SECRET `/Root/secret-name-1`;
-            )sql";
-            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        }
-    }
-
-        Y_UNIT_TEST(SecretsDisabled) {
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableSchemaSecrets(false);
-        const auto settings = TKikimrSettings()
-            .SetFeatureFlags(featureFlags);
-        TKikimrRunner kikimr(settings);
         auto db = kikimr.GetTableClient();
         auto session = db.CreateSession().GetValueSync().GetSession();
 
@@ -13894,6 +13862,38 @@ END DO)",
             )sql";
             const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::INTERNAL_ERROR, result.GetIssues().ToString());
+        }
+    }
+
+    Y_UNIT_TEST(SecretsEnables) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableSchemaSecrets(true);
+        const auto settings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        { // create
+            static const auto query = R"sql(
+                CREATE SECRET `/Root/secret-name-1` WITH (value = "secret-value");
+            )sql";
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        { // alter
+            static const auto query = R"sql(
+                ALTER SECRET `/Root/secret-name-1` WITH (value = "secret-value");
+            )sql";
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        { // drop
+            static const auto query = R"sql(
+                DROP SECRET `/Root/secret-name-1`;
+            )sql";
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
         }
     }
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -226,7 +226,7 @@ message TFeatureFlags {
     optional bool EnableMirroredTopicSplitMerge = 200 [default = false];
     optional bool EnableFulltextIndex = 201 [default = false];
     optional bool EnableSetColumnConstraint = 202 [default = false];
-    optional bool EnableSchemaSecrets = 203 [default = true];
+    optional bool EnableSchemaSecrets = 203 [default = false];
     optional bool EnableTableCacheModes = 204 [default = false];
     optional bool EnableSkipMessagesWithObsoleteTimestamp = 205 [default = false];
     optional bool EnableStreamingQueries = 206 [default = false];

--- a/ydb/services/metadata/manager/abstract.cpp
+++ b/ydb/services/metadata/manager/abstract.cpp
@@ -93,6 +93,9 @@ IOperationsManager::TYqlConclusionStatus IOperationsManager::PrepareCreateObject
     if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
         return TYqlConclusionStatus::Fail("metadata provider service is disabled");
     }
+    if (AppData()->FeatureFlags.GetEnableSchemaSecrets() && to_lower(settings.GetTypeId()) == "secret") {
+        return TYqlConclusionStatus::Fail("Old secrets creation syntax is disabled now. Please use the new one");
+    }
     TInternalModificationContext internalContext(context);
     internalContext.SetActivityType(EActivityType::Create);
     return DoPrepare(schemeOperation, settings, manager, internalContext);

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.oss.ydb_sdk_import import ydb
+
+logger = logging.getLogger(__name__)
+
+
+class Utils:
+    def __init__(self):
+        self.config = KikimrConfigGenerator(use_in_memory_pdisks=False)
+        self.config.yaml_config["feature_flags"]["enable_external_data_sources"] = True
+
+        self.cluster = KiKiMR(self.config)
+        self.cluster.start()
+
+        driver = ydb.Driver(endpoint=self.cluster.nodes[1].endpoint, database="/Root")
+        self.session_pool = ydb.SessionPool(driver)
+        driver.wait(5, fail_fast=True)
+
+    def restart_cluster(self, enable_schema_secrets):
+        self.config.yaml_config["feature_flags"]["enable_schema_secrets"] = enable_schema_secrets
+        self.cluster.update_configurator_and_restart(self.config)
+
+        driver = ydb.Driver(endpoint=self.cluster.nodes[1].endpoint, database="/Root")
+        driver.wait()
+        self.session_pool = ydb.SessionPool(driver)
+
+    def create_old_secret(self, secret_name, value):
+        with self.session_pool.checkout() as session:
+            session.execute_scheme(
+                f"CREATE OBJECT {secret_name} (TYPE SECRET) WITH value='{value}';"
+            )
+
+    def alter_old_secret(self, secret_name, value):
+        with self.session_pool.checkout() as session:
+            session.execute_scheme(
+                f"ALTER OBJECT {secret_name} (TYPE SECRET) SET value='{value}';"
+            )
+
+    def create_eds(self, eds_name, secret_name):
+        with self.session_pool.checkout() as session:
+            query = f"""
+                CREATE EXTERNAL DATA SOURCE `{eds_name}` WITH (
+                    SOURCE_TYPE="ObjectStorage",
+                    LOCATION="my-bucket",
+                    AUTH_METHOD="SERVICE_ACCOUNT",
+                    SERVICE_ACCOUNT_ID="mysa",
+                    SERVICE_ACCOUNT_SECRET_NAME="{secret_name}"
+                );"""
+            session.execute_scheme(query)
+
+    def create_new_secret(self, secret_name, value):
+        with self.session_pool.checkout() as session:
+            session.execute_scheme(
+                f"CREATE SECRET {secret_name} WITH (value='{value}');"
+            )
+
+
+def test_create_eds_with_old_secret_after_enablig_new_secrets_with_success():
+    utils = Utils()
+    utils.create_old_secret("OldSecret", value="")
+    utils.create_eds("eds-before-restart", "OldSecret")
+
+    utils.restart_cluster(enable_schema_secrets=True)
+    utils.create_new_secret("NewSecret", value="")  # check that `enable_schema_secrets` flag is really ON
+
+    utils.create_eds("eds-after-restart", "OldSecret")  # it's still usable
+    utils.alter_old_secret("OldSecret", "NewValue")  # it's still can be altered

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -121,19 +121,6 @@ def test_create_eds_with_single_secret_with_success(db_fixture, ydb_cluster):
     run_with_assert(user2_config, query)
 
 
-def test_create_eds_with_old_secret_with_success(db_fixture, ydb_cluster):
-    user1_config = create_user(ydb_cluster, db_fixture, "user1")
-
-    provide_grants(db_fixture, "user1", DATABASE, ["ydb.granular.create_table"])
-
-    # create eds with own secret
-    secret_name = 'OldSecret'
-    query = f"CREATE OBJECT {secret_name} (TYPE SECRET) WITH value='';"
-    run_with_assert(user1_config, query)
-    query = get_eds_with_one_secret(secret_name)
-    run_with_assert(user1_config, query)
-
-
 def test_create_eds_with_many_secrets_with_success(db_fixture, ydb_cluster):
     user1_config = create_user(ydb_cluster, db_fixture, "user1")
     user2_config = create_user(ydb_cluster, db_fixture, "user2")

--- a/ydb/tests/functional/secrets/ya.make
+++ b/ydb/tests/functional/secrets/ya.make
@@ -4,6 +4,7 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     conftest.py
+    test_old_secrets_usage.py
     test_secrets.py
     test_secrets_usage.py
 )


### PR DESCRIPTION
### Changelog category
* Not for changelog

### Description for reviewers
Пока дорабатываем секреты с расчётом вмёрджить их в 25-3, удобнее в мейне иметь тот же дефолт, что в стейбле.