### PR TITLE
return an empty CloudId/FolderId if the folder service answered with an empty result

### DIFF
--- a/ydb/library/testlib/service_mocks/folder_service_mock.h
+++ b/ydb/library/testlib/service_mocks/folder_service_mock.h
@@ -5,12 +5,16 @@
 class TFolderServiceMock : public yandex::cloud::priv::resourcemanager::v1::FolderService::Service {
 public:
     THashMap<TString, yandex::cloud::priv::resourcemanager::v1::ResolvedFolder> Folders;
+    THashSet<TString> NoAnswerFolders;
 
     virtual grpc::Status Resolve(
             grpc::ServerContext*,
             const yandex::cloud::priv::resourcemanager::v1::ResolveFoldersRequest* request,
             yandex::cloud::priv::resourcemanager::v1::ResolveFoldersResponse* response) override {
         TString key = request->folder_ids(0);
+        if (NoAnswerFolders.contains(key)) {
+            return grpc::Status::OK;
+        }
         auto it = Folders.find(key);
         if (it != Folders.end()) {
             response->add_resolved_folders()->CopyFrom(it->second);
@@ -20,4 +24,3 @@ public:
         }
     }
 };
-

--- a/ydb/library/ycloud/impl/folder_service_adapter.cpp
+++ b/ydb/library/ycloud/impl/folder_service_adapter.cpp
@@ -63,8 +63,11 @@ class TFolderServiceRequestHandler: public NActors::TActor<TFolderServiceRequest
 
         responseEvent->Status = status;
         if (status.Ok()) {
-            responseEvent->CloudId = ev->Get()->Response.resolved_folders(0).cloud_id();
-            responseEvent->FolderId = ev->Get()->Response.resolved_folders(0).id();
+            const auto& resolvedFolders = ev->Get()->Response.resolved_folders();
+            if (resolvedFolders.size() > 0) {
+                responseEvent->CloudId = resolvedFolders[0].cloud_id();
+                responseEvent->FolderId = resolvedFolders[0].id();
+            }
         }
 
         Send(Sender, responseEvent.release());
@@ -160,7 +163,7 @@ public:
     void Bootstrap() {
         if (Config.HasResourceManagerEndpoint() && !Config.GetResourceManagerEndpoint().empty()) {
             RegisterFolderService();
-        }   
+        }
         else {
             RegisterTransitionalFolderService();
         }


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10224
