### PR TITLE
Replace TMemorizableControlWrapper to TControlWrapper (#10005)

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
@@ -325,8 +325,8 @@ private:
     TLight BurstDetector;
     std::atomic<ui64> SeqnoBurstDetector = 0;
 
-    TMemorizableControlWrapper BurstThresholdNs;
-    TMemorizableControlWrapper DiskTimeAvailableScale;
+    TControlWrapper BurstThresholdNs;
+    TControlWrapper DiskTimeAvailableScale;
 
 public:
     TBsCostTracker(const TBlobStorageGroupType& groupType, NPDisk::EDeviceType diskType,
@@ -352,7 +352,7 @@ public:
     }
 
     void CountRequest(ui64 cost) {
-        i64 bucketCapacity = GetDiskTimeAvailableScale() * BurstThresholdNs.Update(TAppData::TimeProvider->Now());
+        i64 bucketCapacity = GetDiskTimeAvailableScale() * BurstThresholdNs;
         BucketUpperLimit.store(bucketCapacity);
         BucketLowerLimit.store(bucketCapacity * -BucketRelativeMinimum);
         Bucket.FillAndTake(cost);
@@ -417,7 +417,7 @@ public:
 
 private:
     float GetDiskTimeAvailableScale() {
-        return 0.001 * DiskTimeAvailableScale.Update(TAppData::TimeProvider->Now());
+        return 0.001 * DiskTimeAvailableScale;
     }
 };
 

--- a/ydb/core/control/immediate_control_board_wrapper.h
+++ b/ydb/core/control/immediate_control_board_wrapper.h
@@ -40,6 +40,7 @@ public:
     }
 };
 
+// WARNING: not thread safe
 class TMemorizableControlWrapper {
     static constexpr i32 RequestCountWithRelevantValue = 1024;
     static constexpr TDuration TimeDurationWithRelevantValue = TDuration::Seconds(15);


### PR DESCRIPTION
Replace TMemorizableControlWrapper to TControlWrapper because of thread-safeness

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
