### PR TITLE
Optimize IC event serializer

### DIFF
--- a/ydb/library/actors/core/actorsystem.cpp
+++ b/ydb/library/actors/core/actorsystem.cpp
@@ -208,6 +208,10 @@ namespace NActors {
             bool WriteString(const TString *s) override {
                 return WriteAliasedRaw(s->data(), s->size());
             }
+
+            NProtoBuf::io::CodedOutputStream *GetCodedOutputStream() override {
+                return nullptr;
+            }
         };
 
         TSerializerChecker checker;

--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -125,7 +125,7 @@ namespace NActors {
         Y_ABORT_UNLESS(count > 0);
         Y_ABORT_UNLESS(!Chunks.empty());
         TChunk& buf = Chunks.back();
-        Y_ABORT_UNLESS((size_t)count <= buf.second);
+        Y_ABORT_UNLESS((size_t)count <= buf.second, "count# %d buf.second# %zu", count, buf.second);
         Y_ABORT_UNLESS(buf.first + buf.second == BufferPtr, "buf# %p:%zu BufferPtr# %p SizeRemain# %zu NumChunks# %zu",
             buf.first, buf.second, BufferPtr, SizeRemain, Chunks.size());
         buf.second -= count;
@@ -188,6 +188,7 @@ namespace NActors {
         while (!CancelFlag) {
             Y_ABORT_UNLESS(Event);
             SerializationSuccess = !AbortFlag && Event->SerializeToArcadiaStream(this);
+            CodedOutputStream.reset();
             Event = nullptr;
             if (!CancelFlag) { // cancel flag may have been received during serialization
                 InnerContext.SwitchTo(BufFeedContext);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Optimize IC event serializer

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This removes redundant byte size calculation during protobuf serialization.
