### PR TITLE
YQ-4950 support advanced storage settings in kqprun

### DIFF
--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -394,7 +394,7 @@ def retry_query_with_endpoints(query, endpoints, request_type, query_name, max_r
             if isinstance(e, urllib.error.URLError):
                 bad_hosts.add(endpoint.host_with_port)
             if not connection_params.quiet:
-                print(f'WARNING: failed to fetch data from host {endpoint.host_with_port} in {query_name}: {e}', file=sys.stderr)
+                print(f'WARNING: failed to fetch data from host {endpoint.host_with_port} in {query_name}: {e} ({type(e).__module__}.{type(e).__name__})', file=sys.stderr)
                 if request_type == 'http' and try_index == max_retries:
                     print('HINT: consider trying different protocol for endpoints when experiencing massive fetch failures from different hosts', file=sys.stderr)
             if try_index == max_retries:

--- a/ydb/core/testlib/basics/helpers.h
+++ b/ydb/core/testlib/basics/helpers.h
@@ -23,6 +23,7 @@ namespace NFake {
         ui64 DiskSize = 0;
         bool FormatDisk = true;
         TString DiskPath;
+        std::optional<TDuration> EventDispatchTimeout;
     };
 
     struct INode {

--- a/ydb/core/testlib/basics/services.cpp
+++ b/ydb/core/testlib/basics/services.cpp
@@ -435,7 +435,7 @@ namespace NKikimr {
                             NFake::INode* factory, NFake::TStorage storage, const NSharedCache::TSharedCacheConfig* sharedCacheConfig, bool forceFollowers,
                             TVector<TIntrusivePtr<NFake::TProxyDS>> dsProxies)
     {
-        runtime.SetDispatchTimeout(storage.UseDisk ? DISK_DISPATCH_TIMEOUT : DEFAULT_DISPATCH_TIMEOUT);
+        runtime.SetDispatchTimeout(storage.UseDisk ? storage.EventDispatchTimeout.value_or(DISK_DISPATCH_TIMEOUT) : DEFAULT_DISPATCH_TIMEOUT);
 
         bool addGroups = dsProxies.empty();
         TTestStorageFactory disk(runtime, storage, mock, addGroups);

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1016,11 +1016,7 @@ namespace Tests {
 
         auto bsConfigureRequest = MakeHolder<TEvBlobStorage::TEvControllerConfigRequest>();
 
-        NKikimrBlobStorage::TDefineBox boxConfig;
-        boxConfig.SetBoxId(Settings->BOX_ID);
-        boxConfig.SetItemConfigGeneration(boxConfigGeneration);
-
-        NKikimrBlobStorage::TDefineHostConfig hostConfig;
+        auto& hostConfig = *bsConfigureRequest->Record.MutableRequest()->AddCommand()->MutableDefineHostConfig();
         hostConfig.SetHostConfigId(nodeId);
         hostConfig.SetItemConfigGeneration(hostConfigGeneration);
         TString path;
@@ -1032,15 +1028,16 @@ namespace Tests {
         }
         hostConfig.AddDrive()->SetPath(path);
         if (Settings->Verbose) {
-            Cerr << "test_client.cpp: SetPath # " << path << Endl;
+            Cerr << "test_client.cpp: SetPath for PDisk # " << path << Endl;
         }
-        bsConfigureRequest->Record.MutableRequest()->AddCommand()->MutableDefineHostConfig()->CopyFrom(hostConfig);
 
+        auto& boxConfig = *bsConfigureRequest->Record.MutableRequest()->AddCommand()->MutableDefineBox();
+        boxConfig.SetBoxId(Settings->BOX_ID);
+        boxConfig.SetItemConfigGeneration(boxConfigGeneration);
         auto& host = *boxConfig.AddHost();
         host.MutableKey()->SetFqdn(nodeInfo.Host);
         host.MutableKey()->SetIcPort(nodeInfo.Port);
         host.SetHostConfigId(hostConfig.GetHostConfigId());
-        bsConfigureRequest->Record.MutableRequest()->AddCommand()->MutableDefineBox()->CopyFrom(boxConfig);
 
         for (const auto& [poolKind, storagePool] : Settings->StoragePoolTypes) {
             if (storagePool.GetNumGroups() > 0) {

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -891,7 +891,7 @@ protected:
 
         // Cluster settings
 
-        options.AddLongOption('N', "node-count", "Number of nodes to create and optionally number of storage groups e. g. -N 10:2 for 2 storage groups and 10 nodes (-N <number of nodes>[:<number of storage groups>])")
+        options.AddLongOption('N', "node-count", "Number of nodes to create and optionally number of storage groups e. g. -N 10:2 for 10 nodes and 2 storage groups (-N <number of nodes>[:<number of storage groups>])")
             .RequiredArgument("uint[:uint]")
             .Handler1([this](const NLastGetopt::TOptsParser* option) {
                 TStringBuf nodesCount;

--- a/ydb/tests/tools/kqprun/runlib/application.cpp
+++ b/ydb/tests/tools/kqprun/runlib/application.cpp
@@ -182,7 +182,10 @@ TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> TMainBase::CreateFunc
 
     auto paths = UdfsPaths;
     NKikimr::NMiniKQL::FindUdfsInDir(UdfsDirectory, &paths);
+
+    const auto previousHandler = std::signal(SIGINT, SIG_DFL);
     auto functionRegistry = NKikimr::NMiniKQL::CreateFunctionRegistry(&PrintBackTrace, NKikimr::NMiniKQL::CreateBuiltinRegistry(), false, paths)->Clone();
+    std::signal(SIGINT, previousHandler); // Preserve default signal handler after udfs load
 
     if (ExcludeLinkedUdfs) {
         for (const auto& wrapper : NYql::NUdf::GetStaticUdfModuleWrapperList()) {

--- a/ydb/tests/tools/kqprun/runlib/application.cpp
+++ b/ydb/tests/tools/kqprun/runlib/application.cpp
@@ -185,7 +185,7 @@ TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> TMainBase::CreateFunc
 
     const auto previousHandler = std::signal(SIGINT, SIG_DFL);
     auto functionRegistry = NKikimr::NMiniKQL::CreateFunctionRegistry(&PrintBackTrace, NKikimr::NMiniKQL::CreateBuiltinRegistry(), false, paths)->Clone();
-    std::signal(SIGINT, previousHandler); // Preserve default signal handler after udfs load
+    std::signal(SIGINT, previousHandler); // Restore previous signal handler after udfs load
 
     if (ExcludeLinkedUdfs) {
         for (const auto& wrapper : NYql::NUdf::GetStaticUdfModuleWrapperList()) {

--- a/ydb/tests/tools/kqprun/runlib/kikimr_setup.cpp
+++ b/ydb/tests/tools/kqprun/runlib/kikimr_setup.cpp
@@ -73,7 +73,6 @@ NKikimr::Tests::TServerSettings TKikimrSetupBase::GetServerSettings(const TServe
     const ui32 msgBusPort = PortManager.GetPort();
 
     NKikimr::Tests::TServerSettings serverSettings(msgBusPort, settings.AppConfig.GetAuthConfig(), settings.AppConfig.GetPQConfig());
-    serverSettings.SetNodeCount(settings.NodeCount);
 
     serverSettings.SetDomainName(TString(NKikimr::ExtractDomain(NKikimr::CanonizePath(settings.DomainName))));
     serverSettings.SetAppConfig(settings.AppConfig);

--- a/ydb/tests/tools/kqprun/runlib/settings.h
+++ b/ydb/tests/tools/kqprun/runlib/settings.h
@@ -24,7 +24,8 @@ struct TAsyncQueriesSettings {
 };
 
 struct TServerSettings {
-    ui32 NodeCount = 1;
+    ui32 NodeCount = 0;
+    ui32 StorageGroupCount = 0;
     TString DomainName = "Root";
 
     bool MonitoringEnabled = false;

--- a/ydb/tests/tools/kqprun/src/proto/storage_meta.proto
+++ b/ydb/tests/tools/kqprun/src/proto/storage_meta.proto
@@ -12,6 +12,7 @@ message TStorageMeta {
 
         EType Type = 1;
         uint32 NodesCount = 2;
+        uint32 StorageGroupsCount = 5;
         string SharedTenant = 3;  // Only for serverless tenants
         bool CreationInProgress = 4;
     }
@@ -19,5 +20,7 @@ message TStorageMeta {
     uint64 StorageGeneration = 1;  // Deprecated (currently not used)
     uint64 StorageSize = 2;
     string DomainName = 3;
+    uint32 NodesCount = 5;
+    uint32 StorageGroupsCount = 6;
     map<string, TTenant> Tenants = 4;
 }

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -296,10 +296,11 @@ private:
         Y_ENSURE(freeSlots >= tenantsToDistribute);
 
         const auto extractSlots = [&freeSlots, &tenantsToDistribute]() {
+            Y_ENSURE(tenantsToDistribute > 0);
             auto slots = freeSlots / tenantsToDistribute;
             freeSlots -= slots;
             tenantsToDistribute--;
-            Y_ENSURE(tenantsToDistribute >= 0 && freeSlots >= tenantsToDistribute);
+            Y_ENSURE(freeSlots >= tenantsToDistribute);
             return slots;
         };
 
@@ -307,6 +308,7 @@ private:
             if (Settings_.Tenants.empty()) {
                 Settings_.StorageGroupCount = extractSlots();
             } else {
+                Y_ENSURE(tenantsToDistribute > 0);
                 Settings_.StorageGroupCount = 1;
                 freeSlots--;
                 tenantsToDistribute--;

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -188,7 +188,8 @@ private:
             .ChunkSize = Settings_.PDisksPath ? NKikimr::TTestStorageFactory::CHUNK_SIZE : NKikimr::TTestStorageFactory::MEM_CHUNK_SIZE,
             .DiskSize = Settings_.DiskSize ? *Settings_.DiskSize : 32_GB,
             .FormatDisk = formatDisk,
-            .DiskPath = storagePath
+            .DiskPath = storagePath,
+            .EventDispatchTimeout = TDuration::Max()
         };
 
         serverSettings.SetEnableMockOnSingleNode(!Settings_.DisableDiskMock && !Settings_.PDisksPath);
@@ -351,13 +352,12 @@ private:
         NKikimr::Tests::TServerSettings serverSettings = GetServerSettings(domainGrpcPort);
 
         Server_ = MakeIntrusive<TKqprunServer>(serverSettings);
+        Server_->GetRuntime()->SetDispatchTimeout(TDuration::Max());
         Server_->Initialize();
 
         if (serverSettings.CustomDiskParams.UseDisk) {
             SetupStorageFileHolder(serverSettings.CustomDiskParams.DiskPath);
         }
-
-        Server_->GetRuntime()->SetDispatchTimeout(TDuration::Max());
 
         if (Settings_.GrpcEnabled) {
             Server_->EnableGRpc(GetGrpcSettings(domainGrpcPort, 0));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported advanced storage settings in kqprun

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Fixed error printing for DS tool
- Fixed event dispatch timeout during storage init
- Fixed UB on storage flush in signal handler
- Fixed kqprun interrupt hanging with Python udf
- Supported tunable number of storage groups per tenant (by default all 15 free slots distributed between created tenants)

