### PR TITLE
Fix fields 'masked_token' and 'subject_type' in cloud events

### DIFF
--- a/ydb/core/ymq/actor/action.h
+++ b/ydb/core/ymq/actor/action.h
@@ -31,8 +31,6 @@
 #include <util/string/ascii.h>
 #include <util/string/join.h>
 
-#include <ydb/library/security/util.h>
-
 namespace NKikimr::NSQS {
 
 template <typename TDerived>
@@ -575,7 +573,7 @@ private:
         UserName_ = request.GetAuth().GetUserName();
         FolderId_ = request.GetAuth().GetFolderId();
         UserSID_ = request.GetAuth().GetUserSID();
-        MaskedToken_ = NKikimr::MaskIAMTicket(SecurityToken_);
+        MaskedToken_ = request.GetAuth().GetMaskedToken();
         AuthType_ = request.GetAuth().GetAuthType();
 
         if (IsCloud() && !FolderId_) {

--- a/ydb/core/ymq/actor/auth_multi_factory.cpp
+++ b/ydb/core/ymq/actor/auth_multi_factory.cpp
@@ -223,7 +223,6 @@ void TBaseCloudAuthRequestProxy::HandleAuthenticationResult(NCloud::TEvAccessSer
         return;
     }
 
-    AuthType_ = "service_account"; // see the conditions from above
     FolderId_ = ev->Get()->Response.Getsubject().Getservice_account().Getfolder_id();
 
     GetCloudIdAndAuthorize();
@@ -267,6 +266,12 @@ void TBaseCloudAuthRequestProxy::ProcessAuthorizationResult(const TEvTicketParse
 
     UserSID_ = result.Token->GetUserSID();
     MaskedToken_ = NKikimr::MaskIAMTicket(IamToken_);
+
+    // Of course, in practice the accounts that come in aren’t always of the "service_account" type.
+    // Nevertheless, this value is used only for logging, as it’s required by the cloud_events format.
+    // To determine the actual type of the cloud account, we would need to do some additional work—essentially,
+    //                                                                  make a careful request to the AccessService.
+    AuthType_ = "service_account";
 
     UserSidCallback_(UserSID_);
     OnFinishedRequest();

--- a/ydb/core/ymq/actor/auth_multi_factory.h
+++ b/ydb/core/ymq/actor/auth_multi_factory.h
@@ -138,6 +138,7 @@ protected:
     TString InfraToken_;
     TString FolderId_;
     TString CloudId_;
+    TString MaskedToken_;
     TString UserSID_;
     TString AuthType_;
     TString ResourceId_;

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -95,7 +95,6 @@ public:
     explicit TUserToken(const TString& token);
     bool IsExist(const TSID& someSID) const; // check for presence of SID specified in the token
     TSID GetUserSID() const;
-    using NACLibProto::TUserToken::GetAuthType;
     using NACLibProto::TUserToken::GetSanitizedToken;
     using NACLibProto::TUserToken::SetSanitizedToken;
     using NACLibProto::TUserToken::GetSubjectType;

--- a/ydb/tests/functional/sqs/cloud/test_yandex_audit.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_audit.py
@@ -76,7 +76,7 @@ class TestCloudEvents(get_test_with_sqs_tenant_installation(KikimrSqsTestBase)):
 
     def _before_test_start(self):
         self.cloud_account = f'acc_{uuid.uuid1()}'
-        self.iam_token = f'usr_{self.cloud_account}'
+        self.iam_token = f't1.prefix_of_token.super_mega_well_formed_iam_token'
         self.folder_id = f'folder_{self.cloud_account}'
         self.cloud_id = f'CLOUD_FOR_{self.folder_id}'
 
@@ -166,8 +166,8 @@ class TestCloudEvents(get_test_with_sqs_tenant_installation(KikimrSqsTestBase)):
                 assert log.count('"reason":') == 0
                 assert log.count('"idempotency_id":') == 1 and log.count(f'"idempotency_id":"{none_value}"') == 0
                 assert log.count(f'"cloud_id":"{self.cloud_id}"') == 1
-                assert log.count('"masked_token":') == 1 and log.count(f'"masked_token":"{none_value}"') == 0
-                assert log.count(f'"auth_type":"{none_value}"') == 1                                                            # there is no auth_type in mock verison of cloud sqs
+                assert log.count('"masked_token":"t1.prefix_of_token.**** (2764EAA0)"') == 1
+                # assert log.count(f'"auth_type":"{none_value}"') == 1                                                            # there is no auth_type in mock verison of cloud sqs
                 assert log.count('"remote_address":') == 1 and log.count(f'"remote_address":"{none_value}"') == 0
                 assert log.count(f'"folder_id":"{self.folder_id}"') == 1
                 assert log.count(f'"resource_id":"{cloud_queue_name}"') == 1

--- a/ydb/tests/functional/sqs/cloud/test_yandex_audit.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_audit.py
@@ -76,7 +76,7 @@ class TestCloudEvents(get_test_with_sqs_tenant_installation(KikimrSqsTestBase)):
 
     def _before_test_start(self):
         self.cloud_account = f'acc_{uuid.uuid1()}'
-        self.iam_token = f't1.prefix_of_token.super_mega_well_formed_iam_token'
+        self.iam_token = 't1.prefix_of_token.super_mega_well_formed_iam_token'
         self.folder_id = f'folder_{self.cloud_account}'
         self.cloud_id = f'CLOUD_FOR_{self.folder_id}'
 
@@ -167,7 +167,7 @@ class TestCloudEvents(get_test_with_sqs_tenant_installation(KikimrSqsTestBase)):
                 assert log.count('"idempotency_id":') == 1 and log.count(f'"idempotency_id":"{none_value}"') == 0
                 assert log.count(f'"cloud_id":"{self.cloud_id}"') == 1
                 assert log.count('"masked_token":"t1.prefix_of_token.**** (2764EAA0)"') == 1
-                # assert log.count(f'"auth_type":"{none_value}"') == 1                                                            # there is no auth_type in mock verison of cloud sqs
+                assert log.count('"auth_type":"service_account"') == 1
                 assert log.count('"remote_address":') == 1 and log.count(f'"remote_address":"{none_value}"') == 0
                 assert log.count(f'"folder_id":"{self.folder_id}"') == 1
                 assert log.count(f'"resource_id":"{cloud_queue_name}"') == 1


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
