### PR TITLE
Move collect counters logic to grpc client side

### DIFF
--- a/ydb/public/api/protos/ydb_monitoring.proto
+++ b/ydb/public/api/protos/ydb_monitoring.proto
@@ -241,6 +241,7 @@ message ClusterStateRequest {
     uint32 duration_seconds = 2;
     uint32 period_seconds = 3;
     bool no_sanitize = 4;
+    bool counters_only = 5;
 }
 
 message ClusterStateResponse {

--- a/ydb/public/lib/ydb_cli/commands/ydb_diagnostics.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_diagnostics.h
@@ -2,7 +2,7 @@
 
 #include "ydb_command.h"
 #include "ydb_common.h"
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_bridge.h>
+#include <library/cpp/streams/bzip2/bzip2.h>
 #include <ydb/public/lib/ydb_cli/common/format.h>
 
 #include <util/generic/string.h>
@@ -23,6 +23,8 @@ public:
     int Run(TConfig& config) override;
 
 private:
+    void ProcessState(TConfig& config, TBZipCompress& compress, ui32 index = 0);
+
     ui32 DurationSeconds = 0;
     ui32 PeriodSeconds = 0;
     TString FileName;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/monitoring/monitoring.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/monitoring/monitoring.h
@@ -39,6 +39,7 @@ struct TClusterStateSettings : public TOperationRequestSettings<TClusterStateSet
     FLUENT_SETTING_OPTIONAL(uint32_t, DurationSeconds);
     FLUENT_SETTING_OPTIONAL(uint32_t, PeriodSeconds);
     FLUENT_SETTING_OPTIONAL(bool, NoSanitize);
+    FLUENT_SETTING_OPTIONAL(bool, CountersOnly);
 };
 
 

--- a/ydb/public/sdk/cpp/src/client/monitoring/monitoring.cpp
+++ b/ydb/public/sdk/cpp/src/client/monitoring/monitoring.cpp
@@ -115,6 +115,10 @@ public:
         if (settings.NoSanitize_) {
             request.set_no_sanitize(settings.NoSanitize_.value());
         }
+
+        if (settings.CountersOnly_) {
+            request.set_counters_only(settings.CountersOnly_.value());
+        }
         auto promise = NThreading::NewPromise<TClusterStateResult>();
 
         auto extractor = [promise]


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

To reduce memory consumption on nodes - request counters on grpc client side and write them to file immediately

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
