### PR TITLE
Invert condition in the assert-like macro

### DIFF
--- a/ydb/core/base/memory_stats.h
+++ b/ydb/core/base/memory_stats.h
@@ -26,7 +26,7 @@ ADD_MEMORY(TargetUtilization)
 class TMemoryStatsAggregator {
     using TMemoryStats = NKikimrMemory::TMemoryStats;
 
-    TMemoryStats Aggregated;    
+    TMemoryStats Aggregated;
     TMap<TString, TMemoryStats> PerHost;
 
 public:
@@ -93,7 +93,7 @@ private:
                             reflection.GetUInt64(left, field) + reflection.GetUInt64(right, field));
                         break;
                     default:
-                        Y_DEBUG_ABORT_UNLESS("Unhandled field type");
+                        Y_DEBUG_ABORT("Unhandled field type");
                 }
             }
         }

--- a/ydb/library/shop/scheduler.h
+++ b/ydb/library/shop/scheduler.h
@@ -501,7 +501,7 @@ void TFreezable<TRes>::Deactivate(ConsumerT* consumer)
             return;
         }
     }
-    Y_ABORT_UNLESS("trying to deactivate unknown consumer");
+    // Y_ABORT("trying to deactivate unknown consumer"); // despite the message, this code runs in tests
 }
 
 template <class TRes>

--- a/ydb/library/shop/sim_shop/myshop.cpp
+++ b/ydb/library/shop/sim_shop/myshop.cpp
@@ -532,7 +532,7 @@ void TMyMachine::Configure(const TMachinePb& cfg)
             fifo->SetName(cfg.GetScheduler().GetFIFO().GetName());
             Scheduler.Reset(fifo);
         } else {
-            Y_ABORT("only FIFO queueing disciplice is supported for now");
+            Y_ABORT("only FIFO queueing discipline is supported for now");
         }
 
         if (oldScheduler) {

--- a/ydb/library/shop/sim_shop/myshop.cpp
+++ b/ydb/library/shop/sim_shop/myshop.cpp
@@ -532,7 +532,7 @@ void TMyMachine::Configure(const TMachinePb& cfg)
             fifo->SetName(cfg.GetScheduler().GetFIFO().GetName());
             Scheduler.Reset(fifo);
         } else {
-            Y_ABORT_UNLESS("only FIFO queueing disciplice is supported for now");
+            Y_ABORT("only FIFO queueing disciplice is supported for now");
         }
 
         if (oldScheduler) {

--- a/ydb/tests/fq/control_plane_storage/ydb_control_plane_storage_internal_ut.cpp
+++ b/ydb/tests/fq/control_plane_storage/ydb_control_plane_storage_internal_ut.cpp
@@ -1527,7 +1527,7 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), true);
                 UNIT_ASSERT_LE_C(*parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp(), TInstant::Now(), "TTL more than current time");
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             }
         }
@@ -1540,7 +1540,7 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), true);
                 UNIT_ASSERT_LE_C(*parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp(), TInstant::Now(), "TTL more than current time");
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             }
         }
@@ -1644,10 +1644,10 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(*parser.ColumnParser(QUERY_ID_COLUMN_NAME).GetOptionalString(), queryId);
                 UNIT_ASSERT_VALUES_EQUAL_C(parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), false, *parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp());
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             } else {
-                UNIT_ASSERT("Row count equal 0");
+                UNIT_FAIL("Row count equal 0");
             }
         }
 
@@ -1659,10 +1659,10 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(*parser.ColumnParser(QUERY_ID_COLUMN_NAME).GetOptionalString(), queryId);
                 UNIT_ASSERT_VALUES_EQUAL_C(parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), false, *parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp());
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             } else {
-                UNIT_ASSERT("Row count equal 0");
+                UNIT_FAIL("Row count equal 0");
             }
         }
 
@@ -1745,7 +1745,7 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), true);
                 UNIT_ASSERT_GE_C(*parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp(), TInstant::Now(), "TTL less than current time");
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             }
         }
@@ -1758,7 +1758,7 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), true);
                 UNIT_ASSERT_GE_C(*parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp(), TInstant::Now(), "TTL less than current time");
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             }
         }
@@ -1832,10 +1832,10 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(*parser.ColumnParser(QUERY_ID_COLUMN_NAME).GetOptionalString(), queryId);
                 UNIT_ASSERT_VALUES_EQUAL_C(parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), false, *parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp());
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             } else {
-                UNIT_ASSERT("Row count equal 0");
+                UNIT_FAIL("Row count equal 0");
             }
         }
 
@@ -1910,7 +1910,7 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), true);
                 UNIT_ASSERT_GE_C(*parser.ColumnParser(EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp(), TInstant::Now(), "TTL less than current time");
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             }
         }
@@ -2004,7 +2004,7 @@ Y_UNIT_TEST_SUITE(TYdbControlPlaneStoragePipeline) {
                 UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(RESULT_SETS_EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp().has_value(), true);
                 UNIT_ASSERT_VALUES_EQUAL(*parser.ColumnParser(RESULT_SETS_EXPIRE_AT_COLUMN_NAME).GetOptionalTimestamp(), deadline);
                 if (parser.TryNextRow()) {
-                    UNIT_ASSERT("Row count more than 1");
+                    UNIT_FAIL("Row count more than 1");
                 }
             }
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

#30109

When a constant string literal is erroneously passed to one of the ASSERT, ABORT, VERIFY or ENSURE macros, it is silently converted to 'true', resulting in the check being skipped completely.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
