### PR TITLE
Temporary fix build under Windows

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_import_getters_fallback.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters_fallback.cpp
@@ -49,6 +49,11 @@ IActor* CreateSchemeGetter(const TActorId& replyTo, TImportInfo::TPtr importInfo
     return new TSchemeGetterFallback(replyTo, std::move(importInfo), itemIdx);
 }
 
+// TODO: move standard implementation to separate file and support build under Windows
+IActor* CreateSchemeGetterFS(const TActorId& replyTo, TImportInfo::TPtr importInfo, ui32 itemIdx) {
+    return new TSchemeGetterFallback(replyTo, std::move(importInfo), itemIdx);
+}
+
 IActor* CreateSchemaMappingGetter(const TActorId& replyTo, TImportInfo::TPtr importInfo) {
     return new TSchemaMappingGetterFallback(replyTo, std::move(importInfo));
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`ydb/core/tx/schemeshard/schemeshard_import_getters_fallback.cpp` file must contain the same set of functions as the file `ydb/core/tx/schemeshard/schemeshard_import_getters.cpp` in order to build under Windows. I temporary made a simple implementation of `CreateSchemeGetterFS` function there. As a normal fix we should maybe move this function in some common cpp-file, because it does not use S3 functionality.
