### PR TITLE
25-2-1: Avoid excessive cpu usage when registering large number of service counters

### DIFF
--- a/library/cpp/monlib/dynamic_counters/counters.cpp
+++ b/library/cpp/monlib/dynamic_counters/counters.cpp
@@ -141,6 +141,18 @@ TIntrusivePtr<TDynamicCounters> TDynamicCounters::GetSubgroup(const TString& nam
     return res;
 }
 
+TIntrusivePtr<TDynamicCounters> TDynamicCounters::FindSubgroup(const TString& name) const {
+    TReadGuard g(Lock);
+    const auto it = Counters.lower_bound({name, TString()});
+    if (it != Counters.end() && it->first.LabelName == name) {
+        const auto it2 = std::next(it);
+        if (it2 == Counters.end() || it2->first.LabelName != name) {
+            return AsDynamicCounters(it->second);
+        }
+    }
+    return nullptr;
+}
+
 TIntrusivePtr<TDynamicCounters> TDynamicCounters::FindSubgroup(const TString& name, const TString& value) const {
     TReadGuard g(Lock);
     const auto it = Counters.find({name, value});

--- a/library/cpp/monlib/dynamic_counters/counters.h
+++ b/library/cpp/monlib/dynamic_counters/counters.h
@@ -331,6 +331,7 @@ namespace NMonitoring {
         void RemoveSubgroupChain(const std::vector<std::pair<TString, TString>>& chain);
 
         TIntrusivePtr<TDynamicCounters> GetSubgroup(const TString& name, const TString& value);
+        TIntrusivePtr<TDynamicCounters> FindSubgroup(const TString& name) const;
         TIntrusivePtr<TDynamicCounters> FindSubgroup(const TString& name, const TString& value) const;
         bool RemoveSubgroup(const TString& name, const TString& value);
         void ReplaceSubgroup(const TString& name, const TString& value, TIntrusivePtr<TDynamicCounters> subgroup);

--- a/library/cpp/monlib/dynamic_counters/counters_ut.cpp
+++ b/library/cpp/monlib/dynamic_counters/counters_ut.cpp
@@ -339,4 +339,30 @@ Y_UNIT_TEST_SUITE(TDynamicCountersTest) {
         histogram = rootGroup->FindNamedHistogram("name", "histogram2");
         UNIT_ASSERT(histogram);
     }
+
+    Y_UNIT_TEST(FindSubgroup) {
+        TDynamicCounterPtr rootGroup(new TDynamicCounters());
+
+        auto a = rootGroup->GetSubgroup("a", "1");
+        auto b1 = rootGroup->GetSubgroup("b", "1");
+        auto b2 = rootGroup->GetSubgroup("b", "2");
+        auto c = rootGroup->GetSubgroup("c", "1");
+        auto e = rootGroup->GetSubgroup("e", "1");
+
+        UNIT_ASSERT(a == rootGroup->FindSubgroup("a"));
+        UNIT_ASSERT(a == rootGroup->FindSubgroup("a", "1"));
+        UNIT_ASSERT(nullptr == rootGroup->FindSubgroup("a", "2"));
+
+        UNIT_ASSERT(nullptr == rootGroup->FindSubgroup("b"));
+        UNIT_ASSERT(b1 == rootGroup->FindSubgroup("b", "1"));
+        UNIT_ASSERT(b2 == rootGroup->FindSubgroup("b", "2"));
+        UNIT_ASSERT(nullptr == rootGroup->FindSubgroup("b", "3"));
+
+        UNIT_ASSERT(c == rootGroup->FindSubgroup("c"));
+        UNIT_ASSERT(c == rootGroup->FindSubgroup("c", "1"));
+        UNIT_ASSERT(nullptr == rootGroup->FindSubgroup("c", "2"));
+
+        UNIT_ASSERT(nullptr == rootGroup->FindSubgroup("d"));
+        UNIT_ASSERT(nullptr == rootGroup->FindSubgroup("f"));
+    }
 }

--- a/library/cpp/monlib/service/pages/index_mon_page.cpp
+++ b/library/cpp/monlib/service/pages/index_mon_page.cpp
@@ -52,6 +52,12 @@ void TIndexMonPage::Output(IMonHttpRequest& request) {
 
 void TIndexMonPage::OutputIndex(IOutputStream& out, bool pathEndsWithSlash) {
     TGuard<TMutex> g(Mtx);
+    if (SortPagesPending) {
+        Pages.sort([](const TMonPagePtr& a, const TMonPagePtr& b) {
+            return AsciiCompareIgnoreCase(a->GetTitle(), b->GetTitle()) < 0;
+        });
+        SortPagesPending = false;
+    }
     for (auto& Page : Pages) {
         IMonPage* page = Page.Get();
         if (page->IsInIndex()) {
@@ -164,9 +170,7 @@ void TIndexMonPage::OutputBody(IMonHttpRequest& req) {
 
 void TIndexMonPage::SortPages() {
     TGuard<TMutex> g(Mtx);
-    Pages.sort([](const TMonPagePtr& a, const TMonPagePtr& b) {
-        return AsciiCompareIgnoreCase(a->GetTitle(), b->GetTitle()) < 0;
-    });
+    SortPagesPending = true;
 }
 
 void TIndexMonPage::ClearPages() {

--- a/library/cpp/monlib/service/pages/index_mon_page.h
+++ b/library/cpp/monlib/service/pages/index_mon_page.h
@@ -11,6 +11,7 @@ namespace NMonitoring {
         TPages Pages; // a list of pages to maintain specific order
         using TPagesByPath = THashMap<TString, TPages::iterator>;
         TPagesByPath PagesByPath;
+        bool SortPagesPending = false;
 
         TIndexMonPage(const TString& path, const TString& title)
             : IMonPage(path, title)

--- a/ydb/core/base/counters.cpp
+++ b/ydb/core/base/counters.cpp
@@ -50,7 +50,7 @@ static const THashSet<TString> DATABASE_SERVICES
 static const THashSet<TString> DATABASE_ATTRIBUTE_SERVICES
     = {{ TString("ydb"), TString("datastreams") }};
 
-static const THashSet<TString> DATABASE_ATTRIBUTE_LABELS
+static const TVector<TString> DATABASE_ATTRIBUTE_LABELS
     = {{ TString("cloud_id"),
          TString("folder_id"),
          TString("database_id")
@@ -76,26 +76,20 @@ const THashSet<TString> &GetDatabaseAttributeSensorServices()
     return DATABASE_ATTRIBUTE_SERVICES;
 }
 
-const THashSet<TString> &GetDatabaseAttributeLabels()
+const TVector<TString> &GetDatabaseAttributeLabels()
 {
     return DATABASE_ATTRIBUTE_LABELS;
 }
 
 static TIntrusivePtr<TDynamicCounters> SkipLabels(TIntrusivePtr<TDynamicCounters> counters,
-                                                  const THashSet<TString> &labels)
+                                                  const TVector<TString> &labels)
 {
-    TString name, value;
-    do {
-        name = "";
-        counters->EnumerateSubgroups([&name, &value, &labels](const TString &n, const TString &v) {
-                if (labels.contains(n)) {
-                    name = n;
-                    value = v;
-                }
-            });
-        if (name)
-            counters = counters->GetSubgroup(name, value);
-    } while (name);
+    for (const TString& label : labels) {
+        auto next = counters->FindSubgroup(label);
+        if (next) {
+            counters = next;
+        }
+    }
 
     return counters;
 }
@@ -121,17 +115,32 @@ TIntrusivePtr<TDynamicCounters> GetServiceCountersRoot(TIntrusivePtr<TDynamicCou
     return root->GetSubgroup("counters", pair.first);
 }
 
-static THashSet<TString> MakeServiceCountersExtraLabels() {
-    THashSet<TString> extraLabels;
-    extraLabels.insert(DATABASE_LABEL);
-    extraLabels.insert(SLOT_LABEL);
-    extraLabels.insert(HOST_LABEL);
-    extraLabels.insert(DATABASE_ATTRIBUTE_LABELS.begin(),
-                       DATABASE_ATTRIBUTE_LABELS.end());
+static TVector<TString> MakeServiceCountersExtraLabels() {
+    // NOTE: order of labels should match labels maintainer order for efficiency
+    TVector<TString> extraLabels;
+    extraLabels.push_back(DATABASE_LABEL);
+    extraLabels.push_back(SLOT_LABEL);
+    extraLabels.push_back(HOST_LABEL);
+    extraLabels.insert(extraLabels.end(),
+        DATABASE_ATTRIBUTE_LABELS.begin(),
+        DATABASE_ATTRIBUTE_LABELS.end());
     return extraLabels;
 }
 
-static const THashSet<TString> SERVICE_COUNTERS_EXTRA_LABELS = MakeServiceCountersExtraLabels();
+static const TVector<TString> SERVICE_COUNTERS_EXTRA_LABELS = MakeServiceCountersExtraLabels();
+
+static TIntrusivePtr<TDynamicCounters> SkipExtraLabels(TIntrusivePtr<TDynamicCounters> counters) {
+    for (;;) {
+        // Keep trying as long as there is something to skip
+        auto next = SkipLabels(counters, SERVICE_COUNTERS_EXTRA_LABELS);
+        if (next == counters) {
+            break;
+        }
+        counters = next;
+    }
+
+    return counters;
+}
 
 TIntrusivePtr<TDynamicCounters> GetServiceCounters(TIntrusivePtr<TDynamicCounters> root,
                                                    const TString &service, bool skipAddedLabels)
@@ -144,10 +153,10 @@ TIntrusivePtr<TDynamicCounters> GetServiceCounters(TIntrusivePtr<TDynamicCounter
     if (!skipAddedLabels)
         return res;
 
-    res = SkipLabels(res, SERVICE_COUNTERS_EXTRA_LABELS);
+    res = SkipExtraLabels(res);
 
     auto utils = root->GetSubgroup("counters", "utils");
-    utils = SkipLabels(utils, SERVICE_COUNTERS_EXTRA_LABELS);
+    utils = SkipExtraLabels(utils);
     auto lookupCounter = utils->GetSubgroup("component", service)->GetCounter("CounterLookups", true);
     res->SetLookupCounter(lookupCounter);
     res->SetOnLookup(OnCounterLookup);

--- a/ydb/core/base/counters.h
+++ b/ydb/core/base/counters.h
@@ -4,6 +4,7 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
 #include <util/generic/hash_set.h>
+#include <util/generic/vector.h>
 
 namespace NKikimr {
     constexpr char DATABASE_LABEL[] = "database";
@@ -22,7 +23,8 @@ namespace NKikimr {
     const THashSet<TString> &GetDatabaseSensorServices();
     // Get list of services which use top-level database attribute labels for own sensors.
     const THashSet<TString> &GetDatabaseAttributeSensorServices();
-    const THashSet<TString> &GetDatabaseAttributeLabels();
+    // Get a list of attribute labels (order is important)
+    const TVector<TString> &GetDatabaseAttributeLabels();
     // Drop all extra labels.
     void ReplaceSubgroup(TIntrusivePtr<::NMonitoring::TDynamicCounters> root, const TString &service);
 } // namespace NKikimr

--- a/ydb/core/mind/tenant_ut_pool.cpp
+++ b/ydb/core/mind/tenant_ut_pool.cpp
@@ -57,7 +57,8 @@ void CheckLabels(TIntrusivePtr<::NMonitoring::TDynamicCounters> counters,
     allServices.insert(attrServices.begin(), attrServices.end());
 
     for (auto &service : allServices) {
-        THashSet<TString> allLabels = GetDatabaseAttributeLabels();
+        const TVector<TString>& attrLabelNames = GetDatabaseAttributeLabels();
+        THashSet<TString> allLabels(attrLabelNames.begin(), attrLabelNames.end());
         allLabels.insert(DATABASE_LABEL);
         allLabels.insert(SLOT_LABEL);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Avoid excessive cpu usage when registering large number of service counters. Fixes #29606.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Avoid sorting registered actor pages until the next render.

Order of database labels is now fixed (should be synchronized between counters and labels maintainer actor for efficiency) and we try to descend the tree once for each such label when performing service counters lookups. When orders match we perform at most two such lookups with logarithmic complexity in the number of trailing subgroups (`12 * O(log N)` string comparions for 6 labels), which is still better than linear complexity for a large number of counters (was `O(N)` where `N` is the number of subgroups after the last label).

Merges #29667.