### PR TITLE
Remove excessive Get+block checks

### DIFF
--- a/ydb/core/blob_depot/agent/storage_get.cpp
+++ b/ydb/core/blob_depot/agent/storage_get.cpp
@@ -28,18 +28,6 @@ namespace NKikimr::NBlobDepot {
                     }
                 }
 
-                if (const auto& blk = Request.ForceBlockTabletData; blk && blk->Generation) {
-                    ui32 blockedGeneration;
-                    if (CheckBlockForTablet(blk->Id, std::nullopt, &blockedGeneration) != NKikimrProto::OK) {
-                        return;
-                    }
-                    if (blockedGeneration != blk->Generation) {
-                        // this can happen only in distributed storage, but not possible in BlobDepot
-                        return EndWithError(NKikimrProto::ERROR, "incorrect blocked generation provided for"
-                            " ForceBlockTabletData in TEvGet query to BlobDepot");
-                    }
-                }
-
                 if (IS_LOG_PRIORITY_ENABLED(NLog::PRI_TRACE, NKikimrServices::BLOB_DEPOT_EVENTS)) {
                     for (ui32 i = 0; i < Request.QuerySize; ++i) {
                         const auto& q = Request.Queries[i];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Remove excessive Get+block checks

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This removes excessive check as it is not possible in BlobDepot anyway, but leads to false-positive failure preventing correct tablet boot-up sometimes.