### PR TITLE
Two-stage ANALYZE with adaptive count-min sketch params

### DIFF
--- a/ydb/core/protos/statistics.proto
+++ b/ydb/core/protos/statistics.proto
@@ -198,3 +198,9 @@ message TEvAggregateStatisticsResponse {
     }
     repeated TFailedTablet FailedTablets = 3;
 }
+
+message TSimpleColumnStatistics {
+    optional uint64 Count = 1;
+    optional uint64 CountNonNull = 2;
+    optional uint64 CountDistinct = 3;
+};

--- a/ydb/core/protos/statistics.proto
+++ b/ydb/core/protos/statistics.proto
@@ -201,6 +201,5 @@ message TEvAggregateStatisticsResponse {
 
 message TSimpleColumnStatistics {
     optional uint64 Count = 1;
-    optional uint64 CountNonNull = 2;
-    optional uint64 CountDistinct = 3;
+    optional uint64 CountDistinct = 2;
 };

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -675,6 +675,8 @@ void TStatisticsAggregator::ScheduleNextAnalyze(NIceDb::TNiceDb& db, const TActo
                 UpdateForceTraversalTableStatus(
                     TForceTraversalTable::EStatus::AnalyzeStarted, operation.OperationId, operationTable, db);
 
+                // operation.Types field is not used, TAnalyzeActor will determine suitable
+                // statistic types itself.
                 ctx.RegisterWithSameMailbox(new TAnalyzeActor(
                     SelfId(), operation.OperationId, operation.DatabaseName, operationTable.PathId,
                     operationTable.ColumnTags));

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -284,6 +284,7 @@ private:
 
     bool IsStatisticsTableCreated = false;
     bool PendingSaveStatistics = false;
+    std::vector<TStatisticsItem> StatisticsToSave;
     bool PendingDeleteStatistics = false;
 
     std::vector<NScheme::TTypeInfo> KeyColumnTypes;

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -23,13 +23,20 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     // StateQuery
 
     struct TColumnDesc {
-        explicit TColumnDesc(ui32 tag, ui32 seq)
-        : Tag(tag), Seq(seq)
+        ui32 Tag;
+        std::optional<ui32> CountDistinctSeq;
+        std::optional<ui32> CmsSeq;
+
+        explicit TColumnDesc(ui32 tag)
+            : Tag(tag)
         {}
 
-        ui32 Tag;
-        ui32 Seq;
+        TString ExtractSimpleStats(ui64 count, const TVector<NYdb::TValue>& aggColumns) const;
+        // Precondition: CmsSeq is non-null.
+        TString ExtractCMS(const TVector<NYdb::TValue>& aggColumns) const;
     };
+
+    std::optional<ui32> CountSeq;
     TVector<TColumnDesc> Columns;
 
     struct TEvPrivate {

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -7,12 +7,31 @@
 
 namespace NKikimr::NStat {
 
+class TSelectBuilder;
+
+class IColumnStatisticEval {
+public:
+    using TPtr = std::unique_ptr<IColumnStatisticEval>;
+
+    static TVector<EStatType> SupportedTypes();
+    static TPtr MaybeCreate(
+        EStatType,
+        const NKikimrStat::TSimpleColumnStatistics&,
+        const NScheme::TTypeInfo&);
+
+    virtual EStatType GetType() const = 0;
+    virtual size_t EstimateSize() const = 0;
+    virtual void AddAggregations(const TString& columnName, TSelectBuilder&) = 0;
+    virtual TString ExtractData(const TVector<NYdb::TValue>& aggColumns) const = 0;
+    virtual ~IColumnStatisticEval() = default;
+};
+
 class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     TActorId Parent;
     TString OperationId;
     TString DatabaseName;
     TPathId PathId;
-    TVector<ui32> ColumnTags;
+    TVector<ui32> RequestedColumnTags;
 
     void FinishWithFailure(TEvStatistics::TEvFinishTraversal::EStatus);
 
@@ -25,21 +44,27 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     struct TColumnDesc {
         ui32 Tag;
         NScheme::TTypeInfo Type;
-        std::optional<ui32> CountDistinctSeq;
-        std::optional<ui32> CmsSeq;
+        TString Name;
 
-        explicit TColumnDesc(ui32 tag, NScheme::TTypeInfo type)
+        std::optional<ui32> CountDistinctSeq;
+        TVector<IColumnStatisticEval::TPtr> Statistics;
+
+        explicit TColumnDesc(ui32 tag, NScheme::TTypeInfo type, TString name)
             : Tag(tag)
             , Type(type)
+            , Name(std::move(name))
         {}
+        TColumnDesc(TColumnDesc&&) noexcept = default;
+        TColumnDesc& operator=(TColumnDesc&) noexcept = default;
 
-        TString ExtractSimpleStats(ui64 count, const TVector<NYdb::TValue>& aggColumns) const;
-        // Precondition: CmsSeq is non-null.
-        TString ExtractCMS(const TVector<NYdb::TValue>& aggColumns) const;
+        NKikimrStat::TSimpleColumnStatistics ExtractSimpleStats(
+            ui64 count, const TVector<NYdb::TValue>& aggColumns) const;
     };
 
+    TString TableName;
     std::optional<ui32> CountSeq;
     TVector<TColumnDesc> Columns;
+    TVector<TStatisticsItem> Results;
 
     struct TEvPrivate {
         enum EEv {
@@ -74,7 +99,8 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 
     class TScanActor;
 
-    void Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
+    void HandleStage1(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
+    void HandleStage2(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
 
 public:
     TAnalyzeActor(
@@ -87,7 +113,7 @@ public:
     , OperationId(std::move(operationId))
     , DatabaseName(std::move(databaseName))
     , PathId(std::move(pathId))
-    , ColumnTags(std::move(columnTags))
+    , RequestedColumnTags(std::move(columnTags))
     {}
 
     void Bootstrap();
@@ -98,9 +124,18 @@ public:
         }
     }
 
-    STFUNC(StateQuery) {
+    // Calculate simple column statistics (count, count distinct) and
+    // determine the parameters for heavy statistics.
+    STFUNC(StateQueryStage1) {
         switch (ev->GetTypeRewrite()) {
-            hFunc(TEvPrivate::TEvAnalyzeScanResult, Handle);
+            hFunc(TEvPrivate::TEvAnalyzeScanResult, HandleStage1);
+        }
+    }
+
+    // Calculate "heavy" statistics requested from stage 1.
+    STFUNC(StateQueryStage2) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvPrivate::TEvAnalyzeScanResult, HandleStage2);
         }
     }
 };

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -24,11 +24,13 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 
     struct TColumnDesc {
         ui32 Tag;
+        NScheme::TTypeInfo Type;
         std::optional<ui32> CountDistinctSeq;
         std::optional<ui32> CmsSeq;
 
-        explicit TColumnDesc(ui32 tag)
+        explicit TColumnDesc(ui32 tag, NScheme::TTypeInfo type)
             : Tag(tag)
+            , Type(type)
         {}
 
         TString ExtractSimpleStats(ui64 count, const TVector<NYdb::TValue>& aggColumns) const;

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -55,7 +55,7 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
             , Name(std::move(name))
         {}
         TColumnDesc(TColumnDesc&&) noexcept = default;
-        TColumnDesc& operator=(TColumnDesc&) noexcept = default;
+        TColumnDesc& operator=(TColumnDesc&&) noexcept = default;
 
         NKikimrStat::TSimpleColumnStatistics ExtractSimpleStats(
             ui64 count, const TVector<NYdb::TValue>& aggColumns) const;

--- a/ydb/core/statistics/aggregator/select_builder.cpp
+++ b/ydb/core/statistics/aggregator/select_builder.cpp
@@ -1,0 +1,79 @@
+#include "select_builder.h"
+
+#include <util/string/builder.h>
+
+#include <format>
+
+namespace NKikimr::NStat {
+
+ui32 TSelectBuilder::AddBuiltinAggregation(std::optional<TString> columnName, TString aggName) {
+    auto column = TAggColumn{
+        .Seq = static_cast<ui32>(Columns.size()),
+        .ColumnName = std::move(columnName),
+        .AggName = std::move(aggName),
+    };
+    Columns.push_back(std::move(column));
+    return Columns.back().Seq;
+}
+
+ui32 TSelectBuilder::AddFactory(const TStringBuf& udafName) {
+    // TODO: check UDAF existence, determine paramcount
+    ui32 curId = Udaf2Factory.size();
+    size_t paramCount = 2;
+    auto [it, emplaced] = Udaf2Factory.try_emplace(udafName, curId, udafName, paramCount);
+    return it->second.Id;
+}
+
+TString TSelectBuilder::Build(const TStringBuf& table) const {
+    TStringBuilder res;
+    for (const auto& [udaf, factory] : Udaf2Factory) {
+        TStringBuilder paramsStr;
+        for (size_t i = 0; i < factory.ParamCount; ++i) {
+            if (i > 0) {
+                paramsStr << ",";
+            }
+            paramsStr << "$p" << i;
+        }
+
+        res << std::format(R"($f{0} = ({2}) -> {{ return AggregationFactory(
+    "UDAF",
+    ($item,$parent) -> {{ return Udf(StatisticsInternal::{1}Create, $parent as Depends)($item,{2}) }},
+    ($state,$item,$parent) -> {{ return Udf(StatisticsInternal::{1}AddValue, $parent as Depends)($state, $item) }},
+    StatisticsInternal::{1}Merge,
+    StatisticsInternal::{1}Finalize,
+    StatisticsInternal::{1}Serialize,
+    StatisticsInternal::{1}Deserialize,
+)
+}};
+)",
+            factory.Id, std::string_view(factory.Udaf), std::string_view(paramsStr));
+    }
+
+    res << "SELECT ";
+    bool first = true;
+    for (const auto& agg : Columns ) {
+        if (first) {
+            first = false;
+        } else {
+            res << ",";
+        }
+        if (agg.UdafFactory) {
+            Y_ABORT_UNLESS(agg.ColumnName);
+            res << "AGGREGATE_BY(" << agg.ColumnName
+                << "," << "$f" << *agg.UdafFactory << "(" << agg.Params << "))";
+        } else {
+            Y_ABORT_UNLESS(agg.AggName);
+            res << *agg.AggName;
+            if (agg.ColumnName) {
+                res << "(" << *agg.ColumnName << ")";
+            } else {
+                res << "(*)";
+            }
+        }
+    }
+
+    res << " FROM `" << table << "`";
+    return res;
+}
+
+} // NKikimr::NStat

--- a/ydb/core/statistics/aggregator/select_builder.cpp
+++ b/ydb/core/statistics/aggregator/select_builder.cpp
@@ -16,10 +16,9 @@ ui32 TSelectBuilder::AddBuiltinAggregation(std::optional<TString> columnName, TS
     return Columns.back().Seq;
 }
 
-ui32 TSelectBuilder::AddFactory(const TStringBuf& udafName) {
-    // TODO: check UDAF existence, determine paramcount
+ui32 TSelectBuilder::AddFactory(const TStringBuf& udafName, size_t paramCount) {
+    // TODO: check UDAF existence, validate paramcount
     ui32 curId = Udaf2Factory.size();
-    size_t paramCount = 2;
     auto [it, emplaced] = Udaf2Factory.try_emplace(udafName, curId, udafName, paramCount);
     return it->second.Id;
 }

--- a/ydb/core/statistics/aggregator/select_builder.h
+++ b/ydb/core/statistics/aggregator/select_builder.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <util/generic/hash.h>
+#include <util/generic/vector.h>
+
+namespace NKikimr::NStat {
+
+// Class that is used to build internal SELECT queries used to calculate column statistics.
+class TSelectBuilder {
+public:
+    ui32 AddBuiltinAggregation(std::optional<TString> columnName, TString aggName);
+
+    template<typename... TArgs>
+    ui32 AddUDAFAggregation(TString columnName, const TStringBuf& udafName, TArgs&&... params);
+
+    TString Build(const TStringBuf& table) const;
+
+    size_t ColumnCount() const {
+        return Columns.size();
+    }
+
+private:
+    ui32 AddFactory(const TStringBuf& udafName);
+
+private:
+    struct TFactory {
+        TFactory(ui32 id, const TStringBuf& udaf, size_t paramCount)
+            : Id(id), Udaf(udaf), ParamCount(paramCount)
+        {}
+
+        ui32 Id = 0;
+        TString Udaf;
+        size_t ParamCount = 0;
+    };
+
+    THashMap<TString, TFactory> Udaf2Factory;
+
+    struct TAggColumn {
+        ui32 Seq = 0;
+        std::optional<TString> ColumnName;
+        std::optional<TString> AggName;
+        std::optional<ui32> UdafFactory;
+        TString Params;
+    };
+
+    TVector<TAggColumn> Columns;
+};
+
+template<typename... TArgs>
+ui32 TSelectBuilder::AddUDAFAggregation(TString columnName, const TStringBuf& udafName, TArgs&&... params) {
+    auto factory = AddFactory(udafName);
+
+    // TODO: parameters escaping/binding
+    TString paramsStr = Join(',', params...);
+
+    auto column = TAggColumn{
+        .Seq = static_cast<ui32>(Columns.size()),
+        .ColumnName = std::move(columnName),
+        .UdafFactory = factory,
+        .Params = std::move(paramsStr),
+    };
+    Columns.push_back(std::move(column));
+    return Columns.back().Seq;
+}
+
+} // NKikimr::NStat

--- a/ydb/core/statistics/aggregator/select_builder.h
+++ b/ydb/core/statistics/aggregator/select_builder.h
@@ -21,7 +21,7 @@ public:
     }
 
 private:
-    ui32 AddFactory(const TStringBuf& udafName);
+    ui32 AddFactory(const TStringBuf& udafName, size_t paramCount);
 
 private:
     struct TFactory {
@@ -49,7 +49,7 @@ private:
 
 template<typename... TArgs>
 ui32 TSelectBuilder::AddUDAFAggregation(TString columnName, const TStringBuf& udafName, TArgs&&... params) {
-    auto factory = AddFactory(udafName);
+    auto factory = AddFactory(udafName, sizeof...(params));
 
     // TODO: parameters escaping/binding
     TString paramsStr = Join(',', params...);

--- a/ydb/core/statistics/aggregator/tx_aggr_stat_response.cpp
+++ b/ydb/core/statistics/aggregator/tx_aggr_stat_response.cpp
@@ -37,6 +37,10 @@ struct TStatisticsAggregator::TTxAggregateStatisticsResponse : public TTxBase {
             auto tag = column.GetTag();
             for (auto& statistic : column.GetStatistics()) {
                 if (statistic.GetType() == NKikimr::NStat::COUNT_MIN_SKETCH) {
+                    if (!Self->ColumnNames.contains(tag)) {
+                        continue;
+                    }
+
                     const auto& cmsStr = statistic.GetData();
                     std::unique_ptr<TCountMinSketch> cms(TCountMinSketch::FromString(
                         cmsStr.data(), cmsStr.size()));

--- a/ydb/core/statistics/aggregator/ut/ut_analyze_datashard.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze_datashard.cpp
@@ -18,7 +18,7 @@ Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        CreateUniformTable(env, "Database", "Table");
+        PrepareUniformTable(env, "Database", "Table");
 
         ui64 saTabletId;
         auto pathId = ResolvePathId(runtime, "/Root/Database/Table", nullptr, &saTabletId);
@@ -34,8 +34,8 @@ Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        CreateUniformTable(env, "Database", "Table1");
-        CreateUniformTable(env, "Database", "Table2");
+        PrepareUniformTable(env, "Database", "Table1");
+        PrepareUniformTable(env, "Database", "Table2");
 
         ui64 saTabletId1;
         auto pathId1 = ResolvePathId(runtime, "/Root/Database/Table1", nullptr, &saTabletId1);
@@ -53,7 +53,7 @@ Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        CreateUniformTable(env, "Database", "Table");
+        PrepareUniformTable(env, "Database", "Table");
 
         ui64 saTabletId = 0;
         auto pathId = ResolvePathId(runtime, "/Root/Database/Table", nullptr, &saTabletId);

--- a/ydb/core/statistics/aggregator/ut/ut_analyze_datashard.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze_datashard.cpp
@@ -10,6 +10,26 @@
 namespace NKikimr {
 namespace NStat {
 
+namespace {
+
+void PrepareTable(TTestEnv& env, const TString& tableName) {
+    CreateUniformTable(env, "Database", tableName);
+    InsertDataIntoTable(env, "Database", tableName, RowsWithFewDistinctValues(1000));
+}
+
+void ValidateCountMinSketch(TTestActorRuntime& runtime, const TPathId& pathId) {
+    std::vector<TCountMinSketchProbes> expected = {
+        {
+            .Tag = 2, // Value column
+            .Probes{ {"1", 100}, {"2", 100}, {"10", 0} }
+        }
+    };
+
+    CheckCountMinSketch(runtime, pathId, expected);
+}
+
+} // namespace
+
 Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
 
     Y_UNIT_TEST(AnalyzeOneTable) {
@@ -18,14 +38,14 @@ Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        PrepareUniformTable(env, "Database", "Table");
+        PrepareTable(env, "Table");
 
         ui64 saTabletId;
         auto pathId = ResolvePathId(runtime, "/Root/Database/Table", nullptr, &saTabletId);
 
         Analyze(runtime, saTabletId, {{pathId}});
 
-        ValidateCountMinDatashard(runtime, pathId);
+        ValidateCountMinSketch(runtime, pathId);
     }
 
     Y_UNIT_TEST(AnalyzeTwoTables) {
@@ -34,8 +54,8 @@ Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        PrepareUniformTable(env, "Database", "Table1");
-        PrepareUniformTable(env, "Database", "Table2");
+        PrepareTable(env, "Table1");
+        PrepareTable(env, "Table2");
 
         ui64 saTabletId1;
         auto pathId1 = ResolvePathId(runtime, "/Root/Database/Table1", nullptr, &saTabletId1);
@@ -43,8 +63,8 @@ Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
 
         Analyze(runtime, saTabletId1, {pathId1, pathId2});
 
-        ValidateCountMinDatashard(runtime, pathId1);
-        ValidateCountMinDatashard(runtime, pathId2);
+        ValidateCountMinSketch(runtime, pathId1);
+        ValidateCountMinSketch(runtime, pathId2);
     }
 
     Y_UNIT_TEST(DropTableNavigateError) {
@@ -53,7 +73,7 @@ Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        PrepareUniformTable(env, "Database", "Table");
+        PrepareTable(env, "Table");
 
         ui64 saTabletId = 0;
         auto pathId = ResolvePathId(runtime, "/Root/Database/Table", nullptr, &saTabletId);

--- a/ydb/core/statistics/aggregator/ut/ut_analyze_datashard.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_analyze_datashard.cpp
@@ -20,8 +20,12 @@ void PrepareTable(TTestEnv& env, const TString& tableName) {
 void ValidateCountMinSketch(TTestActorRuntime& runtime, const TPathId& pathId) {
     std::vector<TCountMinSketchProbes> expected = {
         {
+            .Tag = 1, // Key column
+            .Probes = std::nullopt,
+        },
+        {
             .Tag = 2, // Value column
-            .Probes{ {"1", 100}, {"2", 100}, {"10", 0} }
+            .Probes = { { {"1", 100}, {"2", 100}, {"10", 0} } }
         }
     };
 
@@ -84,7 +88,11 @@ Y_UNIT_TEST_SUITE(AnalyzeDatashard) {
             runtime, saTabletId, {pathId},
             "operationId", {}, NKikimrStat::TEvAnalyzeResponse::STATUS_ERROR);
 
-        ValidateCountMinAbsence(runtime, pathId);
+        std::vector<TCountMinSketchProbes> expected = {
+            { .Tag = 1, .Probes = std::nullopt },
+            { .Tag = 2, .Probes = std::nullopt },
+        };
+        CheckCountMinSketch(runtime, pathId, expected);
     }
 }
 

--- a/ydb/core/statistics/aggregator/ut/ut_traverse_datashard.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_traverse_datashard.cpp
@@ -28,7 +28,7 @@ Y_UNIT_TEST_SUITE(TraverseDatashard) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        CreateUniformTable(env, "Database", "Table");
+        PrepareUniformTable(env, "Database", "Table");
 
         auto pathId = ResolvePathId(runtime, "/Root/Database/Table");
         ValidateCountMinAbsence(runtime, pathId);
@@ -39,8 +39,8 @@ Y_UNIT_TEST_SUITE(TraverseDatashard) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        CreateUniformTable(env, "Database", "Table1");
-        CreateUniformTable(env, "Database", "Table2");
+        PrepareUniformTable(env, "Database", "Table1");
+        PrepareUniformTable(env, "Database", "Table2");
 
         auto pathId1 = ResolvePathId(runtime, "/Root/Database/Table1");
         auto pathId2 = ResolvePathId(runtime, "/Root/Database/Table2");
@@ -54,7 +54,7 @@ Y_UNIT_TEST_SUITE(TraverseDatashard) {
 
         CreateDatabase(env, "Shared", 1, true);
         CreateServerlessDatabase(env, "Serverless", "/Root/Shared");
-        CreateUniformTable(env, "Serverless", "Table");
+        PrepareUniformTable(env, "Serverless", "Table");
 
         auto pathId = ResolvePathId(runtime, "/Root/Serverless/Table");
         ValidateCountMinAbsence(runtime, pathId);
@@ -66,8 +66,8 @@ Y_UNIT_TEST_SUITE(TraverseDatashard) {
 
         CreateDatabase(env, "Shared", 1, true);
         CreateServerlessDatabase(env, "Serverless", "/Root/Shared");
-        CreateUniformTable(env, "Serverless", "Table1");
-        CreateUniformTable(env, "Serverless", "Table2");
+        PrepareUniformTable(env, "Serverless", "Table1");
+        PrepareUniformTable(env, "Serverless", "Table2");
 
         auto pathId1 = ResolvePathId(runtime, "/Root/Serverless/Table1");
         auto pathId2 = ResolvePathId(runtime, "/Root/Serverless/Table2");
@@ -82,8 +82,8 @@ Y_UNIT_TEST_SUITE(TraverseDatashard) {
         CreateDatabase(env, "Shared", 1, true);
         CreateServerlessDatabase(env, "Serverless1", "/Root/Shared");
         CreateServerlessDatabase(env, "Serverless2", "/Root/Shared");
-        CreateUniformTable(env, "Serverless1", "Table1");
-        CreateUniformTable(env, "Serverless2", "Table2");
+        PrepareUniformTable(env, "Serverless1", "Table1");
+        PrepareUniformTable(env, "Serverless2", "Table2");
 
         auto pathId1 = ResolvePathId(runtime, "/Root/Serverless1/Table1");
         auto pathId2 = ResolvePathId(runtime, "/Root/Serverless2/Table2");

--- a/ydb/core/statistics/aggregator/ut/ut_traverse_datashard.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_traverse_datashard.cpp
@@ -19,6 +19,14 @@ TTestEnv CreateTestEnv() {
     });
 }
 
+void ValidateCountMinAbsence(TTestActorRuntime& runtime, TPathId pathId) {
+    std::vector<TCountMinSketchProbes> expected = {
+        { .Tag = 1, .Probes = std::nullopt },
+        { .Tag = 2, .Probes = std::nullopt },
+    };
+    CheckCountMinSketch(runtime, pathId, expected);
+}
+
 }
 
 Y_UNIT_TEST_SUITE(TraverseDatashard) {

--- a/ydb/core/statistics/aggregator/ut/ya.make
+++ b/ydb/core/statistics/aggregator/ut/ya.make
@@ -19,6 +19,8 @@ PEERDIR(
     ydb/core/protos
     ydb/core/testlib/default
     ydb/core/statistics/ut_common
+    yql/essentials/udfs/common/digest
+    yql/essentials/udfs/common/hyperloglog
 )
 
 SRCS(

--- a/ydb/core/statistics/aggregator/ya.make
+++ b/ydb/core/statistics/aggregator/ya.make
@@ -9,6 +9,8 @@ SRCS(
     analyze_actor.cpp
     schema.h
     schema.cpp
+    select_builder.h
+    select_builder.cpp
     tx_ack_timeout.cpp
     tx_aggr_stat_response.cpp
     tx_analyze.cpp

--- a/ydb/core/statistics/database/database.h
+++ b/ydb/core/statistics/database/database.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ydb/core/scheme/scheme_pathid.h>
+#include <ydb/core/protos/statistics.pb.h>
+#include <ydb/core/statistics/events.h>
 #include <ydb/library/actors/core/actor.h>
 
 namespace NKikimr::NStat {
@@ -8,7 +10,7 @@ namespace NKikimr::NStat {
 NActors::IActor* CreateStatisticsTableCreator(std::unique_ptr<NActors::IEventBase> event, const TString& database);
 
 NActors::IActor* CreateSaveStatisticsQuery(const NActors::TActorId& replyActorId, const TString& database,
-    const TPathId& pathId, ui64 statType, std::vector<ui32>&& columnTags, std::vector<TString>&& data);
+    const TPathId& pathId, std::vector<TStatisticsItem>&& items);
 
 NActors::IActor* CreateLoadStatisticsQuery(const NActors::TActorId& replyActorId, const TString& database,
     const TPathId& pathId, ui64 statType, ui32 columnTag);

--- a/ydb/core/statistics/database/ut/ut_database.cpp
+++ b/ydb/core/statistics/database/ut/ut_database.cpp
@@ -23,12 +23,13 @@ Y_UNIT_TEST_SUITE(StatisticsSaveLoad) {
         runtime.GrabEdgeEventRethrow<TEvStatistics::TEvStatTableCreationResponse>(sender);
 
         TPathId pathId(1, 1);
-        ui64 statType = 1;
-        std::vector<ui32> columnTags = {1, 2};
-        std::vector<TString> data = {"dataA", "dataB"};
+        EStatType statType = EStatType::COUNT_MIN_SKETCH;
+        std::vector<TStatisticsItem> statItems;
+        statItems.emplace_back(1, statType, "dataA");
+        statItems.emplace_back(2, statType, "dataB");
 
         runtime.Register(CreateSaveStatisticsQuery(sender, "/Root/Database",
-            pathId, statType, std::move(columnTags), std::move(data)),
+            pathId, std::move(statItems)),
             0, 0, TMailboxType::Simple, 0, sender);
         auto saveResponse = runtime.GrabEdgeEventRethrow<TEvStatistics::TEvSaveStatisticsQueryResponse>(sender);
         UNIT_ASSERT(saveResponse->Get()->Success);
@@ -61,12 +62,13 @@ Y_UNIT_TEST_SUITE(StatisticsSaveLoad) {
         runtime.GrabEdgeEvent<TEvStatistics::TEvStatTableCreationResponse>(sender);
 
         TPathId pathId(1, 1);
-        ui64 statType = 1;
-        std::vector<ui32> columnTags = {1, 2};
-        std::vector<TString> data = {"dataA", "dataB"};
+        EStatType statType = EStatType::COUNT_MIN_SKETCH;
+        std::vector<TStatisticsItem> statItems;
+        statItems.emplace_back(1, statType, "dataA");
+        statItems.emplace_back(2, statType, "dataB");
 
         runtime.Register(CreateSaveStatisticsQuery(sender, "/Root/Database",
-            pathId, statType, std::move(columnTags), std::move(data)),
+            pathId, std::move(statItems)),
             0, 0, TMailboxType::Simple, 0, sender);
         auto saveResponse = runtime.GrabEdgeEvent<TEvStatistics::TEvSaveStatisticsQueryResponse>(sender);
         UNIT_ASSERT(saveResponse->Get()->Success);

--- a/ydb/core/statistics/database/ut/ut_database.cpp
+++ b/ydb/core/statistics/database/ut/ut_database.cpp
@@ -89,7 +89,7 @@ Y_UNIT_TEST_SUITE(StatisticsSaveLoad) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database", 1, true);
-        CreateUniformTable(env, "Database", "Table");
+        PrepareUniformTable(env, "Database", "Table");
 
         NYdb::EStatus status;
         auto test = [&] () {

--- a/ydb/core/statistics/events.h
+++ b/ydb/core/statistics/events.h
@@ -44,6 +44,22 @@ struct TResponse {
     TStatCountMinSketch CountMinSketch;
 };
 
+// A single item of columnar statistics ready to be saved in the internal table.
+struct TStatisticsItem {
+    TStatisticsItem(
+            std::optional<ui32> columnTag,
+            EStatType type,
+            TString data)
+        : ColumnTag(columnTag)
+        , Type(type)
+        , Data(std::move(data))
+    {}
+
+    std::optional<ui32> ColumnTag;
+    EStatType Type;
+    TString Data;
+};
+
 struct TEvStatistics {
     enum EEv {
         EvGetStatistics = EventSpaceBegin(TKikimrEvents::ES_STATISTICS),
@@ -283,6 +299,12 @@ struct TEvStatistics {
             TableNotFound,
         };
         EStatus Status;
+        std::vector<TStatisticsItem> Statistics;
+
+        explicit TEvFinishTraversal(std::vector<TStatisticsItem> statistics)
+            : Status(EStatus::Success)
+            , Statistics(std::move(statistics))
+        {}
 
         explicit TEvFinishTraversal(EStatus status) : Status(status) {}
     };

--- a/ydb/core/statistics/events.h
+++ b/ydb/core/statistics/events.h
@@ -27,7 +27,7 @@ struct TStatCountMinSketch {
 
 enum EStatType {
     SIMPLE = 0,
-    HYPER_LOG_LOG = 1,
+    SIMPLE_COLUMN = 1,
     COUNT_MIN_SKETCH = 2,
 };
 

--- a/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
@@ -322,7 +322,7 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         TTestEnv env(1, 1);
 
         CreateDatabase(env, "Database");
-        CreateUniformTable(env, "Database", "Table");
+        PrepareUniformTable(env, "Database", "Table");
 
         TestNotFullStatistics(env, /*shardCount=*/ 4, /*expectedRowCount=*/ 4);
     }

--- a/ydb/core/statistics/service/ut/ut_column_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_column_statistics.cpp
@@ -74,7 +74,7 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
 
         std::vector<TColumnStatisticsProbes> expected = {
             {
-                .Tag = 1,
+                .Tag = 1, // Key column
                 .Probes{ {1, 4}, {2, 4} }
             }
         };
@@ -104,7 +104,7 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
         auto sender = runtime.AllocateEdgeActor();
         std::vector<TColumnStatisticsProbes> expected = {
             {
-                .Tag = 1,
+                .Tag = 1, // Key column
                 .Probes{ {1, 4}, {2, 4} }
             }
         };

--- a/ydb/core/statistics/service/ut/ut_column_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_column_statistics.cpp
@@ -13,52 +13,15 @@
 namespace NKikimr {
 namespace NStat {
 
-struct TColumnStatisticsProbes {
-    struct TProbe {
-        ui64 Value;
-        ui64 Probe;
-    };
+namespace {
 
-    ui16 Tag;
-    std::vector<TProbe> Probes;
-};
-
-void CheckColumnStatistics(
-    TTestActorRuntime& runtime, const TPathId& pathId, const TActorId& sender, const std::vector<TColumnStatisticsProbes>& expected
-) {
-    auto evGet = std::make_unique<TEvStatistics::TEvGetStatistics>();
-    evGet->StatType = NStat::EStatType::COUNT_MIN_SKETCH;
-
-    for (auto item : expected) {
-        NStat::TRequest req;
-        req.PathId = pathId;
-        req.ColumnTag = item.Tag;
-        evGet->StatRequests.push_back(req);
-    }
-
-    auto statServiceId = NStat::MakeStatServiceID(runtime.GetNodeId(0));
-    runtime.Send(statServiceId, sender, evGet.release(), 0, true);
-
-    auto res = runtime.GrabEdgeEventRethrow<TEvStatistics::TEvGetStatisticsResult>(sender);
-    auto msg = res->Get();
-
-    UNIT_ASSERT(msg->Success);
-    UNIT_ASSERT( msg->StatResponses.size() == expected.size());
-
-    for (size_t i = 0; i < msg->StatResponses.size(); ++i) {
-        const auto& stat = msg->StatResponses[i];
-        UNIT_ASSERT(stat.Success);
-
-        auto countMin = stat.CountMinSketch.CountMin.get();
-        UNIT_ASSERT(countMin != nullptr);
-
-        for (const auto& item : expected[i].Probes) {
-            ui64 value = item.Value;
-            auto probe = countMin->Probe((const char*)&value, sizeof(ui64));
-            UNIT_ASSERT_VALUES_EQUAL(item.Probe, probe);
-        }
-    }
+TTableInfo PrepareTable(TTestEnv& env, const TString& databaseName, const TString& tableName) {
+    auto tableInfo = CreateColumnTable(env, databaseName, tableName, 1);
+    InsertDataIntoTable(env, databaseName, tableName, RowsWithFewDistinctValues(1000));
+    return tableInfo;
 }
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(ColumnStatistics) {
     Y_UNIT_TEST(CountMinSketchStatistics) {
@@ -66,20 +29,16 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
         auto& runtime = *env.GetServer().GetRuntime();
 
         CreateDatabase(env, "Database");
-        PrepareColumnTable(env, "Database", "Table1", 1);
-        ui64 saTabletId = 0;
-        auto pathId = ResolvePathId(runtime, "/Root/Database/Table1", nullptr, &saTabletId);
+        const auto tableInfo = PrepareTable(env, "Database", "Table1");
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
 
-        Analyze(runtime, saTabletId, {pathId});
-
-        std::vector<TColumnStatisticsProbes> expected = {
+        std::vector<TCountMinSketchProbes> expected = {
             {
-                .Tag = 1, // Key column
-                .Probes{ {1, 4}, {2, 4} }
+                .Tag = 2, // Key column
+                .Probes{ {"1", 100}, {"2", 100} }
             }
         };
-        auto sender = runtime.AllocateEdgeActor();
-        CheckColumnStatistics(runtime, pathId, sender, expected);
+        CheckCountMinSketch(runtime, tableInfo.PathId, expected);
     }
 
     Y_UNIT_TEST(CountMinSketchServerlessStatistics) {
@@ -90,27 +49,21 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
         CreateServerlessDatabase(env, "Serverless1", "/Root/Shared", 1);
         CreateServerlessDatabase(env, "Serverless2", "/Root/Shared", 1);
 
-        PrepareColumnTable(env, "Serverless1", "Table1", 1);
-        PrepareColumnTable(env, "Serverless2", "Table2", 1);
+        const auto table1 = PrepareTable(env, "Serverless1", "Table1");
+        const auto table2 = PrepareTable(env, "Serverless2", "Table2");
 
-        // Same SA tablet for both serverless databases
-        ui64 saTabletId = 0;
-        auto pathId1 = ResolvePathId(runtime, "/Root/Serverless1/Table1", nullptr, &saTabletId);
-        auto pathId2 = ResolvePathId(runtime, "/Root/Serverless2/Table2");
+        Analyze(runtime, table1.SaTabletId, {table1.PathId}, "opId1", "/Root/Serverless1");
+        Analyze(runtime, table2.SaTabletId, {table2.PathId}, "opId1", "/Root/Serverless2");
 
-        Analyze(runtime, saTabletId, {pathId1}, "opId1", "/Root/Serverless1");
-        Analyze(runtime, saTabletId, {pathId2}, "opId1", "/Root/Serverless2");
-
-        auto sender = runtime.AllocateEdgeActor();
-        std::vector<TColumnStatisticsProbes> expected = {
+        std::vector<TCountMinSketchProbes> expected = {
             {
-                .Tag = 1, // Key column
-                .Probes{ {1, 4}, {2, 4} }
+                .Tag = 2, // Value column
+                .Probes{ {"1", 100}, {"2", 100} }
             }
         };
 
-        CheckColumnStatistics(runtime, pathId1, sender, expected);
-        CheckColumnStatistics(runtime, pathId2, sender, expected);
+        CheckCountMinSketch(runtime, table1.PathId, expected);
+        CheckCountMinSketch(runtime, table2.PathId, expected);
     }
 }
 

--- a/ydb/core/statistics/service/ut/ut_column_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_column_statistics.cpp
@@ -34,7 +34,7 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
 
         std::vector<TCountMinSketchProbes> expected = {
             {
-                .Tag = 2, // Key column
+                .Tag = 2, // Value column
                 .Probes{ {"1", 100}, {"2", 100} }
             }
         };

--- a/ydb/core/statistics/service/ut/ut_http_request.cpp
+++ b/ydb/core/statistics/service/ut/ut_http_request.cpp
@@ -62,7 +62,7 @@ void ProbeTest(bool isServerless) {
     runtime.Register(new THttpRequest(THttpRequest::ERequestType::PROBE_COUNT_MIN_SKETCH, {
             { THttpRequest::EParamType::PATH, tableInfo.Path },
             { THttpRequest::EParamType::COLUMN_NAME, columnName },
-            { THttpRequest::EParamType::CELL_VALUE, "1" }
+            { THttpRequest::EParamType::CELL_VALUE, "\"1\"" }
         },
         THttpRequest::EResponseContentType::HTML,
         sender));

--- a/ydb/core/statistics/service/ut/ut_http_request.cpp
+++ b/ydb/core/statistics/service/ut/ut_http_request.cpp
@@ -8,13 +8,22 @@
 namespace NKikimr {
 namespace NStat {
 
+namespace {
+
+TTableInfo PrepareDatabaseAndTable(TTestEnv& env, bool isServerless) {
+    if (isServerless) {
+        CreateDatabase(env, "Shared", 1, true);
+        CreateServerlessDatabase(env, "Database", "/Root/Shared");
+    } else {
+        CreateDatabase(env, "Database");
+    }
+    return PrepareColumnTable(env, "Database", "Table", 10);
+}
+
 void AnalyzeTest(bool isServerless) {
     TTestEnv env(1, 1);
     auto& runtime = *env.GetServer().GetRuntime();
-    const auto databaseInfo = isServerless
-        ? PrepareServerlessDatabaseColumnTables(env, 1, 10)
-        : PrepareDatabaseColumnTables(env, 1, 10);
-    const auto& tableInfo = databaseInfo.Tables[0];
+    const auto tableInfo = PrepareDatabaseAndTable(env, isServerless);
     const auto sender = runtime.AllocateEdgeActor();
 
     runtime.Register(new THttpRequest(THttpRequest::ERequestType::ANALYZE, {
@@ -34,10 +43,8 @@ void AnalyzeTest(bool isServerless) {
 void ProbeTest(bool isServerless) {
     TTestEnv env(1, 1);
     auto& runtime = *env.GetServer().GetRuntime();
-    const auto databaseInfo = isServerless
-        ? PrepareServerlessDatabaseColumnTables(env, 1, 10)
-        : PrepareDatabaseColumnTables(env, 1, 10);
-    const auto& tableInfo = databaseInfo.Tables[0];
+    const auto tableInfo = PrepareDatabaseAndTable(env, isServerless);
+
     TString columnName = "Value";
     const auto sender = runtime.AllocateEdgeActor();
 
@@ -116,6 +123,8 @@ void ProbeBaseStatsTest(bool isServerless) {
     UNIT_ASSERT_VALUES_EQUAL(json["row_count"].GetIntegerSafe(), ColumnTableRowsNumber);
 }
 
+} // namespace
+
 Y_UNIT_TEST_SUITE(HttpRequest) {
     Y_UNIT_TEST(Analyze) {
         AnalyzeTest(false);
@@ -128,8 +137,7 @@ Y_UNIT_TEST_SUITE(HttpRequest) {
     Y_UNIT_TEST(Status) {
         TTestEnv env(1, 1);
         auto& runtime = *env.GetServer().GetRuntime();
-        const auto databaseInfo = PrepareDatabaseColumnTables(env, 1, 10);
-        const auto& tableInfo = databaseInfo.Tables[0];
+        const auto tableInfo = PrepareDatabaseAndTable(env, /*isServerless=*/false);
 
         const auto sender = runtime.AllocateEdgeActor();
         const auto operationId = TULIDGenerator().Next(TInstant::Now()).ToString();

--- a/ydb/core/statistics/service/ut/ut_http_request.cpp
+++ b/ydb/core/statistics/service/ut/ut_http_request.cpp
@@ -17,7 +17,9 @@ TTableInfo PrepareDatabaseAndTable(TTestEnv& env, bool isServerless) {
     } else {
         CreateDatabase(env, "Database");
     }
-    return PrepareColumnTable(env, "Database", "Table", 10);
+    auto info = PrepareColumnTable(env, "Database", "Table", 10);
+    InsertDataIntoTable(env, "Database", "Table", RowsWithFewDistinctValues(1000));
+    return info;
 }
 
 void AnalyzeTest(bool isServerless) {

--- a/ydb/core/statistics/service/ut/ya.make
+++ b/ydb/core/statistics/service/ut/ya.make
@@ -19,6 +19,8 @@ PEERDIR(
     ydb/core/protos
     ydb/core/testlib/default
     ydb/core/statistics/ut_common
+    yql/essentials/udfs/common/digest
+    yql/essentials/udfs/common/hyperloglog
 )
 
 SRCS(

--- a/ydb/core/statistics/ut_common/ut_common.cpp
+++ b/ydb/core/statistics/ut_common/ut_common.cpp
@@ -277,7 +277,7 @@ void CreateColumnTable(TTestEnv& env, const TString& databaseName, const TString
     ExecuteYqlScript(env, Sprintf(R"(
         CREATE TABLE `%s` (
             Key Uint64 NOT NULL,
-            Value Uint64,
+            Value String,
             PRIMARY KEY (Key)
         )
         PARTITION BY HASH(Key)
@@ -332,13 +332,13 @@ void PrepareColumnTable(TTestEnv& env, const TString& databaseName, const TStrin
         reqKeyType->mutable_type()->set_type_id(Ydb::Type::UINT64);
         auto* reqValueType = reqRowType->add_members();
         reqValueType->set_name("Value");
-        reqValueType->mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(Ydb::Type::UINT64);
+        reqValueType->mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(Ydb::Type::STRING);
 
         auto* reqRows = rows->mutable_value();
         for (size_t j = 0; j < rowsInBlock && i < ColumnTableRowsNumber; ++i, ++j) {
             auto* row = reqRows->add_items();
             row->add_items()->set_uint64_value(i);
-            row->add_items()->set_uint64_value(i);
+            row->add_items()->set_bytes_value(ToString(i));
         }
         i -= overlap;
         auto future = NRpcService::DoLocalRpc<TEvBulkUpsertRequest>(

--- a/ydb/core/statistics/ut_common/ut_common.cpp
+++ b/ydb/core/statistics/ut_common/ut_common.cpp
@@ -253,6 +253,10 @@ void CreateUniformTable(TTestEnv& env, const TString& databaseName, const TStrin
         )
         WITH ( UNIFORM_PARTITIONS = 4 );
     )", databaseName.c_str(), tableName.c_str()));
+}
+
+void PrepareUniformTable(TTestEnv& env, const TString& databaseName, const TString& tableName) {
+    CreateUniformTable(env, databaseName, tableName);
 
     TStringBuilder replace;
     replace << Sprintf("REPLACE INTO `Root/%s/%s` (Key, Value) VALUES ",
@@ -436,14 +440,6 @@ std::shared_ptr<TCountMinSketch> ExtractCountMin(TTestActorRuntime& runtime, con
     UNIT_ASSERT(stat.CountMin);
 
     return stat.CountMin;
-}
-
-void ValidateCountMinColumnshard(TTestActorRuntime& runtime, const TPathId& pathId, ui64 expectedProbe) {
-    auto countMin = ExtractCountMin(runtime, pathId);
-
-    ui32 value = 1;
-    auto actualProbe = countMin->Probe((const char *)&value, sizeof(value));
-    UNIT_ASSERT_VALUES_EQUAL(actualProbe, expectedProbe);
 }
 
 void ValidateCountMinDatashard(TTestActorRuntime& runtime, TPathId pathId) {

--- a/ydb/core/statistics/ut_common/ut_common.h
+++ b/ydb/core/statistics/ut_common/ut_common.h
@@ -71,12 +71,6 @@ TString CreateDatabase(TTestEnv& env, const TString& databaseName,
 
 TString CreateServerlessDatabase(TTestEnv& env, const TString& databaseName, const TString& sharedName, size_t nodeCount = 0);
 
-// Create empty column table with the requested number of shards.
-void CreateColumnTable(TTestEnv& env, const TString& databaseName, const TString& tableName, int shardCount);
-// Create a column table, enable count-min-sketch column statistics,
-// and insert ColumnTableRowsNumber rows.
-void PrepareColumnTable(TTestEnv& env, const TString& databaseName, const TString& tableName, int shardCount);
-
 struct TTableInfo {
     std::vector<ui64> ShardIds;
     ui64 SaTabletId;
@@ -85,13 +79,17 @@ struct TTableInfo {
     TString Path;
 };
 
-struct TDatabaseInfo {
-    TString FullDatabaseName;
-    std::vector<TTableInfo> Tables;
-};
+// Create empty column table with the requested number of shards.
+TTableInfo CreateColumnTable(TTestEnv& env, const TString& databaseName, const TString& tableName, int shardCount);
 
-TDatabaseInfo PrepareDatabaseColumnTables(TTestEnv& env, ui8 tableCount, ui8 shardCount);
-TDatabaseInfo PrepareServerlessDatabaseColumnTables(TTestEnv& env, ui8 tableCount, ui8 shardCount);
+void InsertDataIntoTable(TTestEnv& env, const TString& databaseName, const TString& tableName, size_t rowCount);
+
+// Create a column table and insert ColumnTableRowsNumber rows.
+TTableInfo PrepareColumnTable(TTestEnv& env, const TString& databaseName, const TString& tableName, int shardCount);
+
+// Create a column table, enable count-min-sketch column indexes,
+// and insert ColumnTableRowsNumber rows with some overlap to trigger compaction.
+TTableInfo PrepareColumnTableWithIndexes(TTestEnv& env, const TString& databaseName, const TString& tableName, int shardCount);
 
 TPathId ResolvePathId(TTestActorRuntime& runtime, const TString& path, TPathId* domainKey = nullptr, ui64* saTabletId = nullptr);
 

--- a/ydb/core/statistics/ut_common/ut_common.h
+++ b/ydb/core/statistics/ut_common/ut_common.h
@@ -116,8 +116,6 @@ void DropTable(TTestEnv& env, const TString& databaseName, const TString& tableN
 
 std::shared_ptr<TCountMinSketch> ExtractCountMin(TTestActorRuntime& runtime, const TPathId& pathId, ui64 columnTag = 1);
 
-void ValidateCountMinAbsence(TTestActorRuntime& runtime, TPathId pathId);
-
 struct TCountMinSketchProbes {
     struct TProbe {
         TString Value;
@@ -125,7 +123,8 @@ struct TCountMinSketchProbes {
     };
 
     ui16 Tag;
-    std::vector<TProbe> Probes;
+    // If nullopt, absence of count-min sketch is expected.
+    std::optional<std::vector<TProbe>> Probes;
 };
 
 void CheckCountMinSketch(

--- a/ydb/core/statistics/ut_common/ut_common.h
+++ b/ydb/core/statistics/ut_common/ut_common.h
@@ -98,11 +98,14 @@ NKikimrScheme::TEvDescribeSchemeResult DescribeTable(
 TVector<ui64> GetTableShards(TTestActorRuntime& runtime, TActorId sender, const TString &path);
 TVector<ui64> GetColumnTableShards(TTestActorRuntime& runtime, TActorId sender,const TString &path);
 
+// Create a datashard table with 4 uniform shards.
 void CreateUniformTable(TTestEnv& env, const TString& databaseName, const TString& tableName);
+// Create a datashard table with 4 uniform shards and insert 1 row into each shard.
+void PrepareUniformTable(TTestEnv& env, const TString& databaseName, const TString& tableName);
+
 void DropTable(TTestEnv& env, const TString& databaseName, const TString& tableName);
 
 std::shared_ptr<TCountMinSketch> ExtractCountMin(TTestActorRuntime& runtime, const TPathId& pathId, ui64 columnTag = 1);
-void ValidateCountMinColumnshard(TTestActorRuntime& runtime, const TPathId& pathId, ui64 expectedProbe);
 
 void ValidateCountMinDatashard(TTestActorRuntime& runtime, TPathId pathId);
 void ValidateCountMinAbsence(TTestActorRuntime& runtime, TPathId pathId);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Calculate column statistics in two stages, first stage determines total count and number of distinct values for each column, second stage calculates count-min sketches for some columns.
