### PR TITLE
Fix missed RDMA dummy impl for non supported platforms.

### DIFF
--- a/ydb/library/actors/interconnect/rdma/dummy.cpp
+++ b/ydb/library/actors/interconnect/rdma/dummy.cpp
@@ -31,6 +31,16 @@ ui32 TQueuePair::GetQpNum() const noexcept { return 0; }
 
 int TQueuePair::ToRtsState(const THandshakeData&) noexcept { return 0; }
 
+bool TQueuePair::IsRtsState(TQueuePair::TQpS) { return false; }
+
+TQueuePair::TQpState TQueuePair::GetState(bool /*forseUpdate*/) const noexcept {
+    return TQpErr { .Err = 22 };
+}
+
+int TQueuePair::ToErrorState() noexcept {
+    return -1;
+}
+
 THandshakeData TQueuePair::GetHandshakeData() const noexcept {
     return THandshakeData {0, 0, 0, 0};
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

We do not support RDMA on mac and windows. This dummy implementation of methods do nothing

### Changelog category <!-- remove all except one -->



* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
