### PR TITLE
Fix the aborting transactions in Column Tables

### DIFF
--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
@@ -144,13 +144,12 @@ void TTxBlobsWritingFinished::DoComplete(const TActorContext& ctx) {
             AFL_VERIFY(CommitSnapshot);
             // No tx writes (bulk upsert) must break decent/proper txs.
             // Decent/proper txs asked for serializable, so we have to give them serializable. 
-            Self->OperationsManager->AddTemporaryTxLink(op->GetLockId());
             Self->OperationsManager->BreakConflictingTxs(op->GetLockId());
-            Self->OperationsManager->CommitTransactionOnComplete(*Self, op->GetLockId(), *CommitSnapshot);
+            Self->OperationsManager->CommitTransactionOnComplete(*Self, 0, op->GetLockId(), *CommitSnapshot);
             Self->Counters.GetTabletCounters()->IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
         } else {
             Self->GetOperationsManager().SetOperationFinished(op->GetWriteId());
-            Self->MaybeCleanupLock(op->GetLockId());
+            Self->MaybeAbortTransaction(op->GetLockId());
         }
         Self->Counters.GetCSCounters().OnWriteTxComplete(now - writeMeta.GetWriteStartInstant());
         Self->Counters.GetCSCounters().OnSuccessWriteResponse();

--- a/ydb/core/tx/columnshard/columnshard__locks.cpp
+++ b/ydb/core/tx/columnshard/columnshard__locks.cpp
@@ -2,31 +2,27 @@
 
 namespace NKikimr::NColumnShard {
 
-void TColumnShard::SubscribeLock(const ui64 lockId, const ui32 lockNodeId) {
-    Send(NLongTxService::MakeLongTxServiceID(SelfId().NodeId()), std::make_unique<NLongTxService::TEvLongTxService::TEvSubscribeLock>(lockId, lockNodeId));
-}
-
-class TAbortWriteLockTransaction: public NTabletFlatExecutor::TTransactionBase<TColumnShard> {
+class TAbortWriteTransaction: public NTabletFlatExecutor::TTransactionBase<TColumnShard> {
 private:
     using TBase = NTabletFlatExecutor::TTransactionBase<TColumnShard>;
 
 public:
-    TAbortWriteLockTransaction(TColumnShard* self, const ui64 lockId)
+    TAbortWriteTransaction(TColumnShard* self, const ui64 lockId)
         : TBase(self)
         , LockId(lockId) {
     }
 
     virtual bool Execute(TTransactionContext& txc, const TActorContext&) override {
-        Self->GetOperationsManager().AbortLockOnExecute(*Self, LockId, txc);
+        Self->GetOperationsManager().AbortTransactionOnExecute(*Self, 0, LockId, txc);
         return true;
     }
 
-    virtual void Complete(const TActorContext&) override {
-        Self->GetOperationsManager().AbortLockOnComplete(*Self, LockId);
+    virtual void Complete(const TActorContext& /*ctx*/) override {
+        Self->GetOperationsManager().AbortTransactionOnComplete(*Self, 0, LockId);
     }
 
     TTxType GetTxType() const override {
-        return TXTYPE_ABORT_LOCK;
+        return TXTYPE_PROPOSE;
     }
 
 private:
@@ -40,17 +36,24 @@ void TColumnShard::SubscribeLockIfNotAlready(const ui64 lockId, const ui32 lockN
         Send(NLongTxService::MakeLongTxServiceID(SelfId().NodeId()), std::make_unique<NLongTxService::TEvLongTxService::TEvSubscribeLock>(lockId, lockNodeId));
     }
 }
-    auto lock = OperationsManager->GetLockOptional(lockId);
-    if (!lock || !lock->IsDeleted() || lock->IsAborted() || lock->IsTxIdAssigned() || lock->GetOperationsInProgress()) {
-        return;
-    }
 
-    if (!lock->SetAborted()) {
-        return;
+void TColumnShard::TransactionToAbort(const ui64 lockId) {
+    if (auto lock = OperationsManager->GetLockOptional(lockId)) {
+        lock->SetNeedsAborting();
+        MaybeAbortTransaction(lockId);
     }
-
-    Execute(new TAbortWriteLockTransaction(this, lockId));
 }
+
+void TColumnShard::MaybeAbortTransaction(const ui64 lockId) {
+    auto lock = OperationsManager->GetLockOptional(lockId);
+    if (!lock || !lock->ReadyForAborting() || lock->IsTxIdAssigned()) {
+        return;
+    }
+
+    lock->SetAborting();
+    Execute(new TAbortWriteTransaction(this, lockId));
+}
+
 
 void TColumnShard::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev, const TActorContext& /*ctx*/) {
     auto* msg = ev->Get();
@@ -58,10 +61,7 @@ void TColumnShard::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr&
     switch (msg->Record.GetStatus()) {
         case NKikimrLongTxService::TEvLockStatus::STATUS_NOT_FOUND:
         case NKikimrLongTxService::TEvLockStatus::STATUS_UNAVAILABLE: {
-            if (auto lock = OperationsManager->GetLockOptional(lockId); lock) {
-                lock->SetDeleted();
-                MaybeCleanupLock(lockId);
-            }
+            TransactionToAbort(lockId);
             break;
         }
         default:

--- a/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
+++ b/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
@@ -36,7 +36,7 @@ public:
         }
         Self->Counters.GetTabletCounters()->SetCounter(COUNTER_TX_COMPLETE_LAG, Self->GetTxCompleteLag().MilliSeconds());
 
-        const size_t removedCount = Self->ProgressTxController->CleanExpiredTxs(txc);
+        const size_t removedCount = Self->ProgressTxController->CleanExpiredTxs();
         if (removedCount > 0) {
             // We cannot continue with this transaction, start a new transaction
             AbortedThroughRemoveExpired = true;

--- a/ydb/core/tx/columnshard/columnshard__propose_cancel.cpp
+++ b/ydb/core/tx/columnshard/columnshard__propose_cancel.cpp
@@ -1,5 +1,4 @@
 #include "columnshard_impl.h"
-#include "columnshard_schema.h"
 
 namespace NKikimr::NColumnShard {
 
@@ -27,7 +26,7 @@ public:
             if (lock->ReadyForAborting()) {
                 lock->SetAborting();
                 Self->ProgressTxController->ExecuteOnCancel(TxId, txc);
-                doComplete = true;
+                DoComplete = true;
             }
         }
         return true;
@@ -35,14 +34,14 @@ public:
 
     void Complete(const TActorContext& ctx) override {
         LOG_S_DEBUG("TTxProposeCancel.Complete");
-        if (doComplete) {
+        if (DoComplete) {
             Self->ProgressTxController->CompleteOnCancel(TxId, ctx);
         }
     }
 
 private:
     ui64 TxId;
-    bool doComplete = false;
+    bool DoComplete = false;
 };
 
 void TColumnShard::Handle(TEvDataShard::TEvCancelTransactionProposal::TPtr& ev, const TActorContext& /*ctx*/) {

--- a/ydb/core/tx/columnshard/columnshard__propose_cancel.cpp
+++ b/ydb/core/tx/columnshard/columnshard__propose_cancel.cpp
@@ -3,11 +3,17 @@
 
 namespace NKikimr::NColumnShard {
 
+/**
+There is a slight chance that TTxProposeCancel is called twice for a single transaction.
+It happens if the tx remains in the deadline queue for too long,
+gets out of there to be cancelled, and at the same time the shard receives
+a TEvCancelTransactionProposal from kqp. So, we have two TTxProposeCancel in the queue.
+*/
 class TColumnShard::TTxProposeCancel : public TTransactionBase<TColumnShard> {
 public:
-    TTxProposeCancel(TColumnShard* self, TEvDataShard::TEvCancelTransactionProposal::TPtr& ev)
+    TTxProposeCancel(TColumnShard* self, const ui64 txId)
         : TTransactionBase(self)
-        , Ev(ev)
+        , TxId(txId)
     { }
 
     TTxType GetTxType() const override { return TXTYPE_PROPOSE_CANCEL; }
@@ -15,27 +21,38 @@ public:
     bool Execute(TTransactionContext& txc, const TActorContext&) override {
         LOG_S_DEBUG("TTxProposeCancel.Execute");
 
-        NIceDb::TNiceDb db(txc.DB);
-
-        const auto* msg = Ev->Get();
-        const ui64 txId = msg->Record.GetTxId();
-        Self->ProgressTxController->ExecuteOnCancel(txId, txc);
+        if (auto* lock = Self->GetOperationsManager().GetLockFeaturesForTxOptional(TxId)) {
+            AFL_VERIFY(lock->IsTxIdAssigned())("tx_id", TxId)("lock_id", lock->GetLockId());
+            lock->SetNeedsAborting();
+            if (lock->ReadyForAborting()) {
+                lock->SetAborting();
+                Self->ProgressTxController->ExecuteOnCancel(TxId, txc);
+                doComplete = true;
+            }
+        }
         return true;
     }
 
     void Complete(const TActorContext& ctx) override {
         LOG_S_DEBUG("TTxProposeCancel.Complete");
-        const auto* msg = Ev->Get();
-        const ui64 txId = msg->Record.GetTxId();
-        Self->ProgressTxController->CompleteOnCancel(txId, ctx);
+        if (doComplete) {
+            Self->ProgressTxController->CompleteOnCancel(TxId, ctx);
+        }
     }
 
 private:
-    const TEvDataShard::TEvCancelTransactionProposal::TPtr Ev;
+    ui64 TxId;
+    bool doComplete = false;
 };
 
-void TColumnShard::Handle(TEvDataShard::TEvCancelTransactionProposal::TPtr& ev, const TActorContext& ctx) {
-    Execute(new TTxProposeCancel(this, ev), ctx);
+void TColumnShard::Handle(TEvDataShard::TEvCancelTransactionProposal::TPtr& ev, const TActorContext& /*ctx*/) {
+    const auto* msg = ev->Get();
+    const ui64 txId = msg->Record.GetTxId();
+    CancelTransaction(txId);
+}
+
+void TColumnShard::CancelTransaction(const ui64 txId) {
+    Execute(new TTxProposeCancel(this, txId));
 }
 
 }

--- a/ydb/core/tx/columnshard/columnshard__write.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write.cpp
@@ -306,38 +306,12 @@ private:
     std::shared_ptr<TTxController::ITransactionOperator> TxOperator;
 };
 
-class TAbortWriteTransaction: public NTabletFlatExecutor::TTransactionBase<TColumnShard> {
-private:
-    using TBase = NTabletFlatExecutor::TTransactionBase<TColumnShard>;
-
-public:
-    TAbortWriteTransaction(TColumnShard* self, const ui64 txId, const TActorId source, const ui64 cookie)
-        : TBase(self)
-        , TxId(txId)
-        , Source(source)
-        , Cookie(cookie) {
+void TColumnShard::ProposeTransaction(std::shared_ptr<TCommitOperation> op, const TActorId source, const ui64 cookie) {
+    if (auto lock = OperationsManager->GetLockOptional(op->GetLockId()); lock) {
+        lock->SetTxId(op->GetTxId());
     }
-
-    virtual bool Execute(TTransactionContext& txc, const TActorContext&) override {
-        Self->GetOperationsManager().AbortTransactionOnExecute(*Self, TxId, txc);
-        return true;
-    }
-
-    virtual void Complete(const TActorContext& ctx) override {
-        LWPROBE(EvWriteResult, Self->TabletID(), Source.ToString(), TxId, Cookie, "abort", true, "");
-        Self->GetOperationsManager().AbortTransactionOnComplete(*Self, TxId);
-        auto result = NEvents::TDataEvents::TEvWriteResult::BuildCompleted(Self->TabletID(), TxId);
-        ctx.Send(Source, result.release(), 0, Cookie);
-    }
-    TTxType GetTxType() const override {
-        return TXTYPE_PROPOSE;
-    }
-
-private:
-    ui64 TxId;
-    TActorId Source;
-    ui64 Cookie;
-};
+    Execute(new TProposeWriteTransaction(this, op, source, cookie));
+}
 
 void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActorContext& ctx) {
     TMemoryProfileGuard mpg("NEvents::TDataEvents::TEvWrite");
@@ -376,7 +350,12 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
 
     if (behaviour == EOperationBehaviour::AbortWriteLock) {
         LWPROBE(EvWrite, TabletID(), source.ToString(), cookie, record.GetTxId(), writeTimeout.value_or(TDuration::Max()), 0, "AbortWriteLock", true, false, ToString(NKikimrDataEvents::TEvWriteResult::STATUS_UNSPECIFIED), "");
-        Execute(new TAbortWriteTransaction(this, record.GetLocks().GetLocks()[0].GetLockId(), source, cookie), ctx);
+        auto lockId = record.GetLocks().GetLocks()[0].GetLockId();
+        TransactionToAbort(lockId);
+        // answer kqp right away, the actual aborting may happen later (or might already happened)
+        LWPROBE(EvWriteResult, TabletID(), source.ToString(), lockId, cookie, "abort", true, "");
+        auto result = NEvents::TDataEvents::TEvWriteResult::BuildCompleted(TabletID(), lockId);
+        ctx.Send(source, result.release(), 0, cookie);
         return;
     }
 
@@ -388,8 +367,8 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
     };
 
     if (behaviour == EOperationBehaviour::WriteWithLock) {
-        if (auto lock = OperationsManager->GetLockOptional(record.GetLockTxId()); lock && lock->IsDeleted()) {
-            sendError("lock is already deleted", NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN);
+        if (auto lock = OperationsManager->GetLockOptional(record.GetLockTxId()); lock && lock->NeedsAborting()) {
+            sendError("lock is already aborted", NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN);
             return;
         }
     }
@@ -397,10 +376,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
     const auto inFlightLocksRangesBytes = NOlap::TPKRangesFilter::GetFiltersTotalMemorySize();
     const ui64 inFlightLocksRangesBytesLimit = AppDataVerified().ColumnShardConfig.GetInFlightLocksRangesBytesLimit();
     if (behaviour == EOperationBehaviour::WriteWithLock && inFlightLocksRangesBytes > inFlightLocksRangesBytesLimit) {
-        if (auto lock = OperationsManager->GetLockOptional(record.GetLockTxId()); lock) {
-            lock->SetDeleted();
-            MaybeCleanupLock(record.GetLockTxId());
-        }
+        TransactionToAbort(record.GetLockTxId());
         AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "In flight locks ranges bytes limit exceeded")
             ("inFlightLocksRangesBytes", inFlightLocksRangesBytes)
             ("inFlightLocksRangesBytesLimit", inFlightLocksRangesBytesLimit);
@@ -449,10 +425,10 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
                                 " != " + ::ToString(commitOperation->GetInternalGenerationCounter()),
                             NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN);
                     } else {
-                        Execute(new TProposeWriteTransaction(this, commitOperation, source, cookie), ctx);
+                        ProposeTransaction(commitOperation, source, cookie);
                     }
                 } else {
-                    Execute(new TProposeWriteTransaction(this, commitOperation, source, cookie), ctx);
+                    ProposeTransaction(commitOperation, source, cookie);
                 }
             }
         }

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -113,6 +113,7 @@ class TTxBlobsWritingFinished;
 class TTxBlobsWritingFailed;
 class TWriteTasksQueue;
 class TWriteTask;
+class TCommitOperation;
 
 namespace NLoading {
 class TTxControllerInitializer;
@@ -308,6 +309,10 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     void Handle(TEvColumnShard::TEvOverloadUnsubscribe::TPtr& ev, const TActorContext& ctx);
     void Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev, const TActorContext& ctx);
     void SubscribeLockIfNotAlready(const ui64 lockId, const ui32 lockNodeId) const;
+    void ProposeTransaction(std::shared_ptr<TCommitOperation> op, const TActorId source, const ui64 cookie);
+    void TransactionToAbort(const ui64 lockId);
+    void MaybeAbortTransaction(const ui64 lockId);
+    void CancelTransaction(const ui64 txId);
 
     void HandleInit(TEvPrivate::TEvTieringModified::TPtr& ev, const TActorContext&);
 

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -63,6 +63,9 @@ class TMovePortionsChange;
 namespace NReader {
 class TTxScan;
 class TTxInternalScan;
+namespace NCommon {
+class TReadMetadata;
+}
 namespace NPlain {
 class TIndexScannerConstructor;
 }
@@ -211,6 +214,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     friend class NOlap::NReader::TTxInternalScan;
     friend class NOlap::NReader::NPlain::TIndexScannerConstructor;
     friend class NOlap::NReader::NSimple::TIndexScannerConstructor;
+    friend class NOlap::NReader::NCommon::TReadMetadata;
     friend class NOlap::TRemovePortionsChange;
     friend class NOlap::TMovePortionsChange;
 
@@ -303,8 +307,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
 
     void Handle(TEvColumnShard::TEvOverloadUnsubscribe::TPtr& ev, const TActorContext& ctx);
     void Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev, const TActorContext& ctx);
-    void SubscribeLock(const ui64 lockId, const ui32 lockNodeId);
-    void MaybeCleanupLock(const ui64 lockId);
+    void SubscribeLockIfNotAlready(const ui64 lockId, const ui32 lockNodeId) const;
 
     void HandleInit(TEvPrivate::TEvTieringModified::TPtr& ev, const TActorContext&);
 

--- a/ydb/core/tx/columnshard/engines/reader/common/description.h
+++ b/ydb/core/tx/columnshard/engines/reader/common/description.h
@@ -34,6 +34,7 @@ public:
     // Table
     ui64 TxId = 0;
     std::optional<ui64> LockId;
+    std::optional<ui32> LockNodeId;
     std::optional<NKikimrDataEvents::ELockMode> LockMode;
     std::shared_ptr<ITableMetadataAccessor> TableMetadataAccessor;
     std::shared_ptr<NOlap::TPKRangesFilter> PKRangesFilter;
@@ -61,10 +62,16 @@ public:
         ScanCursor = cursor;
     }
 
-    void SetLock(std::optional<ui64> lockId, std::optional<NKikimrDataEvents::ELockMode> lockMode, const NColumnShard::TLockFeatures* lock, const bool readOnlyConflicts) {
+    void SetLock(
+        std::optional<ui64> lockId, 
+        std::optional<ui32> lockNodeId,
+        std::optional<NKikimrDataEvents::ELockMode> lockMode, 
+        const NColumnShard::TLockFeatures* lock,
+        const bool readOnlyConflicts
+    ) {
         LockId = lockId;
+        LockNodeId = lockNodeId;
         LockMode = lockMode;
-
         auto snapshotIsolation = lockId.has_value() && lockMode.value_or(NKikimrDataEvents::OPTIMISTIC) == NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION;
 
         readNonconflictingPortions = !readOnlyConflicts;

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
@@ -14,9 +14,13 @@ TConclusionStatus TReadMetadata::Init(const NColumnShard::TColumnShard* owner, c
     InitShardingInfo(readDescription.TableMetadataAccessor);
     TxId = readDescription.TxId;
     LockId = readDescription.LockId;
+    auto lockNodeId = readDescription.LockNodeId;
     LockMode = readDescription.LockMode;
     if (LockId) {
         owner->GetOperationsManager().RegisterLock(*LockId, owner->Generation());
+        if (lockNodeId.has_value()) {
+            owner->SubscribeLockIfNotAlready(LockId.value(), lockNodeId.value());
+        }
         LockSharingInfo = owner->GetOperationsManager().GetLockVerified(*LockId).GetSharingInfo();
     }
     if (!owner->GetIndexOptional()) {

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
@@ -53,8 +53,11 @@ void TTxInternalScan::Complete(const TActorContext& ctx) {
                 read.TableMetadataAccessor = accConclusion.DetachResult();
             }
         }
+        // the parent write has already subscribed to the lock, so no need to subscribe again
+        auto lockNodeId = std::nullopt;
         read.SetLock(
             request.GetLockId(), 
+            lockNodeId,
             NKikimrDataEvents::OPTIMISTIC, 
             request.GetLockId().has_value() ? Self->GetOperationsManager().GetLockOptional(request.GetLockId().value()) : nullptr,
             request.GetReadOnlyConflicts()

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
@@ -72,6 +72,7 @@ void TTxScan::Complete(const TActorContext& ctx) {
         read.TxId = txId;
         read.SetLock(
             request.HasLockTxId() ? std::make_optional(request.GetLockTxId()) : std::nullopt,
+            request.HasLockNodeId() ? std::make_optional(request.GetLockNodeId()) : std::nullopt,
             request.HasLockMode() ? std::make_optional(request.GetLockMode()) : std::nullopt,
             request.HasLockTxId() ? Self->GetOperationsManager().GetLockOptional(request.GetLockTxId()) : nullptr,
             false

--- a/ydb/core/tx/columnshard/operations/manager.cpp
+++ b/ydb/core/tx/columnshard/operations/manager.cpp
@@ -41,6 +41,7 @@ bool TOperationsManager::Load(NTabletFlatExecutor::TTransactionContext& txc) {
                 it = LockFeatures.emplace(lockId, TLockFeatures(lockId, 0)).first;
             }
             it->second.AddWriteOperation(operation);
+            // all the operations are finished at the moment of transaction proposal (or later) 
             it->second.OnWriteOperationFinished();
             LastWriteId = std::max(LastWriteId, operation->GetWriteId());
             if (!rowset.Next()) {
@@ -163,8 +164,8 @@ void TOperationsManager::OnTransactionFinishOnExecute(
     for (auto&& op : operations) {
         RemoveOperationOnExecute(op, txc);
     }
-    NIceDb::TNiceDb db(txc.DB);
     if (txId != 0) {
+        NIceDb::TNiceDb db(txc.DB);
         db.Table<Schema::OperationTxIds>().Key(txId, lock.GetLockId()).Delete();
     }
 }

--- a/ydb/core/tx/columnshard/operations/manager.cpp
+++ b/ydb/core/tx/columnshard/operations/manager.cpp
@@ -85,8 +85,8 @@ void TOperationsManager::BreakConflictingTxs(const TLockFeatures& lock) {
     }
 }
 
-void TOperationsManager::BreakConflictingTxs(const ui64 txId) {
-    auto& lock = GetLockFeaturesForTxVerified(txId);
+void TOperationsManager::BreakConflictingTxs(const ui64 lockId) {
+    auto& lock = GetLockVerified(lockId);
     BreakConflictingTxs(lock);
 }
 
@@ -110,10 +110,11 @@ void TOperationsManager::CommitTransactionOnExecute(
 }
 
 void TOperationsManager::CommitTransactionOnComplete(
-    TColumnShard& owner, const ui64 txId, const NOlap::TSnapshot& snapshot) {
-    auto& lock = GetLockFeaturesForTxVerified(txId);
+    TColumnShard& owner, const ui64 txId, const ui64 lockId, const NOlap::TSnapshot& snapshot) {
     TLogContextGuard gLogging(
-        NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_TX)("commit_tx_id", txId)("commit_lock_id", lock.GetLockId()));
+        NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_TX)("commit_tx_id", txId)("commit_lock_id", lockId));
+
+    auto& lock = GetLockVerified(lockId);
 
     TVector<TWriteOperation::TPtr> commited;
     for (auto&& opPtr : lock.GetWriteOperations()) {
@@ -123,67 +124,36 @@ void TOperationsManager::CommitTransactionOnComplete(
     OnTransactionFinishOnComplete(commited, lock, txId);
 }
 
-void TOperationsManager::AbortTransactionOnExecute(TColumnShard& owner, const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc) {
-    auto* lock = GetLockFeaturesForTxOptional(txId);
-    if (!lock) {
-        AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "abort")("tx_id", txId)("problem", "finished");
-        return;
-    }
+void TOperationsManager::AbortTransactionOnExecute(TColumnShard& owner, const ui64 txId, const ui64 lockId, NTabletFlatExecutor::TTransactionContext& txc) {
     TLogContextGuard gLogging(
-        NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_TX)("tx_id", txId)("lock_id", lock->GetLockId()));
+        NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_TX)("tx_id", txId)("lock_id", lockId));
+
+    auto& lock = GetLockVerified(lockId);
+    lock.SetAborted(txId);
 
     TVector<TWriteOperation::TPtr> aborted;
-    for (auto&& opPtr : lock->GetWriteOperations()) {
+    for (auto&& opPtr : lock.GetWriteOperations()) {
         opPtr->AbortOnExecute(owner, txc);
         aborted.emplace_back(opPtr);
     }
 
-    OnTransactionFinishOnExecute(aborted, *lock, txId, txc);
+    OnTransactionFinishOnExecute(aborted, lock, txId, txc);
 }
 
-void TOperationsManager::AbortTransactionOnComplete(TColumnShard& owner, const ui64 txId) {
-    auto* lock = GetLockFeaturesForTxOptional(txId);
-    if (!lock) {
-        AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "abort")("tx_id", txId)("problem", "finished");
-        return;
-    }
+void TOperationsManager::AbortTransactionOnComplete(TColumnShard& owner, const ui64 txId, const ui64 lockId) {
     TLogContextGuard gLogging(
-        NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_TX)("tx_id", txId)("lock_id", lock->GetLockId()));
+        NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_TX)("tx_id", txId)("lock_id", lockId));
+
+    auto& lock = GetLockVerified(lockId);
+    AFL_VERIFY(lock.IsAborted())("lock_id", lockId)("tx_id", txId);
 
     TVector<TWriteOperation::TPtr> aborted;
-    for (auto&& opPtr : lock->GetWriteOperations()) {
+    for (auto&& opPtr : lock.GetWriteOperations()) {
         opPtr->AbortOnComplete(owner);
         aborted.emplace_back(opPtr);
     }
 
-    OnTransactionFinishOnComplete(aborted, *lock, txId);
-}
-
-void TOperationsManager::AbortLockOnExecute(TColumnShard& owner, const ui64 lockId, NTabletFlatExecutor::TTransactionContext& txc) {
-    auto* lock = GetLockOptional(lockId);
-    if (!lock) {
-        return;
-    }
-
-    for (auto&& opPtr : lock->GetWriteOperations()) {
-        opPtr->AbortOnExecute(owner, txc);
-        RemoveOperationOnExecute(opPtr, txc);
-    }
-}
-
-void TOperationsManager::AbortLockOnComplete(TColumnShard& owner, const ui64 lockId) {
-    auto* lock = GetLockOptional(lockId);
-    if (!lock) {
-        return;
-    }
-
-    for (auto&& opPtr : lock->GetWriteOperations()) {
-        opPtr->AbortOnComplete(owner);
-        RemoveOperationOnComplete(opPtr);
-    }
-
-    lock->RemoveInteractions(InteractionsContext);
-    LockFeatures.erase(lockId);
+    OnTransactionFinishOnComplete(aborted, lock, txId);
 }
 
 void TOperationsManager::OnTransactionFinishOnExecute(
@@ -192,7 +162,9 @@ void TOperationsManager::OnTransactionFinishOnExecute(
         RemoveOperationOnExecute(op, txc);
     }
     NIceDb::TNiceDb db(txc.DB);
-    db.Table<Schema::OperationTxIds>().Key(txId, lock.GetLockId()).Delete();
+    if (txId != 0) {
+        db.Table<Schema::OperationTxIds>().Key(txId, lock.GetLockId()).Delete();
+    }
 }
 
 void TOperationsManager::OnTransactionFinishOnComplete(
@@ -201,7 +173,9 @@ void TOperationsManager::OnTransactionFinishOnComplete(
         lock.RemoveInteractions(InteractionsContext);
         LockFeatures.erase(lock.GetLockId());
     }
-    Tx2Lock.erase(txId);
+    if (txId != 0) {
+        Tx2Lock.erase(txId);
+    }
     for (auto&& op : operations) {
         RemoveOperationOnComplete(op);
     }
@@ -214,7 +188,7 @@ void TOperationsManager::RemoveOperationOnExecute(const TWriteOperation::TPtr& o
 
 void TOperationsManager::RemoveOperationOnComplete(const TWriteOperation::TPtr& op) {
     for (auto&& i : op->GetInsertWriteIds()) {
-        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_WRITE)("event", "remove_by_insert_id")("id", i)("operation_id", op->GetWriteId());
+        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_WRITE)("event", "remove_write_id_to_operation_id")("write_id", i)("operation_id", op->GetWriteId());
         AFL_VERIFY(InsertWriteIdToOpWriteId.erase(i));
     }
     AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_WRITE)("event", "remove_operation")("operation_id", op->GetWriteId());
@@ -234,9 +208,6 @@ std::optional<ui64> TOperationsManager::GetLockForTx(const ui64 txId) const {
 }
 
 void TOperationsManager::LinkTransactionOnExecute(const ui64 lockId, const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc) {
-    auto& lock = GetLockVerified(lockId);
-    lock.SetTxIdAssigned();
-
     NIceDb::TNiceDb db(txc.DB);
     db.Table<Schema::OperationTxIds>().Key(txId, lockId).Update();
     Tx2Lock[txId] = lockId;

--- a/ydb/core/tx/columnshard/operations/manager.cpp
+++ b/ydb/core/tx/columnshard/operations/manager.cpp
@@ -41,6 +41,7 @@ bool TOperationsManager::Load(NTabletFlatExecutor::TTransactionContext& txc) {
                 it = LockFeatures.emplace(lockId, TLockFeatures(lockId, 0)).first;
             }
             it->second.AddWriteOperation(operation);
+            it->second.OnWriteOperationFinished();
             LastWriteId = std::max(LastWriteId, operation->GetWriteId());
             if (!rowset.Next()) {
                 return false;
@@ -61,6 +62,7 @@ bool TOperationsManager::Load(NTabletFlatExecutor::TTransactionContext& txc) {
                 lock.SetBroken();
                 LockFeatures.emplace(lockId, std::move(lock));
             }
+            LockFeatures.find(lockId)->second.SetTxId(txId);
             AFL_VERIFY(Tx2Lock.emplace(txId, lockId).second);
             if (!rowset.Next()) {
                 return false;

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -232,21 +232,14 @@ public:
     void CommitTransactionOnExecute(
         TColumnShard& owner, const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc, const NOlap::TSnapshot& snapshot);
     void CommitTransactionOnComplete(
-        TColumnShard& owner, const ui64 txId, const NOlap::TSnapshot& snapshot);
-    void AddTemporaryTxLink(const ui64 lockId) {
-        AFL_VERIFY(Tx2Lock.emplace(lockId, lockId).second);
-        auto& lock = GetLockVerified(lockId);
-        lock.SetTxIdAssigned();
-    }
+        TColumnShard& owner, const ui64 txId, const ui64 lockId, const NOlap::TSnapshot& snapshot);
     void LinkTransactionOnExecute(const ui64 lockId, const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc);
     void LinkTransactionOnComplete(const ui64 lockId, const ui64 txId);
-    void AbortTransactionOnExecute(TColumnShard& owner, const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc);
-    void AbortTransactionOnComplete(TColumnShard& owner, const ui64 txId);
-    void AbortLockOnExecute(TColumnShard& owner, const ui64 lockId, NTabletFlatExecutor::TTransactionContext& txc);
-    void AbortLockOnComplete(TColumnShard& owner, const ui64 lockId);
+    void AbortTransactionOnExecute(TColumnShard& owner, const ui64 txId, const ui64 lockId, NTabletFlatExecutor::TTransactionContext& txc);
+    void AbortTransactionOnComplete(TColumnShard& owner, const ui64 txId, const ui64 lockId);
 
     void BreakConflictingTxs(const TLockFeatures& lock);
-    void BreakConflictingTxs(const ui64 txId);
+    void BreakConflictingTxs(const ui64 lockId);
 
     std::optional<ui64> GetLockForTx(const ui64 txId) const;
     std::optional<ui64> GetLockForTxOptional(const ui64 txId) const {

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -116,9 +116,13 @@ public:
         return SharingInfo->IsBroken();
     }
 
-    void SetDeleted() {
-        auto prevState = TLockSharingInfo::LockState::Created;
-        SharingInfo->State.compare_exchange_strong(prevState, TLockSharingInfo::LockState::Deleted);
+    bool subscribed = false;
+    void SetSubscribed() {
+        subscribed = true;
+    }
+    bool IsSubscribed() const {
+        return subscribed;
+    }
     }
 
     bool IsDeleted() const {

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -62,7 +62,8 @@ private:
     YDB_READONLY_DEF(THashSet<ui64>, BreakOnCommit);
     YDB_READONLY_DEF(THashSet<ui64>, NotifyOnCommit);
     YDB_READONLY_DEF(THashSet<ui64>, Committed);
-    YDB_READONLY_DEF(TPositiveControlInteger, OperationsInProgress);
+
+    ui64 OperationsInProgress = 0;
 
     bool Subscribed = false;
     bool needsAborting = false;
@@ -93,6 +94,7 @@ public:
     }
 
     void OnWriteOperationFinished() {
+        AFL_VERIFY(OperationsInProgress > 0)("operations_in_progress", OperationsInProgress);
         --OperationsInProgress;
     }
 
@@ -122,11 +124,11 @@ public:
     }
 
     bool ReadyForAborting() const {
-        return NeedsAborting() && !IsAborting() && OperationsInProgress.Val() == 0;
+        return NeedsAborting() && !IsAborting() && OperationsInProgress == 0;
     }
 
     void SetAborting() {
-        AFL_VERIFY(ReadyForAborting())("lock_id", GetLockId())("needs_aborting", NeedsAborting())("operations_in_progress", OperationsInProgress.Val())("aborting", Aborting);
+        AFL_VERIFY(ReadyForAborting())("lock_id", GetLockId())("needs_aborting", NeedsAborting())("operations_in_progress", OperationsInProgress)("aborting", Aborting);
         Aborting = true;
     }
     bool IsAborting() const {

--- a/ydb/core/tx/columnshard/tablet/write_queue.cpp
+++ b/ydb/core/tx/columnshard/tablet/write_queue.cpp
@@ -14,8 +14,8 @@ bool TWriteTask::Execute(TColumnShard* owner, const TActorContext& ctx) const {
     owner->Counters.GetCSCounters().WritingCounters->OnWritingTaskDequeue(TMonotonic::Now() - Created);
 
     if (const auto lock = owner->OperationsManager->GetLockOptional(LockId); lock) {
-        if (lock->IsDeleted()) {
-            Abort(owner, "lock is deleted", ctx, NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN);
+        if (lock->NeedsAborting()) {
+            Abort(owner, "transaction is aborted", ctx, NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN);
             return true;
         }
     }

--- a/ydb/core/tx/columnshard/tablet/write_queue.cpp
+++ b/ydb/core/tx/columnshard/tablet/write_queue.cpp
@@ -21,7 +21,7 @@ bool TWriteTask::Execute(TColumnShard* owner, const TActorContext& ctx) const {
     }
 
     owner->OperationsManager->RegisterLock(LockId, owner->Generation());
-    owner->SubscribeLock(LockId, LockNodeId);
+    owner->SubscribeLockIfNotAlready(LockId, LockNodeId);
     auto writeOperation = owner->OperationsManager->CreateWriteOperation(PathId, LockId, Cookie, GranuleShardingVersionId, ModificationType, IsBulk);
 
     AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_WRITE)("writing_size", ArrowData->GetSize())("operation_id", writeOperation->GetIdentifier())(

--- a/ydb/core/tx/columnshard/transactions/operators/ev_write/secondary.h
+++ b/ydb/core/tx/columnshard/transactions/operators/ev_write/secondary.h
@@ -110,9 +110,6 @@ private:
             } else {
                 op->TxBroken = BrokenFlag;
                 Self->GetProgressTxController().WriteTxOperatorInfo(txc, TxId, op->SerializeToProto().SerializeAsString());
-                if (BrokenFlag) {
-                    Self->GetProgressTxController().ExecuteOnCancel(TxId, txc);
-                }
             }
             return true;
         }
@@ -126,9 +123,6 @@ private:
                 AFL_WARN(NKikimrServices::TX_COLUMNSHARD_WRITE)("event", "duplication_tablet_broken_flag")("txId", TxId);
             } else {
                 op->SendBrokenFlagAck(*Self);
-                if (BrokenFlag) {
-                    Self->GetProgressTxController().CompleteOnCancel(TxId, ctx);
-                }
                 Self->EnqueueProgressTx(ctx, TxId);
             }
         }

--- a/ydb/core/tx/columnshard/transactions/tx_controller.cpp
+++ b/ydb/core/tx/columnshard/transactions/tx_controller.cpp
@@ -166,7 +166,7 @@ bool TTxController::CompleteOnCancel(const ui64 txId, const TActorContext& ctx) 
 bool TTxController::ExecuteOnCancel(const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc) {
     auto opIt = Operators.find(txId);
     AFL_VERIFY(opIt != Operators.end());
-    AFL_ALERT(opIt->second->GetTxInfo().PlanStep == 0)("tx_id", txId)("plan_step", opIt->second->GetTxInfo().PlanStep);
+    AFL_VERIFY(opIt->second->GetTxInfo().PlanStep == 0)("tx_id", txId)("plan_step", opIt->second->GetTxInfo().PlanStep);
 
     opIt->second->ExecuteOnAbort(Owner, txc);
 

--- a/ydb/core/tx/columnshard/transactions/tx_controller.cpp
+++ b/ydb/core/tx/columnshard/transactions/tx_controller.cpp
@@ -137,31 +137,22 @@ TTxController::TTxInfo TTxController::RegisterTxWithDeadline(const std::shared_p
     return txInfo;
 }
 
-bool TTxController::AbortTx(const TPlanQueueItem planQueueItem, NTabletFlatExecutor::TTransactionContext& txc) {
+bool TTxController::AbortTx(const TPlanQueueItem planQueueItem) {
     auto opIt = Operators.find(planQueueItem.TxId);
     AFL_VERIFY(opIt != Operators.end())("tx_id", planQueueItem.TxId);
     AFL_VERIFY(opIt->second->GetTxInfo().PlanStep == 0)("tx_id", planQueueItem.TxId)("plan_step", opIt->second->GetTxInfo().PlanStep);
-    opIt->second->ExecuteOnAbort(Owner, txc);
-    opIt->second->CompleteOnAbort(Owner, NActors::TActivationContext::AsActorContext());
-    Counters.OnAbortTx(opIt->second->GetOpType());
-
-    AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "abort_tx")("tx_id", planQueueItem.TxId);
-    OnTxCompleted(planQueueItem.TxId);
     AFL_VERIFY(DeadlineQueue.erase(planQueueItem))("tx_id", planQueueItem.TxId);
-    NIceDb::TNiceDb db(txc.DB);
-    Schema::EraseTxInfo(db, planQueueItem.TxId);
+    Counters.OnAbortTx(opIt->second->GetOpType());
+    Owner.CancelTransaction(planQueueItem.TxId);
+    AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "abort_tx")("tx_id", planQueueItem.TxId);
     return true;
 }
 
 bool TTxController::CompleteOnCancel(const ui64 txId, const TActorContext& ctx) {
     auto opIt = Operators.find(txId);
-    if (opIt == Operators.end()) {
-        return true;
-    }
     AFL_VERIFY(opIt != Operators.end())("tx_id", txId);
-    if (opIt->second->GetTxInfo().PlanStep != 0) {
-        return false;
-    }
+    AFL_VERIFY(opIt->second->GetTxInfo().PlanStep == 0)("tx_id", txId)("plan_step", opIt->second->GetTxInfo().PlanStep);
+
     opIt->second->CompleteOnAbort(Owner, ctx);
 
     if (opIt->second->GetTxInfo().MaxStep != Max<ui64>()) {
@@ -174,13 +165,8 @@ bool TTxController::CompleteOnCancel(const ui64 txId, const TActorContext& ctx) 
 
 bool TTxController::ExecuteOnCancel(const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc) {
     auto opIt = Operators.find(txId);
-    if (opIt == Operators.end()) {
-        return true;
-    }
-    Y_ABORT_UNLESS(opIt != Operators.end());
-    if (opIt->second->GetTxInfo().PlanStep != 0) {
-        return false;
-    }
+    AFL_VERIFY(opIt != Operators.end());
+    AFL_ALERT(opIt->second->GetTxInfo().PlanStep == 0)("tx_id", txId)("plan_step", opIt->second->GetTxInfo().PlanStep);
 
     opIt->second->ExecuteOnAbort(Owner, txc);
 
@@ -262,7 +248,7 @@ NEvents::TDataEvents::TCoordinatorInfo TTxController::BuildCoordinatorInfo(const
     return NEvents::TDataEvents::TCoordinatorInfo(txInfo.MinStep, txInfo.MaxStep, {});
 }
 
-size_t TTxController::CleanExpiredTxs(NTabletFlatExecutor::TTransactionContext& txc) {
+size_t TTxController::CleanExpiredTxs() {
     size_t removedCount = 0;
     if (HaveOutdatedTxs()) {
         ui64 outdatedStep = Owner.GetOutdatedStep();
@@ -274,7 +260,7 @@ size_t TTxController::CleanExpiredTxs(NTabletFlatExecutor::TTransactionContext& 
             }
             ui64 txId = it->TxId;
             LOG_S_DEBUG(TStringBuilder() << "Removing outdated txId " << txId << " max step " << it->Step << " outdated step ");
-            AbortTx(*it, txc);
+            AbortTx(*it);
             ++removedCount;
         }
     }
@@ -359,7 +345,7 @@ std::shared_ptr<TTxController::ITransactionOperator> TTxController::StartPropose
             } else {
                 RegisterTx(txOperator, txBody, txc);
             }
-            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "registered");
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "registered")("tx_operator", txOperator->GetOpType());
         } else {
             AFL_ERROR(NKikimrServices::TX_COLUMNSHARD_TX)("error", "problem on start")(
                 "message", txOperator->GetProposeStartInfoVerified().GetStatusMessage());

--- a/ydb/core/tx/columnshard/transactions/tx_controller.h
+++ b/ydb/core/tx/columnshard/transactions/tx_controller.h
@@ -426,7 +426,7 @@ private:
 
     THashMap<ui64, ITransactionOperator::TPtr> Operators;
 private:
-    bool AbortTx(const TPlanQueueItem planQueueItem, NTabletFlatExecutor::TTransactionContext& txc);
+    bool AbortTx(const TPlanQueueItem planQueueItem);
 
     TTxInfo RegisterTx(const std::shared_ptr<TTxController::ITransactionOperator>& txOperator, const TString& txBody,
         NTabletFlatExecutor::TTransactionContext& txc);
@@ -504,7 +504,7 @@ public:
     TTxInfo GetTxInfoVerified(const ui64 txId) const;
     NEvents::TDataEvents::TCoordinatorInfo BuildCoordinatorInfo(const TTxInfo& txInfo) const;
 
-    size_t CleanExpiredTxs(NTabletFlatExecutor::TTransactionContext& txc);
+    size_t CleanExpiredTxs();
     TDuration GetTxCompleteLag(ui64 timecastStep) const;
 
     enum class EPlanResult {


### PR DESCRIPTION
fixes #27113

In a nutshell:
1. Added a fairly strict lifecycle for LockFeature NeedsAborting -> Aborting -> Aborted
2. Unified how we process aborts, now there are 3 ways:
    1. Abort transaction before kqp sends EvWrite Prepare. The entry point is ColumnShard::TransactionToAbort() method. It covers the following events:
        1. SubscribeLock -> EvLockStatus Unavailable
        2. EvWrite Rollback, from kqp
        4. TxBlobsWritingFailed
        5. In flight locks ranges bytes limit exceeded
   2. Cancel the proposed transaction. After kqp sends EvWrit Prepare but before coordinator sends PlanStep. The entry point is TColumnShard::CancelTransaction(). It covers the following events:
       1. TEvCancelTransactionProposal, from kqp
       2. The deadline for a transaction comes, but coordinator has not yet sent PlanStep. We cancel this transaction.
    3. After coordinator sends PlanStep. Distributed commit decides that the transaction must be aborted.
3. Made the abort be executed only once
4. Made SubscribeLock happen only once
5. Fixed loading the lock state
6. Deleted AddTemporaryTxLink()
7. Stopped calling cancel when a transaction receives ReadSet with the broken flag. That method never executed, it requires PlanStep == 0, but at the end of the distributed commit PlanStep is never 0.