### PR TITLE
Backport 25-3 hive events to 25-2

### DIFF
--- a/ydb/core/base/hive.h
+++ b/ydb/core/base/hive.h
@@ -88,6 +88,9 @@ namespace NKikimr {
             EvResponseTabletDistribution,
             EvResponseScaleRecommendation,
             EvConfigureScaleRecommenderReply,
+            EvDrainNodeAck,
+            EvResponseDrainInfo,
+            EvSetDownReply,
 
             EvEnd
         };
@@ -907,12 +910,17 @@ namespace NKikimr {
 
         struct TEvResponseScaleRecommendation : TEventPB<TEvResponseScaleRecommendation,
             NKikimrHive::TEvResponseScaleRecommendation, EvResponseScaleRecommendation> {};
-        
+
         struct TEvConfigureScaleRecommender : TEventPB<TEvConfigureScaleRecommender,
             NKikimrHive::TEvConfigureScaleRecommender, EvConfigureScaleRecommender> {};
-        
+
         struct TEvConfigureScaleRecommenderReply : TEventPB<TEvConfigureScaleRecommenderReply,
             NKikimrHive::TEvConfigureScaleRecommenderReply, EvConfigureScaleRecommenderReply> {};
+
+        struct TEvDrainNodeAck: TEventLocal<TEvDrainNodeAck, EvDrainNodeAck>
+        {
+            TEvDrainNodeAck() = default;
+        };
     };
 
     IActor* CreateDefaultHive(const TActorId &tablet, TTabletStorageInfo *info);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

One of NBS's alerts can be triggered by receiving an unknown event (EvDrainNodeAck). This PR backports this event to 25-2 for ignoring it on the NBS side.
No changes to the behaviour have been made.
...
