### PR TITLE
Make NWilson::TTraceId constructor public

### DIFF
--- a/ydb/library/actors/wilson/wilson_trace.h
+++ b/ydb/library/actors/wilson/wilson_trace.h
@@ -29,6 +29,14 @@ namespace NWilson {
         static constexpr ui32 MAX_TIME_TO_LIVE = 4095;
 
     private:
+        static TTrace GenerateTraceId();
+        static ui64 GenerateSpanId();
+
+    public:
+        using TSerializedTraceId = char[sizeof(TTrace) + sizeof(ui64) + sizeof(ui32)];
+
+    public:
+
         TTraceId(TTrace traceId, ui64 spanId, ui8 verbosity, ui32 timeToLive)
             : TraceId(traceId)
         {
@@ -42,13 +50,7 @@ namespace NWilson {
             TimeToLive = timeToLive;
         }
 
-        static TTrace GenerateTraceId();
-        static ui64 GenerateSpanId();
 
-    public:
-        using TSerializedTraceId = char[sizeof(TTrace) + sizeof(ui64) + sizeof(ui32)];
-
-    public:
         TTraceId(ui64) // NBS stub
             : TTraceId()
         {}


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make NWilson::TTraceId constructor public

### Changelog category <!-- remove all except one -->

* Not for changelog 

### Description for reviewers <!-- (optional) description for those who read this PR -->

In NBS, we want to add E2E traces with YDB for debugging latency issues, but we use LWTrace for tracing. Therefore, we need a public constructor to convert our TraceId into NWilson::TTraceId.