### PR TITLE
Invert condition in the assert-like macro

### DIFF
--- a/ydb/core/tx/datashard/datashard__engine_host.cpp
+++ b/ydb/core/tx/datashard/datashard__engine_host.cpp
@@ -118,7 +118,7 @@ public:
             TSysTables::TLocksTable::GetInfo(Columns, KeyTypes, true);
             break;
         default:
-            Y_ASSERT("Unexpected system table id");
+            Y_ASSERT(false && "Unexpected system table id");
         }
     }
 
@@ -144,7 +144,7 @@ public:
         Y_UNUSED(row);
         Y_UNUSED(commands);
 
-        Y_ASSERT("Not supported");
+        Y_ASSERT(false && "Not supported");
     }
 
     void EraseRow(const TArrayRef<const TCell>& row) const {

--- a/ydb/core/tx/locks/sys_tables.h
+++ b/ydb/core/tx/locks/sys_tables.h
@@ -173,7 +173,7 @@ struct TSysTables {
             case EColumns::PathId:
                 return "PathId";
             };
-            Y_ASSERT("Unknown column");
+            Y_ASSERT(false && "Unknown column");
             return "";
         }
 

--- a/ydb/core/tx/replication/ydb_proxy/ydb_proxy_ut.cpp
+++ b/ydb/core/tx/replication/ydb_proxy/ydb_proxy_ut.cpp
@@ -675,7 +675,7 @@ Y_UNIT_TEST_SUITE(YdbProxy) {
                 } else if (ev->Sender == newReader) {
                     continue;
                 } else {
-                    UNIT_ASSERT("Unexpected reader has gone");
+                    UNIT_FAIL("Unexpected reader has gone");
                 }
             } catch (yexception&) {
                 // bad luck, previous session was not closed, close it manually

--- a/ydb/core/tx/schemeshard/olap/ttl/validator.cpp
+++ b/ydb/core/tx/schemeshard/olap/ttl/validator.cpp
@@ -34,7 +34,7 @@ bool TTTLValidator::ValidateColumnTableTtl(const NKikimrSchemeOp::TColumnDataLif
     } else if (sourceColumns.contains(colId)) {
         column = &sourceColumns.at(colId);
     } else {
-        Y_ABORT_UNLESS("Unknown column");
+        Y_ABORT("Unknown column");
     }
 
     if (IsDropped(*column)) {

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
@@ -178,7 +178,7 @@ bool IsCreate(ETxType t) {
             return false; // IsCreate
         case TxInvalid:
         case TxAllocatePQ:
-            Y_DEBUG_ABORT_UNLESS("UNREACHABLE");
+            Y_DEBUG_ABORT("UNREACHABLE");
             Y_UNREACHABLE();
 
         //NOTE: intentionally no default: case
@@ -310,7 +310,7 @@ bool IsDrop(ETxType t) {
             return false; // IsDrop
         case TxInvalid:
         case TxAllocatePQ:
-            Y_DEBUG_ABORT_UNLESS("UNREACHABLE");
+            Y_DEBUG_ABORT("UNREACHABLE");
             Y_UNREACHABLE();
 
         //NOTE: intentionally no default: case
@@ -441,7 +441,7 @@ bool CanDeleteParts(ETxType t) {
             return false; // CanDeleteParts
         case TxInvalid:
         case TxAllocatePQ:
-            Y_DEBUG_ABORT_UNLESS("UNREACHABLE");
+            Y_DEBUG_ABORT("UNREACHABLE");
             Y_UNREACHABLE();
 
         //NOTE: intentionally no default: case

--- a/ydb/core/tx/schemeshard/schemeshard_validate_ttl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_validate_ttl.cpp
@@ -43,7 +43,7 @@ bool ValidateTtlSettings(const NKikimrSchemeOp::TTTLSettings& ttl,
         } else if (auto x = sourceColumns.find(colId); x != sourceColumns.end()) {
             column = &x->second;
         } else {
-            Y_ABORT_UNLESS("Unknown column");
+            Y_ABORT("Unknown column");
         }
 
         if (IsDropped(*column)) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
https://github.com/ydb-platform/ydb/issues/30109
When a constant string literal is erroneously passed to one of the ASSERT, ABORT, VERIFY or ENSURE macros, it is silently converted to 'true', resulting in the check being skipped completely.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
