### PR TITLE
Increment alerts_exception on exceptions in executor context

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -151,7 +151,7 @@ bool TExecutor::OnUnhandledException(const std::exception& e) {
             log << "Tablet " << TabletId() << " unhandled exception " << TypeName(e) << ": " << e.what()
                 << '\n' << TBackTrace::FromCurrentException().PrintToString();
         }
-        Broken();
+        Broken(EBrokenReason::Exception);
         return true;
     }
 
@@ -224,8 +224,20 @@ void TExecutor::PassAway() {
     return TActor::PassAway();
 }
 
-void TExecutor::Broken() {
-    GetServiceCounters(AppData()->Counters, "tablets")->GetCounter("alerts_broken", true)->Inc();
+static TString BrokenAlertNameException("alerts_exception");
+static TString BrokenAlertNameOther("alerts_broken");
+
+const TString& TExecutor::BrokenAlertName(EBrokenReason reason) {
+    switch (reason) {
+        case EBrokenReason::Exception:
+            return BrokenAlertNameException;
+        default:
+            return BrokenAlertNameOther;
+    }
+}
+
+void TExecutor::Broken(EBrokenReason reason) {
+    GetServiceCounters(AppData()->Counters, "tablets")->GetCounter(BrokenAlertName(reason), true)->Inc();
 
     if (BootLogic)
         BootLogic->Cancel();
@@ -562,7 +574,7 @@ void TExecutor::TranscriptBootOpResult(ui32 res, const TActorContext &ctx) {
             logl << NFmt::Do(*this) << " Broken while booting";
         }
 
-        return Broken();
+        return Broken(EBrokenReason::Storage);
     default:
         Y_TABLET_ERROR("unknown boot result");
     }
@@ -581,7 +593,7 @@ void TExecutor::TranscriptFollowerBootOpResult(ui32 res, const TActorContext &ct
             logl << NFmt::Do(*this) << " Broken while follower booting";
         }
 
-        return Broken();
+        return Broken(EBrokenReason::Storage);
     default:
         Y_TABLET_ERROR("unknown boot result");
     }
@@ -1425,7 +1437,7 @@ void TExecutor::Handle(TEvBlobStorage::TEvGetResult::TPtr& ev, const TActorConte
             logl << NFmt::Do(*this) << " Broken while loading blobs";
         }
 
-        return Broken();
+        return Broken(EBrokenReason::Storage);
     }
 }
 
@@ -3001,7 +3013,7 @@ void TExecutor::Handle(TEvPrivate::TEvBrokenTransaction::TPtr &ev, const TActorC
     Y_UNUSED(ctx);
     Y_ENSURE(BrokenTransaction);
 
-    return Broken();
+    return Broken(EBrokenReason::Transaction);
 }
 
 void TExecutor::Wakeup(TEvents::TEvWakeup::TPtr &ev, const TActorContext&) {
@@ -3052,7 +3064,7 @@ void TExecutor::Handle(NSharedCache::TEvResult::TPtr &ev) {
                     GetServiceCounters(AppData()->Counters, "tablets")->GetCounter("alerts_req_nodata", true)->Inc();
                 }
 
-                return Broken();
+                return Broken(EBrokenReason::Storage);
             }
 
             if (requestType == ERequestTypeCookie::StickyPages) {
@@ -3106,7 +3118,7 @@ void TExecutor::Handle(NSharedCache::TEvResult::TPtr &ev) {
                     GetServiceCounters(AppData()->Counters, "tablets")->GetCounter("alerts_pending_nodata", true)->Inc();
                 }
 
-                return Broken();
+                return Broken(EBrokenReason::Storage);
             }
 
             Y_ENSURE(msg->Cookie == 0);
@@ -3200,7 +3212,7 @@ void TExecutor::Handle(TEvTablet::TEvConfirmLeaderResult::TPtr &ev) {
         if (auto logl = Logger->Log(ELnLev::Error)) {
             logl << NFmt::Do(*this) << " Broken on lease confirmation";
         }
-        return Broken();
+        return Broken(EBrokenReason::Storage);
     }
 
     LeaseConfirmed(ev->Cookie);
@@ -3213,7 +3225,7 @@ void TExecutor::Handle(TEvTablet::TEvCommitResult::TPtr &ev, const TActorContext
         if (auto logl = Logger->Log(ELnLev::Error)) {
             logl << NFmt::Do(*this) << " Broken on commit error for step " << msg->Step;
         }
-        return Broken();
+        return Broken(EBrokenReason::Storage);
     }
 
     Y_ENSURE(msg->Generation == Generation());
@@ -3654,7 +3666,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
         }
 
         CheckYellow(std::move(msg->YellowMoveChannels), std::move(msg->YellowStopChannels), /* terminal */ true);
-        return Broken();
+        return Broken(EBrokenReason::Storage);
     }
 
     TActiveTransactionZone activeTransaction(this);

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -358,6 +358,14 @@ class TExecutor
         LowPriority,
     };
 
+    enum class EBrokenReason {
+        Storage,
+        Exception,
+        Transaction,
+    };
+
+    static const TString& BrokenAlertName(EBrokenReason);
+
     const TIntrusivePtr<ITimeProvider> Time = nullptr;
     NFlatExecutorSetup::ITablet * Owner;
     const TActorId OwnerActorId;
@@ -505,7 +513,7 @@ class TExecutor
     ui64 Stamp() const noexcept;
     void Registered(TActorSystem*, const TActorId&) override;
     void PassAway() override;
-    void Broken();
+    void Broken(EBrokenReason reason);
     void Active(const TActorContext &ctx);
     void ActivateFollower(const TActorContext &ctx);
     void RecreatePrivateCache();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Don't increment alerts_broken when breaking due to exceptions, increment alerts_exception instead. Fixes #32020.