### PR TITLE
YQ-4474 support reading from local topics

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -155,7 +155,7 @@ public:
         , VerboseMemoryLimitException(executerConfig.MutableConfig->VerboseMemoryLimitException.load())
         , BatchOperationSettings(std::move(batchOperationSettings))
         , AccountDefaultPoolInScheduler(executerConfig.TableServiceConfig.GetComputeSchedulerSettings().GetAccountDefaultPool())
-        , TasksGraph(Database, Request.Transactions, Request.TxAlloc, partitionPrunerConfig, AggregationSettings, Counters, BufferActorId)
+        , TasksGraph(Database, Request.Transactions, Request.TxAlloc, partitionPrunerConfig, AggregationSettings, Counters, BufferActorId, UserToken)
         , ChannelService(channelService)
     {
         ArrayBufferMinFillPercentage = executerConfig.TableServiceConfig.GetArrayBufferMinFillPercentage();

--- a/ydb/core/kqp/executer_actor/kqp_literal_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_literal_executer.cpp
@@ -84,7 +84,7 @@ public:
         : Request(std::move(request))
         , Counters(counters)
         , OwnerActor(owner)
-        , TasksGraph({}, Request.Transactions, Request.TxAlloc, {}, {}, Counters, {})
+        , TasksGraph({}, Request.Transactions, Request.TxAlloc, {}, {}, Counters, {}, nullptr)
         , LiteralExecuterSpan(TWilsonKqp::LiteralExecuter, std::move(Request.TraceId), "LiteralExecuter")
         , UserRequestContext(userRequestContext)
     {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -2461,7 +2461,13 @@ void TKqpTasksGraph::BuildReadTasksFromSource(TStageInfo& stageInfo, const TVect
     auto sourceName = externalSource.GetSourceName();
     TString structuredToken;
     if (sourceName) {
-        structuredToken = NYql::CreateStructuredTokenParser(externalSource.GetAuthInfo()).ToBuilder().ReplaceReferences(GetMeta().SecureParams).ToJson();
+        const auto parser = NYql::CreateStructuredTokenParser(externalSource.GetAuthInfo());
+        auto builder = parser.ToBuilder();
+        if (!parser.IsCurrentUserAuth()) {
+            structuredToken = builder.ReplaceReferences(GetMeta().SecureParams).ToJson();
+        } else if (UserToken && UserToken->GetSerializedToken()) {
+            structuredToken = builder.SetIAMToken(UserToken->GetSerializedToken()).ToJson();
+        }
     }
 
     ui64 nodeOffset = 0;
@@ -3169,13 +3175,15 @@ TKqpTasksGraph::TKqpTasksGraph(
     const TPartitionPrunerConfig& partitionPrunerConfig,
     const NKikimrConfig::TTableServiceConfig::TAggregationConfig& aggregationSettings,
     const TKqpRequestCounters::TPtr& counters,
-    TActorId bufferActorId)
+    TActorId bufferActorId,
+    TIntrusiveConstPtr<NACLib::TUserToken> userToken)
     : PartitionPruner(MakeHolder<TPartitionPruner>(txAlloc->HolderFactory, txAlloc->TypeEnv, std::move(partitionPrunerConfig)))
     , Transactions(transactions)
     , TxAlloc(txAlloc)
     , AggregationSettings(aggregationSettings)
     , Counters(counters)
     , BufferActorId(bufferActorId)
+    , UserToken(std::move(userToken))
 {
     GetMeta().Arena = MakeIntrusive<NActors::TProtoArenaHolder>();
     GetMeta().Database = database;

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -377,14 +377,15 @@ using TTask = NYql::NDq::TTask<TStageInfoMeta, TTaskMeta, TTaskInputMeta, TTaskO
 
 class TKqpTasksGraph : public NYql::NDq::TDqTasksGraph<TGraphMeta, TStageInfoMeta, TTaskMeta, TTaskInputMeta, TTaskOutputMeta> {
 public:
-    explicit TKqpTasksGraph(
+    TKqpTasksGraph(
         const TString& database,
         const TVector<IKqpGateway::TPhysicalTxData>& transactions,
         const NKikimr::NKqp::TTxAllocatorState::TPtr& txAlloc,
         const TPartitionPrunerConfig& partitionPrunerConfig,
         const NKikimrConfig::TTableServiceConfig::TAggregationConfig& aggregationSettings,
         const TKqpRequestCounters::TPtr& counters,
-        TActorId bufferActorId
+        TActorId bufferActorId,
+        TIntrusiveConstPtr<NACLib::TUserToken> userToken
     );
 
     size_t BuildAllTasks(std::optional<TLlvmSettings> llvmSettings, const TVector<NKikimrKqp::TKqpNodeResources>& resourcesSnapshot,
@@ -467,6 +468,7 @@ private:
     const NKikimrConfig::TTableServiceConfig::TAggregationConfig AggregationSettings;
     TKqpRequestCounters::TPtr Counters;
     TActorId BufferActorId; // TODO: not sure if it belongs here
+    const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
 };
 
 void FillTableMeta(const TStageInfo& stageInfo, NKikimrTxDataShard::TKqpTransaction_TTableMeta* meta);

--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
@@ -7,9 +7,12 @@
 #include <ydb/core/fq/libs/db_id_async_resolver_impl/db_async_resolver_impl.h>
 #include <ydb/core/fq/libs/db_id_async_resolver_impl/http_proxy.h>
 #include <ydb/core/fq/libs/db_id_async_resolver_impl/mdb_endpoint_generator.h>
+#include <ydb/core/kqp/federated_query/local_pq_client/local_topic_client_factory.h>
 #include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/protos/config.pb.h>
+#include <ydb/core/protos/feature_flags.pb.h>
 #include <ydb/core/protos/kqp_physical.pb.h>
+#include <ydb/core/protos/table_service_config.pb.h>
 #include <ydb/library/actors/http/http_proxy.h>
 #include <ydb/library/yql/providers/common/db_id_async_resolver/database_type.h>
 #include <ydb/library/yql/providers/pq/gateway/native/yql_pq_gateway.h>
@@ -179,7 +182,7 @@ namespace {
         return settings;
     }
 
-    NYql::IPqGateway::TPtr MakePqGateway(const std::shared_ptr<NYdb::TDriver>& driver) {
+    NYql::IPqGateway::TPtr MakePqGateway(const std::shared_ptr<NYdb::TDriver>& driver, const std::optional<TLocalTopicClientSettings>& localTopicClientSettings) {
         auto settings = MakeCommonTopicClientSettings(1, 2);
 
         return CreatePqNativeGateway(NYql::TPqGatewayServices(
@@ -189,7 +192,8 @@ namespace {
             std::make_shared<NYql::TPqGatewayConfig>(),
             nullptr,
             nullptr,
-            settings
+            settings,
+            localTopicClientSettings ? CreateLocalTopicClientFactory(*localTopicClientSettings) : nullptr
         ));
     }
 
@@ -246,7 +250,11 @@ namespace {
 
         ActorSystemPtr = std::make_shared<NKikimr::TDeferredActorLogBackend::TAtomicActorSystemPtr>(nullptr);
         Driver = MakeYdbDriver(ActorSystemPtr, queryServiceConfig.GetStreamingQueries().GetTopicSdkSettings());
-        PqGateway = MakePqGateway(Driver);
+
+        if (appConfig.GetFeatureFlags().GetEnableTopicsSqlIoOperations()) {
+            LocalTopicClientSettings.emplace();
+            LocalTopicClientSettings->ChannelBufferSize = appConfig.GetTableServiceConfig().GetResourceManager().GetChannelBufferSize();
+        }
 
         // Initialize Token Accessor
         if (appConfig.GetAuthConfig().HasTokenAccessorConfig()) {
@@ -295,6 +303,10 @@ namespace {
             ActorSystemPtr->store(actorSystem, std::memory_order_relaxed);
         }
 
+        if (LocalTopicClientSettings) {
+            LocalTopicClientSettings->ActorSystem = actorSystem;
+        }
+
         auto result = TKqpFederatedQuerySetup{
             HttpGateway,
             ConnectorClient,
@@ -310,7 +322,7 @@ namespace {
             S3ReadActorFactoryConfig,
             DqTaskTransformFactory,
             PqGatewayConfig,
-            PqGateway,
+            MakePqGateway(Driver, LocalTopicClientSettings),
             ActorSystemPtr,
             Driver};
 
@@ -330,7 +342,6 @@ namespace {
 
     void TKqpFederatedQuerySetupFactoryDefault::Cleanup() {
         HttpGateway.reset();
-        PqGateway.Reset();
     }
 
     IKqpFederatedQuerySetupFactory::TPtr MakeKqpFederatedQuerySetupFactory(

--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/kqp/federated_query/local_pq_client/local_topic_client_settings.h>
 #include <ydb/library/logger/actor.h>
 #include <ydb/library/yql/providers/common/db_id_async_resolver/db_async_resolver.h>
 #include <ydb/library/yql/providers/common/db_id_async_resolver/mdb_endpoint_generator.h>
@@ -39,7 +40,7 @@ namespace NKikimr::NKqp {
 
     std::shared_ptr<NYdb::TDriver> MakeYdbDriver(NKikimr::TDeferredActorLogBackend::TSharedAtomicActorSystemPtr actorSystemPtr, const NKikimrConfig::TStreamingQueriesConfig_TExternalTopicsSettings& config);
 
-    NYql::IPqGateway::TPtr MakePqGateway(const std::shared_ptr<NYdb::TDriver>& driver);
+    NYql::IPqGateway::TPtr MakePqGateway(const std::shared_ptr<NYdb::TDriver>& driver, const std::optional<TLocalTopicClientSettings>& localTopicClientSettings = std::nullopt);
 
     struct TKqpFederatedQuerySetup {
         NYql::IHTTPGateway::TPtr HttpGateway;
@@ -102,9 +103,9 @@ namespace NKikimr::NKqp {
         NYql::NDq::TS3ReadActorFactoryConfig S3ReadActorFactoryConfig;
         NYql::TTaskTransformFactory DqTaskTransformFactory;
         NYql::TPqGatewayConfig PqGatewayConfig;
-        NYql::IPqGateway::TPtr PqGateway;
         NKikimr::TDeferredActorLogBackend::TSharedAtomicActorSystemPtr ActorSystemPtr;
         std::shared_ptr<NYdb::TDriver> Driver;
+        std::optional<TLocalTopicClientSettings> LocalTopicClientSettings;
     };
 
     struct TKqpFederatedQuerySetupFactoryMock: public IKqpFederatedQuerySetupFactory {

--- a/ydb/core/kqp/federated_query/local_pq_client/local_topic_client.cpp
+++ b/ydb/core/kqp/federated_query/local_pq_client/local_topic_client.cpp
@@ -1,0 +1,131 @@
+#include "local_topic_client.h"
+#include "local_topic_read_session.h"
+
+#include <ydb/core/grpc_services/local_rpc/local_rpc_operation.h>
+#include <ydb/core/grpc_services/service_topic.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+using namespace NGRpcService;
+using namespace NRpcService;
+using namespace NYdb;
+using namespace NYdb::NTopic;
+
+class TLocalTopicClient final : public NYql::ITopicClient {
+public:
+    TLocalTopicClient(const TLocalTopicClientSettings& localSettings, const TTopicClientSettings& clientSettings)
+        : ActorSystem(localSettings.ActorSystem)
+        , ChannelBufferSize(localSettings.ChannelBufferSize)
+        , Database(clientSettings.Database_.value_or(""))
+        , CredentialsProvider(CreateCredentialsProvider(clientSettings.CredentialsProviderFactory_))
+    {
+        Y_VALIDATE(ActorSystem, "Actor system is required for local topic client");
+        Y_VALIDATE(ChannelBufferSize, "Channel buffer size is not set");
+        Y_VALIDATE(Database, "Database is required for local topic client");
+        Y_VALIDATE(clientSettings.DiscoveryEndpoint_.value_or("").empty(), "Discovery endpoint is not allowed for local topic client");
+    }
+
+    TAsyncStatus CreateTopic(const TString& path, const TCreateTopicSettings& settings) final {
+        Y_UNUSED(path, settings);
+        Y_VALIDATE(false, __func__ << " is not implemented");
+    }
+
+    TAsyncStatus AlterTopic(const TString& path, const TAlterTopicSettings& settings) final {
+        Y_UNUSED(path, settings);
+        Y_VALIDATE(false, __func__ << " is not implemented");
+    }
+
+    TAsyncStatus DropTopic(const TString& path, const TDropTopicSettings& settings) final {
+        Y_UNUSED(path, settings);
+        Y_VALIDATE(false, __func__ << " is not implemented");
+    }
+
+    TAsyncDescribeTopicResult DescribeTopic(const TString& path, const TDescribeTopicSettings& settings) final {
+        using TDescribeTopicRequest = TGrpcRequestOperationCall<Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>;
+
+        TDescribeTopicRequest::TRequest request;
+        request.set_path(path);
+        request.set_include_stats(settings.IncludeStats_);
+        request.set_include_location(settings.IncludeLocation_);
+
+        return DoLocalRpcRequest<TDescribeTopicRequest, TDescribeTopicSettings>(std::move(request), settings, &DoDescribeTopicRequest).Apply([](const NThreading::TFuture<TLocalRpcOperationResult>& f) {
+            const auto& [status, response] = f.GetValue();
+            Ydb::Topic::DescribeTopicResult result;
+            response.UnpackTo(&result);
+            return TDescribeTopicResult(TStatus(status), std::move(result));
+        });
+    }
+
+    TAsyncDescribeConsumerResult DescribeConsumer(const TString& path, const TString& consumer, const TDescribeConsumerSettings& settings) final {
+        Y_UNUSED(path, consumer, settings);
+        Y_VALIDATE(false, __func__ << " is not implemented");
+    }
+
+    TAsyncDescribePartitionResult DescribePartition(const TString& path, i64 partitionId, const TDescribePartitionSettings& settings) final {
+        Y_UNUSED(path, partitionId, settings);
+        Y_VALIDATE(false, __func__ << " is not implemented");
+    }
+
+    std::shared_ptr<IReadSession> CreateReadSession(const TReadSessionSettings& settings) final {
+        return CreateLocalTopicReadSession({
+            .ActorSystem = ActorSystem,
+            .Database = Database,
+            .CredentialsProvider = CredentialsProvider,
+        }, settings);
+    }
+
+    std::shared_ptr<ISimpleBlockingWriteSession> CreateSimpleBlockingWriteSession(const TWriteSessionSettings& settings) final {
+        Y_UNUSED(settings);
+        Y_VALIDATE(false, __func__ << " is not implemented");
+    }
+
+    std::shared_ptr<IWriteSession> CreateWriteSession(const TWriteSessionSettings& settings) final {
+        Y_UNUSED(settings);
+        Y_VALIDATE(false, __func__ << " is not implemented");
+    }
+
+    TAsyncStatus CommitOffset(const TString& path, ui64 partitionId, const TString& consumerName, ui64 offset, const TCommitOffsetSettings& settings) final {
+        Y_UNUSED(path, partitionId, consumerName, offset, settings);
+        Y_VALIDATE(false, __func__ << " is not implemented");
+    }
+
+private:
+    static std::shared_ptr<ICredentialsProvider> CreateCredentialsProvider(const std::optional<std::shared_ptr<ICredentialsProviderFactory>>& maybeFactory) {
+        if (const auto factory = maybeFactory.value_or(nullptr)) {
+            return factory->CreateProvider();
+        }
+        return nullptr;
+    }
+
+    template <typename TRpc, typename TSettings>
+    NThreading::TFuture<TLocalRpcOperationResult> DoLocalRpcRequest(typename TRpc::TRequest&& proto, const TOperationRequestSettings<TSettings>& settings, TLocalRpcOperationRequestCreator requestCreator) {
+        const auto promise = NThreading::NewPromise<TLocalRpcOperationResult>();
+        auto* actor = new TOperationRequestExecuter<TRpc, TSettings>(std::move(proto), {
+            .ChannelBufferSize = ChannelBufferSize,
+            .OperationSettings = settings,
+            .RequestCreator = std::move(requestCreator),
+            .Database = Database,
+            .Token = CredentialsProvider ? TMaybe<TString>(CredentialsProvider->GetAuthInfo()) : Nothing(),
+            .Promise = promise,
+            .OperationName = "local_topic_rpc_operation",
+        });
+        ActorSystem->Register(actor, TMailboxType::HTSwap, ActorSystem->AppData<TAppData>()->UserPoolId);
+        return promise.GetFuture();
+    }
+
+    TActorSystem* const ActorSystem = nullptr;
+    const ui64 ChannelBufferSize = 0;
+    const TString Database;
+    const std::shared_ptr<ICredentialsProvider> CredentialsProvider;
+};
+
+} // anonymous namespace
+
+NYql::ITopicClient::TPtr CreateLocalTopicClient(const TLocalTopicClientSettings& localSettings, const TTopicClientSettings& clientSettings) {
+    return MakeIntrusive<TLocalTopicClient>(localSettings, clientSettings);
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/local_pq_client/local_topic_client.h
+++ b/ydb/core/kqp/federated_query/local_pq_client/local_topic_client.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "local_topic_client_settings.h"
+
+#include <ydb/library/yql/providers/pq/gateway/abstract/yql_pq_topic_client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+
+namespace NKikimr::NKqp {
+
+NYql::ITopicClient::TPtr CreateLocalTopicClient(const TLocalTopicClientSettings& localSettings, const NYdb::NTopic::TTopicClientSettings& clientSettings);
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/local_pq_client/local_topic_client_factory.cpp
+++ b/ydb/core/kqp/federated_query/local_pq_client/local_topic_client_factory.cpp
@@ -1,0 +1,32 @@
+#include "local_topic_client_factory.h"
+#include "local_topic_client.h"
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+using namespace NYdb::NTopic;
+
+class TPqLocalClientFactory final : public NYql::IPqLocalClientFactory {
+public:
+    explicit TPqLocalClientFactory(const TLocalTopicClientSettings& settings)
+        : Settings(settings)
+    {}
+
+    NYql::ITopicClient::TPtr CreateTopicClient(const TTopicClientSettings& clientSettings) final {
+        return CreateLocalTopicClient(Settings, clientSettings);
+    }
+
+private:
+    const TLocalTopicClientSettings Settings;
+};
+
+} // anonymous namespace
+
+NYql::IPqLocalClientFactory::TPtr CreateLocalTopicClientFactory(const TLocalTopicClientSettings& settings) {
+    return MakeIntrusive<TPqLocalClientFactory>(settings);
+}
+
+} // namespace NKikimr::NKqp
+
+

--- a/ydb/core/kqp/federated_query/local_pq_client/local_topic_client_factory.h
+++ b/ydb/core/kqp/federated_query/local_pq_client/local_topic_client_factory.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "local_topic_client_settings.h"
+
+#include <ydb/library/yql/providers/pq/gateway/clients/local/yql_pq_local_topic_client_factory.h>
+
+namespace NKikimr::NKqp {
+
+NYql::IPqLocalClientFactory::TPtr CreateLocalTopicClientFactory(const TLocalTopicClientSettings& settings);
+
+} // namespace NKikimr::NKqp
+

--- a/ydb/core/kqp/federated_query/local_pq_client/local_topic_client_settings.h
+++ b/ydb/core/kqp/federated_query/local_pq_client/local_topic_client_settings.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+
+#include <util/system/types.h>
+
+namespace NKikimr::NKqp {
+
+struct TLocalTopicClientSettings {
+    NActors::TActorSystem* ActorSystem = nullptr;
+    ui64 ChannelBufferSize = 0;
+};
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/local_pq_client/local_topic_read_session.cpp
+++ b/ydb/core/kqp/federated_query/local_pq_client/local_topic_read_session.cpp
@@ -1,0 +1,1126 @@
+#include "local_topic_read_session.h"
+
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/grpc_services/local_rpc/local_rpc_bi_streaming.h>
+#include <ydb/core/grpc_services/rpc_calls.h>
+#include <ydb/core/kqp/common/kqp_script_executions.h>
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/public/sdk/cpp/adapters/issue/issue.h>
+#include <ydb/services/persqueue_v1/actors/read_session_actor.h>
+
+#include <yql/essentials/public/issue/yql_issue_message.h>
+
+#include <library/cpp/protobuf/interop/cast.h>
+
+#include <util/generic/guid.h>
+
+#include <queue>
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::YDB_SDK, "[LocalTopicReadSession] " << LogPrefix() << stream)
+#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::YDB_SDK, "[LocalTopicReadSession] " << LogPrefix() << stream)
+#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::YDB_SDK, "[LocalTopicReadSession] " << LogPrefix() << stream)
+#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::YDB_SDK, "[LocalTopicReadSession] " << LogPrefix() << stream)
+#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::YDB_SDK, "[LocalTopicReadSession] " << LogPrefix() << stream)
+#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::YDB_SDK, "[LocalTopicReadSession] " << LogPrefix() << stream)
+#define LOG_C(stream) LOG_CRIT_S(*TlsActivationContext, NKikimrServices::YDB_SDK, "[LocalTopicReadSession] " << LogPrefix() << stream)
+
+using namespace NActors;
+using namespace NGRpcService;
+using namespace NRpcService;
+using namespace NYdb;
+using namespace NYdb::NTopic;
+
+struct TLocalTopicReadyEvent {
+    TLocalTopicReadyEvent(TReadSessionEvent::TEvent&& event, i64 size)
+        : Event(std::move(event))
+        , Size(size)
+    {}
+
+    TReadSessionEvent::TEvent Event;
+    i64 Size = 0;
+};
+
+class TLocalTopicReadSessionActor final : public TActorBootstrapped<TLocalTopicReadSessionActor>, public NActors::IActorExceptionHandler {
+    static constexpr TDuration COUNTERS_REFRESH_INTERVAL = TDuration::Seconds(1);
+
+    using TRpcIn = Ydb::Topic::StreamReadMessage::FromClient;
+    using TRpcOut = Ydb::Topic::StreamReadMessage::FromServer;
+    using TLocalRpcCtx = TLocalRpcBiStreamingCtx<TRpcIn, TRpcOut>;
+
+    struct TEvPrivate {
+        enum EEv {
+            EvPartitionStatusRequest = TLocalRpcCtx::TRpcEvents::EvEnd,
+            EvPartitionOffsetsCommitRequest,
+            EvPartitionConfirmCreate,
+            EvPartitionConfirmDestroy,
+            EvExtractReadyEvents,
+            EvEventsConsumed,
+            EvSessionFinished,
+            EvEnd,
+        };
+
+        static_assert(EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE)");
+
+        // Events from partition session callbacks
+
+        struct TEvPartitionStatusRequest : public TEventLocal<TEvPartitionStatusRequest, EvPartitionStatusRequest> {
+            explicit TEvPartitionStatusRequest(i64 partitionSessionId)
+                : PartitionSessionId(partitionSessionId)
+            {}
+
+            const i64 PartitionSessionId;
+        };
+
+        struct TEvPartitionOffsetsCommitRequest : public TEventLocal<TEvPartitionOffsetsCommitRequest, EvPartitionOffsetsCommitRequest> {
+            TEvPartitionOffsetsCommitRequest(i64 partitionSessionId, ui64 startOffset, ui64 endOffset)
+                : PartitionSessionId(partitionSessionId)
+                , StartOffset(startOffset)
+                , EndOffset(endOffset)
+            {}
+
+            const i64 PartitionSessionId;
+            const ui64 StartOffset;
+            const ui64 EndOffset;
+        };
+
+        struct TEvPartitionConfirmCreate : public TEventLocal<TEvPartitionConfirmCreate, EvPartitionConfirmCreate> {
+            TEvPartitionConfirmCreate(i64 partitionSessionId, std::optional<ui64> readOffset, std::optional<ui64> commitOffset)
+                : PartitionSessionId(partitionSessionId)
+                , ReadOffset(readOffset)
+                , CommitOffset(commitOffset)
+            {}
+
+            const i64 PartitionSessionId;
+            const std::optional<ui64> ReadOffset;
+            const std::optional<ui64> CommitOffset;
+        };
+
+        struct TEvPartitionConfirmDestroy : public TEventLocal<TEvPartitionConfirmDestroy, EvPartitionConfirmDestroy> {
+            explicit TEvPartitionConfirmDestroy(i64 partitionSessionId)
+                : PartitionSessionId(partitionSessionId)
+            {}
+
+            const i64 PartitionSessionId;
+        };
+    };
+
+    class TLocalPartitionSession final : public TPartitionSession {
+    public:
+        struct TSettings {
+            i64 PartitionSessionId = 0;
+            i64 PartitionId = 0;
+            TString TopicPath;
+            TString ReadSessionId;
+        };
+
+        TLocalPartitionSession(const TActorSystem* actorSystem, const TActorId& selfId, const TSettings& settings)
+            : ActorSystem(actorSystem)
+            , SelfId(selfId)
+        {
+            Y_VALIDATE(settings.PartitionSessionId >= 0, "PartitionSessionId must be non negative");
+            PartitionSessionId = settings.PartitionSessionId;
+
+            Y_VALIDATE(settings.PartitionId >= 0, "PartitionId must be non negative");
+            PartitionId = settings.PartitionId;
+
+            Y_VALIDATE(settings.TopicPath, "Topic path is not set");
+            TopicPath = settings.TopicPath;
+
+            Y_VALIDATE(settings.ReadSessionId, "Read session is not started");
+            ReadSessionId = settings.ReadSessionId;
+        }
+
+        void RequestStatus() final {
+            ActorSystem->Send(SelfId, new TEvPrivate::TEvPartitionStatusRequest(PartitionSessionId));
+        }
+
+        void Commit(ui64 startOffset, ui64 endOffset) final {
+            ActorSystem->Send(SelfId, new TEvPrivate::TEvPartitionOffsetsCommitRequest(PartitionSessionId, startOffset, endOffset));
+        }
+
+        void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) final {
+            ActorSystem->Send(SelfId, new TEvPrivate::TEvPartitionConfirmCreate(PartitionSessionId, readOffset, commitOffset));
+        }
+
+        void ConfirmDestroy() final {
+            ActorSystem->Send(SelfId, new TEvPrivate::TEvPartitionConfirmDestroy(PartitionSessionId));
+        }
+
+        void ConfirmEnd(const std::vector<ui32>& childIds) final {
+            Y_UNUSED(childIds);
+        }
+
+    private:
+        const TActorSystem* const ActorSystem = nullptr;
+        const TActorId SelfId;
+    };
+
+    struct TReadSettings {
+        TString Consumer;
+        TString Topic;
+        std::optional<TInstant> ReadFrom;
+        std::optional<TDuration> MaxLag;
+        std::vector<i64> PartitionIds;
+    };
+
+public:
+    struct TSessionEvents : private TEvPrivate {
+        // Events from TLocalTopicReadSession
+
+        struct TEvExtractReadyEvents : public TEventLocal<TEvExtractReadyEvents, EvExtractReadyEvents> {
+            explicit TEvExtractReadyEvents(NThreading::TPromise<std::vector<TLocalTopicReadyEvent>> eventsPromise)
+                : EventsPromise(std::move(eventsPromise))
+            {}
+
+            NThreading::TPromise<std::vector<TLocalTopicReadyEvent>> EventsPromise;
+        };
+
+        struct TEvEventsConsumed : public TEventLocal<TEvEventsConsumed, EvEventsConsumed> {
+            TEvEventsConsumed(i64 size, ui64 eventsCount)
+                : Size(size)
+                , EventsCount(eventsCount)
+            {}
+
+            const i64 Size = 0; // Return this size to free memory
+            const ui64 EventsCount = 0;
+        };
+
+        struct TEvSessionFinished : public TEventLocal<TEvSessionFinished, EvSessionFinished> {
+            explicit TEvSessionFinished(bool force)
+                : Force(force)
+            {}
+
+            const bool Force = false;
+        };
+    };
+
+    struct TSettings {
+        TString Database;
+        std::shared_ptr<NYdb::ICredentialsProvider> CredentialsProvider;
+        TReaderCounters::TPtr Counters;
+    };
+
+    TLocalTopicReadSessionActor(const TSettings& actorSettings, const TReadSessionSettings& sessionSettings)
+        : Settings(sessionSettings)
+        , ReadSettings(GetReadSettings(sessionSettings))
+        , Database(actorSettings.Database)
+        , CredentialsProvider(actorSettings.CredentialsProvider)
+        , MaxMemoryUsage(sessionSettings.MaxMemoryUsageBytes_)
+        , Counters(actorSettings.Counters)
+    {
+        Y_VALIDATE(Database, "Missing database");
+        Y_VALIDATE(Counters, "Missing counters");
+    }
+
+    void Bootstrap() {
+        Become(&TThis::StateFunc);
+
+        LOG_I("Start local topic read session, MaxMemoryUsage: " << MaxMemoryUsage);
+        StartSession();
+
+        Schedule(COUNTERS_REFRESH_INTERVAL, new TEvents::TEvWakeup());
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TSessionEvents::TEvExtractReadyEvents, Handle);
+        hFunc(TSessionEvents::TEvEventsConsumed, Handle);
+        hFunc(TSessionEvents::TEvSessionFinished, Handle);
+        hFunc(TLocalRpcCtx::TRpcEvents::TEvActorAttached, Handle);
+        hFunc(TLocalRpcCtx::TRpcEvents::TEvReadRequest, Handle);
+        hFunc(TLocalRpcCtx::TRpcEvents::TEvWriteRequest, Handle);
+        hFunc(TLocalRpcCtx::TRpcEvents::TEvFinishRequest, Handle);
+        hFunc(TEvPrivate::TEvPartitionStatusRequest, Handle);
+        hFunc(TEvPrivate::TEvPartitionOffsetsCommitRequest, Handle);
+        hFunc(TEvPrivate::TEvPartitionConfirmCreate, Handle);
+        hFunc(TEvPrivate::TEvPartitionConfirmDestroy, Handle);
+        hFunc(TEvents::TEvWakeup, Handle);
+        hFunc(TEvents::TEvUndelivered, Handle);
+    );
+
+    bool OnUnhandledException(const std::exception& e) final {
+        LOG_E("Got unexpected exception: " << e.what());
+        CloseSession(EStatus::INTERNAL_ERROR, TStringBuilder() << "Got unexpected exception: " << e.what());
+        return true;
+    }
+
+private:
+    static TReadSettings GetReadSettings(const TReadSessionSettings& sessionSettings) {
+        TReadSettings settings;
+        settings.Consumer = sessionSettings.ConsumerName_;
+
+        Y_VALIDATE(sessionSettings.Topics_.size() == 1, "Only one topic is supported per read session");
+        const auto& topic = sessionSettings.Topics_[0];
+        settings.Topic = topic.Path_;
+        settings.ReadFrom = topic.ReadFromTimestamp_ ? topic.ReadFromTimestamp_ : sessionSettings.ReadFromTimestamp_;
+        settings.MaxLag = topic.MaxLag_ ? topic.MaxLag_ : sessionSettings.MaxLag_;
+
+        settings.PartitionIds.reserve(topic.PartitionIds_.size());
+        for (auto partitionId : topic.PartitionIds_) {
+            Y_VALIDATE(partitionId <= std::numeric_limits<i64>::max(), "PartitionId is too large");
+            settings.PartitionIds.emplace_back(partitionId);
+        }
+
+        return settings;
+    }
+
+    // Events from TLocalTopicReadSession
+
+    void Handle(TSessionEvents::TEvExtractReadyEvents::TPtr& ev) {
+        LOG_T("Got extract ready events request, OutgoingEvents #" << OutgoingEvents.size());
+
+        Y_VALIDATE(!EventsPromise, "Can not handle extract event in parallel");
+        EventsPromise = std::move(ev->Get()->EventsPromise);
+        SendOutgoingEvents();
+    }
+
+    void Handle(TSessionEvents::TEvEventsConsumed::TPtr& ev) {
+        const auto size = std::min(ev->Get()->Size, InflightMemory);
+        InflightMemory -= size;
+        Counters->BytesInflightTotal->Sub(size);
+
+        const auto eventsCount = ev->Get()->EventsCount;
+        Counters->MessagesInflight->Sub(eventsCount);
+
+        LOG_T("Handled #" << eventsCount << " events with amount size: " << size << ", new InflightMemory: " << InflightMemory << ", MaxMemoryUsage: " << MaxMemoryUsage);
+        ContinueReading();
+    }
+
+    void Handle(TSessionEvents::TEvSessionFinished::TPtr& ev) {
+        const bool force = ev->Get()->Force;
+        LOG_I("Local topic read session finished from client side, force: " << force);
+
+        CloseSession(EStatus::SUCCESS);
+
+        if (force) {
+            PassAway();
+        }
+    }
+
+    // Events from local RPC session
+
+    void Handle(TLocalRpcCtx::TRpcEvents::TEvActorAttached::TPtr& ev) {
+        Y_VALIDATE(!RpcActor, "RpcActor is already set");
+        RpcActor = ev->Get()->RpcActor;
+
+        LOG_I("RpcActor attached: " << RpcActor);
+        SendInitMessage();
+    }
+
+    void Handle(TLocalRpcCtx::TRpcEvents::TEvReadRequest::TPtr&) {
+        PendingRpcResponses++;
+
+        if (SessionClosed) {
+            LOG_D("Rpc read request skipped, session is closed");
+            SendSessionEventFail();
+            return;
+        }
+
+        LOG_T("Rpc read request");
+        SendSessionEvents();
+    }
+
+    void Handle(TLocalRpcCtx::TRpcEvents::TEvWriteRequest::TPtr& ev) {
+        Y_VALIDATE(RpcActor, "RpcActor is not set before write request");
+        auto response = std::make_unique<TLocalRpcCtx::TEvWriteFinished>();
+
+        if (SessionClosed) {
+            LOG_D("Rpc write request skipped, session is closed");
+            response->Success = false;
+            Send(RpcActor, response.release());
+            return;
+        }
+
+        response->Success = true;
+        Send(RpcActor, response.release());
+
+        auto& message = ev->Get()->Message;
+        const auto status = message.status();
+        if (status != Ydb::StatusIds::SUCCESS) {
+            NYql::TIssues issues;
+            IssuesFromMessage(message.issues(), issues);
+            LOG_E("Rpc write request, got error " << status << ", reason: " << issues.ToOneLineString());
+            return CloseSession(status, issues);
+        }
+
+        const auto messageCase = message.server_message_case();
+        LOG_T("Rpc write request: " << static_cast<i64>(messageCase));
+
+        switch (messageCase) {
+            case Ydb::Topic::StreamReadMessage::FromServer::kInitResponse:
+                ComputeSessionMessage(message.init_response());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::kReadResponse:
+                ComputeSessionMessage(*message.mutable_read_response());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::kCommitOffsetResponse:
+                ComputeSessionMessage(message.commit_offset_response());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::kPartitionSessionStatusResponse:
+                ComputeSessionMessage(message.partition_session_status_response());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::kUpdateTokenResponse:
+                ComputeSessionMessage(message.update_token_response());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::kStartPartitionSessionRequest:
+                ComputeSessionMessage(message.start_partition_session_request());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::kStopPartitionSessionRequest:
+                ComputeSessionMessage(message.stop_partition_session_request());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::kUpdatePartitionSession:
+                ComputeSessionMessage(message.update_partition_session());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::kEndPartitionSession:
+                ComputeSessionMessage(message.end_partition_session());
+                break;
+            case Ydb::Topic::StreamReadMessage::FromServer::SERVER_MESSAGE_NOT_SET:
+                CloseSession(EStatus::INTERNAL_ERROR, "Unknown server message");
+                break;
+        }
+    }
+
+    void Handle(TLocalRpcCtx::TRpcEvents::TEvFinishRequest::TPtr& ev) {
+        const auto& status = ev->Get()->Status;
+        if (!status.ok()) {
+            LOG_E("Rpc session finished with error status code: " << static_cast<ui64>(status.error_code()) << ", message: " << status.error_message());
+        } else {
+            LOG_I("Rpc session successfully finished");
+        }
+
+        CloseSession(status, "Read session closed");
+    }
+
+    // Events from topic partition session callbacks
+
+    void Handle(TEvPrivate::TEvPartitionStatusRequest::TPtr& ev) {
+        const auto partitionSessionId = ev->Get()->PartitionSessionId;
+        LOG_D("Partition session #" << partitionSessionId << " status request");
+
+        TRpcIn message;
+        message.mutable_partition_session_status_request()->set_partition_session_id(partitionSessionId);
+
+        AddSessionEvent(std::move(message));
+    }
+
+    void Handle(TEvPrivate::TEvPartitionOffsetsCommitRequest::TPtr& ev) {
+        const auto partitionSessionId = ev->Get()->PartitionSessionId;
+        const auto start = ev->Get()->StartOffset;
+        const auto end = ev->Get()->EndOffset;
+        LOG_D("Partition session #" << partitionSessionId << " offsets [" << start << ", " << end << "] commit request");
+
+        TRpcIn message;
+
+        auto& commitRequest = *message.mutable_commit_offset_request()->add_commit_offsets();
+        commitRequest.set_partition_session_id(partitionSessionId);
+
+        auto& offsets = *commitRequest.add_offsets();
+        offsets.set_start(start);
+        offsets.set_end(end);
+
+        AddSessionEvent(std::move(message));
+    }
+
+    void Handle(TEvPrivate::TEvPartitionConfirmCreate::TPtr& ev) {
+        const auto partitionSessionId = ev->Get()->PartitionSessionId;
+        const auto readOffset = ev->Get()->ReadOffset;
+        const auto commitOffset = ev->Get()->CommitOffset;
+        LOG_D("Partition session #" << partitionSessionId << " confirmed"
+            << ", read offset: " << (readOffset ? ToString(*readOffset) : "null")
+            << ", commit offset: " << (commitOffset ? ToString(*commitOffset) : "null"));
+
+        TRpcIn message;
+
+        auto& startResponse = *message.mutable_start_partition_session_response();
+        startResponse.set_partition_session_id(partitionSessionId);
+        if (readOffset) {
+            startResponse.set_read_offset(*readOffset);
+        }
+        if (commitOffset) {
+            startResponse.set_commit_offset(*commitOffset);
+        }
+
+        AddSessionEvent(std::move(message));
+    }
+
+    void Handle(TEvPrivate::TEvPartitionConfirmDestroy::TPtr& ev) {
+        const auto partitionSessionId = ev->Get()->PartitionSessionId;
+        LOG_D("Partition session #" << partitionSessionId << " destroyed");
+
+        TRpcIn message;
+        message.mutable_stop_partition_session_response()->set_partition_session_id(partitionSessionId);
+        AddSessionEvent(std::move(message));
+
+        AddOutgoingSessionClosedEvent(partitionSessionId, TReadSessionEvent::TPartitionSessionClosedEvent::EReason::StopConfirmedByUser);
+    }
+
+    void Handle(TEvents::TEvWakeup::TPtr&) {
+        const auto now = TInstant::Now();
+
+        if (SessionStartedAt) {
+            *Counters->CurrentSessionLifetimeMs = (now - SessionStartedAt).MilliSeconds();
+        }
+
+        if (LastCountersUpdateAt) {
+            const auto delta = (now - LastCountersUpdateAt).MilliSeconds();
+            const double percent = 100.0 / MaxMemoryUsage;
+            Counters->TotalBytesInflightUsageByTime->Collect(InflightMemory * percent, delta);
+        }
+
+        LastCountersUpdateAt = now;
+        Schedule(COUNTERS_REFRESH_INTERVAL, new TEvents::TEvWakeup());
+    }
+
+    void Handle(TEvents::TEvUndelivered::TPtr& ev) {
+        const auto sourceType = ev->Get()->SourceType;
+        const auto reason = ev->Get()->Reason;
+        Y_VALIDATE(sourceType == TEvStreamTopicReadRequest::EventType, "Unexpected undelivered event: " << sourceType << ", reason: " << reason);
+
+        LOG_E("PQ read service is unavailable, reason: " << reason);
+        CloseSession(EStatus::INTERNAL_ERROR, "PQ read service is unavailable, please contact internal support");
+    }
+
+    void StartSession() const {
+        const auto& token = CredentialsProvider ? std::optional<TString>(CredentialsProvider->GetAuthInfo()) : std::nullopt;
+        auto ctx = MakeIntrusive<TLocalRpcCtx>(ActorContext().ActorSystem(), SelfId(), TLocalRpcCtx::TSettings{
+            .Database = Database,
+            .Token = token,
+            .PeerName = "localhost/local_topic_rpc_read",
+            .RequestType = Settings.RequestType_.empty() ? std::nullopt : std::optional<TString>(Settings.RequestType_),
+            .ParentTraceId = TString(Settings.TraceParent_),
+            .TraceId = TString(Settings.TraceId_),
+            .RpcMethodName = "TopicService.StreamRead",
+        });
+
+        for (const auto& [key, value] : Settings.Header_) {
+            ctx->PutPeerMeta(TString(key), TString(value));
+        }
+
+        auto ev = std::make_unique<TEvStreamTopicReadRequest>(std::move(ctx), TRequestAuxSettings{.RequestType = NJaegerTracing::ERequestType::TOPIC_STREAMREAD});
+
+        if (token) {
+            ev->SetInternalToken(MakeIntrusive<NACLib::TUserToken>(*token));
+        }
+
+        Send(NGRpcProxy::V1::GetPQReadServiceActorID(), ev.release(), IEventHandle::FlagTrackDelivery);
+    }
+
+    void SendInitMessage() {
+        LOG_I("Sending init message"
+            << ", Consumer: " << ReadSettings.Consumer
+            << ", ReadFrom: " << (ReadSettings.ReadFrom ? ToString(*ReadSettings.ReadFrom) : "null")
+            << ", MaxLag: " << (ReadSettings.MaxLag ? ToString(*ReadSettings.MaxLag) : "null"));
+
+        TRpcIn message;
+
+        auto& initRequest = *message.mutable_init_request();
+        initRequest.set_consumer(ReadSettings.Consumer);
+
+        auto& topic = *initRequest.add_topics_read_settings();
+        topic.set_path(ReadSettings.Topic);
+        if (ReadSettings.ReadFrom) {
+            *topic.mutable_read_from() = NProtoInterop::CastToProto(*ReadSettings.ReadFrom);
+        }
+        if (ReadSettings.MaxLag) {
+            *topic.mutable_max_lag() = NProtoInterop::CastToProto(*ReadSettings.MaxLag);
+        }
+
+        AddSessionEvent(std::move(message));
+    }
+
+    void ComputeSessionMessage(const Ydb::Topic::StreamReadMessage::InitResponse& message) {
+        SessionStartedAt = TInstant::Now();
+        SessionId = message.session_id();
+        LOG_I("Session initialized with id: " << SessionId);
+        ContinueReading();
+    }
+
+    void ComputeSessionMessage(Ydb::Topic::StreamReadMessage::ReadResponse& message) {
+        const auto responseSize = message.bytes_size();
+        ServerMemoryDelta -= responseSize;
+        Counters->BytesReadCompressed->Add(responseSize);
+        LOG_T("Received read response with size: " << responseSize << ", new ServerMemoryDelta: " << ServerMemoryDelta);
+
+        for (auto& partitionData : *message.mutable_partition_data()) {
+            const auto partitionSessionId = partitionData.partition_session_id();
+            LOG_T("Partition session #" << partitionSessionId << " data received, batches #" << partitionData.batches_size());
+
+            i64 messagesSize = 0;
+            std::vector<TReadSessionEvent::TDataReceivedEvent::TMessage> messages;
+            auto partitionSession = GetPartitionSession(partitionSessionId);
+
+            for (auto& batch : *partitionData.mutable_batches()) {
+                const auto& producerId = batch.producer_id();
+                const auto writtenAt = NProtoInterop::CastFromProto(batch.written_at());
+
+                const auto writeSessionMeta = MakeIntrusive<TWriteSessionMeta>();
+                writeSessionMeta->Fields.reserve(batch.write_session_meta_size());
+                for (auto& [key, value] : *batch.mutable_write_session_meta()) {
+                    messagesSize += key.size() + value.size();
+                    writeSessionMeta->Fields.emplace(key, std::move(value));
+                }
+                messagesSize += sizeof(TWriteSessionMeta);
+
+                for (auto& event : *batch.mutable_message_data()) {
+                    std::string decompressedData;
+                    std::exception_ptr decompressionException;
+                    if (!IsIn({Ydb::Topic::CODEC_RAW, Ydb::Topic::CODEC_UNSPECIFIED}, static_cast<Ydb::Topic::Codec>(batch.codec()))) {
+                        try {
+                            const ICodec* codecImpl = TCodecMap::GetTheCodecMap().GetOrThrow(static_cast<ui32>(batch.codec()));
+                            decompressedData = codecImpl->Decompress(event.data());
+                        } catch (...) {
+                            decompressionException = std::current_exception();
+                        }
+                    } else {
+                        decompressedData = std::move(*event.mutable_data());
+                    }
+
+                    auto messageMeta = MakeIntrusive<TMessageMeta>();
+                    messageMeta->Fields.reserve(event.metadata_items_size());
+                    for (auto& item : *event.mutable_metadata_items()) {
+                        messagesSize += item.key().size() + item.value().size();
+                        messageMeta->Fields.emplace_back(std::move(*item.mutable_key()), std::move(*item.mutable_value()));
+                    }
+
+                    messagesSize += decompressedData.size() + producerId.size() + sizeof(TMessageMeta) + event.message_group_id().size();
+                    Counters->BytesRead->Add(decompressedData.size());
+
+                    messages.emplace_back(std::move(decompressedData), std::move(decompressionException), TReadSessionEvent::TDataReceivedEvent::TMessageInformation(
+                        event.offset(),
+                        producerId,
+                        event.seq_no(),
+                        NProtoInterop::CastFromProto(event.created_at()),
+                        writtenAt,
+                        writeSessionMeta,
+                        std::move(messageMeta),
+                        event.uncompressed_size(),
+                        std::move(*event.mutable_message_group_id())
+                    ), partitionSession);
+                }
+            }
+
+            messagesSize += sizeof(TReadSessionEvent::TDataReceivedEvent::TMessage) * messages.size();
+            Counters->MessagesRead->Add(messages.size());
+
+            AddOutgoingEvent(TReadSessionEvent::TDataReceivedEvent(
+                std::move(messages),
+                {},
+                std::move(partitionSession)
+            ), messagesSize);
+        }
+    }
+
+    void ComputeSessionMessage(const Ydb::Topic::StreamReadMessage::CommitOffsetResponse& message) {
+        for (const auto& commitOffset : message.partitions_committed_offsets()) {
+            const auto partitionSessionId = commitOffset.partition_session_id();
+            const auto offset = commitOffset.committed_offset();
+            LOG_D("Partition session #" << partitionSessionId << " offset " << offset << " commited");
+
+            AddOutgoingEvent(TReadSessionEvent::TCommitOffsetAcknowledgementEvent(
+                GetPartitionSession(partitionSessionId),
+                offset
+            ));
+        }
+    }
+
+    void ComputeSessionMessage(const Ydb::Topic::StreamReadMessage::PartitionSessionStatusResponse& message) {
+        const auto partitionSessionId = message.partition_session_id();
+        LOG_D("Partition session #" << partitionSessionId << " status response: " << message.ShortDebugString());
+
+        AddOutgoingEvent(TReadSessionEvent::TPartitionSessionStatusEvent(
+            GetPartitionSession(partitionSessionId),
+            message.committed_offset(),
+            message.read_offset(),
+            message.partition_offsets().end(),
+            NProtoInterop::CastFromProto(message.write_time_high_watermark())
+        ));
+    }
+
+    void ComputeSessionMessage(const Ydb::Topic::UpdateTokenResponse&) {
+        Y_VALIDATE(false, "Unexpected message type: UpdateTokenResponse");
+    }
+
+    void ComputeSessionMessage(const Ydb::Topic::StreamReadMessage::StartPartitionSessionRequest& message) {
+        const auto& info = message.partition_session();
+        const auto partitionId = info.partition_id();
+        const auto partitionSessionId = info.partition_session_id();
+        const auto committedOffset = message.committed_offset();
+        const auto& offsets = message.partition_offsets();
+        LOG_D("Start partition #" << partitionId << " session with id " << partitionSessionId
+            << ", commited offset: " << committedOffset
+            << ", offsets range: " << offsets.ShortDebugString());
+
+        auto partitionSession = MakeIntrusive<TLocalPartitionSession>(ActorContext().ActorSystem(), SelfId(), TLocalPartitionSession::TSettings{
+            .PartitionSessionId = partitionSessionId,
+            .PartitionId = partitionId,
+            .TopicPath = info.path(),
+            .ReadSessionId = SessionId,
+        });
+        Y_VALIDATE(PartitionSessions.emplace(partitionSessionId, partitionSession).second, "Partition session #" << partitionSessionId << " already exists");
+
+        AddOutgoingEvent(TReadSessionEvent::TStartPartitionSessionEvent(
+            std::move(partitionSession),
+            committedOffset,
+            offsets.end()
+        ));
+    }
+
+    void ComputeSessionMessage(const Ydb::Topic::StreamReadMessage::StopPartitionSessionRequest& message) {
+        const auto partitionSessionId = message.partition_session_id();
+        const auto committedOffset = message.committed_offset();
+        LOG_D("Partition session #" << partitionSessionId << " received stop event, commited offset: " << committedOffset);
+
+        if (!message.graceful()) {
+            return AddOutgoingSessionClosedEvent(partitionSessionId, TReadSessionEvent::TPartitionSessionClosedEvent::EReason::Lost);
+        }
+
+        return AddOutgoingEvent(TReadSessionEvent::TStopPartitionSessionEvent(
+            GetPartitionSession(partitionSessionId),
+            committedOffset
+        ));
+    }
+
+    void ComputeSessionMessage(const Ydb::Topic::StreamReadMessage::UpdatePartitionSession& message) {
+        LOG_D("Partition session #" << message.partition_session_id() << " received update event: " << message.ShortDebugString());
+    }
+
+    void ComputeSessionMessage(const Ydb::Topic::StreamReadMessage::EndPartitionSession& message) {
+        const auto partitionSessionId = message.partition_session_id();
+        const auto& adjacentIds = message.adjacent_partition_ids();
+        const auto& childIds = message.child_partition_ids();
+        LOG_D("Partition session #" << partitionSessionId << " received end event"
+            << ", adjacent ids #" << adjacentIds.size()
+            << ", child ids #" << childIds.size());
+
+        AddOutgoingEvent(TReadSessionEvent::TEndPartitionSessionEvent(
+            GetPartitionSession(partitionSessionId),
+            std::vector<uint32_t>(adjacentIds.begin(), adjacentIds.end()),
+            std::vector<uint32_t>(childIds.begin(), childIds.end())
+        ), sizeof(uint32_t) * (adjacentIds.size() + childIds.size()));
+    }
+
+    TPartitionSession::TPtr GetPartitionSession(i64 partitionSessionId) const {
+        const auto it = PartitionSessions.find(partitionSessionId);
+        Y_VALIDATE(it != PartitionSessions.end(), "Unknown partition session: " << partitionSessionId);
+        return it->second;
+    }
+
+    void ContinueReading() {
+        if (!SessionId) {
+            LOG_D("Session not started yet, skip reading");
+            return;
+        }
+
+        if (InflightMemory >= MaxMemoryUsage) {
+            LOG_T("Max memory usage reached, skip reading, InflightMemory: " << InflightMemory << ", MaxMemoryUsage: " << MaxMemoryUsage);
+            return;
+        }
+
+        const auto readMemoryBudget = MaxMemoryUsage - InflightMemory;
+        if (ServerMemoryDelta >= readMemoryBudget) {
+            LOG_T("Server already has enough memory, skip reading, ServerMemoryDelta: " << ServerMemoryDelta << ", read memory budget: " << readMemoryBudget);
+            return;
+        }
+
+        const auto bytesToRead = readMemoryBudget - ServerMemoryDelta;
+        ServerMemoryDelta = readMemoryBudget;
+        LOG_T("Reading " << bytesToRead << " bytes, new ServerMemoryDelta: " << ServerMemoryDelta << ", InflightMemory: " << InflightMemory << ", MaxMemoryUsage: " << MaxMemoryUsage);
+
+        TRpcIn message;
+        message.mutable_read_request()->set_bytes_size(bytesToRead);
+        AddSessionEvent(std::move(message));
+    }
+
+    // Events to PQ read service
+
+    void AddSessionEvent(TRpcIn&& message) {
+        if (SessionClosed) {
+            LOG_D("Session already closed, skip session event");
+            return;
+        }
+
+        RpcResponses.push(message);
+        LOG_T("Added session event: " << static_cast<i64>(message.client_message_case()));
+
+        if (RpcActor) {
+            SendSessionEvents();            
+        }
+    }
+
+    void SendSessionEvents() {
+        Y_VALIDATE(RpcActor, "RpcActor is not set before read request");
+        LOG_T("Going to send session events, PendingRpcResponses: " << PendingRpcResponses << ", RpcResponses #" << RpcResponses.size());
+
+        while (PendingRpcResponses > 0 && !RpcResponses.empty()) {
+            SendSessionEvent(std::move(RpcResponses.front()));
+            RpcResponses.pop();
+        }
+    }
+
+    void SendSessionEvent(TRpcIn&& message, bool success = true) {
+        LOG_T("Sending session event: " << static_cast<i64>(message.client_message_case()) << ", success: " << success);
+        Y_VALIDATE(PendingRpcResponses > 0, "Rpc read is not expected");
+        PendingRpcResponses--;
+
+        auto ev = std::make_unique<TLocalRpcCtx::TEvReadFinished>();
+        ev->Success = success;
+        ev->Record = std::move(message);
+
+        Y_VALIDATE(RpcActor, "RpcActor is not set before read request");
+        Send(RpcActor, ev.release());
+    }
+
+    void SendSessionEventFail() {
+        SendSessionEvent({}, /* success */ false);
+    }
+
+    // Events to TLocalTopicReadSession
+
+    void AddOutgoingSessionClosedEvent(i64 partitionSessionId, TReadSessionEvent::TPartitionSessionClosedEvent::EReason reason) {
+        AddOutgoingEvent(TReadSessionEvent::TPartitionSessionClosedEvent(
+            GetPartitionSession(partitionSessionId),
+            reason
+        ));
+    }
+
+    template <typename TEvent>
+    void AddOutgoingEvent(TEvent&& event, i64 internalSize = 0) {
+        OutgoingEvents.emplace(std::move(event), sizeof(TEvent) + internalSize);
+        Counters->MessagesInflight->Inc();
+
+        const auto size = OutgoingEvents.back().Size;
+        InflightMemory += size;
+        Counters->BytesInflightTotal->Add(size);
+        LOG_T("Added outgoing event: " << OutgoingEvents.back().Event.index() << ", size: " << size << ", InflightMemory: " << InflightMemory);
+
+        SendOutgoingEvents();
+    }
+
+    void SendOutgoingEvents() {
+        if (!EventsPromise || OutgoingEvents.empty()) {
+            return;
+        }
+
+        LOG_T("Going to send outgoing events, OutgoingEvents #" << OutgoingEvents.size());
+
+        bool closeEventSent = false;
+        std::vector<TLocalTopicReadyEvent> result;
+        result.reserve(OutgoingEvents.size());
+        while (!OutgoingEvents.empty()) {
+            result.push_back(std::move(OutgoingEvents.front()));
+            OutgoingEvents.pop();
+
+            if (std::holds_alternative<TSessionClosedEvent>(result.back().Event)) {
+                LOG_I("Sent close session event, finishing");
+                closeEventSent = true;
+            }
+        }
+
+        EventsPromise->SetValue(std::move(result));
+        EventsPromise.reset();
+
+        if (closeEventSent) {
+            PassAway();
+        }
+    }
+
+    void CloseSession(EStatus status, const NYql::TIssues& issues = {}) {
+        const bool success = status == EStatus::SUCCESS;
+        if (!success) {
+            Counters->Errors->Inc();
+            LOG_E("Closing session with status " << status << " and issues: " << issues.ToOneLineString());
+        } else {
+            LOG_I("Closing session with success status");
+        }
+
+        if (SessionClosed) {
+            LOG_W("Session already closed, but got status " << status << " and issues: " << issues.ToOneLineString());
+            return;
+        }
+        SessionClosed = true;
+
+        // Close session on client side
+        AddOutgoingEvent(TSessionClosedEvent(status, NAdapters::ToSdkIssues(issues)));
+
+        // Close session on server side
+        while (PendingRpcResponses) {
+            SendSessionEventFail();
+        }
+        Send(RpcActor, new TLocalRpcCtx::TEvNotifiedWhenDone(success));
+    }
+
+    void CloseSession(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues = {}) {
+        CloseSession(static_cast<EStatus>(status), issues);
+    }
+
+    void CloseSession(EStatus status, const TString& message) {
+        CloseSession(status, {NYql::TIssue(message)});
+    }
+
+    void CloseSession(const grpc::Status& status, const TString& message = "") {
+        NYql::TIssues issues;
+        if (const auto& errorMessage = status.error_message(); !errorMessage.empty()) {
+            issues.AddIssue(errorMessage);
+        }
+        if (message) {
+            issues = AddRootIssue(message, issues);
+        }
+
+        switch (status.error_code()) {
+            case grpc::OK:
+                return CloseSession(EStatus::SUCCESS, issues);
+            case grpc::CANCELLED:
+                return CloseSession(EStatus::CANCELLED, issues);
+            case grpc::UNKNOWN:
+                return CloseSession(EStatus::UNDETERMINED, issues);
+            case grpc::DEADLINE_EXCEEDED:
+                return CloseSession(EStatus::TIMEOUT, issues);
+            case grpc::NOT_FOUND:
+                return CloseSession(EStatus::NOT_FOUND, issues);
+            case grpc::ALREADY_EXISTS:
+                return CloseSession(EStatus::ALREADY_EXISTS, issues);
+            case grpc::RESOURCE_EXHAUSTED:
+                return CloseSession(EStatus::OVERLOADED, issues);
+            case grpc::ABORTED:
+                return CloseSession(EStatus::ABORTED, issues);
+            case grpc::OUT_OF_RANGE:
+                return CloseSession(EStatus::CLIENT_OUT_OF_RANGE, issues);
+            case grpc::UNIMPLEMENTED:
+                return CloseSession(EStatus::UNSUPPORTED, issues);
+            case grpc::UNAVAILABLE:
+                return CloseSession(EStatus::UNAVAILABLE, issues);
+            case grpc::INVALID_ARGUMENT:
+            case grpc::FAILED_PRECONDITION:
+                return CloseSession(EStatus::PRECONDITION_FAILED, issues);
+            case grpc::UNAUTHENTICATED:
+            case grpc::PERMISSION_DENIED:
+                return CloseSession(EStatus::UNAUTHORIZED, issues);
+            default:
+                return CloseSession(EStatus::INTERNAL_ERROR, issues);
+        }
+    }
+
+    TString LogPrefix() const {
+        return TStringBuilder() << "Database: " << Database << ", Topic: " << ReadSettings.Topic << ", SelfId: " << SelfId() << ". ";
+    }
+
+    const TRequestSettings<TReadSessionSettings> Settings;
+    const TReadSettings ReadSettings;
+    const TString Database;
+    const std::shared_ptr<NYdb::ICredentialsProvider> CredentialsProvider;
+    const i64 MaxMemoryUsage = 0;
+    const TReaderCounters::TPtr Counters;
+    TInstant SessionStartedAt;
+    TInstant LastCountersUpdateAt;
+
+    TActorId RpcActor;
+    i64 InflightMemory = 0;
+    i64 ServerMemoryDelta = 0;
+    TString SessionId;
+    std::unordered_map<i64, TPartitionSession::TPtr> PartitionSessions;
+    bool SessionClosed = false;
+
+    // Outgoing messages to PQ
+    ui64 PendingRpcResponses = 0;
+    std::queue<TRpcIn> RpcResponses;
+
+    // Outgoing messages to TLocalTopicReadSession
+    std::queue<TLocalTopicReadyEvent> OutgoingEvents;
+    std::optional<NThreading::TPromise<std::vector<TLocalTopicReadyEvent>>> EventsPromise;
+};
+
+// Supposed to be used from actor system, so all blocking methods are not supported.
+// Read session is not thread safe and MUST be used from single actor.
+// NOTICE: data is decompressed in one thread inside TLocalTopicReadSessionActor for simplicity.
+class TLocalTopicReadSession final : public IReadSession {
+public:
+    TLocalTopicReadSession(const TLocalTopicReadSettings& localSettings, const TReadSessionSettings& sessionSettings)
+        : ActorSystem(localSettings.ActorSystem)
+        , Counters(SetupCounters(sessionSettings))
+        , SessionId(CreateGuidAsString())
+    {
+        Y_VALIDATE(ActorSystem, "Actor system is required for local topic read session");
+        ValidateSettings(sessionSettings);
+        Start(localSettings.Database, localSettings.CredentialsProvider, sessionSettings);
+    }
+
+    ~TLocalTopicReadSession() {
+        try {
+            if (!Close(TDuration::Zero()) && ActorSystem && ReadSessionActor) {
+                ActorSystem->Send(ReadSessionActor, new TLocalTopicReadSessionActor::TSessionEvents::TEvSessionFinished(/* force */ true));
+            }
+        } catch (...) {
+            // ¯\_(ツ)_/¯
+        }
+    }
+
+    NThreading::TFuture<void> WaitEvent() final {
+        if (!Events.empty() || ExtractEvents()) {
+            return NThreading::MakeFuture();
+        }
+
+        if (!EventFuture) {
+            auto eventsPromise = NThreading::NewPromise<std::vector<TLocalTopicReadyEvent>>();
+            EventFuture = eventsPromise.GetFuture();
+
+            Y_VALIDATE(ReadSessionActor, "Read session actor unexpectedly finished");
+            ActorSystem->Send(ReadSessionActor, new TLocalTopicReadSessionActor::TSessionEvents::TEvExtractReadyEvents(std::move(eventsPromise)));
+        }
+
+        return EventFuture->IgnoreResult();
+    }
+
+    std::vector<TReadSessionEvent::TEvent> GetEvents(bool block, std::optional<size_t> maxEventsCount, size_t maxByteSize) final {
+        Y_VALIDATE(!block, "Blocking is not supported for local topic read session");
+        Y_VALIDATE(maxByteSize > 0, "MaxByteSize must be greater than 0");
+
+        ExtractEvents();
+
+        std::vector<TReadSessionEvent::TEvent> result;
+        const auto maxCount = maxEventsCount.value_or(std::numeric_limits<size_t>::max());
+        result.reserve(std::min(Events.size(), maxCount));
+
+        i64 totalSize = 0;
+        while (!Events.empty() && result.size() < maxCount && static_cast<size_t>(totalSize) < maxByteSize) {
+            auto& event = Events.front();
+            result.emplace_back(std::move(event.Event));
+            totalSize += event.Size;
+
+            if (std::holds_alternative<TSessionClosedEvent>(result.back())) {
+                // Skip all events after session closed event
+                break;
+            }
+
+            Events.pop();
+        }
+
+        if (ReadSessionActor && !result.empty()) {
+            ActorSystem->Send(ReadSessionActor, new TLocalTopicReadSessionActor::TSessionEvents::TEvEventsConsumed(totalSize, result.size()));
+        }
+
+        WaitEvent(); // Request next event batch
+
+        return result;
+    }
+
+    std::vector<TReadSessionEvent::TEvent> GetEvents(const TReadSessionGetEventSettings& settings) final {
+        Y_VALIDATE(!settings.Tx_, "Transaction is not supported for local topic read session");
+        return GetEvents(settings.Block_, settings.MaxEventsCount_, settings.MaxByteSize_);
+    }
+
+    std::optional<TReadSessionEvent::TEvent> GetEvent(bool block, size_t maxByteSize) final {
+        const auto& events = GetEvents(block, 1, maxByteSize);
+        if (events.empty()) {
+            return std::nullopt;
+        }
+        return events[0];
+    }
+
+    std::optional<TReadSessionEvent::TEvent> GetEvent(const TReadSessionGetEventSettings& settings) final {
+        Y_VALIDATE(!settings.MaxEventsCount_, "MaxEventsCount is not allowed for GetEvent");
+        Y_VALIDATE(!settings.Tx_, "Transaction is not supported for local topic read session");
+        return GetEvent(settings.Block_, settings.MaxByteSize_);
+    }
+
+    bool Close(TDuration timeout) final {
+        Y_VALIDATE(!timeout, "Timeout on close is not allowed for local topic read session");
+
+        ExtractEvents(); // Refresh events and maybe accept TSessionClosedEvent
+        WaitEvent(); // Request next event batch if there is no TSessionClosedEvent 
+
+        if (!ReadSessionActor) {
+            // TSessionClosedEvent accepted
+            return true;
+        }
+
+        // Wait for TSessionClosedEvent
+        ActorSystem->Send(ReadSessionActor, new TLocalTopicReadSessionActor::TSessionEvents::TEvSessionFinished(/* force */ false));
+        return false;
+    }
+
+    TReaderCounters::TPtr GetCounters() const final {
+        return Counters;
+    }
+
+    std::string GetSessionId() const final {
+        return SessionId;
+    }
+
+private:
+    static void ValidateSettings(const TReadSessionSettings& settings) {
+        Y_VALIDATE(!settings.AutoPartitioningSupport_, "AutoPartitioningSupport is not supported for local topic read session");
+        Y_VALIDATE(settings.ClientTimeout_ == TDuration::Max(), "Timeout is not allowed for local topic read session");
+        Y_VALIDATE(settings.Deadline_ == TDeadline::Max(), "Timeout is not allowed for local topic read session");
+        Y_VALIDATE(settings.Decompress_, "Read session without decompression is not supported");
+
+        const auto& eventHandlers = settings.EventHandlers_;
+        Y_VALIDATE(!eventHandlers.DataReceivedHandler_, "Event handlers are not supported for local topic read session");
+        Y_VALIDATE(!eventHandlers.CommitOffsetAcknowledgementHandler_, "Event handlers are not supported for local topic read session");
+        Y_VALIDATE(!eventHandlers.StartPartitionSessionHandler_, "Event handlers are not supported for local topic read session");
+        Y_VALIDATE(!eventHandlers.StopPartitionSessionHandler_, "Event handlers are not supported for local topic read session");
+        Y_VALIDATE(!eventHandlers.EndPartitionSessionHandler_, "Event handlers are not supported for local topic read session");
+        Y_VALIDATE(!eventHandlers.PartitionSessionStatusHandler_, "Event handlers are not supported for local topic read session");
+        Y_VALIDATE(!eventHandlers.PartitionSessionClosedHandler_, "Event handlers are not supported for local topic read session");
+        Y_VALIDATE(!eventHandlers.SessionClosedHandler_, "Event handlers are not supported for local topic read session");
+        Y_VALIDATE(!eventHandlers.CommonHandler_, "Event handlers are not supported for local topic read session");
+    }
+
+    static TReaderCounters::TPtr SetupCounters(const TReadSessionSettings& settings) {
+        auto result = settings.Counters_;
+        if (!result || HasNullCounters(*result)) {
+            result = result ? result : MakeIntrusive<TReaderCounters>();
+            MakeCountersNotNull(*result);
+        }
+        return result;
+    }
+
+    void Start(const TString& database, std::shared_ptr<NYdb::ICredentialsProvider> credentialsProvider, const TReadSessionSettings& sessionSettings) {
+        Y_VALIDATE(!ReadSessionActor, "Read session is already started");
+        ReadSessionActor = ActorSystem->Register(new TLocalTopicReadSessionActor({
+            .Database = database,
+            .CredentialsProvider = std::move(credentialsProvider),
+            .Counters = Counters,
+        }, sessionSettings), TMailboxType::HTSwap, ActorSystem->AppData<TAppData>()->UserPoolId);
+    }
+
+    bool ExtractEvents() {
+        if (!EventFuture || !EventFuture->IsReady()) {
+            return false;
+        }
+
+        auto events = EventFuture->ExtractValue();
+        EventFuture.reset();
+
+        for (auto& event : events) {
+            Events.emplace(std::move(event));
+
+            if (std::holds_alternative<TSessionClosedEvent>(Events.back().Event)) {
+                // Session was finished, skip all other events
+                ReadSessionActor = {};
+                break;
+            }
+        }
+
+        return true;
+    }
+
+    TActorSystem* const ActorSystem = nullptr;
+    const TReaderCounters::TPtr Counters;
+    const TString SessionId;
+    TActorId ReadSessionActor;
+    std::optional<NThreading::TFuture<std::vector<TLocalTopicReadyEvent>>> EventFuture;
+    std::queue<TLocalTopicReadyEvent> Events;
+};
+
+} // anonymous namespace
+
+std::shared_ptr<IReadSession> CreateLocalTopicReadSession(const TLocalTopicReadSettings& localSettings, const TReadSessionSettings& sessionSettings) {
+    return std::make_shared<TLocalTopicReadSession>(localSettings, sessionSettings);
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/local_pq_client/local_topic_read_session.h
+++ b/ydb/core/kqp/federated_query/local_pq_client/local_topic_read_session.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_session.h>
+
+namespace NKikimr::NKqp {
+
+struct TLocalTopicReadSettings {
+    NActors::TActorSystem* ActorSystem = nullptr;
+    TString Database;
+    std::shared_ptr<NYdb::ICredentialsProvider> CredentialsProvider;
+};
+
+std::shared_ptr<NYdb::NTopic::IReadSession> CreateLocalTopicReadSession(const TLocalTopicReadSettings& localSettings, const NYdb::NTopic::TReadSessionSettings& sessionSettings);
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/local_pq_client/ya.make
+++ b/ydb/core/kqp/federated_query/local_pq_client/ya.make
@@ -1,0 +1,24 @@
+LIBRARY()
+
+SRCS(
+    local_topic_client_factory.cpp
+    local_topic_client.cpp
+    local_topic_read_session.cpp
+)
+
+PEERDIR(
+    library/cpp/protobuf/interop
+    ydb/core/base
+    ydb/core/grpc_services
+    ydb/core/grpc_services/local_rpc
+    ydb/core/kqp/common
+    ydb/library/actors/core
+    ydb/library/yql/providers/pq/gateway/abstract
+    ydb/library/yql/providers/pq/gateway/clients/local
+    ydb/library/yverify_stream
+    ydb/public/sdk/cpp/adapters/issue
+    ydb/public/sdk/cpp/src/client/topic
+    ydb/services/persqueue_v1/actors
+)
+
+END()

--- a/ydb/core/kqp/federated_query/ya.make
+++ b/ydb/core/kqp/federated_query/ya.make
@@ -7,6 +7,7 @@ SRCS(
 PEERDIR(
     ydb/core/base
     ydb/core/fq/libs/db_id_async_resolver_impl
+    ydb/core/kqp/federated_query/local_pq_client
     ydb/core/protos
     ydb/library/logger
     ydb/library/yql/providers/common/http_gateway
@@ -32,6 +33,7 @@ END()
 
 RECURSE(
     actors
+    local_pq_client
 )
 
 RECURSE_FOR_TESTS(

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -49,7 +49,7 @@ NavigateEntryResult CreateNavigateEntry(const TString& path,
         }
     }
     entry.Path = SplitPath(currentPath);
-    entry.Operation = NSchemeCache::TSchemeCacheNavigate::EOp::OpTable;
+    entry.Operation = settings.AllowTopicsIo ? NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown : NSchemeCache::TSchemeCacheNavigate::EOp::OpTable;
     entry.SyncVersion = true;
     entry.ShowPrivatePath = settings.WithPrivateTables_;
     return {entry, currentPath, queryName};
@@ -405,8 +405,45 @@ TTableMetadataResult GetSysViewMetadataResult(const NSchemeCache::TSchemeCacheNa
     return result;
 }
 
+TTableMetadataResult GetTopicMetadataResult(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry, const TString& cluster,
+    const TString& database, const TString& topicName, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken)
+{
+    auto metadata = MakeIntrusive<NYql::TKikimrTableMetadata>();
+    metadata->DoesExist = true;
+    metadata->Cluster = cluster;
+    metadata->Name = topicName;
+
+    Y_VALIDATE(entry.Self, "Unexpected scheme cache response");
+    const auto& selfInfo = entry.Self->Info;
+    metadata->PathId = NYql::TKikimrPathId(selfInfo.GetSchemeshardId(), selfInfo.GetPathId());
+    metadata->SchemaVersion = selfInfo.GetPathVersion();
+    metadata->Kind = NYql::EKikimrTableKind::External; // Local topics are handled through PQ provider, same as external topics
+    metadata->TableType = NYql::ETableType::ExternalTable;
+
+    auto& source = metadata->ExternalSource;
+    source.SourceType = NYql::ESourceType::ExternalDataSource;
+    source.Type = ToString(NYql::EDatabaseType::YdbTopics);
+    source.TableLocation = topicName;
+    source.DataSourcePath = cluster;
+    source.DataSourceAuth.MutableNone();
+
+    auto& properties = *source.Properties.mutable_properties();
+    properties.emplace("database_name", database);
+
+    if (userToken && userToken->GetSerializedToken()) {
+        properties.emplace("use_current_user_token", "true");
+        properties.emplace("token", userToken->GetSerializedToken());
+    }
+
+    TTableMetadataResult result = {.Metadata = metadata};
+    result.SetSuccess();
+    return result;
+}
+
 TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry,
-        const TString& cluster, const TString& mainCluster, const TString& tableName, std::optional<TString> queryName = std::nullopt) {
+    const TString& cluster, const TString& mainCluster, const TString& database, const TString& tableName,
+    const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, std::optional<TString> queryName = std::nullopt)
+{
     using TResult = NYql::IKikimrGateway::TTableMetadataResult;
     using EStatus = NSchemeCache::TSchemeCacheNavigate::EStatus;
     using EKind = NSchemeCache::TSchemeCacheNavigate::EKind;
@@ -438,7 +475,8 @@ TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCache
                      EKind::KindExternalTable,
                      EKind::KindExternalDataSource,
                      EKind::KindView,
-                     EKind::KindSysView}, entry.Kind));
+                     EKind::KindSysView,
+                     EKind::KindTopic}, entry.Kind));
 
     TTableMetadataResult result;
     switch (entry.Kind) {
@@ -453,6 +491,9 @@ TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCache
             break;
         case EKind::KindSysView:
             result = GetSysViewMetadataResult(entry, cluster, tableName);
+            break;
+        case EKind::KindTopic:
+            result = GetTopicMetadataResult(entry, cluster, database, tableName, userToken);
             break;
         default:
             result = GetTableMetadataResult(entry, cluster, tableName, queryName);
@@ -953,7 +994,7 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
                 auto& entry = InferEntry(navigate.ResultSet);
 
                 if (entry.Status != EStatus::Ok) {
-                    promise.SetValue(GetLoadTableMetadataResult(entry, cluster, mainCluster, table));
+                    promise.SetValue(GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken));
                     return;
                 }
 
@@ -991,7 +1032,7 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
 
                 switch (entry.Kind) {
                     case EKind::KindExternalDataSource: {
-                        auto externalDataSourceMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, table);
+                        auto externalDataSourceMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken);
                         if (!externalDataSourceMetadata.Success() || !settings.RequestAuthInfo_) {
                             promise.SetValue(externalDataSourceMetadata);
                             return;
@@ -1095,7 +1136,7 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
                     case EKind::KindExternalTable: {
                         YQL_ENSURE(entry.ExternalTableInfo, "expected external table info");
                         const auto& dataSourcePath = entry.ExternalTableInfo->Description.GetDataSourcePath();
-                        auto externalTableMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, table);
+                        auto externalTableMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken);
                         if (!externalTableMetadata.Success()) {
                             promise.SetValue(externalTableMetadata);
                             return;
@@ -1127,8 +1168,11 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
                         }
                         break;
                     }
+                    case EKind::KindTopic: {
+                        auto topicMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken);
+                    }
                     default: {
-                        promise.SetValue(GetLoadTableMetadataResult(entry, cluster, mainCluster, table, queryName));
+                        promise.SetValue(GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken, queryName));
                     }
                 }
             }

--- a/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
@@ -279,6 +279,7 @@ public:
                             .WithExternalSourceFactory(ExternalSourceFactory)
                             .WithReadAttributes(readAttrs ? std::move(*readAttrs) : THashMap<TString, TString>{})
                             .WithSysViewRewritten(table.GetSysViewRewritten())
+                            .WithTopicsIo(SessionCtx->Config().FeatureFlags.GetEnableTopicsSqlIoOperations())
             );
 
             futures.push_back(future.Apply([result, queryType]

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -1238,6 +1238,11 @@ public:
             return *this;
         }
 
+        TLoadTableMetadataSettings& WithTopicsIo(bool enable) {
+            AllowTopicsIo = enable;
+            return *this;
+        }
+
         NKikimr::NExternalSource::IExternalSourceFactory::TPtr ExternalSourceFactory;
         THashMap<TString, TString> ReadAttributes;
         bool RequestStats_ = false;
@@ -1245,6 +1250,7 @@ public:
         bool WithExternalDatasources_ = false;
         bool RequestAuthInfo_ = true;
         bool SysViewRewritten_ = false;
+        bool AllowTopicsIo = false;
     };
 
     class IKqpTableMetadataLoader : public std::enable_shared_from_this<IKqpTableMetadataLoader> {

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -841,7 +841,7 @@ public:
             }
 
             if (!txs.empty() && txs.front().Body->GetType() != NKqpProto::TKqpPhyTx::TYPE_SCHEME && isValidParams) {
-                auto tasksGraph = TKqpTasksGraph(Settings.Database, txs, txAlloc, {}, Settings.TableService.GetAggregationConfig(), RequestCounters, {});
+                auto tasksGraph = TKqpTasksGraph(Settings.Database, txs, txAlloc, {}, Settings.TableService.GetAggregationConfig(), RequestCounters, {}, nullptr);
                 tasksGraph.GetMeta().AllowOlapDataQuery = Settings.TableService.GetAllowOlapDataQuery();
                 tasksGraph.GetMeta().UserRequestContext = QueryState ? QueryState->UserRequestContext : MakeIntrusive<TUserRequestContext>("", Settings.Database, SessionId);
                 tasksGraph.GetMeta().SecureParams = std::move(secureParams);

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -247,4 +247,5 @@ message TFeatureFlags {
     optional bool EnableIndexMaterialization = 221 [default = false];
     optional bool EnableFsBackups = 222 [default = false];
     optional bool EnableCmsLocksPriority = 223 [default = false];
+    optional bool EnableTopicsSqlIoOperations = 224 [default = false];
 }

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -89,6 +89,7 @@ public:
     FEATURE_FLAG_SETTER(EnableTopicAutopartitioningForReplication)
     FEATURE_FLAG_SETTER(EnableAccessToIndexImplTables)
     FEATURE_FLAG_SETTER(EnableIndexMaterialization)
+    FEATURE_FLAG_SETTER(EnableTopicsSqlIoOperations)
 
     #undef FEATURE_FLAG_SETTER
 };

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1342,8 +1342,8 @@ namespace Tests {
         {
             auto kqpProxySharedResources = std::make_shared<NKqp::TKqpProxySharedResources>();
 
-            IActor* kqpRmService = NKqp::CreateKqpResourceManagerActor(
-                Settings->AppConfig->GetTableServiceConfig().GetResourceManager(), nullptr, {}, kqpProxySharedResources, Runtime->GetNodeId(nodeIdx));
+            const auto& rmConfig = Settings->AppConfig->GetTableServiceConfig().GetResourceManager();
+            IActor* kqpRmService = NKqp::CreateKqpResourceManagerActor(rmConfig, nullptr, {}, kqpProxySharedResources, Runtime->GetNodeId(nodeIdx));
             TActorId kqpRmServiceId = Runtime->Register(kqpRmService, nodeIdx, userPoolId);
             Runtime->RegisterService(NKqp::MakeKqpRmServiceID(Runtime->GetNodeId(nodeIdx)), kqpRmServiceId, nodeIdx);
 
@@ -1393,7 +1393,7 @@ namespace Tests {
                 actorSystemPtr->store(Runtime->GetActorSystem(nodeIdx));
 
                 auto driver = NKqp::MakeYdbDriver(actorSystemPtr, queryServiceConfig.GetStreamingQueries().GetTopicSdkSettings());
-                auto pqGateway = NKqp::MakePqGateway(driver);
+                auto pqGateway = NKqp::MakePqGateway(driver, NKqp::TLocalTopicClientSettings{.ActorSystem = Runtime->GetActorSystem(nodeIdx), .ChannelBufferSize = rmConfig.GetChannelBufferSize()});
 
                 federatedQuerySetupFactory = std::make_shared<NKikimr::NKqp::TKqpFederatedQuerySetupFactoryMock>(
                     NKqp::MakeHttpGateway(queryServiceConfig.GetHttpGateway(), Runtime->GetAppData(nodeIdx).Counters),

--- a/ydb/library/yql/providers/pq/gateway/clients/local/ya.make
+++ b/ydb/library/yql/providers/pq/gateway/clients/local/ya.make
@@ -1,0 +1,8 @@
+LIBRARY()
+
+PEERDIR(
+    ydb/library/yql/providers/pq/gateway/abstract
+    ydb/public/sdk/cpp/src/client/topic
+)
+
+END()

--- a/ydb/library/yql/providers/pq/gateway/clients/local/yql_pq_local_topic_client_factory.h
+++ b/ydb/library/yql/providers/pq/gateway/clients/local/yql_pq_local_topic_client_factory.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ydb/library/yql/providers/pq/gateway/abstract/yql_pq_topic_client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+
+#include <util/generic/ptr.h>
+
+namespace NYql {
+
+class IPqLocalClientFactory : public TThrRefBase {
+public:
+    using TPtr = TIntrusivePtr<IPqLocalClientFactory>;
+
+    virtual ITopicClient::TPtr CreateTopicClient(const NYdb::NTopic::TTopicClientSettings& clientSettings) = 0;
+};
+
+} // namespace NYql

--- a/ydb/library/yql/providers/pq/gateway/native/ya.make
+++ b/ydb/library/yql/providers/pq/gateway/native/ya.make
@@ -12,6 +12,8 @@ PEERDIR(
     ydb/library/yql/providers/pq/cm_client
     ydb/library/yql/providers/pq/gateway/abstract
     ydb/library/yql/providers/pq/gateway/clients/external
+    ydb/library/yql/providers/pq/gateway/clients/local
+    ydb/library/yverify_stream
     ydb/public/sdk/cpp/src/client/datastreams
     ydb/public/sdk/cpp/src/client/driver
     ydb/public/sdk/cpp/src/client/topic

--- a/ydb/library/yql/providers/pq/gateway/native/yql_pq_gateway.cpp
+++ b/ydb/library/yql/providers/pq/gateway/native/yql_pq_gateway.cpp
@@ -3,6 +3,7 @@
 
 #include <ydb/library/yql/providers/pq/gateway/clients/external/yql_pq_federated_topic_client.h>
 #include <ydb/library/yql/providers/pq/gateway/clients/external/yql_pq_topic_client.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 
 #include <yql/essentials/providers/common/proto/gateways_config.pb.h>
@@ -29,6 +30,7 @@ public:
         , CmConnections(services.CmConnections)
         , YdbDriver(services.YdbDriver)
         , CommonTopicClientSettings(services.CommonTopicClientSettings)
+        , LocalTopicClientFactory(services.LocalTopicClientFactory)
     {
         UpdateClusterConfigs(Config);
     }
@@ -45,7 +47,8 @@ public:
                 CmConnections,
                 YdbDriver,
                 ClusterConfigs,
-                CredentialsFactory
+                CredentialsFactory,
+                LocalTopicClientFactory
             ));
             if (!isNewSession) {
                 YQL_LOG_CTX_THROW yexception() << "Session already exists: " << sessionId;
@@ -98,10 +101,17 @@ public:
     }
 
     ITopicClient::TPtr GetTopicClient(const TDriver& driver, const TTopicClientSettings& settings) final {
+        const bool hasEndpoint = HasEndpoint<TTopicClientSettings>(driver, settings);
+        if (!hasEndpoint && LocalTopicClientFactory) {
+            return LocalTopicClientFactory->CreateTopicClient(settings);
+        }
+
+        Y_VALIDATE(hasEndpoint, "Missing endpoint value for topic client and local topics are not allowed");
         return CreateExternalTopicClient(driver, settings);
     }
 
     IFederatedTopicClient::TPtr GetFederatedTopicClient(const TDriver& driver, const TFederatedTopicClientSettings& settings) final {
+        Y_VALIDATE(HasEndpoint<TFederatedTopicClientSettings>(driver, settings), "Missing endpoint value for federated topic client");
         return CreateExternalFederatedTopicClient(driver, settings);
     }
 
@@ -134,6 +144,14 @@ public:
     }
 
 private:
+    template <typename TSettings>
+    static bool HasEndpoint(const TDriver& driver, const TCommonClientSettingsBase<TSettings>& settings) {
+        if (!driver.GetConfig().GetEndpoint().empty()) {
+            return true;
+        }
+        return !settings.DiscoveryEndpoint_.value_or("").empty();
+    }
+
     TPqSession::TPtr GetExistingSession(const TString& sessionId) const {
         with_lock (Mutex) {
             auto sessionIt = Sessions.find(sessionId);
@@ -151,6 +169,7 @@ private:
     const ::NPq::NConfigurationManager::IConnections::TPtr CmConnections;
     const TDriver YdbDriver;
     const TMaybe<TTopicClientSettings> CommonTopicClientSettings;
+    const IPqLocalClientFactory::TPtr LocalTopicClientFactory;
     mutable TMutex Mutex;
     TPqClusterConfigsMapPtr ClusterConfigs;
     THashMap<TString, TPqSession::TPtr> Sessions;

--- a/ydb/library/yql/providers/pq/gateway/native/yql_pq_gateway_services.cpp
+++ b/ydb/library/yql/providers/pq/gateway/native/yql_pq_gateway_services.cpp
@@ -9,7 +9,8 @@ TPqGatewayServices::TPqGatewayServices(
     TPqGatewayConfigPtr config,
     const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry,
     IMetricsRegistryPtr metrics,
-    TMaybe<NYdb::NTopic::TTopicClientSettings> commonTopicClientSettings)
+    TMaybe<NYdb::NTopic::TTopicClientSettings> commonTopicClientSettings,
+    IPqLocalClientFactory::TPtr localTopicClientFactory)
     : FunctionRegistry(functionRegistry)
     , Config(std::move(config))
     , Metrics(std::move(metrics))
@@ -17,6 +18,7 @@ TPqGatewayServices::TPqGatewayServices(
     , CmConnections(std::move(cmConnections))
     , YdbDriver(std::move(driver))
     , CommonTopicClientSettings(std::move(commonTopicClientSettings))
+    , LocalTopicClientFactory(std::move(localTopicClientFactory))
 {}
 
 } // namespace NYql

--- a/ydb/library/yql/providers/pq/gateway/native/yql_pq_gateway_services.h
+++ b/ydb/library/yql/providers/pq/gateway/native/yql_pq_gateway_services.h
@@ -2,6 +2,7 @@
 
 #include <ydb/library/yql/providers/common/token_accessor/client/factory.h>
 #include <ydb/library/yql/providers/pq/cm_client/client.h>
+#include <ydb/library/yql/providers/pq/gateway/clients/local/yql_pq_local_topic_client_factory.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 
 #include <yql/essentials/providers/common/metrics/metrics_registry.h>
@@ -25,6 +26,7 @@ struct TPqGatewayServices {
     ::NPq::NConfigurationManager::IConnections::TPtr CmConnections;
     NYdb::TDriver YdbDriver;
     TMaybe<NYdb::NTopic::TTopicClientSettings> CommonTopicClientSettings;
+    IPqLocalClientFactory::TPtr LocalTopicClientFactory;
 
     TPqGatewayServices(
         NYdb::TDriver driver,
@@ -33,7 +35,8 @@ struct TPqGatewayServices {
         TPqGatewayConfigPtr config,
         const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry,
         IMetricsRegistryPtr metrics = nullptr,
-        TMaybe<NYdb::NTopic::TTopicClientSettings> commonTopicClientSettings = Nothing());
+        TMaybe<NYdb::NTopic::TTopicClientSettings> commonTopicClientSettings = Nothing(),
+        IPqLocalClientFactory::TPtr localTopicClientFactory = nullptr);
 };
 
 } // namespace NYql

--- a/ydb/library/yql/providers/pq/gateway/native/yql_pq_session.h
+++ b/ydb/library/yql/providers/pq/gateway/native/yql_pq_session.h
@@ -3,6 +3,7 @@
 #include <ydb/library/yql/providers/common/token_accessor/client/factory.h>
 #include <ydb/library/yql/providers/pq/cm_client/client.h>
 #include <ydb/library/yql/providers/pq/gateway/abstract/yql_pq_gateway.h>
+#include <ydb/library/yql/providers/pq/gateway/clients/local/yql_pq_local_topic_client_factory.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/datastreams/datastreams.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 
@@ -20,7 +21,8 @@ public:
     using TPtr = TIntrusivePtr<TPqSession>;
 
     TPqSession(const TString& sessionId, const TString& username, const NPq::NConfigurationManager::IConnections::TPtr& cmConnections,
-        const NYdb::TDriver& ydbDriver, const TPqClusterConfigsMapPtr& clusterConfigs, ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory);
+        const NYdb::TDriver& ydbDriver, const TPqClusterConfigsMapPtr& clusterConfigs, ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory,
+        IPqLocalClientFactory::TPtr localTopicClientFactory);
 
     NPq::NConfigurationManager::TAsyncDescribePathResult DescribePath(const TString& cluster, const TString& database, const TString& path, const TString& token);
 
@@ -44,6 +46,7 @@ private:
     const NYdb::TDriver YdbDriver;
     const TPqClusterConfigsMapPtr ClusterConfigs;
     const ISecuredServiceAccountCredentialsFactory::TPtr CredentialsFactory;
+    const IPqLocalClientFactory::TPtr LocalTopicClientFactory;
 
     TMutex Mutex;
     THashMap<TString, NPq::NConfigurationManager::IClient::TPtr> ClusterCmClients; // Cluster -> CM Client.

--- a/ydb/library/yql/providers/pq/provider/yql_pq_settings.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_settings.cpp
@@ -90,6 +90,8 @@ void TPqConfiguration::AddCluster(
         const TString& password = properties.Value("password", "");
         const TString& passwordReference = properties.Value("passwordReference", "");
         structuredTokenJson = ComposeStructuredTokenJsonForBasicAuthWithSecret(login, passwordReference, password);
+    } else if (properties.Value("use_current_user_token", "false") == "true") {
+        structuredTokenJson = ComposeStructuredTokenJsonForCurrentUserAuth(properties.Value("token", ""));
     } else {
         structuredTokenJson = ComposeStructuredTokenJsonForServiceAccount(cluster.GetServiceAccountId(), cluster.GetServiceAccountIdSignature(), authToken);
     }

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h
@@ -32,6 +32,9 @@ public:
     //! client will connect to others nodes according to client loadbalancing
     TDriverConfig& SetEndpoint(const std::string& endpoint);
 
+    //! Get endpoint, returns the endpoint set via connection string or SetEndpoint()
+    const std::string& GetEndpoint() const;
+
     //! Set number of network threads, default: 2
     TDriverConfig& SetNetworkThreadsNum(size_t sz);
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -18,6 +18,11 @@ public:
     //! Result will come to TPartitionSessionStatusEvent.
     virtual void RequestStatus() = 0;
 
+    virtual void Commit(ui64 startOffset, ui64 endOffset);
+    virtual void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset);
+    virtual void ConfirmDestroy();
+    virtual void ConfirmEnd(const std::vector<ui32>& childIds);
+
     //!
     //! Properties.
     //!
@@ -249,7 +254,7 @@ struct TReadSessionEvent {
         //! This means that from now the first available
         //! message offset in current partition
         //! for current consumer is this offset.
-        //! All messages before are committed and futher never be available.
+        //! All messages before are committed and further never be available.
         uint64_t GetCommittedOffset() const {
             return CommittedOffset;
         }

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
@@ -219,7 +219,7 @@ public:
 
     virtual bool Close(TDuration closeTimeout = TDuration::Max()) = 0;
 
-    //! Returns true if write session is alive and acitve. False if session was closed.
+    //! Returns true if write session is alive and active. False if session was closed.
     virtual bool IsAlive() const = 0;
 
     virtual TWriterCounters::TPtr GetCounters() = 0;
@@ -269,7 +269,7 @@ public:
     //! Return true if all writes were completed and acked, false if timeout was reached and some writes were aborted.
     virtual bool Close(TDuration closeTimeout = TDuration::Max()) = 0;
 
-    //! Writer counters with different stats (see TWriterConuters).
+    //! Writer counters with different stats (see TWriterCounters).
     virtual TWriterCounters::TPtr GetCounters() = 0;
 
     //! Close() with timeout = 0 and destroy everything instantly.

--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -97,6 +97,10 @@ TDriverConfig& TDriverConfig::SetEndpoint(const std::string& endpoint) {
     return *this;
 }
 
+const std::string& TDriverConfig::GetEndpoint() const {
+    return Impl_->Endpoint;
+}
+
 TDriverConfig& TDriverConfig::SetNetworkThreadsNum(size_t sz) {
     Impl_->NetworkThreadsNum = sz;
     return *this;

--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_deferred_commit.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_deferred_commit.cpp
@@ -129,7 +129,7 @@ void TDeferredCommit::TImpl::Add(const TReadSessionEvent::TDataReceivedEvent& da
 void TDeferredCommit::TImpl::Commit() {
     for (auto&& [partitionStream, offsetRanges] : Offsets) {
         for (auto&& [startOffset, endOffset] : offsetRanges) {
-            static_cast<NTopic::TPartitionStreamImpl<false>*>(partitionStream.Get()->PartitionSession.Get())->Commit(startOffset, endOffset);
+            partitionStream->PartitionSession->Commit(startOffset, endOffset);
         }
     }
     Offsets.clear();

--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_read_session_event.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_read_session_event.cpp
@@ -157,7 +157,7 @@ TReadSessionEvent::TDataReceivedEvent::TDataReceivedEvent(NTopic::TReadSessionEv
 
 void TReadSessionEvent::TDataReceivedEvent::Commit() {
     for (auto [from, to] : OffsetRanges) {
-        static_cast<NTopic::TPartitionStreamImpl<false>*>(PartitionSession.Get())->Commit(from, to);
+        PartitionSession->Commit(from, to);
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/deferred_commit.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/deferred_commit.cpp
@@ -122,7 +122,7 @@ void TDeferredCommit::TImpl::Add(const TReadSessionEvent::TDataReceivedEvent& da
 void TDeferredCommit::TImpl::Commit() {
     for (auto&& [partitionStream, offsetRanges] : Offsets) {
         for (auto&& [startOffset, endOffset] : offsetRanges) {
-            static_cast<NTopic::TPartitionStreamImpl<false>*>(partitionStream.Get())->Commit(startOffset, endOffset);
+            partitionStream->Commit(startOffset, endOffset);
         }
     }
     Offsets.clear();

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -70,9 +70,16 @@ using TASessionClosedEvent = std::conditional_t<UseMigrationProtocol,
     NYdb::NPersQueue::TSessionClosedEvent,
     NYdb::NTopic::TSessionClosedEvent>;
 
+struct TMigrationPartitionStream : public NYdb::NPersQueue::TPartitionStream {
+    virtual void Commit(ui64 startOffset, ui64 endOffset) = 0;
+    virtual void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) = 0;
+    virtual void ConfirmDestroy() = 0;
+    virtual void ConfirmEnd(const std::vector<ui32>& childIds) = 0;
+};
+
 template <bool UseMigrationProtocol>
 using TAPartitionStream = std::conditional_t<UseMigrationProtocol,
-    NYdb::NPersQueue::TPartitionStream,
+    TMigrationPartitionStream,
     NYdb::NTopic::TPartitionSession>;
 
 template <bool UseMigrationProtocol>
@@ -684,12 +691,12 @@ public:
         TAPartitionStream<false>::LastDirectReadId = id;
     }
 
-    void Commit(ui64 startOffset, ui64 endOffset) /*override*/;
+    void Commit(ui64 startOffset, ui64 endOffset) override;
     void RequestStatus() override;
 
-    void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset);
-    void ConfirmDestroy();
-    void ConfirmEnd(const std::vector<ui32>& childIds);
+    void ConfirmCreate(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) override;
+    void ConfirmDestroy() override;
+    void ConfirmEnd(const std::vector<ui32>& childIds) override;
 
     void StopReading() /*override*/;
     void ResumeReading() /*override*/;

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -2147,8 +2147,8 @@ bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::AllParentSessionsHasBe
     return true;
 }
 
-template<bool UseMigrationProtocol>
-void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, const std::vector<ui32>& childIds) {
+template <>
+inline void TSingleClusterReadSessionImpl<false>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<false>* partitionStream, const std::vector<ui32>& childIds) {
     {
         std::lock_guard guard(HierarchyDataLock);
         ReadingFinishedData.insert(partitionStream->GetPartitionSessionId());
@@ -2161,6 +2161,12 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStream
             }
         }
     }
+}
+
+template <>
+inline void TSingleClusterReadSessionImpl<true>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<true>* partitionStream, const std::vector<ui32>& childIds) {
+    Y_UNUSED(partitionStream, childIds);
+    Y_ABORT("Not implemented");
 }
 
 template <bool UseMigrationProtocol>

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
@@ -1274,7 +1274,7 @@ public:
     }
 
     /*
-     * Start bidirectional streamming
+     * Start bidirectional streaming
      */
     template<typename TRequest, typename TResponse>
     void DoStreamRequest(TStreamConnectedCallback<TRequest, TResponse> callback,

--- a/ydb/tests/tools/kqprun/configuration/app_config.conf
+++ b/ydb/tests/tools/kqprun/configuration/app_config.conf
@@ -67,6 +67,7 @@ FeatureFlags {
   EnableMetadataObjectsOnServerless: true
   EnableExternalDataSourcesOnServerless: true
   EnableSchemaSecrets: true
+  EnableTopicsSqlIoOperations: true
 }
 
 KQPConfig {

--- a/yql/essentials/providers/common/structured_token/yql_token_builder.cpp
+++ b/yql/essentials/providers/common/structured_token/yql_token_builder.cpp
@@ -40,6 +40,12 @@ TStructuredTokenBuilder& TStructuredTokenBuilder::SetTokenAuthWithSecret(const T
     return *this;
 }
 
+TStructuredTokenBuilder& TStructuredTokenBuilder::SetCurrentUserTokenAuth(const TString& userToken) {
+    Data_.SetField("token", userToken);
+    Data_.SetField("current_user_auth", "true");
+    return *this;
+}
+
 TStructuredTokenBuilder& TStructuredTokenBuilder::SetIAMToken(const TString& token) {
     Data_.SetField("token", token);
     return *this;
@@ -131,6 +137,10 @@ bool TStructuredTokenParser::IsNoAuth() const {
     return Data_.HasField("no_auth");
 }
 
+bool TStructuredTokenParser::IsCurrentUserAuth() const {
+    return Data_.HasField("current_user_auth");
+}
+
 void TStructuredTokenParser::ListReferences(TSet<TString>& references) const {
     if (Data_.HasField("basic_password_ref")) {
         references.insert(Data_.GetField("basic_password_ref"));
@@ -210,6 +220,18 @@ TString ComposeStructuredTokenJsonForTokenAuthWithSecret(const TString& tokenSec
 
     if (tokenSecretName && token) {
         result.SetTokenAuthWithSecret(tokenSecretName, token);
+        return result.ToJson();
+    }
+
+    result.SetNoAuth();
+    return result.ToJson();
+}
+
+TString ComposeStructuredTokenJsonForCurrentUserAuth(const TString& userToken) {
+    TStructuredTokenBuilder result;
+
+    if (userToken) {
+        result.SetCurrentUserTokenAuth(userToken);
         return result.ToJson();
     }
 

--- a/yql/essentials/providers/common/structured_token/yql_token_builder.h
+++ b/yql/essentials/providers/common/structured_token/yql_token_builder.h
@@ -17,6 +17,7 @@ public:
     TStructuredTokenBuilder& SetBasicAuth(const TString& login, const TString& password);
     TStructuredTokenBuilder& SetBasicAuthWithSecret(const TString& login, const TString& passwordReference);
     TStructuredTokenBuilder& SetTokenAuthWithSecret(const TString& tokenReference, const TString& token);
+    TStructuredTokenBuilder& SetCurrentUserTokenAuth(const TString& userToken);
     TStructuredTokenBuilder& SetIAMToken(const TString& token);
     TStructuredTokenBuilder& SetNoAuth();
     TStructuredTokenBuilder& ReplaceReferences(const std::map<TString, TString>& secrets);
@@ -40,6 +41,7 @@ public:
     bool HasIAMToken() const;
     TString GetIAMToken() const;
     bool IsNoAuth() const;
+    bool IsCurrentUserAuth() const;
     void ListReferences(TSet<TString>& references) const;
 
     TStructuredTokenBuilder ToBuilder() const;
@@ -54,4 +56,5 @@ TString ComposeStructuredTokenJsonForServiceAccountWithSecret(const TString& ser
 TString ComposeStructuredTokenJsonForBasicAuth(const TString& login, const TString& password);
 TString ComposeStructuredTokenJsonForBasicAuthWithSecret(const TString& login, const TString& passwordSecretName, const TString& password);
 TString ComposeStructuredTokenJsonForTokenAuthWithSecret(const TString& tokenSecretName, const TString& token);
+TString ComposeStructuredTokenJsonForCurrentUserAuth(const TString& userToken);
 } // namespace NYql


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported construction:

```sql
SELECT * FROM my_topic WITH (
    FORMAT = json_each_row,
    SCHEMA (
        key Int32,
        value String
    )
);
```

Also supported checkpoints, watermarks and shared reading for local topics (same as for external topics). Syntax for local and external topics is same.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Reading from topics implemented via PQ provider same as reading from external topics, with one difference:

- Local topic client uses local rpc to create grpc actors in current AS
