### PR TITLE
Do not require commit to Console to accept new configs

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -341,7 +341,6 @@ namespace NKikimr::NStorage {
         // pipe to Console
         TActorId ConsolePipeId;
         bool ConsoleConnected = false;
-        bool ConfigCommittedToConsole = false;
         ui64 ValidateRequestCookie = 0;
         ui64 ProposeRequestCookie = 0;
         ui64 CommitRequestCookie = 0;

--- a/ydb/core/blobstorage/nodewarden/distconf_console.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_console.cpp
@@ -119,7 +119,6 @@ namespace NKikimr::NStorage {
 
             case NKikimrBlobStorage::TEvControllerProposeConfigResponse::CommitIsNotNeeded:
                 // it's okay, just wait for another configuration change or something like that
-                ConfigCommittedToConsole = true;
                 ProposedConfigHashVersion.reset();
                 break;
 
@@ -148,10 +147,10 @@ namespace NKikimr::NStorage {
                 break;
 
             case NKikimrBlobStorage::TEvControllerConsoleCommitResponse::NotCommitted:
+                STLOG(PRI_ERROR, BS_NODE, NWDC46, "failed to commit config to Console", (Record, ev->Get()->Record));
                 break;
 
             case NKikimrBlobStorage::TEvControllerConsoleCommitResponse::Committed:
-                ConfigCommittedToConsole = true;
                 break;
         }
 
@@ -190,7 +189,6 @@ namespace NKikimr::NStorage {
     void TDistributedConfigKeeper::OnConsolePipeError() {
         ConsolePipeId = {};
         ConsoleConnected = false;
-        ConfigCommittedToConsole = false;
         ProposedConfigHashVersion.reset();
         ProposeRequestInFlight = false;
         ++CommitRequestCookie; // to prevent processing any messages

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
@@ -188,10 +188,6 @@ namespace NKikimr::NStorage {
     void TInvokeRequestHandlerActor::ReplaceStorageConfig(const TQuery::TReplaceStorageConfig& request) {
         RunCommonChecks();
 
-        if (!Self->ConfigCommittedToConsole && Self->SelfManagementEnabled) {
-            throw TExRace() << "Previous config has not been committed to Console yet";
-        }
-
         // extract YAML files provided by the user
         NewYaml = request.HasYAML() ? std::make_optional(request.GetYAML()) : std::nullopt;
         NewStorageYaml = request.HasStorageYAML() ? std::make_optional(request.GetStorageYAML()) : std::nullopt;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Do not require commit to Console to accept new configs

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch makes it unnecessary for previous config to be committed to Console in order to receive new config updates from the user.