### PR TITLE
Introduce fail-fast flag in IC to prevent session establishing when it is not established

### DIFF
--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -141,6 +141,7 @@ namespace NActors {
             FlagGenerateUnsureUndelivered = 1 << 4,
             FlagExtendedFormat = 1 << 5,
             FlagDebugTrackReceive = 1 << 6,
+            FlagFailFastWhenDisconnected = 1 << 7,
         };
         using TEventFlags = ui32;
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -567,6 +567,10 @@ namespace NActors {
     void TInterconnectProxyTCP::EnqueueSessionEvent(STATEFN_SIG) {
         ICPROXY_PROFILED;
 
+        if (ev->Flags & IEventHandle::FlagFailFastWhenDisconnected) {
+            return DropSessionEvent(ev);
+        }
+
         ValidateEvent(ev, "EnqueueSessionEvent");
         const ui32 size = ev->GetSize();
         PendingSessionEventsSize += size;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Introduce fail-fast flag in IC to prevent session establishing when it is not established

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows user to prevent waiting when session is not connected and drop session event as soon as possible.
