### PR TITLE
Fix empty message fetching kafka api

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -223,7 +223,9 @@ void TKafkaFetchActor::FillRecordsBatch(const NKikimrClient::TPersQueueFetchResp
         header.Value = header.CodecValueStr;
         record.Headers.push_back(header);
 
-        record.Value = record.DataChunk.GetData();
+        if (record.DataChunk.HasData()) {
+            record.Value = record.DataChunk.GetData();
+        }
         record.OffsetDelta = lastOffset - baseOffset;
         record.TimestampDelta = lastTimestamp - baseTimestamp;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix empty message fetching to stop converting it to string.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
