### PR TITLE
Fix that disks may become INACTIVE during cluster bootstrap

### DIFF
--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -106,6 +106,7 @@ private:
     class TTxStoreWalleTask;
     class TTxUpdateConfig;
     class TTxUpdateDowntimes;
+    class TTxStoreFirstBootTimestamp;
 
     struct TActionOptions {
         TDuration PermissionDuration;
@@ -150,6 +151,7 @@ private:
     ITransaction *CreateTxUpdateConfig(TEvCms::TEvSetConfigRequest::TPtr &ev);
     ITransaction *CreateTxUpdateConfig(TEvConsole::TEvConfigNotificationRequest::TPtr &ev);
     ITransaction *CreateTxUpdateDowntimes();
+    ITransaction *CreateTxStoreFirstBootTimestamp();
 
     static void AuditLog(const TActorContext &ctx, const TString &message) {
         NCms::AuditLog("CMS tablet", message, ctx);

--- a/ydb/core/cms/cms_state.h
+++ b/ydb/core/cms/cms_state.h
@@ -43,6 +43,7 @@ struct TCmsState : public TAtomicRefCount<TCmsState> {
     ui64 NextRequestId = 0;
     ui64 NextNotificationId = 0;
     ui64 LastLogRecordTimestamp = 0;
+    TInstant FirstBootTimestamp;
 
     // State of Wall-E tasks.
     THashMap<TString, TTaskInfo> WalleTasks;

--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -38,7 +38,7 @@ public:
         if (!db.Precharge<Schema>())
             return false;
 
-        auto paramRow = db.Table<Schema::Param>().Key(1).Select<Schema::Param::TColumns>();
+        auto paramRow = db.Table<Schema::Param>().Key(Schema::Param::Key).Select<Schema::Param::TColumns>();
         auto permissionRowset = db.Table<Schema::Permission>().Range().Select<Schema::Permission::TColumns>();
         auto requestRowset = db.Table<Schema::Request>().Range().Select<Schema::Request::TColumns>();
         auto walleTaskRowset = db.Table<Schema::WalleTask>().Range().Select<Schema::WalleTask::TColumns>();

--- a/ydb/core/cms/cms_tx_process_notification.cpp
+++ b/ydb/core/cms/cms_tx_process_notification.cpp
@@ -30,7 +30,7 @@ public:
             Response->Record.SetNotificationId(id);
 
             NIceDb::TNiceDb db(txc.DB);
-            db.Table<Schema::Param>().Key(1)
+            db.Table<Schema::Param>().Key(Schema::Param::Key)
                 .Update(NIceDb::TUpdate<Schema::Param::NextNotificationID>(Self->State->NextNotificationId));
 
             TString notificationStr;

--- a/ydb/core/cms/cms_tx_store_first_boot_timestamp.cpp
+++ b/ydb/core/cms/cms_tx_store_first_boot_timestamp.cpp
@@ -1,0 +1,33 @@
+#include "cms_impl.h"
+#include "scheme.h"
+
+namespace NKikimr::NCms {
+
+class TCms::TTxStoreFirstBootTimestamp : public TTransactionBase<TCms> {
+public:
+    TTxStoreFirstBootTimestamp(TCms *self)
+        : TBase(self)
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_STORE_FIRST_BOOT_TIMESTAMP; }
+
+    bool Execute(TTransactionContext &txc, const TActorContext &ctx) override {
+        LOG_DEBUG_S(ctx, NKikimrServices::CMS, "TTxStoreFirstBootTimestamp Execute");
+
+        NIceDb::TNiceDb db(txc.DB);
+        db.Table<Schema::Param>().Key(1)
+            .Update<Schema::Param::FirstBootTimestamp>(Self->State->FirstBootTimestamp.MicroSeconds());
+
+        return true;
+    }
+
+    void Complete(const TActorContext &ctx) override {
+        LOG_DEBUG(ctx, NKikimrServices::CMS, "TTxStoreFirstBootTimestamp Complete");
+    }
+};
+
+ITransaction *TCms::CreateTxStoreFirstBootTimestamp() {
+    return new TTxStoreFirstBootTimestamp(this);
+}
+
+} // namespace NKikimr::NCms

--- a/ydb/core/cms/cms_tx_store_first_boot_timestamp.cpp
+++ b/ydb/core/cms/cms_tx_store_first_boot_timestamp.cpp
@@ -15,7 +15,7 @@ public:
         LOG_DEBUG_S(ctx, NKikimrServices::CMS, "TTxStoreFirstBootTimestamp Execute");
 
         NIceDb::TNiceDb db(txc.DB);
-        db.Table<Schema::Param>().Key(1)
+        db.Table<Schema::Param>().Key(Schema::Param::Key)
             .Update<Schema::Param::FirstBootTimestamp>(Self->State->FirstBootTimestamp.MicroSeconds());
 
         return true;

--- a/ydb/core/cms/cms_tx_store_permissions.cpp
+++ b/ydb/core/cms/cms_tx_store_permissions.cpp
@@ -26,8 +26,10 @@ public:
         LOG_DEBUG(ctx, NKikimrServices::CMS, "TTxStorePermissions Execute");
 
         NIceDb::TNiceDb db(txc.DB);
-        db.Table<Schema::Param>().Key(1).Update(NIceDb::TUpdate<Schema::Param::NextPermissionID>(NextPermissionId),
-                                                NIceDb::TUpdate<Schema::Param::NextRequestID>(NextRequestId));
+        db.Table<Schema::Param>().Key(Schema::Param::Key).Update(
+            NIceDb::TUpdate<Schema::Param::NextPermissionID>(NextPermissionId),
+            NIceDb::TUpdate<Schema::Param::NextRequestID>(NextRequestId)
+        );
 
         const auto &rec = Response->Get<TEvCms::TEvPermissionResponse>()->Record;
 

--- a/ydb/core/cms/cms_tx_update_config.cpp
+++ b/ydb/core/cms/cms_tx_update_config.cpp
@@ -24,7 +24,7 @@ public:
 
         if (!google::protobuf::util::MessageDifferencer::Equals(Config, Self->State->ConfigProto)) {
             NIceDb::TNiceDb db(txc.DB);
-            db.Table<Schema::Param>().Key(1)
+            db.Table<Schema::Param>().Key(Schema::Param::Key)
                 .Update<Schema::Param::Config>(Config);
 
             Modify = true;

--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -78,6 +78,8 @@ struct TCmsSentinelConfig {
 
     TStateStorageSelfHealConfig StateStorageSelfHealConfig;
 
+    TDuration InitialDeploymentGracePeriod;
+
     void Serialize(NKikimrCms::TCmsConfig::TSentinelConfig &config) const {
         config.SetEnable(Enable);
         config.SetDryRun(DryRun);
@@ -100,6 +102,8 @@ struct TCmsSentinelConfig {
 
         SaveStateLimits(config);
         SaveEvictVDisksStatus(config);
+
+        config.SetInitialDeploymentGracePeriod(InitialDeploymentGracePeriod.GetValue());
     }
 
     void Deserialize(const NKikimrCms::TCmsConfig::TSentinelConfig &config) {
@@ -125,6 +129,8 @@ struct TCmsSentinelConfig {
         StateLimits.swap(newStateLimits);
 
         EvictVDisksStatus = LoadEvictVDisksStatus(config);
+
+        InitialDeploymentGracePeriod = TDuration::MicroSeconds(config.GetInitialDeploymentGracePeriod());
     }
 
     void SaveStateLimits(NKikimrCms::TCmsConfig::TSentinelConfig &config) const {

--- a/ydb/core/cms/scheme.h
+++ b/ydb/core/cms/scheme.h
@@ -15,10 +15,11 @@ struct Schema : NIceDb::Schema {
         struct NextNotificationID : Column<4, NScheme::NTypeIds::Uint64> {};
         struct Config : Column<5, NScheme::NTypeIds::String> { using Type = NKikimrCms::TCmsConfig; };
         struct LastLogRecordTimestamp : Column<6, NScheme::NTypeIds::Uint64> {};
+        struct FirstBootTimestamp : Column<7, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<ID>;
         using TColumns = TableColumns<ID, NextPermissionID, NextRequestID, NextNotificationID,
-            Config, LastLogRecordTimestamp>;
+            Config, LastLogRecordTimestamp, FirstBootTimestamp>;
     };
 
     struct Permission : Table<2> {

--- a/ydb/core/cms/scheme.h
+++ b/ydb/core/cms/scheme.h
@@ -9,6 +9,8 @@ namespace NKikimr::NCms {
 
 struct Schema : NIceDb::Schema {
     struct Param : Table<1> {
+        static constexpr ui32 Key = 1;
+
         struct ID : Column<1, NScheme::NTypeIds::Uint32> {};
         struct NextPermissionID : Column<2, NScheme::NTypeIds::Uint64> {};
         struct NextRequestID : Column<3, NScheme::NTypeIds::Uint64> {};

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -238,7 +238,7 @@ bool TPDiskStatusComputer::IsInitialDeploymentGracePeriod() const {
 
 
 TPDiskStatus::TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits)
-    : TPDiskStatus(defaultStateLimit, goodStateLimit, stateLimits, TInstant::Zero(), TDuration::Zero())
+    : TPDiskStatus(initialStatus, defaultStateLimit, goodStateLimit, stateLimits, TInstant::Zero(), TDuration::Zero())
 {}
 
 TPDiskStatus::TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit,

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -228,13 +228,18 @@ void TPDiskStatusComputer::ResetForcedStatus() {
 
 bool TPDiskStatusComputer::IsInitialDeploymentGracePeriod() const {
     if (TlsActivationContext) {
-        return CMSFirstBootTimestamp + InitialDeploymentGracePeriod < TActivationContext::Now();
+        return CMSFirstBootTimestamp + InitialDeploymentGracePeriod > TActivationContext::Now();
     } else {
         return false; // unsupported outside of actorsystem
     }
 }
 
 /// TPDiskStatus
+
+
+TPDiskStatus::TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits)
+    : TPDiskStatus(defaultStateLimit, goodStateLimit, stateLimits, TInstant::Zero(), TDuration::Zero())
+{}
 
 TPDiskStatus::TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit,
                            const ui32& goodStateLimit, const TLimitsMap& stateLimits,

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -16,7 +16,8 @@ using TLimitsMap = TMap<EPDiskState, ui32>;
 
 class TPDiskStatusComputer {
 public:
-    explicit TPDiskStatusComputer(const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits);
+    explicit TPDiskStatusComputer(const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits,
+                                  TInstant cmsFirstBootTimestamp, const TDuration& initialDeploymentGracePeriod);
 
     void AddState(EPDiskState state, bool isNodeLocked);
     EPDiskStatus Compute(EPDiskStatus current, TString& reason) const;
@@ -31,6 +32,8 @@ public:
     bool HasForcedStatus() const;
     void ResetForcedStatus();
 
+    bool IsInitialDeploymentGracePeriod() const;
+
 private:
     const ui32& DefaultStateLimit;
     const ui32& GoodStateLimit;
@@ -43,11 +46,16 @@ private:
 
     mutable bool HadBadStateRecently = false;
 
+    TInstant CMSFirstBootTimestamp;
+    const TDuration& InitialDeploymentGracePeriod;
+
 }; // TPDiskStatusComputer
 
 class TPDiskStatus: public TPDiskStatusComputer {
 public:
-    explicit TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits);
+    explicit TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit,
+                          const ui32& goodStateLimit, const TLimitsMap& stateLimits,
+                          TInstant cmsFirstBootTimestamp, const TDuration& initialDeploymentGracePeriod);
 
     void AddState(EPDiskState state, bool isNodeLocked);
     bool IsChanged() const;
@@ -96,7 +104,9 @@ struct TPDiskInfo
     ui32 PrevStatusChangeAttempt = 0;
     EIgnoreReason IgnoreReason = NKikimrCms::TPDiskInfo::NOT_IGNORED;
 
-    explicit TPDiskInfo(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits);
+    explicit TPDiskInfo(EPDiskStatus initialStatus, const ui32& defaultStateLimit,
+                        const ui32& goodStateLimit, const TLimitsMap& stateLimits,
+                        TInstant cmsFirstBootTimestamp, const TDuration& initialDeploymentGracePeriod);
 
     bool IsTouched() const { return Touched; }
     void Touch() { Touched = true; }

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -53,6 +53,7 @@ private:
 
 class TPDiskStatus: public TPDiskStatusComputer {
 public:
+    explicit TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits);
     explicit TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit,
                           const ui32& goodStateLimit, const TLimitsMap& stateLimits,
                           TInstant cmsFirstBootTimestamp, const TDuration& initialDeploymentGracePeriod);

--- a/ydb/core/cms/sentinel_ut.cpp
+++ b/ydb/core/cms/sentinel_ut.cpp
@@ -4,6 +4,8 @@
 #include "sentinel_impl.h"
 #include "cms_impl.h"
 
+#include <ydb/core/testlib/actors/block_events.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/hash_set.h>
@@ -866,6 +868,57 @@ Y_UNIT_TEST_SUITE(TSentinelTests) {
         UNIT_ASSERT(computer.GetCurrentNodeState() == TNodeStatusComputer::ENodeState::GOOD);
     }
 
+    Y_UNIT_TEST(InitialDeploymentGracePeriod) {
+        NKikimrCms::TCmsConfig config;
+        config.MutableSentinelConfig()->SetInitialDeploymentGracePeriod(TDuration::Minutes(10).GetValue());
+        TTestEnv env(8, 4, config);
+
+        const TPDiskID id = env.RandomPDiskID();
+
+        TBlockEvents<TEvBlobStorage::TEvControllerConfigRequest> block(env, [](const auto& ev){
+            const auto& record = ev->Get()->Record;
+
+            if (record.GetRequest().CommandSize() > 0) {
+                return record.GetRequest().GetCommand(0).HasUpdateDriveStatus();
+            }
+
+            return false;
+        });
+
+        Cerr << "...Initializing" << Endl;
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::Initial);
+
+        Cerr << "...Still initializing" << Endl;
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::Initial);
+
+        Cerr << "...Ready to work" << Endl;
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::Normal);
+
+        Cerr << "...Working normally" << Endl;
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::Normal);
+
+        UNIT_ASSERT_C(block.empty(), "Unexpected status change requests");
+        block.Stop();
+
+        Cerr << "...Disconnected" << Endl;
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::NodeDisconnected, NKikimrBlobStorage::INACTIVE);
+
+        Cerr << "...Working normally again" << Endl;
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::Normal, NKikimrBlobStorage::ACTIVE);
+
+        Cerr << "...Initial deployment grace period is over" << Endl;
+        env.AdvanceCurrentTime(TDuration::Minutes(15));
+
+        Cerr << "...Disconnected" << Endl;
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::NodeDisconnected, NKikimrBlobStorage::INACTIVE);
+
+        Cerr << "...Working normally again, but no fast path to ACTIVE" << Endl;
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::Normal, NKikimrBlobStorage::INACTIVE);
+        for (ui32 i = 1; i < DefaultStateLimit - 1; ++i) {
+            env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::Normal);
+        }
+        env.SetPDiskState({id}, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::ACTIVE);
+    }
 } // TSentinelTests
 
 }

--- a/ydb/core/cms/sentinel_ut_helpers.h
+++ b/ydb/core/cms/sentinel_ut_helpers.h
@@ -83,7 +83,7 @@ class TTestEnv: public TCmsTestEnv {
     }
 
 public:
-    explicit TTestEnv(ui32 nodeCount, ui32 pdisks, const NKikimrCms::TCmsConfig &config = {})
+    explicit TTestEnv(ui32 nodeCount, ui32 pdisks, NKikimrCms::TCmsConfig config = {})
         : TCmsTestEnv(nodeCount, pdisks)
     {
         SetLogPriority(NKikimrServices::CMS, NLog::PRI_DEBUG);
@@ -123,6 +123,11 @@ public:
         });
 
         State = new TCmsState;
+
+        auto* sentinelConfig = config.MutableSentinelConfig();
+        if (!sentinelConfig->HasInitialDeploymentGracePeriod()) {
+            sentinelConfig->SetInitialDeploymentGracePeriod(0);
+        }
         State->Config.Deserialize(config);
         MockClusterInfo(State->ClusterInfo);
         State->CmsActorId = GetSender();

--- a/ydb/core/cms/ut_sentinel/ya.make
+++ b/ydb/core/cms/ut_sentinel/ya.make
@@ -1,5 +1,7 @@
 UNITTEST_FOR(ydb/core/cms)
 
+FORK_SUBTESTS()
+
 SIZE(MEDIUM)
 
 PEERDIR(

--- a/ydb/core/cms/ya.make
+++ b/ydb/core/cms/ya.make
@@ -21,6 +21,7 @@ SRCS(
     cms_tx_remove_permissions.cpp
     cms_tx_remove_request.cpp
     cms_tx_remove_task.cpp
+    cms_tx_store_first_boot_timestamp.cpp
     cms_tx_store_permissions.cpp
     cms_tx_store_walle_task.cpp
     cms_tx_update_config.cpp

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -488,6 +488,7 @@ message TCmsConfig {
         optional uint32 GoodStateLimit = 16 [default = 5];
 
         optional TStateStorageSelfHealConfig StateStorageSelfHealConfig = 19;
+        optional uint64 InitialDeploymentGracePeriod = 20 [default = 600000000];
     }
 
     message TLogConfig {

--- a/ydb/core/protos/counters_cms.proto
+++ b/ydb/core/protos/counters_cms.proto
@@ -64,4 +64,5 @@ enum ETxTypes {
     TXTYPE_STORE_WALLE_TASK = 13                          [(TxTypeOpts) = {Name: "TxStoreWalleTask"}];
     TXTYPE_UPDATE_CONFIG = 14                             [(TxTypeOpts) = {Name: "TxUpdateConfig"}];
     TXTYPE_UPDATE_DOWNTIMES = 15                          [(TxTypeOpts) = {Name: "TxUpdateDowntimes"}];
+    TXTYPE_STORE_FIRST_BOOT_TIMESTAMP = 16                [(TxTypeOpts) = {Name: "TxStoreFirstBootTimestamp"}];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes https://github.com/ydb-platform/ydb/issues/27228

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Adds `FirstBootTimestamp` tracking in CMS persistent state
- Introduces `InitialDeploymentGracePeriod` configuration parameter (default: 10 minutes)
- Modifies PDisk status computation to skip `INACTIVE` phase for `Normal` state within grace period