### PR TITLE
Properly handle no-user and the system user with Resource Pool Classifiers

### DIFF
--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.cpp
@@ -98,8 +98,8 @@ TClassifierSettings TResourcePoolClassifierConfig::GetClassifierSettings() const
     resourcePoolClassifierSettings.Rank = Rank;
 
     const auto& properties = resourcePoolClassifierSettings.GetPropertiesMap();
-    for (const auto& [propery, value] : ConfigJson.GetMap()) {
-        const auto it = properties.find(propery);
+    for (const auto& [property, value] : ConfigJson.GetMap()) {
+        const auto it = properties.find(property);
         if (it == properties.end()) {
             continue;
         }

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -467,20 +467,30 @@ public:
     }
 
     TString GetPoolId(const TString& databaseId, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, TActorContext actorContext) {
-        if (userToken && userToken->IsSystemUser()) {
-            return NResourcePool::DEFAULT_POOL_ID;
+        TString resultPoolId;
+        i64 resultRank;
+
+        const bool isSystemUser = userToken && userToken->IsSystemUser();
+        TDatabaseInfo& databaseInfo = *GetOrCreateDatabaseInfo(databaseId);
+
+        if (!isSystemUser) {
+            auto userSID = userToken ? userToken->GetUserSID() : NACLib::TSID();
+            std::tie(resultPoolId, resultRank) = GetPoolIdFromClassifiers(databaseId, userSID, databaseInfo, userToken, actorContext);
         }
 
-        const auto userSID = userToken ? userToken->GetUserSID() : NACLib::TSID();
-
-        TDatabaseInfo& databaseInfo = *GetOrCreateDatabaseInfo(databaseId);
-        auto [resultPoolId, resultRank] = GetPoolIdFromClassifiers(databaseId, userSID, databaseInfo, userToken, actorContext);
-        for (const auto& userSID : userToken->GetGroupSIDs()) {
-            const auto& [poolId, rank] = GetPoolIdFromClassifiers(databaseId, userSID, databaseInfo, userToken, actorContext);
-            if (poolId && (!resultPoolId || resultRank > rank)) {
+        // System user maybe just default unspecified user like "user@system", so if there are group sids then check them first.
+        // TODO: explicitly distinguish "no user but has group" vs "real system user".
+        for (const auto& groupSID : userToken->GetGroupSIDs()) {
+            const auto& [poolId, rank] = GetPoolIdFromClassifiers(databaseId, groupSID, databaseInfo, userToken, actorContext);
+            if (poolId && (resultPoolId.empty() || resultRank > rank)) {
                 resultPoolId = poolId;
                 resultRank = rank;
             }
+        }
+
+        // System user by default always goes to the default pool.
+        if (isSystemUser && resultPoolId.empty()) {
+            return NResourcePool::DEFAULT_POOL_ID;
         }
 
         return resultPoolId ? resultPoolId : NResourcePool::DEFAULT_POOL_ID;
@@ -601,7 +611,7 @@ private:
             return it->second;
         }
 
-        TString poolId = "";
+        TString poolId = ""; // TODO: use optional or replace with DEFAULT_POOL
         i64 rank = -1;
         for (const auto& [_, classifier] : databaseInfo.RankToClassifierInfo) {
             if (classifier.MemberName.value_or(userSID) != userSID) {

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -467,12 +467,14 @@ public:
     }
 
     TString GetPoolId(const TString& databaseId, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, TActorContext actorContext) {
-        if (!userToken || userToken->GetUserSID().empty()) {
+        if (userToken && userToken->IsSystemUser()) {
             return NResourcePool::DEFAULT_POOL_ID;
         }
 
+        const auto userSID = userToken ? userToken->GetUserSID() : NACLib::TSID();
+
         TDatabaseInfo& databaseInfo = *GetOrCreateDatabaseInfo(databaseId);
-        auto [resultPoolId, resultRank] = GetPoolIdFromClassifiers(databaseId, userToken->GetUserSID(), databaseInfo, userToken, actorContext);
+        auto [resultPoolId, resultRank] = GetPoolIdFromClassifiers(databaseId, userSID, databaseInfo, userToken, actorContext);
         for (const auto& userSID : userToken->GetGroupSIDs()) {
             const auto& [poolId, rank] = GetPoolIdFromClassifiers(databaseId, userSID, databaseInfo, userToken, actorContext);
             if (poolId && (!resultPoolId || resultRank > rank)) {

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -891,11 +891,11 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
     Y_UNIT_TEST(TestMultiGroupClassification) {
         auto ydb = TYdbSetupSettings().Create();
 
-        auto settings = TQueryRunnerSettings().PoolId("");
+        auto settings = TQueryRunnerSettings().PoolId("").UserSID("no@user");
 
         const TString& poolId = "my_pool";
-        const TString& firstSID = "first@user";
-        const TString& secondSID = "second@user";
+        const TString& firstSID = "first@group";
+        const TString& secondSID = "second@group";
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
             CREATE RESOURCE POOL )" << poolId << R"( WITH (
                 CONCURRENT_QUERY_LIMIT=0
@@ -910,6 +910,8 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
                 MEMBER_NAME=")" << secondSID << R"(",
                 RANK=2
             );
+            GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << firstSID << R"(`, `)" << secondSID << R"(`
+            ;
         )");
 
         WaitForFail(ydb, settings.GroupSIDs({firstSID}), poolId);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Now no-user will match the empty member name in resource pool classifier and the system user won't

### Changelog category <!-- remove all except one -->

* Improvement