### PR TITLE
feat ydb: support load_factor in ListEndpoints handler

### DIFF
--- a/ydb/core/base/board_publish.cpp
+++ b/ydb/core/base/board_publish.cpp
@@ -292,6 +292,7 @@ public:
     STATEFN(StateResolve) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvStateStorage::TEvResolveReplicasList, Handle);
+            hFunc(TEvStateStorage::TEvBoardPublishUpdate, Handle);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
             cFunc(TEvents::TEvUndelivered::EventType, HandleUndelivered);
         }

--- a/ydb/core/base/statestorage.h
+++ b/ydb/core/base/statestorage.h
@@ -32,6 +32,7 @@ struct TEvStateStorage {
         EvRingGroupPassAway,
         EvConfigVersionInfo,
         EvListBoard,
+        EvBoardPublishUpdate,  // Update payload in existing board publish actor
 
         // replies (local, from proxy)
         EvInfo = EvLookup + 512,
@@ -473,6 +474,15 @@ struct TEvStateStorage {
             , Path(path)
         {}
     };
+
+    struct TEvBoardPublishUpdate : public TEventLocal<TEvBoardPublishUpdate, EvBoardPublishUpdate> {
+        TString NewPayload;
+        
+        TEvBoardPublishUpdate(const TString& newPayload)
+            : NewPayload(newPayload)
+        {}
+    };
+
 };
 
 enum ERingGroupState {

--- a/ydb/core/grpc_services/grpc_endpoint_publish_actor.cpp
+++ b/ydb/core/grpc_services/grpc_endpoint_publish_actor.cpp
@@ -9,33 +9,32 @@
 #include <ydb/core/base/domain.h>
 #include <ydb/core/base/location.h>
 #include <ydb/core/base/statestorage.h>
+#include <ydb/core/node_whiteboard/node_whiteboard.h>
 
 namespace NKikimr::NGRpcService {
 
 using namespace NActors;
 
 class TGRpcEndpointPublishActor : public TActorBootstrapped<TGRpcEndpointPublishActor> {
+    // Update period for load_factor polling from Node Whiteboard.
+    // Synchronized with Node Whiteboard's internal update period (15 seconds)
+    // to ensure we always get fresh data without unnecessary polling.
+    static constexpr int LOAD_FACTOR_UPDATE_PERIOD_SECONDS = 15;
+    
+    // Minimum relative change in load_factor to trigger an update (1%).
+    // This prevents excessive updates to State Storage Board when load fluctuates slightly.
+    static constexpr float LOAD_FACTOR_CHANGE_THRESHOLD = 0.01f;
+
     TIntrusivePtr<TGrpcEndpointDescription> Description;
     TString SelfDatacenter;
     std::optional<TString> BridgePileName;
     TActorId PublishActor;
+    float CurrentLoadFactor = 0.0f;
 
-    void CreatePublishActor() {
-        ui32 nodeId = SelfId().NodeId();
-        TString database = AppData()->TenantName;
-
-        auto *domains = AppData()->DomainsInfo.Get();
-        auto domainName = ExtractDomain(database);
-        auto *domainInfo = domains->GetDomainByName(domainName);
-        if (!domainInfo)
-            return;
-
-        auto assignedPath = MakeEndpointsBoardPath(database);
-        TString payload;
-        NKikimrStateStorage::TEndpointBoardEntry entry;
+    void BuildEndpointBoardEntry(NKikimrStateStorage::TEndpointBoardEntry& entry, ui32 nodeId) {
         entry.SetAddress(Description->Address);
         entry.SetPort(Description->Port);
-        entry.SetLoad(0.0f);
+        entry.SetLoad(CurrentLoadFactor);
         entry.SetSsl(Description->Ssl);
         entry.MutableServices()->Reserve(Description->ServedServices.size());
         entry.SetDataCenter(SelfDatacenter);
@@ -58,10 +57,36 @@ class TGRpcEndpointPublishActor : public TActorBootstrapped<TGRpcEndpointPublish
         if (BridgePileName) {
             entry.SetBridgePileName(*BridgePileName);
         }
+    }
+
+    void CreatePublishActor() {
+        ui32 nodeId = SelfId().NodeId();
+        TString database = AppData()->TenantName;
+
+        auto *domains = AppData()->DomainsInfo.Get();
+        auto domainName = ExtractDomain(database);
+        auto *domainInfo = domains->GetDomainByName(domainName);
+        if (!domainInfo)
+            return;
+
+        auto assignedPath = MakeEndpointsBoardPath(database);
+        TString payload;
+        NKikimrStateStorage::TEndpointBoardEntry entry;
+        BuildEndpointBoardEntry(entry, nodeId);
 
         Y_ABORT_UNLESS(entry.SerializeToString(&payload));
 
         PublishActor = Register(CreateBoardPublishActor(assignedPath, payload, SelfId(), 0, true));
+    }
+    
+    void UpdatePublishActor() {
+        TString payload;
+        NKikimrStateStorage::TEndpointBoardEntry entry;
+        BuildEndpointBoardEntry(entry, SelfId().NodeId());
+        
+        Y_ABORT_UNLESS(entry.SerializeToString(&payload));
+        
+        Send(PublishActor, new TEvStateStorage::TEvBoardPublishUpdate(payload));
     }
 
     void PassAway() override {
@@ -83,6 +108,44 @@ class TGRpcEndpointPublishActor : public TActorBootstrapped<TGRpcEndpointPublish
         }
         CreatePublishActor();
         Become(&TThis::StateWork);
+        
+        // Schedule periodic load factor updates
+        Schedule(TDuration::Seconds(LOAD_FACTOR_UPDATE_PERIOD_SECONDS), new TEvents::TEvWakeup());
+    }
+
+    void Handle(NNodeWhiteboard::TEvWhiteboard::TEvSystemStateResponse::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+
+        if (record.SystemStateInfoSize() == 0) {
+            return;
+        }
+
+        const auto& systemState = record.GetSystemStateInfo(0);
+        if (systemState.LoadAverageSize() == 0) {
+            return;
+        }
+
+        auto loadAvg = systemState.GetLoadAverage(0);
+        auto numCpus = systemState.GetNumberOfCpus();
+        if (numCpus == 0) {
+            return;
+        }
+    
+        auto newLoadFactor = loadAvg / numCpus;
+        if (std::abs(newLoadFactor - CurrentLoadFactor) >= LOAD_FACTOR_CHANGE_THRESHOLD) {
+            CurrentLoadFactor = newLoadFactor;
+
+            if (PublishActor) {
+                UpdatePublishActor();
+            }
+        }
+    }
+
+    void Wakeup() {
+        Send(NNodeWhiteboard::MakeNodeWhiteboardServiceId(SelfId().NodeId()),
+             new NNodeWhiteboard::TEvWhiteboard::TEvSystemStateRequest());
+        
+        Schedule(TDuration::Seconds(LOAD_FACTOR_UPDATE_PERIOD_SECONDS), new TEvents::TEvWakeup());
     }
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -110,6 +173,8 @@ public:
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
+            hFunc(NNodeWhiteboard::TEvWhiteboard::TEvSystemStateResponse, Handle);
+            sFunc(TEvents::TEvWakeup, Wakeup);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }


### PR DESCRIPTION
### Changelog entry

Discovery service now returns actual node load in the load_factor field. Clients can use this metric for load-aware balancing when selecting database endpoints.

### Changelog category

* Improvement

### Description for reviewers

**Problem**:
The `Ydb.Discovery.V1.DiscoveryService/ListEndpoints` method always returned `load_factor = 0`, making it impossible for clients to perform load-aware balancing across database nodes.

**Solution**:
- Added new event `TEvBoardPublishUpdate` for updating data in State Storage Board 
- Added handlers for `TEvBoardPublishUpdate` in `TBoardPublishActor` and `TBoardReplicaPublishActor`
- Updated `TGRpcEndpointPublishActor`, now it:
  - Polls Node Whiteboard every 15 seconds (synchronized with Whiteboard update period)
  - Calculates `load_factor = LoadAverage[0] / NumberOfCpus`
  - Sends updates to State Storage Board when change >= 0.01 using `TEvBoardPublishUpdate`
- Added Python functional test to verify load_factor updates
