### PR TITLE
Support reconfiguration of BlobDepot

### DIFF
--- a/ydb/apps/dstool/lib/commands.py
+++ b/ydb/apps/dstool/lib/commands.py
@@ -27,6 +27,7 @@ import ydb.apps.dstool.lib.dstool_cmd_group_state as group_state
 import ydb.apps.dstool.lib.dstool_cmd_group_take_snapshot as group_take_snapshot
 import ydb.apps.dstool.lib.dstool_cmd_group_virtual_create as group_virtual_create
 import ydb.apps.dstool.lib.dstool_cmd_group_virtual_cancel as group_virtual_cancel
+import ydb.apps.dstool.lib.dstool_cmd_group_virtual_reconfigure as group_virtual_reconfigure
 
 import ydb.apps.dstool.lib.dstool_cmd_pool_create_virtual as pool_create_virtual
 import ydb.apps.dstool.lib.dstool_cmd_pool_list as pool_list
@@ -52,7 +53,7 @@ modules = [
     box_list,
     pool_list, pool_create_virtual,
     group_check, group_decommit, group_show_blob_info, group_show_storage_efficiency, group_show_usage_by_tablets,
-    group_state, group_take_snapshot, group_add, group_list, group_virtual_create, group_virtual_cancel,
+    group_state, group_take_snapshot, group_add, group_list, group_virtual_create, group_virtual_cancel, group_virtual_reconfigure,
     pdisk_add_by_serial, pdisk_remove_by_serial, pdisk_set, pdisk_list, pdisk_stop, pdisk_restart, pdisk_readonly, pdisk_move,
     vdisk_evict, vdisk_list, vdisk_set_read_only, vdisk_remove_donor, vdisk_wipe, vdisk_compact, device_list,
 ]
@@ -61,7 +62,7 @@ default_structure = [
     ('device', ['list']),
     ('pdisk', ['add-by-serial', 'remove-by-serial', 'set', 'list', 'stop', 'restart', 'readonly', 'move']),
     ('vdisk', ['evict', 'list', 'set-read-only', 'remove-donor', 'wipe', 'compact']),
-    ('group', ['add', 'check', 'decommit', ('show', ['blob-info', 'storage-efficiency', 'usage-by-tablets']), 'state', 'take-snapshot', 'list', ('virtual', ['create', 'cancel'])]),
+    ('group', ['add', 'check', 'decommit', ('show', ['blob-info', 'storage-efficiency', 'usage-by-tablets']), 'state', 'take-snapshot', 'list', ('virtual', ['create', 'cancel', 'reconfigure'])]),
     ('pool', ['list', ('create', ['virtual'])]),
     ('box', ['list']),
     ('node', ['list']),

--- a/ydb/apps/dstool/lib/dstool_cmd_group_virtual_reconfigure.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_group_virtual_reconfigure.py
@@ -1,0 +1,28 @@
+import ydb.apps.dstool.lib.common as common
+from argparse import FileType
+import google.protobuf.json_format as pb_json
+
+description = 'Create virtual group backed by BlobDepot'
+
+
+def add_options(p):
+    p.add_argument('--name', type=str, required=True, help='name of virtual group that requires reconfiguring')
+    p.add_argument('--s3-settings', type=FileType('r', encoding='utf-8'), metavar='JSON_FILE', help='path to JSON file containing S3 settings')
+
+
+def do(args):
+    request = common.create_bsc_request(args)
+
+    if args.s3_settings:
+        s3_settings = args.s3_settings.read()
+    else:
+        s3_settings = None
+
+    cmd = request.Command.add().ReconfigureVirtualGroup
+    cmd.Name = args.name
+
+    if s3_settings is not None:
+        pb_json.Parse(s3_settings, cmd.S3BackendSettings)
+
+    response = common.invoke_bsc_request(request)
+    common.print_request_result(args, request, response)

--- a/ydb/apps/dstool/lib/ya.make
+++ b/ydb/apps/dstool/lib/ya.make
@@ -38,6 +38,7 @@ PY_SRCS(
     dstool_cmd_group_take_snapshot.py
     dstool_cmd_group_virtual_create.py
     dstool_cmd_group_virtual_cancel.py
+    dstool_cmd_group_virtual_reconfigure.py
 
     dstool_cmd_pool_create_virtual.py
     dstool_cmd_pool_list.py

--- a/ydb/core/blob_depot/data.cpp
+++ b/ydb/core/blob_depot/data.cpp
@@ -88,6 +88,10 @@ namespace NKikimr::NBlobDepot {
             return false; // no such key existed and will not be created as it hits the barrier
         }
 
+        Y_DEFER {
+            Self->JsonHandler.Invalidate();
+        };
+
         const auto [it, inserted] = Data.try_emplace(std::move(key), std::forward<TArgs>(args)...);
         {
             auto& [key, value] = *it;

--- a/ydb/core/blob_depot/op_apply_config.cpp
+++ b/ydb/core/blob_depot/op_apply_config.cpp
@@ -50,6 +50,9 @@ namespace NKikimr::NBlobDepot {
 
                 if (!std::exchange(Self->Configured, true)) {
                     Self->StartOperation();
+                } else {
+                    // TODO(alexvru): handle it in a better way, without tablet restart
+                    Self->Send(Self->Tablet(), new TEvents::TEvPoison);
                 }
 
                 TActivationContext::Send(Response.release());

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -1163,6 +1163,7 @@ ui32 TBlobStorageController::GetEventPriority(IEventHandle *ev) {
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kGetInterfaceVersion:
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kMovePDisk:
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kUpdateBridgeGroupInfo:
+                    case NKikimrBlobStorage::TConfigRequest::TCommand::kReconfigureVirtualGroup:
                         return 2; // read-write commands go with higher priority as they are needed to keep cluster intact
 
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kReadHostConfig:

--- a/ydb/core/mind/bscontroller/config.h
+++ b/ydb/core/mind/bscontroller/config.h
@@ -366,6 +366,7 @@ namespace NKikimr {
             void ExecuteStep(const NKikimrBlobStorage::TGetInterfaceVersion& cmd, TStatus& status);
             void ExecuteStep(const NKikimrBlobStorage::TMovePDisk& cmd, TStatus& status);
             void ExecuteStep(const NKikimrBlobStorage::TUpdateBridgeGroupInfo& cmd, TStatus& status);
+            void ExecuteStep(const NKikimrBlobStorage::TReconfigureVirtualGroup& cmd, TStatus& status);
         };
 
     } // NBsController

--- a/ydb/core/mind/bscontroller/config_cmd.cpp
+++ b/ydb/core/mind/bscontroller/config_cmd.cpp
@@ -254,6 +254,7 @@ namespace NKikimr::NBsController {
                             MAP_TIMING(SanitizeGroup, SANITIZE_GROUP)
                             MAP_TIMING(CancelVirtualGroup, CANCEL_VIRTUAL_GROUP)
                             MAP_TIMING(ChangeGroupSizeInUnits, CHANGE_GROUP_SIZE_IN_UNITS)
+                            MAP_TIMING(ReconfigureVirtualGroup, RECONFIGURE_VIRTUAL_GROUP)
 
                             default:
                                 break;
@@ -374,6 +375,7 @@ namespace NKikimr::NBsController {
                     HANDLE_COMMAND(GetInterfaceVersion)
                     HANDLE_COMMAND(MovePDisk)
                     HANDLE_COMMAND(UpdateBridgeGroupInfo)
+                    HANDLE_COMMAND(ReconfigureVirtualGroup)
 
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kAddMigrationPlan:
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kDeleteMigrationPlan:

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -599,6 +599,11 @@ message TUpdateBridgeGroupInfo {
     NKikimrBlobStorage.TGroupInfo BridgeGroupInfo = 3; // new value for bridge group info
 }
 
+message TReconfigureVirtualGroup {
+    string Name = 1;
+    optional NKikimrBlobDepot.TS3BackendSettings S3BackendSettings = 2;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // INTERFACE PART
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -649,6 +654,7 @@ message TConfigRequest {
             TChangeGroupSizeInUnits ChangeGroupSizeInUnits = 52;
             TMovePDisk MovePDisk = 53;
             TUpdateBridgeGroupInfo UpdateBridgeGroupInfo = 54;
+            TReconfigureVirtualGroup ReconfigureVirtualGroup = 55;
 
             // commands intended for internal use
             TReassignGroupDisk ReassignGroupDisk = 19;

--- a/ydb/core/protos/counters_bs_controller.proto
+++ b/ydb/core/protos/counters_bs_controller.proto
@@ -91,6 +91,8 @@ enum ECumulativeCounters {
     COUNTER_GROUP_LAYOUT_SANITIZER_BSC_ERR = 47 [(CounterOpts) = {Name: "GroupLayoutSanitizerBscErr"}];
 
     COUNTER_CONFIGCMD_CHANGE_GROUP_SIZE_IN_UNITS_USEC = 48 [(CounterOpts) = {Name: "ChangeGroupSizeInUnits"}];
+
+    COUNTER_CONFIGCMD_RECONFIGURE_VIRTUAL_GROUP_USEC = 49 [(CounterOpts) = {Name: "ReconfigureVirtualGroup"}];
 }
 
 enum EPercentileCounters {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support reconfiguration of BlobDepot

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch adds a command to reconfigure BlobDepot (mainly purposed for S3 over BD).
