### PR TITLE
Add restore backup from filesystem in tablet recovery mode

### DIFF
--- a/ydb/core/base/appdata.cpp
+++ b/ydb/core/base/appdata.cpp
@@ -28,6 +28,7 @@
 #include <ydb/core/protos/memory_controller_config.pb.h>
 #include <ydb/core/protos/netclassifier.pb.h>
 #include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/core/protos/recoveryshard_config.pb.h>
 #include <ydb/core/protos/replication.pb.h>
 #include <ydb/core/protos/shared_cache.pb.h>
 #include <ydb/core/protos/stream.pb.h>
@@ -82,6 +83,7 @@ struct TAppData::TImpl {
     NKikimrConfig::TStatisticsConfig StatisticsConfig;
     TMetricsConfig MetricsConfig;
     NKikimrConfig::TSystemTabletBackupConfig SystemTabletBackupConfig;
+    NKikimrConfig::TRecoveryShardConfig RecoveryShardConfig;
 };
 
 TAppData::TAppData(
@@ -149,6 +151,7 @@ TAppData::TAppData(
     , StatisticsConfig(Impl->StatisticsConfig)
     , MetricsConfig(Impl->MetricsConfig)
     , SystemTabletBackupConfig(Impl->SystemTabletBackupConfig)
+    , RecoveryShardConfig(Impl->RecoveryShardConfig)
     , KikimrShouldContinue(kikimrShouldContinue)
     , TracingConfigurator(MakeIntrusive<NJaegerTracing::TSamplingThrottlingConfigurator>(TimeProvider, RandomProvider))
 {}

--- a/ydb/core/base/appdata_fwd.h
+++ b/ydb/core/base/appdata_fwd.h
@@ -82,6 +82,7 @@ namespace NKikimrConfig {
     class TBridgeConfig;
     class TStatisticsConfig;
     class TSystemTabletBackupConfig;
+    class TRecoveryShardConfig;
 }
 
 namespace NKikimrReplication {
@@ -272,6 +273,7 @@ struct TAppData {
     NKikimrConfig::TStatisticsConfig& StatisticsConfig;
     TMetricsConfig& MetricsConfig;
     NKikimrConfig::TSystemTabletBackupConfig& SystemTabletBackupConfig;
+    NKikimrConfig::TRecoveryShardConfig& RecoveryShardConfig;
     bool EnforceUserTokenRequirement = false;
     bool EnforceUserTokenCheckRequirement = false; // check token if it was specified
     bool AllowHugeKeyValueDeletes = true; // delete when all clients limit deletes per request

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -64,6 +64,7 @@
 #include <ydb/core/protos/datashard_config.pb.h>
 #include <ydb/core/protos/http_config.pb.h>
 #include <ydb/core/protos/node_broker.pb.h>
+#include <ydb/core/protos/recoveryshard_config.pb.h>
 #include <ydb/core/protos/replication.pb.h>
 #include <ydb/core/protos/stream.pb.h>
 #include <ydb/core/protos/workload_manager_config.pb.h>
@@ -1559,6 +1560,10 @@ void TKikimrRunner::InitializeAppData(const TKikimrRunConfig& runConfig)
 
     if (runConfig.AppConfig.HasDataIntegrityTrailsConfig()) {
         AppData->DataIntegrityTrailsConfig = runConfig.AppConfig.GetDataIntegrityTrailsConfig();
+    }
+
+    if (runConfig.AppConfig.HasRecoveryShardConfig()) {
+        AppData->RecoveryShardConfig = runConfig.AppConfig.GetRecoveryShardConfig();
     }
 
     // setup resource profiles

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -28,6 +28,7 @@ import "ydb/core/protos/memory_controller_config.proto";
 import "ydb/core/protos/netclassifier.proto";
 import "ydb/core/protos/node_broker.proto";
 import "ydb/core/protos/pqconfig.proto";
+import "ydb/core/protos/recoveryshard_config.proto";
 import "ydb/core/protos/replication.proto";
 import "ydb/core/protos/resource_broker.proto";
 import "ydb/core/protos/shared_cache.proto";
@@ -2964,6 +2965,8 @@ message TAppConfig {
 
     // Built-in AWS client options (used, for example, to interact with S3).
     optional TAwsClientConfig AwsClientConfig = 116;
+
+    optional TRecoveryShardConfig RecoveryShardConfig = 117;
 }
 
 message TYdbVersion {

--- a/ydb/core/protos/recoveryshard_config.proto
+++ b/ydb/core/protos/recoveryshard_config.proto
@@ -2,7 +2,7 @@ package NKikimrConfig;
 option java_package = "ru.yandex.kikimr.proto";
 
 message TRecoveryShardConfig {
-    optional uint64 RestoreInFlightBytes = 1 [default = 536870912]; // 50 MB
+    optional uint64 RestoreInFlightBytes = 1 [default = 52428800]; // 50 MB
     optional uint64 RestoreTxMaxLines = 2 [default = 10000];
     optional uint64 RestoreTxMaxRedoBytes = 3 [default = 134217728]; // 128 MB
 }

--- a/ydb/core/protos/recoveryshard_config.proto
+++ b/ydb/core/protos/recoveryshard_config.proto
@@ -1,0 +1,8 @@
+package NKikimrConfig;
+option java_package = "ru.yandex.kikimr.proto";
+
+message TRecoveryShardConfig {
+    optional uint64 RestoreInFlightBytes = 1 [default = 536870912]; // 50 MB
+    optional uint64 RestoreTxMaxLines = 2 [default = 10000];
+    optional uint64 RestoreTxMaxRedoBytes = 3 [default = 134217728]; // 128 MB
+}

--- a/ydb/core/protos/ya.make
+++ b/ydb/core/protos/ya.make
@@ -119,6 +119,7 @@ SRCS(
     pqconfig.proto
     profiler.proto
     query_stats.proto
+    recoveryshard_config.proto
     replication.proto
     resource_broker.proto
     s3_settings.proto

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -119,6 +119,7 @@ void WriteColumnToJson(const TString& columnName, NScheme::TTypeId columnType,
         break;
     case NScheme::NTypeIds::Utf8:
         writer.WriteKey(columnName).WriteString(columnData.AsBuf());
+        break;
     case NScheme::NTypeIds::Json:
         writer.WriteKey(columnName);
         WriteJson(columnData.AsBuf(), writer);

--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -658,7 +658,7 @@ public:
             NJson::TJsonValue json;
 
             try {
-                NJson::ReadJsonTree(line, &json);
+                NJson::ReadJsonTree(line, &json, true);
                 UploadData(json, &table, NTable::ERowOp::Upsert, Pool, txc);
             } catch (const std::exception& e) {
                 Error = TStringBuilder() << "Failed to upload snapshot data: " << e.what() << ", line: " << line;
@@ -697,9 +697,9 @@ public:
             NJson::TJsonValue json;
 
             try {
-                NJson::ReadJsonTree(line, &json);
+                NJson::ReadJsonTree(line, &json, true);
             } catch (const std::exception& e) {
-                Error = TStringBuilder() << "Failed to parse changelog line: " << e.what();
+                Error = TStringBuilder() << "Failed to parse changelog: " << e.what() << ", line: " << line;
                 return true;
             }
 

--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -635,11 +635,10 @@ public:
             // Start new tx to upload the rest data
             Self->Execute(Self->CreateTxUploadSnapshot(std::move(Snapshot), i));
             Result.PartialDone(processedBytes);
-            return true;
         } else {
             Result.Done(processedBytes);
-            return true;
         }
+        return true;
     }
 
     void Complete(const TActorContext& ctx) override {

--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -1,14 +1,324 @@
 #include "flat_executor_recovery.h"
 
+#include "flat_cxx_database.h"
+#include "tablet_flat_executed.h"
+
+#include <ydb/core/base/appdata_fwd.h>
 #include <ydb/core/engine/minikql/flat_local_tx_factory.h>
-#include <ydb/core/tablet_flat/tablet_flat_executed.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/hfunc.h>
+
+#include <yql/essentials/types/binary_json/read.h>
+#include <yql/essentials/types/binary_json/write.h>
+
+#include <library/cpp/protobuf/json/json2proto.h>
+#include <library/cpp/string_utils/base64/base64.h>
+
+#include <util/stream/file.h>
+#include <variant>
+
 
 namespace NKikimr::NTabletFlatExecutor::NRecovery {
 
 using NTabletFlatExecutor::TTabletExecutedFlat;
 
+namespace {
+
+template<typename TSchemeType>
+TRawTypeValue ToRawTypeValue(const typename TSchemeType::TValueType& value, TMemoryPool& pool) {
+    auto* p = pool.Allocate<typename TSchemeType::TValueType>();
+    *p = value;
+    return TSchemeType::ToRawTypeValue(*p);
+}
+
+TRawTypeValue MakeTypeValueFromJson(NScheme::TTypeInfo type, const NJson::TJsonValue& value, TMemoryPool& pool) {
+    if (value.IsNull()) {
+        return TRawTypeValue();
+    }
+
+    NScheme::TTypeId typeId = type.GetTypeId();
+
+    switch (typeId) {
+        case NScheme::NTypeIds::Int32:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Int32 type";
+            }
+            return ToRawTypeValue<NScheme::TInt32>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Uint32:
+            if (!value.IsUInteger()) {
+                throw yexception() << "Expected unsigned integer value for Uint32 type";
+            }
+            return ToRawTypeValue<NScheme::TUint32>(value.GetUInteger(), pool);
+        case NScheme::NTypeIds::Int64:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Int64 type";
+            }
+            return ToRawTypeValue<NScheme::TInt64>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Uint64:
+            if (!value.IsUInteger()) {
+                throw yexception() << "Expected unsigned integer value for Uint64 type";
+            }
+            return ToRawTypeValue<NScheme::TUint64>(value.GetUInteger(), pool);
+        case NScheme::NTypeIds::Uint8:
+            if (!value.IsUInteger()) {
+                throw yexception() << "Expected unsigned integer value for Uint8 type";
+            }
+            return ToRawTypeValue<NScheme::TUint8>(value.GetUInteger(), pool);
+        case NScheme::NTypeIds::Int8:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Int8 type";
+            }
+            return ToRawTypeValue<NScheme::TInt8>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Int16:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Int16 type";
+            }
+            return ToRawTypeValue<NScheme::TInt16>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Uint16:
+            if (!value.IsUInteger()) {
+                throw yexception() << "Expected unsigned integer value for Uint16 type";
+            }
+            return ToRawTypeValue<NScheme::TUint16>(value.GetUInteger(), pool);
+        case NScheme::NTypeIds::Bool:
+            if (!value.IsBoolean()) {
+                throw yexception() << "Expected boolean value for Bool type";
+            }
+            return ToRawTypeValue<NScheme::TBool>(value.GetBoolean(), pool);
+        case NScheme::NTypeIds::Double:
+            if (!value.IsDouble()) {
+                throw yexception() << "Expected double value for Double type";
+            }
+            return ToRawTypeValue<NScheme::TDouble>(value.GetDouble(), pool);
+        case NScheme::NTypeIds::Float:
+            if (!value.IsDouble()) {
+                throw yexception() << "Expected double value for Float type";
+            }
+            return ToRawTypeValue<NScheme::TFloat>(value.GetDouble(), pool);
+        case NScheme::NTypeIds::Date:
+            if (!value.IsUInteger()) {
+                throw yexception() << "Expected unsigned integer value for Date type";
+            }
+            return ToRawTypeValue<NScheme::TDate>(value.GetUInteger(), pool);
+        case NScheme::NTypeIds::Datetime:
+            if (!value.IsUInteger()) {
+                throw yexception() << "Expected unsigned integer value for Datetime type";
+            }
+            return ToRawTypeValue<NScheme::TDatetime>(value.GetUInteger(), pool);
+        case NScheme::NTypeIds::Timestamp:
+            if (!value.IsUInteger()) {
+                throw yexception() << "Expected unsigned integer value for Timestamp type";
+            }
+            return ToRawTypeValue<NScheme::TTimestamp>(value.GetUInteger(), pool);
+        case NScheme::NTypeIds::Interval:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Interval type";
+            }
+            return ToRawTypeValue<NScheme::TInterval>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Date32:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Date32 type";
+            }
+            return ToRawTypeValue<NScheme::TDate32>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Datetime64:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Datetime64 type";
+            }
+            return ToRawTypeValue<NScheme::TDatetime64>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Timestamp64:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Timestamp64 type";
+            }
+            return ToRawTypeValue<NScheme::TTimestamp64>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Interval64:
+            if (!value.IsInteger()) {
+                throw yexception() << "Expected integer value for Interval64 type";
+            }
+            return ToRawTypeValue<NScheme::TInterval64>(value.GetInteger(), pool);
+        case NScheme::NTypeIds::Utf8: {
+            if (!value.IsString()) {
+                throw yexception() << "Expected string value for Utf8 type";
+            }
+            auto saved = pool.AppendString(TStringBuf(value.GetString()));
+            return TRawTypeValue(saved, typeId);
+        }
+        case NScheme::NTypeIds::Json: {
+            if (!value.IsString()) {
+                throw yexception() << "Expected string value for Json type";
+            }
+            auto saved = pool.AppendString(TStringBuf(value.GetString()));
+            return TRawTypeValue(saved, typeId);
+        }
+        case NScheme::NTypeIds::JsonDocument: {
+            if (!value.IsString()) {
+                throw yexception() << "Expected string value for JsonDocument type";
+            }
+            TString decoded = Base64StrictDecode(value.GetString());
+            auto maybeBinaryJson = NBinaryJson::SerializeToBinaryJson(decoded);
+            if (std::holds_alternative<TString>(maybeBinaryJson)) {
+                throw yexception() << "Invalid JSON for JsonDocument provided: " + std::get<TString>(maybeBinaryJson);
+            }
+            const auto& binaryJson = std::get<NBinaryJson::TBinaryJson>(maybeBinaryJson);
+            auto saved = pool.AppendString(TStringBuf(binaryJson.Data(), binaryJson.Size()));
+            return TRawTypeValue(saved, typeId);
+        }
+        case NScheme::NTypeIds::PairUi64Ui64: {
+            if (!value.IsArray()) {
+                throw yexception() << "Expected array value for PairUi64Ui64 type";
+            }
+            const auto& arr = value.GetArray();
+            if (arr.size() != 2) {
+                throw yexception() << "Expected array of size 2 for PairUi64Ui64 type";
+            }
+            if (!arr[0].IsUInteger() || !arr[1].IsUInteger()) {
+                throw yexception() << "Expected unsigned integer values in array for PairUi64Ui64 type";
+            }
+            std::pair<ui64, ui64> pair = {arr[0].GetUInteger(), arr[1].GetUInteger()};
+            return ToRawTypeValue<NScheme::TPairUi64Ui64>(pair, pool);
+        }
+        case NScheme::NTypeIds::ActorId: {
+            if (!value.IsString()) {
+                throw yexception() << "Expected string value for ActorId type";
+            }
+            TActorId actorId;
+
+            const auto& v = value.GetString();
+            if (!actorId.Parse(v.data(), v.size())) {
+                throw yexception() << "Failed to parse ActorId from string: " << v;
+            }
+            return ToRawTypeValue<NScheme::TActorId>(actorId, pool);
+        }
+        case NScheme::NTypeIds::String: {
+            if (!value.IsString()) {
+                throw yexception() << "Expected string value for String type";
+            }
+
+            TString decoded = Base64StrictDecode(value.GetString());
+            auto saved = pool.AppendString(TStringBuf(decoded));
+            return TRawTypeValue(saved, typeId);
+        }
+        default: {
+            if (!value.IsString()) {
+                throw yexception() << "Expected string value for type id " << typeId;
+            }
+            TString decoded = Base64StrictDecode(value.GetString());
+            auto saved = pool.AppendString(TStringBuf(decoded));
+            return TRawTypeValue(saved, typeId);
+        }
+    }
+}
+
+    const NTable::TScheme::TTableInfo* FindTableFromJson(const NJson::TJsonValue& json, TTransactionContext& txc) {
+         if (!json.IsMap()) {
+            throw yexception() << TStringBuilder() << "Invalid JSON format, expected object: " << json;
+        }
+        const auto& jsonMap = json.GetMap();
+
+        auto it = jsonMap.find("table");
+        if (it == jsonMap.end()) {
+            throw yexception() << "Table name is not found in json: " << json;
+        }
+
+        if (!it->second.IsString()) {
+            throw yexception() << "Table name is not string in json: " << json;
+        }
+
+        TString tableName = it->second.GetString();
+        const auto& scheme = txc.DB.GetScheme();
+        auto tableIt = scheme.TableNames.find(tableName);
+        if (tableIt == scheme.TableNames.end()) {
+            throw yexception() << "Table " << tableName << " not found in database schema";
+        }
+
+        return &scheme.Tables.at(tableIt->second);
+    }
+
+    NTable::ERowOp FindOpFromJson(const NJson::TJsonValue& json) {
+        if (!json.IsMap()) {
+            throw yexception() << TStringBuilder() << "Invalid JSON format, expected object: " << json;
+        }
+        const auto& jsonMap = json.GetMap();
+
+        auto it = jsonMap.find("op");
+        if (it == jsonMap.end()) {
+            throw yexception() << "Operation name is not found in json: " << json;
+        }
+
+        if (!it->second.IsString()) {
+            throw yexception() << "Operation name is not string in json: " << json;
+        }
+
+        TString opName = it->second.GetString();
+        if (opName == "upsert") {
+            return NTable::ERowOp::Upsert;
+        } else if (opName == "erase") {
+            return NTable::ERowOp::Erase;
+        } else if (opName == "replace") {
+            return NTable::ERowOp::Reset;
+        } else {
+            throw yexception() << "Unknown operation name: " << opName << " in json: " << json;
+        }
+    }
+
+    void UploadData(const NJson::TJsonValue& json,  const NTable::TScheme::TTableInfo* table,
+                    std::optional<NTable::ERowOp> op, TMemoryPool& pool, TTransactionContext &txc) {
+
+        if (table == nullptr) {
+            table = FindTableFromJson(json, txc);
+        }
+
+        if (!op.has_value()) {
+            op = FindOpFromJson(json);
+        }
+
+        TVector<TRawTypeValue> key(table->KeyColumns.size());
+        TVector<NTable::TUpdateOp> ops;
+
+        if (!json.IsMap()) {
+            throw yexception() << TStringBuilder() << "Invalid JSON format, expected object: " << json;
+        }
+        const auto& columns = json.GetMap();
+        for (const auto& [columnName, value] : columns) {
+            if (columnName == "table" || columnName == "op") {
+                continue;
+            }
+
+            auto it = table->ColumnNames.find(columnName);
+            if (it == table->ColumnNames.end()) {
+                throw yexception() << "Column " << columnName << " not found in table " << table->Name;
+            }
+
+            const auto& column = table->Columns.at(it->second);
+
+            if (column.KeyOrder != Max<ui32>()) {
+                key.at(column.KeyOrder) = MakeTypeValueFromJson(column.PType.GetTypeId(), value, pool);
+            } else {
+                ops.emplace_back(NIceDb::TUpdateOp(
+                    column.Id,
+                    NTable::ECellOp::Set,
+                    MakeTypeValueFromJson(column.PType.GetTypeId(), value, pool)
+                ));
+            }
+        }
+
+        try {
+            txc.DB.Update(table->Id, *op, key, ops);
+        } catch (const std::exception& e) {
+            throw yexception() << "Failed to update table " << table->Name << " with value " << json << ": " << e.what();
+        }
+    }
+
+} // anonymous namespace
+
 class TRecoveryShard : public TActor<TRecoveryShard>, public TTabletExecutedFlat {
 public:
+    friend class TTxUploadSchema;
+    friend class TTxUploadSnapshot;
+    friend class TTxUploadChangelog;
+
+    ITransaction *CreateTxUploadSchema(TEvSchemaData::TPtr& ev);
+    ITransaction *CreateTxUploadSnapshot(TEvSnapshotData::TPtr& ev);
+    ITransaction *CreateTxUploadChangelog(TEvChangelogData::TPtr& ev);
+
     explicit TRecoveryShard(const TActorId &tablet, TTabletStorageInfo *info)
         : TActor(&TThis::StateWork)
         , TTabletExecutedFlat(info, tablet, new NMiniKQL::TMiniKQLFactory)
@@ -16,7 +326,10 @@ public:
 
     void OnActivateExecutor(const TActorContext &ctx) override {
         SignalTabletActive(ctx);
-        CompleteRestore();
+
+        if (RestoreState == ERestoreState::InProgress) {
+            Send(BackupReader, new TEvReadBackup);
+        }
     }
 
     void OnDetach(const TActorContext &) override {
@@ -27,11 +340,24 @@ public:
         PassAway();
     }
 
+    void PassAway() override {
+        if (BackupReader) {
+            Send(BackupReader, new TEvents::TEvPoisonPill);
+        }
+        TActor::PassAway();
+    }
+
     void DefaultSignalTabletActive(const TActorContext &) override {}
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvRestoreBackup, Handle);
+            hFunc(TEvBackupReaderResult, Handle);
+            hFunc(TEvBackupInfo, Handle);
+
+            hFunc(TEvSchemaData, Handle);
+            hFunc(TEvSnapshotData, Handle);
+            hFunc(TEvChangelogData, Handle);
             default:
                 HandleDefaultEvents(ev, SelfId());
         }
@@ -43,23 +369,54 @@ public:
         }
     }
 
-    void StartRestore(const TString& backupPath, TActorId subscriber = {}) {
-        RestoreState = ERestoreState::InProgress;
-        TotalBytes = 1;
+    void Handle(TEvBackupReaderResult::TPtr& ev) {
+        const auto* msg = ev->Get();
+        CompleteRestore(msg->Success, msg->Error);
+    }
 
-        BackupPath = backupPath;
-        RestoreSubscriber = subscriber;
+    void Handle(TEvBackupInfo::TPtr& ev) {
+        TotalBytes = ev->Get()->TotalBytes;
 
         using EMode = TEvTablet::TEvCompleteRecoveryBoot::EMode;
         Send(Tablet(), new TEvTablet::TEvCompleteRecoveryBoot(EMode::WipeAllData));
     }
 
-    void CompleteRestore() {
-        RestoreState = ERestoreState::Done;
-        RestoredBytes = 1;
+    void Handle(TEvSchemaData::TPtr& ev) {
+        Execute(CreateTxUploadSchema(ev));
+    }
+
+    void Handle(TEvSnapshotData::TPtr& ev) {
+        Execute(CreateTxUploadSnapshot(ev));
+    }
+
+    void Handle(TEvChangelogData::TPtr& ev) {
+        Execute(CreateTxUploadChangelog(ev));
+    }
+
+    void StartRestore(const TString& backupPath, TActorId subscriber = {}) {
+        RestoreState = ERestoreState::InProgress;
+
+        BackupPath = backupPath;
+        RestoreSubscriber = subscriber;
+
+        BackupReader = Register(CreateBackupReader(SelfId(), backupPath), TMailboxType::HTSwap, AppData()->IOPoolId);
+    }
+
+    void CompleteRestore(bool success, const TString& error) {
+        if (success) {
+            if (!error) {
+                RestoreState = ERestoreState::Done;
+            } else {
+                RestoreState = ERestoreState::DoneWithWarning;
+                Error = error;
+            }
+        } else {
+            RestoreState = ERestoreState::Error;
+            Error = error;
+        }
 
         if (RestoreSubscriber) {
-            Send(RestoreSubscriber, new TEvRestoreCompleted(true));
+            Send(RestoreSubscriber, new TEvRestoreCompleted(success, error));
         }
     }
 
@@ -173,22 +530,24 @@ public:
                     if (RestoreState != ERestoreState::NotStarted) {
                         if (RestoreState == ERestoreState::InProgress) {
                             Info(str, TStringBuilder() << "Restoring from " << BackupPath.GetPath().Quote());
+
+                            double p = TotalBytes != 0 ? (100.0 * ProcessedBytes / TotalBytes) : 0;
+                            DIV_CLASS_ID("progress", "restoreProgress") {
+                                TAG_CLASS_STYLE(TDiv, "progress-bar progress-bar-info", TStringBuilder() << "width:" << p << "%;") {
+                                    str << Sprintf("%.2f%%", p);
+                                }
+                            }
+
+                            TAG_ATTRS(TDiv, {{"id", "restoreDetails"}}) {
+                                str << "Processed Bytes: " << ProcessedBytes
+                                    << " / Total Bytes: " << TotalBytes;
+                            }
                         } else if (RestoreState == ERestoreState::Done) {
                             Success(str, TStringBuilder() << "Restore from " << BackupPath.GetPath().Quote() << " completed successfully");
                         } else if (RestoreState == ERestoreState::Error) {
-                            Danger(str, TStringBuilder() << "Restore from " << BackupPath.GetPath().Quote() << " failed: " << Error);
-                        }
-
-                        double p = TotalBytes != 0 ? (100.0 * RestoredBytes / TotalBytes) : 0;
-                        DIV_CLASS_ID("progress", "restoreProgress") {
-                            TAG_CLASS_STYLE(TDiv, "progress-bar progress-bar-info", TStringBuilder() << "width:" << p << "%;") {
-                                str << Sprintf("%.2f%%", p);
-                            }
-                        }
-
-                        TAG_ATTRS(TDiv, {{"id", "restoreDetails"}}) {
-                            str << "Restored Bytes: " << RestoredBytes
-                                << " / Total Bytes: " << TotalBytes;
+                            Danger(str, TStringBuilder() << "Restore from " << BackupPath.GetPath().Quote() << " failed: " << Error << ". Restart tablet to try again.");
+                        } else if (RestoreState == ERestoreState::DoneWithWarning) {
+                            Warning(str, TStringBuilder() << "Restore from " << BackupPath.GetPath().Quote() << " completed, but changelog is not fully restored: " << Error << ". Restart tablet to try again.");
                         }
                     }
 
@@ -233,14 +592,367 @@ private:
     ERestoreState RestoreState = ERestoreState::NotStarted;
     TString Error;
 
-    ui64 RestoredBytes = 0;
+    TActorId BackupReader;
+    ui64 ProcessedBytes = 0;
     ui64 TotalBytes = 0;
 
     TActorId RestoreSubscriber; // only for tests
 }; // TRecoveryShard
 
+class TTxUploadSchema : public TTransactionBase<TRecoveryShard> {
+public:
+    TTxUploadSchema(TRecoveryShard* self, TEvSchemaData::TPtr& schema)
+        : TBase(self)
+        , Schema(schema)
+    {}
+
+    bool Execute(TTransactionContext &txc, const TActorContext&) override {
+        try {
+            NTable::TSchemeChanges protoSchema;
+            NProtobufJson::Json2Proto(Schema->Get()->Data, protoSchema, {
+                .FieldNameMode = NProtobufJson::TJson2ProtoConfig::FieldNameSnakeCaseDense,
+                .AllowUnknownFields = false,
+                .MapAsObject = true,
+                .EnumValueMode = NProtobufJson::TJson2ProtoConfig::EnumSnakeCaseInsensitive,
+            });
+
+            txc.DB.Alter().Merge(protoSchema);
+        } catch (const yexception& e) {
+            Error = e.what();
+        }
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        if (Error) {
+            Self->CompleteRestore(false, Error);
+            ctx.Send(Schema->Sender, new TEvDataAck(false, Error));
+        } else {
+            Self->ProcessedBytes += Schema->Get()->Data.size();
+            ctx.Send(Schema->Sender, new TEvDataAck(true));
+        }
+    }
+private:
+    TEvSchemaData::TPtr Schema;
+    TString Error;
+}; // TTxUploadSchema
+
+class TTxUploadSnapshot : public TTransactionBase<TRecoveryShard> {
+public:
+    TTxUploadSnapshot(TRecoveryShard* self, TEvSnapshotData::TPtr& snapshot)
+        : TBase(self)
+        , Snapshot(snapshot)
+        , Pool(1_MB)
+    {}
+
+    bool Execute(TTransactionContext &txc, const TActorContext&) override {
+        auto it = txc.DB.GetScheme().TableNames.find(Snapshot->Get()->TableName);
+        if (it == txc.DB.GetScheme().TableNames.end()) {
+            Error = TStringBuilder() << "Table " << Snapshot->Get()->TableName << " not found in database schema";
+            return true;
+        }
+
+        const auto& table = txc.DB.GetScheme().Tables.at(it->second);
+
+        for (const auto& line : Snapshot->Get()->Lines) {
+            NJson::TJsonValue json;
+            NJson::ReadJsonTree(line, &json);
+
+            try {
+                UploadData(json, &table, NTable::ERowOp::Upsert, Pool, txc);
+            } catch (const std::exception& e) {
+                Error = TStringBuilder() << "Failed to upload snapshot data: " << e.what() << ", line: " << line;
+                return true;
+            }
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        if (Error) {
+            Self->CompleteRestore(false, Error);
+            ctx.Send(Snapshot->Sender, new TEvDataAck(false, Error));
+        } else {
+            Self->ProcessedBytes += Snapshot->Get()->Size;
+            ctx.Send(Snapshot->Sender, new TEvDataAck(true));
+        }
+    }
+private:
+    TEvSnapshotData::TPtr Snapshot;
+    TString Error;
+    TMemoryPool Pool;
+}; // TTxUploadSnapshot
+
+class TTxUploadChangelog : public TTransactionBase<TRecoveryShard> {
+public:
+    TTxUploadChangelog(TRecoveryShard* self, TEvChangelogData::TPtr& changelog)
+        : TBase(self)
+        , Changelog(changelog)
+        , Pool(1_MB)
+    {}
+
+    bool Execute(TTransactionContext &txc, const TActorContext&) override {
+        for (const auto& line : Changelog->Get()->Lines) {
+            NJson::TJsonValue json;
+
+            try {
+                NJson::ReadJsonTree(line, &json);
+            } catch (const std::exception& e) {
+                Error = TStringBuilder() << "Failed to parse changelog line: " << e.what();
+                return true;
+            }
+
+            if (!json.IsMap()) {
+                Error = TStringBuilder() << "Invalid JSON format in changelog line: " << line;
+                return true;
+            }
+
+            if (json.Has("schema_changes")) {
+                auto changesJson = json["schema_changes"];
+                if (!changesJson.IsArray()) {
+                    Error = TStringBuilder() << "Invalid schema changes format in changelog line: " << line;
+                    return true;
+                }
+
+                const auto& changesArray = changesJson.GetArray();
+                try {
+                    NTable::TSchemeChanges protoSchema;
+
+                    for (const auto& change : changesArray) {
+                        NProtobufJson::Json2Proto(change, *protoSchema.AddDelta(), {
+                            .FieldNameMode = NProtobufJson::TJson2ProtoConfig::FieldNameSnakeCaseDense,
+                            .AllowUnknownFields = false,
+                            .MapAsObject = true,
+                            .EnumValueMode = NProtobufJson::TJson2ProtoConfig::EnumSnakeCaseInsensitive,
+                        });
+                    }
+
+                    txc.DB.Alter().Merge(protoSchema);
+                } catch (const yexception& e) {
+                    Error = TStringBuilder() << "Failed to upload changelog schema: " << e.what() << ", line: " << line;
+                    return true;
+                }
+            }
+
+            if (json.Has("data_changes")) {
+                auto changesJson = json["data_changes"];
+                if (!changesJson.IsArray()) {
+                    Error = TStringBuilder() << "Invalid data changes format in changelog line: " << line;
+                    return true;
+                }
+
+                const auto& changesArray = changesJson.GetArray();
+                try {
+                    for (const auto& change : changesArray) {
+                        UploadData(change, nullptr, std::nullopt, Pool, txc);
+                    }
+                } catch (const std::exception& e) {
+                    Error = TStringBuilder() << "Failed to upload changelog data: " << e.what() << ", line: " << line;
+                    return true;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        if (Error) {
+            Self->CompleteRestore(true, Error); // changelog errors are warnings
+            ctx.Send(Changelog->Sender, new TEvDataAck(false, Error));
+        } else {
+            Self->ProcessedBytes += Changelog->Get()->Size;
+            ctx.Send(Changelog->Sender, new TEvDataAck(true));
+        }
+    }
+private:
+    TEvChangelogData::TPtr Changelog;
+    TString Error;
+    TMemoryPool Pool;
+}; // TTxUploadChangelog
+
+ITransaction* TRecoveryShard::CreateTxUploadSchema(TEvSchemaData::TPtr& ev) {
+    return new TTxUploadSchema(this, ev);
+}
+
+ITransaction* TRecoveryShard::CreateTxUploadSnapshot(TEvSnapshotData::TPtr& ev) {
+    return new TTxUploadSnapshot(this, ev);
+}
+
+ITransaction* TRecoveryShard::CreateTxUploadChangelog(TEvChangelogData::TPtr& ev) {
+    return new TTxUploadChangelog(this, ev);
+}
+
+class TBackupReader : public TActorBootstrapped<TBackupReader> {
+public:
+    TBackupReader(TActorId owner, const TString& backupPath)
+        : Owner(owner)
+        , BackupPath(backupPath)
+    {}
+
+    void Bootstrap() {
+        auto snapshotDir = BackupPath.Child("snapshot");
+        if (!snapshotDir.Exists()) {
+            return SendResultAndDie(false, TStringBuilder() << "Snapshot dir doesn't exist: " << snapshotDir);
+        }
+
+        auto schemaFile = snapshotDir.Child("schema.json");
+        if (!schemaFile.Exists()) {
+            return SendResultAndDie(false, TStringBuilder() << "Snapshot schema file doesn't exist: " << schemaFile);
+        }
+
+        auto changelogFile = BackupPath.Child("changelog.json");
+        if (!changelogFile.Exists()) {
+            return SendResultAndDie(false, TStringBuilder() << "Changelog file doesn't exist: " << changelogFile);
+        }
+
+        // Calculate total size and collect snapshot files
+        ui64 totalBytes = 0;
+
+        try {
+            TFileStat stat(changelogFile);
+            totalBytes += stat.Size;
+        } catch (const TIoException& e) {
+            return SendResultAndDie(false, TStringBuilder() << "Cannot get size of " << changelogFile << ": " << e.what());
+        }
+
+        TVector<TFsPath> snapshotFiles;
+        snapshotDir.List(snapshotFiles);
+
+        for (const auto& file : snapshotFiles) {
+            if (file.Basename() != "schema.json") {
+                SnapshotFiles.push_back(file);
+            }
+
+            try {
+                TFileStat stat(file);
+                totalBytes += stat.Size;
+            } catch (const TIoException& e) {
+                return SendResultAndDie(false, TStringBuilder() << "Cannot get size of " << file << ": " << e.what());
+            }
+        }
+
+        SchemaFilePath = schemaFile;
+        ChangelogFilePath = changelogFile;
+
+        Send(Owner, new TEvBackupInfo(totalBytes));
+        Become(&TThis::StateWork);
+    }
+
+    STATEFN(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvReadBackup, Handle);
+            hFunc(TEvDataAck, Handle);
+        }
+    }
+
+    void Handle(TEvReadBackup::TPtr&) {
+        try {
+            TString schemaData = TFileInput(SchemaFilePath).ReadAll();
+            Send(Owner, new TEvSchemaData(std::move(schemaData)));
+        } catch (const TIoException& e) {
+            return SendResultAndDie(false, TStringBuilder() << "Failed to read schema file " << SchemaFilePath << ": " << e.what());
+        }
+    }
+
+    void Handle(TEvDataAck::TPtr& ev) {
+        const auto* msg = ev->Get();
+
+        if (!msg->Success) {
+            return PassAway();
+        }
+
+        ProcessNextChunk();
+    }
+
+    void ProcessNextChunk() {
+        // Get current file or open next one
+        if (!CurrentFileInput) {
+            if (!SnapshotFiles.empty()) {
+                CurrentFilePath = SnapshotFiles.front();
+                SnapshotFiles.pop_front();
+
+                CurrentTableName = CurrentFilePath.Basename();
+                // Remove .json extension
+                if (CurrentTableName.EndsWith(".json")) {
+                    CurrentTableName = CurrentTableName.substr(0, CurrentTableName.size() - 5);
+                }
+
+                try {
+                    CurrentFileInput = MakeHolder<TFileInput>(CurrentFilePath, 1_MB);
+                } catch (const TIoException& e) {
+                    return SendResultAndDie(false, TStringBuilder() << "Failed to open snapshot file " << CurrentFilePath << ": " << e.what());
+                }
+            } else if (!ChangelogProcessed) {
+                CurrentFilePath = ChangelogFilePath;
+                CurrentTableName.clear();
+                ChangelogProcessed = true;
+
+                try {
+                    CurrentFileInput = MakeHolder<TFileInput>(CurrentFilePath, 1_MB);
+                } catch (const TIoException& e) {
+                    return SendResultAndDie(false, TStringBuilder() << "Failed to open changelog file " << CurrentFilePath << ": " << e.what());
+                }
+            } else {
+                // All files processed
+                return SendResultAndDie(true);
+            }
+        }
+
+        // Read lines until buffer is full
+        TVector<TString> lines;
+        ui64 linesSize = 0;
+
+        try {
+            TString line;
+            while (linesSize < 1_MB && CurrentFileInput->ReadLine(line)) {
+                linesSize += line.size() + 1; // +1 for \n
+                lines.push_back(std::move(line));
+            }
+        } catch (const TIoException& e) {
+            return SendResultAndDie(false, TStringBuilder() << "Failed to read from file " << CurrentFilePath << ": " << e.what());
+        }
+
+        if (lines.empty()) {
+            // End of file reached
+            CurrentFileInput.Reset();
+            ProcessNextChunk();
+            return;
+        }
+
+        if (CurrentTableName) {
+            Send(Owner, new TEvSnapshotData(CurrentTableName, std::move(lines), linesSize));
+        } else {
+            Send(Owner, new TEvChangelogData(std::move(lines), linesSize));
+        }
+    }
+
+    void SendResultAndDie(bool success, const TString& error = "") {
+        Send(Owner, new TEvBackupReaderResult(success, error));
+        PassAway();
+    }
+
+private:
+    TActorId Owner;
+    TFsPath BackupPath;
+
+    TFsPath SchemaFilePath;
+    TFsPath ChangelogFilePath;
+    TDeque<TFsPath> SnapshotFiles;
+
+    TFsPath CurrentFilePath;
+    TString CurrentTableName;
+    THolder<TFileInput> CurrentFileInput;
+    bool ChangelogProcessed = false;
+}; // TBackupReader
+
 IActor* CreateRecoveryShard(const TActorId &tablet, TTabletStorageInfo *info) {
     return new TRecoveryShard(tablet, info);
+}
+
+IActor* CreateBackupReader(TActorId owner, const TString& backupPath) {
+    return new TBackupReader(owner, backupPath);
 }
 
 } //namespace NKikimr::NTabletFlatExecutor::NRecovery

--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -148,9 +148,9 @@ NTable::ERowOp FindOpFromJson(const NJson::TJsonValue& json) {
     }
 }
 
-void UploadData(const NJson::TJsonValue& json,  const NTable::TScheme::TTableInfo* table,
-                std::optional<NTable::ERowOp> op, TMemoryPool& pool, TTransactionContext &txc) {
-
+void UploadData(const NJson::TJsonValue& json, const NTable::TScheme::TTableInfo* table,
+                std::optional<NTable::ERowOp> op, TMemoryPool& pool, TTransactionContext &txc)
+{
     if (table == nullptr) {
         table = FindTableFromJson(json, txc);
     }
@@ -505,7 +505,7 @@ public:
     enum class EState : ui8 {
         Error,
         PartialDone,
-        Done
+        Done,
     };
 
     void Error(const TString& error) {
@@ -944,8 +944,8 @@ public:
     }
 
 private:
-    TActorId Owner;
-    TFsPath BackupPath;
+    const TActorId Owner;
+    const TFsPath BackupPath;
 
     TFsPath SchemaFilePath;
     TFsPath ChangelogFilePath;

--- a/ydb/core/tablet_flat/flat_executor_recovery.h
+++ b/ydb/core/tablet_flat/flat_executor_recovery.h
@@ -12,6 +12,14 @@ enum EEv {
     EvRestoreBackup = EvBegin + 1792,
     EvRestoreCompleted,
 
+    EvBackupReaderResult,
+    EvBackupInfo,
+    EvReadBackup,
+    EvSchemaData,
+    EvSnapshotData,
+    EvChangelogData,
+    EvDataAck,
+
     EvEnd
 };
 
@@ -35,13 +43,75 @@ struct TEvRestoreCompleted : public TEventLocal<TEvRestoreCompleted, EvRestoreCo
     TString Error;
 };
 
+struct TEvBackupReaderResult : public TEventLocal<TEvBackupReaderResult, EvBackupReaderResult> {
+    TEvBackupReaderResult(bool success, const TString& error = "")
+        : Success(success)
+        , Error(error)
+    {}
+
+    bool Success = false;
+    TString Error;
+};
+
+struct TEvBackupInfo : public TEventLocal<TEvBackupInfo, EvBackupInfo> {
+    TEvBackupInfo(ui64 totalBytes)
+        : TotalBytes(totalBytes)
+    {}
+
+    ui64 TotalBytes = 0;
+};
+
+struct TEvReadBackup : public TEventLocal<TEvReadBackup, EvReadBackup> {};
+
+struct TEvSchemaData : public TEventLocal<TEvSchemaData, EvSchemaData> {
+    TEvSchemaData(const TString&& data)
+        : Data(std::move(data))
+    {}
+
+    TString Data;
+};
+
+struct TEvSnapshotData : public TEventLocal<TEvSnapshotData, EvSnapshotData> {
+    TEvSnapshotData(const TString& tableName, TVector<TString>&& lines, ui64 size)
+        : TableName(tableName)
+        , Lines(std::move(lines))
+        , Size(size)
+    {}
+
+    TString TableName;
+    TVector<TString> Lines;
+    ui64 Size = 0;
+};
+
+struct TEvChangelogData : public TEventLocal<TEvChangelogData, EvChangelogData> {
+    TEvChangelogData(TVector<TString>&& lines, ui64 size)
+        : Lines(std::move(lines))
+        , Size(size)
+    {}
+
+    TVector<TString> Lines;
+    ui64 Size = 0;
+};
+
+struct TEvDataAck : public TEventLocal<TEvDataAck, EvDataAck> {
+    TEvDataAck(bool success, const TString& error = "")
+        : Success(success)
+        , Error(error)
+    {}
+
+    bool Success = false;
+    TString Error;
+};
+
 enum class ERestoreState : ui8 {
     NotStarted,
     InProgress,
     Done,
     Error,
+    DoneWithWarning,
 };
 
 IActor* CreateRecoveryShard(const TActorId &tablet, TTabletStorageInfo *info);
+IActor* CreateBackupReader(TActorId owner, const TString& backupPath);
 
 } // namespace NKikimr::NTabletFlatExecutor::NRecovery

--- a/ydb/core/tablet_flat/flat_executor_recovery.h
+++ b/ydb/core/tablet_flat/flat_executor_recovery.h
@@ -64,7 +64,7 @@ struct TEvBackupInfo : public TEventLocal<TEvBackupInfo, EvBackupInfo> {
 struct TEvReadBackup : public TEventLocal<TEvReadBackup, EvReadBackup> {};
 
 struct TEvSchemaData : public TEventLocal<TEvSchemaData, EvSchemaData> {
-    TEvSchemaData(const TString&& data)
+    TEvSchemaData(TString&& data)
         : Data(std::move(data))
     {}
 

--- a/ydb/core/tablet_flat/flat_executor_recovery.h
+++ b/ydb/core/tablet_flat/flat_executor_recovery.h
@@ -72,25 +72,21 @@ struct TEvSchemaData : public TEventLocal<TEvSchemaData, EvSchemaData> {
 };
 
 struct TEvSnapshotData : public TEventLocal<TEvSnapshotData, EvSnapshotData> {
-    TEvSnapshotData(const TString& tableName, TVector<TString>&& lines, ui64 size)
+    TEvSnapshotData(const TString& tableName, TVector<TString>&& lines)
         : TableName(tableName)
         , Lines(std::move(lines))
-        , Size(size)
     {}
 
     TString TableName;
     TVector<TString> Lines;
-    ui64 Size = 0;
 };
 
 struct TEvChangelogData : public TEventLocal<TEvChangelogData, EvChangelogData> {
-    TEvChangelogData(TVector<TString>&& lines, ui64 size)
+    TEvChangelogData(TVector<TString>&& lines)
         : Lines(std::move(lines))
-        , Size(size)
     {}
 
     TVector<TString> Lines;
-    ui64 Size = 0;
 };
 
 struct TEvDataAck : public TEventLocal<TEvDataAck, EvDataAck> {

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -1448,18 +1448,6 @@ Y_UNIT_TEST_SUITE(Backup) {
         TVector<TFsPath> genDirs;
         tabletIdDir.List(genDirs);
 
-
-        // Check state before and after restore
-        auto assertState = [&env, &data]() {
-            UNIT_ASSERT_VALUES_EQUAL(env.CountRows(), 1'000);
-
-            UNIT_ASSERT_VALUES_EQUAL(env.ReadBinaryValue(0), data);
-            UNIT_ASSERT_VALUES_EQUAL(env.ReadBinaryValue(999), data);
-        };
-
-        assertState();
-        env.RestoreLastBackup(TestTabletFlags);
-        assertState();
         std::sort(genDirs.begin(), genDirs.end(), [](const TFsPath& a, const TFsPath& b) {
             return a.Basename() < b.Basename();
         });
@@ -1472,6 +1460,18 @@ Y_UNIT_TEST_SUITE(Backup) {
         TString content = TFileInput(changelog).ReadAll();
         auto lines = StringSplitter(content).Split('\n').SkipEmpty();
         UNIT_ASSERT_VALUES_EQUAL(lines.Count(), 1'000);
+
+        // Check state before and after restore
+        auto assertState = [&env, &data]() {
+            UNIT_ASSERT_VALUES_EQUAL(env.CountRows(), 1'000);
+
+            UNIT_ASSERT_VALUES_EQUAL(env.ReadBinaryValue(0), data);
+            UNIT_ASSERT_VALUES_EQUAL(env.ReadBinaryValue(999), data);
+        };
+
+        assertState();
+        env.RestoreLastBackup(TestTabletFlags);
+        assertState();
     }
 
     Y_UNIT_TEST(ChangelogSchema) {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds functionality to restore backups from the filesystem in tablet recovery mode. The implementation introduces a new `TBackupReader` actor that reads backup files (schema, snapshot, and changelog) and sends the data to a `TRecoveryShard` which processes and applies the backup through dedicated transactions.

