### PR TITLE
Make queries like SELECT ... WHERE x NOT IN (SELECT x FROM ...) about 4 times faster

### DIFF
--- a/ydb/core/engine/minikql/flat_local_tx_read_columns.h
+++ b/ydb/core/engine/minikql/flat_local_tx_read_columns.h
@@ -183,7 +183,7 @@ private:
                                    keyTo,
                                    valueColumns,
                                    0,
-                                   RowsLimit, BytesLimit);
+                                   RowsLimit, BytesLimit).Ready;
         return ready;
     }
 

--- a/ydb/core/engine/minikql/minikql_engine_host.cpp
+++ b/ydb/core/engine/minikql/minikql_engine_host.cpp
@@ -207,7 +207,7 @@ void TEngineHost::PinPages(const TVector<THolder<TKeyDesc>>& keys, ui64 pageFaul
                                    adjustLimit(key.RangeLimits.ItemsLimit),
                                    adjustLimit(key.RangeLimits.BytesLimit),
                                    key.Reverse ? NTable::EDirection::Reverse : NTable::EDirection::Forward,
-                                   GetReadVersion(key.TableId));
+                                   GetReadVersion(key.TableId)).Ready;
         ret &= ready;
     }
 

--- a/ydb/core/keyvalue/keyvalue_flat_impl.h
+++ b/ydb/core/keyvalue/keyvalue_flat_impl.h
@@ -101,7 +101,7 @@ protected:
             auto mode = NTable::ELookup::GreaterOrEqualThan;
             auto iter = db.Iterate(TABLE_ID, {}, tags, mode);
 
-            if (!db.Precharge(TABLE_ID, {}, {}, tags, 0, -1, -1))
+            if (!db.Precharge(TABLE_ID, {}, {}, tags, 0, -1, -1).Ready)
                 return false;
 
             while (iter->Next(NTable::ENext::Data) == NTable::EReady::Data) {

--- a/ydb/core/tablet_flat/flat_cxx_database.h
+++ b/ydb/core/tablet_flat/flat_cxx_database.h
@@ -127,7 +127,7 @@ public:
     }
 
     operator i32() const {
-        Y_ENSURE((Type() == NScheme::NTypeIds::Int32 
+        Y_ENSURE((Type() == NScheme::NTypeIds::Int32
                   || Type() == NScheme::NTypeIds::Date32)
                  && Size() == sizeof(i32), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         i32 value = ReadUnaligned<i32>(reinterpret_cast<const i32*>(Data()));
@@ -2154,7 +2154,7 @@ inline bool Schema::Precharger<Schema::AutoPrecharge>::Precharge(
         NTable::TRawVals minKey, NTable::TRawVals maxKey,
         NTable::TTagsRef columns, NTable::EDirection direction, ui64 maxRowCount, ui64 maxBytes)
 {
-    return database.Precharge(table, minKey, maxKey, columns, 0, maxRowCount, maxBytes, direction);
+    return database.Precharge(table, minKey, maxKey, columns, 0, maxRowCount, maxBytes, direction).Ready;
 }
 
 template <>

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -274,17 +274,17 @@ void TDatabase::CalculateReadSize(TSizeEnv& env, ui32 table, TRawVals minKey, TR
     Require(table)->Precharge(minKey, maxKey, tags, &env, flg, items, bytes, direction, snapshot, stats);
 }
 
-bool TDatabase::Precharge(ui32 table, TRawVals minKey, TRawVals maxKey,
+TPrechargeResult TDatabase::Precharge(ui32 table, TRawVals minKey, TRawVals maxKey,
                     TTagsRef tags, ui64 flg, ui64 items, ui64 bytes,
                     EDirection direction, TRowVersion snapshot)
 {
     CheckPrechargeAllowed(table, minKey, maxKey);
 
     TSelectStats stats;
-    auto ready = Require(table)->Precharge(minKey, maxKey, tags, Env, flg, items, bytes, direction, snapshot, stats);
+    auto result = Require(table)->Precharge(minKey, maxKey, tags, Env, flg, items, bytes, direction, snapshot, stats);
     Change->Stats.ChargeSieved += stats.Sieved;
     Change->Stats.ChargeWeeded += stats.Weeded;
-    return ready == EReady::Data;
+    return result;
 }
 
 void TDatabase::Update(ui32 table, ERowOp rop, TRawVals key, TArrayRef<const TUpdateOp> ops, TRowVersion rowVersion)

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -135,7 +135,7 @@ public:
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const;
 
-    bool Precharge(ui32 table, TRawVals minKey, TRawVals maxKey,
+    TPrechargeResult Precharge(ui32 table, TRawVals minKey, TRawVals maxKey,
                         TTagsRef tags, ui64 readFlags, ui64 itemsLimit, ui64 bytesLimit,
                         EDirection direction = EDirection::Forward,
                         TRowVersion snapshot = TRowVersion::Max());
@@ -292,8 +292,8 @@ public:
 
     /**
      * Adds a callback, which is called when database changes are rolled back
-     * 
-     * @param callback 
+     *
+     * @param callback
      */
     template<class TCallback>
     void OnRollback(TCallback&& callback) {

--- a/ydb/core/tablet_flat/flat_part_charge_iface.h
+++ b/ydb/core/tablet_flat/flat_part_charge_iface.h
@@ -10,6 +10,30 @@ namespace NKikimr::NTable {
         struct TResult {
             bool Ready;     /* All required pages are already in memory */
             bool Overshot;  /* Search may start outside of bounds */
+
+            /**
+             * The total number of rows precharged.
+             *
+             * @warning The value in this field will be set to an accurate value
+             *          only if the Ready field is set to true.
+             *
+             * @warning The value in this field is meant to be used as an approximation
+             *          of the total size of all items placed into the cache.
+             *          It may not be very accurate in some cases.
+             */
+            ui64 ItemsPrecharged;
+
+            /**
+             * The total number of bytes precharged.
+             *
+             * @warning The value in this field will be set to an accurate value
+             *          only if the Ready field is set to true.
+             *
+             * @warning The value in this field is meant to be used as an approximation
+             *          of the total size of all items placed into the cache.
+             *          It may not be very accurate in some cases.
+             */
+            ui64 BytesPrecharged;
         };
 
         /**
@@ -17,11 +41,11 @@ namespace NKikimr::NTable {
          *
          * Important caveat: assumes iteration won't touch any row > row2
          */
-        bool Do(TRowId row1, TRowId row2,
+        TResult Do(TRowId row1, TRowId row2,
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const
         {
-            return Do(TCells{}, TCells{}, row1, row2, 
-                keyDefaults, itemsLimit, bytesLimit).Ready;
+            return Do(TCells{}, TCells{}, row1, row2,
+                keyDefaults, itemsLimit, bytesLimit);
         }
 
         /**
@@ -29,23 +53,23 @@ namespace NKikimr::NTable {
          *
          * Important caveat: assumes iteration won't touch any row > row2
          */
-        bool DoReverse(TRowId row1, TRowId row2, 
+        TResult DoReverse(TRowId row1, TRowId row2,
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const
         {
-            return DoReverse(TCells{}, TCells{}, row1, row2, 
-                keyDefaults, itemsLimit, bytesLimit).Ready;
+            return DoReverse(TCells{}, TCells{}, row1, row2,
+                keyDefaults, itemsLimit, bytesLimit);
         }
 
         /**
          * Precharges data for rows between max(key1, row1) and min(key2, row2) inclusive
          */
-        virtual TResult Do(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
+        virtual TResult Do(const TCells key1, const TCells key2, TRowId row1, TRowId row2,
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const = 0;
 
         /**
          * Precharges data for rows between min(key1, row1) and max(key2, row2) inclusive in reverse
          */
-        virtual TResult DoReverse(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
+        virtual TResult DoReverse(const TCells key1, const TCells key2, TRowId row1, TRowId row2,
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const = 0;
 
         virtual ~ICharge() = default;

--- a/ydb/core/tablet_flat/flat_part_charge_range.cpp
+++ b/ydb/core/tablet_flat/flat_part_charge_range.cpp
@@ -3,11 +3,11 @@
 
 namespace NKikimr::NTable {
 
-TChargeResult ChargeRange(IPages *env, const TCells key1, const TCells key2,
+TPrechargeResult ChargeRange(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
             ui64 items, ui64 bytes, bool includeHistory)
 {
-    TChargeResult result = {
+    TPrechargeResult result = {
         .Ready = true,
         .ItemsPrecharged = 0,
         .BytesPrecharged = 0
@@ -73,11 +73,11 @@ TChargeResult ChargeRange(IPages *env, const TCells key1, const TCells key2,
     return result;
 }
 
-TChargeResult ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
+TPrechargeResult ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
             ui64 items, ui64 bytes, bool includeHistory)
 {
-    TChargeResult result = {
+    TPrechargeResult result = {
         .Ready = true,
         .ItemsPrecharged = 0,
         .BytesPrecharged = 0

--- a/ydb/core/tablet_flat/flat_part_charge_range.cpp
+++ b/ydb/core/tablet_flat/flat_part_charge_range.cpp
@@ -3,15 +3,20 @@
 
 namespace NKikimr::NTable {
 
-bool ChargeRange(IPages *env, const TCells key1, const TCells key2,
+TChargeResult ChargeRange(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
             ui64 items, ui64 bytes, bool includeHistory)
 {
-    bool ready = true;
+    TChargeResult result = {
+        .Ready = true,
+        .ItemsPrecharged = 0,
+        .BytesPrecharged = 0
+    };
+
     auto pos = run.LowerBound(key1);
 
     if (pos == run.end())
-        return true;
+        return result;
 
     // key1 <= FirstKey
     bool chargeFromSliceFirstRow = TSlice::CompareSearchKeyFirstKey(key1, pos->Slice, keyDefaults) <= 0;
@@ -33,7 +38,10 @@ bool ChargeRange(IPages *env, const TCells key1, const TCells key2,
         }
 
         auto r = CreateCharge(env, *pos->Part, tags, includeHistory)->Do(key1r, key2r, row1, row2, keyDefaults, items, bytes);
-        ready &= r.Ready;
+
+        result.Ready &= r.Ready;
+        result.ItemsPrecharged += r.ItemsPrecharged;
+        result.BytesPrecharged += r.BytesPrecharged;
 
         if (cmp >= 0) {
             // key2 <= LastKey
@@ -41,7 +49,17 @@ bool ChargeRange(IPages *env, const TCells key1, const TCells key2,
                 // Unfortunately first key > key2 might be at the start of the next slice
                 TRowId firstRow = pos->Slice.BeginRowId();
                 // Precharge the first row main key on the next slice
-                ready &= CreateCharge(env, *pos->Part, { }, false)->Do(firstRow, firstRow, keyDefaults, items, bytes);
+                r = CreateCharge(env, *pos->Part, { }, false)->Do(
+                    firstRow,
+                    firstRow,
+                    keyDefaults,
+                    items,
+                    bytes
+                );
+
+                result.Ready &= r.Ready;
+                result.ItemsPrecharged += r.ItemsPrecharged;
+                result.BytesPrecharged += r.BytesPrecharged;
             }
 
             break;
@@ -52,18 +70,23 @@ bool ChargeRange(IPages *env, const TCells key1, const TCells key2,
         ++pos;
     }
 
-    return ready;
+    return result;
 }
 
-bool ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
+TChargeResult ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
             ui64 items, ui64 bytes, bool includeHistory)
 {
-    bool ready = true;
+    TChargeResult result = {
+        .Ready = true,
+        .ItemsPrecharged = 0,
+        .BytesPrecharged = 0
+    };
+
     auto pos = run.LowerBoundReverse(key1);
 
     if (pos == run.end())
-        return true;
+        return result;
 
     // LastKey <= key1
     bool chargeFromSliceLastRow = TSlice::CompareLastKeySearchKey(pos->Slice, key1, keyDefaults) <= 0;
@@ -86,7 +109,10 @@ bool ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
         }
 
         auto r = CreateCharge(env, *pos->Part, tags, includeHistory)->DoReverse(key1r, key2r, row1, row2, keyDefaults, items, bytes);
-        ready &= r.Ready;
+
+        result.Ready &= r.Ready;
+        result.ItemsPrecharged += r.ItemsPrecharged;
+        result.BytesPrecharged += r.BytesPrecharged;
 
         if (pos == run.begin()) {
             break;
@@ -99,7 +125,17 @@ bool ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
                 // Unfortunately first key <= key2 might be at the end of the previous slice
                 TRowId lastRow = pos->Slice.EndRowId() - 1;
                 // Precharge the last row main key on the previous slice
-                ready &= CreateCharge(env, *pos->Part, { }, false)->DoReverse(lastRow, lastRow, keyDefaults, items, bytes);
+                r = CreateCharge(env, *pos->Part, { }, false)->DoReverse(
+                    lastRow,
+                    lastRow,
+                    keyDefaults,
+                    items,
+                    bytes
+                );
+
+                result.Ready &= r.Ready;
+                result.ItemsPrecharged += r.ItemsPrecharged;
+                result.BytesPrecharged += r.BytesPrecharged;
             }
 
             break;
@@ -110,7 +146,7 @@ bool ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
         --pos;
     }
 
-    return ready;
+    return result;
 }
 
 }

--- a/ydb/core/tablet_flat/flat_part_charge_range.h
+++ b/ydb/core/tablet_flat/flat_part_charge_range.h
@@ -9,42 +9,11 @@ namespace {
     using TCells = NPage::TCells;
 }
 
-struct TChargeResult {
-    /**
-     * If set to true, all the necessary pages are already in memory.
-     */
-    bool Ready;
-
-    /**
-     * The total number of rows precharged.
-     *
-     * @warning The value in this field will be set to an accurate value
-     *          only if the Ready field is set to true.
-     *
-     * @warning The value in this field is meant to be used as an approximation
-     *          of the total size of all items placed into the cache.
-     *          It may not be very accurate in some cases.
-     */
-    ui64 ItemsPrecharged;
-
-    /**
-     * The total number of bytes precharged.
-     *
-     * @warning The value in this field will be set to an accurate value
-     *          only if the Ready field is set to true.
-     *
-     * @warning The value in this field is meant to be used as an approximation
-     *          of the total size of all items placed into the cache.
-     *          It may not be very accurate in some cases.
-     */
-    ui64 BytesPrecharged;
-};
-
-TChargeResult ChargeRange(IPages *env, const TCells key1, const TCells key2,
+TPrechargeResult ChargeRange(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
             ui64 items, ui64 bytes, bool includeHistory);
 
-TChargeResult ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
+TPrechargeResult ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
             ui64 items, ui64 bytes, bool includeHistory);
 

--- a/ydb/core/tablet_flat/flat_part_charge_range.h
+++ b/ydb/core/tablet_flat/flat_part_charge_range.h
@@ -9,11 +9,42 @@ namespace {
     using TCells = NPage::TCells;
 }
 
-bool ChargeRange(IPages *env, const TCells key1, const TCells key2,
+struct TChargeResult {
+    /**
+     * If set to true, all the necessary pages are already in memory.
+     */
+    bool Ready;
+
+    /**
+     * The total number of rows precharged.
+     *
+     * @warning The value in this field will be set to an accurate value
+     *          only if the Ready field is set to true.
+     *
+     * @warning The value in this field is meant to be used as an approximation
+     *          of the total size of all items placed into the cache.
+     *          It may not be very accurate in some cases.
+     */
+    ui64 ItemsPrecharged;
+
+    /**
+     * The total number of bytes precharged.
+     *
+     * @warning The value in this field will be set to an accurate value
+     *          only if the Ready field is set to true.
+     *
+     * @warning The value in this field is meant to be used as an approximation
+     *          of the total size of all items placed into the cache.
+     *          It may not be very accurate in some cases.
+     */
+    ui64 BytesPrecharged;
+};
+
+TChargeResult ChargeRange(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
             ui64 items, ui64 bytes, bool includeHistory);
 
-bool ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
+TChargeResult ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
             ui64 items, ui64 bytes, bool includeHistory);
 

--- a/ydb/core/tablet_flat/flat_row_eggs.h
+++ b/ydb/core/tablet_flat/flat_row_eggs.h
@@ -98,6 +98,40 @@ namespace NTable {
         }
     };
 
+    /**
+     * The container for the results of the precharge operation.
+     */
+    struct TPrechargeResult {
+        /**
+         * If true, all the necessary pages are already in the cache.
+         */
+        bool Ready;
+
+        /**
+         * The total number of rows precharged.
+         *
+         * @warning The value in this field will be set to an accurate value
+         *          only if the Ready field is set to true.
+         *
+         * @warning The value in this field is meant to be used as an approximation
+         *          of the total size of all items placed into the cache.
+         *          It may not be very accurate in some cases.
+         */
+        ui64 ItemsPrecharged;
+
+        /**
+         * The total number of bytes precharged.
+         *
+         * @warning The value in this field will be set to an accurate value
+         *          only if the Ready field is set to true.
+         *
+         * @warning The value in this field is meant to be used as an approximation
+         *          of the total size of all items placed into the cache.
+         *          It may not be very accurate in some cases.
+         */
+        ui64 BytesPrecharged;
+    };
+
 #pragma pack(push, 1)
 
     struct TCellOp {

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -946,7 +946,7 @@ TPrechargeResult TTable::Precharge(TRawVals minKey_, TRawVals maxKey_, TTagsRef 
         const TCelled maxKey(maxKey_, *Scheme->Keys, false);
 
         for (const auto& run : GetLevels()) {
-            TChargeResult chargeResult;
+            TPrechargeResult chargeResult;
 
             switch (direction) {
                 case EDirection::Forward:

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -893,14 +893,18 @@ void TTable::AddSafe(TPartView partView)
     }
 }
 
-EReady TTable::Precharge(TRawVals minKey_, TRawVals maxKey_, TTagsRef tags,
+TPrechargeResult TTable::Precharge(TRawVals minKey_, TRawVals maxKey_, TTagsRef tags,
                          IPages* env, ui64 flg,
                          ui64 items, ui64 bytes,
                          EDirection direction,
                          TRowVersion snapshot,
                          TSelectStats& stats) const
 {
-    bool ready = true;
+    TPrechargeResult result = {
+        .Ready = true,
+        .ItemsPrecharged = 0,
+        .BytesPrecharged = 0,
+    };
     bool includeHistory = !snapshot.IsMax();
 
     if (items == Max<ui64>()) {
@@ -924,9 +928,13 @@ EReady TTable::Precharge(TRawVals minKey_, TRawVals maxKey_, TTagsRef tags,
                 {
                     TRowId row1 = pos->Slice.BeginRowId();
                     TRowId row2 = pos->Slice.EndRowId() - 1;
-                    ready &= CreateCharge(env, *pos->Part, tags, includeHistory)
-                        ->Do(key, key, row1, row2, *Scheme->Keys, items, bytes)
-                        .Ready;
+                    auto const chargeResult = CreateCharge(env, *pos->Part, tags, includeHistory)
+                        ->Do(key, key, row1, row2, *Scheme->Keys, items, bytes);
+
+                    result.Ready &= chargeResult.Ready;
+                    result.ItemsPrecharged += chargeResult.ItemsPrecharged;
+                    result.BytesPrecharged += chargeResult.BytesPrecharged;
+
                     ++stats.Sieved;
                 } else {
                     ++stats.Weeded;
@@ -938,18 +946,24 @@ EReady TTable::Precharge(TRawVals minKey_, TRawVals maxKey_, TTagsRef tags,
         const TCelled maxKey(maxKey_, *Scheme->Keys, false);
 
         for (const auto& run : GetLevels()) {
+            TChargeResult chargeResult;
+
             switch (direction) {
                 case EDirection::Forward:
-                    ready &= ChargeRange(env, minKey, maxKey, run, *Scheme->Keys, tags, items, bytes, includeHistory);
+                    chargeResult = ChargeRange(env, minKey, maxKey, run, *Scheme->Keys, tags, items, bytes, includeHistory);
                     break;
                 case EDirection::Reverse:
-                    ready &= ChargeRangeReverse(env, maxKey, minKey, run, *Scheme->Keys, tags, items, bytes, includeHistory);
+                    chargeResult = ChargeRangeReverse(env, maxKey, minKey, run, *Scheme->Keys, tags, items, bytes, includeHistory);
                     break;
             }
+
+            result.Ready &= chargeResult.Ready;
+            result.ItemsPrecharged += chargeResult.ItemsPrecharged;
+            result.BytesPrecharged += chargeResult.BytesPrecharged;
         }
     }
 
-    return ready ? EReady::Data : EReady::Page;
+    return result;
 }
 
 void TTable::Update(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMemGlob> apart, TRowVersion rowVersion)

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -164,7 +164,7 @@ public:
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const;
 
-    EReady Precharge(TRawVals minKey, TRawVals maxKey, TTagsRef tags,
+    TPrechargeResult Precharge(TRawVals minKey, TRawVals maxKey, TTagsRef tags,
                      IPages* env, ui64 flg,
                      ui64 itemsLimit, ui64 bytesLimit,
                      EDirection direction, TRowVersion snapshot, TSelectStats& stats) const;

--- a/ydb/core/tablet_flat/ut/flat_test_db.h
+++ b/ydb/core/tablet_flat/ut/flat_test_db.h
@@ -130,7 +130,7 @@ public:
     void Precharge(ui32 root,
                            TRawVals keyFrom, TRawVals keyTo,
                            TTagsRef tags, ui32 flags) override {
-        bool res = Db->Precharge(root, keyFrom, keyTo, tags, flags, -1, -1);
+        bool res = Db->Precharge(root, keyFrom, keyTo, tags, flags, -1, -1).Ready;
         if (!res)
             throw TIteratorNotReady();
     }

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -1078,11 +1078,13 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIteration) {
                             // The B-Tree implementation ignores the limits and keys when the tree has no levels,
                             // except for the case when the history or the groups are turned on
                             if ((part.IndexPages.GetBTree({}).LevelCount == 0) && (!params.Groups) && (!params.History)) {
-                                UNIT_ASSERT_VALUES_EQUAL_C(
-                                    treeChargeResult.ItemsPrecharged,
-                                    part.IndexPages.GetBTree({}).GetRowCount(),
-                                    message
-                                );
+                                if (treeChargeResult.ItemsPrecharged != 0) {
+                                    UNIT_ASSERT_VALUES_EQUAL_C(
+                                        treeChargeResult.ItemsPrecharged,
+                                        part.IndexPages.GetBTree({}).GetRowCount(),
+                                        message
+                                    );
+                                }
                             // In some cases the flat implementation does not adjust
                             // the precharged counts based on the precise keys
                             } else if ((!params.Groups) && (!params.History)) {

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -857,9 +857,9 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIteration) {
         }, env, message, failsAllowed);
     }
 
-    TChargeResult Charge(const TRun &run, const TVector<TTag> tags, TTouchEnv& env, const TCells key1, const TCells key2, ui64 itemsLimit, ui64 bytesLimit,
+    TPrechargeResult Charge(const TRun &run, const TVector<TTag> tags, TTouchEnv& env, const TCells key1, const TCells key2, ui64 itemsLimit, ui64 bytesLimit,
             bool reverse, const TKeyCellDefaults &keyDefaults, const TString& message, ui32 failsAllowed) {
-        TChargeResult result;
+        TPrechargeResult result;
 
         Retry([&]() {
             result = reverse

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -556,7 +556,8 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
                             UNIT_ASSERT_LE_C(treeChargeResult.ItemsPrecharged, flatChargeResult.ItemsPrecharged + 4, messageWithValues);
                         }
 
-                        UNIT_ASSERT_VALUES_EQUAL_C(treeChargeResult.BytesPrecharged, treeChargeResult.BytesPrecharged, message);
+                        // The flat implementation always returns 0 bytes charged, if the bytes limit is not set
+                        UNIT_ASSERT_VALUES_UNEQUAL_C(treeChargeResult.BytesPrecharged, 0, message);
 
                         AssertLoadedTheSame(part, bTreeEnv, flatEnv, message,
                             false, reverse && itemsLimit, !reverse && itemsLimit);
@@ -629,7 +630,8 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
                                     UNIT_ASSERT_LE_C(treeChargeResult.ItemsPrecharged, flatChargeResult.ItemsPrecharged + 4, messageWithValues);
                                 }
 
-                                UNIT_ASSERT_VALUES_EQUAL_C(treeChargeResult.BytesPrecharged, treeChargeResult.BytesPrecharged, message);
+                                // The flat implementation always returns 0 bytes charged, if the bytes limit is not set
+                                UNIT_ASSERT_VALUES_UNEQUAL_C(treeChargeResult.BytesPrecharged, 0, message);
 
                                 AssertLoadedTheSame(part, bTreeEnv, flatEnv, message,
                                     true, reverse && itemsLimit, !reverse && itemsLimit);

--- a/ydb/core/tablet_flat/ut/ut_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_charge.cpp
@@ -48,7 +48,7 @@ namespace {
     }
 
     struct TTouchEnv : public NTest::TTestEnv {
-        TTouchEnv(bool fail, TSet<std::pair<TGroupId, TPageId>> sticky) 
+        TTouchEnv(bool fail, TSet<std::pair<TGroupId, TPageId>> sticky)
             : Fail(fail)
             , Sticky(std::move(sticky))
             { }
@@ -56,7 +56,7 @@ namespace {
         const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
         {
             Touched[groupId].insert(pageId);
-            
+
             if (!Fail || Sticky.contains({groupId, pageId})) {
                 return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             }
@@ -143,47 +143,107 @@ namespace {
             return cook.Finish();
         }
 
-        void CheckByKeys(ui32 lower, ui32 upper, ui64 items, TArr shouldPrecharge) const
-        {
-            CheckByKeys(lower, upper, items, {{TGroupId{}, shouldPrecharge}});
+        void CheckByKeys(
+            ui32 lower,
+            ui32 upper,
+            ui64 items,
+            ui64 expectedPrechargedItemsNoFail,
+            ui64 expectedPrechargedItemsWithFail,
+            TArr shouldPrecharge
+        ) const {
+            CheckByKeys(
+                lower,
+                upper,
+                items,
+                expectedPrechargedItemsNoFail,
+                expectedPrechargedItemsWithFail,
+                {{TGroupId{}, shouldPrecharge}}
+            );
         }
 
-        void CheckByKeys(ui32 lower, ui32 upper, ui64 items, const TMap<TGroupId, TArr>& shouldPrecharge) const
-        {
-            CheckPrechargeByKeys(lower, upper, items, TPageIdFlags::IfNoFail, shouldPrecharge, false, GetIndexPages());
-            CheckPrechargeByKeys(lower, upper, items, TPageIdFlags::IfFail, shouldPrecharge, false, GetIndexPages());
+        void CheckByKeys(
+            ui32 lower,
+            ui32 upper,
+            ui64 items,
+            ui64 expectedPrechargedItemsNoFail,
+            ui64 expectedPrechargedItemsWithFail,
+            const TMap<TGroupId, TArr>& shouldPrecharge
+        ) const {
+            CheckPrechargeByKeys(lower, upper, items, expectedPrechargedItemsNoFail, TPageIdFlags::IfNoFail, shouldPrecharge, false, GetIndexPages());
+            CheckPrechargeByKeys(lower, upper, items, expectedPrechargedItemsWithFail, TPageIdFlags::IfFail, shouldPrecharge, false, GetIndexPages());
             CheckIterByKeys(lower, upper, items ? items : Max<ui32>(), shouldPrecharge);
         }
 
-        void CheckByKeysReverse(ui32 lower, ui32 upper, ui64 items, const TMap<TGroupId, TArr>& shouldPrecharge) const
-        {
-            CheckPrechargeByKeys(lower, upper, items, TPageIdFlags::IfNoFail, shouldPrecharge, true, GetIndexPages());
-            CheckPrechargeByKeys(lower, upper, items, TPageIdFlags::IfFail, shouldPrecharge, true, GetIndexPages());
+        void CheckByKeysReverse(
+            ui32 lower,
+            ui32 upper,
+            ui64 items,
+            ui64 expectedPrechargedItemsNoFail,
+            ui64 expectedPrechargedItemsWithFail,
+            const TMap<TGroupId, TArr>& shouldPrecharge
+        ) const {
+            CheckPrechargeByKeys(lower, upper, items, expectedPrechargedItemsNoFail, TPageIdFlags::IfNoFail, shouldPrecharge, true, GetIndexPages());
+            CheckPrechargeByKeys(lower, upper, items, expectedPrechargedItemsWithFail, TPageIdFlags::IfFail, shouldPrecharge, true, GetIndexPages());
             CheckIterByKeysReverse(lower, upper, items ? items : Max<ui32>(), shouldPrecharge);
         }
 
-        void CheckByRows(TPageId row1, TPageId row2, ui64 items, const TMap<TGroupId, TArr>& shouldPrecharge) const
-        {
-            CheckPrechargeByRows(row1, row2, items, false, shouldPrecharge, false);
-            CheckPrechargeByRows(row1, row2, items, true, shouldPrecharge, false);
+        void CheckByRows(
+            TPageId row1,
+            TPageId row2,
+            ui64 items,
+            ui64 expectedPrechargedItems,
+            const TMap<TGroupId, TArr> &shouldPrecharge
+        ) const {
+            CheckPrechargeByRows(row1, row2, items, expectedPrechargedItems, false, shouldPrecharge, false);
+            CheckPrechargeByRows(row1, row2, items, expectedPrechargedItems, true, shouldPrecharge, false);
         }
 
-        void CheckByRowsReverse(TPageId row1, TPageId row2, ui64 items, const TMap<TGroupId, TArr>& shouldPrecharge) const
-        {
-            CheckPrechargeByRows(row1, row2, items, false, shouldPrecharge, true);
-            CheckPrechargeByRows(row1, row2, items, true, shouldPrecharge, true);
+        void CheckByRowsReverse(
+            TPageId row1,
+            TPageId row2,
+            ui64 items,
+            ui64 expectedPrechargedItems,
+            const TMap<TGroupId, TArr>& shouldPrecharge
+        ) const {
+            CheckPrechargeByRows(row1, row2, items, expectedPrechargedItems, false, shouldPrecharge, true);
+            CheckPrechargeByRows(row1, row2, items, expectedPrechargedItems, true, shouldPrecharge, true);
         }
 
-        void CheckIndex(ui32 lower, ui32 upper, ui64 items, const TMap<TGroupId, TArr>& shouldPrecharge, TSet<TPageId> stickyIndex) const {
+        void CheckIndex(
+            ui32 lower,
+            ui32 upper,
+            ui64 items,
+            ui64 expectedPrechargedItems,
+            const TMap<TGroupId, TArr>& shouldPrecharge,
+            TSet<TPageId> stickyIndex
+        ) const {
             TSet<std::pair<TGroupId, TPageId>> sticky;
             for (auto x : stickyIndex) {
                 sticky.insert({TGroupId{}, x});
             }
 
-            CheckPrechargeByKeys(lower, upper, items, static_cast<TPageIdFlags>(TPageIdFlags::IfFail | TPageIdFlags::IfSticky), shouldPrecharge, false, sticky);
+            CheckPrechargeByKeys(
+                lower,
+                upper,
+                items,
+                expectedPrechargedItems,
+                static_cast<TPageIdFlags>(TPageIdFlags::IfFail | TPageIdFlags::IfSticky),
+                shouldPrecharge,
+                false,
+                sticky
+            );
         }
 
-        void CheckPrechargeByKeys(ui32 lower, ui32 upper, ui64 items, TPageIdFlags flags, const TMap<TGroupId, TArr>& shouldPrecharge, bool reverse, TSet<std::pair<TGroupId, TPageId>> sticky) const
+        void CheckPrechargeByKeys(
+            ui32 lower,
+            ui32 upper,
+            ui64 items,
+            ui64 expectedPrechargedItems,
+            TPageIdFlags flags,
+            const TMap<TGroupId, TArr>& shouldPrecharge,
+            bool reverse,
+            TSet<std::pair<TGroupId, TPageId>> sticky
+        ) const
         {
             Y_ENSURE(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
 
@@ -205,22 +265,49 @@ namespace {
                 tags.push_back(c.Tag);
             }
 
-            bool ready = !reverse
+            const auto result = !reverse
                 ? ChargeRange(&env, from, to, run, keyDefaults, tags, items, Max<ui64>(), true)
                 : ChargeRangeReverse(&env, from, to, run, keyDefaults, tags, items, Max<ui64>(), true);
 
-            UNIT_ASSERT_VALUES_EQUAL_C(!fail || env.ToLoad.empty(), ready, AssertMessage(fail));
+            UNIT_ASSERT_VALUES_EQUAL_C(!fail || env.ToLoad.empty(), result.Ready, AssertMessage(fail));
+            UNIT_ASSERT_VALUES_EQUAL_C(expectedPrechargedItems, result.ItemsPrecharged, AssertMessage(fail));
+
+            // Count how many pages should be precharged
+            const ui64 prechargedPageCount = std::accumulate(
+                shouldPrecharge.begin(),
+                shouldPrecharge.end(),
+                0,
+                [](const ui64 value, const auto& item) -> ui64 {
+                    return value + item.second.size();
+                }
+            );
+
+            if ((expectedPrechargedItems == 0)
+                && ((flags & TPageIdFlags::IfSticky) || (prechargedPageCount == 0))) {
+                UNIT_ASSERT_VALUES_EQUAL_C(0, result.BytesPrecharged, AssertMessage(fail));
+            } else {
+                // NOTE: It is too hard to calculate the exact number of bytes
+                //       that will be charged here, so only check that it is not zero
+                UNIT_ASSERT_VALUES_UNEQUAL_C(0, result.BytesPrecharged, AssertMessage(fail));
+            }
 
             CheckPrecharged(env.Touched, shouldPrecharge, sticky, flags);
         }
 
-        void CheckPrechargeByRows(TPageId row1, TPageId row2, ui64 items, bool fail, TMap<TGroupId, TArr> shouldPrecharge, bool reverse) const
-        {
+        void CheckPrechargeByRows(
+            TPageId row1,
+            TPageId row2,
+            ui64 items,
+            ui64 expectedPrechargedItems,
+            bool fail,
+            TMap<TGroupId, TArr> shouldPrecharge,
+            bool reverse
+        ) const {
             auto sticky = GetIndexPages();
             TTouchEnv env(fail, sticky);
 
             const auto &keyDefaults = *Tool.Scheme.Keys;
-            
+
             TRun run(keyDefaults);
             auto part = Eggs.Lone();
             for (auto& slice : *part->Slices) {
@@ -233,11 +320,17 @@ namespace {
             }
 
             auto charge = CreateCharge(&env, *run.begin()->Part, tags, false);
-            bool result = reverse
+            const auto result = reverse
                 ? charge->DoReverse(row1, row2, keyDefaults, items, Max<ui64>())
                 : charge->Do(row1, row2, keyDefaults, items, Max<ui64>());
 
-            UNIT_ASSERT_VALUES_EQUAL_C(!fail, result, AssertMessage(fail));
+            UNIT_ASSERT_VALUES_EQUAL_C(!fail, result.Ready, AssertMessage(fail));
+            UNIT_ASSERT_VALUES_EQUAL_C(true, result.Overshot, AssertMessage(fail));
+            UNIT_ASSERT_VALUES_EQUAL_C(expectedPrechargedItems, result.ItemsPrecharged, AssertMessage(fail));
+
+            // NOTE: It is too hard to calculate the exact number of bytes
+            //       that will be charged here, so only check that it is not zero
+            UNIT_ASSERT_VALUES_UNEQUAL_C(0, result.BytesPrecharged, AssertMessage(fail));
 
             CheckPrecharged(env.Touched, shouldPrecharge, sticky, fail ? TPageIdFlags::IfFail : TPageIdFlags::IfNoFail);
         }
@@ -324,7 +417,7 @@ namespace {
 
             auto &pages = Eggs.Lone()->IndexPages;
             TGroupId mainGroupId{};
-            
+
             for (auto x : pages.FlatGroups) {
                 result.insert({mainGroupId, x});
             }
@@ -379,18 +472,18 @@ namespace {
         }
 
         std::string AssertMessage(bool fail) const {
-            return 
-                "Seq: " + CurrentStepStr() + 
+            return
+                "Seq: " + CurrentStepStr() +
                 " Fail: " + (fail ? "Yes" : "No");
         }
         std::string AssertMessage(TGroupId group) const {
-            return 
-                "Seq: " + CurrentStepStr() + 
+            return
+                "Seq: " + CurrentStepStr() +
                 " Group: " + std::to_string(group.Index) + "," + std::to_string(group.IsHistoric());
         }
         std::string AssertMessage(TGroupId group, TPageIdFlags flags) const {
-            auto result = 
-                "Seq: " + CurrentStepStr() + 
+            auto result =
+                "Seq: " + CurrentStepStr() +
                 " Group: " + std::to_string(group.Index) + "," + std::to_string(group.IsHistoric());
 
             if (flags & TPageIdFlags::IfFail) {
@@ -447,16 +540,16 @@ Y_UNIT_TEST_SUITE(Charge) {
 
         { /*_ 1xx: A set of some edge and basic cases */
 
-            me.To(100).CheckByKeys(33, 34, 0, { 8 });     // keys on the last page
-            me.To(101).CheckByKeys(0, 0, 0, { 0, 1_I });    // keys before the part
-            me.To(102).CheckByKeys(3, 4, 0, { 0, 1 });
-            me.To(103).CheckByKeys(3, 5, 0, { 0, 1, 2_I });
-            me.To(104).CheckByKeys(4, 8, 0, { 0, 1, 2 });
-            me.To(105).CheckByKeys(4, 12, 0, { 0, 1, 2, 3 });
-            me.To(106).CheckByKeys(8, 12, 0, { 1, 2, 3 });
-            me.To(107).CheckByKeys(8, 13, 0, { 1, 2, 3, 4_I });
-            me.To(108).CheckByKeys(8, 14, 0, { 1, 2, 3, 4_I });
-            me.To(110).CheckByKeys(0, 35, 0, { 0, 1, 2, 3, 4, 5, 6, 7, 8 });
+            me.To(100).CheckByKeys(33, 34, 0, 0, 0, { 8 });     // keys on the last page
+            me.To(101).CheckByKeys(0, 0, 0, 4, 4, { 0, 1_I });    // keys before the part
+            me.To(102).CheckByKeys(3, 4, 0, 1, 1, { 0, 1 });
+            me.To(103).CheckByKeys(3, 5, 0, 4, 4, { 0, 1, 2_I });
+            me.To(104).CheckByKeys(4, 8, 0, 4, 4, { 0, 1, 2 });
+            me.To(105).CheckByKeys(4, 12, 0, 7, 7, { 0, 1, 2, 3 });
+            me.To(106).CheckByKeys(8, 12, 0, 4, 4, { 1, 2, 3 });
+            me.To(107).CheckByKeys(8, 13, 0, 7, 7, { 1, 2, 3, 4_I });
+            me.To(108).CheckByKeys(8, 14, 0, 7, 7, { 1, 2, 3, 4_I });
+            me.To(110).CheckByKeys(0, 35, 0, 27, 27, { 0, 1, 2, 3, 4, 5, 6, 7, 8 });
         }
 
         /*_ 2xx: Simple loads rows within the same page */
@@ -467,11 +560,11 @@ Y_UNIT_TEST_SUITE(Charge) {
 
             const ui32 base = 200 + it * 10, lead = it * 4;
 
-            me.To(base + 1).CheckByKeys(lead + 1, lead + 1, 0, span1);
-            me.To(base + 2).CheckByKeys(lead + 1, lead + 2, 0, span1);
-            me.To(base + 3).CheckByKeys(lead + 1, lead + 3, 0, span2);
-            me.To(base + 4).CheckByKeys(lead + 2, lead + 3, 0, span2);
-            me.To(base + 5).CheckByKeys(lead + 3, lead + 3, 0, span2);
+            me.To(base + 1).CheckByKeys(lead + 1, lead + 1, 0, (lead == 0) ? 4 : 1, (lead == 0) ? 4 : 1, span1);
+            me.To(base + 2).CheckByKeys(lead + 1, lead + 2, 0, (lead == 0) ? 4 : 1, (lead == 0) ? 4 : 1, span1);
+            me.To(base + 3).CheckByKeys(lead + 1, lead + 3, 0, (lead == 0) ? 4 : 1, (lead == 0) ? 4 : 1, span2);
+            me.To(base + 4).CheckByKeys(lead + 2, lead + 3, 0, 1, 1, span2);
+            me.To(base + 5).CheckByKeys(lead + 3, lead + 3, 0, 1, 1, span2);
         }
 
         /*_ 3xx: Simple loads spans more than one page */
@@ -482,27 +575,27 @@ Y_UNIT_TEST_SUITE(Charge) {
 
             const ui32 base = 300 + it * 10, lead = it * 4;
 
-            me.To(base + 1).CheckByKeys(lead + 1, lead + 9, 0, span1);
-            me.To(base + 2).CheckByKeys(lead + 1, lead + 10, 0, span1);
-            me.To(base + 3).CheckByKeys(lead + 1, lead + 11, 0, span2);
+            me.To(base + 1).CheckByKeys(lead + 1, lead + 9, 0, (lead == 0) ? 10 : 7, (lead == 0) ? 10 : 7, span1);
+            me.To(base + 2).CheckByKeys(lead + 1, lead + 10, 0, (lead == 0) ? 10 : 7, (lead == 0) ? 10 : 7, span1);
+            me.To(base + 3).CheckByKeys(lead + 1, lead + 11, 0, (lead == 0) ? 10 : 7, (lead == 0) ? 10 : 7, span2);
         }
 
         { /*_ 4xx: key2 > key1 */
-            me.To(400).CheckByKeys(9, 8, 0, { 2, 3_I });
-            me.To(401).CheckByKeys(9, 7, 0, { 2, 3_I });
-            me.To(402).CheckByKeys(9, 0, 0, { 2, 3_I });
-            me.To(403).CheckByKeys(8, 7, 0, { 1, 2 });
-            me.To(404).CheckByKeys(8, 6, 0, { 1, 2 });
-            me.To(405).CheckByKeys(8, 0, 0, { 1, 2 });
-            me.To(406).CheckByKeys(7, 6, 0, { 1, 2_I });
-            me.To(407).CheckByKeys(7, 5, 0, { 1, 2_I });
-            me.To(408).CheckByKeys(7, 0, 0, { 1, 2_I });
-            me.To(409).CheckByKeys(6, 5, 0, { 1, 2_I });
-            me.To(410).CheckByKeys(6, 4, 0, { 1, 2_I });
-            me.To(411).CheckByKeys(6, 0, 0, { 1, 2_I });
-            me.To(412).CheckByKeys(5, 4, 0, { 1, 2_I });
-            me.To(413).CheckByKeys(5, 3, 0, { 1, 2_I });
-            me.To(414).CheckByKeys(5, 0, 0, { 1, 2_I });
+            me.To(400).CheckByKeys(9, 8, 0, 1, 1, { 2, 3_I });
+            me.To(401).CheckByKeys(9, 7, 0, 1, 1, { 2, 3_I });
+            me.To(402).CheckByKeys(9, 0, 0, 1, 1, { 2, 3_I });
+            me.To(403).CheckByKeys(8, 7, 0, 1, 1, { 1, 2 });
+            me.To(404).CheckByKeys(8, 6, 0, 1, 1, { 1, 2 });
+            me.To(405).CheckByKeys(8, 0, 0, 1, 1, { 1, 2 });
+            me.To(406).CheckByKeys(7, 6, 0, 1, 1, { 1, 2_I });
+            me.To(407).CheckByKeys(7, 5, 0, 1, 1, { 1, 2_I });
+            me.To(408).CheckByKeys(7, 0, 0, 1, 1, { 1, 2_I });
+            me.To(409).CheckByKeys(6, 5, 0, 1, 1, { 1, 2_I });
+            me.To(410).CheckByKeys(6, 4, 0, 1, 1, { 1, 2_I });
+            me.To(411).CheckByKeys(6, 0, 0, 1, 1, { 1, 2_I });
+            me.To(412).CheckByKeys(5, 4, 0, 1, 1, { 1, 2_I });
+            me.To(413).CheckByKeys(5, 3, 0, 1, 1, { 1, 2_I });
+            me.To(414).CheckByKeys(5, 0, 0, 1, 1, { 1, 2_I });
         }
     }
 
@@ -511,54 +604,54 @@ Y_UNIT_TEST_SUITE(Charge) {
         TModel me(true);
 
         /*
-        
+
         keys by pages:
         group0 = |1 2 3|5 6 7|9 10 11|13 14 15|..
         group1 = |1 2|3 5|6 7|9 10|11 13|14 15|..
         group3 = |1|2|3|5|6|7|9|10|11|13|14|15|..
-        
+
         */
 
         /*_ 1xx: Play with first page */ {
-            me.To(100).CheckByKeys(0, 0, 0, TMap<TGroupId, TArr>{
+            me.To(100).CheckByKeys(0, 0, 0, 4, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {0, 1_I}},
                 {TGroupId{1}, {}},
                 {TGroupId{2}, {}}
             });
 
             // key 0 transforms into row id 0 because it's before the slice first key 1
-            me.To(101).CheckByKeys(0, 9, 0, TMap<TGroupId, TArr>{
+            me.To(101).CheckByKeys(0, 9, 0, 10, 10, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {0, 1, 2, 3_I}},
                 {TGroupId{1}, {0, 1, 2, 3_g}},
                 {TGroupId{2}, {0, 1, 2, 3, 4, 5, 6_g}}
             });
 
             // key 1 also transforms into row id 0 because it's before the slice first key 1
-            me.To(102).CheckByKeys(1, 9, 0, TMap<TGroupId, TArr>{
+            me.To(102).CheckByKeys(1, 9, 0, 10, 10, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {0, 1, 2, 3_I}},
                 {TGroupId{1}, {0, 1, 2, 3_g}},
                 {TGroupId{2}, {0, 1, 2, 3, 4, 5, 6_g}}
             });
 
-            me.To(103).CheckByKeys(2, 9, 0, TMap<TGroupId, TArr>{
+            me.To(103).CheckByKeys(2, 9, 0, 9, 7, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {0, 1, 2, 3_I}},
                 {TGroupId{1}, {0_g, 1, 2, 3_g}},
                 {TGroupId{2}, {1_g, 2_g, 3, 4, 5, 6_g}}
             });
 
-            me.To(104).CheckByKeys(3, 9, 0, TMap<TGroupId, TArr>{
+            me.To(104).CheckByKeys(3, 9, 0, 8, 7, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {0, 1, 2, 3_I}},
                 {TGroupId{1}, {1, 2, 3_g}},
                 {TGroupId{2}, {2_g, 3, 4, 5, 6_g}}
             });
 
-            me.To(105).CheckByKeys(4, 9, 0, TMap<TGroupId, TArr>{
+            me.To(105).CheckByKeys(4, 9, 0, 7, 7, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {0, 1, 2, 3_I}},
                 {TGroupId{1}, {1, 2, 3_g}},
                 {TGroupId{2}, {3, 4, 5, 6_g}}
             });
 
-            me.To(106).CheckByKeys(5, 9, 0, TMap<TGroupId, TArr>{
+            me.To(106).CheckByKeys(5, 9, 0, 7, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3_I}},
                 {TGroupId{1}, {1_g, 2_g, 3_g}},
                 {TGroupId{2}, {3_g, 4_g, 5_g, 6_g}}
@@ -566,127 +659,127 @@ Y_UNIT_TEST_SUITE(Charge) {
         }
 
         /*_ 2xx: Play with intermidiate pages */ {
-            me.To(200).CheckByKeys(4, 4, 0, TMap<TGroupId, TArr>{
+            me.To(200).CheckByKeys(4, 4, 0, 1, 1, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {0, 1}},
                 {TGroupId{1}, {}},
                 {TGroupId{2}, {}}
             });
-            
-            me.To(201).CheckByKeys(5, 5, 0, TMap<TGroupId, TArr>{
+
+            me.To(201).CheckByKeys(5, 5, 0, 4, 1, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2_I}},
                 {TGroupId{1}, {1_g}},
                 {TGroupId{2}, {3_g}}
             });
 
-            me.To(202).CheckByKeys(5, 6, 0, TMap<TGroupId, TArr>{
+            me.To(202).CheckByKeys(5, 6, 0, 4, 1, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2_I}},
                 {TGroupId{1}, {1_g, 2_g}},
                 {TGroupId{2}, {3_g, 4_g}}
             });
 
-            me.To(203).CheckByKeys(5, 7, 0, TMap<TGroupId, TArr>{
+            me.To(203).CheckByKeys(5, 7, 0, 4, 1, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2}},
                 {TGroupId{1}, {1_g, 2_g}},
                 {TGroupId{2}, {3_g, 4_g, 5_g}}
             });
 
-            me.To(204).CheckByKeys(5, 8, 0, TMap<TGroupId, TArr>{
+            me.To(204).CheckByKeys(5, 8, 0, 4, 1, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2}},
                 {TGroupId{1}, {1_g, 2_g}},
                 {TGroupId{2}, {3_g, 4_g, 5_g}} // don't touch 9's columns
             });
 
-            me.To(205).CheckByKeys(5, 9, 0, TMap<TGroupId, TArr>{
+            me.To(205).CheckByKeys(5, 9, 0, 7, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3_I}},
                 {TGroupId{1}, {1_g, 2_g, 3_g}},
                 {TGroupId{2}, {3_g, 4_g, 5_g, 6_g}}
             });
 
-            me.To(206).CheckByKeys(5, 10, 0, TMap<TGroupId, TArr>{
+            me.To(206).CheckByKeys(5, 10, 0, 7, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3_I}},
                 {TGroupId{1}, {1_g, 2_g, 3_g}},
                 {TGroupId{2}, {3_g, 4_g, 5_g, 6_g, 7_g}}
             });
 
-            me.To(207).CheckByKeys(5, 11, 0, TMap<TGroupId, TArr>{
+            me.To(207).CheckByKeys(5, 11, 0, 7, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3}},
                 {TGroupId{1}, {1_g, 2_g, 3_g, 4_g}},
                 {TGroupId{2}, {3_g, 4_g, 5_g, 6_g, 7_g, 8_g}}
             });
 
-            me.To(208).CheckByKeys(5, 12, 0, TMap<TGroupId, TArr>{
+            me.To(208).CheckByKeys(5, 12, 0, 7, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3}},
                 {TGroupId{1}, {1_g, 2_g, 3_g, 4_g}},
                 {TGroupId{2}, {3_g, 4_g, 5_g, 6_g, 7_g, 8_g}}  // don't touch 13's columns
             });
 
-            me.To(209).CheckByKeys(5, 13, 0, TMap<TGroupId, TArr>{
+            me.To(209).CheckByKeys(5, 13, 0, 10, 7, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4_I}},
                 {TGroupId{1}, {1_g, 2_g, 3, 4}}, // pages 3, 4 are always needed
                 {TGroupId{2}, {3_g, 4_g, 5_g, 6, 7, 8, 9_g}} // pages 6, 7, 8 are always needed
             });
 
-            me.To(210).CheckByKeys(5, 18, 0, TMap<TGroupId, TArr>{
+            me.To(210).CheckByKeys(5, 18, 0, 13, 10, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4, 5_I}},
                 {TGroupId{1}, {1_g, 2_g, 3, 4, 5, 6_g}},
                 {TGroupId{2}, {3_g, 4_g, 5_g, 6, 7, 8, 9, 10, 11, 12_g, 13_g}}
             });
 
-            me.To(211).CheckByKeys(6, 11, 0, TMap<TGroupId, TArr>{
+            me.To(211).CheckByKeys(6, 11, 0, 6, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3}},
                 {TGroupId{1}, {2_g, 3_g, 4_g}},
                 {TGroupId{2}, {4_g, 5_g, 6_g, 7_g, 8_g}}
             });
 
-            me.To(212).CheckByKeys(6, 12, 0, TMap<TGroupId, TArr>{
+            me.To(212).CheckByKeys(6, 12, 0, 6, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3}},
                 {TGroupId{1}, {2_g, 3_g, 4_g}},
                 {TGroupId{2}, {4_g, 5_g, 6_g, 7_g, 8_g}}
             });
 
-            me.To(213).CheckByKeys(6, 13, 0, TMap<TGroupId, TArr>{
+            me.To(213).CheckByKeys(6, 13, 0, 9, 7, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4_I}},
                 {TGroupId{1}, {2_g, 3, 4}}, // pages 3, 4 are always needed
                 {TGroupId{2}, {4_g, 5_g, 6, 7, 8, 9_g}} // pages 6, 7, 8 are always needed
             });
 
-            me.To(214).CheckByKeys(7, 11, 0, TMap<TGroupId, TArr>{
+            me.To(214).CheckByKeys(7, 11, 0, 5, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3}},
                 {TGroupId{1}, {2_g, 3_g, 4_g}},
                 {TGroupId{2}, {5_g, 6_g, 7_g, 8_g}}
             });
 
-            me.To(215).CheckByKeys(7, 12, 0, TMap<TGroupId, TArr>{
+            me.To(215).CheckByKeys(7, 12, 0, 5, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3}},
                 {TGroupId{1}, {2_g, 3_g, 4_g}},
                 {TGroupId{2}, {5_g, 6_g, 7_g, 8_g}}
             });
 
-            me.To(216).CheckByKeys(7, 13, 0, TMap<TGroupId, TArr>{
+            me.To(216).CheckByKeys(7, 13, 0, 8, 7, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4_I}},
                 {TGroupId{1}, {2_g, 3, 4}}, // pages 3, 4 are always needed
                 {TGroupId{2}, {5_g, 6, 7, 8, 9_g}} // pages 6, 7, 8 are always needed
             });
 
-            me.To(217).CheckByKeys(8, 11, 0, TMap<TGroupId, TArr>{
+            me.To(217).CheckByKeys(8, 11, 0, 4, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3}},
                 {TGroupId{1}, {3_g, 4_g}},
                 {TGroupId{2}, {6_g, 7_g, 8_g}}
             });
 
-            me.To(218).CheckByKeys(8, 12, 0, TMap<TGroupId, TArr>{
+            me.To(218).CheckByKeys(8, 12, 0, 4, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3}},
                 {TGroupId{1}, {3_g, 4_g}},
                 {TGroupId{2}, {6_g, 7_g, 8_g}}
             });
 
-            me.To(219).CheckByKeys(8, 13, 0, TMap<TGroupId, TArr>{
+            me.To(219).CheckByKeys(8, 13, 0, 7, 7, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4_I}},
                 {TGroupId{1}, {3, 4}}, // pages 3, 4 are always needed
                 {TGroupId{2}, {6, 7, 8, 9_g}} // pages 6, 7, 8 are always needed
             });
 
-            me.To(220).CheckByKeys(9, 13, 0, TMap<TGroupId, TArr>{
+            me.To(220).CheckByKeys(9, 13, 0, 7, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {2, 3, 4_I}},
                 {TGroupId{1}, {3_g, 4_g}},
                 {TGroupId{2}, {6_g, 7_g, 8_g, 9_g}}
@@ -694,38 +787,38 @@ Y_UNIT_TEST_SUITE(Charge) {
         }
 
         /*_ 3xx: Play with last page */ {
-            me.To(300).CheckByKeys(32, 32, 0, TMap<TGroupId, TArr>{
+            me.To(300).CheckByKeys(32, 32, 0, 1, 1, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {7, 8}},
                 {TGroupId{1}, {}},
                 {TGroupId{2}, {}}
             });
 
             // key 35 transforms into row id 26 because it's after the slice last key 35
-            me.To(301).CheckByKeys(27, 35, 0, TMap<TGroupId, TArr>{
+            me.To(301).CheckByKeys(27, 35, 0, 7, 6, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {6, 7, 8}},
                 {TGroupId{1}, {10, 11, 12, 13}},
                 {TGroupId{2}, {20_g, 21, 22, 23, 24, 25, 26}}
             });
 
-            me.To(302).CheckByKeys(27, 34, 0, TMap<TGroupId, TArr>{
+            me.To(302).CheckByKeys(27, 34, 0, 7, 6, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {6, 7, 8}},
                 {TGroupId{1}, {10, 11, 12_g}},
                 {TGroupId{2}, {20_g, 21, 22, 23, 24_g, 25_g}}
             });
 
-            me.To(303).CheckByKeys(27, 33, 0, TMap<TGroupId, TArr>{
+            me.To(303).CheckByKeys(27, 33, 0, 7, 6, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {6, 7, 8}},
                 {TGroupId{1}, {10, 11, 12_g}},
                 {TGroupId{2}, {20_g, 21, 22, 23, 24_g}}
             });
 
-            me.To(305).CheckByKeys(27, 32, 0, TMap<TGroupId, TArr>{
+            me.To(305).CheckByKeys(27, 32, 0, 5, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {6, 7, 8}},
                 {TGroupId{1}, {10_g, 11_g}},
                 {TGroupId{2}, {20_g, 21_g, 22_g, 23_g}}
             });
 
-            me.To(306).CheckByKeys(27, 31, 0, TMap<TGroupId, TArr>{
+            me.To(306).CheckByKeys(27, 31, 0, 5, 4, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {6, 7, 8}},
                 {TGroupId{1}, {10_g, 11_g}},
                 {TGroupId{2}, {20_g, 21_g, 22_g, 23_g}}
@@ -733,21 +826,21 @@ Y_UNIT_TEST_SUITE(Charge) {
         }
 
         { /*_ 4xx: key2 > key1 */
-            me.To(400).CheckByKeys(9, 8, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
-            me.To(401).CheckByKeys(9, 7, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
-            me.To(402).CheckByKeys(9, 0, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(403).CheckByKeys(8, 7, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(404).CheckByKeys(8, 6, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(405).CheckByKeys(8, 0, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(406).CheckByKeys(7, 6, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(407).CheckByKeys(7, 5, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
-            me.To(408).CheckByKeys(7, 0, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(409).CheckByKeys(6, 5, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(410).CheckByKeys(6, 4, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(411).CheckByKeys(6, 0, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(412).CheckByKeys(5, 4, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(413).CheckByKeys(5, 3, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
-            me.To(414).CheckByKeys(5, 0, 0, TMap<TGroupId, TArr>{{TGroupId{2}, {}}}); 
+            me.To(400).CheckByKeys(9, 8, 0, 4, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(401).CheckByKeys(9, 7, 0, 4, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(402).CheckByKeys(9, 0, 0, 4, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(403).CheckByKeys(8, 7, 0, 1, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(404).CheckByKeys(8, 6, 0, 1, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(405).CheckByKeys(8, 0, 0, 1, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(406).CheckByKeys(7, 6, 0, 2, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(407).CheckByKeys(7, 5, 0, 2, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(408).CheckByKeys(7, 0, 0, 2, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(409).CheckByKeys(6, 5, 0, 3, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(410).CheckByKeys(6, 4, 0, 3, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(411).CheckByKeys(6, 0, 0, 3, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(412).CheckByKeys(5, 4, 0, 4, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(413).CheckByKeys(5, 3, 0, 4, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
+            me.To(414).CheckByKeys(5, 0, 0, 4, 1, TMap<TGroupId, TArr>{{TGroupId{2}, {}}});
         }
     }
 
@@ -756,45 +849,45 @@ Y_UNIT_TEST_SUITE(Charge) {
         TModel me(true);
 
         /*
-        
+
         keys by pages:
         group0 = |1 2 3|5 6 7|9 10 11|13 14 15|..
         group1 = |1 2|3 5|6 7|9 10|11 13|14 15|..
         group3 = |1|2|3|5|6|7|9|10|11|13|14|15|..
-        
+
         */
 
-        me.To(101).CheckByKeys(5, 13, 999, TMap<TGroupId, TArr>{
+        me.To(101).CheckByKeys(5, 13, 999, 10, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {1, 2, 3, 4_I}},
             {TGroupId{1}, {1_g, 2_g, 3, 4}}, // pages 3, 4 are always needed
             {TGroupId{2}, {3_g, 4_g, 5_g, 6, 7, 8, 9_g}} // pages 6, 7, 8 are always needed
         });
 
-        me.To(102).CheckByKeys(5, 13, 7, TMap<TGroupId, TArr>{
+        me.To(102).CheckByKeys(5, 13, 7, 8, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {1, 2, 3, 4_f}},
             {TGroupId{1}, {1_g, 2_g, 3, 4}}, // pages 3, 4 are always needed
             {TGroupId{2}, {3_g, 4_g, 5_g, 6, 7, 8, 9_g}} // pages 6, 7, 8 are always needed
         });
 
-        me.To(103).CheckByKeys(5, 13, 6, TMap<TGroupId, TArr>{
+        me.To(103).CheckByKeys(5, 13, 6, 7, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {1, 2, 3, 4_f}},
             {TGroupId{1}, {1_g, 2_g, 3, 4}},
             {TGroupId{2}, {3_g, 4_g, 5_g, 6, 7, 8, 9_g}}
         });
 
-        me.To(104).CheckByKeys(5, 13, 5, TMap<TGroupId, TArr>{
+        me.To(104).CheckByKeys(5, 13, 5, 6, 6, TMap<TGroupId, TArr>{
             {TGroupId{0}, {1, 2, 3_f}},
             {TGroupId{1}, {1_g, 2_g, 3, 4}},
             {TGroupId{2}, {3_g, 4_g, 5_g, 6, 7, 8}}
         });
 
-        me.To(105).CheckByKeys(5, 13, 4, TMap<TGroupId, TArr>{
+        me.To(105).CheckByKeys(5, 13, 4, 5, 5, TMap<TGroupId, TArr>{
             {TGroupId{0}, {1, 2, 3_f}},
             {TGroupId{1}, {1_g, 2_g, 3, 4_f}}, // here we touch extra pages, but it's fine
             {TGroupId{2}, {3_g, 4_g, 5_g, 6, 7, 8_f}} // here we touch extra pages, but it's fine
         });
 
-        me.To(106).CheckByKeys(7, 13, 3, TMap<TGroupId, TArr>{
+        me.To(106).CheckByKeys(7, 13, 3, 4, 4, TMap<TGroupId, TArr>{
             {TGroupId{0}, {1, 2, 3_f}},
             {TGroupId{1}, {2_g, 3, 4}},
             {TGroupId{2}, {5_g, 6, 7, 8}}
@@ -815,18 +908,17 @@ Y_UNIT_TEST_SUITE(Charge) {
         /*_ 1xx: custom spanned loads scenarios */
 
         // key 0 transforms into row id 0 because it's before the slice first key 1
-        me.To(101).CheckByKeys(0, 35, 8 /* rows */, { 0, 1, 2 });
-        me.To(102).CheckByKeys(0, 35, 11 /* rows */, { 0, 1, 2, 3 });
-        me.To(103).CheckByKeys(0, 35, 14 /* rows */, { 0, 1, 2, 3, 4 });
+        me.To(101).CheckByKeys(0, 35, 8 /* rows */, 9, 9, { 0, 1, 2 });
+        me.To(102).CheckByKeys(0, 35, 11 /* rows */, 12, 12, { 0, 1, 2, 3 });
+        me.To(103).CheckByKeys(0, 35, 14 /* rows */, 15, 15, { 0, 1, 2, 3, 4 });
 
-        me.To(104).CheckByKeys(3, 35, 5 /* rows */, { 0, 1, 2 });
-        me.To(105).CheckByKeys(3, 35, 6 /* rows */, { 0, 1, 2, 3_I });
-        me.To(106).CheckByKeys(4, 35, 6 /* rows */, { 0, 1, 2, 3 });
-        me.To(107).CheckByKeys(5, 35, 5 /* rows */, { 1, 2, 3_I });
-        me.To(112).CheckByKeys(9, 35, 11 /* rows */, { 2, 3, 4, 5, 6_I });
-        me.To(113).CheckByKeys(9, 35, 14 /* rows */, { 2, 3, 4, 5, 6, 7_I });
-        me.To(120).CheckByKeys(25, 35, 8 /* rows */, { 6, 7, 8 });
-
+        me.To(104).CheckByKeys(3, 35, 5 /* rows */, 6, 6, { 0, 1, 2 });
+        me.To(105).CheckByKeys(3, 35, 6 /* rows */, 7, 7, { 0, 1, 2, 3_I });
+        me.To(106).CheckByKeys(4, 35, 6 /* rows */, 7, 7, { 0, 1, 2, 3 });
+        me.To(107).CheckByKeys(5, 35, 5 /* rows */, 6, 6, { 1, 2, 3_I });
+        me.To(112).CheckByKeys(9, 35, 11 /* rows */, 12, 12, { 2, 3, 4, 5, 6_I });
+        me.To(113).CheckByKeys(9, 35, 14 /* rows */, 15, 15, { 2, 3, 4, 5, 6, 7_I });
+        me.To(120).CheckByKeys(25, 35, 8 /* rows */, 6, 6, { 6, 7, 8 });
 
         /*_ 2xx: one row charge limit on two page */
 
@@ -836,9 +928,9 @@ Y_UNIT_TEST_SUITE(Charge) {
 
             const ui32 base = 200 + page * 10, lead = page * 4;
 
-            me.To(base + 1).CheckByKeys(lead + 1, 35, 1, span1);
-            me.To(base + 2).CheckByKeys(lead + 2, 35, 1, span1);
-            me.To(base + 3).CheckByKeys(lead + 3, 35, 1, span2);
+            me.To(base + 1).CheckByKeys(lead + 1, 35, 1, (lead == 0) ? 9 : 2, (lead == 0) ? 9 : 2, span1);
+            me.To(base + 2).CheckByKeys(lead + 2, 35, 1, (lead == 0) ? 8 : 2, (lead == 0) ? 8 : 2, span1);
+            me.To(base + 3).CheckByKeys(lead + 3, 35, 1, (lead == 0) ? 7 : 2, (lead == 0) ? 7 : 2, span2);
         }
     }
 
@@ -847,122 +939,122 @@ Y_UNIT_TEST_SUITE(Charge) {
         TModel me(true);
 
         /*
-        
+
         keys by pages:
         group0 = |1 2 3|5 6 7|9 10 11|13 14 15|..
         group1 = |1 2|3 5|6 7|9 10|11 13|14 15|..
         group3 = |1|2|3|5|6|7|9|10|11|13|14|15|..
-        
+
         */
 
-        me.To(100).CheckByKeysReverse(15, 15, 0, TMap<TGroupId, TArr>{
+        me.To(100).CheckByKeysReverse(15, 15, 0, 4, 1, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2_I}},
             {TGroupId{2}, {11_g}}
         });
 
-        me.To(101).CheckByKeysReverse(15, 5, 0, TMap<TGroupId, TArr>{
+        me.To(101).CheckByKeysReverse(15, 5, 0, 10, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1, 0}},
             {TGroupId{2}, {11_g, 10_g, 9_g, 8, 7, 6, 5_g, 4_g, 3_g}}
         });
 
-        me.To(102).CheckByKeysReverse(15, 4, 0, TMap<TGroupId, TArr>{
+        me.To(102).CheckByKeysReverse(15, 4, 0, 12, 9, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1, 0}},
             {TGroupId{2}, {11_g, 10_g, 9_g, 8, 7, 6, 5, 4, 3}}
         });
 
-        me.To(103).CheckByKeysReverse(15, 3, 0, TMap<TGroupId, TArr>{
+        me.To(103).CheckByKeysReverse(15, 3, 0, 12, 9, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1, 0}},
             {TGroupId{2}, {11_g, 10_g, 9_g, 8, 7, 6, 5, 4, 3, 2_g}}
         });
 
         // key 1 transforms into row id 0 because it's before the slice first key 1
-        me.To(104).CheckByKeysReverse(15, 1, 0, TMap<TGroupId, TArr>{
+        me.To(104).CheckByKeysReverse(15, 1, 0, 12, 9, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1, 0}},
             {TGroupId{2}, {11_g, 10_g, 9_g, 8, 7, 6, 5, 4, 3, 2, 1, 0}}
         });
 
-        me.To(105).CheckByKeysReverse(15, 0, 0, TMap<TGroupId, TArr>{
+        me.To(105).CheckByKeysReverse(15, 0, 0, 12, 9, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1, 0}},
             {TGroupId{2}, {11_g, 10_g, 9_g, 8, 7, 6, 5, 4, 3, 2, 1, 0}}
         });
 
-        me.To(106).CheckByKeysReverse(17, 17, 0, TMap<TGroupId, TArr>{
+        me.To(106).CheckByKeysReverse(17, 17, 0, 2, 1, TMap<TGroupId, TArr>{
             {TGroupId{0}, {4, 3}},
             {TGroupId{2}, {12_g}}
         });
-        
-        me.To(107).CheckByKeysReverse(16, 16, 0, TMap<TGroupId, TArr>{
+
+        me.To(107).CheckByKeysReverse(16, 16, 0, 4, 1, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2_I}},
             {TGroupId{2}, {}}
         });
 
-        me.To(108).CheckByKeysReverse(35, 35, 0, TMap<TGroupId, TArr>{
+        me.To(108).CheckByKeysReverse(35, 35, 0, 4, 4, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7_I}},
             {TGroupId{2}, {26_g}}
         });
 
-        me.To(109).CheckByKeysReverse(35, 33, 0, TMap<TGroupId, TArr>{
+        me.To(109).CheckByKeysReverse(35, 33, 0, 4, 4, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7}},
             {TGroupId{2}, {26_g, 25_g, 24_g}}
         });
 
         // key 35 transforms into row id 26 because it's after the slice last key 35
-        me.To(110).CheckByKeysReverse(35, 32, 0, TMap<TGroupId, TArr>{
+        me.To(110).CheckByKeysReverse(35, 32, 0, 7, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7, 6_I}},
             {TGroupId{2}, {26, 25, 24}}
         });
 
-        me.To(111).CheckByKeysReverse(4, 1, 0, TMap<TGroupId, TArr>{
+        me.To(111).CheckByKeysReverse(4, 1, 0, 3, 0, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0}},
             {TGroupId{2}, {2_g, 1_g, 0_g}}
         });
 
-        me.To(112).CheckByKeysReverse(1, 1, 0, TMap<TGroupId, TArr>{
+        me.To(112).CheckByKeysReverse(1, 1, 0, 1, 0, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0}},
             {TGroupId{2}, {0_g}}
         });
 
-        me.To(113).CheckByKeysReverse(1, 0, 0, TMap<TGroupId, TArr>{
+        me.To(113).CheckByKeysReverse(1, 0, 0, 1, 0, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0}},
             {TGroupId{2}, {0_g}}
         });
 
-        me.To(114).CheckByKeysReverse(0, 0, 0, TMap<TGroupId, TArr>{
+        me.To(114).CheckByKeysReverse(0, 0, 0, 0, 0, TMap<TGroupId, TArr>{
             {TGroupId{0}, {}},
             {TGroupId{2}, {}}
         });
 
-        me.To(200).CheckByKeysReverse(15, 3, 6, TMap<TGroupId, TArr>{
+        me.To(200).CheckByKeysReverse(15, 3, 6, 7, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1, 0_f}},
             {TGroupId{2}, {11_g, 10_g, 9_g, 8, 7, 6, 5, 4_f, 3_f}} // here we touch extra pages, but it's fine
         });
 
-        me.To(201).CheckByKeysReverse(15, 3, 5, TMap<TGroupId, TArr>{
+        me.To(201).CheckByKeysReverse(15, 3, 5, 6, 6, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1_f}},
             {TGroupId{2}, {11_g, 10_g, 9_g, 8, 7, 6, 5_f, 4_f, 3_f}} // here we touch extra pages, but it's fine
         });
 
-        me.To(202).CheckByKeysReverse(15, 5, 5, TMap<TGroupId, TArr>{
+        me.To(202).CheckByKeysReverse(15, 5, 5, 6, 6, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1_f}},
             {TGroupId{2}, {11_g, 10_g, 9_g, 8, 7, 6}}
         });
 
-        me.To(203).CheckByKeysReverse(13, 3, 4, TMap<TGroupId, TArr>{
+        me.To(203).CheckByKeysReverse(13, 3, 4, 5, 5, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1}},
             {TGroupId{2}, {9_g, 8, 7, 6, 5, 4_f}} // here we touch extra pages, but it's fine
         });
 
-        me.To(204).CheckByKeysReverse(13, 3, 3, TMap<TGroupId, TArr>{
+        me.To(204).CheckByKeysReverse(13, 3, 3, 4, 4, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2, 1_f}},
             {TGroupId{2}, {9_g, 8, 7, 6, 5_f}} // here we touch extra pages, but it's fine
         });
 
-        me.To(205).CheckByKeysReverse(13, 3, 2, TMap<TGroupId, TArr>{
+        me.To(205).CheckByKeysReverse(13, 3, 2, 3, 3, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2}},
             {TGroupId{2}, {9_g, 8, 7, 6_f}} // here we touch extra pages, but it's fine
         });
 
-        me.To(206).CheckByKeysReverse(13, 3, 1, TMap<TGroupId, TArr>{
+        me.To(206).CheckByKeysReverse(13, 3, 1, 2, 2, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3, 2}},
             {TGroupId{2}, {9_g, 8, 7_f}} // here we touch extra pages, but it's fine
         });
@@ -972,7 +1064,7 @@ Y_UNIT_TEST_SUITE(Charge) {
     {
         TModel me(true, true);
 
-        me.To(100).CheckByKeys(9, 23, 0, TMap<TGroupId, TArr>{
+        me.To(100).CheckByKeys(9, 23, 0, 13, 10, TMap<TGroupId, TArr>{
             {TGroupId{0}, {2, 3, 4, 5, 6}},
             {TGroupId{0, true}, {1_g, 2, 3, 4, 5_g}},
             {TGroupId{1}, {3_g, 4, 5, 6, 7, 8_g}},
@@ -981,11 +1073,11 @@ Y_UNIT_TEST_SUITE(Charge) {
             {TGroupId{2, true}, {6_g, 7_g, 8_g, 9, 10, 11, 12_g, 13_g, 14_g, 15_g, 16_g, 17_g}}
         });
 
-        me.To(200).CheckByKeys(29, 35, 0, TMap<TGroupId, TArr>{
+        me.To(200).CheckByKeys(29, 35, 0, 6, 3, TMap<TGroupId, TArr>{
             {TGroupId{2, true}, {21_g, 22_g, 23_g, 24_g, 25_g, 26_g}}
         });
 
-        me.To(201).CheckByKeys(29, 34, 0, TMap<TGroupId, TArr>{
+        me.To(201).CheckByKeys(29, 34, 0, 6, 3, TMap<TGroupId, TArr>{
             {TGroupId{2, true}, {21_g, 22_g, 23_g, 24_g, 25_g}}
         });
     }
@@ -997,14 +1089,14 @@ Y_UNIT_TEST_SUITE(Charge) {
             auto &pages = me.Eggs.Lone()->IndexPages;
 
             // no index => touch index
-            me.To(100).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(100).CheckIndex(6, 22, 0, 0, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {pages.FlatGroups[0]}},
             }, TSet<TPageId> {
 
             });
 
             // index => touch pages + index
-            me.To(101).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(101).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0]}}
             },
             TSet<TPageId> {
@@ -1017,7 +1109,7 @@ Y_UNIT_TEST_SUITE(Charge) {
             auto &pages = me.Eggs.Lone()->IndexPages;
 
             // no index => touch index
-            me.To(200).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(200).CheckIndex(6, 22, 0, 0, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {pages.FlatGroups[0]}},
                 {TGroupId{0, true}, {}}
             }, TSet<TPageId> {
@@ -1025,7 +1117,7 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // no history index => touch main pages + index + history index
-            me.To(201).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(201).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], pages.FlatHistoric[0]}},
                 {TGroupId{0, true}, {}}
             },
@@ -1034,7 +1126,7 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // history index => touch main pages + history pages + index + history index
-            me.To(202).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(202).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], pages.FlatHistoric[0]}},
                 {TGroupId{0, true}, {1, 2, 3, 4}}
             },
@@ -1042,13 +1134,13 @@ Y_UNIT_TEST_SUITE(Charge) {
                 pages.FlatGroups[0], pages.FlatHistoric[0]
             });
         }
-        
+
         { // index + groups
             TModel me(true, false);
             auto &pages = me.Eggs.Lone()->IndexPages;
 
             // no index => touch index
-            me.To(300).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(300).CheckIndex(6, 22, 0, 0, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {pages.FlatGroups[0]}},
                 {TGroupId{1}, {}}
             }, TSet<TPageId> {
@@ -1056,7 +1148,7 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // no groups index => touch main pages + index + all groups indexes
-            me.To(301).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(301).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], pages.FlatGroups[1], pages.FlatGroups[2], pages.FlatGroups[3]}},
                 {TGroupId{1}, {}}
             },
@@ -1065,7 +1157,7 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // groups index => touch all pages + index + all groups indexes
-            me.To(302).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(302).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], pages.FlatGroups[1], pages.FlatGroups[2], pages.FlatGroups[3]}},
                 {TGroupId{1}, {3, 4, 5, 6, 7}}
             },
@@ -1079,7 +1171,7 @@ Y_UNIT_TEST_SUITE(Charge) {
             auto &pages = me.Eggs.Lone()->IndexPages;
 
             // no index => touch index
-            me.To(400).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(400).CheckIndex(6, 22, 0, 0, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {pages.FlatGroups[0]}},
                 {TGroupId{0, true}, {}},
                 {TGroupId{1}, {}},
@@ -1091,7 +1183,7 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // only index => touch main pages + index + all groups indexes + history index
-            me.To(401).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
+            me.To(401).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
                 {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], pages.FlatHistoric[0], pages.FlatGroups[1], pages.FlatGroups[2], pages.FlatGroups[3]}},
                 {TGroupId{0, true}, {}},
                 {TGroupId{1}, {}},
@@ -1104,8 +1196,8 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // history index => touch main pages + index + all groups indexes + main history pages
-            me.To(402).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
-                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], 
+            me.To(402).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
+                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0],
                     pages.FlatHistoric[0], pages.FlatHistoric[1], pages.FlatHistoric[2], pages.FlatHistoric[3], pages.FlatGroups[1], pages.FlatGroups[2], pages.FlatGroups[3]}},
                 {TGroupId{0, true}, {1, 2, 3, 4}},
                 {TGroupId{1}, {}},
@@ -1118,8 +1210,8 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // main history and history => touch main pages + index + all groups indexes + history pages + history groups pages
-            me.To(403).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
-                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], 
+            me.To(403).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
+                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0],
                     pages.FlatHistoric[0], pages.FlatHistoric[1], pages.FlatHistoric[2], pages.FlatHistoric[3], pages.FlatGroups[1], pages.FlatGroups[2], pages.FlatGroups[3]}},
                 {TGroupId{0, true}, {1, 2, 3, 4}},
                 {TGroupId{1}, {}},
@@ -1128,12 +1220,12 @@ Y_UNIT_TEST_SUITE(Charge) {
                 {TGroupId{2, true}, {}}
             },
             TSet<TPageId> {
-                pages.FlatGroups[0], pages.FlatHistoric[0], pages.FlatHistoric[1] 
+                pages.FlatGroups[0], pages.FlatHistoric[0], pages.FlatHistoric[1]
             });
 
             // groups index => touch main pages + index + history index + all groups indexes + groups pages
-            me.To(404).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
-                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], 
+            me.To(404).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
+                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0],
                     pages.FlatHistoric[0], pages.FlatGroups[1], pages.FlatGroups[2], pages.FlatGroups[3]}},
                 {TGroupId{0, true}, {}},
                 {TGroupId{1}, {3, 4, 5, 6, 7}},
@@ -1146,8 +1238,8 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // main history and groups => touch main pages + index + all groups indexes + groups pages + history main pages
-            me.To(405).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
-                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], 
+            me.To(405).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
+                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0],
                     pages.FlatHistoric[0], pages.FlatHistoric[1], pages.FlatHistoric[2], pages.FlatHistoric[3], pages.FlatGroups[1], pages.FlatGroups[2], pages.FlatGroups[3]}},
                 {TGroupId{0, true}, {1, 2, 3, 4}},
                 {TGroupId{1}, {3, 4, 5, 6, 7}},
@@ -1160,8 +1252,8 @@ Y_UNIT_TEST_SUITE(Charge) {
             });
 
             // all indexes
-            me.To(406).CheckIndex(6, 22, 0, TMap<TGroupId, TArr>{
-                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0], 
+            me.To(406).CheckIndex(6, 22, 0, 13, TMap<TGroupId, TArr>{
+                {TGroupId{0}, {1, 2, 3, 4, 5, 6, pages.FlatGroups[0],
                     pages.FlatHistoric[0], pages.FlatHistoric[1], pages.FlatHistoric[2], pages.FlatHistoric[3], pages.FlatGroups[1], pages.FlatGroups[2], pages.FlatGroups[3]}},
                 {TGroupId{0, true}, {1, 2, 3, 4}},
                 {TGroupId{1}, {3, 4, 5, 6, 7}},
@@ -1180,7 +1272,7 @@ Y_UNIT_TEST_SUITE(Charge) {
         TModel me(true);
 
         /*
-        
+
         row ids by pages:
         group0 = |0 1 2|3 4 5|6 7 8|..
         group1 = |0 1|2 3|4 5|6 7|8 ..
@@ -1188,61 +1280,61 @@ Y_UNIT_TEST_SUITE(Charge) {
 
         */
 
-        me.To(100).CheckByRows(0, 0, 0, TMap<TGroupId, TArr>{
+        me.To(100).CheckByRows(0, 0, 0, 1, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0}},
             {TGroupId{1}, {0}},
             {TGroupId{2}, {0}}
         });
 
-        me.To(101).CheckByRows(0, 1, 0, TMap<TGroupId, TArr>{
+        me.To(101).CheckByRows(0, 1, 0, 2, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0}},
             {TGroupId{1}, {0}},
             {TGroupId{2}, {0, 1}}
         });
 
-        me.To(102).CheckByRows(0, 2, 0, TMap<TGroupId, TArr>{
+        me.To(102).CheckByRows(0, 2, 0, 3, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0}},
             {TGroupId{1}, {0, 1}},
             {TGroupId{2}, {0, 1, 2}}
         });
 
-        me.To(103).CheckByRows(0, 3, 0, TMap<TGroupId, TArr>{
+        me.To(103).CheckByRows(0, 3, 0, 4, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0, 1}},
             {TGroupId{1}, {0, 1}},
             {TGroupId{2}, {0, 1, 2, 3}}
         });
 
-        me.To(104).CheckByRows(0, 4, 0, TMap<TGroupId, TArr>{
+        me.To(104).CheckByRows(0, 4, 0, 5, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0, 1}},
             {TGroupId{1}, {0, 1, 2}},
             {TGroupId{2}, {0, 1, 2, 3, 4}}
         });
 
-        me.To(105).CheckByRows(1, 7, 0, TMap<TGroupId, TArr>{
+        me.To(105).CheckByRows(1, 7, 0, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0, 1, 2}},
             {TGroupId{1}, {0, 1, 2, 3}},
             {TGroupId{2}, {1, 2, 3, 4, 5, 6, 7}}
         });
 
-        me.To(106).CheckByRows(2, 6, 0, TMap<TGroupId, TArr>{
+        me.To(106).CheckByRows(2, 6, 0, 5, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0, 1, 2}},
             {TGroupId{1}, {1, 2, 3}},
             {TGroupId{2}, {2, 3, 4, 5, 6}}
         });
 
-        me.To(107).CheckByRows(3, 5, 0, TMap<TGroupId, TArr>{
+        me.To(107).CheckByRows(3, 5, 0, 3, TMap<TGroupId, TArr>{
             {TGroupId{0}, {1}},
             {TGroupId{1}, {1, 2}},
             {TGroupId{2}, {3, 4, 5}}
         });
 
-        me.To(200).CheckByRows(8, 7, 0, TMap<TGroupId, TArr>{
+        me.To(200).CheckByRows(8, 7, 0, 0, TMap<TGroupId, TArr>{
             {TGroupId{0}, {2}},
             {TGroupId{1}, {}},
             {TGroupId{2}, {}}
         });
 
-        me.To(201).CheckByRows(7, 1, 0, TMap<TGroupId, TArr>{
+        me.To(201).CheckByRows(7, 1, 0, 0, TMap<TGroupId, TArr>{
             {TGroupId{0}, {2}},
             {TGroupId{1}, {}},
             {TGroupId{2}, {}}
@@ -1254,7 +1346,7 @@ Y_UNIT_TEST_SUITE(Charge) {
         TModel me(true);
 
         /*
-        
+
         row ids by pages:
         group0 = ..|18 19 20|21 22 23|24 25 26|
         group1 = ..|18 19|20 21|22 23|24 25|26|
@@ -1262,67 +1354,67 @@ Y_UNIT_TEST_SUITE(Charge) {
 
         */
 
-        me.To(100).CheckByRowsReverse(26, 26, 0, TMap<TGroupId, TArr>{
+        me.To(100).CheckByRowsReverse(26, 26, 0, 1, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8}},
             {TGroupId{1}, {13}},
             {TGroupId{2}, {26}}
         });
 
-        me.To(101).CheckByRowsReverse(26, 25, 0, TMap<TGroupId, TArr>{
+        me.To(101).CheckByRowsReverse(26, 25, 0, 2, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8}},
             {TGroupId{1}, {13, 12}},
             {TGroupId{2}, {26, 25}}
         });
 
-        me.To(102).CheckByRowsReverse(26, 24, 0, TMap<TGroupId, TArr>{
+        me.To(102).CheckByRowsReverse(26, 24, 0, 3, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8}},
             {TGroupId{1}, {13, 12}},
             {TGroupId{2}, {26, 25, 24}}
         });
 
-        me.To(103).CheckByRowsReverse(26, 23, 0, TMap<TGroupId, TArr>{
+        me.To(103).CheckByRowsReverse(26, 23, 0, 4, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7}},
             {TGroupId{1}, {13, 12, 11}},
             {TGroupId{2}, {26, 25, 24, 23}}
         });
 
-        me.To(104).CheckByRowsReverse(26, 22, 0, TMap<TGroupId, TArr>{
+        me.To(104).CheckByRowsReverse(26, 22, 0, 5, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7}},
             {TGroupId{1}, {13, 12, 11}},
             {TGroupId{2}, {26, 25, 24, 23, 22}}
         });
 
-        me.To(105).CheckByRowsReverse(25, 19, 0, TMap<TGroupId, TArr>{
+        me.To(105).CheckByRowsReverse(25, 19, 0, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7, 6}},
             {TGroupId{1}, {12, 11, 10, 9}},
             {TGroupId{2}, {25, 24, 23, 22, 21, 20, 19}}
         });
 
-        me.To(106).CheckByRowsReverse(24, 20, 0, TMap<TGroupId, TArr>{
+        me.To(106).CheckByRowsReverse(24, 20, 0, 5, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7, 6}},
             {TGroupId{1}, {12, 11, 10}},
             {TGroupId{2}, {24, 23, 22, 21, 20}}
         });
 
-        me.To(107).CheckByRowsReverse(23, 21, 0, TMap<TGroupId, TArr>{
+        me.To(107).CheckByRowsReverse(23, 21, 0, 3, TMap<TGroupId, TArr>{
             {TGroupId{0}, {7}},
             {TGroupId{1}, {11, 10}},
             {TGroupId{2}, {23, 22, 21}}
         });
 
-        me.To(200).CheckByRowsReverse(8, 9, 0, TMap<TGroupId, TArr>{
+        me.To(200).CheckByRowsReverse(8, 9, 0, 0, TMap<TGroupId, TArr>{
             {TGroupId{0}, {2}},
             {TGroupId{1}, {}},
             {TGroupId{2}, {}}
         });
 
-        me.To(201).CheckByRowsReverse(9, 15, 0, TMap<TGroupId, TArr>{
+        me.To(201).CheckByRowsReverse(9, 15, 0, 0, TMap<TGroupId, TArr>{
             {TGroupId{0}, {3}},
             {TGroupId{1}, {}},
             {TGroupId{2}, {}}
         });
 
-        me.To(202).CheckByRowsReverse(100, 23, 0, TMap<TGroupId, TArr>{
+        me.To(202).CheckByRowsReverse(100, 23, 0, 4, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7}},
             {TGroupId{1}, {13, 12, 11}},
             {TGroupId{2}, {26, 25, 24, 23}}
@@ -1334,7 +1426,7 @@ Y_UNIT_TEST_SUITE(Charge) {
         TModel me(true);
 
         /*
-        
+
         row ids by pages:
         group0 = |0 1 2|3 4 5|6 7 8|..
         group1 = |0 1|2 3|4 5|6 7|8 ..
@@ -1343,32 +1435,32 @@ Y_UNIT_TEST_SUITE(Charge) {
         */
 
         // Precharge touches [row1 .. Min(row2, row1 + itemsLimit)] rows (1 extra row)
-        
-        me.To(100).CheckByRows(1, 7, 6, TMap<TGroupId, TArr>{
+
+        me.To(100).CheckByRows(1, 7, 6, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0, 1, 2}},
             {TGroupId{1}, {0, 1, 2, 3}},
             {TGroupId{2}, {1, 2, 3, 4, 5, 6, 7}}
         });
 
-        me.To(101).CheckByRows(1, 7, 5, TMap<TGroupId, TArr>{
+        me.To(101).CheckByRows(1, 7, 5, 6, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0, 1, 2}},
             {TGroupId{1}, {0, 1, 2, 3}},
             {TGroupId{2}, {1, 2, 3, 4, 5, 6}}
         });
 
-        me.To(102).CheckByRows(1, 7, 4, TMap<TGroupId, TArr>{
+        me.To(102).CheckByRows(1, 7, 4, 5, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0, 1}},
             {TGroupId{1}, {0, 1, 2}},
             {TGroupId{2}, {1, 2, 3, 4, 5}}
         });
 
-        me.To(103).CheckByRows(1, 7, 1, TMap<TGroupId, TArr>{
+        me.To(103).CheckByRows(1, 7, 1, 2, TMap<TGroupId, TArr>{
             {TGroupId{0}, {0}},
             {TGroupId{1}, {0, 1}},
             {TGroupId{2}, {1, 2}}
         });
 
-        me.To(104).CheckByRows(3, 20, 5, TMap<TGroupId, TArr>{
+        me.To(104).CheckByRows(3, 20, 5, 6, TMap<TGroupId, TArr>{
             {TGroupId{0}, {1, 2}},
             {TGroupId{1}, {1, 2, 3, 4}},
             {TGroupId{2}, {3, 4, 5, 6, 7, 8}}
@@ -1380,7 +1472,7 @@ Y_UNIT_TEST_SUITE(Charge) {
         TModel me(true);
 
         /*
-        
+
         row ids by pages:
         group0 = ..|18 19 20|21 22 23|24 25 26|
         group1 = ..|18 19|20 21|22 23|24 25|26|
@@ -1389,38 +1481,38 @@ Y_UNIT_TEST_SUITE(Charge) {
         */
 
         // Precharge touches [Max(row2, row1 - itemsLimit) .. row1] rows (1 extra row)
-        
-        me.To(100).CheckByRowsReverse(25, 19, 6, TMap<TGroupId, TArr>{
+
+        me.To(100).CheckByRowsReverse(25, 19, 6, 7, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7, 6}},
             {TGroupId{1}, {12, 11, 10, 9}},
             {TGroupId{2}, {25, 24, 23, 22, 21, 20, 19}}
         });
 
-        me.To(101).CheckByRowsReverse(25, 19, 5, TMap<TGroupId, TArr>{
+        me.To(101).CheckByRowsReverse(25, 19, 5, 6, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7, 6}},
             {TGroupId{1}, {12, 11, 10}},
             {TGroupId{2}, {25, 24, 23, 22, 21, 20}}
         });
 
-        me.To(102).CheckByRowsReverse(25, 19, 4, TMap<TGroupId, TArr>{
+        me.To(102).CheckByRowsReverse(25, 19, 4, 5, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7}},
             {TGroupId{1}, {12, 11, 10}},
             {TGroupId{2}, {25, 24, 23, 22, 21}}
         });
 
-        me.To(103).CheckByRowsReverse(25, 19, 1, TMap<TGroupId, TArr>{
+        me.To(103).CheckByRowsReverse(25, 19, 1, 2, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8}},
             {TGroupId{1}, {12}},
             {TGroupId{2}, {25, 24}}
         });
 
-        me.To(104).CheckByRowsReverse(23, 3, 5, TMap<TGroupId, TArr>{
+        me.To(104).CheckByRowsReverse(23, 3, 5, 6, TMap<TGroupId, TArr>{
             {TGroupId{0}, {7, 6}},
             {TGroupId{1}, {11, 10, 9}},
             {TGroupId{2}, {23, 22, 21, 20, 19, 18}}
         });
 
-        me.To(200).CheckByRowsReverse(100, 3, 5, TMap<TGroupId, TArr>{
+        me.To(200).CheckByRowsReverse(100, 3, 5, 6, TMap<TGroupId, TArr>{
             {TGroupId{0}, {8, 7}},
             {TGroupId{1}, {13, 12, 11, 10}},
             {TGroupId{2}, {26, 25, 24, 23, 22, 21}}

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -26,7 +26,7 @@ namespace {
                 auto type = part->GetPageType(pageId, groupId);
                 if (type == EPage::DataPage) {
                     auto dataPage = NPage::TDataPage(page);
-                    
+
                     TouchedBytes += page->size();
                     if (groupId.IsMain()) {
                         TouchedRows += dataPage->Count;
@@ -129,52 +129,52 @@ Y_UNIT_TEST_SUITE(BuildStatsFlatIndex) {
 
     Y_UNIT_TEST(Single)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2106439, 25272);
     }
 
     Y_UNIT_TEST(Single_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 12816, 1121048, 25272);
     }
 
     Y_UNIT_TEST(Single_History)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckMixedIndex(*subset, 24000, 3547100, 49916);
     }
 
     Y_UNIT_TEST(Single_History_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 9582, 1425198, 49916);
     }
 
     Y_UNIT_TEST(Single_Groups)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2460139, 13170);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 10440, 1060798, 13170);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckMixedIndex(*subset, 24000, 4054050, 29361);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 13570, 2277890, 29361);
     }
@@ -225,13 +225,13 @@ Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
 
     Y_UNIT_TEST(Single)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2106439, 49449);
     }
 
     Y_UNIT_TEST(Single_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 12816, 1121048, 49449);
     }
@@ -244,33 +244,33 @@ Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
 
     Y_UNIT_TEST(Single_History_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 9582, 1425198, 81694);
     }
 
     Y_UNIT_TEST(Single_Groups)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2460139, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 10440, 1060798, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckMixedIndex(*subset, 24000, 4054050, 46562);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 13570, 2277890, 46562);
     }
@@ -316,39 +316,39 @@ Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
 
     Y_UNIT_TEST(Single_LowResolution)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2106439, 66674, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Slices_LowResolution)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 12816, 1121048, 66674, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_LowResolution)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2460139, 33541, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices_LowResolution)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 10440, 1060798, 33541, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_History_LowResolution)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckMixedIndex(*subset, 24000, 4054050, 64742, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices_LowResolution)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 13570, 2234982 /* ~2277890 */, 64742, 5310, 531050);
     }
@@ -360,13 +360,13 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
 
     Y_UNIT_TEST(Single)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckBTreeIndex(*subset, 24000, 2106439, 49449);
     }
 
     Y_UNIT_TEST(Single_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 12816, 1121048, 49449);
     }
@@ -379,33 +379,33 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
 
     Y_UNIT_TEST(Single_History_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 9582, 1425282, 81694);
     }
 
     Y_UNIT_TEST(Single_Groups)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckBTreeIndex(*subset, 24000, 2460139, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 10440, 1060767, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckBTreeIndex(*subset, 24000, 4054050, 46562);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 13570, 2273213, 46562);
     }
@@ -461,7 +461,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         for (auto &part : subset.Flatten) {
             TTestEnv env;
             auto index = CreateIndexIter(part.Part.Get(), &env, {});
-            Cerr << "  " << part->Label << " " << index->GetEndRowId() << " rows, " 
+            Cerr << "  " << part->Label << " " << index->GetEndRowId() << " rows, "
                 << IndexTools::CountMainPages(*part.Part) << " pages, "
                 << (part->IndexPages.HasBTree() ? part->IndexPages.GetBTree({}).LevelCount : -1) << " levels: ";
             for (ui32 sample : xrange(1u, samples + 1)) {
@@ -498,7 +498,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         NTest::TChecker<NTest::TWrapIter, TSubset> wrap(subset, { new TTouchEnv });
         auto env = wrap.GetEnv<TTouchEnv>();
         env->Faulty = false;
-        
+
         bytes = 0;
         rows = 0;
         wrap.Seek({}, ESeek::Lower);
@@ -534,7 +534,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             for (auto c : subset.Scheme->Cols) {
                 tags.push_back(c.Tag);
             }
-            Y_ENSURE(ChargeRange(&env, {}, key.GetCells(), run, keyDefaults, tags, 0, 0, true));
+            Y_ENSURE(ChargeRange(&env, {}, key.GetCells(), run, keyDefaults, tags, 0, 0, true).Ready);
         }
 
         bytes = env.TouchedBytes;
@@ -649,7 +649,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode);
         }
     }
@@ -657,7 +657,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single_Slices)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ }, 0, 13);
             subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
             Check(*subset, mode);
         }
@@ -674,7 +674,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single_History_Slices)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
             subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
             Check(*subset, mode);
         }
@@ -739,8 +739,8 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Ten_Mixed_Log)
     {
         struct TMixer {
-            TMixer(ui32 buckets) 
-                : Buckets(buckets) 
+            TMixer(ui32 buckets)
+                : Buckets(buckets)
             {
             }
 
@@ -841,8 +841,8 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Five_Five_Mixed)
     {
         struct TMixer {
-            TMixer(ui32 buckets) 
-                : Buckets(buckets) 
+            TMixer(ui32 buckets)
+                : Buckets(buckets)
             {
             }
 
@@ -952,7 +952,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single_Small_2_Levels)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode, 1000);
         }
     }
@@ -960,7 +960,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single_Small_2_Levels_3_Buckets)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode, 5, false);
         }
     }
@@ -972,7 +972,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             for (auto& group : conf.Groups) {
                 group.BTreeIndexNodeKeysMin = group.BTreeIndexNodeKeysMax = Max<ui32>();
             }
-            auto subset = TMake(Mass3, conf).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass3, conf).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode, 1000);
         }
     }
@@ -984,7 +984,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             for (auto& group : conf.Groups) {
                 group.PageSize = group.PageRows = Max<ui32>();
             }
-            auto subset = TMake(Mass3, conf).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass3, conf).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode, 1000, false);
         }
     }
@@ -992,7 +992,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Three_Mixed_Small_2_Levels)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerRnd(3));   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerRnd(3));
             Check(*subset, mode, 1000, false);
         }
     }
@@ -1000,7 +1000,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Three_Mixed_Small_2_Levels_3_Buckets)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerRnd(3));   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerRnd(3));
             Check(*subset, mode, 5, false);
         }
     }
@@ -1032,7 +1032,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Three_Serial_Small_2_Levels)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerSeq(3, Mass3.Saved.Size()));   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerSeq(3, Mass3.Saved.Size()));
             Check(*subset, mode, 1000, false);
         }
     }
@@ -1040,7 +1040,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Three_Serial_Small_2_Levels_3_Buckets)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerSeq(3, Mass3.Saved.Size()));   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerSeq(3, Mass3.Saved.Size()));
             Check(*subset, mode, 5, false);
         }
     }
@@ -1104,7 +1104,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             conf.WriteBTreeIndex = (mode == FlatIndex ? false : true);
 
             TAutoPtr<TSubset> subset = TMake(*mass, conf).Mixed(0, partsCount, TMixerRnd(partsCount), history ? 0.7 : 0);
-            
+
             Check(*subset, mode, 10, false);
         }
     }
@@ -1124,7 +1124,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             conf.WriteBTreeIndex = (mode == FlatIndex ? false : true);
 
             TAutoPtr<TSubset> subset = TMake(*mass, conf).Mixed(0, partsCount, TMixerRnd(partsCount));
-            
+
             Check(*subset, mode, 10, false, false);
         }
     }
@@ -1144,7 +1144,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             conf.WriteBTreeIndex = (mode == FlatIndex ? false : true);
 
             TAutoPtr<TSubset> subset = TMake(*mass, conf).Mixed(0, partsCount, TMixerSeq(partsCount, mass->Saved.Size()));
-            
+
             Check(*subset, mode, 10, false, false);
         }
     }

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -317,7 +317,7 @@ ui64 ResetRowSkips(NTable::TIteratorStats& stats)
         std::exchange(stats.InvisibleRowSkips, 0UL);
 }
 
-// nota that reader captures state reference and must be used only
+// note that reader captures state reference and must be used only
 // after checking that state is still alive, i.e. read can be aborted
 // between Execute() and Complete()
 class TReader {
@@ -331,7 +331,7 @@ class TReader {
 
     std::vector<NScheme::TTypeInfo> ColumnTypes;
 
-    ui32 FirstUnprocessedQuery; // must be unsigned
+    ui64 FirstUnprocessedQuery; // must be unsigned
     TString LastProcessedKey;
     bool LastProcessedKeyErased = false;
 
@@ -457,7 +457,7 @@ public:
     EReadStatus ReadKey(
         TTransactionContext& txc,
         const TSerializedCellVec& keyCells,
-        size_t keyIndex)
+        ui64 keyIndex)
     {
         if (keyCells.GetCells().size() != TableInfo.KeyColumnCount) {
             // key prefix, treat it as range [prefix, null, null] - [prefix, +inf, +inf]
@@ -524,19 +524,19 @@ public:
             // key prefix, treat it as range [prefix, null, null] - [prefix, +inf, +inf]
             auto minKey = ToRawTypeValue(keyCells.GetCells(), TableInfo, true);
             auto maxKey = ToRawTypeValue(keyCells.GetCells(), TableInfo, false);
-            return Precharge(txc.DB, minKey, maxKey, State.Reverse);
+            return Precharge(txc.DB, minKey, maxKey, State.Reverse).Ready;
         } else {
             auto key = ToRawTypeValue(keyCells.GetCells(), TableInfo, true);
-            return Precharge(txc.DB, key, key, State.Reverse);
+            return Precharge(txc.DB, key, key, State.Reverse).Ready;
         }
     }
 
     bool PrechargeKeysAfter(
         TTransactionContext& txc,
-        ui32 queryIndex)
+        ui64 queryIndex)
     {
         if (UsePrechargeForExtBlobs) {
-            // This is slower for a general case, but faster for the case when we know 
+            // This is slower for a general case, but faster for the case when we know
             // that we have external blobs.
             ui64 rowsLeft = GetRowsLeft();
             ui64 prechargedRowsSize = 0;
@@ -554,7 +554,7 @@ public:
                 if (!(queryIndex < State.Request->Keys.size())) {
                     break;
                 }
-                
+
                 const auto key = ToRawTypeValue(State.Request->Keys[queryIndex].GetCells(), TableInfo, true);
 
                 NTable::TRowState rowState;
@@ -564,7 +564,7 @@ public:
 
                 if (txc.Env.MissingReferencesSize()) {
                     ready = false;
-                    
+
                     prechargedRowsSize += EstimateSize(*rowState);
                 }
 
@@ -602,6 +602,59 @@ public:
         return ready;
     }
 
+    /**
+     * Precharges all remaining ranges in the request (after the current range).
+     *
+     * @param[in,out] txc The transaction context
+     * @param[in] currentRangeIndex The index of the current range (already processed)
+     *
+     * @return If true, all the necessary pages are already in the cache
+     */
+    bool PrechargeRangesAfter(TTransactionContext& txc, ui64 currentRangeIndex) {
+        ui64 prechargedItems = 0;
+        ui64 prechargedBytes = 0;
+        bool ready = true;
+
+        while (true) {
+            // Move to the next query according to the requested direction
+            if (!State.Reverse) {
+                ++currentRangeIndex;
+            } else {
+                --currentRangeIndex;
+            }
+
+            // This works even for the overflow from 0-- because the index is unsigned
+            if (currentRangeIndex >= State.Request->Ranges.size()) {
+                break;
+            }
+
+            // Precharge the current range
+            //
+            // NOTE: CheckRequestAndInit() already normalizes To/From fields
+            //       in all ranges to make sure each key is padded correctly
+            //       according to the FromInclusive and ToInclusive fields
+            const auto& range = State.Request->Ranges[currentRangeIndex];
+
+            const auto prechargeResult = Precharge(
+                txc.DB,
+                ToRawTypeValue(range.To.GetCells(), TableInfo, false),
+                ToRawTypeValue(range.From.GetCells(), TableInfo, false),
+                State.Reverse
+            );
+
+            ready &= prechargeResult.Ready;
+            prechargedItems += prechargeResult.ItemsPrecharged;
+            prechargedBytes += prechargeResult.BytesPrecharged;
+
+            // Do not precharge more than the quota limits in the request
+            if (ShouldStop(prechargedItems, prechargedBytes)) {
+                break;
+            }
+        }
+
+        return ready;
+    }
+
     // TODO: merge ReadRanges and ReadKeys to single template Read?
 
     bool ReadRanges(TTransactionContext& txc) {
@@ -623,8 +676,7 @@ public:
             case EReadStatus::Done:
                 break;
             case EReadStatus::NeedData:
-                // Note: ReadRange has already precharged current range and
-                //       we don't precharge multiple ranges as opposed to keys
+                PrechargeRangesAfter(txc, FirstUnprocessedQuery);
                 return false;
             case EReadStatus::NeedContinue:
                 return true;
@@ -679,7 +731,6 @@ public:
     bool Read(TTransactionContext& txc) {
         // TODO: consider trying to precharge multiple records at once in case
         // when first precharge fails?
-
         if (!State.Request->Keys.empty()) {
             return ReadKeys(txc);
         }
@@ -795,7 +846,7 @@ public:
             record.SetRowCount(RowsRead);
         }
 
-        // not that in case of empty columns set, here we have 0 bytes
+        // note that in case of empty columns set, here we have 0 bytes
         // and if is false
         BytesInResult = BlockBuilder.Bytes();
         if (BytesInResult) {
@@ -951,7 +1002,7 @@ private:
         return bytesLeft;
     }
 
-    bool Precharge(
+    NTable::TPrechargeResult Precharge(
         NTable::TDatabase& db,
         NTable::TRawVals minKey,
         NTable::TRawVals maxKey,
@@ -2110,7 +2161,7 @@ public:
         for (size_t i = 0; i < request->Ranges.size(); ++i) {
             auto& range = request->Ranges[i];
             auto& keyFrom = range.From;
-            auto& keyTo = request->Ranges[i].To;
+            auto& keyTo = range.To;
 
             if (range.FromInclusive && keyFrom.GetCells().size() != TableInfo.KeyColumnCount) {
                 keyFrom = ExtendWithNulls(keyFrom, TableInfo.KeyColumnCount);
@@ -2218,7 +2269,7 @@ public:
                 << " (shard# " << Self->TabletID() << " node# " << ctx.SelfID.NodeId() << " state# " << DatashardStateName(Self->State) << ")");
             Result->Record.SetReadId(state.ReadId.ReadId);
             Self->SendImmediateReadResult(state.ReadId.Sender, Result.release(), 0, state.SessionId, request->ReadSpan.GetTraceId());
-            
+
             request->ReadSpan.EndError("Iterator aborted");
             Self->DeleteReadIterator(it);
             return;
@@ -3221,7 +3272,7 @@ public:
         } else {
             LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID() << " read iterator# " << state.ReadId
                 << " finished in ReadContinue");
-            
+
             state.Request->ReadSpan.EndOk();
             Self->DeleteReadIterator(it);
         }
@@ -3231,7 +3282,7 @@ public:
 void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ctx) {
     // Note that we mutate this request below
     auto* request = ev->Get();
-    
+
     if (ev->TraceId && !request->ReadSpan) {
         request->ReadSpan = NWilson::TSpan(TWilsonTablet::TabletTopLevel, std::move(ev->TraceId), "Datashard.Read", NWilson::EFlags::AUTO_END);
         if (request->ReadSpan) {
@@ -3244,7 +3295,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
     const auto& record = request->Record;
     if (Y_UNLIKELY(!record.HasReadId())) {
         TString msg = TStringBuilder() << "Missing ReadId at shard " << TabletID();
-        
+
         auto result = MakeEvReadResult(ctx.SelfID.NodeId());
         SetStatusError(result->Record, Ydb::StatusIds::BAD_REQUEST, msg);
         ctx.Send(ev->Sender, result.release());
@@ -3264,7 +3315,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
 
     auto replyWithError = [&] (auto code, const auto& msg) {
         auto result = MakeEvReadResult(ctx.SelfID.NodeId());
-        
+
         SetStatusError(
             result->Record,
             code,

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -637,8 +637,8 @@ public:
 
             const auto prechargeResult = Precharge(
                 txc.DB,
-                ToRawTypeValue(range.From.GetCells(), TableInfo, false),
-                ToRawTypeValue(range.To.GetCells(), TableInfo, false),
+                ToRawTypeValue(range.From.GetCells(), TableInfo, range.FromInclusive),
+                ToRawTypeValue(range.To.GetCells(), TableInfo, !range.ToInclusive),
                 State.Reverse
             );
 

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -637,8 +637,8 @@ public:
 
             const auto prechargeResult = Precharge(
                 txc.DB,
-                ToRawTypeValue(range.To.GetCells(), TableInfo, false),
                 ToRawTypeValue(range.From.GetCells(), TableInfo, false),
+                ToRawTypeValue(range.To.GetCells(), TableInfo, false),
                 State.Reverse
             );
 

--- a/ydb/core/tx/datashard/datashard_kqp_compute.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.cpp
@@ -239,7 +239,7 @@ bool TKqpDatashardComputeContext::PinPages(const TVector<IEngineFlat::TValidated
                                          adjustLimit(key.RangeLimits.ItemsLimit),
                                          adjustLimit(key.RangeLimits.BytesLimit),
                                          key.Reverse ? NTable::EDirection::Reverse : NTable::EDirection::Forward,
-                                         GetMvccVersion());
+                                         GetMvccVersion()).Ready;
 
         LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Run precharge on table " << tableInfo->Name
             << ", columns: [" << JoinSeq(", ", columnTags) << "]"

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -90,11 +90,11 @@ TArrayRef<const NIceDb::TUpdateOp> TDataShardUserDb::RemoveDefaultColumnsIfNeede
         // row not exist - no changes need
         return ops;
     }
-    
+
     //newOps is ops without last DefaultFilledColumnCount values
     auto newOps = TArrayRef<const NIceDb::TUpdateOp> (ops.begin(), ops.end() - DefaultFilledColumnCount);
-    
-    return newOps;  
+
+    return newOps;
 }
 
 
@@ -235,11 +235,11 @@ void TDataShardUserDb::IncrementRow(
     }
 
     auto currentRow = GetRowState(tableId, key, columns);
-    
+
     if (currentRow.Size() == 0) {
         return;
     }
-    
+
     TStackVec<NIceDb::TUpdateOp> newOps(ops.size());
 
     Y_ENSURE(currentRow.Size() == ops.size());
@@ -250,12 +250,12 @@ void TDataShardUserDb::IncrementRow(
 
     for (size_t i = 0; i < ops.size(); i++) {
         auto vtype = scheme.GetColumnInfo(tableInfo, ops[i].Tag)->PType.GetTypeId();
-       
+
         auto current = currentRow.Get(i);
         auto delta = ops[i].AsCell();
-        
+
         NFormats::AddTwoCells(incrementResults[i], current, delta, vtype);
-            
+
         TRawTypeValue rawTypeValue(incrementResults[i].Data(), incrementResults[i].Size(), vtype);
         newOps[i] = NIceDb::TUpdateOp(ops[i].Tag, ops[i].Op, rawTypeValue);
     }
@@ -276,7 +276,7 @@ void TDataShardUserDb::EraseRow(
     UpsertRowInt(NTable::ERowOp::Erase, tableId, localTableId, key, {});
 
     ui64 keyBytes = CalculateKeyBytes(key);
-    
+
     Counters.NEraseRow++;
     Counters.EraseRowBytes += keyBytes + 8;
 }
@@ -288,12 +288,12 @@ bool TDataShardUserDb::PrechargeRow(
     auto localTableId = Self.GetLocalTableId(tableId);
     Y_ENSURE(localTableId != 0, "Unexpected PrechargeRow for an unknown table");
 
-    return Db.Precharge(localTableId, key, key, {}, 0, Max<ui64>(), Max<ui64>());     
+    return Db.Precharge(localTableId, key, key, {}, 0, Max<ui64>(), Max<ui64>()).Ready;
 }
 
 void TDataShardUserDb::IncreaseUpdateCounters(
-    const TArrayRef<const TRawTypeValue> key, 
-    const TArrayRef<const NIceDb::TUpdateOp> ops) 
+    const TArrayRef<const TRawTypeValue> key,
+    const TArrayRef<const NIceDb::TUpdateOp> ops)
 {
     ui64 valueBytes = CalculateValueBytes(ops);
     ui64 keyBytes = CalculateKeyBytes(key);
@@ -317,7 +317,7 @@ void TDataShardUserDb::UpsertRowInt(
     const TTableId& tableId,
     ui64 localTableId,
     const TArrayRef<const TRawTypeValue> key,
-    const TArrayRef<const NIceDb::TUpdateOp> ops) 
+    const TArrayRef<const NIceDb::TUpdateOp> ops)
 {
     TSmallVec<TCell> keyCells = ConvertTableKeys(key);
 

--- a/ydb/core/tx/datashard/read_iterator.h
+++ b/ydb/core/tx/datashard/read_iterator.h
@@ -211,7 +211,7 @@ public:
     // note that we send SeqNo's starting from 1
     ui64 SeqNo = 0;
     ui64 LastAckSeqNo = 0;
-    ui32 FirstUnprocessedQuery = 0;
+    ui64 FirstUnprocessedQuery = 0; // must be unsigned
     TString LastProcessedKey;
     bool LastProcessedKeyErased = false;
 


### PR DESCRIPTION
### Changelog entry

Make queries like `SELECT ... WHERE x NOT IN (SELECT x FROM ...)` about 4 times faster

### Changelog category

* Performance improvement

### Description for reviewers

* Changed flat and B-Tree indices to return the number of items/bytes from the precharge operations
* Changed the local database to return the number of items/bytes from the precharge operations
* Fixed a bug in the `EvRead` handler, where it would hang if there are >= 2^32 keys/ranges in the request
* Changed the `EvRead` handler to precharge all remaining ranges (up to the quota) after hitting a page fault
