### PR TITLE
stable 25-4: enable MirroredTopicSplitMerge feature flag by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -223,7 +223,7 @@ message TFeatureFlags {
     optional bool EnableCompactionOverloadDetection = 197 [default = true];
     reserved 198; // DisableColumnShardBulkUpsertRequireAllColumns
     optional bool EnableDataShardWriteAlwaysVolatile = 199 [default = true];
-    optional bool EnableMirroredTopicSplitMerge = 200 [default = false];
+    optional bool EnableMirroredTopicSplitMerge = 200 [default = true];
     optional bool EnableFulltextIndex = 201 [default = false];
     optional bool EnableSetColumnConstraint = 202 [default = false];
     optional bool EnableSchemaSecrets = 203 [default = false];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


Change flag's default value
KIKIMR-23621

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

cherry-pick of #31398
