### PR TITLE
Show SVG plan on demand in KqpExecuter introspection

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -15,6 +15,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/feature_flags.h>
 #include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/library/plan2svg/plan2svg.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/library/ydb_issue/issue_helpers.h>
 #include <ydb/library/yql/dq/common/rope_over_buffer.h>
@@ -582,10 +583,41 @@ protected:
     }
 
     void HandleHttpInfo(NMon::TEvHttpInfo::TPtr& ev) {
+
         TStringStream str;
+
+        const TCgiParameters &cgi = ev->Get()->Request.GetParams();
+        auto view = cgi.Get("view");
+        if (view == "plan") {
+            NYql::NDqProto::TDqExecutionStats execStats;
+            Stats->ExportExecStats(execStats);
+
+            for (ui32 txId = 0; txId < Request.Transactions.size(); ++txId) {
+                const auto& tx = Request.Transactions[txId].Body;
+                auto plans = AddExecStatsToTxPlan(tx->GetPlan(), execStats);
+                TPlanVisualizer viz;
+
+                NJson::TJsonReaderConfig jsonConfig;
+                NJson::TJsonValue jsonNode;
+                if (NJson::ReadJsonTree(plans, &jsonConfig, &jsonNode)) {
+                    viz.LoadPlans(jsonNode);
+                }
+
+                auto svg = viz.PrintSvgSafe();
+                str << svg << Endl;
+            }
+
+            this->Send(ev->Sender, new NMon::TEvHttpInfoRes(str.Str()));
+            return;
+        }
+
         HTML(str) {
             PRE() {
-                str << "KQP Executer, SelfId=" << SelfId() << Endl;
+                str << "KQP Executer, SelfId=" << SelfId() << ' ';
+                HREF(TStringBuilder() << "/node/" << SelfId().NodeId() << "/actors/kqp_node?ex=" << SelfId() << "&view=plan")  {
+                    str << "Plan";
+                }
+                str << Endl;
 
                 TABLE_SORTABLE_CLASS("table table-condensed") {
                     TABLEHEAD() {
@@ -855,15 +887,15 @@ protected:
                                 "Compute node is unavailable"));
                         break;
                     }
-                    
+
                     LOG_D("Received NODE_SHUTTING_DOWN, attempting run tasks locally");
-                    
+
                     ui32 requestId = record.GetNotStartedTasks(0).GetRequestId();
                     auto localNode = MakeKqpNodeServiceID(SelfId().NodeId());
 
                     // changes requests nodeId when redirect tasks on local node: used to check on disconnected
                     if (!Planner->SendStartKqpTasksRequest(requestId, localNode, true)) {
-                        ReplyErrorAndDie(Ydb::StatusIds::UNAVAILABLE, 
+                        ReplyErrorAndDie(Ydb::StatusIds::UNAVAILABLE,
                             MakeIssue(NKikimrIssues::TIssuesIds::SHARD_NOT_AVAILABLE,
                                 "Compute node is unavailable"));
                     }

--- a/ydb/core/kqp/executer_actor/ya.make
+++ b/ydb/core/kqp/executer_actor/ya.make
@@ -39,6 +39,7 @@ PEERDIR(
     ydb/library/actors/core
     ydb/library/mkql_proto
     ydb/library/mkql_proto/protos
+    ydb/library/plan2svg
     ydb/library/yql/dq/actors/compute
     ydb/library/yql/dq/runtime
     ydb/library/yql/dq/tasks


### PR DESCRIPTION
KqpExecuter introspection allows to display live svg plan

<img width="1167" height="580" alt="image" src="https://github.com/user-attachments/assets/e9088083-8ed6-4c4b-aa8b-d131708f1818" />


<img width="1299" height="849" alt="image" src="https://github.com/user-attachments/assets/4da2a37f-5859-47e7-bcf6-761a249c9cfd" />
