### PR TITLE
YQ-4495 supported streaming disposition

### DIFF
--- a/ydb/core/kqp/common/events/events.h
+++ b/ydb/core/kqp/common/events/events.h
@@ -142,6 +142,7 @@ struct TEvKqp {
         TString CheckpointId;
         TString StreamingQueryPath;
         TString CustomerSuppliedId;
+        std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
     };
 
     struct TEvScriptResponse : public TEventLocal<TEvScriptResponse, TKqpEvents::EvScriptResponse> {

--- a/ydb/core/kqp/common/kqp_user_request_context.h
+++ b/ydb/core/kqp/common/kqp_user_request_context.h
@@ -7,6 +7,10 @@
 #include <ydb/core/resource_pools/resource_pool_settings.h>
 #include <ydb/library/actors/core/actorid.h>
 
+namespace NYql::NPq::NProto {
+    class StreamingDisposition;
+} // namespace NYql::NPq::NProto
+
 namespace NKikimr::NKqp {
 
     struct TUserRequestContext : public TAtomicRefCount<TUserRequestContext> {
@@ -22,6 +26,7 @@ namespace NKikimr::NKqp {
         bool IsStreamingQuery = false;
         TString CheckpointId;
         TString StreamingQueryPath;
+        std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
 
         TUserRequestContext() = default;
 

--- a/ydb/core/kqp/executer_actor/ya.make
+++ b/ydb/core/kqp/executer_actor/ya.make
@@ -45,6 +45,7 @@ PEERDIR(
     ydb/library/yql/dq/comp_nodes
     ydb/library/yql/dq/tasks
     ydb/library/yql/providers/common/http_gateway
+    ydb/library/yql/providers/pq/proto
     ydb/services/metadata/abstract
 )
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.cpp
@@ -2,6 +2,8 @@
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/library/yql/providers/pq/proto/dq_io.pb.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
 
 #include <yql/essentials/sql/v1/node.h>
 
@@ -21,6 +23,9 @@ TStreamingQuerySettings& TStreamingQuerySettings::FromProto(const NKikimrSchemeO
             ResourcePool = value;
         } else if (name == TStreamingQueryMeta::TProperties::QueryTextRevision) {
             QueryTextRevision = TryFromString<ui64>(value).GetOrElse(0);
+        } else if (name == TStreamingQueryMeta::TProperties::StreamingDisposition) {
+            StreamingDisposition = std::make_shared<NYql::NPq::NProto::StreamingDisposition>();
+            Y_VALIDATE(StreamingDisposition->ParseFromString(value), "Failed to parse StreamingDisposition");
         }
     }
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.h
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/common/utils.h
@@ -10,6 +10,12 @@ class TStreamingQueryProperties;
 
 } // namespace NKikimrSchemeOp
 
+namespace NYql::NPq::NProto {
+
+class StreamingDisposition;
+
+} // namespace NYql::NPq::NProto
+
 namespace NKikimr::NKqp {
 
 class TStreamingQueryMeta {
@@ -27,6 +33,9 @@ public:
         static inline constexpr char Run[] = "run";
         static inline constexpr char ResourcePool[] = "resource_pool";
         static inline constexpr char Force[] = "force";
+        static inline constexpr char StreamingDisposition[] = "streaming_disposition";
+        static inline constexpr char StreamingDispositionFromTime[] = "from_time";
+        static inline constexpr char StreamingDispositionTimeAgo[] = "time_ago";
 
         // Internal query info
         static inline constexpr char QueryTextRevision[] = "__query_text_revision";
@@ -47,6 +56,7 @@ public:
     bool Run = false;
     TString ResourcePool;
     ui64 QueryTextRevision = 0;
+    std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
 };
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/common/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/common/ya.make
@@ -7,6 +7,8 @@ SRCS(
 PEERDIR(
     ydb/core/base
     ydb/core/protos
+    ydb/library/yql/providers/pq/proto
+    ydb/library/yverify_stream
     yql/essentials/sql/v1
 )
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/manager.cpp
@@ -87,7 +87,7 @@ TYqlConclusion<std::optional<NYql::NPq::NProto::StreamingDisposition>> ParseStre
         return TYqlConclusionStatus::Fail(NYql::TIssuesIds::KIKIMR_BAD_REQUEST, TStringBuilder() << "Unknown streaming_disposition property: " << streamingDispositionExtractor.GetRemainedParamsString());
     }
 
-    Y_VALIDATE(result.GetDispositionCase() != NYql::NPq::NProto::StreamingDisposition::DISPOSITION_NOT_SET, "Failed to parse streamin disposition");
+    Y_VALIDATE(result.GetDispositionCase() != NYql::NPq::NProto::StreamingDisposition::DISPOSITION_NOT_SET, "Failed to parse streaming disposition");
 
     return result;
 }

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -21,6 +21,7 @@
 #include <ydb/library/actors/core/interconnect.h>
 #include <ydb/library/conclusion/status.h>
 #include <ydb/library/query_actor/query_actor.h>
+#include <ydb/library/yql/providers/pq/proto/dq_io.pb.h>
 
 #include <fmt/format.h>
 
@@ -1517,6 +1518,7 @@ public:
         NKikimrKqp::TStreamingQueryState InitialState;
         TPathId QueryPathId;
         ui64 QueryTextRevision = 0;
+        std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
     };
 
     TStartStreamingQueryTableActor(const TExternalContext& context, const TString& queryPath, const TSettings& settings)
@@ -1748,6 +1750,7 @@ private:
         ev->CheckpointId = State.GetCheckpointId();
         ev->StreamingQueryPath = QueryPath;
         ev->CustomerSuppliedId = State.GetCurrentExecutionId();
+        ev->StreamingDisposition = Settings.StreamingDisposition;
 
         if (const auto statsPeriod = AppData()->QueryServiceConfig.GetProgressStatsPeriodMs()) {
             ev->ProgressStatsPeriod = TDuration::MilliSeconds(statsPeriod);
@@ -2114,6 +2117,7 @@ private:
             .InitialState = State,
             .QueryPathId = SchemeInfo.PathId,
             .QueryTextRevision = QuerySettings.QueryTextRevision,
+            .StreamingDisposition = QuerySettings.StreamingDisposition,
         }));
         LOG_D("Start TStartStreamingQueryTableActor " << startActorId);
     }
@@ -2347,9 +2351,17 @@ template <typename TDerived>
 class TRequestHandlerWithSync : public TRequestHandlerBase<TDerived> {
     using TBase = TRequestHandlerBase<TDerived>;
 
+    static NYql::NPq::NProto::StreamingDisposition GetDefaultStreamingDisposition() {
+        NYql::NPq::NProto::StreamingDisposition result;
+        result.mutable_from_last_checkpoint()->set_force(true);
+        return result;
+    }
+
 public:
     using TBase::LogPrefix;
     using TBase::TBase;
+
+    static inline const TString DefaultStreamingDisposition = GetDefaultStreamingDisposition().SerializeAsString();
 
     STFUNC(StateFuncSync) {
         switch (ev->GetTypeRewrite()) {
@@ -2523,6 +2535,7 @@ private:
         CHECK_STATUS(validator.SaveRequired(ESqlSettings::QUERY_TEXT_FEATURE, &TPropertyValidator::ValidateNotEmpty));
         CHECK_STATUS(validator.SaveDefault(EName::Run, "true", &TPropertyValidator::ValidateBool));
         CHECK_STATUS(validator.SaveDefault(EName::ResourcePool, NResourcePool::DEFAULT_POOL_ID));
+        CHECK_STATUS(validator.SaveDefault(EName::StreamingDisposition, DefaultStreamingDisposition));
         CHECK_STATUS(validator.Save(
             EName::QueryTextRevision,
             ToString(SchemeInfo ? TStreamingQuerySettings().FromProto(SchemeInfo->Properties).QueryTextRevision + 1 : 1)
@@ -2629,6 +2642,7 @@ private:
         TPropertyValidator validator(*SchemeTx.MutableCreateStreamingQuery()->MutableProperties());
         CHECK_STATUS(validator.SaveDefault(EName::Run, previousSettings.Run ? "true" : "false", &TPropertyValidator::ValidateBool));
         CHECK_STATUS(validator.SaveDefault(EName::ResourcePool, previousSettings.ResourcePool));
+        CHECK_STATUS(validator.SaveDefault(EName::StreamingDisposition, DefaultStreamingDisposition));
         CHECK_STATUS_RET(force, validator.ExtractDefault(EName::Force, "false", &TPropertyValidator::ValidateBool));
         CHECK_STATUS_RET(queryText, validator.ExtractOptional(ESqlSettings::QUERY_TEXT_FEATURE, &TPropertyValidator::ValidateNotEmpty));
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/ya.make
@@ -29,6 +29,7 @@ PEERDIR(
     ydb/library/conclusion
     ydb/library/query_actor
     ydb/library/table_creator
+    ydb/library/yql/providers/pq/proto
     ydb/services/metadata
     ydb/services/metadata/abstract
     ydb/services/metadata/manager

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1930,6 +1930,10 @@ private:
         state->DqIntegration = NYql::CreatePqDqIntegration(state);
         state->Gateway->OpenSession(sessionId, "username");
 
+        if (const auto requestContext = SessionCtx->GetUserRequestContext(); requestContext && requestContext->StreamingDisposition) {
+            state->Disposition = *requestContext->StreamingDisposition;
+        }
+
         TypesCtx->AddDataSource(NYql::PqProviderName, NYql::CreatePqDataSource(state, state->Gateway));
         TypesCtx->AddDataSink(NYql::PqProviderName, NYql::CreatePqDataSink(state, state->Gateway));
 

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -1136,6 +1136,7 @@ public:
             .CheckpointId = meta.GetCheckpointId(),
             .StreamingQueryPath = meta.GetStreamingQueryPath(),
             .CustomerSuppliedId = meta.GetCustomerSuppliedId(),
+            .StreamingDisposition = streamingDisposition,
         }, QueryServiceConfig));
 
         KQP_PROXY_LOG_D("Restart with RunScriptActorId: " << RunScriptActorId << ", has PhysicalGraph: " << hasPhysicalGraph);

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -230,7 +230,7 @@ private:
                 Col("plan_compression_method", NScheme::NTypeIds::Text),
                 Col("meta", NScheme::NTypeIds::JsonDocument),
                 Col("streaming_disposition", NScheme::NTypeIds::Json),
-                Col("parameters", NScheme::NTypeIds::String), // TODO: store aparameters separately to support bigger storage.
+                Col("parameters", NScheme::NTypeIds::String), // TODO: store parameters separately to support bigger storage.
                 Col("result_set_metas", NScheme::NTypeIds::JsonDocument),
                 Col("stats", NScheme::NTypeIds::JsonDocument),
                 Col("expire_at", NScheme::NTypeIds::Timestamp), // Will be deleted from database after this deadline.

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -17,6 +17,7 @@
 #include <ydb/library/query_actor/query_actor.h>
 #include <ydb/library/services/services.pb.h>
 #include <ydb/library/table_creator/table_creator.h>
+#include <ydb/library/yql/providers/pq/proto/dq_io.pb.h>
 #include <ydb/public/api/protos/ydb_issue_message.pb.h>
 #include <ydb/public/api/protos/ydb_operation.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/params/params.h>
@@ -24,6 +25,8 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h>
 
 #include <yql/essentials/public/issue/yql_issue_message.h>
+
+#include <contrib/libs/fmt/include/fmt/format.h>
 
 #include <google/protobuf/util/time_util.h>
 
@@ -226,6 +229,7 @@ private:
                 Col("plan_compressed", NScheme::NTypeIds::String),
                 Col("plan_compression_method", NScheme::NTypeIds::Text),
                 Col("meta", NScheme::NTypeIds::JsonDocument),
+                Col("streaming_disposition", NScheme::NTypeIds::Json),
                 Col("parameters", NScheme::NTypeIds::String), // TODO: store aparameters separately to support bigger storage.
                 Col("result_set_metas", NScheme::NTypeIds::JsonDocument),
                 Col("stats", NScheme::NTypeIds::JsonDocument),
@@ -348,7 +352,7 @@ public:
         const NKikimrKqp::TEvQueryRequest& req, const NKikimrKqp::TScriptExecutionOperationMeta& meta,
         TDuration maxRunTime, const NKikimrKqp::TScriptExecutionRetryState& retryState,
         const std::optional<NKikimrKqp::TQueryPhysicalGraph>& physicalGraph, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig,
-        i64 generation)
+        std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> streamingDisposition, i64 generation)
         : TQueryBase(__func__, {.Database = req.GetRequest().GetDatabase(), .ExecutionId = executionId})
         , ExecutionId(executionId)
         , RunScriptActorId(runScriptActorId)
@@ -357,6 +361,7 @@ public:
         , MaxRunTime(Max(maxRunTime, TDuration::Days(1)))
         , RetryState(retryState)
         , PhysicalGraph(physicalGraph)
+        , StreamingDisposition(std::move(streamingDisposition))
         , Generation(generation)
         , Compressor(queryServiceConfig.GetQueryArtifactsCompressionMethod(), queryServiceConfig.GetQueryArtifactsCompressionMinSize())
     {}
@@ -372,6 +377,7 @@ public:
             DECLARE $query_text AS Text;
             DECLARE $syntax AS Int32;
             DECLARE $meta AS JsonDocument;
+            DECLARE $streaming_disposition AS Optional<Json>;
             DECLARE $lease_duration AS Interval;
             DECLARE $lease_state AS Int32;
             DECLARE $execution_meta_ttl AS Interval;
@@ -385,12 +391,12 @@ public:
 
             UPSERT INTO `.metadata/script_executions` (
                 database, execution_id, run_script_actor_id, execution_status, execution_mode, start_ts,
-                query_text, syntax, meta, expire_at, retry_state,
+                query_text, syntax, meta, streaming_disposition, expire_at, retry_state,
                 user_token, user_group_sids, parameters,
                 graph_compressed, graph_compression_method, lease_generation
             ) VALUES (
                 $database, $execution_id, $run_script_actor_id, $execution_status, $execution_mode, CurrentUtcTimestamp(),
-                $query_text, $syntax, $meta, CurrentUtcTimestamp() + $execution_meta_ttl, $retry_state,
+                $query_text, $syntax, $meta, $streaming_disposition, CurrentUtcTimestamp() + $execution_meta_ttl, $retry_state,
                 $user_sid, $user_group_sids, $parameters,
                 $graph_compressed, $graph_compression_method, $lease_generation
             );
@@ -443,6 +449,9 @@ public:
                 .Build()
             .AddParam("$meta")
                 .JsonDocument(SerializeBinaryProto(Meta))
+                .Build()
+            .AddParam("$streaming_disposition")
+                .OptionalJson(StreamingDisposition ? std::optional<std::string>(SerializeBinaryProto(*StreamingDisposition)) : std::nullopt)
                 .Build()
             .AddParam("$lease_duration")
                 .Interval(static_cast<i64>(GetDuration(Meta.GetLeaseDuration()).MicroSeconds()))
@@ -525,6 +534,7 @@ private:
     const TDuration MaxRunTime;
     const NKikimrKqp::TScriptExecutionRetryState RetryState;
     const std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
+    const std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
     const i64 Generation = 0;
     const TCompressor Compressor;
 };
@@ -574,9 +584,15 @@ public:
             .CheckpointId = ev.CheckpointId,
             .StreamingQueryPath = ev.StreamingQueryPath,
             .CustomerSuppliedId = ev.CustomerSuppliedId,
+            .StreamingDisposition = ev.StreamingDisposition,
         }, QueryServiceConfig));
 
-        const auto& creatorId = Register(new TCreateScriptOperationQuery(ExecutionId, RunScriptActorId, ev.Record, meta, MaxRunTime, GetRetryState(), ev.QueryPhysicalGraph, QueryServiceConfig, ev.Generation));
+        auto disposition = ev.StreamingDisposition;
+        if (ev.QueryPhysicalGraph && ev.QueryPhysicalGraph->GetZeroCheckpointSaved()) {
+            disposition = nullptr; // Do not save disposition if state already saved
+        }
+
+        const auto& creatorId = Register(new TCreateScriptOperationQuery(ExecutionId, RunScriptActorId, ev.Record, meta, MaxRunTime, GetRetryState(), ev.QueryPhysicalGraph, QueryServiceConfig, std::move(disposition), ev.Generation));
         KQP_PROXY_LOG_D("Bootstrap. Start TCreateScriptOperationQuery " << creatorId << ", RunScriptActorId: " << RunScriptActorId);
     }
 
@@ -900,7 +916,8 @@ public:
                 user_token,
                 user_group_sids,
                 graph_compressed,
-                graph_compression_method
+                graph_compression_method,
+                streaming_disposition
             FROM `.metadata/script_executions`
             WHERE database = $database AND execution_id = $execution_id AND
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
@@ -975,6 +992,7 @@ public:
 
         NKikimrKqp::TScriptExecutionOperationMeta meta;
         std::optional<NKikimrKqp::TQueryPhysicalGraph> physicalGraph;
+        std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> streamingDisposition;
 
         {   // Execution info
             NYdb::TResultSetParser result(ResultSets[0]);
@@ -995,11 +1013,11 @@ public:
                 return;
             }
 
-            if (const auto issuesSerialized = result.ColumnParser("issues").GetOptionalJsonDocument()) {
+            if (const auto& issuesSerialized = result.ColumnParser("issues").GetOptionalJsonDocument()) {
                 TransientIssues.AddIssues(DeserializeIssues(*issuesSerialized));
             }
 
-            if (const auto transientIssuesSerialized = result.ColumnParser("transient_issues").GetOptionalJsonDocument()) {
+            if (const auto& transientIssuesSerialized = result.ColumnParser("transient_issues").GetOptionalJsonDocument()) {
                 const auto previousIssues = DeserializeIssues(*transientIssuesSerialized);
 
                 TransientIssues.Reserve(TransientIssues.Size() + previousIssues.Size());
@@ -1013,7 +1031,7 @@ public:
             }
 
             TVector<NACLib::TSID> userGroupSids;
-            if (const auto serializedUserGroupSids = result.ColumnParser("user_group_sids").GetOptionalJsonDocument()) {
+            if (const auto& serializedUserGroupSids = result.ColumnParser("user_group_sids").GetOptionalJsonDocument()) {
                 if (!GetUserGroupSids(*serializedUserGroupSids, userGroupSids)) {
                     Finish(Ydb::StatusIds::INTERNAL_ERROR, "User group sids are corrupted");
                     return;
@@ -1024,7 +1042,7 @@ public:
                 queryRequest.SetUserToken(NACLib::TUserToken(*userSID, userGroupSids).SerializeAsString());
             }
 
-            if (const auto serializedParameters = result.ColumnParser("parameters").GetOptionalString()) {
+            if (const auto& serializedParameters = result.ColumnParser("parameters").GetOptionalString()) {
                 NJson::TJsonValue value;
                 if (!NJson::ReadJsonTree(*serializedParameters, &value) || value.GetType() != NJson::JSON_MAP) {
                     Finish(Ydb::StatusIds::INTERNAL_ERROR, "Parameters are corrupted");
@@ -1037,7 +1055,7 @@ public:
                 }
             }
 
-            if (const std::optional<TString> graphCompressed = result.ColumnParser("graph_compressed").GetOptionalString()) {
+            if (const std::optional<TString>& graphCompressed = result.ColumnParser("graph_compressed").GetOptionalString()) {
                 const std::optional<TString> compressionMethod = result.ColumnParser("graph_compression_method").GetOptionalUtf8();
                 if (!compressionMethod) {
                     Finish(Ydb::StatusIds::INTERNAL_ERROR, "Graph compression method is not found");
@@ -1053,7 +1071,18 @@ public:
                 }
             }
 
-            const std::optional<TString> queryText = result.ColumnParser("query_text").GetOptionalUtf8();
+            if (const auto& serializedStreamingDisposition = result.ColumnParser("streaming_disposition").GetOptionalJson()) {
+                NJson::TJsonValue serializedStreamingDispositionJson;
+                if (!NJson::ReadJsonTree(*serializedStreamingDisposition, &serializedStreamingDispositionJson)) {
+                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Streaming disposition is corrupted");
+                    return;
+                }
+
+                streamingDisposition = std::make_shared<NYql::NPq::NProto::StreamingDisposition>();
+                DeserializeBinaryProto(serializedStreamingDispositionJson, *streamingDisposition);
+            }
+
+            const std::optional<TString>& queryText = result.ColumnParser("query_text").GetOptionalUtf8();
             if (!queryText) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Query text is not found");
                 return;
@@ -4881,7 +4910,15 @@ public:
     {}
 
     void OnRunQuery() override {
-        TString sql = R"(
+        using namespace fmt::literals;
+
+        TString streamingDispositionUpdate;
+        if (PhysicalGraph.GetZeroCheckpointSaved()) {
+            // Reset streaming disposition after state save
+            streamingDispositionUpdate = "streaming_disposition = NULL,";
+        }
+
+        TString sql = fmt::format(R"(
             -- TSaveScriptExecutionPhysicalGraphActor::OnRunQuery
             DECLARE $execution_id AS Text;
             DECLARE $database AS Text;
@@ -4891,12 +4928,13 @@ public:
 
             UPDATE `.metadata/script_executions`
             SET
+                {streaming_disposition}
                 graph_compressed = $graph_compressed,
                 graph_compression_method = $graph_compression_method
             WHERE database = $database
               AND execution_id = $execution_id
               AND (lease_generation IS NULL OR lease_generation = $lease_generation);
-        )";
+        )", "streaming_disposition"_a = streamingDispositionUpdate);
 
         const auto [graphCompressionMethod, graphCompressed] = Compressor.Compress(PhysicalGraph.SerializeAsString());
 
@@ -5101,7 +5139,7 @@ IActor* CreateGetScriptExecutionPhysicalGraphActor(const TActorId& replyActorId,
 namespace NPrivate {
 
 IActor* CreateCreateScriptOperationQueryActor(const TString& executionId, const TActorId& runScriptActorId, const NKikimrKqp::TEvQueryRequest& record, const NKikimrKqp::TScriptExecutionOperationMeta& meta) {
-    return new TCreateScriptOperationQuery(executionId, runScriptActorId, record, meta, SCRIPT_TIMEOUT_LIMIT, {}, std::nullopt, {}, 1);
+    return new TCreateScriptOperationQuery(executionId, runScriptActorId, record, meta, SCRIPT_TIMEOUT_LIMIT, {}, std::nullopt, {}, nullptr, 1);
 }
 
 IActor* CreateCheckLeaseStatusActor(const TActorId& replyActorId, const TString& database, const TString& executionId, ui64 cookie) {

--- a/ydb/core/kqp/proxy_service/ya.make
+++ b/ydb/core/kqp/proxy_service/ya.make
@@ -35,6 +35,7 @@ PEERDIR(
     ydb/library/table_creator
     ydb/library/yql/dq/actors/spilling
     ydb/library/yql/providers/common/http_gateway
+    ydb/library/yql/providers/pq/proto
     ydb/library/yql/providers/s3/actors_factory
     ydb/public/api/protos
     ydb/public/lib/scheme_types

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -151,10 +151,10 @@ public:
         UserRequestContext->StreamingQueryPath = StreamingQueryPath;
         UserRequestContext->StreamingDisposition = StreamingDisposition;
 
-        LOG_I("Bootstrap"
+        LOG_I("Bootstrap "
             << "StreamingQueryPath: " << StreamingQueryPath
-            << "CheckpointId: " << CheckpointId
-            << "StreamingDisposition: " << (StreamingDisposition ? StreamingDisposition->DebugString() : "null"));
+            << ", CheckpointId: " << CheckpointId
+            << ", StreamingDisposition: " << (StreamingDisposition ? StreamingDisposition->DebugString() : "null"));
 
         Become(&TRunScriptActor::StateFunc);
     }

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -15,6 +15,7 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/ydb_issue/issue_helpers.h>
 #include <ydb/library/ydb_issue/proto/issue_id.pb.h>
+#include <ydb/library/yql/providers/pq/proto/dq_io.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
 #include <library/cpp/protobuf/json/json2proto.h>
@@ -129,6 +130,7 @@ public:
         , PhysicalGraph(std::move(settings.PhysicalGraph))
         , StreamingQueryPath(settings.StreamingQueryPath)
         , CustomerSuppliedId(std::move(settings.CustomerSuppliedId))
+        , StreamingDisposition(std::move(settings.StreamingDisposition))
         , Counters(settings.Counters)
     {}
 
@@ -147,8 +149,12 @@ public:
         UserRequestContext->IsStreamingQuery = SaveQueryPhysicalGraph;
         UserRequestContext->CheckpointId = CheckpointId;
         UserRequestContext->StreamingQueryPath = StreamingQueryPath;
+        UserRequestContext->StreamingDisposition = StreamingDisposition;
 
-        LOG_I("Bootstrap");
+        LOG_I("Bootstrap"
+            << "StreamingQueryPath: " << StreamingQueryPath
+            << "CheckpointId: " << CheckpointId
+            << "StreamingDisposition: " << (StreamingDisposition ? StreamingDisposition->DebugString() : "null"));
 
         Become(&TRunScriptActor::StateFunc);
     }
@@ -984,6 +990,7 @@ private:
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     const TString StreamingQueryPath;
     const TString CustomerSuppliedId;
+    const std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
     std::optional<TActorId> PhysicalGraphSender;
     TIntrusivePtr<TKqpCounters> Counters;
     TString SessionId;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
@@ -1,15 +1,22 @@
 #pragma once
 
-#include <ydb/core/kqp/counters/kqp_counters.h>
-
-#include <ydb/core/protos/kqp.pb.h>
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/kqp/counters/kqp_counters.h>
+// #include <ydb/core/protos/kqp.pb.h>
 
 #include <ydb/library/actors/core/actor.h>
 
 namespace NKikimrConfig {
-    class TQueryServiceConfig;
-}
+
+class TQueryServiceConfig;
+
+} // namespace NKikimrConfig
+
+namespace NYql::NPq::NProto {
+
+class StreamingDisposition;
+
+} // namespace NYql::NPq::NProto
 
 namespace NKikimr::NKqp {
 
@@ -27,6 +34,7 @@ struct TKqpRunScriptActorSettings {
     TString CheckpointId;
     TString StreamingQueryPath;
     TString CustomerSuppliedId;
+    std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
 };
 
 NActors::IActor* CreateRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig queryServiceConfig);

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
@@ -2,7 +2,6 @@
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/kqp/counters/kqp_counters.h>
-// #include <ydb/core/protos/kqp.pb.h>
 
 #include <ydb/library/actors/core/actor.h>
 

--- a/ydb/core/kqp/run_script_actor/ya.make
+++ b/ydb/core/kqp/run_script_actor/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
     ydb/core/kqp/proxy_service/proto
     ydb/core/protos
     ydb/library/actors/core
+    ydb/library/yql/providers/pq/proto
     ydb/public/api/protos
 )
 

--- a/ydb/services/metadata/abstract/parsing.cpp
+++ b/ydb/services/metadata/abstract/parsing.cpp
@@ -2,4 +2,42 @@
 
 namespace NYql {
 
+using namespace NNodes;
+
+TObjectSettingsImpl::TObjectSettingsImpl(const TString& typeId, const TString& objectId, const THashMap<TString, TString>& features, const TResetFeatures& resetFeatures)
+    : TypeId(typeId)
+    , ObjectId(objectId)
+    , Features(features.begin(), features.end())
+    , ResetFeatures(resetFeatures)
+    , FeaturesExtractor(std::make_shared<TFeaturesExtractor>(Features, ResetFeatures))
+{}
+
+TFeaturesExtractor& TObjectSettingsImpl::GetFeaturesExtractor() const {
+    Y_ABORT_UNLESS(!!FeaturesExtractor);
+    return *FeaturesExtractor;
 }
+
+void TObjectSettingsImpl::DeserializeFeatures(const TCoNameValueTupleList& features, TFeaturesExtractor::TFeatures& result) {
+    for (const auto& feature : features) {
+        if (const auto& maybeAtom = feature.Maybe<TCoAtom>()) {
+            result.emplace(maybeAtom.Cast(), ""sv);
+        } else if (const auto& maybeTuple = feature.Maybe<TCoNameValueTuple>()) {
+            const auto& tuple = maybeTuple.Cast();
+            const TString name(tuple.Name());
+            const auto& value = tuple.Value();
+            if (const auto& maybeAtom = value.Maybe<TCoAtom>()) {
+                result.emplace(name, maybeAtom.Cast());
+            } else if (const auto& maybeInt = value.Maybe<TCoIntegralCtor>()) {
+                result.emplace(name, maybeInt.Cast().Literal().Cast<TCoAtom>());
+            } else if (const auto& maybeBool = value.Maybe<TCoBool>()) {
+                result.emplace(name, maybeBool.Cast().Literal().Cast<TCoAtom>());
+            } else if (const auto& maybeList = value.Maybe<TCoNameValueTupleList>()) {
+                TFeaturesExtractor::TFeatures features;
+                DeserializeFeatures(maybeList.Cast(), features);
+                result.emplace(name, std::move(features));
+            }
+        }
+    }
+}
+
+} // namespace NYql

--- a/ydb/services/metadata/abstract/request_features.cpp
+++ b/ydb/services/metadata/abstract/request_features.cpp
@@ -46,7 +46,7 @@ bool TFeaturesExtractor::IsFinished() const {
 }
 
 TString TFeaturesExtractor::GetRemainedParamsString() const {
-    std::unordered_set<TString> features;
+    std::set<TString> features;
 
     GetRemainedFeatures(Features, "", features);
 
@@ -58,7 +58,7 @@ TString TFeaturesExtractor::GetRemainedParamsString() const {
 }
 
 std::optional<TString> TFeaturesExtractor::ValidateResetFeatures() const {
-    std::unordered_set<TString> duplicateFeatures;
+    std::set<TString> duplicateFeatures;
     for (const auto& feature : ResetFeatures) {
         if (Features.contains(feature)) {
             duplicateFeatures.emplace(feature);
@@ -109,7 +109,7 @@ bool TFeaturesExtractor::ExtractResetFeature(const TString& featureId) {
     return true;
 }
 
-void TFeaturesExtractor::GetRemainedFeatures(const TFeatures& features, const TString& prefix, std::unordered_set<TString>& result) {
+void TFeaturesExtractor::GetRemainedFeatures(const TFeatures& features, const TString& prefix, std::set<TString>& result) {
     for (const auto& [key, value] : features) {
         auto name = TStringBuilder() << prefix << key;
         if (std::holds_alternative<TString>(value.Value)) {

--- a/ydb/services/metadata/abstract/request_features.cpp
+++ b/ydb/services/metadata/abstract/request_features.cpp
@@ -48,9 +48,7 @@ bool TFeaturesExtractor::IsFinished() const {
 TString TFeaturesExtractor::GetRemainedParamsString() const {
     std::unordered_set<TString> features;
 
-    for (const auto& [key, _] : Features) {
-        features.emplace(key);
-    }
+    GetRemainedFeatures(Features, "", features);
 
     for (const auto& feature : ResetFeatures) {
         features.emplace(feature);

--- a/ydb/services/metadata/abstract/request_features.cpp
+++ b/ydb/services/metadata/abstract/request_features.cpp
@@ -3,51 +3,123 @@
 #include <util/string/builder.h>
 #include <util/string/join.h>
 
-#include <set>
-
 namespace NYql {
+
+TFeaturesExtractor::TFeature::TFeature(TString&& value)
+    : Value(std::move(value))
+{}
+
+TFeaturesExtractor::TFeature::TFeature(const TString& value)
+    : Value(value)
+{}
+
+TFeaturesExtractor::TFeature::TFeature(TStringBuf value)
+    : Value(TString(value))
+{}
+
+TFeaturesExtractor::TFeature::TFeature(THashMap<TString, TFeature>&& value)
+    : Value(std::move(value))
+{}
+
+TFeaturesExtractor::TFeaturesExtractor(const THashMap<TString, TString>& features, const std::unordered_set<TString>& resetFeatures)
+    : Features(features.begin(), features.end())
+    , ResetFeatures(resetFeatures)
+{}
+
+TFeaturesExtractor::TFeaturesExtractor(THashMap<TString, TString>&& features, std::unordered_set<TString>&& resetFeatures)
+    : Features(std::make_move_iterator(features.begin()), std::make_move_iterator(features.end()))
+    , ResetFeatures(std::move(resetFeatures))
+{}
+
+TFeaturesExtractor::TFeaturesExtractor(TFeatures&& features, std::unordered_set<TString>&& resetFeatures)
+    : Features(std::move(features))
+    , ResetFeatures(std::move(resetFeatures))
+{}
+
+TFeaturesExtractor::TFeaturesExtractor(const TFeatures& features, const std::unordered_set<TString>& resetFeatures)
+    : Features(features)
+    , ResetFeatures(resetFeatures)
+{}
+
+bool TFeaturesExtractor::IsFinished() const {
+    return Features.empty() && ResetFeatures.empty();
+}
+
 TString TFeaturesExtractor::GetRemainedParamsString() const {
-    std::set<TString> features;
-    for (auto&& i : Features) {
-        features.emplace(i.first);
+    std::unordered_set<TString> features;
+
+    for (const auto& [key, _] : Features) {
+        features.emplace(key);
     }
-    for (auto&& feature : ResetFeatures) {
+
+    for (const auto& feature : ResetFeatures) {
         features.emplace(feature);
     }
+
     return JoinSeq(", ", features);
 }
 
 std::optional<TString> TFeaturesExtractor::ValidateResetFeatures() const {
-    std::set<TString> duplicateFeatures;
-    for (auto&& feature : ResetFeatures) {
+    std::unordered_set<TString> duplicateFeatures;
+    for (const auto& feature : ResetFeatures) {
         if (Features.contains(feature)) {
             duplicateFeatures.emplace(feature);
         }
     }
+
     if (!duplicateFeatures.empty()) {
         return TStringBuilder() << "Duplicate reset feature: " << JoinSeq(", ", duplicateFeatures);
     }
+
     return std::nullopt;
 }
 
-std::optional<TString> TFeaturesExtractor::Extract(const TString& paramName) {
-    auto it = Features.find(paramName);
-    if (it == Features.end()) {
+std::optional<TString> TFeaturesExtractor::Extract(const TString& featureId) {
+    const auto it = Features.find(featureId);
+    if (it == Features.end() || !std::holds_alternative<TString>(it->second.Value)) {
         return {};
-    } else {
-        const TString result = it->second;
-        Features.erase(it);
-        return result;
     }
+
+    TString result = std::get<TString>(std::move(it->second.Value));
+    Features.erase(it);
+    return std::move(result);
 }
 
-bool TFeaturesExtractor::ExtractResetFeature(const TString& paramName) {
-    auto it = ResetFeatures.find(paramName);
+std::optional<std::variant<TString, TFeaturesExtractor>> TFeaturesExtractor::ExtractNested(const TString& featureId) {
+    const auto it = Features.find(featureId);
+    if (it == Features.end()) {
+        return {};
+    }
+
+    auto result = std::move(it->second.Value);
+    Features.erase(it);
+
+    if (std::holds_alternative<TString>(result)) {
+        return std::get<TString>(std::move(result));
+    }
+
+    return TFeaturesExtractor(std::get<TFeatures>(std::move(result)), {});
+}
+
+bool TFeaturesExtractor::ExtractResetFeature(const TString& featureId) {
+    const auto it = ResetFeatures.find(featureId);
     if (it == ResetFeatures.end()) {
         return false;
     }
+
     ResetFeatures.erase(it);
     return true;
 }
 
+void TFeaturesExtractor::GetRemainedFeatures(const TFeatures& features, const TString& prefix, std::unordered_set<TString>& result) {
+    for (const auto& [key, value] : features) {
+        auto name = TStringBuilder() << prefix << key;
+        if (std::holds_alternative<TString>(value.Value)) {
+            result.emplace(name);
+        } else {
+            GetRemainedFeatures(std::get<TFeatures>(value.Value), name << ".", result);
+        }
+    }
 }
+
+} // namespace NYql

--- a/ydb/services/metadata/abstract/request_features.h
+++ b/ydb/services/metadata/abstract/request_features.h
@@ -6,6 +6,8 @@
 #include <optional>
 #include <unordered_set>
 
+#include <set>
+
 namespace NYql {
 
 class TFeaturesExtractor : TMoveOnly {
@@ -66,7 +68,7 @@ public:
     bool ExtractResetFeature(const TString& featureId);
 
 private:
-    static void GetRemainedFeatures(const TFeatures& features, const TString& prefix, std::unordered_set<TString>& result);
+    static void GetRemainedFeatures(const TFeatures& features, const TString& prefix, std::set<TString>& result);
 };
 
 } // namespace NYql

--- a/ydb/services/metadata/abstract/request_features.h
+++ b/ydb/services/metadata/abstract/request_features.h
@@ -1,30 +1,43 @@
 #pragma once
+
 #include <util/generic/string.h>
 #include <util/generic/hash.h>
-#include <map>
+
 #include <optional>
 #include <unordered_set>
 
 namespace NYql {
-class TFeaturesExtractor: TNonCopyable {
+
+class TFeaturesExtractor : TMoveOnly {
+public:
+    struct TFeature {
+        TFeature(TString&& value);
+
+        TFeature(const TString& value);
+
+        TFeature(TStringBuf value);
+
+        TFeature(THashMap<TString, TFeature>&& value);
+
+        std::variant<TString, THashMap<TString, TFeature>> Value;
+    };
+
+    using TFeatures = THashMap<TString, TFeature>;
+
 private:
-    THashMap<TString, TString> Features;
+    TFeatures Features;
     std::unordered_set<TString> ResetFeatures;
 
 public:
-    TFeaturesExtractor(const THashMap<TString, TString>& features, const std::unordered_set<TString>& resetFeatures)
-        : Features(features)
-        , ResetFeatures(resetFeatures)
-    {}
+    TFeaturesExtractor(THashMap<TString, TString>&& features, std::unordered_set<TString>&& resetFeatures);
 
-    TFeaturesExtractor(THashMap<TString, TString>&& features, std::unordered_set<TString>&& resetFeatures)
-        : Features(std::move(features))
-        , ResetFeatures(std::move(resetFeatures))
-    {}
+    TFeaturesExtractor(const THashMap<TString, TString>& features, const std::unordered_set<TString>& resetFeatures);
 
-    bool IsFinished() const {
-        return Features.empty() && ResetFeatures.empty();
-    }
+    TFeaturesExtractor(TFeatures&& features, std::unordered_set<TString>&& resetFeatures);
+
+    TFeaturesExtractor(const TFeatures& features, const std::unordered_set<TString>& resetFeatures);
+
+    bool IsFinished() const;
 
     TString GetRemainedParamsString() const;
 
@@ -32,21 +45,28 @@ public:
     [[nodiscard]] std::optional<TString> ValidateResetFeatures() const;
 
     template <class T>
-    std::optional<T> Extract(const TString& featureId, const std::optional<T> noExistsValue = {}) {
-        T result;
-        auto it = Features.find(featureId);
-        if (it == Features.end()) {
+    std::optional<T> Extract(const TString& featureId, std::optional<T> noExistsValue = {}) {
+        const auto it = Features.find(featureId);
+        if (it == Features.end() || !std::holds_alternative<TString>(it->second.Value)) {
             return noExistsValue;
-        } else if (TryFromString(it->second, result)) {
+        }
+
+        if (T result; TryFromString(std::get<TString>(it->second.Value), result)) {
             Features.erase(it);
             return result;
-        } else {
-            return {};
         }
+
+        return {};
     }
 
-    std::optional<TString> Extract(const TString& paramName);
+    std::optional<TString> Extract(const TString& featureId);
 
-    bool ExtractResetFeature(const TString& paramName);
+    std::optional<std::variant<TString, TFeaturesExtractor>> ExtractNested(const TString& featureId);
+
+    bool ExtractResetFeature(const TString& featureId);
+
+private:
+    static void GetRemainedFeatures(const TFeatures& features, const TString& prefix, std::unordered_set<TString>& result);
 };
-}
+
+} // namespace NYql


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported streaming disposition (described in [rfc](https://github.com/ydb-platform/ydb-rfc/blob/main/streaming_in_ydb.md#настройки-with)):

```sql
CREATE STREAMING QUERY my_query WITH (
    STREAMING_DISPOSITION = (
        TIME_AGO = "PT1H"
    )
) AS DO BEGIN

INSERT INTO source.output_topic SELECT * FROM source.input_topic

END DO
```

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->
