### PR TITLE
Fix missing read locks when updating keys which don't exist

### DIFF
--- a/ydb/core/kqp/ut/tx/kqp_sink_locks_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_locks_ut.cpp
@@ -542,8 +542,7 @@ Y_UNIT_TEST_SUITE(KqpSinkLocks) {
                     UPDATE KV ON (Key, Value) VALUES (0u, "TEST"); -- exists
                 )"), TTxControl::Tx(*tx1).CommitTx()).ExtractValueSync();
 
-                // TODO: Must be ABORTED.
-                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), GetIsOlap() ? EStatus::ABORTED : EStatus::SUCCESS, result.GetIssues().ToString());
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());
             }
 
             {
@@ -553,14 +552,8 @@ Y_UNIT_TEST_SUITE(KqpSinkLocks) {
                 )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
                 UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
-                // TODO: Must be "OTHER" for both rows.
-                if (GetIsOlap()) {
-                    CompareYson(R"([[0u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(0)));
-                    CompareYson(R"([[0u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(1)));
-                } else {
-                    CompareYson(R"([[0u;["TEST"]]])", FormatResultSetYson(result.GetResultSet(0)));
-                    CompareYson(R"([[0u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(1)));
-                }
+                CompareYson(R"([[0u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(0)));
+                CompareYson(R"([[0u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(1)));
             }
         }
     };
@@ -607,8 +600,7 @@ Y_UNIT_TEST_SUITE(KqpSinkLocks) {
                     UPDATE KV ON (Key, Value) VALUES (0u, "TEST"); -- exists
                 )"), TTxControl::Tx(*tx1).CommitTx()).ExtractValueSync();
 
-                // TODO: Must be ABORTED.
-                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), GetIsOlap() ? EStatus::ABORTED : EStatus::SUCCESS, result.GetIssues().ToString());
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());
             }
 
             {
@@ -618,14 +610,8 @@ Y_UNIT_TEST_SUITE(KqpSinkLocks) {
                 )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
                 UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
-                // TODO: Must be "OTHER" for both rows.
-                if (GetIsOlap()) {
-                    CompareYson(R"([[0u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(0)));
-                    CompareYson(R"([[4u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(1)));
-                } else {
-                    CompareYson(R"([[0u;["TEST"]]])", FormatResultSetYson(result.GetResultSet(0)));
-                    CompareYson(R"([[4u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(1)));
-                }
+                CompareYson(R"([[0u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(0)));
+                CompareYson(R"([[4u;["OTHER"]]])", FormatResultSetYson(result.GetResultSet(1)));
             }
         }
     };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix missing optimistic read locks when using update operations over keys which don't exist. Fixes #30169.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

When kqp uses `TEvWrite` with `OPERATION_UPDATE` rows which don't exist in the snapshot are not updated. However, due to an error read lock was not obtained either, which made it possible for conflicting writes to insert new rows, which would go undetected by previous `OPERATION_UPDATE` writes, and allow non-serializable commits.