### PR TITLE
Fix get_muted_tests.py  for stable branches

### DIFF
--- a/.github/scripts/tests/get_muted_tests.py
+++ b/.github/scripts/tests/get_muted_tests.py
@@ -197,10 +197,11 @@ def mute_applier(args):
     all_tests_file = os.path.join(output_path, '1_all_tests.txt')
     all_muted_tests_file = os.path.join(output_path, '1_all_muted_tests.txt')
 
-    # all muted
-    print(f'📋 Loading mute rules from: {muted_ya_path}')
+    # Используем переданный путь или путь по умолчанию
+    current_muted_ya_path = getattr(args, 'muted_ya_file', None) or muted_ya_path
+    print(f'📋 Loading mute rules from: {current_muted_ya_path}')
     mute_check = YaMuteCheck()
-    mute_check.load(muted_ya_path)
+    mute_check.load(current_muted_ya_path)
     print(f'✅ Mute rules loaded successfully')
 
     if args.mode == 'upload_muted_tests':
@@ -252,7 +253,8 @@ def mute_applier(args):
         removed_mute_lines_file = os.path.join(output_path, '3_removed_mute_lines.txt')
         unmuted_tests_file = os.path.join(output_path, '3_unmuted_tests.txt')
 
-        added_lines, removed_lines = get_diff_lines_of_file(args.base_sha, args.head_sha, muted_ya_path)
+        current_muted_ya_path = getattr(args, 'muted_ya_file', None) or muted_ya_path
+        added_lines, removed_lines = get_diff_lines_of_file(args.base_sha, args.head_sha, current_muted_ya_path)
 
         # checking added lines
         write_to_file('\n'.join(added_lines), added_mute_lines_file)
@@ -300,7 +302,7 @@ def mute_applier(args):
 if __name__ == "__main__":
     print(f'🚀 Starting get_muted_tests.py script')
     print(f'📅 Current time: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')
-    print(f'📋 Muted YA file path: {muted_ya_path}')
+    print(f'📋 Muted YA file path (default): {muted_ya_path}')
     
     parser = argparse.ArgumentParser(description="Generate diff files for mute_ya.txt")
 
@@ -321,6 +323,11 @@ if __name__ == "__main__":
     )
     upload_muted_tests_parser.add_argument(
         '--build_type', required=True, help='build type for filtering tests'
+    )
+    upload_muted_tests_parser.add_argument(
+        '--muted_ya_file',
+        type=str,
+        help='Path to muted_ya.txt file (default: .github/config/muted_ya.txt)'
     )
 
     get_mute_details_parser = subparsers.add_parser(

--- a/.github/scripts/tests/get_muted_tests.py
+++ b/.github/scripts/tests/get_muted_tests.py
@@ -197,7 +197,7 @@ def mute_applier(args):
     all_tests_file = os.path.join(output_path, '1_all_tests.txt')
     all_muted_tests_file = os.path.join(output_path, '1_all_muted_tests.txt')
 
-    # Используем переданный путь или путь по умолчанию
+    # Use the provided path or default path
     current_muted_ya_path = getattr(args, 'muted_ya_file', None) or muted_ya_path
     print(f'📋 Loading mute rules from: {current_muted_ya_path}')
     mute_check = YaMuteCheck()

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -96,7 +96,7 @@ jobs:
         run: python3 .github/scripts/analytics/flaky_tests_history.py --branch=${{ env.BASE_BRANCH }} --build_type=${{ env.BUILD_TYPE }}
       
       - name: Update muted tests in DB
-        run: python3 .github/scripts/tests/get_muted_tests.py upload_muted_tests --branch=${{ env.BASE_BRANCH }} --build_type=${{ env.BUILD_TYPE }} 
+        run: python3 .github/scripts/tests/get_muted_tests.py upload_muted_tests --branch=${{ env.BASE_BRANCH }} --build_type=${{ env.BUILD_TYPE }} --muted_ya_file=base_muted_ya.txt 
       
       - name: Update test monitor
         run: python3 .github/scripts/analytics/tests_monitor.py --branch=${{ env.BASE_BRANCH }} --build_type=${{ env.BUILD_TYPE }}


### PR DESCRIPTION
…update workflow to use this option. Default path is retained for backward compatibility.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
