### PR TITLE
External Table export to S3

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
@@ -43,6 +43,7 @@ bool IsPathTypeSchemeObject(const NKikimr::NSchemeShard::TExportInfo::TItem& ite
     case NKikimrSchemeOp::EPathTypeReplication:
     case NKikimrSchemeOp::EPathTypeTransfer:
     case NKikimrSchemeOp::EPathTypeExternalDataSource:
+    case NKikimrSchemeOp::EPathTypeExternalTable:
         return true;
     default:
         return false;

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -970,6 +970,7 @@ bool CheckAvailableInExports(NKikimrSchemeOp::EPathType pathType) {
         case NKikimrSchemeOp::EPathTypeReplication:
         case NKikimrSchemeOp::EPathTypeTransfer:
         case NKikimrSchemeOp::EPathTypeExternalDataSource:
+        case NKikimrSchemeOp::EPathTypeExternalTable:
             return true;
         default:
             return false;

--- a/ydb/core/tx/schemeshard/schemeshard_scheme_builders.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_scheme_builders.cpp
@@ -166,7 +166,7 @@ bool BuildExternalTableScheme(
 {
     const auto& pathDesc = describeResult.GetPathDescription();
     if (!pathDesc.HasExternalTableDescription()) {
-        error = "Path description does not contain a description of external data source";
+        error = "Path description does not contain a description of external table";
         return false;
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_scheme_builders.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_scheme_builders.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>
 #include <ydb/core/ydb_convert/external_data_source_description.h>
+#include <ydb/core/ydb_convert/external_table_description.h>
 #include <ydb/core/ydb_convert/replication_description.h>
 #include <ydb/core/ydb_convert/topic_description.h>
 
@@ -11,6 +12,7 @@
 #include <ydb/public/api/protos/ydb_table.pb.h>
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <ydb/public/lib/ydb_cli/dump/util/external_data_source_utils.h>
+#include <ydb/public/lib/ydb_cli/dump/util/external_table_utils.h>
 #include <ydb/public/lib/ydb_cli/dump/util/replication_utils.h>
 #include <ydb/public/lib/ydb_cli/dump/util/view_utils.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_replication.h>
@@ -157,6 +159,30 @@ bool BuildExternalDataSourceScheme(
     return true;
 }
 
+bool BuildExternalTableScheme(
+    const NKikimrScheme::TEvDescribeSchemeResult& describeResult,
+    TString& scheme,
+    TString& error)
+{
+    const auto& pathDesc = describeResult.GetPathDescription();
+    if (!pathDesc.HasExternalTableDescription()) {
+        error = "Path description does not contain a description of external data source";
+        return false;
+    }
+
+    const auto& externalTableDesc = pathDesc.GetExternalTableDescription();
+    Ydb::Table::DescribeExternalTableResult externalTableDescResult;
+    Ydb::StatusIds::StatusCode status;
+
+    if (!FillExternalTableDescription(externalTableDescResult, externalTableDesc, pathDesc.GetSelf(), status, error)) {
+        return false;
+    }
+
+    scheme = NYdb::NDump::BuildCreateExternalTableQuery(externalTableDescResult);
+
+    return true;
+}
+
 bool BuildScheme(
     const NKikimrScheme::TEvDescribeSchemeResult& describeResult,
     TString& scheme,
@@ -176,6 +202,8 @@ bool BuildScheme(
             return BuildTransferScheme(describeResult, scheme, databaseRoot, databaseRoot, error);
         case NKikimrSchemeOp::EPathTypeExternalDataSource:
             return BuildExternalDataSourceScheme(describeResult, scheme, databaseRoot, error);
+        case NKikimrSchemeOp::EPathTypeExternalTable:
+            return BuildExternalTableScheme(describeResult, scheme, error);
         default:
             error = TStringBuilder() << "unsupported path type: " << pathType;
             return false;

--- a/ydb/core/tx/schemeshard/schemeshard_xxport__helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_xxport__helpers.cpp
@@ -47,6 +47,7 @@ const TVector<XxportProperties>& GetXxportProperties() {
         {NYdb::NDump::NFiles::CreateAsyncReplication().FileName, NBackup::EBackupFileType::AsyncReplicationCreate, NKikimrSchemeOp::EPathType::EPathTypeReplication},
         {NYdb::NDump::NFiles::CreateTransfer().FileName, NBackup::EBackupFileType::TransferCreate, NKikimrSchemeOp::EPathType::EPathTypeTransfer},
         {NYdb::NDump::NFiles::CreateExternalDataSource().FileName, NBackup::EBackupFileType::ExternalDataSourceCreate, NKikimrSchemeOp::EPathType::EPathTypeExternalDataSource},
+        {NYdb::NDump::NFiles::CreateExternalTable().FileName, NBackup::EBackupFileType::ExternalTableCreate, NKikimrSchemeOp::EPathType::EPathTypeExternalTable},
     };
 
     return properties;

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -893,14 +893,14 @@ namespace {
                 TStringBuilder() << "\nExpected query to start with:\n\n"
                     << expectedStartsWith << "\n\nActual query:\n\n" << content);
 
-			// Check if all expected properties are presented
+            // Check if all expected properties are presented
             for (const auto& property : expectedProperties) {
                 UNIT_ASSERT_C(content.find(property) != TString::npos,
                     TStringBuilder() << "Property not found:\n"
                     << "\nExpected property:\n\n" << property << "\n\nActual query:\n\n" << content);
             }
 
-			// Check if no other properties are presented
+            // Check if no other properties are presented
             UNIT_ASSERT_EQUAL_C(
                 std::ranges::count(content, '='),
                 static_cast<long>(expectedProperties.size()),

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -843,6 +843,77 @@ namespace {
                 TStringBuilder() << "\nExpected:\n\n" << permissions_expected << "\n\nActual:\n\n" << permissions);
         }
 
+        void TestExternalTable(
+            const TString& scheme,
+            const TString& expectedStartsWith,
+            const TVector<TString>& expectedProperties)
+        {
+            Env();
+            ui64 txId = 100;
+
+            const auto dataSourceScheme = R"(
+                Name: "DataSource"
+                SourceType: "ObjectStorage"
+                Location: "https://s3.cloud.net/bucket"
+                Auth {
+                    Aws {
+                        AwsAccessKeyIdSecretName: "id_secret",
+                        AwsSecretAccessKeySecretName: "access_secret"
+                        AwsRegion: "ru-central-1"
+                    }
+                }
+            )";
+
+            TestCreateExternalDataSource(Runtime(), ++txId, "/MyRoot", dataSourceScheme);
+            Env().TestWaitNotification(Runtime(), txId);
+
+            TestCreateExternalTable(Runtime(), ++txId, "/MyRoot", scheme);
+            Env().TestWaitNotification(Runtime(), txId);
+
+            TString request = Sprintf(R"(
+                ExportToS3Settings {
+                    endpoint: "localhost:%d"
+                    scheme: HTTP
+                    items {
+                        source_path: "/MyRoot/ExternalTable"
+                        destination_prefix: "ExternalTable"
+                    }
+                }
+            )", S3Port());
+
+            TestExport(Runtime(), ++txId, "/MyRoot", request);
+            Env().TestWaitNotification(Runtime(), txId);
+
+            TestGetExport(Runtime(), txId, "/MyRoot", Ydb::StatusIds::SUCCESS);
+
+            UNIT_ASSERT(HasS3File("/ExternalTable/create_external_table.sql"));
+            const auto content = GetS3FileContent("/ExternalTable/create_external_table.sql");
+
+            UNIT_ASSERT_C(content.find(expectedStartsWith) != TString::npos,
+                TStringBuilder() << "\nExpected query to start with:\n\n"
+                    << expectedStartsWith << "\n\nActual query:\n\n" << content);
+
+			// Check if all expected properties are presented
+            for (const auto& property : expectedProperties) {
+                UNIT_ASSERT_C(content.find(property) != TString::npos,
+                    TStringBuilder() << "Property not found:\n"
+                    << "\nExpected property:\n\n" << property << "\n\nActual query:\n\n" << content);
+            }
+
+			// Check if no other properties are presented
+            UNIT_ASSERT_EQUAL_C(
+                std::ranges::count(content, '='),
+                static_cast<long>(expectedProperties.size()),
+                TStringBuilder() << "Properties count mismatch: ");
+
+            UNIT_ASSERT(HasS3File("/ExternalTable/permissions.pb"));
+            const auto permissions = GetS3FileContent("/ExternalTable/permissions.pb");
+            const auto permissions_expected = "actions {\n  change_owner: \"root@builtin\"\n}\n";
+            UNIT_ASSERT_EQUAL_C(
+                permissions, permissions_expected,
+                TStringBuilder() << "\nExpected:\n\n" << permissions_expected << "\n\nActual:\n\n" << permissions);
+        }
+
     protected:
         TS3Mock::TSettings& S3Settings() {
             if (!S3ServerSettings) {
@@ -3832,6 +3903,31 @@ WITH (
         };
 
         TestExternalDataSource(scheme, expectedProperties);
+    }
+
+    Y_UNIT_TEST(ExternalTable) {
+        TString scheme = R"(
+            Name: "ExternalTable"
+            SourceType: "General"
+            DataSourcePath: "/MyRoot/DataSource"
+            Location: "bucket"
+            Columns { Name: "key" Type: "Uint64" NotNull: true }
+            Columns { Name: "value1" Type: "Uint64" }
+            Columns { Name: "value2" Type: "Utf8" NotNull: true }
+        )";
+
+        TString expectedStartsWith = R"(CREATE EXTERNAL TABLE IF NOT EXISTS `ExternalTable` (
+      key Uint64 NOT NULL,
+    value1 Uint64?,
+    value2 Utf8 NOT NULL
+) WITH ()";
+
+        TVector<TString> expectedProperties = {
+            "DATA_SOURCE = '/MyRoot/DataSource'",
+            "LOCATION = 'bucket'"
+        };
+
+        TestExternalTable(scheme, expectedStartsWith, expectedProperties);
     }
 
 }

--- a/ydb/core/tx/schemeshard/ut_helpers/export_reboots_common.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/export_reboots_common.cpp
@@ -24,6 +24,7 @@ void TestCreate(TTestActorRuntime& runtime, ui64 txId, const TString& scheme, NK
         {EPathTypeReplication, &TestCreateReplication},
         {EPathTypeTransfer, &TestCreateTransfer},
         {EPathTypeExternalDataSource, &TestCreateExternalDataSource},
+        {EPathTypeExternalTable, &TestCreateExternalTable},
     };
 
     auto it = functions.find(pathType);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

External Table export to S3. External tables are exported as `CREATE EXTERNAL TABLE` SQL queries.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
