### PR TITLE
Added message size limit for write to topic

### DIFF
--- a/ydb/core/persqueue/ut/ut_with_sdk/topic_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/topic_ut.cpp
@@ -279,7 +279,7 @@ Y_UNIT_TEST_SUITE(WithSDK) {
             if (event.has_value()) {
                 auto closeEvent = std::get_if<NYdb::NTopic::TSessionClosedEvent>(&*event);
                 if (closeEvent) {
-                    UNIT_ASSERT_C(closeEvent->GetIssues().ToOneLineString().contains("The size of the message is too big"), closeEvent->GetIssues().ToOneLineString());
+                    UNIT_ASSERT_C(closeEvent->GetIssues().ToOneLineString().contains("Too big message"), closeEvent->GetIssues().ToOneLineString());
                     return;
                 }
             }
@@ -290,5 +290,4 @@ Y_UNIT_TEST_SUITE(WithSDK) {
         UNIT_ASSERT_C(false, "Session closed event not received");
     }
 }
-
 } // namespace NKikimr

--- a/ydb/core/persqueue/ut/ut_with_sdk/topic_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/topic_ut.cpp
@@ -253,6 +253,42 @@ Y_UNIT_TEST_SUITE(WithSDK) {
         // check that verify didn`t happened
         UNIT_ASSERT(event.has_value());
     }
+
+    Y_UNIT_TEST(WriteBigMessage) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.GetRuntime().GetAppData().PQConfig.SetMaxMessageSizeBytes(1_KB);
+        setup.CreateTopic(TEST_TOPIC);
+
+        TTopicClient client(setup.MakeDriver());
+        TWriteSessionSettings settings;
+        settings.Path(TEST_TOPIC)
+            .ProducerId("producer-1")
+            .MessageGroupId("producer-1")
+            .Codec(ECodec::RAW);
+
+        auto session = client.CreateWriteSession(settings);
+
+        auto event = session->GetEvent(true);
+        UNIT_ASSERT(event.has_value());
+        auto* readyEvent = std::get_if<NYdb::NTopic::TWriteSessionEvent::TReadyToAcceptEvent>(&*event);
+        UNIT_ASSERT(readyEvent);
+        session->Write(std::move(readyEvent->ContinuationToken), TString(2_KB, 'a'));
+
+        for (size_t i = 0; i < 10; ++i) {
+            event = session->GetEvent(false);
+            if (event.has_value()) {
+                auto closeEvent = std::get_if<NYdb::NTopic::TSessionClosedEvent>(&*event);
+                if (closeEvent) {
+                    UNIT_ASSERT_C(closeEvent->GetIssues().ToOneLineString().contains("The size of the message is too big"), closeEvent->GetIssues().ToOneLineString());
+                    return;
+                }
+            }
+
+            Sleep(TDuration::Seconds(1));
+        }
+
+        UNIT_ASSERT_C(false, "Session closed event not received");
+    }
 }
 
 } // namespace NKikimr

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -591,7 +591,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, private TR
         auto& pqConfig = AppData(ActorContext())->PQConfig;
         for (const auto& write : record.GetPartitionRequest().GetCmdWrite()) {
             if (write.GetData().size() > pqConfig.GetMaxMessageSizeBytes()) {
-                auto errorMsg = TStringBuilder() << "The size of the message is too big. Max message size is " << pqConfig.GetMaxMessageSizeBytes()
+                auto errorMsg = TStringBuilder() << "Too big message. Max message size is " << pqConfig.GetMaxMessageSizeBytes()
                     << " bytes, but got " << write.GetData().size() << " bytes";
 
                 BecomeZombie(EErrorCode::InternalError, errorMsg);

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -220,6 +220,7 @@ message TPQConfig {
     }
 
     optional TCompactionConfig CompactionConfig = 58;
+    optional uint64 MaxMessageSizeBytes = 59 [default = 125829120]; // 120MB
 }
 
 message TChannelProfile {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Требуется явно добавить лимит размера сообщений т.к. иначе при чтении упираемся в grpc лимит, что делает невозможным чтение из топика

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10220
