### PR TITLE
Use UPSERT_INCREMENT to update flat_relevance fulltext indexes

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_partitioned_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_partitioned_executer.cpp
@@ -414,6 +414,7 @@ private:
 
         switch (settings->GetType()) {
             case NKikimrKqp::TKqpTableSinkSettings::MODE_UPSERT:
+            case NKikimrKqp::TKqpTableSinkSettings::MODE_UPSERT_INCREMENT:
                 OperationType = TKeyDesc::ERowOperation::Update;
                 break;
             case NKikimrKqp::TKqpTableSinkSettings::MODE_DELETE:

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -969,6 +969,9 @@ private:
             } else if (settings.Mode().StringValue() == "fill_table") {
                 op.Properties["Name"] = "FillTable";
                 writeInfo.Type = EPlanTableWriteType::MultiReplace;
+            } else if (settings.Mode().StringValue() == "upsert_increment") {
+                op.Properties["Name"] = "UpsertIncrement";
+                writeInfo.Type = EPlanTableWriteType::MultiUpsertIncrement;
             } else {
                 YQL_ENSURE(false, "Unsupported sink mode");
             }

--- a/ydb/core/kqp/opt/kqp_query_plan.h
+++ b/ydb/core/kqp/opt/kqp_query_plan.h
@@ -30,6 +30,7 @@ enum class EPlanTableWriteType {
     MultiReplace,
     MultiInsert,
     MultiUpdate,
+    MultiUpsertIncrement,
 };
 
 /*

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -359,7 +359,8 @@ private:
                     mode == "insert_abort" ||
                     mode == "delete_on" ||
                     mode == "update_on" ||
-                    mode == "fill_table")
+                    mode == "fill_table" ||
+                    mode == "upsert_increment")
                 {
                     SessionCtx->Tables().GetOrAddTable(TString(cluster), SessionCtx->GetDatabase(), key.GetTablePath());
                     return TStatus::Ok;

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1596,6 +1596,8 @@ private:
                 settingsProto.SetType(NKikimrKqp::TKqpTableSinkSettings::MODE_UPDATE_CONDITIONAL);
             } else if (settings.Mode().Cast().StringValue() == "fill_table") {
                 settingsProto.SetType(NKikimrKqp::TKqpTableSinkSettings::MODE_FILL);
+            } else if (settings.Mode().Cast().StringValue() == "upsert_increment") {
+                settingsProto.SetType(NKikimrKqp::TKqpTableSinkSettings::MODE_UPSERT_INCREMENT);
             } else {
                 YQL_ENSURE(false, "Unsupported sink mode");
             }

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -52,6 +52,8 @@ namespace {
         case NKikimrKqp::TKqpTableSinkSettings::MODE_UPSERT:
         case NKikimrKqp::TKqpTableSinkSettings::MODE_UPDATE_CONDITIONAL: // Rows were already checked during WHERE execution.
             return NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT;
+        case NKikimrKqp::TKqpTableSinkSettings::MODE_UPSERT_INCREMENT:
+            return NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT_INCREMENT;
         case NKikimrKqp::TKqpTableSinkSettings::MODE_INSERT:
             return NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT;
         case NKikimrKqp::TKqpTableSinkSettings::MODE_DELETE:

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -810,6 +810,7 @@ message TKqpTableSinkSettings {
         MODE_UPDATE = 4;
         MODE_FILL = 5;
         MODE_UPDATE_CONDITIONAL = 6; // UPDATE WHERE
+        MODE_UPSERT_INCREMENT = 7;
     }
 
     optional NKqpProto.TKqpPhyTableId Table = 3;


### PR DESCRIPTION
Performance boost is about +40%, 1050 rows/sec vs 750 rows/sec insertion

Simple FLAT index is 1100 rows/sec. So, with increments, FLAT_RELEVANCE is almost as fast

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers
