### PR TITLE
Fix bug with ability to not set suite dir in `workload query init` command

### DIFF
--- a/ydb/library/workload/query/query.cpp
+++ b/ydb/library/workload/query/query.cpp
@@ -175,7 +175,10 @@ std::string TQueryGenerator::GetDDLQueries() const {
     for (const auto& cq: Params.GetCustomQueries()) {
         result << cq.c_str() << ";" << std::endl;
     }
-    result << GetDDLQueriesFromDir(Params.GetSuitePath() / "init");
+    const auto initPath = Params.GetSuitePath() / "init";
+    if (Params.GetSuitePath().IsDefined() && initPath.IsDirectory()) {
+        result << GetDDLQueriesFromDir(initPath);
+    }
     return result.str();
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
