### PR TITLE
Remove BridgePileName ephemeral field

### DIFF
--- a/ydb/library/yaml_config/protos/config.proto
+++ b/ydb/library/yaml_config/protos/config.proto
@@ -101,7 +101,6 @@ message THosts {
     optional string Address = 9;
     optional string Name = 10;
     repeated TExtendedHostConfigDrive Drive = 11;
-    optional string BridgePileName = 12;
 }
 
 message TTls {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Remove BridgePileName ephemeral field

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This removes BridgePileName from ephemeral fields in Hosts to reduce probability of an error during configuration of bridged cluster.
