### PR TITLE
fix erroneous implicit iterator-to-pointer conversion IGNIETFERRO-2163

### DIFF
--- a/ydb/core/tablet/tablet_counters_protobuf.h
+++ b/ydb/core/tablet/tablet_counters_protobuf.h
@@ -69,7 +69,7 @@ public:
 
     const char* const * GetNames() const
     {
-        return Names.begin();
+        return Names.data();
     }
 
     virtual const TVector<TTabletPercentileCounter::TRangeDef>& GetRanges(size_t idx) const

--- a/ydb/core/tablet_flat/flat_mem_iter.h
+++ b/ydb/core/tablet_flat/flat_mem_iter.h
@@ -133,13 +133,13 @@ namespace NTable {
             const auto *key = RowIt.GetKey();
 
             if (len >= KeyCellDefaults->BasicTypes().size()) {
-                return { KeyCellDefaults->BasicTypes().begin(), key, len };
+                return { KeyCellDefaults->BasicTypes().data(), key, len };
             } else if (!Key) {
                 Key.insert(Key.end(), key, key + len);
                 Key.insert(Key.end(), (**KeyCellDefaults).begin() + len, (**KeyCellDefaults).end());
             }
 
-            return { KeyCellDefaults->BasicTypes().begin(), Key.begin(), ui32(Key.size()) };
+            return { KeyCellDefaults->BasicTypes().data(), Key.data(), ui32(Key.size()) };
         }
 
         bool IsDelta() const


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->





### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implicit casting an iterator to a pointer type is a non-portable extension.
 IGNIETFERRO-2163