### PR TITLE
Add configurable limit for PhantomFlagStorage size, improve UT

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden.h
@@ -50,6 +50,7 @@ namespace NKikimr {
         bool UseActorSystemTimeInBSQueue = false;
         std::optional<ui32> ReplMaxQuantumBytes = std::nullopt;
         std::optional<ui32> ReplMaxDonorNotReadyCount = std::nullopt;
+        bool TinySyncLog = false;
 
         TNodeWardenConfig(const TIntrusivePtr<IPDiskServiceFactory> &pDiskServiceFactory)
             : PDiskServiceFactory(pDiskServiceFactory)

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -59,6 +59,7 @@ TNodeWarden::TNodeWarden(const TIntrusivePtr<TNodeWardenConfig> &cfg)
     , ThrottlingMaxLogChunkCount(130, 1, 100000)
     , MaxInProgressSyncCount(0, 0, 1000)
     , EnablePhantomFlagStorage(0, 0, 1)
+    , PhantomFlagStorageLimitPerVDiskBytes(10'000'000, 0, 100'000'000'000)
     , MaxCommonLogChunksHDD(NPDisk::MaxCommonLogChunks, 1, 1'000'000)
     , MaxCommonLogChunksSSD(NPDisk::MaxCommonLogChunks, 1, 1'000'000)
     , CommonStaticLogChunks(NPDisk::CommonStaticLogChunks, 1, 1'000'000)
@@ -410,6 +411,7 @@ void TNodeWarden::Bootstrap() {
 
         TControlBoard::RegisterSharedControl(MaxInProgressSyncCount, icb->VDiskControls.MaxInProgressSyncCount);
         TControlBoard::RegisterSharedControl(EnablePhantomFlagStorage, icb->VDiskControls.EnablePhantomFlagStorage);
+        TControlBoard::RegisterSharedControl(PhantomFlagStorageLimitPerVDiskBytes, icb->VDiskControls.PhantomFlagStorageLimitPerVDiskBytes);
 
         TControlBoard::RegisterSharedControl(MaxCommonLogChunksHDD, icb->PDiskControls.MaxCommonLogChunksHDD);
         TControlBoard::RegisterSharedControl(MaxCommonLogChunksSSD, icb->PDiskControls.MaxCommonLogChunksSSD);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -234,6 +234,7 @@ namespace NKikimr::NStorage {
 
         TControlWrapper MaxInProgressSyncCount;
         TControlWrapper EnablePhantomFlagStorage;
+        TControlWrapper PhantomFlagStorageLimitPerVDiskBytes;
 
         TControlWrapper MaxCommonLogChunksHDD;
         TControlWrapper MaxCommonLogChunksSSD;

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -230,6 +230,7 @@ namespace NKikimr::NStorage {
 
         vdiskConfig->MaxInProgressSyncCount = MaxInProgressSyncCount;
         vdiskConfig->EnablePhantomFlagStorage = EnablePhantomFlagStorage;
+        vdiskConfig->PhantomFlagStorageLimit = PhantomFlagStorageLimitPerVDiskBytes;
 
         vdiskConfig->CostMetricsParametersByMedia = CostMetricsParametersByMedia;
 
@@ -262,6 +263,12 @@ namespace NKikimr::NStorage {
         vdiskConfig->GroupSizeInUnits = groupInfo->GroupSizeInUnits;
 
         vdiskConfig->EnableDeepScrubbing = EnableDeepScrubbing;
+
+        // debug options
+        if (Cfg->TinySyncLog) {
+            vdiskConfig->SyncLogMaxDiskAmount = 1;
+            vdiskConfig->SyncLogMaxMemAmount = 1;
+        }
 
         // issue initial report to whiteboard before creating actor to avoid races
         Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvVDiskStateUpdate(vdiskId, groupInfo->GetStoragePoolName(),

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -66,6 +66,7 @@ struct TEnvironmentSetup {
         const bool AutomaticBootstrap = false;
         const std::function<TIntrusivePtr<TStateStorageInfo>(std::function<TActorId(ui32, ui32)>, ui32)> StateStorageInfoGenerator = nullptr;
         const bool EnablePhantomFlagStorage = false;
+        const bool TinySyncLog = false;
     };
 
     const TSettings Settings;
@@ -495,6 +496,7 @@ config:
                     config->ReplMaxDonorNotReadyCount = Settings.ReplMaxDonorNotReadyCount;
                 }
                 config->UseActorSystemTimeInBSQueue = Settings.UseActorSystemTimeInBSQueue;
+                config->TinySyncLog = Settings.TinySyncLog;
                 if (Settings.ConfigPreprocessor) {
                     Settings.ConfigPreprocessor(nodeId, *config);
                 }

--- a/ydb/core/blobstorage/ut_blobstorage/phantom_blobs.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/phantom_blobs.cpp
@@ -21,7 +21,7 @@ Y_UNIT_TEST_SUITE(PhantomBlobs) {
         void RunTest(ui32 initialBlobs, ui32 unsyncedBlobs, std::vector<ENodeState> nodeStates) {
             Y_VERIFY(nodeStates.size() == NodeCount);
             const ui64 blobSize = 10;
-            const ui32 unsyncedBatchSize = 1;
+            const ui32 unsyncedBatchSize = 1000;
             Initialize();
 
             ui64 tabletId = 5000;
@@ -101,6 +101,7 @@ Y_UNIT_TEST_SUITE(PhantomBlobs) {
                 collectEverything(nullptr, nullptr);
             }
 
+            Ctest << "Send TEvBaldSyncLog" << Endl;
             const TIntrusivePtr<TBlobStorageGroupInfo> groupInfo = Env->GetGroupInfo(GroupId);
             UNIT_ASSERT(groupInfo);
             for (ui32 orderNumber = 0; orderNumber < groupInfo->Type.BlobSubgroupSize(); ++orderNumber) {
@@ -113,7 +114,7 @@ Y_UNIT_TEST_SUITE(PhantomBlobs) {
                 const TActorId edge = Env->Runtime->AllocateEdgeActor(actorId.NodeId());
                 Env->Runtime->WrapInActorContext(edge, [&]{
                     TActivationContext::Send(new IEventHandle(
-                            actorId, edge, new TEvBlobStorage::TEvVBaldSyncLog(vdiskId)));
+                            actorId, edge, new TEvBlobStorage::TEvVBaldSyncLog(vdiskId, true)));
                 });
                 Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvVBaldSyncLogResult>(edge, false);
             }
@@ -213,8 +214,9 @@ Y_UNIT_TEST_SUITE(PhantomBlobs) {
             .ControllerNodeId = controllerNodeId,
             .PDiskChunkSize = 32_MB,
             .EnablePhantomFlagStorage = true,
+            .TinySyncLog = true,
         });
-        ctx.RunTest(1000, 10, nodeStates);
+        ctx.RunTest(1000, 1000, nodeStates);
     }
 
 

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
@@ -228,7 +228,8 @@ class TSyncLogTestWriteActor : public TActorBootstrapped<TSyncLogTestWriteActor>
                 VDiskConfig->MaxResponseSize,
                 Db->SyncLogFirstLsnToKeep,
                 false,
-                TControlWrapper(0, 0, 1));
+                TControlWrapper(0, 0, 1),
+                TControlWrapper(20'000'000, 1, 100'000'000'000));
         TestCtx->SyncLogId = ctx.Register(CreateSyncLogActor(slCtx, Conf->GroupInfo, TestCtx->SelfVDiskId, std::move(repaired)));
         // Send Db birth lsn
         ui64 dbBirthLsn = 0;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -277,6 +277,7 @@ namespace NKikimr {
         ///////////// SYNC SETTINGS //////////////////
         TControlWrapper MaxInProgressSyncCount;
         TControlWrapper EnablePhantomFlagStorage;
+        TControlWrapper PhantomFlagStorageLimit;
 
         ///////////// FEATURE FLAGS ////////////////////////
         NKikimrConfig::TFeatureFlags FeatureFlags;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -2655,9 +2655,9 @@ namespace NKikimr {
     {
         TEvVBaldSyncLog() = default;
 
-        TEvVBaldSyncLog(const TVDiskID &vdisk, bool dropChunksExplicitely = false) {
+        TEvVBaldSyncLog(const TVDiskID &vdisk, bool dropChunksExplicitly = false) {
             VDiskIDFromVDiskID(vdisk, Record.MutableVDiskID());
-            Record.SetDropChunksExplicitely(dropChunksExplicitely);
+            Record.SetDropChunksExplicitly(dropChunksExplicitly);
         }
     };
 

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -2655,8 +2655,9 @@ namespace NKikimr {
     {
         TEvVBaldSyncLog() = default;
 
-        TEvVBaldSyncLog(const TVDiskID &vdisk) {
+        TEvVBaldSyncLog(const TVDiskID &vdisk, bool dropChunksExplicitely = false) {
             VDiskIDFromVDiskID(vdisk, Record.MutableVDiskID());
+            Record.SetDropChunksExplicitely(dropChunksExplicitely);
         }
     };
 

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -2016,7 +2016,8 @@ namespace NKikimr {
                     Config->MaxResponseSize,
                     Db->SyncLogFirstLsnToKeep,
                     Config->BaseInfo.ReadOnly,
-                    Config->EnablePhantomFlagStorage);
+                    Config->EnablePhantomFlagStorage,
+                    Config->PhantomFlagStorageLimit);
             Db->SyncLogID.Set(ctx.Register(CreateSyncLogActor(slCtx, GInfo, SelfVDiskId, std::move(repairedSyncLog))));
             ActiveActors.Insert(Db->SyncLogID, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE); // keep forever
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_context.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_context.h
@@ -54,6 +54,7 @@ public:
     const bool IsReadOnlyVDisk;
 
     TControlWrapper EnablePhantomFlagStorage;
+    TControlWrapper PhantomFlagStorageLimit;
 
     TSyncLogCtx(TIntrusivePtr<TVDiskContext> vctx,
             TIntrusivePtr<TLsnMngr> lsnMngr,
@@ -66,7 +67,8 @@ public:
             ui32 maxResponseSize,
             std::shared_ptr<TSyncLogFirstLsnToKeep> syncLogFirstLsnToKeep,
             bool isReadOnlyVDisk,
-            const TControlWrapper& enablePhantomFlagStorage)
+            const TControlWrapper& enablePhantomFlagStorage,
+            const TControlWrapper& phantomFlagStorageLimit)
         : VCtx(std::move(vctx))
         , LsnMngr(std::move(lsnMngr))
         , PDiskCtx(std::move(pdiskCtx))
@@ -82,6 +84,7 @@ public:
         , PhantomFlagStorageGroup(VCtx->VDiskCounters, "subsystem", "phantomflagstorage")
         , IsReadOnlyVDisk(isReadOnlyVDisk)
         , EnablePhantomFlagStorage(enablePhantomFlagStorage)
+        , PhantomFlagStorageLimit(phantomFlagStorageLimit)
     {}
 };
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogformat.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogformat.h
@@ -20,6 +20,8 @@ namespace NKikimr {
             ui64 Raw[3]; // TLogoBlobID
             TIngress Ingress;
 
+            TLogoBlobRec() = default;
+
             explicit TLogoBlobRec(const TLogoBlobID &id, ui64 ingressRaw)
                 :  Ingress(ingressRaw)
             {

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogformat.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogformat.h
@@ -20,8 +20,6 @@ namespace NKikimr {
             ui64 Raw[3]; // TLogoBlobID
             TIngress Ingress;
 
-            TLogoBlobRec() = default;
-
             explicit TLogoBlobRec(const TLogoBlobID &id, ui64 ingressRaw)
                 :  Ingress(ingressRaw)
             {

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
@@ -240,10 +240,10 @@ namespace NKikimr {
             // for tests/debug purposes only, remove almost all log
             void Handle(TEvBlobStorage::TEvVBaldSyncLog::TPtr &ev, const TActorContext &ctx) {
                 Y_UNUSED(ev);
-                bool dropChunksExplicitely = ev->Get()->Record.HasDropChunksExplicitely()
-                        ? ev->Get()->Record.GetDropChunksExplicitely()
+                bool dropChunksExplicitly = ev->Get()->Record.HasDropChunksExplicitly()
+                        ? ev->Get()->Record.GetDropChunksExplicitly()
                         : false;
-                KeepState.BaldLogEvent(dropChunksExplicitely);
+                KeepState.BaldLogEvent(dropChunksExplicitly);
                 PerformActions(ctx);
             }
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
@@ -35,7 +35,8 @@ namespace NKikimr {
             void Bootstrap(const TActorContext &ctx) {
                 KeepState.Init(
                     std::make_shared<TActorNotify>(ctx.ActorSystem(), ctx.SelfID),
-                    std::make_shared<TActorSystemLoggerCtx>(ctx.ActorSystem()));
+                    std::make_shared<TActorSystemLoggerCtx>(ctx.ActorSystem()),
+                    ctx.SelfID);
                 PerformActions(ctx);
                 Become(&TThis::StateFunc);
             }
@@ -239,7 +240,10 @@ namespace NKikimr {
             // for tests/debug purposes only, remove almost all log
             void Handle(TEvBlobStorage::TEvVBaldSyncLog::TPtr &ev, const TActorContext &ctx) {
                 Y_UNUSED(ev);
-                KeepState.BaldLogEvent();
+                bool dropChunksExplicitely = ev->Get()->Record.HasDropChunksExplicitely()
+                        ? ev->Get()->Record.GetDropChunksExplicitely()
+                        : false;
+                KeepState.BaldLogEvent(dropChunksExplicitely);
                 PerformActions(ctx);
             }
 
@@ -296,7 +300,7 @@ namespace NKikimr {
                 : TActorBootstrapped<TSyncLogKeeperActor>()
                 , SlCtx(std::move(slCtx))
                 , KeepState(SlCtx, std::move(repaired), SlCtx->SyncLogMaxMemAmount, SlCtx->SyncLogMaxDiskAmount,
-                    SlCtx->SyncLogMaxEntryPointSize, SelfId())
+                    SlCtx->SyncLogMaxEntryPointSize)
             {}
         };
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
@@ -487,7 +487,6 @@ namespace NKikimr {
                 PhantomFlagStorageState.Deactivate();
             }
 
-            // append scheduledChunks to ChunksToDeleteDelayed
             ChunksToDeleteDelayed.Insert(chunks);
         }
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
@@ -140,8 +140,8 @@ namespace NKikimr {
             DelayedActions.SetTrimTail();
         }
 
-        void TSyncLogKeeperState::BaldLogEvent(bool dropChunksExplicitely) {
-            if (dropChunksExplicitely) {
+        void TSyncLogKeeperState::BaldLogEvent(bool dropChunksExplicitly) {
+            if (dropChunksExplicitly) {
                 const ui32 numCurChunks = SyncLogPtr->GetSizeInChunks();
                 if (numCurChunks > 0) {
                     TVector<ui32> droppedChunks = SyncLogPtr->TrimLogByRemovingChunks(numCurChunks, Notifier);
@@ -150,7 +150,7 @@ namespace NKikimr {
 
                 LOG_DEBUG(*LoggerCtx, BS_SYNCLOG,
                         VDISKP(SlCtx->VCtx->VDiskLogPrefix,
-                            "KEEPER: TEvSyncLogBaldLog DropChunksExplicitely: numChunks# %" PRIu32,
+                            "KEEPER: TEvSyncLogBaldLog DropChunksExplicitly: numChunks# %" PRIu32,
                             numCurChunks));
             } else {
                 const ui64 baldLsn = SyncLogPtr->GetLastLsn();

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
@@ -111,12 +111,13 @@ namespace NKikimr {
                     std::unique_ptr<TSyncLogRepaired> repaired,
                     ui64 syncLogMaxMemAmount,
                     ui64 syncLogMaxDiskAmount,
-                    ui64 syncLogMaxEntryPointSize,
-                    const TActorId& selfId);
+                    ui64 syncLogMaxEntryPointSize);
 
-            void Init(std::shared_ptr<IActorNotify> notifier, std::shared_ptr<ILoggerCtx> loggerCtx) {
+            void Init(std::shared_ptr<IActorNotify> notifier, std::shared_ptr<ILoggerCtx> loggerCtx,
+                    const TActorId& selfId) {
                 Notifier = std::move(notifier);
                 LoggerCtx = std::move(loggerCtx);
+                SelfId = selfId;
             }
 
             bool HasDelayedActions() const {
@@ -141,7 +142,7 @@ namespace NKikimr {
 
             // incoming events
             void TrimTailEvent(ui64 trimTailLsn);
-            void BaldLogEvent();
+            void BaldLogEvent(bool dropChunksExplicitely);
             void CutLogEvent(ui64 freeUpToLsn);
             void RetryCutLogEvent();
             void FreeChunkEvent(ui32 chunkIdx);
@@ -164,7 +165,6 @@ namespace NKikimr {
             void UpdateNeighbourSyncedLsn(ui32 orderNumber, ui64 syncedLsn);
 
             // Add flags from cut sync log snapshot
-            void PrunePhantomFlagStorage();
             void AddFlagsToPhantomFlagStorage(TPhantomFlags&& flags);
             TPhantomFlagStorageSnapshot GetPhantomFlagStorageSnapshot() const;
             void ProcessLocalSyncData(ui32 orderNumber, const TString& data);
@@ -201,7 +201,7 @@ namespace NKikimr {
             // Snapshot that can be used by Commiter and PhantomFlagStorageBuilder actors
             TSyncLogSnapshotPtr Snapshot;
             // Id of Keeper actor which possesses the state
-            const TActorId SelfId;
+            TActorId SelfId;
 
             // synced lsns of neighbours
             std::vector<ui64> SyncedLsns;
@@ -209,6 +209,7 @@ namespace NKikimr {
             // phantom flag storage
             TPhantomFlagStorageState PhantomFlagStorageState;
             TMemorizableControlWrapper EnablePhantomFlagStorage;
+            TMemorizableControlWrapper PhantomFlagStorageLimit;
 
         private:
             // Fix Disk overflow, i.e. remove some chunks from SyncLog
@@ -225,6 +226,8 @@ namespace NKikimr {
             // Calculate first lsn to keep in recovery log for _DATA_RECORDS_,
             // i.e. for those records in SyncLog which keep user data
             ui64 CalculateFirstDataInRecovLogLsnToKeep() const;
+            // Schedule chunks deletion and activate PhantomFlagStorage if needed
+            void DropUnsyncedChunks(const TVector<ui32>& chunks);
         };
 
     } // NSyncLog

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
@@ -142,7 +142,7 @@ namespace NKikimr {
 
             // incoming events
             void TrimTailEvent(ui64 trimTailLsn);
-            void BaldLogEvent(bool dropChunksExplicitely);
+            void BaldLogEvent(bool dropChunksExplicitly);
             void CutLogEvent(ui64 freeUpToLsn);
             void RetryCutLogEvent();
             void FreeChunkEvent(ui32 chunkIdx);

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
@@ -119,7 +119,7 @@ namespace NKikimr {
             TControlWrapper(20'000'000, 1, 100'000'000'000));
 
         State = std::make_unique<TSyncLogKeeperState>(slCtx, std::move(repaired), syncLogMaxMemAmount, syncLogMaxDiskAmount,
-                syncLogMaxEntryPointSize, TActorId{});
+                syncLogMaxEntryPointSize);
         State->Init(nullptr, std::make_shared<TFakeLoggerCtx>(), TActorId{});
 
         STR << "CREATE STATE entryPointLsn# " << ep.EntryPointLsn <<

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
@@ -120,7 +120,7 @@ namespace NKikimr {
 
         State = std::make_unique<TSyncLogKeeperState>(slCtx, std::move(repaired), syncLogMaxMemAmount, syncLogMaxDiskAmount,
                 syncLogMaxEntryPointSize, TActorId{});
-        State->Init(nullptr, std::make_shared<TFakeLoggerCtx>());
+        State->Init(nullptr, std::make_shared<TFakeLoggerCtx>(), TActorId{});
 
         STR << "CREATE STATE entryPointLsn# " << ep.EntryPointLsn <<
             " entryPoint# " << (ep.EntryPoint.empty() ? "<empty>" : "<exists>") << "\n";

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
@@ -115,7 +115,8 @@ namespace NKikimr {
             maxResponseSize,
             nullptr,
             false,
-            TControlWrapper(0, 0, 1));
+            TControlWrapper(0, 0, 1),
+            TControlWrapper(20'000'000, 1, 100'000'000'000));
 
         State = std::make_unique<TSyncLogKeeperState>(slCtx, std::move(repaired), syncLogMaxMemAmount, syncLogMaxDiskAmount,
                 syncLogMaxEntryPointSize, TActorId{});

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
@@ -89,7 +89,11 @@ void TPhantomFlagStorageState::AdjustSize(ui64 sizeLimit) {
     if (newCapacity > StoredFlags.capacity()) {
         StoredFlags.reserve(newCapacity);
     } else if (newCapacity < StoredFlags.capacity()) {
-        StoredFlags.resize(newCapacity);
+        if (newCapacity < StoredFlags.size()) {
+            StoredFlags = TPhantomFlags(StoredFlags.begin(), StoredFlags.begin() + newCapacity);
+        }
+        StoredFlags.shrink_to_fit();
+        StoredFlags.reserve(newCapacity);
     }
 }
 

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
@@ -15,9 +15,10 @@ void TPhantomFlagStorageState::Activate() {
     Active = true;
 }
 
-void TPhantomFlagStorageState::ProcessBlobRecordFromSyncLog(const TLogoBlobRec* blobRec) {
+void TPhantomFlagStorageState::ProcessBlobRecordFromSyncLog(const TLogoBlobRec* blobRec, ui64 sizeLimit) {
+    AdjustSize(sizeLimit);
     if (blobRec->Ingress.IsDoNotKeep(GType) && Thresholds.IsBehindThreshold(blobRec->LogoBlobID())) {
-        StoredFlags.push_back(*blobRec);
+        AddFlag(*blobRec);
     }
 }
 
@@ -32,8 +33,14 @@ void TPhantomFlagStorageState::ProcessBarrierRecordFromNeighbour(ui32 orderNumbe
     }
 }
 
-void TPhantomFlagStorageState::AddFlags(TPhantomFlags flags) {
-    StoredFlags.insert(StoredFlags.end(), flags.begin(), flags.end());
+void TPhantomFlagStorageState::AddFlags(TPhantomFlags flags, ui64 sizeLimit) {
+    AdjustSize(sizeLimit);
+    for (const TLogoBlobRec& rec : flags) {
+        bool added = AddFlag(rec);
+        if (!added) {
+            break;
+        }
+    }
 }
 
 void TPhantomFlagStorageState::Deactivate() {
@@ -66,6 +73,34 @@ void TPhantomFlagStorageState::ProcessLocalSyncData(ui32 orderNumber, const TStr
     // process synclog data
     NSyncLog::TFragmentReader fragment(data);
     fragment.ForEach(blobHandler, blockHandler, barrierHandler, blockHandlerV2);
+}
+
+
+ui64 TPhantomFlagStorageState::EstimateFlagsMemoryConsumption() const {
+    return StoredFlags.capacity() * sizeof(decltype(StoredFlags)::value_type);
+}
+
+ui64 TPhantomFlagStorageState::EstimateThresholdsMemoryConsumption() const {
+    return Thresholds.EstimatedMemoryConsumption();
+}
+
+void TPhantomFlagStorageState::AdjustSize(ui64 sizeLimit) {
+    ui32 newCapacity = sizeLimit / sizeof(decltype(StoredFlags)::value_type);
+    if (newCapacity > StoredFlags.capacity()) {
+        StoredFlags.reserve(newCapacity);
+    } else if (newCapacity < StoredFlags.capacity()) {
+        StoredFlags.resize(newCapacity);
+    }
+}
+
+bool TPhantomFlagStorageState::AddFlag(const TLogoBlobRec& blobRec) {
+    StoredFlags.emplace_back(blobRec);
+    return true;
+    if (StoredFlags.size() < StoredFlags.capacity()) {
+        StoredFlags.emplace_back(blobRec);
+        return true;
+    }
+    return false;
 }
 
 } // namespace NSyncLog

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
@@ -94,8 +94,6 @@ void TPhantomFlagStorageState::AdjustSize(ui64 sizeLimit) {
 }
 
 bool TPhantomFlagStorageState::AddFlag(const TLogoBlobRec& blobRec) {
-    StoredFlags.emplace_back(blobRec);
-    return true;
     if (StoredFlags.size() < StoredFlags.capacity()) {
         StoredFlags.emplace_back(blobRec);
         return true;

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.h
@@ -21,9 +21,9 @@ public:
 
     void Activate();
 
-    void ProcessBlobRecordFromSyncLog(const TLogoBlobRec* blobRec);
-    // Add all DoNotKeep records from cut synclog snapshot
-    void AddFlags(TPhantomFlags flags);
+    void ProcessBlobRecordFromSyncLog(const TLogoBlobRec* blobRec, ui64 sizeLimit);
+    // Add all DoNotKeep records from cut synclog snapshot up to sizeLimit
+    void AddFlags(TPhantomFlags flags, ui64 sizeLimit);
     void Deactivate();
 
     // TODO: rebuild thresholds structure after restart. Either write it to VDisk log or rebuild from hull snapshot
@@ -34,11 +34,17 @@ public:
 
     void ProcessLocalSyncData(ui32 orderNumber, const TString& data);
 
+    ui64 EstimateFlagsMemoryConsumption() const;
+    ui64 EstimateThresholdsMemoryConsumption() const;
+
 private:
     // Adds DoNotKeep flags to storage and Keeps to Thresholds for specified neighbour
     void ProcessBlobRecordFromNeighbour(ui32 orderNumber, const TLogoBlobRec* blobRec);
     // Prune Thresholds
     void ProcessBarrierRecordFromNeighbour(ui32 orderNumber, const TBarrierRec* barrierRec);
+
+    void AdjustSize(ui64 sizeLimit);
+    bool AddFlag(const TLogoBlobRec& blobRec);
 
 private:
     const TBlobStorageGroupType GType;

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_thresholds.h
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_thresholds.h
@@ -27,6 +27,7 @@ public:
     void AddHardBarrier(ui32 orderNumber, ui64 tabletId, ui32 channel, ui32 generation, ui32 step);
     bool IsBehindThreshold(const TLogoBlobID& blob) const;
     TPhantomFlags Sift(const TPhantomFlags& flags);
+    ui64 EstimatedMemoryConsumption() const;
 
 private:
     using TGenStep = std::pair<ui32, ui32>;
@@ -38,6 +39,7 @@ private:
         void AddBlob(const TLogoBlobID& blob);
         void AddHardBarrier(ui64 tabletId, ui8 channel, TGenStep barrier);
         bool IsBehindThreshold(const TLogoBlobID& blob) const;
+        ui64 EstimatedMemoryConsumption() const;
 
     private:
         class TTabletThresholds {
@@ -46,6 +48,7 @@ private:
             void AddHardBarrier(ui8 channel, TGenStep barrier);
             bool IsBehindThreshold(const TLogoBlobID& blob) const;
             bool IsEmpty() const;
+            ui64 EstimatedMemoryConsumption() const;
     
         private:
             std::unordered_map<ui8, TGenStep> ChannelThresholds;

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -979,7 +979,7 @@ message TEvVDefragResult {
 message TEvVBaldSyncLog {
     optional NKikimrBlobStorage.TVDiskID VDiskID = 1;
     optional bool NotifyIfNotReady = 2;
-    optional bool DropChunksExplicitely = 3;
+    optional bool DropChunksExplicitly = 3;
 }
 
 message TEvVBaldSyncLogResult {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -979,6 +979,7 @@ message TEvVDefragResult {
 message TEvVBaldSyncLog {
     optional NKikimrBlobStorage.TVDiskID VDiskID = 1;
     optional bool NotifyIfNotReady = 2;
+    optional bool DropChunksExplicitely = 3;
 }
 
 message TEvVBaldSyncLogResult {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1757,6 +1757,13 @@ message TImmediateControlsConfig {
             MaxValue: 1,
             DefaultValue: 0,
         }];
+
+        optional uint64 PhantomFlagStorageLimitPerVDiskBytes = 39 [(ControlOptions) = {
+            Description: "Maximum size in bytes of in-memory structures of PhantomFlagStorage per VDisk",
+            MinValue: 0,
+            MaxValue: 100000000000, // 100 GB
+            DefaultValue: 10000000, // 10 MB
+        }];
     }
 
     message TTabletControls {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Minor changes for PhantomFlagStorage. Add ICB-configurable size limit, make UT much faster, don't put flags to non-activated PhantomFlagStorage.

### Changelog category <!-- remove all except one -->

* Improvement