### PR TITLE
merge to stable-25-4 YQ federated query fixes

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
@@ -41,6 +41,10 @@ TKqpScanComputeActor::TKqpScanComputeActor(NScheduler::TSchedulableActorOptions 
     YQL_ENSURE(Meta.GetTable().GetTableKind() != (ui32)ETableKind::SysView);
 }
 
+TKqpScanComputeActor::~TKqpScanComputeActor() {
+    FreeComputeCtxData();
+}
+
 void TKqpScanComputeActor::ProcessRlNoResourceAndDie() {
     const NYql::TIssue issue = MakeIssue(NKikimrIssues::TIssuesIds::YDB_RESOURCE_USAGE_LIMITED,
         "Throughput limit exceeded for query");

--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
@@ -74,6 +74,8 @@ public:
         const NYql::NDq::TComputeRuntimeSettings& settings, const NYql::NDq::TComputeMemoryLimits& memoryLimits, NWilson::TTraceId traceId,
         TIntrusivePtr<NActors::TProtoArenaHolder> arena, EBlockTrackingMode mode);
 
+    ~TKqpScanComputeActor();
+
     STFUNC(StateFunc) {
         try {
             switch (ev->GetTypeRewrite()) {

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -2781,19 +2781,38 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
         }
 
         auto db = kikimr->GetQueryClient();
-        const TString query = R"(
-            INSERT INTO test_bucket.`/result/` WITH (
-                FORMAT = "csv_with_names",
-                PARTITIONED_BY = (data)
-            )
-                (data)
-            VALUES
-                ("some_string")
-        )";
-        const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
-        const auto& issues = result.GetIssues().ToString();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, issues);
-        UNIT_ASSERT_STRING_CONTAINS(issues, "Write schema contains no columns except partitioning columns.");
+        {
+            const TString query = R"(
+                INSERT INTO test_bucket.`/result/` WITH (
+                    FORMAT = "csv_with_names",
+                    PARTITIONED_BY = (data)
+                )
+                    (data)
+                VALUES
+                    ("some_string")
+            )";
+            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            const auto& issues = result.GetIssues().ToString();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, issues);
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Write schema contains no columns except partitioning columns.");
+        }
+
+        {
+            const TString query = R"(
+                INSERT INTO test_bucket.`/result/` WITH (
+                    FORMAT = "csv_with_names",
+                    PARTITIONED_BY = (data)
+                )
+                    (data)
+                VALUES
+                    (CurrentUtcTimestamp() + Interval("PT2H"))
+            )";
+            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            const auto& issues = result.GetIssues().ToString();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, issues);
+            UNIT_ASSERT_STRING_CONTAINS(issues, "At partition key: 'data'");
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Expected data type, but got: Optional<Timestamp>");
+        }
     }
 
     Y_UNIT_TEST(TestVariantTypeValidation) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -139,12 +139,12 @@ struct IDqComputeActorAsyncInput {
     virtual void FillExtraStats(NDqProto::TDqTaskStats* /* stats */, bool /* finalized stats */, const NYql::NDq::TDqMeteringStats*) { }
 
     // The same signature as IActor::PassAway().
-    // It is guaranted that this method will be called with bound MKQL allocator.
+    // It is guaranteed that this method will be called with bound MKQL allocator.
     // So, it is the right place to destroy all internal UnboxedValues.
     virtual void PassAway() = 0;
 
-    // Do not destroy UnboxedValues inside destructor!!!
-    // It is called from actor system thread, and MKQL allocator is not bound in this case.
+    // You must also destroy all internal UnboxedValues inside destructor (same as in PassAway)
+    // But you should explicitly bind MKQL allocator here, because it is called from actor system thread.
     virtual ~IDqComputeActorAsyncInput() = default;
 };
 
@@ -205,6 +205,8 @@ struct IDqComputeActorAsyncOutput {
 
     virtual void PassAway() = 0; // The same signature as IActor::PassAway()
 
+    // You must also destroy all internal UnboxedValues inside destructor (same as in PassAway)
+    // But you should explicitly bind MKQL allocator here, because it is called from actor system thread.
     virtual ~IDqComputeActorAsyncOutput() = default;
 };
 

--- a/ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
@@ -24,7 +24,8 @@ namespace NYql::NDq {
                 args.ReadRanges,
                 args.ComputeActorId,
                 securedServiceAccountCredentialsFactory,
-                args.HolderFactory);
+                args.HolderFactory,
+                std::move(args.Alloc));
         };
 
         auto lookupActorFactory = [securedServiceAccountCredentialsFactory, genericClient](Generic::TLookupSource&& lookupSource, IDqAsyncIoFactory::TLookupSourceArguments&& args) {

--- a/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.h
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.h
@@ -20,6 +20,7 @@ namespace NYql::NDq {
         const TVector<TString>& readRanges,
         const NActors::TActorId& computeActorId,
         ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory,
-        const NKikimr::NMiniKQL::THolderFactory& holderFactory);
+        const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc);
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.h
@@ -35,6 +35,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateDqPqReadActor(
     ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory,
     const NActors::TActorId& computeActorId,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     const ::NMonitoring::TDynamicCounterPtr& counters,
     IPqGateway::TPtr pqGateway,
     ui32 topicPartitionsCount,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.cpp
@@ -70,7 +70,7 @@ namespace NYql::NDq {
                 NDB::registerFormats();
                 factory.RegisterSource<NS3::TSource>("S3Source",
                     [credentialsFactory, gateway, retryPolicy, cfg, counters, allowLocalFiles](NS3::TSource&& settings, IDqAsyncIoFactory::TSourceArguments&& args) {
-                        return CreateS3ReadActor(args.TypeEnv, args.HolderFactory, gateway,
+                        return CreateS3ReadActor(args.TypeEnv, args.HolderFactory, std::move(args.Alloc), gateway,
                             std::move(settings), args.InputIndex, args.StatsLevel, args.TxId, args.SecureParams,
                             args.TaskParams, args.ReadRanges, args.ComputeActorId, credentialsFactory, retryPolicy, cfg,
                             counters, args.TaskCounters, args.MemoryQuotaManager, allowLocalFiles);

--- a/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.h
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.h
@@ -18,6 +18,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, NActors::IActor*> CreateRawRead
     const TTxId& txId,
     IHTTPGateway::TPtr gateway,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     const TString& url,
     const TS3Credentials& credentials,
     const TString& pattern,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -1310,6 +1310,7 @@ public:
         const TTxId& txId,
         IHTTPGateway::TPtr gateway,
         const THolderFactory& holderFactory,
+        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
         const TString& url,
         const TS3Credentials& credentials,
         const TString& pattern,
@@ -1338,6 +1339,7 @@ public:
         , ReadActorFactoryCfg(readActorFactoryCfg)
         , Gateway(std::move(gateway))
         , HolderFactory(holderFactory)
+        , Alloc(std::move(alloc))
         , TxId(txId)
         , ComputeActorId(computeActorId)
         , RetryPolicy(retryPolicy)
@@ -1385,6 +1387,13 @@ public:
             RawInflightSize = TaskCounters->GetCounter("RawInflightSize");
         }
         IngressStats.Level = statsLevel;
+    }
+
+    ~TS3StreamReadActor() {
+        if (Alloc) {
+            TGuard<NKikimr::NMiniKQL::TScopedAlloc> allocGuard(*Alloc);
+            ClearMkqlData();
+        }
     }
 
     void Bootstrap() {
@@ -1687,9 +1696,7 @@ private:
             LOG_T("TS3StreamReadActor", "PassAway FileQueue RemoveConfirmedEvents=" << FileQueueEvents.RemoveConfirmedEvents());
             FileQueueEvents.Unsubscribe();
 
-            ContainerCache.Clear();
-            ArrowTupleContainerCache.Clear();
-            ArrowRowContainerCache.Clear();
+            ClearMkqlData();
 
             MemoryQuotaManager->FreeQuota(ReadActorFactoryCfg.DataInflight);
         } else {
@@ -1900,9 +1907,17 @@ private:
         Send(ComputeActorId, ev.release());
     }
 
+    // Should be called with bound MKQL alloc
+    void ClearMkqlData() {
+        ContainerCache.Clear();
+        ArrowTupleContainerCache.Clear();
+        ArrowRowContainerCache.Clear();
+    }
+
     const TS3ReadActorFactoryConfig ReadActorFactoryCfg;
     const IHTTPGateway::TPtr Gateway;
     const THolderFactory& HolderFactory;
+    const std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
     TPlainContainerCache ContainerCache;
     TPlainContainerCache ArrowTupleContainerCache;
     TPlainContainerCache ArrowRowContainerCache;
@@ -2105,6 +2120,7 @@ NDB::FormatSettings::TimestampFormat ToTimestampFormat(const TString& formatName
 std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
     const TTypeEnvironment& typeEnv,
     const THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     IHTTPGateway::TPtr gateway,
     NS3::TSource&& params,
     ui64 inputIndex,
@@ -2314,7 +2330,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
             sizeLimit = FromString<ui64>(it->second);
         }
 
-        const auto actor = new TS3StreamReadActor(inputIndex, statsLevel, txId, std::move(gateway), holderFactory, params.GetUrl(), credentials, pathPattern, pathPatternVariant,
+        const auto actor = new TS3StreamReadActor(inputIndex, statsLevel, txId, std::move(gateway), holderFactory, std::move(alloc), params.GetUrl(), credentials, pathPattern, pathPatternVariant,
                                                   std::move(paths), addPathIndex, readSpec, computeActorId, retryPolicy,
                                                   cfg, counters, taskCounters, fileSizeLimit, sizeLimit, rowsLimitHint, memoryQuotaManager,
                                                   params.GetUseRuntimeListing(), fileQueueActor, fileQueueBatchSizeLimit, fileQueueBatchObjectCountLimit, fileQueueConsumersCountDelta,
@@ -2326,7 +2342,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
         if (const auto it = settings.find("sizeLimit"); settings.cend() != it)
             sizeLimit = FromString<ui64>(it->second);
 
-        return CreateRawReadActor(inputIndex, statsLevel, txId, std::move(gateway), holderFactory, params.GetUrl(), credentials, pathPattern, pathPatternVariant,
+        return CreateRawReadActor(inputIndex, statsLevel, txId, std::move(gateway), holderFactory, std::move(alloc), params.GetUrl(), credentials, pathPattern, pathPatternVariant,
                                             std::move(paths), addPathIndex, computeActorId, sizeLimit, retryPolicy,
                                             cfg, counters, taskCounters, fileSizeLimit, rowsLimitHint,
                                             params.GetUseRuntimeListing(), fileQueueActor, fileQueueBatchSizeLimit, fileQueueBatchObjectCountLimit, fileQueueConsumersCountDelta, allowLocalFiles);

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.h
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.h
@@ -35,6 +35,7 @@ NActors::IActor* CreateS3FileQueueActor(
 std::pair<NYql::NDq::IDqComputeActorAsyncInput*, NActors::IActor*> CreateS3ReadActor(
     const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     IHTTPGateway::TPtr gateway,
     NS3::TSource&& params,
     ui64 inputIndex,

--- a/ydb/library/yql/providers/s3/provider/yql_s3_datasink_type_ann.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_datasink_type_ann.cpp
@@ -424,24 +424,31 @@ private:
         auto keysCount = keys.size();
         if (keysCount) {
             if (isSingleRowPerFileFormat) {
-                ctx.AddError(TIssue(ctx.GetPosition(format.Pos()), TStringBuilder() << "Partitioned isn't supported for " << (TStringBuf)format << " output format."));
+                ctx.AddError(TIssue(ctx.GetPosition(format.Pos()), TStringBuilder() << "Partitioned isn't supported for " << format.Value() << " output format."));
                 return nullptr;
             }
 
+            bool hasErrors = false;
             for (auto i = 0U; i < keysCount; ++i) {
                 const auto key = keys[i];
+                TIssueScopeGuard issueScopePartitionKey(ctx.IssueManager, [&]() {
+                    return MakeIntrusive<TIssue>(ctx.GetPosition(key->Pos()), TStringBuilder() << "At partition key: '" << key->Content() << "'");
+                });
+
                 if (const auto keyType = structType->FindItemType(key->Content())) {
-                    if (!EnsureDataType(key->Pos(), *keyType, ctx)) {
-                        return nullptr;
-                    }
+                    hasErrors = !EnsureDataType(key->Pos(), *keyType, ctx) || hasErrors;
                 } else {
-                    ctx.AddError(TIssue(ctx.GetPosition(key->Pos()), TStringBuilder() << "Missing key column for partitioning: '" << key->Content() << "'. Please ensure the column is included in the schema."));
-                    return nullptr;
+                    ctx.AddError(TIssue(ctx.GetPosition(key->Pos()), "Missing key column for partitioning. Please ensure the column is included in the schema."));
+                    hasErrors = true;
                 }
             }
 
             if (structType->GetSize() <= keysCount) {
-                ctx.AddError(TIssue(ctx.GetPosition(format.Pos()), TStringBuilder() << "Write schema contains no columns except partitioning columns."));
+                ctx.AddError(TIssue(ctx.GetPosition(format.Pos()), "Write schema contains no columns except partitioning columns."));
+                hasErrors = true;
+            }
+
+            if (hasErrors) {
                 return nullptr;
             }
 

--- a/ydb/tests/fq/pq_async_io/ut/dq_pq_read_actor_ut.cpp
+++ b/ydb/tests/fq/pq_async_io/ut/dq_pq_read_actor_ut.cpp
@@ -54,6 +54,7 @@ public:
                 nullptr,
                 actor.SelfId(),
                 actor.GetHolderFactory(),
+                nullptr,
                 MakeIntrusive<NMonitoring::TDynamicCounters>(),
                 CreatePqNativeGateway(std::move(pqServices)),
                 1,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Federated query fixes

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

* YQ-4997 fixed MKQL allocator bound in Scan/Source/Sinks DQ actors (#31435) -- fault on kikimr stop
* YQ-4998 improved S3 error message for unsupported partitioning columns (#31439)
