### PR TITLE
Add test for the default split-by-load CPU threshold

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1546,12 +1546,12 @@ message TImmediateControlsConfig {
         optional uint64 FastSplitSizeThreshold = 9 [(ControlOptions) = {
             Description: "FastSplitSize Threshold",
             MinValue: 100000,
-            MaxValue: 4000000000,
+            MaxValue: 411000000000,
             DefaultValue: 4000000 }];
         optional uint64 FastSplitRowCountThreshold = 10 [(ControlOptions) = {
             Description: "Disable publications of dropping",
             MinValue: 1000,
-            MaxValue: 1000000000,
+            MaxValue: 111000000000,
             DefaultValue: 100000 }];
         optional uint64 FastSplitCpuPercentageThreshold = 11 [(ControlOptions) = {
             Description: "Max Fast split cpu usage",
@@ -1566,17 +1566,17 @@ message TImmediateControlsConfig {
         optional uint64 SplitByLoadMaxShardsDefault = 13 [(ControlOptions) = {
             Description: "Max shards that cant be split by load",
             MinValue: 0,
-            MaxValue: 50,
-            DefaultValue: 10000 }];
+            MaxValue: 10000,
+            DefaultValue: 50 }];
         optional uint64 MergeByLoadMinUptimeSec = 14 [(ControlOptions) = {
             Description: "Min uptime to merge by load in seconds",
             MinValue: 0,
-            MaxValue: 4000000000,
+            MaxValue: 411000000000,
             DefaultValue: 600 }];
         optional uint64 MergeByLoadMinLowLoadDurationSec = 15 [(ControlOptions) = {
             Description: "Min low load duration in sec to merge by load",
             MinValue: 0,
-            MaxValue: 4000000000,
+            MaxValue: 411000000000,
             DefaultValue: 3600 }];
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2307,7 +2307,8 @@ bool TTableInfo::CheckSplitByLoad(
             << " shardSize: " << stats->DataSize << " minShardSize: " << MIN_SIZE_FOR_SPLIT_BY_LOAD
             << " shardCount: " << Stats.PartitionStats.size()
             << " expectedShardCount: " << ExpectedPartitionCount << " maxShardCount: " << maxShards
-            << " cpuUsage: " << currentCpuUsage << " cpuUsageThreshold: " << cpuUsageThreshold * 1000000;
+            << " cpuUsage: " << currentCpuUsage
+            << " cpuUsageThreshold: " << static_cast<ui64>(cpuUsageThreshold * 1000000);
         return false;
     }
 
@@ -2320,7 +2321,7 @@ bool TTableInfo::CheckSplitByLoad(
         << "expectedShardCount: " << ExpectedPartitionCount << ", "
         << "maxShardCount: " << maxShards << ", "
         << "cpuUsage: " << currentCpuUsage << ", "
-        << "cpuUsageThreshold: " << cpuUsageThreshold * 1000000 << ")";
+        << "cpuUsageThreshold: " << static_cast<ui64>(cpuUsageThreshold * 1000000) << ")";
 
     return true;
 }


### PR DESCRIPTION
### Changelog entry

Added tests to verify the default value for the split-by-load CPU load threshold

### Changelog category

* Improvement

### Description for reviewers

* Added the `TSchemeShardSplitByLoad::CorrectSplitThresholdDefaultValueLeader` test
* Added the `TSchemeShardSplitByLoad::CorrectSplitThresholdDefaultValueFollower` test
* Fix the max value for `TSchemeShardControls.FastSplitSizeThreshold`
* Fix the max value for `TSchemeShardControls.FastSplitRowCountThreshold`
* Fix the default value for `TSchemeShardControls.SplitByLoadMaxShardsDefault`
* Fix the max value for `TSchemeShardControls.MergeByLoadMinUptimeSec`
* Fix the max value for `TSchemeShardControls.MergeByLoadMinLowLoadDurationSec`
* Fix log formatting for the split-by-load CPU threshold in the logs