### PR TITLE
YQ-4999 enabled S3 write in streaming queries

### DIFF
--- a/ydb/core/kqp/common/events/events.h
+++ b/ydb/core/kqp/common/events/events.h
@@ -141,6 +141,7 @@ struct TEvKqp {
         i64 Generation = 1;
         TString CheckpointId;
         TString StreamingQueryPath;
+        TString CustomerSuppliedId;
     };
 
     struct TEvScriptResponse : public TEventLocal<TEvScriptResponse, TKqpEvents::EvScriptResponse> {

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/optimization.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/optimization.cpp
@@ -61,7 +61,7 @@ bool ExploreStreamingQueryNode(TExprNode::TPtr node, TStreamingExploreCtx& res) 
         ++res.Writes;
 
         const auto dataSinkCategory = maybeDataSink.Cast().Category().Value();
-        if (IsIn({NYql::PqProviderName, NYql::SolomonProviderName}, dataSinkCategory)) {
+        if (IsIn({NYql::PqProviderName, NYql::SolomonProviderName, NYql::S3ProviderName}, dataSinkCategory)) {
             return true;
         }
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1747,6 +1747,7 @@ private:
         ev->Generation = PreviousGeneration + 1;
         ev->CheckpointId = State.GetCheckpointId();
         ev->StreamingQueryPath = QueryPath;
+        ev->CustomerSuppliedId = State.GetCurrentExecutionId();
 
         if (const auto statsPeriod = AppData()->QueryServiceConfig.GetProgressStatsPeriodMs()) {
             ev->ProgressStatsPeriod = TDuration::MilliSeconds(statsPeriod);

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1814,9 +1814,8 @@ private:
         if (const auto requestContext = SessionCtx->GetUserRequestContext(); requestContext && requestContext->IsStreamingQuery) {
             configuration.DisablePragma(configuration.UseRuntimeListing, false, "Runtime listing is not supported for streaming queries, pragma value was ignored");
             configuration.DisablePragma(configuration.AtomicUploadCommit, false, "Atomic upload commit is not supported for streaming queries, pragma value was ignored");
-            configuration.AllowAtomicUploadCommit = false;
-        } else {
-            configuration.AllowAtomicUploadCommit = queryType == EKikimrQueryType::Script;
+        } else if (queryType != EKikimrQueryType::Script) {
+            configuration.DisablePragma(configuration.AtomicUploadCommit, false, "Atomic upload commit is supported only for script execution operations, pragma value was ignored");
         }
         configuration.WriteThroughDqIntegration = true;
         configuration.Init(FederatedQuerySetup->S3GatewayConfig, TypesCtx);

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1814,7 +1814,7 @@ private:
         if (const auto requestContext = SessionCtx->GetUserRequestContext(); requestContext && requestContext->IsStreamingQuery) {
             configuration.DisablePragma(configuration.UseRuntimeListing, false, "Runtime listing is not supported for streaming queries, pragma value was ignored");
             configuration.DisablePragma(configuration.AtomicUploadCommit, false, "Atomic upload commit is not supported for streaming queries, pragma value was ignored");
-            configuration.DefaultOuputKeyFlushTimeout = TDuration::Minutes(1);
+            configuration.DefaultOutputKeyFlushTimeout = TDuration::Minutes(1);
         } else if (queryType != EKikimrQueryType::Script) {
             configuration.DisablePragma(configuration.AtomicUploadCommit, false, "Atomic upload commit is supported only for script execution operations, pragma value was ignored");
         }

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1818,7 +1818,6 @@ private:
         } else {
             configuration.AllowAtomicUploadCommit = queryType == EKikimrQueryType::Script;
         }
-
         configuration.WriteThroughDqIntegration = true;
         configuration.Init(FederatedQuerySetup->S3GatewayConfig, TypesCtx);
 

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1813,9 +1813,13 @@ private:
         auto& configuration = *state->Configuration;
         if (const auto requestContext = SessionCtx->GetUserRequestContext(); requestContext && requestContext->IsStreamingQuery) {
             configuration.DisablePragma(configuration.UseRuntimeListing, false, "Runtime listing is not supported for streaming queries, pragma value was ignored");
+            configuration.DisablePragma(configuration.AtomicUploadCommit, false, "Atomic upload commit is not supported for streaming queries, pragma value was ignored");
+            configuration.AllowAtomicUploadCommit = false;
+        } else {
+            configuration.AllowAtomicUploadCommit = queryType == EKikimrQueryType::Script;
         }
+
         configuration.WriteThroughDqIntegration = true;
-        configuration.AllowAtomicUploadCommit = queryType == EKikimrQueryType::Script;
         configuration.Init(FederatedQuerySetup->S3GatewayConfig, TypesCtx);
 
         state->Types = TypesCtx.Get();

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1814,6 +1814,7 @@ private:
         if (const auto requestContext = SessionCtx->GetUserRequestContext(); requestContext && requestContext->IsStreamingQuery) {
             configuration.DisablePragma(configuration.UseRuntimeListing, false, "Runtime listing is not supported for streaming queries, pragma value was ignored");
             configuration.DisablePragma(configuration.AtomicUploadCommit, false, "Atomic upload commit is not supported for streaming queries, pragma value was ignored");
+            configuration.DefaultOuputKeyFlushTimeout = TDuration::Minutes(1);
         } else if (queryType != EKikimrQueryType::Script) {
             configuration.DisablePragma(configuration.AtomicUploadCommit, false, "Atomic upload commit is supported only for script execution operations, pragma value was ignored");
         }

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -572,7 +572,8 @@ public:
             .PhysicalGraph = ev.QueryPhysicalGraph,
             .DisableDefaultTimeout = ev.DisableDefaultTimeout,
             .CheckpointId = ev.CheckpointId,
-            .StreamingQueryPath = ev.StreamingQueryPath
+            .StreamingQueryPath = ev.StreamingQueryPath,
+            .CustomerSuppliedId = ev.CustomerSuppliedId,
         }, QueryServiceConfig));
 
         const auto& creatorId = Register(new TCreateScriptOperationQuery(ExecutionId, RunScriptActorId, ev.Record, meta, MaxRunTime, GetRetryState(), ev.QueryPhysicalGraph, QueryServiceConfig, ev.Generation));
@@ -627,6 +628,7 @@ private:
         meta.SetResourcePoolId(request.GetPoolId());
         meta.SetCheckpointId(ev.CheckpointId);
         meta.SetStreamingQueryPath(ev.StreamingQueryPath);
+        meta.SetCustomerSuppliedId(ev.CustomerSuppliedId);
         meta.SetClientAddress(request.GetClientAddress());
         meta.SetCollectStats(request.GetCollectStats());
         meta.SetSaveQueryPhysicalGraph(ev.SaveQueryPhysicalGraph);
@@ -1103,7 +1105,8 @@ public:
             .PhysicalGraph = std::move(physicalGraph),
             .DisableDefaultTimeout = meta.GetDisableDefaultTimeout(),
             .CheckpointId = meta.GetCheckpointId(),
-            .StreamingQueryPath = meta.GetStreamingQueryPath()
+            .StreamingQueryPath = meta.GetStreamingQueryPath(),
+            .CustomerSuppliedId = meta.GetCustomerSuppliedId(),
         }, QueryServiceConfig));
 
         KQP_PROXY_LOG_D("Restart with RunScriptActorId: " << RunScriptActorId << ", has PhysicalGraph: " << hasPhysicalGraph);

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -128,6 +128,7 @@ public:
         , CheckpointId(settings.CheckpointId)
         , PhysicalGraph(std::move(settings.PhysicalGraph))
         , StreamingQueryPath(settings.StreamingQueryPath)
+        , CustomerSuppliedId(std::move(settings.CustomerSuppliedId))
         , Counters(settings.Counters)
     {}
 
@@ -140,7 +141,7 @@ public:
             Database,
             /* SessionId*/ "",
             ExecutionId,
-            /* CustomerSuppliedId */ traceId,
+            /* CustomerSuppliedId */ CustomerSuppliedId ? CustomerSuppliedId : traceId,
             SelfId()
         );
         UserRequestContext->IsStreamingQuery = SaveQueryPhysicalGraph;
@@ -982,6 +983,7 @@ private:
     const TString CheckpointId;
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     const TString StreamingQueryPath;
+    const TString CustomerSuppliedId;
     std::optional<TActorId> PhysicalGraphSender;
     TIntrusivePtr<TKqpCounters> Counters;
     TString SessionId;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
@@ -26,6 +26,7 @@ struct TKqpRunScriptActorSettings {
     bool DisableDefaultTimeout = false;
     TString CheckpointId;
     TString StreamingQueryPath;
+    TString CustomerSuppliedId;
 };
 
 NActors::IActor* CreateRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig queryServiceConfig);

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -2327,6 +2327,13 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
         if (const auto& s3Data = GetAllObjects(sourceBucket); !IsIn({"12344321", "43211234"}, s3Data)) {
             UNIT_FAIL("Unexpected S3 data: " << s3Data);
         }
+
+        const auto& keys = GetObjectKeys(sourceBucket);
+        UNIT_ASSERT_VALUES_EQUAL(keys.size(), 2);
+        for (const auto& key : keys) {
+            UNIT_ASSERT_STRING_CONTAINS(key, "test/");
+            UNIT_ASSERT_C(!key.substr(5).Contains("/"), key);
+        }
     }
 
     Y_UNIT_TEST_F(StreamingQueryWithS3Join, TStreamingTestFixture) {

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -1704,7 +1704,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         CreatePqSource(pqSourceName);
 
         const auto& [_, operationId] = ExecScriptNative(fmt::format(R"(
-            PRAGMA s3.OuputKeyFlushTimeout = "1s";
+            PRAGMA s3.OutputKeyFlushTimeout = "1s";
             PRAGMA ydb.DisableCheckpoints = "TRUE";
             PRAGMA ydb.MaxTasksPerStage = "1";
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -2324,7 +2324,9 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
         pqGateway->WaitReadSession(inputTopicName)->AddDataReceivedEvent(1, "4321");
         Sleep(TDuration::Seconds(2));
 
-        UNIT_ASSERT_VALUES_EQUAL(GetAllObjects(sourceBucket), "1234\n4321");
+        if (const auto& s3Data = GetAllObjects(sourceBucket); !IsIn({"12344321", "43211234"}, s3Data)) {
+            UNIT_FAIL("Unexpected S3 data: " << s3Data);
+        }
     }
 
     Y_UNIT_TEST_F(StreamingQueryWithS3Join, TStreamingTestFixture) {

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -976,6 +976,7 @@ message TScriptExecutionOperationMeta {
     optional bool DisableDefaultTimeout = 13;
     optional string CheckpointId = 14;
     optional string StreamingQueryPath = 15;
+    optional string CustomerSuppliedId = 16;
 }
 
 // stored in column "retry_state" of .metadata/script_executions table

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -188,7 +188,7 @@ struct IDqComputeActorAsyncOutput {
     virtual const TDqAsyncStats& GetEgressStats() const = 0;
 
     // Sends data.
-    // Method shoud be called under bound mkql allocator.
+    // Method should be called under bound mkql allocator.
     // Could throw YQL errors.
     // Checkpoint (if any) is supposed to be ordered after batch,
     // and finished flag is supposed to be ordered after checkpoint.

--- a/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
@@ -792,7 +792,7 @@ private:
 
     std::queue<NDqProto::TCheckpoint> PendingCheckpoints;
     std::optional<NDqProto::TCheckpoint> CheckpointInProgress;
-    std::unordered_set<TS3FileWriteActor*> FileWritesInProgress; // All in progress file writes, which are created before CheckpointInProgress
+    std::unordered_set<TS3FileWriteActor*> FileWritesInProgress; // File writes that must complete before CheckpointInProgress can be acknowledged
 };
 
 class TS3ScalarWriteActor : public TS3WriteActorBase {

--- a/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
@@ -640,7 +640,7 @@ private:
         data.clear();
 
         if (checkpoint) {
-            PendingCheckpoints.emplace(std::move(*checkpoint));
+            PendingCheckpoints.emplace(*checkpoint);
             AdvanceCheckpoints();
         }
     }

--- a/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
@@ -18,6 +18,7 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/http/http.h>
 #include <ydb/library/services/services.pb.h>
+#include <ydb/library/yql/dq/actors/compute/dq_checkpoints_states.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h>
 #include <ydb/library/yql/providers/s3/common/util.h>
 #include <ydb/library/yql/providers/s3/compressors/factory.h>
@@ -606,13 +607,14 @@ private:
         return Prefix + Base64EncodeUrl(TStringBuf(reinterpret_cast<const char*>(&rand), sizeof(rand)));
     }
 
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvPrivate::TEvUploadError, Handle);
-        hFunc(TEvPrivate::TEvUploadFinished, Handle);
-        sFunc(TEvPrivate::TEvResumeExecution, ResumeExecution);
+    STRICT_STFUNC_EXC(StateFunc,
+        hFunc(TEvPrivate::TEvUploadError, Handle)
+        hFunc(TEvPrivate::TEvUploadFinished, Handle)
+        sFunc(TEvPrivate::TEvResumeExecution, ResumeExecution),
+        ExceptionFunc(std::exception, HandleException)
     )
 
-    void SendData(TUnboxedValueBatch&& data, i64, const TMaybe<NDqProto::TCheckpoint>&, bool finished) final {
+    void SendData(TUnboxedValueBatch&& data, i64, const TMaybe<NDqProto::TCheckpoint>& checkpoint, bool finished) final {
         ProcessedActors.clear();
         EgressStats.Resume();
 
@@ -636,6 +638,11 @@ private:
             FinishIfNeeded();
         }
         data.clear();
+
+        if (checkpoint) {
+            PendingCheckpoints.emplace(std::move(*checkpoint));
+            AdvanceCheckpoints();
+        }
     }
 
     void Handle(TEvPrivate::TEvUploadError::TPtr& result) {
@@ -661,11 +668,13 @@ private:
             if (const auto ft = std::find_if(it->second.cbegin(), it->second.cend(), [&](TS3FileWriteActor* actor){ return result->Get()->Url == actor->GetUrl(); }); it->second.cend() != ft) {
                 (*ft)->PassAway();
                 it->second.erase(ft);
+                FileWritesInProgress.erase(*ft);
                 if (it->second.empty()) {
                     FileWriteActors.erase(it);
                 }
             }
         }
+        AdvanceCheckpoints();
         ResumeExecution();
         FinishIfNeeded();
     }
@@ -700,6 +709,10 @@ private:
         }
     }
 
+    void HandleException(const std::exception& e) {
+        OnFatalError({NYql::TIssue(e.what())}, NDqProto::StatusIds::INTERNAL_ERROR);
+    }
+
     void OnFatalError(TIssues&& issues, NYql::NDqProto::StatusIds::StatusCode fatalCode, std::source_location location = std::source_location::current()) const {
         TSourceErrorHandler::CanonizeFatalError(issues, fatalCode, location);
         Callbacks->OnAsyncOutputError(OutputIndex, issues, fatalCode);
@@ -715,6 +728,7 @@ private:
             }
         }
         FileWriteActors.clear();
+        FileWritesInProgress.clear();
 
         if (fileWriterCount) {
             LOG_W("TS3WriteActor", "PassAway: " << " with " << fileWriterCount << " NOT finished FileWriter(s)");
@@ -723,6 +737,29 @@ private:
         }
 
         TBase::PassAway();
+    }
+
+    void AdvanceCheckpoints() {
+        while (CheckpointInProgress || !PendingCheckpoints.empty()) {
+            if (CheckpointInProgress) {
+                if (!FileWritesInProgress.empty()) {
+                    // Wait write finish
+                    break;
+                }
+
+                Callbacks->OnAsyncOutputStateSaved({}, OutputIndex, *CheckpointInProgress);
+                CheckpointInProgress = std::nullopt;
+                continue;
+            }
+
+            CheckpointInProgress = std::move(PendingCheckpoints.front());
+            PendingCheckpoints.pop();
+
+            YQL_ENSURE(FileWritesInProgress.empty());
+            for (const auto& [_, fileWriters] : FileWriteActors) {
+                FileWritesInProgress.insert(fileWriters.begin(), fileWriters.end());
+            }
+        }
     }
 
 protected:
@@ -752,6 +789,10 @@ private:
     bool Finished = false;
     std::unordered_set<TS3FileWriteActor*> ProcessedActors;
     std::unordered_map<TString, std::vector<TS3FileWriteActor*>> FileWriteActors;
+
+    std::queue<NDqProto::TCheckpoint> PendingCheckpoints;
+    std::optional<NDqProto::TCheckpoint> CheckpointInProgress;
+    std::unordered_set<TS3FileWriteActor*> FileWritesInProgress; // All in progress file writes, which are created before CheckpointInProgress
 };
 
 class TS3ScalarWriteActor : public TS3WriteActorBase {

--- a/ydb/library/yql/providers/s3/provider/yql_s3_dq_integration.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_dq_integration.cpp
@@ -604,7 +604,7 @@ public:
             }
 
             sinkDesc.SetMultipart(GetMultipart(settings.Settings().Ref()));
-            sinkDesc.SetAtomicUploadCommit(State_->Configuration->AllowAtomicUploadCommit && State_->Configuration->AtomicUploadCommit.GetOrDefault());
+            sinkDesc.SetAtomicUploadCommit(State_->Configuration->AtomicUploadCommit.GetOrDefault());
 
             if (GetBlockOutput(settings.Settings().Ref())) {
                 auto& arrowSettings = *sinkDesc.MutableArrowSettings();

--- a/ydb/library/yql/providers/s3/provider/yql_s3_mkql_compiler.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_mkql_compiler.cpp
@@ -97,6 +97,7 @@ TRuntimeNode BuildSerializeCall(
 
     writer.Write("total_size_limit", ToString(config->SerializeMemoryLimit.GetOrDefault()));
     writer.Write("block_size_limit", ToString(config->BlockSizeMemoryLimit.GetOrDefault()));
+    writer.Write("key_flush_timeout_ms", ToString(config->OuputKeyFlushTimeout.Get().GetOrElse(config->DefaultOuputKeyFlushTimeout).MilliSeconds()));
 
     for (const auto& v : settings) {
         writer.Write(v.first, v.second);

--- a/ydb/library/yql/providers/s3/provider/yql_s3_mkql_compiler.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_mkql_compiler.cpp
@@ -97,7 +97,7 @@ TRuntimeNode BuildSerializeCall(
 
     writer.Write("total_size_limit", ToString(config->SerializeMemoryLimit.GetOrDefault()));
     writer.Write("block_size_limit", ToString(config->BlockSizeMemoryLimit.GetOrDefault()));
-    writer.Write("key_flush_timeout_ms", ToString(config->OuputKeyFlushTimeout.Get().GetOrElse(config->DefaultOuputKeyFlushTimeout).MilliSeconds()));
+    writer.Write("key_flush_timeout_ms", ToString(config->OutputKeyFlushTimeout.Get().GetOrElse(config->DefaultOutputKeyFlushTimeout).MilliSeconds()));
 
     for (const auto& v : settings) {
         writer.Write(v.first, v.second);

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
@@ -32,6 +32,7 @@ TS3Configuration::TS3Configuration() {
     REGISTER_SETTING(*this, AsyncDecoding);
     REGISTER_SETTING(*this, UsePredicatePushdown);
     REGISTER_SETTING(*this, AsyncDecompressing);
+    REGISTER_SETTING(*this, OuputKeyFlushTimeout);
 }
 
 TS3Settings::TConstPtr TS3Configuration::Snapshot() const {

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
@@ -32,7 +32,7 @@ TS3Configuration::TS3Configuration() {
     REGISTER_SETTING(*this, AsyncDecoding);
     REGISTER_SETTING(*this, UsePredicatePushdown);
     REGISTER_SETTING(*this, AsyncDecompressing);
-    REGISTER_SETTING(*this, OuputKeyFlushTimeout);
+    REGISTER_SETTING(*this, OutputKeyFlushTimeout);
 }
 
 TS3Settings::TConstPtr TS3Configuration::Snapshot() const {

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.h
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.h
@@ -80,7 +80,7 @@ public:
     TS3ConfSettingDefault<bool, false> AsyncDecoding;                 // Parse and decode input data at separate mailbox/thread of TaskRunner
     TS3ConfSettingDefault<bool, false> UsePredicatePushdown;
     TS3ConfSettingDefault<bool, false> AsyncDecompressing;            // Decompression and parsing input data in different mailbox/thread
-    TS3ConfSettingOptional<TDuration> OuputKeyFlushTimeout;
+    TS3ConfSettingOptional<TDuration> OutputKeyFlushTimeout;
 };
 
 struct TS3ClusterSettings {
@@ -127,7 +127,7 @@ struct TS3Configuration : public TS3Settings, public NCommon::TSettingDispatcher
     bool WriteThroughDqIntegration = false;
     ui64 MaxListingResultSizePerPhysicalPartition;
     NDq::TS3ReadActorFactoryConfig S3ReadActorFactoryConfig;
-    TDuration DefaultOuputKeyFlushTimeout;
+    TDuration DefaultOutputKeyFlushTimeout;
 
 private:
     std::vector<IS3ConfSettingWithDisableCheck*> DisabledPragmas;

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.h
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.h
@@ -80,6 +80,7 @@ public:
     TS3ConfSettingDefault<bool, false> AsyncDecoding;                 // Parse and decode input data at separate mailbox/thread of TaskRunner
     TS3ConfSettingDefault<bool, false> UsePredicatePushdown;
     TS3ConfSettingDefault<bool, false> AsyncDecompressing;            // Decompression and parsing input data in different mailbox/thread
+    TS3ConfSettingOptional<TDuration> OuputKeyFlushTimeout;
 };
 
 struct TS3ClusterSettings {
@@ -126,6 +127,7 @@ struct TS3Configuration : public TS3Settings, public NCommon::TSettingDispatcher
     bool WriteThroughDqIntegration = false;
     ui64 MaxListingResultSizePerPhysicalPartition;
     NDq::TS3ReadActorFactoryConfig S3ReadActorFactoryConfig;
+    TDuration DefaultOuputKeyFlushTimeout;
 
 private:
     std::vector<IS3ConfSettingWithDisableCheck*> DisabledPragmas;

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.h
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.h
@@ -125,7 +125,6 @@ struct TS3Configuration : public TS3Settings, public NCommon::TSettingDispatcher
     ui64 GeneratorPathsLimit = 0;
     bool WriteThroughDqIntegration = false;
     ui64 MaxListingResultSizePerPhysicalPartition;
-    bool AllowAtomicUploadCommit = true;
     NDq::TS3ReadActorFactoryConfig S3ReadActorFactoryConfig;
 
 private:

--- a/ydb/library/yql/udfs/common/clickhouse/client/clickhouse_client_udf.cpp
+++ b/ydb/library/yql/udfs/common/clickhouse/client/clickhouse_client_udf.cpp
@@ -37,6 +37,7 @@
 #include "src/Processors/Formats/InputStreamFromInputFormat.h"
 #include "src/Processors/Formats/OutputStreamToOutputFormat.h"
 
+#include <util/datetime/base.h>
 #include <util/generic/size_literals.h>
 #include <util/generic/yexception.h>
 #include <util/string/split.h>
@@ -45,6 +46,7 @@ using namespace NYql;
 using namespace NUdf;
 
 namespace {
+
 struct TPgConvertInfo {
     ui32 TypeId = 0;
     TStringRef TypeName;
@@ -1027,20 +1029,25 @@ class TSerializeFormat : public TBoxedValue {
         using TPartitionByKey = std::vector<TUnboxedValue, TStdAllocatorForUdf<TUnboxedValue>>;
 
         struct TPartitionMapStuff {
-            explicit TPartitionMapStuff(size_t size) : Size(size) {}
+            explicit TPartitionMapStuff(size_t size)
+                : Size(size)
+            {}
 
             bool operator()(const TPartitionByKey& left, const TPartitionByKey& right) const {
-                for (auto i = 0U; i < Size; ++i)
-                    if (left[i].AsStringRef() != right[i].AsStringRef())
+                for (auto i = 0U; i < Size; ++i) {
+                    if (left[i].AsStringRef() != right[i].AsStringRef()) {
                         return false;
+                    }
+                }
 
                 return true;
             }
 
             size_t operator()(const TPartitionByKey& value) const {
                 size_t hash = 0ULL;
-                for (auto i = 0U; i < Size; ++i)
+                for (auto i = 0U; i < Size; ++i) {
                     hash = CombineHashes(hash, std::hash<std::string_view>()(value[i].AsStringRef()));
+                }
                 return hash;
             }
 
@@ -1052,15 +1059,33 @@ class TSerializeFormat : public TBoxedValue {
                 : Block(std::move(block))
             {}
 
+            TInstant CreatedAt = TInstant::Now();
             NDB::Block Block;
             std::unique_ptr<NDB::IBlockOutputStream> OutputStream;
             size_t CurrentFileSize = 0; // Sum of size of blocks that were written to output with this key before closing footer
-            bool hasDataInBlock = false; // We wrote something to block at least once.
+            bool HasDataInBlock = false; // We wrote something to block at least once.
         };
 
         using TPartitionsMap = std::unordered_map<TPartitionByKey, TPartitionByPayload, TPartitionMapStuff, TPartitionMapStuff, TStdAllocatorForUdf<std::pair<const TPartitionByKey, TPartitionByPayload>>>;
+
+        struct TPartitionCreationTime {
+            TPartitionCreationTime(TInstant time, TPartitionsMap::iterator iterator)
+                : Time(time)
+                , Iterator(std::move(iterator))
+            {}
+
+            bool operator<(const TPartitionCreationTime& other) const {
+                // assumes iterator returns stable references
+                return Time < other.Time ||
+                    (Time == other.Time && (uintptr_t)&*Iterator < (uintptr_t)&*other.Iterator);
+            }
+
+            TInstant Time;
+            TPartitionsMap::iterator Iterator;
+        };
+
     public:
-        TStreamValue(const IValueBuilder* valueBuilder, const TUnboxedValue& stream, const std::string& type, const NDB::FormatSettings& settings, const std::vector<ui32>& keysIndexes, const std::vector<ui32>& payloadsIndexes, size_t blockSizeLimit, size_t keysCountLimit, size_t totalSizeLimit, size_t fileSizeLimit, const std::vector<TColumnMeta>& inMeta, const NDB::ColumnsWithTypeAndName& columns, const TSourcePosition& pos)
+        TStreamValue(const IValueBuilder* valueBuilder, const TUnboxedValue& stream, const std::string& type, const NDB::FormatSettings& settings, const std::vector<ui32>& keysIndexes, const std::vector<ui32>& payloadsIndexes, size_t blockSizeLimit, size_t keysCountLimit, size_t totalSizeLimit, size_t fileSizeLimit, TDuration keyFlushTimeout, const std::vector<TColumnMeta>& inMeta, const NDB::ColumnsWithTypeAndName& columns, const TSourcePosition& pos)
             : ValueBuilder(valueBuilder)
             , Stream(stream)
             , InMeta(inMeta)
@@ -1070,6 +1095,7 @@ class TSerializeFormat : public TBoxedValue {
             , KeysCountLimit(keysCountLimit)
             , TotalSizeLimit(totalSizeLimit)
             , FileSizeLimit(fileSizeLimit)
+            , KeyFlushTimeout(keyFlushTimeout)
             , Pos(pos)
             , HeaderBlock(columns)
             , Buffer(std::make_unique<NDB::WriteBufferFromOwnString>())
@@ -1078,44 +1104,46 @@ class TSerializeFormat : public TBoxedValue {
             , PartitionsMap(0ULL, TPartitionMapStuff(KeysIndexes.size()), TPartitionMapStuff(KeysIndexes.size()))
             , Cache(KeysIndexes.size() + 1U)
         {}
+
     private:
         bool FlushKey(const TPartitionsMap::iterator it, TUnboxedValue& result, bool finishFile = false) {
-            const size_t currentBlockSize = it->second.Block.bytes();
-            TotalSize -= currentBlockSize;
-            const bool hasDataInFile = it->second.hasDataInBlock || it->second.OutputStream;
-            if (!hasDataInFile) {
+            auto& payload = it->second;
+            auto& block = payload.Block;
+            TotalSize -= block.bytes();
+
+            auto& hasDataInBlock = payload.HasDataInBlock;
+            auto& outputStream = payload.OutputStream;
+            if (!hasDataInBlock && !outputStream) {
                 return false;
             }
-            if (!it->second.OutputStream) {
-                it->second.OutputStream = std::make_unique<NDB::OutputStreamToOutputFormat>(NDB::FormatFactory::instance().getOutputFormat(Type, *Buffer, HeaderBlock, nullptr, {}, Settings));
-                it->second.OutputStream->writePrefix();
+
+            if (!outputStream) {
+                outputStream = std::make_unique<NDB::OutputStreamToOutputFormat>(NDB::FormatFactory::instance().getOutputFormat(Type, *Buffer, HeaderBlock, nullptr, {}, Settings));
+                outputStream->writePrefix();
             }
-            if (it->second.hasDataInBlock) {
-                it->second.OutputStream->write(it->second.Block);
+            if (hasDataInBlock) {
+                outputStream->write(block);
             }
-            it->second.CurrentFileSize += Buffer->stringRef().size;
-            if (it->second.CurrentFileSize >= FileSizeLimit) { // Finish current file.
+
+            auto& currentFileSize = payload.CurrentFileSize;
+            currentFileSize += Buffer->stringRef().size;
+            if (currentFileSize >= FileSizeLimit) { // Finish current file.
                 finishFile = true;
             }
 
-            if (finishFile && hasDataInFile) {
-                it->second.OutputStream->writeSuffix(); // Finish current file with optional footer.
-            }
-            it->second.OutputStream->flush();
-
             if (finishFile) {
-                it->second.OutputStream.reset();
-                it->second.CurrentFileSize = 0;
+                outputStream->writeSuffix(); // Finish current file with optional footer.
             }
-            it->second.Block = HeaderBlock.cloneEmpty();
-            it->second.hasDataInBlock = false;
+            outputStream->flush();
+            block = HeaderBlock.cloneEmpty();
+            hasDataInBlock = false;
 
-            std::string& resultString = Buffer->str();
+            const std::string& resultString = Buffer->str();
             bool hasResult = resultString.size() > 0;
             if (hasResult) {
-                if (KeysIndexes.empty())
+                if (KeysIndexes.empty()) {
                     result = ValueBuilder->NewString(resultString);
-                else {
+                } else {
                     TUnboxedValue* tupleItems = nullptr;
                     result = Cache.NewArray(*ValueBuilder, tupleItems);
                     *tupleItems++ = ValueBuilder->NewString(resultString);
@@ -1131,11 +1159,17 @@ class TSerializeFormat : public TBoxedValue {
                     *tupleItems++ = TUnboxedValue(); // Empty optional as finishing mark of current file.
                     std::copy(it->first.cbegin(), it->first.cend(), tupleItems);
                 }
+
                 if (!hasResult) {
                     FinishCurrentFileFlag = false;
                     result = FinishCurrentFileValue;
                     hasResult = true;
                 }
+
+                if (KeyFlushTimeout) {
+                    PartitionCreationTimes.erase(TPartitionCreationTime(it->second.CreatedAt, it));
+                }
+                PartitionsMap.erase(it);
             }
 
             Buffer->restart();
@@ -1149,22 +1183,38 @@ class TSerializeFormat : public TBoxedValue {
                 return EFetchStatus::Ok;
             }
 
-            if (IsFinished && PartitionsMap.empty())
+            if (IsFinished && PartitionsMap.empty()) {
                 return EFetchStatus::Finish;
+            }
 
             for (TUnboxedValue row; !IsFinished;) {
                 switch (const auto status = Stream.Fetch(row)) {
-                    case EFetchStatus::Yield:
+                    case EFetchStatus::Yield: {
+                        if (KeyFlushTimeout) {
+                            const auto now = TInstant::Now();
+                            while (!PartitionCreationTimes.empty() && PartitionCreationTimes.cbegin()->Time + KeyFlushTimeout < now) {
+                                if (FlushKey(PartitionCreationTimes.cbegin()->Iterator, result, true)) {
+                                    return EFetchStatus::Ok;
+                                }
+                            }
+                        }
                         return EFetchStatus::Yield;
+                    }
                     case EFetchStatus::Ok: {
                         TPartitionByKey keys(KeysIndexes.size());
-                        for (auto i = 0U; i < keys.size(); ++i)
+                        for (auto i = 0U; i < keys.size(); ++i) {
                             keys[i] = row.GetElement(KeysIndexes[i]);
+                        }
 
                         const auto [partIt, insertedNew] = PartitionsMap.emplace(std::move(keys), HeaderBlock.cloneEmpty());
 
-                        if (insertedNew && PartitionsMap.size() > KeysCountLimit) {
-                            UdfTerminate((TStringBuilder() << ValueBuilder->WithCalleePosition(Pos) << " Too many unique keys: " << PartitionsMap.size()).data());
+                        if (insertedNew) {
+                            if (PartitionsMap.size() > KeysCountLimit) {
+                                UdfTerminate((TStringBuilder() << ValueBuilder->WithCalleePosition(Pos) << " Too many unique keys: " << PartitionsMap.size()).data());
+                            }
+                            if (KeyFlushTimeout) {
+                                Y_ABORT_UNLESS(PartitionCreationTimes.emplace(partIt->second.CreatedAt, partIt).second);
+                            }
                         }
 
                         bool flush = !insertedNew && partIt->second.Block.bytes() >= BlockSizeLimit;
@@ -1182,7 +1232,7 @@ class TSerializeFormat : public TBoxedValue {
 
                         TotalSize -= partIt->second.Block.bytes();
                         auto columns = partIt->second.Block.mutateColumns();
-                        partIt->second.hasDataInBlock = true;
+                        partIt->second.HasDataInBlock = true;
                         for (auto i = 0U; i < columns.size(); ++i) {
                             const auto index = PayloadsIndexes[i];
                             ConvertInputValue(row.GetElement(index), columns[i].get(), InMeta[index]);
@@ -1190,33 +1240,32 @@ class TSerializeFormat : public TBoxedValue {
                         partIt->second.Block.setColumns(std::move(columns));
                         TotalSize += partIt->second.Block.bytes();
 
-                        if (flush)
+                        if (flush) {
                             return EFetchStatus::Ok;
-                        else
-                            continue;
+                        }
+
+                        break;
                     }
-                    case EFetchStatus::Finish:
+                    case EFetchStatus::Finish: {
                         IsFinished = true;
                         break;
+                    }
                 }
             }
 
-            if (PartitionsMap.empty() && !FinishCurrentFileFlag)
+            if (PartitionsMap.empty() && !FinishCurrentFileFlag) {
                 return EFetchStatus::Finish;
+            }
 
             while (!PartitionsMap.empty()) {
-                const bool hasResult = FlushKey(PartitionsMap.begin(), result, true);
-                PartitionsMap.erase(PartitionsMap.cbegin());
-                if (hasResult) {
+                if (FlushKey(PartitionsMap.begin(), result, true)) {
                     return EFetchStatus::Ok;
                 }
             }
             return EFetchStatus::Finish;
-        }
-        catch (const Poco::Exception& e) {
+        } catch (const Poco::Exception& e) {
             UdfTerminate((TStringBuilder() << ValueBuilder->WithCalleePosition(Pos) << " " << e.displayText()).data());
-        }
-        catch (const std::exception& e) {
+        } catch (const std::exception& e) {
             UdfTerminate((TStringBuilder() << ValueBuilder->WithCalleePosition(Pos) << " " << e.what()).data());
         }
 
@@ -1229,6 +1278,7 @@ class TSerializeFormat : public TBoxedValue {
         const size_t KeysCountLimit;
         const size_t TotalSizeLimit;
         const size_t FileSizeLimit;
+        const TDuration KeyFlushTimeout;
         const TSourcePosition Pos;
         TUnboxedValue FinishCurrentFileValue;
         bool FinishCurrentFileFlag = false;
@@ -1239,26 +1289,38 @@ class TSerializeFormat : public TBoxedValue {
         const std::string Type;
 
         TPartitionsMap PartitionsMap;
+        std::set<TPartitionCreationTime> PartitionCreationTimes;
 
         TPlainArrayCache Cache;
 
         bool IsFinished = false;
         size_t TotalSize = 0ULL;
     };
+
 public:
-    TSerializeFormat(const std::string_view& type, const std::string_view& settings, std::vector<ui32>&& keysIndexes, std::vector<ui32>&& payloadsIndexes, size_t blockSizeLimit, size_t keysCountLimit, size_t totalSizeLimit, size_t fileSizeLimit, const TSourcePosition& pos, std::vector<TColumnMeta>&& inMeta, NDB::ColumnsWithTypeAndName&& columns)
-        : Type(type), Settings(GetFormatSettings(settings)), KeysIndexes(std::move(keysIndexes)), PayloadsIndexes(std::move(payloadsIndexes)), BlockSizeLimit(blockSizeLimit), KeysCountLimit(keysCountLimit), TotalSizeLimit(totalSizeLimit), FileSizeLimit(fileSizeLimit), Pos(pos), InMeta(std::move(inMeta)), Columns(std::move(columns))
+    TSerializeFormat(const std::string_view& type, const std::string_view& settings, std::vector<ui32>&& keysIndexes, std::vector<ui32>&& payloadsIndexes, size_t blockSizeLimit, size_t keysCountLimit, size_t totalSizeLimit, size_t fileSizeLimit, TDuration keyFlushTimeout, const TSourcePosition& pos, std::vector<TColumnMeta>&& inMeta, NDB::ColumnsWithTypeAndName&& columns)
+        : Type(type)
+        , Settings(GetFormatSettings(settings))
+        , KeysIndexes(std::move(keysIndexes))
+        , PayloadsIndexes(std::move(payloadsIndexes))
+        , BlockSizeLimit(blockSizeLimit)
+        , KeysCountLimit(keysCountLimit)
+        , TotalSizeLimit(totalSizeLimit)
+        , FileSizeLimit(fileSizeLimit)
+        , KeyFlushTimeout(keyFlushTimeout)
+        , Pos(pos)
+        , InMeta(std::move(inMeta))
+        , Columns(std::move(columns))
     {}
 
     TUnboxedValue Run(const IValueBuilder* valueBuilder, const TUnboxedValuePod* args) const final try {
-        return TUnboxedValuePod(new TStreamValue(valueBuilder, *args, Type, Settings, KeysIndexes, PayloadsIndexes, BlockSizeLimit, KeysCountLimit, TotalSizeLimit, FileSizeLimit, InMeta, Columns, Pos));
-    }
-    catch (const Poco::Exception& e) {
+        return TUnboxedValuePod(new TStreamValue(valueBuilder, *args, Type, Settings, KeysIndexes, PayloadsIndexes, BlockSizeLimit, KeysCountLimit, TotalSizeLimit, FileSizeLimit, KeyFlushTimeout, InMeta, Columns, Pos));
+    } catch (const Poco::Exception& e) {
         UdfTerminate((TStringBuilder() << valueBuilder->WithCalleePosition(Pos) << " " << e.displayText()).data());
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
         UdfTerminate((TStringBuilder() << valueBuilder->WithCalleePosition(Pos) << " " << e.what()).data());
     }
+
 private:
     const std::string Type;
     const NDB::FormatSettings Settings;
@@ -1268,6 +1330,7 @@ private:
     const size_t KeysCountLimit;
     const size_t TotalSizeLimit;
     const size_t FileSizeLimit;
+    const TDuration KeyFlushTimeout;
     const TSourcePosition Pos;
 
     const std::vector<TColumnMeta> InMeta;
@@ -1404,10 +1467,9 @@ SIMPLE_UDF(TToYqlType, TOptional<TUtf8>(TUtf8, TUtf8)) {
     return TUnboxedValue();
 }
 
-}
+} // anonymous namespace
 
-class TClickHouseClientModule : public IUdfModule
-{
+class TClickHouseClientModule : public IUdfModule {
 public:
     TClickHouseClientModule() = default;
 
@@ -1426,12 +1488,7 @@ public:
         sink.Add(TStringRef::Of("SerializeFormat"))->SetTypeAwareness();
     }
 
-    void BuildFunctionTypeInfo(
-                        const TStringRef& name,
-                        TType* userType,
-                        const TStringRef& typeConfig,
-                        ui32 flags,
-                        IFunctionTypeInfoBuilder& builder) const final try {
+    void BuildFunctionTypeInfo(const TStringRef& name, TType* userType, const TStringRef& typeConfig, ui32 flags, IFunctionTypeInfoBuilder& builder) const final try {
         LazyInitContext();
         auto argBuilder = builder.Args();
         if (name == "ToYqlType") {
@@ -1615,6 +1672,7 @@ public:
             size_t keysCountLimit = 4096;
             size_t totalSizeLimit = 10_MB;
             size_t fileSizeLimit = 50_MB;
+            TDuration keyFlushTimeout;
             if (!tail.empty()) {
                 const std::string str(tail);
                 const JSON json(str);
@@ -1635,18 +1693,22 @@ public:
                 if (json.has("file_size_limit")) {
                     fileSizeLimit = FromString(TStringBuf(json["file_size_limit"].getString()));
                 }
+                if (json.has("key_flush_timeout_ms")) {
+                    keyFlushTimeout = TDuration::MilliSeconds(FromString<ui64>(TStringBuf(json["key_flush_timeout_ms"].getString())));
+                }
             }
             blockSizeLimit = Min(blockSizeLimit, fileSizeLimit);
 
             builder.UserType(userType);
             builder.Args()->Add(inputType).Done();
-            if (keys.empty())
+            if (keys.empty()) {
                 builder.Returns(builder.Stream()->Item(builder.Optional()->Item<const char*>()));
-            else {
+            } else {
                 const auto tuple = builder.Tuple();
                 tuple->Add(builder.Optional()->Item<const char*>());
-                for (auto k =0U; k < keys.size(); ++k)
+                for (size_t k = 0; k < keys.size(); ++k) {
                     tuple->Add<TUtf8>();
+                }
                 builder.Returns(builder.Stream()->Item(tuple->Build()));
             }
 
@@ -1679,7 +1741,7 @@ public:
                 }
 
                 if (!(flags & TFlags::TypesOnly)) {
-                    builder.Implementation(new TSerializeFormat(typeCfg.substr(0U, jsonFrom), tail, std::move(keyIndexes), std::move(payloadIndexes), blockSizeLimit, keysCountLimit, totalSizeLimit, fileSizeLimit, builder.GetSourcePosition(), std::move(inMeta), std::move(columns)));
+                    builder.Implementation(new TSerializeFormat(typeCfg.substr(0U, jsonFrom), tail, std::move(keyIndexes), std::move(payloadIndexes), blockSizeLimit, keysCountLimit, totalSizeLimit, fileSizeLimit, keyFlushTimeout, builder.GetSourcePosition(), std::move(inMeta), std::move(columns)));
                 }
                 return;
             } else {
@@ -1722,13 +1784,12 @@ public:
                 return builder.SetError(sb);
             }
         }
-    }
-    catch (const Poco::Exception& e) {
+    } catch (const Poco::Exception& e) {
         builder.SetError(e.displayText());
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
         builder.SetError(TStringBuf(e.what()));
     }
+
 private:
     void LazyInitContext() const {
         const std::unique_lock lock(CtxMutex);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Enabled S3 write in streaming queries:

```
CREATE STREAMING QUERY query AS DO BEGIN

INSERT INTO s3_sink.`path/`
SELECT * FROM topic_source.topic_name

AND DO
```

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Note:** for all formats except `raw` and `json_each_row` there is no at least once guarantee due to buffering in CH udf serializer 
