### PR TITLE
Fix `Acquire(): requirement result == 0 failed` in ydb tools restore

### DIFF
--- a/ydb/library/backup/query_uploader.h
+++ b/ydb/library/backup/query_uploader.h
@@ -27,12 +27,12 @@ private:
     const TString Query;
 
     TAtomic ShouldStop;
-    TSimpleSharedPtr<IThreadPool> TasksQueue;
 
     using TRpsLimiter = TBucketQuoter<ui64>;
     TRpsLimiter RequestLimiter;
     NYdb::NTable::TTableClient& Client;
 
+    TSimpleSharedPtr<IThreadPool> TasksQueue;
 public:
     TUploader(const TOptions& opts, NYdb::NTable::TTableClient& client, const TString& query);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes [#29431](https://github.com/ydb-platform/ydb/issues/29431)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Если процесс восстановления завершается из-за ошибки в момент, когда `TUploader` еще не закончил работу. То при разрушении `TUploader` еще неостановленные треды в `TaskQueue` могут использовать уже разрушенный `RequestLimiter`, который внутри себя имеет `mutex`. Попытки залочить этот `mutex` после разрушения приводят к ошибке.