### PR TITLE
Large message in both zones

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1157,6 +1157,10 @@ void TPartition::LogAndCollectError(NKikimrServices::EServiceKikimr service, con
 
 const TPartitionBlobEncoder& TPartition::GetBlobEncoder(ui64 offset) const
 {
+    if ((offset >= CompactionBlobEncoder.EndOffset) && (offset < BlobEncoder.StartOffset)) {
+        offset = BlobEncoder.StartOffset;
+    }
+
     if (BlobEncoder.DataKeysBody.empty()) {
         return CompactionBlobEncoder;
     }
@@ -1174,12 +1178,6 @@ const TPartitionBlobEncoder& TPartition::GetBlobEncoder(ui64 offset) const
 
 const std::deque<TDataKey>& GetContainer(const TPartitionBlobEncoder& zone, ui64 offset)
 {
-    if (zone.HeadKeys.empty()) {
-        return zone.DataKeysBody;
-    } else if (zone.DataKeysBody.empty()) {
-        return zone.HeadKeys;
-    }
-
     return zone.PositionInBody(offset, 0) ? zone.DataKeysBody : zone.HeadKeys;
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1157,10 +1157,6 @@ void TPartition::LogAndCollectError(NKikimrServices::EServiceKikimr service, con
 
 const TPartitionBlobEncoder& TPartition::GetBlobEncoder(ui64 offset) const
 {
-    //if ((offset >= CompactionBlobEncoder.EndOffset) && (offset < BlobEncoder.StartOffset)) {
-    //    offset = BlobEncoder.StartOffset;
-    //}
-
     if (BlobEncoder.DataKeysBody.empty()) {
         return CompactionBlobEncoder;
     }

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1157,9 +1157,9 @@ void TPartition::LogAndCollectError(NKikimrServices::EServiceKikimr service, con
 
 const TPartitionBlobEncoder& TPartition::GetBlobEncoder(ui64 offset) const
 {
-    if ((offset >= CompactionBlobEncoder.EndOffset) && (offset < BlobEncoder.StartOffset)) {
-        offset = BlobEncoder.StartOffset;
-    }
+    //if ((offset >= CompactionBlobEncoder.EndOffset) && (offset < BlobEncoder.StartOffset)) {
+    //    offset = BlobEncoder.StartOffset;
+    //}
 
     if (BlobEncoder.DataKeysBody.empty()) {
         return CompactionBlobEncoder;
@@ -1178,6 +1178,12 @@ const TPartitionBlobEncoder& TPartition::GetBlobEncoder(ui64 offset) const
 
 const std::deque<TDataKey>& GetContainer(const TPartitionBlobEncoder& zone, ui64 offset)
 {
+    if (zone.HeadKeys.empty()) {
+        return zone.DataKeysBody;
+    } else if (zone.DataKeysBody.empty()) {
+        return zone.HeadKeys;
+    }
+
     return zone.PositionInBody(offset, 0) ? zone.DataKeysBody : zone.HeadKeys;
 }
 

--- a/ydb/core/persqueue/ut/common/pq_ut_common.h
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.h
@@ -653,4 +653,8 @@ void CmdRunCompaction(const ui32 partition,
 
 THolder<TEvPersQueue::TEvPeriodicTopicStats> GetReadBalancerPeriodicTopicStats(TTestActorRuntime& runtime, ui64 balancerId);
 
+void CmdRenameKey(const TString& oldKey,
+                  const TString& newKey,
+                  TTestContext& tc);
+
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -2909,7 +2909,6 @@ Y_UNIT_TEST(Large_Message_On_The_Border_Of_The_Zones) {
         activeZone = false;
         tc.Runtime->SetLogPriority(NKikimrServices::PERSQUEUE, NLog::PRI_DEBUG);
         tc.Runtime->SetScheduledLimit(3000);
-        //tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(100'000);
 
         ui32 sourceIdx = 0;
         auto cmdWrite = [&](const TVector<size_t>& sizes) {
@@ -2955,6 +2954,68 @@ Y_UNIT_TEST(Large_Message_On_The_Border_Of_The_Zones) {
 
         PQTabletRestart(tc);
         PQGetPartInfo(3, 6, tc);
+
+        // проверяем, что может прочитать сообщение, которое лежит между зонами
+        CmdRead(0, 4, 1, Max<i32>(), 1, false, tc, {4});
+        CmdRead(0, 3, 2, Max<i32>(), 2, false, tc, {3, 4});
+    });
+}
+
+Y_UNIT_TEST(Large_Message_On_The_Border_Of_The_Zones_2) {
+    TTestContext tc;
+    tc.EnableDetailedPQLog = true;
+    RunTestWithReboots(tc.TabletIds, [&]() {
+        return tc.InitialEventsFilter.Prepare();
+    }, [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
+        TFinalizer finalizer(tc);
+        tc.Prepare(dispatchName, setup, activeZone);
+        activeZone = false;
+        tc.Runtime->SetLogPriority(NKikimrServices::PERSQUEUE, NLog::PRI_DEBUG);
+        tc.Runtime->SetScheduledLimit(3000);
+        //tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(100'000);
+
+        ui32 sourceIdx = 0;
+        auto cmdWrite = [&](const TVector<size_t>& sizes) {
+            TVector<std::pair<ui64, TString>> data;
+            for (size_t k = 1; k <= sizes.size(); ++k) {
+                data.emplace_back(k, TString(sizes[k - 1], 'x'));
+            }
+            TString sourceId = "sourceid_" + ToString(sourceIdx++);
+            CmdWrite(0, sourceId, data, tc, false, {}, false, "", -1, -1, false, false, true);
+        };
+        auto cmdCompaction = [&]() {
+            CmdRunCompaction(0, tc);
+        };
+
+        PQTabletPrepare({.partitions = 1, .writeSpeed = 50_MB}, {}, tc);
+
+        cmdWrite({3500000, 3500000, 3500000, 3500001, 2900001});
+        cmdCompaction();
+
+        PQTabletRestart(tc);
+        PQGetPartInfo(3, 5, tc);
+
+        // Эмулируем, что CompactedZone.Head пустая. В отличие от предыдущего теста
+        // здесь нет сообщений в FWZ. Только "хвост" последнего сообщения из CZ
+        CmdRenameKey("d0000000000_00000000000000000004_00004_0000000001_00001|",
+                     "d0000000000_00000000000000000004_00004_0000000001_00001?",
+                     tc);
+
+        PQTabletRestart(tc);
+        PQGetPartInfo(3, 5, tc);
+
+        //
+        // остались ключи:
+        // d0000000000_00000000000000000002_00002_0000000002_00014
+        // d0000000000_00000000000000000004_00004_0000000001_00001?
+        //
+
+        // проверям, что можем перейти на любое из оставшихся сообщений
+        CmdSetOffset(0, "user", 3, false, tc);
+        CmdSetOffset(0, "user", 4, false, tc);
+
+        PQTabletRestart(tc);
+        PQGetPartInfo(3, 5, tc);
 
         // проверяем, что может прочитать сообщение, которое лежит между зонами
         CmdRead(0, 4, 1, Max<i32>(), 1, false, tc, {4});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue #32589

A large message on the border of CompatedZone and FastWriteZone. At the same time, the beginning of the message is in CZ.Body and ending in FWZ.Body, and CZ.Head is empty. The program expects that if a message starts in CZ.Body, then it continues in CZ.Head.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
