### PR TITLE
unified syntax for explicit partitioning

### DIFF
--- a/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
@@ -786,6 +786,7 @@ public:
                 }
 
                 if (name == "projection"sv) {
+                    haveProjection = true;
                     TStringBuf projection;
                     if (!ExtractSettingValue(setting.Tail(), "projection"sv, format, {}, ctx, projection)) {
                         return false;
@@ -805,6 +806,7 @@ public:
                 }
 
                 if (name == "projection.enabled"sv) {
+                    haveProjection = true;
                     TStringBuf unused;
                     if (!ExtractSettingValue(setting.Tail(), "projection.enabled"sv, format, {}, ctx, unused)) {
                         return false;

--- a/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
@@ -846,8 +846,8 @@ public:
                     return false;
                 }
 
-                if (partitioningColumns.contains(name)) {
-                    ctx.AddError(TIssue(ctx.GetPosition(setting.Pos()), "Expected projection column parameter to contain partitioned column name"));
+                if (!partitioningColumns.contains(name)) {
+                    ctx.AddError(TIssue(ctx.GetPosition(setting.Pos()), "Expected parameter to contain partitioned column name"));
                     return false;
                 }
 

--- a/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
@@ -655,12 +655,12 @@ public:
                         return false;
                     }
 
+                    THashSet<TStringBuf> uniqs;
                     for (size_t i = 1; i < setting.ChildrenSize(); ++i) {
                         const auto& column = setting.Child(i);
                         if (!EnsureAtom(*column, ctx)) {
                             return false;
                         }
-                        THashSet<TStringBuf> uniqs;
                         if (!uniqs.emplace(column->Content()).second) {
                             ctx.AddError(TIssue(ctx.GetPosition(column->Pos()),
                                 TStringBuilder() << "Duplicate partitioned_by column '" << column->Content() << "'"));

--- a/ydb/library/yql/providers/s3/provider/yql_s3_io_discovery.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_io_discovery.cpp
@@ -705,24 +705,98 @@ private:
                 return false;
             }
 
-            THashSet<TStringBuf> uniqs;
-            for (size_t i = 1; i < partitionedBySetting->ChildrenSize(); ++i) {
-                const auto& column = partitionedBySetting->Child(i);
-                if (!EnsureAtom(*column, ctx)) {
+            if (partitionedBySetting->ChildrenSize() > 2) {
+                THashSet<TStringBuf> uniqs;
+                for (size_t i = 1; i < partitionedBySetting->ChildrenSize(); ++i) {
+                    const auto& column = partitionedBySetting->Child(i);
+                    if (!EnsureAtom(*column, ctx)) {
+                        return false;
+                    }
+                    if (!uniqs.emplace(column->Content()).second) {
+                        ctx.AddError(TIssue(ctx.GetPosition(column->Pos()), TStringBuilder() << "Duplicate partitioned_by column '" << column->Content() << "'"));
+                        return false;
+                    }
+                    partitionedBy.push_back(ToString(column->Content()));
+                }
+            } else {
+                if (!EnsureAtom(partitionedBySetting->Tail(), ctx)) {
                     return false;
                 }
-                if (!uniqs.emplace(column->Content()).second) {
-                    ctx.AddError(TIssue(ctx.GetPosition(column->Pos()), TStringBuilder() << "Duplicate partitioned_by column '" << column->Content() << "'"));
-                    return false;
-                }
-                partitionedBy.push_back(ToString(column->Content()));
 
+                if (partitionedBySetting->Tail().Content().empty()) {
+                    ctx.AddError(TIssue(ctx.GetPosition(partitionedBySetting->Pos()), "Expecting non-empty patitionedby setting"));
+                    return false;
+                }
+
+                std::string partitioningStr;
+                NJson::TJsonValue partitioningJson;
+                TPositionHandle partitioningPos;
+
+                partitioningStr = partitionedBySetting->Tail().Content();
+                partitioningPos = partitionedBySetting->Tail().Pos();
+
+                if (!(partitioningStr.starts_with("[\'") && partitioningStr.ends_with("\']"))) {
+                    partitioningStr = TStringBuilder{} << "[\'" << partitioningStr << "\']";
+                }
+                std::replace(partitioningStr.begin(), partitioningStr.end(), '\'', '\"');
+
+                try {
+                    NJson::ReadJsonTree(partitioningStr, &partitioningJson, /*throwOnError*/ true);
+                } catch (const std::exception& e) {
+                    ctx.AddError(TIssue(ctx.GetPosition(partitionedBySetting->Pos()), "Invalid partitionedby format"));
+                    return false;
+                }
+
+                for (const auto& value : partitioningJson.GetArray()) {
+                    if (!value.IsString()) {
+                        ctx.AddError(TIssue(ctx.GetPosition(partitionedBySetting->Pos()), "Invalid partitionedby format"));
+                        return false;
+                    }
+                    partitionedBy.push_back(value.GetString());
+                }
             }
         }
 
         TString projection;
         TPositionHandle projectionPos;
+        if (auto projectionSetting = GetSetting(settings, "projection.enabled")) {
+            std::vector<TExprNode::TPtr> projectionSettings;
+            for (auto& setting : settings.Children()) {
+                if (setting->ChildrenSize() != 0) {
+                    const TStringBuf settingName = setting->Child(0)->Content();
+                    if (settingName.StartsWith("projection") || settingName == "storage.location.template"sv) {
+                        projectionSettings.push_back(setting);
+                    }
+                }
+            }
+
+            std::vector<TString> projectionDictValues;
+            for (const auto& setting : projectionSettings) {
+                if (!EnsureTupleSize(*setting, 2, ctx)) {
+                    return false;
+                }
+
+                if (!EnsureAtom(setting->Tail(), ctx)) {
+                    return false;
+                }
+
+                if (setting->Tail().Content().empty()) {
+                    ctx.AddError(TIssue(ctx.GetPosition(setting->Pos()), "Expecting non-empty projection setting"));
+                    return false;
+                }
+
+                projectionDictValues.push_back(TStringBuilder{} << "\"" << setting->Head().Content() << "\": \"" << setting->Tail().Content() << "\"");
+            }
+
+            projection = TStringBuilder{} << "{" << JoinSeq(",", projectionDictValues) << "}";
+            projectionPos = projectionSetting->Head().Pos();
+        }
         if (auto projectionSetting = GetSetting(settings, "projection")) {
+            if (!projection.empty()) {
+                ctx.AddError(TIssue(ctx.GetPosition(projectionSetting->Pos()), "Should use both projection synaxis at the same time"));
+                return false;
+            }
+
             if (!EnsureTupleSize(*projectionSetting, 2, ctx)) {
                 return false;
             }

--- a/ydb/library/yql/providers/s3/provider/yql_s3_io_discovery.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_io_discovery.cpp
@@ -735,8 +735,8 @@ private:
                 partitioningStr = partitionedBySetting->Tail().Content();
                 partitioningPos = partitionedBySetting->Tail().Pos();
 
-                if (!(partitioningStr.starts_with("[\'") && partitioningStr.ends_with("\']"))) {
-                    partitioningStr = TStringBuilder{} << "[\'" << partitioningStr << "\']";
+                if (!(partitioningStr.starts_with("['") && partitioningStr.ends_with("']"))) {
+                    partitioningStr = TStringBuilder{} << "['" << partitioningStr << "']";
                 }
                 std::replace(partitioningStr.begin(), partitioningStr.end(), '\'', '\"');
 
@@ -744,7 +744,7 @@ private:
                 try {
                     NJson::ReadJsonTree(partitioningStr, &partitioningJson, /*throwOnError*/ true);
                 } catch (const std::exception& e) {
-                    ctx.AddError(TIssue(ctx.GetPosition(partitionedBySetting->Pos()), "partitioned_by is not a json"));
+                    ctx.AddError(TIssue(ctx.GetPosition(partitionedBySetting->Pos()), TStringBuilder() << "Failed to parse partitioned_by as JSON: " << e.what()));
                     ctx.AddWarning(TIssue(ctx.GetPosition(partitionedBySetting->Pos()), formattingTip));
                     return false;
                 }

--- a/ydb/tests/fq/s3/test_explicit_partitioning_1.py
+++ b/ydb/tests/fq/s3/test_explicit_partitioning_1.py
@@ -687,7 +687,7 @@ text3''',
 
     @yq_all
     @pytest.mark.parametrize("client", [{"folder_id": "my_folder"}], indirect=True)
-    def test_valid_new_syntaxis(self, kikimr, s3, client, yq_version, unique_prefix):
+    def test_valid_new_syntax(self, kikimr, s3, client, yq_version, unique_prefix):
         resource = boto3.resource(
             "s3", endpoint_url=s3.s3_url, aws_access_key_id="key", aws_secret_access_key="secret_key"
         )

--- a/ydb/tests/fq/s3/test_explicit_partitioning_1.py
+++ b/ydb/tests/fq/s3/test_explicit_partitioning_1.py
@@ -684,3 +684,101 @@ text3''',
         assert result_set.rows[0].items[0].bytes_value == b"text2"
         assert result_set.rows[0].items[1].int32_value == 2
         assert result_set.rows[0].items[2].int32_value == 2024
+
+    @yq_all
+    @pytest.mark.parametrize("client", [{"folder_id": "my_folder"}], indirect=True)
+    def test_valid_new_syntaxis(self, kikimr, s3, client, yq_version, unique_prefix):
+        resource = boto3.resource(
+            "s3", endpoint_url=s3.s3_url, aws_access_key_id="key", aws_secret_access_key="secret_key"
+        )
+
+        bucket = resource.Bucket("bucket")
+        bucket.create(ACL='public-read')
+
+        s3_client = boto3.client(
+            "s3", endpoint_url=s3.s3_url, aws_access_key_id="key", aws_secret_access_key="secret_key"
+        )
+
+        s3_client.put_object(
+            Body='''data
+text1''',
+            Bucket='bucket',
+            Key='2024/01/file.txt',
+            ContentType='text/plain',
+        )
+        s3_client.put_object(
+            Body='''data
+text2''',
+            Bucket='bucket',
+            Key='2024/02/file.txt',
+            ContentType='text/plain',
+        )
+        s3_client.put_object(
+            Body='''data
+text3''',
+            Bucket='bucket',
+            Key='2025/01/file.txt',
+            ContentType='text/plain',
+        )
+
+        kikimr.control_plane.wait_bootstrap(1)
+        storage_connection_name = unique_prefix + "bucket"
+        client.create_storage_connection(storage_connection_name, "bucket")
+
+        sql = (
+            f'''
+            SELECT
+                *
+            FROM
+                `{storage_connection_name}`.`/`
+            WITH
+            (
+                format=csv_with_names,
+                schema=(
+                    data String NOT NULL,
+                    year Int NOT NULL,
+                    month Int NOT NULL,
+                ),
+                partitioned_by="['year', 'month']",
+            '''
+            + R'''
+                `projection.enabled` = "true",
+
+                `projection.year.type` = "integer",
+                `projection.year.min` = "2024",
+                `projection.year.max` = "2025",
+                `projection.year.interval` = "1",
+
+                `projection.month.type` = "integer",
+                `projection.month.min` = "1",
+                `projection.month.max` = "2",
+                `projection.month.interval` = "1",
+                `projection.month.digits` = "2",
+
+                `storage.location.template` = "${year}/${month}"
+            )
+            WHERE data ILIKE '%text2%';
+        '''
+        )
+
+        query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
+        client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
+
+        describe_result = client.describe_query(query_id).result
+        logging.info("AST: {}".format(describe_result.query.ast.data))
+
+        data = client.get_result_data(query_id)
+        result_set = data.result.result_set
+        logging.debug(str(result_set))
+
+        assert len(result_set.columns) == 3
+        assert result_set.columns[0].name == "data"
+        assert result_set.columns[0].type.type_id == ydb.Type.STRING
+        assert result_set.columns[1].name == "month"
+        assert result_set.columns[1].type.type_id == ydb.Type.INT32
+        assert result_set.columns[2].name == "year"
+        assert result_set.columns[2].type.type_id == ydb.Type.INT32
+        assert len(result_set.rows) == 1
+        assert result_set.rows[0].items[0].bytes_value == b"text2"
+        assert result_set.rows[0].items[1].int32_value == 2
+        assert result_set.rows[0].items[2].int32_value == 2024


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

syntax for object storage explicit partitioning is now uniform for both reading data with external data sources and creating external tables

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
