### PR TITLE
Make new snapshot based on changelog size in system tablet backup

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2852,6 +2852,7 @@ message TSystemTabletBackupConfig {
         TFilesystemBackend Filesystem = 1;
     }
     repeated fixed64 ExcludeTabletIds = 2;
+    optional uint64 NewBackupChangelogMinBytes = 3 [default = 524288000]; // 500 MB
 }
 
 message TAppConfig {

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -97,7 +97,17 @@ namespace NTabletFlatExecutor {
 
         void SetTactic(ETactic tactic) noexcept { Tactic = tactic; }
 
-        void SetBackupWriter(TActorId backupWriter) noexcept { BackupWriter = backupWriter; }
+        void SetBackupWriter(TActorId backupWriter) {
+            if (BackupWriter) {
+                Y_ENSURE(Ops, "Commit manager is not started");
+                Ops->Send(BackupWriter, new TEvents::TEvPoisonPill());
+            }
+            BackupWriter = backupWriter;
+        }
+
+        TActorId GetBackupWriter() const noexcept {
+            return BackupWriter;
+        }
 
         ui64 Stamp() const noexcept
         {

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5140,8 +5140,7 @@ void TExecutor::StartNewBackup() {
         return;
     }
 
-    // Ensure that pending commits are flushed to the old backup changelog,
-    // and the step is incremented before starting a new backup
+    // Ensure that pending commits are flushed to the old backup changelog
     LogicRedo->FlushBatchedLog();
 
     TTabletTypes::EType tabletType = Owner->TabletType();

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5151,8 +5151,6 @@ void TExecutor::StartNewBackup() {
         tabletId, Generation0, scheme, exclusion);
 
     if (snapshotWriter && changelogWriter) {
-        CommitManager->SetBackupWriter(Register(changelogWriter, TMailboxType::HTSwap, AppData()->IOPoolId));
-
         auto snapshotWriterActor = Register(snapshotWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
         for (const auto& [tableId, table] : tables) {
             if (exclusion && exclusion->HasTable(tableId)) {
@@ -5162,6 +5160,7 @@ void TExecutor::StartNewBackup() {
             auto opts = TScanOptions().SetResourceBroker("system_tablet_backup", 10);
             QueueScan(tableId, NBackup::CreateSnapshotScan(snapshotWriterActor, tableId, table.Columns, exclusion), 0, opts);
         }
+        CommitManager->SetBackupWriter(Register(changelogWriter, TMailboxType::HTSwap, AppData()->IOPoolId));
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -548,7 +548,7 @@ class TExecutor
     void AddPageCollection(const TIntrusivePtr<TPrivatePageCache::TPageCollection> &pageCollection);
     void DropPartStorePageCollections(const NTable::TPart &part);
     void DropPageCollection(const TLogoBlobID& pageCollectionId);
-    void StartBackup();
+    void StartNewBackup();
 
     void UpdateCacheModesForPartStore(NTable::TPartView& partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);
     void UpdateCachePagesForDatabase(bool pendingOnly = false);

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -145,7 +145,7 @@ TFsPath CreateBackupPath(TTabletTypes::EType tabletType, ui64 tabletId, ui32 gen
 
     auto path = TFsPath(tabletTypeName)
         .Child(ToString(tabletId))
-        .Child("backup_" + timestamp + "_g" + ToString(generation) + "_s" + ToString(step));
+        .Child(TStringBuilder() << "backup_" << timestamp << "_g" << generation << "_s" << step);
 
     return path;
 }

--- a/ydb/core/tablet_flat/flat_executor_backup.h
+++ b/ydb/core/tablet_flat/flat_executor_backup.h
@@ -93,14 +93,14 @@ struct TEvStartNewBackup : public TEventLocal<TEvStartNewBackup, EvStartNewBacku
 
 IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                              const THashMap<ui32, NTable::TScheme::TTableInfo>& tables,
-                             TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation,
+                             TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation, ui32 step,
                              TAutoPtr<NTable::TSchemeChanges> schema, TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
 
 NTable::IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<ui32, NTable::TColumn>& columns,
                                   TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
 
 IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
-                              TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation,
+                              TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation, ui32 step,
                               const NTable::TScheme& schema, TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
 
 } // NKikimr::NTabletFlatExecutor::NBackup

--- a/ydb/core/tablet_flat/flat_executor_backup.h
+++ b/ydb/core/tablet_flat/flat_executor_backup.h
@@ -24,19 +24,26 @@ enum EEv {
     EvWriteChangelog,
     EvChangelogFailed,
 
+    EvStartNewBackup,
+
     EvEnd
 };
 
 static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_FLAT_EXECUTOR));
 
 struct TEvSnapshotCompleted : public TEventLocal<TEvSnapshotCompleted, EvSnapshotCompleted> {
-    TEvSnapshotCompleted(bool success, const TString& error = "")
-        : Success(success)
-        , Error(error)
+    TEvSnapshotCompleted(const TString& error)
+        : Error(error)
     {}
 
-    bool Success;
+    TEvSnapshotCompleted(ui64 writtenBytes)
+        : Success(true)
+        , WrittenBytes(writtenBytes)
+    {}
+
+    bool Success = false;
     TString Error;
+    ui64 WrittenBytes = 0;
 };
 
 enum class EScanStatus {
@@ -81,6 +88,8 @@ struct TEvChangelogFailed : public TEventLocal<TEvChangelogFailed, EvChangelogFa
 
     TString Error;
 };
+
+struct TEvStartNewBackup : public TEventLocal<TEvStartNewBackup, EvStartNewBackup> {};
 
 IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                              const THashMap<ui32, NTable::TScheme::TTableInfo>& tables,

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -1406,8 +1406,6 @@ Y_UNIT_TEST_SUITE(Backup) {
 
         Cerr << "...writing little bit more data to changelog" << Endl;
         env.WriteValue(1000, 10);
-
-        env.WaitChangelogFlush();
     }
 }
 

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -1406,6 +1406,17 @@ Y_UNIT_TEST_SUITE(Backup) {
 
         Cerr << "...writing little bit more data to changelog" << Endl;
         env.WriteValue(1000, 10);
+
+        env.WaitChangelogFlush();
+
+        // Check state before and after restore
+        auto assertState = [&env]() {
+            UNIT_ASSERT_VALUES_EQUAL(env.CountRows<TSchema::Data>(), 1001);
+        };
+
+        assertState();
+        env.RestoreLastBackup(TestTabletFlags);
+        assertState();
     }
 }
 

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -1409,6 +1409,15 @@ Y_UNIT_TEST_SUITE(Backup) {
 
         env.WaitChangelogFlush();
 
+        auto tabletIdDir = TFsPath(env->GetTempDir())
+            .Child("dummy")
+            .Child(ToString(env.Tablet));
+
+        TVector<TFsPath> backupDirs;
+        tabletIdDir.List(backupDirs);
+
+        UNIT_ASSERT_VALUES_EQUAL(backupDirs.size(), 2);
+
         // Check state before and after restore
         auto assertState = [&env]() {
             UNIT_ASSERT_VALUES_EQUAL(env.CountRows<TSchema::Data>(), 1001);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds functionality to automatically create new backup snapshots based on the size of the changelog in system tablet backups. The main change is tracking the amount of data written to both snapshots and changelogs, and triggering a new backup when the changelog size exceeds the snapshot size and a configurable minimum threshold.

Key changes:
- Tracks bytes written in both snapshot and changelog writers
- Adds a new event `TEvStartNewBackup` to trigger backup creation based on changelog size
- Introduces a configurable threshold `NewBackupChangelogMinBytes` (default 500 MB) for triggering new backups
- Updates backup directory naming from `gen_X` to `backup_TIMESTAMP_gGEN_sSTEP` to prevent collisions when one generation makes several snapshots
