### PR TITLE
Fix potential data race in BlobDepot

### DIFF
--- a/ydb/core/blob_depot/agent.cpp
+++ b/ydb/core/blob_depot/agent.cpp
@@ -35,6 +35,7 @@ namespace NKikimr::NBlobDepot {
         for (TS3Locator locator : agent.S3WritesInFlight) {
             // they were not in InFlightTrashS3, so we just have to delete them
             S3Manager->AddTrashToCollect(locator);
+            Data->RemoveS3WriteInFlight(locator);
         }
         agent.S3WritesInFlight.clear();
     }

--- a/ydb/core/blob_depot/data.cpp
+++ b/ydb/core/blob_depot/data.cpp
@@ -809,7 +809,16 @@ namespace NKikimr::NBlobDepot {
 
     bool TData::IsUseful(const TS3Locator& locator) const {
         Y_DEBUG_ABORT_UNLESS(IsLoaded());
-        return RefCountS3.contains(locator);
+        return RefCountS3.contains(locator) || S3WritesInFlight.contains(locator);
+    }
+
+    void TData::AddS3WriteInFlight(TS3Locator locator) {
+        S3WritesInFlight.insert(locator);
+    }
+
+    void TData::RemoveS3WriteInFlight(TS3Locator locator) {
+        const size_t n = S3WritesInFlight.erase(locator);
+        Y_ABORT_UNLESS(n == 1);
     }
 
 } // NKikimr::NBlobDepot

--- a/ydb/core/blob_depot/data.h
+++ b/ydb/core/blob_depot/data.h
@@ -459,6 +459,7 @@ namespace NKikimr::NBlobDepot {
         TClosedIntervalSet<TKey> LoadedKeys; // keys that are already scanned and loaded in the local database
         THashMap<TLogoBlobID, ui32> RefCountBlobs;
         THashMap<TS3Locator, ui32> RefCountS3;
+        THashSet<TS3Locator> S3WritesInFlight;
         THashMap<std::tuple<ui8, ui32>, TRecordsPerChannelGroup> RecordsPerChannelGroup;
         std::optional<TLogoBlobID> LastAssimilatedBlobId;
         THashSet<std::tuple<ui8, ui32>> AlreadyCutHistory;
@@ -718,6 +719,9 @@ namespace NKikimr::NBlobDepot {
         bool CanBeCollected(TBlobSeqId id) const;
 
         void OnLeastExpectedBlobIdChange(ui8 channel);
+
+        void AddS3WriteInFlight(TS3Locator locator);
+        void RemoveS3WriteInFlight(TS3Locator locator);
 
         template<typename TCallback>
         void EnumerateRefCount(TCallback&& callback) {

--- a/ydb/core/blob_depot/op_commit_blob_seq.cpp
+++ b/ydb/core/blob_depot/op_commit_blob_seq.cpp
@@ -77,6 +77,7 @@ namespace NKikimr::NBlobDepot {
                             const size_t numErased = agent.S3WritesInFlight.erase(locator);
                             Y_ABORT_UNLESS(numErased);
                             Self->S3Manager->AddTrashToCollect(locator);
+                            Self->Data->RemoveS3WriteInFlight(locator);
                         }
                     };
 
@@ -177,6 +178,7 @@ namespace NKikimr::NBlobDepot {
                             // remove item from agent's inflight
                             const size_t numErased = agent.S3WritesInFlight.erase(locator);
                             Y_ABORT_UNLESS(numErased == 1);
+                            Self->Data->RemoveS3WriteInFlight(locator);
 
                             Self->TabletCounters->Cumulative()[NKikimrBlobDepot::COUNTER_S3_PUTS_OK] += 1;
                             Self->TabletCounters->Cumulative()[NKikimrBlobDepot::COUNTER_S3_PUTS_BYTES] += locator.Len;
@@ -244,6 +246,7 @@ namespace NKikimr::NBlobDepot {
             const size_t numErased = agent.S3WritesInFlight.erase(locator);
             Y_ABORT_UNLESS(numErased == 1);
             S3Manager->AddTrashToCollect(locator);
+            Data->RemoveS3WriteInFlight(locator);
         }
     }
 

--- a/ydb/core/blob_depot/s3_write.cpp
+++ b/ydb/core/blob_depot/s3_write.cpp
@@ -58,6 +58,7 @@ namespace NKikimr::NBlobDepot {
 
                     const bool inserted = agent.S3WritesInFlight.insert(locator).second;
                     Y_ABORT_UNLESS(inserted);
+                    Self->Data->AddS3WriteInFlight(locator);
                 }
             }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix potential data race in BlobDepot

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch prevents potential data race which may occur when file has been enumerated in S3 for the key that is still being in write-in-flight state.
