### PR TITLE
Make string field in DB monpage in flat_executor_db_mon.cpp configurable via a cgi param

### DIFF
--- a/ydb/core/tablet_flat/flat_executor_db_mon.cpp
+++ b/ydb/core/tablet_flat/flat_executor_db_mon.cpp
@@ -140,6 +140,8 @@ public:
                     rowOffset = Max<ssize_t>(rowOffset, 0);
                     ssize_t rowLimit = FromStringWithDefault<ssize_t>(cgi.Get("MaxRows"), 1000);
                     rowLimit = Max<ssize_t>(rowLimit, 1);
+                    ssize_t stringlimit = FromStringWithDefault<ssize_t>(cgi.Get("MaxString"), 1024);
+                    stringlimit = Max<ssize_t>(stringlimit, 1);
                     ssize_t rowCount = 0;
                     while (result->Next(NTable::ENext::Data) == NTable::EReady::Data && rowCount < rowOffset + rowLimit) {
                             ++rowCount;
@@ -217,7 +219,7 @@ public:
                                         case NScheme::NTypeIds::String:
                                         case NScheme::NTypeIds::String4k:
                                         case NScheme::NTypeIds::String2m:
-                                            str << EncodeHtmlPcdata(EscapeC(TStringBuf(static_cast<const char*>(data), Min(size, (ui32)1024))));
+                                            str << EncodeHtmlPcdata(EscapeC(TStringBuf(static_cast<const char*>(data), Min(size, (ui32)stringlimit))));
                                             break;
                                         case NScheme::NTypeIds::ActorId:
                                             str << *(TActorId*)data;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Monpage of a database was used by us as an alternative to using miniKQL. But, since strings are cropped to 1024 chars, it renders this approach unusable sometimes
