### PR TITLE
[ICRDMA] Fix msan RDMA allocator tests. EXT-1788

### DIFF
--- a/ydb/library/actors/interconnect/rdma/mem_pool.cpp
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.cpp
@@ -666,9 +666,4 @@ namespace NInterconnect::NRdma {
         static TSlotMemPool pool(MakeCounters(counters), settings);
         return std::shared_ptr<TSlotMemPool>(&pool, [](TSlotMemPool*) {});
     }
-
-    // Just for UT
-    std::shared_ptr<IMemPool> CreateNonStaticSlotMemPool(TDynamicCounters* counters, std::optional<TMemPoolSettings> settings) noexcept {
-        return std::make_shared<TSlotMemPool>(MakeCounters(counters), settings);
-    }
 }

--- a/ydb/library/actors/interconnect/rdma/ut_mem_pool_limit/allocator_ut.cpp
+++ b/ydb/library/actors/interconnect/rdma/ut_mem_pool_limit/allocator_ut.cpp
@@ -1,0 +1,57 @@
+#include <ydb/library/actors/interconnect/rdma/mem_pool.h>
+#include <ydb/library/actors/interconnect/rdma/ut/utils/utils.h>
+
+#include <library/cpp/testing/gtest/gtest.h>
+#include <ydb/library/testlib/unittest_gtest_macro_subst.h>
+
+namespace NMonitoring {
+    struct TDynamicCounters;
+}
+
+static void GTestSkip() {
+    GTEST_SKIP() << "Skipping all rdma tests for suit, set \""
+                 << NRdmaTest::RdmaTestEnvSwitchName << "\" env if it is RDMA compatible";
+}
+
+class TAllocatorSuite : public ::testing::Test {
+protected:
+    void SetUp() override {
+        using namespace NRdmaTest;
+        if (IsRdmaTestDisabled()) {
+            GTestSkip();
+        }
+    }
+};
+
+TEST_F(TAllocatorSuite, SlotPoolLimit) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 32
+    };
+    static auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    const size_t sz = 4 << 20;
+    std::vector<NInterconnect::NRdma::TMemRegionPtr> regions;
+    regions.reserve(8);
+    size_t i = 0;
+    for (;;i++) {
+        auto reg = pool->Alloc(sz, 0);
+        if (!reg) {
+            UNIT_ASSERT(i == 8); // 32 / 4
+            break;
+        }
+        ASSERT_TRUE(reg->GetAddr()) << "invalid address";
+        ASSERT_TRUE(reg->GetSize() == sz) << "invalid size of allocated chunk";
+        regions.push_back(reg);
+    }
+
+    regions.erase(regions.begin()); // free one region
+
+    {
+        auto reg = pool->Alloc(sz, 0); // allocate one
+        ASSERT_TRUE(reg->GetAddr()) << "invalid address";
+        ASSERT_TRUE(reg->GetSize() == sz) << "invalid size of allocated chunk";
+        UNIT_ASSERT(!pool->Alloc(sz, 0)); // pool is full
+    }
+
+    regions.clear();
+}

--- a/ydb/library/actors/interconnect/rdma/ut_mem_pool_limit/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ut_mem_pool_limit/ya.make
@@ -1,0 +1,23 @@
+GTEST()
+
+IF (OS_LINUX AND SANITIZER_TYPE != "memory")
+
+IF (SANITIZER_TYPE == "thread")
+    SIZE(LARGE)
+    TAG(ya:fat)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+SRCS(
+    allocator_ut.cpp
+)
+
+PEERDIR(
+    ydb/library/actors/interconnect/rdma
+    ydb/library/actors/interconnect/rdma/ut/utils
+)
+
+ENDIF()
+
+END()

--- a/ydb/library/actors/interconnect/rdma/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ya.make
@@ -12,8 +12,10 @@ IF (OS_LINUX)
 
     PEERDIR(
         ydb/library/actors/interconnect/address
+        ydb/library/actors/util
         contrib/libs/ibdrv
         contrib/libs/protobuf
+        library/cpp/monlib/dynamic_counters
     )
 
 ELSE()
@@ -26,7 +28,9 @@ ELSE()
 
     PEERDIR(
         ydb/library/actors/interconnect/address
+        ydb/library/actors/util
         contrib/libs/protobuf
+        library/cpp/monlib/dynamic_counters
     )
 
 ENDIF()
@@ -39,4 +43,5 @@ RECURSE(
 
 RECURSE_FOR_TESTS(
     ut
+    ut_mem_pool_limit
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The allocator is a static object so we can't place tests with different settings in the one process. The attempt to use non static version of allocator was wrong due to TLS cache issues inside slot allocator. So right now we just split tests in to 2 processes.


### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
