### PR TITLE
Remove dependency on test library from nodewarden 

### DIFF
--- a/ydb/core/blobstorage/nodewarden/ut/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ut/ya.make
@@ -11,6 +11,7 @@ ENDIF()
 
 PEERDIR(
     ydb/core/testlib/default
+    ydb/core/util/actorsys_test
 )
 
 SRCS(

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -61,7 +61,6 @@ PEERDIR(
     ydb/core/control/lib
     ydb/library/pdisk_io
     ydb/library/yaml_config
-    ydb/core/util/actorsys_test
 )
 
 END()

--- a/ydb/core/keyvalue/ut/ya.make
+++ b/ydb/core/keyvalue/ut/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     library/cpp/regex/pcre
     library/cpp/svnversion
     ydb/core/testlib/default
+    ydb/core/util/actorsys_test
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/mind/bscontroller/ut_selfheal/ya.make
+++ b/ydb/core/mind/bscontroller/ut_selfheal/ya.make
@@ -23,6 +23,7 @@ PEERDIR(
     ydb/core/blobstorage/pdisk/mock
     ydb/core/mind/bscontroller
     ydb/core/tx/scheme_board
+    ydb/core/util/actorsys_test
     yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy


### PR DESCRIPTION
After the pull request https://github.com/ydb-platform/ydb/pull/10800, a dependency on ydb/core/util/actorsys_test from nodewarden appeared.

This led to a transitive dependency on contrib/ydb/apps/version appearing.

As a result, for the nbs project, the MakeCurrent function gets linked from the wrong location.