### PR TITLE
Fix large SchemeShard tests failures due to sys views creation

### DIFF
--- a/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
@@ -19,7 +19,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
             .EnableLocalDBBtreeIndex(enableLocalDBBtreeIndex)
-            .EnablePersistentPartitionStats(enablePersistentPartitionStats);
+            .EnablePersistentPartitionStats(enablePersistentPartitionStats)
+            .EnableRealSystemViewPaths(false);
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;
@@ -233,6 +234,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
 
     Y_UNIT_TEST(Replace) {
         TTestWithReboots t(true);
+        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;
             {
@@ -293,6 +295,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
 
     Y_UNIT_TEST(Chain) {
         TTestWithReboots t(true);
+        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;
             {
@@ -356,7 +359,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
 
     Y_UNIT_TEST(AlterAfter) {
         TTestWithReboots t;
-
+        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
                 TInactiveZone inactive(activeZone);

--- a/ydb/core/tx/schemeshard/ut_pq_reboots/ut_pq_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_pq_reboots/ut_pq_reboots.cpp
@@ -78,7 +78,7 @@ Y_UNIT_TEST_SUITE(TPqGroupTestReboots) {
 
     Y_UNIT_TEST(AlterWithProfileChange) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
         ui64 txId = 100;
         TPathVersion pqVer;
 
@@ -250,7 +250,7 @@ Y_UNIT_TEST_SUITE(TPqGroupTestReboots) {
 
     Y_UNIT_TEST(CreateDrop) {
         TTestWithReboots t;
-
+        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& /*activeZone*/) {
             t.Runtime->SetScheduledLimit(400);
 
@@ -287,7 +287,7 @@ Y_UNIT_TEST_SUITE(TPqGroupTestReboots) {
 
     Y_UNIT_TEST(CreateDropAbort) {
         TTestWithReboots t;
-
+        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& /*activeZone*/) {
             t.Runtime->SetScheduledLimit(400);
 

--- a/ydb/core/tx/schemeshard/ut_split_merge_reboots/ut_split_merge_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge_reboots/ut_split_merge_reboots.cpp
@@ -824,6 +824,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
 
     Y_UNIT_TEST(MergeCopyParallelWithChannelsBindings) { //+
         TTestWithReboots t(true);
+        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;
             {
@@ -894,6 +895,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
 
     Y_UNIT_TEST(ForceDropAndCopyInParallelAllPathsAreLocked) { //+
         TTestWithReboots t(true);
+        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
                 TInactiveZone inactive(activeZone);


### PR DESCRIPTION
Enabling RealSystemViewPaths flag caused fails of SchemeShard large tests. This PR fixed this.
