### PR TITLE
[NBS-6758]: read, write events for NBS 2, grpc draft api

### DIFF
--- a/library/cpp/lwtrace/protos/ya.make
+++ b/library/cpp/lwtrace/protos/ya.make
@@ -6,6 +6,4 @@ SRCS(
     lwtrace.proto
 )
 
-CPP_PROTO_PLUGIN0(validation ydb/public/lib/validation)
-
 END()

--- a/library/cpp/lwtrace/protos/ya.make
+++ b/library/cpp/lwtrace/protos/ya.make
@@ -6,4 +6,6 @@ SRCS(
     lwtrace.proto
 )
 
+CPP_PROTO_PLUGIN0(validation ydb/public/lib/validation)
+
 END()

--- a/ydb/apps/dstool/lib/commands.py
+++ b/ydb/apps/dstool/lib/commands.py
@@ -44,6 +44,7 @@ import ydb.apps.dstool.lib.dstool_cmd_cluster_workload_run as cluster_workload_r
 
 import ydb.apps.dstool.lib.dstool_cmd_nbs_partition_create as nbs_partition_create
 import ydb.apps.dstool.lib.dstool_cmd_nbs_partition_delete as nbs_partition_delete
+import ydb.apps.dstool.lib.dstool_cmd_nbs_partition_io as nbs_partition_io
 
 import sys
 import ydb.apps.dstool.lib.common as common
@@ -59,7 +60,7 @@ modules = [
     group_state, group_take_snapshot, group_add, group_list, group_virtual_create, group_virtual_cancel, group_virtual_reconfigure,
     pdisk_add_by_serial, pdisk_remove_by_serial, pdisk_set, pdisk_list, pdisk_stop, pdisk_restart, pdisk_readonly, pdisk_move,
     vdisk_evict, vdisk_list, vdisk_set_read_only, vdisk_remove_donor, vdisk_wipe, vdisk_compact, device_list,
-    nbs_partition_create, nbs_partition_delete,
+    nbs_partition_create, nbs_partition_delete, nbs_partition_io,
 ]
 
 default_structure = [
@@ -71,7 +72,7 @@ default_structure = [
     ('box', ['list']),
     ('node', ['list']),
     ('cluster', ['balance', 'get', 'set', ('workload', ['run']), 'list']),
-    ('nbs', [('partition', ['create', 'delete'])]),
+    ('nbs', [('partition', ['create', 'delete', 'io'])]),
 ]
 
 

--- a/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_delete.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_delete.py
@@ -19,7 +19,7 @@ def do(args):
     request = nbs.DeletePartitionRequest(TabletId=args.id)
     response = invoke_nbs_request('DeletePartition', request)
 
-    common.print_request_result(args, request, response)
+    common.print_nbs_request_result(args, request, response)
 
 
 def invoke_nbs_request(request_type, request):

--- a/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_io.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_nbs_partition_io.py
@@ -1,0 +1,46 @@
+import ydb.apps.dstool.lib.common as common
+import ydb.public.api.protos.draft.ydb_nbs_pb2 as nbs
+import ydb.core.nbs.cloud.blockstore.public.api.protos.io_pb2 as nbs_io
+
+
+description = 'Send IO to NBS 2.0 partition'
+
+
+def add_options(p):
+    p.add_argument('--id', type=str, required=True, help='Partition tablet id')
+    p.add_argument('--start_index', type=int, default=0, help='Offset')
+    p.add_argument('--blocks_count', type=int, default=1, help='Count of blocks (fore read operations)')
+    p.add_argument('--data', type=str, default="test_data", help='Data (for write operations)')
+    p.add_argument('--type', type=str, default="write", help='Operation type (write/read)')
+
+
+def is_successful_response(response):
+    return response.Success
+
+
+def do(args):
+    if args.type == "write":
+        do_write(args)
+    elif args.type == "read":
+        do_read(args)
+    else:
+        raise ValueError("Unknown operation type")
+
+
+def do_write(args):
+    blocks = nbs_io.TIOVector(Buffers=[args.data.encode()])
+    req_data = nbs_io.TWriteBlocksRequest(DiskId=args.id, StartIndex=args.start_index, Blocks=blocks)
+    request = nbs.WriteBlocksRequest(request=req_data)
+    response = common.invoke_nbs_request('WriteBlocks', request)
+
+    common.print_nbs_request_result(args, request, response)
+
+
+def do_read(args):
+    req_data = nbs_io.TReadBlocksRequest(DiskId=args.id, StartIndex=args.start_index, BlocksCount=args.blocks_count)
+    request = nbs.ReadBlocksRequest(request=req_data)
+    response = common.invoke_nbs_request('ReadBlocks', request)
+
+    common.print_nbs_request_result(args, request, response)
+
+    print(response)

--- a/ydb/apps/dstool/lib/ya.make
+++ b/ydb/apps/dstool/lib/ya.make
@@ -55,6 +55,7 @@ PY_SRCS(
 
     dstool_cmd_nbs_partition_create.py
     dstool_cmd_nbs_partition_delete.py
+    dstool_cmd_nbs_partition_io.py
 )
 
 PEERDIR(
@@ -62,6 +63,7 @@ PEERDIR(
     ydb/public/api/protos
     ydb/public/api/grpc
     ydb/public/api/grpc/draft
+    ydb/core/nbs/cloud/blockstore/public/api/protos
 )
 
 END()

--- a/ydb/core/base/events.h
+++ b/ydb/core/base/events.h
@@ -195,6 +195,7 @@ struct TKikimrEvents : TEvents {
         ES_COUNTERS_INFO = 4272,
         ES_SASL_AUTH = 4273,
         ES_DDISK = 4274,
+        ES_NBS_V2 = 4275,
     };
 };
 

--- a/ydb/core/grpc_services/rpc_nbs_io.cpp
+++ b/ydb/core/grpc_services/rpc_nbs_io.cpp
@@ -1,0 +1,123 @@
+#include "rpc_deferrable.h"
+
+#include <ydb/core/grpc_services/rpc_common/rpc_common.h>
+#include <ydb/core/base/auth.h>
+#include <ydb/core/driver_lib/run/grpc_servers_manager.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h>
+#include <ydb/public/api/protos/draft/ydb_nbs.pb.h>
+
+namespace NKikimr::NGRpcService {
+
+
+using TEvOpWriteBlocksRequest =
+    TGrpcRequestOperationCall<NYdb::NBS::NProto::WriteBlocksRequest,
+        NYdb::NBS::NProto::WriteBlocksResponse>;
+using TEvOpReadBlocksRequest =
+    TGrpcRequestOperationCall<NYdb::NBS::NProto::ReadBlocksRequest,
+        NYdb::NBS::NProto::ReadBlocksResponse>;
+
+using namespace NActors;
+using namespace Ydb;
+
+class TWriteBlocksRequestHandler
+    : public TRpcOperationRequestActor<TWriteBlocksRequestHandler, TEvOpWriteBlocksRequest> {
+
+public:
+    TWriteBlocksRequestHandler(IRequestOpCtx* request)
+        : TRpcOperationRequestActor(request) {}
+
+    void Bootstrap() {
+        const auto& ctx = TActivationContext::AsActorContext();
+
+        Become(&TThis::StateWork);
+
+        auto req = GetProtoRequest()->Getrequest();
+        auto diskIdStr = req.GetDiskId();
+
+        // For now diskIdStr == partition actor id
+        NActors::TActorId tabletId;
+        tabletId.Parse(diskIdStr.data(), diskIdStr.size());
+
+        // Construct WriteBlocks request event from the protobuf request
+        auto callContext = MakeIntrusive<NYdb::NBS::TCallContext>();
+        auto request = std::make_unique<NYdb::NBS::TEvService::TEvWriteBlocksRequest>(callContext, req);
+
+        // Send event to partition actor
+        ctx.Send(new IEventHandle(tabletId, ctx.SelfID, request.release()));
+
+        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
+            "Grpc service: sent WriteBlocksRequest to partition: %s",
+            diskIdStr.data());
+    }
+
+private:
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NYdb::NBS::TEvService::TEvWriteBlocksResponse, Handle);
+        }
+    }
+
+    void Handle(NYdb::NBS::TEvService::TEvWriteBlocksResponse::TPtr& ev) {
+        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
+            "Grpc service: received WriteBlocksResponse from partition: %s",
+            ev->Sender.ToString().data());
+        ReplyWithResult(Ydb::StatusIds::SUCCESS, ev->Get()->Record, ActorContext());
+    }
+};
+
+
+class TReadBlocksRequestHandler
+    : public TRpcOperationRequestActor<TReadBlocksRequestHandler, TEvOpReadBlocksRequest> {
+
+public:
+    TReadBlocksRequestHandler(IRequestOpCtx* request)
+        : TRpcOperationRequestActor(request) {}
+
+    void Bootstrap() {
+        const auto& ctx = TActivationContext::AsActorContext();
+
+        Become(&TThis::StateWork);
+
+        auto req = GetProtoRequest()->Getrequest();
+        auto diskIdStr = req.GetDiskId();
+
+        // For now diskIdStr == partition actor id
+        NActors::TActorId tabletId;
+        tabletId.Parse(diskIdStr.data(), diskIdStr.size());
+
+        // Construct ReadBlocks request event from the protobuf request
+        auto callContext = MakeIntrusive<NYdb::NBS::TCallContext>();
+        auto request = std::make_unique<NYdb::NBS::TEvService::TEvReadBlocksRequest>(callContext, req);
+
+        // Send event to partition actor
+        ctx.Send(new IEventHandle(tabletId, ctx.SelfID, request.release()));
+
+        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
+            "Grpc service: sent ReadBlocksRequest to partition: %s",
+            diskIdStr.data());
+    }
+
+private:
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NYdb::NBS::TEvService::TEvReadBlocksResponse, Handle);
+        }
+    }
+
+    void Handle(NYdb::NBS::TEvService::TEvReadBlocksResponse::TPtr& ev) {
+        LOG_DEBUG(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
+            "Grpc service: received ReadBlocksResponse from partition: %s",
+            ev->Sender.ToString().data());
+        ReplyWithResult(Ydb::StatusIds::SUCCESS, ev->Get()->Record, ActorContext());
+    }
+};
+
+void DoWriteBlocks(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
+    TActivationContext::AsActorContext().Register(new TWriteBlocksRequestHandler(p.release()));
+}
+
+void DoReadBlocks(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
+    TActivationContext::AsActorContext().Register(new TReadBlocksRequestHandler(p.release()));
+}
+
+} // namespace NKikimr::NGRpcService

--- a/ydb/core/grpc_services/service_nbs.h
+++ b/ydb/core/grpc_services/service_nbs.h
@@ -11,4 +11,7 @@ namespace NKikimr::NGRpcService {
     void DoDeletePartition(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&);
     void DoListPartitions(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&);
 
+    void DoWriteBlocks(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&);
+    void DoReadBlocks(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&);
+
 } // NKikimr::NGRpcService

--- a/ydb/core/grpc_services/ya.make
+++ b/ydb/core/grpc_services/ya.make
@@ -73,6 +73,7 @@ SRCS(
     rpc_modify_permissions.cpp
     rpc_monitoring.cpp
     rpc_nbs.cpp
+    rpc_nbs_io.cpp
     rpc_node_registration.cpp
     rpc_object_storage.cpp
     rpc_ping.cpp
@@ -136,7 +137,10 @@ PEERDIR(
     ydb/core/io_formats/ydb_dump
     ydb/core/kesus/tablet
     ydb/core/kqp/common
+    ydb/core/nbs/cloud/blockstore/libs/service
     ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct
+    ydb/core/nbs/cloud/blockstore/public/api/protos
+    ydb/core/nbs/cloud/storage/core/libs/common
     ydb/core/protos
     ydb/core/scheme
     ydb/core/sys_view

--- a/ydb/core/jaeger_tracing/request_discriminator.h
+++ b/ydb/core/jaeger_tracing/request_discriminator.h
@@ -126,6 +126,8 @@ enum class ERequestType: size_t {
     NBS_CREATEPARTITION,
     NBS_DELETEPARTITION,
     NBS_LISTPARTITIONS,
+    NBS_WRITEBLOCKS,
+    NBS_READBLOCKS,
 
     REQUEST_TYPES_CNT, // Add new types above this line
 };

--- a/ydb/core/nbs/cloud/blockstore/libs/kikimr/events.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/kikimr/events.cpp
@@ -1,0 +1,1 @@
+#include "events.h"

--- a/ydb/core/nbs/cloud/blockstore/libs/kikimr/events.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/kikimr/events.h
@@ -1,0 +1,223 @@
+#pragma once
+
+#include "public.h"
+
+#include <ydb/core/nbs/cloud/blockstore/libs/service/context.h>
+#include <ydb/core/nbs/cloud/storage/core/libs/common/error.h>
+
+#include <ydb/library/actors/core/event.h>
+#include <ydb/library/actors/core/event_local.h>
+#include <ydb/library/actors/core/event_pb.h>
+
+#include <library/cpp/lwtrace/shuttle.h>
+
+#include <util/generic/string.h>
+#include <util/generic/typetraits.h>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TEmpty
+{
+    static TString Name()
+    {
+        return "Empty";
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TArgs, ui32 EventId>
+struct TRequestEvent
+    : public NActors::TEventLocal<TRequestEvent<TArgs, EventId>, EventId>
+    , public TArgs
+{
+    TCallContextPtr CallContext = MakeIntrusive<TCallContext>();
+
+    TRequestEvent() = default;
+
+    template <typename ...Args>
+    TRequestEvent(TCallContextPtr callContext, Args&& ...args)
+        : TArgs(std::forward<Args>(args)...)
+        , CallContext(std::move(callContext))
+    {
+    }
+
+    template <typename ...Args>
+    TRequestEvent(Args&& ...args)
+        : TArgs(std::forward<Args>(args)...)
+    {
+    }
+
+    static TString Name()
+    {
+        return TypeName<TArgs>();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TArgs, ui32 EventId>
+struct TResponseEvent
+    : public NActors::TEventLocal<TResponseEvent<TArgs, EventId>, EventId>
+    , public TArgs
+{
+    const NProto::TError Error;
+
+    TResponseEvent() = default;
+
+    template <
+        typename T1,
+        typename = std::enable_if_t<
+            !std::is_convertible<T1, NProto::TError>::value &&
+            !std::is_same<std::decay_t<T1>, TResponseEvent<TArgs, EventId>>::
+                value>,
+        typename... Args>
+    explicit TResponseEvent(T1&& a1, Args&&... args)
+        : TArgs(std::forward<T1>(a1), std::forward<Args>(args)...)
+    {}
+
+    template <typename... Args>
+    explicit TResponseEvent(NProto::TError error, Args&&... args)
+        : TArgs(std::forward<Args>(args)...)
+        , Error(std::move(error))
+    {}
+
+    const NProto::TError& GetError() const
+    {
+        return Error;
+    }
+
+    ui32 GetStatus() const
+    {
+        return GetError().GetCode();
+    }
+
+    const TString& GetErrorReason() const
+    {
+        return GetError().GetMessage();
+    }
+
+    static TString Name()
+    {
+        return TypeName<TArgs>();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TArgs, ui32 EventId>
+struct TProtoRequestEvent
+    : public NActors::TEventPB<TProtoRequestEvent<TArgs, EventId>, TArgs, EventId>
+{
+    TCallContextPtr CallContext = MakeIntrusive<TCallContext>();
+
+    TProtoRequestEvent() = default;
+
+    TProtoRequestEvent(TCallContextPtr callContext)
+        : CallContext(std::move(callContext))
+    {
+    }
+
+    template <typename T>
+    TProtoRequestEvent(TCallContextPtr callContext, T&& proto)
+        : CallContext(std::move(callContext))
+    {
+        TProtoRequestEvent::Record = std::forward<T>(proto);
+    }
+
+    static TString Name()
+    {
+        return TypeName<TArgs>();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TArgs, ui32 EventId>
+struct TProtoResponseEvent
+    : public NActors::TEventPB<TProtoResponseEvent<TArgs, EventId>, TArgs, EventId>
+{
+    TProtoResponseEvent() = default;
+
+    template <typename T, typename = std::enable_if_t<!std::is_convertible<T, NProto::TError>::value>>
+    TProtoResponseEvent(T&& proto)
+    {
+        TProtoResponseEvent::Record = std::forward<T>(proto);
+    }
+
+    TProtoResponseEvent(const NProto::TError& error)
+    {
+        if (error.GetCode() != 0 || !error.GetMessage().empty()) {
+            *TProtoResponseEvent::Record.MutableError() = error;
+        }
+    }
+
+    const NProto::TError& GetError() const
+    {
+        return TProtoResponseEvent::Record.GetError();
+    }
+
+    ui32 GetStatus() const
+    {
+        return GetError().GetCode();
+    }
+
+    const TString& GetErrorReason() const
+    {
+        return GetError().GetMessage();
+    }
+
+    static TString Name()
+    {
+        return TypeName<TArgs>();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define BLOCKSTORE_DECLARE_EVENT_IDS(name, ...)                                \
+        Ev##name##Request,                                                     \
+        Ev##name##Response,                                                    \
+// BLOCKSTORE_DECLARE_EVENT_IDS
+
+#define BLOCKSTORE_DECLARE_REQUEST(name, ...)                                  \
+    struct T##name##Method                                                     \
+    {                                                                          \
+        static constexpr const char* Name = #name;                             \
+                                                                               \
+        using TRequest = TEv##name##Request;                                   \
+        using TResponse = TEv##name##Response;                                 \
+    };                                                                         \
+// BLOCKSTORE_DECLARE_REQUEST
+
+#define BLOCKSTORE_DECLARE_EVENTS(name, ...)                                   \
+    using TEv##name##Request = TRequestEvent<                                  \
+        T##name##Request,                                                      \
+        Ev##name##Request                                                      \
+    >;                                                                         \
+                                                                               \
+    using TEv##name##Response = TResponseEvent<                                \
+        T##name##Response,                                                     \
+        Ev##name##Response                                                     \
+    >;                                                                         \
+                                                                               \
+    BLOCKSTORE_DECLARE_REQUEST(name, __VA_ARGS__)                              \
+// BLOCKSTORE_DECLARE_EVENTS
+
+#define BLOCKSTORE_DECLARE_PROTO_EVENTS(name, ...)                             \
+    using TEv##name##Request = TProtoRequestEvent<                             \
+        NProto::T##name##Request,                                              \
+        Ev##name##Request                                                      \
+    >;                                                                         \
+                                                                               \
+    using TEv##name##Response = TProtoResponseEvent<                           \
+        NProto::T##name##Response,                                             \
+        Ev##name##Response                                                     \
+    >;                                                                         \
+                                                                               \
+    BLOCKSTORE_DECLARE_REQUEST(name, __VA_ARGS__)                              \
+// BLOCKSTORE_DECLARE_PROTO_EVENTS
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/blockstore/libs/kikimr/public.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/kikimr/public.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/ydb/core/nbs/cloud/blockstore/libs/kikimr/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/kikimr/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+SRCS(
+    events.cpp
+)
+
+PEERDIR(
+    ydb/library/actors/core
+    ydb/core/protos
+)
+
+END()

--- a/ydb/core/nbs/cloud/blockstore/libs/service/context.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/service/context.cpp
@@ -1,0 +1,33 @@
+#include "context.h"
+
+#include <util/datetime/cputimer.h>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCallContext::TCallContext(ui64 requestId)
+    : TCallContextBase(requestId)
+{}
+
+bool TCallContext::GetSilenceRetriableErrors() const
+{
+    return AtomicGet(SilenceRetriableErrors);
+}
+
+void TCallContext::SetSilenceRetriableErrors(bool silence)
+{
+    AtomicSet(SilenceRetriableErrors, silence);
+}
+
+bool TCallContext::GetHasUncountableRejects() const
+{
+    return AtomicGet(HasUncountableRejects);
+}
+
+void TCallContext::SetHasUncountableRejects()
+{
+    AtomicSet(HasUncountableRejects, true);
+}
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/blockstore/libs/service/context.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/service/context.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "public.h"
+
+#include <ydb/core/nbs/cloud/storage/core/libs/common/context.h>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCallContext final
+    : public TCallContextBase
+{
+private:
+    TAtomic SilenceRetriableErrors = false;
+    TAtomic HasUncountableRejects = false;
+
+public:
+    TCallContext(ui64 requestId = 0);
+
+    bool GetSilenceRetriableErrors() const;
+    void SetSilenceRetriableErrors(bool silence);
+
+    bool GetHasUncountableRejects() const;
+    void SetHasUncountableRejects();
+};
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/blockstore/libs/service/public.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/service/public.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <util/generic/ptr.h>
+
+#include <memory>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCallContext;
+using TCallContextPtr = TIntrusivePtr<TCallContext>;
+
+struct IBlockStore;
+using IBlockStorePtr = std::shared_ptr<IBlockStore>;
+
+struct IAuthProvider;
+using IAuthProviderPtr = std::shared_ptr<IAuthProvider>;
+
+struct IStorage;
+using IStoragePtr = std::shared_ptr<IStorage>;
+
+struct IStorageProvider;
+using IStorageProviderPtr = std::shared_ptr<IStorageProvider>;
+
+struct IDeviceHandler;
+using IDeviceHandlerPtr = std::shared_ptr<IDeviceHandler>;
+
+struct IDeviceHandlerFactory;
+using IDeviceHandlerFactoryPtr = std::shared_ptr<IDeviceHandlerFactory>;
+
+using TStorageBuffer = std::shared_ptr<char>;
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/blockstore/libs/service/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/service/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+SRCS(
+    context.cpp
+)
+
+PEERDIR(
+    ydb/core/nbs/cloud/storage/core/libs/common
+    ydb/core/nbs/cloud/blockstore/public/api/protos
+)
+
+END()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/api/service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/api/service.cpp
@@ -1,0 +1,14 @@
+#include "service.h"
+
+namespace NYdb::NBS::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TActorId MakeStorageServiceId()
+{
+    return TActorId(0, "blk-service");
+}
+
+}   // namespace NYdb::NBS::NStorage

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ydb/core/base/events.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/kikimr/events.h>
+#include <ydb/core/nbs/cloud/blockstore/public/api/protos/io.pb.h>
+#include <ydb/library/actors/core/actorid.h>
+
+
+namespace NYdb::NBS {
+
+    struct TEvService {
+
+        //
+        // Events declaration
+        //
+
+        enum EEvents
+        {
+            EvBegin = EventSpaceBegin(NKikimr::TKikimrEvents::ES_NBS_V2),
+
+            EvReadBlocksRequest,
+            EvReadBlocksResponse,
+
+            EvWriteBlocksRequest,
+            EvWriteBlocksResponse,
+        };
+
+        BLOCKSTORE_DECLARE_PROTO_EVENTS(WriteBlocks)
+        BLOCKSTORE_DECLARE_PROTO_EVENTS(ReadBlocks)
+    };
+
+} // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/api/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/api/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+SRCS(
+    service.cpp
+)
+
+PEERDIR(
+    ydb/core/nbs/cloud/blockstore/public/api/protos
+    ydb/library/actors/core
+)
+
+END()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct.cpp
@@ -3,7 +3,7 @@
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/core/base/appdata_fwd.h>
 
-namespace NCloud::NBlockStore::NStorage::NPartitionDirect {
+namespace NYdb::NBS::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -19,4 +19,4 @@ TActorId CreatePartitionTablet(
         NKikimr::AppData()->SystemPoolId);
 }
 
-} // namespace NCloud::NBlockStore::NStorage::NPartitionDirect
+} // namespace NYdb::NBS::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct.h
@@ -3,10 +3,10 @@
 #include <ydb/library/actors/core/actor.h>
 
 
-namespace NCloud::NBlockStore::NStorage::NPartitionDirect {
+namespace NYdb::NBS::NStorage::NPartitionDirect {
 
 NActors::TActorId CreatePartitionTablet(
     const NActors::TActorId& owner
 );
 
-}   // namespace NCloud::NBlockStore::NStorage::NPartitionDirect
+}   // namespace NYdb::NBS::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -1,15 +1,19 @@
 #include "partition_direct_actor.h"
 
-namespace NCloud::NBlockStore::NStorage::NPartitionDirect {
+
+namespace NYdb::NBS::NStorage::NPartitionDirect {
 
 using namespace NActors;
-using namespace NCloud::NBlockStore;
+using namespace NYdb::NBS;
 
 ////////////////////////////////////////////////////////////////////////////////
 void TPartitionActor::Bootstrap(const TActorContext& ctx)
 {
     Y_UNUSED(ctx);
     Become(&TThis::StateWork);
+
+    LOG_INFO(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
+        "Started NBS partition: actor id %s", SelfId().ToString().data());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -21,6 +25,9 @@ STFUNC(TPartitionActor::StateWork)
         ev->Sender.LocalId());
 
     switch (ev->GetTypeRewrite()) {
+        cFunc(TEvents::TEvPoison::EventType, PassAway);
+        HFunc(TEvService::TEvWriteBlocksRequest, HandleWriteBlocksRequest);
+        HFunc(TEvService::TEvReadBlocksRequest, HandleReadBlocksRequest);
         default:
             LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
                 "Unhandled event type: " << ev->GetTypeRewrite()
@@ -29,4 +36,42 @@ STFUNC(TPartitionActor::StateWork)
     }
 }
 
-}   // namespace NCloud::NBlockStore::NStorage::NPartitionDirect
+//////////////////////////////////////////////////////////////////////////////
+
+void TPartitionActor::HandleWriteBlocksRequest(
+    const TEvService::TEvWriteBlocksRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
+                "Handle WriteBlocks request event: " << ev->ToString());
+
+    auto response = std::make_unique<TEvService::TEvWriteBlocksResponse>();
+    response->Record.MutableError()->CopyFrom(MakeError(S_OK));
+
+    ctx.Send(
+        ev->Sender,
+        response.release(),
+        0,  // flags
+        ev->Cookie);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void TPartitionActor::HandleReadBlocksRequest(
+    const TEvService::TEvReadBlocksRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::NBS_PARTITION,
+                "Handle ReadBlocks request event: " << ev->ToString());
+
+    auto response = std::make_unique<TEvService::TEvReadBlocksResponse>();
+    response->Record.MutableError()->CopyFrom(MakeError(S_OK));
+
+    ctx.Send(
+        ev->Sender,
+        response.release(),
+        0,  // flags
+        ev->Cookie);
+}
+
+}   // namespace NYdb::NBS::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -3,8 +3,11 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
 
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/api/service.h>
+#include <ydb/core/nbs/cloud/storage/core/libs/common/error.h>
 
-namespace NCloud::NBlockStore::NStorage::NPartitionDirect {
+
+namespace NYdb::NBS::NStorage::NPartitionDirect {
 
 using namespace NActors;
 
@@ -17,6 +20,14 @@ public:
 
 private:
     STFUNC(StateWork);
+
+    void HandleWriteBlocksRequest(
+        const TEvService::TEvWriteBlocksRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleReadBlocksRequest(
+        const TEvService::TEvReadBlocksRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
 };
 
-} // namespace NCloud::NBlockStore::NStorage::NPartitionDirect
+} // namespace NYdb::NBS::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
@@ -8,6 +8,8 @@ SRCS(
 PEERDIR(
     library/cpp/containers/absl_flat_hash
     ydb/library/actors/core
+    ydb/core/nbs/cloud/blockstore/libs/storage/api
+    ydb/core/nbs/cloud/storage/core/libs/common
 )
 
 END()

--- a/ydb/core/nbs/cloud/blockstore/public/api/protos/headers.proto
+++ b/ydb/core/nbs/cloud/blockstore/public/api/protos/headers.proto
@@ -1,0 +1,96 @@
+syntax = "proto3";
+
+import "ydb/core/nbs/cloud/storage/core/protos/request_source.proto";
+import "library/cpp/lwtrace/protos/lwtrace.proto";
+
+package NYdb.NBS.NProto;
+
+option go_package = "github.com/ydb-platform/ydb/ydb/core/nbs/cloud/blockstore/public/api/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+// Control plane request source.
+
+enum EControlRequestSource
+{
+    SOURCE_CLIENT = 0;
+    SOURCE_SERVICE_MONITORING = 1;
+}
+
+enum EOptimizeNetworkTransfer
+{
+    // No optimization enabled
+    NO_OPTIMIZATION = 0;
+
+    // When the block contains only zeros, then pass it with a size of 0.
+    SKIP_VOID_BLOCKS = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Common message headers.
+
+message THeaders
+{
+    // Trace identifier for logging.
+    string TraceId = 1;
+
+    // Idempotence identifier for retries.
+    string IdempotenceId = 2;
+
+    // Client identifier for client detection.
+    string ClientId = 3;
+
+    // Request timestamp.
+    uint64 Timestamp = 4;
+
+    // Request identifier.
+    uint64 RequestId = 5;
+
+    // Request timeout (in milliseconds).
+    uint32 RequestTimeout = 6;
+
+    // Request generation number.
+    uint32 RequestGeneration = 7;
+
+    message TInternal
+    {
+        // IAM auth token.
+        string AuthToken = 1;
+
+        // From which channel this request comes from.
+        NYdb.NBS.NProto.ERequestSource RequestSource = 2;
+
+        NLWTrace.TTraceRequest Trace = 3;
+
+        // Ts when request tracing actually started.
+        uint64 TraceTs = 4;
+
+        // Source of control plane request.
+        EControlRequestSource ControlSource = 5;
+    }
+
+    // These headers must not be set by end clients. They will be overwritten
+    // internally.
+    TInternal Internal = 8;
+
+    // True for requests that originate from blockstore-server itself
+    // e.g. NRD migration-related reads and writes.
+    bool IsBackgroundRequest = 9;
+
+    // This flag controls the optimization of data transmission over the network.
+    EOptimizeNetworkTransfer OptimizeNetworkTransfer = 10;
+
+    // For which replica this request will be performed.
+    // Only for STORAGE_MEDIA_SSD_MIRROR* disks.
+    uint32 ReplicaIndex = 11;
+
+    // For how many replicas will this read request be executed.
+    // Only for STORAGE_MEDIA_SSD_MIRROR* disks.
+    uint32 ReplicaCount = 12;
+
+    // Monotonously increasing request ID counter needed by the disk agent to
+    // order write requests.
+    uint64 VolumeRequestId = 13;
+
+    // Attempt number of the request.
+    uint32 RetryNumber = 14;
+}

--- a/ydb/core/nbs/cloud/blockstore/public/api/protos/headers.proto
+++ b/ydb/core/nbs/cloud/blockstore/public/api/protos/headers.proto
@@ -59,13 +59,13 @@ message THeaders
         // From which channel this request comes from.
         NYdb.NBS.NProto.ERequestSource RequestSource = 2;
 
-        NLWTrace.TTraceRequest Trace = 3;
+        // NLWTrace.TTraceRequest Trace = 3;
 
-        // Ts when request tracing actually started.
-        uint64 TraceTs = 4;
+        // // Ts when request tracing actually started.
+        // uint64 TraceTs = 4;
 
-        // Source of control plane request.
-        EControlRequestSource ControlSource = 5;
+        // // Source of control plane request.
+        // EControlRequestSource ControlSource = 5;
     }
 
     // These headers must not be set by end clients. They will be overwritten

--- a/ydb/core/nbs/cloud/blockstore/public/api/protos/io.proto
+++ b/ydb/core/nbs/cloud/blockstore/public/api/protos/io.proto
@@ -1,0 +1,142 @@
+syntax = "proto3";
+
+import "ydb/core/nbs/cloud/blockstore/public/api/protos/headers.proto";
+import "ydb/core/nbs/cloud/storage/core/protos/error.proto";
+import "ydb/core/nbs/cloud/storage/core/protos/trace.proto";
+
+package NYdb.NBS.NProto;
+
+option go_package = "github.com/ydb-platform/ydb/ydb/core/nbs/cloud/blockstore/public/api/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+// I/O vector message.
+
+message TIOVector
+{
+    // I/O buffers.
+    repeated bytes Buffers = 1;
+
+    // IPC buffer handles. Obsolete.
+    /* repeated fixed32 Handles = 2; */
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Blocks read request/response.
+
+message TReadBlocksRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    // Label of volume to read from.
+    string DiskId = 2;
+
+    // Start block index.
+    uint64 StartIndex = 3;
+
+    // Number of blocks to read.
+    uint32 BlocksCount = 4;
+
+    // Additional flags. Do we need it?
+    uint32 Flags = 5;
+
+    // Checkpoint identifier.
+    string CheckpointId = 6;
+
+    // Session identifier.
+    string SessionId = 7;
+}
+
+message TReadBlocksResponse
+{
+    // Optional error, set only if error happened.
+    NYdb.NBS.NProto.TError Error = 1;
+
+    // Requested blocks.
+    TIOVector Blocks = 2;
+
+    // Request traces.
+    NYdb.NBS.NProto.TTraceInfo Trace = 3;
+
+    // Bitmask for unencrypted blocks
+    bytes UnencryptedBlockMask = 4;
+
+    // Throttler delay.
+    uint64 ThrottlerDelay = 5;
+
+    // If true, it means that all the data read was zeros.
+    // It's a hint, false negatives are allowed.
+    bool AllZeroes = 6;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Blocks write request/response.
+
+message TWriteBlocksRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    // Label of volume to write to.
+    string DiskId = 2;
+
+    // Start block index.
+    uint64 StartIndex = 3;
+
+    // Blocks to write.
+    TIOVector Blocks = 4;
+
+    // Additional flags. Do we need it?
+    uint32 Flags = 5;
+
+    // Session identifier.
+    string SessionId = 6;
+}
+
+message TWriteBlocksResponse
+{
+    // Optional error, set only if error happened.
+    NYdb.NBS.NProto.TError Error = 1;
+
+    // Request traces.
+    NYdb.NBS.NProto.TTraceInfo Trace = 2;
+
+    // Throttler delay.
+    uint64 ThrottlerDelay = 3;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Blocks zero request/response.
+
+message TZeroBlocksRequest
+{
+    // Optional request headers.
+    THeaders Headers = 1;
+
+    // Label of volume to write to.
+    string DiskId = 2;
+
+    // Start block index.
+    uint64 StartIndex = 3;
+
+    // Number of blocks to delete.
+    uint32 BlocksCount = 4;
+
+    // Additional flags. Do we need it?
+    uint32 Flags = 5;
+
+    // Session identifier.
+    string SessionId = 6;
+}
+
+message TZeroBlocksResponse
+{
+    // Optional error, set only if error happened.
+    NYdb.NBS.NProto.TError Error = 1;
+
+    // Request traces.
+    NYdb.NBS.NProto.TTraceInfo Trace = 2;
+
+    // Throttler delay.
+    uint64 ThrottlerDelay = 3;
+}

--- a/ydb/core/nbs/cloud/blockstore/public/api/protos/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/public/api/protos/ya.make
@@ -1,0 +1,19 @@
+PROTO_LIBRARY()
+
+INCLUDE_TAGS(GO_PROTO)
+EXCLUDE_TAGS(JAVA_PROTO)
+
+SRCS(
+    headers.proto
+    io.proto
+)
+
+PEERDIR(
+    ydb/core/nbs/cloud/storage/core/protos
+
+    library/cpp/lwtrace/protos
+)
+
+CPP_PROTO_PLUGIN0(validation ydb/public/lib/validation)
+
+END()

--- a/ydb/core/nbs/cloud/storage/core/libs/common/context.cpp
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/context.cpp
@@ -1,0 +1,115 @@
+#include "context.h"
+
+#include <util/datetime/cputimer.h>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCallContextBase::TCallContextBase(ui64 requestId)
+    : RequestId(requestId)
+{}
+
+TRequestTime TCallContextBase::CalcRequestTime(ui64 nowCycles) const
+{
+    const ui64 startCycles = GetRequestStartedCycles();
+    if (!startCycles || startCycles >= nowCycles) {
+        return TRequestTime {
+            .TotalTime = TDuration::Zero(),
+            .ExecutionTime = TDuration::Zero(),
+        };
+    }
+
+    TRequestTime requestTime;
+    requestTime.TotalTime = CyclesToDurationSafe(nowCycles - startCycles);
+
+    const ui64 postponeStart = AtomicGet(PostponeTsCycles);
+    if (postponeStart && startCycles < postponeStart && postponeStart < nowCycles) {
+        nowCycles = postponeStart;
+    }
+
+    const auto postponeDuration = Time(EProcessingStage::Postponed);
+    const auto backoffTime = Time(EProcessingStage::Backoff);
+
+    auto responseSentCycles = GetResponseSentCycles();
+    auto responseDuration = CyclesToDurationSafe(
+        (responseSentCycles ? responseSentCycles : nowCycles) - startCycles);
+
+    requestTime.ExecutionTime = responseDuration - postponeDuration -
+        backoffTime - GetPossiblePostponeDuration();
+
+    return requestTime;
+}
+
+TDuration TCallContextBase::GetPossiblePostponeDuration() const
+{
+    return TDuration::MicroSeconds(AtomicGet(PossiblePostponeMicroSeconds));
+}
+
+void TCallContextBase::SetPossiblePostponeDuration(TDuration d)
+{
+    AtomicSet(PossiblePostponeMicroSeconds, d.MicroSeconds());
+}
+
+ui64 TCallContextBase::GetRequestStartedCycles() const
+{
+    return AtomicGet(RequestStartedCycles);
+}
+
+void TCallContextBase::SetRequestStartedCycles(ui64 cycles)
+{
+    AtomicSet(RequestStartedCycles, cycles);
+}
+
+TInstant TCallContextBase::GetPostponeTs() const
+{
+    return PostponeTs;
+}
+
+void TCallContextBase::SetPostponeTs(TInstant ts)
+{
+    PostponeTs = ts;
+}
+
+ui64 TCallContextBase::GetResponseSentCycles() const
+{
+    return AtomicGet(ResponseSentCycles);
+}
+
+void TCallContextBase::SetResponseSentCycles(ui64 cycles)
+{
+    AtomicSet(ResponseSentCycles, cycles);
+}
+
+void TCallContextBase::Postpone(ui64 nowCycles)
+{
+    Y_DEBUG_ABORT_UNLESS(
+        AtomicGet(PostponeTsCycles) == 0,
+        "Request was not advanced.");
+    Y_DEBUG_ABORT_UNLESS(nowCycles > 0);
+    AtomicSet(PostponeTsCycles, nowCycles);
+}
+
+TDuration TCallContextBase::Advance(ui64 nowCycles)
+{
+    const auto start = AtomicGet(PostponeTsCycles);
+    Y_DEBUG_ABORT_UNLESS(start != 0, "Request was not postponed.");
+
+    const auto delay = CyclesToDurationSafe(nowCycles - start);
+    AddTime(EProcessingStage::Postponed, delay);
+    AtomicSet(PostponeTsCycles, 0);
+
+    return delay;
+}
+
+TDuration TCallContextBase::Time(EProcessingStage stage) const
+{
+    return TDuration::MicroSeconds(AtomicGet(Stage2Time[static_cast<int>(stage)]));
+}
+
+void TCallContextBase::AddTime(EProcessingStage stage, TDuration d)
+{
+    AtomicAdd(Stage2Time[static_cast<int>(stage)], d.MicroSeconds());
+}
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/storage/core/libs/common/context.h
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/context.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "public.h"
+
+#include <library/cpp/deprecated/atomic/atomic.h>
+#include <library/cpp/lwtrace/shuttle.h>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class EProcessingStage
+{
+    Postponed,
+    Backoff,
+    Last
+};
+
+struct TRequestTime
+{
+    TDuration TotalTime;
+    TDuration ExecutionTime;
+
+    explicit operator bool() const
+    {
+        return TotalTime || ExecutionTime;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCallContextBase
+    : public TThrRefBase
+{
+private:
+    TAtomic Stage2Time[static_cast<int>(EProcessingStage::Last)] = {};
+    TAtomic RequestStartedCycles = 0;
+    TAtomic ResponseSentCycles = 0;
+    TAtomic PossiblePostponeMicroSeconds = 0;
+    TAtomic PostponeTsCycles = 0;
+
+    // Used only in tablet throttler.
+    TInstant PostponeTs = TInstant::Zero();
+
+public:
+    ui64 RequestId;
+    NLWTrace::TOrbit LWOrbit;
+
+    TCallContextBase(ui64 requestId);
+
+    TDuration GetPossiblePostponeDuration() const;
+    void SetPossiblePostponeDuration(TDuration d);
+
+    ui64 GetRequestStartedCycles() const;
+    void SetRequestStartedCycles(ui64 cycles);
+
+    TInstant GetPostponeTs() const;
+    void SetPostponeTs(TInstant ts);
+
+    ui64 GetResponseSentCycles() const;
+    void SetResponseSentCycles(ui64 cycles);
+
+    void Postpone(ui64 nowCycles);
+    TDuration Advance(ui64 nowCycles);
+
+    TDuration Time(EProcessingStage stage) const;
+    void AddTime(EProcessingStage stage, TDuration d);
+
+    TRequestTime CalcRequestTime(ui64 nowCycles) const;
+};
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/storage/core/libs/common/context_ut.cpp
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/context_ut.cpp
@@ -1,0 +1,59 @@
+#include "context.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/datetime/cputimer.h>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TCallContext)
+{
+    void CheckCalcRequestTime(
+        ui64 cycles,
+        TCallContextBasePtr context,
+        TRequestTime requestTimeAnswer)
+    {
+        auto requestTime = context->CalcRequestTime(cycles);
+        UNIT_ASSERT_VALUES_EQUAL(requestTimeAnswer.ExecutionTime,
+            requestTime.ExecutionTime);
+        UNIT_ASSERT_VALUES_EQUAL(requestTimeAnswer.TotalTime,
+            requestTime.TotalTime);
+    }
+
+    Y_UNIT_TEST(CheckCalcRequestTime)
+    {
+        auto callContext = MakeIntrusive<TCallContextBase>(static_cast<ui64>(0));
+        callContext->SetRequestStartedCycles(5);
+        CheckCalcRequestTime(
+            3, callContext, {TDuration::Zero(), TDuration::Zero()});
+
+        CheckCalcRequestTime(
+            20,
+            callContext,
+            TRequestTime {
+                .TotalTime = CyclesToDurationSafe(15),
+                .ExecutionTime = CyclesToDurationSafe(15)});
+
+        callContext->SetResponseSentCycles(13);
+
+        CheckCalcRequestTime(
+            20,
+            callContext,
+            TRequestTime {
+                .TotalTime = CyclesToDurationSafe(15),
+                .ExecutionTime = CyclesToDurationSafe(7)});
+
+        callContext->SetResponseSentCycles(0);
+
+        CheckCalcRequestTime(
+            20,
+            callContext,
+            TRequestTime {
+                .TotalTime = CyclesToDurationSafe(15),
+                .ExecutionTime = CyclesToDurationSafe(2)});
+    }
+}
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/storage/core/libs/common/error.cpp
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/error.cpp
@@ -1,0 +1,282 @@
+#include "error.h"
+
+#include <ydb/core/nbs/cloud/storage/core/libs/common/helpers.h>
+
+#include <util/stream/format.h>
+#include <util/stream/output.h>
+#include <util/stream/str.h>
+
+namespace NYdb::NBS {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void FormatResultCodeRaw(IOutputStream& out, ui32 code)
+{
+    out << static_cast<ESeverityCode>(SUCCEEDED(code) ? 0 : 1) << " | ";
+
+    ui32 facility = FACILITY_FROM_CODE(code);
+    if (facility < FACILITY_MAX) {
+        out << static_cast<EFacilityCode>(facility);
+    } else {
+        out << "FACILITY_UNKNOWN";
+    }
+
+    out << " | " << STATUS_FROM_CODE(code);
+}
+
+void FormatResultCodePretty(IOutputStream& out, ui32 code)
+{
+    // TODO
+    try {
+        out << static_cast<EWellKnownResultCodes>(code);
+    } catch (...) {
+        FormatResultCodeRaw(out, code);
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+EErrorKind GetErrorKind(const NProto::TError& e)
+{
+    const ui32 code = e.GetCode();
+
+    if (SUCCEEDED(code)) {
+        return EErrorKind::Success;
+    }
+
+    switch (code) {
+        case E_REJECTED:
+        case E_TIMEOUT:
+        case E_BS_OUT_OF_SPACE:
+        case E_FS_OUT_OF_SPACE:
+        case E_BS_THROTTLED:
+        case E_FS_THROTTLED:
+        case E_RDMA_UNAVAILABLE:
+            return EErrorKind::ErrorRetriable;
+
+        case E_BS_INVALID_SESSION:
+        case E_FS_INVALID_SESSION:
+            return EErrorKind::ErrorSession;
+        case E_ABORTED:
+            return EErrorKind::ErrorAborted;
+    }
+
+    if (FACILITY_FROM_CODE(code) == FACILITY_GRPC) {
+        if (code == E_GRPC_UNIMPLEMENTED) {
+            return EErrorKind::ErrorFatal;
+        }
+        return EErrorKind::ErrorRetriable;
+    }
+
+    // FACILITY_SYSTEM error codes are obtained from "errno". The list of all
+    // possible errors: contrib/libs/linux-headers/asm-generic/errno-base.h
+    if (FACILITY_FROM_CODE(code) == FACILITY_SYSTEM) {
+        switch (STATUS_FROM_CODE(code)) {
+            case EIO:
+            case ENODATA:
+                return EErrorKind::ErrorFatal;
+            default:
+                // system/network errors should be retriable
+                return EErrorKind::ErrorRetriable;
+        }
+    }
+
+    if (FACILITY_FROM_CODE(code) == FACILITY_KIKIMR) {
+        switch (STATUS_FROM_CODE(code)) {
+            case 1:  // NKikimrProto::ERROR
+            case 3:  // NKikimrProto::TIMEOUT
+            case 4:  // NKikimrProto::RACE
+            case 6:  // NKikimrProto::BLOCKED
+            case 7:  // NKikimrProto::NOTREADY
+            case 12: // NKikimrProto::DEADLINE
+            case 20: // NKikimrProto::NOT_YET
+                return EErrorKind::ErrorRetriable;
+        }
+    }
+
+    if (FACILITY_FROM_CODE(code) == FACILITY_SCHEMESHARD) {
+        switch (STATUS_FROM_CODE(code)) {
+            case 13: // NKikimrScheme::StatusNotAvailable
+            case 8:  // NKikimrScheme::StatusMultipleModifications
+                return EErrorKind::ErrorRetriable;
+        }
+    }
+
+    if (FACILITY_FROM_CODE(code) == FACILITY_TXPROXY) {
+        switch (STATUS_FROM_CODE(code)) {
+            case 16: // NKikimr::NTxProxy::TResultStatus::ProxyNotReady
+            case 20: // NKikimr::NTxProxy::TResultStatus::ProxyShardNotAvailable
+            case 21: // NKikimr::NTxProxy::TResultStatus::ProxyShardTryLater
+            case 22: // NKikimr::NTxProxy::TResultStatus::ProxyShardOverloaded
+            case 51: // NKikimr::NTxProxy::TResultStatus::ExecTimeout:
+            case 55: // NKikimr::NTxProxy::TResultStatus::ExecResultUnavailable:
+                return EErrorKind::ErrorRetriable;
+        }
+    }
+
+    // any other errors should not be retried automatically
+    return EErrorKind::ErrorFatal;
+}
+
+EDiagnosticsErrorKind GetDiagnosticsErrorKind(const NProto::TError& e)
+{
+    const ui32 code = e.GetCode();
+
+    if (SUCCEEDED(code)) {
+        return EDiagnosticsErrorKind::Success;
+    }
+
+    // TODO: do not retrieve E_THROTTLED from error message
+    // on client side: NBS-568
+    if (code == E_REJECTED && e.GetMessage() == "Throttled") {
+        return EDiagnosticsErrorKind::ErrorThrottling;
+    }
+
+    // NBS-4447
+    if (code == E_REJECTED &&
+        e.GetMessage().StartsWith("Checkpoint reject request."))
+    {
+        return EDiagnosticsErrorKind::ErrorWriteRejectedByCheckpoint;
+    }
+
+    if (HasProtoFlag(e.GetFlags(), NProto::EF_SILENT)
+        || code == E_IO_SILENT) // TODO: NBS-3124#622886b937bf95501db66aad
+    {
+        return EDiagnosticsErrorKind::ErrorSilent;
+    }
+
+    switch (code) {
+        case E_BS_THROTTLED:
+        case E_FS_THROTTLED:
+            return EDiagnosticsErrorKind::ErrorThrottling;
+
+        case E_FS_INVALID_SESSION:
+        case E_BS_INVALID_SESSION:
+            return EDiagnosticsErrorKind::ErrorSession;
+        case E_ABORTED:
+            return EDiagnosticsErrorKind::ErrorAborted;
+    }
+
+    if (GetErrorKind(e) == EErrorKind::ErrorRetriable) {
+        return EDiagnosticsErrorKind::ErrorRetriable;
+    }
+
+    if (FACILITY_FROM_CODE(code) == FACILITY_FILESTORE) {
+        return EDiagnosticsErrorKind::ErrorSilent;
+    }
+
+    // any other errors should not be retried automatically
+    return EDiagnosticsErrorKind::ErrorFatal;
+}
+
+bool IsConnectionError(const NProto::TError& e)
+{
+    return e.GetCode() == E_GRPC_UNAVAILABLE;
+}
+
+NJson::TJsonValue FormatErrorJson(const NProto::TError& e)
+{
+    NJson::TJsonValue result;
+    if (e.GetCode()) {
+        result["Code"] = e.GetCode();
+        TStringStream stream;
+        FormatResultCodePretty(stream, e.GetCode());
+        result["CodeString"] = stream.Str();
+    }
+
+    if (e.GetMessage()){
+        TStringStream stream;
+        ::google::protobuf::io::PrintJSONString(stream, e.GetMessage());
+        result["Message"] = stream.Str();
+    }
+
+    if (e.GetFlags()){
+        result["Flags"] = e.GetFlags();
+    }
+
+    return result;
+}
+
+TString FormatError(const NProto::TError& e)
+{
+    TStringStream out;
+    FormatResultCodePretty(out, e.GetCode());
+
+    if (const auto& s = e.GetMessage()) {
+        out << " " << s;
+    }
+    auto flags = e.GetFlags();
+    ui32 flag = 1;
+    while (flags) {
+        if (flags & 1) {
+            switch (static_cast<NProto::EErrorFlag>(flag)) {
+                case NProto::EF_SILENT:
+                    out << " f@silent";
+                    break;
+                case NProto::EF_HW_PROBLEMS_DETECTED:
+                    out << " f@hw_problems";
+                    break;
+                case NProto::EF_INSTANT_RETRIABLE:
+                    out << " f@instant_retry";
+                    break;
+                case NProto::EF_NONE:
+                case NProto::EErrorFlag_INT_MIN_SENTINEL_DO_NOT_USE_:
+                case NProto::EErrorFlag_INT_MAX_SENTINEL_DO_NOT_USE_:
+                    Y_DEBUG_ABORT_UNLESS(false);
+                    break;
+            }
+        }
+
+        flags >>= 1;
+        ++flag;
+    }
+    return out.Str();
+}
+
+TString FormatResultCode(ui32 code)
+{
+    TStringStream out;
+    FormatResultCodePretty(out, code);
+
+    return out.Str();
+}
+
+NProto::TError MakeError(ui32 code, TString message, ui32 flags)
+{
+    NProto::TError error;
+    error.SetCode(code);
+    error.SetFlags(flags);
+
+    if (message) {
+        error.SetMessage(std::move(message));
+    }
+
+    return error;
+}
+
+NProto::TError MakeTabletIsDeadError(ui32 code, const TSourceLocation& location)
+{
+    TStringStream out;
+    out << "Tablet is dead: " << location.File << ":" << location.Line;
+    return MakeError(code, out.Str());
+}
+
+}   // namespace NYdb::NBS
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <>
+void Out<NYdb::NBS::TServiceError>(
+    IOutputStream& out,
+    const NYdb::NBS::TServiceError& e)
+{
+    NYdb::NBS::FormatResultCodePretty(out, e.GetCode());
+
+    if (const auto& s = e.GetMessage()) {
+        out << " " << s;
+    }
+}

--- a/ydb/core/nbs/cloud/storage/core/libs/common/error.h
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/error.h
@@ -1,0 +1,501 @@
+#pragma once
+
+#include "public.h"
+
+#include <ydb/core/nbs/cloud/storage/core/protos/error.pb.h>
+
+#include <library/cpp/json/writer/json_value.h>
+#include <library/cpp/threading/future/future.h>
+
+#include <util/generic/string.h>
+#include <util/generic/yexception.h>
+
+#include <tuple>
+#include <type_traits>
+
+namespace NYdb::NBS {
+
+namespace NProto {
+    using namespace NYdb::NBS::NProto;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// We should combine errors from different facilities:
+// * Generic errors
+// * System errors (file system, network etc)
+// * gRPC errors
+// * KiKiMR errors
+// * Application errors (storage, service etc)
+
+enum ESeverityCode
+{
+    SEVERITY_SUCCESS        = 0,
+    SEVERITY_ERROR          = 1,
+};
+
+enum EFacilityCode
+{
+    FACILITY_NULL           = 0,
+    FACILITY_SYSTEM         = 1,
+    FACILITY_GRPC           = 2,
+    FACILITY_KIKIMR         = 3,
+    FACILITY_SCHEMESHARD    = 4,
+    FACILITY_BLOCKSTORE     = 5,
+    FACILITY_TXPROXY        = 6,
+    FACILITY_FILESTORE      = 7,
+    FACILITY_RDMA           = 8,
+    FACILITY_MAX            // should be the last one
+};
+
+#define SUCCEEDED(code)              ((ui32(code) & 0x80000000u) == 0)
+#define FAILED(code)                 ((ui32(code) & 0x80000000u) != 0)
+#define FACILITY_FROM_CODE(code)     ((ui32(code) & 0x7FFFFFFFu) >> 16)
+#define STATUS_FROM_CODE(code)       ((ui32(code) & 0x0000FFFFu))
+
+#define MAKE_RESULT_CODE(severity, facility, status)                           \
+    ( ((ui32(severity) & 0x00000001u) << 31)                                   \
+    | ((ui32(facility) & 0x00007FFFu) << 16)                                   \
+    | ((ui32(status)   & 0x0000FFFFu)      )                                   \
+    )                                                                          \
+// MAKE_RESULT_CODE
+
+#define MAKE_SUCCESS(status) \
+    MAKE_RESULT_CODE(SEVERITY_SUCCESS, FACILITY_NULL, status)
+
+#define MAKE_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_NULL, status)
+
+#define MAKE_SYSTEM_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_SYSTEM, status)
+
+#define MAKE_GRPC_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_GRPC, status)
+
+#define MAKE_KIKIMR_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_KIKIMR, status)
+
+#define MAKE_SCHEMESHARD_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_SCHEMESHARD, status)
+
+#define MAKE_TXPROXY_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_TXPROXY, status)
+
+#define MAKE_BLOCKSTORE_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_BLOCKSTORE, status)
+
+#define MAKE_FILESTORE_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_FILESTORE, status)
+
+#define MAKE_RDMA_ERROR(status) \
+    MAKE_RESULT_CODE(SEVERITY_ERROR, FACILITY_RDMA, status)
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum EWellKnownResultCodes: ui32
+{
+    S_OK                         = MAKE_SUCCESS(0),  // The request was completed successfully
+    S_FALSE                      = MAKE_SUCCESS(1),  // The request was not completed because there is nothing to operate on
+    S_ALREADY                    = MAKE_SUCCESS(2),
+
+    E_FAIL                       = MAKE_ERROR(0),  // Critical failure occured
+    E_ARGUMENT                   = MAKE_ERROR(1),  // Request arguments are ill-formed; no point in retrying
+    E_REJECTED                   = MAKE_ERROR(2),  // Request can be retried immediately (the most common code for retriable errors)
+    // see MDB-11177#5fe20bc27e06002b58fe3eec
+    // E_IO                      = MAKE_ERROR(3),
+    E_INVALID_STATE              = MAKE_ERROR(4),  // The object is in an inappropriate state to perform the request
+    E_TIMEOUT                    = MAKE_ERROR(5),  // The underlying layer failed to meet the deadline
+    E_NOT_FOUND                  = MAKE_ERROR(6),
+    E_UNAUTHORIZED               = MAKE_ERROR(7),
+    E_NOT_IMPLEMENTED            = MAKE_ERROR(8),
+    E_ABORTED                    = MAKE_ERROR(9),  // This request must not be retried; you should retry the higher-level request instead
+    E_TRY_AGAIN                  = MAKE_ERROR(10),  // The control-plane request cannot be executed at this time; please try again later. Unlike E_REJECTED, which can be retried immediately
+    E_IO                         = MAKE_ERROR(11),  // Input/output error. This is fatal, indicating it is impossible to read or write a block due to hardware failure
+    E_CANCELLED                  = MAKE_ERROR(12),  // A legacy code for input/output errors. Unlike E_IO, it does not increment the fatal error counter in monitoring
+    E_IO_SILENT                  = MAKE_ERROR(13),  // A legacy code for input/output errors. Unlike E_IO, it does not increment the fatal error counter in monitoring
+    E_RETRY_TIMEOUT              = MAKE_ERROR(14),  // The total time limit (24 hours) for executing the request has expired
+    E_PRECONDITION_FAILED        = MAKE_ERROR(15),  // Transition to the requested state would violate object's preconditions (e.g. unexpected order of operations, write request in read-only state...). This error is not retryable
+
+    E_GRPC_CANCELLED             = MAKE_GRPC_ERROR(1),
+    E_GRPC_UNKNOWN               = MAKE_GRPC_ERROR(2),
+    E_GRPC_INVALID_ARGUMENT      = MAKE_GRPC_ERROR(3),
+    E_GRPC_DEADLINE_EXCEEDED     = MAKE_GRPC_ERROR(4),
+    E_GRPC_NOT_FOUND             = MAKE_GRPC_ERROR(5),
+    E_GRPC_ALREADY_EXISTS        = MAKE_GRPC_ERROR(6),
+    E_GRPC_PERMISSION_DENIED     = MAKE_GRPC_ERROR(7),
+    E_GRPC_RESOURCE_EXHAUSTED    = MAKE_GRPC_ERROR(8),
+    E_GRPC_FAILED_PRECONDITION   = MAKE_GRPC_ERROR(9),
+    E_GRPC_ABORTED               = MAKE_GRPC_ERROR(10),
+    E_GRPC_OUT_OF_RANGE          = MAKE_GRPC_ERROR(11),
+    E_GRPC_UNIMPLEMENTED         = MAKE_GRPC_ERROR(12),
+    E_GRPC_INTERNAL              = MAKE_GRPC_ERROR(13),
+    E_GRPC_UNAVAILABLE           = MAKE_GRPC_ERROR(14),
+    E_GRPC_DATA_LOSS             = MAKE_GRPC_ERROR(15),
+    E_GRPC_UNAUTHENTICATED       = MAKE_GRPC_ERROR(16),
+
+    E_BS_INVALID_SESSION         = MAKE_BLOCKSTORE_ERROR(1),
+    E_BS_OUT_OF_SPACE            = MAKE_BLOCKSTORE_ERROR(2),
+    E_BS_THROTTLED               = MAKE_BLOCKSTORE_ERROR(3),
+    E_BS_RESOURCE_EXHAUSTED      = MAKE_BLOCKSTORE_ERROR(4),
+    E_BS_DISK_ALLOCATION_FAILED  = MAKE_BLOCKSTORE_ERROR(5),
+    E_BS_MOUNT_CONFLICT          = MAKE_BLOCKSTORE_ERROR(6),
+
+    E_FS_IO                      = MAKE_FILESTORE_ERROR(0),
+    E_FS_PERM                    = MAKE_FILESTORE_ERROR(1),
+    E_FS_NOENT                   = MAKE_FILESTORE_ERROR(2),
+    E_FS_NXIO                    = MAKE_FILESTORE_ERROR(3),
+    E_FS_ACCESS                  = MAKE_FILESTORE_ERROR(4),
+    E_FS_EXIST                   = MAKE_FILESTORE_ERROR(5),
+    E_FS_XDEV                    = MAKE_FILESTORE_ERROR(6),
+    E_FS_NODEV                   = MAKE_FILESTORE_ERROR(7),
+    E_FS_NOTDIR                  = MAKE_FILESTORE_ERROR(8),
+    E_FS_ISDIR                   = MAKE_FILESTORE_ERROR(9),
+    E_FS_INVAL                   = MAKE_FILESTORE_ERROR(10),
+    E_FS_FBIG                    = MAKE_FILESTORE_ERROR(11),
+    E_FS_NOSPC                   = MAKE_FILESTORE_ERROR(12),
+    E_FS_ROFS                    = MAKE_FILESTORE_ERROR(13),
+    E_FS_MLINK                   = MAKE_FILESTORE_ERROR(14),
+    E_FS_NAMETOOLONG             = MAKE_FILESTORE_ERROR(15),
+    E_FS_NOTEMPTY                = MAKE_FILESTORE_ERROR(16),
+    E_FS_DQUOT                   = MAKE_FILESTORE_ERROR(17),
+    E_FS_STALE                   = MAKE_FILESTORE_ERROR(18),
+    E_FS_REMOTE                  = MAKE_FILESTORE_ERROR(19),
+    E_FS_BADHANDLE               = MAKE_FILESTORE_ERROR(20),
+    E_FS_NOTSUPP                 = MAKE_FILESTORE_ERROR(21),
+
+    E_FS_WOULDBLOCK              = MAKE_FILESTORE_ERROR(30),
+    E_FS_NOLCK                   = MAKE_FILESTORE_ERROR(31),
+
+    E_FS_INVALID_SESSION         = MAKE_FILESTORE_ERROR(100),
+    E_FS_OUT_OF_SPACE            = MAKE_FILESTORE_ERROR(101),
+    E_FS_THROTTLED               = MAKE_FILESTORE_ERROR(102),
+
+    E_RDMA_UNAVAILABLE           = MAKE_RDMA_ERROR(1),
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// error classification used in retry policies
+enum class EErrorKind
+{
+    Success,
+    ErrorAborted,
+    ErrorFatal,
+    ErrorRetriable,
+    ErrorSession,
+};
+
+bool IsConnectionError(const NProto::TError& e);
+EErrorKind GetErrorKind(const NProto::TError& e);
+
+// error classification used for logging and stats
+enum class EDiagnosticsErrorKind
+{
+    Success,
+    ErrorAborted,
+    ErrorFatal,
+    ErrorRetriable,
+    ErrorThrottling,
+    ErrorWriteRejectedByCheckpoint,
+    ErrorSession,
+    ErrorSilent,
+    Max,
+};
+
+EDiagnosticsErrorKind GetDiagnosticsErrorKind(const NProto::TError& e);
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TServiceError
+    : public yexception
+{
+private:
+    const ui32 Code;
+
+public:
+    explicit TServiceError(ui32 code)
+        : Code(code)
+    {}
+
+    TServiceError(const NProto::TError& error)
+        : Code(error.GetCode())
+    {
+        Append(error.GetMessage());
+    }
+
+    ui32 GetCode() const
+    {
+        return Code;
+    }
+
+    TStringBuf GetMessage() const
+    {
+        return AsStrBuf();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString FormatError(const NProto::TError& e);
+TString FormatResultCode(ui32 code);
+NJson::TJsonValue FormatErrorJson(const NProto::TError& e);
+
+NProto::TError MakeError(ui32 code, TString message = {}, ui32 flags = 0);
+
+template <typename T>
+concept TAcceptsError = requires(T a)
+{
+    { *a.MutableError() = MakeError(S_OK) };
+};
+
+template <typename T>
+T ErrorResponse(ui32 code, TString message, ui32 flags = 0)
+{
+    T response;
+    *response.MutableError() = MakeError(code, std::move(message), flags);
+    return response;
+}
+
+inline bool HasError(const NProto::TError& e)
+{
+    return FAILED(e.GetCode());
+}
+
+template <typename T>
+bool HasError(const T& response)
+{
+    return response.HasError()
+        && HasError(response.GetError());
+}
+
+inline void CheckError(const NProto::TError& error)
+{
+    if (HasError(error)) {
+        ythrow TServiceError(error.GetCode()) << error.GetMessage();
+    }
+}
+
+template <typename T>
+void CheckError(const T& response)
+{
+    if (HasError(response)) {
+        ythrow TServiceError(response.GetError().GetCode())
+            << response.GetError().GetMessage();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+class TResultOrError
+{
+private:
+    T Result;
+    NProto::TError Error;
+
+public:
+    TResultOrError(T result)
+        : Result(std::move(result))
+    {}
+
+    TResultOrError(NProto::TError error)
+        : Result{}
+        , Error(std::move(error))
+    {}
+
+    const T& GetResult() const
+    {
+        return Result;
+    }
+
+    T ExtractResult()
+    {
+        return std::move(Result);
+    }
+
+    const NProto::TError& GetError() const
+    {
+        return Error;
+    }
+
+    bool HasError() const
+    {
+        // emulate protobuf message ('true' means Error-field exists)
+        return true;
+    }
+
+    // Structured bindings support
+
+    template<int I>
+    const auto& get() const
+    {
+        if constexpr (I == 0) {
+            return Result;
+        }
+
+        if constexpr (I == 1) {
+            return Error;
+        }
+    }
+
+    template<int I>
+    auto&& get() &&
+    {
+        if constexpr (I == 0) {
+            return std::move(Result);
+        }
+
+        if constexpr (I == 1) {
+            return std::move(Error);
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <>
+class TResultOrError<void>
+{
+private:
+    const NProto::TError Error;
+
+public:
+    TResultOrError()
+    {}
+
+    TResultOrError(NProto::TError error)
+        : Error(std::move(error))
+    {}
+
+    const NProto::TError& GetError() const
+    {
+        return Error;
+    }
+
+    bool HasError() const
+    {
+        // emulate protobuf message ('true' means Error-field exists)
+        return true;
+    }
+
+    // Explicitly disallow structured bindings
+    template<int I> const auto& get() const = delete;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TErrorResponse
+{
+private:
+    NProto::TError Error;
+
+public:
+    TErrorResponse(ui32 code, TString message = {}, ui32 flags = 0)
+        : Error(MakeError(code, std::move(message), flags))
+    {}
+
+    TErrorResponse(const NProto::TError& e)
+        : Error(e)
+    {}
+
+    TErrorResponse(NProto::TError&& e)
+        : Error(std::move(e))
+    {}
+
+    TErrorResponse(const TServiceError& e)
+        : Error(MakeError(e.GetCode(), TString(e.GetMessage())))
+    {}
+
+    template <TAcceptsError T>
+    operator T() const
+    {
+        return ErrorResponse<T>(
+            Error.GetCode(),
+            Error.GetMessage(),
+            Error.GetFlags());
+    }
+
+    template <typename T>
+    operator TResultOrError<T>() const
+    {
+        return TResultOrError<T>(Error);
+    }
+
+    operator NProto::TError() const
+    {
+        return Error;
+    }
+
+    operator NProto::TError&& () &&
+    {
+        return std::move(Error);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TResponse, typename T>
+TResponse SafeExecute(T&& block)
+{
+    try {
+        return block();
+    } catch (const TServiceError& e) {
+        return TErrorResponse(e);
+    } catch (const TIoSystemError& e) {
+        return TErrorResponse(MAKE_SYSTEM_ERROR(e.Status()), e.what());
+    } catch (...) {
+        return TErrorResponse(E_FAIL, CurrentExceptionMessage());
+    }
+}
+
+template <typename T>
+T ExtractResponse(NThreading::TFuture<T>& future)
+{
+    return SafeExecute<T>([&] {
+        return future.ExtractValue();
+    });
+}
+
+template <typename T>
+TResultOrError<T> ResultOrError(NThreading::TFuture<T>& future)
+{
+    return SafeExecute<TResultOrError<T>>([&] {
+        return future.ExtractValue();
+    });
+}
+
+inline TResultOrError<void> ResultOrError(NThreading::TFuture<void>& future)
+{
+    return SafeExecute<TResultOrError<void>>([&] {
+        future.TryRethrow();
+        return NProto::TError();
+    });
+}
+
+NProto::TError MakeTabletIsDeadError(
+    ui32 code,
+    const TSourceLocation& location);
+
+}   // namespace NYdb::NBS
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace std {
+
+    // Structured bindings support for TResultOrError<T>
+
+    template <typename T>
+    struct tuple_size<NYdb::NBS::TResultOrError<T>>
+        : integral_constant<size_t, 2>
+    {};
+
+    template <typename T>
+    struct tuple_element<0, NYdb::NBS::TResultOrError<T>> {
+        using type = T;
+    };
+
+    template <typename T>
+    struct tuple_element<1, NYdb::NBS::TResultOrError<T>> {
+        using type = NYdb::NBS::NProto::TError;
+    };
+
+}   // namespace std

--- a/ydb/core/nbs/cloud/storage/core/libs/common/helpers.h
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/helpers.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "public.h"
+
+#include <ydb/core/nbs/cloud/storage/core/protos/error.pb.h>
+
+#include <util/system/defaults.h>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+bool HasProtoFlag(ui32 flags, const T flag)
+{
+    auto iflag = static_cast<ui32>(flag);
+    return iflag ? flags & (1 << (iflag - 1)) : false;
+}
+
+template <typename T>
+void SetProtoFlag(ui32& flags, const T flag)
+{
+    auto iflag = static_cast<ui32>(flag);
+    if (iflag) {
+        flags |= 1 << (iflag - 1);
+    }
+}
+
+template <typename T>
+void SetErrorProtoFlag(NProto::TError& error, const T flag)
+{
+    auto flags = error.GetFlags();
+    SetProtoFlag(flags, flag);
+    error.SetFlags(flags);
+}
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/storage/core/libs/common/public.h
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/public.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <util/generic/ptr.h>
+#include <util/generic/size_literals.h>
+
+#include <memory>
+
+////////////////////////////////////////////////////////////////////////////////
+
+#if !defined(NDEBUG) && defined(NBS_FORCE_MOVE)
+namespace std {
+    template <typename T>
+    T&& move(const T&) = delete;
+}
+#endif
+
+namespace NYdb::NBS {
+namespace NProbeParam {
+
+////////////////////////////////////////////////////////////////////////////////
+
+#if !defined(PLATFORM_PAGE_SIZE)
+#   define PLATFORM_PAGE_SIZE 4096
+#endif
+
+#if !defined(PLATFORM_CACHE_LINE)
+#   define PLATFORM_CACHE_LINE 64
+#endif
+
+#if !defined(Y_CACHE_ALIGNED)
+#   define Y_CACHE_ALIGNED alignas(PLATFORM_CACHE_LINE)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr const char* MediaKind = "mediaKind";
+constexpr const char* RequestId = "requestId";
+constexpr const char* RequestType = "requestType";
+constexpr const char* StartBlock = "startBlock";
+constexpr const char* RequestSize = "requestSize";
+constexpr const char* RequestTime = "requestTime";
+constexpr const char* RequestExecutionTime = "requestExecutionTime";
+constexpr const char* DiskId = "diskId";
+constexpr const char* FsId = "fsId";
+
+}   // namespace NProbeParam
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 DefaultBlockSize = 4_KB;
+constexpr ui32 DefaultLocalSSDBlockSize = 512_B;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCallContextBase;
+using TCallContextBasePtr = TIntrusivePtr<TCallContextBase>;
+
+struct IScheduler;
+using ISchedulerPtr = std::shared_ptr<IScheduler>;
+
+struct IStartable;
+using IStartablePtr = std::shared_ptr<IStartable>;
+
+struct ITask;
+using ITaskPtr = std::unique_ptr<ITask>;
+
+struct ITaskQueue;
+using ITaskQueuePtr = std::shared_ptr<ITaskQueue>;
+
+struct ITimer;
+using ITimerPtr = std::shared_ptr<ITimer>;
+
+struct TFileIOCompletion;
+
+struct IFileIOService;
+using IFileIOServicePtr = std::shared_ptr<IFileIOService>;
+
+struct IFileIOServiceFactory;
+using IFileIOServiceFactoryPtr = std::shared_ptr<IFileIOServiceFactory>;
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/storage/core/libs/common/ya.make
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/ya.make
@@ -1,0 +1,17 @@
+LIBRARY()
+
+GENERATE_ENUM_SERIALIZATION(error.h)
+
+SRCS(
+    context.cpp
+    error.cpp
+)
+
+PEERDIR(
+    ydb/core/nbs/cloud/storage/core/protos
+
+    library/cpp/json/writer
+    library/cpp/threading/future
+)
+
+END()

--- a/ydb/core/nbs/cloud/storage/core/protos/error.proto
+++ b/ydb/core/nbs/cloud/storage/core/protos/error.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package NYdb.NBS.NProto;
+
+option go_package = "github.com/ydb-platform/ydb/core/nbs/cloud/storage/core/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+// Error Flags.
+
+enum EErrorFlag
+{
+    // Note: sequential flag numbers starting from one are used, not powers of two
+
+    EF_NONE = 0;
+
+    // A flag that makes the target error EErrorKind::ErrorSilent. Such an error
+    // does not increment the fatal error counter.
+    // Be careful using EF_SILENT with retriable errors. This flag changes error
+    // kind to EErrorKind::ErrorSilent making the error non-retriable.
+    EF_SILENT = 1;
+
+    // Currently set if a problem with nonreplicated disk/agent was detected.
+    EF_HW_PROBLEMS_DETECTED = 2;
+
+    // A flag for retriable errors that indicates which requests can be retried
+    // without any delay. It works only once per request to prevent the
+    // possibility of a retry storm.
+    EF_INSTANT_RETRIABLE = 3;
+
+    // TODO: EF_RETRIABLE, EF_CLIENT
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Error description.
+
+message TError
+{
+    // Error code.
+    uint32 Code = 1;
+
+    // Error message.
+    string Message = 2;
+
+    // Flags.
+    uint32 Flags = 3;
+}

--- a/ydb/core/nbs/cloud/storage/core/protos/media.proto
+++ b/ydb/core/nbs/cloud/storage/core/protos/media.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package NYdb.NBS.NProto;
+
+option go_package = "github.com/ydb-platform/ydb/core/nbs/cloud/storage/core/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+// Disk/FS media kind
+
+enum EStorageMediaKind
+{
+    STORAGE_MEDIA_DEFAULT = 0;
+    STORAGE_MEDIA_SSD = 1;
+    STORAGE_MEDIA_HYBRID = 2;
+    STORAGE_MEDIA_HDD = 3;
+    STORAGE_MEDIA_SSD_NONREPLICATED = 4;
+    STORAGE_MEDIA_SSD_MIRROR2 = 5;
+    STORAGE_MEDIA_SSD_LOCAL = 6;
+    STORAGE_MEDIA_SSD_MIRROR3 = 7;
+    STORAGE_MEDIA_HDD_NONREPLICATED = 8;
+    STORAGE_MEDIA_HDD_LOCAL = 9;
+}

--- a/ydb/core/nbs/cloud/storage/core/protos/request_source.proto
+++ b/ydb/core/nbs/cloud/storage/core/protos/request_source.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package NYdb.NBS.NProto;
+
+option go_package = "github.com/ydb-platform/ydb/core/nbs/cloud/storage/core/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum ERequestSource
+{
+    SOURCE_INSECURE_CONTROL_CHANNEL = 0;
+    SOURCE_SECURE_CONTROL_CHANNEL = 1;
+    SOURCE_TCP_DATA_CHANNEL = 2;
+    SOURCE_FD_DATA_CHANNEL = 3;
+    SOURCE_FD_CONTROL_CHANNEL = 4;
+}

--- a/ydb/core/nbs/cloud/storage/core/protos/trace.proto
+++ b/ydb/core/nbs/cloud/storage/core/protos/trace.proto
@@ -19,7 +19,7 @@ message TTraceInfo
     uint64 RequestEndTime = 2;
 
     // serialized lwtrace probes.
-    NLWTrace.TTraceResponse LWTrace = 3;
+    // NLWTrace.TTraceResponse LWTrace = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/storage/core/protos/trace.proto
+++ b/ydb/core/nbs/cloud/storage/core/protos/trace.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+import "ydb/core/nbs/cloud/storage/core/protos/media.proto";
+import "library/cpp/lwtrace/protos/lwtrace.proto";
+
+package NYdb.NBS.NProto;
+
+option go_package = "github.com/ydb-platform/nbs/cloud/storage/core/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+// Message trace information.
+
+message TTraceInfo
+{
+    // Timestamp of remote trace start.
+    uint64 RequestStartTime = 1;
+
+    // Timestamp of remote trace completion.
+    uint64 RequestEndTime = 2;
+
+    // serialized lwtrace probes.
+    NLWTrace.TTraceResponse LWTrace = 3;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The tracks of the requests whose processing time in ms exceeds
+// corresponding values have a chance to be logged.
+
+message TLWTraceThreshold
+{
+    // Default threshold of this mediaKind.
+    optional uint32 Default = 1;
+
+    // Mapping from requestTypes to thresholds.
+    map<string, uint32> ByRequestType = 2;
+
+    // Storage media kind.
+    NYdb.NBS.NProto.EStorageMediaKind MediaKind = 3;
+
+    // Default threshold increment per 1KiB of the request size.
+    optional uint32 PerSizeUnit = 4;
+};

--- a/ydb/core/nbs/cloud/storage/core/protos/ya.make
+++ b/ydb/core/nbs/cloud/storage/core/protos/ya.make
@@ -1,0 +1,19 @@
+PROTO_LIBRARY()
+
+INCLUDE_TAGS(GO_PROTO)
+EXCLUDE_TAGS(JAVA_PROTO)
+
+PEERDIR(
+    library/cpp/lwtrace/protos
+)
+
+SRCS(
+    error.proto
+    media.proto
+    request_source.proto
+    trace.proto
+)
+
+CPP_PROTO_PLUGIN0(validation ydb/public/lib/validation)
+
+END()

--- a/ydb/public/api/grpc/draft/ya.make
+++ b/ydb/public/api/grpc/draft/ya.make
@@ -28,6 +28,7 @@ SRCS(
 
 PEERDIR(
     ydb/public/api/protos
+    ydb/core/nbs/cloud/blockstore/public/api/protos
 )
 
 EXCLUDE_TAGS(GO_PROTO)

--- a/ydb/public/api/grpc/draft/ydb_nbs_v1.proto
+++ b/ydb/public/api/grpc/draft/ydb_nbs_v1.proto
@@ -11,11 +11,20 @@ import "ydb/public/api/protos/draft/ydb_nbs.proto";
 // Service for managing nbs 2.0
 service NbsService {
     // Create NBS partition
-    rpc CreatePartition(Ydb.Nbs.CreatePartitionRequest) returns (Ydb.Nbs.CreatePartitionResponse);
+    rpc CreatePartition(NYdb.NBS.NProto.CreatePartitionRequest) returns (NYdb.NBS.NProto.CreatePartitionResponse);
 
     // Delete NBS partition
-    rpc DeletePartition(Ydb.Nbs.DeletePartitionRequest) returns (Ydb.Nbs.DeletePartitionResponse);
+    rpc DeletePartition(NYdb.NBS.NProto.DeletePartitionRequest) returns (NYdb.NBS.NProto.DeletePartitionResponse);
 
     // List NBS partitions
-    rpc ListPartitions(Ydb.Nbs.ListPartitionsRequest) returns (Ydb.Nbs.ListPartitionsResponse);
+    rpc ListPartitions(NYdb.NBS.NProto.ListPartitionsRequest) returns (NYdb.NBS.NProto.ListPartitionsResponse);
+
+
+    //
+    // Block I/O.
+    //
+
+    rpc ReadBlocks(NYdb.NBS.NProto.ReadBlocksRequest) returns (NYdb.NBS.NProto.ReadBlocksResponse);
+
+    rpc WriteBlocks(NYdb.NBS.NProto.WriteBlocksRequest) returns (NYdb.NBS.NProto.WriteBlocksResponse);
 }

--- a/ydb/public/api/protos/draft/ydb_nbs.proto
+++ b/ydb/public/api/protos/draft/ydb_nbs.proto
@@ -1,12 +1,13 @@
 syntax = "proto3";
 option cc_enable_arenas = true;
 
-package Ydb.Nbs;
+package NYdb.NBS.NProto;
 
 option java_package = "com.yandex.ydb.nbs.proto";
 option java_outer_classname = "NbsProtos";
 option java_multiple_files = true;
 
+import "ydb/core/nbs/cloud/blockstore/public/api/protos/io.proto";
 import "ydb/public/api/protos/ydb_operation.proto";
 
 
@@ -65,4 +66,34 @@ message ListPartitionsResponse {
 
 message ListPartitionsResult {
     repeated string TabletId = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Blocks read request/response.
+
+message ReadBlocksRequest
+{
+    Ydb.Operations.OperationParams operation_params = 1;
+
+    TReadBlocksRequest request = 2;
+}
+
+message ReadBlocksResponse
+{
+    Ydb.Operations.Operation operation = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Blocks write request/response.
+
+message WriteBlocksRequest
+{
+    Ydb.Operations.OperationParams operation_params = 1;
+
+    TWriteBlocksRequest request = 2;
+}
+
+message WriteBlocksResponse
+{
+    Ydb.Operations.Operation operation = 1;
 }

--- a/ydb/public/api/protos/ya.make
+++ b/ydb/public/api/protos/ya.make
@@ -4,6 +4,8 @@ PROTOC_FATAL_WARNINGS()
 MAVEN_GROUP_ID(com.yandex.ydb)
 
 PEERDIR(
+    ydb/core/nbs/cloud/blockstore/public/api/protos
+    ydb/core/nbs/cloud/storage/core/protos
     ydb/public/api/protos/annotations
 )
 

--- a/ydb/public/lib/validation/main.cpp
+++ b/ydb/public/lib/validation/main.cpp
@@ -329,7 +329,7 @@ public:
         , Vars({
             {"class", className},
             {"func", "validate_" + field->name()},
-            {"field", field->name()},
+            {"field", field->lowercase_name()},
             {"PascalName", PascalName(field->camelcase_name())},
         })
     {

--- a/ydb/services/nbs/grpc_service.cpp
+++ b/ydb/services/nbs/grpc_service.cpp
@@ -23,7 +23,7 @@ void TNbsGRpcService::InitService(grpc::ServerCompletionQueue* cq, NYdbGrpc::TLo
 }
 
 void TNbsGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
-    using namespace Ydb::Nbs;
+    using namespace NYdb::NBS::NProto;
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
 
 #ifdef SETUP_NBS_METHOD
@@ -33,9 +33,12 @@ void TNbsGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #define SETUP_NBS_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
     SETUP_METHOD(methodName, methodCallback, rlMode, requestType, nbs, auditMode)
 
-    SETUP_NBS_METHOD(CreatePartition, DoCreatePartition, RLMODE(Rps), NBS_CREATEPARTITION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
-    SETUP_NBS_METHOD(DeletePartition, DoDeletePartition, RLMODE(Rps), NBS_DELETEPARTITION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
+    SETUP_NBS_METHOD(CreatePartition, DoCreatePartition, RLMODE(Rps), NBS_CREATEPARTITION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Default));
+    SETUP_NBS_METHOD(DeletePartition, DoDeletePartition, RLMODE(Rps), NBS_DELETEPARTITION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Default));
     SETUP_NBS_METHOD(ListPartitions, DoListPartitions, RLMODE(Rps), NBS_LISTPARTITIONS, TAuditMode::NonModifying());
+
+    SETUP_NBS_METHOD(WriteBlocks, DoWriteBlocks, RLMODE(Rps), NBS_WRITEBLOCKS, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Default));
+    SETUP_NBS_METHOD(ReadBlocks, DoReadBlocks, RLMODE(Rps), NBS_READBLOCKS, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Default));
 
 #undef SETUP_NBS_METHOD
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Read/write events for NBS 2 partition.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Read, write events for NBS 2. Some protos and parts of common libs are taken from nbs repo.
grpc draft api for read/write operations to facilitate testing.
dstool operations for read/write to NBS2 partition.

'ydb/public/lib/validation' ccp proto plugin changes to correctly generate validate() methods lowercase to support proto fields like 'Blocks', not only lowercase 'blocks'.

Added validation cpp proto plugin to lwtrace as it is taken as dependency for NBS read/write requests definition and YDB draft grpc api proto definitions expect all to have validation methods generated.
