### PR TITLE
dq ca mon page: add watermarks tracker state dump (backport #31632, #31423), add idleness events sensors (backport #29958) [without sync ca changes]

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -185,6 +185,9 @@ private:
 
         html << "<h3>Watermarks</h3>";
         DUMP(WatermarksTracker, GetPendingWatermark, ());
+        html << "<pre>";
+        DUMP((*this), WatermarksTracker);
+        html << "</pre>";
 
         html << "<h3>CPU Quota</h3>";
         html << "QuoterServiceActorId: " << QuoterServiceActorId.ToString() << "<br />";

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -200,7 +200,7 @@ protected:
         , FunctionRegistry(functionRegistry)
         , CheckpointingMode(GetTaskCheckpointingMode(Task))
         , State(Task.GetCreateSuspended() ? NDqProto::COMPUTE_STATE_UNKNOWN : NDqProto::COMPUTE_STATE_EXECUTING)
-        , WatermarksTracker(LogPrefix)
+        , WatermarksTracker(LogPrefix, taskCounters)
         , TaskCounters(taskCounters)
         , MetricsReporter(taskCounters)
         , ComputeActorSpan(NKikimr::TWilsonKqp::ComputeActor, std::move(traceId), "ComputeActor")

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
@@ -19,8 +19,10 @@ namespace NYql::NDq {
 
 using namespace NActors;
 
-TDqComputeActorWatermarks::TDqComputeActorWatermarks(const TString& logPrefix)
-    : LogPrefix(logPrefix), Impl(logPrefix) {
+TDqComputeActorWatermarks::TDqComputeActorWatermarks(const TString& logPrefix, const ::NMonitoring::TDynamicCounterPtr& counters)
+    : LogPrefix(logPrefix)
+    , Impl(logPrefix, counters)
+{
 }
 
 void TDqComputeActorWatermarks::RegisterInputChannel(ui64 inputId, TDuration idleTimeout, TInstant systemTime) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
@@ -42,19 +42,19 @@ void TDqComputeActorWatermarks::RegisterInput(ui64 inputId, bool isChannel, TDur
     }
 }
 
-void TDqComputeActorWatermarks::UnregisterInputChannel(ui64 inputId) {
+void TDqComputeActorWatermarks::UnregisterInputChannel(ui64 inputId, bool silent) {
     LOG_D("Unregister input channel " << inputId);
-    UnregisterInput(inputId, true);
+    UnregisterInput(inputId, true, silent);
 }
 
-void TDqComputeActorWatermarks::UnregisterAsyncInput(ui64 inputId) {
+void TDqComputeActorWatermarks::UnregisterAsyncInput(ui64 inputId, bool silent) {
     LOG_D("Unregister async input " << inputId);
-    UnregisterInput(inputId, false);
+    UnregisterInput(inputId, false, silent);
 }
 
-void TDqComputeActorWatermarks::UnregisterInput(ui64 inputId, bool isChannel) {
+void TDqComputeActorWatermarks::UnregisterInput(ui64 inputId, bool isChannel, bool silent) {
     auto result = Impl.UnregisterInput(std::make_pair(inputId, isChannel));
-    if (!result) {
+    if (!result && !silent) {
         LOG_E("Unregistered " << (isChannel ? "input channel" : "async input") << " " << inputId << " was not found");
     }
 }

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <ydb/library/yql/dq/common/dq_common.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h>
@@ -9,7 +10,7 @@ namespace NYql::NDq {
 class TDqComputeActorWatermarks
 {
 public:
-    TDqComputeActorWatermarks(const TString& logPrefix);
+    explicit TDqComputeActorWatermarks(const TString& logPrefix, const ::NMonitoring::TDynamicCounterPtr& counters = {});
 
     void RegisterAsyncInput(ui64 inputId, TDuration idleTimeout = TDuration::Max()) {
         RegisterAsyncInput(inputId, idleTimeout, TInstant::Now());

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -12,30 +12,17 @@ class TDqComputeActorWatermarks
 public:
     explicit TDqComputeActorWatermarks(const TString& logPrefix, const ::NMonitoring::TDynamicCounterPtr& counters = {});
 
-    void RegisterAsyncInput(ui64 inputId, TDuration idleTimeout = TDuration::Max()) {
-        RegisterAsyncInput(inputId, idleTimeout, TInstant::Now());
-    }
-    void RegisterInputChannel(ui64 inputId, TDuration idleTimeout = TDuration::Max()) {
-        RegisterInputChannel(inputId, idleTimeout, TInstant::Now());
-    }
+    void RegisterAsyncInput(ui64 inputId, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());
+    void RegisterInputChannel(ui64 inputId, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());
 
-    void RegisterAsyncInput(ui64 inputId, TDuration idleTimeout, TInstant systemTime);
-    void RegisterInputChannel(ui64 inputId, TDuration idleTimeout, TInstant systemTime);
-
-    void UnregisterAsyncInput(ui64 inputId);
-    void UnregisterInputChannel(ui64 inputId);
+    void UnregisterAsyncInput(ui64 inputId, bool silent = false);
+    void UnregisterInputChannel(ui64 inputId, bool silent = false);
 
     // Will return true, if local watermark inside this async input was moved forward.
-    bool NotifyAsyncInputWatermarkReceived(ui64 inputId, TInstant watermark) {
-        return NotifyAsyncInputWatermarkReceived(inputId, watermark, TInstant::Now());
-    }
-    bool NotifyAsyncInputWatermarkReceived(ui64 inputId, TInstant watermark, TInstant systemTime);
+    bool NotifyAsyncInputWatermarkReceived(ui64 inputId, TInstant watermark, TInstant systemTime = TInstant::Now());
 
     // Will return true, if local watermark inside this input channel was moved forward.
-    bool NotifyInChannelWatermarkReceived(ui64 inputId, TInstant watermark) {
-        return NotifyInChannelWatermarkReceived(inputId, watermark, TInstant::Now());
-    }
-    bool NotifyInChannelWatermarkReceived(ui64 inputId, TInstant watermark, TInstant systemTime);
+    bool NotifyInChannelWatermarkReceived(ui64 inputId, TInstant watermark, TInstant systemTime = TInstant::Now());
 
     // Will return true, if pending watermark completed.
     bool NotifyWatermarkWasSent(TInstant watermark);
@@ -56,10 +43,9 @@ public:
 
     void SetLogPrefix(const TString& logPrefix);
 
-private:
-    void RegisterInput(ui64 inputId, bool isChannel, TDuration idleTimeout, TInstant systemTime);
-    void UnregisterInput(ui64 inputId, bool isChannel);
-    bool NotifyInputWatermarkReceived(ui64 inputId, bool isChannel, TInstant watermark, TInstant systemTime);
+    void RegisterInput(ui64 inputId, bool isChannel, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());
+    void UnregisterInput(ui64 inputId, bool isChannel, bool silent = false);
+    bool NotifyInputWatermarkReceived(ui64 inputId, bool isChannel, TInstant watermark, TInstant systemTime = TInstant::Now());
 
 private:
     TString LogPrefix;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -5,8 +5,23 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h>
 
-namespace NYql::NDq {
+namespace NYql::NDq::NDqComputeActorWatermarksImpl {
+    struct TInputKey {
+        ui64 InputId;
+        bool IsChannel;
 
+        constexpr auto operator<=> (const TInputKey&) const = default;
+    };
+} // namespace NYql::NDq::NDqComputeActorWatermarksImpl
+
+template<>
+struct THash<NYql::NDq::NDqComputeActorWatermarksImpl::TInputKey> {
+    constexpr size_t operator() (const auto& x) const noexcept {
+        return (x.InputId << 1) ^ x.IsChannel; // better than CombineHashes for this particular purpose
+    }
+};
+
+namespace NYql::NDq {
 class TDqComputeActorWatermarks
 {
 public:
@@ -43,6 +58,8 @@ public:
 
     void SetLogPrefix(const TString& logPrefix);
 
+    void Out(IOutputStream& str) const;
+
     void RegisterInput(ui64 inputId, bool isChannel, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());
     void UnregisterInput(ui64 inputId, bool isChannel, bool silent = false);
     bool NotifyInputWatermarkReceived(ui64 inputId, bool isChannel, TInstant watermark, TInstant systemTime = TInstant::Now());
@@ -50,7 +67,7 @@ public:
 private:
     TString LogPrefix;
 
-    using TInputKey = std::pair<ui64, bool>;
+    using TInputKey = NDqComputeActorWatermarksImpl::TInputKey;
     TDqWatermarkTrackerImpl<TInputKey> Impl;
 
     TMaybe<TInstant> PendingWatermark;

--- a/ydb/library/yql/dq/actors/compute/dq_source_watermark_tracker.h
+++ b/ydb/library/yql/dq/actors/compute/dq_source_watermark_tracker.h
@@ -17,12 +17,13 @@ public:
         bool idlePartitionsEnabled,
         TDuration lateArrivalDelay,
         TDuration idleTimeout,
-        const TString& logPrefix)
+        const TString& logPrefix,
+        const ::NMonitoring::TDynamicCounterPtr& counters = {})
         : Granularity_(granularity)
         , IdlePartitionsEnabled_(idlePartitionsEnabled)
         , LateArrivalDelay_(lateArrivalDelay)
         , IdleTimeout_(idleTimeout)
-        , Impl_(logPrefix)
+        , Impl_(logPrefix, counters)
     {}
 
     [[nodiscard]] TMaybe<TInstant> NotifyNewPartitionTime(

--- a/ydb/library/yql/dq/actors/compute/dq_source_watermark_tracker.h
+++ b/ydb/library/yql/dq/actors/compute/dq_source_watermark_tracker.h
@@ -62,6 +62,10 @@ public:
         return Impl_.GetWatermarkDiscrepancy();
     }
 
+    void Out(IOutputStream& str) const {
+        Impl_.Out(str);
+    }
+
 private:
     TInstant ToDiscreteTime(TInstant time) const {
         return TInstant::MicroSeconds(time.MicroSeconds() - time.MicroSeconds() % Granularity_.MicroSeconds());
@@ -80,4 +84,4 @@ private:
     TDqWatermarkTrackerImpl<TPartitionKey> Impl_;
 };
 
-}
+} // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <util/datetime/base.h>
 #include <util/generic/maybe.h>
 #include <util/system/types.h>
@@ -15,9 +16,21 @@ namespace NYql::NDq {
 template <typename TInputKey>
 struct TDqWatermarkTrackerImpl {
 public:
-    explicit TDqWatermarkTrackerImpl(const TString& logPrefix)
+    explicit TDqWatermarkTrackerImpl(const TString& logPrefix, const ::NMonitoring::TDynamicCounterPtr& counters = {})
         : LogPrefix_(logPrefix)
+        , Counters_(counters)
     {}
+
+    ~TDqWatermarkTrackerImpl() {
+        if (IdleInputs_) {
+            size_t idleableCount = 0;
+            for (auto& [_, data]: Data_) {
+                idleableCount += (data.IdleTimeout != TDuration::Max());
+            }
+            Y_DEBUG_ABORT_UNLESS(idleableCount >= ExpiresQueue_.size());
+            IdleInputs_->Sub(idleableCount - ExpiresQueue_.size());
+        }
+    }
 
     void SetLogPrefix(const TString& logPrefix) {
         LogPrefix_ = logPrefix;
@@ -57,6 +70,9 @@ public:
             if (rec.empty()) {
                 WATERMARK_LOG_T("Unidle " << it->first << " got " << watermark << " > " << data.Watermark);
                 WatermarksQueue_.emplace(watermark, it);
+                if (IdleInputs_) {
+                    IdleInputs_->Dec();
+                }
             } else {
                 WATERMARK_LOG_T("Update " << it->first << " watermark from " << rec.value().Time << " to " << watermark);
                 rec.value().Time = watermark;
@@ -69,6 +85,9 @@ public:
             if (inserted) {
                 //updated = true;
                 WATERMARK_LOG_T("Unidle " << it->first << " got " << watermark << " <= " << data.Watermark);
+                if (IdleInputs_) {
+                    IdleInputs_->Dec();
+                }
             }
         } else {
             Y_DEBUG_ABORT_UNLESS(WatermarksQueue_.contains(TWatermarksQueueItem { data.Watermark, it }));
@@ -88,6 +107,10 @@ public:
             data.ExpiresAt = systemTime + idleTimeout;
             auto [_, inserted] = ExpiresQueue_.emplace(data.ExpiresAt, it);
             Y_DEBUG_ABORT_UNLESS(inserted);
+            if (Counters_ && !IdleInputs_) {
+                IdleEvents_ = Counters_->GetCounter("WatermarksIdleEvents", true);
+                IdleInputs_ = Counters_->GetCounter("WatermarksIdleInputs");
+            }
         }
         {
             auto [_, inserted] = WatermarksQueue_.emplace(Nothing(), it);
@@ -105,7 +128,10 @@ public:
         WatermarksQueue_.erase(TWatermarksQueueItem { data.Watermark, it });
         // note: erases nothing if input was idle
         if (data.IdleTimeout != TDuration::Max()) {
-            ExpiresQueue_.erase(TExpiresQueueItem { data.ExpiresAt, it });
+            auto removed = ExpiresQueue_.erase(TExpiresQueueItem { data.ExpiresAt, it });
+            if (!removed && IdleInputs_) {
+                IdleInputs_->Dec();
+            }
             // note: erases nothing if input was idle
         }
         Data_.erase(it);
@@ -124,6 +150,11 @@ public:
            auto removed = WatermarksQueue_.erase(TWatermarksQueueItem { data.Watermark, it->Iterator } );
            Y_DEBUG_ABORT_UNLESS(removed); // any partition in ExpiresQueue_ must have matching record in WatermarksQueue_
            it = ExpiresQueue_.erase(it);
+           if (IdleInputs_) {
+               IdleInputs_->Inc();
+               Y_DEBUG_ABORT_UNLESS(IdleEvents_);
+               IdleEvents_->Inc();
+           }
         }
 
         return RecalcWatermark();
@@ -230,6 +261,10 @@ private:
     TMaybe<TInstant> Watermark_;
     TString LogPrefix_;
     std::deque<TInstant> InflyIdlenessChecks_;
+
+    const NMonitoring::TDynamicCounterPtr Counters_;
+    NMonitoring::TDynamicCounters::TCounterPtr IdleEvents_;
+    NMonitoring::TDynamicCounters::TCounterPtr IdleInputs_;
 };
 #undef WATERMARK_LOG_T
 #undef WATERMARK_LOG_D

--- a/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
@@ -5,6 +5,7 @@
 #include <util/generic/maybe.h>
 #include <util/system/types.h>
 #include <util/string/builder.h>
+#include <util/string/join.h>
 #include <util/generic/set.h>
 #include <algorithm>
 #include <deque>
@@ -200,6 +201,30 @@ public:
         return true;
     }
 
+    void Out(IOutputStream& str) const {
+        if (!Data_.empty()) {
+            str << "Watermarks: {";
+            for (auto it = Data_.cbegin(); it != Data_.cend(); ++it) {
+                const auto& [key, data] = *it;
+                str << "\n    " << key << ": {" << " watermark: " << data.Watermark;
+                if (data.IdleTimeout != TDuration::Max()) {
+                    str << ", expires: " << data.ExpiresAt << ", timeout: " << data.IdleTimeout;
+                    if (!WatermarksQueue_.contains(TWatermarksQueueItem { data.Watermark, it })) {
+                        str << ", expired";
+                    }
+                }
+                str << " },";
+            }
+            str << "};\n";
+        }
+        if (Watermark_) {
+            str << "Watermark: " << Watermark_ << ";\n";
+        }
+        if (!InflyIdlenessChecks_.empty()) {
+            str << "InflyIdlenessChecks: [ " << JoinSeq(", ", InflyIdlenessChecks_) << " ];\n";
+        }
+    }
+
 private:
     TMaybe<TInstant> RecalcWatermark() {
         if (WatermarksQueue_.empty()) {
@@ -228,7 +253,7 @@ private:
 
     template <typename TTimeType, typename TMapType>
     struct TTimeState {
-        using TDataIterator = typename TMapType::iterator;
+        using TDataIterator = typename TMapType::const_iterator;
         TTimeType Time;
         TDataIterator Iterator;
         bool operator< (const TTimeState& other) const noexcept {
@@ -269,4 +294,4 @@ private:
 #undef WATERMARK_LOG_T
 #undef WATERMARK_LOG_D
 
-}
+} // namespace NYql::NDq

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -1268,6 +1268,11 @@ TString TDqPqRdReadActor::GetInternalState() {
         }
         str << "\n";
     }
+    if (Parent->WatermarkTracker) {
+        str << "WatermarksTracker:";
+        Parent->WatermarkTracker->Out(str);
+        str << "\n";
+    }
     return str.Str();
 }
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
@@ -144,7 +144,7 @@ const NYql::NDq::TDqAsyncStats& TDqPqReadActorBase::GetIngressStats() const {
     return IngressStats;
 }
 
-void TDqPqReadActorBase::InitWatermarkTracker(TDuration lateArrivalDelay, TDuration idleTimeout) {
+void TDqPqReadActorBase::InitWatermarkTracker(TDuration lateArrivalDelay, TDuration idleTimeout, const ::NMonitoring::TDynamicCounterPtr& counters) {
     const auto granularity = TDuration::MicroSeconds(SourceParams.GetWatermarks().GetGranularityUs());
     SRC_LOG_D("SessionId: " << GetSessionId() << " Watermarks enabled: " << SourceParams.GetWatermarks().GetEnabled() << " granularity: " << granularity
         << " late arrival delay: " << lateArrivalDelay
@@ -161,7 +161,8 @@ void TDqPqReadActorBase::InitWatermarkTracker(TDuration lateArrivalDelay, TDurat
         SourceParams.GetWatermarks().GetIdlePartitionsEnabled(),
         lateArrivalDelay,
         idleTimeout,
-        LogPrefix
+        LogPrefix,
+        counters
     );
 }
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
@@ -44,7 +44,7 @@ public:
     virtual void SchedulePartitionIdlenessCheck(TInstant) = 0;
 
     virtual void InitWatermarkTracker() = 0;
-    void InitWatermarkTracker(TDuration, TDuration);
+    void InitWatermarkTracker(TDuration, TDuration, const ::NMonitoring::TDynamicCounterPtr& counters = {});
     void MaybeSchedulePartitionIdlenessCheck(TInstant systemTime);
 
     virtual TString GetSessionId() const {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
