### PR TITLE
25-2-1-enterprise: Fix race condition in login authentication (#28655)

### DIFF
--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -347,6 +347,7 @@ private:
     TPriorityQueue<TTokenRefreshRecord> RefreshQueue;
     std::unordered_map<TString, NLogin::TLoginProvider> LoginProviders;
     bool UseLoginProvider = false;
+    std::unordered_map<TString, std::pair<TInstant, std::unordered_set<TString>>> DeferredLoginTokens;
 
     TDerived* GetDerived() {
         return static_cast<TDerived*>(this);
@@ -738,6 +739,13 @@ private:
     template <typename TTokenRecord>
     bool CanInitLoginToken(const TString& key, TTokenRecord& record) {
         if (UseLoginProvider && (record.TokenType == TDerived::ETokenType::Unknown || record.TokenType == TDerived::ETokenType::Login)) {
+            if (record.TokenType == TDerived::ETokenType::Unknown) {
+                if (NLogin::TLoginProvider::CanDecodeToken(record.Ticket)) {
+                    record.TokenType = TDerived::ETokenType::Login;
+                } else {
+                    return false;
+                }
+            }
             // Lookup the token in the login provider for the target database, with the possible fallback to the root (domain) database.
             //
             // Target database could be unspecified (some anonymous or backward-compatible mode).
@@ -802,9 +810,23 @@ private:
                 }
             } else {
                 if (record.TokenType == TDerived::ETokenType::Login) {
-                    SetError(key, record, {.Message = "Login state is not available yet", .Retryable = false});
-                    CounterTicketsLogin->Inc();
-                    BLOG_TRACE("CanInitLoginToken, database " << database << ", A5 error");
+                    auto it = DeferredLoginTokens.find(database);
+                    if (it != DeferredLoginTokens.end()) {
+                        auto& tokenKeys = it->second.second;
+                        static constexpr ui64 MAX_NUMBER_DEFERRED_TOKENS = 100'000;
+                        if (tokenKeys.size() < MAX_NUMBER_DEFERRED_TOKENS) {
+                            tokenKeys.insert(key);
+                        } else {
+                            SetError(key, record, {.Message = "Login state is not available yet", .Retryable = false});
+                            CounterTicketsLogin->Inc();
+                            BLOG_TRACE("CanInitLoginToken, database " << database << ", login state is not available yet, cannot deffer token (" << MaskTicket(record.Ticket) << ")");
+                            return true;
+                        }
+                    } else {
+                        static const ui64 NUM_SECONDS_TO_WAIT_FOR_SECURITY_STATE_UPDATE = std::max(RefreshPeriod.Seconds(), 2UL);
+                        DeferredLoginTokens.insert(std::make_pair(database, std::make_pair(TlsActivationContext->Now() + TDuration::Seconds(NUM_SECONDS_TO_WAIT_FOR_SECURITY_STATE_UPDATE), std::unordered_set<TString>({key}))));
+                    }
+                    BLOG_TRACE("CanInitLoginToken, database " << database << ", login state is not available yet, deffer token (" << MaskTicket(record.Ticket) << ")");
                     return true;
                 }
                 BLOG_TRACE("CanInitLoginToken, database " << database << ", A6 error");
@@ -825,6 +847,7 @@ private:
     template <typename TTokenRecord>
     void SendRequestToLdap(const TString& key, TTokenRecord& record, const TString& user) {
         if (Config.HasLdapAuthentication()) {
+            ++record.ResponsesLeft;
             Send(MakeLdapAuthProviderID(), new TEvLdapAuthProvider::TEvEnrichGroupsRequest(key, user));
         } else {
             SetError(key, record, {.Message = "LdapAuthProvider is not initialized", .Retryable = false});
@@ -841,6 +864,7 @@ private:
         } else {
             const auto& key = it->first;
             auto& record = it->second;
+            record.ResponsesLeft--;
             if (response->Status == TEvLdapAuthProvider::EStatus::SUCCESS) {
                 const TString domain {"@" + Config.GetLdapAuthenticationDomain()};
                 TVector<NACLib::TSID> groups(response->Groups.cbegin(), response->Groups.cend());
@@ -856,7 +880,9 @@ private:
             } else {
                 SetError(key, record, response->Error);
             }
-            Respond(record);
+            if (record.ResponsesLeft == 0) {
+                Respond(record);
+            }
         }
     }
 
@@ -1478,12 +1504,32 @@ private:
         auto& loginProvider = LoginProviders[ev->Get()->SecurityState.GetAudience()];
         loginProvider.UpdateSecurityState(ev->Get()->SecurityState);
         BLOG_D("Updated state for " << loginProvider.Audience << " keys " << GetLoginProviderKeys(loginProvider));
+
+        auto it = DeferredLoginTokens.find(loginProvider.Audience);
+        if (it != DeferredLoginTokens.end()) {
+            BLOG_TRACE("Handle deferred tokens for database: " << loginProvider.Audience);
+            for (const TString& key : it->second.second) {
+                auto& userTokens = GetDerived()->GetUserTokens();
+                auto tokenIt = userTokens.find(key);
+                if (tokenIt == userTokens.end()) {
+                    continue;
+                }
+                auto& record = tokenIt->second;
+                CanInitLoginToken(key, record);
+                if (record.ResponsesLeft == 0) {
+                    Respond(record);
+                }
+            }
+            DeferredLoginTokens.erase(it);
+        }
     }
 
     void Handle(TEvTicketParser::TEvDiscardTicket::TPtr& ev) {
         auto& userTokens = GetDerived()->GetUserTokens();
         userTokens.erase(ev->Get()->Ticket);
     }
+
+    void RefreshDeferredLoginTokens(const TInstant& now);
 
     void HandleRefresh() {
         TInstant now = TlsActivationContext->Now();
@@ -1510,6 +1556,7 @@ private:
                 userTokens.erase(it);
             }
         }
+        RefreshDeferredLoginTokens(now);
         Schedule(RefreshPeriod, new NActors::TEvents::TEvWakeup());
     }
 
@@ -2213,5 +2260,39 @@ public:
         , CertificateChecker(settings.CertificateAuthValues)
     {}
 };
+
+template <typename TDerived>
+void TTicketParserImpl<TDerived>::RefreshDeferredLoginTokens(const TInstant& now) {
+    static constexpr ui32 FINISH_WAITING_FOR_LOGIN_PROVIDERS_NUM = 10;
+    TVector<TString> finishWaitingForLoginProviders;
+    finishWaitingForLoginProviders.reserve(FINISH_WAITING_FOR_LOGIN_PROVIDERS_NUM);
+    for (const auto& [database, deferredTokens] : DeferredLoginTokens) {
+        const auto& expiredTimeWaitingForLoginProvider = deferredTokens.first;
+        if (expiredTimeWaitingForLoginProvider <= now) {
+            finishWaitingForLoginProviders.push_back(database);
+            for (const TString& key : deferredTokens.second) {
+                auto& userTokens = GetDerived()->GetUserTokens();
+                auto it = userTokens.find(key);
+                if (it == userTokens.end()) {
+                    continue;
+                }
+                auto& record = it->second;
+                SetError(key, record, {.Message = "Login state is not available", .Retryable = false});
+                CounterTicketsLogin->Inc();
+                Respond(record);
+            }
+        }
+    }
+    TStringBuilder deferredLoginTokensMessage;
+    deferredLoginTokensMessage << "Finish waiting for login providers for " << finishWaitingForLoginProviders.size() << " databases: ";
+    for (size_t i = 0; i < finishWaitingForLoginProviders.size() && i < FINISH_WAITING_FOR_LOGIN_PROVIDERS_NUM; ++i) {
+        const TString& key = finishWaitingForLoginProviders[i];
+        deferredLoginTokensMessage << key << ", ";
+        DeferredLoginTokens.erase(key);
+    }
+    if (!finishWaitingForLoginProviders.empty()) {
+        BLOG_TRACE(deferredLoginTokensMessage);
+    }
+}
 
 }

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -155,6 +155,141 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT(result->Token->IsExist("group1"));
     }
 
+    Y_UNIT_TEST(LoginGoodWithDelayUpdateSecurityState) {
+        using namespace Tests;
+        TPortManager tp;
+        ui16 kikimrPort = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        NKikimrProto::TAuthConfig authConfig;
+        authConfig.SetUseBlackBox(false);
+        authConfig.SetUseLoginProvider(true);
+        authConfig.SetDomainLoginOnly(false);
+        auto settings = TServerSettings(kikimrPort, authConfig);
+        settings.SetDomainName("Root");
+        settings.CreateTicketParser = NKikimr::CreateTicketParser;
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::TICKET_PARSER, NLog::PRI_TRACE);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
+        TClient client(settings);
+        NClient::TKikimr kikimr(client.GetClientConfig());
+        client.InitRootScheme();
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        {
+            NLogin::TLoginProvider loginProviderDb1;
+            loginProviderDb1.Audience = "/Root/Db1";
+            loginProviderDb1.RotateKeys();
+
+            TActorId sender = runtime->AllocateEdgeActor();
+
+            loginProviderDb1.CreateGroup({.Group = "group1"});
+            loginProviderDb1.CreateUser({.User = "user1", .Password = "password1"});
+            loginProviderDb1.AddGroupMembership({.Group = "group1", .Member = "user1"});
+
+
+            auto loginResponse = loginProviderDb1.LoginUser({.User = "user1", .Password = "password1"});
+
+            UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
+
+            // Send token without type
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Database = "/Root/Db1", .Ticket = loginResponse.Token})), 0);
+            Sleep(TDuration::Seconds(1));
+            // Send update security state in 1 second after send TEvAuthorizeTicket
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb1.GetSecurityState())), 0);
+
+            TAutoPtr<IEventHandle> handle;
+
+            TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+            UNIT_ASSERT(result->Error.empty());
+            UNIT_ASSERT(result->Token != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
+            UNIT_ASSERT(result->Token->IsExist("group1"));
+        }
+
+        {
+            NLogin::TLoginProvider loginProviderDb2;
+            loginProviderDb2.Audience = "/Root/Db2";
+            loginProviderDb2.RotateKeys();
+
+            TActorId sender = runtime->AllocateEdgeActor();
+
+            loginProviderDb2.CreateGroup({.Group = "group1"});
+            loginProviderDb2.CreateUser({.User = "user1", .Password = "password1"});
+            loginProviderDb2.AddGroupMembership({.Group = "group1", .Member = "user1"});
+
+
+            auto loginResponse = loginProviderDb2.LoginUser({.User = "user1", .Password = "password1"});
+
+            UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
+
+            // Send token with type Login
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Database = "/Root/Db2", .Ticket = "Login " + loginResponse.Token})), 0);
+            Sleep(TDuration::Seconds(1));
+            // Send update security state in 1 second after send TEvAuthorizeTicket
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb2.GetSecurityState())), 0);
+
+            TAutoPtr<IEventHandle> handle;
+
+            TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+            UNIT_ASSERT(result->Error.empty());
+            UNIT_ASSERT(result->Token != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
+            UNIT_ASSERT(result->Token->IsExist("group1"));
+        }
+    }
+
+    Y_UNIT_TEST(CanGetErrorIfAppropriateLoginProviderIsAbsent) {
+        using namespace Tests;
+        TPortManager tp;
+        ui16 kikimrPort = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        NKikimrProto::TAuthConfig authConfig;
+        authConfig.SetUseBlackBox(false);
+        authConfig.SetUseLoginProvider(true);
+        authConfig.SetDomainLoginOnly(false);
+        auto settings = TServerSettings(kikimrPort, authConfig);
+        settings.SetDomainName("Root");
+        settings.CreateTicketParser = NKikimr::CreateTicketParser;
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::TICKET_PARSER, NLog::PRI_TRACE);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
+        TClient client(settings);
+        NClient::TKikimr kikimr(client.GetClientConfig());
+        client.InitRootScheme();
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        NLogin::TLoginProvider loginProviderDb1;
+        loginProviderDb1.Audience = "/Root/Db1";
+        loginProviderDb1.RotateKeys();
+
+        TActorId sender = runtime->AllocateEdgeActor();
+
+        loginProviderDb1.CreateGroup({.Group = "group1"});
+        loginProviderDb1.CreateUser({.User = "user1", .Password = "password1"});
+        loginProviderDb1.AddGroupMembership({.Group = "group1", .Member = "user1"});
+
+
+        auto loginResponse = loginProviderDb1.LoginUser({.User = "user1", .Password = "password1"});
+
+        UNIT_ASSERT_VALUES_EQUAL(loginResponse.Error, "");
+
+        // Send token without type
+        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket({.Database = "/Root/Db1", .Ticket = loginResponse.Token})), 0);
+        // Do no send update security state
+        // runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(loginProviderDb1.GetSecurityState())), 0);
+
+        TAutoPtr<IEventHandle> handle;
+
+        TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->Token == nullptr);
+        UNIT_ASSERT_EQUAL_C(result->Error.Message, "Login state is not available", result->Error);
+        UNIT_ASSERT_EQUAL_C(result->Error.Retryable, false, result->Error.Retryable);
+    }
+
+
     Y_UNIT_TEST(LoginBad) {
         using namespace Tests;
         TPortManager tp;

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -608,6 +608,16 @@ TLoginProvider::TValidateTokenResponse TLoginProvider::ValidateToken(const TVali
     }
     return response;
 }
+bool TLoginProvider::CanDecodeToken(const TString& token) {
+    try {
+        jwt::decoded_jwt decoded_token = jwt::decode(token);
+    } catch (const std::invalid_argument& e) {
+        return false;
+    } catch (const std::runtime_error& e) {
+        return false;
+    }
+    return true;
+}
 
 TString TLoginProvider::GetTokenAudience(const TString& token) {
     try {

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -213,6 +213,7 @@ public:
     ~TLoginProvider();
 
     std::vector<TString> GetGroupsMembership(const TString& member) const;
+    static bool CanDecodeToken(const TString& token);
     static TString GetTokenAudience(const TString& token);
     static std::chrono::system_clock::time_point GetTokenExpiresAt(const TString& token);
     static TString SanitizeJwtToken(const TString& token);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes race condition where clients receive "Could not find correct token validator" error when
using newly issued tokens before LoginProvider state is updated.
https://github.com/ydb-platform/ydb/issues/28510

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Add structure for deferred tokens
* When loginProvider is absent do not return error immediate, defer parsing of token when security state will be updated
* Process deferred tokens when UpdateSecurityState arrives
* Return error for deferred tokens when delay will expired
* Add count send requests to LDAP provider in order to do not response to client before get response from LDAP provider
