### PR TITLE
Parametrize tests with pools encryption

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -127,13 +127,17 @@ ydb/tests/functional/config test_distconf_sentinel_node_status.py.TestKiKiMRDist
 ydb/tests/functional/encryption test_encryption.py.TestEncryption.test_simple_encryption
 ydb/tests/functional/hive test_drain.py.TestHive.test_drain_on_stop
 ydb/tests/functional/restarts test_restarts.py.TestRestartMultipleMirror34.test_tablets_are_successfully_started_after_few_killed_nodes
-ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--false]
-ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--true]
+ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--false-enable_pool_encryption--false]
+ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--true-enable_pool_encryption--false]
+ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--false-enable_pool_encryption--true]
+ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--true-enable_pool_encryption--true]
 ydb/tests/functional/sqs/cloud test_yandex_cloud_mode.py.TestSqsYandexCloudMode.test_dlq_mechanics_in_cloud[tables_format_v0-tables_format_v1-fifo]
 ydb/tests/functional/sqs/cloud test_yandex_cloud_mode.py.TestSqsYandexCloudMode.test_yc_events_processor[tables_format_v0]
 ydb/tests/functional/statistics test_restarts.py.test_basic
-ydb/tests/functional/tenants test_tenants.py.TestTenants.test_list_database_above[enable_alter_database_create_hive_first--false]
-ydb/tests/functional/tenants test_tenants.py.TestTenants.test_list_database_above[enable_alter_database_create_hive_first--true]
+ydb/tests/functional/tenants test_tenants.py.TestTenants.test_list_database_above[enable_alter_database_create_hive_first--false-enable_pool_encryption--false]
+ydb/tests/functional/tenants test_tenants.py.TestTenants.test_list_database_above[enable_alter_database_create_hive_first--true-enable_pool_encryption--false]
+ydb/tests/functional/tenants test_tenants.py.TestTenants.test_list_database_above[enable_alter_database_create_hive_first--false-enable_pool_encryption--true]
+ydb/tests/functional/tenants test_tenants.py.TestTenants.test_list_database_above[enable_alter_database_create_hive_first--true-enable_pool_encryption--true]
 ydb/tests/functional/tpc/medium/tpch py3test.[test_duplicates.py] chunk
 ydb/tests/functional/tpc/medium/tpch test_duplicates.py.TestTpchDuplicatesZeroLevel.test_tpch[20]
 ydb/tests/functional/tpc/medium/tpch test_duplicates.py.TestTpchDuplicatesZeroLevel.test_tpch[21]

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -645,18 +645,12 @@ def test_discovery_exclusive_nodes(ydb_hostel_db, ydb_serverless_db_with_exclusi
     assert_that(serverless_db_exclusive_endpoints, only_contains(not_(is_in(serverless_db_shared_endpoints))))
 
 
-def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nodes, ydb_endpoint, ydb_cluster, enable_pool_encryption):
+def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nodes, ydb_endpoint, ydb_cluster):
     alter_database_serverless_compute_resources_mode(
         ydb_cluster,
         ydb_serverless_db_with_exclusive_nodes,
         "EServerlessComputeResourcesModeExclusive"
     )
-
-    if enable_pool_encryption:
-        # During the test db is being moved from /Root/hostel to
-        # /Root/serverless_with_exclusive_nodes and encryption key changes
-        # The test hangs on create_table and fails after 10m timeout
-        pytest.skip("Hangs with enable_pool_encryption=True")
 
     database = ydb_serverless_db_with_exclusive_nodes
     driver_config = ydb.DriverConfig(ydb_endpoint, database)

--- a/ydb/tests/functional/tenants/test_dynamic_tenants.py
+++ b/ydb/tests/functional/tenants/test_dynamic_tenants.py
@@ -50,11 +50,17 @@ def enable_alter_database_create_hive_first(request):
     return request.param
 
 
+@pytest.fixture(scope='module', params=[True, False], ids=["enable_pool_encryption--true", "enable_pool_encryption--false"])
+def enable_pool_encryption(request):
+    return request.param
+
+
 # fixtures.ydb_cluster_configuration local override
 @pytest.fixture(scope='module')
-def ydb_cluster_configuration(enable_alter_database_create_hive_first):
+def ydb_cluster_configuration(enable_alter_database_create_hive_first, enable_pool_encryption):
     conf = copy.deepcopy(CLUSTER_CONFIG)
     conf['enable_alter_database_create_hive_first'] = enable_alter_database_create_hive_first
+    conf['enable_pool_encryption'] = enable_pool_encryption
     return conf
 
 

--- a/ydb/tests/functional/tenants/test_tenants.py
+++ b/ydb/tests/functional/tenants/test_tenants.py
@@ -45,11 +45,17 @@ def enable_alter_database_create_hive_first(request):
     return request.param
 
 
+@pytest.fixture(scope='module', params=[True, False], ids=["enable_pool_encryption--true", "enable_pool_encryption--false"])
+def enable_pool_encryption(request):
+    return request.param
+
+
 # fixtures.ydb_cluster_configuration local override
 @pytest.fixture(scope='module')
-def ydb_cluster_configuration(enable_alter_database_create_hive_first):
+def ydb_cluster_configuration(enable_alter_database_create_hive_first, enable_pool_encryption):
     conf = copy.deepcopy(CLUSTER_CONFIG)
     conf['enable_alter_database_create_hive_first'] = enable_alter_database_create_hive_first
+    conf['enable_pool_encryption'] = enable_pool_encryption
     return conf
 
 

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -194,7 +194,8 @@ class KikimrConfigGenerator(object):
             cms_config=None,
             explicit_statestorage_config=None,
             system_tablets=None,
-            protected_mode=False,
+            protected_mode=False,  # Authentication
+            enable_pool_encryption=False,
             tiny_mode=False,
             module=None,
     ):
@@ -226,6 +227,7 @@ class KikimrConfigGenerator(object):
         erasure = Erasure.NONE if erasure is None else erasure
         self.system_tablets = system_tablets
         self.protected_mode = protected_mode
+        self.enable_pool_encryption = enable_pool_encryption
         self.module = module
         self.__grpc_ssl_enable = grpc_ssl_enable or protected_mode
         self.__grpc_tls_data_path = None
@@ -688,6 +690,7 @@ class KikimrConfigGenerator(object):
     @property
     def domains_txt(self):
         app_config = config_pb2.TAppConfig()
+        assert not self.enable_pool_encryption, "pool encryption is not addressed in domains.txt"
         Parse(read_binary(__name__, "resources/default_domains.txt"), app_config.DomainsConfig)
         return app_config.DomainsConfig
 
@@ -951,3 +954,8 @@ class KikimrConfigGenerator(object):
         self._add_state_storage_config()
         if not self.use_self_management and not self.explicit_hosts_and_host_configs:
             self._initialize_pdisks_info()
+
+        if self.enable_pool_encryption:
+            for domain in self.yaml_config['domains_config']['domain']:
+                for pool_type in domain['storage_pool_types']:
+                    pool_type['pool_config']['encryption_mode'] = 1

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -641,6 +641,21 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
             self.nodes[1].grpc_ssl_port if self.__configurator.grpc_ssl_enable
             else self.nodes[1].grpc_port
         )
+
+        if tenant_affiliation is None:
+            tenant_affiliation = "dynamic"
+
+        if encryption_key is None and self.__configurator.enable_pool_encryption:
+            workdir = os.path.join(self.__configurator.working_dir, self.__cluster_name)
+            slug = tenant_affiliation.replace('/', '_')
+            secret_path = os.path.join(workdir, slug + "_secret.txt")
+            with open(secret_path, "w") as writer:
+                writer.write("fake_secret_data_for_%s" % slug)
+            keyfile_path = os.path.join(workdir, slug + "_key.txt")
+            with open(keyfile_path, "w") as writer:
+                writer.write('Keys { ContainerPath: "%s" Pin: "" Id: "%s" Version: 1 } ' % (secret_path, slug))
+            encryption_key = keyfile_path
+
         self._slots[slot_index] = KiKiMRNode(
             node_id=slot_index,
             config_path=self.config_path,
@@ -650,7 +665,7 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
             udfs_dir=self.__common_udfs_dir,
             role='slot',
             node_broker_port=node_broker_port,
-            tenant_affiliation=tenant_affiliation if tenant_affiliation is not None else 'dynamic',
+            tenant_affiliation=tenant_affiliation,
             encryption_key=encryption_key,
             binary_path=self.__configurator.get_binary_path(slot_index),
             seed_nodes_file=seed_nodes_file,


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Part of #29326

Parametrized tests:

```
test_serverless.py::test_fixtures
test_serverless.py::test_create_table
test_serverless.py::test_turn_on_serverless_storage_billing
test_serverless.py::test_create_table_with_quotas
test_serverless.py::test_create_table_with_alter_quotas
test_serverless.py::test_database_with_disk_quotas
test_serverless.py::test_database_with_column_disk_quotas
test_serverless.py::test_discovery
test_serverless.py::test_discovery_exclusive_nodes
test_serverless.py::test_seamless_migration_to_exclusive_nodes
test_tenants.py::TestTenants::test_create_remove_database
test_tenants.py::TestTenants::test_create_remove_database_wait
test_tenants.py::TestTenants::test_when_deactivate_fat_tenant_creation_another_tenant_is_ok
test_tenants.py::TestTenants::test_register_tenant_and_force_drop_with_table
test_tenants.py::TestTenants::test_force_delete_tenant_when_table_has_been_deleted
test_tenants.py::TestTenants::test_progress_when_tenant_tablets_run_on_dynamic_nodes
test_tenants.py::TestTenants::test_yql_operations_over_dynamic_nodes
test_tenants.py::TestTenants::test_resolve_nodes
test_tenants.py::TestTenants::test_create_tables
test_tenants.py::TestTenants::test_stop_start
test_tenants.py::TestTenants::test_create_drop_create_table
test_tenants.py::TestTenants::test_create_drop_create_table2
test_tenants.py::TestTenants::test_create_drop_create_table3 [tags: xfail]
test_tenants.py::TestTenants::test_create_create_table
test_tenants.py::TestTenants::test_list_database_above
test_tenants.py::test_operation_with_locks
test_dynamic_tenants.py::test_create_tenant_no_cpu
test_dynamic_tenants.py::test_create_tenant_with_cpu
test_dynamic_tenants.py::test_drop_tenant_without_nodes_could_continue
test_dynamic_tenants.py::test_drop_tenant_without_nodes_could_complete
test_dynamic_tenants.py::test_create_tenant_then_exec_yql_empty_database_header
test_dynamic_tenants.py::test_create_tenant_then_exec_yql
test_dynamic_tenants.py::test_create_and_drop_tenants
test_dynamic_tenants.py::test_create_and_drop_the_same_tenant2
test_dynamic_tenants.py::test_check_access
test_dynamic_tenants.py::test_custom_coordinator_options
```