### PR TITLE
Add kv api v2

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -117,7 +117,8 @@
 #include <ydb/services/fq/private_grpc.h>
 #include <ydb/services/fq/ydb_over_fq.h>
 #include <ydb/services/kesus/grpc_service.h>
-#include <ydb/services/keyvalue/grpc_service.h>
+#include <ydb/services/keyvalue/grpc_service_v1.h>
+#include <ydb/services/keyvalue/grpc_service_v2.h>
 #include <ydb/services/local_discovery/grpc_service.h>
 #include <ydb/services/maintenance/grpc_service.h>
 #include <ydb/services/monitoring/grpc_service.h>
@@ -1087,7 +1088,9 @@ TGRpcServers TKikimrRunner::CreateGRpcServers(const TKikimrRunConfig& runConfig)
         }
 
         if (hasKeyValue) {
-            server.AddService(new NGRpcService::TKeyValueGRpcService(ActorSystem.Get(), Counters,
+            server.AddService(new NGRpcService::TKeyValueGRpcServiceV1(ActorSystem.Get(), Counters,
+                grpcRequestProxies[0]));
+            server.AddService(new NGRpcService::TKeyValueGRpcServiceV2(ActorSystem.Get(), Counters,
                 grpcRequestProxies[0]));
         }
 

--- a/ydb/core/grpc_services/rpc_keyvalue.cpp
+++ b/ydb/core/grpc_services/rpc_keyvalue.cpp
@@ -940,11 +940,12 @@ protected:
             TResultRecord result;
             CopyProtobuf(ev->Get()->Record, &result);
             this->ReplyWithResult(status, result, TActivationContext::AsActorContext());
-        } else {
-            TResultRecord* result = google::protobuf::Arena::CreateMessage<TResultRecord>(this->Request->GetArena());
-            CopyProtobuf(ev->Get()->Record, result);
-            result->set_status(status);
-            this->Request->Reply(result, status);
+        } else {      
+            TResultRecord result;//google::protobuf::Arena::CreateMessage<TResultRecord>(this->Request->GetArena());
+            CopyProtobuf(ev->Get()->Record, &result);
+            result.set_status(status);
+            this->Request->Reply(&result, status);
+            PassAway();
         }
     }
 
@@ -983,10 +984,12 @@ protected:
             if (const auto& userToken = this->Request_->GetSerializedToken()) {
                 return new NACLib::TUserToken(userToken);
             }
-            return nullptr;
         } else {
-            return new NACLib::TUserToken(*this->TBase::UserToken);
+            if (this->TBase::UserToken) {
+                return new NACLib::TUserToken(*this->TBase::UserToken);
+            }
         }
+        return nullptr;
     }
 
     TString GetDatabaseName() {

--- a/ydb/core/grpc_services/rpc_keyvalue.cpp
+++ b/ydb/core/grpc_services/rpc_keyvalue.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/base/path.h>
 #include <ydb/core/grpc_services/rpc_scheme_base.h>
 #include <ydb/core/grpc_services/rpc_common/rpc_common.h>
+#include <ydb/core/grpc_services/rpc_request_base.h>
 #include <ydb/core/keyvalue/keyvalue_events.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
@@ -36,21 +37,39 @@ using TEvListLocalPartitionsKeyValueRequest =
 using TEvAcquireLockKeyValueRequest =
     TGrpcRequestOperationCall<Ydb::KeyValue::AcquireLockRequest,
         Ydb::KeyValue::AcquireLockResponse>;
+using TEvAcquireLockKeyValueV2Request =
+    TGrpcRequestNoOperationCall<Ydb::KeyValue::AcquireLockRequest,
+        Ydb::KeyValue::AcquireLockResult>;
 using TEvExecuteTransactionKeyValueRequest =
     TGrpcRequestOperationCall<Ydb::KeyValue::ExecuteTransactionRequest,
         Ydb::KeyValue::ExecuteTransactionResponse>;
+using TEvExecuteTransactionKeyValueV2Request =
+    TGrpcRequestNoOperationCall<Ydb::KeyValue::ExecuteTransactionRequest,
+        Ydb::KeyValue::ExecuteTransactionResult>;
 using TEvReadKeyValueRequest =
     TGrpcRequestOperationCall<Ydb::KeyValue::ReadRequest,
         Ydb::KeyValue::ReadResponse>;
+using TEvReadKeyValueV2Request =
+    TGrpcRequestNoOperationCall<Ydb::KeyValue::ReadRequest,
+        Ydb::KeyValue::ReadResult>;
 using TEvReadRangeKeyValueRequest =
     TGrpcRequestOperationCall<Ydb::KeyValue::ReadRangeRequest,
         Ydb::KeyValue::ReadRangeResponse>;
+using TEvReadRangeKeyValueV2Request =
+    TGrpcRequestNoOperationCall<Ydb::KeyValue::ReadRangeRequest,
+        Ydb::KeyValue::ReadRangeResult>;
 using TEvListRangeKeyValueRequest =
     TGrpcRequestOperationCall<Ydb::KeyValue::ListRangeRequest,
         Ydb::KeyValue::ListRangeResponse>;
+using TEvListRangeKeyValueV2Request =
+    TGrpcRequestNoOperationCall<Ydb::KeyValue::ListRangeRequest,
+        Ydb::KeyValue::ListRangeResult>;
 using TEvGetStorageChannelStatusKeyValueRequest =
     TGrpcRequestOperationCall<Ydb::KeyValue::GetStorageChannelStatusRequest,
         Ydb::KeyValue::GetStorageChannelStatusResponse>;
+using TEvGetStorageChannelStatusKeyValueV2Request =
+    TGrpcRequestNoOperationCall<Ydb::KeyValue::GetStorageChannelStatusRequest,
+        Ydb::KeyValue::GetStorageChannelStatusResult>;
 
 } // namespace NKikimr::NGRpcService
 
@@ -439,14 +458,11 @@ protected:
     void OnBootstrap() {
         auto self = static_cast<TDerived*>(this);
         Ydb::StatusIds::StatusCode status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
-        NYql::TIssues issues;
-        if (!self->ValidateRequest(status, issues)) {
-            self->Reply(status, issues, self->ActorContext());
+        if (!self->ValidateRequest(status)) {
+            self->Reply(status);
             return;
         }
-        if (const auto& userToken = self->Request_->GetSerializedToken()) {
-            UserToken = new NACLib::TUserToken(userToken);
-        }
+        UserToken = self->GetToken();
         SendNavigateRequest();
     }
 
@@ -460,9 +476,9 @@ protected:
         entry.ShowPrivatePath = true;
         entry.SyncVersion = false;
         req->UserToken = UserToken;
-        req->DatabaseName = self->Request_->GetDatabaseName().GetOrElse("");
+        req->DatabaseName = self->GetDatabaseName();
         auto ev = new TEvTxProxySchemeCache::TEvNavigateKeySet(req.Release());
-        self->Send(MakeSchemeCacheID(), ev, 0, 0, self->Span_.GetTraceId());
+        self->Send(MakeSchemeCacheID(), ev, 0, 0, self->GetTraceId());
     }
 
     bool OnNavigateKeySetResult(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev, ui32 access) {
@@ -470,10 +486,8 @@ protected:
         TEvTxProxySchemeCache::TEvNavigateKeySetResult* res = ev->Get();
         NSchemeCache::TSchemeCacheNavigate *request = res->Request.Get();
 
-        auto ctx = self->ActorContext();
-
         if (res->Request->ResultSet.size() != 1) {
-            self->Reply(StatusIds::INTERNAL_ERROR, "Received an incorrect answer from SchemeCache.", NKikimrIssues::TIssuesIds::UNEXPECTED, ctx);
+            self->Reply(StatusIds::INTERNAL_ERROR, "Received an incorrect answer from SchemeCache.", NKikimrIssues::TIssuesIds::UNEXPECTED);
             return false;
         }
 
@@ -481,33 +495,33 @@ protected:
         case NSchemeCache::TSchemeCacheNavigate::EStatus::Ok:
             break;
         case NSchemeCache::TSchemeCacheNavigate::EStatus::AccessDenied:
-            self->Reply(StatusIds::UNAUTHORIZED, "Access denied.", NKikimrIssues::TIssuesIds::ACCESS_DENIED, ctx);
+            self->Reply(StatusIds::UNAUTHORIZED, "Access denied.", NKikimrIssues::TIssuesIds::ACCESS_DENIED);
             return false;
         case NSchemeCache::TSchemeCacheNavigate::EStatus::RootUnknown:
         case NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown:
-            self->Reply(StatusIds::SCHEME_ERROR, "Path isn't exist.", NKikimrIssues::TIssuesIds::PATH_NOT_EXIST, ctx);
+            self->Reply(StatusIds::SCHEME_ERROR, "Path isn't exist.", NKikimrIssues::TIssuesIds::PATH_NOT_EXIST);
             return false;
         case NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError:
         case NSchemeCache::TSchemeCacheNavigate::EStatus::RedirectLookupError:
-            self->Reply(StatusIds::UNAVAILABLE, "Database resolve failed with no certain result.", NKikimrIssues::TIssuesIds::RESOLVE_LOOKUP_ERROR, ctx);
+            self->Reply(StatusIds::UNAVAILABLE, "Database resolve failed with no certain result.", NKikimrIssues::TIssuesIds::RESOLVE_LOOKUP_ERROR);
             return false;
         default:
-            self->Reply(StatusIds::UNAVAILABLE, "Resolve error", NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, ctx);
+            self->Reply(StatusIds::UNAVAILABLE, "Resolve error", NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR);
             return false;
         }
 
-        if (!self->CheckAccess(CanonizePath(res->Request->ResultSet[0].Path), res->Request->ResultSet[0].SecurityObject, access)) {
+        if (!self->InternalCheckAccess(CanonizePath(res->Request->ResultSet[0].Path), res->Request->ResultSet[0].SecurityObject, access)) {
             return false;
         }
         if (!request->ResultSet[0].SolomonVolumeInfo) {
-            self->Reply(StatusIds::SCHEME_ERROR, "Table isn't keyvalue.", NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ctx);
+            self->Reply(StatusIds::SCHEME_ERROR, "Table isn't keyvalue.", NKikimrIssues::TIssuesIds::DEFAULT_ERROR);
             return false;
         }
 
         return true;
     }
 
-    bool CheckAccess(const TString& path, TIntrusivePtr<TSecurityObject> securityObject, ui32 access) {
+    bool InternalCheckAccess(const TString& path, TIntrusivePtr<TSecurityObject> securityObject, ui32 access) {
         auto self = static_cast<TDerived*>(this);
         if (!UserToken || !securityObject) {
             return true;
@@ -522,8 +536,7 @@ protected:
                 << ": for# " << UserToken->GetUserSID()
                 << ", path# " << path
                 << ", access# " << NACLib::AccessRightsToString(access),
-            NKikimrIssues::TIssuesIds::ACCESS_DENIED,
-            self->ActorContext());
+            NKikimrIssues::TIssuesIds::ACCESS_DENIED);
         return false;
     }
 
@@ -577,12 +590,24 @@ protected:
         this->ReplyWithResult(Ydb::StatusIds::SUCCESS, result, TActivationContext::AsActorContext());
     }
 
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
     }
 
-private:
-    TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    TIntrusiveConstPtr<NACLib::TUserToken> GetToken() {
+        if (const auto& userToken = this->Request_->GetSerializedToken()) {
+            return new NACLib::TUserToken(userToken);
+        }
+        return nullptr;
+    }
+
+    TString GetDatabaseName() {
+        return this->Request_->GetDatabaseName().GetOrElse("");
+    }
+
+    NWilson::TTraceId GetTraceId() {
+        return this->Span_.GetTraceId();
+    }
 };
 
 
@@ -607,7 +632,7 @@ public:
         }
     }
 
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
     } 
 
@@ -670,8 +695,22 @@ public:
         SendProposeRequest(TActivationContext::AsActorContext());
     }
 
+    TIntrusiveConstPtr<NACLib::TUserToken> GetToken() {
+        if (const auto& userToken = this->Request_->GetSerializedToken()) {
+            return new NACLib::TUserToken(userToken);
+        }
+        return nullptr;
+    }
+
+    TString GetDatabaseName() {
+        return this->Request_->GetDatabaseName().GetOrElse("");
+    }
+
+    NWilson::TTraceId GetTraceId() {
+        return this->Span_.GetTraceId();
+    }
+
 private:
-    TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     Ydb::KeyValue::StorageConfig StorageConfig;
 };
 
@@ -768,8 +807,23 @@ protected:
         this->ReplyWithResult(Ydb::StatusIds::SUCCESS, result, TActivationContext::AsActorContext());
     }
 
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
+    }
+
+    TIntrusiveConstPtr<NACLib::TUserToken> GetToken() {
+        if (const auto& userToken = this->Request_->GetSerializedToken()) {
+            return new NACLib::TUserToken(userToken);
+        }
+        return nullptr;
+    }
+
+    TString GetDatabaseName() {
+        return this->Request_->GetDatabaseName().GetOrElse("");
+    }
+
+    NWilson::TTraceId GetTraceId() {
+        return this->Span_.GetTraceId();
     }
 
 private:
@@ -777,14 +831,21 @@ private:
 };
 
 
-template <typename TDerived, typename TRequest, typename TResultRecord, typename TKVRequest>
+template <typename TDerived, typename TRequest, typename TResultRecord, typename TKVRequest, bool IsOperational>
 class TKeyValueRequestGrpc
-    : public TRpcOperationRequestActor<TDerived, TRequest>
-    , public TBaseKeyValueRequest<TKeyValueRequestGrpc<TDerived, TRequest, TResultRecord, TKVRequest>>
+    : public std::conditional_t<IsOperational,
+        TRpcOperationRequestActor<TDerived, TRequest>,
+        TRpcRequestActor<TDerived, TRequest>
+    >
+    , public TBaseKeyValueRequest<TDerived>
 {
 public:
-    using TBase = TRpcOperationRequestActor<TDerived, TRequest>;
+    using TBase = std::conditional_t<IsOperational,
+        TRpcOperationRequestActor<TDerived, TRequest>,
+        TRpcRequestActor<TDerived, TRequest>
+    >;
     using TBase::TBase;
+    using TBase::Reply;
 
     template<typename T, typename = void>
     struct THasMsg: std::false_type
@@ -795,10 +856,12 @@ public:
     template<typename T>
     static constexpr bool HasMsgV = THasMsg<T>::value;
 
-    friend class TBaseKeyValueRequest<TKeyValueRequestGrpc<TDerived, TRequest, TResultRecord, TKVRequest>>;
+    friend class TBaseKeyValueRequest<TDerived>;
 
     void Bootstrap(const TActorContext& ctx) {
-        TBase::Bootstrap(ctx);
+        if constexpr (IsOperational) {
+            TBase::Bootstrap(ctx);
+        }
         this->OnBootstrap();
         this->Become(&TKeyValueRequestGrpc::StateFunc);
     }
@@ -812,7 +875,11 @@ protected:
             hFunc(TKVRequest::TResponse, Handle);
             hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
         default:
-            return TBase::StateFuncBase(ev);
+            if constexpr (IsOperational) {
+                return TBase::StateFuncBase(ev);
+            } else {
+                this->Reply(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Unexpected event received in TKeyValueRequestGrpc::StateWork: " << ev->GetTypeRewrite());
+            }
         }
     }
 
@@ -828,7 +895,7 @@ protected:
         const NKikimrSchemeOp::TSolomonVolumeDescription &desc = request->ResultSet[0].SolomonVolumeInfo->Description;
 
         if (rec.partition_id() >= desc.PartitionsSize()) {
-            this->Reply(StatusIds::SCHEME_ERROR, "The partition wasn't found. Partition ID was larger or equal partition count.", NKikimrIssues::TIssuesIds::DEFAULT_ERROR, this->ActorContext());
+            this->Reply(StatusIds::SCHEME_ERROR, "The partition wasn't found. Partition ID was larger or equal partition count.", NKikimrIssues::TIssuesIds::DEFAULT_ERROR);
             return;
         }
 
@@ -846,7 +913,7 @@ protected:
         }
 
         if (!KVTabletId) {
-            this->Reply(StatusIds::INTERNAL_ERROR, "Partition wasn't found.", NKikimrIssues::TIssuesIds::DEFAULT_ERROR, this->ActorContext());
+            this->Reply(StatusIds::INTERNAL_ERROR, "Partition wasn't found.", NKikimrIssues::TIssuesIds::DEFAULT_ERROR);
             return;
         }
 
@@ -859,19 +926,26 @@ protected:
         auto &rec = *this->GetProtoRequest();
         CopyProtobuf(rec, &req->Record);
         req->Record.set_tablet_id(KVTabletId);
-        NTabletPipe::SendData(this->SelfId(), KVPipeClient, req.release(), 0, TBase::Span_.GetTraceId());
+        NTabletPipe::SendData(this->SelfId(), KVPipeClient, req.release(), 0, GetTraceId());
     }
 
     void Handle(typename TKVRequest::TResponse::TPtr &ev) {
         auto status = PullStatus(ev->Get()->Record);
         if constexpr (HasMsgV<decltype(ev->Get()->Record)>) {
             if (status != Ydb::StatusIds::SUCCESS) {
-                this->Reply(status, ev->Get()->Record.msg(), NKikimrIssues::TIssuesIds::DEFAULT_ERROR, this->ActorContext());
+                this->Reply(status, ev->Get()->Record.msg(), NKikimrIssues::TIssuesIds::DEFAULT_ERROR);
             }
         }
-        TResultRecord result;
-        CopyProtobuf(ev->Get()->Record, &result);
-        this->ReplyWithResult(status, result, TActivationContext::AsActorContext());
+        if constexpr (IsOperational) {
+            TResultRecord result;
+            CopyProtobuf(ev->Get()->Record, &result);
+            this->ReplyWithResult(status, result, TActivationContext::AsActorContext());
+        } else {
+            TResultRecord* result = google::protobuf::Arena::CreateMessage<TResultRecord>(this->Request->GetArena());
+            CopyProtobuf(ev->Get()->Record, result);
+            result->set_status(status);
+            this->Request->Reply(result, status);
+        }
     }
 
     NTabletPipe::TClientConfig GetPipeConfig() {
@@ -888,15 +962,13 @@ protected:
 
     void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
         if (ev->Get()->Status != NKikimrProto::OK) {
-            this->Reply(StatusIds::UNAVAILABLE, "Failed to connect to coordination node.", NKikimrIssues::TIssuesIds::SHARD_NOT_AVAILABLE, this->ActorContext());
+            this->Reply(StatusIds::UNAVAILABLE, "Failed to connect to partition.", NKikimrIssues::TIssuesIds::SHARD_NOT_AVAILABLE);
         }
     }
 
     void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr&) {
-        this->Reply(StatusIds::UNAVAILABLE, "Connection to coordination node was lost.", NKikimrIssues::TIssuesIds::SHARD_NOT_AVAILABLE, this->ActorContext());
+        this->Reply(StatusIds::UNAVAILABLE, "Connection to partition was lost.", NKikimrIssues::TIssuesIds::SHARD_NOT_AVAILABLE);
     }
-
-    virtual bool ValidateRequest(Ydb::StatusIds::StatusCode& status, NYql::TIssues& issues) = 0;
 
     void PassAway() override {
         if (KVPipeClient) {
@@ -906,21 +978,51 @@ protected:
         TBase::PassAway();
     }
 
+    TIntrusiveConstPtr<NACLib::TUserToken> GetToken() {
+        if constexpr (IsOperational) {
+            if (const auto& userToken = this->Request_->GetSerializedToken()) {
+                return new NACLib::TUserToken(userToken);
+            }
+            return nullptr;
+        } else {
+            return new NACLib::TUserToken(*this->TBase::UserToken);
+        }
+    }
+
+    TString GetDatabaseName() {
+        if constexpr (IsOperational) {
+            return this->Request_->GetDatabaseName().GetOrElse("");
+        } else {
+            return this->TBase::GetDatabaseName();
+        }
+    }
+
+    NWilson::TTraceId GetTraceId() {
+        if constexpr (IsOperational) {
+            return this->Span_.GetTraceId();
+        } else {
+            return NWilson::TTraceId();
+        }
+    }
+
 protected:
     ui64 KVTabletId = 0;
     TActorId KVPipeClient;
 };
 
+template <bool IsOperational>
 class TAcquireLockRequest
-    : public TKeyValueRequestGrpc<TAcquireLockRequest, TEvAcquireLockKeyValueRequest,
-            Ydb::KeyValue::AcquireLockResult, TEvKeyValue::TEvAcquireLock>
+    : public TKeyValueRequestGrpc<TAcquireLockRequest<IsOperational>,
+            std::conditional_t<IsOperational, TEvAcquireLockKeyValueRequest, TEvAcquireLockKeyValueV2Request>,
+            Ydb::KeyValue::AcquireLockResult, TEvKeyValue::TEvAcquireLock, IsOperational>
 {
 public:
-    using TBase = TKeyValueRequestGrpc<TAcquireLockRequest, TEvAcquireLockKeyValueRequest,
-            Ydb::KeyValue::AcquireLockResult, TEvKeyValue::TEvAcquireLock>;
+    using TBase = TKeyValueRequestGrpc<TAcquireLockRequest,
+            std::conditional_t<IsOperational, TEvAcquireLockKeyValueRequest, TEvAcquireLockKeyValueV2Request>,
+            Ydb::KeyValue::AcquireLockResult, TEvKeyValue::TEvAcquireLock, IsOperational>;
     using TBase::TBase;
 
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) override {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
     }
     NACLib::EAccessRights GetRequiredAccessRights() const {
@@ -928,16 +1030,18 @@ public:
     }
 };
 
-
+template <bool IsOperational>
 class TExecuteTransactionRequest
-    : public TKeyValueRequestGrpc<TExecuteTransactionRequest, TEvExecuteTransactionKeyValueRequest,
-            Ydb::KeyValue::ExecuteTransactionResult, TEvKeyValue::TEvExecuteTransaction> {
+    : public TKeyValueRequestGrpc<TExecuteTransactionRequest<IsOperational>,
+            std::conditional_t<IsOperational, TEvExecuteTransactionKeyValueRequest, TEvExecuteTransactionKeyValueV2Request>,
+            Ydb::KeyValue::ExecuteTransactionResult, TEvKeyValue::TEvExecuteTransaction, IsOperational> {
 public:
-    using TBase = TKeyValueRequestGrpc<TExecuteTransactionRequest, TEvExecuteTransactionKeyValueRequest,
-            Ydb::KeyValue::ExecuteTransactionResult, TEvKeyValue::TEvExecuteTransaction>;
+    using TBase = TKeyValueRequestGrpc<TExecuteTransactionRequest,
+            std::conditional_t<IsOperational, TEvExecuteTransactionKeyValueRequest, TEvExecuteTransactionKeyValueV2Request>,
+            Ydb::KeyValue::ExecuteTransactionResult, TEvKeyValue::TEvExecuteTransaction, IsOperational>;
     using TBase::TBase;
 
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) override {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
     }
 
@@ -968,12 +1072,15 @@ public:
     }
 };
 
+template <bool IsOperational>
 class TReadRequest
-    : public TKeyValueRequestGrpc<TReadRequest, TEvReadKeyValueRequest,
-            Ydb::KeyValue::ReadResult, TEvKeyValue::TEvRead> {
+    : public TKeyValueRequestGrpc<TReadRequest<IsOperational>, 
+            std::conditional_t<IsOperational, TEvReadKeyValueRequest, TEvReadKeyValueV2Request>,
+            Ydb::KeyValue::ReadResult, TEvKeyValue::TEvRead, IsOperational> {
 public:
-    using TBase = TKeyValueRequestGrpc<TReadRequest, TEvReadKeyValueRequest,
-            Ydb::KeyValue::ReadResult, TEvKeyValue::TEvRead>;
+    using TBase = TKeyValueRequestGrpc<TReadRequest,
+            std::conditional_t<IsOperational, TEvReadKeyValueRequest, TEvReadKeyValueV2Request>,
+            Ydb::KeyValue::ReadResult, TEvKeyValue::TEvRead, IsOperational>;
     using TBase::TBase;
     using TBase::Handle;
     STFUNC(StateFunc) {
@@ -982,7 +1089,7 @@ public:
             return TBase::StateFunc(ev);
         }
     }
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) override {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
     }
     NACLib::EAccessRights GetRequiredAccessRights() const {
@@ -990,12 +1097,15 @@ public:
     }
 };
 
+template <bool IsOperational>
 class TReadRangeRequest
-    : public TKeyValueRequestGrpc<TReadRangeRequest, TEvReadRangeKeyValueRequest,
-            Ydb::KeyValue::ReadRangeResult, TEvKeyValue::TEvReadRange> {
+    : public TKeyValueRequestGrpc<TReadRangeRequest<IsOperational>,
+            std::conditional_t<IsOperational, TEvReadRangeKeyValueRequest, TEvReadRangeKeyValueV2Request>,
+            Ydb::KeyValue::ReadRangeResult, TEvKeyValue::TEvReadRange, IsOperational> {
 public:
-    using TBase = TKeyValueRequestGrpc<TReadRangeRequest, TEvReadRangeKeyValueRequest,
-            Ydb::KeyValue::ReadRangeResult, TEvKeyValue::TEvReadRange>;
+    using TBase = TKeyValueRequestGrpc<TReadRangeRequest,
+            std::conditional_t<IsOperational, TEvReadRangeKeyValueRequest, TEvReadRangeKeyValueV2Request>,
+            Ydb::KeyValue::ReadRangeResult, TEvKeyValue::TEvReadRange, IsOperational>;
     using TBase::TBase;
     using TBase::Handle;
     STFUNC(StateFunc) {
@@ -1004,7 +1114,7 @@ public:
             return TBase::StateFunc(ev);
         }
     }
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) override {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
     }
     NACLib::EAccessRights GetRequiredAccessRights() const {
@@ -1012,12 +1122,15 @@ public:
     }
 };
 
+template <bool IsOperational>
 class TListRangeRequest
-    : public TKeyValueRequestGrpc<TListRangeRequest, TEvListRangeKeyValueRequest,
-            Ydb::KeyValue::ListRangeResult, TEvKeyValue::TEvReadRange> {
+    : public TKeyValueRequestGrpc<TListRangeRequest<IsOperational>,
+            std::conditional_t<IsOperational, TEvListRangeKeyValueRequest, TEvListRangeKeyValueV2Request>,
+            Ydb::KeyValue::ListRangeResult, TEvKeyValue::TEvReadRange, IsOperational> {
 public:
-    using TBase = TKeyValueRequestGrpc<TListRangeRequest, TEvListRangeKeyValueRequest,
-            Ydb::KeyValue::ListRangeResult, TEvKeyValue::TEvReadRange>;
+    using TBase = TKeyValueRequestGrpc<TListRangeRequest,
+            std::conditional_t<IsOperational, TEvListRangeKeyValueRequest, TEvListRangeKeyValueV2Request>,
+            Ydb::KeyValue::ListRangeResult, TEvKeyValue::TEvReadRange, IsOperational>;
     using TBase::TBase;
     using TBase::Handle;
     STFUNC(StateFunc) {
@@ -1026,7 +1139,7 @@ public:
             return TBase::StateFunc(ev);
         }
     }
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) override {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
     }
     NACLib::EAccessRights GetRequiredAccessRights() const {
@@ -1034,12 +1147,15 @@ public:
     }
 };
 
+template <bool IsOperational>
 class TGetStorageChannelStatusRequest
-    : public TKeyValueRequestGrpc<TGetStorageChannelStatusRequest, TEvGetStorageChannelStatusKeyValueRequest,
-            Ydb::KeyValue::GetStorageChannelStatusResult, TEvKeyValue::TEvGetStorageChannelStatus> {
+    : public TKeyValueRequestGrpc<TGetStorageChannelStatusRequest<IsOperational>,
+            std::conditional_t<IsOperational, TEvGetStorageChannelStatusKeyValueRequest, TEvGetStorageChannelStatusKeyValueV2Request>,
+            Ydb::KeyValue::GetStorageChannelStatusResult, TEvKeyValue::TEvGetStorageChannelStatus, IsOperational> {
 public:
-    using TBase = TKeyValueRequestGrpc<TGetStorageChannelStatusRequest, TEvGetStorageChannelStatusKeyValueRequest,
-            Ydb::KeyValue::GetStorageChannelStatusResult, TEvKeyValue::TEvGetStorageChannelStatus>;
+    using TBase = TKeyValueRequestGrpc<TGetStorageChannelStatusRequest,
+            std::conditional_t<IsOperational, TEvGetStorageChannelStatusKeyValueRequest, TEvGetStorageChannelStatusKeyValueV2Request>,
+            Ydb::KeyValue::GetStorageChannelStatusResult, TEvKeyValue::TEvGetStorageChannelStatus, IsOperational>;
     using TBase::TBase;
     using TBase::Handle;
     STFUNC(StateFunc) {
@@ -1048,7 +1164,7 @@ public:
             return TBase::StateFunc(ev);
         }
     }
-    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) override {
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/) {
         return true;
     }
     NACLib::EAccessRights GetRequiredAccessRights() const {
@@ -1079,28 +1195,53 @@ void DoListLocalPartitionsKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFaci
     TActivationContext::AsActorContext().Register(new TListLocalPartitionsRequest(p.release()));
 }
 
+
 void DoAcquireLockKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
-    TActivationContext::AsActorContext().Register(new TAcquireLockRequest(p.release()));
+    TActivationContext::AsActorContext().Register(new TAcquireLockRequest<true>(p.release()));
+}
+
+void DoAcquireLockKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&) {
+    TActivationContext::AsActorContext().Register(new TAcquireLockRequest<false>(p.release()));
 }
 
 void DoExecuteTransactionKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
-    TActivationContext::AsActorContext().Register(new TExecuteTransactionRequest(p.release()));
+    TActivationContext::AsActorContext().Register(new TExecuteTransactionRequest<true>(p.release()));
+}
+
+void DoExecuteTransactionKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&) {
+    TActivationContext::AsActorContext().Register(new TExecuteTransactionRequest<false>(p.release()));
 }
 
 void DoReadKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
-    TActivationContext::AsActorContext().Register(new TReadRequest(p.release()));
+    TActivationContext::AsActorContext().Register(new TReadRequest<true>(p.release()));
+}
+
+void DoReadKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&) {
+    TActivationContext::AsActorContext().Register(new TReadRequest<false>(p.release()));
 }
 
 void DoReadRangeKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
-    TActivationContext::AsActorContext().Register(new TReadRangeRequest(p.release()));
+    TActivationContext::AsActorContext().Register(new TReadRangeRequest<true>(p.release()));
+}
+
+void DoReadRangeKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&) {
+    TActivationContext::AsActorContext().Register(new TReadRangeRequest<false>(p.release()));
 }
 
 void DoListRangeKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
-    TActivationContext::AsActorContext().Register(new TListRangeRequest(p.release()));
+    TActivationContext::AsActorContext().Register(new TListRangeRequest<true>(p.release()));
+}
+
+void DoListRangeKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&) {
+    TActivationContext::AsActorContext().Register(new TListRangeRequest<false>(p.release()));
 }
 
 void DoGetStorageChannelStatusKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
-    TActivationContext::AsActorContext().Register(new TGetStorageChannelStatusRequest(p.release()));
+    TActivationContext::AsActorContext().Register(new TGetStorageChannelStatusRequest<true>(p.release()));
+}
+
+void DoGetStorageChannelStatusKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&) {
+    TActivationContext::AsActorContext().Register(new TGetStorageChannelStatusRequest<false>(p.release()));
 }
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/core/grpc_services/service_keyvalue.h
+++ b/ydb/core/grpc_services/service_keyvalue.h
@@ -5,6 +5,7 @@
 namespace NKikimr::NGRpcService {
 
     class IRequestOpCtx;
+    class IRequestNoOpCtx;
     class IFacilityProvider;
 
     void DoCreateVolumeKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&);
@@ -19,5 +20,12 @@ namespace NKikimr::NGRpcService {
     void DoReadRangeKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&);
     void DoListRangeKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&);
     void DoGetStorageChannelStatusKeyValue(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&);
+
+    void DoAcquireLockKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&);
+    void DoExecuteTransactionKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&);
+    void DoReadKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&);
+    void DoReadRangeKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&);
+    void DoListRangeKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&);
+    void DoGetStorageChannelStatusKeyValueV2(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&);
 
 } // NKikimr::NGRpcService

--- a/ydb/core/keyvalue/keyvalue_events.h
+++ b/ydb/core/keyvalue/keyvalue_events.h
@@ -61,6 +61,19 @@ namespace TEvKeyValue {
     struct TEvReadResponse : public TEventPB<TEvReadResponse,
             NKikimrKeyValue::ReadResult, EvReadResponse> {
         TEvReadResponse() { }
+
+        void SetBuffer(TRope&& buffer) {
+            ui32 id = AddPayload(std::move(buffer));
+            Record.set_payload_id(id);
+        }
+
+        bool IsPayload() const {
+            return Record.has_payload_id();
+        }
+
+        TRope GetBuffer() const {
+            return GetPayload(Record.payload_id());
+        }
     };
 
     struct TEvReadRangeResponse;
@@ -75,6 +88,19 @@ namespace TEvKeyValue {
     struct TEvReadRangeResponse : public TEventPB<TEvReadRangeResponse,
             NKikimrKeyValue::ReadRangeResult, EvReadRangeResponse> {
         TEvReadRangeResponse() { }
+
+        void SetBuffer(TRope&& buffer, ui32 itemIdx) {
+            ui32 id = AddPayload(std::move(buffer));
+            Record.mutable_pair(itemIdx)->set_payload_id(id);
+        }
+
+        bool IsPayload(ui32 itemIdx) const {
+            return Record.pair(itemIdx).has_payload_id();
+        }
+
+        TRope GetBuffer(ui32 itemIdx) const {
+            return GetPayload(Record.pair(itemIdx).payload_id());
+        }
     };
 
     struct TEvExecuteTransactionResponse;

--- a/ydb/core/keyvalue/keyvalue_storage_read_request.cpp
+++ b/ydb/core/keyvalue/keyvalue_storage_read_request.cpp
@@ -1,11 +1,13 @@
 #include "keyvalue_storage_read_request.h"
 #include "keyvalue_const.h"
 
+#include <ydb/core/base/appdata_fwd.h>
 #include <ydb/core/util/stlog.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <util/generic/overloaded.h>
+#include <library/cpp/time_provider/time_provider.h>
 
 
 namespace NKikimr {
@@ -512,7 +514,9 @@ public:
         , TabletInfo(const_cast<TTabletStorageInfo*>(tabletInfo))
         , TabletGeneration(tabletGeneration)
         , Span(TWilsonTablet::TabletBasic, IntermediateResult->Span.GetTraceId(), "KeyValue.StorageReadRequest")
-    {}
+    {
+        IntermediateResult->Stat.KeyvalueStorageRequestSentAt = TAppData::TimeProvider->Now();
+    }
 };
 
 

--- a/ydb/core/keyvalue/protos/events.proto
+++ b/ydb/core/keyvalue/protos/events.proto
@@ -85,7 +85,10 @@ message ReadResult {
     string requested_key = 1;
     uint64 requested_offset = 2;
     uint64 requested_size = 3;
-    bytes value = 4;
+    oneof buffer {
+        bytes value = 4;
+        uint32 payload_id = 9;
+    }
     string msg = 5;
     Statuses.ReplyStatus status = 6;
     uint64 cookie = 7;
@@ -108,7 +111,10 @@ message ReadRangeRequest {
 message ReadRangeResult {
     message KeyValuePair {
         string key = 1;
-        bytes value = 2;
+        oneof buffer {
+            bytes value = 2;
+            uint32 payload_id = 7;
+        }
         uint32 value_size = 3;
 
         // Unix time of the creation of the key-value pair (in ms).

--- a/ydb/public/api/grpc/ya.make
+++ b/ydb/public/api/grpc/ya.make
@@ -16,6 +16,7 @@ SRCS(
     ydb_federation_discovery_v1.proto
     ydb_import_v1.proto
     ydb_keyvalue_v1.proto
+    ydb_keyvalue_v2.proto
     ydb_monitoring_v1.proto
     ydb_operation_v1.proto
     ydb_query_v1.proto

--- a/ydb/public/api/grpc/ydb_keyvalue_v2.proto
+++ b/ydb/public/api/grpc/ydb_keyvalue_v2.proto
@@ -23,9 +23,6 @@ service KeyValueService {
     // Read the value stored in the item with the key specified.
     rpc Read(KeyValue.ReadRequest) returns (KeyValue.ReadResult);
 
-    // Read the batch of values stored in the items with the keys specified.
-    rpc ReadBatch(KeyValue.ReadBatchRequest) returns (KeyValue.ReadBatchResult);
-
     // Read items with keys in the specified range.
     rpc ReadRange(KeyValue.ReadRangeRequest) returns (KeyValue.ReadRangeResult);
 

--- a/ydb/public/api/grpc/ydb_keyvalue_v2.proto
+++ b/ydb/public/api/grpc/ydb_keyvalue_v2.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package Ydb.KeyValue.V2;
+
+option java_package = "com.yandex.ydb.keyvalue.v1";
+option java_outer_classname = "KeyValueGrpc";
+option java_multiple_files = true;
+
+import "ydb/public/api/protos/ydb_keyvalue.proto";
+
+// KeyValue tablets provide a simple key-value storage in a low-overhead and easy-to-shoot-your-leg manner.
+// To use KeyValue tablets in an efficient way one must be familiar with the design of both the KeyValue tablet
+// and the Distributed Storage underneath it.
+
+service KeyValueService {
+
+    // Acquire an exclusive lock for the partition.
+    rpc AcquireLock(KeyValue.AcquireLockRequest) returns (KeyValue.AcquireLockResult);
+
+    // Perform list of commands to modify the state of the partition as an atomic transaction.
+    rpc ExecuteTransaction(KeyValue.ExecuteTransactionRequest) returns (KeyValue.ExecuteTransactionResult);
+
+    // Read the value stored in the item with the key specified.
+    rpc Read(KeyValue.ReadRequest) returns (KeyValue.ReadResult);
+
+    // Read items with keys in the specified range.
+    rpc ReadRange(KeyValue.ReadRangeRequest) returns (KeyValue.ReadRangeResult);
+
+    // List keys and metadata of items with keys in the specified range.
+    rpc ListRange(KeyValue.ListRangeRequest) returns (KeyValue.ListRangeResult);
+
+    // Get storage channel status of the partition.
+    rpc GetStorageChannelStatus(KeyValue.GetStorageChannelStatusRequest) returns (KeyValue.GetStorageChannelStatusResult);
+
+}

--- a/ydb/public/api/grpc/ydb_keyvalue_v2.proto
+++ b/ydb/public/api/grpc/ydb_keyvalue_v2.proto
@@ -23,6 +23,9 @@ service KeyValueService {
     // Read the value stored in the item with the key specified.
     rpc Read(KeyValue.ReadRequest) returns (KeyValue.ReadResult);
 
+    // Read the batch of values stored in the items with the keys specified.
+    rpc ReadBatch(KeyValue.ReadBatchRequest) returns (KeyValue.ReadBatchResult);
+
     // Read items with keys in the specified range.
     rpc ReadRange(KeyValue.ReadRangeRequest) returns (KeyValue.ReadRangeResult);
 

--- a/ydb/public/api/grpc/ydb_keyvalue_v2.proto
+++ b/ydb/public/api/grpc/ydb_keyvalue_v2.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package Ydb.KeyValue.V2;
 
-option java_package = "com.yandex.ydb.keyvalue.v1";
+option java_package = "com.yandex.ydb.keyvalue.v2";
 option java_outer_classname = "KeyValueGrpc";
 option java_multiple_files = true;
 

--- a/ydb/public/api/protos/ydb_keyvalue.proto
+++ b/ydb/public/api/protos/ydb_keyvalue.proto
@@ -8,6 +8,8 @@ option java_outer_classname = "KeyValueProtos";
 option java_multiple_files = true;
 
 import "ydb/public/api/protos/ydb_operation.proto";
+import "ydb/public/api/protos/ydb_status_codes.proto";
+import "ydb/public/api/protos/ydb_issue_message.proto";
 
 //
 // KeyValue API.
@@ -109,6 +111,10 @@ message AcquireLockResult {
 
     // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
     uint32 node_id = 2;
+
+    // Response status, use in V2.
+    StatusIds.StatusCode status = 16;
+    repeated Ydb.Issue.IssueMessage issues = 17;
 }
 
 message ExecuteTransactionRequest {
@@ -234,6 +240,10 @@ message ExecuteTransactionResult {
 
     // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
     uint32 node_id = 2;
+
+    // Response status, use in V2.
+    StatusIds.StatusCode status = 16;
+    repeated Ydb.Issue.IssueMessage issues = 17;
 }
 
 message ReadRequest {
@@ -290,6 +300,10 @@ message ReadResult {
 
     // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
     uint32 node_id = 6;
+
+    // Response status, use in V2.
+    StatusIds.StatusCode status = 16;
+    repeated Ydb.Issue.IssueMessage issues = 17;
 }
 
 message ReadRangeRequest {
@@ -354,6 +368,10 @@ message ReadRangeResult {
 
     // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
     uint32 node_id = 3;
+
+    // Response status, use in V2.
+    StatusIds.StatusCode status = 16;
+    repeated Ydb.Issue.IssueMessage issues = 17;
 }
 
 message ListRangeRequest {
@@ -407,6 +425,10 @@ message ListRangeResult {
 
     // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
     uint32 node_id = 3;
+
+    // Response status, use in V2.
+    StatusIds.StatusCode status = 16;
+    repeated Ydb.Issue.IssueMessage issues = 17;
 }
 
 message GetStorageChannelStatusRequest {
@@ -435,6 +457,10 @@ message GetStorageChannelStatusResult {
 
     // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
     uint32 node_id = 2;
+
+    // Response status, use in V2.
+    StatusIds.StatusCode status = 16;
+    repeated Ydb.Issue.IssueMessage issues = 17;
 }
 
 message CreateVolumeRequest {

--- a/ydb/public/api/protos/ydb_keyvalue.proto
+++ b/ydb/public/api/protos/ydb_keyvalue.proto
@@ -306,68 +306,6 @@ message ReadResult {
     repeated Ydb.Issue.IssueMessage issues = 17;
 }
 
-message ReadBatchRequest {
-    message ReadItem {
-        // Key of the key-value pair to read.
-        string key = 1;
-
-        // Offset in bytes from the beginning of the value to read data from.
-        uint64 offset = 2;
-
-        // Size of the data to read in bytes. 0 means "read to the end of the value".
-        uint64 size = 3;
-    }
-
-    // Volume path.
-    string path = 2;
-    // Partition of the volume.
-    uint64 partition_id = 3;
-
-    // Generation of the exclusive lock acquired for the partition as a result of an AcquireLock call.
-    optional uint64 lock_generation = 4;
-
-    // Items to read.
-    repeated ReadItem items = 5;
-
-    // Result protobuf size limit.
-    // Overrides the default limit only with a smaller value.
-    // 0 means "use the default limit".
-    uint64 limit_bytes = 8;
-
-    // Priority to use for the Distributed Storage Get operation.
-    // Has no effect for the INLINE storage channel.
-    Priorities.Priority priority = 9;
-}
-
-message ReadBatchResult {
-    message ReadResultItem {
-        // The key of the requested key-value pair.
-        string requested_key = 1;
-
-        // Offset in bytes from the beginning of the value requested.
-        uint64 requested_offset = 2;
-
-        // Size of the data requested.
-        uint64 requested_size = 3;
-
-        // The bytes of the requested part of the value.
-        bytes value = 4;
-
-        // If requested data size is larger than limit_bytes then result will contain only part of the requested value and
-        // the is_overrun flag will be set.
-        bool is_overrun = 5;
-    }
-
-    repeated ReadResultItem items = 1;
-
-    // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
-    uint32 node_id = 2;
-
-    // Response status, use in V2.
-    StatusIds.StatusCode status = 16;
-    repeated Ydb.Issue.IssueMessage issues = 17; 
-}
-
 message ReadRangeRequest {
     Ydb.Operations.OperationParams operation_params = 1;
 

--- a/ydb/public/api/protos/ydb_keyvalue.proto
+++ b/ydb/public/api/protos/ydb_keyvalue.proto
@@ -358,8 +358,10 @@ message ReadBatchResult {
         bool is_overrun = 5;
     }
 
+    repeated ReadResultItem items = 1;
+
     // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
-    uint32 node_id = 6;
+    uint32 node_id = 2;
 
     // Response status, use in V2.
     StatusIds.StatusCode status = 16;

--- a/ydb/public/api/protos/ydb_keyvalue.proto
+++ b/ydb/public/api/protos/ydb_keyvalue.proto
@@ -306,6 +306,66 @@ message ReadResult {
     repeated Ydb.Issue.IssueMessage issues = 17;
 }
 
+message ReadBatchRequest {
+    message ReadItem {
+        // Key of the key-value pair to read.
+        string key = 1;
+
+        // Offset in bytes from the beginning of the value to read data from.
+        uint64 offset = 2;
+
+        // Size of the data to read in bytes. 0 means "read to the end of the value".
+        uint64 size = 3;
+    }
+
+    // Volume path.
+    string path = 2;
+    // Partition of the volume.
+    uint64 partition_id = 3;
+
+    // Generation of the exclusive lock acquired for the partition as a result of an AcquireLock call.
+    optional uint64 lock_generation = 4;
+
+    // Items to read.
+    repeated ReadItem items = 5;
+
+    // Result protobuf size limit.
+    // Overrides the default limit only with a smaller value.
+    // 0 means "use the default limit".
+    uint64 limit_bytes = 8;
+
+    // Priority to use for the Distributed Storage Get operation.
+    // Has no effect for the INLINE storage channel.
+    Priorities.Priority priority = 9;
+}
+
+message ReadBatchResult {
+    message ReadResultItem {
+        // The key of the requested key-value pair.
+        string requested_key = 1;
+
+        // Offset in bytes from the beginning of the value requested.
+        uint64 requested_offset = 2;
+
+        // Size of the data requested.
+        uint64 requested_size = 3;
+
+        // The bytes of the requested part of the value.
+        bytes value = 4;
+
+        // If requested data size is larger than limit_bytes then result will contain only part of the requested value and
+        // the is_overrun flag will be set.
+        bool is_overrun = 5;
+    }
+
+    // Contains 0 if the request was sent to the node of the partition, node ID of the partition otherwise.
+    uint32 node_id = 6;
+
+    // Response status, use in V2.
+    StatusIds.StatusCode status = 16;
+    repeated Ydb.Issue.IssueMessage issues = 17; 
+}
+
 message ReadRangeRequest {
     Ydb.Operations.OperationParams operation_params = 1;
 

--- a/ydb/services/keyvalue/grpc_service_v1.cpp
+++ b/ydb/services/keyvalue/grpc_service_v1.cpp
@@ -1,4 +1,4 @@
-#include "grpc_service.h"
+#include "grpc_service_v1.h"
 
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/base/base.h>
@@ -8,21 +8,21 @@
 
 namespace NKikimr::NGRpcService {
 
-TKeyValueGRpcService::TKeyValueGRpcService(NActors::TActorSystem* actorSystem, TIntrusivePtr<NMonitoring::TDynamicCounters> counters, NActors::TActorId grpcRequestProxyId)
+TKeyValueGRpcServiceV1::TKeyValueGRpcServiceV1(NActors::TActorSystem* actorSystem, TIntrusivePtr<NMonitoring::TDynamicCounters> counters, NActors::TActorId grpcRequestProxyId)
     : ActorSystem_(actorSystem)
     , Counters_(std::move(counters))
     , GRpcRequestProxyId_(grpcRequestProxyId)
 {
 }
 
-TKeyValueGRpcService::~TKeyValueGRpcService() = default;
+TKeyValueGRpcServiceV1::~TKeyValueGRpcServiceV1() = default;
 
-void TKeyValueGRpcService::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::TLoggerPtr logger) {
+void TKeyValueGRpcServiceV1::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::TLoggerPtr logger) {
     CQ_ = cq;
     SetupIncomingRequests(std::move(logger));
 }
 
-void TKeyValueGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+void TKeyValueGRpcServiceV1::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     using namespace Ydb::KeyValue;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 

--- a/ydb/services/keyvalue/grpc_service_v1.h
+++ b/ydb/services/keyvalue/grpc_service_v1.h
@@ -9,13 +9,13 @@
 
 namespace NKikimr::NGRpcService {
 
-class TKeyValueGRpcService
+class TKeyValueGRpcServiceV1
         : public NYdbGrpc::TGrpcServiceBase<Ydb::KeyValue::V1::KeyValueService>
 {
 public:
-    TKeyValueGRpcService(NActors::TActorSystem* actorSystem, TIntrusivePtr<NMonitoring::TDynamicCounters> counters,
+    TKeyValueGRpcServiceV1(NActors::TActorSystem* actorSystem, TIntrusivePtr<NMonitoring::TDynamicCounters> counters,
             NActors::TActorId grpcRequestProxyId);
-    ~TKeyValueGRpcService();
+    ~TKeyValueGRpcServiceV1();
 
     void InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::TLoggerPtr logger) override;
 private:

--- a/ydb/services/keyvalue/grpc_service_v2.cpp
+++ b/ydb/services/keyvalue/grpc_service_v2.cpp
@@ -1,0 +1,61 @@
+#include "grpc_service_v2.h"
+
+#include <ydb/core/grpc_services/grpc_helper.h>
+#include <ydb/core/grpc_services/base/base.h>
+#include <ydb/core/grpc_services/service_keyvalue.h>
+#include <ydb/core/jaeger_tracing/request_discriminator.h>
+#include <ydb/library/grpc/server/grpc_method_setup.h>
+
+namespace NKikimr::NGRpcService {
+
+TKeyValueGRpcServiceV2::TKeyValueGRpcServiceV2(NActors::TActorSystem* actorSystem, TIntrusivePtr<NMonitoring::TDynamicCounters> counters, NActors::TActorId grpcRequestProxyId)
+    : ActorSystem_(actorSystem)
+    , Counters_(std::move(counters))
+    , GRpcRequestProxyId_(grpcRequestProxyId)
+{
+}
+
+TKeyValueGRpcServiceV2::~TKeyValueGRpcServiceV2() = default;
+
+void TKeyValueGRpcServiceV2::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::TLoggerPtr logger) {
+    CQ_ = cq;
+    SetupIncomingRequests(std::move(logger));
+}
+
+void TKeyValueGRpcServiceV2::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+    Y_UNUSED(logger);
+    using namespace Ydb::KeyValue;
+    auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
+
+#ifdef SETUP_KV_METHOD
+#error SETUP_KV_METHOD macro already defined
+#endif
+
+#define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditMode)             \
+    SETUP_RUNTIME_EVENT_METHOD(methodName,                                                                \
+        YDB_API_DEFAULT_REQUEST_TYPE(methodName),                                                         \
+        Y_CAT(methodName, Result),                                                        \
+        methodCallback,                                                                                   \
+        rlMode,                                                                                           \
+        requestType,                                                                                      \
+        YDB_API_DEFAULT_COUNTER_BLOCK(keyvalue_v2, methodName),                                           \
+        auditMode,                                                                                        \
+        COMMON,                                                                                           \
+        ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                                               \
+        GRpcRequestProxyId_,                                                                              \
+        CQ_,                                                                                              \
+        nullptr,                                                                                          \
+        nullptr                                                                                           \
+    )
+
+    SETUP_KV_METHOD(AcquireLock, DoAcquireLockKeyValueV2, RLMODE(Rps), KEYVALUE_ACQUIRELOCK, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(ExecuteTransaction, DoExecuteTransactionKeyValueV2, RLMODE(Rps), KEYVALUE_EXECUTETRANSACTION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
+    SETUP_KV_METHOD(Read, DoReadKeyValueV2, RLMODE(Rps), KEYVALUE_READ, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(ReadRange, DoReadRangeKeyValueV2, RLMODE(Rps), KEYVALUE_READRANGE, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(ListRange, DoListRangeKeyValueV2, RLMODE(Rps), KEYVALUE_LISTRANGE, TAuditMode::NonModifying());
+    SETUP_KV_METHOD(GetStorageChannelStatus, DoGetStorageChannelStatusKeyValueV2, RLMODE(Rps), KEYVALUE_GETSTORAGECHANNELSTATUS, TAuditMode::NonModifying());
+
+#undef SETUP_KV_METHOD
+}
+
+} // namespace NKikimr::NGRpcService

--- a/ydb/services/keyvalue/grpc_service_v2.h
+++ b/ydb/services/keyvalue/grpc_service_v2.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ydb/public/api/grpc/ydb_keyvalue_v2.grpc.pb.h>
+
+#include <ydb/library/grpc/server/grpc_server.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
+
+
+namespace NKikimr::NGRpcService {
+
+class TKeyValueGRpcServiceV2
+        : public NYdbGrpc::TGrpcServiceBase<Ydb::KeyValue::V2::KeyValueService>
+{
+public:
+    TKeyValueGRpcServiceV2(NActors::TActorSystem* actorSystem, TIntrusivePtr<NMonitoring::TDynamicCounters> counters,
+            NActors::TActorId grpcRequestProxyId);
+    ~TKeyValueGRpcServiceV2();
+
+    void InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::TLoggerPtr logger) override;
+private:
+    void SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger);
+
+private:
+    NActors::TActorSystem* ActorSystem_ = nullptr;
+    TIntrusivePtr<NMonitoring::TDynamicCounters> Counters_;
+    NActors::TActorId GRpcRequestProxyId_;
+
+    grpc::ServerCompletionQueue* CQ_ = nullptr;
+};
+
+} // namespace NKikimr::NGRpcService

--- a/ydb/services/keyvalue/ya.make
+++ b/ydb/services/keyvalue/ya.make
@@ -1,7 +1,8 @@
 LIBRARY()
 
 SRCS(
-    grpc_service.cpp
+    grpc_service_v1.cpp
+    grpc_service_v2.cpp
 )
 
 PEERDIR(

--- a/ydb/tests/library/clients/kikimr_keyvalue_client.py
+++ b/ydb/tests/library/clients/kikimr_keyvalue_client.py
@@ -9,6 +9,7 @@ import six
 import logging
 
 from ydb.public.api.grpc import ydb_keyvalue_v1_pb2_grpc as grpc_server
+from ydb.public.api.grpc import ydb_keyvalue_v2_pb2_grpc as grpc_server_v2
 from ydb.public.api.protos import ydb_keyvalue_pb2 as keyvalue_api
 
 logger = logging.getLogger()
@@ -51,15 +52,18 @@ class KeyValueClient(object):
         ]
         self._channel = grpc.insecure_channel("%s:%s" % (self.server, self.port), options=self._options)
         self._stub = grpc_server.KeyValueServiceStub(self._channel)
+        self._stub_v2 = grpc_server_v2.KeyValueServiceStub(self._channel)
 
-    def _get_invoke_callee(self, method):
+    def _get_invoke_callee(self, method, version):
+        if version == 'v2':
+            return getattr(self._stub_v2, method)
         return getattr(self._stub, method)
 
-    def invoke(self, request, method):
+    def invoke(self, request, method, version):
         retry = self.__retry_count
         while True:
             try:
-                callee = self._get_invoke_callee(method)
+                callee = self._get_invoke_callee(method, version)
                 return callee(request)
             except (RuntimeError, grpc.RpcError):
                 retry -= 1
@@ -69,7 +73,7 @@ class KeyValueClient(object):
 
                 time.sleep(self.__retry_sleep_seconds)
 
-    def kv_write(self, path, partition_id, key, value, channel=None):
+    def kv_write(self, path, partition_id, key, value, channel=None, version='v1'):
         request = keyvalue_api.ExecuteTransactionRequest()
         request.path = path
         request.partition_id = partition_id
@@ -78,9 +82,9 @@ class KeyValueClient(object):
         write.value = to_bytes(value)
         if channel is not None:
             write.storage_channel = channel
-        return self.invoke(request, 'ExecuteTransaction')
+        return self.invoke(request, 'ExecuteTransaction', version)
 
-    def kv_read(self, path, partition_id, key, offset=None, size=None):
+    def kv_read(self, path, partition_id, key, offset=None, size=None, version='v1'):
         request = keyvalue_api.ReadRequest()
         request.path = path
         request.partition_id = partition_id
@@ -89,7 +93,7 @@ class KeyValueClient(object):
             request.offset = offset
         if size is not None:
             request.size = size
-        return self.invoke(request, 'Read')
+        return self.invoke(request, 'Read', version)
 
     def kv_get_tablets_read_state(self, path, partition_ids):
         for id in partition_ids:
@@ -123,12 +127,12 @@ class KeyValueClient(object):
                 for media in channels:
                     new_channel = request.storage_config.channel.add()
                     new_channel.media = media
-        return self.invoke(request, 'CreateVolume')
+        return self.invoke(request, 'CreateVolume', version='v1')
 
     def drop_tablets(self, path):
         request = keyvalue_api.DropVolumeRequest()
         request.path = path
-        return self.invoke(request, 'DropVolume')
+        return self.invoke(request, 'DropVolume', version='v1')
 
     def close(self):
         self._channel.close()

--- a/ydb/tests/stress/kv_volume/__main__.py
+++ b/ydb/tests/stress/kv_volume/__main__.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     parser.add_argument('--log-file', default=None, help='Append log into specified file')
     parser.add_argument('--partitions', default=1, type=int, help='Append log into specified file')
     parser.add_argument('--storage-channels', default=['ssd']*3, nargs='*', help='Storage channels')
-    parser.add_argument('--use-multiprocessing', action='store_true', help='Use processes instead of threads')
+    parser.add_argument('--version', default='v1', choices=['v1', 'v2'], help='Keyvalue grpc api version')
 
     args = parser.parse_args()
 
@@ -38,6 +38,7 @@ if __name__ == '__main__':
         storage_channels=args.storage_channels,
         kv_load_type=args.load_type,
         inflight=args.in_flight,
+        version=args.version
     )
     workload.start(use_multiprocessing=True)
     workload.wait_stop()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add keyvalue grpc api v2

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Новое апи направлено на оптимизацию чтений и убирание лишней сериализации при использовании Any полня operation.result.

Предыдущее апи использовало operation. Имелся тип Response в котором было поле operation, и тип Result который клался в operation.result.
Когда в operation.result присваивался результа, то он сериализовывался и записывался вместе с полным именем типа результата. После чего response отправлялся по grpc и тоже сериализовывлся (вместе с полем operation.result). Из-за чего данные которые были в результате копировались дважды, сначала при сериализации результата, после при сериализации ответа. На стороне клиента, так же происходит двойная десериализация.

Operation изначально задумывался с долгими асинхронными операциями, в kv api таких операций нет, все синхронно и делалось больше для единообразия. В новой версии api решили убрать response типы и отправлять сразу result.

Для этого во все result добавили status и issues для сохранения функционала из operation.
В остальном все остальные операции идентичны, перенесены только data-plane операции: блокировка, чтения, записи. scheme-plane пока не перенесеносятся (в будущем можно будет перенести).

По первым замерам, это увеличивает пропускную способность чтений на 20% для inline канала, и на 10% для обычных. 

