### PR TITLE
sync ca: implement idleness watermarks in channels

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -2138,7 +2138,16 @@ protected:
     void HandleCheckIdleness(const TEvPrivate::TEvCheckIdleness::TPtr& ev) {
         auto checkTime = Max(ev->Get()->CheckTime, TInstant::Now());
         if (WatermarksTracker.ProcessIdlenessCheck(checkTime)) {
-            auto idleWatermark = WatermarksTracker.HandleIdleness(checkTime);
+            TMaybe<TInstant> idleWatermark;
+            if constexpr (!std::is_same_v<TDerived, TDqAsyncComputeActor>) {
+                for (const auto& [id, _]: InputTransformsMap) {
+                    auto transformWatermarksTracker = GetInputTransformWatermarksTracker(id);
+                    if (transformWatermarksTracker) {
+                        idleWatermark = Max(idleWatermark, transformWatermarksTracker->HandleIdleness(checkTime));
+                    }
+                }
+            }
+            idleWatermark = Max(idleWatermark, WatermarksTracker.HandleIdleness(checkTime));
             if (idleWatermark) {
                 CA_LOG_T("Idleness watermark " << idleWatermark);
                 ResumeExecution(EResumeSource::CAWatermarkIdleness);
@@ -2148,7 +2157,23 @@ protected:
     }
 
     void ScheduleIdlenessCheck() {
-        if (auto checkTime = WatermarksTracker.PrepareIdlenessCheck()) {
+        TMaybe<TInstant> checkTime = WatermarksTracker.GetNextIdlenessCheckAt();
+        if constexpr (!std::is_same_v<TDerived, TDqAsyncComputeActor>) {
+            for (const auto& [id, _]: InputTransformsMap) {
+                auto transformWatermarksTracker = GetInputTransformWatermarksTracker(id);
+                if (transformWatermarksTracker) {
+                    auto transformCheckTime = transformWatermarksTracker->GetNextIdlenessCheckAt();
+                    if (transformCheckTime) {
+                        if (checkTime) {
+                            checkTime = Min(*checkTime, *transformCheckTime);
+                        } else {
+                            checkTime = *transformCheckTime;
+                        }
+                    }
+                }
+            }
+        }
+        if (checkTime && WatermarksTracker.AddScheduledIdlenessCheck(*checkTime)) {
             CA_LOG_T("Schedule next idleness check at " << checkTime);
             this->Schedule(*checkTime, new TEvPrivate::TEvCheckIdleness(*checkTime));
         }

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
@@ -147,6 +147,13 @@ void TDqComputeActorWatermarks::Out(IOutputStream& str) const {
     Impl.Out(str);
 }
 
+void TDqComputeActorWatermarks::TransferInput(TDqComputeActorWatermarks& otherTracker, ui64 inputId, bool isChannel) {
+    Impl.TransferInput(otherTracker.Impl, TInputKey { inputId, isChannel });
+}
+
+TDuration TDqComputeActorWatermarks::GetMaxIdleTimeout() const {
+    return Impl.GetMaxIdleTimeout();
+}
 } // namespace NYql::NDq
 
 template<>

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
@@ -25,6 +25,12 @@ TDqComputeActorWatermarks::TDqComputeActorWatermarks(const TString& logPrefix, c
 {
 }
 
+TDqComputeActorWatermarks::TDqComputeActorWatermarks(const TDqComputeActorWatermarks& parent, bool)
+    : LogPrefix(parent.LogPrefix)
+    , Impl(parent.Impl, true)
+{
+}
+
 void TDqComputeActorWatermarks::RegisterInputChannel(ui64 inputId, TDuration idleTimeout, TInstant systemTime) {
     RegisterInput(inputId, true, idleTimeout, systemTime);
 }

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -42,6 +42,9 @@ public:
     // Will return true, if local watermark inside this input channel was moved forward.
     bool NotifyInChannelWatermarkReceived(ui64 inputId, TInstant watermark, TInstant systemTime = TInstant::Now());
 
+    using TNotifyHandler = std::function<void()>;
+    void SetNotifyHandler(TNotifyHandler notifyHandler);
+
     // Will return true, if pending watermark completed.
     bool NotifyWatermarkWasSent(TInstant watermark);
 
@@ -54,8 +57,8 @@ public:
     // Return watermark that was generated after input idleness processing
     TMaybe<TInstant> HandleIdleness(TInstant systemTime);
 
-    // Return idleness check that should be scheduled or Nothing()
-    [[nodiscard]] TMaybe<TInstant> PrepareIdlenessCheck();
+    [[nodiscard]] TMaybe<TInstant> GetNextIdlenessCheckAt() const;
+    [[nodiscard]] bool AddScheduledIdlenessCheck(TInstant notifyTime);
     // Return true if idleness check should be performed
     [[nodiscard]] bool ProcessIdlenessCheck(TInstant notifyTime);
 
@@ -76,6 +79,7 @@ private:
 
     TMaybe<TInstant> PendingWatermark;
     TMaybe<TInstant> MaxWatermark;
+    TNotifyHandler NotifyHandler;
 };
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -26,6 +26,7 @@ class TDqComputeActorWatermarks
 {
 public:
     explicit TDqComputeActorWatermarks(const TString& logPrefix, const ::NMonitoring::TDynamicCounterPtr& counters = {});
+    TDqComputeActorWatermarks(const TDqComputeActorWatermarks& parent, bool);
 
     void RegisterAsyncInput(ui64 inputId, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());
     void RegisterInputChannel(ui64 inputId, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -33,6 +33,8 @@ public:
     void UnregisterAsyncInput(ui64 inputId, bool silent = false);
     void UnregisterInputChannel(ui64 inputId, bool silent = false);
 
+    void TransferInput(TDqComputeActorWatermarks &otherTracker, ui64 inputId, bool isChannel);
+
     // Will return true, if local watermark inside this async input was moved forward.
     bool NotifyAsyncInputWatermarkReceived(ui64 inputId, TInstant watermark, TInstant systemTime = TInstant::Now());
 
@@ -63,6 +65,7 @@ public:
     void RegisterInput(ui64 inputId, bool isChannel, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());
     void UnregisterInput(ui64 inputId, bool isChannel, bool silent = false);
     bool NotifyInputWatermarkReceived(ui64 inputId, bool isChannel, TInstant watermark, TInstant systemTime = TInstant::Now());
+    TDuration GetMaxIdleTimeout() const;
 
 private:
     TString LogPrefix;

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -275,6 +275,7 @@ protected:
         }
 
         this->WatermarksTracker.SetNotifyHandler([this]() {
+            // This code is called from TaskRunner (either directly or from input transform/helper code), which is owned by sync CA, so `*this` must be alive at that point
             this->ScheduleIdlenessCheck();
         });
 

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -274,6 +274,10 @@ protected:
             TaskRunner->SetSpillerFactory(std::make_shared<TDqSpillerFactory>(execCtx.GetTxId(), NActors::TActivationContext::ActorSystem(), execCtx.GetWakeupCallback(), execCtx.GetErrorCallback()));
         }
 
+        this->WatermarksTracker.SetNotifyHandler([this]() {
+            this->ScheduleIdlenessCheck();
+        });
+
         TaskRunner->Prepare(this->Task, limits, execCtx, &this->WatermarksTracker);
 
         for (auto& [channelId, channel] : this->InputChannelsMap) {

--- a/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
@@ -22,6 +22,11 @@ public:
         , Counters_(counters)
     {}
 
+    TDqWatermarkTrackerImpl(const TDqWatermarkTrackerImpl& parent, bool)
+        : LogPrefix_(parent.LogPrefix_)
+        , Counters_(parent.Counters_)
+    {}
+
     ~TDqWatermarkTrackerImpl() {
         if (IdleInputs_) {
             size_t idleableCount = 0;

--- a/ydb/library/yql/dq/runtime/dq_input_producer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_input_producer.cpp
@@ -72,6 +72,8 @@ private:
 
         // wait for drain only if watermarks enabled
         if (WatermarksEnabled() && WatermarksTracker->HasPendingWatermark()) {
+            Y_DEBUG_ABORT_UNLESS(WatermarkStorage->WatermarkIn <= *WatermarksTracker->GetPendingWatermark());
+            WatermarkStorage->WatermarkIn = WatermarksTracker->GetPendingWatermark();
             return NUdf::EFetchStatus::Yield;
         }
 
@@ -113,6 +115,8 @@ private:
 
         // wait for drain only if watermarks enabled
         if (WatermarksEnabled() && WatermarksTracker->HasPendingWatermark()) {
+            Y_DEBUG_ABORT_UNLESS(WatermarkStorage->WatermarkIn <= *WatermarksTracker->GetPendingWatermark());
+            WatermarkStorage->WatermarkIn = WatermarksTracker->GetPendingWatermark();
             return NUdf::EFetchStatus::Yield;
         }
 
@@ -192,8 +196,11 @@ private:
         auto hasPendingWatermark = WatermarksTracker->NotifyInputWatermarkReceived(InputKey.InputId, InputKey.IsChannel, *Watermark) && WatermarksTracker->HasPendingWatermark();
         Watermark.Clear();
         if (hasPendingWatermark) {
+            Y_DEBUG_ABORT_UNLESS(WatermarkStorage->WatermarkIn <= *WatermarksTracker->GetPendingWatermark());
             WatermarkStorage->WatermarkIn = WatermarksTracker->GetPendingWatermark();
             return true;
+        } else {
+            Y_DEBUG_ABORT_UNLESS(!WatermarksTracker->HasPendingWatermark());
         }
         return false;
     }

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -640,7 +640,7 @@ public:
                     inputUsesWatermarks = true;
                     if (transform && WatermarksTracker) {
                         transform->WatermarksTracker.emplace(/*logPrefix=*/"");
-                        transform->WatermarksTracker->RegisterAsyncInput(i/*TODO: , idleTimeout */);
+                        transform->WatermarksTracker->TransferInput(*WatermarksTracker, i, false);
                     }
                 }
             } else {
@@ -674,17 +674,16 @@ public:
                     if (inputChannelDesc.GetWatermarksMode() != NDqProto::WATERMARKS_MODE_DISABLED) {
                         inputUsesWatermarks = true;
                         if (transform && WatermarksTracker) {
-                            WatermarksTracker->UnregisterInputChannel(channelId);
                             if (!transform->WatermarksTracker) {
                                 transform->WatermarksTracker.emplace(/*logPrefix=*/"");
                             }
-                            transform->WatermarksTracker->RegisterInputChannel(channelId/*TODO: , idleTimeout */);
+                            transform->WatermarksTracker->TransferInput(*WatermarksTracker, channelId, true);
                         }
                     }
                 }
-                if (inputUsesWatermarks && transform && WatermarksTracker) {
-                    WatermarksTracker->RegisterAsyncInput(i/*TODO: , idleTimeout */);
-                }
+            }
+            if (inputUsesWatermarks && transform && WatermarksTracker) {
+                WatermarksTracker->RegisterAsyncInput(i, transform->WatermarksTracker->GetMaxIdleTimeout());
             }
 
             auto entryNode = AllocatedHolder->ProgramParsed.CompGraph->GetEntryPoint(i, false);

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -639,7 +639,7 @@ public:
                 if (inputDesc.GetSource().GetWatermarksMode() != NDqProto::WATERMARKS_MODE_DISABLED) {
                     inputUsesWatermarks = true;
                     if (transform && WatermarksTracker) {
-                        transform->WatermarksTracker.emplace(/*logPrefix=*/"");
+                        transform->WatermarksTracker.emplace(*WatermarksTracker, true);
                         transform->WatermarksTracker->TransferInput(*WatermarksTracker, i, false);
                     }
                 }
@@ -675,7 +675,7 @@ public:
                         inputUsesWatermarks = true;
                         if (transform && WatermarksTracker) {
                             if (!transform->WatermarksTracker) {
-                                transform->WatermarksTracker.emplace(/*logPrefix=*/"");
+                                transform->WatermarksTracker.emplace(*WatermarksTracker, true);
                             }
                             transform->WatermarksTracker->TransferInput(*WatermarksTracker, channelId, true);
                         }

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -951,10 +951,8 @@ class TestJoinStreaming(TestYdsBase):
         fq_client: FederatedQueryClient,
         yq_version,
     ):
-        self.init_topics(
-            f"slj_{partitions_count}{streamlookup}{testcase}{ca}_{yq_version}",
-            partitions_count=partitions_count,
-        )
+        title = f"slj_{partitions_count}{str(streamlookup)[:1]}{testcase}{ca[:1]}{yq_version}"
+        self.init_topics(title, partitions_count=partitions_count)
         fq_client.create_yds_connection("myyds", os.getenv("YDB_DATABASE"), os.getenv("YDB_ENDPOINT"))
 
         table_name = 'join_table'
@@ -976,11 +974,7 @@ class TestJoinStreaming(TestYdsBase):
 
         one_time_waiter.wait()
 
-        query_id = fq_client.create_query(
-            f"slj_{partitions_count}{streamlookup}{testcase}{ca}",
-            sql,
-            type=fq.QueryContent.QueryType.STREAMING,
-        ).result.query_id
+        query_id = fq_client.create_query(title, sql, type=fq.QueryContent.QueryType.STREAMING).result.query_id
 
         if not streamlookup and "MultiGet true" in sql:
             fq_client.wait_query_status(query_id, fq.QueryMeta.FAILED)
@@ -1037,7 +1031,7 @@ class TestJoinStreaming(TestYdsBase):
     @pytest.mark.parametrize("streamlookup", [True, False])
     @pytest.mark.parametrize("ca", ["sync", "async"])
     @pytest.mark.parametrize("limit", [6, 7, 8, 9, None])
-    def test_streamlookup_with_watermarks(
+    def test_streamlookup_watermarks(
         self,
         kikimr,
         ca,
@@ -1048,10 +1042,8 @@ class TestJoinStreaming(TestYdsBase):
         fq_client: FederatedQueryClient,
         yq_version,
     ):
-        self.init_topics(
-            f"slj_wm_{partitions_count}{streamlookup}{limit}{ca}{tasks}_{yq_version}",
-            partitions_count=partitions_count,
-        )
+        title = f"slj_wm_{partitions_count}{str(streamlookup)[:1]}{limit}{ca[:1]}{tasks}"
+        self.init_topics(title, partitions_count=partitions_count)
         fq_client.create_yds_connection(
             "wmyds",
             os.getenv("YDB_DATABASE"),
@@ -1135,9 +1127,7 @@ class TestJoinStreaming(TestYdsBase):
 
         one_time_waiter.wait()
 
-        query_id = fq_client.create_query(
-            f"slj_wm_{partitions_count}{streamlookup}{limit}{ca}{tasks}", sql, type=fq.QueryContent.QueryType.STREAMING
-        ).result.query_id
+        query_id = fq_client.create_query(title, sql, type=fq.QueryContent.QueryType.STREAMING).result.query_id
 
         fq_client.wait_query_status(query_id, fq.QueryMeta.RUNNING)
         kikimr.compute_plane.wait_zero_checkpoint(query_id)

--- a/ydb/tests/fq/streaming/test_watermarks.py
+++ b/ydb/tests/fq/streaming/test_watermarks.py
@@ -10,21 +10,22 @@ logger = logging.getLogger(__name__)
 
 class TestWatermarksInYdb(StreamingTestBase):
     @pytest.mark.parametrize("kikimr", [{"enable_watermarks": True}], indirect=["kikimr"])
-    @pytest.mark.parametrize("shared_reading", [False], ids=["no_shared"])
-    @pytest.mark.parametrize("tasks", [1])
+    @pytest.mark.parametrize("shared_reading", [False, True], ids=["no_shared", "shared"])
+    @pytest.mark.parametrize("tasks", [1, 2])
     @pytest.mark.parametrize("local_topics", [True, False])
     def test_watermarks(self: StreamingTestBase, kikimr: Kikimr, entity_name: Callable[[str], str], shared_reading: bool, tasks: int, local_topics: bool) -> None:
         if local_topics and shared_reading:
             pytest.skip("Shared reading is not supported for local topics: YQ-5036")
 
         endpoint = self.get_endpoint(kikimr, local_topics)
-        query_name = f"test_watermarks_{shared_reading}_{tasks}"
+        query_name = f"test_watermarks_{shared_reading}{tasks}{local_topics}"
         source_name = entity_name(query_name)
         self.init_topics(source_name, partitions_count=tasks, endpoint=endpoint)
         self.create_source(kikimr, source_name, shared_reading)
 
         ts = "CAST(ts AS Timestamp)" if shared_reading else "SystemMetadata('write_time')"
         cluster = f"{source_name}." if not local_topics else ""
+        idleness_clause = ', WATERMARK_IDLE_TIMEOUT = "PT5S"' if tasks > 1 else ''
 
         sql = f'''
             CREATE STREAMING QUERY `{query_name}` AS
@@ -43,8 +44,8 @@ class TestWatermarksInYdb(StreamingTestBase):
                             pass Uint64
                         )
                         , WATERMARK AS ({ts} - Interval('PT5S'))
-                        , WATERMARK_IDLE_TIMEOUT = "PT10S"
                         , WATERMARK_GRANULARITY = "PT1S"
+                        {idleness_clause}
                     )
                 );
 
@@ -79,11 +80,15 @@ class TestWatermarksInYdb(StreamingTestBase):
         kikimr.ydb_client.query(sql)
         self.wait_completed_checkpoints(kikimr, f"/Root/{query_name}")
 
-        self.write_stream(['{"ts": "1970-01-01T00:00:40Z", "pass": 1}'], endpoint=endpoint)
-        time.sleep(10)
-        self.write_stream(['{"ts": "1970-01-01T00:00:50Z", "pass": 1}'], endpoint=endpoint)
-        time.sleep(10)
-        self.write_stream(['{"ts": "1970-01-01T00:01:00Z", "pass": 0}'], endpoint=endpoint)
+        self.write_stream(['{"ts": "1970-01-01T00:00:40Z", "pass": 1}'], endpoint=endpoint, partition_key=b'1')
+        if not shared_reading:
+            time.sleep(10)
+        self.write_stream(['{"ts": "1970-01-01T00:00:50Z", "pass": 1}'], endpoint=endpoint, partition_key=b'1')
+        if not shared_reading:
+            time.sleep(10)
+        self.write_stream(['{"ts": "1970-01-01T00:01:00Z", "pass": 0}'], endpoint=endpoint, partition_key=b'1')
+        if shared_reading and tasks > 1:
+            time.sleep(10)  # leave a bit more time to fire up idle timeout
 
         expected = [
             '[["1970-01-01T00:00:40Z"]]',

--- a/ydb/tests/tools/datastreams_helpers/data_plane.py
+++ b/ydb/tests/tools/datastreams_helpers/data_plane.py
@@ -44,7 +44,7 @@ def write_stream(path, data, partition_key=None, database=None, endpoint=None):
 
 
 #  Data plane grpc API is not implemented in datastreams.
-def read_stream(path, messages_count, commit_after_processing=True, consumer_name="test_client", timeout=READ_TOOL_TIMEOUT, database=None, endpoint=None):
+def read_stream(path, messages_count, commit_after_processing=True, consumer_name="test_client", timeout=None, database=None, endpoint=None):
     result_file_name = "{}-{}-read-result-{}-{}-out".format(
         os.getenv("PYTEST_CURRENT_TEST").replace(":", "_").replace(" (call)", ""),
         path.replace("/", "_"),
@@ -55,6 +55,8 @@ def read_stream(path, messages_count, commit_after_processing=True, consumer_nam
         database = os.getenv("YDB_DATABASE")
     if endpoint is None:
         endpoint = os.getenv("YDB_ENDPOINT")
+    if timeout is None:
+        timeout = READ_TOOL_TIMEOUT
     result_file = yatest.common.output_path(result_file_name)
     cmd = [
         yatest.common.binary_path("ydb/tests/tools/pq_read/pq_read"),

--- a/ydb/tests/tools/datastreams_helpers/test_yds_base.py
+++ b/ydb/tests/tools/datastreams_helpers/test_yds_base.py
@@ -32,10 +32,10 @@ class TestYdsBase(object):
         topic = topic_path if topic_path else self.input_topic
         write_stream(topic, data, partition_key=partition_key, database=database, endpoint=fqdn)
 
-    def read_stream(self, messages_count, commit_after_processing=True, topic_path=None, endpoint=None):
+    def read_stream(self, messages_count, commit_after_processing=True, topic_path=None, endpoint=None, timeout=None):
         database, fqdn = self.__unwrap_endpoint(endpoint)
         topic = topic_path if topic_path else self.output_topic
-        return read_stream(topic, messages_count, commit_after_processing, self.consumer_name, database=database, endpoint=fqdn)
+        return read_stream(topic, messages_count, commit_after_processing, self.consumer_name, database=database, endpoint=fqdn, timeout=timeout)
 
     def wait_until(self, predicate, wait_time=plain_or_under_sanitizer(10, 50)):
         deadline = time.time() + wait_time


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

New idleness scheduled upon on either update watermark, or after check processed (at most one check at once scheduled);
When idle channel (or input) detected, this channel is excluded from resulting watermark calculation (and as a result, new watermark may be produced).
Special handling may be required for input transform (as they have separate watermark trackers).
(`if  constexpr (!async_ca)` is purely optimization -- for async CA `GetInpitTransform...Tracker` is always null)