### PR TITLE
Ya make report: fix flake8 errors + Not_Launched badge

### DIFF
--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -107,11 +107,12 @@ def parse_build_results_report(test_results_file, build_type, job_name, job_id, 
         duration = result.get("duration", 0)
         
         # Determine status
+        # Status normalization (OK->PASSED, NOT_LAUNCHED->SKIPPED, mute->MUTE) is done by transform_build_results.py
         status_str = result.get("status", "OK")
         error_type = result.get("error_type", "")
         status_description = result.get("rich-snippet", "")  # Already cleaned by transform_build_results.py
         
-        if result.get("muted", False):
+        if status_str == "MUTE":
             status = "mute"
         elif status_str == "FAILED":
             status = "failure"

--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -84,7 +84,7 @@ def parse_build_results_report(test_results_file, build_type, job_name, job_id, 
 
     results = []
     for result in report.get("results", []):
-        # Filtering (suite, build, import/configure) is done by transform_build_results.py
+        # Filtering (suite, build, configure) is done by transform_build_results.py
         status = result.get("status")
         if not status:
             continue

--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -84,7 +84,9 @@ def parse_build_results_report(test_results_file, build_type, job_name, job_id, 
 
     results = []
     for result in report.get("results", []):
-        if result.get("type") != "test":
+        # Filtering (suite, build, import/configure) is done by transform_build_results.py
+        status = result.get("status")
+        if not status:
             continue
         
         suite_folder = result.get("path", "")

--- a/.github/scripts/tests/fail-checker.py
+++ b/.github/scripts/tests/fail-checker.py
@@ -25,11 +25,6 @@ def check_for_fail(paths: List[str], output_path: str):
                 if not status:
                     continue
                 
-                # Skip suite-level entries (they are aggregates, not individual tests)
-                if result.get("suite") is True:
-                    continue
-                
-                status = result.get("status", "")
                 error_type = result.get("error_type", "")
                 path_str = result.get("path", "")
                 name = result.get("name", "")

--- a/.github/scripts/tests/fail-checker.py
+++ b/.github/scripts/tests/fail-checker.py
@@ -20,7 +20,7 @@ def check_for_fail(paths: List[str], output_path: str):
                 report = json.load(f)
             
             for result in report.get("results", []):
-                # Filtering (suite, build, import/configure) is done by transform_build_results.py
+                # Filtering (suite, build, configure) is done by transform_build_results.py
                 status = result.get("status")
                 if not status:
                     continue

--- a/.github/scripts/tests/fail-checker.py
+++ b/.github/scripts/tests/fail-checker.py
@@ -20,7 +20,9 @@ def check_for_fail(paths: List[str], output_path: str):
                 report = json.load(f)
             
             for result in report.get("results", []):
-                if result.get("type") != "test":
+                # Filtering (suite, build, import/configure) is done by transform_build_results.py
+                status = result.get("status")
+                if not status:
                     continue
                 
                 # Skip suite-level entries (they are aggregates, not individual tests)

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -202,7 +202,8 @@ class TestResult:
             error_type=error_type or '',
             is_sanitizer_issue=is_sanitizer_issue(status_description or ''),
             is_timeout_issue=(error_type or '').upper() == 'TIMEOUT',
-            is_not_launched=(error_type or '').upper() == 'NOT_LAUNCHED' and status == TestStatus.SKIP
+            # NOT_LAUNCHED can be in SKIPPED or MUTE status (if muted after being NOT_LAUNCHED)
+            is_not_launched=(error_type or '').upper() == 'NOT_LAUNCHED' and status in (TestStatus.SKIP, TestStatus.MUTE)
         )
 
 

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -489,11 +489,13 @@ def iter_build_results_files(path):
                 report = json.load(f)
             
             for result in report.get("results") or []:
-                if result.get("type") == "test":
-                    # Skip suite-level entries (they are aggregates, not individual tests)
-                    if result.get("suite") is True:
-                        continue
-                    yield fn, result
+                # Only include results that have a status field (indicates it's a test/check)
+                # Filtering (suite, build, import/configure) is done by transform_build_results.py
+                status = result.get("status")
+                if not status:
+                    continue
+                
+                yield fn, result
         except (json.JSONDecodeError, KeyError) as e:
             print(f"Warning: Unable to parse {fn}: {e}", file=sys.stderr)
             continue

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -490,7 +490,7 @@ def iter_build_results_files(path):
             
             for result in report.get("results") or []:
                 # Only include results that have a status field (indicates it's a test/check)
-                # Filtering (suite, build, import/configure) is done by transform_build_results.py
+                # Filtering (suite, build, configure) is done by transform_build_results.py
                 status = result.get("status")
                 if not status:
                     continue

--- a/.github/scripts/tests/transform_build_results.py
+++ b/.github/scripts/tests/transform_build_results.py
@@ -205,8 +205,8 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
         if result_type == "build":
             continue  # Skip build results completely
         
-        # For import, configure types: include only non-passing results
-        if result_type in ("import", "configure"):
+        # For configure type: include only non-passing results
+        if result_type == "configure":
             if status.upper() == "OK":
                 continue  # Skip this result - don't add to suites or filtered_results
         

--- a/.github/scripts/tests/transform_build_results.py
+++ b/.github/scripts/tests/transform_build_results.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import sys
+import time
 import urllib.parse
 import zipfile
 from typing import Set
@@ -184,11 +185,23 @@ def mute_test_result(result):
 
 def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, log_out_dir, log_truncate_size,
               test_stuff_out, test_stuff_prefix, test_dir):
+    start_time = time.time()
+    
+    # Load JSON report
+    load_start = time.time()
     with open(report_file, 'r') as f:
         report = json.load(f)
+    load_time = time.time() - load_start
+    log_print(f"Loaded JSON report: {load_time:.2f}s ({len(report.get('results', []))} results)")
 
+    # Load user properties
+    props_start = time.time()
     user_properties = load_user_properties(test_dir)
+    props_time = time.time() - props_start
+    log_print(f"Loaded user properties: {props_time:.2f}s")
 
+    # Filter and group results
+    filter_start = time.time()
     suites = {}
     filtered_results = []  # Keep track of results that pass the filter
     for result in report.get("results", []):
@@ -216,8 +229,17 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
         if suite_name not in suites:
             suites[suite_name] = []
         suites[suite_name].append(result)
+    filter_time = time.time() - filter_start
+    log_print(f"Filtered and grouped results: {filter_time:.2f}s ({len(suites)} suites, {len(filtered_results)} results)")
 
+    # Process suites
+    suites_start = time.time()
+    total_save_log_time = 0
+    total_save_zip_time = 0
+    suite_count = 0
+    
     for suite_name, results in suites.items():
+        suite_count += 1
         has_fail_tests = False
         suite_logsdirs = set()
         results_with_logsdir = []
@@ -272,10 +294,23 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
             is_fail = status in ("FAILED", "ERROR")
             has_fail_tests |= is_fail
 
+            # Check if test will be muted (before processing links)
+            # Muted tests keep their logs (they were failed before muting)
+            # Check for all tests to avoid calling mute_check() multiple times
+            will_be_muted = mute_check(suite_name, test_name_for_mute) if is_fail else False
+
             if "links" not in result:
                 result["links"] = {}
             
             original_links = result.get("links", {}).copy()
+            
+            # For passed tests, remove log/stderr/stdout links early to avoid keeping incorrect paths
+            # They will be processed only for failed tests
+            # Note: "Log" (capital L) and "log" (lowercase) are both possible
+            if not is_fail and not will_be_muted:
+                for link_type in ["Log", "log", "stderr", "stdout"]:
+                    if link_type in result.get("links", {}):
+                        result["links"].pop(link_type, None)
             
             for link_type, paths in original_links.items():
                 if not isinstance(paths, list):
@@ -286,6 +321,10 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
                             suite_logsdirs.add(file_path)
                             if result not in results_with_logsdir:
                                 results_with_logsdir.append(result)
+                    # Remove logsdir from original_links to avoid keeping incorrect paths
+                    # It will be set later if ZIP is created
+                    if "logsdir" in result.get("links", {}):
+                        result["links"].pop("logsdir", None)
                     break
             
             if is_fail:
@@ -308,7 +347,7 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
                             except ValueError:
                                 pass
 
-            if mute_check(suite_name, test_name_for_mute):
+            if will_be_muted:
                 log_print("mute", suite_name, test_name_for_mute)
                 mute_test_result(result)
 
@@ -318,6 +357,8 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
                         result["properties"] = {}
                     result["properties"].update(user_properties[path_str][subtest_name])
 
+        # Save log files
+        save_log_start = time.time()
         for result, link_type, file_path in results_file_links:
             if file_path not in processed_files_cache:
                 url = save_log(ya_out_dir, file_path, log_out_dir, log_url_prefix, log_truncate_size)
@@ -328,9 +369,15 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
             if "links" not in result:
                 result["links"] = {}
             result["links"][link_type] = [url]
+        save_log_time = time.time() - save_log_start
+        total_save_log_time += save_log_time
 
+        # Create ZIP archives
         if has_fail_tests and suite_logsdirs:
+            save_zip_start = time.time()
             url = save_zip(suite_name, test_stuff_out, test_stuff_prefix, suite_logsdirs)
+            save_zip_time = time.time() - save_zip_start
+            total_save_zip_time += save_zip_time
             for result in results:
                 if "links" not in result:
                     result["links"] = {}
@@ -342,21 +389,43 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
             is_muted = result.get("muted", False)
             # Keep all logs for muted tests (they were failed before muting)
             if not is_fail and not is_muted:
-                processed_link_types = set()
+                # Remove logsdir for passed tests if no failed tests in suite
+                # (ZIP was not created, so logsdir would point to raw path which is incorrect)
                 if "links" in result:
-                    processed_link_types.add("logsdir")
+                    # Only remove if ZIP was not created (no failed tests in suite)
+                    if not has_fail_tests and "logsdir" in result["links"]:
+                        result["links"].pop("logsdir", None)
+                    # Keep only logsdir for passed tests (if ZIP was created)
+                    processed_link_types = set()
+                    if "logsdir" in result.get("links", {}):
+                        processed_link_types.add("logsdir")
                     result["links"] = {k: v for k, v in result["links"].items() if k in processed_link_types}
 
+    suites_time = time.time() - suites_start
+    log_print(f"Processed {suite_count} suites: {suites_time:.2f}s (save_log: {total_save_log_time:.2f}s, save_zip: {total_save_zip_time:.2f}s)")
+
     # Process rich-snippet for filtered results only
+    rich_start = time.time()
+    rich_count = 0
     for result in filtered_results:
         if "rich-snippet" in result and result["rich-snippet"]:
             result["rich-snippet"] = strip_rich_markup(result["rich-snippet"])
+            rich_count += 1
+    rich_time = time.time() - rich_start
+    log_print(f"Processed rich-snippet: {rich_time:.2f}s ({rich_count} results)")
 
     # Replace report results with filtered results only
     report["results"] = filtered_results
 
+    # Save JSON report
+    save_start = time.time()
     with open(report_file, 'w') as f:
         json.dump(report, f, indent=2)
+    save_time = time.time() - save_start
+    log_print(f"Saved JSON report: {save_time:.2f}s")
+    
+    total_time = time.time() - start_time
+    log_print(f"Total transformation time: {total_time:.2f}s")
 
 
 def main():
@@ -383,11 +452,18 @@ def main():
 
     args = parser.parse_args()
 
-    mute_check = YaMuteCheck()
+    log_print(f"Start")
 
+    # Initialize mute check
+    mute_start = time.time()
+    mute_check = YaMuteCheck()
     if args.m:
         mute_check.load(args.m)
+    mute_time = time.time() - mute_start
+    log_print(f"Initialized mute check: {mute_time:.2f}s")
 
+    # Setup directories
+    dirs_start = time.time()
     log_out_dir = os.path.join(args.public_dir, args.log_out_dir)
     os.makedirs(log_out_dir, exist_ok=True)
     log_url_prefix = os.path.join(args.public_dir_url, args.log_out_dir)
@@ -395,6 +471,8 @@ def main():
     test_stuff_out = os.path.join(args.public_dir, args.test_stuff_out)
     os.makedirs(test_stuff_out, exist_ok=True)
     test_stuff_prefix = os.path.join(args.public_dir_url, args.test_stuff_out)
+    dirs_time = time.time() - dirs_start
+    log_print(f"Setup directories: {dirs_time:.2f}s")
 
     transform(
         args.build_results_report,

--- a/.github/scripts/tests/transform_build_results.py
+++ b/.github/scripts/tests/transform_build_results.py
@@ -207,7 +207,7 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
         
         # For import, configure types: include only non-passing results
         if result_type in ("import", "configure"):
-            if status.upper() in ("OK"):
+            if status.upper() == "OK":
                 continue  # Skip this result - don't add to suites or filtered_results
         
         # This result passed the filter, add it to both suites and filtered_results


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/pull/30941

# Рефакторинг обработки результатов тестов

## Основные изменения

**Нормализация статусов:**
- Централизована в `transform_build_results. py`: OK→PASSED, NOT_LAUNCHED→SKIPPED, mute→MUTE
- Добавлена обработка неизвестных статусов (конвертируются в ERROR)

**Фильтрация результатов:**
- Логика перенесена в этап трансформации
- Build-результаты полностью исключены, configure — только при ошибках
- Проверка на наличие поля `status` вместо `type == "test"` ( это позволило не пропускать flake8 которые не  `type == "test"` а  `type == "style")

**Управление логами:**
- Улучшена обработка ссылок на логи для прошедших тестов
- Логи сохраняются для muted и NOT_LAUNCHED тестов

**Производительность:**
- Добавлена логирование времени выполнения всех этапов

**Очистка кода:**
- Удалены дублирующиеся проверки статусов
- Консолидирована логика работы с muted тестами

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
