### PR TITLE
Transfer import from S3

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -70,6 +70,10 @@ bool IsCreateReplicationQuery(const TString& query) {
     return query.Contains("CREATE ASYNC REPLICATION");
 }
 
+bool IsCreateTransferQuery(const TString& query) {
+    return query.Contains("CREATE TRANSFER");
+}
+
 bool RewriteCreateQuery(
     TString& query,
     const TString& dbRestoreRoot,
@@ -81,6 +85,9 @@ bool RewriteCreateQuery(
     }
     if (IsCreateReplicationQuery(query)) {
         return NYdb::NDump::RewriteCreateAsyncReplicationQuery(query, dbRestoreRoot, dbPath, issues);
+    }
+    if (IsCreateTransferQuery(query)) {
+        return NYdb::NDump::RewriteCreateTransferQuery(query, dbRestoreRoot, dbPath, issues);
     }
 
     issues.AddIssue(TStringBuilder() << "unsupported create query: " << query);

--- a/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
@@ -336,9 +336,14 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
         return schemeKey.EndsWith(NYdb::NDump::NFiles::CreateAsyncReplication().FileName);
     }
 
+    static bool IsTransfer(TStringBuf schemeKey) {
+        return schemeKey.EndsWith(NYdb::NDump::NFiles::CreateTransfer().FileName);
+    }
+
     static bool IsCreatedByQuery(TStringBuf schemeKey) {
         return IsView(schemeKey)
-            || IsReplication(schemeKey);
+            || IsReplication(schemeKey)
+            || IsTransfer(schemeKey);
     }
 
     static bool NoObjectFound(Aws::S3::S3Errors errorType) {

--- a/ydb/core/tx/schemeshard/schemeshard_import_scheme_query_executor.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_scheme_query_executor.cpp
@@ -102,6 +102,11 @@ class TSchemeQueryExecutor: public TActorBootstrapped<TSchemeQueryExecutor> {
             return Finish(result->Status, createReplication);
         }
 
+        if (transactions[0].GetSchemeOperation().HasCreateTransfer()) {
+            const auto& createTransfer = transactions[0].GetSchemeOperation().GetCreateTransfer();
+            return Finish(result->Status, createTransfer);
+        }
+
         return Finish(Ydb::StatusIds::GENERIC_ERROR, "no supported create operation");
     }
 

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -492,6 +492,10 @@ void IsReplication(const NKikimrScheme::TEvDescribeSchemeResult& record) {
     CheckPathType(record, NKikimrSchemeOp::EPathTypeReplication);
 }
 
+void IsTransfer(const NKikimrScheme::TEvDescribeSchemeResult& record) {
+    CheckPathType(record, NKikimrSchemeOp::EPathTypeTransfer);
+}
+
 void CheckPathType(const NKikimrScheme::TEvDescribeSchemeResult& record, NKikimrSchemeOp::EPathType pathType) {
     UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrScheme::StatusSuccess);
     const auto& pathDescr = record.GetPathDescription();

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
@@ -120,6 +120,7 @@ namespace NLs {
     void IsStreamingQuery(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void IsDirectory(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void IsReplication(const NKikimrScheme::TEvDescribeSchemeResult& record);
+    void IsTransfer(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void CheckPathType(const NKikimrScheme::TEvDescribeSchemeResult& record, const NKikimrSchemeOp::EPathType pathType);
     TCheckFunc CheckColumns(const TString& name, const TSet<TString>& columns, const TSet<TString>& droppedColumns, const TSet<TString> keyColumns, bool strictCount = false);
     TCheckFunc CheckColumnType(const ui64 columnIndex, const TString& columnTypename);

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -7465,4 +7465,26 @@ Y_UNIT_TEST_SUITE(TImportWithRebootsTests) {
             }
         );
     }
+
+    Y_UNIT_TEST(ShouldSucceedOnSingleTransfer) {
+        ShouldSucceed(
+            {
+                EPathTypeTransfer,
+                R"(
+                    -- database: "/MyRoot"
+                    -- backup root: "/MyRoot"
+                    $transformation_lambda = ($msg) -> { return [ <| partition: $msg._partition, offset: $msg._offset, message: CAST($msg._data AS Utf8) |> ]; };
+
+                    CREATE TRANSFER `Transfer`
+                        FROM `/MyRoot/Topic` TO `/MyRoot/Table` USING $transformation_lambda
+                    WITH (
+                        CONNECTION_STRING = 'grpc://localhost:2135/?database=/MyRoot',
+                        CONSUMER = 'consumerName',
+                        BATCH_SIZE_BYTES = 8388608,
+                        FLUSH_INTERVAL = Interval('PT60S')
+                    );
+                )"
+            }
+        );
+    }
 }

--- a/ydb/public/lib/ydb_cli/dump/util/replication_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/replication_utils.cpp
@@ -230,7 +230,7 @@ bool RewriteCreateTransferQuery(
     const TString& dbPath,
     NYql::TIssues& issues) {
 
-    if (!RewriteSecretsNoCheck(query, dbRestoreRoot, issues)) {
+    if (!RewriteQuerySecretsNoCheck(query, dbRestoreRoot, issues)) {
         return false;
     }
     return RewriteCreateTransferQueryNoSecrets(query, dbRestoreRoot, dbPath, issues);

--- a/ydb/public/lib/ydb_cli/dump/util/replication_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/replication_utils.cpp
@@ -224,4 +224,28 @@ bool RewriteCreateAsyncReplicationQuery(
     return RewriteCreateAsyncReplicationQueryNoSecrets(query, dbRestoreRoot, dbPath, issues);
 }
 
+bool RewriteCreateTransferQueryNoSecrets(
+    TString& query,
+    const TString& dbRestoreRoot,
+    const TString& dbPath,
+    NYql::TIssues& issues) {
+
+    if (!RewriteObjectRefs(query, dbRestoreRoot, issues)) {
+        return false;
+    }
+    return RewriteCreateQuery(query, "CREATE TRANSFER `{}`", dbPath, issues);
+}
+
+bool RewriteCreateTransferQuery(
+    TString& query,
+    const TString& dbRestoreRoot,
+    const TString& dbPath,
+    NYql::TIssues& issues) {
+
+    if (!RewriteSecretsNoCheck(query, dbRestoreRoot, issues)) {
+        return false;
+    }
+    return RewriteCreateTransferQueryNoSecrets(query, dbRestoreRoot, dbPath, issues);
+}
+
 } // namespace NYdb::NDump

--- a/ydb/public/lib/ydb_cli/dump/util/replication_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/replication_utils.cpp
@@ -228,8 +228,8 @@ bool RewriteCreateTransferQuery(
     TString& query,
     const TString& dbRestoreRoot,
     const TString& dbPath,
-    NYql::TIssues& issues) {
-
+    NYql::TIssues& issues)
+{
     if (!RewriteQuerySecretsNoCheck(query, dbRestoreRoot, issues)) {
         return false;
     }

--- a/ydb/public/lib/ydb_cli/dump/util/replication_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/replication_utils.cpp
@@ -224,18 +224,6 @@ bool RewriteCreateAsyncReplicationQuery(
     return RewriteCreateAsyncReplicationQueryNoSecrets(query, dbRestoreRoot, dbPath, issues);
 }
 
-bool RewriteCreateTransferQueryNoSecrets(
-    TString& query,
-    const TString& dbRestoreRoot,
-    const TString& dbPath,
-    NYql::TIssues& issues) {
-
-    if (!RewriteObjectRefs(query, dbRestoreRoot, issues)) {
-        return false;
-    }
-    return RewriteCreateQuery(query, "CREATE TRANSFER `{}`", dbPath, issues);
-}
-
 bool RewriteCreateTransferQuery(
     TString& query,
     const TString& dbRestoreRoot,

--- a/ydb/public/lib/ydb_cli/dump/util/replication_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/replication_utils.h
@@ -45,12 +45,6 @@ bool RewriteCreateAsyncReplicationQuery(
     const TString& dbPath,
     NYql::TIssues& issues);
 
-bool RewriteCreateTransferQueryNoSecrets(
-    TString& query,
-    const TString& dbRestoreRoot,
-    const TString& dbPath,
-    NYql::TIssues& issues);
-
 bool RewriteCreateTransferQuery(
     TString& query,
     const TString& dbRestoreRoot,

--- a/ydb/public/lib/ydb_cli/dump/util/replication_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/replication_utils.h
@@ -45,4 +45,16 @@ bool RewriteCreateAsyncReplicationQuery(
     const TString& dbPath,
     NYql::TIssues& issues);
 
+bool RewriteCreateTransferQueryNoSecrets(
+    TString& query,
+    const TString& dbRestoreRoot,
+    const TString& dbPath,
+    NYql::TIssues& issues);
+
+bool RewriteCreateTransferQuery(
+    TString& query,
+    const TString& dbRestoreRoot,
+    const TString& dbPath,
+    NYql::TIssues& issues);
+
 } // namespace NYdb::NDump


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Transfer import from S3

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Немного изменена логика ретраев для создания объектов, зависящих от других еще не созданных объектов. Связано с тем, что трансферы на этапе построения запроса не умеют определять, существует ли целевая таблица.
