### PR TITLE
Broken tests in ydb/core/tx/schemeshard/ut_pq_reboots

### DIFF
--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -3702,9 +3702,8 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
         }
     }
 
-    if (step > PlanStep) {
+    if ((step > PlanStep) && lastPlannedTxId.Defined()) {
         // если это план из будущего, то надо запомнить, последнюю запланированную транзакцию
-        PQ_ENSURE(lastPlannedTxId.Defined());
         PlanStep = step;
         PlanTxId = *lastPlannedTxId;
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

If the PQ tablet has already processed the transaction, the lastPlannedTxId in the TEvPlanStep handler will remain empty.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
