### PR TITLE
Consider the CPU load on followers when splitting/merging partitions

### DIFF
--- a/ydb/core/protos/datashard_config.proto
+++ b/ydb/core/protos/datashard_config.proto
@@ -30,5 +30,5 @@ message TDataShardConfig {
     optional uint32 BackupTableStatsReportIntervalSeconds = 26 [default = 30];
     optional uint32 KeyAccessSampleCollectionMinIntervalSeconds = 27 [default = 5];
     optional uint32 KeyAccessSampleCollectionMaxIntervalSeconds = 28 [default = 60];
-    optional uint32 KeyAccessSampleVaidityIntervalSeconds = 29 [default = 30];
+    optional uint32 KeyAccessSampleValidityIntervalSeconds = 29 [default = 30];
 }

--- a/ydb/core/protos/datashard_config.proto
+++ b/ydb/core/protos/datashard_config.proto
@@ -28,4 +28,7 @@ message TDataShardConfig {
     optional uint64 InMemoryStateMigrationTimeoutMs = 24 [default = 1000];
     optional uint32 StatsReportIntervalSeconds = 25 [default = 10];
     optional uint32 BackupTableStatsReportIntervalSeconds = 26 [default = 30];
+    optional uint32 KeyAccessSampleCollectionMinIntervalSeconds = 27 [default = 5];
+    optional uint32 KeyAccessSampleCollectionMaxIntervalSeconds = 28 [default = 60];
+    optional uint32 KeyAccessSampleVaidityIntervalSeconds = 29 [default = 30];
 }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -855,6 +855,7 @@ message TEvGetTableStatsResult {
     repeated uint64 SysTablesPartOwners = 7;
     optional bool FullStatsReady = 8;
     optional uint64 TableOwnerId = 9;
+    optional uint32 FollowerId = 10;
 }
 
 message TEvPeriodicTableStats {

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -272,7 +272,7 @@ public:
         );
 
         const TDuration sampleValidity = TDuration::Seconds(
-            appData->DataShardConfig.GetKeyAccessSampleVaidityIntervalSeconds()
+            appData->DataShardConfig.GetKeyAccessSampleValidityIntervalSeconds()
         );
 
         bool returnKeyAccessSample = false;

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -143,7 +143,7 @@ private:
 
             if (now > CoroutineDeadline) {
                 Send(new IEventHandle(EvResume, 0, SelfActorId, {}, nullptr, 0));
-                
+
                 Interrupt();
                 WaitForSpecificEvent([](IEventHandle& ev) {
                     return ev.Type == EvResume;
@@ -244,15 +244,69 @@ public:
         ui64 tableId = Ev->Get()->Record.GetTableId();
 
         Result = new TEvDataShard::TEvGetTableStatsResult(Self->TabletID(), Self->PathOwnerId, tableId);
+        Result->Record.SetFollowerId(Self->FollowerId());
 
-        if (!Self->TableInfos.contains(tableId))
+        const auto tableInfoIt = Self->TableInfos.find(tableId);
+
+        if (tableInfoIt == Self->TableInfos.end()) {
             return true;
-
-        if (Ev->Get()->Record.GetCollectKeySample()) {
-            Self->EnableKeyAccessSampling(ctx, AppData(ctx)->TimeProvider->Now() + TDuration::Seconds(60));
         }
 
-        const TUserTable& tableInfo = *Self->TableInfos[tableId];
+        const TUserTable& tableInfo = *(tableInfoIt->second);
+
+        // Return the key access sample if it has been collected no more
+        // than 30 seconds ago or it has been active for at least 5 seconds
+        //
+        // NOTE: This must be done before calling EnableKeyAccessSampling()
+        //       because this function resets StopKeyAccessSamplingAt and clears
+        //       the current key access data (if available)
+        const auto appData = AppData(ctx);
+        const auto currentTime = appData->TimeProvider->Now();
+
+        const TDuration sampleMinCollection = TDuration::Seconds(
+            appData->DataShardConfig.GetKeyAccessSampleCollectionMinIntervalSeconds()
+        );
+
+        const TDuration sampleMaxCollection = TDuration::Seconds(
+            appData->DataShardConfig.GetKeyAccessSampleCollectionMaxIntervalSeconds()
+        );
+
+        const TDuration sampleValidity = TDuration::Seconds(
+            appData->DataShardConfig.GetKeyAccessSampleVaidityIntervalSeconds()
+        );
+
+        bool returnKeyAccessSample = false;
+
+        if (Self->CurrentKeySampler == Self->EnabledKeySampler) {
+            // Key access collection is active
+            if (Self->StartedKeyAccessSamplingAt + sampleMinCollection <= currentTime) {
+                // The key collection has been active for at least the min required time
+                returnKeyAccessSample = true;
+            }
+        } else {
+            // Key access collection is not active
+            if (Self->StopKeyAccessSamplingAt + sampleValidity >= currentTime) {
+                // There is a valid key access data not older than some min age
+                returnKeyAccessSample = true;
+            }
+        }
+
+        if (returnKeyAccessSample) {
+            // NOTE: It is important to return the key access data even if the caller
+            //       did not set the collectKeySample flag. SchemeShard may initiate
+            //       the split-by-load operation (and use the key access data)
+            //       even if it did not want to do the split-by-load when sending
+            //       the EvGetTableStats message
+            FillKeyAccessSample(
+                tableInfo.Stats.AccessStats,
+                *Result->Record.MutableTableStats()->MutableKeyAccessSample()
+            );
+        }
+
+        // Start collecting key samples or extend the duration of the active collection
+        if (Ev->Get()->Record.GetCollectKeySample()) {
+            Self->EnableKeyAccessSampling(ctx, currentTime + sampleMaxCollection);
+        }
 
         // Fill stats with current mem table size:
         auto memSize = txc.DB.GetTableMemSize(tableInfo.LocalTid);
@@ -270,38 +324,42 @@ public:
         tableInfo.Stats.RowCountResolution = Ev->Get()->Record.GetRowCountResolution();
         tableInfo.Stats.HistogramBucketsCount = Ev->Get()->Record.GetHistogramBucketsCount();
 
-        // Check if first stats update has been completed:
+        // Check if first stats update has been completed (happens only for leaders)
         bool ready = (tableInfo.Stats.StatsUpdateTime != TInstant());
         Result->Record.SetFullStatsReady(ready);
-        if (!ready) {
-            return true;
+
+        if (ready) {
+            const TStats& stats = tableInfo.Stats.DataStats;
+            Result->Record.MutableTableStats()->SetIndexSize(stats.IndexSize.Size);
+            Result->Record.MutableTableStats()->SetByKeyFilterSize(stats.ByKeyFilterSize);
+            Result->Record.MutableTableStats()->SetDataSize(stats.DataSize.Size + memSize);
+            Result->Record.MutableTableStats()->SetRowCount(stats.RowCount + memRowCount);
+            FillHistogram(stats.DataSizeHistogram, *Result->Record.MutableTableStats()->MutableDataSizeHistogram());
+            FillHistogram(stats.RowCountHistogram, *Result->Record.MutableTableStats()->MutableRowCountHistogram());
+
+            Result->Record.MutableTableStats()->SetPartCount(tableInfo.Stats.PartCount);
+            Result->Record.MutableTableStats()->SetSearchHeight(tableInfo.Stats.SearchHeight);
+            Result->Record.MutableTableStats()->SetHasSchemaChanges(tableInfo.Stats.HasSchemaChanges);
+            Result->Record.MutableTableStats()->SetLastFullCompactionTs(tableInfo.Stats.LastFullCompaction.Seconds());
+            Result->Record.MutableTableStats()->SetHasLoanedParts(Self->Executor()->HasLoanedParts());
+
+            Result->Record.SetShardState(Self->State);
+            for (const auto& pi : tableInfo.Stats.PartOwners) {
+                Result->Record.AddUserTablePartOwners(pi);
+            }
+
+            for (const auto& pi : Self->SysTablesPartOwners) {
+                Result->Record.AddSysTablesPartOwners(pi);
+            }
         }
 
-        const TStats& stats = tableInfo.Stats.DataStats;
-        Result->Record.MutableTableStats()->SetIndexSize(stats.IndexSize.Size);
-        Result->Record.MutableTableStats()->SetByKeyFilterSize(stats.ByKeyFilterSize);
-        Result->Record.MutableTableStats()->SetDataSize(stats.DataSize.Size + memSize);
-        Result->Record.MutableTableStats()->SetRowCount(stats.RowCount + memRowCount);
-        FillHistogram(stats.DataSizeHistogram, *Result->Record.MutableTableStats()->MutableDataSizeHistogram());
-        FillHistogram(stats.RowCountHistogram, *Result->Record.MutableTableStats()->MutableRowCountHistogram());
-        // Fill key access sample if it was collected not too long ago:
-        if (Self->StopKeyAccessSamplingAt + TDuration::Seconds(30) >= AppData(ctx)->TimeProvider->Now()) {
-            FillKeyAccessSample(tableInfo.Stats.AccessStats, *Result->Record.MutableTableStats()->MutableKeyAccessSample());
-        }
+        // Also return back the CPU usage data
+        auto* resourceMetrics = Self->Executor()->GetResourceMetrics();
 
-        Result->Record.MutableTableStats()->SetPartCount(tableInfo.Stats.PartCount);
-        Result->Record.MutableTableStats()->SetSearchHeight(tableInfo.Stats.SearchHeight);
-        Result->Record.MutableTableStats()->SetHasSchemaChanges(tableInfo.Stats.HasSchemaChanges);
-        Result->Record.MutableTableStats()->SetLastFullCompactionTs(tableInfo.Stats.LastFullCompaction.Seconds());
-        Result->Record.MutableTableStats()->SetHasLoanedParts(Self->Executor()->HasLoanedParts());
-
-        Result->Record.SetShardState(Self->State);
-        for (const auto& pi : tableInfo.Stats.PartOwners) {
-            Result->Record.AddUserTablePartOwners(pi);
-        }
-
-        for (const auto& pi : Self->SysTablesPartOwners) {
-            Result->Record.AddSysTablesPartOwners(pi);
+        if ((resourceMetrics != nullptr) && (resourceMetrics->CPU.IsValueReady())) {
+            Result->Record.MutableTabletMetrics()->SetCPU(
+                resourceMetrics->CPU.GetValue()
+            );
         }
 
         return true;
@@ -402,7 +460,7 @@ void TDataShard::Handle(TEvPrivate::TEvBuildTableStatsError::TPtr& ev, const TAc
     LOG_ERROR_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "Stats rebuilt error '" << msg->Message
         << "', code: " << ui32(msg->Code)
         << " at datashard " << TabletID() << ", for tableId " << msg->TableId);
-    
+
     if (msg->Exception) {
         std::rethrow_exception(msg->Exception);
     }

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -356,10 +356,8 @@ public:
         // Also return back the CPU usage data
         auto* resourceMetrics = Self->Executor()->GetResourceMetrics();
 
-        if ((resourceMetrics != nullptr) && (resourceMetrics->CPU.IsValueReady())) {
-            Result->Record.MutableTabletMetrics()->SetCPU(
-                resourceMetrics->CPU.GetValue()
-            );
+        if (resourceMetrics != nullptr) {
+            resourceMetrics->Fill(*(Result->Record.MutableTabletMetrics()));
         }
 
         return true;

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3310,6 +3310,7 @@ protected:
             HFuncTraced(TEvDataShard::TEvReadCancel, Handle);
             hFuncTraced(TEvDataShard::TEvReadScanStarted, Handle);
             hFuncTraced(TEvDataShard::TEvReadScanFinished, Handle);
+            HFunc(TEvDataShard::TEvGetTableStats, Handle);
             HFuncTraced(TEvPrivate::TEvPeriodicWakeup, DoPeriodicTasks);
             HFunc(TEvPrivate::TEvBuildTableStatsResult, Handle);
             HFunc(TEvPrivate::TEvBuildTableStatsError, Handle);

--- a/ydb/core/tx/datashard/datashard_ut_stats.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_stats.cpp
@@ -949,7 +949,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
 
         datashardConfig->SetKeyAccessSampleCollectionMinIntervalSeconds(collectionMinInterval);
         datashardConfig->SetKeyAccessSampleCollectionMaxIntervalSeconds(collectionMaxInterval);
-        datashardConfig->SetKeyAccessSampleVaidityIntervalSeconds(collectionValidInterval);
+        datashardConfig->SetKeyAccessSampleValidityIntervalSeconds(collectionValidInterval);
 
         TServer::TPtr server = new TServer(serverSettings);
         auto& runtime = *(server->GetRuntime());

--- a/ydb/core/tx/datashard/datashard_ut_stats.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_stats.cpp
@@ -280,12 +280,12 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
 
         auto opts = TShardedTableOptions()
             .Columns({
-                {"key", "Uint32", true, false}, 
-                {"value", "String", false, false}, 
+                {"key", "Uint32", true, false},
+                {"value", "String", false, false},
                 {"value2", "String", false, false, "hdd"}})
             .Families({
-                {.Name = "default", .LogPoolKind = "ssd", .SysLogPoolKind = "ssd", .DataPoolKind = "ssd", 
-                    .ExternalPoolKind = "ext", .DataThreshold = 100u, .ExternalThreshold = 200u}, 
+                {.Name = "default", .LogPoolKind = "ssd", .SysLogPoolKind = "ssd", .DataPoolKind = "ssd",
+                    .ExternalPoolKind = "ext", .DataThreshold = 100u, .ExternalThreshold = 200u},
                 {.Name = "hdd", .DataPoolKind = "hdd"}});
         CreateShardedTable(server, sender, "/Root", "table-1", opts);
         const auto shard1 = GetTableShards(server, sender, "/Root/table-1").at(0);
@@ -293,11 +293,11 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
 
         TString smallValue(150, 'S');
         TString largeValue(1500, 'L');
-        ExecSQL(server, sender, (TString)"UPSERT INTO `/Root/table-1` (key, value, value2) VALUES " + 
-            "(1, \"AAA\", \"AAA\"), " + 
-            "(2, \"" + smallValue + "\", \"BBB\"), " + 
-            "(3, \"CCC\", \"" + smallValue + "\"), " + 
-            "(4, \"" + largeValue + "\", \"BBB\"), " + 
+        ExecSQL(server, sender, (TString)"UPSERT INTO `/Root/table-1` (key, value, value2) VALUES " +
+            "(1, \"AAA\", \"AAA\"), " +
+            "(2, \"" + smallValue + "\", \"BBB\"), " +
+            "(3, \"CCC\", \"" + smallValue + "\"), " +
+            "(4, \"" + largeValue + "\", \"BBB\"), " +
             "(5, \"CCC\", \"" + largeValue + "\")");
 
         {
@@ -353,7 +353,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
 
         auto opts = TShardedTableOptions()
             .Columns({
-                {"key", "Uint32", true, false}, 
+                {"key", "Uint32", true, false},
                 {"value", "String", true, false}});
         CreateShardedTable(server, sender, "/Root", "table-1", opts);
         const auto shard1 = GetTableShards(server, sender, "/Root/table-1").at(0);
@@ -417,7 +417,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
 
         auto opts = TShardedTableOptions()
             .Columns({
-                {"key", "Uint32", true, false}, 
+                {"key", "Uint32", true, false},
                 {"value", "Uint32", true, false}})
             .Policy(policy.Get());
 
@@ -514,7 +514,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         TServer::TPtr server = new TServer(serverSettings);
         auto& runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
-        
+
         //runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         // runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
@@ -533,11 +533,11 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetDatashardId(), shard1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowUpdates(), 2);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowCount(), 2);
-        }        
-        
+        }
+
         {
             auto selectResult = KqpSimpleStaleRoExec(runtime, "SELECT * FROM `/Root/table-1`", "/Root");
-            TString expectedSelectResult = 
+            TString expectedSelectResult =
                 "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
                 "{ items { uint32_value: 2 } items { uint32_value: 2 } }";
             UNIT_ASSERT_VALUES_EQUAL(selectResult, expectedSelectResult);
@@ -562,7 +562,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         TServer::TPtr server = new TServer(serverSettings);
         auto& runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
-        
+
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
@@ -570,7 +570,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
 
         const ui64 lockTxId = 1011121314;
         i64 txId = 100;
-        TShardedTableOptions opts;        
+        TShardedTableOptions opts;
         auto [shards, tableId1] = CreateShardedTable(server, sender, "/Root", "table-1", opts);
         ui64 shard1 = shards.at(0);
 
@@ -589,7 +589,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetDatashardId(), shard1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowUpdates(), 1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowCount(), 1);
-        }          
+        }
 
         {
             Cerr << "... Read and set lock" << Endl;
@@ -610,7 +610,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowReads(), 1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetLocksAcquired(), 1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetLocksBroken(), 0);
-        }        
+        }
 
         {
             Cerr << "... UPSERT and break lock" << Endl;
@@ -627,7 +627,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
 
             UNIT_ASSERT_VALUES_EQUAL(readResult2->Record.TxLocksSize(), 0);
             UNIT_ASSERT_VALUES_EQUAL(readResult2->Record.BrokenTxLocksSize(), 1);
-        }     
+        }
 
         {
             Cerr << "... waiting for SELECT stats with broken locks" << Endl;
@@ -637,7 +637,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetLocksAcquired(), 1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetLocksBroken(), 1);
         }
-    }    
+    }
 
     Y_UNIT_TEST(HasSchemaChanges_BTreeIndex) {
         TPortManager pm;
@@ -874,6 +874,572 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         // Once every 30 seconds
         UNIT_ASSERT_GE(tableToStatsCount[tableId2.PathId.LocalPathId], 1);
         UNIT_ASSERT_LE(tableToStatsCount[tableId2.PathId.LocalPathId], 2);
+    }
+
+    /**
+     * Send the EvGetTableStats message to the given tablet
+     * and wait for the EvGetTableStatsResult message to come back.
+     *
+     * @param[in] runtime The test runtime
+     * @param[in] senderActorId The ID of the actor to use for sending messages
+     * @param[in] tabletId The ID of the tablet to send the message to
+     * @param[in] tableId The ID of the table to send the message to
+     * @param[in] collectKeySample If true, request the key sample to be collected
+     * @param[in] toFollower If true, send the message to the follower (the leader otherwise)
+     *
+     * @return The corresponding EvGetTableStatsResult response message
+     */
+    NKikimrTxDataShard::TEvGetTableStatsResult SendEvTableStats(
+        TTestActorRuntime& runtime,
+        TActorId senderActorId,
+        ui64 tabletId,
+        ui64 tableId,
+        bool collectKeySample,
+        bool toFollower
+    ) {
+        Cerr << "TEST Sending the EvGetTableStats message to the tablet " << tabletId
+            << ", tableId=" << tableId
+            << ", collectKeySample=" << collectKeySample
+            << ", toFollower=" << toFollower
+            << Endl;
+
+        auto request = MakeHolder<TEvDataShard::TEvGetTableStats>(tableId);
+        request->Record.SetCollectKeySample(collectKeySample);
+
+        auto pipeConfig = GetPipeConfigWithRetries();
+        pipeConfig.ForceFollower = toFollower;
+
+        runtime.SendToPipe(tabletId, senderActorId, request.Release(), 0, pipeConfig);
+        auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvGetTableStatsResult>(senderActorId);
+
+        Cerr << "TEST Received the TEvGetTableStatsResult response from the tablet " << tabletId
+            << ", tableId=" << tableId
+            << ", collectKeySample=" << collectKeySample
+            << ", toFollower=" << toFollower
+            << Endl
+            << ev->Get()->Record.DebugString()
+            << Endl;
+
+        return ev->Get()->Record;
+    }
+
+    /**
+     * Execute a number of tests, which verify the key sample collection logic
+     * in DataShard by sending various EvGetTableStats messages to the tablet
+     * leader/follower and verifying the responses in EvGetTableStatsResult.
+     *
+     * @param[in] testFollower If true, use the follower for testing (the leader otherwise)
+     */
+    void VerifyKeySampleCollection(bool testFollower) {
+        const ui64 followerId = (testFollower) ? 1 : 0;
+
+        // Create a table with a single follower
+        Cerr << "TEST Creating a sample table" << Endl;
+
+        auto serverSettings = TServerSettings(TPortManager().GetPort(2134))
+            .SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableForceFollowers(true);
+
+        auto datashardConfig = serverSettings.AppConfig->MutableDataShardConfig();
+
+        const ui32 collectionMinInterval = 5;
+        const ui32 collectionMaxInterval = 30;
+        const ui32 collectionValidInterval = 15;
+
+        datashardConfig->SetKeyAccessSampleCollectionMinIntervalSeconds(collectionMinInterval);
+        datashardConfig->SetKeyAccessSampleCollectionMaxIntervalSeconds(collectionMaxInterval);
+        datashardConfig->SetKeyAccessSampleVaidityIntervalSeconds(collectionValidInterval);
+
+        TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *(server->GetRuntime());
+        auto senderActorId = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, senderActorId);
+
+        auto [shards, tableId] = CreateShardedTable(
+            server,
+            senderActorId,
+            "/Root",
+            "table-1",
+            TShardedTableOptions()
+                .Followers(1)
+        );
+
+        const auto shardId = shards.at(0);
+
+        // Populate it with some fake data
+        Cerr << "TEST Populating the table with test data" << Endl;
+        UpsertRows(server, senderActorId, 1, 100);
+
+        // Before the key sample collection is active, send some reads
+        // for some keys - they should be ignored in subsequent key samples
+        {
+            auto result = KqpSimpleExec(
+                runtime,
+                (
+                    "SELECT key FROM `/Root/table-1` "
+                    "WHERE (key = 2) OR (key = 4) OR (key = 6) "
+                    "ORDER BY key ASC"
+                ),
+                testFollower /* staleRo */,
+                "/Root"
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                result,
+                (
+                    "{ items { uint32_value: 2 } }, "
+                    "{ items { uint32_value: 4 } }, "
+                    "{ items { uint32_value: 6 } }"
+                )
+            );
+        }
+
+        // Wait for some time to make sure the average CPU values become ready
+        runtime.SimulateSleep(TDuration::Seconds(20));
+
+        // TEST 1: Send EvGetTableStats before the key sample collection is active
+        //         without requesting a key sample.
+        //
+        // EXPECTED RESULT: No key sample in the EvGetTableStatsResult response
+        //                  because the collection is not active yet
+        {
+            const TString msg = (
+                "TEST 1: EvGetTableStats(collectKeySample=false) "
+                "before starting the key sample collection"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                false /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+            UNIT_ASSERT_C(result.GetTableStats().GetKeyAccessSample().GetBuckets().empty(), msg);
+        }
+
+        // TEST 2: Send EvGetTableStats with the collectKeySample flag set to activate
+        //         the collection of the key access statistics.
+        //
+        // EXPECTED RESULT: No key sample in the EvGetTableStatsResult response
+        //                  because the collection has not been running long enough
+        const auto collectionStartTime = runtime.GetCurrentTime();
+
+        {
+            const TString msg = (
+                "TEST 2: EvGetTableStats(collectKeySample=true) "
+                "to activate the key collection"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                true /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+            UNIT_ASSERT_C(result.GetTableStats().GetKeyAccessSample().GetBuckets().empty(), msg);
+        }
+
+        // Send some additional reads for new keys - they should be captured
+        // in the key access sample, but only after the minimal collection times has passed
+        {
+            auto result = KqpSimpleExec(
+                runtime,
+                (
+                    "SELECT key FROM `/Root/table-1` "
+                    "WHERE (key = 12) OR (key = 14) OR (key = 16) "
+                    "ORDER BY key ASC"
+                ),
+                testFollower /* staleRo */,
+                "/Root"
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                result,
+                (
+                    "{ items { uint32_value: 12 } }, "
+                    "{ items { uint32_value: 14 } }, "
+                    "{ items { uint32_value: 16 } }"
+                )
+            );
+        }
+
+        // TEST 3: Send EvGetTableStats before the minimal collection time has passed.
+        //
+        // EXPECTED RESULT: No key sample in the EvGetTableStatsResult response
+        //                  because the collection has not been running long enough
+        {
+            const TString msg = (
+                "TEST 3: EvGetTableStats(collectKeySample=false) "
+                "before the min collection time"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                false /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+            UNIT_ASSERT_C(result.GetTableStats().GetKeyAccessSample().GetBuckets().empty(), msg);
+        }
+
+        // Wait for the collection statistics to be accumulated
+        //
+        // NOTE: This is exactly min interval + 1 seconds from the moment
+        //       the key collection was started to ignore the time
+        //       spent on executing the above SELECT queries
+        runtime.SimulateSleep(
+            TDuration::Seconds(collectionMinInterval + 1)
+                - (runtime.GetCurrentTime() - collectionStartTime)
+        );
+
+        // TEST 4: Send EvGetTableStats after the minimal collection time has passed.
+        //
+        // EXPECTED RESULT: The key sample in the EvGetTableStatsResult response
+        //                  should be populated because the collection has been running
+        //                  for longer than the minimal collection time
+        {
+            const TString msg = (
+                "TEST 4: EvGetTableStats(collectKeySample=false) "
+                "after the min collection time"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                false /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+
+            const auto keyAccessSample = ReadHistogram(result.GetTableStats().GetKeyAccessSample());
+            const TVector<std::pair<ui64, ui64>> expectedKeyAccessSample = {
+                {12, 1},
+                {14, 1},
+                {16, 1},
+            };
+
+            UNIT_ASSERT_VALUES_EQUAL_C(keyAccessSample, expectedKeyAccessSample, msg);
+        }
+
+        // TEST 5: Send EvGetTableStats with the collectKeySample flag set to extend
+        //         the collection of the key access statistics.
+        //
+        // EXPECTED RESULT: The key sample in the EvGetTableStatsResult response
+        //                  should be populated because the collection has been running
+        //                  for longer than the minimal collection time
+        const auto collectionExtendTime = runtime.GetCurrentTime();
+
+        {
+            const TString msg = (
+                "TEST 5: EvGetTableStats(collectKeySample=true) "
+                "to extend the duration of the key collection"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                true /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+
+            const auto keyAccessSample = ReadHistogram(result.GetTableStats().GetKeyAccessSample());
+            const TVector<std::pair<ui64, ui64>> expectedKeyAccessSample = {
+                {12, 1},
+                {14, 1},
+                {16, 1},
+            };
+
+            UNIT_ASSERT_VALUES_EQUAL_C(keyAccessSample, expectedKeyAccessSample, msg);
+        }
+
+        // TEST 6: Send EvGetTableStats after extending the duration of the key collection
+        //
+        // EXPECTED RESULT: The key sample in the EvGetTableStatsResult response
+        //                  should be populated because the collection has been running
+        //                  for longer than the minimal collection time
+        {
+            const TString msg = (
+                "TEST 6: EvGetTableStats(collectKeySample=false) "
+                "after extending the duration of the key collection"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                false /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+
+            const auto keyAccessSample = ReadHistogram(result.GetTableStats().GetKeyAccessSample());
+            const TVector<std::pair<ui64, ui64>> expectedKeyAccessSample = {
+                {12, 1},
+                {14, 1},
+                {16, 1},
+            };
+
+            UNIT_ASSERT_VALUES_EQUAL_C(keyAccessSample, expectedKeyAccessSample, msg);
+        }
+
+        // Wait for the initial key collection period to expire but before
+        // the extended period completes
+        //
+        // NOTE: This is exactly max interval + 6 seconds from the moment
+        //       the key collection was started to ignore the time
+        //       spent on executing the above SELECT queries.
+        //       6 seconds are needed because the collection expiration is handled
+        //       by the periodic task working in DataShard, which runs every 5 seconds
+        runtime.SimulateSleep(
+            TDuration::Seconds(collectionMaxInterval + 6)
+                - (runtime.GetCurrentTime() - collectionStartTime)
+        );
+
+        // Send some additional reads for new keys - they should be captured
+        // in the key access sample, but only if the key collection was extended
+        {
+            auto result = KqpSimpleExec(
+                runtime,
+                (
+                    "SELECT key FROM `/Root/table-1` "
+                    "WHERE (key = 22) OR (key = 24) OR (key = 26) "
+                    "ORDER BY key ASC"
+                ),
+                testFollower /* staleRo */,
+                "/Root"
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                result,
+                (
+                    "{ items { uint32_value: 22 } }, "
+                    "{ items { uint32_value: 24 } }, "
+                    "{ items { uint32_value: 26 } }"
+                )
+            );
+        }
+
+        // TEST 7: Send EvGetTableStats after the initial collection expires
+        //
+        // EXPECTED RESULT: The key sample in the EvGetTableStatsResult response
+        //                  should be populated because the collection has been extended
+        {
+            const TString msg = (
+                "TEST 7: EvGetTableStats(collectKeySample=false) "
+                "after the initial collection period expires"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                false /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+
+            const auto keyAccessSample = ReadHistogram(result.GetTableStats().GetKeyAccessSample());
+            const TVector<std::pair<ui64, ui64>> expectedKeyAccessSample = {
+                {12, 1},
+                {14, 1},
+                {16, 1},
+                {22, 1},
+                {24, 1},
+                {26, 1},
+            };
+
+            UNIT_ASSERT_VALUES_EQUAL_C(keyAccessSample, expectedKeyAccessSample, msg);
+        }
+
+        // Wait for the extended key collection period to expire
+        //
+        // NOTE: This is exactly max interval + 6 seconds from the moment
+        //       the key collection was extended to ignore the time
+        //       spent on executing the above SELECT queries.
+        //       6 seconds are needed because the collection expiration is handled
+        //       by the periodic task working in DataShard, which runs every 5 seconds
+        runtime.SimulateSleep(
+            TDuration::Seconds(collectionMaxInterval + 6)
+                - (runtime.GetCurrentTime() - collectionExtendTime)
+        );
+
+        // Send some additional reads for new keys - they should not be captured
+        // in the key access sample because the collection has already been stopped
+        {
+            auto result = KqpSimpleExec(
+                runtime,
+                (
+                    "SELECT key FROM `/Root/table-1` "
+                    "WHERE (key = 32) OR (key = 34) OR (key = 36) "
+                    "ORDER BY key ASC"
+                ),
+                testFollower /* staleRo */,
+                "/Root"
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                result,
+                (
+                    "{ items { uint32_value: 32 } }, "
+                    "{ items { uint32_value: 34 } }, "
+                    "{ items { uint32_value: 36 } }"
+                )
+            );
+        }
+
+        // TEST 8: Send EvGetTableStats after the extended collection expires
+        //
+        // EXPECTED RESULT: The key sample in the EvGetTableStatsResult response
+        //                  should be populated because the collected key sample
+        //                  is still valid
+        {
+            const TString msg = (
+                "TEST 8: EvGetTableStats(collectKeySample=false) "
+                "after the extended collection period expires"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                false /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+
+            const auto keyAccessSample = ReadHistogram(result.GetTableStats().GetKeyAccessSample());
+            const TVector<std::pair<ui64, ui64>> expectedKeyAccessSample = {
+                {12, 1},
+                {14, 1},
+                {16, 1},
+                {22, 1},
+                {24, 1},
+                {26, 1},
+            };
+
+            UNIT_ASSERT_VALUES_EQUAL_C(keyAccessSample, expectedKeyAccessSample, msg);
+        }
+
+        // Wait for the collected key sample to become invalid
+        runtime.SimulateSleep(TDuration::Seconds(collectionValidInterval + 1));
+
+        // Send some additional reads for new keys - they should not be captured
+        // in the key access sample because the collection has already been stopped
+        {
+            auto result = KqpSimpleExec(
+                runtime,
+                (
+                    "SELECT key FROM `/Root/table-1` "
+                    "WHERE (key = 42) OR (key = 44) OR (key = 46) "
+                    "ORDER BY key ASC"
+                ),
+                testFollower /* staleRo */,
+                "/Root"
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                result,
+                (
+                    "{ items { uint32_value: 42 } }, "
+                    "{ items { uint32_value: 44 } }, "
+                    "{ items { uint32_value: 46 } }"
+                )
+            );
+        }
+
+        // TEST 9: Send EvGetTableStats after the collected key sample becomes invalid
+        //
+        // EXPECTED RESULT: No key sample in the EvGetTableStatsResult response
+        //                  because the collection is not active and the collected
+        //                  key sample has already expired
+        {
+            const TString msg = (
+                "TEST 9: EvGetTableStats(collectKeySample=false) "
+                "after the collected key sample becomes invalid"
+            );
+
+            Cerr << msg << Endl;
+
+            auto result = SendEvTableStats(
+                runtime,
+                senderActorId,
+                shardId,
+                tableId.PathId.LocalPathId,
+                false /* collectKeySample */,
+                testFollower
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetFollowerId(), followerId, msg);
+            UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetTabletMetrics().GetCPU(), 0, msg);
+            UNIT_ASSERT_C(result.GetTableStats().GetKeyAccessSample().GetBuckets().empty(), msg);
+        }
+    }
+
+    /**
+     * Verify that the key sample collection works correctly for the leader.
+     */
+    Y_UNIT_TEST(CollectKeySampleLeader) {
+        VerifyKeySampleCollection(false /* testFollower */);
+    }
+
+    /**
+     * Verify that the key sample collection works correctly for the follower.
+     */
+    Y_UNIT_TEST(CollectKeySampleFollower) {
+        VerifyKeySampleCollection(true /* testFollower */);
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -102,8 +102,36 @@ public:
     bool PersistSingleStats(const TPathId& pathId, const TStatsQueue<TEvDataShard::TEvPeriodicTableStats>::TItem& item, TInstant now, TTransactionContext& txc, const TActorContext& ctx) override;
     void ScheduleNextBatch(const TActorContext& ctx) override;
 
+private:
     template <typename T>
     TPartitionStats PrepareStats(const T& rec, TInstant now, const NKikimr::TStoragePools& pools, const NKikimr::TChannelsBindings& bindings) const;
+
+    /**
+     * Verify that splitting the given partition is allowed (either by size or by load)
+     * and send the EvGetTableStats message to the given tablet to prepare
+     * the split operation.
+     *
+     * @param[in] ctx The actor execution context
+     * @param[in] statsEventSender The ID of the actor which sent EvPeriodicTableStats
+     * @param[in] datashardId The corresponding datashard ID
+     * @param[in] shardIdx The corresponding shard index
+     * @param[in] pathId The corresponding path ID
+     * @param[in] pathElement The corresponding path element
+     * @param[in] subDomainInfo The information about the corresponding subdomain
+     * @param[in] newPartitionStats The new partition statistics (from the event)
+     * @param[in] collectKeySample If true, request the key access sample to be collected
+     */
+    bool VerifySplitAndRequestStats(
+        const TActorContext& ctx,
+        const TActorId& statsEventSender,
+        TTabletId datashardId,
+        const TShardIdx& shardIdx,
+        const TPathId& pathId,
+        TPathElement::TPtr pathElement,
+        TSubDomainInfo::TPtr subDomainInfo,
+        const TPartitionStats& newPartitionStats,
+        bool collectKeySample
+    );
 };
 
 
@@ -303,6 +331,74 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
 
     // Skip statistics from follower
     if (followerId) {
+        if (!isDataShard) {
+            return true;
+        }
+
+        table = Self->Tables[pathId];
+        table->UpdateShardStatsForFollower(followerId, shardIdx, newStats);
+
+        // NOTE: For split-by-size and merge-by-load cases it is sufficient
+        //       to use EvPeriodicTableStats messages only from the leader
+        //       as the trigger point. Using EvPeriodicTableStats messages from
+        //       followers to start these operations would only introduce
+        //       unnecessary load because the operations started from the follower
+        //       messages and the leader message would compete with each other,
+        //       but only one of them would win. These messages from leaders
+        //       come frequently enough to trigger these operations within
+        //       a reasonable time frame. More importantly, merge-by-load considers
+        //       only the aggregated CPU usage across all followers (and the leader).
+        //       This operation does not consider the CPU load on each individual
+        //       follower (and the leader). And split-by-size does not even consider
+        //       the CPU usage level when deciding to split a partition.
+        //
+        //       Only the split-by-load operation must be considered (and started)
+        //       when the EvPeriodicTableStats message arrives from a follower
+        //       because this operation should consider the CPU load on each specific
+        //       follower (and the leader).
+        const TTableIndexInfo* index = Self->Indexes.Value(pathElement->ParentPathId, nullptr).Get();
+        const TTableInfo* mainTableForIndex = (index ? Self->GetMainTableForIndex(pathId) : nullptr);
+
+        TString splitReason;
+
+        if (!(table->CheckSplitByLoad(
+            Self->SplitSettings,
+            shardIdx,
+            newStats.GetCurrentRawCpuUsage(),
+            mainTableForIndex,
+            splitReason
+        ))) {
+            LOG_DEBUG_S(
+                ctx,
+                NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "Do not want to split tablet " << datashardId
+                    << " by the CPU load from the follower ID " << followerId
+                    << ", reason: " << splitReason
+            );
+
+            return true;
+        }
+
+        LOG_NOTICE_S(
+            ctx,
+            NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "Want to split tablet " << datashardId
+                << " by the CPU load from the follower ID " << followerId
+                << ", reason: " << splitReason
+        );
+
+        VerifySplitAndRequestStats(
+            ctx,
+            item.Ev->Sender,
+            datashardId,
+            shardIdx,
+            pathId,
+            pathElement,
+            subDomainInfo,
+            newStats,
+            true /* collectKeySample */
+        );
+
         return true;
     }
 
@@ -465,10 +561,16 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
     } else if (table->GetPartitions().size() >= table->GetMaxPartitionsCount()) {
         // We cannot split as there are max partitions already
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-            "Do not want to split tablet " << datashardId << " by size,"
+            "Do not want to split tablet " << datashardId << " by load,"
             << " its table already has "<< table->GetPartitions().size() << " out of " << table->GetMaxPartitionsCount() << " partitions");
         return true;
-    } else if (table->CheckSplitByLoad(Self->SplitSettings, shardIdx, dataSize, rowCount, mainTableForIndex, reason)) {
+    } else if (table->CheckSplitByLoad(
+        Self->SplitSettings,
+        shardIdx,
+        newStats.GetCurrentRawCpuUsage(),
+        mainTableForIndex,
+        reason
+    )) {
         LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "Want to split tablet " << datashardId << " by load: " << reason);
         collectKeySample = true;
@@ -478,56 +580,108 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
         return true;
     }
 
-    //NOTE: intentionally avoid using TPath.Check().{PathShardsLimit,ShardsLimit}() here.
+    // This partition needs to be split (by size or by load),
+    // perform the final verification steps and send the EvGetTableStats request
+    VerifySplitAndRequestStats(
+        ctx,
+        item.Ev->Sender,
+        datashardId,
+        shardIdx,
+        pathId,
+        pathElement,
+        subDomainInfo,
+        newStats,
+        collectKeySample
+    );
+
+    return true;
+}
+
+bool TTxStoreTableStats::VerifySplitAndRequestStats(
+    const TActorContext& ctx,
+    const TActorId& statsEventSender,
+    TTabletId datashardId,
+    const TShardIdx& shardIdx,
+    const TPathId& pathId,
+    TPathElement::TPtr pathElement,
+    TSubDomainInfo::TPtr subDomainInfo,
+    const TPartitionStats& newPartitionStats,
+    bool collectKeySample
+) {
+    // NOTE: intentionally avoid using TPath.Check().{PathShardsLimit,ShardsLimit}() here.
     // PathShardsLimit() performs pedantic validation by recalculating shard count through
     // iteration over entire ShardInfos, which is too slow for this hot spot. It also performs
     // additional lookups we want to avoid.
     {
         constexpr ui64 deltaShards = 2;
         if ((pathElement->GetShardsInside() + deltaShards) > subDomainInfo->GetSchemeLimits().MaxShardsInPath) {
-            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Do not request full stats from datashard " << datashardId
-                << ", reason: shards count limit exceeded (in path)"
-                << ", limit: " << subDomainInfo->GetSchemeLimits().MaxShardsInPath
-                << ", current: " << pathElement->GetShardsInside()
-                << ", delta: " << deltaShards
+            LOG_NOTICE_S(
+                ctx,
+                NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "Do not request full stats from datashard " << datashardId
+                    << ", reason: shards count limit exceeded (in path)"
+                    << ", limit: " << subDomainInfo->GetSchemeLimits().MaxShardsInPath
+                    << ", current: " << pathElement->GetShardsInside()
+                    << ", delta: " << deltaShards
             );
-            return true;
+
+            return false;
         }
+
         const auto currentShards = (subDomainInfo->GetShardsInside() - subDomainInfo->GetBackupShards());
         if ((currentShards + deltaShards) > subDomainInfo->GetSchemeLimits().MaxShards) {
-            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Do not request full stats from datashard " << datashardId
-                << ", datashard: " << datashardId
-                << ", reason: shards count limit exceeded (in subdomain)"
-                << ", limit: " << subDomainInfo->GetSchemeLimits().MaxShards
-                << ", current: " << currentShards
-                << ", delta: " << deltaShards
+            LOG_NOTICE_S(
+                ctx,
+                NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "Do not request full stats from datashard " << datashardId
+                    << ", datashard: " << datashardId
+                    << ", reason: shards count limit exceeded (in subdomain)"
+                    << ", limit: " << subDomainInfo->GetSchemeLimits().MaxShards
+                    << ", current: " << currentShards
+                    << ", delta: " << deltaShards
             );
-            return true;
+
+            return false;
         }
     }
 
-    if (newStats.HasBorrowedData) {
-        LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-            "Postpone split tablet " << datashardId << " because it has borrow parts, enqueue compact them first");
+    if (newPartitionStats.HasBorrowedData) {
+        LOG_NOTICE_S(
+            ctx,
+            NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "Postpone split tablet " << datashardId
+                << " because it has borrow parts, enqueue compact them first"
+        );
+
         Self->EnqueueBorrowedCompaction(shardIdx);
-        return true;
+        return false;
     }
 
     // path.IsLocked() and path.LockedBy() equivalent
     if (const auto& found = Self->LockedPaths.find(pathId); found != Self->LockedPaths.end()) {
         const auto txId = found->second;
-        LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-            "Postpone split tablet " << datashardId << " because it is locked by " << txId);
-        return true;
+        LOG_NOTICE_S(
+            ctx,
+            NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "Postpone split tablet " << datashardId
+                << " because it is locked by " << txId
+        );
+
+        return false;
     }
 
     // Request histograms from the datashard
-    LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-        "Requesting full tablet stats " << datashardId << " to split it");
+    LOG_NOTICE_S(
+        ctx,
+        NKikimrServices::FLAT_TX_SCHEMESHARD,
+        "Requesting full tablet stats " << datashardId
+            << " to split it"
+    );
+
     auto request = new TEvDataShard::TEvGetTableStats(pathId.LocalPathId);
     request->Record.SetCollectKeySample(collectKeySample);
-    PendingMessages.emplace_back(item.Ev->Sender, request);
 
+    PendingMessages.emplace_back(statsEventSender, request);
     return true;
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
@@ -305,7 +305,7 @@ void TSchemeShard::Handle(TEvDataShard::TEvGetTableStatsResult::TPtr& ev, const 
 }
 
 THolder<TProposeRequest> SplitRequest(
-    TSchemeShard* ss, TTxId& txId, TPathId& pathId, TTabletId datashardId, const TString& keyBuff)
+    TSchemeShard* ss, TTxId& txId, const TPathId& pathId, TTabletId datashardId, const TString& keyBuff)
 {
     auto request = MakeHolder<TProposeRequest>(ui64(txId), ui64(ss->SelfTabletId()));
     auto& record = request->Record;
@@ -332,51 +332,66 @@ THolder<TProposeRequest> SplitRequest(
 bool TTxPartitionHistogram::Execute(TTransactionContext& txc, const TActorContext& ctx) {
     const auto& rec = Ev->Get()->Record;
 
-    if (!rec.GetFullStatsReady()) {
+    // NOTE: To make a decision how to split the partition (if needed),
+    //       the EvGetTableStatsResult message should contain either
+    //       the full table statistics (from the leader only, needed for
+    //       the split-by-size) or the key access sample (either from the leader
+    //       or any of the followers, needed for the split-by-load)
+    bool trySplitBySize = (
+        (rec.GetFollowerId() == 0) &&
+        (rec.GetFullStatsReady()) &&
+        (!(rec.GetTableStats().GetDataSizeHistogram().GetBuckets().empty()))
+    );
+
+    bool trySplitByLoad = !(rec.GetTableStats().GetKeyAccessSample().GetBuckets().empty());
+
+    if ((!trySplitBySize) && (!trySplitByLoad)) {
         return true;
     }
 
-    auto datashardId = TTabletId(rec.GetDatashardId());
-    TPathId tableId = InvalidPathId;
-    if (rec.HasTableOwnerId()) {
-        tableId = TPathId(TOwnerId(rec.GetTableOwnerId()), TLocalPathId(rec.GetTableLocalId()));
-    } else {
-        tableId = Self->MakeLocalId(TLocalPathId(rec.GetTableLocalId()));
-    }
-    ui64 dataSize = rec.GetTableStats().GetDataSize();
-    ui64 rowCount = rec.GetTableStats().GetRowCount();
+    const TTabletId datashardId = TTabletId(rec.GetDatashardId());
+    const TPathId tableId = (rec.HasTableOwnerId())
+        ? TPathId(TOwnerId(rec.GetTableOwnerId()), TLocalPathId(rec.GetTableLocalId()))
+        : Self->MakeLocalId(TLocalPathId(rec.GetTableLocalId()));
 
     LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-        "TTxPartitionHistogram Execute partition histogram"
+        "TTxPartitionHistogram Execute processing detailed partition statistics"
             << " at tablet " << Self->SelfTabletId()
             << " from datashard " << datashardId
+            << " from follower ID " << rec.GetFollowerId()
             << " for pathId " << tableId
-            << " state " << DatashardStateName(rec.GetShardState())
-            << " data size " << dataSize
-            << " row count " << rowCount
-            << " buckets " << rec.GetTableStats().GetDataSizeHistogram().BucketsSize());
+            << ", state " << DatashardStateName(rec.GetShardState())
+            << ", data size buckets " << rec.GetTableStats().GetDataSizeHistogram().GetBuckets().size()
+            << ", key access buckets " << rec.GetTableStats().GetKeyAccessSample().GetBuckets().size()
+    );
 
-    if (!Self->Tables.contains(tableId)) {
+    const auto tableInfoIt = Self->Tables.find(tableId);
+
+    if (tableInfoIt == Self->Tables.end()) {
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "TTxPartitionHistogram Unknown table " << tableId << " tablet " << datashardId);
         return true;
     }
 
-    TTableInfo::TPtr table = Self->Tables[tableId];
-    auto path = TPath::Init(tableId, Self);
+    const TTableInfo::TPtr tableInfo = tableInfoIt->second;
+    const auto shardIt = Self->TabletIdToShardIdx.find(datashardId);
 
-    if (!Self->TabletIdToShardIdx.contains(datashardId)) {
+    if (shardIt == Self->TabletIdToShardIdx.end()) {
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "TTxPartitionHistogram Unknown tablet " << datashardId);
         return true;
     }
 
+    const auto& shardIdx = shardIt->second;
+
     // Don't split/merge backup tables
-    if (table->IsBackup) {
+    if (tableInfo->IsBackup) {
         LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "TTxPartitionHistogram Skip backup table tablet " << datashardId);
         return true;
     }
+
+    const auto path = TPath::Init(tableId, Self);
 
     if (path.IsLocked()) {
         LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
@@ -384,21 +399,66 @@ bool TTxPartitionHistogram::Execute(TTransactionContext& txc, const TActorContex
         return true;
     }
 
-    auto shardIdx = Self->TabletIdToShardIdx[datashardId];
-    const auto forceShardSplitSettings = Self->SplitSettings.GetForceShardSplitSettings();
-
-    const TTableInfo* mainTableForIndex = Self->GetMainTableForIndex(tableId);
-
+    // The first priority is split-by-size
     ESplitReason splitReason = ESplitReason::NO_SPLIT;
     TString splitReasonMsg;
-    if (table->ShouldSplitBySize(dataSize, forceShardSplitSettings, splitReasonMsg)) {
-        splitReason = ESplitReason::SPLIT_BY_SIZE;
+
+    if (trySplitBySize) {
+        if (tableInfo->ShouldSplitBySize(
+            rec.GetTableStats().GetDataSize(),
+            Self->SplitSettings.GetForceShardSplitSettings(),
+            splitReasonMsg
+        )) {
+            splitReason = ESplitReason::SPLIT_BY_SIZE;
+        }
     }
 
-    if (splitReason == ESplitReason::NO_SPLIT && table->CheckSplitByLoad(Self->SplitSettings, shardIdx, dataSize, rowCount, mainTableForIndex, splitReasonMsg)) {
-        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-            "Want to split tablet " << datashardId << ": " << splitReasonMsg);
-        splitReason = ESplitReason::SPLIT_BY_LOAD;
+    // The second priority is split-by-load
+    if ((splitReason == ESplitReason::NO_SPLIT) && trySplitByLoad) {
+        // NOTE: When considering split-by-load, prefer using the current CPU usage
+        //       from the EvGetTableStatsResult message. It is the most recent
+        //       and the most accurate. However, it may not be present in some cases.
+        //       If this happens, use the cached CPU usage, which is reported
+        //       by the leader though the EvPeriodicTableStats messages.
+        ui64 currentCpuUsage = rec.GetTabletMetrics().GetCPU();
+
+        if (!(rec.GetTabletMetrics().HasCPU())) {
+            const auto* stats = tableInfo->GetStats().PartitionStats.FindPtr(shardIdx);
+
+            if (!stats) {
+                LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                    "TTxPartitionHistogram Unknown shard index " << shardIdx
+                        << " at tablet " << Self->SelfTabletId()
+                        << " from datashard " << datashardId
+                        << " for pathId " << tableId
+                );
+
+                return true;
+            }
+
+            currentCpuUsage = stats->GetCurrentRawCpuUsage();
+        }
+
+        if (tableInfo->CheckSplitByLoad(
+            Self->SplitSettings,
+            shardIdx,
+            currentCpuUsage,
+            Self->GetMainTableForIndex(tableId),
+            splitReasonMsg
+        )) {
+            splitReason = ESplitReason::SPLIT_BY_LOAD;
+
+            if (tableInfo->GetPartitions().size() >= tableInfo->GetMaxPartitionsCount()) {
+                LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                    "TTxPartitionHistogram Do not want to split tablet " << datashardId
+                        << " by load, its table already has " << tableInfo->GetPartitions().size()
+                        << " out of " << tableInfo->GetMaxPartitionsCount()
+                        << " partitions"
+                );
+
+                return true;
+            }
+        }
     }
 
     if (splitReason == ESplitReason::NO_SPLIT) {
@@ -408,35 +468,36 @@ bool TTxPartitionHistogram::Execute(TTransactionContext& txc, const TActorContex
         return true;
     }
 
-    if (splitReason != ESplitReason::SPLIT_BY_SIZE && table->GetPartitions().size() >= table->GetMaxPartitionsCount()) {
-        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-            "TTxPartitionHistogram Do not want to split tablet " << datashardId << " by size,"
-            << " its table already has "<< table->GetPartitions().size() << " out of " << table->GetMaxPartitionsCount() << " partitions");
-        return true;
-    }
-
     LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-        "TTxPartitionHistogram Want to"
-        << " " << ToString(splitReason) << ": " << splitReasonMsg
-        << " tablet " << datashardId);
+        "TTxPartitionHistogram Want to " << ToString(splitReason)
+            << ": " << splitReasonMsg
+            << " tablet " << datashardId
+    );
 
-    TSmallVec<NScheme::TTypeInfo> keyColumnTypes(table->KeyColumnIds.size());
-    for (size_t ki = 0; ki < table->KeyColumnIds.size(); ++ki) {
-        keyColumnTypes[ki] = table->Columns.FindPtr(table->KeyColumnIds[ki])->PType;
+    TSmallVec<NScheme::TTypeInfo> keyColumnTypes(tableInfo->KeyColumnIds.size());
+    for (size_t ki = 0; ki < tableInfo->KeyColumnIds.size(); ++ki) {
+        keyColumnTypes[ki] = tableInfo->Columns.FindPtr(tableInfo->KeyColumnIds[ki])->PType;
     }
 
     TSerializedCellVec splitKey;
+
     if (splitReason == ESplitReason::SPLIT_BY_LOAD) {
         // TODO: choose split key based on access stats for split by load
         const auto& keySample = rec.GetTableStats().GetKeyAccessSample();
         splitKey = ChooseSplitKeyByKeySample(keySample, keyColumnTypes);
 
-        // TODO: check that the choosen key is valid
+        if (splitKey.GetBuffer().empty()) {
+            LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "TTxPartitionHistogram Failed to find proper split key for"
+                << " " << ToString(splitReason) << ": " << splitReasonMsg
+                << " tablet " << datashardId);
+            return true;
+        }
     } else {
         // Choose number of parts and split boundaries
         const auto& histogram = rec.GetTableStats().GetDataSizeHistogram();
 
-        splitKey = ChooseSplitKeyByHistogram(histogram, dataSize, keyColumnTypes);
+        splitKey = ChooseSplitKeyByHistogram(histogram, rec.GetTableStats().GetDataSize(), keyColumnTypes);
         if (splitKey.GetBuffer().empty()) {
             LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                 "TTxPartitionHistogram Failed to find proper split key (initially) for"
@@ -457,14 +518,6 @@ bool TTxPartitionHistogram::Execute(TTransactionContext& txc, const TActorContex
                 << " tablet " << datashardId);
             return true;
         }
-    }
-
-    if (splitKey.GetBuffer().empty()) {
-        LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-            "TTxPartitionHistogram Failed to find proper split key for"
-            << " " << ToString(splitReason) << ": " << splitReasonMsg
-            << " tablet " << datashardId);
-        return true;
     }
 
     TTxId txId = Self->GetCachedTxId(ctx);

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
@@ -345,7 +345,7 @@ bool TTxPartitionHistogram::Execute(TTransactionContext& txc, const TActorContex
 
     bool trySplitByLoad = !(rec.GetTableStats().GetKeyAccessSample().GetBuckets().empty());
 
-    if ((!trySplitBySize) && (!trySplitByLoad)) {
+    if (!trySplitBySize && !trySplitByLoad) {
         return true;
     }
 
@@ -365,15 +365,14 @@ bool TTxPartitionHistogram::Execute(TTransactionContext& txc, const TActorContex
             << ", key access buckets " << rec.GetTableStats().GetKeyAccessSample().GetBuckets().size()
     );
 
-    const auto tableInfoIt = Self->Tables.find(tableId);
+    const TTableInfo::TPtr tableInfo = Self->Tables.Value(tableId, nullptr);
 
-    if (tableInfoIt == Self->Tables.end()) {
+    if (!tableInfo) {
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "TTxPartitionHistogram Unknown table " << tableId << " tablet " << datashardId);
         return true;
     }
 
-    const TTableInfo::TPtr tableInfo = tableInfoIt->second;
     const auto shardIt = Self->TabletIdToShardIdx.find(datashardId);
 
     if (shardIt == Self->TabletIdToShardIdx.end()) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1915,6 +1915,52 @@ void TTableAggregatedStats::UpdateShardStats(TDiskSpaceUsageDelta* diskSpaceUsag
     UpdatedStats.insert(datashardIdx);
 }
 
+void TTableInfo::UpdateShardStatsForFollower(
+    ui64 followerId,
+    const TShardIdx& shardIdx,
+    const TPartitionStats& newStats
+) {
+    Stats.UpdateShardStatsForFollower(followerId, shardIdx, newStats);
+}
+
+void TTableAggregatedStats::UpdateShardStatsForFollower(
+    ui64 /* followerId */,
+    const TShardIdx& shardIdx,
+    const TPartitionStats& newStats
+) {
+    // Find the statistics record for the given partition
+    const auto statsIt = PartitionStats.find(shardIdx);
+
+    if (statsIt == PartitionStats.end()) {
+        return;
+    }
+
+    TPartitionStats& oldStats = statsIt->second;
+
+    // Ignore messages coming from older generations of the given partition
+    //
+    // NOTE: Each EvPeriodicTableStats message contains two fields, which help
+    //       identify and filter old/stale messages: the generation and the round.
+    //       The generation is updated every time the partition is relocated
+    //       (comes from the state storage) and the round is incremented for
+    //       every message sent (comes from the DataShard actor memory).
+    //       Comparing the round requires keeping track of the round field
+    //       received from every follower. This is both too hard and too expensive.
+    //       For the purposes of tracking statistics from followers, it is sufficient
+    //       to compare only the generation (and ignore the round) - it is compared
+    //       to the generation that came from the most recent EvPeriodicTableStats
+    //       message from the leader for the given partition.
+    if (newStats.SeqNo.Generation < oldStats.SeqNo.Generation) {
+        return;
+    }
+
+    // Update only the top CPU usage and ignore the rest of the statistics
+    //
+    // NOTE: See the comment for the TPartitionStats.TopCpuUsage field
+    //       for the reasons why this is sufficient
+    oldStats.TopCpuUsage.Update(newStats.TopCpuUsage); // The left is new stats now!
+}
+
 void TAggregatedStats::UpdateTableStats(TDiskSpaceUsageDelta* diskSpaceUsageDelta, TShardIdx shardIdx, const TPathId& pathId, const TPartitionStats& newStats, TInstant now) {
     auto& tableStats = TableStats[pathId];
     tableStats.PartitionStats[shardIdx]; // insert if none
@@ -2146,10 +2192,12 @@ bool TTableInfo::CheckCanMergePartitions(const TSplitSettings& splitSettings,
 }
 
 bool TTableInfo::CheckSplitByLoad(
-        const TSplitSettings& splitSettings, TShardIdx shardIdx,
-        ui64 dataSize, ui64 rowCount,
-        const TTableInfo* mainTableForIndex, TString& reason) const
-{
+    const TSplitSettings& splitSettings,
+    const TShardIdx& shardIdx,
+    ui64 currentCpuUsage,
+    const TTableInfo* mainTableForIndex,
+    TString& reason
+) const {
     // Don't split/merge backup tables
     if (IsBackup) {
         reason = "IsBackup";
@@ -2209,29 +2257,29 @@ bool TTableInfo::CheckSplitByLoad(
     //       operations (which reduce the expected partition count).
     const ui64 effectiveShardCount = Max(ExpectedPartitionCount, Stats.PartitionStats.size());
 
-    if (rowCount < MIN_ROWS_FOR_SPLIT_BY_LOAD ||
-        dataSize < MIN_SIZE_FOR_SPLIT_BY_LOAD ||
+    if (stats->RowCount < MIN_ROWS_FOR_SPLIT_BY_LOAD ||
+        stats->DataSize < MIN_SIZE_FOR_SPLIT_BY_LOAD ||
         effectiveShardCount >= maxShards ||
-        stats->GetCurrentRawCpuUsage() < cpuUsageThreshold * 1000000)
+        currentCpuUsage < cpuUsageThreshold * 1000000)
     {
         reason = TStringBuilder() << "ConditionsNotMet"
-            << " rowCount: " << rowCount << " minRowCount: " << MIN_ROWS_FOR_SPLIT_BY_LOAD
-            << " shardSize: " << dataSize << " minShardSize: " << MIN_SIZE_FOR_SPLIT_BY_LOAD
+            << " rowCount: " << stats->RowCount << " minRowCount: " << MIN_ROWS_FOR_SPLIT_BY_LOAD
+            << " shardSize: " << stats->DataSize << " minShardSize: " << MIN_SIZE_FOR_SPLIT_BY_LOAD
             << " shardCount: " << Stats.PartitionStats.size()
             << " expectedShardCount: " << ExpectedPartitionCount << " maxShardCount: " << maxShards
-            << " cpuUsage: " << stats->GetCurrentRawCpuUsage() << " cpuUsageThreshold: " << cpuUsageThreshold * 1000000;
+            << " cpuUsage: " << currentCpuUsage << " cpuUsageThreshold: " << cpuUsageThreshold * 1000000;
         return false;
     }
 
     reason = TStringBuilder() << "split by load ("
-        << "rowCount: " << rowCount << ", "
+        << "rowCount: " << stats->RowCount << ", "
         << "minRowCount: " << MIN_ROWS_FOR_SPLIT_BY_LOAD << ", "
-        << "shardSize: " << dataSize << ", "
+        << "shardSize: " << stats->DataSize << ", "
         << "minShardSize: " << MIN_SIZE_FOR_SPLIT_BY_LOAD << ", "
         << "shardCount: " << Stats.PartitionStats.size() << ", "
         << "expectedShardCount: " << ExpectedPartitionCount << ", "
         << "maxShardCount: " << maxShards << ", "
-        << "cpuUsage: " << stats->GetCurrentRawCpuUsage() << ", "
+        << "cpuUsage: " << currentCpuUsage << ", "
         << "cpuUsageThreshold: " << cpuUsageThreshold * 1000000 << ")";
 
     return true;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -375,6 +375,52 @@ struct TPartitionStats {
     // Tablet actor started at
     TInstant StartTime;
 
+    /**
+     * The CPU usage percentage statistics represented as a time series:
+     * the last time the CPU usage exceeded 30%, the last time the CPU usage
+     * exceeded 20% and so on.
+     *
+     * @warning This is a combined statistics, which includes both the leader
+     *          and all the followers for the given partition. The CPU usage is treated
+     *          as a maximum across all followers and the leader, not as a sum.
+     *          For example, the data bucket for the 30% contains the last time,
+     *          when the CPU usage exceeded 30% for any follower or the leader.
+     *
+     * @note This field is used to control the merge-by-load operations.
+     *       It is not used for the split-by-load operations or for any other purposes.
+     *
+     * @note Why does this work for the merge-by-load operation?
+     *
+     *       When the SchemeShard actor received the EvPeriodicTableStats message
+     *       from one of the followers (or the leader) for the given partition,
+     *       it updates this field and then figures out the maximum CPU load
+     *       percentage that was used by the given partition over a preconfigured
+     *       time interval into the past (1 hour by default). If this maximum
+     *       CPU usage percentage does not exceed a certain preconfigured threshold
+     *       (70% of the split-by-load threshold), then this partition becomes
+     *       the anchor for the merge-by-load operation.
+     *
+     *       Once the anchor is picked, the code tries to add to the given partition
+     *       as many partitions to the left and to the right of it as possible.
+     *       When adding a potential candidate to the merge set, the code takes
+     *       the maximum CPU usage percentage for the given potential candidate
+     *       over the same time interval into the past and adds it to the combined
+     *       CPU usage percentage. The code continues adding partitions
+     *       to the merge set as long as the combined CPU usage percentage for
+     *       all partitions in the merge set stays below the same preconfigured
+     *       threshold (70% of the split-by-load threshold).
+     *
+     *       Once all possible partitions have been added to the merge set
+     *       (and this set contains more than one partition), the entire set
+     *       is merged into a single partition.
+     *
+     *       Notice that both picking the anchor partition for the merge-by-load
+     *       operation and adding a partition to the merge set requires that
+     *       the observed CPU load for the given partition stays below a certain level
+     *       for all followers and the leader for the given partition.
+     *       Keeping the maximum CPU usage percentage across all followers
+     *       and the leader is sufficient to verify this requirement.
+     */
     TTopCpuUsage TopCpuUsage;
 
     void SetCurrentRawCpuUsage(ui64 rawCpuUsage, TInstant now) {
@@ -391,6 +437,12 @@ struct TPartitionStats {
     }
 
 private:
+    /**
+     * The last observed CPU usage for the given partition.
+     *
+     * @warning This value is updated only by the data received from the leader.
+     *          Unlike the TopCpuUsage field, it does not include any followers.
+     */
     ui64 CPU = 0;
 };
 
@@ -412,6 +464,20 @@ struct TTableAggregatedStats {
     }
 
     void UpdateShardStats(TDiskSpaceUsageDelta* diskSpaceUsageDelta, TShardIdx datashardIdx, const TPartitionStats& newStats, TInstant now);
+
+    /**
+     * Update the statistics data for the given shard and the given follower
+     * using the data from the EvPeriodicTableStats message.
+     *
+     * @param[in] followerId The follower ID
+     * @param[in] shardIdx The shard index
+     * @param[in] newStats The new statistics to use for updating
+     */
+    void UpdateShardStatsForFollower(
+        ui64 followerId,
+        const TShardIdx& shardIdx,
+        const TPartitionStats& newStats
+    );
 };
 
 struct TAggregatedStats : public TTableAggregatedStats {
@@ -742,6 +808,20 @@ public:
 
     void UpdateShardStats(TDiskSpaceUsageDelta* diskSpaceUsageDelta, TShardIdx datashardIdx, const TPartitionStats& newStats, TInstant now);
 
+    /**
+     * Update the statistics data for the given shard and the given follower
+     * using the data from the EvPeriodicTableStats message.
+     *
+     * @param[in] followerId The follower ID
+     * @param[in] shardIdx The shard index
+     * @param[in] newStats The new statistics to use for updating
+     */
+    void UpdateShardStatsForFollower(
+        ui64 followerId,
+        const TShardIdx& shardIdx,
+        const TPartitionStats& newStats
+    );
+
     void RegisterSplitMergeOp(TOperationId txId, const TTxState& txState);
 
     bool IsShardInSplitMergeOp(TShardIdx idx) const;
@@ -771,10 +851,24 @@ public:
                                  TShardIdx shardIdx, const TTabletId& tabletId, TVector<TShardIdx>& shardsToMerge,
                                  const TTableInfo* mainTableForIndex, TInstant now, TString& reason) const;
 
+    /**
+     * Check if the given partition should be split by load.
+     *
+     * @param[in] splitSettings The current split settings
+     * @param[in] shardIdx The shard index
+     * @param[in] currentCpuUsage The current CPU usage to use for checking the split conditions
+     * @param[in] mainTableForIndex The parent table (set only for index tables)
+     * @param[out] reason Receives the human readable explanation for the decision
+     *
+     * @return True if the given partition should be split by load
+     */
     bool CheckSplitByLoad(
-            const TSplitSettings& splitSettings, TShardIdx shardIdx,
-            ui64 dataSize, ui64 rowCount,
-            const TTableInfo* mainTableForIndex, TString& reason) const;
+        const TSplitSettings& splitSettings,
+        const TShardIdx& shardIdx,
+        ui64 currentCpuUsage,
+        const TTableInfo* mainTableForIndex,
+        TString& reason
+    ) const;
 
     bool IsSplitBySizeEnabled(const TForceShardSplitSettings& params) const {
         // Respect unspecified SizeToSplit when force shard splits are disabled

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
@@ -687,7 +687,8 @@ enum class ESendDuplicateTableStatsStrategy {
 // Assumed index configuration: 1 initial datashard, Uint64 key.
 //
 struct TLoadAndSplitSimulator {
-    std::map<ui32, NKikimrTabletBase::TMetrics> MetricsPatchByFollowerId;
+    std::map<ui32, NKikimrTabletBase::TMetrics> MetricsPatchByFollowerIdPeriodic;
+    std::map<ui32, NKikimrTabletBase::TMetrics> MetricsPatchByFollowerIdStats;
     NKikimrTableStats::THistogram KeyAccessHistogramPatch;
     ui64 TableLocalPathId;
     ui64 TableOwnerId;
@@ -726,7 +727,8 @@ struct TLoadAndSplitSimulator {
         ui64 initialDatashardId,
         bool shouldSendReadRequests,
         ESendDuplicateTableStatsStrategy sendDuplicateTableStats,
-        const std::map<ui32, ui32>& targetCpuLoadByFolowerId,
+        const std::map<ui32, i32>& targetCpuLoadByFolowerIdPeriodic,
+        const std::map<ui32, i32>& targetCpuLoadByFolowerIdStats,
         TTestActorRuntime& testRuntime
     ) : TableLocalPathId(tableLocalPathId)
         , TableOwnerId(tableOwnerId)
@@ -734,11 +736,19 @@ struct TLoadAndSplitSimulator {
         , SendDuplicateTableStats(sendDuplicateTableStats)
         , TestRuntime(&testRuntime)
     {
-        for (const auto& [followerId, targetCpuLoad] : targetCpuLoadByFolowerId) {
-            MetricsPatchByFollowerId[followerId].SetCPU(CpuLoadMicroseconds(targetCpuLoad));
+        for (const auto& [followerId, targetCpuLoad] : targetCpuLoadByFolowerIdPeriodic) {
+            MetricsPatchByFollowerIdPeriodic[followerId].SetCPU(CpuLoadMicroseconds(targetCpuLoad));
         }
 
-        //NOTE: histogram must have at least 3 buckets with different keys to be able to produce split key
+        for (const auto& [followerId, targetCpuLoad] : targetCpuLoadByFolowerIdStats) {
+            if (targetCpuLoad >= 0) {
+                MetricsPatchByFollowerIdStats[followerId].SetCPU(CpuLoadMicroseconds(targetCpuLoad));
+            } else {
+                MetricsPatchByFollowerIdStats[followerId].ClearCPU();
+            }
+        }
+
+        // NOTE: histogram must have at least 3 buckets with different keys to be able to produce split key
         // (see ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp, DoFindSplitKey() and ChooseSplitKeyByKeySample())
         HistogramAddBucket(KeyAccessHistogramPatch, 999998, 1000);
         HistogramAddBucket(KeyAccessHistogramPatch, 999999, 1000);
@@ -752,12 +762,27 @@ struct TLoadAndSplitSimulator {
             SenderActorId = TestRuntime->Register(new TDummyActor());
         }
 
-        for (const auto& [followerId, targetCpuLoad] : targetCpuLoadByFolowerId) {
+        for (const auto& [followerId, targetCpuLoad] : targetCpuLoadByFolowerIdPeriodic) {
             Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
-                << ", target CPU load for followerId " << followerId
+                << ", target CPU load (EvPeriodicTableStats) for followerId " << followerId
                 << " is " << targetCpuLoad
                 << "%"
                 << Endl;
+        }
+
+        for (const auto& [followerId, targetCpuLoad] : targetCpuLoadByFolowerIdStats) {
+            if (targetCpuLoad >= 0) {
+                Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
+                    << ", target CPU load (EvGetTableStatsResult) for followerId " << followerId
+                    << " is " << targetCpuLoad
+                    << "%"
+                    << Endl;
+            } else {
+                Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
+                    << ", target CPU load (EvGetTableStatsResult) for followerId " << followerId
+                    << " is UNSET"
+                    << Endl;
+            }
         }
     }
 
@@ -863,9 +888,9 @@ struct TLoadAndSplitSimulator {
                         return;
                     }
 
-                    const auto itTargetCpuForFollower = MetricsPatchByFollowerId.find(msg->Record.GetFollowerId());
+                    const auto itTargetCpuForFollower = MetricsPatchByFollowerIdPeriodic.find(msg->Record.GetFollowerId());
 
-                    if (itTargetCpuForFollower != MetricsPatchByFollowerId.end()) {
+                    if (itTargetCpuForFollower != MetricsPatchByFollowerIdPeriodic.end()) {
                         const auto prevCPU = msg->Record.GetTabletMetrics().GetCPU();
                         msg->Record.MutableTabletMetrics()->MergeFrom(itTargetCpuForFollower->second);
                         const auto newCPU = msg->Record.GetTabletMetrics().GetCPU();
@@ -895,8 +920,9 @@ struct TLoadAndSplitSimulator {
                         return;
                     }
 
-                    // Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
-                    //     << ", intercept EvGetTableStats" << Endl;
+                    Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
+                         << ", intercept EvGetTableStats, collectKeySample " << msg->Record.GetCollectKeySample()
+                         << Endl;
 
                     if (msg->Record.GetCollectKeySample()) {
                         ++KeyAccessSampleReqCount;
@@ -927,10 +953,41 @@ struct TLoadAndSplitSimulator {
                         break;
                     }
 
+                    const auto itTargetCpuForFollower = MetricsPatchByFollowerIdStats.find(msg->Record.GetFollowerId());
+
+                    if (itTargetCpuForFollower != MetricsPatchByFollowerIdStats.end()) {
+                        const auto prevCPU = msg->Record.GetTabletMetrics().GetCPU();
+
+                        if (itTargetCpuForFollower->second.HasCPU()) {
+                            msg->Record.MutableTabletMetrics()->MergeFrom(itTargetCpuForFollower->second);
+                            const auto newCPU = msg->Record.GetTabletMetrics().GetCPU();
+
+                            Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
+                                << ", intercept EvGetTableStatsResult, from datashard " << msg->Record.GetDatashardId()
+                                << ", from followerId " << msg->Record.GetFollowerId()
+                                << ", patched CPU: " << prevCPU << "->" << newCPU
+                                << Endl;
+                        } else {
+                            msg->Record.MutableTabletMetrics()->ClearCPU();
+
+                            Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
+                                << ", intercept EvGetTableStatsResult, from datashard " << msg->Record.GetDatashardId()
+                                << ", from followerId " << msg->Record.GetFollowerId()
+                                << ", patched CPU: " << prevCPU << "->UNSET"
+                                << Endl;
+                        }
+                    } else {
+                        Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
+                            << ", intercept EvGetTableStatsResult, from datashard " << msg->Record.GetDatashardId()
+                            << ", from followerId " << msg->Record.GetFollowerId()
+                            << ", unpatched CPU: " << msg->Record.GetTabletMetrics().GetCPU()
+                            << Endl;
+                    }
+
                     msg->Record.MutableTableStats()->MutableKeyAccessSample()->CopyFrom(KeyAccessHistogramPatch);
 
                     auto [start, end] = DatashardsKeyRanges[msg->Record.GetDatashardId()];
-                    //NOTE: zero end means infinity -- this is a final shard
+                    // NOTE: zero end means infinity -- this is a final shard
                     if (end == 0) {
                         end = 1000000;
                     }
@@ -941,6 +998,7 @@ struct TLoadAndSplitSimulator {
 
                     Cerr << "TEST TLoadAndSplitSimulator for table id " << TableLocalPathId
                         << ", intercept EvGetTableStatsResult, from datashard " << msg->Record.GetDatashardId()
+                        << ", from followerId " << msg->Record.GetFollowerId()
                         << ", patch KeyAccessSample: split point " << splitPoint
                         << " (start=" << start
                         << ", end=" << end
@@ -1134,8 +1192,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
      *
      * @param[in] runtime The test runtime
      * @param[in] tablePath The table to use for the test
-     * @param[in] targetCpuLoadByFolowerId The map from the follower ID (0 == leader)
-     *                                     to the corresponding induced CPU load (as percent)
+     * @param[in] targetCpuLoadByFolowerIdPeriodic The map from the follower ID (0 == leader)
+     *                                             to the corresponding induced CPU load (as percent)
+     *                                             (for EvPeriodicTableStats)
+     * @param[in] targetCpuLoadByFolowerIdStats The map from the follower ID (0 == leader)
+     *                                          to the corresponding induced CPU load (as percent)
+     *                                          (for EvGetTableStatsResult)
+     *                                          (any negative value == unset the CPU usage value)
      * @param[in] shouldSendReadRequests If true, send EvRead requests to all followers
      * @param[in] sendDuplicateTableStats Determines if/when to send duplicate EvGetTableStatsResult messages
      * @param[in] expectTableToBeSplitted If true, expect the table to be splitted
@@ -1143,7 +1206,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
     void SplitByLoad(
         TTestActorRuntime& runtime,
         const TString& tablePath,
-        const std::map<ui32, ui32>& targetCpuLoadByFolowerId,
+        const std::map<ui32, i32>& targetCpuLoadByFolowerIdPeriodic,
+        const std::map<ui32, i32>& targetCpuLoadByFolowerIdStats,
         bool shouldSendReadRequests = false,
         ESendDuplicateTableStatsStrategy sendDuplicateTableStats = ESendDuplicateTableStatsStrategy::None,
         bool expectTableToBeSplitted = true
@@ -1161,7 +1225,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
             initialDatashardId,
             shouldSendReadRequests,
             sendDuplicateTableStats,
-            targetCpuLoadByFolowerId,
+            targetCpuLoadByFolowerIdPeriodic,
+            targetCpuLoadByFolowerIdStats,
             runtime
         );
 
@@ -1184,7 +1249,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
             runtime.WaitFor(
                 "the confirmation that the table is not splitting",
                 [&simulator]() -> bool {
-                    return (simulator.PeriodicTableStatsCount > 10) && (simulator.KeyAccessSampleReqCount == 0);
+                    return (simulator.PeriodicTableStatsCount > 10) && (simulator.SplitReqCount == 0);
                 },
                 TDuration::Seconds(60)
             );
@@ -1212,6 +1277,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
             initialDatashardId,
             false /* shouldSendReadRequests */,
             ESendDuplicateTableStatsStrategy::None,
+            {{0, targetCpuLoadPercent}}, // Target CPU load for the leader only
             {{0, targetCpuLoadPercent}}, // Target CPU load for the leader only
             runtime
         );
@@ -1278,6 +1344,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
         SplitByLoad(
             runtime,
             "/MyRoot/Table",
+            {{0, cpuLoadSimulated}}, // Target CPU load for the leader only
             {{0, cpuLoadSimulated}} // Target CPU load for the leader only
         );
 
@@ -1338,6 +1405,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
         SplitByLoad(
             runtime,
             "/MyRoot/Table/by-value/indexImplTable",
+            {{0, cpuLoadSimulated}}, // Target CPU load for the leader only
             {{0, cpuLoadSimulated}} // Target CPU load for the leader only
         );
 
@@ -1437,6 +1505,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
             runtime,
             "/MyRoot/Table",
             {{0, cpuLoadSimulated}}, // Target CPU load for the leader only
+            {{0, cpuLoadSimulated}}, // Target CPU load for the leader only
             false /* shouldSendReadRequests */,
             ESendDuplicateTableStatsStrategy::Immediately // Trigger concurrent split transactions
         );
@@ -1489,6 +1558,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
             runtime,
             "/MyRoot/Table",
             {{0, cpuLoadSimulated}}, // Target CPU load for the leader only
+            {{0, cpuLoadSimulated}}, // Target CPU load for the leader only
             false /* shouldSendReadRequests */,
             ESendDuplicateTableStatsStrategy::AfterSplitAck // Trigger duplicate split transactions
         );
@@ -1501,11 +1571,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
     /**
      * Verify that a shard is split automatically, when some of the followers
      * become overloaded with requests.
-     *
-     * @todo Once splitting by the follower load is implemented,
-     *       this test should be adjusted to match the splitting logic.
-     *       For now this test is essentially reversed - it verifies that
-     *       no splitting is triggered, when one of the followers is overloaded.
      */
     Y_UNIT_TEST(TableSplitsByFollowerLoad) {
         TTestBasicRuntime runtime;
@@ -1545,22 +1610,193 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitByLoad) {
             runtime,
             "/MyRoot/Table",
             {
-                // No simulated CPU load for the leader, only for the followers
-                {1, cpuLoadSimulated},
+                // No simulated CPU load for the leader, only for one of the followers
+                {0, 0},
+                {1, 0},
                 {2, cpuLoadSimulated},
-                {3, cpuLoadSimulated},
+                {3, 0},
             },
-            true /* shouldSendReadRequests */,
+            {
+                // No simulated CPU load for the leader, only for one of the followers
+                {0, 0},
+                {1, 0},
+                {2, cpuLoadSimulated},
+                {3, 0},
+            },
+            true /* shouldSendReadRequests */
+        );
+
+        auto tableInfo = DescribePrivatePath(runtime, "/MyRoot/Table", true, true);
+        Cerr << "TEST table final state:" << Endl << tableInfo.DebugString() << Endl;
+        TestDescribeResult(tableInfo, {NLs::PartitionCount(expectedPartitionCount)});
+    }
+
+    /**
+     * Verify that a shard does not split, if the CPU load just to a high value,
+     * when the EvPeriodicTableStats message is generated, but drops to a low value,
+     * when the EvGetTableStats message is processed and the EvGetTableStatsResult
+     * response is generated. This is for the CPU load on the leader only.
+     */
+    Y_UNIT_TEST(NoSplitWithLeaderSpikeLoad) {
+        TTestBasicRuntime runtime;
+        auto env = SetupEnv(runtime);
+
+        const ui32 expectedPartitionCount = 5;
+        const ui64 cpuLoadSimulated = 100;  // percents
+
+        const auto tableScheme = Sprintf(
+            R"(
+                Name: "Table"
+                Columns { Name: "key"       Type: "Uint64"}
+                Columns { Name: "value"     Type: "Uint64"}
+                KeyColumnNames: ["key"]
+                UniformPartitionsCount: 1
+                PartitionConfig {
+                    PartitioningPolicy {
+                        MaxPartitionsCount: %d  # replacement field for required number of partitions
+
+                        SplitByLoadSettings: {
+                            Enabled: true
+                            CpuPercentageThreshold: 1
+                        }
+                    }
+                }
+            )",
+            expectedPartitionCount
+        );
+
+        ui64 txId = 100;
+        TestCreateTable(runtime, txId, "/MyRoot", tableScheme);
+        env.TestWaitNotification(runtime, txId);
+
+        SplitByLoad(
+            runtime,
+            "/MyRoot/Table",
+            {{0, cpuLoadSimulated}}, // Target CPU load for the leader only
+            {{0, 0}}, // The CPU load drops to 0% for EvGetTableStatsResult
+            false /* shouldSendReadRequests */,
             ESendDuplicateTableStatsStrategy::None,
-            /// @todo Remove the time limit once splitting by the replica load is implemented
             false /* expectTableToBeSplitted */
         );
 
         auto tableInfo = DescribePrivatePath(runtime, "/MyRoot/Table", true, true);
         Cerr << "TEST table final state:" << Endl << tableInfo.DebugString() << Endl;
-
-        /// @todo Use expectedPartitionCount instead of 1 once splitting by the follower load is implemented
         TestDescribeResult(tableInfo, {NLs::PartitionCount(1)});
+    }
+
+    /**
+     * Verify that a shard does not split, if the CPU load just to a high value,
+     * when the EvPeriodicTableStats message is generated, but drops to a low value,
+     * when the EvGetTableStats message is processed and the EvGetTableStatsResult
+     * response is generated. This is for the CPU load on the leader only.
+     */
+    Y_UNIT_TEST(NoSplitWithFollowerSpikeLoad) {
+        TTestBasicRuntime runtime;
+        auto env = SetupEnv(runtime);
+
+        const ui32 expectedPartitionCount = 5;
+        const ui64 cpuLoadSimulated = 100;  // percents
+
+        const auto tableScheme = Sprintf(
+            R"(
+                Name: "Table"
+                Columns { Name: "key"   Type: "Uint64"}
+                Columns { Name: "value" Type: "Uint64"}
+                KeyColumnNames: ["key"]
+                UniformPartitionsCount: 1
+                PartitionConfig {
+                    PartitioningPolicy {
+                        MaxPartitionsCount: %d  # replacement field for required number of partitions
+
+                        SplitByLoadSettings: {
+                            Enabled: true
+                            CpuPercentageThreshold: 1
+                        }
+                    }
+
+                    FollowerCount: 3
+                }
+            )",
+            expectedPartitionCount
+        );
+
+        ui64 txId = 100;
+        TestCreateTable(runtime, txId, "/MyRoot", tableScheme);
+        env.TestWaitNotification(runtime, txId);
+
+        SplitByLoad(
+            runtime,
+            "/MyRoot/Table",
+            {
+                // No simulated CPU load for the leader, only for one of the followers
+                {0, 0},
+                {1, 0},
+                {2, cpuLoadSimulated},
+                {3, 0},
+            },
+            {
+                // The CPU load drops to 0% for EvGetTableStatsResult
+                {0, 0},
+                {1, 0},
+                {2, 0},
+                {3, 0},
+            },
+            true /* shouldSendReadRequests */,
+            ESendDuplicateTableStatsStrategy::None,
+            false /* expectTableToBeSplitted */
+        );
+
+        auto tableInfo = DescribePrivatePath(runtime, "/MyRoot/Table", true, true);
+        Cerr << "TEST table final state:" << Endl << tableInfo.DebugString() << Endl;
+        TestDescribeResult(tableInfo, {NLs::PartitionCount(1)});
+    }
+
+    /**
+     * Verify that a shard splits correctly, even if the CPU usage value
+     * is the EvGetTableStatsResult response is not populated.
+     */
+    Y_UNIT_TEST(SplitWithoutCpuUsageInStatsResponse) {
+        TTestBasicRuntime runtime;
+        auto env = SetupEnv(runtime);
+
+        const ui32 expectedPartitionCount = 5;
+        const ui64 cpuLoadSimulated = 100;  // percents
+
+        const auto tableScheme = Sprintf(
+            R"(
+                Name: "Table"
+                Columns { Name: "key"       Type: "Uint64"}
+                Columns { Name: "value"     Type: "Uint64"}
+                KeyColumnNames: ["key"]
+                UniformPartitionsCount: 1
+                PartitionConfig {
+                    PartitioningPolicy {
+                        MaxPartitionsCount: %d  # replacement field for required number of partitions
+
+                        SplitByLoadSettings: {
+                            Enabled: true
+                            CpuPercentageThreshold: 1
+                        }
+                    }
+                }
+            )",
+            expectedPartitionCount
+        );
+
+        ui64 txId = 100;
+        TestCreateTable(runtime, txId, "/MyRoot", tableScheme);
+        env.TestWaitNotification(runtime, txId);
+
+        SplitByLoad(
+            runtime,
+            "/MyRoot/Table",
+            {{0, cpuLoadSimulated}}, // Target CPU load for the leader only
+            {{0, -100}} // Explicitly clear the CPU value from EvGetTableStatsResult
+        );
+
+        auto tableInfo = DescribePrivatePath(runtime, "/MyRoot/Table", true, true);
+        Cerr << "TEST table final state:" << Endl << tableInfo.DebugString() << Endl;
+        TestDescribeResult(tableInfo, {NLs::PartitionCount(expectedPartitionCount)});
     }
 }
 
@@ -1590,8 +1826,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardMergeByLoad) {
         const TString& tablePath,
         ui32 maxPartitionCount,
         ui32 finalPartitionCount,
-        const std::map<ui32, ui32>& splitCpuLoadByFolowerId,
-        const std::map<ui32, ui32>& mergeCpuLoadByFolowerId,
+        const std::map<ui32, i32>& splitCpuLoadByFolowerId,
+        const std::map<ui32, i32>& mergeCpuLoadByFolowerId,
         bool shouldSendReadRequests,
         bool expectTableToBeMerged
     ) {
@@ -1610,6 +1846,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMergeByLoad) {
             initialDatashardId,
             shouldSendReadRequests,
             ESendDuplicateTableStatsStrategy::None,
+            splitCpuLoadByFolowerId,
             splitCpuLoadByFolowerId,
             runtime
         );
@@ -1646,6 +1883,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMergeByLoad) {
             initialDatashardId,
             shouldSendReadRequests,
             ESendDuplicateTableStatsStrategy::None,
+            mergeCpuLoadByFolowerId,
             mergeCpuLoadByFolowerId,
             runtime
         );
@@ -1847,11 +2085,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardMergeByLoad) {
     /**
      * Verify that a shard does not merge partitions when there is CPU load
      * on the followers.
-     *
-     * @todo Once merging by the follower load is implemented,
-     *       this test should be adjusted to match the merging logic.
-     *       For now this test is essentially reversed - it verifies that
-     *       the merging is triggered, even if all followers are overloaded.
      */
     Y_UNIT_TEST(NoMergeWithFollowerLoad) {
         TTestBasicRuntime runtime;
@@ -1890,9 +2123,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMergeByLoad) {
             runtime,
             "/MyRoot/Table",
             maxPartitionCount,
-            /// @todo This limit should be adjusting once merging-by-load is changed
-            ///       to taking into account the CPU load on the followers
-            1 /* finalPartitionCount */,
+            5 /* finalPartitionCount */,
             {
                 // The initial CPU load only on the leaders to force the split
                 {0, 100},
@@ -1913,7 +2144,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMergeByLoad) {
                 {3, 60},
             },
             true /* shouldSendReadRequests */,
-            true /* expectTableToBeMerged */
+            false /* expectTableToBeMerged */
         );
     }
 }


### PR DESCRIPTION
### Changelog entry

Consider the CPU load on followers when making the decision to split a partition or to merge partitions.

### Changelog category

* Improvement

### Description for reviewers

* Added `TDataShardConfig.KeyAccessSampleCollectionMinIntervalSeconds`
* Added `TDataShardConfig.KeyAccessSampleCollectionMaxIntervalSeconds`
* Added `TDataShardConfig.KeyAccessSampleVaidityIntervalSeconds`
* Added `TEvGetTableStatsResult.FollowerId`
* Handle `TEvGetTableStats` on followers
* Populate `TEvGetTableStatsResult.TabletMetrics.CPU`
* Fixed the logic which collects key access data and populates `TEvGetTableStatsResult.KeyAccessSample`
* Added unit tests to verify the key access collection logic (both leaders and followers)
* Save the CPU usage data from `TEvPeriodicTableStats` coming from followers
* Update `TPartitionStats.TopCpuUsage` to keep the max CPU load across all followers and the leader
* Use the CPU usage from `TEvPeriodicTableStats` when considering split-by-load
* Send `TEvGetTableStats` to the correct leader/follower when preparing split-by-load
* Handle split-by-load for `TEvGetTableStatsResult` coming from followers
* Use the CPU usage from `TEvGetTableStatsResult` when starting split-by-load
* Updated the `TSchemeShardSplitByLoad::TableSplitsByFollowerLoad` test to verify the new split-by-load logic
* Added the `TSchemeShardSplitByLoad::NoSplitWithLeaderSpikeLoad` test
* Added the `TSchemeShardSplitByLoad::NoSplitWithFollowerSpikeLoad` test
* Added the `TSchemeShardSplitByLoad::SplitWithoutCpuUsageInStatsResponse` test
* Updated the `TSchemeShardMergeByLoad::NoMergeWithFollowerLoad` test to verify the new merge-by-load logic
