### PR TITLE
CMS: allow locks with higher priority on already locked nodes

### DIFF
--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -39,6 +39,7 @@ bool TLockableItem::IsLocked(TErrorInfo &error, TDuration defaultRetryTime,
     }
 
     if (HasSameOrHigherPriorityLock(Locks, PriorityToCheck)) {
+        Y_ABORT_UNLESS(!Locks.empty());
         error.Code = TStatus::DISALLOW_TEMP;
         error.Reason = Sprintf("%s has planned shutdown (permission %s owned by %s)",
                                PrettyItemName().data(), Locks.begin()->PermissionId.data(), Locks.begin()->Owner.data());

--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -26,23 +26,34 @@ namespace NKikimr::NCms {
 using namespace NNodeWhiteboard;
 using namespace NKikimrCms;
 
+bool TLockableItem::IsLockedByPriorityLock() const {
+    if (Locks.empty()) {
+        return false;
+    }
+
+    if (AppData()->FeatureFlags.GetEnableCmsLocksPriority()) {
+        return Locks.begin()->Priority <= DeactivatedLocksPriority;
+    } else {
+        return true; // only one lock is allowed despite of its priority
+    }
+};
+
 bool TLockableItem::IsLocked(TErrorInfo &error, TDuration defaultRetryTime,
                              TInstant now, TDuration duration) const
 {
-    if (State == RESTART) {
-        Y_ABORT_UNLESS(Lock.Defined());
+    if (State == RESTART && IsLockedByPriorityLock()) {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Reason = Sprintf("%s is restarting (permission %s owned by %s)",
-                               PrettyItemName().data(), Lock->PermissionId.data(), Lock->Owner.data());
-        error.Deadline = Lock->ActionDeadline;
+                               PrettyItemName().data(), Locks.begin()->PermissionId.data(), Locks.begin()->Owner.data());
+        error.Deadline = Locks.begin()->ActionDeadline;
         return true;
     }
 
-    if (Lock.Defined()) {
+    if (IsLockedByPriorityLock()) {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Reason = Sprintf("%s has planned shutdown (permission %s owned by %s)",
-                               PrettyItemName().data(), Lock->PermissionId.data(), Lock->Owner.data());
-        error.Deadline = Lock->ActionDeadline;
+                               PrettyItemName().data(), Locks.begin()->PermissionId.data(), Locks.begin()->Owner.data());
+        error.Deadline = Locks.begin()->ActionDeadline;
         return true;
     }
 
@@ -63,10 +74,9 @@ bool TLockableItem::IsLocked(TErrorInfo &error, TDuration defaultRetryTime,
 
     if (!ScheduledLocks.empty() && ScheduledLocks.begin()->Priority < DeactivatedLocksPriority) {
         error.Code = TStatus::DISALLOW_TEMP;
-        error.Reason = Sprintf("%s has scheduled action %s owned by %s (priority %" PRIi32 " vs %" PRIi32 ")",
+        error.Reason = Sprintf("%s has scheduled action %s owned by %s",
                                PrettyItemName().data(), ScheduledLocks.begin()->RequestId.data(),
-                               ScheduledLocks.begin()->Owner.data(), ScheduledLocks.begin()->Priority,
-                               DeactivatedLocksPriority);
+                               ScheduledLocks.begin()->Owner.data());
         error.Deadline = now + defaultRetryTime;
         return true;
     }
@@ -84,12 +94,11 @@ bool TLockableItem::IsLocked(TErrorInfo &error, TDuration defaultRetryTime,
 
 bool TLockableItem::IsDown(TErrorInfo &error, TInstant defaultDeadline) const
 {
-    if (State == RESTART) {
-        Y_ABORT_UNLESS(Lock.Defined());
+    if (State == RESTART && IsLockedByPriorityLock()) {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Reason = Sprintf("%s is restarting (permission %s owned by %s)",
-                               PrettyItemName().data(), Lock->PermissionId.data(), Lock->Owner.data());
-        error.Deadline = Lock->ActionDeadline;
+                               PrettyItemName().data(), Locks.begin()->PermissionId.data(), Locks.begin()->Owner.data());
+        error.Deadline = Locks.begin()->ActionDeadline;
         return true;
     }
 
@@ -112,12 +121,12 @@ void TLockableItem::RollbackLocks(ui64 point)
         }
 }
 
-void TLockableItem::ReactivateScheduledLocks()
+void TLockableItem::ReactivateLocks()
 {
     DeactivatedLocksPriority = Max<i32>();
 }
 
-void TLockableItem::DeactivateScheduledLocks(i32 priority)
+void TLockableItem::DeactivateLocks(i32 priority)
 {
     DeactivatedLocksPriority = priority;
 }
@@ -139,8 +148,8 @@ void TLockableItem::MigrateOldInfo(const TLockableItem &old)
 
 void TLockableItem::DebugLocksDump(IOutputStream &ss, const TString &prefix) const
 {
-    if (Lock.Defined())
-        ss << prefix << "Locked by permission " << Lock->PermissionId << Endl;
+    for (auto &lock : Locks)
+        ss << prefix << "Locked by permission " << lock.PermissionId;
 
     for (auto &lock : ExternalLocks)
         ss << prefix << "External lock by notifications " << lock.NotificationId;
@@ -639,7 +648,7 @@ static TServices MakeServices(const NKikimrCms::TAction &action) {
     return services;
 }
 
-void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action)
+void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action, i32 priority)
 {
     if (ActionRequiresHost(action) && !HasNode(action.GetHost())) {
         return;
@@ -652,8 +661,8 @@ void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action)
         if (auto nodes = NodePtrs(action.GetHost(), MakeServices(action))) {
             for (const auto node : nodes) {
                 for (auto &nodeGroup: node->NodeGroups) {
-                    if (!nodeGroup->IsNodeLocked(node->NodeId)) {
-                        nodeGroup->LockNode(node->NodeId);
+                    if (!nodeGroup->IsNodeLocked(node->NodeId, priority)) {
+                        nodeGroup->LockNode(node->NodeId, priority);
                     }
                 }
             }
@@ -664,15 +673,15 @@ void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action)
             if (HasPDisk(device)) {
                 auto pdisk = &PDiskRef(device);
                 for (auto &nodeGroup: NodeRef(pdisk->NodeId).NodeGroups) {
-                    if (!nodeGroup->IsNodeLocked(pdisk->NodeId)) {
-                        nodeGroup->LockNode(pdisk->NodeId);
+                    if (!nodeGroup->IsNodeLocked(pdisk->NodeId, priority)) {
+                        nodeGroup->LockNode(pdisk->NodeId, priority);
                     }
                 }
             } else if (HasVDisk(device)) {
                 auto vdisk = &VDiskRef(device);
                 for (auto &nodeGroup: NodeRef(vdisk->NodeId).NodeGroups) {
-                    if (!nodeGroup->IsNodeLocked(vdisk->NodeId)) {
-                        nodeGroup->LockNode(vdisk->NodeId);
+                    if (!nodeGroup->IsNodeLocked(vdisk->NodeId, priority)) {
+                        nodeGroup->LockNode(vdisk->NodeId, priority);
                     }
                 } 
             }
@@ -785,7 +794,7 @@ ui64 TClusterInfo::AddLocks(const TPermissionInfo &permission, const TActorConte
         }
     }
 
-    ApplyActionWithoutLog(permission.Action);
+    ApplyActionWithoutLog(permission.Action, permission.Priority);
 
     return locks;
 }
@@ -795,7 +804,7 @@ ui64 TClusterInfo::AddExternalLocks(const TNotificationInfo &notification, const
     ui64 locks = 0;
     for (const auto &action : notification.Notification.GetActions()) {
         auto items = FindLockedItems(action, ctx);
-        ApplyActionWithoutLog(action);
+        ApplyActionWithoutLog(action, 0);
 
         for (auto item : items) {
             if (ctx)
@@ -851,11 +860,11 @@ void TClusterInfo::UpdateDowntimes(TDowntimes &downtimes, const TActorContext &c
     }
 }
 
-ui64 TClusterInfo::AddTempLocks(const NKikimrCms::TAction &action, const TActorContext *ctx)
+ui64 TClusterInfo::AddTempLocks(const NKikimrCms::TAction &action, i32 priority, const TActorContext *ctx)
 {
     auto items = FindLockedItems(action, ctx);
 
-    LogManager.ApplyAction(action, this);
+    LogManager.ApplyAction(action, priority, this);
 
     for (auto item : items)
         item->TempLocks.push_back({RollbackPoint, action});
@@ -884,16 +893,16 @@ void TClusterInfo::UnscheduleActions(const TString &requestId)
         entry.second->RemoveScheduledLocks(requestId);
 }
 
-void TClusterInfo::DeactivateScheduledLocks(i32 priority)
+void TClusterInfo::DeactivateLocks(i32 priority)
 {
     for (auto &entry : LockableItems)
-        entry.second->DeactivateScheduledLocks(priority);
+        entry.second->DeactivateLocks(priority);
 }
 
-void TClusterInfo::ReactivateScheduledLocks()
+void TClusterInfo::ReactivateLocks()
 {
     for (auto &entry : LockableItems)
-        entry.second->ReactivateScheduledLocks();
+        entry.second->ReactivateLocks();
 }
 
 void TClusterInfo::RollbackLocks(ui64 point)
@@ -1047,7 +1056,7 @@ void TClusterInfo::DebugDump(const TActorContext &ctx) const
     }
 }
 
-void TOperationLogManager::ApplyAction(const NKikimrCms::TAction &action,
+void TOperationLogManager::ApplyAction(const NKikimrCms::TAction &action, i32 priority,
                                       TClusterInfoPtr clusterState)
 {
     switch (action.GetType()) {
@@ -1057,8 +1066,8 @@ void TOperationLogManager::ApplyAction(const NKikimrCms::TAction &action,
         if (auto nodes = clusterState->NodePtrs(action.GetHost(), MakeServices(action))) {
             for (const auto node : nodes) {
                 for (auto &nodeGroup: node->NodeGroups) {
-                    if (!nodeGroup->IsNodeLocked(node->NodeId)) {
-                        AddNodeLockOperation(node->NodeId, nodeGroup);
+                    if (!nodeGroup->IsNodeLocked(node->NodeId, priority)) {
+                        AddNodeLockOperation(node->NodeId, priority, nodeGroup);
                     }
                 }     
             }
@@ -1069,15 +1078,15 @@ void TOperationLogManager::ApplyAction(const NKikimrCms::TAction &action,
             if (clusterState->HasPDisk(device)) {
                 auto pdisk = &clusterState->PDisk(device);
                 for (auto &nodeGroup: clusterState->NodeRef(pdisk->NodeId).NodeGroups) {
-                    if (!nodeGroup->IsNodeLocked(pdisk->NodeId)) {
-                        AddNodeLockOperation(pdisk->NodeId, nodeGroup);
+                    if (!nodeGroup->IsNodeLocked(pdisk->NodeId, priority)) {
+                        AddNodeLockOperation(pdisk->NodeId, priority, nodeGroup);
                     }
                 }       
             } else if (clusterState->HasVDisk(device)) {
                 auto vdisk = &clusterState->VDisk(device);
                 for (auto &nodeGroup: clusterState->NodeRef(vdisk->NodeId).NodeGroups) {
-                    if (!nodeGroup->IsNodeLocked(vdisk->NodeId)) {
-                        AddNodeLockOperation(vdisk->NodeId, nodeGroup);
+                    if (!nodeGroup->IsNodeLocked(vdisk->NodeId, priority)) {
+                        AddNodeLockOperation(vdisk->NodeId, priority, nodeGroup);
                     }
                 }     
             }

--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -31,7 +31,7 @@ bool TLockableItem::IsLockedByPriorityLock() const {
         return false;
     }
 
-    if (AppData()->FeatureFlags.GetEnableCmsLocksPriority()) {
+    if (HasAppData() && AppData()->FeatureFlags.GetEnableCmsLocksPriority()) {
         return Locks.begin()->Priority <= DeactivatedLocksPriority;
     } else {
         return true; // only one lock is allowed despite of its priority

--- a/ydb/core/cms/cluster_info_ut.cpp
+++ b/ydb/core/cms/cluster_info_ut.cpp
@@ -369,15 +369,16 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
         permission.Deadline = now + TDuration::Seconds(60);
         UNIT_ASSERT_VALUES_EQUAL(cluster->AddLocks(permission, nullptr), 1);
         UNIT_ASSERT_VALUES_EQUAL(cluster->HostNodes("test2").size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(cluster->HostNodes("test2")[0]->Lock->Action.GetType(), TAction::SHUTDOWN_HOST);
-        UNIT_ASSERT_VALUES_EQUAL(cluster->HostNodes("test2")[0]->Lock->ActionDeadline, now + TDuration::Minutes(2));
+        UNIT_ASSERT_VALUES_EQUAL(cluster->HostNodes("test2")[0]->Locks.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->HostNodes("test2")[0]->Locks.begin()->Action.GetType(), TAction::SHUTDOWN_HOST);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->HostNodes("test2")[0]->Locks.begin()->ActionDeadline, now + TDuration::Minutes(2));
 
         permission.Action.SetHost("2");
         permission.Deadline = now - TDuration::Seconds(30);
         cluster->SetNodeState(2, DOWN, MakeSystemStateInfo("1"));
         UNIT_ASSERT_VALUES_EQUAL(cluster->AddLocks(permission, nullptr), 1);
         UNIT_ASSERT_VALUES_EQUAL(cluster->Node(2).State, EState::RESTART);
-        UNIT_ASSERT_VALUES_EQUAL(cluster->Node(2).Lock->ActionDeadline, now + TDuration::Seconds(30));
+        UNIT_ASSERT_VALUES_EQUAL(cluster->Node(2).Locks.begin()->ActionDeadline, now + TDuration::Seconds(30));
 
         cluster->ClearNode(1);
         UNIT_ASSERT(!cluster->HasTablet(1));
@@ -386,7 +387,7 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
 
         auto point1 = cluster->PushRollbackPoint();
         auto action1 = MakeAction(TAction::SHUTDOWN_HOST, 3, 60000000);
-        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action1, nullptr), 1);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action1, 0, nullptr), 1);
         UNIT_ASSERT_VALUES_EQUAL(cluster->Node(3).TempLocks.size(), 1);
 
         cluster->RollbackLocks(point1);
@@ -397,17 +398,17 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
                                   "pdisk-1-1", "vdisk-0-1-0-1-0");
         permission.Action = action2;
         permission.Deadline = now + TDuration::Seconds(60);
-        UNIT_ASSERT(!cluster->PDisk(NCms::TPDiskID(1, 1)).Lock.Defined());
-        UNIT_ASSERT(!cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).Lock.Defined());
+        UNIT_ASSERT(cluster->PDisk(NCms::TPDiskID(1, 1)).Locks.empty());
+        UNIT_ASSERT(cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).Locks.empty());
         UNIT_ASSERT_VALUES_EQUAL(cluster->AddLocks(permission, nullptr), 2);
-        UNIT_ASSERT(cluster->PDisk(NCms::TPDiskID(1, 1)).Lock.Defined());
-        UNIT_ASSERT(cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).Lock.Defined());
-        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action2, nullptr), 2);
+        UNIT_ASSERT(!cluster->PDisk(NCms::TPDiskID(1, 1)).Locks.empty());
+        UNIT_ASSERT(!cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).Locks.empty());
+        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action2, 0, nullptr), 2);
         UNIT_ASSERT_VALUES_EQUAL(cluster->PDisk(NCms::TPDiskID(1, 1)).TempLocks.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).TempLocks.size(), 1);
         cluster->RollbackLocks(point2);
-        UNIT_ASSERT(cluster->PDisk(NCms::TPDiskID(1, 1)).Lock.Defined());
-        UNIT_ASSERT(cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).Lock.Defined());
+        UNIT_ASSERT(!cluster->PDisk(NCms::TPDiskID(1, 1)).Locks.empty());
+        UNIT_ASSERT(!cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).Locks.empty());
         UNIT_ASSERT_VALUES_EQUAL(cluster->PDisk(NCms::TPDiskID(1, 1)).TempLocks.size(), 0);
         UNIT_ASSERT_VALUES_EQUAL(cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).TempLocks.size(), 0);
 
@@ -442,13 +443,13 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
                             "request-3", "user-3", 3,
                             "request-4", "user-4", 4);
 
-        cluster->DeactivateScheduledLocks(request2.Priority);
+        cluster->DeactivateLocks(request2.Priority);
 
         TErrorInfo error;
         UNIT_ASSERT(cluster->Node(1).IsLocked(error, TDuration(), Now(), TDuration()));
         UNIT_ASSERT(!cluster->Node(3).IsLocked(error, TDuration(), Now(), TDuration()));
 
-        cluster->ReactivateScheduledLocks();
+        cluster->ReactivateLocks();
 
         UNIT_ASSERT(cluster->Node(1).IsLocked(error, TDuration(), Now(), TDuration()));
         UNIT_ASSERT(cluster->Node(3).IsLocked(error, TDuration(), Now(), TDuration()));

--- a/ydb/core/cms/cluster_info_ut.cpp
+++ b/ydb/core/cms/cluster_info_ut.cpp
@@ -443,13 +443,13 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
                             "request-3", "user-3", 3,
                             "request-4", "user-4", 4);
 
-        cluster->DeactivateLocks(request2.Priority);
+        cluster->SetPriorityToCheck(request2.Priority);
 
         TErrorInfo error;
         UNIT_ASSERT(cluster->Node(1).IsLocked(error, TDuration(), Now(), TDuration()));
         UNIT_ASSERT(!cluster->Node(3).IsLocked(error, TDuration(), Now(), TDuration()));
 
-        cluster->ReactivateLocks();
+        cluster->ResetPriorityToCheck();
 
         UNIT_ASSERT(cluster->Node(1).IsLocked(error, TDuration(), Now(), TDuration()));
         UNIT_ASSERT(cluster->Node(3).IsLocked(error, TDuration(), Now(), TDuration()));

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1547,9 +1547,9 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
             TErrorInfo error;
             TDuration duration = TDuration::MicroSeconds(action.GetDuration());
             duration += TDuration::MicroSeconds(copy->Request.GetDuration());
-            item->DeactivateLocks(Min<i32>());
+            item->SetPriorityToCheck(Min<i32>());
             bool isLocked = item->IsLocked(error, State->Config.DefaultRetryTime, TActivationContext::Now(), duration);
-            item->ReactivateLocks();
+            item->ResetPriorityToCheck();
             if (isLocked) {
                 return ReplyWithError<TEvCms::TEvManageRequestResponse>(
                     ev, TStatus::WRONG_REQUEST, "Request has already locked items: " + error.Reason.GetMessage(), ctx);

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1547,10 +1547,9 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
             TErrorInfo error;
             TDuration duration = TDuration::MicroSeconds(action.GetDuration());
             duration += TDuration::MicroSeconds(copy->Request.GetDuration());
-            // To get permissions ASAP and not in the priority order.
-            item->DeactivateScheduledLocks(Min<i32>());
+            item->DeactivateLocks(Min<i32>());
             bool isLocked = item->IsLocked(error, State->Config.DefaultRetryTime, TActivationContext::Now(), duration);
-            item->ReactivateScheduledLocks();
+            item->ReactivateLocks();
             if (isLocked) {
                 return ReplyWithError<TEvCms::TEvManageRequestResponse>(
                     ev, TStatus::WRONG_REQUEST, "Request has already locked items: " + error.Reason.GetMessage(), ctx);
@@ -1567,7 +1566,7 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
 
     it->second = *copy;
 
-    AcceptPermissions(resp->Record, rec.GetRequestId(), rec.GetUser(), ctx, true);
+    AcceptPermissions(resp->Record, rec.GetRequestId(), rec.GetUser(), Min<i32>(), ctx, true);
 
     auto actor = new TRequestApproveActor(requestId, State, ev->Sender);
     TActorId approveActorId = ctx.RegisterWithSameMailbox(actor);

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -2104,9 +2104,9 @@ void TCms::Handle(TEvCms::TEvPermissionRequest::TPtr &ev,
             }
         }
     }
-    ClusterInfo->DeactivateLocks(priority);
+    ClusterInfo->SetPriorityToCheck(priority);
     bool ok = CheckPermissionRequest(rec, resp->Record, scheduled.Request, ctx);
-    ClusterInfo->ReactivateLocks();
+    ClusterInfo->ResetPriorityToCheck();
     ClusterInfo->LogManager.RollbackOperations();
 
     // Schedule request if required.
@@ -2182,10 +2182,10 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
         }
     }
 
-    ClusterInfo->DeactivateLocks(request.Priority);
+    ClusterInfo->SetPriorityToCheck(request.Priority);
     request.Request.SetAvailabilityMode(rec.GetAvailabilityMode());
     bool ok = CheckPermissionRequest(request.Request, resp->Record, scheduled.Request, ctx);
-    ClusterInfo->ReactivateLocks();
+    ClusterInfo->ResetPriorityToCheck();
     ClusterInfo->LogManager.RollbackOperations();
 
     // Schedule request if required.

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -205,9 +205,9 @@ void TCms::GenerateNodeState(IOutputStream& out)
             TABLEBODY() {
                 for (const auto& node : ClusterInfo->AllNodes()) {
                     auto currentInMemoryState = INodesChecker::NODE_STATE_UNSPECIFIED;
-                    const auto& nodeState = ClusterInfo->ClusterNodes[node.second->PileId.GetOrElse(0)]->GetNodeToState();
-                    if (nodeState.contains(node.first)) {
-                        currentInMemoryState = nodeState.at(node.first);
+                    const auto& nodes = ClusterInfo->ClusterNodes[node.second->PileId.GetOrElse(0)]->GetNodes();
+                    if (nodes.contains(node.first)) {
+                        currentInMemoryState = nodes.at(node.first).State;
                     }
                     TABLER() {
                         TABLED() {
@@ -390,6 +390,7 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
         opts.TenantPolicy = request.GetTenantPolicy();
         opts.AvailabilityMode = request.GetAvailabilityMode();
         opts.PartialPermissionAllowed = allowPartial;
+        opts.Priority = request.GetPriority();
 
         TErrorInfo error;
 
@@ -409,7 +410,7 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
             permission->SetDeadline(error.Deadline.GetValue());
             AddPermissionExtensions(action, *permission);
 
-            ClusterInfo->AddTempLocks(action, &ctx);
+            ClusterInfo->AddTempLocks(action, request.GetPriority(), &ctx);
         } else {
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Result: %s (reason: %s)",
                       ToString(error.Code).data(), error.Reason.GetMessage().data());
@@ -843,7 +844,7 @@ bool TCms::CheckSysTabletsNode(const TActionOptions &opts,
     }
 
     for (auto &tabletType : ClusterInfo->NodeToTabletTypes[node.NodeId]) {
-        if (!ClusterInfo->SysNodesCheckers[node.PileId.GetOrElse(0)][tabletType]->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason)) {
+        if (!ClusterInfo->SysNodesCheckers[node.PileId.GetOrElse(0)][tabletType]->TryToLockNode(node.NodeId, opts.AvailabilityMode, opts.Priority, error.Reason)) {
             error.Code = TStatus::DISALLOW_TEMP;
             error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;
             return false;
@@ -861,7 +862,7 @@ bool TCms::TryToLockNode(const TAction& action,
     TDuration duration = TDuration::MicroSeconds(action.GetDuration());
     duration += opts.PermissionDuration;
 
-    if (!ClusterInfo->ClusterNodes[node.PileId.GetOrElse(0)]->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason)) {
+    if (!ClusterInfo->ClusterNodes[node.PileId.GetOrElse(0)]->TryToLockNode(node.NodeId, opts.AvailabilityMode, opts.Priority, error.Reason)) {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;
         return false;
@@ -869,7 +870,7 @@ bool TCms::TryToLockNode(const TAction& action,
 
     if (node.Tenant
         && opts.TenantPolicy != NONE
-        && !ClusterInfo->TenantNodesChecker[node.PileId.GetOrElse(0)][node.Tenant]->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason))
+        && !ClusterInfo->TenantNodesChecker[node.PileId.GetOrElse(0)][node.Tenant]->TryToLockNode(node.NodeId, opts.AvailabilityMode, opts.Priority, error.Reason))
     {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;
@@ -1038,7 +1039,7 @@ bool TCms::CheckActionReplaceDevices(const TAction &action,
 }
 
 void TCms::AcceptPermissions(TPermissionResponse &resp, const TString &requestId,
-                             const TString &owner, const TActorContext &ctx, bool check)
+                             const TString &owner, i32 priority, const TActorContext &ctx, bool check)
 {
     auto acceptTaskPermission = [](auto &tasks, auto &requests, const TString &requestId, const TString &permissionId) {
         auto reqIt = requests.find(requestId);
@@ -1057,12 +1058,13 @@ void TCms::AcceptPermissions(TPermissionResponse &resp, const TString &requestId
     for (size_t i = 0; i < resp.PermissionsSize(); ++i) {
         auto &permission = *resp.MutablePermissions(i);
         permission.SetId(owner + "-p-" + ToString(State->NextPermissionId++));
-        State->Permissions.emplace(permission.GetId(), TPermissionInfo(permission, requestId, owner));
+        State->Permissions.emplace(permission.GetId(), TPermissionInfo(permission, requestId, owner, priority));
         LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS, "Accepting permission"
             << ": id# " << permission.GetId()
             << ", requestId# " << requestId
-            << ", owner# " << owner);
-        ClusterInfo->AddLocks(permission, requestId, owner, &ctx);
+            << ", owner# " << owner
+            << ", priority# " << priority);
+        ClusterInfo->AddLocks(permission, requestId, owner, priority, &ctx);
 
         if (!check) {
             continue;
@@ -2099,13 +2101,13 @@ void TCms::Handle(TEvCms::TEvPermissionRequest::TPtr &ev,
     for (const auto &[_, scheduledRequest] : State->ScheduledRequests) {
         if (scheduledRequest.Priority < priority) {
             for (const auto &action : scheduledRequest.Request.GetActions()) {
-                ClusterInfo->LogManager.ApplyAction(action, ClusterInfo);
+                ClusterInfo->LogManager.ApplyAction(action, scheduledRequest.Priority, ClusterInfo);
             }
         }
     }
-    ClusterInfo->DeactivateScheduledLocks(priority);
+    ClusterInfo->DeactivateLocks(priority);
     bool ok = CheckPermissionRequest(rec, resp->Record, scheduled.Request, ctx);
-    ClusterInfo->ReactivateScheduledLocks();
+    ClusterInfo->ReactivateLocks();
     ClusterInfo->LogManager.RollbackOperations();
 
     // Schedule request if required.
@@ -2134,7 +2136,7 @@ void TCms::Handle(TEvCms::TEvPermissionRequest::TPtr &ev,
         }
 
         if (ok)
-            AcceptPermissions(resp->Record, reqId, user, ctx);
+            AcceptPermissions(resp->Record, reqId, user, priority, ctx);
 
         TMaybe<TString> maintenanceTaskId;
         if (rec.HasMaintenanceTaskId()) {
@@ -2177,14 +2179,14 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
     for (const auto &scheduled_request : State->ScheduledRequests) {
         if (scheduled_request.second.Priority < request.Priority) {
             for (const auto &action : scheduled_request.second.Request.GetActions())
-                ClusterInfo->LogManager.ApplyAction(action, ClusterInfo);
+                ClusterInfo->LogManager.ApplyAction(action, scheduled_request.second.Priority, ClusterInfo);
         }
     }
 
-    ClusterInfo->DeactivateScheduledLocks(request.Priority);
+    ClusterInfo->DeactivateLocks(request.Priority);
     request.Request.SetAvailabilityMode(rec.GetAvailabilityMode());
     bool ok = CheckPermissionRequest(request.Request, resp->Record, scheduled.Request, ctx);
-    ClusterInfo->ReactivateScheduledLocks();
+    ClusterInfo->ReactivateLocks();
     ClusterInfo->LogManager.RollbackOperations();
 
     // Schedule request if required.
@@ -2215,7 +2217,7 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
         }
 
         if (ok)
-            AcceptPermissions(resp->Record, rec.GetRequestId(), user, ctx, true);
+            AcceptPermissions(resp->Record, rec.GetRequestId(), user, priority, ctx, true);
 
         auto handle = new IEventHandle(ev->Sender, SelfId(), resp.Release(), 0, ev->Cookie);
         Execute(CreateTxStorePermissions(std::move(ev->Release()), handle, user, std::move(copy)), ctx);

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -113,12 +113,14 @@ private:
         NKikimrCms::ETenantPolicy TenantPolicy;
         NKikimrCms::EAvailabilityMode AvailabilityMode;
         bool PartialPermissionAllowed;
+        i32 Priority;
 
         TActionOptions(TDuration dur)
             : PermissionDuration(dur)
             , TenantPolicy(NKikimrCms::DEFAULT)
             , AvailabilityMode(NKikimrCms::MODE_MAX_AVAILABILITY)
             , PartialPermissionAllowed(false)
+            , Priority(0)
         {}
     };
 
@@ -362,7 +364,7 @@ private:
         TErrorInfo &error,
         const TActorContext &ctx) const;
     void AcceptPermissions(NKikimrCms::TPermissionResponse &resp, const TString &requestId,
-        const TString &owner, const TActorContext &ctx, bool check = false);
+        const TString &owner, i32 priority, const TActorContext &ctx, bool check = false);
     void ScheduleUpdateClusterInfo(const TActorContext &ctx, bool now = false);
     void ScheduleCleanup(TInstant time, const TActorContext &ctx);
     void SchedulePermissionsCleanup(const TActorContext &ctx);

--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -167,6 +167,7 @@ public:
             TString owner = permissionRowset.GetValue<Schema::Permission::Owner>();
             TString actionStr = permissionRowset.GetValue<Schema::Permission::Action>();
             ui64 deadline = permissionRowset.GetValue<Schema::Permission::Deadline>();
+            i32 priority = permissionRowset.GetValue<Schema::Permission::Priority>();
 
             TPermissionInfo permission;
             permission.PermissionId = id;
@@ -174,6 +175,7 @@ public:
             permission.Owner = owner;
             ParseFromStringSafe(actionStr, &permission.Action);
             permission.Deadline = TInstant::MicroSeconds(deadline);
+            permission.Priority = priority;
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded permission %s owned by %s valid until %s: %s",
                       id.data(), owner.data(), TInstant::MicroSeconds(deadline).ToStringLocalUpToSeconds().data(), actionStr.data());

--- a/ydb/core/cms/cms_tx_store_permissions.cpp
+++ b/ydb/core/cms/cms_tx_store_permissions.cpp
@@ -67,6 +67,7 @@ public:
         for (const auto &permission : rec.GetPermissions()) {
             const auto &id = permission.GetId();
             const auto &requestId = Scheduled ? Scheduled->RequestId : "";
+            i32 priority = Scheduled ? Scheduled->Priority : 0;
             ui64 deadline = permission.GetDeadline();
             TString actionStr;
             google::protobuf::TextFormat::PrintToString(permission.GetAction(), &actionStr);
@@ -75,7 +76,8 @@ public:
             row.Update(NIceDb::TUpdate<Schema::Permission::Owner>(Owner),
                        NIceDb::TUpdate<Schema::Permission::Action>(actionStr),
                        NIceDb::TUpdate<Schema::Permission::Deadline>(deadline),
-                       NIceDb::TUpdate<Schema::Permission::RequestID>(requestId));
+                       NIceDb::TUpdate<Schema::Permission::RequestID>(requestId),
+                       NIceDb::TUpdate<Schema::Permission::Priority>(priority));
 
             if (MaintenanceTaskId) {
                 Y_ABORT_UNLESS(Self->State->MaintenanceTasks.contains(*MaintenanceTaskId));

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -2878,7 +2878,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         env.CheckListPermissions("user", 1);
 
         // Middle priority request can continue
-        env.CheckRequest("user", r3.GetRequestId(), false, TStatus::ALLOW, 1);
+        r3 = env.CheckRequest("user", r3.GetRequestId(), false, TStatus::ALLOW, 1);
         env.CheckListPermissions("user", 2);
 
         // Done with basic request

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -625,7 +625,8 @@ static void SetupServices(TTestBasicRuntime &runtime, const TTestEnvOpts &option
     runtime.GetAppData().DynamicNameserviceConfig = dnsConfig;
     runtime.GetAppData().DisableCheckingSysNodesCms = true;
     runtime.GetAppData().BootstrapConfig = TFakeNodeWhiteboardService::BootstrapConfig;
-    
+    runtime.GetAppData().FeatureFlags.SetEnableCmsLocksPriority(options.EnableCmsLocksPriority);
+
     if (options.IsBridgeMode) {
         for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {
             for (ui32 pileId = 0; pileId < options.PileCount; ++pileId) {

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -602,6 +602,7 @@ static void SetupServices(TTestBasicRuntime &runtime, const TTestEnvOpts &option
     appConfig.MutableBootstrapConfig()->CopyFrom(TFakeNodeWhiteboardService::BootstrapConfig);
     appConfig.MutableFeatureFlags()->SetEnableCMSRequestPriorities(options.EnableCMSRequestPriorities);
     appConfig.MutableFeatureFlags()->SetEnableSingleCompositeActionGroup(options.EnableSingleCompositeActionGroup);
+    appConfig.MutableFeatureFlags()->SetEnableCmsLocksPriority(options.EnableCmsLocksPriority);
     runtime.AddLocalService(
         MakeConfigsDispatcherID(
             runtime.GetNodeId(0)),

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -96,6 +96,7 @@ struct TTestEnvOpts {
     bool EnableDynamicGroups;
     bool IsBridgeMode;
     bool EnableSimpleStateStorageConfig;
+    bool EnableCmsLocksPriority;
 
     using TNodeLocationCallback = std::function<TNodeLocation(ui32)>;
     TNodeLocationCallback NodeLocationCallback;
@@ -122,6 +123,7 @@ struct TTestEnvOpts {
         , EnableDynamicGroups(false)
         , IsBridgeMode(false)
         , EnableSimpleStateStorageConfig(false)
+        , EnableCmsLocksPriority(false)
     {
     }
 
@@ -137,6 +139,11 @@ struct TTestEnvOpts {
 
     TTestEnvOpts& WithoutEnableCMSRequestPriorities() {
         EnableCMSRequestPriorities = false;
+        return *this;
+    }
+
+    TTestEnvOpts& WithEnableCmsLocksPriority() {
+        EnableCmsLocksPriority = true;
         return *this;
     }
 

--- a/ydb/core/cms/downtime.cpp
+++ b/ydb/core/cms/downtime.cpp
@@ -50,10 +50,10 @@ void TDowntime::AddDowntime(const TLockableItem &item, TInstant now) {
     if (item.State != NKikimrCms::UP)
         AddDowntime(item.Timestamp, now, "known downtime");
 
-    if (item.Lock.Defined()) {
-        auto end = Min(now + TDuration::MicroSeconds(item.Lock->Action.GetDuration()),
-                       item.Lock->ActionDeadline);
-        AddDowntime(now, end, item.Lock->PermissionId);
+    for (auto &lock : item.Locks) {
+        auto end = Min(now + TDuration::MicroSeconds(lock.Action.GetDuration()),
+                       lock.ActionDeadline);
+        AddDowntime(now, end, lock.PermissionId);
     }
 
     for (auto &lock : item.ExternalLocks) {

--- a/ydb/core/cms/downtime_ut.cpp
+++ b/ydb/core/cms/downtime_ut.cpp
@@ -121,7 +121,7 @@ Y_UNIT_TEST_SUITE(TDowntimeTest) {
                       t6, t8, "notification-1");
 
         pdisk.State = DOWN;
-        pdisk.Lock.Clear();
+        pdisk.Locks.clear();
         pdisk.ExternalLocks.clear();
         pdisk.Downtime.Clear();
         downtime2.Clear();
@@ -138,7 +138,7 @@ Y_UNIT_TEST_SUITE(TDowntimeTest) {
         downtime2.AddDowntime(pdisk, t3);
         CheckDowntime(downtime2, t3, t4, "permission-2");
 
-        pdisk.Lock.Clear();
+        pdisk.Locks.clear();
         TNotificationInfo notification2;
         notification2.NotificationId = "notification-2";
         notification2.Notification.SetTime(t2.GetValue());

--- a/ydb/core/cms/node_checkers.cpp
+++ b/ydb/core/cms/node_checkers.cpp
@@ -69,7 +69,7 @@ bool TNodesCounterBase::IsNodeLocked(ui32 nodeId, i32 priority) const {
         return false;
     }
 
-    if (AppData()->FeatureFlags.GetEnableCmsLocksPriority()) {
+    if (HasAppData() && AppData()->FeatureFlags.GetEnableCmsLocksPriority()) {
         return node.Locks.begin()->Priority <= priority;
     } else {
         return true; // only one lock is allowed despite of its priority

--- a/ydb/core/cms/node_checkers.cpp
+++ b/ydb/core/cms/node_checkers.cpp
@@ -1,11 +1,18 @@
 #include "node_checkers.h"
 
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/base/feature_flags.h>
+
 #include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NCms {
 
 #define NCH_LOG_D(stream) LOG_DEBUG_S (*TlsActivationContext, NKikimrServices::CMS, "[Nodes Counter] " << stream)
 #define NCH_LOG_T(stream) LOG_TRACE_S (*TlsActivationContext, NKikimrServices::CMS, "[Nodes Counter] " << stream)
+
+INodesChecker::TLock::TLock(i32 priority)
+    : Priority(priority)
+{}
 
 TNodesLimitsCounterBase::ENodeState INodesChecker::NodeState(NKikimrCms::EState state) {
     switch (state) {
@@ -23,27 +30,27 @@ TNodesLimitsCounterBase::ENodeState INodesChecker::NodeState(NKikimrCms::EState 
 }
 
 void TNodesCounterBase::AddNode(ui32 nodeId) {
-    if (NodeToState.contains(nodeId)) {
+    if (Nodes.contains(nodeId)) {
         return;
     }
-    NodeToState[nodeId] = NODE_STATE_UNSPECIFIED;
+    Nodes[nodeId] = { .State = NODE_STATE_UNSPECIFIED };
 }
 
 void TNodesCounterBase::UpdateNode(ui32 nodeId, NKikimrCms::EState state) {
-    if (!NodeToState.contains(nodeId)) {
+    if (!Nodes.contains(nodeId)) {
         AddNode(nodeId);
     }
 
-    if (NodeToState[nodeId] == NODE_STATE_DOWN) {
+    if (Nodes[nodeId].State == NODE_STATE_DOWN) {
         --DownNodesCount;
     }
 
-    if (IsNodeLocked(nodeId)) {
+    if (Nodes[nodeId].State == NODE_STATE_RESTART || Nodes[nodeId].State == NODE_STATE_LOCKED) {
         --LockedNodesCount;
     }
 
     const auto nodeState = NodeState(state);
-    NodeToState[nodeId] = nodeState;
+    Nodes[nodeId].State = nodeState;
 
     if (nodeState == NODE_STATE_RESTART || nodeState == NODE_STATE_LOCKED) {
         ++LockedNodesCount;
@@ -54,42 +61,70 @@ void TNodesCounterBase::UpdateNode(ui32 nodeId, NKikimrCms::EState state) {
     }
 }
 
-bool TNodesCounterBase::IsNodeLocked(ui32 nodeId) const {
-    Y_ABORT_UNLESS(NodeToState.contains(nodeId));
-    return NodeToState.at(nodeId) == NODE_STATE_RESTART || NodeToState.at(nodeId) == NODE_STATE_LOCKED;
-}   
+bool TNodesCounterBase::IsNodeLocked(ui32 nodeId, i32 priority) const {
+    Y_ABORT_UNLESS(Nodes.contains(nodeId));
+    const auto& node = Nodes.at(nodeId);
 
-void TNodesCounterBase::LockNode(ui32 nodeId) {
-    Y_ABORT_UNLESS(!IsNodeLocked(nodeId));
+    if (node.Locks.empty()) {
+        return false;
+    }
 
-    ++LockedNodesCount;
-    if (NodeToState[nodeId] == NODE_STATE_DOWN) {
-        NodeToState[nodeId] = NODE_STATE_RESTART;
-        --DownNodesCount;
+    if (AppData()->FeatureFlags.GetEnableCmsLocksPriority()) {
+        return node.Locks.begin()->Priority <= priority;
     } else {
-        NodeToState[nodeId] = NODE_STATE_LOCKED;
+        return true; // only one lock is allowed despite of its priority
     }
 }
 
-void TNodesCounterBase::UnlockNode(ui32 nodeId) {
-    Y_ABORT_UNLESS(IsNodeLocked(nodeId));
-   
-    --LockedNodesCount;
-    if (NodeToState[nodeId] == NODE_STATE_RESTART) {
-        NodeToState[nodeId] = NODE_STATE_DOWN;
-        ++DownNodesCount;
-    } else {
-        NodeToState[nodeId] = NODE_STATE_UP;
+void TNodesCounterBase::LockNode(ui32 nodeId, i32 priority) {
+    Y_ABORT_UNLESS(!IsNodeLocked(nodeId, priority));
+
+    auto& node = Nodes[nodeId];
+
+    if (node.Locks.empty()) {
+        ++LockedNodesCount;
+        if (node.State == NODE_STATE_DOWN) {
+            node.State = NODE_STATE_RESTART;
+            --DownNodesCount;
+        } else {
+            node.State = NODE_STATE_LOCKED;
+        }
+    }
+
+    TLock lock(priority);
+    auto pos = LowerBound(node.Locks.begin(), node.Locks.end(), lock, [](auto &l, auto &r) {
+        return l.Priority < r.Priority;
+    });
+    node.Locks.insert(pos, std::move(lock));
+}
+
+void TNodesCounterBase::UnlockNode(ui32 nodeId, i32 priority) {
+    auto& node = Nodes[nodeId];
+
+    auto pos = LowerBoundBy(node.Locks.begin(), node.Locks.end(), priority, [](auto &l) {
+        return l.Priority;
+    });
+    Y_ABORT_UNLESS(pos != node.Locks.end());
+    node.Locks.erase(pos);
+
+    if (node.Locks.empty()) {
+        --LockedNodesCount;
+        if (node.State == NODE_STATE_RESTART) {
+            node.State = NODE_STATE_DOWN;
+            ++DownNodesCount;
+        } else {
+            node.State = NODE_STATE_UP;
+        }
     }
 }
 
-const THashMap<ui32, INodesChecker::ENodeState>& TNodesCounterBase::GetNodeToState() const {
-    return NodeToState;
+const THashMap<ui32, INodesChecker::TNodeInfo>& TNodesCounterBase::GetNodes() const {
+    return Nodes;
 }
 
-bool TNodesLimitsCounterBase::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabilityMode mode, TReason& reason) const {
-    Y_ABORT_UNLESS(NodeToState.contains(nodeId));
-    auto nodeState = NodeToState.at(nodeId);
+bool TNodesLimitsCounterBase::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabilityMode mode, i32 priority, TReason& reason) const {
+    Y_ABORT_UNLESS(Nodes.contains(nodeId));
+    auto nodeState = Nodes.at(nodeId).State;
 
     NCH_LOG_D("Checking Node: "
             << nodeId << ", with state: " << nodeState
@@ -102,11 +137,19 @@ bool TNodesLimitsCounterBase::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabili
         case NODE_STATE_UP:
             break;
         case NODE_STATE_UNSPECIFIED:
-        case NODE_STATE_LOCKED:
-        case NODE_STATE_RESTART:
             reason = TStringBuilder() << ReasonPrefix(nodeId)
                 << ": node state: '" << nodeState << "'";
             return false;
+        case NODE_STATE_LOCKED:
+        case NODE_STATE_RESTART:
+            if (IsNodeLocked(nodeId, priority)) {
+                reason = TStringBuilder() << ReasonPrefix(nodeId)
+                    << ": node state: '" << nodeState << "'";
+                return false;
+            } else {
+                // Allow to maintain nodes that locked by lower priority locks
+                return true;
+            }
         case NODE_STATE_DOWN:
             // Allow to maintain down/unavailable node
             return true;
@@ -135,13 +178,13 @@ bool TNodesLimitsCounterBase::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabili
         return false;
     }
 
-    if (DisabledNodesRatioLimit > 0 && (disabledNodes * 100 > NodeToState.size() * DisabledNodesRatioLimit)) {
+    if (DisabledNodesRatioLimit > 0 && (disabledNodes * 100 > Nodes.size() * DisabledNodesRatioLimit)) {
         reason = TReason(
             TStringBuilder() << ReasonPrefix(nodeId)
             << ": too many unavailable nodes."
             << " Locked: " << LockedNodesCount
             << ", down: " << DownNodesCount
-            << ", total: " << NodeToState.size()
+            << ", total: " << Nodes.size()
             << ", limit: " << DisabledNodesRatioLimit << "%",
             DisabledNodesLimitReachedReasonType()
         );
@@ -151,9 +194,9 @@ bool TNodesLimitsCounterBase::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabili
     return true;
 }
 
-bool TSysTabletsNodesCounter::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabilityMode mode, TReason& reason) const {
-    Y_ABORT_UNLESS(NodeToState.contains(nodeId));
-    auto nodeState = NodeToState.at(nodeId);
+bool TSysTabletsNodesCounter::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabilityMode mode, i32 priority, TReason& reason) const {
+    Y_ABORT_UNLESS(Nodes.contains(nodeId));
+    auto nodeState = Nodes.at(nodeId).State;
 
     NCH_LOG_D("Checking limits for sys tablet: " << NKikimrConfig::TBootstrap_ETabletType_Name(TabletType)
             << ", on node: " << nodeId
@@ -165,17 +208,25 @@ bool TSysTabletsNodesCounter::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabili
         case NODE_STATE_UP:
             break;
         case NODE_STATE_UNSPECIFIED:
-        case NODE_STATE_LOCKED:
-        case NODE_STATE_RESTART:
             reason = TStringBuilder() << "Cannot lock node '" << nodeId << "'"
                 << ": node state: '" << nodeState << "'";
             return false;
+        case NODE_STATE_LOCKED:
+        case NODE_STATE_RESTART:
+            if (IsNodeLocked(nodeId, priority)) {
+                reason = TStringBuilder() << "Cannot lock node '" << nodeId << "'"
+                    << ": node state: '" << nodeState << "'";
+                return false;
+            } else {
+                // Allow to maintain nodes that locked by lower priority locks
+                return true;
+            }
         case NODE_STATE_DOWN:
             // Allow to maintain down/unavailable node
             return true;
     }
 
-    const auto tabletNodes = NodeToState.size();
+    const auto tabletNodes = Nodes.size();
     if (tabletNodes < 1) {
         return true;
     }
@@ -187,13 +238,13 @@ bool TSysTabletsNodesCounter::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabili
         case NKikimrCms::MODE_FORCE_RESTART:
             return true;
         case NKikimrCms::MODE_MAX_AVAILABILITY:
-            limit = NodeToState.size() / 2;
+            limit = Nodes.size() / 2;
             if (disabledNodes * 2 <= tabletNodes) {
                 return true;
             }
             break;
         case NKikimrCms::MODE_KEEP_AVAILABLE:
-            limit = NodeToState.size() - 1;
+            limit = Nodes.size() - 1;
             if (disabledNodes < tabletNodes) {
                 return true;
             }

--- a/ydb/core/cms/priority_lock.h
+++ b/ydb/core/cms/priority_lock.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "defs.h"
+
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/base/feature_flags.h>
+
+#include <list>
+
+namespace NKikimr::NCms {
+
+template<typename T>
+void AddPriorityLock(std::list<T>& locks, T&& lock) {
+    auto pos = LowerBound(locks.begin(), locks.end(), lock, [](auto &l, auto &r) {
+        return l.Priority < r.Priority;
+    });
+    locks.insert(pos, std::move(lock));
+}
+
+template<typename T>
+void RemovePriorityLocks(std::list<T>& locks, i32 priority) {
+    auto begin = LowerBoundBy(locks.begin(), locks.end(), priority, [](auto &l) {
+        return l.Priority;
+    });
+
+    auto end = UpperBoundBy(locks.begin(), locks.end(), priority, [](auto &l) {
+        return l.Priority;
+    });
+
+    Y_ABORT_UNLESS(begin != end);
+    locks.erase(begin, end);
+}
+
+template<typename T>
+bool HasSameOrHigherPriorityLock(const std::list<T>& locks, i32 priority) {
+    if (locks.empty()) {
+        return false;
+    }
+
+    if (HasAppData() && AppData()->FeatureFlags.GetEnableCmsLocksPriority()) {
+        return locks.begin()->Priority <= priority;
+    } else {
+        return true; // only one lock is allowed despite of its priority
+    }
+}
+
+} // namespace NKikimr::NCms

--- a/ydb/core/cms/scheme.h
+++ b/ydb/core/cms/scheme.h
@@ -30,9 +30,10 @@ struct Schema : NIceDb::Schema {
         struct Action : Column<3, NScheme::NTypeIds::Utf8> {};
         struct Deadline : Column<4, NScheme::NTypeIds::Uint64> {};
         struct RequestID : Column<5, NScheme::NTypeIds::Utf8> {};
+        struct Priority : Column<6, NScheme::NTypeIds::Int32> {};
 
         using TKey = TableKey<ID>;
-        using TColumns = TableColumns<ID, Owner, Action, Deadline, RequestID>;
+        using TColumns = TableColumns<ID, Owner, Action, Deadline, RequestID, Priority>;
     };
 
     struct Request : Table<3> {

--- a/ydb/core/cms/ya.make
+++ b/ydb/core/cms/ya.make
@@ -27,10 +27,10 @@ SRCS(
     cms_tx_update_config.cpp
     cms_tx_update_downtimes.cpp
     defs.h
-    downtime.h
     downtime.cpp
-    erasure_checkers.h
+    downtime.h
     erasure_checkers.cpp
+    erasure_checkers.h
     error_info.h
     http.cpp
     http.h
@@ -46,12 +46,13 @@ SRCS(
     json_proxy_proto.h
     json_proxy_sentinel.h
     json_proxy_toggle_config_validator.h
+    log_formatter.h
     logger.cpp
     logger.h
     node_checkers.cpp
     node_checkers.h
-    log_formatter.h
     pdiskid.h
+    priority_lock.h
     scheme.h
     sentinel.cpp
     services.cpp

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -246,4 +246,5 @@ message TFeatureFlags {
     optional bool UseYdsTopicStorageMetering = 220 [default = false];
     optional bool EnableIndexMaterialization = 221 [default = false];
     optional bool EnableFsBackups = 222 [default = false];
+    optional bool EnableCmsLocksPriority = 223 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add that maintenance task can acquire lock on a host even if it is already locked by lower priority task

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

This pull request adds support for maintenance tasks to acquire locks on hosts that are already locked by lower priority tasks. The feature is controlled by a new feature flag `EnableCmsLocksPriority` and introduces priority-based lock management where multiple locks can coexist on a single node, ordered by priority (lower values = higher priority).

### Key Changes:
- Introduced priority field to permission schema and lock structures
- Changed lock management from single lock per item to a priority-ordered list of locks
- Updated lock checking logic to allow higher priority requests to proceed even when nodes are locked by lower priority requests
- Added feature flag `EnableCmsLocksPriority` for gradual rollout

