### PR TITLE
Fix datashard crash when writing too many uncommitted changes

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
@@ -3349,13 +3349,14 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         auto locks2 = observer.LastLocks;
         observer.Inject = {};
 
-        // Write uncommitted changes to key 2 with tx 345
+        // Write uncommitted changes to key 1 and 2 with tx 345
+        // We expect write to key 1 to also be rolled back
         observer.Inject.LockId = 345;
         observer.Inject.LockNodeId = runtime.GetNodeId(0);
         observer.Inject.MvccSnapshot = snapshot;
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSimpleExec(runtime, Q_(R"(
-                UPSERT INTO `/Root/table-1` (key, value) VALUES (2, 23)
+                UPSERT INTO `/Root/table-1` (key, value) VALUES (1, 13), (2, 23)
                 )")),
             UseSink ? "ERROR: INTERNAL_ERROR" : "ERROR: GENERIC_ERROR");
         observer.Inject = {};

--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -673,7 +673,7 @@ void TWriteOperation::BuildExecutionPlan(bool loaded)
 }
 
 std::optional<TString> TWriteOperation::OnMigration(TDataShard& self, const TActorContext&) {
-    if (!IsImmediate() && HasVolatilePrepareFlag() && !HasCompletedFlag() && !HasResultSentFlag() && !Result()) {
+    if (!IsImmediate() && HasVolatilePrepareFlag() && !HasCompletedFlag() && !HasResultSentFlag() && !GetWriteResult()) {
         self.SendRestartNotification(this);
         return GetTxBody();
     }
@@ -749,7 +749,7 @@ bool TWriteOperation::OnStopping(TDataShard& self, const TActorContext& ctx) {
     } else if (HasVolatilePrepareFlag()) {
         // Volatile transactions may be aborted at any time unless executed,
         // but we want them to migrate and run to completion when possible.
-        if (!HasCompletedFlag() && !HasResultSentFlag() && !Result()) {
+        if (!HasCompletedFlag() && !HasResultSentFlag() && !GetWriteResult()) {
             // It is possible this transaction already migrated or will migrate soon
             self.SendRestartNotification(this);
             return false;

--- a/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
@@ -457,20 +457,9 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
 
         BuildResult(op, NKikimrTxDataShard::TEvProposeTransactionResult::EXEC_ERROR);
 
+        // Note: we don't return TxLocks in the reply since all changes are rolled back and lock is unaffected
         op->Result()->AddError(NKikimrTxDataShard::TError::SHARD_IS_BLOCKED,
             TStringBuilder() << "Shard " << DataShard.TabletID() << " cannot write more uncommitted changes");
-
-        for (auto& table : guardLocks.AffectedTables) {
-            Y_ENSURE(guardLocks.LockTxId);
-            op->Result()->AddTxLock(
-                guardLocks.LockTxId,
-                DataShard.TabletID(),
-                DataShard.Generation(),
-                Max<ui64>(),
-                table.GetTableId().OwnerId,
-                table.GetTableId().LocalPathId,
-                false);
-        }
 
         tx->ReleaseTxData(txc, ctx);
 

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -23,12 +23,14 @@ public:
     }
 
     bool IsReadyToExecute(TOperation::TPtr op) const override {
-        if (op->HasWaitingForGlobalTxIdFlag()) {
-            return false;
+        TWriteOperation* writeOp = TWriteOperation::CastWriteOperation(op);
+
+        if (writeOp->GetWriteResult() || op->HasResultSentFlag() || op->IsImmediate() && WillRejectDataTx(op)) {
+            return true;
         }
 
-        if (op->Result() || op->HasResultSentFlag() || op->IsImmediate() && WillRejectDataTx(op)) {
-            return true;
+        if (op->HasWaitingForGlobalTxIdFlag()) {
+            return false;
         }
 
         if (DataShard.IsStopping()) {
@@ -261,7 +263,7 @@ public:
 
         LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, "Executing write operation for " << *op << " at " << tabletId);
 
-        if (op->Result() || op->HasResultSentFlag() || op->IsImmediate() && CheckRejectDataTx(op, ctx)) {
+        if (writeOp->GetWriteResult() || op->HasResultSentFlag() || op->IsImmediate() && CheckRejectDataTx(op, ctx)) {
             return EExecutionStatus::Executed;
         }
 
@@ -575,20 +577,8 @@ public:
         } catch (const TLockedWriteLimitException&) {
             userDb.ResetCollectedChanges();
 
+            // Note: we don't return TxLocks in the reply since all changes are rolled back and lock is unaffected
             writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, TStringBuilder() << "Shard " << tabletId << " cannot write more uncommitted changes");
-
-            for (auto& table : guardLocks.AffectedTables) {
-                Y_ENSURE(guardLocks.LockTxId);
-                op->Result()->AddTxLock(
-                    guardLocks.LockTxId,
-                    tabletId,
-                    DataShard.Generation(),
-                    Max<ui64>(),
-                    table.GetTableId().OwnerId,
-                    table.GetTableId().LocalPathId,
-                    false
-                );
-            }
 
             // Transaction may have made some changes before it hit the limit,
             // so we need to roll them back.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix datashard crashing when per-key uncommitted changes limit is exceeded with OLTP sink feature enabled. Fixes #32391.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

I also noticed that `op->Result()` is sometimes used incorrectly when handling EvWrites elsewhere.
