### PR TITLE
Fix VDisk sync log race by alexvru (#30779)

### DIFF
--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
@@ -52,21 +52,11 @@ namespace NKikimr {
 
             // just trim log based by TrimTailLsn (which is confirmed lsn from peers)
             bool PerformTrimTailAction() {
-                const bool hasToCommit = KeepState.PerformTrimTailAction();
-
-                // we don't need to commit because we either remove mem pages or
-                // schedule to remove some chunks (but they may be used by snapshots,
-                // so wait until TEvSyncLogFreeChunk message)
-                Y_VERIFY_S(!hasToCommit, SlCtx->VCtx->VDiskLogPrefix);
-                return false;
+                return KeepState.PerformTrimTailAction();
             }
 
             bool PerformMemOverflowAction() {
                 return KeepState.PerformMemOverflowAction();
-            }
-
-            bool PerformDeleteChunkAction() {
-                return KeepState.PerformDeleteChunkAction();
             }
 
             bool PerformInitialCommit() {
@@ -78,6 +68,11 @@ namespace NKikimr {
             // PERFORM ACTIONS
             ////////////////////////////////////////////////////////////////////////
             void PerformActions(const TActorContext &ctx) {
+                if (auto v = KeepState.GetChunksToForget(); !v.empty()) {
+                    Send(SlCtx->PDiskCtx->PDiskId, new NPDisk::TEvChunkForget(SlCtx->PDiskCtx->Dsk->Owner,
+                        SlCtx->PDiskCtx->Dsk->OwnerRound, std::move(v)));
+                }
+
                 if (CommitterId || !KeepState.HasDelayedActions()) {
                     // be fast: already committing or has no actions? Return.
                     return;
@@ -87,8 +82,8 @@ namespace NKikimr {
                 generateCommit |= PerformTrimTailAction();
                 generateCommit |= PerformCutLogAction(ctx);
                 generateCommit |= PerformMemOverflowAction();
-                generateCommit |= PerformDeleteChunkAction();
                 generateCommit |= PerformInitialCommit();
+                generateCommit |= KeepState.GetDeleteChunkAndClear();
 
                 if (generateCommit) {
                     Y_VERIFY_S(!CommitterId, SlCtx->VCtx->VDiskLogPrefix);
@@ -259,6 +254,7 @@ namespace NKikimr {
                 HFunc(NPDisk::TEvCutLog, Handle)
                 HFunc(TEvents::TEvPoisonPill, Handle)
                 HFunc(TEvListChunks, Handle)
+                hFunc(NPDisk::TEvChunkForgetResult, [&](auto&) {});
             )
 
         public:

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.h
@@ -55,13 +55,16 @@ namespace NKikimr {
             const TCommitHistory CommitInfo;
             const TEntryPointDbgInfo EntryPointDbgInfo;
             TDeltaToDiskRecLog Delta;
+            TVector<ui32> ChunksDeleted;
 
             TEvSyncLogCommitDone(const TCommitHistory &commitInfo,
                                  const TEntryPointDbgInfo &layout,
-                                 TDeltaToDiskRecLog &&delta)
+                                 TDeltaToDiskRecLog &&delta,
+                                 TVector<ui32>&& chunksDeleted)
                 : CommitInfo(commitInfo)
                 , EntryPointDbgInfo(layout)
                 , Delta(std::move(delta))
+                , ChunksDeleted(std::move(chunksDeleted))
             {}
 
             void Output(IOutputStream &s) const {
@@ -87,19 +90,16 @@ namespace NKikimr {
         struct TSyncLogKeeperCommitData {
             TSyncLogSnapshotPtr SyncLogSnap;
             TMemRecLogSnapshotPtr SwapSnap;
-            TVector<ui32> ChunksToDeleteDelayed;
             TVector<ui32> ChunksToDelete;
             const ui64 RecoveryLogConfirmedLsn;
 
             TSyncLogKeeperCommitData(
                     TSyncLogSnapshotPtr &&syncLogSnap,
                     TMemRecLogSnapshotPtr &&swapSnap,
-                    TVector<ui32> &&chunksToDeleteDelayed,
                     TVector<ui32> &&chunksToDelete,
                     ui64 recoveryLogConfirmedLsn)
                 : SyncLogSnap(std::move(syncLogSnap))
                 , SwapSnap(std::move(swapSnap))
-                , ChunksToDeleteDelayed(std::move(chunksToDeleteDelayed))
                 , ChunksToDelete(std::move(chunksToDelete))
                 , RecoveryLogConfirmedLsn(recoveryLogConfirmedLsn)
             {}
@@ -111,7 +111,6 @@ namespace NKikimr {
             void Output(IOutputStream &str) const {
                 str << "{SyncLogSnap->Boundaries# " << SyncLogSnap->BoundariesToString()
                     << " SwapSnap# " << (SwapSnap ? SwapSnap->BoundariesToString() : "<empty>")
-                    << " ChunksToDeleteDelayed.size# " << ChunksToDeleteDelayed.size()
                     << " ChunksToDelete# " << ChunksToDelete.size()
                     << " RecoveryLogConfirmedLsn# " << RecoveryLogConfirmedLsn
                     << "}";

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
@@ -136,7 +136,6 @@ namespace NKikimr {
         void Start(TSyncLogKeeperState *state, ui64 recoveryLogConfirmedLsn) {
             CommitData = std::make_unique<TSyncLogKeeperCommitData>(state->PrepareCommitData(recoveryLogConfirmedLsn));
             Y_ABORT_UNLESS((!CommitData->SwapSnap || CommitData->SwapSnap->Empty()) &&
-                    CommitData->ChunksToDeleteDelayed.empty() &&
                     CommitData->ChunksToDelete.empty());
             STR << "Commit started\n";
             PrintStatus(state);
@@ -146,12 +145,12 @@ namespace NKikimr {
             TStringStream s;
             TDeltaToDiskRecLog delta(10);
             TEntryPointSerializer entryPointSerializer(CommitData->SyncLogSnap,
-                std::move(CommitData->ChunksToDeleteDelayed), CommitData->RecoveryLogConfirmedLsn);
+                {}, CommitData->RecoveryLogConfirmedLsn);
             entryPointSerializer.Serialize(delta);
 
             TCommitHistory commitHistory(TInstant(), commitLsn, CommitData->RecoveryLogConfirmedLsn);
             TEvSyncLogCommitDone commitDone(commitHistory, entryPointSerializer.GetEntryPointDbgInfo(),
-                std::move(delta));
+                std::move(delta), {});
 
             // apply commit result
             state->ApplyCommitResult(&commitDone);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix VDisk sync log race

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes race with deleting chunks leading to assertion failure and causing possible double-free corruption.
