### PR TITLE
Fix YqlParser: unitialized variables and ignoring BuildType return value

### DIFF
--- a/ydb/public/lib/ydb_cli/common/yql_parser/yql_parser.cpp
+++ b/ydb/public/lib/ydb_cli/common/yql_parser/yql_parser.cpp
@@ -136,14 +136,6 @@ private:
                 return std::nullopt;
             }
             node = *parseResult;
-        } else if (lowerContent == "emptylist") {
-            node.TypeKind = TTypeParser::ETypeKind::EmptyList;
-        } else if (lowerContent == "emptydict") {
-            node.TypeKind = TTypeParser::ETypeKind::EmptyDict;
-        } else if (lowerContent == "void") {
-            node.TypeKind = TTypeParser::ETypeKind::Void;
-        } else if (lowerContent == "null") {
-            node.TypeKind = TTypeParser::ETypeKind::Null;
         } else {
             auto parseResult = ParsePrimitive(lowerContent);
             if (!parseResult) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
