### PR TITLE
[ICRDMA] Do not use RoCEv1 gid index if present. Improve rdma diagnostic info.  EXT-1667 (#29694)

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_handshake.cpp
+++ b/ydb/library/actors/interconnect/interconnect_handshake.cpp
@@ -1447,6 +1447,9 @@ namespace NActors {
                     } else {
                         sb << "Unable to complete rdma READ work request due to cq runtime error";
                     }
+                    if (Rdma.Qp) {
+                        sb << " qp: " << Rdma.Qp;
+                    }
                     LOG_LOG_IC_X(NActorsServices::INTERCONNECT, "ICRDMA", NLog::PRI_ERROR, sb.c_str());
                     rdmaReadAck.SetErr(sb);
                 }

--- a/ydb/library/actors/interconnect/interconnect_mon.cpp
+++ b/ydb/library/actors/interconnect/interconnect_mon.cpp
@@ -78,6 +78,22 @@ namespace NInterconnect {
                 }
             }
 
+            TString XdcFlagsToString(const ui8 xdcFlags) {
+                TString res;
+                if (xdcFlags & TInterconnectProxyTCP::TProxyStats::XDCFlags::MSG_ZERO_COPY_SEND) {
+                    res.append("MSG_ZC_SEND|");
+                }
+                if (xdcFlags & TInterconnectProxyTCP::TProxyStats::XDCFlags::RDMA_READ) {
+                    res.append("RDMA_READ|");
+                }
+                if (res.empty()) {
+                    res.append("_");
+                } else {
+                    res.pop_back();
+                }
+                return res;
+            }
+
             TString GenerateHtml() {
                 TStringStream str;
                 HTML(str) {
@@ -131,7 +147,7 @@ namespace NInterconnect {
                                     TABLED() { str << kv.second.TotalOutputQueueSize; }
                                     TABLED() { str << (kv.second.Connected ? "yes" : "<strong>no</strong>"); }
                                     TABLED() { str << (kv.second.ExternalDataChannel ? "yes" : "no")
-                                        << " (" << (kv.second.XDCFlags & TInterconnectProxyTCP::TProxyStats::XDCFlags::MSG_ZERO_COPY_SEND ? "MSG_ZC_SEND" : "_")  << ")"; }
+                                        << " (" << XdcFlagsToString(kv.second.XDCFlags) << ")"; }
                                     TABLED() { str << kv.second.Host; }
                                     TABLED() { str << kv.second.Port; }
                                     TABLED() {

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
@@ -53,6 +53,7 @@ namespace NActors {
             enum XDCFlags {
                 NONE = 0,
                 MSG_ZERO_COPY_SEND = 1,
+                RDMA_READ = 1 << 1,
             };
             ui8 XDCFlags;
         };

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -466,7 +466,7 @@ namespace NActors {
             return ReceiveContext->ClockSkew_us;
         }
 
-        std::optional<ui8> GetXDCFlags() const;
+        std::optional<ui8> GetXDCFlags() const noexcept;
 
     private:
         friend class TInterconnectProxyTCP;

--- a/ydb/library/actors/interconnect/rdma/rdma.cpp
+++ b/ydb/library/actors/interconnect/rdma/rdma.cpp
@@ -290,6 +290,9 @@ void TQueuePair::Output(IOutputStream& os) const noexcept {
     } else {
         os << attr.qp_state;
     }
+    if (Ctx) {
+        os << ", ctx: " << *Ctx;
+    }
 }
 
 TQueuePair::TQpState TQueuePair::GetState(bool forseUpdate) const noexcept {
@@ -324,7 +327,7 @@ size_t TQueuePair::GetDeviceIndex() const noexcept {
     return Ctx->GetDeviceIndex();
 }
 
-bool TQueuePair::IsRtsState(TQpS state) {
+bool TQueuePair::IsRtsState(TQpS state) noexcept {
      enum ibv_qp_state qpState = static_cast<enum ibv_qp_state>(state.State);
      return qpState == IBV_QPS_RTS;
 }

--- a/ydb/library/actors/interconnect/rdma/rdma.h
+++ b/ydb/library/actors/interconnect/rdma/rdma.h
@@ -94,7 +94,7 @@ public:
     struct TQpS {
         int State;
     };
-    static bool IsRtsState(TQpS state);
+    static bool IsRtsState(TQpS state) noexcept;
     struct TQpErr {
         int Err;
     };

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -225,7 +225,7 @@ Y_UNIT_TEST_SUITE(Interconnect) {
         {
             auto s = GetRdmaQpStatus(cluster, 1, 2);
             auto tokens = SplitString(s, ",");
-            UNIT_ASSERT(tokens.size() == 2);
+            UNIT_ASSERT(tokens.size() > 2);
             UNIT_ASSERT(tokens[1] == "QPS_RTS");
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

One port can have multiple indexes for same GID. The app must use correct index (RoCEv1 or RoCEv2). Unfortunately we can't check index type (no support in the ibdrv wrapper) so right now we use some hack to pick RoCEv2 index.

This pr also adds more diagnostic info.





### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
