### PR TITLE
Fix WriteKeepFlags for Storage LoadActor

### DIFF
--- a/ydb/core/load_test/group_write.cpp
+++ b/ydb/core/load_test/group_write.cpp
@@ -1020,7 +1020,7 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
                         };
 
                         auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, Generation,
-                                GarbageCollectStep, Channel, true, Generation, GarbageCollectStep,
+                                GarbageCollectStep, Channel, false, Generation, GarbageCollectStep,
                                 new TVector<TLogoBlobID>({id}), nullptr, TInstant::Max(), false);
                         SendToBSProxy(ctx, GroupId, ev.release(), Self.QueryDispatcher.ObtainCookie(std::move(gcCallback)));
                     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improve garbage collection logic for Storage LoadActor with WriteKeepFlags mode.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
