### PR TITLE
Report sucess rate

### DIFF
--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import dataclasses
+import json
+import math
 import os
+import re
 import sys
 import traceback
-import re
-import json
 from codeowners import CodeOwners
 from enum import Enum
 from operator import attrgetter
@@ -102,7 +103,6 @@ class TestResult:
 
     @property
     def elapsed_display(self):
-        import math
         # Round up to 1 decimal place: 10.545s -> 10.6s (ceiling to 0.1)
         elapsed_rounded = math.ceil(self.elapsed * 10) / 10
         m, s = divmod(elapsed_rounded, 60)

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -102,11 +102,14 @@ class TestResult:
 
     @property
     def elapsed_display(self):
-        m, s = divmod(self.elapsed, 60)
+        import math
+        # Round up to 1 decimal place: 10.545s -> 10.6s (ceiling to 0.1)
+        elapsed_rounded = math.ceil(self.elapsed * 10) / 10
+        m, s = divmod(elapsed_rounded, 60)
         parts = []
         if m > 0:
             parts.append(f'{int(m)}m')
-        parts.append(f"{s:.3f}s")
+        parts.append(f"{s:.1f}s")
         return ' '.join(parts)
 
     def __str__(self):

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -11,7 +11,7 @@ from enum import Enum
 from operator import attrgetter
 from typing import List, Dict
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
-from get_test_history_new import get_test_history
+from get_test_history import get_test_history
 
 
 def load_owner_area_mapping():

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -11,7 +11,7 @@ from enum import Enum
 from operator import attrgetter
 from typing import List, Dict
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
-from get_test_history import get_test_history
+from get_test_history_new import get_test_history
 
 
 def load_owner_area_mapping():
@@ -360,7 +360,7 @@ def render_testlist_html(rows, fn, build_preset, branch, pr_number=None, workflo
     get_codeowners_for_tests(codeowners, all_tests)
     
     # statuses for history
-    status_for_history = [TestStatus.FAIL, TestStatus.MUTE]
+    status_for_history = [TestStatus.FAIL, TestStatus.MUTE, TestStatus.ERROR]
     status_for_history = [s for s in status_for_history if s in status_test]
     
     tests_names_for_history = []
@@ -372,20 +372,66 @@ def render_testlist_html(rows, fn, build_preset, branch, pr_number=None, workflo
         tests_names_for_history.append(test.full_name)
 
     try:
-        history = get_test_history(tests_names_for_history, last_n_runs, build_preset, branch)
+        # Get history for last 4 days instead of last N runs
+        history = get_test_history(tests_names_for_history, 4, build_preset, branch)
     except Exception:
         print(traceback.format_exc())
    
-    #geting count of passed tests in history for sorting
+    # Calculate success rate for each test
+    def calculate_success_rate(test_history):
+        """Calculate success rate separately for pr-check and other runs"""
+        pr_check_runs = []
+        other_runs = []
+        
+        for timestamp, run_data in test_history.items():
+            job_name = run_data.get("job_name", "").lower()
+            # Check if it's a pr-check run (common patterns: pr-check, pr_check, pr/check, etc.)
+            is_pr_check = "pr-check" in job_name or "pr_check" in job_name or "pr/check" in job_name
+            
+            if is_pr_check:
+                pr_check_runs.append(run_data)
+            else:
+                other_runs.append(run_data)
+        
+        def calc_rate(runs):
+            if not runs:
+                return None
+            passed = sum(1 for r in runs if r.get("status") == "passed")
+            total = len(runs)
+            return {
+                "rate": round(passed / total * 100, 1) if total > 0 else 0,
+                "passed": passed,
+                "total": total
+            }
+        
+        return {
+            "pr_check": calc_rate(pr_check_runs),
+            "other": calc_rate(other_runs)
+        }
+    
+    # Calculate success rates for all tests with history
+    test_success_rates = {}
+    
+    print(f"Processing history for {len(history)} tests with history data")
+    print(f"Total tests in statuses: {len(tests_in_statuses)}")
+    
     for test in tests_in_statuses:
         if test.full_name in history:
-            test.count_of_passed = len(
-                [
-                    history[test.full_name][x]
-                    for x in history[test.full_name]
-                    if history[test.full_name][x]["status"] == "passed"
-                ]
-            )
+            test_history = history[test.full_name]
+            if test_history:  # Check that history is not empty
+                rates = calculate_success_rate(test_history)
+                test_success_rates[test.full_name] = rates
+                # Also update count_of_passed for backward compatibility
+                test.count_of_passed = len(
+                    [
+                        history[test.full_name][x]
+                        for x in history[test.full_name]
+                        if history[test.full_name][x]["status"] == "passed"
+                    ]
+                )
+    
+    print(f"Calculated success rates for {len(test_success_rates)} tests")
+    
     # sorted by test name
     for current_status in status_for_history:
         status_test.get(current_status,[]).sort(key=lambda val: (val.full_name, ))
@@ -420,12 +466,71 @@ def render_testlist_html(rows, fn, build_preset, branch, pr_number=None, workflo
     
     # Load owner to area mapping
     owner_area_mapping = load_owner_area_mapping()
+    
+    # Prepare history data for JavaScript (without status_description to reduce HTML size)
+    # Store status_description separately - only for failed/error/mute entries to save space
+    history_for_js = {}
+    history_descriptions = {}  # Separate object for status descriptions (only non-empty, failed/error/mute)
+    if history:
+        for test_name, test_history in history.items():
+            history_for_js[test_name] = {}
+            history_descriptions[test_name] = {}
+            for timestamp, hist_data in test_history.items():
+                timestamp_str = str(timestamp)
+                status = hist_data.get("status", "")
+                history_for_js[test_name][timestamp_str] = {
+                    "status": status,
+                    "date": hist_data.get("datetime", ""),
+                    "commit": hist_data.get("commit", ""),
+                    "job_name": hist_data.get("job_name", ""),
+                    "job_id": hist_data.get("job_id", ""),
+                    "branch": hist_data.get("branch", "")
+                    # status_description removed to reduce HTML size - stored separately
+                }
+                # Store description separately (only for failed/error/mute and if not empty to save space)
+                desc = hist_data.get("status_description", "")
+                if desc and desc.strip() and status in ("failure", "error", "mute"):
+                    history_descriptions[test_name][timestamp_str] = desc
+    
+    # Prepare test descriptions for current tests (without embedding in HTML to reduce size)
+    # Store only for tests with errors (FAIL, ERROR, MUTE, SKIP) and if not empty
+    test_descriptions = {}
+    for test in all_tests:
+        if test.status in (TestStatus.FAIL, TestStatus.ERROR, TestStatus.MUTE, TestStatus.SKIP):
+            desc = test.status_description
+            if desc and desc.strip():
+                test_descriptions[test.full_name] = desc
+    
+    # Save data to separate JSON file to reduce HTML size
+    # fn is the full path to HTML file (e.g., /path/to/public_dir/try_1/ya-test.html)
+    data_file = fn.replace('.html', '_data.json')
+    data_to_save = {
+        'history_for_js': history_for_js,
+        'history_descriptions': history_descriptions,
+        'test_descriptions': test_descriptions,
+        'test_success_rates': test_success_rates
+    }
+    with open(data_file, "w", encoding="utf-8") as f:
+        json.dump(data_to_save, f, separators=(',', ':'))  # Minified JSON
+    
+    # Calculate data file URL (relative to HTML file location)
+    # JSON file is in the same directory as HTML file, so we use just the filename
+    # This way fetch() in browser will load JSON from the same directory as HTML
+    # Example: if HTML is at /path/to/try_1/ya-test.html,
+    #          JSON is at /path/to/try_1/ya-test_data.json,
+    #          and URL should be "ya-test_data.json" (relative to HTML location)
+    data_file_url = os.path.basename(data_file)
         
     content = env.get_template("summary.html").render(
         status_order=status_order,
         tests=status_test,
         has_any_log=has_any_log,
-        history=history,
+        history=history,  # Keep for template checks (test.full_name in history)
+        history_for_js={},  # Empty - will be loaded from JSON
+        history_descriptions={},  # Empty - will be loaded from JSON
+        test_descriptions={},  # Empty - will be loaded from JSON
+        test_success_rates={},  # Empty - will be loaded from JSON
+        data_file_url=data_file_url,  # URL to JSON data file
         build_preset=build_preset,
         buid_preset_params=buid_preset_params,
         branch=branch,
@@ -437,7 +542,7 @@ def render_testlist_html(rows, fn, build_preset, branch, pr_number=None, workflo
         commit_sha=github_sha
     )
 
-    with open(fn, "w") as fp:
+    with open(fn, "w", encoding="utf-8") as fp:
         fp.write(content)
 
 

--- a/.github/scripts/tests/get_test_history.py
+++ b/.github/scripts/tests/get_test_history.py
@@ -11,14 +11,32 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'analytics'))
 from ydb_wrapper import YDBWrapper
 
 
-def get_test_history(test_names_array, last_n_runs_of_test_amount, build_type, branch):
+def get_test_history(test_names_array, days_back, build_type, branch):
+    """
+    Get test history for the specified number of days back.
+    
+    Args:
+        test_names_array: List of test full names (suite_folder/test_name)
+        days_back: Number of days to look back (instead of last N runs)
+        build_type: Build type filter (can be empty string for all)
+        branch: Branch filter (can be empty string for all)
+    
+    Returns:
+        Dictionary with test history: {test_name: {timestamp: {status, datetime, ...}}}
+    """
     with YDBWrapper() as ydb_wrapper:
         # Check credentials
         if not ydb_wrapper.check_credentials():
+            print(f"Warning: YDB credentials not found, returning empty history")
             return {}
 
         # Get table paths from config
         test_runs_table = ydb_wrapper.get_table_path("test_results")
+        
+        print(f"Querying history for {len(test_names_array)} tests:")
+        print(f"  build_type: {build_type}")
+        print(f"  branch: {branch}")
+        print(f"  days_back: {days_back}")
         
         results = {}
         batch_size = 500
@@ -28,51 +46,18 @@ def get_test_history(test_names_array, last_n_runs_of_test_amount, build_type, b
             history_query = f"""
     PRAGMA AnsiInForEmptyOrNullableItemsCollections;
     DECLARE $test_names AS List<Utf8>;
-    DECLARE $rn_max AS Int32;
+    DECLARE $days_back AS Int32;
     DECLARE $build_type AS Utf8;
     DECLARE $branch AS Utf8;
 
     $test_names = [{','.join("'{0}'".format(x) for x in test_names_batch)}];
-    $rn_max = {last_n_runs_of_test_amount};
+    $days_back = {days_back};
     $build_type = '{build_type}';
     $branch = '{branch}';
 
-    -- Оптимизированный запрос с учетом особенностей YDB
-    $filtered_tests = (
-        SELECT 
-            suite_folder || '/' || test_name AS full_name,
-            test_name,
-            build_type, 
-            commit, 
-            branch, 
-            run_timestamp, 
-            status, 
-            status_description,
-            job_id,
-            job_name,
-            ROW_NUMBER() OVER (PARTITION BY suite_folder, test_name ORDER BY run_timestamp DESC) AS rn
-        FROM 
-            `{test_runs_table}` AS t
-        WHERE 
-            t.build_type = $build_type
-            AND t.branch = $branch
-            AND t.job_name IN (
-                'Nightly-run',
-                'Regression-run',
-                'Regression-whitelist-run',
-                'Regression-run_Large',
-                'Regression-run_Small_and_Medium',
-                'Postcommit_relwithdebinfo', 
-                'Postcommit_asan'
-            )
-            AND t.status != 'skipped'
-            AND suite_folder || '/' || test_name IN $test_names
-            AND t.run_timestamp >  CurrentUtcDate() - 180 * Interval("P1D")
-    );
-
-    -- Финальный запрос с ограничением по количеству запусков
+    -- Запрос для получения истории за указанное количество дней
     SELECT 
-        full_name,
+        suite_folder || '/' || test_name AS full_name,
         test_name,
         build_type, 
         commit, 
@@ -81,36 +66,51 @@ def get_test_history(test_names_array, last_n_runs_of_test_amount, build_type, b
         status, 
         status_description,
         job_id,
-        job_name,
-        rn
+        job_name
     FROM 
-        $filtered_tests
+        `{test_runs_table}` AS t
     WHERE 
-        rn <= $rn_max
+        t.status != 'skipped'
+        AND suite_folder || '/' || test_name IN $test_names
+        AND t.run_timestamp > CurrentUtcDate() - $days_back * Interval("P1D")
+        AND ($build_type = '' OR t.build_type = $build_type)
+        AND ($branch = '' OR t.branch = $branch)
     ORDER BY 
         test_name, 
-        run_timestamp;
+        run_timestamp DESC;
 
 """
             query_result = ydb_wrapper.execute_scan_query(history_query)
-
+            
+            rows_found = 0
             for row in query_result:
-                if not row["full_name"].decode("utf-8") in results:
-                    results[row["full_name"].decode("utf-8")] = {}
+                rows_found += 1
+                full_name = row["full_name"].decode("utf-8") if isinstance(row["full_name"], bytes) else row["full_name"]
+                if full_name not in results:
+                    results[full_name] = {}
 
-                results[row["full_name"].decode("utf-8")][row["run_timestamp"]] = {
-                    "branch": row["branch"],
-                    "status": row["status"],
-                    "commit": row["commit"],
-                    "datetime": datetime.datetime.fromtimestamp(int(row["run_timestamp"] / 1000000)).strftime("%H:%m %B %d %Y"),
-                    "status_description": row["status_description"].replace(';;','\n'),
-                    "job_id": row["job_id"],
-                    "job_name": row["job_name"]
+                results[full_name][row["run_timestamp"]] = {
+                    "branch": row["branch"].decode("utf-8") if isinstance(row["branch"], bytes) else row["branch"],
+                    "status": row["status"].decode("utf-8") if isinstance(row["status"], bytes) else row["status"],
+                    "commit": row["commit"].decode("utf-8") if isinstance(row["commit"], bytes) else row["commit"],
+                    "datetime": datetime.datetime.fromtimestamp(int(row["run_timestamp"] / 1000000)).strftime("%Y-%m-%d %H:%M:%S"),
+                    "status_description": (row["status_description"].decode("utf-8") if isinstance(row["status_description"], bytes) else row["status_description"]).replace(';;','\n'),
+                    "job_id": row["job_id"].decode("utf-8") if isinstance(row["job_id"], bytes) else row["job_id"],
+                    "job_name": row["job_name"].decode("utf-8") if isinstance(row["job_name"], bytes) else row["job_name"]
                 }
+            
+            if rows_found == 0:
+                print(f"  Warning: No rows found in YDB for batch {start // batch_size + 1}")
+                print(f"  This could mean:")
+                print(f"    - No data with build_type='{build_type}' and branch='{branch}' in last {days_back} days")
+                print(f"    - Test names don't match (check format: suite_folder/test_name)")
         
-        print(f'Retrieved history for {len(test_names_array)} tests')
+        print(f'Retrieved history: {len(results)} tests with data out of {len(test_names_array)} requested')
+        if results:
+            sample_test = list(results.keys())[0]
+            print(f"  Sample: {sample_test} has {len(results[sample_test])} runs")
         return results
 
 
 if __name__ == "__main__":
-    get_test_history(test_names_array, last_n_runs_of_test_amount, build_type, branch)
+    get_test_history(test_names_array, days_back, build_type, branch)

--- a/.github/scripts/tests/get_test_history.py
+++ b/.github/scripts/tests/get_test_history.py
@@ -83,6 +83,7 @@ def get_test_history(test_names_array, days_back, build_type, branch):
         AND t.run_timestamp > CurrentUtcDate() - $days_back * Interval("P1D")
         AND ($build_type = '' OR t.build_type = $build_type)
         AND ($branch = '' OR t.branch = $branch)
+        AND t.job_name != 'Run-tests'
     ORDER BY 
         test_name, 
         run_timestamp DESC;

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -132,6 +132,32 @@
             text-decoration: none;
         }
 
+        .success-rate-button {
+            background-color: #0366d6;
+            color: white;
+            border: none;
+            padding: 4px 8px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 11px;
+            font-weight: 500;
+            white-space: nowrap;
+            flex-shrink: 1;
+            min-width: 0;
+        }
+        .success-rate-button:hover {
+            background-color: #0256cc;
+        }
+        .emoji {
+            font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", sans-serif;
+            font-style: normal;
+            font-variant: normal;
+            font-weight: normal;
+            line-height: 1;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
         .svg-icon {
             float: left;
             width: 14px;
@@ -403,14 +429,23 @@
             border-radius: 5px;
             max-height: 80vh;
             overflow-y: auto;
+            position: relative;
         }
     
         .close-modal {
             color: #aaa;
-            float: right;
             font-size: 28px;
             font-weight: bold;
             cursor: pointer;
+            position: absolute;
+            top: 15px;
+            right: 20px;
+            line-height: 1;
+            padding: 0;
+            z-index: 1;
+        }
+        .close-modal:hover {
+            color: #000;
         }
         
         .modal-header {
@@ -434,6 +469,118 @@
             font-weight: bold;
             display: inline-block;
             width: 80px;
+        }
+        
+        /* Success rate modal styles */
+        #successRateModal {
+            display: none;
+            position: fixed;
+            z-index: 1000;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+            background-color: rgba(0,0,0,0.5);
+            padding: 16px;
+            box-sizing: border-box;
+        }
+        #successRateModal .modal-content {
+            width: min(1200px, 90vw);
+            max-width: 90vw;
+            max-height: 90vh;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            margin: 2% auto;
+            position: relative;
+        }
+        #successRateModal .modal-header {
+            flex-shrink: 0;
+        }
+        #successRateModalContent {
+            overflow-y: auto;
+            overflow-x: hidden;
+            flex: 1 1 auto;
+            min-height: 0;
+            padding-right: 10px;
+        }
+        #successRateModalContent::-webkit-scrollbar {
+            width: 8px;
+        }
+        #successRateModalContent::-webkit-scrollbar-track {
+            background: #f1f1f1;
+            border-radius: 4px;
+        }
+        #successRateModalContent::-webkit-scrollbar-thumb {
+            background: #888;
+            border-radius: 4px;
+        }
+        #successRateModalContent::-webkit-scrollbar-thumb:hover {
+            background: #555;
+        }
+        .sr-runs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+        }
+        .sr-runs span[data-tooltip] {
+            position: relative;
+        }
+        .sr-runs span[data-tooltip]:hover::after {
+            content: attr(data-tooltip);
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: #333;
+            color: white;
+            padding: 6px 10px;
+            border-radius: 4px;
+            font-size: 12px;
+            white-space: nowrap;
+            z-index: 1000;
+            margin-bottom: 5px;
+            pointer-events: none;
+            opacity: 1;
+            transition: opacity 0.1s;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+        }
+        .sr-runs span[data-tooltip]:hover::before {
+            content: '';
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            border: 5px solid transparent;
+            border-top-color: #333;
+            z-index: 1001;
+            margin-bottom: -5px;
+            pointer-events: none;
+        }
+        .sr-table-wrap {
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            max-width: 100%;
+            margin: 0 -4px;
+            padding: 0 4px;
+        }
+        .sr-table-wrap table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 15px;
+        }
+        .sr-table-wrap thead th {
+            background-color: #f6f8fa;
+            border-bottom: 2px solid #d0d7de;
+            padding: 10px;
+            text-align: left;
+        }
+        .sr-table-wrap tbody td {
+            padding: 10px;
+            border-bottom: 1px solid #d0d7de;
+        }
+        .sr-table-wrap tbody tr:last-child td {
+            border-bottom: none;
         }
 </style>
 <script>
@@ -589,7 +736,7 @@
         return labels.join(',');
     }
 
-    function buildIssueBody(issueType, path, testName, buildPreset, branch, commitSha, testRunCommand, owner, success_count, fail_count, logUrls, errorText) {
+    function buildIssueBody(issueType, path, testName, buildPreset, branch, commitSha, testRunCommand, owner, success_count, fail_count, logUrls, errorText, reportUrl) {
         let body = encodeURIComponent(path) + "/" + encodeURIComponent(testName) + "%0A%0A";
         
         // Add type-specific header
@@ -608,6 +755,11 @@
         }
         body += "- Build Preset: " + encodeURIComponent(buildPreset) + "%0A";
         body += "- Branch: " + encodeURIComponent(branch) + "%0A%0A";
+        
+        // Report link (if available)
+        if (reportUrl && reportUrl.trim() !== "") {
+            body += "**Test Report:** [View report](" + encodeURIComponent(reportUrl) + ")%0A%0A";
+        }
         
         // Run command
         body += "**Run Command:**%0A```%0A" + encodeURIComponent(testRunCommand) + "%0A```%0A%0A";
@@ -692,6 +844,9 @@
         const testRunCommand = getTestRunCommand(test);
         const ownerAreaLabel = getOwnerAreaLabel(owner);
         
+        // Get report URL - use current page URL (the report page itself)
+        const reportUrl = window.location.href;
+        
         // Determine issue type based on parameters
         let actualIssueType = issueType;
         if (is_sanitizer && issueType === 'bug') {
@@ -709,7 +864,7 @@
         }
         
         // Build body
-        const body = buildIssueBody(actualIssueType, path, testName, buildPreset, branch, commitSha, testRunCommand, owner, success_count, fail_count, logUrls, errorText);
+        const body = buildIssueBody(actualIssueType, path, testName, buildPreset, branch, commitSha, testRunCommand, owner, success_count, fail_count, logUrls, errorText, reportUrl);
         
         // Build labels
         const labels = buildLabels(actualIssueType, buildPreset, ownerAreaLabel);
@@ -862,32 +1017,8 @@
             }    
         });
 
-        const svgIcons = document.querySelectorAll('.svg-icon');
-        svgIcons.forEach(icon => {
-            icon.addEventListener('click', function(event) {
-                event.stopPropagation();
-                
-                // Получаем данные для модального окна
-                const testName = icon.getAttribute('data-test-name');
-                const status = icon.getAttribute('data-status');
-                const date = icon.getAttribute('data-date');
-                const errorText = icon.getAttribute('data-error');
-                const commit = icon.getAttribute('data-commit');
-                const job_name = icon.getAttribute('data-job-name');
-                const job_id = icon.getAttribute('data-job-id');
-                
-                // Открываем модальное окно с данными
-                showTestInfo({
-                    testName: testName,
-                    status: status,
-                    date: date,
-                    errorText: errorText,
-                    commit: commit,
-                    job_name: job_name,
-                    job_id: job_id
-                });
-            });
-        });
+        // SVG icons are no longer used - replaced with success rate button
+        // History entries are now shown in success rate modal
         
         const copyButtons = document.querySelectorAll(".copy");
         copyButtons.forEach(button => {
@@ -912,13 +1043,27 @@
         });
         const createIssueButton = document.querySelectorAll(".create_issue");
         createIssueButton.forEach(button => {
-            button.addEventListener('click', function(event) {
+            button.addEventListener('click', async function(event) {
                 event.preventDefault();
                 const testRow = findParentBySelector(event.target,'tr');
-                const success_count = testRow.querySelectorAll('.svg_passed').length;
-                const fail_count = testRow.querySelectorAll('.svg_failure').length + testRow.querySelectorAll('.svg_mute').length;
                 const testName = testRow.querySelector('.test_name').querySelector('span').innerText;
                 const owner = testRow.querySelector('.test_owner').innerText;
+                
+                // Get success/fail counts from history if available
+                let success_count = 0;
+                let fail_count = 0;
+                try {
+                    const history = await getTestHistory();
+                    if (history && history[testName]) {
+                        for (const timestamp in history[testName]) {
+                            const status = history[testName][timestamp].status;
+                            if (status === 'passed') success_count++;
+                            else if (status === 'failure' || status === 'mute') fail_count++;
+                        }
+                    }
+                } catch (e) {
+                    console.warn('Failed to load history for issue creation:', e);
+                }
                 
                 // Check if this is a sanitizer issue by looking for the SANITIZER badge
                 const is_sanitizer = testRow.querySelector('.test_name span[style*="background-color: #ff4500"]') !== null;
@@ -950,13 +1095,27 @@
         
         const createMuteIssueButton = document.querySelectorAll(".create_mute_issue");
         createMuteIssueButton.forEach(button => {
-            button.addEventListener('click', function(event) {
+            button.addEventListener('click', async function(event) {
                 event.preventDefault();
                 const testRow = findParentBySelector(event.target,'tr');
-                const success_count = testRow.querySelectorAll('.svg_passed').length;
-                const fail_count = testRow.querySelectorAll('.svg_failure').length + testRow.querySelectorAll('.svg_mute').length;
                 const testName = testRow.querySelector('.test_name').querySelector('span').innerText;
                 const owner = testRow.querySelector('.test_owner').innerText;
+                
+                // Get success/fail counts from history if available
+                let success_count = 0;
+                let fail_count = 0;
+                try {
+                    const history = await getTestHistory();
+                    if (history && history[testName]) {
+                        for (const timestamp in history[testName]) {
+                            const status = history[testName][timestamp].status;
+                            if (status === 'passed') success_count++;
+                            else if (status === 'failure' || status === 'mute') fail_count++;
+                        }
+                    }
+                } catch (e) {
+                    console.warn('Failed to load history for issue creation:', e);
+                }
                 
                 // Get error text from the test description if available
                 let errorText = '';
@@ -1003,18 +1162,449 @@
             toggleAllTables('collapse');
         });
         
-        // Обработчик для закрытия модального окна
-        document.querySelector('.close-modal').onclick = function() {
-            document.getElementById('errorModal').style.display = 'none';
-        }
+        // Обработчик для закрытия модальных окон
+        document.querySelectorAll('.close-modal').forEach(closeBtn => {
+            closeBtn.onclick = function(event) {
+                event.stopPropagation();
+                // Find parent modal
+                let modal = this.closest('.modal');
+                if (!modal) {
+                    // Try to find by id
+                    modal = document.getElementById('errorModal');
+                    if (!modal) {
+                        modal = document.getElementById('successRateModal');
+                    }
+                }
+                if (modal) {
+                    modal.style.display = 'none';
+                }
+            };
+        });
         
         // Закрытие при клике вне модального окна
         window.onclick = function(event) {
-            const modal = document.getElementById('errorModal');
-            if (event.target == modal) {
+            const errorModal = document.getElementById('errorModal');
+            const successRateModal = document.getElementById('successRateModal');
+            if (event.target == errorModal) {
+                errorModal.style.display = 'none';
+            }
+            if (event.target == successRateModal) {
+                successRateModal.style.display = 'none';
+            }
+        }
+        
+        // Close modals on Escape key
+        document.addEventListener('keydown', function(event) {
+            if (event.key === 'Escape' || event.keyCode === 27) {
+                const errorModal = document.getElementById('errorModal');
+                const successRateModal = document.getElementById('successRateModal');
+                if (errorModal && errorModal.style.display === 'block') {
+                    errorModal.style.display = 'none';
+                }
+                if (successRateModal && successRateModal.style.display === 'block') {
+                    successRateModal.style.display = 'none';
+                }
+            }
+        });
+        
+        // Add click handlers for success rate buttons
+        document.addEventListener('click', function(e) {
+            const button = e.target.closest('.success-rate-button');
+            if (!button) return;
+            
+            const testFullName = button.getAttribute('data-test-full-name');
+            if (!testFullName) return;
+            
+            showSuccessRateModal(testFullName);
+        });
+    });
+    
+    // Data loading and success rate modal functions
+    const dataFileUrl = "{{ data_file_url }}";
+    let testData = null;
+    let dataLoadPromise = null;
+    
+    // Lazy load test data from JSON file
+    async function loadTestData() {
+        if (testData) {
+            return testData;
+        }
+        if (dataLoadPromise) {
+            return dataLoadPromise;
+        }
+        
+        // Check if we're in a local file:// context (CORS will fail)
+        const isLocalFile = window.location.protocol === 'file:';
+        
+        // For local file:// protocol, fetch won't work due to CORS
+        // Return empty data structure immediately to avoid errors
+        if (isLocalFile) {
+            console.warn('Local file mode detected (file://). JSON data cannot be loaded via fetch due to CORS restrictions.');
+            console.warn('For local testing, use a local web server: python3 -m http.server 8000');
+            testData = {
+                history_for_js: {},
+                history_descriptions: {},
+                test_descriptions: {},
+                test_success_rates: {}
+            };
+            return Promise.resolve(testData);
+        }
+        
+        dataLoadPromise = fetch(dataFileUrl)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`Failed to load data: ${response.status}`);
+                }
+                return response.json();
+            })
+            .then(data => {
+                console.log('Test data loaded successfully. Keys:', Object.keys(data));
+                testData = data;
+                return testData;
+            })
+            .catch(error => {
+                console.error('Error loading test data from JSON file:', error);
+                console.error('Data file URL:', dataFileUrl);
+                // Return empty data structure on error
+                testData = {
+                    history_for_js: {},
+                    history_descriptions: {},
+                    test_descriptions: {},
+                    test_success_rates: {}
+                };
+                return testData;
+            });
+        
+        return dataLoadPromise;
+    }
+    
+    // Initialize with empty data structures (will be populated when needed)
+    let testHistory = {};
+    let historyDescriptions = {};
+    let testDescriptions = {};
+    let testSuccessRates = {};
+    
+    // Helper functions to get data (with lazy loading)
+    async function getTestHistory() {
+        if (Object.keys(testHistory).length === 0) {
+            const data = await loadTestData();
+            testHistory = data.history_for_js || {};
+        }
+        return testHistory;
+    }
+    
+    async function getHistoryDescriptions() {
+        if (Object.keys(historyDescriptions).length === 0) {
+            const data = await loadTestData();
+            historyDescriptions = data.history_descriptions || {};
+        }
+        return historyDescriptions;
+    }
+    
+    async function getTestDescriptions() {
+        if (Object.keys(testDescriptions).length === 0) {
+            const data = await loadTestData();
+            testDescriptions = data.test_descriptions || {};
+        }
+        return testDescriptions;
+    }
+    
+    async function getTestSuccessRates() {
+        if (Object.keys(testSuccessRates).length === 0) {
+            const data = await loadTestData();
+            testSuccessRates = data.test_success_rates || {};
+        }
+        return testSuccessRates;
+    }
+    
+    // Flag to prevent multiple simultaneous updates
+    let isUpdatingButtons = false;
+    
+    // Update success rate buttons with loaded data
+    async function updateSuccessRateButtons() {
+        // Prevent multiple simultaneous calls
+        if (isUpdatingButtons) {
+            return;
+        }
+        
+        isUpdatingButtons = true;
+        try {
+            const branch = "{{ branch }}";
+            const buttons = document.querySelectorAll('.success-rate-button');
+            
+            // If no buttons, nothing to update
+            if (buttons.length === 0) {
+                return;
+            }
+            
+            // If no data yet, load it once and then proceed
+            if (Object.keys(testSuccessRates).length === 0) {
+                await getTestSuccessRates().catch(() => {});
+            }
+        
+            let updatedCount = 0;
+            buttons.forEach(button => {
+                const testFullName = button.getAttribute('data-test-full-name');
+                if (!testFullName) {
+                    console.warn('Button missing data-test-full-name attribute');
+                    return;
+                }
+                
+                const rates = testSuccessRates[testFullName];
+                if (!rates) {
+                    // Don't log every missing test to avoid spam
+                    return;
+                }
+                
+                const rateText = button.querySelector('.success-rate-text');
+                if (!rateText) {
+                    console.warn('Button missing .success-rate-text element for test:', testFullName);
+                    return;
+                }
+                
+                let text = '';
+                if (rates.other) {
+                    text += branch.toUpperCase() + ':' + rates.other.rate + '%';
+                }
+                if (rates.other && rates.pr_check) {
+                    text += ' | ';
+                }
+                if (rates.pr_check) {
+                    text += 'PR:' + rates.pr_check.rate + '%';
+                }
+                
+                if (text) {
+                    rateText.textContent = text;
+                    updatedCount++;
+                }
+            });
+            // Only log if we actually updated something
+            if (updatedCount > 0) {
+                console.log('Updated', updatedCount, 'success rate buttons');
+            }
+        } finally {
+            isUpdatingButtons = false;
+        }
+    }
+    
+    async function showSuccessRateModal(testFullName) {
+        const modal = document.getElementById('successRateModal');
+        const modalTitle = document.getElementById('successRateModalTitle');
+        const modalContent = document.getElementById('successRateModalContent');
+        
+        // Load data asynchronously
+        const [history, rates] = await Promise.all([
+            getTestHistory(),
+            getTestSuccessRates()
+        ]);
+
+        // After data is loaded, also refresh buttons so the clicked one updates
+        updateSuccessRateButtons();
+        
+        if (!history || !history[testFullName] || !rates || !rates[testFullName]) {
+            modalTitle.textContent = `Success Rate: ${testFullName}`;
+            modalContent.innerHTML = '<div style="padding: 20px;"><p>No history data available for this test.</p><p>History is collected for the last 4 days for failed, error, and muted tests.</p></div>';
+            modal.style.display = 'block';
+            return;
+        }
+        
+        const testRates = rates[testFullName];
+        const testHistory = history[testFullName];
+        
+        // Build modal content
+        let html = '<div style="margin-bottom: 20px;">';
+        html += '<h3>Overall Success Rate (Last 4 Days)</h3>';
+        html += '<div style="display: flex; gap: 30px; margin: 15px 0;">';
+        if (testRates.other) {
+            html += `<div><strong>Branch Runs:</strong> ${testRates.other.rate}% (${testRates.other.passed}/${testRates.other.total})</div>`;
+        }
+        if (testRates.pr_check) {
+            html += `<div><strong>PR-Check:</strong> ${testRates.pr_check.rate}% (${testRates.pr_check.passed}/${testRates.pr_check.total})</div>`;
+        }
+        html += '</div></div>';
+        
+        // Group history by date and calculate daily success rates
+        const historyByDate = {};
+        for (const timestamp in testHistory) {
+            const entry = testHistory[timestamp];
+            if (!entry) continue;
+            
+            // Safely get date - handle both 'date' and 'datetime' fields
+            const dateStr = entry.date || entry.datetime || '';
+            if (!dateStr) continue;
+            
+            const date = dateStr.split(' ')[0]; // Get date part only
+            if (!date) continue;
+            
+            if (!historyByDate[date]) {
+                historyByDate[date] = {
+                    pr_check: { passed: 0, total: 0 },
+                    other: { passed: 0, total: 0 },
+                    entries: []
+                };
+            }
+            const isPrCheck = entry.job_name && (
+                entry.job_name.toLowerCase().includes('pr-check') ||
+                entry.job_name.toLowerCase().includes('pr_check') ||
+                entry.job_name.toLowerCase().includes('pr/check')
+            );
+            const group = isPrCheck ? 'pr_check' : 'other';
+            historyByDate[date][group].total++;
+            if (entry.status === 'passed') {
+                historyByDate[date][group].passed++;
+            }
+            historyByDate[date].entries.push({
+                timestamp: timestamp,
+                entry: entry
+            });
+        }
+        
+        // Sort dates (newest first)
+        const sortedDates = Object.keys(historyByDate).sort((a, b) => new Date(b) - new Date(a));
+        
+        html += '<h3>Daily History</h3>';
+        html += '<div class="sr-table-wrap"><table class="sr-table" style="width: 100%; border-collapse: collapse; margin-top: 15px;">';
+        html += '<thead><tr style="background-color: #f6f8fa; border-bottom: 2px solid #d0d7de;">';
+        html += '<th style="padding: 10px; text-align: left;">Date</th>';
+        const branch = "{{ branch }}";
+        html += `<th style="padding: 10px; text-align: center;">Success Rate Branch (${branch})</th>`;
+        html += `<th style="padding: 10px; text-align: left;">Runs in Branch (${branch})</th>`;
+        html += '<th style="padding: 10px; text-align: center;">Success Rate PR-Check</th>';
+        html += '<th style="padding: 10px; text-align: left;">Runs in PR-Check</th>';
+        html += '</tr></thead><tbody>';
+        
+        for (const date of sortedDates) {
+            const dayData = historyByDate[date];
+            const prRate = dayData.pr_check.total > 0 
+                ? ((dayData.pr_check.passed / dayData.pr_check.total) * 100).toFixed(1)
+                : '-';
+            const otherRate = dayData.other.total > 0
+                ? ((dayData.other.passed / dayData.other.total) * 100).toFixed(1)
+                : '-';
+            
+            // Sort entries by timestamp (newest first) and separate by type
+            dayData.entries.sort((a, b) => parseInt(b.timestamp) - parseInt(a.timestamp));
+            
+            // Separate entries by type
+            const prCheckEntries = dayData.entries.filter(({ entry }) => {
+                const jobName = entry.job_name || '';
+                return jobName.toLowerCase().includes('pr-check') ||
+                       jobName.toLowerCase().includes('pr_check') ||
+                       jobName.toLowerCase().includes('pr/check');
+            });
+            const otherEntries = dayData.entries.filter(({ entry }) => {
+                const jobName = entry.job_name || '';
+                return !jobName.toLowerCase().includes('pr-check') &&
+                       !jobName.toLowerCase().includes('pr_check') &&
+                       !jobName.toLowerCase().includes('pr/check');
+            });
+            
+            html += `<tr style="border-bottom: 1px solid #d0d7de;">`;
+            html += `<td style="padding: 10px;"><strong>${date}</strong></td>`;
+            
+            // Column 1: Success Rate Branch (main)
+            html += `<td style="padding: 10px; text-align: center;">${dayData.other.total > 0 ? `${otherRate}% (${dayData.other.passed}/${dayData.other.total})` : '-'}</td>`;
+            
+            // Column 2: Runs in Branch (main)
+            html += `<td style="padding: 10px;"><div class="sr-runs">`;
+            for (const { timestamp, entry } of otherEntries) {
+                if (!entry) continue;
+                const status = entry.status || 'unknown';
+                const date = entry.date || entry.datetime || '';
+                const jobName = entry.job_name || '';
+                const statusColor = status === 'passed' ? '#28a745' : 
+                                   status === 'failure' ? '#dc3545' : '#007bff';
+                const statusSymbol = status === 'passed' ? '\u2713' : 
+                                    status === 'failure' ? '\u2717' : '\u2298';
+                const tooltipText = `${status} - ${date} - ${jobName}`;
+                html += `<span style="cursor: pointer; padding: 4px 8px; border-radius: 3px; background-color: ${statusColor}; color: white; font-size: 11px;" `;
+                html += `onclick="showHistoryEntry('${testFullName}', '${timestamp}')" `;
+                html += `data-tooltip="${tooltipText.replace(/"/g, '&quot;')}" title="${tooltipText.replace(/"/g, '&quot;')}">`;
+                html += `${statusSymbol}</span>`;
+            }
+            html += '</div></td>';
+            
+            // Column 3: Success Rate PR-Check
+            html += `<td style="padding: 10px; text-align: center;">${dayData.pr_check.total > 0 ? `${prRate}% (${dayData.pr_check.passed}/${dayData.pr_check.total})` : '-'}</td>`;
+            
+            // Column 4: Runs in PR-Check
+            html += `<td style="padding: 10px;"><div class="sr-runs">`;
+            for (const { timestamp, entry } of prCheckEntries) {
+                if (!entry) continue;
+                const status = entry.status || 'unknown';
+                const date = entry.date || entry.datetime || '';
+                const jobName = entry.job_name || '';
+                const statusColor = status === 'passed' ? '#28a745' : 
+                                   status === 'failure' ? '#dc3545' : '#007bff';
+                const statusSymbol = status === 'passed' ? '\u2713' : 
+                                    status === 'failure' ? '\u2717' : '\u2298';
+                const tooltipText = `${status} - ${date} - ${jobName}`;
+                html += `<span style="cursor: pointer; padding: 4px 8px; border-radius: 3px; background-color: ${statusColor}; color: white; font-size: 11px;" `;
+                html += `onclick="showHistoryEntry('${testFullName}', '${timestamp}')" `;
+                html += `data-tooltip="${tooltipText.replace(/"/g, '&quot;')}" title="${tooltipText.replace(/"/g, '&quot;')}">`;
+                html += `${statusSymbol}</span>`;
+            }
+            html += '</div></td></tr>';
+        }
+        html += '</tbody></table>';
+        html += '</div>'; // sr-table-wrap
+        
+        modalTitle.textContent = `Success Rate: ${testFullName}`;
+        modalContent.innerHTML = html;
+        modal.style.display = 'block';
+    }
+    
+    async function showHistoryEntry(testName, timestamp) {
+        const history = await getTestHistory();
+        if (!history || !history[testName] || !history[testName][timestamp]) return;
+        
+        const entry = history[testName][timestamp];
+        const timestampStr = String(timestamp);
+        // Get error text from separate historyDescriptions object
+        const descs = await getHistoryDescriptions();
+        const errorText = descs[testName] && descs[testName][timestampStr] ? descs[testName][timestampStr] : '';
+        
+        // Find the test row to get log URLs
+        // Search for test name in all rows
+        const allRows = document.querySelectorAll('tbody tr');
+        let testRow = null;
+        for (const row of allRows) {
+            const testNameCell = row.querySelector('.test_name span');
+            if (testNameCell && testNameCell.textContent.trim() === testName) {
+                testRow = row;
+                break;
+            }
+        }
+        const logUrls = {};
+        if (testRow) {
+            const logCells = testRow.querySelectorAll('td:last-child a');
+            logCells.forEach(link => {
+                logUrls[link.textContent.trim()] = link.href;
+            });
+        }
+        
+        showTestInfo({
+            testName: testName,
+            status: entry.status || '',
+            date: entry.date || entry.datetime || '',
+            errorText: errorText,
+            commit: entry.commit || '',
+            job_name: entry.job_name || '',
+            job_id: entry.job_id || '',
+            logUrls: logUrls
+        });
+    }
+    
+    function closeSuccessRateModal() {
+        const modal = document.getElementById('successRateModal');
+        if (modal) {
                 modal.style.display = 'none';
             }
         }
+    
+    // Initialize success rate buttons on page load
+    document.addEventListener('DOMContentLoaded', function() {
+        updateSuccessRateButtons();
     });
     function toggleError(button) {
     const errorContent = button.nextElementSibling;
@@ -1067,9 +1657,7 @@
         <th>test owner</th>
         <th>test name</th>
     {% if status.is_error  and history%}
-        <th>history<br>
-            old->new
-        </th>
+        <th>Success rate</th>
     {% endif %}
         <th>elapsed</th>
         <th>status</th>
@@ -1181,36 +1769,14 @@
             </div>
             {% endif %}
         </td>
-        {% if (status.is_error and t.full_name in history) %}
+        {% if status.is_error %}
         <td>
-            {% for h in history[t.full_name] %}
-                <span class="svg-icon" 
-                      data-test-name="{{ t.full_name }}" 
-                      data-status="{{ history[t.full_name][h].status }}" 
-                      data-date="{{ history[t.full_name][h].datetime }}" 
-                      data-error="{{ history[t.full_name][h].status_description | e }}" 
-                      data-commit="{{ history[t.full_name][h].commit }}"
-                      data-job-name="{{ history[t.full_name][h].job_name }}[{{ history[t.full_name][h].branch}}:{{ build_preset }}]"
-                      data-job-id="{{ history[t.full_name][h].job_id }}">
-                    {% if history[t.full_name][h].status == 'failure' %}
-                    <svg class="svg_failure" viewBox="0 0 16 16" >
-                        <path  fill-rule="evenodd" d="M13.5 8a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0M6.53 5.47a.75.75 0 0 0-1.06 1.06L6.94 8 5.47 9.47a.75.75 0 1 0 1.06 1.06L8 9.06l1.47 1.47a.75.75 0 1 0 1.06-1.06L9.06 8l1.47-1.47a.75.75 0 1 0-1.06-1.06L8 6.94z" clip-rule="evenodd"></path>
-                    </svg>
-                    {% elif history[t.full_name][h].status == 'passed' %}
-                    <svg class="svg_passed" viewBox="0 0 16 16" >
-                        <path fill-rule="evenodd" d="M13.5 8a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0m-3.9-1.55a.75.75 0 1 0-1.2-.9L7.419 8.858 6.03 7.47a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.13-.08z" clip-rule="evenodd"></path>
-                    </svg>
-                    {% elif history[t.full_name][h].status == 'mute' %}
-                    <svg class="svg_mute" viewBox="0 0 17 16" >
-                        <path  fill-rule="evenodd" d="M5.06 9.94A1.5 1.5 0 0 0 4 9.5H2a.5.5 0 0 1-.5-.5V7a.5.5 0 0 1 .5-.5h2a1.5 1.5 0 0 0 1.06-.44l2.483-2.482a.268.268 0 0 1 .457.19v8.464a.268.268 0 0 1-.457.19zM2 5h2l2.482-2.482A1.768 1.768 0 0 1 9.5 3.768v8.464a1.768 1.768 0 0 1-3.018 1.25L4 11H2a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2m10.28.72a.75.75 0 1 0-1.06 1.06L12.44 8l-1.22 1.22a.75.75 0 1 0 1.06 1.06l1.22-1.22 1.22 1.22a.75.75 0 1 0 1.06-1.06L14.56 8l1.22-1.22a.75.75 0 0 0-1.06-1.06L13.5 6.94z" clip-rule="evenodd"></path>                    </svg>
-                    </svg>
+            {% if t.full_name in history %}
+            <button class="success-rate-button" data-test-full-name="{{ t.full_name|e }}" data-action="show-success-rate" title="View success rate and history">
+                <span class="emoji">&#128202;</span> <span class="success-rate-text">No history</span>
+            </button>
                     {% endif %}
-                </span>
-            {% endfor %}
         </td> 
-        {% elif (status.is_error and  history) %}
-        <td></td>
-        {% elif status.is_error %}
         {% endif %}
         <td><span title="{{ t.elapsed }}s">{{ t.elapsed_display }}</span></td>
         <td>
@@ -1233,6 +1799,17 @@
     </tbody>
 </table>
 {% endfor %}
+
+<!-- Модальное окно для success rate и детальной истории -->
+<div id="successRateModal" class="modal">
+    <div class="modal-content">
+        <span class="close-modal">&times;</span>
+        <div class="modal-header">
+            <h2 id="successRateModalTitle">Test Success Rate</h2>
+        </div>
+        <div id="successRateModalContent"></div>
+    </div>
+</div>
 
 <!-- Модальное окно для детального отображения ошибок -->
 <div id="errorModal" class="modal">

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -95,22 +95,6 @@
             border-radius: 3px;
             border-left: 3px solid #ff4500;
         }
-        .svg_passed {
-            fill: green;
-        }
-    
-        .svg_failure {
-            fill: red;
-        }
-    
-        .svg_skipped {
-            fill: gray;
-        }
-    
-        .svg_mute {
-            fill: blue;
-        }
-
         .issue-button {
             display: inline-block;
             background-color: #f6f8fa;
@@ -158,17 +142,6 @@
             vertical-align: middle;
         }
 
-        .svg-icon {
-            float: left;
-            width: 14px;
-            height: 14px;
-            padding-left: 1px;
-            padding-right: 1px;
-            margin-right: 0px;
-            border-radius: 50%;
-            position: relative; /* Essential for tooltips */
-            cursor: pointer;
-        }
         .button {
             display: inline-flex;
             align-items: center;

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -1215,12 +1215,12 @@
                 const successRateModal = document.getElementById('successRateModal');
                 
                 // Check which modal is currently visible (has display: block)
-                // Close only the one that is visible, prioritizing successRateModal if both are visible
-                // (successRateModal typically has higher z-index and is on top)
-                if (successRateModal && successRateModal.style.display === 'block') {
-                    successRateModal.style.display = 'none';
-                } else if (errorModal && errorModal.style.display === 'block') {
+                // Close only the one that is visible, prioritizing errorModal (test details) if both are visible
+                // errorModal (test details) is typically opened on top of successRateModal
+                if (errorModal && errorModal.style.display === 'block') {
                     errorModal.style.display = 'none';
+                } else if (successRateModal && successRateModal.style.display === 'block') {
+                    successRateModal.style.display = 'none';
                 }
             }
         });

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -126,7 +126,6 @@
             font-size: 11px;
             font-weight: 500;
             white-space: nowrap;
-            flex-shrink: 1;
             min-width: 0;
         }
         .success-rate-button:hover {
@@ -380,7 +379,7 @@
             overflow: auto;
         }
 
-        /* Стили для модального окна */
+        /* Modal window styles */
         #errorModal {
             display: none;
             position: fixed;
@@ -731,7 +730,7 @@
         
         // Report link (if available)
         if (reportUrl && reportUrl.trim() !== "") {
-            body += "**Test Report:** [View report](" + encodeURIComponent(reportUrl) + ")%0A%0A";
+            body += "**Test Report:** [View report](" + reportUrl + ")%0A%0A";
         }
         
         // Run command
@@ -866,7 +865,7 @@
         window.open(url, '_blank');
     }
 
-    // Функция для отображения информации о тесте в модальном окне
+    // Function to display test information in a modal window
     function showTestInfo(testInfo) {
         const modal = document.getElementById('errorModal');
         const modalTitle = document.getElementById('modalTitle');
@@ -876,21 +875,21 @@
         const modalJob = document.getElementById('modalJob');
         const modalErrorContent = document.getElementById('modalErrorContent');
 
-        // Заполняем информацию
+        // Fill in the information
         modalTitle.textContent = 'Test details: ' + testInfo.testName;
         modalStatus.textContent = testInfo.status;
         modalDate.textContent = testInfo.date;
         
-        // Обновляем ссылку на запуск
+        // Update the job run link
         const jobLink = document.getElementById('modalJobLink');
         jobLink.href = `https://github.com/ydb-platform/ydb/actions/runs/${testInfo.job_id}`;
         jobLink.textContent = testInfo.job_name;
-        // Обновляем ссылку на коммит
+        // Update the commit link
         const shaLink = document.getElementById('modalShaLink');
         shaLink.href = `https://github.com/ydb-platform/ydb//commit/${testInfo.commit}`;
         shaLink.textContent = testInfo.commit.substring(0, 8);
         
-        // Класс для статуса
+        // Status class
         modalStatus.className = '';
         if (testInfo.status === 'passed') {
             modalStatus.classList.add('test_pass');
@@ -900,15 +899,15 @@
             modalStatus.classList.add('test_mute');
         }
         
-        // Обработка текста ошибки
+        // Error text handling
         if (testInfo.errorText && testInfo.errorText.trim() !== "") {
             document.getElementById('modalErrorSection').style.display = 'block';
             modalErrorContent.textContent = testInfo.errorText;
             
-            // Определяем язык для подсветки синтаксиса
+            // Determine language for syntax highlighting
             modalErrorContent.className = 'language-' + (testInfo.testName.includes('.py') ? 'python' : 'cpp');
             
-            // Активируем подсветку синтаксиса
+            // Activate syntax highlighting
             if (typeof Prism !== 'undefined') {
                 Prism.highlightElement(modalErrorContent);
             }
@@ -916,7 +915,7 @@
             document.getElementById('modalErrorSection').style.display = 'none';
         }
         
-        // Показываем модальное окно
+        // Show the modal window
         modal.style.display = 'block';
     }
     
@@ -1135,7 +1134,7 @@
             toggleAllTables('collapse');
         });
         
-        // Обработчик для закрытия модальных окон
+        // Handler for closing modal windows
         document.querySelectorAll('.close-modal').forEach(closeBtn => {
             closeBtn.onclick = function(event) {
                 event.stopPropagation();
@@ -1154,7 +1153,7 @@
             };
         });
         
-        // Закрытие при клике вне модального окна
+        // Close on click outside the modal window
         window.onclick = function(event) {
             const errorModal = document.getElementById('errorModal');
             const successRateModal = document.getElementById('successRateModal');
@@ -1312,7 +1311,9 @@
             
             // If no data yet, load it once and then proceed
             if (Object.keys(testSuccessRates).length === 0) {
-                await getTestSuccessRates().catch(() => {});
+                await getTestSuccessRates().catch((e) => {
+                    console.warn('Failed to load success rates:', e);
+                });
             }
         
             let updatedCount = 0;
@@ -1382,7 +1383,7 @@
         }
         
         const testRates = rates[testFullName];
-        const testHistory = history[testFullName];
+        const historyEntries = history[testFullName];
         
         // Build modal content
         let html = '<div style="margin-bottom: 20px;">';
@@ -1398,8 +1399,8 @@
         
         // Group history by date and calculate daily success rates
         const historyByDate = {};
-        for (const timestamp in testHistory) {
-            const entry = testHistory[timestamp];
+        for (const timestamp in historyEntries) {
+            const entry = historyEntries[timestamp];
             if (!entry) continue;
             
             // Safely get date - handle both 'date' and 'datetime' fields
@@ -1571,9 +1572,9 @@
     function closeSuccessRateModal() {
         const modal = document.getElementById('successRateModal');
         if (modal) {
-                modal.style.display = 'none';
-            }
+            modal.style.display = 'none';
         }
+    }
     
     // Initialize success rate buttons on page load
     document.addEventListener('DOMContentLoaded', function() {
@@ -1749,7 +1750,7 @@
             </div>
             {% endif %}
         </td>
-        {% if status.is_error %}
+        {% if status.is_error and history %}
         <td>
             {% if t.full_name in history %}
             <button class="success-rate-button" data-test-full-name="{{ t.full_name|e }}" data-action="show-success-rate" title="View success rate and history">
@@ -1780,7 +1781,7 @@
 </table>
 {% endfor %}
 
-<!-- Модальное окно для success rate и детальной истории -->
+<!-- Modal window for success rate and detailed history -->
 <div id="successRateModal" class="modal">
     <div class="modal-content">
         <span class="close-modal">&times;</span>
@@ -1791,7 +1792,7 @@
     </div>
 </div>
 
-<!-- Модальное окно для детального отображения ошибок -->
+<!-- Modal window for detailed error display -->
 <div id="errorModal" class="modal">
     <div class="modal-content">
         <span class="close-modal">&times;</span>

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -1615,6 +1615,7 @@
 {% for status in status_order %}
 {% set sanitizer_count = tests[status] | selectattr('is_sanitizer_issue') | list | length %}
 {% set timeout_count = tests[status] | selectattr('is_timeout_issue') | list | length %}
+{% set not_launched_count = tests[status] | selectattr('is_not_launched') | list | length %}
 <h1 id="{{ status.name}}" class="collapsible-header">
     {{ status.name }} ({{ tests[status] | length }})
     {% if sanitizer_count > 0 %}
@@ -1622,6 +1623,9 @@
     {% endif %}
     {% if timeout_count > 0 %}
         <span style="color: #ff8c00; font-weight: bold;">- {{ timeout_count }} TIMEOUT ISSUE{{ 's' if timeout_count != 1 else '' }}</span>
+    {% endif %}
+    {% if not_launched_count > 0 %}
+        <span style="color: #6c757d; font-weight: bold;">- {{ not_launched_count }} NOT LAUNCHED ISSUE{{ 's' if not_launched_count != 1 else '' }}</span>
     {% endif %}
 </h1>
 <table class="collapsible-content active" border="1">
@@ -1659,6 +1663,9 @@
             {% endif %}
             {% if t.is_timeout_issue %}
                 <span style="background-color: #ff8c00; color: white; padding: 2px 6px; border-radius: 12px; font-size: 11px; margin-left: 8px; font-weight: bold;">TIMEOUT</span>
+            {% endif %}
+            {% if t.is_not_launched %}
+                <span style="background-color: #6c757d; color: white; padding: 2px 6px; border-radius: 12px; font-size: 11px; margin-left: 8px; font-weight: bold;">NOT LAUNCHED</span>
             {% endif %}
             {% if status.is_error %}
             <div class="button-group">

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -302,6 +302,22 @@
         table > tbody > tr > td:nth-child(4) {
             text-align: left;
         }
+        
+        /* Status column styling */
+        th.status-column,
+        td.status-column {
+            width: 60px;
+            min-width: 50px;
+            max-width: 60px;
+            text-align: center;
+        }
+        
+        /* Ensure status text is centered */
+        td.status-column span.test_status {
+            display: inline-block;
+            width: 100%;
+            text-align: center;
+        }
     
         .collapsible-content {
             display: table-row-group;
@@ -469,6 +485,10 @@
         #successRateModal .modal-header {
             flex-shrink: 0;
         }
+        #successRateModalTitle {
+            font-size: 14px;
+            word-break: break-word;
+        }
         #successRateModalContent {
             overflow-y: auto;
             overflow-x: hidden;
@@ -614,7 +634,9 @@
 
     // Utility functions
     function buildGitHubIssueUrl(title, body, labels) {
-        return GITHUB_ISSUE_BASE_URL + "?title=" + title + "&body=" + body + "&labels=" + labels + "&type=Bug";
+        // Body is already partially encoded (contains %0A for newlines, etc.)
+        // Title and labels need to be encoded, but body is already encoded
+        return GITHUB_ISSUE_BASE_URL + "?title=" + encodeURIComponent(title) + "&body=" + body + "&labels=" + encodeURIComponent(labels) + "&type=Bug";
     }
 
     // Show tooltip stub to avoid runtime errors (visual feedback provided by icon swap)
@@ -708,7 +730,7 @@
         return labels.join(',');
     }
 
-    function buildIssueBody(issueType, path, testName, buildPreset, branch, commitSha, testRunCommand, owner, success_count, fail_count, logUrls, errorText, reportUrl) {
+    function buildIssueBody(issueType, path, testName, buildPreset, branch, commitSha, testRunCommand, owner, successRates, logUrls, errorText, reportUrl) {
         let body = encodeURIComponent(path) + "/" + encodeURIComponent(testName) + "%0A%0A";
         
         // Add type-specific header
@@ -729,8 +751,14 @@
         body += "- Branch: " + encodeURIComponent(branch) + "%0A%0A";
         
         // Report link (if available)
+        // Always include report link if reportUrl is provided, even if it's a local file:// URL
         if (reportUrl && reportUrl.trim() !== "") {
-            body += "**Test Report:** [View report](" + reportUrl + ")%0A%0A";
+            // Encode the URL part of the markdown link to prevent special characters (like #) from breaking the link
+            // when the body is used as a URL parameter. This matches the pattern used for other URLs in the body.
+            body += "**Test Report:** [View report](" + encodeURIComponent(reportUrl) + ")%0A%0A";
+        } else {
+            // Log warning if reportUrl is missing
+            console.warn('reportUrl is empty or undefined in buildIssueBody, Test Report link will not be included');
         }
         
         // Run command
@@ -739,12 +767,20 @@
         // Owner
         body += "**Owner:** [TEAM:@ydb-platform/" + owner + "](https://github.com/orgs/ydb-platform/teams/" + owner + ")%0A%0A";
         
-        // Summary history (only for non-sanitizer issues)
-        if (issueType !== 'sanitizer') {
-            if (success_count + fail_count != 0) {
-                body += "**Summary history:**%0A Success rate **" + (success_count/(success_count+fail_count)*100) + "%25**%0APass:" + success_count + " Fail:" + fail_count + "%0A%0A";
+        // Success rate (for all issue types)
+        if (successRates) {
+            body += "**Success rate (last 4 days):**%0A";
+            const parts = [];
+            if (successRates.other) {
+                parts.push(branch.toUpperCase() + ": " + successRates.other.rate + "%25 (" + successRates.other.passed + "/" + successRates.other.total + ")");
+            }
+            if (successRates.pr_check) {
+                parts.push("PR-Check: " + successRates.pr_check.rate + "%25 (" + successRates.pr_check.passed + "/" + successRates.pr_check.total + ")");
+            }
+            if (parts.length > 0) {
+                body += parts.join(" | ") + "%0A%0A";
             } else {
-                body += "**Summary history:**%0APass:" + success_count + " Fail:" + fail_count + "%0A%0A";
+                body += "No history data available%0A%0A";
             }
         }
         
@@ -774,7 +810,7 @@
         if (errorText && errorText.trim() !== "") {
             const errorPrefix = "**Error Summary:**%0A```%0A";
             const errorSuffix = "%0A```%0A%0A";
-            const truncationMsg = "%0A<TRUNCATED>";
+            const tooLongMsg = "**Error Summary:**%0A```%0A_Error text is too long to include automatically. Please copy the error text from the test report and paste it here manually._%0A```%0A%0A";
             
             const fullErrorText = errorText.trim();
             const encodedFullError = encodeURIComponent(fullErrorText);
@@ -782,28 +818,29 @@
             // Compute minimal overhead URL length (without error content)
             const minimalSection = errorPrefix + errorSuffix;
             const minimalUrl = buildGitHubIssueUrl(title, body + minimalSection, labels);
-            if (minimalUrl.length > maxUrlLength) {
-                // Can't include error section at all
-            } else {
+            
+            // Check if we can add the full error text
+            if (minimalUrl.length <= maxUrlLength) {
                 const allowedDelta = maxUrlLength - minimalUrl.length;
                 if (encodedFullError.length <= allowedDelta) {
+                    // Error text fits, include it fully
                     body += errorPrefix + encodedFullError + errorSuffix;
-                } else {
-                    const allowedForEncoded = allowedDelta - truncationMsg.length;
-                    if (allowedForEncoded > 0) {
-                        const truncatedEncoded = safeTruncateEncoded(encodedFullError, allowedForEncoded);
-                        if (truncatedEncoded) {
-                            body += errorPrefix + truncatedEncoded + truncationMsg + errorSuffix;
-                        }
-                    }
+                    return body;
                 }
             }
+            
+            // Error text doesn't fit or minimal section doesn't fit - try to add message instead
+            const urlWithMsg = buildGitHubIssueUrl(title, body + tooLongMsg, labels);
+            if (urlWithMsg.length <= maxUrlLength) {
+                body += tooLongMsg;
+            }
+            // If even the message doesn't fit, we skip it entirely
         }
         
         return body;
     }
 
-    function createIssueGeneric(issueType, test, owner, success_count, fail_count, is_sanitizer, errorText, logUrls = {}) {
+    function createIssueGeneric(issueType, test, owner, successRates, is_sanitizer, errorText, logUrls = {}) {
         const parsed = parseTestName(test);
         if (!parsed) return;
         
@@ -819,6 +856,11 @@
         // Get report URL - use current page URL (the report page itself)
         const reportUrl = window.location.href;
         
+        // Log warning if reportUrl is empty (shouldn't happen in normal browser context)
+        if (!reportUrl || reportUrl.trim() === "") {
+            console.warn('Warning: reportUrl is empty, Test Report link will not be included');
+        }
+        
         // Determine issue type based on parameters
         let actualIssueType = issueType;
         if (is_sanitizer && issueType === 'bug') {
@@ -826,17 +868,18 @@
         }
         
         // Create title based on issue type
+        // Don't encode here - encoding will be done in buildGitHubIssueUrl
         let title;
         if (actualIssueType === 'sanitizer') {
-            title = "Sanitizer error in " + encodeURIComponent(path) + "/" + encodeURIComponent(testName);
+            title = "Sanitizer error in " + path + "/" + testName;
         } else if (actualIssueType === 'mute') {
-            title = "Mute test " + encodeURIComponent(path) + "/" + encodeURIComponent(testName);
+            title = "Mute test " + path + "/" + testName;
         } else {
-            title = "Test failure in " + encodeURIComponent(path) + "/" + encodeURIComponent(testName);
+            title = "Test failure in " + path + "/" + testName;
         }
         
         // Build body
-        const body = buildIssueBody(actualIssueType, path, testName, buildPreset, branch, commitSha, testRunCommand, owner, success_count, fail_count, logUrls, errorText, reportUrl);
+        const body = buildIssueBody(actualIssueType, path, testName, buildPreset, branch, commitSha, testRunCommand, owner, successRates, logUrls, errorText, reportUrl);
         
         // Build labels
         const labels = buildLabels(actualIssueType, buildPreset, ownerAreaLabel);
@@ -849,12 +892,12 @@
         window.open(finalUrl, '_blank');
     }
 
-    function createIssue(test, owner, success_count, fail_count, is_sanitizer, errorText, logUrls = {}) {
-        createIssueGeneric('bug', test, owner, success_count, fail_count, is_sanitizer, errorText, logUrls);
+    function createIssue(test, owner, successRates, is_sanitizer, errorText, logUrls = {}) {
+        createIssueGeneric('bug', test, owner, successRates, is_sanitizer, errorText, logUrls);
     }
 
-    function createMuteIssue(test, owner, success_count, fail_count, errorText = '', logUrls = {}) {
-        createIssueGeneric('mute', test, owner, success_count, fail_count, false, errorText, logUrls);
+    function createMuteIssue(test, owner, successRates, errorText = '', logUrls = {}) {
+        createIssueGeneric('mute', test, owner, successRates, false, errorText, logUrls);
     }
 
     function openHistory(test) {
@@ -1021,20 +1064,17 @@
                 const testName = testRow.querySelector('.test_name').querySelector('span').innerText;
                 const owner = testRow.querySelector('.test_owner').innerText;
                 
-                // Get success/fail counts from history if available
-                let success_count = 0;
-                let fail_count = 0;
+                // Get success rates from testSuccessRates (same data used for the button)
+                let successRates = null;
                 try {
-                    const history = await getTestHistory();
-                    if (history && history[testName]) {
-                        for (const timestamp in history[testName]) {
-                            const status = history[testName][timestamp].status;
-                            if (status === 'passed') success_count++;
-                            else if (status === 'failure' || status === 'mute') fail_count++;
-                        }
+                    if (Object.keys(testSuccessRates).length === 0) {
+                        await getTestSuccessRates().catch((e) => {
+                            console.warn('Failed to load success rates for issue creation:', e);
+                        });
                     }
+                    successRates = testSuccessRates[testName] || null;
                 } catch (e) {
-                    console.warn('Failed to load history for issue creation:', e);
+                    console.warn('Failed to load success rates for issue creation:', e);
                 }
                 
                 // Check if this is a sanitizer issue by looking for the SANITIZER badge
@@ -1052,16 +1092,19 @@
                 
                 // Extract log URLs from the test row
                 let logUrls = {};
-                const logCells = testRow.querySelectorAll('td:last-child a');
-                logCells.forEach(link => {
-                    const logName = link.textContent.trim();
-                    const logUrl = link.href;
-                    if (logName && logUrl) {
-                        logUrls[logName] = logUrl;
-                    }
-                });
+                const logCell = testRow.querySelector('td.log-column');
+                if (logCell) {
+                    const logLinks = logCell.querySelectorAll('a');
+                    logLinks.forEach(link => {
+                        const logName = link.textContent.trim();
+                        const logUrl = link.href;
+                        if (logName && logUrl) {
+                            logUrls[logName] = logUrl;
+                        }
+                    });
+                }
 
-                createIssue(testName, owner, success_count, fail_count, is_sanitizer, errorText, logUrls);
+                createIssue(testName, owner, successRates, is_sanitizer, errorText, logUrls);
             });
         });
         
@@ -1073,20 +1116,17 @@
                 const testName = testRow.querySelector('.test_name').querySelector('span').innerText;
                 const owner = testRow.querySelector('.test_owner').innerText;
                 
-                // Get success/fail counts from history if available
-                let success_count = 0;
-                let fail_count = 0;
+                // Get success rates from testSuccessRates (same data used for the button)
+                let successRates = null;
                 try {
-                    const history = await getTestHistory();
-                    if (history && history[testName]) {
-                        for (const timestamp in history[testName]) {
-                            const status = history[testName][timestamp].status;
-                            if (status === 'passed') success_count++;
-                            else if (status === 'failure' || status === 'mute') fail_count++;
-                        }
+                    if (Object.keys(testSuccessRates).length === 0) {
+                        await getTestSuccessRates().catch((e) => {
+                            console.warn('Failed to load success rates for issue creation:', e);
+                        });
                     }
+                    successRates = testSuccessRates[testName] || null;
                 } catch (e) {
-                    console.warn('Failed to load history for issue creation:', e);
+                    console.warn('Failed to load success rates for issue creation:', e);
                 }
                 
                 // Get error text from the test description if available
@@ -1101,16 +1141,19 @@
                 
                 // Extract log URLs from the test row
                 let logUrls = {};
-                const logCells = testRow.querySelectorAll('td:last-child a');
-                logCells.forEach(link => {
-                    const logName = link.textContent.trim();
-                    const logUrl = link.href;
-                    if (logName && logUrl) {
-                        logUrls[logName] = logUrl;
-                    }
-                });
+                const logCell = testRow.querySelector('td.log-column');
+                if (logCell) {
+                    const logLinks = logCell.querySelectorAll('a');
+                    logLinks.forEach(link => {
+                        const logName = link.textContent.trim();
+                        const logUrl = link.href;
+                        if (logName && logUrl) {
+                            logUrls[logName] = logUrl;
+                        }
+                    });
+                }
 
-                createMuteIssue(testName, owner, success_count, fail_count, errorText, logUrls);
+                createMuteIssue(testName, owner, successRates, errorText, logUrls);
             });
         });
 
@@ -1165,16 +1208,19 @@
             }
         }
         
-        // Close modals on Escape key
+        // Close modals on Escape key - close only the topmost (last opened) modal
         document.addEventListener('keydown', function(event) {
             if (event.key === 'Escape' || event.keyCode === 27) {
                 const errorModal = document.getElementById('errorModal');
                 const successRateModal = document.getElementById('successRateModal');
-                if (errorModal && errorModal.style.display === 'block') {
-                    errorModal.style.display = 'none';
-                }
+                
+                // Check which modal is currently visible (has display: block)
+                // Close only the one that is visible, prioritizing successRateModal if both are visible
+                // (successRateModal typically has higher z-index and is on top)
                 if (successRateModal && successRateModal.style.display === 'block') {
                     successRateModal.style.display = 'none';
+                } else if (errorModal && errorModal.style.display === 'block') {
+                    errorModal.style.display = 'none';
                 }
             }
         });
@@ -1551,10 +1597,13 @@
         }
         const logUrls = {};
         if (testRow) {
-            const logCells = testRow.querySelectorAll('td:last-child a');
-            logCells.forEach(link => {
-                logUrls[link.textContent.trim()] = link.href;
-            });
+            const logCell = testRow.querySelector('td.log-column');
+            if (logCell) {
+                const logLinks = logCell.querySelectorAll('a');
+                logLinks.forEach(link => {
+                    logUrls[link.textContent.trim()] = link.href;
+                });
+            }
         }
         
         showTestInfo({
@@ -1638,7 +1687,7 @@
         <th>Success rate</th>
     {% endif %}
         <th>elapsed</th>
-        <th>status</th>
+        <th class="status-column">status</th>
     {% if status in has_any_log %}
         <th>LOG</th>
     {% endif %}
@@ -1754,17 +1803,17 @@
         <td>
             {% if t.full_name in history %}
             <button class="success-rate-button" data-test-full-name="{{ t.full_name|e }}" data-action="show-success-rate" title="View success rate and history">
-                <span class="emoji">&#128202;</span> <span class="success-rate-text">No history</span>
+                <span class="success-rate-text">No history</span>
             </button>
                     {% endif %}
         </td> 
         {% endif %}
         <td><span title="{{ t.elapsed }}s">{{ t.elapsed_display }}</span></td>
-        <td>
+        <td class="status-column">
             <span class="test_status test_{{ t.status_display }}">{{ t.status_display }}</span>
         </td>
         {% if status in has_any_log %}
-        <td>
+        <td class="log-column">
             {% if t.log_urls %}
                 {% for log_name, log_url in t.log_urls.items() %}
                 <a href="{{ log_url }}">{{ log_name }}</a>{% if not loop.last %} | {% endif %}


### PR DESCRIPTION
Added success rate reporting for tests in the test summary report, displaying overall success rates over the last 4 days, separated by PR-check and regular branch runs, with interactive daily history views.

This PR introduces a new feature to display test success rates in the GitHub Actions test summary reports. Key changes:

- **Success Rate Calculation**: Added logic to compute and display success rates for failed/error/muted tests over the last 4 days, separating PR-check runs from regular branch runs.
- **Interactive UI**: Replaced static history icons with clickable success rate buttons that open detailed modals showing:
  - Overall success rates (PR-check vs. branch runs)
  - Daily breakdown with individual run statuses and clickable entries for full details
- **Performance Optimization**: Moved large data structures (history, descriptions, success rates) to a separate JSON file to reduce HTML size and improve load times.
- **Data Source Changes**: Modified test history querying to use time-based (4 days) instead of run-count-based limits for more consistent reporting.
- **Enhanced Modal**: Added a new success rate modal with sortable daily tables, tooltips, and integrated error details.

The feature helps developers quickly assess test stability and identify patterns in failures across different run types. No breaking changes to existing functionality.


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->



