### PR TITLE
Allow to try to cancel broken index builds

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_build_index__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__cancel.cpp
@@ -65,6 +65,10 @@ public:
 
         NIceDb::TNiceDb db(txc.DB);
         indexBuildInfo.CancelRequested = true;
+        indexBuildInfo.IsBroken = false; // allow to recover by cancelling broken index builds
+        if (indexBuildInfo.State == TIndexBuildInfo::EState::Invalid) {
+            indexBuildInfo.State = TIndexBuildInfo::EState::Filling;
+        }
         Self->PersistBuildIndexCancelRequest(db, indexBuildInfo);
 
         Progress(indexBuildInfo.Id);

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -1504,16 +1504,12 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, TTestTxConfig::SchemeShard, buildIndexTx);
             Cout << "BuildIndex 3 " << buildIndexOperation.DebugString() << Endl << buildIndexHtml << Endl;
             UNIT_ASSERT_VALUES_EQUAL_C(
-                buildIndexOperation.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_TRANSFERING_DATA,
+                buildIndexOperation.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_CANCELLATION,
                 buildIndexOperation.DebugString()
             );
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "IsBroken: YES");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "IsBroken: NO");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "CancelRequested: YES");
         }
-
-        // but we need to turn EnableVectorIndex back to progress:
-        runtime.GetAppData().FeatureFlags.SetEnableVectorIndex(true);
-        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
 
         env.TestWaitNotification(runtime, buildIndexTx);
 
@@ -1610,14 +1606,7 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
         }
     }
 
-    Y_UNIT_TEST(UnknownState) {
-        TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
-        ui64 txId = 100;
-
-        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
-        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
-
+    ui64 DoCreateBrokenIndex(TTestBasicRuntime& runtime, TTestEnv& env, ui64& txId) {
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "vectors"
             Columns { Name: "id" Type: "Uint64" }
@@ -1683,6 +1672,19 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "IsBroken: YES");
         }
 
+        return buildIndexTx;
+    }
+
+    Y_UNIT_TEST(UnknownState) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        const ui64 buildIndexTx = DoCreateBrokenIndex(runtime, env, txId);
+
         {
             // set a known State but unknown SubState
             TString writeQuery = Sprintf(R"(
@@ -1740,6 +1742,29 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Unknown build kind");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "IsBroken: YES");
         }
+    }
+
+    Y_UNIT_TEST(CancelBroken) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        const ui64 buildIndexTx = DoCreateBrokenIndex(runtime, env, txId);
+
+        const ui64 cancelTxId = ++txId;
+        TestCancelBuildIndex(runtime, cancelTxId, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexTx);
+        env.TestWaitNotification(runtime, buildIndexTx);
+
+        auto descr = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexTx);
+        Y_ASSERT(descr.GetIndexBuild().GetState() == Ydb::Table::IndexBuildState::STATE_CANCELLED);
+
+        // Check that another index is built successfully (i.e. the table is not left in a locked state)
+        const ui64 buildIndex2Tx = ++txId;
+        AsyncBuildVectorIndex(runtime, buildIndex2Tx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/vectors", "index1", {"embedding"});
+        env.TestWaitNotification(runtime, buildIndex2Tx);
     }
 
     Y_UNIT_TEST(CreateBuildProposeReject) {


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Зачем это нужно:
- IsBroken это сейчас защита от падения schemeshard по кругу. Этот флаг не персистится, а проставляется, если schemeshard не может при старте продолжить построение индекса. В том числе, если это тип индекса от более нового schemeshard.
- Однако, сейчас, если построение сваливается в IsBroken, с ним невозможно ничего сделать, а таблица остаётся заблокированной и её не спасёшь.
- Даниил столкнулся с этой проблемой и предложил это как-то поправить, здесь идея фикса такая: при запросе отмены разово выводить индекс из состояния IsBroken и разрешать процессу "построения" (отмены) пройти.
- Если при этом schemeshard упадёт снова, то при следующем запуске ничего уже не поменяется, опять поставится IsBroken, так что защита от падения по кругу сохраняется.