### PR TITLE
EXT-1791 Fix incorrect DSProxy huge blob size aggregation

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_costmodel.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_costmodel.cpp
@@ -294,7 +294,7 @@ namespace NKikimr {
         WriteSpeedBps = std::min(WriteSpeedBps, other.WriteSpeedBps);
         ReadBlockSize = std::min(ReadBlockSize, other.ReadBlockSize);
         WriteBlockSize = std::min(WriteBlockSize, other.WriteBlockSize);
-        MinREALHugeBlobInBytes = std::max(MinREALHugeBlobInBytes, other.MinREALHugeBlobInBytes);
+        MinREALHugeBlobInBytes = std::min(MinREALHugeBlobInBytes, other.MinREALHugeBlobInBytes);
     }
 
     // PDisk messages cost


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Fix dsproxy getting max huge blob size across all VDisks instead of min. If one vdisk has higher size, then dsproxy can send multiput with the respect to the higher huge size and VDisks with lower huge size will treat this is as error since MultiPut with huge blobs are prohibited

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
