### PR TITLE
YQ-4849 supported precomputes in streaming queries

### DIFF
--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1505,7 +1505,7 @@ public:
             }
         }
 
-        // Ensure that last transactions can be saved
+        // Ensure that the last transaction can be saved
 
         const auto& txCtx = *QueryState->TxCtx;
         if (txCtx.TopicOperations.GetSize()) {

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1490,10 +1490,12 @@ public:
         for (size_t i = 0; i + 1 < txCount; ++i) {
             const auto tx = QueryState->PreparedQuery->GetPhyTx(i);
             bool hasWrites = tx->GetHasEffects();
-            for (const auto& stage : tx->GetStages()) {
-                if (hasWrites || stage.SinksSize()) {
-                    hasWrites = true;
-                    break;
+            if (!hasWrites) {
+                for (const auto& stage : tx->GetStages()) {
+                    if (stage.SinksSize()) {
+                        hasWrites = true;
+                        break;
+                    }
                 }
             }
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1485,7 +1485,7 @@ public:
             return false;
         }
 
-        // Ensure that transactions before last one is precomputes
+        // Ensure that the transactions before the last one are precomputes
 
         for (size_t i = 0; i + 1 < txCount; ++i) {
             const auto tx = QueryState->PreparedQuery->GetPhyTx(i);

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -926,6 +926,10 @@ public:
 
         QueryState->TxCtx->OnBeginQuery();
 
+        if (!CheckScriptExecutionState()) {
+            co_return;
+        }
+
         if (QueryState->NeedPersistentSnapshot()) {
             AcquirePersistentSnapshot();
             co_return;
@@ -1445,7 +1449,7 @@ public:
         return false;
     }
 
-    bool CheckScriptExecutionState(TKqpPhyTxHolder::TConstPtr tx, bool isBatchQuery) {
+    bool CheckScriptExecutionState() {
         if (!QueryState->SaveQueryPhysicalGraph) {
             return true;
         }
@@ -1459,7 +1463,8 @@ public:
             return false;
         }
 
-        if (isBatchQuery) {
+        const auto& phyQuery = QueryState->PreparedQuery->GetPhysicalQuery();
+        if (IsBatchQuery(phyQuery)) {
             ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, "Save state of query is not supported for batch queries");
             return false;
         }
@@ -1469,10 +1474,36 @@ public:
             return false;
         }
 
-        if (const auto txCount = QueryState->PreparedQuery->GetPhysicalQuery().TransactionsSize(); txCount != 1) {
-            ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, TStringBuilder() << "Save state of query supported only for exactly one transaction, but got: " << txCount);
+        if (phyQuery.ResultBindingsSize()) {
+            ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, "Save state of query is not supported for queries with results");
             return false;
         }
+
+        const auto txCount = phyQuery.TransactionsSize();
+        if (!txCount) {
+            ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, "Save state of query is not supported for empty queries");
+            return false;
+        }
+
+        // Ensure that transactions before last one is precomputes
+
+        for (size_t i = 0; i + 1 < txCount; ++i) {
+            const auto tx = QueryState->PreparedQuery->GetPhyTx(i);
+            bool hasWrites = tx->GetHasEffects();
+            for (const auto& stage : tx->GetStages()) {
+                if (hasWrites || stage.SinksSize()) {
+                    hasWrites = true;
+                    break;
+                }
+            }
+
+            if (hasWrites) {
+                ReplyQueryError(Ydb::StatusIds::UNSUPPORTED, "Save state of query is not supported for queries with intermediate writes");
+                return false;
+            }
+        }
+
+        // Ensure that last transactions can be saved
 
         const auto& txCtx = *QueryState->TxCtx;
         if (txCtx.TopicOperations.GetSize()) {
@@ -1492,16 +1523,7 @@ public:
             }
         }
 
-        if (!tx) {
-            if (txCtx.DeferredEffects.Empty()) {
-                // All transactions already finished
-                return true;
-            }
-            tx = txCtx.DeferredEffects.begin()->PhysicalTx;
-        }
-
-        YQL_ENSURE(tx);
-
+        const auto tx = QueryState->PreparedQuery->GetPhyTx(txCount - 1);
         for (const auto& stage : tx->GetStages()) {
             for (const auto& source : stage.GetSources()) {
                 // Solomon provider may use runtime listing,
@@ -1550,11 +1572,11 @@ public:
             ythrow TRequestFail(Ydb::StatusIds::BAD_REQUEST) << ex.what();
         }
 
-        const bool isBatchQuery = IsBatchQuery(QueryState->PreparedQuery->GetPhysicalQuery());
-        if (!CheckTransactionLocks(tx) || !CheckTopicOperations() || !CheckScriptExecutionState(tx, isBatchQuery)) {
+        if (!CheckTransactionLocks(tx) || !CheckTopicOperations()) {
             return;
         }
 
+        const bool isBatchQuery = IsBatchQuery(QueryState->PreparedQuery->GetPhysicalQuery());
         if (isBatchQuery && (!tx || !tx->IsLiteralTx())) {
             ExecutePartitioned(tx);
         } else if (QueryState->TxCtx->ShouldExecuteDeferredEffects()) {
@@ -1848,17 +1870,19 @@ public:
     }
 
     void SendToExecuter(TKqpTransactionContext* txCtx, IKqpGateway::TExecPhysicalRequest&& request, bool isRollback = false) {
+        bool allowSaveState = false;
         if (QueryState) {
             request.Orbit = std::move(QueryState->Orbit);
             QueryState->StatementResultSize = GetResultsCount(request);
+            allowSaveState = !isRollback && QueryState->CurrentTx + 1 == QueryState->PreparedQuery->GetPhysicalQuery().TransactionsSize();
         }
         request.PerRequestDataSizeLimit = RequestControls.PerRequestDataSizeLimit;
         request.MaxShardCount = RequestControls.MaxShardCount;
         request.TraceId = QueryState ? QueryState->KqpSessionSpan.GetTraceId() : NWilson::TTraceId();
         request.CaFactory_ = CaFactory_;
         request.ResourceManager_ = ResourceManager_;
-        request.SaveQueryPhysicalGraph = QueryState && QueryState->SaveQueryPhysicalGraph && request.Transactions.size() == 1 && !isRollback;
-        request.QueryPhysicalGraph = QueryState && !isRollback ? QueryState->QueryPhysicalGraph : nullptr;
+        request.SaveQueryPhysicalGraph = allowSaveState && QueryState->SaveQueryPhysicalGraph;
+        request.QueryPhysicalGraph = allowSaveState ? QueryState->QueryPhysicalGraph : nullptr;
         STLOG_D("Sending to Executer",
             (span_id_size, request.TraceId.GetSpanIdSize()),
             (trace_id, TraceId()));

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1450,7 +1450,7 @@ public:
     }
 
     bool CheckScriptExecutionState() {
-        if (!QueryState->SaveQueryPhysicalGraph) {
+        if (!QueryState || !QueryState->SaveQueryPhysicalGraph) {
             return true;
         }
 
@@ -1876,7 +1876,10 @@ public:
         if (QueryState) {
             request.Orbit = std::move(QueryState->Orbit);
             QueryState->StatementResultSize = GetResultsCount(request);
-            allowSaveState = !isRollback && QueryState->CurrentTx + 1 == QueryState->PreparedQuery->GetPhysicalQuery().TransactionsSize();
+
+            if (const auto& preparedQuery = QueryState->PreparedQuery) {
+                allowSaveState = !isRollback && QueryState->CurrentTx + 1 == preparedQuery->GetPhysicalQuery().TransactionsSize();
+            }
         }
         request.PerRequestDataSizeLimit = RequestControls.PerRequestDataSizeLimit;
         request.MaxShardCount = RequestControls.MaxShardCount;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported precomputes in streaming queries, for example:

```sql
$r = SELECT Value FROM table;

INSERT INTO pq_source.output_topic
SELECT
    Unwrap(Data || "-" || $r)
FROM pq_source.input_topic
```

`$r` - is precompute

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->
