### PR TITLE
Add BackupBytesBatchSize to datashard config

### DIFF
--- a/ydb/core/protos/datashard_config.proto
+++ b/ydb/core/protos/datashard_config.proto
@@ -6,7 +6,7 @@ message TDataShardConfig {
     optional uint32 BackupTaskPriority = 2 [default = 10];
     optional uint64 BackupReadAheadLo = 3 [default = 524288];
     optional uint64 BackupReadAheadHi = 4 [default = 1048576];
-    optional uint64 BackupBytesBatchSize = 25 [default = 33554432]; // 32 MB
+    optional uint64 BackupBytesBatchSize = 27 [default = 33554432]; // 32 MB
     optional uint64 KeepSnapshotTimeout = 5 [default = 300000]; // milliseconds
     optional uint64 ChangesQueueItemsLimit = 6 [default = 10000];
     optional uint64 ChangesQueueBytesLimit = 7 [default = 131072000]; // 125 MB

--- a/ydb/core/protos/datashard_config.proto
+++ b/ydb/core/protos/datashard_config.proto
@@ -6,7 +6,7 @@ message TDataShardConfig {
     optional uint32 BackupTaskPriority = 2 [default = 10];
     optional uint64 BackupReadAheadLo = 3 [default = 524288];
     optional uint64 BackupReadAheadHi = 4 [default = 1048576];
-    optional uint64 BackupBytesBatchSize = 27 [default = 33554432]; // 32 MB
+    optional uint64 BackupBytesBatchSize = 30 [default = 33554432]; // 32 MB
     optional uint64 KeepSnapshotTimeout = 5 [default = 300000]; // milliseconds
     optional uint64 ChangesQueueItemsLimit = 6 [default = 10000];
     optional uint64 ChangesQueueBytesLimit = 7 [default = 131072000]; // 125 MB

--- a/ydb/core/protos/datashard_config.proto
+++ b/ydb/core/protos/datashard_config.proto
@@ -6,6 +6,7 @@ message TDataShardConfig {
     optional uint32 BackupTaskPriority = 2 [default = 10];
     optional uint64 BackupReadAheadLo = 3 [default = 524288];
     optional uint64 BackupReadAheadHi = 4 [default = 1048576];
+    optional uint64 BackupBytesBatchSize = 25 [default = 33554432]; // 32 MB
     optional uint64 KeepSnapshotTimeout = 5 [default = 300000]; // milliseconds
     optional uint64 ChangesQueueItemsLimit = 6 [default = 10000];
     optional uint64 ChangesQueueBytesLimit = 7 [default = 131072000]; // 125 MB

--- a/ydb/core/tx/datashard/export_s3_buffer.cpp
+++ b/ydb/core/tx/datashard/export_s3_buffer.cpp
@@ -6,6 +6,8 @@
 #include "type_serialization.h"
 
 #include <ydb/core/backup/common/checksum.h>
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/protos/datashard_config.pb.h>
 #include <ydb/core/protos/s3_settings.pb.h>
 #include <ydb/core/tablet_flat/flat_row_state.h>
 #include <yql/essentials/types/binary_json/read.h>
@@ -439,7 +441,10 @@ IExport::IBuffer* TS3Export::CreateBuffer() const {
 
     const auto& scanSettings = Task.GetScanSettings();
     const ui64 maxRows = scanSettings.GetRowsBatchSize() ? scanSettings.GetRowsBatchSize() : Max<ui64>();
-    const ui64 maxBytes = scanSettings.GetBytesBatchSize();
+
+    const ui64 configMaxBytes = AppData()->DataShardConfig.GetBackupBytesBatchSize();
+    const ui64 maxBytes = scanSettings.HasBytesBatchSize() ? scanSettings.GetBytesBatchSize() : configMaxBytes;
+
     const ui64 minBytes = Task.GetS3Settings().GetLimits().GetMinWriteBatchSize();
 
     TS3ExportBufferSettings bufferSettings;

--- a/ydb/core/yt/export_yt.cpp
+++ b/ydb/core/yt/export_yt.cpp
@@ -7,6 +7,8 @@
     #include <ydb/core/protos/flat_scheme_op.deps.pb.h> // Y_IGNORE
 #endif
 #include <ydb/library/services/services.pb.h>
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/protos/datashard_config.pb.h>
 #include <ydb/core/tablet_flat/flat_row_state.h>
 #include <ydb/core/tx/datashard/export_common.h>
 #include <ydb/core/tx/datashard/type_serialization.h>
@@ -686,7 +688,9 @@ IBuffer* TYtExport::CreateBuffer() const {
     const auto& settings = Task.GetYTSettings();
     const auto& scanSettings = Task.GetScanSettings();
     const ui64 maxRows = scanSettings.GetRowsBatchSize() ? scanSettings.GetRowsBatchSize() : Max<ui64>();
-    const ui64 maxBytes = scanSettings.GetBytesBatchSize();
+
+    const ui64 configMaxBytes = AppData()->DataShardConfig.GetBackupBytesBatchSize();
+    const ui64 maxBytes = scanSettings.HasBytesBatchSize() ? scanSettings.GetBytesBatchSize() : configMaxBytes;
 
     return new TYtBuffer(Columns, maxRows, maxBytes, settings.GetUseTypeV3());
 }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds a new configuration parameter `BackupBytesBatchSize` to the datashard config to provide a default bytes batch size for backup operations.

- Adds `BackupBytesBatchSize` field to `TDataShardConfig` protobuf with a default value of 32 MB (33554432 bytes)
- Updates S3 and YT export buffer creation logic to use the config value as a fallback when scan settings don't specify a bytes batch size
