### PR TITLE
[ICRDMA] Allow to split RDMA credentials in to multiple parts EXT-1874

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -494,7 +494,10 @@ namespace NActors {
         Y_ABORT_UNLESS(rdmaCreds->SerializePartialToArray(ptr, credsSerializedSize));
         ptr += credsSerializedSize;
         WriteUnaligned<ui32>(ptr, checkSum);
-        OutputQueueSize -= event.EventSerializedSize;
+
+        if (lastPart) {
+            OutputQueueSize -= event.EventSerializedSize;
+        }
 
         task.Write<false>(buffer, partSize);
 

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -13,7 +13,25 @@
 
 LWTRACE_USING(ACTORLIB_PROVIDER);
 
+static void AddFakeCredRecord(NActorsInterconnect::TRdmaCreds& creds) noexcept {
+    NActorsInterconnect::TRdmaCred* cred = creds.AddCreds();
+    // fixed64, fixed32 - any value
+    cred->SetAddress(0);
+    cred->SetRkey(12345);
+    // uint64 - protobuf uses VLC - max possible value 
+    cred->SetSize(Max<ui64>());
+}
+
+// Calculate min size required to save one cred
+static ui32 CalcRdmaCredsMinSizeSerialized() noexcept {
+    NActorsInterconnect::TRdmaCreds tmp;
+    AddFakeCredRecord(tmp);
+    return tmp.ByteSizeLong();
+}
+
 namespace NActors {
+    const ui32 TEventOutputChannel::RdmaCredsMinSizeSerialized = CalcRdmaCredsMinSizeSerialized();
+
     bool TEventOutputChannel::FeedDescriptor(TTcpPacketOutTask& task, TEventHolder& event) {
         const size_t amount = sizeof(TChannelPart) + sizeof(TEventDescr2);
         if (task.GetInternalFreeAmount() < amount) {
@@ -289,7 +307,8 @@ namespace NActors {
             if (IsPartInline) {
                 complete = FeedInlinePayload(task, event);
             } else if (SendViaRdma) {
-                complete = FeedRdmaPayload(task, event, rdmaDeviceIndex);
+                Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
+                complete = FeedRdmaPayload(task, event);
             } else {
                 complete = FeedExternalPayload(task, event);
             }
@@ -369,21 +388,93 @@ namespace NActors {
         return true;
     }
 
-    std::optional<bool> TEventOutputChannel::FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex) {
-        Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
-        const NActorsInterconnect::TRdmaCreds& rdmaCreds = SendViaRdma->RdmaCreds;
-        ui32 checkSum = SendViaRdma->CheckSum;
-
-        ui16 credsSerializedSize = rdmaCreds.ByteSizeLong();
-        // Part = | TChannelPart | EXdcCommand::RDMA_READ | rdmaCreds.Size | rdmaCreds | checkSum |
-        size_t partSize = sizeof(TChannelPart) + sizeof(ui8) + sizeof(ui16) + credsSerializedSize + sizeof(ui32);
-        Y_ABORT_UNLESS(partSize < 4096);
-
-        if (partSize > Max<ui16>() || partSize > task.GetInternalFreeAmount()) {
-            // TODO: support split into multiple parts
-            return std::nullopt; // not enough space to serialize RDMA payload
+    std::optional<bool> TEventOutputChannel::FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event) {
+        // The part layout is:
+        // Part = | TChannelPart | EXdcCommand::RDMA_READ (ui8)| rdmaCreds.Size (ui16) | seialized rdmaCreds | checkSum (ui32) |
+        const size_t fixedPartSize = sizeof(TChannelPart) + sizeof(ui8) + sizeof(ui16) + sizeof(ui32);
+        const ui32 minThreshold = fixedPartSize + RdmaCredsMinSizeSerialized;
+        // No free amount even for one rdma cred - we need new packet
+        if (task.GetInternalFreeAmount() < minThreshold) {
+            return std::nullopt;
         }
 
+        auto calcPartCredLen = [] (size_t freeAmount, float credsPerByteAvg) -> size_t {
+            return (freeAmount - fixedPartSize) * credsPerByteAvg;
+        };
+
+        const NActorsInterconnect::TRdmaCreds* rdmaCreds = &SendViaRdma->RdmaCreds;
+
+        NActorsInterconnect::TRdmaCreds tmpCreds; 
+
+        bool lastPart = true;
+
+        size_t partSize;
+        size_t credsSerializedSize;
+
+        size_t curPartCredLen = 0;
+        /*
+         * Split rdma creds in to multiple parts if serialized credential data doesn't fit in to one IC packets.
+         * Prerequisites:
+         * - We assume this situation should be quite rare, so do not perform any additional copy in happy path
+         * - If we need to split (and credential copy to perform serialization of its part) we want to reduce number of itterations
+         * - There is no guarantee to get task with well known ammount of free space
+         */
+        for (;;) {
+            if (Y_UNLIKELY(curPartCredLen || SendViaRdma->PartCredPos)) {
+                // First iteration for non first part
+                if (!curPartCredLen) {
+                    curPartCredLen = calcPartCredLen(task.GetInternalFreeAmount(), SendViaRdma->CredsPerByteAvg);
+                    if (!curPartCredLen) {
+                        return std::nullopt;
+                    }
+                }
+                // Check is it a last part?
+                if (SendViaRdma->PartCredPos + curPartCredLen >= SendViaRdma->RdmaCreds.CredsSize()) {
+                    curPartCredLen = SendViaRdma->RdmaCreds.CredsSize() - SendViaRdma->PartCredPos; 
+                    lastPart = true;
+                } else {
+                    lastPart = false;
+                }
+
+                //TODO: Find the way to perform partial serialzation of repeated field
+                tmpCreds.Clear();
+                for (size_t i = 0, j = SendViaRdma->PartCredPos; i < curPartCredLen; i++, j++) {
+                    tmpCreds.AddCreds()->CopyFrom(SendViaRdma->RdmaCreds.GetCreds(j));
+                }
+                rdmaCreds = &tmpCreds;
+            }
+
+            credsSerializedSize = rdmaCreds->ByteSizeLong();
+
+            partSize = fixedPartSize + credsSerializedSize;
+
+            if (Y_UNLIKELY(partSize > task.GetInternalFreeAmount())) {
+                SendViaRdma->CredsPerByteAvg = rdmaCreds->CredsSize() / (double)credsSerializedSize; 
+                size_t newLen = calcPartCredLen(task.GetInternalFreeAmount(), SendViaRdma->CredsPerByteAvg);
+
+                // Guarantee progress even in case of huge error of average calculation
+                if (newLen >= curPartCredLen) {
+                    curPartCredLen--;
+                } else {
+                    curPartCredLen = newLen;
+                }
+
+                if (!curPartCredLen) {
+                    return std::nullopt;
+                }
+            } else {
+                // Report to mon if it is first part of multipart rdma events
+                // huge number of multipart events may be a reason of some additional latency
+                if (Y_UNLIKELY(SendViaRdma->PartCredPos == 0 && curPartCredLen != 0)) {
+                    Metrics->IncRdmaMultipartEvents();
+                }
+                // Shift start position for the next packet
+                SendViaRdma->PartCredPos += curPartCredLen; 
+                break;
+            }
+        }
+
+        const ui32 checkSum = SendViaRdma->CheckSum;
         char buffer[partSize];
         TChannelPart *part = reinterpret_cast<TChannelPart*>(buffer);
         *part = {
@@ -396,11 +487,11 @@ namespace NActors {
         ptr += sizeof(ui16);
 
         ui32 payloadSz = 0;
-        for (const auto& rdmaCred : rdmaCreds.GetCreds()) {
+        for (const auto& rdmaCred : rdmaCreds->GetCreds()) {
             payloadSz += rdmaCred.GetSize();
         }
 
-        Y_ABORT_UNLESS(rdmaCreds.SerializePartialToArray(ptr, credsSerializedSize));
+        Y_ABORT_UNLESS(rdmaCreds->SerializePartialToArray(ptr, credsSerializedSize));
         ptr += credsSerializedSize;
         WriteUnaligned<ui32>(ptr, checkSum);
         OutputQueueSize -= event.EventSerializedSize;
@@ -409,7 +500,7 @@ namespace NActors {
 
         task.AttachRdmaPayloadSize(payloadSz);
 
-        return true;
+        return lastPart;
     }
 
     std::optional<bool> TEventOutputChannel::FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event) {
@@ -484,5 +575,4 @@ namespace NActors {
         }
         pool.Release(Queue);
     }
-
 }

--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -153,8 +153,13 @@ namespace NActors {
         struct TRdmaSerializationArtifacts {
             NActorsInterconnect::TRdmaCreds RdmaCreds;
             ui32 CheckSum = 0;
+            // Variable is used to split creds if the serialized size is grather than one IC packet
+            ui32 PartCredPos = 0;
+            float CredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
+
         };
         std::optional<TRdmaSerializationArtifacts> SendViaRdma;
+        const static ui32 RdmaCredsMinSizeSerialized;
 
         template<bool External>
         bool SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, size_t *bytesSerialized);
@@ -163,7 +168,7 @@ namespace NActors {
         bool FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex);
         std::optional<bool> FeedInlinePayload(TTcpPacketOutTask& task, TEventHolder& event);
         std::optional<bool> FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event);
-        std::optional<bool> FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex);
+        std::optional<bool> FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event);
 
         bool FeedDescriptor(TTcpPacketOutTask& task, TEventHolder& event);
 

--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -254,6 +254,10 @@ namespace {
             RdmaReadTimeHistogram->Collect(value);
         }
 
+        void IncRdmaMultipartEvents() override {
+            ++*RdmaMultipartEvents;
+        }
+
         void UpdateOutputChannelTraffic(ui16 channel, ui64 value) override {
             auto& ch = GetOutputChannel(channel);
             *ch.OutgoingTraffic += value;
@@ -332,6 +336,7 @@ namespace {
                     "InterconnectQueueTimeHistogramUs", NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 RdmaReadTimeHistogram = AdaptiveCounters->GetHistogram(
 +                    "RdmaReadTimeUs", NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
+                RdmaMultipartEvents = AdaptiveCounters->GetCounter("RdmaMultipartEvents", true);
             }
 
             if (updateGlobal) {
@@ -397,6 +402,7 @@ namespace {
         NMonitoring::THistogramPtr PingTimeHistogram;
         NMonitoring::THistogramPtr InterconnectQueueTimeHistogram;
         NMonitoring::THistogramPtr RdmaReadTimeHistogram;
+        NMonitoring::TDynamicCounters::TCounterPtr RdmaMultipartEvents;
 
         std::unordered_map<ui16, TOutputChannel> OutputChannels;
         TOutputChannel OtherOutputChannel;
@@ -616,6 +622,10 @@ namespace {
             RdmaReadTimeHistogram_->Record(value);
         }
 
+        void IncRdmaMultipartEvents() override {
+            RdmaMultipartEvents_->Inc();
+        }
+
         void UpdateOutputChannelTraffic(ui16 channel, ui64 value) override {
             auto& ch = GetOutputChannel(channel);
             if (ch.OutgoingTraffic) {
@@ -713,6 +723,7 @@ namespace {
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ic_queue_time_us"}}), NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 RdmaReadTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.rdma_read_time_us"}}), NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
+                RdmaMultipartEvents_ = createRate(AdaptiveMetrics_, "interconnect.rdma_multipart_events");
             }
 
             if (updateGlobal) {
@@ -800,6 +811,7 @@ namespace {
         NMonitoring::IHistogram* PingTimeHistogram_;
         NMonitoring::IHistogram* InterconnectQueueTimeHistogram_;
         NMonitoring::IHistogram* RdmaReadTimeHistogram_;
+        NMonitoring::IRate* RdmaMultipartEvents_;
 
         THashMap<ui16, TOutputChannel> OutputChannels_;
         TOutputChannel OtherOutputChannel_;

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -48,6 +48,7 @@ public:
     virtual void UpdateOutputChannelTraffic(ui16 channel, ui64 value) = 0;
     virtual void UpdateOutputChannelEvents(ui16 channel) = 0;
     virtual void SetUtilization(ui32 total, ui32 starvation) = 0;
+    virtual void IncRdmaMultipartEvents() = 0;
     TString GetHumanFriendlyPeerHostName() const {
         return HumanFriendlyPeerHostName.value_or(TString());
     }

--- a/ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h
+++ b/ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h
@@ -41,7 +41,7 @@ private:
 public:
     TTestICCluster(ui32 numNodes = 1, NActors::TChannelsConfig channelsConfig = NActors::TChannelsConfig(),
                    TTrafficInterrupterSettings* tiSettings = nullptr, TIntrusivePtr<NLog::TSettings> loggerSettings = nullptr, Flags flags = EMPTY,
-                   TCheckerFactory checkerFactory = {}, TDuration deadPeerTimeout = TDuration::Seconds(2))
+                   TCheckerFactory checkerFactory = {}, TDuration deadPeerTimeout = TDuration::Seconds(2), ui32 inflight = TNode::DefaultInflight())
         : NumNodes(numNodes)
         , DeadPeerTimeout(deadPeerTimeout)
         , Counters(new NMonitoring::TDynamicCounters)
@@ -75,7 +75,7 @@ public:
         for (ui32 i = 1; i <= NumNodes; ++i) {
             auto& portMap = tiSettings ? specificNodePortMap[i] : nodeToPortMap;
             Nodes.emplace(i, MakeHolder<TNode>(i, NumNodes, portMap, Address, Counters, DeadPeerTimeout, ChannelsConfig,
-                /*numDynamicNodes=*/0, /*numThreads=*/1, LoggerSettings, TNode::DefaultInflight(),
+                /*numDynamicNodes=*/0, /*numThreads=*/1, LoggerSettings, inflight,
                 flags & USE_ZC ? ESocketSendOptimization::IC_MSG_ZEROCOPY : ESocketSendOptimization::DISABLED,
                 flags & USE_TLS, checkerFactory, flags & RDMA_POLLING_CQ ? NInterconnect::NRdma::ECqMode::POLLING : NInterconnect::NRdma::ECqMode::EVENT));
         }

--- a/ydb/library/actors/interconnect/ut/lib/node.h
+++ b/ydb/library/actors/interconnect/ut/lib/node.h
@@ -93,7 +93,7 @@ public:
         setup.LocalServices.emplace_back(MakePollerActorId(), TActorSetupCmd(CreatePollerActor(),
             TMailboxType::ReadAsFilled, 0));
         setup.LocalServices.emplace_back(NInterconnect::NRdma::MakeCqActorId(),
-            TActorSetupCmd(NInterconnect::NRdma::CreateCqActor(-1, 32, rdmaCqMode, nullptr),
+            TActorSetupCmd(NInterconnect::NRdma::CreateCqActor(-1, 1024, rdmaCqMode, nullptr),
             TMailboxType::ReadAsFilled, 0));
 
         const TActorId loggerActorId = loggerSettings ? loggerSettings->LoggerActorId : TActorId(0, "logger");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

If the ammount of payloads for events become huge
the metadata size will be grather than size of one IC packet. In this case we can split rdma credentioals in to multiple IC packets.

The current implementation requires to set inflight limit grater that max expected rdma event size, otherwise we can stuck due to no ACK from receiver for non completed rdma event. This well be solved in a future.




### Changelog category <!-- remove all except one -->


* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
