### PR TITLE
EXT-1584 Improve readability of the BSC group allocation error

### DIFF
--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -1386,7 +1386,7 @@ def dump_group_mapper_error(response: kikimr_bsconfig.TConfigResponse, args):
     else:
         print("No matching domains")
     print(
-        f"Missing Fail Realms Count: {err.MissingFailRealmsCount}\n"
-        f"Fail Realms With Missing Domains Count: {err.FailRealmsWithMissingDomainsCount}\n"
-        f"Domains With Missing Disks Count: {err.DomainsWithMissingDisksCount}"
+        f"Missing {err.RealmLocationKey}s Count: {err.MissingFailRealmsCount}\n"
+        f"{err.RealmLocationKey}s With Missing {err.DomainLocationKey}s Count: {err.FailRealmsWithMissingDomainsCount}\n"
+        f"{err.DomainLocationKey}s With Missing Disks Count: {err.DomainsWithMissingDisksCount}"
     )

--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -1347,11 +1347,12 @@ def dump_group_mapper_error(response: kikimr_bsconfig.TConfigResponse, args):
         for fail_param in response.Status[0].FailParam:
             if fail_param.HasField("GroupMapperError"):
                 err = fail_param.GroupMapperError
-    
+
     if err is None:
         return
-    
+
     table_args = SimpleNamespace(sort_by=None, columns=None, format=args.format, no_header=None)
+
     def table_generator(data: typing.Iterable[kikimr_bsconfig.TGroupMapperError.TStats], print_domain: bool = True):
         all_columns = []
         if print_domain:
@@ -1375,9 +1376,9 @@ def dump_group_mapper_error(response: kikimr_bsconfig.TConfigResponse, args):
             row['Not operational'] = str(st.NotOperational)
             row['Decommission'] = str(st.Decommission)
             rows.append(row)
-        
+
         table_output.dump(rows, table_args)
-    
+
     print("Total stats")
     table_generator([err.TotalStats], print_domain=False)
     if len(err.MatchingDomainsStats) > 0:

--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -1385,6 +1385,7 @@ def dump_group_mapper_error(response: kikimr_bsconfig.TConfigResponse, args):
         table_generator(err.MatchingDomainsStats)
     else:
         print("No matching domains")
+    print(f"OK Discs Count: {err.OkDisksCount}")
     print(
         f"Missing {err.RealmLocationKey}s Count: {err.MissingFailRealmsCount}\n"
         f"{err.RealmLocationKey}s With Missing {err.DomainLocationKey}s Count: {err.FailRealmsWithMissingDomainsCount}\n"

--- a/ydb/apps/dstool/lib/dstool_cmd_group_add.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_group_add.py
@@ -61,6 +61,7 @@ def do(args):
     response = perform_request(request)
     if not is_successful_response(response):
         common.print_request_result(args, request, response)
+        common.dump_group_mapper_error(response, args)
         sys.exit(1)
 
     pdisk_usage_before = common.build_pdisk_usage_map(base_config, count_donors=False, storage_pool=sp)

--- a/ydb/apps/dstool/lib/dstool_cmd_vdisk_evict.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_vdisk_evict.py
@@ -1,4 +1,8 @@
 import ydb.apps.dstool.lib.common as common
+import ydb.apps.dstool.lib.table as table
+import ydb.core.protos.blobstorage_config_pb2 as kikimr_bsconfig
+from typing import Iterable
+from types import SimpleNamespace
 import sys
 
 description = 'Relocate vdisks to other pdisks'
@@ -45,9 +49,64 @@ def is_successful_response(response):
     return common.is_successful_bsc_response(response)
 
 
+def stats_to_dict(st):
+    return {
+        "PDiskId": f"{st.ExamplePDiskId.NodeId}:{st.ExamplePDiskId.PDiskId}",
+        "AllSlotsAreOccupied": st.AllSlotsAreOccupied,
+        "NotEnoughSpace": st.NotEnoughSpace,
+        "NotAcceptingNewSlots": st.NotAcceptingNewSlots,
+        "NotOperational": st.NotOperational,
+        "Decommission": st.Decommission,
+    }
+
+
+def dump_group_mapper_error(err: kikimr_bsconfig.TGroupMapperError, args):
+    table_args = SimpleNamespace(sort_by=None, columns=None, format=args.format, no_header=None)
+    def table_generator(data: Iterable[kikimr_bsconfig.TGroupMapperError.TStats], print_pdisk_id: bool = True):
+        all_columns = []
+        if print_pdisk_id:
+            all_columns += ['Example PDiskId from domain']
+        all_columns += [
+            'All slots are occupied',
+            'Not enough space',
+            'Not accepting new slots',
+            'Not operational',
+            'Decommission',
+        ]
+        table_output = table.TableOutput(all_columns)
+        rows = []
+        for st in data:
+            row = {}
+            if print_pdisk_id:
+                row['Example PDiskId from domain'] = f"{st.ExamplePDiskId.NodeId}:{st.ExamplePDiskId.PDiskId}"
+            row['All slots are occupied'] = str(st.AllSlotsAreOccupied)
+            row['Not enough space'] = str(st.NotEnoughSpace)
+            row['Not accepting new slots'] = str(st.NotAcceptingNewSlots)
+            row['Not operational'] = str(st.NotOperational)
+            row['Decommission'] = str(st.Decommission)
+            rows.append(row)
+        
+        table_output.dump(rows, table_args)
+    
+    print("Total stats")
+    table_generator([err.TotalStats], print_pdisk_id=False)
+    if len(err.MatchingDomainsStats) > 0:
+        print("Matching domains")
+        table_generator(err.MatchingDomainsStats)
+    else:
+        print("No matching domains")
+
+
 def do(args):
     request = create_request(args)
     response = perform_request(request)
     common.print_request_result(args, request, response)
     if not is_successful_response(response):
+        verbose = getattr(args, 'verbose', False)
+        if (len(response.Status) == 1) and verbose:
+            for fail_param in response.Status[0].FailParam:
+                if fail_param.HasField("GroupMapperError"):
+                    group_mapper_error = fail_param.GroupMapperError
+                    dump_group_mapper_error(group_mapper_error, args)
+                    
         sys.exit(1)

--- a/ydb/apps/dstool/lib/dstool_cmd_vdisk_evict.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_vdisk_evict.py
@@ -1,8 +1,5 @@
 import ydb.apps.dstool.lib.common as common
-import ydb.apps.dstool.lib.table as table
 import ydb.core.protos.blobstorage_config_pb2 as kikimr_bsconfig
-from typing import Iterable
-from types import SimpleNamespace
 import sys
 
 description = 'Relocate vdisks to other pdisks'
@@ -49,64 +46,10 @@ def is_successful_response(response):
     return common.is_successful_bsc_response(response)
 
 
-def stats_to_dict(st):
-    return {
-        "PDiskId": f"{st.ExamplePDiskId.NodeId}:{st.ExamplePDiskId.PDiskId}",
-        "AllSlotsAreOccupied": st.AllSlotsAreOccupied,
-        "NotEnoughSpace": st.NotEnoughSpace,
-        "NotAcceptingNewSlots": st.NotAcceptingNewSlots,
-        "NotOperational": st.NotOperational,
-        "Decommission": st.Decommission,
-    }
-
-
-def dump_group_mapper_error(err: kikimr_bsconfig.TGroupMapperError, args):
-    table_args = SimpleNamespace(sort_by=None, columns=None, format=args.format, no_header=None)
-    def table_generator(data: Iterable[kikimr_bsconfig.TGroupMapperError.TStats], print_pdisk_id: bool = True):
-        all_columns = []
-        if print_pdisk_id:
-            all_columns += ['Example PDiskId from domain']
-        all_columns += [
-            'All slots are occupied',
-            'Not enough space',
-            'Not accepting new slots',
-            'Not operational',
-            'Decommission',
-        ]
-        table_output = table.TableOutput(all_columns)
-        rows = []
-        for st in data:
-            row = {}
-            if print_pdisk_id:
-                row['Example PDiskId from domain'] = f"{st.ExamplePDiskId.NodeId}:{st.ExamplePDiskId.PDiskId}"
-            row['All slots are occupied'] = str(st.AllSlotsAreOccupied)
-            row['Not enough space'] = str(st.NotEnoughSpace)
-            row['Not accepting new slots'] = str(st.NotAcceptingNewSlots)
-            row['Not operational'] = str(st.NotOperational)
-            row['Decommission'] = str(st.Decommission)
-            rows.append(row)
-        
-        table_output.dump(rows, table_args)
-    
-    print("Total stats")
-    table_generator([err.TotalStats], print_pdisk_id=False)
-    if len(err.MatchingDomainsStats) > 0:
-        print("Matching domains")
-        table_generator(err.MatchingDomainsStats)
-    else:
-        print("No matching domains")
-
-
 def do(args):
     request = create_request(args)
     response = perform_request(request)
     common.print_request_result(args, request, response)
     if not is_successful_response(response):
-        verbose = getattr(args, 'verbose', False)
-        if (len(response.Status) == 1) and verbose:
-            for fail_param in response.Status[0].FailParam:
-                if fail_param.HasField("GroupMapperError"):
-                    group_mapper_error = fail_param.GroupMapperError
-                    dump_group_mapper_error(group_mapper_error, args)
-                    
+        common.dump_group_mapper_error(response, args)
         sys.exit(1)

--- a/ydb/apps/dstool/lib/dstool_cmd_vdisk_evict.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_vdisk_evict.py
@@ -1,5 +1,4 @@
 import ydb.apps.dstool.lib.common as common
-import ydb.core.protos.blobstorage_config_pb2 as kikimr_bsconfig
 import sys
 
 description = 'Relocate vdisks to other pdisks'

--- a/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
@@ -483,11 +483,11 @@ namespace NKikimr::NStorage {
             return s.Str();
         };
 
-        TString error;
+        NBsController::TGroupMapperError error;
         const ui32 groupSizeInUnits = 1; // static groups are always single-unit
         if (!mapper.AllocateGroup(groupId.GetRawId(), groupDefinition, replacedDisks, forbid,
                 groupSizeInUnits, requiredSpace, false, {}, error)) {
-            throw TExConfigError() << "group allocation failed Error# " << error
+            throw TExConfigError() << "group allocation failed Error# " << error.ErrorMessage
                 << " groupDefinition# " << dumpGroupDefinition();
         }
 

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_genconfig.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_genconfig.cpp
@@ -233,9 +233,9 @@ public:
         }
 
         NBsController::TGroupMapper::TGroupDefinition group;
-        TString error;
+        NBsController::TGroupMapperError error;
         if (!mapper.AllocateGroup(0, group, {}, {}, 1u, 0, false, {}, error)) {
-            Cerr << "Can't allocate group: " << error << Endl;
+            Cerr << "Can't allocate group: " << error.ErrorMessage << Endl;
             return EXIT_FAILURE;
         }
 

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -819,6 +819,8 @@ namespace NKikimr {
             groupMapperErrorProto.SetMissingFailRealmsCount(error.MissingFailRealmsCount);
             groupMapperErrorProto.SetFailRealmsWithMissingDomainsCount(error.FailRealmsWithMissingDomainsCount);
             groupMapperErrorProto.SetDomainsWithMissingDisksCount(error.DomainsWithMissingDisksCount);
+            groupMapperErrorProto.SetRealmLocationKey(error.RealmLocationKey);
+            groupMapperErrorProto.SetDomainLocationKey(error.DomainLocationKey);
         }
 
         void TBlobStorageController::FitGroupsForUserConfig(TConfigState& state, ui32 availabilityDomainId,

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -804,10 +804,7 @@ namespace NKikimr {
 
         void FillGroupMapperError(NKikimrBlobStorage::TGroupMapperError& groupMapperErrorProto, const TGroupMapperError& error) {
             auto fillStats = [](NKikimrBlobStorage::TGroupMapperError::TStats& statsProto, const TGroupMapperError::TStats& stats) {
-                auto* examplePdiskId = statsProto.MutableExamplePDiskId();
-                examplePdiskId->SetNodeId(stats.ExamplePDiskId.NodeId);
-                examplePdiskId->SetPDiskId(stats.ExamplePDiskId.PDiskId);
-
+                statsProto.SetDomain(stats.Domain);
                 statsProto.SetAllSlotsAreOccupied(stats.AllSlotsAreOccupied);
                 statsProto.SetNotEnoughSpace(stats.NotEnoughSpace);
                 statsProto.SetNotAcceptingNewSlots(stats.NotAcceptingNewSlots);
@@ -819,6 +816,9 @@ namespace NKikimr {
                 auto* domainStatsProto = groupMapperErrorProto.AddMatchingDomainsStats();
                 fillStats(*domainStatsProto, domainStat);
             }
+            groupMapperErrorProto.SetMissingFailRealmsCount(error.MissingFailRealmsCount);
+            groupMapperErrorProto.SetFailRealmsWithMissingDomainsCount(error.FailRealmsWithMissingDomainsCount);
+            groupMapperErrorProto.SetDomainsWithMissingDisksCount(error.DomainsWithMissingDisksCount);
         }
 
         void TBlobStorageController::FitGroupsForUserConfig(TConfigState& state, ui32 availabilityDomainId,

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -818,7 +818,7 @@ namespace NKikimr {
             }
             groupMapperErrorProto.SetMissingFailRealmsCount(error.MissingFailRealmsCount);
             groupMapperErrorProto.SetFailRealmsWithMissingDomainsCount(error.FailRealmsWithMissingDomainsCount);
-            groupMapperErrorProto.SetDomainsWithMissingDisksCount(error.DomainsWithMissingDisksCount);
+            groupMapperErrorProto.SetOkDisksCount(error.OkDisksCount);
             groupMapperErrorProto.SetRealmLocationKey(error.RealmLocationKey);
             groupMapperErrorProto.SetDomainLocationKey(error.DomainLocationKey);
         }

--- a/ydb/core/mind/bscontroller/group_geometry_info.h
+++ b/ydb/core/mind/bscontroller/group_geometry_info.h
@@ -8,7 +8,9 @@
 
 namespace NKikimr::NBsController {
 
-    struct TExFitGroupError : yexception {};
+    struct TExFitGroupError : yexception {
+        std::optional<TGroupMapperError> GroupMapperError;
+    };
 
     class TGroupGeometryInfo {
         TBlobStorageGroupType Type;
@@ -87,14 +89,17 @@ namespace NKikimr::NBsController {
                 TGroupMapper::TGroupConstraintsDefinition& constrainsts,
                 const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TGroupMapper::TForbiddenPDisks forbid,
                 ui32 groupSizeInUnits, i64 requiredSpace, TBridgePileId bridgePileId) const {
-            TString error;
+            TGroupMapperError error;
             for (const bool requireOperational : {true, false}) {
                 if (mapper.AllocateGroup(groupId.GetRawId(), group, constrainsts, replacedDisks, forbid, groupSizeInUnits, requiredSpace,
                         requireOperational, bridgePileId, error)) {
                     return;
                 }
-            }
-            throw TExFitGroupError() << "failed to allocate group: " << error;
+            };
+            TExFitGroupError errorException;
+            errorException << "failed to allocate group: " << error.ErrorMessage;
+            errorException.GroupMapperError = std::move(error);
+            throw errorException;
         }
 
         // returns pair of previous VDisk and PDisk id's

--- a/ydb/core/mind/bscontroller/group_mapper.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper.cpp
@@ -1145,7 +1145,7 @@ namespace NKikimr::NBsController {
 
                     prevPosition = position;
                 }
-                s << ")]}\n";
+                s << ")]}";
 
                 // Handle last domain
                 if (!domainAlreadyOccupied) {

--- a/ydb/core/mind/bscontroller/group_mapper.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper.cpp
@@ -92,7 +92,7 @@ namespace NKikimr::NBsController {
             TImpl& Self;
             const TBlobStorageGroupInfo::TTopology Topology;
             THashSet<TPDiskId> OldGroupContent; // set of all existing disks in the group, inclusing ones which are replaced
-            THashSet<TPDiskId> ReplacedDisks; // set of replaced pdisks
+            THashSet<TPDiskId> ReplacedDisks; // set of pdisks whose vdisks are being replaced
             const i64 RequiredSpace;
             const bool RequireOperational;
             TForbiddenPDisks ForbiddenDisks;

--- a/ydb/core/mind/bscontroller/group_mapper.h
+++ b/ydb/core/mind/bscontroller/group_mapper.h
@@ -24,6 +24,8 @@ namespace NKikimr {
             ui32 MissingFailRealmsCount = 0;
             ui32 FailRealmsWithMissingDomainsCount = 0;
             ui32 DomainsWithMissingDisksCount = 0;
+            TString RealmLocationKey;
+            TString DomainLocationKey;
         };
 
         class TPDiskSlotTracker {

--- a/ydb/core/mind/bscontroller/group_mapper.h
+++ b/ydb/core/mind/bscontroller/group_mapper.h
@@ -24,6 +24,7 @@ namespace NKikimr {
             ui32 MissingFailRealmsCount = 0;
             ui32 FailRealmsWithMissingDomainsCount = 0;
             ui32 DomainsWithMissingDisksCount = 0;
+            ui32 OkDisksCount = 0;
             TString RealmLocationKey;
             TString DomainLocationKey;
         };

--- a/ydb/core/mind/bscontroller/group_mapper.h
+++ b/ydb/core/mind/bscontroller/group_mapper.h
@@ -10,7 +10,7 @@ namespace NKikimr {
 
         struct TGroupMapperError {
             struct TStats {
-                TPDiskId ExamplePDiskId;
+                TString Domain;
                 ui32 AllSlotsAreOccupied = 0;
                 ui32 NotEnoughSpace = 0;
                 ui32 NotAcceptingNewSlots = 0;
@@ -21,6 +21,9 @@ namespace NKikimr {
             TString ErrorMessage;
             TStats TotalStats;
             std::vector<TStats> MatchingDomainsStats;
+            ui32 MissingFailRealmsCount = 0;
+            ui32 FailRealmsWithMissingDomainsCount = 0;
+            ui32 DomainsWithMissingDisksCount = 0;
         };
 
         class TPDiskSlotTracker {

--- a/ydb/core/mind/bscontroller/group_mapper.h
+++ b/ydb/core/mind/bscontroller/group_mapper.h
@@ -8,6 +8,21 @@ namespace NKikimr {
 
         class TGroupGeometryInfo;
 
+        struct TGroupMapperError {
+            struct TStats {
+                TPDiskId ExamplePDiskId;
+                ui32 AllSlotsAreOccupied = 0;
+                ui32 NotEnoughSpace = 0;
+                ui32 NotAcceptingNewSlots = 0;
+                ui32 NotOperational = 0;
+                ui32 Decommission = 0;
+            };
+
+            TString ErrorMessage;
+            TStats TotalStats;
+            std::vector<TStats> MatchingDomainsStats;
+        };
+
         class TPDiskSlotTracker {
             absl::flat_hash_map<ui32, ui16> ReplicatingVDisksByNode;
             absl::flat_hash_map<TPDiskId, ui8> ReplicatingVDisksByPDisk;
@@ -141,10 +156,10 @@ namespace NKikimr {
             // prefix+infix part gives us distinct fail realms we can use while generating groups.
             bool AllocateGroup(ui32 groupId, TGroupDefinition& group, TGroupMapper::TGroupConstraintsDefinition& constraints,
                 const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TForbiddenPDisks forbid, ui32 groupSizeInUnits, i64 requiredSpace,
-                bool requireOperational, TBridgePileId bridgePileId, TString& error);
+                bool requireOperational, TBridgePileId bridgePileId, TGroupMapperError& error);
             bool AllocateGroup(ui32 groupId, TGroupDefinition& group, const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks,
                 TForbiddenPDisks forbid, ui32 groupSizeInUnits, i64 requiredSpace, bool requireOperational, TBridgePileId bridgePileId,
-                TString& error);
+                TGroupMapperError& error);
 
             struct TMisplacedVDisks {
                 enum EFailLevel : ui32 {

--- a/ydb/core/mind/bscontroller/group_mapper_ut.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper_ut.cpp
@@ -194,13 +194,13 @@ public:
 
     ui32 AllocateGroup(TGroupMapper& mapper, TGroupMapper::TGroupDefinition& group, ui32 groupSizeInUnits = 0u, bool allowFailure = false) {
         ui32 groupId = NextGroupId++;
-        TString error;
+        TGroupMapperError error;
         bool success = mapper.AllocateGroup(groupId, group, {}, {}, groupSizeInUnits, 0, false, TBridgePileId(), error);
         if (!success && allowFailure) {
-            Ctest << "error# " << error << Endl;
+            Ctest << "error# " << error.ErrorMessage << Endl;
             return 0;
         }
-        UNIT_ASSERT_C(success, error);
+        UNIT_ASSERT_C(success, error.ErrorMessage);
         TGroupRecord& record = Groups[groupId];
         record.Group = group;
         record.GroupSizeInUnits = groupSizeInUnits;
@@ -242,11 +242,11 @@ public:
 
         Ctest << "groupId# " << groupId << " reallocating group# " << FormatGroup(group.Group) << Endl;
 
-        TString error;
+        TGroupMapperError error;
         bool success = mapper.AllocateGroup(groupId, group.Group, replacedDisks, std::move(forbid), group.GroupSizeInUnits, 0,
             requireOperational, TBridgePileId(), error);
         if (!success) {
-            Ctest << "error# " << error << Endl;
+            Ctest << "error# " << error.ErrorMessage << Endl;
             if (allowError) {
                 // revert group to its original state
                 for (const auto& [vdiskId, pdiskId] : replacedDisks) {

--- a/ydb/core/mind/bscontroller/storage_stats_calculator.cpp
+++ b/ydb/core/mind/bscontroller/storage_stats_calculator.cpp
@@ -157,7 +157,7 @@ public:
 
                 // calculate number of groups we can create without accounting reserve
                 TGroupMapper::TGroupDefinition group;
-                TString error;
+                TGroupMapperError error;
                 std::deque<ui64> groupSizes;
                 while (mapper.AllocateGroup(groupSizes.size(), group, {}, {}, 1u, 0, false, {}, error)) {
                     std::vector<TGroupDiskInfo> disks;

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -842,6 +842,19 @@ message TReassignedItem {
     string ToPath = 7;
 }
 
+message TGroupMapperError {
+    message TStats {
+        NKikimrBlobStorage.TPDiskId ExamplePDiskId = 1;
+        uint32 AllSlotsAreOccupied = 2;
+        uint32 NotEnoughSpace = 3;
+        uint32 NotAcceptingNewSlots = 4;
+        uint32 NotOperational = 5;
+        uint32 Decommission = 6;
+    }
+    TStats TotalStats = 1;
+    repeated TStats MatchingDomainsStats = 2;
+}
+
 message TConfigResponse {
     message TStatus {
         enum EFailReason {
@@ -880,6 +893,7 @@ message TConfigResponse {
                 string DiskSerialNumber = 15;
                 uint32 GroupGenerationProvided = 16;
                 uint32 GroupGenerationExpected = 17;
+                TGroupMapperError GroupMapperError = 18;
             }
         }
 

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -844,7 +844,7 @@ message TReassignedItem {
 
 message TGroupMapperError {
     message TStats {
-        NKikimrBlobStorage.TPDiskId ExamplePDiskId = 1;
+        string Domain = 1;
         uint32 AllSlotsAreOccupied = 2;
         uint32 NotEnoughSpace = 3;
         uint32 NotAcceptingNewSlots = 4;
@@ -853,6 +853,9 @@ message TGroupMapperError {
     }
     TStats TotalStats = 1;
     repeated TStats MatchingDomainsStats = 2;
+    uint32 MissingFailRealmsCount = 3;
+    uint32 FailRealmsWithMissingDomainsCount = 4;
+    uint32 DomainsWithMissingDisksCount = 5;
 }
 
 message TConfigResponse {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -856,8 +856,9 @@ message TGroupMapperError {
     uint32 MissingFailRealmsCount = 3;
     uint32 FailRealmsWithMissingDomainsCount = 4;
     uint32 DomainsWithMissingDisksCount = 5;
-    string RealmLocationKey = 6;
-    string DomainLocationKey = 7;
+    uint32 OkDisksCount = 6;
+    string RealmLocationKey = 7;
+    string DomainLocationKey = 8;
 }
 
 message TConfigResponse {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -856,6 +856,8 @@ message TGroupMapperError {
     uint32 MissingFailRealmsCount = 3;
     uint32 FailRealmsWithMissingDomainsCount = 4;
     uint32 DomainsWithMissingDisksCount = 5;
+    string RealmLocationKey = 6;
+    string DomainLocationKey = 7;
 }
 
 message TConfigResponse {

--- a/ydb/core/viewer/pdisk_restart.h
+++ b/ydb/core/viewer/pdisk_restart.h
@@ -71,13 +71,7 @@ public:
                 json["result"] = true;
             } else {
                 json["result"] = false;
-                TString error;
-                bool forceRetryPossible = false;
-                Viewer->TranslateFromBSC2Human(Response->Record.GetResponse(), GetRequest(), error, forceRetryPossible);
-                json["error"] = error;
-                if (!Force && forceRetryPossible) {
-                    json["forceRetryPossible"] = true;
-                }
+                Viewer->BSCError2JSON(Response->Record.GetResponse(), GetRequest(), json, Force);
             }
             json["debugMessage"] = Response->Record.ShortDebugString();
             ReplyAndPassAway(GetHTTPOKJSON(json));

--- a/ydb/core/viewer/pdisk_status.h
+++ b/ydb/core/viewer/pdisk_status.h
@@ -98,13 +98,7 @@ public:
                 json["result"] = true;
             } else {
                 json["result"] = false;
-                TString error;
-                bool forceRetryPossible = false;
-                Viewer->TranslateFromBSC2Human(Response->Record.GetResponse(), GetRequest(), error, forceRetryPossible);
-                json["error"] = error;
-                if (!Force && forceRetryPossible) {
-                    json["forceRetryPossible"] = true;
-                }
+                Viewer->BSCError2JSON(Response->Record.GetResponse(), GetRequest(), json, Force);
             }
             json["debugMessage"] = Response->Record.ShortDebugString();
             ReplyAndPassAway(GetHTTPOKJSON(json));

--- a/ydb/core/viewer/vdisk_evict.h
+++ b/ydb/core/viewer/vdisk_evict.h
@@ -102,39 +102,9 @@ public:
                 json["result"] = true;
             } else {
                 json["result"] = false;
-                TString error;
-                bool forceRetryPossible = false;
-                Viewer->TranslateFromBSC2Human(Response->Record.GetResponse(), GetRequest(), error, forceRetryPossible);
-                json["error"] = error;
-                if (!Force && forceRetryPossible) {
-                    json["forceRetryPossible"] = true;
-                }
+                Viewer->BSCError2JSON(Response->Record.GetResponse(), GetRequest(), json, Force);
             }
             json["debugMessage"] = Response->Record.ShortDebugString();
-            
-            auto& statuses = Response->Record.GetResponse().GetStatus();
-            NJson::TJsonValue groupMapperErrors(NJson::EJsonValueType::JSON_ARRAY);
-            auto config = NProtobufJson::TProto2JsonConfig()
-                .SetFormatOutput(false)
-                .SetEnumMode(NProtobufJson::TProto2JsonConfig::EnumName);
-            
-            for (auto& status : statuses) {
-                if (status.FailParamSize() == 0) {
-                    continue;
-                }
-                for (auto& failParam : status.GetFailParam()) {
-                    if (failParam.HasGroupMapperError()) {
-                        NJson::TJsonValue groupMapperError;
-                        const auto& gme = failParam.GetGroupMapperError();
-                        NJson::TJsonValue gmeJson;
-                        NProtobufJson::Proto2Json(gme, gmeJson, config);
-                        groupMapperErrors.AppendValue(gmeJson);
-                    }
-                }
-            }
-
-            json["groupMapperErrors"] = std::move(groupMapperErrors);
-
             TBase::ReplyAndPassAway(GetHTTPOKJSON(json));
         } else {
             TBase::ReplyAndPassAway(GetHTTPINTERNALERROR("text/plain", Response.GetError()));

--- a/ydb/core/viewer/viewer.h
+++ b/ydb/core/viewer/viewer.h
@@ -322,7 +322,7 @@ public:
     virtual bool CheckAccessViewer(const TRequestState& request) = 0;
     virtual bool CheckAccessMonitoring(const TRequestState& request) = 0;
     virtual bool CheckAccessAdministration(const TRequestState& request) = 0;
-    virtual void TranslateFromBSC2Human(const NKikimrBlobStorage::TConfigResponse& response, const TRequestState& request, TString& bscError, bool& forceRetryPossible) = 0;
+    virtual void BSCError2JSON(const NKikimrBlobStorage::TConfigResponse& response, const TRequestState& request, NJson::TJsonValue& json, bool forced) = 0;
     virtual TString MakeForward(const TRequestState& request, const std::vector<ui32>& nodes) = 0;
 
     virtual void AddRunningQuery(const TString& queryId, const TActorId& actorId) = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Print helpful message in the group allocation error. Adds count of disks with various (unusable) statuses and also same stats but by domain (only for domains that can be used as targets)

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
