### PR TITLE
Support SnapshotRW transactions for OLTP tables

### DIFF
--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1157,13 +1157,6 @@ public:
             return false;
         }
 
-        if (QueryState->TxCtx->EffectiveIsolationLevel == NKikimrKqp::ISOLATION_LEVEL_SNAPSHOT_RW
-            && QueryState->TxCtx->HasOltpTable) {
-            ReplyQueryError(Ydb::StatusIds::PRECONDITION_FAILED,
-                            "SnapshotRW can only be used with column-oriented tables.");
-            return false;
-        }
-
         if (QueryState->TxCtx->HasOlapTable && QueryState->TxCtx->HasOltpTable && QueryState->TxCtx->HasTableWrite
                 && !QueryState->TxCtx->EnableHtapTx.value_or(false) && !QueryState->IsSplitted()) {
             ReplyQueryError(Ydb::StatusIds::PRECONDITION_FAILED,

--- a/ydb/core/kqp/ut/tx/kqp_snapshot_isolation_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_snapshot_isolation_ut.cpp
@@ -48,7 +48,6 @@ Y_UNIT_TEST_SUITE(KqpSnapshotIsolation) {
     };
 
     Y_UNIT_TEST(TSimpleOltp) {
-        return;
         TSimple tester;
         tester.SetIsOlap(false);
         tester.Execute();
@@ -136,7 +135,6 @@ Y_UNIT_TEST_SUITE(KqpSnapshotIsolation) {
     };
 
     Y_UNIT_TEST(TConflictWriteOltp) {
-        return;
         TConflictWrite tester("upsert_partial");
         tester.SetIsOlap(false);
         tester.Execute();
@@ -216,7 +214,6 @@ Y_UNIT_TEST_SUITE(KqpSnapshotIsolation) {
     };
 
     Y_UNIT_TEST(TConflictReadWriteOltp) {
-        return;
         TConflictReadWrite tester;
         tester.SetIsOlap(false);
         tester.Execute();
@@ -273,7 +270,6 @@ Y_UNIT_TEST_SUITE(KqpSnapshotIsolation) {
     };
 
     Y_UNIT_TEST(TReadOnlyOltp) {
-        return;
         TReadOnly tester;
         tester.SetIsOlap(false);
         tester.Execute();
@@ -419,7 +415,6 @@ Y_UNIT_TEST_SUITE(KqpSnapshotIsolation) {
     };
 
     Y_UNIT_TEST(TReadOwnChangesOltp) {
-        return;
         TReadOwnChanges tester;
         tester.SetIsOlap(false);
         tester.Execute();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Enable SnapshotRW transactions for OLTP tables and related kqp changes. Fixes #12971.