### PR TITLE
Brute force KNN vector search pushdown

### DIFF
--- a/ydb/core/base/kmeans_clusters.cpp
+++ b/ydb/core/base/kmeans_clusters.cpp
@@ -502,9 +502,9 @@ std::unique_ptr<IClusters> CreateClustersAutoDetect(Ydb::Table::VectorIndexSetti
                 error = "Target vector too short for bit type";
                 return nullptr;
             }
-            // For bit vectors: size = ceil(dim/8) + 1 (padding info) + 1 (format byte)
-            // padding = targetVector[size - 2], actual bits = (size - 2) * 8 - padding
-            settings.set_vector_dimension((targetVector.size() - 2) * 8 - static_cast<ui8>(targetVector[targetVector.size() - 2]));
+            // For bit vectors: size = HeaderLen + ceil(dim/8) + 1 (padding info) + 1 (format byte)
+            // padding = targetVector[size - 2], actual bits = (targetVector.size() - HeaderLen - 1) * 8 - padding
+            settings.set_vector_dimension((targetVector.size() - HeaderLen - 1) * 8 - static_cast<ui8>(targetVector[targetVector.size() - 2]));
             break;
         default:
             error = TStringBuilder() << "Unknown vector format byte: " << static_cast<int>(formatByte);

--- a/ydb/core/base/kmeans_clusters.h
+++ b/ydb/core/base/kmeans_clusters.h
@@ -47,6 +47,9 @@ public:
 
 std::unique_ptr<IClusters> CreateClusters(const Ydb::Table::VectorIndexSettings& settings, ui32 maxRounds, TString& error);
 
+// Auto-detect vector type and dimension from target vector when settings have dimension=0
+std::unique_ptr<IClusters> CreateClustersAutoDetect(Ydb::Table::VectorIndexSettings settings, const TStringBuf& targetVector, ui32 maxRounds, TString& error);
+
 bool ValidateSettings(const Ydb::Table::VectorIndexSettings& settings, TString& error);
 bool ValidateSettings(const Ydb::Table::KMeansTreeSettings& settings, TString& error);
 bool FillSetting(Ydb::Table::KMeansTreeSettings& settings, const TString& name, const TString& value, TString& error);

--- a/ydb/core/kqp/common/kqp_yql.cpp
+++ b/ydb/core/kqp/common/kqp_yql.cpp
@@ -182,7 +182,18 @@ TKqpReadTableSettings ParseInternal(const TCoNameValueTupleList& node) {
             for(const auto& kv: lv) {
                 settings.IndexSelectionInfo.emplace(kv.Name().Value(), kv.Value().Cast<TCoAtom>().Value());
             }
-
+        } else if (name == TKqpReadTableSettings::VectorTopKColumnSettingName) {
+            YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
+            settings.VectorTopKColumn = tuple.Value().Cast<TCoAtom>().Value();
+        } else if (name == TKqpReadTableSettings::VectorTopKMetricSettingName) {
+            YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
+            settings.VectorTopKMetric = tuple.Value().Cast<TCoAtom>().Value();
+        } else if (name == TKqpReadTableSettings::VectorTopKTargetSettingName) {
+            YQL_ENSURE(tuple.Value().IsValid());
+            settings.VectorTopKTarget = tuple.Value().Cast().Ptr();
+        } else if (name == TKqpReadTableSettings::VectorTopKLimitSettingName) {
+            YQL_ENSURE(tuple.Value().IsValid());
+            settings.VectorTopKLimit = tuple.Value().Cast().Ptr();
         } else {
             YQL_ENSURE(false, "Unknown KqpReadTable setting name '" << name << "'");
         }
@@ -314,6 +325,38 @@ NNodes::TCoNameValueTupleList TKqpReadTableSettings::BuildNode(TExprContext& ctx
                 .Value<TCoNameValueTupleList>()
                     .Add(isi)
                     .Build()
+                .Done());
+    }
+
+    if (VectorTopKColumn) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name().Build(VectorTopKColumnSettingName)
+                .Value<TCoAtom>().Build(VectorTopKColumn)
+                .Done());
+    }
+
+    if (VectorTopKMetric) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name().Build(VectorTopKMetricSettingName)
+                .Value<TCoAtom>().Build(VectorTopKMetric)
+                .Done());
+    }
+
+    if (VectorTopKTarget) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name().Build(VectorTopKTargetSettingName)
+                .Value(VectorTopKTarget)
+                .Done());
+    }
+
+    if (VectorTopKLimit) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name().Build(VectorTopKLimitSettingName)
+                .Value(VectorTopKLimit)
                 .Done());
     }
 

--- a/ydb/core/kqp/common/kqp_yql.h
+++ b/ydb/core/kqp/common/kqp_yql.h
@@ -130,6 +130,10 @@ public:
     static constexpr TStringBuf TabletIdName = "TabletId";
     static constexpr TStringBuf PointPrefixLenSettingName = "PointPrefixLen";
     static constexpr TStringBuf IndexSelectionDebugInfoSettingName = "IndexSelectionDebugInfo";
+    static constexpr TStringBuf VectorTopKColumnSettingName = "VectorTopKColumn";
+    static constexpr TStringBuf VectorTopKMetricSettingName = "VectorTopKMetric";
+    static constexpr TStringBuf VectorTopKTargetSettingName = "VectorTopKTarget";
+    static constexpr TStringBuf VectorTopKLimitSettingName = "VectorTopKLimit";
 
     TVector<TString> SkipNullKeys;
     TExprNode::TPtr ItemsLimit;
@@ -138,6 +142,12 @@ public:
     bool ForcePrimary = false;
     ui64 PointPrefixLen = 0;
     THashMap<TString, TString> IndexSelectionInfo;
+
+    // Vector top-K pushdown settings for brute force vector search
+    TString VectorTopKColumn;
+    TString VectorTopKMetric;
+    TExprNode::TPtr VectorTopKTarget;
+    TExprNode::TPtr VectorTopKLimit;
 
     void AddSkipNullKey(const TString& key);
     void SetItemsLimit(const TExprNode::TPtr& expr) { ItemsLimit = expr; }

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -2670,6 +2670,16 @@ TMaybe<size_t> TKqpTasksGraph::BuildScanTasksFromSource(TStageInfo& stageInfo, b
             settings->SetItemsLimit(itemsLimit);
         }
 
+        if (source.HasVectorTopK()) {
+            const auto& in = source.GetVectorTopK();
+            auto& out = *settings->MutableVectorTopK();
+            out.SetColumn(in.GetColumn());
+            *out.MutableSettings() = in.GetSettings();
+            auto target = ExtractPhyValue(stageInfo, in.GetTargetVector(), TxAlloc->HolderFactory, TxAlloc->TypeEnv, NUdf::TUnboxedValuePod());
+            out.SetTargetVector(TString(target.AsStringRef()));
+            out.SetLimit((ui32)ExtractPhyValue(stageInfo, in.GetLimit(), TxAlloc->HolderFactory, TxAlloc->TypeEnv, NUdf::TUnboxedValuePod()).Get<ui64>());
+        }
+
         auto& lockTxId = GetMeta().LockTxId;
         if (lockTxId) {
             settings->SetLockTxId(*lockTxId);

--- a/ydb/core/kqp/opt/kqp_opt_build_txs.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_build_txs.cpp
@@ -378,20 +378,26 @@ private:
             return parameter;
         };
 
+        // Helper to collect TKqpTxResultBinding nodes and replace them with parameters
         TNodeOnNodeOwnedMap sourceReplaceMap;
+        auto collectBindings = [&](const TExprNode::TPtr& root) {
+            VisitExpr(root,
+                [&](const TExprNode::TPtr& node) {
+                    TExprBase expr(node);
+                    if (auto binding = expr.Maybe<TKqpTxResultBinding>()) {
+                        sourceReplaceMap.emplace(node.Get(), makeParameterBinding(binding.Cast(), node->Pos()).Ptr());
+                    }
+                    return true;
+                });
+        };
+
         for (ui32 i = 0; i < stage.Inputs().Size(); ++i) {
             const auto& input = stage.Inputs().Item(i);
             const auto& inputArg = stage.Program().Args().Arg(i);
 
+            // Scan inputs that may contain TKqpTxResultBinding
             if (input.Maybe<TDqSource>() || input.Maybe<TKqpCnStreamLookup>()) {
-                VisitExpr(input.Ptr(),
-                    [&](const TExprNode::TPtr& node) {
-                        TExprBase expr(node);
-                        if (auto binding = expr.Maybe<TKqpTxResultBinding>()) {
-                            sourceReplaceMap.emplace(node.Get(), makeParameterBinding(binding.Cast(), node->Pos()).Ptr());
-                        }
-                        return true;
-                    });
+                collectBindings(input.Ptr());
             }
 
             auto maybeBinding = input.Maybe<TKqpTxResultBinding>();
@@ -407,15 +413,8 @@ private:
             argsMap.emplace(inputArg.Raw(), makeParameterBinding(maybeBinding.Cast(), input.Pos()).Ptr());
         }
 
-        // Also scan the program body for TKqpTxResultBinding (for VectorTopK precompute settings)
-        VisitExpr(stage.Program().Body().Ptr(),
-            [&](const TExprNode::TPtr& node) {
-                TExprBase expr(node);
-                if (auto binding = expr.Maybe<TKqpTxResultBinding>()) {
-                    sourceReplaceMap.emplace(node.Get(), makeParameterBinding(binding.Cast(), node->Pos()).Ptr());
-                }
-                return true;
-            });
+        // Scan program body for TKqpTxResultBinding (e.g. in TKqpReadTableRanges VectorTopK settings)
+        collectBindings(stage.Program().Body().Ptr());
 
         auto inputs = Build<TExprList>(ctx, stage.Pos())
             .Add(newInputs)
@@ -473,45 +472,38 @@ private:
 
 TVector<TDqPhyPrecompute> PrecomputeInputs(const TDqStage& stage) {
     TVector<TDqPhyPrecompute> result;
+
+    // Helper to collect precomputes from an expression tree
+    auto collectPrecomputes = [&result](const TExprNode::TPtr& root, bool checkConnections = false) {
+        VisitExpr(root,
+            [&](const TExprNode::TPtr& ptr) {
+                TExprBase node(ptr);
+                if (auto maybePrecompute = node.Maybe<TDqPhyPrecompute>()) {
+                    result.push_back(maybePrecompute.Cast());
+                    return false;
+                }
+                if (checkConnections) {
+                    if (auto maybeConnection = node.Maybe<TDqConnection>()) {
+                        YQL_ENSURE(false, "unexpected connection in source");
+                    }
+                }
+                return true;
+            });
+    };
+
+    // Scan stage inputs for precomputes
     for (const auto& input : stage.Inputs()) {
         if (auto maybePrecompute = input.Maybe<TDqPhyPrecompute>()) {
             result.push_back(maybePrecompute.Cast());
         } else if (auto maybeSource = input.Maybe<TDqSource>()) {
-            VisitExpr(maybeSource.Cast().Ptr(),
-                  [&] (const TExprNode::TPtr& ptr) {
-                    TExprBase node(ptr);
-                    if (auto maybePrecompute = node.Maybe<TDqPhyPrecompute>()) {
-                        result.push_back(maybePrecompute.Cast());
-                        return false;
-                    }
-                    if (auto maybeConnection = node.Maybe<TDqConnection>()) {
-                        YQL_ENSURE(false, "unexpected connection in source");
-                    }
-                    return true;
-                  });
+            collectPrecomputes(maybeSource.Cast().Ptr(), /* checkConnections */ true);
         } else if (auto maybeStreamLookup = input.Maybe<TKqpCnStreamLookup>()) {
-            VisitExpr(maybeStreamLookup.Cast().Settings().Ptr(),
-                  [&] (const TExprNode::TPtr& ptr) {
-                    TExprBase node(ptr);
-                    if (auto maybePrecompute = node.Maybe<TDqPhyPrecompute>()) {
-                        result.push_back(maybePrecompute.Cast());
-                        return false;
-                    }
-                    return true;
-                  });
+            collectPrecomputes(maybeStreamLookup.Cast().Settings().Ptr());
         }
     }
 
-    // Also scan the program body for precomputes in read settings (for VectorTopK pushdown)
-    VisitExpr(stage.Program().Body().Ptr(),
-          [&] (const TExprNode::TPtr& ptr) {
-            TExprBase node(ptr);
-            if (auto maybePrecompute = node.Maybe<TDqPhyPrecompute>()) {
-                result.push_back(maybePrecompute.Cast());
-                return false;
-            }
-            return true;
-          });
+    // Scan program body for precomputes (e.g. in TKqpReadTableRanges VectorTopK settings)
+    collectPrecomputes(stage.Program().Body().Ptr());
 
     return result;
 }

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy.cpp
@@ -46,6 +46,7 @@ public:
         AddHandler(0, &TCoTake::Match, HNDL(ApplyLimitToReadTable));
         AddHandler(0, &TCoTopSort::Match, HNDL(ApplyLimitToOlapReadTable));
         AddHandler(0, &TCoTopSort::Match, HNDL(ApplyVectorTopKToReadTable));
+        AddHandler(0, &TDqStage::Match, HNDL(ApplyVectorTopKToStageWithSource));
         AddHandler(0, &TCoFlatMap::Match, HNDL(PushOlapFilter));
         AddHandler(0, &TCoFlatMap::Match, HNDL(PushOlapProjections));
         AddHandler(0, &TCoAggregateCombine::Match, HNDL(PushAggregateCombineToStage));
@@ -264,6 +265,12 @@ protected:
     TMaybeNode<TExprBase> ApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx) {
         TExprBase output = KqpApplyVectorTopKToReadTable(node, ctx, KqpCtx);
         DumpAppliedRule("ApplyVectorTopKToReadTable", node.Ptr(), output.Ptr(), ctx);
+        return output;
+    }
+
+    TMaybeNode<TExprBase> ApplyVectorTopKToStageWithSource(TExprBase node, TExprContext& ctx) {
+        TExprBase output = KqpApplyVectorTopKToStageWithSource(node, ctx, KqpCtx);
+        DumpAppliedRule("ApplyVectorTopKToStageWithSource", node.Ptr(), output.Ptr(), ctx);
         return output;
     }
 

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy.cpp
@@ -45,6 +45,7 @@ public:
         AddHandler(0, IsSort, HNDL(RemoveRedundantSortOverReadTable));
         AddHandler(0, &TCoTake::Match, HNDL(ApplyLimitToReadTable));
         AddHandler(0, &TCoTopSort::Match, HNDL(ApplyLimitToOlapReadTable));
+        AddHandler(0, &TCoTopSort::Match, HNDL(ApplyVectorTopKToReadTable));
         AddHandler(0, &TCoFlatMap::Match, HNDL(PushOlapFilter));
         AddHandler(0, &TCoFlatMap::Match, HNDL(PushOlapProjections));
         AddHandler(0, &TCoAggregateCombine::Match, HNDL(PushAggregateCombineToStage));
@@ -206,7 +207,7 @@ protected:
         else {
             TExprBase output = KqpBuildStreamIdxLookupJoinStagesKeepSorted(node, ctx, TypesCtx, true);
             DumpAppliedRule("BuildStreamIdxLookupJoinStagesKeepSorted", node.Ptr(), output.Ptr(), ctx);
-            return output;   
+            return output;
         }
     }
 
@@ -257,6 +258,12 @@ protected:
     TMaybeNode<TExprBase> ApplyLimitToOlapReadTable(TExprBase node, TExprContext& ctx) {
         TExprBase output = KqpApplyLimitToOlapReadTable(node, ctx, KqpCtx);
         DumpAppliedRule("ApplyLimitToOlapReadTable", node.Ptr(), output.Ptr(), ctx);
+        return output;
+    }
+
+    TMaybeNode<TExprBase> ApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx) {
+        TExprBase output = KqpApplyVectorTopKToReadTable(node, ctx, KqpCtx);
+        DumpAppliedRule("ApplyVectorTopKToReadTable", node.Ptr(), output.Ptr(), ctx);
         return output;
     }
 

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_impl.h
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_impl.h
@@ -19,6 +19,8 @@ NYql::NNodes::TMaybeNode<NYql::NNodes::TDqPhyPrecompute> BuildLookupKeysPrecompu
 NYql::NNodes::TCoAtomList BuildColumnsList(const THashSet<TStringBuf>& columns, NYql::TPositionHandle pos,
     NYql::TExprContext& ctx);
 
+NYql::NNodes::TExprBase KqpPrecomputeParameter(NYql::NNodes::TExprBase param, NYql::TExprContext& ctx);
+
 NYql::NNodes::TCoAtomList BuildColumnsList(const TVector<TStringBuf>& columns, NYql::TPositionHandle pos,
     NYql::TExprContext& ctx);
 

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
@@ -192,35 +192,30 @@ namespace {
 
 // Helper function to extract info from a Knn::*Distance Apply node
 // argSubstitutions maps lambda arguments to their corresponding input expressions
-// Returns: {column name, method name, target expression} or nullopt if not a valid Knn distance call
-TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceFromApply(
+// Returns: vector of {column name, method name, target expression} for all possible interpretations
+// For subquery cases, both arguments might be Members, so we return all possibilities
+TVector<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceFromApplyAll(
     const TCoApply& apply,
     const TNodeMap<TExprNode::TPtr>& argSubstitutions = {}) {
+    TVector<std::tuple<TString, TString, TExprNode::TPtr>> result;
+
     auto udf = apply.Callable().Maybe<TCoUdf>();
     if (!udf) {
-        return {};
+        return result;
     }
 
     const auto methodName = TString(udf.Cast().MethodName().Value());
     if (!methodName.StartsWith("Knn.")) {
-        return {};
+        return result;
     }
 
-    // Find the member (column) and target expression
-    // Knn distance functions have exactly 2 arguments: column and target vector
-    // The arguments are symmetric (distance is commutative), so either order is valid:
-    //   Knn::Distance(column, target) or Knn::Distance(target, column)
-    TMaybe<TString> columnName;
-    TExprNode::TPtr targetExpr;
     TVector<std::pair<TExprNode::TPtr, TExprBase>> resolvedArgs;
 
     for (const auto& arg : apply.Args()) {
-        // Skip the callable itself (first element in Args)
         if (arg.Raw() == apply.Callable().Raw()) {
             continue;
         }
 
-        // Resolve the argument through substitutions
         TExprNode::TPtr resolvedArg = arg.Ptr();
         auto it = argSubstitutions.find(arg.Raw());
         if (it != argSubstitutions.end()) {
@@ -229,25 +224,19 @@ TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceFromAppl
         resolvedArgs.emplace_back(resolvedArg, TExprBase(resolvedArg));
     }
 
-    // Knn distance functions should have exactly 2 arguments
     if (resolvedArgs.size() != 2) {
-        return {};
+        return result;
     }
 
-    // Check both argument orders since distance is symmetric
+    // Return all possible interpretations where one argument is a Member
     for (size_t i = 0; i < 2; ++i) {
         if (auto member = resolvedArgs[i].second.Maybe<TCoMember>()) {
-            columnName = TString(member.Cast().Name().Value());
-            targetExpr = resolvedArgs[1 - i].first;
-            break;
+            TString memberName = TString(member.Cast().Name().Value());
+            result.emplace_back(memberName, methodName, resolvedArgs[1 - i].first);
         }
     }
 
-    if (!columnName || !targetExpr) {
-        return {};
-    }
-
-    return std::make_tuple(*columnName, methodName, targetExpr);
+    return result;
 }
 
 // Try to find a Knn distance expression in a struct literal by column name
@@ -265,60 +254,53 @@ TMaybeNode<TExprBase> FindColumnExprInStruct(const TExprBase& structExpr, const 
     return {};
 }
 
-// Check if the lambda body is a Knn::*Distance function call and extract information
-// Returns: {column name, metric name, target expression} or nullopt if not a Knn distance function
+// Check if the lambda body is a Knn::*Distance function call and extract ALL possible interpretations
+// Returns: vector of {column name, metric name, target expression}
 // Handles both direct Apply and FlatMap-wrapped cases (for nullable columns)
-TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceInfo(const TExprBase& lambdaBody) {
+TVector<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceInfoAll(const TExprBase& lambdaBody) {
     // Case 1: Direct Apply - Knn::Distance(Member(input, 'emb'), expr)
     if (auto apply = lambdaBody.Maybe<TCoApply>()) {
-        return ExtractKnnDistanceFromApply(apply.Cast());
+        return ExtractKnnDistanceFromApplyAll(apply.Cast());
     }
 
     // Case 2: FlatMap-wrapped (for optional target expression like String::HexDecode)
-    // FlatMap(<input>, lambda(arg): Knn::Distance(Member(lambda_arg, 'emb'), arg))
-    // Where <input> is the actual target expression and 'arg' is bound to it
     if (auto flatMap = lambdaBody.Maybe<TCoFlatMap>()) {
         auto input = flatMap.Cast().Input();
         auto lambda = flatMap.Cast().Lambda();
         auto innerBody = lambda.Body();
 
-        // Build substitution map: lambda arg -> FlatMap input
         TNodeMap<TExprNode::TPtr> argSubstitutions;
         if (lambda.Args().Size() == 1) {
             argSubstitutions[lambda.Args().Arg(0).Raw()] = input.Ptr();
         }
 
-        // Check if the inner body is a Just(Apply(...))
         if (auto just = innerBody.Maybe<TCoJust>()) {
             if (auto apply = just.Cast().Input().Maybe<TCoApply>()) {
-                return ExtractKnnDistanceFromApply(apply.Cast(), argSubstitutions);
+                return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
             }
         }
 
-        // Check if the inner body is directly an Apply
         if (auto apply = innerBody.Maybe<TCoApply>()) {
-            return ExtractKnnDistanceFromApply(apply.Cast(), argSubstitutions);
+            return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
         }
 
         // Case 3: Nested FlatMap (for cases with multiple nullables)
-        // FlatMap(expr, lambda(arg1): FlatMap(input, lambda(arg2): Knn::Distance(...)))
         if (auto innerFlatMap = innerBody.Maybe<TCoFlatMap>()) {
             auto innerInput = innerFlatMap.Cast().Input();
             auto innerLambda = innerFlatMap.Cast().Lambda();
             auto innerInnerBody = innerLambda.Body();
 
-            // Add substitution for inner lambda arg
             if (innerLambda.Args().Size() == 1) {
                 argSubstitutions[innerLambda.Args().Arg(0).Raw()] = innerInput.Ptr();
             }
 
             if (auto just = innerInnerBody.Maybe<TCoJust>()) {
                 if (auto apply = just.Cast().Input().Maybe<TCoApply>()) {
-                    return ExtractKnnDistanceFromApply(apply.Cast(), argSubstitutions);
+                    return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
                 }
             }
             if (auto apply = innerInnerBody.Maybe<TCoApply>()) {
-                return ExtractKnnDistanceFromApply(apply.Cast(), argSubstitutions);
+                return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
             }
         }
     }
@@ -328,22 +310,121 @@ TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceInfo(con
 
 // Get the metric enum value from the method name
 TString GetMetricFromMethodName(const TString& methodName, bool isAsc) {
-    if (methodName == "Knn.CosineDistance" && isAsc) {
-        return "CosineDistance";
-    }
-    if (methodName == "Knn.CosineSimilarity" && !isAsc) {
-        return "CosineSimilarity";
-    }
-    if (methodName == "Knn.InnerProductSimilarity" && !isAsc) {
-        return "InnerProductSimilarity";
-    }
-    if (methodName == "Knn.ManhattanDistance" && isAsc) {
-        return "ManhattanDistance";
-    }
-    if (methodName == "Knn.EuclideanDistance" && isAsc) {
-        return "EuclideanDistance";
+    static const std::pair<TStringBuf, std::pair<TStringBuf, bool>> metrics[] = {
+        {"Knn.CosineDistance", {"CosineDistance", true}},
+        {"Knn.CosineSimilarity", {"CosineSimilarity", false}},
+        {"Knn.InnerProductSimilarity", {"InnerProductSimilarity", false}},
+        {"Knn.ManhattanDistance", {"ManhattanDistance", true}},
+        {"Knn.EuclideanDistance", {"EuclideanDistance", true}},
+    };
+    for (const auto& [name, info] : metrics) {
+        if (methodName == name && isAsc == info.second) {
+            return TString(info.first);
+        }
     }
     return {};
+}
+
+// Helper to find KNN distance info from a computed column (alias) in FlatMap/Map structures
+TVector<std::tuple<TString, TString, TExprNode::TPtr>> FindKnnInfoInComputedColumn(
+    const TExprBase& body, const TStringBuf& aliasName) {
+
+    // Check if body contains a FlatMap/Map that builds a struct with our alias
+    if (auto map = body.Maybe<TCoMap>()) {
+        auto mapBody = map.Cast().Lambda().Body();
+        if (auto asStruct = mapBody.Maybe<TCoAsStruct>()) {
+            auto maybeColumnExpr = FindColumnExprInStruct(asStruct.Cast(), aliasName);
+            if (maybeColumnExpr) {
+                return ExtractKnnDistanceInfoAll(maybeColumnExpr.Cast());
+            }
+        }
+        return FindKnnInfoInComputedColumn(mapBody, aliasName);
+    }
+
+    if (auto flatMap = body.Maybe<TCoFlatMapBase>()) {
+        auto fmBody = flatMap.Cast().Lambda().Body();
+
+        // Check for Just(AsStruct(...))
+        if (auto just = fmBody.Maybe<TCoJust>()) {
+            if (auto asStruct = just.Cast().Input().Maybe<TCoAsStruct>()) {
+                auto maybeColumnExpr = FindColumnExprInStruct(asStruct.Cast(), aliasName);
+                if (maybeColumnExpr) {
+                    return ExtractKnnDistanceInfoAll(maybeColumnExpr.Cast());
+                }
+            }
+        }
+
+        // Check for nested FlatMap (nullable subquery case)
+        if (auto innerFlatMap = fmBody.Maybe<TCoFlatMap>()) {
+            auto innerBody = innerFlatMap.Cast().Lambda().Body();
+            if (auto innerJust = innerBody.Maybe<TCoJust>()) {
+                if (auto asStruct = innerJust.Cast().Input().Maybe<TCoAsStruct>()) {
+                    auto maybeColumnExpr = FindColumnExprInStruct(asStruct.Cast(), aliasName);
+                    if (maybeColumnExpr) {
+                        TNodeMap<TExprNode::TPtr> argSubstitutions;
+                        auto innerLambda = innerFlatMap.Cast().Lambda();
+                        if (innerLambda.Args().Size() == 1) {
+                            argSubstitutions[innerLambda.Args().Arg(0).Raw()] = innerFlatMap.Cast().Input().Ptr();
+                        }
+
+                        if (auto apply = maybeColumnExpr.Cast().Maybe<TCoApply>()) {
+                            return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
+                        }
+                        if (auto innerExprFm = maybeColumnExpr.Cast().Maybe<TCoFlatMap>()) {
+                            auto ieBody = innerExprFm.Cast().Lambda().Body();
+                            if (innerExprFm.Cast().Lambda().Args().Size() == 1) {
+                                argSubstitutions[innerExprFm.Cast().Lambda().Args().Arg(0).Raw()] = innerExprFm.Cast().Input().Ptr();
+                            }
+                            if (auto ieJust = ieBody.Maybe<TCoJust>()) {
+                                if (auto ieApply = ieJust.Cast().Input().Maybe<TCoApply>()) {
+                                    return ExtractKnnDistanceFromApplyAll(ieApply.Cast(), argSubstitutions);
+                                }
+                            }
+                        }
+                        return ExtractKnnDistanceInfoAll(maybeColumnExpr.Cast());
+                    }
+                }
+            }
+        }
+        return FindKnnInfoInComputedColumn(fmBody, aliasName);
+    }
+
+    return {};
+}
+
+// Find valid KNN candidate from a list (column exists in table, metric is valid for sort direction)
+TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> FindValidKnnCandidate(
+    const TVector<std::tuple<TString, TString, TExprNode::TPtr>>& candidates,
+    const TKikimrTableDescription& tableDesc, bool isAsc, TString& outMetric) {
+    for (const auto& [col, method, target] : candidates) {
+        if (!tableDesc.Metadata->Columns.contains(col)) {
+            continue;
+        }
+        TString metric = GetMetricFromMethodName(method, isAsc);
+        if (!metric.empty()) {
+            outMetric = metric;
+            return std::make_tuple(col, method, target);
+        }
+    }
+    return {};
+}
+
+// Extract KNN info from TopSort's key selector, with optional FlatMap for alias lookup
+TVector<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnInfoFromTopSort(
+    const TCoTopSort& topSort, const TMaybeNode<TCoFlatMapBase>& maybeFlatMap = {}) {
+    auto lambdaBody = topSort.KeySelectorLambda().Body();
+    auto result = ExtractKnnDistanceInfoAll(lambdaBody);
+    if (result.empty()) {
+        if (auto member = lambdaBody.Maybe<TCoMember>()) {
+            auto aliasName = member.Cast().Name().Value();
+            if (maybeFlatMap) {
+                result = FindKnnInfoInComputedColumn(maybeFlatMap.Cast(), aliasName);
+            } else {
+                result = FindKnnInfoInComputedColumn(topSort.Input(), aliasName);
+            }
+        }
+    }
+    return result;
 }
 
 } // anonymous namespace
@@ -364,15 +445,30 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
     TMaybeNode<TDqStage> maybeStage;
     TMaybeNode<TKqpReadTableRanges> maybeReadTableRanges;
 
+    // Track if there's a DqSource with KqpReadRangesSourceSettings
+    TMaybeNode<TDqSource> maybeDqSource;
+    TMaybeNode<TKqpReadRangesSourceSettings> maybeSourceSettings;
+    size_t sourceInputIndex = 0;
+
     // Track if there's a FlatMap between TopSort and read (for ORDER BY alias case)
     TMaybeNode<TCoFlatMapBase> maybeFlatMap;
     TExprBase flatMapInput = input;
 
-    // Check for FlatMap (used when ORDER BY references an alias/computed column)
-    // The FlatMap could be directly under TopSort or inside a TDqCnUnionAll stage
+    // Check for FlatMap/Map (used when ORDER BY references an alias/computed column or subquery)
+    // The FlatMap/Map could be directly under TopSort or inside a TDqCnUnionAll stage
     if (input.Maybe<TCoFlatMapBase>()) {
         maybeFlatMap = input.Cast<TCoFlatMapBase>();
         flatMapInput = maybeFlatMap.Cast().Input();
+    } else if (input.Maybe<TCoMap>()) {
+        // TCoMap is used when the target vector comes from a subquery
+        // We treat it similarly to FlatMap for pattern matching
+        auto mapNode = input.Cast<TCoMap>();
+        flatMapInput = mapNode.Input();
+        // The Map's input might be another FlatMap wrapping DqCnUnionAll
+        if (flatMapInput.Maybe<TCoFlatMapBase>()) {
+            auto innerFlatMap = flatMapInput.Cast<TCoFlatMapBase>();
+            flatMapInput = innerFlatMap.Input();
+        }
     }
 
     if (!isReadTableRanges && flatMapInput.Maybe<TDqCnUnionAll>()) {
@@ -403,6 +499,27 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
                     }
                 }
             }
+
+            // Check if the stage has a DqSource with KqpReadRangesSourceSettings
+            // This happens for data queries where reads are converted to sources
+            if (!isReadTableRanges) {
+                for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
+                    if (auto dqSource = stage.Inputs().Item(i).Maybe<TDqSource>()) {
+                        if (auto sourceSettings = dqSource.Cast().Settings().Maybe<TKqpReadRangesSourceSettings>()) {
+                            maybeDqSource = dqSource.Cast();
+                            maybeSourceSettings = sourceSettings.Cast();
+                            sourceInputIndex = i;
+                            isReadTableRanges = true;
+                            break;
+                        }
+                    }
+                }
+
+                // Check if there's a FlatMap in the stage body for alias resolution
+                if (isReadTableRanges && stageBody.Maybe<TCoFlatMapBase>() && !maybeFlatMap) {
+                    maybeFlatMap = stageBody.Cast<TCoFlatMapBase>();
+                }
+            }
         }
     }
 
@@ -410,10 +527,22 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
         return node;
     }
 
-    // Only apply to full table scans (no WHERE clause filtering)
+    // Get table path and settings depending on whether we have direct read or source-based read
+    TCoAtom tablePath = maybeSourceSettings
+        ? maybeSourceSettings.Cast().Table().Path()
+        : GetReadTablePath(input, true);
+
+    TKqpReadTableSettings settings = maybeSourceSettings
+        ? TKqpReadTableSettings::Parse(maybeSourceSettings.Cast().Settings())
+        : GetReadTableSettings(input, true);
+
+    // Check ranges - only apply to full table scans (no WHERE clause filtering)
     // When there's a WHERE clause, the Ranges() will not be TCoVoid
-    auto readTableRanges = input.Cast<TKqpReadTableRanges>();
-    if (!TCoVoid::Match(readTableRanges.Ranges().Raw())) {
+    TExprBase rangesExpr = maybeSourceSettings
+        ? maybeSourceSettings.Cast().RangesExpr()
+        : input.Cast<TKqpReadTableRanges>().Ranges();
+
+    if (!TCoVoid::Match(rangesExpr.Raw())) {
         return node;
     }
 
@@ -428,14 +557,13 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
         }
     }
 
-    auto& tableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, GetReadTablePath(input, true));
+    auto& tableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, tablePath);
 
     // Only for datashard tables
     if (tableDesc.Metadata->Kind != EKikimrTableKind::Datashard) {
         return node;
     }
 
-    auto settings = GetReadTableSettings(input, true);
     if (settings.VectorTopKColumn) {
         return node; // already set
     }
@@ -447,47 +575,15 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
     }
     const bool isAsc = (direction == ESortDirection::Forward);
 
-    // Extract Knn distance info from the key selector lambda
-    auto lambdaBody = topSort.KeySelectorLambda().Body();
-    auto knnInfo = ExtractKnnDistanceInfo(lambdaBody);
-
-    // If not found directly, check if it's a Member accessing a computed column from FlatMap
-    if (!knnInfo && maybeFlatMap) {
-        if (auto member = lambdaBody.Maybe<TCoMember>()) {
-            auto columnName = member.Cast().Name().Value();
-            // Look for this column in the FlatMap's lambda body
-            auto flatMapLambda = maybeFlatMap.Cast().Lambda();
-            auto flatMapBody = flatMapLambda.Body();
-
-            // The FlatMap body might be Just(AsStruct(...)) or AsStruct(...)
-            TExprBase structExpr = flatMapBody;
-            if (auto just = flatMapBody.Maybe<TCoJust>()) {
-                structExpr = just.Cast().Input();
-            }
-
-            auto maybeColumnExpr = FindColumnExprInStruct(structExpr, columnName);
-            if (maybeColumnExpr.IsValid()) {
-                knnInfo = ExtractKnnDistanceInfo(maybeColumnExpr.Cast());
-            }
-        }
-    }
-
+    // Extract and validate KNN info
+    auto knnInfoAll = ExtractKnnInfoFromTopSort(topSort, maybeFlatMap);
+    TString metric;
+    auto knnInfo = FindValidKnnCandidate(knnInfoAll, tableDesc, isAsc, metric);
     if (!knnInfo) {
         return node;
     }
 
     auto [columnName, methodName, targetExpr] = *knnInfo;
-
-    // Check if the metric is valid for the sort direction
-    TString metric = GetMetricFromMethodName(methodName, isAsc);
-    if (metric.empty()) {
-        return node;
-    }
-
-    // Check if the column exists in the table
-    if (!tableDesc.Metadata->Columns.contains(columnName)) {
-        return node;
-    }
 
     YQL_CLOG(TRACE, ProviderKqp) << "-- applying vector top-K pushdown for column " << columnName << " with metric " << metric;
 
@@ -511,6 +607,81 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
         settings.VectorTopKLimit = limitExpr.Ptr();
     } else {
         settings.VectorTopKLimit = KqpPrecomputeParameter(limitExpr, ctx).Ptr();
+    }
+
+    // Handle source-based read (data queries)
+    if (maybeSourceSettings && maybeStage) {
+        auto stage = maybeStage.Cast();
+        auto oldSourceSettings = maybeSourceSettings.Cast();
+
+        // Build new settings node
+        auto newSettingsNode = settings.BuildNode(ctx, oldSourceSettings.Settings().Pos());
+
+        // Build new source settings with updated read settings
+        auto newSourceSettings = Build<TKqpReadRangesSourceSettings>(ctx, oldSourceSettings.Pos())
+            .Table(oldSourceSettings.Table())
+            .Columns(oldSourceSettings.Columns())
+            .Settings(newSettingsNode)
+            .RangesExpr(oldSourceSettings.RangesExpr())
+            .ExplainPrompt(oldSourceSettings.ExplainPrompt())
+            .Done();
+
+        // Build new source
+        auto newSource = Build<TDqSource>(ctx, maybeDqSource.Cast().Pos())
+            .Settings(newSourceSettings)
+            .DataSource(maybeDqSource.Cast().DataSource())
+            .Done();
+
+        // Rebuild inputs with the new source
+        TVector<TExprBase> newInputs;
+        for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
+            if (i == sourceInputIndex) {
+                newInputs.push_back(newSource);
+            } else {
+                newInputs.push_back(stage.Inputs().Item(i));
+            }
+        }
+
+        // Rebuild the stage with the new inputs
+        auto newStage = Build<TDqStage>(ctx, stage.Pos())
+            .Inputs()
+                .Add(newInputs)
+                .Build()
+            .Program(stage.Program())
+            .Settings(stage.Settings())
+            .Done();
+
+        // Rebuild the connection
+        auto newCnUnionAll = Build<TDqCnUnionAll>(ctx, maybeCnUnionAll.Cast().Pos())
+            .Output()
+                .Stage(newStage)
+                .Index(maybeCnUnionAll.Cast().Output().Index())
+                .Build()
+            .Done();
+
+        // If there was a FlatMap between TopSort and connection, preserve it
+        TExprBase newTopSortInput = newCnUnionAll;
+        if (maybeFlatMap && maybeFlatMap.Cast().Raw() != stage.Program().Body().Raw()) {
+            // FlatMap was outside the stage (between TopSort and CnUnionAll)
+            if (maybeFlatMap.Cast().Maybe<TCoOrderedFlatMap>()) {
+                newTopSortInput = Build<TCoOrderedFlatMap>(ctx, maybeFlatMap.Cast().Pos())
+                    .Input(newCnUnionAll)
+                    .Lambda(maybeFlatMap.Cast().Lambda())
+                    .Done();
+            } else {
+                newTopSortInput = Build<TCoFlatMap>(ctx, maybeFlatMap.Cast().Pos())
+                    .Input(newCnUnionAll)
+                    .Lambda(maybeFlatMap.Cast().Lambda())
+                    .Done();
+            }
+        }
+
+        return Build<TCoTopSort>(ctx, topSort.Pos())
+            .Input(newTopSortInput)
+            .Count(topSort.Count())
+            .SortDirections(topSort.SortDirections())
+            .KeySelectorLambda(topSort.KeySelectorLambda())
+            .Done();
     }
 
     auto newReadNode = BuildReadNode(node.Pos(), ctx, input, settings);
@@ -573,6 +744,217 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
         .Count(topSort.Count())
         .SortDirections(topSort.SortDirections())
         .KeySelectorLambda(topSort.KeySelectorLambda())
+        .Done();
+}
+
+namespace {
+
+// Helper to find TopSort in a stage body (recursively looking through Map/FlatMap)
+TMaybeNode<TCoTopSort> FindTopSortInBody(const TExprBase& body) {
+    if (auto topSort = body.Maybe<TCoTopSort>()) {
+        return topSort;
+    }
+    if (auto map = body.Maybe<TCoMap>()) {
+        return FindTopSortInBody(map.Cast().Lambda().Body());
+    }
+    if (auto flatMap = body.Maybe<TCoFlatMapBase>()) {
+        return FindTopSortInBody(flatMap.Cast().Lambda().Body());
+    }
+    if (auto toFlow = body.Maybe<TCoToFlow>()) {
+        return FindTopSortInBody(toFlow.Cast().Input());
+    }
+    return {};
+}
+
+// Helper to build a precompute that extracts a column from a subquery result
+TExprNode::TPtr BuildSubqueryTargetPrecompute(
+    const TCoMember& member, const TDqPhyPrecompute& precompute, TExprContext& ctx) {
+
+    auto memberName = member.Name();
+    auto newArg = Build<TCoArgument>(ctx, member.Pos())
+        .Name("_kqp_extract_arg")
+        .Done();
+
+    // Build: Unwrap(Member(Unwrap(arg), "column_name"))
+    auto memberExpr = Build<TCoMember>(ctx, member.Pos())
+        .Struct<TCoUnwrap>()
+            .Optional(newArg)
+            .Build()
+        .Name(memberName)
+        .Done();
+    auto extractExpr = Build<TCoUnwrap>(ctx, member.Pos())
+        .Optional(memberExpr)
+        .Done();
+
+    return Build<TDqPhyPrecompute>(ctx, member.Pos())
+        .Connection<TDqCnValue>()
+            .Output()
+                .Stage<TDqStage>()
+                    .Inputs()
+                        .Add(precompute)
+                        .Build()
+                    .Program()
+                        .Args({newArg})
+                        .Body<TCoToStream>()
+                            .Input<TCoAsList>()
+                                .Add(extractExpr)
+                                .Build()
+                            .Build()
+                        .Build()
+                    .Settings().Build()
+                    .Build()
+                .Index().Build("0")
+                .Build()
+            .Build()
+        .Done().Ptr();
+}
+
+} // anonymous namespace
+
+TExprBase KqpApplyVectorTopKToStageWithSource(TExprBase node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx) {
+    if (!node.Maybe<TDqStage>()) {
+        return node;
+    }
+    auto stage = node.Cast<TDqStage>();
+
+    // Find DqSource with KqpReadRangesSourceSettings
+    TMaybeNode<TDqSource> maybeDqSource;
+    TMaybeNode<TKqpReadRangesSourceSettings> maybeSourceSettings;
+    size_t sourceInputIndex = 0;
+
+    for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
+        if (auto dqSource = stage.Inputs().Item(i).Maybe<TDqSource>()) {
+            if (auto sourceSettings = dqSource.Cast().Settings().Maybe<TKqpReadRangesSourceSettings>()) {
+                maybeDqSource = dqSource.Cast();
+                maybeSourceSettings = sourceSettings.Cast();
+                sourceInputIndex = i;
+                break;
+            }
+        }
+    }
+
+    if (!maybeSourceSettings) {
+        return node;
+    }
+
+    auto sourceSettings = maybeSourceSettings.Cast();
+    auto settings = TKqpReadTableSettings::Parse(sourceSettings.Settings());
+
+    // Skip if already has VectorTopK or not a full table scan
+    if (settings.VectorTopKColumn || !TCoVoid::Match(sourceSettings.RangesExpr().Raw())) {
+        return node;
+    }
+
+    auto& tableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, sourceSettings.Table().Path());
+    if (tableDesc.Metadata->Kind != EKikimrTableKind::Datashard) {
+        return node;
+    }
+
+    // Find TopSort in stage body
+    auto maybeTopSort = FindTopSortInBody(stage.Program().Body());
+    if (!maybeTopSort) {
+        return node;
+    }
+    auto topSort = maybeTopSort.Cast();
+
+    // Check sort direction
+    ESortDirection direction = GetSortDirection(topSort.SortDirections());
+    if (direction != ESortDirection::Forward && direction != ESortDirection::Reverse) {
+        return node;
+    }
+    const bool isAsc = (direction == ESortDirection::Forward);
+
+    // Extract and validate KNN info
+    auto knnInfoAll = ExtractKnnInfoFromTopSort(topSort);
+    TString validMetric;
+    auto validKnnInfo = FindValidKnnCandidate(knnInfoAll, tableDesc, isAsc, validMetric);
+    if (!validKnnInfo) {
+        return node;
+    }
+
+    auto [columnName, methodName, targetExpr] = *validKnnInfo;
+    TExprBase targetExprBase(targetExpr);
+    TExprNode::TPtr resolvedTarget;
+
+    // Handle subquery targets: Member(arg, "column") where arg -> DqPhyPrecompute
+    if (auto member = targetExprBase.Maybe<TCoMember>()) {
+        if (auto arg = member.Cast().Struct().Maybe<TCoArgument>()) {
+            auto stageArgs = stage.Program().Args();
+            for (size_t i = 0; i < stageArgs.Size() && i < stage.Inputs().Size(); ++i) {
+                if (stageArgs.Arg(i).Raw() == arg.Cast().Raw()) {
+                    if (auto precompute = stage.Inputs().Item(i).Maybe<TDqPhyPrecompute>()) {
+                        resolvedTarget = BuildSubqueryTargetPrecompute(member.Cast(), precompute.Cast(), ctx);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // For non-subquery cases
+    if (!resolvedTarget) {
+        bool hasArgument = false;
+        VisitExpr(*targetExpr, [&](const TExprNode& n) {
+            if (n.IsArgument()) { hasArgument = true; return false; }
+            return true;
+        });
+        if (hasArgument) {
+            return node;
+        }
+        resolvedTarget = targetExprBase.Maybe<TCoString>() || targetExprBase.Maybe<TCoParameter>()
+            ? targetExpr
+            : KqpPrecomputeParameter(targetExprBase, ctx).Ptr();
+    }
+    YQL_CLOG(TRACE, ProviderKqp) << "-- applying vector top-K pushdown (stage) for column " << columnName << " with metric " << validMetric;
+
+    // Set the vector top-K settings
+    settings.VectorTopKColumn = columnName;
+    settings.VectorTopKMetric = validMetric;
+    settings.VectorTopKTarget = resolvedTarget;
+
+    // Limit expression
+    auto limitExpr = topSort.Count();
+    if (limitExpr.Maybe<TCoUint64>() || limitExpr.Maybe<TCoParameter>()) {
+        settings.VectorTopKLimit = limitExpr.Ptr();
+    } else {
+        settings.VectorTopKLimit = KqpPrecomputeParameter(limitExpr, ctx).Ptr();
+    }
+
+    // Build new settings node
+    auto newSettingsNode = settings.BuildNode(ctx, sourceSettings.Settings().Pos());
+
+    // Build new source settings
+    auto newSourceSettings = Build<TKqpReadRangesSourceSettings>(ctx, sourceSettings.Pos())
+        .Table(sourceSettings.Table())
+        .Columns(sourceSettings.Columns())
+        .Settings(newSettingsNode)
+        .RangesExpr(sourceSettings.RangesExpr())
+        .ExplainPrompt(sourceSettings.ExplainPrompt())
+        .Done();
+
+    // Build new source
+    auto newSource = Build<TDqSource>(ctx, maybeDqSource.Cast().Pos())
+        .Settings(newSourceSettings)
+        .DataSource(maybeDqSource.Cast().DataSource())
+        .Done();
+
+    // Rebuild inputs
+    TVector<TExprBase> newInputs;
+    for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
+        if (i == sourceInputIndex) {
+            newInputs.push_back(newSource);
+        } else {
+            newInputs.push_back(stage.Inputs().Item(i));
+        }
+    }
+
+    // Rebuild the stage
+    return Build<TDqStage>(ctx, stage.Pos())
+        .Inputs()
+            .Add(newInputs)
+            .Build()
+        .Program(stage.Program())
+        .Settings(stage.Settings())
         .Done();
 }
 

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
@@ -359,106 +359,6 @@ TVector<TExprBase> ReplaceStageInput(const TDqStage& stage, size_t index, TExprB
     return inputs;
 }
 
-// Result of finding DqSource with KqpReadRangesSourceSettings in a stage
-struct TDqSourceInfo {
-    TDqSource Source;
-    TKqpReadRangesSourceSettings Settings;
-    size_t InputIndex;
-};
-
-// Find DqSource with KqpReadRangesSourceSettings in stage inputs
-TMaybe<TDqSourceInfo> FindDqSourceWithReadRanges(const TDqStage& stage) {
-    for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
-        if (auto dqSource = stage.Inputs().Item(i).Maybe<TDqSource>()) {
-            if (auto sourceSettings = dqSource.Cast().Settings().Maybe<TKqpReadRangesSourceSettings>()) {
-                return TDqSourceInfo{dqSource.Cast(), sourceSettings.Cast(), i};
-            }
-        }
-    }
-    return {};
-}
-
-// Build new DqSource with updated settings (adding VectorTopK)
-TDqSource BuildSourceWithVectorTopK(
-    const TDqSource& oldSource,
-    const TKqpReadRangesSourceSettings& oldSettings,
-    const TKqpReadTableSettings& newSettings,
-    TExprContext& ctx)
-{
-    auto newSettingsNode = newSettings.BuildNode(ctx, oldSettings.Settings().Pos());
-    auto newSourceSettings = Build<TKqpReadRangesSourceSettings>(ctx, oldSettings.Pos())
-        .Table(oldSettings.Table())
-        .Columns(oldSettings.Columns())
-        .Settings(newSettingsNode)
-        .RangesExpr(oldSettings.RangesExpr())
-        .ExplainPrompt(oldSettings.ExplainPrompt())
-        .Done();
-    return Build<TDqSource>(ctx, oldSource.Pos())
-        .Settings(newSourceSettings)
-        .DataSource(oldSource.DataSource())
-        .Done();
-}
-
-// Build new stage with replaced input at given index
-TDqStage BuildStageWithNewInput(const TDqStage& stage, size_t inputIndex, TExprBase newInput, TExprContext& ctx) {
-    return Build<TDqStage>(ctx, stage.Pos())
-        .Inputs()
-            .Add(ReplaceStageInput(stage, inputIndex, newInput))
-            .Build()
-        .Program(stage.Program())
-        .Settings(stage.Settings())
-        .Done();
-}
-
-// Build TDqCnUnionAll with given stage
-TDqCnUnionAll BuildCnUnionAll(const TDqCnUnionAll& oldCnUnionAll, TDqStage newStage, TExprContext& ctx) {
-    return Build<TDqCnUnionAll>(ctx, oldCnUnionAll.Pos())
-        .Output()
-            .Stage(newStage)
-            .Index(oldCnUnionAll.Output().Index())
-            .Build()
-        .Done();
-}
-
-// Build TCoTopSort with given input
-TCoTopSort BuildTopSort(const TCoTopSort& oldTopSort, TExprBase newInput, TExprContext& ctx) {
-    return Build<TCoTopSort>(ctx, oldTopSort.Pos())
-        .Input(newInput)
-        .Count(oldTopSort.Count())
-        .SortDirections(oldTopSort.SortDirections())
-        .KeySelectorLambda(oldTopSort.KeySelectorLambda())
-        .Done();
-}
-
-// Check sort direction - returns true for valid ASC/DESC, false otherwise
-// Sets isAsc output parameter
-bool CheckSortDirection(const TCoTopSort& topSort, bool& isAsc) {
-    ESortDirection direction = GetSortDirection(topSort.SortDirections());
-    if (direction != ESortDirection::Forward && direction != ESortDirection::Reverse) {
-        return false;
-    }
-    isAsc = (direction == ESortDirection::Forward);
-    return true;
-}
-
-// Extract and validate KNN info from TopSort
-// Returns tuple of (columnName, metric, targetExpr) or nullopt if invalid
-std::optional<std::tuple<TString, TString, TExprNode::TPtr>> ExtractValidKnnInfo(
-    const TCoTopSort& topSort,
-    const TKikimrTableDescription& tableDesc,
-    bool isAsc,
-    const TMaybeNode<TCoFlatMapBase>& maybeFlatMap = {})
-{
-    TString metric;
-    auto knnInfo = FindValidKnnCandidate(
-        ExtractKnnInfoFromTopSort(topSort, maybeFlatMap), tableDesc, isAsc, metric);
-    if (!knnInfo) {
-        return std::nullopt;
-    }
-    auto [columnName, _, targetExpr] = *knnInfo;
-    return std::make_tuple(columnName, metric, targetExpr);
-}
-
 } // anonymous namespace
 
 TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx) {
@@ -524,14 +424,19 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
             // Check if the stage has a DqSource with KqpReadRangesSourceSettings
             // This happens for data queries where reads are converted to sources
             if (!isReadTableRanges) {
-                if (auto sourceInfo = FindDqSourceWithReadRanges(stage)) {
-                    maybeDqSource = sourceInfo->Source;
-                    maybeSourceSettings = sourceInfo->Settings;
-                    sourceInputIndex = sourceInfo->InputIndex;
-                    isReadTableRanges = true;
-                    if (stageBody.Maybe<TCoFlatMapBase>() && !maybeFlatMap) {
-                        maybeFlatMap = stageBody.Cast<TCoFlatMapBase>();
+                for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
+                    if (auto dqSource = stage.Inputs().Item(i).Maybe<TDqSource>()) {
+                        if (auto sourceSettings = dqSource.Cast().Settings().Maybe<TKqpReadRangesSourceSettings>()) {
+                            maybeDqSource = dqSource.Cast();
+                            maybeSourceSettings = sourceSettings.Cast();
+                            sourceInputIndex = i;
+                            isReadTableRanges = true;
+                            break;
+                        }
                     }
+                }
+                if (isReadTableRanges && stageBody.Maybe<TCoFlatMapBase>() && !maybeFlatMap) {
+                    maybeFlatMap = stageBody.Cast<TCoFlatMapBase>();
                 }
             }
         }
@@ -576,18 +481,21 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
         return node; // already set
     }
 
-    // Check sort direction and extract KNN info
-    bool isAsc;
-    if (!CheckSortDirection(topSort, isAsc)) {
+    // Check sort direction
+    ESortDirection direction = GetSortDirection(topSort.SortDirections());
+    if (direction != ESortDirection::Forward && direction != ESortDirection::Reverse) {
         return node;
     }
+    const bool isAsc = (direction == ESortDirection::Forward);
 
-    auto knnInfo = ExtractValidKnnInfo(topSort, tableDesc, isAsc, maybeFlatMap);
+    // Extract and validate KNN info
+    TString metric;
+    auto knnInfo = FindValidKnnCandidate(ExtractKnnInfoFromTopSort(topSort, maybeFlatMap), tableDesc, isAsc, metric);
     if (!knnInfo) {
         return node;
     }
 
-    auto [columnName, metric, targetExpr] = *knnInfo;
+    auto [columnName, _, targetExpr] = *knnInfo;
     settings.VectorTopKColumn = columnName;
     settings.VectorTopKMetric = metric;
     settings.VectorTopKTarget = WrapInPrecompute(TExprBase(targetExpr), ctx);
@@ -596,10 +504,33 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
     // Handle source-based read (data queries)
     if (maybeSourceSettings && maybeStage) {
         auto stage = maybeStage.Cast();
-        auto newSource = BuildSourceWithVectorTopK(
-            maybeDqSource.Cast(), maybeSourceSettings.Cast(), settings, ctx);
-        auto newStage = BuildStageWithNewInput(stage, sourceInputIndex, newSource, ctx);
-        auto newCnUnionAll = BuildCnUnionAll(maybeCnUnionAll.Cast(), newStage, ctx);
+        auto oldSourceSettings = maybeSourceSettings.Cast();
+
+        auto newSettingsNode = settings.BuildNode(ctx, oldSourceSettings.Settings().Pos());
+        auto newSourceSettings = Build<TKqpReadRangesSourceSettings>(ctx, oldSourceSettings.Pos())
+            .Table(oldSourceSettings.Table())
+            .Columns(oldSourceSettings.Columns())
+            .Settings(newSettingsNode)
+            .RangesExpr(oldSourceSettings.RangesExpr())
+            .ExplainPrompt(oldSourceSettings.ExplainPrompt())
+            .Done();
+        auto newSource = Build<TDqSource>(ctx, maybeDqSource.Cast().Pos())
+            .Settings(newSourceSettings)
+            .DataSource(maybeDqSource.Cast().DataSource())
+            .Done();
+        auto newStage = Build<TDqStage>(ctx, stage.Pos())
+            .Inputs()
+                .Add(ReplaceStageInput(stage, sourceInputIndex, newSource))
+                .Build()
+            .Program(stage.Program())
+            .Settings(stage.Settings())
+            .Done();
+        auto newCnUnionAll = Build<TDqCnUnionAll>(ctx, maybeCnUnionAll.Cast().Pos())
+            .Output()
+                .Stage(newStage)
+                .Index(maybeCnUnionAll.Cast().Output().Index())
+                .Build()
+            .Done();
 
         TExprBase newTopSortInput = newCnUnionAll;
         if (maybeFlatMap && maybeFlatMap.Cast().Raw() != stage.Program().Body().Raw()) {
@@ -616,7 +547,12 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
             }
         }
 
-        return BuildTopSort(topSort, newTopSortInput, ctx);
+        return Build<TCoTopSort>(ctx, topSort.Pos())
+            .Input(newTopSortInput)
+            .Count(topSort.Count())
+            .SortDirections(topSort.SortDirections())
+            .KeySelectorLambda(topSort.KeySelectorLambda())
+            .Done();
     }
 
     auto newReadNode = BuildReadNode(node.Pos(), ctx, input, settings);
@@ -651,12 +587,27 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
                 .Build()
             .Settings(stage.Settings())
             .Done();
-        auto newCnUnionAll = BuildCnUnionAll(maybeCnUnionAll.Cast(), newStage, ctx);
+        auto newCnUnionAll = Build<TDqCnUnionAll>(ctx, maybeCnUnionAll.Cast().Pos())
+            .Output()
+                .Stage(newStage)
+                .Index(maybeCnUnionAll.Cast().Output().Index())
+                .Build()
+            .Done();
 
-        return BuildTopSort(topSort, newCnUnionAll, ctx);
+        return Build<TCoTopSort>(ctx, topSort.Pos())
+            .Input(newCnUnionAll)
+            .Count(topSort.Count())
+            .SortDirections(topSort.SortDirections())
+            .KeySelectorLambda(topSort.KeySelectorLambda())
+            .Done();
     }
 
-    return BuildTopSort(topSort, newReadNode, ctx);
+    return Build<TCoTopSort>(ctx, topSort.Pos())
+        .Input(newReadNode)
+        .Count(topSort.Count())
+        .SortDirections(topSort.SortDirections())
+        .KeySelectorLambda(topSort.KeySelectorLambda())
+        .Done();
 }
 
 namespace {
@@ -758,12 +709,26 @@ TExprBase KqpApplyVectorTopKToStageWithSource(TExprBase node, TExprContext& ctx,
     auto stage = node.Cast<TDqStage>();
 
     // Find DqSource with KqpReadRangesSourceSettings
-    auto sourceInfo = FindDqSourceWithReadRanges(stage);
-    if (!sourceInfo) {
+    TMaybeNode<TDqSource> maybeDqSource;
+    TMaybeNode<TKqpReadRangesSourceSettings> maybeSourceSettings;
+    size_t sourceInputIndex = 0;
+
+    for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
+        if (auto dqSource = stage.Inputs().Item(i).Maybe<TDqSource>()) {
+            if (auto sourceSettings = dqSource.Cast().Settings().Maybe<TKqpReadRangesSourceSettings>()) {
+                maybeDqSource = dqSource.Cast();
+                maybeSourceSettings = sourceSettings.Cast();
+                sourceInputIndex = i;
+                break;
+            }
+        }
+    }
+
+    if (!maybeSourceSettings) {
         return node;
     }
 
-    auto sourceSettings = sourceInfo->Settings;
+    auto sourceSettings = maybeSourceSettings.Cast();
     auto settings = TKqpReadTableSettings::Parse(sourceSettings.Settings());
 
     // Skip if already has VectorTopK or not a full table scan
@@ -783,18 +748,21 @@ TExprBase KqpApplyVectorTopKToStageWithSource(TExprBase node, TExprContext& ctx,
     }
     auto topSort = maybeTopSort.Cast();
 
-    // Check sort direction and extract KNN info
-    bool isAsc;
-    if (!CheckSortDirection(topSort, isAsc)) {
+    // Check sort direction
+    ESortDirection direction = GetSortDirection(topSort.SortDirections());
+    if (direction != ESortDirection::Forward && direction != ESortDirection::Reverse) {
         return node;
     }
+    const bool isAsc = (direction == ESortDirection::Forward);
 
-    auto knnInfo = ExtractValidKnnInfo(topSort, tableDesc, isAsc);
+    // Extract and validate KNN info
+    TString metric;
+    auto knnInfo = FindValidKnnCandidate(ExtractKnnInfoFromTopSort(topSort), tableDesc, isAsc, metric);
     if (!knnInfo) {
         return node;
     }
 
-    auto [columnName, metric, targetExpr] = *knnInfo;
+    auto [columnName, _, targetExpr] = *knnInfo;
     TExprNode::TPtr resolvedTarget = ResolveStageTarget(TExprBase(targetExpr), stage, ctx);
     if (!resolvedTarget) {
         return node;
@@ -805,9 +773,26 @@ TExprBase KqpApplyVectorTopKToStageWithSource(TExprBase node, TExprContext& ctx,
     settings.VectorTopKTarget = resolvedTarget;
     settings.VectorTopKLimit = WrapInPrecompute(topSort.Count(), ctx);
 
-    auto newSource = BuildSourceWithVectorTopK(sourceInfo->Source, sourceSettings, settings, ctx);
+    auto newSettingsNode = settings.BuildNode(ctx, sourceSettings.Settings().Pos());
+    auto newSourceSettings = Build<TKqpReadRangesSourceSettings>(ctx, sourceSettings.Pos())
+        .Table(sourceSettings.Table())
+        .Columns(sourceSettings.Columns())
+        .Settings(newSettingsNode)
+        .RangesExpr(sourceSettings.RangesExpr())
+        .ExplainPrompt(sourceSettings.ExplainPrompt())
+        .Done();
+    auto newSource = Build<TDqSource>(ctx, maybeDqSource.Cast().Pos())
+        .Settings(newSourceSettings)
+        .DataSource(maybeDqSource.Cast().DataSource())
+        .Done();
 
-    return BuildStageWithNewInput(stage, sourceInfo->InputIndex, newSource, ctx);
+    return Build<TDqStage>(ctx, stage.Pos())
+        .Inputs()
+            .Add(ReplaceStageInput(stage, sourceInputIndex, newSource))
+            .Build()
+        .Program(stage.Program())
+        .Settings(stage.Settings())
+        .Done();
 }
 
 } // namespace NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
@@ -214,7 +214,9 @@ TVector<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceFromApp
         resolvedArgs.emplace_back(resolved, TExprBase(resolved));
     }
 
-    if (resolvedArgs.size() != 2) return result;
+    if (resolvedArgs.size() != 2) {
+        return result;
+    }
 
     // Return interpretations where one argument is a Member (column reference)
     for (size_t i = 0; i < 2; ++i) {
@@ -260,9 +262,15 @@ TMaybeNode<TExprBase> FindColumnExprInStruct(const TExprBase& structExpr, const 
 
 // Unwrap Just/FlatMap to find AsStruct
 TMaybeNode<TCoAsStruct> UnwrapToStruct(const TExprBase& body) {
-    if (auto asStruct = body.Maybe<TCoAsStruct>()) return asStruct;
-    if (auto just = body.Maybe<TCoJust>()) return just.Cast().Input().Maybe<TCoAsStruct>();
-    if (auto flatMap = body.Maybe<TCoFlatMap>()) return UnwrapToStruct(flatMap.Cast().Lambda().Body());
+    if (auto asStruct = body.Maybe<TCoAsStruct>()) {
+        return asStruct;
+    }
+    if (auto just = body.Maybe<TCoJust>()) {
+        return just.Cast().Input().Maybe<TCoAsStruct>();
+    }
+    if (auto flatMap = body.Maybe<TCoFlatMap>()) {
+        return UnwrapToStruct(flatMap.Cast().Lambda().Body());
+    }
     return {};
 }
 
@@ -606,10 +614,18 @@ namespace {
 
 // Find TopSort in stage body (through Map/FlatMap/ToFlow wrappers)
 TMaybeNode<TCoTopSort> FindTopSortInBody(const TExprBase& body) {
-    if (auto t = body.Maybe<TCoTopSort>()) return t;
-    if (auto m = body.Maybe<TCoMap>()) return FindTopSortInBody(m.Cast().Lambda().Body());
-    if (auto f = body.Maybe<TCoFlatMapBase>()) return FindTopSortInBody(f.Cast().Lambda().Body());
-    if (auto t = body.Maybe<TCoToFlow>()) return FindTopSortInBody(t.Cast().Input());
+    if (auto t = body.Maybe<TCoTopSort>()) {
+        return t;
+    }
+    if (auto m = body.Maybe<TCoMap>()) {
+        return FindTopSortInBody(m.Cast().Lambda().Body());
+    }
+    if (auto f = body.Maybe<TCoFlatMapBase>()) {
+        return FindTopSortInBody(f.Cast().Lambda().Body());
+    }
+    if (auto t = body.Maybe<TCoToFlow>()) {
+        return FindTopSortInBody(t.Cast().Input());
+    }
     return {};
 }
 
@@ -677,7 +693,9 @@ TExprNode::TPtr ResolveStageTarget(const TExprBase& expr, const TDqStage& stage,
         if (n.IsArgument()) { hasArgument = true; return false; }
         return true;
     });
-    if (hasArgument) return nullptr;
+    if (hasArgument) {
+        return nullptr;
+    }
 
     return WrapInPrecompute(expr, ctx);
 }

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
@@ -3,6 +3,8 @@
 
 #include <ydb/core/kqp/common/kqp_yql.h>
 
+#include <ydb/public/api/protos/ydb_table.pb.h>
+
 namespace NKikimr::NKqp::NOpt {
 
 using namespace NYql;
@@ -180,6 +182,369 @@ TExprBase KqpApplyLimitToOlapReadTable(TExprBase node, TExprContext& ctx, const 
 
     return Build<TCoTopSort>(ctx, topSort.Pos())
         .Input(input)
+        .Count(topSort.Count())
+        .SortDirections(topSort.SortDirections())
+        .KeySelectorLambda(topSort.KeySelectorLambda())
+        .Done();
+}
+
+namespace {
+
+// Helper function to extract info from a Knn::*Distance Apply node
+// argSubstitutions maps lambda arguments to their corresponding input expressions
+// Returns: {column name, method name, target expression} or nullopt if not a valid Knn distance call
+TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceFromApply(
+    const TCoApply& apply,
+    const TNodeMap<TExprNode::TPtr>& argSubstitutions = {}) {
+    auto udf = apply.Callable().Maybe<TCoUdf>();
+    if (!udf) {
+        return {};
+    }
+
+    const auto methodName = TString(udf.Cast().MethodName().Value());
+    if (!methodName.StartsWith("Knn.")) {
+        return {};
+    }
+
+    // Find the member (column) and target expression
+    // Knn distance functions have exactly 2 arguments: column and target vector
+    TMaybe<TString> columnName;
+    TExprNode::TPtr targetExpr;
+    size_t argCount = 0;
+
+    for (const auto& arg : apply.Args()) {
+        // Skip the callable itself (first element in Args)
+        if (arg.Raw() == apply.Callable().Raw()) {
+            continue;
+        }
+        argCount++;
+
+        // Try to resolve the argument through substitutions first
+        TExprNode::TPtr resolvedArg = arg.Ptr();
+        auto it = argSubstitutions.find(arg.Raw());
+        if (it != argSubstitutions.end()) {
+            resolvedArg = it->second;
+        }
+
+        // Check if the (possibly resolved) argument is a Member - that's the column
+        TExprBase resolvedExpr(resolvedArg);
+        if (auto member = resolvedExpr.Maybe<TCoMember>()) {
+            columnName = TString(member.Cast().Name().Value());
+        } else {
+            // Not a column reference - it's the target expression
+            targetExpr = resolvedArg;
+        }
+    }
+
+    // Knn distance functions should have exactly 2 arguments
+    if (!columnName || !targetExpr || argCount != 2) {
+        return {};
+    }
+
+    return std::make_tuple(*columnName, methodName, targetExpr);
+}
+
+// Try to find a Knn distance expression in a struct literal by column name
+// Returns the expression if found, nullopt otherwise
+TMaybeNode<TExprBase> FindColumnExprInStruct(const TExprBase& structExpr, const TStringBuf& columnName) {
+    if (auto asStruct = structExpr.Maybe<TCoAsStruct>()) {
+        for (const auto& item : asStruct.Cast()) {
+            if (auto tuple = item.Maybe<TCoNameValueTuple>()) {
+                if (tuple.Cast().Name().Value() == columnName) {
+                    return tuple.Cast().Value();
+                }
+            }
+        }
+    }
+    return {};
+}
+
+// Check if the lambda body is a Knn::*Distance function call and extract information
+// Returns: {column name, metric name, target expression} or nullopt if not a Knn distance function
+// Handles both direct Apply and FlatMap-wrapped cases (for nullable columns)
+TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceInfo(const TExprBase& lambdaBody) {
+    // Case 1: Direct Apply - Knn::Distance(Member(input, 'emb'), expr)
+    if (auto apply = lambdaBody.Maybe<TCoApply>()) {
+        return ExtractKnnDistanceFromApply(apply.Cast());
+    }
+
+    // Case 2: FlatMap-wrapped (for optional target expression like String::HexDecode)
+    // FlatMap(<input>, lambda(arg): Knn::Distance(Member(lambda_arg, 'emb'), arg))
+    // Where <input> is the actual target expression and 'arg' is bound to it
+    if (auto flatMap = lambdaBody.Maybe<TCoFlatMap>()) {
+        auto input = flatMap.Cast().Input();
+        auto lambda = flatMap.Cast().Lambda();
+        auto innerBody = lambda.Body();
+
+        // Build substitution map: lambda arg -> FlatMap input
+        TNodeMap<TExprNode::TPtr> argSubstitutions;
+        if (lambda.Args().Size() == 1) {
+            argSubstitutions[lambda.Args().Arg(0).Raw()] = input.Ptr();
+        }
+
+        // Check if the inner body is a Just(Apply(...))
+        if (auto just = innerBody.Maybe<TCoJust>()) {
+            if (auto apply = just.Cast().Input().Maybe<TCoApply>()) {
+                return ExtractKnnDistanceFromApply(apply.Cast(), argSubstitutions);
+            }
+        }
+
+        // Check if the inner body is directly an Apply
+        if (auto apply = innerBody.Maybe<TCoApply>()) {
+            return ExtractKnnDistanceFromApply(apply.Cast(), argSubstitutions);
+        }
+
+        // Case 3: Nested FlatMap (for cases with multiple nullables)
+        // FlatMap(expr, lambda(arg1): FlatMap(input, lambda(arg2): Knn::Distance(...)))
+        if (auto innerFlatMap = innerBody.Maybe<TCoFlatMap>()) {
+            auto innerInput = innerFlatMap.Cast().Input();
+            auto innerLambda = innerFlatMap.Cast().Lambda();
+            auto innerInnerBody = innerLambda.Body();
+
+            // Add substitution for inner lambda arg
+            if (innerLambda.Args().Size() == 1) {
+                argSubstitutions[innerLambda.Args().Arg(0).Raw()] = innerInput.Ptr();
+            }
+
+            if (auto just = innerInnerBody.Maybe<TCoJust>()) {
+                if (auto apply = just.Cast().Input().Maybe<TCoApply>()) {
+                    return ExtractKnnDistanceFromApply(apply.Cast(), argSubstitutions);
+                }
+            }
+            if (auto apply = innerInnerBody.Maybe<TCoApply>()) {
+                return ExtractKnnDistanceFromApply(apply.Cast(), argSubstitutions);
+            }
+        }
+    }
+
+    return {};
+}
+
+// Get the metric enum value from the method name
+TString GetMetricFromMethodName(const TString& methodName, bool isAsc) {
+    if (methodName == "Knn.CosineDistance" && isAsc) {
+        return "CosineDistance";
+    }
+    if (methodName == "Knn.CosineSimilarity" && !isAsc) {
+        return "CosineSimilarity";
+    }
+    if (methodName == "Knn.InnerProductSimilarity" && !isAsc) {
+        return "InnerProductSimilarity";
+    }
+    if (methodName == "Knn.ManhattanDistance" && isAsc) {
+        return "ManhattanDistance";
+    }
+    if (methodName == "Knn.EuclideanDistance" && isAsc) {
+        return "EuclideanDistance";
+    }
+    return {};
+}
+
+} // anonymous namespace
+
+TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx) {
+    if (!node.Maybe<TCoTopSort>()) {
+        return node;
+    }
+    auto topSort = node.Cast<TCoTopSort>();
+
+    auto input = topSort.Input();
+
+    // Check if input is directly TKqpReadTableRanges
+    bool isReadTableRanges = input.Maybe<TKqpReadTableRanges>().IsValid();
+
+    // Also check if input is TDqCnUnionAll with a stage containing TKqpReadTableRanges
+    TMaybeNode<TDqCnUnionAll> maybeCnUnionAll;
+    TMaybeNode<TDqStage> maybeStage;
+    TMaybeNode<TKqpReadTableRanges> maybeReadTableRanges;
+
+    // Track if there's a FlatMap between TopSort and read (for ORDER BY alias case)
+    TMaybeNode<TCoFlatMapBase> maybeFlatMap;
+    TExprBase flatMapInput = input;
+
+    // Check for FlatMap (used when ORDER BY references an alias/computed column)
+    // The FlatMap could be directly under TopSort or inside a TDqCnUnionAll stage
+    if (input.Maybe<TCoFlatMapBase>()) {
+        maybeFlatMap = input.Cast<TCoFlatMapBase>();
+        flatMapInput = maybeFlatMap.Cast().Input();
+    }
+
+    if (!isReadTableRanges && flatMapInput.Maybe<TDqCnUnionAll>()) {
+        maybeCnUnionAll = flatMapInput.Cast<TDqCnUnionAll>();
+        maybeStage = maybeCnUnionAll.Cast().Output().Stage().Maybe<TDqStage>();
+        if (maybeStage) {
+            auto stage = maybeStage.Cast();
+            auto stageBody = stage.Program().Body();
+
+            // Check if the stage program body is TKqpReadTableRanges directly
+            maybeReadTableRanges = stageBody.Maybe<TKqpReadTableRanges>();
+            if (maybeReadTableRanges) {
+                isReadTableRanges = true;
+                input = maybeReadTableRanges.Cast();
+            }
+
+            // Also check if the stage body is a FlatMap over TKqpReadTableRanges
+            // This happens when ORDER BY references an alias computed in the FlatMap
+            if (!isReadTableRanges && stageBody.Maybe<TCoFlatMapBase>()) {
+                auto stageFlatMap = stageBody.Cast<TCoFlatMapBase>();
+                maybeReadTableRanges = stageFlatMap.Input().Maybe<TKqpReadTableRanges>();
+                if (maybeReadTableRanges) {
+                    isReadTableRanges = true;
+                    input = maybeReadTableRanges.Cast();
+                    // Use the FlatMap from the stage for alias resolution
+                    if (!maybeFlatMap) {
+                        maybeFlatMap = stageFlatMap;
+                    }
+                }
+            }
+        }
+    }
+
+    if (!isReadTableRanges) {
+        return node;
+    }
+
+    auto& tableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, GetReadTablePath(input, true));
+
+    // Only for datashard tables
+    if (tableDesc.Metadata->Kind != EKikimrTableKind::Datashard) {
+        return node;
+    }
+
+    auto settings = GetReadTableSettings(input, true);
+    if (settings.VectorTopKColumn) {
+        return node; // already set
+    }
+
+    // Check sort direction - only handle single direction (either all forward or all reverse)
+    ESortDirection direction = GetSortDirection(topSort.SortDirections());
+    if (direction != ESortDirection::Forward && direction != ESortDirection::Reverse) {
+        return node;
+    }
+    const bool isAsc = (direction == ESortDirection::Forward);
+
+    // Extract Knn distance info from the key selector lambda
+    auto lambdaBody = topSort.KeySelectorLambda().Body();
+    auto knnInfo = ExtractKnnDistanceInfo(lambdaBody);
+
+    // If not found directly, check if it's a Member accessing a computed column from FlatMap
+    if (!knnInfo && maybeFlatMap) {
+        if (auto member = lambdaBody.Maybe<TCoMember>()) {
+            auto columnName = member.Cast().Name().Value();
+            // Look for this column in the FlatMap's lambda body
+            auto flatMapLambda = maybeFlatMap.Cast().Lambda();
+            auto flatMapBody = flatMapLambda.Body();
+
+            // The FlatMap body might be Just(AsStruct(...)) or AsStruct(...)
+            TExprBase structExpr = flatMapBody;
+            if (auto just = flatMapBody.Maybe<TCoJust>()) {
+                structExpr = just.Cast().Input();
+            }
+
+            auto maybeColumnExpr = FindColumnExprInStruct(structExpr, columnName);
+            if (maybeColumnExpr.IsValid()) {
+                knnInfo = ExtractKnnDistanceInfo(maybeColumnExpr.Cast());
+            }
+        }
+    }
+
+    if (!knnInfo) {
+        return node;
+    }
+
+    auto [columnName, methodName, targetExpr] = *knnInfo;
+
+    // Check if the metric is valid for the sort direction
+    TString metric = GetMetricFromMethodName(methodName, isAsc);
+    if (metric.empty()) {
+        return node;
+    }
+
+    // Check if the column exists in the table
+    if (!tableDesc.Metadata->Columns.contains(columnName)) {
+        return node;
+    }
+
+    YQL_CLOG(TRACE, ProviderKqp) << "-- applying vector top-K pushdown for column " << columnName << " with metric " << metric;
+
+    // Set the vector top-K settings
+    settings.VectorTopKColumn = columnName;
+    settings.VectorTopKMetric = metric;
+
+    // Target expression - wrap in precompute if not a simple type
+    TExprBase targetExprBase(targetExpr);
+    if (targetExprBase.Maybe<TCoString>() || targetExprBase.Maybe<TCoParameter>()) {
+        settings.VectorTopKTarget = targetExpr;
+    } else {
+        // Wrap non-simple expressions in precompute (TDqPhyPrecompute)
+        settings.VectorTopKTarget = KqpPrecomputeParameter(targetExprBase, ctx).Ptr();
+    }
+
+    // Limit expression - wrap in precompute if not a simple type
+    auto limitExpr = topSort.Count();
+    if (limitExpr.Maybe<TCoUint64>() || limitExpr.Maybe<TCoParameter>()) {
+        settings.VectorTopKLimit = limitExpr.Ptr();
+    } else {
+        settings.VectorTopKLimit = KqpPrecomputeParameter(limitExpr, ctx).Ptr();
+    }
+
+    auto newReadNode = BuildReadNode(node.Pos(), ctx, input, settings);
+
+    // If we found the read inside a stage, we need to rebuild the stage and connection
+    if (maybeStage) {
+        auto stage = maybeStage.Cast();
+        auto stageBody = stage.Program().Body();
+
+        // Determine the new stage body
+        TExprBase newStageBody = newReadNode;
+
+        // If the stage body was a FlatMap over the read, preserve the FlatMap structure and type
+        if (auto orderedFlatMap = stageBody.Maybe<TCoOrderedFlatMap>()) {
+            if (orderedFlatMap.Cast().Input().Maybe<TKqpReadTableRanges>()) {
+                // Rebuild as OrderedFlatMap to preserve ordering semantics
+                newStageBody = Build<TCoOrderedFlatMap>(ctx, orderedFlatMap.Cast().Pos())
+                    .Input(newReadNode)
+                    .Lambda(orderedFlatMap.Cast().Lambda())
+                    .Done();
+            }
+        } else if (auto flatMap = stageBody.Maybe<TCoFlatMap>()) {
+            if (flatMap.Cast().Input().Maybe<TKqpReadTableRanges>()) {
+                // Rebuild as regular FlatMap
+                newStageBody = Build<TCoFlatMap>(ctx, flatMap.Cast().Pos())
+                    .Input(newReadNode)
+                    .Lambda(flatMap.Cast().Lambda())
+                    .Done();
+            }
+        }
+
+        // Rebuild the stage with the new body
+        auto newStage = Build<TDqStage>(ctx, stage.Pos())
+            .Inputs(stage.Inputs())
+            .Program()
+                .Args(stage.Program().Args())
+                .Body(newStageBody)
+                .Build()
+            .Settings(stage.Settings())
+            .Done();
+
+        // Rebuild the connection
+        auto newCnUnionAll = Build<TDqCnUnionAll>(ctx, maybeCnUnionAll.Cast().Pos())
+            .Output()
+                .Stage(newStage)
+                .Index(maybeCnUnionAll.Cast().Output().Index())
+                .Build()
+            .Done();
+
+        return Build<TCoTopSort>(ctx, topSort.Pos())
+            .Input(newCnUnionAll)
+            .Count(topSort.Count())
+            .SortDirections(topSort.SortDirections())
+            .KeySelectorLambda(topSort.KeySelectorLambda())
+            .Done();
+    }
+
+    return Build<TCoTopSort>(ctx, topSort.Pos())
+        .Input(newReadNode)
         .Count(topSort.Count())
         .SortDirections(topSort.SortDirections())
         .KeySelectorLambda(topSort.KeySelectorLambda())

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_limit.cpp
@@ -191,56 +191,60 @@ TExprBase KqpApplyLimitToOlapReadTable(TExprBase node, TExprContext& ctx, const 
 namespace {
 
 // Helper function to extract info from a Knn::*Distance Apply node
-// argSubstitutions maps lambda arguments to their corresponding input expressions
-// Returns: vector of {column name, method name, target expression} for all possible interpretations
-// For subquery cases, both arguments might be Members, so we return all possibilities
+// Returns all valid {column, method, target} tuples where one arg is a Member (table column)
 TVector<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceFromApplyAll(
     const TCoApply& apply,
     const TNodeMap<TExprNode::TPtr>& argSubstitutions = {}) {
+
     TVector<std::tuple<TString, TString, TExprNode::TPtr>> result;
 
     auto udf = apply.Callable().Maybe<TCoUdf>();
-    if (!udf) {
+    if (!udf || !udf.Cast().MethodName().Value().StartsWith("Knn.")) {
         return result;
     }
 
     const auto methodName = TString(udf.Cast().MethodName().Value());
-    if (!methodName.StartsWith("Knn.")) {
-        return result;
-    }
 
+    // Collect resolved arguments (skip the callable itself)
     TVector<std::pair<TExprNode::TPtr, TExprBase>> resolvedArgs;
-
     for (const auto& arg : apply.Args()) {
-        if (arg.Raw() == apply.Callable().Raw()) {
-            continue;
-        }
-
-        TExprNode::TPtr resolvedArg = arg.Ptr();
+        if (arg.Raw() == apply.Callable().Raw()) continue;
         auto it = argSubstitutions.find(arg.Raw());
-        if (it != argSubstitutions.end()) {
-            resolvedArg = it->second;
-        }
-        resolvedArgs.emplace_back(resolvedArg, TExprBase(resolvedArg));
+        auto resolved = (it != argSubstitutions.end()) ? it->second : arg.Ptr();
+        resolvedArgs.emplace_back(resolved, TExprBase(resolved));
     }
 
-    if (resolvedArgs.size() != 2) {
-        return result;
-    }
+    if (resolvedArgs.size() != 2) return result;
 
-    // Return all possible interpretations where one argument is a Member
+    // Return interpretations where one argument is a Member (column reference)
     for (size_t i = 0; i < 2; ++i) {
         if (auto member = resolvedArgs[i].second.Maybe<TCoMember>()) {
-            TString memberName = TString(member.Cast().Name().Value());
-            result.emplace_back(memberName, methodName, resolvedArgs[1 - i].first);
+            result.emplace_back(TString(member.Cast().Name().Value()), methodName, resolvedArgs[1 - i].first);
         }
     }
-
     return result;
 }
 
-// Try to find a Knn distance expression in a struct literal by column name
-// Returns the expression if found, nullopt otherwise
+// Recursively extract KNN info, unwrapping Just/FlatMap wrappers
+TVector<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceInfoAll(
+    const TExprBase& expr, TNodeMap<TExprNode::TPtr> argSubstitutions = {}) {
+
+    if (auto apply = expr.Maybe<TCoApply>()) {
+        return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
+    }
+    if (auto just = expr.Maybe<TCoJust>()) {
+        return ExtractKnnDistanceInfoAll(just.Cast().Input(), argSubstitutions);
+    }
+    if (auto flatMap = expr.Maybe<TCoFlatMap>()) {
+        if (flatMap.Cast().Lambda().Args().Size() == 1) {
+            argSubstitutions[flatMap.Cast().Lambda().Args().Arg(0).Raw()] = flatMap.Cast().Input().Ptr();
+        }
+        return ExtractKnnDistanceInfoAll(flatMap.Cast().Lambda().Body(), argSubstitutions);
+    }
+    return {};
+}
+
+// Find column expression in AsStruct by name
 TMaybeNode<TExprBase> FindColumnExprInStruct(const TExprBase& structExpr, const TStringBuf& columnName) {
     if (auto asStruct = structExpr.Maybe<TCoAsStruct>()) {
         for (const auto& item : asStruct.Cast()) {
@@ -254,152 +258,56 @@ TMaybeNode<TExprBase> FindColumnExprInStruct(const TExprBase& structExpr, const 
     return {};
 }
 
-// Check if the lambda body is a Knn::*Distance function call and extract ALL possible interpretations
-// Returns: vector of {column name, metric name, target expression}
-// Handles both direct Apply and FlatMap-wrapped cases (for nullable columns)
-TVector<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnDistanceInfoAll(const TExprBase& lambdaBody) {
-    // Case 1: Direct Apply - Knn::Distance(Member(input, 'emb'), expr)
-    if (auto apply = lambdaBody.Maybe<TCoApply>()) {
-        return ExtractKnnDistanceFromApplyAll(apply.Cast());
-    }
-
-    // Case 2: FlatMap-wrapped (for optional target expression like String::HexDecode)
-    if (auto flatMap = lambdaBody.Maybe<TCoFlatMap>()) {
-        auto input = flatMap.Cast().Input();
-        auto lambda = flatMap.Cast().Lambda();
-        auto innerBody = lambda.Body();
-
-        TNodeMap<TExprNode::TPtr> argSubstitutions;
-        if (lambda.Args().Size() == 1) {
-            argSubstitutions[lambda.Args().Arg(0).Raw()] = input.Ptr();
-        }
-
-        if (auto just = innerBody.Maybe<TCoJust>()) {
-            if (auto apply = just.Cast().Input().Maybe<TCoApply>()) {
-                return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
-            }
-        }
-
-        if (auto apply = innerBody.Maybe<TCoApply>()) {
-            return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
-        }
-
-        // Case 3: Nested FlatMap (for cases with multiple nullables)
-        if (auto innerFlatMap = innerBody.Maybe<TCoFlatMap>()) {
-            auto innerInput = innerFlatMap.Cast().Input();
-            auto innerLambda = innerFlatMap.Cast().Lambda();
-            auto innerInnerBody = innerLambda.Body();
-
-            if (innerLambda.Args().Size() == 1) {
-                argSubstitutions[innerLambda.Args().Arg(0).Raw()] = innerInput.Ptr();
-            }
-
-            if (auto just = innerInnerBody.Maybe<TCoJust>()) {
-                if (auto apply = just.Cast().Input().Maybe<TCoApply>()) {
-                    return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
-                }
-            }
-            if (auto apply = innerInnerBody.Maybe<TCoApply>()) {
-                return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
-            }
-        }
-    }
-
+// Unwrap Just/FlatMap to find AsStruct
+TMaybeNode<TCoAsStruct> UnwrapToStruct(const TExprBase& body) {
+    if (auto asStruct = body.Maybe<TCoAsStruct>()) return asStruct;
+    if (auto just = body.Maybe<TCoJust>()) return just.Cast().Input().Maybe<TCoAsStruct>();
+    if (auto flatMap = body.Maybe<TCoFlatMap>()) return UnwrapToStruct(flatMap.Cast().Lambda().Body());
     return {};
 }
 
-// Get the metric enum value from the method name
-TString GetMetricFromMethodName(const TString& methodName, bool isAsc) {
-    static const std::pair<TStringBuf, std::pair<TStringBuf, bool>> metrics[] = {
-        {"Knn.CosineDistance", {"CosineDistance", true}},
-        {"Knn.CosineSimilarity", {"CosineSimilarity", false}},
-        {"Knn.InnerProductSimilarity", {"InnerProductSimilarity", false}},
-        {"Knn.ManhattanDistance", {"ManhattanDistance", true}},
-        {"Knn.EuclideanDistance", {"EuclideanDistance", true}},
-    };
-    for (const auto& [name, info] : metrics) {
-        if (methodName == name && isAsc == info.second) {
-            return TString(info.first);
-        }
-    }
-    return {};
-}
-
-// Helper to find KNN distance info from a computed column (alias) in FlatMap/Map structures
+// Find KNN info in computed column (alias) within Map/FlatMap structures
 TVector<std::tuple<TString, TString, TExprNode::TPtr>> FindKnnInfoInComputedColumn(
     const TExprBase& body, const TStringBuf& aliasName) {
 
-    // Check if body contains a FlatMap/Map that builds a struct with our alias
+    if (auto asStruct = UnwrapToStruct(body)) {
+        if (auto columnExpr = FindColumnExprInStruct(asStruct.Cast(), aliasName)) {
+            return ExtractKnnDistanceInfoAll(columnExpr.Cast());
+        }
+    }
     if (auto map = body.Maybe<TCoMap>()) {
-        auto mapBody = map.Cast().Lambda().Body();
-        if (auto asStruct = mapBody.Maybe<TCoAsStruct>()) {
-            auto maybeColumnExpr = FindColumnExprInStruct(asStruct.Cast(), aliasName);
-            if (maybeColumnExpr) {
-                return ExtractKnnDistanceInfoAll(maybeColumnExpr.Cast());
-            }
-        }
-        return FindKnnInfoInComputedColumn(mapBody, aliasName);
+        return FindKnnInfoInComputedColumn(map.Cast().Lambda().Body(), aliasName);
     }
-
     if (auto flatMap = body.Maybe<TCoFlatMapBase>()) {
-        auto fmBody = flatMap.Cast().Lambda().Body();
-
-        // Check for Just(AsStruct(...))
-        if (auto just = fmBody.Maybe<TCoJust>()) {
-            if (auto asStruct = just.Cast().Input().Maybe<TCoAsStruct>()) {
-                auto maybeColumnExpr = FindColumnExprInStruct(asStruct.Cast(), aliasName);
-                if (maybeColumnExpr) {
-                    return ExtractKnnDistanceInfoAll(maybeColumnExpr.Cast());
-                }
-            }
-        }
-
-        // Check for nested FlatMap (nullable subquery case)
-        if (auto innerFlatMap = fmBody.Maybe<TCoFlatMap>()) {
-            auto innerBody = innerFlatMap.Cast().Lambda().Body();
-            if (auto innerJust = innerBody.Maybe<TCoJust>()) {
-                if (auto asStruct = innerJust.Cast().Input().Maybe<TCoAsStruct>()) {
-                    auto maybeColumnExpr = FindColumnExprInStruct(asStruct.Cast(), aliasName);
-                    if (maybeColumnExpr) {
-                        TNodeMap<TExprNode::TPtr> argSubstitutions;
-                        auto innerLambda = innerFlatMap.Cast().Lambda();
-                        if (innerLambda.Args().Size() == 1) {
-                            argSubstitutions[innerLambda.Args().Arg(0).Raw()] = innerFlatMap.Cast().Input().Ptr();
-                        }
-
-                        if (auto apply = maybeColumnExpr.Cast().Maybe<TCoApply>()) {
-                            return ExtractKnnDistanceFromApplyAll(apply.Cast(), argSubstitutions);
-                        }
-                        if (auto innerExprFm = maybeColumnExpr.Cast().Maybe<TCoFlatMap>()) {
-                            auto ieBody = innerExprFm.Cast().Lambda().Body();
-                            if (innerExprFm.Cast().Lambda().Args().Size() == 1) {
-                                argSubstitutions[innerExprFm.Cast().Lambda().Args().Arg(0).Raw()] = innerExprFm.Cast().Input().Ptr();
-                            }
-                            if (auto ieJust = ieBody.Maybe<TCoJust>()) {
-                                if (auto ieApply = ieJust.Cast().Input().Maybe<TCoApply>()) {
-                                    return ExtractKnnDistanceFromApplyAll(ieApply.Cast(), argSubstitutions);
-                                }
-                            }
-                        }
-                        return ExtractKnnDistanceInfoAll(maybeColumnExpr.Cast());
-                    }
-                }
-            }
-        }
-        return FindKnnInfoInComputedColumn(fmBody, aliasName);
+        return FindKnnInfoInComputedColumn(flatMap.Cast().Lambda().Body(), aliasName);
     }
-
     return {};
 }
 
-// Find valid KNN candidate from a list (column exists in table, metric is valid for sort direction)
+// Get metric name from Knn method if sort direction matches
+TString GetMetricFromMethodName(const TString& methodName, bool isAsc) {
+    static const std::tuple<TStringBuf, TStringBuf, bool> metrics[] = {
+        {"Knn.CosineDistance", "CosineDistance", true},
+        {"Knn.CosineSimilarity", "CosineSimilarity", false},
+        {"Knn.InnerProductSimilarity", "InnerProductSimilarity", false},
+        {"Knn.ManhattanDistance", "ManhattanDistance", true},
+        {"Knn.EuclideanDistance", "EuclideanDistance", true},
+    };
+    for (auto [method, metric, requiresAsc] : metrics) {
+        if (methodName == method && isAsc == requiresAsc) {
+            return TString(metric);
+        }
+    }
+    return {};
+}
+
+// Find first valid KNN candidate (column exists, metric valid for direction)
 TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> FindValidKnnCandidate(
     const TVector<std::tuple<TString, TString, TExprNode::TPtr>>& candidates,
     const TKikimrTableDescription& tableDesc, bool isAsc, TString& outMetric) {
+
     for (const auto& [col, method, target] : candidates) {
-        if (!tableDesc.Metadata->Columns.contains(col)) {
-            continue;
-        }
+        if (!tableDesc.Metadata->Columns.contains(col)) continue;
         TString metric = GetMetricFromMethodName(method, isAsc);
         if (!metric.empty()) {
             outMetric = metric;
@@ -409,22 +317,38 @@ TMaybe<std::tuple<TString, TString, TExprNode::TPtr>> FindValidKnnCandidate(
     return {};
 }
 
-// Extract KNN info from TopSort's key selector, with optional FlatMap for alias lookup
+// Extract KNN info from TopSort key selector
 TVector<std::tuple<TString, TString, TExprNode::TPtr>> ExtractKnnInfoFromTopSort(
     const TCoTopSort& topSort, const TMaybeNode<TCoFlatMapBase>& maybeFlatMap = {}) {
+
     auto lambdaBody = topSort.KeySelectorLambda().Body();
     auto result = ExtractKnnDistanceInfoAll(lambdaBody);
     if (result.empty()) {
         if (auto member = lambdaBody.Maybe<TCoMember>()) {
             auto aliasName = member.Cast().Name().Value();
-            if (maybeFlatMap) {
-                result = FindKnnInfoInComputedColumn(maybeFlatMap.Cast(), aliasName);
-            } else {
-                result = FindKnnInfoInComputedColumn(topSort.Input(), aliasName);
-            }
+            result = maybeFlatMap ? FindKnnInfoInComputedColumn(maybeFlatMap.Cast(), aliasName)
+                                  : FindKnnInfoInComputedColumn(topSort.Input(), aliasName);
         }
     }
     return result;
+}
+
+// Wrap expression in precompute if not a simple literal/parameter
+TExprNode::TPtr WrapInPrecompute(const TExprBase& expr, TExprContext& ctx) {
+    if (expr.Maybe<TCoString>() || expr.Maybe<TCoParameter>() ||
+        expr.Maybe<TCoUint64>() || expr.Maybe<TCoArgument>()) {
+        return expr.Ptr();
+    }
+    return KqpPrecomputeParameter(expr, ctx).Ptr();
+}
+
+// Replace stage input at given index
+TVector<TExprBase> ReplaceStageInput(const TDqStage& stage, size_t index, TExprBase newInput) {
+    TVector<TExprBase> inputs;
+    for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
+        inputs.push_back(i == index ? newInput : stage.Inputs().Item(i));
+    }
+    return inputs;
 }
 
 } // anonymous namespace
@@ -440,34 +364,25 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
     // Check if input is directly TKqpReadTableRanges
     bool isReadTableRanges = input.Maybe<TKqpReadTableRanges>().IsValid();
 
-    // Also check if input is TDqCnUnionAll with a stage containing TKqpReadTableRanges
+    // Track various intermediate nodes
     TMaybeNode<TDqCnUnionAll> maybeCnUnionAll;
     TMaybeNode<TDqStage> maybeStage;
     TMaybeNode<TKqpReadTableRanges> maybeReadTableRanges;
-
-    // Track if there's a DqSource with KqpReadRangesSourceSettings
     TMaybeNode<TDqSource> maybeDqSource;
     TMaybeNode<TKqpReadRangesSourceSettings> maybeSourceSettings;
-    size_t sourceInputIndex = 0;
-
-    // Track if there's a FlatMap between TopSort and read (for ORDER BY alias case)
     TMaybeNode<TCoFlatMapBase> maybeFlatMap;
+    size_t sourceInputIndex = 0;
     TExprBase flatMapInput = input;
 
     // Check for FlatMap/Map (used when ORDER BY references an alias/computed column or subquery)
-    // The FlatMap/Map could be directly under TopSort or inside a TDqCnUnionAll stage
     if (input.Maybe<TCoFlatMapBase>()) {
         maybeFlatMap = input.Cast<TCoFlatMapBase>();
         flatMapInput = maybeFlatMap.Cast().Input();
     } else if (input.Maybe<TCoMap>()) {
         // TCoMap is used when the target vector comes from a subquery
-        // We treat it similarly to FlatMap for pattern matching
-        auto mapNode = input.Cast<TCoMap>();
-        flatMapInput = mapNode.Input();
-        // The Map's input might be another FlatMap wrapping DqCnUnionAll
+        flatMapInput = input.Cast<TCoMap>().Input();
         if (flatMapInput.Maybe<TCoFlatMapBase>()) {
-            auto innerFlatMap = flatMapInput.Cast<TCoFlatMapBase>();
-            flatMapInput = innerFlatMap.Input();
+            flatMapInput = flatMapInput.Cast<TCoFlatMapBase>().Input();
         }
     }
 
@@ -478,14 +393,13 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
             auto stage = maybeStage.Cast();
             auto stageBody = stage.Program().Body();
 
-            // Check if the stage program body is TKqpReadTableRanges directly
             maybeReadTableRanges = stageBody.Maybe<TKqpReadTableRanges>();
             if (maybeReadTableRanges) {
                 isReadTableRanges = true;
                 input = maybeReadTableRanges.Cast();
             }
 
-            // Also check if the stage body is a FlatMap over TKqpReadTableRanges
+            // Check if the stage body is a FlatMap over TKqpReadTableRanges
             // This happens when ORDER BY references an alias computed in the FlatMap
             if (!isReadTableRanges && stageBody.Maybe<TCoFlatMapBase>()) {
                 auto stageFlatMap = stageBody.Cast<TCoFlatMapBase>();
@@ -493,7 +407,6 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
                 if (maybeReadTableRanges) {
                     isReadTableRanges = true;
                     input = maybeReadTableRanges.Cast();
-                    // Use the FlatMap from the stage for alias resolution
                     if (!maybeFlatMap) {
                         maybeFlatMap = stageFlatMap;
                     }
@@ -514,8 +427,6 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
                         }
                     }
                 }
-
-                // Check if there's a FlatMap in the stage body for alias resolution
                 if (isReadTableRanges && stageBody.Maybe<TCoFlatMapBase>() && !maybeFlatMap) {
                     maybeFlatMap = stageBody.Cast<TCoFlatMapBase>();
                 }
@@ -527,31 +438,25 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
         return node;
     }
 
-    // Get table path and settings depending on whether we have direct read or source-based read
+    // Get table path and settings
     TCoAtom tablePath = maybeSourceSettings
         ? maybeSourceSettings.Cast().Table().Path()
         : GetReadTablePath(input, true);
-
     TKqpReadTableSettings settings = maybeSourceSettings
         ? TKqpReadTableSettings::Parse(maybeSourceSettings.Cast().Settings())
         : GetReadTableSettings(input, true);
-
-    // Check ranges - only apply to full table scans (no WHERE clause filtering)
-    // When there's a WHERE clause, the Ranges() will not be TCoVoid
     TExprBase rangesExpr = maybeSourceSettings
         ? maybeSourceSettings.Cast().RangesExpr()
         : input.Cast<TKqpReadTableRanges>().Ranges();
 
+    // Only apply to full table scans (no WHERE clause filtering)
     if (!TCoVoid::Match(rangesExpr.Raw())) {
         return node;
     }
 
-    // If there's a FlatMap, check if it's filtering (WHERE on non-key columns)
-    // We allow FlatMaps that add computed columns (ORDER BY alias), but reject filtering FlatMaps
-    // Filtering FlatMaps use OptionalIf/ListIf, while projection FlatMaps use Just/SingleAsList
+    // Reject filtering FlatMaps (OptionalIf/ListIf), allow projection FlatMaps (ORDER BY alias)
     if (maybeFlatMap) {
         auto flatMapBody = maybeFlatMap.Cast().Lambda().Body();
-        // Check if the FlatMap body is conditional (filtering)
         if (flatMapBody.Maybe<TCoOptionalIf>() || flatMapBody.Maybe<TCoListIf>()) {
             return node;
         }
@@ -568,7 +473,7 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
         return node; // already set
     }
 
-    // Check sort direction - only handle single direction (either all forward or all reverse)
+    // Check sort direction
     ESortDirection direction = GetSortDirection(topSort.SortDirections());
     if (direction != ESortDirection::Forward && direction != ESortDirection::Reverse) {
         return node;
@@ -576,48 +481,24 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
     const bool isAsc = (direction == ESortDirection::Forward);
 
     // Extract and validate KNN info
-    auto knnInfoAll = ExtractKnnInfoFromTopSort(topSort, maybeFlatMap);
     TString metric;
-    auto knnInfo = FindValidKnnCandidate(knnInfoAll, tableDesc, isAsc, metric);
+    auto knnInfo = FindValidKnnCandidate(ExtractKnnInfoFromTopSort(topSort, maybeFlatMap), tableDesc, isAsc, metric);
     if (!knnInfo) {
         return node;
     }
 
-    auto [columnName, methodName, targetExpr] = *knnInfo;
-
-    YQL_CLOG(TRACE, ProviderKqp) << "-- applying vector top-K pushdown for column " << columnName << " with metric " << metric;
-
-    // Set the vector top-K settings
+    auto [columnName, _, targetExpr] = *knnInfo;
     settings.VectorTopKColumn = columnName;
     settings.VectorTopKMetric = metric;
-
-    // Target expression - wrap in precompute if not a simple type
-    TExprBase targetExprBase(targetExpr);
-    if (targetExprBase.Maybe<TCoString>() || targetExprBase.Maybe<TCoParameter>() || targetExprBase.Maybe<TCoArgument>()) {
-        // TCoArgument represents a stage input (e.g., precomputed subquery result)
-        settings.VectorTopKTarget = targetExpr;
-    } else {
-        // Wrap non-simple expressions in precompute (TDqPhyPrecompute)
-        settings.VectorTopKTarget = KqpPrecomputeParameter(targetExprBase, ctx).Ptr();
-    }
-
-    // Limit expression - wrap in precompute if not a simple type
-    auto limitExpr = topSort.Count();
-    if (limitExpr.Maybe<TCoUint64>() || limitExpr.Maybe<TCoParameter>()) {
-        settings.VectorTopKLimit = limitExpr.Ptr();
-    } else {
-        settings.VectorTopKLimit = KqpPrecomputeParameter(limitExpr, ctx).Ptr();
-    }
+    settings.VectorTopKTarget = WrapInPrecompute(TExprBase(targetExpr), ctx);
+    settings.VectorTopKLimit = WrapInPrecompute(topSort.Count(), ctx);
 
     // Handle source-based read (data queries)
     if (maybeSourceSettings && maybeStage) {
         auto stage = maybeStage.Cast();
         auto oldSourceSettings = maybeSourceSettings.Cast();
 
-        // Build new settings node
         auto newSettingsNode = settings.BuildNode(ctx, oldSourceSettings.Settings().Pos());
-
-        // Build new source settings with updated read settings
         auto newSourceSettings = Build<TKqpReadRangesSourceSettings>(ctx, oldSourceSettings.Pos())
             .Table(oldSourceSettings.Table())
             .Columns(oldSourceSettings.Columns())
@@ -625,33 +506,17 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
             .RangesExpr(oldSourceSettings.RangesExpr())
             .ExplainPrompt(oldSourceSettings.ExplainPrompt())
             .Done();
-
-        // Build new source
         auto newSource = Build<TDqSource>(ctx, maybeDqSource.Cast().Pos())
             .Settings(newSourceSettings)
             .DataSource(maybeDqSource.Cast().DataSource())
             .Done();
-
-        // Rebuild inputs with the new source
-        TVector<TExprBase> newInputs;
-        for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
-            if (i == sourceInputIndex) {
-                newInputs.push_back(newSource);
-            } else {
-                newInputs.push_back(stage.Inputs().Item(i));
-            }
-        }
-
-        // Rebuild the stage with the new inputs
         auto newStage = Build<TDqStage>(ctx, stage.Pos())
             .Inputs()
-                .Add(newInputs)
+                .Add(ReplaceStageInput(stage, sourceInputIndex, newSource))
                 .Build()
             .Program(stage.Program())
             .Settings(stage.Settings())
             .Done();
-
-        // Rebuild the connection
         auto newCnUnionAll = Build<TDqCnUnionAll>(ctx, maybeCnUnionAll.Cast().Pos())
             .Output()
                 .Stage(newStage)
@@ -659,10 +524,8 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
                 .Build()
             .Done();
 
-        // If there was a FlatMap between TopSort and connection, preserve it
         TExprBase newTopSortInput = newCnUnionAll;
         if (maybeFlatMap && maybeFlatMap.Cast().Raw() != stage.Program().Body().Raw()) {
-            // FlatMap was outside the stage (between TopSort and CnUnionAll)
             if (maybeFlatMap.Cast().Maybe<TCoOrderedFlatMap>()) {
                 newTopSortInput = Build<TCoOrderedFlatMap>(ctx, maybeFlatMap.Cast().Pos())
                     .Input(newCnUnionAll)
@@ -686,18 +549,14 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
 
     auto newReadNode = BuildReadNode(node.Pos(), ctx, input, settings);
 
-    // If we found the read inside a stage, we need to rebuild the stage and connection
     if (maybeStage) {
         auto stage = maybeStage.Cast();
         auto stageBody = stage.Program().Body();
-
-        // Determine the new stage body
         TExprBase newStageBody = newReadNode;
 
-        // If the stage body was a FlatMap over the read, preserve the FlatMap structure and type
+        // Preserve FlatMap structure if present
         if (auto orderedFlatMap = stageBody.Maybe<TCoOrderedFlatMap>()) {
             if (orderedFlatMap.Cast().Input().Maybe<TKqpReadTableRanges>()) {
-                // Rebuild as OrderedFlatMap to preserve ordering semantics
                 newStageBody = Build<TCoOrderedFlatMap>(ctx, orderedFlatMap.Cast().Pos())
                     .Input(newReadNode)
                     .Lambda(orderedFlatMap.Cast().Lambda())
@@ -705,7 +564,6 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
             }
         } else if (auto flatMap = stageBody.Maybe<TCoFlatMap>()) {
             if (flatMap.Cast().Input().Maybe<TKqpReadTableRanges>()) {
-                // Rebuild as regular FlatMap
                 newStageBody = Build<TCoFlatMap>(ctx, flatMap.Cast().Pos())
                     .Input(newReadNode)
                     .Lambda(flatMap.Cast().Lambda())
@@ -713,7 +571,6 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
             }
         }
 
-        // Rebuild the stage with the new body
         auto newStage = Build<TDqStage>(ctx, stage.Pos())
             .Inputs(stage.Inputs())
             .Program()
@@ -722,8 +579,6 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
                 .Build()
             .Settings(stage.Settings())
             .Done();
-
-        // Rebuild the connection
         auto newCnUnionAll = Build<TDqCnUnionAll>(ctx, maybeCnUnionAll.Cast().Pos())
             .Output()
                 .Stage(newStage)
@@ -749,28 +604,19 @@ TExprBase KqpApplyVectorTopKToReadTable(TExprBase node, TExprContext& ctx, const
 
 namespace {
 
-// Helper to find TopSort in a stage body (recursively looking through Map/FlatMap)
+// Find TopSort in stage body (through Map/FlatMap/ToFlow wrappers)
 TMaybeNode<TCoTopSort> FindTopSortInBody(const TExprBase& body) {
-    if (auto topSort = body.Maybe<TCoTopSort>()) {
-        return topSort;
-    }
-    if (auto map = body.Maybe<TCoMap>()) {
-        return FindTopSortInBody(map.Cast().Lambda().Body());
-    }
-    if (auto flatMap = body.Maybe<TCoFlatMapBase>()) {
-        return FindTopSortInBody(flatMap.Cast().Lambda().Body());
-    }
-    if (auto toFlow = body.Maybe<TCoToFlow>()) {
-        return FindTopSortInBody(toFlow.Cast().Input());
-    }
+    if (auto t = body.Maybe<TCoTopSort>()) return t;
+    if (auto m = body.Maybe<TCoMap>()) return FindTopSortInBody(m.Cast().Lambda().Body());
+    if (auto f = body.Maybe<TCoFlatMapBase>()) return FindTopSortInBody(f.Cast().Lambda().Body());
+    if (auto t = body.Maybe<TCoToFlow>()) return FindTopSortInBody(t.Cast().Input());
     return {};
 }
 
-// Helper to build a precompute that extracts a column from a subquery result
+// Build precompute to extract column from subquery result
 TExprNode::TPtr BuildSubqueryTargetPrecompute(
     const TCoMember& member, const TDqPhyPrecompute& precompute, TExprContext& ctx) {
 
-    auto memberName = member.Name();
     auto newArg = Build<TCoArgument>(ctx, member.Pos())
         .Name("_kqp_extract_arg")
         .Done();
@@ -780,7 +626,7 @@ TExprNode::TPtr BuildSubqueryTargetPrecompute(
         .Struct<TCoUnwrap>()
             .Optional(newArg)
             .Build()
-        .Name(memberName)
+        .Name(member.Name())
         .Done();
     auto extractExpr = Build<TCoUnwrap>(ctx, member.Pos())
         .Optional(memberExpr)
@@ -807,6 +653,33 @@ TExprNode::TPtr BuildSubqueryTargetPrecompute(
                 .Build()
             .Build()
         .Done().Ptr();
+}
+
+// Resolve target expression for stage-based queries (handles subquery Member references)
+TExprNode::TPtr ResolveStageTarget(const TExprBase& expr, const TDqStage& stage, TExprContext& ctx) {
+    // Handle subquery: Member(arg, "column") where arg maps to DqPhyPrecompute input
+    if (auto member = expr.Maybe<TCoMember>()) {
+        if (auto arg = member.Cast().Struct().Maybe<TCoArgument>()) {
+            auto stageArgs = stage.Program().Args();
+            for (size_t i = 0; i < stageArgs.Size() && i < stage.Inputs().Size(); ++i) {
+                if (stageArgs.Arg(i).Raw() == arg.Cast().Raw()) {
+                    if (auto precompute = stage.Inputs().Item(i).Maybe<TDqPhyPrecompute>()) {
+                        return BuildSubqueryTargetPrecompute(member.Cast(), precompute.Cast(), ctx);
+                    }
+                }
+            }
+        }
+    }
+
+    // Reject expressions containing unresolved arguments
+    bool hasArgument = false;
+    VisitExpr(expr.Ref(), [&](const TExprNode& n) {
+        if (n.IsArgument()) { hasArgument = true; return false; }
+        return true;
+    });
+    if (hasArgument) return nullptr;
+
+    return WrapInPrecompute(expr, ctx);
 }
 
 } // anonymous namespace
@@ -865,65 +738,24 @@ TExprBase KqpApplyVectorTopKToStageWithSource(TExprBase node, TExprContext& ctx,
     const bool isAsc = (direction == ESortDirection::Forward);
 
     // Extract and validate KNN info
-    auto knnInfoAll = ExtractKnnInfoFromTopSort(topSort);
-    TString validMetric;
-    auto validKnnInfo = FindValidKnnCandidate(knnInfoAll, tableDesc, isAsc, validMetric);
-    if (!validKnnInfo) {
+    TString metric;
+    auto knnInfo = FindValidKnnCandidate(ExtractKnnInfoFromTopSort(topSort), tableDesc, isAsc, metric);
+    if (!knnInfo) {
         return node;
     }
 
-    auto [columnName, methodName, targetExpr] = *validKnnInfo;
-    TExprBase targetExprBase(targetExpr);
-    TExprNode::TPtr resolvedTarget;
-
-    // Handle subquery targets: Member(arg, "column") where arg -> DqPhyPrecompute
-    if (auto member = targetExprBase.Maybe<TCoMember>()) {
-        if (auto arg = member.Cast().Struct().Maybe<TCoArgument>()) {
-            auto stageArgs = stage.Program().Args();
-            for (size_t i = 0; i < stageArgs.Size() && i < stage.Inputs().Size(); ++i) {
-                if (stageArgs.Arg(i).Raw() == arg.Cast().Raw()) {
-                    if (auto precompute = stage.Inputs().Item(i).Maybe<TDqPhyPrecompute>()) {
-                        resolvedTarget = BuildSubqueryTargetPrecompute(member.Cast(), precompute.Cast(), ctx);
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    // For non-subquery cases
+    auto [columnName, _, targetExpr] = *knnInfo;
+    TExprNode::TPtr resolvedTarget = ResolveStageTarget(TExprBase(targetExpr), stage, ctx);
     if (!resolvedTarget) {
-        bool hasArgument = false;
-        VisitExpr(*targetExpr, [&](const TExprNode& n) {
-            if (n.IsArgument()) { hasArgument = true; return false; }
-            return true;
-        });
-        if (hasArgument) {
-            return node;
-        }
-        resolvedTarget = targetExprBase.Maybe<TCoString>() || targetExprBase.Maybe<TCoParameter>()
-            ? targetExpr
-            : KqpPrecomputeParameter(targetExprBase, ctx).Ptr();
+        return node;
     }
-    YQL_CLOG(TRACE, ProviderKqp) << "-- applying vector top-K pushdown (stage) for column " << columnName << " with metric " << validMetric;
 
-    // Set the vector top-K settings
     settings.VectorTopKColumn = columnName;
-    settings.VectorTopKMetric = validMetric;
+    settings.VectorTopKMetric = metric;
     settings.VectorTopKTarget = resolvedTarget;
+    settings.VectorTopKLimit = WrapInPrecompute(topSort.Count(), ctx);
 
-    // Limit expression
-    auto limitExpr = topSort.Count();
-    if (limitExpr.Maybe<TCoUint64>() || limitExpr.Maybe<TCoParameter>()) {
-        settings.VectorTopKLimit = limitExpr.Ptr();
-    } else {
-        settings.VectorTopKLimit = KqpPrecomputeParameter(limitExpr, ctx).Ptr();
-    }
-
-    // Build new settings node
     auto newSettingsNode = settings.BuildNode(ctx, sourceSettings.Settings().Pos());
-
-    // Build new source settings
     auto newSourceSettings = Build<TKqpReadRangesSourceSettings>(ctx, sourceSettings.Pos())
         .Table(sourceSettings.Table())
         .Columns(sourceSettings.Columns())
@@ -931,27 +763,14 @@ TExprBase KqpApplyVectorTopKToStageWithSource(TExprBase node, TExprContext& ctx,
         .RangesExpr(sourceSettings.RangesExpr())
         .ExplainPrompt(sourceSettings.ExplainPrompt())
         .Done();
-
-    // Build new source
     auto newSource = Build<TDqSource>(ctx, maybeDqSource.Cast().Pos())
         .Settings(newSourceSettings)
         .DataSource(maybeDqSource.Cast().DataSource())
         .Done();
 
-    // Rebuild inputs
-    TVector<TExprBase> newInputs;
-    for (size_t i = 0; i < stage.Inputs().Size(); ++i) {
-        if (i == sourceInputIndex) {
-            newInputs.push_back(newSource);
-        } else {
-            newInputs.push_back(stage.Inputs().Item(i));
-        }
-    }
-
-    // Rebuild the stage
     return Build<TDqStage>(ctx, stage.Pos())
         .Inputs()
-            .Add(newInputs)
+            .Add(ReplaceStageInput(stage, sourceInputIndex, newSource))
             .Build()
         .Program(stage.Program())
         .Settings(stage.Settings())

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_rules.h
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_rules.h
@@ -62,6 +62,9 @@ NYql::NNodes::TExprBase KqpApplyLimitToReadTable(NYql::NNodes::TExprBase node, N
 NYql::NNodes::TExprBase KqpApplyLimitToOlapReadTable(NYql::NNodes::TExprBase node, NYql::TExprContext& ctx,
     const TKqpOptimizeContext& kqpCtx);
 
+NYql::NNodes::TExprBase KqpApplyVectorTopKToReadTable(NYql::NNodes::TExprBase node, NYql::TExprContext& ctx,
+    const TKqpOptimizeContext& kqpCtx);
+
 NYql::NNodes::TExprBase KqpPushOlapFilter(NYql::NNodes::TExprBase node, NYql::TExprContext& ctx,
     const TKqpOptimizeContext& kqpCtx, NYql::TTypeAnnotationContext& typesCtx, NYql::IGraphTransformer &typeAnnTransformer);
 

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_rules.h
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_rules.h
@@ -65,6 +65,9 @@ NYql::NNodes::TExprBase KqpApplyLimitToOlapReadTable(NYql::NNodes::TExprBase nod
 NYql::NNodes::TExprBase KqpApplyVectorTopKToReadTable(NYql::NNodes::TExprBase node, NYql::TExprContext& ctx,
     const TKqpOptimizeContext& kqpCtx);
 
+NYql::NNodes::TExprBase KqpApplyVectorTopKToStageWithSource(NYql::NNodes::TExprBase node, NYql::TExprContext& ctx,
+    const TKqpOptimizeContext& kqpCtx);
+
 NYql::NNodes::TExprBase KqpPushOlapFilter(NYql::NNodes::TExprBase node, NYql::TExprContext& ctx,
     const TKqpOptimizeContext& kqpCtx, NYql::TTypeAnnotationContext& typesCtx, NYql::IGraphTransformer &typeAnnTransformer);
 

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -49,6 +49,8 @@ void SetVectorTopKMetric(Ydb::Table::VectorIndexSettings* indexSettings, const T
         indexSettings->set_metric(Ydb::Table::VectorIndexSettings::DISTANCE_MANHATTAN);
     } else if (metric == "EuclideanDistance") {
         indexSettings->set_metric(Ydb::Table::VectorIndexSettings::DISTANCE_EUCLIDEAN);
+    } else {
+        YQL_ENSURE(false, "Unrecognized VectorTopK metric: " << metric);
     }
 }
 

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -2,7 +2,6 @@
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
-#include <ydb/core/kqp/gateway/kqp_gateway.h>
 #include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/core/kqp/opt/kqp_opt.h>
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
@@ -65,13 +64,6 @@ void SetVectorTopKTarget(NKqpProto::TKqpPhyValue* targetProto, const TExprNode::
         literal->MutableValue()->SetText(TString(expr.Cast<TCoString>().Literal().Value()));
     } else if (expr.Maybe<TCoParameter>()) {
         targetProto->MutableParamValue()->SetParamName(expr.Cast<TCoParameter>().Name().StringValue());
-    } else if (auto maybeBinding = expr.Maybe<TKqpTxResultBinding>()) {
-        // TKqpTxResultBinding should have been replaced with TCoParameter by kqp_opt_build_txs,
-        // but handle it defensively by constructing the expected parameter name
-        auto binding = maybeBinding.Cast();
-        TString paramName = TStringBuilder() << ParamNamePrefix
-            << "tx_result_binding_" << binding.TxIndex().Value() << "_" << binding.ResultIndex().Value();
-        targetProto->MutableParamValue()->SetParamName(paramName);
     } else {
         YQL_ENSURE(false, "Unexpected VectorTopKTarget callable " << expr.Ref().Content());
     }
@@ -87,13 +79,6 @@ void SetVectorTopKLimit(NKqpProto::TKqpPhyValue* limitProto, const TExprNode::TP
         literal->MutableValue()->SetUint64(FromString<ui64>(expr.Cast<TCoUint64>().Literal().Value()));
     } else if (expr.Maybe<TCoParameter>()) {
         limitProto->MutableParamValue()->SetParamName(expr.Cast<TCoParameter>().Name().StringValue());
-    } else if (auto maybeBinding = expr.Maybe<TKqpTxResultBinding>()) {
-        // TKqpTxResultBinding should have been replaced with TCoParameter by kqp_opt_build_txs,
-        // but handle it defensively by constructing the expected parameter name
-        auto binding = maybeBinding.Cast();
-        TString paramName = TStringBuilder() << ParamNamePrefix
-            << "tx_result_binding_" << binding.TxIndex().Value() << "_" << binding.ResultIndex().Value();
-        limitProto->MutableParamValue()->SetParamName(paramName);
     } else {
         YQL_ENSURE(false, "Unexpected VectorTopKLimit callable " << expr.Ref().Content());
     }

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -65,7 +65,8 @@ void SetVectorTopKTarget(NKqpProto::TKqpPhyValue* targetProto, const TExprNode::
     } else if (expr.Maybe<TCoParameter>()) {
         targetProto->MutableParamValue()->SetParamName(expr.Cast<TCoParameter>().Name().StringValue());
     } else {
-        YQL_ENSURE(false, "Unexpected VectorTopKTarget callable " << expr.Ref().Content());
+        YQL_ENSURE(false, "Unexpected VectorTopKTarget callable '" << expr.Ref().Content()
+            << "'. Expected TCoString or TCoParameter.");
     }
 }
 
@@ -80,7 +81,8 @@ void SetVectorTopKLimit(NKqpProto::TKqpPhyValue* limitProto, const TExprNode::TP
     } else if (expr.Maybe<TCoParameter>()) {
         limitProto->MutableParamValue()->SetParamName(expr.Cast<TCoParameter>().Name().StringValue());
     } else {
-        YQL_ENSURE(false, "Unexpected VectorTopKLimit callable " << expr.Ref().Content());
+        YQL_ENSURE(false, "Unexpected VectorTopKLimit callable '" << expr.Ref().Content()
+            << "'. Expected TCoUint64 or TCoParameter.");
     }
 }
 
@@ -108,7 +110,8 @@ void FillVectorTopKSettings(
     auto* indexSettings = vectorTopK.MutableSettings();
     SetVectorTopKMetric(indexSettings, settings.VectorTopKMetric);
 
-    // Default vector settings - actual type will be determined from data
+    // Default vector settings: when vector_dimension is 0, actual type and dimension
+    // will be auto-detected from the target vector's format at runtime.
     indexSettings->set_vector_type(Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT);
     indexSettings->set_vector_dimension(0);
 

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
+#include <ydb/core/kqp/gateway/kqp_gateway.h>
 #include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/core/kqp/opt/kqp_opt.h>
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
@@ -64,6 +65,13 @@ void SetVectorTopKTarget(NKqpProto::TKqpPhyValue* targetProto, const TExprNode::
         literal->MutableValue()->SetText(TString(expr.Cast<TCoString>().Literal().Value()));
     } else if (expr.Maybe<TCoParameter>()) {
         targetProto->MutableParamValue()->SetParamName(expr.Cast<TCoParameter>().Name().StringValue());
+    } else if (auto maybeBinding = expr.Maybe<TKqpTxResultBinding>()) {
+        // TKqpTxResultBinding should have been replaced with TCoParameter by kqp_opt_build_txs,
+        // but handle it defensively by constructing the expected parameter name
+        auto binding = maybeBinding.Cast();
+        TString paramName = TStringBuilder() << ParamNamePrefix
+            << "tx_result_binding_" << binding.TxIndex().Value() << "_" << binding.ResultIndex().Value();
+        targetProto->MutableParamValue()->SetParamName(paramName);
     } else {
         YQL_ENSURE(false, "Unexpected VectorTopKTarget callable " << expr.Ref().Content());
     }
@@ -79,6 +87,13 @@ void SetVectorTopKLimit(NKqpProto::TKqpPhyValue* limitProto, const TExprNode::TP
         literal->MutableValue()->SetUint64(FromString<ui64>(expr.Cast<TCoUint64>().Literal().Value()));
     } else if (expr.Maybe<TCoParameter>()) {
         limitProto->MutableParamValue()->SetParamName(expr.Cast<TCoParameter>().Name().StringValue());
+    } else if (auto maybeBinding = expr.Maybe<TKqpTxResultBinding>()) {
+        // TKqpTxResultBinding should have been replaced with TCoParameter by kqp_opt_build_txs,
+        // but handle it defensively by constructing the expected parameter name
+        auto binding = maybeBinding.Cast();
+        TString paramName = TStringBuilder() << ParamNamePrefix
+            << "tx_result_binding_" << binding.TxIndex().Value() << "_" << binding.ResultIndex().Value();
+        limitProto->MutableParamValue()->SetParamName(paramName);
     } else {
         YQL_ENSURE(false, "Unexpected VectorTopKLimit callable " << expr.Ref().Content());
     }

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -893,6 +893,10 @@ public:
             record.SetLockNodeId(Settings->GetLockNodeId());
         }
 
+        if (Settings->HasVectorTopK()) {
+            *record.MutableVectorTopK() = Settings->GetVectorTopK();
+        }
+
         CA_LOG_D(TStringBuilder() << "Send EvRead to shardId: " << state->TabletId << ", tablePath: " << Settings->GetTable().GetTablePath()
             << ", ranges: " << DebugPrintRanges(KeyColumnTypes, ev->Ranges, *AppData()->TypeRegistry)
             << ", limit: " << limit

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -8,6 +8,7 @@
 #include <ydb/core/kqp/gateway/kqp_gateway.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/protos/tx_datashard.pb.h>
+#include <ydb/core/protos/query_stats.pb.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/datashard/range_ops.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
@@ -1380,6 +1381,11 @@ public:
             }
 
             auto id = result.ReadResult->Get()->Record.GetReadId();
+            // For VectorTopK pushdown, accumulate actual scanned rows from datashard stats
+            if (result.ProcessedRows == 0 && Settings->HasVectorTopK() && msg.Record.HasStats()) {
+                ScannedRowCount += msg.Record.GetStats().GetRows();
+                ScannedBytesCount += msg.Record.GetStats().GetBytes();
+            }
 
             for (; result.ProcessedRows < result.PackedRows; ++result.ProcessedRows) {
                 NMiniKQL::TBytesStatistics rowSize = GetRowSize((*batch)[result.ProcessedRows].GetElements());
@@ -1477,11 +1483,18 @@ public:
 
             }
 
-            auto consumedRows = mstats ? mstats->Inputs[InputIndex]->RowsConsumed : ReceivedRowCount;
-
             //FIXME: use real rows count
+            auto consumedRows = mstats ? mstats->Inputs[InputIndex]->RowsConsumed : ReceivedRowCount;
+            auto consumedBytes = mstats ? mstats->Inputs[InputIndex]->BytesConsumed : BytesStats.DataBytes;
+
+            // For VectorTopK pushdown, use actual scanned rows from datashard stats
+            if (Settings->HasVectorTopK()) {
+                consumedRows = ScannedRowCount;
+                consumedBytes = ScannedBytesCount;
+            }
+
             tableStats->SetReadRows(tableStats->GetReadRows() + consumedRows);
-            tableStats->SetReadBytes(tableStats->GetReadBytes() + (mstats ? mstats->Inputs[InputIndex]->BytesConsumed : BytesStats.DataBytes));
+            tableStats->SetReadBytes(tableStats->GetReadBytes() + consumedBytes);
             tableStats->SetAffectedPartitions(tableStats->GetAffectedPartitions() + InFlightShards.Size());
 
             //FIXME: use evread statistics after KIKIMR-16924
@@ -1619,6 +1632,8 @@ private:
 
     NMiniKQL::TBytesStatistics BytesStats;
     ui64 ReceivedRowCount = 0;
+    ui64 ScannedRowCount = 0;  // Actual rows scanned (for VectorTopK, may differ from ReceivedRowCount)
+    ui64 ScannedBytesCount = 0;
     ui64 ProcessedRowCount = 0;
     ui64 ResetReads = 0;
     ui64 ReadId = 0;

--- a/ydb/core/kqp/ut/cost/kqp_cost_ut.cpp
+++ b/ydb/core/kqp/ut/cost/kqp_cost_ut.cpp
@@ -391,7 +391,7 @@ Y_UNIT_TEST_SUITE(KqpCost) {
             )", name.c_str()));
 
             auto result = session.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx(), GetDataQuerySettings()).ExtractValueSync();
-        
+
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
 
             Cerr << name << ":" << Endl;
@@ -400,7 +400,7 @@ Y_UNIT_TEST_SUITE(KqpCost) {
 
         auto checkSelect = [&](auto query, TMap<TString, ui64> expectedReadsByTable) {
             auto result = session.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx(), GetDataQuerySettings()).ExtractValueSync();
-        
+
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
 
             auto stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
@@ -419,14 +419,14 @@ Y_UNIT_TEST_SUITE(KqpCost) {
             UNIT_ASSERT_VALUES_EQUAL_C(expectedReadsByTable, readsByTable, query);
         };
 
-        { // 5x. SELECT VIEW PRIMARY KEY
+        { // 5x. SELECT VIEW PRIMARY KEY (with brute force vector search pushdown)
             // SELECT Key
             checkSelect(Q_(R"(
                 SELECT Key FROM `/Root/Vectors` VIEW PRIMARY KEY
                     ORDER BY Knn::CosineDistance(Embedding, "pQ\x02")
                     LIMIT 10;
             )"), {
-                {"/Root/Vectors", 100} // full scan
+                {"/Root/Vectors", 10} // brute force vector search pushdown returns only LIMIT rows
             });
 
             // SELECT Key, Value --- same stats
@@ -435,7 +435,7 @@ Y_UNIT_TEST_SUITE(KqpCost) {
                     ORDER BY Knn::CosineDistance(Embedding, "pQ\x02")
                     LIMIT 10;
             )"), {
-                {"/Root/Vectors", 100}
+                {"/Root/Vectors", 10}
             });
         }
 
@@ -1120,7 +1120,7 @@ Y_UNIT_TEST_SUITE(KqpCost) {
         UNIT_ASSERT_VALUES_EQUAL(lhs.Reads, rhs.Reads);
         UNIT_ASSERT_VALUES_EQUAL(lhs.Deletes, rhs.Deletes);
     }
-    
+
 
     Y_UNIT_TEST_QUAD(WriteRow, isSink, isOlap) {
         if (isOlap) {

--- a/ydb/core/kqp/ut/cost/kqp_cost_ut.cpp
+++ b/ydb/core/kqp/ut/cost/kqp_cost_ut.cpp
@@ -426,7 +426,7 @@ Y_UNIT_TEST_SUITE(KqpCost) {
                     ORDER BY Knn::CosineDistance(Embedding, "pQ\x02")
                     LIMIT 10;
             )"), {
-                {"/Root/Vectors", 10} // brute force vector search pushdown returns only LIMIT rows
+                {"/Root/Vectors", 100} // brute force vector search pushdown returns only 10 rows but scans 100 rows
             });
 
             // SELECT Key, Value --- same stats
@@ -435,7 +435,7 @@ Y_UNIT_TEST_SUITE(KqpCost) {
                     ORDER BY Knn::CosineDistance(Embedding, "pQ\x02")
                     LIMIT 10;
             )"), {
-                {"/Root/Vectors", 10}
+                {"/Root/Vectors", 100}
             });
         }
 

--- a/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
+++ b/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
@@ -1,0 +1,246 @@
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+
+#include <ydb/core/tx/datashard/datashard.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+
+#include <ydb/library/testlib/helpers.h>
+
+namespace NKikimr {
+namespace NKqp {
+
+using namespace NYdb;
+using namespace NYdb::NTable;
+
+Y_UNIT_TEST_SUITE(KqpKnn) {
+
+    TSession CreateTableForVectorSearch(TTableClient& db, bool nullable, const TString& dataCol = "data") {
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto tableBuilder = db.GetTableBuilder();
+            if (nullable) {
+                tableBuilder
+                    .AddNullableColumn("pk", EPrimitiveType::Int64)
+                    .AddNullableColumn("emb", EPrimitiveType::String)
+                    .AddNullableColumn(dataCol, EPrimitiveType::String);
+            } else {
+                tableBuilder
+                    .AddNonNullableColumn("pk", EPrimitiveType::Int64)
+                    .AddNonNullableColumn("emb", EPrimitiveType::String)
+                    .AddNonNullableColumn(dataCol, EPrimitiveType::String);
+            }
+            tableBuilder.SetPrimaryKeyColumns({"pk"});
+            tableBuilder.BeginPartitioningSettings()
+                .SetMinPartitionsCount(3)
+            .EndPartitioningSettings();
+            auto partitions = TExplicitPartitions{}
+                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(4).EndTuple().Build())
+                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(6).EndTuple().Build());
+            tableBuilder.SetPartitionAtKeys(partitions);
+            auto result = session.CreateTable("/Root/TestTable", tableBuilder.Build()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.IsTransportError(), false);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            const TString query1 = TStringBuilder()
+                << "UPSERT INTO `/Root/TestTable` (pk, emb, " << dataCol << ") VALUES "
+                << "(0, \"\x03\x30\x02\", \"0\"),"
+                    "(1, \"\x13\x31\x02\", \"1\"),"
+                    "(2, \"\x23\x32\x02\", \"2\"),"
+                    "(3, \"\x53\x33\x02\", \"3\"),"
+                    "(4, \"\x43\x34\x02\", \"4\"),"
+                    "(5, \"\x50\x60\x02\", \"5\"),"
+                    "(6, \"\x61\x11\x02\", \"6\"),"
+                    "(7, \"\x12\x62\x02\", \"7\"),"
+                    "(8, \"\x75\x76\x02\", \"8\"),"
+                    "(9, \"\x76\x76\x02\", \"9\");";
+
+            auto result = session.ExecuteDataQuery(Q_(query1), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        return session;
+    }
+
+    Y_UNIT_TEST_TWIN(VectorSearchKnnPushdown, Nullable) {
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetUseRealThreads(false)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto runtime = kikimr.GetTestServer().GetRuntime();
+        runtime->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        auto db = kikimr.RunCall([&] { return kikimr.GetTableClient(); });
+        auto session = kikimr.RunCall([&] { return CreateTableForVectorSearch(db, Nullable, "___data"); });
+
+        ui64 expectedLimit = 3;
+        auto captureEvents = [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvDataShard::TEvRead::EventType) {
+                auto& read = ev->Get<TEvDataShard::TEvRead>()->Record;
+                UNIT_ASSERT(read.HasVectorTopK());
+                auto& topK = read.GetVectorTopK();
+                UNIT_ASSERT(topK.GetTargetVector() == "\x67\x71\x02");
+                UNIT_ASSERT_VALUES_EQUAL(topK.GetLimit(), expectedLimit);
+            }
+            return false;
+        };
+        runtime->SetEventFilter(captureEvents);
+
+        auto runQuery = [&](const TString& query) {
+            auto result = kikimr.RunCall([&] {
+                return session.ExecuteDataQuery(query,
+                    TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+            });
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        };
+
+        auto runQueryWithParams = [&](const TString& query, TParams params) {
+            auto result = kikimr.RunCall([&] {
+                return session.ExecuteDataQuery(query,
+                    TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(), params).ExtractValueSync();
+            });
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        };
+
+        // Explicit columns
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT pk, emb, ___data FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance(emb, $TargetEmbedding)
+            LIMIT 3
+        )"));
+
+        // Implicit columns
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance(emb, $TargetEmbedding)
+            LIMIT 3
+        )"));
+
+        // Inner product similarity
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::InnerProductSimilarity(emb, $TargetEmbedding) DESC
+            LIMIT 3
+        )"));
+
+        // Cosine similarity (DESC)
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::CosineSimilarity(emb, $TargetEmbedding) DESC
+            LIMIT 3
+        )"));
+
+        // Manhattan distance (ASC)
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::ManhattanDistance(emb, $TargetEmbedding)
+            LIMIT 3
+        )"));
+
+        // Euclidean distance (ASC)
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::EuclideanDistance(emb, $TargetEmbedding)
+            LIMIT 3
+        )"));
+
+        // Parameters
+        runQueryWithParams(Q_(R"(
+            DECLARE $TargetEmbedding AS String;
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance(emb, $TargetEmbedding)
+            LIMIT 3
+        )"), db.GetParamsBuilder()
+            .AddParam("$TargetEmbedding")
+                .String(TString("\x67\x71\x02", 3))
+                .Build()
+            .Build());
+
+        // LIMIT 1 (minimum)
+        expectedLimit = 1;
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance(emb, $TargetEmbedding)
+            LIMIT 1
+        )"));
+
+        // Larger LIMIT
+        expectedLimit = 100;
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance(emb, $TargetEmbedding)
+            LIMIT 100
+        )"));
+
+        // Verify actual results - check that top 3 PKs are correct
+        // Target vector is 0x67, 0x71 (103, 113)
+        // Cosine distances calculated:
+        //   pk=8 (117, 118): 0.000882 - closest
+        //   pk=5 (80, 96):   0.000985
+        //   pk=9 (118, 118): 0.001070
+        expectedLimit = 3;
+        {
+            TString query(Q_(R"(
+                $TargetEmbedding = String::HexDecode("677102");
+                SELECT pk, Knn::CosineDistance(emb, $TargetEmbedding) AS distance FROM `/Root/TestTable`
+                ORDER BY distance
+                LIMIT 3
+            )"));
+
+            auto result = kikimr.RunCall([&] {
+                return session.ExecuteDataQuery(query,
+                    TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+            });
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            // Extract PKs and distances from result
+            std::vector<std::pair<i64, float>> results;
+            auto parser = result.GetResultSetParser(0);
+            while (parser.TryNextRow()) {
+                i64 pk;
+                if constexpr (Nullable) {
+                    auto pkOpt = parser.ColumnParser("pk").GetOptionalInt64();
+                    UNIT_ASSERT(pkOpt.has_value());
+                    pk = *pkOpt;
+                } else {
+                    pk = parser.ColumnParser("pk").GetInt64();
+                }
+                auto distanceOpt = parser.ColumnParser("distance").GetOptionalFloat();
+                UNIT_ASSERT(distanceOpt.has_value());
+                float distance = *distanceOpt;
+                results.push_back({pk, distance});
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(results.size(), 3u);
+            UNIT_ASSERT_VALUES_EQUAL(results[0].first, 8);
+            UNIT_ASSERT_VALUES_EQUAL(results[1].first, 5);
+            UNIT_ASSERT_VALUES_EQUAL(results[2].first, 9);
+
+            // Check exact distance values (with small epsilon for float comparison)
+            auto checkDistance = [](float actual, float expected) {
+                UNIT_ASSERT_C(std::abs(actual - expected) < 0.0001f,
+                    "Expected distance " << expected << ", got " << actual);
+            };
+            checkDistance(results[0].second, 0.000882f);
+            checkDistance(results[1].second, 0.000985f);
+            checkDistance(results[2].second, 0.001070f);
+        }
+    }
+
+}
+
+}
+}
+

--- a/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
+++ b/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
@@ -302,11 +302,18 @@ Y_UNIT_TEST_SUITE(KqpKnn) {
                 (1, "\x67\x71\x02")
             )"));
 
-            // Run query with subquery
-            expectedLimit = 3;
+            // Run query with subquery target, normal argument order (column first)
             runQuery(Q_(R"(
                 $TargetEmbedding = (SELECT target_emb FROM `/Root/TargetVectors` WHERE id = 1);
                 SELECT pk, Knn::CosineDistance(emb, $TargetEmbedding) AS distance FROM `/Root/TestTable`
+                ORDER BY distance
+                LIMIT 3
+            )"));
+
+            // Run query with subquery target, reversed argument order (target first)
+            runQuery(Q_(R"(
+                $TargetEmbedding = (SELECT target_emb FROM `/Root/TargetVectors` WHERE id = 1);
+                SELECT pk, Knn::CosineDistance($TargetEmbedding, emb) AS distance FROM `/Root/TestTable`
                 ORDER BY distance
                 LIMIT 3
             )"));

--- a/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
+++ b/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
@@ -152,18 +152,33 @@ Y_UNIT_TEST_SUITE(KqpKnn) {
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         };
 
-        // Literal target vector
+        // Literal target vector, normal order (column, target)
         runQuery(Q_(R"(
             SELECT pk FROM `/Root/TestTable`
             ORDER BY Knn::CosineDistance(emb, "\x67\x71\x02")
             LIMIT 3
         )"));
 
-        // Explicit columns
+        // Literal target vector, reversed order (target, column)
+        runQuery(Q_(R"(
+            SELECT pk FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance("\x67\x71\x02", emb)
+            LIMIT 3
+        )"));
+
+        // Variable equal to function call, normal order (column, target)
         runQuery(Q_(R"(
             $TargetEmbedding = String::HexDecode("677102");
             SELECT pk, emb, ___data FROM `/Root/TestTable`
             ORDER BY Knn::CosineDistance(emb, $TargetEmbedding)
+            LIMIT 3
+        )"));
+
+        // Variable equal to function call, reversed order (target, column)
+        runQuery(Q_(R"(
+            $TargetEmbedding = String::HexDecode("677102");
+            SELECT pk, emb, ___data FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance($TargetEmbedding, emb)
             LIMIT 3
         )"));
 

--- a/ydb/core/kqp/ut/knn/ya.make
+++ b/ydb/core/kqp/ut/knn/ya.make
@@ -1,0 +1,27 @@
+UNITTEST_FOR(ydb/core/kqp)
+
+FORK_SUBTESTS()
+SPLIT_FACTOR(50)
+
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    SIZE(LARGE)
+    TAG(ya:fat)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+SRCS(
+    kqp_knn_ut.cpp
+)
+
+PEERDIR(
+    ydb/core/kqp
+    ydb/core/kqp/ut/common
+    ydb/library/yql/udfs/common/knn
+    yql/essentials/sql/pg_dummy
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()
+

--- a/ydb/core/kqp/ut/ya.make
+++ b/ydb/core/kqp/ut/ya.make
@@ -11,6 +11,7 @@ RECURSE_FOR_TESTS(
     indexes
     idx_test
     join
+    knn
     olap
     opt
     perf

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -224,6 +224,8 @@ message TKqpPhyOpReadRanges {
     TKqpPhyValue ItemsLimit = 2;
     // Reverse sign, i.e. if user ask ORDER BY ... DESC we need to read table in reverse direction
     bool Reverse = 3;
+    // Vector top-K pushdown settings for brute force vector search
+    TKqpPhyVectorTopK VectorTopK = 4;
 }
 
 message TKqpPhyTableOperation {
@@ -411,6 +413,8 @@ message TKqpReadRangesSource {
     repeated string SkipNullKeys = 8;
     uint64 SequentialInFlightShards = 9;
     bool IsTableImmutable = 10;
+    // Vector top-K pushdown for brute force vector search
+    TKqpPhyVectorTopK VectorTopK = 11;
 }
 
 message TKqpExternalSource {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -276,6 +276,9 @@ message TKqpReadRangesSourceSettings {
     optional NKikimrKqp.EIsolationLevel IsolationLevel = 24 [default = ISOLATION_LEVEL_UNDEFINED];
 
     optional string Database = 25;
+
+    // Vector top-K pushdown for brute force vector search
+    optional NKikimrKqp.TReadVectorTopK VectorTopK = 26;
 }
 
 // Takes input rows with a vector column, resolves the leaf cluster ID using the given

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -2213,7 +2213,12 @@ public:
             } else if (!topK.HasTargetVector()) {
                 error = "Target vector is not specified";
             } else {
-                topState->KMeans = NKMeans::CreateClusters(topK.GetSettings(), 0, error);
+                // Use auto-detect if vector_dimension is 0 (brute force search without index)
+                if (topK.GetSettings().vector_dimension() == 0) {
+                    topState->KMeans = NKMeans::CreateClustersAutoDetect(topK.GetSettings(), topK.GetTargetVector(), 0, error);
+                } else {
+                    topState->KMeans = NKMeans::CreateClusters(topK.GetSettings(), 0, error);
+                }
                 if (!topState->KMeans && error == "") {
                     error = "CreateClusters failed";
                 }

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -2219,7 +2219,7 @@ public:
                 } else {
                     topState->KMeans = NKMeans::CreateClusters(topK.GetSettings(), 0, error);
                 }
-                if (!topState->KMeans && error == "") {
+                if (!topState->KMeans && error.empty()) {
                     error = "CreateClusters failed";
                 }
                 if (topState->KMeans && !topState->KMeans->IsExpectedFormat(topK.GetTargetVector())) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add optimization rule KqpApplyVectorTopKToReadTable that pushes down
ORDER BY Knn::*Distance/Similarity(...) LIMIT N queries to datashards.

It gives boost x25 in latency and RPS 

### Changelog category <!-- remove all except one -->


* Performance improvement


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
