### PR TITLE
[NBS] Add VhostDiscardEnabled flag to volume config

### DIFF
--- a/ydb/core/protos/blockstore_config.proto
+++ b/ydb/core/protos/blockstore_config.proto
@@ -140,6 +140,10 @@ message TVolumeConfig {
 
     // Mount requests with incorrect FillGeneration will be rejected unless filling is finished.
     optional uint64 FillGeneration = 51;
+
+    // Enables discard (ZeroBlocks) requests for the volume.
+    // If this flag is set, it should never be unset anymore!
+    optional bool VhostDiscardEnabled = 52;
 }
 
 message TUpdateVolumeConfig {


### PR DESCRIPTION
We (NBS) are going to enable the discard feature for NBS disks. To deploy it safely, we need to be able to turn on this feature at the volume level. To do this, we need to add the corresponding flag to the VolumeConfig.