### PR TITLE
Do not reuse S3 locators in BlobDepot

### DIFF
--- a/ydb/core/blob_depot/agent/agent_impl.h
+++ b/ydb/core/blob_depot/agent/agent_impl.h
@@ -449,7 +449,7 @@ namespace NKikimr::NBlobDepot {
             using TFinishCallback = std::function<void(std::optional<TString>, const char*)>;
             void IssueReadS3(const TString& key, ui32 offset, ui32 len, TFinishCallback finish, ui64 readId);
 
-            TActorId IssueWriteS3(TString&& key, TRope&& buffer, TLogoBlobID id);
+            TActorId IssueWriteS3(TString&& key, TRope&& buffer, TLogoBlobID id, TS3Locator locator);
 
         protected: // reading logic
             struct TReadContext;

--- a/ydb/core/blob_depot/agent/storage_put.cpp
+++ b/ydb/core/blob_depot/agent/storage_put.cpp
@@ -361,12 +361,13 @@ namespace NKikimr::NBlobDepot {
 
                 LocatorInFlight.emplace(TS3Locator::FromProto(*locator));
 
-                TString key = TS3Locator::FromProto(*locator).MakeObjectName(Agent.S3BasePath);
+                const TS3Locator temp = TS3Locator::FromProto(*locator);
+                TString key = temp.MakeObjectName(Agent.S3BasePath);
 
                 STLOG(PRI_DEBUG, BLOB_DEPOT_AGENT, BDA54, "starting WriteActor", (AgentId, Agent.LogId),
                     (QueryId, GetQueryId()), (Key, key));
 
-                WriterActorId = IssueWriteS3(std::move(key), std::move(Request.Buffer), Request.Id);
+                WriterActorId = IssueWriteS3(std::move(key), std::move(Request.Buffer), Request.Id, temp);
 
                 ConnectionInstanceOnStart = Agent.ConnectionInstance;
 #else

--- a/ydb/core/blob_depot/s3.h
+++ b/ydb/core/blob_depot/s3.h
@@ -70,8 +70,7 @@ namespace NKikimr::NBlobDepot {
         static constexpr size_t MaxObjectsToDeleteAtOnce = 10;
 
         // items we are definitely going to delete (must be present in TrashS3)
-        std::deque<TS3Locator> DeleteQueueInPrevGenerations;
-        std::deque<TS3Locator> DeleteQueueInCurrentGeneration;
+        std::deque<TS3Locator> DeleteQueue;
         THashSet<TActorId> ActiveDeleters;
         ui32 NumDeleteTxInFlight = 0;
         ui64 TotalS3TrashObjects = 0;

--- a/ydb/core/blob_depot/s3_scan.cpp
+++ b/ydb/core/blob_depot/s3_scan.cpp
@@ -193,6 +193,8 @@ namespace NKikimr::NBlobDepot {
                         const bool allow = locator->Generation < generation;
                         STLOG(PRI_DEBUG, BLOB_DEPOT, BDTS15, "TEvScanFound: found key", (Id, Self->GetLogId()),
                             (Locator, *locator), (Useful, useful), (Allow, allow), (Error, error));
+                        BDEV(BDEV35, "scan_S3_found_key", (BDT, Self->TabletID()), (Locator, *locator), (Useful, useful),
+                            (Allow, allow));
                         if (!useful && allow) {
                             trash.insert(*locator);
                         }

--- a/ydb/core/blob_depot/s3_write.cpp
+++ b/ydb/core/blob_depot/s3_write.cpp
@@ -98,14 +98,6 @@ namespace NKikimr::NBlobDepot {
     };
 
     TS3Locator TS3Manager::AllocateS3Locator(ui32 len) {
-        if (!DeleteQueueInCurrentGeneration.empty()) {
-            TS3Locator res = DeleteQueueInCurrentGeneration.front();
-            DeleteQueueInCurrentGeneration.pop_front();
-            Self->TabletCounters->Simple()[NKikimrBlobDepot::COUNTER_TOTAL_S3_TRASH_OBJECTS] = --TotalS3TrashObjects;
-            Self->TabletCounters->Simple()[NKikimrBlobDepot::COUNTER_TOTAL_S3_TRASH_SIZE] = TotalS3TrashSize -= res.Len;
-            res.Len = len;
-            return res;
-        }
         return {
             .Len = len,
             .Generation = Self->Executor()->Generation(),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Do not reuse S3 locators in BlobDepot

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Locator reuse code has been removes as it may lead to data races with long writes at agent side.
