### PR TITLE
heap-use-after-free in a PQ tablet

### DIFF
--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -5217,6 +5217,7 @@ void TPersQueue::BeginDeletePartitions(const TWriteId& writeId, TTxWriteInfo& wr
         PQ_LOG_TX_D("Already deleting WriteInfo");
         return;
     }
+    writeInfo.Deleting = true;
     if (writeInfo.Partitions.empty()) {
         TryDeleteWriteId(writeId, writeInfo, ActorContext());
     } else {
@@ -5227,7 +5228,6 @@ void TPersQueue::BeginDeletePartitions(const TWriteId& writeId, TTxWriteInfo& wr
             Send(partition.Actor, new TEvPQ::TEvDeletePartition);
         }
     }
-    writeInfo.Deleting = true;
 }
 
 void TPersQueue::BeginDeletePartitions(const TDistributedTransaction& tx)

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -5220,6 +5220,7 @@ void TPersQueue::BeginDeletePartitions(const TWriteId& writeId, TTxWriteInfo& wr
     writeInfo.Deleting = true;
     if (writeInfo.Partitions.empty()) {
         TryDeleteWriteId(writeId, writeInfo, ActorContext());
+        TxWritesChanged = true;
     } else {
         for (auto& [_, partitionId] : writeInfo.Partitions) {
             PQ_ENSURE(Partitions.contains(partitionId));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue #30258

The BeginDeletePartitions method uses a value that can previously be deleted in TryDeleteWriteId.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
