### PR TITLE
ydb/core/kqp/ut/federated_query/common: add missing peerdir

### DIFF
--- a/ydb/core/kqp/ut/federated_query/common/ya.make
+++ b/ydb/core/kqp/ut/federated_query/common/ya.make
@@ -9,6 +9,7 @@ STYLE_CPP()
 PEERDIR(
     ydb/core/kqp/rm_service
     ydb/core/kqp/ut/common
+    ydb/library/yql/providers/generic/connector/libcpp/ut_helpers
     ydb/library/yql/providers/s3/actors_factory
     ydb/public/sdk/cpp/src/client/operation
     ydb/public/sdk/cpp/src/client/query


### PR DESCRIPTION
in ydb/core/kqp/ut/federated_query/common/common.h CreateCredentialsFactory has default value, NYql::NConnector::NTest::DEFAULT_PASSWORD ; it is defined in ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/defaults.cpp

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Problem is not triggered in main (there are implicit dependency in callers), only by some partial backports