### PR TITLE
schemeshard: make path-shards-limit cheaper

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -619,9 +619,8 @@ bool TTxStoreTableStats::VerifySplitAndRequestStats(
     bool collectKeySample
 ) {
     // NOTE: intentionally avoid using TPath.Check().{PathShardsLimit,ShardsLimit}() here.
-    // PathShardsLimit() performs pedantic validation by recalculating shard count through
-    // iteration over entire ShardInfos, which is too slow for this hot spot. It also performs
-    // additional lookups we want to avoid.
+    // PathShardsLimit() no longer performs full shard count validation by iterating all ShardInfos
+    // (too slow for this hot path), but still does additional lookups we want to avoid.
     {
         constexpr ui64 deltaShards = 2;
         if ((pathElement->GetShardsInside() + deltaShards) > subDomainInfo->GetSchemeLimits().MaxShardsInPath) {

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -987,14 +987,6 @@ const TPath::TChecker& TPath::TChecker::PathShardsLimit(ui64 delta, EStatus stat
     TSubDomainInfo::TPtr domainInfo = Path.DomainInfo();
     const ui64 shardInPath = Path.Shards();
 
-    if (Path.IsResolved() && !Path.IsDeleted()) {
-        const auto allShards = Path.SS->CollectAllShards({Path.Base()->PathId});
-        Y_VERIFY_DEBUG_S(allShards.size() == shardInPath, "pedantic check"
-            << ": CollectAllShards(): " << allShards.size()
-            << ", Path.Shards(): " << shardInPath
-            << ", path: " << Path.PathString());
-    }
-
     if (!delta || shardInPath + delta <= domainInfo->GetSchemeLimits().MaxShardsInPath) {
         return *this;
     }
@@ -1208,17 +1200,17 @@ const TPath::TChecker& TPath::TChecker::Or(TCheckerMethodPtr leftFunc, TCheckerM
     if (Failed) {
         return *this;
     }
-    
+
     TChecker left(*this);
     (left.*leftFunc)(status);
-    
+
     if (!left.Failed) {
         return *this;
     }
-    
+
     TChecker right(*this);
     (right.*rightFunc)(status);
-    
+
     if (right.Failed) {
         return Fail(left.Status, TStringBuilder() << left.Error << " and " << right.Error);
     }


### PR DESCRIPTION
Follow-up to (and may be depend on):
- https://github.com/ydb-platform/ydb/pull/27165

Remove iteration over all ShardInfos in `PathShardsLimit()`.

Currently, `PathShardsLimit()` performs full database shard count check on every call, which is excessive and expensive when processing statistics and initiating merge operations (since merges are triggered directly in `PersistSingleStats()`).

Seemingly, that behavior was supposed to provide some kind of sanity check, but wasn't really useful (had effect only in debug builds).

Closes #30976