### PR TITLE
Regression: test that selects from index with limit fails

### DIFF
--- a/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
@@ -1465,6 +1465,8 @@ Y_UNIT_TEST_SUITE(KqpLimits) {
                 .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_NODE, NLog::EPriority::PRI_DEBUG)
                 .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_COMPILE_SERVICE, NLog::EPriority::PRI_DEBUG))
             .SetLogStream(&Cerr);
+        // This line will fix the test: // TODO: remove
+        //settings.AppConfig.MutableTableServiceConfig()->SetBlockChannelsMode(NKikimrConfig::TTableServiceConfig::BLOCK_CHANNELS_SCALAR);
         TKikimrRunner kikimr(settings);
 
         auto db = kikimr.GetQueryClient();

--- a/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
@@ -1455,6 +1455,87 @@ Y_UNIT_TEST_SUITE(KqpLimits) {
         }
     }
 
+    Y_UNIT_TEST(BigSortingLimitInParam) {
+        SetRandomSeed(42);
+
+        auto settings = TKikimrSettings()
+            .SetWithSampleTables(false)
+            .SetLogSettings(TTestLogSettings()
+                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_COMPILE_ACTOR, NLog::EPriority::PRI_DEBUG)
+                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_NODE, NLog::EPriority::PRI_DEBUG)
+                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_COMPILE_SERVICE, NLog::EPriority::PRI_DEBUG))
+            .SetLogStream(&Cerr);
+        TKikimrRunner kikimr(settings);
+
+        auto db = kikimr.GetQueryClient();
+        auto tableClient = kikimr.GetTableClient();
+        auto sessionResult = tableClient.GetSession().GetValueSync();
+        UNIT_ASSERT_C(sessionResult.IsSuccess(), sessionResult.GetIssues().ToString());
+        auto session = sessionResult.GetSession();
+        auto res = session.ExecuteSchemeQuery(R"(
+            --!syntax_v1
+            CREATE TABLE TableWithIndex (
+                Id Utf8,
+                ForeignId Utf8,
+                Name Utf8,
+                Description Utf8,
+                PRIMARY KEY (Id),
+                INDEX Index GLOBAL ON (ForeignId, Name)
+            );
+        )").GetValueSync();
+        UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+
+        for (const char* additionalColumn : {"", ", Description"}) {
+            NYdb::NQuery::TExecuteQuerySettings querySettings;
+            querySettings.StatsMode(NYdb::NQuery::EStatsMode::Full);
+
+            auto result = db.ExecuteQuery(
+                Sprintf(R"(
+                    DECLARE $ForeignId AS Utf8;
+                    DECLARE $Name     AS Utf8;
+                    DECLARE $Id       AS Utf8;
+                    DECLARE $Limit    AS Uint64;
+
+                    SELECT
+                        Id,
+                        ForeignId,
+                        Name
+                        %s
+                    FROM
+                        TableWithIndex
+                    VIEW
+                        Index
+                    WHERE
+                        ForeignId = $ForeignId AND ((Name = $Name AND Id > $Id) OR Name > $Name)
+                    ORDER BY
+                        ForeignId, Name, Id
+                    LIMIT
+                        $Limit
+                )", additionalColumn),
+            NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+            NYdb::TParamsBuilder()
+                .AddParam("$ForeignId")
+                    .Utf8("")
+                    .Build()
+                .AddParam("$Name")
+                    .Utf8("")
+                    .Build()
+                .AddParam("$Id")
+                    .Utf8("")
+                    .Build()
+                .AddParam("$Limit")
+                    .Uint64(ui32(-1)) // big limit, but YDB does not fail
+                    .Build()
+                .Build(),
+            querySettings).ExtractValueSync();
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, "AdditionalColumn parameter: \"" << additionalColumn << "\". Issues:\n" << result.GetIssues().ToString());
+
+            const auto resultSet = result.GetResultSet(0);
+            UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 0);
+        }
+    }
+
     Y_UNIT_TEST_TWIN(QSReplySize, useSink) {
         auto settings = TKikimrSettings().SetWithSampleTables(true);
         settings.AppConfig.MutableTableServiceConfig()->SetEnableOltpSink(useSink);

--- a/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
@@ -1456,7 +1456,7 @@ Y_UNIT_TEST_SUITE(KqpLimits) {
     }
 
     Y_UNIT_TEST(BigSortingLimitInParam) {
-        //return; // TODO: uncomment
+        return; // TODO: remove
         SetRandomSeed(42);
 
         auto settings = TKikimrSettings()

--- a/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
@@ -1456,6 +1456,7 @@ Y_UNIT_TEST_SUITE(KqpLimits) {
     }
 
     Y_UNIT_TEST(BigSortingLimitInParam) {
+        //return; // TODO: uncomment
         SetRandomSeed(42);
 
         auto settings = TKikimrSettings()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/issues/31905

This test illustrates a regression between version 24.4 and 25.1 and upper.

There are two queries performed in the database, the second one fails on attempt to allocate 768GiB - the amount for all the elements requested in the LIMIT parameter.

Allocation fails here: https://github.com/ydb-platform/ydb/blob/cb77d014972b2cdb27d2e6d979fc3a2772b27ad4/yql/essentials/minikql/comp_nodes/mkql_wide_top_sort.cpp#L601 - the count is passed "as is".
