### PR TITLE
[stable-25-3-1] Olap s3 import/export: integer overflow bugfix (#28275)

### DIFF
--- a/ydb/library/yql/providers/s3/actors/yql_arrow_column_converters.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_arrow_column_converters.cpp
@@ -115,7 +115,7 @@ std::shared_ptr<arrow::Array> ArrowTypeAsYqlDatetime(const std::shared_ptr<arrow
         }
 
         const TArrowType baseValue = item.As<TArrowType>();
-        if (baseValue < 0 && baseValue > static_cast<int64_t>(::NYql::NUdf::MAX_DATETIME)) {
+        if (baseValue < 0 || baseValue > static_cast<int64_t>(::NYql::NUdf::MAX_DATETIME)) {
             throw parquet::ParquetException(TStringBuilder() << "datetime in parquet is out of range [0, " << ::NYql::NUdf::MAX_DATETIME << "]: " << baseValue);
         }
 
@@ -128,9 +128,9 @@ std::shared_ptr<arrow::Array> ArrowTypeAsYqlDatetime(const std::shared_ptr<arrow
     return builder.Build(true).make_array();
 }
 
-template <bool isOptional, typename TArrowType>
+template <bool isOptional>
 std::shared_ptr<arrow::Array> ArrowTimestampAsYqlDatetime(const std::shared_ptr<arrow::DataType>& targetType, const std::shared_ptr<arrow::Array>& value, ui32 multiplier) {
-    ::NYql::NUdf::TFixedSizeArrayBuilder<TArrowType, isOptional> builder(NKikimr::NMiniKQL::TTypeInfoHelper(), targetType, *arrow::system_memory_pool(), value->length());
+    ::NYql::NUdf::TFixedSizeArrayBuilder<ui32, isOptional> builder(NKikimr::NMiniKQL::TTypeInfoHelper(), targetType, *arrow::system_memory_pool(), value->length());
     ::NYql::NUdf::TFixedSizeBlockReader<i64, isOptional> reader;
     for (i64 i = 0; i < value->length(); ++i) {
         const NUdf::TBlockItem item = reader.GetItem(*value->data(), i);
@@ -144,15 +144,54 @@ std::shared_ptr<arrow::Array> ArrowTimestampAsYqlDatetime(const std::shared_ptr<
         }
 
         const i64 baseValue = item.As<i64>();
-        if (baseValue < 0 && baseValue > static_cast<int64_t>(::NYql::NUdf::MAX_DATETIME)) {
-            throw parquet::ParquetException(TStringBuilder() << "datetime in parquet is out of range [0, " << ::NYql::NUdf::MAX_DATETIME << "]: " << baseValue);
+        if (baseValue < 0 || baseValue > static_cast<int64_t>(::NYql::NUdf::MAX_DATETIME) * multiplier) {
+            throw parquet::ParquetException(TStringBuilder()
+                << "datetime in parquet is out of range [0, " << ::NYql::NUdf::MAX_DATETIME << "](seconds): "
+                << baseValue << "(seconds)");
         }
 
         if (baseValue % multiplier) {
-            throw parquet::ParquetException(TStringBuilder() << "datetime in parquet should have integer amount of seconds, have: " << baseValue * 1.0 / multiplier);
+            throw parquet::ParquetException(TStringBuilder()
+                << "datetime in parquet should have integer amount of seconds, have: "
+                << baseValue * 1.0 / multiplier);
         }
-        const TArrowType v = baseValue / static_cast<ui64>(multiplier);
-        builder.Add(NUdf::TBlockItem(static_cast<TArrowType>(v)));
+        const ui32 v = baseValue / multiplier;
+        builder.Add(NUdf::TBlockItem(v));
+    }
+    return builder.Build(true).make_array();
+}
+
+template <bool isOptional>
+std::shared_ptr<arrow::Array> ArrowTimestampAsYqlDatetime64(const std::shared_ptr<arrow::DataType>& targetType, const std::shared_ptr<arrow::Array>& value, ui32 multiplier) {
+    ::NYql::NUdf::TFixedSizeArrayBuilder<i64, isOptional> builder(NKikimr::NMiniKQL::TTypeInfoHelper(), targetType, *arrow::system_memory_pool(), value->length());
+    ::NYql::NUdf::TFixedSizeBlockReader<i64, isOptional> reader;
+    const i64 minDatetime64 = static_cast<int64_t>(::NYql::NUdf::MIN_DATETIME64);
+    const i64 maxDatetime64 = static_cast<int64_t>(::NYql::NUdf::MAX_DATETIME64);
+    for (i64 i = 0; i < value->length(); ++i) {
+        const NUdf::TBlockItem item = reader.GetItem(*value->data(), i);
+        if constexpr (isOptional) {
+            if (!item) {
+                builder.Add(item);
+                continue;
+            }
+        } else if (!item) {
+            throw parquet::ParquetException(TStringBuilder() << "null value for datetime could not be represented in non-optional type");
+        }
+
+        const i64 baseValue = item.As<i64>();
+        if (baseValue < minDatetime64 * multiplier || baseValue > maxDatetime64 * multiplier) {
+            throw parquet::ParquetException(TStringBuilder()
+                << "datetime in parquet is out of range [" << minDatetime64 << ", " << maxDatetime64 << "](seconds): "
+                << baseValue / multiplier << "(seconds)");
+        }
+
+        if (baseValue % multiplier) {
+            throw parquet::ParquetException(TStringBuilder()
+                << "datetime in parquet should have integer amount of seconds, have: "
+                << baseValue * 1.0 / multiplier);
+        }
+        const i64 v = baseValue / static_cast<i64>(multiplier);
+        builder.Add(NUdf::TBlockItem(v));
     }
     return builder.Build(true).make_array();
 }
@@ -360,16 +399,16 @@ TColumnConverter ArrowDate64AsYqlDatetime(const std::shared_ptr<arrow::DataType>
 TColumnConverter ArrowTimestampAsYqlDatetime(const std::shared_ptr<arrow::DataType>& targetType, bool isOptional, arrow::TimeUnit::type timeUnit) {
     return [targetType, isOptional, multiplier = GetMultiplierForDatetime(timeUnit)](const std::shared_ptr<arrow::Array>& value) {
         return isOptional
-                ? ArrowTimestampAsYqlDatetime<true, ui32>(targetType, value, multiplier)
-                : ArrowTimestampAsYqlDatetime<false, ui32>(targetType, value, multiplier);
+                ? ArrowTimestampAsYqlDatetime<true>(targetType, value, multiplier)
+                : ArrowTimestampAsYqlDatetime<false>(targetType, value, multiplier);
     };
 }
 
 TColumnConverter ArrowTimestampAsYqlDatetime64(const std::shared_ptr<arrow::DataType>& targetType, bool isOptional, arrow::TimeUnit::type timeUnit) {
     return [targetType, isOptional, multiplier = GetMultiplierForDatetime(timeUnit)](const std::shared_ptr<arrow::Array>& value) {
         return isOptional
-                ? ArrowTimestampAsYqlDatetime<true, i64>(targetType, value, multiplier)
-                : ArrowTimestampAsYqlDatetime<false, i64>(targetType, value, multiplier);
+                ? ArrowTimestampAsYqlDatetime64<true>(targetType, value, multiplier)
+                : ArrowTimestampAsYqlDatetime64<false>(targetType, value, multiplier);
     };
 }
 

--- a/ydb/tests/olap/s3_import/test_types_and_formats.py
+++ b/ydb/tests/olap/s3_import/test_types_and_formats.py
@@ -364,7 +364,7 @@ class TestTypesAndFormats(S3ImportTestBase):
                 )
         """)
 
-        test_bucket = "parquet_bucket"
+        test_bucket = "datetime_bucket"
         self.s3_client.create_bucket(test_bucket)
 
         access_key_id_secret_name = f"{test_bucket}_key_id"

--- a/ydb/tests/olap/s3_import/test_types_and_formats.py
+++ b/ydb/tests/olap/s3_import/test_types_and_formats.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import ydb
 
 from ydb.tests.library.test_meta import link_test_case
 from ydb.tests.olap.s3_import.base import S3ImportTestBase
@@ -286,3 +287,167 @@ class TestTypesAndFormats(S3ImportTestBase):
         """)
 
         self._check_tables_hash(olap_table_name, from_s3_table_name)
+
+    @link_test_case("#18784")
+    def test_parquet_datetime_types(self):
+        olap_table_name = "olap_table"
+        s3_source_name = "s3_source"
+        s3_table_name = "s3_table"
+        from_s3_table_name = "from_s3"
+
+        table_schema = """
+            c_int32 Int32 NOT NULL,
+            c_date Date,
+            c_date32 Date32,
+            c_datetime Datetime,
+            c_datetime64 Datetime64,
+            c_timestamp Timestamp,
+            c_timestamp64 Timestamp64
+        """
+
+        self.ydb_client.query(f"""
+            CREATE TABLE {olap_table_name} (
+                {table_schema},
+                PRIMARY KEY (c_int32)
+            ) WITH (
+                STORE = COLUMN
+            );
+        """)
+
+        self.ydb_client.query(f"""
+            UPSERT INTO {olap_table_name} (c_int32, c_date, c_date32, c_datetime, c_datetime64, c_timestamp, c_timestamp64)
+            VALUES
+                (
+                    1,
+                    Date("2025-08-25"),
+                    Date32("2025-08-25"),
+                    Datetime("2025-08-25T10:00:00Z"),
+                    Datetime64("2025-08-25T10:00:00Z"),
+                    Timestamp("2025-08-25T10:00:00Z"),
+                    Timestamp64("2025-08-25T10:00:00Z")
+                ),
+                (
+                    2,
+                    Date("1970-01-01"),
+                    Date32("1900-01-01"),
+                    Datetime("1970-01-01T00:00:00Z"),
+                    Datetime64("1900-01-01T00:00:00Z"),
+                    Timestamp("1970-01-01T00:00:00Z"),
+                    Timestamp64("1900-01-01T00:00:00Z")
+                ),
+                (
+                    3,
+                    Date("2100-01-01"),
+                    Date32("3100-01-01"),
+                    Datetime("2100-01-01T00:00:00Z"),
+                    Datetime64("3100-01-01T00:00:00Z"),
+                    Timestamp("2100-01-01T00:00:00Z"),
+                    Timestamp64("3100-01-01T00:00:00Z")
+                ),
+                (
+                    4,
+                    Date("1970-01-01"),
+                    Date32("0001-01-01"),
+                    Datetime("1970-01-01T00:00:00Z"),
+                    Datetime64("0001-01-01T00:00:00Z"),
+                    Timestamp("1970-01-01T00:00:00Z"),
+                    Timestamp64("0001-01-01T00:00:00Z")
+                ),
+                (
+                    5,
+                    Date("2105-12-31"),
+                    Date32("148107-12-31"),
+                    Datetime("2105-12-31T23:59:59Z"),
+                    Datetime64("148107-12-31T23:59:59Z"),
+                    Timestamp("2105-12-31T23:59:59Z"),
+                    Timestamp64("148107-12-31T23:59:59Z")
+                )
+        """)
+
+        test_bucket = "parquet_bucket"
+        self.s3_client.create_bucket(test_bucket)
+
+        access_key_id_secret_name = f"{test_bucket}_key_id"
+        access_key_secret_secret_name = f"{test_bucket}_key_secret"
+        self.ydb_client.query(f"CREATE OBJECT {access_key_id_secret_name} (TYPE SECRET) WITH value='{self.s3_client.key_id}'")
+        self.ydb_client.query(f"CREATE OBJECT {access_key_secret_secret_name} (TYPE SECRET) WITH value='{self.s3_client.key_secret}'")
+
+        self.ydb_client.query(f"""
+            CREATE EXTERNAL DATA SOURCE {s3_source_name} WITH (
+                SOURCE_TYPE = "ObjectStorage",
+                LOCATION = "{self.s3_mock.endpoint}/{test_bucket}",
+                AUTH_METHOD="AWS",
+                AWS_ACCESS_KEY_ID_SECRET_NAME="{access_key_id_secret_name}",
+                AWS_SECRET_ACCESS_KEY_SECRET_NAME="{access_key_secret_secret_name}",
+                AWS_REGION="{self.s3_client.region}"
+            );
+
+            CREATE EXTERNAL TABLE {s3_table_name} (
+                {table_schema}
+            ) WITH (
+                DATA_SOURCE="{s3_source_name}",
+                LOCATION="/test_folder/",
+                FORMAT="parquet"
+            );
+        """)
+
+        logger.info("Exporting into s3...")
+        self.ydb_client.query(f"""
+            PRAGMA s3.UseBlocksSink = "true";
+
+            INSERT INTO {s3_table_name} SELECT * FROM {olap_table_name};
+        """)
+        logger.info(f"Exporting finished, bucket stats: {self.s3_client.get_bucket_stat(test_bucket)}")
+
+        logger.info("Importing into ydb...")
+        self.ydb_client.query(f"""
+            CREATE TABLE {from_s3_table_name} (
+                PRIMARY KEY (c_int32)
+            ) WITH (
+                STORE = COLUMN
+            ) AS SELECT * FROM {s3_table_name}
+        """)
+
+        self._check_tables_hash(olap_table_name, from_s3_table_name)
+
+        erronious_query = f"""
+            UPSERT INTO {olap_table_name} (c_int32, c_date, c_date32, c_datetime, c_datetime64, c_timestamp, c_timestamp64)
+            VALUES
+                (
+                    6,
+                    Date("1969-12-31"),
+                    Date32("-144170-12-31"),
+                    Datetime("1969-12-31T23:59:59Z"),
+                    Datetime64("-144170-12-31T23:59:59Z"),
+                    Timestamp("1969-12-31T23:59:59Z"),
+                    Timestamp64("-144170-12-31T23:59:59Z")
+                ),
+                (
+                    7,
+                    Date("2106-01-01"),
+                    Date32("148108-01-01"),
+                    Datetime("2106-01-01T00:00:00Z"),
+                    Datetime64("148108-01-01T00:00:00Z"),
+                    Timestamp("2106-01-01T00:00:00Z"),
+                    Timestamp64("148108-01-01T00:00:00Z")
+                )
+        """
+        expected_errors = [
+            "Invalid value \\\"1969-12-31\\\" for type Date",
+            "Invalid value \\\"-144170-12-31\\\" for type Date32",
+            "Invalid value \\\"1969-12-31T23:59:59Z\\\" for type Datetime",
+            "Invalid value \\\"-144170-12-31T23:59:59Z\\\" for type Datetime64",
+            "Invalid value \\\"1969-12-31T23:59:59Z\\\" for type Timestamp",
+            "Invalid value \\\"-144170-12-31T23:59:59Z\\\" for type Timestamp64",
+            "Invalid value \\\"2106-01-01\\\" for type Date",
+            "Invalid value \\\"148108-01-01\\\" for type Date32",
+            "Invalid value \\\"2106-01-01T00:00:00Z\\\" for type Datetime",
+            "Invalid value \\\"148108-01-01T00:00:00Z\\\" for type Datetime64",
+            "Invalid value \\\"2106-01-01T00:00:00Z\\\" for type Timestamp",
+            "Invalid value \\\"148108-01-01T00:00:00Z\\\" for type Timestamp64"
+        ]
+        try:
+            self.ydb_client.query(erronious_query)
+        except ydb.issues.GenericError as error:
+            for expected_error in expected_errors:
+                assert expected_error in error.message

--- a/ydb/tests/olap/s3_import/test_types_and_formats.py
+++ b/ydb/tests/olap/s3_import/test_types_and_formats.py
@@ -136,10 +136,10 @@ class TestTypesAndFormats(S3ImportTestBase):
 
     @link_test_case("#18784")
     def test_parquet_format(self):
-        olap_table_name = "olap_table"
-        s3_source_name = "s3_source"
-        s3_table_name = "s3_table"
-        from_s3_table_name = "from_s3"
+        olap_table_name = "olap_table_parquet"
+        s3_source_name = "s3_source_parquet"
+        s3_table_name = "s3_table_parquet"
+        from_s3_table_name = "from_s3_parquet"
 
         table_schema = """
             c_int8 Int8,
@@ -290,10 +290,10 @@ class TestTypesAndFormats(S3ImportTestBase):
 
     @link_test_case("#18784")
     def test_parquet_datetime_types(self):
-        olap_table_name = "olap_table"
-        s3_source_name = "s3_source"
-        s3_table_name = "s3_table"
-        from_s3_table_name = "from_s3"
+        olap_table_name = "olap_table_datetime"
+        s3_source_name = "s3_source_datetime"
+        s3_table_name = "s3_table_datetime"
+        from_s3_table_name = "from_s3_datetime"
 
         table_schema = """
             c_int32 Int32 NOT NULL,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fixes bug, that caused datetime64 values to be different after export and then import

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

fix for [YQ-4856](https://st.yandex-team.ru/YQ-4865)