### PR TITLE
Fixed the order of the key deletion

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -2675,9 +2675,12 @@ bool TPartition::TryAddDeleteHeadKeysToPersistRequest()
             auto& k = deletedKeys.front();
 
             if (auto lock = k.Lock.lock(); lock) {
+                LOG_D("Key locked: " << k.Key);
                 // key is locked, wait for it to be unlocked
                 break;
             }
+
+            LOG_D("Key deleted: " << k.Key);
 
             haveChanges = true;
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -4149,17 +4149,6 @@ void TPartition::ScheduleUpdateAvailableSize(const TActorContext& ctx) {
     ctx.Schedule(UPDATE_AVAIL_SIZE_INTERVAL, new TEvPQ::TEvUpdateAvailableSize());
 }
 
-void TPartition::ClearOldHead(const ui64 offset, const ui16 partNo) {
-    for (auto it = BlobEncoder.HeadKeys.rbegin(); it != BlobEncoder.HeadKeys.rend(); ++it) {
-        if (it->Key.GetOffset() > offset || it->Key.GetOffset() == offset && it->Key.GetPartNo() >= partNo) {
-            // The repackaged blocks will be deleted after writing.
-            DefferedKeysForDeletion.push_back(std::move(it->BlobKeyToken));
-        } else {
-            break;
-        }
-    }
-}
-
 ui32 TPartition::NextChannel(bool isHead, ui32 blobSize) {
 
     if (isHead) {

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -2587,13 +2587,13 @@ void TPartition::RunPersist() {
         WritesTotal.Inc();
         HaveWriteMsg = true;
 
-        AddMetaKey(PersistRequest.Get());
         AddCmdWriteTxMeta(PersistRequest->Record);
         AddCmdWriteUserInfos(PersistRequest->Record);
         AddCmdWriteConfig(PersistRequest->Record);
     }
 
     if (PersistRequest->Record.CmdDeleteRangeSize() || PersistRequest->Record.CmdWriteSize() || PersistRequest->Record.CmdRenameSize()) {
+        AddMetaKey(PersistRequest.Get());
         AddMessageDeduplicatorKeys(PersistRequest.Get());
 
         // Apply counters

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -509,8 +509,8 @@ void TPartition::AddMetaKey(TEvKeyValue::TEvRequest* request) {
     TKeyPrefix ikey(TKeyPrefix::TypeMeta, Partition);
 
     NKikimrPQ::TPartitionMeta meta;
-    meta.SetStartOffset(GetStartOffset());
-    meta.SetEndOffset(Max(BlobEncoder.NewHead.GetNextOffset(), GetEndOffset()));
+    //meta.SetStartOffset(GetStartOffset());
+    //meta.SetEndOffset(Max(BlobEncoder.NewHead.GetNextOffset(), GetEndOffset()));
     meta.SetSubDomainOutOfSpace(SubDomainOutOfSpace);
     meta.SetEndWriteTimestamp(PendingWriteTimestamp.MilliSeconds());
 
@@ -530,7 +530,7 @@ void TPartition::AddMetaKey(TEvKeyValue::TEvRequest* request) {
     Y_PROTOBUF_SUPPRESS_NODISCARD meta.SerializeToString(&out);
 
     write->SetKey(ikey.Data(), ikey.Size());
-    write->SetValue(out.c_str(), out.size());
+    write->SetValue(std::move(out));
     write->SetStorageChannel(NKikimrClient::TKeyValueRequest::INLINE);
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -2587,13 +2587,13 @@ void TPartition::RunPersist() {
         WritesTotal.Inc();
         HaveWriteMsg = true;
 
+        AddMetaKey(PersistRequest.Get());
         AddCmdWriteTxMeta(PersistRequest->Record);
         AddCmdWriteUserInfos(PersistRequest->Record);
         AddCmdWriteConfig(PersistRequest->Record);
     }
 
     if (PersistRequest->Record.CmdDeleteRangeSize() || PersistRequest->Record.CmdWriteSize() || PersistRequest->Record.CmdRenameSize()) {
-        AddMetaKey(PersistRequest.Get());
         AddMessageDeduplicatorKeys(PersistRequest.Get());
 
         // Apply counters

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -141,6 +141,7 @@ class TPartition : public TBaseTabletActor<TPartition> {
     friend TInitMetaStep;
     friend TInitInfoRangeStep;
     friend TInitDataRangeStep;
+    friend TDeleteKeysStep;
     friend TInitMessageDeduplicatorStep;
     friend TInitDataStep;
     friend TInitEndWriteTimestampStep;
@@ -800,13 +801,6 @@ private:
 
     TMessageQueue PendingRequests;
     TMessageQueue QuotaWaitingRequests;
-
-    struct TDeletedKey {
-        TString Key;
-        std::weak_ptr<TBlobKeyToken> Lock;
-    };
-    void ScheduleKeyDelete(const TDataKey& key);
-    std::deque<TDeletedKey> DeletedKeys;
 
     TPartitionBlobEncoder CompactionBlobEncoder; // Compaction zone
     TPartitionBlobEncoder BlobEncoder;           // FastWrite zone

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -210,7 +210,6 @@ private:
                                const TString& errorStr,
                                const TWriteMsg& p,
                                NPersQueue::NErrorCode::EErrorCode errorCode);
-    void ClearOldHead(const ui64 offset, const ui16 partNo);
     void CreateMirrorerActor();
     void DoRead(TEvPQ::TEvRead::TPtr&& ev, TDuration waitQuotaTime, const TActorContext& ctx);
     void FillReadFromTimestamps(const TActorContext& ctx);
@@ -803,7 +802,6 @@ private:
     TMessageQueue QuotaWaitingRequests;
 
     std::shared_ptr<std::deque<TString>> DeletedKeys;
-    std::deque<TBlobKeyTokenPtr> DefferedKeysForDeletion;
 
     TPartitionBlobEncoder CompactionBlobEncoder; // Compaction zone
     TPartitionBlobEncoder BlobEncoder;           // FastWrite zone

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -801,7 +801,12 @@ private:
     TMessageQueue PendingRequests;
     TMessageQueue QuotaWaitingRequests;
 
-    std::shared_ptr<std::deque<TString>> DeletedKeys;
+    struct TDeletedKey {
+        TString Key;
+        std::weak_ptr<TBlobKeyToken> Lock;
+    };
+    void ScheduleKeyDelete(const TDataKey& key);
+    std::deque<TDeletedKey> DeletedKeys;
 
     TPartitionBlobEncoder CompactionBlobEncoder; // Compaction zone
     TPartitionBlobEncoder BlobEncoder;           // FastWrite zone

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -370,6 +370,12 @@ void TPartitionBlobEncoder::ClearPartitionedBlob(const TPartitionId& partitionId
 void TPartitionBlobEncoder::SyncHeadKeys()
 {
     if (!CompactedKeys.empty()) {
+        for (auto& k : HeadKeys) {
+            if (k.BlobKeyToken->NeedDelete) {
+                DeletedKeys.emplace_back(k.BlobKeyToken);
+            }
+        }
+
         HeadKeys.clear();
     }
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -392,7 +392,7 @@ void TPartitionBlobEncoder::SyncNewHeadKey()
 
     while (!HeadKeys.empty() && !isLess(HeadKeys.back().Key, NewHeadKey.Key)) {
         // HeadKeys.back >= NewHeadKey
-        DeletedKeys.emplace_back(HeadKeys.back().BlobKeyToken->Key, std::weak_ptr<TBlobKeyToken>(HeadKeys.back().BlobKeyToken));
+        DeletedKeys.emplace_back(HeadKeys.back().BlobKeyToken);
         HeadKeys.pop_back();
     }
 
@@ -558,7 +558,7 @@ std::pair<TKey, ui32> TPartitionBlobEncoder::Compact(const TKey& key, bool headC
 void TPartitionBlobEncoder::pop_front() {
     auto& key = DataKeysBody.front();
     if (key.BlobKeyToken->NeedDelete) {
-        DeletedKeys.emplace_back(key.BlobKeyToken->Key, std::weak_ptr<TBlobKeyToken>(key.BlobKeyToken));
+        DeletedKeys.emplace_back(key.BlobKeyToken);
     }
     BodySize -= key.Size;
     DataKeysBody.pop_front();

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -392,6 +392,7 @@ void TPartitionBlobEncoder::SyncNewHeadKey()
 
     while (!HeadKeys.empty() && !isLess(HeadKeys.back().Key, NewHeadKey.Key)) {
         // HeadKeys.back >= NewHeadKey
+        DeletedKeys.emplace_back(HeadKeys.back().BlobKeyToken->Key, std::weak_ptr<TBlobKeyToken>(HeadKeys.back().BlobKeyToken));
         HeadKeys.pop_back();
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -554,6 +554,15 @@ std::pair<TKey, ui32> TPartitionBlobEncoder::Compact(const TKey& key, bool headC
     return res;
 }
 
+void TPartitionBlobEncoder::pop_front() {
+    auto& key = DataKeysBody.front();
+    if (key.BlobKeyToken->NeedDelete) {
+        DeletedKeys.emplace_back(key.BlobKeyToken->Key, std::weak_ptr<TBlobKeyToken>(key.BlobKeyToken));
+    }
+    BodySize -= key.Size;
+    DataKeysBody.pop_front();
+}
+
 //void TPartitionBlobEncoder::Dump() const
 //{
 //    auto dumpCompactedKeys = [this](const std::deque<std::pair<TKey, ui32>>& keys, const char* prefix) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -392,7 +392,9 @@ void TPartitionBlobEncoder::SyncNewHeadKey()
 
     while (!HeadKeys.empty() && !isLess(HeadKeys.back().Key, NewHeadKey.Key)) {
         // HeadKeys.back >= NewHeadKey
-        DeletedKeys.emplace_back(HeadKeys.back().BlobKeyToken);
+        if (HeadKeys.back().BlobKeyToken->NeedDelete) {
+            DeletedKeys.emplace_back(HeadKeys.back().BlobKeyToken);
+        }
         HeadKeys.pop_back();
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h
@@ -101,6 +101,14 @@ struct TPartitionBlobEncoder {
     std::deque<TDataKey> HeadKeys;
     ui64 FirstUncompactedOffset = 0;
 
+    void pop_front();
+
+    struct TDeletedKey {
+        TString Key;
+        std::weak_ptr<TBlobKeyToken> Lock;
+    };
+    std::deque<TDeletedKey> DeletedKeys;
+
     bool HaveData = false;
     bool HeadCleared = false;
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h
@@ -106,6 +106,11 @@ struct TPartitionBlobEncoder {
     struct TDeletedKey {
         TString Key;
         std::weak_ptr<TBlobKeyToken> Lock;
+
+        TDeletedKey(const TBlobKeyTokenPtr& token) {
+            Key = token->Key;
+            Lock = std::weak_ptr<TBlobKeyToken>(token);
+        }
     };
     std::deque<TDeletedKey> DeletedKeys;
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h
@@ -102,6 +102,7 @@ struct TPartitionBlobEncoder {
     ui64 FirstUncompactedOffset = 0;
 
     void pop_front();
+    void ScheduleDelete(TDataKey& key);
 
     struct TDeletedKey {
         TString Key;

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -551,7 +551,11 @@ void TPartition::BlobsForCompactionWereWrite()
     AFL_ENSURE(BlobEncoder.DataKeysBody.size() >= KeysForCompaction.size());
 
     for (size_t i = 0; i < KeysForCompaction.size(); ++i) {
-        BlobEncoder.BodySize -= BlobEncoder.DataKeysBody.front().Size;
+        auto& key = BlobEncoder.DataKeysBody.front();
+
+        ScheduleKeyDelete(key);
+
+        BlobEncoder.BodySize -= key.Size;
         BlobEncoder.DataKeysBody.pop_front();
 
         if (BlobEncoder.DataKeysBody.empty()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -551,12 +551,7 @@ void TPartition::BlobsForCompactionWereWrite()
     AFL_ENSURE(BlobEncoder.DataKeysBody.size() >= KeysForCompaction.size());
 
     for (size_t i = 0; i < KeysForCompaction.size(); ++i) {
-        auto& key = BlobEncoder.DataKeysBody.front();
-
-        ScheduleKeyDelete(key);
-
-        BlobEncoder.BodySize -= key.Size;
-        BlobEncoder.DataKeysBody.pop_front();
+        BlobEncoder.pop_front();
 
         if (BlobEncoder.DataKeysBody.empty()) {
             if (BlobEncoder.HeadKeys.empty()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -869,13 +869,14 @@ void TDeleteKeysStep::Execute(const TActorContext &ctx) {
     }
 
     auto request = std::make_unique<TEvKeyValue::TEvRequest>();
-    for (const auto& key : GetContext().DeletedKeys) {
+    for (auto& key : GetContext().DeletedKeys) {
         auto* cmd = request->Record.AddCmdDeleteRange();
         cmd->MutableRange()->SetFrom(key);
         cmd->MutableRange()->SetIncludeFrom(true);
-        cmd->MutableRange()->SetTo(key);
+        cmd->MutableRange()->SetTo(std::move(key));
         cmd->MutableRange()->SetIncludeTo(true);
     }
+    GetContext().DeletedKeys = {};
 
     ctx.Send(Partition()->TabletActorId, request.release());
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1012,9 +1012,13 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
 
                 ui32 size = headKeys[i].Size;
                 ui64 offset = key.GetOffset();
-                while (currentLevel + 1 < totalLevels && size < compactLevelBorder[currentLevel + 1])
+                while (currentLevel + 1 < totalLevels && size < compactLevelBorder[currentLevel + 1]) {
                     ++currentLevel;
-                PQ_INIT_ENSURE(size < compactLevelBorder[currentLevel]);
+                }
+                PQ_INIT_ENSURE(size < compactLevelBorder[currentLevel])
+                    ("l", size)
+                    ("r", compactLevelBorder[currentLevel])
+                    ("c", currentLevel);
 
                 dataKeysHead[currentLevel].AddKey(key, size);
                 PQ_INIT_ENSURE(dataKeysHead[currentLevel].KeysCount() < AppData(ctx)->PQConfig.GetMaxBlobsPerLevel());

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1021,8 +1021,12 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
                     ("c", currentLevel);
 
                 dataKeysHead[currentLevel].AddKey(key, size);
-                PQ_INIT_ENSURE(dataKeysHead[currentLevel].KeysCount() < AppData(ctx)->PQConfig.GetMaxBlobsPerLevel());
-                PQ_INIT_ENSURE(!dataKeysHead[currentLevel].NeedCompaction());
+                PQ_INIT_ENSURE(dataKeysHead[currentLevel].KeysCount() < AppData(ctx)->PQConfig.GetMaxBlobsPerLevel())
+                    ("l", dataKeysHead[currentLevel].KeysCount())
+                    ("r", AppData(ctx)->PQConfig.GetMaxBlobsPerLevel())
+                    ("c", currentLevel);
+                PQ_INIT_ENSURE(!dataKeysHead[currentLevel].NeedCompaction())
+                    ("c", currentLevel);
 
                 PQ_LOG_D("read res partition offset " << offset << " endOffset " << Partition()->BlobEncoder.EndOffset
                         << " key " << key.GetOffset() << "," << key.GetCount() << " valuesize " << read.GetValue().size()

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -36,10 +36,10 @@ TInitializer::TInitializer(TPartition* partition)
     Steps.push_back(MakeHolder<TInitMetaStep>(this));
     Steps.push_back(MakeHolder<TInitInfoRangeStep>(this));
     Steps.push_back(MakeHolder<TInitDataRangeStep>(this));
-    Steps.push_back(MakeHolder<TDeleteKeysStep>(this));
     Steps.push_back(MakeHolder<TInitDataStep>(this));
     Steps.push_back(MakeHolder<TInitEndWriteTimestampStep>(this));
     Steps.push_back(MakeHolder<TInitMessageDeduplicatorStep>(this));
+    Steps.push_back(MakeHolder<TDeleteKeysStep>(this));
     Steps.push_back(MakeHolder<TInitFieldsStep>(this));
 
     CurrentStep = Steps.begin();
@@ -512,15 +512,15 @@ void TInitDataRangeStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActor
             FillBlobsMetaData(ctx);
             FormHeadAndProceed();
 
-            AFL_ENSURE(!GetContext().StartOffset || *GetContext().StartOffset >= Partition()->GetStartOffset())
-                ("d", "StartOffset from meta and blobs are different")
-                ("l", *GetContext().StartOffset)
-                ("r", Partition()->GetStartOffset());
+            // AFL_ENSURE(!GetContext().StartOffset || *GetContext().StartOffset >= Partition()->GetStartOffset())
+            //     ("d", "StartOffset from meta and blobs are different")
+            //     ("l", *GetContext().StartOffset)
+            //     ("r", Partition()->GetStartOffset());
 
-            AFL_ENSURE(!GetContext().EndOffset || *GetContext().EndOffset == Partition()->GetEndOffset())
-                ("d", "EndOffset from meta and blobs are different")
-                ("l", *GetContext().EndOffset)
-                ("r", Partition()->GetEndOffset());
+            // AFL_ENSURE(!GetContext().EndOffset || *GetContext().EndOffset == Partition()->GetEndOffset())
+            //     ("d", "EndOffset from meta and blobs are different")
+            //     ("l", *GetContext().EndOffset)
+            //     ("r", Partition()->GetEndOffset());
 
             Done(ctx);
             break;

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.h
@@ -21,6 +21,7 @@ class TPartition;
 struct TInitializionContext {
     std::optional<ui64> StartOffset;
     std::optional<ui64> EndOffset;
+    std::deque<TString> DeletedKeys;
 };
 
 
@@ -156,6 +157,14 @@ private:
     void FormHeadAndProceed();
 
     TVector<NKikimrClient::TKeyValueResponse::TReadRangeResult> Ranges;
+};
+
+class TDeleteKeysStep: public TBaseKVStep {
+public:
+    TDeleteKeysStep(TInitializer* initializer);
+
+    void Execute(const TActorContext& ctx) override;
+    void Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext& ctx) override;
 };
 
 class TInitMessageDeduplicatorStep: public TBaseKVStep {

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -428,10 +428,6 @@ void TPartition::SyncMemoryStateWithKVState(const TActorContext& ctx) {
     LOG_T("TPartition::SyncMemoryStateWithKVState.");
 
     BlobEncoder.SyncHeadKeys();
-
-    // New blocks have been recorded. You can now delete the keys of the repackaged blocks.
-    DefferedKeysForDeletion.clear();
-
     BlobEncoder.SyncNewHeadKey();
 
     if (BlobEncoder.IsNothingWritten()) { //Nothing writed at all

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -2546,6 +2546,7 @@ Y_UNIT_TEST(PQ_Tablet_Removes_Blobs_Asynchronously)
 
     auto observe = [&](TAutoPtr<IEventHandle>& ev) {
         if (auto* event = ev->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+            Cerr << ">>> got event: " << event->Record.ShortDebugString() << Endl;
             foundCmdDeleteFirstMessage = false;
             const auto& record = event->Record;
             for (size_t i = 0; i < record.CmdDeleteRangeSize(); ++i) {
@@ -2599,7 +2600,7 @@ Y_UNIT_TEST(PQ_Tablet_Removes_Blobs_Asynchronously)
     data[0].second = TString(1_KB, 'x');
     CmdWrite(0, "sourceid1", data, tc, false, {}, true, "", -1, 2);
 
-    Cerr << ">>> write #1" << Endl;
+    Cerr << ">>> write #4" << Endl;
 
     keys = GetTabletKeys(tc);
     UNIT_ASSERT_C(!keys.contains(firstMessageKey),
@@ -2726,6 +2727,8 @@ Y_UNIT_TEST(PQ_Tablet_Does_Not_Remove_The_Blob_Until_The_Reading_Is_Complete)
     // Making sure that the blobs have not been deleted yet
     auto keys = GetTabletKeys(tc);
 
+    Cerr << "keys: " << JoinRange(", ", keys.begin(), keys.end()) << Endl;
+
     UNIT_ASSERT(keys.contains("d0000000000_00000000000000000001_00000_0000000001_00014"));
     UNIT_ASSERT(keys.contains("d0000000000_00000000000000000002_00000_0000000001_00014"));
     UNIT_ASSERT(keys.contains("d0000000000_00000000000000000003_00000_0000000001_00014"));
@@ -2770,11 +2773,13 @@ Y_UNIT_TEST(PQ_Tablet_Does_Not_Remove_The_Blob_Until_The_Reading_Is_Complete)
 
     keys = GetTabletKeys(tc);
 
+    Cerr << "keys: " << JoinRange(", ", keys.begin(), keys.end()) << Endl;
+
     // We make sure that the blobs with messages on offsets 2 and 3 have not been deleted
     UNIT_ASSERT(!keys.contains("d0000000000_00000000000000000001_00000_0000000001_00014"));
     UNIT_ASSERT(keys.contains("d0000000000_00000000000000000002_00000_0000000001_00014"));
     UNIT_ASSERT(keys.contains("d0000000000_00000000000000000003_00000_0000000001_00014"));
-    UNIT_ASSERT(!keys.contains("d0000000000_00000000000000000004_00000_0000000001_00014"));
+    UNIT_ASSERT(keys.contains("d0000000000_00000000000000000004_00000_0000000001_00014"));
 
     tc.Runtime->Send(blobResponseEvent);
 
@@ -2786,9 +2791,12 @@ Y_UNIT_TEST(PQ_Tablet_Does_Not_Remove_The_Blob_Until_The_Reading_Is_Complete)
 
     keys = GetTabletKeys(tc);
 
+    Cerr << "keys: " << JoinRange(", ", keys.begin(), keys.end()) << Endl;
+
     // Making sure that the blobs for messages with offsets 2 and 3 are removed
     UNIT_ASSERT(!keys.contains("d0000000000_00000000000000000002_00000_0000000001_00014"));
     UNIT_ASSERT(!keys.contains("d0000000000_00000000000000000003_00000_0000000001_00014"));
+    UNIT_ASSERT(!keys.contains("d0000000000_00000000000000000004_00000_0000000001_00014"));
 }
 
 Y_UNIT_TEST(IncompleteProxyResponse) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The topic's blobs could be deleted out of order, which caused the application to crash.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10159