### PR TITLE
Make max deadline for put in DSProxy customizable via ICB (#30501)

### DIFF
--- a/ydb/core/blobstorage/common/immediate_control_defaults.cpp
+++ b/ydb/core/blobstorage/common/immediate_control_defaults.cpp
@@ -14,4 +14,7 @@ TControlWrapper MaxNumOfSlowDisksDefaultControl =
 TControlWrapper LongRequestThresholdDefaultControl =
         TControlWrapper(DefaultLongRequestThreshold.MilliSeconds(), 1, 1'000'000);
 
+TControlWrapper MaxPutTimeoutDefaultControl =
+        TControlWrapper(DefaultMaxPutTimeout.Seconds(), 1, 1'000'000);
+
 } // namespace NKikimr

--- a/ydb/core/blobstorage/common/immediate_control_defaults.h
+++ b/ydb/core/blobstorage/common/immediate_control_defaults.h
@@ -12,10 +12,12 @@ constexpr float DefaultSlowDiskThreshold = 2;
 constexpr float DefaultPredictedDelayMultiplier = 1;
 constexpr TDuration DefaultLongRequestThreshold = TDuration::Seconds(50);
 constexpr ui32 DefaultMaxNumOfSlowDisks = 2;
+constexpr TDuration DefaultMaxPutTimeout = TDuration::Seconds(60);
 
 extern TControlWrapper SlowDiskThresholdDefaultControl;
 extern TControlWrapper PredictedDelayMultiplierDefaultControl;
 extern TControlWrapper MaxNumOfSlowDisksDefaultControl;
 extern TControlWrapper LongRequestThresholdDefaultControl;
+extern TControlWrapper MaxPutTimeoutDefaultControl;
 
 }

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -38,7 +38,6 @@ const ui64 UnconfiguredBufferSizeLimit = 32 << 20;
 const TDuration ProxyEstablishSessionsTimeout = TDuration::Seconds(5);
 
 const TDuration DsMinimumDelayBetweenPutWakeups = TDuration::Seconds(1);
-const TDuration DsMaximumPutTimeout = TDuration::Seconds(60);
 
 const ui64 BufferSizeThreshold = 1 << 20;
 
@@ -363,6 +362,7 @@ struct TBlobStorageGroupPutParameters {
     bool EnableRequestMod3x3ForMinLatency;
     TAccelerationParams AccelerationParams;
     TDuration LongRequestThreshold;
+    TDuration MaxTimeout = TDuration::Seconds(60);
 };
 IActor* CreateBlobStorageGroupPutRequest(TBlobStorageGroupPutParameters params);
 
@@ -382,6 +382,7 @@ struct TBlobStorageGroupMultiPutParameters {
     bool EnableRequestMod3x3ForMinLatency;
     TAccelerationParams AccelerationParams;
     TDuration LongRequestThreshold;
+    TDuration MaxTimeout = TDuration::Seconds(60);
 
     static ui32 CalculateRestartCounter(TBatchedVec<TEvBlobStorage::TEvPut::TPtr>& events) {
         ui32 maxRestarts = 0;
@@ -528,6 +529,7 @@ struct TBlobStorageProxyControlWrappers {
     TMemorizableControlWrapper EnableVPatch;
 
     TMemorizableControlWrapper LongRequestThresholdMs = LongRequestThresholdDefaultControl;
+    TMemorizableControlWrapper MaxPutTimeoutSeconds = MaxPutTimeoutDefaultControl;
 
 #define DEVICE_TYPE_SEPECIFIC_MEMORIZABLE_CONTROLS(prefix)              \
     TMemorizableControlWrapper prefix = prefix##DefaultControl;         \

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -91,6 +91,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
     TBlobStorageGroupInfo::TGroupVDisks ExpiredVDiskSet;
 
     TDuration LongRequestThreshold;
+    TDuration MaxTimeout;
 
     void SanityCheck() {
         if (RequestsSent <= MaxSaneRequests) {
@@ -589,6 +590,7 @@ public:
         , IncarnationRecords(Info->GetTotalVDisksNum())
         , ExpiredVDiskSet(&Info->GetTopology())
         , LongRequestThreshold(params.LongRequestThreshold)
+        , MaxTimeout(params.MaxTimeout)
     {
         if (params.Common.Event->Orbit.HasShuttles()) {
             RootCauseTrack.IsOn = true;
@@ -615,6 +617,7 @@ public:
         , IncarnationRecords(Info->GetTotalVDisksNum())
         , ExpiredVDiskSet(&Info->GetTopology())
         , LongRequestThreshold(params.LongRequestThreshold)
+        , MaxTimeout(params.MaxTimeout)
     {
         Y_DEBUG_ABORT_UNLESS(params.Events.size() <= MaxBatchedPutRequests);
         for (auto &ev : params.Events) {
@@ -652,7 +655,7 @@ public:
         TInstant now = TActivationContext::Now();
 
         for (size_t blobIdx = 0; blobIdx < PutImpl.Blobs.size(); ++blobIdx) {
-            TInstant deadline = std::min(now + DsMaximumPutTimeout, PutImpl.Blobs[blobIdx].Deadline);
+            TInstant deadline = std::min(now + MaxTimeout, PutImpl.Blobs[blobIdx].Deadline);
             PutDeadlineMasks[deadline].set(blobIdx);
             LWTRACK(DSProxyPutBootstrapStart, PutImpl.Blobs[blobIdx].Orbit);
         }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -251,6 +251,7 @@ namespace NKikimr {
                     .EnableRequestMod3x3ForMinLatency = enableRequestMod3x3ForMinLatency,
                     .AccelerationParams = GetAccelerationParams(),
                     .LongRequestThreshold = TDuration::MilliSeconds(Controls.LongRequestThresholdMs.Update(now)),
+                    .MaxTimeout = TDuration::Seconds(Controls.MaxPutTimeoutSeconds.Update(now)),
                 }),
                 ev->Get()->Deadline
             );
@@ -563,6 +564,7 @@ namespace NKikimr {
             if (CurrentStateFunc() == &TThis::StateWork) {
                 TAppData *app = NKikimr::AppData(TActivationContext::AsActorContext());
                 bool enableRequestMod3x3ForMinLatency = app->FeatureFlags.GetEnable3x3RequestsForMirror3DCMinLatencyPut();
+                TInstant now = TActivationContext::Now();
                 // TODO(alexvru): MinLatency support
                 auto process = [&](std::optional<ui32> forceGroupGeneration, TBatchedPutQueue& batch) {
                     if (batch.Queue.size() == 1) {
@@ -588,7 +590,8 @@ namespace NKikimr {
                                 .Stats = PerDiskStats,
                                 .EnableRequestMod3x3ForMinLatency = enableRequestMod3x3ForMinLatency,
                                 .AccelerationParams = GetAccelerationParams(),
-                                .LongRequestThreshold = TDuration::MilliSeconds(Controls.LongRequestThresholdMs.Update(TActivationContext::Now())),
+                                .LongRequestThreshold = TDuration::MilliSeconds(Controls.LongRequestThresholdMs.Update(now)),
+                                .MaxTimeout = TDuration::Seconds(Controls.MaxPutTimeoutSeconds.Update(now)),
                             }),
                             ev->Get()->Deadline
                         );
@@ -612,7 +615,8 @@ namespace NKikimr {
                                 .Tactic = tactic,
                                 .EnableRequestMod3x3ForMinLatency = enableRequestMod3x3ForMinLatency,
                                 .AccelerationParams = GetAccelerationParams(),
-                                .LongRequestThreshold = TDuration::MilliSeconds(Controls.LongRequestThresholdMs.Update(TActivationContext::Now())),
+                                .LongRequestThreshold = TDuration::MilliSeconds(Controls.LongRequestThresholdMs.Update(now)),
+                                .MaxTimeout = TDuration::Seconds(Controls.MaxPutTimeoutSeconds.Update(now)),
                             }),
                             TInstant::Max()
                         );

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -71,6 +71,7 @@ TNodeWarden::TNodeWarden(const TIntrusivePtr<TNodeWardenConfig> &cfg)
     , ReportingControllerBucketSize(1, 1, 100'000)
     , ReportingControllerLeakDurationMs(60'000, 1, 3'600'000)
     , ReportingControllerLeakRate(1, 1, 100'000)
+    , MaxPutTimeoutSeconds(DefaultMaxPutTimeout.Seconds(), 1, 1'000'000)
     , EnableDeepScrubbing(false, false, true)
 {
     Y_ABORT_UNLESS(Cfg->BlobStorageConfig.GetServiceSet().AvailabilityDomainsSize() <= 1);
@@ -430,6 +431,7 @@ void TNodeWarden::Bootstrap() {
         icb->RegisterSharedControl(ReportingControllerLeakRate, "DSProxyControls.RequestReportingSettings.LeakRate");
 
         icb->RegisterSharedControl(EnableDeepScrubbing, "VDiskControls.EnableDeepScrubbing");
+        icb->RegisterSharedControl(MaxPutTimeoutSeconds, "DSProxyControls.MaxPutTimeoutSeconds");
     }
 
     // start replication broker

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -256,6 +256,7 @@ namespace NKikimr::NStorage {
         TControlWrapper ReportingControllerBucketSize;
         TControlWrapper ReportingControllerLeakDurationMs;
         TControlWrapper ReportingControllerLeakRate;
+        TControlWrapper MaxPutTimeoutSeconds;
 
         TControlWrapper EnableDeepScrubbing;
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
@@ -53,6 +53,7 @@ void TNodeWarden::StartLocalProxy(ui32 groupId) {
                             .Controls = TBlobStorageProxyControlWrappers{
                                 .EnablePutBatching = EnablePutBatching,
                                 .EnableVPatch = EnableVPatch,
+                                .MaxPutTimeoutSeconds = MaxPutTimeoutSeconds,
                                 ADD_CONTROLS_FOR_DEVICE_TYPES(SlowDiskThreshold),
                                 ADD_CONTROLS_FOR_DEVICE_TYPES(PredictedDelayMultiplier),
                                 ADD_CONTROLS_FOR_DEVICE_TYPES(MaxNumOfSlowDisks),
@@ -78,6 +79,7 @@ void TNodeWarden::StartLocalProxy(ui32 groupId) {
                         .Controls = TBlobStorageProxyControlWrappers{
                             .EnablePutBatching = EnablePutBatching,
                             .EnableVPatch = EnableVPatch,
+                            .MaxPutTimeoutSeconds = MaxPutTimeoutSeconds,
                             ADD_CONTROLS_FOR_DEVICE_TYPES(SlowDiskThreshold),
                             ADD_CONTROLS_FOR_DEVICE_TYPES(PredictedDelayMultiplier),
                             ADD_CONTROLS_FOR_DEVICE_TYPES(MaxNumOfSlowDisks),
@@ -93,6 +95,7 @@ void TNodeWarden::StartLocalProxy(ui32 groupId) {
             .Controls = TBlobStorageProxyControlWrappers{
                 .EnablePutBatching = EnablePutBatching,
                 .EnableVPatch = EnableVPatch,
+                .MaxPutTimeoutSeconds = MaxPutTimeoutSeconds,
                 ADD_CONTROLS_FOR_DEVICE_TYPES(SlowDiskThreshold),
                 ADD_CONTROLS_FOR_DEVICE_TYPES(PredictedDelayMultiplier),
                 ADD_CONTROLS_FOR_DEVICE_TYPES(MaxNumOfSlowDisks),

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -66,6 +66,7 @@ struct TEnvironmentSetup {
         const ui32 NumPiles = 0;
         const bool AutomaticBootstrap = false;
         const std::function<TIntrusivePtr<TStateStorageInfo>(std::function<TActorId(ui32, ui32)>, ui32)> StateStorageInfoGenerator = nullptr;
+        const TDuration MaxPutTimeoutDSProxy = TDuration::Seconds(60);
     };
 
     const TSettings Settings;
@@ -544,6 +545,7 @@ config:
                 ADD_ICB_CONTROL("DSProxyControls.MaxNumOfSlowDisksSSD", 2, 1, 2, Settings.MaxNumOfSlowDisks);
 
                 ADD_ICB_CONTROL("VDiskControls.EnableDeepScrubbing", false, false, true, Settings.EnableDeepScrubbing);
+                ADD_ICB_CONTROL("DSProxyControls.MaxPutTimeoutSeconds", 60, 1, 1'000'000, Settings.MaxPutTimeoutDSProxy.Seconds());
 
 #undef ADD_ICB_CONTROL
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1751,6 +1751,12 @@ message TImmediateControlsConfig {
             DefaultValue: 2 }];
 
         optional TRequestReportingSettings RequestReportingSettings = 12;
+
+        optional uint64 MaxPutTimeoutSeconds = 13 [(ControlOptions) = {
+            Description: "Maximum amount of time TEvPut request can work until it is terminated with DEADLINE status by DSProxy",
+            MinValue: 1,
+            MaxValue: 1000000,
+            DefaultValue: 60 }]; // 1 minute
     }
 
     message TPDiskControls {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This change makes maximum deadline for TEvPut requests customizable via ICB, previously it was hard set to 60 seconds.

### Changelog category <!-- remove all except one -->

* Improvement