### PR TITLE
Support new (*_PATH) secret settings in backups

### DIFF
--- a/ydb/core/grpc_services/rpc_describe_external_data_source.cpp
+++ b/ydb/core/grpc_services/rpc_describe_external_data_source.cpp
@@ -18,31 +18,39 @@ namespace {
 
 using TProperties = google::protobuf::Map<TProtoStringType, TProtoStringType>;
 
+TString AdjustSecretSettingName(TStringBuf secretName, const TString& secretSettingPrefix) {
+    return secretName.StartsWith('/') ? secretSettingPrefix + "_PATH" : secretSettingPrefix + "_NAME";
+}
+
+void SetSecretSettingName(TStringBuf secretName, const TString& secretSettingPrefix, TProperties& out) {
+    out[AdjustSecretSettingName(secretName, secretSettingPrefix)] = secretName;
+}
+
 void Convert(const TServiceAccountAuth& in, TProperties& out) {
     out["SERVICE_ACCOUNT_ID"] = in.GetId();
-    out["SERVICE_ACCOUNT_SECRET_NAME"] = in.GetSecretName();
+    SetSecretSettingName(in.GetSecretName(), "SERVICE_ACCOUNT_SECRET", out);
 }
 
 void Convert(const TBasic& in, TProperties& out) {
     out["LOGIN"] = in.GetLogin();
-    out["PASSWORD_SECRET_NAME"] = in.GetPasswordSecretName();
+    SetSecretSettingName(in.GetPasswordSecretName(), "PASSWORD_SECRET", out);
 }
 
 void Convert(const TMdbBasic& in, TProperties& out) {
     out["SERVICE_ACCOUNT_ID"] = in.GetServiceAccountId();
-    out["SERVICE_ACCOUNT_SECRET_NAME"] = in.GetServiceAccountSecretName();
+    SetSecretSettingName(in.GetServiceAccountSecretName(), "SERVICE_ACCOUNT_SECRET", out);
     out["LOGIN"] = in.GetLogin();
-    out["PASSWORD_SECRET_NAME"] = in.GetPasswordSecretName();
+    SetSecretSettingName(in.GetPasswordSecretName(), "PASSWORD_SECRET", out);
 }
 
 void Convert(const TAws& in, TProperties& out) {
-    out["AWS_ACCESS_KEY_ID_SECRET_NAME"] = in.GetAwsAccessKeyIdSecretName();
-    out["AWS_SECRET_ACCESS_KEY_SECRET_NAME"] = in.GetAwsSecretAccessKeySecretName();
+    SetSecretSettingName(in.GetAwsAccessKeyIdSecretName(), "AWS_ACCESS_KEY_ID_SECRET", out);
+    SetSecretSettingName(in.GetAwsSecretAccessKeySecretName(), "AWS_SECRET_ACCESS_KEY_SECRET", out);
     out["AWS_REGION"] = in.GetAwsRegion();
 }
 
 void Convert(const TToken& in, TProperties& out) {
-    out["TOKEN_SECRET_NAME"] = in.GetTokenSecretName();
+    SetSecretSettingName(in.GetTokenSecretName(), "TOKEN_SECRET", out);
 }
 
 void Convert(const TAuth& in, TProperties& out) {

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
@@ -230,9 +230,6 @@ void TDescribeSchemaSecretsService::SendSchemeCacheRequests(const TEvResolveSecr
         }
         request->ResultSet.emplace_back(entry);
     }
-    if (userToken) {
-        LOG_N("SendSchemeCacheRequests: userToken->GetUserSID()=" << userToken->GetUserSID()); // TODO remove !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    }
     if (userToken && userToken->GetUserSID()) {
         request->UserToken = userToken;
     }

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
@@ -230,6 +230,9 @@ void TDescribeSchemaSecretsService::SendSchemeCacheRequests(const TEvResolveSecr
         }
         request->ResultSet.emplace_back(entry);
     }
+    if (userToken) {
+        LOG_N("SendSchemeCacheRequests: userToken->GetUserSID()=" << userToken->GetUserSID()); // TODO remove !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    }
     if (userToken && userToken->GetUserSID()) {
         request->UserToken = userToken;
     }

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -781,13 +781,12 @@ void AddSecretSettingIfNotEmpty(const std::string& secretName, const TString& se
 void AddConnectionOptions(const NReplication::TConnectionParams& connectionParams, TVector<TString>& options) {
     options.push_back(BuildOption("CONNECTION_STRING", Quote(BuildConnectionString(connectionParams))));
     switch (connectionParams.GetCredentials()) {
-        case NReplication::TConnectionParams::ECredentials::Static: {
+        case NReplication::TConnectionParams::ECredentials::Static:
             options.push_back(BuildOption("USER", Quote(connectionParams.GetStaticCredentials().User)));
             AddSecretSettingIfNotEmpty(connectionParams.GetStaticCredentials().PasswordSecretName,
                 "PASSWORD_SECRET", options);
             break;
-        }
-        case NReplication::TConnectionParams::ECredentials::OAuth: {
+        case NReplication::TConnectionParams::ECredentials::OAuth:
             AddSecretSettingIfNotEmpty(connectionParams.GetOAuthCredentials().TokenSecretName,
                 "TOKEN_SECRET", options);
             break;

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -772,12 +772,10 @@ TString GetSecretSettingName(TStringBuf secretName, const TString& secretSetting
     return secretName.StartsWith('/') ? secretSettingPrefix + "_PATH" : secretSettingPrefix + "_NAME";
 }
 
-bool AddSecretSettingIfNotEmpty(const std::string& secretName, const TString& secretSettingName, TVector<TString>& options) {
+void AddSecretSettingIfNotEmpty(const std::string& secretName, const TString& secretSettingName, TVector<TString>& options) {
     if (!secretName.empty()) {
         options.push_back(BuildOption(GetSecretSettingName(secretName, secretSettingName).c_str(), Quote(secretName)));
-        return true;
     }
-    return false;
 }
 
 void AddConnectionOptions(const NReplication::TConnectionParams& connectionParams, TVector<TString>& options) {
@@ -785,18 +783,14 @@ void AddConnectionOptions(const NReplication::TConnectionParams& connectionParam
     switch (connectionParams.GetCredentials()) {
         case NReplication::TConnectionParams::ECredentials::Static: {
             options.push_back(BuildOption("USER", Quote(connectionParams.GetStaticCredentials().User)));
-            if (AddSecretSettingIfNotEmpty(connectionParams.GetStaticCredentials().PasswordSecretName,
-                "PASSWORD_SECRET", options)
-            ) {
-                break;
-            }
+            AddSecretSettingIfNotEmpty(connectionParams.GetStaticCredentials().PasswordSecretName,
+                "PASSWORD_SECRET", options);
+            break;
         }
         case NReplication::TConnectionParams::ECredentials::OAuth: {
-            if (AddSecretSettingIfNotEmpty(connectionParams.GetOAuthCredentials().TokenSecretName,
-                "TOKEN_SECRET", options)
-            ) {
-                break;
-            }
+            AddSecretSettingIfNotEmpty(connectionParams.GetOAuthCredentials().TokenSecretName,
+                "TOKEN_SECRET", options);
+            break;
         }
     }
 }

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -790,7 +790,6 @@ void AddConnectionOptions(const NReplication::TConnectionParams& connectionParam
             AddSecretSettingIfNotEmpty(connectionParams.GetOAuthCredentials().TokenSecretName,
                 "TOKEN_SECRET", options);
             break;
-        }
     }
 }
 

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -1534,12 +1534,12 @@ TRestoreResult TRestoreClient::CheckSecretExistence(const TString& secretName) {
     const auto tmpUser = CreateGuidAsString();
     TString createAccessQuery;
     TString dropAccessQuery;
-    if (!IsSchemaSecret(secretName)) {
-        createAccessQuery = std::format("CREATE OBJECT `{}:{}` (TYPE SECRET_ACCESS);", secretName.c_str(), tmpUser.c_str());
-        dropAccessQuery = std::format("DROP OBJECT `{}:{}` (TYPE SECRET_ACCESS);", secretName.c_str(), tmpUser.c_str());
-    } else {
+    if (IsSchemaSecret(secretName)) {
         createAccessQuery = std::format("GRANT describe schema ON `{}` TO `{}`;", secretName.c_str(), tmpUser.c_str());
         dropAccessQuery = std::format("REVOKE describe schema ON `{}` FROM `{}`;", secretName.c_str(), tmpUser.c_str());
+    } else {
+        createAccessQuery = std::format("CREATE OBJECT `{}:{}` (TYPE SECRET_ACCESS);", secretName.c_str(), tmpUser.c_str());
+        dropAccessQuery = std::format("DROP OBJECT `{}:{}` (TYPE SECRET_ACCESS);", secretName.c_str(), tmpUser.c_str());
     }
 
     auto result = QueryClient.RetryQuerySync([&](NQuery::TSession session) {
@@ -1586,8 +1586,7 @@ TRestoreResult TRestoreClient::RestoreReplication(
     const TString& dbPathRelativeToRestoreRoot,
     const TRestoreSettings& settings)
 {
-    LOG_D("Process " << "fsPath=" << fsPath.GetPath().Quote() << ", dbRestoreRoot=" << dbRestoreRoot.Quote()
-        << ", dbPathRelativeToRestoreRoot=" << dbPathRelativeToRestoreRoot.Quote());
+    LOG_D("Process " << fsPath.GetPath().Quote());
 
     const TString dbPath = dbRestoreRoot + dbPathRelativeToRestoreRoot;
     LOG_I("Restore async replication " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -1227,7 +1227,8 @@ TRestoreResult TRestoreClient::Restore(NScheme::ESchemeEntryType type, const TFs
 }
 
 TRestoreResult TRestoreClient::DropAndRestoreExternals(const TVector<TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources,
-    const THashMap<TString, size_t>& externalTables, const TString& dbRestoreRoot, const TRestoreSettings& settings) {
+    const THashMap<TString, size_t>& externalTables, const TString& dbRestoreRoot, const TRestoreSettings& settings)
+{
     for (size_t i : externalDataSources) {
         const auto& [fsPath, dbPath, type] = backupEntries[i];
         if (!ExistingEntries.contains(dbPath)) {

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -1593,19 +1593,6 @@ TRestoreResult TRestoreClient::RestoreReplication(
     }
 
     auto query = ReadAsyncReplicationQuery(fsPath, Log.get());
-    // if (auto secretName = GetSecretName(query)) {
-    //     if (IsSchemaSecret(secretName)) {
-    //         secretName = RewriteAbsolutePath(secretName, GetDatabase(query), dbRestoreRoot);
-    //     }
-    //     if (auto result = CheckSecretExistence(secretName); !result.IsSuccess()) {
-    //         return Result<TRestoreResult>(fsPath.GetPath(), std::move(result));
-    //     }
-    //     NYql::TIssues issues;
-    //     if (!RewriteCreateQuery(query, "PASSWORD_SECRET_NAME = '{}'", secretName, issues)) { // change to path!!!!!!
-    //        return Result<TRestoreResult>(fsPath.GetPath(), EStatus::BAD_REQUEST, issues.ToString());
-    //     }
-    // }
-
     if (const auto result = ProcessSecretInQuery(query, dbRestoreRoot, fsPath); !result.IsSuccess()) {
         return result;
     }
@@ -1647,10 +1634,8 @@ TRestoreResult TRestoreClient::RestoreTransfer(
     }
 
     auto query = ReadTransferQuery(fsPath, Log.get());
-    if (const auto secretName = GetSecretName(query)) {
-        if (auto result = CheckSecretExistence(secretName); !result.IsSuccess()) {
-            return Result<TRestoreResult>(fsPath.GetPath(), std::move(result));
-        }
+    if (const auto result = ProcessSecretInQuery(query, dbRestoreRoot, fsPath); !result.IsSuccess()) {
+        return result;
     }
 
     NYql::TIssues issues;

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -1757,8 +1757,7 @@ TRestoreResult TRestoreClient::RestoreExternalDataSource(
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
-    LOG_I("Restore external data source " << fsPath.GetPath().Quote() << " to " << dbPath.Quote()
-        << ", dbRestoreRoot=" << dbRestoreRoot.Quote());
+    LOG_I("Restore external data source " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
         return CheckExistenceAndType(dbPath, ESchemeEntryType::ExternalDataSource);

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -233,8 +233,6 @@ class TRestoreClient {
         const TString& dbPath, const TRestoreSettings& settings, const NTable::TTableDescription& desc,
         ui32 dataFilesCount);
 
-    TRestoreResult CheckSecretExistence(const TString& secretName);
-    TRestoreResult ProcessSecretInQuery(TString& query, const TString& dbRestoreRoot, const TFsPath& fsPath);
     TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, const TRestoreSettings& settings);
     TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool delay);
     TRestoreResult DropAndRestore(const TFsPath& fsPath, const TString& dbRestoreRoot, const TRestoreSettings& settings);

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -201,7 +201,7 @@ class TRestoreClient {
     TRestoreResult RestoreCoordinationNode(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
     TRestoreResult RestoreDependentResources(const TFsPath& fsPath, const TString& dbPath);
     TRestoreResult RestoreRateLimiter(const TFsPath& fsPath, const TString& coordinationNodePath, const TString& resourcePath);
-    TRestoreResult RestoreExternalDataSource(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
+    TRestoreResult RestoreExternalDataSource(const TFsPath& fsPath, const TString& dbPath, const TString& dbRestoreRoot, const TRestoreSettings& settings);
     TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
     TRestoreResult RestoreSysView(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
 
@@ -238,7 +238,8 @@ class TRestoreClient {
     TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, const TRestoreSettings& settings);
     TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool delay);
     TRestoreResult DropAndRestore(const TFsPath& fsPath, const TString& dbRestoreRoot, const TRestoreSettings& settings);
-    TRestoreResult DropAndRestoreExternals(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources, const THashMap<TString, size_t>& externalTables, const TRestoreSettings& settings);
+    TRestoreResult DropAndRestoreExternals(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources,
+        const THashMap<TString, size_t>& externalTables, const TString& dbRestoreRoot, const TRestoreSettings& settings);
     TRestoreResult DropAndRestoreTablesAndDependents(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const THashMap<TString, size_t>& tables, const TVector<size_t>& views, const THashMap<TString, size_t>& replications, const TVector<size_t>& transfers, const TString& dbRestoreRoot, const TRestoreSettings& settings);
 
 public:

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -234,6 +234,7 @@ class TRestoreClient {
         ui32 dataFilesCount);
 
     TRestoreResult CheckSecretExistence(const TString& secretName);
+    TRestoreResult ProcessSecretInQuery(TString& query, const TString& dbRestoreRoot, const TFsPath& fsPath);
     TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, const TRestoreSettings& settings);
     TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool delay);
     TRestoreResult DropAndRestore(const TFsPath& fsPath, const TString& dbRestoreRoot, const TRestoreSettings& settings);

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -233,6 +233,9 @@ class TRestoreClient {
         const TString& dbPath, const TRestoreSettings& settings, const NTable::TTableDescription& desc,
         ui32 dataFilesCount);
 
+    static TRestoreResult CheckSecretExistence(const TString& secretName, const TLog* log, NQuery::TQueryClient& queryClient);
+    static TRestoreResult CheckSecretsAndRewriteTheirPathsIfNeeded(TString& query, const TString& dbRestoreRoot, const TFsPath& fsPath,
+        const TLog* log, NQuery::TQueryClient& queryClient);
     TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, const TRestoreSettings& settings);
     TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool delay);
     TRestoreResult DropAndRestore(const TFsPath& fsPath, const TString& dbRestoreRoot, const TRestoreSettings& settings);

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
@@ -284,7 +284,10 @@ TVector<TSecretSetting> GetSecretSettings(const TString& query) {
         if (secretSettingValue.EndsWith("'")) {
             secretSettingValue.resize(secretSettingValue.size() - 1);
         }
-        result.push_back(TSecretSetting{.Name = settingName, .Value = secretSettingValue});
+        result.push_back(TSecretSetting{
+            .Name = settingName,
+            .Value = secretSettingValue,
+        });
     }
 
     return result;

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
@@ -257,6 +257,27 @@ TString GetDatabase(const TString& query) {
     return GetToken(query, R"(-- database: ")");
 }
 
+TMaybe<TSecretSetting> GetSecretSetting(const TString& query) {
+    static const TVector<TString> SECRET_SETTING_NAMES{
+        "PASSWORD_SECRET_NAME",
+        "PASSWORD_SECRET_PATH",
+        "TOKEN_SECRET_NAME",
+        "TOKEN_SECRET_PATH",
+    };
+    for (const auto& settingName : SECRET_SETTING_NAMES) {
+        auto secretSettingValue = GetToken(query, settingName + " = '");
+        if (!secretSettingValue) {
+            continue;
+        }
+        if (secretSettingValue.EndsWith("'")) {
+            secretSettingValue.resize(secretSettingValue.size() - 1);
+        }
+        return TSecretSetting{.Name = settingName, .Value = secretSettingValue};
+    }
+
+    return {};
+}
+
 TString GetSecretName(const TString& query) {
     TString secretName;
     if (auto pwd = GetToken(query, R"(PASSWORD_SECRET_NAME = ')")) {

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
@@ -258,7 +258,7 @@ TString GetDatabase(const TString& query) {
     return GetToken(query, R"(-- database: ")");
 }
 
-TMaybe<TSecretSetting> GetSecretSetting(const TString& query) {
+TVector<TSecretSetting> GetSecretSettings(const TString& query) {
     static const TVector<TString> SECRET_SETTING_NAMES = [] {
         static const TSet<TString> settings = {
             "TOKEN_SECRET",
@@ -276,6 +276,7 @@ TMaybe<TSecretSetting> GetSecretSetting(const TString& query) {
         return result;
     }();
 
+    TVector<TSecretSetting> result;
     for (const auto& settingName : SECRET_SETTING_NAMES) {
         auto secretSettingValue = GetToken(query, settingName + " = '");
         if (!secretSettingValue) {
@@ -284,10 +285,10 @@ TMaybe<TSecretSetting> GetSecretSetting(const TString& query) {
         if (secretSettingValue.EndsWith("'")) {
             secretSettingValue.resize(secretSettingValue.size() - 1);
         }
-        return TSecretSetting{.Name = settingName, .Value = secretSettingValue};
+        result.push_back(TSecretSetting{.Name = settingName, .Value = secretSettingValue});
     }
 
-    return {};
+    return result;
 }
 
 bool SqlToProtoAst(const TString& queryStr, TRule_sql_query& queryProto, NYql::TIssues& issues) {

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
@@ -17,7 +17,6 @@
 #include <util/stream/str.h>
 #include <util/string/builder.h>
 #include <util/string/strip.h>
-#include <util/generic/set.h>
 
 #include <re2/re2.h>
 
@@ -260,7 +259,7 @@ TString GetDatabase(const TString& query) {
 
 TVector<TSecretSetting> GetSecretSettings(const TString& query) {
     static const TVector<TString> SECRET_SETTING_NAMES = [] {
-        static const TSet<TString> settings = {
+        static const TVector<TString> settings = {
             "TOKEN_SECRET",
             "PASSWORD_SECRET",
             "SERVICE_ACCOUNT_SECRET",

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
@@ -261,7 +261,11 @@ TString GetSecretName(const TString& query) {
     TString secretName;
     if (auto pwd = GetToken(query, R"(PASSWORD_SECRET_NAME = ')")) {
         secretName = std::move(pwd);
+    } else if (auto token = GetToken(query, R"(PASSWORD_SECRET_PATH = ')")) {
+        secretName = std::move(token);
     } else if (auto token = GetToken(query, R"(TOKEN_SECRET_NAME = ')")) {
+        secretName = std::move(token);
+    } else if (auto token = GetToken(query, R"(TOKEN_SECRET_PATH = ')")) {
         secretName = std::move(token);
     }
 

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.h
@@ -32,6 +32,6 @@ bool RewriteCreateQuery(TString& query, std::string_view pattern, const std::str
 
 TString GetBackupRoot(const TString& query);
 TString GetDatabase(const TString& query);
-TMaybe<TSecretSetting> GetSecretSetting(const TString& query);
+TVector<TSecretSetting> GetSecretSettings(const TString& query);
 
 } // NYdb::NDump

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.h
@@ -15,6 +15,11 @@ namespace NSQLv1Generated {
 
 namespace NYdb::NDump {
 
+struct TSecretSetting {
+    TString Name;
+    TString Value;
+};
+
 bool SqlToProtoAst(const TString& queryStr, NSQLv1Generated::TRule_sql_query& queryProto, NYql::TIssues& issues);
 bool Format(const TString& query, TString& formattedQuery, NYql::TIssues& issues);
 
@@ -28,5 +33,6 @@ bool RewriteCreateQuery(TString& query, std::string_view pattern, const std::str
 TString GetBackupRoot(const TString& query);
 TString GetDatabase(const TString& query);
 TString GetSecretName(const TString& query);
+TMaybe<TSecretSetting> GetSecretSetting(const TString& query);
 
 } // NYdb::NDump

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.h
@@ -32,7 +32,6 @@ bool RewriteCreateQuery(TString& query, std::string_view pattern, const std::str
 
 TString GetBackupRoot(const TString& query);
 TString GetDatabase(const TString& query);
-TString GetSecretName(const TString& query);
 TMaybe<TSecretSetting> GetSecretSetting(const TString& query);
 
 } // NYdb::NDump


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Новые секреты используются в параметрах вида `*_PATH`. Сделана их поддержка в дампах репликаций, трансферов и внешних источников – это все сущности, которые сейчас используют секреты.

1. Тип секрета для дампа и рестора (старый или новый) выводится по его имени: если начинается со слеша, то это новый секрет, причём это так и для случаев, когда секрет задан просто как `..._SECRET_PATH = "secret-name"` – такие имена при парсинге sql-команд дополняются до полных путей, как это делается с другими схемными объектами.

2. Запрос на создание внешнего источника начал дампить и саму базу в комментарий (в `BuildCreateExternalDataSourceQuery`) – это нужно, чтобы при восстановлении не в корень, правился путь до новых секретов (аналогичные механики с таблицами и топиками сделаны, например, в трансферах и асинхронных репликациях).

3. Во внешних источниках может быть несколько секретов, но такие источники не восстанавливались: не было поддержки нескольких секретов в ресторе, а так же там явно перечисляются имена параметров, и некоторые были пропущены. Это починено.