### PR TITLE
[ICRDMA] SA_INTERRUPT is noop flag. No need to set it.

### DIFF
--- a/ydb/library/actors/interconnect/rdma/rdma.cpp
+++ b/ydb/library/actors/interconnect/rdma/rdma.cpp
@@ -31,7 +31,7 @@ void SetSigHandler() noexcept {
     struct sigaction sigActionData;
     sigemptyset(&sigActionData.sa_mask);
     sigActionData.sa_handler = &SigHandler;
-    sigActionData.sa_flags = SA_INTERRUPT;
+    sigActionData.sa_flags = 0;
     sigaction(SIGUSR1, &sigActionData, nullptr);
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

SA_INTERRUPT is noop flag. No need to set it.
We just need to interrupt blocked read syscall. 

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
