### PR TITLE
YQ-4900 fixed empty streaming queries sys view without user token

### DIFF
--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -3388,6 +3388,20 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesSysView) {
         }, "Path = '/Root/C'");
     }
 
+    Y_UNIT_TEST_F(ReadWithoutAuth, TStreamingSysViewTestFixture) {
+        QueryClientSettings = TClientSettings();
+        Setup();
+
+        StartQuery("A");
+        StartQuery("B");
+        StartQuery("C");
+        Sleep(STATS_WAIT_DURATION);
+
+        CheckSysView({
+            {"A"}, {"B"}, {"C"}
+        });
+    }
+
     Y_UNIT_TEST_F(SortOrderForSysView, TStreamingSysViewTestFixture) {
         Setup();
 

--- a/ydb/core/sys_view/streaming_queries/streaming_queries.cpp
+++ b/ydb/core/sys_view/streaming_queries/streaming_queries.cpp
@@ -285,7 +285,10 @@ public:
 
         auto request = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
         request->DatabaseName = Database;
-        request->UserToken = UserToken;
+
+        if (UserToken && UserToken->GetSanitizedToken()) {
+            request->UserToken = UserToken;
+        }
 
         request->ResultSet.reserve(Paths.size());
         for (const auto& path : Paths) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed empty streaming queries sys view without user token

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Bugfix ticket: https://st.yandex-team.ru/YQ-4900
