### PR TITLE
Separate DeleteQueue to allow reusing only current-generation locators

### DIFF
--- a/ydb/core/blob_depot/data_load.cpp
+++ b/ydb/core/blob_depot/data_load.cpp
@@ -110,12 +110,16 @@ namespace NKikimr::NBlobDepot {
         if (!rows.IsReady()) {
             return false;
         }
+        const ui32 generation = Self->Executor()->Generation();
         while (rows.IsValid()) {
             TS3Locator item{
                 .Len = rows.GetValue<Schema::TrashS3::Len>(),
                 .Generation = rows.GetValue<Schema::TrashS3::Generation>(),
                 .KeyId = rows.GetValue<Schema::TrashS3::KeyId>(),
             };
+            if (item.Generation == generation) {
+                return true; // we don't want to read newly added items by this tablet's generation
+            }
             if (item != from) {
                 Self->S3Manager->AddTrashToCollect(item);
                 from = item;

--- a/ydb/core/blob_depot/s3.h
+++ b/ydb/core/blob_depot/s3.h
@@ -69,7 +69,9 @@ namespace NKikimr::NBlobDepot {
         static constexpr ui32 MaxDeletesInFlight = 3;
         static constexpr size_t MaxObjectsToDeleteAtOnce = 10;
 
-        std::deque<TS3Locator> DeleteQueue; // items we are definitely going to delete (must be present in TrashS3)
+        // items we are definitely going to delete (must be present in TrashS3)
+        std::deque<TS3Locator> DeleteQueueInPrevGenerations;
+        std::deque<TS3Locator> DeleteQueueInCurrentGeneration;
         THashSet<TActorId> ActiveDeleters;
         ui32 NumDeleteTxInFlight = 0;
         ui64 TotalS3TrashObjects = 0;

--- a/ydb/core/blob_depot/s3_write.cpp
+++ b/ydb/core/blob_depot/s3_write.cpp
@@ -98,9 +98,9 @@ namespace NKikimr::NBlobDepot {
     };
 
     TS3Locator TS3Manager::AllocateS3Locator(ui32 len) {
-        if (!DeleteQueue.empty()) {
-            TS3Locator res = DeleteQueue.front();
-            DeleteQueue.pop_front();
+        if (!DeleteQueueInCurrentGeneration.empty()) {
+            TS3Locator res = DeleteQueueInCurrentGeneration.front();
+            DeleteQueueInCurrentGeneration.pop_front();
             Self->TabletCounters->Simple()[NKikimrBlobDepot::COUNTER_TOTAL_S3_TRASH_OBJECTS] = --TotalS3TrashObjects;
             Self->TabletCounters->Simple()[NKikimrBlobDepot::COUNTER_TOTAL_S3_TRASH_SIZE] = TotalS3TrashSize -= res.Len;
             res.Len = len;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Separate DeleteQueue to allow reusing only current-generation locators

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch removes possibility for potential data race occuring with previous-generation agent trying to write blob that is being collected with fresh-generation BlobDepot (which may be reused and contain inconsistent data as a result).
