### PR TITLE
Fix EnableConfigV2 enabled by default on new cluster

### DIFF
--- a/ydb/core/mind/bscontroller/migrate.cpp
+++ b/ydb/core/mind/bscontroller/migrate.cpp
@@ -240,10 +240,6 @@ public:
 
         Queue.emplace_back(new TTxUpdateCompatibilityInfo);
 
-        if (!hasInstanceId) {
-            Queue.emplace_back(new TTxUpdateEnableConfigV2);
-        }
-
         return true;
     }
 

--- a/ydb/tests/functional/config/test_config_v2_fallbacks.py
+++ b/ydb/tests/functional/config/test_config_v2_fallbacks.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+import logging
+import pytest
+import yaml
+from hamcrest import assert_that, is_
+
+from ydb.tests.library.common.types import Erasure
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.clients.kikimr_config_client import ConfigClient
+from ydb.tests.library.clients.kikimr_dynconfig_client import DynConfigClient
+from ydb.tests.library.harness.util import LogLevels
+from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
+import ydb.public.api.protos.draft.ydb_dynamic_config_pb2 as dynconfig
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture(scope="module")
+def erasure():
+    return Erasure.NONE
+
+@pytest.fixture(scope="module")
+def nodes_count():
+    return 1
+
+@pytest.fixture(scope="module")
+def configurator(erasure, nodes_count):
+    log_configs = {
+        'BS_NODE': LogLevels.DEBUG,
+        'GRPC_SERVER': LogLevels.DEBUG,
+        'GRPC_PROXY': LogLevels.DEBUG,
+        'BS_CONTROLLER': LogLevels.DEBUG,
+    }
+    return KikimrConfigGenerator(
+        erasure=erasure,
+        nodes=nodes_count,
+        use_in_memory_pdisks=True,
+        separate_node_configs=True,
+        simple_config=True,
+        extra_grpc_services=['config'],
+        additional_log_configs=log_configs,
+        explicit_hosts_and_host_configs=True,
+    )
+
+@pytest.fixture(scope="module")
+def cluster(configurator):
+    cluster = KiKiMR(configurator=configurator)
+    cluster.start()
+    yield cluster
+    cluster.stop()
+
+@pytest.fixture(scope="module")
+def config_client(cluster):
+    host = cluster.nodes[1].host
+    port = cluster.nodes[1].port
+    return ConfigClient(host, port)
+
+@pytest.fixture(scope="module")
+def dynconfig_client(cluster):
+    host = cluster.nodes[1].host
+    port = cluster.nodes[1].port
+    return DynConfigClient(host, port)
+
+def test_v2_commands_on_v1_cluster(cluster, config_client, dynconfig_client):
+    resp = dynconfig_client.fetch_startup_config()
+    result = dynconfig.FetchStartupConfigResult()
+    resp.operation.result.Unpack(result)
+    startup_config = result.config
+    assert_that(resp.operation.status, is_(StatusIds.SUCCESS))
+    logger.info("Successfully fetched startup config via DynConfig")
+
+    # try V2 FetchConfig
+    # we expect this to return UNSUPPORTED status because V2 is not enabled via feature flag
+    resp = config_client.fetch_all_configs()
+    logger.info(f"V2 FetchConfig response on V1 cluster: {resp}")
+    assert_that(resp.operation.status, is_(StatusIds.UNSUPPORTED))
+    assert_that(resp.operation.issues[0].message, is_("failed to fetch config: configuration v2 is disabled"))
+
+    # try V2 ReplaceConfig
+    # we expect this to return UNSUPPORTED status because V2 is not enabled via feature flag
+    yaml_config = yaml.safe_load(startup_config)
+    replace_config = dict()
+    replace_config["metadata"] = {
+        "kind": "MainConfig",
+        "version": 0,
+        "cluster": ""
+    }
+    replace_config["config"] = yaml_config
+    dumped_replace_config = yaml.dump(replace_config)
+    logger.debug("Config %s", dumped_replace_config)
+    resp = config_client.replace_config(dumped_replace_config)
+    logger.info(f"V2 ReplaceConfig response on V1 cluster: {resp}")
+
+    assert_that(resp.operation.status, is_(StatusIds.UNSUPPORTED))
+    assert_that(resp.operation.issues[0].message, is_("failed to replace configuration: InvalidRequest: configuration v2 is disabled"))

--- a/ydb/tests/functional/config/ya.make
+++ b/ydb/tests/functional/config/ya.make
@@ -2,6 +2,7 @@ PY3TEST()
 
 TEST_SRCS(
     test_config_migration.py
+    test_config_v2_fallbacks.py
     test_config_with_metadata.py
     test_configuration_version.py
     test_distconf.py


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix EnableConfigV2 enabled by default on new cluster

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
