### PR TITLE
EXT-1270 Add --mon-key option with the same meaning as the --ic-key/--grpc-key options

### DIFF
--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -297,6 +297,7 @@ struct TCommonAppOptions {
     ui32 MonitoringThreads = 10;
     ui32 MonitoringMaxRequestsPerSecond = 0;
     TString MonitoringCertificateFile;
+    TString MonitoringPrivateKeyFile;
     TString RestartsCountFile = "";
     size_t CompileInflightLimit = 100000; // MiniKQLCompileService
     TString UDFsDir;
@@ -393,7 +394,8 @@ struct TCommonAppOptions {
             .RequiredArgument("NAME").StoreResult(&TenantName);
         opts.AddLongOption("mon-port", "Monitoring port").OptionalArgument("NUM").StoreResult(&MonitoringPort);
         opts.AddLongOption("mon-address", "Monitoring address").OptionalArgument("ADDR").StoreResult(&MonitoringAddress);
-        opts.AddLongOption("mon-cert", "Monitoring certificate (https)").OptionalArgument("PATH").StoreResult(&MonitoringCertificateFile);
+        opts.AddLongOption("mon-cert", "Path to monitoring certificate file (https)").OptionalArgument("PATH").StoreResult(&MonitoringCertificateFile);
+        opts.AddLongOption("mon-key", "Path to monitoring private key file (https)").OptionalArgument("PATH").StoreResult(&MonitoringPrivateKeyFile);
         opts.AddLongOption("mon-threads", "Monitoring http server threads").RequiredArgument("NUM").StoreResult(&MonitoringThreads);
         opts.AddLongOption("suppress-version-check", "Suppress version compatibility checking via IC").NoArgument().SetFlag(&SuppressVersionCheck);
 
@@ -598,13 +600,12 @@ struct TCommonAppOptions {
             ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::MonitoringConfigItem, TConfigItemInfo::EUpdateKind::UpdateExplicitly);
         }
         if (MonitoringCertificateFile) {
-            TString sslCertificate = TUnbufferedFileInput(MonitoringCertificateFile).ReadAll();
-            if (!sslCertificate.empty()) {
-                appConfig.MutableMonitoringConfig()->SetMonitoringCertificate(sslCertificate);
-                ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::MonitoringConfigItem, TConfigItemInfo::EUpdateKind::UpdateExplicitly);
-            } else {
-                ythrow yexception() << "invalid ssl certificate file";
-            }
+            appConfig.MutableMonitoringConfig()->SetMonitoringCertificateFile(MonitoringCertificateFile);
+            ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::MonitoringConfigItem, TConfigItemInfo::EUpdateKind::UpdateExplicitly);
+        }
+        if (MonitoringPrivateKeyFile) {
+            appConfig.MutableMonitoringConfig()->SetMonitoringPrivateKeyFile(MonitoringPrivateKeyFile);
+            ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::MonitoringConfigItem, TConfigItemInfo::EUpdateKind::UpdateExplicitly);
         }
         if (SqsHttpPort) {
             appConfig.MutableSqsConfig()->MutableHttpServerConfig()->SetPort(SqsHttpPort);

--- a/ydb/core/driver_lib/run/config_parser.cpp
+++ b/ydb/core/driver_lib/run/config_parser.cpp
@@ -265,7 +265,8 @@ void TRunCommandConfigParser::ParseRunOpts(int argc, char **argv) {
     opts.AddLongOption("proxy", "Bind to proxy(-ies)").RequiredArgument("ADDR").AppendTo(&RunOpts.ProxyBindToProxy);
     opts.AddLongOption("mon-port", "Monitoring port").OptionalArgument("NUM").StoreResult(&RunOpts.MonitoringPort);
     opts.AddLongOption("mon-address", "Monitoring address").OptionalArgument("ADDR").StoreResult(&RunOpts.MonitoringAddress);
-    opts.AddLongOption("mon-cert", "Monitoring certificate (https)").OptionalArgument("PATH").StoreResult(&RunOpts.MonitoringCertificateFile);
+    opts.AddLongOption("mon-cert", "Path to monitoring certificate file (https)").OptionalArgument("PATH").StoreResult(&RunOpts.MonitoringCertificateFile);
+    opts.AddLongOption("mon-key", "Path to monitoring private key file (https)").OptionalArgument("PATH").StoreResult(&RunOpts.MonitoringPrivateKeyFile);
     opts.AddLongOption("mon-threads", "Monitoring http server threads").RequiredArgument("NUM").StoreResult(&RunOpts.MonitoringThreads);
 
     SetupLastGetOptForConfigFiles(opts);
@@ -371,7 +372,8 @@ void TRunCommandConfigParser::ApplyParsedOptions() {
     Config.AppConfig.MutableMonitoringConfig()->SetMonitoringThreads(RunOpts.MonitoringThreads);
     Config.AppConfig.MutableMonitoringConfig()->SetMaxRequestsPerSecond(RunOpts.MonitoringMaxRequestsPerSecond);
     Config.AppConfig.MutableMonitoringConfig()->SetInactivityTimeout(ToString(RunOpts.MonitoringInactivityTimeout.Seconds()));
-    Config.AppConfig.MutableMonitoringConfig()->SetMonitoringCertificate(TUnbufferedFileInput(RunOpts.MonitoringCertificateFile).ReadAll());
+    Config.AppConfig.MutableMonitoringConfig()->SetMonitoringCertificateFile(RunOpts.MonitoringCertificateFile);
+    Config.AppConfig.MutableMonitoringConfig()->SetMonitoringPrivateKeyFile(RunOpts.MonitoringPrivateKeyFile);
     Config.AppConfig.MutableRestartsCountConfig()->SetRestartsCountFile(RunOpts.RestartsCountFile);
 }
 

--- a/ydb/core/driver_lib/run/config_parser.h
+++ b/ydb/core/driver_lib/run/config_parser.h
@@ -49,6 +49,7 @@ protected:
         ui32 MonitoringPort;
         TString MonitoringAddress;
         TString MonitoringCertificateFile;
+        TString MonitoringPrivateKeyFile;
         ui32 MonitoringThreads;
         ui32 MonitoringMaxRequestsPerSecond;
         TDuration MonitoringInactivityTimeout;

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -611,9 +611,8 @@ void TKikimrRunner::InitializeMonitoring(const TKikimrRunConfig& runConfig, bool
         monConfig.Certificate = appConfig.GetMonitoringConfig().GetMonitoringCertificate();
         monConfig.MaxRequestsPerSecond = appConfig.GetMonitoringConfig().GetMaxRequestsPerSecond();
         monConfig.InactivityTimeout = TDuration::Parse(appConfig.GetMonitoringConfig().GetInactivityTimeout());
-        if (appConfig.GetMonitoringConfig().HasMonitoringCertificateFile()) {
-            monConfig.Certificate = TUnbufferedFileInput(appConfig.GetMonitoringConfig().GetMonitoringCertificateFile()).ReadAll();
-        }
+        monConfig.CertificateFile = appConfig.GetMonitoringConfig().GetMonitoringCertificateFile();
+        monConfig.PrivateKeyFile = appConfig.GetMonitoringConfig().GetMonitoringPrivateKeyFile();
         monConfig.RedirectMainPageTo = appConfig.GetMonitoringConfig().GetRedirectMainPageTo();
         if (includeHostName) {
             if (appConfig.HasNameserviceConfig() && appConfig.GetNameserviceConfig().NodeSize() > 0) {

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1441,7 +1441,7 @@ std::future<void> TMon::Start(TActorSystem* actorSystem) {
     addPort->SslCertificatePem = Config.Certificate;
     addPort->CertificateFile = Config.CertificateFile;
     addPort->PrivateKeyFile = Config.PrivateKeyFile;
-    addPort->Secure = !Config.Certificate.empty() || !Config.CertificateFile.empty() || !Config.PrivateKeyFile.empty();
+    addPort->Secure = !Config.Certificate.empty() || !Config.CertificateFile.empty();
     addPort->MaxRequestsPerSecond = Config.MaxRequestsPerSecond;
 
     std::promise<void> promise;

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1439,7 +1439,9 @@ std::future<void> TMon::Start(TActorSystem* actorSystem) {
         "application/yaml",
     };
     addPort->SslCertificatePem = Config.Certificate;
-    addPort->Secure = !Config.Certificate.empty();
+    addPort->CertificateFile = Config.CertificateFile;
+    addPort->PrivateKeyFile = Config.PrivateKeyFile;
+    addPort->Secure = !Config.Certificate.empty() || !Config.CertificateFile.empty() || !Config.PrivateKeyFile.empty();
     addPort->MaxRequestsPerSecond = Config.MaxRequestsPerSecond;
 
     std::promise<void> promise;

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -35,7 +35,9 @@ public:
         TRequestAuthorizer Authorizer = DefaultAuthorizer;
         TVector<TString> AllowedSIDs;
         TString RedirectMainPageTo;
-        TString Certificate;
+        TString Certificate; // certificate/private key data in PEM format
+        TString CertificateFile; // certificate file path in PEM format // can contain private key if PrivateKeyFile is not set
+        TString PrivateKeyFile; // private key file path for the certificate in PEM format
         ui32 MaxRequestsPerSecond = 0;
         TDuration InactivityTimeout = TDuration::Minutes(2);
         TString AllowOrigin;

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -36,7 +36,7 @@ public:
         TVector<TString> AllowedSIDs;
         TString RedirectMainPageTo;
         TString Certificate; // certificate/private key data in PEM format
-        TString CertificateFile; // certificate file path in PEM format // can contain private key if PrivateKeyFile is not set
+        TString CertificateFile; // certificate file path in PEM format (OpenSSL feature: may optionally contain both certificate chain and private key in the same PEM file if PrivateKeyFile is not set)
         TString PrivateKeyFile; // private key file path for the certificate in PEM format
         ui32 MaxRequestsPerSecond = 0;
         TDuration InactivityTimeout = TDuration::Minutes(2);

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -609,6 +609,7 @@ message TMonitoringConfig {
     optional string RedirectMainPageTo = 13 [default = "monitoring/"];
     optional string MonitoringCertificate = 14 [(Ydb.sensitive) = true];
     optional string MonitoringCertificateFile = 15;
+    optional string MonitoringPrivateKeyFile = 20;
     optional string MemAllocDumpPathPrefix = 16;
     optional uint32 MaxRequestsPerSecond = 17 [default = 0];
     optional string InactivityTimeout = 18 [default = "2m"];

--- a/ydb/library/actors/http/http_proxy_ssl.h
+++ b/ydb/library/actors/http/http_proxy_ssl.h
@@ -61,7 +61,8 @@ struct TSslHelpers {
             // TODO(xenoxeno): more diagnostics?
             return nullptr;
         }
-        res = SSL_CTX_use_PrivateKey_file(ctx.Get(), key.c_str(), SSL_FILETYPE_PEM);
+        // Load key. The key can be set through explicit key field or with the same file with certificate
+        res = SSL_CTX_use_PrivateKey_file(ctx.Get(), key.empty() ? certificate.c_str() : key.c_str(), SSL_FILETYPE_PEM);
         if (res < 0) {
             // TODO(xenoxeno): more diagnostics?
             return nullptr;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

For all other TLS connections we have several options: --xx-key and --xx-cert: separate options for certificate and key. The aim of this PR is to do the same for monitoring options.
