### PR TITLE
[25-3] Fix empty vector index build with overlapping clusters due to incorrect IsEmpty tracking

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -2538,7 +2538,11 @@ struct TSchemeShard::TIndexBuilder::TTxReplyLocalKMeans: public TTxShardReply<TE
     }
 
     void HandleDone(NIceDb::TNiceDb& db, TIndexBuildInfo& buildInfo) {
-        if (Response->Get()->Record.GetIsEmpty()) {
+        if (Response->Get()->Record.GetIsEmpty() &&
+            buildInfo.KMeans.Parent == 0)
+        {
+            // We only handle the root level through MultiLocal if the table has exactly 1 shard.
+            // If that shard is empty then it means the whole index is empty.
             buildInfo.KMeans.IsEmpty = true;
             Self->PersistBuildIndexKMeansState(db, buildInfo);
         }


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Cherry-pick of #31040