### PR TITLE
Allow correct operation of seed nodes while adding new hosts in distconf

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -25,6 +25,7 @@ namespace NKikimr::NStorage {
 
         bool InvokedWithoutScepter = false;
         bool EnablingDistconf = false;
+        bool Detached = false;
 
     public: // Error handling
         struct TExError : yexception {
@@ -108,12 +109,14 @@ namespace NKikimr::NStorage {
         void ReassignStateStorageNode(const TQuery::TReassignStateStorageNode& cmd);
         void ReconfigStateStorage(const NKikimrBlobStorage::TStateStorageConfig& cmd);
         void SelfHealStateStorage(const TQuery::TSelfHealStateStorage& cmd);
-        void SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasSpecificVolume);
+        void SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas, ui32 overrideReplicasInRingCount,
+            ui32 overrideRingsCount, ui32 replicasSpecificVolume);
         void SelfHealNodesStateUpdate(const TQuery::TSelfHealNodesStateUpdate& cmd);
         void GetStateStorageConfig(const TQuery::TGetStateStorageConfig& cmd);
 
         void GetCurrentStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool getNodesState);
-        bool GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas, ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasSpecificVolume);
+        bool GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas,
+            ui32 overrideReplicasInRingCount, ui32 overrideRingsCount, ui32 replicasSpecificVolume);
         void AdjustRingGroupActorIdOffsetInRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -135,10 +138,15 @@ namespace NKikimr::NStorage {
             OTHER,
         } ControllerOp = EControllerOp::UNSET;
 
-        void FetchStorageConfig(bool fetchMain, bool fetchStorage, bool addExplicitMgmtSections, bool addV1);
+        void FetchStorageConfig(const TQuery::TFetchStorageConfig& request);
+        void Handle(TEvNodeWardenStorageConfig::TPtr ev);
+        void HandleWakeup();
+        void ReplyToFetchStorageConfig(const std::optional<TString>& mainConfigYaml,
+            const std::optional<TString>& storageConfigYaml, bool transient);
         void ReplaceStorageConfig(const TQuery::TReplaceStorageConfig& request);
         void ReplaceStorageConfigResume(const std::optional<TString>& storageConfigYaml, ui64 expectedMainYamlVersion,
                 ui64 expectedStorageYamlVersion, bool enablingDistconf);
+        void ReplaceStorageConfigExecute();
         void TryEnableDistconf();
         void ConnectToController();
         void Handle(TEvTabletPipe::TEvClientConnected::TPtr ev);
@@ -173,6 +181,8 @@ namespace NKikimr::NStorage {
 
         void Finish(TResult::EStatus status, std::optional<TStringBuf> errorReason,
             const std::function<void(TResult*)>& callback = {});
+
+        void DetachQuery();
 
         void PassAway() override;
 

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
@@ -80,28 +80,49 @@ namespace NKikimr::NStorage {
         }
     }
 
-    void TInvokeRequestHandlerActor::FetchStorageConfig(bool fetchMain, bool fetchStorage, bool addExplicitMgmtSections,
-            bool addV1) {
+    void TInvokeRequestHandlerActor::FetchStorageConfig(const TQuery::TFetchStorageConfig& request) {
         RunCommonChecks();
 
         if (!Self->MainConfigYaml) {
             throw TExError() << "No stored YAML for storage config";
         }
 
+        if (request.RequestorHostSize()) {
+            bool found = false;
+            for (const auto& host : request.GetRequestorHost()) {
+                if (Self->Hosts.contains(std::make_tuple(host, request.GetRequestorPort()))) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                STLOG(PRI_DEBUG, BS_NODE, NWDC62, "FetchStorageConfig: requestor put to pending queue", (SelfId, SelfId()),
+                    (Request, request));
+                DetachQuery();
+                Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new TEvNodeWardenQueryStorageConfig(true));
+                TActivationContext::Schedule(TDuration::Seconds(3), new IEventHandle(TEvents::TSystem::Wakeup, 0,
+                    SelfId(), {}, nullptr, 0));
+                return;
+            }
+        }
+
         Finish(TResult::OK, std::nullopt, [&](TResult *record) {
             auto *res = record->MutableFetchStorageConfig();
-            if (fetchMain) {
+            if (request.GetMainConfig()) {
                 res->SetYAML(Self->MainConfigYaml);
             }
-            if (fetchStorage && Self->StorageConfigYaml) {
+            if (request.GetStorageConfig() && Self->StorageConfigYaml) {
                 res->SetStorageYAML(*Self->StorageConfigYaml);
             }
+
+            const bool addV1 = request.GetAddSectionsForMigrationToV1();
+            const bool addExplicitMgmtSections = request.GetAddExplicitConfigs();
 
             if (addExplicitMgmtSections && addV1) {
                 throw TExError() << "Can't provide both explicit sections and config suitable for downgrade to v1";
             } else if (Self->StorageConfigYaml && addV1) {
                 throw TExError() << "Can't downgrade to v1 when dedicated storage section is enabled";
-            } else if (addExplicitMgmtSections && Self->StorageConfigYaml && !fetchStorage) {
+            } else if (addExplicitMgmtSections && Self->StorageConfigYaml && !request.GetStorageConfig()) {
                 throw TExError() << "Can't add explicit sections to storage config as it is not fetched";
             }
 
@@ -183,6 +204,76 @@ namespace NKikimr::NStorage {
                 }
             }
         });
+    }
+
+    void TInvokeRequestHandlerActor::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
+        Y_ABORT_UNLESS(std::holds_alternative<TInvokeExternalOperation>(Query));
+        auto& op = std::get<TInvokeExternalOperation>(Query);
+        Y_ABORT_UNLESS(op.Command.HasFetchStorageConfig());
+        auto& cmd = op.Command.GetFetchStorageConfig();
+        Y_ABORT_UNLESS(cmd.RequestorHostSize());
+        const auto& hosts = cmd.GetRequestorHost();
+        THashSet<TString> requestorHosts(hosts.begin(), hosts.end());
+        auto& config = *ev->Get()->Config;
+        bool transient = ev->Cookie;
+        for (const auto& node : config.GetAllNodes()) {
+            if (requestorHosts.contains(node.GetHost()) && node.GetPort() == cmd.GetRequestorPort()) {
+                STLOG(PRI_DEBUG, BS_NODE, NWDC82, "FetchStorageConfig: TEvNodeWardenStorageConfig received, host found",
+                    (SelfId, SelfId()));
+
+                std::optional<TString> mainConfigYaml;
+                std::optional<TString> storageConfigYaml;
+
+                if (cmd.GetMainConfig() && config.HasConfigComposite()) {
+                    if (DecomposeConfig(config.GetConfigComposite(), &mainConfigYaml.emplace(), nullptr, nullptr)) {
+                        mainConfigYaml.reset(); // error has occured during config decomposition
+                    }
+                }
+                if (cmd.GetStorageConfig()) {
+                    storageConfigYaml = GetStorageYaml(config);
+                }
+
+                ReplyToFetchStorageConfig(mainConfigYaml, storageConfigYaml, transient);
+
+                return PassAway();
+            }
+        }
+        STLOG(PRI_DEBUG, BS_NODE, NWDC86, "FetchConfigConfig: TEvNodeWardenStorageConfig received, host still not found",
+            (SelfId, SelfId()));
+    }
+
+    void TInvokeRequestHandlerActor::HandleWakeup() {
+        STLOG(PRI_DEBUG, BS_NODE, NWDC87, "FetchStorageConfig: timed out", (SelfId, SelfId()));
+        ReplyToFetchStorageConfig(std::nullopt, std::nullopt, false);
+        PassAway();
+    }
+
+    void TInvokeRequestHandlerActor::ReplyToFetchStorageConfig(const std::optional<TString>& mainConfigYaml,
+            const std::optional<TString>& storageConfigYaml, bool transient) {
+        auto ev = std::make_unique<TEvNodeConfigInvokeOnRootResult>();
+
+        // prepare record
+        auto& record = ev->Record;
+        record.SetStatus(TResult::OK);
+        auto *res = record.MutableFetchStorageConfig();
+        if (mainConfigYaml) {
+            res->SetYAML(*mainConfigYaml);
+        }
+        if (storageConfigYaml) {
+            res->SetStorageYAML(*storageConfigYaml);
+        }
+        if (transient) {
+            res->SetTransient(true);
+        }
+
+        // issue it to the sender
+        auto& op = std::get<TInvokeExternalOperation>(Query);
+        Y_ABORT_UNLESS(op.Command.HasFetchStorageConfig());
+        auto handle = std::make_unique<IEventHandle>(op.Sender, SelfId(), ev.release(), 0, op.Cookie);
+        if (op.SessionId) {
+            handle->Rewrite(TEvInterconnect::EvForward, op.SessionId);
+        }
+        TActivationContext::Send(handle.release());
     }
 
     void TInvokeRequestHandlerActor::ReplaceStorageConfig(const TQuery::TReplaceStorageConfig& request) {
@@ -294,8 +385,8 @@ namespace NKikimr::NStorage {
         }
     }
 
-    void TInvokeRequestHandlerActor::ReplaceStorageConfigResume(const std::optional<TString>& storageConfigYaml, ui64 expectedMainYamlVersion,
-            ui64 expectedStorageYamlVersion, bool enablingDistconf) {
+    void TInvokeRequestHandlerActor::ReplaceStorageConfigResume(const std::optional<TString>& storageConfigYaml,
+            ui64 expectedMainYamlVersion, ui64 expectedStorageYamlVersion, bool enablingDistconf) {
         auto *op = std::get_if<TInvokeExternalOperation>(&Query);
         Y_ABORT_UNLESS(op);
         const auto& request = op->Command.GetReplaceStorageConfig();
@@ -362,13 +453,23 @@ namespace NKikimr::NStorage {
             ProposedStorageConfig.ClearCompressedStorageYaml();
         }
 
+        EnablingDistconf = enablingDistconf;
         if (request.GetSkipConsoleValidation() || !NewYaml) {
-            StartProposition(&ProposedStorageConfig, /*mindPrev=*/ true, /*propositionBase=*/ nullptr, enablingDistconf);
+            ReplaceStorageConfigExecute();
         } else if (!Self->EnqueueConsoleConfigValidation(SelfId(), enablingDistconf, *NewYaml)) {
             throw TExRace() << "Console pipe is not available";
-        } else {
-            EnablingDistconf = enablingDistconf;
         }
+    }
+
+    void TInvokeRequestHandlerActor::ReplaceStorageConfigExecute() {
+        Y_ABORT_UNLESS(!LifetimeToken.expired());
+        for (const auto& actorId : Self->DetachedQueries) {
+            Send(actorId, new TEvNodeWardenStorageConfig(std::make_shared<const NKikimrBlobStorage::TStorageConfig>(
+                ProposedStorageConfig), false, nullptr, nullptr), 0, 1);
+        }
+
+        return StartProposition(&ProposedStorageConfig, /*mindPrev=*/ true, /*propositionBase=*/ nullptr,
+            /*fromBootstrap=*/ EnablingDistconf);
     }
 
     void TInvokeRequestHandlerActor::TryEnableDistconf() {
@@ -564,7 +665,7 @@ namespace NKikimr::NStorage {
                 if (const auto& error = UpdateConfigComposite(ProposedStorageConfig, *NewYaml, record.GetYAML())) {
                     throw TExError() << "Failed to update config yaml: " << *error;
                 }
-                return StartProposition(&ProposedStorageConfig, /*mindPrev=*/ true, /*propositionBase=*/ nullptr, EnablingDistconf);
+                return ReplaceStorageConfigExecute();
         }
     }
 
@@ -597,13 +698,15 @@ namespace NKikimr::NStorage {
             } else if (r.ConfigToPropose) {
                 // config validation, which is basically done in Console
                 TString mainYaml;
-                if (auto err = DecomposeConfig(r.ConfigToPropose->GetConfigComposite(), &mainYaml, /*mainConfigVersion=*/ nullptr, /*mainConfigFetchYaml=*/ nullptr)) {
+                if (auto err = DecomposeConfig(r.ConfigToPropose->GetConfigComposite(), &mainYaml,
+                        /*mainConfigVersion=*/ nullptr, /*mainConfigFetchYaml=*/ nullptr)) {
                     throw TExError() << "Failed to decompose composite config: " << *err;
                 }
                 if (auto err = LocalYamlValidate(mainYaml, /*allowUnknown=*/ true)) {
                     throw TExError() << "YAML validation failed: " << *err;
                 }
-                StartProposition(&r.ConfigToPropose.value(), /*mindPrev=*/ true, /*propositionBase=*/ nullptr, /*fromBootstrap=*/ true);
+                StartProposition(&r.ConfigToPropose.value(), /*mindPrev=*/ true, /*propositionBase=*/ nullptr,
+                    /*fromBootstrap=*/ true);
             } else { // no new proposition has been made
                 Finish(TResult::OK, std::nullopt);
             }

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -237,12 +237,9 @@ namespace NKikimr::NStorage {
                                         out << "<pre>" << yaml << "</pre>";
                                     }
                                 }
-                                if (config->HasCompressedStorageYaml()) {
-                                    TStringInput ss(config->GetCompressedStorageYaml());
-                                    TZstdDecompress zstd(&ss);
-                                    TString yaml = zstd.ReadAll();
-                                    out << "<strong>storage.yaml (size " << yaml.size() << ")</strong><br/><pre>"
-                                        << yaml << "</pre>";
+                                if (auto yaml = GetStorageYaml(*config)) {
+                                    out << "<strong>storage.yaml (size " << yaml->size() << ")</strong><br/><pre>"
+                                        << *yaml << "</pre>";
                                 }
                             } else {
                                 out << "not defined";

--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -122,17 +122,10 @@ void TNodeWarden::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
         if (error) {
             STLOG_DEBUG_FAIL(BS_NODE, NW49, "failed to decompose yaml configuration", (Error, error));
         } else if (mainConfigYaml) {
-            std::optional<TString> storageConfigYaml;
-            std::optional<ui64> storageConfigYamlVersion;
-            if (StorageConfig->HasCompressedStorageYaml()) {
-                try {
-                    TStringInput s(StorageConfig->GetCompressedStorageYaml());
-                    storageConfigYaml.emplace(TZstdDecompress(&s).ReadAll());
-                    storageConfigYamlVersion.emplace(NYamlConfig::GetStorageMetadata(*storageConfigYaml).Version.value_or(0));
-                } catch (const std::exception& ex) {
-                    Y_ABORT("CompressedStorageYaml format incorrect: %s", ex.what());
-                }
-            }
+            std::optional<TString> storageConfigYaml = GetStorageYaml(*StorageConfig);
+            std::optional<ui64> storageConfigYamlVersion = storageConfigYaml
+                ? std::make_optional(NYamlConfig::GetStorageMetadata(*storageConfigYaml).Version.value_or(0))
+                : std::nullopt;
 
             // TODO(alexvru): make this blocker for confirmation?
             PersistConfig(std::move(mainConfigYaml), mainConfigYamlVersion, std::move(storageConfigYaml),

--- a/ydb/core/cms/console/configs_dispatcher.cpp
+++ b/ydb/core/cms/console/configs_dispatcher.cpp
@@ -926,10 +926,6 @@ public:
         return Config;
     }
 
-    bool HasMainYamlConfig() const override {
-        return !MainYamlConfig.empty();
-    }
-
     TMap<ui64, TString> GetVolatileYamlConfigs() const override {
         return VolatileYamlConfigs;
     }
@@ -942,7 +938,7 @@ public:
         return DatabaseYamlConfig;
     }
 
-    const TString& GetStorageYamlConfig() const override {
+    const std::optional<TString>& GetStorageYamlConfig() const override {
         return StorageYamlConfig;
     }
 
@@ -950,15 +946,19 @@ public:
         return SourceAddress;
     }
 
-    const TString& GetMainYamlConfig() const override {
+    const std::optional<TString>& GetMainYamlConfig() const override {
         return MainYamlConfig;
     }
 
+    bool IsTransient() const override {
+        return false;
+    }
+
     NKikimrConfig::TAppConfig Config;
-    TString MainYamlConfig;
+    std::optional<TString> MainYamlConfig;
     TMap<ui64, TString> VolatileYamlConfigs;
     TString DatabaseYamlConfig;
-    TString StorageYamlConfig;
+    std::optional<TString> StorageYamlConfig;
     TString SourceAddress;
 };
 
@@ -990,7 +990,9 @@ try {
     
     switch (configSource) {
         case EConfigSource::SeedNodes:
-            configs->StorageYamlConfig = StartupStorageYaml;
+            if (StartupStorageYaml) {
+                configs->StorageYamlConfig = StartupStorageYaml;
+            }
             {
                 auto configClient = std::make_unique<TConfigClientMock>();
                 configClient->SavedResult = configs;

--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -2,6 +2,7 @@
 #include "mock.h"
 #include <ydb/library/yaml_json/yaml_to_json.h>
 #include <ydb/core/util/backoff.h>
+#include <util/generic/overloaded.h>
 
 namespace NKikimr::NConfig {
 
@@ -293,21 +294,23 @@ class TDynConfigResultWrapper
     : public IConfigurationResult
 {
     NKikimr::NClient::TConfigurationResult Result;
+    std::optional<TString> MainYamlConfig;
+
 public:
     TDynConfigResultWrapper(NKikimr::NClient::TConfigurationResult&& result)
         : Result(std::move(result))
-    {}
+    {
+        if (Result.HasMainYamlConfig()) {
+            MainYamlConfig.emplace(Result.GetMainYamlConfig());
+        }
+    }
 
     const NKikimrConfig::TAppConfig& GetConfig() const override {
         return Result.GetConfig();
     }
 
-    bool HasMainYamlConfig() const override {
-        return Result.HasMainYamlConfig();
-    }
-
-    const TString& GetMainYamlConfig() const override {
-        return Result.GetMainYamlConfig();
+    const std::optional<TString>& GetMainYamlConfig() const override {
+        return MainYamlConfig;
     }
 
     TMap<ui64, TString> GetVolatileYamlConfigs() const override {
@@ -471,26 +474,23 @@ class TConfigResultWrapper
 public:
     TConfigResultWrapper(const NYdb::NConfig::TFetchConfigResult& result, const TString& sourceAddress = TString()) 
         : SourceAddress(sourceAddress)
+        , Transient(result.Transient())
     {
-        TString clusterConfig;
-        TString storageConfig;
         for (const auto& entry : result.GetConfigs()) {
-            std::visit([&](auto&& arg) {
-                using T = std::decay_t<decltype(arg)>;
-                if constexpr (std::is_same_v<T, NYdb::NConfig::TMainConfigIdentity>) {
-                    MainYamlConfig = entry.Config;
-                } else if constexpr (std::is_same_v<T, NYdb::NConfig::TStorageConfigIdentity>) {
-                    StorageYamlConfig = entry.Config;
-                }
+            std::visit(TOverloaded{
+                [&](const NYdb::NConfig::TMainConfigIdentity&) { MainYamlConfig.emplace(entry.Config); },
+                [&](const NYdb::NConfig::TStorageConfigIdentity&) { StorageYamlConfig.emplace(entry.Config); },
+                [&](const NYdb::NConfig::TDatabaseConfigIdentity&) {},
+                [&](const std::monostate&) { Y_DEBUG_ABORT(); }
             }, entry.Identity);
         }
     }
 
-    const TString& GetMainYamlConfig() const override {
+    const std::optional<TString>& GetMainYamlConfig() const override {
         return MainYamlConfig;
     }
 
-    const TString& GetStorageYamlConfig() const override {
+    const std::optional<TString>& GetStorageYamlConfig() const override {
         return StorageYamlConfig;
     }
 
@@ -498,10 +498,15 @@ public:
         return SourceAddress;
     }
 
+    bool IsTransient() const override {
+        return Transient;
+    }
+
 private:
-    TString MainYamlConfig;
-    TString StorageYamlConfig;
+    std::optional<TString> MainYamlConfig;
+    std::optional<TString> StorageYamlConfig;
     TString SourceAddress;
+    bool Transient;
 };
 
 class TDefaultConfigClient
@@ -511,15 +516,20 @@ private:
     static NYdb::NConfig::TFetchConfigResult TryToFetchConfig(
         const TGrpcSslSettings& grpcSettings,
         const TString& addrs,
-        const IEnv& env)
+        const IEnv& env,
+        const std::vector<TString>& hostOptions,
+        int interconnectPort)
     {
-
         NYdb::TDriverConfig config = CreateDriverConfig(grpcSettings, addrs, env);
 
         auto connection = NYdb::TDriver(config);
 
         auto client = NYdb::NConfig::TConfigClient(connection);
-        NYdb::NConfig::TFetchConfigResult result = client.FetchAllConfigs().GetValueSync();
+        std::vector<std::string> hostOptionsAdopted;
+        for (const TString& host : hostOptions) {
+            hostOptionsAdopted.emplace_back(host.data(), host.size());
+        }
+        NYdb::NConfig::TFetchConfigResult result = client.FetchAllConfigs(hostOptionsAdopted, interconnectPort).GetValueSync();
         connection.Stop(true);
         return result;
     }
@@ -533,7 +543,9 @@ private:
         const TGrpcSslSettings& grpcSettings,
         const TVector<TString>& addrs,
         const IEnv& env,
-        IInitLogger& logger)
+        IInitLogger& logger,
+        const std::vector<TString>& hostOptions,
+        int interconnectPort)
     {
         std::optional<NYdb::NConfig::TFetchConfigResult> result;
         TString sourceAddress;
@@ -541,7 +553,7 @@ private:
 
         auto attempt = [&](const TString& addr) {
             logger.Out() << "Trying to fetch config from " << addr << Endl;
-            result = TryToFetchConfig(grpcSettings, addr, env);
+            result = TryToFetchConfig(grpcSettings, addr, env, hostOptions, interconnectPort);
             if (result->IsSuccess()) {
                 logger.Out() << "Success. Fetched config from " << addr << Endl;
                 sourceAddress = addr;
@@ -566,9 +578,11 @@ public:
         const TGrpcSslSettings& grpcSettings,
         const TVector<TString>& addrs,
         const IEnv& env,
-        IInitLogger& logger) const override
+        IInitLogger& logger,
+        const std::vector<TString>& hostOptions,
+        int interconnectPort) const override
     {
-        auto fetchResult = FetchConfigImpl(grpcSettings, addrs, env, logger);
+        auto fetchResult = FetchConfigImpl(grpcSettings, addrs, env, logger, hostOptions, interconnectPort);
         if (!fetchResult.Result.IsSuccess()) {
             return nullptr;
         }
@@ -748,37 +762,15 @@ void LoadBootstrapConfig(IProtoConfigFileProvider& protoConfigFileProvider, IErr
     }
 }
 
-void LoadMainYamlConfig(
+void ApplyMainYamlConfig(
     TConfigRefs refs,
-    const TString& mainYamlConfigFile,
-    const TString& storageYamlConfigFile,
+    const TString& mainYamlConfigString,
+    const std::optional<TString>& storageYamlConfigString,
     bool loadedFromStore,
     NKikimrConfig::TAppConfig& appConfig,
-    NYamlConfig::IConfigSwissKnife* csk,
     const NCompat::TSourceLocation location)
 {
-    if (!mainYamlConfigFile) {
-        return;
-    }
-
     IConfigUpdateTracer& configUpdateTracer = refs.Tracer;
-    IErrorCollector& errorCollector = refs.ErrorCollector;
-    IProtoConfigFileProvider& protoConfigFileProvider = refs.ProtoConfigFileProvider;
-
-    std::optional<TString> storageYamlConfigString;
-    if (storageYamlConfigFile) {
-        storageYamlConfigString.emplace(protoConfigFileProvider.GetProtoFromFile(storageYamlConfigFile, errorCollector));
-
-        if (csk) {
-            csk->VerifyStorageConfig(*storageYamlConfigString);
-        }
-    }
-
-    const TString mainYamlConfigString = protoConfigFileProvider.GetProtoFromFile(mainYamlConfigFile, errorCollector);
-
-    if (csk) {
-        csk->VerifyMainConfig(mainYamlConfigString);
-    }
 
     appConfig.SetStartupConfigYaml(mainYamlConfigString);
     if (storageYamlConfigString) {
@@ -901,9 +893,9 @@ NClient::TKikimr GetKikimr(const TGrpcSslSettings& cf, const TString& addr, cons
 
 NKikimrConfig::TAppConfig GetYamlConfigFromResult(const IConfigurationResult& result, const TMap<TString, TString>& labels) {
     NKikimrConfig::TAppConfig appConfig;
-    if (result.HasMainYamlConfig() && !result.GetMainYamlConfig().empty()) {
+    if (const auto& config = result.GetMainYamlConfig(); config && *config) {
         NYamlConfig::ResolveAndParseYamlConfig(
-            result.GetMainYamlConfig(),
+            *config,
             result.GetVolatileYamlConfigs(),
             labels,
             appConfig,

--- a/ydb/core/config/init/init.h
+++ b/ydb/core/config/init/init.h
@@ -158,8 +158,7 @@ class IConfigurationResult {
 public:
     virtual ~IConfigurationResult() {}
     virtual const NKikimrConfig::TAppConfig& GetConfig() const = 0;
-    virtual bool HasMainYamlConfig() const = 0;
-    virtual const TString& GetMainYamlConfig() const = 0;
+    virtual const std::optional<TString>& GetMainYamlConfig() const = 0;
     virtual TMap<ui64, TString> GetVolatileYamlConfigs() const = 0;
     virtual bool HasDatabaseYamlConfig() const = 0;
     virtual const TString& GetDatabaseYamlConfig() const = 0;
@@ -181,9 +180,10 @@ public:
 class IStorageConfigResult {
 public:
     virtual ~IStorageConfigResult() {}
-    virtual const TString& GetMainYamlConfig() const = 0;
-    virtual const TString& GetStorageYamlConfig() const = 0;
+    virtual const std::optional<TString>& GetMainYamlConfig() const = 0;
+    virtual const std::optional<TString>& GetStorageYamlConfig() const = 0;
     virtual const TString& GetSourceAddress() const = 0;
+    virtual bool IsTransient() const = 0;
 };
 
 class IConfigClient {
@@ -193,7 +193,9 @@ public:
         const TGrpcSslSettings& grpcSettings,
         const TVector<TString>& addrs,
         const IEnv& env,
-        IInitLogger& logger) const = 0;
+        IInitLogger& logger,
+        const std::vector<TString>& hostOptions,
+        int interconnectPort) const = 0;
 };
 
 // ===

--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -179,9 +179,9 @@ auto MutableConfigPartMerge(
 
 void AddProtoConfigOptions(IProtoConfigFileProvider& out);
 void LoadBootstrapConfig(IProtoConfigFileProvider& protoConfigFileProvider, IErrorCollector& errorCollector, TVector<TString> configFiles, NKikimrConfig::TAppConfig& out);
-void LoadMainYamlConfig(TConfigRefs refs, const TString& mainYamlConfigFile, const TString& storageYamlConfigFile,
+void ApplyMainYamlConfig(TConfigRefs refs, const TString& mainYamlConfigString,
+    const std::optional<TString>& storageYamlConfigString,
     bool loadedFromStore, NKikimrConfig::TAppConfig& appConfig,
-    NYamlConfig::IConfigSwissKnife* csk,
     const NCompat::TSourceLocation location = NCompat::TSourceLocation::current());
 void CopyNodeLocation(NActorsInterconnect::TNodeLocation* dst, const NYdb::NDiscovery::TNodeLocation& src);
 void CopyNodeLocation(NYdb::NDiscovery::TNodeLocation* dst, const NActorsInterconnect::TNodeLocation& src);
@@ -1123,9 +1123,10 @@ public:
         Option("auth-file", TCfg::TAuthConfigFieldTag{});
         LoadBootstrapConfig(ProtoConfigFileProvider, ErrorCollector, freeArgs, BaseConfig);
 
-        TString yamlConfigFile = CommonAppOptions.YamlConfigFile;
-        TString storageYamlConfigFile;
         bool loadedFromStore = false;
+
+        std::optional<TString> mainYamlConfigString;
+        std::optional<TString> storageYamlConfigString;
 
         if (CommonAppOptions.ConfigDirPath) {
             AppConfig.SetConfigDirPath(CommonAppOptions.ConfigDirPath);
@@ -1133,14 +1134,27 @@ public:
             auto dir = fs::path(CommonAppOptions.ConfigDirPath.c_str());
 
             if (auto path = dir / STORAGE_CONFIG_NAME; fs::is_regular_file(path)) {
-                storageYamlConfigFile = path.string();
+                storageYamlConfigString.emplace(ProtoConfigFileProvider.GetProtoFromFile(path.string(), ErrorCollector));
+                if (csk) {
+                    csk->VerifyStorageConfig(*storageYamlConfigString);
+                }
             }
 
             if (auto path = dir / CONFIG_NAME; fs::is_regular_file(path)) {
-                yamlConfigFile = path.string();
+                mainYamlConfigString.emplace(ProtoConfigFileProvider.GetProtoFromFile(path.string(), ErrorCollector));
+                if (csk) {
+                    csk->VerifyMainConfig(*mainYamlConfigString);
+                }
                 loadedFromStore = true;
             } else {
-                storageYamlConfigFile.clear();
+                storageYamlConfigString.reset();
+            }
+        }
+
+        if (!mainYamlConfigString && CommonAppOptions.YamlConfigFile) {
+            mainYamlConfigString.emplace(ProtoConfigFileProvider.GetProtoFromFile(CommonAppOptions.YamlConfigFile, ErrorCollector));
+            if (csk) {
+                csk->VerifyMainConfig(*mainYamlConfigString);
             }
         }
 
@@ -1148,16 +1162,19 @@ public:
             ParseSeedNodes(CommonAppOptions);
         }
 
-        if (CommonAppOptions.IsStaticNode()) {
-            if (yamlConfigFile.empty() && CommonAppOptions.SeedNodesFile) {
-                InitConfigFromSeedNodes(yamlConfigFile, storageYamlConfigFile);
-            }
-            if (!CommonAppOptions.ConfigDirPath.empty() && yamlConfigFile.empty()) {
-                ythrow yexception() << "YAML config is not provided for static node";
+        if (CommonAppOptions.IsStaticNode() && !mainYamlConfigString) {
+            if (CommonAppOptions.SeedNodesFile) {
+                InitConfigFromSeedNodes(mainYamlConfigString.emplace(), storageYamlConfigString);
+                Y_ABORT_UNLESS(mainYamlConfigString);
+            } else {
+                ythrow yexception() << "YAML config is not provided for static node and no seed nodes given";
             }
         }
 
-        LoadMainYamlConfig(refs, yamlConfigFile, storageYamlConfigFile, loadedFromStore, AppConfig, csk);
+        if (mainYamlConfigString) {
+            ApplyMainYamlConfig(refs, *mainYamlConfigString, storageYamlConfigString, loadedFromStore, AppConfig);
+        }
+
         OptionMerge("auth-token-file", TCfg::TAuthConfigFieldTag{});
 
         // start memorylog as soon as possible
@@ -1179,7 +1196,9 @@ public:
             InitDynamicNode();
         }
 
-        LoadMainYamlConfig(refs, yamlConfigFile, storageYamlConfigFile, loadedFromStore, AppConfig, csk);
+        if (mainYamlConfigString) {
+            ApplyMainYamlConfig(refs, *mainYamlConfigString, storageYamlConfigString, loadedFromStore, AppConfig);
+        }
 
         // disable as early as possible to properly propagate it everywhere
         if (CommonAppOptions.TinyMode) {
@@ -1561,75 +1580,83 @@ public:
         }
     }
 
-    void InitConfigFromSeedNodes(TString& yamlConfigFile, TString& storageYamlConfigFile) {
-        if (AppConfig.GetConfigDirPath().empty()) {
+    void InitConfigFromSeedNodes(TString& mainYamlConfigString, std::optional<TString>& storageYamlConfigString) {
+        if (!AppConfig.GetConfigDirPath()) {
             ythrow yexception() << "Seed nodes file provided, but config dir path is not set";
         }
 
-        if (CommonAppOptions.SeedNodes.empty()) {
-            ythrow yexception() << "No seed nodes provided";
+        std::vector<TString> hostOptions = {
+            // possible variants how host can be identified in config; they should be kept consistent with DeduceNodeId code
+            Env.HostName(),
+            Env.FQDNHostName(),
+        };
+        std::ranges::sort(hostOptions);
+        auto [begin, end] = std::ranges::unique(hostOptions);
+        hostOptions.erase(begin, end);
+        auto result = ConfigClient.FetchConfig(CommonAppOptions.GrpcSslSettings, CommonAppOptions.SeedNodes, Env, Logger,
+            hostOptions, CommonAppOptions.InterconnectPort);
+        if (!result) {
+            ythrow yexception() << "Failed to fetch config from seed nodes for static node";
         }
 
-        auto result = ConfigClient.FetchConfig(CommonAppOptions.GrpcSslSettings, CommonAppOptions.SeedNodes, Env, Logger);
-        if (!result) {
-            Logger.Out() << "Failed to fetch config from seed nodes" << Endl;
+        if (const auto& config = result->GetMainYamlConfig()) {
+            mainYamlConfigString = *config;
+        } else {
+            ythrow yexception() << "No main YAML config has been provided from seed nodes for static node";
+        }
+
+        storageYamlConfigString = result->GetStorageYamlConfig();
+
+        if (result->IsTransient()) {
+            // we do not want to save transient configs into filesystem
             return;
         }
 
-        const TString& clusterConfig = result->GetMainYamlConfig();
-        const TString& storageConfig = result->GetStorageYamlConfig();
-        const TString configDirPath = AppConfig.GetConfigDirPath();
+        const fs::path configDirPath(AppConfig.GetConfigDirPath().c_str());
 
         auto saveConfig = [&](const TString& config, const TString& configName) {
             try {
-                TString tempPath = TStringBuilder() << AppConfig.GetConfigDirPath() << "/temp_" << configName;
-                TString configPath = TStringBuilder() << AppConfig.GetConfigDirPath() << "/" << configName;
-            {
-                TFileOutput tempFile(tempPath);
-                tempFile << config;
-                tempFile.Flush();
-
+                fs::path tempPath = configDirPath / (TStringBuilder() << configName << "."
+                    << Sprintf("%08" PRIx32, RandomNumber<ui32>())).c_str();
+                *std::make_unique<TFileOutput>(tempPath) << config;
                 if (Chmod(tempPath.c_str(), S_IRUSR | S_IRGRP | S_IROTH) != 0) {
+                    NFs::Remove(tempPath.string());
                     return false;
                 }
-            }
 
-            return NFs::Rename(tempPath, configPath);
+                fs::path configPath = configDirPath / configName.c_str();
+                if (!NFs::Rename(tempPath.string(), configPath.string())) {
+                    NFs::Remove(tempPath.string());
+                    return false;
+                }
+
+                return true;
             } catch (const std::exception& e) {
                 return false;
             }
         };
 
-        bool clusterSaved = !clusterConfig.empty() && saveConfig(clusterConfig, CONFIG_NAME);
-        bool storageSaved = !storageConfig.empty() && saveConfig(storageConfig, STORAGE_CONFIG_NAME);
+        const bool mainError = !saveConfig(mainYamlConfigString, CONFIG_NAME);
+        const bool storageError = storageYamlConfigString && !saveConfig(*storageYamlConfigString, STORAGE_CONFIG_NAME);
 
-        if (clusterSaved) {
-            yamlConfigFile = configDirPath + "/" + CONFIG_NAME;
-        }
-        if (storageSaved) {
-            storageYamlConfigFile = configDirPath + "/" + STORAGE_CONFIG_NAME;
-        }
-
-        if (clusterSaved && storageSaved) {
-            Logger.Out() << "Initialized main and storage configs in " << configDirPath << "/"
-                         << CONFIG_NAME << " and " << STORAGE_CONFIG_NAME << Endl;
-        } else if (clusterSaved) {
-            Logger.Out() << "Initialized config in " << configDirPath << "/" << CONFIG_NAME << Endl;
-        } else if (!clusterConfig.empty() || !storageConfig.empty()) {
+        if (mainError || storageError) {
             TStringBuilder errorMsg;
             errorMsg << "Failed to save configs: ";
-            if (!clusterConfig.empty() && !clusterSaved) {
+            if (mainError) {
                 errorMsg << "main config";
             }
-            if (!storageConfig.empty() && !storageSaved) {
-                if (!clusterConfig.empty() && !clusterSaved) {
+            if (storageError) {
+                if (mainError) {
                     errorMsg << ", ";
                 }
                 errorMsg << "storage config";
             }
             ythrow yexception() << errorMsg;
+        } else if (storageYamlConfigString) {
+            Logger.Out() << "Initialized main and storage configs in " << configDirPath << "/"
+                << CONFIG_NAME << " and " << STORAGE_CONFIG_NAME << Endl;
         } else {
-            Logger.Out() << "No configs received from seed nodes" << Endl;
+            Logger.Out() << "Initialized config in " << configDirPath << "/" << CONFIG_NAME << Endl;
         }
     }
 
@@ -1649,21 +1676,21 @@ public:
             ythrow yexception() << "No seed nodes provided";
         }
 
-        auto cfgResult = ConfigClient.FetchConfig(CommonAppOptions.GrpcSslSettings, CommonAppOptions.SeedNodes, Env, Logger);
+        auto cfgResult = ConfigClient.FetchConfig(CommonAppOptions.GrpcSslSettings, CommonAppOptions.SeedNodes, Env, Logger, {}, 0);
         if (!cfgResult) {
             Logger.Out() << "Failed to fetch config from seed nodes" << Endl;
             return;
         }
 
-        const TString& mainYaml = cfgResult->GetMainYamlConfig();
-        if (mainYaml.empty()) {
+        const std::optional<TString>& mainYaml = cfgResult->GetMainYamlConfig();
+        if (!mainYaml) {
             Logger.Out() << "No main config received from seed nodes" << Endl;
             return;
         }
 
         const TString& sourceAddress = cfgResult->GetSourceAddress();
         NKikimrConfig::TAppConfig yamlConfig;
-        NYamlConfig::ResolveAndParseYamlConfig(mainYaml, {}, Labels, yamlConfig);
+        NYamlConfig::ResolveAndParseYamlConfig(*mainYaml, {}, Labels, yamlConfig);
 
         yamlConfig.SetYamlConfigEnabled(true);
         Labels["config_source"] = "seed_nodes";

--- a/ydb/core/config/init/init_noop.cpp
+++ b/ydb/core/config/init/init_noop.cpp
@@ -70,7 +70,9 @@ public:
         const TGrpcSslSettings&,
         const TVector<TString>&,
         const IEnv&,
-        IInitLogger&) const override
+        IInitLogger&,
+        const std::vector<TString>&,
+        int) const override
     {
         return nullptr;
     }

--- a/ydb/core/config/init/mock.h
+++ b/ydb/core/config/init/mock.h
@@ -242,7 +242,9 @@ public:
         const TGrpcSslSettings& grpcSettings,
         const TVector<TString>& addrs,
         const IEnv& env,
-        IInitLogger& logger) const override
+        IInitLogger& logger,
+        const std::vector<TString>&,
+        int) const override
     {
         Y_UNUSED(grpcSettings, addrs, env, logger);
         return SavedResult;
@@ -265,9 +267,11 @@ public:
         const TGrpcSslSettings& grpcSettings,
         const TVector<TString>& addrs,
         const IEnv& env,
-        IInitLogger& logger) const override
+        IInitLogger& logger,
+        const std::vector<TString>& hostOptions,
+        int interconnectPort) const override
     {
-        Mock.SavedResult = Impl.FetchConfig(grpcSettings, addrs, env, logger);
+        Mock.SavedResult = Impl.FetchConfig(grpcSettings, addrs, env, logger, hostOptions, interconnectPort);
         return Mock.SavedResult;
     }
 

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -438,6 +438,13 @@ public:
                     default:
                         break;
                 }
+                if (request.has_seed_node_fetch_requestor()) {
+                    auto& r = request.seed_node_fetch_requestor();
+                    for (const auto& host : r.host()) {
+                        record->AddRequestorHost(host);
+                    }
+                    record->SetRequestorPort(r.port());
+                }
                 break;
 
             case Ydb::Config::FetchConfigRequest::ModeCase::kTarget:
@@ -474,6 +481,9 @@ public:
             identity.set_cluster(AppData()->ClusterName);
             identity.mutable_storage();
             config.set_config(conf);
+        }
+        if (res.GetTransient()) {
+            result.set_transient(true);
         }
     }
 

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -250,6 +250,8 @@ message TEvNodeConfigInvokeOnRoot {
         bool StorageConfig = 3;
         bool AddSectionsForMigrationToV1 = 5; // add sections so this config becomes suitable for migration to v1
         bool AddExplicitConfigs = 4; // add explicit settings for all managed entities
+        repeated string RequestorHost = 6;
+        uint32 RequestorPort = 7;
     }
 
     message TReplaceStorageConfig {
@@ -339,6 +341,7 @@ message TEvNodeConfigInvokeOnRootResult {
     message TFetchStorageConfig {
         optional string YAML = 1;
         optional string StorageYAML = 2;
+        bool Transient = 3;
     }
 
     message TReplaceStorageConfig {

--- a/ydb/public/api/protos/ydb_config.proto
+++ b/ydb/public/api/protos/ydb_config.proto
@@ -108,6 +108,14 @@ message ReplaceConfigResult {}
 message FetchConfigRequest {
     Ydb.Operations.OperationParams operation_params = 1;
 
+    message SeedNodeFetchRequestor {
+        // Config requestor hostname options (any of them will do).
+        repeated string host = 1;
+
+        // Config requestor IC port.
+        int32 port = 2;
+    }
+
     // Settings for mode "all"
     // In this mode server will return all configs to user
     // There are additional settings allowing to transform configs in server answer
@@ -158,6 +166,10 @@ message FetchConfigRequest {
         // Fetch all configs with matching identities
         FetchModeByIdentity target = 3;
     }
+
+    // This is filled in when the config is being fetched from seed node. It will block until requestor is available
+    // in reported config node list.
+    SeedNodeFetchRequestor seed_node_fetch_requestor = 4;
 }
 
 message FetchConfigResponse {
@@ -174,6 +186,9 @@ message ConfigEntry {
 
 message FetchConfigResult {
     repeated ConfigEntry config = 1;
+
+    // if set to true, this config can not be persisted on the receiving node
+    bool transient = 2;
 }
 
 message BootstrapClusterRequest {

--- a/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
@@ -126,7 +126,7 @@ int TCommandConfigFetch::Run(TConfig& config) {
     auto driver = std::make_unique<NYdb::TDriver>(CreateDriver(config));
     auto client = NYdb::NConfig::TConfigClient(*driver);
 
-    NYdb::NConfig::TFetchConfigResult result(TStatus(EStatus::CLIENT_CALL_UNIMPLEMENTED, {}), {});
+    NYdb::NConfig::TFetchConfigResult result(TStatus(EStatus::CLIENT_CALL_UNIMPLEMENTED, {}), {}, {});
 
     if (!UseLegacyApi) {
         NYdb::NConfig::TFetchAllConfigsSettings settings;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/config/config.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/config/config.h
@@ -62,17 +62,24 @@ struct TConfig {
 struct TFetchConfigResult : public TStatus {
     TFetchConfigResult(
             TStatus&& status,
-            std::vector<TConfig>&& configs)
+            std::vector<TConfig>&& configs,
+            bool transient)
         : TStatus(std::move(status))
         , Configs_(std::move(configs))
+        , Transient_(transient)
     {}
 
     const std::vector<TConfig>& GetConfigs() const {
         return Configs_;
     }
 
+    bool Transient() const {
+        return Transient_;
+    }
+
 private:
     std::vector<TConfig> Configs_;
+    bool Transient_;
 };
 
 using TAsyncFetchConfigResult = NThreading::TFuture<TFetchConfigResult>;
@@ -107,6 +114,11 @@ public:
 
     // Fetch current cluster storage config
     TAsyncFetchConfigResult FetchAllConfigs(const TFetchAllConfigsSettings& settings = {});
+
+    // Fetch current cluster storage config
+    TAsyncFetchConfigResult FetchAllConfigs(const std::vector<std::string>& requestor_host_options,
+        std::int32_t requestor_port,
+        const TFetchAllConfigsSettings& settings = {});
 
     // Bootstrap cluster with automatic configuration
     TAsyncStatus BootstrapCluster(

--- a/ydb/tests/functional/config/test_distconf.py
+++ b/ydb/tests/functional/config/test_distconf.py
@@ -372,7 +372,7 @@ class TestKiKiMRDistConfBasic(DistConfKiKiMRTest):
         try:
             pdisk_info = self.swagger_client.pdisk_info(new_node.node_id)
 
-            pdisks_list = pdisk_info['PDiskStateInfo']
+            pdisks_list = pdisk_info.get('PDiskStateInfo', [])
 
             found_pdisk_in_viewer = False
             for pdisk_entry in pdisks_list:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow correct operation of seed nodes while adding new hosts in distconf

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch ensures correct adding of new nodes into cluster when using seed nodes. It allows distconf to hold with answer until configuration is replaced by user.
