### PR TITLE
EXT-1705 Fix TBlockIO TraceId is moved into the first TEvGet

### DIFF
--- a/ydb/core/tablet_flat/flat_bio_actor.cpp
+++ b/ydb/core/tablet_flat/flat_bio_actor.cpp
@@ -125,7 +125,7 @@ void TBlockIO::Dispatch() noexcept
 
         auto *ev = new TEvGet(query, +more, TInstant::Max(), klass, false);
 
-        SendToBSProxy(ctx, group, ev, more.From /* cookie, request offset */, std::move(Origin->TraceId));
+        SendToBSProxy(ctx, group, ev, more.From /* cookie, request offset */, NWilson::TTraceId(Origin->TraceId));
     }
 
     if (auto logl = Logger->Log(ELnLev::Debug)) {

--- a/ydb/core/tablet_flat/shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/shared_sausagecache.cpp
@@ -674,7 +674,7 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
                         AddInFlyPages(toLoad.size(), sizeToLoad);
                         // fetch cookie -> requested size;
                         // event cookie -> ptr to queue
-                        auto *fetch = new NPageCollection::TFetch(sizeToLoad, wa.PageCollection, std::move(toLoad), std::move(wa.TraceId));
+                        auto *fetch = new NPageCollection::TFetch(sizeToLoad, wa.PageCollection, std::move(toLoad), NWilson::TTraceId(wa.TraceId));
                         NBlockIO::Start(this, wa.Owner, (ui64)&queue, wa.Priority, fetch);
                     }
                 }


### PR DESCRIPTION
(cherry picked from commit 398b7692a5826a200d932e142302bba5a2480486)