### PR TITLE
sync ca: input producer watermark fixes

### DIFF
--- a/ydb/library/yql/dq/runtime/dq_input_producer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_input_producer.cpp
@@ -198,14 +198,16 @@ private:
     }
 
     bool TrySendWatermark() {
-        if (!WatermarksEnabled()) {
+        if (!Watermark || !WatermarksEnabled()) {
             return false;
         }
-        if (!Watermark || !WatermarksTracker->NotifyInputWatermarkReceived(InputKey.InputId, InputKey.IsChannel, *Watermark) || !WatermarksTracker->HasPendingWatermark()) {
-            return false;
+        auto hasPendingWatermark = WatermarksTracker->NotifyInputWatermarkReceived(InputKey.InputId, InputKey.IsChannel, *Watermark) && WatermarksTracker->HasPendingWatermark();
+        Watermark.Clear();
+        if (hasPendingWatermark) {
+            WatermarkStorage->WatermarkIn = WatermarksTracker->GetPendingWatermark();
+            return true;
         }
-        WatermarkStorage->WatermarkIn = WatermarksTracker->GetPendingWatermark();
-        return true;
+        return false;
     }
 
 private:

--- a/ydb/library/yql/dq/runtime/dq_input_producer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_input_producer.cpp
@@ -75,7 +75,7 @@ private:
             return NUdf::EFetchStatus::Yield;
         }
 
-        if (Batch.empty()) {
+        while (Batch.empty()) {
             // pass watermark and wait for drain only if watermarks enabled
             if (TrySendWatermark()) {
                 return NUdf::EFetchStatus::Yield;
@@ -92,12 +92,6 @@ private:
                     [[fallthrough]];
                 case NUdf::EFetchStatus::Yield:
                     return status;
-            }
-
-            // pass watermark and wait for drain only if watermarks enabled and batch is still empty
-            if (Batch.empty()) {
-                TrySendWatermark();
-                return NUdf::EFetchStatus::Yield;
             }
         }
 
@@ -122,7 +116,7 @@ private:
             return NUdf::EFetchStatus::Yield;
         }
 
-        if (Batch.empty()) {
+        while (Batch.empty()) {
             // pass watermark and wait for drain only if watermarks enabled
             if (TrySendWatermark()) {
                 return NUdf::EFetchStatus::Yield;
@@ -139,12 +133,6 @@ private:
                     [[fallthrough]];
                 case NUdf::EFetchStatus::Yield:
                     return status;
-            }
-
-            // pass watermark and wait for drain only if watermarks enabled and batch is still empty
-            if (Batch.empty()) {
-                TrySendWatermark();
-                return NUdf::EFetchStatus::Yield;
             }
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

1) после передачи ватермарки в watermark tracker она оставалась определённой, это могло приводить к повторной или некорректной отсылки ватермарки с другим каналом/входом (некоторые реализации `Pop` могут оставлять старое значение ватермарки); скорее всего, путаницу с входами получить на практике невозможно, но хрупкость надо в любом случае исправлять;
2) если какой-то вход пуст, в нём была ватермарка, но ватермарк-трекер не вернул ватермарку, возвращался yield, хотя в других входах могли быть ещё данные/ватермарки; теоретически на этом можно подзависнуть (до прихода новой порции с данными)
