### PR TITLE
Moved EHashType to protobuf for usage in Proto Events

### DIFF
--- a/ydb/core/security/sasl/hasher.h
+++ b/ydb/core/security/sasl/hasher.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <ydb/library/actors/core/actor.h>
-#include <ydb/library/login/hashes_checker/hash_types.h>
 #include <ydb/library/login/password_checker/password_checker.h>
+#include <ydb/library/login/protos/login.pb.h>
 
 namespace NKikimr::NSasl {
 
@@ -13,7 +13,7 @@ struct TStaticCredentials {
 
 std::unique_ptr<NActors::IActor> CreateHasher(
     NActors::TActorId sender, const TStaticCredentials& creds,
-    const std::vector<NLogin::EHashType>& hashTypes,
+    const std::vector<NLoginProto::EHashType::HashType>& hashTypes,
     NLogin::TPasswordComplexity passwordComplexity = NLogin::TPasswordComplexity()
 );
 

--- a/ydb/core/security/sasl/ya.make
+++ b/ydb/core/security/sasl/ya.make
@@ -5,6 +5,7 @@ PEERDIR(
     library/cpp/digest/argonish
     library/cpp/json
     library/cpp/string_utils/base64
+    ydb/core/protos
     ydb/library/actors/core
     ydb/library/login/hashes_checker
     ydb/library/login/password_checker

--- a/ydb/core/security/ya.make
+++ b/ydb/core/security/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     ydb/library/aclib
     ydb/library/aclib/protos
     ydb/library/login
+    ydb/library/login/protos
     ydb/library/ncloud/impl
     ydb/library/security
     ydb/library/ycloud/api

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -29,9 +29,9 @@
 
 namespace {
 
-const TVector<NLogin::EHashType> HASHES_TO_COMPUTE = {
-    NLogin::EHashType::Argon,
-    NLogin::EHashType::ScramSha256,
+const TVector<NLoginProto::EHashType::HashType> HASHES_TO_COMPUTE = {
+    NLoginProto::EHashType::Argon,
+    NLoginProto::EHashType::ScramSha256,
 };
 
 }

--- a/ydb/library/login/hashes_checker/hash_types.cpp
+++ b/ydb/library/login/hashes_checker/hash_types.cpp
@@ -2,6 +2,8 @@
 
 namespace NLogin {
 
+using namespace NLoginProto;
+
 const TVector<THashTypeDescription> THashTypesRegistry::HashTypeDescriptions = {
     { .Class = EHashClass::Argon, .Type = EHashType::Argon, .Name = "argon2id", .SaltSize = 16, .HashSize = 32, .IsEmptyPasswordAllowed = true },
     { .Class = EHashClass::Scram, .Type = EHashType::ScramSha256, .Name = "scram-sha-256", .IterationsCount = 4096, .SaltSize = 16, .HashSize = 32, .IsEmptyPasswordAllowed = false },

--- a/ydb/library/login/hashes_checker/hash_types.h
+++ b/ydb/library/login/hashes_checker/hash_types.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ydb/library/login/protos/login.pb.h>
+
 #include <util/generic/hash.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
@@ -12,14 +14,9 @@ enum class EHashClass {
     Scram,
 };
 
-enum class EHashType {
-    Argon,
-    ScramSha256,
-};
-
 struct THashTypeDescription {
     const EHashClass Class;
-    const EHashType Type;
+    const NLoginProto::EHashType::HashType Type;
     const TString Name;
     const ui32 IterationsCount;
     const ui32 SaltSize;
@@ -33,7 +30,7 @@ struct THashTypesRegistry {
 
     static const TVector<THashTypeDescription> HashTypeDescriptions;
 
-    THashMap<EHashType, const THashTypeDescription&> HashTypesMap;
+    THashMap<NLoginProto::EHashType::HashType, const THashTypeDescription&> HashTypesMap;
     THashMap<TStringBuf, const THashTypeDescription&> HashNamesMap;
 
 } const extern HashesRegistry;

--- a/ydb/library/login/hashes_checker/hashes_checker.h
+++ b/ydb/library/login/hashes_checker/hashes_checker.h
@@ -10,9 +10,24 @@ namespace NLogin {
 
 constexpr ui16 HASHES_JSON_SCHEMA_VERSION = 1;
 
+struct THashSecret {
+    TString HashInitParams;
+    TString HashValues;
+};
+
 struct TArgonSecret {
     TString Salt;
     TString Hash;
+};
+
+struct TScramInitHashParams {
+    TString IterationsCount;
+    TString Salt;
+};
+
+struct TScramHashValues {
+    TString StoredKey;
+    TString ServerKey;
 };
 
 struct TScramSecret {
@@ -32,8 +47,12 @@ TString HashedPasswordFromNewArgonHashFormat(const TString& argonHash);
 TMaybe<TString> ArgonHashToOldFormat(const TStringBuf newArgonHash);
 TMaybe<THashes> ConvertHashes(const TString& hash);
 
-TArgonSecret ParseArgonHash(const TStringBuf hash);
-TScramSecret ParseScramHash(const TStringBuf hash);
+THashSecret SplitPasswordHash(const TStringBuf hash);
+TArgonSecret ParseArgonHash(const TStringBuf argonHash);
+TScramInitHashParams ParseScramHashInitParams(const TStringBuf hashInitParams);
+TScramHashValues ParseScramHashValues(const TStringBuf hashValues);
+TScramSecret ParseScramHash(const TStringBuf scramHash);
+THashMap<NLoginProto::EHashType::HashType, TString> MakePasswordHashesMap(const TString& hashes);
 
 class THashesChecker {
 public:

--- a/ydb/library/login/hashes_checker/hashes_checker_ut.cpp
+++ b/ydb/library/login/hashes_checker/hashes_checker_ut.cpp
@@ -346,3 +346,168 @@ Y_UNIT_TEST_SUITE(HashesCheckerNewFormat) {
     }
 
 }
+
+Y_UNIT_TEST_SUITE(HashParsingFunctions) {
+
+    Y_UNIT_TEST(SplitPasswordHash_ValidHash) {
+        auto result = SplitPasswordHash("initParams$hashValues");
+        UNIT_ASSERT_EQUAL(result.HashInitParams, "initParams");
+        UNIT_ASSERT_EQUAL(result.HashValues, "hashValues");
+    }
+
+    Y_UNIT_TEST(SplitPasswordHash_NoDelimiter) {
+        auto result = SplitPasswordHash("noDelimiterHash");
+        UNIT_ASSERT(result.HashInitParams.empty());
+        UNIT_ASSERT(result.HashValues.empty());
+    }
+
+    Y_UNIT_TEST(SplitPasswordHash_EmptyInitParams) {
+        auto result = SplitPasswordHash("$hashValues");
+        UNIT_ASSERT(result.HashInitParams.empty());
+        UNIT_ASSERT(result.HashValues.empty());
+    }
+
+    Y_UNIT_TEST(SplitPasswordHash_EmptyHashValues) {
+        auto result = SplitPasswordHash("initParams$");
+        UNIT_ASSERT(result.HashInitParams.empty());
+        UNIT_ASSERT(result.HashValues.empty());
+    }
+
+    Y_UNIT_TEST(SplitPasswordHash_MultipleDelimiters) {
+        auto result = SplitPasswordHash("init$Params$hashValues");
+        UNIT_ASSERT_EQUAL(result.HashInitParams, "init");
+        UNIT_ASSERT_EQUAL(result.HashValues, "Params$hashValues");
+    }
+
+    Y_UNIT_TEST(ParseArgonHash_ValidHash) {
+        auto result = ParseArgonHash("U+tzBtgo06EBQCjlARA6Jg==$p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=");
+        UNIT_ASSERT_EQUAL(result.Salt, "U+tzBtgo06EBQCjlARA6Jg==");
+        UNIT_ASSERT_EQUAL(result.Hash, "p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=");
+    }
+
+    Y_UNIT_TEST(ParseArgonHash_NoDelimiter) {
+        auto result = ParseArgonHash("invalidArgonHash");
+        UNIT_ASSERT(result.Salt.empty());
+        UNIT_ASSERT(result.Hash.empty());
+    }
+
+    Y_UNIT_TEST(ParseArgonHash_EmptySalt) {
+        auto result = ParseArgonHash("$p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=");
+        UNIT_ASSERT(result.Salt.empty());
+        UNIT_ASSERT(result.Hash.empty());
+    }
+
+    Y_UNIT_TEST(ParseArgonHash_EmptyHash) {
+        auto result = ParseArgonHash("U+tzBtgo06EBQCjlARA6Jg==$");
+        UNIT_ASSERT(result.Salt.empty());
+        UNIT_ASSERT(result.Hash.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHashInitParams_ValidParams) {
+        auto result = ParseScramHashInitParams("4096:dgnDNb/a9Qc8e/LclrONVw==");
+        UNIT_ASSERT_EQUAL(result.IterationsCount, "4096");
+        UNIT_ASSERT_EQUAL(result.Salt, "dgnDNb/a9Qc8e/LclrONVw==");
+    }
+
+    Y_UNIT_TEST(ParseScramHashInitParams_NoDelimiter) {
+        auto result = ParseScramHashInitParams("4096dgnDNb/a9Qc8e/LclrONVw==");
+        UNIT_ASSERT(result.IterationsCount.empty());
+        UNIT_ASSERT(result.Salt.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHashInitParams_EmptyIterations) {
+        auto result = ParseScramHashInitParams(":dgnDNb/a9Qc8e/LclrONVw==");
+        UNIT_ASSERT(result.IterationsCount.empty());
+        UNIT_ASSERT(result.Salt.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHashInitParams_EmptySalt) {
+        auto result = ParseScramHashInitParams("4096:");
+        UNIT_ASSERT(result.IterationsCount.empty());
+        UNIT_ASSERT(result.Salt.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHashInitParams_MultipleDelimiters) {
+        auto result = ParseScramHashInitParams("4096:salt:extra");
+        UNIT_ASSERT_EQUAL(result.IterationsCount, "4096");
+        UNIT_ASSERT_EQUAL(result.Salt, "salt:extra");
+    }
+
+    Y_UNIT_TEST(ParseScramHashValues_ValidValues) {
+        auto result = ParseScramHashValues("26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=:MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+        UNIT_ASSERT_EQUAL(result.StoredKey, "26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=");
+        UNIT_ASSERT_EQUAL(result.ServerKey, "MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+    }
+
+    Y_UNIT_TEST(ParseScramHashValues_NoDelimiter) {
+        auto result = ParseScramHashValues("26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+        UNIT_ASSERT(result.StoredKey.empty());
+        UNIT_ASSERT(result.ServerKey.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHashValues_EmptyStoredKey) {
+        auto result = ParseScramHashValues(":MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+        UNIT_ASSERT(result.StoredKey.empty());
+        UNIT_ASSERT(result.ServerKey.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHashValues_EmptyServerKey) {
+        auto result = ParseScramHashValues("26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=:");
+        UNIT_ASSERT(result.StoredKey.empty());
+        UNIT_ASSERT(result.ServerKey.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHashValues_MultipleDelimiters) {
+        auto result = ParseScramHashValues("storedKey:serverKey:extra");
+        UNIT_ASSERT_EQUAL(result.StoredKey, "storedKey");
+        UNIT_ASSERT_EQUAL(result.ServerKey, "serverKey:extra");
+    }
+
+    Y_UNIT_TEST(ParseScramHash_ValidHash) {
+        auto result = ParseScramHash("4096:dgnDNb/a9Qc8e/LclrONVw==$26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=:MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+        UNIT_ASSERT_EQUAL(result.IterationsCount, "4096");
+        UNIT_ASSERT_EQUAL(result.Salt, "dgnDNb/a9Qc8e/LclrONVw==");
+        UNIT_ASSERT_EQUAL(result.StoredKey, "26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=");
+        UNIT_ASSERT_EQUAL(result.ServerKey, "MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+    }
+
+    Y_UNIT_TEST(ParseScramHash_NoMainDelimiter) {
+        auto result = ParseScramHash("4096:dgnDNb/a9Qc8e/LclrONVw==26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=:MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+        UNIT_ASSERT(result.IterationsCount.empty());
+        UNIT_ASSERT(result.Salt.empty());
+        UNIT_ASSERT(result.StoredKey.empty());
+        UNIT_ASSERT(result.ServerKey.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHash_InvalidInitParams) {
+        auto result = ParseScramHash("4096dgnDNb/a9Qc8e/LclrONVw==$26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=:MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+        UNIT_ASSERT(result.IterationsCount.empty());
+        UNIT_ASSERT(result.Salt.empty());
+        UNIT_ASSERT(result.StoredKey.empty());
+        UNIT_ASSERT(result.ServerKey.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHash_InvalidHashValues) {
+        auto result = ParseScramHash("4096:dgnDNb/a9Qc8e/LclrONVw==$26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+        UNIT_ASSERT(result.IterationsCount.empty());
+        UNIT_ASSERT(result.Salt.empty());
+        UNIT_ASSERT(result.StoredKey.empty());
+        UNIT_ASSERT(result.ServerKey.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHash_EmptyInitParams) {
+        auto result = ParseScramHash("$26pg7R/Q4k3mT2a9P1Sm1mDnq1X7tDhXlS3BRu/9oUc=:MLFyR60CNFATMLnxoI2b7IcQUA/SGAIEF2cHUrM/Jj8=");
+        UNIT_ASSERT(result.IterationsCount.empty());
+        UNIT_ASSERT(result.Salt.empty());
+        UNIT_ASSERT(result.StoredKey.empty());
+        UNIT_ASSERT(result.ServerKey.empty());
+    }
+
+    Y_UNIT_TEST(ParseScramHash_EmptyHashValues) {
+        auto result = ParseScramHash("4096:dgnDNb/a9Qc8e/LclrONVw==$");
+        UNIT_ASSERT(result.IterationsCount.empty());
+        UNIT_ASSERT(result.Salt.empty());
+        UNIT_ASSERT(result.StoredKey.empty());
+        UNIT_ASSERT(result.ServerKey.empty());
+    }
+}

--- a/ydb/library/login/hashes_checker/ya.make
+++ b/ydb/library/login/hashes_checker/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 PEERDIR(
     library/cpp/string_utils/base64
+    ydb/library/login/protos
 )
 
 SRCS(

--- a/ydb/library/login/protos/login.proto
+++ b/ydb/library/login/protos/login.proto
@@ -17,6 +17,14 @@ message ESidType {
     }
 }
 
+message EHashType {
+    enum HashType {
+        Unknown = 0;
+        Argon = 1;
+        ScramSha256 = 2;
+    }
+}
+
 message TSid {
     string Name = 1;
     ESidType.SidType Type = 2;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- moved EHashType to protobuf msg
- refactored hash secrets parsing for further usage in SchemeShard

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
