### PR TITLE
Abort export if the factory is not created

### DIFF
--- a/ydb/core/tx/datashard/backup_unit.cpp
+++ b/ydb/core/tx/datashard/backup_unit.cpp
@@ -56,6 +56,10 @@ protected:
 
             if (auto* exportFactory = appData->DataShardExportFactory) {
                 std::shared_ptr<IExport>(exportFactory->CreateExportToYt(backup, columns)).swap(exp);
+                if (!exp) {
+                    Abort(op, ctx, "Failed to create YT export");
+                    return false;
+                }
             } else {
                 Abort(op, ctx, "Exports to YT are disabled");
                 return false;
@@ -70,6 +74,10 @@ protected:
 
             if (auto* exportFactory = appData->DataShardExportFactory) {
                 std::shared_ptr<IExport>(exportFactory->CreateExportToS3(backup, columns)).swap(exp);
+                if (!exp) {
+                    Abort(op, ctx, "Failed to create S3 export");
+                    return false;
+                }
             } else {
                 Abort(op, ctx, "Exports to S3 are disabled");
                 return false;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix coredump when export factory is not created.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
