### PR TITLE
[Backport stable-25-3] Properly handle no-user and the system user with Resource Pool Classifiers

### DIFF
--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.cpp
@@ -98,8 +98,8 @@ TClassifierSettings TResourcePoolClassifierConfig::GetClassifierSettings() const
     resourcePoolClassifierSettings.Rank = Rank;
 
     const auto& properties = resourcePoolClassifierSettings.GetPropertiesMap();
-    for (const auto& [propery, value] : ConfigJson.GetMap()) {
-        const auto it = properties.find(propery);
+    for (const auto& [property, value] : ConfigJson.GetMap()) {
+        const auto it = properties.find(property);
         if (it == properties.end()) {
             continue;
         }

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -891,11 +891,11 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
     Y_UNIT_TEST(TestMultiGroupClassification) {
         auto ydb = TYdbSetupSettings().Create();
 
-        auto settings = TQueryRunnerSettings().PoolId("");
+        auto settings = TQueryRunnerSettings().PoolId("").UserSID("no@user");
 
         const TString& poolId = "my_pool";
-        const TString& firstSID = "first@user";
-        const TString& secondSID = "second@user";
+        const TString& firstSID = "first@group";
+        const TString& secondSID = "second@group";
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
             CREATE RESOURCE POOL )" << poolId << R"( WITH (
                 CONCURRENT_QUERY_LIMIT=0
@@ -910,6 +910,8 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
                 MEMBER_NAME=")" << secondSID << R"(",
                 RANK=2
             );
+            GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << firstSID << R"(`, `)" << secondSID << R"(`
+            ;
         )");
 
         WaitForFail(ydb, settings.GroupSIDs({firstSID}), poolId);


### PR DESCRIPTION
Backport of #30331