### PR TITLE
statistics: serialize histogram min/max as literals of correct types

### DIFF
--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -242,10 +242,11 @@ bool IColumnStatisticEval::AreMinMaxNeeded(const NScheme::TTypeInfo& typeInfo) {
 
 template<>
 void Out<NKikimr::NStat::TBorder>(IOutputStream& os, const NKikimr::NStat::TBorder& x) {
+    // Serialize as a YQL literal with a correct type.
     struct TVisitor {
         IOutputStream& Os;
-        void operator()(ui64 val) { Os << val; }
-        void operator()(i64 val) { Os << val; }
+        void operator()(ui64 val) { Os << val << "ul"; }
+        void operator()(i64 val) { Os << val << "l"; }
         void operator()(float val) { Os << "CAST(" << val << " AS Float)"; }
         void operator()(double val) { Os << "CAST(" << val << " AS Double)"; }
     };


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Previously, histogram min/max values were serialized into literals that could have Int32 type. When queried with `param.Get<i64>()` inside the UDAF code, this led to incorrect min/max values.