### PR TITLE
EXT-1705 Fix TBlockIO TraceId is moved into the first TEvGet

### DIFF
--- a/ydb/core/tablet_flat/flat_bio_actor.cpp
+++ b/ydb/core/tablet_flat/flat_bio_actor.cpp
@@ -122,7 +122,7 @@ void TBlockIO::Dispatch()
 
         auto *ev = new TEvGet(query, +more, TInstant::Max(), klass, false);
 
-        SendToBSProxy(ctx, group, ev, more.From /* cookie, request offset */, std::move(TraceId));
+        SendToBSProxy(ctx, group, ev, more.From /* cookie, request offset */, NWilson::TTraceId(TraceId));
     }
 
     if (auto logl = Logger->Log(ELnLev::Debug)) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

In TBlockIO only the first TEvGet is traced because TraceId is std::move-d. Need to copy it.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
