### PR TITLE
[KQP] Truncate table

### DIFF
--- a/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
+++ b/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
@@ -918,9 +918,11 @@ public:
         return NotImplemented<TGenericResult>();
     }
 
-    TFuture<TGenericResult> AlterDatabase(const TString& cluster, const NYql::TAlterDatabaseSettings& settings) override {
-        Y_UNUSED(cluster);
-        Y_UNUSED(settings);
+    TFuture<TGenericResult> AlterDatabase(const TString&, const NYql::TAlterDatabaseSettings&) override {
+        return NotImplemented<TGenericResult>();
+    }
+
+    TFuture<TGenericResult> TruncateTable(const TString&, const NYql::TTruncateTableSettings&) override {
         return NotImplemented<TGenericResult>();
     }
 

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -766,6 +766,24 @@ public:
         }
     }
 
+    TFuture<TGenericResult> TruncateTable(const TString& cluster, const TTruncateTableSettings& settings) override {
+        CHECK_PREPARED_DDL(TruncateTable);
+
+        Y_UNUSED(settings);
+        if (cluster != SessionCtx->GetCluster()) {
+            return InvalidCluster<TGenericResult>(cluster);
+        }
+
+        auto tablePromise = NewPromise<TGenericResult>();
+        auto code = Ydb::StatusIds::BAD_REQUEST;
+        auto error = TStringBuilder() << "Truncate table not supported yet";
+        IKqpGateway::TGenericResult errResult;
+        errResult.AddIssue(NYql::TIssue(error));
+        errResult.SetStatus(NYql::YqlStatusFromYdbStatus(code));
+        tablePromise.SetValue(errResult);
+        return tablePromise.GetFuture();
+    }
+
     TFuture<TGenericResult> CreateTable(TKikimrTableMetadataPtr metadata, bool createDir, bool existingOk, bool replaceIfExists) override {
         Y_UNUSED(replaceIfExists);
         CHECK_PREPARED_DDL(CreateTable);

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -199,6 +199,10 @@ private:
         return TStatus::Ok;
     }
 
+    TStatus HandleTruncateTable(NNodes::TKiTruncateTable, TExprContext&) override {
+        return TStatus::Ok;
+    }
+
     TStatus HandleModifyPermissions(TKiModifyPermissions node, TExprContext& ctx) override {
         Y_UNUSED(ctx, node);
         return TStatus::Ok;
@@ -359,9 +363,6 @@ private:
                 {
                     SessionCtx->Tables().GetOrAddTable(TString(cluster), SessionCtx->GetDatabase(), key.GetTablePath());
                     return TStatus::Ok;
-                } else if (mode == "fill_table") {
-                    SessionCtx->Tables().GetOrAddTable(TString(cluster), SessionCtx->GetDatabase(), key.GetTablePath());
-                    return TStatus::Ok;
                 } else if (mode == "insert_ignore") {
                     ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
                         << "INSERT OR IGNORE is not yet supported for Kikimr."));
@@ -450,6 +451,9 @@ private:
                     return TStatus::Ok;
                 } else if (mode == "drop" || mode == "drop_if_exists") {
                     HandleDropTable(SessionCtx, settings, key, cluster);
+                    return TStatus::Ok;
+                } else if (mode == "truncateTable") {
+                    SessionCtx->Tables().GetOrAddTable(TString(cluster), SessionCtx->GetDatabase(), key.GetTablePath(), tableType);
                     return TStatus::Ok;
                 }
 
@@ -634,6 +638,10 @@ public:
 
     bool CanExecute(const TExprNode& node) override {
         if (node.IsCallable(TKiAlterDatabase::CallableName())) {
+            return true;
+        }
+
+        if (node.IsCallable(TKiTruncateTable::CallableName())) {
             return true;
         }
 
@@ -1398,6 +1406,14 @@ public:
 
                 } else if (mode == "drop" || mode == "drop_if_exists") {
                     return MakeKiDropTable(node, settings, key, ctx);
+                } else if (mode == "truncateTable") {
+                    auto truncateTable = Build<TKiTruncateTable>(ctx, node->Pos())
+                        .World(node->Child(0))
+                        .DataSink(node->Child(1))
+                        .TablePath().Build(key.GetTablePath())
+                        .Done();
+
+                    return truncateTable.Ptr();
                 } else {
                     YQL_ENSURE(false, "unknown TableScheme mode \"" << TString(mode) << "\"");
                 }
@@ -2140,6 +2156,10 @@ IGraphTransformer::TStatus TKiSinkVisitorTransformer::DoTransform(TExprNode::TPt
 
     if (auto node = callable.Maybe<TKiAlterSequence>()) {
         return HandleAlterSequence(node.Cast(), ctx);
+    }
+
+    if (auto node = callable.Maybe<TKiTruncateTable>()) {
+        return HandleTruncateTable(node.Cast(), ctx);
     }
 
     if (auto node = callable.Maybe<TKiAnalyzeTable>()) {

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -166,7 +166,7 @@ namespace {
 
     TTruncateTableSettings ParseTruncateTableSettings(TKiTruncateTable truncateTable) {
         TTruncateTableSettings truncateTableSettings;
-        Y_UNUSED(truncateTable);
+        truncateTableSettings.TablePath = truncateTable.TablePath().Value();
         return truncateTableSettings;
     }
 

--- a/ydb/core/kqp/provider/yql_kikimr_expr_nodes.json
+++ b/ydb/core/kqp/provider/yql_kikimr_expr_nodes.json
@@ -26,6 +26,16 @@
             ]
         },
         {
+            "Name": "TKiTruncateTable",
+            "Base": "TCallable",
+            "Match": {"Type": "Callable", "Name": "KiTruncateTable!"},
+            "Children": [
+                {"Index": 0, "Name": "World", "Type": "TExprBase"},
+                {"Index": 1, "Name": "DataSink", "Type": "TKiDataSink"},
+                {"Index": 2, "Name": "TablePath", "Type": "TCoAtom"}
+            ]
+        },
+        {
             "Name": "TKiAlterDatabase",
             "Base": "TCallable",
             "Match": {"Type": "Callable", "Name": "KiAlterDatabase!"},

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -768,6 +768,10 @@ struct TAlterDatabaseSettings {
     std::optional<NKikimrSubDomains::TSchemeLimits> SchemeLimits;
 };
 
+struct TTruncateTableSettings {
+    TString TablePath;
+};
+
 struct TCreateUserSettings {
     TString UserName;
     TString Password;
@@ -1277,6 +1281,8 @@ public:
     virtual NThreading::TFuture<TGenericResult> SetConstraint(const TString& tableName, TVector<TSetColumnConstraintSettings>&& settings) = 0;
 
     virtual NThreading::TFuture<TGenericResult> AlterDatabase(const TString& cluster, const TAlterDatabaseSettings& settings) = 0;
+
+    virtual NThreading::TFuture<TGenericResult> TruncateTable(const TString& cluster, const TTruncateTableSettings& settings) = 0;
 
     virtual NThreading::TFuture<TGenericResult> CreateTable(TKikimrTableMetadataPtr metadata, bool createDir, bool existingOk = false, bool replaceIfExists = false) = 0;
 

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -714,6 +714,17 @@ bool ExploreNode(TExprBase node, TExprContext& ctx, const TKiDataSink& dataSink,
         return true;
     }
 
+    if (auto maybeTruncateTable = node.Maybe<TKiTruncateTable>()) {
+        auto truncateTable = maybeTruncateTable.Cast();
+        if (!checkDataSink(truncateTable.DataSink())) {
+            return false;
+        }
+
+        txRes.Ops.insert(node.Raw());
+        txRes.AddTableOperation(BuildYdbOpNode(cluster, TYdbOperation::TruncateTable, truncateTable.Pos(), ctx));
+        return true;
+    }
+
     if (node.Maybe<TCoCommit>()) {
         return true;
     }

--- a/ydb/core/kqp/provider/yql_kikimr_provider.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.cpp
@@ -49,6 +49,7 @@ struct TKikimrData {
         DataSinkNames.insert(TKiCreateTable::CallableName());
         DataSinkNames.insert(TKiAlterTable::CallableName());
         DataSinkNames.insert(TKiDropTable::CallableName());
+        DataSinkNames.insert(TKiTruncateTable::CallableName());
         DataSinkNames.insert(TKiCreateTopic::CallableName());
         DataSinkNames.insert(TKiAlterTopic::CallableName());
         DataSinkNames.insert(TKiDropTopic::CallableName());
@@ -148,7 +149,8 @@ struct TKikimrData {
             TYdbOperation::Restore |
             TYdbOperation::CreateSecret |
             TYdbOperation::AlterSecret |
-            TYdbOperation::DropSecret;
+            TYdbOperation::DropSecret |
+            TYdbOperation::TruncateTable;
 
         SystemColumns = {
             {"_yql_partition_id", NKikimr::NUdf::EDataSlot::Uint64}

--- a/ydb/core/kqp/provider/yql_kikimr_provider.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.h
@@ -286,6 +286,7 @@ enum class TYdbOperation : ui64 {
     CreateSecret           = 1ull << 39,
     AlterSecret            = 1ull << 40,
     DropSecret             = 1ull << 41,
+    TruncateTable          = 1ull << 42,
 };
 
 Y_DECLARE_FLAGS(TYdbOperations, TYdbOperation);

--- a/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
@@ -76,6 +76,7 @@ private:
     virtual TStatus HandleDropSequence(NNodes::TKiDropSequence node, TExprContext& ctx) = 0;
     virtual TStatus HandleAlterSequence(NNodes::TKiAlterSequence node, TExprContext& ctx) = 0;
 
+    virtual TStatus HandleTruncateTable(NNodes::TKiTruncateTable node, TExprContext& ctx) = 0;
     virtual TStatus HandleModifyPermissions(NNodes::TKiModifyPermissions node, TExprContext& ctx) = 0;
 
     virtual TStatus HandleReturningList(NNodes::TKiReturningList node, TExprContext& ctx) = 0;

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -915,7 +915,7 @@ private:
         return TStatus::Ok;
     }
 
-virtual TStatus HandleCreateTable(TKiCreateTable create, TExprContext& ctx) override {
+    virtual TStatus HandleCreateTable(TKiCreateTable create, TExprContext& ctx) override {
         TString cluster = TString(create.DataSink().Cluster());
         TString table = TString(create.Table());
         TString tableType = TString(create.TableType());
@@ -2034,6 +2034,11 @@ virtual TStatus HandleCreateTable(TKiCreateTable create, TExprContext& ctx) over
     }
 
     virtual TStatus HandleModifyPermissions(TKiModifyPermissions node, TExprContext&) override {
+        node.Ptr()->SetTypeAnn(node.World().Ref().GetTypeAnn());
+        return TStatus::Ok;
+    }
+
+    virtual TStatus HandleTruncateTable(NNodes::TKiTruncateTable node, TExprContext&) override {
         node.Ptr()->SetTypeAnn(node.World().Ref().GetTypeAnn());
         return TStatus::Ok;
     }

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -2038,8 +2038,15 @@ private:
         return TStatus::Ok;
     }
 
-    virtual TStatus HandleTruncateTable(NNodes::TKiTruncateTable node, TExprContext&) override {
+    virtual TStatus HandleTruncateTable(NNodes::TKiTruncateTable node, TExprContext& ctx) override {
+        // there is will be checking on feature flag
         node.Ptr()->SetTypeAnn(node.World().Ref().GetTypeAnn());
+
+        if (!node.TablePath().Value()) {
+            ctx.AddError(TIssue(ctx.GetPosition(node.TablePath().Pos()), "TablePath can't be empty."));
+            return TStatus::Error;
+        }
+
         return TStatus::Ok;
     }
 
@@ -2051,7 +2058,7 @@ private:
         }
 
         if (!node.DatabasePath().Value()) {
-                ctx.AddError(TIssue(ctx.GetPosition(node.DatabasePath().Pos()), "DatabasePath can't be empty."));
+            ctx.AddError(TIssue(ctx.GetPosition(node.DatabasePath().Pos()), "DatabasePath can't be empty."));
             return TStatus::Error;
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

`Truncate Table` in general is a new operation in YDB, the idea of which is to quickly delete all data from the table.

Before that, a new statement was added to the YQL grammar, there is [PR](https://github.com/ydb-platform/ydb/commit/e83df9db92b52025eb5c715434893520170e5292).

[There](https://github.com/ydb-platform/ydb/pull/29125) is common PR into SchemeShard and DataShard.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

In this implementation, it is not possible to send a message to schemshard, because it is impossible to verify whether the processing of this message is working. Completion will be performed after merging the pull request in schemeshard's and datashard's code.

So, there is dummy implementation in kqp_gateway_proxy.cpp::TruncateTable.