### PR TITLE
Fix VDisk sync log race

### DIFF
--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
@@ -82,7 +82,7 @@ namespace NKikimr {
             // TODO: put blobs and hard barriers in phantom flag storage thresholds
             // Check for memory overflow
             if (SyncLogPtr->GetNumberOfPagesInMemory() > MaxMemPages)
-                DelayedActions.SetMemOverflow();
+                DelayedActions.MemOverflow = true;
 
             // Put blob record to PhantomFlagStorage
             if (PhantomFlagStorageState.IsActive() && rec->RecType == TRecordHdr::RecLogoBlob) {
@@ -95,7 +95,7 @@ namespace NKikimr {
             SyncLogPtr->PutMany(buf, size);
             // Check for memory overflow
             if (SyncLogPtr->GetNumberOfPagesInMemory() > MaxMemPages)
-                DelayedActions.SetMemOverflow();
+                DelayedActions.MemOverflow = true;
 
             // Put all blob records to PhantomFlagStorage
             TRecordHdr* rec = (TRecordHdr*)buf;
@@ -132,7 +132,7 @@ namespace NKikimr {
             Y_VERIFY_S(lsn <= seg->Info.LastLsn + 1, SlCtx->VCtx->VDiskLogPrefix);
             // Check for memory overflow
             if (SyncLogPtr->GetNumberOfPagesInMemory() > MaxMemPages)
-                DelayedActions.SetMemOverflow();
+                DelayedActions.MemOverflow = true;
         }
 
         void TSyncLogKeeperState::TrimTailEvent(ui64 trimTailLsn) {
@@ -141,7 +141,7 @@ namespace NKikimr {
                         "KEEPER: TEvSyncLogTrim: trimLsn# %" PRIu64, trimTailLsn));
 
             TrimTailLsn = trimTailLsn;
-            DelayedActions.SetTrimTail();
+            DelayedActions.TrimTail = true;
         }
 
         void TSyncLogKeeperState::BaldLogEvent(bool dropChunksExplicitly) {
@@ -164,7 +164,7 @@ namespace NKikimr {
                             "KEEPER: TEvSyncLogBaldLog: baldLsn# %" PRIu64, baldLsn));
     
                 TrimTailLsn = baldLsn;
-                DelayedActions.SetTrimTail();
+                DelayedActions.TrimTail = true;
             }
         }
 
@@ -175,7 +175,7 @@ namespace NKikimr {
 
             FreeUpToLsn = freeUpToLsn;
             CutLogRetries = 0;
-            DelayedActions.SetCutLog();
+            DelayedActions.CutLog = true;
         }
 
         void TSyncLogKeeperState::RetryCutLogEvent() {
@@ -191,24 +191,26 @@ namespace NKikimr {
                             "KEEPER: RetryCutLogEvent: retried; FreeUpToLsn# %" PRIu64, FreeUpToLsn));
 
                 // retry event with old value of FreeUpToLsn
-                DelayedActions.SetCutLog();
+                DelayedActions.CutLog = true;
             }
         }
 
         void TSyncLogKeeperState::FreeChunkEvent(ui32 chunkIdx) {
-            LOG_DEBUG(*LoggerCtx, BS_SYNCLOG,
-                    VDISKP(SlCtx->VCtx->VDiskLogPrefix,
-                        "KEEPER: TEvSyncLogFreeChunk: chunkIdx# %" PRIu32,
-                        chunkIdx));
-
-            ChunksToDeleteDelayed.Erase(chunkIdx);
-            ChunksToDelete.push_back(chunkIdx);
-            DelayedActions.SetDeleteChunk();
+            LOG_DEBUG(*LoggerCtx, BS_SYNCLOG, VDISKP(SlCtx->VCtx->VDiskLogPrefix,
+                "KEEPER: TEvSyncLogFreeChunk: chunkIdx# %" PRIu32, chunkIdx));
+            const size_t n = DeletedChunksPending.erase(chunkIdx);
+            Y_ABORT_UNLESS(n == 1);
+            if (DeletedChunks.erase(chunkIdx)) {
+                ChunksToForget.push_back(chunkIdx);
+            } else { // we haven't committed this chunk deletion yet, postpone its forgetting
+                const auto [it, inserted] = ChunksToForgetPending.insert(chunkIdx);
+                Y_ABORT_UNLESS(inserted);
+            }
         }
 
         bool TSyncLogKeeperState::PerformCutLogAction(std::function<void(ui64)> &&notCommitHandler) {
-            if (DelayedActions.HasCutLog()) {
-                DelayedActions.ClearCutLog();
+            if (DelayedActions.CutLog) {
+                DelayedActions.CutLog = false;
             } else {
                 return false;
             }
@@ -240,8 +242,8 @@ namespace NKikimr {
         }
 
         bool TSyncLogKeeperState::PerformTrimTailAction() {
-            if (DelayedActions.HasTrimTail()) {
-                DelayedActions.ClearTrimTail();
+            if (DelayedActions.TrimTail) {
+                DelayedActions.TrimTail = false;
             } else {
                 return false;
             }
@@ -249,8 +251,8 @@ namespace NKikimr {
             LOG_DEBUG(*LoggerCtx, BS_SYNCLOG,
                     VDISKP(SlCtx->VCtx->VDiskLogPrefix,
                         "KEEPER: cut log: TrimTailLsn# %" PRIu64
-                        " ChunksToDeleteDelayed# %s", TrimTailLsn,
-                        ChunksToDeleteDelayed.ToString().data()));
+                        " ChunksToDelete# %s", TrimTailLsn,
+                        FormatList(ChunksToDelete).data()));
 
             // If TrimTailLsn is outdated, we just ignore it and log it,
             // SynclogKeeper can decide to cut log by some other reason.
@@ -262,17 +264,14 @@ namespace NKikimr {
             };
 
             TVector<ui32> scheduledChunks = SyncLogPtr->TrimLogByConfirmedLsn(TrimTailLsn, Notifier, logger);
-            ChunksToDeleteDelayed.Insert(scheduledChunks);
-
-            // we don't need to commit because we either remove mem pages or
-            // schedule to remove some chunks (but they may be used by snapshots,
-            // so wait until TEvSyncLogFreeChunk message)
-            return false;
+            ChunksToDelete.insert(ChunksToDelete.end(), scheduledChunks.begin(), scheduledChunks.end());
+            DeletedChunksPending.insert(scheduledChunks.begin(), scheduledChunks.end());
+            return !ChunksToDelete.empty();
         }
 
         bool TSyncLogKeeperState::PerformMemOverflowAction() {
-            if (DelayedActions.HasMemOverflow()) {
-                DelayedActions.ClearMemOverflow();
+            if (DelayedActions.MemOverflow) {
+                DelayedActions.MemOverflow = false;
             } else {
                 return false;
             }
@@ -289,31 +288,15 @@ namespace NKikimr {
             return stillMemOverflow;
         }
 
-        bool TSyncLogKeeperState::PerformDeleteChunkAction() {
-            if (DelayedActions.HasDeleteChunk()) {
-                DelayedActions.ClearDeleteChunk();
-            } else {
-                return false;
-            }
-
-            // yes, log new entry point, if we have some chunks ready
-            // for returning to PDisk
-            return !ChunksToDelete.empty();
-        }
-
         bool TSyncLogKeeperState::PerformInitialCommit() {
             return std::exchange(NeedsInitialCommit, false);
         }
 
         TSyncLogKeeperCommitData TSyncLogKeeperState::PrepareCommitData(ui64 recoveryLogConfirmedLsn) {
-            // we _copy_ ChunksToDeleteDelayed and _move_ ChunksToDelete
-
             // take snap
             TSyncLogSnapshotPtr syncLogSnapshot = SyncLogPtr->GetSnapshot();
             // fix mem and disk overflow
             TMemRecLogSnapshotPtr swapSnap = FixMemoryAndDiskOverflow(syncLogSnapshot);
-            // copy from TSet to vector
-            TVector<ui32> deleteDelayed = ChunksToDeleteDelayed.Copy();
 
             // NOTE: if there is no updates going to SyncLog (and recovery log respectively),
             // recoveryLogConfirmedLsn can be very old and pessimistic. And more important, it doens't
@@ -327,8 +310,7 @@ namespace NKikimr {
             TSyncLogKeeperCommitData result(
                     std::move(syncLogSnapshot),
                     std::move(swapSnap),
-                    std::move(deleteDelayed),
-                    std::move(ChunksToDelete),
+                    std::exchange(ChunksToDelete, {}),
                     refinedRecoveryLogConfirmedLsn);
             return result;
         }
@@ -338,6 +320,15 @@ namespace NKikimr {
             SyncLogPtr->UpdateDiskIndex(msg->Delta, msg->EntryPointDbgInfo);
             // save last commit info
             LastCommit = msg->CommitInfo;
+
+            for (ui32 chunkIdx : msg->ChunksDeleted) {
+                if (ChunksToForgetPending.erase(chunkIdx)) { // this chunk has been released while commit was in flight
+                    ChunksToForget.push_back(chunkIdx);
+                } else {
+                    const auto [it, inserted] = DeletedChunks.insert(chunkIdx);
+                    Y_ABORT_UNLESS(inserted);
+                }
+            }
 
             const TEntryPointDbgInfo &info = SyncLogPtr->GetLastEntryPointDbgInfo();
             if (info.ByteSize > SyncLogMaxEntryPointSize) {
@@ -445,7 +436,6 @@ namespace NKikimr {
             };
 
             process(ChunksToDelete);
-            process(ChunksToDeleteDelayed.Get());
 
             TSet<ui32> temp;
             SyncLogPtr->GetOwnedChunks(temp);
@@ -496,7 +486,11 @@ namespace NKikimr {
                 }
             }
 
-            ChunksToDeleteDelayed.Insert(chunks);
+            ChunksToDelete.insert(ChunksToDelete.end(), chunks.begin(), chunks.end());
+            DeletedChunksPending.insert(chunks.begin(), chunks.end());
+            if (!ChunksToDelete.empty()) {
+                DelayedActions.DeleteChunk = true;
+            }
         }
 
         void TSyncLogKeeperState::UpdateMetrics() {

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
@@ -14,89 +14,18 @@ namespace NKikimr {
     namespace NSyncLog {
 
         ////////////////////////////////////////////////////////////////////////////
-        // TChunksToDeleteDelayed
-        ////////////////////////////////////////////////////////////////////////////
-        class TChunksToDeleteDelayed {
-        public:
-            void Insert(const TVector<ui32> &chunks) {
-                for (auto chunkIdx : chunks) {
-                    bool inserted = Chunks.insert(chunkIdx).second;
-                    Y_ABORT_UNLESS(inserted);
-                }
-            }
-
-            TVector<ui32> Copy() const {
-                // copy from TSet to vector
-                TVector<ui32> vec;
-                vec.assign(Chunks.begin(), Chunks.end());
-                return vec;
-            }
-
-            void Erase(ui32 chunkIdx) {
-                const ui32 del = Chunks.erase(chunkIdx);
-                Y_ABORT_UNLESS(del == 1);
-            }
-
-            TString ToString() const {
-                TStringStream str;
-                Output(str);
-                return str.Str();
-            }
-
-            void Output(IOutputStream &s) const {
-                s << "[";
-                bool first = true;
-                for (auto chunkIdx : Chunks) {
-                    if (first)
-                        first = false;
-                    else
-                        s << " ";
-                    s << chunkIdx;
-                }
-                s << "]";
-            }
-
-            const TSet<ui32>& Get() const {
-                return Chunks;
-            }
-
-        private:
-            TSet<ui32> Chunks;
-        };
-
-
-
-        ////////////////////////////////////////////////////////////////////////////
         // TDelayedActions
         ////////////////////////////////////////////////////////////////////////////
-        class TDelayedActions {
-        public:
-            // Set methods
-            void SetTrimTail()          { TrimTailAction = true; }
-            void SetCutLog()            { CutLogAction = true; }
-            void SetMemOverflow()       { MemOverflowAction = true; }
-            void SetDeleteChunk()       { DeleteChunkAction = true; }
-            // Has methods
-            bool HasTrimTail()          { return TrimTailAction; }
-            bool HasCutLog()            { return CutLogAction; }
-            bool HasMemOverflow()       { return MemOverflowAction; }
-            bool HasDeleteChunk()       { return DeleteChunkAction; }
-            // Clear methods
-            void ClearTrimTail()        { TrimTailAction = false; }
-            void ClearCutLog()          { CutLogAction = false; }
-            void ClearMemOverflow()     { MemOverflowAction = false; }
-            void ClearDeleteChunk()     { DeleteChunkAction = false; }
-
+        struct TDelayedActions {
             // Has any action?
             bool HasActions() const {
-                return TrimTailAction || CutLogAction || MemOverflowAction || DeleteChunkAction;
+                return TrimTail || CutLog || MemOverflow || DeleteChunk;
             }
 
-        private:
-            bool TrimTailAction = false;
-            bool CutLogAction = false;
-            bool MemOverflowAction = false;
-            bool DeleteChunkAction = false;
+            bool TrimTail = false;
+            bool CutLog = false;
+            bool MemOverflow = false;
+            bool DeleteChunk = false;
         };
 
         ////////////////////////////////////////////////////////////////////////////
@@ -119,9 +48,8 @@ namespace NKikimr {
                 SelfId = selfId;
             }
 
-            bool HasDelayedActions() const {
-                return DelayedActions.HasActions();
-            }
+            bool HasDelayedActions() const { return DelayedActions.HasActions(); }
+            bool GetDeleteChunkAndClear() { return std::exchange(DelayedActions.DeleteChunk, false); }
 
             TSyncLogSnapshotPtr GetSyncLogSnapshot() const {
                 return SyncLogPtr->GetSnapshot();
@@ -151,7 +79,6 @@ namespace NKikimr {
             // just trim log based by TrimTailLsn (which is confirmed lsn from peers)
             bool PerformTrimTailAction();
             bool PerformMemOverflowAction();
-            bool PerformDeleteChunkAction();
             bool PerformInitialCommit();
 
             bool FreeUpToLsnSatisfied() const { return CalculateFirstLsnToKeep() >= FreeUpToLsn; }
@@ -170,6 +97,10 @@ namespace NKikimr {
 
             void UpdateMetrics();
 
+            TVector<ui32> GetChunksToForget() {
+                return std::exchange(ChunksToForget, {});
+            }
+
         private:
             // VDisk Context
             TIntrusivePtr<TSyncLogCtx> SlCtx;
@@ -185,8 +116,6 @@ namespace NKikimr {
             ui64 FreeUpToLsn = 0;
             // actions we must apply but have not applied yet
             TDelayedActions DelayedActions;
-            // chunks that are still used by snapshots
-            TChunksToDeleteDelayed ChunksToDeleteDelayed;
             // notifier for deleted chunks
             std::shared_ptr<IActorNotify> Notifier;
             // logger ctx
@@ -213,6 +142,11 @@ namespace NKikimr {
 
             ui32 SelfOrderNumber;
 
+            TVector<ui32> ChunksToForget;
+            THashSet<ui32> ChunksToForgetPending;
+            THashSet<ui32> DeletedChunks;
+            THashSet<ui32> DeletedChunksPending;
+
         private:
             // Fix Disk overflow, i.e. remove some chunks from SyncLog
             TVector<ui32> FixDiskOverflow(ui32 numChunksToAdd);
@@ -223,7 +157,7 @@ namespace NKikimr {
             // 2. Disk chunks used for SyncLog
             // The function fixes limitation excess by
             // 1. returning swapSnap to write to disk (frees memory)
-            // 2. removing some old chunks (putting them to ChunksToDeleteDelayed)
+            // 2. removing some old chunks (putting them to ChunksToDelete)
             TMemRecLogSnapshotPtr FixMemoryAndDiskOverflow(const TSyncLogSnapshotPtr& snapshot);
             // Calculate first lsn to keep in recovery log for _DATA_RECORDS_,
             // i.e. for those records in SyncLog which keep user data


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix VDisk sync log race

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes race with deleting chunks leading to assertion failure and causing possible double-free corruption.
