### PR TITLE
fq control plane storage: prevent u-a-f in future callbacks on termination

### DIFF
--- a/ydb/core/fq/libs/control_plane_storage/in_memory_control_plane_storage.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/in_memory_control_plane_storage.cpp
@@ -419,11 +419,12 @@ private:
         const TString& queryId = query.meta().common().id();
         ctx.Response.first.set_query_id(queryId);
 
-        auto queryInternal = GetQueryInternalProto(ctx.Request, ctx.CloudId, ctx.Token, ctx.Quotas);
+        auto queryInternal = GetQueryInternalProto(Config, ctx.Request, ctx.CloudId, ctx.Token, ctx.Quotas);
         const auto queryType = ctx.Request.content().type();
         if (ctx.Request.execute_mode() != FederatedQuery::SAVE) {
             *queryInternal.mutable_compute_connection() = ctx.ComputeDatabase.connection();
             FillConnectionsAndBindings(
+                Config,
                 queryInternal,
                 queryType,
                 GetEntities(Connections, ctx.Scope, ctx.User),
@@ -472,7 +473,7 @@ private:
         }
 
         *ctx.Response.mutable_query() = query->Query;
-        FillDescribeQueryResult(ctx.Response, query->QueryInternal, ctx.User, ctx.Permissions);
+        FillDescribeQueryResult(Config, ctx.Response, query->QueryInternal, ctx.User, ctx.Permissions);
     }
 
     void Handle(TEvControlPlaneStorage::TEvModifyQueryRequest::TPtr& ev) {
@@ -833,7 +834,7 @@ private:
 
         TDuration backoff = Config->TaskLeaseTtl;
         TInstant expireAt = ctx.StartTime + Config->AutomaticQueriesTtl;
-        UpdateTaskInfo(TActivationContext::ActorSystem(), resuest, finalStatus, query->Query, query->QueryInternal, job->Job, pendingQuery->Owner, pendingQuery->RetryLimiter, backoff, expireAt);
+        UpdateTaskInfo(TActivationContext::ActorSystem(), Config, resuest, finalStatus, query->Query, query->QueryInternal, job->Job, pendingQuery->Owner, pendingQuery->RetryLimiter, backoff, expireAt);
         PingTask(ctx, *query, *job, *pendingQuery, backoff, expireAt);
 
         if (IsTerminalStatus(ctx.Request.status())) {

--- a/ydb/core/fq/libs/control_plane_storage/internal/nodes_health_check.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/internal/nodes_health_check.cpp
@@ -67,7 +67,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvNodesHealth
         "WHERE `" TENANT_COLUMN_NAME"` = $tenant AND `" EXPIRE_AT_COLUMN_NAME "` >= $now;\n"
     );
 
-    auto prepareParams = [=, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [tenant, nodeId, instanceId, hostName, deadline, activeWorkers, memoryLimit, memoryAllocated, icPort, nodeAddress, dataCenter, response=response, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
         for (const auto& resultSet : resultSets) {
             TResultSetParser parser(resultSet);
             while (parser.TryNextRow()) {

--- a/ydb/core/fq/libs/control_plane_storage/internal/nodes_health_check.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/internal/nodes_health_check.cpp
@@ -67,7 +67,10 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvNodesHealth
         "WHERE `" TENANT_COLUMN_NAME"` = $tenant AND `" EXPIRE_AT_COLUMN_NAME "` >= $now;\n"
     );
 
-    auto prepareParams = [tenant, nodeId, instanceId, hostName, deadline, activeWorkers, memoryLimit, memoryAllocated, icPort, nodeAddress, dataCenter, response=response, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [tenant, nodeId, instanceId, hostName, deadline, activeWorkers, memoryLimit, memoryAllocated, icPort, nodeAddress, dataCenter, response=response, tablePathPrefix=YdbConnection->TablePathPrefix, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         for (const auto& resultSet : resultSets) {
             TResultSetParser parser(resultSet);
             while (parser.TryNextRow()) {

--- a/ydb/core/fq/libs/control_plane_storage/internal/nodes_health_check.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/internal/nodes_health_check.cpp
@@ -67,10 +67,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvNodesHealth
         "WHERE `" TENANT_COLUMN_NAME"` = $tenant AND `" EXPIRE_AT_COLUMN_NAME "` >= $now;\n"
     );
 
-    auto prepareParams = [tenant, nodeId, instanceId, hostName, deadline, activeWorkers, memoryLimit, memoryAllocated, icPort, nodeAddress, dataCenter, response=response, tablePathPrefix=YdbConnection->TablePathPrefix, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [tenant, nodeId, instanceId, hostName, deadline, activeWorkers, memoryLimit, memoryAllocated, icPort, nodeAddress, dataCenter, response=response, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
         for (const auto& resultSet : resultSets) {
             TResultSetParser parser(resultSet);
             while (parser.TryNextRow()) {

--- a/ydb/core/fq/libs/control_plane_storage/internal/task_get.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/internal/task_get.cpp
@@ -134,7 +134,8 @@ std::tuple<TString, NYdb::TParams, std::function<std::pair<TString, NYdb::TParam
     const TDuration& resultSetsTtl,
     std::shared_ptr<TTenantInfo> tenantInfo,
     const TRequestCommonCountersPtr& commonCounters,
-    ui32 requestNodeId)
+    ui32 requestNodeId,
+    std::weak_ptr<bool>& Alive)
 {
     const auto& task = taskInternal.Task;
 
@@ -153,7 +154,10 @@ std::tuple<TString, NYdb::TParams, std::function<std::pair<TString, NYdb::TParam
         "WHERE `" TENANT_COLUMN_NAME "` = $tenant AND `" SCOPE_COLUMN_NAME "` = $scope AND `" QUERY_ID_COLUMN_NAME "` = $query_id AND `" ASSIGNED_UNTIL_COLUMN_NAME "` < $now;\n"
     );
 
-    auto prepareParams = [commonCounters=commonCounters, nowTimestamp=nowTimestamp, taskLeaseUntil=taskLeaseUntil, automaticQueriesTtl=automaticQueriesTtl, resultSetsTtl=resultSetsTtl, disableCurrentIam, requestNodeId, taskInternal=taskInternal, responseTasks=responseTasks, tenantInfo=tenantInfo](const std::vector<TResultSet>& resultSets) mutable {
+    auto prepareParams = [commonCounters=commonCounters, nowTimestamp=nowTimestamp, taskLeaseUntil=taskLeaseUntil, automaticQueriesTtl=automaticQueriesTtl, resultSetsTtl=resultSetsTtl, disableCurrentIam, requestNodeId, taskInternal=taskInternal, responseTasks=responseTasks, tenantInfo=tenantInfo, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) mutable {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         auto& task = taskInternal.Task;
         const auto shouldAbortTask = taskInternal.ShouldAbortTask;
         constexpr size_t expectedResultSetsSize = 2;
@@ -420,8 +424,12 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvGetTaskRequ
                              tenantInfo=ev->Get()->TenantInfo,
                              owner, hostName, tenantName, tasksBatchSize, requestNodeId,
                              numTasksProportion, Config=Config,
-                             tablePathPrefix=YdbConnection->TablePathPrefix
+                             tablePathPrefix=YdbConnection->TablePathPrefix,
+                             alive=std::weak_ptr(Alive)
                         ](const std::vector<TResultSet>& resultSets) mutable {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         TVector<TTaskInternal> tasks;
         TVector<TPickTaskParams> pickTaskParams;
         const auto now = TInstant::Now();
@@ -472,7 +480,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvGetTaskRequ
         for (size_t i = 0; i < numTasks; ++i) {
             auto tupleParams = MakeGetTaskUpdateQuery(tasks[i],
                 responseTasks, now, now + Config->TaskLeaseTtl, Config->Proto.GetDisableCurrentIam(),
-                Config->AutomaticQueriesTtl, Config->ResultSetsTtl, tenantInfo, commonCounters, requestNodeId); // using for win32 build
+                Config->AutomaticQueriesTtl, Config->ResultSetsTtl, tenantInfo, commonCounters, requestNodeId, alive); // using for win32 build
             auto readQuery = std::get<0>(tupleParams);
             auto readParams = std::get<1>(tupleParams);
             auto prepareParams = std::get<2>(tupleParams);

--- a/ydb/core/fq/libs/control_plane_storage/internal/task_get.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/internal/task_get.cpp
@@ -492,7 +492,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvGetTaskRequ
     const auto query = queryBuilder.Build();
     auto [readStatus, resultSets] = Read(query.Sql, query.Params, requestCounters, debugInfo, TTxSettings::StaleRO());
     auto result = readStatus.Apply(
-        [this, // TODO used for PickTasks, try to avoid
+        [dbPool=DbPool,
         prepareParams, Config=Config, response, owner,
         resultSets=resultSets,
         requestCounters=requestCounters,
@@ -521,7 +521,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvGetTaskRequ
 
         TVector<TFuture<void>> futures;
         for (size_t i = 0; i < pickTaskParams.size(); ++i) {
-            futures.emplace_back(PickTask(pickTaskParams[i], requestCounters, (*debugInfos)[i], responseTasks));
+            futures.emplace_back(PickTask(dbPool, pickTaskParams[i], requestCounters, (*debugInfos)[i], responseTasks));
         }
 
         auto allFuture = NThreading::WaitExceptionOrAll(futures);

--- a/ydb/core/fq/libs/control_plane_storage/internal/task_ping.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/internal/task_ping.cpp
@@ -70,8 +70,7 @@ TYdbControlPlaneStorageActor::TPingTaskParams TYdbControlPlaneStorageActor::Cons
     );
 
     auto meteringRecords = std::make_shared<std::vector<TString>>();
-
-    auto prepareParams = [=, this, counters=counters, actorSystem = NActors::TActivationContext::ActorSystem(), request=request](const std::vector<TResultSet>& resultSets) mutable {
+    auto prepareParams = [meteringRecords, commonCounters=commonCounters, leaseLeftMs=Counters.LeaseLeftMs, config=Config, tablePathPrefix=YdbConnection->TablePathPrefix, finalStatus=finalStatus, response=response, counters=counters, actorSystem=NActors::TActivationContext::ActorSystem(), request=request](const std::vector<TResultSet>& resultSets) mutable {
         TString jobId;
         FederatedQuery::Query query;
         FederatedQuery::Internal::QueryInternal internal;
@@ -120,7 +119,7 @@ TYdbControlPlaneStorageActor::TPingTaskParams TYdbControlPlaneStorageActor::Cons
                 ythrow NKikimr::TCodeLineException(TIssuesIds::BAD_REQUEST) << "OWNER of QUERY ID = \"" << request.query_id().value() << "\" MISMATCHED: \"" << request.owner_id() << "\" (received) != \"" << owner << "\" (selected)";
             }
             auto assignedUntil = parser.ColumnParser(ASSIGNED_UNTIL_COLUMN_NAME).GetOptionalTimestamp().value_or(TInstant::Now());
-            Counters.LeaseLeftMs->Collect((assignedUntil - TInstant::Now()).MilliSeconds());
+            leaseLeftMs->Collect((assignedUntil - TInstant::Now()).MilliSeconds());
             retryLimiter.Assign(
                 parser.ColumnParser(RETRY_COUNTER_COLUMN_NAME).GetOptionalUint64().value_or(0),
                 parser.ColumnParser(RETRY_COUNTER_UPDATE_COLUMN_NAME).GetOptionalTimestamp().value_or(TInstant::Zero()),
@@ -129,11 +128,11 @@ TYdbControlPlaneStorageActor::TPingTaskParams TYdbControlPlaneStorageActor::Cons
         }
 
         // running query us locked for lease period
-        TDuration backoff = Config->TaskLeaseTtl;
-        TInstant expireAt = TInstant::Now() + Config->AutomaticQueriesTtl;
-        UpdateTaskInfo(actorSystem, request, finalStatus, query, internal, job, owner, retryLimiter, backoff, expireAt);
+        TDuration backoff = config->TaskLeaseTtl;
+        TInstant expireAt = TInstant::Now() + config->AutomaticQueriesTtl;
+        UpdateTaskInfo(actorSystem, config, request, finalStatus, query, internal, job, owner, retryLimiter, backoff, expireAt);
 
-        TSqlQueryBuilder writeQueryBuilder(YdbConnection->TablePathPrefix, "HardPingTask(write)");
+        TSqlQueryBuilder writeQueryBuilder(tablePathPrefix, "HardPingTask(write)");
         writeQueryBuilder.AddString("tenant", request.tenant());
         writeQueryBuilder.AddString("scope", request.scope());
         writeQueryBuilder.AddString("job_id", jobId);
@@ -258,7 +257,7 @@ TYdbControlPlaneStorageActor::TPingTaskParams TYdbControlPlaneStorageActor::Cons
         "FROM `" PENDING_SMALL_TABLE_NAME "` WHERE `" TENANT_COLUMN_NAME "` = $tenant AND `" SCOPE_COLUMN_NAME "` = $scope AND `" QUERY_ID_COLUMN_NAME "` = $query_id;\n"
     );
 
-    auto prepareParams = [=, this](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [request=request, leaseLeftMs=Counters.LeaseLeftMs, config=Config, tablePathPrefix=YdbConnection->TablePathPrefix, response, commonCounters=commonCounters](const std::vector<TResultSet>& resultSets) {
         TString owner;
         FederatedQuery::Internal::QueryInternal internal;
 
@@ -288,14 +287,14 @@ TYdbControlPlaneStorageActor::TPingTaskParams TYdbControlPlaneStorageActor::Cons
                 ythrow NKikimr::TCodeLineException(TIssuesIds::BAD_REQUEST) << "OWNER of QUERY ID = \"" << request.query_id().value() << "\" MISMATCHED: \"" << request.owner_id() << "\" (received) != \"" << owner << "\" (selected)";
             }
             auto assignedUntil = parser.ColumnParser(ASSIGNED_UNTIL_COLUMN_NAME).GetOptionalTimestamp().value_or(TInstant::Now());
-            Counters.LeaseLeftMs->Collect((assignedUntil - TInstant::Now()).MilliSeconds());
+            leaseLeftMs->Collect((assignedUntil - TInstant::Now()).MilliSeconds());
         }
 
-        TInstant ttl = TInstant::Now() + Config->TaskLeaseTtl;
+        TInstant ttl = TInstant::Now() + config->TaskLeaseTtl;
         response->set_action(internal.action());
         *response->mutable_expired_at() = google::protobuf::util::TimeUtil::MillisecondsToTimestamp(ttl.MilliSeconds());
 
-        TSqlQueryBuilder writeQueryBuilder(YdbConnection->TablePathPrefix, "SoftPingTask(write)");
+        TSqlQueryBuilder writeQueryBuilder(tablePathPrefix, "SoftPingTask(write)");
         writeQueryBuilder.AddTimestamp("now", TInstant::Now());
         writeQueryBuilder.AddTimestamp("ttl", ttl);
         writeQueryBuilder.AddString("tenant", request.tenant());
@@ -328,9 +327,9 @@ NYql::TIssues TControlPlaneStorageBase::ValidateRequest(TEvControlPlaneStorage::
 }
 
 void TControlPlaneStorageBase::UpdateTaskInfo(
-    NActors::TActorSystem* actorSystem, Fq::Private::PingTaskRequest& request, const std::shared_ptr<TFinalStatus>& finalStatus, FederatedQuery::Query& query,
+    NActors::TActorSystem* actorSystem, const std::shared_ptr<::NFq::TControlPlaneStorageConfig>& config, Fq::Private::PingTaskRequest& request, const std::shared_ptr<TFinalStatus>& finalStatus, FederatedQuery::Query& query,
     FederatedQuery::Internal::QueryInternal& internal, FederatedQuery::Job& job, TString& owner,
-    NKikimr::NKqp::TRetryLimiter& retryLimiter, TDuration& backoff, TInstant& expireAt) const
+    NKikimr::NKqp::TRetryLimiter& retryLimiter, TDuration& backoff, TInstant& expireAt)
 {
     TMaybe<FederatedQuery::QueryMeta::ComputeStatus> queryStatus;
     if (request.status() != FederatedQuery::QueryMeta::COMPUTE_STATUS_UNSPECIFIED) {
@@ -358,8 +357,8 @@ void TControlPlaneStorageBase::UpdateTaskInfo(
         }
 
         NKikimr::NKqp::TRetryPolicyItem policy(0, 0, TDuration::Seconds(1), TDuration::Zero());
-        auto it = Config->RetryPolicies.find(request.status_code());
-        auto policyFound = it != Config->RetryPolicies.end();
+        auto it = config->RetryPolicies.find(request.status_code());
+        auto policyFound = it != config->RetryPolicies.end();
         if (policyFound) {
             policy = it->second;
         }
@@ -462,7 +461,7 @@ void TControlPlaneStorageBase::UpdateTaskInfo(
         }
 
         // global dumpRawStatistics will be removed with YQv1
-        if (!Config->Proto.GetDumpRawStatistics() && !request.dump_raw_statistics()) {
+        if (!config->Proto.GetDumpRawStatistics() && !request.dump_raw_statistics()) {
             try {
                 statistics = GetPrettyStatistics(statistics);
             } catch (const std::exception&) {
@@ -598,7 +597,7 @@ void TControlPlaneStorageBase::UpdateTaskInfo(
         *internal.mutable_resources() = request.resources();
     }
 
-    const auto maxRequestSize = Config->Proto.GetMaxRequestSize();
+    const auto maxRequestSize = config->Proto.GetMaxRequestSize();
     if (job.ByteSizeLong() > maxRequestSize) {
         ythrow NKikimr::TCodeLineException(TIssuesIds::BAD_REQUEST) << "Job proto exceeded the size limit: " << job.ByteSizeLong() << " of " << maxRequestSize << " " << TSizeFormatPrinter(job).ToString();
     }
@@ -622,7 +621,7 @@ void TControlPlaneStorageBase::UpdateTaskInfo(
 
 void TControlPlaneStorageBase::FillQueryStatistics(
     const std::shared_ptr<TFinalStatus>& finalStatus, const FederatedQuery::Query& query,
-    const FederatedQuery::Internal::QueryInternal& internal, const NKikimr::NKqp::TRetryLimiter& retryLimiter) const
+    const FederatedQuery::Internal::QueryInternal& internal, const NKikimr::NKqp::TRetryLimiter& retryLimiter)
 {
     finalStatus->FinalStatistics = ExtractStatisticsFromProtobuf(internal.statistics());
     finalStatus->FinalStatistics.push_back(std::make_pair("IsAutomatic", query.content().automatic()));

--- a/ydb/core/fq/libs/control_plane_storage/internal/task_ping.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/internal/task_ping.cpp
@@ -70,10 +70,7 @@ TYdbControlPlaneStorageActor::TPingTaskParams TYdbControlPlaneStorageActor::Cons
     );
 
     auto meteringRecords = std::make_shared<std::vector<TString>>();
-    auto prepareParams = [meteringRecords, commonCounters=commonCounters, leaseLeftMs=Counters.LeaseLeftMs, config=Config, tablePathPrefix=YdbConnection->TablePathPrefix, finalStatus=finalStatus, response=response, counters=counters, actorSystem=NActors::TActivationContext::ActorSystem(), request=request, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) mutable {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [meteringRecords, commonCounters=commonCounters, leaseLeftMs=Counters.LeaseLeftMs, config=Config, tablePathPrefix=YdbConnection->TablePathPrefix, finalStatus=finalStatus, response=response, counters=counters, actorSystem=NActors::TActivationContext::ActorSystem(), request=request](const std::vector<TResultSet>& resultSets) mutable {
         TString jobId;
         FederatedQuery::Query query;
         FederatedQuery::Internal::QueryInternal internal;
@@ -260,10 +257,7 @@ TYdbControlPlaneStorageActor::TPingTaskParams TYdbControlPlaneStorageActor::Cons
         "FROM `" PENDING_SMALL_TABLE_NAME "` WHERE `" TENANT_COLUMN_NAME "` = $tenant AND `" SCOPE_COLUMN_NAME "` = $scope AND `" QUERY_ID_COLUMN_NAME "` = $query_id;\n"
     );
 
-    auto prepareParams = [request=request, leaseLeftMs=Counters.LeaseLeftMs, config=Config, tablePathPrefix=YdbConnection->TablePathPrefix, response, commonCounters=commonCounters, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [request=request, leaseLeftMs=Counters.LeaseLeftMs, config=Config, tablePathPrefix=YdbConnection->TablePathPrefix, response, commonCounters=commonCounters](const std::vector<TResultSet>& resultSets) {
         TString owner;
         FederatedQuery::Internal::QueryInternal internal;
 

--- a/ydb/core/fq/libs/control_plane_storage/request_actor.h
+++ b/ydb/core/fq/libs/control_plane_storage/request_actor.h
@@ -89,9 +89,9 @@ protected:
         AsDerived()->LwProbe(success);
 
         for (const auto& issue : event->Issues) {
-            NYql::WalkThroughIssues(issue, true, [this](const NYql::TIssue& err, ui16 level) {
+            NYql::WalkThroughIssues(issue, true, [issuesCounters=RequestCounters.Common->Issues](const NYql::TIssue& err, ui16 level) {
                 Y_UNUSED(level);
-                RequestCounters.Common->Issues->GetCounter(ToString(err.GetCode()), true)->Inc();
+                issuesCounters->GetCounter(ToString(err.GetCode()), true)->Inc();
             });
         }
 

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_bindings.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_bindings.cpp
@@ -473,10 +473,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyBindi
     );
 
     std::shared_ptr<std::pair<FederatedQuery::ModifyBindingResult, TAuditDetails<FederatedQuery::Binding>>> response = std::make_shared<std::pair<FederatedQuery::ModifyBindingResult, TAuditDetails<FederatedQuery::Binding>>>();
-    auto prepareParams = [response, permissions, bindingId, idempotencyKey, user, scope, request=request, tablePathPrefix=YdbConnection->TablePathPrefix, idempotencyKeyTtl=Config->IdempotencyKeyTtl, commonCounters=requestCounters.Common, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [response, permissions, bindingId, idempotencyKey, user, scope, request=request, tablePathPrefix=YdbConnection->TablePathPrefix, idempotencyKeyTtl=Config->IdempotencyKeyTtl, commonCounters=requestCounters.Common](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 2) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 2 but equal " << resultSets.size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_bindings.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_bindings.cpp
@@ -473,7 +473,10 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyBindi
     );
 
     std::shared_ptr<std::pair<FederatedQuery::ModifyBindingResult, TAuditDetails<FederatedQuery::Binding>>> response = std::make_shared<std::pair<FederatedQuery::ModifyBindingResult, TAuditDetails<FederatedQuery::Binding>>>();
-    auto prepareParams = [response, permissions, bindingId, idempotencyKey, user, scope, request=request, tablePathPrefix=YdbConnection->TablePathPrefix, idempotencyKeyTtl=Config->IdempotencyKeyTtl, commonCounters=requestCounters.Common](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [response, permissions, bindingId, idempotencyKey, user, scope, request=request, tablePathPrefix=YdbConnection->TablePathPrefix, idempotencyKeyTtl=Config->IdempotencyKeyTtl, commonCounters=requestCounters.Common, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         if (resultSets.size() != 2) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 2 but equal " << resultSets.size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_bindings.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_bindings.cpp
@@ -380,7 +380,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvDescribeBin
     const auto query = queryBuilder.Build();
     auto debugInfo = Config->Proto.GetEnableDebugMode() ? std::make_shared<TDebugInfo>() : TDebugInfoPtr{};
     auto [result, resultSets] = Read(query.Sql, query.Params, requestCounters, debugInfo);
-    auto prepare = [=, resultSets=resultSets, commonCounters=requestCounters.Common] {
+    auto prepare = [permissions, user, resultSets=resultSets, commonCounters=requestCounters.Common] {
         if (resultSets->size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets->size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_bindings.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_bindings.cpp
@@ -473,7 +473,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyBindi
     );
 
     std::shared_ptr<std::pair<FederatedQuery::ModifyBindingResult, TAuditDetails<FederatedQuery::Binding>>> response = std::make_shared<std::pair<FederatedQuery::ModifyBindingResult, TAuditDetails<FederatedQuery::Binding>>>();
-    auto prepareParams = [=, this, config=Config, commonCounters=requestCounters.Common](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [response, permissions, bindingId, idempotencyKey, user, scope, request=request, tablePathPrefix=YdbConnection->TablePathPrefix, idempotencyKeyTtl=Config->IdempotencyKeyTtl, commonCounters=requestCounters.Common](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 2) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 2 but equal " << resultSets.size() << ". Please contact internal support";
         }
@@ -538,7 +538,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyBindi
         response->second.After.ConstructInPlace().CopyFrom(binding);
         response->second.CloudId = bindingInternal.cloud_id();
 
-        TSqlQueryBuilder writeQueryBuilder(YdbConnection->TablePathPrefix, "ModifyBinding(write)");
+        TSqlQueryBuilder writeQueryBuilder(tablePathPrefix, "ModifyBinding(write)");
         writeQueryBuilder.AddString("scope", scope);
         writeQueryBuilder.AddString("binding_id", bindingId);
         writeQueryBuilder.AddInt64("visibility", binding.content().acl().visibility());
@@ -546,7 +546,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyBindi
         writeQueryBuilder.AddInt64("revision", meta.revision());
         writeQueryBuilder.AddString("internal", bindingInternal.SerializeAsString());
         writeQueryBuilder.AddString("binding", binding.SerializeAsString());
-        InsertIdempotencyKey(writeQueryBuilder, scope, idempotencyKey, response->first.SerializeAsString(), TInstant::Now() + Config->IdempotencyKeyTtl);
+        InsertIdempotencyKey(writeQueryBuilder, scope, idempotencyKey, response->first.SerializeAsString(), TInstant::Now() + idempotencyKeyTtl);
         writeQueryBuilder.AddText(
             "UPDATE `" BINDINGS_TABLE_NAME "` SET `" VISIBILITY_COLUMN_NAME "` = $visibility, `" NAME_COLUMN_NAME "` = $name, `" REVISION_COLUMN_NAME "` = $revision, `" INTERNAL_COLUMN_NAME "` = $internal, `" BINDING_COLUMN_NAME "` = $binding\n"
             "WHERE `" SCOPE_COLUMN_NAME "` = $scope AND `" BINDING_ID_COLUMN_NAME "` = $binding_id;\n"

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_compute_database.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_compute_database.cpp
@@ -33,10 +33,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvCreateDatab
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope;"
     );
 
-    auto prepareParams = [tablePathPrefix=YdbConnection->TablePathPrefix, scope, request, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [tablePathPrefix=YdbConnection->TablePathPrefix, scope, request](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }
@@ -193,10 +190,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyDatab
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope;"
     );
 
-    auto prepareParams = [synchronized=ev->Get()->Synchronized, workloadManagerSynchronized=ev->Get()->WorkloadManagerSynchronized, commonCounters=requestCounters.Common, scope, tablePathPrefix=YdbConnection->TablePathPrefix, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [synchronized=ev->Get()->Synchronized, workloadManagerSynchronized=ev->Get()->WorkloadManagerSynchronized, commonCounters=requestCounters.Common, scope, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_compute_database.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_compute_database.cpp
@@ -33,7 +33,10 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvCreateDatab
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope;"
     );
 
-    auto prepareParams = [tablePathPrefix=YdbConnection->TablePathPrefix, scope, request](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [tablePathPrefix=YdbConnection->TablePathPrefix, scope, request, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }
@@ -190,7 +193,10 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyDatab
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope;"
     );
 
-    auto prepareParams = [synchronized=ev->Get()->Synchronized, workloadManagerSynchronized=ev->Get()->WorkloadManagerSynchronized, commonCounters=requestCounters.Common, scope, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [synchronized=ev->Get()->Synchronized, workloadManagerSynchronized=ev->Get()->WorkloadManagerSynchronized, commonCounters=requestCounters.Common, scope, tablePathPrefix=YdbConnection->TablePathPrefix, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_compute_database.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_compute_database.cpp
@@ -102,7 +102,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvDescribeDat
     const auto query = queryBuilder.Build();
     auto debugInfo = Config->Proto.GetEnableDebugMode() ? std::make_shared<TDebugInfo>() : TDebugInfoPtr{};
     auto [result, resultSets] = Read(query.Sql, query.Params, requestCounters, debugInfo);
-    auto prepare = [=, resultSets=resultSets, commonCounters=requestCounters.Common] {
+    auto prepare = [resultSets=resultSets, commonCounters=requestCounters.Common] {
         if (resultSets->size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets->size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_compute_database.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_compute_database.cpp
@@ -33,7 +33,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvCreateDatab
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope;"
     );
 
-    auto prepareParams = [=, this](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [tablePathPrefix=YdbConnection->TablePathPrefix, scope, request](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }
@@ -43,7 +43,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvCreateDatab
             return make_pair(TString{}, NYdb::TParamsBuilder{}.Build()); // already exists
         }
 
-        TSqlQueryBuilder writeQueryBuilder(YdbConnection->TablePathPrefix, "CreateDatabase");
+        TSqlQueryBuilder writeQueryBuilder(tablePathPrefix, "CreateDatabase");
         writeQueryBuilder.AddString("scope", scope);
         writeQueryBuilder.AddString("internal", request.SerializeAsString());
         writeQueryBuilder.AddText(
@@ -190,7 +190,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyDatab
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope;"
     );
 
-    auto prepareParams = [=, this, synchronized = ev->Get()->Synchronized, workloadManagerSynchronized = ev->Get()->WorkloadManagerSynchronized, commonCounters=requestCounters.Common](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [synchronized=ev->Get()->Synchronized, workloadManagerSynchronized=ev->Get()->WorkloadManagerSynchronized, commonCounters=requestCounters.Common, scope, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }
@@ -214,7 +214,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyDatab
             result.set_workload_manager_synchronized(*workloadManagerSynchronized);
         }
 
-        TSqlQueryBuilder writeQueryBuilder(YdbConnection->TablePathPrefix, "ModifyDatabase(write)");
+        TSqlQueryBuilder writeQueryBuilder(tablePathPrefix, "ModifyDatabase(write)");
         writeQueryBuilder.AddString("internal", result.SerializeAsString());
         writeQueryBuilder.AddString("scope", scope);
         writeQueryBuilder.AddText(

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
@@ -503,10 +503,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyConne
     );
 
     std::shared_ptr<std::pair<FederatedQuery::ModifyConnectionResult, TAuditDetails<FederatedQuery::Connection>>> response = std::make_shared<std::pair<FederatedQuery::ModifyConnectionResult, TAuditDetails<FederatedQuery::Connection>>>();
-    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, response, user, request, scope, connectionId, idempotencyKey, tablePathPrefix=YdbConnection->TablePathPrefix, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, response, user, request, scope, connectionId, idempotencyKey, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
@@ -412,7 +412,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvDescribeCon
     const auto query = queryBuilder.Build();
     auto debugInfo = Config->Proto.GetEnableDebugMode() ? std::make_shared<TDebugInfo>() : TDebugInfoPtr{};
     auto [result, resultSets] = Read(query.Sql, query.Params, requestCounters, debugInfo);
-    auto prepare = [=, resultSets=resultSets, commonCounters=requestCounters.Common] {
+    auto prepare = [permissions, user, extractSensitiveFields, resultSets=resultSets, commonCounters=requestCounters.Common] {
         if (resultSets->size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets->size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
@@ -503,7 +503,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyConne
     );
 
     std::shared_ptr<std::pair<FederatedQuery::ModifyConnectionResult, TAuditDetails<FederatedQuery::Connection>>> response = std::make_shared<std::pair<FederatedQuery::ModifyConnectionResult, TAuditDetails<FederatedQuery::Connection>>>();
-    auto prepareParams = [=, this, config=Config, commonCounters=requestCounters.Common](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, response, user, request, scope, connectionId, idempotencyKey, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }
@@ -559,7 +559,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyConne
         response->second.After.ConstructInPlace().CopyFrom(connection);
         response->second.CloudId = connectionInternal.cloud_id();
 
-        TSqlQueryBuilder writeQueryBuilder(YdbConnection->TablePathPrefix, "ModifyConnection(write)");
+        TSqlQueryBuilder writeQueryBuilder(tablePathPrefix, "ModifyConnection(write)");
         writeQueryBuilder.AddString("scope", scope);
         writeQueryBuilder.AddString("connection_id", connectionId);
         writeQueryBuilder.AddInt64("visibility", connection.content().acl().visibility());

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
@@ -503,7 +503,10 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyConne
     );
 
     std::shared_ptr<std::pair<FederatedQuery::ModifyConnectionResult, TAuditDetails<FederatedQuery::Connection>>> response = std::make_shared<std::pair<FederatedQuery::ModifyConnectionResult, TAuditDetails<FederatedQuery::Connection>>>();
-    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, response, user, request, scope, connectionId, idempotencyKey, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, response, user, request, scope, connectionId, idempotencyKey, tablePathPrefix=YdbConnection->TablePathPrefix, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_connections.cpp
@@ -503,7 +503,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyConne
     );
 
     std::shared_ptr<std::pair<FederatedQuery::ModifyConnectionResult, TAuditDetails<FederatedQuery::Connection>>> response = std::make_shared<std::pair<FederatedQuery::ModifyConnectionResult, TAuditDetails<FederatedQuery::Connection>>>();
-    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, response, user, request, scope, connectionId, idempotencyKey, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [config=Config, commonCounters=requestCounters.Common, response, user, request, scope, connectionId, idempotencyKey, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets.size() << ". Please contact internal support";
         }
@@ -567,7 +567,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyConne
         writeQueryBuilder.AddInt64("revision", meta.revision());
         writeQueryBuilder.AddString("internal", connectionInternal.SerializeAsString());
         writeQueryBuilder.AddString("connection", connection.SerializeAsString());
-        InsertIdempotencyKey(writeQueryBuilder, scope, idempotencyKey, response->first.SerializeAsString(), TInstant::Now() + Config->IdempotencyKeyTtl);
+        InsertIdempotencyKey(writeQueryBuilder, scope, idempotencyKey, response->first.SerializeAsString(), TInstant::Now() + config->IdempotencyKeyTtl);
         writeQueryBuilder.AddText(
             "UPDATE `" CONNECTIONS_TABLE_NAME "` SET `" VISIBILITY_COLUMN_NAME "` = $visibility, `" NAME_COLUMN_NAME "` = $name, `" REVISION_COLUMN_NAME "` = $revision, `" INTERNAL_COLUMN_NAME "` = $internal, `" CONNECTION_COLUMN_NAME "` = $connection\n"
             "WHERE `" SCOPE_COLUMN_NAME "` = $scope AND `" CONNECTION_ID_COLUMN_NAME "` = $connection_id;"

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_folder.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_folder.cpp
@@ -66,7 +66,7 @@ void NFq::TYdbControlPlaneStorageActor::Handle(NFq::TEvControlPlaneStorage::TEvD
     auto result = Write(query.Sql, query.Params, requestCounters, debugInfo);
     auto prepare = [response] { return *response; };
 
-    auto success = result.Apply([=, requestCounters=requestCounters](const auto& future) mutable {
+    auto success = result.Apply([scope, user, prepare, debugInfo, requestCounters=requestCounters, sender=ev->Sender, cookie=ev->Cookie, selfId=SelfId(), startTime](const auto& future) mutable {
             NYql::TIssues internalIssues;
             NYql::TIssues issues;
             Ydb::Operations::Operation result;
@@ -101,7 +101,7 @@ void NFq::TYdbControlPlaneStorageActor::Handle(NFq::TEvControlPlaneStorage::TEvD
                 auto event = std::make_unique<TEvControlPlaneStorage::TEvDeleteFolderResourcesResponse>(issues);
                 event->DebugInfo = debugInfo;
                 responseByteSize = event->GetByteSize();
-                NActors::TActivationContext::ActorSystem()->Send(new IEventHandle(ev->Sender, SelfId(), event.release(), 0, ev->Cookie));
+                NActors::TActivationContext::ActorSystem()->Send(new IEventHandle(sender, selfId, event.release(), 0, cookie));
                 requestCounters.IncError();
                 for (const auto& issue : issues) {
                     NYql::WalkThroughIssues(issue, true, [&requestCounters](const NYql::TIssue& err, ui16 level) {
@@ -115,7 +115,7 @@ void NFq::TYdbControlPlaneStorageActor::Handle(NFq::TEvControlPlaneStorage::TEvD
                 event = std::make_unique<TEvControlPlaneStorage::TEvDeleteFolderResourcesResponse>(result);
                 event->DebugInfo = debugInfo;
                 responseByteSize = event->GetByteSize();
-                NActors::TActivationContext::ActorSystem()->Send(new IEventHandle(ev->Sender, SelfId(), event.release(), 0, ev->Cookie));
+                NActors::TActivationContext::ActorSystem()->Send(new IEventHandle(sender, selfId, event.release(), 0, cookie));
                 requestCounters.IncOk();
             }
             requestCounters.DecInFly();

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_impl.h
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_impl.h
@@ -281,7 +281,8 @@ protected:
         TTxSettings transactionMode = TTxSettings::SerializableRW(),
         bool retryTli = true);
 
-    TAsyncStatus ReadModifyWrite(
+    static TAsyncStatus ReadModifyWrite(
+        TDbPool::TPtr dbPool,
         const TString& readQuery,
         const NYdb::TParams& readParams,
         const std::function<std::pair<TString, NYdb::TParams>(const std::vector<NYdb::TResultSet>&)>& prepare,
@@ -290,6 +291,18 @@ protected:
         const TVector<TValidationQuery>& validators = {},
         TTxSettings transactionMode = TTxSettings::SerializableRW(),
         bool retryOnTli = true);
+
+    TAsyncStatus ReadModifyWrite(
+        const TString& readQuery,
+        const NYdb::TParams& readParams,
+        const std::function<std::pair<TString, NYdb::TParams>(const std::vector<NYdb::TResultSet>&)>& prepare,
+        const TRequestCounters& requestCounters,
+        TDebugInfoPtr debugInfo = {},
+        const TVector<TValidationQuery>& validators = {},
+        TTxSettings transactionMode = TTxSettings::SerializableRW(),
+        bool retryOnTli = true) {
+        return ReadModifyWrite(DbPool, readQuery, readParams, prepare, requestCounters, debugInfo, validators, transactionMode, retryOnTli);
+    }
 
 protected:
     TDbPool::TPtr DbPool;
@@ -1050,7 +1063,8 @@ private:
         bool RetryOnTli = false;
     };
 
-    NThreading::TFuture<void> PickTask(
+    static NThreading::TFuture<void> PickTask(
+        TDbPool::TPtr dbPool,
         const TPickTaskParams& taskParams,
         const TRequestCounters& requestCounters,
         TDebugInfoPtr debugInfo,

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_impl.h
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_impl.h
@@ -845,7 +845,6 @@ class TYdbControlPlaneStorageActor : public NActors::TActorBootstrapped<TYdbCont
     std::shared_ptr<TQueryQuotaState> Quotas = std::make_shared<TQueryQuotaState>();
 
     TString TablePathPrefix;
-    std::shared_ptr<bool> Alive = std::make_shared<bool>();
 
 public:
     TYdbControlPlaneStorageActor(

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_impl.h
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_impl.h
@@ -832,6 +832,7 @@ class TYdbControlPlaneStorageActor : public NActors::TActorBootstrapped<TYdbCont
     std::shared_ptr<TQueryQuotaState> Quotas = std::make_shared<TQueryQuotaState>();
 
     TString TablePathPrefix;
+    std::shared_ptr<bool> Alive = std::make_shared<bool>();
 
 public:
     TYdbControlPlaneStorageActor(

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_queries.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_queries.cpp
@@ -1889,7 +1889,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvDescribeJob
     auto debugInfo = Config->Proto.GetEnableDebugMode() ? std::make_shared<TDebugInfo>() : TDebugInfoPtr{};
     auto [result, resultSets] = Read(query.Sql, query.Params, requestCounters, debugInfo);
 
-    auto prepare = [=, id=request.job_id(), resultSets=resultSets, commonCounters=requestCounters.Common] {
+    auto prepare = [permissions, user, id=request.job_id(), resultSets=resultSets, commonCounters=requestCounters.Common] {
         if (resultSets->size() != 1) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 1 but equal " << resultSets->size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_queries.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_queries.cpp
@@ -267,10 +267,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvCreateQuery
         );
     }
 
-    auto prepareParams = [as=TActivationContext::ActorSystem(), commonCounters=requestCounters.Common, quotas=event.Quotas, idempotencyKey, request, response, cloudId, token, computeDatabase, queryType, query, queryId, mapResult, scope, user, jobId, startTime, tablePathPrefix=YdbConnection->TablePathPrefix, job, Config=Config, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) mutable {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [as=TActivationContext::ActorSystem(), commonCounters=requestCounters.Common, quotas=event.Quotas, idempotencyKey, request, response, cloudId, token, computeDatabase, queryType, query, queryId, mapResult, scope, user, jobId, startTime, tablePathPrefix=YdbConnection->TablePathPrefix, job, Config=Config](const std::vector<TResultSet>& resultSets) mutable {
         const size_t countSets = (idempotencyKey ? 1 : 0) + (request.execute_mode() != FederatedQuery::SAVE ? 2 : 0);
         if (resultSets.size() != countSets) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to " << countSets << " but equal " << resultSets.size() << ". Please contact internal support";
@@ -877,10 +874,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyQuery
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope AND `" QUERY_ID_COLUMN_NAME "` = $query_id AND (`" EXPIRE_AT_COLUMN_NAME "` is NULL OR `" EXPIRE_AT_COLUMN_NAME "` > $now);"
     );
 
-    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, user, token, permissions, request=std::move(request), response, executionLimitMills, computeDatabase, tablePathPrefix=YdbConnection->TablePathPrefix, mapResult=std::move(mapResult), scope, queryId, idempotencyKey, startTime, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, user, token, permissions, request=std::move(request), response, executionLimitMills, computeDatabase, tablePathPrefix=YdbConnection->TablePathPrefix, mapResult=std::move(mapResult), scope, queryId, idempotencyKey, startTime](const std::vector<TResultSet>& resultSets) {
         const size_t countSets = 1 + (request.execute_mode() != FederatedQuery::SAVE ? 2 : 0);
 
         if (resultSets.size() != countSets) {
@@ -1375,10 +1369,7 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvControlQuer
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope AND `" QUERY_ID_COLUMN_NAME "` = $query_id AND `" JOB_ID_COLUMN_NAME "` = $job_id;\n"
     );
 
-    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, permissions, user, action, response, idempotencyKey, scope, queryId, tablePathPrefix=YdbConnection->TablePathPrefix, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
-        if (alive.expired()) {
-            throw yexception() << "Actor died";
-        }
+    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, permissions, user, action, response, idempotencyKey, scope, queryId, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
         if (resultSets.size() != 2) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 2 but equal " << resultSets.size() << ". Please contact internal support";
         }

--- a/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_queries.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/ydb_control_plane_storage_queries.cpp
@@ -267,7 +267,10 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvCreateQuery
         );
     }
 
-    auto prepareParams = [as=TActivationContext::ActorSystem(), commonCounters=requestCounters.Common, quotas=event.Quotas, idempotencyKey, request, response, cloudId, token, computeDatabase, queryType, query, queryId, mapResult, scope, user, jobId, startTime, tablePathPrefix=YdbConnection->TablePathPrefix, job, Config=Config](const std::vector<TResultSet>& resultSets) mutable {
+    auto prepareParams = [as=TActivationContext::ActorSystem(), commonCounters=requestCounters.Common, quotas=event.Quotas, idempotencyKey, request, response, cloudId, token, computeDatabase, queryType, query, queryId, mapResult, scope, user, jobId, startTime, tablePathPrefix=YdbConnection->TablePathPrefix, job, Config=Config, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) mutable {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         const size_t countSets = (idempotencyKey ? 1 : 0) + (request.execute_mode() != FederatedQuery::SAVE ? 2 : 0);
         if (resultSets.size() != countSets) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to " << countSets << " but equal " << resultSets.size() << ". Please contact internal support";
@@ -874,7 +877,10 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvModifyQuery
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope AND `" QUERY_ID_COLUMN_NAME "` = $query_id AND (`" EXPIRE_AT_COLUMN_NAME "` is NULL OR `" EXPIRE_AT_COLUMN_NAME "` > $now);"
     );
 
-    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, user, token, permissions, request=std::move(request), response, executionLimitMills, computeDatabase, tablePathPrefix=YdbConnection->TablePathPrefix, mapResult=std::move(mapResult), scope, queryId, idempotencyKey, startTime](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, user, token, permissions, request=std::move(request), response, executionLimitMills, computeDatabase, tablePathPrefix=YdbConnection->TablePathPrefix, mapResult=std::move(mapResult), scope, queryId, idempotencyKey, startTime, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         const size_t countSets = 1 + (request.execute_mode() != FederatedQuery::SAVE ? 2 : 0);
 
         if (resultSets.size() != countSets) {
@@ -1369,7 +1375,10 @@ void TYdbControlPlaneStorageActor::Handle(TEvControlPlaneStorage::TEvControlQuer
         "WHERE `" SCOPE_COLUMN_NAME "` = $scope AND `" QUERY_ID_COLUMN_NAME "` = $query_id AND `" JOB_ID_COLUMN_NAME "` = $job_id;\n"
     );
 
-    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, permissions, user, action, response, idempotencyKey, scope, queryId, tablePathPrefix=YdbConnection->TablePathPrefix](const std::vector<TResultSet>& resultSets) {
+    auto prepareParams = [Config=Config, commonCounters=requestCounters.Common, permissions, user, action, response, idempotencyKey, scope, queryId, tablePathPrefix=YdbConnection->TablePathPrefix, alive=std::weak_ptr(Alive)](const std::vector<TResultSet>& resultSets) {
+        if (alive.expired()) {
+            throw yexception() << "Actor died";
+        }
         if (resultSets.size() != 2) {
             ythrow NKikimr::TCodeLineException(TIssuesIds::INTERNAL_ERROR) << "Result set size is not equal to 2 but equal " << resultSets.size() << ". Please contact internal support";
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

There can be u-a-f when future completed after actor is destroyed (this mostly affects tests, actors are long-lived).
Avoid capturing and using `this` in futures and replace most of implicit capture (`[=]`) with explicit

v2: added similar bugfix for private_client
v3: reverted Alive check, that mostly optimization to avoid potentially expensive processing after actor died; it is not strictly necessary, intentionally racy, and can be confusing for future readers and prone to produce cargo-code