### PR TITLE
External Table import from S3

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -123,7 +123,6 @@ bool ShouldDelayQueryExecutionOnError(
             return IsIn({
                 NKikimrScheme::StatusPathDoesNotExist,
                 NKikimrScheme::StatusSchemeError,
-                NKikimrScheme::StatusMultipleModifications,
             }, status);
         default:
             return false;
@@ -1506,6 +1505,9 @@ private:
             )) {
                 if (record.GetPathCreateTxId()) {
                     txId = TTxId(record.GetPathCreateTxId());
+                } else if (item.State == EState::CreateSchemeObject) {
+                    // In case dependency object is being created
+                    return DelayObjectCreation(importInfo, itemIdx, db, record.GetReason(), ctx);
                 } else if (item.State == EState::Transferring) {
                     txId = GetActiveRestoreTxId(*importInfo, itemIdx);
                 } else if (item.State == EState::CreateChangefeed) {
@@ -1514,7 +1516,6 @@ private:
                     } else {
                         txId = GetActiveCreateConsumerTxId(*importInfo, itemIdx);
                     }
-
                 }
             }
 

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -102,7 +102,7 @@ bool RewriteCreateQuery(
         return NYdb::NDump::RewriteCreateExternalDataSourceQuery(query, dbRestoreRoot, dbPath, issues);
     }
     if (IsCreateExternalTableQuery(query)) {
-        return NYdb::NDump::RewriteCreateExternalTableQuery(query, dbPath, issues);
+        return NYdb::NDump::RewriteCreateExternalTableQuery(query, dbRestoreRoot, dbPath, issues);
     }
 
     issues.AddIssue(TStringBuilder() << "unsupported create query: " << query);

--- a/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
@@ -344,11 +344,16 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
         return schemeKey.EndsWith(NYdb::NDump::NFiles::CreateExternalDataSource().FileName);
     }
 
+    static bool IsExternalTable(TStringBuf schemeKey) {
+        return schemeKey.EndsWith(NYdb::NDump::NFiles::CreateExternalTable().FileName);
+    }
+
     static bool IsCreatedByQuery(TStringBuf schemeKey) {
         return IsView(schemeKey)
             || IsReplication(schemeKey)
             || IsTransfer(schemeKey)
-            || IsExternalDataSource(schemeKey);
+            || IsExternalDataSource(schemeKey)
+            || IsExternalTable(schemeKey);
     }
 
     static bool NoObjectFound(Aws::S3::S3Errors errorType) {

--- a/ydb/core/tx/schemeshard/schemeshard_import_scheme_query_executor.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_scheme_query_executor.cpp
@@ -106,6 +106,11 @@ class TSchemeQueryExecutor: public TActorBootstrapped<TSchemeQueryExecutor> {
             return Finish(result->Status, createExternalDataSource);
         }
 
+        if (transactions[0].GetSchemeOperation().HasCreateExternalTable()) {
+            const auto& createExternalTable = transactions[0].GetSchemeOperation().GetCreateExternalTable();
+            return Finish(result->Status, createExternalTable);
+        }
+
         return Finish(Ydb::StatusIds::GENERIC_ERROR, "no supported create operation");
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_import_scheme_query_executor.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_scheme_query_executor.cpp
@@ -104,9 +104,7 @@ class TSchemeQueryExecutor: public TActorBootstrapped<TSchemeQueryExecutor> {
         } else if (transactions[0].GetSchemeOperation().HasCreateExternalDataSource()) {
             const auto& createExternalDataSource = transactions[0].GetSchemeOperation().GetCreateExternalDataSource();
             return Finish(result->Status, createExternalDataSource);
-        }
-
-        if (transactions[0].GetSchemeOperation().HasCreateExternalTable()) {
+        } else if (transactions[0].GetSchemeOperation().HasCreateExternalTable()) {
             const auto& createExternalTable = transactions[0].GetSchemeOperation().GetCreateExternalTable();
             return Finish(result->Status, createExternalTable);
         }

--- a/ydb/core/tx/schemeshard/schemeshard_scheme_builders.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_scheme_builders.cpp
@@ -159,6 +159,8 @@ bool BuildExternalDataSourceScheme(
 bool BuildExternalTableScheme(
     const NKikimrScheme::TEvDescribeSchemeResult& describeResult,
     TString& scheme,
+    const TString& database,
+    const TString& backupRoot,
     TString& error)
 {
     const auto& pathDesc = describeResult.GetPathDescription();
@@ -175,7 +177,7 @@ bool BuildExternalTableScheme(
         return false;
     }
 
-    scheme = NYdb::NDump::BuildCreateExternalTableQuery(externalTableDescResult);
+    scheme = NYdb::NDump::BuildCreateExternalTableQuery(database, backupRoot, externalTableDescResult);
 
     return true;
 }
@@ -200,7 +202,7 @@ bool BuildScheme(
         case NKikimrSchemeOp::EPathTypeExternalDataSource:
             return BuildExternalDataSourceScheme(describeResult, scheme, databaseRoot, error);
         case NKikimrSchemeOp::EPathTypeExternalTable:
-            return BuildExternalTableScheme(describeResult, scheme, error);
+            return BuildExternalTableScheme(describeResult, scheme, databaseRoot, databaseRoot, error);
         default:
             error = TStringBuilder() << "unsupported path type: " << pathType;
             return false;

--- a/ydb/core/tx/schemeshard/schemeshard_scheme_builders.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_scheme_builders.cpp
@@ -160,7 +160,6 @@ bool BuildExternalTableScheme(
     const NKikimrScheme::TEvDescribeSchemeResult& describeResult,
     TString& scheme,
     const TString& database,
-    const TString& backupRoot,
     TString& error)
 {
     const auto& pathDesc = describeResult.GetPathDescription();
@@ -177,7 +176,7 @@ bool BuildExternalTableScheme(
         return false;
     }
 
-    scheme = NYdb::NDump::BuildCreateExternalTableQuery(database, backupRoot, externalTableDescResult);
+    scheme = NYdb::NDump::BuildCreateExternalTableQuery(database, database, externalTableDescResult);
 
     return true;
 }
@@ -202,7 +201,7 @@ bool BuildScheme(
         case NKikimrSchemeOp::EPathTypeExternalDataSource:
             return BuildExternalDataSourceScheme(describeResult, scheme, databaseRoot, error);
         case NKikimrSchemeOp::EPathTypeExternalTable:
-            return BuildExternalTableScheme(describeResult, scheme, databaseRoot, databaseRoot, error);
+            return BuildExternalTableScheme(describeResult, scheme, databaseRoot, error);
         default:
             error = TStringBuilder() << "unsupported path type: " << pathType;
             return false;

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -891,7 +891,7 @@ namespace {
 
             TestGetExport(Runtime(), txId, "/MyRoot", Ydb::StatusIds::SUCCESS);
 
-            UNIT_ASSERT(HasS3File("/ExternalTable/create_external_table.sql"));
+            CheckPathWithChecksum("/ExternalTable/create_external_table.sql");
             const auto content = GetS3FileContent("/ExternalTable/create_external_table.sql");
 
             UNIT_ASSERT_C(content.find(expectedStartsWith) != TString::npos,
@@ -911,7 +911,7 @@ namespace {
                 static_cast<long>(expectedProperties.size()),
                 TStringBuilder() << "Properties count mismatch: ");
 
-            UNIT_ASSERT(HasS3File("/ExternalTable/permissions.pb"));
+            CheckPathWithChecksum("/ExternalTable/permissions.pb");
             const auto permissions = GetS3FileContent("/ExternalTable/permissions.pb");
             const auto permissions_expected = "actions {\n  change_owner: \"root@builtin\"\n}\n";
             UNIT_ASSERT_EQUAL_C(

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -3925,7 +3925,9 @@ WITH (
             Columns { Name: "value2" Type: "Utf8" NotNull: true }
         )";
 
-        TString expectedStartsWith = R"(CREATE EXTERNAL TABLE IF NOT EXISTS `ExternalTable` (
+        TString expectedStartsWith = R"(-- database: "/MyRoot"
+-- backup root: "/MyRoot"
+CREATE EXTERNAL TABLE IF NOT EXISTS `ExternalTable` (
       key Uint64 NOT NULL,
     value1 Uint64?,
     value2 Utf8 NOT NULL

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -319,6 +319,7 @@ namespace {
         case EPathTypeReplication:
         case EPathTypeTransfer:
         case EPathTypeExternalDataSource:
+        case EPathTypeExternalTable:
             result.CreationQuery = typedScheme.Scheme;
             break;
         case EPathTypeCdcStream:
@@ -386,6 +387,14 @@ namespace {
                 result.emplace(externalDataSourceKey, item.CreationQuery);
                 if (withChecksum) {
                     result.emplace(NBackup::ChecksumKey(externalDataSourceKey), item.CreationQuery.Checksum);
+                }
+                break;
+            }
+            case EPathTypeExternalTable: {
+                auto externalTableKey = prefix + "/create_external_table.sql";
+                result.emplace(externalTableKey, item.CreationQuery);
+                if (withChecksum) {
+                    result.emplace(NBackup::ChecksumKey(externalTableKey), item.CreationQuery.Checksum);
                 }
                 break;
             }
@@ -6914,6 +6923,171 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         TestDescribeResult(DescribePath(runtime, "/MyRoot/DataSource"), {
             NLs::Finished,
             NLs::IsExternalDataSource,
+        });
+    }
+
+    Y_UNIT_TEST(ExternalTableImport) {
+        TTestBasicRuntime runtime;
+        auto options = TTestEnvOptions()
+            .RunFakeConfigDispatcher(true)
+            .SetupKqpProxy(true);
+        TTestEnv env(runtime, options);
+        runtime.GetAppData().FeatureFlags.SetEnableExternalDataSources(true);
+        runtime.SetLogPriority(NKikimrServices::IMPORT, NActors::NLog::PRI_TRACE);
+        ui64 txId = 100;
+
+        THashMap<TString, TTestDataWithScheme> bucketContent(2);
+        bucketContent.emplace("/DataSource", GenerateTestData(
+            {
+                EPathTypeExternalDataSource,
+                R"(
+                    -- database: "/MyRoot"
+                    CREATE EXTERNAL DATA SOURCE IF NOT EXISTS `DataSource`
+                    WITH (
+                        SOURCE_TYPE = 'ObjectStorage',
+                        LOCATION = 'https://s3.cloud.net/bucket',
+                        AUTH_METHOD = 'AWS',
+                        AWS_ACCESS_KEY_ID_SECRET_NAME = 'id_secret',
+                        AWS_SECRET_ACCESS_KEY_SECRET_NAME = 'access_secret',
+                        AWS_REGION = 'ru-central-1'
+                    );
+                )"
+            }
+        ));
+        bucketContent.emplace("/ExternalTable", GenerateTestData(
+            {
+                EPathTypeExternalTable,
+                R"(
+                    CREATE EXTERNAL TABLE IF NOT EXISTS `ExternalTable` (
+                        key Uint64 NOT NULL,
+                        value1 Uint64?,
+                        value2 Utf8 NOT NULL
+                    ) WITH (
+                        DATA_SOURCE = '/MyRoot/DataSource',
+                        LOCATION = 'bucket'
+                    )
+                )"
+            }
+        ));
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock(ConvertTestData(bucketContent), TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TestImport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: "ExternalTable"
+                destination_path: "/MyRoot/ExternalTable"
+              }
+              items {
+                source_prefix: "DataSource"
+                destination_path: "/MyRoot/DataSource"
+              }
+            }
+        )", port));
+
+        env.TestWaitNotification(runtime, txId);
+        TestGetImport(runtime, txId, "/MyRoot");
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/ExternalTable"), {
+            NLs::Finished,
+            NLs::IsExternalTable,
+        });
+    }
+
+    Y_UNIT_TEST(ExternalTableExportImport) {
+        TTestBasicRuntime runtime;
+        auto options = TTestEnvOptions()
+            .RunFakeConfigDispatcher(true)
+            .SetupKqpProxy(true);
+        TTestEnv env(runtime, options);
+        runtime.GetAppData().FeatureFlags.SetEnableExternalDataSources(true);
+        runtime.SetLogPriority(NKikimrServices::IMPORT, NActors::NLog::PRI_TRACE);
+        ui64 txId = 100;
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "DataSource"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/bucket"
+            Auth {
+                Aws {
+                    AwsAccessKeyIdSecretName: "id_secret",
+                    AwsSecretAccessKeySecretName: "access_secret"
+                    AwsRegion: "ru-central-1"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalTable"
+            SourceType: "General"
+            DataSourcePath: "/MyRoot/DataSource"
+            Location: "bucket"
+            Columns { Name: "key" Type: "Uint64" NotNull: true }
+            Columns { Name: "value1" Type: "Uint64" }
+            Columns { Name: "value2" Type: "Utf8" NotNull: true }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock({}, TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TString exportRequest = Sprintf(R"(
+            ExportToS3Settings {
+                endpoint: "localhost:%d"
+                scheme: HTTP
+                items {
+                    source_path: "/MyRoot/DataSource"
+                    destination_prefix: "DataSource"
+                }
+                items {
+                    source_path: "/MyRoot/ExternalTable"
+                    destination_prefix: "ExternalTable"
+                }
+            }
+        )", port);
+
+        TestExport(runtime, ++txId, "/MyRoot", exportRequest);
+        env.TestWaitNotification(runtime, txId);
+        TestGetExport(runtime, txId, "/MyRoot");
+
+        TestDropExternalTable(runtime, ++txId, "/MyRoot", "ExternalTable");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropExternalDataSource(runtime, ++txId, "/MyRoot", "DataSource");
+        env.TestWaitNotification(runtime, txId);
+
+        TString importRequest = Sprintf(R"(
+            ImportFromS3Settings {
+                endpoint: "localhost:%d"
+                scheme: HTTP
+                items {
+                    source_prefix: "ExternalTable"
+                    destination_path: "/MyRoot/ExternalTable"
+                }
+                items {
+                    source_prefix: "DataSource"
+                    destination_path: "/MyRoot/DataSource"
+                }
+            }
+        )", port);
+
+        TestImport(runtime, ++txId, "/MyRoot", importRequest);
+        env.TestWaitNotification(runtime, txId);
+        TestGetImport(runtime, txId, "/MyRoot");
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/ExternalTable"), {
+            NLs::Finished,
+            NLs::IsExternalTable,
         });
     }
 }

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -7090,6 +7090,202 @@ Y_UNIT_TEST_SUITE(TImportTests) {
             NLs::IsExternalTable,
         });
     }
+
+    Y_UNIT_TEST(SchemeObjectsImportToAnotherDirectory) {
+        TTestBasicRuntime runtime;
+        auto options = TTestEnvOptions()
+            .RunFakeConfigDispatcher(true)
+            .SetupKqpProxy(true)
+            .InitYdbDriver(true);
+        TTestEnv env(runtime, options);
+        runtime.GetAppData().FeatureFlags.SetEnableReplication(true);
+        runtime.GetAppData().FeatureFlags.SetEnableExternalDataSources(true);
+        runtime.GetAppData().FeatureFlags.SetEnableEncryptedExport(true);
+        runtime.SetLogPriority(NKikimrServices::IMPORT, NActors::NLog::PRI_TRACE);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication"
+            Config {
+                SrcConnectionParams {
+                    Endpoint: "localhost:2135"
+                    Database: "/MyRoot"
+                    StaticCredentials {
+                        User: "user"
+                        Password: "pwd"
+                        PasswordSecretName: "pwd-secret-name"
+                    }
+                }
+                Specific {
+                    Targets {
+                        SrcPath: "/MyRoot/Table"
+                        DstPath: "/MyRoot/TableReplica"
+                    }
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTransfer(runtime, ++txId, "/MyRoot", R"(
+            Name: "Transfer"
+            Config {
+                SrcConnectionParams {
+                    Endpoint: "localhost:2135"
+                    Database: "/MyRoot"
+                }
+                TransferSpecific {
+                    Target {
+                        SrcPath: "/MyRoot/Topic"
+                        DstPath: "/MyRoot/Table"
+                        TransformLambda: "PRAGMA OrderedColumns;$transformation_lambda = ($msg) -> { return [ <| partition: $msg._partition, offset: $msg._offset, message: CAST($msg._data AS Utf8) |> ]; };$__ydb_transfer_lambda = $transformation_lambda;"
+                    }
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot", R"(
+            Name: "DataSource"
+            SourceType: "ObjectStorage"
+            Location: "https://s3.cloud.net/bucket"
+            Auth {
+                Aws {
+                    AwsAccessKeyIdSecretName: "id_secret",
+                    AwsSecretAccessKeySecretName: "access_secret"
+                    AwsRegion: "ru-central-1"
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ExternalTable"
+            SourceType: "General"
+            DataSourcePath: "/MyRoot/DataSource"
+            Location: "bucket"
+            Columns { Name: "key" Type: "Uint64" NotNull: true }
+            Columns { Name: "value1" Type: "Uint64" }
+            Columns { Name: "value2" Type: "Utf8" NotNull: true }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock({}, TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TString exportRequest = Sprintf(R"(
+            ExportToS3Settings {
+                endpoint: "localhost:%d"
+                scheme: HTTP
+                items {
+                    source_path: "/MyRoot/Table"
+                    destination_prefix: "Table"
+                }
+                items {
+                    source_path: "/MyRoot/Replication"
+                    destination_prefix: "Replication"
+                }
+                items {
+                    source_path: "/MyRoot/Transfer"
+                    destination_prefix: "Transfer"
+                }
+                items {
+                    source_path: "/MyRoot/DataSource"
+                    destination_prefix: "DataSource"
+                }
+                items {
+                    source_path: "/MyRoot/ExternalTable"
+                    destination_prefix: "ExternalTable"
+                }
+            }
+        )", port);
+
+        TestExport(runtime, ++txId, "/MyRoot", exportRequest);
+        env.TestWaitNotification(runtime, txId);
+        TestGetExport(runtime, txId, "/MyRoot");
+
+        // Drop all objects
+        TestDropExternalTable(runtime, ++txId, "/MyRoot", "ExternalTable");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropExternalDataSource(runtime, ++txId, "/MyRoot", "DataSource");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropTransfer(runtime, ++txId, "/MyRoot", "Transfer");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropReplication(runtime, ++txId, "/MyRoot", "Replication");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropTable(runtime, ++txId, "/MyRoot", "Table");
+        env.TestWaitNotification(runtime, txId);
+
+        TString importRequest = Sprintf(R"(
+            ImportFromS3Settings {
+                endpoint: "localhost:%d"
+                scheme: HTTP
+                items {
+                    source_prefix: "Table"
+                    destination_path: "/MyRoot/Table"
+                }
+                items {
+                    source_prefix: "Replication"
+                    destination_path: "/MyRoot/Replication"
+                }
+                items {
+                    source_prefix: "Transfer"
+                    destination_path: "/MyRoot/Transfer"
+                }
+                items {
+                    source_prefix: "DataSource"
+                    destination_path: "/MyRoot/DataSource"
+                }
+                items {
+                    source_prefix: "ExternalTable"
+                    destination_path: "/MyRoot/ExternalTable"
+                }
+            }
+        )", port);
+
+        TestImport(runtime, ++txId, "/MyRoot", importRequest);
+        env.TestWaitNotification(runtime, txId);
+        TestGetImport(runtime, txId, "/MyRoot");
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"), {
+            NLs::Finished,
+            NLs::IsTable,
+        });
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Replication"), {
+            NLs::Finished,
+            NLs::IsReplication,
+        });
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Transfer"), {
+            NLs::Finished,
+            NLs::IsTransfer,
+        });
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/DataSource"), {
+            NLs::Finished,
+            NLs::IsExternalDataSource,
+        });
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/ExternalTable"), {
+            NLs::Finished,
+            NLs::IsExternalTable,
+        });
+    }
 }
 
 Y_UNIT_TEST_SUITE(TImportWithRebootsTests) {

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -418,7 +418,7 @@ TRestoreResult TDelayedRestoreManager::Restore(const TDelayedRestoreCall& call) 
             return Client->RestoreView(call.FsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, call.Settings);
         }
         case ESchemeEntryType::ExternalTable: {
-            const auto& [dbPath, dbRestoreRoot] = std::get<TDelayedRestoreCall::TTwoComponentPath>(call.DbPath);
+            const auto& [dbRestoreRoot, dbPath] = std::get<TDelayedRestoreCall::TTwoComponentPath>(call.DbPath);
             return Client->RestoreExternalTable(call.FsPath, dbRestoreRoot, dbPath, call.Settings);
         }
         case ESchemeEntryType::Replication: {
@@ -1193,7 +1193,7 @@ TRestoreResult TRestoreClient::Restore(NScheme::ESchemeEntryType type, const TFs
             return RestoreCoordinationNode(fsPath, dbPath, settings);
         case ESchemeEntryType::ExternalTable:
             if (delay) {
-                DelayedRestoreManager.Add(ESchemeEntryType::ExternalTable, fsPath, dbPath, dbRestoreRoot, settings);
+                DelayedRestoreManager.Add(ESchemeEntryType::ExternalTable, fsPath, dbRestoreRoot, dbPath, settings);
                 return Result<TRestoreResult>();
             }
             return RestoreExternalTable(fsPath, dbRestoreRoot, dbPath, settings);

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -419,7 +419,7 @@ TRestoreResult TDelayedRestoreManager::Restore(const TDelayedRestoreCall& call) 
         }
         case ESchemeEntryType::ExternalTable: {
             const auto& [dbPath, dbRestoreRoot] = std::get<TDelayedRestoreCall::TTwoComponentPath>(call.DbPath);
-            return Client->RestoreExternalTable(call.FsPath, dbPath, dbRestoreRoot, call.Settings);
+            return Client->RestoreExternalTable(call.FsPath, dbRestoreRoot, dbPath, call.Settings);
         }
         case ESchemeEntryType::Replication: {
             const auto& [dbRestoreRoot, dbPathRelativeToRestoreRoot] = std::get<TDelayedRestoreCall::TTwoComponentPath>(call.DbPath);
@@ -1196,7 +1196,7 @@ TRestoreResult TRestoreClient::Restore(NScheme::ESchemeEntryType type, const TFs
                 DelayedRestoreManager.Add(ESchemeEntryType::ExternalTable, fsPath, dbPath, dbRestoreRoot, settings);
                 return Result<TRestoreResult>();
             }
-            return RestoreExternalTable(fsPath, dbPath, dbRestoreRoot, settings);
+            return RestoreExternalTable(fsPath, dbRestoreRoot, dbPath, settings);
         case ESchemeEntryType::ExternalDataSource:
             return RestoreExternalDataSource(fsPath, dbRestoreRoot, dbPath, settings);
         case ESchemeEntryType::SysView:
@@ -1266,7 +1266,7 @@ TRestoreResult TRestoreClient::DropAndRestoreExternals(const TVector<TFsBackupEn
     }
     for (const auto& [dbPath, i] : externalTables) {
         const auto& fsPath = backupEntries[i].FsPath;
-        auto result = RestoreExternalTable(fsPath, dbPath, dbRestoreRoot, settings);
+        auto result = RestoreExternalTable(fsPath, dbRestoreRoot, dbPath, settings);
         if (!result.IsSuccess()) {
             return result;
         }
@@ -1779,8 +1779,8 @@ TRestoreResult TRestoreClient::RestoreExternalDataSource(
 
 TRestoreResult TRestoreClient::RestoreExternalTable(
     const TFsPath& fsPath,
-    const TString& dbPath,
     const TString& dbRestoreRoot,
+    const TString& dbPath,
     const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -202,7 +202,7 @@ class TRestoreClient {
     TRestoreResult RestoreDependentResources(const TFsPath& fsPath, const TString& dbPath);
     TRestoreResult RestoreRateLimiter(const TFsPath& fsPath, const TString& coordinationNodePath, const TString& resourcePath);
     TRestoreResult RestoreExternalDataSource(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPath, const TRestoreSettings& settings);
-    TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPath, const TRestoreSettings& settings);
+    TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings);
     TRestoreResult RestoreSysView(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
 
     TRestoreResult CheckExistenceAndType(const TString& dbPath, NScheme::ESchemeEntryType expectedType) const;

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -202,7 +202,7 @@ class TRestoreClient {
     TRestoreResult RestoreDependentResources(const TFsPath& fsPath, const TString& dbPath);
     TRestoreResult RestoreRateLimiter(const TFsPath& fsPath, const TString& coordinationNodePath, const TString& resourcePath);
     TRestoreResult RestoreExternalDataSource(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPath, const TRestoreSettings& settings);
-    TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbPath, const TString& dbRestoreRoot, const TRestoreSettings& settings);
+    TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPath, const TRestoreSettings& settings);
     TRestoreResult RestoreSysView(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
 
     TRestoreResult CheckExistenceAndType(const TString& dbPath, NScheme::ESchemeEntryType expectedType) const;

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -202,7 +202,7 @@ class TRestoreClient {
     TRestoreResult RestoreDependentResources(const TFsPath& fsPath, const TString& dbPath);
     TRestoreResult RestoreRateLimiter(const TFsPath& fsPath, const TString& coordinationNodePath, const TString& resourcePath);
     TRestoreResult RestoreExternalDataSource(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPath, const TRestoreSettings& settings);
-    TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
+    TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbPath, const TString& dbRestoreRoot, const TRestoreSettings& settings);
     TRestoreResult RestoreSysView(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
 
     TRestoreResult CheckExistenceAndType(const TString& dbPath, NScheme::ESchemeEntryType expectedType) const;

--- a/ydb/public/lib/ydb_cli/dump/util/external_table_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/external_table_utils.h
@@ -12,10 +12,14 @@ namespace NYql {
 
 namespace NYdb::NDump {
 
-TString BuildCreateExternalTableQuery(const Ydb::Table::DescribeExternalTableResult& description);
+TString BuildCreateExternalTableQuery(
+    const TString& db,
+    const TString& backupRoot,
+    const Ydb::Table::DescribeExternalTableResult& description);
 
 bool RewriteCreateExternalTableQuery(
     TString& query,
+    const TString& dbRestoreRoot,
     const TString& dbPath,
     NYql::TIssues& issues);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

External Tables import from S3

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

По аналогии с трансферами у внешних таблиц возникают ошибки при выполнении запроса, если внешние источники, от которых они зависят, еще не импортированы. Для проверки того, что ошибка именно в порядке импорта объектов, служит `ShouldDelayQueryExecutionOnError `
