### PR TITLE
Move InferPDiskSlotCount settings to node warden

### DIFF
--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -292,8 +292,6 @@ def get_vslot_extended_id(vslot):
 def get_pdisk_inferred_settings(pdisk):
     if (pdisk.PDiskMetrics.HasField('SlotCount')):
         return pdisk.PDiskMetrics.SlotCount, pdisk.PDiskMetrics.SlotSizeInUnits
-    elif (pdisk.InferPDiskSlotCountFromUnitSize != 0):
-        return 0, 0
     else:
         return pdisk.ExpectedSlotCount, pdisk.PDiskConfig.SlotSizeInUnits
 

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -11,6 +11,7 @@
 #include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
 #include <ydb/core/mind/bscontroller/bsc.h>
 #include <ydb/core/util/actorsys_test/testactorsys.h>
+#include <ydb/core/cms/console/console.h>
 
 #include <ydb/library/pdisk_io/sector_map.h>
 #include <ydb/core/testlib/actors/block_events.h>
@@ -268,8 +269,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
     }
 
     ui32 CreatePDisk(TTestActorRuntime &runtime, ui32 nodeIdx, TString path, ui64 guid, ui32 pdiskId, ui64 pDiskCategory,
-            const NKikimrBlobStorage::TPDiskConfig* pdiskConfig = nullptr, ui64 inferPDiskSlotCountFromUnitSize = 0,
-            ui32 inferPDiskSlotCountMax = 0, TActorId nodeWarden = {}) {
+            const NKikimrBlobStorage::TPDiskConfig* pdiskConfig = nullptr, TActorId nodeWarden = {}) {
         VERBOSE_COUT(" Creating pdisk");
 
         ui32 nodeId = runtime.GetNodeId(nodeIdx);
@@ -284,10 +284,6 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         pdisk->SetEntityStatus(NKikimrBlobStorage::CREATE);
         if (pdiskConfig) {
             pdisk->MutablePDiskConfig()->CopyFrom(*pdiskConfig);
-        }
-        if (inferPDiskSlotCountFromUnitSize != 0) {
-            pdisk->SetInferPDiskSlotCountFromUnitSize(inferPDiskSlotCountFromUnitSize);
-            pdisk->SetInferPDiskSlotCountMax(inferPDiskSlotCountMax);
         }
 
         if (!nodeWarden) {
@@ -1091,14 +1087,34 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         return realNodeWarden;
     }
 
+    void UpdateInferPDiskSlotCountSettings(TTestBasicRuntime& runtime, TActorId realNodeWarden,
+            ui64 unitSize, ui32 maxSlots, bool preferInferredSettings) {
+        auto request = std::make_unique<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+        auto& record = request->Record;
+        auto* blobStorageConfig = record.MutableConfig()->MutableBlobStorageConfig();
+        auto* inferSettings = blobStorageConfig->MutableInferPDiskSlotCountSettings();
+        auto* inferRotSettings = inferSettings->MutableRot();
+
+        inferRotSettings->SetUnitSize(unitSize);
+        inferRotSettings->SetMaxSlots(maxSlots);
+        inferRotSettings->SetPreferInferredSettingsOverExplicit(preferInferredSettings);
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        runtime.Send(new IEventHandle(realNodeWarden, sender, request.release()));
+
+        auto response = runtime.GrabEdgeEventRethrow<NConsole::TEvConsole::TEvConfigNotificationResponse>(sender);
+        Y_UNUSED(response);
+    }
+
     CUSTOM_UNIT_TEST(TestInferPDiskSlotCountExplicitConfig) {
         TTestBasicRuntime runtime(1, false);
         TActorId realNodeWarden = SetupNodeWardenOnly(runtime);
+        UpdateInferPDiskSlotCountSettings(runtime, realNodeWarden,
+            100_GB, 16, false);
 
         const ui32 nodeId = runtime.GetNodeId(0);
         const ui32 pdiskId = 1001;
         const TString pdiskPath = "SectorMap:TestInferPDiskSlotCountExplicitConfig:2400";
-        const ui64 inferPDiskSlotCountFromUnitSize = 100_GB; // 12 * 2u slots
 
         TActorId fakeNodeWarden = runtime.AllocateEdgeActor();
         runtime.RegisterService(MakeBlobStorageNodeWardenID(nodeId), fakeNodeWarden);
@@ -1109,19 +1125,32 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         NKikimrBlobStorage::TPDiskConfig pdiskConfig;
         pdiskConfig.SetExpectedSlotCount(13);
         CreatePDisk(runtime, 0, pdiskPath, 0, pdiskId, 0,
-            &pdiskConfig, inferPDiskSlotCountFromUnitSize, 16, realNodeWarden);
+            &pdiskConfig, realNodeWarden);
         CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
             pdiskId, 13, 0u);
+
+        VERBOSE_COUT("- Test case 2 - enable PreferInferredSettingsOverExplicit");
+        UpdateInferPDiskSlotCountSettings(runtime, realNodeWarden,
+            100_GB, 16, true);
+        CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
+            pdiskId, 12, 2u);
+
+        VERBOSE_COUT("- Test case 3 - update InferPDiskSlotCountSettings");
+        UpdateInferPDiskSlotCountSettings(runtime, realNodeWarden,
+            50_GB, 9, true);
+        CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
+            pdiskId, 6, 8u);
     }
 
     CUSTOM_UNIT_TEST(TestInferPDiskSlotCountWithRealNodeWarden) {
         TTestBasicRuntime runtime(1, false);
         TActorId realNodeWarden = SetupNodeWardenOnly(runtime);
+        UpdateInferPDiskSlotCountSettings(runtime, realNodeWarden,
+            100_GB, 16, false);
 
         const ui32 nodeId = runtime.GetNodeId(0);
         const ui32 pdiskId = 1002;
         const TString pdiskPath = "SectorMap:TestInferPDiskSlotCount:2400";
-        const ui64 inferPDiskSlotCountFromUnitSize = 100_GB; // 12 * 2u slots
 
         TActorId fakeNodeWarden = runtime.AllocateEdgeActor();
         runtime.RegisterService(MakeBlobStorageNodeWardenID(nodeId), fakeNodeWarden);
@@ -1131,7 +1160,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         VERBOSE_COUT("- Test case 1 - create PDisk");
         NKikimrBlobStorage::TPDiskConfig pdiskConfig;
         CreatePDisk(runtime, 0, pdiskPath, 0, pdiskId, 0,
-            &pdiskConfig, inferPDiskSlotCountFromUnitSize, 16, realNodeWarden);
+            &pdiskConfig, realNodeWarden);
         CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
             pdiskId, 12, 2u);
 
@@ -1141,21 +1170,26 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
                 UNIT_FAIL(TStringBuilder() << "EvChangeExpectedSlotCount shouldn't be sent in this case");
             });
         CreatePDisk(runtime, 0, pdiskPath, 0, pdiskId, 0,
-            &pdiskConfig, inferPDiskSlotCountFromUnitSize, 16, realNodeWarden);
-
+            &pdiskConfig, realNodeWarden);
         runtime.SimulateSleep(TDuration::MilliSeconds(100));
+
+        VERBOSE_COUT("- Test case 1b - change InferPDiskSlotCountSettings insignificantly");
+        UpdateInferPDiskSlotCountSettings(runtime, realNodeWarden,
+            100_GB, 18, false);
+        runtime.SimulateSleep(TDuration::MilliSeconds(100));
+
         observer.Remove();
 
         VERBOSE_COUT("- Test case 2 - update InferPDiskSlotCountSettings");
-        CreatePDisk(runtime, 0, pdiskPath, 0, pdiskId, 0,
-            &pdiskConfig, inferPDiskSlotCountFromUnitSize, 24, realNodeWarden);
+        UpdateInferPDiskSlotCountSettings(runtime, realNodeWarden,
+            100_GB, 24, false);
         CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
             pdiskId, 24, 1u);
 
         VERBOSE_COUT("- Test case 3 - set ExpectedSlotCount explicitly");
         pdiskConfig.SetExpectedSlotCount(17);
         CreatePDisk(runtime, 0, pdiskPath, 0, pdiskId, 0,
-            &pdiskConfig, inferPDiskSlotCountFromUnitSize, 24, realNodeWarden);
+            &pdiskConfig, realNodeWarden);
         CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
             pdiskId, 17, 0u);
     }

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -1140,6 +1140,18 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
             50_GB, 9, true);
         CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
             pdiskId, 6, 8u);
+
+        VERBOSE_COUT("- Test case 4 - remove InferPDiskSlotCountSettings");
+        auto request = std::make_unique<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+        {
+            auto& record = request->Record;
+            record.MutableConfig()->MutableBlobStorageConfig();
+            TActorId sender = runtime.AllocateEdgeActor();
+            runtime.Send(new IEventHandle(realNodeWarden, sender, request.release()));
+            runtime.GrabEdgeEventRethrow<NConsole::TEvConsole::TEvConfigNotificationResponse>(sender);
+        }
+        CheckInferredPDiskSettings(runtime, fakeWhiteboard, fakeNodeWarden,
+            pdiskId, 13, 0u);
     }
 
     CUSTOM_UNIT_TEST(TestInferPDiskSlotCountWithRealNodeWarden) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -196,6 +196,10 @@ STATEFN(TNodeWarden::StateOnline) {
 
         hFunc(TEvNodeWardenNotifySyncerFinished, Handle);
 
+        hFunc(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse, Handle);
+        hFunc(NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscriptionResponse, Handle);
+        hFunc(NConsole::TEvConsole::TEvConfigNotificationRequest, Handle);
+
         default:
             EnqueuePendingMessage(ev);
             break;
@@ -338,6 +342,10 @@ void TNodeWarden::StartRequestReportingThrottler() {
 
 void TNodeWarden::PassAway() {
     STLOG(PRI_DEBUG, BS_NODE, NW25, "PassAway");
+
+    Send(NConsole::MakeConfigsDispatcherID(SelfId().NodeId()),
+        new NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscriptionRequest(SelfId()));
+
     NTabletPipe::CloseClient(SelfId(), PipeClientId);
     StopInvalidGroupProxy();
     TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, DsProxyNodeMonActor, {}, nullptr, 0));
@@ -503,6 +511,11 @@ void TNodeWarden::Bootstrap() {
     StorageConfig = std::move(config);
 
     YamlConfig = std::move(Cfg->YamlConfig);
+
+    InferPDiskSlotCountSettings.CopyFrom(Cfg->BlobStorageConfig.GetInferPDiskSlotCountSettings());
+    ui32 blobStorageConfigItem = NKikimrConsole::TConfigItem::BlobStorageConfigItem;
+    Send(NConsole::MakeConfigsDispatcherID(SelfId().NodeId()),
+        new NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionRequest(blobStorageConfigItem));
 
     // Start a statically configured set
     if (Cfg->BlobStorageConfig.HasServiceSet()) {
@@ -1259,6 +1272,43 @@ void TNodeWarden::Handle(TEvStatusUpdate::TPtr ev) {
             }
         }
     }
+}
+
+void TNodeWarden::Handle(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::TPtr /*ev*/)
+{}
+
+void TNodeWarden::Handle(NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscriptionResponse::TPtr /*ev*/)
+{}
+
+void TNodeWarden::Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr ev) {
+    auto& record = ev->Get()->Record;
+    if (record.HasConfig() &&
+            record.GetConfig().HasBlobStorageConfig() &&
+            record.GetConfig().GetBlobStorageConfig().HasInferPDiskSlotCountSettings()) {
+        auto inferSettings = record.GetConfig().GetBlobStorageConfig().GetInferPDiskSlotCountSettings();
+        InferPDiskSlotCountSettings.CopyFrom(inferSettings);
+
+        for (auto& [key, localPDisk] : LocalPDisks) {
+            TIntrusivePtr<TPDiskConfig> newPDiskConfig = CreatePDiskConfig(localPDisk.Record);
+            ui64 newExpectedSlotCount = newPDiskConfig->ExpectedSlotCount;
+            ui32 newSlotSizeInUnits = newPDiskConfig->SlotSizeInUnits;
+
+            if (newExpectedSlotCount != localPDisk.ExpectedSlotCount ||
+                    newSlotSizeInUnits != localPDisk.SlotSizeInUnits) {
+                STLOG(PRI_DEBUG, BS_NODE, NW112, "SendChangeExpectedSlotCount from config notification",
+                    (PDiskId, key.PDiskId),
+                    (ExpectedSlotCount, newExpectedSlotCount),
+                    (SlotSizeInUnits, newSlotSizeInUnits));
+
+                const TActorId pdiskActorId = MakeBlobStoragePDiskID(LocalNodeId, key.PDiskId);
+                Send(pdiskActorId, new NPDisk::TEvChangeExpectedSlotCount(newExpectedSlotCount, newSlotSizeInUnits));
+
+                localPDisk.ExpectedSlotCount = newExpectedSlotCount;
+                localPDisk.SlotSizeInUnits = newSlotSizeInUnits;
+            }
+        }
+    }
+    Send(ev->Sender, new NConsole::TEvConsole::TEvConfigNotificationResponse(record), 0, ev->Cookie);
 }
 
 void TNodeWarden::FillInVDiskStatus(google::protobuf::RepeatedPtrField<NKikimrBlobStorage::TVDiskStatus> *pb, bool initial) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -1282,9 +1282,7 @@ void TNodeWarden::Handle(NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscrip
 
 void TNodeWarden::Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr ev) {
     auto& record = ev->Get()->Record;
-    if (record.HasConfig() &&
-            record.GetConfig().HasBlobStorageConfig() &&
-            record.GetConfig().GetBlobStorageConfig().HasInferPDiskSlotCountSettings()) {
+    if (record.HasConfig() && record.GetConfig().HasBlobStorageConfig()) {
         auto inferSettings = record.GetConfig().GetBlobStorageConfig().GetInferPDiskSlotCountSettings();
         auto equals = ::google::protobuf::util::MessageDifferencer::Equals;
         if (!equals(InferPDiskSlotCountSettings, inferSettings)) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -7,6 +7,8 @@
 #include <ydb/core/blobstorage/dsproxy/group_sessions.h>
 #include <ydb/core/blobstorage/dsproxy/dsproxy_nodemon.h>
 #include <ydb/core/blobstorage/incrhuge/incrhuge.h>
+#include <ydb/core/cms/console/configs_dispatcher.h>
+#include <ydb/core/cms/console/console.h>
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/protos/blobstorage_distributed_config.pb.h>
 #include <ydb/core/util/backoff.h>
@@ -165,6 +167,7 @@ namespace NKikimr::NStorage {
 
         bool EnableProxyMock = false;
         NKikimrBlobStorage::TMockDevicesConfig MockDevicesConfig;
+        NKikimrBlobStorage::TInferPDiskSlotCountSettings InferPDiskSlotCountSettings;
 
         struct TEvPrivate {
             enum EEv {
@@ -657,6 +660,10 @@ namespace NKikimr::NStorage {
         void SendScrubRequests();
 
         void Handle(NNodeWhiteboard::TEvWhiteboard::TEvBSGroupStateUpdate::TPtr ev);
+
+        void Handle(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::TPtr ev);
+        void Handle(NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscriptionResponse::TPtr ev);
+        void Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr ev);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Bridge syncer operation

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -452,4 +452,32 @@ struct TPDiskConfig : public TThrRefBase {
     }
 };
 
+struct TInferPDiskSlotCountSettingsForDriveType {
+    ui64 UnitSize = 0;
+    ui32 MaxSlots = 0;
+    bool PreferInferredSettingsOverExplicit = false;
+
+    TInferPDiskSlotCountSettingsForDriveType(const NKikimrBlobStorage::TInferPDiskSlotCountSettings& settings, NPDisk::EDeviceType type) {
+        switch (type) {
+            case NPDisk::DEVICE_TYPE_ROT:
+                UnitSize = settings.GetRot().GetUnitSize();
+                MaxSlots = settings.GetRot().GetMaxSlots();
+                PreferInferredSettingsOverExplicit = settings.GetRot().GetPreferInferredSettingsOverExplicit();
+                break;
+            case NPDisk::DEVICE_TYPE_SSD:
+            case NPDisk::DEVICE_TYPE_NVME:
+                UnitSize = settings.GetSsd().GetUnitSize();
+                MaxSlots = settings.GetSsd().GetMaxSlots();
+                PreferInferredSettingsOverExplicit = settings.GetSsd().GetPreferInferredSettingsOverExplicit();
+                break;
+            case NPDisk::DEVICE_TYPE_UNKNOWN:
+                break;
+        }
+    }
+
+    explicit operator bool() const {
+        return UnitSize && MaxSlots;
+    }
+};
+
 } // NKikimr

--- a/ydb/core/mind/bscontroller/cmds_host_config.cpp
+++ b/ydb/core/mind/bscontroller/cmds_host_config.cpp
@@ -23,8 +23,6 @@ namespace NKikimr::NBsController {
             driveInfo.SharedWithOs = drive.GetSharedWithOs();
             driveInfo.ReadCentric = drive.GetReadCentric();
             driveInfo.Kind = drive.GetKind();
-            driveInfo.InferPDiskSlotCountFromUnitSize = drive.GetInferPDiskSlotCountFromUnitSize();
-            driveInfo.InferPDiskSlotCountMax = drive.GetInferPDiskSlotCountMax();
 
             if (drive.HasPDiskConfig()) {
                 TString config;
@@ -48,8 +46,6 @@ namespace NKikimr::NBsController {
             driveInfo.SharedWithOs = false;
             driveInfo.ReadCentric = false;
             driveInfo.Kind = 0;
-            driveInfo.InferPDiskSlotCountFromUnitSize = 0;
-            driveInfo.InferPDiskSlotCountMax = 0;
             driveInfo.PDiskConfig = defaultPDiskConfig;
 
             for (const auto& path : field) {

--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -632,8 +632,6 @@ namespace NKikimr::NBsController {
                     x->SetDriveStatus(NKikimrBlobStorage::EDriveStatus::ACTIVE);
                     x->SetExpectedSlotCount(pdisk.ExpectedSlotCount);
                     x->SetDecommitStatus(NKikimrBlobStorage::EDecommitStatus::DECOMMIT_NONE);
-                    x->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
-                    x->SetInferPDiskSlotCountMax(pdisk.InferPDiskSlotCountMax);
                     if (pdisk.PDiskMetrics) {
                         x->MutablePDiskMetrics()->CopyFrom(*pdisk.PDiskMetrics);
                         x->MutablePDiskMetrics()->ClearPDiskId();

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -83,9 +83,7 @@ namespace NKikimr::NBsController {
             void ApplyPDiskDiff(const TPDiskId &pdiskId, const TPDiskInfo &prev, const TPDiskInfo &cur) {
                 if (prev.Mood != cur.Mood ||
                         prev.ExpectedSlotCount != cur.ExpectedSlotCount ||
-                        prev.SlotSizeInUnits != cur.SlotSizeInUnits ||
-                        prev.InferPDiskSlotCountFromUnitSize != cur.InferPDiskSlotCountFromUnitSize ||
-                        prev.InferPDiskSlotCountMax != cur.InferPDiskSlotCountMax) {
+                        prev.SlotSizeInUnits != cur.SlotSizeInUnits) {
                     CreatePDiskEntry(pdiskId, cur);
                 }
             }
@@ -118,8 +116,6 @@ namespace NKikimr::NBsController {
                 pdisk->SetPDiskCategory(pdiskInfo.Kind.GetRaw());
                 pdisk->SetExpectedSerial(pdiskInfo.ExpectedSerial);
                 pdisk->SetManagementStage(Self->SerialManagementStage);
-                pdisk->SetInferPDiskSlotCountFromUnitSize(pdiskInfo.InferPDiskSlotCountFromUnitSize);
-                pdisk->SetInferPDiskSlotCountMax(pdiskInfo.InferPDiskSlotCountMax);
                 if (pdiskInfo.PDiskConfig && !pdisk->MutablePDiskConfig()->ParseFromString(pdiskInfo.PDiskConfig)) {
                     // TODO(alexvru): report this somehow
                 }
@@ -983,8 +979,6 @@ namespace NKikimr::NBsController {
                 drive.SetSharedWithOs(value.SharedWithOs);
                 drive.SetReadCentric(value.ReadCentric);
                 drive.SetKind(value.Kind);
-                drive.SetInferPDiskSlotCountFromUnitSize(value.InferPDiskSlotCountFromUnitSize);
-                drive.SetInferPDiskSlotCountMax(value.InferPDiskSlotCountMax);
 
                 if (const auto& config = value.PDiskConfig) {
                     NKikimrBlobStorage::TPDiskConfig& pb = *drive.MutablePDiskConfig();
@@ -1123,12 +1117,6 @@ namespace NKikimr::NBsController {
             pb->SetLastSeenSerial(pdisk.LastSeenSerial);
             pb->SetReadOnly(pdisk.Mood == TPDiskMood::ReadOnly);
             pb->SetMaintenanceStatus(pdisk.MaintenanceStatus);
-            if (pdisk.InferPDiskSlotCountFromUnitSize) {
-                pb->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
-            }
-            if (pdisk.InferPDiskSlotCountMax) {
-                pb->SetInferPDiskSlotCountMax(pdisk.InferPDiskSlotCountMax);
-            }
         }
 
         void TBlobStorageController::Serialize(NKikimrBlobStorage::TVSlotId *pb, TVSlotId id) {

--- a/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
@@ -25,8 +25,6 @@ namespace NKikimr {
             bool ReadCentric = false;
             TPDiskCategory PDiskCategory = {};
             TString PDiskConfig;
-            ui64 InferPDiskSlotCountFromUnitSize = 0;
-            ui32 InferPDiskSlotCountMax = 0;
 
             TDiskId GetId() const {
                 return {NodeId, Path};
@@ -74,9 +72,7 @@ namespace NKikimr {
                 pdiskInfo->SharedWithOs != disk.SharedWithOs ||
                 pdiskInfo->ReadCentric != disk.ReadCentric ||
                 pdiskInfo->BoxId != disk.BoxId ||
-                pdiskInfo->PDiskConfig != disk.PDiskConfig ||
-                pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize ||
-                pdiskInfo->InferPDiskSlotCountMax != disk.InferPDiskSlotCountMax)
+                pdiskInfo->PDiskConfig != disk.PDiskConfig)
             {
                 // update PDisk configuration
                 auto pdiskInfo = state.PDisks.FindForUpdate(pdiskId);
@@ -85,19 +81,21 @@ namespace NKikimr {
                 pdiskInfo->SharedWithOs = disk.SharedWithOs;
                 pdiskInfo->ReadCentric = disk.ReadCentric;
                 pdiskInfo->BoxId = disk.BoxId;
-                if (pdiskInfo->PDiskConfig != disk.PDiskConfig
-                        || pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize
-                        || pdiskInfo->InferPDiskSlotCountMax != disk.InferPDiskSlotCountMax) {
+                if (pdiskInfo->PDiskConfig != disk.PDiskConfig) {
                     const std::optional<TBlobStorageController::TStaticPDiskInfo> staticPDisk = FindStaticPDisk(disk, state).transform(
                         [&](TPDiskId id) {return state.StaticPDisks.at(id);});
-                    if (staticPDisk && (staticPDisk->PDiskConfig != disk.PDiskConfig
-                            || staticPDisk->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize
-                            || staticPDisk->InferPDiskSlotCountMax != disk.InferPDiskSlotCountMax)) {
-                        throw TExError() << "PDiskConfig mismatch for static disk" << TErrorParams::NodeId(disk.NodeId) << TErrorParams::Path(disk.Path);
+                    if (staticPDisk && staticPDisk->PDiskConfig != disk.PDiskConfig) {
+                        throw TExError() << "PDiskConfig mismatch for static disk"
+                            << " Expected# {"
+                                << " PDiskConfig# { " << FormatPDiskConfig(staticPDisk->PDiskConfig) << " }"
+                            << " }"
+                            << " Provided# {"
+                                << " PDiskConfig# { " << FormatPDiskConfig(disk.PDiskConfig) << " }"
+                            << " }"
+                            << TErrorParams::NodeId(disk.NodeId)
+                            << TErrorParams::Path(disk.Path);
                     } else {
                         pdiskInfo->PDiskConfig = disk.PDiskConfig;
-                        pdiskInfo->InferPDiskSlotCountFromUnitSize = disk.InferPDiskSlotCountFromUnitSize;
-                        pdiskInfo->InferPDiskSlotCountMax = disk.InferPDiskSlotCountMax;
                     }
                 }
                 // run ExtractConfig as the very last step
@@ -190,8 +188,6 @@ namespace NKikimr {
                         disk.ReadCentric = driveInfo.ReadCentric;
                         disk.Serial = serial;
                         disk.SharedWithOs = driveInfo.SharedWithOs;
-                        disk.InferPDiskSlotCountFromUnitSize = driveInfo.InferPDiskSlotCountFromUnitSize;
-                        disk.InferPDiskSlotCountMax = driveInfo.InferPDiskSlotCountMax;
 
                         auto diskId = disk.GetId();
                         auto [_, inserted] = disks.try_emplace(diskId, std::move(disk));
@@ -347,9 +343,7 @@ namespace NKikimr {
                             NKikimrBlobStorage::EDecommitStatus::DECOMMIT_NONE, NBsController::TPDiskMood::Normal,
                             disk.Serial, disk.LastSeenSerial, disk.LastSeenPath, staticSlotUsage,
                             true /* assume shred completed for this disk */,
-                            NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST,
-                            disk.InferPDiskSlotCountFromUnitSize,
-                            disk.InferPDiskSlotCountMax);
+                            NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST);
 
                     // Preserve metrics from static PDisk
                     if (staticMetrics) {

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -353,9 +353,7 @@ public:
                     Self->DefaultMaxSlots, disks.GetValue<T::Status>(), disks.GetValue<T::Timestamp>(),
                     disks.GetValue<T::DecommitStatus>(), disks.GetValue<T::Mood>(), disks.GetValue<T::ExpectedSerial>(),
                     disks.GetValue<T::LastSeenSerial>(), disks.GetValue<T::LastSeenPath>(), staticSlotUsage,
-                    disks.GetValueOrDefault<T::ShredComplete>(), disks.GetValueOrDefault<T::MaintenanceStatus>(),
-                    disks.GetValueOrDefault<T::InferPDiskSlotCountFromUnitSize>(),
-                    disks.GetValueOrDefault<T::InferPDiskSlotCountMax>());
+                    disks.GetValueOrDefault<T::ShredComplete>(), disks.GetValueOrDefault<T::MaintenanceStatus>());
 
                 if (!disks.Next())
                     return false;

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -464,12 +464,6 @@ void TBlobStorageController::ReadPDisk(const TPDiskId& pdiskId, const TPDiskInfo
             STLOG(PRI_CRIT, BS_CONTROLLER, BSCTXRN02, "PDiskConfig invalid", (NodeId, pdiskId.NodeId),
                 (PDiskId, pdiskId.PDiskId));
         }
-        if (pdisk.InferPDiskSlotCountFromUnitSize) {
-            pDisk->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
-        }
-        if (pdisk.InferPDiskSlotCountMax) {
-            pDisk->SetInferPDiskSlotCountMax(pdisk.InferPDiskSlotCountMax);
-        }
     }
     pDisk->SetExpectedSerial(pdisk.ExpectedSerial);
     pDisk->SetManagementStage(SerialManagementStage);

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -45,13 +45,13 @@ struct Schema : NIceDb::Schema {
         struct Mood : Column<18, NScheme::NTypeIds::Uint8> { using Type = TPDiskMood::EValue; static constexpr Type Default = Type::Normal; };
         struct ShredComplete : Column<19, NScheme::NTypeIds::Bool> { static constexpr Type Default = true; };
         struct MaintenanceStatus : Column<20, NScheme::NTypeIds::Uint8> { using Type = NKikimrBlobStorage::TMaintenanceStatus::E; static constexpr Type Default = NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST; };
-        struct InferPDiskSlotCountFromUnitSize : Column<21, NScheme::NTypeIds::Uint64> { static constexpr Type Default = 0; };
-        struct InferPDiskSlotCountMax : Column<22, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
+        // struct InferPDiskSlotCountFromUnitSize : Column<21, NScheme::NTypeIds::Uint64> { static constexpr Type Default = 0; };
+        // struct InferPDiskSlotCountMax : Column<22, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
 
         using TKey = TableKey<NodeID, PDiskID>; // order is important
         using TColumns = TableColumns<NodeID, PDiskID, Path, Category, Guid, SharedWithOs, ReadCentric, NextVSlotId,
               Status, Timestamp, PDiskConfig, ExpectedSerial, LastSeenSerial, LastSeenPath, DecommitStatus, Mood,
-              ShredComplete, MaintenanceStatus, InferPDiskSlotCountFromUnitSize, InferPDiskSlotCountMax>;
+              ShredComplete, MaintenanceStatus>;
     };
 
     struct Group : Table<4> {
@@ -248,12 +248,11 @@ struct Schema : NIceDb::Schema {
         struct ReadCentric : Column<5, NScheme::NTypeIds::Bool> {};
         struct Kind : Column<6, NScheme::NTypeIds::Uint64> {};
         struct PDiskConfig : Column<7, NScheme::NTypeIds::String> {};
-        struct InferPDiskSlotCountFromUnitSize : Column<8, NScheme::NTypeIds::Uint64> { static constexpr Type Default = 0; };
-        struct InferPDiskSlotCountMax : Column<9, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
+        // struct InferPDiskSlotCountFromUnitSize : Column<8, NScheme::NTypeIds::Uint64> { static constexpr Type Default = 0; };
+        // struct InferPDiskSlotCountMax : Column<9, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
 
         using TKey = TableKey<HostConfigId, Path>;
-        using TColumns = TableColumns<HostConfigId, Path, TypeCol, SharedWithOs, ReadCentric, Kind, PDiskConfig, InferPDiskSlotCountFromUnitSize,
-            InferPDiskSlotCountMax>;
+        using TColumns = TableColumns<HostConfigId, Path, TypeCol, SharedWithOs, ReadCentric, Kind, PDiskConfig>;
     };
 
     struct BoxHostV2 : Table<105> {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1008,11 +1008,8 @@ message TNodeWardenServiceSet {
         optional bool ReadOnly = 14;
         optional bool Stop = 15;
 
-        // If not zero, NodeWarded infers PDiskConfig ExpectedSlotCount and SlotSizeInUnits (if unset) by the formula
-        // ExpectedSlotCount * SlotSizeInUnits = TotalSize / InferPDiskSlotCountFromUnitSize
-        // where SlotSizeInUnits = 2^N is chosen to meet ExpectedSlotCount <= InferPDiskSlotCountMax
-        optional uint64 InferPDiskSlotCountFromUnitSize = 16;
-        optional uint32 InferPDiskSlotCountMax = 17;
+        reserved 16; // optional uint64 InferPDiskSlotCountFromUnitSize, deprecated in favor of BlobStorageConfig.InferPDiskSlotCount
+        reserved 17; // optional uint32 InferPDiskSlotCountMax, deprecated in favor of BlobStorageConfig.InferPDiskSlotCount
     }
 
     message TVDisk {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -647,7 +647,7 @@ message TRecommissionGroups {
 }
 
 message TInferPDiskSlotCountForDriveTypeSettings {
-    // NodeWarded infers PDiskConfig ExpectedSlotCount and SlotSizeInUnits by the formula
+    // NodeWarden infers PDiskConfig ExpectedSlotCount and SlotSizeInUnits by the formula
     // ExpectedSlotCount = TotalSize / (UnitSize * SlotSizeInUnits)
     // where SlotSizeInUnits = 2^N is chosen to meet ExpectedSlotCount <= MaxSlots
     optional uint64 UnitSize = 1; // in bytes

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -656,8 +656,8 @@ message TInferPDiskSlotCountForDriveTypeSettings {
 }
 
 message TInferPDiskSlotCountSettings {
-    optional TInferPDiskSlotCountForDriveTypeSettings Rot = 2;
-    optional TInferPDiskSlotCountForDriveTypeSettings Ssd = 3;
+    optional TInferPDiskSlotCountForDriveTypeSettings Rot = 1;
+    optional TInferPDiskSlotCountForDriveTypeSettings Ssd = 2;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -26,8 +26,8 @@ message THostConfigDrive {
 
     // optional PDisk config for these drives; if not set, default configuration is applied; overrides host-wide default
     NKikimrBlobStorage.TPDiskConfig PDiskConfig = 6;
-    uint64 InferPDiskSlotCountFromUnitSize = 7;
-    uint32 InferPDiskSlotCountMax = 8;
+    reserved 7; // uint64 InferPDiskSlotCountFromUnitSize, deprecated in favor of BlobStorageConfig.InferPDiskSlotCount
+    reserved 8; // uint32 InferPDiskSlotCountMax, deprecated in favor of BlobStorageConfig.InferPDiskSlotCount
 }
 
 // Command used to define typical host configuration. It it used while defining new typical host configurations and as
@@ -646,6 +646,20 @@ message TRecommissionGroups {
     repeated uint32 GroupIds = 1;
 }
 
+message TInferPDiskSlotCountForDriveTypeSettings {
+    // NodeWarded infers PDiskConfig ExpectedSlotCount and SlotSizeInUnits by the formula
+    // ExpectedSlotCount = TotalSize / (UnitSize * SlotSizeInUnits)
+    // where SlotSizeInUnits = 2^N is chosen to meet ExpectedSlotCount <= MaxSlots
+    optional uint64 UnitSize = 1; // in bytes
+    optional uint32 MaxSlots = 2;
+    optional bool PreferInferredSettingsOverExplicit = 3; // Unless true, PDisk.ExpectedSlotCount overrides inferred settings
+}
+
+message TInferPDiskSlotCountSettings {
+    optional TInferPDiskSlotCountForDriveTypeSettings Rot = 2;
+    optional TInferPDiskSlotCountForDriveTypeSettings Ssd = 3;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // INTERFACE PART
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -787,8 +801,8 @@ message TBaseConfig {
         string LastSeenSerial = 18;
         bool ReadOnly = 19;
         TMaintenanceStatus.E MaintenanceStatus = 20;
-        uint64 InferPDiskSlotCountFromUnitSize = 21;
-        uint32 InferPDiskSlotCountMax = 22;
+        reserved 21; // uint64 InferPDiskSlotCountFromUnitSize = 21
+        reserved 22; // uint32 InferPDiskSlotCountMax = 22
     }
     message TVSlot {
         message TDonorDisk {
@@ -859,6 +873,7 @@ message TBaseConfig {
     repeated TNode Node = 4;
     repeated TDevice Device = 5;
     TUpdateSettings Settings = 6;
+    TInferPDiskSlotCountSettings InferPDiskSlotCountSettings = 7;
 }
 
 message TMoveCommand {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -369,7 +369,8 @@ message TBlobStorageConfig {
     optional NKikimrBlobStorage.TBscConfig BscSettings = 12;
 
     optional uint64 BridgeSyncRateBytesPerSecond = 13 [default = 500000000]; // default 500 MB/s per node
- }
+    optional NKikimrBlobStorage.TInferPDiskSlotCountSettings InferPDiskSlotCountSettings = 14;
+}
 
 message TSelfManagementConfig {
     // whether the self management is enabled (through distconf)? (mandatory field)

--- a/ydb/library/yaml_config/protos/config.proto
+++ b/ydb/library/yaml_config/protos/config.proto
@@ -75,18 +75,8 @@ message TExtendedHostConfigDrive {
     optional NKikimrBlobStorage.TPDiskConfig PDiskConfig = 6 [(NMarkers.CopyTo) = "THostConfigDrive"];
     optional uint64 ExpectedSlotCount = 7;
     optional uint32 SlotSizeInUnits = 8;
-    optional uint64 InferPDiskSlotCountFromUnitSize = 9 [(NMarkers.CopyTo) = "THostConfigDrive"];
-    optional uint32 InferPDiskSlotCountMax = 10 [(NMarkers.CopyTo) = "THostConfigDrive"];
-}
-
-message TInferPDiskSlotCountFromUnitSize {
-    optional uint64 Rot = 1;
-    optional uint64 Ssd = 2; // Implies both ssd and nvme
-}
-
-message TInferPDiskSlotCountMax {
-    optional uint32 Rot = 1;
-    optional uint32 Ssd = 2; // Implies both ssd and nvme
+    reserved 9; // optional uint64 InferPDiskSlotCountFromUnitSize = 9 [(NMarkers.CopyTo) = "THostConfigDrive"]; // deprecated
+    reserved 10; // optional uint32 InferPDiskSlotCountMax = 10 [(NMarkers.CopyTo) = "THostConfigDrive"]; // deprecated
 }
 
 message THosts {
@@ -153,8 +143,8 @@ message TExtendedDefineHostConfig {
     repeated string Ssd = 6 [(NMarkers.CopyTo) = "TDefineHostConfig"];
     repeated string Nvme = 7 [(NMarkers.CopyTo) = "TDefineHostConfig"];
 
-    optional TInferPDiskSlotCountFromUnitSize InferPDiskSlotCountFromUnitSize = 8;
-    optional TInferPDiskSlotCountMax InferPDiskSlotCountMax = 9;
+    reserved 8; // optional TInferPDiskSlotCountFromUnitSize InferPDiskSlotCountFromUnitSize = 8; // deprecated
+    reserved 9; // optional TInferPDiskSlotCountMax InferPDiskSlotCountMax = 9; // deprecated
 
     optional uint64 ItemConfigGeneration = 100 [(NMarkers.CopyTo) = "TDefineHostConfig"];
 }

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:898: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:884: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:902: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:888: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -641,20 +641,6 @@ namespace NKikimr::NYaml {
                         drive.MutablePDiskConfig()->SetSlotSizeInUnits(drive.GetSlotSizeInUnits());
                     }
                 }
-
-                if (hostConfig.HasInferPDiskSlotCountFromUnitSize()) {
-                    auto unitSizeByType = hostConfig.GetInferPDiskSlotCountFromUnitSize();
-                    for(auto& drive : *hostConfig.MutableDrive()) {
-                        if (drive.HasInferPDiskSlotCountFromUnitSize()) {
-                            continue;
-                        }
-                        if (drive.GetType() == "ROT" && unitSizeByType.HasRot()) {
-                            drive.SetInferPDiskSlotCountFromUnitSize(unitSizeByType.GetRot());
-                        } else if (auto& type = drive.GetType(); (type == "SSD" || type == "NVME") && unitSizeByType.HasSsd()) {
-                            drive.SetInferPDiskSlotCountFromUnitSize(unitSizeByType.GetSsd());
-                        }
-                    }
-                }
             }
         }
 

--- a/ydb/tests/functional/dstool/canondata/result.json
+++ b/ydb/tests/functional/dstool/canondata/result.json
@@ -75,6 +75,11 @@
             "uri": "file://test_canonical_requests.Test.test_essential/results.txt.8"
         }
     ],
+    "test_canonical_requests.Test.test_infer_pdisk_slot_count": [
+        {
+            "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt"
+        }
+    ],
     "test_canonical_requests.Test.test_pdisk_set_status_inactive": [
         {
             "uri": "file://test_canonical_requests.Test.test_pdisk_set_status_inactive/results.txt"

--- a/ydb/tests/functional/dstool/canondata/result.json
+++ b/ydb/tests/functional/dstool/canondata/result.json
@@ -76,9 +76,16 @@
         }
     ],
     "test_canonical_requests.Test.test_infer_pdisk_slot_count": [
-        {
-            "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt"
-        }
+        [
+            {
+                "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt"
+            }
+        ],
+        [
+            {
+                "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt.0"
+            }
+        ]
     ],
     "test_canonical_requests.Test.test_pdisk_set_status_inactive": [
         {

--- a/ydb/tests/functional/dstool/canondata/result.json
+++ b/ydb/tests/functional/dstool/canondata/result.json
@@ -76,16 +76,12 @@
         }
     ],
     "test_canonical_requests.Test.test_infer_pdisk_slot_count": [
-        [
-            {
-                "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt"
-            }
-        ],
-        [
-            {
-                "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt.0"
-            }
-        ]
+        {
+            "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt"
+        },
+        {
+            "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt.0"
+        }
     ],
     "test_canonical_requests.Test.test_pdisk_set_status_inactive": [
         {

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt
@@ -1,0 +1,23 @@
+dstool -e <endpoint> --mon-port <mon_port> pdisk list -H --columns NodeId:PDiskId Path TotalSize ExpectedSlotCount SlotSizeInUnits
+Exit Status: 0
+===== stdout =====
+┌────────────────┬────────────────┬───────────────────┬─────────────────┬───────────┐
+│ NodeId:PDiskId │ Path           │ ExpectedSlotCount │ SlotSizeInUnits │ TotalSize │
+├────────────────┼────────────────┼───────────────────┼─────────────────┼───────────┤
+│ [1:1]          │ SectorMap:1:64 │ 8                 │ 2               │  64.0 GiB │
+│ [1:1000]       │ SectorMap:2:4  │ 2                 │ 1               │     8 GiB │
+│ [2:1]          │ SectorMap:1:64 │ 8                 │ 2               │  64.0 GiB │
+│ [2:1000]       │ SectorMap:2:4  │ 2                 │ 1               │     8 GiB │
+│ [3:1]          │ SectorMap:1:64 │ 8                 │ 2               │  64.0 GiB │
+│ [3:1000]       │ SectorMap:2:4  │ 2                 │ 1               │     8 GiB │
+│ [4:1]          │ SectorMap:1:64 │ 8                 │ 2               │  64.0 GiB │
+│ [4:1000]       │ SectorMap:2:4  │ 2                 │ 1               │     8 GiB │
+│ [5:1]          │ SectorMap:1:64 │ 8                 │ 2               │  64.0 GiB │
+│ [5:1000]       │ SectorMap:2:4  │ 2                 │ 1               │     8 GiB │
+│ [6:1]          │ SectorMap:1:64 │ 8                 │ 2               │  64.0 GiB │
+│ [6:1000]       │ SectorMap:2:4  │ 2                 │ 1               │     8 GiB │
+│ [7:1]          │ SectorMap:1:64 │ 8                 │ 2               │  64.0 GiB │
+│ [7:1000]       │ SectorMap:2:4  │ 2                 │ 1               │     8 GiB │
+│ [8:1]          │ SectorMap:1:64 │ 8                 │ 2               │  64.0 GiB │
+│ [8:1000]       │ SectorMap:2:4  │ 2                 │ 1               │     8 GiB │
+└────────────────┴────────────────┴───────────────────┴─────────────────┴───────────┘

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt.0
@@ -1,0 +1,23 @@
+dstool -e <endpoint> --mon-port <mon_port> pdisk list -H --columns NodeId:PDiskId Path TotalSize ExpectedSlotCount SlotSizeInUnits
+Exit Status: 0
+===== stdout =====
+┌────────────────┬────────────────┬───────────────────┬─────────────────┬───────────┐
+│ NodeId:PDiskId │ Path           │ ExpectedSlotCount │ SlotSizeInUnits │ TotalSize │
+├────────────────┼────────────────┼───────────────────┼─────────────────┼───────────┤
+│ [1:1]          │ SectorMap:1:64 │ 9                 │ 0               │  64.0 GiB │
+│ [1:1000]       │ SectorMap:2:4  │ 9                 │ 0               │     8 GiB │
+│ [2:1]          │ SectorMap:1:64 │ 9                 │ 0               │  64.0 GiB │
+│ [2:1000]       │ SectorMap:2:4  │ 9                 │ 0               │     8 GiB │
+│ [3:1]          │ SectorMap:1:64 │ 9                 │ 0               │  64.0 GiB │
+│ [3:1000]       │ SectorMap:2:4  │ 9                 │ 0               │     8 GiB │
+│ [4:1]          │ SectorMap:1:64 │ 9                 │ 0               │  64.0 GiB │
+│ [4:1000]       │ SectorMap:2:4  │ 9                 │ 0               │     8 GiB │
+│ [5:1]          │ SectorMap:1:64 │ 9                 │ 0               │  64.0 GiB │
+│ [5:1000]       │ SectorMap:2:4  │ 9                 │ 0               │     8 GiB │
+│ [6:1]          │ SectorMap:1:64 │ 9                 │ 0               │  64.0 GiB │
+│ [6:1000]       │ SectorMap:2:4  │ 9                 │ 0               │     8 GiB │
+│ [7:1]          │ SectorMap:1:64 │ 9                 │ 0               │  64.0 GiB │
+│ [7:1000]       │ SectorMap:2:4  │ 9                 │ 0               │     8 GiB │
+│ [8:1]          │ SectorMap:1:64 │ 9                 │ 0               │  64.0 GiB │
+│ [8:1000]       │ SectorMap:2:4  │ 9                 │ 0               │     8 GiB │
+└────────────────┴────────────────┴───────────────────┴─────────────────┴───────────┘

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -267,7 +267,7 @@ class Test(TestBase):
             'SlotSizeInUnits',
         ]
 
-        trace1 = self._trace('pdisk', 'list', '-H', '--columns', *pdisk_columns),
+        trace1 = self._trace('pdisk', 'list', '-H', '--columns', *pdisk_columns)
 
         del full_config["config"]["blob_storage_config"]["infer_pdisk_slot_count_settings"]
         full_config["metadata"]["version"] = 1
@@ -279,6 +279,6 @@ class Test(TestBase):
                 assert pdisk.PDiskMetrics.SlotSizeInUnits == 0
         retry_assertions(check_pdisk_metrics_updated)
 
-        trace2 = self._trace('pdisk', 'list', '-H', '--columns', *pdisk_columns),
+        trace2 = self._trace('pdisk', 'list', '-H', '--columns', *pdisk_columns)
 
         return [trace1, trace2]

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 import yatest
 import time
+import yaml
 
 from io import StringIO
 from unittest.mock import patch
@@ -18,7 +19,10 @@ from ydb.tests.library.common.types import Erasure
 from ydb.tests.library.common.wait_for import retry_assertions
 from ydb.tests.library.harness.kikimr_cluster import KiKiMR
 from ydb.tests.library.harness.util import LogLevels
+from ydb.tests.library.clients.kikimr_dynconfig_client import DynConfigClient
 from ydb.core.protos.whiteboard_disk_states_pb2 import EVDiskState
+from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
+import ydb.public.api.protos.draft.ydb_dynamic_config_pb2 as dynconfig
 
 logger = logging.getLogger(__name__)
 C_4GB = 4 * 2**30
@@ -93,6 +97,7 @@ class TestBase:
         assert len(base_config.PDisk) == 2 * NODES_COUNT
         for pdisk in base_config.PDisk:
             assert pdisk.PDiskMetrics.HasField('UpdateTimestamp')
+        return base_config
 
     def check_vdisks_state_ok(self):
         base_config = self.cluster.client.query_base_config().BaseConfig
@@ -211,4 +216,52 @@ class Test(TestBase):
             self._trace('cluster', 'set', '--pdisk-space-margin-promille', '1001'),
             self._trace('cluster', 'set', '--pdisk-space-color-border', 'UNKNOWN'),
             self._trace('--dry-run', 'cluster', 'set', '--disable-self-heal'),
+        ]
+
+    def test_infer_pdisk_slot_count(self):
+        dynconfig_client = DynConfigClient(self.host, self.grpc_port)
+
+        generate_config_response = dynconfig_client.fetch_startup_config()
+        logger.info(f"{generate_config_response=}")
+        assert generate_config_response.operation.status == StatusIds.SUCCESS
+
+        result = dynconfig.FetchStartupConfigResult()
+        generate_config_response.operation.result.Unpack(result)
+
+        full_config = {
+            "metadata": {
+                "kind": "MainConfig",
+                "version": 0,
+                "cluster": "",
+            },
+            "config": yaml.safe_load(result.config)
+        }
+
+        full_config["config"]["blob_storage_config"]["infer_pdisk_slot_count_settings"] = {
+            "rot": {
+                "prefer_inferred_settings_over_explicit": True,
+                "unit_size": C_4GB,
+                "max_slots": 12,
+            }
+        }
+
+        replace_config_response = dynconfig_client.replace_config(yaml.dump(full_config))
+        logger.info(f"{replace_config_response=}")
+        assert replace_config_response.operation.status == StatusIds.SUCCESS
+
+        def check_pdisk_metrics_updated():
+            base_config = self.check_pdisk_metrics_collected()
+            for pdisk in base_config.PDisk:
+                assert pdisk.PDiskMetrics.SlotSizeInUnits > 0
+        retry_assertions(check_pdisk_metrics_updated)
+
+        pdisk_columns = [
+            'NodeId:PDiskId',
+            'Path',
+            'TotalSize',
+            'ExpectedSlotCount',
+            'SlotSizeInUnits',
+        ]
+        return [
+            self._trace('pdisk', 'list', '-H', '--columns', *pdisk_columns),
         ]

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
@@ -346,16 +346,6 @@
                 "ColumnId": 20,
                 "ColumnName": "MaintenanceStatus",
                 "ColumnType": "Byte"
-            },
-            {
-                "ColumnId": 21,
-                "ColumnName": "InferPDiskSlotCountFromUnitSize",
-                "ColumnType": "Uint64"
-            },
-            {
-                "ColumnId": 22,
-                "ColumnName": "InferPDiskSlotCountMax",
-                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
@@ -379,9 +369,7 @@
                     17,
                     18,
                     19,
-                    20,
-                    21,
-                    22
+                    20
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -1914,6 +1902,11 @@
         ],
         "ColumnsAdded": [
             {
+                "ColumnId": 7,
+                "ColumnName": "PDiskConfig",
+                "ColumnType": "String"
+            },
+            {
                 "ColumnId": 1,
                 "ColumnName": "HostConfigId",
                 "ColumnType": "Uint64"
@@ -1942,36 +1935,19 @@
                 "ColumnId": 6,
                 "ColumnName": "Kind",
                 "ColumnType": "Uint64"
-            },
-            {
-                "ColumnId": 7,
-                "ColumnName": "PDiskConfig",
-                "ColumnType": "String"
-            },
-            {
-                "ColumnId": 8,
-                "ColumnName": "InferPDiskSlotCountFromUnitSize",
-                "ColumnType": "Uint64"
-            },
-            {
-                "ColumnId": 9,
-                "ColumnName": "InferPDiskSlotCountMax",
-                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
+                    7,
                     1,
                     2,
                     3,
                     4,
                     5,
-                    6,
-                    7,
-                    8,
-                    9
+                    6
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Remove `InferPDiskSlotCountFromUnitSize` and `InferPDiskSlotCountMax` individual fields from protobuf structures:
  - THostConfigDrive used in `DefineHostConfig` and `QueryBaseConfig` BSController command
  - TNodeWardenServiceSet handled by NodeWarden
  - host_configs in config.yaml

Also these fields are removed from BSController internal tables.

In sysview there only was one field `InferPDiskSlotCountFromUnitSize`. For compatibility reasons it is preserved, but remains unused.

To replace deleted fields, one-piece structure `InferPDiskSlotCountSettings` is added to TBlobStorageConfig that is processed by NodeWarden. NodeWarden reads it on startup and subscribes to updates in the Console.
When a notification arrives, NodeWarden iterates over LocalPDisks and sends TEvChangeExpectedSlotCount when necessary.

Also, InferPDiskSlotCountSettings field is added to the QueryBaseConfig response.

- Closes https://github.com/ydb-platform/ydb/issues/21246

See also:
- https://github.com/ydb-platform/ydb/pull/31762
  - https://github.com/ydb-platform/ydb/pull/32333
  - https://github.com/ydb-platform/ydb/pull/32334
- https://github.com/ydb-platform/ydb/pull/31998
  - https://github.com/ydb-platform/ydb/pull/32335
  - https://github.com/ydb-platform/ydb/pull/32336