### PR TITLE
Use fixed database labels order and avoid quadratic lookups

### DIFF
--- a/ydb/core/base/counters.h
+++ b/ydb/core/base/counters.h
@@ -4,6 +4,7 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
 #include <util/generic/hash_set.h>
+#include <util/generic/vector.h>
 
 namespace NKikimr {
     constexpr char DATABASE_LABEL[] = "database";
@@ -22,7 +23,8 @@ namespace NKikimr {
     const THashSet<TString> &GetDatabaseSensorServices();
     // Get list of services which use top-level database attribute labels for own sensors.
     const THashSet<TString> &GetDatabaseAttributeSensorServices();
-    const THashSet<TString> &GetDatabaseAttributeLabels();
+    // Get a list of attribute labels (order is important)
+    const TVector<TString> &GetDatabaseAttributeLabels();
     // Drop all extra labels.
     void ReplaceSubgroup(TIntrusivePtr<::NMonitoring::TDynamicCounters> root, const TString &service);
 } // namespace NKikimr

--- a/ydb/core/mind/tenant_ut_pool.cpp
+++ b/ydb/core/mind/tenant_ut_pool.cpp
@@ -57,7 +57,8 @@ void CheckLabels(TIntrusivePtr<::NMonitoring::TDynamicCounters> counters,
     allServices.insert(attrServices.begin(), attrServices.end());
 
     for (auto &service : allServices) {
-        THashSet<TString> allLabels = GetDatabaseAttributeLabels();
+        const TVector<TString>& attrLabelNames = GetDatabaseAttributeLabels();
+        THashSet<TString> allLabels(attrLabelNames.begin(), attrLabelNames.end());
         allLabels.insert(DATABASE_LABEL);
         allLabels.insert(SLOT_LABEL);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Avoid excessive cpu usage when registering large number of service counters. Fixes #29606.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Order of database labels is now fixed (should be synchronized between counters and labels maintainer actor for efficiency) and we try to descend the tree once for each such label when performing service counters lookups. When orders match we perform at most two such lookups with logarithmic complexity in the number of trailing subgroups (`12 * O(log N)` string comparions for 6 labels), which is still better than linear complexity for a large number of counters (was `O(N)` where `N` is the number of subgroups after the last label).