### PR TITLE
Add BlobId into PDisk sector footer salt for huge blobs

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -976,6 +976,7 @@ struct TEvChunkRead : TEventLocal<TEvChunkRead, TEvBlobStorage::EvChunkRead> {
     TOwnerRound OwnerRound;
     ui8 PriorityClass;
     void *Cookie;
+    TLogoBlobID BlobId; // when set, this blob id is used to salt sector hash
 
     TEvChunkRead(TOwner owner, TOwnerRound ownerRound, TChunkIdx chunkIdx, ui32 offset, ui32 size,
             ui8 priorityClass, void *cookie)
@@ -1092,6 +1093,7 @@ struct TEvChunkWrite : TEventLocal<TEvChunkWrite, TEvBlobStorage::EvChunkWrite> 
     ui8 PriorityClass;
     bool DoFlush;
     bool IsSeqWrite; // sequential write to this chunk (normally, it is 'true', for huge blobs -- 'false')
+    TLogoBlobID BlobId; // when set, this blob id is used to salt sector hash
 
     mutable NLWTrace::TOrbit Orbit;
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion_impl.cpp
@@ -184,11 +184,11 @@ void TCompletionChunkReadPart::UnencryptData(TActorSystem *actorSystem) {
     while (PayloadReadSize > 0) {
         ui32 beginUserOffset = sectorIdx * userSectorSize;
 
-        TSectorRestorator restorator(false, 1, false,
-            format, PDisk->PCtx.get(), &PDisk->Mon, PDisk->BufferPool.Get());
+        TSectorRestorator restorator(false, 1, false, format, PDisk->PCtx.get(), &PDisk->Mon, PDisk->BufferPool.Get(),
+            Read->BlobId);
         ui64 lastNonce = Min((ui64)0, ChunkNonce - 1);
         restorator.Restore(source, format.Offset(Read->ChunkIdx, sectorIdx), format.MagicDataChunk, lastNonce,
-                Read->Owner);
+            Read->Owner);
 
         const ui32 sectorCount = 1;
         if (restorator.GoodSectorCount != sectorCount) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_crypto.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_crypto.h
@@ -3,6 +3,8 @@
 
 #include <ydb/core/blobstorage/crypto/crypto.h>
 
+#include <ydb/core/base/logoblob.h>
+
 namespace NKikimr {
 namespace NPDisk {
 
@@ -13,14 +15,21 @@ namespace NPDisk {
 class TPDiskHashCalculator : public THashCalculator {
     bool UseT1ha0Hasher;
 
+    enum EHashMode {
+        UNKNOWN,
+        SALTED,
+        ORDINARY,
+        OLD,
+    };
+    EHashMode HashMode = EHashMode::UNKNOWN;
+
 public:
     // T1ha0 hash is default for current version, but old hash is used to test backward compatibility
     TPDiskHashCalculator(bool useT1ha0Hasher = true)
         : UseT1ha0Hasher(useT1ha0Hasher)
     {}
 
-    ui64 OldHashSector(const ui64 sectorOffset, const ui64 magic, const ui8 *sector,
-            const ui32 sectorSize) {
+    ui64 OldHashSector(ui64 sectorOffset, ui64 magic, const ui8 *sector, ui32 sectorSize) {
         REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&sectorOffset, sizeof sectorOffset);
         REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&magic, sizeof magic);
         REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(sector, sectorSize - sizeof(ui64));
@@ -33,8 +42,7 @@ public:
     }
 
     template<class THasher>
-    ui64 T1ha0HashSector(const ui64 sectorOffset, const ui64 magic, const ui8 *sector,
-            const ui32 sectorSize) {
+    ui64 T1ha0HashSector(ui64 sectorOffset, ui64 magic, const ui8 *sector, ui32 sectorSize) {
         REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&sectorOffset, sizeof sectorOffset);
         REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&magic, sizeof magic);
         REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(sector, sectorSize - sizeof(ui64));
@@ -44,22 +52,60 @@ public:
         return hasher.Hash(sector, sectorSize - sizeof(ui64));
     }
 
-    ui64 HashSector(const ui64 sectorOffset, const ui64 magic, const ui8 *sector,
-            const ui32 sectorSize) {
+    ui64 HashSector(ui64 sectorOffset, ui64 magic, const ui8 *sector, ui32 sectorSize, TLogoBlobID blobId) {
         if (UseT1ha0Hasher) {
-            return T1ha0HashSector<TT1ha0NoAvxHasher>(sectorOffset, magic, sector, sectorSize);
+            return T1ha0HashSector<TT1ha0NoAvxHasher>(sectorOffset, magic ^ (blobId ? blobId.Hash() : 0), sector, sectorSize);
         } else {
             return OldHashSector(sectorOffset, magic, sector, sectorSize);
         }
     }
 
-    bool CheckSectorHash(const ui64 sectorOffset, const ui64 magic, const ui8 *sector,
-            const ui32 sectorSize, const ui64 sectorHash) {
-        // On production servers may be two versions.
-        // If by default used OldHash version, then use it first
-        // If by default used T1ha0NoAvx version, then use it
-        return sectorHash == T1ha0HashSector<TT1ha0NoAvxHasher>(sectorOffset, magic, sector, sectorSize)
-            || sectorHash == OldHashSector(sectorOffset, magic, sector, sectorSize);
+    bool CheckSectorHash(ui64 sectorOffset, ui64 magic, const ui8 *sector, ui32 sectorSize, ui64 sectorHash,
+            TLogoBlobID blobId) {
+        auto checkSalted = [&] {
+            return blobId && sectorHash == T1ha0HashSector<TT1ha0NoAvxHasher>(sectorOffset, magic ^ blobId.Hash(),
+                sector, sectorSize);
+        };
+        auto checkOrdinary = [&] {
+            return sectorHash == T1ha0HashSector<TT1ha0NoAvxHasher>(sectorOffset, magic, sector, sectorSize);
+        };
+        auto checkOld = [&] {
+            return sectorHash == OldHashSector(sectorOffset, magic, sector, sectorSize);
+        };
+
+        switch (HashMode) {
+            case EHashMode::UNKNOWN:
+                break;
+
+            case EHashMode::SALTED:
+                if (Y_LIKELY(checkSalted())) {
+                    return true;
+                }
+                break;
+
+            case EHashMode::ORDINARY:
+                if (Y_LIKELY(checkOrdinary())) {
+                    return true;
+                }
+                break;
+
+            case EHashMode::OLD:
+                if (Y_LIKELY(checkOld())) {
+                    return true;
+                }
+                break;
+        }
+
+        if (checkSalted()) {
+            HashMode = EHashMode::SALTED;
+        } else if (checkOrdinary()) {
+            HashMode = EHashMode::ORDINARY;
+        } else if (checkOld()) {
+            HashMode = EHashMode::OLD;
+        } else {
+            return false;
+        }
+        return true;
     }
 };
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -980,7 +980,7 @@ bool TPDisk::ChunkWritePiece(TChunkWrite *evChunkWrite, ui32 pieceShift, ui32 pi
         ui32 dataChunkSizeSectors = Format.ChunkSize / Format.SectorSize;
         TChunkWriter writer(Mon, *BlockDevice.Get(), Format, state.CurrentNonce, Format.ChunkKey, BufferPool.Get(),
                 desiredSectorIdx, dataChunkSizeSectors, Format.MagicDataChunk, chunkIdx, nullptr, desiredSectorIdx,
-                nullptr, PCtx, &DriveModel, Cfg->FeatureFlags.GetEnablePDiskDataEncryption());
+                nullptr, PCtx, &DriveModel, Cfg->FeatureFlags.GetEnablePDiskDataEncryption(), evChunkWrite->BlobId);
 
         guard.Release();
         bool end = ChunkWritePieceEncrypted(evChunkWrite, writer, pieceSize);
@@ -1763,7 +1763,7 @@ void TPDisk::WriteApplyFormatRecord(TDiskFormat format, const TKey &mainKey) {
         bool encrypt = Cfg->EnableFormatAndMetadataEncryption;
         TSysLogWriter formatWriter(Mon, *BlockDevice.Get(), Format, nonce, mainKey, BufferPool.Get(),
                 0, ReplicationFactor, Format.MagicFormatChunk, 0, nullptr, 0, nullptr, PCtx,
-                &DriveModel, encrypt);
+                &DriveModel, encrypt, {});
 
         if (format.IsFormatInProgress()) {
             // Fill first bytes with magic pattern
@@ -1875,7 +1875,7 @@ void TPDisk::WriteDiskFormat(ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 user
     SysLogger.Reset(new TSysLogWriter(Mon, *BlockDevice.Get(), Format, SysLogRecord.Nonces.Value[NonceSysLog],
                 Format.SysLogKey, BufferPool.Get(), firstSectorIdx, endSectorIdx, Format.MagicSysLogChunk, 0,
                 nullptr, firstSectorIdx, nullptr, PCtx, &DriveModel,
-                Cfg->FeatureFlags.GetEnablePDiskDataEncryption()));
+                Cfg->FeatureFlags.GetEnablePDiskDataEncryption(), {}));
 
     bool isFull = false;
     while (!isFull) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -87,7 +87,7 @@ void TPDisk::InitSysLogger() {
     SysLogger.Reset(new TSysLogWriter(Mon, *BlockDevice.Get(), Format,
         SysLogRecord.Nonces.Value[NonceSysLog], Format.SysLogKey, BufferPool.Get(),
         beginSectorIdx, endSectorIdx, Format.MagicSysLogChunk, 0, nullptr, writeSectorIdx, nullptr, PCtx,
-        &DriveModel, Cfg->FeatureFlags.GetEnablePDiskDataEncryption()));
+        &DriveModel, Cfg->FeatureFlags.GetEnablePDiskDataEncryption(), {}));
 }
 
 bool TPDisk::InitCommonLogger() {
@@ -106,7 +106,7 @@ bool TPDisk::InitCommonLogger() {
     CommonLogger.Reset(new TLogWriter(Mon, *BlockDevice.Get(), Format,
             SysLogRecord.Nonces.Value[NonceLog], Format.LogKey, BufferPool.Get(), 0, UsableSectorsPerLogChunk(),
             Format.MagicLogChunk, chunkIdx, info, std::min(sectorIdx, UsableSectorsPerLogChunk()),
-            InitialTailBuffer, PCtx, &DriveModel, Cfg->FeatureFlags.GetEnablePDiskDataEncryption()));
+            InitialTailBuffer, PCtx, &DriveModel, Cfg->FeatureFlags.GetEnablePDiskDataEncryption(), {}));
     InitialTailBuffer = nullptr;
     if (sectorIdx >= UsableSectorsPerLogChunk()) {
         if (!AllocateLogChunks(1, 0, OwnerSystem, 0, EOwnerGroupType::Static, true)) {
@@ -1522,7 +1522,7 @@ void TPDisk::MarkChunksAsReleased(TReleaseChunks& req) {
         ui32 dataChunkSizeSectors = Format.ChunkSize / Format.SectorSize;
         TLogWriter writer(Mon, *BlockDevice.Get(), Format, nonce, Format.LogKey, BufferPool.Get(), desiredSectorIdx,
                 dataChunkSizeSectors, Format.MagicLogChunk, req.GapStart->ChunkIdx, nullptr, desiredSectorIdx,
-                nullptr, PCtx, &DriveModel, Cfg->FeatureFlags.GetEnablePDiskDataEncryption());
+                nullptr, PCtx, &DriveModel, Cfg->FeatureFlags.GetEnablePDiskDataEncryption(), {});
 
         Y_VERIFY_S(req.GapEnd->DesiredPrevChunkLastNonce, PCtx->PDiskLogPrefix
             << "Zero GapEnd->DesiredPrevChunkLastNonce, chunkInfo# " << *req.GapEnd);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_logreader.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_logreader.cpp
@@ -797,8 +797,8 @@ bool TLogReader::ProcessSectorSet(TSectorData *sector) {
     UpdateLastGoodToWritePosition();
 
     const ui64 magic = format.MagicLogChunk;
-    TSectorRestorator restorator(false, LogErasureDataParts, false, format,
-        PCtx.get(), &PDisk->Mon, PDisk->BufferPool.Get());
+    TSectorRestorator restorator(false, LogErasureDataParts, false, format, PCtx.get(), &PDisk->Mon,
+        PDisk->BufferPool.Get(), {});
     restorator.Restore(sector->GetData(), sector->Offset, magic, LastNonce, Owner);
 
     if (!restorator.GoodSectorFlags) {
@@ -1190,7 +1190,7 @@ bool TLogReader::ProcessNextChunkReference(TSectorData& sector) {
 
     TSectorRestorator restorator(true, 0, format.IsErasureEncodeNextChunkReference(),
             PDisk->Format, PCtx.get(), &PDisk->Mon,
-            PDisk->BufferPool.Get());
+            PDisk->BufferPool.Get(), {});
     restorator.Restore(sector.GetData(), sector.Offset, format.MagicNextLogChunkReference, LastNonce,
             Owner);
     P_LOG(PRI_DEBUG, BPD01, SelfInfo() << " ProcessNextChunkReference");

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.cpp
@@ -54,6 +54,7 @@ TChunkWrite::TChunkWrite(const NPDisk::TEvChunkWrite &ev, const TActorId &sender
     , Cookie(ev.Cookie)
     , DoFlush(ev.DoFlush)
     , IsSeqWrite(ev.IsSeqWrite)
+    , BlobId(ev.BlobId)
 {
     if (PartsPtr) {
         for (size_t i = 0; i < PartsPtr->Size(); ++i) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
@@ -402,6 +402,7 @@ public:
     ui64 Offset;
     ui64 Size;
     void *Cookie;
+    TLogoBlobID BlobId;
 
     ui64 CurrentSector = 0;
     ui64 RemainingSize;
@@ -428,6 +429,7 @@ public:
         , Offset(ev.Offset)
         , Size(ev.Size)
         , Cookie(ev.Cookie)
+        , BlobId(ev.BlobId)
         , RemainingSize(ev.Size)
         , SlackSize(Max<ui32>())
         , DoubleFreeCanary(ReferenceCanary)
@@ -521,6 +523,8 @@ public:
     bool IsSeqWrite;
     bool IsReplied = false;
     bool ChunkEncrypted = true;
+
+    TLogoBlobID BlobId;
 
     ui32 TotalSize;
     ui32 CurrentPart = 0;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_sectorrestorator.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_sectorrestorator.cpp
@@ -8,7 +8,7 @@ namespace NPDisk {
 TSectorRestorator::TSectorRestorator(const bool isTrippleCopy, const ui32 erasureDataParts,
         const bool isErasureEncode, const TDiskFormat &format,
         const TPDiskCtx *pCtx, TPDiskMon *mon,
-        TBufferPool *bufferPool)
+        TBufferPool *bufferPool, TLogoBlobID blobId)
     : IsTrippleCopy(isTrippleCopy)
     , ErasureDataParts(erasureDataParts)
     , LastGoodIdx((ui32)-1)
@@ -21,12 +21,13 @@ TSectorRestorator::TSectorRestorator(const bool isTrippleCopy, const ui32 erasur
     , IsErasureEncode(isErasureEncode)
     , Mon(mon)
     , BufferPool(bufferPool)
+    , BlobId(blobId)
 {}
 
 TSectorRestorator::TSectorRestorator(const bool isTrippleCopy, const ui32 erasureDataParts,
-        const bool isErasureEncode, const TDiskFormat &format)
+        const bool isErasureEncode, const TDiskFormat &format, TLogoBlobID blobId)
     : TSectorRestorator(isTrippleCopy, erasureDataParts, isErasureEncode, format, nullptr, nullptr,
-            nullptr)
+            nullptr, blobId)
 {}
 
 void TSectorRestorator::Restore(ui8 *source, const ui64 offset, const ui64 magic, const ui64 lastNonce,
@@ -42,7 +43,7 @@ void TSectorRestorator::Restore(ui8 *source, const ui64 offset, const ui64 magic
 
         ui64 sectorOffset = offset + (IsTrippleCopy ? 0 : (ui64)i * (ui64)Format.SectorSize);
         ui8 *sectorData = source + i * Format.SectorSize;
-        bool isCrcOk = hasher.CheckSectorHash(sectorOffset, magic, sectorData, Format.SectorSize, sectorFooter->Hash);
+        bool isCrcOk = hasher.CheckSectorHash(sectorOffset, magic, sectorData, Format.SectorSize, sectorFooter->Hash, BlobId);
         if (!isCrcOk) {
             if (PCtx) {
                 P_LOG(PRI_INFO, BPD01, " Bad hash",
@@ -125,13 +126,13 @@ void TSectorRestorator::Restore(ui8 *source, const ui64 offset, const ui64 magic
                 TDataSectorFooter *goodDataFooter = (TDataSectorFooter*)
                     (source + (ErasureDataParts) * Format.SectorSize - sizeof(TDataSectorFooter));
                 sectorFooter->Nonce = goodDataFooter->Nonce + 1;
-                sectorFooter->Hash = hasher.HashSector(sectorOffset, magic, sectorData, Format.SectorSize);
+                sectorFooter->Hash = hasher.HashSector(sectorOffset, magic, sectorData, Format.SectorSize, BlobId);
             } else {
                 // restoring data sector
                 TDataSectorFooter *sectorFooter = (TDataSectorFooter*)
                     (sectorData + Format.SectorSize - sizeof(TDataSectorFooter));
                 sectorFooter->SetVersionAndEncryption(sectorFooter->IsEncrypted());
-                sectorFooter->Hash = hasher.HashSector(sectorOffset, magic, sectorData, Format.SectorSize);
+                sectorFooter->Hash = hasher.HashSector(sectorOffset, magic, sectorData, Format.SectorSize, BlobId);
                 // Increment here because we don't want to count initialy not written parts
                 *Mon->DeviceErasureSectorRestorations += 1;
             }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_sectorrestorator.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_sectorrestorator.h
@@ -22,14 +22,15 @@ struct TSectorRestorator {
     bool IsErasureEncode;
     TPDiskMon *Mon;
     TBufferPool *BufferPool;
+    TLogoBlobID BlobId;
 
     TSectorRestorator(const bool isTrippleCopy, const ui32 erasureDataParts,
             const bool isErasureEncode, const TDiskFormat &format,
             const TPDiskCtx *pCtx, TPDiskMon *mon,
-            TBufferPool *bufferPool);
+            TBufferPool *bufferPool, TLogoBlobID blobId);
 
     TSectorRestorator(const bool isTrippleCopy, const ui32 erasureDataParts,
-            const bool isErasureEncode, const TDiskFormat &format);
+            const bool isErasureEncode, const TDiskFormat &format, TLogoBlobID blobId);
 
 
     void Restore(ui8 *source, const ui64 offset, const ui64 magic, const ui64 lastNonce, TOwner owner);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_syslogreader.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_syslogreader.cpp
@@ -157,7 +157,7 @@ void TSysLogReader::RestoreSectorSets() {
         const ui64 magic = format.MagicSysLogChunk;
         const bool isErasureEncode = format.IsErasureEncodeSysLog();
         TSectorRestorator restorator(true, LogErasureDataParts, isErasureEncode, format,
-            PCtx.get(), &PDisk->Mon, PDisk->BufferPool.Get());
+            PCtx.get(), &PDisk->Mon, PDisk->BufferPool.Get(), {});
         restorator.Restore(sectorSetData, sectorIdx * format.SectorSize, magic, 0, 0);
 
         if (!restorator.GoodSectorFlags) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
@@ -221,8 +221,8 @@ bool ReadPDiskFormatInfo(const TString &path, const NPDisk::TMainKey &mainKey, T
                     (sector + format.SectorSize - sizeof(NPDisk::TDataSectorFooter));
 
                 ui64 sectorOffset = sysLogOffset + (ui64)((idx / 3) * 3) * (ui64)format.SectorSize;
-                bool isCrcOk = NPDisk::TPDiskHashCalculator().CheckSectorHash(
-                        sectorOffset, format.MagicSysLogChunk, sector, format.SectorSize, logFooter->Hash);
+                bool isCrcOk = NPDisk::TPDiskHashCalculator().CheckSectorHash(sectorOffset, format.MagicSysLogChunk,
+                    sector, format.SectorSize, logFooter->Hash, {});
                 outInfo.SectorInfo.push_back(TPDiskInfo::TSectorInfo(logFooter->Nonce, logFooter->GetVersion(), isCrcOk));
             }
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_ut.cpp
@@ -361,10 +361,10 @@ void TestPayloadOffset(ui64 firstSector, ui64 lastSector, ui64 currentSector, ui
                 NPDisk::TPDiskHashCalculator hasher(useT1haHash);
                 if (i < LogErasureDataParts) {
                     ui64 offset = format.SectorSize * i;
-                    footer->Hash = hasher.HashSector(offset, magic, sectors[i].Begin(), sectors[i].Size());
+                    footer->Hash = hasher.HashSector(offset, magic, sectors[i].Begin(), sectors[i].Size(), {});
                 }
             }
-            TSectorRestorator restorator(false, LogErasureDataParts, true, format);
+            TSectorRestorator restorator(false, LogErasureDataParts, true, format, {});
             restorator.Restore(sectors.Data(), 0, magic, 0, 0);
             UNIT_ASSERT_C(restorator.GoodSectorCount == LogErasureDataParts + 1,
                     "restorator.GoodSectorCount# " << restorator.GoodSectorCount);
@@ -395,12 +395,12 @@ void TestPayloadOffset(ui64 firstSector, ui64 lastSector, ui64 currentSector, ui
                     footer->Hash = hasher.T1ha0HashSector<TT1ha0NoAvxHasher>(offset, magic, sectors[i].Begin(), sectors[i].Size());
                     break;
                 case 2:
-                    footer->Hash = hasher.HashSector(offset, magic, sectors[i].Begin(), sectors[i].Size());
+                    footer->Hash = hasher.HashSector(offset, magic, sectors[i].Begin(), sectors[i].Size(), {});
                     break;
                 default:
                     UNIT_ASSERT(false);
                 }
-                TSectorRestorator restorator(false, 1, false, format);
+                TSectorRestorator restorator(false, 1, false, format, {});
                 restorator.Restore(sectors[i].Begin(), offset, magic, 0, 0);
                 UNIT_ASSERT_C(restorator.GoodSectorCount == 1, "i# " << i
                         << " GoodSectorCount# " << restorator.GoodSectorCount);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_writer.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_writer.h
@@ -84,14 +84,14 @@ public:
     TDiskFormat &Format;
     ui64 &Nonce;
     THolder<TBufferedWriter> BufferedWriter;
-    ui64 CurrentPosition;
+    ui64 CurrentPosition = 0;
     ui32 SectorBytesFree;
     ui64 SectorIdx;
     ui64 FirstSectorIdx;
     ui64 EndSectorIdx;
     ui32 ChunkIdx;
     std::atomic<TFirstUncommitted> FirstUncommitted = TFirstUncommitted(0, 0);
-    ui64 RecordBytesLeft;
+    ui64 RecordBytesLeft = 0;
     ui64 DataMagic;
     TDeque<TChunkIdxWithInfo> NextChunks;
     TLogChunkInfo *LogChunkInfo = nullptr;
@@ -104,7 +104,9 @@ public:
     // ui32 PDiskId;
     TDriveModel *DriveModel;
 
-    bool OnNewChunk;
+    TLogoBlobID BlobId;
+
+    bool OnNewChunk = true;
 
     bool IsEmptySector() const {
         return (SectorBytesFree == Format.SectorPayloadSize());
@@ -113,18 +115,16 @@ public:
     TSectorWriter(TPDiskMon &mon, IBlockDevice &blockDevice, TDiskFormat &format, ui64 &nonce,
             const TKey &key, TBufferPool *pool, ui64 firstSectorIdx, ui64 endSectorIdx, ui64 dataMagic, ui32 chunkIdx,
             TLogChunkInfo *logChunkInfo, ui64 sectorIdx, TBuffer *buffer, std::shared_ptr<TPDiskCtx> pCtx,
-            TDriveModel *driveModel, bool enableSectorEncryption)
+            TDriveModel *driveModel, bool enableSectorEncryption, TLogoBlobID blobId)
         : Mon(mon)
         , BlockDevice(blockDevice)
         , Format(format)
         , Nonce(nonce)
-        , CurrentPosition(0)
         , SectorBytesFree(format.SectorPayloadSize())
         , SectorIdx(sectorIdx)
         , FirstSectorIdx(firstSectorIdx)
         , EndSectorIdx(endSectorIdx)
         , ChunkIdx(chunkIdx)
-        , RecordBytesLeft(0)
         , DataMagic(dataMagic)
         , LogChunkInfo(logChunkInfo)
         , Hash()
@@ -132,7 +132,7 @@ public:
         , EnableSectorEncryption(enableSectorEncryption)
         , PCtx(std::move(pCtx))
         , DriveModel(driveModel)
-        , OnNewChunk(true)
+        , BlobId(blobId)
     {
         Y_VERIFY_S(!LogChunkInfo || LogChunkInfo->ChunkIdx == ChunkIdx, PCtx->PDiskLogPrefix);
         BufferedWriter.Reset(new TBufferedWriter(Format.SectorSize, BlockDevice, Format, pool,
@@ -256,7 +256,7 @@ public:
                 memcpy(sectorData, BufferedWriter->Get(), Format.SectorSize);
                 // Check sector CRC
                 const ui64 sectorHash = *(ui64*)(void*)(sectorData + Format.SectorSize - sizeof(ui64));
-                Y_VERIFY_S(Hash.CheckSectorHash(sectorOffset, dataMagic, sectorData, Format.SectorSize, sectorHash),
+                Y_VERIFY_S(Hash.CheckSectorHash(sectorOffset, dataMagic, sectorData, Format.SectorSize, sectorHash, {}),
                         PCtx->PDiskLogPrefix << "Sector hash corruption detected!");
             }
             BufferedWriter->MarkDirty();
@@ -302,7 +302,7 @@ public:
         TDataSectorFooter &sectorFooter = *(TDataSectorFooter*)(sector + Format.SectorSize - sizeof(TDataSectorFooter));
         sectorFooter.SetVersionAndEncryption(EnableSectorEncryption);
         sectorFooter.Nonce = Nonce;
-        sectorFooter.Hash = Hash.HashSector(sectorOffset, magic, sector, Format.SectorSize);
+        sectorFooter.Hash = Hash.HashSector(sectorOffset, magic, sector, Format.SectorSize, BlobId);
 
         BufferedWriter->MarkDirty();
         ++Nonce;
@@ -313,7 +313,7 @@ public:
         TParitySectorFooter &sectorFooter = *(TParitySectorFooter*)
             (sector + Format.SectorSize - sizeof(TParitySectorFooter));
         sectorFooter.Nonce = Nonce;
-        sectorFooter.Hash = Hash.HashSector(sectorOffset, magic, sector, Format.SectorSize);
+        sectorFooter.Hash = Hash.HashSector(sectorOffset, magic, sector, Format.SectorSize, {});
         if (!IsLog) {
             P_LOG(PRI_TRACE, BPD01, SelfInfo() << " PrepareParitySectorFooter",
                     (SectorOffset, sectorOffset),

--- a/ydb/core/blobstorage/vdisk/balance/balancing_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/balance/balancing_actor.cpp
@@ -156,12 +156,13 @@ namespace NBalancing {
                 // collect parts to send on main
                 if (Ctx->Cfg.EnableSend && SendOnMainParts.Size() < Ctx->Cfg.MaxToSendPerEpoch) {
                     if (auto partsToSend = merger.Ingress.LocalParts(top.GType) & moveMask; !partsToSend.Empty()) {
-                        for (const auto& [parts, data]: merger.Parts) {
+                        for (const auto& [parts, data, isHugeBlob] : merger.Parts) {
                             if (!(partsToSend & parts).Empty()) {
                                 SendOnMainParts.Data.emplace_back(TPartInfo{
-                                    .Key=It.GetCurKey().LogoBlobID(),
-                                    .PartsMask=parts,
-                                    .PartData=data
+                                    .Key = It.GetCurKey().LogoBlobID(),
+                                    .PartsMask = parts,
+                                    .PartData = data,
+                                    .IsHugeBlob = isHugeBlob,
                                 });
                             }
                         }
@@ -177,10 +178,13 @@ namespace NBalancing {
                             STLOG(PRI_DEBUG, BS_VDISK_BALANCING, BSVB10, VDISKP(Ctx->VCtx, "Delete"), (LogoBlobId, TryDeleteParts.Data.back().ToString()));
                         }
 
-                        for (const auto& [parts, data]: merger.Parts) {
+                        for (const auto& [parts, data, isHugeBlob] : merger.Parts) {
                             if (!(partsToDelete & parts).Empty()) {
                                 TryDeletePartsFullData[key].emplace_back(TPartInfo{
-                                    .Key=key, .PartsMask=parts, .PartData=data
+                                    .Key = key,
+                                    .PartsMask = parts,
+                                    .PartData = data,
+                                    .IsHugeBlob = isHugeBlob,
                                 });
                             }
                         }

--- a/ydb/core/blobstorage/vdisk/balance/defs.h
+++ b/ydb/core/blobstorage/vdisk/balance/defs.h
@@ -77,6 +77,7 @@ namespace NBalancing {
         TLogoBlobID Key;
         NMatrix::TVectorType PartsMask;
         std::variant<TDiskPart, TRope> PartData;
+        bool IsHugeBlob;
     };
 
     static constexpr ui64 READ_TIMEOUT_TAG = 0;

--- a/ydb/core/blobstorage/vdisk/balance/utils.h
+++ b/ydb/core/blobstorage/vdisk/balance/utils.h
@@ -15,7 +15,7 @@ namespace NBalancing {
         const TBlobStorageGroupType GType;
 
         TIngress Ingress;
-        TVector<std::pair<NMatrix::TVectorType, std::variant<TDiskPart, TRope>>> Parts;
+        TVector<std::tuple<NMatrix::TVectorType, std::variant<TDiskPart, TRope>, bool>> Parts;
 
         TPartsCollectorMerger(const TBlobStorageGroupType gType);
 

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
@@ -86,6 +86,7 @@ namespace NKikimr {
                     const TDiskPart& p = rec.OldDiskPart;
                     auto msg = std::make_unique<NPDisk::TEvChunkRead>(DCtx->PDiskCtx->Dsk->Owner,
                         DCtx->PDiskCtx->Dsk->OwnerRound, p.ChunkIdx, p.Offset, p.Size, NPriRead::HullComp, nullptr);
+                    msg->BlobId = id;
                     DCtx->VCtx->CountDefragCost(*msg);
                     ctx.Send(DCtx->PDiskCtx->PDiskId, msg.release());
                     DCtx->DefragMonGroup.DefragBytesRewritten() += p.Size;

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
@@ -214,6 +214,9 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             auto ev = std::make_unique<NPDisk::TEvChunkWrite>(HugeKeeperCtx->PDiskCtx->Dsk->Owner,
                         HugeKeeperCtx->PDiskCtx->Dsk->OwnerRound, chunkId, offset,
                         partsPtr, Cookie, true, GetWritePriority(), false);
+            if (AppData()->FeatureFlags.GetEnableBlobIdInSectorChecksum()) {
+                ev->BlobId = Item->LogoBlobId;
+            }
             ev->Orbit = std::move(Item->Orbit);
             ctx.Send(HugeKeeperCtx->PDiskCtx->PDiskId, ev.release(), 0, 0, Span.GetTraceId());
             DiskAddr = TDiskPart(chunkId, offset, storedBlobSize);

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullrecmerger.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullrecmerger.h
@@ -252,7 +252,7 @@ namespace NKikimr {
                     if (memRec.GetType() == TBlobType::DiskBlob) {
                         // don't deduplicate inplaced data
                         if (!v.Empty()) {
-                            (*Callback)(extr.SwearOne(), v);
+                            (*Callback)(extr.SwearOne(), v, false);
                         }
                     } else if (memRec.GetType() == TBlobType::HugeBlob) {
                         Y_ABORT_UNLESS(v.CountBits() == 1u);
@@ -338,7 +338,7 @@ namespace NKikimr {
 
             void Finish(TCallback *callback) {
                 for (ui8 i = ResParts.FirstPosition(); i != ResParts.GetSize(); i = ResParts.NextPosition(i)) {
-                    (*callback)(Res[i].Part, NMatrix::TVectorType::MakeOneHot(i, ResParts.GetSize()));
+                    (*callback)(Res[i].Part, NMatrix::TVectorType::MakeOneHot(i, ResParts.GetSize()), true);
                 }
             }
 

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
@@ -690,8 +690,9 @@ namespace NKikimr {
                     // ensure preallocated location has correct size
                     Y_DEBUG_ABORT_UNLESS(preallocatedLocation.ChunkIdx && preallocatedLocation.Size == MemRec->DataSize());
                     // producing inline blob with data here
-                    for (const auto& [location, partIdx] : collectTask.Reads) {
-                        ReadBatcher.AddReadItem(location, {NextDeferredItemId, partIdx, blobId, location});
+                    for (const auto& [location, partIdx, isHugeBlob] : collectTask.Reads) {
+                        ReadBatcher.AddReadItem(location, {NextDeferredItemId, partIdx, blobId, location},
+                            isHugeBlob ? TLogoBlobID(blobId, partIdx + 1) : TLogoBlobID());
                     }
                     if (!collectTask.Reads.empty() || WriterHasPendingOperations) { // defer this blob
                         DeferredItems.Put(NextDeferredItemId++, collectTask.Reads.size(), preallocatedLocation,
@@ -713,7 +714,8 @@ namespace NKikimr {
                 }
 
                 for (const auto& [partIdx, from, to] : dataMerger.GetHugeBlobMoves()) {
-                    ReadBatcher.AddReadItem(from, {NextDeferredItemId, partIdx, blobId, from});
+                    ReadBatcher.AddReadItem(from, {NextDeferredItemId, partIdx, blobId, from},
+                        TLogoBlobID(blobId, partIdx + 1));
                     DeferredItems.Put(NextDeferredItemId++, 1, to, TDiskBlobMerger(), blobId, false);
                 }
             }

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_readbatch_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_readbatch_ut.cpp
@@ -66,7 +66,7 @@ Y_UNIT_TEST_SUITE(ReadBatcher) {
             const ui32 offset = rng() % chunkSize;
             const ui32 len = 1 + rng() % Min<ui32>(100000, chunkSize + 1 - offset);
             TPayload payload{it->first, offset, len};
-            batcher.AddReadItem({it->first, offset, len}, std::move(payload));
+            batcher.AddReadItem({it->first, offset, len}, std::move(payload), {});
         }
         batcher.Start();
 

--- a/ydb/core/blobstorage/vdisk/query/query_readactor.cpp
+++ b/ydb/core/blobstorage/vdisk/query/query_readactor.cpp
@@ -41,8 +41,10 @@ namespace NKikimr {
 
                 // create request
                 std::unique_ptr<NPDisk::TEvChunkRead> msg(new NPDisk::TEvChunkRead(Ctx->PDiskCtx->Dsk->Owner,
-                            Ctx->PDiskCtx->Dsk->OwnerRound, it->Part.ChunkIdx, it->Part.Offset, it->Part.Size,
-                            Priority, cookie));
+                    Ctx->PDiskCtx->Dsk->OwnerRound, it->Part.ChunkIdx, it->Part.Offset, it->Part.Size,
+                    Priority, cookie));
+
+                msg->BlobId = it->HugeBlobId;
 
                 LOG_DEBUG(ctx, BS_VDISK_GET,
                     VDISKP(Ctx->VCtx->VDiskLogPrefix, "GLUEREAD(%p): %s", this, msg->ToString().data()));

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_huge.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_huge.cpp
@@ -21,10 +21,10 @@ namespace NKikimr {
             heapIt.SeekToLast();
         }
 
-        auto readHugeBlob = [&](const TDiskPart& location) {
+        auto readHugeBlob = [&](const TDiskPart& location, TLogoBlobID blobId) {
             ++MonGroup.HugeBlobsRead();
             MonGroup.HugeBlobBytesRead() += location.Size;
-            return Read(location);
+            return Read(location, blobId);
         };
 
         auto essence = GetBarriersEssence();

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_huge_blob_merger.h
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_huge_blob_merger.h
@@ -10,7 +10,7 @@ namespace NKikimr {
         NMatrix::TVectorType Local;
         NMatrix::TVectorType ReadableLocal;
         std::vector<TDiskPart> CorruptedParts;
-        std::function<std::optional<TRcBuf>(const TDiskPart&)> Read;
+        std::function<std::optional<TRcBuf>(const TDiskPart&, TLogoBlobID)> Read;
         const TBlobStorageGroupType GType;
         TScrubCoroImpl *Impl;
 
@@ -49,7 +49,8 @@ namespace NKikimr {
                     const TDiskPart *part = extr.Begin;
                     for (ui32 i = local.FirstPosition(); i != local.GetSize(); i = local.NextPosition(i), ++part) {
                         if (part->ChunkIdx && part->Size) {
-                            std::optional<TRcBuf> data = Read(*part);
+                            const TLogoBlobID partId(key.LogoBlobID(), i + 1); // part id for this blob
+                            std::optional<TRcBuf> data = Read(*part, partId);
                             STLOGX(Impl->GetActorContext(), data ? PRI_DEBUG : PRI_ERROR, BS_VDISK_SCRUB, VDS21,
                                 VDISKP(LogPrefix, "huge blob read"), (Id, key.LogoBlobID()), (Local, local),
                                 (Location, *part), (IsReadable, data.has_value()));

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_impl.h
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_impl.h
@@ -121,8 +121,8 @@ namespace NKikimr {
         // PDISK INTERACTION
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        std::optional<TRcBuf> Read(const TDiskPart& part);
-        bool IsReadable(const TDiskPart& part);
+        std::optional<TRcBuf> Read(const TDiskPart& part, TLogoBlobID hugeBlobId);
+        bool IsReadable(const TDiskPart& part, TLogoBlobID hugeBlobId);
         void Write(const TDiskPart& part, TString data);
 
         template<typename T>

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -260,4 +260,5 @@ message TFeatureFlags {
     optional bool EnableLocalBloomNgramFilterIndex = 233 [default = false];
     optional bool EnableSetDropDefaultValue = 234 [ default = false];
     optional bool EnableStreamingQueriesPqSinkDeduplication = 235 [default = false];
+    optional bool EnableBlobIdInSectorChecksum = 236 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add BlobId into PDisk sector footer salt for huge blobs

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch adds support for PDisk sector footer hash salted by BlobIds to prevent reading replayed sector data for huge blobs.

#27298
