### PR TITLE
25-3: schemeshard: temporary break alter database scheme limits

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -487,7 +487,9 @@ void TSideEffects::DoUpdateTenant(TSchemeShard* ss, NTabletFlatExecutor::TTransa
             if (subDomain->GetDatabaseQuotas()) {
                 message->Record.MutableDatabaseQuotas()->CopyFrom(*subDomain->GetDatabaseQuotas());
             }
-            message->Record.MutableSchemeLimits()->CopyFrom(subDomain->GetSchemeLimits().AsProto());
+            if (AppData()->FeatureFlags.GetEnableAlterDatabase()) {
+                message->Record.MutableSchemeLimits()->CopyFrom(subDomain->GetSchemeLimits().AsProto());
+            }
             if (const auto& auditSettings = subDomain->GetAuditSettings()) {
                 message->Record.MutableAuditSettings()->CopyFrom(*auditSettings);
             }

--- a/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/testlib/actors/wait_events.h>  // for TWaitForFirstEvent
 
 #include <ydb/public/lib/value/value.h>
 
@@ -2089,5 +2090,230 @@ Y_UNIT_TEST_SUITE(TSchemeShardExtSubDomainTest) {
                             Columns { Name: "Value"      Type: "Utf8"}
                             KeyColumnNames: ["key"]
                 )", {NKikimrScheme::StatusQuotaExceeded});
+    }
+
+    Y_UNIT_TEST(AlterSchemeLimits_EnableAlterDatabase) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime,
+            TTestEnvOptions()
+                .EnableRealSystemViewPaths(false)
+                .EnableAlterDatabase(true)
+        );
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot",
+            R"(Name: "USER_0")"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
+            R"(
+                Name: "USER_0"
+                PlanResolution: 50
+                Coordinators: 1
+                Mediators: 1
+                TimeCastBucketsPerMediator: 2
+                ExternalSchemeShard: true
+                StoragePools {
+                    Name: "/dc-1/users/tenant-1:hdd"
+                    Kind: "hdd"
+                }
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        ui64 tenantSchemeShard = 0;
+        // test what the parent knows about the subdomain
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::IsExternalSubDomain("USER_0"),
+            NLs::ExtractTenantSchemeshard(&tenantSchemeShard),
+            NLs::ShardsInsideDomain(3),
+            NLs::PathsInsideDomain(0)
+        });
+
+        NSchemeShard::TSchemeLimits defaultLimits;
+        NSchemeShard::TSchemeLimits directlySetLimits;
+        directlySetLimits.MaxShards = 10;
+        directlySetLimits.MaxShardsInPath = 10;
+        directlySetLimits.MaxPaths = 10;
+        directlySetLimits.MaxChildrenInDir = 10;
+        NSchemeShard::TSchemeLimits alteredLimits;
+        alteredLimits.MaxShards = 7;
+        alteredLimits.MaxShardsInPath = 3;
+        alteredLimits.MaxPaths = 5;
+        alteredLimits.MaxChildrenInDir = 3;
+
+        // test that subdomain scheme limits are default
+        TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::SchemeLimits(defaultLimits.AsProto()),
+        });
+
+        // change subdomain scheme limits the prehistoric way
+        SetSchemeshardSchemaLimits(runtime, directlySetLimits, tenantSchemeShard);
+
+        {
+            // test that the root knows about the subdomain
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+                NLs::PathExist,
+                NLs::SchemeLimits(defaultLimits.AsProto()),
+            });
+
+            // test that the subdomain scheme limits are changed to prehistoric
+            TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0"), {
+                NLs::PathExist,
+                NLs::SchemeLimits(directlySetLimits.AsProto())
+            });
+        }
+
+        TWaitForFirstEvent<TEvSchemeShard::TEvUpdateTenantSchemeShard> syncWaiter(runtime, [](const TEvSchemeShard::TEvUpdateTenantSchemeShard::TPtr& ev) {
+            return ev.Get()->Get()->Record.HasSchemeLimits();
+        });
+
+        // change subdomain scheme limits with alter-extsubdomain
+        TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
+            Sprintf(R"(
+                Name: "USER_0"
+                SchemeLimits {
+                    MaxShards: %lu
+                    MaxShardsInPath: %lu
+                    MaxPaths: %lu
+                    MaxChildrenInDir: %lu
+                }
+            )", alteredLimits.MaxShards, alteredLimits.MaxShardsInPath, alteredLimits.MaxPaths, alteredLimits.MaxChildrenInDir
+        ));
+        env.TestWaitNotification(runtime, txId);
+
+        syncWaiter.Wait();
+        syncWaiter.Stop();
+
+        {
+            // test that the root knows about the subdomain
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+                NLs::PathExist,
+                NLs::SchemeLimits(alteredLimits.AsProto()),
+            });
+
+            // test that the subdomain scheme limits are changed to altered limits
+            TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0"), {
+                NLs::PathExist,
+                NLs::SchemeLimits(alteredLimits.AsProto())
+            });
+        }
+    }
+
+    Y_UNIT_TEST(AlterSchemeLimits_NoEnableAlterDatabase) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime,
+            TTestEnvOptions()
+                .EnableRealSystemViewPaths(false)
+                .EnableAlterDatabase(false)
+        );
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot",
+            R"(Name: "USER_0")"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
+            R"(
+                Name: "USER_0"
+                PlanResolution: 50
+                Coordinators: 1
+                Mediators: 1
+                TimeCastBucketsPerMediator: 2
+                ExternalSchemeShard: true
+                StoragePools {
+                    Name: "/dc-1/users/tenant-1:hdd"
+                    Kind: "hdd"
+                }
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        ui64 tenantSchemeShard = 0;
+        // test what the parent knows about the subdomain
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::IsExternalSubDomain("USER_0"),
+            NLs::ExtractTenantSchemeshard(&tenantSchemeShard),
+            NLs::ShardsInsideDomain(3),
+            NLs::PathsInsideDomain(0)
+        });
+
+        NSchemeShard::TSchemeLimits defaultLimits;
+        NSchemeShard::TSchemeLimits directlySetLimits;
+        directlySetLimits.MaxShards = 10;
+        directlySetLimits.MaxShardsInPath = 10;
+        directlySetLimits.MaxPaths = 10;
+        directlySetLimits.MaxChildrenInDir = 10;
+        NSchemeShard::TSchemeLimits alteredLimits;
+        alteredLimits.MaxShards = 7;
+        alteredLimits.MaxShardsInPath = 3;
+        alteredLimits.MaxPaths = 5;
+        alteredLimits.MaxChildrenInDir = 3;
+
+        // test that subdomain scheme limits are default
+        TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::SchemeLimits(defaultLimits.AsProto()),
+        });
+
+        // change subdomain scheme limits the prehistoric way
+        SetSchemeshardSchemaLimits(runtime, directlySetLimits, tenantSchemeShard);
+
+        {
+            // test that the root knows about the subdomain
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+                NLs::PathExist,
+                NLs::SchemeLimits(defaultLimits.AsProto()),
+            });
+
+            // test that the subdomain scheme limits are changed to prehistoric
+            TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0"), {
+                NLs::PathExist,
+                NLs::SchemeLimits(directlySetLimits.AsProto())
+            });
+        }
+
+        TWaitForFirstEvent<TEvSchemeShard::TEvUpdateTenantSchemeShard> syncWaiter(runtime, [](const TEvSchemeShard::TEvUpdateTenantSchemeShard::TPtr& ev) {
+            return (ev.Get()->Get()->Record.HasSchemeLimits() == false);
+        });
+
+        // try to change subdomain scheme limits with alter-extsubdomain
+        TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
+            Sprintf(R"(
+                Name: "USER_0"
+                SchemeLimits {
+                    MaxShards: %lu
+                    MaxShardsInPath: %lu
+                    MaxPaths: %lu
+                    MaxChildrenInDir: %lu
+                }
+            )", alteredLimits.MaxShards, alteredLimits.MaxShardsInPath, alteredLimits.MaxPaths, alteredLimits.MaxChildrenInDir
+        ));
+        env.TestWaitNotification(runtime, txId);
+
+        syncWaiter.Wait();
+        syncWaiter.Stop();
+
+        // ...and that should not work.
+        // With EnableAlterDatabase=false, alter-extsubdomain will not overwrite limits directly set on the subdomain
+
+        {
+            // test that the root knows about the subdomain
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+                NLs::PathExist,
+                NLs::SchemeLimits(alteredLimits.AsProto()),
+            });
+
+            // test that the subdomain scheme limits remain unchanged (directly set limits)
+            TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0"), {
+                NLs::PathExist,
+                NLs::SchemeLimits(directlySetLimits.AsProto())
+            });
+        }
     }
 }

--- a/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
@@ -469,6 +469,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     Y_UNIT_TEST(AlterSchemeLimits) {
         TTestWithReboots t;
         t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
+        //INFO: Temporarily this test will not run when EnableAlterDatabase is not set
+        t.GetTestEnvOptions().EnableAlterDatabase(true);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TSchemeLimits limits;
             limits.MaxShards = 7;
@@ -523,11 +525,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                const auto tenantSchemeShard = TTestTxConfig::FakeHiveTablets;
+                ui64 tenantSchemeShard = 0;
                 // test what the parent knows about the subdomain
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Alice"), {
                     NLs::PathExist,
                     NLs::IsExternalSubDomain("Alice"),
+                    NLs::ExtractTenantSchemeshard(&tenantSchemeShard),
                     NLs::SchemeLimits(limits.AsProto()),
                     NLs::ShardsInsideDomain(3),
                     NLs::PathsInsideDomain(0)

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -825,10 +825,15 @@ TCheckFunc SchemeLimits(const NKikimrSubDomains::TSchemeLimits& expected) {
         const auto& domain = record.GetPathDescription().GetDomainDescription();
         const auto& actual = domain.GetSchemeLimits();
 
-        UNIT_ASSERT_C(google::protobuf::util::MessageDifferencer::Equals(actual, expected),
-            "scheme limits mismatch, domain with id " << domain.GetDomainKey().GetPathId()
-                << " has limits: " << actual.ShortDebugString().Quote()
-                << ", but expected limits are: " << expected.ShortDebugString().Quote()
+        TString diff;
+        google::protobuf::util::MessageDifferencer differencer;
+        differencer.ReportDifferencesToString(&diff);
+        //NOTE: because SetSchemeshardSchemaLimits mangles ExtraPathSymbolsAllowed's default value
+        differencer.IgnoreField(NKikimrSubDomains::TSchemeLimits::descriptor()->FindFieldByName("ExtraPathSymbolsAllowed"));
+        UNIT_ASSERT_C(differencer.Compare(actual, expected),
+            "scheme limits mismatch, subdomain PathId " << domain.GetDomainKey().GetPathId() << " limits"
+            << " differ from the expected ones: "
+            << diff
         );
     };
 }

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -620,6 +620,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.SetEnableLocalDBBtreeIndex(opts.EnableLocalDBBtreeIndex_);
     app.SetEnableSystemNamesProtection(opts.EnableSystemNamesProtection_);
     app.SetEnableRealSystemViewPaths(opts.EnableRealSystemViewPaths_);
+    app.FeatureFlags.SetEnableAlterDatabase(opts.EnableAlterDatabase_);
 
     app.ColumnShardConfig.SetDisabledOnSchemeShard(false);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -82,6 +82,7 @@ namespace NSchemeShardUT_Private {
         OPTION(std::optional<bool>, EnableRealSystemViewPaths, std::nullopt);
         OPTION(ui32, NStoragePools, 2);
         OPTION(std::optional<ui32>, DataShardStatsReportIntervalSeconds, std::nullopt);
+        OPTION(bool, EnableAlterDatabase, false);
 
         #undef OPTION
     };


### PR DESCRIPTION
Cherry-pick:
- a24a1e1 https://github.com/ydb-platform/ydb/pull/28849

ALTER DATABASE functionality introduced a way to change database scheme limits via SQL statement, but also moved the source of truth about scheme limits from tenant schemeshards to root schemeshard. This causes current scheme limits set directly on tenants to be overwritten with defaults by any alter-extsubdomain operation - even those that shouldn't change scheme limits, and even when the `enable_alter_database` feature flag is disabled.

This PR prevents scheme limit updates from root to tenant schemeshard when `enable_alter_database is disabled.

This is temporary; ALTER DATABASE functionality requires further changes to fully resolve this overwrite issue.

Also add tests to verify required (for now) behavior for all states of `enable_alter_database`.