### PR TITLE
Fixed receiving a request timeout error during kafka production

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -415,7 +415,6 @@ void TKafkaProduceActor::Handle(TEvPartitionWriter::TEvWriteAccepted::TPtr reque
     expectedCookies.erase(cookie);
 
     if (expectedCookies.empty()) {
-        Become(&TKafkaProduceActor::StateWork);
         ProcessRequests(ctx);
     } else {
         KAFKA_LOG_W("Still in accepting after receive TEvPartitionWriter::TEvWriteAccepted cause cookies are expected: " << JoinSeq(", ", expectedCookies));

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -487,7 +487,7 @@ bool TKafkaProduceActor::WriterDied(const TActorId& writerId, EKafkaErrors error
             info.Request->WaitAcceptingCookies.erase(cookie);
             info.Request->WaitResultCookies.erase(cookie);
 
-            if (info.Request->WaitAcceptingCookies.empty() && info.Request->WaitResultCookies.empty()) {
+            if (info.Request->WaitResultCookies.empty()) {
                 SendResults(ActorContext());
             }
 

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -43,7 +43,7 @@ void TKafkaProduceActor::LogEvent(IEventHandle& ev) {
 void TKafkaProduceActor::SendMetrics(const TString& topicName, size_t delta, const TString& name, const TActorContext& ctx) {
     TString topic = "unknown";
 
-    auto it = Topics.find(topicName);
+    auto it = Topics.find(NormalizePath(Context->DatabasePath, topicName));
     if (it != Topics.end() && it->second.Status != ETopicStatus::NOT_FOUND) {
         topic = it->first;
     }

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -615,6 +615,10 @@ protected:
             OnRequestProcessed(request);
         }
 
+        if (!CloseConnection && Step == INFLIGTH_CHECK) {
+            DoRead(ctx);
+        }
+
         return true;
     }
 
@@ -866,6 +870,10 @@ protected:
                 OnRequestProcessed(request);
                 KAFKA_LOG_D("Sent reply (after retry): ApiKey=" << header.RequestApiKey << ", Version=" << header.RequestApiVersion << ", Correlation=" << header.CorrelationId);
                 ProcessReplyQueue(ctx);
+
+                if (!CloseConnection && Step == INFLIGTH_CHECK) {
+                    DoRead(ctx);
+                }
             }
         }
 

--- a/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
@@ -330,7 +330,31 @@ namespace {
             auto response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
             UNIT_ASSERT(response);
             UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::NOT_LEADER_OR_FOLLOWER);
-            UNIT_ASSERT_VALUES_EQUAL(std::dynamic_pointer_cast<NKafka::TProduceResponseData>(response->Response)->Responses[0].PartitionResponses[0].ErrorCode, NKafka::EKafkaErrors::NOT_LEADER_OR_FOLLOWER);
+            UNIT_ASSERT_VALUES_EQUAL(std::dynamic_pointer_cast<NKafka::TProduceResponseData>(response->Response)->Responses[0].PartitionResponses[0].ErrorCode,
+                NKafka::EKafkaErrors::NOT_LEADER_OR_FOLLOWER);
+        }
+
+        Y_UNIT_TEST(OnProduce_ManyRequests) {
+            i64 producerId = 1;
+            i32 producerEpoch = 2;
+
+            SendProduce({}, producerId, producerEpoch, 1);
+            SendProduce({}, producerId, producerEpoch, 2);
+
+            {
+                auto response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+                UNIT_ASSERT(response);
+                UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(std::dynamic_pointer_cast<NKafka::TProduceResponseData>(response->Response)->Responses[0].PartitionResponses[0].ErrorCode,
+                    NKafka::EKafkaErrors::NONE_ERROR);
+            }
+            {
+                auto response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+                UNIT_ASSERT(response);
+                UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::NONE_ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(std::dynamic_pointer_cast<NKafka::TProduceResponseData>(response->Response)->Responses[0].PartitionResponses[0].ErrorCode,
+                    NKafka::EKafkaErrors::NONE_ERROR);
+            }
         }
     }
 } // anonymous namespace


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The error could occur if multiple topics were produced within the same Kafka connection.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10178
