### PR TITLE
Add lock statistics to KQP query metrics COMMIT

### DIFF
--- a/ydb/core/kqp/common/kqp_tx.h
+++ b/ydb/core/kqp/common/kqp_tx.h
@@ -220,9 +220,15 @@ public:
         LastAccessTime = TInstant::Now();
     }
 
-    void OnBeginQuery() {
+    void OnBeginQuery(const TString& queryText = "") {
         ++QueriesCount;
         BeginQueryTime = TInstant::Now();
+        if (!queryText.empty()) {
+            // Only add if it's different from the previous query to avoid duplicates
+            if (QueryTexts.empty() || QueryTexts.back() != queryText) {
+                QueryTexts.push_back(queryText);
+            }
+        }
     }
 
     void OnEndQuery() {
@@ -242,6 +248,7 @@ public:
         HasTableWrite = false;
         HasTableRead = false;
         NeedUncommittedChangesFlush = false;
+        QueryTexts.clear();
     }
 
     TKqpTransactionInfo GetInfo() const;
@@ -345,6 +352,7 @@ public:
     TDuration QueriesDuration;
     ui32 QueriesCount = 0;
     ui32 ExecutorId = 0;
+    TVector<TString> QueryTexts;
 
     TKqpTxLocks Locks;
 

--- a/ydb/core/sys_view/service/sysview_service.cpp
+++ b/ydb/core/sys_view/service/sysview_service.cpp
@@ -923,6 +923,12 @@ private:
             }
         }
 
+        // Skip COMMIT queries for top queries system views
+        // They should only appear in 'query_metrics_one_minute'
+        if (stats->GetQueryText().StartsWith("COMMIT")) {
+            return;
+        }
+
         // gather old style stats while migrating
         // TODO: remove later
         TopByDuration1Minute->Add(stats);
@@ -1046,6 +1052,11 @@ private:
 
         void Add(TQueryStatsPtr stats) {
             Metrics.Collect.Add(stats);
+            // Skip COMMIT queries for top queries system views - they should only appear in query_metrics_one_minute
+            if (stats->GetQueryText().StartsWith("COMMIT")) {
+                return;
+            }
+
             TopByDuration.Collect.Add(stats);
             TopByReadBytes.Collect.Add(stats);
             TopByCpuTime.Collect.Add(stats);

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -4472,6 +4472,155 @@ R"(CREATE TABLE `test_show_create` (
         UNIT_ASSERT_VALUES_EQUAL(locksBrokenAsBreaker, 1u);
         UNIT_ASSERT_VALUES_EQUAL(locksBrokenAsVictim, 1u);
     }
+
+    Y_UNIT_TEST_TWIN(QueryMetricsLocksBrokenSeparateCommit, UseSink) {
+        TTestEnvSettings settings;
+        settings.EnableSVP = true;
+        settings.TableServiceConfig.SetEnableOltpSink(UseSink);
+        TTestEnv env(1, 2, settings);
+        CreateTenant(env, "Tenant1", true);
+
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(env.GetEndpoint())
+            .SetDiscoveryMode(EDiscoveryMode::Off)
+            .SetDatabase("/Root/Tenant1");
+        auto driver = TDriver(driverConfig);
+
+        TTableClient client(driver);
+        auto session = client.CreateSession().GetValueSync().GetSession();
+        auto victimSession = client.CreateSession().GetValueSync().GetSession();
+
+        // Create table and insert initial data
+        NKqp::AssertSuccessResult(session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/Tenant1/TableLocks` (
+                Key Uint64,
+                Value String,
+                PRIMARY KEY (Key)
+            );
+        )").GetValueSync());
+
+        NKqp::AssertSuccessResult(session.ExecuteDataQuery(
+            "UPSERT INTO `/Root/Tenant1/TableLocks` (Key, Value) VALUES (1u, \"Initial\")",
+            TTxControl::BeginTx().CommitTx()
+        ).GetValueSync());
+
+        // Establish locks by reading in a transaction (victim)
+        std::optional<TTransaction> victimTx;
+        while (!victimTx) {
+            auto result = victimSession.ExecuteDataQuery(
+                "SELECT * FROM `/Root/Tenant1/TableLocks` WHERE Key = 1u /* victim-query */",
+                TTxControl::BeginTx()
+            ).ExtractValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == EStatus::SUCCESS, result.GetIssues().ToString());
+
+            TString yson = FormatResultSetYson(result.GetResultSet(0));
+            if (yson == "[]") {
+                continue;  // Data not visible yet, retry
+            }
+
+            victimTx = result.GetTransaction();
+            UNIT_ASSERT(victimTx);
+        }
+
+        // Breaker transaction: writes to key 1 and makes an empty final commit using separate operations
+        std::optional<TTransaction> breakerTx;
+        {
+            auto result = session.ExecuteDataQuery(
+                "UPSERT INTO `/Root/Tenant1/TableLocks` (Key, Value) VALUES (1u, \"BreakerValue\") /* lock-breaker */",
+                TTxControl::BeginTx()
+            ).ExtractValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == EStatus::SUCCESS, result.GetIssues().ToString());
+            breakerTx = result.GetTransaction();
+            UNIT_ASSERT(breakerTx);
+        }
+
+        // (Optional) Non-breaker query: writes to key 2
+        {
+            auto result = session.ExecuteDataQuery(
+                "UPSERT INTO `/Root/Tenant1/TableLocks` (Key, Value) VALUES (2u, \"UsualValue\") /* non-breaker */",
+                TTxControl::Tx(*breakerTx)
+            ).ExtractValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // Separate COMMIT should break the lock
+        {
+            auto result = breakerTx->Commit().ExtractValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // Victim tries to commit with write to the same key
+        // This triggers lock validation, which fails because the lock on key 1 was broken
+        auto victimCommitResult = victimSession.ExecuteDataQuery(
+            "UPSERT INTO `/Root/Tenant1/TableLocks` (Key, Value) VALUES (1u, \"VictimValue\") /* victim-commit */",
+            TTxControl::Tx(*victimTx).CommitTx()
+        ).ExtractValueSync();
+
+        // Victim should be ABORTED because its locks were broken
+        UNIT_ASSERT_VALUES_EQUAL(victimCommitResult.GetStatus(), EStatus::ABORTED);
+
+        // Wait for stats to be collected and check both LocksBrokenAsBreaker and LocksBrokenAsVictim
+        ui64 locksBrokenAsBreaker = 0;
+        ui64 locksBrokenAsVictim = 0;
+        bool foundBreaker = false;
+        bool foundVictim = false;
+
+        for (size_t iter = 0; iter < 30 && (!foundBreaker || !foundVictim); ++iter) {
+            // Query both breaker and victim metrics in one pass
+            auto it = client.StreamExecuteScanQuery(R"(
+                SELECT QueryText, LocksBrokenAsBreaker, LocksBrokenAsVictim
+                FROM `/Root/Tenant1/.sys/query_metrics_one_minute`
+                WHERE QueryText = 'COMMIT' OR QueryText LIKE '%victim-commit%';
+            )").GetValueSync();
+
+            UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
+            TString ysonString = NKqp::StreamResultToYson(it);
+            Cerr << "Query metrics result: " << ysonString << Endl;
+
+            auto node = NYT::NodeFromYsonString(ysonString, ::NYson::EYsonType::Node);
+            UNIT_ASSERT(node.IsList());
+
+            for (const auto& row : node.AsList()) {
+                if (!row.IsList() || row.AsList().size() < 3) continue;
+
+                auto getStringValue = [](const NYT::TNode& n) -> TString {
+                    if (n.IsList() && !n.AsList().empty()) {
+                        return n.AsList()[0].AsString();
+                    }
+                    return n.AsString();
+                };
+                auto getUint64Value = [](const NYT::TNode& n) -> ui64 {
+                    if (n.IsList() && !n.AsList().empty()) {
+                        return n.AsList()[0].AsUint64();
+                    }
+                    return n.AsUint64();
+                };
+
+                TString queryText = getStringValue(row.AsList()[0]);
+                ui64 breaker = getUint64Value(row.AsList()[1]);
+                ui64 victim = getUint64Value(row.AsList()[2]);
+
+                if (queryText == "COMMIT") {
+                    locksBrokenAsBreaker = breaker;
+                    foundBreaker = true;
+                }
+                if (queryText.Contains("victim-commit") && !queryText.Contains("query_metrics")) {
+                    locksBrokenAsVictim = victim;
+                    foundVictim = true;
+                }
+            }
+
+            if (!foundBreaker || !foundVictim) {
+                Sleep(TDuration::Seconds(10));
+            }
+        }
+
+        UNIT_ASSERT_C(foundBreaker, "Breaker not found in metrics");
+        UNIT_ASSERT_C(foundVictim, "Victim not found in metrics");
+
+        UNIT_ASSERT_VALUES_EQUAL(locksBrokenAsBreaker, 1u);
+        UNIT_ASSERT_VALUES_EQUAL(locksBrokenAsVictim, 1u);
+    }
 }
 
 Y_UNIT_TEST_SUITE(ShowCreateView) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

If the final COMMIT in an interactive transaction causes another locks to be broken, a COMMIT row should be added to the `.sys/query_metrics_one_minute` system view, with the `LocksBrokenAsBreaker` field populated.

Continuation of #30268

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->


