### PR TITLE
Set default user ip for black box

### DIFF
--- a/ydb/mvp/security/simple/security.cpp
+++ b/ydb/mvp/security/simple/security.cpp
@@ -1,7 +1,7 @@
 #include "security.h"
 
 TStringBuf NKikimr::NSecurity::DefaultUserIp() {
-    return "";
+    return "2a02:6b8:0:80b::5f6c:8ead";
 }
 
 TString NKikimr::NSecurity::BlackBoxTokenFromSessionId(TStringBuf sessionId, TStringBuf userIp) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

If `userip` is empty then get error `Error parsing BlackBox response for ticket **** (00000000): 'status' not found`
