### PR TITLE
Handle incorrect BlobId (CrcMode) during compaction in VDisk

### DIFF
--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
@@ -601,7 +601,20 @@ namespace NKikimr {
                 keep = Barriers->Keep(Key, IndexMerger.GetMemRecForBarriers(), {subsKeep, subsDoNotKeep, wholeKeep,
                     wholeDoNotKeep}, HullCtx->AllowKeepFlags, AllowGarbageCollection);
 
-                IndexMerger.Finish(HugeBlobCtx->IsHugeBlob(GType, Key.LogoBlobID(), MinHugeBlobInBytes), keep.KeepData);
+                const TLogoBlobID& id = Key.LogoBlobID();
+                if (!TBlobStorageGroupType::IsCrcModeValid(id.CrcMode())) {
+                    LOG_CRIT_S(*TlsActivationContext, NKikimrServices::BS_SKELETON, HullCtx->VCtx->VDiskLogPrefix
+                        << "invalid CrcMode in BlobId found during compaction"
+                        << " BlobId# " << id.ToString()
+                        << " KeepIndex# " << keep.KeepIndex
+                        << " KeepData# " << keep.KeepData
+                        << " SubsKeep# " << subsKeep
+                        << " SubsDoNotKeep# " << subsDoNotKeep
+                        << " WholeKeep# " << wholeKeep
+                        << " WholeDoNotKeep# " << wholeDoNotKeep);
+                }
+
+                IndexMerger.Finish(HugeBlobCtx->IsHugeBlob(GType, id, MinHugeBlobInBytes), keep.KeepData);
             } else {
                 keep = Barriers->Keep(Key, IndexMerger.GetMemRecForBarriers(), {}, HullCtx->AllowKeepFlags,
                     AllowGarbageCollection);

--- a/ydb/core/erasure/erasure.cpp
+++ b/ydb/core/erasure/erasure.cpp
@@ -2099,6 +2099,10 @@ ui64 TErasureType::PartSize(ECrcMode crcMode, ui64 dataSize) const {
             } else {
                 return 0;
             }
+#ifdef NDEBUG
+        default:
+            return dataSize;
+#endif
         }
         ythrow TWithBackTrace<yexception>() << "Unknown crcMode = " << (i32)crcMode;
     case TErasureType::ErasureParityStripe:
@@ -2112,6 +2116,10 @@ ui64 TErasureType::PartSize(ECrcMode crcMode, ui64 dataSize) const {
                 return partSize;
             case CrcModeWholePart:
                 return partSize + sizeof(ui32);
+#ifdef NDEBUG
+            default:
+                return partSize;
+#endif
             }
             ythrow TWithBackTrace<yexception>() << "Unknown crcMode = " << (i32)crcMode;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Handle incorrect BlobId (CrcMode) during compaction in VDisk

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows handling of incorrect CrcMode in blob.
