### PR TITLE
Made tests independent on sys views creation P.1

### DIFF
--- a/ydb/core/client/flat_ut.cpp
+++ b/ydb/core/client/flat_ut.cpp
@@ -926,7 +926,7 @@ Y_UNIT_TEST_SUITE(TFlatTest) {
     Y_UNIT_TEST(Ls) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port).SetEnableRealSystemViewPaths(true));
+        TServer cleverServer = TServer(TServerSettings(port));
 
         TFlatMsgBusClient annoyingClient(port);
         annoyingClient.InitRoot();
@@ -1019,7 +1019,7 @@ Y_UNIT_TEST_SUITE(TFlatTest) {
     Y_UNIT_TEST(PathSorting) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port).SetEnableRealSystemViewPaths(true));
+        TServer cleverServer = TServer(TServerSettings(port));
 
         TFlatMsgBusClient annoyingClient(port);
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -5369,11 +5369,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
     }
 
     Y_UNIT_TEST(ModifySysViewDirPermissions) {
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableRealSystemViewPaths(true);
         TKikimrSettings settings;
         settings.SetWithSampleTables(false);
-        settings.SetFeatureFlags(featureFlags);
         settings.SetAuthToken("root@builtin");  // root@builtin becomes cluster admin
         TKikimrRunner kikimr(settings);
 
@@ -5467,11 +5464,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
     }
 
     Y_UNIT_TEST(ModifySysViewPermissions) {
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableRealSystemViewPaths(true);
         TKikimrSettings settings;
         settings.SetWithSampleTables(false);
-        settings.SetFeatureFlags(featureFlags);
         settings.SetAuthToken("root@builtin");  // root@builtin becomes cluster admin
         TKikimrRunner kikimr(settings);
 

--- a/ydb/core/kqp/ut/sysview/kqp_sys_view_ut.cpp
+++ b/ydb/core/kqp/ut/sysview/kqp_sys_view_ut.cpp
@@ -64,12 +64,9 @@ Y_UNIT_TEST_SUITE(KqpSystemView) {
         CompareYson(R"([[["::1"];["/Root/KeyValue"];[2u]]])", StreamResultToYson(it));
     }
 
-    Y_UNIT_TEST_TWIN(Sessions, EnableRealSystemViewPaths) {
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableRealSystemViewPaths(EnableRealSystemViewPaths);
+    Y_UNIT_TEST(Sessions) {
         TKikimrSettings settings;
         settings.SetWithSampleTables(false);
-        settings.SetFeatureFlags(featureFlags);
         settings.SetAuthToken("root@builtin");  // root@builtin becomes cluster admin
         TKikimrRunner kikimr(settings);
 
@@ -666,11 +663,8 @@ order by SessionId;)", "%Y-%m-%d %H:%M:%S %Z", sessionsSet.front().GetId().data(
 
     Y_UNIT_TEST(QuerySessionsOrderByDesc) {
         // Test ORDER BY DESC for query_sessions sys view
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableRealSystemViewPaths(true);
         TKikimrSettings settings;
         settings.SetWithSampleTables(false);
-        settings.SetFeatureFlags(featureFlags);
         settings.SetAuthToken("root@builtin");
         TKikimrRunner kikimr(settings);
 

--- a/ydb/core/tx/schemeshard/ut_base/ut_counters.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_counters.cpp
@@ -15,7 +15,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardCountersTest) {
         };
         TTestBasicRuntime runtime;
         TTestEnvOptions opts;
-        opts.EnableRealSystemViewPaths(false);
         TTestEnv env(runtime, opts, ssFactory);
         runtime.GetAppData().FeatureFlags.SetEnableAlterDatabase(true);
         ui64 txId = 100;
@@ -28,13 +27,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardCountersTest) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        ui64 initPathsCount = DescribePath(runtime, "/MyRoot").GetPathDescription().GetDomainDescription()
+                                                                 .GetPathsInside();
+
         TSchemeLimits defaultLimits;
         TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
             NLs::DomainLimitsIs(1, defaultLimits.MaxShards),
-            NLs::PathsInsideDomain(0)
+            NLs::PathsInsideDomain(initPathsCount)
         });
 
-        UNIT_ASSERT_VALUES_EQUAL(schemeshard->TabletCounters->Simple()[COUNTER_PATHS].Get(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(schemeshard->TabletCounters->Simple()[COUNTER_PATHS].Get(), initPathsCount);
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Dir/Table"
             Columns { Name: "key"   Type: "Uint64"}
@@ -44,9 +46,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardCountersTest) {
         env.TestWaitNotification(runtime, txId);
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
-            NLs::PathsInsideDomain(0)
+            NLs::PathsInsideDomain(initPathsCount)
         });
-        UNIT_ASSERT_VALUES_EQUAL(schemeshard->TabletCounters->Simple()[COUNTER_PATHS].Get(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(schemeshard->TabletCounters->Simple()[COUNTER_PATHS].Get(), initPathsCount);
     }
 
 }

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -1265,14 +1265,16 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
     void AuditLogLoginTest(TTestBasicRuntime& runtime, bool isUserAdmin) {
         std::vector<std::string> lines;
         runtime.AuditLogBackends = CreateTestAuditLogBackends(lines);
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime);
 
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+        size_t expectedLines = lines.size();
 
         ui64 txId = 100;
 
         CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);   // +user creation
+        // User creation adds 1 audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         // test body
         const auto target = runtime.Register(CreateWebLoginService());
@@ -1290,7 +1292,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             NHttp::TCookies cookies(headers["Set-Cookie"]);
             UNIT_ASSERT(!cookies["ydb_session_id"].empty());
         }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);  // +user login
+        // After login, we should have 1 additional audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         auto last = FindAuditLine(lines, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
@@ -1335,14 +1339,16 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         TTestBasicRuntime runtime;
         std::vector<std::string> lines;
         runtime.AuditLogBackends = CreateTestAuditLogBackends(lines);
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime);
 
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+        size_t expectedLines = lines.size();
 
         ui64 txId = 100;
 
         CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);   // +user creation
+        // User creation adds 1 audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         // test body
         const auto target = runtime.Register(CreateWebLoginService());
@@ -1360,7 +1366,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             NJson::TJsonValue body(responseEv->Response->Body);
             UNIT_ASSERT_STRINGS_EQUAL(body.GetStringRobust(), "{\"error\":\"Invalid password\"}");
         }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);  // +user login
+        // After failed login, we should have 1 additional audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         auto last = FindAuditLine(lines, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
@@ -1379,7 +1387,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         runtime.AuditLogBackends = CreateTestAuditLogBackends(lines);
         // Enable and configure ldap auth
         runtime.SetLogPriority(NKikimrServices::LDAP_AUTH_PROVIDER, NActors::NLog::PRI_DEBUG);
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime);
 
         // configure ldap auth
         auto ldapPort = runtime.GetPortManager().GetPort();  // randomized port
@@ -1436,7 +1444,8 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         };
         LdapMock::TLdapSimpleServer ldapServer(ldapPort, ldapResponses("user1", "password1"));
 
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+        // Get initial audit log size after environment setup and use single counter
+        size_t expectedLines = lines.size();
 
         // test body
         const auto target = runtime.Register(CreateWebLoginService());
@@ -1454,7 +1463,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             NHttp::TCookies cookies(headers["Set-Cookie"]);
             UNIT_ASSERT(!cookies["ydb_session_id"].empty());
         }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user login
+        // After LDAP login, we should have 1 additional audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         auto last = FindAuditLine(lines, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
@@ -1475,7 +1486,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         runtime.AuditLogBackends =CreateTestAuditLogBackends(lines);
         // Enable and configure ldap auth
         runtime.SetLogPriority(NKikimrServices::LDAP_AUTH_PROVIDER, NActors::NLog::PRI_DEBUG);
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime);
 
         // configure ldap auth
         auto ldapPort = runtime.GetPortManager().GetPort();  // randomized port
@@ -1532,7 +1543,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         };
         LdapMock::TLdapSimpleServer ldapServer(ldapPort, ldapResponses("user1", "bad_password"));
 
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+        size_t expectedLines = lines.size();
 
         // test body
         const auto target = runtime.Register(CreateWebLoginService());
@@ -1550,7 +1561,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             NHttp::TCookies cookies(headers["Set-Cookie"]);
             UNIT_ASSERT(cookies["ydb_session_id"].empty());
         }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user login
+        // After failed LDAP login, we should have 1 additional audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         auto last = FindAuditLine(lines, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
@@ -1567,10 +1580,10 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
     Y_UNIT_TEST(AuditLogLdapLoginBadUser) {
         TTestBasicRuntime runtime;
         std::vector<std::string> lines;
-        runtime.AuditLogBackends =CreateTestAuditLogBackends(lines);
+        runtime.AuditLogBackends = CreateTestAuditLogBackends(lines);
         // Enable and configure ldap auth
         runtime.SetLogPriority(NKikimrServices::LDAP_AUTH_PROVIDER, NActors::NLog::PRI_DEBUG);
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime);
 
         // configure ldap auth
         auto ldapPort = runtime.GetPortManager().GetPort();  // randomized port
@@ -1627,7 +1640,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         };
         LdapMock::TLdapSimpleServer ldapServer(ldapPort, ldapResponses("bad_user", "password1"));
 
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+        size_t expectedLines = lines.size();
 
         // test body
         const auto target = runtime.Register(CreateWebLoginService());
@@ -1645,7 +1658,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             NHttp::TCookies cookies(headers["Set-Cookie"]);
             UNIT_ASSERT(cookies["ydb_session_id"].empty());
         }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user login
+        // After failed LDAP login, we should have 1 additional audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         auto last = FindAuditLine(lines, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
@@ -1666,7 +1681,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         runtime.AuditLogBackends = CreateTestAuditLogBackends(lines);
         // Enable and configure ldap auth
         runtime.SetLogPriority(NKikimrServices::LDAP_AUTH_PROVIDER, NActors::NLog::PRI_DEBUG);
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime);
 
         // configure ldap auth
         auto ldapPort = runtime.GetPortManager().GetPort();  // randomized port
@@ -1723,7 +1738,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         };
         LdapMock::TLdapSimpleServer ldapServer(ldapPort, ldapResponses("user1", "password1"));
 
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+        size_t expectedLines = lines.size();
 
         // test body
         const auto target = runtime.Register(CreateWebLoginService());
@@ -1741,7 +1756,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             NHttp::TCookies cookies(headers["Set-Cookie"]);
             UNIT_ASSERT(cookies["ydb_session_id"].empty());
         }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user login
+        // After failed LDAP login, we should have 1 additional audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         auto last = FindAuditLine(lines, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
@@ -1759,7 +1776,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         TTestBasicRuntime runtime;
         std::vector<std::string> lines;
         runtime.AuditLogBackends = CreateTestAuditLogBackends(lines);
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime);
 
         // Add ticket parser to the mix
         {
@@ -1772,12 +1789,14 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             runtime.RegisterService(NKikimr::MakeTicketParserID(), ticketParserId);
         }
 
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);  // alter root subdomain
+        size_t expectedLines = lines.size();
 
         ui64 txId = 100;
 
         CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user creation
+        // User creation adds 1 audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         // test body
         const auto target = runtime.Register(CreateWebLoginService());
@@ -1796,7 +1815,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             NHttp::TCookies cookies(headers["Set-Cookie"]);
             ydbSessionId = cookies["ydb_session_id"];
         }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);  // +user login
+        // After login, we should have 1 additional audit log entry
+        expectedLines += 1;
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
         // New security keys are created in the subdomain as a consequence of a login.
         // In real system they are transferred to the ticket parser by the grpc-proxy
@@ -1820,7 +1841,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "401");
 
             // no audit record for actions without auth
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
         }
         {  // bad cookie
             runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
@@ -1832,7 +1853,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "403");
 
             // no audit record for actions without auth
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
         }
         {  // good cookie
             runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
@@ -1847,7 +1868,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
                 UNIT_ASSERT_STRINGS_EQUAL(headers["Set-Cookie"], "ydb_session_id=; Max-Age=0");
             }
 
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 4);  // +user web logout
+            // After logout, we should have 1 additional audit log entry
+            expectedLines += 1;
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
 
             auto last = FindAuditLine(lines, "operation=LOGOUT");
             UNIT_ASSERT_STRING_CONTAINS(last, "component=web-login");
@@ -1864,8 +1887,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         TTestBasicRuntime runtime;
         std::vector<std::string> lines;
         runtime.AuditLogBackends = CreateTestAuditLogBackends(lines);
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);
+        TTestEnv env(runtime);
+
+        size_t expectedLines = lines.size();
         ui64 txId = 100;
 
         TString database = "/MyRoot";
@@ -1905,31 +1929,36 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
 
         CreateAlterLoginCreateUser(runtime, ++txId, database, user, password);
         {
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);
+            expectedLines += 1;
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
             check("CREATE USER");
         }
 
         ChangePasswordUser(runtime, ++txId, database, user, newPassword);
         {
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);
+            expectedLines += 1;
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
             check("MODIFY USER", {"password"});
         }
 
         ChangeIsEnabledUser(runtime, ++txId, database, user, false);
         {
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 4);
+            expectedLines += 1;
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
             check("MODIFY USER", {"blocking"});
         }
 
         ChangeIsEnabledUser(runtime, ++txId, database, user, true);
         {
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 5);
+            expectedLines += 1;
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
             check("MODIFY USER", {"unblocking"});
         }
 
         ChangePasswordHashUser(runtime, ++txId, database, user, hash);
         {
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 6);
+            expectedLines += 1;
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
             check("MODIFY USER", {"password"});
         }
 
@@ -1939,7 +1968,8 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             alterUser->SetPassword(std::move(password));
         });
         {
-            UNIT_ASSERT_VALUES_EQUAL(lines.size(), 7);
+            expectedLines += 1;
+            UNIT_ASSERT_VALUES_EQUAL(lines.size(), expectedLines);
             check("MODIFY USER", {"password", "blocking"});
         }
     }

--- a/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
@@ -36,7 +36,7 @@ namespace {
 Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
     Y_UNIT_TEST(CreateSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -68,7 +68,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(DropSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -90,7 +90,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(CreateExistingSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -117,7 +117,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(AsyncCreateDifferentSysViews) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -179,7 +179,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(AsyncCreateSameSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -208,7 +208,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(AsyncDropSameSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -233,7 +233,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(ReadOnlyMode) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         SetSchemeshardReadOnlyMode(runtime, true);
@@ -264,7 +264,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(EmptyName) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -280,7 +280,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
     Y_UNIT_TEST(CreateDirWithDomainSysViews) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot/.sys"), {NLs::Finished, NLs::HasOwner("metadata@system")});
 
@@ -311,7 +311,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
 
     Y_UNIT_TEST(RestoreAbsentSysViews) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         TestLs(runtime, "/MyRoot/.sys/partition_stats", false, NLs::PathExist);
@@ -345,7 +345,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewsUpdateTest) {
 
     Y_UNIT_TEST(DeleteObsoleteSysViews) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(true));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         TestLs(runtime, "/MyRoot/.sys/partition_stats", false, NLs::PathExist);

--- a/ydb/core/tx/schemeshard/ut_sysview_reboots/ut_sysview_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview_reboots/ut_sysview_reboots.cpp
@@ -6,7 +6,6 @@ using namespace NSchemeShardUT_Private;  // for helpers.h's Test*() methods
 Y_UNIT_TEST_SUITE(TSchemeShardSysViewTestReboots) {
     Y_UNIT_TEST(CreateSysView) {
         TTestWithReboots t;
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(true);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TestCreateSysView(runtime, ++t.TxId, "/MyRoot/.sys",
                               R"(
@@ -25,7 +24,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTestReboots) {
 
     Y_UNIT_TEST(DropSysView) {
         TTestWithReboots t;
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(true);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
                 TestCreateSysView(runtime, ++t.TxId, "/MyRoot/.sys",


### PR DESCRIPTION
Some tests depend on number of sysviews created at SchemeShard initialization, so I have to compute some counters in tests dynamically
