### PR TITLE
Do not reinitialize TReallyFastRng32 each time. 

### DIFF
--- a/ydb/library/actors/wilson/wilson_trace.cpp
+++ b/ydb/library/actors/wilson/wilson_trace.cpp
@@ -111,17 +111,15 @@ namespace NWilson {
     }
 
     TTraceId::TTrace TTraceId::GenerateTraceId() {
+        static thread_local TReallyFastRng32 rng(RandomNumber<ui64>());
+
         for (;;) {
             TTrace res;
-            ui32 *p = reinterpret_cast<ui32*>(res.data());
 
-            TReallyFastRng32 rng(RandomNumber<ui64>());
-            p[0] = rng();
-            p[1] = rng();
-            p[2] = rng();
-            p[3] = rng();
+            res[0] = (ui64)rng() | ((ui64)rng() << 32);
+            res[1] = (ui64)rng() | ((ui64)rng() << 32);
 
-            if (res[0] || res[1]) {
+            if (Y_LIKELY(res[0])) {
                 return res;
             }
         }

--- a/ydb/library/actors/wilson/wilson_trace_ut.cpp
+++ b/ydb/library/actors/wilson/wilson_trace_ut.cpp
@@ -28,6 +28,19 @@ inline T HostToBig(T val) noexcept {
 }
 
 Y_UNIT_TEST_SUITE(TTraceId) {
+    Y_UNIT_TEST(GenerateTraceIdBench) {
+        ui64 x= 0;
+        auto now = TInstant::Now();
+        size_t count = 10000000;
+        for (size_t i = 0; i < count; i++) {
+            auto traceId = TTraceId::NewTraceId(10, 4095);
+            x += *(ui64*)traceId.GetTraceIdPtr();
+        }
+        ui64 spentUs = (TInstant::Now() - now).MicroSeconds();
+        Cerr << x << Endl;
+        Cerr << spentUs << " uS per test, " << (1000ul * spentUs / count) << " ns per one traceId generation ";
+    }
+
     Y_UNIT_TEST(OpenTelemetryHeaderParser) {
         const auto incorrectHeaders = std::array {
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-011", // Wrong length


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


Also fixed possible ub due to ui64 -> ui32 cast.

The added simplest benchmark shows:

The original code:
109554 uS per test, 10 ns per one traceId generation

After current patch:
79954 uS per test, 7 ns per one traceId generation

Additionaly i have checked simple code without TReallyFastRng32 (just call RandomNumber<ui64> twice) 92459 uS per test, 9 ns per one traceId generation



### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
