### PR TITLE
schemeshard: reject splits early on in-flight limit

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -528,12 +528,18 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
     const TTableIndexInfo* index = Self->Indexes.Value(pathElement->ParentPathId, nullptr).Get();
     const TTableInfo* mainTableForIndex = (index ? Self->GetMainTableForIndex(pathId) : nullptr);
 
-    TString errStr;
+    // Save CPU resources when potential merge will certainly be immediately rejected by Self->IgniteOperation()
+    // and potential split will probably be rejected later.
+    TString inflightLimitErrStr;
+    if (!Self->CheckInFlightLimit(TTxState::ETxType::TxSplitTablePartition, inflightLimitErrStr)) {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Do not consider split-merge: " << inflightLimitErrStr);
+        return true;
+    }
+
     const auto forceShardSplitSettings = Self->SplitSettings.GetForceShardSplitSettings();
     TVector<TShardIdx> shardsToMerge;
     TString mergeReason;
     if ((!index || index->State == NKikimrSchemeOp::EIndexStateReady)
-        && Self->CheckInFlightLimit(TTxState::ETxType::TxSplitTablePartition, errStr)
         && table->CheckCanMergePartitions(Self->SplitSettings, forceShardSplitSettings, shardIdx, Self->ShardInfos[shardIdx].TabletID, shardsToMerge, mainTableForIndex, now, mergeReason)
     ) {
         TTxId txId = Self->GetCachedTxId(ctx);


### PR DESCRIPTION
Avoid wasting CPU on splits that will certainly (or likely) be rejected due to exceeding the split-merge in-flight limit.

Schemeshard already does this for potential merges.

For potential splits, the in-flight limit is currently checked only when `TSplitMerge` operation starts. By then, Schemeshard has already spent significant CPU time:
- (Point A) Checking conditions, requesting histograms
- (Point B) Rechecking conditions, processing histograms
- Only then starting `TSplitMerge`

This PR adds in-flight limit checks at points A and B:
- Point B (`TTxPartitionHistogram::Execute()`) -- avoid CPU waste on splits guaranteed to be rejected
- Point A (`PersistSingleStats()`) -- avoid CPU waste on splits likely to be rejected later at point B