### PR TITLE
Test vectors should not be proportional

### DIFF
--- a/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
+++ b/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
@@ -389,7 +389,7 @@ Y_UNIT_TEST_SUITE(KqpKnn) {
                     (1, Untag(Knn::ToBinaryStringFloat([1.0f, 2.0f, 3.0f]), "FloatVector")),
                     (2, Untag(Knn::ToBinaryStringFloat([4.0f, 5.0f, 6.0f]), "FloatVector")),
                     (3, Untag(Knn::ToBinaryStringFloat([7.0f, 8.0f, 9.0f]), "FloatVector")),
-                    (4, Untag(Knn::ToBinaryStringFloat([10.0f, 11.0f, 12.0f]), "FloatVector")),
+                    (4, Untag(Knn::ToBinaryStringFloat([10.0f, 20.0f, 30.0f]), "FloatVector")),
                     (5, Untag(Knn::ToBinaryStringFloat([13.0f, 14.0f, 15.0f]), "FloatVector")),
                     (6, Untag(Knn::ToBinaryStringFloat([100.0f, 110.0f, 120.0f]), "FloatVector"));
                 )";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The test expects PK 6 to be the exact match because that's the vector that matches the target exactly. But PK 4 [10, 11, 12] is proportional to the target [100, 110, 120], so it has the same cosine similarity.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
