### PR TITLE
[CONFLICT] [Backport stable-25-3] PR 29487

### DIFF
--- a/ydb/core/kqp/ut/common/columnshard.cpp
+++ b/ydb/core/kqp/ut/common/columnshard.cpp
@@ -24,6 +24,11 @@ namespace NKqp {
             kikimrSettings.AppConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
         }
 
+        if (!kikimrSettings.AppConfig.GetColumnShardConfig().HasStatistics()) {
+            kikimrSettings.AppConfig.MutableColumnShardConfig()->MutableStatistics()->SetReportBaseStatisticsPeriodMs(1000);
+            kikimrSettings.AppConfig.MutableColumnShardConfig()->MutableStatistics()->SetReportExecutorStatisticsPeriodMs(1000);
+        }
+
         Kikimr = std::make_unique<TKikimrRunner>(kikimrSettings);
         TableClient =
             std::make_unique<NYdb::NTable::TTableClient>(Kikimr->GetTableClient(NYdb::NTable::TClientSettings().AuthToken("root@builtin")));

--- a/ydb/core/kqp/ut/olap/kqp_olap_stats_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_stats_ut.cpp
@@ -54,7 +54,7 @@ Y_UNIT_TEST_SUITE(KqpOlapStats) {
             testHelper.BulkUpsert(testTable, tableInserter);
         }
 
-        Sleep(TDuration::Seconds(1));
+        Sleep(TDuration::Seconds(10));
 
         auto settings = TDescribeTableSettings().WithTableStatistics(true);
         auto describeResult = testHelper.GetSession().DescribeTable("/Root/ColumnTableTest", settings).GetValueSync();
@@ -94,7 +94,7 @@ Y_UNIT_TEST_SUITE(KqpOlapStats) {
             testHelper.BulkUpsert(testTable, tableInserter);
         }
 
-        Sleep(TDuration::Seconds(1));
+        Sleep(TDuration::Seconds(10));
 
         auto settings = TDescribeTableSettings().WithTableStatistics(true);
         auto describeResult =

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2140,7 +2140,17 @@ message TColumnShardConfig {
     optional uint64 BadPortionSizeLimit = 51 [default = 524288];
     optional uint64 BadPortionsLimit = 52;
     optional bool CombineChunksInResult = 54 [default = true];
+<<<<<<< HEAD
     optional bool EnableParallelCompaction = 56 [default = true];
+=======
+
+    message TStatistics {
+        optional uint32 ReportBaseStatisticsPeriodMs = 1 [default = 60000];
+        optional uint32 ReportExecutorStatisticsPeriodMs = 2 [default = 60000];
+    }
+
+    optional TStatistics Statistics = 57;
+>>>>>>> 360d718749d (Divide statistics into base and executor (#26925))
 }
 
 message TSchemeShardConfig {

--- a/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
@@ -247,6 +247,67 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         TestNotFullStatistics(env, 1000);
     }
 
+    Y_UNIT_TEST(StatisticsOnShardsRestart) {
+        TTestEnv env(1, 1);
+
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        auto dbName =  "Database";
+        auto table1 = "Table1";
+        auto table2 = "Table2";
+        auto table3 = "Table3";
+
+        auto path1 = "/Root/Database/Table1";
+        auto path2 = "/Root/Database/Table2";
+        auto path3 = "/Root/Database/Table3";
+
+        const ui32 nodeIdx = 1;
+        ui64 saTabletId = 0;
+
+        CreateDatabase(env, dbName);
+        CreateColumnStoreTable(env, dbName, table1, 4);
+        auto pathId1 = ResolvePathId(runtime, path1, nullptr, &saTabletId);
+
+        ui64 ssTabletId = pathId1.OwnerId;
+        auto sender = runtime.AllocateEdgeActor();
+
+        auto getDescribeRowCount = [&](const TString& path) {
+            auto describe = DescribeTable(runtime, sender, path);
+            return describe.GetPathDescription().GetTableStats().GetRowCount();
+        };
+
+        runtime.SimulateSleep(TDuration::Seconds(100));
+        UNIT_ASSERT_EQUAL(getDescribeRowCount(path1), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, nodeIdx, pathId1), 1000);
+
+        auto ids = GetColumnTableShards(runtime, sender, path1);
+        for (auto& id : ids) {
+            RebootTablet(runtime, id, sender);
+        }
+
+        CreateColumnStoreTable(env, dbName, table2, 4);
+        auto pathId2 = ResolvePathId(runtime, path2, nullptr, &saTabletId);
+
+        runtime.SimulateSleep(TDuration::Seconds(100));
+        UNIT_ASSERT_EQUAL(getDescribeRowCount(path1), 1000);
+        UNIT_ASSERT_EQUAL(getDescribeRowCount(path2), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, nodeIdx, pathId1), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, nodeIdx, pathId2), 1000);
+
+        RebootTablet(runtime, ssTabletId, runtime.AllocateEdgeActor());
+
+        CreateColumnStoreTable(env, dbName, table3, 4);
+        auto pathId3 = ResolvePathId(runtime, path3, nullptr, &saTabletId);
+
+        runtime.SimulateSleep(TDuration::Seconds(140));
+        UNIT_ASSERT_EQUAL(getDescribeRowCount(path1), 1000);
+        UNIT_ASSERT_EQUAL(getDescribeRowCount(path2), 1000);
+        UNIT_ASSERT_EQUAL(getDescribeRowCount(path3), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, nodeIdx, pathId1), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, nodeIdx, pathId2), 1000);
+        UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, nodeIdx, pathId3), 1000);
+    }
+
     Y_UNIT_TEST(SimpleGlobalIndex) {
         TTestEnv env(1, 1);
 

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -88,6 +88,8 @@ void TColumnShard::TrySwitchToWork(const TActorContext& ctx) {
     ctx.Send(SelfId(), new NActors::TEvents::TEvWakeup());
     ctx.Send(SelfId(), new TEvPrivate::TEvPeriodicWakeup());
     ctx.Send(SelfId(), new TEvPrivate::TEvPingSnapshotsUsage());
+    ctx.Send(SelfId(), new TEvPrivate::TEvReportExecutorStatistics());
+    ctx.Send(SelfId(), new TEvPrivate::TEvReportBaseStatistics());
     NYDBTest::TControllers::GetColumnShardController()->OnSwitchToWork(TabletID());
     AFL_VERIFY(!!StartInstant);
     Counters.GetCSCounters().Initialization.OnSwitchToWork(TMonotonic::Now() - *StartInstant, TMonotonic::Now() - CreateInstant);
@@ -180,6 +182,7 @@ void TColumnShard::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TAc
 
     if (clientId == StatsReportPipe) {
         StatsReportPipe = {};
+        LastStats = {};
         return;
     }
 
@@ -248,8 +251,6 @@ void TColumnShard::Handle(TEvPrivate::TEvPeriodicWakeup::TPtr& ev, const TActorC
     } else {
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvPrivate::TEvPeriodicWakeup")("tablet_id", TabletID());
         SendWaitPlanStep(GetOutdatedStep());
-
-        SendPeriodicStats();
         EnqueueBackgroundActivities();
         ctx.Schedule(PeriodicWakeupActivationPeriod, new TEvPrivate::TEvPeriodicWakeup());
     }
@@ -381,77 +382,111 @@ void TColumnShard::UpdateResourceMetrics(const TActorContext& ctx, const TUsage&
     metrics->TryUpdate(ctx);
 }
 
-void TColumnShard::FillOlapStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev) {
-    ev->Record.SetShardState(2);   // NKikimrTxDataShard.EDatashardState.Ready
-    ev->Record.SetGeneration(Executor()->Generation());
-    ev->Record.SetRound(StatsReportRound++);
-    ev->Record.SetNodeId(ctx.SelfID.NodeId());
-    ev->Record.SetStartTime(StartTime().MilliSeconds());
-    if (auto* resourceMetrics = Executor()->GetResourceMetrics()) {
-        resourceMetrics->Fill(*ev->Record.MutableTabletMetrics());
+void TColumnShard::FillOlapStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev, IExecutor* executor) {
+    ev->Record.SetShardState(2);
+    ev->Record.SetRound(StatsReportRound);
+
+    if (executor) {
+        ev->Record.SetGeneration(executor->Generation());
     }
 
-    TTableStatsBuilder statsBuilder(Counters, Executor());
+    ev->Record.SetNodeId(ctx.SelfID.NodeId());
+    ev->Record.SetStartTime(StartTime().MilliSeconds());
+
+    if (executor) {
+        if (auto* resourceMetrics = executor->GetResourceMetrics()) {
+            resourceMetrics->Fill(*ev->Record.MutableTabletMetrics());
+        }
+    }
+
+    TTableStatsBuilder statsBuilder(Counters, executor);
     statsBuilder.FillTotalTableStats(*ev->Record.MutableTableStats());
 }
 
-void TColumnShard::FillColumnTableStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev) {
+void TColumnShard::FillColumnTableStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev, IExecutor* executor) {
     auto tables = TablesManager.GetTables();
-    TTableStatsBuilder tableStatsBuilder(Counters, Executor());
+    TTableStatsBuilder tableStatsBuilder(Counters);
 
-    LOG_S_DEBUG("There are stats for " << tables.size() << " tables");
+    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("There are stats for tables", tables.size());
+    ev->Record.ClearTables();
     for (const auto& [internalPathId, table] : tables) {
         const auto& schemeShardLocalPathId = table.GetPathId().SchemeShardLocalPathId;
         auto* periodicTableStats = ev->Record.AddTables();
         periodicTableStats->SetDatashardId(TabletID());
         periodicTableStats->SetTableLocalId(schemeShardLocalPathId.GetRawValue());
 
-        periodicTableStats->SetShardState(2);   // NKikimrTxDataShard.EDatashardState.Ready
-        periodicTableStats->SetGeneration(Executor()->Generation());
-        periodicTableStats->SetRound(StatsReportRound++);
+        periodicTableStats->SetShardState(2);
+        if (ev->Record.HasGeneration()) {
+            periodicTableStats->SetGeneration(ev->Record.GetGeneration());
+        }
+        periodicTableStats->SetRound(StatsReportRound);
         periodicTableStats->SetNodeId(ctx.SelfID.NodeId());
         periodicTableStats->SetStartTime(StartTime().MilliSeconds());
 
-        if (auto* resourceMetrics = Executor()->GetResourceMetrics()) {
-            resourceMetrics->Fill(*periodicTableStats->MutableTabletMetrics());
+        if (executor) {
+            if (auto* resourceMetrics = executor->GetResourceMetrics()) {
+                resourceMetrics->Fill(*ev->Record.MutableTabletMetrics());
+            }
         }
 
         tableStatsBuilder.FillTableStats(internalPathId, *(periodicTableStats->MutableTableStats()));
-
-        LOG_S_TRACE("Add stats for table, tableLocalID=" << schemeShardLocalPathId);
+        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("Add stats for table, tableLocalID", schemeShardLocalPathId);
     }
 }
 
-void TColumnShard::SendPeriodicStats() {
-    LOG_S_DEBUG("Send periodic stats.");
-
+void TColumnShard::SendPeriodicStats(bool withExecutor) {
     if (!CurrentSchemeShardId || !TablesManager.GetTabletPathIdOptional()) {
-        LOG_S_DEBUG("Disabled periodic stats at tablet " << TabletID());
+        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("Disabled periodic stats at tablet", TabletID());
         return;
     }
+
     const auto& tabletSchemeShardLocalPathId = TablesManager.GetTabletPathIdVerified().SchemeShardLocalPathId;
-
     const TActorContext& ctx = ActorContext();
-    const TInstant now = TAppData::TimeProvider->Now();
-
-    if (LastStatsReport + StatsReportInterval > now) {
-        LOG_S_TRACE("Skip send periodic stats: report interval = " << StatsReportInterval);
-        return;
-    }
-    LastStatsReport = now;
 
     if (!StatsReportPipe) {
-        LOG_S_DEBUG("Create periodic stats pipe to " << CurrentSchemeShardId << " at tablet " << TabletID());
+        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("reate periodic stats pipe to ", CurrentSchemeShardId)("at tablet", TabletID());
         NTabletPipe::TClientConfig clientConfig;
         StatsReportPipe = ctx.Register(NTabletPipe::CreateClient(ctx.SelfID, CurrentSchemeShardId, clientConfig));
     }
 
-    auto ev = std::make_unique<TEvDataShard::TEvPeriodicTableStats>(TabletID(), tabletSchemeShardLocalPathId.GetRawValue());
+    if (!LastStats) {
+        LastStats = std::make_unique<TEvDataShard::TEvPeriodicTableStats>(TabletID(), tabletSchemeShardLocalPathId.GetRawValue());
+    }
+    auto newStats = std::make_unique<TEvDataShard::TEvPeriodicTableStats>(TabletID(), tabletSchemeShardLocalPathId.GetRawValue());
 
-    FillOlapStats(ctx, ev);
-    FillColumnTableStats(ctx, ev);
+    google::protobuf::util::MessageDifferencer differencer;
+    differencer.IgnoreField(NKikimrTxDataShard::TEvPeriodicTableStats::descriptor()->FindFieldByName("Round"));
+    newStats->Record.CopyFrom(LastStats->Record);
+    IExecutor* executor = withExecutor ? Executor() : nullptr;
+    FillOlapStats(ctx, newStats, executor);
+    FillColumnTableStats(ctx, newStats, executor);
 
-    NTabletPipe::SendData(ctx, StatsReportPipe, ev.release());
+    if (!differencer.Compare(newStats->Record, LastStats->Record)) {
+        LastStats->Record.CopyFrom(newStats->Record);
+        if (newStats->Record.HasGeneration() && newStats->Record.HasStartTime()) {
+            NTabletPipe::SendData(ctx, StatsReportPipe, newStats.release());
+            StatsReportRound++;
+        }
+    }
+
+}
+
+void TColumnShard::Handle(TEvPrivate::TEvReportBaseStatistics::TPtr& /*ev*/) {
+    auto statistics = AppDataVerified().ColumnShardConfig.GetStatistics();
+    auto scheduleDuration = TDuration::MilliSeconds(statistics.GetReportBaseStatisticsPeriodMs() + RandomNumber<ui32>(JitterIntervalMS));
+    ActorContext().Schedule(scheduleDuration, new TEvPrivate::TEvReportBaseStatistics);
+    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvReportBaseStatistics")("ReportBaseStatisticsPeriodMs", statistics.GetReportBaseStatisticsPeriodMs())("scheduleDuration", scheduleDuration);
+    SendPeriodicStats(false);
+    return;
+}
+
+void TColumnShard::Handle(TEvPrivate::TEvReportExecutorStatistics::TPtr& /*ev*/) {
+    auto statistics = AppDataVerified().ColumnShardConfig.GetStatistics();
+    auto scheduleDuration = TDuration::MilliSeconds(statistics.GetReportExecutorStatisticsPeriodMs() + RandomNumber<ui32>(JitterIntervalMS));
+    ActorContext().Schedule(scheduleDuration, new TEvPrivate::TEvReportExecutorStatistics);
+    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvReportExecutorStatistics")("ReportExecutorStatisticsPeriodMs", statistics.GetReportExecutorStatisticsPeriodMs())("scheduleDuration", scheduleDuration);
+    SendPeriodicStats(true);
+    return;
 }
 
 }   // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -88,8 +88,10 @@ void TColumnShard::TrySwitchToWork(const TActorContext& ctx) {
     ctx.Send(SelfId(), new NActors::TEvents::TEvWakeup());
     ctx.Send(SelfId(), new TEvPrivate::TEvPeriodicWakeup());
     ctx.Send(SelfId(), new TEvPrivate::TEvPingSnapshotsUsage());
-    ctx.Send(SelfId(), new TEvPrivate::TEvReportExecutorStatistics());
-    ctx.Send(SelfId(), new TEvPrivate::TEvReportBaseStatistics());
+    ExecutorStatsEvInflight++;
+    ctx.Send(SelfId(), new TEvPrivate::TEvReportExecutorStatistics);
+    ScheduleBaseStatistics();
+
     NYDBTest::TControllers::GetColumnShardController()->OnSwitchToWork(TabletID());
     AFL_VERIFY(!!StartInstant);
     Counters.GetCSCounters().Initialization.OnSwitchToWork(TMonotonic::Now() - *StartInstant, TMonotonic::Now() - CreateInstant);
@@ -161,8 +163,11 @@ void TColumnShard::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TAc
             LOG_S_DEBUG("Connected to " << tabletId << " at tablet " << TabletID());
         } else {
             LOG_S_INFO("Failed to connect to " << tabletId << " at tablet " << TabletID());
+            LastStats = {};
             StatsReportPipe = {};
         }
+        ExecutorStatsEvInflight++;
+        ActorContext().Send(SelfId(), new TEvPrivate::TEvReportExecutorStatistics());
         return;
     }
 
@@ -435,19 +440,24 @@ void TColumnShard::FillColumnTableStats(const TActorContext& ctx, std::unique_pt
 }
 
 void TColumnShard::SendPeriodicStats(bool withExecutor) {
-    if (!CurrentSchemeShardId || !TablesManager.GetTabletPathIdOptional()) {
-        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("Disabled periodic stats at tablet", TabletID());
+    if (!CurrentSchemeShardId) {
+        AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("No CurrentSchemeShardId", TabletID());
+        return;
+    }
+
+    if (!StatsReportPipe) {
+        AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("StatsReportPipe created", TabletID());
+        StatsReportPipe = ActorContext().Register(NTabletPipe::CreateClient(ActorContext().SelfID, CurrentSchemeShardId, {}));
+        return;
+    }
+
+    if (!TablesManager.GetTabletPathIdOptional()) {
+        AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("TablesManager not ready", TabletID());
         return;
     }
 
     const auto& tabletSchemeShardLocalPathId = TablesManager.GetTabletPathIdVerified().SchemeShardLocalPathId;
     const TActorContext& ctx = ActorContext();
-
-    if (!StatsReportPipe) {
-        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("reate periodic stats pipe to ", CurrentSchemeShardId)("at tablet", TabletID());
-        NTabletPipe::TClientConfig clientConfig;
-        StatsReportPipe = ctx.Register(NTabletPipe::CreateClient(ctx.SelfID, CurrentSchemeShardId, clientConfig));
-    }
 
     if (!LastStats) {
         LastStats = std::make_unique<TEvDataShard::TEvPeriodicTableStats>(TabletID(), tabletSchemeShardLocalPathId.GetRawValue());
@@ -472,21 +482,35 @@ void TColumnShard::SendPeriodicStats(bool withExecutor) {
 }
 
 void TColumnShard::Handle(TEvPrivate::TEvReportBaseStatistics::TPtr& /*ev*/) {
-    auto statistics = AppDataVerified().ColumnShardConfig.GetStatistics();
-    auto scheduleDuration = TDuration::MilliSeconds(statistics.GetReportBaseStatisticsPeriodMs() + RandomNumber<ui32>(JitterIntervalMS));
-    ActorContext().Schedule(scheduleDuration, new TEvPrivate::TEvReportBaseStatistics);
-    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvReportBaseStatistics")("ReportBaseStatisticsPeriodMs", statistics.GetReportBaseStatisticsPeriodMs())("scheduleDuration", scheduleDuration);
+    BaseStatsEvInflight--;
+    ScheduleBaseStatistics();
     SendPeriodicStats(false);
-    return;
 }
 
 void TColumnShard::Handle(TEvPrivate::TEvReportExecutorStatistics::TPtr& /*ev*/) {
+    ExecutorStatsEvInflight--;
+    ScheduleExecutorStatistics();
+    SendPeriodicStats(true);
+}
+
+void TColumnShard::ScheduleBaseStatistics() {
+    auto statistics = AppDataVerified().ColumnShardConfig.GetStatistics();
+    auto scheduleDuration = TDuration::MilliSeconds(statistics.GetReportBaseStatisticsPeriodMs() + RandomNumber<ui32>(JitterIntervalMS));
+    if (!BaseStatsEvInflight) {
+        BaseStatsEvInflight++;
+        ActorContext().Schedule(scheduleDuration, new TEvPrivate::TEvReportBaseStatistics);
+        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvReportBaseStatistics")("ReportBaseStatisticsPeriodMs", statistics.GetReportBaseStatisticsPeriodMs())("scheduleDuration", scheduleDuration);
+    }
+}
+
+void TColumnShard::ScheduleExecutorStatistics() {
     auto statistics = AppDataVerified().ColumnShardConfig.GetStatistics();
     auto scheduleDuration = TDuration::MilliSeconds(statistics.GetReportExecutorStatisticsPeriodMs() + RandomNumber<ui32>(JitterIntervalMS));
-    ActorContext().Schedule(scheduleDuration, new TEvPrivate::TEvReportExecutorStatistics);
-    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvReportExecutorStatistics")("ReportExecutorStatisticsPeriodMs", statistics.GetReportExecutorStatisticsPeriodMs())("scheduleDuration", scheduleDuration);
-    SendPeriodicStats(true);
-    return;
+    if (!ExecutorStatsEvInflight) {
+        ExecutorStatsEvInflight++;
+        ActorContext().Schedule(scheduleDuration, new TEvPrivate::TEvReportExecutorStatistics);
+        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvReportExecutorStatistics")("ReportExecutorStatisticsPeriodMs", statistics.GetReportExecutorStatisticsPeriodMs())("scheduleDuration", scheduleDuration);
+    }
 }
 
 }   // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -265,8 +265,8 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
 
     void Handle(TEvPrivate::TEvScanStats::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvReadFinished::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvPrivate::TEvReportBaseStatistics::TPtr& ev);
-    void Handle(TEvPrivate::TEvReportExecutorStatistics::TPtr& ev);
+    void Handle(TEvPrivate::TEvReportBaseStatistics::TPtr&);
+    void Handle(TEvPrivate::TEvReportExecutorStatistics::TPtr&);
     void Handle(TEvPrivate::TEvPeriodicWakeup::TPtr& ev, const TActorContext& ctx);
     void Handle(NActors::TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvPingSnapshotsUsage::TPtr& ev, const TActorContext& ctx);
@@ -437,7 +437,6 @@ protected:
             HFunc(TEvPrivate::TEvPingSnapshotsUsage, Handle);
             hFunc(TEvPrivate::TEvReportBaseStatistics, Handle);
             hFunc(TEvPrivate::TEvReportExecutorStatistics, Handle);
-
             HFunc(NEvents::TDataEvents::TEvWrite, Handle);
             HFunc(TEvPrivate::TEvWriteDraft, Handle);
             HFunc(TEvPrivate::TEvGarbageCollectionFinished, Handle);
@@ -520,7 +519,6 @@ private:
     NOlap::NDataAccessorControl::TDataAccessorsManagerContainer DataAccessorsManager;
     NBackgroundTasks::TControlInterfaceContainer<NOlap::NColumnFetching::TColumnDataManager> ColumnDataManager;
 
-    TActorId StatsReportPipe;
     std::vector<TActorId> ActorsToStop;
 
     TInFlightReadsTracker InFlightReadsTracker;
@@ -543,8 +541,11 @@ private:
     TActorId SpaceWatcherId;
     THashMap<TActorId, TActorId> PipeServersInterconnectSessions;
 
+    TActorId StatsReportPipe;
     std::unique_ptr<TEvDataShard::TEvPeriodicTableStats> LastStats;
     ui32 JitterIntervalMS = 200;
+    ui32 BaseStatsEvInflight = 0;
+    ui32 ExecutorStatsEvInflight = 0;
     void TryRegisterMediatorTimeCast();
     void UnregisterMediatorTimeCast();
 
@@ -594,6 +595,8 @@ private:
     ui64 MemoryUsage() const;
 
     void SendPeriodicStats(bool);
+    void ScheduleBaseStatistics();
+    void ScheduleExecutorStatistics();
 
     void FillOlapStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev, IExecutor* executor);
     void FillColumnTableStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev, IExecutor* executor);

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -265,6 +265,8 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
 
     void Handle(TEvPrivate::TEvScanStats::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvReadFinished::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvReportBaseStatistics::TPtr& ev);
+    void Handle(TEvPrivate::TEvReportExecutorStatistics::TPtr& ev);
     void Handle(TEvPrivate::TEvPeriodicWakeup::TPtr& ev, const TActorContext& ctx);
     void Handle(NActors::TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvPingSnapshotsUsage::TPtr& ev, const TActorContext& ctx);
@@ -433,6 +435,8 @@ protected:
             HFunc(TEvPrivate::TEvPeriodicWakeup, Handle);
             HFunc(NActors::TEvents::TEvWakeup, Handle);
             HFunc(TEvPrivate::TEvPingSnapshotsUsage, Handle);
+            hFunc(TEvPrivate::TEvReportBaseStatistics, Handle);
+            hFunc(TEvPrivate::TEvReportExecutorStatistics, Handle);
 
             HFunc(NEvents::TDataEvents::TEvWrite, Handle);
             HFunc(TEvPrivate::TEvWriteDraft, Handle);
@@ -539,6 +543,8 @@ private:
     TActorId SpaceWatcherId;
     THashMap<TActorId, TActorId> PipeServersInterconnectSessions;
 
+    std::unique_ptr<TEvDataShard::TEvPeriodicTableStats> LastStats;
+    ui32 JitterIntervalMS = 200;
     void TryRegisterMediatorTimeCast();
     void UnregisterMediatorTimeCast();
 
@@ -587,9 +593,10 @@ private:
     void UpdateResourceMetrics(const TActorContext& ctx, const TUsage& usage);
     ui64 MemoryUsage() const;
 
-    void SendPeriodicStats();
-    void FillOlapStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
-    void FillColumnTableStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
+    void SendPeriodicStats(bool);
+
+    void FillOlapStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev, IExecutor* executor);
+    void FillColumnTableStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev, IExecutor* executor);
 
 public:
     ui64 TabletTxCounter = 0;

--- a/ydb/core/tx/columnshard/columnshard_private_events.h
+++ b/ydb/core/tx/columnshard/columnshard_private_events.h
@@ -40,6 +40,8 @@ struct TEvPrivate {
         EvScanStats,
         EvReadFinished,
         EvPeriodicWakeup,
+        EvReportBaseStatistics,
+        EvReportExecutorStatistics,
         EvEviction,
         EvS3Settings,
         EvExport,
@@ -287,6 +289,10 @@ struct TEvPrivate {
 
         bool Manual;
     };
+
+    struct TEvReportBaseStatistics: public TEventLocal<TEvReportBaseStatistics, EvReportBaseStatistics> {};
+
+    struct TEvReportExecutorStatistics: public TEventLocal<TEvReportExecutorStatistics, EvReportExecutorStatistics> {};
 
     struct TEvPingSnapshotsUsage: public TEventLocal<TEvPingSnapshotsUsage, EvPingSnapshotsUsage> {
         TEvPingSnapshotsUsage() = default;

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -624,6 +624,11 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
 
     app.ColumnShardConfig.SetDisabledOnSchemeShard(false);
 
+    if (!app.ColumnShardConfig.HasStatistics()) {
+        app.ColumnShardConfig.MutableStatistics()->SetReportBaseStatisticsPeriodMs(1000);
+        app.ColumnShardConfig.MutableStatistics()->SetReportExecutorStatisticsPeriodMs(1000);
+    }
+
     if (opts.DisableStatsBatching_.value_or(false)) {
         app.SchemeShardConfig.SetStatsMaxBatchSize(0);
         app.SchemeShardConfig.SetStatsBatchTimeoutMs(0);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Statistics Improvement

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

#### Original PR(s)
* PR https://github.com/ydb-platform/ydb/pull/29487

#### Metadata
- **Original PR author(s):** @XJIE6
- **Cherry-picked by:** @kirrysin
- **Related issues:** None

#### Conflicts Require Manual Resolution

This PR contains merge conflicts that require manual resolution.

**Files with conflicts:**

- [ydb/core/protos/config.proto](https://github.com/ydb-platform/ydb/pull/29547/files)

**How to resolve conflicts:**

```bash
git fetch origin
git checkout --track origin/cherry-pick-stable-25-3-251125-163101
# Resolve conflicts in files
git add .
git commit -m "Resolved merge conflicts"
git push
```

After resolving conflicts:
1. Fix the PR title (remove `[CONFLICT]` if conflicts are resolved)
2. Mark PR as ready for review


### Git Cherry-Pick Log

```
=== Cherry-picking 360d718 ===
Auto-merging ydb/core/kqp/ut/common/columnshard.cpp
Auto-merging ydb/core/protos/config.proto
CONFLICT (content): Merge conflict in ydb/core/protos/config.proto
Auto-merging ydb/core/statistics/service/ut/ut_basic_statistics.cpp
Auto-merging ydb/core/tx/columnshard/columnshard.cpp
Auto-merging ydb/core/tx/columnshard/columnshard_impl.h
Auto-merging ydb/core/tx/schemeshard/ut_helpers/test_env.cpp

error: could not apply 360d718749d... Divide statistics into base and executor (#26925)
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".

=== Cherry-picking db03b5c ===
Auto-merging ydb/core/tx/columnshard/columnshard.cpp
Auto-merging ydb/core/tx/columnshard/columnshard_impl.h
[cherry-pick-stable-25-3-251125-163101 b616111caa2] Statistics report improvement (#28176)
 Author: Iurii Kravchenko <xjie6@ydb.tech>
 Date: Thu Nov 6 16:51:26 2025 +0100
 2 files changed, 50 insertions(+), 23 deletions(-)
```


---

PR was created by cherry-pick script
