### PR TITLE
multihopping/HoppingWindow: add unlimited/far/sparse windows (stable 25-3)

### DIFF
--- a/yql/essentials/minikql/comp_nodes/mkql_multihopping.h
+++ b/yql/essentials/minikql/comp_nodes/mkql_multihopping.h
@@ -8,5 +8,5 @@ namespace NMiniKQL {
 
 IComputationNode* WrapMultiHoppingCore(TCallable& callable, const TComputationNodeFactoryContext& ctx, TWatermark& watermark);
 
-}
-}
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
@@ -16,247 +16,255 @@ namespace NKikimr {
 namespace NMiniKQL {
 
 namespace {
-    TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
-        return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
-            if (callable.GetType()->GetName() == "OneYieldStream") {
-                return new TExternalComputationNode(ctx.Mutables);
-            } else if (callable.GetType()->GetName() == "MultiHoppingCore") {
-                return WrapMultiHoppingCore(callable, ctx, watermark);
-            }
-
-            return GetBuiltinFactory()(callable, ctx);
-        };
-    }
-    struct TStreamWithYield : public NUdf::TBoxedValue {
-        TStreamWithYield(const TUnboxedValueVector& items, ui32 yieldPos, ui32 index)
-            : Items(items)
-            , YieldPos(yieldPos)
-            , Index(index)
-        {}
-
-    private:
-        TUnboxedValueVector Items;
-        ui32 YieldPos;
-        ui32 Index;
-
-        ui32 GetTraverseCount() const override {
-            return 0;
+TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
+    return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
+        if (callable.GetType()->GetName() == "OneYieldStream") {
+            return new TExternalComputationNode(ctx.Mutables);
+        } else if (callable.GetType()->GetName() == "MultiHoppingCore") {
+            return WrapMultiHoppingCore(callable, ctx, watermark);
         }
 
-        NUdf::TUnboxedValue Save() const override {
-            return NUdf::TUnboxedValue::Zero();
-        }
-
-        bool Load2(const NUdf::TUnboxedValue& state) override {
-            Y_UNUSED(state);
-            return false;
-        }
-
-        NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) final {
-            if (Index >= Items.size()) {
-                return NUdf::EFetchStatus::Finish;
-            }
-            if (Index == YieldPos) {
-                return NUdf::EFetchStatus::Yield;
-            }
-            result = Items[Index++];
-            return NUdf::EFetchStatus::Ok;
-        }
+        return GetBuiltinFactory()(callable, ctx);
     };
-
-    THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<std::tuple<ui32, i64, ui32>> items,
-                                          ui32 yieldPos, ui32 startIndex, bool dataWatermarks) {
-        TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-
-        auto structType = pgmBuilder.NewEmptyStructType();
-        structType = pgmBuilder.NewStructType(structType, "key",
-            pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
-        structType = pgmBuilder.NewStructType(structType, "time",
-            pgmBuilder.NewDataType(NUdf::TDataType<NUdf::TTimestamp>::Id));
-        structType = pgmBuilder.NewStructType(structType, "sum",
-            pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
-        auto keyIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("key");
-        auto timeIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("time");
-        auto sumIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("sum");
-
-        auto inStreamType = pgmBuilder.NewStreamType(structType);
-
-        TCallableBuilder inStream(pgmBuilder.GetTypeEnvironment(), "OneYieldStream", inStreamType);
-        auto streamNode = inStream.Build();
-
-        ui64 hop = 10, interval = 30, delay = 20;
-
-        auto pgmReturn = pgmBuilder.MultiHoppingCore(
-            TRuntimeNode(streamNode, false),
-            [&](TRuntimeNode item) { // keyExtractor
-                return pgmBuilder.Member(item, "key");
-            },
-            [&](TRuntimeNode item) { // timeExtractor
-                return pgmBuilder.Member(item, "time");
-            },
-            [&](TRuntimeNode item) { // init
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", pgmBuilder.Member(item, "sum"));
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode item, TRuntimeNode state) { // update
-                auto add = pgmBuilder.AggrAdd(
-                    pgmBuilder.Member(item, "sum"),
-                    pgmBuilder.Member(state, "sum"));
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", add);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode state) { // save
-                return pgmBuilder.Member(state, "sum");
-            },
-            [&](TRuntimeNode savedState) { // load
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", savedState);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode state1, TRuntimeNode state2) { // merge
-                auto add = pgmBuilder.AggrAdd(
-                    pgmBuilder.Member(state1, "sum"),
-                    pgmBuilder.Member(state2, "sum"));
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", add);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
-                Y_UNUSED(time);
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("key", key);
-                members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
-                return pgmBuilder.NewStruct(members);
-            },
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))), // hop
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),  // delay
-            pgmBuilder.NewDataLiteral<bool>(dataWatermarks),  // dataWatermarks
-            pgmBuilder.NewDataLiteral<bool>(false)
-        );
-
-        auto graph = setup.BuildGraph(pgmReturn, {streamNode});
-
-        TUnboxedValueVector streamItems;
-        for (size_t i = 0; i < items.size(); ++i) {
-            NUdf::TUnboxedValue* itemsPtr;
-            auto structValues = graph->GetHolderFactory().CreateDirectArrayHolder(3, itemsPtr);
-            itemsPtr[keyIndex] = NUdf::TUnboxedValuePod(std::get<0>(items[i]));
-            itemsPtr[timeIndex] = NUdf::TUnboxedValuePod(std::get<1>(items[i]));
-            itemsPtr[sumIndex] = NUdf::TUnboxedValuePod(std::get<2>(items[i]));
-            streamItems.push_back(std::move(structValues));
-        }
-
-        auto streamValue = NUdf::TUnboxedValuePod(new TStreamWithYield(streamItems, yieldPos, startIndex));
-        graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
-        return graph;
-    }
 }
+struct TStreamWithYield: public NUdf::TBoxedValue {
+    TStreamWithYield(const TUnboxedValueVector& items, ui32 yieldPos, ui32 index)
+        : Items(items)
+        , YieldPos(yieldPos)
+        , Index(index)
+    {
+    }
+
+private:
+    TUnboxedValueVector Items;
+    ui32 YieldPos;
+    ui32 Index;
+
+    ui32 GetTraverseCount() const override {
+        return 0;
+    }
+
+    NUdf::TUnboxedValue Save() const override {
+        return NUdf::TUnboxedValue::Zero();
+    }
+
+    bool Load2(const NUdf::TUnboxedValue& state) override {
+        Y_UNUSED(state);
+        return false;
+    }
+
+    NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) final {
+        if (Index >= Items.size()) {
+            return NUdf::EFetchStatus::Finish;
+        }
+        if (Index == YieldPos) {
+            return NUdf::EFetchStatus::Yield;
+        }
+        result = Items[Index++];
+        return NUdf::EFetchStatus::Ok;
+    }
+};
+
+THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<std::tuple<ui32, i64, ui32>> items,
+                                      ui32 yieldPos, ui32 startIndex, bool dataWatermarks) {
+    TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
+
+    auto structType = pgmBuilder.NewEmptyStructType();
+    structType = pgmBuilder.NewStructType(structType, "key",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
+    structType = pgmBuilder.NewStructType(structType, "time",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<NUdf::TTimestamp>::Id));
+    structType = pgmBuilder.NewStructType(structType, "sum",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
+    auto keyIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("key");
+    auto timeIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("time");
+    auto sumIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("sum");
+
+    auto inStreamType = pgmBuilder.NewStreamType(structType);
+
+    TCallableBuilder inStream(pgmBuilder.GetTypeEnvironment(), "OneYieldStream", inStreamType);
+    auto streamNode = inStream.Build();
+
+    ui64 hop = 10, interval = 30, delay = 20;
+
+    auto pgmReturn = pgmBuilder.MultiHoppingCore(
+        TRuntimeNode(streamNode, false),
+        [&](TRuntimeNode item) { // keyExtractor
+            return pgmBuilder.Member(item, "key");
+        },
+        [&](TRuntimeNode item) { // timeExtractor
+            return pgmBuilder.Member(item, "time");
+        },
+        [&](TRuntimeNode item) { // init
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", pgmBuilder.Member(item, "sum"));
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode item, TRuntimeNode state) { // update
+            auto add = pgmBuilder.AggrAdd(
+                pgmBuilder.Member(item, "sum"),
+                pgmBuilder.Member(state, "sum"));
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", add);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode state) { // save
+            return pgmBuilder.Member(state, "sum");
+        },
+        [&](TRuntimeNode savedState) { // load
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", savedState);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode state1, TRuntimeNode state2) { // merge
+            auto add = pgmBuilder.AggrAdd(
+                pgmBuilder.Member(state1, "sum"),
+                pgmBuilder.Member(state2, "sum"));
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", add);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
+            Y_UNUSED(time);
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("key", key);
+            members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
+            return pgmBuilder.NewStruct(members);
+        },
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))),           // hop
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),       // delay
+        pgmBuilder.NewDataLiteral<bool>(dataWatermarks),                                                                  // dataWatermarks
+        pgmBuilder.NewDataLiteral<bool>(false));
+
+    auto graph = setup.BuildGraph(pgmReturn, {streamNode});
+
+    TUnboxedValueVector streamItems;
+    for (size_t i = 0; i < items.size(); ++i) {
+        NUdf::TUnboxedValue* itemsPtr;
+        auto structValues = graph->GetHolderFactory().CreateDirectArrayHolder(3, itemsPtr);
+        itemsPtr[keyIndex] = NUdf::TUnboxedValuePod(std::get<0>(items[i]));
+        itemsPtr[timeIndex] = NUdf::TUnboxedValuePod(std::get<1>(items[i]));
+        itemsPtr[sumIndex] = NUdf::TUnboxedValuePod(std::get<2>(items[i]));
+        streamItems.push_back(std::move(structValues));
+    }
+
+    auto streamValue = NUdf::TUnboxedValuePod(new TStreamWithYield(streamItems, yieldPos, startIndex));
+    graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
+    return graph;
+}
+} // namespace
 
 Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingSaveLoadTest) {
-    void TestWithSaveLoadImpl(
-        const std::vector<std::tuple<ui32, i64, ui32>> input,
-        const std::vector<std::tuple<ui32, ui32>> expected,
-        bool withTraverse,
-        bool dataWatermarks)
-    {
-        TWatermark watermark;
-        for (ui32 yieldPos = 0; yieldPos < input.size(); ++yieldPos) {
-            std::vector<std::tuple<ui32, ui32>> result;
+void TestWithSaveLoadImpl(
+    const std::vector<std::tuple<ui32, i64, ui32>> input,
+    const std::vector<std::tuple<ui32, ui32>> expected,
+    bool withTraverse,
+    bool dataWatermarks)
+{
+    TWatermark watermark;
+    for (ui32 yieldPos = 0; yieldPos < input.size(); ++yieldPos) {
+        std::vector<std::tuple<ui32, ui32>> result;
 
-            TSetup<false> setup1(GetAuxCallableFactory(watermark));
-            auto graph1 = BuildGraph(setup1, input, yieldPos, 0, dataWatermarks);
-            auto root1 = graph1->GetValue();
+        TSetup<false> setup1(GetAuxCallableFactory(watermark));
+        auto graph1 = BuildGraph(setup1, input, yieldPos, 0, dataWatermarks);
+        auto root1 = graph1->GetValue();
 
-            NUdf::EFetchStatus status = NUdf::EFetchStatus::Ok;
-            while (status == NUdf::EFetchStatus::Ok) {
-                NUdf::TUnboxedValue val;
-                status = root1.Fetch(val);
-                if (status == NUdf::EFetchStatus::Ok) {
-                    result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
-                }
+        NUdf::EFetchStatus status = NUdf::EFetchStatus::Ok;
+        while (status == NUdf::EFetchStatus::Ok) {
+            NUdf::TUnboxedValue val;
+            status = root1.Fetch(val);
+            if (status == NUdf::EFetchStatus::Ok) {
+                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
             }
-            UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Yield);
-
-            TString graphState;
-            if (withTraverse) {
-                SaveGraphState(&root1, 1, 0ULL, graphState);
-            } else {
-                graphState = graph1->SaveGraphState();
-            }
-
-            TSetup<false> setup2(GetAuxCallableFactory(watermark));
-            auto graph2 = BuildGraph(setup2, input, -1, yieldPos, dataWatermarks);
-            NUdf::TUnboxedValue root2;
-            if (withTraverse) {
-                root2 = graph2->GetValue();
-                LoadGraphState(&root2, 1, 0ULL, graphState);
-            } else {
-                graph2->LoadGraphState(graphState);
-                root2 = graph2->GetValue();
-            }
-
-            status = NUdf::EFetchStatus::Ok;
-            while (status == NUdf::EFetchStatus::Ok) {
-                NUdf::TUnboxedValue val;
-                status = root2.Fetch(val);
-                if (status == NUdf::EFetchStatus::Ok) {
-                    result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
-                }
-            }
-            UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Finish);
-
-            auto sortedExpected = expected;
-            std::sort(result.begin(), result.end());
-            std::sort(sortedExpected.begin(), sortedExpected.end());
-            UNIT_ASSERT_EQUAL(result, sortedExpected);
         }
-    }
+        UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Yield);
 
-    const std::vector<std::tuple<ui32, i64, ui32>> input1 = {
-        // Group; Time; Value
-        {2, 1, 2},
-        {1, 1, 2},
-        {2, 2, 3},
-        {1, 2, 3},
-        {2, 15, 4},
-        {1, 15, 4},
-        {2, 23, 6},
-        {1, 23, 6},
-        {2, 24, 5},
-        {1, 24, 5},
-        {2, 25, 7},
-        {1, 25, 7},
-        {2, 40, 2},
-        {1, 40, 2},
-        {2, 47, 1},
-        {1, 47, 1},
-        {2, 51, 6},
-        {1, 51, 6},
-        {2, 59, 2},
-        {1, 59, 2},
-        {2, 85, 8},
-        {1, 85, 8}
-    };
+        TString graphState;
+        if (withTraverse) {
+            SaveGraphState(&root1, 1, 0ULL, graphState);
+        } else {
+            graphState = graph1->SaveGraphState();
+        }
 
-    const std::vector<std::tuple<ui32, ui32>> expected = {
-        {1, 8}, {1, 8}, {1, 8}, {1, 8},
-        {1, 11}, {1, 11}, {1, 21}, {1, 22},
-        {1, 27},
-        {2, 8}, {2, 8}, {2, 8}, {2, 8},
-        {2, 11}, {2, 11}, {2, 21},
-        {2, 22}, {2, 27}};
+        TSetup<false> setup2(GetAuxCallableFactory(watermark));
+        auto graph2 = BuildGraph(setup2, input, -1, yieldPos, dataWatermarks);
+        NUdf::TUnboxedValue root2;
+        if (withTraverse) {
+            root2 = graph2->GetValue();
+            LoadGraphState(&root2, 1, 0ULL, graphState);
+        } else {
+            graph2->LoadGraphState(graphState);
+            root2 = graph2->GetValue();
+        }
 
-    Y_UNIT_TEST(Test1) {
-        TestWithSaveLoadImpl(input1, expected, true, false);
-    }
+        status = NUdf::EFetchStatus::Ok;
+        while (status == NUdf::EFetchStatus::Ok) {
+            NUdf::TUnboxedValue val;
+            status = root2.Fetch(val);
+            if (status == NUdf::EFetchStatus::Ok) {
+                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
+            }
+        }
+        UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Finish);
 
-    Y_UNIT_TEST(Test2) {
-        TestWithSaveLoadImpl(input1, expected, false, false);
+        auto sortedExpected = expected;
+        std::sort(result.begin(), result.end());
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+        UNIT_ASSERT_EQUAL(result, sortedExpected);
     }
 }
+
+const std::vector<std::tuple<ui32, i64, ui32>> input1 = {
+    // Group; Time; Value
+    {2, 1, 2},
+    {1, 1, 2},
+    {2, 2, 3},
+    {1, 2, 3},
+    {2, 15, 4},
+    {1, 15, 4},
+    {2, 23, 6},
+    {1, 23, 6},
+    {2, 24, 5},
+    {1, 24, 5},
+    {2, 25, 7},
+    {1, 25, 7},
+    {2, 40, 2},
+    {1, 40, 2},
+    {2, 47, 1},
+    {1, 47, 1},
+    {2, 51, 6},
+    {1, 51, 6},
+    {2, 59, 2},
+    {1, 59, 2},
+    {2, 85, 8},
+    {1, 85, 8}};
+
+const std::vector<std::tuple<ui32, ui32>> expected = {
+    {1, 8}, {1, 8}, {1, 8}, {1, 8},
+    {1, 11},
+    {1, 11},
+    {1, 21},
+    {1, 22},
+    {1, 27},
+    {2, 8},
+    {2, 8},
+    {2, 8},
+    {2, 8},
+    {2, 11},
+    {2, 11},
+    {2, 21},
+    {2, 22},
+    {2, 27}};
+
+Y_UNIT_TEST(Test1) {
+    TestWithSaveLoadImpl(input1, expected, true, false);
+}
+
+Y_UNIT_TEST(Test2) {
+    TestWithSaveLoadImpl(input1, expected, false, false);
+}
+} // Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingSaveLoadTest)
 
 } // namespace NMiniKQL
 } // namespace NKikimr

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
@@ -16,6 +16,7 @@ namespace NKikimr {
 namespace NMiniKQL {
 
 namespace {
+using TWatermarksPattern = std::vector<std::tuple<ui32, TInstant>>;
 TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
     return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
         if (callable.GetType()->GetName() == "OneYieldStream") {
@@ -28,10 +29,13 @@ TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
     };
 }
 struct TStreamWithYield: public NUdf::TBoxedValue {
-    TStreamWithYield(const TUnboxedValueVector& items, ui32 yieldPos, ui32 index)
+    TStreamWithYield(const TUnboxedValueVector& items, ui32 yieldPos, ui32 index, TWatermark& watermark, const TWatermarksPattern& watermarksPattern)
         : Items(items)
         , YieldPos(yieldPos)
         , Index(index)
+        , Watermark(watermark)
+        , WatermarksPattern(watermarksPattern)
+        , WatermarkIndex(0)
     {
     }
 
@@ -39,6 +43,9 @@ private:
     TUnboxedValueVector Items;
     ui32 YieldPos;
     ui32 Index;
+    TWatermark& Watermark;
+    TWatermarksPattern WatermarksPattern;
+    ui32 WatermarkIndex;
 
     ui32 GetTraverseCount() const override {
         return 0;
@@ -60,13 +67,22 @@ private:
         if (Index == YieldPos) {
             return NUdf::EFetchStatus::Yield;
         }
+        if (WatermarkIndex < WatermarksPattern.size()) {
+            auto [patternIndex, patternValue] = WatermarksPattern[WatermarkIndex];
+            if (Index >= patternIndex) {
+                Watermark.WatermarkIn = patternValue;
+                return NUdf::EFetchStatus::Yield;
+            }
+        }
         result = Items[Index++];
         return NUdf::EFetchStatus::Ok;
     }
 };
 
 THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<std::tuple<ui32, i64, ui32>> items,
-                                      ui32 yieldPos, ui32 startIndex, bool dataWatermarks) {
+                                      ui32 yieldPos, ui32 startIndex, bool dataWatermarks,
+                                      bool withWatermarks, TWatermark& watermark,
+                                      const TWatermarksPattern& watermarksPattern) {
     TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
 
     auto structType = pgmBuilder.NewEmptyStructType();
@@ -125,17 +141,17 @@ THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<st
             return pgmBuilder.NewStruct(members);
         },
         [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
-            Y_UNUSED(time);
             std::vector<std::pair<std::string_view, TRuntimeNode>> members;
             members.emplace_back("key", key);
             members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
+            members.emplace_back("time", time);
             return pgmBuilder.NewStruct(members);
         },
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))),           // hop
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),       // delay
         pgmBuilder.NewDataLiteral<bool>(dataWatermarks),                                                                  // dataWatermarks
-        pgmBuilder.NewDataLiteral<bool>(false));
+        pgmBuilder.NewDataLiteral<bool>(withWatermarks));
 
     auto graph = setup.BuildGraph(pgmReturn, {streamNode});
 
@@ -149,7 +165,7 @@ THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<st
         streamItems.push_back(std::move(structValues));
     }
 
-    auto streamValue = NUdf::TUnboxedValuePod(new TStreamWithYield(streamItems, yieldPos, startIndex));
+    auto streamValue = NUdf::TUnboxedValuePod(new TStreamWithYield(streamItems, yieldPos, startIndex, watermark, watermarksPattern));
     graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
     return graph;
 }
@@ -158,16 +174,19 @@ THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<st
 Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingSaveLoadTest) {
 void TestWithSaveLoadImpl(
     const std::vector<std::tuple<ui32, i64, ui32>> input,
-    const std::vector<std::tuple<ui32, ui32>> expected,
+    const std::vector<std::tuple<ui32, ui32, ui64>> expected,
     bool withTraverse,
-    bool dataWatermarks)
+    bool dataWatermarks,
+    bool withWatermarks = false,
+    const TWatermarksPattern& watermarksPattern = {})
 {
     TWatermark watermark;
+    UNIT_ASSERT(!dataWatermarks || !withWatermarks);
     for (ui32 yieldPos = 0; yieldPos < input.size(); ++yieldPos) {
-        std::vector<std::tuple<ui32, ui32>> result;
+        std::vector<std::tuple<ui32, ui32, ui64>> result;
 
         TSetup<false> setup1(GetAuxCallableFactory(watermark));
-        auto graph1 = BuildGraph(setup1, input, yieldPos, 0, dataWatermarks);
+        auto graph1 = BuildGraph(setup1, input, yieldPos, 0, dataWatermarks, withWatermarks, watermark, watermarksPattern);
         auto root1 = graph1->GetValue();
 
         NUdf::EFetchStatus status = NUdf::EFetchStatus::Ok;
@@ -175,7 +194,7 @@ void TestWithSaveLoadImpl(
             NUdf::TUnboxedValue val;
             status = root1.Fetch(val);
             if (status == NUdf::EFetchStatus::Ok) {
-                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
+                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>(), val.GetElement(2).Get<ui64>());
             }
         }
         UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Yield);
@@ -188,7 +207,7 @@ void TestWithSaveLoadImpl(
         }
 
         TSetup<false> setup2(GetAuxCallableFactory(watermark));
-        auto graph2 = BuildGraph(setup2, input, -1, yieldPos, dataWatermarks);
+        auto graph2 = BuildGraph(setup2, input, -1, yieldPos, dataWatermarks, withWatermarks, watermark, watermarksPattern);
         NUdf::TUnboxedValue root2;
         if (withTraverse) {
             root2 = graph2->GetValue();
@@ -203,15 +222,16 @@ void TestWithSaveLoadImpl(
             NUdf::TUnboxedValue val;
             status = root2.Fetch(val);
             if (status == NUdf::EFetchStatus::Ok) {
-                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
+                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>(), val.GetElement(2).Get<ui64>());
             }
         }
         UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Finish);
 
+        auto copy = result;
         auto sortedExpected = expected;
         std::sort(result.begin(), result.end());
         std::sort(sortedExpected.begin(), sortedExpected.end());
-        UNIT_ASSERT_EQUAL(result, sortedExpected);
+        UNIT_ASSERT_EQUAL_C(result, sortedExpected, " withTraverse = " << withTraverse << " dataWatermarks = " << dataWatermarks << " withWatermarks = " << withWatermarks << " yieldPos = " << yieldPos);
     }
 }
 
@@ -240,22 +260,26 @@ const std::vector<std::tuple<ui32, i64, ui32>> input1 = {
     {2, 85, 8},
     {1, 85, 8}};
 
-const std::vector<std::tuple<ui32, ui32>> expected = {
-    {1, 8}, {1, 8}, {1, 8}, {1, 8},
-    {1, 11},
-    {1, 11},
-    {1, 21},
-    {1, 22},
-    {1, 27},
-    {2, 8},
-    {2, 8},
-    {2, 8},
-    {2, 8},
-    {2, 11},
-    {2, 11},
-    {2, 21},
-    {2, 22},
-    {2, 27}};
+const std::vector<std::tuple<ui32, ui32, ui64>> expected = {
+    {1, 8, 80},
+    {1, 8, 90},
+    {1, 8, 100},
+    {1, 8, 110},
+    {1, 11, 60},
+    {1, 11, 70},
+    {1, 21, 50},
+    {1, 22, 40},
+    {1, 27, 30},
+    {2, 8, 80},
+    {2, 8, 90},
+    {2, 8, 100},
+    {2, 8, 110},
+    {2, 11, 60},
+    {2, 11, 70},
+    {2, 21, 50},
+    {2, 22, 40},
+    {2, 27, 30},
+};
 
 Y_UNIT_TEST(Test1) {
     TestWithSaveLoadImpl(input1, expected, true, false);
@@ -263,6 +287,13 @@ Y_UNIT_TEST(Test1) {
 
 Y_UNIT_TEST(Test2) {
     TestWithSaveLoadImpl(input1, expected, false, false);
+}
+Y_UNIT_TEST(TestWatermark1) {
+    TestWithSaveLoadImpl(input1, expected, true, false, true);
+}
+
+Y_UNIT_TEST(TestWatermark2) {
+    TestWithSaveLoadImpl(input1, expected, false, false, true);
 }
 } // Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingSaveLoadTest)
 

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_ut.cpp
@@ -15,48 +15,277 @@
 namespace NKikimr::NMiniKQL {
 
 namespace {
-    struct TInputItem {
-        ui32 Key = 0;
-        i64 Time = 0;
-        ui32 Val = 0;
+struct TInputItem {
+    ui32 Key = 0;
+    i64 Time = 0;
+    ui32 Val = 0;
+};
+
+struct TOutputItem {
+    ui32 Key = 0;
+    ui32 Val = 0;
+    ui64 Time = 0;
+
+    constexpr auto operator<=>(const TOutputItem&) const = default;
+};
+
+[[maybe_unused]] IOutputStream& operator<<(IOutputStream& output, const TOutputItem& item) {
+    return output << "TItem{Key = " << item.Key << ", Val = " << item.Val << ", Time = " << item.Time << "}";
+}
+
+using TOutputGroup = std::vector<TOutputItem>;
+
+using TCheckCallback = std::function<void()>;
+
+using TStatsMap = TMap<TString, i64>;
+
+TStatsMap DefaultStatsMap = {
+    {"MultiHop_NewHopsCount", 0},
+    {"MultiHop_EarlyThrownEventsCount", 0},
+    {"MultiHop_LateThrownEventsCount", 0},
+    {"MultiHop_EmptyTimeCount", 0},
+    {"MultiHop_KeysCount", 1},
+};
+
+using TEncoder = std::function<NUdf::TUnboxedValue(const TInputItem&, const THolderFactory&)>;
+using TDecoder = std::function<TOutputItem(const NUdf::TUnboxedValue&)>;
+using TFetchCallback = std::function<NUdf::EFetchStatus(NUdf::TUnboxedValue&)>;
+using TFetchFactory = std::function<TFetchCallback(TUnboxedValueVector&&)>;
+
+TFetchFactory DefaultFetchFactory = [](TUnboxedValueVector&& input) -> TFetchCallback {
+    return [input = std::move(input),
+            inputIndex = 0ull](NUdf::TUnboxedValue& result) mutable -> NUdf::EFetchStatus {
+        if (inputIndex >= input.size()) {
+            return NUdf::EFetchStatus::Finish;
+        }
+        result = input[inputIndex++];
+        return NUdf::EFetchStatus::Ok;
     };
+};
 
-    struct TOutputItem {
-        ui32 Key = 0;
-        ui32 Val = 0;
-        ui64 Time = 0;
+TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
+    return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
+        if (callable.GetType()->GetName() == "MyStream") {
+            return new TExternalComputationNode(ctx.Mutables);
+        } else if (callable.GetType()->GetName() == "MultiHoppingCore") {
+            return WrapMultiHoppingCore(callable, ctx, watermark);
+        }
 
-        constexpr auto operator<=>(const TOutputItem&) const = default;
+        return GetBuiltinFactory()(callable, ctx);
     };
+}
 
-    [[maybe_unused]] IOutputStream& operator<<(IOutputStream& output, const TOutputItem& item) {
-        return output << "TItem{Key = " << item.Key << ", Val = " << item.Val << ", Time = " << item.Time << "}";
+using TSetupFactory = std::function<TSetup<false>()>;
+
+TWatermark GlobalWatermark;
+TSetupFactory DefaultSetupFactory = []() -> TSetup<false> {
+    return TSetup<false>(GetAuxCallableFactory(GlobalWatermark));
+};
+
+struct TStream: public NUdf::TBoxedValue {
+    TStream(TCheckCallback&& checkCallback, TFetchCallback&& fetchCallback)
+        : CheckCallback_(std::move(checkCallback))
+        , FetchCallback_(std::move(fetchCallback))
+    {
     }
 
-    using TOutputGroup = std::vector<TOutputItem>;
+private:
+    TCheckCallback CheckCallback_;
+    TFetchCallback FetchCallback_;
 
-    using TCheckCallback = std::function<void()>;
+private:
+    NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) final {
+        CheckCallback_();
+        return FetchCallback_(result);
+    }
+};
 
-    using TStatsMap = TMap<TString, i64>;
+std::tuple<TType*, TEncoder, TDecoder> BuildInputType(TSetup<false>& setup) {
+    TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
 
-    TStatsMap DefaultStatsMap = {
-        {"MultiHop_NewHopsCount", 0},
-        {"MultiHop_EarlyThrownEventsCount", 0},
-        {"MultiHop_LateThrownEventsCount", 0},
-        {"MultiHop_EmptyTimeCount", 0},
-        {"MultiHop_KeysCount", 1},
+    auto structType = pgmBuilder.NewEmptyStructType();
+    structType = pgmBuilder.NewStructType(structType, "key",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
+    structType = pgmBuilder.NewStructType(structType, "time",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<NUdf::TTimestamp>::Id));
+    structType = pgmBuilder.NewStructType(structType, "sum",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
+    auto keyIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("key");
+    auto timeIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("time");
+    auto sumIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("sum");
+
+    auto encode = [keyIndex, timeIndex, sumIndex](const TInputItem& input, const THolderFactory& holderFactory) -> NUdf::TUnboxedValue {
+        NUdf::TUnboxedValue* itemsPtr;
+        auto structValues = holderFactory.CreateDirectArrayHolder(3, itemsPtr);
+        itemsPtr[keyIndex] = NUdf::TUnboxedValuePod(input.Key);
+        itemsPtr[timeIndex] = NUdf::TUnboxedValuePod(input.Time);
+        itemsPtr[sumIndex] = NUdf::TUnboxedValuePod(input.Val);
+        return structValues;
     };
 
-    using TEncoder = std::function<NUdf::TUnboxedValue(const TInputItem&, const THolderFactory&)>;
-    using TDecoder = std::function<TOutputItem(const NUdf::TUnboxedValue&)>;
-    using TFetchCallback = std::function<NUdf::EFetchStatus(NUdf::TUnboxedValue&)>;
-    using TFetchFactory = std::function<TFetchCallback(TUnboxedValueVector&&)>;
+    auto decode = [keyIndex, timeIndex, sumIndex](const NUdf::TUnboxedValue& result) -> TOutputItem {
+        return {
+            result.GetElement(keyIndex).Get<ui32>(),
+            result.GetElement(sumIndex).Get<ui32>(),
+            result.GetElement(timeIndex).Get<ui64>(),
+        };
+    };
 
-    TFetchFactory DefaultFetchFactory = [](TUnboxedValueVector&& input) -> TFetchCallback {
-        return [
-            input = std::move(input),
-            inputIndex = 0ull
-        ](NUdf::TUnboxedValue& result) mutable -> NUdf::EFetchStatus {
+    return {structType, encode, decode};
+}
+
+THolder<IComputationGraph> BuildGraph(
+    TSetup<false>& setup,
+    TType* itemType,
+    ui64 hop,
+    ui64 interval,
+    ui64 delay,
+    bool dataWatermarks,
+    bool watermarkMode) {
+    TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
+
+    auto inStreamType = pgmBuilder.NewStreamType(itemType);
+
+    TCallableBuilder inStream(pgmBuilder.GetTypeEnvironment(), "MyStream", inStreamType);
+    auto streamNode = inStream.Build();
+
+    auto pgmReturn = pgmBuilder.MultiHoppingCore(
+        TRuntimeNode(streamNode, false),
+        [&](TRuntimeNode item) { // keyExtractor
+            return pgmBuilder.Member(item, "key");
+        },
+        [&](TRuntimeNode item) { // timeExtractor
+            return pgmBuilder.Member(item, "time");
+        },
+        [&](TRuntimeNode item) { // init
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", pgmBuilder.Member(item, "sum"));
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode item, TRuntimeNode state) { // update
+            auto add = pgmBuilder.AggrAdd(
+                pgmBuilder.Member(item, "sum"),
+                pgmBuilder.Member(state, "sum"));
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", add);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode state) { // save
+            return pgmBuilder.Member(state, "sum");
+        },
+        [&](TRuntimeNode savedState) { // load
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", savedState);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode state1, TRuntimeNode state2) { // merge
+            auto add = pgmBuilder.AggrAdd(
+                pgmBuilder.Member(state1, "sum"),
+                pgmBuilder.Member(state2, "sum"));
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", add);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("key", key);
+            members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
+            members.emplace_back("time", time);
+            return pgmBuilder.NewStruct(members);
+        },
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))),           // hop
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),       // delay
+        pgmBuilder.NewDataLiteral<bool>(dataWatermarks),
+        pgmBuilder.NewDataLiteral<bool>(watermarkMode));
+
+    return setup.BuildGraph(pgmReturn, {streamNode});
+}
+} // namespace
+
+Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingTest) {
+void TestImpl(
+    const std::vector<TInputItem>& input,
+    const std::vector<TOutputGroup>& expected,
+    const TStatsMap& expectedStatsMap,
+    ui64 hop = 10,
+    ui64 interval = 30,
+    ui64 delay = 20,
+    bool dataWatermarks = false,
+    bool watermarkMode = false,
+    TFetchFactory fetchFactory = DefaultFetchFactory,
+    TSetupFactory setupFactory = DefaultSetupFactory) {
+    auto setup = setupFactory();
+
+    auto [itemType, encode, decode] = BuildInputType(setup);
+
+    auto graph = BuildGraph(setup, itemType, hop, interval, delay, dataWatermarks, watermarkMode);
+
+    size_t index = 0;
+    std::vector<TOutputItem> actual;
+    auto checkCallback = [&expected, &index, &actual]() -> void {
+        UNIT_ASSERT_LT_C(index, expected.size(), index << " < " << expected.size());
+        auto expectedItems = expected[index];
+        std::ranges::sort(expectedItems);
+        std::ranges::sort(actual);
+        UNIT_ASSERT_VALUES_EQUAL_C(expectedItems, actual, index);
+        ++index;
+        actual.clear();
+    };
+
+    TUnboxedValueVector boxedInput;
+    for (size_t i = 0; i < input.size(); ++i) {
+        boxedInput.push_back(encode(input[i], graph->GetHolderFactory()));
+    }
+    auto fetchCallback = fetchFactory(std::move(boxedInput));
+
+    auto streamValue = NUdf::TUnboxedValuePod(new TStream(checkCallback, std::move(fetchCallback)));
+    graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
+
+    auto root = graph->GetValue();
+
+    auto status = NUdf::EFetchStatus::Ok;
+    while (NUdf::EFetchStatus::Finish != status) {
+        NUdf::TUnboxedValue result;
+        status = root.Fetch(result);
+        if (status == NUdf::EFetchStatus::Ok) {
+            actual.push_back(decode(result));
+        }
+    }
+
+    checkCallback();
+    UNIT_ASSERT_VALUES_EQUAL(expected.size(), index);
+
+    TStatsMap actualStatsMap;
+    setup.StatsRegistry->ForEachStat([&expectedStatsMap, &actualStatsMap](const TStatKey& key, i64 value) {
+        if (auto iter = expectedStatsMap.find(key.GetName());
+            iter != expectedStatsMap.end()) {
+            actualStatsMap.emplace(key.GetName(), value);
+        }
+    });
+    UNIT_ASSERT_VALUES_EQUAL(expectedStatsMap, actualStatsMap);
+}
+
+void TestWatermarksImpl(
+    const std::vector<TInputItem>& input,
+    const std::vector<TOutputGroup>& expected,
+    const std::vector<std::pair<ui64, TInstant>>& watermarks,
+    const TStatsMap& expectedStatsMap,
+    ui64 hop = 10,
+    ui64 interval = 30,
+    ui64 delay = 20) {
+    TWatermark watermark;
+    auto fetchFactory = [watermarks = watermarks, &watermark](TUnboxedValueVector input) -> TFetchCallback {
+        return [input = input,
+                inputIndex = 0ull,
+                watermarks = watermarks,
+                watermarkIndex = 0ull,
+                &watermark](NUdf::TUnboxedValue& result) mutable -> NUdf::EFetchStatus {
+            if (watermarkIndex < watermarks.size() && watermarks[watermarkIndex].first == inputIndex) {
+                watermark.WatermarkIn = watermarks[watermarkIndex].second;
+                ++watermarkIndex;
+                return NUdf::EFetchStatus::Yield;
+            }
             if (inputIndex >= input.size()) {
                 return NUdf::EFetchStatus::Finish;
             }
@@ -64,716 +293,503 @@ namespace {
             return NUdf::EFetchStatus::Ok;
         };
     };
-
-    TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
-        return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
-            if (callable.GetType()->GetName() == "MyStream") {
-                return new TExternalComputationNode(ctx.Mutables);
-            } else if (callable.GetType()->GetName() == "MultiHoppingCore") {
-                return WrapMultiHoppingCore(callable, ctx, watermark);
-            }
-
-            return GetBuiltinFactory()(callable, ctx);
-        };
-    }
-
-    using TSetupFactory = std::function<TSetup<false>()>;
-
-    TWatermark GlobalWatermark;
-    TSetupFactory DefaultSetupFactory = []() -> TSetup<false> {
-        return TSetup<false>(GetAuxCallableFactory(GlobalWatermark));
+    auto setupFactory = [&watermark]() -> TSetup<false> {
+        return TSetup<false>(GetAuxCallableFactory(watermark));
     };
-
-    struct TStream : public NUdf::TBoxedValue {
-        TStream(TCheckCallback&& checkCallback, TFetchCallback&& fetchCallback)
-            : CheckCallback_(std::move(checkCallback))
-            , FetchCallback_(std::move(fetchCallback))
-        {}
-
-    private:
-        TCheckCallback CheckCallback_;
-        TFetchCallback FetchCallback_;
-
-    private:
-        NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) final {
-            CheckCallback_();
-            return FetchCallback_(result);
-        }
-    };
-
-    std::tuple<TType*, TEncoder, TDecoder> BuildInputType(TSetup<false>& setup) {
-        TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-
-        auto structType = pgmBuilder.NewEmptyStructType();
-        structType = pgmBuilder.NewStructType(structType, "key",
-            pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
-        structType = pgmBuilder.NewStructType(structType, "time",
-            pgmBuilder.NewDataType(NUdf::TDataType<NUdf::TTimestamp>::Id));
-        structType = pgmBuilder.NewStructType(structType, "sum",
-            pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
-        auto keyIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("key");
-        auto timeIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("time");
-        auto sumIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("sum");
-
-        auto encode = [keyIndex, timeIndex, sumIndex](const TInputItem& input, const THolderFactory& holderFactory) -> NUdf::TUnboxedValue {
-            NUdf::TUnboxedValue* itemsPtr;
-            auto structValues = holderFactory.CreateDirectArrayHolder(3, itemsPtr);
-            itemsPtr[keyIndex] = NUdf::TUnboxedValuePod(input.Key);
-            itemsPtr[timeIndex] = NUdf::TUnboxedValuePod(input.Time);
-            itemsPtr[sumIndex] = NUdf::TUnboxedValuePod(input.Val);
-            return structValues;
-        };
-
-        auto decode = [keyIndex, timeIndex, sumIndex](const NUdf::TUnboxedValue& result) -> TOutputItem {
-            return {
-                result.GetElement(keyIndex).Get<ui32>(),
-                result.GetElement(sumIndex).Get<ui32>(),
-                result.GetElement(timeIndex).Get<ui64>(),
-            };
-        };
-
-        return {structType, encode, decode};
-    }
-
-    THolder<IComputationGraph> BuildGraph(
-        TSetup<false>& setup,
-        TType* itemType,
-        ui64 hop,
-        ui64 interval,
-        ui64 delay,
-        bool dataWatermarks,
-        bool watermarkMode
-    ) {
-        TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-
-        auto inStreamType = pgmBuilder.NewStreamType(itemType);
-
-        TCallableBuilder inStream(pgmBuilder.GetTypeEnvironment(), "MyStream", inStreamType);
-        auto streamNode = inStream.Build();
-
-        auto pgmReturn = pgmBuilder.MultiHoppingCore(
-            TRuntimeNode(streamNode, false),
-            [&](TRuntimeNode item) { // keyExtractor
-                return pgmBuilder.Member(item, "key");
-            },
-            [&](TRuntimeNode item) { // timeExtractor
-                return pgmBuilder.Member(item, "time");
-            },
-            [&](TRuntimeNode item) { // init
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", pgmBuilder.Member(item, "sum"));
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode item, TRuntimeNode state) { // update
-                auto add = pgmBuilder.AggrAdd(
-                    pgmBuilder.Member(item, "sum"),
-                    pgmBuilder.Member(state, "sum"));
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", add);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode state) { // save
-                return pgmBuilder.Member(state, "sum");
-            },
-            [&](TRuntimeNode savedState) { // load
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", savedState);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode state1, TRuntimeNode state2) { // merge
-                auto add = pgmBuilder.AggrAdd(
-                    pgmBuilder.Member(state1, "sum"),
-                    pgmBuilder.Member(state2, "sum"));
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", add);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("key", key);
-                members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
-                members.emplace_back("time", time);
-                return pgmBuilder.NewStruct(members);
-            },
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))), // hop
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),  // delay
-            pgmBuilder.NewDataLiteral<bool>(dataWatermarks),
-            pgmBuilder.NewDataLiteral<bool>(watermarkMode)
-        );
-
-        return setup.BuildGraph(pgmReturn, {streamNode});
-    }
+    TestImpl(
+        input,
+        expected,
+        expectedStatsMap,
+        hop,
+        interval,
+        delay,
+        false,
+        true,
+        fetchFactory,
+        setupFactory);
 }
 
-Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingTest) {
-    void TestImpl(
-        const std::vector<TInputItem>& input,
-        const std::vector<TOutputGroup>& expected,
-        const TStatsMap& expectedStatsMap,
-        ui64 hop = 10,
-        ui64 interval = 30,
-        ui64 delay = 20,
-        bool dataWatermarks = false,
-        bool watermarkMode = false,
-        TFetchFactory fetchFactory = DefaultFetchFactory,
-        TSetupFactory setupFactory = DefaultSetupFactory
-    ) {
-        auto setup = setupFactory();
+Y_UNIT_TEST(TestThrowWatermarkFromPast) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 2, 110},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 2, 120},
+            {1, 2, 130},
+            {1, 3, 140},
+            {1, 3, 150},
+            {1, 3, 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 4, 210},
+            {1, 4, 220},
+            {1, 4, 230},
+        }),
+        TOutputGroup({
+            {1, 5, 310},
+            {1, 5, 320},
+            {1, 5, 330},
+        }),
+        TOutputGroup({
+            {1, 6, 410},
+            {1, 6, 420},
+            {1, 6, 430},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {2, TInstant::MicroSeconds(20)},
+        {3, TInstant::MicroSeconds(40)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 15;
 
-        auto [itemType, encode, decode] = BuildInputType(setup);
-
-        auto graph = BuildGraph(setup, itemType, hop, interval, delay, dataWatermarks, watermarkMode);
-
-        size_t index = 0;
-        std::vector<TOutputItem> actual;
-        auto checkCallback = [&expected, &index, &actual]() -> void {
-            UNIT_ASSERT_LT_C(index, expected.size(), index << " < " << expected.size());
-            auto expectedItems = expected[index];
-            std::ranges::sort(expectedItems);
-            std::ranges::sort(actual);
-            UNIT_ASSERT_VALUES_EQUAL_C(expectedItems, actual, index);
-            ++index;
-            actual.clear();
-        };
-
-        TUnboxedValueVector boxedInput;
-        for (size_t i = 0; i < input.size(); ++i) {
-            boxedInput.push_back(encode(input[i], graph->GetHolderFactory()));
-        }
-        auto fetchCallback = fetchFactory(std::move(boxedInput));
-
-        auto streamValue = NUdf::TUnboxedValuePod(new TStream(checkCallback, std::move(fetchCallback)));
-        graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
-
-        auto root = graph->GetValue();
-
-        auto status = NUdf::EFetchStatus::Ok;
-        while (NUdf::EFetchStatus::Finish != status) {
-            NUdf::TUnboxedValue result;
-            status = root.Fetch(result);
-            if (status == NUdf::EFetchStatus::Ok) {
-                actual.push_back(decode(result));
-            }
-        }
-
-        checkCallback();
-        UNIT_ASSERT_VALUES_EQUAL(expected.size(), index);
-
-        TStatsMap actualStatsMap;
-        setup.StatsRegistry->ForEachStat([&expectedStatsMap, &actualStatsMap](const TStatKey& key, i64 value) {
-            if (auto iter = expectedStatsMap.find(key.GetName());
-                iter != expectedStatsMap.end()) {
-                actualStatsMap.emplace(key.GetName(), value);
-            }
-        });
-        UNIT_ASSERT_VALUES_EQUAL(expectedStatsMap, actualStatsMap);
-    }
-
-    void TestWatermarksImpl(
-        const std::vector<TInputItem>& input,
-        const std::vector<TOutputGroup>& expected,
-        const std::vector<std::pair<ui64, TInstant>>& watermarks,
-        const TStatsMap& expectedStatsMap,
-        ui64 hop = 10,
-        ui64 interval = 30,
-        ui64 delay = 20
-    ) {
-        TWatermark watermark;
-        auto fetchFactory = [watermarks = watermarks, &watermark](TUnboxedValueVector input) -> TFetchCallback {
-            return [
-                input = input,
-                inputIndex = 0ull,
-                watermarks = watermarks,
-                watermarkIndex = 0ull,
-                &watermark
-            ](NUdf::TUnboxedValue& result) mutable -> NUdf::EFetchStatus {
-                if (watermarkIndex < watermarks.size() && watermarks[watermarkIndex].first == inputIndex) {
-                    watermark.WatermarkIn = watermarks[watermarkIndex].second;
-                    ++watermarkIndex;
-                    return NUdf::EFetchStatus::Yield;
-                }
-                if (inputIndex >= input.size()) {
-                    return NUdf::EFetchStatus::Finish;
-                }
-                result = input[inputIndex++];
-                return NUdf::EFetchStatus::Ok;
-            };
-        };
-        auto setupFactory = [&watermark]() -> TSetup<false> {
-            return TSetup<false>(GetAuxCallableFactory(watermark));
-        };
-        TestImpl(
-            input,
-            expected,
-            expectedStatsMap,
-            hop,
-            interval,
-            delay,
-            false,
-            true,
-            fetchFactory,
-            setupFactory
-        );
-    }
-
-    Y_UNIT_TEST(TestThrowWatermarkFromPast) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {1, 131, 3},
-            {1, 200, 4},
-            {1, 300, 5},
-            {1, 400, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 2, 110},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 2, 120},
-                {1, 2, 130},
-                {1, 3, 140},
-                {1, 3, 150},
-                {1, 3, 160},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 4, 210},
-                {1, 4, 220},
-                {1, 4, 230},
-            }),
-            TOutputGroup({
-                {1, 5, 310},
-                {1, 5, 320},
-                {1, 5, 330},
-            }),
-            TOutputGroup({
-                {1, 6, 410},
-                {1, 6, 420},
-                {1, 6, 430},
-            })
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {2, TInstant::MicroSeconds(20)},
-            {3, TInstant::MicroSeconds(40)}
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 15;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestThrowWatermarkFromFuture) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {1, 131, 3},
-            {1, 200, 4},
-            {1, 300, 5},
-            {1, 400, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 2, 110},
-            }),
-            TOutputGroup({
-                {1, 2, 120},
-                {1, 2, 130},
-                {1, 3, 140},
-                {1, 3, 150},
-                {1, 3, 160},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({})
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {2, TInstant::MicroSeconds(1000)},
-            {3, TInstant::MicroSeconds(2000)}
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 6;
-        expectedStatsMap["MultiHop_LateThrownEventsCount"] = 3;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWatermarkFlow1) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {1, 131, 3},
-            {1, 200, 4},
-            {1, 300, 5},
-            {1, 400, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 2, 110},
-            }),
-            TOutputGroup({
-                {1, 2, 120},
-                {1, 2, 130},
-                {1, 3, 140},
-                {1, 3, 150},
-                {1, 3, 160},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 4, 210},
-                {1, 4, 220},
-                {1, 4, 230},
-            }),
-            TOutputGroup({
-                {1, 5, 310},
-                {1, 5, 320},
-                {1, 5, 330},
-            }),
-            TOutputGroup({
-                {1, 6, 410},
-                {1, 6, 420},
-                {1, 6, 430},
-            })
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {0, TInstant::MicroSeconds(100)},
-            {3, TInstant::MicroSeconds(200)}
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 15;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWatermarkFlow2) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 100, 2},
-            {1, 105, 3},
-            {1, 80, 4},
-            {1, 107, 5},
-            {1, 106, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 4, 90},
-                {1, 4, 100},
-                {1, 20, 110},
-                {1, 16, 120},
-                {1, 16, 130},
-            })
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {0, TInstant::MicroSeconds(76)},
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 5;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWatermarkFlow3) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 90, 2},
-            {1, 99, 3},
-            {1, 80, 4},
-            {1, 107, 5},
-            {1, 106, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 4, 90},
-                {1, 9, 100},
-                {1, 20, 110},
-                {1, 16, 120},
-                {1, 11, 130},
-            })
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {0, TInstant::MicroSeconds(76)},
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 5;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWatermarkFlowOverflow) {
-        // TODO this tests fails before this change, but it does not exercise
-        // exact expected bug scenario (hop stuck forever in the future)
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 1, 2},
-            {1, 2, 3},
-            {1, 5, 4},
-            {1, 6, 5},
-            {1, 7, 6},
-            {1, 8, 7},
-            {1, 9, 8},
-            {1, 10, 9},
-            {1, 11, 10},
-            {1, 22, 11},
-            {1, 23, 12},
-            {1, 24, 13},
-            {1, 100, 14},
-            {1, 117, 15},
-            {1, 121, 16},
-            {1, 126, 17},
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 90, 100},
-            }),
-            TOutputGroup({
-                {1, 69, 110},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 65, 120},
-            }),
-            TOutputGroup({
-                {1, 62, 130},
-                {1, 62, 140},
-                {1, 62, 150},
-                {1, 62, 160},
-                {1, 62, 170},
-                {1, 62, 180},
-                {1, 62, 190},
-                {1, 62, 200},
-                {1, 48, 210},
-                {1, 33, 220},
-            }),
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {9, TInstant::MicroSeconds(1)},
-            {12, TInstant::MicroSeconds(2)},
-            {14, TInstant::MicroSeconds(50)},
-            {15, TInstant::MicroSeconds(110)},
-            {16, TInstant::MicroSeconds(120)},
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 13;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap, 10, 100, 20);
-    }
-
-    Y_UNIT_TEST(TestDataWatermarks) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {2, 101, 2},
-            {1, 111, 3},
-            {2, 140, 5},
-            {2, 160, 1}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 2, 110}, {1, 5, 120}, {2, 2, 110}, {2, 2, 120}}),
-            TOutputGroup({{2, 2, 130}, {1, 5, 130}, {1, 3, 140}}),
-            TOutputGroup({{2, 5, 150}, {2, 5, 160}, {2, 6, 170}, {2, 1, 180}, {2, 1, 190}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 12;
-
-        TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true);
-    }
-
-    Y_UNIT_TEST(TestDataWatermarksNoGarbage) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 100, 2},
-            {2, 150, 1}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 2, 110}, {1, 2, 120}, {1, 2, 130}}),
-            TOutputGroup({{2, 1, 160}, {2, 1, 170}, {2, 1, 180}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 6;
-
-        TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true, false);
-    }
-
-    Y_UNIT_TEST(TestValidness1) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {2, 101, 2},
-            {1, 111, 3},
-            {2, 140, 5},
-            {2, 160, 1}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{2, 2, 110}, {2, 2, 120}}),
-            TOutputGroup({{2, 2, 130}}),
-            TOutputGroup({{1, 2, 110}, {1, 5, 120}, {1, 5, 130}, {1, 3, 140}, {2, 5, 150},
-                          {2, 5, 160}, {2, 6, 170}, {2, 1, 190}, {2, 1, 180}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 12;
-        expectedStatsMap["MultiHop_KeysCount"] = 2;
-
-        TestImpl(input, expected, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestValidness2) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {2, 101, 2}, {1, 101, 2}, {2, 102, 3}, {1, 102, 3}, {2, 115, 4},
-            {1, 115, 4}, {2, 123, 6}, {1, 123, 6}, {2, 124, 5}, {1, 124, 5},
-            {2, 125, 7}, {1, 125, 7}, {2, 140, 2}, {1, 140, 2}, {2, 147, 1},
-            {1, 147, 1}, {2, 151, 6}, {1, 151, 6}, {2, 159, 2}, {1, 159, 2},
-            {2, 185, 8}, {1, 185, 8}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{1, 5, 110}, {1, 9, 120}, {2, 5, 110}, {2, 9, 120}}),
-            TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{2, 27, 130}, {1, 27, 130}}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{2, 22, 140}, {2, 21, 150},  {2, 11, 160}, {1, 22, 140}, {1, 21, 150}, {1, 11, 160}}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 11, 170}, {1, 8, 180}, {1, 8, 190}, {1, 8, 200}, {1, 8, 210}, {2, 11, 170},
-                          {2, 8, 180}, {2, 8, 190}, {2, 8, 200}, {2, 8, 210}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 22;
-        expectedStatsMap["MultiHop_KeysCount"] = 2;
-
-        TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true);
-    }
-
-    Y_UNIT_TEST(TestValidness3) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 105, 1}, {1, 107, 4}, {2, 106, 3}, {1, 111, 7}, {1, 117, 3},
-            {2, 110, 2}, {1, 108, 9}, {1, 121, 4}, {2, 107, 2}, {2, 141, 5},
-            {1, 141, 10}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{1, 14, 110}, {2, 3, 110}}),
-            TOutputGroup({}),
-            TOutputGroup({{2, 7, 115}, {2, 2, 120}, {1, 21, 115}, {1, 10, 120}, {1, 7, 125}, {1, 4, 130}}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 10, 145}, {1, 10, 150}, {2, 5, 145}, {2, 5, 150}})
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 12;
-        expectedStatsMap["MultiHop_KeysCount"] = 2;
-
-        TestImpl(input, expected, expectedStatsMap, 5, 10, 10, true);
-    }
-
-    Y_UNIT_TEST(TestDelay) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 3}, {1, 111, 5}, {1, 120, 7}, {1, 80, 9}, {1, 79, 11}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{1, 12, 110}, {1, 8, 120}, {1, 15, 130}, {1, 12, 140}, {1, 7, 150}})
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 5;
-        expectedStatsMap["MultiHop_LateThrownEventsCount"] = 1;
-
-        TestImpl(input, expected, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWindowsBeforeFirstElement) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2}, {1, 111, 3}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 2, 110}, {1, 5, 120}, {1, 5, 130}, {1, 3, 140}})
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 4;
-
-        TestImpl(input, expected, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestSubzeroValues) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 1, 2}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 2, 30}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 1;
-
-        TestImpl(input, expected, expectedStatsMap);
-    }
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
 }
+
+Y_UNIT_TEST(TestThrowWatermarkFromFuture) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 2, 110},
+        }),
+        TOutputGroup({
+            {1, 2, 120},
+            {1, 2, 130},
+            {1, 3, 140},
+            {1, 3, 150},
+            {1, 3, 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({})};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {2, TInstant::MicroSeconds(1000)},
+        {3, TInstant::MicroSeconds(2000)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 6;
+    expectedStatsMap["MultiHop_LateThrownEventsCount"] = 3;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWatermarkFlow1) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 2, 110},
+        }),
+        TOutputGroup({
+            {1, 2, 120},
+            {1, 2, 130},
+            {1, 3, 140},
+            {1, 3, 150},
+            {1, 3, 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 4, 210},
+            {1, 4, 220},
+            {1, 4, 230},
+        }),
+        TOutputGroup({
+            {1, 5, 310},
+            {1, 5, 320},
+            {1, 5, 330},
+        }),
+        TOutputGroup({
+            {1, 6, 410},
+            {1, 6, 420},
+            {1, 6, 430},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 15;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWatermarkFlow2) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 100, 2},
+        {1, 105, 3},
+        {1, 80, 4},
+        {1, 107, 5},
+        {1, 106, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 4, 90},
+            {1, 4, 100},
+            {1, 20, 110},
+            {1, 16, 120},
+            {1, 16, 130},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(76)},
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 5;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWatermarkFlow3) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 90, 2},
+        {1, 99, 3},
+        {1, 80, 4},
+        {1, 107, 5},
+        {1, 106, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 4, 90},
+            {1, 9, 100},
+            {1, 20, 110},
+            {1, 16, 120},
+            {1, 11, 130},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(76)},
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 5;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWatermarkFlowOverflow) {
+    // TODO this tests fails before this change, but it does not exercise
+    // exact expected bug scenario (hop stuck forever in the future)
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 1, 2},
+        {1, 2, 3},
+        {1, 5, 4},
+        {1, 6, 5},
+        {1, 7, 6},
+        {1, 8, 7},
+        {1, 9, 8},
+        {1, 10, 9},
+        {1, 11, 10},
+        {1, 22, 11},
+        {1, 23, 12},
+        {1, 24, 13},
+        {1, 100, 14},
+        {1, 117, 15},
+        {1, 121, 16},
+        {1, 126, 17},
+    };
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 90, 100},
+        }),
+        TOutputGroup({
+            {1, 69, 110},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 65, 120},
+        }),
+        TOutputGroup({
+            {1, 62, 130},
+            {1, 62, 140},
+            {1, 62, 150},
+            {1, 62, 160},
+            {1, 62, 170},
+            {1, 62, 180},
+            {1, 62, 190},
+            {1, 62, 200},
+            {1, 48, 210},
+            {1, 33, 220},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {9, TInstant::MicroSeconds(1)},
+        {12, TInstant::MicroSeconds(2)},
+        {14, TInstant::MicroSeconds(50)},
+        {15, TInstant::MicroSeconds(110)},
+        {16, TInstant::MicroSeconds(120)},
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 13;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap, 10, 100, 20);
+}
+
+Y_UNIT_TEST(TestDataWatermarks) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {2, 101, 2},
+        {1, 111, 3},
+        {2, 140, 5},
+        {2, 160, 1}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 2, 110}, {1, 5, 120}, {2, 2, 110}, {2, 2, 120}}),
+        TOutputGroup({{2, 2, 130}, {1, 5, 130}, {1, 3, 140}}),
+        TOutputGroup({{2, 5, 150}, {2, 5, 160}, {2, 6, 170}, {2, 1, 180}, {2, 1, 190}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 12;
+
+    TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true);
+}
+
+Y_UNIT_TEST(TestDataWatermarksNoGarbage) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 100, 2},
+        {2, 150, 1}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 2, 110}, {1, 2, 120}, {1, 2, 130}}),
+        TOutputGroup({{2, 1, 160}, {2, 1, 170}, {2, 1, 180}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 6;
+
+    TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true, false);
+}
+
+Y_UNIT_TEST(TestValidness1) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {2, 101, 2},
+        {1, 111, 3},
+        {2, 140, 5},
+        {2, 160, 1}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{2, 2, 110}, {2, 2, 120}}),
+        TOutputGroup({{2, 2, 130}}),
+        TOutputGroup({{1, 2, 110}, {1, 5, 120}, {1, 5, 130}, {1, 3, 140}, {2, 5, 150},
+                      {2, 5, 160},
+                      {2, 6, 170},
+                      {2, 1, 190},
+                      {2, 1, 180}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 12;
+    expectedStatsMap["MultiHop_KeysCount"] = 2;
+
+    TestImpl(input, expected, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestValidness2) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {2, 101, 2},
+        {1, 101, 2},
+        {2, 102, 3},
+        {1, 102, 3},
+        {2, 115, 4},
+        {1, 115, 4},
+        {2, 123, 6},
+        {1, 123, 6},
+        {2, 124, 5},
+        {1, 124, 5},
+        {2, 125, 7},
+        {1, 125, 7},
+        {2, 140, 2},
+        {1, 140, 2},
+        {2, 147, 1},
+        {1, 147, 1},
+        {2, 151, 6},
+        {1, 151, 6},
+        {2, 159, 2},
+        {1, 159, 2},
+        {2, 185, 8},
+        {1, 185, 8}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 5, 110}, {1, 9, 120}, {2, 5, 110}, {2, 9, 120}}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{2, 27, 130}, {1, 27, 130}}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{2, 22, 140}, {2, 21, 150}, {2, 11, 160}, {1, 22, 140}, {1, 21, 150}, {1, 11, 160}}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 11, 170}, {1, 8, 180}, {1, 8, 190}, {1, 8, 200}, {1, 8, 210}, {2, 11, 170},
+                      {2, 8, 180},
+                      {2, 8, 190},
+                      {2, 8, 200},
+                      {2, 8, 210}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 22;
+    expectedStatsMap["MultiHop_KeysCount"] = 2;
+
+    TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true);
+}
+
+Y_UNIT_TEST(TestValidness3) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 105, 1},
+        {1, 107, 4},
+        {2, 106, 3},
+        {1, 111, 7},
+        {1, 117, 3},
+        {2, 110, 2},
+        {1, 108, 9},
+        {1, 121, 4},
+        {2, 107, 2},
+        {2, 141, 5},
+        {1, 141, 10}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
+        TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
+        TOutputGroup({{1, 14, 110}, {2, 3, 110}}),
+        TOutputGroup({}),
+        TOutputGroup({{2, 7, 115}, {2, 2, 120}, {1, 21, 115}, {1, 10, 120}, {1, 7, 125}, {1, 4, 130}}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 10, 145}, {1, 10, 150}, {2, 5, 145}, {2, 5, 150}})};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 12;
+    expectedStatsMap["MultiHop_KeysCount"] = 2;
+
+    TestImpl(input, expected, expectedStatsMap, 5, 10, 10, true);
+}
+
+Y_UNIT_TEST(TestDelay) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 3},
+        {1, 111, 5},
+        {1, 120, 7},
+        {1, 80, 9},
+        {1, 79, 11}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
+        TOutputGroup({}), TOutputGroup({}),
+        TOutputGroup({{1, 12, 110}, {1, 8, 120}, {1, 15, 130}, {1, 12, 140}, {1, 7, 150}})};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 5;
+    expectedStatsMap["MultiHop_LateThrownEventsCount"] = 1;
+
+    TestImpl(input, expected, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWindowsBeforeFirstElement) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 111, 3}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 2, 110}, {1, 5, 120}, {1, 5, 130}, {1, 3, 140}})};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 4;
+
+    TestImpl(input, expected, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestSubzeroValues) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 1, 2}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 2, 30}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 1;
+
+    TestImpl(input, expected, expectedStatsMap);
+}
+} // Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingTest)
 
 } // namespace NKikimr::NMiniKQL

--- a/yql/essentials/minikql/computation/mkql_computation_node_holders.h
+++ b/yql/essentials/minikql/computation/mkql_computation_node_holders.h
@@ -34,6 +34,8 @@ template <typename Type, EMemorySubPool MemoryPool = EMemorySubPool::Default>
 using TMKQLVector = std::vector<Type, TMKQLAllocator<Type, MemoryPool>>;
 template<typename Key, typename T, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>, EMemorySubPool MemoryPool = EMemorySubPool::Default>
 using TMKQLHashMap = std::unordered_map<Key, T, Hash, KeyEqual, TMKQLAllocator<std::pair<const Key, T>, MemoryPool>>;
+template <typename Key, typename T, typename TComp = std::less<Key>, EMemorySubPool MemoryPool = EMemorySubPool::Default>
+using TMKQLMap = std::map<Key, T, TComp, TMKQLAllocator<std::pair<const Key, T>, MemoryPool>>;
 
 using TKeyTypes = std::vector<std::pair<NUdf::EDataSlot, bool>>;
 using TUnboxedValueVector = std::vector<NUdf::TUnboxedValue, TMKQLAllocator<NUdf::TUnboxedValue>>;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

[f98cdc1](https://github.com/ydb-platform/ydb/pull/30226/commits/f98cdc1319309916c228bab55183a4b21bd2a397)
is pure cherry-pick from main (part of import from arcadia)
[adb79ad](https://github.com/ydb-platform/ydb/pull/30226/commits/adb79addf030ef23fa00a8c17ea8a1a8c6409af4)
is trimmed commit cb77d014972b2cdb27d2e6d979fc3a2772b27ad4 from main (cosmetics/style/reformat only; unfortunately, it also depends on some code altered in main, so cannot be completely applied; I only took *multihopping* parts)