### PR TITLE
ca new mon page: fix links in yqv1

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -1585,15 +1585,17 @@ protected:
         Y_UNUSED(str);
     }
 
-    void DefaultMonitoringPage(TStringStream& str) {
+    void DefaultMonitoringPage(TStringStream& str, TCgiParameters cgi) {
         HTML(str) {
             PRE() {
                 str << "TDqComputeActorBase, SelfId=" << this->SelfId() << ' ';
-                HREF(TStringBuilder() << "?ca=" << this->SelfId() << "&view=dump") {
+                cgi.ReplaceUnescaped("view", "dump");
+                HREF(TStringBuilder() << "?" << cgi.Print()) {
                     str << "Dump";
                 }
                 str << ' ';
-                HREF(TStringBuilder() << "?ca=" << this->SelfId() << "&view=run") {
+                cgi.ReplaceUnescaped("view", "run");
+                HREF(TStringBuilder() << "?" << cgi.Print()) {
                     str << "Run";
                 }
                 str << Endl;
@@ -1771,9 +1773,9 @@ protected:
             if (this->Running) {
                 this->DoExecute();
             }
-            DefaultMonitoringPage(str);
+            DefaultMonitoringPage(str, cgi);
         } else {
-            DefaultMonitoringPage(str);
+            DefaultMonitoringPage(str, cgi);
         }
 
         this->Send(ev->Sender, new NActors::NMon::TEvHttpInfoRes(str.Str()));


### PR DESCRIPTION
new mon page contains links to old ("dump") page, but it does not work in yqv1
TODO peer link is still broken

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TODO it *should* work in kqp, but I have not verified yet
