### PR TITLE
Fix CLI auth mixing and harden auth-related tests

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added the `--include-index-data` option to the `ydb export s3` command, enabling index data export.
 * Added the `--index-population-mode` option to the `ydb import s3` command, allowing selection of the index population mode (e.g. build or import).
 * Added unified time interval format support across CLI commands. Options accepting time durations now support explicit time units (e.g., `5s`, `2m`, `1h`) while maintaining backward compatibility with plain numbers interpreted using their original default units.
+* Fixed static credentials parsing to avoid using a profile password when the username comes from another source.
 
 ## 2.28.0 ##
 

--- a/ydb/apps/ydb/ut/parse_command_line.cpp
+++ b/ydb/apps/ydb/ut/parse_command_line.cpp
@@ -855,14 +855,16 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         },
         profile);
 
-        // --user option + password from active profile
-        ExpectUserAndPassword("user-from-explicit-option", "password-from-active-profile");
+        // --user option + password from environment (active profile password is ignored)
+        ExpectUserAndPassword("user-from-explicit-option", "password-from-env");
         RunCli({
             "-v",
             "--user", "user-from-explicit-option",
             "scheme", "ls",
         },
-        {},
+        {
+            {"YDB_PASSWORD", "password-from-env"},
+        },
         profile);
 
         // user from environment + --password-file option
@@ -879,14 +881,15 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         },
         profile);
 
-        // user from environment + password from active profile
-        ExpectUserAndPassword("user-from-env", "password-from-active-profile");
+        // user from environment + password from environment (active profile password is ignored)
+        ExpectUserAndPassword("user-from-env", "password-from-env");
         RunCli({
             "-v",
             "scheme", "ls",
         },
         {
             {"YDB_USER", "user-from-env"},
+            {"YDB_PASSWORD", "password-from-env"},
         },
         profile);
 
@@ -914,15 +917,17 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         {},
         profile);
 
-        // --user option + password from explicit profile (user and password from active profile are overridden)
-        ExpectUserAndPassword("user-from-explicit-option", "password-from-explicit-profile");
+        // --user option + password from env (explicit profile password is ignored)
+        ExpectUserAndPassword("user-from-explicit-option", "password-from-env");
         RunCli({
             "-v",
             "-p", "test_profile",
             "--user", "user-from-explicit-option",
             "scheme", "ls",
         },
-        {},
+        {
+            {"YDB_PASSWORD", "password-from-env"},
+        },
         profile);
 
         // --user option + --no-password (override env and active profile password)

--- a/ydb/apps/ydb/ut/parse_command_line.cpp
+++ b/ydb/apps/ydb/ut/parse_command_line.cpp
@@ -733,6 +733,27 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
             "--password-file", explicitPasswordFile,
             "scheme", "ls",
         });
+
+        // password-file without user is not allowed
+        ExpectFail();
+        RunCli({
+            "-v",
+            "-e", GetEndpoint(),
+            "-d", GetDatabase(),
+            "--password-file", explicitPasswordFile,
+            "scheme", "ls",
+        });
+
+        // password from env without user is ignored
+        RunCli({
+            "-v",
+            "-e", GetEndpoint(),
+            "-d", GetDatabase(),
+            "scheme", "ls",
+        },
+        {
+            {"YDB_PASSWORD", "env-password"},
+        });
     }
 
     Y_UNIT_TEST_F(StaticCredentialsProfileActivePasswordFile, TCliTestFixture) {

--- a/ydb/apps/ydb/ut/run_ydb.cpp
+++ b/ydb/apps/ydb/ut/run_ydb.cpp
@@ -3,6 +3,7 @@
 #include <util/generic/yexception.h>
 #include <util/system/shellcommand.h>
 #include <util/system/env.h>
+#include <util/folder/tempdir.h>
 #include <util/stream/str.h>
 #include <util/string/cast.h>
 #include <util/string/printf.h>
@@ -11,6 +12,8 @@
 
 #include <library/cpp/testing/common/env.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <memory>
 
 TString GetYdbEndpoint()
 {
@@ -28,6 +31,14 @@ public:
         const TStringBuf varsToUnset[] = {
             "YDB_ENDPOINT",
             "YDB_DATABASE",
+            "YDB_USER",
+            "YDB_PASSWORD",
+            "YDB_TOKEN",
+            "IAM_TOKEN",
+            "YC_TOKEN",
+            "USE_METADATA_CREDENTIALS",
+            "SA_KEY_FILE",
+            "YDB_OAUTH2_KEY_FILE",
             "YDB_CA_FILE",
             "YDB_CLIENT_CERT_FILE",
             "YDB_CLIENT_CERT_KEY_FILE",
@@ -41,6 +52,10 @@ public:
         }
         for (const auto& [key, value] : env) {
             Set(key, value);
+        }
+        if (!env.contains("HOME")) {
+            TempHomeDir = std::make_unique<TTempDir>();
+            Set("HOME", TempHomeDir->Name());
         }
     }
 
@@ -65,6 +80,7 @@ public:
     }
 
     THashMap<TString, TMaybe<TString>> Env;
+    std::unique_ptr<TTempDir> TempHomeDir;
 };
 
 TString RunYdb(const TList<TString>& args1, const TList<TString>& args2, bool checkExitCode, bool autoAddEndpointAndDatabase, const THashMap<TString, TString>& env, int expectedExitCode)

--- a/ydb/apps/ydb/ut/run_ydb.cpp
+++ b/ydb/apps/ydb/ut/run_ydb.cpp
@@ -24,11 +24,22 @@ TString GetYdbDatabase()
 class TShellCommandEnvScope {
 public:
     explicit TShellCommandEnvScope(const THashMap<TString, TString>& env) {
-        if (!env.contains("YDB_ENDPOINT")) {
-            Unset("YDB_ENDPOINT");
-        }
-        if (!env.contains("YDB_DATABASE")) {
-            Unset("YDB_DATABASE");
+        const TStringBuf varsToUnset[] = {
+            "YDB_ENDPOINT",
+            "YDB_DATABASE",
+            "YDB_USER",
+            "YDB_PASSWORD",
+            "YDB_TOKEN",
+            "IAM_TOKEN",
+            "YC_TOKEN",
+            "USE_METADATA_CREDENTIALS",
+            "SA_KEY_FILE",
+            "YDB_OAUTH2_KEY_FILE",
+        };
+        for (const TStringBuf var : varsToUnset) {
+            if (!env.contains(TString{var})) {
+                Unset(TString{var});
+            }
         }
         for (const auto& [key, value] : env) {
             Set(key, value);

--- a/ydb/apps/ydb/ut/run_ydb.h
+++ b/ydb/apps/ydb/ut/run_ydb.h
@@ -8,6 +8,7 @@ TString GetYdbEndpoint();
 TString GetYdbDatabase();
 
 TString RunYdb(const TList<TString>& args1, const TList<TString>& args2, bool checkExitCode = true, bool autoAddEndpointAndDatabase = true, const THashMap<TString, TString>& env = {}, int expectedExitCode = 0);
+TString RunYdbWithInput(const TList<TString>& args1, const TList<TString>& args2, const TString& input, bool checkExitCode = true, bool autoAddEndpointAndDatabase = true, const THashMap<TString, TString>& env = {}, int expectedExitCode = 0);
 
 ui64 GetFullTimeValue(const TString& output);
 THashSet<TString> GetCodecsList(const TString& output);

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -616,7 +616,12 @@ void TClientCommandRootCommon::ParseStaticCredentials(TConfig& config) {
                 Password = envPassword.GetRef();
             }
         }
-        if (passwordResult->GetValueSource() != EOptionValueSource::DefaultValue && userResult->GetValueSource() == EOptionValueSource::DefaultValue) { // Both from command line or both from env
+        if (passwordResult->GetValueSource() != EOptionValueSource::DefaultValue && userResult->GetValueSource() == EOptionValueSource::DefaultValue) { // Password provided without user (user has default value)
+            if (passwordResult->GetValueSource() == EOptionValueSource::EnvironmentVariable) {
+                Password.reset();
+                PasswordFile.clear();
+                return;
+            }
             MisuseErrors.push_back("User password was provided without user name");
             return;
         }

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -622,6 +622,10 @@ void TClientCommandRootCommon::ParseStaticCredentials(TConfig& config) {
         }
     }
 
+    if (!MisuseErrors.empty()) {
+        return;
+    }
+
     if (UserName.empty()) {
         return;
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR addresses inconsistent static-credentials parsing and improves test reliability:

- Prevents mixing profile passwords with usernames coming from a different source (explicit options, env, other profile).
- Ensures a profile is not treated as a user source unless it actually provides a user.
- Avoids interactive password prompts when parsing already produced misuse errors.
- Adds fallback to `YDB_PASSWORD` if a profile password is ignored due to source mismatch.
- Splits static-credentials tests into smaller, isolated cases for easier debugging.
- Adds interactive-password tests using a new helper that feeds stdin input.
- Adds environment isolation in CLI tests (clears auth-related env vars).
- Forces a temporary `HOME` in tests to avoid picking up local profiles/tokens.
