### PR TITLE
Fix possible schemeshard crash on reboot because of missing sequence AlterData persistence

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_sequence.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_sequence.cpp
@@ -532,6 +532,7 @@ public:
 
         sequencePath->PathState = TPathElement::EPathState::EPathStateAlter;
         sequencePath->LastTxId = OperationId.GetTxId();
+        context.SS->PersistSequenceAlter(db, dstPath->PathId, *alterData);
         context.SS->PersistLastTxId(db, sequencePath);
         context.SS->PersistTxState(db, OperationId);
 


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Поймал в процессе отладки #30180.

Тест проверил - без исправления падает. Падение было после ребуте на Propose операции AlterSequence с формулировкой:
```
2025-12-08T12:11:39.577323Z node 300 :FLAT_TX_SCHEMESHARD INFO: schemeshard__operation_alter_sequence.cpp:93: TAlterSequence TConfigureParts operationId# 281474976710762:0 ProgressState, at schemeshard: 72057594046678944

VERIFY failed (2025-12-08T12:11:39.577338Z): 
  ydb/core/tx/schemeshard/schemeshard__operation_alter_sequence.cpp:105
  ProgressState(): requirement alterData failed
```

Потому что схемная операция персистилась, а AlterData нет.