### PR TITLE
Fix vector index query failure when selecting non-PK columns without overlap

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -613,7 +613,8 @@ void VectorReadMain(
 
     const auto& targetTable = isCovered ? postingTable : mainTable;
 
-    if (withOverlap) {
+    const bool needPkColumns = pushdownSettings.VectorTopDistinct || withOverlap;
+    if (needPkColumns) {
         // mainColumns must contain primary key columns for DistinctColumns pushdown
         THashSet<TStringBuf> cols;
         for (const auto& col: mainColumns) {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -613,8 +613,7 @@ void VectorReadMain(
 
     const auto& targetTable = isCovered ? postingTable : mainTable;
 
-    const bool needPkColumns = pushdownSettings.VectorTopDistinct || withOverlap;
-    if (needPkColumns) {
+    if (withOverlap) {
         // mainColumns must contain primary key columns for DistinctColumns pushdown
         THashSet<TStringBuf> cols;
         for (const auto& col: mainColumns) {
@@ -754,7 +753,7 @@ TExprBase DoRewriteTopSortOverKMeansTree(
 
     settings.VectorTopColumn = indexDesc.KeyColumns.back();
     settings.VectorTopLimit = top.Count().Ptr();
-    settings.VectorTopDistinct = true;
+    settings.VectorTopDistinct = withOverlap;
     VectorReadMain(ctx, pos, postingTable, postingTableDesc->Metadata, mainTable, tableDesc.Metadata, mainColumns, settings, withOverlap, read);
 
     if (flatMap) {
@@ -891,7 +890,7 @@ TExprBase DoRewriteTopSortOverPrefixedKMeansTree(
 
     settings.VectorTopColumn = indexDesc.KeyColumns.back();
     settings.VectorTopLimit = top.Count().Ptr();
-    settings.VectorTopDistinct = true;
+    settings.VectorTopDistinct = withOverlap;
     VectorReadMain(ctx, pos, postingTable, postingTableDesc->Metadata, mainTable, tableDesc.Metadata, mainColumns, settings, withOverlap, read);
 
     if (mainLambda) {

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
@@ -316,6 +316,88 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         }
     }
 
+    // Test that vector index queries work when selecting only non-PK columns
+    Y_UNIT_TEST_TWIN(VectorIndexSelectWithoutPkColumns, WithOverlap) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        // Create table with multiple PK columns
+        {
+            auto tableBuilder = db.GetTableBuilder();
+            tableBuilder
+                .AddNonNullableColumn("pk1", EPrimitiveType::Int64)
+                .AddNonNullableColumn("pk2", EPrimitiveType::Int64)
+                .AddNonNullableColumn("emb", EPrimitiveType::String)
+                .AddNonNullableColumn("data", EPrimitiveType::String);
+            tableBuilder.SetPrimaryKeyColumns({"pk1", "pk2"});
+            auto result = session.CreateTable("/Root/TestTable", tableBuilder.Build()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.IsTransportError(), false);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // Insert test data
+        {
+            const TString query1(Q_(R"(
+                UPSERT INTO `/Root/TestTable` (pk1, pk2, emb, data) VALUES
+                (0, 0, "\x03\x30\x02", "0"),
+                (1, 1, "\x13\x31\x02", "1"),
+                (2, 2, "\x23\x32\x02", "2"),
+                (3, 3, "\x53\x33\x02", "3"),
+                (4, 4, "\x43\x34\x02", "4"),
+                (5, 5, "\x50\x60\x02", "5"),
+                (6, 6, "\x61\x11\x02", "6"),
+                (7, 7, "\x12\x62\x02", "7"),
+                (8, 8, "\x75\x76\x02", "8"),
+                (9, 9, "\x76\x76\x02", "9");
+            )"));
+
+            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        // Create vector index
+        {
+            const TString createIndex(Q_(Sprintf(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (emb)
+                    WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2%s);
+            )", WithOverlap ? ", overlap_clusters=2" : "")));
+
+            auto result = session.ExecuteSchemeQuery(createIndex).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        // Query selecting only 'data' column (not PK columns)
+        {
+            const TString query1(Q1_(R"(
+                pragma ydb.KMeansTreeSearchTopSize = "1";
+                $target = "\x67\x71\x02";
+                SELECT data FROM `/Root/TestTable` VIEW index
+                ORDER BY Knn::CosineDistance(emb, $target)
+                LIMIT 3;
+            )"));
+
+            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(),
+                "Failed to execute: `" << query1 << "` with " << result.GetIssues().ToString());
+        }
+    }
+
     void DoTestOrderByCosine(ui32 indexLevels, int flags) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

When VectorTopDistinct is enabled in stream lookup settings, the query
compiler requires all main table PK columns to be present in the read
columns. However, VectorReadMain() only added PK columns when overlap
was enabled (withOverlap=true), causing queries that select only non-PK
columns to fail with assertion error:
  readColumnIndexes.contains(keyColumn) failed

The fix ensures PK columns are always added when VectorTopDistinct is
true, regardless of the overlap setting.

Added unit test VectorIndexSelectWithoutPkColumns with TWIN macro to
test both with and without overlap scenarios.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
