### PR TITLE
Removed the magic trick handling an empty database name in tests

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -116,14 +116,6 @@ TKqpPlanner::TKqpPlanner(TKqpPlanner::TArgs&& args)
         SerializedGUCSettings = GUCSettings->SerializeToString();
     }
 
-    if (!Database) {
-        // a piece of magic for tests
-        if (const auto& domain = AppData()->DomainsInfo->Domain) {
-            Database = TStringBuilder() << '/' << domain->Name;
-            LOG_E("Database not set, use " << Database);
-        }
-    }
-
     if (LimitCPU(UserRequestContext)) {
         TasksGraph.GetMeta().SinglePartitionOptAllowed = false;
     }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -28,7 +28,7 @@ message TFeatureFlags {
     optional bool EnableChunkGraceForPDisk = 7 [default = true];
     optional bool AllowConsistentOperationsForSchemeShard = 8 [default = true];
     optional bool EnableSchemeBoard = 9 [default = true]; // deprecated: always true
-    optional bool AllowYdbRequestsWithoutDatabase = 10 [default = true, (RequireRestart) = true];
+    optional bool AllowYdbRequestsWithoutDatabase = 10 [default = false, (RequireRestart) = true];
     optional bool EnableExternalSubdomains = 11 [default = true];
     optional bool AllowRecursiveMkDir = 12 [default = true]; // deprecated: always true
     optional bool AllowHugeKeyValueDeletes = 13 [default = true]; // delete when all clients limit deletes per request

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -28,7 +28,7 @@ message TFeatureFlags {
     optional bool EnableChunkGraceForPDisk = 7 [default = true];
     optional bool AllowConsistentOperationsForSchemeShard = 8 [default = true];
     optional bool EnableSchemeBoard = 9 [default = true]; // deprecated: always true
-    optional bool AllowYdbRequestsWithoutDatabase = 10 [default = false, (RequireRestart) = true];
+    optional bool AllowYdbRequestsWithoutDatabase = 10 [default = true, (RequireRestart) = true];
     optional bool EnableExternalSubdomains = 11 [default = true];
     optional bool AllowRecursiveMkDir = 12 [default = true]; // deprecated: always true
     optional bool AllowHugeKeyValueDeletes = 13 [default = true]; // delete when all clients limit deletes per request


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

To make tests show the real behavior removed hiding an empty database name in kqp. This trick resulted in different database name in different ydb components so it was incoherent.
