### PR TITLE
Delay Replication creation during import from S3

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -624,9 +624,8 @@ private:
         auto& item = importInfo->Items.at(itemIdx);
 
         LOG_D("TImport::TTxProgress: delay scheme object query execution"
-                << ": id# " << importInfo->Id
-                << ", delayed item# " << itemIdx
-            );
+            << ": id# " << importInfo->Id
+            << ", delayed item# " << itemIdx);
 
         item.State = EState::Waiting;
         Self->PersistImportItemState(db, *importInfo, itemIdx);

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -46,10 +46,6 @@ bool AllDone(const THashMap<EState, int>& stateCounts) {
     return AllOf(stateCounts, [](const auto& stateCount) { return stateCount.first == EState::Done; });
 }
 
-bool AllWaiting(const THashMap<EState, int>& stateCounts) {
-    return AllOf(stateCounts, [](const auto& stateCount) { return stateCount.first == EState::Waiting; });
-}
-
 bool AllDoneOrWaiting(const THashMap<EState, int>& stateCounts) {
     return AllOf(stateCounts, [](const auto& stateCount) {
         return stateCount.first == EState::Done
@@ -627,17 +623,19 @@ private:
         Y_ABORT_UNLESS(itemIdx < importInfo->Items.size());
         auto& item = importInfo->Items.at(itemIdx);
 
+        LOG_D("TImport::TTxProgress: delay scheme object query execution"
+                << ": id# " << importInfo->Id
+                << ", delayed item# " << itemIdx
+            );
+
         item.State = EState::Waiting;
         Self->PersistImportItemState(db, *importInfo, itemIdx);
 
         const auto stateCounts = CountItemsByState(importInfo->Items);
-        if (AllWaiting(stateCounts)) {
-            // Cancel the import, or we will end up waiting indefinitely.
-            return CancelAndPersist(db, importInfo, itemIdx, error, "creation query failed");
-        } else if (AllDoneOrWaiting(stateCounts)) {
+        if (AllDoneOrWaiting(stateCounts)) {
             if (stateCounts.at(EState::Waiting) == importInfo->WaitingSchemeObjects) {
-                // No progress has been made since the last scheme objec creation retry.
-                return CancelAndPersist(db, importInfo, itemIdx, error, "creation query failed");
+                // No progress has been made since the last scheme object creation retry.
+                return CancelAndPersist(db, importInfo, itemIdx, error, "creation query failed, no progress");
             }
             RetrySchemeObjectsQueryExecution(*importInfo, db, ctx);
         }
@@ -1320,6 +1318,11 @@ private:
         if (item.State == EState::CreateSchemeObject) {
             item.PreparedCreationQuery = std::get<NKikimrSchemeOp::TModifyScheme>(message.Result);
             PersistImportItemPreparedCreationQuery(db, *importInfo, message.ItemIdx);
+            if (item.PreparedCreationQuery->HasReplication()) {
+                // In case async replication or transfer is created, it is essential to execute modify scheme
+                // After all other objects, as they do not fail in case their dependencies are not imported yet
+                return DelayObjectCreation(importInfo, message.ItemIdx, db, error, ctx);
+            }
             AllocateTxId(*importInfo, message.ItemIdx);
         }
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Асинхронные репликации и трансферы не всегда сообщают о том, что объекты, от которых они зависят, еще не созданы. Решением является всегда создавать их после других объектов.

Вероятно, из-за этой проблемы иногда падает тест `ydb/services/ydb/backup_ut/BackupRestoreS3.TestAllSchemeObjectTypes-EPathTypeTransfer-IsOlap `
