### PR TITLE
Add lock statistics to KQP query metrics (#30268)

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -367,10 +367,8 @@ public:
     }
 
     void HandleFinalize(TEvKqpBuffer::TEvResult::TPtr& ev) {
-        if (ev->Get()->Stats) {
-            if (Stats) {
-                Stats->AddBufferStats(std::move(*ev->Get()->Stats));
-            }
+        if (ev->Get()->Stats && Stats) {
+            Stats->AddBufferStats(std::move(*ev->Get()->Stats));
         }
         MakeResponseAndPassAway();
     }

--- a/ydb/core/kqp/executer_actor/kqp_executer.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer.h
@@ -35,6 +35,8 @@ struct TEvKqpExecuter {
 
         ui64 ResultRowsCount = 0;
         ui64 ResultRowsBytes = 0;
+        ui64 LocksBrokenAsBreaker = 0;
+        ui64 LocksBrokenAsVictim = 0;
 
         THashSet<ui32> ParticipantNodes;
 

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -2188,6 +2188,9 @@ protected:
         Counters->Counters->QueryStatMemFinishInflightBytes->Sub(StatFinishInflightBytes);
         StatFinishInflightBytes = 0;
 
+        ResponseEv->LocksBrokenAsBreaker = Stats->LocksBrokenAsBreaker;
+        ResponseEv->LocksBrokenAsVictim = Stats->LocksBrokenAsVictim;
+
         Request.Transactions.crop(0);
         this->Send(Target, ResponseEv.release());
 

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -1,5 +1,6 @@
 #include "kqp_executer_stats.h"
 
+#include <ydb/core/protos/kqp_stats.pb.h>
 
 namespace NKikimr::NKqp {
 
@@ -1109,6 +1110,9 @@ void TQueryExecutionStats::AddComputeActorStats(ui32 /* nodeId */, NYql::NDqProt
 void TQueryExecutionStats::AddDatashardPrepareStats(NKikimrQueryStats::TTxStats&& txStats) {
 //    Cerr << (TStringBuilder() << "::AddDatashardPrepareStats " << txStats.DebugString() << Endl);
 
+    LocksBrokenAsBreaker += txStats.GetLocksBrokenAsBreaker();
+    LocksBrokenAsVictim += txStats.GetLocksBrokenAsVictim();
+
     ui64 cpuUs = txStats.GetComputeCpuTimeUsec();
     for (const auto& perShard : txStats.GetPerShardStats()) {
         AffectedShards.emplace(perShard.GetShardId());
@@ -1187,6 +1191,9 @@ void TQueryExecutionStats::AddDatashardStats(NYql::NDqProto::TDqComputeActorStat
 {
 //    Cerr << (TStringBuilder() << "::AddDatashardStats " << stats.DebugString() << ", " << txStats.DebugString() << Endl);
 
+    LocksBrokenAsBreaker += txStats.GetLocksBrokenAsBreaker();
+    LocksBrokenAsVictim += txStats.GetLocksBrokenAsVictim();
+
     ui64 datashardCpuTimeUs = 0;
     for (const auto& perShard : txStats.GetPerShardStats()) {
         AffectedShards.emplace(perShard.GetShardId());
@@ -1261,6 +1268,9 @@ void TQueryExecutionStats::AddDatashardStats(NYql::NDqProto::TDqComputeActorStat
 }
 
 void TQueryExecutionStats::AddDatashardStats(NKikimrQueryStats::TTxStats&& txStats) {
+    LocksBrokenAsBreaker += txStats.GetLocksBrokenAsBreaker();
+    LocksBrokenAsVictim += txStats.GetLocksBrokenAsVictim();
+
     ui64 datashardCpuTimeUs = 0;
     for (const auto& perShard : txStats.GetPerShardStats()) {
         AffectedShards.emplace(perShard.GetShardId());
@@ -1277,6 +1287,12 @@ void TQueryExecutionStats::AddDatashardStats(NKikimrQueryStats::TTxStats&& txSta
 }
 
 void TQueryExecutionStats::AddBufferStats(NYql::NDqProto::TDqTaskStats&& taskStats) {
+    NKqpProto::TKqpTaskExtraStats extraStats;
+    if (taskStats.GetExtra().UnpackTo(&extraStats)) {
+        LocksBrokenAsBreaker += extraStats.GetLockStats().GetBrokenAsBreaker();
+        LocksBrokenAsVictim += extraStats.GetLockStats().GetBrokenAsVictim();
+    }
+
     for (auto& table : taskStats.GetTables()) {
         NYql::NDqProto::TDqTableStats* tableAggr = nullptr;
         if (auto it = TableStats.find(table.GetTablePath()); it != TableStats.end()) {

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.h
@@ -363,6 +363,9 @@ public:
     void AddDatashardStats(NKikimrQueryStats::TTxStats&& txStats);
     void AddBufferStats(NYql::NDqProto::TDqTaskStats&& taskStats);
 
+    ui64 LocksBrokenAsBreaker = 0;
+    ui64 LocksBrokenAsVictim = 0;
+
     void UpdateTaskStats(ui64 taskId, const NYql::NDqProto::TDqComputeActorStats& stats, NYql::NDqProto::EComputeState state);
     void ExportExecStats(NYql::NDqProto::TDqExecutionStats& stats);
     void FillStageDurationUs(NYql::NDqProto::TDqStageStats& stats);

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -1463,6 +1463,17 @@ public:
             //tableStats->SetReadRows(tableStats->GetReadRows() + ReceivedRowCount);
             //tableStats->SetReadBytes(tableStats->GetReadBytes() + BytesStats.DataBytes);
             //tableStats->SetAffectedPartitions(tableStats->GetAffectedPartitions() + InFlightShards.Size());
+
+            // Add lock stats for broken locks from read operations
+            if (!BrokenLocks.empty()) {
+                NKqpProto::TKqpTaskExtraStats extraStats;
+                if (stats->HasExtra()) {
+                    stats->GetExtra().UnpackTo(&extraStats);
+                }
+                extraStats.MutableLockStats()->SetBrokenAsVictim(
+                    extraStats.GetLockStats().GetBrokenAsVictim() + BrokenLocks.size());
+                stats->MutableExtra()->PackFrom(extraStats);
+            }
         }
     }
 

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -112,6 +112,17 @@ public:
             }
 
             tableStats->MutableExtra()->PackFrom(tableExtraStats);
+
+            // Add lock stats for broken locks from stream lookup operations
+            if (!BrokenLocks.empty()) {
+                NKqpProto::TKqpTaskExtraStats extraStats;
+                if (stats->HasExtra()) {
+                    stats->GetExtra().UnpackTo(&extraStats);
+                }
+                extraStats.MutableLockStats()->SetBrokenAsVictim(
+                    extraStats.GetLockStats().GetBrokenAsVictim() + BrokenLocks.size());
+                stats->MutableExtra()->PackFrom(extraStats);
+            }
         }
     }
 

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -14,6 +14,7 @@
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/common/simple/kqp_event_ids.h>
 #include <ydb/core/protos/kqp_physical.pb.h>
+#include <ydb/core/protos/kqp_stats.pb.h>
 #include <ydb/core/protos/query_stats.pb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/tx/data_events/events.h>
@@ -173,8 +174,22 @@ struct TKqpTableWriterStatistics {
     ui64 WriteBytes = 0;
     ui64 EraseRows = 0;
     ui64 EraseBytes = 0;
+    ui64 LocksBrokenAsBreaker = 0;
+    ui64 LocksBrokenAsVictim = 0;
 
     THashSet<ui64> AffectedPartitions;
+
+    static void AddLockStats(NYql::NDqProto::TDqTaskStats* stats, ui64 brokenAsBreaker, ui64 brokenAsVictim) {
+        NKqpProto::TKqpTaskExtraStats extraStats;
+        if (stats->HasExtra()) {
+            stats->GetExtra().UnpackTo(&extraStats);
+        }
+        extraStats.MutableLockStats()->SetBrokenAsBreaker(
+            extraStats.GetLockStats().GetBrokenAsBreaker() + brokenAsBreaker);
+        extraStats.MutableLockStats()->SetBrokenAsVictim(
+            extraStats.GetLockStats().GetBrokenAsVictim() + brokenAsVictim);
+        stats->MutableExtra()->PackFrom(extraStats);
+    }
 };
 
 class TKqpTableWriteActor : public TActorBootstrapped<TKqpTableWriteActor> {
@@ -1274,9 +1289,16 @@ public:
         for (const auto& perShardStats : txStats.GetPerShardStats()) {
             Stats.AffectedPartitions.insert(perShardStats.GetShardId());
         }
+
+        Stats.LocksBrokenAsBreaker += txStats.GetLocksBrokenAsBreaker();
+        Stats.LocksBrokenAsVictim += txStats.GetLocksBrokenAsVictim();
     }
 
     void FillStats(NYql::NDqProto::TDqTaskStats* stats) {
+        TKqpTableWriterStatistics::AddLockStats(stats, Stats.LocksBrokenAsBreaker, Stats.LocksBrokenAsVictim);
+        Stats.LocksBrokenAsBreaker = 0;
+        Stats.LocksBrokenAsVictim = 0;
+
         if (Stats.ReadRows + Stats.WriteRows + Stats.EraseRows == 0) {
             // Avoid empty table_access stats
             return;
@@ -2817,6 +2839,11 @@ public:
                 return builder;
             }());
 
+        if (ev->Get()->Record.HasTxStats()) {
+            LocksBrokenAsBreaker += ev->Get()->Record.GetTxStats().GetLocksBrokenAsBreaker();
+            LocksBrokenAsVictim += ev->Get()->Record.GetTxStats().GetLocksBrokenAsVictim();
+        }
+
         OnCommitted(ev->Get()->Record.GetOrigin(), 0);
     }
 
@@ -2973,6 +3000,7 @@ public:
         for (const auto& [_, writeInfo] : WriteInfos) {
             writeInfo.WriteTableActor->FillStats(&result);
         }
+        TKqpTableWriterStatistics::AddLockStats(&result, LocksBrokenAsBreaker, LocksBrokenAsVictim);
         return result;
     }
 
@@ -3010,6 +3038,9 @@ private:
     bool IsImmediateCommit = false;
     bool TxPlanned = false;
     std::optional<ui64> Coordinator;
+
+    ui64 LocksBrokenAsBreaker = 0;
+    ui64 LocksBrokenAsVictim = 0;
 
     std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
 

--- a/ydb/core/kqp/session_actor/kqp_query_stats.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_stats.cpp
@@ -145,6 +145,11 @@ void CollectQueryStatsImpl(const TActorContext& ctx, const T* queryStats,
 
     stats.SetRequestUnits(requestUnits);
 
+    if constexpr (std::is_same_v<T, TKqpQueryStats>) {
+        stats.SetLocksBrokenAsBreaker(queryStats->LocksBrokenAsBreaker);
+        stats.SetLocksBrokenAsVictim(queryStats->LocksBrokenAsVictim);
+    }
+
     ctx.Send(NSysView::MakeSysViewServiceID(nodeId), std::move(collectEv));
 }
 

--- a/ydb/core/kqp/session_actor/kqp_query_stats.h
+++ b/ydb/core/kqp/session_actor/kqp_query_stats.h
@@ -15,6 +15,8 @@ struct TKqpQueryStats {
     ui64 ReadSetsCount = 0;
     ui64 MaxShardProgramSize = 0;
     ui64 MaxShardReplySize = 0;
+    ui64 LocksBrokenAsBreaker = 0;
+    ui64 LocksBrokenAsVictim = 0;
 
     TVector<NYql::NDqProto::TDqExecutionStats> Executions;
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1828,6 +1828,9 @@ public:
             QueryState->QueryStats.Executions.back().Swap(executerResults.MutableStats());
         }
 
+        QueryState->QueryStats.LocksBrokenAsBreaker += ev->LocksBrokenAsBreaker;
+        QueryState->QueryStats.LocksBrokenAsVictim += ev->LocksBrokenAsVictim;
+
         if (QueryState->TxCtx->TxManager) {
             QueryState->ParticipantNodes = QueryState->TxCtx->TxManager->GetParticipantNodes();
         } else {
@@ -2001,6 +2004,8 @@ public:
 
         stats->DurationUs = ((TInstant::Now() - QueryState->StartTime).MicroSeconds());
         stats->WorkerCpuTimeUs = (QueryState->GetCpuTime().MicroSeconds());
+        stats->LocksBrokenAsBreaker = QueryState->QueryStats.LocksBrokenAsBreaker;
+        stats->LocksBrokenAsVictim = QueryState->QueryStats.LocksBrokenAsVictim;
         if (const auto continueTime = QueryState->ContinueTime) {
             stats->QueuedTimeUs = (continueTime - QueryState->StartTime).MicroSeconds();
         }

--- a/ydb/core/protos/kqp_stats.proto
+++ b/ydb/core/protos/kqp_stats.proto
@@ -48,9 +48,15 @@ message TKqpScanTaskExtraStats {
     uint32 RetriesCount = 1;
 }
 
+message TKqpLockStats {
+    uint64 BrokenAsBreaker = 1;
+    uint64 BrokenAsVictim = 2;
+}
+
 // extra for NYql.NDqProto.TDqTaskStats
 message TKqpTaskExtraStats {
     TKqpScanTaskExtraStats ScanTaskExtraStats = 1;
+    TKqpLockStats LockStats = 2;
 }
 
 message TNodeExecutionStats {

--- a/ydb/core/protos/query_stats.proto
+++ b/ydb/core/protos/query_stats.proto
@@ -44,6 +44,8 @@ message TTxStats {
     optional uint64 DurationUs = 2;
     optional uint64 ComputeCpuTimeUsec = 3;
     repeated TPerShardStats PerShardStats = 4;
+    optional uint64 LocksBrokenAsBreaker = 5; // locks broken by this transaction
+    optional uint64 LocksBrokenAsVictim = 6;  // this transaction's locks were broken by others
 
     // TODO:
     // optional uint64 CommitLatencyUsec = 3;

--- a/ydb/core/protos/sys_view.proto
+++ b/ydb/core/protos/sys_view.proto
@@ -114,6 +114,8 @@ message TQueryStats {
     optional uint64 TotalCpuTimeUs = 15;
     optional string Type = 16;
     optional uint64 RequestUnits = 17;
+    optional uint64 LocksBrokenAsBreaker = 18;
+    optional uint64 LocksBrokenAsVictim = 19;
 }
 
 message TTopQueryStats {
@@ -402,6 +404,8 @@ message TQueryMetrics {
     optional TMetrics UpdateBytes = 8;
     optional TMetrics DeleteRows = 9;
     optional TMetrics RequestUnits = 10;
+    optional uint64 LocksBrokenAsBreaker = 11;
+    optional uint64 LocksBrokenAsVictim = 12;
 }
 
 // node -> sysview processor tablet

--- a/ydb/core/sys_view/common/schema.h
+++ b/ydb/core/sys_view/common/schema.h
@@ -424,6 +424,8 @@ struct Schema : NIceDb::Schema {
         struct MinRequestUnits: Column<26, NScheme::NTypeIds::Uint64> {};
         struct MaxRequestUnits: Column<27, NScheme::NTypeIds::Uint64> {};
         struct SumRequestUnits: Column<28, NScheme::NTypeIds::Uint64> {};
+        struct LocksBrokenAsBreaker: Column<29, NScheme::NTypeIds::Uint64> {};
+        struct LocksBrokenAsVictim: Column<30, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<IntervalEnd, Rank>;
         using TColumns = TableColumns<
@@ -438,7 +440,8 @@ struct Schema : NIceDb::Schema {
             SumUpdateRows, MinUpdateRows, MaxUpdateRows,
             SumUpdateBytes, MinUpdateBytes, MaxUpdateBytes,
             SumDeleteRows, MinDeleteRows, MaxDeleteRows,
-            SumRequestUnits, MinRequestUnits, MaxRequestUnits>;
+            SumRequestUnits, MinRequestUnits, MaxRequestUnits,
+            LocksBrokenAsBreaker, LocksBrokenAsVictim>;
     };
 
     struct PrimaryIndexStats : Table<10> {

--- a/ydb/core/sys_view/query_stats/query_metrics.cpp
+++ b/ydb/core/sys_view/query_stats/query_metrics.cpp
@@ -58,6 +58,13 @@ struct TQueryMetricsExtractorsMap :
         ADD_METRICS(DeleteRows, DeleteRows);
         ADD_METRICS(RequestUnits, RequestUnits);
 #undef ADD_METRICS
+
+        insert({S::LocksBrokenAsBreaker::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetMetrics().GetLocksBrokenAsBreaker());
+        }});
+        insert({S::LocksBrokenAsVictim::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetMetrics().GetLocksBrokenAsVictim());
+        }});
     }
 };
 

--- a/ydb/core/sys_view/service/query_interval.cpp
+++ b/ydb/core/sys_view/service/query_interval.cpp
@@ -33,6 +33,13 @@ static void Aggregate(NKikimrSysView::TQueryMetrics& metrics, TQueryStatsPtr sta
     Aggregate(*metrics.MutableUpdateRows(), dataStats.GetUpdateRows());
     Aggregate(*metrics.MutableUpdateBytes(), dataStats.GetUpdateBytes());
     Aggregate(*metrics.MutableDeleteRows(), dataStats.GetDeleteRows());
+
+    if (stats->HasLocksBrokenAsBreaker()) {
+        metrics.SetLocksBrokenAsBreaker(metrics.GetLocksBrokenAsBreaker() + stats->GetLocksBrokenAsBreaker());
+    }
+    if (stats->HasLocksBrokenAsVictim()) {
+        metrics.SetLocksBrokenAsVictim(metrics.GetLocksBrokenAsVictim() + stats->GetLocksBrokenAsVictim());
+    }
 }
 
 static void Aggregate(NKikimrSysView::TQueryMetrics::TMetrics& metrics,
@@ -56,6 +63,13 @@ void Aggregate(NKikimrSysView::TQueryMetrics& metrics,
     Aggregate(*metrics.MutableUpdateRows(), from.GetUpdateRows());
     Aggregate(*metrics.MutableUpdateBytes(), from.GetUpdateBytes());
     Aggregate(*metrics.MutableDeleteRows(), from.GetDeleteRows());
+
+    if (from.HasLocksBrokenAsBreaker()) {
+        metrics.SetLocksBrokenAsBreaker(metrics.GetLocksBrokenAsBreaker() + from.GetLocksBrokenAsBreaker());
+    }
+    if (from.HasLocksBrokenAsVictim()) {
+        metrics.SetLocksBrokenAsVictim(metrics.GetLocksBrokenAsVictim() + from.GetLocksBrokenAsVictim());
+    }
 }
 
 bool TQueryInterval::Empty() const {

--- a/ydb/core/sys_view/ut_common.cpp
+++ b/ydb/core/sys_view/ut_common.cpp
@@ -53,7 +53,11 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, const TTestEnvSettings& 
 
     NKikimrConfig::TAppConfig appConfig;
     *appConfig.MutableFeatureFlags() = Settings->FeatureFlags;
-    appConfig.MutableTableServiceConfig()->SetEnableTempTablesForUser(true);
+
+    auto& tableServiceConfig = *appConfig.MutableTableServiceConfig();
+    tableServiceConfig = settings.TableServiceConfig;
+    tableServiceConfig.SetEnableTempTablesForUser(true);
+
     Settings->SetAppConfig(appConfig);
 
     for (ui32 i : xrange(settings.StoragePools)) {

--- a/ydb/core/sys_view/ut_common.h
+++ b/ydb/core/sys_view/ut_common.h
@@ -22,6 +22,7 @@ struct TTestEnvSettings {
     bool EnableSVP = false;
     bool EnableForceFollowers = false;
     TMaybe<ui32> DataShardStatsReportIntervalSeconds;
+    NKikimrConfig::TTableServiceConfig TableServiceConfig;
 };
 
 class TTestEnv {

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -2322,6 +2322,134 @@ Y_UNIT_TEST_SUITE(SystemView) {
         ])", ysonString);
     }
 
+    Y_UNIT_TEST(QueryMetricsLocksBroken) {
+        TTestEnvSettings settings;
+        settings.EnableSVP = true;
+        settings.TableServiceConfig.SetEnableOltpSink(false);
+        TTestEnv env(1, 2, settings);
+        CreateTenant(env, "Tenant1", true);
+
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(env.GetEndpoint())
+            .SetDiscoveryMode(EDiscoveryMode::Off)
+            .SetDatabase("/Root/Tenant1");
+        auto driver = TDriver(driverConfig);
+
+        TTableClient client(driver);
+        auto session = client.CreateSession().GetValueSync().GetSession();
+        auto victimSession = client.CreateSession().GetValueSync().GetSession();
+
+        // Create table and insert initial data
+        NKqp::AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/Tenant1/TableLocks` (
+                Key Uint64,
+                Value String,
+                PRIMARY KEY (Key)
+            );
+        )").GetValueSync());
+
+        NKqp::AssertSuccessResult(session.ExecuteDataQuery(
+            "UPSERT INTO `/Root/Tenant1/TableLocks` (Key, Value) VALUES (1u, \"Initial\")",
+            TTxControl::BeginTx().CommitTx()
+        ).GetValueSync());
+
+        // Establish locks by reading in a transaction (victim)
+        std::optional<TTransaction> victimTx;
+        while (!victimTx) {
+            auto result = victimSession.ExecuteDataQuery(
+                "SELECT * FROM `/Root/Tenant1/TableLocks` WHERE Key = 1u /* victim-query */",
+                TTxControl::BeginTx()
+            ).ExtractValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == EStatus::SUCCESS, result.GetIssues().ToString());
+
+            TString yson = FormatResultSetYson(result.GetResultSet(0));
+            if (yson == "[]") {
+                continue;  // Data not visible yet, retry
+            }
+
+            victimTx = result.GetTransaction();
+            UNIT_ASSERT(victimTx);
+        }
+
+        // Breaker transaction: writes to key 1, breaking victim's read lock
+        NKqp::AssertSuccessResult(session.ExecuteDataQuery(
+            "UPSERT INTO `/Root/Tenant1/TableLocks` (Key, Value) VALUES (1u, \"BreakerValue\") /* lock-breaker */",
+            TTxControl::BeginTx().CommitTx()
+        ).GetValueSync());
+
+        // Victim tries to commit with write to the same key
+        // This triggers lock validation, which fails because the lock on key 1 was broken
+        auto commitResult = victimSession.ExecuteDataQuery(
+            "UPSERT INTO `/Root/Tenant1/TableLocks` (Key, Value) VALUES (1u, \"VictimValue\") /* victim-commit */",
+            TTxControl::Tx(*victimTx).CommitTx()
+        ).ExtractValueSync();
+
+        // Victim should be ABORTED because its locks were broken
+        UNIT_ASSERT_VALUES_EQUAL(commitResult.GetStatus(), EStatus::ABORTED);
+
+        // Wait for stats to be collected and check both LocksBrokenAsBreaker and LocksBrokenAsVictim
+        ui64 locksBrokenAsBreaker = 0;
+        ui64 locksBrokenAsVictim = 0;
+        bool foundBreaker = false;
+        bool foundVictim = false;
+
+        for (size_t iter = 0; iter < 30 && (!foundBreaker || !foundVictim); ++iter) {
+            // Query both breaker and victim metrics in one pass
+            auto it = client.StreamExecuteScanQuery(R"(
+                SELECT QueryText, LocksBrokenAsBreaker, LocksBrokenAsVictim
+                FROM `/Root/Tenant1/.sys/query_metrics_one_minute`
+                WHERE QueryText LIKE '%lock-breaker%' OR QueryText LIKE '%victim-commit%';
+            )").GetValueSync();
+
+            UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
+            TString ysonString = NKqp::StreamResultToYson(it);
+            Cerr << "Query metrics result: " << ysonString << Endl;
+
+            auto node = NYT::NodeFromYsonString(ysonString, ::NYson::EYsonType::Node);
+            UNIT_ASSERT(node.IsList());
+
+            for (const auto& row : node.AsList()) {
+                if (!row.IsList() || row.AsList().size() < 3) continue;
+
+                auto getStringValue = [](const NYT::TNode& n) -> TString {
+                    if (n.IsList() && !n.AsList().empty()) {
+                        return n.AsList()[0].AsString();
+                    }
+                    return n.AsString();
+                };
+                auto getUint64Value = [](const NYT::TNode& n) -> ui64 {
+                    if (n.IsList() && !n.AsList().empty()) {
+                        return n.AsList()[0].AsUint64();
+                    }
+                    return n.AsUint64();
+                };
+
+                TString queryText = getStringValue(row.AsList()[0]);
+                ui64 breaker = getUint64Value(row.AsList()[1]);
+                ui64 victim = getUint64Value(row.AsList()[2]);
+
+                if (queryText.Contains("lock-breaker") && !queryText.Contains("query_metrics")) {
+                    locksBrokenAsBreaker = breaker;
+                    foundBreaker = true;
+                }
+                if (queryText.Contains("victim-commit") && !queryText.Contains("query_metrics")) {
+                    locksBrokenAsVictim = victim;
+                    foundVictim = true;
+                }
+            }
+
+            if (!foundBreaker || !foundVictim) {
+                Sleep(TDuration::Seconds(5));
+            }
+        }
+
+        UNIT_ASSERT_C(foundBreaker, "Breaker not found in metrics");
+        UNIT_ASSERT_C(foundVictim, "Victim not found in metrics");
+
+        UNIT_ASSERT_VALUES_EQUAL(locksBrokenAsBreaker, 1u);
+        UNIT_ASSERT_VALUES_EQUAL(locksBrokenAsVictim, 1u);
+    }
+
     Y_UNIT_TEST(AuthUsers) {
         TTestEnv env;
         SetupAuthEnvironment(env);

--- a/ydb/core/tx/datashard/datashard_ut_order.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_order.cpp
@@ -2,6 +2,7 @@
 #include "datashard_ut_common_kqp.h"
 #include "datashard_active_transaction.h"
 
+#include <ydb/core/protos/query_stats.pb.h>
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/base/tablet_resolver.h>
 #include <ydb/core/base/blobstorage_common.h>
@@ -4392,6 +4393,73 @@ Y_UNIT_TEST(UncommittedReads) {
             "{ items { uint32_value: 3 } items { uint32_value: 3 } }, "
             "{ items { uint32_value: 4 } items { uint32_value: 4 } }");
     }
+}
+
+Y_UNIT_TEST(LocksBrokenStats) {
+    NKikimrConfig::TAppConfig app;
+    app.MutableTableServiceConfig()->SetEnableOltpSink(false);
+    TPortManager pm;
+    TServerSettings serverSettings(pm.GetPort(2134));
+    serverSettings.SetDomainName("Root")
+        .SetUseRealThreads(false)
+        .SetAppConfig(app);
+
+    Tests::TServer::TPtr server = new TServer(serverSettings);
+    auto &runtime = *server->GetRuntime();
+    auto sender = runtime.AllocateEdgeActor();
+
+    runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+    InitRoot(server, sender);
+
+    TShardedTableOptions opts;
+    auto [shards, tableId] = CreateShardedTable(server, sender, "/Root", "table-1", opts);
+    const ui64 shard = shards[0];
+
+    // Insert initial data
+    ExecSQL(server, sender, Q_("UPSERT INTO `/Root/table-1` (key, value) VALUES (1, 100);"));
+
+    // Start a KQP transaction with a read (this establishes locks via KQP)
+    TString sessionId, txId;
+    KqpSimpleBegin(runtime, sessionId, txId, Q_("SELECT * FROM `/Root/table-1` WHERE key = 1;"));
+    UNIT_ASSERT(!txId.empty());
+
+    // Set up typed observer to capture TEvProposeTransactionResult
+    // We need to copy the record data since the event pointer may become invalid
+    TMaybe<NKikimrTxDataShard::TEvProposeTransactionResult> breakerRecord;
+    TMaybe<NKikimrTxDataShard::TEvProposeTransactionResult> victimRecord;
+    auto observer = runtime.AddObserver<TEvDataShard::TEvProposeTransactionResult>([&](TEvDataShard::TEvProposeTransactionResult::TPtr& ev) {
+        auto* result = ev->Get();
+        if (result && result->GetTxKind() == NKikimrTxDataShard::TX_KIND_DATA &&
+            result->GetOrigin() == shard) {
+            if (result->Record.GetStatus() == NKikimrTxDataShard::TEvProposeTransactionResult::COMPLETE) {
+                breakerRecord = result->Record;
+            } else if (result->Record.GetStatus() == NKikimrTxDataShard::TEvProposeTransactionResult::LOCKS_BROKEN) {
+                victimRecord = result->Record;
+            }
+        }
+    });
+
+    // Execute SQL using KqpSimpleExec - this will commit immediately and break the locks
+    // The observer will capture TEvProposeTransactionResult during execution
+    KqpSimpleExec(runtime, Q_("UPSERT INTO `/Root/table-1` (key, value) VALUES (1, 200);"));
+
+    // Verify we captured a COMPLETE result with LocksBrokenAsBreaker set
+    UNIT_ASSERT(breakerRecord.Defined());
+    UNIT_ASSERT_VALUES_EQUAL(breakerRecord->GetStatus(), NKikimrTxDataShard::TEvProposeTransactionResult::COMPLETE);
+    UNIT_ASSERT(breakerRecord->HasTxStats());
+    UNIT_ASSERT_VALUES_EQUAL(breakerRecord->GetTxStats().GetLocksBrokenAsBreaker(), 1u);
+
+    // Now try to commit the victim transaction - it should fail with ABORTED (LOCKS_BROKEN at datashard level)
+    auto commitResult = KqpSimpleCommit(runtime, sessionId, txId, Q_("UPSERT INTO `/Root/table-1` (key, value) VALUES (1, 300);"));
+    UNIT_ASSERT_VALUES_EQUAL(commitResult, "ERROR: ABORTED");
+
+    // Verify we captured a LOCKS_BROKEN result
+    UNIT_ASSERT(victimRecord.Defined());
+    UNIT_ASSERT_VALUES_EQUAL(victimRecord->GetStatus(), NKikimrTxDataShard::TEvProposeTransactionResult::LOCKS_BROKEN);
+
+    auto tableState = ReadTable(server, shards, tableId);
+    UNIT_ASSERT(tableState.find("key = 1, value = 200") != TString::npos);
 }
 
 } // Y_UNIT_TEST_SUITE(DataShardOutOfOrder)

--- a/ydb/core/tx/datashard/execute_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_data_tx_unit.cpp
@@ -1,3 +1,5 @@
+#include "datashard_impl.h"
+#include "datashard_integrity_trails.h"
 #include "datashard_kqp.h"
 #include "execution_unit_ctors.h"
 #include "setup_sys_locks.h"
@@ -153,6 +155,7 @@ EExecutionStatus TExecuteDataTxUnit::Execute(TOperation::TPtr op,
                     // Lock cannot be created and we must abort
                     op->SetAbortedFlag();
                     BuildResult(op, NKikimrTxDataShard::TEvProposeTransactionResult::LOCKS_BROKEN);
+                    op->Result()->Record.MutableTxStats()->SetLocksBrokenAsVictim(1);
                     return EExecutionStatus::Executed;
             }
         }
@@ -345,7 +348,10 @@ void TExecuteDataTxUnit::ExecuteDataTx(TOperation::TPtr op,
 }
 
 void TExecuteDataTxUnit::AddLocksToResult(TOperation::TPtr op, const TActorContext& ctx) {
-    auto [locks, _] = DataShard.SysLocksTable().ApplyLocks();
+    auto [locks, locksBrokenByTx] = DataShard.SysLocksTable().ApplyLocks();
+    op->Result()->Record.MutableTxStats()->SetLocksBrokenAsBreaker(locksBrokenByTx.size());
+    NDataIntegrity::LogIntegrityTrailsLocks(ctx, DataShard.TabletID(), op->GetTxId(), locksBrokenByTx);
+
     for (const auto& lock : locks) {
         if (lock.IsError()) {
             LOG_NOTICE_S(TActivationContext::AsActorContext(), NKikimrServices::TX_DATASHARD,

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -43,6 +43,7 @@ public:
         NEvents::TDataEvents::TEvWriteResult& writeResult = *writeOp->GetWriteResult();
 
         auto [locks, locksBrokenByTx] = DataShard.SysLocksTable().ApplyLocks();
+        writeResult.Record.MutableTxStats()->SetLocksBrokenAsBreaker(locksBrokenByTx.size());
         NDataIntegrity::LogIntegrityTrailsLocks(ctx, DataShard.TabletID(), writeOp->GetTxId(), locksBrokenByTx);
         LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "add locks to result: " << locks.size());
         for (const auto& lock : locks) {
@@ -116,11 +117,11 @@ public:
                 key.emplace_back(cell.Data(), cell.Size(), vtypeId);
             }
         }
-    };    
+    };
 
     EExecutionStatus OnTabletNotReadyException(TDataShardUserDb& userDb, TWriteOperation& writeOp, size_t operationIndexToPrecharge, TTransactionContext& txc, const TActorContext& ctx) {
         LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Tablet " << DataShard.TabletID() << " is not ready for " << writeOp << " execution");
-        
+
         // Precharge
         if (operationIndexToPrecharge != SIZE_MAX) {
             const TValidatedWriteTx::TPtr& writeTx = writeOp.GetWriteTx();
@@ -164,6 +165,7 @@ public:
         if (userDb.GetSnapshotReadConflict()) {
             LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with another transaction.");
             writeOp.SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Read conflict with concurrent transaction.");
+            writeOp.GetWriteResult()->Record.MutableTxStats()->SetLocksBrokenAsVictim(1);
             ResetChanges(userDb, writeOp, txc);
             return EExecutionStatus::Executed;
         }
@@ -236,7 +238,7 @@ public:
             case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT:
             case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_REPLACE:
             case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT:
-            case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPDATE: 
+            case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPDATE:
             case NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INCREMENT: {
                 DataShard.IncCounter(COUNTER_WRITE_ROWS, matrix.GetRowCount());
                 DataShard.IncCounter(COUNTER_WRITE_BYTES, matrix.GetBuffer().size());
@@ -353,6 +355,7 @@ public:
                 auto abortLock = [&]() {
                     LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << *op << " at " << tabletId << " aborting because it cannot acquire locks");
                     writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Operation is aborting because it cannot acquire locks");
+                    writeOp->GetWriteResult()->Record.MutableTxStats()->SetLocksBrokenAsVictim(1);
                     return EExecutionStatus::Executed;
                 };
 
@@ -402,6 +405,7 @@ public:
             if (!validated) {
                 LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << *op << " at " << tabletId << " aborting because locks are not valid");
                 writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Operation is aborting because locks are not valid");
+                writeOp->GetWriteResult()->Record.MutableTxStats()->SetLocksBrokenAsVictim(brokenLocks.size());
 
                 for (auto& brokenLock : brokenLocks) {
                     writeOp->GetWriteResult()->Record.MutableTxLocks()->Add()->Swap(&brokenLock);
@@ -409,6 +413,7 @@ public:
 
                 KqpEraseLocks(tabletId, kqpLocks, sysLocks);
                 auto [_, locksBrokenByTx] = sysLocks.ApplyLocks();
+                writeOp->GetWriteResult()->Record.MutableTxStats()->SetLocksBrokenAsBreaker(locksBrokenByTx.size());
                 NDataIntegrity::LogIntegrityTrailsLocks(ctx, tabletId, txId, locksBrokenByTx);
                 DataShard.SubscribeNewLocks(ctx);
                 if (locksDb.HasChanges()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Expose `LocksBrokenAsBreaker` and `LocksBrokenAsVictim` statistics in
`.sys/query_metrics_one_minute` system view.

- `LocksBrokenAsBreaker`: Number of locks broken by this transaction.

- `LocksBrokenAsVictim`: Number of times this transaction's locks were
  broken by others. 

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
