### PR TITLE
Try to process blocks in DqHashCombiner if possible

### DIFF
--- a/ydb/core/kqp/opt/peephole/kqp_opt_peephole.cpp
+++ b/ydb/core/kqp/opt/peephole/kqp_opt_peephole.cpp
@@ -206,6 +206,7 @@ class TKqpPeepholeNewOperatorTransformer : public TOptimizeTransformerBase {
 public:
     TKqpPeepholeNewOperatorTransformer(TTypeAnnotationContext& ctx, TKikimrConfiguration::TPtr config)
         : TOptimizeTransformerBase(&ctx, NYql::NLog::EComponent::ProviderKqp, {})
+        , DqHashCombineUsesBlocks(config->GetDqHashCombineUsesBlocks())
     {
 #define HNDL(name) "KqpPeepholeNewOperator-"#name, Hndl(&TKqpPeepholeNewOperatorTransformer::name)
         if (config->GetUseDqHashCombine()) {
@@ -215,10 +216,13 @@ public:
     }
 
     TMaybeNode<TExprBase> RewriteWideCombinerToDqHashCombiner(TExprBase node, TExprContext& ctx) {
-        TExprBase output = DqPeepholeRewriteWideCombiner(node, ctx);
+        TExprBase output = DqPeepholeRewriteWideCombiner(DqHashCombineUsesBlocks, node, ctx);
         DumpAppliedRule(__func__, node.Ptr(), output.Ptr(), ctx);
         return output;
     }
+
+private:
+    bool DqHashCombineUsesBlocks;
 };
 
 class TKqpPeepholeFinalTransformer : public TOptimizeTransformerBase {

--- a/ydb/core/kqp/provider/yql_kikimr_settings.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.cpp
@@ -98,6 +98,7 @@ TKikimrConfiguration::TKikimrConfiguration() {
     REGISTER_SETTING(*this, OptEnableParallelUnionAllConnectionsForExtend);
 
     REGISTER_SETTING(*this, UseDqHashCombine);
+    REGISTER_SETTING(*this, DqHashCombineUsesBlocks);
 
     REGISTER_SETTING(*this, OptUseFinalizeByKey);
     REGISTER_SETTING(*this, CostBasedOptimizationLevel);
@@ -235,5 +236,9 @@ bool TKikimrConfiguration::GetEnableOlapPushdownAggregate() const {
 
 bool TKikimrConfiguration::GetUseDqHashCombine() const {
     return UseDqHashCombine.Get().GetOrElse(EnableDqHashCombineByDefault);
+}
+
+bool TKikimrConfiguration::GetDqHashCombineUsesBlocks() const {
+    return DqHashCombineUsesBlocks.Get().GetOrElse(false);
 }
 }

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -64,6 +64,7 @@ public:
     NCommon::TConfSetting<bool, Static> OptEnableParallelUnionAllConnectionsForExtend;
 
     NCommon::TConfSetting<bool, Static> UseDqHashCombine;
+    NCommon::TConfSetting<bool, Static> DqHashCombineUsesBlocks;
 
     NCommon::TConfSetting<TString, Static> OptOverrideStatistics;
     NCommon::TConfSetting<NYql::TOptimizerHints, Static> OptimizerHints;
@@ -240,6 +241,7 @@ struct TKikimrConfiguration : public TKikimrSettings, public NCommon::TSettingDi
     bool GetEnableParallelUnionAllConnectionsForExtend() const;
     bool GetEnableOlapPushdownAggregate() const;
     bool GetUseDqHashCombine() const;
+    bool GetDqHashCombineUsesBlocks() const;
 };
 
 }

--- a/ydb/core/kqp/ut/opt/kqp_hash_combine_ut.cpp
+++ b/ydb/core/kqp/ut/opt/kqp_hash_combine_ut.cpp
@@ -6,8 +6,9 @@ namespace NKqp {
 using namespace NYdb;
 using namespace NYdb::NTable;
 
-Y_UNIT_TEST_SUITE(KqpHashCombineReplacement) {
-    Y_UNIT_TEST_TWIN(DqHashCombineTest, UseDqHashCombine) {
+namespace {
+    TKikimrSettings CreateSettings()
+    {
         TKikimrSettings settings = TKikimrSettings().SetWithSampleTables(false);
 
         settings.AppConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
@@ -17,9 +18,12 @@ Y_UNIT_TEST_SUITE(KqpHashCombineReplacement) {
         combinerMemLimit.SetName("_KqpYqlCombinerMemoryLimit");
         combinerMemLimit.SetValue("1000000");
         settings.KqpSettings.emplace_back(combinerMemLimit);
-        TKikimrRunner kikimr(settings);
 
-        auto queryClient = kikimr.GetQueryClient();
+        return settings;
+    }
+
+    void PrefillTables(NYdb::NQuery::TQueryClient& queryClient)
+    {
         {
             auto status = queryClient.ExecuteQuery(
                 R"(
@@ -34,19 +38,41 @@ Y_UNIT_TEST_SUITE(KqpHashCombineReplacement) {
             ).GetValueSync();
             UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
         }
-
         {
             auto status = queryClient.ExecuteQuery(
                 R"(
                     INSERT INTO `/Root/aggregatable` (id, group_key, data) VALUES
                         (1, 0, 100),
-                        (2, 0, 200),
+                        (2, 0, 600),
                         (3, 1, 300),
                         (4, 1, 400)
                 )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()
             ).GetValueSync();
             UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
         }
+    }
+
+    void CheckGroupByResultSet(TResultSet& resultSet)
+    {
+        // Check the result of sum(data) as data_sum group by group_key
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 2);
+        TResultSetParser rp(resultSet);
+        while (rp.TryNextRow()) {
+            ssize_t idx = rp.ColumnIndex("data_sum");
+            UNIT_ASSERT(idx >= 0);
+            UNIT_ASSERT(rp.GetValue(idx).GetProto().int64_value() == 700);
+        }
+    }
+}
+
+
+Y_UNIT_TEST_SUITE(KqpHashCombineReplacement) {
+    Y_UNIT_TEST_TWIN(DqHashCombineTest, UseDqHashCombine) {
+        auto settings = CreateSettings();
+        TKikimrRunner kikimr(settings);
+
+        auto queryClient = kikimr.GetQueryClient();
+        PrefillTables(queryClient);
 
         {
             TString hints = R"(
@@ -57,7 +83,7 @@ Y_UNIT_TEST_SUITE(KqpHashCombineReplacement) {
                 PRAGMA ydb.OptUseFinalizeByKey = "true";
                 PRAGMA ydb.OptEnableOlapPushdown = "false"; -- need this to force intermediate/final combiner pair over the sample table
 
-                SELECT T.group_key, SUM(T.data)
+                SELECT T.group_key as group_key, SUM(T.data) as data_sum
                 FROM `aggregatable` AS T
                 GROUP BY group_key
             )";
@@ -69,7 +95,7 @@ Y_UNIT_TEST_SUITE(KqpHashCombineReplacement) {
             UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
 
             auto resultSet = status.GetResultSets()[0];
-            UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 2);
+            CheckGroupByResultSet(resultSet);
 
             auto explainResult = queryClient.ExecuteQuery(
                 groupQuery,
@@ -91,6 +117,50 @@ Y_UNIT_TEST_SUITE(KqpHashCombineReplacement) {
                     TStringBuilder() << "AST should NOT contain DqPhyHashCombine when disabled! Actual AST: " << ast);
             }
         }
+    }
+
+    Y_UNIT_TEST(DqHashCombineBlockTest) {
+        auto settings = CreateSettings();
+        TKikimrRunner kikimr(settings);
+
+        auto queryClient = kikimr.GetQueryClient();
+        PrefillTables(queryClient);
+
+        TString hints = R"(
+            PRAGMA TablePathPrefix = "/Root";
+            PRAGMA ydb.UseDqHashCombine = "true";
+            PRAGMA ydb.DqHashCombineUsesBlocks = "true";
+            PRAGMA ydb.OptUseFinalizeByKey = "true";
+            PRAGMA ydb.OptEnableOlapPushdown = "false"; -- need this to force intermediate/final combiner pair over the sample table
+        )";
+        TString select = R"(
+            SELECT T.group_key as group_key, SUM(T.data) as data_sum
+            FROM `aggregatable` AS T
+            GROUP BY group_key
+        )";
+
+        TString groupQuery = TStringBuilder() << hints << select;
+        auto status = queryClient.ExecuteQuery(groupQuery, NYdb::NQuery::TTxControl::BeginTx().CommitTx()).GetValueSync();
+        UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        auto resultSet = status.GetResultSets()[0];
+        CheckGroupByResultSet(resultSet);
+
+        auto explainResult = queryClient.ExecuteQuery(
+            groupQuery,
+            NYdb::NQuery::TTxControl::NoTx(),
+            NYdb::NQuery::TExecuteQuerySettings().ExecMode(NYdb::NQuery::EExecMode::Explain)
+        ).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(explainResult.GetStatus(), EStatus::SUCCESS, explainResult.GetIssues().ToString());
+        auto astOpt = explainResult.GetStats()->GetAst();
+        UNIT_ASSERT(astOpt.has_value());
+
+        TString ast = TString(*astOpt);
+        Cout << "AST: " << ast << Endl;
+
+        UNIT_ASSERT_C(ast.Contains("(return (DqPhyHashCombine"),
+            TStringBuilder() << "AST should return the result of DqPhyHashCombine directly: " << groupQuery << Endl << ast);
+        UNIT_ASSERT_C(ast.Contains("(WideCombiner (ToFlow (WideFromBlocks"),
+            TStringBuilder() << "WideCombiner input should be a block stream" << groupQuery << Endl << ast);
     }
 }
 

--- a/ydb/library/yql/dq/opt/dq_opt_peephole.h
+++ b/ydb/library/yql/dq/opt/dq_opt_peephole.h
@@ -17,6 +17,6 @@ NNodes::TExprBase DqPeepholeRewriteReplicate(const NNodes::TExprBase& node, TExp
 NNodes::TExprBase DqPeepholeRewritePureJoin(const NNodes::TExprBase& node, TExprContext& ctx);
 NNodes::TExprBase DqPeepholeDropUnusedInputs(const NNodes::TExprBase& node, TExprContext& ctx);
 NNodes::TExprBase DqPeepholeRewriteLength(const NNodes::TExprBase& node, TExprContext& ctx, TTypeAnnotationContext& typesCtx);
-NNodes::TExprBase DqPeepholeRewriteWideCombiner(const NNodes::TExprBase& node, TExprContext& ctx);
+NNodes::TExprBase DqPeepholeRewriteWideCombiner(bool useBlocks, const NNodes::TExprBase& node, TExprContext& ctx);
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -1268,15 +1268,53 @@ TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
     }
 
     auto& inputStream = input->ChildRef(TDqPhyHashCombine::idx_Input);
-    if (!EnsureStreamType(*inputStream, ctx)) {
+    if (!inputStream->GetTypeAnn()) {
         return TStatus::Error;
     }
-    auto streamType = inputStream->GetTypeAnn()->Cast<TStreamExprType>();
-    auto multiType = streamType->GetItemType();
+
+    const TTypeAnnotationNode* multiType = nullptr;
+    bool isFlow = false;
+
+    if (inputStream->GetTypeAnn()->GetKind() == ETypeAnnotationKind::Stream) {
+        auto streamType = inputStream->GetTypeAnn()->Cast<TStreamExprType>();
+        multiType = streamType->GetItemType();
+    } else if (inputStream->GetTypeAnn()->GetKind() == ETypeAnnotationKind::Flow) {
+        auto flowType = inputStream->GetTypeAnn()->Cast<TFlowExprType>();
+        multiType = flowType->GetItemType();
+        isFlow = true;
+    } else {
+        return TStatus::Error;
+    }
+
     if (!EnsureMultiType(inputStream->Pos(), *multiType, ctx)) {
         return TStatus::Error;
     }
+
+    bool needBlockWrap = false;
+
     auto itemTypes = multiType->Cast<TMultiExprType>()->GetItems();
+
+    auto firstInputColumn = itemTypes.at(0);
+    if (firstInputColumn->IsBlockOrScalar()) {
+        needBlockWrap = true;
+        TTypeAnnotationNode::TListType unwrappedTypes;
+        for (size_t i = 0; i < itemTypes.size() - 1; ++i) {
+            auto colType = itemTypes.at(i);
+            if (!EnsureBlockOrScalarType(inputStream->Pos(), *colType, ctx)) {
+                return TStatus::Error;
+            }
+            const TTypeAnnotationNode* blockContentType = nullptr;
+            if (colType->IsBlock()) {
+                blockContentType = colType->Cast<TBlockExprType>()->GetItemType();
+            } else if (colType->IsScalar()) {
+                blockContentType = colType->Cast<TScalarExprType>()->GetItemType();
+            } else {
+                YQL_ENSURE(false, "Block or scalar type expected after EnsureBlockOrScalarType");
+            }
+            unwrappedTypes.push_back(blockContentType);
+        }
+        itemTypes.swap(unwrappedTypes);
+    }
 
     // key extractor lambda
     auto& keyExtractor = input->ChildRef(TDqPhyHashCombine::idx_KeyExtractor);
@@ -1360,11 +1398,24 @@ TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
     // Derive the output type from the finishHandler
     TTypeAnnotationNode::TListType finishOutputTypes;
     for (ui32 i = 1; i < finishHandler->ChildrenSize(); ++i) {
-        finishOutputTypes.emplace_back(finishHandler->Child(i)->GetTypeAnn());
+        const auto colType = finishHandler->Child(i)->GetTypeAnn();
+        if (!needBlockWrap) {
+            finishOutputTypes.emplace_back(colType);
+        } else {
+            finishOutputTypes.emplace_back(ctx.MakeType<TBlockExprType>(colType));
+        }
+    }
+    if (needBlockWrap) {
+        finishOutputTypes.emplace_back(ctx.MakeType<TScalarExprType>(ctx.MakeType<TDataExprType>(NUdf::EDataSlot::Uint64)));
     }
     auto finishOutputType = ctx.MakeType<TMultiExprType>(finishOutputTypes);
 
-    input->SetTypeAnn(ctx.MakeType<TStreamExprType>(finishOutputType));
+    if (isFlow) {
+        input->SetTypeAnn(ctx.MakeType<TFlowExprType>(finishOutputType));
+    } else {
+        input->SetTypeAnn(ctx.MakeType<TStreamExprType>(finishOutputType));
+    }
+
     return TStatus::Ok;
 }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Remove ToFlow/WideFromBlocks/ToFlow at the DqHashCombiner input. Automatically switch between flow/stream and wide/block implementations and ensure proper type annotations. Add FromFlow/WideFromBlocks on top of the DqHashCombiner output if necessary. The optimizer will remove these extra FromFlow/WideFromBlocks if possible (e.g. in case the DqHashCombiner is the only computation node before the output channel) and properly propagate the block type to the next DQ stage.