### PR TITLE
Fix implementation of macros 'Y_UNIT_TEST_WITH_REBOOTS_BUCKETS'

### DIFF
--- a/ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h
@@ -31,6 +31,7 @@ public:
     struct TTestRegistration##N {                                           \
         std::vector<std::string> names;                                     \
         TTestRegistration##N() {                                            \
+            names.reserve(REBOOT_BUCKETS + PIPE_RESET_BUCKETS);             \
             for (int i = 0; i < REBOOT_BUCKETS; i++) {                      \
                 std::string name = (REBOOT_BUCKETS > 1                      \
                     ? (#N "[TabletRebootsBucket") + std::to_string(i) + "]" \


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The issue was caused by using names.back().c_str() when registering tests: a pointer to the string buffer was effectively kept while the std::vector<std::string> names continued to grow. As the vector grows it may reallocate, which moves the contained std::string objects. This is particularly problematic for short strings because of [SSO](https://stackoverflow.com/questions/10315041/meaning-of-acronym-sso-in-the-context-of-stdstring): the character data is stored inside the std::string object itself, so moving the object changes the buffer address and previously captured c_str() pointers become dangling.

The fix is to pre-reserve the vector capacity (std::vector::reserve) before populating it, preventing reallocations and therefore avoiding pointer invalidation.

