### PR TITLE
schemeshard: fix move column-table operation on reboot

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -1057,7 +1057,7 @@ TVector<TTableShardInfo> ApplyPartitioningCopyTable(const TShardInfo &templateDa
 }
 
 // NTableState::TProposedWaitParts
-//
+// Must be in sync with NTableState::TMoveTableProposedWaitParts
 TProposedWaitParts::TProposedWaitParts(TOperationId id, TTxState::ETxState nextState)
     : OperationId(id)
     , NextState(nextState)

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -1131,16 +1131,8 @@ bool TProposedWaitParts::ProgressState(TOperationContext& context) {
         }
 
         Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shard.Idx));
-        TTabletId tablet = context.SS->ShardInfos.at(shard.Idx).TabletID;
 
-        const TShardInfo& shardInfo = context.SS->ShardInfos.at(shard.Idx);
-
-        if (shardInfo.TabletType == ETabletType::ColumnShard) {
-            auto event = std::make_unique<TEvColumnShard::TEvNotifyTxCompletion>(ui64(OperationId.GetTxId()));
-            context.OnComplete.BindMsgToPipe(OperationId, tablet, shard.Idx, event.release());
-        }
-        
-        context.OnComplete.RouteByTablet(OperationId, tablet);
+        context.OnComplete.RouteByTablet(OperationId, context.SS->ShardInfos.at(shard.Idx).TabletID);
     }
 
     txState->UpdateShardsInProgress(TTxState::ProposedWaitParts);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -1129,7 +1129,6 @@ bool TProposedWaitParts::ProgressState(TOperationContext& context) {
             shard.Operation = TTxState::ProposedWaitParts;
             context.SS->PersistUpdateTxShard(db, OperationId, shard.Idx, shard.Operation);
         }
-
         Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shard.Idx));
         context.OnComplete.RouteByTablet(OperationId,  context.SS->ShardInfos.at(shard.Idx).TabletID);
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -1131,10 +1131,8 @@ bool TProposedWaitParts::ProgressState(TOperationContext& context) {
         }
 
         Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shard.Idx));
-
-        context.OnComplete.RouteByTablet(OperationId, context.SS->ShardInfos.at(shard.Idx).TabletID);
+        context.OnComplete.RouteByTablet(OperationId,  context.SS->ShardInfos.at(shard.Idx).TabletID);
     }
-
     txState->UpdateShardsInProgress(TTxState::ProposedWaitParts);
 
     // Move all notifications that were already received

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -533,6 +533,105 @@ public:
     }
 };
 
+class TMoveTableProposedWaitParts: public TSubOperationState {
+private:
+    TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder() << "TMoveTable TProposedWaitParts"
+                                << " operationId: " << OperationId;
+    }
+
+    template <typename TEvent>
+    bool HandleReplyImpl(const TEvent& ev, TOperationContext& context) {
+        TTabletId ssId = context.SS->SelfTabletId();
+        const auto& evRecord = ev->Get()->Record;
+
+        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+            DebugHint() << " HandleReply " << TEvSchemaChangedTraits<TEvent>::GetName() << " at tablet: " << ssId);
+        LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+            DebugHint() << " HandleReply " << TEvSchemaChangedTraits<TEvent>::GetName() << " at tablet: " << ssId
+                        << " message: " << evRecord.ShortDebugString());
+
+        if (!NTableState::CollectSchemaChanged(OperationId, ev, context)) {
+            LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                DebugHint() << " HandleReply " << TEvSchemaChangedTraits<TEvent>::GetName() << " CollectSchemaChanged: false");
+            return false;
+        }
+
+        Y_ABORT_UNLESS(context.SS->FindTx(OperationId));
+        TTxState& txState = *context.SS->FindTx(OperationId);
+
+        if (!txState.ReadyForNotifications) {
+            LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                DebugHint() << " HandleReply " << TEvSchemaChangedTraits<TEvent>::GetName() << " ReadyForNotifications: false");
+            return false;
+        }
+
+        return true;
+    }
+
+public:
+    TMoveTableProposedWaitParts(TOperationId id)
+        : OperationId(id) {
+        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::FLAT_TX_SCHEMESHARD, DebugHint() << " Constructed");
+        IgnoreMessages(DebugHint(), { TEvHive::TEvCreateTabletReply::EventType, TEvDataShard::TEvProposeTransactionResult::EventType,
+                                        TEvColumnShard::TEvProposeTransactionResult::EventType, TEvPrivate::TEvOperationPlan::EventType });
+    }
+
+    bool ProgressState(TOperationContext& context) override {
+        TTabletId ssId = context.SS->SelfTabletId();
+
+        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+            DebugHint() << " ProgressState"
+                        << " at tablet: " << ssId);
+
+        TTxState* txState = context.SS->FindTx(OperationId);
+
+        NIceDb::TNiceDb db(context.GetDB());
+
+        txState->ClearShardsInProgress();
+        for (auto&& shard : txState->Shards) {
+            if (shard.Operation < TTxState::ProposedWaitParts) {
+                shard.Operation = TTxState::ProposedWaitParts;
+                context.SS->PersistUpdateTxShard(db, OperationId, shard.Idx, shard.Operation);
+            }
+
+            Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shard.Idx));
+            TTabletId tablet = context.SS->ShardInfos.at(shard.Idx).TabletID;
+
+            const TShardInfo& shardInfo = context.SS->ShardInfos.at(shard.Idx);
+
+            if (shardInfo.TabletType == ETabletType::ColumnShard) {
+                auto event = std::make_unique<TEvColumnShard::TEvNotifyTxCompletion>(ui64(OperationId.GetTxId()));
+                context.OnComplete.BindMsgToPipe(OperationId, tablet, shard.Idx, event.release());
+            }
+
+            context.OnComplete.RouteByTablet(OperationId, tablet);
+        }
+
+        txState->UpdateShardsInProgress(TTxState::ProposedWaitParts);
+
+        txState->AcceptPendingSchemeNotification();
+
+        if (txState->ShardsInProgress.empty()) {
+            NTableState::AckAllSchemaChanges(OperationId, *txState, context);
+            context.SS->ChangeTxState(db, OperationId, TTxState::Done);
+            return true;
+        }
+
+        return false;
+    }
+
+    bool HandleReply(TEvDataShard::TEvSchemaChanged::TPtr& ev, TOperationContext& context) override {
+        return HandleReplyImpl(ev, context);
+    }
+
+    bool HandleReply(TEvColumnShard::TEvNotifyTxCompletionResult::TPtr& ev, TOperationContext& context) override {
+        return HandleReplyImpl(ev, context);
+    }
+};
+    
 class TDone: public TSubOperationState {
 private:
     TOperationId OperationId;
@@ -640,7 +739,7 @@ class TMoveTable: public TSubOperation {
         case TTxState::DeletePathBarrier:
             return MakeHolder<TDeleteTableBarrier>(OperationId);
         case TTxState::ProposedWaitParts:
-            return MakeHolder<NTableState::TProposedWaitParts>(OperationId);
+            return MakeHolder<TMoveTableProposedWaitParts>(OperationId);
         case TTxState::Done:
             return MakeHolder<TDone>(OperationId);
         default:

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -533,6 +533,7 @@ public:
     }
 };
 
+// Must be in sync with NTableState::TProposedWaitParts
 class TMoveTableProposedWaitParts : public TSubOperationState {
 private:
     const TOperationId OperationId;
@@ -633,6 +634,10 @@ public:
 
         txState->UpdateShardsInProgress(TTxState::ProposedWaitParts);
 
+        // Move all notifications that were already received
+        // NOTE: SchemeChangeNotification is sent form DS after it has got PlanStep from coordinator and the schema tx has completed
+        // At that moment the SS might not have received PlanStep from coordinator yet (this message might be still on its way to SS)
+        // So we are going to accumulate SchemeChangeNotification that are received before this Tx switches to WaitParts state
         txState->AcceptPendingSchemeNotification();
 
         if (txState->ShardsInProgress.empty()) {

--- a/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
@@ -464,7 +464,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
         });
     }
 
-    Y_UNIT_TEST(WithDataColumnTable) {
+    Y_UNIT_TEST(ColumnTable) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;

--- a/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
@@ -463,5 +463,45 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
             }
         });
     }
+
+    Y_UNIT_TEST(WithDataColumnTable) {
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            TPathVersion pathVersion;
+            {
+                TInactiveZone inactive(activeZone);
+                TestCreateColumnTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "ColumnTable"
+                    ColumnShardCount: 1
+                    Schema {
+                        Columns { Name: "key" Type: "Uint64" NotNull: true }
+                        Columns { Name: "value" Type: "Utf8" }
+                        KeyColumnNames: "key"
+                    }
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                pathVersion = TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                                   {NLs::PathExist,
+                                    NLs::ChildrenCount(2)});
+            }
+
+            t.TestEnv->ReliablePropose(runtime, MoveTableRequest(++t.TxId, "/MyRoot/ColumnTable", "/MyRoot/ColumnTableMove", TTestTxConfig::SchemeShard, {pathVersion}),
+                                       {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusMultipleModifications, NKikimrScheme::StatusPreconditionFailed});
+
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                                   {NLs::ChildrenCount(2)});
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/ColumnTableMove"),
+                                   {NLs::PathVersionEqual(4),
+                                    NLs::PathExist});
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/ColumnTable"),
+                                   {NLs::PathNotExist});
+            }
+        });
+    }
 }
 


### PR DESCRIPTION
Fixup to:
- https://github.com/ydb-platform/ydb/pull/16961

Fix move column-table continuation after schemeshard reboot.
Extend move table reboot tests to include column-table case.