### PR TITLE
Enabled shuffle elimination for aggregates by default

### DIFF
--- a/ydb/core/kqp/opt/physical/kqp_opt_phy.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy.cpp
@@ -387,7 +387,7 @@ protected:
     TMaybeNode<TExprBase> BuildShuffleStage(TExprBase node, TExprContext& ctx,
         IOptimizationContext& optCtx, const TGetParents& getParents)
     {
-        bool enableShuffleElimination = KqpCtx.Config->OptShuffleEliminationForAggregation.Get().GetOrElse(KqpCtx.Config->DefaultEnableShuffleEliminationForAggregation);
+        bool enableShuffleElimination = KqpCtx.Config->OptShuffleElimination.Get().GetOrElse(KqpCtx.Config->DefaultEnableShuffleElimination);
         TExprBase output = DqBuildShuffleStage(node, ctx, optCtx, *getParents(), IsGlobal, &TypesCtx, enableShuffleElimination);
         DumpAppliedRule("BuildShuffleStage", node.Ptr(), output.Ptr(), ctx);
         return output;
@@ -404,7 +404,7 @@ protected:
     TMaybeNode<TExprBase> BuildPartitionsStage(TExprBase node, TExprContext& ctx,
         IOptimizationContext& optCtx, const TGetParents& getParents)
     {
-        bool enableShuffleElimination = KqpCtx.Config->OptShuffleEliminationForAggregation.Get().GetOrElse(KqpCtx.Config->DefaultEnableShuffleEliminationForAggregation);
+        bool enableShuffleElimination = KqpCtx.Config->OptShuffleElimination.Get().GetOrElse(KqpCtx.Config->DefaultEnableShuffleElimination);
         TExprBase output = DqBuildPartitionsStage(node, ctx, optCtx, *getParents(), IsGlobal, &TypesCtx, enableShuffleElimination);
         DumpAppliedRule("BuildPartitionsStage", node.Ptr(), output.Ptr(), ctx);
         return output;
@@ -414,7 +414,7 @@ protected:
     TMaybeNode<TExprBase> BuildPartitionStage(TExprBase node, TExprContext& ctx,
         IOptimizationContext& optCtx, const TGetParents& getParents)
     {
-        bool enableShuffleElimination = KqpCtx.Config->OptShuffleEliminationForAggregation.Get().GetOrElse(KqpCtx.Config->DefaultEnableShuffleEliminationForAggregation);
+        bool enableShuffleElimination = KqpCtx.Config->OptShuffleElimination.Get().GetOrElse(KqpCtx.Config->DefaultEnableShuffleElimination);
         TExprBase output = DqBuildPartitionStage(node, ctx, optCtx, *getParents(), IsGlobal, &TypesCtx, enableShuffleElimination);
         DumpAppliedRule("BuildPartitionStage", node.Ptr(), output.Ptr(), ctx);
         return output;

--- a/ydb/core/kqp/provider/yql_kikimr_settings.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.cpp
@@ -90,7 +90,6 @@ TKikimrConfiguration::TKikimrConfiguration() {
     REGISTER_SETTING(*this, OptimizerHints).Parser([](const TString& v) { return NYql::TOptimizerHints::Parse(v); });
     REGISTER_SETTING(*this, OptShuffleElimination);
     REGISTER_SETTING(*this, OptShuffleEliminationWithMap);
-    REGISTER_SETTING(*this, OptShuffleEliminationForAggregation);
     REGISTER_SETTING(*this, OverridePlanner);
     REGISTER_SETTING(*this, UseGraceJoinCoreForMap);
     REGISTER_SETTING(*this, UseBlockHashJoin);

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -80,8 +80,7 @@ public:
     NCommon::TConfSetting<bool, Static> OptUseFinalizeByKey;
     NCommon::TConfSetting<bool, Static> OptShuffleElimination;
     NCommon::TConfSetting<bool, Static> OptShuffleEliminationWithMap;
-    NCommon::TConfSetting<bool, Static> OptShuffleEliminationForAggregation;
-    NCommon::TConfSetting<ui32, Static> CostBasedOptimizationLevel;
+=    NCommon::TConfSetting<ui32, Static> CostBasedOptimizationLevel;
 
     // Use CostBasedOptimizationLevel for internal usage. This is a dummy flag that is mapped to the optimization level during parsing.
     NCommon::TConfSetting<TString, Static> CostBasedOptimization;
@@ -205,7 +204,6 @@ struct TKikimrConfiguration : public TKikimrSettings, public NCommon::TSettingDi
     bool EnableSnapshotIsolationRW = false;
     bool AllowMultiBroadcasts = false;
     bool DefaultEnableShuffleElimination = false;
-    bool DefaultEnableShuffleEliminationForAggregation = false;
     bool FilterPushdownOverJoinOptionalSide = false;
     THashSet<TString> YqlCoreOptimizerFlags;
     bool EnableNewRBO = false;

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -80,7 +80,7 @@ public:
     NCommon::TConfSetting<bool, Static> OptUseFinalizeByKey;
     NCommon::TConfSetting<bool, Static> OptShuffleElimination;
     NCommon::TConfSetting<bool, Static> OptShuffleEliminationWithMap;
-=    NCommon::TConfSetting<ui32, Static> CostBasedOptimizationLevel;
+    NCommon::TConfSetting<ui32, Static> CostBasedOptimizationLevel;
 
     // Use CostBasedOptimizationLevel for internal usage. This is a dummy flag that is mapped to the optimization level during parsing.
     NCommon::TConfSetting<TString, Static> CostBasedOptimization;

--- a/ydb/core/kqp/ut/join/data/join_order/tpch10_1000s_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/tpch10_1000s_column_store.json
@@ -1,46 +1,40 @@
 {
-  "op_name":"HashShuffle",
+  "op_name":"InnerJoin (Grace)",
   "args":
     [
       {
-        "op_name":"InnerJoin (Grace)",
+        "op_name":"InnerJoin (MapJoin)",
         "args":
           [
             {
-              "op_name":"InnerJoin (MapJoin)",
-              "args":
-                [
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"customer"
-                  },
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"nation"
-                  }
-                ]
+              "op_name":"TableFullScan",
+              "table":"customer"
             },
             {
-              "op_name":"HashShuffle",
+              "op_name":"TableFullScan",
+              "table":"nation"
+            }
+          ]
+      },
+      {
+        "op_name":"HashShuffle",
+        "args":
+          [
+            {
+              "op_name":"InnerJoin (Grace)",
               "args":
                 [
                   {
-                    "op_name":"InnerJoin (Grace)",
+                    "op_name":"TableFullScan",
+                    "table":"orders"
+                  },
+                  {
+                    "op_name":"HashShuffle",
                     "args":
                       [
                         {
                           "op_name":"TableFullScan",
-                          "table":"orders"
-                        },
-                        {
-                          "op_name":"HashShuffle",
-                          "args":
-                            [
-                              {
-                                "op_name":"TableFullScan",
-                                "table":"lineitem"
-                              }
-                            ]
+                          "table":"lineitem"
                         }
                       ]
                   }

--- a/ydb/core/kqp/ut/join/data/join_order/tpch13_1000s_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/tpch13_1000s_column_store.json
@@ -3,26 +3,20 @@
   "args":
     [
       {
-        "op_name":"HashShuffle",
+        "op_name":"LeftJoin (Grace)",
         "args":
           [
             {
-              "op_name":"LeftJoin (Grace)",
+              "op_name":"TableFullScan",
+              "table":"customer"
+            },
+            {
+              "op_name":"HashShuffle",
               "args":
                 [
                   {
                     "op_name":"TableFullScan",
-                    "table":"customer"
-                  },
-                  {
-                    "op_name":"HashShuffle",
-                    "args":
-                      [
-                        {
-                          "op_name":"TableFullScan",
-                          "table":"orders"
-                        }
-                      ]
+                    "table":"orders"
                   }
                 ]
             }

--- a/ydb/core/kqp/ut/join/data/join_order/tpch17_1000s_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/tpch17_1000s_column_store.json
@@ -17,28 +17,22 @@
         "args":
           [
             {
-              "op_name":"HashShuffle",
+              "op_name":"InnerJoin (Grace)",
               "args":
                 [
                   {
-                    "op_name":"InnerJoin (Grace)",
+                    "op_name":"HashShuffle",
                     "args":
                       [
                         {
-                          "op_name":"HashShuffle",
-                          "args":
-                            [
-                              {
-                                "op_name":"TableFullScan",
-                                "table":"lineitem"
-                              }
-                            ]
-                        },
-                        {
                           "op_name":"TableFullScan",
-                          "table":"part"
+                          "table":"lineitem"
                         }
                       ]
+                  },
+                  {
+                    "op_name":"TableFullScan",
+                    "table":"part"
                   }
                 ]
             }

--- a/ydb/core/kqp/ut/join/data/join_order/tpch3_1000s_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/tpch3_1000s_column_store.json
@@ -1,46 +1,40 @@
 {
-  "op_name":"HashShuffle",
+  "op_name":"InnerJoin (Grace)",
   "args":
     [
       {
-        "op_name":"InnerJoin (Grace)",
+        "op_name":"HashShuffle",
         "args":
           [
             {
-              "op_name":"HashShuffle",
-              "args":
-                [
-                  {
-                    "op_name":"InnerJoin (Grace)",
-                    "args":
-                      [
-                        {
-                          "op_name":"TableFullScan",
-                          "table":"customer"
-                        },
-                        {
-                          "op_name":"HashShuffle",
-                          "args":
-                            [
-                              {
-                                "op_name":"TableFullScan",
-                                "table":"orders"
-                              }
-                            ]
-                        }
-                      ]
-                  }
-                ]
-            },
-            {
-              "op_name":"HashShuffle",
+              "op_name":"InnerJoin (Grace)",
               "args":
                 [
                   {
                     "op_name":"TableFullScan",
-                    "table":"lineitem"
+                    "table":"customer"
+                  },
+                  {
+                    "op_name":"HashShuffle",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"orders"
+                        }
+                      ]
                   }
                 ]
+            }
+          ]
+      },
+      {
+        "op_name":"HashShuffle",
+        "args":
+          [
+            {
+              "op_name":"TableFullScan",
+              "table":"lineitem"
             }
           ]
       }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Remove unnecessary shuffle from aggregation operators, if the data is already distributed by aggregation key

### Changelog category <!-- remove all except one -->


* Performance improvement


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
