### PR TITLE
Regression: test with query that works in version 24.4 and does not work now

### DIFF
--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -3401,6 +3401,7 @@ Y_UNIT_TEST_SUITE(KqpQuery) {
     }
 
     Y_UNIT_TEST(AsListTakesOptional) {
+        return; // TODO: remove when fixed
         auto settings = TKikimrSettings().SetWithSampleTables(false);
         TKikimrRunner kikimr(settings);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/issues/32105
This test illustrates regression while updating from 24.4 to 25.1.
We get the following YQL issue from the query that successfully executes in 24.4:
```
<main>: Error: Type annotation, code: 1030
    <main>:16:17: Error: At function: RemovePrefixMembers, At function: PersistableRepr, At function: SqlProject, At tuple, At function: SqlProjectItem, At lambda
        <main>:12:46: Error: At function: SingleMember, At function: SqlAccess, At function: Take
            <main>:12:27: Error: At function: PersistableRepr, At function: SqlProject
                <main>:14:17: Error: At function: AssumeColumnOrderPartial, At function: Aggregate
                    <main>:12:67: Error: Expected struct type, but got: Optional<Struct<'flag':Bool?,'id':Uint32?>>
```