### PR TITLE
Fix static analyzers complaining about uninitialized RowVersion

### DIFF
--- a/ydb/core/tablet_flat/flat_row_eggs.h
+++ b/ydb/core/tablet_flat/flat_row_eggs.h
@@ -86,6 +86,7 @@ namespace NTable {
 
         explicit TSelectRowVersionResult(EReady ready)
             : Ready(ready)
+            , RowVersion()
         { }
 
         explicit TSelectRowVersionResult(const TRowVersion& rowVersion)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Static analyzers are too picky about uninitialized variables. Initialize TSelectRowVersionResult::RowVersion even in error cases (RowVersion should not be used in those cases, but this is only catchable under sanitizers).

https://nda.ya.ru/t/es8YExqa7NHh89