### PR TITLE
Support user provided parameters when starting local-ydb

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -62,4 +62,4 @@ EXPOSE ${YDB_KAFKA_PROXY_PORT:-9092}
 
 HEALTHCHECK --start-period=60s --interval=60s CMD sh /health_check
 
-CMD ["bash", "/initialize_local_ydb"]
+ENTRYPOINT ["bash", "/initialize_local_ydb"]


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

If user want to add custom parameters to initialize_local_ydb, they should use something like this:

```
docker run ghcr.io/ydb-platform/local-ydb:nightly bash /initialize_local_ydb --user-provided-options...
```

After this fix, user can just add `--user-provided-options...` after image name
