### PR TITLE
services: fix possible use-after-free on destruction

### DIFF
--- a/ydb/core/client/server/grpc_server.cpp
+++ b/ydb/core/client/server/grpc_server.cpp
@@ -117,7 +117,7 @@ void TGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #error SETUP_SERVER_METHOD macro already defined
 #endif
 
-#define SETUP_SERVER_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, auditMode) \
+#define SETUP_SERVER_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, auditMode,...) \
     SETUP_RUNTIME_EVENT_METHOD(methodName,                 \
         inputType,                                         \
         outputType,                                        \
@@ -131,14 +131,14 @@ void TGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         GRpcRequestProxyId_,                               \
         CQ_,                                               \
         nullptr,                                           \
-        nullptr)
+        nullptr,## __VA_ARGS__)
 
-    SETUP_SERVER_METHOD(SchemeOperation, TSchemeOperation, TResponse, DoSchemeOperation(MsgBusProxy_, ActorSystem_), RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_SERVER_METHOD(SchemeOperation, TSchemeOperation, TResponse, callback, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin), callback = DoSchemeOperation(MsgBusProxy_, ActorSystem_));
     SETUP_SERVER_METHOD(SchemeOperationStatus, TSchemeOperationStatus, TResponse, DoSchemeOperationStatus, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
-    SETUP_SERVER_METHOD(SchemeDescribe, TSchemeDescribe, TResponse, DoSchemeDescribe(MsgBusProxy_, ActorSystem_), RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
+    SETUP_SERVER_METHOD(SchemeDescribe, TSchemeDescribe, TResponse, callback, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying(), callback = DoSchemeDescribe(MsgBusProxy_, ActorSystem_));
     SETUP_SERVER_METHOD(ChooseProxy, TChooseProxyRequest, TResponse, DoChooseProxy, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
-    SETUP_SERVER_METHOD(PersQueueRequest, TPersQueueRequest, TResponse, DoPersQueueRequest(MsgBusProxy_, ActorSystem_), RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml));
-    SETUP_SERVER_METHOD(SchemeInitRoot, TSchemeInitRoot, TResponse, DoSchemeInitRoot(MsgBusProxy_, ActorSystem_), RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_SERVER_METHOD(PersQueueRequest, TPersQueueRequest, TResponse, callback, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml), callback = DoPersQueueRequest(MsgBusProxy_, ActorSystem_));
+    SETUP_SERVER_METHOD(SchemeInitRoot, TSchemeInitRoot, TResponse, callback, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin), callback = DoSchemeInitRoot(MsgBusProxy_, ActorSystem_));
     SETUP_SERVER_METHOD(ResolveNode, TResolveNodeRequest, TResponse, DoResolveNode, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_SERVER_METHOD(FillNode, TFillNodeRequest, TResponse, DoFillNode, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
     SETUP_SERVER_METHOD(DrainNode, TDrainNodeRequest, TResponse, DoDrainNode, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -358,7 +358,7 @@ enum class TRateLimiterMode : ui8 {
     ::NKikimr::NGRpcService::TRateLimiterMode::mode
 
 #define RLSWITCH(mode) \
-    IsRlAllowed() ? RLMODE(mode) : RLMODE(Off)
+    isRlAllowed ? RLMODE(mode) : RLMODE(Off)
 
 struct TAuditMode {
     using TLogClassConfig = NKikimrConfig::TAuditConfig::TLogClassConfig;

--- a/ydb/library/grpc/server/grpc_server.h
+++ b/ydb/library/grpc/server/grpc_server.h
@@ -324,15 +324,23 @@ public:
         ReportSdkBuildInfo_ = true;
     }
 
-    TString GetSdkBuildInfoIfNeeded(NYdbGrpc::IRequestContextBase* reqCtx) const {
+    static TString GetSdkBuildInfoIfNeeded(NYdbGrpc::IRequestContextBase* reqCtx, bool reportSdkBuildInfo) {
         TString result;
-        if (ReportSdkBuildInfo_) {
+        if (reportSdkBuildInfo) {
             const auto& res = reqCtx->GetPeerMetaValues(NYdb::YDB_SDK_BUILD_INFO_HEADER);
             if (!res.empty()) {
                 result = res[0];
             }
         }
         return result;
+    }
+
+    TString GetSdkBuildInfoIfNeeded(NYdbGrpc::IRequestContextBase* reqCtx) const {
+        return GetSdkBuildInfoIfNeeded(reqCtx, ReportSdkBuildInfo_);
+    }
+
+    bool GetReportSdkBuildInfo() const {
+        return ReportSdkBuildInfo_;
     }
 
 private:

--- a/ydb/services/cms/grpc_service.cpp
+++ b/ydb/services/cms/grpc_service.cpp
@@ -1,5 +1,6 @@
 #include "grpc_service.h"
 
+
 #include <ydb/core/grpc_services/service_cms.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/base/base.h>
@@ -30,7 +31,9 @@ void TGRpcCmsService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         GRpcRequestProxyId_,                                                                             \
         CQ_,                                                                                             \
         nullptr,                                                                                         \
-        nullptr)
+        nullptr,                                                                                         \
+        isRlAllowed = IsRlAllowed()                                                                      \
+            )
 
     SETUP_CMS_METHOD(CreateDatabase, DoCreateTenantRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin), TGrpcRequestOperationCall);
     SETUP_CMS_METHOD(AlterDatabase, DoAlterTenantRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin), TGrpcRequestOperationCall);

--- a/ydb/services/datastreams/grpc_service.cpp
+++ b/ydb/services/datastreams/grpc_service.cpp
@@ -58,7 +58,9 @@ void TGRpcDataStreamsService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
         GRpcRequestProxyId_,                                     \
         CQ_,                                                     \
         nullptr,                                                 \
-        customAttributeProcessorCallback)
+        customAttributeProcessorCallback,                        \
+        isRlAllowed = IsRlAllowed()                              \
+    )
 
     SETUP_DS_METHOD(DescribeStream, DoDataStreamsDescribeStreamRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying(), nullptr);
     SETUP_DS_METHOD(CreateStream, DoDataStreamsCreateStreamRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), nullptr);

--- a/ydb/services/discovery/grpc_service.cpp
+++ b/ydb/services/discovery/grpc_service.cpp
@@ -19,7 +19,7 @@ void TGRpcDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_DISCOVERY_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, discovery, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, discovery, auditMode, isRlAllowed = IsRlAllowed())
 
     SETUP_DISCOVERY_METHOD(WhoAmI, DoWhoAmIRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_DISCOVERY_METHOD(NodeRegistration, DoNodeRegistrationRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::NodeRegistration));

--- a/ydb/services/dynamic_config/grpc_service.cpp
+++ b/ydb/services/dynamic_config/grpc_service.cpp
@@ -17,7 +17,7 @@ void TGRpcDynamicConfigService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logge
 #endif
 
 #define SETUP_CFG_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, console, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, console, auditMode, isRlAllowed = IsRlAllowed())
 
     SETUP_CFG_METHOD(SetConfig, DoSetConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
     SETUP_CFG_METHOD(ReplaceConfig, DoReplaceConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/services/fq/ydb_over_fq.cpp
+++ b/ydb/services/fq/ydb_over_fq.cpp
@@ -27,7 +27,7 @@ void TGRpcYdbOverFqService::InitService(grpc::ServerCompletionQueue *cq, NYdbGrp
     SETUP_RUNTIME_EVENT_METHOD(methodName,                          \
         inputType,                                                  \
         outputType,                                                 \
-        NYdbOverFq::Get##methodName##Executor(GRpcRequestProxyId_), \
+        NYdbOverFq::Get##methodName##Executor(proxyId),             \
         rlMode,                                                     \
         requestType,                                                \
         YDB_API_DEFAULT_COUNTER_BLOCK(ydb_over_fq, methodName),     \

--- a/ydb/services/kesus/grpc_service.cpp
+++ b/ydb/services/kesus/grpc_service.cpp
@@ -668,7 +668,8 @@ void TKesusGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             GRpcRequestProxyId_,                                                       \
             cq,                                                                        \
             nullptr,                                                                   \
-            nullptr);                                                                  \
+            nullptr,                                                                   \
+            isRlAllowed = IsRlAllowed());                                                                  \
     }
 
 #define GET_LIMITER_BY_PATH(ICB_PATH) \

--- a/ydb/services/local_discovery/grpc_service.cpp
+++ b/ydb/services/local_discovery/grpc_service.cpp
@@ -66,7 +66,7 @@ void TGRpcLocalDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logg
 #error SETUP_LOCAL_DISCOVERY_METHOD macro already defined
 #endif
 
-#define SETUP_LOCAL_DISCOVERY_METHOD(methodName, methodCallback, rlMode, requestType, auditMode, operationCallClass) \
+#define SETUP_LOCAL_DISCOVERY_METHOD(methodName, methodCallback, rlMode, requestType, auditMode, operationCallClass,...) \
     SETUP_RUNTIME_EVENT_METHOD(methodName,                    \
         YDB_API_DEFAULT_REQUEST_TYPE(methodName),             \
         YDB_API_DEFAULT_RESPONSE_TYPE(methodName),            \
@@ -80,11 +80,12 @@ void TGRpcLocalDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logg
         GRpcRequestProxyId_,                                  \
         CQ_,                                                  \
         nullptr,                                              \
-        nullptr)
+        nullptr, ##__VA_ARGS__                                \
+    )
 
     SETUP_LOCAL_DISCOVERY_METHOD(WhoAmI, DoWhoAmIRequest, RLMODE(Rps), DISCOVERY_WHOAMI, TAuditMode::NonModifying(), TGrpcRequestOperationCall);
     SETUP_LOCAL_DISCOVERY_METHOD(NodeRegistration, DoNodeRegistrationRequest, RLMODE(Rps), DISCOVERY_NODEREGISTRATION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::NodeRegistration), TGrpcRequestOperationCall);
-    SETUP_LOCAL_DISCOVERY_METHOD(ListEndpoints, std::bind(&TGRpcLocalDiscoveryService::DoListEndpointsRequest, this, _1, _2), RLMODE(Rps), DISCOVERY_LISTENDPOINTS, TAuditMode::NonModifying(), TGrpcRequestFunctionCall);
+    SETUP_LOCAL_DISCOVERY_METHOD(ListEndpoints, callback, RLMODE(Rps), DISCOVERY_LISTENDPOINTS, TAuditMode::NonModifying(), TGrpcRequestFunctionCall, callback = std::bind(&TGRpcLocalDiscoveryService::DoListEndpointsRequest, this, _1, _2)); // XXX unsafe
 
 #undef SETUP_LOCAL_DISCOVERY_METHOD
 }

--- a/ydb/services/maintenance/grpc_service.cpp
+++ b/ydb/services/maintenance/grpc_service.cpp
@@ -31,7 +31,7 @@ void TGRpcMaintenanceService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
         GRpcRequestProxyId_,                                    \
         CQ_,                                                    \
         nullptr,                                                \
-        nullptr)
+        nullptr, isRlAllowed = IsRlAllowed())
 
     SETUP_MAINTENANCE_METHOD(ListClusterNodes, ListClusterNodesRequest, ListClusterNodesResponse, DoListClusterNodes, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_MAINTENANCE_METHOD(CreateMaintenanceTask, CreateMaintenanceTaskRequest, MaintenanceTaskResponse, DoCreateMaintenanceTask, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/services/persqueue_v1/topic.cpp
+++ b/ydb/services/persqueue_v1/topic.cpp
@@ -78,7 +78,7 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #error SETUP_TOPIC_STREAM_METHOD macro already defined
 #endif
 
-#define SETUP_TOPIC_METHOD(methodName, methodCallback, rlMode, requestType, auditMode, customAttributeProcessorCallback) \
+#define SETUP_TOPIC_METHOD(methodName, methodCallback, rlMode, requestType, auditMode, customAttributeProcessorCallback,...) \
     SETUP_RUNTIME_EVENT_METHOD(methodName,                                                                \
         YDB_API_DEFAULT_REQUEST_TYPE(methodName),                                                         \
         YDB_API_DEFAULT_RESPONSE_TYPE(methodName),                                                        \
@@ -92,9 +92,10 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         GRpcRequestProxyId_,                                                                              \
         CQ_,                                                                                              \
         nullptr,                                                                                          \
-        customAttributeProcessorCallback)
+        customAttributeProcessorCallback,\
+        isRlAllowed = IsRlAllowed(), ##__VA_ARGS__)
 
-#define SETUP_TOPIC_STREAM_METHOD(methodName, rlMode, requestType, auditMode, operationCallClass) \
+#define SETUP_TOPIC_STREAM_METHOD(methodName, rlMode, requestType, auditMode, operationCallClass,...) \
         SETUP_RUNTIME_EVENT_STREAM_METHOD(methodName,                \
             Y_CAT(methodName, Message)::FromClient,                  \
             Y_CAT(methodName, Message)::FromServer,                  \
@@ -106,11 +107,11 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             GRpcRequestProxyId_,                                     \
             CQ_,                                                     \
             nullptr,                                                 \
-            nullptr)
+            nullptr, isRlAllowed = IsRlAllowed(), ##__VA_ARGS__)
 
     SETUP_TOPIC_METHOD(CommitOffset, DoCommitOffsetRequest, RLSWITCH(Rps), TOPIC_COMMITOFFSET, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml), nullptr);
     SETUP_TOPIC_METHOD(DropTopic, DoDropTopicRequest, RLSWITCH(Rps), TOPIC_DROPTOPIC, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), nullptr);
-    SETUP_TOPIC_METHOD(CreateTopic, std::bind(DoCreateTopicRequest, _1, _2, ClustersCfgProvider->GetCfg()), RLSWITCH(Rps), TOPIC_CREATETOPIC, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), nullptr);
+    SETUP_TOPIC_METHOD(CreateTopic, std::bind(DoCreateTopicRequest, _1, _2, clustersCfgProvider->GetCfg()), RLSWITCH(Rps), TOPIC_CREATETOPIC, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), nullptr, clustersCfgProvider = ClustersCfgProvider);
     SETUP_TOPIC_METHOD(AlterTopic, DoAlterTopicRequest, RLSWITCH(Rps), TOPIC_ALTERTOPIC, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl), nullptr);
     SETUP_TOPIC_METHOD(DescribeTopic, DoDescribeTopicRequest, RLSWITCH(Rps), TOPIC_DESCRIBETOPIC, TAuditMode::NonModifying(), nullptr);
     SETUP_TOPIC_METHOD(DescribeConsumer, DoDescribeConsumerRequest, RLSWITCH(Rps), TOPIC_DESCRIBECONSUMER, TAuditMode::NonModifying(), nullptr);

--- a/ydb/services/replication/grpc_service.cpp
+++ b/ydb/services/replication/grpc_service.cpp
@@ -18,7 +18,7 @@ void TGRpcReplicationService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
 #endif
 
 #define SETUP_REPLICATION_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, replication, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, replication, auditMode, isRlAllowed = IsRlAllowed())
 
     SETUP_REPLICATION_METHOD(DescribeReplication, DoDescribeReplication, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_REPLICATION_METHOD(DescribeTransfer, DoDescribeTransfer, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());

--- a/ydb/services/tablet/ydb_tablet.cpp
+++ b/ydb/services/tablet/ydb_tablet.cpp
@@ -43,7 +43,8 @@ void TGRpcYdbTabletService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \
                 cq,                                                                    \
                 nullptr,                                                               \
-                nullptr                                                                \
+                nullptr,                                                               \
+                isRlAllowed = IsRlAllowed()                                            \
             );                                                                         \
             ++proxyCounter;                                                            \
         }                                                                              \

--- a/ydb/services/view/grpc_service.cpp
+++ b/ydb/services/view/grpc_service.cpp
@@ -16,7 +16,7 @@ void TGRpcViewService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_VIEW_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, view, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, view, auditMode, isRlAllowed = IsRlAllowed())
 
     SETUP_VIEW_METHOD(DescribeView, DoDescribeView, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
 

--- a/ydb/services/ydb/ydb_clickhouse_internal.cpp
+++ b/ydb/services/ydb/ydb_clickhouse_internal.cpp
@@ -49,7 +49,8 @@ void TGRpcYdbClickhouseInternalService::SetupIncomingRequests(NYdbGrpc::TLoggerP
         GRpcRequestProxyId_,                                                        \
         CQ_,                                                                        \
         GET_LIMITER_BY_PATH(GRpcControls.RequestConfigs.ClickhouseInternal_##methodName.MaxInFlight), \
-        nullptr)
+        nullptr,                                                                   \
+        isRlAllowed = IsRlAllowed())
 
     SETUP_CH_METHOD(Scan, DoReadColumnsRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_CH_METHOD(GetShardLocations, DoGetShardLocationsRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());

--- a/ydb/services/ydb/ydb_debug.cpp
+++ b/ydb/services/ydb/ydb_debug.cpp
@@ -68,7 +68,8 @@ void TGRpcYdbDebugService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \
                 cq,                                                                    \
                 nullptr,                                                               \
-                nullptr                                                                \
+                nullptr,                                                               \
+                isRlAllowed = IsRlAllowed()                                            \
             );                                                                         \
             ++proxyCounter;                                                            \
         }                                                                              \

--- a/ydb/services/ydb/ydb_logstore.cpp
+++ b/ydb/services/ydb/ydb_logstore.cpp
@@ -16,7 +16,7 @@ void TGRpcYdbLogStoreService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
 #endif
 
 #define SETUP_LOGSTORE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, logstore, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, logstore, auditMode, isRlAllowed = IsRlAllowed())
 
     SETUP_LOGSTORE_METHOD(CreateLogStore, DoCreateLogStoreRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_LOGSTORE_METHOD(DescribeLogStore, DoDescribeLogStoreRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());

--- a/ydb/services/ydb/ydb_operation.cpp
+++ b/ydb/services/ydb/ydb_operation.cpp
@@ -32,7 +32,8 @@ void TGRpcOperationService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         GRpcRequestProxyId_,                                  \
         CQ_,                                                  \
         nullptr,                                              \
-        nullptr)
+        nullptr,                                              \
+        isRlAllowed = IsRlAllowed())
 
     SETUP_OPERATION_METHOD(GetOperation, DoGetOperationRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying(), TGrpcRequestOperationCall);
     SETUP_OPERATION_METHOD(CancelOperation, DoCancelOperationRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Operations), TGrpcRequestNoOperationCall);

--- a/ydb/services/ydb/ydb_query.cpp
+++ b/ydb/services/ydb/ydb_query.cpp
@@ -55,7 +55,8 @@ void TGRpcYdbQueryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \
                 cq,                                                                    \
                 nullptr,                                                               \
-                nullptr                                                                \
+                nullptr,                                                               \
+                isRlAllowed = IsRlAllowed()                                            \
             );                                                                         \
             ++proxyCounter;                                                            \
         }                                                                              \

--- a/ydb/services/ydb/ydb_scheme.cpp
+++ b/ydb/services/ydb/ydb_scheme.cpp
@@ -18,7 +18,7 @@ void TGRpcYdbSchemeService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_SCHEME_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, scheme, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, scheme, auditMode, isRlAllowed = IsRlAllowed())
 
     SETUP_SCHEME_METHOD(MakeDirectory, DoMakeDirectoryRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_SCHEME_METHOD(RemoveDirectory, DoRemoveDirectoryRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));

--- a/ydb/services/ydb/ydb_scripting.cpp
+++ b/ydb/services/ydb/ydb_scripting.cpp
@@ -32,7 +32,9 @@ void TGRpcYdbScriptingService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger
         GRpcRequestProxyId_,                                  \
         CQ_,                                                  \
         nullptr,                                              \
-        nullptr)
+        nullptr,                                              \
+        isRlAllowed = IsRlAllowed()                           \
+    )
 
     SETUP_SCRIPTING_METHOD(ExecuteYql, ExecuteYqlRequest, ExecuteYqlResponse, DoExecuteYqlScript, RLSWITCH(Ru), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml), TGrpcRequestOperationCall);
     SETUP_SCRIPTING_METHOD(StreamExecuteYql, ExecuteYqlRequest, ExecuteYqlPartialResponse, DoStreamExecuteYqlScript, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Dml), TGrpcRequestNoOperationCall);

--- a/ydb/services/ydb/ydb_table.cpp
+++ b/ydb/services/ydb/ydb_table.cpp
@@ -70,7 +70,8 @@ void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \
                 cq,                                                                    \
                 nullptr,                                                               \
-                nullptr                                                                \
+                nullptr,                                                               \
+                isRlAllowed = IsRlAllowed()                                            \
             );                                                                         \
             ++proxyCounter;                                                            \
         }                                                                              \
@@ -96,7 +97,8 @@ void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                                                             \
                 cq,                                                                                                           \
                 limiter,                                                                                                      \
-                nullptr                                                                                                       \
+                nullptr,                                                                                                      \
+                isRlAllowed = IsRlAllowed()                                                                                   \
             );                                                                                                                \
             ++proxyCounter;                                                                                                   \
         }                                                                                                                     \


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
E   WARNING: ThreadSanitizer: data race (pid=711629)
E   Read of size 8 at 0x722c00104bb8 by main thread:
E   #0 DoDestroy /-S/util/generic/ptr.h:375:13 (ydbd+0x1a3a7c9a) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #1 ~THolder /-S/util/generic/ptr.h:306:9 (ydbd+0x1a3a7c9a)
E   #2 ~IEventHandle /-S/ydb/library/actors/core/event.h:52:11 (ydbd+0x1a3a7c9a)
E   #3 CleanupEvents /-S/ydb/library/actors/core/mailbox_lockfree.cpp:346:17 (ydbd+0x1a3a7c9a)
E   #4 Cleanup /-S/ydb/library/actors/core/mailbox_lockfree.cpp:356:27 (ydbd+0x1a3a7c9a)
E   #5 NActors::TMailboxTable::Cleanup() /-S/ydb/library/actors/core/mailbox_lockfree.cpp:689:48 (ydbd+0x1a3a7c9a)
E   #6 NActors::TExecutorPoolBaseMailboxed::Cleanup() /-S/ydb/library/actors/core/executor_pool_base.cpp:298:30 (ydbd+0x1a344503) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #7 NActors::TCpuManager::Shutdown() /-S/ydb/library/actors/core/cpu_manager.cpp:172:40 (ydbd+0x1a304acc) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #8 NActors::TActorSystem::Stop() /-S/ydb/library/actors/core/actorsystem.cpp:432:21 (ydbd+0x1a2fdcc5) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #9 NKikimr::TKikimrRunner::KikimrStop(bool) /-S/ydb/core/driver_lib/run/run.cpp:2153:22 (ydbd+0x2c51f130) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #10 NKikimr::MainRun(NKikimr::TKikimrRunConfig const&, std::__y1::shared_ptr<NKikimr::TModuleFactories>) /-S/ydb/core/driver_lib/run/main.cpp:50:17 (ydbd+0x2abaa85a) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #11 NKikimr::NDriverClient::TClientCommandServer::Run(NYdb::NConsoleClient::TClientCommand::TConfig&) /-S/ydb/core/driver_lib/cli_utils/cli_cmds_server.cpp:51:12 (ydbd+0x2c4481d1) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #12 NYdb::NConsoleClient::TClientCommand::ValidateAndRun(NYdb::NConsoleClient::TClientCommand::TConfig&) /-S/ydb/public/lib/ydb_cli/common/command.cpp:315:16 (ydbd+0x2abf432a) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #13 NYdb::NConsoleClient::TClientCommandTree::Run(NYdb::NConsoleClient::TClientCommand::TConfig&) /-S/ydb/public/lib/ydb_cli/common/command.cpp:512:33 (ydbd+0x2abf6e3b) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #14 NYdb::NConsoleClient::TClientCommand::ValidateAndRun(NYdb::NConsoleClient::TClientCommand::TConfig&) /-S/ydb/public/lib/ydb_cli/common/command.cpp:315:16 (ydbd+0x2abf432a) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #15 NYdb::NConsoleClient::TClientCommand::Process(NYdb::NConsoleClient::TClientCommand::TConfig&) /-S/ydb/public/lib/ydb_cli/common/command.cpp:257:16 (ydbd+0x2abf34fd) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #16 NKikimr::NDriverClient::NewClient(int, char**, std::__y1::shared_ptr<NKikimr::TModuleFactories>) /-S/ydb/core/driver_lib/cli_utils/cli_cmds_root.cpp:77:26 (ydbd+0x2abeb9cc) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #17 NKikimr::Main(int, char**, std::__y1::shared_ptr<NKikimr::TModuleFactories>) /-S/ydb/core/driver_lib/run/main.cpp:151:20 (ydbd+0x2abaec04) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #18 ParameterizedMain(int, char**, std::__y1::shared_ptr<NKikimr::TModuleFactories>) /-S/ydb/core/driver_lib/run/main.cpp:201:16 (ydbd+0x2abb03b3) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #19 main /-S/ydb/apps/ydbd/main.cpp:31:12 (ydbd+0x18b0783c) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   
E   Previous write of size 8 at 0x722c00104bb8 by thread T66:
E   #0 operator new(unsigned long) /place/sandbox-data/tasks/1/1/3398177511/ydb/contrib/libs/clang20-rt/lib/tsan/rtl/tsan_new_delete.cpp:64:3 (ydbd+0x18bb3e52) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #1 NActors::TActorSystem::Send(NActors::TActorId const&, NActors::IEventBase*, unsigned int, unsigned long) const /-S/ydb/library/actors/core/actorsystem.cpp:257:27 (ydbd+0x1a2fb633) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #2 operator() /-S/ydb/services/fq/private_grpc.cpp:44:5 (ydbd+0x2f14dfb9) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #3 __invoke<(lambda at /-S/ydb/services/fq/private_grpc.cpp:44:5) &, NYdbGrpc::IRequestContextBase *> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:149:25 (ydbd+0x2f14dfb9)
E   #4 __call<(lambda at /-S/ydb/services/fq/private_grpc.cpp:44:5) &, NYdbGrpc::IRequestContextBase *> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:224:5 (ydbd+0x2f14dfb9)
E   #5 operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:169:12 (ydbd+0x2f14dfb9)
E   #6 std::__y1::__function::__func<NKikimr::NGRpcService::TGRpcFqPrivateTaskService::SetupIncomingRequests(TIntrusivePtr<NYdbGrpc::TLogger, TDefaultIntrusivePtrOps<NYdbGrpc::TLogger>>)::$_1, std::__y1::allocator<NKikimr::NGRpcService::TGRpcFqPrivateTaskService::SetupIncomingRequests(TIntrusivePtr<NYdbGrpc::TLogger, TDefaultIntrusivePtrOps<NYdbGrpc::TLogger>>)::$_1>, void (NYdbGrpc::IRequestContextBase*)>::operator()(NYdbGrpc::IRequestContextBase*&&) /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:314:10 (ydbd+0x2f14dfb9)
E   #7 operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:431:12 (ydbd+0x2f157446) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #8 operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:990:10 (ydbd+0x2f157446)
E   #9 NYdbGrpc::TGRpcRequestImpl<Fq::Private::GetTaskRequest, Fq::Private::GetTaskResponse, NKikimr::NGRpcService::TGRpcFqPrivateTaskService, NKikimr::TSecurityTextFormatPrinter<Fq::Private::GetTaskRequest>, NKikimr::TSecurityTextFormatPrinter<Fq::Private::GetTaskResponse>>::SetRequestDone(bool) /-S/ydb/library/grpc/server/grpc_request.h:452:13 (ydbd+0x2f157446)
E   #10 Execute /-S/ydb/library/grpc/server/grpc_request.h:156:16 (ydbd+0x2f155e16) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #11 non-virtual thunk to NYdbGrpc::TGRpcRequestImpl<Fq::Private::GetTaskRequest, Fq::Private::GetTaskResponse, NKikimr::NGRpcService::TGRpcFqPrivateTaskService, NKikimr::TSecurityTextFormatPrinter<Fq::Private::GetTaskRequest>, NKikimr::TSecurityTextFormatPrinter<Fq::Private::GetTaskResponse>>::Execute(bool) /-S/ydb/library/grpc/server/grpc_request.h (ydbd+0x2f155e16)
E   #12 PullEvents /-S/ydb/library/grpc/server/grpc_server.cpp:44:21 (ydbd+0x2868d57a) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #13 operator() /-S/ydb/library/grpc/server/grpc_server.cpp:266:13 (ydbd+0x2868d57a)
E   #14 __invoke<(lambda at /-S/ydb/library/grpc/server/grpc_server.cpp:265:49) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:149:25 (ydbd+0x2868d57a)
E   #15 __call<(lambda at /-S/ydb/library/grpc/server/grpc_server.cpp:265:49) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:224:5 (ydbd+0x2868d57a)
E   #16 operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:169:12 (ydbd+0x2868d57a)
E   #17 std::__y1::__function::__func<NYdbGrpc::TGRpcServer::Start()::$_0, std::__y1::allocator<NYdbGrpc::TGRpcServer::Start()::$_0>, void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:314:10 (ydbd+0x2868d57a)
E   #18 operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:431:12 (ydbd+0x1a10ece5) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b)
E   #19 operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:990:10 (ydbd+0x1a10ece5)
E   #20 (anonymous namespace)::TThreadFactoryFuncObj::DoExecute() /-S/util/thread/factory.cpp:61:13 (ydbd+0x1a10ece5)
E   #21 Execute /-S/util/thread/factory.h:15:13 (ydbd+0x1a10f1b2) (BuildId: 46474ab5ea02114270c4120bf95ba7d93863647b
```