### PR TITLE
Implement new test helper retry_assertions

### DIFF
--- a/.github/TESTOWNERS
+++ b/.github/TESTOWNERS
@@ -91,6 +91,7 @@
 /ydb/tests/functional/config @ydb-platform/blobstorage
 /ydb/services/keyvalue/ut @ydb-platform/blobstorage
 /ydb/tests/functional/bridge @ydb-platform/blobstorage
+/ydb/tests/functional/dstool @ydb-platform/blobstorage
 
 #Core Functionality Team @CyberROFL TEAM:@ydb-platform/core
 /ydb/core/config/ut @ydb-platform/core

--- a/ydb/tests/library/common/wait_for.py
+++ b/ydb/tests/library/common/wait_for.py
@@ -72,3 +72,25 @@ def wait_for_and_assert(callable_, matcher, message='', timeout_seconds=60, step
     )
     assert_that(result, matcher, message)
     return result
+
+
+def retry_assertions(callable_, timeout_seconds=60, step_seconds=1.0):
+    """
+    Repeatedly call a function retrying AssertionError exceptions.
+
+    :param callable_: zero argument function
+    :param timeout_seconds:
+    :param step_seconds:
+
+    :return: return value of successful callable_ invocation
+    """
+    deadline = time.time() + timeout_seconds
+    while True:
+        try:
+            return callable_()
+        except AssertionError as e:
+            logger.info(str(e))
+            if time.time() > deadline:
+                raise e
+            else:
+                time.sleep(step_seconds)


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The main advantage over `wait_for` is that `retry_assertions` preserves original error message for easier diagnostics