### PR TITLE
Fix excessive usage in ByteSizeLong while creating serialization info

### DIFF
--- a/ydb/core/actorlib_impl/test_interconnect_ut.cpp
+++ b/ydb/core/actorlib_impl/test_interconnect_ut.cpp
@@ -110,7 +110,7 @@ Y_UNIT_TEST_SUITE(TInterconnectTest) {
     TAutoPtr<IEventHandle> GetSerialized(const TAutoPtr<IEventHandle>& ev) {
         NActors::TAllocChunkSerializer chunker;
         ev->GetBase()->SerializeToArcadiaStream(&chunker);
-        auto Data = chunker.Release(ev->GetBase()->CreateSerializationInfo());
+        auto Data = chunker.Release(ev->GetBase()->CreateSerializationInfo(false));
         TAutoPtr<IEventHandle> serev =
             new IEventHandle(ev->GetBase()->Type(), ev->Flags,
                              ev->Recipient, ev->Sender,

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
@@ -65,7 +65,7 @@ class TDataWriterActor : public TActorBootstrapped<TDataWriterActor> {
             TEvBlobStorage::TEvVBlock logCmd(tabletId, Generation, TestCtx->SelfVDiskId, TInstant::Max());
             TAllocChunkSerializer serializer;
             logCmd.SerializeToArcadiaStream(&serializer);
-            TIntrusivePtr<TEventSerializedData> buffers = serializer.Release(logCmd.CreateSerializationInfo());
+            TIntrusivePtr<TEventSerializedData> buffers = serializer.Release(logCmd.CreateSerializationInfo(false));
             ctx.Send(TestCtx->LoggerId,
                      new NPDisk::TEvLog(TestCtx->PDiskCtx->Dsk->Owner, TestCtx->PDiskCtx->Dsk->OwnerRound,
                                         TLogSignature::SignatureBlock, TRcBuf(buffers->GetString()), seg, nullptr));

--- a/ydb/core/kqp/common/events/query.h
+++ b/ydb/core/kqp/common/events/query.h
@@ -93,7 +93,7 @@ public:
         return true;
     }
 
-    TEventSerializationInfo CreateSerializationInfo() const override { return {}; }
+    TEventSerializationInfo CreateSerializationInfo(bool /*allowExternalDataChannel*/) const override { return {}; }
 
     const TString& GetDatabase() const {
         return RequestCtx ? Database : Record.GetRequest().GetDatabase();

--- a/ydb/core/tablet/tablet_pipe_client.cpp
+++ b/ydb/core/tablet/tablet_pipe_client.cpp
@@ -627,7 +627,7 @@ namespace NTabletPipe {
                     Y_ABORT_UNLESS(Event, "Sending an empty event without a buffer");
                     TAllocChunkSerializer serializer;
                     Event->SerializeToArcadiaStream(&serializer);
-                    Buffer = serializer.Release(Event->CreateSerializationInfo());
+                    Buffer = serializer.Release(Event->CreateSerializationInfo(false));
                 }
 
                 auto msg = MakeHolder<TEvTabletPipe::TEvPush>(tabletId, Type, Sender, Buffer, cookie,

--- a/ydb/core/testlib/fake_coordinator.h
+++ b/ydb/core/testlib/fake_coordinator.h
@@ -217,7 +217,7 @@ namespace NKikimr {
                     ev->SerializeToArcadiaStream(&serializer);
                     Cerr << "FAKE_COORDINATOR:  Send Plan to tablet " << tabletId << " for txId: " << ev->Record.GetTransactions(0).GetTxId() << " at step: " << step << "\n";
 
-                    Pipes->Send(ctx, tabletId, ev->EventType, serializer.Release(ev->CreateSerializationInfo()));
+                    Pipes->Send(ctx, tabletId, ev->EventType, serializer.Release(ev->CreateSerializationInfo(false)));
                 }
             }
         }

--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -431,7 +431,7 @@ TString TWriteOperation::GetTxBody() const {
     TAllocChunkSerializer serializer;
     bool success = WriteRequest->SerializeToArcadiaStream(&serializer);
     Y_ENSURE(success);
-    TEventSerializationInfo serializationInfo = WriteRequest->CreateSerializationInfo();
+    TEventSerializationInfo serializationInfo = WriteRequest->CreateSerializationInfo(false);
 
     NKikimrTxDataShard::TSerializedEvent proto;
     proto.SetIsExtendedFormat(serializationInfo.IsExtendedFormat);

--- a/ydb/core/tx/mediator/tablet_queue.cpp
+++ b/ydb/core/tx/mediator/tablet_queue.cpp
@@ -162,7 +162,7 @@ class TTxMediatorTabletQueue : public TActor<TTxMediatorTabletQueue> {
             TAllocChunkSerializer serializer;
             const bool success = evx.SerializeToArcadiaStream(&serializer);
             Y_ABORT_UNLESS(success);
-            TIntrusivePtr<TEventSerializedData> data = serializer.Release(evx.CreateSerializationInfo());
+            TIntrusivePtr<TEventSerializedData> data = serializer.Release(evx.CreateSerializationInfo(false));
 
             // todo: we must throttle delivery
             const ui32 sendFlags = IEventHandle::FlagTrackDelivery;
@@ -385,7 +385,7 @@ class TTxMediatorTabletQueue : public TActor<TTxMediatorTabletQueue> {
         TAllocChunkSerializer serializer;
         const bool success = evx.SerializeToArcadiaStream(&serializer);
         Y_ABORT_UNLESS(success);
-        TIntrusivePtr<TEventSerializedData> data = serializer.Release(evx.CreateSerializationInfo());
+        TIntrusivePtr<TEventSerializedData> data = serializer.Release(evx.CreateSerializationInfo(false));
 
         LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TABLETQUEUE, "Actor# " << ctx.SelfID.ToString()
             << " Mediator# " << Mediator << " SEND to# " << source.ToString() << " " << evx.ToString());

--- a/ydb/core/tx/scheme_board/helpers.cpp
+++ b/ydb/core/tx/scheme_board/helpers.cpp
@@ -124,7 +124,7 @@ TSet<ui64> GetAbandonedSchemeShardIds(const NKikimrSchemeBoard::TEvNotify& recor
 TIntrusivePtr<TEventSerializedData> SerializeEvent(IEventBase* ev) {
     TAllocChunkSerializer serializer;
     Y_ABORT_UNLESS(ev->SerializeToArcadiaStream(&serializer));
-    return serializer.Release(ev->CreateSerializationInfo());
+    return serializer.Release(ev->CreateSerializationInfo(false));
 }
 
 void MultiSend(const TVector<const TActorId*>& recipients, const TActorId& sender, TAutoPtr<IEventBase> ev, ui32 flags, ui64 cookie) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -684,7 +684,7 @@ void TSideEffects::DoBindMsg(TSchemeShard *ss, const TActorContext &ctx) {
         TAllocChunkSerializer serializer;
         const bool success = message->SerializeToArcadiaStream(&serializer);
         Y_ABORT_UNLESS(success);
-        TIntrusivePtr<TEventSerializedData> data = serializer.Release(message->CreateSerializationInfo());
+        TIntrusivePtr<TEventSerializedData> data = serializer.Release(message->CreateSerializationInfo(false));
         operation->PipeBindedMessages[tablet][cookie] = TOperation::TPreSerializedMessage(msgType, data, opId);
 
         ss->PipeClientCache->Send(ctx, ui64(tablet), msgType,  data, cookie.second);

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -494,7 +494,7 @@ private:
         TAllocChunkSerializer serializer;
         const bool success = message->SerializeToArcadiaStream(&serializer);
         Y_ABORT_UNLESS(success);
-        TIntrusivePtr<TEventSerializedData> data = serializer.Release(message->CreateSerializationInfo());
+        TIntrusivePtr<TEventSerializedData> data = serializer.Release(message->CreateSerializationInfo(false));
         return TPreSerializedMessage(message->Type(), data);
     }
 

--- a/ydb/library/actors/core/event.cpp
+++ b/ydb/library/actors/core/event.cpp
@@ -33,7 +33,7 @@ namespace NActors {
         if (Event) {
             TAllocChunkSerializer serializer;
             Event->SerializeToArcadiaStream(&serializer);
-            auto chainBuf = serializer.Release(Event->CreateSerializationInfo());
+            auto chainBuf = serializer.Release(Event->CreateSerializationInfo(false));
             Event.Reset();
             return chainBuf;
         }
@@ -47,7 +47,7 @@ namespace NActors {
         if (Event) {
             TAllocChunkSerializer serializer;
             Event->SerializeToArcadiaStream(&serializer);
-            Buffer = serializer.Release(Event->CreateSerializationInfo());
+            Buffer = serializer.Release(Event->CreateSerializationInfo(false));
             return Buffer;
         }
         return new TEventSerializedData;

--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -44,7 +44,7 @@ namespace NActors {
         virtual ui32 CalculateSerializedSizeCached() const {
             return CalculateSerializedSize();
         }
-        virtual TEventSerializationInfo CreateSerializationInfo() const { return {}; }
+        virtual TEventSerializationInfo CreateSerializationInfo(bool /*allowExternalDataChannel*/) const { return {}; }
     };
 
     template <typename TEventType>

--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -248,8 +248,10 @@ namespace NActors {
             CachedByteSize = 0;
         }
 
-        TEventSerializationInfo CreateSerializationInfo() const override {
-            return CreateSerializationInfoImpl(0, static_cast<const TEv&>(*this).AllowExternalDataChannel(), GetPayload(), Record.ByteSize());
+        TEventSerializationInfo CreateSerializationInfo(bool allowExternalDataChannel) const override {
+            allowExternalDataChannel = allowExternalDataChannel && static_cast<const TEv&>(*this).AllowExternalDataChannel();
+            return CreateSerializationInfoImpl(0, allowExternalDataChannel, GetPayload(),
+                allowExternalDataChannel ? Record.ByteSize() : 0);
         }
 
         bool AllowExternalDataChannel() const {
@@ -437,8 +439,10 @@ namespace NActors {
             return GetCachedByteSize();
         }
 
-        TEventSerializationInfo CreateSerializationInfo() const override {
-            return CreateSerializationInfoImpl(PreSerializedData.size(), static_cast<const TEv&>(*this).AllowExternalDataChannel(), TBase::GetPayload(), Record.ByteSize());
+        TEventSerializationInfo CreateSerializationInfo(bool allowExternalDataChannel) const override {
+            allowExternalDataChannel = allowExternalDataChannel && static_cast<const TEv&>(*this).AllowExternalDataChannel();
+            return CreateSerializationInfoImpl(PreSerializedData.size(), allowExternalDataChannel, TBase::GetPayload(),
+                allowExternalDataChannel ? Record.ByteSize() : 0);
         }
     };
 

--- a/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
+++ b/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
@@ -50,7 +50,7 @@ Y_UNIT_TEST_SUITE(TEventProtoWithPayload) {
 
         auto serializer = MakeHolder<TAllocChunkSerializer>();
         msg.SerializeToArcadiaStream(serializer.Get());
-        auto buffers = serializer->Release(msg.CreateSerializationInfo());
+        auto buffers = serializer->Release(msg.CreateSerializationInfo(false));
         UNIT_ASSERT_VALUES_EQUAL(buffers->GetSize(), msg.CalculateSerializedSize());
         TString ser = buffers->GetString();
 
@@ -128,14 +128,14 @@ Y_UNIT_TEST_SUITE(TEventProtoWithPayload) {
 
         auto serializer1 = MakeHolder<TAllocChunkSerializer>();
         e1.SerializeToArcadiaStream(serializer1.Get());
-        auto buffers1 = serializer1->Release(e1.CreateSerializationInfo());
+        auto buffers1 = serializer1->Release(e1.CreateSerializationInfo(false));
         UNIT_ASSERT_VALUES_EQUAL(buffers1->GetSize(), e1.CalculateSerializedSize());
         TString ser1 = buffers1->GetString();
 
         TEvMessageWithPayload e2(msg);
         auto serializer2 = MakeHolder<TAllocChunkSerializer>();
         e2.SerializeToArcadiaStream(serializer2.Get());
-        auto buffers2 = serializer2->Release(e2.CreateSerializationInfo());
+        auto buffers2 = serializer2->Release(e2.CreateSerializationInfo(false));
         UNIT_ASSERT_VALUES_EQUAL(buffers2->GetSize(), e2.CalculateSerializedSize());
         TString ser2 = buffers2->GetString();
         UNIT_ASSERT_VALUES_EQUAL(ser1, ser2);

--- a/ydb/library/actors/core/ut/mon_ut.cpp
+++ b/ydb/library/actors/core/ut/mon_ut.cpp
@@ -18,7 +18,7 @@ Y_UNIT_TEST_SUITE(ActorSystemMon) {
         TAllocChunkSerializer ser;
         const bool success = ev->SerializeToArcadiaStream(&ser);
         Y_ABORT_UNLESS(success);
-        auto buffer = ser.Release(ev->CreateSerializationInfo());
+        auto buffer = ser.Release(ev->CreateSerializationInfo(false));
         std::unique_ptr<TEvRemoteHttpInfo> restored(TEvRemoteHttpInfo::Load(buffer.Get()));
         UNIT_ASSERT(restored->Query == ev->Query);
         UNIT_ASSERT(restored->Query.size());

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -91,7 +91,7 @@ namespace NActors {
                         if (event.EventSerializedSize) {
                             Chunker.SetSerializingEvent(base);
                         }
-                        SerializationInfoContainer = base->CreateSerializationInfo();
+                        SerializationInfoContainer = base->CreateSerializationInfo(Params.UseExternalDataChannel);
                         SerializationInfo = &SerializationInfoContainer;
                         SectionIndex = 0;
                         PartLenRemain = 0;
@@ -334,7 +334,7 @@ namespace NActors {
                 return false; // serialization failed
             }
             event.Buffer = MakeIntrusive<TEventSerializedData>(
-                std::move(*rope), event.Event->CreateSerializationInfo()
+                std::move(*rope), event.Event->CreateSerializationInfo(Params.UseExternalDataChannel)
             );
             Iter = event.Buffer->GetBeginIter();
         }

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -284,7 +284,7 @@ TEST_F(XdcRdmaTest, SerializeToRope) {
         }
     }
 
-    auto serializationInfo = ev->CreateSerializationInfo();
+    auto serializationInfo = ev->CreateSerializationInfo(false);
     auto parsedEventHandle = std::make_unique<IEventHandle>(
         TActorId(),
         ev->Type(),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix excessive usage in ByteSizeLong while creating serialization info

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes excessive call of heavy ByteSizeLong with result dropped.
