### PR TITLE
Add runtime feature flag to enable/disable CPU Scheduler

### DIFF
--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -2,11 +2,25 @@
 
 #include "tree/dynamic.h"
 
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/base/feature_flags.h>
+#include <ydb/core/cms/console/configs_dispatcher.h>
+#include <ydb/core/cms/console/console.h>
 #include <ydb/core/kqp/common/events/workload_service.h>
 #include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/protos/feature_flags.pb.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
 
+#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_C(stream) LOG_CRIT_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+
+using namespace NKikimr;
 using namespace NKikimr::NKqp;
 using namespace NKikimr::NKqp::NScheduler;
 using namespace NKikimr::NKqp::NScheduler::NHdrf::NDynamic;
@@ -23,6 +37,18 @@ public:
     {}
 
     void Bootstrap() {
+        Send(
+            NConsole::MakeConfigsDispatcherID(SelfId().NodeId()),
+            new NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionRequest({(ui32)NKikimrConsole::TConfigItem::FeatureFlagsItem}),
+            NActors::IEventHandle::FlagTrackDelivery
+        );
+
+        if (Enabled = AppData()->FeatureFlags.GetEnableResourcePools()) {
+            LOG_I("Enabled on start");
+        } else {
+            LOG_I("Disabled on start");
+        }
+
         Scheduler->SetTotalCpuLimit(CalculateTotalCpuLimit()); // TODO: take total cpu limit from outside
 
         Become(&TComputeSchedulerService::State);
@@ -31,6 +57,9 @@ public:
 
     STATEFN(State) {
         switch (ev->GetTypeRewrite()) {
+            hFunc(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse, Handle);
+            hFunc(NConsole::TEvConsole::TEvConfigNotificationRequest, Handle);
+
             hFunc(TEvAddDatabase, Handle);
             hFunc(TEvRemoveDatabase, Handle);
             hFunc(TEvAddPool, Handle);
@@ -42,8 +71,25 @@ public:
             hFunc(NActors::TEvents::TEvWakeup, Handle);
 
             default:
-                Y_ABORT("Unexpected event for TComputeSchedulerService: %u", ev->GetTypeRewrite());
+                LOG_E("Unexpected event: " << ev->GetTypeRewrite());
         }
+    }
+
+    void Handle(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::TPtr&) {
+        LOG_D("Subscribed to config changes");
+    }
+
+    void Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr& ev) {
+        const auto& event = ev->Get()->Record;
+
+        if (Enabled = event.GetConfig().GetFeatureFlags().GetEnableResourcePoolsScheduler()) {
+            LOG_I("Become enabled");
+        } else {
+            LOG_I("Become disabled");
+        }
+
+        auto responseEvent = std::make_unique<NKikimr::NConsole::TEvConsole::TEvConfigNotificationResponse>(event);
+        Send(ev->Sender, responseEvent.release(), NActors::IEventHandle::FlagTrackDelivery, ev->Cookie);
     }
 
     void Handle(TEvAddDatabase::TPtr& ev) {
@@ -51,6 +97,8 @@ public:
             .Weight = ev->Get()->Weight, // TODO: weight shouldn't be negative!
         };
         Scheduler->AddOrUpdateDatabase(ev->Get()->Id, attrs);
+
+        LOG_D("Add database: " << ev->Get()->Id);
     }
 
     void Handle(TEvRemoveDatabase::TPtr&) {
@@ -70,6 +118,8 @@ public:
         }
 
         Y_ASSERT(!poolId.empty());
+
+        LOG_D("Add pool: " << databaseId << "/" << poolId);
 
         if (PoolSubscribtions.insert({std::make_pair(databaseId, poolId), {false, resourceWeight}}).second) {
             PoolExternalWeightSum += resourceWeight;
@@ -118,7 +168,7 @@ public:
                 // TODO: Scheduler->UpdatePool(…);
             }
         } else {
-            LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, "Trying to remove unknown pool: " << databaseId << "/" << poolId);
+            LOG_E("Trying to remove unknown pool: " << databaseId << "/" << poolId);
             // TODO: the removing message for unknown pool - should we check?
         }
     }
@@ -131,15 +181,21 @@ public:
             .Weight = ev->Get()->Weight, // TODO: weight shouldn't be negative!
         };
 
-        auto query = Scheduler->AddOrUpdateQuery(databaseId, poolId.empty() ? NKikimr::NResourcePool::DEFAULT_POOL_ID : poolId, queryId, attrs);
         auto response = MakeHolder<TEvQueryResponse>();
-        response->Query = query;
+        if (Enabled) {
+            auto query = Scheduler->AddOrUpdateQuery(databaseId, poolId.empty() ? NKikimr::NResourcePool::DEFAULT_POOL_ID : poolId, queryId, attrs);
+            response->Query = query;
+            LOG_D("Add query: " << databaseId << "/" << poolId << ", TxId: " << queryId);
+        }
         Send(ev->Sender, response.Release(), 0, queryId);
     }
 
     void Handle(TEvRemoveQuery::TPtr& ev) {
-        if (!Scheduler->RemoveQuery(ev->Get()->QueryId)) {
-            LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, "Trying to remove unknown query: " << ev->Get()->QueryId);
+        const auto& queryId = ev->Get()->QueryId;
+        if (!Scheduler->RemoveQuery(queryId)) {
+            LOG_E("Trying to remove unknown query: " << queryId);
+        } else {
+            LOG_D("Remove query: TxId: " << queryId);
         }
     }
 
@@ -171,6 +227,7 @@ private:
     }
 
 private:
+    bool Enabled = true;
     TComputeSchedulerPtr Scheduler;
     const TDuration UpdateFairSharePeriod;
 
@@ -188,9 +245,10 @@ namespace NKikimr::NKqp {
 
 namespace NScheduler {
 
-TComputeScheduler::TComputeScheduler(TIntrusivePtr<TKqpCounters> counters, const TDelayParams& delayParams)
+TComputeScheduler::TComputeScheduler(TIntrusivePtr<TKqpCounters> counters, const TDelayParams& delayParams, bool allowFairShareOverlimit)
     : Root(std::make_shared<TRoot>(counters))
     , DelayParams(delayParams)
+    , AllowFairShareOverlimit(allowFairShareOverlimit)
     , KqpCounters(counters)
 {
     auto group = counters->GetKqpCounters();
@@ -248,7 +306,8 @@ TQueryPtr TComputeScheduler::AddOrUpdateQuery(const NHdrf::TDatabaseId& database
     if (query = std::static_pointer_cast<TQuery>(pool->GetQuery(queryId))) {
         query->Update(attrs);
     } else {
-        query = std::make_shared<TQuery>(queryId, &DelayParams, attrs);
+        bool allowMinFairShare = (!pool->Limit || *pool->Limit > 0) && AllowFairShareOverlimit;
+        query = std::make_shared<TQuery>(queryId, &DelayParams, allowMinFairShare, attrs);
         pool->AddQuery(query);
         Y_ENSURE(Queries.emplace(queryId, query).second);
     }
@@ -268,7 +327,7 @@ bool TComputeScheduler::RemoveQuery(const NHdrf::TQueryId& queryId) {
     return false;
 }
 
-void TComputeScheduler::UpdateFairShare(bool allowFairShareOverlimit) {
+void TComputeScheduler::UpdateFairShare() {
     auto startTime = TMonotonic::Now();
 
     NHdrf::NSnapshot::TRootPtr snapshot;
@@ -278,7 +337,7 @@ void TComputeScheduler::UpdateFairShare(bool allowFairShareOverlimit) {
     }
 
     snapshot->UpdateBottomUp(Root->TotalLimit);
-    snapshot->UpdateTopDown(allowFairShareOverlimit);
+    snapshot->UpdateTopDown(AllowFairShareOverlimit);
 
     {
         TWriteGuard lock(Mutex);

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
@@ -10,7 +10,7 @@ namespace NKikimr::NKqp::NScheduler {
 
 class TComputeScheduler : public std::enable_shared_from_this<TComputeScheduler> {
 public:
-    TComputeScheduler(TIntrusivePtr<TKqpCounters> counters, const TDelayParams& delayParams);
+    TComputeScheduler(TIntrusivePtr<TKqpCounters> counters, const TDelayParams& delayParams, bool allowFairShareOverlimit = true);
 
     void SetTotalCpuLimit(ui64 cpu);
     ui64 GetTotalCpuLimit() const;
@@ -22,9 +22,10 @@ public:
     NHdrf::NDynamic::TQueryPtr AddOrUpdateQuery(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId, const NHdrf::TQueryId& queryId, const NHdrf::TStaticAttributes& attrs);
     bool RemoveQuery(const NHdrf::TQueryId& queryId);
 
-    // We want to allow FairShare to be over Limit.
-    // If you need to change this behaviour change variable's default value
-    void UpdateFairShare(bool allowFairShareOverlimit = true);
+    void UpdateFairShare();
+    bool IsAllowedFairShareOverlimit() const {
+        return AllowFairShareOverlimit;
+    }
 
 private:
     TRWMutex Mutex;
@@ -32,6 +33,7 @@ private:
     THashMap<NHdrf::TQueryId, NHdrf::NDynamic::TQueryPtr> Queries; // protected by Mutex
 
     const TDelayParams DelayParams;
+    const bool AllowFairShareOverlimit;
     TIntrusivePtr<TKqpCounters> KqpCounters;
 
     struct {

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
@@ -1,5 +1,7 @@
 #include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
 
+#include <ydb/library/testlib/helpers.h>
+
 namespace NKikimr::NKqp {
 
 using namespace NWorkload;
@@ -7,14 +9,41 @@ using namespace NWorkload;
 Y_UNIT_TEST_SUITE(KqpComputeSchedulerService) {
 
     /* Scenario:
-        - Create Resource Pool with zero CPU.
-        - Disable Scheduler.
-        - Run query inside this Pool.
+        - Create resource pool with zero CPU.
+        - Enable or disable Scheduler on start.
+        - Run query inside this pool.
+        - Query shouldn't timeout or should be cancelled by timeout.
+     */
+    Y_UNIT_TEST_TWIN(FeatureFlagOnStart, Enabled) {
+        auto ydb = TYdbSetupSettings()
+            .EnableResourcePools(true)
+            .EnableResourcePoolsScheduler(Enabled)
+            .Create();
+
+        const TString& poolId = "zero_pool";
+        NResourcePool::TPoolSettings poolSettings;
+        poolSettings.TotalCpuLimitPercentPerNode = 0;
+        poolSettings.QueryCancelAfter = TDuration::Seconds(10);
+        ydb->CreateResourcePool(poolId, poolSettings);
+
+        auto request = ydb->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, TQueryRunnerSettings().PoolId(poolId));
+        if (!Enabled) {
+            TSampleQueries::TSelect42::CheckResult(request.GetResult());
+        } else {
+            TSampleQueries::CheckCancelled(request.GetResult());
+        }
+    }
+
+    /* Scenario:
+        - Create resource pool with zero CPU.
+        - Enable Scheduler on start, but disable Workload Manager.
+        - Run query inside this pool - it should actually go to default pool.
         - Query shouldn't timeout.
      */
-    Y_UNIT_TEST(DisabledByFeatureFlag) {
+    Y_UNIT_TEST(EnabledSchedulerWithDisabledWorkloadManager) {
         auto ydb = TYdbSetupSettings()
-            .EnableResourcePoolsScheduler(false)
+            .EnableResourcePools(false)
+            .EnableResourcePoolsScheduler(true)
             .Create();
 
         const TString& poolId = "zero_pool";

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
@@ -55,7 +55,9 @@ Y_UNIT_TEST_SUITE(KqpComputeSchedulerService) {
         ydb->CreateResourcePool(poolId, poolSettings);
 
         auto request = ydb->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, TQueryRunnerSettings().PoolId(poolId));
-        TSampleQueries::TSelect42::CheckResult(request.GetResult());
+        auto result = request.GetResult();
+        UNIT_ASSERT_EQUAL(result.Response.GetResponse().GetEffectivePoolId(), NResourcePool::DEFAULT_POOL_ID);
+        TSampleQueries::TSelect42::CheckResult(result);
     }
 
 }

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
@@ -27,10 +27,12 @@ Y_UNIT_TEST_SUITE(KqpComputeSchedulerService) {
         ydb->CreateResourcePool(poolId, poolSettings);
 
         auto request = ydb->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, TQueryRunnerSettings().PoolId(poolId));
+        const auto& result = request.GetResult();
+        UNIT_ASSERT_EQUAL(result.Response.GetResponse().GetEffectivePoolId(), poolId);
         if (!Enabled) {
-            TSampleQueries::TSelect42::CheckResult(request.GetResult());
+            TSampleQueries::TSelect42::CheckResult(result);
         } else {
-            TSampleQueries::CheckCancelled(request.GetResult());
+            TSampleQueries::CheckCancelled(result);
         }
     }
 

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
@@ -1,0 +1,32 @@
+#include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+
+namespace NKikimr::NKqp {
+
+using namespace NWorkload;
+
+Y_UNIT_TEST_SUITE(KqpComputeSchedulerService) {
+
+    /* Scenario:
+        - Create Resource Pool with zero CPU.
+        - Disable Scheduler.
+        - Run query inside this Pool.
+        - Query shouldn't timeout.
+     */
+    Y_UNIT_TEST(DisabledByFeatureFlag) {
+        auto ydb = TYdbSetupSettings()
+            .EnableResourcePoolsScheduler(false)
+            .Create();
+
+        const TString& poolId = "zero_pool";
+        NResourcePool::TPoolSettings poolSettings;
+        poolSettings.TotalCpuLimitPercentPerNode = 0;
+        poolSettings.QueryCancelAfter = TDuration::Seconds(10);
+        ydb->CreateResourcePool(poolId, poolSettings);
+
+        auto request = ydb->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, TQueryRunnerSettings().PoolId(poolId));
+        TSampleQueries::TSelect42::CheckResult(request.GetResult());
+    }
+
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_ut.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_ut.cpp
@@ -107,7 +107,7 @@ Y_UNIT_TEST_SUITE(TKqpScheduler) {
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams);
+        TComputeScheduler scheduler(options.Counters, options.DelayParams, AllowOverlimit);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -123,7 +123,7 @@ Y_UNIT_TEST_SUITE(TKqpScheduler) {
             tasks.emplace_back(CreateDemandTasks(query, kQueryDemand));
         }
 
-        scheduler.UpdateFairShare(AllowOverlimit);
+        scheduler.UpdateFairShare();
 
         for (const auto& query : queries) {
             auto querySnapshot = query->GetSnapshot();

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
@@ -38,8 +38,7 @@ bool TSchedulableTask::TryIncreaseUsage() {
         poolOrQuery = Query->GetParent();
     } else {
         // TODO: check directly for the pool snapshot - even if there is no query snapshot yet.
-        // TODO: check if each query is allowed minimum fair-share?
-        fairShare = 1;
+        fairShare = Query->AllowMinFairShare;
         poolOrQuery = Query.get();
     }
 

--- a/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
+++ b/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
@@ -16,11 +16,12 @@ TPool* TTreeElement::GetParent() const {
 // TQuery
 ///////////////////////////////////////////////////////////////////////////////
 
-TQuery::TQuery(const TQueryId& id, const TDelayParams* delayParams, const TStaticAttributes& attrs)
+TQuery::TQuery(const TQueryId& id, const TDelayParams* delayParams, bool allowMinFairShare, const TStaticAttributes& attrs)
     : NHdrf::TTreeElementBase<ETreeType::DYNAMIC>(id, attrs)
     , TTreeElement(id, attrs)
     , NHdrf::TQuery<ETreeType::DYNAMIC>(id, attrs)
     , DelayParams(delayParams)
+    , AllowMinFairShare(allowMinFairShare)
 {
 }
 

--- a/ydb/core/kqp/runtime/scheduler/tree/dynamic.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/dynamic.h
@@ -50,7 +50,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NDynamic {
     class TQuery : public TTreeElement, public NHdrf::TQuery<ETreeType::DYNAMIC>, public TSnapshotSwitch<NSnapshot::TQueryPtr>, public std::enable_shared_from_this<TQuery> {
     public:
         // TODO: pass delay params directly to actors from table_service_config
-        TQuery(const TQueryId& id, const TDelayParams* delayParams, const TStaticAttributes& attrs = {});
+        TQuery(const TQueryId& id, const TDelayParams* delayParams, bool allowMinFairShare, const TStaticAttributes& attrs = {});
 
         NSnapshot::TQuery* TakeSnapshot() override;
 
@@ -65,6 +65,8 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NDynamic {
 
         NMonitoring::THistogramPtr Delay; // TODO: hacky counter for delays from queries - initialize from pool
         const TDelayParams* const DelayParams; // owned by scheduler
+
+        const bool AllowMinFairShare; // tasks should look at this in case of missing snapshot
 
     private:
         // used to calculate adjusted satisfaction between snapshots

--- a/ydb/core/kqp/runtime/ut/ya.make
+++ b/ydb/core/kqp/runtime/ut/ya.make
@@ -7,6 +7,7 @@ SIZE(MEDIUM)
 SRCS(
     kqp_scan_data_ut.cpp
     kqp_scan_fetcher_ut.cpp
+    scheduler/kqp_compute_scheduler_service_ut.cpp
     scheduler/kqp_compute_scheduler_ut.cpp
 )
 
@@ -16,6 +17,7 @@ PEERDIR(
     library/cpp/testing/unittest
     ydb/core/kqp/common
     ydb/core/kqp/ut/common
+    ydb/core/kqp/workload_service/ut/common
     ydb/core/testlib/basics/pg
     yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/public/udf/service/exception_policy

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -223,7 +223,7 @@ public:
 
         TempTablesState.Database = Settings.Database;
         TempTablesState.TempDirName = TAppData::RandomProvider->GenUuid4().AsUuidString();
-        STLOG_D("Create session actor", 
+        STLOG_D("Create session actor",
             (ydb_session_id, *optSessionId),
             (temp_dir_name, TempTablesState.TempDirName),
             (trace_id, TraceId()));
@@ -275,7 +275,7 @@ public:
 
     void PassRequestToResourcePool() {
         if (QueryState->UserRequestContext->PoolConfig) {
-            STLOG_D("Request placed into pool from cache", 
+            STLOG_D("Request placed into pool from cache",
                 (pool_id, QueryState->UserRequestContext->PoolId),
                 (trace_id, TraceId()));
             CompileQuery();
@@ -342,7 +342,7 @@ public:
         STLOG_D("QueryRequest",
             (tx_control, txControl.DebugString()),
             (tx_ctx, (uintptr_t)txCtx.Get()),
-            (trace_id, TraceId()));    
+            (trace_id, TraceId()));
         if (!txCtx) {
             ReplyTransactionNotFound(txControl.tx_id());
             return;
@@ -383,7 +383,7 @@ public:
     }
 
     void HandleClientLost(NGRpcService::TEvClientLost::TPtr&) {
-        STLOG_D("Got ClientLost event, send AbortExecution to executer", 
+        STLOG_D("Got ClientLost event, send AbortExecution to executer",
             (executer_id, ExecuterId),
             (trace_id, TraceId()));
 
@@ -414,7 +414,7 @@ public:
             TString errMsg = issues.ToString();
             auto status = ev->Get()->GetYdbStatus();
 
-            STLOG_N("Got invalid query request, reply with error", 
+            STLOG_N("Got invalid query request, reply with error",
                 (status, status),
                 (error_msg, errMsg),
                 (trace_id, TraceId()));
@@ -445,16 +445,16 @@ public:
             action,
             QueryState->GetQuery());
 
-        STLOG_D("Received request", 
+        STLOG_D("Received request",
             (proxy_request_id, proxyRequestId),
             (prepared, QueryState->HasPreparedQuery()),
             (has_tx_control, QueryState->HasTxControl()),
             (action, action),
             (type, QueryState->GetType()),
-            (text, QueryState->GetQuery()), 
-            (rpc_actor, QueryState->RequestActorId), 
+            (text, QueryState->GetQuery()),
+            (rpc_actor, QueryState->RequestActorId),
             (database, QueryState->GetDatabase()),
-            (database_id, QueryState->UserRequestContext->DatabaseId), 
+            (database_id, QueryState->UserRequestContext->DatabaseId),
             (pool_id, QueryState->UserRequestContext->PoolId),
             (trace_id, TraceId()));
 
@@ -548,7 +548,7 @@ public:
             FillQueryIssues(ev->Get()->Issues);
         }
 
-        STLOG_D("Continue request", 
+        STLOG_D("Continue request",
             (pool_id, poolId),
             (trace_id, TraceId()));
 
@@ -1001,9 +1001,9 @@ public:
             QueryState->Orbit = std::move(response->Orbit);
         }
 
-        STLOG_T("Read snapshot result", 
-            (status, StatusForSnapshotError(response->Status)), 
-            (step, response->Snapshot.Step), 
+        STLOG_T("Read snapshot result",
+            (status, StatusForSnapshotError(response->Status)),
+            (step, response->Snapshot.Step),
             (tx_id, response->Snapshot.TxId),
             (trace_id, TraceId()));
         if (response->Status != NKikimrIssues::TStatusIds::SUCCESS) {
@@ -1035,8 +1035,8 @@ public:
         alloc->Alloc->SetLimit(mkqlInitialLimit);
         alloc->Alloc->Ref().SetIncreaseMemoryLimitCallback([this, &alloc, mkqlMaxLimit](ui64 currentLimit, ui64 required) {
             if (required < mkqlMaxLimit) {
-                STLOG_D("Increase memory limit", 
-                    (current_limit, currentLimit), 
+                STLOG_D("Increase memory limit",
+                    (current_limit, currentLimit),
                     (required, required),
                     (trace_id, TraceId()));
                 alloc->Alloc->SetLimit(required);
@@ -1610,7 +1610,7 @@ public:
 
         for (const auto& effect : txCtx.DeferredEffects) {
             request.Transactions.emplace_back(effect.PhysicalTx, effect.Params);
-            STLOG_D("TExecPhysicalRequest, add DeferredEffect to Transaction", 
+            STLOG_D("TExecPhysicalRequest, add DeferredEffect to Transaction",
                 (transactions_size, request.Transactions.size()),
                 (trace_id, TraceId()));
         }
@@ -1628,7 +1628,7 @@ public:
         for (const auto& effect : txCtx.DeferredEffects) {
             request.Transactions.emplace_back(effect.PhysicalTx, effect.Params);
 
-            STLOG_D("TExecPhysicalRequest, add DeferredEffect to Transaction", 
+            STLOG_D("TExecPhysicalRequest, add DeferredEffect to Transaction",
                 (transactions_size, request.Transactions.size()),
                 (trace_id, TraceId()));
         }
@@ -1696,7 +1696,7 @@ public:
 
         auto request = PrepareRequest(tx, literal, QueryState.get());
 
-        STLOG_D("ExecutePhyTx", 
+        STLOG_D("ExecutePhyTx",
             (literal, literal),
             (commit, commit),
             (deferred_effects_size, txCtx.DeferredEffects.Size()),
@@ -1746,7 +1746,7 @@ public:
             for (const auto& effect : txCtx.DeferredEffects) {
                 request.Transactions.emplace_back(effect.PhysicalTx, effect.Params);
 
-                STLOG_D("TExecPhysicalRequest, add DeferredEffect to Transaction", 
+                STLOG_D("TExecPhysicalRequest, add DeferredEffect to Transaction",
                     (transactions_size, request.Transactions.size()),
                     (trace_id, TraceId()));
             }
@@ -1864,7 +1864,7 @@ public:
         request.ResourceManager_ = ResourceManager_;
         request.SaveQueryPhysicalGraph = QueryState && QueryState->SaveQueryPhysicalGraph && request.Transactions.size() == 1 && !isRollback;
         request.QueryPhysicalGraph = QueryState && !isRollback ? QueryState->QueryPhysicalGraph : nullptr;
-        STLOG_D("Sending to Executer", 
+        STLOG_D("Sending to Executer",
             (span_id_size, request.TraceId.GetSpanIdSize()),
             (trace_id, TraceId()));
 
@@ -1893,7 +1893,7 @@ public:
             alloc->SetLimit(writeBufferInitialMemoryLimit);
             alloc->Ref().SetIncreaseMemoryLimitCallback([this, alloc=alloc.get(), writeBufferMemoryLimit](ui64 currentLimit, ui64 required) {
                 if (required < writeBufferMemoryLimit) {
-                    STLOG_D("Increase memory limit", 
+                    STLOG_D("Increase memory limit",
                         (current_limit, currentLimit),
                         (required, required),
                         (trace_id, TraceId()));
@@ -1933,7 +1933,7 @@ public:
             llvmSettings, QueryServiceConfig, QueryState ? QueryState->Generation : 0, ChannelService);
 
         auto exId = RegisterWithSameMailbox(executerActor);
-        STLOG_D("Created new KQP executer", 
+        STLOG_D("Created new KQP executer",
             (executer_id, exId),
             (is_rollback, isRollback),
             (trace_id, TraceId()));
@@ -2009,7 +2009,7 @@ public:
         auto executerActor = CreateKqpPartitionedExecuter(std::move(settings), ChannelService);
 
         ExecuterId = RegisterWithSameMailbox(executerActor);
-        STLOG_D("Created new KQP partitioned executer", 
+        STLOG_D("Created new KQP partitioned executer",
             (executer_id, ExecuterId),
             (trace_id, TraceId()));
     }
@@ -2144,7 +2144,7 @@ public:
 
     void FillQueryIssues(const NYql::TIssues& issues) {
         if (!QueryState) {
-            STLOG_W("Try to put issues into empty QueryState", 
+            STLOG_W("Try to put issues into empty QueryState",
                 (issues, issues.ToOneLineString()),
                 (trace_id, TraceId())
             );
@@ -2164,7 +2164,7 @@ public:
 
         auto* response = ev->Record.MutableResponse();
 
-        STLOG_D("TEvTxResponse", 
+        STLOG_D("TEvTxResponse",
             (current_tx, QueryState->CurrentTx),
             (transactions_size, QueryState->PreparedQuery ? QueryState->PreparedQuery->GetPhysicalQuery().TransactionsSize() : 0),
             (status, response->GetStatus()),
@@ -2192,7 +2192,7 @@ public:
         if (response->GetStatus() != Ydb::StatusIds::SUCCESS) {
             const auto executionType = ev->ExecutionType;
 
-            STLOG_D("TEvTxResponse has non-success status", 
+            STLOG_D("TEvTxResponse has non-success status",
                 (current_tx, QueryState->CurrentTx),
                 (execution_type, executionType),
                 (status, response->GetStatus()),
@@ -2289,7 +2289,7 @@ public:
     void HandleExecute(TEvKqp::TEvAbortExecution::TPtr& ev) {
         auto& msg = ev->Get()->Record;
 
-        STLOG_I("Got TEvAbortExecution, send it to Executer", 
+        STLOG_I("Got TEvAbortExecution, send it to Executer",
             (status_code, NYql::NDqProto::StatusIds_StatusCode_Name(msg.GetStatusCode())),
             (executer_id, ExecuterId),
             (trace_id, TraceId()));
@@ -2470,7 +2470,7 @@ public:
 
         if (QueryState->TxCtx) {
             auto txInfo = QueryState->TxCtx->GetInfo();
-            STLOG_I("TxInfo", 
+            STLOG_I("TxInfo",
                 (status, txInfo.Status),
                 (kind, txInfo.Kind),
                 (total_duration, txInfo.TotalDuration.SecondsFloat()*1e3),
@@ -2481,7 +2481,18 @@ public:
         }
     }
 
-    void UpdateQueryExecutionCountes() {
+    void FillPoolId(NKikimrKqp::TQueryResponse* response) {
+        YQL_ENSURE(QueryState);
+        if (QueryState->UserRequestContext) {
+            if (QueryState->UserRequestContext->PoolId.empty()) {
+                response->SetEffectivePoolId(NResourcePool::DEFAULT_POOL_ID);
+            } else {
+                response->SetEffectivePoolId(QueryState->UserRequestContext->PoolId);
+            }
+        }
+    }
+
+    void UpdateQueryExecutionCounters() {
         auto now = TInstant::Now();
         auto queryDuration = now - QueryState->StartTime;
 
@@ -2546,8 +2557,9 @@ public:
         }
 
         FillTxInfo(response);
+        FillPoolId(response);
 
-        UpdateQueryExecutionCountes();
+        UpdateQueryExecutionCounters();
 
         bool replyQueryId = false;
         bool replyQueryParameters = false;
@@ -2635,10 +2647,10 @@ public:
             }
         }
 
-            resEv->Record.SetYdbStatus(Ydb::StatusIds::SUCCESS);
-            STLOG_D("Create QueryResponse for action with SUCCESS status", 
-                (action, QueryState->GetAction()),
-                (trace_id, TraceId()));
+        resEv->Record.SetYdbStatus(Ydb::StatusIds::SUCCESS);
+        STLOG_D("Create QueryResponse for action with SUCCESS status",
+            (action, QueryState->GetAction()),
+            (trace_id, TraceId()));
 
         QueryResponse = std::move(resEv);
 
@@ -2684,7 +2696,9 @@ public:
         }
 
         auto* record = &QueryResponse->Record;
-        FillTxInfo(record->MutableResponse());
+        auto* response = record->MutableResponse();
+        FillTxInfo(response);
+        FillPoolId(response);
         record->SetConsumedRu(1);
 
         Cleanup(IsFatalError(record->GetYdbStatus()));
@@ -2704,7 +2718,8 @@ public:
             Transactions.AddToBeAborted(std::move(ctx));
         }
 
-        FillTxInfo(record.MutableResponse());
+        FillTxInfo(&response);
+        FillPoolId(&response);
 
         Cleanup(false);
     }
@@ -2749,7 +2764,8 @@ public:
             Transactions.AddToBeAborted(std::move(ctx));
         }
 
-        FillTxInfo(record.MutableResponse());
+        FillTxInfo(&response);
+        FillPoolId(&response);
 
         Cleanup(false);
     }
@@ -2768,7 +2784,8 @@ public:
             Transactions.AddToBeAborted(std::move(ctx));
         }
 
-        FillTxInfo(record.MutableResponse());
+        FillTxInfo(&response);
+        FillPoolId(&response);
 
         Cleanup(false);
     }
@@ -2831,13 +2848,13 @@ public:
         );
 
         Send<ESendingType::Tail>(QueryState->Sender, QueryResponse.release(), 0, QueryState->ProxyRequestId);
-        STLOG_D("Sent query response back to proxy", 
+        STLOG_D("Sent query response back to proxy",
             (proxy_request_id, QueryState->ProxyRequestId),
             (proxy_id, QueryState->Sender.ToString()),
             (trace_id, TraceId()));
 
         if (IsFatalError(status)) {
-            STLOG_N("SessionActor destroyed", 
+            STLOG_N("SessionActor destroyed",
             (status, status),
             (trace_id, TraceId()));
             Counters->ReportSessionActorClosedError(Settings.DbCounters);
@@ -3036,7 +3053,7 @@ public:
             }
         }
 
-        STLOG_I("Cleanup start", 
+        STLOG_I("Cleanup start",
             (is_final, isFinal),
             (has_cleanup_ctx, bool{CleanupCtx}),
             (transactions_to_be_aborted_size, CleanupCtx ? CleanupCtx->TransactionsToBeAborted.size() : 0),
@@ -3105,7 +3122,7 @@ public:
         CleanupCtx->IsWaitingForWorkloadServiceCleanup = false;
 
         if (ev->Get()->Status != Ydb::StatusIds::SUCCESS && ev->Get()->Status != Ydb::StatusIds::NOT_FOUND) {
-            STLOG_E("Failed to cleanup workload service", 
+            STLOG_E("Failed to cleanup workload service",
                 (status, ev->Get()->Status),
                 (issues, ev->Get()->Issues.ToOneLineString()),
                 (trace_id, TraceId()));
@@ -3117,7 +3134,7 @@ public:
     }
 
     void EndCleanup(bool isFinal) {
-        STLOG_D("EndCleanup", 
+        STLOG_D("EndCleanup",
             (is_final, isFinal),
             (trace_id, TraceId()));
 
@@ -3131,7 +3148,7 @@ public:
             auto userToken = QueryState ? QueryState->UserToken : TIntrusiveConstPtr<NACLib::TUserToken>();
             Become(&TKqpSessionActor::FinalCleanupState);
 
-            STLOG_D("Cleanup temp tables", 
+            STLOG_D("Cleanup temp tables",
                 (temp_tables_size, TempTablesState.TempTables.size()),
                 (trace_id, TraceId()));
             auto tempTablesManager = CreateKqpTempTablesManager(
@@ -3197,6 +3214,7 @@ public:
         }
 
         FillTxInfo(response);
+        FillPoolId(response);
 
         ExecuterId = TActorId{};
         Cleanup(IsFatalError(ydbStatus));

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -72,6 +72,7 @@ struct TYdbSetupSettings {
     FLUENT_SETTING_DEFAULT(TString, DomainName, "Root");
     FLUENT_SETTING_DEFAULT(bool, CreateSampleTenants, false);
     FLUENT_SETTING_DEFAULT(bool, EnableResourcePools, true);
+    FLUENT_SETTING_DEFAULT(bool, EnableResourcePoolsScheduler, true);
     FLUENT_SETTING_DEFAULT(bool, EnableResourcePoolsOnServerless, false);
     FLUENT_SETTING_DEFAULT(bool, EnableMetadataObjectsOnServerless, true);
     FLUENT_SETTING_DEFAULT(bool, EnableExternalDataSourcesOnServerless, true);
@@ -116,6 +117,7 @@ public:
     virtual NActors::TActorId CreateInFlightCoordinator(ui32 numberRequests, ui32 expectedInFlight) const = 0;
 
     // Pools actions
+    virtual void CreateResourcePool(const TString& poolId, const NResourcePool::TPoolSettings& settings) const = 0;
     virtual void CreateSamplePoolOn(const TString& databaseId) const = 0;
     virtual TPoolStateDescription GetPoolDescription(TDuration leaseDuration = FUTURE_WAIT_TIMEOUT, const TString& poolId = "") const = 0;
     virtual void WaitPoolState(const TPoolStateDescription& state, const TString& poolId = "") const = 0;

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -160,6 +160,7 @@ struct TSampleQueries {
     static void CheckNotFound(const TResult& result, const TString& poolId) {
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::NOT_FOUND, result.GetIssues().ToString());
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), TStringBuilder() << "Resource pool " << poolId << " not found or you don't have access permissions");
+        UNIT_ASSERT_UNEQUAL(result.Response.GetResponse().GetEffectivePoolId(), poolId);
     }
 
     struct TSelect42 {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -160,7 +160,6 @@ struct TSampleQueries {
     static void CheckNotFound(const TResult& result, const TString& poolId) {
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::NOT_FOUND, result.GetIssues().ToString());
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), TStringBuilder() << "Resource pool " << poolId << " not found or you don't have access permissions");
-        UNIT_ASSERT_UNEQUAL(result.Response.GetResponse().GetEffectivePoolId(), poolId);
     }
 
     struct TSelect42 {

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -45,7 +45,10 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
             .EnableResourcePools(false)
             .Create();
 
-        TSampleQueries::TSelect42::CheckResult(ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, TQueryRunnerSettings().PoolId("another_pool_id")));
+        const auto& result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, TQueryRunnerSettings().PoolId("another_pool_id"));
+        const auto& resultPoolId = result.Response.GetResponse().GetEffectivePoolId();
+        UNIT_ASSERT_EQUAL_C(resultPoolId, NResourcePool::DEFAULT_POOL_ID, resultPoolId);
+        TSampleQueries::TSelect42::CheckResult(result);
     }
 
     Y_UNIT_TEST(WorkloadServiceDisabledByFeatureFlagOnServerless) {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -247,4 +247,5 @@ message TFeatureFlags {
     optional bool EnableIndexMaterialization = 221 [default = false];
     optional bool EnableFsBackups = 222 [default = false];
     optional bool EnableCmsLocksPriority = 223 [default = false];
+    optional bool EnableResourcePoolsScheduler = 224 [default = true]; // works only with EnableResourcePools = true
 }

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -278,9 +278,8 @@ message TQueryResponseExtraInfo {
 message TQueryResponse {
     optional bytes SessionId = 1;
     reserved 2; // (deprecated) QueryErrors
-    // repeated NKikimrMiniKQL.TResult Results = 3;
-    // optional TQueryProfile Profile = 4; // TODO: Deprecate, use QueryStats
-    reserved 4;
+    reserved 3; // (deprecated) repeated NKikimrMiniKQL.TResult Results = 3
+    reserved 4; // (deprecated) optional TQueryProfile Profile = 4
     optional bytes PreparedQuery = 5;
     optional string QueryAst = 6;
     reserved 7;
@@ -293,6 +292,7 @@ message TQueryResponse {
     optional TTopicOperationsResponse TopicOperations = 14;
     optional string QueryDiagnostics = 15;
     optional TQueryResponseExtraInfo ExtraInfo = 16;
+    optional string EffectivePoolId = 17;
 }
 
 message TEvQueryResponse {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow to enable/disable CPU Scheduler in runtime with enabled Workload Manager. Enabled by default.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Also introduce EffectivePoolId in the query response message
