### PR TITLE
Add excluding tablets from System Tablet Backup

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2794,6 +2794,7 @@ message TSystemTabletBackupConfig {
     oneof Backend {
         TFilesystemBackend Filesystem = 1;
     }
+    repeated fixed64 ExcludeTabletIds = 2;
 }
 
 message TAppConfig {

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5131,8 +5131,14 @@ void TExecutor::StartBackup() {
     }
 
     const auto& backupConfig = AppData()->SystemTabletBackupConfig;
-    TTabletTypes::EType tabletType = Owner->TabletType();
+    const auto& excludeTabletIds = backupConfig.GetExcludeTabletIds();
     ui64 tabletId = Owner->TabletID();
+
+    if (std::find(excludeTabletIds.begin(), excludeTabletIds.end(), tabletId) != excludeTabletIds.end()) {
+        return;
+    }
+
+    TTabletTypes::EType tabletType = Owner->TabletType();
     const auto& scheme = Database->GetScheme();
     const auto& tables = scheme.Tables;
 

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -1026,6 +1026,33 @@ Y_UNIT_TEST_SUITE(Backup) {
         );
     }
 
+    Y_UNIT_TEST(ExcludeTablet) {
+        TEnv env;
+
+        env->GetAppData().SystemTabletBackupConfig.AddExcludeTabletIds(env.Tablet);
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+
+        Cerr << "...sleeping while tablet is doing some work" << Endl;
+        env->SimulateSleep(TDuration::Seconds(1));
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+
+        Cerr << "...sleeping while tablet is doing some work" << Endl;
+        env->SimulateSleep(TDuration::Seconds(1));
+
+        auto tabletIdDir = TFsPath(env->GetTempDir())
+            .Child("dummy")
+            .Child(ToString(env.Tablet));
+
+        UNIT_ASSERT_C(!tabletIdDir.Exists(), "Tablet is not excluded from backup");
+    }
+
     Y_UNIT_TEST(RecoveryModeKeepsData) {
         TEnv env;
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds the ability to exclude specific tablets from the system tablet backup functionality by configuring a list of tablet IDs that should be excluded.

- Added `ExcludeTabletIds` field to the `TSystemTabletBackupConfig` protobuf message
- Modified `TExecutor::StartBackup()` to check if a tablet is in the exclusion list before starting backup
- Added a unit test to verify that excluded tablets do not create backup
