### PR TITLE
EXT-1711 Fix TSharedPageCache using empty TraceId

### DIFF
--- a/ydb/core/tablet_flat/shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/shared_sausagecache.cpp
@@ -1064,7 +1064,7 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
         auto *fetch = new NBlockIO::TEvFetch(request.Priority, request.PageCollection, std::move(pages), bytes);
         if (cookie == EBlockIOFetchTypeCookie::AsyncQueue || cookie == EBlockIOFetchTypeCookie::ScanQueue) {
             // Note: queued requests can fetch multiple times, so copy trace id
-            fetch->TraceId = request.TraceId.GetTraceId();
+            fetch->TraceId = NWilson::TTraceId(request.TraceId);
         } else {
             fetch->TraceId = std::move(request.TraceId);            
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
TSharedPageCache uses GetTraceId() which is a stub for NBS compatibility and returns `0`

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)
