### PR TITLE
Do not fail queries in a WM if a db does not have free space

### DIFF
--- a/ydb/core/kqp/common/events/workload_service.h
+++ b/ydb/core/kqp/common/events/workload_service.h
@@ -9,7 +9,7 @@
 #include <yql/essentials/public/issue/yql_issue.h>
 
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
-
+#include <yql/essentials/core/issue/yql_issue.h>
 
 namespace NKikimr::NKqp::NWorkload {
 
@@ -44,6 +44,17 @@ struct TEvContinueRequest : public NActors::TEventLocal<TEvContinueRequest, TKqp
         , PoolConfig(poolConfig)
         , Issues(std::move(issues))
     {}
+
+    bool IsDiskFull() {
+        if (Issues.Empty() || Issues.Size() > 1) {
+            return false;
+        }
+
+        const auto& issue = *Issues.begin();
+
+        return issue.GetCode() == NYql::TIssuesIds::KIKIMR_DATABASE_DISK_SPACE_QUOTA_EXCEEDED ||
+            issue.GetCode() == NYql::TIssuesIds::KIKIMR_DISK_GROUP_OUT_OF_SPACE;
+    }
 
     const Ydb::StatusIds::StatusCode Status;
     const TString PoolId;

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -535,19 +535,27 @@ public:
         }
 
         const TString& poolId = ev->Get()->PoolId;
-        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
+        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS && !ev->Get()->IsDiskFull()) {
             google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage> issues;
             NYql::IssuesToMessage(std::move(ev->Get()->Issues), &issues);
             ReplyQueryError(ev->Get()->Status, TStringBuilder() << "Query failed during adding/waiting in workload pool " << poolId, issues);
             return;
         }
 
+        if (ev->Get()->IsDiskFull()) {
+            STLOG_W("Database disks are without free space",
+                (pool_id, poolId),(trace_id, TraceId()));
+            FillQueryIssues(ev->Get()->Issues);
+        }
+
         STLOG_D("Continue request", 
             (pool_id, poolId),
             (trace_id, TraceId()));
+
         QueryState->PoolHandlerActor = ev->Sender;
         QueryState->UserRequestContext->PoolId = poolId;
         QueryState->UserRequestContext->PoolConfig = ev->Get()->PoolConfig;
+
         CompileQuery();
     }
 
@@ -2134,6 +2142,20 @@ public:
         }
     }
 
+    void FillQueryIssues(const NYql::TIssues& issues) {
+        if (!QueryState) {
+            STLOG_W("Try to put issues into empty QueryState", (trace_id, TraceId()));
+            return;
+        }
+
+        if (!QueryState->Issues) {
+            QueryState->Issues = issues;
+            return;
+        }
+
+        QueryState->Issues.AddIssues(issues);
+    }
+
     void ProcessExecuterResult(TEvKqpExecuter::TEvTxResponse* ev) {
         QueryState->Orbit = std::move(ev->Orbit);
 
@@ -2239,7 +2261,9 @@ public:
         }
 
         if (!response->GetIssues().empty()){
-            NYql::IssuesFromMessage(response->GetIssues(), QueryState->Issues);
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(response->GetIssues(), issues);
+            FillQueryIssues(issues);
         }
 
         ExecuteOrDefer();

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2144,7 +2144,10 @@ public:
 
     void FillQueryIssues(const NYql::TIssues& issues) {
         if (!QueryState) {
-            STLOG_W("Try to put issues into empty QueryState", (trace_id, TraceId()));
+            STLOG_W("Try to put issues into empty QueryState", 
+                (issues, issues.ToOneLineString()),
+                (trace_id, TraceId())
+            );
             return;
         }
 

--- a/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
@@ -704,7 +704,7 @@ private:
         LastNodesInfoRefreshTime = TInstant::Now();
         NodeCount = ev->Get()->NodeCount;
 
-        LOG_T("Updated node info, noode count: " << NodeCount);
+        LOG_T("Updated node info, node count: " << NodeCount);
     }
 
     void Handle(TEvPrivate::TEvTablesCreationFinished::TPtr& ev) {
@@ -743,7 +743,7 @@ private:
             ScheduleRefresh();
         }
         FifoCounters.UpdateGlobalState(GlobalState);
-        LOG_T("succefully refreshed pool state, in flight: " << GlobalState.RunningRequests << ", delayed: " << GlobalState.DelayedRequests);
+        LOG_T("successfully refreshed pool state, in flight: " << GlobalState.RunningRequests << ", delayed: " << GlobalState.DelayedRequests);
 
         RemoveFinishedRequests();
 
@@ -785,7 +785,7 @@ private:
 
         GlobalState.DelayedRequests++;
         FifoCounters.GlobalDelayedRequests->Inc();
-        LOG_D("succefully delayed request, session id: " << ev->Get()->SessionId);
+        LOG_D("successfully delayed request, session id: " << ev->Get()->SessionId);
 
         DoStartDelayedRequest(GetLoadCpuThreshold());
         RefreshState();

--- a/ydb/core/kqp/workload_service/kqp_workload_service.cpp
+++ b/ydb/core/kqp/workload_service/kqp_workload_service.cpp
@@ -110,7 +110,7 @@ public:
         EnabledResourcePoolsOnServerless = event.GetConfig().GetFeatureFlags().GetEnableResourcePoolsOnServerless() || WorkloadManagerConfig.GetEnabled();
         EnableResourcePoolsCounters = event.GetConfig().GetFeatureFlags().GetEnableResourcePoolsCounters();
         if (EnabledResourcePools) {
-            LOG_I("Resource pools was enanbled");
+            LOG_I("Resource pools was enabled");
             InitializeWorkloadService();
         } else {
             LOG_I("Resource pools was disabled");
@@ -129,7 +129,7 @@ public:
         NodeCount = ev->Get()->AssignedNodes.size();
         ScheduleNodeInfoRequest();
 
-        LOG_T("Updated node info, noode count: " << NodeCount);
+        LOG_T("Updated node info, node count: " << NodeCount);
     }
 
     void Handle(TEvents::TEvUndelivered::TPtr& ev) const {
@@ -161,7 +161,7 @@ public:
             return;
         }
 
-        LOG_D("Recieved subscription request, DatabaseId: " << databaseId << ", PoolId: " << poolId);
+        LOG_D("Received subscription request, DatabaseId: " << databaseId << ", PoolId: " << poolId);
         GetOrCreateDatabaseState(databaseId)->DoSubscribeRequest(std::move(ev));
     }
 
@@ -173,7 +173,7 @@ public:
         }
 
         const TString& databaseId = ev->Get()->DatabaseId;
-        LOG_D("Recieved new request from " << workerActorId << ", DatabaseId: " << databaseId << ", PoolId: " << ev->Get()->PoolId << ", SessionId: " << ev->Get()->SessionId);
+        LOG_D("Received new request from " << workerActorId << ", DatabaseId: " << databaseId << ", PoolId: " << ev->Get()->PoolId << ", SessionId: " << ev->Get()->SessionId);
         GetOrCreateDatabaseState(databaseId)->DoPlaceRequest(std::move(ev));
     }
 

--- a/ydb/core/kqp/workload_service/tables/table_queries.cpp
+++ b/ydb/core/kqp/workload_service/tables/table_queries.cpp
@@ -61,7 +61,7 @@ public:
         })
     {}
 
-    static TVector<TVector<TString>> GetTablePahs() {
+    static TVector<TVector<TString>> GetTablePaths() {
         return {GetTablePath(DelayedRequests), GetTablePath(RunningRequests)};
     }
 
@@ -162,7 +162,7 @@ class TCleanupTablesActor : public TSchemeActorBase<TCleanupTablesActor> {
 
 public:
     TCleanupTablesActor()
-        : TablePathsToCheck(TTablesCreator::GetTablePahs())
+        : TablePathsToCheck(TTablesCreator::GetTablePaths())
     {}
 
     void DoBootstrap() {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -244,6 +244,7 @@ struct TFakeTicketParserActor : public TActor<TFakeTicketParserActor> {
 IActor* CreateFakeTicketParser(const TTicketParserSettings&) {
     return new TFakeTicketParserActor();
 }
+
 // Ydb setup
 
 class TWorkloadServiceYdbSetup : public IYdbSetup {
@@ -316,6 +317,12 @@ private:
         {  // Dedicated
             Ydb::Cms::CreateDatabaseRequest request;
             SetupResourcesTenant(request, request.mutable_resources()->add_storage_units(), Settings_.GetDedicatedTenantName());
+
+            if (Settings_.DedicatedDiskQuota_ > -1) {
+                request.mutable_database_quotas()->set_data_size_hard_quota(Settings_.DedicatedDiskQuota_);
+                request.mutable_database_quotas()->set_data_size_soft_quota(Settings_.DedicatedDiskQuota_);
+            }
+
             Tenants_->CreateTenant(std::move(request));
             const auto describeResult = Client_->Describe(GetRuntime(), Settings_.GetDedicatedTenantName());
             DedicatedTenantPathId = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey().GetPathId();
@@ -385,7 +392,6 @@ public:
         CreateSamplePool();
     }
 
-    // Cluster helpers
     void UpdateNodeCpuInfo(double usage, ui32 threads, ui64 nodeIndex = 0) override {
         TVector<std::tuple<TString, double, ui32, ui32>> pools;
         pools.emplace_back("User", usage, threads, threads);
@@ -470,9 +476,9 @@ public:
         auto event = GetQueryRequest(query, settings);
         auto promise = NewPromise<TQueryRunnerResult>();
         auto edgeActor = GetRuntime()->AllocateEdgeActor();
-        auto runerActor = GetRuntime()->Register(new TQueryRunnerActor(std::move(event), promise, settings, GetRuntime()->GetNodeId(settings.NodeIndex_)), 0, 0, TMailboxType::Simple, 0, edgeActor);
+        auto runnerActor = GetRuntime()->Register(new TQueryRunnerActor(std::move(event), promise, settings, GetRuntime()->GetNodeId(settings.NodeIndex_)), 0, 0, TMailboxType::Simple, 0, edgeActor);
 
-        return {.AsyncResult = promise.GetFuture(), .QueryRunnerActor = runerActor, .EdgeActor = edgeActor};
+        return {.AsyncResult = promise.GetFuture(), .QueryRunnerActor = runnerActor, .EdgeActor = edgeActor};
     }
 
     void ExecuteQueryRetry(const TString& retryMessage, const TString& query, TQueryRunnerSettings settings = TQueryRunnerSettings(), TDuration timeout = FUTURE_WAIT_TIMEOUT) const override {
@@ -500,6 +506,22 @@ public:
     }
 
     // Pools actions
+    void CreateSamplePoolOn(const TString& databaseId) const override {
+        auto edgeActor = GetRuntime()->AllocateEdgeActor();
+        auto actor = CreatePoolCreatorActor(
+            edgeActor,
+            databaseId,
+            Settings_.PoolId_,
+            Settings_.GetDefaultPoolSettings(),
+            nullptr,
+            {}
+        );
+
+        GetRuntime()->Register(actor);
+        auto response = GetRuntime()->GrabEdgeEvent<TEvPrivate::TEvCreatePoolResponse>(edgeActor, FUTURE_WAIT_TIMEOUT);
+        UNIT_ASSERT_VALUES_EQUAL_C(response->Get()->Status, Ydb::StatusIds::SUCCESS, response->Get()->Issues.ToOneLineString());
+    }
+
     TPoolStateDescription GetPoolDescription(TDuration leaseDuration = FUTURE_WAIT_TIMEOUT, const TString& poolId = "") const override {
         const auto& edgeActor = GetRuntime()->AllocateEdgeActor();
 
@@ -671,6 +693,8 @@ private:
 
     std::unique_ptr<NYdb::NTable::TTableClient> TableClient_;
     std::unique_ptr<NYdb::NTable::TSession> TableClientSession_;
+
+    TActorId FailureInjectorActorId_;
 };
 
 }  // anonymous namespace

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -693,8 +693,6 @@ private:
 
     std::unique_ptr<NYdb::NTable::TTableClient> TableClient_;
     std::unique_ptr<NYdb::NTable::TSession> TableClientSession_;
-
-    TActorId FailureInjectorActorId_;
 };
 
 }  // anonymous namespace

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -76,7 +76,7 @@ struct TYdbSetupSettings {
     FLUENT_SETTING_DEFAULT(bool, EnableMetadataObjectsOnServerless, true);
     FLUENT_SETTING_DEFAULT(bool, EnableExternalDataSourcesOnServerless, true);
     FLUENT_SETTING(NKikimrConfig::TWorkloadManagerConfig, WorkloadManagerConfig);
-
+    FLUENT_SETTING_DEFAULT(i32, DedicatedDiskQuota, -1);
 
     // Default pool settings
     FLUENT_SETTING_DEFAULT(TString, PoolId, "sample_pool_id");
@@ -116,6 +116,7 @@ public:
     virtual NActors::TActorId CreateInFlightCoordinator(ui32 numberRequests, ui32 expectedInFlight) const = 0;
 
     // Pools actions
+    virtual void CreateSamplePoolOn(const TString& databaseId) const = 0;
     virtual TPoolStateDescription GetPoolDescription(TDuration leaseDuration = FUTURE_WAIT_TIMEOUT, const TString& poolId = "") const = 0;
     virtual void WaitPoolState(const TPoolStateDescription& state, const TString& poolId = "") const = 0;
     virtual void WaitPoolHandlersCount(i64 finalCount, std::optional<i64> initialCount = std::nullopt, TDuration timeout = FUTURE_WAIT_TIMEOUT) const = 0;

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -346,14 +346,8 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
 
         UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
 
-        uint i = 0;
-        auto data = TStringBuilder();
-
-        while (i++ < 1000) {
-            data << 'X';
-        }
-
-        i = 1;
+        uint i = 1;
+        auto data = TString(1000,'X');
 
         do {
             auto insertQuery = TStringBuilder()

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -84,9 +84,9 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
 
         TSampleQueries::CheckNotFound(ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings), poolId);
 
-        const TString& tabmleName = "sub_path";
+        const TString& tableName = "sub_path";
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
-            CREATE TABLE )" << tabmleName << R"( (
+            CREATE TABLE )" << tableName << R"( (
                 Key Int32,
                 PRIMARY KEY (Key)
             );
@@ -94,7 +94,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
 
         TSampleQueries::TSelect42::CheckResult(ydb->ExecuteQuery(
             TSampleQueries::TSelect42::Query,
-            settings.Database(TStringBuilder() << CanonizePath(ydb->GetSettings().DomainName_) << "/" << tabmleName)
+            settings.Database(TStringBuilder() << CanonizePath(ydb->GetSettings().DomainName_) << "/" << tableName)
         ));
     }
 
@@ -107,8 +107,8 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
         if (secondRequest.HasValue()) {
             std::swap(firstRequest, secondRequest);
         }
-        UNIT_ASSERT_C(firstRequest.HasValue(), "One of two requests shoud be rejected");
-        UNIT_ASSERT_C(!secondRequest.HasValue(), "One of two requests shoud be placed in pool");
+        UNIT_ASSERT_C(firstRequest.HasValue(), "One of two requests should be rejected");
+        UNIT_ASSERT_C(!secondRequest.HasValue(), "One of two requests should be placed in pool");
 
         auto result = firstRequest.GetResult();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::OVERLOADED, result.GetIssues().ToOneLineString());
@@ -318,6 +318,75 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
         )");
 
         ydb->WaitPoolHandlersCount(0, std::nullopt, TDuration::Seconds(95));
+    }
+
+    void TestWhenDiskSpaceIsExhausted(i32 queryLimit, const TString& table) {
+        auto ydb = TYdbSetupSettings()
+            .NodeCount(1)
+            .CreateSampleTenants(true)
+            .ConcurrentQueryLimit(queryLimit)
+            .DedicatedDiskQuota(10000)
+            .Create();
+
+        const auto& dedicatedTenant = ydb->GetSettings().GetDedicatedTenantName();
+        ydb->CreateSamplePoolOn(dedicatedTenant);
+
+        auto settings = TQueryRunnerSettings()
+            .PoolId(ydb->GetSettings().PoolId_)
+            .NodeIndex(ydb->GetDedicatedTenantInfo().NodeIdx)
+            .Database(dedicatedTenant);
+
+        auto result = ydb->ExecuteQuery(TStringBuilder() << R"(
+            CREATE TABLE big_table (
+                Key Int32,
+                Value String,
+                PRIMARY KEY (Key)
+            );
+        )", settings);
+
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+
+        uint i = 0;
+        auto data = TStringBuilder();
+
+        while (i++ < 1000) {
+            data << 'X';
+        }
+
+        i = 1;
+
+        do {
+            auto insertQuery = TStringBuilder()
+                << "insert into big_table(Key, Value) values("
+                << i++ << ",'" << data << "');";
+            result = ydb->ExecuteQuery(insertQuery, settings);
+        } while (result.GetStatus() == NYdb::EStatus::SUCCESS);
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            result.GetIssues().ToString(),
+            "database is out of disk space"
+        );
+
+        result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
+
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(
+            result.GetIssues().ToString(),
+            TStringBuilder() << "Error: Disk space exhausted. Table `/Root/test-dedicated/.metadata/workload_manager/" << table
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            result.GetIssues().begin()->GetCode(),
+            (ui32)NYql::TIssuesIds::KIKIMR_DATABASE_DISK_SPACE_QUOTA_EXCEEDED
+        );
+    }
+
+    Y_UNIT_TEST(TestDiskIsFullRunBelowQueryLimit) {
+        TestWhenDiskSpaceIsExhausted(10, "running_requests");
+    }
+
+    Y_UNIT_TEST(TestDiskIsFullRunOverQueryLimit) {
+        TestWhenDiskSpaceIsExhausted(1, "delayed_requests");
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
#25683 Do not fail queries in a WM if a db does not have free space
### Changelog category <!-- remove all except one -->
* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

The Workload Manager saves information about each query in metadata tables. When the dedicated database quota is exceeded or the disk is full, the Workload Manager cannot write metadata and fails every query. This fix adds error handling for metadata write failures and, in the case of disk exhaustion, allows the query to execute.
