### PR TITLE
Fix usage of the same secret multiple time in the same request

### DIFF
--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
@@ -212,7 +212,7 @@ void TDescribeSchemaSecretsService::Bootstrap() {
 void TDescribeSchemaSecretsService::SaveIncomingRequestInfo(const TEvResolveSecret& ev) {
     TResponseContext ctx;
     for (size_t i = 0; i < ev.SecretNames.size(); ++i) {
-        ctx.Secrets[ev.SecretNames[i]] = i;
+        ctx.Secrets.emplace(ev.SecretNames[i], i);
         ctx.Result = ev.Promise;
     }
     ResolveInFlight[LastCookie] = std::move(ctx);

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -13,6 +13,8 @@
 
 #include <library/cpp/threading/future/future.h>
 
+#include <util/generic/hash_multi_map.h>
+
 namespace NKikimr::NKqp {
 
 class TDescribeSchemaSecretsService: public NActors::TActorBootstrapped<TDescribeSchemaSecretsService> {
@@ -55,7 +57,7 @@ private:
 
     struct TResponseContext {
         using TIncomingOrderId = ui64;
-        THashMap<TString, TIncomingOrderId> Secrets;
+        THashMultiMap<TString, TIncomingOrderId> Secrets;
         NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> Result;
         size_t FilledSecretsCnt = 0;
     };


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
В федеративных запросах может быть использование нескольких секретов в одной sql-команде. Сейчас если спрашивается один и тот же секрет два раза, он сохраняется в мапу один раз, из-за чего теряется информация о том, что запрошено было больше секретов.