### PR TITLE
Fix YMQ cloud events

### DIFF
--- a/ydb/core/ymq/actor/cloud_events/cloud_events.cpp
+++ b/ydb/core/ymq/actor/cloud_events/cloud_events.cpp
@@ -99,6 +99,7 @@ namespace NCloudEvents {
             TString jsonEv;
             google::protobuf::util::JsonPrintOptions printOpts;
             printOpts.preserve_proto_field_names = true;
+            printOpts.always_print_primitive_fields = true;
             auto status = google::protobuf::util::MessageToJsonString(ev, &jsonEv, printOpts);
             Y_ASSERT(status.ok());
             writer->Write(jsonEv);


### PR DESCRIPTION
Prints default value of subject type.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

