### PR TITLE
Add exclude regexps to export/import S3 API (RFC)

### DIFF
--- a/ydb/public/api/protos/ydb_export.proto
+++ b/ydb/public/api/protos/ydb_export.proto
@@ -44,6 +44,11 @@ message ExportToYtSettings {
     string description = 5 [(length).le = 128];
     uint32 number_of_retries = 6;
     bool use_type_v3 = 7;
+
+    // Patterns (PCRE) for paths excluded from export operation.
+    // - Patterns are matched against the object path relative to database root path.
+    // - Object is excluded from export operation if it matches any of the specified exclude regexps.
+    repeated string exclude_regexps = 8;
 }
 
 message ExportToYtResult {
@@ -145,6 +150,11 @@ message ExportToS3Settings {
     // and reduces export time, but it can potentially increase the import time.
     // Indexes can be materialized, then their data will be uploaded during export and downloaded during import.
     bool materialize_indexes = 16;
+
+    // Patterns (PCRE) for paths excluded from export operation.
+    // - Patterns are matched against the object path relative to the export's source_path.
+    // - Object is excluded from export operation if it matches any of the specified exclude regexps.
+    repeated string exclude_regexps = 17;
 }
 
 message ExportToS3Result {
@@ -209,16 +219,16 @@ message ExportToFsSettings {
     // Example: /mnt/exports
     // SchemaMapping file with the list of objects is written to this path
     string base_path = 1 [(required) = true];
-    
+
     // List of items to export
     repeated Item items = 2;
-    
+
     // Optional description
     string description = 3 [(length).le = 128];
-    
+
     // Number of retries for failed operations
     uint32 number_of_retries = 4;
-    
+
     // Codec used to compress data. Codecs are available:
     // - zstd.
     // - zstd-N, where N is compression level, e.g. zstd-3.
@@ -232,6 +242,11 @@ message ExportToFsSettings {
     // Defaults to database root if not provided.
     // All object names are calculated and written relative to this path.
     string source_path = 7;
+
+    // Patterns (PCRE) for paths excluded from export operation.
+    // - Patterns are matched against the object path relative to the export's source_path.
+    // - Object is excluded from export operation if it matches any of the specified exclude regexps.
+    repeated string exclude_regexps = 8;
 }
 
 message ExportToFsResult {

--- a/ydb/public/api/protos/ydb_import.proto
+++ b/ydb/public/api/protos/ydb_import.proto
@@ -115,6 +115,11 @@ message ImportFromS3Settings {
     // Index filling mode.
     // If not specified, indexes will be built.
     IndexFillingMode index_filling_mode = 16;
+
+    // Patterns (PCRE) for paths excluded from import operation.
+    // - Patterns are matched against the database object names stored in the backup listing.
+    // - Object is excluded from import operation if it matches any of the specified exclude regexps.
+    repeated string exclude_regexps = 17;
 }
 
 message ImportFromS3Result {
@@ -188,6 +193,11 @@ message ImportFromFsSettings {
     // If encryption_settings field is not specified,
     // the resulting data is considered not encrypted.
     Ydb.Export.EncryptionSettings encryption_settings = 8;
+
+    // Patterns (PCRE) for paths excluded from import operation.
+    // - Patterns are matched against the database object names stored in the backup listing.
+    // - Object is excluded from import operation if it matches any of the specified exclude regexps.
+    repeated string exclude_regexps = 9;
 }
 
 message ImportFromFsResult {
@@ -243,6 +253,11 @@ message ListObjectsInS3ExportSettings {
     // If encryption_settings field is not specified,
     // the resulting data is considered not encrypted.
     Ydb.Export.EncryptionSettings encryption_settings = 11;
+
+    // Patterns (PCRE) for paths excluded from import operation.
+    // - Patterns are matched against the database object names stored in the backup listing.
+    // - Object is excluded from import operation if it matches any of the specified exclude regexps.
+    repeated string exclude_regexps = 12;
 }
 
 message ListObjectsInS3ExportResult {
@@ -306,6 +321,11 @@ message ListObjectsInFsExportSettings {
     // If encryption_settings field is not specified,
     // the resulting data is considered not encrypted.
     Ydb.Export.EncryptionSettings encryption_settings = 4;
+
+    // Patterns (PCRE) for paths excluded from import operation.
+    // - Patterns are matched against the database object names stored in the backup listing.
+    // - Object is excluded from import operation if it matches any of the specified exclude regexps.
+    repeated string exclude_regexps = 5;
 }
 
 message ListObjectsInFsExportResult {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added exclude_regexps field to export/import S3 API according to RFC: https://github.com/ydb-platform/ydb-rfc/blob/exclude-server-side-in-export-import/exclude_in_export_import.md