### PR TITLE
[NOT-FOR-MERGE-YET] dq: propagate watermark settings from sources to graph

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -2528,6 +2528,13 @@ void TKqpTasksGraph::BuildReadTasksFromSource(TStageInfo& stageInfo, const TVect
             input.ConnectionInfo = NYql::NDq::TSourceInput{};
             input.SourceSettings = externalSource.GetSettings();
             input.SourceType = externalSource.GetType();
+            if (externalSource.HasWatermarksSettings()) {
+                const auto& watermarksSettings = externalSource.GetWatermarksSettings();
+                input.WatermarksMode = NYql::NDqProto::EWatermarksMode::WATERMARKS_MODE_DEFAULT;
+                if (watermarksSettings.HasIdleTimeoutUs()) {
+                    input.WatermarksIdleTimeoutUs = watermarksSettings.GetIdleTimeoutUs();
+                }
+            }
         }
 
         FillReadTaskFromSource(task, sourceName, structuredToken, resourceSnapshot, nodeOffset++);

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -1234,9 +1234,6 @@ TMaybe<TKqlQueryList> BuildKqlQuery(TKiDataQueryBlocks dataQueryBlocks, const TK
                             if (kqpCtx->Config->EnableWatermarks) {
                                 wrSettings = {
                                     .WatermarksMode = "default",
-                                    .WatermarksGranularityMs = 1000,
-                                    .WatermarksLateArrivalDelayMs = 5000,
-                                    .WatermarksEnableIdlePartitions = false,
                                 };
                             }
                             auto newRead = dqIntegration->WrapRead(input.Cast().Ptr(), ctx, wrSettings);

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1442,7 +1442,14 @@ private:
 
             google::protobuf::Any& settings = *externalSource.MutableSettings();
             TString& sourceType = *externalSource.MutableType();
-            dqIntegration->FillSourceSettings(*source, settings, sourceType, maxTasksPerStage, ctx);
+            IDqIntegration::TSourceWatermarksSettings watermarksSettings;
+            dqIntegration->FillSourceSettings(*source, settings, sourceType, maxTasksPerStage, ctx, watermarksSettings);
+            if (watermarksSettings.Enabled) {
+                auto& protoWatermarksSettings = *externalSource.MutableWatermarksSettings();
+                if (watermarksSettings.IdleTimeoutUs) {
+                    protoWatermarksSettings.SetIdleTimeoutUs(*watermarksSettings.IdleTimeoutUs);
+                }
+            }
             YQL_ENSURE(!settings.type_url().empty(), "Data source provider \"" << dataSourceCategory << "\" didn't fill dq source settings for its dq source node");
             YQL_ENSURE(sourceType, "Data source provider \"" << dataSourceCategory << "\" didn't fill dq source settings type for its dq source node");
         } else {

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -463,6 +463,11 @@ message TKqpExternalSource {
 
     string SourceName = 5;
     string AuthInfo = 6;
+
+    message TWatermarksSettings {
+        optional uint64 IdleTimeoutUs = 1;
+    };
+    optional TWatermarksSettings WatermarksSettings = 8;
 }
 
 message TKqpSource {

--- a/ydb/library/yql/dq/tasks/dq_tasks_graph.h
+++ b/ydb/library/yql/dq/tasks/dq_tasks_graph.h
@@ -387,7 +387,7 @@ public:
         return sourceType == "PqSource"; // Now it is the only infinite source type. Others are finite.
     }
 
-    void BuildCheckpointingAndWatermarksMode(bool enableCheckpoints, bool enableWatermarks, TMaybe<ui64> watermarksIdleTimeoutUs = Nothing()) {
+    void BuildCheckpointingAndWatermarksMode(bool enableCheckpoints, bool enableWatermarks) {
         if (!enableCheckpoints && !enableWatermarks) {
             return;
         }
@@ -453,13 +453,9 @@ public:
             if (enableWatermarks) {
                 for (auto& input : task.Inputs) {
                     if (input.SourceType) {
-                        if (IsInfiniteSourceType(input.SourceType)) {
-                            if (input.WatermarksMode == NDqProto::WATERMARKS_MODE_DEFAULT) {
-                                watermarksMode = NDqProto::WATERMARKS_MODE_DEFAULT;
-                                if (watermarksIdleTimeoutUs) {
-                                    input.WatermarksIdleTimeoutUs = watermarksIdleTimeoutUs;
-                                }
-                            }
+                        if (input.WatermarksMode == NDqProto::WATERMARKS_MODE_DEFAULT) {
+                            Y_DEBUG_ABORT_UNLESS(IsInfiniteSourceType(input.SourceType));
+                            watermarksMode = NDqProto::WATERMARKS_MODE_DEFAULT;
                         }
                     } else {
                         for (ui64 channelId : input.Channels) {

--- a/ydb/library/yql/dq/tasks/dq_tasks_graph.h
+++ b/ydb/library/yql/dq/tasks/dq_tasks_graph.h
@@ -476,6 +476,7 @@ public:
                 for (auto& input : task.Inputs) {
                     input.WatermarksMode = NDqProto::WATERMARKS_MODE_DISABLED;
                     input.WatermarksIdleTimeoutUs.Clear();
+                    /* note: GetChannel().WatermarksMode default-initialized to DISABLED */
                 }
             }
 

--- a/ydb/library/yql/dq/tasks/dq_tasks_graph.h
+++ b/ydb/library/yql/dq/tasks/dq_tasks_graph.h
@@ -454,9 +454,9 @@ public:
                 for (auto& input : task.Inputs) {
                     if (input.SourceType) {
                         if (IsInfiniteSourceType(input.SourceType)) {
-                            watermarksMode = NDqProto::WATERMARKS_MODE_DEFAULT;
-                            input.WatermarksIdleTimeoutUs = watermarksIdleTimeoutUs; // TODO extract from source settings
-                            input.WatermarksMode = NDqProto::WATERMARKS_MODE_DEFAULT;
+                            if (watermarksIdleTimeoutUs) {
+                                input.WatermarksIdleTimeoutUs = watermarksIdleTimeoutUs;
+                            }
                         }
                     } else {
                         for (ui64 channelId : input.Channels) {
@@ -468,6 +468,10 @@ public:
                         }
                     }
                     task.WatermarksIdleTimeoutUs = Max(task.WatermarksIdleTimeoutUs, input.WatermarksIdleTimeoutUs);
+                }
+            } else {
+                for (auto& input : task.Inputs) {
+                    input.WatermarksMode = NDqProto::WATERMARKS_MODE_DISABLED;
                 }
             }
 

--- a/ydb/library/yql/dq/tasks/dq_tasks_graph.h
+++ b/ydb/library/yql/dq/tasks/dq_tasks_graph.h
@@ -454,8 +454,11 @@ public:
                 for (auto& input : task.Inputs) {
                     if (input.SourceType) {
                         if (IsInfiniteSourceType(input.SourceType)) {
-                            if (watermarksIdleTimeoutUs) {
-                                input.WatermarksIdleTimeoutUs = watermarksIdleTimeoutUs;
+                            if (input.WatermarksMode == NDqProto::WATERMARKS_MODE_DEFAULT) {
+                                watermarksMode = NDqProto::WATERMARKS_MODE_DEFAULT;
+                                if (watermarksIdleTimeoutUs) {
+                                    input.WatermarksIdleTimeoutUs = watermarksIdleTimeoutUs;
+                                }
                             }
                         }
                     } else {
@@ -472,6 +475,7 @@ public:
             } else {
                 for (auto& input : task.Inputs) {
                     input.WatermarksMode = NDqProto::WATERMARKS_MODE_DISABLED;
+                    input.WatermarksIdleTimeoutUs.Clear();
                 }
             }
 

--- a/ydb/library/yql/providers/dq/planner/execution_planner.cpp
+++ b/ydb/library/yql/providers/dq/planner/execution_planner.cpp
@@ -266,8 +266,7 @@ namespace NYql::NDqs {
             SourceTaskID = resultTask.Id;
         }
 
-        // TODO switch from `PRAGMA dq.WatermarksIdleTimeoutMs` to `... WITH Watermarks IDLE TIMEOUT ....`
-        TasksGraph.BuildCheckpointingAndWatermarksMode(true, Settings->WatermarksMode.Get().GetOrElse("") == "default", Settings->WatermarksIdleTimeoutMs.Get().Transform([](auto t) { return TDuration::MilliSeconds(t).MicroSeconds();}));
+        TasksGraph.BuildCheckpointingAndWatermarksMode(true, Settings->WatermarksMode.Get().GetOrElse("") == "default");
 
         return TasksGraph.GetTasks().size() <= maxTasksPerOperation;
     }

--- a/ydb/library/yql/providers/dq/planner/execution_planner.h
+++ b/ydb/library/yql/providers/dq/planner/execution_planner.h
@@ -74,8 +74,6 @@ namespace NYql::NDqs {
         void FillOutputDesc(NDqProto::TTaskOutput& outputDesc, const TTaskOutput& output, bool enableSpilling);
 
         void GatherPhyMapping(THashMap<std::tuple<TString, TString>, TString>& clusters, THashMap<std::tuple<TString, TString, TString>, TString>& tables);
-        void BuildCheckpointingAndWatermarksMode(bool enableCheckpoints, bool enableWatermarks);
-        bool IsEgressTask(const TDqsTasksGraph::TTaskType& task) const;
 
     private:
         const TDqSettings::TPtr Settings;

--- a/ydb/library/yql/providers/generic/provider/ut/pushdown/pushdown_ut.cpp
+++ b/ydb/library/yql/providers/generic/provider/ut/pushdown/pushdown_ut.cpp
@@ -223,7 +223,8 @@ public:
                 .Ptr();
         ::google::protobuf::Any settings;
         TString sourceType;
-        dqIntegration->FillSourceSettings(*dqSourceNode, settings, sourceType, 1, ctx);
+        IDqIntegration::TSourceWatermarksSettings watermarksSettings;
+        dqIntegration->FillSourceSettings(*dqSourceNode, settings, sourceType, 1, ctx, watermarksSettings);
         UNIT_ASSERT_STRINGS_EQUAL(sourceType, "PostgreSqlGeneric");
         UNIT_ASSERT(settings.Is<Generic::TSource>());
         settings.UnpackTo(DqSourceSettings_);

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -427,7 +427,7 @@ private:
                     return Nothing();
                 }
             }
-            if (member.Name() != "_yql_sys_tsp_write_time") {
+            if (!IsIn({"_yql_sys_tsp_write_time", "_yql_sys_write_time"}, member.Name())) {
                 return Nothing();
             }
         }

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -604,7 +604,7 @@ public:
         if (wrSettings.WatermarksMode.GetOrElse("") == "default" && maybeWatermark) {
             Add(props, WatermarksEnableSetting, ToString(true), pos, ctx);
             Add(props, WatermarksGranularityUsSetting,
-                ToString(watermarksGranularityUs.GetOrElse(TDuration::MilliSeconds(wrSettings.WatermarksGranularityMs.GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs)).MicroSeconds())), pos, ctx);
+                ToString(watermarksGranularityUs.GetOrElse(TDuration::MilliSeconds(wrSettings.WatermarksGranularityMs.GetOrElse(TDqSettings::TDefault::WatermarksGranularityMs)).MicroSeconds())), pos, ctx);
             Add(props, WatermarksLateArrivalDelayUsSetting,
                 ToString(watermarksLateArrivalDelayUs.GetOrElse(TDuration::MilliSeconds(wrSettings.WatermarksLateArrivalDelayMs.GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs)).MicroSeconds())), pos, ctx);
 

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -629,11 +629,6 @@ public:
             Add(props, WatermarksLateArrivalDelayUsSetting,
                 ToString(watermarksLateArrivalDelayUs.GetOrElse(TDuration::MilliSeconds(wrSettings.WatermarksLateArrivalDelayMs.GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs)).MicroSeconds())), pos, ctx);
 
-            const auto lateArrivalDelay = TDuration::MilliSeconds(wrSettings
-                .WatermarksLateArrivalDelayMs
-                .GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs));
-            Add(props, WatermarksLateArrivalDelayUsSetting, ToString(lateArrivalDelay.MicroSeconds()), pos, ctx);
-
             const auto lateEventsPolicy = watermarksLateEventsPolicy
                 .GetOrElse("adjust");
             Add(props, WatermarksLateEventsPolicySetting, lateEventsPolicy, pos, ctx);

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -332,10 +332,8 @@ public:
                 if (sharedReading && !predicateSql.empty()) {
                     ctx.AddWarning(TIssue(ctx.GetPosition(node.Pos()), "Row dispatcher will use the predicate: " + predicateSql));
                 }
-                if (!watermarkExprSql.empty()) {
-                    if (sharedReading) {
-                        ctx.AddWarning(TIssue(ctx.GetPosition(node.Pos()), "Row dispatcher will use watermark expr: " + watermarkExprSql));
-                    }
+                if (sharedReading && !watermarkExprSql.empty()) {
+                    ctx.AddWarning(TIssue(ctx.GetPosition(node.Pos()), "Row dispatcher will use watermark expr: " + watermarkExprSql));
                 }
                 sourceType = "PqSource";
             }

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -187,7 +187,13 @@ public:
         }
     }
 
-    void FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& protoSettings, TString& sourceType, size_t, TExprContext& ctx) override {
+    void FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& protoSettings, TString& sourceType, size_t maxPartitions, TExprContext& ctx) override {
+        Y_DEBUG_ABORT("Shound not have been called");
+        TSourceWatermarksSettings watermarksSettings;
+        FillSourceSettings(node, protoSettings, sourceType, maxPartitions, ctx, watermarksSettings);
+    }
+
+    void FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& protoSettings, TString& sourceType, size_t, TExprContext& ctx, TSourceWatermarksSettings& watermarksSettings) override {
         if (auto maybeDqSource = TMaybeNode<TDqSource>(&node)) {
             auto settings = maybeDqSource.Cast().Settings();
             if (auto maybeTopicSource = TMaybeNode<TDqPqTopicSource>(settings.Raw())) {
@@ -246,12 +252,15 @@ public:
                         srcDesc.SetAddBearerToToken(FromString<bool>(Value(setting)));
                     } else if (name == WatermarksEnableSetting) {
                         srcDesc.MutableWatermarks()->SetEnabled(true);
+                        watermarksSettings.Enabled = true;
                     } else if (name == WatermarksGranularityUsSetting) {
                         srcDesc.MutableWatermarks()->SetGranularityUs(FromString<ui64>(Value(setting)));
                     } else if (name == WatermarksLateArrivalDelayUsSetting) {
                         srcDesc.MutableWatermarks()->SetLateArrivalDelayUs(FromString<ui64>(Value(setting)));
                     } else if (name == WatermarksIdleTimeoutUsSetting) {
-                        srcDesc.MutableWatermarks()->SetIdleTimeoutUs(FromString<ui64>(Value(setting)));
+                        auto idleTimeoutUs = FromString<ui64>(Value(setting));
+                        srcDesc.MutableWatermarks()->SetIdleTimeoutUs(idleTimeoutUs);
+                        watermarksSettings.IdleTimeoutUs = idleTimeoutUs;
                     } else if (name == WatermarksIdlePartitionsSetting) {
                         srcDesc.MutableWatermarks()->SetIdlePartitionsEnabled(true);
                     } else if (name == SkipJsonErrors) {

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -337,8 +337,12 @@ public:
                 if (sharedReading && !predicateSql.empty()) {
                     ctx.AddWarning(TIssue(ctx.GetPosition(node.Pos()), "Row dispatcher will use the predicate: " + predicateSql));
                 }
-                if (sharedReading && !watermarkExprSql.empty()) {
-                    ctx.AddWarning(TIssue(ctx.GetPosition(node.Pos()), "Row dispatcher will use watermark expr: " + watermarkExprSql));
+                if (!watermarkExprSql.empty()) {
+                    if (sharedReading) {
+                        ctx.AddWarning(TIssue(ctx.GetPosition(node.Pos()), "Row dispatcher will use watermark expr: " + watermarkExprSql));
+                    } else {
+                        ctx.AddWarning(TIssue(ctx.GetPosition(node.Pos()), "Watermark expr specified, but will not be used (currently only implemented with row dispatcher): " + watermarkExprSql));
+                    }
                 }
                 sourceType = "PqSource";
             }

--- a/ydb/tests/fq/streaming/test_watermarks.py
+++ b/ydb/tests/fq/streaming/test_watermarks.py
@@ -55,7 +55,7 @@ class TestWatermarksInYdb(StreamingTestBase):
                         CAST(HOP_END() AS String) AS event_time,
                         AGGREGATE_LIST(ts) AS ts
                     FROM $filter
-                    GROUP BY HoppingWindow(CAST(event_time AS Timestamp), "PT1S", "PT1S", "max" as TimeLimit)
+                    GROUP BY HoppingWindow(CAST(event_time AS Timestamp), "PT1S", "PT1S")
                 );
 
                 $output = (
@@ -63,7 +63,7 @@ class TestWatermarksInYdb(StreamingTestBase):
                         CAST(HOP_END() AS String) AS event_time,
                         AGGREGATE_LIST(ts) AS ts
                     FROM $hop
-                    GROUP BY HoppingWindow(CAST(event_time AS Timestamp), "PT1S", "PT1S", "max" as TimeLimit)
+                    GROUP BY HoppingWindow(CAST(event_time AS Timestamp), "PT1S", "PT1S")
                 );
 
                 INSERT INTO {self.output_topic}

--- a/ydb/tests/fq/streaming/test_watermarks.py
+++ b/ydb/tests/fq/streaming/test_watermarks.py
@@ -13,13 +13,13 @@ class TestWatermarksInYdb(StreamingTestBase):
     @pytest.mark.parametrize("shared_reading", [False], ids=["no_shared"])
     @pytest.mark.parametrize("tasks", [1])
     def test_watermarks(self: StreamingTestBase, kikimr: Kikimr, entity_name: Callable[[str], str], shared_reading: bool, tasks: int) -> None:
-        source_name = entity_name("test_watermarks")
+        query_name = f"test_watermarks_{shared_reading}_{tasks}"
+        source_name = entity_name(query_name)
         self.init_topics(source_name, partitions_count=tasks)
         self.create_source(kikimr, source_name, shared_reading)
 
-        event_time = "ts" if shared_reading else "write_time"
+        ts = "CAST(ts AS Timestamp)" if shared_reading else "SystemMetadata('write_time')"
 
-        query_name = "test_watermarks"
         sql = f'''
             CREATE STREAMING QUERY `{query_name}` AS
             DO BEGIN
@@ -29,7 +29,7 @@ class TestWatermarksInYdb(StreamingTestBase):
                 $input = (
                     SELECT
                         {self.input_topic}.*,
-                        SystemMetadata("write_time") as write_time
+                        {ts} AS event_time,
                     FROM {self.input_topic}
                     WITH (
                         FORMAT=json_each_row,
@@ -37,13 +37,15 @@ class TestWatermarksInYdb(StreamingTestBase):
                             ts String NOT NULL,
                             pass Uint64
                         )
+                        , WATERMARK AS ({ts} - Interval('PT5S'))
+                        , WATERMARK_IDLE_TIMEOUT = "PT10S"
+                        , WATERMARK_GRANULARITY = "PT1S"
                     )
                 );
 
                 $filter = (
                     SELECT
-                        input.*,
-                        {event_time} AS event_time
+                        input.*
                     FROM $input AS input
                     WHERE pass > 0
                 );
@@ -53,7 +55,7 @@ class TestWatermarksInYdb(StreamingTestBase):
                         CAST(HOP_END() AS String) AS event_time,
                         AGGREGATE_LIST(ts) AS ts
                     FROM $filter
-                    GROUP BY HoppingWindow(CAST(event_time AS Timestamp), "PT1S", "PT1S")
+                    GROUP BY HoppingWindow(CAST(event_time AS Timestamp), "PT1S", "PT1S", "max" as TimeLimit)
                 );
 
                 $output = (
@@ -61,7 +63,7 @@ class TestWatermarksInYdb(StreamingTestBase):
                         CAST(HOP_END() AS String) AS event_time,
                         AGGREGATE_LIST(ts) AS ts
                     FROM $hop
-                    GROUP BY HoppingWindow(CAST(event_time AS Timestamp), "PT1S", "PT1S")
+                    GROUP BY HoppingWindow(CAST(event_time AS Timestamp), "PT1S", "PT1S", "max" as TimeLimit)
                 );
 
                 INSERT INTO {self.output_topic}
@@ -83,7 +85,7 @@ class TestWatermarksInYdb(StreamingTestBase):
             '[["1970-01-01T00:00:50Z"]]',
         ]
         actual = self.read_stream(len(expected), topic_path=self.output_topic)
-        assert actual == expected
+        assert sorted(actual) == expected
 
         sql = f'''DROP STREAMING QUERY `{query_name}`;'''
         kikimr.ydb_client.query(sql)

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindow-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindow-default.txt_/ast.txt
@@ -18,7 +18,7 @@
 (let $17 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $18 '('"SharedReading" '"1"))
 (let $19 '('"UseSsl" '"1"))
-(let $20 '('('"Consumer" '"test_client") $17 $18 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $19 '('"WatermarksEnable" '"1") '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $20 '('('"Consumer" '"test_client") $17 $18 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $19))
 (let $21 (SecureParam '"cluster:default_pq"))
 (let $22 (DqPqTopicSource $6 $15 $16 $20 $21 '"" $14 '""))
 (let $23 (DqStage '((DqSource $7 $22)) (lambda '($27) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowByStringKey-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowByStringKey-default.txt_/ast.txt
@@ -18,7 +18,7 @@
 (let $17 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $18 '('"SharedReading" '"1"))
 (let $19 '('"UseSsl" '"1"))
-(let $20 '('('"Consumer" '"test_client") $17 $18 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $19 '('"WatermarksEnable" '"1") '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $20 '('('"Consumer" '"test_client") $17 $18 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $19))
 (let $21 (SecureParam '"cluster:default_pq"))
 (let $22 (DqPqTopicSource $6 $15 $16 $20 $21 '"" $14 '""))
 (let $23 (DqStage '((DqSource $7 $22)) (lambda '($27) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowExprKey-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowExprKey-default.txt_/ast.txt
@@ -16,7 +16,7 @@
 (let $15 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $16 '('"SharedReading" '"1"))
 (let $17 '('"UseSsl" '"1"))
-(let $18 '('('"Consumer" '"test_client") $15 $16 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $17 '('"WatermarksEnable" '"1") '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $18 '('('"Consumer" '"test_client") $15 $16 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $17))
 (let $19 (SecureParam '"cluster:default_pq"))
 (let $20 (DqPqTopicSource $6 $13 $14 $18 $19 '"" $12 '""))
 (let $21 (DqStage '((DqSource $7 $20)) (lambda '($25) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowListKey-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowListKey-default.txt_/ast.txt
@@ -16,7 +16,7 @@
 (let $15 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $16 '('"SharedReading" '1))
 (let $17 '('"UseSsl" '1))
-(let $18 '('('"Consumer" '"test_client") $15 $16 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $17 '('"WatermarksEnable" '1) '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $18 '('('"Consumer" '"test_client") $15 $16 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $17))
 (let $19 (SecureParam '"cluster:default_pq"))
 (let $20 (DqPqTopicSource $6 $13 $14 $18 $19 '"" $12 '""))
 (let $21 (DqStage '((DqSource $7 $20)) (lambda '($25) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowNoKey-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowNoKey-default.txt_/ast.txt
@@ -15,7 +15,7 @@
 (let $14 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $15 '('"SharedReading" '"1"))
 (let $16 '('"UseSsl" '"1"))
-(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16 '('"WatermarksEnable" '"1") '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16))
 (let $18 (SecureParam '"cluster:default_pq"))
 (let $19 (DqPqTopicSource $6 $13 '('"t" '"v") $17 $18 '"" $12 '""))
 (let $20 (DqStage '((DqSource $7 $19)) (lambda '($24) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowPercentile-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowPercentile-default.txt_/ast.txt
@@ -15,7 +15,7 @@
 (let $14 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $15 '('"SharedReading" '1))
 (let $16 '('"UseSsl" '1))
-(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16 '('"WatermarksEnable" '1) '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16))
 (let $18 (SecureParam '"cluster:default_pq"))
 (let $19 (DqPqTopicSource $6 $13 '('"t" '"v") $17 $18 '"" $12 '""))
 (let $20 (DqStage '((DqSource $7 $19)) (lambda '($25) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowTimeExtractorUnusedColumns-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowTimeExtractorUnusedColumns-default.txt_/ast.txt
@@ -15,7 +15,7 @@
 (let $14 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $15 '('"SharedReading" '1))
 (let $16 '('"UseSsl" '1))
-(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16 '('"WatermarksEnable" '1) '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16))
 (let $18 (SecureParam '"cluster:default_pq"))
 (let $19 (DqPqTopicSource $6 $13 '('"t" '"v") $17 $18 '"" $12 '""))
 (let $20 (DqStage '((DqSource $7 $19)) (lambda '($25) (block '(

--- a/yql/essentials/core/dq_integration/yql_dq_integration.h
+++ b/yql/essentials/core/dq_integration/yql_dq_integration.h
@@ -55,6 +55,11 @@ public:
         bool CanFallback = false;
     };
 
+    struct TSourceWatermarksSettings {
+        bool Enabled = false;
+        TMaybe<ui64> IdleTimeoutUs;
+    };
+
     virtual ui64 Partition(const TExprNode& node, TVector<TString>& partitions, TString* clusterName, TExprContext& ctx, const TPartitionSettings& settings) = 0;
     virtual bool CheckPragmas(const TExprNode& node, TExprContext& ctx, bool skipIssues = false) = 0;
     virtual bool CanRead(const TExprNode& read, TExprContext& ctx, bool skipIssues = true) = 0;
@@ -82,6 +87,7 @@ public:
     virtual void RegisterMkqlCompiler(NCommon::TMkqlCallableCompilerBase& compiler) = 0;
     virtual bool CanFallback() = 0;
     virtual void FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sourceType, size_t maxPartitions, TExprContext& ctx) = 0;
+    virtual void FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sourceType, size_t maxPartitions, TExprContext& ctx, TSourceWatermarksSettings&) = 0;
     virtual void FillLookupSourceSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sourceType) = 0;
     virtual void FillSinkSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sinkType) = 0;
     virtual void FillTransformSettings(const TExprNode& node, ::google::protobuf::Any& settings) = 0;

--- a/yql/essentials/providers/common/dq/yql_dq_integration_impl.cpp
+++ b/yql/essentials/providers/common/dq/yql_dq_integration_impl.cpp
@@ -58,6 +58,10 @@ bool TDqIntegrationBase::CanFallback() {
 void TDqIntegrationBase::FillSourceSettings(const TExprNode&, ::google::protobuf::Any&, TString&, size_t, TExprContext&) {
 }
 
+void TDqIntegrationBase::FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sourceType, size_t maxPartitions, TExprContext& ctx, TSourceWatermarksSettings&) {
+    FillSourceSettings(node, settings, sourceType, maxPartitions, ctx);
+}
+
 void TDqIntegrationBase::FillLookupSourceSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sourceType) {
     Y_UNUSED(node);
     Y_UNUSED(settings);

--- a/yql/essentials/providers/common/dq/yql_dq_integration_impl.h
+++ b/yql/essentials/providers/common/dq/yql_dq_integration_impl.h
@@ -19,6 +19,7 @@ public:
     TExprNode::TPtr WrapWrite(const TExprNode::TPtr& write, TExprContext& ctx) override;
     bool CanFallback() override;
     void FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sourceType, size_t, TExprContext&) override;
+    void FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sourceType, size_t, TExprContext&, TSourceWatermarksSettings&) override;
     void FillLookupSourceSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sourceType) override;
     void FillSinkSettings(const TExprNode& node, ::google::protobuf::Any& settings, TString& sinkType) override;
     void FillTransformSettings(const TExprNode& node, ::google::protobuf::Any& settings) override;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`yql/essentials` part should be integrated separately and rebased upon import.
There maybe cleanup pr to get rid of old version of FillSourceSettings.
Expected to require *both* `pragma WatermarksMode="default"` *and* `WITH (...., WATERMARK = ...)`
It makes sense to enable dq.WatermarksMode="default" to default sever flags

TODO:
- [x] Kqp (streaming/v2) is broken (does not propagate watermark settings from sources)
- [x] Not shared-reading tests are broken (requires dummy WITH WATERMARKS expression)
- [x] Passing/defaults for settings in pq dq integration (Fill*) should be rechecked and updated
- [ ] Integrate YQL part and rebase upon imported version