### PR TITLE
KIKIMR-21962: Remove antlr4 flag references

### DIFF
--- a/ydb/core/fq/libs/actors/run_actor.cpp
+++ b/ydb/core/fq/libs/actors/run_actor.cpp
@@ -2078,7 +2078,6 @@ private:
         NSQLTranslation::TTranslationSettings sqlSettings;
         sqlSettings.ClusterMapping = clusters;
         sqlSettings.SyntaxVersion = 1;
-        sqlSettings.Antlr4Parser = true;
         sqlSettings.PgParser = (Params.QuerySyntax == FederatedQuery::QueryContent::PG);
         sqlSettings.V0Behavior = NSQLTranslation::EV0Behavior::Disable;
         sqlSettings.Flags.insert({ "DqEngineEnable", "DqEngineForce", "DisableAnsiOptionalAs", "FlexibleTypes", "AnsiInForEmptyOrNullableItemsCollections" });

--- a/ydb/core/kqp/host/kqp_translate.cpp
+++ b/ydb/core/kqp/host/kqp_translate.cpp
@@ -195,7 +195,6 @@ TKqpTranslationSettingsBuilder& TKqpTranslationSettingsBuilder::SetFromConfig(co
 NSQLTranslation::TTranslationSettings TKqpTranslationSettingsBuilder::Build(NYql::TExprContext& ctx) {
     NSQLTranslation::TTranslationSettings settings;
     settings.PgParser = UsePgParser && *UsePgParser;
-    settings.Antlr4Parser = true;
     settings.EmitReadsForExists = true;
     settings.LangVer = LangVer;
     settings.BackportMode = BackportMode;

--- a/ydb/core/sys_view/show_create/create_view_formatter.cpp
+++ b/ydb/core/sys_view/show_create/create_view_formatter.cpp
@@ -90,7 +90,7 @@ TString TrimQuotes(TString&& s) {
 }
 
 bool GetTablePathPrefix(const TString& query, const TParsers& parsers, const TTranslationSettings& settings, TString& tablePathPrefix, TIssues& issues) {
-    const auto* message = SqlAST(parsers, query, settings.File, issues, SQL_MAX_PARSER_ERRORS, settings.AnsiLexer, settings.Antlr4Parser, settings.Arena);
+    const auto* message = SqlAST(parsers, query, settings.File, issues, SQL_MAX_PARSER_ERRORS, settings.AnsiLexer, settings.Arena);
     if (!message || message->GetDescriptor()->name() != "TSQLv1ParserAST") {
         issues.AddIssue(TStringBuilder() << "Cannot parse query: " << query.Quote());
         return false;

--- a/ydb/public/lib/ydb_cli/common/yql_parser/yql_parser.cpp
+++ b/ydb/public/lib/ydb_cli/common/yql_parser/yql_parser.cpp
@@ -345,7 +345,7 @@ std::optional<std::map<std::string, TType>> TYqlParamParser::GetParamTypes(const
     lexers.Antlr4 = NSQLTranslationV1::MakeAntlr4LexerFactory();
     lexers.Antlr4Ansi = NSQLTranslationV1::MakeAntlr4AnsiLexerFactory();
 
-    auto lexer = MakeLexer(lexers, /* ansi = */ false, /* antlr4 = */ true);
+    auto lexer = MakeLexer(lexers, /* ansi = */ false);
 
     TVector<NSQLTranslation::TParsedToken> tokens;
     NYql::TIssues issues;
@@ -357,19 +357,19 @@ std::optional<std::map<std::string, TType>> TYqlParamParser::GetParamTypes(const
     EParseState state = EParseState::Start;
     TString paramName;
 
-    for (size_t i = 0; i < tokens.size(); ++i) {      
+    for (size_t i = 0; i < tokens.size(); ++i) {
         if (tokens[i].Name == "WS") {
             continue;
         }
 
         if (state == EParseState::Start) {
             if (ToLower(tokens[i].Content) != "declare") {
-                continue;   
+                continue;
             }
 
             state = EParseState::Declare;
         } else if (state == EParseState::Declare) {
-            if (tokens[i].Content != "$") { 
+            if (tokens[i].Content != "$") {
                 return std::nullopt;
             }
 

--- a/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/query_utils.cpp
@@ -309,7 +309,7 @@ bool SqlToProtoAst(const TString& queryStr, TRule_sql_query& queryProto, NYql::T
 
     google::protobuf::Arena arena;
     const auto* parserProto = NSQLTranslationV1::SqlAST(
-        parsers, queryStr, "query", issues, NSQLTranslation::SQL_MAX_PARSER_ERRORS, settings.AnsiLexer, settings.Antlr4Parser, &arena
+        parsers, queryStr, "query", issues, NSQLTranslation::SQL_MAX_PARSER_ERRORS, settings.AnsiLexer, &arena
     );
     if (!parserProto) {
         return false;

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -133,7 +133,7 @@ bool SplitViewQuery(
         NYql::TIssues& issues)
 {
     TVector<TString> statements;
-    auto lexer = MakeLexer(lexers, translationSettings.AnsiLexer, translationSettings.Antlr4Parser);
+    auto lexer = MakeLexer(lexers, translationSettings.AnsiLexer);
     if (!SplitQueryToStatements(query, lexer, statements, issues)) {
         return false;
     }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Want to remove the `Antlr4Parser` flag from the `TTranslationSettings`, so trying to remove all references from the YDB.
