### PR TITLE
Fix S3 data loss in BlobDepot

### DIFF
--- a/ydb/core/blob_depot/data.cpp
+++ b/ydb/core/blob_depot/data.cpp
@@ -808,6 +808,7 @@ namespace NKikimr::NBlobDepot {
     }
 
     bool TData::IsUseful(const TS3Locator& locator) const {
+        Y_DEBUG_ABORT_UNLESS(IsLoaded());
         return RefCountS3.contains(locator);
     }
 

--- a/ydb/core/blob_depot/data_load.cpp
+++ b/ydb/core/blob_depot/data_load.cpp
@@ -204,6 +204,7 @@ namespace NKikimr::NBlobDepot {
 
     void TBlobDepot::OnDataLoadComplete() {
         BarrierServer->OnDataLoaded();
+        S3Manager->OnDataLoaded();
         StartGroupAssimilator();
         TabletCounters->Simple()[NKikimrBlobDepot::COUNTER_MODE_LOADING_KEYS] = 0;
         TabletCounters->Simple()[NKikimrBlobDepot::COUNTER_MODE_LOADED] = 1;

--- a/ydb/core/blob_depot/s3.cpp
+++ b/ydb/core/blob_depot/s3.cpp
@@ -21,10 +21,11 @@ namespace NKikimr::NBlobDepot {
             Bucket = settings->GetSettings().GetBucket();
             SyncMode = settings->HasSyncMode();
             AsyncMode = settings->HasAsyncMode();
-            RunScannerActor();
+            Enabled = true;
         } else {
             SyncMode = false;
             AsyncMode = false;
+            Enabled = false;
         }
     }
 
@@ -45,6 +46,12 @@ namespace NKikimr::NBlobDepot {
             fFunc(TEvPrivate::EvDeleteResult, HandleDeleter)
             fFunc(TEvPrivate::EvScanFound, HandleScanner)
         )
+    }
+
+    void TS3Manager::OnDataLoaded() {
+        if (Enabled) {
+            RunScannerActor();
+        }
     }
 
     void TBlobDepot::InitS3Manager() {

--- a/ydb/core/blob_depot/s3.h
+++ b/ydb/core/blob_depot/s3.h
@@ -13,6 +13,7 @@ namespace NKikimr::NBlobDepot {
         TString BasePath;
         TString Bucket;
 
+        bool Enabled = false;
         bool SyncMode = false;
         bool AsyncMode = false;
 
@@ -37,6 +38,8 @@ namespace NKikimr::NBlobDepot {
 
         ui64 GetTotalS3TrashObjects() const { return TotalS3TrashObjects; }
         ui64 GetTotalS3TrashSize() const { return TotalS3TrashSize; }
+
+        void OnDataLoaded();
 
     private: ///////////////////////////////////////////////////////////////////////////////////////////////////////////
         class TTxPrepareWriteS3;

--- a/ydb/core/blob_depot/s3_windows_stub.cpp
+++ b/ydb/core/blob_depot/s3_windows_stub.cpp
@@ -43,6 +43,8 @@ namespace NKikimr::NBlobDepot {
         Y_ABORT("S3 is not supported on Windows");
     }
 
+    void TBlobDepot::OnDataLoaded() {}
+
     void TBlobDepot::InitS3Manager() {
         S3Manager->Init(Config.HasS3BackendSettings() ? &Config.GetS3BackendSettings() : nullptr);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix S3 data loss in BlobDepot

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes possible data loss during S3 blob depot bootup induced by race between loading index and scanning S3 storage for files.
