### PR TITLE
Fix datashard SnapshotRW isolation errors in some operations

### DIFF
--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -47,12 +47,18 @@ NTable::EReady TDataShardUserDb::SelectRow(
 
     SetPerformedUserReads(true);
 
+    auto version = MvccVersion;
+    if (LockMode == ELockMode::OptimisticSnapshotIsolation && SnapshotVersion < version) {
+        // We want to keep using snapshot version at commit time in SnapshotRW isolation
+        version = SnapshotVersion;
+    }
+
     NTable::EReady ready = Db.Select(tid, key, tags, row, stats, /* readFlags */ 0,
-        MvccVersion,
+        version,
         GetReadTxMap(tableId),
         GetReadTxObserver(tableId));
 
-    if (stats.InvisibleRowSkips > 0) {
+    if (LockMode != ELockMode::OptimisticSnapshotIsolation && stats.InvisibleRowSkips > 0) {
         if (LockTxId) {
             Self.SysLocksTable().BreakSetLocks();
         }
@@ -219,7 +225,7 @@ void TDataShardUserDb::UpdateRow(
     Y_ENSURE(localTableId != 0, "Unexpected UpdateRow for an unknown table");
 
     if (!RowExists(tableId, key)) {
-        if (LockTxId) {
+        if (LockTxId && LockMode != ELockMode::OptimisticSnapshotIsolation) {
             // We don't perform an update, but this key may be modified later
             // by a different transaction. Make sure we set the read lock to
             // guard against that.
@@ -288,6 +294,15 @@ void TDataShardUserDb::EraseRow(
 {
     auto localTableId = Self.GetLocalTableId(tableId);
     Y_ENSURE(localTableId != 0, "Unexpected UpdateRow for an unknown table");
+
+    if (LockMode == ELockMode::OptimisticSnapshotIsolation) {
+        if (!RowExists(tableId, key)) {
+            // Don't perform write for keys which don't exist, SnapshotRW
+            // transaction may break otherwise even when not actually
+            // performing operations from the user's viewpoint
+            return;
+        }
+    }
 
     UpsertRowInt(NTable::ERowOp::Erase, tableId, localTableId, key, {});
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

DataShard in SnapshotRW isolation was taking unnecessary read locks, and wasn't performing internal reads using the initial snapshot version. Fix datashard to keep using snapshot for all reads in SnapshotRW and never take any read locks, only checking for conflicts on writes. Fixes #32398.