### PR TITLE
YQ-4937: fix ydb external datasource tests

### DIFF
--- a/ydb/library/yql/providers/generic/connector/tests/utils/run/kqprun.py
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/run/kqprun.py
@@ -200,7 +200,7 @@ QueryServiceConfig {
   AvailableExternalDataSources: "Redis"
   AvailableExternalDataSources: "Prometheus"
   AvailableExternalDataSources: "OpenSearch"
-  AllExternalDataSourcesAreAvailable: true
+  AllExternalDataSourcesAreAvailable: false
   Generic {
     Connector {
         Endpoint {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Now to distinguish YDB/YDB topics kqprun executes query to external YDB and for this it does DNS query. This DNS query fails for IT fq-connector-go test. This commit turns off YDB topic and consequently disables DNS. 