### PR TITLE
Fix and optimize the distributed commit logic

### DIFF
--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
@@ -57,37 +57,47 @@ bool TTxBlobsWritingFinished::DoExecute(TTransactionContext& txc, const TActorCo
     std::set<TOperationWriteId> operationIds;
     for (auto&& writeResult : Pack.GetWriteResults()) {
         const auto& writeMeta = writeResult.GetWriteMeta();
-        auto operation = Self->OperationsManager->GetOperationVerified((TOperationWriteId)writeMeta.GetWriteId());
-        if (!operationIds.emplace(operation->GetWriteId()).second) {
+        auto op = Self->OperationsManager->GetOperationVerified((TOperationWriteId)writeMeta.GetWriteId());
+        if (!operationIds.emplace(op->GetWriteId()).second) {
             continue;
         }
         AFL_VERIFY(Self->TablesManager.IsReadyForFinishWrite(writeMeta.GetPathId().InternalPathId, minReadSnapshot));
-        Y_ABORT_UNLESS(operation->GetStatus() == EOperationStatus::Started);
-        if (operation->GetBehaviour() == EOperationBehaviour::NoTxWrite) {
-            operation->OnWriteFinish(txc, {}, true);
+        Y_ABORT_UNLESS(op->GetStatus() == EOperationStatus::Started);
+        if (op->GetBehaviour() == EOperationBehaviour::NoTxWrite) {
+            op->OnWriteFinish(txc, {}, true);
         } else {
-            operation->OnWriteFinish(txc, InsertWriteIds, false);
-            Self->OperationsManager->LinkInsertWriteIdToOperationWriteId(InsertWriteIds, operation->GetWriteId());
+            op->OnWriteFinish(txc, InsertWriteIds, false);
+            Self->OperationsManager->LinkInsertWriteIdToOperationWriteId(InsertWriteIds, op->GetWriteId());
         }
-        if (operation->GetBehaviour() == EOperationBehaviour::NoTxWrite) {
-            LWPROBE(EvWriteResult, Self->TabletID(), writeMeta.GetSource().ToString(), 0, operation->GetCookie(), "no_tx_write", true, "");
+        if (op->GetBehaviour() == EOperationBehaviour::NoTxWrite) {
+            LWPROBE(EvWriteResult, Self->TabletID(), writeMeta.GetSource().ToString(), 0, op->GetCookie(), "no_tx_write", true, "");
             auto ev = NEvents::TDataEvents::TEvWriteResult::BuildCompleted(Self->TabletID());
             AddTableAccessStatsToTxStats(*ev->Record.MutableTxStats(), writeMeta.GetPathId().SchemeShardLocalPathId.GetRawValue(),
-                                         writeResult.GetRecordsCount(), writeResult.GetDataSize(), operation->GetModificationType(), Self->TabletID());
-            Results.emplace_back(std::move(ev), writeMeta.GetSource(), operation->GetCookie());
+                                         writeResult.GetRecordsCount(), writeResult.GetDataSize(), op->GetModificationType(), Self->TabletID());
+            Results.emplace_back(std::move(ev), writeMeta.GetSource(), op->GetCookie());
+
+            if (Self->GetOperationsManager().HasReadLocks(writeMeta.GetPathId().InternalPathId)) {
+                // detect active reads which the given noTxWrite has conflicts with
+                auto evWrite = std::make_shared<NOlap::NTxInteractions::TEvWriteWriter>(
+                    writeMeta.GetPathId().InternalPathId, writeResult.GetPKBatchVerified(), Self->GetIndexOptional()->GetVersionedIndex().GetPrimaryKey());
+                Self->GetOperationsManager().AddEventForLock(*Self, op->GetLockId(), evWrite);
+                // No tx writes (bulk upsert) must break decent/proper txs.
+                // Decent/proper txs asked for isolation, so we have to give them isolation. 
+                Self->OperationsManager->BreakConflictingTxs(op->GetLockId(), txc);
+            }
         } else {
-            auto& info = Self->OperationsManager->GetLockVerified(operation->GetLockId());
+            auto& info = Self->OperationsManager->GetLockVerified(op->GetLockId());
             NKikimrDataEvents::TLock lock;
-            lock.SetLockId(operation->GetLockId());
+            lock.SetLockId(op->GetLockId());
             lock.SetDataShard(Self->TabletID());
             lock.SetGeneration(info.GetGeneration());
             lock.SetCounter(info.GetInternalGenerationCounter());
             writeMeta.GetPathId().SchemeShardLocalPathId.ToProto(lock);
-            LWPROBE(EvWriteResult, Self->TabletID(), writeMeta.GetSource().ToString(), 0, operation->GetCookie(), "tx_write", true, "");
-            auto ev = NEvents::TDataEvents::TEvWriteResult::BuildCompleted(Self->TabletID(), operation->GetLockId(), lock);
+            LWPROBE(EvWriteResult, Self->TabletID(), writeMeta.GetSource().ToString(), 0, op->GetCookie(), "tx_write", true, "");
+            auto ev = NEvents::TDataEvents::TEvWriteResult::BuildCompleted(Self->TabletID(), op->GetLockId(), lock);
             AddTableAccessStatsToTxStats(*ev->Record.MutableTxStats(), writeMeta.GetPathId().SchemeShardLocalPathId.GetRawValue(),
-                                         writeResult.GetRecordsCount(), writeResult.GetDataSize(), operation->GetModificationType(), Self->TabletID());
-            Results.emplace_back(std::move(ev), writeMeta.GetSource(), operation->GetCookie());
+                                         writeResult.GetRecordsCount(), writeResult.GetDataSize(), op->GetModificationType(), Self->TabletID());
+            Results.emplace_back(std::move(ev), writeMeta.GetSource(), op->GetCookie());
         }
     }
     TransactionTime = TInstant::Now() - startTransactionTime;
@@ -116,13 +126,11 @@ void TTxBlobsWritingFinished::DoComplete(const TActorContext& ctx) {
         }
         auto op = Self->GetOperationsManager().GetOperationVerified((TOperationWriteId)writeMeta.GetWriteId());
         pathIds.emplace(op->GetPathId().InternalPathId);
-        if (op->GetBehaviour() == EOperationBehaviour::WriteWithLock || op->GetBehaviour() == EOperationBehaviour::NoTxWrite) {
-            if (op->GetBehaviour() != EOperationBehaviour::NoTxWrite || Self->GetOperationsManager().HasReadLocks(writeMeta.GetPathId().InternalPathId)) {
-                // detect active reads which the given tx has conflicts with
-                auto evWrite = std::make_shared<NOlap::NTxInteractions::TEvWriteWriter>(
-                    writeMeta.GetPathId().InternalPathId, writeResult.GetPKBatchVerified(), Self->GetIndexOptional()->GetVersionedIndex().GetPrimaryKey());
-                Self->GetOperationsManager().AddEventForLock(*Self, op->GetLockId(), evWrite);
-            }
+        if (op->GetBehaviour() == EOperationBehaviour::WriteWithLock) {
+            // detect active reads which the given tx has conflicts with
+            auto evWrite = std::make_shared<NOlap::NTxInteractions::TEvWriteWriter>(
+                writeMeta.GetPathId().InternalPathId, writeResult.GetPKBatchVerified(), Self->GetIndexOptional()->GetVersionedIndex().GetPrimaryKey());
+            Self->GetOperationsManager().AddEventForLock(*Self, op->GetLockId(), evWrite);
         }
     }
     auto& index = Self->MutableIndexAs<NOlap::TColumnEngineForLogs>();
@@ -142,9 +150,6 @@ void TTxBlobsWritingFinished::DoComplete(const TActorContext& ctx) {
         auto op = Self->GetOperationsManager().GetOperationVerified((TOperationWriteId)writeMeta.GetWriteId());
         if (op->GetBehaviour() == EOperationBehaviour::NoTxWrite) {
             AFL_VERIFY(CommitSnapshot);
-            // No tx writes (bulk upsert) must break decent/proper txs.
-            // Decent/proper txs asked for serializable, so we have to give them serializable. 
-            Self->OperationsManager->BreakConflictingTxs(op->GetLockId());
             Self->OperationsManager->CommitTransactionOnComplete(*Self, 0, op->GetLockId(), *CommitSnapshot);
             Self->Counters.GetTabletCounters()->IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
         } else {

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -1014,21 +1014,17 @@ void TColumnShard::Handle(NActors::TEvents::TEvUndelivered::TPtr& ev, const TAct
 
 void TColumnShard::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorContext& ctx) {
     const ui64 txId = ev->Get()->Record.GetTxId();
+    const ui64 tabletDest = ev->Get()->Record.GetTabletProducer();
     if (!GetProgressTxController().GetTxOperatorOptional(txId)) {
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "read_set_ignored")("proto", ev->Get()->Record.DebugString());
-        Send(MakePipePerNodeCacheID(false),
-            new TEvPipeCache::TEvForward(
-                new TEvTxProcessing::TEvReadSetAck(ev->Get()->Record.GetStep(), txId, TabletID(), ev->Get()->Record.GetTabletProducer(), TabletID(), 0),
-                ev->Get()->Record.GetTabletProducer(), true),
-            IEventHandle::FlagTrackDelivery, txId);
+        TEvWriteCommitSyncTransactionOperator::SendBrokenFlagAck(*this, ev->Get()->Record.GetStep(), txId, tabletDest);
         return;
     }
     auto op = GetProgressTxController().GetTxOperatorVerifiedAs<TEvWriteCommitSyncTransactionOperator>(txId);
     AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "read_set")("proto", ev->Get()->Record.DebugString())("lock_id", op->GetLockId());
     NKikimrTx::TReadSetData data;
     AFL_VERIFY(data.ParseFromArray(ev->Get()->Record.GetReadSet().data(), ev->Get()->Record.GetReadSet().size()));
-    auto tx = op->CreateReceiveBrokenFlagTx(
-        *this, ev->Get()->Record.GetTabletProducer(), data.GetDecision() != NKikimrTx::TReadSetData::DECISION_COMMIT);
+    auto tx = op->CreateReceiveBrokenFlagTx(*this, tabletDest, data.GetDecision() != NKikimrTx::TReadSetData::DECISION_COMMIT);
     Execute(tx.release(), ctx);
 }
 

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -163,6 +163,7 @@ template <typename T>
 using TTransactionBase = NTabletFlatExecutor::TTransactionBase<T>;
 
 class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTabletExecutedFlat {
+    friend class TEvWriteCommitSyncTransactionOperator;
     friend class TEvWriteCommitSecondaryTransactionOperator;
     friend class TEvWriteCommitPrimaryTransactionOperator;
     friend class TTxInit;

--- a/ydb/core/tx/columnshard/columnshard_schema.h
+++ b/ydb/core/tx/columnshard/columnshard_schema.h
@@ -373,9 +373,10 @@ struct Schema : NIceDb::Schema {
     struct OperationTxIds : NIceDb::Schema::Table<OperationTxIdsId> {
         struct TxId : Column<1, NScheme::NTypeIds::Uint64> {};
         struct LockId : Column<2, NScheme::NTypeIds::Uint64> {};
+        struct Broken: Column<3, NScheme::NTypeIds::Bool> {};
 
         using TKey = TableKey<TxId, LockId>;
-        using TColumns = TableColumns<TxId, LockId>;
+        using TColumns = TableColumns<TxId, LockId, Broken>;
     };
 
     struct TierBlobsDraft: NIceDb::Schema::Table<(ui32)ETierTables::TierBlobsDraft> {

--- a/ydb/core/tx/columnshard/operations/manager.cpp
+++ b/ydb/core/tx/columnshard/operations/manager.cpp
@@ -36,10 +36,7 @@ bool TOperationsManager::Load(NTabletFlatExecutor::TTransactionContext& txc) {
             AFL_VERIFY(Operations.emplace(operation->GetWriteId(), operation).second);
             LinkInsertWriteIdToOperationWriteId(operation->GetInsertWriteIds(), operation->GetWriteId());
 
-            auto it = LockFeatures.find(lockId);
-            if (it == LockFeatures.end()) {
-                it = LockFeatures.emplace(lockId, TLockFeatures(lockId, 0)).first;
-            }
+            auto it = LockFeatures.try_emplace(lockId, lockId, 0).first;
             it->second.AddWriteOperation(operation);
             // all the operations are finished at the moment of transaction proposal (or later) 
             it->second.OnWriteOperationFinished();
@@ -60,10 +57,7 @@ bool TOperationsManager::Load(NTabletFlatExecutor::TTransactionContext& txc) {
             const ui64 txId = rowset.GetValue<Schema::OperationTxIds::TxId>();
             const bool broken = rowset.GetValueOrDefault<Schema::OperationTxIds::Broken>(true);
 
-            auto it = LockFeatures.find(lockId);
-            if (it == LockFeatures.end()) {
-                it = LockFeatures.emplace(lockId, TLockFeatures(lockId, 0)).first;
-            }
+            auto it = LockFeatures.try_emplace(lockId, lockId, 0).first;
             auto& lock = it->second;
 
             lock.SetTxId(txId);

--- a/ydb/core/tx/columnshard/operations/manager.cpp
+++ b/ydb/core/tx/columnshard/operations/manager.cpp
@@ -4,6 +4,18 @@
 
 namespace NKikimr::NColumnShard {
 
+void TLockFeatures::SetTxId(const ui64 txId) {
+    AFL_VERIFY(!TxId || TxId == txId)("tx_id", txId)("lock_id", GetLockId())("tx_id_assigned", TxId);
+    TxId = txId;
+}
+bool TLockFeatures::IsTxIdAssigned() const {
+    return TxId != 0;
+}
+ui64 TLockFeatures::GetTxId() const {
+    AFL_VERIFY(IsTxIdAssigned())("lock_id", GetLockId());
+    return TxId;
+}
+
 bool TOperationsManager::Load(NTabletFlatExecutor::TTransactionContext& txc) {
     NIceDb::TNiceDb db(txc.DB);
     {

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -150,6 +150,10 @@ public:
     bool IsTxIdAssigned() const {
         return TxId != 0;
     }
+    ui64 GetTxId() const {
+        AFL_VERIFY(IsTxIdAssigned())("lock_id", GetLockId());
+        return TxId;
+    }
 
     bool IsCommitted(const ui64 lockId) const {
         return Committed.contains(lockId);
@@ -235,13 +239,14 @@ public:
         TColumnShard& owner, const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc, const NOlap::TSnapshot& snapshot);
     void CommitTransactionOnComplete(
         TColumnShard& owner, const ui64 txId, const ui64 lockId, const NOlap::TSnapshot& snapshot);
-    void LinkTransactionOnExecute(const ui64 lockId, const ui64 txId, NTabletFlatExecutor::TTransactionContext& txc);
+    void LinkTransactionOnExecute(TLockFeatures& lock, NTabletFlatExecutor::TTransactionContext& txc);
+    void PersistLock(TLockFeatures& lock, NTabletFlatExecutor::TTransactionContext& txc);
     void LinkTransactionOnComplete(const ui64 lockId, const ui64 txId);
     void AbortTransactionOnExecute(TColumnShard& owner, const ui64 txId, const ui64 lockId, NTabletFlatExecutor::TTransactionContext& txc);
     void AbortTransactionOnComplete(TColumnShard& owner, const ui64 txId, const ui64 lockId);
 
-    void BreakConflictingTxs(const TLockFeatures& lock);
-    void BreakConflictingTxs(const ui64 lockId);
+    void BreakConflictingTxs(const TLockFeatures& lock, NTabletFlatExecutor::TTransactionContext& txc);
+    void BreakConflictingTxs(const ui64 lockId, NTabletFlatExecutor::TTransactionContext& txc);
 
     std::optional<ui64> GetLockForTx(const ui64 txId) const;
     std::optional<ui64> GetLockForTxOptional(const ui64 txId) const {

--- a/ydb/core/tx/columnshard/operations/manager.h
+++ b/ydb/core/tx/columnshard/operations/manager.h
@@ -143,17 +143,9 @@ public:
         return Aborted;
     }
 
-    void SetTxId(const ui64 txId) {
-        AFL_VERIFY(!TxId || TxId == txId)("tx_id", txId)("lock_id", GetLockId())("tx_id_assigned", TxId);
-        TxId = txId;
-    }
-    bool IsTxIdAssigned() const {
-        return TxId != 0;
-    }
-    ui64 GetTxId() const {
-        AFL_VERIFY(IsTxIdAssigned())("lock_id", GetLockId());
-        return TxId;
-    }
+    void SetTxId(const ui64 txId);
+    bool IsTxIdAssigned() const; 
+    ui64 GetTxId() const;
 
     bool IsCommitted(const ui64 lockId) const {
         return Committed.contains(lockId);

--- a/ydb/core/tx/columnshard/transactions/operators/ev_write/abstract.h
+++ b/ydb/core/tx/columnshard/transactions/operators/ev_write/abstract.h
@@ -18,7 +18,8 @@ protected:
 private:
     virtual bool DoParseImpl(TColumnShard& owner, const NKikimrTxColumnShard::TCommitWriteTxBody& commitTxBody) = 0;
     virtual TProposeResult DoStartProposeOnExecute(TColumnShard& owner, NTabletFlatExecutor::TTransactionContext& txc) override final {
-        owner.GetOperationsManager().LinkTransactionOnExecute(LockId, GetTxId(), txc);
+        auto& lock = owner.GetOperationsManager().GetLockVerified(LockId);
+        owner.GetOperationsManager().LinkTransactionOnExecute(lock, txc);
         return TProposeResult();
     }
     virtual void DoStartProposeOnComplete(TColumnShard& owner, const TActorContext& /*ctx*/) override final {

--- a/ydb/core/tx/columnshard/transactions/operators/ev_write/primary.h
+++ b/ydb/core/tx/columnshard/transactions/operators/ev_write/primary.h
@@ -231,7 +231,6 @@ private:
     };
 
     virtual void OnTimeout(TColumnShard& owner) override {
-        AFL_ERROR(NKikimrServices::TX_COLUMNSHARD_TX)("iea", "primary on timeout")("wait_broken_flags", WaitShardsBrokenFlags.size())("wait_result_ack", WaitShardsResultAck.size());
         InitializeRequests(owner);
     }
 

--- a/ydb/core/tx/columnshard/transactions/operators/ev_write/primary.h
+++ b/ydb/core/tx/columnshard/transactions/operators/ev_write/primary.h
@@ -78,41 +78,45 @@ private:
     private:
         using TBase = TExtendedTransactionBase;
         const ui64 TxId;
+        const ui64 Step;
         const ui64 TabletId;
         const bool BrokenFlag;
-        bool SendAckFlag = false;
+        TEvTxProcessing::TEvReadSetAck* BrokenFlagAck = nullptr;
 
         virtual bool DoExecute(NTabletFlatExecutor::TTransactionContext& txc, const NActors::TActorContext& /*ctx*/) override {
             auto op = Self->GetProgressTxController().GetTxOperatorVerifiedAs<TEvWriteCommitPrimaryTransactionOperator>(TxId, true);
             if (!op) {
-                AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "repeated shard broken_flag info")("shard_id", TabletId)("reason", "absent operation");
-            } else if (!op->WaitShardsBrokenFlags.contains(TabletId)) {
+                AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "repeated shard broken_flag info, operator not found")("shard_id", TabletId);
+                // send the ack anyway, so that the secondary waits less time to progress
+                TEvWriteCommitSyncTransactionOperator::SendBrokenFlagAck(*Self, Step, TxId, TabletId);
+                return true;
+            }
+            
+            BrokenFlagAck = TEvWriteCommitSyncTransactionOperator::MakeBrokenFlagAck(op->GetStep(), op->GetTxId(), Self->TabletID(), TabletId);
+            if (!op->WaitShardsBrokenFlags.erase(TabletId)) {
                 AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "repeated shard broken_flag info")("shard_id", TabletId);
+                // we cannot send the ack here, because the previous transaction (that successfully erased TabletId) may be not completed yet
             } else {
                 op->TxBroken = op->TxBroken.value_or(false) || BrokenFlag;
                 Self->GetProgressTxController().WriteTxOperatorInfo(txc, TxId, op->SerializeToProto().SerializeAsString());
-                SendAckFlag = true;
+                // we cannot send the ack right away, we must make sure that we have stored the TxBroken value
+                // but we can proceed right away if we have collected all the broken flags from the secondary
+                op->InitializeRequests(*Self);
             }
             return true;
         }
+
         virtual void DoComplete(const NActors::TActorContext& /*ctx*/) override {
-            auto op = Self->GetProgressTxController().GetTxOperatorVerifiedAs<TEvWriteCommitPrimaryTransactionOperator>(TxId, true);
-            if (!op) {
-                AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "repeated shard broken_flag info")("shard_id", TabletId)("reason", "absent operator");
-            } else if (!SendAckFlag || !op->WaitShardsBrokenFlags.erase(TabletId)) {
-                AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "repeated shard broken_flag info")("shard_id", TabletId);
-            } else {
-                AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "remove_tablet_id")("wait", JoinSeq(",", op->WaitShardsBrokenFlags))(
-                    "receive", TabletId);
-                op->SendBrokenFlagAck(*Self, TabletId);
-                op->InitializeRequests(*Self);
+            if (BrokenFlagAck != nullptr) {
+                TEvWriteCommitSyncTransactionOperator::SendBrokenFlagAck(*Self, BrokenFlagAck);
             }
         }
 
     public:
-        TTxWriteReceivedBrokenFlag(TColumnShard& owner, const ui64 txId, const ui64 tabletId, const bool broken)
+        TTxWriteReceivedBrokenFlag(TColumnShard& owner, const ui64 txId, const ui64 step, const ui64 tabletId, const bool broken)
             : TBase(&owner, ::ToString(txId))
             , TxId(txId)
+            , Step(step)
             , TabletId(tabletId)
             , BrokenFlag(broken) {
         }
@@ -120,7 +124,7 @@ private:
 
     virtual std::unique_ptr<NTabletFlatExecutor::ITransaction> CreateReceiveBrokenFlagTx(
         TColumnShard& owner, const ui64 sendTabletId, const bool broken) const override {
-        return std::make_unique<TTxWriteReceivedBrokenFlag>(owner, GetTxId(), sendTabletId, broken);
+        return std::make_unique<TTxWriteReceivedBrokenFlag>(owner, GetTxId(), GetStep(), sendTabletId, broken);
     }
 
     class TTxWriteReceivedResultAck: public TExtendedTransactionBase {
@@ -132,14 +136,11 @@ private:
         virtual bool DoExecute(NTabletFlatExecutor::TTransactionContext& txc, const NActors::TActorContext& /*ctx*/) override {
             auto op = Self->GetProgressTxController().GetTxOperatorVerifiedAs<TEvWriteCommitPrimaryTransactionOperator>(TxId, true);
             if (!op) {
-                AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "ack_tablet_duplication")("receive", TabletId)(
-                    "reason", "operation absent");
+                AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "ack_tablet_duplication")("receive", TabletId)("reason", "operation absent");
             } else if (!op->WaitShardsResultAck.erase(TabletId)) {
-                AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "ack_tablet_duplication")("wait", JoinSeq(",", op->WaitShardsResultAck))(
-                    "receive", TabletId);
+                AFL_WARN(NKikimrServices::TX_COLUMNSHARD_TX)("event", "ack_tablet_duplication")("wait", JoinSeq(",", op->WaitShardsResultAck))("receive", TabletId);
             } else {
-                AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "ack_tablet")("wait", JoinSeq(",", op->WaitShardsResultAck))(
-                    "receive", TabletId);
+                AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "ack_tablet")("wait", JoinSeq(",", op->WaitShardsResultAck))("receive", TabletId);
                 Self->GetProgressTxController().WriteTxOperatorInfo(txc, TxId, op->SerializeToProto().SerializeAsString());
                 op->CheckFinished(*Self);
             }
@@ -184,31 +185,14 @@ private:
         return std::make_unique<TTxWriteReceivedResultAck>(owner, GetTxId(), recvTabletId);
     }
 
-    void SendBrokenFlagAck(TColumnShard& owner, const std::optional<ui64> tabletId = {}) {
-        for (auto&& i : SendingShards) {
-            if (!WaitShardsBrokenFlags.contains(i)) {
-                if (tabletId && *tabletId != i) {
-                    continue;
-                }
-                owner.Send(MakePipePerNodeCacheID(EPipePerNodeCache::Persistent),
-                    new TEvPipeCache::TEvForward(
-                        new TEvTxProcessing::TEvReadSetAck(GetStep(), GetTxId(), owner.TabletID(), i, owner.TabletID(), 0), i, true),
-                    IEventHandle::FlagTrackDelivery, GetTxId());
-            }
-        }
-    }
-
     void SendResult(TColumnShard& owner) {
         AFL_VERIFY(!!TxBroken);
         NKikimrTx::TReadSetData readSetData;
         readSetData.SetDecision(*TxBroken ? NKikimrTx::TReadSetData::DECISION_ABORT : NKikimrTx::TReadSetData::DECISION_COMMIT);
-        for (auto&& i : ReceivingShards) {
-            if (WaitShardsResultAck.contains(i)) {
-                owner.Send(MakePipePerNodeCacheID(EPipePerNodeCache::Persistent),
-                    new TEvPipeCache::TEvForward(new TEvTxProcessing::TEvReadSet(TxInfo.PlanStep, GetTxId(), owner.TabletID(), i,
-                                                     owner.TabletID(), readSetData.SerializeAsString()),
-                        i, true),
-                    IEventHandle::FlagTrackDelivery, GetTxId());
+        for (auto&& tabletDest : ReceivingShards) {
+            if (WaitShardsResultAck.contains(tabletDest)) {
+                auto* event = new TEvTxProcessing::TEvReadSet(TxInfo.PlanStep, GetTxId(), owner.TabletID(), tabletDest, owner.TabletID(), readSetData.SerializeAsString());
+                TEvWriteCommitSyncTransactionOperator::SendPersistent(owner, event, tabletDest, GetTxId());
             }
         }
     }
@@ -232,15 +216,11 @@ private:
                 AFL_VERIFY(op->WaitShardsResultAck.erase(Self->TabletID()));
                 AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_TX)("event", "remove_tablet_id")("wait_broken_flags", JoinSeq(",", op->WaitShardsBrokenFlags))("wait_result_ack", JoinSeq(",", op->WaitShardsResultAck))("receive", Self->TabletID());
                 Self->GetProgressTxController().WriteTxOperatorInfo(txc, TxId, op->SerializeToProto().SerializeAsString());
+                op->InitializeRequests(*Self);
             }
             return true;
         }
         virtual void DoComplete(const NActors::TActorContext& /*ctx*/) override {
-            // the tx may already be finished and the operator deleted,
-            // and that is good, we improve the latency!
-            if (auto op = Self->GetProgressTxController().GetTxOperatorVerifiedAs<TEvWriteCommitPrimaryTransactionOperator>(TxId, true)) {
-                op->InitializeRequests(*Self);
-            }
         }
 
     public:
@@ -251,6 +231,7 @@ private:
     };
 
     virtual void OnTimeout(TColumnShard& owner) override {
+        AFL_ERROR(NKikimrServices::TX_COLUMNSHARD_TX)("iea", "primary on timeout")("wait_broken_flags", WaitShardsBrokenFlags.size())("wait_result_ack", WaitShardsResultAck.size());
         InitializeRequests(owner);
     }
 

--- a/ydb/core/tx/columnshard/transactions/operators/ev_write/secondary.h
+++ b/ydb/core/tx/columnshard/transactions/operators/ev_write/secondary.h
@@ -175,6 +175,9 @@ private:
             op->SelfBroken = lock.IsBroken();
             Self->GetProgressTxController().WriteTxOperatorInfo(txc, TxId, op->SerializeToProto().SerializeAsString());
             if (!op->ReceiveAck) {
+                // We send the result here before SelfBroken is truly persisted, yes.
+                // But we persist lock.IsBroken(), so if the secondary crushes and restarts,
+                // the secondary will send the same result again, and the primary will ignore it (if already processed)
                 op->SendResult(*Self);
             }
             return true;

--- a/ydb/core/tx/columnshard/transactions/operators/ev_write/secondary.h
+++ b/ydb/core/tx/columnshard/transactions/operators/ev_write/secondary.h
@@ -202,7 +202,6 @@ private:
     }
 
     virtual void OnTimeout(TColumnShard& owner) override {
-        AFL_ERROR(NKikimrServices::TX_COLUMNSHARD_TX)("iea", "secondary on timeout")("receive_ack", ReceiveAck)("tx_broken_has_value", TxBroken.has_value());
         if (!ReceiveAck) {
             SendResult(owner);
         }

--- a/ydb/core/tx/columnshard/transactions/tx_controller.cpp
+++ b/ydb/core/tx/columnshard/transactions/tx_controller.cpp
@@ -199,11 +199,11 @@ void TTxController::ProgressOnExecute(const ui64 txId, NTabletFlatExecutor::TTra
     AFL_VERIFY(opIt != Operators.end())("tx_id", txId);
     Counters.OnFinishPlannedTx(opIt->second->GetOpType());
     AFL_NOTICE(NKikimrServices::TX_COLUMNSHARD_TX)("event", "finished_tx")("tx_id", txId);
-    OnTxCompleted(txId);
     Schema::EraseTxInfo(db, txId);
 }
 
 void TTxController::ProgressOnComplete(const TPlanQueueItem& txItem) {
+    OnTxCompleted(txItem.TxId);
     AFL_VERIFY(RunningQueue.erase(txItem))("info", txItem.DebugString());
 }
 


### PR DESCRIPTION
fixes #31556 #28769 #28768

See the problem details in the issues.

# Correctness

Here I changed how primary and secondary handles the state persisting - it fixes the issues.

After the changes I ran jepsen + nemesis for 24 hours. The cluster consisted of 8 nodes, nemesis crushed a random node every in 30 seconds. Nemesis crushed only 3 out of 8 nodes (for example: 1, 2, 3), it was intentional, so that we can see if other nodes crush. We expect that none of the other 5 nodes ever crush.

No anomalies were found
<img width="944" height="467" alt="image" src="https://github.com/user-attachments/assets/2eec3a2c-f83a-49ae-8806-97dcfd20bc0d" />

No nodes have crushed (except for 3 that nemesis crushed)
<img width="1111" height="395" alt="image" src="https://github.com/user-attachments/assets/132457bc-fa01-4da2-8a34-dfe4ca97a9df" />

I have also run jepsen for 24 hours with with an especially sinister nemesis: nemesis crushed a random node every 10 seconds, this time with no exceptions, so all the nodes were regularly crushed. Success, no anomalies.

<img width="959" height="613" alt="image" src="https://github.com/user-attachments/assets/7f83a5b3-b9fa-40cc-9dd0-61e57abaf51f" />


# Faster commit

Also I made the shards progress faster, that is, for example, primary progress the state right in Execute instead of Complete. It must reduce the latency of the distributed commit.

Here I measured the commit time before and after changes. I ran jepsen (without nemesis) for an hour on my slice.
commit latency before: https://nda.ya.ru/t/IOLTw36v7SCHU7
commit latency with the fixes: https://nda.ya.ru/t/3D06A-Fg7SCHZK

|  latency ms  | p50         |       p90     |       p99        | max during the whole run     |
| -------|--------|-------------|-------------|----------------------------|
|before  |  24.31      |       36.03 |       62.58      |  131.07   |
| now     |   17.81   |   29.97        |       37.79       |   131.07  |
| diff      |   27%    |    17%         |        40%       |   equal    |

