### PR TITLE
dq streamlookup join: add support for non-right-ANY join

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -607,6 +607,7 @@ void TKqpTasksGraph::BuildDqSourceStreamLookupChannels(const TStageInfo& stageIn
     settings->SetCacheTtlSeconds(dqSourceStreamLookup.GetCacheTtlSeconds());
     settings->SetMaxDelayedRows(dqSourceStreamLookup.GetMaxDelayedRows());
     settings->SetIsMultiget(dqSourceStreamLookup.GetIsMultiGet());
+    settings->SetIsMultiMatches(dqSourceStreamLookup.GetIsMultiMatches());
 
     const auto& leftJointKeys = dqSourceStreamLookup.GetLeftJoinKeyNames();
     settings->MutableLeftJoinKeyNames()->Assign(leftJointKeys.begin(), leftJointKeys.end());

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -2152,6 +2152,10 @@ private:
                 dqSourceLookupCn.SetIsMultiGet(FromString<bool>(maybeMultiget.Cast()));
             }
 
+            if (const auto maybeIsMultiMatches = streamLookup.IsMultiMatches()) {
+                dqSourceLookupCn.SetIsMultiMatches(FromString<bool>(maybeIsMultiMatches.Cast()));
+            }
+
             for (const auto& key : streamLookup.LeftJoinKeyNames()) {
                 *dqSourceLookupCn.AddLeftJoinKeyNames() = leftLabel ? RemoveJoinAliases(key) : key;
             }

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -376,6 +376,7 @@ message TKqpPhyCnDqSourceStreamLookup {
     uint64 CacheTtlSeconds = 13;
     uint64 MaxDelayedRows = 14;
     bool IsMultiGet = 15;
+    bool IsMultiMatches = 16;
 }
 
 message TKqpPhyConnection {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -279,6 +279,7 @@ public:
         const NKikimr::NMiniKQL::THolderFactory& HolderFactory;
         const THashMap<TString, TString>& SecureParams;
         size_t MaxKeysInRequest;
+        const bool IsMultiMatches;
     };
 
     struct TSinkArguments {

--- a/ydb/library/yql/dq/expr_nodes/dq_expr_nodes.json
+++ b/ydb/library/yql/dq/expr_nodes/dq_expr_nodes.json
@@ -213,7 +213,8 @@
             {"Index": 8, "Name": "TTL", "Type": "TCoAtom"},
             {"Index": 9, "Name": "MaxDelayedRows", "Type": "TCoAtom"},
             {"Index": 10, "Name": "MaxCachedRows", "Type": "TCoAtom"},
-            {"Index": 11, "Name": "IsMultiget", "Type": "TCoAtom", "Optional": true}
+            {"Index": 11, "Name": "IsMultiget", "Type": "TCoAtom", "Optional": true},
+            {"Index": 12, "Name": "IsMultiMatches", "Type": "TCoAtom", "Optional": true}
         ]
     },
     {

--- a/ydb/library/yql/dq/proto/dq_tasks.proto
+++ b/ydb/library/yql/dq/proto/dq_tasks.proto
@@ -209,6 +209,7 @@ message TDqInputTransformLookupSettings {
     uint64 CacheTtlSeconds = 10;
     uint64 MaxDelayedRows = 11;
     bool IsMultiget = 12;
+    bool IsMultiMatches = 13;
 }
 
 message TDqTask {

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -684,7 +684,7 @@ TStatus AnnotateDqConnection(const TExprNode::TPtr& input, TExprContext& ctx) {
 }
 
 TStatus AnnotateDqCnStreamLookup(const TExprNode::TPtr& input, TExprContext& ctx) {
-    if (!EnsureMinMaxArgsCount(*input, 11, 12, ctx)) {
+    if (!EnsureMinMaxArgsCount(*input, 11, 13, ctx)) {
         return TStatus::Error;
     }
     if (!EnsureCallable(*input->Child(TDqCnStreamLookup::idx_Output), ctx)) {

--- a/ydb/library/yql/providers/dq/planner/execution_planner.cpp
+++ b/ydb/library/yql/providers/dq/planner/execution_planner.cpp
@@ -521,6 +521,10 @@ namespace NYql::NDqs {
             settings.SetIsMultiget(FromString<bool>(maybeMultiget.Cast().StringValue()));
         }
 
+        if (auto maybeIsMultiMatches = streamLookup.IsMultiMatches()) {
+            settings.SetIsMultiMatches(FromString<bool>(maybeIsMultiMatches.Cast().StringValue()));
+        }
+
         const auto inputRowType = GetSeqItemType(streamLookup.Output().Stage().Program().Ref().GetTypeAnn());
         const auto outputRowType = GetSeqItemType(stage.Program().Args().Arg(inputIndex).Ref().GetTypeAnn());
         TTransform streamLookupTransform {

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -157,14 +157,14 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
                         MakeArray<arrow::StringBuilder, std::string>("string_value", {"a", "b", "c"}, arrow::utf8())
                     ),
                     NewSuccess()
-                )    
+                )
         ;
         // clang-format on
 
         NYql::Generic::TLookupSource lookupSourceSettings;
         *lookupSourceSettings.mutable_data_source_instance() = dsi;
         lookupSourceSettings.Settable("lookup_test");
-        lookupSourceSettings.SetTokenName("test_token");   
+        lookupSourceSettings.SetTokenName("test_token");
 
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
@@ -214,17 +214,184 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         UNIT_ASSERT(lookupResult);
 
         UNIT_ASSERT_EQUAL(3, lookupResult->size());
+    }
+
+    Y_UNIT_TEST(LookupMultiMatches) {
+        auto alloc = std::make_shared<NKikimr::NMiniKQL::TScopedAlloc>(__LOCATION__, NKikimr::TAlignedPagePoolCounters(), true, false);
+        NKikimr::NMiniKQL::TMemoryUsageInfo memUsage("TestMemUsage");
+        NKikimr::NMiniKQL::THolderFactory holderFactory(alloc->Ref(), memUsage);
+        NKikimr::NMiniKQL::TTypeEnvironment typeEnv(*alloc);
+        NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
+
+        auto loggerConfig = NYql::NProto::TLoggingConfig();
+        loggerConfig.set_allcomponentslevel(::NYql::NProto::TLoggingConfig_ELevel::TLoggingConfig_ELevel_TRACE);
+        NYql::NLog::InitLogger(loggerConfig, false);
+
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+        auto edge = runtime.AllocateEdgeActor();
+
+        NYql::TGenericDataSourceInstance dsi;
+        dsi.Setkind(NYql::EGenericDataSourceKind::YDB);
+        dsi.mutable_endpoint()->Sethost("some_host");
+        dsi.mutable_endpoint()->Setport(2135);
+        dsi.Setdatabase("some_db");
+        dsi.Setuse_tls(true);
+        dsi.set_protocol(::NYql::EGenericProtocol::NATIVE);
+        auto token = dsi.mutable_credentials()->mutable_token();
+        token->Settype("IAM");
+        token->Setvalue("token_value");
+
+        auto connectorMock = std::make_shared<NYql::NConnector::NTest::TConnectorClientMock>();
+
+        // clang-format off
+        // step 1: ListSplits
+        connectorMock->ExpectListSplits()
+            .Select()
+                .DataSourceInstance(dsi)
+                .What()
+                    .Column("id", Ydb::Type::UINT64)
+                    .NullableColumn("optional_id", Ydb::Type::UINT64)
+                    .NullableColumn("string_value", Ydb::Type::STRING)
+                    .Done()
+                .Table("lookup_test")
+                .Where()
+                    .Filter()
+                        .Disjunction()
+                            .Operand()
+                                .Conjunction()
+                                    .Operand().Equal().Column("id").Value<ui64>(2).Done().Done()
+                                    .Operand().Equal().Column("optional_id").OptionalValue<ui64>(102).Done().Done()
+                                    .Done()
+                                .Done()
+                            .Operand()
+                                .Conjunction()
+                                    .Operand().Equal().Column("id").Value<ui64>(1).Done().Done()
+                                    .Operand().Equal().Column("optional_id").OptionalValue<ui64>(101).Done().Done()
+                                    .Done()
+                                .Done()
+                            .Operand()
+                                .Conjunction()
+                                    .Operand().Equal().Column("id").Value<ui64>(0).Done().Done()
+                                    .Operand().Equal().Column("optional_id").OptionalValue<ui64>(100).Done().Done()
+                                    .Done()
+                                .Done()
+                            .Operand()
+                                .Conjunction()
+                                    .Operand().Equal().Column("id").Value<ui64>(2).Done().Done()
+                                    .Operand().Equal().Column("optional_id").OptionalValue<ui64>(102).Done().Done()
+                                    .Done()
+                                .Done()
+                            .Done()
+                        .Done()
+                    .Done()
+                .Done()
+            .MaxSplitCount(1)
+            .Result()
+                .AddResponse(NewSuccess())
+                    .Description("Actual split info is not important")
+        ;
+
+        connectorMock->ExpectReadSplits()
+            .DataSourceInstance(dsi)
+            .Filtering(NYql::NConnector::NApi::TReadSplitsRequest::FILTERING_MANDATORY)
+            .Split()
+                .Description("Actual split info is not important")
+                .Done()
+            .Result()
+                .AddResponse(
+                    MakeRecordBatch(
+                        MakeArray<arrow::UInt64Builder, uint64_t>("id", {0, 1, 1, 2}, arrow::uint64()),
+                        MakeArray<arrow::UInt64Builder, uint64_t>("optional_id", {100, 101, 101, 103}, arrow::uint64()), // the last value is intentially wrong
+                        MakeArray<arrow::StringBuilder, std::string>("string_value", {"a", "b", "ba", "c"}, arrow::utf8())
+                    ),
+                    NewSuccess()
+                )
+        ;
+        // clang-format on
+
+        NYql::Generic::TLookupSource lookupSourceSettings;
+        *lookupSourceSettings.mutable_data_source_instance() = dsi;
+        lookupSourceSettings.Settable("lookup_test");
+        lookupSourceSettings.SetTokenName("test_token");
+
+        google::protobuf::Any packedLookupSource;
+        Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
+
+        NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
+        keyTypeBuilder.Add("id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, false));
+        keyTypeBuilder.Add("optional_id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, true));
+        NKikimr::NMiniKQL::TStructTypeBuilder outputypeBuilder{typeEnv};
+        outputypeBuilder.Add("string_value", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::String, true));
+
+        auto guard = Guard(*alloc.get());
+        auto keyTypeHelper = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TKeyTypeHelper>(keyTypeBuilder.Build());
+
+        auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
+            connectorMock,
+            NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
+            edge,
+            nullptr,
+            alloc,
+            keyTypeHelper,
+            std::move(lookupSourceSettings),
+            keyTypeBuilder.Build(),
+            outputypeBuilder.Build(),
+            typeEnv,
+            holderFactory,
+            1'000'000,
+            {{"test_token", "{\"token\": \"token_value\"}"}},
+            true);
+        auto lookupActor = runtime.Register(actor);
+
+        auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
+        for (size_t i = 0; i != 3; ++i) {
+            NYql::NUdf::TUnboxedValue* keyItems;
+            auto key = holderFactory.CreateDirectArrayHolder(2, keyItems);
+            keyItems[0] = NYql::NUdf::TUnboxedValuePod(ui64(i));
+            keyItems[1] = NYql::NUdf::TUnboxedValuePod(ui64(100 + i));
+            request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
+        }
+
+        guard.Release(); // let actors use alloc
+
+        auto callLookupActor = new TCallLookupActor(alloc, lookupActor, request);
+        runtime.Register(callLookupActor);
+
+        auto ev = runtime.GrabEdgeEventRethrow<NYql::NDq::IDqAsyncLookupSource::TEvLookupResult>(edge);
+        auto guard2 = Guard(*alloc.get());
+        auto lookupResult = ev->Get()->Result.lock();
+        UNIT_ASSERT(lookupResult);
+
+        UNIT_ASSERT_EQUAL(3, lookupResult->size());
         {
             const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {0, 100}));
             UNIT_ASSERT(v);
-            NYql::NUdf::TUnboxedValue val = v->GetElement(0);
-            UNIT_ASSERT(val.AsStringRef() == TStringBuf("a"));
+            UNIT_ASSERT_VALUES_EQUAL(v->GetListLength(), 1);
+            auto ptr = v->GetElements();
+            UNIT_ASSERT(ptr);
+            {
+                auto val = ptr->GetElement(0);
+                UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("a"));
+                ++ptr;
+            }
         }
         {
             const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {1, 101}));
             UNIT_ASSERT(v);
-            NYql::NUdf::TUnboxedValue val = v->GetElement(0);
-            UNIT_ASSERT(val.AsStringRef() == TStringBuf("b"));
+            UNIT_ASSERT_VALUES_EQUAL(v->GetListLength(), 2);
+            auto ptr = v->GetElements();
+            UNIT_ASSERT(ptr);
+            {
+                auto val = ptr->GetElement(0);
+                UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("b"));
+                ++ptr;
+            }
+            {
+                auto val = ptr->GetElement(0);
+                UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("ba"));
+                ++ptr;
+            }
         }
         {
             const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {2, 102}));
@@ -355,7 +522,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         NYql::Generic::TLookupSource lookupSourceSettings;
         *lookupSourceSettings.mutable_data_source_instance() = dsi;
         lookupSourceSettings.Settable("lookup_test");
-        lookupSourceSettings.SetTokenName("test_token");   
+        lookupSourceSettings.SetTokenName("test_token");
 
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -153,7 +153,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
                 .AddResponse(
                     MakeRecordBatch(
                         MakeArray<arrow::UInt64Builder, uint64_t>("id", {0, 1, 2}, arrow::uint64()),
-                        MakeArray<arrow::UInt64Builder, uint64_t>("optional_id", {100, 101, 103}, arrow::uint64()), // the last value is intentially wrong
+                        MakeArray<arrow::UInt64Builder, uint64_t>("optional_id", {100, 101, 103}, arrow::uint64()), // the last value is intentionally wrong
                         MakeArray<arrow::StringBuilder, std::string>("string_value", {"a", "b", "c"}, arrow::utf8())
                     ),
                     NewSuccess()
@@ -302,7 +302,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
                 .AddResponse(
                     MakeRecordBatch(
                         MakeArray<arrow::UInt64Builder, uint64_t>("id", {0, 1, 1, 2}, arrow::uint64()),
-                        MakeArray<arrow::UInt64Builder, uint64_t>("optional_id", {100, 101, 101, 103}, arrow::uint64()), // the last value is intentially wrong
+                        MakeArray<arrow::UInt64Builder, uint64_t>("optional_id", {100, 101, 101, 103}, arrow::uint64()), // the last value is intentionally wrong
                         MakeArray<arrow::StringBuilder, std::string>("string_value", {"a", "b", "ba", "c"}, arrow::utf8())
                     ),
                     NewSuccess()
@@ -509,7 +509,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
                         .AddResponse(
                             MakeRecordBatch(
                                 MakeArray<arrow::UInt64Builder, uint64_t>("id", {0, 1, 2}, arrow::uint64()),
-                                MakeArray<arrow::UInt64Builder, uint64_t>("optional_id", {100, 101, 103}, arrow::uint64()), // the last value is intentially wrong
+                                MakeArray<arrow::UInt64Builder, uint64_t>("optional_id", {100, 101, 103}, arrow::uint64()), // the last value is intentionally wrong
                                 MakeArray<arrow::StringBuilder, std::string>("string_value", {"a", "b", "c"}, arrow::utf8())
                             ),
                             NewSuccess()

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.h
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.h
@@ -24,7 +24,8 @@ namespace NYql::NDq {
         const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
         const NKikimr::NMiniKQL::THolderFactory& holderFactory,
         const size_t maxKeysInRequest,
-        const THashMap<TString, TString>& secureParams
+        const THashMap<TString, TString>& secureParams,
+        bool isMultiMatches = false
     );
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
@@ -41,7 +41,8 @@ namespace NYql::NDq {
                 args.TypeEnv,
                 args.HolderFactory,
                 args.MaxKeysInRequest,
-                args.SecureParams
+                args.SecureParams,
+                args.IsMultiMatches
             );
         };
 

--- a/ydb/library/yql/providers/yt/actors/yql_yt_lookup_actor.h
+++ b/ydb/library/yql/providers/yt/actors/yql_yt_lookup_actor.h
@@ -20,7 +20,8 @@ std::pair<NYql::NDq::IDqAsyncLookupSource*, NActors::IActor*> CreateYtLookupActo
     const NKikimr::NMiniKQL::TStructType* payloadType,
     const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
-    const size_t maxKeysInRequest
+    const size_t maxKeysInRequest,
+    const bool isMultiMatches
 );
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/yt/actors/yql_yt_provider_factories.cpp
+++ b/ydb/library/yql/providers/yt/actors/yql_yt_provider_factories.cpp
@@ -19,7 +19,8 @@ namespace NYql::NDq {
                 args.PayloadType,
                 args.TypeEnv,
                 args.HolderFactory,
-                args.MaxKeysInRequest);
+                args.MaxKeysInRequest,
+                args.IsMultiMatches);
         };
         factory.RegisterLookupSource<NYql::NYt::NSource::TLookupSource>(TString(YtProviderName), lookupActorFactory);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Adds support for `LEFT JOIN  /*+streamlookup()*/` with multiple matches on right side (previously only ANY join was supported)