### PR TITLE
Replace "Keep in memory" with "Cache mode" in CLI

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added the `--index-population-mode` option to the `ydb import s3` command, allowing selection of the index population mode (e.g. build or import).
 * Added unified time interval format support across CLI commands. Options accepting time durations now support explicit time units (e.g., `5s`, `2m`, `1h`) while maintaining backward compatibility with plain numbers interpreted using their original default units.
 * Fixed static credentials parsing to avoid using a profile password when the username comes from another source.
+* Added "Cache mode" option to column families description instead of deprecated "Keep in memory" option in the `ydb scheme describe` command.
 
 ## 2.28.0 ##
 

--- a/ydb/public/lib/ydb_cli/common/describe.cpp
+++ b/ydb/public/lib/ydb_cli/common/describe.cpp
@@ -342,7 +342,7 @@ void PrintColumnFamilies(const NTable::TTableDescription& tableDescription, IOut
     if (tableDescription.GetColumnFamilies().empty()) {
         return;
     }
-    TPrettyTable table({ "Name", "Data", "Compression", "Keep in memory" },
+    TPrettyTable table({ "Name", "Data", "Compression", "Cache mode" },
         TPrettyTableConfig().WithoutRowDelimiters());
 
     for (const NTable::TColumnFamilyDescription& family : tableDescription.GetColumnFamilies()) {
@@ -361,15 +361,15 @@ void PrintColumnFamilies(const NTable::TTableDescription& tableDescription, IOut
                     << static_cast<size_t>(family.GetCompression().value()) << ")";
             }
         }
-        TStringBuilder keepInMemory;
-        if (family.GetKeepInMemory().has_value()) {
-            keepInMemory << keepInMemory << family.GetKeepInMemory().value();
+        TStringBuilder cacheMode;
+        if (family.GetCacheMode().has_value()) {
+            cacheMode << family.GetCacheMode().value();
         }
         table.AddRow()
             .Column(0, family.GetName())
             .Column(1, data ? data.value() : "")
             .Column(2, compression)
-            .Column(3, keepInMemory);
+            .Column(3, cacheMode);
     }
     out << Endl << "Column families: " << Endl;
     out << table;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Replace deprecated "Keep in memory" option with new "Cache mode" in CLI.
RFC about "Cache mode": https://nda.ya.ru/t/81zpH6s87StvnM
Epic: https://github.com/ydb-platform/ydb/issues/18691
