### PR TITLE
Add download progress bar to `ydb update` and improve progress bars UX

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added download progress bar to the `ydb update` command.
+* Improved progress bars: consistent MiB/GiB units, stable speed display, dual progress bar for `ydb import file` showing both in-progress and confirmed bytes.
 * Interactive mode enhancements:
   * Introduced `/help` for interactive command guidance.
   * Introduced the `/config` command, providing an interactive dialog to view and customize CLI settings, including:

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,5 +1,5 @@
 * Added download progress bar to the `ydb update` command.
-* Improved progress bars: consistent MiB/GiB units, stable speed display, dual progress bar for `ydb import file` showing both in-progress and confirmed bytes.
+* Improved progress bars: consistent MiB/GiB units, stable speed display, dual progress bar for the `ydb import file` command showing both in-progress and confirmed bytes.
 * Interactive mode enhancements:
   * Introduced `/help` for interactive command guidance.
   * Introduced the `/config` command, providing an interactive dialog to view and customize CLI settings, including:

--- a/ydb/public/lib/ydb_cli/common/download_manager.cpp
+++ b/ydb/public/lib/ydb_cli/common/download_manager.cpp
@@ -157,11 +157,7 @@ TDownloadResult DownloadFile(
         // Build host string with scheme for TKeepAliveHttpClient
         TString hostWithScheme = TStringBuilder() << scheme << host;
 
-        TKeepAliveHttpClient client(hostWithScheme, port, socketTimeout, connectTimeout, false);
-        if (isHttps) {
-            // Disable verification for simplicity, as we're downloading from trusted storage
-            client.DisableVerificationForHttps();
-        }
+        TKeepAliveHttpClient client(hostWithScheme, port, socketTimeout, connectTimeout);
 
         // First, do a HEAD request to get Content-Length
         THttpHeaders responseHeaders;

--- a/ydb/public/lib/ydb_cli/common/download_manager.cpp
+++ b/ydb/public/lib/ydb_cli/common/download_manager.cpp
@@ -1,0 +1,181 @@
+#include "download_manager.h"
+
+#include <library/cpp/http/simple/http_client.h>
+#include <library/cpp/string_utils/url/url.h>
+
+#include <util/stream/file.h>
+#include <util/string/ascii.h>
+#include <util/string/builder.h>
+
+namespace NYdb {
+namespace NConsoleClient {
+
+namespace {
+
+// Stream wrapper that tracks write progress and calls callback
+class TProgressOutputStream : public IOutputStream {
+public:
+    TProgressOutputStream(IOutputStream* output, ui64 totalSize, TDownloadProgressCallback callback)
+        : Output(output)
+        , TotalSize(totalSize)
+        , Callback(std::move(callback))
+        , LastProgressUpdate(TInstant::Now())
+    {
+    }
+
+    ui64 GetWrittenBytes() const {
+        return WrittenBytes;
+    }
+
+private:
+    void DoWrite(const void* buf, size_t len) override {
+        Output->Write(buf, len);
+        WrittenBytes += len;
+        UpdateProgress();
+    }
+
+    void DoFlush() override {
+        Output->Flush();
+    }
+
+    void UpdateProgress() {
+        if (!Callback) {
+            return;
+        }
+
+        TInstant now = TInstant::Now();
+        TDuration elapsed = now - LastProgressUpdate;
+
+        // Update progress at most 30 times per second
+        if (elapsed < TDuration::MilliSeconds(33) && WrittenBytes < TotalSize) {
+            return;
+        }
+        LastProgressUpdate = now;
+
+        Callback(WrittenBytes, TotalSize);
+    }
+
+    IOutputStream* Output;
+    ui64 TotalSize;
+    TDownloadProgressCallback Callback;
+    ui64 WrittenBytes = 0;
+    TInstant LastProgressUpdate;
+};
+
+} // namespace
+
+TDownloadResult DownloadFile(
+    const TString& url,
+    const TString& destinationPath,
+    TDownloadProgressCallback progressCallback,
+    TDuration connectTimeout,
+    TDuration socketTimeout)
+{
+    TDownloadResult result;
+
+    try {
+        // Parse URL to extract scheme, host, port, and path
+        TStringBuf scheme;
+        TStringBuf host;
+        ui16 port = 0;
+
+        GetSchemeHostAndPort(url, scheme, host, port);
+
+        TStringBuf pathAndQuery = GetPathAndQuery(url);
+        if (pathAndQuery.empty()) {
+            pathAndQuery = "/";
+        }
+
+        // Determine if HTTPS
+        bool isHttps = scheme.StartsWith("https");
+        if (port == 0) {
+            port = isHttps ? 443 : 80;
+        }
+
+        // Build host string with scheme for TKeepAliveHttpClient
+        TString hostWithScheme = TStringBuilder() << scheme << host;
+
+        TKeepAliveHttpClient client(hostWithScheme, port, socketTimeout, connectTimeout, false);
+        if (isHttps) {
+            // Disable verification for simplicity, as we're downloading from trusted storage
+            client.DisableVerificationForHttps();
+        }
+
+        // First, do a HEAD request to get Content-Length
+        THttpHeaders responseHeaders;
+        ui64 contentLength = 0;
+
+        try {
+            unsigned code = client.DoRequest(
+                "HEAD",
+                pathAndQuery,
+                {},
+                nullptr,
+                {},
+                &responseHeaders);
+
+            if (code >= 200 && code < 300) {
+                for (const auto& header : responseHeaders) {
+                    if (AsciiEqualsIgnoreCase(header.Name(), "Content-Length")) {
+                        contentLength = FromString<ui64>(header.Value());
+                        break;
+                    }
+                }
+            }
+        } catch (...) {
+            // HEAD request failed, continue without content length
+            contentLength = 0;
+        }
+
+        // Reset connection after HEAD request
+        client.ResetConnection();
+
+        // Now do the actual GET request
+        TFileOutput fileOutput(destinationPath);
+
+        if (progressCallback) {
+            TProgressOutputStream progressOutput(&fileOutput, contentLength, progressCallback);
+
+            unsigned code = client.DoGet(
+                pathAndQuery,
+                &progressOutput,
+                {},
+                nullptr);
+
+            if (code < 200 || code >= 300) {
+                result.ErrorMessage = TStringBuilder() << "HTTP error: " << code;
+                return result;
+            }
+
+            result.BytesDownloaded = progressOutput.GetWrittenBytes();
+        } else {
+            unsigned code = client.DoGet(
+                pathAndQuery,
+                &fileOutput,
+                {},
+                nullptr);
+
+            if (code < 200 || code >= 300) {
+                result.ErrorMessage = TStringBuilder() << "HTTP error: " << code;
+                return result;
+            }
+        }
+
+        fileOutput.Finish();
+        result.Success = true;
+
+    } catch (const THttpRequestException& e) {
+        result.ErrorMessage = TStringBuilder()
+            << "HTTP request failed: " << e.what()
+            << " (status code: " << e.GetStatusCode() << ")";
+    } catch (const yexception& e) {
+        result.ErrorMessage = TStringBuilder() << "Download failed: " << e.what();
+    } catch (const std::exception& e) {
+        result.ErrorMessage = TStringBuilder() << "Download failed: " << e.what();
+    }
+
+    return result;
+}
+
+} // namespace NConsoleClient
+} // namespace NYdb

--- a/ydb/public/lib/ydb_cli/common/download_manager.h
+++ b/ydb/public/lib/ydb_cli/common/download_manager.h
@@ -26,7 +26,7 @@ TDownloadResult DownloadFile(
     const TString& destinationPath,
     TDownloadProgressCallback progressCallback = {},
     TDuration connectTimeout = TDuration::Seconds(60),
-    TDuration socketTimeout = TDuration::Minutes(10));
+    TDuration socketTimeout = TDuration::Seconds(60));
 
 } // namespace NConsoleClient
 } // namespace NYdb

--- a/ydb/public/lib/ydb_cli/common/download_manager.h
+++ b/ydb/public/lib/ydb_cli/common/download_manager.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <util/datetime/base.h>
+
+#include <functional>
+
+namespace NYdb {
+namespace NConsoleClient {
+
+// Callback function for download progress updates
+// Parameters: downloaded bytes, total bytes (0 if unknown)
+using TDownloadProgressCallback = std::function<void(ui64 downloaded, ui64 total)>;
+
+struct TDownloadResult {
+    bool Success = false;
+    TString ErrorMessage;
+    ui64 BytesDownloaded = 0;
+};
+
+// Downloads a file from URL to the specified path with progress tracking
+// Supports HTTP and HTTPS URLs
+// Progress callback is called periodically during download
+TDownloadResult DownloadFile(
+    const TString& url,
+    const TString& destinationPath,
+    TDownloadProgressCallback progressCallback = {},
+    TDuration connectTimeout = TDuration::Seconds(60),
+    TDuration socketTimeout = TDuration::Minutes(10));
+
+} // namespace NConsoleClient
+} // namespace NYdb

--- a/ydb/public/lib/ydb_cli/common/print_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_utils.cpp
@@ -157,12 +157,18 @@ TString FormatEta(TDuration duration) {
 
     TStringBuilder result;
     if (hours > 0) {
-        result << hours << "h ";
+        result << hours << "h";
+        if (minutes > 0) {
+            result << " " << minutes << "m";
+        }
+    } else if (minutes > 0) {
+        result << minutes << "m";
+        if (seconds > 0) {
+            result << " " << seconds << "s";
+        }
+    } else {
+        result << seconds << "s";
     }
-    if (minutes > 0 || hours > 0) {
-        result << minutes << "m ";
-    }
-    result << seconds << "s";
 
     return result;
 }

--- a/ydb/public/lib/ydb_cli/common/print_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_utils.cpp
@@ -3,6 +3,7 @@
 #include <google/protobuf/util/json_util.h>
 #include <google/protobuf/port_def.inc>
 
+#include <util/string/builder.h>
 #include <util/string/printf.h>
 #include <util/stream/format.h>
 
@@ -79,9 +80,92 @@ TString FormatTime(TInstant time) {
 };
 
 TString FormatDuration(TDuration duration) {
-    return Sprintf("%.02f seconds",(duration.MilliSeconds() * 0.001));
-};
+    if (duration == TDuration::Zero()) {
+        return "0s";
+    }
 
+    ui64 totalMs = duration.MilliSeconds();
+
+    // For sub-second durations, show milliseconds
+    if (totalMs < 1000) {
+        return TStringBuilder() << totalMs << "ms";
+    }
+
+    ui64 totalSeconds = duration.Seconds();
+    ui64 hours = totalSeconds / 3600;
+    ui64 minutes = (totalSeconds % 3600) / 60;
+    ui64 seconds = totalSeconds % 60;
+
+    TStringBuilder result;
+
+    if (hours > 0) {
+        result << hours << "h";
+        if (minutes > 0) {
+            result << " " << minutes << "m";
+        }
+    } else if (minutes > 0) {
+        result << minutes << "m";
+        if (seconds > 0) {
+            result << " " << seconds << "s";
+        }
+    } else {
+        // Show seconds with one decimal for precision when < 1 minute
+        double secs = duration.SecondsFloat();
+        if (secs < 10) {
+            result << Sprintf("%.1fs", secs);
+        } else {
+            result << seconds << "s";
+        }
+    }
+
+    return result;
+}
+
+namespace {
+
+TString InsertSpaceBeforeUnit(TString result) {
+    // Insert space before unit suffix (KiB, MiB, GiB, TiB, or B)
+    for (size_t i = 0; i < result.size(); ++i) {
+        char c = result[i];
+        if (c == 'K' || c == 'M' || c == 'G' || c == 'T' || c == 'B') {
+            result.insert(i, " ");
+            break;
+        }
+    }
+    return result;
+}
+
+} // namespace
+
+TString FormatBytes(ui64 bytes) {
+    return InsertSpaceBeforeUnit(ToString(HumanReadableSize(bytes, SF_BYTES)));
+}
+
+TString FormatSpeed(double bytesPerSecond) {
+    return InsertSpaceBeforeUnit(ToString(HumanReadableSize(bytesPerSecond, SF_BYTES))) + "/s";
+}
+
+TString FormatEta(TDuration duration) {
+    ui64 totalSeconds = duration.Seconds();
+    if (totalSeconds == 0) {
+        return "<1s";
+    }
+
+    ui64 hours = totalSeconds / 3600;
+    ui64 minutes = (totalSeconds % 3600) / 60;
+    ui64 seconds = totalSeconds % 60;
+
+    TStringBuilder result;
+    if (hours > 0) {
+        result << hours << "h ";
+    }
+    if (minutes > 0 || hours > 0) {
+        result << minutes << "m ";
+    }
+    result << seconds << "s";
+
+    return result;
+}
 
 TString EntryTypeToString(NScheme::ESchemeEntryType entry) {
     switch (entry) {

--- a/ydb/public/lib/ydb_cli/common/print_utils.h
+++ b/ydb/public/lib/ydb_cli/common/print_utils.h
@@ -9,6 +9,9 @@ namespace NYdb::NConsoleClient {
 void PrintSchemeEntry(IOutputStream& o, const NScheme::TSchemeEntry& entry, NColorizer::TColors colors);
 TString FormatTime(TInstant time);
 TString FormatDuration(TDuration duration);
+TString FormatBytes(ui64 bytes);
+TString FormatSpeed(double bytesPerSecond);
+TString FormatEta(TDuration duration);
 TString PrettySize(ui64 size);
 TString PrettyNumber(ui64 number);
 TString EntryTypeToString(NScheme::ESchemeEntryType entry);

--- a/ydb/public/lib/ydb_cli/common/progress_bar.cpp
+++ b/ydb/public/lib/ydb_cli/common/progress_bar.cpp
@@ -81,6 +81,11 @@ TFancyProgressBarRenderer::~TFancyProgressBarRenderer() {
 }
 
 void TFancyProgressBarRenderer::Render(double percent, const TString& leftText, const TString& rightText) {
+    // Don't render after Finish() was called to avoid duplicate lines
+    if (Finished) {
+        return;
+    }
+
     TInstant now = TInstant::Now();
     TDuration elapsed = now - LastRenderTime;
 
@@ -415,6 +420,11 @@ TFancyDualProgressBarRenderer::~TFancyDualProgressBarRenderer() {
 
 void TFancyDualProgressBarRenderer::Render(double primaryPercent, double secondaryPercent,
                                            const TString& leftText, const TString& rightText) {
+    // Don't render after Finish() was called to avoid duplicate lines
+    if (Finished) {
+        return;
+    }
+
     TInstant now = TInstant::Now();
     TDuration elapsed = now - LastRenderTime;
 

--- a/ydb/public/lib/ydb_cli/common/progress_bar.cpp
+++ b/ydb/public/lib/ydb_cli/common/progress_bar.cpp
@@ -1,79 +1,383 @@
-#include "common.h"
 #include "progress_bar.h"
+#include "interactive.h"
 
-#include <ydb/public/lib/ydb_cli/common/interactive.h>
+#include <contrib/libs/ftxui/include/ftxui/dom/elements.hpp>
+#include <contrib/libs/ftxui/include/ftxui/screen/screen.hpp>
+#include <contrib/libs/ftxui/include/ftxui/screen/color.hpp>
+#include <contrib/libs/ftxui/include/ftxui/screen/terminal.hpp>
+
+#include <util/stream/output.h>
+#include <util/string/builder.h>
 #include <util/string/cast.h>
+#include <util/string/printf.h>
 
 namespace NYdb {
 namespace NConsoleClient {
 
-TProgressBar::TProgressBar(size_t capacity, size_t parts)
-     : Capacity(capacity)
-     , Parts(parts)
-{}
+// ============================================================================
+// Helper functions
+// ============================================================================
 
-void TProgressBar::SetProgress(size_t progress)
-{
-    const auto partSize = Parts ? Max<size_t>(Capacity / Parts, 1) : Max<size_t>();
-    const auto curPartNum = CurProgress / partSize;
-    CurProgress = Min(progress, Capacity);
-    if (Capacity != 0) {
-        Render(Parts && CurProgress / partSize != curPartNum);
+TString FormatBytes(ui64 bytes) {
+    const char* suffixes[] = {"B", "KB", "MB", "GB", "TB"};
+    int suffixIndex = 0;
+    double size = static_cast<double>(bytes);
+
+    while (size >= 1024.0 && suffixIndex < 4) {
+        size /= 1024.0;
+        suffixIndex++;
     }
+
+    if (suffixIndex == 0) {
+        return Sprintf("%.0f %s", size, suffixes[suffixIndex]);
+    }
+    return Sprintf("%.1f %s", size, suffixes[suffixIndex]);
+}
+
+TString FormatSpeed(ui64 bytesPerSecond) {
+    return FormatBytes(bytesPerSecond) + "/s";
+}
+
+TString FormatEta(TDuration duration) {
+    ui64 totalSeconds = duration.Seconds();
+    if (totalSeconds == 0) {
+        return "<1s";
+    }
+
+    ui64 hours = totalSeconds / 3600;
+    ui64 minutes = (totalSeconds % 3600) / 60;
+    ui64 seconds = totalSeconds % 60;
+
+    TStringBuilder result;
+    if (hours > 0) {
+        result << hours << "h ";
+    }
+    if (minutes > 0 || hours > 0) {
+        result << minutes << "m ";
+    }
+    result << seconds << "s";
+
+    return result;
+}
+
+// ============================================================================
+// TTextProgressBarRenderer - for non-interactive terminals
+// ============================================================================
+
+TTextProgressBarRenderer::TTextProgressBarRenderer(size_t updateIntervalMs)
+    : UpdateIntervalMs(updateIntervalMs)
+{
+}
+
+TTextProgressBarRenderer::~TTextProgressBarRenderer() {
+    if (!Finished) {
+        Cerr << Endl;
+    }
+}
+
+void TTextProgressBarRenderer::Render(double percent, const TString& leftText, const TString& rightText) {
+    TInstant now = TInstant::Now();
+    TDuration elapsed = now - LastRenderTime;
+
+    // Always render at 100% (final state), otherwise throttle
+    bool isFinal = (percent >= 100.0);
+    bool intervalPassed = (elapsed.MilliSeconds() >= UpdateIntervalMs);
+
+    if (!isFinal && !intervalPassed) {
+        return;
+    }
+
+    // Don't render final state twice
+    if (isFinal && RenderedFinal) {
+        return;
+    }
+
+    LastRenderTime = now;
+    if (isFinal) {
+        RenderedFinal = true;
+    }
+
+    TStringBuilder output;
+    output << leftText;
+    if (rightText) {
+        output << " " << rightText;
+    }
+    Cerr << output << Endl;
+}
+
+void TTextProgressBarRenderer::Finish() {
+    Finished = true;
+}
+
+void TTextProgressBarRenderer::Clear() {
+    // Nothing to clear in text mode
+}
+
+// ============================================================================
+// TFancyProgressBarRenderer - for interactive terminals using ftxui
+// ============================================================================
+
+TFancyProgressBarRenderer::TFancyProgressBarRenderer() {
+}
+
+TFancyProgressBarRenderer::~TFancyProgressBarRenderer() {
+    if (!Finished) {
+        Cerr << Endl;
+    }
+}
+
+void TFancyProgressBarRenderer::Render(double percent, const TString& leftText, const TString& rightText) {
+    TInstant now = TInstant::Now();
+    TDuration elapsed = now - LastRenderTime;
+
+    // Throttle rendering to ~30 FPS
+    if (elapsed.MilliSeconds() < 33 && percent < 100.0) {
+        return;
+    }
+    LastRenderTime = now;
+
+    Percent = percent;
+    LeftText = leftText;
+    RightText = rightText;
+    DoRender();
+}
+
+void TFancyProgressBarRenderer::DoRender() {
+    using namespace ftxui;
+
+    int termWidth = Terminal::Size().dimx;
+    if (termWidth <= 0) {
+        termWidth = 80;
+    }
+
+    // Colors
+    Color gaugeColor = (Percent >= 100.0) ? Color::Green : Color::Cyan;
+    Color bgColor = Color::Grey23;  // Dark gray background for unfilled part
+
+    auto left = text(std::string(LeftText)) | bold;
+
+    // Reserve fixed width for right text (metadata)
+    // This prevents the progress bar from jumping when ETA disappears
+    // Format: "15.2 MB/s | 102.4 MB / 102.4 MB | ETA: 59m 59s" = ~45 chars max
+    const int reservedRightWidth = 45;
+    int actualRightWidth = static_cast<int>(RightText.size());
+
+    // Pad right text to reserved width (left-aligned within reserved space)
+    std::string paddedRight = std::string(RightText);
+    if (actualRightWidth < reservedRightWidth) {
+        paddedRight.append(reservedRightWidth - actualRightWidth, ' ');
+    }
+
+    auto right = text(paddedRight) | dim;
+
+    // Calculate gauge width
+    // Format: "100% │████████████████████│ metadata..."
+    int leftWidth = static_cast<int>(LeftText.size());
+    int rightWidth = Max(actualRightWidth, reservedRightWidth);
+    int bordersAndSpaces = 4; // " │" + "│ "
+    int gaugeMinWidth = 15;
+
+    int gaugeWidth = gaugeMinWidth;
+    int availableForGauge = termWidth - leftWidth - rightWidth - bordersAndSpaces;
+    if (availableForGauge > gaugeMinWidth) {
+        gaugeWidth = availableForGauge;
+    }
+
+    // Build progress bar with visible borders and background
+    auto gauge_element = gauge(static_cast<float>(Percent / 100.0))
+        | color(gaugeColor)
+        | bgcolor(bgColor)
+        | size(WIDTH, EQUAL, gaugeWidth);
+
+    auto document = hbox({
+        left,
+        text(" "),
+        text("▕") | bold,
+        gauge_element,
+        text("▏") | bold,
+        text(" "),
+        right,
+    });
+
+    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
+    ftxui::Render(screen, document);
+
+    // Move cursor to beginning of line and print
+    Cerr << "\r";
+    screen.Print();
+    Cerr.Flush();
+}
+
+void TFancyProgressBarRenderer::Finish() {
+    if (!Finished) {
+        Finished = true;
+        Cerr << Endl;
+    }
+}
+
+void TFancyProgressBarRenderer::Clear() {
+    // Clear the current line
+    Cerr << "\r\033[K";
+    Cerr.Flush();
+}
+
+// ============================================================================
+// Factory function
+// ============================================================================
+
+std::unique_ptr<IProgressBarRenderer> CreateProgressBarRenderer(size_t updateIntervalMs) {
+    std::optional<size_t> termWidth = GetErrTerminalWidth();
+    if (termWidth) {
+        return std::make_unique<TFancyProgressBarRenderer>();
+    } else {
+        return std::make_unique<TTextProgressBarRenderer>(updateIntervalMs);
+    }
+}
+
+// ============================================================================
+// TProgressBar - simple progress bar
+// ============================================================================
+
+TProgressBar::TProgressBar(size_t capacity, size_t parts)
+    : Capacity(capacity)
+    , Parts(parts)
+    , Renderer(CreateProgressBarRenderer())
+{
+}
+
+TProgressBar::~TProgressBar() {
+    if (!Finished && Renderer) {
+        Renderer->Finish();
+    }
+}
+
+void TProgressBar::SetProgress(size_t progress) {
+    CurProgress = Min(progress, Capacity);
+    Render();
 }
 
 void TProgressBar::AddProgress(size_t value) {
     SetProgress(CurProgress + value);
 }
 
-TProgressBar::~TProgressBar() {
-    if (!Finished) {
-        Cerr << Endl;
-    }
-}
-
-void TProgressBar::Render(bool newPart)
-{
-    std::optional<size_t> barLenOpt = GetErrTerminalWidth();
-    if (!barLenOpt) {
-        if (newPart) {
-            Cerr << CurProgress << " / " << Capacity << Endl;
-        }
+void TProgressBar::Render(bool force) {
+    if (Capacity == 0 || !Renderer) {
         return;
     }
 
-    size_t barLen = *barLenOpt;
-    TString output = "\r";
-    output += ToString(CurProgress * 100 / Capacity);
-    output += "% |";
-    TString outputEnd = "| [";
-    outputEnd += ToString(CurProgress);
-    outputEnd += "/";
-    outputEnd += ToString(Capacity);
-    outputEnd += "]";
-
-    if (barLen > output.size() - 1) {
-        barLen -= output.size() - 1;
+    // Check if we need to render (for text mode with parts)
+    bool shouldRender = force;
+    if (Parts > 0) {
+        size_t partSize = Max<size_t>(Capacity / Parts, 1);
+        size_t currentPart = CurProgress / partSize;
+        if (currentPart != LastRenderedPart) {
+            LastRenderedPart = currentPart;
+            shouldRender = true;
+        }
     } else {
-        barLen = 1;
+        shouldRender = true;
     }
 
-    if (barLen > outputEnd.size()) {
-        barLen -= outputEnd.size();
-    } else {
-        barLen = 1;
+    if (!shouldRender && CurProgress < Capacity) {
+        return;
     }
 
-    size_t filledBarLen = CurProgress * barLen / Capacity;
-    output += TString("█") * filledBarLen;
-    output += TString("░") * (barLen - filledBarLen);
-    output += outputEnd;
-    Cerr << output;
-    if (CurProgress == Capacity) {
-        Cerr << "\n";
+    double percent = static_cast<double>(CurProgress) * 100.0 / static_cast<double>(Capacity);
+    TString leftText = Sprintf("%3.0f%%", percent);
+    TString rightText = TStringBuilder() << CurProgress << " / " << Capacity;
+
+    Renderer->Render(percent, leftText, rightText);
+
+    if (CurProgress >= Capacity) {
         Finished = true;
+        Renderer->Finish();
     }
-    Cerr.Flush();
+}
+
+// ============================================================================
+// TBytesProgressBar - progress bar for byte transfers
+// ============================================================================
+
+TBytesProgressBar::TBytesProgressBar(ui64 totalBytes)
+    : TotalBytes(totalBytes)
+    , Renderer(CreateProgressBarRenderer())
+    , StartTime(TInstant::Now())
+{
+}
+
+TBytesProgressBar::~TBytesProgressBar() {
+    if (!Finished && Renderer) {
+        Renderer->Finish();
+    }
+}
+
+void TBytesProgressBar::SetProgress(ui64 downloadedBytes) {
+    DownloadedBytes = downloadedBytes;
+    if (TotalBytes > 0) {
+        DownloadedBytes = Min(DownloadedBytes, TotalBytes);
+    }
+    Render();
+}
+
+void TBytesProgressBar::AddProgress(ui64 bytes) {
+    SetProgress(DownloadedBytes + bytes);
+}
+
+void TBytesProgressBar::SetTotal(ui64 totalBytes) {
+    TotalBytes = totalBytes;
+}
+
+void TBytesProgressBar::Render() {
+    if (!Renderer) {
+        return;
+    }
+
+    TInstant now = TInstant::Now();
+    TDuration elapsed = now - StartTime;
+
+    // Calculate speed
+    ui64 bytesPerSecond = 0;
+    if (elapsed.Seconds() > 0) {
+        bytesPerSecond = DownloadedBytes / elapsed.Seconds();
+    } else if (elapsed.MilliSeconds() > 0) {
+        bytesPerSecond = DownloadedBytes * 1000 / elapsed.MilliSeconds();
+    }
+
+    // Build info string
+    TStringBuilder rightText;
+    rightText << FormatSpeed(bytesPerSecond);
+
+    if (TotalBytes > 0) {
+        rightText << " | " << FormatBytes(DownloadedBytes) << " / " << FormatBytes(TotalBytes);
+
+        // Calculate ETA
+        if (bytesPerSecond > 0 && DownloadedBytes < TotalBytes) {
+            ui64 remaining = TotalBytes - DownloadedBytes;
+            TDuration eta = TDuration::Seconds(remaining / bytesPerSecond);
+            rightText << " | ETA: " << FormatEta(eta);
+        }
+    } else {
+        rightText << " | " << FormatBytes(DownloadedBytes);
+    }
+
+    // Calculate percent
+    double percent = 0;
+    TString leftText;
+    if (TotalBytes > 0) {
+        percent = static_cast<double>(DownloadedBytes) * 100.0 / static_cast<double>(TotalBytes);
+        leftText = Sprintf("%3.0f%%", percent);
+    } else {
+        // Unknown total - show indeterminate progress
+        percent = 50.0; // Show half-filled gauge
+        leftText = "  ?%";
+    }
+
+    Renderer->Render(percent, leftText, rightText);
+
+    if (TotalBytes > 0 && DownloadedBytes >= TotalBytes) {
+        Finished = true;
+        Renderer->Finish();
+    }
 }
 
 } // namespace NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/progress_bar.cpp
+++ b/ydb/public/lib/ydb_cli/common/progress_bar.cpp
@@ -1,5 +1,6 @@
 #include "progress_bar.h"
 #include "interactive.h"
+#include "print_utils.h"
 
 #include <contrib/libs/ftxui/include/ftxui/dom/elements.hpp>
 #include <contrib/libs/ftxui/include/ftxui/screen/screen.hpp>
@@ -8,57 +9,10 @@
 
 #include <util/stream/output.h>
 #include <util/string/builder.h>
-#include <util/string/cast.h>
 #include <util/string/printf.h>
 
 namespace NYdb {
 namespace NConsoleClient {
-
-// ============================================================================
-// Helper functions
-// ============================================================================
-
-TString FormatBytes(ui64 bytes) {
-    const char* suffixes[] = {"B", "KB", "MB", "GB", "TB"};
-    int suffixIndex = 0;
-    double size = static_cast<double>(bytes);
-
-    while (size >= 1024.0 && suffixIndex < 4) {
-        size /= 1024.0;
-        suffixIndex++;
-    }
-
-    if (suffixIndex == 0) {
-        return Sprintf("%.0f %s", size, suffixes[suffixIndex]);
-    }
-    return Sprintf("%.1f %s", size, suffixes[suffixIndex]);
-}
-
-TString FormatSpeed(ui64 bytesPerSecond) {
-    return FormatBytes(bytesPerSecond) + "/s";
-}
-
-TString FormatEta(TDuration duration) {
-    ui64 totalSeconds = duration.Seconds();
-    if (totalSeconds == 0) {
-        return "<1s";
-    }
-
-    ui64 hours = totalSeconds / 3600;
-    ui64 minutes = (totalSeconds % 3600) / 60;
-    ui64 seconds = totalSeconds % 60;
-
-    TStringBuilder result;
-    if (hours > 0) {
-        result << hours << "h ";
-    }
-    if (minutes > 0 || hours > 0) {
-        result << minutes << "m ";
-    }
-    result << seconds << "s";
-
-    return result;
-}
 
 // ============================================================================
 // TTextProgressBarRenderer - for non-interactive terminals
@@ -139,6 +93,14 @@ void TFancyProgressBarRenderer::Render(double percent, const TString& leftText, 
     Percent = percent;
     LeftText = leftText;
     RightText = rightText;
+
+    // Update cached text less frequently to make it readable
+    TDuration textElapsed = now - LastTextUpdateTime;
+    if (textElapsed.MilliSeconds() >= TextUpdateIntervalMs || CachedRightText.empty() || percent >= 100.0) {
+        CachedRightText = rightText;
+        LastTextUpdateTime = now;
+    }
+
     DoRender();
 }
 
@@ -150,20 +112,20 @@ void TFancyProgressBarRenderer::DoRender() {
         termWidth = 80;
     }
 
-    // Colors
-    Color gaugeColor = (Percent >= 100.0) ? Color::Green : Color::Cyan;
+    // Colors: always green
+    Color gaugeColor = Color::Green;
     Color bgColor = Color::Grey23;  // Dark gray background for unfilled part
 
     auto left = text(std::string(LeftText)) | bold;
 
     // Reserve fixed width for right text (metadata)
     // This prevents the progress bar from jumping when ETA disappears
-    // Format: "15.2 MB/s | 102.4 MB / 102.4 MB | ETA: 59m 59s" = ~45 chars max
-    const int reservedRightWidth = 45;
-    int actualRightWidth = static_cast<int>(RightText.size());
+    // Format: "15.2 MiB/s | 102.4 MiB / 102.4 MiB | ETA: 59m 59s" = ~48 chars max
+    const int reservedRightWidth = 48;
+    int actualRightWidth = static_cast<int>(CachedRightText.size());
 
     // Pad right text to reserved width (left-aligned within reserved space)
-    std::string paddedRight = std::string(RightText);
+    std::string paddedRight = std::string(CachedRightText);
     if (actualRightWidth < reservedRightWidth) {
         paddedRight.append(reservedRightWidth - actualRightWidth, ' ');
     }
@@ -335,12 +297,11 @@ void TBytesProgressBar::Render() {
     TInstant now = TInstant::Now();
     TDuration elapsed = now - StartTime;
 
-    // Calculate speed
-    ui64 bytesPerSecond = 0;
-    if (elapsed.Seconds() > 0) {
-        bytesPerSecond = DownloadedBytes / elapsed.Seconds();
-    } else if (elapsed.MilliSeconds() > 0) {
-        bytesPerSecond = DownloadedBytes * 1000 / elapsed.MilliSeconds();
+    // Calculate speed using floating point for accuracy
+    double bytesPerSecond = 0;
+    double elapsedSeconds = elapsed.SecondsFloat();
+    if (elapsedSeconds > 0) {
+        bytesPerSecond = static_cast<double>(DownloadedBytes) / elapsedSeconds;
     }
 
     // Build info string
@@ -375,6 +336,351 @@ void TBytesProgressBar::Render() {
     Renderer->Render(percent, leftText, rightText);
 
     if (TotalBytes > 0 && DownloadedBytes >= TotalBytes) {
+        Finished = true;
+        Renderer->Finish();
+    }
+}
+
+// ============================================================================
+// TTextDualProgressBarRenderer - for non-interactive terminals
+// ============================================================================
+
+TTextDualProgressBarRenderer::TTextDualProgressBarRenderer(size_t updateIntervalMs)
+    : UpdateIntervalMs(updateIntervalMs)
+{
+}
+
+TTextDualProgressBarRenderer::~TTextDualProgressBarRenderer() {
+    if (!Finished) {
+        Cerr << Endl;
+    }
+}
+
+void TTextDualProgressBarRenderer::Render(double primaryPercent, double secondaryPercent,
+                                          const TString& leftText, const TString& rightText) {
+    TInstant now = TInstant::Now();
+    TDuration elapsed = now - LastRenderTime;
+
+    // Always render at 100% (final state), otherwise throttle
+    bool isFinal = (primaryPercent >= 100.0);
+    bool intervalPassed = (elapsed.MilliSeconds() >= UpdateIntervalMs);
+
+    if (!isFinal && !intervalPassed) {
+        return;
+    }
+
+    // Don't render final state twice
+    if (isFinal && RenderedFinal) {
+        return;
+    }
+
+    LastRenderTime = now;
+    if (isFinal) {
+        RenderedFinal = true;
+    }
+
+    TStringBuilder output;
+    output << leftText;
+    // In text mode, also show buffered progress if significantly ahead of primary
+    double inProgressPercent = secondaryPercent - primaryPercent;
+    if (inProgressPercent >= 1.0) {
+        output << " (+ " << Sprintf("%.0f%%", inProgressPercent) << " in progress)";
+    }
+    if (rightText) {
+        output << " " << rightText;
+    }
+    Cerr << output << Endl;
+}
+
+void TTextDualProgressBarRenderer::Finish() {
+    Finished = true;
+}
+
+void TTextDualProgressBarRenderer::Clear() {
+    // Nothing to clear in text mode
+}
+
+// ============================================================================
+// TFancyDualProgressBarRenderer - for interactive terminals using ftxui
+// ============================================================================
+
+TFancyDualProgressBarRenderer::TFancyDualProgressBarRenderer() {
+}
+
+TFancyDualProgressBarRenderer::~TFancyDualProgressBarRenderer() {
+    if (!Finished) {
+        Cerr << Endl;
+    }
+}
+
+void TFancyDualProgressBarRenderer::Render(double primaryPercent, double secondaryPercent,
+                                           const TString& leftText, const TString& rightText) {
+    TInstant now = TInstant::Now();
+    TDuration elapsed = now - LastRenderTime;
+
+    // Throttle rendering to ~30 FPS
+    if (elapsed.MilliSeconds() < 33 && primaryPercent < 100.0) {
+        return;
+    }
+    LastRenderTime = now;
+
+    PrimaryPercent = primaryPercent;
+    SecondaryPercent = secondaryPercent;
+    LeftText = leftText;
+    RightText = rightText;
+
+    // Update cached text less frequently to make it readable
+    TDuration textElapsed = now - LastTextUpdateTime;
+    if (textElapsed.MilliSeconds() >= TextUpdateIntervalMs || CachedRightText.empty() || primaryPercent >= 100.0) {
+        CachedRightText = rightText;
+        LastTextUpdateTime = now;
+    }
+
+    DoRender();
+}
+
+void TFancyDualProgressBarRenderer::DoRender() {
+    using namespace ftxui;
+
+    int termWidth = Terminal::Size().dimx;
+    if (termWidth <= 0) {
+        termWidth = 80;
+    }
+
+    // Colors
+    Color primaryColor = Color::Green;      // Confirmed progress
+    // Buffered progress: subtle gray, visible on both dark and light backgrounds
+    // Grey50 (RGB ~128,128,128) is a good middle ground
+    Color secondaryColor = Color::Grey50;
+    Color bgColor = Color::Grey23;          // Background (dark)
+
+    auto left = text(std::string(LeftText)) | bold;
+
+    // Reserve fixed width for right text (metadata)
+    // Format: "15.2 MiB/s | 102.4 MiB / 102.4 MiB | ETA: 59m 59s" = ~48 chars max
+    const int reservedRightWidth = 48;
+    int actualRightWidth = static_cast<int>(CachedRightText.size());
+
+    std::string paddedRight = std::string(CachedRightText);
+    if (actualRightWidth < reservedRightWidth) {
+        paddedRight.append(reservedRightWidth - actualRightWidth, ' ');
+    }
+
+    auto right = text(paddedRight) | dim;
+
+    // Calculate gauge width
+    int leftWidth = static_cast<int>(LeftText.size());
+    int rightWidth = Max(actualRightWidth, reservedRightWidth);
+    int bordersAndSpaces = 4;
+    int gaugeMinWidth = 15;
+
+    int gaugeWidth = gaugeMinWidth;
+    int availableForGauge = termWidth - leftWidth - rightWidth - bordersAndSpaces;
+    if (availableForGauge > gaugeMinWidth) {
+        gaugeWidth = availableForGauge;
+    }
+
+    // Build dual progress bar manually
+    // We'll use character-based approach for dual progress
+    float primaryRatio = static_cast<float>(PrimaryPercent / 100.0);
+    float secondaryRatio = static_cast<float>(SecondaryPercent / 100.0);
+
+    primaryRatio = std::max(0.0f, std::min(1.0f, primaryRatio));
+    secondaryRatio = std::max(0.0f, std::min(1.0f, secondaryRatio));
+
+    int primaryChars = static_cast<int>(primaryRatio * gaugeWidth);
+    int secondaryChars = static_cast<int>(secondaryRatio * gaugeWidth);
+    int emptyChars = gaugeWidth - secondaryChars;
+
+    // Ensure secondary >= primary (secondary is "ahead" of primary)
+    secondaryChars = std::max(secondaryChars, primaryChars);
+    int bufferChars = secondaryChars - primaryChars;
+
+    // Check if we need a separator (when both primary and buffer exist)
+    bool needsSeparator = (bufferChars > 0 && primaryChars > 0);
+
+    // Build the gauge as text elements with centered labels
+    // [green filled with "completed"][separator][gray buffer with "in progress"][dark empty]
+
+    // Helper to center text in a string of given width
+    auto centerText = [](const std::string& label, int width) -> std::string {
+        if (width <= 0) return "";
+        if (static_cast<int>(label.size()) > width) return std::string(width, ' ');
+        int padding = (width - static_cast<int>(label.size())) / 2;
+        std::string result(padding, ' ');
+        result += label;
+        result.append(width - result.size(), ' ');
+        return result;
+    };
+
+    // For drawing, account for separator (it takes 1 char from primary space)
+    int primaryDrawChars = needsSeparator ? primaryChars - 1 : primaryChars;
+    if (primaryDrawChars < 0) primaryDrawChars = 0;
+
+    // Create strings with centered labels if they fit
+    // Center based on full primary width for stable positioning, then trim if needed
+    std::string primaryStr;
+    if (primaryChars >= static_cast<int>(CompletedLabel.size()) + 2) {
+        std::string centered = centerText(CompletedLabel, primaryChars);
+        // Trim to actual draw width (removes last char when separator present)
+        primaryStr = centered.substr(0, primaryDrawChars);
+    } else {
+        primaryStr = std::string(primaryDrawChars, ' ');
+    }
+    std::string bufferStr = (bufferChars >= static_cast<int>(InProgressLabel.size()) + 2)
+        ? centerText(InProgressLabel, bufferChars)
+        : std::string(bufferChars, ' ');
+    std::string emptyStr(emptyChars, ' ');
+
+    Elements gauge_parts;
+    if (primaryChars > 0) {
+        gauge_parts.push_back(text(primaryStr) | bgcolor(primaryColor) | color(Color::Black));
+    }
+    // Add thin separator on green background (▕ = right eighth block, visually marks the end of confirmed progress)
+    if (needsSeparator) {
+        gauge_parts.push_back(text("▕") | bold | bgcolor(primaryColor));
+    }
+    if (bufferChars > 0) {
+        gauge_parts.push_back(text(bufferStr) | bgcolor(secondaryColor) | color(Color::White));
+    }
+    if (emptyChars > 0) {
+        gauge_parts.push_back(text(emptyStr) | bgcolor(bgColor));
+    }
+
+    auto gauge_element = hbox(gauge_parts);
+
+    auto document = hbox({
+        left,
+        text(" "),
+        text("▕") | bold,
+        gauge_element,
+        text("▏") | bold,
+        text(" "),
+        right,
+    });
+
+    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
+    ftxui::Render(screen, document);
+
+    // Move cursor to beginning of line and print
+    Cerr << "\r";
+    screen.Print();
+    Cerr.Flush();
+}
+
+void TFancyDualProgressBarRenderer::Finish() {
+    if (!Finished) {
+        Finished = true;
+        Cerr << Endl;
+    }
+}
+
+void TFancyDualProgressBarRenderer::Clear() {
+    Cerr << "\r\033[K";
+    Cerr.Flush();
+}
+
+// ============================================================================
+// Factory function for dual progress bar
+// ============================================================================
+
+std::unique_ptr<IDualProgressBarRenderer> CreateDualProgressBarRenderer(size_t updateIntervalMs) {
+    std::optional<size_t> termWidth = GetErrTerminalWidth();
+    if (termWidth) {
+        return std::make_unique<TFancyDualProgressBarRenderer>();
+    } else {
+        return std::make_unique<TTextDualProgressBarRenderer>(updateIntervalMs);
+    }
+}
+
+// ============================================================================
+// TDualBytesProgressBar - dual progress bar for import operations
+// ============================================================================
+
+TDualBytesProgressBar::TDualBytesProgressBar(ui64 totalBytes)
+    : TotalBytes(totalBytes)
+    , Renderer(CreateDualProgressBarRenderer())
+    , StartTime(TInstant::Now())
+{
+}
+
+TDualBytesProgressBar::~TDualBytesProgressBar() {
+    if (!Finished && Renderer) {
+        Renderer->Finish();
+    }
+}
+
+void TDualBytesProgressBar::SetBufferedProgress(ui64 bufferedBytes) {
+    BufferedBytes = bufferedBytes;
+    if (TotalBytes > 0) {
+        BufferedBytes = Min(BufferedBytes, TotalBytes);
+    }
+    Render();
+}
+
+void TDualBytesProgressBar::SetConfirmedProgress(ui64 confirmedBytes) {
+    ConfirmedBytes = confirmedBytes;
+    if (TotalBytes > 0) {
+        ConfirmedBytes = Min(ConfirmedBytes, TotalBytes);
+    }
+    Render();
+}
+
+void TDualBytesProgressBar::SetTotal(ui64 totalBytes) {
+    TotalBytes = totalBytes;
+}
+
+void TDualBytesProgressBar::Render() {
+    if (!Renderer) {
+        return;
+    }
+
+    TInstant now = TInstant::Now();
+    TDuration elapsed = now - StartTime;
+
+    // Calculate speed based on confirmed bytes (real progress) using floating point for accuracy
+    double bytesPerSecond = 0;
+    double elapsedSeconds = elapsed.SecondsFloat();
+    if (elapsedSeconds > 0) {
+        bytesPerSecond = static_cast<double>(ConfirmedBytes) / elapsedSeconds;
+    }
+
+    // Build info string
+    TStringBuilder rightText;
+    rightText << FormatSpeed(bytesPerSecond);
+
+    if (TotalBytes > 0) {
+        rightText << " | " << FormatBytes(ConfirmedBytes) << " / " << FormatBytes(TotalBytes);
+
+        // Calculate ETA based on confirmed bytes
+        if (bytesPerSecond > 0 && ConfirmedBytes < TotalBytes) {
+            ui64 remaining = TotalBytes - ConfirmedBytes;
+            TDuration eta = TDuration::Seconds(remaining / bytesPerSecond);
+            rightText << " | ETA: " << FormatEta(eta);
+        }
+    } else {
+        rightText << " | " << FormatBytes(ConfirmedBytes);
+    }
+
+    // Calculate percentages
+    double primaryPercent = 0;   // Confirmed (green)
+    double secondaryPercent = 0; // Buffered (grey)
+    TString leftText;
+
+    if (TotalBytes > 0) {
+        primaryPercent = static_cast<double>(ConfirmedBytes) * 100.0 / static_cast<double>(TotalBytes);
+        secondaryPercent = static_cast<double>(BufferedBytes) * 100.0 / static_cast<double>(TotalBytes);
+        // Show primary (confirmed) percent as main percentage
+        leftText = Sprintf("%3.0f%%", primaryPercent);
+    } else {
+        primaryPercent = 50.0;
+        secondaryPercent = 50.0;
+        leftText = "  ?%";
+    }
+
+    Renderer->Render(primaryPercent, secondaryPercent, leftText, rightText);
+
+    if (TotalBytes > 0 && ConfirmedBytes >= TotalBytes) {
         Finished = true;
         Renderer->Finish();
     }

--- a/ydb/public/lib/ydb_cli/common/progress_bar.h
+++ b/ydb/public/lib/ydb_cli/common/progress_bar.h
@@ -1,19 +1,86 @@
 #pragma once
 
-#include <cstddef>
+#include <util/datetime/base.h>
+#include <util/generic/string.h>
 #include <ydb/library/accessor/accessor.h>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
 
 namespace NYdb {
 namespace NConsoleClient {
 
+// Base progress bar renderer interface
+class IProgressBarRenderer {
+public:
+    virtual ~IProgressBarRenderer() = default;
+
+    // Render progress bar
+    // percent: 0-100
+    // leftText: text to show on the left (e.g., "45%")
+    // rightText: text to show on the right (e.g., "45/100" or "15.2 MB/s | 45.3 MB / 102.5 MB | ETA: 2m 15s")
+    virtual void Render(double percent, const TString& leftText, const TString& rightText) = 0;
+
+    // Called when progress is complete
+    virtual void Finish() = 0;
+
+    // Called to clear/reset the progress bar
+    virtual void Clear() = 0;
+};
+
+// Creates appropriate renderer based on terminal capabilities
+// If stderr is a terminal - returns ftxui-based renderer
+// Otherwise - returns text-based renderer that prints periodically
+std::unique_ptr<IProgressBarRenderer> CreateProgressBarRenderer(size_t updateIntervalMs = 10000);
+
+// Text renderer that prints progress periodically (for non-interactive mode)
+class TTextProgressBarRenderer : public IProgressBarRenderer {
+public:
+    explicit TTextProgressBarRenderer(size_t updateIntervalMs = 10000);
+    ~TTextProgressBarRenderer() override;
+
+    void Render(double percent, const TString& leftText, const TString& rightText) override;
+    void Finish() override;
+    void Clear() override;
+
+private:
+    size_t UpdateIntervalMs;
+    TInstant LastRenderTime;
+    bool Finished = false;
+    bool RenderedFinal = false;
+};
+
+// Interactive renderer using ftxui with colors and gauge
+class TFancyProgressBarRenderer : public IProgressBarRenderer {
+public:
+    TFancyProgressBarRenderer();
+    ~TFancyProgressBarRenderer() override;
+
+    void Render(double percent, const TString& leftText, const TString& rightText) override;
+    void Finish() override;
+    void Clear() override;
+
+private:
+    void DoRender();
+
+    double Percent = 0;
+    TString LeftText;
+    TString RightText;
+    TInstant LastRenderTime;
+    bool Finished = false;
+};
+
+// Simple progress bar: shows current/total with percentage
+// Compatible with existing TProgressBar API
 class TProgressBar {
 public:
+    // capacity: total number of items
+    // parts: if non-zero, in non-interactive mode prints only when crossing part boundaries
     explicit TProgressBar(size_t capacity, size_t parts = 0);
-
     ~TProgressBar();
 
     void SetProgress(size_t progress);
-
     void AddProgress(size_t value);
 
     YDB_READONLY(size_t, Capacity, 0);
@@ -21,10 +88,42 @@ public:
     YDB_READONLY(size_t, Parts, 0);
 
 private:
-    void Render(bool newPart);
+    void Render(bool force = false);
 
+    std::unique_ptr<IProgressBarRenderer> Renderer;
+    size_t LastRenderedPart = 0;
     bool Finished = false;
 };
+
+// Progress bar for byte transfers: shows speed and ETA
+class TBytesProgressBar {
+public:
+    // totalBytes: total size in bytes (0 if unknown)
+    explicit TBytesProgressBar(ui64 totalBytes = 0);
+    ~TBytesProgressBar();
+
+    void SetProgress(ui64 downloadedBytes);
+    void AddProgress(ui64 bytes);
+
+    // Update total if it wasn't known at construction time
+    void SetTotal(ui64 totalBytes);
+
+    YDB_READONLY(ui64, TotalBytes, 0);
+    YDB_READONLY(ui64, DownloadedBytes, 0);
+
+private:
+    void Render();
+
+    std::unique_ptr<IProgressBarRenderer> Renderer;
+    TInstant StartTime;
+    TInstant LastRenderTime;
+    bool Finished = false;
+};
+
+// Helper functions for formatting
+TString FormatBytes(ui64 bytes);
+TString FormatSpeed(ui64 bytesPerSecond);
+TString FormatEta(TDuration duration);
 
 } // namespace NConsoleClient
 } // namespace NYdb

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.h
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.h
@@ -61,7 +61,7 @@ namespace NInternal {
         TIterator begin,
         TIterator end,
         TRemover& remover,
-        std::optional<TProgressBar> progressBar
+        TProgressBar* progressBar
     ) {
         TVector<const NScheme::TSchemeEntry*> entriesToRemoveInSecondPass;
         for (const NScheme::TSchemeEntry& entry : std::ranges::subrange(begin, end)) {
@@ -107,11 +107,11 @@ TStatus RemovePathsRecursive(
     if (!remover) {
         remover = NInternal::CreateDefaultRemover(schemeClient, tableClient, topicClient, queryClient, coordinationClient, settings);
     }
-    std::optional<TProgressBar> progressBar;
+    std::unique_ptr<TProgressBar> progressBar;
     if (settings.CreateProgressBar_) {
-        progressBar = std::make_optional<TProgressBar>(end - begin);
+        progressBar = std::make_unique<TProgressBar>(end - begin);
     }
-    return NInternal::RemovePathsRecursive(begin, end, remover, progressBar);
+    return NInternal::RemovePathsRecursive(begin, end, remover, progressBar.get());
 }
 
 }

--- a/ydb/public/lib/ydb_cli/common/recursive_remove_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove_ut.cpp
@@ -35,7 +35,7 @@ Y_UNIT_TEST(SecondPass) {
         removedEntries.emplace_back(entry);
         return TStatus(EStatus::SUCCESS, {});
     };
-    NInternal::RemovePathsRecursive(entries.begin(), entries.end(), remover, std::nullopt);
+    NInternal::RemovePathsRecursive(entries.begin(), entries.end(), remover, nullptr);
 
     std::swap(entries[1], entries[2]);
     UNIT_ASSERT_VALUES_EQUAL(removedEntries, entries);

--- a/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
@@ -65,21 +65,22 @@ Y_UNIT_TEST_SUITE(FormatEtaTests) {
     }
 
     Y_UNIT_TEST(Seconds) {
-        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(1)), "0m 1s");
-        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(30)), "0m 30s");
-        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(59)), "0m 59s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(1)), "1s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(30)), "30s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(59)), "59s");
     }
 
     Y_UNIT_TEST(Minutes) {
-        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(60)), "1m 0s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(60)), "1m");
         UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(90)), "1m 30s");
         UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3599)), "59m 59s");
     }
 
     Y_UNIT_TEST(Hours) {
-        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3600)), "1h 0m 0s");
-        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3661)), "1h 1m 1s");
-        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(7200)), "2h 0m 0s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3600)), "1h");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3660)), "1h 1m");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3661)), "1h 1m");  // seconds ignored when hours present
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(7200)), "2h");
     }
 }
 

--- a/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
@@ -1,0 +1,249 @@
+#include <ydb/public/lib/ydb_cli/common/print_utils.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/stream/str.h>
+
+using namespace NYdb::NConsoleClient;
+
+Y_UNIT_TEST_SUITE(FormatBytesTests) {
+    Y_UNIT_TEST(Zero) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(0), "0 B");
+    }
+
+    Y_UNIT_TEST(Bytes) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1), "1 B");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(512), "512 B");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1023), "1023 B");
+    }
+
+    Y_UNIT_TEST(KiB) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1024), "1 KiB");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1536), "1.5 KiB");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(10240), "10 KiB");
+    }
+
+    Y_UNIT_TEST(MiB) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1024 * 1024), "1 MiB");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1024 * 1024 * 100), "100 MiB");
+    }
+
+    Y_UNIT_TEST(GiB) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1024ULL * 1024 * 1024), "1 GiB");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1024ULL * 1024 * 1024 * 10), "10 GiB");
+    }
+
+    Y_UNIT_TEST(TiB) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatBytes(1024ULL * 1024 * 1024 * 1024), "1 TiB");
+    }
+}
+
+Y_UNIT_TEST_SUITE(FormatSpeedTests) {
+    Y_UNIT_TEST(Zero) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatSpeed(0), "0 B/s");
+    }
+
+    Y_UNIT_TEST(BytesPerSecond) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatSpeed(100), "100 B/s");
+    }
+
+    Y_UNIT_TEST(KiBPerSecond) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatSpeed(1024), "1 KiB/s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatSpeed(10240), "10 KiB/s");
+    }
+
+    Y_UNIT_TEST(MiBPerSecond) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatSpeed(1024 * 1024), "1 MiB/s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatSpeed(1024 * 1024 * 50), "50 MiB/s");
+    }
+}
+
+Y_UNIT_TEST_SUITE(FormatEtaTests) {
+    Y_UNIT_TEST(LessThanSecond) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::MilliSeconds(500)), "<1s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Zero()), "<1s");
+    }
+
+    Y_UNIT_TEST(Seconds) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(1)), "0m 1s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(30)), "0m 30s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(59)), "0m 59s");
+    }
+
+    Y_UNIT_TEST(Minutes) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(60)), "1m 0s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(90)), "1m 30s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3599)), "59m 59s");
+    }
+
+    Y_UNIT_TEST(Hours) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3600)), "1h 0m 0s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(3661)), "1h 1m 1s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatEta(TDuration::Seconds(7200)), "2h 0m 0s");
+    }
+}
+
+Y_UNIT_TEST_SUITE(FormatDurationTests) {
+    Y_UNIT_TEST(Zero) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Zero()), "0s");
+    }
+
+    Y_UNIT_TEST(Milliseconds) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::MilliSeconds(1)), "1ms");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::MilliSeconds(500)), "500ms");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::MilliSeconds(999)), "999ms");
+    }
+
+    Y_UNIT_TEST(Seconds) {
+        // Less than 10 seconds - shows decimal
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::MilliSeconds(1500)), "1.5s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(5)), "5.0s");
+        // 10 seconds or more - no decimal
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(10)), "10s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(59)), "59s");
+    }
+
+    Y_UNIT_TEST(Minutes) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(60)), "1m");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(90)), "1m 30s");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(3599)), "59m 59s");
+    }
+
+    Y_UNIT_TEST(Hours) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(3600)), "1h");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(3660)), "1h 1m");
+        UNIT_ASSERT_STRINGS_EQUAL(FormatDuration(TDuration::Seconds(7200)), "2h");
+    }
+}
+
+Y_UNIT_TEST_SUITE(FormatTimeTests) {
+    Y_UNIT_TEST(Zero) {
+        UNIT_ASSERT_STRINGS_EQUAL(FormatTime(TInstant::Zero()), "Unknown");
+    }
+
+    Y_UNIT_TEST(NonZero) {
+        TInstant time = TInstant::Seconds(1000000000);
+        TString result = FormatTime(time);
+        // Should be a valid RFC822 string, not "Unknown"
+        UNIT_ASSERT(result != "Unknown");
+        UNIT_ASSERT(result.size() > 0);
+    }
+}
+
+Y_UNIT_TEST_SUITE(PrettySizeTests) {
+    Y_UNIT_TEST(Zero) {
+        UNIT_ASSERT_STRINGS_EQUAL(PrettySize(0), "0B");
+    }
+
+    Y_UNIT_TEST(Small) {
+        UNIT_ASSERT_STRINGS_EQUAL(PrettySize(100), "100B");
+    }
+
+    Y_UNIT_TEST(Kilo) {
+        UNIT_ASSERT_STRINGS_EQUAL(PrettySize(1000), "1KB");
+        UNIT_ASSERT_STRINGS_EQUAL(PrettySize(1500), "1.5KB");
+    }
+
+    Y_UNIT_TEST(Mega) {
+        UNIT_ASSERT_STRINGS_EQUAL(PrettySize(1000000), "1MB");
+    }
+}
+
+Y_UNIT_TEST_SUITE(PrettyNumberTests) {
+    Y_UNIT_TEST(Zero) {
+        UNIT_ASSERT_STRINGS_EQUAL(PrettyNumber(0), "0");
+    }
+
+    Y_UNIT_TEST(Small) {
+        UNIT_ASSERT_STRINGS_EQUAL(PrettyNumber(100), "100");
+    }
+
+    Y_UNIT_TEST(Thousands) {
+        UNIT_ASSERT_STRINGS_EQUAL(PrettyNumber(1000), "1K");
+        UNIT_ASSERT_STRINGS_EQUAL(PrettyNumber(1500), "1.5K");
+    }
+
+    Y_UNIT_TEST(Millions) {
+        UNIT_ASSERT_STRINGS_EQUAL(PrettyNumber(1000000), "1M");
+    }
+}
+
+Y_UNIT_TEST_SUITE(BlurSecretTests) {
+    Y_UNIT_TEST(Empty) {
+        UNIT_ASSERT_STRINGS_EQUAL(BlurSecret(""), "");
+    }
+
+    Y_UNIT_TEST(Short) {
+        // Very short strings - less blurring
+        TString result = BlurSecret("abc");
+        UNIT_ASSERT_EQUAL(result.size(), 3u);
+    }
+
+    Y_UNIT_TEST(Medium) {
+        TString result = BlurSecret("12345678901234567890");
+        // First 5 and last 5 chars should be visible (10 = min(10, 20/4))
+        UNIT_ASSERT(result.StartsWith("12345"));
+        UNIT_ASSERT(result.EndsWith("67890"));
+        // Middle should be asterisks
+        UNIT_ASSERT(result.Contains("*"));
+    }
+
+    Y_UNIT_TEST(Long) {
+        TString input(100, 'x');
+        TString result = BlurSecret(input);
+        UNIT_ASSERT_EQUAL(result.size(), 100u);
+        // First 10 and last 10 should be 'x'
+        UNIT_ASSERT(result.substr(0, 10) == TString(10, 'x'));
+        UNIT_ASSERT(result.substr(90, 10) == TString(10, 'x'));
+        // Middle should be asterisks
+        UNIT_ASSERT(result[50] == '*');
+    }
+}
+
+Y_UNIT_TEST_SUITE(EntryTypeToStringTests) {
+    Y_UNIT_TEST(Directory) {
+        UNIT_ASSERT_STRINGS_EQUAL(EntryTypeToString(NYdb::NScheme::ESchemeEntryType::Directory), "dir");
+    }
+
+    Y_UNIT_TEST(Table) {
+        UNIT_ASSERT_STRINGS_EQUAL(EntryTypeToString(NYdb::NScheme::ESchemeEntryType::Table), "table");
+    }
+
+    Y_UNIT_TEST(ColumnTable) {
+        UNIT_ASSERT_STRINGS_EQUAL(EntryTypeToString(NYdb::NScheme::ESchemeEntryType::ColumnTable), "column-table");
+    }
+
+    Y_UNIT_TEST(Topic) {
+        UNIT_ASSERT_STRINGS_EQUAL(EntryTypeToString(NYdb::NScheme::ESchemeEntryType::Topic), "topic");
+    }
+
+    Y_UNIT_TEST(SubDomain) {
+        UNIT_ASSERT_STRINGS_EQUAL(EntryTypeToString(NYdb::NScheme::ESchemeEntryType::SubDomain), "sub-domain");
+    }
+
+    Y_UNIT_TEST(View) {
+        UNIT_ASSERT_STRINGS_EQUAL(EntryTypeToString(NYdb::NScheme::ESchemeEntryType::View), "view");
+    }
+
+    Y_UNIT_TEST(Unknown) {
+        UNIT_ASSERT_STRINGS_EQUAL(EntryTypeToString(NYdb::NScheme::ESchemeEntryType::Unknown), "unknown");
+    }
+}
+
+Y_UNIT_TEST_SUITE(PrintPermissionsTests) {
+    Y_UNIT_TEST(Empty) {
+        TStringStream ss;
+        std::vector<NYdb::NScheme::TPermissions> permissions;
+        PrintPermissions(permissions, ss);
+        UNIT_ASSERT_STRINGS_EQUAL(ss.Str(), "none\n");
+    }
+
+    Y_UNIT_TEST(Single) {
+        TStringStream ss;
+        std::vector<NYdb::NScheme::TPermissions> permissions;
+        NYdb::NScheme::TPermissions perm("user@domain", {"read", "write"});
+        permissions.push_back(perm);
+        PrintPermissions(permissions, ss);
+        UNIT_ASSERT_STRINGS_EQUAL(ss.Str(), "user@domain:read,write\n");
+    }
+}

--- a/ydb/public/lib/ydb_cli/common/ut/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ut/ya.make
@@ -7,6 +7,7 @@ SRCS(
     duration_ut.cpp
     normalize_path_ut.cpp
     pg_dump_parser_ut.cpp
+    print_utils_ut.cpp
     recursive_remove_ut.cpp
 )
 

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -12,6 +12,7 @@ SRCS(
     log.cpp
     csv_parser.cpp
     describe.cpp
+    download_manager.cpp
     duration.cpp
     examples.cpp
     format.cpp
@@ -50,10 +51,12 @@ PEERDIR(
     contrib/libs/yaml-cpp
     contrib/restricted/patched/replxx
     library/cpp/getopt
+    library/cpp/http/simple
     library/cpp/json/writer
     library/cpp/logger
     library/cpp/regex/pcre
     library/cpp/string_utils/csv
+    library/cpp/string_utils/url
     library/cpp/yaml/as
     ydb/public/lib/json_value
     ydb/public/sdk/cpp/src/library/operation_id

--- a/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
+++ b/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
@@ -99,13 +99,12 @@ int TYdbUpdater::Update(bool forceUpdate) {
                 progressBar.SetTotal(total);
             }
             progressBar.SetProgress(downloaded);
-        },
-        TDuration::Seconds(60),
-        TDuration::Minutes(30)
+        }
     );
 
     if (!downloadResult.Success) {
         Cerr << Endl << "Failed to download from url \"" << downloadUrl << "\". " << downloadResult.ErrorMessage << Endl;
+        Cerr << "If the problem persists, consider reinstalling YDB CLI: https://ydb.tech/docs/en/reference/ydb-cli/install" << Endl;
         tmpPathToBinary.DeleteIfExists();
         return EXIT_FAILURE;
     }
@@ -224,8 +223,7 @@ bool TYdbUpdater::GetLatestVersion() {
         SetConfigValue("last_check", TInstant::Now().Seconds());
         return true;
     }
-    Cerr << "(!) Couldn't get latest version from url \"" << versionUrl << "\". " << curlCmd.GetError() << Endl
-        << "You can disable further version checks with 'ydb version --disable-checks' command." << Endl;
+    Cerr << "(!) Couldn't get latest version from url \"" << versionUrl << "\". " << curlCmd.GetError() << Endl;
     return false;
 }
 
@@ -236,6 +234,7 @@ void TYdbUpdater::PrintUpdateMessageIfNeeded(bool forceVersionCheck) {
         return;
     }
     if (!GetLatestVersion()) {
+        Cerr << "You can disable further version checks with 'ydb version --disable-checks' command." << Endl;
         return;
     }
     if (MyVersion != LatestVersion) {

--- a/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
+++ b/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
@@ -1,6 +1,5 @@
 #include "ydb_updater.h"
 #include "download_manager.h"
-#include "print_utils.h"
 #include "progress_bar.h"
 
 #include <library/cpp/json/writer/json.h>
@@ -110,11 +109,7 @@ int TYdbUpdater::Update(bool forceUpdate) {
         tmpPathToBinary.DeleteIfExists();
         return EXIT_FAILURE;
     }
-    Cout << "Downloaded to " << tmpPathToBinary.GetPath() << " (" << FormatBytes(downloadResult.BytesDownloaded) << ")" << Endl;
-
-    if (true) {
-        return EXIT_SUCCESS;
-    }
+    Cout << "Downloaded to " << tmpPathToBinary.GetPath() << Endl;
 
 #ifndef _win32_
     int chmodResult = Chmod(tmpPathToBinary.GetPath().data(), MODE0777);

--- a/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
+++ b/ydb/public/lib/ydb_cli/common/ydb_updater.cpp
@@ -1,5 +1,6 @@
 #include "ydb_updater.h"
 #include "download_manager.h"
+#include "print_utils.h"
 #include "progress_bar.h"
 
 #include <library/cpp/json/writer/json.h>
@@ -110,6 +111,10 @@ int TYdbUpdater::Update(bool forceUpdate) {
         return EXIT_FAILURE;
     }
     Cout << "Downloaded to " << tmpPathToBinary.GetPath() << " (" << FormatBytes(downloadResult.BytesDownloaded) << ")" << Endl;
+
+    if (true) {
+        return EXIT_SUCCESS;
+    }
 
 #ifndef _win32_
     int chmodResult = Chmod(tmpPathToBinary.GetPath().data(), MODE0777);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

#### `ydb update` command
- Added real-time download progress bar with speed and ETA display
- Replaced shell `curl` call with native HTTP client (`TKeepAliveHttpClient`)
- Added helpful error message suggesting CLI reinstallation on download failure
- Fixed idle timeout (60s) to prevent hanging on network issues

#### Progress bars improvements
- Standardized byte units to MiB/GiB (binary) across all progress bars
- Added text caching (500ms) to prevent unreadable flickering of speed/size values
- Fixed speed calculation to use floating-point seconds for accuracy

#### `ydb import file` command
- Implemented dual progress bar showing:
  - Green: confirmed bytes (server acknowledged)
  - Grey: in-progress bytes (sent, awaiting confirmation)
- Progress now updates in non-interactive mode (every 10s)
- Fixed final progress reporting (was stuck at ~97%)

#### Other
- Added unit tests for `print_utils` formatting functions
- Moved version check hint to appropriate context (not shown during explicit `ydb update`)
