### PR TITLE
SIGSEGV error in TKafkaProduceActor

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -230,9 +230,16 @@ void TKafkaProduceActor::ProcessRequests(const TActorContext& ctx) {
         return;
     }
 
+    if (ProcessingRequests) {
+        return;
+    }
+
     if (Requests.empty()) {
         return;
     }
+
+    ProcessingRequests = true;
+    Y_DEFER { ProcessingRequests = false; };
 
     auto canProcess = EnqueueInitialization();
     while (canProcess--) {

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
@@ -195,6 +195,8 @@ private:
     std::pair<TKafkaProduceActor::ETopicStatus, TActorId> GetOrCreateNonTransactionalWriter(const TTopicPartition& topicPartition, const TTopicInfo& topicInfo, const TProducerInstanceId& producerInstanceId, const TActorContext& ctx);
     std::pair<TKafkaProduceActor::ETopicStatus, TActorId> GetOrCreateTransactionalWriter(const TTopicPartition& topicPartition, const TTopicInfo& topicInfo, const TProducerInstanceId& producerInstanceId, const TString& transactionalId, const TActorContext& ctx);
     std::pair<TKafkaProduceActor::ETopicStatus, TActorId> CreateTransactionalWriter(const TTopicPartition& topicPartition, const TTopicInfo& topicInfo, const TProducerInstanceId& producerInstanceId, const TString& transactionalId, const TActorContext& ctx);
+
+    bool ProcessingRequests = false;
 };
 
 }

--- a/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
@@ -9,6 +9,13 @@ namespace {
 
     class TDummySchemeCacheActor : public TActor<TDummySchemeCacheActor> {
         public:
+            enum EEv {
+                EvReplyTopicNotFound = EventSpaceBegin(TEvents::ES_PRIVATE),
+            };
+
+            struct TEvReplyTopicNotFound : public TEventLocal<TEvReplyTopicNotFound, EvReplyTopicNotFound> {
+            };
+
             TDummySchemeCacheActor(ui64 pqTabletId) :
                 TActor<TDummySchemeCacheActor>(&TDummySchemeCacheActor::StateFunc),
                 PqTabletId(pqTabletId) {}
@@ -17,7 +24,9 @@ namespace {
                 auto response = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
                 for (auto& requestedEntry : ev->Get()->Request->ResultSet) {
                     NSchemeCache::TSchemeCacheNavigate::TEntry entry;
-                    entry.Status = NSchemeCache::TSchemeCacheNavigate::EStatus::Ok;
+                    entry.Status = ReplyTopicNotFound
+                        ? NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown
+                        : NSchemeCache::TSchemeCacheNavigate::EStatus::Ok;
                     entry.Path = requestedEntry.Path;
                     auto groupInfo = std::make_unique<NKikimr::NSchemeCache::TSchemeCacheNavigate::TPQGroupInfo>();
                     groupInfo->Description.MutablePQTabletConfig()->SetMeteringMode(NKikimrPQ::TPQTabletConfig_EMeteringMode_METERING_MODE_REQUEST_UNITS);
@@ -31,14 +40,24 @@ namespace {
                 Send(ev->Sender, MakeHolder<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(response.release()));
             }
 
+            void Handle(TEvReplyTopicNotFound::TPtr&, const TActorContext&) {
+                SetReplyTopicNotFound(true);
+            }
+
         private:
             STFUNC(StateFunc) {
                 switch (ev->GetTypeRewrite()) {
                     HFunc(TEvTxProxySchemeCache::TEvNavigateKeySet, Handle);
+                    HFunc(TEvReplyTopicNotFound, Handle);
                 }
             }
 
+            void SetReplyTopicNotFound(bool value) {
+                ReplyTopicNotFound = value;
+            }
+
             ui64 PqTabletId;
+            bool ReplyTopicNotFound = false;
         };
 
     class TProduceActorFixture : public NUnitTest::TBaseFixture {
@@ -125,6 +144,11 @@ namespace {
                 record.MutablePartitionResponse()->SetCookie(cookie);
                 event->Record = record;
                 return event;
+            }
+
+            void SetSchemeCacheReplyTopicNotFound() {
+                auto ev = std::make_unique<TDummySchemeCacheActor::TEvReplyTopicNotFound>();
+                Ctx->Runtime->SingleSys()->Send(new IEventHandle(MakeSchemeCacheID(), Ctx->Edge, ev.release()));
             }
         };
 
@@ -355,6 +379,29 @@ namespace {
                 UNIT_ASSERT_VALUES_EQUAL(std::dynamic_pointer_cast<NKafka::TProduceResponseData>(response->Response)->Responses[0].PartitionResponses[0].ErrorCode,
                     NKafka::EKafkaErrors::NONE_ERROR);
             }
+        }
+
+        Y_UNIT_TEST(OnUnknownTopic_ShouldReturnUNKNOWN_TOPIC_OR_PARTITION) {
+            const i64 producerId = 0;
+            const i32 producerEpoch = 0;
+
+            SetSchemeCacheReplyTopicNotFound();
+
+            SendProduce(TransactionalId, producerId, producerEpoch + 0);
+            SendProduce(TransactionalId, producerId, producerEpoch + 1);
+            SendProduce(TransactionalId, producerId, producerEpoch + 2);
+
+            auto response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+            UNIT_ASSERT(response != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+
+            response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+            UNIT_ASSERT(response != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+
+            response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+            UNIT_ASSERT(response != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
         }
     }
 } // anonymous namespace


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue #31381

Recursive calls to `ProcessRequests` are possible. As a result, the loop for `canProcess` works with outdated data and does not take into account that the `Requests` queue has already changed. As a result, `Requests.front` is called for an empty queue.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
