### PR TITLE
Support SASL SCRAM authentication with Kafka protocol

### DIFF
--- a/ydb/core/kafka_proxy/actors/actors.h
+++ b/ydb/core/kafka_proxy/actors/actors.h
@@ -94,7 +94,7 @@ public:
 
     T& operator*() const {
         return *Ptr;
-    } 
+    }
 
     operator bool() const {
         return nullptr != Ptr;
@@ -201,7 +201,7 @@ NActors::IActor* CreateKafkaReadSessionProxyActor(const TContext::TPtr context, 
 NActors::IActor* CreateKafkaReadSessionActor(const TContext::TPtr context, ui64 cookie);
 NActors::IActor* CreateKafkaBalancerActor(const TContext::TPtr context, ui64 cookie);
 NActors::IActor* CreateKafkaSaslHandshakeActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TSaslHandshakeRequestData>& message);
-NActors::IActor* CreateKafkaSaslAuthActor(const TContext::TPtr context, const ui64 correlationId, const NKikimr::NRawSocket::TSocketDescriptor::TSocketAddressType address, const TMessagePtr<TSaslAuthenticateRequestData>& message);
+NActors::IActor* CreateKafkaSaslAuthActor(const TContext::TPtr context, const NKikimr::NRawSocket::TSocketDescriptor::TSocketAddressType address);
 NActors::IActor* CreateKafkaListOffsetsActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TListOffsetsRequestData>& message);
 NActors::IActor* CreateKafkaListGroupsActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TListGroupsRequestData>& message);
 NActors::IActor* CreateKafkaDescribeGroupsActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TDescribeGroupsRequestData>& message);

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -1,24 +1,47 @@
-#include <ydb/core/grpc_services/local_rpc/local_rpc.h>
-#include <ydb/public/api/grpc/ydb_auth_v1.grpc.pb.h>
+#include "kafka_sasl_auth_actor.h"
+
+#include <ydb/core/audit/login_op.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/base/ticket_parser.h>
 #include <ydb/core/kafka_proxy/kafka_events.h>
-#include <ydb/core/tx/scheme_board/subscriber.h>
+#include <ydb/core/security/login_shared_func.h>
+#include <ydb/core/security/sasl/plain_auth_actor.h>
+#include <ydb/core/security/sasl/plain_ldap_auth_proxy_actor.h>
+#include <ydb/core/security/sasl/scram_auth_actor.h>
+#include <ydb/library/login/sasl/scram.h>
 #include <ydb/services/persqueue_v1/actors/persqueue_utils.h>
-#include <ydb/library/actors/core/actor.h>
-
-#include "kafka_sasl_auth_actor.h"
 
 
 namespace NKafka {
 
-static constexpr char EmptyAuthBytes[] = "";
+using namespace NSasl;
 
-NActors::IActor* CreateKafkaSaslAuthActor(const TContext::TPtr context, const ui64 correlationId, const NKikimr::NRawSocket::TSocketDescriptor::TSocketAddressType address, const TMessagePtr<TSaslAuthenticateRequestData>& message) {
-    return new TKafkaSaslAuthActor(context, correlationId, address, message);
+constexpr char AuditLogKafkaLoginComponent[] = "kafka-login";
+
+void AuditLogLogin(const NRawSocket::TNetworkConfig::TSocketAddressType& address, const TString& database,
+    const TString& username, const Ydb::StatusIds_StatusCode status, const TString& reason,
+    const TString& errorDetails, const TString& sanitizedToken, bool isAdmin = false)
+{
+    NAudit::LogLoginOperationResult(AuditLogKafkaLoginComponent, address->ToString(), database, username,
+        status, reason, errorDetails, sanitizedToken, isAdmin);
 }
 
-void TKafkaSaslAuthActor::Bootstrap(const NActors::TActorContext& ctx) {
+const TDuration TKafkaSaslAuthActor::Timeout = TDuration::MilliSeconds(60000);
+
+NActors::IActor* CreateKafkaSaslAuthActor(const TContext::TPtr context, const NRawSocket::TSocketDescriptor::TSocketAddressType address) {
+    return new TKafkaSaslAuthActor(context, address);
+}
+
+void TKafkaSaslAuthActor::Bootstrap() {
+    Become(&TKafkaSaslAuthActor::StateWork);
+}
+
+void TKafkaSaslAuthActor::HandleAuthRequest(TEvKafka::TEvAuthRequest::TPtr& ev, const NActors::TActorContext& ctx) {
+    auto& loginRequest = *ev->Get();
+    CorrelationId = loginRequest.CorrelationId;
+    const auto requestRowBytes = loginRequest.Request->AuthBytes.value_or(TKafkaRawBytes());
+    AuthRequest = TString(requestRowBytes.data(), requestRowBytes.size());
+
     if (Context->AuthenticationStep != EAuthSteps::WAIT_AUTH) {
         SendResponseAndDie(EKafkaErrors::ILLEGAL_SASL_STATE,
                              "Request is not valid given the current SASL state.",
@@ -26,44 +49,185 @@ void TKafkaSaslAuthActor::Bootstrap(const NActors::TActorContext& ctx) {
                              ctx);
         return;
     }
-    if (Context->SaslMechanism != "PLAIN") {
-        SendResponseAndDie(EKafkaErrors::UNSUPPORTED_SASL_MECHANISM,
-                             "Does not support the requested SASL mechanism.",
-                             TStringBuilder() << "Requested mechanism '" << Context->SaslMechanism << "'",
-                             ctx);
+
+    if (CurrentStateFunc() == &TThis::StateWork) {
+        if (Context->SaslMechanism == "PLAIN") {
+            StartPlainAuth(ctx);
+        } else if (Context->SaslMechanism == "SCRAM-SHA-256") {
+            StartScramAuth();
+        } else {
+            SendResponseAndDie(EKafkaErrors::UNSUPPORTED_SASL_MECHANISM,
+                                "Does not support the requested SASL mechanism.",
+                                TStringBuilder() << "Requested mechanism '" << Context->SaslMechanism << "'",
+                                ctx);
+            return;
+        }
+
+        SendDescribeRequest();
+        Become(&TKafkaSaslAuthActor::StateResolveDatabase);
+    } else if (CurrentStateFunc() == &TThis::StateSaslScramLogin) {
+        SendScramLoginRequest(ctx);
         return;
     }
-    Become(&TKafkaSaslAuthActor::StateWork);
-    StartPlainAuth(ctx);
 }
 
 void TKafkaSaslAuthActor::StartPlainAuth(const NActors::TActorContext& ctx) {
     if (!TryParseAuthDataTo(ClientAuthData, ctx)) {
         return;
     }
+}
 
-    DatabasePath = CanonizePath(ClientAuthData.Database);
+void TKafkaSaslAuthActor::StartScramAuth() {
+    DatabasePath = AppData()->TenantName;
+}
 
-    RequestState = ENavigateRequestState::DESCRIBING_DATABASE;
-    SendDescribeRequest(ctx);
+void TKafkaSaslAuthActor::HandleFirstLoginResponse(NSasl::TEvSasl::TEvSaslScramFirstServerResponse::TPtr& ev) {
+    auto& loginResponse = *ev->Get();
+    AuthResponse = std::move(loginResponse.Msg);
+    SendResponse();
+}
+
+void TKafkaSaslAuthActor::HandleLoginResult(const NYql::TIssue& issue, const std::string& reason, const std::string& token,
+    const std::string& sanitizedToken, bool isAdmin, const NActors::TActorContext& ctx)
+{
+    Ydb::StatusIds_StatusCode status;
+    TString errorMessage;
+    TString errorDetails;
+    switch (issue.GetCode()) {
+    case NKikimrIssues::TIssuesIds::SUCCESS: {
+        Ticket = "Login " + token;
+
+        AuditLogLogin(Address, DatabasePath, ClientAuthData.UserName, Ydb::StatusIds::SUCCESS, /* reason */ "",
+            /* errorDetails */ "", TString(sanitizedToken), isAdmin);
+        SendTicketParserRequest();
+        return;
+    }
+    case NKikimrIssues::TIssuesIds::ACCESS_DENIED: {
+        status = Ydb::StatusIds::UNAUTHORIZED;
+        errorMessage = issue.GetMessage();
+        errorDetails = reason;
+        break;
+    }
+    case NKikimrIssues::TIssuesIds::UNEXPECTED: {
+        status = Ydb::StatusIds::INTERNAL_ERROR;
+        errorMessage = issue.GetMessage();
+        break;
+    }
+    case NKikimrIssues::TIssuesIds::DATABASE_NOT_EXIST: {
+        status = Ydb::StatusIds::SCHEME_ERROR;
+        errorMessage = "No database found";
+        break;
+    }
+    case NKikimrIssues::TIssuesIds::SHARD_NOT_AVAILABLE: {
+        status = Ydb::StatusIds::UNAVAILABLE;
+        errorMessage = "SchemeShard is unreachable";
+        break;
+    }
+    case NKikimrIssues::TIssuesIds::DEFAULT_ERROR: {
+        status = Ydb::StatusIds::INTERNAL_ERROR;
+        errorMessage = issue.GetMessage();
+        break;
+    }
+    case NKikimrIssues::TIssuesIds::YDB_AUTH_UNAVAILABLE: {
+        status = Ydb::StatusIds::UNAVAILABLE;
+        errorMessage = issue.GetMessage();
+        errorDetails = reason;
+        break;
+    }
+    case NKikimrIssues::TIssuesIds::YDB_API_VALIDATION_ERROR: {
+        status = Ydb::StatusIds::BAD_REQUEST;
+        errorMessage = issue.GetMessage();
+        errorDetails = reason;
+        break;
+    }
+    default: {
+        status = Ydb::StatusIds::GENERIC_ERROR;
+        errorMessage = issue.GetMessage();
+        break;
+    }
+    }
+
+    if (ClientAuthData.UserName) {
+        AuditLogLogin(Address, DatabasePath, ClientAuthData.UserName, status, errorMessage, errorDetails,
+            /* sanitizedToken */ "");
+    }
+
+    if (errorMessage.empty()) {
+        errorMessage = Ydb::StatusIds_StatusCode_Name(status);
+    }
+
+    SendResponseAndDie(EKafkaErrors::SASL_AUTHENTICATION_FAILED, "", errorMessage, ctx);
+}
+
+void TKafkaSaslAuthActor::HandleLoginResult(TEvSasl::TEvSaslPlainLoginResponse::TPtr& ev, const NActors::TActorContext& ctx) {
+    auto& loginResult = *ev->Get();
+    HandleLoginResult(loginResult.Issue, "", loginResult.Token, loginResult.SanitizedToken, loginResult.IsAdmin, ctx);
+}
+
+void TKafkaSaslAuthActor::HandleLoginResult(TEvSasl::TEvSaslPlainLdapLoginResponse::TPtr& ev, const NActors::TActorContext& ctx) {
+    auto& loginResult = *ev->Get();
+    HandleLoginResult(loginResult.Issue, loginResult.Reason, loginResult.Token, loginResult.SanitizedToken, loginResult.IsAdmin, ctx);
+}
+
+void TKafkaSaslAuthActor::HandleLoginResult(TEvSasl::TEvSaslScramFinalServerResponse::TPtr& ev, const NActors::TActorContext& ctx) {
+    auto& loginResult = *ev->Get();
+    AuthResponse = std::move(loginResult.Msg);
+    ClientAuthData.UserName = std::move(loginResult.AuthcId);
+    ScramAuthActor = TActorId();
+
+    HandleLoginResult(loginResult.Issue, "", loginResult.Token, loginResult.SanitizedToken, loginResult.IsAdmin, ctx);
 }
 
 void TKafkaSaslAuthActor::Handle(NKikimr::TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const NActors::TActorContext& ctx) {
     if (ev->Get()->Error) {
+        if (Context->SaslMechanism == "SCRAM-SHA-256") {
+            AuthResponse = NLogin::NSasl::BuildErrorMsg(NLogin::NSasl::EScramServerError::OtherError);
+        }
+
         SendResponseAndDie(EKafkaErrors::SASL_AUTHENTICATION_FAILED, "", TString{ev->Get()->Error.Message}, ctx);
         return;
     }
-    UserToken = ev->Get()->Token;
 
+    UserToken = ev->Get()->Token;
     SendResponseAndDie(EKafkaErrors::NONE_ERROR, "", "", ctx);
 }
 
-void TKafkaSaslAuthActor::Handle(TEvPrivate::TEvTokenReady::TPtr& ev, const NActors::TActorContext& /*ctx*/) {
+void TKafkaSaslAuthActor::HandleTimeout(const NActors::TActorContext& ctx) {
+    const TString reason = "Login timeout";
+    SendResponseAndDie(EKafkaErrors::SASL_AUTHENTICATION_FAILED, "", reason, ctx);
+}
+
+void TKafkaSaslAuthActor::SendTicketParserRequest() {
     Send(NKikimr::MakeTicketParserID(), new NKikimr::TEvTicketParser::TEvAuthorizeTicket({
-        .Ticket = "Login " + ev->Get()->LoginResult.token(),
-        .Database = CanonizePath(ev->Get()->Database),
+        .Ticket = Ticket,
+        .Database = DatabasePath,
         .PeerName = TStringBuilder() << Address,
+        .Entries = TicketParserEntries,
     }));
+
+    Become(&TKafkaSaslAuthActor::StateTicketResolve);
+}
+
+void TKafkaSaslAuthActor::CleanupAndDie(const NActors::TActorContext& ctx) {
+    if (ScramAuthActor) {
+        Send(ScramAuthActor, new TEvents::TEvPoison());
+    }
+
+    Die(ctx);
+}
+
+void TKafkaSaslAuthActor::SendResponse() {
+    auto responseToClient = std::make_shared<TSaslAuthenticateResponseData>();
+    responseToClient->ErrorCode = EKafkaErrors::NONE_ERROR;
+    responseToClient->AuthBytesStr = AuthResponse;
+    responseToClient->AuthBytes = ToRawBytes(responseToClient->AuthBytesStr);
+    responseToClient->ErrorMessage = "";
+
+    KAFKA_LOG_D("Authentication first step finished."
+                    << " FirstServerMessage='" << AuthResponse << "'");
+
+    auto evResponse = std::make_unique<TEvKafka::TEvResponse>(CorrelationId, responseToClient, EKafkaErrors::NONE_ERROR);
+    Send(Context->ConnectionId, evResponse.release());
 }
 
 void TKafkaSaslAuthActor::SendResponseAndDie(EKafkaErrors errorCode, const TString& errorMessage, const TString& details, const NActors::TActorContext& ctx) {
@@ -71,7 +235,8 @@ void TKafkaSaslAuthActor::SendResponseAndDie(EKafkaErrors errorCode, const TStri
 
     auto responseToClient = std::make_shared<TSaslAuthenticateResponseData>();
     responseToClient->ErrorCode = errorCode;
-    responseToClient->AuthBytes = TKafkaRawBytes(EmptyAuthBytes, sizeof(EmptyAuthBytes));
+    responseToClient->AuthBytesStr = AuthResponse;
+    responseToClient->AuthBytes = ToRawBytes(responseToClient->AuthBytesStr);
 
     if (isFailed) {
         KAFKA_LOG_ERROR("Authentication failure. " << errorMessage << " " << details);
@@ -81,7 +246,7 @@ void TKafkaSaslAuthActor::SendResponseAndDie(EKafkaErrors errorCode, const TStri
         auto authResult = new TEvKafka::TEvAuthResult(EAuthSteps::FAILED, evResponse, errorMessage);
         Send(Context->ConnectionId, authResult);
     } else {
-        KAFKA_LOG_D("Authentificated success. Database='" << DatabasePath << "', "
+        KAFKA_LOG_D("Authentication success. Database='" << DatabasePath << "', "
                                       << "FolderId='" << FolderId << "', "
                                       << "ServiceAccountId='" << ServiceAccountId << "', "
                                       << "DatabaseId='" << DatabaseId << "', "
@@ -98,19 +263,13 @@ void TKafkaSaslAuthActor::SendResponseAndDie(EKafkaErrors errorCode, const TStri
     Die(ctx);
 }
 
-void TKafkaSaslAuthActor::Handle(TEvPrivate::TEvAuthFailed::TPtr& ev, const NActors::TActorContext& ctx) {
-    SendResponseAndDie(EKafkaErrors::SASL_AUTHENTICATION_FAILED, "", ev->Get()->ErrorMessage, ctx);
-}
-
 bool TKafkaSaslAuthActor::TryParseAuthDataTo(TKafkaSaslAuthActor::TAuthData& authData, const NActors::TActorContext& ctx) {
-    if (!AuthenticateRequestData->AuthBytes.has_value()) {
+    if (AuthRequest.empty()) {
         SendResponseAndDie(EKafkaErrors::SASL_AUTHENTICATION_FAILED, "", "AuthBytes is empty.",  ctx);
         return false;
     }
 
-    TKafkaRawBytes rawAuthBytes = AuthenticateRequestData->AuthBytes.value();
-    TString auth(rawAuthBytes.data(), rawAuthBytes.size());
-    TVector<TString> tokens = StringSplitter(auth).Split('\0');
+    TVector<TString> tokens = StringSplitter(AuthRequest).Split('\0');
     if (tokens.size() != 3) {
         SendResponseAndDie(EKafkaErrors::SASL_AUTHENTICATION_FAILED, TStringBuilder() << "Invalid SASL/PLAIN response: expected 3 tokens, got " << tokens.size(), "", ctx);
         return false;
@@ -122,61 +281,45 @@ bool TKafkaSaslAuthActor::TryParseAuthDataTo(TKafkaSaslAuthActor::TAuthData& aut
     size_t atPos = userAndDatabase.rfind('@');
     if (atPos == TString::npos) {
         authData.UserName = "";
-        authData.Database = userAndDatabase;
+        DatabasePath = CanonizePath(userAndDatabase);
     } else {
         authData.UserName = userAndDatabase.substr(0, atPos);
-        authData.Database = userAndDatabase.substr(atPos + 1);
+        DatabasePath = CanonizePath(userAndDatabase.substr(atPos + 1));
     }
 
     authData.Password = password;
     return true;
 }
 
-void TKafkaSaslAuthActor::SendLoginRequest(TKafkaSaslAuthActor::TAuthData authData, const NActors::TActorContext& ctx) {
-    Ydb::Auth::LoginRequest request;
-    request.set_user(authData.UserName);
-    request.set_password(authData.Password);
-    auto* actorSystem = ctx.ActorSystem();
-
-    using TRpcEv = NKikimr::NGRpcService::TGRpcRequestWrapperNoAuth<NKikimr::NGRpcService::TRpcServices::EvLogin, Ydb::Auth::LoginRequest, Ydb::Auth::LoginResponse>;
-    auto rpcFuture = NKikimr::NRpcService::DoLocalRpc<TRpcEv>(std::move(request), authData.Database, {}, actorSystem);
-    rpcFuture.Subscribe([authData, actorSystem, selfId = SelfId()](const NThreading::TFuture<Ydb::Auth::LoginResponse>& future) {
-        auto& response = future.GetValueSync();
-
-        if (response.operation().status() == Ydb::StatusIds::SUCCESS) {
-            auto tokenReadyEvent = std::make_unique<TEvPrivate::TEvTokenReady>();
-            response.operation().result().UnpackTo(&(tokenReadyEvent->LoginResult));
-            tokenReadyEvent->Database = authData.Database;
-            actorSystem->Schedule(TDuration::Seconds(1), new IEventHandle(selfId, selfId, tokenReadyEvent.release())); // FIXME(savnik): replace Schedule to Send
-        } else {
-            auto authFailedEvent = std::make_unique<TEvPrivate::TEvAuthFailed>();
-            if (response.operation().issues_size() > 0) {
-                authFailedEvent->ErrorMessage = response.operation().issues(0).message();
-            } else {
-                authFailedEvent->ErrorMessage = Ydb::StatusIds_StatusCode_Name(response.operation().status());
-            }
-            actorSystem->Send(selfId, authFailedEvent.release());
-        }
-    });
-}
-
-void TKafkaSaslAuthActor::SendApiKeyRequest() {
-    auto entries = NKikimr::NGRpcProxy::V1::GetTicketParserEntries(DatabaseId, FolderId);
-    TString ticket;
-    if (Context->Config.GetAuthViaApiKey()) {
-        ticket = "ApiKey " + ClientAuthData.Password;
+void TKafkaSaslAuthActor::SendPlainLoginRequest(const NActors::TActorContext& ctx) {
+    std::unique_ptr<IActor> authActor;
+    if (IsUsernameFromLdapDomain(ClientAuthData.UserName, AppData()->AuthConfig)) {
+        const TString ldapUsername = PrepareLdapUsername(ClientAuthData.UserName, AppData()->AuthConfig);
+        const TString authMsg = PrepareSaslPlainAuthMsg(ldapUsername, ClientAuthData.Password);
+        authActor = CreatePlainLdapAuthProxyActor(ctx.SelfID, DatabasePath, authMsg, Address->ToString());
     } else {
-        ticket = ClientAuthData.Password;
+        const TString authMsg = PrepareSaslPlainAuthMsg(ClientAuthData.UserName, ClientAuthData.Password);
+        authActor = CreatePlainAuthActor(ctx.SelfID, DatabasePath, authMsg, Address->ToString());
     }
-    Send(NKikimr::MakeTicketParserID(), new NKikimr::TEvTicketParser::TEvAuthorizeTicket({
-        .Ticket = ticket,
-        .Database = DatabasePath,
-        .PeerName = TStringBuilder() << Address,
-        .Entries = entries
-    }));
+
+    Register(authActor.release());
+    Become(&TKafkaSaslAuthActor::StateSaslPlainLogin, Timeout, new TEvents::TEvWakeup());
 }
 
-void TKafkaSaslAuthActor::SendDescribeRequest(const TActorContext& ctx) {
+void TKafkaSaslAuthActor::SendScramLoginRequest(const NActors::TActorContext& ctx) {
+    std::string authMsg = AuthRequest;
+    if (!ScramAuthActor) {
+        auto authActor = CreateScramAuthActor(ctx.SelfID, DatabasePath, NLoginProto::EHashType::ScramSha256, authMsg, Address->ToString());
+        ScramAuthActor = Register(authActor.release());
+        Become(&TKafkaSaslAuthActor::StateSaslScramLogin, Timeout, new TEvents::TEvWakeup());
+    } else {
+        auto event = std::make_unique<NKikimr::NSasl::TEvSasl::TEvSaslScramFinalClientRequest>();
+        event->Msg = std::move(authMsg);
+        Send(ScramAuthActor, event.release());
+    }
+}
+
+void TKafkaSaslAuthActor::SendDescribeRequest() {
     auto schemeCacheRequest = std::make_unique<NKikimr::NSchemeCache::TSchemeCacheNavigate>();
     NKikimr::NSchemeCache::TSchemeCacheNavigate::TEntry entry;
     entry.Path = NKikimr::SplitPath(DatabasePath);
@@ -184,10 +327,10 @@ void TKafkaSaslAuthActor::SendDescribeRequest(const TActorContext& ctx) {
     entry.SyncVersion = false;
     schemeCacheRequest->ResultSet.emplace_back(entry);
     schemeCacheRequest->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
-    ctx.Send(NKikimr::MakeSchemeCacheID(), MakeHolder<NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
+    Send(NKikimr::MakeSchemeCacheID(), MakeHolder<NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
 }
 
-void TKafkaSaslAuthActor::GetPathByPathId(const TPathId& pathId, const TActorContext& ctx) {
+void TKafkaSaslAuthActor::GetPathByPathId(const TPathId& pathId) {
     auto schemeCacheRequest = std::make_unique<NKikimr::NSchemeCache::TSchemeCacheNavigate>();
     NKikimr::NSchemeCache::TSchemeCacheNavigate::TEntry entry;
     entry.TableId.PathId = pathId;
@@ -197,10 +340,10 @@ void TKafkaSaslAuthActor::GetPathByPathId(const TPathId& pathId, const TActorCon
     entry.RedirectRequired = false;
     schemeCacheRequest->ResultSet.emplace_back(entry);
     schemeCacheRequest->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
-    ctx.Send(NKikimr::MakeSchemeCacheID(), MakeHolder<NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
+    Send(NKikimr::MakeSchemeCacheID(), MakeHolder<NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
 }
 
-void TKafkaSaslAuthActor::Handle(NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx) {
+void TKafkaSaslAuthActor::HandleNavigate(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx) {
     const NKikimr::NSchemeCache::TSchemeCacheNavigate* navigate = ev->Get()->Request.Get();
     if (navigate->ErrorCount) {
         switch(navigate->ResultSet.front().Status) {
@@ -217,31 +360,58 @@ void TKafkaSaslAuthActor::Handle(NKikimr::TEvTxProxySchemeCache::TEvNavigateKeyS
         }
         return;
     }
-    if (RequestState == ENavigateRequestState::DESCRIBING_DATABASE) {
+
+    if (CurrentStateFunc() == &TThis::StateResolveDatabase) {
         Y_ABORT_UNLESS(navigate->ResultSet.size() == 1);
         IsServerless = navigate->ResultSet.front().DomainInfo->IsServerless();
 
         for (const auto& attr : navigate->ResultSet.front().Attributes) {
-            if (attr.first == "folder_id") FolderId = attr.second;
-            else if (attr.first == "cloud_id") CloudId = attr.second;
-            else if (attr.first == "database_id") DatabaseId = attr.second;
-            else if (attr.first == "service_account_id") ServiceAccountId = attr.second;
-            else if (attr.first == "serverless_rt_coordination_node_path") Coordinator = attr.second;
-            else if (attr.first == "serverless_rt_topic_resource_ru") ResourcePath = attr.second;
-            else if (attr.first == "kafka_api") KafkaApiFlag = attr.second;
+            if (attr.first == "folder_id") {
+                FolderId = attr.second;
+            } else if (attr.first == "cloud_id") {
+                CloudId = attr.second;
+            } else if (attr.first == "database_id") {
+                DatabaseId = attr.second;
+            } else if (attr.first == "service_account_id") {
+                ServiceAccountId = attr.second;
+            } else if (attr.first == "serverless_rt_coordination_node_path") {
+                Coordinator = attr.second;
+            } else if (attr.first == "serverless_rt_topic_resource_ru") {
+                ResourcePath = attr.second;
+            } else if (attr.first == "kafka_api") {
+                KafkaApiFlag = attr.second;
+            }
         }
 
-        RequestState = ENavigateRequestState::RESOLVING_DOMAIN_KEY;
-        GetPathByPathId(navigate->ResultSet.front().DomainInfo->GetResourcesDomainKey(), ctx);
-
-    } else if (RequestState == ENavigateRequestState::RESOLVING_DOMAIN_KEY) {
-        ResourseDatabasePath = NKikimr::JoinPath(navigate->ResultSet.front().Path);
-        if (ClientAuthData.UserName.empty()) {
-            // ApiKey IAM authentification
-            SendApiKeyRequest();
+        if (IsServerless) {
+            GetPathByPathId(navigate->ResultSet.front().DomainInfo->GetResourcesDomainKey());
+            Become(&TKafkaSaslAuthActor::StateResolveSharedDatabase);
+            return;
         } else {
-            // Login/Password authentification
-            SendLoginRequest(ClientAuthData, ctx);
+            ResourseDatabasePath = NKikimr::JoinPath(navigate->ResultSet.front().Path);
+        }
+    } else if (CurrentStateFunc() == &TThis::StateResolveSharedDatabase) {
+        ResourseDatabasePath = NKikimr::JoinPath(navigate->ResultSet.front().Path);
+    }
+
+    if (ResourseDatabasePath) {
+        if (Context->SaslMechanism == "PLAIN") {
+            if (ClientAuthData.UserName.empty()) {
+                // ApiKey IAM authentification
+                if (Context->Config.GetAuthViaApiKey()) {
+                    Ticket = "ApiKey " + ClientAuthData.Password;
+                } else {
+                    Ticket = ClientAuthData.Password;
+                }
+                TicketParserEntries = NKikimr::NGRpcProxy::V1::GetTicketParserEntries(DatabaseId, FolderId);
+                SendTicketParserRequest();
+            } else {
+                // Plain Login/Password authentication
+                SendPlainLoginRequest(ctx);
+            }
+        } else if (Context->SaslMechanism == "SCRAM-SHA-256") {
+            // Scram Login/Password authentication
+            SendScramLoginRequest(ctx);
         }
     }
 }

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/security/login_shared_func.h>
 #include <ydb/core/security/sasl/plain_auth_actor.h>
 #include <ydb/core/security/sasl/plain_ldap_auth_proxy_actor.h>
+#include <ydb/library/login/sasl/plain.h>
 #include <ydb/core/security/sasl/scram_auth_actor.h>
 #include <ydb/library/login/sasl/scram.h>
 #include <ydb/services/persqueue_v1/actors/persqueue_utils.h>
@@ -293,12 +294,12 @@ bool TKafkaSaslAuthActor::TryParseAuthDataTo(TKafkaSaslAuthActor::TAuthData& aut
 
 void TKafkaSaslAuthActor::SendPlainLoginRequest(const NActors::TActorContext& ctx) {
     std::unique_ptr<IActor> authActor;
-    if (IsUsernameFromLdapDomain(ClientAuthData.UserName, AppData()->AuthConfig)) {
+    if (IsUsernameFromLdapAuthDomain(ClientAuthData.UserName, AppData()->AuthConfig)) {
         const TString ldapUsername = PrepareLdapUsername(ClientAuthData.UserName, AppData()->AuthConfig);
-        const TString authMsg = PrepareSaslPlainAuthMsg(ldapUsername, ClientAuthData.Password);
+        const TString authMsg = NLogin::NSasl::BuildSaslPlainAuthMsg(ldapUsername, ClientAuthData.Password);
         authActor = CreatePlainLdapAuthProxyActor(ctx.SelfID, DatabasePath, authMsg, Address->ToString());
     } else {
-        const TString authMsg = PrepareSaslPlainAuthMsg(ClientAuthData.UserName, ClientAuthData.Password);
+        const TString authMsg = NLogin::NSasl::BuildSaslPlainAuthMsg(ClientAuthData.UserName, ClientAuthData.Password);
         authActor = CreatePlainAuthActor(ctx.SelfID, DatabasePath, authMsg, Address->ToString());
     }
 

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_handshake_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_handshake_actor.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/base/ticket_parser.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/core/kafka_proxy/kafka_events.h>
+#include <ydb/core/security/login_shared_func.h>
 
 #include "kafka_sasl_handshake_actor.h"
 
@@ -26,6 +27,11 @@ void TKafkaSaslHandshakeActor::Handshake() {
         SendResponse("Does not support the requested SASL mechanism.", EKafkaErrors::UNSUPPORTED_SASL_MECHANISM, EAuthSteps::FAILED);
         return;
     }
+
+    if (HandshakeRequestData->Mechanism->StartsWith("SCRAM") && NKikimr::IsLdapAuthenticationEnable(NKikimr::AppData()->AuthConfig)) {
+        SendResponse("Does not support Scram mechanisms with LDAP authentication.", EKafkaErrors::UNSUPPORTED_SASL_MECHANISM, EAuthSteps::FAILED);
+    }
+
     SendResponse("", EKafkaErrors::NONE_ERROR, EAuthSteps::WAIT_AUTH, TStringBuilder() << HandshakeRequestData->Mechanism);
 }
 

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_handshake_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_handshake_actor.h
@@ -12,7 +12,8 @@ namespace NKafka {
 class TKafkaSaslHandshakeActor: public NActors::TActorBootstrapped<TKafkaSaslHandshakeActor> {
 
 const TVector<TString> SUPPORTED_SASL_MECHANISMS = {
-    "PLAIN"
+    "PLAIN",
+    "SCRAM-SHA-256",
 };
 
 public:

--- a/ydb/core/kafka_proxy/kafka_events.h
+++ b/ydb/core/kafka_proxy/kafka_events.h
@@ -18,6 +18,7 @@ struct TEvKafka {
     enum EEv {
         EvRequest = EventSpaceBegin(NKikimr::TKikimrEvents::TKikimrEvents::ES_KAFKA),
         EvProduceRequest,
+        EvAuthRequest,
         EvAuthResult,
         EvHandshakeResult,
         EvWakeup,
@@ -138,6 +139,17 @@ struct TEvKafka {
         const ui64 CorrelationId;
         const TApiMessage::TPtr Response;
         const EKafkaErrors ErrorCode;
+    };
+
+    struct TEvAuthRequest : public TEventLocal<TEvAuthRequest, EvAuthRequest> {
+        TEvAuthRequest(const ui64 correlationId, const TMessagePtr<TSaslAuthenticateRequestData>& request)
+            : CorrelationId(correlationId)
+            , Request(request)
+        {
+        }
+
+        ui64 CorrelationId;
+        const TMessagePtr<TSaslAuthenticateRequestData> Request;
     };
 
     struct TEvAuthResult : public TEventLocal<TEvAuthResult, EvAuthResult> {

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
@@ -1,8 +1,12 @@
 #include "kafka_test_client.h"
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/string_utils/base64/base64.h>
 
 #include <ydb/core/kafka_proxy/kafka_constants.h>
+#include <ydb/library/login/sasl/scram.h>
+
+#include <util/random/random.h>
 
 static constexpr TKafkaUint16 ASSIGNMENT_VERSION = 3;
 
@@ -62,16 +66,49 @@ TMessagePtr<TSaslHandshakeResponseData> TKafkaTestClient::SaslHandshake(const TS
     return WriteAndRead<TSaslHandshakeResponseData>(header, request);
 }
 
-TMessagePtr<TSaslAuthenticateResponseData> TKafkaTestClient::SaslAuthenticate(const TString& user, const TString& password) {
+TMessagePtr<TSaslAuthenticateResponseData> TKafkaTestClient::SaslPlainAuthenticate(const TString& user, const TString& password) {
     Cerr << ">>>>> SaslAuthenticateRequestData\n";
 
     TStringBuilder authBytes;
-    authBytes << "ignored" << '\0' << user << '\0' << password;
+    authBytes << "authzid" << '\0' << user << '\0' << password;
 
     TRequestHeaderData header = Header(NKafka::EApiKey::SASL_AUTHENTICATE, 2);
 
     TSaslAuthenticateRequestData request;
     request.AuthBytes = ToRawBytes(authBytes);
+
+    return WriteAndRead<TSaslAuthenticateResponseData>(header, request);
+}
+
+TMessagePtr<TSaslAuthenticateResponseData> TKafkaTestClient::SaslScramAuthenticateFirstMsg(const TString& user, const TString& clientNonce) {
+    Cerr << ">>>>> SaslAuthenticateRequestData (SCRAM first message)\n";
+
+    // Build first client message
+    TString gs2Header = "n,,"; // No channel binding, no authzid
+    TString clientFirstMessageBare = TStringBuilder() << "n=" << user << ",r=" << clientNonce;
+    TString clientFirstMessage = gs2Header + clientFirstMessageBare;
+
+    TRequestHeaderData header = Header(NKafka::EApiKey::SASL_AUTHENTICATE, 2);
+    TSaslAuthenticateRequestData request;
+    request.AuthBytes = ToRawBytes(clientFirstMessage);
+
+    return WriteAndRead<TSaslAuthenticateResponseData>(header, request);
+}
+
+TMessagePtr<TSaslAuthenticateResponseData> TKafkaTestClient::SaslScramAuthenticateFinalMsg(const TString& nonce, const TString& clientProof) {
+    Cerr << ">>>>> SaslAuthenticateRequestData (SCRAM final message)\n";
+
+    // Build client final message without proof
+    TString gs2Header = "n,,"; // No channel binding, no authzid
+    TString channelBinding = Base64Encode(gs2Header);
+    TString clientFinalMessageWithoutProof = TStringBuilder() << "c=" << channelBinding << ",r=" << nonce;
+
+    // Build final client message (clientProof is already base64 encoded)
+    TString clientFinalMessage = clientFinalMessageWithoutProof + ",p=" + clientProof;
+
+    TRequestHeaderData header = Header(NKafka::EApiKey::SASL_AUTHENTICATE, 2);
+    TSaslAuthenticateRequestData request;
+    request.AuthBytes = ToRawBytes(clientFinalMessage);
 
     return WriteAndRead<TSaslAuthenticateResponseData>(header, request);
 }
@@ -707,11 +744,11 @@ void TKafkaTestClient::UnknownApiKey() {
     Write(So, &header, &request);
 }
 
-void TKafkaTestClient::AuthenticateToKafka() {
-    AuthenticateToKafka("ouruser@/Root", "ourUserPassword");
+void TKafkaTestClient::PlainAuthenticateToKafka() {
+    PlainAuthenticateToKafka("ouruser@/Root", "ourUserPassword");
 }
 
-void TKafkaTestClient::AuthenticateToKafka(const TString& userName, const TString& userPassword) {
+void TKafkaTestClient::PlainAuthenticateToKafka(const TString& userName, const TString& userPassword) {
     {
         auto msg = ApiVersions();
 
@@ -723,15 +760,165 @@ void TKafkaTestClient::AuthenticateToKafka(const TString& userName, const TStrin
         auto msg = SaslHandshake();
 
         UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-        UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 2u);
         UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[0], "PLAIN");
+        UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[1], "SCRAM-SHA-256");
     }
 
     {
-        auto msg = SaslAuthenticate(userName, userPassword);
+        auto msg = SaslPlainAuthenticate(userName, userPassword);
         UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
     }
 
+}
+
+void TKafkaTestClient::ScramAuthenticateToKafka() {
+    ScramAuthenticateToKafka("ouruser", "ourUserPassword");
+}
+
+void TKafkaTestClient::ScramAuthenticateToKafka(const TString& userName, const TString& userPassword) {
+    {
+        auto msg = ApiVersions();
+
+        UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(msg->ApiKeys.size(), EXPECTED_API_KEYS_COUNT);
+    }
+
+    {
+        auto msg = SaslHandshake("SCRAM-SHA-256");
+
+        UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[0], "PLAIN");
+        UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[1], "SCRAM-SHA-256");
+    }
+
+    // Generate random client nonce (16 random bytes encoded as base64)
+    TString randomBytes;
+    randomBytes.reserve(16);
+    for (size_t i = 0; i < 16; ++i) {
+        randomBytes += static_cast<char>(RandomNumber<ui8>());
+    }
+    TString clientNonce = Base64Encode(randomBytes);
+
+    // Build first client message bare for auth message computation
+    TString clientFirstMessageBare = TStringBuilder() << "n=" << userName << ",r=" << clientNonce;
+
+    // Send first SCRAM message
+    auto response1 = SaslScramAuthenticateFirstMsg(userName, clientNonce);
+
+    // Check for errors in the first response
+    if (response1->ErrorCode != static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR)) {
+        // Try to parse as error message
+        std::string errorMessage(response1->AuthBytes->data(), response1->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        if (parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success && !errorMsg.Error.empty()) {
+            UNIT_FAIL("SCRAM authentication failed with error: " + TString(errorMsg.Error));
+        } else {
+            UNIT_FAIL("SCRAM authentication failed with error code: " + ToString(response1->ErrorCode));
+        }
+    }
+
+    // Parse server first message
+    UNIT_ASSERT(response1->AuthBytes.has_value());
+    const auto& authBytes1 = response1->AuthBytes.value();
+    std::string serverFirstMessage(reinterpret_cast<const char*>(authBytes1.data()), authBytes1.size());
+
+    NLogin::NSasl::TFirstServerMsg parsedServerMsg;
+    auto parseResult = NLogin::NSasl::ParseFirstServerMsg(serverFirstMessage, parsedServerMsg);
+    UNIT_ASSERT_C(parseResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse server first message");
+
+    // Decode salt from base64
+    TString decodedSalt = Base64StrictDecode(parsedServerMsg.Salt);
+
+    // Build client final message without proof
+    TString gs2Header = "n,,"; // No channel binding, no authzid
+    TString channelBinding = Base64Encode(gs2Header);
+    TString clientFinalMessageWithoutProof = TStringBuilder() << "c=" << channelBinding << ",r=" << parsedServerMsg.Nonce;
+
+    // Compute auth message
+    TString authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
+
+    // Compute client proof
+    std::string clientProof;
+    std::string errorText;
+    bool success = NLogin::NSasl::ComputeClientProof(
+        "SCRAM-SHA-256",
+        std::string(userPassword.data(), userPassword.size()),
+        std::string(decodedSalt.data(), decodedSalt.size()),
+        parsedServerMsg.IterationsCount,
+        std::string(authMessage.data(), authMessage.size()),
+        clientProof,
+        errorText
+    );
+    UNIT_ASSERT_C(success, TString(errorText));
+
+    // Encode client proof to base64
+    TString encodedClientProof = Base64Encode(clientProof);
+
+    // Send final SCRAM message
+    auto response2 = SaslScramAuthenticateFinalMsg(TString(parsedServerMsg.Nonce), encodedClientProof);
+    UNIT_ASSERT_VALUES_EQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+    // Parse server final message to verify server signature
+    UNIT_ASSERT(response2->AuthBytes.has_value());
+    const auto& authBytes2 = response2->AuthBytes.value();
+    std::string serverFinalMessage(reinterpret_cast<const char*>(authBytes2.data()), authBytes2.size());
+
+    Cerr << ">>>>> Server final message: " << serverFinalMessage << Endl;
+    Cerr << ">>>>> Server final message length: " << serverFinalMessage.size() << Endl;
+
+    // DEBUG: Print raw bytes
+    Cerr << ">>>>> Raw bytes: ";
+    for (size_t i = 0; i < authBytes2.size(); ++i) {
+        Cerr << "0x" << Hex((unsigned char)authBytes2[i]) << " ";
+    }
+    Cerr << Endl;
+
+    NLogin::NSasl::TFinalServerMsg parsedFinalServerMsg;
+    auto parseFinalResult = NLogin::NSasl::ParseFinalServerMsg(serverFinalMessage, parsedFinalServerMsg);
+    UNIT_ASSERT_C(parseFinalResult == NLogin::NSasl::EParseMsgReturnCodes::Success,
+        "Failed to parse server final message. Message: '" + TString(serverFinalMessage) + "'");
+
+    // Check if there's an error in the server response
+    UNIT_ASSERT_C(parsedFinalServerMsg.Error.empty(), "Server returned error: " + TString(parsedFinalServerMsg.Error));
+
+    // Verify server signature
+    UNIT_ASSERT_C(!parsedFinalServerMsg.ServerSignature.empty(), "Server signature is empty");
+
+    // Compute expected server signature
+    std::string serverKey;
+    std::string errorText2;
+    bool success2 = NLogin::NSasl::ComputeServerKey(
+        "SCRAM-SHA-256",
+        std::string(userPassword.data(), userPassword.size()),
+        std::string(decodedSalt.data(), decodedSalt.size()),
+        parsedServerMsg.IterationsCount,
+        serverKey,
+        errorText2
+    );
+    UNIT_ASSERT_C(success2, TString(errorText2));
+
+    std::string expectedServerSignature;
+    success2 = NLogin::NSasl::ComputeServerSignature(
+        "SCRAM-SHA-256",
+        serverKey,
+        std::string(authMessage.data(), authMessage.size()),
+        expectedServerSignature,
+        errorText2
+    );
+    UNIT_ASSERT_C(success2, TString(errorText2));
+
+    // Decode received server signature from base64
+    TString decodedServerSignature = Base64StrictDecode(parsedFinalServerMsg.ServerSignature);
+
+    // Compare signatures
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        TString(expectedServerSignature.data(), expectedServerSignature.size()),
+        decodedServerSignature,
+        "Server signature verification failed"
+    );
 }
 
 TRequestHeaderData TKafkaTestClient::Header(NKafka::EApiKey apiKey, TKafkaVersion version) {

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.h
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.h
@@ -63,7 +63,11 @@ class TKafkaTestClient {
 
         TMessagePtr<TSaslHandshakeResponseData> SaslHandshake(const TString& mechanism = "PLAIN");
 
-        TMessagePtr<TSaslAuthenticateResponseData> SaslAuthenticate(const TString& user, const TString& password);
+        TMessagePtr<TSaslAuthenticateResponseData> SaslPlainAuthenticate(const TString& user, const TString& password);
+
+        TMessagePtr<TSaslAuthenticateResponseData> SaslScramAuthenticateFirstMsg(const TString& user, const TString& clientNonce);
+
+        TMessagePtr<TSaslAuthenticateResponseData> SaslScramAuthenticateFinalMsg(const TString& nonce, const TString& clientProof);
 
         TMessagePtr<TInitProducerIdResponseData> InitProducerId(const std::optional<TString>& transactionalId = {}, ui64 txnTimeoutMs = 1000);
 
@@ -135,9 +139,13 @@ class TKafkaTestClient {
 
         void UnknownApiKey();
 
-        void AuthenticateToKafka();
+        void PlainAuthenticateToKafka();
 
-        void AuthenticateToKafka(const TString& userName, const TString& userPassword);
+        void PlainAuthenticateToKafka(const TString& userName, const TString& userPassword);
+
+        void ScramAuthenticateToKafka();
+
+        void ScramAuthenticateToKafka(const TString& userName, const TString& userPassword);
 
         TRequestHeaderData Header(NKafka::EApiKey apiKey, TKafkaVersion version);
 

--- a/ydb/core/kafka_proxy/ut/test_server.cpp
+++ b/ydb/core/kafka_proxy/ut/test_server.cpp
@@ -1,0 +1,207 @@
+#include "test_server.h"
+
+template <class TKikimr, bool secure>
+TTestServer<TKikimr, secure>::TTestServer(const TTestServerSettings& settings) {
+    TPortManager portManager;
+    Port = portManager.GetTcpPort();
+
+    ui16 accessServicePort = portManager.GetPort(4284);
+    TString accessServiceEndpoint = "localhost:" + ToString(accessServicePort);
+
+    NKikimrConfig::TAppConfig appConfig;
+    appConfig.MutableAuthConfig()->SetUseLoginProvider(true);
+    appConfig.MutableAuthConfig()->SetUseBlackBox(false);
+    appConfig.MutableAuthConfig()->SetUseBlackBox(false);
+    appConfig.MutableAuthConfig()->SetUseAccessService(true);
+    appConfig.MutableAuthConfig()->SetUseAccessServiceApiKey(true);
+    appConfig.MutableAuthConfig()->SetUseAccessServiceTLS(false);
+    appConfig.MutableAuthConfig()->SetAccessServiceEndpoint(accessServiceEndpoint);
+
+    appConfig.MutablePQConfig()->SetTopicsAreFirstClassCitizen(true);
+    appConfig.MutablePQConfig()->SetEnabled(true);
+    // NOTE(shmel1k@): KIKIMR-14221
+    if (!settings.CheckACL) {
+        appConfig.MutablePQConfig()->SetCheckACL(false);
+    }
+    appConfig.MutablePQConfig()->SetRequireCredentialsInNewProtocol(false);
+
+    auto cst = appConfig.MutablePQConfig()->AddClientServiceType();
+    cst->SetName("data-transfer");
+    cst = appConfig.MutablePQConfig()->AddClientServiceType();
+    cst->SetName("data-transfer2");
+
+    appConfig.MutableKafkaProxyConfig()->SetEnableKafkaProxy(true);
+    appConfig.MutableKafkaProxyConfig()->SetListeningPort(Port);
+    appConfig.MutableKafkaProxyConfig()->SetMaxMessageSize(1024);
+    appConfig.MutableKafkaProxyConfig()->SetMaxInflightSize(2048);
+    if (settings.EnableAutoTopicCreation) {
+        appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(true);
+    }
+    appConfig.MutableKafkaProxyConfig()->SetTopicCreationDefaultPartitions(2);
+    if (!settings.EnableAutoConsumerCreation) {
+        appConfig.MutableKafkaProxyConfig()->SetAutoCreateConsumersEnable(false);
+    }
+    if (settings.Serverless) {
+        appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetHostname("localhost");
+        appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetPort(FAKE_SERVERLESS_KAFKA_PROXY_PORT);
+    }
+
+    appConfig.MutablePQConfig()->MutableQuotingConfig()->SetEnableQuoting(settings.EnableQuoting);
+    if (!settings.EnableQuoting)
+        appConfig.MutablePQConfig()->MutableQuotingConfig()->SetEnableReadQuoting(false);
+
+    appConfig.MutablePQConfig()->MutableQuotingConfig()->SetQuotaWaitDurationMs(300);
+    appConfig.MutablePQConfig()->MutableQuotingConfig()->SetPartitionReadQuotaIsTwiceWriteQuota(settings.EnableQuoting);
+    appConfig.MutablePQConfig()->MutableBillingMeteringConfig()->SetEnabled(true);
+    appConfig.MutablePQConfig()->MutableBillingMeteringConfig()->SetFlushIntervalSec(1);
+    appConfig.MutablePQConfig()->AddClientServiceType()->SetName("data-streams");
+    appConfig.MutablePQConfig()->AddNonChargeableUser(NON_CHARGEABLE_USER);
+    appConfig.MutablePQConfig()->AddNonChargeableUser(NON_CHARGEABLE_USER_X);
+    appConfig.MutablePQConfig()->AddNonChargeableUser(NON_CHARGEABLE_USER_Y);
+
+    appConfig.MutablePQConfig()->AddValidWriteSpeedLimitsKbPerSec(128);
+    appConfig.MutablePQConfig()->AddValidWriteSpeedLimitsKbPerSec(512);
+    appConfig.MutablePQConfig()->AddValidWriteSpeedLimitsKbPerSec(1_KB);
+
+    appConfig.MutableGRpcConfig()->SetHost("::1");
+    auto limit = appConfig.MutablePQConfig()->AddValidRetentionLimits();
+    limit->SetMinPeriodSeconds(0);
+    limit->SetMaxPeriodSeconds(TDuration::Days(1).Seconds());
+    limit->SetMinStorageMegabytes(0);
+    limit->SetMaxStorageMegabytes(0);
+
+    limit = appConfig.MutablePQConfig()->AddValidRetentionLimits();
+    limit->SetMinPeriodSeconds(0);
+    limit->SetMaxPeriodSeconds(TDuration::Days(7).Seconds());
+    limit->SetMinStorageMegabytes(50_KB);
+    limit->SetMaxStorageMegabytes(1_MB);
+
+    MeteringFile = MakeHolder<TTempFileHandle>();
+    appConfig.MutableMeteringConfig()->SetMeteringFilePath(MeteringFile->Name());
+
+    if (secure) {
+        appConfig.MutablePQConfig()->SetRequireCredentialsInNewProtocol(true);
+        appConfig.MutableDomainsConfig()->MutableSecurityConfig()->SetEnforceUserTokenRequirement(true);
+    }
+    KikimrServer = std::unique_ptr<TKikimr>(new TKikimr(std::move(appConfig), {}, {}, false, nullptr, nullptr, 0));
+    KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::KAFKA_PROXY, NActors::NLog::PRI_TRACE);
+    KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_DEBUG);
+    KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PQ_DESCRIBER, NActors::NLog::PRI_TRACE);
+    KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PQ_FETCH_REQUEST, NActors::NLog::PRI_TRACE);
+    KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PQ_WRITE_PROXY, NActors::NLog::PRI_TRACE);
+    KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::TICKET_PARSER, NLog::PRI_TRACE);
+    KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
+    KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, NLog::PRI_TRACE);
+
+    if (!settings.EnableNativeKafkaBalancing) {
+        KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableKafkaNativeBalancing(false);
+    }
+    KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableKafkaTransactions(true);
+    KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableTopicCompactificationByKey(true);
+
+    TClient client(*(KikimrServer->ServerSettings));
+    if (secure) {
+        client.SetSecurityToken("root@builtin");
+    }
+
+    ui16 grpc = KikimrServer->GetPort();
+    TString location = TStringBuilder() << "localhost:" << grpc;
+    auto driverConfig = TDriverConfig()
+        .SetEndpoint(location)
+        .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", TLOG_DEBUG).Release()));
+    if (secure) {
+        driverConfig.UseSecureConnection(TString(NYdbSslTestData::CaCrt));
+        driverConfig.SetAuthToken("root@builtin");
+    } else {
+        driverConfig.SetDatabase("/Root/");
+    }
+
+    Driver = std::make_unique<TDriver>(std::move(driverConfig));
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        NMsgBusProxy::MSTATUS_OK,
+        client.AlterUserAttributes("/", "Root",
+                                   {{"folder_id", DEFAULT_FOLDER_ID},
+                                    {"cloud_id", DEFAULT_CLOUD_ID},
+                                    {"kafka_api", settings.KafkaApiMode},
+                                    {"database_id", "root"},
+                                    {"serverless_rt_coordination_node_path", "/Coordinator/Root"},
+                                    {"serverless_rt_base_resource_ru", "/ru_Root"}}));
+
+    {
+        auto status = client.CreateUser("/Root", "ouruser", "ourUserPassword");
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
+
+        NYdb::NScheme::TSchemeClient schemeClient(*Driver);
+        NYdb::NScheme::TPermissions permissions("ouruser", {"ydb.generic.read", "ydb.generic.write", "ydb.generic.full"});
+
+        auto result = schemeClient
+                          .ModifyPermissions(
+                              "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
+                          .ExtractValueSync();
+        Cerr << result.GetIssues().ToString() << "\n";
+        UNIT_ASSERT(result.IsSuccess());
+    }
+
+    {
+        auto status = client.CreateUser("/Root", "user123", "UsErPassword");
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
+
+        NYdb::NScheme::TSchemeClient schemeClient(*Driver);
+        NYdb::NScheme::TPermissions permissions("user123", {"ydb.generic.read", "ydb.generic.write", "ydb.generic.full"});
+
+        auto result = schemeClient
+                          .ModifyPermissions(
+                              "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
+                          .ExtractValueSync();
+        Cerr << result.GetIssues().ToString() << "\n";
+        UNIT_ASSERT(result.IsSuccess());
+    }
+
+    {
+        auto status = client.CreateUser("/Root", "usernorights", "dummyPass");
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
+
+        NYdb::NScheme::TSchemeClient schemeClient(*Driver);
+        NYdb::NScheme::TPermissions permissions("usernorights", {});
+
+        auto result = schemeClient
+                          .ModifyPermissions(
+                              "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
+                          .ExtractValueSync();
+        Cerr << result.GetIssues().ToString() << "\n";
+        UNIT_ASSERT(result.IsSuccess());
+    }
+
+    {
+        auto status = client.CreateUser("/Root", "useronlyreadrights", "AbAcAbA");
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
+
+        NYdb::NScheme::TSchemeClient schemeClient(*Driver);
+        NYdb::NScheme::TPermissions permissions("useronlyreadrights", {"ydb.generic.read"});
+
+        auto result = schemeClient
+                          .ModifyPermissions(
+                              "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
+                          .ExtractValueSync();
+        Cerr << result.GetIssues().ToString() << "\n";
+        UNIT_ASSERT(result.IsSuccess());
+    }
+
+    {
+        // Access Server Mock
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(accessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&accessServiceMock);
+        AccessServer = builder.BuildAndStart();
+    }
+}
+
+template <class TKikimr, bool secure>
+TTestServer<TKikimr, secure>::TTestServer(const TString& kafkaApiMode, bool serverless, bool enableNativeKafkaBalancing,
+            bool enableAutoTopicCreation, bool enableAutoConsumerCreation, bool enableQuoting, bool checkACL)
+    : TTestServer(TTestServerSettings{kafkaApiMode, serverless, enableNativeKafkaBalancing, enableAutoTopicCreation, enableAutoConsumerCreation, enableQuoting, checkACL})
+{}
+
+// Explicit template instantiations
+template class TTestServer<TKikimrWithGrpcAndRootSchema, false>;
+template class TTestServer<TKikimrWithGrpcAndRootSchemaSecure, true>;

--- a/ydb/core/kafka_proxy/ut/test_server.h
+++ b/ydb/core/kafka_proxy/ut/test_server.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/core/client/flat_ut_client.h>
+#include <ydb/core/kafka_proxy/kafka_events.h>
+#include <ydb/core/kafka_proxy/kafka_messages.h>
+#include <ydb/core/kafka_proxy/kafka_metrics.h>
+#include <ydb/core/kafka_proxy/kafka_constants.h>
+#include <ydb/core/kafka_proxy/actors/actors.h>
+#include <ydb/services/ydb/ydb_common_ut.h>
+#include <ydb/services/ydb/ydb_keys_ut.h>
+
+#include <ydb/library/testlib/service_mocks/access_service_mock.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/datastreams/datastreams.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status_codes.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
+
+#include <util/system/tempfile.h>
+
+using namespace NYdb;
+
+static constexpr const char NON_CHARGEABLE_USER[] = "superuser@builtin";
+static constexpr const char NON_CHARGEABLE_USER_X[] = "superuser_x@builtin";
+static constexpr const char NON_CHARGEABLE_USER_Y[] = "superuser_y@builtin";
+
+static constexpr const char DEFAULT_CLOUD_ID[] = "somecloud";
+static constexpr const char DEFAULT_FOLDER_ID[] = "somefolder";
+
+static constexpr const ui64 FAKE_SERVERLESS_KAFKA_PROXY_PORT = 19092;
+
+struct WithSslAndAuth: TKikimrTestSettings {
+    static constexpr bool SSL = true;
+    static constexpr bool AUTH = true;
+};
+using TKikimrWithGrpcAndRootSchemaSecure = NYdb::TBasicKikimrWithGrpcAndRootSchema<WithSslAndAuth>;
+
+struct TTestServerSettings {
+    const TString KafkaApiMode = "1";
+    bool Serverless = false;
+    bool EnableNativeKafkaBalancing = true;
+    bool EnableAutoTopicCreation = false;
+    bool EnableAutoConsumerCreation = true;
+    bool EnableQuoting = true;
+    bool CheckACL = false;
+};
+
+template <class TKikimr, bool secure>
+class TTestServer {
+public:
+    TIpPort Port;
+
+    TTestServer(const TTestServerSettings& settings);
+
+    TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = true,
+                bool enableAutoTopicCreation = false, bool enableAutoConsumerCreation = true, bool enableQuoting = true, bool checkACL = false);
+
+public:
+    std::unique_ptr<TKikimr> KikimrServer;
+    std::unique_ptr<TDriver> Driver;
+    THolder<TTempFileHandle> MeteringFile;
+
+    TTicketParserAccessServiceMock accessServiceMock;
+    std::unique_ptr<grpc::Server> AccessServer;
+};
+
+class TInsecureTestServer : public TTestServer<TKikimrWithGrpcAndRootSchema, false> {
+    using TTestServer::TTestServer;
+};
+class TSecureTestServer : public TTestServer<TKikimrWithGrpcAndRootSchemaSecure, true> {
+    using TTestServer::TTestServer;
+};

--- a/ydb/core/kafka_proxy/ut/ut_auth.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_auth.cpp
@@ -1,0 +1,535 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/string_utils/base64/base64.h>
+
+#include "kafka_test_client.h"
+#include "test_server.h"
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/library/login/sasl/scram.h>
+
+#include <util/random/random.h>
+
+using namespace NKafka;
+using namespace NYdb;
+
+Y_UNIT_TEST_SUITE(KafkaScramFirstMessage) {
+
+    // Test successful first SCRAM message with valid user
+    Y_UNIT_TEST(FirstMsgValidUser) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        auto apiVersionsMsg = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersionsMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        auto handshakeMsg = client.SaslHandshake("SCRAM-SHA-256");
+        UNIT_ASSERT_VALUES_EQUAL(handshakeMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(handshakeMsg->Mechanisms.size(), 2u);
+
+        TString randomBytes;
+        randomBytes.reserve(16);
+        for (size_t i = 0; i < 16; ++i) {
+            randomBytes += static_cast<char>(RandomNumber<ui8>());
+        }
+        TString clientNonce = Base64Encode(randomBytes);
+
+        auto response = client.SaslScramAuthenticateFirstMsg("ouruser", clientNonce);
+
+        UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT(!response->ErrorMessage.has_value() || response->ErrorMessage->empty());
+        UNIT_ASSERT(response->AuthBytes.has_value());
+        UNIT_ASSERT_GT(response->AuthBytes->size(), 0);
+
+        const auto& authBytes = response->AuthBytes.value();
+        std::string serverFirstMessage(authBytes.data(), authBytes.size());
+        NLogin::NSasl::TFirstServerMsg parsedServerMsg;
+        auto parseResult = NLogin::NSasl::ParseFirstServerMsg(serverFirstMessage, parsedServerMsg);
+        UNIT_ASSERT_C(parseResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse server first message");
+        UNIT_ASSERT_GT(parsedServerMsg.IterationsCount, 0);
+        UNIT_ASSERT(!parsedServerMsg.Salt.empty());
+        UNIT_ASSERT(!parsedServerMsg.Nonce.empty());
+    }
+
+    // Test first SCRAM message with non-existent user
+    Y_UNIT_TEST(FirstMsgNonExistentUser) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        auto apiVersionsMsg = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersionsMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        auto handshakeMsg = client.SaslHandshake("SCRAM-SHA-256");
+        UNIT_ASSERT_VALUES_EQUAL(handshakeMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        TString randomBytes;
+        randomBytes.reserve(16);
+        for (size_t i = 0; i < 16; ++i) {
+            randomBytes += static_cast<char>(RandomNumber<ui8>());
+        }
+        TString clientNonce = Base64Encode(randomBytes);
+
+        auto response = client.SaslScramAuthenticateFirstMsg("nonexistentuser", clientNonce);
+
+        UNIT_ASSERT_VALUES_UNEQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::SASL_AUTHENTICATION_FAILED));
+
+        UNIT_ASSERT(response->ErrorMessage.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*response->ErrorMessage, "Authentication failure. ");
+
+        UNIT_ASSERT(response->AuthBytes.has_value());
+        std::string errorMessage(response->AuthBytes->data(), response->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        UNIT_ASSERT_C(parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse error message");
+        UNIT_ASSERT_C(!errorMsg.Error.empty(), "Error field should not be empty");
+        UNIT_ASSERT_STRING_CONTAINS(errorMsg.Error, "unknown-user");
+    }
+
+    // Test first SCRAM message with empty username
+    Y_UNIT_TEST(FirstMsgEmptyUsername) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        auto apiVersionsMsg = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersionsMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        auto handshakeMsg = client.SaslHandshake("SCRAM-SHA-256");
+        UNIT_ASSERT_VALUES_EQUAL(handshakeMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        TString randomBytes;
+        randomBytes.reserve(16);
+        for (size_t i = 0; i < 16; ++i) {
+            randomBytes += static_cast<char>(RandomNumber<ui8>());
+        }
+        TString clientNonce = Base64Encode(randomBytes);
+
+        auto response = client.SaslScramAuthenticateFirstMsg("", clientNonce);
+
+        UNIT_ASSERT_VALUES_UNEQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::SASL_AUTHENTICATION_FAILED));
+
+        UNIT_ASSERT(response->ErrorMessage.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*response->ErrorMessage, "Authentication failure. ");
+
+        // Check error message
+        UNIT_ASSERT(response->AuthBytes.has_value());
+        std::string errorMessage(response->AuthBytes->data(), response->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        UNIT_ASSERT_C(parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse error message");
+        UNIT_ASSERT_C(!errorMsg.Error.empty(), "Error field should not be empty");
+        UNIT_ASSERT_VALUES_EQUAL(errorMsg.Error, "other-error");
+    }
+
+    // Test first SCRAM message with different nonce lengths
+    Y_UNIT_TEST(FirstMsgDifferentNonceLengths) {
+        TInsecureTestServer testServer("2");
+
+        // Test with short nonce (8 bytes)
+        {
+            TKafkaTestClient client(testServer.Port);
+
+            auto apiVersionsMsg = client.ApiVersions();
+            UNIT_ASSERT_VALUES_EQUAL(apiVersionsMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+            auto handshakeMsg = client.SaslHandshake("SCRAM-SHA-256");
+            UNIT_ASSERT_VALUES_EQUAL(handshakeMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+            TString randomBytes;
+            randomBytes.reserve(8);
+            for (size_t i = 0; i < 8; ++i) {
+                randomBytes += static_cast<char>(RandomNumber<ui8>());
+            }
+            TString clientNonce = Base64Encode(randomBytes);
+
+            auto response = client.SaslScramAuthenticateFirstMsg("ouruser", clientNonce);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            UNIT_ASSERT(!response->ErrorMessage.has_value() || response->ErrorMessage->empty());
+            UNIT_ASSERT(response->AuthBytes.has_value());
+        }
+
+        // Test with long nonce (32 bytes)
+        {
+            TKafkaTestClient client(testServer.Port);
+
+            auto apiVersionsMsg = client.ApiVersions();
+            UNIT_ASSERT_VALUES_EQUAL(apiVersionsMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+            auto handshakeMsg = client.SaslHandshake("SCRAM-SHA-256");
+            UNIT_ASSERT_VALUES_EQUAL(handshakeMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+            TString randomBytes;
+            randomBytes.reserve(32);
+            for (size_t i = 0; i < 32; ++i) {
+                randomBytes += static_cast<char>(RandomNumber<ui8>());
+            }
+            TString clientNonce = Base64Encode(randomBytes);
+
+            auto response = client.SaslScramAuthenticateFirstMsg("ouruser", clientNonce);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            UNIT_ASSERT(!response->ErrorMessage.has_value() || response->ErrorMessage->empty());
+            UNIT_ASSERT(response->AuthBytes.has_value());
+        }
+    }
+
+    // Test first SCRAM message with non-printable characters in nonce (not base64-encoded)
+    Y_UNIT_TEST(FirstMsgNonPrintableNonce) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        auto apiVersionsMsg = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersionsMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        auto handshakeMsg = client.SaslHandshake("SCRAM-SHA-256");
+        UNIT_ASSERT_VALUES_EQUAL(handshakeMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        TString clientNonce;
+        clientNonce.reserve(16);
+        for (size_t i = 0; i < 16; ++i) {
+            // Include control characters (0x00-0x1F)
+            clientNonce += static_cast<char>(i % 32);
+        }
+
+        auto response = client.SaslScramAuthenticateFirstMsg("ouruser", clientNonce);
+
+        UNIT_ASSERT_VALUES_UNEQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::SASL_AUTHENTICATION_FAILED));
+
+        UNIT_ASSERT(response->ErrorMessage.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*response->ErrorMessage, "Authentication failure. ");
+
+        UNIT_ASSERT(response->AuthBytes.has_value());
+        std::string errorMessage(response->AuthBytes->data(), response->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        UNIT_ASSERT_C(parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse error message");
+        UNIT_ASSERT_C(!errorMsg.Error.empty(), "Error field should not be empty");
+    }
+} // Y_UNIT_TEST_SUITE(KafkaScramFirstMessage)
+
+Y_UNIT_TEST_SUITE(KafkaScramFinalMessage) {
+    // Helper function to perform first message exchange and return parsed server response
+    struct TFirstMessageResult {
+        TString ServerNonce;
+        TString Salt;
+        ui32 IterationsCount;
+        TString ClientFirstMessageBare;
+        TString ServerFirstMessage;
+        TString AuthMessage;
+    };
+
+    TFirstMessageResult PerformFirstMessage(TKafkaTestClient& client, const TString& userName, const TString& /* userPassword */) {
+        auto apiVersionsMsg = client.ApiVersions();
+        UNIT_ASSERT_VALUES_EQUAL(apiVersionsMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        auto handshakeMsg = client.SaslHandshake("SCRAM-SHA-256");
+        UNIT_ASSERT_VALUES_EQUAL(handshakeMsg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        TString randomBytes;
+        randomBytes.reserve(16);
+        for (size_t i = 0; i < 16; ++i) {
+            randomBytes += static_cast<char>(RandomNumber<ui8>());
+        }
+        TString clientNonce = Base64Encode(randomBytes);
+
+        TString clientFirstMessageBare = TStringBuilder() << "n=" << userName << ",r=" << clientNonce;
+
+        auto response1 = client.SaslScramAuthenticateFirstMsg(userName, clientNonce);
+        UNIT_ASSERT_VALUES_EQUAL(response1->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        UNIT_ASSERT(response1->AuthBytes.has_value());
+        const auto& authBytes1 = response1->AuthBytes.value();
+        std::string serverFirstMessage(authBytes1.data(), authBytes1.size());
+
+        NLogin::NSasl::TFirstServerMsg parsedServerMsg;
+        auto parseResult = NLogin::NSasl::ParseFirstServerMsg(serverFirstMessage, parsedServerMsg);
+        UNIT_ASSERT_C(parseResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse server first message");
+
+        // Decode salt from base64
+        TString decodedSalt = Base64StrictDecode(parsedServerMsg.Salt);
+
+        // Build client final message without proof
+        TString gs2Header = "n,,";
+        TString channelBinding = Base64Encode(gs2Header);
+        TString clientFinalMessageWithoutProof = TStringBuilder() << "c=" << channelBinding << ",r=" << parsedServerMsg.Nonce;
+
+        // Compute auth message
+        TString authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
+
+        TFirstMessageResult result;
+        result.ServerNonce = TString(parsedServerMsg.Nonce);
+        result.Salt = parsedServerMsg.Salt;
+        result.IterationsCount = parsedServerMsg.IterationsCount;
+        result.ClientFirstMessageBare = clientFirstMessageBare;
+        result.ServerFirstMessage = TString(serverFirstMessage);
+        result.AuthMessage = authMessage;
+
+        return result;
+    }
+
+    // Test successful final SCRAM message with correct credentials
+    Y_UNIT_TEST(FinalMsgCorrectCredentials) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        TString userName = "ouruser";
+        TString userPassword = "ourUserPassword";
+
+        auto firstMsgResult = PerformFirstMessage(client, userName, userPassword);
+
+        TString decodedSalt = Base64StrictDecode(firstMsgResult.Salt);
+
+        std::string clientProof;
+        std::string errorText;
+        bool success = NLogin::NSasl::ComputeClientProof(
+            "SCRAM-SHA-256",
+            std::string(userPassword.data(), userPassword.size()),
+            std::string(decodedSalt.data(), decodedSalt.size()),
+            firstMsgResult.IterationsCount,
+            std::string(firstMsgResult.AuthMessage.data(), firstMsgResult.AuthMessage.size()),
+            clientProof,
+            errorText
+        );
+        UNIT_ASSERT_C(success, TString(errorText));
+
+        TString encodedClientProof = Base64Encode(clientProof);
+
+        auto response2 = client.SaslScramAuthenticateFinalMsg(firstMsgResult.ServerNonce, encodedClientProof);
+        UNIT_ASSERT_VALUES_EQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT(!response2->ErrorMessage.has_value() || response2->ErrorMessage->empty());
+        UNIT_ASSERT(response2->AuthBytes.has_value());
+
+        const auto& authBytes2 = response2->AuthBytes.value();
+        std::string serverFinalMessage(reinterpret_cast<const char*>(authBytes2.data()), authBytes2.size());
+
+        NLogin::NSasl::TFinalServerMsg parsedFinalServerMsg;
+        auto parseFinalResult = NLogin::NSasl::ParseFinalServerMsg(serverFinalMessage, parsedFinalServerMsg);
+        UNIT_ASSERT_C(parseFinalResult == NLogin::NSasl::EParseMsgReturnCodes::Success,
+                      "Failed to parse server final message: " + serverFinalMessage);
+
+        UNIT_ASSERT_C(parsedFinalServerMsg.Error.empty(), "Server returned error: " + parsedFinalServerMsg.Error);
+
+        UNIT_ASSERT_C(!parsedFinalServerMsg.ServerSignature.empty(), "Server signature is empty");
+
+        std::string serverKey;
+        std::string errorText2;
+        bool success2 = NLogin::NSasl::ComputeServerKey(
+            "SCRAM-SHA-256",
+            std::string(userPassword.data(), userPassword.size()),
+            std::string(decodedSalt.data(), decodedSalt.size()),
+            firstMsgResult.IterationsCount,
+            serverKey,
+            errorText2
+        );
+        UNIT_ASSERT_C(success2, TString(errorText2));
+
+        std::string expectedServerSignature;
+        success2 = NLogin::NSasl::ComputeServerSignature(
+            "SCRAM-SHA-256",
+            serverKey,
+            std::string(firstMsgResult.AuthMessage.data(), firstMsgResult.AuthMessage.size()),
+            expectedServerSignature,
+            errorText2
+        );
+        UNIT_ASSERT_C(success2, TString(errorText2));
+
+        TString decodedServerSignature = Base64StrictDecode(parsedFinalServerMsg.ServerSignature);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            TString(expectedServerSignature.data(), expectedServerSignature.size()),
+            decodedServerSignature,
+            "Server signature verification failed"
+        );
+    }
+
+    // Test final SCRAM message with incorrect client proof
+    Y_UNIT_TEST(FinalMsgIncorrectProof) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        TString userName = "ouruser";
+        TString userPassword = "ourUserPassword";
+
+        auto firstMsgResult = PerformFirstMessage(client, userName, userPassword);
+
+        TString randomBytes;
+        randomBytes.reserve(32);
+        for (size_t i = 0; i < 32; ++i) {
+            randomBytes += static_cast<char>(RandomNumber<ui8>());
+        }
+        TString incorrectProof = Base64Encode(randomBytes);
+
+        auto response2 = client.SaslScramAuthenticateFinalMsg(firstMsgResult.ServerNonce, incorrectProof);
+
+        UNIT_ASSERT_VALUES_UNEQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::SASL_AUTHENTICATION_FAILED));
+
+        UNIT_ASSERT(response2->ErrorMessage.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*response2->ErrorMessage, "Authentication failure. ");
+
+        UNIT_ASSERT(response2->AuthBytes.has_value());
+        std::string errorMessage(response2->AuthBytes->data(), response2->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        UNIT_ASSERT_C(parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse error message");
+        UNIT_ASSERT_C(!errorMsg.Error.empty(), "Error field should not be empty");
+        UNIT_ASSERT_STRING_CONTAINS(errorMsg.Error, "invalid-proof");
+    }
+
+    // Test final SCRAM message with wrong nonce
+    Y_UNIT_TEST(FinalMsgWrongNonce) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        TString userName = "ouruser";
+        TString userPassword = "ourUserPassword";
+
+        auto firstMsgResult = PerformFirstMessage(client, userName, userPassword);
+
+        TString decodedSalt = Base64StrictDecode(firstMsgResult.Salt);
+
+        TString wrongNonce = "wrongNonce123456";
+        TString gs2Header = "n,,";
+        TString channelBinding = Base64Encode(gs2Header);
+        TString clientFinalMessageWithoutProof = TStringBuilder() << "c=" << channelBinding << ",r=" << wrongNonce;
+
+        TString authMessage = firstMsgResult.ClientFirstMessageBare + "," + firstMsgResult.ServerFirstMessage + "," + clientFinalMessageWithoutProof;
+
+        std::string clientProof;
+        std::string errorText;
+        bool success = NLogin::NSasl::ComputeClientProof(
+            "SCRAM-SHA-256",
+            std::string(userPassword.data(), userPassword.size()),
+            std::string(decodedSalt.data(), decodedSalt.size()),
+            firstMsgResult.IterationsCount,
+            std::string(authMessage.data(), authMessage.size()),
+            clientProof,
+            errorText
+        );
+        UNIT_ASSERT_C(success, TString(errorText));
+
+        TString encodedClientProof = Base64Encode(clientProof);
+
+        auto response2 = client.SaslScramAuthenticateFinalMsg(wrongNonce, encodedClientProof);
+
+        UNIT_ASSERT_VALUES_UNEQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::SASL_AUTHENTICATION_FAILED));
+
+        UNIT_ASSERT(response2->ErrorMessage.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*response2->ErrorMessage, "Authentication failure. ");
+
+        UNIT_ASSERT(response2->AuthBytes.has_value());
+        std::string errorMessage(response2->AuthBytes->data(), response2->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        UNIT_ASSERT_C(parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse error message");
+        UNIT_ASSERT_C(!errorMsg.Error.empty(), "Error field should not be empty");
+        UNIT_ASSERT_VALUES_EQUAL(errorMsg.Error, "other-error");
+    }
+
+    // Test final SCRAM message with empty proof
+    Y_UNIT_TEST(FinalMsgEmptyProof) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        TString userName = "ouruser";
+        TString userPassword = "ourUserPassword";
+
+        auto firstMsgResult = PerformFirstMessage(client, userName, userPassword);
+
+        auto response2 = client.SaslScramAuthenticateFinalMsg(firstMsgResult.ServerNonce, "");
+
+        UNIT_ASSERT_VALUES_UNEQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::SASL_AUTHENTICATION_FAILED));
+
+        UNIT_ASSERT(response2->ErrorMessage.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*response2->ErrorMessage, "Authentication failure. ");
+
+        UNIT_ASSERT(response2->AuthBytes.has_value());
+        std::string errorMessage(response2->AuthBytes->data(), response2->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        UNIT_ASSERT_C(parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse error message");
+        UNIT_ASSERT_C(!errorMsg.Error.empty(), "Error field should not be empty");
+        UNIT_ASSERT_VALUES_EQUAL(errorMsg.Error, "other-error");
+    }
+
+    // Test final SCRAM message with malformed proof (not base64)
+    Y_UNIT_TEST(FinalMsgMalformedProof) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        TString userName = "ouruser";
+        TString userPassword = "ourUserPassword";
+
+        auto firstMsgResult = PerformFirstMessage(client, userName, userPassword);
+
+        TString malformedProof = "this-is-not-valid-base64!!!";
+
+        auto response2 = client.SaslScramAuthenticateFinalMsg(firstMsgResult.ServerNonce, malformedProof);
+
+        // Server should return error for malformed proof
+        UNIT_ASSERT_VALUES_UNEQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::SASL_AUTHENTICATION_FAILED));
+
+        // Check ErrorMessage field
+        UNIT_ASSERT(response2->ErrorMessage.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*response2->ErrorMessage, "Authentication failure. ");
+
+        // Check error message
+        UNIT_ASSERT(response2->AuthBytes.has_value());
+        std::string errorMessage(response2->AuthBytes->data(), response2->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        UNIT_ASSERT_C(parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse error message");
+        UNIT_ASSERT_C(!errorMsg.Error.empty(), "Error field should not be empty");
+        UNIT_ASSERT_VALUES_EQUAL(errorMsg.Error, "invalid-encoding");
+    }
+
+    // Test final SCRAM message with proof computed using wrong password
+    Y_UNIT_TEST(FinalMsgWrongPassword) {
+        TInsecureTestServer testServer("2");
+        TKafkaTestClient client(testServer.Port);
+
+        TString userName = "ouruser";
+        TString correctPassword = "ourUserPassword";
+        TString wrongPassword = "wrongPassword123";
+
+        auto firstMsgResult = PerformFirstMessage(client, userName, correctPassword);
+
+        // Decode salt from base64
+        TString decodedSalt = Base64StrictDecode(firstMsgResult.Salt);
+
+        // Compute client proof with WRONG password
+        std::string clientProof;
+        std::string errorText;
+        bool success = NLogin::NSasl::ComputeClientProof(
+            "SCRAM-SHA-256",
+            std::string(wrongPassword.data(), wrongPassword.size()),
+            std::string(decodedSalt.data(), decodedSalt.size()),
+            firstMsgResult.IterationsCount,
+            std::string(firstMsgResult.AuthMessage.data(), firstMsgResult.AuthMessage.size()),
+            clientProof,
+            errorText
+        );
+        UNIT_ASSERT_C(success, TString(errorText));
+
+        TString encodedClientProof = Base64Encode(clientProof);
+
+        auto response2 = client.SaslScramAuthenticateFinalMsg(firstMsgResult.ServerNonce, encodedClientProof);
+
+        UNIT_ASSERT_VALUES_UNEQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(response2->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::SASL_AUTHENTICATION_FAILED));
+
+        UNIT_ASSERT(response2->ErrorMessage.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(*response2->ErrorMessage, "Authentication failure. ");
+
+        UNIT_ASSERT(response2->AuthBytes.has_value());
+        std::string errorMessage(response2->AuthBytes->data(), response2->AuthBytes->size());
+        NLogin::NSasl::TFinalServerMsg errorMsg;
+        auto parseErrorResult = NLogin::NSasl::ParseFinalServerMsg(errorMessage, errorMsg);
+        UNIT_ASSERT_C(parseErrorResult == NLogin::NSasl::EParseMsgReturnCodes::Success, "Failed to parse error message");
+        UNIT_ASSERT_C(!errorMsg.Error.empty(), "Error field should not be empty");
+        UNIT_ASSERT_STRING_CONTAINS(errorMsg.Error, "invalid-proof");
+    }
+} // Y_UNIT_TEST_SUITE(KafkaScramFinalMessage)

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -4,27 +4,13 @@
 #include <library/cpp/retry/retry.h>
 
 #include "kafka_test_client.h"
+#include "test_server.h"
 
-#include <ydb/core/client/flat_ut_client.h>
-#include <ydb/core/kafka_proxy/kafka_events.h>
-#include <ydb/core/kafka_proxy/kafka_messages.h>
-#include <ydb/core/kafka_proxy/kafka_metrics.h>
-#include <ydb/core/kafka_proxy/kafka_constants.h>
-#include <ydb/core/kafka_proxy/actors/actors.h>
 #include <ydb/core/kafka_proxy/kafka_transactional_producers_initializers.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/public/constants.h>
-#include <ydb/services/ydb/ydb_common_ut.h>
-#include <ydb/services/ydb/ydb_keys_ut.h>
 
-#include <ydb/library/testlib/service_mocks/access_service_mock.h>
-
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/datastreams/datastreams.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 #include <ydb/public/sdk/cpp/src/client/persqueue_public/persqueue.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status_codes.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/codecs.h>
 #include <ydb/public/api/grpc/draft/ydb_datastreams_v1.grpc.pb.h>
 
@@ -32,261 +18,12 @@
 #include <library/cpp/digest/md5/md5.h>
 #include <library/cpp/string_utils/base64/base64.h>
 
-#include <util/system/tempfile.h>
-
 using namespace NKafka;
 using namespace NYdb;
 using namespace NYdb::NTable;
 
-static constexpr const char NON_CHARGEABLE_USER[] = "superuser@builtin";
-static constexpr const char NON_CHARGEABLE_USER_X[] = "superuser_x@builtin";
-static constexpr const char NON_CHARGEABLE_USER_Y[] = "superuser_y@builtin";
-
-static constexpr const char DEFAULT_CLOUD_ID[] = "somecloud";
-static constexpr const char DEFAULT_FOLDER_ID[] = "somefolder";
-
 static constexpr const ui64 FirstTopicOffset = -2;
 static constexpr const ui64 LastTopicOffset = -1;
-
-static constexpr const ui64 FAKE_SERVERLESS_KAFKA_PROXY_PORT = 19092;
-
-struct WithSslAndAuth: TKikimrTestSettings {
-    static constexpr bool SSL = true;
-    static constexpr bool AUTH = true;
-};
-using TKikimrWithGrpcAndRootSchemaSecure = NYdb::TBasicKikimrWithGrpcAndRootSchema<WithSslAndAuth>;
-
-struct TTestServerSettings {
-    const TString KafkaApiMode = "1";
-    bool Serverless = false;
-    bool EnableNativeKafkaBalancing = true;
-    bool EnableAutoTopicCreation = false;
-    bool EnableAutoConsumerCreation = true;
-    bool EnableQuoting = true;
-    bool CheckACL = false;
-};
-
-template <class TKikimr, bool secure>
-class TTestServer {
-public:
-    TIpPort Port;
-
-    TTestServer(const TTestServerSettings& settings) {
-        TPortManager portManager;
-        Port = portManager.GetTcpPort();
-
-        ui16 accessServicePort = portManager.GetPort(4284);
-        TString accessServiceEndpoint = "localhost:" + ToString(accessServicePort);
-
-        NKikimrConfig::TAppConfig appConfig;
-        appConfig.MutableAuthConfig()->SetUseLoginProvider(true);
-        appConfig.MutableAuthConfig()->SetUseBlackBox(false);
-        appConfig.MutableAuthConfig()->SetUseBlackBox(false);
-        appConfig.MutableAuthConfig()->SetUseAccessService(true);
-        appConfig.MutableAuthConfig()->SetUseAccessServiceApiKey(true);
-        appConfig.MutableAuthConfig()->SetUseAccessServiceTLS(false);
-        appConfig.MutableAuthConfig()->SetAccessServiceEndpoint(accessServiceEndpoint);
-
-        appConfig.MutablePQConfig()->SetTopicsAreFirstClassCitizen(true);
-        appConfig.MutablePQConfig()->SetEnabled(true);
-        // NOTE(shmel1k@): KIKIMR-14221
-        if (!settings.CheckACL) {
-            appConfig.MutablePQConfig()->SetCheckACL(false);
-        }
-        appConfig.MutablePQConfig()->SetRequireCredentialsInNewProtocol(false);
-
-        auto cst = appConfig.MutablePQConfig()->AddClientServiceType();
-        cst->SetName("data-transfer");
-        cst = appConfig.MutablePQConfig()->AddClientServiceType();
-        cst->SetName("data-transfer2");
-
-        appConfig.MutableKafkaProxyConfig()->SetEnableKafkaProxy(true);
-        appConfig.MutableKafkaProxyConfig()->SetListeningPort(Port);
-        appConfig.MutableKafkaProxyConfig()->SetMaxMessageSize(1024);
-        appConfig.MutableKafkaProxyConfig()->SetMaxInflightSize(2048);
-        if (settings.EnableAutoTopicCreation) {
-            appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(true);
-        }
-        appConfig.MutableKafkaProxyConfig()->SetTopicCreationDefaultPartitions(2);
-        if (!settings.EnableAutoConsumerCreation) {
-            appConfig.MutableKafkaProxyConfig()->SetAutoCreateConsumersEnable(false);
-        }
-        if (settings.Serverless) {
-            appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetHostname("localhost");
-            appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetPort(FAKE_SERVERLESS_KAFKA_PROXY_PORT);
-        }
-
-        appConfig.MutablePQConfig()->MutableQuotingConfig()->SetEnableQuoting(settings.EnableQuoting);
-        if (!settings.EnableQuoting)
-            appConfig.MutablePQConfig()->MutableQuotingConfig()->SetEnableReadQuoting(false);
-
-        appConfig.MutablePQConfig()->MutableQuotingConfig()->SetQuotaWaitDurationMs(300);
-        appConfig.MutablePQConfig()->MutableQuotingConfig()->SetPartitionReadQuotaIsTwiceWriteQuota(settings.EnableQuoting);
-        appConfig.MutablePQConfig()->MutableBillingMeteringConfig()->SetEnabled(true);
-        appConfig.MutablePQConfig()->MutableBillingMeteringConfig()->SetFlushIntervalSec(1);
-        appConfig.MutablePQConfig()->AddClientServiceType()->SetName("data-streams");
-        appConfig.MutablePQConfig()->AddNonChargeableUser(NON_CHARGEABLE_USER);
-        appConfig.MutablePQConfig()->AddNonChargeableUser(NON_CHARGEABLE_USER_X);
-        appConfig.MutablePQConfig()->AddNonChargeableUser(NON_CHARGEABLE_USER_Y);
-
-        appConfig.MutablePQConfig()->AddValidWriteSpeedLimitsKbPerSec(128);
-        appConfig.MutablePQConfig()->AddValidWriteSpeedLimitsKbPerSec(512);
-        appConfig.MutablePQConfig()->AddValidWriteSpeedLimitsKbPerSec(1_KB);
-
-        appConfig.MutableGRpcConfig()->SetHost("::1");
-        auto limit = appConfig.MutablePQConfig()->AddValidRetentionLimits();
-        limit->SetMinPeriodSeconds(0);
-        limit->SetMaxPeriodSeconds(TDuration::Days(1).Seconds());
-        limit->SetMinStorageMegabytes(0);
-        limit->SetMaxStorageMegabytes(0);
-
-        limit = appConfig.MutablePQConfig()->AddValidRetentionLimits();
-        limit->SetMinPeriodSeconds(0);
-        limit->SetMaxPeriodSeconds(TDuration::Days(7).Seconds());
-        limit->SetMinStorageMegabytes(50_KB);
-        limit->SetMaxStorageMegabytes(1_MB);
-
-        MeteringFile = MakeHolder<TTempFileHandle>();
-        appConfig.MutableMeteringConfig()->SetMeteringFilePath(MeteringFile->Name());
-
-        if (secure) {
-            appConfig.MutablePQConfig()->SetRequireCredentialsInNewProtocol(true);
-            appConfig.MutableDomainsConfig()->MutableSecurityConfig()->SetEnforceUserTokenRequirement(true);
-        }
-        KikimrServer = std::unique_ptr<TKikimr>(new TKikimr(std::move(appConfig), {}, {}, false, nullptr, nullptr, 0));
-        KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::KAFKA_PROXY, NActors::NLog::PRI_TRACE);
-        KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_DEBUG);
-        KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PQ_DESCRIBER, NActors::NLog::PRI_TRACE);
-        KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PQ_FETCH_REQUEST, NActors::NLog::PRI_TRACE);
-        KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PQ_WRITE_PROXY, NActors::NLog::PRI_TRACE);
-        KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::TICKET_PARSER, NLog::PRI_TRACE);
-        KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
-        KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, NLog::PRI_TRACE);
-
-        if (!settings.EnableNativeKafkaBalancing) {
-            KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableKafkaNativeBalancing(false);
-        }
-        KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableKafkaTransactions(true);
-        KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableTopicCompactificationByKey(true);
-
-        TClient client(*(KikimrServer->ServerSettings));
-        if (secure) {
-            client.SetSecurityToken("root@builtin");
-        }
-
-        ui16 grpc = KikimrServer->GetPort();
-        TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driverConfig = TDriverConfig()
-            .SetEndpoint(location)
-            .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", TLOG_DEBUG).Release()));
-        if (secure) {
-            driverConfig.UseSecureConnection(TString(NYdbSslTestData::CaCrt));
-            driverConfig.SetAuthToken("root@builtin");
-        } else {
-            driverConfig.SetDatabase("/Root/");
-        }
-
-        Driver = std::make_unique<TDriver>(std::move(driverConfig));
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            NMsgBusProxy::MSTATUS_OK,
-            client.AlterUserAttributes("/", "Root",
-                                       {{"folder_id", DEFAULT_FOLDER_ID},
-                                        {"cloud_id", DEFAULT_CLOUD_ID},
-                                        {"kafka_api", settings.KafkaApiMode},
-                                        {"database_id", "root"},
-                                        {"serverless_rt_coordination_node_path", "/Coordinator/Root"},
-                                        {"serverless_rt_base_resource_ru", "/ru_Root"}}));
-
-        {
-            auto status = client.CreateUser("/Root", "ouruser", "ourUserPassword");
-            UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
-
-            NYdb::NScheme::TSchemeClient schemeClient(*Driver);
-            NYdb::NScheme::TPermissions permissions("ouruser", {"ydb.generic.read", "ydb.generic.write", "ydb.generic.full"});
-
-            auto result = schemeClient
-                              .ModifyPermissions(
-                                  "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
-                              .ExtractValueSync();
-            Cerr << result.GetIssues().ToString() << "\n";
-            UNIT_ASSERT(result.IsSuccess());
-        }
-
-        {
-            auto status = client.CreateUser("/Root", "user123", "UsErPassword");
-            UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
-
-            NYdb::NScheme::TSchemeClient schemeClient(*Driver);
-            NYdb::NScheme::TPermissions permissions("user123", {"ydb.generic.read", "ydb.generic.write", "ydb.generic.full"});
-
-            auto result = schemeClient
-                              .ModifyPermissions(
-                                  "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
-                              .ExtractValueSync();
-            Cerr << result.GetIssues().ToString() << "\n";
-            UNIT_ASSERT(result.IsSuccess());
-        }
-
-        {
-            auto status = client.CreateUser("/Root", "usernorights", "dummyPass");
-            UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
-
-            NYdb::NScheme::TSchemeClient schemeClient(*Driver);
-            NYdb::NScheme::TPermissions permissions("usernorights", {});
-
-            auto result = schemeClient
-                              .ModifyPermissions(
-                                  "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
-                              .ExtractValueSync();
-            Cerr << result.GetIssues().ToString() << "\n";
-            UNIT_ASSERT(result.IsSuccess());
-        }
-
-        {
-            auto status = client.CreateUser("/Root", "useronlyreadrights", "AbAcAbA");
-            UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
-
-            NYdb::NScheme::TSchemeClient schemeClient(*Driver);
-            NYdb::NScheme::TPermissions permissions("useronlyreadrights", {"ydb.generic.read"});
-
-            auto result = schemeClient
-                              .ModifyPermissions(
-                                  "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
-                              .ExtractValueSync();
-            Cerr << result.GetIssues().ToString() << "\n";
-            UNIT_ASSERT(result.IsSuccess());
-        }
-
-        {
-            // Access Server Mock
-            grpc::ServerBuilder builder;
-            builder.AddListeningPort(accessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&accessServiceMock);
-            AccessServer = builder.BuildAndStart();
-        }
-    }
-
-    TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = true,
-                bool enableAutoTopicCreation = false, bool enableAutoConsumerCreation = true, bool enableQuoting = true, bool checkACL = false)
-        : TTestServer(TTestServerSettings{kafkaApiMode, serverless, enableNativeKafkaBalancing, enableAutoTopicCreation, enableAutoConsumerCreation, enableQuoting, checkACL})
-    {}
-
-
-public:
-    std::unique_ptr<TKikimr> KikimrServer;
-    std::unique_ptr<TDriver> Driver;
-    THolder<TTempFileHandle> MeteringFile;
-
-    TTicketParserAccessServiceMock accessServiceMock;
-    std::unique_ptr<grpc::Server> AccessServer;
-};
-
-class TInsecureTestServer : public TTestServer<TKikimrWithGrpcAndRootSchema, false> {
-    using TTestServer::TTestServer;
-};
-class TSecureTestServer : public TTestServer<TKikimrWithGrpcAndRootSchemaSecure, true> {
-    using TTestServer::TTestServer;
-};
 
 TString GetMessageMetaKey(const NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent::TMessage& msg, const TString& key) {
     if (msg.GetMessageMeta()) {
@@ -447,26 +184,9 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         TKafkaTestClient client(testServer.Port);
 
-        {
-            auto msg = client.ApiVersions();
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(msg->ApiKeys.size(), EXPECTED_API_KEYS_COUNT);
-        }
-
         // authenticate
         {
-            auto msg = client.SaslHandshake();
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[0], "PLAIN");
-        }
-
-        {
-            auto msg = client.SaslAuthenticate("ouruser@/Root", "ourUserPassword");
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            client.ScramAuthenticateToKafka("ouruser", "ourUserPassword");
         }
 
         // acquire producer id and epoch
@@ -1068,7 +788,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         TKafkaTestClient client(testServer.Port);
 
-        client.AuthenticateToKafka();
+        client.PlainAuthenticateToKafka();
 
         {
             // Check list offsets for empty topic
@@ -1323,7 +1043,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         TKafkaTestClient client(testServer.Port);
 
-        client.AuthenticateToKafka();
+        client.PlainAuthenticateToKafka();
 
         {
             auto msg = client.InitProducerId();
@@ -1380,7 +1100,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         TKafkaTestClient client(testServer.Port);
 
-        client.AuthenticateToKafka();
+        client.PlainAuthenticateToKafka();
 
         {
             // Check FETCH
@@ -1413,8 +1133,8 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TKafkaTestClient client0(testServer.Port);
         TKafkaTestClient client1(testServer.Port);
 
-        client0.AuthenticateToKafka();
-        client1.AuthenticateToKafka();
+        client0.PlainAuthenticateToKafka();
+        client1.PlainAuthenticateToKafka();
 
         TString memberId0;
         i32 generationId0;
@@ -1511,23 +1231,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TKafkaTestClient clientD(testServer.Port);
 
         {
-            auto msg = clientA.ApiVersions();
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(msg->ApiKeys.size(), EXPECTED_API_KEYS_COUNT);
-        }
-
-        {
-            auto msg = clientA.SaslHandshake();
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[0], "PLAIN");
-        }
-
-        {
-            auto msg = clientA.SaslAuthenticate("ouruser@/Root", "ourUserPassword");
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            clientA.PlainAuthenticateToKafka("ouruser@/Root", "ourUserPassword");
         }
 
         {
@@ -1542,7 +1246,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
             // clientB join group, and get 0 partitions, becouse it's all at clientA
             UNIT_ASSERT_VALUES_EQUAL(clientB.SaslHandshake()->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(clientB.SaslAuthenticate("ouruser@/Root", "ourUserPassword")->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            UNIT_ASSERT_VALUES_EQUAL(clientB.SaslPlainAuthenticate("ouruser@/Root", "ourUserPassword")->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
             auto readInfoB = clientB.JoinAndSyncGroup(topics, group, protocolName, 1000000, minActivePartitions);
             UNIT_ASSERT_VALUES_EQUAL(readInfoB.Partitions.size(), 0);
 
@@ -1562,7 +1266,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
             // clientC join group, and get 0 partitions, becouse it's all at clientA and clientB
             UNIT_ASSERT_VALUES_EQUAL(clientC.SaslHandshake()->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(clientC.SaslAuthenticate("ouruser@/Root", "ourUserPassword")->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            UNIT_ASSERT_VALUES_EQUAL(clientC.SaslPlainAuthenticate("ouruser@/Root", "ourUserPassword")->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
             auto readInfoC = clientC.JoinAndSyncGroup(topics, group, protocolName, 1000000, minActivePartitions);
             UNIT_ASSERT_VALUES_EQUAL(readInfoC.Partitions.size(), 0);
 
@@ -1584,7 +1288,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
             // clientD join group, and get 0 partitions, becouse it's all at clientA, clientB and clientC
             UNIT_ASSERT_VALUES_EQUAL(clientD.SaslHandshake()->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(clientD.SaslAuthenticate("ouruser@/Root", "ourUserPassword")->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            UNIT_ASSERT_VALUES_EQUAL(clientD.SaslPlainAuthenticate("ouruser@/Root", "ourUserPassword")->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
             auto readInfoD = clientD.JoinAndSyncGroup(topics, group, protocolName, 1000000, minActivePartitions);
             UNIT_ASSERT_VALUES_EQUAL(readInfoD.Partitions.size(), 0);
 
@@ -1769,19 +1473,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         for(auto name : {feedPath, feedShortPath} ) {
             TKafkaTestClient clientA(testServer.Port);
             {
-                auto msg = clientA.ApiVersions();
-                UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-                UNIT_ASSERT_VALUES_EQUAL(msg->ApiKeys.size(), EXPECTED_API_KEYS_COUNT);
-            }
-            {
-                auto msg = clientA.SaslHandshake();
-                UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-                UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 1u);
-                UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[0], "PLAIN");
-            }
-            {
-                auto msg = clientA.SaslAuthenticate("ouruser@/Root", "ourUserPassword");
-                UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+                clientA.PlainAuthenticateToKafka("ouruser@/Root", "ourUserPassword");
             }
 
             {
@@ -1831,7 +1523,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "useronlyreadrights@/Root";
             TString userPassword = "AbAcAbA";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
             std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
             for (ui64 i = 0; i < minActivePartitions; ++i) {
@@ -1863,7 +1555,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "user123@/Root";
             TString userPassword = "UsErPassword";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
 
             {
                 // checking that if a request contains a topic that is not assigned to this consumer
@@ -1969,7 +1661,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "usernorights@/Root";
             TString userPassword = "dummyPass";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
             std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
             for (ui64 i = 0; i < minActivePartitions; ++i) {
@@ -2002,7 +1694,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "usernorights@/Root";
             TString userPassword = "dummyPass";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
             std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
             for (ui64 i = 0; i < minActivePartitions; ++i) {
@@ -2049,7 +1741,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         TKafkaTestClient client(testServer.Port);
 
-        client.AuthenticateToKafka();
+        client.PlainAuthenticateToKafka();
 
         auto recordsCount = 5;
         {
@@ -2477,7 +2169,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
     Y_UNIT_TEST(CreateTopicsScenarioWithKafkaAuth) {
         TInsecureTestServer testServer("2");
         TKafkaTestClient client(testServer.Port);
-        client.AuthenticateToKafka();
+        client.PlainAuthenticateToKafka();
 
         RunCreateTopicsScenario(testServer, client);
     } // Y_UNIT_TEST(CreateTopicsScenarioWithKafkaAuth)
@@ -2510,7 +2202,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         TKafkaTestClient client(testServer.Port);
 
-        client.AuthenticateToKafka();
+        client.PlainAuthenticateToKafka();
 
         auto describeTopicSettings = NTopic::TDescribeTopicSettings().IncludeStats(true);
 
@@ -3030,7 +2722,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         TKafkaTestClient client(testServer.Port);
 
-        client.AuthenticateToKafka();
+        client.PlainAuthenticateToKafka();
 
         auto getConfigsMap = [&](const auto& describeResult) {
             THashMap<TString, TDescribeConfigsResponseData::TDescribeConfigsResult::TDescribeConfigsResourceResult> configs;
@@ -3096,7 +2788,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         TKafkaTestClient client(testServer.Port);
 
-        client.AuthenticateToKafka();
+        client.PlainAuthenticateToKafka();
 
         auto describeTopicSettings = NTopic::TDescribeTopicSettings().IncludeStats(true);
 
@@ -3246,24 +2938,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TKafkaTestClient client(testServer.Port);
 
         {
-            auto msg = client.ApiVersions();
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(msg->ApiKeys.size(), EXPECTED_API_KEYS_COUNT);
-        }
-
-        {
-            auto msg = client.SaslHandshake();
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[0], "PLAIN");
-        }
-
-        {
-            auto msg = client.SaslAuthenticate("@/Root", "ApiKey-value-valid");
-            Cerr << msg->ErrorMessage << "\n";
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            client.PlainAuthenticateToKafka("@/Root", "ApiKey-value-valid");
         }
 
         Sleep(TDuration::Seconds(1));
@@ -3285,24 +2960,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TKafkaTestClient client(testServer.Port);
 
         {
-            auto msg = client.ApiVersions();
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(msg->ApiKeys.size(), EXPECTED_API_KEYS_COUNT);
-        }
-
-        {
-            auto msg = client.SaslHandshake();
-
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
-            UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[0], "PLAIN");
-        }
-
-        {
-            auto msg = client.SaslAuthenticate("/Root", "ApiKey-value-valid");
-            Cerr << msg->ErrorMessage << "\n";
-            UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+            client.PlainAuthenticateToKafka("/Root", "ApiKey-value-valid");
         }
 
         Sleep(TDuration::Seconds(1));
@@ -3392,7 +3050,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             // authenticating as user with read and write rights
             TString userName = "user123@/Root";
             TString userPassword = "UsErPassword";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             {
                 // checking consumer autocreation for existing topic
                 std::map<TString, std::vector<i32>> topicsToPartions;
@@ -3428,7 +3086,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "usernorights@/Root";
             TString userPassword = "dummyPass";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             {
                 // checking that consumer autocreation for existing topic for user with no rights
                 // returns authorisation error
@@ -3487,7 +3145,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             // authenticating as user with read and write rights
             TString userName = "user123@/Root";
             TString userPassword = "UsErPassword";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             {
                 // existent topic with existent consumer
                 std::map<TString, std::vector<i32>> topicsToPartions;
@@ -3642,7 +3300,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             // authenticating as a user with no write rights
             TString userName = "usernorights@/Root";
             TString userPassword = "dummyPass";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
 
             std::map<TString, std::vector<i32>> topicsToPartions;
             topicsToPartions[nonExistedTopicName3] = std::vector<i32>{0};
@@ -3657,7 +3315,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             // authenticating as a user with only read rights
             TString userName = "useronlyreadrights@/Root";
             TString userPassword = "AbAcAbA";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
 
             std::map<TString, std::vector<i32>> topicsToPartions;
             topicsToPartions[nonExistedTopicName3] = std::vector<i32>{0};
@@ -3708,7 +3366,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "user123@/Root";
             TString userPassword = "UsErPassword";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             TVector<TString> nonExistentTopics = {nonExistedTopicName1};
             auto msg = client.Metadata(nonExistentTopics);
             UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
@@ -3723,7 +3381,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "useronlyreadrights@/Root";
             TString userPassword = "AbAcAbA";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             TVector<TString> nonExistentTopic = {nonExistedTopicName2};
             auto msg = client.Metadata(nonExistentTopic);
             UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
@@ -3736,7 +3394,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "usernorights@/Root";
             TString userPassword = "dummyPass";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             TVector<TString> nonExistentTopic = {nonExistedTopicName2};
             auto msg = client.Metadata(nonExistentTopic);
             UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
@@ -3748,7 +3406,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             TKafkaTestClient client(testServer.Port);
             TString userName = "user123@/Root";
             TString userPassword = "UsErPassword";
-            client.AuthenticateToKafka(userName, userPassword);
+            client.PlainAuthenticateToKafka(userName, userPassword);
             TVector<TString> nonExistentTopics = {nonExistedTopicName2, existedTopicName};
             auto msg = client.Metadata(nonExistentTopics);
             UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 2);
@@ -4103,9 +3761,9 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         {
             TString user = "ouruser@/Root";
             TString pass = "ourUserPassword";
-            auto rA = clientA.SaslAuthenticate(user, pass);
-            auto rB = clientB.SaslAuthenticate(user, pass);
-            auto rC = clientC.SaslAuthenticate(user, pass);
+            auto rA = clientA.SaslPlainAuthenticate(user, pass);
+            auto rB = clientB.SaslPlainAuthenticate(user, pass);
+            auto rC = clientC.SaslPlainAuthenticate(user, pass);
             UNIT_ASSERT_VALUES_EQUAL(rA->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
             UNIT_ASSERT_VALUES_EQUAL(rB->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
             UNIT_ASSERT_VALUES_EQUAL(rC->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
@@ -5092,7 +4750,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         client.ApiVersions();
         client.SaslHandshake();
-        client.SaslAuthenticate("ouruser@/Root", "ourUserPassword");
+        client.SaslPlainAuthenticate("ouruser@/Root", "ourUserPassword");
         client.InitProducerId();
 
 

--- a/ydb/core/kafka_proxy/ut/ya.make
+++ b/ydb/core/kafka_proxy/ut/ya.make
@@ -14,6 +14,8 @@ ENDIF()
 SRCS(
     kafka_test_client.cpp
     kafka_test_client.h
+    test_server.cpp
+    ut_auth.cpp
     ut_kafka_functions.cpp
     ut_protocol.cpp
     ut_serialization.cpp

--- a/ydb/core/kafka_proxy/ya.make
+++ b/ydb/core/kafka_proxy/ya.make
@@ -67,6 +67,7 @@ PEERDIR(
     ydb/core/persqueue/public/write_meta
     ydb/core/protos
     ydb/core/raw_socket
+    ydb/core/security/sasl
     ydb/services/persqueue_v1
 )
 

--- a/ydb/core/security/login_shared_func.cpp
+++ b/ydb/core/security/login_shared_func.cpp
@@ -7,6 +7,10 @@
 
 namespace NKikimr {
 
+bool IsLdapAuthenticationEnable(const NKikimrProto::TAuthConfig& config) {
+    return config.HasLdapAuthentication();
+}
+
 bool IsUsernameFromLdapAuthDomain(const TString& username, const NKikimrProto::TAuthConfig& config) {
     if (config.HasLdapAuthentication() && !config.GetLdapAuthenticationDomain().empty()) {
         const TString ldapDomain = "@" + config.GetLdapAuthenticationDomain();

--- a/ydb/core/security/login_shared_func.h
+++ b/ydb/core/security/login_shared_func.h
@@ -9,6 +9,7 @@
 
 namespace NKikimr {
 
+bool IsLdapAuthenticationEnable(const NKikimrProto::TAuthConfig& config);
 bool IsUsernameFromLdapAuthDomain(const TString& username, const NKikimrProto::TAuthConfig& config);
 TString PrepareLdapUsername(const TString& username, const NKikimrProto::TAuthConfig& config);
 NKikimrScheme::TEvLogin CreatePlainLoginRequest(const TString& username, NLoginProto::EHashType::HashType hashType,

--- a/ydb/core/security/sasl/plain_auth_actor.cpp
+++ b/ydb/core/security/sasl/plain_auth_actor.cpp
@@ -190,7 +190,7 @@ private:
                 const auto scramInitParams = ParseScramHashInitParams(itHashesInitParams->second);
                 ui32 iterationsCount;
                 if (!TryFromString(scramInitParams.IterationsCount, iterationsCount)
-                    || !IsBase64(scramInitParams.Salt)) {
+                    || (iterationsCount == 0) || !IsBase64(scramInitParams.Salt)) {
                     LOG_ERROR_S(ctx, NKikimrServices::SASL_AUTH,
                         ActorName << "# " << ctx.SelfID.ToString() <<
                         ", " << "Authentication failed: " <<

--- a/ydb/library/login/sasl/scram.cpp
+++ b/ydb/library/login/sasl/scram.cpp
@@ -202,20 +202,21 @@ bool IsPrintable(const std::string_view str) {
 	return true;
 }
 
-bool IsUnsignedInt(const std::string_view str) {
-	   if (str.empty()) {
-	       return false;
-	   }
+bool IsPositiveInt(const std::string_view str) {
+    if (str.empty()) {
+	    return false;
+	}
 
-	   try {
-	       ui32 result = std::stoul(std::string(str));
-	       if (result == 0) {
-	           return false;
-	       }
-	       return true;
-	   } catch (...) {
-	       return false;
-	   }
+	try {
+        ui32 result = std::stoul(std::string(str));
+        if (result == 0) {
+            return false;
+        } else {
+            return true;
+        }
+    } catch (...) {
+        return false;
+    }
 }
 
 } // namespace
@@ -802,7 +803,7 @@ EParseMsgReturnCodes ParseFirstServerMsg(const std::string& msg, TFirstServerMsg
         }
 
         const std::string_view iterStr = iterAttr->second;
-        if (!IsUnsignedInt(iterStr)) {
+        if (!IsPositiveInt(iterStr)) {
             return EParseMsgReturnCodes::InvalidFormat;
         } else {
             parsedMsg.IterationsCount = std::stoul(std::string(iterStr));

--- a/ydb/library/login/sasl/scram.cpp
+++ b/ydb/library/login/sasl/scram.cpp
@@ -202,6 +202,22 @@ bool IsPrintable(const std::string_view str) {
 	return true;
 }
 
+bool IsUnsignedInt(const std::string_view str) {
+	   if (str.empty()) {
+	       return false;
+	   }
+
+	   try {
+	       ui32 result = std::stoul(std::string(str));
+	       if (result == 0) {
+	           return false;
+	       }
+	       return true;
+	   } catch (...) {
+	       return false;
+	   }
+}
+
 } // namespace
 
 namespace NLogin::NSasl {
@@ -728,6 +744,157 @@ EParseMsgReturnCodes ParseFinalClientMsg(const std::string& msg, TFinalClientMsg
     }
 
     parsedMsg.ClientFinalMessageWithoutProof = msgView.substr(0, clientFinalMsgWithoutProofLength);
+    return EParseMsgReturnCodes::Success;
+}
+
+EParseMsgReturnCodes ParseFirstServerMsg(const std::string& msg, TFirstServerMsg& parsedMsg) {
+    if (msg.empty()) {
+        return EParseMsgReturnCodes::InvalidFormat;
+    }
+
+    const std::string_view msgView = msg;
+    size_t i = 0;
+
+    // read nonce
+    if (auto nonceAttr = ReadAttribute(msgView, i); nonceAttr.has_value()) {
+        if (nonceAttr->first != 'r') {
+            return EParseMsgReturnCodes::InvalidFormat;
+        }
+
+        const std::string_view nonce = nonceAttr->second;
+        if (!IsPrintable(nonce)) {
+            return EParseMsgReturnCodes::InvalidEncoding;
+        } else {
+            parsedMsg.Nonce = nonce;
+        }
+    } else {
+        return EParseMsgReturnCodes::InvalidFormat;
+    }
+
+    if (i == msgView.size() || msgView[i++] != ',') {
+        return EParseMsgReturnCodes::InvalidFormat;
+    }
+
+    // read salt
+    if (auto saltAttr = ReadAttribute(msgView, i); saltAttr.has_value()) {
+        if (saltAttr->first != 's') {
+            return EParseMsgReturnCodes::InvalidFormat;
+        }
+
+        const std::string_view salt = saltAttr->second;
+        if (!IsBase64(salt)) {
+            return EParseMsgReturnCodes::InvalidEncoding;
+        } else {
+            parsedMsg.Salt = salt;
+        }
+    } else {
+        return EParseMsgReturnCodes::InvalidFormat;
+    }
+
+    if (i == msgView.size() || msgView[i++] != ',') {
+        return EParseMsgReturnCodes::InvalidFormat;
+    }
+
+    // read iterations count
+    if (auto iterAttr = ReadAttribute(msgView, i); iterAttr.has_value()) {
+        if (iterAttr->first != 'i') {
+            return EParseMsgReturnCodes::InvalidFormat;
+        }
+
+        const std::string_view iterStr = iterAttr->second;
+        if (!IsUnsignedInt(iterStr)) {
+            return EParseMsgReturnCodes::InvalidFormat;
+        } else {
+            parsedMsg.IterationsCount = std::stoul(std::string(iterStr));
+        }
+    } else {
+        return EParseMsgReturnCodes::InvalidFormat;
+    }
+
+    // read extensions
+    while (i != msgView.size()) {
+        if (msgView[i++] != ',') {
+            return EParseMsgReturnCodes::InvalidFormat;
+        }
+
+        if (auto attr = ReadAttribute(msgView, i); attr.has_value()) {
+            if (RESERVED_ATTRIBUTE_NAMES.contains(attr->first)) {
+                return EParseMsgReturnCodes::InvalidFormat;
+            }
+
+            const std::string_view attrValue = attr->second;
+            if (!IsUtf(attrValue.data(), attrValue.size())) {
+                return EParseMsgReturnCodes::InvalidEncoding;
+            } else {
+                if (!parsedMsg.Extensions.emplace(attr->first, attrValue).second){
+                    return EParseMsgReturnCodes::InvalidFormat;
+                }
+            }
+        } else {
+            return EParseMsgReturnCodes::InvalidFormat;
+        }
+    }
+
+    return EParseMsgReturnCodes::Success;
+}
+
+EParseMsgReturnCodes ParseFinalServerMsg(const std::string& msg, TFinalServerMsg& parsedMsg) {
+    if (msg.empty()) {
+        return EParseMsgReturnCodes::InvalidFormat;
+    }
+
+    const std::string_view msgView = msg;
+    size_t i = 0;
+
+    // read first attribute (either 'v' for server signature or 'e' for error)
+    if (auto firstAttr = ReadAttribute(msgView, i); firstAttr.has_value()) {
+        if (firstAttr->first == 'v') {
+            // server signature
+            const std::string_view serverSignature = firstAttr->second;
+            if (!IsBase64(serverSignature)) {
+                return EParseMsgReturnCodes::InvalidEncoding;
+            } else {
+                parsedMsg.ServerSignature = serverSignature;
+            }
+        } else if (firstAttr->first == 'e') {
+            // error
+            const std::string_view error = firstAttr->second;
+            if (!IsPrintable(error)) {
+                return EParseMsgReturnCodes::InvalidEncoding;
+            } else {
+                parsedMsg.Error = error;
+            }
+        } else {
+            return EParseMsgReturnCodes::InvalidFormat;
+        }
+    } else {
+        return EParseMsgReturnCodes::InvalidFormat;
+    }
+
+    // read extensions
+    while (i != msgView.size()) {
+        if (msgView[i++] != ',') {
+            return EParseMsgReturnCodes::InvalidFormat;
+        }
+
+        if (auto attr = ReadAttribute(msgView, i); attr.has_value()) {
+            if (RESERVED_ATTRIBUTE_NAMES.contains(attr->first)) {
+                return EParseMsgReturnCodes::InvalidFormat;
+            }
+
+            const std::string_view attrValue = attr->second;
+            if (!IsUtf(attrValue.data(), attrValue.size())) {
+                return EParseMsgReturnCodes::InvalidEncoding;
+            } else {
+                if (!parsedMsg.Extensions.emplace(attr->first, attrValue).second){
+                    return EParseMsgReturnCodes::InvalidFormat;
+                }
+            }
+        } else {
+            return EParseMsgReturnCodes::InvalidFormat;
+        }
+    }
+
     return EParseMsgReturnCodes::Success;
 }
 

--- a/ydb/library/login/sasl/scram.h
+++ b/ydb/library/login/sasl/scram.h
@@ -37,6 +37,19 @@ struct TFinalClientMsg {
     std::string ClientFinalMessageWithoutProof;
 };
 
+struct TFirstServerMsg {
+    std::string Nonce;
+    std::string Salt;
+    ui32 IterationsCount;
+    std::unordered_map<char, std::string> Extensions;
+};
+
+struct TFinalServerMsg {
+    std::string ServerSignature;
+    std::string Error;
+    std::unordered_map<char, std::string> Extensions;
+};
+
 enum class EParseMsgReturnCodes {
     Success,
     InvalidEncoding,
@@ -78,6 +91,8 @@ bool VerifyClientProof(const std::string& hashType, const std::string& clientPro
 
 EParseMsgReturnCodes ParseFirstClientMsg(const std::string& msg, TFirstClientMsg& parsedMsg);
 EParseMsgReturnCodes ParseFinalClientMsg(const std::string& msg, TFinalClientMsg& parsedMsg);
+EParseMsgReturnCodes ParseFirstServerMsg(const std::string& msg, TFirstServerMsg& parsedMsg);
+EParseMsgReturnCodes ParseFinalServerMsg(const std::string& msg, TFinalServerMsg& parsedMsg);
 
 std::string BuildFirstServerMsg(const std::string& nonce, const std::string& salt, const std::string& iterationsCount,
     const std::unordered_map<char, std::string>& extensions = {});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
**Add SASL SCRAM-SHA-256 Authentication Support for Kafka Protocol**

This change introduces SASL SCRAM-SHA-256 authentication mechanism for the Kafka protocol when using YDB local users. 
Kafka clients can now specify `SCRAM-SHA-256` as the SASL mechanism when connecting to YDB's Kafka-compatible API with local user credentials.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

