### PR TITLE
fix typo in storage resources

### DIFF
--- a/ydb/core/mind/hive/storage_group_info.h
+++ b/ydb/core/mind/hive/storage_group_info.h
@@ -24,13 +24,13 @@ struct TStorageResources {
 
     void Add(const TLeaderTabletInfo::TChannel& channel) {
         IOPS += channel.ChannelInfo->GetIOPS();
-        Throughput += channel.ChannelInfo->GetIOPS();
+        Throughput += channel.ChannelInfo->GetThroughput();
         Size += channel.ChannelInfo->GetSize();
     }
 
     void Subtract(const TLeaderTabletInfo::TChannel& channel) {
         IOPS -= channel.ChannelInfo->GetIOPS();
-        Throughput -= channel.ChannelInfo->GetIOPS();
+        Throughput -= channel.ChannelInfo->GetThroughput();
         Size -= channel.ChannelInfo->GetSize();
     }
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

:skull: :skull: :skull: 
Обнаружил потрясающее, пробуя крутить некоторые настройки вместе с dorooleg. По факту конечно ничего не толком не меняет, потому что увы у нас все метрики на allocation unit-ах друг другу пропорциональны, но очень печальная история.

Также выяснено, что настройка опции DefaultUnitIOPS через ui хайва домножает значение на 100. Из-за криво написанной обработки совместимости с версиями 20-5 и младше. 
