### PR TITLE
Topic SDK read session: break circular references

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -242,7 +242,7 @@ public:
     void PlanDecompressionTasks(double averageCompressionRatio,
                                 TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream);
 
-    void OnDestroyReadSession();
+    void ClearParents();
 
     bool IsReady() const {
         return SourceDataNotProcessed == 0;


### PR DESCRIPTION
Break circular references before removing references to decompression objects

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Without this fix reading may stall after a lot of non-graceful StopPartitionSession events, because decompression objects are not deleted and memory leaks.