### PR TITLE
YQ-5016 disabled default timeout for streaming queries

### DIFF
--- a/ydb/core/kqp/common/kqp_timeouts.cpp
+++ b/ydb/core/kqp/common/kqp_timeouts.cpp
@@ -38,18 +38,20 @@ ui64 GetDefaultQueryTimeoutMs(NKikimrKqp::EQueryType queryType,
     }
 }
 
-}
+} // anonymous namespace
 
-TDuration GetQueryTimeout(NKikimrKqp::EQueryType queryType,
-                          ui64 timeoutMs,
-                          const NKikimrConfig::TTableServiceConfig& tableServiceConfig,
-                          const NKikimrConfig::TQueryServiceConfig& queryServiceConfig) {
+TDuration GetQueryTimeout(NKikimrKqp::EQueryType queryType, ui64 timeoutMs, const NKikimrConfig::TTableServiceConfig& tableServiceConfig,
+    const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, bool disableDefaultTimeout)
+{
+    if (disableDefaultTimeout && timeoutMs) {
+        return TDuration::MilliSeconds(timeoutMs);
+    }
+
     ui64 defaultTimeoutMs = GetDefaultQueryTimeoutMs(queryType, tableServiceConfig, queryServiceConfig);
-
 
     return timeoutMs
         ? TDuration::MilliSeconds(Min(defaultTimeoutMs, timeoutMs))
         : TDuration::MilliSeconds(defaultTimeoutMs);
 }
 
-}
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/kqp_timeouts.h
+++ b/ydb/core/kqp/common/kqp_timeouts.h
@@ -9,9 +9,7 @@ namespace NKikimr::NKqp {
 
 constexpr TDuration SCRIPT_TIMEOUT_LIMIT = TDuration::Days(365);
 
-TDuration GetQueryTimeout(NKikimrKqp::EQueryType queryType,
-                          ui64 timeoutMs,
-                          const NKikimrConfig::TTableServiceConfig& tableServiceConfig,
-                          const NKikimrConfig::TQueryServiceConfig& queryServiceConfig);
+TDuration GetQueryTimeout(NKikimrKqp::EQueryType queryType, ui64 timeoutMs, const NKikimrConfig::TTableServiceConfig& tableServiceConfig,
+    const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, bool disableDefaultTimeout);
 
-}
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -731,7 +731,7 @@ public:
 
         auto cancelAfter = ev->Get()->GetCancelAfter();
         auto timeout = ev->Get()->GetOperationTimeout();
-        auto timerDuration = ev->Get()->GetDisableDefaultTimeout() ? timeout : GetQueryTimeout(queryType, timeout.MilliSeconds(), TableServiceConfig, QueryServiceConfig);
+        auto timerDuration = GetQueryTimeout(queryType, timeout.MilliSeconds(), TableServiceConfig, QueryServiceConfig, ev->Get()->GetDisableDefaultTimeout());
         if (cancelAfter) {
             timerDuration = Min(timerDuration, cancelAfter);
         }
@@ -746,7 +746,7 @@ public:
     void Handle(TEvKqp::TEvScriptRequest::TPtr& ev) {
         if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::ScriptRequest)) {
             auto req = ev->Get()->Record.MutableRequest();
-            auto maxRunTime = ev->Get()->DisableDefaultTimeout ? TDuration::MilliSeconds(req->GetTimeoutMs()) : GetQueryTimeout(req->GetType(), req->GetTimeoutMs(), TableServiceConfig, QueryServiceConfig);
+            auto maxRunTime = GetQueryTimeout(req->GetType(), req->GetTimeoutMs(), TableServiceConfig, QueryServiceConfig, ev->Get()->DisableDefaultTimeout);
             req->SetTimeoutMs(maxRunTime.MilliSeconds());
             if (req->GetCancelAfterMs()) {
                 maxRunTime = TDuration::MilliSeconds(Min(req->GetCancelAfterMs(), maxRunTime.MilliSeconds()));

--- a/ydb/core/kqp/rm_service/kqp_snapshot_manager.cpp
+++ b/ydb/core/kqp/rm_service/kqp_snapshot_manager.cpp
@@ -300,7 +300,9 @@ private:
     const TDuration MaxRefreshDuration = TDuration::Seconds(10);
 
     TDuration RequestTimeout;
-    TDuration SnapshotTimeout = RequestTimeout * SnapshotToRequestTimeoutRatio;
+    TDuration SnapshotTimeout = TDuration::FromValue(
+        Min(RequestTimeout.GetValue() * SnapshotToRequestTimeoutRatio, MaxFloor<TDuration::TValue>())
+    ); // Multiply with saturation
     TDuration RefreshInterval = Min(RequestTimeout * RefreshToRequestTimeoutRatio, MaxRefreshDuration);
 };
 

--- a/ydb/core/kqp/rm_service/kqp_snapshot_manager.cpp
+++ b/ydb/core/kqp/rm_service/kqp_snapshot_manager.cpp
@@ -27,6 +27,8 @@ public:
     TSnapshotManagerActor(const TString& database, TDuration queryTimeout)
         : Database(database)
         , RequestTimeout(queryTimeout)
+        , SnapshotTimeout(MultiplyWithSaturation(RequestTimeout, SnapshotToRequestTimeoutRatio))
+        , RefreshInterval(Min(MultiplyWithSaturation(RequestTimeout, RefreshToRequestTimeoutRatio), MaxRefreshDuration))
     {}
 
     void Bootstrap() {
@@ -283,6 +285,10 @@ private:
         PassAway();
     }
 
+    static TDuration MultiplyWithSaturation(TDuration duration, double value) {
+        return TDuration::FromValue(Min(duration.GetValue() * value, MaxFloor<TDuration::TValue>()));
+    }
+
 private:
     const TString Database;
     TVector<TString> Tables;
@@ -298,12 +304,9 @@ private:
     const double SnapshotToRequestTimeoutRatio = 1.5;
     const double RefreshToRequestTimeoutRatio = 0.5;
     const TDuration MaxRefreshDuration = TDuration::Seconds(10);
-
-    TDuration RequestTimeout;
-    TDuration SnapshotTimeout = TDuration::FromValue(
-        Min(RequestTimeout.GetValue() * SnapshotToRequestTimeoutRatio, MaxFloor<TDuration::TValue>())
-    ); // Multiply with saturation
-    TDuration RefreshInterval = Min(RequestTimeout * RefreshToRequestTimeoutRatio, MaxRefreshDuration);
+    const TDuration RequestTimeout;
+    const TDuration SnapshotTimeout;
+    const TDuration RefreshInterval;
 };
 
 } // anonymous namespace

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -694,7 +694,7 @@ private:
         }
 
         if (record.GetYdbStatus() == Ydb::StatusIds::TIMEOUT) {
-            const TDuration timeout = GetQueryTimeout(NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT, Request.GetRequest().GetTimeoutMs(), {}, QueryServiceConfig);
+            const TDuration timeout = GetQueryTimeout(NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT, Request.GetRequest().GetTimeoutMs(), {}, QueryServiceConfig, DisableDefaultTimeout);
             NYql::TIssue timeoutIssue(TStringBuilder() << "Current request timeout is " << timeout.MilliSeconds() << "ms");
             timeoutIssue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
             Issues.AddIssue(std::move(timeoutIssue));

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -274,8 +274,8 @@ public:
             QueryDeadlines.CancelAt = now + cancelAfter;
         }
 
-        auto timeoutMs = GetQueryTimeout(GetType(), timeout.MilliSeconds(), tableService, queryService);
-        QueryDeadlines.TimeoutAt = now + timeoutMs;
+        auto timeoutDuration = GetQueryTimeout(GetType(), timeout.MilliSeconds(), tableService, queryService, RequestEv->GetDisableDefaultTimeout());
+        QueryDeadlines.TimeoutAt = now + timeoutDuration;
     }
 
     bool HasTopicOperations() const {

--- a/ydb/core/kqp/session_actor/kqp_worker_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_worker_actor.cpp
@@ -213,7 +213,7 @@ public:
             QueryState->QueryDeadlines.CancelAt = now + QueryState->RequestEv->GetCancelAfter();
         }
 
-        auto timeoutMs = GetQueryTimeout(QueryState->RequestEv->GetType(), QueryState->RequestEv->GetOperationTimeout().MilliSeconds(), Settings.TableService, Settings.QueryService);
+        auto timeoutMs = GetQueryTimeout(QueryState->RequestEv->GetType(), QueryState->RequestEv->GetOperationTimeout().MilliSeconds(), Settings.TableService, Settings.QueryService, QueryState->RequestEv->GetDisableDefaultTimeout());
         QueryState->QueryDeadlines.TimeoutAt = now + timeoutMs;
 
         auto onError = [this, &ctx] (Ydb::StatusIds::StatusCode status, const TString& message) {

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -3660,6 +3660,46 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
 
         CheckScriptExecutionsCount(0, 0);
     }
+
+    Y_UNIT_TEST_F(CreateStreamingQueryUnderTimeout, TStreamingWithSchemaSecretsTestFixture) {
+        auto& config = *SetupAppConfig().MutableQueryServiceConfig();
+        config.SetQueryTimeoutDefaultSeconds(3);
+        config.SetScriptOperationTimeoutDefaultSeconds(3);
+
+        constexpr char inputTopicName[] = "createStreamingQueryUnderTimeoutInputTopic";
+        constexpr char outputTopicName[] = "createStreamingQueryUnderTimeoutOutputTopic";
+        CreateTopic(inputTopicName);
+        CreateTopic(outputTopicName);
+
+        constexpr char pqSourceName[] = "sourceName";
+        CreatePqSource(pqSourceName);
+
+        constexpr char queryName[] = "streamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}`
+                SELECT * FROM `{pq_source}`.`{input_topic}`
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(5));
+
+        WriteTopicMessage(inputTopicName, "data1");
+        ReadTopicMessage(outputTopicName, "data1");
+        Sleep(TDuration::Seconds(5));
+
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+        const auto& result = ExecQuery("SELECT RetryCount FROM `.sys/streaming_queries`");
+        UNIT_ASSERT_VALUES_EQUAL(result.size(), 1);
+        CheckScriptResult(result[0], 1, 1, [&](TResultSetParser& resultSet) {
+            UNIT_ASSERT_VALUES_EQUAL(*resultSet.ColumnParser("RetryCount").GetOptionalUint64(), 0);
+        });
+    }
 }
 
 Y_UNIT_TEST_SUITE(KqpStreamingQueriesSysView) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Disabled default timeout for streaming queries

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Bugfix ticket: https://st.yandex-team.ru/YQ-5016
