### PR TITLE
YQ-4474 add public interface to partition session control in topic sdk

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h
@@ -32,6 +32,9 @@ public:
     //! client will connect to others nodes according to client loadbalancing
     TDriverConfig& SetEndpoint(const std::string& endpoint);
 
+    //! Get endpoint, returns the endpoint set via connection string or SetEndpoint()
+    const std::string& GetEndpoint() const;
+
     //! Set number of network threads, default: 2
     TDriverConfig& SetNetworkThreadsNum(size_t sz);
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -10,7 +10,7 @@
 namespace NYdb::inline Dev::NTopic {
 
 //! Partition session.
-struct TPartitionSession : public TThrRefBase, public TPrintable<TPartitionSession> {
+struct TPartitionSession: public TThrRefBase, public TPrintable<TPartitionSession> {
     using TPtr = TIntrusivePtr<TPartitionSession>;
 
 public:
@@ -57,7 +57,7 @@ protected:
 template<>
 void TPrintable<TPartitionSession>::DebugString(TStringBuilder& res, bool) const;
 
-struct TPartitionSessionControl : public TPartitionSession {
+struct TPartitionSessionControl: public TPartitionSession {
     //! Commit offsets range.
     //! Can be used from TDataReceivedEvent or TDeferredCommit.
     virtual void Commit(uint64_t startOffset, uint64_t endOffset) = 0;
@@ -88,7 +88,7 @@ struct TReadSessionEvent {
 
     //! Event with new data.
     //! Contains batch of messages from single partition session.
-    struct TDataReceivedEvent : public TPartitionSessionAccessor, public TPrintable<TDataReceivedEvent> {
+    struct TDataReceivedEvent: public TPartitionSessionAccessor, public TPrintable<TDataReceivedEvent> {
         struct TMessageInformation {
             TMessageInformation(uint64_t offset,
                                 std::string producerId,
@@ -110,7 +110,7 @@ struct TReadSessionEvent {
             std::string MessageGroupId;
         };
 
-        class TMessageBase : public TPrintable<TMessageBase> {
+        class TMessageBase: public TPrintable<TMessageBase> {
         public:
             TMessageBase(const std::string& data, TMessageInformation info);
 
@@ -256,8 +256,8 @@ struct TReadSessionEvent {
     };
 
     //! Acknowledgement for commit request.
-    struct TCommitOffsetAcknowledgementEvent : public TPartitionSessionAccessor,
-                                               public TPrintable<TCommitOffsetAcknowledgementEvent> {
+    struct TCommitOffsetAcknowledgementEvent: public TPartitionSessionAccessor,
+                                              public TPrintable<TCommitOffsetAcknowledgementEvent> {
         TCommitOffsetAcknowledgementEvent(TPartitionSession::TPtr partitionSession, uint64_t committedOffset);
 
         //! Committed offset.
@@ -274,8 +274,8 @@ struct TReadSessionEvent {
     };
 
     //! Server command for creating and starting partition session.
-    struct TStartPartitionSessionEvent : public TPartitionSessionAccessor,
-                                         public TPrintable<TStartPartitionSessionEvent> {
+    struct TStartPartitionSessionEvent: public TPartitionSessionAccessor,
+                                        public TPrintable<TStartPartitionSessionEvent> {
         explicit TStartPartitionSessionEvent(TPartitionSession::TPtr, uint64_t committedOffset, uint64_t endOffset);
 
         //! Current committed offset in partition session.
@@ -301,7 +301,7 @@ struct TReadSessionEvent {
     //! Server command for stopping and destroying partition session.
     //! Server can destroy partition session gracefully
     //! for rebalancing among all topic clients.
-    struct TStopPartitionSessionEvent : public TPartitionSessionAccessor, public TPrintable<TStopPartitionSessionEvent> {
+    struct TStopPartitionSessionEvent: public TPartitionSessionAccessor, public TPrintable<TStopPartitionSessionEvent> {
         TStopPartitionSessionEvent(TPartitionSession::TPtr partitionSession, uint64_t committedOffset);
 
         //! Last offset of the partition session that was committed.
@@ -319,7 +319,7 @@ struct TReadSessionEvent {
 
     //! Server command for ending partition session.
     //! This is a hint that all messages from the partition have been read and will no longer appear, and that the client must commit offsets.
-    struct TEndPartitionSessionEvent : public TPartitionSessionAccessor, public TPrintable<TEndPartitionSessionEvent> {
+    struct TEndPartitionSessionEvent: public TPartitionSessionAccessor, public TPrintable<TEndPartitionSessionEvent> {
         TEndPartitionSessionEvent(TPartitionSession::TPtr partitionSession, std::vector<uint32_t>&& adjacentPartitionIds, std::vector<uint32_t>&& childPartitionIds);
 
         //! A list of the partition IDs that also participated in the partition's merge.
@@ -342,8 +342,8 @@ struct TReadSessionEvent {
     };
 
     //! Status for partition session requested via TPartitionSession::RequestStatus()
-    struct TPartitionSessionStatusEvent : public TPartitionSessionAccessor,
-                                          public TPrintable<TPartitionSessionStatusEvent> {
+    struct TPartitionSessionStatusEvent: public TPartitionSessionAccessor,
+                                         public TPrintable<TPartitionSessionStatusEvent> {
         TPartitionSessionStatusEvent(TPartitionSession::TPtr partitionSession, uint64_t committedOffset, uint64_t readOffset,
                                      uint64_t endOffset, TInstant writeTimeHighWatermark);
 
@@ -379,8 +379,8 @@ struct TReadSessionEvent {
     //! partition session death.
     //! This could be after graceful stop of partition session
     //! or when connection with partition was lost.
-    struct TPartitionSessionClosedEvent : public TPartitionSessionAccessor,
-                                          public TPrintable<TPartitionSessionClosedEvent> {
+    struct TPartitionSessionClosedEvent: public TPartitionSessionAccessor,
+                                         public TPrintable<TPartitionSessionClosedEvent> {
         enum class EReason {
             StopConfirmedByUser,
             Lost,

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -60,16 +60,16 @@ void TPrintable<TPartitionSession>::DebugString(TStringBuilder& res, bool) const
 struct TPartitionSessionControl : public TPartitionSession {
     //! Commit offsets range.
     //! Can be used from TDataReceivedEvent or TDeferredCommit.
-    virtual void Commit(ui64 startOffset, ui64 endOffset) = 0;
+    virtual void Commit(uint64_t startOffset, uint64_t endOffset) = 0;
 
     //! Confirm partition session creation from TStartPartitionSessionEvent.
-    virtual void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) = 0;
+    virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) = 0;
 
     //! Confirm partition session destruction from TStopPartitionSessionEvent.
     virtual void ConfirmDestroy() = 0;
 
     //! Confirm partition session end from TEndPartitionSessionEvent.
-    virtual void ConfirmEnd(const std::vector<ui32>& childIds) = 0;
+    virtual void ConfirmEnd(std::span<const uint32_t> childIds) = 0;
 };
 
 //! Events for read session.

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -10,7 +10,7 @@
 namespace NYdb::inline Dev::NTopic {
 
 //! Partition session.
-struct TPartitionSession: public TThrRefBase, public TPrintable<TPartitionSession> {
+struct TPartitionSession : public TThrRefBase, public TPrintable<TPartitionSession> {
     using TPtr = TIntrusivePtr<TPartitionSession>;
 
 public:
@@ -241,15 +241,15 @@ struct TReadSessionEvent {
     };
 
     //! Acknowledgement for commit request.
-    struct TCommitOffsetAcknowledgementEvent: public TPartitionSessionAccessor,
-                                              public TPrintable<TCommitOffsetAcknowledgementEvent> {
+    struct TCommitOffsetAcknowledgementEvent : public TPartitionSessionAccessor,
+                                               public TPrintable<TCommitOffsetAcknowledgementEvent> {
         TCommitOffsetAcknowledgementEvent(TPartitionSession::TPtr partitionSession, uint64_t committedOffset);
 
         //! Committed offset.
         //! This means that from now the first available
         //! message offset in current partition
         //! for current consumer is this offset.
-        //! All messages before are committed and futher never be available.
+        //! All messages before are committed and further never be available.
         uint64_t GetCommittedOffset() const {
             return CommittedOffset;
         }
@@ -259,8 +259,8 @@ struct TReadSessionEvent {
     };
 
     //! Server command for creating and starting partition session.
-    struct TStartPartitionSessionEvent: public TPartitionSessionAccessor,
-                                        public TPrintable<TStartPartitionSessionEvent> {
+    struct TStartPartitionSessionEvent : public TPartitionSessionAccessor,
+                                         public TPrintable<TStartPartitionSessionEvent> {
         explicit TStartPartitionSessionEvent(TPartitionSession::TPtr, uint64_t committedOffset, uint64_t endOffset);
 
         //! Current committed offset in partition session.
@@ -286,7 +286,7 @@ struct TReadSessionEvent {
     //! Server command for stopping and destroying partition session.
     //! Server can destroy partition session gracefully
     //! for rebalancing among all topic clients.
-    struct TStopPartitionSessionEvent: public TPartitionSessionAccessor, public TPrintable<TStopPartitionSessionEvent> {
+    struct TStopPartitionSessionEvent : public TPartitionSessionAccessor, public TPrintable<TStopPartitionSessionEvent> {
         TStopPartitionSessionEvent(TPartitionSession::TPtr partitionSession, uint64_t committedOffset);
 
         //! Last offset of the partition session that was committed.
@@ -304,7 +304,7 @@ struct TReadSessionEvent {
 
     //! Server command for ending partition session.
     //! This is a hint that all messages from the partition have been read and will no longer appear, and that the client must commit offsets.
-    struct TEndPartitionSessionEvent: public TPartitionSessionAccessor, public TPrintable<TEndPartitionSessionEvent> {
+    struct TEndPartitionSessionEvent : public TPartitionSessionAccessor, public TPrintable<TEndPartitionSessionEvent> {
         TEndPartitionSessionEvent(TPartitionSession::TPtr partitionSession, std::vector<uint32_t>&& adjacentPartitionIds, std::vector<uint32_t>&& childPartitionIds);
 
         //! A list of the partition IDs that also participated in the partition's merge.
@@ -327,8 +327,8 @@ struct TReadSessionEvent {
     };
 
     //! Status for partition session requested via TPartitionSession::RequestStatus()
-    struct TPartitionSessionStatusEvent: public TPartitionSessionAccessor,
-                                         public TPrintable<TPartitionSessionStatusEvent> {
+    struct TPartitionSessionStatusEvent : public TPartitionSessionAccessor,
+                                          public TPrintable<TPartitionSessionStatusEvent> {
         TPartitionSessionStatusEvent(TPartitionSession::TPtr partitionSession, uint64_t committedOffset, uint64_t readOffset,
                                      uint64_t endOffset, TInstant writeTimeHighWatermark);
 
@@ -364,8 +364,8 @@ struct TReadSessionEvent {
     //! partition session death.
     //! This could be after graceful stop of partition session
     //! or when connection with partition was lost.
-    struct TPartitionSessionClosedEvent: public TPartitionSessionAccessor,
-                                         public TPrintable<TPartitionSessionClosedEvent> {
+    struct TPartitionSessionClosedEvent : public TPartitionSessionAccessor,
+                                          public TPrintable<TPartitionSessionClosedEvent> {
         enum class EReason {
             StopConfirmedByUser,
             Lost,
@@ -452,4 +452,4 @@ void TPrintable<TSessionClosedEvent>::DebugString(TStringBuilder& ret, bool prin
 
 std::string DebugString(const TReadSessionEvent::TEvent& event);
 
-}
+} // namespace NYdb::NTopic

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -57,6 +57,21 @@ protected:
 template<>
 void TPrintable<TPartitionSession>::DebugString(TStringBuilder& res, bool) const;
 
+struct TPartitionSessionControl : public TPartitionSession {
+    //! Commit offsets range.
+    //! Can be used from TDataReceivedEvent or TDeferredCommit.
+    virtual void Commit(ui64 startOffset, ui64 endOffset) = 0;
+
+    //! Confirm partition session creation from TStartPartitionSessionEvent.
+    virtual void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) = 0;
+
+    //! Confirm partition session destruction from TStopPartitionSessionEvent.
+    virtual void ConfirmDestroy() = 0;
+
+    //! Confirm partition session end from TEndPartitionSessionEvent.
+    virtual void ConfirmEnd(const std::vector<ui32>& childIds) = 0;
+};
+
 //! Events for read session.
 struct TReadSessionEvent {
     class TPartitionSessionAccessor {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
@@ -219,7 +219,7 @@ public:
 
     virtual bool Close(TDuration closeTimeout = TDuration::Max()) = 0;
 
-    //! Returns true if write session is alive and acitve. False if session was closed.
+    //! Returns true if write session is alive and active. False if session was closed.
     virtual bool IsAlive() const = 0;
 
     virtual TWriterCounters::TPtr GetCounters() = 0;
@@ -269,11 +269,11 @@ public:
     //! Return true if all writes were completed and acked, false if timeout was reached and some writes were aborted.
     virtual bool Close(TDuration closeTimeout = TDuration::Max()) = 0;
 
-    //! Writer counters with different stats (see TWriterConuters).
+    //! Writer counters with different stats (see TWriterCounters).
     virtual TWriterCounters::TPtr GetCounters() = 0;
 
     //! Close() with timeout = 0 and destroy everything instantly.
     virtual ~IWriteSession() = default;
 };
 
-}
+} // namespace NYdb::NTopic

--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -97,6 +97,10 @@ TDriverConfig& TDriverConfig::SetEndpoint(const std::string& endpoint) {
     return *this;
 }
 
+const std::string& TDriverConfig::GetEndpoint() const {
+    return Impl_->Endpoint;
+}
+
 TDriverConfig& TDriverConfig::SetNetworkThreadsNum(size_t sz) {
     Impl_->NetworkThreadsNum = sz;
     return *this;

--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_deferred_commit.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_deferred_commit.cpp
@@ -135,4 +135,4 @@ void TDeferredCommit::TImpl::Commit() {
     Offsets.clear();
 }
 
-}
+} // namespace NYdb::NFederatedTopic

--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_deferred_commit.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_deferred_commit.cpp
@@ -129,7 +129,7 @@ void TDeferredCommit::TImpl::Add(const TReadSessionEvent::TDataReceivedEvent& da
 void TDeferredCommit::TImpl::Commit() {
     for (auto&& [partitionStream, offsetRanges] : Offsets) {
         for (auto&& [startOffset, endOffset] : offsetRanges) {
-            static_cast<NTopic::TPartitionStreamImpl<false>*>(partitionStream.Get()->PartitionSession.Get())->Commit(startOffset, endOffset);
+            static_cast<NTopic::TPartitionSessionControl*>(partitionStream.Get()->PartitionSession.Get())->Commit(startOffset, endOffset);
         }
     }
     Offsets.clear();

--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_read_session_event.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_read_session_event.cpp
@@ -165,4 +165,4 @@ std::string DebugString(const TReadSessionEvent::TEvent& event) {
     return std::visit([](const auto& ev) { return ev.DebugString(); }, event);
 }
 
-} // namespace NYdb::Dev::NFederatedTopic
+} // namespace NYdb::NFederatedTopic

--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_read_session_event.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_read_session_event.cpp
@@ -157,7 +157,7 @@ TReadSessionEvent::TDataReceivedEvent::TDataReceivedEvent(NTopic::TReadSessionEv
 
 void TReadSessionEvent::TDataReceivedEvent::Commit() {
     for (auto [from, to] : OffsetRanges) {
-        static_cast<NTopic::TPartitionStreamImpl<false>*>(PartitionSession.Get())->Commit(from, to);
+        static_cast<NTopic::TPartitionSessionControl*>(PartitionSession.Get())->Commit(from, to);
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/deferred_commit.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/deferred_commit.cpp
@@ -128,4 +128,4 @@ void TDeferredCommit::TImpl::Commit() {
     Offsets.clear();
 }
 
-}
+} // namespace NYdb::NTopic

--- a/ydb/public/sdk/cpp/src/client/topic/impl/deferred_commit.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/deferred_commit.cpp
@@ -122,7 +122,7 @@ void TDeferredCommit::TImpl::Add(const TReadSessionEvent::TDataReceivedEvent& da
 void TDeferredCommit::TImpl::Commit() {
     for (auto&& [partitionStream, offsetRanges] : Offsets) {
         for (auto&& [startOffset, endOffset] : offsetRanges) {
-            static_cast<NTopic::TPartitionStreamImpl<false>*>(partitionStream.Get())->Commit(startOffset, endOffset);
+            static_cast<TPartitionSessionControl*>(partitionStream.Get())->Commit(startOffset, endOffset);
         }
     }
     Offsets.clear();

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
@@ -191,7 +191,7 @@ bool TMessage::HasException() const {
 }
 
 void TMessage::Commit() {
-    static_cast<TPartitionStreamImpl<false>*>(PartitionSession.Get())
+    static_cast<TPartitionSessionControl*>(PartitionSession.Get())
         ->Commit(Information.Offset, Information.Offset + 1);
 }
 
@@ -225,7 +225,7 @@ uint64_t TCompressedMessage::GetUncompressedSize() const {
 }
 
 void TCompressedMessage::Commit() {
-    static_cast<TPartitionStreamImpl<false>*>(PartitionSession.Get())
+    static_cast<TPartitionSessionControl*>(PartitionSession.Get())
         ->Commit(Information.Offset, Information.Offset + 1);
 }
 
@@ -264,7 +264,7 @@ void TDataReceivedEvent::Commit() {
     }
 
     for (auto [from, to] : OffsetRanges) {
-        static_cast<TPartitionStreamImpl<false>*>(PartitionSession.Get())->Commit(from, to);
+        static_cast<TPartitionSessionControl*>(PartitionSession.Get())->Commit(from, to);
     }
 }
 
@@ -317,7 +317,7 @@ TStartPartitionSessionEvent::TStartPartitionSessionEvent(TPartitionSession::TPtr
 
 void TStartPartitionSessionEvent::Confirm(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) {
     if (PartitionSession) {
-        static_cast<TPartitionStreamImpl<false>*>(PartitionSession.Get())
+        static_cast<TPartitionSessionControl*>(PartitionSession.Get())
             ->ConfirmCreate(readOffset, commitOffset);
     }
 }
@@ -342,7 +342,7 @@ TStopPartitionSessionEvent::TStopPartitionSessionEvent(TPartitionSession::TPtr p
 
 void TStopPartitionSessionEvent::Confirm() {
     if (PartitionSession) {
-        static_cast<TPartitionStreamImpl<false>*>(PartitionSession.Get())->ConfirmDestroy();
+        static_cast<TPartitionSessionControl*>(PartitionSession.Get())->ConfirmDestroy();
     }
 }
 
@@ -366,7 +366,7 @@ TEndPartitionSessionEvent::TEndPartitionSessionEvent(TPartitionSession::TPtr par
 
 void TEndPartitionSessionEvent::Confirm() {
     if (PartitionSession) {
-        static_cast<TPartitionStreamImpl<false>*>(PartitionSession.Get())->ConfirmEnd(GetChildPartitionIds());
+        static_cast<TPartitionSessionControl*>(PartitionSession.Get())->ConfirmEnd(GetChildPartitionIds());
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
@@ -454,4 +454,4 @@ std::string DebugString(const TReadSessionEvent::TEvent& event) {
     return std::visit([](const auto& ev) { return ev.DebugString(); }, event);
 }
 
-} // namespace NYdb::NPersQueue
+} // namespace NYdb::NTopic

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -70,7 +70,7 @@ using TASessionClosedEvent = std::conditional_t<UseMigrationProtocol,
     NYdb::NPersQueue::TSessionClosedEvent,
     NYdb::NTopic::TSessionClosedEvent>;
 
-struct TMigrationPartitionStream : public NYdb::NPersQueue::TPartitionStream {
+struct TMigrationPartitionStream: public NYdb::NPersQueue::TPartitionStream {
     virtual void Commit(uint64_t startOffset, uint64_t endOffset) = 0;
     virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) = 0;
     virtual void ConfirmDestroy() = 0;

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -71,10 +71,10 @@ using TASessionClosedEvent = std::conditional_t<UseMigrationProtocol,
     NYdb::NTopic::TSessionClosedEvent>;
 
 struct TMigrationPartitionStream : public NYdb::NPersQueue::TPartitionStream {
-    virtual void Commit(ui64 startOffset, ui64 endOffset) = 0;
-    virtual void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) = 0;
+    virtual void Commit(uint64_t startOffset, uint64_t endOffset) = 0;
+    virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) = 0;
     virtual void ConfirmDestroy() = 0;
-    virtual void ConfirmEnd(std::span<const ui32> childIds) = 0;
+    virtual void ConfirmEnd(std::span<const uint32_t> childIds) = 0;
 };
 
 template <bool UseMigrationProtocol>
@@ -691,12 +691,12 @@ public:
         TAPartitionStream<false>::LastDirectReadId = id;
     }
 
-    void Commit(ui64 startOffset, ui64 endOffset) override;
+    void Commit(uint64_t startOffset, uint64_t endOffset) override;
     void RequestStatus() override;
 
-    void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) override;
+    void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) override;
     void ConfirmDestroy() override;
-    void ConfirmEnd(std::span<const ui32> childIds) override;
+    void ConfirmEnd(std::span<const uint32_t> childIds) override;
 
     void StopReading() /*override*/;
     void ResumeReading() /*override*/;

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -74,7 +74,7 @@ struct TMigrationPartitionStream : public NYdb::NPersQueue::TPartitionStream {
     virtual void Commit(ui64 startOffset, ui64 endOffset) = 0;
     virtual void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) = 0;
     virtual void ConfirmDestroy() = 0;
-    virtual void ConfirmEnd(const std::vector<ui32>& childIds) = 0;
+    virtual void ConfirmEnd(std::span<const ui32> childIds) = 0;
 };
 
 template <bool UseMigrationProtocol>
@@ -696,7 +696,7 @@ public:
 
     void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) override;
     void ConfirmDestroy() override;
-    void ConfirmEnd(const std::vector<ui32>& childIds) override;
+    void ConfirmEnd(std::span<const ui32> childIds) override;
 
     void StopReading() /*override*/;
     void ResumeReading() /*override*/;
@@ -1170,7 +1170,7 @@ public:
     void Start();
     void ConfirmPartitionStreamCreate(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, std::optional<ui64> readOffset, std::optional<ui64> commitOffset);
     void ConfirmPartitionStreamDestroy(TPartitionStreamImpl<UseMigrationProtocol>* partitionStream);
-    void ConfirmPartitionStreamEnd(TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, const std::vector<ui32>& childIds);
+    void ConfirmPartitionStreamEnd(TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, std::span<const ui32> childIds);
     void RequestPartitionStreamStatus(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream);
     void Commit(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, ui64 startOffset, ui64 endOffset);
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -95,7 +95,7 @@ void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmDestroy() {
 }
 
 template<bool UseMigrationProtocol>
-void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmEnd(const std::vector<ui32>& childIds) {
+void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmEnd(std::span<const ui32> childIds) {
     if (auto sessionShared = CbContext->LockShared()) {
         sessionShared->ConfirmPartitionStreamEnd(this, childIds);
     }
@@ -2148,7 +2148,7 @@ bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::AllParentSessionsHasBe
 }
 
 template <>
-inline void TSingleClusterReadSessionImpl<false>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<false>* partitionStream, const std::vector<ui32>& childIds) {
+inline void TSingleClusterReadSessionImpl<false>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<false>* partitionStream, std::span<const ui32> childIds) {
     {
         std::lock_guard guard(HierarchyDataLock);
         ReadingFinishedData.insert(partitionStream->GetPartitionSessionId());
@@ -2164,7 +2164,7 @@ inline void TSingleClusterReadSessionImpl<false>::ConfirmPartitionStreamEnd(TPar
 }
 
 template <>
-inline void TSingleClusterReadSessionImpl<true>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<true>* partitionStream, const std::vector<ui32>& childIds) {
+inline void TSingleClusterReadSessionImpl<true>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<true>* partitionStream, std::span<const ui32> childIds) {
     Y_UNUSED(partitionStream, childIds);
     Y_ABORT("Not implemented");
 }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -2147,8 +2147,8 @@ bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::AllParentSessionsHasBe
     return true;
 }
 
-template<bool UseMigrationProtocol>
-void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, const std::vector<ui32>& childIds) {
+template <>
+inline void TSingleClusterReadSessionImpl<false>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<false>* partitionStream, const std::vector<ui32>& childIds) {
     {
         std::lock_guard guard(HierarchyDataLock);
         ReadingFinishedData.insert(partitionStream->GetPartitionSessionId());
@@ -2161,6 +2161,12 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStream
             }
         }
     }
+}
+
+template <>
+inline void TSingleClusterReadSessionImpl<true>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<true>* partitionStream, const std::vector<ui32>& childIds) {
+    Y_UNUSED(partitionStream, childIds);
+    Y_ABORT("Not implemented");
 }
 
 template <bool UseMigrationProtocol>

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -48,7 +48,7 @@ TLog TPartitionStreamImpl<UseMigrationProtocol>::GetLog() const {
 }
 
 template<bool UseMigrationProtocol>
-void TPartitionStreamImpl<UseMigrationProtocol>::Commit(ui64 startOffset, ui64 endOffset) {
+void TPartitionStreamImpl<UseMigrationProtocol>::Commit(uint64_t startOffset, uint64_t endOffset) {
     std::vector<std::pair<ui64, ui64>> toCommit;
     if (auto sessionShared = CbContext->LockShared()) {
         Y_ABORT_UNLESS(endOffset > startOffset);
@@ -78,7 +78,7 @@ void TPartitionStreamImpl<UseMigrationProtocol>::RequestStatus() {
 }
 
 template<bool UseMigrationProtocol>
-void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) {
+void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) {
     if (auto sessionShared = CbContext->LockShared()) {
         if (commitOffset.has_value()) {
             SetFirstNotReadOffset(commitOffset.value());
@@ -95,7 +95,7 @@ void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmDestroy() {
 }
 
 template<bool UseMigrationProtocol>
-void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmEnd(std::span<const ui32> childIds) {
+void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmEnd(std::span<const uint32_t> childIds) {
     if (auto sessionShared = CbContext->LockShared()) {
         sessionShared->ConfirmPartitionStreamEnd(this, childIds);
     }

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
@@ -1274,7 +1274,7 @@ public:
     }
 
     /*
-     * Start bidirectional streamming
+     * Start bidirectional streaming
      */
     template<typename TRequest, typename TResponse>
     void DoStreamRequest(TStreamConnectedCallback<TRequest, TResponse> callback,
@@ -1412,7 +1412,7 @@ private:
     std::mutex JoinMutex_;
 };
 
-}
+} // namespace NYdbGrpc
 
 template <>
 class grpc::TimePoint<NYdb::TDeadline> {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added public interface to partition session control in topic sdk. It allows to implement full `IReadSession` interface from topic sdk.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Also included:

* Added necessary method into driver for checking endpoint set or not
* Fixed typos / style issues 
