### PR TITLE
Fixed an error in calculating metrics in the PQ tablet (#29321)

### DIFF
--- a/ydb/core/persqueue/mirrorer.cpp
+++ b/ydb/core/persqueue/mirrorer.cpp
@@ -46,6 +46,7 @@ TMirrorer::TMirrorer(
     , Config(config)
 {
     Counters.Populate(counters);
+    Counters.ResetCounters();
 }
 
 void TMirrorer::Bootstrap(const TActorContext& ctx) {
@@ -251,6 +252,8 @@ void TMirrorer::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext&
 void TMirrorer::Handle(TEvPQ::TEvUpdateCounters::TPtr& /*ev*/, const TActorContext& ctx) {
     ctx.Schedule(UPDATE_COUNTERS_INTERVAL, new TEvPQ::TEvUpdateCounters);
     ctx.Send(PartitionActor, new TEvPQ::TEvMirrorerCounters(Counters));
+    Counters.Cumulative().ResetCounters();
+    Counters.Percentile().ResetCounters();
 
     if (ctx.Now() - LastStateLogTimestamp > LOG_STATE_INTERVAL) {
         LastStateLogTimestamp = ctx.Now();

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -171,13 +171,11 @@ bool TPartition::LastOffsetHasBeenCommited(const TUserInfoBase& userInfo) const 
 }
 
 struct TMirrorerInfo {
-    TMirrorerInfo(const TActorId& actor, const TTabletCountersBase& baseline)
+    TMirrorerInfo(const TActorId& actor)
     : Actor(actor) {
-        Baseline.Populate(baseline);
     }
 
     TActorId Actor;
-    TTabletCountersBase Baseline;
 };
 
 const TString& TPartition::TopicName() const {
@@ -339,9 +337,10 @@ TPartition::TPartition(ui64 tabletId, const TPartitionId& partition, const TActo
     , WriteBufferIsFullCounter(nullptr)
     , WriteLagMs(TDuration::Minutes(1), 100)
     , LastEmittedHeartbeat(TRowVersion::Min())
-    , SamplingControl(samplingControl) {
-
+    , SamplingControl(samplingControl)
+{
     TabletCounters.Populate(Counters);
+    TabletCounters.ResetCounters();
 }
 
 void TPartition::EmplaceResponse(TMessage&& message, const TActorContext& ctx) {
@@ -437,6 +436,8 @@ void TPartition::HandleWakeup(const TActorContext& ctx) {
 
     ctx.Schedule(WAKE_TIMEOUT, new TEvents::TEvWakeup());
     ctx.Send(Tablet, new TEvPQ::TEvPartitionCounters(Partition, TabletCounters));
+    TabletCounters.Cumulative().ResetCounters();
+    TabletCounters.Percentile().ResetCounters();
 
     ui64 usedStorage = GetUsedStorage(now);
     if (usedStorage > 0) {
@@ -592,9 +593,7 @@ bool TPartition::CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorCont
 
 void TPartition::Handle(TEvPQ::TEvMirrorerCounters::TPtr& ev, const TActorContext& /*ctx*/) {
     if (Mirrorer) {
-        auto diff = ev->Get()->Counters.MakeDiffForAggr(Mirrorer->Baseline);
-        TabletCounters.Populate(*diff.Get());
-        ev->Get()->Counters.RememberCurrentStateAsBaseline(Mirrorer->Baseline);
+        TabletCounters.Populate(ev->Get()->Counters);
     }
 }
 
@@ -4085,7 +4084,6 @@ size_t TPartition::GetQuotaRequestSize(const TEvKeyValue::TEvRequest& request) {
 void TPartition::CreateMirrorerActor() {
     Mirrorer = MakeHolder<TMirrorerInfo>(
         Register(new TMirrorer(Tablet, SelfId(), TopicConverter, Partition.InternalPartitionId, IsLocalDC,  EndOffset, Config.GetPartitionConfig().GetMirrorFrom(), TabletCounters)),
-        TabletCounters
     );
 }
 

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -4083,7 +4083,7 @@ size_t TPartition::GetQuotaRequestSize(const TEvKeyValue::TEvRequest& request) {
 
 void TPartition::CreateMirrorerActor() {
     Mirrorer = MakeHolder<TMirrorerInfo>(
-        Register(new TMirrorer(Tablet, SelfId(), TopicConverter, Partition.InternalPartitionId, IsLocalDC,  EndOffset, Config.GetPartitionConfig().GetMirrorFrom(), TabletCounters)),
+        Register(new TMirrorer(Tablet, SelfId(), TopicConverter, Partition.InternalPartitionId, IsLocalDC,  EndOffset, Config.GetPartitionConfig().GetMirrorFrom(), TabletCounters))
     );
 }
 

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -911,8 +911,7 @@ void TPersQueue::CreateOriginalPartition(const NKikimrPQ::TPQTabletConfig& confi
     Partitions.emplace(std::piecewise_construct,
                        std::forward_as_tuple(partitionId),
                        std::forward_as_tuple(actorId,
-                                             GetPartitionKeyRange(config, partition),
-                                             *Counters));
+                                             GetPartitionKeyRange(config, partition)));
     ++OriginalPartitionsCount;
 }
 
@@ -949,8 +948,7 @@ void TPersQueue::AddSupportivePartition(const TPartitionId& partitionId)
 {
     Partitions.emplace(partitionId,
                        TPartitionInfo(TActorId(),
-                                      {},
-                                      *Counters));
+                                      {}));
     NewSupportivePartitions.insert(partitionId);
 }
 
@@ -1359,11 +1357,12 @@ void TPersQueue::Handle(TEvPQ::TEvPartitionCounters::TPtr& ev, const TActorConte
     PQ_LOG_T("Handle TEvPQ::TEvPartitionCounters" <<
              " PartitionId " << ev->Get()->Partition);
 
-    const auto& partitionId = ev->Get()->Partition;
+    auto& partitionId = ev->Get()->Partition;
     auto& partition = GetPartitionInfo(partitionId);
-    auto diff = ev->Get()->Counters.MakeDiffForAggr(partition.Baseline);
-    ui64 cpuUsage = diff->Cumulative()[COUNTER_PQ_TABLET_CPU_USAGE].Get();
-    ui64 networkBytesUsage = diff->Cumulative()[COUNTER_PQ_TABLET_NETWORK_BYTES_USAGE].Get();
+
+    auto& counters = ev->Get()->Counters;
+    ui64 cpuUsage = counters.Cumulative()[COUNTER_PQ_TABLET_CPU_USAGE].Get();
+    ui64 networkBytesUsage = counters.Cumulative()[COUNTER_PQ_TABLET_NETWORK_BYTES_USAGE].Get();
     if (ResourceMetrics) {
         if (cpuUsage > 0) {
             ResourceMetrics->CPU.Increment(cpuUsage);
@@ -1375,17 +1374,15 @@ void TPersQueue::Handle(TEvPQ::TEvPartitionCounters::TPtr& ev, const TActorConte
             ResourceMetrics->TryUpdate(ctx);
         }
     }
+    Counters->Percentile().Populate(counters.Percentile());
+    Counters->Cumulative().Populate(counters.Cumulative());
 
-    Counters->Populate(*diff.Get());
-    ev->Get()->Counters.RememberCurrentStateAsBaseline(partition.Baseline);
+    partition.ReservedBytes = counters.Simple()[COUNTER_PQ_TABLET_RESERVED_BYTES_SIZE].Get();
 
     // restore cache's simple counters cleaned by partition's counters
     SetCacheCounters(CacheCounters);
-    ui64 reservedSize = 0;
-    for (auto& p : Partitions) {
-        if (p.second.Baseline.Simple().Size() > 0) //there could be no counters from this partition yet
-            reservedSize += p.second.Baseline.Simple()[COUNTER_PQ_TABLET_RESERVED_BYTES_SIZE].Get();
-    }
+    ui64 reservedSize = std::accumulate(Partitions.begin(), Partitions.end(), 0ul,
+        [](ui64 sum, const auto& p) { return sum + p.second.ReservedBytes; });
     Counters->Simple()[COUNTER_PQ_TABLET_RESERVED_BYTES_SIZE].Set(reservedSize);
 
     // Features of the implementation of SimpleCounters. It is necessary to restore the value of

--- a/ydb/core/persqueue/pq_impl_types.h
+++ b/ydb/core/persqueue/pq_impl_types.h
@@ -6,13 +6,11 @@ namespace NKikimr::NPQ {
 
 struct TPartitionInfo {
     TPartitionInfo(const TActorId& actor,
-                   TMaybe<TPartitionKeyRange>&& keyRange,
-                   const TTabletCountersBase& baseline)
+                   TMaybe<TPartitionKeyRange>&& keyRange)
         : Actor(actor)
         , KeyRange(std::move(keyRange))
         , InitDone(false)
     {
-        Baseline.Populate(baseline);
     }
 
     TPartitionInfo(const TPartitionInfo& info)
@@ -21,14 +19,13 @@ struct TPartitionInfo {
         , InitDone(info.InitDone)
         , PendingRequests(info.PendingRequests)
     {
-        Baseline.Populate(info.Baseline);
     }
 
     TActorId Actor;
     TMaybe<TPartitionKeyRange> KeyRange;
     bool InitDone;
-    TTabletCountersBase Baseline;
     THashMap<TString, TTabletLabeledCountersBase> LabeledCounters;
+    size_t ReservedBytes = 0;
 
     struct TPendingRequest {
         TPendingRequest(ui64 cookie,

--- a/ydb/core/tablet/tablet_counters.h
+++ b/ydb/core/tablet/tablet_counters.h
@@ -129,10 +129,16 @@ private:
     void Initialize(const TTabletCumulativeCounter& rp) {
         SetTo(rp);
     }
+
+    void Set(ui64 value) {
+        Value = value;
+    }
+
     void AdjustToBaseLine(const TTabletCumulativeCounter& baseLine) {
         Y_DEBUG_ABORT_UNLESS(Value >= baseLine.Value);
         Value -= baseLine.Value;
     }
+
     void SetTo(const TTabletCumulativeCounter& rp) {
         Value = rp.Value;
     }
@@ -375,6 +381,18 @@ public:
         return CountersQnt;
     }
 
+    void Populate(const TCountersArray<T>& rp) {
+        if (CountersQnt != rp.CountersQnt) {
+            Reset(rp);
+        } else {
+            for (ui32 i = 0, e = CountersQnt; i < e; ++i) {
+                Counters[i].Populate(rp.Counters[i]);
+            }
+        }
+    }
+
+    void ResetCounters();
+
 private:
     //
     void Reset(const TCountersArray<T>& rp) {
@@ -408,21 +426,32 @@ private:
         }
     }
 
-    void Populate(const TCountersArray<T>& rp) {
-        if (CountersQnt != rp.CountersQnt) {
-            Reset(rp);
-        } else {
-            for (ui32 i = 0, e = CountersQnt; i < e; ++i) {
-                Counters[i].Populate(rp.Counters[i]);
-            }
-        }
-    }
-
     //
     ui32 CountersQnt;
     TCountersHolder CountersHolder;
     T* Counters;
 };
+
+template <>
+inline void TCountersArray<TTabletSimpleCounter>::ResetCounters() {
+    for (ui32 i = 0; i < CountersQnt; ++i) {
+        Counters[i].Set(0);
+    }
+}
+
+template <>
+inline void TCountersArray<TTabletCumulativeCounter>::ResetCounters() {
+    for (ui32 i = 0; i < CountersQnt; ++i) {
+        Counters[i].Set(0);
+    }
+}
+
+template <>
+inline void TCountersArray<TTabletPercentileCounter>::ResetCounters() {
+    for (ui32 i = 0; i < CountersQnt; ++i) {
+        Counters[i].Clear();
+    }
+}
 
 ////////////////////////////////////////////
 /// The TTabletCountersBase class
@@ -536,6 +565,12 @@ public:
             CumulativeCounters.Populate(rp.CumulativeCounters);
             PercentileCounters.Populate(rp.PercentileCounters);
         }
+    }
+
+    void ResetCounters() {
+        SimpleCounters.ResetCounters();
+        CumulativeCounters.ResetCounters();
+        PercentileCounters.ResetCounters();
     }
 
 private:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed an error in calculating metrics in the PQ tablet, as a result of which the resource usage was incorrectly determined, which led to unnecessary balancing of tablets.

### Changelog category <!-- remove all except one -->

* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10121
