### PR TITLE
Prepare tests to use DQ Channels 2.0 by default

### DIFF
--- a/ydb/core/kqp/ut/arrow/kqp_result_set_formats_ut.cpp
+++ b/ydb/core/kqp/ut/arrow/kqp_result_set_formats_ut.cpp
@@ -27,6 +27,8 @@ TKikimrRunner CreateKikimrRunner(bool withSampleTables, ui64 channelBufferSize =
     NKikimrConfig::TAppConfig appConfig;
     appConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
     appConfig.MutableTableServiceConfig()->MutableResourceManager()->SetChannelBufferSize(channelBufferSize);
+    appConfig.MutableTableServiceConfig()->MutableResourceManager()->SetMinChannelBufferSize(std::min(2_KB, channelBufferSize));
+    appConfig.MutableTableServiceConfig()->MutableResourceManager()->SetChannelChunkSizeLimit(channelBufferSize);
 
     auto settings = TKikimrSettings(appConfig).SetFeatureFlags(featureFlags).SetWithSampleTables(withSampleTables);
     return TKikimrRunner(settings);
@@ -1851,7 +1853,7 @@ R"(column0:   -- is_valid: all not null
             UNIT_ASSERT_VALUES_EQUAL(batch->num_columns(), 1);
             UNIT_ASSERT_C(batch->column(0)->type()->id() == arrow::Type::LIST, "Column type must be arrow::Type::LIST");
 
-            const TString expected = 
+            const TString expected =
 R"(column0:   [
     -- is_valid: all not null
     -- child 0 type: binary

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -81,7 +81,7 @@ public:
         EnsureNotInitialized("AppConfig");
 
         auto& result = AppConfig.emplace();
-        result.MutableTableServiceConfig()->SetEnableFastChannels(false);
+        result.MutableTableServiceConfig()->SetDqChannelVersion(1u);
         return result;
     }
 
@@ -121,7 +121,7 @@ public:
             queryServiceConfig.SetEnableMatchRecognize(true);
 
             auto& tableServiceConfig = *AppConfig->MutableTableServiceConfig();
-            tableServiceConfig.SetEnableFastChannels(false);
+            tableServiceConfig.SetDqChannelVersion(1u);
 
             LogSettings
                 .AddLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NLog::PRI_DEBUG)

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -80,7 +80,9 @@ public:
         UNIT_ASSERT_C(!AppConfig, "AppConfig is already initialized");
         EnsureNotInitialized("AppConfig");
 
-        return AppConfig.emplace();
+        auto& result = AppConfig.emplace();
+        result.MutableTableServiceConfig()->SetEnableFastChannels(false);
+        return result;
     }
 
     TIntrusivePtr<IMockPqGateway> SetupMockPqGateway() {
@@ -117,6 +119,9 @@ public:
 
             auto& queryServiceConfig = *AppConfig->MutableQueryServiceConfig();
             queryServiceConfig.SetEnableMatchRecognize(true);
+
+            auto& tableServiceConfig = *AppConfig->MutableTableServiceConfig();
+            tableServiceConfig.SetEnableFastChannels(false);
 
             LogSettings
                 .AddLogPriority(NKikimrServices::STREAMS_STORAGE_SERVICE, NLog::PRI_DEBUG)

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -2420,7 +2420,11 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
         runtime->SetObserverFunc(captureEvents);
         auto streamSender = runtime->AllocateEdgeActor();
-        NDataShard::NKqpHelpers::SendRequest(*runtime, streamSender, NDataShard::NKqpHelpers::MakeStreamRequest(streamSender, "SELECT * FROM `/Root/selectStore/selectTable` LIMIT 1;", false));
+        NDataShard::NKqpHelpers::SendRequest(*runtime, streamSender,
+            NDataShard::NKqpHelpers::MakeStreamRequest(streamSender, R"(
+                pragma ydb.UseFastChannels = "false";
+                SELECT * FROM `/Root/selectStore/selectTable` LIMIT 1;
+            )", false));
         auto ev = runtime->GrabEdgeEventRethrow<NKqp::TEvKqp::TEvQueryResponse>(streamSender);
         UNIT_ASSERT_VALUES_EQUAL(result, 1);
     }

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -2422,7 +2422,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         auto streamSender = runtime->AllocateEdgeActor();
         NDataShard::NKqpHelpers::SendRequest(*runtime, streamSender,
             NDataShard::NKqpHelpers::MakeStreamRequest(streamSender, R"(
-                pragma ydb.UseFastChannels = "false";
+                pragma ydb.DqChannelVersion = "1";
                 SELECT * FROM `/Root/selectStore/selectTable` LIMIT 1;
             )", false));
         auto ev = runtime->GrabEdgeEventRethrow<NKqp::TEvKqp::TEvQueryResponse>(streamSender);

--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -3562,7 +3562,7 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
         {
             auto result = kikimr.RunCall([&] {
                 return db.ExecuteQuery(R"(
-                    pragma ydb.UseFastChannels = "false";
+                    pragma ydb.DqChannelVersion = "1";
                     DISCARD SELECT COUNT(*) FROM `/Root/TwoShard`;
                 )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             });
@@ -3580,7 +3580,7 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
 
             auto result = kikimr.RunCall([&] {
                 return db.ExecuteQuery(R"(
-                    pragma ydb.UseFastChannels = "false";
+                    pragma ydb.DqChannelVersion = "1";
                     SELECT COUNT(*) FROM `/Root/TwoShard`;
                 )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             });

--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -3498,7 +3498,7 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
 
         auto failingEnsureQuery = std::vector{R"(
             DISCARD SELECT Ensure(Data, Data > 1000000, "some error message") AS value
-            FROM `/Root/EightShard`)", 
+            FROM `/Root/EightShard`)",
             R"(DISCARD SELECT Ensure(r2, r2 > 100, "some error message") AS final
                 FROM (SELECT Ensure(r1, r1 IS NOT NULL, "ok") AS r2
                 FROM (SELECT Ensure(1, true, "ok") AS r1) AS t1) AS t2;)"
@@ -3542,9 +3542,9 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
             }
             if (ev->GetTypeRewrite() == NYql::NDq::TEvDqCompute::TEvChannelData::EventType) {
                 auto& record = ev->Get<NYql::NDq::TEvDqCompute::TEvChannelData>()->Record;
-                    Cerr << "ChannelData event detected, channelId: " << record.GetChannelData().GetChannelId() 
+                    Cerr << "ChannelData event detected, channelId: " << record.GetChannelData().GetChannelId()
                         << ", sender: " << ev->Sender << ", recipient: " << ev->Recipient << Endl;
-                    
+
                     if (executerIdCaptured && ev->Recipient == executerId) {
                         ++channelDataCount;
                         Cerr << "ChannelData sent to Executer! Count: " << channelDataCount << Endl;
@@ -3554,7 +3554,7 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
             return TTestActorRuntime::EEventAction::PROCESS;
         };
         runtime.SetObserverFunc(observer);
-        
+
         Y_DEFER {
             runtime.SetObserverFunc(TTestActorRuntime::DefaultObserverFunc);
         };
@@ -3562,6 +3562,7 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
         {
             auto result = kikimr.RunCall([&] {
                 return db.ExecuteQuery(R"(
+                    pragma ydb.UseFastChannels = "false";
                     DISCARD SELECT COUNT(*) FROM `/Root/TwoShard`;
                 )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             });
@@ -3570,7 +3571,7 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetResultSets().size(), 0,
                 "DISCARD SELECT should return no result sets");
 
-            UNIT_ASSERT_VALUES_EQUAL_C(channelDataCount, 0, 
+            UNIT_ASSERT_VALUES_EQUAL_C(channelDataCount, 0,
                 "ChannelData should not be sent when DISCARD is used, count: " << channelDataCount);
         }
         {
@@ -3579,13 +3580,14 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
 
             auto result = kikimr.RunCall([&] {
                 return db.ExecuteQuery(R"(
+                    pragma ydb.UseFastChannels = "false";
                     SELECT COUNT(*) FROM `/Root/TwoShard`;
                 )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             });
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
             UNIT_ASSERT(result.GetResultSets().size() > 0);
 
-            UNIT_ASSERT_C(channelDataCount > 0, 
+            UNIT_ASSERT_C(channelDataCount > 0,
                 "ChannelDataCount for SELECT: " << channelDataCount);
         }
     }
@@ -3593,10 +3595,10 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
     Y_UNIT_TEST(DiscardSelectMultiLine) {
         auto kikimr = CreateKikimrWithDiscardSelect();
         auto db = kikimr.GetQueryClient();
-        
+
         auto verifyResultValue = [](auto& result, ui32 resultSetIndex, i32 expectedValue) {
             TResultSetParser parser(result.GetResultSet(resultSetIndex));
-            UNIT_ASSERT_C(parser.TryNextRow(), 
+            UNIT_ASSERT_C(parser.TryNextRow(),
                 "Failed to get row from result set " << resultSetIndex);
             UNIT_ASSERT_VALUES_EQUAL_C(parser.ColumnParser(0).GetInt32(), expectedValue,
                 "Result set " << resultSetIndex << " has wrong value");
@@ -3608,7 +3610,7 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
 
         ExecuteQueryAndCheckResultSets(db, R"(
             SELECT 1;
-            DISCARD SELECT Ensure(Data, Data < 1000000, "Data value too large") 
+            DISCARD SELECT Ensure(Data, Data < 1000000, "Data value too large")
                 FROM `/Root/EightShard`;
             SELECT 2
         )", 2, "DISCARD with Ensure");
@@ -3652,8 +3654,8 @@ Y_UNIT_TEST_SUITE(KqpQueryDiscard) {
             )", 2, "Data Executor only");
         }
         {
-            auto result = ExecuteQueryAndCheckResultSets(db, R"(SELECT 1; DISCARD SELECT 2; SELECT 3; 
-                                                                DISCARD SELECT 4; SELECT 5; DISCARD SELECT 6; 
+            auto result = ExecuteQueryAndCheckResultSets(db, R"(SELECT 1; DISCARD SELECT 2; SELECT 3;
+                                                                DISCARD SELECT 4; SELECT 5; DISCARD SELECT 6;
                                                                 SELECT 7)", 4, "Many transactions (> 2)");
             auto resultValues = std::vector{1, 3, 5, 7};
             for (auto&& [i, value] : Enumerate(resultValues)) {

--- a/ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp
+++ b/ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp
@@ -176,6 +176,7 @@ Y_UNIT_TEST(SelfJoinQueryService) {
     auto query = R"(
         --!syntax_v1
         PRAGMA ydb.CostBasedOptimizationLevel='0';
+        PRAGMA ydb.UseFastChannels='false';
         select t1.Key, t1.Value, t2.Key, t2.Value
         from `/Root/KeyValue` as t1 join `/Root/KeyValue` as t2 on t1.Value = t2.Value
         order by t1.Key
@@ -237,6 +238,7 @@ Y_UNIT_TEST(SelfJoin) {
     auto query = R"(
         --!syntax_v1
         PRAGMA ydb.CostBasedOptimizationLevel='0';
+        PRAGMA ydb.UseFastChannels='false';
         select t1.Key, t1.Value, t2.Key, t2.Value
         from `/Root/KeyValue` as t1 join `/Root/KeyValue` as t2 on t1.Key = t2.Key
         order by t1.Key

--- a/ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp
+++ b/ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp
@@ -176,7 +176,7 @@ Y_UNIT_TEST(SelfJoinQueryService) {
     auto query = R"(
         --!syntax_v1
         PRAGMA ydb.CostBasedOptimizationLevel='0';
-        PRAGMA ydb.UseFastChannels='false';
+        PRAGMA ydb.DqChannelVersion='1';
         select t1.Key, t1.Value, t2.Key, t2.Value
         from `/Root/KeyValue` as t1 join `/Root/KeyValue` as t2 on t1.Value = t2.Value
         order by t1.Key
@@ -238,7 +238,7 @@ Y_UNIT_TEST(SelfJoin) {
     auto query = R"(
         --!syntax_v1
         PRAGMA ydb.CostBasedOptimizationLevel='0';
-        PRAGMA ydb.UseFastChannels='false';
+        PRAGMA ydb.DqChannelVersion='1';
         select t1.Key, t1.Value, t2.Key, t2.Value
         from `/Root/KeyValue` as t1 join `/Root/KeyValue` as t2 on t1.Key = t2.Key
         order by t1.Key

--- a/ydb/core/kqp/ut/scan/kqp_flowcontrol_ut.cpp
+++ b/ydb/core/kqp/ut/scan/kqp_flowcontrol_ut.cpp
@@ -77,6 +77,8 @@ void DoFlowControlTest(ui64 limit, bool hasBlockedByCapacity) {
     settings.CollectQueryStats(ECollectQueryStatsMode::Profile);
 
     auto it = db.StreamExecuteScanQuery(R"(
+            pragma ydb.UseFastChannels = "false";
+
             $r = (select * from `/Root/FourShard` where Key > 201);
 
             SELECT l.Key as key, l.Text as text, r.Value1 as value

--- a/ydb/core/kqp/ut/scan/kqp_flowcontrol_ut.cpp
+++ b/ydb/core/kqp/ut/scan/kqp_flowcontrol_ut.cpp
@@ -77,7 +77,7 @@ void DoFlowControlTest(ui64 limit, bool hasBlockedByCapacity) {
     settings.CollectQueryStats(ECollectQueryStatsMode::Profile);
 
     auto it = db.StreamExecuteScanQuery(R"(
-            pragma ydb.UseFastChannels = "false";
+            pragma ydb.DqChannelVersion = "1";
 
             $r = (select * from `/Root/FourShard` where Key > 201);
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12187,7 +12187,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         config.MutableFeatureFlags()->SetEnableStreamingQueries(enableStreamingQueries);
         config.MutableFeatureFlags()->SetEnableExternalDataSources(true);
         config.MutableFeatureFlags()->SetEnableResourcePools(true);
-        config.MutableTableServiceConfig()->SetEnableFastChannels(false);
+        config.MutableTableServiceConfig()->SetDqChannelVersion(1u);
 
         auto kikimr = std::make_unique<TKikimrRunner>(NKqp::TKikimrSettings(config)
             .SetEnableStreamingQueries(enableStreamingQueries)

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12187,6 +12187,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         config.MutableFeatureFlags()->SetEnableStreamingQueries(enableStreamingQueries);
         config.MutableFeatureFlags()->SetEnableExternalDataSources(true);
         config.MutableFeatureFlags()->SetEnableResourcePools(true);
+        config.MutableTableServiceConfig()->SetEnableFastChannels(false);
 
         auto kikimr = std::make_unique<TKikimrRunner>(NKqp::TKikimrSettings(config)
             .SetEnableStreamingQueries(enableStreamingQueries)

--- a/ydb/core/kqp/ut/service/kqp_qs_queries_ut.cpp
+++ b/ydb/core/kqp/ut/service/kqp_qs_queries_ut.cpp
@@ -1004,7 +1004,7 @@ Y_UNIT_TEST_SUITE(KqpQueryService) {
             auto [totalRows, totalBatches] = CalcRowsAndBatches(it);
 
             UNIT_ASSERT_VALUES_EQUAL(totalRows, 100);
-            UNIT_ASSERT_VALUES_EQUAL(totalBatches, 100);
+            UNIT_ASSERT_GE_C(totalBatches, 100, "At least 100 batches are expected"); // ignore final empty batch, if any
         }
 
         auto settings = TExecuteQuerySettings().OutputChunkMaxSize(10000);

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -266,7 +266,7 @@ private:
         queryServiceConfig.SetProgressStatsPeriodMs(1000);
 
         auto& tableServiceConfig = *appConfig.MutableTableServiceConfig();
-        tableServiceConfig.SetEnableFastChannels(false);
+        tableServiceConfig.SetDqChannelVersion(1u);
 
         appConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
         return appConfig;

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -265,6 +265,9 @@ private:
         queryServiceConfig.SetAllExternalDataSourcesAreAvailable(true);
         queryServiceConfig.SetProgressStatsPeriodMs(1000);
 
+        auto& tableServiceConfig = *appConfig.MutableTableServiceConfig();
+        tableServiceConfig.SetEnableFastChannels(false);
+
         appConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
         return appConfig;
     }

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -458,7 +458,7 @@ message TTableServiceConfig {
     optional uint64 RemoteChannelInflightBytes = 112 [default = 16777216];
     optional uint64 NodeSessionIcInflightBytes = 113 [default = 67108864];
 
-    optional uint32 DqChannelVersion = 114 [ default = 2, (InvalidateCompileCache) = true];
+    optional uint32 DqChannelVersion = 114 [ default = 1, (InvalidateCompileCache) = true];
 
     optional bool EnableDiscardSelect = 115 [default = false, (InvalidateCompileCache) = true];
 

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -458,7 +458,7 @@ message TTableServiceConfig {
     optional uint64 RemoteChannelInflightBytes = 112 [default = 16777216];
     optional uint64 NodeSessionIcInflightBytes = 113 [default = 67108864];
 
-    optional uint32 DqChannelVersion = 114 [ default = 1, (InvalidateCompileCache) = true];
+    optional uint32 DqChannelVersion = 114 [ default = 2, (InvalidateCompileCache) = true];
 
     optional bool EnableDiscardSelect = 115 [default = false, (InvalidateCompileCache) = true];
 

--- a/ydb/tests/fq/streaming/conftest.py
+++ b/ydb/tests/fq/streaming/conftest.py
@@ -34,7 +34,7 @@ def kikimr(request):
             },
             table_service_config={
                 "enable_watermarks": enable_watermarks,
-                "enable_fast_channels": False,
+                "dq_channel_version": 1,
             },
             default_clusteradmin="root@builtin",
             use_in_memory_pdisks=False,

--- a/ydb/tests/fq/streaming/conftest.py
+++ b/ydb/tests/fq/streaming/conftest.py
@@ -34,6 +34,7 @@ def kikimr(request):
             },
             table_service_config={
                 "enable_watermarks": enable_watermarks,
+                "enable_fast_channels": False,
             },
             default_clusteradmin="root@builtin",
             use_in_memory_pdisks=False,

--- a/ydb/tests/stress/streaming/tests/test_workload.py
+++ b/ydb/tests/stress/streaming/tests/test_workload.py
@@ -24,6 +24,9 @@ class TestYdbWorkload(StressFixture):
                 'FQ_ROW_DISPATCHER': LogLevels.TRACE,
                 'KQP_PROXY': LogLevels.DEBUG,
                 'KQP_EXECUTOR': LogLevels.DEBUG},
+            table_service_config={
+                "enable_fast_channels": False
+            },
         )
 
     def test(self):

--- a/ydb/tests/stress/streaming/tests/test_workload.py
+++ b/ydb/tests/stress/streaming/tests/test_workload.py
@@ -25,7 +25,7 @@ class TestYdbWorkload(StressFixture):
                 'KQP_PROXY': LogLevels.DEBUG,
                 'KQP_EXECUTOR': LogLevels.DEBUG},
             table_service_config={
-                "enable_fast_channels": False
+                "dq_channel_version": 1
             },
         )
 


### PR DESCRIPTION
#23704

Following tests are explicitly forced to use old (v1) channels:

1. Streaming tests should use channels v1 until CP/WM is supported by v2
- [ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp](/ydb-platform/ydb/blob/main/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp#L83) and [this](/ydb-platform/ydb/blob/main/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp#L121)
- [ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp](/ydb-platform/ydb/blob/main/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp#L12190) -- KqpScheme::StreamingQueriesAclValidation etc.
- [ydb/tests/fq/streaming/conftest.py](/ydb-platform/ydb/blob/main/ydb/tests/fq/streaming/conftest.py#L37)
- [ydb/tests/stress/streaming/tests/test_workload.py](/ydb-platform/ydb/blob/main/ydb/tests/stress/streaming/tests/test_workload.py#L27)

2. These tests rely on legacy TEvChannelData message
- [ydb/core/kqp/ut/olap/kqp_olap_ut.cpp ](/ydb-platform/ydb/blob/main/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp#L2423)-- KqpOlap::SelectLimit1ManyShards
- [ydb/core/kqp/ut/query/kqp_query_ut.cpp](/ydb-platform/ydb/blob/main/ydb/core/kqp/ut/query/kqp_query_ut.cpp#L3565) -- KqpQueryDiscard::NoChannelDataEventsWhenDiscard

3. Next tests use specific for v1 flow control control features
- ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp -- [KqpScanSpilling::SelfJoin](/ydb-platform/ydb/blob/main/ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp#L179), [KqpScanSpilling::SelfJoinQueryService](/ydb-platform/ydb/blob/main/ydb/core/kqp/ut/runtime/kqp_scan_spilling_ut.cpp#L241)
- [ydb/core/kqp/ut/scan/kqp_flowcontrol_ut.cpp](/ydb-platform/ydb/blob/main/ydb/core/kqp/ut/scan/kqp_flowcontrol_ut.cpp#L79) -- KqpFlowControl*

4. There is clash on use EvResumeExecution message with WM
- [ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp](/ydb-platform/ydb/blob/main/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp#L268)