### PR TITLE
25-3: Fix datashards losing lock conflicts during in-memory migration

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -5282,6 +5282,247 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorConsistency) {
             "ERROR: ABORTED");
     }
 
+    Y_UNIT_TEST(ReadLockConflictUncommittedRemoveMigration) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(1)
+            .SetUseRealThreads(false);
+
+        // This test requires in-memory state migration to work
+        serverSettings.FeatureFlags.SetEnableDataShardInMemoryStateMigration(true);
+
+        TServer::TPtr server = new TServer(serverSettings);
+
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, index int, value int, PRIMARY KEY (key, index))
+                WITH (PARTITION_AT_KEYS = (10));
+            )"),
+            "SUCCESS"
+        );
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+
+        // Populate tables with initial values
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, index, value) VALUES
+                (1, 0, 1001),
+                (1, 1, 1002),
+                (11, 0, 2001);
+        )");
+
+        ui64 tx1lockId = 0;
+        ui32 tx1lockNode = 0;
+        auto shard1actor = ResolveTablet(runtime, shards.at(0));
+        auto lockStatusObserver = runtime.AddObserver<TEvLongTxService::TEvLockStatus>(
+            [&](auto& ev) {
+                if (ev->GetRecipientRewrite() == shard1actor) {
+                    auto* msg = ev->Get();
+                    tx1lockId = msg->Record.GetLockId();
+                    tx1lockNode = msg->Record.GetLockNode();
+                }
+            });
+
+        // Begin the 1st transaction appending to key 1
+        TString session1, tx1;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, session1, tx1, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 3003);
+                SELECT key, index, value FROM `/Root/table` WHERE key = 11 ORDER BY key, index;
+                )"),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }\n"
+            "{ items { int32_value: 11 } items { int32_value: 0 } items { int32_value: 2001 } }");
+
+        runtime.WaitFor("subscribed lock", [&]{ return tx1lockId != 0; });
+        lockStatusObserver.Remove();
+
+        // Begin the 2nd transaction reading key 1
+        TString session2, tx2;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, session2, tx2, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+                )"),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }");
+
+        // Make sure everything settles down
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Note: originally a graceful restart supposedly caused shards to send
+        // restart notifications, which caused an internal error in kqp, which
+        // aborted the commit and removed the lock. We send an unavailable lock
+        // status here with a blocked and failing commit, which covers a broader
+        // range of failures which could happen in practice.
+        TBlockEvents<TEvBlobStorage::TEvPut> blockedCommits(runtime, [&](auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Id.Channel() == 0 && msg->Id.TabletID() == shards.at(0)) {
+                Cerr << "... blocking commit " << msg->Id << Endl;
+                return true;
+            }
+            return false;
+        });
+        runtime.Send(
+            new IEventHandle(shard1actor, {},
+                new TEvLongTxService::TEvLockStatus(tx1lockId, tx1lockNode, NKikimrLongTxService::TEvLockStatus::STATUS_UNAVAILABLE)),
+            0, true);
+        runtime.WaitFor("blocked commits", [&]{ return blockedCommits.size() >= 1; });
+
+        // Stop blocking commits and make them fail (will cause shards to restart)
+        blockedCommits.Stop();
+        for (auto& ev : blockedCommits) {
+            auto proxy = ev->Recipient;
+            ui32 groupId = GroupIDFromBlobStorageProxyID(proxy);
+            auto response = ev->Get()->MakeErrorResponse(NKikimrProto::ERROR, "Something went wrong", TGroupId::FromValue(groupId));
+            runtime.Send(new IEventHandle(ev->Sender, proxy, response.release()), 0, true);
+        }
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Commit the 1st transaction
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, session1, tx1, R"(SELECT 1)"),
+            "{ items { int32_value: 1 } }");
+
+        // Commit the 2nd transaction writing to the same index
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, session2, tx2, R"(
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 4003);
+                )"),
+            "ERROR: ABORTED");
+    }
+
+    Y_UNIT_TEST(ReadLockConflictUncommittedBreakMigration) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(1)
+            .SetUseRealThreads(false);
+
+        // This test requires in-memory state migration to work
+        serverSettings.FeatureFlags.SetEnableDataShardInMemoryStateMigration(true);
+
+        TServer::TPtr server = new TServer(serverSettings);
+
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, index int, value int, PRIMARY KEY (key, index))
+                WITH (PARTITION_AT_KEYS = (10));
+            )"),
+            "SUCCESS"
+        );
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+
+        // Populate tables with initial values
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, index, value) VALUES
+                (1, 0, 1001),
+                (1, 1, 1002),
+                (11, 0, 2001);
+        )");
+
+        ui64 tx1lockId = 0;
+        ui32 tx1lockNode = 0;
+        auto shard1actor = ResolveTablet(runtime, shards.at(0));
+        auto lockStatusObserver = runtime.AddObserver<TEvLongTxService::TEvLockStatus>(
+            [&](auto& ev) {
+                if (ev->GetRecipientRewrite() == shard1actor) {
+                    auto* msg = ev->Get();
+                    tx1lockId = msg->Record.GetLockId();
+                    tx1lockNode = msg->Record.GetLockNode();
+                }
+            });
+
+        // Begin the 1st transaction appending to key 1
+        TString session1, tx1;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, session1, tx1, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 3003);
+                SELECT key, index, value FROM `/Root/table` WHERE key = 2 ORDER BY key, index;
+                SELECT key, index, value FROM `/Root/table` WHERE key = 11 ORDER BY key, index;
+                )"),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }"
+            "\n"
+            // empty result set
+            "\n"
+            "{ items { int32_value: 11 } items { int32_value: 0 } items { int32_value: 2001 } }");
+
+        runtime.WaitFor("subscribed lock", [&]{ return tx1lockId != 0; });
+        lockStatusObserver.Remove();
+
+        // Begin the 2nd transaction reading key 1
+        TString session2, tx2;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, session2, tx2, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+                )"),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }");
+
+        // Make sure everything settles down
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Block commits and try to break the first transaction by a blind upsert
+        TBlockEvents<TEvBlobStorage::TEvPut> blockedCommits(runtime, [&](auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Id.Channel() == 0 && msg->Id.TabletID() == shards.at(0)) {
+                Cerr << "... blocking commit " << msg->Id << Endl;
+                return true;
+            }
+            return false;
+        });
+        KqpSimpleSend(runtime, R"(
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (2, 0, 4001);
+            )");
+        runtime.WaitFor("blocked commits", [&]{ return blockedCommits.size() >= 1; });
+
+        // Stop blocking commits and make them fail (will cause shards to restart)
+        blockedCommits.Stop();
+        for (auto& ev : blockedCommits) {
+            auto proxy = ev->Recipient;
+            ui32 groupId = GroupIDFromBlobStorageProxyID(proxy);
+            auto response = ev->Get()->MakeErrorResponse(NKikimrProto::ERROR, "Something went wrong", TGroupId::FromValue(groupId));
+            runtime.Send(new IEventHandle(ev->Sender, proxy, response.release()), 0, true);
+        }
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Commit the 1st transaction (it must succeed)
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, session1, tx1, R"(SELECT 1)"),
+            "{ items { int32_value: 1 } }");
+
+        // Commit the 2nd transaction writing to the same index
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, session2, tx2, R"(
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 4003);
+                )"),
+            "ERROR: ABORTED");
+    }
+
 }
 
 Y_UNIT_TEST_SUITE(DataShardReadIteratorLatency) {

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -218,6 +218,7 @@ enum class ELockFlags : ui64 {
     Frozen = 1,
     WholeShard = 2,
     Persistent = 4,
+    Removed = 8,
     PersistentMask = Frozen,
 };
 
@@ -330,6 +331,7 @@ public:
     bool IsShardLock() const { return !!(Flags & ELockFlags::WholeShard); }
     bool IsWriteLock() const { return !WriteTables.empty(); }
     bool IsPersistent() const { return !!(Flags & ELockFlags::Persistent); }
+    bool IsRemoved() const { return !!(Flags & ELockFlags::Removed); }
     bool HasUnpersistedRanges() const { return UnpersistedRanges; }
     //ui64 MemorySize() const { return 1; } // TODO
 
@@ -359,7 +361,7 @@ public:
     bool PersistConflicts(ILocksDb* db);
     void CleanupConflicts();
 
-    void RestoreInMemoryState(const ILocksDb::TLockRow& lockRow);
+    bool RestoreInMemoryState(const ILocksDb::TLockRow& lockRow);
     bool RestoreInMemoryRange(const ILocksDb::TLockRange& rangeRow);
     void RestorePersistentRange(const ILocksDb::TLockRange& rangeRow);
     void RestoreInMemoryConflict(TLockInfo* otherLock);
@@ -680,9 +682,14 @@ public:
         return Locks;
     }
 
+    const THashMap<ui64, TLockInfo::TPtr>& GetRemovedLocks() const {
+        return RemovedLocks;
+    }
+
 private:
     const THolder<TLocksDataShard> Self;
     THashMap<ui64, TLockInfo::TPtr> Locks; // key is LockId
+    THashMap<ui64, TLockInfo::TPtr> RemovedLocks; // key is LockId
     THashMap<TPathId, TTableLocks::TPtr> Tables;
     THashSet<ui64> ShardLocks;
     // A list of locks that have ranges (from oldest to newest)
@@ -960,6 +967,10 @@ public:
 
     const THashMap<ui64, TLockInfo::TPtr>& GetLocks() const {
         return Locker.GetLocks();
+    }
+
+    const THashMap<ui64, TLockInfo::TPtr>& GetRemovedLocks() const {
+        return Locker.GetRemovedLocks();
     }
 
 private:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed datashards losing lock conflicts during some in-memory migrations which could allow non-serializable ordering of transactions. Fixes #27123.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Datashards have in-memory optimistic read locks and persistent optimistic write locks, with write locks also tracking conflicts between transactions. In some rare cases where a persistent lock is broken or removed, it could be unlinked from conflicting locks, however persistence could still fail. In-memory migration could then migrate in-memory locks to subsequent generations while restoring persistent locks from storage without the necessary in-memory conflicts. This in turn allowed multiple conflicting transactions to commit, resulting in a non-serializable ordering of transactions.

Merges #29108.