### PR TITLE
EXT-1705 Fix TBlockIO TraceId is moved into the first TEvGet

### DIFF
--- a/ydb/core/tablet_flat/flat_bio_actor.cpp
+++ b/ydb/core/tablet_flat/flat_bio_actor.cpp
@@ -122,7 +122,12 @@ void TBlockIO::Dispatch()
 
         auto *ev = new TEvGet(query, +more, TInstant::Max(), klass, false);
 
-        SendToBSProxy(ctx, group, ev, more.From /* cookie, request offset */, NWilson::TTraceId(TraceId));
+        NWilson::TTraceId traceId;
+        if (TraceId) {
+            traceId = NWilson::TTraceId(TraceId);
+        }
+
+        SendToBSProxy(ctx, group, ev, more.From /* cookie, request offset */, std::move(traceId));
     }
 
     if (auto logl = Logger->Log(ELnLev::Debug)) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Fix TBlockIO TraceId is moved into the first TEvGet

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
