### PR TITLE
Move index-specific functions out of schemeshard_utils to specific files

### DIFF
--- a/ydb/core/tx/schemeshard/olap/columns/update.cpp
+++ b/ydb/core/tx/schemeshard/olap/columns/update.cpp
@@ -1,6 +1,5 @@
 #include "update.h"
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
-#include <ydb/core/tx/schemeshard/schemeshard_utils.h>
 #include <yql/essentials/minikql/mkql_type_ops.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/scheme_types/scheme_type_registry.h>

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1,7 +1,7 @@
 #include "schemeshard__shred_manager.h"
 #include "schemeshard_impl.h"
 #include "schemeshard_index_build_info.h"
-#include "schemeshard_utils.h"  // for PQGroupReserve
+#include "schemeshard_pq_helpers.h"  // for PQGroupReserve
 
 #include <ydb/core/protos/s3_settings.pb.h>
 #include <ydb/core/protos/table_stats.pb.h>  // for TStoragePoolsStats

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_cdc_stream.cpp
@@ -2,7 +2,6 @@
 
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
 #define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_continuous_backup.cpp
@@ -4,7 +4,6 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard__operation_rotate_cdc_stream.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/engine/mkql_proto.h>
 #include <ydb/core/scheme/scheme_types_proto.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
@@ -3,7 +3,6 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard__operation_states.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/hive.h>
 #include <ydb/core/base/subdomain.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
@@ -1,7 +1,7 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for PQGroupReserve
+#include "schemeshard_pq_helpers.h"  // for PQGroupReserve
 
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/mind/hive/hive.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -1,7 +1,6 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/auth.h>
 #include <ydb/core/base/hive.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
@@ -2,8 +2,6 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
 #include "schemeshard_path_element.h"
-#include "schemeshard_utils.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_backup_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_backup_backup_collection.cpp
@@ -3,7 +3,6 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_create_cdc_stream.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"
 #include "schemeshard_impl.h"
 
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
@@ -1,6 +1,5 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -5,7 +5,6 @@
 #include "schemeshard_cdc_stream_common.h"
 #include "schemeshard_impl.h"
 #include "schemeshard_tx_infly.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/mind/hive/hive.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -1,6 +1,6 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
+#include "schemeshard_index_utils.h"
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
@@ -4,7 +4,6 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard_cdc_stream_common.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/engine/mkql_proto.h>
 #include <ydb/core/scheme/scheme_types_proto.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -1,7 +1,7 @@
 #include "schemeshard__op_traits.h"
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
+#include "schemeshard_index_utils.h"
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
@@ -2,7 +2,7 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for PQGroupReserve
+#include "schemeshard_pq_helpers.h"  // for PQGroupReserve
 
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/engine/mkql_proto.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_restore_incremental_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_restore_incremental_backup.cpp
@@ -4,7 +4,6 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard__operation_states.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
 #define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint.cpp
@@ -1,6 +1,5 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_check.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_check.cpp
@@ -1,6 +1,5 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_finalize.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_finalize.cpp
@@ -1,6 +1,5 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_lock.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_set_constraint_lock.cpp
@@ -1,6 +1,5 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -2,7 +2,6 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for IsAllowedKeyType
 
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/mind/hive/hive.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_backup_collection.cpp
@@ -3,7 +3,6 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard__operation.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"
 
 #include <algorithm>
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_cdc_stream.cpp
@@ -2,7 +2,6 @@
 
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
 #define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_index.cpp
@@ -1,7 +1,6 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_pq.cpp
@@ -2,7 +2,7 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard__operation.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for PQGroupReserve
+#include "schemeshard_pq_helpers.h"  // for PQGroupReserve
 
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/persqueue/events/global.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_index.cpp
@@ -2,7 +2,6 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
 #include "schemeshard_path_element.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/mind/hive/hive.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_tables.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_tables.cpp
@@ -2,7 +2,6 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
 #include "schemeshard_path_element.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_part.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_part.cpp
@@ -2,7 +2,6 @@
 
 #include "schemeshard_impl.h"
 #include "schemeshard_path.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/hive.h>
 #include <ydb/core/blob_depot/events.h>

--- a/ydb/core/tx/schemeshard/schemeshard__operation_part.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_part.h
@@ -756,5 +756,13 @@ ISubOperation::TPtr CreateAlterStreamingQuery(TOperationId id, TTxState::ETxStat
 ISubOperation::TPtr CreateDropStreamingQuery(TOperationId id, const TTxTransaction& tx);
 ISubOperation::TPtr CreateDropStreamingQuery(TOperationId id, TTxState::ETxState state);
 
+inline NKikimrSchemeOp::TModifyScheme TransactionTemplate(const TString& workingDir, NKikimrSchemeOp::EOperationType type) {
+    NKikimrSchemeOp::TModifyScheme tx;
+    tx.SetWorkingDir(workingDir);
+    tx.SetOperationType(type);
+
+    return tx;
+}
+
 }
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.cpp
@@ -3,7 +3,6 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_cdc_stream_common.h"
-#include "schemeshard_utils.h"  // for TransactionTemplate
 
 #define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
 #define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -2,7 +2,7 @@
 #include "schemeshard_build_index_helpers.h"
 #include "schemeshard_build_index_tx_base.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for NTableIndex::CommonCheck
+#include "schemeshard_index_utils.h"
 #include "schemeshard_xxport__helpers.h"
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -2,7 +2,7 @@
 #include "schemeshard_build_index_helpers.h"
 #include "schemeshard_build_index_tx_base.h"
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"  // for NTableIndex::ExtractInfo
+#include "schemeshard_index_utils.h"
 
 #include <ydb/public/api/protos/ydb_issue_message.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard_import_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_import_helpers.h
@@ -34,4 +34,8 @@ TString MakeIndexBuildUid(const TImportInfo& importInfo, ui32 itemIdx);
 
 bool NeedToBuildIndexes(const TImportInfo& importInfo, ui32 itemIdx);
 
+class TSchemeShard;
+
+bool ValidateImportDstPath(const TString& dstPath, TSchemeShard* ss, TString& explain);
+
 } // NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_incremental_restore_scan.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_incremental_restore_scan.cpp
@@ -1,5 +1,4 @@
 #include "schemeshard_impl.h"
-#include "schemeshard_utils.h"
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>

--- a/ydb/core/tx/schemeshard/schemeshard_index_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_index_utils.cpp
@@ -1,21 +1,9 @@
-#include "schemeshard_utils.h"
-
-#include "schemeshard_info_types.h"
+#include "schemeshard_index_utils.h"
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/persqueue/public/utils.h>
 
 namespace NKikimr {
-namespace NSchemeShard {
-
-PQGroupReserve::PQGroupReserve(const ::NKikimrPQ::TPQTabletConfig& tabletConfig, ui64 partitions, ui64 currentStorageUsage) {
-    Storage = NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS == tabletConfig.GetMeteringMode()
-        ? currentStorageUsage : partitions * NPQ::TopicPartitionReserveSize(tabletConfig);
-    Throughput = partitions * NPQ::TopicPartitionReserveThroughput(tabletConfig);
-}
-
-}
-
 namespace NTableIndex {
 
 TTableColumns ExtractInfo(const NKikimrSchemeOp::TTableDescription &tableDescr) {

--- a/ydb/core/tx/schemeshard/schemeshard_index_utils.h
+++ b/ydb/core/tx/schemeshard/schemeshard_index_utils.h
@@ -13,41 +13,6 @@
 
 
 namespace NKikimr {
-namespace NSchemeShard {
-
-inline bool IsValidColumnName(const TString& name, bool allowSystemColumnNames = false) {
-    if (!allowSystemColumnNames && name.StartsWith(SYSTEM_COLUMN_PREFIX)) {
-        return false;
-    }
-
-    for (auto c: name) {
-        if (!std::isalnum(c) && c != '_' && c != '-') {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-inline NKikimrSchemeOp::TModifyScheme TransactionTemplate(const TString& workingDir, NKikimrSchemeOp::EOperationType type) {
-    NKikimrSchemeOp::TModifyScheme tx;
-    tx.SetWorkingDir(workingDir);
-    tx.SetOperationType(type);
-
-    return tx;
-}
-
-class PQGroupReserve {
-public:
-    PQGroupReserve(const ::NKikimrPQ::TPQTabletConfig& tabletConfig, ui64 partitions, ui64 currentStorageUsage = 0);
-
-    ui64 Storage;
-    ui64 Throughput;
-};
-
-bool ValidateImportDstPath(const TString& dstPath, TSchemeShard* ss, TString& explain);
-
-} // NSchemeShard
 
 namespace NTableIndex {
 
@@ -217,16 +182,16 @@ bool CommonCheck(const TTableDesc& tableDesc, const NKikimrSchemeOp::TIndexCreat
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree: {
             // We have already checked this in IsCompatibleIndex
             Y_ABORT_UNLESS(indexKeys.KeyColumns.size() >= 1);
-    
+
             if (indexKeys.KeyColumns.size() > 1 && !IsCompatibleKeyTypes(baseColumnTypes, implTableColumns, uniformTable, error)) {
                 status = NKikimrScheme::EStatus::StatusInvalidParameter;
                 return false;
             }
-    
+
             const TString& embeddingColumnName = indexKeys.KeyColumns.back();
             Y_ABORT_UNLESS(baseColumnTypes.contains(embeddingColumnName));
             auto typeInfo = baseColumnTypes.at(embeddingColumnName);
-    
+
             if (typeInfo.GetTypeId() != NScheme::NTypeIds::String) {
                 status = NKikimrScheme::EStatus::StatusInvalidParameter;
                 error = TStringBuilder() << "Embedding column '" << embeddingColumnName << "' expected type 'String' but got " << NScheme::TypeName(typeInfo);
@@ -255,7 +220,7 @@ bool CommonCheck(const TTableDesc& tableDesc, const NKikimrSchemeOp::TIndexCreat
                     }
                 }
             }
-            
+
             break;
         }
         default:

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2,7 +2,7 @@
 
 #include "schemeshard_impl.h"
 #include "schemeshard_path.h"
-#include "schemeshard_utils.h"  // for IsValidColumnName, ValidateImportDstPath
+#include "schemeshard_import_helpers.h"  // for ValidateImportDstPath
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/channel_profiles.h>

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3605,6 +3605,20 @@ std::optional<std::pair<i64, i64>> ValidateSequenceType(const TString& sequenceN
 
 NProtoBuf::Timestamp SecondsToProtoTimeStamp(ui64 sec);
 
+inline bool IsValidColumnName(const TString& name, bool allowSystemColumnNames = false) {
+    if (!allowSystemColumnNames && name.StartsWith(SYSTEM_COLUMN_PREFIX)) {
+        return false;
+    }
+
+    for (auto c: name) {
+        if (!std::isalnum(c) && c != '_' && c != '-') {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 }
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_pq_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_pq_helpers.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ydb/core/protos/pqconfig.pb.h>
+
+namespace NKikimr {
+namespace NSchemeShard {
+
+class PQGroupReserve {
+public:
+    PQGroupReserve(const ::NKikimrPQ::TPQTabletConfig& tabletConfig, ui64 partitions, ui64 currentStorageUsage = 0) {
+        Storage = NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS == tabletConfig.GetMeteringMode()
+            ? currentStorageUsage : partitions * NPQ::TopicPartitionReserveSize(tabletConfig);
+        Throughput = partitions * NPQ::TopicPartitionReserveThroughput(tabletConfig);
+    }
+
+    ui64 Storage;
+    ui64 Throughput;
+};
+
+} // NSchemeShard
+} // NKikimr

--- a/ydb/core/tx/schemeshard/ut_index/ut_fulltext_index.cpp
+++ b/ydb/core/tx/schemeshard/ut_index/ut_fulltext_index.cpp
@@ -2,7 +2,7 @@
 #include <ydb/core/change_exchange/change_exchange.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/testlib/tablet_helpers.h>
-#include <ydb/core/tx/schemeshard/schemeshard_utils.h>
+#include <ydb/core/tx/schemeshard/schemeshard_index_utils.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
 

--- a/ydb/core/tx/schemeshard/ut_index/ut_vector_index.cpp
+++ b/ydb/core/tx/schemeshard/ut_index/ut_vector_index.cpp
@@ -3,7 +3,7 @@
 #include <ydb/core/change_exchange/change_exchange.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/testlib/tablet_helpers.h>
-#include <ydb/core/tx/schemeshard/schemeshard_utils.h>
+#include <ydb/core/tx/schemeshard/schemeshard_index_utils.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
 

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -283,6 +283,8 @@ SRCS(
     schemeshard_import_scheme_query_executor.cpp
     schemeshard_index_build_info.cpp
     schemeshard_index_build_info.h
+    schemeshard_index_utils.cpp
+    schemeshard_index_utils.h
     schemeshard_info_types.cpp
     schemeshard_info_types.h
     schemeshard_login_helper.cpp
@@ -292,6 +294,7 @@ SRCS(
     schemeshard_path_describer.cpp
     schemeshard_path_element.cpp
     schemeshard_path_element.h
+    schemeshard_pq_helpers.h
     schemeshard_schema.h
     schemeshard_self_pinger.cpp
     schemeshard_self_pinger.h
@@ -311,8 +314,6 @@ SRCS(
     schemeshard_types.cpp
     schemeshard_types.h
     schemeshard_user_attr_limits.h
-    schemeshard_utils.cpp
-    schemeshard_utils.h
     schemeshard_validate_ttl.cpp
     schemeshard_xxport__helpers.cpp
     user_attributes.cpp


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Обещал уже два раза вытащить TIndexBuildInfo, в PR #29274 и #30180 :)

После #30495, там TIndexBuildInfo.

Тут растащил utils - большую часть оставил в нём же и переименовал его в index_utils, кроме него там было всего 4 мелких фенечки:
- PQGroupReserve положил в отдельный .h и включил только туда, где используется
- TransactionTemplate засунул в operation_part.h т.к. он использовался только там где это и так уже включается, и по смыслу относится туда
- IsValidColumnName засунул в info_types, т.к. достаточно общая вещь
- ValidateImportDstPath засунул в import_helpers