### PR TITLE
[25-3] Indexed vector search pushdown

### DIFF
--- a/ydb/core/base/kmeans_clusters.cpp
+++ b/ydb/core/base/kmeans_clusters.cpp
@@ -366,6 +366,10 @@ public:
         return FindCluster(row.at(embeddingPos).AsRef());
     }
 
+    double CalcDistance(const TStringBuf a, const TStringBuf b) override {
+        return TMetric::Distance(a, b);
+    }
+
     void AggregateToCluster(ui32 pos, const TArrayRef<const char>& embedding, ui64 weight) override {
         auto& aggregate = NextClusters.at(pos);
         auto* coords = aggregate.data();

--- a/ydb/core/base/kmeans_clusters.cpp
+++ b/ydb/core/base/kmeans_clusters.cpp
@@ -367,7 +367,7 @@ public:
     }
 
     double CalcDistance(const TStringBuf a, const TStringBuf b) override {
-        return TMetric::Distance(a, b);
+        return TMetric::Distance(a.data(), b.data(), Dimensions);
     }
 
     void AggregateToCluster(ui32 pos, const TArrayRef<const char>& embedding, ui64 weight) override {

--- a/ydb/core/base/kmeans_clusters.h
+++ b/ydb/core/base/kmeans_clusters.h
@@ -36,6 +36,8 @@ public:
 
     virtual std::optional<ui32> FindCluster(TArrayRef<const TCell> row, ui32 embeddingPos) = 0;
 
+    virtual double CalcDistance(const TStringBuf a, const TStringBuf b) = 0;
+
     virtual void AggregateToCluster(ui32 pos, const TArrayRef<const char>& embedding, ui64 weight = 1) = 0;
 
     virtual bool IsExpectedSize(const TArrayRef<const char>& data) = 0;

--- a/ydb/core/kqp/common/kqp_yql.cpp
+++ b/ydb/core/kqp/common/kqp_yql.cpp
@@ -656,6 +656,42 @@ NNodes::TCoNameValueTupleList TKqpStreamLookupSettings::BuildNode(TExprContext& 
         );
     }
 
+    if (VectorTopColumn) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name().Build(VectorTopColumnSettingName)
+                .Value<TCoAtom>().Build(VectorTopColumn)
+            .Done()
+        );
+    }
+
+    if (VectorTopIndex) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name().Build(VectorTopIndexSettingName)
+                .Value<TCoAtom>().Build(VectorTopIndex)
+            .Done()
+        );
+    }
+
+    if (VectorTopTarget) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name()
+                    .Build(VectorTopTargetSettingName)
+                .Value(VectorTopTarget)
+                .Done());
+    }
+
+    if (VectorTopLimit) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name()
+                    .Build(VectorTopLimitSettingName)
+                .Value(VectorTopLimit)
+                .Done());
+    }
+
     return Build<TCoNameValueTupleList>(ctx, pos)
         .Add(settings)
         .Done();
@@ -684,6 +720,18 @@ TKqpStreamLookupSettings TKqpStreamLookupSettings::Parse(const NNodes::TCoNameVa
         } else if (name == AllowNullKeysSettingName) {
             YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
             settings.AllowNullKeysPrefixSize = FromString<ui32>(tuple.Value().Cast<TCoAtom>().Value());
+        } else if (name == VectorTopColumnSettingName) {
+            YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
+            settings.VectorTopColumn = tuple.Value().Cast<TCoAtom>().Value();
+        } else if (name == VectorTopIndexSettingName) {
+            YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
+            settings.VectorTopIndex = tuple.Value().Cast<TCoAtom>().Value();
+        } else if (name == VectorTopTargetSettingName) {
+            YQL_ENSURE(tuple.Value().IsValid());
+            settings.VectorTopTarget = tuple.Value().Cast().Ptr();
+        } else if (name == VectorTopLimitSettingName) {
+            YQL_ENSURE(tuple.Value().IsValid());
+            settings.VectorTopLimit = tuple.Value().Cast().Ptr();
         } else {
             YQL_ENSURE(false, "Unknown KqpStreamLookup setting name '" << name << "'");
         }

--- a/ydb/core/kqp/common/kqp_yql.h
+++ b/ydb/core/kqp/common/kqp_yql.h
@@ -56,6 +56,10 @@ enum class EStreamLookupStrategyType {
 struct TKqpStreamLookupSettings {
     static constexpr TStringBuf StrategySettingName = "Strategy";
     static constexpr TStringBuf AllowNullKeysSettingName = "AllowNullKeysPrefixSize";
+    static constexpr TStringBuf VectorTopColumnSettingName = "VectorTopColumn";
+    static constexpr TStringBuf VectorTopIndexSettingName = "VectorTopIndex";
+    static constexpr TStringBuf VectorTopLimitSettingName = "VectorTopLimit";
+    static constexpr TStringBuf VectorTopTargetSettingName = "VectorTopTarget";
 
     // stream lookup strategy types
     static constexpr std::string_view LookupStrategyName = "LookupRows"sv;
@@ -64,6 +68,13 @@ struct TKqpStreamLookupSettings {
 
     TMaybe<ui32> AllowNullKeysPrefixSize;
     EStreamLookupStrategyType Strategy = EStreamLookupStrategyType::Unspecified;
+
+    // VectorTopColumn must be a fixed string, but Target and Limit may be calculated in runtime
+    // Vector index settings are not needed here because we know them from the indexImpl table name or index name
+    TString VectorTopColumn;
+    TString VectorTopIndex;
+    TExprNode::TPtr VectorTopTarget;
+    TExprNode::TPtr VectorTopLimit;
 
     NNodes::TCoNameValueTupleList BuildNode(TExprContext& ctx, TPositionHandle pos) const;
     static TKqpStreamLookupSettings Parse(const NNodes::TKqlStreamLookupTable& node);

--- a/ydb/core/kqp/executer_actor/kqp_partition_helper.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_partition_helper.cpp
@@ -774,37 +774,39 @@ THashMap<ui64, TShardInfo> PruneEffectPartitions(const NKqpProto::TKqpPhyTableOp
     }
 }
 
-ui64 ExtractItemsLimit(const TStageInfo& stageInfo, const NKqpProto::TKqpPhyValue& protoItemsLimit,
-    const NMiniKQL::THolderFactory& holderFactory, const NMiniKQL::TTypeEnvironment& typeEnv)
+NUdf::TUnboxedValue ExtractPhyValue(const TStageInfo& stageInfo, const NKqpProto::TKqpPhyValue& protoPhyValue,
+    const NMiniKQL::THolderFactory& holderFactory, const NMiniKQL::TTypeEnvironment& typeEnv,
+    const NUdf::TUnboxedValue& defaultValue)
 {
-    switch (protoItemsLimit.GetKindCase()) {
+    switch (protoPhyValue.GetKindCase()) {
         case NKqpProto::TKqpPhyValue::kLiteralValue: {
-            const auto& literalValue = protoItemsLimit.GetLiteralValue();
+            const auto& literalValue = protoPhyValue.GetLiteralValue();
 
             auto [type, value] = NMiniKQL::ImportValueFromProto(
                 literalValue.GetType(), literalValue.GetValue(), typeEnv, holderFactory);
 
             YQL_ENSURE(type->GetKind() == NMiniKQL::TType::EKind::Data);
-            return value.Get<ui64>();
+            return value;
         }
 
         case NKqpProto::TKqpPhyValue::kParamValue: {
-            const TString& itemsLimitParamName = protoItemsLimit.GetParamValue().GetParamName();
-            if (!itemsLimitParamName) {
-                return 0;
+            const TString& paramName = protoPhyValue.GetParamValue().GetParamName();
+            if (!paramName) {
+                return defaultValue;
             }
 
-            auto [type, value] = stageInfo.Meta.Tx.Params->GetParameterUnboxedValue(itemsLimitParamName);
-            YQL_ENSURE(type->GetKind() == NMiniKQL::TType::EKind::Data);
-            return value.Get<ui64>();
+            auto [type, value] = stageInfo.Meta.Tx.Params->GetParameterUnboxedValue(paramName);
+            YQL_ENSURE(type->GetKind() == NMiniKQL::TType::EKind::Data ||
+                type->GetKind() == NMiniKQL::TType::EKind::Tagged, "Unexpected PhyValue kind " << (int)type->GetKind());
+            return value;
         }
 
         case NKqpProto::TKqpPhyValue::kParamElementValue:
         case NKqpProto::TKqpPhyValue::kRowsList:
-            YQL_ENSURE(false, "Unexpected ItemsLimit kind " << protoItemsLimit.DebugString());
+            YQL_ENSURE(false, "Unexpected PhyValue kind " << protoPhyValue.DebugString());
 
         case NKqpProto::TKqpPhyValue::KIND_NOT_SET:
-            return 0;
+            return defaultValue;
     }
 }
 
@@ -815,7 +817,7 @@ TPhysicalShardReadSettings ExtractReadSettings(const NKqpProto::TKqpPhyTableOper
 
     switch(operation.GetTypeCase()){
         case NKqpProto::TKqpPhyTableOperation::kReadRanges: {
-            readSettings.ItemsLimit = ExtractItemsLimit(stageInfo, operation.GetReadRanges().GetItemsLimit(), holderFactory, typeEnv);
+            readSettings.ItemsLimit = ExtractPhyValue(stageInfo, operation.GetReadRanges().GetItemsLimit(), holderFactory, typeEnv, NUdf::TUnboxedValuePod((ui32)0)).Get<ui64>();
             if (operation.GetReadRanges().GetReverse()) {
                 readSettings.SetSorting(ERequestSorting::DESC);
             }
@@ -823,7 +825,7 @@ TPhysicalShardReadSettings ExtractReadSettings(const NKqpProto::TKqpPhyTableOper
         }
 
         case NKqpProto::TKqpPhyTableOperation::kReadRange: {
-            readSettings.ItemsLimit = ExtractItemsLimit(stageInfo, operation.GetReadRange().GetItemsLimit(), holderFactory, typeEnv);
+            readSettings.ItemsLimit = ExtractPhyValue(stageInfo, operation.GetReadRange().GetItemsLimit(), holderFactory, typeEnv, NUdf::TUnboxedValuePod((ui32)0)).Get<ui64>();
             if (operation.GetReadRange().GetReverse()) {
                 readSettings.SetSorting(ERequestSorting::DESC);
             }
@@ -838,7 +840,7 @@ TPhysicalShardReadSettings ExtractReadSettings(const NKqpProto::TKqpPhyTableOper
             } else {
                 readSettings.SetSorting(ERequestSorting::NONE);
             }
-            readSettings.ItemsLimit = ExtractItemsLimit(stageInfo, operation.GetReadOlapRange().GetItemsLimit(), holderFactory, typeEnv);
+            readSettings.ItemsLimit = ExtractPhyValue(stageInfo, operation.GetReadOlapRange().GetItemsLimit(), holderFactory, typeEnv, NUdf::TUnboxedValuePod((ui32)0)).Get<ui64>();
             NKikimrMiniKQL::TType minikqlProtoResultType;
             ConvertYdbTypeToMiniKQLType(operation.GetReadOlapRange().GetResultType(), minikqlProtoResultType);
             readSettings.ResultType = ImportTypeFromProto(minikqlProtoResultType, typeEnv);

--- a/ydb/core/kqp/executer_actor/kqp_partition_helper.h
+++ b/ydb/core/kqp/executer_actor/kqp_partition_helper.h
@@ -87,8 +87,9 @@ THashMap<ui64, TShardInfo> PrunePartitions(const NKqpProto::TKqpReadRangesSource
     const NMiniKQL::THolderFactory& holderFactory, const NMiniKQL::TTypeEnvironment& typeEnv,
     const TPartitionPrunerConfig& prunerConfig, bool& isFullScan);
 
-ui64 ExtractItemsLimit(const TStageInfo& stageInfo, const NKqpProto::TKqpPhyValue& protoItemsLimit,
-    const NMiniKQL::THolderFactory& holderFactory, const NMiniKQL::TTypeEnvironment& typeEnv);
+NUdf::TUnboxedValue ExtractPhyValue(const TStageInfo& stageInfo, const NKqpProto::TKqpPhyValue& protoItemsLimit,
+    const NMiniKQL::THolderFactory& holderFactory, const NMiniKQL::TTypeEnvironment& typeEnv,
+    const NUdf::TUnboxedValue& defaultValue);
 
 // Returns the list of ColumnShards that can store rows from the specified range
 // NOTE: Unlike OLTP tables that store data in DataShards, data in OLAP tables is not range

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -489,6 +489,16 @@ void TKqpTasksGraph::BuildStreamLookupChannels(const TStageInfo& stageInfo, ui32
         settings->SetIsTableImmutable(true);
     }
 
+    if (streamLookup.HasVectorTopK()) {
+        const auto& in = streamLookup.GetVectorTopK();
+        auto& out = *settings->MutableVectorTopK();
+        out.SetColumn(in.GetColumn());
+        *out.MutableSettings() = in.GetSettings();
+        auto target = ExtractPhyValue(stageInfo, in.GetTargetVector(), TxAlloc->HolderFactory, TxAlloc->TypeEnv, NUdf::TUnboxedValuePod());
+        out.SetTargetVector(TString(target.AsStringRef()));
+        out.SetLimit((ui32)ExtractPhyValue(stageInfo, in.GetLimit(), TxAlloc->HolderFactory, TxAlloc->TypeEnv, NUdf::TUnboxedValuePod()).Get<ui64>());
+    }
+
     TTransform streamLookupTransform;
     streamLookupTransform.Type = "StreamLookupInputTransformer";
     streamLookupTransform.InputType = streamLookup.GetLookupKeysType();
@@ -2650,7 +2660,7 @@ TMaybe<size_t> TKqpTasksGraph::BuildScanTasksFromSource(TStageInfo& stageInfo, b
             settings->SetItemsLimit(*GetMeta().MaxBatchSize);
             settings->SetIsBatch(true);
         } else {
-            ui64 itemsLimit = ExtractItemsLimit(stageInfo, source.GetItemsLimit(), TxAlloc->HolderFactory, TxAlloc->TypeEnv);
+            ui64 itemsLimit = ExtractPhyValue(stageInfo, source.GetItemsLimit(), TxAlloc->HolderFactory, TxAlloc->TypeEnv, NUdf::TUnboxedValuePod((ui32)0)).Get<ui64>();
             settings->SetItemsLimit(itemsLimit);
         }
 

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -40,6 +40,7 @@ public:
         , AllowInconsistentReads(settings.GetAllowInconsistentReads())
         , UseFollowers(settings.GetAllowUseFollowers())
         , IsTableImmutable(settings.GetIsTableImmutable())
+        , HasVectorTopK(settings.HasVectorTopK())
         , PipeCacheId(UseFollowers ? FollowersPipeCacheId : MainPipeCacheId)
         , LockTxId(settings.HasLockTxId() ? settings.GetLockTxId() : TMaybe<ui64>())
         , NodeLockId(settings.HasLockNodeId() ? settings.GetLockNodeId() : TMaybe<ui32>())
@@ -90,10 +91,10 @@ public:
             ui64 rowsReadEstimate = ReadRowsCount;
             ui64 bytesReadEstimate = ReadBytesCount;
 
-            if (mstats) {
+            if (mstats && !HasVectorTopK) {
                 switch(LookupStrategy) {
                     case NKqpProto::EStreamLookupStrategy::LOOKUP: {
-                        // in lookup case we return as result actual data, that we read from the datashard.
+                        // in lookup case without top-K pushdown we return as result actual data, that we read from the datashard.
                         rowsReadEstimate = mstats->Inputs[InputIndex]->RowsConsumed;
                         bytesReadEstimate = mstats->Inputs[InputIndex]->BytesConsumed;
                         break;
@@ -806,6 +807,7 @@ private:
     const bool AllowInconsistentReads;
     const bool UseFollowers;
     const bool IsTableImmutable;
+    const bool HasVectorTopK;
     const TActorId PipeCacheId;
     const TMaybe<ui64> LockTxId;
     const TMaybe<ui32> NodeLockId;

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/kqp/runtime/kqp_scan_data.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/tx/datashard/range_ops.h>
+#include <ydb/core/protos/query_stats.pb.h>
 #include <ydb/core/scheme/protos/type_info.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
@@ -333,6 +334,11 @@ public:
 
         while (!ReadResults.empty() && !resultStats.SizeLimitExceeded) {
             auto& result = ReadResults.front();
+            if (!result.UnprocessedResultRow && Settings.VectorTopK &&
+                result.ReadResult->Get()->Record.HasStats()) {
+                resultStats.ReadRowsCount += result.ReadResult->Get()->Record.GetStats().GetRows();
+                resultStats.ReadBytesCount += result.ReadResult->Get()->Record.GetStats().GetBytes();
+            }
             for (; result.UnprocessedResultRow < result.ReadResult->Get()->GetRowsCount(); ++result.UnprocessedResultRow) {
                 const auto& resultRow = result.ReadResult->Get()->GetCells(result.UnprocessedResultRow);
                 YQL_ENSURE(resultRow.size() <= Settings.Columns.size(), "Result columns mismatch");
@@ -368,8 +374,10 @@ public:
                 batch.push_back(std::move(row));
                 storageRowSize = std::max(storageRowSize, (i64)8);
 
-                resultStats.ReadRowsCount += 1;
-                resultStats.ReadBytesCount += storageRowSize;
+                if (!Settings.VectorTopK || !result.ReadResult->Get()->Record.HasStats()) {
+                    resultStats.ReadRowsCount += 1;
+                    resultStats.ReadBytesCount += storageRowSize;
+                }
                 resultStats.ResultRowsCount += 1;
                 resultStats.ResultBytesCount += storageRowSize;
             }
@@ -468,6 +476,10 @@ private:
             if (!IsSystemColumn(column.Name)) {
                 record.AddColumns(column.Id);
             }
+        }
+
+        if (Settings.VectorTopK) {
+            *record.MutableVectorTopK() = *Settings.VectorTopK;
         }
 
         YQL_ENSURE(!ranges.empty());
@@ -1252,6 +1264,10 @@ std::unique_ptr<TKqpStreamLookupWorker> CreateStreamLookupWorker(NKikimrKqp::TKq
             typeInfo,
             column.GetTypeInfo().GetPgTypeMod()
         });
+    }
+
+    if (settings.HasVectorTopK()) {
+        preparedSettings.VectorTopK = std::make_unique<NKikimrKqp::TReadVectorTopK>(settings.GetVectorTopK());
     }
 
     switch (settings.GetLookupStrategy()) {

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
@@ -18,6 +18,7 @@ struct TLookupSettings {
     ui32 AllowNullKeysPrefixSize;
     bool KeepRowsOrder;
     NKqpProto::EStreamLookupStrategy LookupStrategy;
+    std::unique_ptr<NKikimrKqp::TReadVectorTopK> VectorTopK;
 
     std::unordered_map<TString, TSysTables::TTableColumnInfo> KeyColumns;
     std::vector<TSysTables::TTableColumnInfo*> LookupKeyColumns;

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_prefixed_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_prefixed_vector_ut.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/kqp/common/kqp.h>
 #include <ydb/core/kqp/gateway/kqp_metadata_loader.h>
 #include <ydb/core/kqp/host/kqp_host_impl.h>
+#include <ydb/core/tx/datashard/datashard.h>
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
@@ -945,6 +946,82 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
 
     Y_UNIT_TEST_TWIN(PrefixedVectorIndexUpsertClusterChangeReturning, Covered) {
         DoTestPrefixedVectorIndexUpdateClusterChange(Q_(R"(UPSERT INTO `/Root/TestTable` (`pk`, `user`, `emb`, `data`) VALUES (91, "user_a", "\x03\x31\x03", "19") RETURNING `data`, `emb`, `user`, `pk`;)"), true, Covered);
+    }
+
+    Y_UNIT_TEST_TWIN(VectorSearchPushdown, Covered) {
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            // SetUseRealThreads(false) is required to capture events (!) but then you have to do kikimr.RunCall() for everything
+            .SetUseRealThreads(false)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto runtime = kikimr.GetTestServer().GetRuntime();
+        runtime->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        auto db = kikimr.RunCall([&] { return kikimr.GetTableClient(); });
+        auto session = kikimr.RunCall([&] {
+            auto session = DoCreateTableForPrefixedVectorIndex(db, false);
+            DoCreatePrefixedVectorIndex(session, false, Covered ? "COVER (user, emb, data)" : "", 2);
+            return session;
+        });
+
+        constexpr static int prefixType = 1, levelType = 2, postingType = 3, mainType = 4;
+        THashMap<TActorId, int> actorTypes;
+        auto resolveActors = [&](const char* tableName, int type) {
+            auto shards = GetTableShards(&kikimr.GetTestServer(), runtime->AllocateEdgeActor(), tableName);
+            for (auto shardId: shards) {
+                auto actorId = ResolveTablet(*runtime, shardId);
+                actorTypes[actorId] = type;
+            }
+        };
+        resolveActors("/Root/TestTable/index/indexImplPrefixTable", prefixType);
+        resolveActors("/Root/TestTable/index/indexImplLevelTable", levelType);
+        resolveActors("/Root/TestTable/index/indexImplPostingTable", postingType);
+        resolveActors("/Root/TestTable", mainType);
+
+        auto captureEvents = [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvDataShard::TEvRead::EventType) {
+                int shardType = actorTypes[ev->GetRecipientRewrite()];
+                auto & read = ev->Get<TEvDataShard::TEvRead>()->Record;
+                if (shardType == (Covered ? mainType : postingType)) {
+                    // Non-covering index does topK on main table, covering does it on posting
+                    UNIT_ASSERT(!read.HasVectorTopK());
+                } else if (shardType != prefixType) {
+                    UNIT_ASSERT(shardType != 0);
+                    UNIT_ASSERT(read.HasVectorTopK());
+                    auto & topK = read.GetVectorTopK();
+                    // Check that target and limit are pushed down
+                    UNIT_ASSERT(topK.GetTargetVector() == "\x67\x71\x02");
+                    if (shardType == levelType) {
+                        // Equal to pragma
+                        UNIT_ASSERT(topK.GetLimit() == 2);
+                    } else if (shardType == (Covered ? postingType : mainType)) {
+                        // Equal to LIMIT
+                        UNIT_ASSERT(topK.GetLimit() == 3);
+                    }
+                }
+            }
+            return false;
+        };
+        runtime->SetEventFilter(captureEvents);
+
+        {
+            TString query1(Q_(R"(
+                pragma ydb.KMeansTreeSearchTopSize = "2";
+                SELECT * FROM `/Root/TestTable`
+                VIEW index
+                WHERE user="user_a"
+                ORDER BY Knn::CosineDistance(emb, "\x67\x71\x02")
+                LIMIT 3
+            )"));
+
+            auto result = kikimr.RunCall([&] {
+                return session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                    .ExtractValueSync();
+            });
+            UNIT_ASSERT(result.IsSuccess());
+        }
     }
 
 }

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -2996,7 +2996,7 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
     }
 
 
-    Y_UNIT_TEST_TWIN(MultipleSecondaryIndexWithSameComulns, UseSink) {
+    Y_UNIT_TEST_TWIN(MultipleSecondaryIndexWithSameColumns, UseSink) {
         auto setting = NKikimrKqp::TKqpSetting();
         auto serverSettings = TKikimrSettings().SetKqpSettings({setting});
         serverSettings.AppConfig.MutableTableServiceConfig()->SetEnableOltpSink(UseSink);
@@ -3335,7 +3335,7 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
         }
     }
 
-    Y_UNIT_TEST_TWIN(SecondaryIndexWithPrimaryKeySameComulns, UseSink) {
+    Y_UNIT_TEST_TWIN(SecondaryIndexWithPrimaryKeySameColumns, UseSink) {
         auto setting = NKikimrKqp::TKqpSetting();
         auto serverSettings = TKikimrSettings().SetKqpSettings({setting});
         serverSettings.AppConfig.MutableTableServiceConfig()->SetEnableOltpSink(UseSink);

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
@@ -1050,11 +1050,22 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         }
     }
 
-    Y_UNIT_TEST_TWIN(VectorSearchPushdown, Covered) {
+    TVector<std::pair<TActorId, TActorId>> ResolveFollowers(TTestActorRuntime &runtime, ui64 tabletId, ui32 nodeIndex) {
+        auto sender = runtime.AllocateEdgeActor(nodeIndex);
+        runtime.Send(new IEventHandle(MakeStateStorageProxyID(), sender,
+            new TEvStateStorage::TEvLookup(tabletId, 0)),
+            nodeIndex, true);
+        auto ev = runtime.GrabEdgeEventRethrow<TEvStateStorage::TEvInfo>(sender);
+        Y_ABORT_UNLESS(ev->Get()->Status == NKikimrProto::OK, "Failed to resolve tablet %" PRIu64, tabletId);
+        return std::move(ev->Get()->Followers);
+    }
+
+    Y_UNIT_TEST_QUAD(VectorSearchPushdown, Covered, Followers) {
         auto setting = NKikimrKqp::TKqpSetting();
         auto serverSettings = TKikimrSettings()
             // SetUseRealThreads(false) is required to capture events (!) but then you have to do kikimr.RunCall() for everything
             .SetUseRealThreads(false)
+            .SetEnableForceFollowers(Followers)
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
@@ -1064,13 +1075,35 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         auto db = kikimr.RunCall([&] { return kikimr.GetTableClient(); });
         auto session = kikimr.RunCall([&] { return DoCreateTableAndVectorIndex(db, true, Covered); });
 
-        constexpr static int levelType = 1, postingType = 2, mainType = 3;
-        THashMap<TActorId, int> actorTypes;
-        auto resolveActors = [&](const char* tableName, int type) {
+        if (Followers) {
+            std::vector<TString> tableNames = {
+                "/Root/TestTable",
+                "/Root/TestTable/index1/indexImplLevelTable",
+                "/Root/TestTable/index1/indexImplPostingTable"
+            };
+            for (const TString& tableName: tableNames) {
+                const TString alterTable(Q_(Sprintf(R"(
+                    ALTER TABLE `%s` SET (READ_REPLICAS_SETTINGS = "PER_AZ:3");
+                )", tableName.c_str())));
+                auto result = kikimr.RunCall([&] { return session.ExecuteSchemeQuery(alterTable).ExtractValueSync(); });
+                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            }
+        }
+
+        constexpr static ui32 levelType = 1, postingType = 2, mainType = 3;
+        constexpr static ui32 followerTypeFlag = 8;
+        THashMap<TActorId, ui32> actorTypes;
+        auto resolveActors = [&](const char* tableName, ui32 type) {
             auto shards = GetTableShards(&kikimr.GetTestServer(), runtime->AllocateEdgeActor(), tableName);
             for (auto shardId: shards) {
                 auto actorId = ResolveTablet(*runtime, shardId);
                 actorTypes[actorId] = type;
+                if (Followers) {
+                    auto followers = ResolveFollowers(*runtime, shardId, 0);
+                    for (auto& [_, followerId]: followers) {
+                        actorTypes[followerId] = type | followerTypeFlag;
+                    }
+                }
             }
         };
         resolveActors("/Root/TestTable/index1/indexImplLevelTable", levelType);
@@ -1079,7 +1112,11 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
 
         auto captureEvents = [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
             if (ev->GetTypeRewrite() == TEvDataShard::TEvRead::EventType) {
-                int shardType = actorTypes[ev->GetRecipientRewrite()];
+                ui32 shardType = actorTypes[ev->GetRecipientRewrite()];
+                bool isFollower = (shardType & followerTypeFlag);
+                shardType = shardType & ~followerTypeFlag;
+                // Check that level & posting are read from followers
+                UNIT_ASSERT(isFollower == (Followers && (shardType == levelType || shardType == postingType)));
                 auto & read = ev->Get<TEvDataShard::TEvRead>()->Record;
                 if (shardType == (Covered ? mainType : postingType)) {
                     // Non-covering index does topK on main table, covering does it on posting
@@ -1113,7 +1150,8 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
             )"));
 
             auto result = kikimr.RunCall([&] {
-                return session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                return session.ExecuteDataQuery(query1, TTxControl::BeginTx(
+                    Followers ? TTxSettings::StaleRO() : TTxSettings::SerializableRW()).CommitTx())
                     .ExtractValueSync();
             });
             UNIT_ASSERT(result.IsSuccess());

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -856,6 +856,14 @@ message TKqpTableSinkSettings {
     optional bool IsIndexImplTable = 21;
 }
 
+message TReadVectorTopK {
+    // Top-K pushdown by vector distance between Column and TargetVector
+    optional uint32 Column = 1;
+    optional Ydb.Table.VectorIndexSettings Settings = 2;
+    optional string TargetVector = 3;
+    optional uint32 Limit = 4;
+}
+
 message TKqpStreamLookupSettings {
     optional NKqpProto.TKqpPhyTableId Table = 1;
     repeated TKqpColumnMetadataProto KeyColumns = 2;
@@ -873,6 +881,9 @@ message TKqpStreamLookupSettings {
     optional NKikimrDataEvents.ELockMode LockMode = 14;
     optional bool AllowUseFollowers = 15;
     optional bool IsTableImmutable = 16;
+    optional EIsolationLevel IsolationLevel = 17 [default = ISOLATION_LEVEL_UNDEFINED];
+    optional string Database = 18;
+    optional TReadVectorTopK VectorTopK = 19;
 }
 
 message TKqpSequencerSettings {

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -301,6 +301,15 @@ enum EStreamLookupStrategy {
     SEMI_JOIN = 3;
 };
 
+message TKqpPhyVectorTopK {
+    // Top-K pushdown by vector distance between Column and TargetVector
+    // Where TargetVector and Limit may be runtime expressions
+    uint32 Column = 1;
+    Ydb.Table.VectorIndexSettings Settings = 2;
+    TKqpPhyValue TargetVector = 3;
+    TKqpPhyValue Limit = 4;
+}
+
 message TKqpPhyCnStreamLookup {
     TKqpPhyTableId Table = 1;
     repeated string KeyColumns = 2;
@@ -312,6 +321,7 @@ message TKqpPhyCnStreamLookup {
     bool AllowNullKeys = 8;
     uint32 AllowNullKeysPrefixSize = 9;
     bool IsTableImmutable = 10;
+    TKqpPhyVectorTopK VectorTopK = 11;
 }
 
 message TKqpPhyCnVectorResolve {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2052,15 +2052,7 @@ message TEvRead {
 
     optional NKikimrDataEvents.ELockMode LockMode = 904;
 
-    optional TReadVectorTopK VectorTopK = 905;
-}
-
-message TReadVectorTopK {
-    // Top-K pushdown by vector distance between Column and TargetVector
-    optional uint32 Column = 1;
-    optional Ydb.Table.VectorIndexSettings Settings = 2;
-    optional string TargetVector = 3;
-    optional uint32 Limit = 4;
+    optional NKikimrKqp.TReadVectorTopK VectorTopK = 905;
 }
 
 message TReadContinuationToken {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2051,6 +2051,16 @@ message TEvRead {
     optional NKikimrSchemeOp.EOlapProgramType ProgramType = 903;
 
     optional NKikimrDataEvents.ELockMode LockMode = 904;
+
+    optional TReadVectorTopK VectorTopK = 905;
+}
+
+message TReadVectorTopK {
+    // Top-K pushdown by vector distance between Column and TargetVector
+    optional uint32 Column = 1;
+    optional Ydb.Table.VectorIndexSettings Settings = 2;
+    optional string TargetVector = 3;
+    optional uint32 Limit = 4;
 }
 
 message TReadContinuationToken {

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -48,7 +48,7 @@ struct TReadIteratorVectorTop {
 
     void AddRow(TConstArrayRef<TCell> cells) {
         const auto embedding = cells.at(Column).AsBuf();
-        if (!KMeans->IsExpectedFormat(embedding)) {
+        if (!KMeans->IsExpectedSize(embedding)) {
             return;
         }
         TotalReadRows++;
@@ -2166,7 +2166,7 @@ public:
                 if (!topState->KMeans && error == "") {
                     error = "CreateClusters failed";
                 }
-                if (topState->KMeans && !topState->KMeans->IsExpectedFormat(topK.GetTargetVector())) {
+                if (topState->KMeans && !topState->KMeans->IsExpectedSize(topK.GetTargetVector())) {
                     error = "Target vector has invalid format";
                 }
             }

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -5,6 +5,7 @@
 #include "datashard_locks_db.h"
 #include "probes.h"
 
+#include <ydb/core/base/kmeans_clusters.h>
 #include <ydb/core/base/counters.h>
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
 
@@ -19,6 +20,60 @@ LWTRACE_USING(DATASHARD_PROVIDER)
 namespace NKikimr::NDataShard {
 
 using namespace NTabletFlatExecutor;
+
+struct TReadIteratorVectorTopItem {
+    TOwnedCellVec Row;
+    double Distance = 0;
+
+    TReadIteratorVectorTopItem(TArrayRef<const TCell> cells, double distance):
+        Row(TOwnedCellVec(cells)),
+        Distance(distance) {
+    }
+
+    bool operator<(const TReadIteratorVectorTopItem& rhs) const {
+        return Distance < rhs.Distance;
+    }
+};
+
+struct TReadIteratorVectorTop {
+    ui32 Column = 0;
+    ui32 Limit = 0;
+    TString Target;
+    std::unique_ptr<NKMeans::IClusters> KMeans;
+    std::vector<TReadIteratorVectorTopItem> Rows;
+    ui64 ByteSize = 0;
+
+    void AddRow(TConstArrayRef<TCell> cells) {
+        size_t bytes = EstimateSize(cells);
+        double distance = KMeans->CalcDistance(cells.at(Column).AsBuf(), Target);
+        if (Rows.size() < Limit) {
+            ByteSize += bytes;
+            Rows.emplace_back(cells, distance);
+            std::push_heap(Rows.begin(), Rows.end());
+        } else if (distance < Rows.front().Distance) {
+            ByteSize += bytes;
+            Rows.emplace_back(cells, distance);
+            std::push_heap(Rows.begin(), Rows.end());
+            std::pop_heap(Rows.begin(), Rows.end());
+            auto& item = Rows.back();
+            ByteSize -= EstimateSize(item.Row);
+            Rows.pop_back();
+        }
+    }
+
+    // Move all rows to BlockBuilder in sorted order
+    size_t ToBlockBuilder(IBlockBuilder& blockBuilder, const NScheme::TTypeInfo* columnTypes) {
+        size_t n = Rows.size();
+        for (auto it = Rows.end(); it != Rows.begin(); it--) {
+            std::pop_heap(Rows.begin(), it);
+        }
+        for (auto& item: Rows) {
+            blockBuilder.AddRow(TDbTupleRef(), TDbTupleRef(columnTypes, item.Row.data(), item.Row.size()));
+        }
+        Rows.clear();
+        return n;
+    }
+};
 
 namespace {
 
@@ -445,8 +500,12 @@ public:
 
         // note that if user requests key columns then they will be in
         // rowValues and we don't have to add rowKey columns
-        BlockBuilder.AddRow(TDbTupleRef(), value);
-        ++RowsRead;
+        if (State.VectorTopK) {
+            State.VectorTopK->AddRow(value.Cells());
+        } else {
+            BlockBuilder.AddRow(TDbTupleRef(), value);
+            ++RowsRead;
+        }
 
         return EReadStatus::Done;
     }
@@ -706,6 +765,10 @@ public:
             } else {
                 Self->IncCounter(COUNTER_ENGINE_HOST_SELECT_RANGE, State.Request->Ranges.size());
             }
+
+            if (State.VectorTopK) {
+                RowsRead += State.VectorTopK->ToBlockBuilder(BlockBuilder, ColumnTypes.data());
+            }
         }
 
         if (record.TxLocksSize() > 0 || record.BrokenTxLocksSize() > 0) {
@@ -948,8 +1011,12 @@ private:
 
             // note that if user requests key columns then they will be in
             // rowValues and we don't have to add rowKey columns
-            BlockBuilder.AddRow(TDbTupleRef(), rowValues);
-            ++RowsRead;
+            if (State.VectorTopK) {
+                State.VectorTopK->AddRow(rowValues.Cells());
+            } else {
+                BlockBuilder.AddRow(TDbTupleRef(), rowValues);
+                ++RowsRead;
+            }
 
             if (ReachedTotalRowsLimit()) {
                 LastProcessedKey.clear();
@@ -1225,6 +1292,7 @@ public:
         , Format(state.Format)
         , ReadVersion(state.ReadVersion)
         , Ev(std::move(state.Ev))
+        , VectorTopK(state.VectorTopK)
         , Request(Ev->Get())
     {
         TotalRowsLimit = state.TotalRowsLimit;
@@ -1298,9 +1366,13 @@ private:
         }
 
         TArrayRef<const TCell> cells = *row;
-        BlockBuilder->AddRow(TDbTupleRef(), TDbTupleRef(ColumnTypes.data(), cells.data(), cells.size()));
-        ++BlockRows;
-        ++TotalRows;
+        if (VectorTopK) {
+            VectorTopK->AddRow(cells);
+        } else {
+            BlockBuilder->AddRow(TDbTupleRef(), TDbTupleRef(ColumnTypes.data(), cells.data(), cells.size()));
+            ++BlockRows;
+            ++TotalRows;
+        }
 
         if (TotalRows >= TotalRowsLimit) {
             return EScan::Final;
@@ -1373,6 +1445,12 @@ private:
 
         record.SetReadId(Request->Record.GetReadId());
         record.SetSeqNo(Quota.SeqNo + 1);
+
+        if (last && VectorTopK) {
+            auto topRows = VectorTopK->ToBlockBuilder(*BlockBuilder, ColumnTypes.data());
+            BlockRows += topRows;
+            TotalRows += topRows;
+        }
 
         if (last) {
             record.SetFinished(true);
@@ -1494,6 +1572,7 @@ private:
     const NKikimrDataEvents::EDataFormat Format;
     const TRowVersion ReadVersion;
     const TEvDataShard::TEvRead::TPtr Ev;
+    std::shared_ptr<TReadIteratorVectorTop> VectorTopK;
     TEvDataShard::TEvRead* const Request;
 
     IDriver* Driver;
@@ -2060,6 +2139,36 @@ public:
             }
 
             state.Columns.push_back(col);
+        }
+
+        if (record.HasVectorTopK()) {
+            const auto& topK = record.GetVectorTopK();
+            auto topState = std::make_shared<TReadIteratorVectorTop>();
+            TString error;
+            if (topK.GetColumn() >= record.ColumnsSize()) {
+                error = TStringBuilder() << "Too large topK column index: " << topK.GetColumn();
+            } else if (!topK.GetLimit()) {
+                error = "TopK limit is 0";
+            } else if (!topK.HasTargetVector()) {
+                error = "Target vector is not specified";
+            } else {
+                topState->KMeans = NKMeans::CreateClusters(topK.GetSettings(), 0, error);
+                if (!topState->KMeans && error == "") {
+                    error = "CreateClusters failed";
+                }
+                if (topState->KMeans && !topState->KMeans->IsExpectedFormat(topK.GetTargetVector())) {
+                    error = "Target vector has invalid format";
+                }
+            }
+            if (error != "") {
+                SetStatusError(Result->Record, Ydb::StatusIds::BAD_REQUEST, TStringBuilder()
+                    << error << " (shard# " << Self->TabletID() << " node# " << ctx.SelfID.NodeId() << " state# " << DatashardStateName(Self->State) << ")");
+                return;
+            }
+            topState->Column = topK.GetColumn();
+            topState->Limit = topK.GetLimit();
+            topState->Target = topK.GetTargetVector();
+            state.VectorTopK = std::move(topState);
         }
 
         state.State = TReadIteratorState::EState::Executing;

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -5639,7 +5639,7 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorVectorTopK) {
         UNIT_ASSERT(readResult1->Record.GetStatus().GetIssues(0).message().Contains("Target vector is not specified"));
 
         request1 = createRequest();
-        request1->Record.MutableVectorTopK()->SetTargetVector("\xE4\x16\x10");
+        request1->Record.MutableVectorTopK()->SetTargetVector("\xE4\x16\x20\x10"); // 25-3 only has length check
         readResult1 = helper.SendRead("table-vector", request1.release());
         UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().GetCode(), Ydb::StatusIds::BAD_REQUEST);
         UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().IssuesSize(), 1);

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -391,6 +391,30 @@ struct TTestHelper {
         }
     }
 
+    void CreateCustomTable(const TString & name, TVector<TShardedTableOptions::TColumn> columns) {
+        auto &runtime = *Server->GetRuntime();
+
+        auto& table1 = Tables[name];
+        table1.Name = name;
+
+        auto opts = TShardedTableOptions()
+            .Shards(ShardCount)
+            .Columns(columns);
+        if (WithFollower)
+            opts.Followers(1);
+        auto [shards, tableId] = CreateShardedTable(Server, Sender, "/Root", name, opts);
+
+        table1.TableId = tableId;
+        table1.TabletId = shards.at(0);
+
+        auto [tables, ownerId] = GetTables(Server, table1.TabletId);
+        table1.UserTable = tables[name];
+
+        table1.ClientId = runtime.ConnectToPipe(table1.TabletId, Sender, 0, GetTestPipeConfig());
+
+        table1.Columns = columns;
+    }
+
     void UpsertMany(ui32 startRow, ui32 rowCount) {
         auto &runtime = *Server->GetRuntime();
         const auto& table = Tables["table-1-many"];
@@ -472,7 +496,7 @@ struct TTestHelper {
         if (!snapshot) {
             readVersion = CreateVolatileSnapshot(
                 Server,
-                {"/Root/movies", "/Root/table-1"},
+                {"/Root/"+tableName},
                 TDuration::Hours(1));
         } else {
             readVersion = snapshot;
@@ -5566,6 +5590,119 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorFastCancel) {
 
         auto ev = runtime.GrabEdgeEvent<TEvDataShard::TEvReadResult>(sender, TDuration::Seconds(1));
         UNIT_ASSERT_C(!ev, "Unexpected response received (should have been cancelled)");
+    }
+
+}
+
+Y_UNIT_TEST_SUITE(DataShardReadIteratorVectorTopK) {
+
+    Y_UNIT_TEST(BadRequest) {
+        TTestHelper helper;
+        TVector<TShardedTableOptions::TColumn> columns = {
+            {"key", "Uint32", true, false},
+            {"emb", "String", false, false}};
+        helper.CreateCustomTable("table-vector", columns);
+
+        auto createRequest = [&]() {
+            auto request1 = helper.GetBaseReadRequest("table-vector", 1, NKikimrDataEvents::FORMAT_CELLVEC);
+            AddRangeQuery<ui32>(*request1, { 1 }, true, { 20 }, true);
+            auto topK = request1->Record.MutableVectorTopK();
+            topK->SetColumn(1);
+            topK->SetTargetVector("\xE4\x16\x02");
+            topK->SetLimit(3);
+            auto idx = topK->MutableSettings();
+            idx->set_metric(Ydb::Table::VectorIndexSettings::DISTANCE_COSINE);
+            idx->set_vector_type(Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8);
+            idx->set_vector_dimension(2);
+            return request1;
+        };
+
+        auto request1 = createRequest();
+        request1->Record.MutableVectorTopK()->SetLimit(0);
+        auto readResult1 = helper.SendRead("table-vector", request1.release());
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().GetCode(), Ydb::StatusIds::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().IssuesSize(), 1);
+        UNIT_ASSERT(readResult1->Record.GetStatus().GetIssues(0).message().Contains("limit is 0"));
+
+        request1 = createRequest();
+        request1->Record.MutableVectorTopK()->SetColumn(2);
+        readResult1 = helper.SendRead("table-vector", request1.release());
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().GetCode(), Ydb::StatusIds::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().IssuesSize(), 1);
+        UNIT_ASSERT(readResult1->Record.GetStatus().GetIssues(0).message().Contains("Too large topK column index"));
+
+        request1 = createRequest();
+        request1->Record.MutableVectorTopK()->ClearTargetVector();
+        readResult1 = helper.SendRead("table-vector", request1.release());
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().GetCode(), Ydb::StatusIds::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().IssuesSize(), 1);
+        UNIT_ASSERT(readResult1->Record.GetStatus().GetIssues(0).message().Contains("Target vector is not specified"));
+
+        request1 = createRequest();
+        request1->Record.MutableVectorTopK()->SetTargetVector("\xE4\x16\x10");
+        readResult1 = helper.SendRead("table-vector", request1.release());
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().GetCode(), Ydb::StatusIds::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().IssuesSize(), 1);
+        UNIT_ASSERT(readResult1->Record.GetStatus().GetIssues(0).message().Contains("Target vector has invalid format"));
+
+        request1 = createRequest();
+        request1->Record.MutableVectorTopK()->MutableSettings()->set_metric(Ydb::Table::VectorIndexSettings::METRIC_UNSPECIFIED);
+        readResult1 = helper.SendRead("table-vector", request1.release());
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().GetCode(), Ydb::StatusIds::BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(readResult1->Record.GetStatus().IssuesSize(), 1);
+        UNIT_ASSERT(readResult1->Record.GetStatus().GetIssues(0).message().Contains("either distance or similarity"));
+    }
+
+    Y_UNIT_TEST_TWIN(Simple, Batch) {
+        TTestHelper helper;
+        TVector<TShardedTableOptions::TColumn> columns = {
+            {"key", "Uint32", true, false},
+            {"emb", "String", false, false}};
+        helper.CreateCustomTable("table-vector", columns);
+
+        // Insert initial data
+        ExecSQL(helper.Server, helper.Sender, R"(UPSERT INTO `/Root/table-vector` (key, emb) VALUES
+            ( 1, "\x00\xFF\x02"),
+            ( 2, "\x10\xF0\x02"),
+            ( 3, "\x20\xE0\x02"),
+            ( 4, "\x30\xD0\x02"),
+            ( 5, "\x40\xC0\x02"),
+            ( 6, "\x50\xB0\x02"),
+            ( 7, "\x60\xA0\x02"),
+            ( 8, "\x70\x90\x02"),
+            ( 9, "\x80\x80\x02"),
+            (10, "\x90\x70\x02"),
+            (11, "\xA0\x60\x02"),
+            (12, "\xB0\x50\x02"),
+            (13, "\xC0\x40\x02"),
+            (14, "\xD0\x30\x02"),
+            (15, "\xE0\x20\x02"),
+            (16, "\xF0\x10\x02"),
+            (17, "\xFF\x00\x02");)");
+
+        auto request1 = helper.GetBaseReadRequest("table-vector", 1, NKikimrDataEvents::FORMAT_CELLVEC);
+        if (Batch) {
+            request1->Record.SetHints(TEvDataShard::TEvRead::HINT_BATCH);
+        }
+        AddRangeQuery<ui32>(*request1, { 1 }, true, { 20 }, true);
+        auto topK = request1->Record.MutableVectorTopK();
+        topK->SetColumn(1);
+        topK->SetTargetVector("\xE4\x16\x02");
+        topK->SetLimit(3);
+        auto idx = topK->MutableSettings();
+        idx->set_metric(Ydb::Table::VectorIndexSettings::DISTANCE_COSINE);
+        idx->set_vector_type(Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8);
+        idx->set_vector_dimension(2);
+        auto readResult1 = helper.SendRead("table-vector", request1.release());
+        UNIT_ASSERT(readResult1->Record.GetFinished());
+        CheckResult(helper.Tables.at("table-vector").UserTable, *readResult1, {
+            {TCell::Make(16), TCell("\xF0\x10\x02", 3)},
+            {TCell::Make(15), TCell("\xE0\x20\x02", 3)},
+            {TCell::Make(17), TCell("\xFF\x00\x02", 3)},
+        }, {
+            NScheme::TTypeInfo(NScheme::NTypeIds::Uint32),
+            NScheme::TTypeInfo(NScheme::NTypeIds::String)
+        });
     }
 
 }

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -5695,6 +5695,8 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorVectorTopK) {
         idx->set_vector_dimension(2);
         auto readResult1 = helper.SendRead("table-vector", request1.release());
         UNIT_ASSERT(readResult1->Record.GetFinished());
+        UNIT_ASSERT(readResult1->Record.GetStats().GetRows() == 17);
+        UNIT_ASSERT(readResult1->Record.GetStats().GetBytes() == 544);
         CheckResult(helper.Tables.at("table-vector").UserTable, *readResult1, {
             {TCell::Make(16), TCell("\xF0\x10\x02", 3)},
             {TCell::Make(15), TCell("\xE0\x20\x02", 3)},

--- a/ydb/core/tx/datashard/read_iterator.h
+++ b/ydb/core/tx/datashard/read_iterator.h
@@ -44,6 +44,8 @@ struct TReadIteratorSession {
     THashSet<TReadIteratorId, TReadIteratorId::THash> Iterators;
 };
 
+struct TReadIteratorVectorTop;
+
 struct TReadIteratorState {
     enum class EState {
         Init,
@@ -222,6 +224,9 @@ public:
 
     // May be used to cancel enqueued transactions
     ui64 EnqueuedLocalTxId = 0;
+
+    // Vector search pushdown
+    std::shared_ptr<TReadIteratorVectorTop> VectorTopK;
 };
 
 using TReadIteratorsMap = THashMap<TReadIteratorId, TReadIteratorState, TReadIteratorId::THash>;

--- a/ydb/library/mkql_proto/mkql_proto.cpp
+++ b/ydb/library/mkql_proto/mkql_proto.cpp
@@ -794,6 +794,12 @@ Y_FORCE_INLINE NUdf::TUnboxedValue HandleKindDataImport(const TType* type, const
         case NUdf::TDataType<double>::Id:
             MKQL_ENSURE_S(oneOfCase == NKikimrMiniKQL::TValue::ValueValueCase::kDouble);
             return NUdf::TUnboxedValuePod(value.GetDouble());
+        case NUdf::TDataType<char*>::Id:
+            if (oneOfCase == NKikimrMiniKQL::TValue::ValueValueCase::kText)
+                return MakeString(value.GetText());
+            else if (oneOfCase == NKikimrMiniKQL::TValue::ValueValueCase::kBytes)
+                return MakeString(value.GetBytes());
+            MKQL_ENSURE_S(false);
         case NUdf::TDataType<NUdf::TJson>::Id:
         case NUdf::TDataType<NUdf::TUtf8>::Id:
             MKQL_ENSURE_S(oneOfCase == NKikimrMiniKQL::TValue::ValueValueCase::kText);


### PR DESCRIPTION
### Changelog entry

Improve performance of indexed vector search by pushing distance calculation to datashards, thus reducing the amount of data exchange between datashards and KQP.

### Changelog category

* Performance improvement

### Description for reviewers

Cherry-pick of #27686, #28574, #28978