### PR TITLE
Reset counters on monitoring project id change; use the id from config (main)

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -3440,11 +3440,12 @@ void TPartition::EndChangePartitionConfig(NKikimrPQ::TPQTabletConfig&& config,
         OffloadActor = {};
     }
 
-    MonitoringProjectId = Config.GetMonitoringProjectId();
-    if (DetailedMetricsAreEnabled(Config)) {
-        SetupDetailedMetrics();
-    } else {
+    if (MonitoringProjectId != Config.GetMonitoringProjectId() || !DetailedMetricsAreEnabled()) {
         ResetDetailedMetrics();
+    }
+    MonitoringProjectId = Config.GetMonitoringProjectId();
+    if (DetailedMetricsAreEnabled()) {
+        SetupDetailedMetrics();
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -3440,11 +3440,11 @@ void TPartition::EndChangePartitionConfig(NKikimrPQ::TPQTabletConfig&& config,
         OffloadActor = {};
     }
 
-    if (MonitoringProjectId != Config.GetMonitoringProjectId() || !DetailedMetricsAreEnabled()) {
+    if (MonitoringProjectId != Config.GetMonitoringProjectId() || !DetailedMetricsAreEnabled(Config)) {
         ResetDetailedMetrics();
     }
     MonitoringProjectId = Config.GetMonitoringProjectId();
-    if (DetailedMetricsAreEnabled()) {
+    if (DetailedMetricsAreEnabled(Config)) {
         SetupDetailedMetrics();
     }
 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1099,8 +1099,7 @@ void TPartition::Initialize(const TActorContext& ctx) {
                                       DbId,
                                       Config.GetYdbDatabasePath(),
                                       IsServerless,
-                                      FolderId,
-                                      MonitoringProjectId);
+                                      FolderId);
     TotalChannelWritesByHead.resize(NumChannels);
 
     if (!IsSupportive()) {

--- a/ydb/core/persqueue/pqtablet/partition/user_info.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.cpp
@@ -450,7 +450,7 @@ TUserInfo& TUsersInfoStorage::GetOrCreate(const TString& user, const TActorConte
         auto s = counters
             ->GetSubgroup("counters", IsServerless ? "topics_per_partition_serverless" : "topics_per_partition")
             ->GetSubgroup("host", "");
-        if (auto id = Config.GetMonitoringProjectId(); !id.empty()) {
+        if (const auto& id = Config.GetMonitoringProjectId(); !id.empty()) {
             s = s->GetSubgroup("monitoring_project_id", id);
         }
         return s
@@ -464,7 +464,7 @@ TUserInfo& TUsersInfoStorage::GetOrCreate(const TString& user, const TActorConte
         auto s = counters
             ->GetSubgroup("counters", "topics_per_partition")
             ->GetSubgroup("host", "cluster");
-        if (auto id = Config.GetMonitoringProjectId(); !id.empty()) {
+        if (const auto& id = Config.GetMonitoringProjectId(); !id.empty()) {
             s = s->GetSubgroup("monitoring_project_id", id);
         }
         return s

--- a/ydb/core/persqueue/pqtablet/partition/user_info.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.cpp
@@ -323,8 +323,7 @@ TUsersInfoStorage::TUsersInfoStorage(
     const TString& dbId,
     const TString& dbPath,
     const bool isServerless,
-    const TString& folderId,
-    const TString& monitoringProjectId
+    const TString& folderId
 )
     : DCId(std::move(dcId))
     , TopicConverter(topicConverter)
@@ -335,7 +334,6 @@ TUsersInfoStorage::TUsersInfoStorage(
     , DbPath(dbPath)
     , IsServerless(isServerless)
     , FolderId(folderId)
-    , MonitoringProjectId(monitoringProjectId)
     , CurReadRuleGeneration(0)
 {
 }
@@ -452,8 +450,8 @@ TUserInfo& TUsersInfoStorage::GetOrCreate(const TString& user, const TActorConte
         auto s = counters
             ->GetSubgroup("counters", IsServerless ? "topics_per_partition_serverless" : "topics_per_partition")
             ->GetSubgroup("host", "");
-        if (!MonitoringProjectId.empty()) {
-            s = s->GetSubgroup("monitoring_project_id", MonitoringProjectId);
+        if (auto id = Config.GetMonitoringProjectId(); !id.empty()) {
+            s = s->GetSubgroup("monitoring_project_id", id);
         }
         return s
             ->GetSubgroup("database", Config.GetYdbDatabasePath())
@@ -466,8 +464,8 @@ TUserInfo& TUsersInfoStorage::GetOrCreate(const TString& user, const TActorConte
         auto s = counters
             ->GetSubgroup("counters", "topics_per_partition")
             ->GetSubgroup("host", "cluster");
-        if (!MonitoringProjectId.empty()) {
-            s = s->GetSubgroup("monitoring_project_id", MonitoringProjectId);
+        if (auto id = Config.GetMonitoringProjectId(); !id.empty()) {
+            s = s->GetSubgroup("monitoring_project_id", id);
         }
         return s
             ->GetSubgroup("Account", TopicConverter->GetAccount())

--- a/ydb/core/persqueue/pqtablet/partition/user_info.h
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.h
@@ -192,8 +192,7 @@ public:
         const TString& DbId,
         const TString& DbPath,
         const bool isServerless,
-        const TString& FolderId,
-        const TString& MonitoringProjectId);
+        const TString& FolderId);
 
     void Init(TActorId tabletActor, TActorId partitionActor, const TActorContext& ctx);
 
@@ -280,7 +279,6 @@ private:
     TString DbPath;
     bool IsServerless;
     TString FolderId;
-    TString MonitoringProjectId;
     mutable ui64 CurReadRuleGeneration;
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Get MonitoringProjectId from config so the counters are updated when MonitoringProjectId is changed.

Reset counters on MonitoringProjectId, so they are recreated.