### PR TITLE
watermark: don't idle single input

### DIFF
--- a/ydb/library/yql/dq/runtime/streaming/dq_watermark_tracker_impl.h
+++ b/ydb/library/yql/dq/runtime/streaming/dq_watermark_tracker_impl.h
@@ -171,11 +171,12 @@ public:
     }
 
     [[nodiscard]] TMaybe<TInstant> HandleIdleness(TInstant systemTime) {
-        if (ExpiresQueue_.empty()) {
+        if (WatermarksQueue_.size() <= 1 || ExpiresQueue_.empty()) {
+            // ^^ there are no point in expiration of single input
             return Nothing();
         }
 
-        for (auto it = ExpiresQueue_.begin(); it != ExpiresQueue_.end() && it->Time <= systemTime; ) {
+        for (auto it = ExpiresQueue_.begin(); it != ExpiresQueue_.end() && it->Time <= systemTime && WatermarksQueue_.size() > 1; ) {
            auto& [key, data] = *it->Iterator;
            Y_DEBUG_ABORT_UNLESS (data.IdleTimeout != TDuration::Max());
            WATERMARK_LOG_T("Mark " << key << " idle: " << it->Time <<  " >= " << systemTime);
@@ -193,7 +194,7 @@ public:
     }
 
     [[nodiscard]] TMaybe<TInstant> GetNextIdlenessCheckAt() const {
-        if (ExpiresQueue_.empty()) {
+        if (WatermarksQueue_.size() <= 1 || ExpiresQueue_.empty()) {
             return Nothing();
         }
         return ExpiresQueue_.cbegin()->Time;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Minor optimization: avoid expiring single input. When one unexpired input left,  expiring it won't result in watermark generation.
TODO: consider user tunable (minimum number of unexpired inputs)
Note: there can be mixed idleable and non-idleable inputs. It is possible that `WatermarksQueue_.size() > ExpiresQueue_.size() == 1`, in this case we *should* expire this last idleable input.
In practice, this optimization is only interesting for one case: single idleable input/channel. In this case it completely removes idle channel overhead.