### PR TITLE
List import/export/index build operations by start time (fix #29586)

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4465,10 +4465,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         exportInfo->ExportMetadata = rowset.GetValue<Schema::Exports::ExportMetadata>();
                     }
 
-                    Self->Exports[id] = exportInfo;
-                    if (uid) {
-                        Self->ExportsByUid[uid] = exportInfo;
-                    }
+                    Self->AddExport(exportInfo);
 
                     if (exportInfo->WaitTxId != InvalidTxId) {
                         Self->TxIdToExport[exportInfo->WaitTxId] = {id, Max<ui32>()};
@@ -4562,10 +4559,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     importInfo->StartTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Imports::StartTime>());
                     importInfo->EndTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Imports::EndTime>());
 
-                    Self->Imports[id] = importInfo;
-                    if (uid) {
-                        Self->ImportsByUid[uid] = importInfo;
-                    }
+                    Self->AddImport(importInfo);
 
                     switch (importInfo->State) {
                     case TImportInfo::EState::DownloadExportMetadata:
@@ -4740,13 +4734,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     }
 
                     // Note: broken build are also added to IndexBuilds
-                    Y_ASSERT(!Self->IndexBuilds.contains(buildInfo->Id));
-                    Self->IndexBuilds[buildInfo->Id] = buildInfo;
-
-                    if (buildInfo->Uid) {
-                        Y_ASSERT(!Self->IndexBuildsByUid.contains(buildInfo->Uid));
-                        Self->IndexBuildsByUid[buildInfo->Uid] = buildInfo;
-                    }
+                    Self->AddIndexBuild(buildInfo);
 
                     OnComplete.ToProgress(buildInfo->Id);
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -207,13 +207,7 @@ public:
         buildInfo->State = TIndexBuildInfo::EState::Locking;
 
         Self->PersistBuildIndexState(db, *buildInfo);
-
-        auto [it, emplaced] = Self->IndexBuilds.emplace(BuildId, buildInfo);
-        Y_ASSERT(emplaced);
-        if (uid) {
-            std::tie(std::ignore, emplaced) = Self->IndexBuildsByUid.emplace(uid, buildInfo);
-            Y_ASSERT(emplaced);
-        }
+        Self->AddIndexBuild(buildInfo);
 
         Progress(BuildId);
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__list.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__list.cpp
@@ -42,12 +42,12 @@ public:
         page = Max(page, DefaultPage);
         const ui64 pageSize = Min(record.GetPageSize() ? Max(record.GetPageSize(), MinPageSize) : DefaultPageSize, MaxPageSize);
 
-
-        auto it = Self->IndexBuilds.end();
+        auto it = Self->IndexBuildsByTime.end();
         ui64 skip = (page - 1) * pageSize;
-        while ((it != Self->IndexBuilds.begin()) && skip) {
+        while ((it != Self->IndexBuildsByTime.begin()) && skip) {
             --it;
-            if (it->second->DomainPathId == domainPathId) {
+            auto buildInfo = Self->IndexBuilds.at(it->second);
+            if (buildInfo->DomainPathId == domainPathId) {
                 --skip;
             }
         }
@@ -56,15 +56,16 @@ public:
         respRecord.SetStatus(Ydb::StatusIds::SUCCESS);
 
         ui64 size = 0;
-        while ((it != Self->IndexBuilds.begin()) && size < pageSize) {
+        while ((it != Self->IndexBuildsByTime.begin()) && size < pageSize) {
             --it;
-            if (it->second->DomainPathId == domainPathId) {
-                Fill(*respRecord.MutableEntries()->Add(), *it->second);
+            auto buildInfo = Self->IndexBuilds.at(it->second);
+            if (buildInfo->DomainPathId == domainPathId) {
+                Fill(*respRecord.MutableEntries()->Add(), *buildInfo);
                 ++size;
             }
         }
 
-        if (it == Self->IndexBuilds.begin()) {
+        if (it == Self->IndexBuildsByTime.begin()) {
             respRecord.SetNextPageToken("0");
         } else {
             respRecord.SetNextPageToken(ToString(page + 1));

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -345,6 +345,17 @@ void TSchemeShard::TIndexBuilder::TTxBase::SendNotificationsIfFinished(TIndexBui
     }
 }
 
+void TSchemeShard::AddIndexBuild(const std::shared_ptr<TIndexBuildInfo>& buildInfo) {
+    Y_ASSERT(!IndexBuilds.contains(buildInfo->Id));
+    IndexBuilds[buildInfo->Id] = buildInfo;
+    IndexBuildsByTime.emplace(buildInfo->StartTime, buildInfo->Id);
+
+    if (buildInfo->Uid) {
+        Y_ASSERT(!IndexBuildsByUid.contains(buildInfo->Uid));
+        IndexBuildsByUid[buildInfo->Uid] = buildInfo;
+    }
+}
+
 void TSchemeShard::TIndexBuilder::TTxBase::EraseBuildInfo(const TIndexBuildInfo& indexBuildInfo) {
     Self->TxIdToIndexBuilds.erase(indexBuildInfo.LockTxId);
     Self->TxIdToIndexBuilds.erase(indexBuildInfo.InitiateTxId);
@@ -354,6 +365,7 @@ void TSchemeShard::TIndexBuilder::TTxBase::EraseBuildInfo(const TIndexBuildInfo&
     Self->TxIdToIndexBuilds.erase(indexBuildInfo.DropColumnsTxId);
 
     Self->IndexBuildsByUid.erase(indexBuildInfo.Uid);
+    Self->IndexBuildsByTime.erase(std::make_pair(indexBuildInfo.StartTime, indexBuildInfo.Id));
     Self->IndexBuilds.erase(indexBuildInfo.Id);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_export.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export.cpp
@@ -182,7 +182,21 @@ void TSchemeShard::PersistCreateExport(NIceDb::TNiceDb& db, const TExportInfo& e
     }
 }
 
+void TSchemeShard::AddExport(const TExportInfo::TPtr& exportInfo) {
+    Exports[exportInfo->Id] = exportInfo;
+    ExportsByTime.emplace(exportInfo->StartTime, exportInfo->Id);
+    if (exportInfo->Uid) {
+        ExportsByUid[exportInfo->Uid] = exportInfo;
+    }
+}
+
 void TSchemeShard::PersistRemoveExport(NIceDb::TNiceDb& db, const TExportInfo& exportInfo) {
+    if (exportInfo.Uid) {
+        ExportsByUid.erase(exportInfo.Uid);
+    }
+    ExportsByTime.erase(std::make_pair(exportInfo.StartTime, exportInfo.Id));
+    Exports.erase(exportInfo.Id);
+
     for (ui32 itemIdx : xrange(exportInfo.Items.size())) {
         db.Table<Schema::ExportItems>().Key(exportInfo.Id, itemIdx).Delete();
     }

--- a/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
@@ -207,11 +207,7 @@ struct TSchemeShard::TExport::TTxCreate: public TSchemeShard::TXxport::TTxBase {
         exportInfo->StartTime = TAppData::TimeProvider->Now();
         Self->PersistExportState(db, *exportInfo);
 
-        Self->Exports[id] = exportInfo;
-        if (uid) {
-            Self->ExportsByUid[uid] = exportInfo;
-        }
-
+        Self->AddExport(exportInfo);
         Self->FromXxportInfo(*response->Record.MutableResponse()->MutableEntry(), *exportInfo);
 
         Progress = true;
@@ -1495,11 +1491,6 @@ private:
                     return EndExport(exportInfo, EState::Done, db);
                 }
 
-                if (exportInfo->Uid) {
-                    Self->ExportsByUid.erase(exportInfo->Uid);
-                }
-
-                Self->Exports.erase(exportInfo->Id);
                 Self->PersistRemoveExport(db, *exportInfo);
             }
             return;

--- a/ydb/core/tx/schemeshard/schemeshard_export__forget.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__forget.cpp
@@ -67,11 +67,6 @@ struct TSchemeShard::TExport::TTxForget: public TSchemeShard::TXxport::TTxBase {
         if (!exportPath.IsResolved()) {
             SendNotificationsIfFinished(exportInfo, true); // for tests
 
-            if (exportInfo->Uid) {
-                Self->ExportsByUid.erase(exportInfo->Uid);
-            }
-
-            Self->Exports.erase(exportInfo->Id);
             Self->PersistRemoveExport(db, *exportInfo);
         } else {
             LOG_D("TExport::TTxForget, dropping export tables"

--- a/ydb/core/tx/schemeshard/schemeshard_export__list.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__list.cpp
@@ -31,7 +31,7 @@ struct TSchemeShard::TExport::TTxList: public TSchemeShard::TXxport::TTxList<
     }
 
     bool DoExecute(TTransactionContext& txc, const TActorContext& ctx) override {
-        return DoExecuteImpl(Self->Exports, txc, ctx);
+        return DoExecuteImpl(Self->Exports, Self->ExportsByTime, txc, ctx);
     }
 
 }; // TTxList

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1353,8 +1353,9 @@ public:
     // } // NLongRunningCommon
 
     // namespace NExport {
-    TMap<ui64, TExportInfo::TPtr> Exports;
+    THashMap<ui64, TExportInfo::TPtr> Exports;
     THashMap<TString, TExportInfo::TPtr> ExportsByUid;
+    TSet<std::pair<TInstant, ui64>> ExportsByTime;
     THashMap<TTxId, std::pair<ui64, ui32>> TxIdToExport;
     THashMap<TTxId, THashSet<ui64>> TxIdToDependentExport;
     // This set is needed to kill all the running scheme uploaders on SchemeShard death.
@@ -1364,9 +1365,10 @@ public:
     THashMap<TTxId, ui64> TxIdToIncrementalRestore;
 
     void FromXxportInfo(NKikimrExport::TExport& exprt, const TExportInfo& exportInfo);
+    void AddExport(const TExportInfo::TPtr& exportInfo);
 
     static void PersistCreateExport(NIceDb::TNiceDb& db, const TExportInfo& exportInfo);
-    static void PersistRemoveExport(NIceDb::TNiceDb& db, const TExportInfo& exportInfo);
+    void PersistRemoveExport(NIceDb::TNiceDb& db, const TExportInfo& exportInfo);
     static void PersistExportPathId(NIceDb::TNiceDb& db, const TExportInfo& exportInfo);
     static void PersistExportState(NIceDb::TNiceDb& db, const TExportInfo& exportInfo);
     static void PersistExportMetadata(NIceDb::TNiceDb& db, const TExportInfo& exportInfo);
@@ -1410,18 +1412,20 @@ public:
     // } // NExport
 
     // namespace NImport {
-    TMap<ui64, TImportInfo::TPtr> Imports;
+    THashMap<ui64, TImportInfo::TPtr> Imports;
     THashMap<TString, TImportInfo::TPtr> ImportsByUid;
+    TSet<std::pair<TInstant, ui64>> ImportsByTime;
     THashMap<TTxId, std::pair<ui64, ui32>> TxIdToImport;
     THashSet<TActorId> RunningImportSchemeGetters;
     THashSet<TActorId> RunningImportSchemeQueryExecutors;
 
     void FromXxportInfo(NKikimrImport::TImport& exprt, const TImportInfo& importInfo);
+    void AddImport(const TImportInfo::TPtr& importInfo);
 
     static void PersistCreateImport(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
     static void PersistNewImportItem(NIceDb::TNiceDb& db, const TImportInfo& importInfo, ui32 itemIdx);
     static void PersistSchemaMappingImportFields(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
-    static void PersistRemoveImport(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
+    void PersistRemoveImport(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
     static void PersistImportState(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
     static void PersistImportItemState(NIceDb::TNiceDb& db, const TImportInfo& importInfo, ui32 itemIdx);
     static void PersistImportItemScheme(NIceDb::TNiceDb& db, const TImportInfo& importInfo, ui32 itemIdx);
@@ -1528,13 +1532,16 @@ public:
     // namespace NIndexBuilder {
     TControlWrapper AllowDataColumnForIndexTable;
 
-    TMap<TIndexBuildId, std::shared_ptr<TIndexBuildInfo>> IndexBuilds;
+    THashMap<TIndexBuildId, std::shared_ptr<TIndexBuildInfo>> IndexBuilds;
     THashMap<TString, std::shared_ptr<TIndexBuildInfo>> IndexBuildsByUid;
+    TSet<std::pair<TInstant, TIndexBuildId>> IndexBuildsByTime;
     THashMap<TTxId, TIndexBuildId> TxIdToIndexBuilds;
 
     // do not share pipes with operations
     // also do not share pipes between IndexBuilds
     TDedicatedPipePool<TIndexBuildId> IndexBuildPipes;
+
+    void AddIndexBuild(const std::shared_ptr<TIndexBuildInfo>& indexInfo);
 
     void PersistCreateBuildIndex(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexState(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -292,7 +292,21 @@ void TSchemeShard::PersistSchemaMappingImportFields(NIceDb::TNiceDb& db, const T
     }
 }
 
+void TSchemeShard::AddImport(const TImportInfo::TPtr& importInfo) {
+    Imports[importInfo->Id] = importInfo;
+    ImportsByTime.emplace(importInfo->StartTime, importInfo->Id);
+    if (importInfo->Uid) {
+        ImportsByUid[importInfo->Uid] = importInfo;
+    }
+}
+
 void TSchemeShard::PersistRemoveImport(NIceDb::TNiceDb& db, const TImportInfo& importInfo) {
+    if (importInfo.Uid) {
+        ImportsByUid.erase(importInfo.Uid);
+    }
+    ImportsByTime.erase(std::make_pair(importInfo.StartTime, importInfo.Id));
+    Imports.erase(importInfo.Id);
+
     for (ui32 itemIdx : xrange(importInfo.Items.size())) {
         db.Table<Schema::ImportItems>().Key(importInfo.Id, itemIdx).Delete();
     }

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -281,11 +281,7 @@ struct TSchemeShard::TImport::TTxCreate: public TSchemeShard::TXxport::TTxBase {
         importInfo->StartTime = TAppData::TimeProvider->Now();
         Self->PersistImportState(db, *importInfo);
 
-        Self->Imports[id] = importInfo;
-        if (uid) {
-            Self->ImportsByUid[uid] = importInfo;
-        }
-
+        Self->AddImport(importInfo);
         Self->FromXxportInfo(*response->Record.MutableResponse()->MutableEntry(), *importInfo);
 
         Progress = true;

--- a/ydb/core/tx/schemeshard/schemeshard_import__forget.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__forget.cpp
@@ -53,8 +53,6 @@ struct TSchemeShard::TImport::TTxForget: public TSchemeShard::TXxport::TTxBase {
         switch (importInfo->State) {
         case TImportInfo::EState::Done:
         case TImportInfo::EState::Cancelled:
-            Self->ImportsByUid.erase(importInfo->Uid);
-            Self->Imports.erase(importInfo->Id);
             Self->PersistRemoveImport(db, *importInfo);
             return respond(Ydb::StatusIds::SUCCESS);
 

--- a/ydb/core/tx/schemeshard/schemeshard_import__list.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__list.cpp
@@ -31,7 +31,7 @@ struct TSchemeShard::TImport::TTxList: public TSchemeShard::TXxport::TTxList<
     }
 
     bool DoExecute(TTransactionContext& txc, const TActorContext& ctx) override {
-        return DoExecuteImpl(Self->Imports, txc, ctx);
+        return DoExecuteImpl(Self->Imports, Self->ImportsByTime, txc, ctx);
     }
 
 }; // TTxList

--- a/ydb/core/tx/schemeshard/schemeshard_xxport__get.h
+++ b/ydb/core/tx/schemeshard/schemeshard_xxport__get.h
@@ -20,7 +20,7 @@ struct TSchemeShard::TXxport::TTxGet: public TSchemeShard::TXxport::TTxBase {
     {
     }
 
-    bool DoExecuteImpl(const TMap<ui64, typename TInfo::TPtr>& container, TTransactionContext&, const TActorContext&) {
+    bool DoExecuteImpl(const THashMap<ui64, typename TInfo::TPtr>& container, TTransactionContext&, const TActorContext&) {
         const auto& request = Request->Get()->Record;
 
         auto response = MakeHolder<TEvResponse>();


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Previous version listed them in descending ID order. But it seems that ID = txId and they don't always monotonically increase.