### PR TITLE
Support better SchemeCache errors handling

### DIFF
--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
@@ -139,6 +139,9 @@ void TDescribeSchemaSecretsService::HandleIncomingRetryRequest(TEvResolveSecretR
 void TDescribeSchemaSecretsService::HandleSchemeCacheResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
     const auto requestId = ev->Cookie;
     LOG_D(GetLogLabel("TEvNavigateKeySetResult", requestId));
+    if (SchemeCacheResponseModifier) {
+        SchemeCacheResponseModifier->Modify(*ev->Get()->Request);
+    }
 
     auto respIt = ResolveInFlight.find(requestId);
     Y_ENSURE(respIt != ResolveInFlight.end(), "such requestId is not registered");

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.cpp
@@ -110,7 +110,7 @@ IActor* CreateDescribeSecretsActor(const TString& ownerUserId, const std::vector
     return new TDescribeSecretsActor(ownerUserId, secretIds, promise);
 }
 
-// It's a hack so we can simulate Scheme Cache retryable errors
+// It's a hack so we can simulate Scheme Cache retryable errors in tests
 NSchemeCache::TSchemeCacheNavigate::EStatus GetSchemeCacheEntryStatus(
     const TDescribeSchemaSecretsService::ISchemeCacheStatusGetter* schemeCacheStatusGetter,
     NSchemeCache::TSchemeCacheNavigate::TEntry& entry)
@@ -339,7 +339,7 @@ bool TDescribeSchemaSecretsService::ScheduleSchemeCacheRetry(const ui64& request
         )->CreateRetryState();
     }
 
-    if (const auto delay = RequestsInFlight.at(requestId).RetryState->GetNextRetryDelay()) {
+    if (const auto delay = requestIt->second.RetryState->GetNextRetryDelay()) {
         LOG_N(GetLogLabel("TEvNavigateKeySetResult", requestId) << "secret `" << unresolvedSecretPath
             << "` not found. Request will be retried in: " << *delay);
         this->Schedule(*delay, new TEvResolveSecretRetry(requestId));

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -132,6 +132,15 @@ public:
         SecretUpdateListener = secretUpdateListener;
     }
 
+    class ISchemeCacheResponseModifier : public TThrRefBase {
+    public:
+        virtual void Modify(NSchemeCache::TSchemeCacheNavigate& result) = 0;
+        virtual ~ISchemeCacheResponseModifier() = default;
+    };
+    void SetSchemeCacheResponseModifier(ISchemeCacheResponseModifier* modifier) {
+        SchemeCacheResponseModifier = modifier;
+    }
+
 private:
     ui64 LastRequestId = 0;
     THashMap<ui64, TRequestContext> RequestsInFlight;
@@ -139,6 +148,7 @@ private:
     THashMap<TString, TVersionedSecret> VersionedSecrets;
     THashMap<TString, TActorId> SchemeBoardSubscribers;
     ISecretUpdateListener* SecretUpdateListener;
+    ISchemeCacheResponseModifier* SchemeCacheResponseModifier;
 };
 
 void RegisterDescribeSecretsActor(

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -16,7 +16,6 @@
 
 #include <util/generic/hash_multi_map.h>
 
-
 namespace NKikimr::NKqp {
 
 class TDescribeSchemaSecretsService: public NActors::TActorBootstrapped<TDescribeSchemaSecretsService> {

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -11,16 +11,21 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/aclib/aclib.h>
 
+#include <library/cpp/retry/retry_policy.h>
 #include <library/cpp/threading/future/future.h>
 
 #include <util/generic/hash_multi_map.h>
+
 
 namespace NKikimr::NKqp {
 
 class TDescribeSchemaSecretsService: public NActors::TActorBootstrapped<TDescribeSchemaSecretsService> {
 public:
+    using TRetryPolicy = IRetryPolicy<>;
+
     enum ESecretEvents {
         EvResolveSecret = EventSpaceBegin(TKikimrEvents::ES_PRIVATE),
+        EvResolveSecretRetry,
         EvEnd,
     };
 
@@ -40,11 +45,23 @@ public:
             Y_ENSURE(!Database.empty(), "Database name must be set in secret requests");
         }
 
+        THolder<TEvResolveSecret> MakeCopy() const {
+            return MakeHolder<TEvResolveSecret>(UserToken, Database, SecretNames, Promise);
+        }
+
     public:
         const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
         const TString Database;
         const TVector<TString> SecretNames;
         NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> Promise;
+    };
+
+    struct TEvResolveSecretRetry : public NActors::TEventLocal<TEvResolveSecretRetry, EvResolveSecretRetry> {
+        TEvResolveSecretRetry(ui64 initialRequestId)
+            : InitialRequestId(initialRequestId)
+        {}
+
+        ui64 InitialRequestId = 0;
     };
 
 private:
@@ -62,9 +79,20 @@ private:
         size_t FilledSecretsCnt = 0;
     };
 
+    struct TRequestContext {
+        THolder<TEvResolveSecret> Request;
+        TRetryPolicy::IRetryState::TPtr RetryState;
+
+        TRequestContext(THolder<TEvResolveSecret> request)
+            : Request(std::move(request))
+        {
+        }
+    };
+
 private:
     STRICT_STFUNC(StateWait,
         hFunc(TEvResolveSecret, HandleIncomingRequest);
+        hFunc(TEvResolveSecretRetry, HandleIncomingRetryRequest);
         hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleSchemeCacheResponse);
         hFunc(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult, HandleSchemeShardResponse);
         hFunc(TSchemeBoardEvents::TEvNotifyDelete, HandleNotifyDelete);
@@ -73,6 +101,7 @@ private:
     )
 
     void HandleIncomingRequest(TEvResolveSecret::TPtr& ev);
+    void HandleIncomingRetryRequest(TEvResolveSecretRetry::TPtr& ev);
     void HandleSchemeCacheResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
     void HandleSchemeShardResponse(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev);
     void HandleNotifyDelete(TSchemeBoardEvents::TEvNotifyDelete::TPtr& ev);
@@ -80,11 +109,12 @@ private:
 
     void FillResponse(const ui64& requestId, const TEvDescribeSecretsResponse::TDescription& response);
     void SaveIncomingRequestInfo(const TEvResolveSecret& ev);
-    void SendSchemeCacheRequests(const TEvResolveSecret& ev);
+    void SendSchemeCacheRequests(const TEvResolveSecret& ev, const ui64 requestId);
     bool LocalCacheHasActualVersion(const TVersionedSecret& secret, const ui64& cacheSecretVersion);
     bool LocalCacheHasActualObject(const TVersionedSecret& secret, const ui64& cacheSecretPathId);
     bool HandleSchemeCacheErrorsIfAny(const ui64& requestId, NSchemeCache::TSchemeCacheNavigate& result);
     void FillResponseIfFinished(const ui64& requestId, const TResponseContext& responseCtx);
+    bool ScheduleSchemeCacheRetry(const ui64& requestId, const TString& unresolvedSecretPath);
 
 public:
     TDescribeSchemaSecretsService() = default;
@@ -104,6 +134,7 @@ public:
 
 private:
     ui64 LastCookie = 0;
+    THashMap<ui64, TRequestContext> RequestsInFlight;
     THashMap<ui64, TResponseContext> ResolveInFlight;
     THashMap<TString, TVersionedSecret> VersionedSecrets;
     THashMap<TString, TActorId> SchemeBoardSubscribers;

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -60,7 +60,7 @@ public:
             : InitialRequestId(initialRequestId)
         {}
 
-        ui64 InitialRequestId = 0;
+        const ui64 InitialRequestId = 0;
     };
 
 private:

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -128,17 +128,21 @@ public:
         virtual void HandleNotifyDelete(const TString& secretName) = 0;
         virtual ~ISecretUpdateListener() = default;
     };
+    // For tests only
     void SetSecretUpdateListener(ISecretUpdateListener* secretUpdateListener) {
         SecretUpdateListener = secretUpdateListener;
     }
 
-    class ISchemeCacheResponseModifier : public TThrRefBase {
+    // For tests only
+    class ISchemeCacheStatusGetter : public TThrRefBase {
     public:
-        virtual void Modify(NSchemeCache::TSchemeCacheNavigate& result) = 0;
-        virtual ~ISchemeCacheResponseModifier() = default;
+        virtual NSchemeCache::TSchemeCacheNavigate::EStatus GetStatus(
+            NSchemeCache::TSchemeCacheNavigate::TEntry& entry) const = 0;
+        virtual ~ISchemeCacheStatusGetter() = default;
     };
-    void SetSchemeCacheResponseModifier(ISchemeCacheResponseModifier* modifier) {
-        SchemeCacheResponseModifier = modifier;
+    // For tests only
+    void SetSchemeCacheStatusGetter(ISchemeCacheStatusGetter* schemeCacheStatusGetter) {
+        SchemeCacheStatusGetter = schemeCacheStatusGetter;
     }
 
 private:
@@ -147,8 +151,8 @@ private:
     THashMap<ui64, TResponseContext> ResolveInFlight;
     THashMap<TString, TVersionedSecret> VersionedSecrets;
     THashMap<TString, TActorId> SchemeBoardSubscribers;
-    ISecretUpdateListener* SecretUpdateListener;
-    ISchemeCacheResponseModifier* SchemeCacheResponseModifier;
+    ISecretUpdateListener* SecretUpdateListener = nullptr;
+    ISchemeCacheStatusGetter* SchemeCacheStatusGetter = nullptr;
 };
 
 void RegisterDescribeSecretsActor(

--- a/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_actors.h
@@ -133,7 +133,7 @@ public:
     }
 
 private:
-    ui64 LastCookie = 0;
+    ui64 LastRequestId = 0;
     THashMap<ui64, TRequestContext> RequestsInFlight;
     THashMap<ui64, TResponseContext> ResolveInFlight;
     THashMap<TString, TVersionedSecret> VersionedSecrets;

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.cpp
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.cpp
@@ -76,25 +76,25 @@ namespace NKikimr::NKqp {
         return service;
     }
 
-    TTestSchemeCacheStatusGetter::TTestSchemeCacheStatusGetter(EFailProbablity failProbability)
-        : FailProbabitity(failProbability)
+    TTestSchemeCacheStatusGetter::TTestSchemeCacheStatusGetter(EFailProbability failProbability)
+        : FailProbability(failProbability)
     {
     }
 
    NSchemeCache::TSchemeCacheNavigate::EStatus TTestSchemeCacheStatusGetter::GetStatus(
         NSchemeCache::TSchemeCacheNavigate::TEntry& entry) const
     {
-        switch (FailProbabitity) {
-            case EFailProbablity::None:
+        switch (FailProbability) {
+            case EFailProbability::None:
                 return entry.Status;
-            case EFailProbablity::OneTenth: {
+            case EFailProbability::OneTenth: {
                 static const int MOD = 10;
-                if ((std::uniform_int_distribution<int>(0, MOD - 1))(RandomGen) % MOD == 0) {
+                if ((std::uniform_int_distribution<int>(0, MOD - 1))(RandomGen) == 0) {
                     return NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError;
                 }
                 return entry.Status;
             }
-            case EFailProbablity::Always:
+            case EFailProbability::Always:
                 return NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError;
             default:
                 Y_ENSURE(false, "Unexpected value");
@@ -104,8 +104,8 @@ namespace NKikimr::NKqp {
         return entry.Status;
     }
 
-    void TTestSchemeCacheStatusGetter::SetFailProbability(EFailProbablity failProbabitity) {
-        FailProbabitity = failProbabitity;
+    void TTestSchemeCacheStatusGetter::SetFailProbability(EFailProbability failProbability) {
+        FailProbability = failProbability;
     }
 
 } // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.cpp
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.cpp
@@ -83,7 +83,7 @@ namespace NKikimr::NKqp {
     {
     }
 
-   NSchemeCache::TSchemeCacheNavigate::EStatus TTestSchemeCacheStatusGetter::GetStatus(
+    NSchemeCache::TSchemeCacheNavigate::EStatus TTestSchemeCacheStatusGetter::GetStatus(
         NSchemeCache::TSchemeCacheNavigate::TEntry& entry) const
     {
         switch (FailProbability) {

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.cpp
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.cpp
@@ -88,7 +88,8 @@ namespace NKikimr::NKqp {
             case EFailProbablity::None:
                 return entry.Status;
             case EFailProbablity::OneTenth: {
-                if (rand() % 10 == 1) {
+                static const int MOD = 10;
+                if ((std::uniform_int_distribution<int>(0, MOD - 1))(RandomGen) % MOD == 0) {
                     return NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError;
                 }
                 return entry.Status;

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.cpp
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.cpp
@@ -76,25 +76,25 @@ namespace NKikimr::NKqp {
         return service;
     }
 
-    TTestSchemeCacheStatusGetter::TTestSchemeCacheStatusGetter(EFailProbablity failProbablitity)
-        : FailProbablitity(failProbablitity)
+    TTestSchemeCacheStatusGetter::TTestSchemeCacheStatusGetter(EFailProbablity failProbability)
+        : FailProbabitity(failProbability)
     {
     }
 
    NSchemeCache::TSchemeCacheNavigate::EStatus TTestSchemeCacheStatusGetter::GetStatus(
-            NSchemeCache::TSchemeCacheNavigate::TEntry& entry) const {
-        switch (FailProbablitity) {
+        NSchemeCache::TSchemeCacheNavigate::TEntry& entry) const
+    {
+        switch (FailProbabitity) {
             case EFailProbablity::None:
                 return entry.Status;
             case EFailProbablity::OneTenth: {
-                if (rand() % 10 == 0) {
-                    entry.Status = NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError;
+                if (rand() % 10 == 1) {
+                    return NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError;
                 }
-                break;
+                return entry.Status;
             }
             case EFailProbablity::Always:
-                entry.Status = NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError;
-                break;
+                return NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError;
             default:
                 Y_ENSURE(false, "Unexpected value");
         }
@@ -103,8 +103,8 @@ namespace NKikimr::NKqp {
         return entry.Status;
     }
 
-    void TTestSchemeCacheStatusGetter::SetFailProbablitity(EFailProbablity failProbablitity) {
-        FailProbablitity = failProbablitity;    
+    void TTestSchemeCacheStatusGetter::SetFailProbability(EFailProbablity failProbabitity) {
+        FailProbabitity = failProbabitity;
     }
 
 } // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.h
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/kqp/federated_query/kqp_federated_query_actors.h>
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+
+#include <util/generic/vector.h>
+#include <util/generic/string.h>
+#include <util/generic/ptr.h>
+
+namespace NKikimr::NKqp {
+    using TDescriptionPromise = NThreading::TPromise<TEvDescribeSecretsResponse::TDescription>;
+
+    void CreateSchemaSecret(const TString& secretName, const TString& secretValue, NYdb::NTable::TSession& session);
+    void AlterSchemaSecret(const TString& secretName, const TString& secretValue, NYdb::NTable::TSession& session);
+    void DropSchemaSecret(const TString& secretName, NYdb::NTable::TSession& session);
+
+    TDescriptionPromise
+    ResolveSecrets(const TVector<TString>& secretNames, TKikimrRunner& kikimr, const TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr);
+    TDescriptionPromise
+    ResolveSecret(const TString& secretName, TKikimrRunner& kikimr, const TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr);
+
+    void AssertBadRequest(TDescriptionPromise promise, const TString& err, Ydb::StatusIds::StatusCode status = Ydb::StatusIds::BAD_REQUEST);
+
+    TIntrusiveConstPtr<NACLib::TUserToken> GetUserToken(const TString& userSid = "", const TVector<TString>& groupSids = {});
+
+    void AssertSecretValues(const TVector<TString>& secretValues, TDescriptionPromise promise);
+    void AssertSecretValue(const TString& secretValue, TDescriptionPromise promise);
+
+    class TTestDescribeSchemaSecretsServiceFactory : public IDescribeSchemaSecretsServiceFactory {
+    public:
+        TTestDescribeSchemaSecretsServiceFactory(
+            TDescribeSchemaSecretsService::ISecretUpdateListener* secretUpdateListener,
+            TDescribeSchemaSecretsService::ISchemeCacheResponseModifier* schemeCacheResponseModifier
+        );
+
+        NActors::IActor* CreateService() override;
+
+    private:
+        TDescribeSchemaSecretsService::ISecretUpdateListener* SecretUpdateListener;
+        TDescribeSchemaSecretsService::ISchemeCacheResponseModifier* SchemeCacheResponseModifier;
+    };
+
+    class TTestSchemeCacheResponseModifier : public TDescribeSchemaSecretsService::ISchemeCacheResponseModifier {
+    public:
+        enum class EFailProbablity {
+            FailProbabilityNever = 0,
+            FailProbabilityQuoter = 1,
+            FailProbabilityHalf = 2,
+            FailProbabilityAlways = 3,
+        };
+
+        TTestSchemeCacheResponseModifier(EFailProbablity failProbablitity);
+
+        void Modify(NSchemeCache::TSchemeCacheNavigate& result) override;
+
+        void SetFailProbablitity(EFailProbablity failProbablitity);
+
+    private:
+        EFailProbablity FailProbablitity;
+    };
+
+} // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.h
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.h
@@ -33,28 +33,28 @@ namespace NKikimr::NKqp {
     public:
         TTestDescribeSchemaSecretsServiceFactory(
             TDescribeSchemaSecretsService::ISecretUpdateListener* secretUpdateListener,
-            TDescribeSchemaSecretsService::ISchemeCacheResponseModifier* schemeCacheResponseModifier
+            TDescribeSchemaSecretsService::ISchemeCacheStatusGetter* schemeCacheStatusGetter
         );
 
         NActors::IActor* CreateService() override;
 
     private:
         TDescribeSchemaSecretsService::ISecretUpdateListener* SecretUpdateListener;
-        TDescribeSchemaSecretsService::ISchemeCacheResponseModifier* SchemeCacheResponseModifier;
+        TDescribeSchemaSecretsService::ISchemeCacheStatusGetter* SchemeCacheStatusGetter;
     };
 
-    class TTestSchemeCacheResponseModifier : public TDescribeSchemaSecretsService::ISchemeCacheResponseModifier {
+    class TTestSchemeCacheStatusGetter : public TDescribeSchemaSecretsService::ISchemeCacheStatusGetter {
     public:
         enum class EFailProbablity {
-            FailProbabilityNever = 0,
-            FailProbabilityQuoter = 1,
-            FailProbabilityHalf = 2,
-            FailProbabilityAlways = 3,
+            None = 0,
+            OneTenth = 1,
+            Always = 2,
         };
 
-        TTestSchemeCacheResponseModifier(EFailProbablity failProbablitity);
+        TTestSchemeCacheStatusGetter(EFailProbablity failProbablitity);
 
-        void Modify(NSchemeCache::TSchemeCacheNavigate& result) override;
+        NSchemeCache::TSchemeCacheNavigate::EStatus GetStatus(
+            NSchemeCache::TSchemeCacheNavigate::TEntry& entry) const override;
 
         void SetFailProbablitity(EFailProbablity failProbablitity);
 

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.h
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.h
@@ -45,21 +45,21 @@ namespace NKikimr::NKqp {
 
     class TTestSchemeCacheStatusGetter : public TDescribeSchemaSecretsService::ISchemeCacheStatusGetter {
     public:
-        enum class EFailProbablity {
+        enum class EFailProbability {
             None = 0,
             OneTenth = 1,
             Always = 2,
         };
 
-        TTestSchemeCacheStatusGetter(EFailProbablity failProbabitity);
+        TTestSchemeCacheStatusGetter(EFailProbability failProbability);
 
         NSchemeCache::TSchemeCacheNavigate::EStatus GetStatus(
             NSchemeCache::TSchemeCacheNavigate::TEntry& entry) const override;
 
-        void SetFailProbability(EFailProbablity failProbabitity);
+        void SetFailProbability(EFailProbability failProbability);
 
     private:
-        EFailProbablity FailProbabitity;
+        EFailProbability FailProbability;
         mutable std::mt19937 RandomGen;
     };
 

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.h
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.h
@@ -51,15 +51,15 @@ namespace NKikimr::NKqp {
             Always = 2,
         };
 
-        TTestSchemeCacheStatusGetter(EFailProbablity failProbablitity);
+        TTestSchemeCacheStatusGetter(EFailProbablity failProbabitity);
 
         NSchemeCache::TSchemeCacheNavigate::EStatus GetStatus(
             NSchemeCache::TSchemeCacheNavigate::TEntry& entry) const override;
 
-        void SetFailProbablitity(EFailProbablity failProbablitity);
+        void SetFailProbability(EFailProbablity failProbabitity);
 
     private:
-        EFailProbablity FailProbablitity;
+        EFailProbablity FailProbabitity;
     };
 
 } // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/ut_service/common/helpers.h
+++ b/ydb/core/kqp/federated_query/ut_service/common/helpers.h
@@ -60,6 +60,7 @@ namespace NKikimr::NKqp {
 
     private:
         EFailProbablity FailProbabitity;
+        mutable std::mt19937 RandomGen;
     };
 
 } // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/ut_service/common/ya.make
+++ b/ydb/core/kqp/federated_query/ut_service/common/ya.make
@@ -1,0 +1,17 @@
+LIBRARY()
+
+SRCS(
+    helpers.cpp
+)
+
+PEERDIR(
+    ydb/public/sdk/cpp/src/client/table
+    ydb/library/aclib
+    ydb/core/kqp/common/events
+    ydb/core/kqp/federated_query
+    ydb/core/kqp/ut/common
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/federated_query/ut_service/fast/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/ut_service/fast/kqp_federated_query_actors_ut.cpp
@@ -355,7 +355,7 @@ Y_UNIT_TEST_SUITE(DescribeSchemaSecretsService) {
     Y_UNIT_TEST(SchemeCacheRetryErrors) {
         TKikimrSettings settings;
         auto schemeCacheStatusGetter = MakeHolder<TTestSchemeCacheStatusGetter>(
-            TTestSchemeCacheStatusGetter::EFailProbablity::OneTenth);
+            TTestSchemeCacheStatusGetter::EFailProbability::OneTenth);
         auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
             /* secretUpdateListener */ nullptr,
             schemeCacheStatusGetter.Get());

--- a/ydb/core/kqp/federated_query/ut_service/fast/ya.make
+++ b/ydb/core/kqp/federated_query/ut_service/fast/ya.make
@@ -1,0 +1,18 @@
+UNITTEST_FOR(ydb/core/kqp/federated_query)
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    ydb/core/kqp/federated_query
+    ydb/core/kqp/federated_query/ut_service/common
+    ydb/core/kqp/ut/common
+    yql/essentials/sql/pg_dummy
+)
+
+SRCS(
+    kqp_federated_query_actors_ut.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/federated_query/ut_service/slow/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/ut_service/slow/kqp_federated_query_actors_ut.cpp
@@ -16,7 +16,7 @@ Y_UNIT_TEST_SUITE(DescribeSchemaSecretsServiceSlow) {
         TKikimrSettings settings;
         // SchemeCache will return only retry errors, so secrets retrieval will be slow due to retries and never succeed
         auto schemeCacheStatusGetter = MakeHolder<TTestSchemeCacheStatusGetter>(
-            TTestSchemeCacheStatusGetter::EFailProbablity::Always);
+            TTestSchemeCacheStatusGetter::EFailProbability::Always);
         auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
             /* secretUpdateListener */ nullptr,
             schemeCacheStatusGetter.Get());
@@ -47,7 +47,7 @@ Y_UNIT_TEST_SUITE(DescribeSchemaSecretsServiceSlow) {
         }
 
         // SchemeCache will return OK responses, so secrets retrieval should be fast and succeeded
-        schemeCacheStatusGetter->SetFailProbability(TTestSchemeCacheStatusGetter::EFailProbablity::None);
+        schemeCacheStatusGetter->SetFailProbability(TTestSchemeCacheStatusGetter::EFailProbability::None);
         promises.clear();
         for (const auto& [secretName, secretValue] : secrets) {
             promises.push_back(ResolveSecret(secretName, kikimr));

--- a/ydb/core/kqp/federated_query/ut_service/slow/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/ut_service/slow/kqp_federated_query_actors_ut.cpp
@@ -47,7 +47,7 @@ Y_UNIT_TEST_SUITE(DescribeSchemaSecretsServiceSlow) {
         }
 
         // SchemeCache will return OK responses, so secrets retrieval should be fast and succeeded
-        schemeCacheStatusGetter->SetFailProbablitity(TTestSchemeCacheStatusGetter::EFailProbablity::None);
+        schemeCacheStatusGetter->SetFailProbability(TTestSchemeCacheStatusGetter::EFailProbablity::None);
         promises.clear();
         for (const auto& [secretName, secretValue] : secrets) {
             promises.push_back(ResolveSecret(secretName, kikimr));

--- a/ydb/core/kqp/federated_query/ut_service/slow/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/ut_service/slow/kqp_federated_query_actors_ut.cpp
@@ -1,0 +1,62 @@
+#include "kqp_federated_query_actors.h"
+
+#include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/kqp/federated_query/ut_service/common/helpers.h>
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NKqp {
+
+using TDescriptionPromise = NThreading::TPromise<TEvDescribeSecretsResponse::TDescription>;
+
+Y_UNIT_TEST_SUITE(DescribeSchemaSecretsServiceSlow) {
+    Y_UNIT_TEST(SchemeCacheRecoverAfterLookupErrorFails) {
+        TKikimrSettings settings;
+        // SchemeCache will return only retry errors, so secrets retrieval will be slow due to retries and never succeed
+        auto modifier = MakeHolder<TTestSchemeCacheResponseModifier>(
+            TTestSchemeCacheResponseModifier::EFailProbablity::FailProbabilityAlways);
+        auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
+            /* secretUpdateListener */ nullptr,
+            modifier.Get());
+        settings.SetDescribeSchemaSecretsServiceFactory(factory);
+        TKikimrRunner kikimr(settings);
+        kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.SetEnableSchemaSecrets(true);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        static const auto SECRETS_CNT = 10;
+        std::vector<std::pair<TString, TString>> secrets;
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            secrets.push_back({"/Root/secret-name-" + ToString(i), "secret-value-" + ToString(i)});
+            CreateSchemaSecret(secrets.back().first, secrets.back().second, session);
+        }
+        std::vector<TDescriptionPromise> promises;
+        for (const auto& [secretName, secretValue] : secrets) {
+            promises.push_back(ResolveSecret(secretName, kikimr));
+        }
+
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            AssertBadRequest(
+                promises[i],
+                Sprintf(
+                    "<main>: Error: Retry limit exceeded for secret `%s`\n",
+                    secrets[i].first.c_str()),
+                Ydb::StatusIds::UNAVAILABLE);
+        }
+
+        // SchemeCache will return OK responses, so secrets retrieval should be fast and succeeded
+        modifier->SetFailProbablitity(TTestSchemeCacheResponseModifier::EFailProbablity::FailProbabilityNever);
+        promises.clear();
+        for (const auto& [secretName, secretValue] : secrets) {
+            promises.push_back(ResolveSecret(secretName, kikimr));
+        }
+
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            AssertSecretValue(secrets[i].second, promises[i]);
+        }
+    }
+}
+
+} // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/ut_service/slow/ya.make
+++ b/ydb/core/kqp/federated_query/ut_service/slow/ya.make
@@ -1,0 +1,22 @@
+UNITTEST_FOR(ydb/core/kqp/federated_query)
+
+SIZE(LARGE)
+
+TAG(
+    ya:fat
+)
+
+PEERDIR(
+    ydb/core/kqp/federated_query
+    ydb/core/kqp/federated_query/ut_service/common
+    ydb/core/kqp/ut/common
+    yql/essentials/sql/pg_dummy
+)
+
+SRCS(
+    kqp_federated_query_actors_ut.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/federated_query/ut_service/ya.make
+++ b/ydb/core/kqp/federated_query/ut_service/ya.make
@@ -1,5 +1,5 @@
 RECURSE_FOR_TESTS(
-    common    
+    common
     fast
     slow
 )

--- a/ydb/core/kqp/federated_query/ut_service/ya.make
+++ b/ydb/core/kqp/federated_query/ut_service/ya.make
@@ -1,17 +1,5 @@
-UNITTEST_FOR(ydb/core/kqp/federated_query)
-
-SIZE(MEDIUM)
-
-PEERDIR(
-    ydb/core/kqp/federated_query
-    ydb/core/kqp/ut/common
-    yql/essentials/sql/pg_dummy
+RECURSE_FOR_TESTS(
+    common    
+    fast
+    slow
 )
-
-SRCS(
-    kqp_federated_query_actors_ut.cpp
-)
-
-YQL_LAST_ABI_VERSION()
-
-END()


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
- Сделан экспоненциальный бекап ошибок типа `LookupError` от SchemeCache, который должен помочь при его временной недоступности на старте, чтобы все клиенты не ретраили сами. При неуспехе ретраев возвращается код `Ydb::StatusIds::UNAVAILABLE`, чтобы клиенты могли сделать перезапросы при необходимости на своей стороне.
- Более единообразные логи сервиса `TDescribeSecretsActor`.