### PR TITLE
25-2: schemeshard: cpu usage opt 2

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1970,7 +1970,7 @@ message TSchemeShardConfig {
         // to disable set to 0
         optional uint32 InFlightLimit = 2 [default = 10000];
     }
-    // after this amount of time we forcely write full stats to local DB
+    // after this amount of time we forcibly write full stats to local DB
     // to disable set to 0
     optional uint32 StatsBatchTimeoutMs = 1 [default = 100];
 
@@ -1988,6 +1988,11 @@ message TSchemeShardConfig {
     // number of shards per table
     // 0 means default - NKikimrIndexBuilder.TIndexBuildSettings.max_shards_in_flight
     optional uint32 MaxRestoreBuildIndexShardsInFlight = 6 [default = 1000];
+
+    // number of shards per table
+    // database level default for TTL mechanics
+    // 0 means no limit
+    optional uint32 MaxTTLShardsInFlight = 7 [default = 0];
 }
 
 message TCompactionConfig {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -220,7 +220,7 @@ message TTTLSettings {
         optional uint32 BatchMaxBytes = 3 [default = 512000];
         optional uint32 BatchMinKeys = 4 [default = 1];
         optional uint32 BatchMaxKeys = 5 [default = 256];
-        optional uint32 MaxShardsInFlight = 6 [default = 1000]; // zero means no limit
+        optional uint32 MaxShardsInFlight = 6 [default = 0]; // zero means no limit
     }
 
     message TEvictionToExternalStorageSettings {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -220,7 +220,7 @@ message TTTLSettings {
         optional uint32 BatchMaxBytes = 3 [default = 512000];
         optional uint32 BatchMinKeys = 4 [default = 1];
         optional uint32 BatchMaxKeys = 5 [default = 256];
-        optional uint32 MaxShardsInFlight = 6 [default = 0]; // zero means no limit
+        optional uint32 MaxShardsInFlight = 6 [default = 1000]; // zero means no limit
     }
 
     message TEvictionToExternalStorageSettings {

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
@@ -78,7 +78,12 @@ struct TSchemeShard::TTxRunConditionalErase: public TSchemeShard::TRwTxBase {
             return;
         }
 
-        const auto maxInFlight = tableInfo->TTLSettings().GetEnabled().GetSysSettings().GetMaxShardsInFlight();
+        // table-level MaxShardsInFlight overrides database-level MaxTTLShardsInFlight
+        const auto& sysSettings = tableInfo->TTLSettings().GetEnabled().GetSysSettings();
+        const auto maxInFlight = (sysSettings.HasMaxShardsInFlight()
+            ? sysSettings.GetMaxShardsInFlight()
+            : Self->MaxTTLShardsInFlight
+        );
 
         while (true) {
             if (maxInFlight && tableInfo->GetInFlightCondErase().size() >= maxInFlight) {

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -491,9 +491,8 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
     }
 
     //NOTE: intentionally avoid using TPath.Check().{PathShardsLimit,ShardsLimit}() here.
-    // PathShardsLimit() performs pedantic validation by recalculating shard count through
-    // iteration over entire ShardInfos, which is too slow for this hot spot. It also performs
-    // additional lookups we want to avoid.
+    // PathShardsLimit() no longer performs full shard count validation by iterating all ShardInfos
+    // (too slow for this hot path), but still does additional lookups we want to avoid.
     {
         constexpr ui64 deltaShards = 2;
         if ((pathElement->GetShardsInside() + deltaShards) > subDomainInfo->GetSchemeLimits().MaxShardsInPath) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4718,6 +4718,7 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     ConfigureStatsOperations(appData->SchemeShardConfig, ctx);
     MaxCdcInitialScanShardsInFlight = appData->SchemeShardConfig.GetMaxCdcInitialScanShardsInFlight();
     MaxRestoreBuildIndexShardsInFlight = appData->SchemeShardConfig.GetMaxRestoreBuildIndexShardsInFlight();
+    MaxTTLShardsInFlight = appData->SchemeShardConfig.GetMaxTTLShardsInFlight();
 
     ConfigureBackgroundCleaningQueue(appData->BackgroundCleaningConfig, ctx);
     ConfigureDataErasureManager(appData->DataErasureConfig);
@@ -7318,6 +7319,7 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TAppConfig& appConfi
         ConfigureStatsOperations(schemeShardConfig, ctx);
         MaxCdcInitialScanShardsInFlight = schemeShardConfig.GetMaxCdcInitialScanShardsInFlight();
         MaxRestoreBuildIndexShardsInFlight = schemeShardConfig.GetMaxRestoreBuildIndexShardsInFlight();
+        MaxTTLShardsInFlight = schemeShardConfig.GetMaxTTLShardsInFlight();
     }
 
     if (appConfig.HasTableProfilesConfig()) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -246,6 +246,7 @@ public:
 
     THashMap<TPathId, TTableInfo::TPtr> Tables;
     THashMap<TPathId, TTableInfo::TPtr> TTLEnabledTables;
+    ui32 MaxTTLShardsInFlight = 0;
 
     THashMap<TPathId, TTableIndexInfo::TPtr> Indexes;
     THashMap<TPathId, TCdcStreamInfo::TPtr> CdcStreams;

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -956,14 +956,6 @@ const TPath::TChecker& TPath::TChecker::PathShardsLimit(ui64 delta, EStatus stat
     TSubDomainInfo::TPtr domainInfo = Path.DomainInfo();
     const ui64 shardInPath = Path.Shards();
 
-    if (Path.IsResolved() && !Path.IsDeleted()) {
-        const auto allShards = Path.SS->CollectAllShards({Path.Base()->PathId});
-        Y_VERIFY_DEBUG_S(allShards.size() == shardInPath, "pedantic check"
-            << ": CollectAllShards(): " << allShards.size()
-            << ", Path.Shards(): " << shardInPath
-            << ", path: " << Path.PathString());
-    }
-
     if (!delta || shardInPath + delta <= domainInfo->GetSchemeLimits().MaxShardsInPath) {
         return *this;
     }


### PR DESCRIPTION
Cherry-pick from `main`:
- e9e8433, https://github.com/ydb-platform/ydb/pull/31226
- 4d569d1, https://github.com/ydb-platform/ydb/pull/31005
- 7ab950d, https://github.com/ydb-platform/ydb/pull/31103

Changes:
- Add ability to set reasonable default for TTL `MaxShardsInFlight` to prevent schemeshard freeze from datashard response flooding
- Make split-merges less CPU intensive
- Avoid wasting CPU on splits that will certainly (or likely) be rejected due to exceeding the split-merge in-flight limit