### PR TITLE
yql/dq: forward SSL_CERT_FILE environment variable to dq worker

### DIFF
--- a/ydb/library/yql/tools/dq/worker_job/dq_worker.cpp
+++ b/ydb/library/yql/tools/dq/worker_job/dq_worker.cpp
@@ -258,6 +258,9 @@ namespace NYql::NDq::NWorker {
         if (backendConfig.GetEnforceJobUtc()) {
             pfOptions.Env["TZ"] = "UTC0";
         }
+        if (auto certFile = TryGetEnv("SSL_CERT_FILE")) {
+            pfOptions.Env["SSL_CERT_FILE"] = *certFile;
+        }
         if (backendConfig.GetEnforceJobYtIsolation()) {
             pfOptions.Env["YT_ALLOW_HTTP_REQUESTS_TO_YT_FROM_JOB"] = "0";
             pfOptions.Env["YT_FORBID_REQUESTS_FROM_JOB"] = "1";


### PR DESCRIPTION
Environment variable SSL_CERT_FILE is a common way to control source of
trusted certificate authorities. The same variable will be used for
switching away from arcadian built-in CA bundle (certs/cacert.pem).

This allows to access HTTPS-only resources with certificates issued by
non-public certificate authorities, or CA newer than built-in bundle.

Link: https://docs.openssl.org/master/man7/openssl-env/
Link: https://github.com/ytsaurus/ytsaurus/pull/1607
Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
