### PR TITLE
Implement equal-to-parent fair-share mode to fix segfaults

### DIFF
--- a/ydb/core/kqp/runtime/scheduler/fwd.h
+++ b/ydb/core/kqp/runtime/scheduler/fwd.h
@@ -31,6 +31,12 @@ namespace NKikimr::NKqp::NScheduler {
         } // namespace NDynamic
 
         namespace NSnapshot {
+            enum class ELeafFairShare : ui8 {
+                DEFAULT_FIFO = 0,
+                ALLOW_OVERLIMIT = 1,
+                EQUAL_TO_PARENT = 2,
+            };
+
             struct TTreeElement;
 
             class TQuery;

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
@@ -10,7 +10,8 @@ namespace NKikimr::NKqp::NScheduler {
 
 class TComputeScheduler : public std::enable_shared_from_this<TComputeScheduler> {
 public:
-    TComputeScheduler(TIntrusivePtr<TKqpCounters> counters, const TDelayParams& delayParams, bool allowFairShareOverlimit = true);
+    TComputeScheduler(TIntrusivePtr<TKqpCounters> counters, const TDelayParams& delayParams,
+        NHdrf::NSnapshot::ELeafFairShare fairShareMode = NHdrf::NSnapshot::ELeafFairShare::EQUAL_TO_PARENT);
 
     void SetTotalCpuLimit(ui64 cpu);
     ui64 GetTotalCpuLimit() const;
@@ -23,9 +24,6 @@ public:
     bool RemoveQuery(const NHdrf::TQueryId& queryId);
 
     void UpdateFairShare();
-    bool IsAllowedFairShareOverlimit() const {
-        return AllowFairShareOverlimit;
-    }
 
 private:
     TRWMutex Mutex;
@@ -33,7 +31,7 @@ private:
     THashMap<NHdrf::TQueryId, NHdrf::NDynamic::TQueryPtr> Queries; // protected by Mutex
 
     const TDelayParams DelayParams;
-    const bool AllowFairShareOverlimit;
+    const NHdrf::NSnapshot::ELeafFairShare FairShareMode;
     TIntrusivePtr<TKqpCounters> KqpCounters;
 
     struct {

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
@@ -27,17 +27,16 @@ void TSchedulableTask::Resume() {
     NActors::TActivationContext::Send(ActorId, GetResumeEvent());
 }
 
-// TODO: referring to the pool's fair-share and usage - query's fair-share is ignored.
+// TODO: referring to the pool's usage - to support all-equal fair-share query mode.
 bool TSchedulableTask::TryIncreaseUsage() {
     bool increased = false;
     ui64 fairShare = 0;
     NHdrf::NDynamic::TTreeElement* poolOrQuery = nullptr;
 
     if (const auto snapshot = Query->GetSnapshot()) {
-        fairShare = snapshot->GetParent()->FairShare;
+        fairShare = snapshot->FairShare;
         poolOrQuery = Query->GetParent();
-    } else {
-        // TODO: check directly for the pool snapshot - even if there is no query snapshot yet.
+    } else { // TODO: check directly for the pool snapshot - even if there is no query snapshot yet.
         fairShare = Query->AllowMinFairShare;
         poolOrQuery = Query.get();
     }
@@ -63,14 +62,12 @@ bool TSchedulableTask::TryIncreaseUsage() {
     return true;
 }
 
-// TODO: referring to the pool's fair-share and usage - query's fair-share is ignored.
 void TSchedulableTask::IncreaseUsage() {
     for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
         ++parent->Usage;
     }
 }
 
-// TODO: referring to the pool's fair-share and usage - query's fair-share is ignored.
 void TSchedulableTask::DecreaseUsage(const TDuration& burstUsage, bool forcedResume) {
     for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
         --parent->Usage;
@@ -84,9 +81,8 @@ void TSchedulableTask::DecreaseUsage(const TDuration& burstUsage, bool forcedRes
 
 size_t TSchedulableTask::GetSpareUsage() const {
     if (const auto snapshot = Query->GetSnapshot()) {
-        // TODO: check this code when the pool removal will be implemented, since the `parent` may be gone.
         auto usage = Query->GetParent()->Usage.load(std::memory_order_relaxed);
-        auto fairShare = snapshot->GetParent()->FairShare;
+        auto fairShare = snapshot->FairShare;
         return fairShare >= usage ? (fairShare - usage) : 0;
     }
 

--- a/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
@@ -24,7 +24,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
 
         virtual void AccountSnapshotDuration(const TDuration& period);
         virtual void UpdateBottomUp(ui64 totalLimit);
-        void UpdateTopDown(bool allowFairShareOverlimit);
+        void UpdateTopDown(ELeafFairShare fairShareMode);
     };
 
     class TQuery : public TTreeElement, public NHdrf::TQuery<ETreeType::SNAPSHOT>, public std::enable_shared_from_this<TQuery> {
@@ -62,4 +62,4 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
         void AccountPreviousSnapshot(const TRootPtr& snapshot);
     };
 
-}
+} // namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Implement equal-to-parent fair-share mode to fix segfaults #32223

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Original problem scenario was caused by inconsistent snapshot tree update:
- Take current query snapshot.
- The snapshot is being removed and the parent pool gets removed.
- Try to take fair-share from the query's parent pool.
- Segfault.

Now we propagate fair-share from parent pool to all queries - and don't look at parent any more. It works well since we don't use real query's fair-share anyway.
