### PR TITLE
25-3-1: Fix race condition in login authentication (#28655)

### DIFF
--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -204,7 +204,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
             UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
 
             // Send token without type
-            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Ticket = loginResponse.Token, .Database = "/Root/Db1"})), 0);
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Database = "/Root/Db1", .Ticket = loginResponse.Token})), 0);
             Sleep(TDuration::Seconds(1));
             // Send update security state in 1 second after send TEvAuthorizeTicket
             runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb1.GetSecurityState())), 0);
@@ -235,7 +235,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
             UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
 
             // Send token with type Login
-            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Ticket = "Login " + loginResponse.Token, .Database = "/Root/Db2"})), 0);
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Database = "/Root/Db2", .Ticket = "Login " + loginResponse.Token})), 0);
             Sleep(TDuration::Seconds(1));
             // Send update security state in 1 second after send TEvAuthorizeTicket
             runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb2.GetSecurityState())), 0);
@@ -287,7 +287,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
 
         // Send token without type
-        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Ticket = loginResponse.Token, .Database = "/Root/Db1"})), 0);
+        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Database = "/Root/Db1", .Ticket = loginResponse.Token})), 0);
         // Do no send update security state
         // runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb1.GetSecurityState())), 0);
 

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -709,6 +709,16 @@ TLoginProvider::TValidateTokenResponse TLoginProvider::ValidateToken(const TVali
     }
     return response;
 }
+bool TLoginProvider::CanDecodeToken(const TString& token) {
+    try {
+        jwt::decoded_jwt decoded_token = jwt::decode(token);
+    } catch (const std::invalid_argument& e) {
+        return false;
+    } catch (const std::runtime_error& e) {
+        return false;
+    }
+    return true;
+}
 
 TString TLoginProvider::GetTokenAudience(const TString& token) {
     try {

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -253,6 +253,7 @@ public:
     ~TLoginProvider();
 
     std::vector<TString> GetGroupsMembership(const TString& member) const;
+    static bool CanDecodeToken(const TString& token);
     static TString GetTokenAudience(const TString& token);
     static std::chrono::system_clock::time_point GetTokenExpiresAt(const TString& token);
     static TString SanitizeJwtToken(const TString& token);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes race condition where clients receive "Could not find correct token validator" error when
using newly issued tokens before LoginProvider state is updated.
https://github.com/ydb-platform/ydb/issues/28510

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Add structure for deferred tokens
* When loginProvider is absent do not return error immediate, defer parsing of token when security state will be updated
* Process deferred tokens when UpdateSecurityState arrives
* Return error for deferred tokens when delay will expired
* Add count send requests to LDAP provider in order to do not response to client before get response from LDAP provider
