### PR TITLE
[NOT-FOR-MERGE-YET] [backport 25-3] multihopping/HoppingWindow: add unlimited/far/sparse windows / Watermarks: YQL: fix constraints / multihopping: add FarFuture statistics and limits

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_hopping.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_hopping.cpp
@@ -168,6 +168,32 @@ TMaybeNode<TExprBase> RewriteAsHoppingWindowFullOutput(
     } else {
         multiHoppingCoreBuilder.Delay(hopTraits.Traits.Delay());
     }
+    if (TCoHoppingTraits::idx_SizeLimit < hopTraits.Traits.Raw()->ChildrenSize()) {
+        if (hopTraits.Traits.SizeLimit()) {
+            multiHoppingCoreBuilder.SizeLimit(hopTraits.Traits.SizeLimit());
+        } else {
+            multiHoppingCoreBuilder.SizeLimit<TCoVoid>().Build();
+        }
+        if (hopTraits.Traits.TimeLimit()) {
+            multiHoppingCoreBuilder.TimeLimit(hopTraits.Traits.TimeLimit());
+        } else {
+            multiHoppingCoreBuilder.TimeLimit<TCoVoid>().Build();
+        }
+        if (hopTraits.EarlyPolicy) {
+            multiHoppingCoreBuilder.EarlyPolicy<TCoUint32>()
+                .Literal().Build(ToString((ui32)*hopTraits.EarlyPolicy))
+            .Build();
+        } else {
+            multiHoppingCoreBuilder.EarlyPolicy<TCoVoid>().Build();
+        }
+        if (hopTraits.LatePolicy) {
+            multiHoppingCoreBuilder.LatePolicy<TCoUint32>()
+                .Literal().Build(ToString((ui32)*hopTraits.LatePolicy))
+            .Build();
+        } else {
+            multiHoppingCoreBuilder.LatePolicy<TCoVoid>().Build();
+        }
+    }
 
     if (analyticsMode) {
         return Build<TCoPartitionsByKeys>(ctx, node.Pos())

--- a/yql/essentials/core/common_opt/yql_co_flow2.cpp
+++ b/yql/essentials/core/common_opt/yql_co_flow2.cpp
@@ -2664,13 +2664,9 @@ void RegisterCoFlowCallables2(TCallableOptimizerMap& map) {
         auto subsetType = ctx.MakeType<TStructExprType>(subsetItems);
         YQL_CLOG(DEBUG, Core) << "FieldSubset for HoppingTraits";
         return Build<TCoHoppingTraits>(ctx, node->Pos())
+            .InitFrom(self)
             .ItemType(ExpandType(node->Pos(), *subsetType, ctx))
             .TimeExtractor(ctx.DeepCopyLambda(self.TimeExtractor().Ref()))
-            .Hop(self.Hop())
-            .Interval(self.Interval())
-            .Delay(self.Delay())
-            .DataWatermarks(self.DataWatermarks())
-            .Version(self.Version())
             .Done().Ptr();
     };
 

--- a/yql/essentials/core/common_opt/yql_co_simple1.cpp
+++ b/yql/essentials/core/common_opt/yql_co_simple1.cpp
@@ -3468,7 +3468,8 @@ TExprNode::TPtr RewriteAsHoppingWindowFullOutput(const TCoAggregate& aggregate, 
         .FinishHandler(finishLambda)
         .SaveHandler(saveLambda)
         .LoadHandler(loadLambda)
-        .template WatermarkMode<TCoAtom>().Build(ToString(false));
+        .WatermarkMode<TCoAtom>().Build(ToString(false))
+        .HoppingColumn<TCoAtom>().Build(hopTraits.Column);
 
     return Build<TCoPartitionsByKeys>(ctx, pos)
         .Input(aggregate.Input())
@@ -3481,10 +3482,10 @@ TExprNode::TPtr RewriteAsHoppingWindowFullOutput(const TCoAggregate& aggregate, 
         .SortKeySelectorLambda(timeExtractorLambda)
         .ListHandlerLambda()
             .Args(streamArg)
-            .template Body<TCoForwardList>()
+            .Body<TCoForwardList>()
                 .Stream(Build<TCoMap>(ctx, pos)
                     .Input(multiHoppingCoreBuilder
-                        .template Input<TCoIterator>()
+                        .Input<TCoIterator>()
                             .List(streamArg)
                             .Build()
                         .Done())

--- a/yql/essentials/core/common_opt/yql_co_simple1.cpp
+++ b/yql/essentials/core/common_opt/yql_co_simple1.cpp
@@ -3470,7 +3470,32 @@ TExprNode::TPtr RewriteAsHoppingWindowFullOutput(const TCoAggregate& aggregate, 
         .LoadHandler(loadLambda)
         .WatermarkMode<TCoAtom>().Build(ToString(false))
         .HoppingColumn<TCoAtom>().Build(hopTraits.Column);
-
+    if (TCoHoppingTraits::idx_SizeLimit < hopTraits.Traits.Raw()->ChildrenSize()) {
+        if (hopTraits.Traits.SizeLimit()) {
+            multiHoppingCoreBuilder.SizeLimit(hopTraits.Traits.SizeLimit());
+        } else {
+            multiHoppingCoreBuilder.SizeLimit<TCoVoid>().Build();
+        }
+        if (hopTraits.Traits.TimeLimit()) {
+            multiHoppingCoreBuilder.TimeLimit(hopTraits.Traits.TimeLimit());
+        } else {
+            multiHoppingCoreBuilder.TimeLimit<TCoVoid>().Build();
+        }
+        if (hopTraits.EarlyPolicy) {
+            multiHoppingCoreBuilder.EarlyPolicy<TCoUint32>()
+                .Literal().Build(ToString((ui32)*hopTraits.EarlyPolicy))
+            .Build();
+        } else {
+            multiHoppingCoreBuilder.EarlyPolicy<TCoVoid>().Build();
+        }
+        if (hopTraits.LatePolicy) {
+            multiHoppingCoreBuilder.LatePolicy<TCoUint32>()
+                .Literal().Build(ToString((ui32)*hopTraits.LatePolicy))
+            .Build();
+        } else {
+            multiHoppingCoreBuilder.LatePolicy<TCoVoid>().Build();
+        }
+    }
     return Build<TCoPartitionsByKeys>(ctx, pos)
         .Input(aggregate.Input())
         .KeySelectorLambda(keyLambda)

--- a/yql/essentials/core/expr_nodes/yql_expr_nodes.json
+++ b/yql/essentials/core/expr_nodes/yql_expr_nodes.json
@@ -2082,7 +2082,8 @@
                 {"Index": 10, "Name": "LoadHandler",    "Type": "TExprBase"},
                 {"Index": 11, "Name": "MergeHandler",   "Type": "TCoLambda"},
                 {"Index": 12, "Name": "FinishHandler",  "Type": "TCoLambda"},
-                {"Index": 13, "Name": "WatermarkMode",  "Type": "TExprBase"}
+                {"Index": 13, "Name": "WatermarkMode",  "Type": "TExprBase"},
+                {"Index": 14, "Name": "HoppingColumn",  "Type": "TCoAtom"}
             ]
         },
         {

--- a/yql/essentials/core/expr_nodes/yql_expr_nodes.json
+++ b/yql/essentials/core/expr_nodes/yql_expr_nodes.json
@@ -656,13 +656,17 @@
             "Base": "TCallable",
             "Match": {"Type": "Callable", "Name": "HoppingTraits"},
             "Children": [
-                {"Index": 0, "Name": "ItemType",       "Type": "TExprBase"},
-                {"Index": 1, "Name": "TimeExtractor",  "Type": "TCoLambda"},
-                {"Index": 2, "Name": "Hop",            "Type": "TExprBase"},
-                {"Index": 3, "Name": "Interval",       "Type": "TExprBase"},
-                {"Index": 4, "Name": "Delay",          "Type": "TExprBase"},
-                {"Index": 5, "Name": "DataWatermarks", "Type": "TExprBase"},
-                {"Index": 6, "Name": "Version",        "Type": "TExprBase"}
+                {"Index": 0,  "Name": "ItemType",       "Type": "TExprBase"},
+                {"Index": 1,  "Name": "TimeExtractor",  "Type": "TCoLambda"},
+                {"Index": 2,  "Name": "Hop",            "Type": "TExprBase"},
+                {"Index": 3,  "Name": "Interval",       "Type": "TExprBase"},
+                {"Index": 4,  "Name": "Delay",          "Type": "TExprBase"},
+                {"Index": 5,  "Name": "DataWatermarks", "Type": "TExprBase"},
+                {"Index": 6,  "Name": "Version",        "Type": "TExprBase"},
+                {"Index": 7,  "Name": "SizeLimit",      "Type": "TExprBase", "Optional": true},
+                {"Index": 8,  "Name": "TimeLimit",      "Type": "TExprBase", "Optional": true},
+                {"Index": 9,  "Name": "EarlyPolicy",    "Type": "TExprBase", "Optional": true},
+                {"Index": 10, "Name": "LatePolicy",     "Type": "TExprBase", "Optional": true}
             ]
         },
         {
@@ -2083,7 +2087,11 @@
                 {"Index": 11, "Name": "MergeHandler",   "Type": "TCoLambda"},
                 {"Index": 12, "Name": "FinishHandler",  "Type": "TCoLambda"},
                 {"Index": 13, "Name": "WatermarkMode",  "Type": "TExprBase"},
-                {"Index": 14, "Name": "HoppingColumn",  "Type": "TCoAtom"}
+                {"Index": 14, "Name": "HoppingColumn",  "Type": "TCoAtom"},
+                {"Index": 15, "Name": "SizeLimit",      "Type": "TExprBase", "Optional": true},
+                {"Index": 16, "Name": "TimeLimit",      "Type": "TExprBase", "Optional": true},
+                {"Index": 17, "Name": "EarlyPolicy",    "Type": "TExprBase", "Optional": true},
+                {"Index": 18, "Name": "LatePolicy",     "Type": "TExprBase", "Optional": true}
             ]
         },
         {

--- a/yql/essentials/core/sql_types/hopping.h
+++ b/yql/essentials/core/sql_types/hopping.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <util/datetime/base.h>
+
+namespace NYql::NHoppingWindow {
+
+// Careful: stored in ast as ui32, don't reuse/reorder values
+enum class EPolicy: ui32 { // Note: only effective after watermark set
+    Drop /* "drop" */,     // drop events outside limit
+    Adjust /* "adjust" */, // reassign event to first possible/last possible window
+    Close /* "close" */,   // adjust window so that limit is satisfied; unimplemented for late events
+};
+
+struct TSettings {
+    EPolicy LatePolicy = EPolicy::Drop;
+    EPolicy EarlyPolicy = EPolicy::Close;
+    TDuration FarFutureTimeLimit = TDuration::Zero(); // ahead of current watermark (effective only when watermark is set)
+    ui64 FarFutureSizeLimit = Max<ui64>();            // number of "far future" hops
+    auto operator<=>(const TSettings&) const = default;
+};
+
+} // namespace NYql::NHoppingWindow

--- a/yql/essentials/core/sql_types/ya.make
+++ b/yql/essentials/core/sql_types/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     yql/essentials/core/issue
 )
 
+GENERATE_ENUM_SERIALIZATION(hopping.h)
 GENERATE_ENUM_SERIALIZATION(match_recognize.h)
 GENERATE_ENUM_SERIALIZATION(yql_atom_enums.h)
 

--- a/yql/essentials/core/type_ann/type_ann_core.cpp
+++ b/yql/essentials/core/type_ann/type_ann_core.cpp
@@ -13078,7 +13078,7 @@ template <NKikimr::NUdf::EDataSlot DataSlot>
         Functions["GraceSelfJoinCore"] = &GraceSelfJoinCoreWrapper;
         Functions["CombineCore"] = &CombineCoreWrapper;
         Functions["GroupingCore"] = &GroupingCoreWrapper;
-        Functions["HoppingTraits"] = &HoppingTraitsWrapper;
+        ExtFunctions["HoppingTraits"] = &HoppingTraitsWrapper;
         Functions["HoppingCore"] = &HoppingCoreWrapper;
         Functions["MultiHoppingCore"] = &MultiHoppingCoreWrapper;
         Functions["EquiJoin"] = &EquiJoinWrapper;

--- a/yql/essentials/core/type_ann/type_ann_list.cpp
+++ b/yql/essentials/core/type_ann/type_ann_list.cpp
@@ -7035,7 +7035,7 @@ namespace {
 
     IGraphTransformer::TStatus MultiHoppingCoreWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx) {
         Y_UNUSED(output);
-        if (!EnsureArgsCount(*input, 14, ctx.Expr)) {
+        if (!EnsureArgsCount(*input, 15, ctx.Expr)) {
             return IGraphTransformer::TStatus::Error;
         }
         auto& item = input->ChildRef(0);
@@ -7045,6 +7045,7 @@ namespace {
         auto* hop = input->Child(3);
         auto* interval = input->Child(4);
         auto* delay = input->Child(5);
+        auto dataWatermarks = input->Child(6);
 
         auto& lambdaInit = input->ChildRef(7);
         auto& lambdaUpdate = input->ChildRef(8);
@@ -7052,6 +7053,9 @@ namespace {
         auto& loadLambda = input->ChildRef(10);
         auto& lambdaMerge = input->ChildRef(11);
         auto& lambdaFinish = input->ChildRef(12);
+
+        auto watermarkMode = input->Child(13);
+        auto hoppingColumn = input->Child(14);
 
         if (!EnsureStreamType(*item, ctx.Expr)) {
             return IGraphTransformer::TStatus::Error;
@@ -7099,6 +7103,10 @@ namespace {
             return IGraphTransformer::TStatus::Error;
         }
         if (!EnsureSpecificDataType(*delay, EDataSlot::Interval, ctx.Expr, true)) {
+            return IGraphTransformer::TStatus::Error;
+        }
+
+        if (!EnsureAtom(*dataWatermarks, ctx.Expr)) {
             return IGraphTransformer::TStatus::Error;
         }
 
@@ -7189,6 +7197,14 @@ namespace {
                     << *loadLambda->GetTypeAnn() << " != " << *stateType));
                 return IGraphTransformer::TStatus::Error;
             }
+        }
+
+        if (!EnsureAtom(*watermarkMode, ctx.Expr)) {
+            return IGraphTransformer::TStatus::Error;
+        }
+
+        if (!EnsureAtom(*hoppingColumn, ctx.Expr)) {
+            return IGraphTransformer::TStatus::Error;
         }
 
         input->SetTypeAnn(ctx.Expr.MakeType<TStreamExprType>(lambdaFinish->GetTypeAnn()));

--- a/yql/essentials/core/type_ann/type_ann_list.cpp
+++ b/yql/essentials/core/type_ann/type_ann_list.cpp
@@ -6800,9 +6800,9 @@ namespace {
         return IGraphTransformer::TStatus::Ok;
     }
 
-    IGraphTransformer::TStatus HoppingTraitsWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx) {
+    IGraphTransformer::TStatus HoppingTraitsWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExtContext& ctx) {
         Y_UNUSED(output);
-        if (!EnsureArgsCount(*input, 7, ctx.Expr)) {
+        if (!EnsureMinMaxArgsCount(*input, TCoHoppingTraits::idx_Version + 1, TCoHoppingTraits::idx_LatePolicy + 1, ctx.Expr)) {
             return IGraphTransformer::TStatus::Error;
         }
         if (auto status = EnsureTypeRewrite(input->HeadRef(), ctx.Expr); status != IGraphTransformer::TStatus::Ok) {
@@ -6874,6 +6874,59 @@ namespace {
                 << "Expected unit type, but got: "
                 << *dataWatermarksNodePtr->GetTypeAnn()));
             return IGraphTransformer::TStatus::Error;
+        }
+
+        if (TCoHoppingTraits::idx_SizeLimit < input->ChildrenSize()) {
+            auto& farFutureSizeLimit = input->ChildRef(TCoHoppingTraits::idx_SizeLimit);
+            if (!farFutureSizeLimit->IsCallable("Void")) {
+                if (farFutureSizeLimit->IsCallable("String") && farFutureSizeLimit->Child(0)->Content() == "max") {
+                    // special cast
+                    farFutureSizeLimit = ctx.Expr.Builder(farFutureSizeLimit->Pos())
+                        .Callable("Uint64")
+                            .Atom(0, ToString(Max<ui64>()))
+                        .Seal()
+                        .Build();
+                    return IGraphTransformer::TStatus::Repeat;
+                }
+                const TTypeAnnotationNode* expectedType = ctx.Expr.MakeType<TDataExprType>(EDataSlot::Uint64);
+                auto convertStatus = TryConvertTo(farFutureSizeLimit, *expectedType, ctx.Expr, ctx.Types);
+                if (convertStatus.Level != IGraphTransformer::TStatus::Ok) {
+                    return convertStatus;
+                }
+            }
+        }
+        if (TCoHoppingTraits::idx_TimeLimit < input->ChildrenSize()) {
+            auto& farFutureTimeLimit = input->ChildRef(TCoHoppingTraits::idx_TimeLimit);
+            if (!farFutureTimeLimit->IsCallable("Void")) {
+                if (farFutureTimeLimit->IsCallable("String") && farFutureTimeLimit->Child(0)->Content() == "max") {
+                    // special cast
+                    farFutureTimeLimit = ctx.Expr.Builder(farFutureTimeLimit->Pos())
+                        .Callable("Interval")
+                            .Atom(0, ToString(NUdf::MAX_TIMESTAMP - 1))
+                        .Seal()
+                        .Build();
+                    return IGraphTransformer::TStatus::Repeat;
+                }
+                if (!EnsureSpecificDataType(*farFutureTimeLimit, EDataSlot::Interval, ctx.Expr, /*allowOptional=*/true)) {
+                    return IGraphTransformer::TStatus::Error;
+                }
+            }
+        }
+        if (TCoHoppingTraits::idx_EarlyPolicy < input->ChildrenSize()) {
+            auto* earlyPolicy = input->Child(TCoHoppingTraits::idx_EarlyPolicy);
+            if (!earlyPolicy->IsCallable("Void")) {
+                if (!EnsureSpecificDataType(*earlyPolicy, EDataSlot::String, ctx.Expr, /*allowOptional=*/true)) {
+                    return IGraphTransformer::TStatus::Error;
+                }
+            }
+        }
+        if (TCoHoppingTraits::idx_LatePolicy < input->ChildrenSize()) {
+            auto* latePolicy = input->Child(TCoHoppingTraits::idx_LatePolicy);
+            if (!latePolicy->IsCallable("Void")) {
+                if (!EnsureSpecificDataType(*latePolicy, EDataSlot::String, ctx.Expr, /*allowOptional=*/true)) {
+                    return IGraphTransformer::TStatus::Error;
+                }
+            }
         }
 
         input->SetTypeAnn(ctx.Expr.MakeType<TUnitExprType>());
@@ -7035,7 +7088,7 @@ namespace {
 
     IGraphTransformer::TStatus MultiHoppingCoreWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx) {
         Y_UNUSED(output);
-        if (!EnsureArgsCount(*input, 15, ctx.Expr)) {
+        if (!EnsureMinMaxArgsCount(*input, TCoMultiHoppingCore::idx_HoppingColumn + 1, TCoMultiHoppingCore::idx_LatePolicy + 1, ctx.Expr)) {
             return IGraphTransformer::TStatus::Error;
         }
         auto& item = input->ChildRef(0);
@@ -7108,6 +7161,39 @@ namespace {
 
         if (!EnsureAtom(*dataWatermarks, ctx.Expr)) {
             return IGraphTransformer::TStatus::Error;
+        }
+
+        if (TCoMultiHoppingCore::idx_SizeLimit < input->ChildrenSize()) {
+            auto* farFutureSizeLimit = input->Child(TCoMultiHoppingCore::idx_SizeLimit);
+            if (!farFutureSizeLimit->IsCallable("Void")) {
+                if (!EnsureSpecificDataType(*farFutureSizeLimit, EDataSlot::Uint64, ctx.Expr, /*allowOptional=*/true)) {
+                    return IGraphTransformer::TStatus::Error;
+                }
+            }
+        }
+        if (TCoMultiHoppingCore::idx_TimeLimit < input->ChildrenSize()) {
+            auto* farFutureTimeLimit = input->Child(TCoMultiHoppingCore::idx_TimeLimit);
+            if (!farFutureTimeLimit->IsCallable("Void")) {
+                if (!EnsureSpecificDataType(*farFutureTimeLimit, EDataSlot::Interval, ctx.Expr, /*allowOptional=*/true)) {
+                    return IGraphTransformer::TStatus::Error;
+                }
+            }
+        }
+        if (TCoMultiHoppingCore::idx_EarlyPolicy < input->ChildrenSize()) {
+            auto* earlyPolicy = input->Child(TCoMultiHoppingCore::idx_EarlyPolicy);
+            if (!earlyPolicy->IsCallable("Void")) {
+                if (!EnsureSpecificDataType(*earlyPolicy, EDataSlot::Uint32, ctx.Expr, /*allowOptional=*/true)) {
+                    return IGraphTransformer::TStatus::Error;
+                }
+            }
+        }
+        if (TCoMultiHoppingCore::idx_LatePolicy < input->ChildrenSize()) {
+            auto* latePolicy = input->Child(TCoMultiHoppingCore::idx_LatePolicy);
+            if (!latePolicy->IsCallable("Void")) {
+                if (!EnsureSpecificDataType(*latePolicy, EDataSlot::Uint32, ctx.Expr, /*allowOptional=*/true)) {
+                    return IGraphTransformer::TStatus::Error;
+                }
+            }
         }
 
         if (!UpdateLambdaAllArgumentsTypes(lambdaInit, {itemType}, ctx.Expr)) {

--- a/yql/essentials/core/type_ann/type_ann_list.h
+++ b/yql/essentials/core/type_ann/type_ann_list.h
@@ -125,7 +125,7 @@ namespace NTypeAnnImpl {
     IGraphTransformer::TStatus WinNTileWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExtContext& ctx);
     IGraphTransformer::TStatus HoppingCoreWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus MultiHoppingCoreWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
-    IGraphTransformer::TStatus HoppingTraitsWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
+    IGraphTransformer::TStatus HoppingTraitsWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExtContext& ctx);
     IGraphTransformer::TStatus ListMinWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus ListMaxWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus ListSumWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);

--- a/yql/essentials/core/ut/yql_expr_constraint_ut.cpp
+++ b/yql/essentials/core/ut/yql_expr_constraint_ut.cpp
@@ -3465,8 +3465,13 @@ Y_UNIT_TEST_SUITE(TYqlExprConstraints) {
         CheckConstraint<TDistinctConstraintNode>(exprRoot, "LazyList", "");
     }
 
+<<<<<<< HEAD
     Y_UNIT_TEST(GroupByHop) {
         const TStringBuf s = R"((
+=======
+Y_UNIT_TEST(HOP) {
+    const TStringBuf s = R"((
+>>>>>>> ce841fb266c (Watermarks: YQL: fix constraints)
 (let list (AsList
     (AsStruct '('"time" (String '"2024-01-01T00:00:01Z")) '('"user" (Int32 '"1")) '('"data" (Null)))
     (AsStruct '('"time" (String '"2024-01-01T00:00:02Z")) '('"user" (Int32 '"1")) '('"data" (Null)))
@@ -3476,23 +3481,60 @@ Y_UNIT_TEST_SUITE(TYqlExprConstraints) {
 (let keySelector (lambda '(row) '((StablePickle (Member row '"data")) (StablePickle (Member row 'group0)))))
 (let sortKeySelector (lambda '(row) (SafeCast (Member row '"time") (OptionalType (DataType 'Timestamp)))))
 (let result (PartitionsByKeys input keySelector (Bool 'true) sortKeySelector (lambda '(row) (block '(
-  (let interval (Interval '1000000))
-  (let map (lambda '(item) (AsStruct)))
-  (let reduce (lambda '(lhs rhs) (AsStruct)))
-  (let hopping (MultiHoppingCore (Iterator row) keySelector sortKeySelector interval interval interval 'true map reduce map map reduce (lambda '(key state time) (AsStruct '('_yql_time time) '('"data" (Nth key '"0")) '('group0 (Nth key '"1")))) '"0"))
-  (return (ForwardList (FlatMap hopping (lambda '(row) (Just (AsStruct '('_yql_time (Member row '_yql_time)) '('"data" (Unpickle (NullType) (Member row '"data"))) '('group0 (Unpickle (ListType (DataType 'Int32)) (Member row 'group0)))))))))
+    (let interval (Interval '1000000))
+    (let map (lambda '(item) (AsStruct)))
+    (let reduce (lambda '(lhs rhs) (AsStruct)))
+    (let hopping (MultiHoppingCore (Iterator row) keySelector sortKeySelector interval interval interval 'true map reduce map map reduce (lambda '(key state time) (AsStruct '('_yql_time time) '('"data" (Nth key '"0")) '('group0 (Nth key '"1")))) '"0" '"_yql_time"))
+    (return (ForwardList (FlatMap hopping (lambda '(row) (Just (AsStruct '('_yql_time (Member row '_yql_time)) '('"data" (Unpickle (NullType) (Member row '"data"))) '('group0 (Unpickle (ListType (DataType 'Int32)) (Member row 'group0)))))))))
 )))))
 
 (let res (DataSink 'result))
 (let world (Write! world res (Key) result '()))
 (return (Commit! world res))
-        ))";
+    ))";
 
+<<<<<<< HEAD
         TExprContext exprCtx;
         const auto exprRoot = ParseAndAnnotate(s, exprCtx);
         CheckConstraint<TDistinctConstraintNode>(exprRoot, "PartitionsByKeys", "Distinct((data,group0))");
         CheckConstraint<TUniqueConstraintNode>(exprRoot, "PartitionsByKeys", "Unique((data,group0))");
     }
+=======
+    TExprContext exprCtx;
+    const auto exprRoot = ParseAndAnnotate(s, exprCtx);
+    CheckConstraint<TDistinctConstraintNode>(exprRoot, "MultiHoppingCore", "Distinct((data,group0))");
+    CheckConstraint<TUniqueConstraintNode>(exprRoot, "MultiHoppingCore", "Unique((data,group0))");
+}
+
+Y_UNIT_TEST(HoppingWindow) {
+    const TStringBuf s = R"((
+(let list (AsList
+    (AsStruct '('"time" (String '"2024-01-01T00:00:01Z")) '('"user" (Int32 '"1")) '('"data" (Null)))
+    (AsStruct '('"time" (String '"2024-01-01T00:00:02Z")) '('"user" (Int32 '"1")) '('"data" (Null)))
+    (AsStruct '('"time" (String '"2024-01-01T00:00:03Z")) '('"user" (Int32 '"1")) '('"data" (Null)))
+))
+(let input (FlatMap list (lambda '(row) (Just (AsStruct '('"data" (Member row '"data")) '('group0 (AsList (Member row '"user"))) '('"time" (Member row '"time")) '('"user" (Member row '"user")))))))
+(let keySelector (lambda '(row) '((StablePickle (Member row '"data")) (StablePickle (Member row 'group0)))))
+(let sortKeySelector (lambda '(row) (SafeCast (Member row '"time") (OptionalType (DataType 'Timestamp)))))
+(let result (PartitionsByKeys input keySelector (Bool 'true) sortKeySelector (lambda '(row) (block '(
+    (let interval (Interval '1000000))
+    (let map (lambda '(item) (AsStruct)))
+    (let reduce (lambda '(lhs rhs) (AsStruct)))
+    (let hopping (MultiHoppingCore (Iterator row) keySelector sortKeySelector interval interval interval 'true map reduce map map reduce (lambda '(key state time) (AsStruct '('_yql_time time) '('"data" (Nth key '"0")) '('group0 (Nth key '"1")))) '"0" 'group0))
+    (return (ForwardList (FlatMap hopping (lambda '(row) (Just (AsStruct '('_yql_time (Member row '_yql_time)) '('"data" (Unpickle (NullType) (Member row '"data"))) '('group0 (Unpickle (ListType (DataType 'Int32)) (Member row 'group0)))))))))
+)))))
+
+(let res (DataSink 'result))
+(let world (Write! world res (Key) result '()))
+(return (Commit! world res))
+    ))";
+
+    TExprContext exprCtx;
+    const auto exprRoot = ParseAndAnnotate(s, exprCtx);
+    CheckConstraint<TDistinctConstraintNode>(exprRoot, "MultiHoppingCore", "Distinct((data,group0))");
+    CheckConstraint<TUniqueConstraintNode>(exprRoot, "MultiHoppingCore", "Unique((data,group0))");
+}
+>>>>>>> ce841fb266c (Watermarks: YQL: fix constraints)
 
     Y_UNIT_TEST(StablePickleOfComplexUnique) {
         const TStringBuf s = R"(

--- a/yql/essentials/core/ut/yql_expr_constraint_ut.cpp
+++ b/yql/essentials/core/ut/yql_expr_constraint_ut.cpp
@@ -3465,13 +3465,8 @@ Y_UNIT_TEST_SUITE(TYqlExprConstraints) {
         CheckConstraint<TDistinctConstraintNode>(exprRoot, "LazyList", "");
     }
 
-<<<<<<< HEAD
-    Y_UNIT_TEST(GroupByHop) {
-        const TStringBuf s = R"((
-=======
 Y_UNIT_TEST(HOP) {
     const TStringBuf s = R"((
->>>>>>> ce841fb266c (Watermarks: YQL: fix constraints)
 (let list (AsList
     (AsStruct '('"time" (String '"2024-01-01T00:00:01Z")) '('"user" (Int32 '"1")) '('"data" (Null)))
     (AsStruct '('"time" (String '"2024-01-01T00:00:02Z")) '('"user" (Int32 '"1")) '('"data" (Null)))
@@ -3493,13 +3488,6 @@ Y_UNIT_TEST(HOP) {
 (return (Commit! world res))
     ))";
 
-<<<<<<< HEAD
-        TExprContext exprCtx;
-        const auto exprRoot = ParseAndAnnotate(s, exprCtx);
-        CheckConstraint<TDistinctConstraintNode>(exprRoot, "PartitionsByKeys", "Distinct((data,group0))");
-        CheckConstraint<TUniqueConstraintNode>(exprRoot, "PartitionsByKeys", "Unique((data,group0))");
-    }
-=======
     TExprContext exprCtx;
     const auto exprRoot = ParseAndAnnotate(s, exprCtx);
     CheckConstraint<TDistinctConstraintNode>(exprRoot, "MultiHoppingCore", "Distinct((data,group0))");
@@ -3534,7 +3522,6 @@ Y_UNIT_TEST(HoppingWindow) {
     CheckConstraint<TDistinctConstraintNode>(exprRoot, "MultiHoppingCore", "Distinct((data,group0))");
     CheckConstraint<TUniqueConstraintNode>(exprRoot, "MultiHoppingCore", "Unique((data,group0))");
 }
->>>>>>> ce841fb266c (Watermarks: YQL: fix constraints)
 
     Y_UNIT_TEST(StablePickleOfComplexUnique) {
         const TStringBuf s = R"(

--- a/yql/essentials/core/yql_expr_constraint.cpp
+++ b/yql/essentials/core/yql_expr_constraint.cpp
@@ -3126,6 +3126,11 @@ private:
         std::transform(keys.begin(), keys.end(), columns.begin(), [](const TPartOfConstraintBase::TPathType& path) -> std::string_view {
             return path.front();
         });
+        if (const auto hoppingColumn = input->Child(TCoMultiHoppingCore::idx_HoppingColumn)->Content();
+            "_yql_time" != hoppingColumn) {
+            columns.push_back(hoppingColumn);
+        }
+
         if (!columns.empty()) {
             input->AddConstraint(ctx.MakeConstraint<TUniqueConstraintNode>(columns));
             input->AddConstraint(ctx.MakeConstraint<TDistinctConstraintNode>(columns));

--- a/yql/essentials/core/yql_opt_hopping.h
+++ b/yql/essentials/core/yql_opt_hopping.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <yql/essentials/core/expr_nodes/yql_expr_nodes.h>
+#include <yql/essentials/core/sql_types/hopping.h>
 #include <yql/essentials/ast/yql_expr.h>
 
 #include <util/datetime/base.h>
@@ -13,6 +14,8 @@ struct THoppingTraits {
     ui64 Hop;
     ui64 Interval;
     ui64 Delay;
+    TMaybe<NHoppingWindow::EPolicy> EarlyPolicy;
+    TMaybe<NHoppingWindow::EPolicy> LatePolicy;
 };
 
 struct TKeysDescription {

--- a/yql/essentials/minikql/comp_nodes/mkql_multihopping.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_multihopping.cpp
@@ -1,6 +1,7 @@
 #include "mkql_multihopping.h"
 #include "mkql_saveload.h"
 
+#include <yql/essentials/core/sql_types/hopping.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
 #include <yql/essentials/minikql/mkql_node_cast.h>
 #include <yql/essentials/minikql/mkql_stats_registry.h>
@@ -9,6 +10,8 @@
 #include <yql/essentials/minikql/watermark_tracker.h>
 
 #include <util/generic/scope.h>
+#include <util/generic/ymath.h>
+#include <util/generic/is_in.h>
 
 namespace NKikimr {
 namespace NMiniKQL {
@@ -21,9 +24,11 @@ const TStatKey Hop_InvalidEventsCount("MultiHop_InvalidEventsCount", true);
 const TStatKey Hop_LateThrownEventsCount("MultiHop_LateThrownEventsCount", true);
 const TStatKey Hop_EmptyTimeCount("MultiHop_EmptyTimeCount", true);
 const TStatKey Hop_KeysCount("MultiHop_KeysCount", true);
+const TStatKey Hop_FarFutureStateSize("MultiHop_FarFutureStateSize", false);
 
 constexpr ui32 StateVersion = 1;
 constexpr ui32 StateVersionWithFutureEvents = 2;
+using EPolicy = NYql::NHoppingWindow::EPolicy;
 
 using TEqualsFunc = std::function<bool(NUdf::TUnboxedValuePod, NUdf::TUnboxedValuePod)>;
 using THashFunc = std::function<NYql::NUdf::THashType(NUdf::TUnboxedValuePod)>;
@@ -47,6 +52,10 @@ public:
             ui64 delayHopCount,
             bool dataWatermarks,
             bool watermarkMode,
+            ui64 farFutureSizeLimit,
+            ui64 farFutureTimeLimit,
+            EPolicy earlyPolicy,
+            EPolicy latePolicy,
             TComputationContext& ctx,
             const THashFunc& hash,
             const TEqualsFunc& equal,
@@ -59,6 +68,10 @@ public:
             , DelayHopCount(delayHopCount)
             , Watermark(watermark)
             , WatermarkMode(watermarkMode)
+            , FarFutureSizeLimit(farFutureSizeLimit)
+            , FarFutureTimeLimit(Max(farFutureTimeLimit, intervalHopCount + delayHopCount))
+            , EarlyPolicy(earlyPolicy)
+            , LatePolicy(latePolicy)
             , StatesMap(0, hash, equal)
             , Ctx(ctx)
         {
@@ -226,11 +239,13 @@ public:
                             THROW yexception() << "Invalid state: duplicated time " << time;
                         }
                     }
+                    MKQL_ADD_STAT(Ctx.Stats, Hop_FarFutureStateSize, (i64)keyState.FutureEvents.size());
                 }
                 StatesMap.emplace(key, std::move(keyState));
 
                 key.Ref();
             }
+            MKQL_SET_STAT(Ctx.Stats, Hop_KeysCount, StatesMap.size());
 
             in(Finished);
         }
@@ -254,6 +269,7 @@ public:
             i64 lateEventsThrown = 0;
             i64 newHopsStat = 0;
             i64 emptyTimeCtStat = 0;
+            i64 farFutureStateSizeChange = 0;
 
             Y_DEFER {
                 MKQL_ADD_STAT(Ctx.Stats, Hop_FutureEventsCount, farFutureEventsCount);
@@ -261,6 +277,7 @@ public:
                 MKQL_ADD_STAT(Ctx.Stats, Hop_LateThrownEventsCount, lateEventsThrown);
                 MKQL_ADD_STAT(Ctx.Stats, Hop_NewHopsCount, newHopsStat);
                 MKQL_ADD_STAT(Ctx.Stats, Hop_EmptyTimeCount, emptyTimeCtStat);
+                MKQL_ADD_STAT(Ctx.Stats, Hop_FarFutureStateSize, farFutureStateSizeChange);
             };
 
             for (NUdf::TUnboxedValue item;;) {
@@ -282,13 +299,13 @@ public:
                 const auto status = Stream.Fetch(item);
                 if (status != NUdf::EFetchStatus::Ok) {
                     if (status == NUdf::EFetchStatus::Finish) {
-                        CloseOldBuckets(Max<ui64>(), newHopsStat);
+                        CloseOldBuckets(Max<ui64>(), newHopsStat, farFutureStateSizeChange);
                         Finished = true;
                         continue;
                     } else if (status == NUdf::EFetchStatus::Yield) {
                         if (WatermarkMode) {
                             if (auto watermark = GetWatermark()) {
-                                CloseOldBuckets(watermark->MicroSeconds(), newHopsStat);
+                                CloseOldBuckets(watermark->MicroSeconds(), newHopsStat, farFutureStateSizeChange);
                                 PendingYield = true;
                                 continue;
                             }
@@ -307,36 +324,95 @@ public:
                 }
 
                 const auto ts = time.Get<ui64>();
-                const auto hopIndex = ts / HopTime;
+                auto hopIndex = ts / HopTime;
 
                 const auto initialBufferPosition = WatermarkMode ? GetWatermark().GetOrElse(TInstant::Zero()).MicroSeconds() / HopTime : hopIndex;
                 auto& keyState = GetOrCreateKeyState(key, initialBufferPosition);
                 if (hopIndex < keyState.HopIndex) {
                     ++lateEventsThrown;
-                    continue;
+                    switch (LatePolicy) {
+                        case EPolicy::Close:
+                            Y_DEBUG_ABORT();
+                            [[fallthrough]];
+                        case EPolicy::Drop:
+                            continue;
+                        case EPolicy::Adjust:
+                            hopIndex = keyState.HopIndex;
+                            break;
+                    }
                 }
                 if (Y_UNLIKELY(hopIndex == Max<ui64>())) { // reject invalid timestamp
                     ++invalidEventsThrown;
-                    continue;
+                    switch (EarlyPolicy) {
+                        case EPolicy::Close:
+                            [[fallthrough]];
+                        case EPolicy::Drop:
+                            continue;
+                        case EPolicy::Adjust:
+                            hopIndex = Max<ui64>() - 1;
+                            break;
+                    }
                 }
                 if (WatermarkMode && (hopIndex - keyState.HopIndex >= keyState.Buckets.size())) {
-                    ++farFutureEventsCount;
-                    auto [it, inserted] = keyState.FutureEvents.try_emplace(hopIndex);
-                    auto& [_, value] = *it;
-                    if (inserted) {
-                        value = Self->OutInit->GetValue(Ctx);
-                    } else {
-                        Self->Key->SetValue(Ctx, std::move(key));
-                        Self->State->SetValue(Ctx, std::move(value));
-                        value = Self->OutUpdate->GetValue(Ctx);
+                    if (Y_UNLIKELY(hopIndex - keyState.HopIndex >= FarFutureTimeLimit) && keyState.HopIndex) {
+                        switch (EarlyPolicy) {
+                            case EPolicy::Drop:
+                                continue;
+                            case EPolicy::Adjust:
+                                hopIndex = keyState.HopIndex + FarFutureTimeLimit - 1;
+                                break;
+                            case EPolicy::Close: {
+                                auto closeBeforeIndex = Max<i64>(hopIndex + 1 - FarFutureTimeLimit, 0);
+                                CloseOldBucketsForKey(key, keyState, closeBeforeIndex, newHopsStat, farFutureStateSizeChange);
+                                break;
+                            }
+                        }
                     }
-                    continue;
+                    if (Y_LIKELY(hopIndex - keyState.HopIndex >= keyState.Buckets.size())) {
+                        ++farFutureEventsCount;
+                        auto it = keyState.FutureEvents.find(hopIndex);
+                        if (it == keyState.FutureEvents.end()) {
+                            keyState.FutureEvents.emplace(hopIndex, Self->OutInit->GetValue(Ctx));
+                            ++farFutureStateSizeChange;
+
+                            if (keyState.FutureEvents.size() > FarFutureSizeLimit) {
+                                switch (EarlyPolicy) {
+                                    case EPolicy::Close: {
+                                        // move window so that first hop of FutureEvents became last hop of circular buffer
+                                        auto first = keyState.FutureEvents.begin();
+                                        auto closeBeforeIndex = first->first + 1 - keyState.Buckets.size();
+                                        CloseOldBucketsForKey(key, keyState, closeBeforeIndex, newHopsStat, farFutureStateSizeChange);
+                                        break;
+                                    }
+                                    case EPolicy::Adjust:
+                                        Y_DEBUG_ABORT();
+                                        [[fallthrough]];
+                                    case EPolicy::Drop: {
+                                        // drop last hop in FutureEvents
+                                        auto last = keyState.FutureEvents.end();
+                                        Y_DEBUG_ABORT_UNLESS(last != keyState.FutureEvents.begin());
+                                        --last;
+                                        keyState.FutureEvents.erase(last);
+                                        --farFutureStateSizeChange;
+                                        break;
+                                    }
+                                }
+                                Y_DEBUG_ABORT_UNLESS(keyState.FutureEvents.size() == FarFutureSizeLimit);
+                            }
+                        } else {
+                            auto& value = it->second;
+                            Self->Key->SetValue(Ctx, std::move(key));
+                            Self->State->SetValue(Ctx, std::move(value));
+                            value = Self->OutUpdate->GetValue(Ctx);
+                        }
+                        continue;
+                    }
                 }
 
                 // Overflow is not possible, because hopIndex is a product of a division
                 if (!WatermarkMode) {
                     auto closeBeforeIndex = Max<i64>(hopIndex + 1 - DelayHopCount - IntervalHopCount, 0);
-                    CloseOldBucketsForKey(key, keyState, closeBeforeIndex, newHopsStat);
+                    CloseOldBucketsForKey(key, keyState, closeBeforeIndex, newHopsStat, farFutureStateSizeChange);
                 }
 
                 auto& bucket = keyState.Buckets[hopIndex % keyState.Buckets.size()];
@@ -352,7 +428,7 @@ public:
 
                 if (DataWatermarkTracker) {
                     if (const auto newWatermark = DataWatermarkTracker->HandleNextEventTime(ts)) {
-                        CloseOldBuckets(*newWatermark, newHopsStat);
+                        CloseOldBuckets(*newWatermark, newHopsStat, farFutureStateSizeChange);
                     }
                 }
                 MKQL_SET_STAT(Ctx.Stats, Hop_KeysCount, StatesMap.size());
@@ -402,7 +478,8 @@ public:
             const NUdf::TUnboxedValue& key,
             TKeyState& keyState,
             const ui64 closeBeforeIndex, // Excluded bound
-            i64& newHopsStat)
+            i64& newHopsStat,
+            i64& farFutureStateSizeChange)
         {
             auto& bucketsForKey = keyState.Buckets;
             auto curHopIndex = keyState.HopIndex;
@@ -488,6 +565,7 @@ public:
                 newHopsStat += FinishAggregation(key, curHopIndex, aggregated);
                 if (futureIt->first == curHopIndex) {
                     futureIt = keyState.FutureEvents.erase(futureIt);
+                    --farFutureStateSizeChange;
                     if (futureIt == keyState.FutureEvents.end()) {
                         break;
                     }
@@ -502,18 +580,19 @@ public:
                 keyState.NextHopIndex = futureIt->first + 1;
                 bucket.Value = std::move(futureIt->second);
                 bucket.HasValue = true;
+                --farFutureStateSizeChange;
             }
 
             keyState.HopIndex = closeBeforeIndex;
             return keyState.NextHopIndex <= keyState.HopIndex && keyState.FutureEvents.empty();
         }
 
-        void CloseOldBuckets(ui64 watermarkTs, i64& newHops) {
+        void CloseOldBuckets(ui64 watermarkTs, i64& newHops, i64& farFutureStateSizeChange) {
             const auto watermarkIndex = watermarkTs / HopTime;
             EraseNodesIf(StatesMap, [&](auto& iter) {
                 auto& [key, val] = iter;
                 ui64 closeBeforeIndex = Max<i64>(watermarkIndex + 1 - IntervalHopCount, 0);
-                const auto keyStateBecameEmpty = CloseOldBucketsForKey(key, val, closeBeforeIndex, newHops);
+                const auto keyStateBecameEmpty = CloseOldBucketsForKey(key, val, closeBeforeIndex, newHops, farFutureStateSizeChange);
                 if (keyStateBecameEmpty) {
                     key.UnRef();
                 }
@@ -524,6 +603,7 @@ public:
 
         void ClearState() {
             EraseNodesIf(StatesMap, [&](auto& iter) {
+                MKQL_ADD_STAT(Ctx.Stats, Hop_FarFutureStateSize, -(i64)iter.second.FutureEvents.size());
                 iter.first.UnRef();
                 return true;
             });
@@ -538,6 +618,10 @@ public:
         const ui64 DelayHopCount;
         TWatermark& Watermark;
         bool WatermarkMode;
+        ui64 FarFutureSizeLimit;
+        ui64 FarFutureTimeLimit;
+        EPolicy EarlyPolicy;
+        EPolicy LatePolicy;
         bool PendingYield = false;
 
         using TStatesMap = std::unordered_map<
@@ -576,6 +660,10 @@ public:
         IComputationNode* delay,
         IComputationNode* dataWatermarks,
         IComputationNode* watermarkMode,
+        IComputationNode* farFutureSizeLimit,
+        IComputationNode* farFutureTimeLimitUs,
+        IComputationNode* earlyPolicy,
+        IComputationNode* latePolicy,
         TType* keyType,
         TType* stateType,
         TWatermark& watermark)
@@ -601,6 +689,10 @@ public:
         , Delay(delay)
         , DataWatermarks(dataWatermarks)
         , WatermarkMode(watermarkMode)
+        , FarFutureSizeLimit(farFutureSizeLimit)
+        , FarFutureTimeLimitUs(farFutureTimeLimitUs)
+        , EarlyPolicy(earlyPolicy)
+        , LatePolicy(latePolicy)
         , KeyType(keyType)
         , StateType(stateType)
         , KeyPacker(mutables)
@@ -624,6 +716,19 @@ public:
         const auto delay = Delay->GetValue(ctx).Get<ui64>();
         const auto dataWatermarks = DataWatermarks->GetValue(ctx).Get<bool>();
         const auto watermarkMode = WatermarkMode->GetValue(ctx).Get<bool>();
+#define INIT_OPTIONAL_ARGUMENT(var, Type, Member, Default) \
+    const auto var = (Member ? Member->GetValue(ctx) : NUdf::TUnboxedValue()).GetOrDefault<Type>(static_cast<Type>(NYql::NHoppingWindow::TSettings{}.Default))
+        INIT_OPTIONAL_ARGUMENT(farFutureSizeLimit, ui64, FarFutureSizeLimit, FarFutureSizeLimit);
+        INIT_OPTIONAL_ARGUMENT(farFutureTimeLimitUs, ui64, FarFutureTimeLimitUs, FarFutureTimeLimit.MicroSeconds());
+        INIT_OPTIONAL_ARGUMENT(earlyPolicy, ui32, EarlyPolicy, EarlyPolicy);
+        MKQL_ENSURE(IsIn({static_cast<ui32>(EPolicy::Drop), static_cast<ui32>(EPolicy::Adjust), static_cast<ui32>(EPolicy::Close)}, earlyPolicy),
+                    "Unexpected earlyPolicy " << earlyPolicy);
+        INIT_OPTIONAL_ARGUMENT(latePolicy, ui32, LatePolicy, LatePolicy);
+        MKQL_ENSURE(IsIn({static_cast<ui32>(EPolicy::Drop), static_cast<ui32>(EPolicy::Adjust)}, latePolicy),
+                    "Unexpected latePolicy " << latePolicy);
+        MKQL_ENSURE(!(earlyPolicy == static_cast<ui32>(EPolicy::Adjust) && farFutureSizeLimit != Max<ui64>()),
+                    "Combination of EarlyPolicy=adjust with SizeLimit is not implemented, please set HoppingWindow SizeLimit to 'max' or use different EarlyPolicy");
+#undef INIT_OPTIONAL_ARGUMENT
         const auto intervalHopCount = interval / hopTime;
         const auto delayHopCount = delay / hopTime;
 
@@ -635,6 +740,10 @@ public:
             delayHopCount,
             dataWatermarks,
             watermarkMode,
+            farFutureSizeLimit,
+            CeilDiv(farFutureTimeLimitUs, hopTime),
+            static_cast<EPolicy>(earlyPolicy),
+            static_cast<EPolicy>(latePolicy),
             ctx,
             TValueHasher(KeyTypes, IsTuple, Hash.Get()),
             TValueEqual(KeyTypes, IsTuple, Equate.Get()),
@@ -683,6 +792,10 @@ private:
         DependsOn(Delay);
         DependsOn(DataWatermarks);
         DependsOn(WatermarkMode);
+        DependsOn(FarFutureSizeLimit);
+        DependsOn(FarFutureTimeLimitUs);
+        DependsOn(EarlyPolicy);
+        DependsOn(LatePolicy);
     }
 
     IComputationNode* const Stream;
@@ -709,6 +822,10 @@ private:
     IComputationNode* const Delay;
     IComputationNode* const DataWatermarks;
     IComputationNode* const WatermarkMode;
+    IComputationNode* const FarFutureSizeLimit;
+    IComputationNode* const FarFutureTimeLimitUs;
+    IComputationNode* const EarlyPolicy;
+    IComputationNode* const LatePolicy;
 
     TType* const KeyType;
     TType* const StateType;
@@ -727,7 +844,7 @@ private:
 } // namespace
 
 IComputationNode* WrapMultiHoppingCore(TCallable& callable, const TComputationNodeFactoryContext& ctx, TWatermark& watermark) {
-    MKQL_ENSURE(callable.GetInputsCount() == 21, "Expected 21 args");
+    MKQL_ENSURE(callable.GetInputsCount() > 20, "Expected at least 21 args");
 
     auto hasSaveLoad = !callable.GetInput(12).GetStaticType()->IsVoid();
 
@@ -772,10 +889,17 @@ IComputationNode* WrapMultiHoppingCore(TCallable& callable, const TComputationNo
 
     auto stateType = hasSaveLoad ? callable.GetInput(12).GetStaticType() : nullptr;
 
+    IComputationNode* farFutureSizeLimit = (callable.GetInputsCount() > 21) ? LocateNode(ctx.NodeLocator, callable, 21) : nullptr;
+    IComputationNode* farFutureTimeLimitUs = (callable.GetInputsCount() > 22) ? LocateNode(ctx.NodeLocator, callable, 22) : nullptr;
+    IComputationNode* earlyPolicy = (callable.GetInputsCount() > 23) ? LocateNode(ctx.NodeLocator, callable, 23) : nullptr;
+    IComputationNode* latePolicy = (callable.GetInputsCount() > 24) ? LocateNode(ctx.NodeLocator, callable, 24) : nullptr;
+
     return new TMultiHoppingCoreWrapper(ctx.Mutables,
                                         stream, item, key, state, state2, time, inSave, inLoad, keyExtract,
                                         outTime, outInit, outUpdate, outSave, outLoad, outMerge, outFinish,
-                                        hop, interval, delay, dataWatermarks, watermarkMode, keyType, stateType, watermark);
+                                        hop, interval, delay, dataWatermarks, watermarkMode,
+                                        farFutureSizeLimit, farFutureTimeLimitUs, earlyPolicy, latePolicy,
+                                        keyType, stateType, watermark);
 }
 
 } // namespace NMiniKQL

--- a/yql/essentials/minikql/comp_nodes/mkql_multihopping.h
+++ b/yql/essentials/minikql/comp_nodes/mkql_multihopping.h
@@ -8,5 +8,5 @@ namespace NMiniKQL {
 
 IComputationNode* WrapMultiHoppingCore(TCallable& callable, const TComputationNodeFactoryContext& ctx, TWatermark& watermark);
 
-}
-}
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
@@ -16,247 +16,255 @@ namespace NKikimr {
 namespace NMiniKQL {
 
 namespace {
-    TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
-        return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
-            if (callable.GetType()->GetName() == "OneYieldStream") {
-                return new TExternalComputationNode(ctx.Mutables);
-            } else if (callable.GetType()->GetName() == "MultiHoppingCore") {
-                return WrapMultiHoppingCore(callable, ctx, watermark);
-            }
-
-            return GetBuiltinFactory()(callable, ctx);
-        };
-    }
-    struct TStreamWithYield : public NUdf::TBoxedValue {
-        TStreamWithYield(const TUnboxedValueVector& items, ui32 yieldPos, ui32 index)
-            : Items(items)
-            , YieldPos(yieldPos)
-            , Index(index)
-        {}
-
-    private:
-        TUnboxedValueVector Items;
-        ui32 YieldPos;
-        ui32 Index;
-
-        ui32 GetTraverseCount() const override {
-            return 0;
+TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
+    return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
+        if (callable.GetType()->GetName() == "OneYieldStream") {
+            return new TExternalComputationNode(ctx.Mutables);
+        } else if (callable.GetType()->GetName() == "MultiHoppingCore") {
+            return WrapMultiHoppingCore(callable, ctx, watermark);
         }
 
-        NUdf::TUnboxedValue Save() const override {
-            return NUdf::TUnboxedValue::Zero();
-        }
-
-        bool Load2(const NUdf::TUnboxedValue& state) override {
-            Y_UNUSED(state);
-            return false;
-        }
-
-        NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) final {
-            if (Index >= Items.size()) {
-                return NUdf::EFetchStatus::Finish;
-            }
-            if (Index == YieldPos) {
-                return NUdf::EFetchStatus::Yield;
-            }
-            result = Items[Index++];
-            return NUdf::EFetchStatus::Ok;
-        }
+        return GetBuiltinFactory()(callable, ctx);
     };
-
-    THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<std::tuple<ui32, i64, ui32>> items,
-                                          ui32 yieldPos, ui32 startIndex, bool dataWatermarks) {
-        TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-
-        auto structType = pgmBuilder.NewEmptyStructType();
-        structType = pgmBuilder.NewStructType(structType, "key",
-            pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
-        structType = pgmBuilder.NewStructType(structType, "time",
-            pgmBuilder.NewDataType(NUdf::TDataType<NUdf::TTimestamp>::Id));
-        structType = pgmBuilder.NewStructType(structType, "sum",
-            pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
-        auto keyIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("key");
-        auto timeIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("time");
-        auto sumIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("sum");
-
-        auto inStreamType = pgmBuilder.NewStreamType(structType);
-
-        TCallableBuilder inStream(pgmBuilder.GetTypeEnvironment(), "OneYieldStream", inStreamType);
-        auto streamNode = inStream.Build();
-
-        ui64 hop = 10, interval = 30, delay = 20;
-
-        auto pgmReturn = pgmBuilder.MultiHoppingCore(
-            TRuntimeNode(streamNode, false),
-            [&](TRuntimeNode item) { // keyExtractor
-                return pgmBuilder.Member(item, "key");
-            },
-            [&](TRuntimeNode item) { // timeExtractor
-                return pgmBuilder.Member(item, "time");
-            },
-            [&](TRuntimeNode item) { // init
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", pgmBuilder.Member(item, "sum"));
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode item, TRuntimeNode state) { // update
-                auto add = pgmBuilder.AggrAdd(
-                    pgmBuilder.Member(item, "sum"),
-                    pgmBuilder.Member(state, "sum"));
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", add);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode state) { // save
-                return pgmBuilder.Member(state, "sum");
-            },
-            [&](TRuntimeNode savedState) { // load
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", savedState);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode state1, TRuntimeNode state2) { // merge
-                auto add = pgmBuilder.AggrAdd(
-                    pgmBuilder.Member(state1, "sum"),
-                    pgmBuilder.Member(state2, "sum"));
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", add);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
-                Y_UNUSED(time);
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("key", key);
-                members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
-                return pgmBuilder.NewStruct(members);
-            },
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))), // hop
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),  // delay
-            pgmBuilder.NewDataLiteral<bool>(dataWatermarks),  // dataWatermarks
-            pgmBuilder.NewDataLiteral<bool>(false)
-        );
-
-        auto graph = setup.BuildGraph(pgmReturn, {streamNode});
-
-        TUnboxedValueVector streamItems;
-        for (size_t i = 0; i < items.size(); ++i) {
-            NUdf::TUnboxedValue* itemsPtr;
-            auto structValues = graph->GetHolderFactory().CreateDirectArrayHolder(3, itemsPtr);
-            itemsPtr[keyIndex] = NUdf::TUnboxedValuePod(std::get<0>(items[i]));
-            itemsPtr[timeIndex] = NUdf::TUnboxedValuePod(std::get<1>(items[i]));
-            itemsPtr[sumIndex] = NUdf::TUnboxedValuePod(std::get<2>(items[i]));
-            streamItems.push_back(std::move(structValues));
-        }
-
-        auto streamValue = NUdf::TUnboxedValuePod(new TStreamWithYield(streamItems, yieldPos, startIndex));
-        graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
-        return graph;
-    }
 }
+struct TStreamWithYield: public NUdf::TBoxedValue {
+    TStreamWithYield(const TUnboxedValueVector& items, ui32 yieldPos, ui32 index)
+        : Items(items)
+        , YieldPos(yieldPos)
+        , Index(index)
+    {
+    }
+
+private:
+    TUnboxedValueVector Items;
+    ui32 YieldPos;
+    ui32 Index;
+
+    ui32 GetTraverseCount() const override {
+        return 0;
+    }
+
+    NUdf::TUnboxedValue Save() const override {
+        return NUdf::TUnboxedValue::Zero();
+    }
+
+    bool Load2(const NUdf::TUnboxedValue& state) override {
+        Y_UNUSED(state);
+        return false;
+    }
+
+    NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) final {
+        if (Index >= Items.size()) {
+            return NUdf::EFetchStatus::Finish;
+        }
+        if (Index == YieldPos) {
+            return NUdf::EFetchStatus::Yield;
+        }
+        result = Items[Index++];
+        return NUdf::EFetchStatus::Ok;
+    }
+};
+
+THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<std::tuple<ui32, i64, ui32>> items,
+                                      ui32 yieldPos, ui32 startIndex, bool dataWatermarks) {
+    TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
+
+    auto structType = pgmBuilder.NewEmptyStructType();
+    structType = pgmBuilder.NewStructType(structType, "key",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
+    structType = pgmBuilder.NewStructType(structType, "time",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<NUdf::TTimestamp>::Id));
+    structType = pgmBuilder.NewStructType(structType, "sum",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
+    auto keyIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("key");
+    auto timeIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("time");
+    auto sumIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("sum");
+
+    auto inStreamType = pgmBuilder.NewStreamType(structType);
+
+    TCallableBuilder inStream(pgmBuilder.GetTypeEnvironment(), "OneYieldStream", inStreamType);
+    auto streamNode = inStream.Build();
+
+    ui64 hop = 10, interval = 30, delay = 20;
+
+    auto pgmReturn = pgmBuilder.MultiHoppingCore(
+        TRuntimeNode(streamNode, false),
+        [&](TRuntimeNode item) { // keyExtractor
+            return pgmBuilder.Member(item, "key");
+        },
+        [&](TRuntimeNode item) { // timeExtractor
+            return pgmBuilder.Member(item, "time");
+        },
+        [&](TRuntimeNode item) { // init
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", pgmBuilder.Member(item, "sum"));
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode item, TRuntimeNode state) { // update
+            auto add = pgmBuilder.AggrAdd(
+                pgmBuilder.Member(item, "sum"),
+                pgmBuilder.Member(state, "sum"));
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", add);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode state) { // save
+            return pgmBuilder.Member(state, "sum");
+        },
+        [&](TRuntimeNode savedState) { // load
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", savedState);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode state1, TRuntimeNode state2) { // merge
+            auto add = pgmBuilder.AggrAdd(
+                pgmBuilder.Member(state1, "sum"),
+                pgmBuilder.Member(state2, "sum"));
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", add);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
+            Y_UNUSED(time);
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("key", key);
+            members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
+            return pgmBuilder.NewStruct(members);
+        },
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))),           // hop
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),       // delay
+        pgmBuilder.NewDataLiteral<bool>(dataWatermarks),                                                                  // dataWatermarks
+        pgmBuilder.NewDataLiteral<bool>(false));
+
+    auto graph = setup.BuildGraph(pgmReturn, {streamNode});
+
+    TUnboxedValueVector streamItems;
+    for (size_t i = 0; i < items.size(); ++i) {
+        NUdf::TUnboxedValue* itemsPtr;
+        auto structValues = graph->GetHolderFactory().CreateDirectArrayHolder(3, itemsPtr);
+        itemsPtr[keyIndex] = NUdf::TUnboxedValuePod(std::get<0>(items[i]));
+        itemsPtr[timeIndex] = NUdf::TUnboxedValuePod(std::get<1>(items[i]));
+        itemsPtr[sumIndex] = NUdf::TUnboxedValuePod(std::get<2>(items[i]));
+        streamItems.push_back(std::move(structValues));
+    }
+
+    auto streamValue = NUdf::TUnboxedValuePod(new TStreamWithYield(streamItems, yieldPos, startIndex));
+    graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
+    return graph;
+}
+} // namespace
 
 Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingSaveLoadTest) {
-    void TestWithSaveLoadImpl(
-        const std::vector<std::tuple<ui32, i64, ui32>> input,
-        const std::vector<std::tuple<ui32, ui32>> expected,
-        bool withTraverse,
-        bool dataWatermarks)
-    {
-        TWatermark watermark;
-        for (ui32 yieldPos = 0; yieldPos < input.size(); ++yieldPos) {
-            std::vector<std::tuple<ui32, ui32>> result;
+void TestWithSaveLoadImpl(
+    const std::vector<std::tuple<ui32, i64, ui32>> input,
+    const std::vector<std::tuple<ui32, ui32>> expected,
+    bool withTraverse,
+    bool dataWatermarks)
+{
+    TWatermark watermark;
+    for (ui32 yieldPos = 0; yieldPos < input.size(); ++yieldPos) {
+        std::vector<std::tuple<ui32, ui32>> result;
 
-            TSetup<false> setup1(GetAuxCallableFactory(watermark));
-            auto graph1 = BuildGraph(setup1, input, yieldPos, 0, dataWatermarks);
-            auto root1 = graph1->GetValue();
+        TSetup<false> setup1(GetAuxCallableFactory(watermark));
+        auto graph1 = BuildGraph(setup1, input, yieldPos, 0, dataWatermarks);
+        auto root1 = graph1->GetValue();
 
-            NUdf::EFetchStatus status = NUdf::EFetchStatus::Ok;
-            while (status == NUdf::EFetchStatus::Ok) {
-                NUdf::TUnboxedValue val;
-                status = root1.Fetch(val);
-                if (status == NUdf::EFetchStatus::Ok) {
-                    result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
-                }
+        NUdf::EFetchStatus status = NUdf::EFetchStatus::Ok;
+        while (status == NUdf::EFetchStatus::Ok) {
+            NUdf::TUnboxedValue val;
+            status = root1.Fetch(val);
+            if (status == NUdf::EFetchStatus::Ok) {
+                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
             }
-            UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Yield);
-
-            TString graphState;
-            if (withTraverse) {
-                SaveGraphState(&root1, 1, 0ULL, graphState);
-            } else {
-                graphState = graph1->SaveGraphState();
-            }
-
-            TSetup<false> setup2(GetAuxCallableFactory(watermark));
-            auto graph2 = BuildGraph(setup2, input, -1, yieldPos, dataWatermarks);
-            NUdf::TUnboxedValue root2;
-            if (withTraverse) {
-                root2 = graph2->GetValue();
-                LoadGraphState(&root2, 1, 0ULL, graphState);
-            } else {
-                graph2->LoadGraphState(graphState);
-                root2 = graph2->GetValue();
-            }
-
-            status = NUdf::EFetchStatus::Ok;
-            while (status == NUdf::EFetchStatus::Ok) {
-                NUdf::TUnboxedValue val;
-                status = root2.Fetch(val);
-                if (status == NUdf::EFetchStatus::Ok) {
-                    result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
-                }
-            }
-            UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Finish);
-
-            auto sortedExpected = expected;
-            std::sort(result.begin(), result.end());
-            std::sort(sortedExpected.begin(), sortedExpected.end());
-            UNIT_ASSERT_EQUAL(result, sortedExpected);
         }
-    }
+        UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Yield);
 
-    const std::vector<std::tuple<ui32, i64, ui32>> input1 = {
-        // Group; Time; Value
-        {2, 1, 2},
-        {1, 1, 2},
-        {2, 2, 3},
-        {1, 2, 3},
-        {2, 15, 4},
-        {1, 15, 4},
-        {2, 23, 6},
-        {1, 23, 6},
-        {2, 24, 5},
-        {1, 24, 5},
-        {2, 25, 7},
-        {1, 25, 7},
-        {2, 40, 2},
-        {1, 40, 2},
-        {2, 47, 1},
-        {1, 47, 1},
-        {2, 51, 6},
-        {1, 51, 6},
-        {2, 59, 2},
-        {1, 59, 2},
-        {2, 85, 8},
-        {1, 85, 8}
-    };
+        TString graphState;
+        if (withTraverse) {
+            SaveGraphState(&root1, 1, 0ULL, graphState);
+        } else {
+            graphState = graph1->SaveGraphState();
+        }
 
-    const std::vector<std::tuple<ui32, ui32>> expected = {
-        {1, 8}, {1, 8}, {1, 8}, {1, 8},
-        {1, 11}, {1, 11}, {1, 21}, {1, 22},
-        {1, 27},
-        {2, 8}, {2, 8}, {2, 8}, {2, 8},
-        {2, 11}, {2, 11}, {2, 21},
-        {2, 22}, {2, 27}};
+        TSetup<false> setup2(GetAuxCallableFactory(watermark));
+        auto graph2 = BuildGraph(setup2, input, -1, yieldPos, dataWatermarks);
+        NUdf::TUnboxedValue root2;
+        if (withTraverse) {
+            root2 = graph2->GetValue();
+            LoadGraphState(&root2, 1, 0ULL, graphState);
+        } else {
+            graph2->LoadGraphState(graphState);
+            root2 = graph2->GetValue();
+        }
 
-    Y_UNIT_TEST(Test1) {
-        TestWithSaveLoadImpl(input1, expected, true, false);
-    }
+        status = NUdf::EFetchStatus::Ok;
+        while (status == NUdf::EFetchStatus::Ok) {
+            NUdf::TUnboxedValue val;
+            status = root2.Fetch(val);
+            if (status == NUdf::EFetchStatus::Ok) {
+                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
+            }
+        }
+        UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Finish);
 
-    Y_UNIT_TEST(Test2) {
-        TestWithSaveLoadImpl(input1, expected, false, false);
+        auto sortedExpected = expected;
+        std::sort(result.begin(), result.end());
+        std::sort(sortedExpected.begin(), sortedExpected.end());
+        UNIT_ASSERT_EQUAL(result, sortedExpected);
     }
 }
+
+const std::vector<std::tuple<ui32, i64, ui32>> input1 = {
+    // Group; Time; Value
+    {2, 1, 2},
+    {1, 1, 2},
+    {2, 2, 3},
+    {1, 2, 3},
+    {2, 15, 4},
+    {1, 15, 4},
+    {2, 23, 6},
+    {1, 23, 6},
+    {2, 24, 5},
+    {1, 24, 5},
+    {2, 25, 7},
+    {1, 25, 7},
+    {2, 40, 2},
+    {1, 40, 2},
+    {2, 47, 1},
+    {1, 47, 1},
+    {2, 51, 6},
+    {1, 51, 6},
+    {2, 59, 2},
+    {1, 59, 2},
+    {2, 85, 8},
+    {1, 85, 8}};
+
+const std::vector<std::tuple<ui32, ui32>> expected = {
+    {1, 8}, {1, 8}, {1, 8}, {1, 8},
+    {1, 11},
+    {1, 11},
+    {1, 21},
+    {1, 22},
+    {1, 27},
+    {2, 8},
+    {2, 8},
+    {2, 8},
+    {2, 8},
+    {2, 11},
+    {2, 11},
+    {2, 21},
+    {2, 22},
+    {2, 27}};
+
+Y_UNIT_TEST(Test1) {
+    TestWithSaveLoadImpl(input1, expected, true, false);
+}
+
+Y_UNIT_TEST(Test2) {
+    TestWithSaveLoadImpl(input1, expected, false, false);
+}
+} // Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingSaveLoadTest)
 
 } // namespace NMiniKQL
 } // namespace NKikimr

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
@@ -150,8 +150,13 @@ THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<st
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))),           // hop
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),       // delay
-        pgmBuilder.NewDataLiteral<bool>(dataWatermarks),                                                                  // dataWatermarks
-        pgmBuilder.NewDataLiteral<bool>(withWatermarks));
+        pgmBuilder.NewDataLiteral<bool>(dataWatermarks),
+        pgmBuilder.NewDataLiteral<bool>(withWatermarks),
+        {}, // SizeLimit
+        {}, // TimeLimit
+        {}, // EarlyPolicy
+        {}  // LatePolicy
+    );
 
     auto graph = setup.BuildGraph(pgmReturn, {streamNode});
 

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_saveload_ut.cpp
@@ -16,6 +16,7 @@ namespace NKikimr {
 namespace NMiniKQL {
 
 namespace {
+using TWatermarksPattern = std::vector<std::tuple<ui32, TInstant>>;
 TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
     return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
         if (callable.GetType()->GetName() == "OneYieldStream") {
@@ -28,10 +29,13 @@ TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
     };
 }
 struct TStreamWithYield: public NUdf::TBoxedValue {
-    TStreamWithYield(const TUnboxedValueVector& items, ui32 yieldPos, ui32 index)
+    TStreamWithYield(const TUnboxedValueVector& items, ui32 yieldPos, ui32 index, TWatermark& watermark, const TWatermarksPattern& watermarksPattern)
         : Items(items)
         , YieldPos(yieldPos)
         , Index(index)
+        , Watermark(watermark)
+        , WatermarksPattern(watermarksPattern)
+        , WatermarkIndex(0)
     {
     }
 
@@ -39,6 +43,9 @@ private:
     TUnboxedValueVector Items;
     ui32 YieldPos;
     ui32 Index;
+    TWatermark& Watermark;
+    TWatermarksPattern WatermarksPattern;
+    ui32 WatermarkIndex;
 
     ui32 GetTraverseCount() const override {
         return 0;
@@ -60,13 +67,22 @@ private:
         if (Index == YieldPos) {
             return NUdf::EFetchStatus::Yield;
         }
+        if (WatermarkIndex < WatermarksPattern.size()) {
+            auto [patternIndex, patternValue] = WatermarksPattern[WatermarkIndex];
+            if (Index >= patternIndex) {
+                Watermark.WatermarkIn = patternValue;
+                return NUdf::EFetchStatus::Yield;
+            }
+        }
         result = Items[Index++];
         return NUdf::EFetchStatus::Ok;
     }
 };
 
 THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<std::tuple<ui32, i64, ui32>> items,
-                                      ui32 yieldPos, ui32 startIndex, bool dataWatermarks) {
+                                      ui32 yieldPos, ui32 startIndex, bool dataWatermarks,
+                                      bool withWatermarks, TWatermark& watermark,
+                                      const TWatermarksPattern& watermarksPattern) {
     TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
 
     auto structType = pgmBuilder.NewEmptyStructType();
@@ -125,17 +141,17 @@ THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<st
             return pgmBuilder.NewStruct(members);
         },
         [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
-            Y_UNUSED(time);
             std::vector<std::pair<std::string_view, TRuntimeNode>> members;
             members.emplace_back("key", key);
             members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
+            members.emplace_back("time", time);
             return pgmBuilder.NewStruct(members);
         },
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))),           // hop
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),       // delay
         pgmBuilder.NewDataLiteral<bool>(dataWatermarks),                                                                  // dataWatermarks
-        pgmBuilder.NewDataLiteral<bool>(false));
+        pgmBuilder.NewDataLiteral<bool>(withWatermarks));
 
     auto graph = setup.BuildGraph(pgmReturn, {streamNode});
 
@@ -149,7 +165,7 @@ THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<st
         streamItems.push_back(std::move(structValues));
     }
 
-    auto streamValue = NUdf::TUnboxedValuePod(new TStreamWithYield(streamItems, yieldPos, startIndex));
+    auto streamValue = NUdf::TUnboxedValuePod(new TStreamWithYield(streamItems, yieldPos, startIndex, watermark, watermarksPattern));
     graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
     return graph;
 }
@@ -158,16 +174,19 @@ THolder<IComputationGraph> BuildGraph(TSetup<false>& setup, const std::vector<st
 Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingSaveLoadTest) {
 void TestWithSaveLoadImpl(
     const std::vector<std::tuple<ui32, i64, ui32>> input,
-    const std::vector<std::tuple<ui32, ui32>> expected,
+    const std::vector<std::tuple<ui32, ui32, ui64>> expected,
     bool withTraverse,
-    bool dataWatermarks)
+    bool dataWatermarks,
+    bool withWatermarks = false,
+    const TWatermarksPattern& watermarksPattern = {})
 {
     TWatermark watermark;
+    UNIT_ASSERT(!dataWatermarks || !withWatermarks);
     for (ui32 yieldPos = 0; yieldPos < input.size(); ++yieldPos) {
-        std::vector<std::tuple<ui32, ui32>> result;
+        std::vector<std::tuple<ui32, ui32, ui64>> result;
 
         TSetup<false> setup1(GetAuxCallableFactory(watermark));
-        auto graph1 = BuildGraph(setup1, input, yieldPos, 0, dataWatermarks);
+        auto graph1 = BuildGraph(setup1, input, yieldPos, 0, dataWatermarks, withWatermarks, watermark, watermarksPattern);
         auto root1 = graph1->GetValue();
 
         NUdf::EFetchStatus status = NUdf::EFetchStatus::Ok;
@@ -175,7 +194,7 @@ void TestWithSaveLoadImpl(
             NUdf::TUnboxedValue val;
             status = root1.Fetch(val);
             if (status == NUdf::EFetchStatus::Ok) {
-                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
+                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>(), val.GetElement(2).Get<ui64>());
             }
         }
         UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Yield);
@@ -188,7 +207,7 @@ void TestWithSaveLoadImpl(
         }
 
         TSetup<false> setup2(GetAuxCallableFactory(watermark));
-        auto graph2 = BuildGraph(setup2, input, -1, yieldPos, dataWatermarks);
+        auto graph2 = BuildGraph(setup2, input, -1, yieldPos, dataWatermarks, withWatermarks, watermark, watermarksPattern);
         NUdf::TUnboxedValue root2;
         if (withTraverse) {
             root2 = graph2->GetValue();
@@ -203,15 +222,16 @@ void TestWithSaveLoadImpl(
             NUdf::TUnboxedValue val;
             status = root2.Fetch(val);
             if (status == NUdf::EFetchStatus::Ok) {
-                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>());
+                result.emplace_back(val.GetElement(0).Get<ui32>(), val.GetElement(1).Get<ui32>(), val.GetElement(2).Get<ui64>());
             }
         }
         UNIT_ASSERT_EQUAL(status, NUdf::EFetchStatus::Finish);
 
+        auto copy = result;
         auto sortedExpected = expected;
         std::sort(result.begin(), result.end());
         std::sort(sortedExpected.begin(), sortedExpected.end());
-        UNIT_ASSERT_EQUAL(result, sortedExpected);
+        UNIT_ASSERT_EQUAL_C(result, sortedExpected, " withTraverse = " << withTraverse << " dataWatermarks = " << dataWatermarks << " withWatermarks = " << withWatermarks << " yieldPos = " << yieldPos);
     }
 }
 
@@ -240,22 +260,26 @@ const std::vector<std::tuple<ui32, i64, ui32>> input1 = {
     {2, 85, 8},
     {1, 85, 8}};
 
-const std::vector<std::tuple<ui32, ui32>> expected = {
-    {1, 8}, {1, 8}, {1, 8}, {1, 8},
-    {1, 11},
-    {1, 11},
-    {1, 21},
-    {1, 22},
-    {1, 27},
-    {2, 8},
-    {2, 8},
-    {2, 8},
-    {2, 8},
-    {2, 11},
-    {2, 11},
-    {2, 21},
-    {2, 22},
-    {2, 27}};
+const std::vector<std::tuple<ui32, ui32, ui64>> expected = {
+    {1, 8, 80},
+    {1, 8, 90},
+    {1, 8, 100},
+    {1, 8, 110},
+    {1, 11, 60},
+    {1, 11, 70},
+    {1, 21, 50},
+    {1, 22, 40},
+    {1, 27, 30},
+    {2, 8, 80},
+    {2, 8, 90},
+    {2, 8, 100},
+    {2, 8, 110},
+    {2, 11, 60},
+    {2, 11, 70},
+    {2, 21, 50},
+    {2, 22, 40},
+    {2, 27, 30},
+};
 
 Y_UNIT_TEST(Test1) {
     TestWithSaveLoadImpl(input1, expected, true, false);
@@ -263,6 +287,13 @@ Y_UNIT_TEST(Test1) {
 
 Y_UNIT_TEST(Test2) {
     TestWithSaveLoadImpl(input1, expected, false, false);
+}
+Y_UNIT_TEST(TestWatermark1) {
+    TestWithSaveLoadImpl(input1, expected, true, false, true);
+}
+
+Y_UNIT_TEST(TestWatermark2) {
+    TestWithSaveLoadImpl(input1, expected, false, false, true);
 }
 } // Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingSaveLoadTest)
 

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_ut.cpp
@@ -15,48 +15,277 @@
 namespace NKikimr::NMiniKQL {
 
 namespace {
-    struct TInputItem {
-        ui32 Key = 0;
-        i64 Time = 0;
-        ui32 Val = 0;
+struct TInputItem {
+    ui32 Key = 0;
+    i64 Time = 0;
+    ui32 Val = 0;
+};
+
+struct TOutputItem {
+    ui32 Key = 0;
+    ui32 Val = 0;
+    ui64 Time = 0;
+
+    constexpr auto operator<=>(const TOutputItem&) const = default;
+};
+
+[[maybe_unused]] IOutputStream& operator<<(IOutputStream& output, const TOutputItem& item) {
+    return output << "TItem{Key = " << item.Key << ", Val = " << item.Val << ", Time = " << item.Time << "}";
+}
+
+using TOutputGroup = std::vector<TOutputItem>;
+
+using TCheckCallback = std::function<void()>;
+
+using TStatsMap = TMap<TString, i64>;
+
+TStatsMap DefaultStatsMap = {
+    {"MultiHop_NewHopsCount", 0},
+    {"MultiHop_EarlyThrownEventsCount", 0},
+    {"MultiHop_LateThrownEventsCount", 0},
+    {"MultiHop_EmptyTimeCount", 0},
+    {"MultiHop_KeysCount", 1},
+};
+
+using TEncoder = std::function<NUdf::TUnboxedValue(const TInputItem&, const THolderFactory&)>;
+using TDecoder = std::function<TOutputItem(const NUdf::TUnboxedValue&)>;
+using TFetchCallback = std::function<NUdf::EFetchStatus(NUdf::TUnboxedValue&)>;
+using TFetchFactory = std::function<TFetchCallback(TUnboxedValueVector&&)>;
+
+TFetchFactory DefaultFetchFactory = [](TUnboxedValueVector&& input) -> TFetchCallback {
+    return [input = std::move(input),
+            inputIndex = 0ull](NUdf::TUnboxedValue& result) mutable -> NUdf::EFetchStatus {
+        if (inputIndex >= input.size()) {
+            return NUdf::EFetchStatus::Finish;
+        }
+        result = input[inputIndex++];
+        return NUdf::EFetchStatus::Ok;
     };
+};
 
-    struct TOutputItem {
-        ui32 Key = 0;
-        ui32 Val = 0;
-        ui64 Time = 0;
+TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
+    return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
+        if (callable.GetType()->GetName() == "MyStream") {
+            return new TExternalComputationNode(ctx.Mutables);
+        } else if (callable.GetType()->GetName() == "MultiHoppingCore") {
+            return WrapMultiHoppingCore(callable, ctx, watermark);
+        }
 
-        constexpr auto operator<=>(const TOutputItem&) const = default;
+        return GetBuiltinFactory()(callable, ctx);
     };
+}
 
-    [[maybe_unused]] IOutputStream& operator<<(IOutputStream& output, const TOutputItem& item) {
-        return output << "TItem{Key = " << item.Key << ", Val = " << item.Val << ", Time = " << item.Time << "}";
+using TSetupFactory = std::function<TSetup<false>()>;
+
+TWatermark GlobalWatermark;
+TSetupFactory DefaultSetupFactory = []() -> TSetup<false> {
+    return TSetup<false>(GetAuxCallableFactory(GlobalWatermark));
+};
+
+struct TStream: public NUdf::TBoxedValue {
+    TStream(TCheckCallback&& checkCallback, TFetchCallback&& fetchCallback)
+        : CheckCallback_(std::move(checkCallback))
+        , FetchCallback_(std::move(fetchCallback))
+    {
     }
 
-    using TOutputGroup = std::vector<TOutputItem>;
+private:
+    TCheckCallback CheckCallback_;
+    TFetchCallback FetchCallback_;
 
-    using TCheckCallback = std::function<void()>;
+private:
+    NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) final {
+        CheckCallback_();
+        return FetchCallback_(result);
+    }
+};
 
-    using TStatsMap = TMap<TString, i64>;
+std::tuple<TType*, TEncoder, TDecoder> BuildInputType(TSetup<false>& setup) {
+    TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
 
-    TStatsMap DefaultStatsMap = {
-        {"MultiHop_NewHopsCount", 0},
-        {"MultiHop_EarlyThrownEventsCount", 0},
-        {"MultiHop_LateThrownEventsCount", 0},
-        {"MultiHop_EmptyTimeCount", 0},
-        {"MultiHop_KeysCount", 1},
+    auto structType = pgmBuilder.NewEmptyStructType();
+    structType = pgmBuilder.NewStructType(structType, "key",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
+    structType = pgmBuilder.NewStructType(structType, "time",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<NUdf::TTimestamp>::Id));
+    structType = pgmBuilder.NewStructType(structType, "sum",
+                                          pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
+    auto keyIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("key");
+    auto timeIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("time");
+    auto sumIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("sum");
+
+    auto encode = [keyIndex, timeIndex, sumIndex](const TInputItem& input, const THolderFactory& holderFactory) -> NUdf::TUnboxedValue {
+        NUdf::TUnboxedValue* itemsPtr;
+        auto structValues = holderFactory.CreateDirectArrayHolder(3, itemsPtr);
+        itemsPtr[keyIndex] = NUdf::TUnboxedValuePod(input.Key);
+        itemsPtr[timeIndex] = NUdf::TUnboxedValuePod(input.Time);
+        itemsPtr[sumIndex] = NUdf::TUnboxedValuePod(input.Val);
+        return structValues;
     };
 
-    using TEncoder = std::function<NUdf::TUnboxedValue(const TInputItem&, const THolderFactory&)>;
-    using TDecoder = std::function<TOutputItem(const NUdf::TUnboxedValue&)>;
-    using TFetchCallback = std::function<NUdf::EFetchStatus(NUdf::TUnboxedValue&)>;
-    using TFetchFactory = std::function<TFetchCallback(TUnboxedValueVector&&)>;
+    auto decode = [keyIndex, timeIndex, sumIndex](const NUdf::TUnboxedValue& result) -> TOutputItem {
+        return {
+            result.GetElement(keyIndex).Get<ui32>(),
+            result.GetElement(sumIndex).Get<ui32>(),
+            result.GetElement(timeIndex).Get<ui64>(),
+        };
+    };
 
-    TFetchFactory DefaultFetchFactory = [](TUnboxedValueVector&& input) -> TFetchCallback {
-        return [
-            input = std::move(input),
-            inputIndex = 0ull
-        ](NUdf::TUnboxedValue& result) mutable -> NUdf::EFetchStatus {
+    return {structType, encode, decode};
+}
+
+THolder<IComputationGraph> BuildGraph(
+    TSetup<false>& setup,
+    TType* itemType,
+    ui64 hop,
+    ui64 interval,
+    ui64 delay,
+    bool dataWatermarks,
+    bool watermarkMode) {
+    TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
+
+    auto inStreamType = pgmBuilder.NewStreamType(itemType);
+
+    TCallableBuilder inStream(pgmBuilder.GetTypeEnvironment(), "MyStream", inStreamType);
+    auto streamNode = inStream.Build();
+
+    auto pgmReturn = pgmBuilder.MultiHoppingCore(
+        TRuntimeNode(streamNode, false),
+        [&](TRuntimeNode item) { // keyExtractor
+            return pgmBuilder.Member(item, "key");
+        },
+        [&](TRuntimeNode item) { // timeExtractor
+            return pgmBuilder.Member(item, "time");
+        },
+        [&](TRuntimeNode item) { // init
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", pgmBuilder.Member(item, "sum"));
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode item, TRuntimeNode state) { // update
+            auto add = pgmBuilder.AggrAdd(
+                pgmBuilder.Member(item, "sum"),
+                pgmBuilder.Member(state, "sum"));
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", add);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode state) { // save
+            return pgmBuilder.Member(state, "sum");
+        },
+        [&](TRuntimeNode savedState) { // load
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", savedState);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode state1, TRuntimeNode state2) { // merge
+            auto add = pgmBuilder.AggrAdd(
+                pgmBuilder.Member(state1, "sum"),
+                pgmBuilder.Member(state2, "sum"));
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("sum", add);
+            return pgmBuilder.NewStruct(members);
+        },
+        [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
+            std::vector<std::pair<std::string_view, TRuntimeNode>> members;
+            members.emplace_back("key", key);
+            members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
+            members.emplace_back("time", time);
+            return pgmBuilder.NewStruct(members);
+        },
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))),           // hop
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),       // delay
+        pgmBuilder.NewDataLiteral<bool>(dataWatermarks),
+        pgmBuilder.NewDataLiteral<bool>(watermarkMode));
+
+    return setup.BuildGraph(pgmReturn, {streamNode});
+}
+} // namespace
+
+Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingTest) {
+void TestImpl(
+    const std::vector<TInputItem>& input,
+    const std::vector<TOutputGroup>& expected,
+    const TStatsMap& expectedStatsMap,
+    ui64 hop = 10,
+    ui64 interval = 30,
+    ui64 delay = 20,
+    bool dataWatermarks = false,
+    bool watermarkMode = false,
+    TFetchFactory fetchFactory = DefaultFetchFactory,
+    TSetupFactory setupFactory = DefaultSetupFactory) {
+    auto setup = setupFactory();
+
+    auto [itemType, encode, decode] = BuildInputType(setup);
+
+    auto graph = BuildGraph(setup, itemType, hop, interval, delay, dataWatermarks, watermarkMode);
+
+    size_t index = 0;
+    std::vector<TOutputItem> actual;
+    auto checkCallback = [&expected, &index, &actual]() -> void {
+        UNIT_ASSERT_LT_C(index, expected.size(), index << " < " << expected.size());
+        auto expectedItems = expected[index];
+        std::ranges::sort(expectedItems);
+        std::ranges::sort(actual);
+        UNIT_ASSERT_VALUES_EQUAL_C(expectedItems, actual, index);
+        ++index;
+        actual.clear();
+    };
+
+    TUnboxedValueVector boxedInput;
+    for (size_t i = 0; i < input.size(); ++i) {
+        boxedInput.push_back(encode(input[i], graph->GetHolderFactory()));
+    }
+    auto fetchCallback = fetchFactory(std::move(boxedInput));
+
+    auto streamValue = NUdf::TUnboxedValuePod(new TStream(checkCallback, std::move(fetchCallback)));
+    graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
+
+    auto root = graph->GetValue();
+
+    auto status = NUdf::EFetchStatus::Ok;
+    while (NUdf::EFetchStatus::Finish != status) {
+        NUdf::TUnboxedValue result;
+        status = root.Fetch(result);
+        if (status == NUdf::EFetchStatus::Ok) {
+            actual.push_back(decode(result));
+        }
+    }
+
+    checkCallback();
+    UNIT_ASSERT_VALUES_EQUAL(expected.size(), index);
+
+    TStatsMap actualStatsMap;
+    setup.StatsRegistry->ForEachStat([&expectedStatsMap, &actualStatsMap](const TStatKey& key, i64 value) {
+        if (auto iter = expectedStatsMap.find(key.GetName());
+            iter != expectedStatsMap.end()) {
+            actualStatsMap.emplace(key.GetName(), value);
+        }
+    });
+    UNIT_ASSERT_VALUES_EQUAL(expectedStatsMap, actualStatsMap);
+}
+
+void TestWatermarksImpl(
+    const std::vector<TInputItem>& input,
+    const std::vector<TOutputGroup>& expected,
+    const std::vector<std::pair<ui64, TInstant>>& watermarks,
+    const TStatsMap& expectedStatsMap,
+    ui64 hop = 10,
+    ui64 interval = 30,
+    ui64 delay = 20) {
+    TWatermark watermark;
+    auto fetchFactory = [watermarks = watermarks, &watermark](TUnboxedValueVector input) -> TFetchCallback {
+        return [input = input,
+                inputIndex = 0ull,
+                watermarks = watermarks,
+                watermarkIndex = 0ull,
+                &watermark](NUdf::TUnboxedValue& result) mutable -> NUdf::EFetchStatus {
+            if (watermarkIndex < watermarks.size() && watermarks[watermarkIndex].first == inputIndex) {
+                watermark.WatermarkIn = watermarks[watermarkIndex].second;
+                ++watermarkIndex;
+                return NUdf::EFetchStatus::Yield;
+            }
             if (inputIndex >= input.size()) {
                 return NUdf::EFetchStatus::Finish;
             }
@@ -64,716 +293,503 @@ namespace {
             return NUdf::EFetchStatus::Ok;
         };
     };
-
-    TComputationNodeFactory GetAuxCallableFactory(TWatermark& watermark) {
-        return [&watermark](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
-            if (callable.GetType()->GetName() == "MyStream") {
-                return new TExternalComputationNode(ctx.Mutables);
-            } else if (callable.GetType()->GetName() == "MultiHoppingCore") {
-                return WrapMultiHoppingCore(callable, ctx, watermark);
-            }
-
-            return GetBuiltinFactory()(callable, ctx);
-        };
-    }
-
-    using TSetupFactory = std::function<TSetup<false>()>;
-
-    TWatermark GlobalWatermark;
-    TSetupFactory DefaultSetupFactory = []() -> TSetup<false> {
-        return TSetup<false>(GetAuxCallableFactory(GlobalWatermark));
+    auto setupFactory = [&watermark]() -> TSetup<false> {
+        return TSetup<false>(GetAuxCallableFactory(watermark));
     };
-
-    struct TStream : public NUdf::TBoxedValue {
-        TStream(TCheckCallback&& checkCallback, TFetchCallback&& fetchCallback)
-            : CheckCallback_(std::move(checkCallback))
-            , FetchCallback_(std::move(fetchCallback))
-        {}
-
-    private:
-        TCheckCallback CheckCallback_;
-        TFetchCallback FetchCallback_;
-
-    private:
-        NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) final {
-            CheckCallback_();
-            return FetchCallback_(result);
-        }
-    };
-
-    std::tuple<TType*, TEncoder, TDecoder> BuildInputType(TSetup<false>& setup) {
-        TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-
-        auto structType = pgmBuilder.NewEmptyStructType();
-        structType = pgmBuilder.NewStructType(structType, "key",
-            pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
-        structType = pgmBuilder.NewStructType(structType, "time",
-            pgmBuilder.NewDataType(NUdf::TDataType<NUdf::TTimestamp>::Id));
-        structType = pgmBuilder.NewStructType(structType, "sum",
-            pgmBuilder.NewDataType(NUdf::TDataType<ui32>::Id));
-        auto keyIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("key");
-        auto timeIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("time");
-        auto sumIndex = AS_TYPE(TStructType, structType)->GetMemberIndex("sum");
-
-        auto encode = [keyIndex, timeIndex, sumIndex](const TInputItem& input, const THolderFactory& holderFactory) -> NUdf::TUnboxedValue {
-            NUdf::TUnboxedValue* itemsPtr;
-            auto structValues = holderFactory.CreateDirectArrayHolder(3, itemsPtr);
-            itemsPtr[keyIndex] = NUdf::TUnboxedValuePod(input.Key);
-            itemsPtr[timeIndex] = NUdf::TUnboxedValuePod(input.Time);
-            itemsPtr[sumIndex] = NUdf::TUnboxedValuePod(input.Val);
-            return structValues;
-        };
-
-        auto decode = [keyIndex, timeIndex, sumIndex](const NUdf::TUnboxedValue& result) -> TOutputItem {
-            return {
-                result.GetElement(keyIndex).Get<ui32>(),
-                result.GetElement(sumIndex).Get<ui32>(),
-                result.GetElement(timeIndex).Get<ui64>(),
-            };
-        };
-
-        return {structType, encode, decode};
-    }
-
-    THolder<IComputationGraph> BuildGraph(
-        TSetup<false>& setup,
-        TType* itemType,
-        ui64 hop,
-        ui64 interval,
-        ui64 delay,
-        bool dataWatermarks,
-        bool watermarkMode
-    ) {
-        TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-
-        auto inStreamType = pgmBuilder.NewStreamType(itemType);
-
-        TCallableBuilder inStream(pgmBuilder.GetTypeEnvironment(), "MyStream", inStreamType);
-        auto streamNode = inStream.Build();
-
-        auto pgmReturn = pgmBuilder.MultiHoppingCore(
-            TRuntimeNode(streamNode, false),
-            [&](TRuntimeNode item) { // keyExtractor
-                return pgmBuilder.Member(item, "key");
-            },
-            [&](TRuntimeNode item) { // timeExtractor
-                return pgmBuilder.Member(item, "time");
-            },
-            [&](TRuntimeNode item) { // init
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", pgmBuilder.Member(item, "sum"));
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode item, TRuntimeNode state) { // update
-                auto add = pgmBuilder.AggrAdd(
-                    pgmBuilder.Member(item, "sum"),
-                    pgmBuilder.Member(state, "sum"));
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", add);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode state) { // save
-                return pgmBuilder.Member(state, "sum");
-            },
-            [&](TRuntimeNode savedState) { // load
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", savedState);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode state1, TRuntimeNode state2) { // merge
-                auto add = pgmBuilder.AggrAdd(
-                    pgmBuilder.Member(state1, "sum"),
-                    pgmBuilder.Member(state2, "sum"));
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("sum", add);
-                return pgmBuilder.NewStruct(members);
-            },
-            [&](TRuntimeNode key, TRuntimeNode state, TRuntimeNode time) { // finish
-                std::vector<std::pair<std::string_view, TRuntimeNode>> members;
-                members.emplace_back("key", key);
-                members.emplace_back("sum", pgmBuilder.Member(state, "sum"));
-                members.emplace_back("time", time);
-                return pgmBuilder.NewStruct(members);
-            },
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&hop, sizeof(hop))), // hop
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
-            pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),  // delay
-            pgmBuilder.NewDataLiteral<bool>(dataWatermarks),
-            pgmBuilder.NewDataLiteral<bool>(watermarkMode)
-        );
-
-        return setup.BuildGraph(pgmReturn, {streamNode});
-    }
+    TestImpl(
+        input,
+        expected,
+        expectedStatsMap,
+        hop,
+        interval,
+        delay,
+        false,
+        true,
+        fetchFactory,
+        setupFactory);
 }
 
-Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingTest) {
-    void TestImpl(
-        const std::vector<TInputItem>& input,
-        const std::vector<TOutputGroup>& expected,
-        const TStatsMap& expectedStatsMap,
-        ui64 hop = 10,
-        ui64 interval = 30,
-        ui64 delay = 20,
-        bool dataWatermarks = false,
-        bool watermarkMode = false,
-        TFetchFactory fetchFactory = DefaultFetchFactory,
-        TSetupFactory setupFactory = DefaultSetupFactory
-    ) {
-        auto setup = setupFactory();
+Y_UNIT_TEST(TestThrowWatermarkFromPast) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 2, 110},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 2, 120},
+            {1, 2, 130},
+            {1, 3, 140},
+            {1, 3, 150},
+            {1, 3, 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 4, 210},
+            {1, 4, 220},
+            {1, 4, 230},
+        }),
+        TOutputGroup({
+            {1, 5, 310},
+            {1, 5, 320},
+            {1, 5, 330},
+        }),
+        TOutputGroup({
+            {1, 6, 410},
+            {1, 6, 420},
+            {1, 6, 430},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {2, TInstant::MicroSeconds(20)},
+        {3, TInstant::MicroSeconds(40)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 15;
 
-        auto [itemType, encode, decode] = BuildInputType(setup);
-
-        auto graph = BuildGraph(setup, itemType, hop, interval, delay, dataWatermarks, watermarkMode);
-
-        size_t index = 0;
-        std::vector<TOutputItem> actual;
-        auto checkCallback = [&expected, &index, &actual]() -> void {
-            UNIT_ASSERT_LT_C(index, expected.size(), index << " < " << expected.size());
-            auto expectedItems = expected[index];
-            std::ranges::sort(expectedItems);
-            std::ranges::sort(actual);
-            UNIT_ASSERT_VALUES_EQUAL_C(expectedItems, actual, index);
-            ++index;
-            actual.clear();
-        };
-
-        TUnboxedValueVector boxedInput;
-        for (size_t i = 0; i < input.size(); ++i) {
-            boxedInput.push_back(encode(input[i], graph->GetHolderFactory()));
-        }
-        auto fetchCallback = fetchFactory(std::move(boxedInput));
-
-        auto streamValue = NUdf::TUnboxedValuePod(new TStream(checkCallback, std::move(fetchCallback)));
-        graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(streamValue));
-
-        auto root = graph->GetValue();
-
-        auto status = NUdf::EFetchStatus::Ok;
-        while (NUdf::EFetchStatus::Finish != status) {
-            NUdf::TUnboxedValue result;
-            status = root.Fetch(result);
-            if (status == NUdf::EFetchStatus::Ok) {
-                actual.push_back(decode(result));
-            }
-        }
-
-        checkCallback();
-        UNIT_ASSERT_VALUES_EQUAL(expected.size(), index);
-
-        TStatsMap actualStatsMap;
-        setup.StatsRegistry->ForEachStat([&expectedStatsMap, &actualStatsMap](const TStatKey& key, i64 value) {
-            if (auto iter = expectedStatsMap.find(key.GetName());
-                iter != expectedStatsMap.end()) {
-                actualStatsMap.emplace(key.GetName(), value);
-            }
-        });
-        UNIT_ASSERT_VALUES_EQUAL(expectedStatsMap, actualStatsMap);
-    }
-
-    void TestWatermarksImpl(
-        const std::vector<TInputItem>& input,
-        const std::vector<TOutputGroup>& expected,
-        const std::vector<std::pair<ui64, TInstant>>& watermarks,
-        const TStatsMap& expectedStatsMap,
-        ui64 hop = 10,
-        ui64 interval = 30,
-        ui64 delay = 20
-    ) {
-        TWatermark watermark;
-        auto fetchFactory = [watermarks = watermarks, &watermark](TUnboxedValueVector input) -> TFetchCallback {
-            return [
-                input = input,
-                inputIndex = 0ull,
-                watermarks = watermarks,
-                watermarkIndex = 0ull,
-                &watermark
-            ](NUdf::TUnboxedValue& result) mutable -> NUdf::EFetchStatus {
-                if (watermarkIndex < watermarks.size() && watermarks[watermarkIndex].first == inputIndex) {
-                    watermark.WatermarkIn = watermarks[watermarkIndex].second;
-                    ++watermarkIndex;
-                    return NUdf::EFetchStatus::Yield;
-                }
-                if (inputIndex >= input.size()) {
-                    return NUdf::EFetchStatus::Finish;
-                }
-                result = input[inputIndex++];
-                return NUdf::EFetchStatus::Ok;
-            };
-        };
-        auto setupFactory = [&watermark]() -> TSetup<false> {
-            return TSetup<false>(GetAuxCallableFactory(watermark));
-        };
-        TestImpl(
-            input,
-            expected,
-            expectedStatsMap,
-            hop,
-            interval,
-            delay,
-            false,
-            true,
-            fetchFactory,
-            setupFactory
-        );
-    }
-
-    Y_UNIT_TEST(TestThrowWatermarkFromPast) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {1, 131, 3},
-            {1, 200, 4},
-            {1, 300, 5},
-            {1, 400, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 2, 110},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 2, 120},
-                {1, 2, 130},
-                {1, 3, 140},
-                {1, 3, 150},
-                {1, 3, 160},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 4, 210},
-                {1, 4, 220},
-                {1, 4, 230},
-            }),
-            TOutputGroup({
-                {1, 5, 310},
-                {1, 5, 320},
-                {1, 5, 330},
-            }),
-            TOutputGroup({
-                {1, 6, 410},
-                {1, 6, 420},
-                {1, 6, 430},
-            })
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {2, TInstant::MicroSeconds(20)},
-            {3, TInstant::MicroSeconds(40)}
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 15;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestThrowWatermarkFromFuture) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {1, 131, 3},
-            {1, 200, 4},
-            {1, 300, 5},
-            {1, 400, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 2, 110},
-            }),
-            TOutputGroup({
-                {1, 2, 120},
-                {1, 2, 130},
-                {1, 3, 140},
-                {1, 3, 150},
-                {1, 3, 160},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({})
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {2, TInstant::MicroSeconds(1000)},
-            {3, TInstant::MicroSeconds(2000)}
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 6;
-        expectedStatsMap["MultiHop_LateThrownEventsCount"] = 3;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWatermarkFlow1) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {1, 131, 3},
-            {1, 200, 4},
-            {1, 300, 5},
-            {1, 400, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 2, 110},
-            }),
-            TOutputGroup({
-                {1, 2, 120},
-                {1, 2, 130},
-                {1, 3, 140},
-                {1, 3, 150},
-                {1, 3, 160},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 4, 210},
-                {1, 4, 220},
-                {1, 4, 230},
-            }),
-            TOutputGroup({
-                {1, 5, 310},
-                {1, 5, 320},
-                {1, 5, 330},
-            }),
-            TOutputGroup({
-                {1, 6, 410},
-                {1, 6, 420},
-                {1, 6, 430},
-            })
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {0, TInstant::MicroSeconds(100)},
-            {3, TInstant::MicroSeconds(200)}
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 15;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWatermarkFlow2) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 100, 2},
-            {1, 105, 3},
-            {1, 80, 4},
-            {1, 107, 5},
-            {1, 106, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 4, 90},
-                {1, 4, 100},
-                {1, 20, 110},
-                {1, 16, 120},
-                {1, 16, 130},
-            })
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {0, TInstant::MicroSeconds(76)},
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 5;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWatermarkFlow3) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 90, 2},
-            {1, 99, 3},
-            {1, 80, 4},
-            {1, 107, 5},
-            {1, 106, 6}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 4, 90},
-                {1, 9, 100},
-                {1, 20, 110},
-                {1, 16, 120},
-                {1, 11, 130},
-            })
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {0, TInstant::MicroSeconds(76)},
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 5;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWatermarkFlowOverflow) {
-        // TODO this tests fails before this change, but it does not exercise
-        // exact expected bug scenario (hop stuck forever in the future)
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 1, 2},
-            {1, 2, 3},
-            {1, 5, 4},
-            {1, 6, 5},
-            {1, 7, 6},
-            {1, 8, 7},
-            {1, 9, 8},
-            {1, 10, 9},
-            {1, 11, 10},
-            {1, 22, 11},
-            {1, 23, 12},
-            {1, 24, 13},
-            {1, 100, 14},
-            {1, 117, 15},
-            {1, 121, 16},
-            {1, 126, 17},
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 90, 100},
-            }),
-            TOutputGroup({
-                {1, 69, 110},
-            }),
-            TOutputGroup({}),
-            TOutputGroup({
-                {1, 65, 120},
-            }),
-            TOutputGroup({
-                {1, 62, 130},
-                {1, 62, 140},
-                {1, 62, 150},
-                {1, 62, 160},
-                {1, 62, 170},
-                {1, 62, 180},
-                {1, 62, 190},
-                {1, 62, 200},
-                {1, 48, 210},
-                {1, 33, 220},
-            }),
-        };
-        const std::vector<std::pair<ui64, TInstant>> watermarks = {
-            {9, TInstant::MicroSeconds(1)},
-            {12, TInstant::MicroSeconds(2)},
-            {14, TInstant::MicroSeconds(50)},
-            {15, TInstant::MicroSeconds(110)},
-            {16, TInstant::MicroSeconds(120)},
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 13;
-
-        TestWatermarksImpl(input, expected, watermarks, expectedStatsMap, 10, 100, 20);
-    }
-
-    Y_UNIT_TEST(TestDataWatermarks) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {2, 101, 2},
-            {1, 111, 3},
-            {2, 140, 5},
-            {2, 160, 1}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 2, 110}, {1, 5, 120}, {2, 2, 110}, {2, 2, 120}}),
-            TOutputGroup({{2, 2, 130}, {1, 5, 130}, {1, 3, 140}}),
-            TOutputGroup({{2, 5, 150}, {2, 5, 160}, {2, 6, 170}, {2, 1, 180}, {2, 1, 190}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 12;
-
-        TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true);
-    }
-
-    Y_UNIT_TEST(TestDataWatermarksNoGarbage) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 100, 2},
-            {2, 150, 1}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 2, 110}, {1, 2, 120}, {1, 2, 130}}),
-            TOutputGroup({{2, 1, 160}, {2, 1, 170}, {2, 1, 180}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 6;
-
-        TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true, false);
-    }
-
-    Y_UNIT_TEST(TestValidness1) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2},
-            {2, 101, 2},
-            {1, 111, 3},
-            {2, 140, 5},
-            {2, 160, 1}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{2, 2, 110}, {2, 2, 120}}),
-            TOutputGroup({{2, 2, 130}}),
-            TOutputGroup({{1, 2, 110}, {1, 5, 120}, {1, 5, 130}, {1, 3, 140}, {2, 5, 150},
-                          {2, 5, 160}, {2, 6, 170}, {2, 1, 190}, {2, 1, 180}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 12;
-        expectedStatsMap["MultiHop_KeysCount"] = 2;
-
-        TestImpl(input, expected, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestValidness2) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {2, 101, 2}, {1, 101, 2}, {2, 102, 3}, {1, 102, 3}, {2, 115, 4},
-            {1, 115, 4}, {2, 123, 6}, {1, 123, 6}, {2, 124, 5}, {1, 124, 5},
-            {2, 125, 7}, {1, 125, 7}, {2, 140, 2}, {1, 140, 2}, {2, 147, 1},
-            {1, 147, 1}, {2, 151, 6}, {1, 151, 6}, {2, 159, 2}, {1, 159, 2},
-            {2, 185, 8}, {1, 185, 8}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{1, 5, 110}, {1, 9, 120}, {2, 5, 110}, {2, 9, 120}}),
-            TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{2, 27, 130}, {1, 27, 130}}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{2, 22, 140}, {2, 21, 150},  {2, 11, 160}, {1, 22, 140}, {1, 21, 150}, {1, 11, 160}}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 11, 170}, {1, 8, 180}, {1, 8, 190}, {1, 8, 200}, {1, 8, 210}, {2, 11, 170},
-                          {2, 8, 180}, {2, 8, 190}, {2, 8, 200}, {2, 8, 210}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 22;
-        expectedStatsMap["MultiHop_KeysCount"] = 2;
-
-        TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true);
-    }
-
-    Y_UNIT_TEST(TestValidness3) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 105, 1}, {1, 107, 4}, {2, 106, 3}, {1, 111, 7}, {1, 117, 3},
-            {2, 110, 2}, {1, 108, 9}, {1, 121, 4}, {2, 107, 2}, {2, 141, 5},
-            {1, 141, 10}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{1, 14, 110}, {2, 3, 110}}),
-            TOutputGroup({}),
-            TOutputGroup({{2, 7, 115}, {2, 2, 120}, {1, 21, 115}, {1, 10, 120}, {1, 7, 125}, {1, 4, 130}}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 10, 145}, {1, 10, 150}, {2, 5, 145}, {2, 5, 150}})
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 12;
-        expectedStatsMap["MultiHop_KeysCount"] = 2;
-
-        TestImpl(input, expected, expectedStatsMap, 5, 10, 10, true);
-    }
-
-    Y_UNIT_TEST(TestDelay) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 3}, {1, 111, 5}, {1, 120, 7}, {1, 80, 9}, {1, 79, 11}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({}), TOutputGroup({}),
-            TOutputGroup({{1, 12, 110}, {1, 8, 120}, {1, 15, 130}, {1, 12, 140}, {1, 7, 150}})
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 5;
-        expectedStatsMap["MultiHop_LateThrownEventsCount"] = 1;
-
-        TestImpl(input, expected, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestWindowsBeforeFirstElement) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 101, 2}, {1, 111, 3}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 2, 110}, {1, 5, 120}, {1, 5, 130}, {1, 3, 140}})
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 4;
-
-        TestImpl(input, expected, expectedStatsMap);
-    }
-
-    Y_UNIT_TEST(TestSubzeroValues) {
-        const std::vector<TInputItem> input = {
-            // Group; Time; Value
-            {1, 1, 2}
-        };
-        const std::vector<TOutputGroup> expected = {
-            TOutputGroup({}),
-            TOutputGroup({}),
-            TOutputGroup({{1, 2, 30}}),
-        };
-        auto expectedStatsMap = DefaultStatsMap;
-        expectedStatsMap["MultiHop_NewHopsCount"] = 1;
-
-        TestImpl(input, expected, expectedStatsMap);
-    }
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
 }
+
+Y_UNIT_TEST(TestThrowWatermarkFromFuture) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 2, 110},
+        }),
+        TOutputGroup({
+            {1, 2, 120},
+            {1, 2, 130},
+            {1, 3, 140},
+            {1, 3, 150},
+            {1, 3, 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({})};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {2, TInstant::MicroSeconds(1000)},
+        {3, TInstant::MicroSeconds(2000)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 6;
+    expectedStatsMap["MultiHop_LateThrownEventsCount"] = 3;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWatermarkFlow1) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 2, 110},
+        }),
+        TOutputGroup({
+            {1, 2, 120},
+            {1, 2, 130},
+            {1, 3, 140},
+            {1, 3, 150},
+            {1, 3, 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 4, 210},
+            {1, 4, 220},
+            {1, 4, 230},
+        }),
+        TOutputGroup({
+            {1, 5, 310},
+            {1, 5, 320},
+            {1, 5, 330},
+        }),
+        TOutputGroup({
+            {1, 6, 410},
+            {1, 6, 420},
+            {1, 6, 430},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 15;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWatermarkFlow2) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 100, 2},
+        {1, 105, 3},
+        {1, 80, 4},
+        {1, 107, 5},
+        {1, 106, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 4, 90},
+            {1, 4, 100},
+            {1, 20, 110},
+            {1, 16, 120},
+            {1, 16, 130},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(76)},
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 5;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWatermarkFlow3) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 90, 2},
+        {1, 99, 3},
+        {1, 80, 4},
+        {1, 107, 5},
+        {1, 106, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 4, 90},
+            {1, 9, 100},
+            {1, 20, 110},
+            {1, 16, 120},
+            {1, 11, 130},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(76)},
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 5;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWatermarkFlowOverflow) {
+    // TODO this tests fails before this change, but it does not exercise
+    // exact expected bug scenario (hop stuck forever in the future)
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 1, 2},
+        {1, 2, 3},
+        {1, 5, 4},
+        {1, 6, 5},
+        {1, 7, 6},
+        {1, 8, 7},
+        {1, 9, 8},
+        {1, 10, 9},
+        {1, 11, 10},
+        {1, 22, 11},
+        {1, 23, 12},
+        {1, 24, 13},
+        {1, 100, 14},
+        {1, 117, 15},
+        {1, 121, 16},
+        {1, 126, 17},
+    };
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 90, 100},
+        }),
+        TOutputGroup({
+            {1, 69, 110},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, 65, 120},
+        }),
+        TOutputGroup({
+            {1, 62, 130},
+            {1, 62, 140},
+            {1, 62, 150},
+            {1, 62, 160},
+            {1, 62, 170},
+            {1, 62, 180},
+            {1, 62, 190},
+            {1, 62, 200},
+            {1, 48, 210},
+            {1, 33, 220},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {9, TInstant::MicroSeconds(1)},
+        {12, TInstant::MicroSeconds(2)},
+        {14, TInstant::MicroSeconds(50)},
+        {15, TInstant::MicroSeconds(110)},
+        {16, TInstant::MicroSeconds(120)},
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 13;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap, 10, 100, 20);
+}
+
+Y_UNIT_TEST(TestDataWatermarks) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {2, 101, 2},
+        {1, 111, 3},
+        {2, 140, 5},
+        {2, 160, 1}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 2, 110}, {1, 5, 120}, {2, 2, 110}, {2, 2, 120}}),
+        TOutputGroup({{2, 2, 130}, {1, 5, 130}, {1, 3, 140}}),
+        TOutputGroup({{2, 5, 150}, {2, 5, 160}, {2, 6, 170}, {2, 1, 180}, {2, 1, 190}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 12;
+
+    TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true);
+}
+
+Y_UNIT_TEST(TestDataWatermarksNoGarbage) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 100, 2},
+        {2, 150, 1}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 2, 110}, {1, 2, 120}, {1, 2, 130}}),
+        TOutputGroup({{2, 1, 160}, {2, 1, 170}, {2, 1, 180}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 6;
+
+    TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true, false);
+}
+
+Y_UNIT_TEST(TestValidness1) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {2, 101, 2},
+        {1, 111, 3},
+        {2, 140, 5},
+        {2, 160, 1}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{2, 2, 110}, {2, 2, 120}}),
+        TOutputGroup({{2, 2, 130}}),
+        TOutputGroup({{1, 2, 110}, {1, 5, 120}, {1, 5, 130}, {1, 3, 140}, {2, 5, 150},
+                      {2, 5, 160},
+                      {2, 6, 170},
+                      {2, 1, 190},
+                      {2, 1, 180}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 12;
+    expectedStatsMap["MultiHop_KeysCount"] = 2;
+
+    TestImpl(input, expected, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestValidness2) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {2, 101, 2},
+        {1, 101, 2},
+        {2, 102, 3},
+        {1, 102, 3},
+        {2, 115, 4},
+        {1, 115, 4},
+        {2, 123, 6},
+        {1, 123, 6},
+        {2, 124, 5},
+        {1, 124, 5},
+        {2, 125, 7},
+        {1, 125, 7},
+        {2, 140, 2},
+        {1, 140, 2},
+        {2, 147, 1},
+        {1, 147, 1},
+        {2, 151, 6},
+        {1, 151, 6},
+        {2, 159, 2},
+        {1, 159, 2},
+        {2, 185, 8},
+        {1, 185, 8}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 5, 110}, {1, 9, 120}, {2, 5, 110}, {2, 9, 120}}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{2, 27, 130}, {1, 27, 130}}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{2, 22, 140}, {2, 21, 150}, {2, 11, 160}, {1, 22, 140}, {1, 21, 150}, {1, 11, 160}}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 11, 170}, {1, 8, 180}, {1, 8, 190}, {1, 8, 200}, {1, 8, 210}, {2, 11, 170},
+                      {2, 8, 180},
+                      {2, 8, 190},
+                      {2, 8, 200},
+                      {2, 8, 210}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 22;
+    expectedStatsMap["MultiHop_KeysCount"] = 2;
+
+    TestImpl(input, expected, expectedStatsMap, 10, 30, 20, true);
+}
+
+Y_UNIT_TEST(TestValidness3) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 105, 1},
+        {1, 107, 4},
+        {2, 106, 3},
+        {1, 111, 7},
+        {1, 117, 3},
+        {2, 110, 2},
+        {1, 108, 9},
+        {1, 121, 4},
+        {2, 107, 2},
+        {2, 141, 5},
+        {1, 141, 10}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}), TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
+        TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
+        TOutputGroup({{1, 14, 110}, {2, 3, 110}}),
+        TOutputGroup({}),
+        TOutputGroup({{2, 7, 115}, {2, 2, 120}, {1, 21, 115}, {1, 10, 120}, {1, 7, 125}, {1, 4, 130}}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 10, 145}, {1, 10, 150}, {2, 5, 145}, {2, 5, 150}})};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 12;
+    expectedStatsMap["MultiHop_KeysCount"] = 2;
+
+    TestImpl(input, expected, expectedStatsMap, 5, 10, 10, true);
+}
+
+Y_UNIT_TEST(TestDelay) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 3},
+        {1, 111, 5},
+        {1, 120, 7},
+        {1, 80, 9},
+        {1, 79, 11}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}), TOutputGroup({}), TOutputGroup({}),
+        TOutputGroup({}), TOutputGroup({}),
+        TOutputGroup({{1, 12, 110}, {1, 8, 120}, {1, 15, 130}, {1, 12, 140}, {1, 7, 150}})};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 5;
+    expectedStatsMap["MultiHop_LateThrownEventsCount"] = 1;
+
+    TestImpl(input, expected, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestWindowsBeforeFirstElement) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 111, 3}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 2, 110}, {1, 5, 120}, {1, 5, 130}, {1, 3, 140}})};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 4;
+
+    TestImpl(input, expected, expectedStatsMap);
+}
+
+Y_UNIT_TEST(TestSubzeroValues) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 1, 2}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({{1, 2, 30}}),
+    };
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 1;
+
+    TestImpl(input, expected, expectedStatsMap);
+}
+} // Y_UNIT_TEST_SUITE(TMiniKQLMultiHoppingTest)
 
 } // namespace NKikimr::NMiniKQL

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_multihopping_ut.cpp
@@ -1,9 +1,11 @@
 #include "../mkql_multihopping.h"
 #include "mkql_computation_node_ut.h"
+#include <yql/essentials/core/sql_types/hopping.h>
 #include <yql/essentials/minikql/mkql_node.h>
 #include <yql/essentials/minikql/mkql_node_cast.h>
 #include <yql/essentials/minikql/mkql_program_builder.h>
 #include <yql/essentials/minikql/mkql_function_registry.h>
+#include <yql/essentials/minikql/mkql_runtime_version.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_graph_saveload.h>
@@ -48,6 +50,7 @@ TStatsMap DefaultStatsMap = {
     {"MultiHop_LateThrownEventsCount", 0},
     {"MultiHop_EmptyTimeCount", 0},
     {"MultiHop_KeysCount", 1},
+    {"MultiHop_FarFutureStateSize", 0},
 };
 
 using TEncoder = std::function<NUdf::TUnboxedValue(const TInputItem&, const THolderFactory&)>;
@@ -141,6 +144,8 @@ std::tuple<TType*, TEncoder, TDecoder> BuildInputType(TSetup<false>& setup) {
     return {structType, encode, decode};
 }
 
+using EHoppingWindowPolicy = NYql::NHoppingWindow::EPolicy;
+
 THolder<IComputationGraph> BuildGraph(
     TSetup<false>& setup,
     TType* itemType,
@@ -148,7 +153,17 @@ THolder<IComputationGraph> BuildGraph(
     ui64 interval,
     ui64 delay,
     bool dataWatermarks,
-    bool watermarkMode) {
+    bool watermarkMode,
+    ui64 farFutureSizeLimit = Max<ui64>(),
+    ui64 farFutureTimeLimitUs = Max<ui64>(),
+    EHoppingWindowPolicy earlyPolicy = EHoppingWindowPolicy::Drop,
+    EHoppingWindowPolicy latePolicy = EHoppingWindowPolicy::Drop) {
+#if MKQL_RUNTIME_VERSION < 70U
+    Y_UNUSED(farFutureSizeLimit);
+    Y_UNUSED(farFutureTimeLimitUs);
+    Y_UNUSED(earlyPolicy);
+    Y_UNUSED(latePolicy);
+#endif
     TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
 
     auto inStreamType = pgmBuilder.NewStreamType(itemType);
@@ -214,7 +229,19 @@ THolder<IComputationGraph> BuildGraph(
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&interval, sizeof(interval))), // interval
         pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&delay, sizeof(delay))),       // delay
         pgmBuilder.NewDataLiteral<bool>(dataWatermarks),
-        pgmBuilder.NewDataLiteral<bool>(watermarkMode));
+        pgmBuilder.NewDataLiteral<bool>(watermarkMode),
+#if MKQL_RUNTIME_VERSION >= 70U
+        pgmBuilder.NewDataLiteral<ui64>(farFutureSizeLimit),
+        pgmBuilder.NewDataLiteral<NUdf::EDataSlot::Interval>(NUdf::TStringRef((const char*)&farFutureTimeLimitUs, sizeof(farFutureTimeLimitUs))),
+        pgmBuilder.NewDataLiteral<ui32>((ui32)earlyPolicy),
+        pgmBuilder.NewDataLiteral<ui32>((ui32)latePolicy)
+#else
+        {}, // SizeLimit
+        {}, // TimeLimit
+        {}, // EarlyPolicy
+        {}  // LatePolicy
+#endif
+    );
 
     return setup.BuildGraph(pgmReturn, {streamNode});
 }
@@ -230,13 +257,17 @@ void TestImpl(
     ui64 delay = 20,
     bool dataWatermarks = false,
     bool watermarkMode = false,
+    ui64 farFutureSizeLimit = Max<ui64>(),
+    ui64 farFutureTimeLimitUs = Max<ui64>(),
+    EHoppingWindowPolicy earlyPolicy = EHoppingWindowPolicy::Drop,
+    EHoppingWindowPolicy latePolicy = EHoppingWindowPolicy::Drop,
     TFetchFactory fetchFactory = DefaultFetchFactory,
     TSetupFactory setupFactory = DefaultSetupFactory) {
     auto setup = setupFactory();
 
     auto [itemType, encode, decode] = BuildInputType(setup);
 
-    auto graph = BuildGraph(setup, itemType, hop, interval, delay, dataWatermarks, watermarkMode);
+    auto graph = BuildGraph(setup, itemType, hop, interval, delay, dataWatermarks, watermarkMode, farFutureSizeLimit, farFutureTimeLimitUs, earlyPolicy, latePolicy);
 
     size_t index = 0;
     std::vector<TOutputItem> actual;
@@ -290,7 +321,11 @@ void TestWatermarksImpl(
     const TStatsMap& expectedStatsMap,
     ui64 hop = 10,
     ui64 interval = 30,
-    ui64 delay = 20) {
+    ui64 delay = 20,
+    ui64 farFutureSizeLimit = Max<ui64>(),
+    ui64 farFutureTimeLimitUs = Max<ui64>(),
+    EHoppingWindowPolicy earlyPolicy = EHoppingWindowPolicy::Drop,
+    EHoppingWindowPolicy latePolicy = EHoppingWindowPolicy::Drop) {
     TWatermark watermark;
     auto fetchFactory = [watermarks = watermarks, &watermark](TUnboxedValueVector input) -> TFetchCallback {
         return [input = input,
@@ -322,10 +357,15 @@ void TestWatermarksImpl(
         delay,
         false,
         true,
+        farFutureSizeLimit,
+        farFutureTimeLimitUs,
+        earlyPolicy,
+        latePolicy,
         fetchFactory,
         setupFactory);
 }
 
+#if MKQL_RUNTIME_VERSION >= 70U
 Y_UNIT_TEST(TestThrowWatermarkFromPast) {
     const std::vector<TInputItem> input = {
         // Group; Time; Value
@@ -372,6 +412,104 @@ Y_UNIT_TEST(TestThrowWatermarkFromPast) {
     TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
 }
 
+Y_UNIT_TEST(TestAdjustWatermarkFromPastTime0) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "5 6 Add", 70},
+            {1, "5 6 Add", 80},
+            {1, "5 6 Add", 90},
+            {1, "2", 110},
+            {1, "2", 120},
+            {1, "2", 130},
+            {1, "3", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+            {1, "4", 210},
+            {1, "4", 220},
+            {1, "4", 230},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {2, TInstant::MicroSeconds(20)},
+        {3, TInstant::MicroSeconds(40)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 12;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 3;
+    expectedStatsMap["MultiHop_KeysCount"] = 1;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                           // hop
+                       30,                           // interval
+                       20,                           // delay
+                       Max<ui64>(),                  // farFutureSizeLimit
+                       0,                            // farFutureTimeLimit
+                       EHoppingWindowPolicy::Adjust, // earlyPolicy
+                       EHoppingWindowPolicy::Drop);  // latePolicy
+}
+
+Y_UNIT_TEST(TestAdjustWatermarkFromPastTime100) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+            {1, "5 6 Add 2 Merge", 120},
+            {1, "5 6 Add 2 Merge", 130},
+            {1, "3 5 6 Add Merge", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+            {1, "4", 210},
+            {1, "4", 220},
+            {1, "4", 230},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {2, TInstant::MicroSeconds(20)},
+        {3, TInstant::MicroSeconds(40)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 9;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 5;
+    expectedStatsMap["MultiHop_KeysCount"] = 0;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                           // hop
+                       30,                           // interval
+                       20,                           // delay
+                       Max<ui64>(),                  // farFutureSizeLimit
+                       100,                          // farFutureTimeLimit
+                       EHoppingWindowPolicy::Adjust, // earlyPolicy
+                       EHoppingWindowPolicy::Drop);  // latePolicy
+}
+#endif
+
 Y_UNIT_TEST(TestThrowWatermarkFromFuture) {
     const std::vector<TInputItem> input = {
         // Group; Time; Value
@@ -407,6 +545,55 @@ Y_UNIT_TEST(TestThrowWatermarkFromFuture) {
     expectedStatsMap["MultiHop_KeysCount"] = 0;
 
     TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+
+#if MKQL_RUNTIME_VERSION >= 70U
+Y_UNIT_TEST(TestAdjustWatermarkFromFuture) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+            {1, "2", 120},
+            {1, "2", 130},
+            {1, "3", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "4", 1010},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "5 6 Add", 2010},
+        })};
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {2, TInstant::MicroSeconds(1000)},
+        {3, TInstant::MicroSeconds(2000)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 8;
+    expectedStatsMap["MultiHop_LateThrownEventsCount"] = 3;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 2;
+    expectedStatsMap["MultiHop_KeysCount"] = 1;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                            // hop
+                       30,                            // interval
+                       20,                            // delay
+                       Max<ui64>(),                   // farFutureSizeLimit
+                       Max<ui64>(),                   // farFutureTimeLimit
+                       EHoppingWindowPolicy::Drop,    // earlyPolicy
+                       EHoppingWindowPolicy::Adjust); // latePolicy
 }
 
 Y_UNIT_TEST(TestWatermarkFlow1) {
@@ -453,6 +640,402 @@ Y_UNIT_TEST(TestWatermarkFlow1) {
     expectedStatsMap["MultiHop_FarFutureEventsCount"] = 4;
 
     TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
+}
+#endif
+
+Y_UNIT_TEST(TestWatermarkFlow1CloseTime0) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+        }),
+        TOutputGroup({
+            {1, "2", 120},
+            {1, "2", 130},
+            {1, "3", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "4", 210},
+            {1, "4", 220},
+            {1, "4", 230},
+        }),
+        TOutputGroup({
+            {1, "5", 310},
+            {1, "5", 320},
+            {1, "5", 330},
+        }),
+        TOutputGroup({
+            {1, "6", 410},
+            {1, "6", 420},
+            {1, "6", 430},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 15;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 0;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                          // hop
+                       30,                          // interval
+                       20,                          // delay
+                       Max<ui64>(),                 // farFutureSizeLimit
+                       0,                           // farFutureTimeLimit
+                       EHoppingWindowPolicy::Close, // earlyPolicy
+                       EHoppingWindowPolicy::Drop); // latePolicy
+}
+
+#if MKQL_RUNTIME_VERSION >= 70U
+Y_UNIT_TEST(TestWatermarkFlow1CloseTime100) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+            {1, "2", 120},
+            {1, "2", 130},
+        }),
+        TOutputGroup({
+            {1, "3", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+        }),
+        TOutputGroup({
+            {1, "4", 210},
+            {1, "4", 220},
+            {1, "4", 230},
+        }),
+        TOutputGroup({
+            {1, "5", 310},
+            {1, "5", 320},
+            {1, "5", 330},
+        }),
+        TOutputGroup({
+            {1, "6", 410},
+            {1, "6", 420},
+            {1, "6", 430},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 15;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 4;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                          // hop
+                       30,                          // interval
+                       20,                          // delay
+                       Max<ui64>(),                 // farFutureSizeLimit
+                       100,                         // farFutureTimeLimit
+                       EHoppingWindowPolicy::Close, // earlyPolicy
+                       EHoppingWindowPolicy::Drop); // latePolicy
+}
+
+Y_UNIT_TEST(TestWatermarkFlow1CloseCount0) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+        }),
+        TOutputGroup({
+            {1, "2", 120},
+            {1, "2", 130},
+            {1, "3", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "4", 210},
+            {1, "4", 220},
+            {1, "4", 230},
+        }),
+        TOutputGroup({
+            {1, "5", 310},
+            {1, "5", 320},
+            {1, "5", 330},
+        }),
+        TOutputGroup({
+            {1, "6", 410},
+            {1, "6", 420},
+            {1, "6", 430},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 15;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 4;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                          // hop
+                       30,                          // interval
+                       20,                          // delay
+                       0,                           // farFutureSizeLimit
+                       Max<ui64>(),                 // farFutureTimeLimit
+                       EHoppingWindowPolicy::Close, // earlyPolicy
+                       EHoppingWindowPolicy::Drop); // latePolicy
+}
+
+Y_UNIT_TEST(TestWatermarkFlow1CloseCount1) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+        }),
+        TOutputGroup({
+            {1, "2", 120},
+            {1, "2", 130},
+            {1, "3", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "4", 210},
+            {1, "4", 220},
+            {1, "4", 230},
+        }),
+        TOutputGroup({
+            {1, "5", 310},
+            {1, "5", 320},
+            {1, "5", 330},
+            {1, "6", 410},
+            {1, "6", 420},
+            {1, "6", 430},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 15;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 4;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                          // hop
+                       30,                          // interval
+                       20,                          // delay
+                       1,                           // farFutureSizeLimit
+                       Max<ui64>(),                 // farFutureTimeLimit
+                       EHoppingWindowPolicy::Close, // earlyPolicy
+                       EHoppingWindowPolicy::Drop); // latePolicy
+}
+
+Y_UNIT_TEST(TestWatermarkFlow1DropTime0) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+            {1, "2", 120},
+            {1, "2", 130},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 3;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 0;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                          // hop
+                       30,                          // interval
+                       20,                          // delay
+                       Max<ui64>(),                 // farFutureSizeLimit
+                       0,                           // farFutureTimeLimit
+                       EHoppingWindowPolicy::Drop,  // earlyPolicy
+                       EHoppingWindowPolicy::Drop); // latePolicy
+}
+
+Y_UNIT_TEST(TestWatermarkFlow1DropTime100) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            // no watermark -> time limit unused
+            {1, "2", 110},
+            {1, "2", 120},
+            {1, "2", 130},
+            {1, "3", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 6;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 1;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                          // hop
+                       30,                          // interval
+                       20,                          // delay
+                       Max<ui64>(),                 // farFutureSizeLimit
+                       100,                         // farFutureTimeLimit
+                       EHoppingWindowPolicy::Drop,  // earlyPolicy
+                       EHoppingWindowPolicy::Drop); // latePolicy
+}
+
+Y_UNIT_TEST(TestWatermarkFlow1DropCount0) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+            {1, "2", 120},
+            {1, "2", 130},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 3;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 4;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                          // hop
+                       30,                          // interval
+                       20,                          // delay
+                       0,                           // farFutureSizeLimit
+                       Max<ui64>(),                 // farFutureTimeLimit
+                       EHoppingWindowPolicy::Drop,  // earlyPolicy
+                       EHoppingWindowPolicy::Drop); // latePolicy
+}
+
+Y_UNIT_TEST(TestWatermarkFlow1DropCount1) {
+    const std::vector<TInputItem> input = {
+        // Group; Time; Value
+        {1, 101, 2},
+        {1, 131, 3},
+        {1, 200, 4},
+        {1, 300, 5},
+        {1, 400, 6}};
+    const std::vector<TOutputGroup> expected = {
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "2", 110},
+            {1, "2", 120},
+            {1, "2", 130},
+            {1, "3", 140},
+            {1, "3", 150},
+            {1, "3", 160},
+        }),
+        TOutputGroup({}),
+        TOutputGroup({}),
+        TOutputGroup({
+            {1, "5", 310},
+            {1, "5", 320},
+            {1, "5", 330},
+        }),
+    };
+    const std::vector<std::pair<ui64, TInstant>> watermarks = {
+        {0, TInstant::MicroSeconds(100)},
+        {3, TInstant::MicroSeconds(200)}};
+    auto expectedStatsMap = DefaultStatsMap;
+    expectedStatsMap["MultiHop_NewHopsCount"] = 9;
+    expectedStatsMap["MultiHop_FarFutureEventsCount"] = 4;
+
+    TestWatermarksImpl(input, expected, watermarks, expectedStatsMap,
+                       10,                          // hop
+                       30,                          // interval
+                       20,                          // delay
+                       1,                           // farFutureSizeLimit
+                       Max<ui64>(),                 // farFutureTimeLimit
+                       EHoppingWindowPolicy::Drop,  // earlyPolicy
+                       EHoppingWindowPolicy::Drop); // latePolicy
 }
 
 Y_UNIT_TEST(TestWatermarkFlow2) {
@@ -523,6 +1106,7 @@ Y_UNIT_TEST(TestWatermarkFlow3) {
 
     TestWatermarksImpl(input, expected, watermarks, expectedStatsMap);
 }
+#endif
 
 Y_UNIT_TEST(TestWatermarkFlowOverflow) {
     // TODO this tests fails before this change, but it does not exercise

--- a/yql/essentials/minikql/computation/mkql_computation_node_holders.h
+++ b/yql/essentials/minikql/computation/mkql_computation_node_holders.h
@@ -34,6 +34,8 @@ template <typename Type, EMemorySubPool MemoryPool = EMemorySubPool::Default>
 using TMKQLVector = std::vector<Type, TMKQLAllocator<Type, MemoryPool>>;
 template<typename Key, typename T, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>, EMemorySubPool MemoryPool = EMemorySubPool::Default>
 using TMKQLHashMap = std::unordered_map<Key, T, Hash, KeyEqual, TMKQLAllocator<std::pair<const Key, T>, MemoryPool>>;
+template <typename Key, typename T, typename TComp = std::less<Key>, EMemorySubPool MemoryPool = EMemorySubPool::Default>
+using TMKQLMap = std::map<Key, T, TComp, TMKQLAllocator<std::pair<const Key, T>, MemoryPool>>;
 
 using TKeyTypes = std::vector<std::pair<NUdf::EDataSlot, bool>>;
 using TUnboxedValueVector = std::vector<NUdf::TUnboxedValue, TMKQLAllocator<NUdf::TUnboxedValue>>;

--- a/yql/essentials/minikql/mkql_program_builder.cpp
+++ b/yql/essentials/minikql/mkql_program_builder.cpp
@@ -5399,18 +5399,6 @@ TRuntimeNode TProgramBuilder::HoppingCore(TRuntimeNode list,
 }
 
 TRuntimeNode TProgramBuilder::MultiHoppingCore(TRuntimeNode list,
-<<<<<<< HEAD
-    const TUnaryLambda& keyExtractor,
-    const TUnaryLambda& timeExtractor,
-    const TUnaryLambda& init,
-    const TBinaryLambda& update,
-    const TUnaryLambda& save,
-    const TUnaryLambda& load,
-    const TBinaryLambda& merge,
-    const TTernaryLambda& finish,
-    TRuntimeNode hop, TRuntimeNode interval, TRuntimeNode delay,
-    TRuntimeNode dataWatermarks, TRuntimeNode watermarksMode)
-=======
                                                const TUnaryLambda& keyExtractor,
                                                const TUnaryLambda& timeExtractor,
                                                const TUnaryLambda& init,
@@ -5423,7 +5411,6 @@ TRuntimeNode TProgramBuilder::MultiHoppingCore(TRuntimeNode list,
                                                TRuntimeNode dataWatermarks, TRuntimeNode watermarksMode,
                                                TRuntimeNode farFutureSizeLimit, TRuntimeNode farFutureTimeLimit,
                                                TRuntimeNode earlyPolicy, TRuntimeNode latePolicy)
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 {
     auto streamType = AS_TYPE(TStreamType, list);
     auto itemType = AS_TYPE(TStructType, streamType->GetItemType());

--- a/yql/essentials/minikql/mkql_program_builder.cpp
+++ b/yql/essentials/minikql/mkql_program_builder.cpp
@@ -5399,6 +5399,7 @@ TRuntimeNode TProgramBuilder::HoppingCore(TRuntimeNode list,
 }
 
 TRuntimeNode TProgramBuilder::MultiHoppingCore(TRuntimeNode list,
+<<<<<<< HEAD
     const TUnaryLambda& keyExtractor,
     const TUnaryLambda& timeExtractor,
     const TUnaryLambda& init,
@@ -5409,6 +5410,20 @@ TRuntimeNode TProgramBuilder::MultiHoppingCore(TRuntimeNode list,
     const TTernaryLambda& finish,
     TRuntimeNode hop, TRuntimeNode interval, TRuntimeNode delay,
     TRuntimeNode dataWatermarks, TRuntimeNode watermarksMode)
+=======
+                                               const TUnaryLambda& keyExtractor,
+                                               const TUnaryLambda& timeExtractor,
+                                               const TUnaryLambda& init,
+                                               const TBinaryLambda& update,
+                                               const TUnaryLambda& save,
+                                               const TUnaryLambda& load,
+                                               const TBinaryLambda& merge,
+                                               const TTernaryLambda& finish,
+                                               TRuntimeNode hop, TRuntimeNode interval, TRuntimeNode delay,
+                                               TRuntimeNode dataWatermarks, TRuntimeNode watermarksMode,
+                                               TRuntimeNode farFutureSizeLimit, TRuntimeNode farFutureTimeLimit,
+                                               TRuntimeNode earlyPolicy, TRuntimeNode latePolicy)
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 {
     auto streamType = AS_TYPE(TStreamType, list);
     auto itemType = AS_TYPE(TStructType, streamType->GetItemType());
@@ -5475,6 +5490,15 @@ TRuntimeNode TProgramBuilder::MultiHoppingCore(TRuntimeNode list,
     callableBuilder.Add(delay);
     callableBuilder.Add(dataWatermarks);
     callableBuilder.Add(watermarksMode);
+    if (farFutureSizeLimit || farFutureTimeLimit || earlyPolicy || latePolicy) {
+        if constexpr (RuntimeVersion < 70U) {
+            THROW yexception() << "Runtime version (" << RuntimeVersion << ") too old for " << __func__;
+        }
+        callableBuilder.Add(farFutureSizeLimit);
+        callableBuilder.Add(farFutureTimeLimit);
+        callableBuilder.Add(earlyPolicy);
+        callableBuilder.Add(latePolicy);
+    }
 
     return TRuntimeNode(callableBuilder.Build(), false);
 }

--- a/yql/essentials/minikql/mkql_program_builder.h
+++ b/yql/essentials/minikql/mkql_program_builder.h
@@ -519,18 +519,6 @@ public:
         const TBinaryLambda& finish,
         TRuntimeNode hop, TRuntimeNode interval, TRuntimeNode delay);
     TRuntimeNode MultiHoppingCore(TRuntimeNode list,
-<<<<<<< HEAD
-        const TUnaryLambda& keyExtractor,
-        const TUnaryLambda& timeExtractor,
-        const TUnaryLambda& init,
-        const TBinaryLambda& update,
-        const TUnaryLambda& save,
-        const TUnaryLambda& load,
-        const TBinaryLambda& merge,
-        const TTernaryLambda& finish,
-        TRuntimeNode hop, TRuntimeNode interval, TRuntimeNode delay,
-        TRuntimeNode dataWatermarks, TRuntimeNode watermarksMode);
-=======
                                   const TUnaryLambda& keyExtractor,
                                   const TUnaryLambda& timeExtractor,
                                   const TUnaryLambda& init,
@@ -543,7 +531,6 @@ public:
                                   TRuntimeNode dataWatermarks, TRuntimeNode watermarksMode,
                                   TRuntimeNode farFutureCountMax, TRuntimeNode farFutureTimeMax,
                                   TRuntimeNode earlyPolicy, TRuntimeNode latePolicy);
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
     TRuntimeNode Chopper(TRuntimeNode flow, const TUnaryLambda& keyExtractor, const TBinaryLambda& groupSwitch, const TBinaryLambda& groupHandler);
 

--- a/yql/essentials/minikql/mkql_program_builder.h
+++ b/yql/essentials/minikql/mkql_program_builder.h
@@ -519,6 +519,7 @@ public:
         const TBinaryLambda& finish,
         TRuntimeNode hop, TRuntimeNode interval, TRuntimeNode delay);
     TRuntimeNode MultiHoppingCore(TRuntimeNode list,
+<<<<<<< HEAD
         const TUnaryLambda& keyExtractor,
         const TUnaryLambda& timeExtractor,
         const TUnaryLambda& init,
@@ -529,6 +530,20 @@ public:
         const TTernaryLambda& finish,
         TRuntimeNode hop, TRuntimeNode interval, TRuntimeNode delay,
         TRuntimeNode dataWatermarks, TRuntimeNode watermarksMode);
+=======
+                                  const TUnaryLambda& keyExtractor,
+                                  const TUnaryLambda& timeExtractor,
+                                  const TUnaryLambda& init,
+                                  const TBinaryLambda& update,
+                                  const TUnaryLambda& save,
+                                  const TUnaryLambda& load,
+                                  const TBinaryLambda& merge,
+                                  const TTernaryLambda& finish,
+                                  TRuntimeNode hop, TRuntimeNode interval, TRuntimeNode delay,
+                                  TRuntimeNode dataWatermarks, TRuntimeNode watermarksMode,
+                                  TRuntimeNode farFutureCountMax, TRuntimeNode farFutureTimeMax,
+                                  TRuntimeNode earlyPolicy, TRuntimeNode latePolicy);
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
     TRuntimeNode Chopper(TRuntimeNode flow, const TUnaryLambda& keyExtractor, const TBinaryLambda& groupSwitch, const TBinaryLambda& groupHandler);
 

--- a/yql/essentials/minikql/mkql_runtime_version.h
+++ b/yql/essentials/minikql/mkql_runtime_version.h
@@ -24,7 +24,11 @@ namespace NMiniKQL {
 // 1. Bump this version every time incompatible runtime nodes are introduced.
 // 2. Make sure you provide runtime node generation for previous runtime versions.
 #ifndef MKQL_RUNTIME_VERSION
+<<<<<<< HEAD
 #define MKQL_RUNTIME_VERSION 59U
+=======
+    #define MKQL_RUNTIME_VERSION 70U
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 #endif
 
 // History:

--- a/yql/essentials/minikql/mkql_runtime_version.h
+++ b/yql/essentials/minikql/mkql_runtime_version.h
@@ -24,11 +24,7 @@ namespace NMiniKQL {
 // 1. Bump this version every time incompatible runtime nodes are introduced.
 // 2. Make sure you provide runtime node generation for previous runtime versions.
 #ifndef MKQL_RUNTIME_VERSION
-<<<<<<< HEAD
 #define MKQL_RUNTIME_VERSION 59U
-=======
-    #define MKQL_RUNTIME_VERSION 70U
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 #endif
 
 // History:

--- a/yql/essentials/providers/common/mkql/yql_provider_mkql.cpp
+++ b/yql/essentials/providers/common/mkql/yql_provider_mkql.cpp
@@ -1981,10 +1981,26 @@ TMkqlCommonCallableCompiler::TShared::TShared() {
         };
 
         const auto watermarksMode = ctx.ProgramBuilder.NewDataLiteral(FromString<bool>(*node.Child(13), NUdf::EDataSlot::Bool));
-
+        TRuntimeNode sizeLimit;
+        if (NNodes::TCoMultiHoppingCore::idx_SizeLimit < node.ChildrenSize()) {
+            sizeLimit = MkqlBuildExpr(*node.Child(NNodes::TCoMultiHoppingCore::idx_SizeLimit), ctx);
+        }
+        TRuntimeNode timeLimit;
+        if (NNodes::TCoMultiHoppingCore::idx_TimeLimit < node.ChildrenSize()) {
+            timeLimit = MkqlBuildExpr(*node.Child(NNodes::TCoMultiHoppingCore::idx_TimeLimit), ctx);
+        }
+        TRuntimeNode earlyPolicy;
+        if (NNodes::TCoMultiHoppingCore::idx_EarlyPolicy < node.ChildrenSize()) {
+            earlyPolicy = MkqlBuildExpr(*node.Child(NNodes::TCoMultiHoppingCore::idx_EarlyPolicy), ctx);
+        }
+        TRuntimeNode latePolicy;
+        if (NNodes::TCoMultiHoppingCore::idx_LatePolicy < node.ChildrenSize()) {
+            latePolicy = MkqlBuildExpr(*node.Child(NNodes::TCoMultiHoppingCore::idx_LatePolicy), ctx);
+        }
         return ctx.ProgramBuilder.MultiHoppingCore(
             stream, keyExtractor, timeExtractor, init, update, save, load, merge, finish,
-            hop, interval, delay, dataWatermarks, watermarksMode);
+            hop, interval, delay, dataWatermarks, watermarksMode,
+            sizeLimit, timeLimit, earlyPolicy, latePolicy);
     });
 
     AddCallable("ToDict", [](const TExprNode& node, TMkqlBuildContext& ctx) {

--- a/yql/essentials/sql/v1/builtin.cpp
+++ b/yql/essentials/sql/v1/builtin.cpp
@@ -3983,7 +3983,7 @@ TNodePtr BuildBuiltinFunc(TContext& ctx, TPosition pos, TString name, const TVec
             if (useNamed) {
                 *mustUseNamed = false;
             }
-            return TNonNull(TNodePtr(new THoppingWindow(pos, args, useNamed)));
+            return new THoppingWindow(pos, args, useNamed);
         } else {
             return new TInvalidBuiltin(pos, TStringBuilder() << "Unknown builtin: " << name);
         }

--- a/yql/essentials/sql/v1/builtin.cpp
+++ b/yql/essentials/sql/v1/builtin.cpp
@@ -2196,17 +2196,18 @@ private:
     TNodePtr Node_;
 };
 
-THoppingWindow::THoppingWindow(TPosition pos, TVector<TNodePtr> args)
+THoppingWindow::THoppingWindow(TPosition pos, TVector<TNodePtr> args, bool useNamed)
     : INode(pos)
     , Args_(std::move(args))
     , FakeSource_(BuildFakeSource(pos))
+    , UseNamed_(useNamed)
     , Valid_(false)
 {}
 
 TNodePtr THoppingWindow::BuildTraits(const TString& label) const {
     YQL_ENSURE(HasState(ENodeState::Initialized));
 
-    return Y(
+    auto result = Y(
         "HoppingTraits",
         Y("ListItemType", Y("TypeOf", label)),
         BuildLambda(Pos_, Y("row"), TimeExtractor_),
@@ -2214,8 +2215,20 @@ TNodePtr THoppingWindow::BuildTraits(const TString& label) const {
         Interval_,
         Delay_,
         Q(DataWatermarks_),
+<<<<<<< HEAD
         Q("v2")
     );
+=======
+        Q("v2"));
+    if (SizeLimit_ || TimeLimit_ || EarlyPolicy_ || LatePolicy_) {
+        result->Add(
+            SizeLimit_ ? SizeLimit_ : Y("Void"),
+            TimeLimit_ ? TimeLimit_ : Y("Void"),
+            EarlyPolicy_ ? EarlyPolicy_ : Y("Void"),
+            LatePolicy_ ? LatePolicy_ : Y("Void"));
+    }
+    return result;
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 }
 
 TNodePtr THoppingWindow::GetInterval() const {
@@ -2233,19 +2246,57 @@ bool THoppingWindow::DoInit(TContext& ctx, ISource* src) {
         return false;
     }
 
-    if (Args_.size() != 3) {
-        ctx.Error(Pos_) << "HoppingWindow requires three arguments";
-        return false;
-    }
-
     if (!Valid_) {
         ctx.Error(Pos_) << "HoppingWindow can only be used as a top-level GROUP BY expression";
         return false;
     }
 
-    auto timeExtractor = Args_[0];
-    auto hopExpr = Args_[1];
-    auto intervalExpr = Args_[2];
+    TNodePtr timeExtractor;
+    TNodePtr hopExpr;
+    TNodePtr intervalExpr;
+    if (UseNamed_) {
+        YQL_ENSURE(Args_.size() == 2);
+        auto posArgs = Args_[0]->GetTupleNode();
+        Y_DEBUG_ABORT_UNLESS(posArgs);
+        if (posArgs->GetTupleSize() != 3) {
+            ctx.Error(Pos_) << "HoppingWindow requires three positional arguments";
+            return false;
+        }
+        timeExtractor = posArgs->GetTupleElement(0);
+        hopExpr = posArgs->GetTupleElement(1);
+        intervalExpr = posArgs->GetTupleElement(2);
+        auto namedArgs = Args_[1]->GetStructNode();
+        Y_DEBUG_ABORT_UNLESS(namedArgs);
+        for (auto arg : namedArgs->GetExprs()) {
+            if (!arg->Init(ctx, FakeSource_.Get())) {
+                return false;
+            }
+
+            const auto& label = arg->GetLabel();
+            if (label == "SizeLimit") {
+                SizeLimit_ = std::move(arg);
+            } else if (label == "TimeLimit") {
+                TimeLimit_ = ProcessIntervalParam(arg);
+            } else if (label == "EarlyPolicy") {
+                EarlyPolicy_ = std::move(arg);
+            } else if (label == "LatePolicy") {
+                LatePolicy_ = std::move(arg);
+            } else {
+                ctx.Error(arg->GetPos()) << "HoppingWindow: unsupported parameter: " << label
+                                         << "; expected: SizeLimit, TimeLimit, EarlyPolicy, LatePolicy";
+                return false;
+            }
+        }
+    } else {
+        if (Args_.size() != 3) {
+            ctx.Error(Pos_) << "HoppingWindow requires three positional arguments";
+            return false;
+        }
+
+        timeExtractor = Args_[0];
+        hopExpr = Args_[1];
+        intervalExpr = Args_[2];
+    }
 
     if (!timeExtractor->Init(ctx, src) ||
         !hopExpr->Init(ctx, FakeSource_.Get()) ||
@@ -2270,7 +2321,7 @@ void THoppingWindow::DoUpdateState() const {
 }
 
 TNodePtr THoppingWindow::DoClone() const {
-    return new THoppingWindow(Pos_, CloneContainer(Args_));
+    return new THoppingWindow(Pos_, CloneContainer(Args_), UseNamed_);
 }
 
 TString THoppingWindow::GetOpName() const {
@@ -2281,6 +2332,9 @@ TNodePtr THoppingWindow::ProcessIntervalParam(const TNodePtr& node) const {
     auto literal = node->GetLiteral("String");
     if (!literal) {
         return Y("EvaluateExpr", node);
+    }
+    if (*literal == "max") {
+        return node;
     }
 
     return new TYqlData(node->GetPos(), "Interval", {node});
@@ -3283,9 +3337,6 @@ struct TBuiltinFuncData {
             {"sessionstart", {"SessionStart", "Agg", BuildSimpleBuiltinFactoryCallback<TSessionStart<true>>()}},
             {"sessionstate", {"SessionState", "Agg", BuildSimpleBuiltinFactoryCallback<TSessionStart<false>>()}},
 
-            // New hopping
-            {"hoppingwindow", {"", "", BuildSimpleBuiltinFactoryCallback<THoppingWindow>()}},
-
             // Hopping intervals time functions
             {"hopstart", {"HopStart", "Agg", BuildSimpleBuiltinFactoryCallback<THoppingTime<true>>()}},
             {"hopend", {"HopEnd", "Agg", BuildSimpleBuiltinFactoryCallback<THoppingTime<false>>()}}
@@ -3931,7 +3982,17 @@ TNodePtr BuildBuiltinFunc(TContext& ctx, TPosition pos, TString name, const TVec
             }
             return new TCallNodeImpl(pos, "SqlVisit", 1, -1, resultArgs);
         } else if (normalizedName == "sqlexternalfunction") {
+<<<<<<< HEAD
             return new TCallNodeImpl(pos, "SqlExternalFunction", args);
+=======
+            return TNonNull(TNodePtr(new TCallNodeImpl(pos, "SqlExternalFunction", args)));
+        } else if (normalizedName == "hoppingwindow") {
+            bool useNamed = mustUseNamed && *mustUseNamed;
+            if (useNamed) {
+                *mustUseNamed = false;
+            }
+            return TNonNull(TNodePtr(new THoppingWindow(pos, args, useNamed)));
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
         } else {
             return new TInvalidBuiltin(pos, TStringBuilder() << "Unknown builtin: " << name);
         }

--- a/yql/essentials/sql/v1/builtin.cpp
+++ b/yql/essentials/sql/v1/builtin.cpp
@@ -2215,10 +2215,6 @@ TNodePtr THoppingWindow::BuildTraits(const TString& label) const {
         Interval_,
         Delay_,
         Q(DataWatermarks_),
-<<<<<<< HEAD
-        Q("v2")
-    );
-=======
         Q("v2"));
     if (SizeLimit_ || TimeLimit_ || EarlyPolicy_ || LatePolicy_) {
         result->Add(
@@ -2228,7 +2224,6 @@ TNodePtr THoppingWindow::BuildTraits(const TString& label) const {
             LatePolicy_ ? LatePolicy_ : Y("Void"));
     }
     return result;
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 }
 
 TNodePtr THoppingWindow::GetInterval() const {
@@ -3982,17 +3977,13 @@ TNodePtr BuildBuiltinFunc(TContext& ctx, TPosition pos, TString name, const TVec
             }
             return new TCallNodeImpl(pos, "SqlVisit", 1, -1, resultArgs);
         } else if (normalizedName == "sqlexternalfunction") {
-<<<<<<< HEAD
             return new TCallNodeImpl(pos, "SqlExternalFunction", args);
-=======
-            return TNonNull(TNodePtr(new TCallNodeImpl(pos, "SqlExternalFunction", args)));
         } else if (normalizedName == "hoppingwindow") {
             bool useNamed = mustUseNamed && *mustUseNamed;
             if (useNamed) {
                 *mustUseNamed = false;
             }
             return TNonNull(TNodePtr(new THoppingWindow(pos, args, useNamed)));
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
         } else {
             return new TInvalidBuiltin(pos, TStringBuilder() << "Unknown builtin: " << name);
         }

--- a/yql/essentials/sql/v1/source.h
+++ b/yql/essentials/sql/v1/source.h
@@ -113,41 +113,14 @@ namespace NSQLTranslationV1 {
         TString GetGroupByColumnAlias(const TString& column) const;
         const TVector<TNodePtr>& Expressions(EExprSeat exprSeat) const;
 
-<<<<<<< HEAD
         virtual TWindowSpecificationPtr FindWindowSpecification(TContext& ctx, const TString& windowName) const;
-=======
-class THoppingWindow final: public INode {
-public:
-    THoppingWindow(TPosition pos, TVector<TNodePtr> args, bool useNamed);
-    TNodePtr BuildTraits(const TString& label) const;
-    TNodePtr GetInterval() const;
-    void MarkValid();
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
         TIntrusivePtr<ISource> CloneSource() const;
         TNodePtr BuildSortSpec(const TVector<TSortSpecificationPtr>& orderBy, const TString& label, bool traits, bool assume);
 
-<<<<<<< HEAD
     protected:
         ISource(TPosition pos);
         virtual TAstNode* Translate(TContext& ctx) const;
-=======
-private:
-    TVector<TNodePtr> Args_;
-    TSourcePtr FakeSource_;
-    TNodePtr TimeExtractor_;
-    TNodePtr Hop_;
-    TNodePtr Interval_;
-    TNodePtr SizeLimit_;
-    TNodePtr TimeLimit_;
-    TNodePtr EarlyPolicy_;
-    TNodePtr LatePolicy_;
-    const TNodePtr Delay_ = Y("Interval", Q("0"));
-    const TString DataWatermarks_ = "true";
-    bool UseNamed_ = false;
-    bool Valid_;
-};
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
         void FillSortParts(const TVector<TSortSpecificationPtr>& orderBy, TNodePtr& sortKeySelector, TNodePtr& sortDirection);
 
@@ -236,12 +209,12 @@ private:
         bool Valid_;
     };
 
-    class THoppingWindow final : public INode {
-    public:
-        THoppingWindow(TPosition pos, TVector<TNodePtr> args);
-        TNodePtr BuildTraits(const TString& label) const;
-        TNodePtr GetInterval() const;
-        void MarkValid();
+class THoppingWindow final: public INode {
+public:
+    THoppingWindow(TPosition pos, TVector<TNodePtr> args, bool useNamed);
+    TNodePtr BuildTraits(const TString& label) const;
+    TNodePtr GetInterval() const;
+    void MarkValid();
 
     private:
         bool DoInit(TContext& ctx, ISource* src) override;
@@ -251,16 +224,21 @@ private:
         TString GetOpName() const override;
         TNodePtr ProcessIntervalParam(const TNodePtr& val) const;
 
-    private:
-        TVector<TNodePtr> Args_;
-        TSourcePtr FakeSource_;
-        TNodePtr TimeExtractor_;
-        TNodePtr Hop_;
-        TNodePtr Interval_;
-        const TNodePtr Delay_ = Y("Interval", Q("0"));
-        const TString DataWatermarks_ = "true";
-        bool Valid_;
-    };
+private:
+    TVector<TNodePtr> Args_;
+    TSourcePtr FakeSource_;
+    TNodePtr TimeExtractor_;
+    TNodePtr Hop_;
+    TNodePtr Interval_;
+    TNodePtr SizeLimit_;
+    TNodePtr TimeLimit_;
+    TNodePtr EarlyPolicy_;
+    TNodePtr LatePolicy_;
+    const TNodePtr Delay_ = Y("Interval", Q("0"));
+    const TString DataWatermarks_ = "true";
+    bool UseNamed_ = false;
+    bool Valid_;
+};
 
 
     // Implemented in join.cpp

--- a/yql/essentials/sql/v1/source.h
+++ b/yql/essentials/sql/v1/source.h
@@ -113,14 +113,41 @@ namespace NSQLTranslationV1 {
         TString GetGroupByColumnAlias(const TString& column) const;
         const TVector<TNodePtr>& Expressions(EExprSeat exprSeat) const;
 
+<<<<<<< HEAD
         virtual TWindowSpecificationPtr FindWindowSpecification(TContext& ctx, const TString& windowName) const;
+=======
+class THoppingWindow final: public INode {
+public:
+    THoppingWindow(TPosition pos, TVector<TNodePtr> args, bool useNamed);
+    TNodePtr BuildTraits(const TString& label) const;
+    TNodePtr GetInterval() const;
+    void MarkValid();
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
         TIntrusivePtr<ISource> CloneSource() const;
         TNodePtr BuildSortSpec(const TVector<TSortSpecificationPtr>& orderBy, const TString& label, bool traits, bool assume);
 
+<<<<<<< HEAD
     protected:
         ISource(TPosition pos);
         virtual TAstNode* Translate(TContext& ctx) const;
+=======
+private:
+    TVector<TNodePtr> Args_;
+    TSourcePtr FakeSource_;
+    TNodePtr TimeExtractor_;
+    TNodePtr Hop_;
+    TNodePtr Interval_;
+    TNodePtr SizeLimit_;
+    TNodePtr TimeLimit_;
+    TNodePtr EarlyPolicy_;
+    TNodePtr LatePolicy_;
+    const TNodePtr Delay_ = Y("Interval", Q("0"));
+    const TString DataWatermarks_ = "true";
+    bool UseNamed_ = false;
+    bool Valid_;
+};
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
         void FillSortParts(const TVector<TSortSpecificationPtr>& orderBy, TNodePtr& sortKeySelector, TNodePtr& sortDirection);
 

--- a/yql/essentials/sql/v1/sql_ut_common.h
+++ b/yql/essentials/sql/v1/sql_ut_common.h
@@ -9653,12 +9653,52 @@ Y_UNIT_TEST_SUITE(HoppingWindow) {
         UNIT_ASSERT_VALUES_EQUAL(0, res.Issues.Size());
     }
 
+<<<<<<< HEAD
     Y_UNIT_TEST(HoppingWindowWithoutSource) {
         ExpectFailWithError(
             R"sql(SELECT 1 + HoppingWindow(key, 39, 42);)sql",
             "<main>:1:12: Error: HoppingWindow requires data source\n"
         );
     }
+=======
+Y_UNIT_TEST(HoppingWindowNamedParameters) {
+    {
+        auto query = R"sql(
+            SELECT
+                *
+            FROM plato.Input
+            GROUP BY HoppingWindow(key, 39, 42,
+                                   "max" AS SizeLimit, "PT10S" AS TimeLimit,
+                                   "close" AS EarlyPolicy, "adjust" AS LatePolicy);
+            )sql";
+
+        NYql::TAstParseResult res = SqlToYql(query);
+        UNIT_ASSERT_VALUES_UNEQUAL(nullptr, res.Root);
+        UNIT_ASSERT(res.IsOk());
+        UNIT_ASSERT_VALUES_EQUAL(0, res.Issues.Size());
+    }
+    {
+        auto query = R"sql(
+            SELECT
+                *
+            FROM plato.Input
+            GROUP BY HoppingWindow(key, 39, 42,
+                                   "drop" AS LatePolicy, "adjust" AS EarlyPolicy);
+            )sql";
+
+        NYql::TAstParseResult res = SqlToYql(query);
+        UNIT_ASSERT_VALUES_UNEQUAL(nullptr, res.Root);
+        UNIT_ASSERT(res.IsOk());
+        UNIT_ASSERT_VALUES_EQUAL(0, res.Issues.Size());
+    }
+}
+
+Y_UNIT_TEST(HoppingWindowWithoutSource) {
+    ExpectFailWithError(
+        R"sql(SELECT 1 + HoppingWindow(key, 39, 42);)sql",
+        "<main>:1:12: Error: HoppingWindow requires data source\n");
+}
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
     Y_UNIT_TEST(HoppingWindowInProjection) {
         ExpectFailWithError(
@@ -9694,10 +9734,44 @@ Y_UNIT_TEST_SUITE(HoppingWindow) {
                     key;
             )sql",
 
+<<<<<<< HEAD
             "<main>:7:21: Error: Source does not allow column references\n"
             "<main>:7:45: Error: Column reference 'subkey'\n"
         );
     }
+=======
+        "<main>:7:21: Error: Source does not allow column references\n"
+        "<main>:7:45: Error: Column reference 'subkey'\n");
+
+    ExpectFailWithError(
+        R"sql(
+                SELECT
+                    key,
+                    hopping_start
+                FROM plato.Input
+                GROUP BY
+                    HoppingWindow(key, 39, 42, (subkey + 42) AS SizeLimit) AS hopping_start,
+                    key;
+            )sql",
+
+        "<main>:7:21: Error: Source does not allow column references\n"
+        "<main>:7:49: Error: Column reference 'subkey'\n");
+
+    ExpectFailWithError(
+        R"sql(
+                SELECT
+                    key,
+                    hopping_start
+                FROM plato.Input
+                GROUP BY
+                    HoppingWindow(key, 39, 42, subkey AS LatePolicy) AS hopping_start,
+                    key;
+            )sql",
+
+        "<main>:7:21: Error: Source does not allow column references\n"
+        "<main>:7:48: Error: Column reference 'subkey'\n");
+}
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
     Y_UNIT_TEST(HoppingWindowWithWrongNumberOfArgs) {
         ExpectFailWithError(
@@ -9708,8 +9782,12 @@ Y_UNIT_TEST_SUITE(HoppingWindow) {
                 GROUP BY HoppingWindow(key, 39);
             )sql",
 
+<<<<<<< HEAD
             "<main>:5:26: Error: HoppingWindow requires three arguments\n"
         );
+=======
+        "<main>:5:26: Error: HoppingWindow requires three positional arguments\n");
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
         ExpectFailWithError(
             R"sql(
@@ -9719,9 +9797,42 @@ Y_UNIT_TEST_SUITE(HoppingWindow) {
                 GROUP BY HoppingWindow(key, 39, 42, 63);
             )sql",
 
+<<<<<<< HEAD
             "<main>:5:26: Error: HoppingWindow requires three arguments\n"
         );
     }
+=======
+        "<main>:5:26: Error: HoppingWindow requires three positional arguments\n");
+}
+
+Y_UNIT_TEST(HoppingWindowWithUnknownNamedArg) {
+    ExpectFailWithError(
+        R"sql(
+                SELECT
+                    *
+                FROM plato.Input
+                GROUP BY HoppingWindow(key, 39, 42, 13 AS Foobar);
+            )sql",
+
+        "<main>:5:53: Error: HoppingWindow: unsupported parameter: Foobar; expected: SizeLimit, TimeLimit, EarlyPolicy, LatePolicy\n");
+}
+
+Y_UNIT_TEST(HoppingWindowWithEvaluatedLimit) {
+    {
+        auto query = R"sql(
+            SELECT
+                *
+            FROM plato.Input
+            GROUP BY HoppingWindow(key, 39, 42, (Uint64("13") + Uint64("17")) AS SizeLimit);
+            )sql";
+
+        NYql::TAstParseResult res = SqlToYql(query);
+        UNIT_ASSERT_VALUES_UNEQUAL(nullptr, res.Root);
+        UNIT_ASSERT(res.IsOk());
+        UNIT_ASSERT_VALUES_EQUAL(0, res.Issues.Size());
+    }
+}
+>>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
     Y_UNIT_TEST(DuplicateHoppingWindow) {
         ExpectFailWithError(

--- a/yql/essentials/sql/v1/sql_ut_common.h
+++ b/yql/essentials/sql/v1/sql_ut_common.h
@@ -9653,14 +9653,6 @@ Y_UNIT_TEST_SUITE(HoppingWindow) {
         UNIT_ASSERT_VALUES_EQUAL(0, res.Issues.Size());
     }
 
-<<<<<<< HEAD
-    Y_UNIT_TEST(HoppingWindowWithoutSource) {
-        ExpectFailWithError(
-            R"sql(SELECT 1 + HoppingWindow(key, 39, 42);)sql",
-            "<main>:1:12: Error: HoppingWindow requires data source\n"
-        );
-    }
-=======
 Y_UNIT_TEST(HoppingWindowNamedParameters) {
     {
         auto query = R"sql(
@@ -9693,12 +9685,12 @@ Y_UNIT_TEST(HoppingWindowNamedParameters) {
     }
 }
 
-Y_UNIT_TEST(HoppingWindowWithoutSource) {
-    ExpectFailWithError(
-        R"sql(SELECT 1 + HoppingWindow(key, 39, 42);)sql",
-        "<main>:1:12: Error: HoppingWindow requires data source\n");
-}
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
+    Y_UNIT_TEST(HoppingWindowWithoutSource) {
+        ExpectFailWithError(
+            R"sql(SELECT 1 + HoppingWindow(key, 39, 42);)sql",
+            "<main>:1:12: Error: HoppingWindow requires data source\n"
+        );
+    }
 
     Y_UNIT_TEST(HoppingWindowInProjection) {
         ExpectFailWithError(
@@ -9734,14 +9726,9 @@ Y_UNIT_TEST(HoppingWindowWithoutSource) {
                     key;
             )sql",
 
-<<<<<<< HEAD
             "<main>:7:21: Error: Source does not allow column references\n"
             "<main>:7:45: Error: Column reference 'subkey'\n"
         );
-    }
-=======
-        "<main>:7:21: Error: Source does not allow column references\n"
-        "<main>:7:45: Error: Column reference 'subkey'\n");
 
     ExpectFailWithError(
         R"sql(
@@ -9770,8 +9757,7 @@ Y_UNIT_TEST(HoppingWindowWithoutSource) {
 
         "<main>:7:21: Error: Source does not allow column references\n"
         "<main>:7:48: Error: Column reference 'subkey'\n");
-}
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
+    }
 
     Y_UNIT_TEST(HoppingWindowWithWrongNumberOfArgs) {
         ExpectFailWithError(
@@ -9782,12 +9768,7 @@ Y_UNIT_TEST(HoppingWindowWithoutSource) {
                 GROUP BY HoppingWindow(key, 39);
             )sql",
 
-<<<<<<< HEAD
-            "<main>:5:26: Error: HoppingWindow requires three arguments\n"
-        );
-=======
         "<main>:5:26: Error: HoppingWindow requires three positional arguments\n");
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
         ExpectFailWithError(
             R"sql(
@@ -9797,11 +9778,6 @@ Y_UNIT_TEST(HoppingWindowWithoutSource) {
                 GROUP BY HoppingWindow(key, 39, 42, 63);
             )sql",
 
-<<<<<<< HEAD
-            "<main>:5:26: Error: HoppingWindow requires three arguments\n"
-        );
-    }
-=======
         "<main>:5:26: Error: HoppingWindow requires three positional arguments\n");
 }
 
@@ -9832,7 +9808,6 @@ Y_UNIT_TEST(HoppingWindowWithEvaluatedLimit) {
         UNIT_ASSERT_VALUES_EQUAL(0, res.Issues.Size());
     }
 }
->>>>>>> bb5e850eb09 (multihopping: add FarFuture statistics and limits)
 
     Y_UNIT_TEST(DuplicateHoppingWindow) {
         ExpectFailWithError(

--- a/yql/essentials/tests/s-expressions/suites/Stream/MultiHoppingCore.yqls
+++ b/yql/essentials/tests/s-expressions/suites/Stream/MultiHoppingCore.yqls
@@ -10,12 +10,12 @@
 (let interval (Interval '1000000))
 (let map (lambda '(item) (AsStruct)))
 (let reduce (lambda '(lhs rhs) (AsStruct)))
-(let hopping (MultiHoppingCore (Iterator input) keySelector sortKeySelector interval interval interval 
-    'true map reduce map map reduce 
-    (lambda '(key state time) (AsStruct 
-        '('_yql_time time) 
-        '('"data" (Nth key '"0")) 
-        '('group0 (Nth key '"1")))) '0))
+(let hopping (MultiHoppingCore (Iterator input) keySelector sortKeySelector interval interval interval
+    'true map reduce map map reduce
+    (lambda '(key state time) (AsStruct
+        '('_yql_time time)
+        '('"data" (Nth key '"0"))
+        '('group0 (Nth key '"1")))) '0 'group0))
 (let data (FormatType (TypeOf hopping))) # no typical comp node
 (let res (DataSink 'result))
 (let world (Write! world res (Key) data '('('type))))


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Undecided if it makes sense in 25-3/25-4 context: without MKQL bump it practically does nothing, and stable-* and version bump within stable branch feels unfeasible/impossible
TODO:
- [x] ydb part