### PR TITLE
Fix flaky auth system view tests by adding retry logic for login credentials

### DIFF
--- a/ydb/core/sys_view/ut_auth.cpp
+++ b/ydb/core/sys_view/ut_auth.cpp
@@ -68,7 +68,7 @@ TString ExecuteScanQueryWithRetry(TTableClient& client, const TString& query, in
                         gotUnauthorized = true;
                         break;
                     }
-                    UNIT_ASSERT_C(streamPart.EOS(), streamPart.GetIssues().ToString());
+                    UNIT_ASSERT_C(false, streamPart.GetIssues().ToString());
                     break;
                 }
                 if (streamPart.HasResultSet()) {


### PR DESCRIPTION
When using CreateLoginCredentialsProviderFactory, there's a race condition
where authentication might not be fully established before the first query,
causing transient UNAUTHORIZED errors. Added ExecuteScanQueryWithRetry helper
to retry queries with exponential backoff.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
