### PR TITLE
Multi-Pipe Follower Cache Implementation

### DIFF
--- a/ydb/core/base/tablet_pipecache.h
+++ b/ydb/core/base/tablet_pipecache.h
@@ -134,6 +134,7 @@ struct TEvPipeCache {
 struct TPipePerNodeCacheConfig : public TAtomicRefCount<TPipePerNodeCacheConfig>{
     ui64 TabletCacheLimit = 500000;
     TDuration PipeRefreshTime = TDuration::Zero();
+    ui32 MaxActiveClients = 1;  // Max concurrent follower connections per tablet
     NTabletPipe::TClientConfig PipeConfig = DefaultPipeConfig();
     ::NMonitoring::TDynamicCounterPtr Counters;
 

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -1435,6 +1435,7 @@ void TTabletPipePerNodeCachesInitializer::InitializeServices(
 
     TIntrusivePtr<TPipePerNodeCacheConfig> followerPipeConfig = new TPipePerNodeCacheConfig();
     followerPipeConfig->PipeRefreshTime = TDuration::Seconds(30);
+    followerPipeConfig->MaxActiveClients = 10;
     followerPipeConfig->PipeConfig.AllowFollower = true;
     followerPipeConfig->Counters = counters->GetSubgroup("type", "FOLLOWER_PIPE_CACHE");
 

--- a/ydb/core/tablet/tablet_pipecache.cpp
+++ b/ydb/core/tablet/tablet_pipecache.cpp
@@ -7,6 +7,8 @@
 #include <util/generic/hash_set.h>
 #include <ydb/library/actors/core/hfunc.h>
 
+#include <algorithm>
+
 namespace NKikimr {
 
 class TPipePerNodeCache : public TActor<TPipePerNodeCache> {
@@ -80,7 +82,9 @@ class TPipePerNodeCache : public TActor<TPipePerNodeCache> {
         THashMap<TActorId, TClientState> ByClient;
         THashMap<TActorId, TClientState*> ByPeer;
 
-        TActorId LastClient;
+        // Multiple active clients for round-robin distribution
+        TVector<TActorId> ActiveClients;
+        ui32 NextClientIndex = 0;
         TInstant LastCreated;
 
         TClientState* FindClient(const TActorId& clientId) {
@@ -92,21 +96,71 @@ class TPipePerNodeCache : public TActor<TPipePerNodeCache> {
         }
 
         TClientState* GetActive() {
-            return ByClient.FindPtr(LastClient);
+            if (ActiveClients.empty()) {
+                return nullptr;
+            }
+            return FindClient(ActiveClients[0]);
+        }
+
+        TClientState* GetNextActiveClient() {
+            if (ActiveClients.empty()) {
+                return nullptr;
+            }
+            // Round-robin selection among active clients
+            NextClientIndex = (NextClientIndex + 1) % ActiveClients.size();
+            return FindClient(ActiveClients[NextClientIndex]);
         }
 
         bool IsActive(const TActorId& client) const {
-            return client == LastClient;
+            return std::find(ActiveClients.begin(), ActiveClients.end(), client) != ActiveClients.end();
         }
 
         bool IsActive(TClientState* clientState) const {
-            return clientState->Client == LastClient;
+            return IsActive(clientState->Client);
+        }
+
+        void AddActiveClient(const TActorId& client) {
+            if (!IsActive(client)) {
+                ActiveClients.push_back(client);
+            }
+        }
+
+        void RemoveActiveClient(const TActorId& client) {
+            auto it = std::find(ActiveClients.begin(), ActiveClients.end(), client);
+            if (it != ActiveClients.end()) {
+                ActiveClients.erase(it);
+                if (NextClientIndex >= ActiveClients.size() && !ActiveClients.empty()) {
+                    NextClientIndex = 0;
+                }
+            }
         }
 
         void Deactivate(const TActorId& client) {
-            if (LastClient == client) {
-                LastClient = TActorId();
+            RemoveActiveClient(client);
+        }
+
+        // Count how many active clients are connected to a specific follower node
+        ui32 CountClientsOnNode(ui32 nodeId) const {
+            ui32 count = 0;
+            for (const auto& clientId : ActiveClients) {
+                auto it = ByClient.find(clientId);
+                if (it != ByClient.end() && it->second.NodeId == nodeId && it->second.Connected) {
+                    ++count;
+                }
             }
+            return count;
+        }
+
+        // Get a list of connected follower NodeIds
+        THashSet<ui32> GetConnectedNodes() const {
+            THashSet<ui32> nodes;
+            for (const auto& clientId : ActiveClients) {
+                auto it = ByClient.find(clientId);
+                if (it != ByClient.end() && it->second.Connected && it->second.NodeId != 0) {
+                    nodes.insert(it->second.NodeId);
+                }
+            }
+            return nodes;
         }
     };
 
@@ -231,39 +285,111 @@ class TPipePerNodeCache : public TActor<TPipePerNodeCache> {
         }
     }
 
-    TClientState* EnsureClient(TTabletState *tabletState, ui64 tabletId) {
-        TClientState *clientState = nullptr;
-        if (!tabletState->LastClient || tabletState->ForceReconnect || Config->PipeRefreshTime && tabletState->ByClient.size() < 2 && Config->PipeRefreshTime < (TActivationContext::Now() - tabletState->LastCreated)) {
-            tabletState->ForceReconnect = false;
-            // Remove current client if it is idle
-            if (tabletState->LastClient) {
-                clientState = tabletState->FindClient(tabletState->LastClient);
-                Y_ABORT_UNLESS(clientState);
-                if (clientState->Peers.empty()) {
-                    if (Counters) {
-                        if (clientState->Connected) {
-                            Counters.PipesActive->Dec();
-                        } else {
-                            Counters.PipesConnecting->Dec();
-                        }
-                    }
-                    NTabletPipe::CloseClient(SelfId(), tabletState->LastClient);
-                    tabletState->ByClient.erase(tabletState->LastClient);
-                    tabletState->LastClient = TActorId();
+    bool TryRemoveIdleClient(TTabletState *tabletState, const TActorId& clientId) {
+        auto* cs = tabletState->FindClient(clientId);
+        if (!cs || !cs->Peers.empty()) {
+            return false;  // Client has peers, can't remove
+        }
+        if (Counters) {
+            if (cs->Connected) {
+                Counters.PipesActive->Dec();
+            } else {
+                Counters.PipesConnecting->Dec();
+            }
+        }
+        NTabletPipe::CloseClient(SelfId(), clientId);
+        tabletState->ByClient.erase(clientId);
+        tabletState->RemoveActiveClient(clientId);
+        return true;
+    }
+
+    void CleanupIdleClients(TTabletState *tabletState) {
+        // Remove idle active clients (those with no peers)
+        // Keep at least one client for immediate use
+        TVector<TActorId> toRemove;
+        for (const auto& clientId : tabletState->ActiveClients) {
+            if (tabletState->ActiveClients.size() - toRemove.size() <= 1) {
+                break;  // Keep at least one client
+            }
+            if (auto* cs = tabletState->FindClient(clientId)) {
+                if (cs->Peers.empty() && cs->Connected) {
+                    toRemove.push_back(clientId);
                 }
             }
+        }
+
+        for (const auto& clientId : toRemove) {
+            TryRemoveIdleClient(tabletState, clientId);
+        }
+    }
+
+    TClientState* EnsureClient(TTabletState *tabletState, ui64 tabletId) {
+        // Count connected clients among active ones
+        ui32 connectedCount = 0;
+        for (const auto& clientId : tabletState->ActiveClients) {
+            if (auto* cs = tabletState->FindClient(clientId)) {
+                if (cs->Connected) {
+                    connectedCount++;
+                }
+            }
+        }
+
+        bool refreshExpired = Config->PipeRefreshTime &&
+            Config->PipeRefreshTime < (TActivationContext::Now() - tabletState->LastCreated);
+
+        // Periodically cleanup idle clients when we have many
+        if (refreshExpired && tabletState->ActiveClients.size() > 1) {
+            CleanupIdleClients(tabletState);
+        }
+
+        // Determine if we need to create a new client
+        bool needNewClient = tabletState->ActiveClients.empty() ||
+            tabletState->ForceReconnect ||
+            (connectedCount < Config->MaxActiveClients &&
+             tabletState->ActiveClients.size() < Config->MaxActiveClients &&
+             refreshExpired);
+
+        // When at MaxActiveClients limit and need new client (refresh or force), try to remove an idle client
+        if (needNewClient && tabletState->ActiveClients.size() >= Config->MaxActiveClients) {
+            // Copy the list to avoid iterator invalidation when removing
+            TVector<TActorId> clientsCopy = tabletState->ActiveClients;
+            for (const auto& clientId : clientsCopy) {
+                if (TryRemoveIdleClient(tabletState, clientId)) {
+                    break;
+                }
+            }
+        }
+
+        // Also try to rotate when refresh expired even if we didn't initially need a new client
+        if (!needNewClient && refreshExpired &&
+            tabletState->ActiveClients.size() >= Config->MaxActiveClients) {
+            // Copy the list to avoid iterator invalidation when removing
+            TVector<TActorId> clientsCopy = tabletState->ActiveClients;
+            for (const auto& clientId : clientsCopy) {
+                if (TryRemoveIdleClient(tabletState, clientId)) {
+                    needNewClient = true;
+                    break;
+                }
+            }
+        }
+
+        if (needNewClient && tabletState->ActiveClients.size() < Config->MaxActiveClients) {
+            tabletState->ForceReconnect = false;
             if (Counters) {
                 Counters.PipesConnecting->Inc();
                 Counters.EventCreate->Inc();
             }
-            tabletState->LastClient = Register(NTabletPipe::CreateClient(SelfId(), tabletId, PipeConfig));
+            TActorId newClient = Register(NTabletPipe::CreateClient(SelfId(), tabletId, PipeConfig));
             tabletState->LastCreated = TActivationContext::Now();
-            clientState = &tabletState->ByClient[tabletState->LastClient];
-            clientState->Client = tabletState->LastClient;
-        } else {
-            clientState = tabletState->FindClient(tabletState->LastClient);
-            Y_ABORT_UNLESS(clientState, "Missing expected client state for active client");
+            auto& clientState = tabletState->ByClient[newClient];
+            clientState.Client = newClient;
+            tabletState->AddActiveClient(newClient);
+            return &clientState;
         }
+
+        // Round-robin among existing active clients
+        TClientState* clientState = tabletState->GetNextActiveClient();
+        Y_ABORT_UNLESS(clientState, "Missing expected client state for active client");
         return clientState;
     }
 
@@ -439,6 +565,29 @@ class TPipePerNodeCache : public TActor<TPipePerNodeCache> {
                 auto nodeRequests = std::move(clientState->NodeRequests);
                 for (auto &req : nodeRequests) {
                     Send(req.Sender, new TEvPipeCache::TEvGetTabletNodeResult(msg->TabletId, clientState->NodeId), 0, req.Cookie);
+                }
+
+                // Check for duplicate connections to the same follower node
+                // If this is a duplicate and we have many clients, close an idle duplicate
+                if (Config->MaxActiveClients > 1 && clientState->NodeId != 0) {
+                    ui32 duplicateCount = tabletState->CountClientsOnNode(clientState->NodeId);
+                    if (duplicateCount > 1) {
+                        // We have multiple connections to the same follower - try to close an idle one
+                        TVector<TActorId> clientsCopy = tabletState->ActiveClients;
+                        for (const auto& otherId : clientsCopy) {
+                            if (otherId == msg->ClientId) {
+                                continue;  // Don't close the one we just connected
+                            }
+                            auto* otherClient = tabletState->FindClient(otherId);
+                            if (otherClient && otherClient->NodeId == clientState->NodeId &&
+                                otherClient->Connected && otherClient->Peers.empty()) {
+                                // Found an idle duplicate - close it and force reconnect
+                                TryRemoveIdleClient(tabletState, otherId);
+                                tabletState->ForceReconnect = true;
+                                break;
+                            }
+                        }
+                    }
                 }
                 return;
             }

--- a/ydb/core/tablet/tablet_pipecache_ut.cpp
+++ b/ydb/core/tablet/tablet_pipecache_ut.cpp
@@ -282,6 +282,563 @@ Y_UNIT_TEST_SUITE(TPipeCacheTest) {
             UNIT_ASSERT(!ev);
         }
     }
+
+    Y_UNIT_TEST(TestMultipleActiveClients) {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        size_t observedConnects = 0;
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->Type == TEvTabletPipe::EvConnect) {
+                ++observedConnects;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        // Configure pipe cache with multiple active clients
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->PipeRefreshTime = TDuration::Seconds(1);
+        config->MaxActiveClients = 3;
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Send 3 requests with time advances to create up to 3 clients
+        for (size_t i = 0; i < 3; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                true)), 0, true);  // subscribe = true to keep client alive
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        }
+
+        // With MaxActiveClients=3, we should have created 3 connections
+        UNIT_ASSERT_C(observedConnects == 3,
+            "Expected 3 connections with MaxActiveClients=3, got " << observedConnects);
+    }
+
+    Y_UNIT_TEST(TestRoundRobinDistribution) {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        size_t totalConnects = 0;
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->Type == TEvTabletPipe::EvConnect) {
+                ++totalConnects;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        // Configure pipe cache with multiple active clients
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->PipeRefreshTime = TDuration::Seconds(1);
+        config->MaxActiveClients = 3;
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // First, create all 3 clients by sending requests with time advances
+        for (size_t i = 0; i < 3; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                true)), 0, true);  // subscribe = true to keep client alive
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        }
+
+        size_t connectsAfterSetup = totalConnects;
+        UNIT_ASSERT_C(connectsAfterSetup == 3,
+            "Expected 3 connections during setup, got " << connectsAfterSetup);
+
+        // Now send many requests without time advance - should reuse existing clients via round-robin
+        for (size_t i = 0; i < 30; ++i) {
+            runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                false)), 0, true);  // subscribe = false for round-robin test
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        }
+
+        // No new connections should be created (round-robin uses existing)
+        UNIT_ASSERT_C(totalConnects == connectsAfterSetup,
+            "Expected no new connections during round-robin, but got " << (totalConnects - connectsAfterSetup) << " new ones");
+    }
+
+    Y_UNIT_TEST(TestForceReconnect) {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        size_t observedConnects = 0;
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->Type == TEvTabletPipe::EvConnect) {
+                ++observedConnects;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->MaxActiveClients = 1;  // Single client to test force reconnect
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // First request creates a connection
+        runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0,
+            false)), 0, true);
+        runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        UNIT_ASSERT_VALUES_EQUAL(observedConnects, 1u);
+
+        // Second request without force reconnect reuses the connection
+        runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0,
+            false)), 0, true);
+        runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        UNIT_ASSERT_VALUES_EQUAL(observedConnects, 1u);
+
+        // Force reconnect
+        runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForcePipeReconnect(TTestTxConfig::TxTablet0)), 0, true);
+        // Ensure the force reconnect event is processed
+        {
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&]() { return true; };
+            runtime.DispatchEvents(options, TDuration::MilliSeconds(10));
+        }
+
+        // Next request should create a new connection
+        runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0,
+            false)), 0, true);
+        runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        UNIT_ASSERT_VALUES_EQUAL(observedConnects, 2u);
+    }
+
+    Y_UNIT_TEST(TestIdleClientCleanup) {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        size_t observedConnects = 0;
+        size_t observedCloses = 0;
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->Type == TEvTabletPipe::EvConnect) {
+                ++observedConnects;
+            } else if (ev->Type == TEvents::TEvPoisonPill::EventType) {
+                ++observedCloses;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->PipeRefreshTime = TDuration::Seconds(1);
+        config->MaxActiveClients = 3;
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Create 3 clients with time advances
+        for (size_t i = 0; i < 3; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                false)), 0, true);
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(observedConnects, 3u);
+
+        // Now advance time and send requests - idle clients should be cleaned up and rotated
+        size_t initialCloses = observedCloses;
+        for (size_t i = 0; i < 5; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                false)), 0, true);
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        }
+
+        // Some idle clients should have been closed and new ones created
+        UNIT_ASSERT_C(observedConnects > 3u,
+            "Expected more connections due to rotation, got " << observedConnects);
+        UNIT_ASSERT_C(observedCloses > initialCloses,
+            "Expected some client closes due to idle cleanup, got " << (observedCloses - initialCloses));
+    }
+
+    Y_UNIT_TEST(TestClientDisconnectWithMultipleActive) {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->PipeRefreshTime = TDuration::Seconds(1);
+        config->MaxActiveClients = 2;
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Create first client with subscription
+        runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0, {
+                .Subscribe = true,
+                .SubscribeCookie = 1,
+            })), 0, true);
+        auto ev1 = runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        TActorId client1 = ev1->Get()->ClientId;
+
+        // Create second client with time advance
+        runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+        TActorId sender2 = runtime.AllocateEdgeActor();
+        runtime.Send(new IEventHandle(cacheActor, sender2, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0, {
+                .Subscribe = true,
+                .SubscribeCookie = 2,
+            })), 0, true);
+        auto ev2 = runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender2);
+        TActorId client2 = ev2->Get()->ClientId;
+
+        UNIT_ASSERT(client1 != client2);
+
+        // Kill client1 - sender should get delivery problem
+        runtime.Send(new IEventHandle(client1, sender, new TEvents::TEvPoison), 0, true);
+        auto problem = runtime.GrabEdgeEventRethrow<TEvPipeCache::TEvDeliveryProblem>(sender, TDuration::Seconds(1));
+        UNIT_ASSERT(problem);
+        UNIT_ASSERT_VALUES_EQUAL(problem->Cookie, 1u);
+
+        // sender2 should still work with client2
+        runtime.Send(new IEventHandle(cacheActor, sender2, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0, {
+                .AutoConnect = false,
+                .Subscribe = false,
+            })), 0, true);
+        auto ev3 = runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender2, TDuration::Seconds(1));
+        UNIT_ASSERT(ev3);
+        UNIT_ASSERT_VALUES_EQUAL(ev3->Get()->ClientId, client2);
+    }
+
+    Y_UNIT_TEST(TestMaxActiveClientsLimit) {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        size_t observedConnects = 0;
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->Type == TEvTabletPipe::EvConnect) {
+                ++observedConnects;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->PipeRefreshTime = TDuration::Seconds(1);
+        config->MaxActiveClients = 2;  // Limit to 2
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        // Use 2 senders that subscribe to keep clients alive
+        TActorId sender1 = runtime.AllocateEdgeActor();
+        TActorId sender2 = runtime.AllocateEdgeActor();
+
+        // Create first client
+        runtime.Send(new IEventHandle(cacheActor, sender1, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0, {
+                .Subscribe = true,
+            })), 0, true);
+        runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender1);
+        UNIT_ASSERT_VALUES_EQUAL(observedConnects, 1u);
+
+        // Create second client with time advance
+        runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+        runtime.Send(new IEventHandle(cacheActor, sender2, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0, {
+                .Subscribe = true,
+            })), 0, true);
+        runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender2);
+        UNIT_ASSERT_VALUES_EQUAL(observedConnects, 2u);
+
+        // Try to create a third client with time advance - should not create new one
+        // because both existing clients have subscribers
+        runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+        TActorId sender3 = runtime.AllocateEdgeActor();
+        runtime.Send(new IEventHandle(cacheActor, sender3, new TEvPipeCache::TEvForward(
+            new TEvCustomTablet::TEvHelloRequest,
+            TTestTxConfig::TxTablet0, {
+                .Subscribe = true,
+            })), 0, true);
+        runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender3);
+        // No new connection because we're at limit and no idle clients to remove
+        UNIT_ASSERT_VALUES_EQUAL(observedConnects, 2u);
+    }
+
+    Y_UNIT_TEST(TestBackwardCompatibilitySingleClient) {
+        // Test that with MaxActiveClients=1 (default), behavior is similar to before
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        size_t observedConnects = 0;
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->Type == TEvTabletPipe::EvConnect) {
+                ++observedConnects;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->PipeRefreshTime = TDuration::Seconds(1);
+        // MaxActiveClients defaults to 1
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Send multiple requests without subscription
+        for (size_t i = 0; i < 5; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                false)), 0, true);
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        }
+
+        // With MaxActiveClients=1 and PipeRefreshTime, idle clients get rotated
+        // Each time the refresh expires, the idle client is replaced
+        UNIT_ASSERT_C(observedConnects >= 4,
+            "Expected at least 4 connections due to idle rotation with MaxActiveClients=1, got " << observedConnects);
+    }
+
+    Y_UNIT_TEST(TestDuplicateFollowerDetection) {
+        // Test that duplicate connections to the same follower node are detected and removed
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        size_t observedConnects = 0;
+        size_t observedCloses = 0;
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->Type == TEvTabletPipe::EvConnect) {
+                ++observedConnects;
+            } else if (ev->Type == TEvents::TEvPoisonPill::EventType) {
+                ++observedCloses;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        // Configure pipe cache with multiple active clients
+        // All clients will connect to the same node (single-node test), triggering duplicate detection
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->PipeRefreshTime = TDuration::Seconds(1);
+        config->MaxActiveClients = 3;
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Create 3 idle clients (no subscribers) with time advances
+        // All will connect to the same node, so duplicates will be detected
+        for (size_t i = 0; i < 3; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                false)), 0, true);  // subscribe = false means clients are idle
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        }
+
+        // Initially we should have created 3 connections
+        UNIT_ASSERT_C(observedConnects >= 3,
+            "Expected at least 3 connections, got " << observedConnects);
+
+        // When duplicate detection triggers on the 2nd and 3rd client connecting to the same node,
+        // it should close idle duplicates and set ForceReconnect.
+        // The next request after ForceReconnect should create additional connections.
+        size_t connectsAfterInitial = observedConnects;
+
+        // Send more requests with time advances to trigger ForceReconnect processing
+        for (size_t i = 0; i < 5; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, sender, new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                false)), 0, true);
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(sender);
+        }
+
+        // With duplicate detection, we should see more connections as duplicates are replaced
+        UNIT_ASSERT_C(observedConnects > connectsAfterInitial,
+            "Expected more connections due to duplicate detection and ForceReconnect, "
+            "got " << observedConnects << " (was " << connectsAfterInitial << ")");
+
+        // We should also see some closes due to duplicate removal
+        UNIT_ASSERT_C(observedCloses > 0,
+            "Expected some client closes due to duplicate detection, got " << observedCloses);
+    }
+
+    Y_UNIT_TEST(TestDuplicateDetectionWithSubscribers) {
+        // Test that duplicate detection does NOT remove clients that have subscribers
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TCustomTablet(tablet, info);
+            });
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
+        size_t observedConnects = 0;
+        size_t observedCloses = 0;
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->Type == TEvTabletPipe::EvConnect) {
+                ++observedConnects;
+            } else if (ev->Type == TEvents::TEvPoisonPill::EventType) {
+                ++observedCloses;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
+        config->PipeRefreshTime = TDuration::Seconds(1);
+        config->MaxActiveClients = 3;
+        auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
+
+        // Create 3 clients WITH subscribers - they should not be removed by duplicate detection
+        TVector<TActorId> senders;
+        for (size_t i = 0; i < 3; ++i) {
+            senders.push_back(runtime.AllocateEdgeActor());
+        }
+
+        for (size_t i = 0; i < 3; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, senders[i], new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0, {
+                    .Subscribe = true,  // Subscribe keeps client alive
+                })), 0, true);
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(senders[i]);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(observedConnects, 3u);
+        size_t closesAfterInitial = observedCloses;
+
+        // Send more requests - since all clients have subscribers, no duplicates should be removed
+        for (size_t i = 0; i < 5; ++i) {
+            runtime.AdvanceCurrentTime(TDuration::Seconds(2));
+            runtime.Send(new IEventHandle(cacheActor, senders[0], new TEvPipeCache::TEvForward(
+                new TEvCustomTablet::TEvHelloRequest,
+                TTestTxConfig::TxTablet0,
+                false)), 0, true);
+            runtime.GrabEdgeEventRethrow<TEvCustomTablet::TEvHelloResponse>(senders[0]);
+        }
+
+        // No new closes because all clients have subscribers (non-idle)
+        UNIT_ASSERT_C(observedCloses == closesAfterInitial,
+            "Expected no additional closes when all clients have subscribers, "
+            "but got " << (observedCloses - closesAfterInitial) << " more closes");
+    }
 }
 
 } // namespace NKikimr

--- a/ydb/core/testlib/basics/services.cpp
+++ b/ydb/core/testlib/basics/services.cpp
@@ -95,6 +95,7 @@ namespace NKikimr {
 
         TIntrusivePtr<TPipePerNodeCacheConfig> followerPipeConfig = new TPipePerNodeCacheConfig();
         followerPipeConfig->PipeRefreshTime = TDuration::Seconds(30);
+        followerPipeConfig->MaxActiveClients = 10;  // Multiple follower connections for load distribution
         followerPipeConfig->PipeConfig.AllowFollower = true;
         followerPipeConfig->PipeConfig.ForceFollower = forceFollowers;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Currently, each dynnode maintains one cached pipe per tablet to a follower. 
With many followers, only few of them are ever used simultaneously.

This change adds support for multiple concurrent follower connections per tablet with round-robin selection.

### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
