### PR TITLE
Transactions are not deleted immediately

### DIFF
--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -354,7 +354,8 @@ private:
                      const TActorContext& ctx);
     void TryWriteTxs(const TActorContext& ctx);
 
-    void ProcessProposeTransactionQueue(const TActorContext& ctx);
+    void ProcessProposeTransactionQueue(const TActorContext& ctx,
+                                        NKikimrClient::TKeyValueRequest& request);
     void ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxProcessing::TEvPlanStep>&& ev,
                          const TActorContext& ctx);
     void ProcessWriteTxs(const TActorContext& ctx,
@@ -503,7 +504,6 @@ private:
 
     bool CanProcessProposeTransactionQueue() const;
     bool CanProcessWriteTxs() const;
-    bool CanProcessDeleteTxs() const;
     bool CanProcessTxWrites() const;
 
     ui64 GetGeneration();

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -315,6 +315,7 @@ private:
     TDeque<std::unique_ptr<TEvPersQueue::TEvProposeTransaction>> EvProposeTransactionQueue;
     THashMap<ui64, NKikimrPQ::TTransaction::EState> WriteTxs;
     THashSet<ui64> DeleteTxs;
+    bool DeleteTxsContainsKafkaTxs = false;
     TSet<std::pair<ui64, ui64>> ChangedTxs;
     TMaybe<NKikimrPQ::TPQTabletConfig> TabletConfigTx;
     TMaybe<NKikimrPQ::TBootstrapConfig> BootstrapConfigTx;

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -395,7 +395,7 @@ private:
     void SendReplies(const TActorContext& ctx);
     void CheckChangedTxStates(const TActorContext& ctx);
 
-    bool AllTransactionsHaveBeenProcessed() const;
+    bool ReadyForDroppedReply() const;
 
     void BeginWriteTabletState(const TActorContext& ctx, NKikimrPQ::ETabletState state);
     void EndWriteTabletState(const NKikimrClient::TResponse& resp,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Transactions are not deleted after completion. Instead, the deletion is postponed until the next TEvProposeTransaction.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
