### PR TITLE
Support DistinctColumns pushdown at the datashard side (required for #24390)

### DIFF
--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -877,6 +877,7 @@ message TReadVectorTopK {
     optional Ydb.Table.VectorIndexSettings Settings = 2;
     optional string TargetVector = 3;
     optional uint32 Limit = 4;
+    repeated uint32 DistinctColumns = 5;
 }
 
 message TKqpStreamLookupSettings {

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -26,10 +26,12 @@ using namespace NTabletFlatExecutor;
 struct TReadIteratorVectorTopItem {
     TOwnedCellVec Row;
     double Distance = 0;
+    TString UniqueKey;
 
-    TReadIteratorVectorTopItem(TArrayRef<const TCell> cells, double distance):
+    TReadIteratorVectorTopItem(TArrayRef<const TCell> cells, double distance, TString&& uniqueKey):
         Row(TOwnedCellVec(cells)),
-        Distance(distance) {
+        Distance(distance),
+        UniqueKey(std::move(uniqueKey)) {
     }
 
     bool operator<(const TReadIteratorVectorTopItem& rhs) const {
@@ -42,25 +44,48 @@ struct TReadIteratorVectorTop {
     ui32 Limit = 0;
     TString Target;
     std::unique_ptr<NKMeans::IClusters> KMeans;
+    std::vector<ui32> DistinctColumns;
+
+    std::unordered_set<TString> UniqueKeys;
     std::vector<TReadIteratorVectorTopItem> Rows;
     ui64 TotalReadRows = 0;
     ui64 TotalReadBytes = 0;
 
     void AddRow(TConstArrayRef<TCell> cells) {
+        TotalReadRows++;
+        TotalReadBytes += EstimateSize(cells);
+        TString serializedKey;
+        if (DistinctColumns.size()) {
+            TVector<TCell> key;
+            for (auto colIdx: DistinctColumns) {
+                key.push_back(cells.at(colIdx));
+            }
+            serializedKey = TSerializedCellVec::Serialize(key);
+            if (UniqueKeys.contains(serializedKey)) {
+                return;
+            }
+        }
         const auto embedding = cells.at(Column).AsBuf();
         if (!KMeans->IsExpectedFormat(embedding)) {
             return;
         }
-        TotalReadRows++;
-        TotalReadBytes += EstimateSize(cells);
         double distance = KMeans->CalcDistance(embedding, Target);
         if (Rows.size() < Limit) {
-            Rows.emplace_back(cells, distance);
+            if (DistinctColumns.size()) {
+                UniqueKeys.insert(serializedKey);
+            }
+            Rows.emplace_back(cells, distance, std::move(serializedKey));
             std::push_heap(Rows.begin(), Rows.end());
         } else if (distance < Rows.front().Distance) {
-            Rows.emplace_back(cells, distance);
+            if (DistinctColumns.size()) {
+                UniqueKeys.insert(serializedKey);
+            }
+            Rows.emplace_back(cells, distance, std::move(serializedKey));
             std::push_heap(Rows.begin(), Rows.end());
             std::pop_heap(Rows.begin(), Rows.end());
+            if (DistinctColumns.size()) {
+                UniqueKeys.erase(Rows.back().UniqueKey);
+            }
             Rows.pop_back();
         }
     }
@@ -2220,6 +2245,12 @@ public:
                 if (topState->KMeans && !topState->KMeans->IsExpectedFormat(topK.GetTargetVector())) {
                     error = "Target vector has invalid format";
                 }
+            }
+            for (auto& colIdx: topK.GetDistinctColumns()) {
+                if (colIdx >= record.ColumnsSize()) {
+                    error = TStringBuilder() << "Too large unique column index: " << colIdx;
+                }
+                topState->DistinctColumns.push_back(colIdx);
             }
             if (error != "") {
                 SetStatusError(Result->Record, Ydb::StatusIds::BAD_REQUEST, TStringBuilder()


### PR DESCRIPTION
### Changelog category

* Not for changelog

### Description for reviewers

Так как уже включён обычный pushdown, то если вектора находятся в нескольких кластерах (#24390), приходится ещё pushdown-ить и уникальность строк, иначе получается, что даташарды возвращают меньше строк, чем мы попросили в лимите. То есть, условно, мы просим 3 строки, а нам возвращают 3, из которых 2 - одинаковые, но с разным ID кластера.

Вынес в отдельный ПР, возможно так будет легче мержить. Ну или смержим общим скопом в #30180