### PR TITLE
dq: sync CA: implement watermark with input transform / streamlookup join

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -466,6 +466,10 @@ private:
         return inputChannel->FreeSpace;
     }
 
+    TDqComputeActorWatermarks *GetInputTransformWatermarksTracker(ui64 /*inputId*/) override {
+        return nullptr;
+    }
+
     void OnTaskRunnerCreated(NTaskRunnerActor::TEvTaskRunnerCreateFinished::TPtr& ev) {
         const auto& secureParams = ev->Get()->SecureParams;
         const auto& taskParams = ev->Get()->TaskParams;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -315,6 +315,7 @@ public:
         const NKikimr::NMiniKQL::TTypeEnvironment& TypeEnv;
         const NKikimr::NMiniKQL::THolderFactory& HolderFactory;
         std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
+        TDqComputeActorWatermarks* WatermarksTracker = nullptr;
         NWilson::TTraceId TraceId;
     };
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -1860,6 +1860,8 @@ public:
     }
 
 protected:
+    virtual TDqComputeActorWatermarks *GetInputTransformWatermarksTracker(ui64 inputId) = 0;
+
     void FillIoMaps(
         const NKikimr::NMiniKQL::THolderFactory& holderFactory,
         const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
@@ -1929,6 +1931,7 @@ protected:
                         .TypeEnv = typeEnv,
                         .HolderFactory = holderFactory,
                         .Alloc = Alloc,
+                        .WatermarksTracker = GetInputTransformWatermarksTracker(inputIndex),
                         .TraceId = ComputeActorSpan.GetTraceId()
                     });
             } catch (const std::exception& ex) {

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -326,6 +326,10 @@ protected:
         return sinkInfo.Buffer.Get();
     }
 
+    TDqComputeActorWatermarks *GetInputTransformWatermarksTracker(ui64 inputId) override {
+        return TaskRunner ? TaskRunner->GetInputTransformWatermarksTracker(inputId): nullptr;
+    }
+
 protected:
     // methods that are called via static_cast<TDerived*>(this) and may be overriden by a dervied class
     void* GetSourcesState() const {

--- a/ydb/library/yql/dq/actors/compute/ut/dq_sync_compute_actor_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_sync_compute_actor_ut.cpp
@@ -1071,11 +1071,6 @@ Y_UNIT_TEST_SUITE(TSyncComputeActorTest) {
     }
 
     Y_UNIT_TEST_F(InputTransformMultichannel, TSyncComputeActorTestFixture) {
-        if constexpr (true) {
-            // test temporarily disabled
-            // (functionality was broken before, but test was broken and checked nothing)
-            return;
-        }
         TVector<ui32> sizes{ 1, 2, 3, 4, 5, 51, 128, 251 };
         std::mt19937 rng(GetRandomSeed());
         for (ui32 t = 0; t < 16; ++t) sizes.push_back(1 + rng() % 734);

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -1,6 +1,7 @@
 #include "dq_input_transform_lookup.h"
 
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io_factory.h>
+#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h>
 #include <yql/essentials/minikql/mkql_string_util.h>
 #include <yql/essentials/minikql/mkql_node_serialization.h>
 #include <yql/essentials/minikql/mkql_type_builder.h>
@@ -47,6 +48,7 @@ public:
         const NMiniKQL::TStructType* lookupPayloadType,
         const NMiniKQL::TMultiType* outputRowType,
         TOutputRowColumnOrder&& outputRowColumnOrder,
+        TDqComputeActorWatermarks* watermarksTracker,
         const THashMap<TString, TString>& secureParams)
         : TActor(&TInputTransformStreamLookupDerivedBase::StateFunc)
         , Alloc(alloc)
@@ -67,6 +69,7 @@ public:
         , LookupPayloadType(lookupPayloadType)
         , OutputRowType(outputRowType)
         , OutputRowColumnOrder(std::move(outputRowColumnOrder))
+        , WatermarksTracker(watermarksTracker)
         , InputFlowFetchStatus(NUdf::EFetchStatus::Yield)
         , LruCache(std::make_unique<NKikimr::NMiniKQL::TUnboxedKeyValueLruCacheWithTtl>(Settings.GetCacheLimit(), lookupKeyType))
         , MaxDelayedRows(Settings.GetMaxDelayedRows())
@@ -139,6 +142,33 @@ private: //IDqComputeActorAsyncInput
         while (!ReadyQueue.empty()) {
             PushOutputValue(batch, ReadyQueue.Head());
             ReadyQueue.Pop();
+        }
+    }
+
+    void CheckPendingWatermark() {
+        if (WatermarksTracker && InputFlowFetchStatus == NUdf::EFetchStatus::Yield) {
+            if (auto pendingWatermark = WatermarksTracker->GetPendingWatermark()) {
+                Y_DEBUG_ABORT_UNLESS(PendingWatermark < *pendingWatermark);
+                WatermarksTracker->PopPendingWatermark();
+                PendingWatermark = *pendingWatermark;
+            }
+        }
+    }
+
+    void PushReadyWatermark() {
+        if (PendingWatermark) {
+            Y_DEBUG_ABORT_UNLESS(WatermarksTracker);
+            Y_DEBUG_ABORT_UNLESS(ReadyWatermark < *PendingWatermark);
+            ReadyWatermark = *PendingWatermark;
+            PendingWatermark.Clear();
+        }
+    }
+
+    void PopReadyWatermark(TMaybe<TInstant>& watermark) {
+        if (ReadyWatermark) {
+            Y_DEBUG_ABORT_UNLESS(WatermarksTracker);
+            watermark = *ReadyWatermark;
+            ReadyWatermark.Clear();
         }
     }
 
@@ -235,6 +265,7 @@ protected:
     const NMiniKQL::TMultiType* const OutputRowType;
     const TOutputRowColumnOrder OutputRowColumnOrder;
 
+    TDqComputeActorWatermarks* WatermarksTracker;
     NUdf::EFetchStatus InputFlowFetchStatus;
     std::unique_ptr<NKikimr::NMiniKQL::TUnboxedKeyValueLruCacheWithTtl> LruCache;
     size_t MaxDelayedRows;
@@ -243,6 +274,8 @@ protected:
     size_t MinimumRowSize; // only account for unboxed parts
     size_t PayloadExtraSize; // non-embedded part of strings in ReadyQueue
     NKikimr::NMiniKQL::TUnboxedValueBatch ReadyQueue;
+    TMaybe<TInstant> PendingWatermark;
+    TMaybe<TInstant> ReadyWatermark;
     NYql::NDq::TDqAsyncStats IngressStats;
     std::shared_ptr<IDqAsyncLookupSource::TUnboxedValueMap> KeysForLookup;
     i64 LastLruSize;
@@ -344,6 +377,7 @@ private:
             LruCache->Update(NUdf::TUnboxedValue(const_cast<NUdf::TUnboxedValue&&>(k)), std::move(v), now + CacheTtl);
         }
         KeysForLookup->clear();
+        PushReadyWatermark();
         auto deltaLruSize = (i64)LruCache->Size() - LastLruSize;
         auto deltaTime = GetCpuTimeDelta(startCycleCount);
         CpuTime += deltaTime;
@@ -361,7 +395,7 @@ private:
         TCommon::Free();
     }
 
-    i64 GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>&, bool& finished, i64 freeSpace) final {
+    i64 GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>& watermark, bool& finished, i64 freeSpace) final {
         Y_UNUSED(freeSpace);
         auto startCycleCount = GetCycleCountFast();
         auto guard = BindAllocator();
@@ -409,16 +443,21 @@ private:
                 }
                 ++row;
             }
+            CheckPendingWatermark();
             if (Batches && (!KeysForLookup->empty() || ReadyQueue.RowCount())) {
                 Batches->Inc();
                 LruHits->Add(ReadyQueue.RowCount());
                 LruMiss->Add(AwaitingQueue.size());
             }
-            if (!KeysForLookup->empty()) {
+            if (KeysForLookup->empty()) {
+                PushReadyWatermark();
+            } else {
                 Send(LookupSourceId, new IDqAsyncLookupSource::TEvLookupRequest(KeysForLookup));
             }
             DrainReadyQueue(batch);
         }
+        PopReadyWatermark(watermark);
+
         auto deltaTime = GetCpuTimeDelta(startCycleCount);
         CpuTime += deltaTime;
         if (CpuTimeUs) {
@@ -544,7 +583,10 @@ private: //events
                 ReadyQueue.PushRow(output.OutputRowItems, OutputRowType->GetElementsCount());
                 AwaitingQueue.pop_front();
                 LastRequestedIncomplete.reset();
+                PushReadyWatermark();
             }
+        } else {
+            PushReadyWatermark();
         }
         for (auto&& [k, v]: *lookupResult) {
             LruCache->Update(NUdf::TUnboxedValue(const_cast<NUdf::TUnboxedValue&&>(k)), std::move(v), now + CacheTtl);
@@ -587,7 +629,7 @@ private: //events
     }
 
 public:
-    i64 GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>&, bool& finished, i64 freeSpace) final {
+    i64 GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>& watermark, bool& finished, i64 freeSpace) final {
         Y_UNUSED(freeSpace);
         auto startCycleCount = GetCycleCountFast();
         auto guard = BindAllocator();
@@ -633,6 +675,7 @@ public:
                 ReadyQueue.PushRow(output.OutputRowItems, outputColumns);
                 AwaitingQueue.pop_front();
                 LastRequestedIncomplete.reset();
+                PushReadyWatermark();
             }
         }
         DrainReadyQueue(batch);
@@ -733,13 +776,19 @@ public:
                 }
                 ++row;
             }
+            CheckPendingWatermark();
             if (Batches && (!KeysForLookup->empty() || ReadyQueue.RowCount())) {
                 Batches->Inc();
             }
             DrainReadyQueue(batch);
         }
-        if (keysForLookupWasEmpty && !KeysForLookup->empty()) {
-            Send(LookupSourceId, new IDqAsyncLookupSource::TEvLookupRequest(KeysForLookup));
+        PopReadyWatermark(watermark);
+        if (keysForLookupWasEmpty) {
+           if (KeysForLookup->empty()) {
+               PushReadyWatermark();
+           } else {
+               Send(LookupSourceId, new IDqAsyncLookupSource::TEvLookupRequest(KeysForLookup));
+           }
         }
         auto deltaTime = GetCpuTimeDelta(startCycleCount);
         CpuTime += deltaTime;
@@ -1117,6 +1166,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
                 lookupPayloadType,
                 outputRowType,
                 std::move(outputColumnsOrder),
+                args.WatermarksTracker,
                 args.SecureParams
             ) :
             (TInputTransformStreamMultiLookupBase*)new TInputTransformStreamMultiLookupNarrow(
@@ -1136,6 +1186,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
                 lookupPayloadType,
                 outputRowType,
                 std::move(outputColumnsOrder),
+                args.WatermarksTracker,
                 args.SecureParams
             );
         return {actor, actor};
@@ -1158,6 +1209,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
             lookupPayloadType,
             outputRowType,
             std::move(outputColumnsOrder),
+            args.WatermarksTracker,
             args.SecureParams
         ) :
         (TInputTransformStreamLookupBase*)new TInputTransformStreamLookupNarrow(
@@ -1177,6 +1229,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
             lookupPayloadType,
             outputRowType,
             std::move(outputColumnsOrder),
+            args.WatermarksTracker,
             args.SecureParams
         );
     return {actor, actor};

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -997,7 +997,6 @@ public:
         }
     }
 
-
     std::pair<IDqAsyncOutputBuffer::TPtr, IDqOutputConsumer::TPtr> GetOutputTransform(ui64 outputIndex) override {
         auto ptr = AllocatedHolder->OutputTransforms.FindPtr(outputIndex);
         YQL_ENSURE(ptr, "task: " << TaskId << " does not have output index: " << outputIndex << " or such transform");

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.h
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.h
@@ -461,6 +461,7 @@ public:
     virtual IDqOutputChannel::TPtr GetOutputChannel(ui64 channelId) = 0;
     virtual IDqAsyncOutputBuffer::TPtr GetSink(ui64 outputIndex) = 0;
     virtual std::optional<std::pair<NUdf::TUnboxedValue, IDqAsyncInputBuffer::TPtr>> GetInputTransform(ui64 inputIndex) = 0;
+    virtual TDqComputeActorWatermarks *GetInputTransformWatermarksTracker(ui64 inputId) = 0;
     virtual std::pair<IDqAsyncOutputBuffer::TPtr, IDqOutputConsumer::TPtr> GetOutputTransform(ui64 outputIndex) = 0;
 
     virtual IRandomProvider* GetRandomProvider() const = 0;

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
@@ -1820,6 +1820,10 @@ public:
         return {};
     }
 
+    TDqComputeActorWatermarks *GetInputTransformWatermarksTracker(ui64 /*inputId*/) override {
+        return nullptr;
+    }
+
     std::pair<IDqAsyncOutputBuffer::TPtr, IDqOutputConsumer::TPtr> GetOutputTransform(ui64 /*outputIndex*/) override {
         return {};
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
    channel1---> inputValue1-> transform-->helper-> inputValue3--> syncCA -> output
                 ^ ^ |  ^        ^         ^           ^ |         |^  ^^
    channel2-----/ / v  |        |         |           | v         v|  ||
    channel3------/  transformWT-+-out wm--/           caWT------->TR  ||
                                                        | ^\           ||
                                                        | | \---out wm-/|
                                                        v |             /
    input ------------------------------------------inputValue2--------/
```    
* Channels [1-3] are unregistered at main tracker and moved to separate transform watermark tracker
* When watermark received from channel[1-3], they go to transform watermark tracker,
* when resulting watermark generated by transformWT, inputValue returns yield, it goes into transform
* when transform processed all preceding input (this either happens immediately, if everything was served from LRU cache, or delayed until GenericLookup produces lookup result), transform->GetAsyncInputData produces watermark, it goes into inputValue3 and tracked in main/CA watermark tracker