### PR TITLE
Fixed an error that caused the pipe break to not be handled.

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -584,7 +584,8 @@ void TKafkaProduceActor::SendResults(const TActorContext& ctx) {
                 size_t recordsCount = partitionData.Records.has_value() ? partitionData.Records->Records.size() : 0;
                 partitionResponse.Index = partitionData.Index;
                 if (EKafkaErrors::NONE_ERROR != result.ErrorCode) {
-                    KAFKA_LOG_ERROR("Produce actor: Partition result with error: ErrorCode=" << static_cast<int>(result.ErrorCode) << ", ErrorMessage=" << result.ErrorMessage << ", #01");
+                    KAFKA_LOG_ERROR("Produce actor: Partition result with error: ErrorCode=" << static_cast<int>(result.ErrorCode)
+                        << ", ErrorMessage=" << result.ErrorMessage << ", #01");
                     partitionResponse.ErrorCode = result.ErrorCode;
                     metricsErrorCode = result.ErrorCode;
                     partitionResponse.ErrorMessage = result.ErrorMessage;

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
@@ -54,6 +54,7 @@ private:
     void Handle(TEvKafka::TEvWakeup::TPtr request, const TActorContext& ctx);
     void Handle(TEvPartitionWriter::TEvWriteResponse::TPtr request, const TActorContext& ctx);
     void Handle(TEvPartitionWriter::TEvInitResult::TPtr request, const TActorContext& ctx);
+    void Handle(TEvPartitionWriter::TEvDisconnected::TPtr request, const TActorContext& ctx);
     void EnqueueRequest(TEvKafka::TEvProduceRequest::TPtr request, const TActorContext& ctx);
     void Handle(TEvTxProxySchemeCache::TEvWatchNotifyDeleted::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr& ev, const TActorContext& ctx);
@@ -69,6 +70,7 @@ private:
             HFunc(TEvKafka::TEvProduceRequest, EnqueueRequest);
             HFunc(TEvPartitionWriter::TEvInitResult, Handle);
             HFunc(TEvPartitionWriter::TEvWriteResponse, Handle);
+            HFunc(TEvPartitionWriter::TEvDisconnected, Handle);
 
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyDeleted, Handle);
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
@@ -87,6 +89,7 @@ private:
             HFunc(TEvKafka::TEvProduceRequest, Handle);
             HFunc(TEvPartitionWriter::TEvInitResult, Handle);
             HFunc(TEvPartitionWriter::TEvWriteResponse, Handle);
+            HFunc(TEvPartitionWriter::TEvDisconnected, Handle);
 
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyDeleted, Handle);
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
@@ -108,6 +111,7 @@ private:
             HFunc(TEvKafka::TEvProduceRequest, EnqueueRequest);
             HFunc(TEvPartitionWriter::TEvInitResult, Handle);
             HFunc(TEvPartitionWriter::TEvWriteResponse, Handle);
+            HFunc(TEvPartitionWriter::TEvDisconnected, Handle);
 
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyDeleted, Handle);
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
@@ -129,6 +133,7 @@ private:
     void CleanTopics(const TActorContext& ctx);
     void CleanWriters(const TActorContext& ctx);
     std::pair<ETopicStatus, TActorId> PartitionWriter(const TTopicPartition& topicPartition, const TProducerInstanceId& producerInstanceId, const TMaybe<TString>& transactionalId, const TActorContext& ctx);
+    std::pair<TString, ui32> WriterDied(const TActorId& writerId);
 
     TString LogPrefix();
     void LogEvent(IEventHandle& ev);

--- a/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
@@ -301,5 +301,36 @@ namespace {
             UNIT_ASSERT(response != nullptr);
             UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::REQUEST_TIMED_OUT);
         }
+
+        Y_UNIT_TEST(OnProduce_andPipeDisconnected) {
+            i64 producerId = 1;
+            i32 producerEpoch = 2;
+
+            int writeRequestsCounter = 0;
+            int poisonPillCounter = 0;
+
+            auto observer = [&](TAutoPtr<IEventHandle>& input) {
+                if (input->CastAsLocal<TEvPartitionWriter::TEvWriteRequest>()) {
+                    if (writeRequestsCounter++ == 0) {
+                        auto r = std::make_unique<TEvPartitionWriter::TEvDisconnected>(TEvPartitionWriter::TEvWriteResponse::EErrorCode::InternalError);
+                        Ctx->Runtime->Send(new IEventHandle(input->Sender, input->Recipient, r.release()));
+                        return TTestActorRuntimeBase::EEventAction::DROP;
+                    }
+                } else if (input->CastAsLocal<TEvents::TEvPoison>()) {
+                    poisonPillCounter++;
+                }
+
+                return TTestActorRuntimeBase::EEventAction::PROCESS;
+            };
+
+            Ctx->Runtime->SetObserverFunc(observer);
+
+            SendProduce({}, producerId, producerEpoch);
+
+            auto response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+            UNIT_ASSERT(response);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::NOT_LEADER_OR_FOLLOWER);
+            UNIT_ASSERT_VALUES_EQUAL(std::dynamic_pointer_cast<NKafka::TProduceResponseData>(response->Response)->Responses[0].PartitionResponses[0].ErrorCode, NKafka::EKafkaErrors::NOT_LEADER_OR_FOLLOWER);
+        }
     }
 } // anonymous namespace


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Запись по кафка протоколу иногда могла останавливаться, и возобновляться только по таймауту в 30 сек. с переустановкой сессии записи.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10178
