### PR TITLE
Topic SDK: fix read stall on tablet restart

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -223,6 +223,12 @@ void TRawPartitionStreamEventQueue<UseMigrationProtocol>::DeleteNotReadyTail(TDe
         }
     }
 
+    for (auto& info : infos) {
+        if (info) {
+            info->OnDestroyReadSession();
+        }
+    }
+
     deferred.DeferDestroyDecompressionInfos(std::move(infos));
 
     swap(ready, NotReady);


### PR DESCRIPTION
When partition streams are destroyed during tablet restarts, DeleteNotReadyTail() collects decompression infos from not-ready events but did not call OnDestroyReadSession() on them.

The fix adds the missing OnDestroyReadSession() call, matching the pattern used in ~TSingleClusterReadSessionImpl() destructor.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
