### PR TITLE
YQ-5013 fixed S3 async decompression

### DIFF
--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -102,6 +102,8 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
             appConfig->MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(true);
         }
 
+        appConfig->MutableQueryServiceConfig()->MutableS3()->SetAllowLocalFiles(true);
+
         auto settings = TKikimrSettings(*appConfig);
 
         NYql::IHTTPGateway::TPtr httpGateway;

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -2870,6 +2870,177 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
         UNIT_ASSERT_STRING_CONTAINS(issues, "Field 'data' has incompatible with S3 json_list input format type: Variant");
     }
 
+    Y_UNIT_TEST(TestReadingFromFileValidation) {
+        {
+            TFileOutput out("data.txt");
+            out << R"({"data": "test_data"})";
+        }
+
+        auto kikimr = NTestUtils::MakeKikimrRunner();
+        auto tc = kikimr->GetTableClient();
+        auto session = tc.CreateSession().ExtractValueSync().GetSession();
+        {
+            const TString query = R"(
+                CREATE EXTERNAL DATA SOURCE test_bucket WITH (
+                    SOURCE_TYPE = "ObjectStorage",
+                    LOCATION = "file://./",
+                    AUTH_METHOD = "NONE"
+                );)";
+            const auto result = session.ExecuteSchemeQuery(query).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        auto db = kikimr->GetQueryClient();
+        {
+            const TString query = R"(
+                SELECT * FROM test_bucket.`data.txt` WITH (
+                    FORMAT = raw,
+                    SCHEMA (
+                        data String
+                    )
+                );
+            )";
+            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            const auto& issues = result.GetIssues().ToString();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, issues);
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Reading from files is not supported with format 'raw'");
+        }
+
+        {
+            const TString query = R"(
+                PRAGMA s3.AsyncDecompressing = "TRUE";
+
+                SELECT * FROM test_bucket.`data.txt` WITH (
+                    FORMAT = json_each_row,
+                    SCHEMA (
+                        data String
+                    )
+                );
+            )";
+            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            const auto& issues = result.GetIssues().ToString();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, issues);
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Reading from files is not supported with enabled pragma s3.AsyncDecompressing, to read from files use: PRAGMA s3.AsyncDecompressing = \"FALSE\"");
+        }
+
+        {
+            const TString query = R"(
+                PRAGMA s3.UseRuntimeListing = "TRUE";
+
+                SELECT * FROM test_bucket.`/` WITH (
+                    FORMAT = json_each_row,
+                    SCHEMA (
+                        data String
+                    )
+                );
+            )";
+            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            const auto& issues = result.GetIssues().ToOneLineString();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, issues);
+            UNIT_ASSERT_STRING_CONTAINS(issues, "Subdirectory listing is not supported for local files (can not use delimiter: '/')");
+        }
+    }
+
+    Y_UNIT_TEST(TestAsyncDecompressionErrorHandle) {
+        const TString bucket = "test_async_decompressing_error_bucket";
+        CreateBucketWithObject(bucket, "test/data.json", R"({"data": "test_data"})");
+
+        auto kikimr = NTestUtils::MakeKikimrRunner();
+        auto tc = kikimr->GetTableClient();
+        auto session = tc.CreateSession().ExtractValueSync().GetSession();
+        {
+            const TString query = fmt::format(R"(
+                CREATE EXTERNAL DATA SOURCE test_bucket WITH (
+                    SOURCE_TYPE = "ObjectStorage",
+                    LOCATION = "{location}",
+                    AUTH_METHOD = "NONE"
+                );)",
+                "location"_a = GetBucketLocation(bucket)
+            );
+            const auto result = session.ExecuteSchemeQuery(query).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        auto db = kikimr->GetQueryClient();
+
+        const TString query = R"(
+            PRAGMA s3.AsyncDecompressing = "TRUE";
+
+            SELECT * FROM test_bucket.`test/data.json` WITH (
+                FORMAT = json_each_row,
+                COMPRESSION = zstd,
+                SCHEMA (
+                    data String
+                )
+            );
+        )";
+        const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+        const auto& issues = result.GetIssues().ToString();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, issues);
+        UNIT_ASSERT_STRING_CONTAINS(issues, "Error while reading file test/data.json");
+        UNIT_ASSERT_STRING_CONTAINS(issues, "Decompress failed: Unknown frame descriptor");
+    }
+
+    Y_UNIT_TEST(TestAsyncDecompressionWithLargeFile) {
+        const TString bucket = "test_async_decompressing_with_large_file_bucket";
+        CreateBucket(bucket);
+
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableQueryServiceConfig()->MutableS3()->SetDataInflight(1_KB);
+
+        auto kikimr = NTestUtils::MakeKikimrRunner(appConfig);
+        auto tc = kikimr->GetTableClient();
+        auto session = tc.CreateSession().ExtractValueSync().GetSession();
+        {
+            const TString query = fmt::format(R"(
+                CREATE EXTERNAL DATA SOURCE test_bucket WITH (
+                    SOURCE_TYPE = "ObjectStorage",
+                    LOCATION = "{location}",
+                    AUTH_METHOD = "NONE"
+                );)",
+                "location"_a = GetBucketLocation(bucket)
+            );
+            const auto result = session.ExecuteSchemeQuery(query).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        auto db = kikimr->GetQueryClient();
+        {
+            const TString query = fmt::format(R"(
+                INSERT INTO test_bucket.`test/` WITH (
+                    FORMAT = csv_with_names,
+                    COMPRESSION = zstd
+                ) SELECT
+                    data,
+                    RandomNumber(TableRow()) AS guid
+                FROM AS_TABLE(ListReplicate(<|data: "{payload}"|>, 10000)))",
+                "payload"_a = TString(200, 'X')
+            );
+            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        const TString query = R"(
+            PRAGMA s3.AsyncDecompressing = "TRUE";
+
+            SELECT COUNT(*) FROM test_bucket.`test/` WITH (
+                FORMAT = csv_with_names,
+                COMPRESSION = zstd,
+                SCHEMA (
+                    data String NOT NULL,
+                    guid Uint64 NOT NULL,
+                )
+            );
+        )";
+        const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetResultSets().size(), 1);
+
+        auto resultSet = result.GetResultSetParser(0);
+        UNIT_ASSERT(resultSet.TryNextRow());
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser(0).GetUint64(), 10000);
+    }
+
     Y_UNIT_TEST(TestRestartQueryAndCleanupWithGetOperation) {
         auto kikimr = NTestUtils::MakeKikimrRunner(std::nullopt, {.EnableScriptExecutionBackgroundChecks = false});
         auto db = kikimr->GetQueryClient();

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -563,8 +563,9 @@ TDqPqRdReadActor::TDqPqRdReadActor(
 
     // Parse output schema (expected struct output type)
     const auto& outputTypeYson = SourceParams.GetRowType();
-    const auto outputItemType = NCommon::ParseTypeFromYson(TStringBuf(outputTypeYson), *programBuilder, Cerr);
-    YQL_ENSURE(outputItemType, "Failed to parse output type: " << outputTypeYson);
+    TStringStream error;
+    const auto outputItemType = NCommon::ParseTypeFromYson(TStringBuf(outputTypeYson), *programBuilder, error);
+    YQL_ENSURE(outputItemType, "Failed to parse output type: " << outputTypeYson << ", reason: " << error.Str());
     YQL_ENSURE(outputItemType->IsStruct(), "Output type " << outputTypeYson << " is not struct");
     const auto structType = static_cast<TStructType*>(outputItemType);
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -562,9 +562,9 @@ TDqPqRdReadActor::TDqPqRdReadActor(
     const auto programBuilder = std::make_unique<TProgramBuilder>(typeEnv, *holderFactory.GetFunctionRegistry());
 
     // Parse output schema (expected struct output type)
-    const auto& outputTypeYson = SourceParams.GetRowType();
+    const TStringBuf outputTypeYson(SourceParams.GetRowType());
     TStringStream error;
-    const auto outputItemType = NCommon::ParseTypeFromYson(TStringBuf(outputTypeYson), *programBuilder, error);
+    const auto outputItemType = NCommon::ParseTypeFromYson(outputTypeYson, *programBuilder, error);
     YQL_ENSURE(outputItemType, "Failed to parse output type: " << outputTypeYson << ", reason: " << error.Str());
     YQL_ENSURE(outputItemType->IsStruct(), "Output type " << outputTypeYson << " is not struct");
     const auto structType = static_cast<TStructType*>(outputItemType);

--- a/ydb/library/yql/providers/s3/actors/yql_s3_decompressor_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_decompressor_actor.cpp
@@ -31,7 +31,7 @@ private:
     class TCoroReadBuffer : public NDB::ReadBuffer {
     public:
         explicit TCoroReadBuffer(TS3DecompressorCoroImpl* coro)
-            : NDB::ReadBuffer(nullptr, 0ULL)
+            : NDB::ReadBuffer(nullptr, 0)
             , Coro(coro)
         {}
 

--- a/ydb/library/yql/providers/s3/actors/yql_s3_decompressor_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_decompressor_actor.cpp
@@ -30,10 +30,11 @@ public:
 private:
     class TCoroReadBuffer : public NDB::ReadBuffer {
     public:
-        TCoroReadBuffer(TS3DecompressorCoroImpl* coro)
+        explicit TCoroReadBuffer(TS3DecompressorCoroImpl* coro)
             : NDB::ReadBuffer(nullptr, 0ULL)
             , Coro(coro)
-        { }
+        {}
+
     private:
         bool nextImpl() final {
             while (!Coro->InputFinished || !Coro->Requests.empty()) {
@@ -50,7 +51,8 @@ private:
             }
             return false;
         }
-        TS3DecompressorCoroImpl *const Coro;
+
+        TS3DecompressorCoroImpl* const Coro;
         TString RawDataBuffer;
     };
 
@@ -107,7 +109,7 @@ private:
         InputBuffer = std::move(event.Data);
     }
 
-    TDuration GetCpuTimeDelta() {
+    TDuration GetCpuTimeDelta() const {
         return TDuration::Seconds(NHPTimer::GetSeconds(GetCycleCountFast() - StartCycleCount));
     }
 
@@ -129,16 +131,17 @@ private:
 
 class TS3DecompressorCoroActor : public TActorCoro {
 public:
-    TS3DecompressorCoroActor(THolder<TS3DecompressorCoroImpl> impl)
-        : TActorCoro(THolder<TS3DecompressorCoroImpl>(impl.Release()))
+    explicit TS3DecompressorCoroActor(THolder<TS3DecompressorCoroImpl> impl)
+        : TActorCoro(std::move(impl))
     {}
+
 private:
     void Registered(TActorSystem* actorSystem, const TActorId& parent) override {
         TActorCoro::Registered(actorSystem, parent); // Calls TActorCoro::OnRegister and sends bootstrap event to ourself.
     }
 };
 
-}
+} // anonymous namespace
 
 NActors::IActor* CreateS3DecompressorActor(const NActors::TActorId& parent, const TString& compression) {
     return new TS3DecompressorCoroActor(MakeHolder<TS3DecompressorCoroImpl>(parent, compression));

--- a/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.cpp
@@ -111,6 +111,11 @@ public:
     }
 
     void Bootstrap() {
+        if (Url.StartsWith("file://")) {
+            OnFatalError({TIssue("Reading from files is not supported in raw read actor, please contact internal support")}, NDqProto::StatusIds::INTERNAL_ERROR);
+            return;
+        }
+
         if (!UseRuntimeListing) {
             FileQueueActor = RegisterWithSameMailbox(CreateS3FileQueueActor(
                 TxId,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -355,7 +355,7 @@ public:
     class TCoroReadBuffer : public NDB::ReadBuffer {
     public:
         explicit TCoroReadBuffer(TS3ReadCoroImpl* coro)
-            : NDB::ReadBuffer(nullptr, 0ULL)
+            : NDB::ReadBuffer(nullptr, 0)
             , Coro(coro)
         {}
 
@@ -383,7 +383,7 @@ public:
     class TCoroDecompressorBuffer : public NDB::ReadBuffer {
     public:
         explicit TCoroDecompressorBuffer(TS3ReadCoroImpl* coro)
-            : NDB::ReadBuffer(nullptr, 0ULL)
+            : NDB::ReadBuffer(nullptr, 0)
             , Coro(coro)
         {}
 
@@ -505,8 +505,7 @@ public:
     };
 
     struct TReadRangeCompare {
-        bool operator() (const TEvS3Provider::TReadRange& lhs, const TEvS3Provider::TReadRange& rhs) const
-        {
+        bool operator() (const TEvS3Provider::TReadRange& lhs, const TEvS3Provider::TReadRange& rhs) const {
             return (lhs.Offset < rhs.Offset) || (lhs.Offset == rhs.Offset && lhs.Length < rhs.Length);
         }
     };
@@ -892,7 +891,7 @@ public:
             }
 
             if (!DeferredDataParts.empty()) {
-                ExtractDataPart(*DeferredDataParts.front(), true);
+                ExtractDataPart(*DeferredDataParts.front(), /* deferred */ true);
                 DeferredDataParts.pop();
                 if (DeferredQueueSize) {
                     DeferredQueueSize->Dec();
@@ -1205,11 +1204,11 @@ private:
             FatalCode = static_cast<NYql::NDqProto::StatusIds::StatusCode>(err.Code);
             RetryStuff->Cancel();
         } catch (const std::exception& err) {
-            Issues.AddIssue(TIssue(err.what()));
+            Issues.AddIssue(err.what());
             FatalCode = NYql::NDqProto::StatusIds::INTERNAL_ERROR;
             RetryStuff->Cancel();
         } catch (...) {
-            Issues.AddIssue(TIssue("Got unknown exception, please contact internal support"));
+            Issues.AddIssue("Got unknown exception, please contact internal support");
             FatalCode = NYql::NDqProto::StatusIds::INTERNAL_ERROR;
             RetryStuff->Cancel();
         }

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -276,7 +276,6 @@ class TS3ReadCoroImpl : public TActorCoroImpl, public TSourceErrorHandler {
     static constexpr ui64 MAX_ERROR_TEXT_SIZE = 256_KB;
 
 public:
-
     class THttpRandomAccessFile : public arrow::io::RandomAccessFile {
     public:
         THttpRandomAccessFile(TS3ReadCoroImpl* coro, size_t fileSize) : Coro(coro), FileSize(fileSize) {
@@ -355,10 +354,11 @@ public:
 
     class TCoroReadBuffer : public NDB::ReadBuffer {
     public:
-        TCoroReadBuffer(TS3ReadCoroImpl* coro)
+        explicit TCoroReadBuffer(TS3ReadCoroImpl* coro)
             : NDB::ReadBuffer(nullptr, 0ULL)
             , Coro(coro)
-        { }
+        {}
+
     private:
         bool nextImpl() final {
             while (!Coro->InputFinished || !Coro->DeferredDataParts.empty()) {
@@ -375,16 +375,18 @@ public:
             }
             return false;
         }
-        TS3ReadCoroImpl *const Coro;
+
+        TS3ReadCoroImpl* const Coro;
         TString RawDataBuffer;
     };
 
     class TCoroDecompressorBuffer : public NDB::ReadBuffer {
     public:
-        TCoroDecompressorBuffer(TS3ReadCoroImpl* coro)
+        explicit TCoroDecompressorBuffer(TS3ReadCoroImpl* coro)
             : NDB::ReadBuffer(nullptr, 0ULL)
             , Coro(coro)
-        { }
+        {}
+
     private:
         bool nextImpl() final {
             while (!Coro->DecompressedInputFinished || !Coro->DeferredDecompressedDataParts.empty()) {
@@ -399,16 +401,20 @@ public:
                     return true;
                 } else if (Coro->InputBuffer) {
                     Coro->Send(Coro->DecompressorActorId, new TEvS3Provider::TEvDecompressDataRequest(std::move(Coro->InputBuffer)));
+                    Coro->InputBuffer.clear();
+                    if (Coro->InputFinished && Coro->DeferredDataParts.empty()) {
+                        Coro->FinishDecompressor();
+                    }
                 }
             }
             return false;
         }
-        TS3ReadCoroImpl *const Coro;
+
+        TS3ReadCoroImpl* const Coro;
         TString RawDataBuffer;
     };
 
     void RunClickHouseParserOverHttp() {
-
         LOG_CORO_D("RunClickHouseParserOverHttp");
 
         std::unique_ptr<NDB::ReadBuffer> coroBuffer = AsyncDecompressing ? std::unique_ptr<NDB::ReadBuffer>(std::make_unique<TCoroDecompressorBuffer>(this)) : std::unique_ptr<NDB::ReadBuffer>(std::make_unique<TCoroReadBuffer>(this));
@@ -450,16 +456,16 @@ public:
     }
 
     void RunClickHouseParserOverFile() {
-
         LOG_CORO_D("RunClickHouseParserOverFile");
+        YQL_ENSURE(!AsyncDecompressing, "Async decompression is not supported for file input");
 
         TString fileName = Url.substr(7) + Path;
 
-        std::unique_ptr<NDB::ReadBuffer> coroBuffer = AsyncDecompressing ? std::unique_ptr<NDB::ReadBuffer>(std::make_unique<TCoroDecompressorBuffer>(this)) : std::unique_ptr<NDB::ReadBuffer>(std::make_unique<NDB::ReadBufferFromFile>(fileName));
+        std::unique_ptr<NDB::ReadBuffer> coroBuffer = std::unique_ptr<NDB::ReadBuffer>(std::make_unique<NDB::ReadBufferFromFile>(fileName));
         std::unique_ptr<NDB::ReadBuffer> decompressorBuffer;
         NDB::ReadBuffer* buffer = coroBuffer.get();
 
-        if (ReadSpec->Compression && !AsyncDecompressing) {
+        if (ReadSpec->Compression) {
             decompressorBuffer = MakeDecompressor(*buffer, ReadSpec->Compression);
             YQL_ENSURE(decompressorBuffer, "Unsupported " << ReadSpec->Compression << " compression.");
             buffer = decompressorBuffer.get();
@@ -498,8 +504,7 @@ public:
         bool Ready = false;
     };
 
-    struct TReadRangeCompare
-    {
+    struct TReadRangeCompare {
         bool operator() (const TEvS3Provider::TReadRange& lhs, const TEvS3Provider::TReadRange& rhs) const
         {
             return (lhs.Offset < rhs.Offset) || (lhs.Offset == rhs.Offset && lhs.Length < rhs.Length);
@@ -532,7 +537,6 @@ public:
         }
         return inflight;
     }
-
 
     TReadCache& GetOrCreate(TEvS3Provider::TReadRange range) {
         auto it = RangeCache.find(range);
@@ -576,7 +580,6 @@ public:
     }
 
     void HandleEvent(TEvS3Provider::TEvReadResult2::THandle& event) {
-
         if (event.Get()->Failure) {
             ythrow TCodeLineException(NYql::NDqProto::StatusIds::INTERNAL_ERROR) << event.Get()->Issues.ToOneLineString();
         }
@@ -592,7 +595,7 @@ public:
         }
 
         if (it->second.Cookie != event.Cookie) {
-            LOG_CORO_W("Mistmatched cookie for range [" << readyRange.Offset << "-" << readyRange.Length << "], received " << event.Cookie << ", expected " << it->second.Cookie);
+            LOG_CORO_W("Mismatched cookie for range [" << readyRange.Offset << "-" << readyRange.Length << "], received " << event.Cookie << ", expected " << it->second.Cookie);
             return;
         }
 
@@ -612,7 +615,6 @@ public:
     }
 
     arrow::Result<std::shared_ptr<arrow::Buffer>> ReadAt(int64_t position, int64_t nbytes) {
-
         LOG_CORO_D("ReadAt STARTED [" << position << "-" << nbytes << "]");
         TEvS3Provider::TReadRange range { .Offset = position, .Length = nbytes };
         auto& cache = GetOrCreate(range);
@@ -635,7 +637,6 @@ public:
     }
 
     void RunCoroBlockArrowParserOverHttp() {
-
         LOG_CORO_D("RunCoroBlockArrowParserOverHttp");
 
         ui64 readerCount = 1;
@@ -804,7 +805,6 @@ public:
     }
 
     void RunCoroBlockArrowParserOverFile() {
-
         LOG_CORO_D("RunCoroBlockArrowParserOverFile");
 
         std::shared_ptr<arrow::io::RandomAccessFile> arrowFile =
@@ -886,14 +886,21 @@ public:
     )
 
     void ProcessOneEvent() {
-        if (!Paused && !DeferredDataParts.empty()) {
-            ExtractDataPart(*DeferredDataParts.front(), true);
-            DeferredDataParts.pop();
-            if (DeferredQueueSize) {
-                DeferredQueueSize->Dec();
+        if (!Paused) {
+            if (!DeferredDecompressedDataParts.empty()) {
+                return;
             }
-            return;
+
+            if (!DeferredDataParts.empty()) {
+                ExtractDataPart(*DeferredDataParts.front(), true);
+                DeferredDataParts.pop();
+                if (DeferredQueueSize) {
+                    DeferredQueueSize->Dec();
+                }
+                return;
+            }
         }
+
         TAutoPtr<IEventHandle> ev(WaitForEvent().Release());
         StateFunc(ev);
     }
@@ -914,7 +921,7 @@ public:
             auto result = std::move(DeferredDecompressedDataParts.front());
             DeferredDecompressedDataParts.pop();
             if (result->Exception) {
-                throw result->Exception;
+                std::rethrow_exception(result->Exception);
             }
             return result->Data;
         }
@@ -956,7 +963,6 @@ public:
     void Handle(TEvS3Provider::TEvDecompressDataResult::TPtr& ev) {
         CpuTime += ev->Get()->CpuTime;
         DeferredDecompressedDataParts.push(std::move(ev->Release()));
-        
     }
 
     void Handle(TEvS3Provider::TEvDecompressDataFinish::TPtr& ev) {
@@ -965,7 +971,6 @@ public:
     }
 
     void Handle(TEvS3Provider::TEvDownloadFinish::TPtr& ev) {
-
         if (CurlResponseCode == CURLE_OK) {
             CurlResponseCode = ev->Get()->CurlResponseCode;
         }
@@ -1000,7 +1005,7 @@ public:
                 // can't retry here: fail download
                 RetryStuff->RetryState = nullptr;
                 InputFinished = true;
-                FinishDecompressor();
+                FinishDecompressor(/* force */ true);
                 LOG_CORO_W("ReadError: " << Issues.ToOneLineString() << ", LastOffset: " << LastOffset << ", LastData: " << GetLastDataAsText());
                 throw TS3ReadError(); // Don't pass control to data parsing, because it may validate eof and show wrong issues about incorrect data format
             }
@@ -1019,9 +1024,12 @@ public:
         } else {
             LOG_CORO_D("TEvDownloadFinish, LastOffset: " << LastOffset << ", Error: " << ServerReturnedError);
             InputFinished = true;
-            FinishDecompressor();
             if (ServerReturnedError) {
+                FinishDecompressor(/* force */ true);
                 throw TS3ReadError(); // Don't pass control to data parsing, because it may validate eof and show wrong issues about incorrect data format
+            }
+            if (DeferredDataParts.empty()) {
+                FinishDecompressor();
             }
         }
     }
@@ -1042,7 +1050,7 @@ public:
     void Handle(TEvents::TEvPoison::TPtr&) {
         LOG_CORO_D("TEvPoison");
         RetryStuff->Cancel();
-        FinishDecompressor(true);
+        FinishDecompressor(/* force */ true);
         throw TS3ReadAbort();
     }
 
@@ -1200,6 +1208,10 @@ private:
             Issues.AddIssue(TIssue(err.what()));
             FatalCode = NYql::NDqProto::StatusIds::INTERNAL_ERROR;
             RetryStuff->Cancel();
+        } catch (...) {
+            Issues.AddIssue(TIssue("Got unknown exception, please contact internal support"));
+            FatalCode = NYql::NDqProto::StatusIds::INTERNAL_ERROR;
+            RetryStuff->Cancel();
         }
 
         CpuTime += GetCpuTimeDelta();
@@ -1221,7 +1233,6 @@ private:
     }
 
     TString GetLastDataAsText() {
-
         if (LastData.empty()) {
             return "[]";
         }
@@ -1293,9 +1304,10 @@ private:
 
 class TS3ReadCoroActor : public TActorCoro {
 public:
-    TS3ReadCoroActor(THolder<TS3ReadCoroImpl> impl)
-        : TActorCoro(THolder<TActorCoroImpl>(impl.Release()))
+    explicit TS3ReadCoroActor(THolder<TS3ReadCoroImpl> impl)
+        : TActorCoro(std::move(impl))
     {}
+
 private:
     void Registered(TActorSystem* actorSystem, const TActorId& parent) override {
         TActorCoro::Registered(actorSystem, parent); // Calls TActorCoro::OnRegister and sends bootstrap event to ourself.
@@ -1498,10 +1510,7 @@ public:
         if (TaskCounters) {
             HttpInflightLimit->Add(Gateway->GetBuffersSizePerStream());
         }
-        LOG_D(
-            "TS3StreamReadActor",
-            "RegisterCoro with path " << object.GetPath() << " with pathIndex "
-                                      << pathIndex);
+        LOG_D("TS3StreamReadActor", "RegisterCoro with path " << object.GetPath() << " with pathIndex " << pathIndex);
 
         TActorId actorId;
         const auto& authInfo = Credentials.GetAuthInfo();
@@ -1553,11 +1562,13 @@ public:
         TrySendPathBatchRequest();
         return object;
     }
+
     void TrySendPathBatchRequest() {
         if (PathBatchQueue.size() < 2 && !IsFileQueueEmpty && !IsWaitingFileQueueResponse) {
             SendPathBatchRequest();
         }
     }
+
     void SendPathBatchRequest() {
         FileQueueEvents.Send(new TEvS3Provider::TEvGetNextBatch());
         IsWaitingFileQueueResponse = true;
@@ -1677,7 +1688,6 @@ private:
 
     // IActor & IDqComputeActorAsyncInput
     void PassAway() override { // Is called from Compute Actor
-
         if (Bootstrapped) {
             LOG_D("TS3StreamReadActor", "PassAway");
             if (Counters) {
@@ -2217,7 +2227,10 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
 
     if (params.HasFormat() && params.HasRowType()) {
         const auto pb = std::make_unique<TProgramBuilder>(typeEnv, functionRegistry);
-        const auto outputItemType = NCommon::ParseTypeFromYson(TStringBuf(params.GetRowType()), *pb, Cerr);
+        const TStringBuf outputTypeYson(params.GetRowType());
+        TStringStream error;
+        const auto outputItemType = NCommon::ParseTypeFromYson(outputTypeYson, *pb, error);
+        YQL_ENSURE(outputItemType, "Failed to parse output type: " << outputTypeYson << ", reason: " << error.Str());
         YQL_ENSURE(outputItemType->IsStruct(), "Row type is not struct");
         const auto structType = static_cast<TStructType*>(outputItemType);
 

--- a/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
@@ -988,7 +988,10 @@ std::pair<IDqComputeActorAsyncOutput*, IActor*> CreateS3WriteActor(
     const auto& arrowSettings = params.GetArrowSettings();
 
     const auto programBuilder = std::make_unique<TProgramBuilder>(typeEnv, functionRegistry);
-    const auto outputItemType = NCommon::ParseTypeFromYson(TStringBuf(arrowSettings.GetRowType()), *programBuilder, Cerr);
+    const TStringBuf outputTypeYson(arrowSettings.GetRowType());
+    TStringStream error;
+    const auto outputItemType = NCommon::ParseTypeFromYson(outputTypeYson, *programBuilder, error);
+    YQL_ENSURE(outputItemType, "Failed to parse output type: " << outputTypeYson << ", reason: " << error.Str());
     YQL_ENSURE(outputItemType->IsStruct(), "Row type is not struct");
     const auto structType = static_cast<TStructType*>(outputItemType);
 

--- a/ydb/library/yql/providers/s3/actors_factory/yql_s3_actors_factory.cpp
+++ b/ydb/library/yql/providers/s3/actors_factory/yql_s3_actors_factory.cpp
@@ -65,28 +65,28 @@ namespace NYql::NDq {
     }
 
     TS3ReadActorFactoryConfig CreateReadActorFactoryConfig(const ::NYql::TS3GatewayConfig& s3Config) {
-        TS3ReadActorFactoryConfig s3ReadActoryConfig;
+        TS3ReadActorFactoryConfig s3ReadFactoryConfig;
         if (const ui64 rowsInBatch = s3Config.GetRowsInBatch()) {
-            s3ReadActoryConfig.RowsInBatch = rowsInBatch;
+            s3ReadFactoryConfig.RowsInBatch = rowsInBatch;
         }
         if (const ui64 maxInflight = s3Config.GetMaxInflight()) {
-            s3ReadActoryConfig.MaxInflight = maxInflight;
+            s3ReadFactoryConfig.MaxInflight = maxInflight;
         }
         if (const ui64 dataInflight = s3Config.GetDataInflight()) {
-            s3ReadActoryConfig.DataInflight = dataInflight;
+            s3ReadFactoryConfig.DataInflight = dataInflight;
         }
-        for (auto& formatSizeLimit: s3Config.GetFormatSizeLimit()) {
+        for (auto& formatSizeLimit : s3Config.GetFormatSizeLimit()) {
             if (formatSizeLimit.GetName()) { // ignore unnamed limits
-                s3ReadActoryConfig.FormatSizeLimits.emplace(
+                s3ReadFactoryConfig.FormatSizeLimits.emplace(
                     formatSizeLimit.GetName(), formatSizeLimit.GetFileSizeLimit());
             }
         }
         if (s3Config.HasFileSizeLimit()) {
-            s3ReadActoryConfig.FileSizeLimit = s3Config.GetFileSizeLimit();
+            s3ReadFactoryConfig.FileSizeLimit = s3Config.GetFileSizeLimit();
         }
         if (s3Config.HasBlockFileSizeLimit()) {
-            s3ReadActoryConfig.BlockFileSizeLimit = s3Config.GetBlockFileSizeLimit();
+            s3ReadFactoryConfig.BlockFileSizeLimit = s3Config.GetBlockFileSizeLimit();
         }
-        return s3ReadActoryConfig;
+        return s3ReadFactoryConfig;
     }
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/s3/common/source_context.cpp
+++ b/ydb/library/yql/providers/s3/common/source_context.cpp
@@ -49,7 +49,7 @@ bool TSourceContext::Add(ui64 delta, NActors::TActorId producer, bool paused) {
     if (TaskQueueDataSize) {
         TaskQueueDataSize->Add(delta);
     }
-    if ((Value.load() + delta / 2) >= Limit) {
+    if (Value.load() + delta / 2 >= Limit) {
         if (!paused) {
             {
                 std::lock_guard<std::mutex> guard(Mutex);

--- a/ydb/library/yql/providers/s3/common/source_context.h
+++ b/ydb/library/yql/providers/s3/common/source_context.h
@@ -44,8 +44,7 @@ struct TSourceContext {
         , HttpInflightSize(httpInflightSize)
         , HttpDataRps(httpDataRps)
         , DeferredQueueSize(deferredQueueSize)
-    {
-    }
+    {}
 
     ~TSourceContext();
 
@@ -90,6 +89,7 @@ struct TSourceContext {
     NMonitoring::TDynamicCounters::TCounterPtr HttpInflightSize;
     NMonitoring::TDynamicCounters::TCounterPtr HttpDataRps;
     NMonitoring::TDynamicCounters::TCounterPtr DeferredQueueSize;
+
 private:
     std::atomic_uint64_t Value;
     std::mutex Mutex;

--- a/ydb/library/yql/providers/s3/compressors/lz4io.cpp
+++ b/ydb/library/yql/providers/s3/compressors/lz4io.cpp
@@ -220,8 +220,9 @@ public:
     }
 
     ~TCompressor() {
-        if (LZ4F_errorCode_t const errorCode = LZ4F_freeCompressionContext(Ctx); LZ4F_isError(errorCode))
+        if (LZ4F_errorCode_t const errorCode = LZ4F_freeCompressionContext(Ctx); LZ4F_isError(errorCode)) {
             Cerr << "Error: can't free LZ4F context resource: " << LZ4F_getErrorName(errorCode);
+        }
     }
 
 private:

--- a/ydb/library/yql/providers/s3/credentials/credentials.cpp
+++ b/ydb/library/yql/providers/s3/credentials/credentials.cpp
@@ -42,8 +42,8 @@ bool TS3Credentials::operator<(const TS3Credentials& other) const {
 IOutputStream& operator<<(IOutputStream& stream, const TS3Credentials& credentials) {
     const auto& authInfo = credentials.AuthInfo;
     return stream << "TS3Credentials{.ServiceAccountAuth=" << static_cast<bool>(credentials.CredentialsProvider)
-                  << ",.AwsUserPwd=<some token with length" << authInfo.GetAwsUserPwd().length() << ">"
-                  << ",.AwsSigV4=<some sig with length" << authInfo.GetAwsSigV4().length() << ">}";
+                  << ",.AwsUserPwd=<some token with length " << authInfo.GetAwsUserPwd().length() << ">"
+                  << ",.AwsSigV4=<some sig with length " << authInfo.GetAwsSigV4().length() << ">}";
 }
 
 // string value after AWS prefix should be suitable for passing it to curl as CURLOPT_USERPWD, see details here:

--- a/ydb/library/yql/providers/s3/events/events.h
+++ b/ydb/library/yql/providers/s3/events/events.h
@@ -176,7 +176,10 @@ struct TEvS3Provider {
     };
 
     struct TEvRetryEventFunc : public NActors::TEventLocal<TEvRetryEventFunc, EvRetry> {
-        explicit TEvRetryEventFunc(std::function<void()> functor) : Functor(std::move(functor)) {}
+        explicit TEvRetryEventFunc(std::function<void()> functor)
+            : Functor(std::move(functor))
+        {}
+
         const std::function<void()> Functor;
     };
 
@@ -204,7 +207,10 @@ struct TEvS3Provider {
     };
 
     struct TEvDecompressDataRequest : public NActors::TEventLocal<TEvDecompressDataRequest, EvDecompressDataRequest> {
-        TEvDecompressDataRequest(TString&& data) : Data(std::move(data)) {}
+        explicit TEvDecompressDataRequest(TString&& data)
+            : Data(std::move(data))
+        {}
+
         TString Data;
     };
 
@@ -215,7 +221,7 @@ struct TEvS3Provider {
         {}
 
         TEvDecompressDataResult(std::exception_ptr exception, const TDuration& cpuTime) 
-            : Exception(exception)
+            : Exception(std::move(exception))
             , CpuTime(cpuTime)
         {}
 
@@ -238,8 +244,19 @@ struct TEvS3Provider {
     };
 
     struct TEvReadResult2 : public NActors::TEventLocal<TEvReadResult2, EvReadResult2> {
-        TEvReadResult2(TReadRange readRange, IHTTPGateway::TContent&& result) : ReadRange(readRange), Failure(false), Result(std::move(result)) { }
-        TEvReadResult2(TReadRange readRange, TIssues&& issues) : ReadRange(readRange), Failure(true), Result(""), Issues(std::move(issues)) { }
+        TEvReadResult2(TReadRange readRange, IHTTPGateway::TContent&& result)
+            : ReadRange(readRange)
+            , Failure(false)
+            , Result(std::move(result))
+        {}
+
+        TEvReadResult2(TReadRange readRange, TIssues&& issues)
+            : ReadRange(readRange)
+            , Failure(true)
+            , Result("")
+            , Issues(std::move(issues))
+        {}
+
         const TReadRange ReadRange;
         const bool Failure;
         IHTTPGateway::TContent Result;

--- a/ydb/library/yql/providers/s3/object_listers/yql_s3_list.cpp
+++ b/ydb/library/yql/providers/s3/object_listers/yql_s3_list.cpp
@@ -175,7 +175,7 @@ class TLocalS3Lister : public IS3Lister {
 public:
     TLocalS3Lister(const TListingRequest& listingRequest, const TMaybe<TString>& delimiter)
         : ListingRequest(listingRequest) {
-        Y_ENSURE(!delimiter.Defined(), "delimiter is not supported for local files");
+        Y_ENSURE(!delimiter, "Subdirectory listing is not supported for local files (can not use delimiter: '" << *delimiter << "')");
         Filter =
             MakeFilter(listingRequest.Pattern, listingRequest.PatternType, nullptr).first;
     }

--- a/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
@@ -452,8 +452,6 @@ public:
     }
 
     TStatus HandleRead(const TExprNode::TPtr& input, TExprContext& ctx) {
-        using namespace NS3Details;
-
         State_->Configuration->CheckDisabledPragmas(ctx);
 
         if (!EnsureMinMaxArgsCount(*input, 6U, 7U, ctx)) {

--- a/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
@@ -290,7 +290,7 @@ bool EnsureParquetTypeSupported(TPositionHandle position, const TTypeAnnotationN
 
 class TS3DataSourceTypeAnnotationTransformer : public TVisitorTransformerBase {
 public:
-    TS3DataSourceTypeAnnotationTransformer(TS3State::TPtr state)
+    explicit TS3DataSourceTypeAnnotationTransformer(TS3State::TPtr state)
         : TVisitorTransformerBase(true)
         , State_(state)
     {
@@ -452,6 +452,8 @@ public:
     }
 
     TStatus HandleRead(const TExprNode::TPtr& input, TExprContext& ctx) {
+        using namespace NS3Details;
+
         State_->Configuration->CheckDisabledPragmas(ctx);
 
         if (!EnsureMinMaxArgsCount(*input, 6U, 7U, ctx)) {
@@ -462,7 +464,8 @@ public:
             return TStatus::Error;
         }
 
-        if (!EnsureSpecificDataSource(*input->Child(TS3ReadObject::idx_DataSource), S3ProviderName, ctx)) {
+        const auto* dataSourceNode = input->Child(TS3ReadObject::idx_DataSource);
+        if (!EnsureSpecificDataSource(*dataSourceNode, S3ProviderName, ctx)) {
             return TStatus::Error;
         }
 
@@ -493,6 +496,30 @@ public:
             TS3Object s3Object(input->Child(TS3ReadObject::idx_Object));
             auto format = s3Object.Format().Ref().Content();
             const TStructExprType* structRowType = rowType->Cast<TStructExprType>();
+
+            const auto& clusterSettings = State_->Configuration->Clusters.at(TS3DataSource(dataSourceNode).Cluster().StringValue());
+            if (clusterSettings.Url.StartsWith("file://")) {
+                bool hasErrors = false;
+
+                if (!useCoro) {
+                    ctx.AddError(TIssue(ctx.GetPosition(dataSourceNode->Pos()), "Reading from files is not supported with disabled pragma s3.SourceCoroActor, to read from files use: PRAGMA s3.SourceCoroActor = \"TRUE\""));
+                    hasErrors = true;
+                }
+
+                if (State_->Configuration->AsyncDecompressing.GetOrDefault()) {
+                    ctx.AddError(TIssue(ctx.GetPosition(dataSourceNode->Pos()), "Reading from files is not supported with enabled pragma s3.AsyncDecompressing, to read from files use: PRAGMA s3.AsyncDecompressing = \"FALSE\""));
+                    hasErrors = true;
+                }
+
+                if (IsIn({"raw", "json_list"}, format)) {
+                    ctx.AddError(TIssue(ctx.GetPosition(dataSourceNode->Pos()), TStringBuilder() << "Reading from files is not supported with format '" << format << "'"));
+                    hasErrors = true;
+                }
+
+                if (hasErrors) {
+                    return TStatus::Error;
+                }
+            }
 
             THashSet<TStringBuf> columns;
             for (const TItemExprType* item : structRowType->GetItems()) {
@@ -805,6 +832,7 @@ public:
             {
                 return TStatus::Error;
             }
+
             if (haveProjection && !havePartitionedBy) {
                 ctx.AddError(TIssue(ctx.GetPosition(input->Child(TS3Object::idx_Settings)->Pos()), "Missing partitioned_by setting for projection"));
                 return TStatus::Error;
@@ -824,6 +852,7 @@ public:
         input->SetTypeAnn(ctx.MakeType<TUnitExprType>());
         return TStatus::Ok;
     }
+
 private:
     const TS3State::TPtr State_;
 };

--- a/ydb/library/yql/providers/s3/provider/yql_s3_listing_strategy.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_listing_strategy.cpp
@@ -60,7 +60,8 @@ public:
 
     TCollectingS3ListingStrategy(TListerFactoryMethod&& listerFactoryMethod, TString collectingName)
         : ListerFactoryMethod(std::move(listerFactoryMethod))
-        , CollectingName(std::move(collectingName)) { }
+        , CollectingName(std::move(collectingName))
+    {}
 
     TFuture<TListResult> List(
         const TListingRequest& listingRequest,
@@ -71,7 +72,8 @@ public:
         auto futureLister = ListerFactoryMethod(listingRequest, options);
 
         return futureLister.Apply([listingRequest, options, name = CollectingName, limit = options.MaxResultSet](
-                                      const TFuture<IS3Lister::TPtr>& lister) {
+            const TFuture<IS3Lister::TPtr>& lister)
+        {
             try {
                 return DoListCallback(lister.GetValue(), options, name, limit);
             } catch (...) {
@@ -103,17 +105,20 @@ private:
             return EAggregationAction::Proceed;
         };
     }
+
     static inline auto MakeIssuesHandler(TListResult& state) {
         return [&state](const TListError& error) {
             state = error;
             return EAggregationAction::Stop;
         };
     }
+
     static inline EAggregationAction ExceptionHandler(
         TListResult& state, const std::exception& exception) {
         state = MakeGenericError(exception.what());
         return EAggregationAction::Stop;
     }
+
     static TFuture<TListResult> DoListCallback(
         IS3Lister::TPtr lister, TS3ListingOptions options, TString name, ui64 limit) {
         Y_UNUSED(options);
@@ -161,14 +166,16 @@ public:
         const IHTTPGateway::TRetryPolicy::TPtr& retryPolicy,
         bool allowLocalFiles)
         : TCollectingS3ListingStrategy(
-              [allowLocalFiles, httpGateway, retryPolicy, listerFactory](
-                  const TListingRequest& listingRequest,
-                  TS3ListingOptions options) {
-                  Y_UNUSED(options);
-                  return listerFactory->Make(
-                      httpGateway, retryPolicy, listingRequest, "/", allowLocalFiles);
-              },
-              "TDirectoryS3ListingStrategy") { }
+            [allowLocalFiles, httpGateway, retryPolicy, listerFactory](
+                const TListingRequest& listingRequest,
+                TS3ListingOptions options) {
+                Y_UNUSED(options);
+                return listerFactory->Make(
+                    httpGateway, retryPolicy, listingRequest, "/", allowLocalFiles);
+            },
+            "TDirectoryS3ListingStrategy"
+        )
+    {}
 };
 
 class TCompositeS3ListingStrategy : public IS3ListingStrategy {
@@ -612,8 +619,7 @@ public:
         const TListingRequest& defaultParams, const TString& pathPrefix)>;
 
     struct TSharedState {
-        using TDirectoryToListMatcher =
-            std::function<bool(const TDirectoryListEntry& entry)>;
+        using TDirectoryToListMatcher = std::function<bool(const TDirectoryListEntry& entry)>;
         using TEarlyStopMatcher = std::function<bool(const TSharedState& state)>;
 
         // Initial params
@@ -625,7 +631,7 @@ public:
         const TDirectoryToListMatcher DirectoryToListMatcher;
         const TEarlyStopMatcher EarlyStopMatcher;
         // Mutable state
-        std::mutex StateLock;
+        TMutex StateLock;
         std::deque<TString> DirectoryPrefixQueue;
         std::list<TString> InProgressPaths;
         TMaybe<TListError> MaybeError;
@@ -633,28 +639,30 @@ public:
         std::vector<TDirectoryListEntry> Directories;
         std::vector<TFuture<TListResult>> NextDirectoryListeningChunk;
         ui64 ListedObjectSize = 0;
-        // CurrentListing
+        // Current listing
         TPromise<TListResult> CurrentPromise;
         bool IsListingFinished = false;
         // Configuration
         const size_t Limit = 1;
         const size_t MaxParallelOps = 1;
-        //
         std::weak_ptr<TSharedState> This;
-    public:
+
+    private:
         static void ListingCallback(
             const std::weak_ptr<TSharedState>& stateWeakPtr,
             const TFuture<TListResult>& future,
-            const TString& sourcePath
-        ) {
+            const TString& sourcePath,
+            bool continueListing)
+        {
             auto state = stateWeakPtr.lock();
             if (!state) {
                 YQL_CLOG(TRACE, ProviderS3)
                     << "[TConcurrentBFSDirectoryResolverIterator] No state" << sourcePath;
                 return;
             }
-            YQL_CLOG(TRACE, ProviderS3) << "ListingCallback before lock";
-            auto lock = std::lock_guard(state->StateLock);
+
+            YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] ListingCallback before lock";
+            const auto lock = Guard(state->StateLock);
 
             YQL_CLOG(TRACE, ProviderS3)
                 << "[TConcurrentBFSDirectoryResolverIterator] Got new listing result. Collected entries: "
@@ -675,9 +683,9 @@ public:
                 state->AddChunkToState(nextChunk, sourcePath);
                 YQL_CLOG(TRACE, ProviderS3)
                     << "[TConcurrentBFSDirectoryResolverIterator] Added listing to state ";
-                while (state->TryScheduleNextListing()) {
-                    YQL_CLOG(TRACE, ProviderS3)
-                        << "[TConcurrentBFSDirectoryResolverIterator] Scheduled new listing";
+
+                if (continueListing) {
+                    state->TryScheduleNextListing();
                 }
             } catch (std::exception& e) {
                 YQL_CLOG(TRACE, ProviderS3)
@@ -690,6 +698,7 @@ public:
             YQL_CLOG(TRACE, ProviderS3)
                 << "[TConcurrentBFSDirectoryResolverIterator] Callback end";
         }
+
         void RemovePathFromInProgress(const TString& path) {
             Y_ABORT_UNLESS(!InProgressPaths.empty());
             auto sizeBeforeRemoval = InProgressPaths.size();
@@ -698,6 +707,7 @@ public:
             InProgressPaths.erase(pos);
             Y_ABORT_UNLESS(sizeBeforeRemoval == InProgressPaths.size() + 1);
         }
+
         void HandleLimitExceeded(const TString& sourcePath, const TListError& error) {
             IsListingFinished = true;
             if (LimitExceededAction == ELimitExceededAction::RaiseError) {
@@ -708,10 +718,11 @@ public:
                 DirectoryPrefixQueue.push_back(sourcePath);
             };
         }
+
         void AddChunkToState(
             const TListResult& nextBatch,
-            const TString& sourcePath) {
-
+            const TString& sourcePath)
+        {
             if (std::holds_alternative<TListError>(nextBatch)) {
                 auto& error = std::get<TListError>(nextBatch);
                 HandleLimitExceeded(sourcePath, error);
@@ -764,6 +775,8 @@ public:
             }
             SetPromise();
         }
+
+    public:
         void SetPromise() {
             Y_ENSURE(IsListingFinished);
             YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] SetPromise going to set promise";
@@ -791,36 +804,50 @@ public:
             YQL_CLOG(DEBUG, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] SetPromise promise was set";
         }
 
-        bool TryScheduleNextListing() {
-            YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] TryScheduleNextListing next listing";
-            if (IsListingFinished) {
-                return false;
+        void TryScheduleNextListing() {
+            while (true) {
+                YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] TryScheduleNextListing next listing";
+
+                if (IsListingFinished) {
+                    break;
+                }
+
+                if (InProgressPaths.size() >= MaxParallelOps) {
+                    break;
+                }
+
+                if (DirectoryPrefixQueue.empty()) {
+                    break;
+                }
+
+                ScheduleNextListing();
+                YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] Scheduled new listing";
             }
-            if (InProgressPaths.size() >= MaxParallelOps) {
-                return false;
-            }
-            if (DirectoryPrefixQueue.empty()) {
-                return false;
-            }
-            ScheduleNextListing();
-            return true;
         }
+
+    private:
         void ScheduleNextListing() {
             Y_ABORT_UNLESS(!DirectoryPrefixQueue.empty());
             auto prefix = DirectoryPrefixQueue.front();
             DirectoryPrefixQueue.pop_front();
             InProgressPaths.push_back(prefix);
-            YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] ScheduleNextListing next listing " << prefix;
+            YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] ScheduleNextListing next listing for prefix: '" << prefix << "'";
             const auto& listingRequest = ListingRequestFactory(DefaultParams, prefix);
 
-            DirectoryListingStrategy.List(listingRequest, Options)
-                .Subscribe(
-                    [prefix, self = This](const TFuture<TListResult>& future) {
-                        ListingCallback(self, future, prefix);
-                    });
+            const auto& feature = DirectoryListingStrategy.List(listingRequest, Options);
+            if (feature.IsReady()) {
+                // Avoid deadlock if feature already resolved and do not continue listing in this case
+                ListingCallback(This, feature, prefix, /* continueListing */ false);
+            } else {
+                feature.Subscribe([prefix, self = This](const TFuture<TListResult>& future) {
+                    ListingCallback(self, future, prefix, /* continueListing */ true);
+                });
+            }
         }
     };
+
     using TSharedStatePtr = std::shared_ptr<TSharedState>;
+
     static TSharedStatePtr MakeState(
         TListingRequest defaultParams,
         TListingRequestFactory listingRequestFactory,
@@ -833,16 +860,16 @@ public:
         size_t limit,
         size_t maxParallelOps) {
         auto res = TSharedStatePtr(new TSharedState{
-            .DefaultParams = (std::move(defaultParams)),
-            .Options = (options),
-            .DirectoryListingStrategy = (std::move(directoryListingStrategy)),
-            .ListingRequestFactory = (std::move(listingRequestFactory)),
-            .LimitExceededAction = (std::move(limitExceededAction)),
-            .DirectoryToListMatcher = (std::move(directoryToListMatcher)),
-            .EarlyStopMatcher = (std::move(earlyStopMatcher)),
-            .DirectoryPrefixQueue = (std::move(initialPathPrefixes)),
+            .DefaultParams = std::move(defaultParams),
+            .Options = options,
+            .DirectoryListingStrategy = std::move(directoryListingStrategy),
+            .ListingRequestFactory = std::move(listingRequestFactory),
+            .LimitExceededAction = std::move(limitExceededAction),
+            .DirectoryToListMatcher = std::move(directoryToListMatcher),
+            .EarlyStopMatcher = std::move(earlyStopMatcher),
+            .DirectoryPrefixQueue = std::move(initialPathPrefixes),
             .CurrentPromise = NewPromise<TListResult>(),
-            .Limit = (limit),
+            .Limit = limit,
             .MaxParallelOps = maxParallelOps});
         res->This = res;
         return res;
@@ -860,16 +887,18 @@ public:
         size_t limit,
         size_t maxParallelOps)
         : State(MakeState(
-              std::move(defaultParams),
-              std::move(listingRequestFactory),
-              std::move(limitExceededAction),
-              std::move(directoryToListMatcher),
-              std::move(earlyStopMatcher),
-              options,
-              std::move(initialPathPrefixes),
-              std::move(directoryListingStrategy),
-              limit,
-              maxParallelOps)) { }
+            std::move(defaultParams),
+            std::move(listingRequestFactory),
+            std::move(limitExceededAction),
+            std::move(directoryToListMatcher),
+            std::move(earlyStopMatcher),
+            options,
+            std::move(initialPathPrefixes),
+            std::move(directoryListingStrategy),
+            limit,
+            maxParallelOps
+        ))
+    {}
 
     TFuture<TListResult> Next() override {
         if (!First) {
@@ -878,7 +907,7 @@ public:
         }
 
         YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] Next before lock";
-        auto lock = std::lock_guard{State->StateLock};
+        const auto lock = Guard(State->StateLock);
 
         First = false;
         if (State->DirectoryPrefixQueue.empty()) {
@@ -886,10 +915,10 @@ public:
         }
 
         if (!State->IsListingFinished) {
-            YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] Next listing is not finished ";
-            while (State->TryScheduleNextListing());
+            YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] Next listing is not finished";
+            State->TryScheduleNextListing();
         } else {
-            YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] Next listing is finished - reading result ";
+            YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] Next listing is finished - reading result";
             State->SetPromise();
         }
 
@@ -897,8 +926,9 @@ public:
     }
 
     bool HasNext() override {
-        YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] HasNext";
-        return (First & !State->DirectoryPrefixQueue.empty());
+        bool hasNext = First && !State->DirectoryPrefixQueue.empty();
+        YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] HasNext: " << hasNext;
+        return hasNext;
     }
 
 private:
@@ -906,8 +936,7 @@ private:
     bool First = true;
 };
 
-class TConcurrentUnPartitionedDatasetS3ListingStrategy :
-    public TCollectingS3ListingStrategy {
+class TConcurrentUnPartitionedDatasetS3ListingStrategy : public TCollectingS3ListingStrategy {
 public:
     TConcurrentUnPartitionedDatasetS3ListingStrategy(
         const IS3ListerFactory::TPtr& listerFactory,
@@ -917,48 +946,45 @@ public:
         size_t maxParallelOps,
         bool allowLocalFiles)
         : TCollectingS3ListingStrategy(
-              [listerFactory, httpGateway, retryPolicy, minParallelism, allowLocalFiles, maxParallelOps](
-                  const TListingRequest& listingRequest,
-                  TS3ListingOptions options) {
-                  auto ptr = std::shared_ptr<IS3Lister>(
-                      new TConcurrentBFSDirectoryResolverIterator{
-                          listingRequest,
-                          [](const TListingRequest& defaultParams,
-                             const TString& pathPrefix) {
-                              TListingRequest request(defaultParams);
-                              request.Prefix = pathPrefix;
-                              return request;
-                          },
-                          ELimitExceededAction::Proceed,
-                          [](const TDirectoryListEntry& entry) -> bool {
-                              Y_UNUSED(entry);
-                              return true;
-                          },
-                          [minParallelism](const TConcurrentBFSDirectoryResolverIterator::TSharedState&
-                                 state) -> bool {
-                              auto currentListedSize = state.InProgressPaths.size() +
-                                                       state.DirectoryPrefixQueue.size() +
-                                                       state.Objects.size() +
-                                                       state.Directories.size();
-                              return currentListedSize > minParallelism;
-                          },
-                          options,
-                          std::deque<TString>{
-                              (!listingRequest.Prefix.empty())
-                                  ? listingRequest.Prefix
-                                  : listingRequest.Pattern.substr(
-                                        0, NS3::GetFirstWildcardPos(listingRequest.Pattern))},
-                          TDirectoryS3ListingStrategy{
-                              listerFactory, httpGateway, retryPolicy, allowLocalFiles},
-                          options.MaxResultSet,
-                          maxParallelOps});
-                  return MakeFuture(std::move(ptr));
-              },
-              "TConcurrentUnPartitionedDatasetS3ListingStrategy") { }
+            [listerFactory, httpGateway, retryPolicy, minParallelism, allowLocalFiles, maxParallelOps](
+                const TListingRequest& listingRequest,
+                TS3ListingOptions options) {
+                auto ptr = std::make_shared<TConcurrentBFSDirectoryResolverIterator>(
+                    listingRequest,
+                    [](const TListingRequest& defaultParams, const TString& pathPrefix) {
+                        TListingRequest request(defaultParams);
+                        request.Prefix = pathPrefix;
+                        return request;
+                    },
+                    ELimitExceededAction::Proceed,
+                    [](const TDirectoryListEntry& entry) -> bool {
+                        Y_UNUSED(entry);
+                        return true;
+                    },
+                    [minParallelism](const TConcurrentBFSDirectoryResolverIterator::TSharedState& state) -> bool {
+                        auto currentListedSize = state.InProgressPaths.size() +
+                            state.DirectoryPrefixQueue.size() +
+                            state.Objects.size() +
+                            state.Directories.size();
+                        return currentListedSize > minParallelism;
+                    },
+                    options,
+                    std::deque<TString>{listingRequest.Prefix
+                        ? listingRequest.Prefix
+                        : listingRequest.Pattern.substr(0, NS3::GetFirstWildcardPos(listingRequest.Pattern))
+                    },
+                    TDirectoryS3ListingStrategy(listerFactory, httpGateway, retryPolicy, allowLocalFiles),
+                    options.MaxResultSet,
+                    maxParallelOps
+                );
+                return MakeFuture<std::shared_ptr<IS3Lister>>(std::move(ptr));
+            },
+            "TConcurrentUnPartitionedDatasetS3ListingStrategy"
+        )
+    {}
 };
 
-class TConcurrentPartitionedDatasetS3ListingStrategy :
-    public TCollectingS3ListingStrategy {
+class TConcurrentPartitionedDatasetS3ListingStrategy : public TCollectingS3ListingStrategy {
 public:
     TConcurrentPartitionedDatasetS3ListingStrategy(
         const IS3ListerFactory::TPtr& listerFactory,
@@ -1003,9 +1029,7 @@ public:
               "TConcurrentPartitionedDatasetS3ListingStrategy") { }
 };
 
-
-
-} // namespace
+} // anonymous namespace
 
 class TLoggingS3ListingStrategy : public IS3ListingStrategy {
 public:

--- a/ydb/library/yql/providers/s3/provider/yql_s3_listing_strategy.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_listing_strategy.cpp
@@ -834,13 +834,13 @@ public:
             YQL_CLOG(TRACE, ProviderS3) << "[TConcurrentBFSDirectoryResolverIterator] ScheduleNextListing next listing for prefix: '" << prefix << "'";
             const auto& listingRequest = ListingRequestFactory(DefaultParams, prefix);
 
-            const auto& feature = DirectoryListingStrategy.List(listingRequest, Options);
-            if (feature.IsReady()) {
-                // Avoid deadlock if feature already resolved and do not continue listing in this case
-                ListingCallback(This, feature, prefix, /* continueListing */ false);
+            const auto& future = DirectoryListingStrategy.List(listingRequest, Options);
+            if (future.IsReady()) {
+                // Avoid deadlock if future already resolved and do not continue listing in this case
+                ListingCallback(This, future, prefix, /* continueListing */ false);
             } else {
-                feature.Subscribe([prefix, self = This](const TFuture<TListResult>& future) {
-                    ListingCallback(self, future, prefix, /* continueListing */ true);
+                future.Subscribe([prefix, self = This](const TFuture<TListResult>& listingFuture) {
+                    ListingCallback(self, listingFuture, prefix, /* continueListing */ true);
                 });
             }
         }

--- a/ydb/library/yql/providers/s3/range_helpers/path_list_reader.h
+++ b/ydb/library/yql/providers/s3/range_helpers/path_list_reader.h
@@ -19,8 +19,10 @@ struct TPath {
         : Path(std::move(path))
         , Size(size)
         , IsDirectory(isDirectory)
-        , PathIndex(pathIndex) { }
+        , PathIndex(pathIndex)
+    {}
 };
+
 using TPathList = std::vector<TPath>;
 
 void ReadPathsList(const THashMap<TString, TString>& taskParams, const TVector<TString>& readRanges, TPathList& paths);

--- a/ydb/tests/tools/kqprun/runlib/actors.h
+++ b/ydb/tests/tools/kqprun/runlib/actors.h
@@ -100,7 +100,7 @@ public:
             }
         } else {
             Failed_++;
-            Cout << CoutColors_.Red() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " failed " << response.GetStatus() << ". " << CoutColors_.Yellow() << GetInfoString() << "\n" << CoutColors_.Red() << "Issues:\n" << response.GetError() << CoutColors_.Default();
+            Cout << CoutColors_.Red() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " failed " << response.GetStatus() << ". " << CoutColors_.Yellow() << GetInfoString() << "\n" << CoutColors_.Red() << "Issues:\n" << response.GetError() << CoutColors_.Default() << Endl;
         }
 
         if (Settings_.Verbosity == TAsyncQueriesSettings::EVerbosity::Final && TInstant::Now() - LastReportTime_ > TDuration::Seconds(1)) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed S3 async decompression, bug ticket: https://st.yandex-team.ru/YQ-5013

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Main fixes:

* Fixed DefferedData parts loss for async decompression:
   https://github.com/ydb-platform/ydb/pull/31655/changes#diff-ec0dce4b9d614a34fc221710d42054a532a2d9c349b46a7d541c36d8c885ee26R890-R892
* Fixed async decompression hanging after pause:
   https://github.com/ydb-platform/ydb/pull/31655/changes#diff-ec0dce4b9d614a34fc221710d42054a532a2d9c349b46a7d541c36d8c885ee26L1022-R1033
* Fixed data decompression exception handling:
   https://github.com/ydb-platform/ydb/pull/31655/changes#diff-ec0dce4b9d614a34fc221710d42054a532a2d9c349b46a7d541c36d8c885ee26L917-R924

Other fixes:

* Fixed request hanging on directory listing with `file://` url schema
* Fixed error text when `file://` schema used wih S3 raw read actor or with async decompression
* Fixed YSON type parsing error printing
* Fixed style issues and typos
* Fixed kqprun colored output flush
