### PR TITLE
remove explicit JSON float/double precision settings

### DIFF
--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1007,8 +1007,6 @@ void TViewerPipeClient::InitConfig(const TCgiParameters& params) {
     Proto2JsonConfig.MapAsObject = true;
     Proto2JsonConfig.ConvertAny = true;
     Proto2JsonConfig.WriteNanAsString = true;
-    Proto2JsonConfig.DoubleNDigits = 17;
-    Proto2JsonConfig.FloatNDigits = 9;
     Timeout = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("timeout"), Timeout.MilliSeconds()));
     UseCache = FromStringWithDefault<bool>(params.Get("use_cache"), UseCache);
 }
@@ -1082,14 +1080,8 @@ TString TViewerPipeClient::GetHTTPOKJSON(TString response, TInstant lastModified
 }
 
 TString TViewerPipeClient::GetHTTPOKJSON(const NJson::TJsonValue& response, TInstant lastModified) {
-    constexpr ui32 doubleNDigits = 17;
-    constexpr ui32 floatNDigits = 9;
-    constexpr EFloatToStringMode floatMode = EFloatToStringMode::PREC_NDIGITS;
     TStringStream content;
     NJson::WriteJson(&content, &response, {
-        .DoubleNDigits = doubleNDigits,
-        .FloatNDigits = floatNDigits,
-        .FloatToStringMode = floatMode,
         .ValidateUtf8 = false,
         .WriteNanAsString = true,
     });


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

it needed to avoid generating objects with type=Big Number instead of doubles
