### PR TITLE
YQ-4839 supported multi sink DQ replicate

### DIFF
--- a/ydb/core/kqp/opt/kqp_opt_build_txs.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_build_txs.cpp
@@ -509,6 +509,42 @@ TVector<TDqPhyPrecompute> PrecomputeInputs(const TDqStage& stage) {
 }
 
 class TKqpBuildTxsTransformer : public TSyncTransformerBase {
+    class TEffectsInfo {
+    public:
+        enum class EType {
+            KQP_EFFECT,
+            KQP_SINK,
+            KQP_BATCH_SINK,
+        };
+
+        EType Type;
+        THashSet<TStringBuf> TablesPathIds;
+        THashMap<std::pair<const TExprNode*, ui64>, TKqpSinkEffect> SinkEffects; // (stage, sink index) -> effect
+
+        const TVector<TExprNode::TPtr>& GetExprs() const {
+            return Exprs;
+        }
+
+        TMaybeNode<TKqpSinkEffect> GetSinkEffect(const TDqStageBase& stage, ui64 index) const {
+            const auto it = SinkEffects.find(std::pair(stage.Raw(), index));
+            if (it == SinkEffects.end()) {
+                return {};
+            }
+            return it->second;
+        }
+
+        void AddExpr(const TExprNode::TPtr& expr) {
+            if (const auto maybeSinkEffect = TMaybeNode<TKqpSinkEffect>(expr)) {
+                const auto sinkEffect = maybeSinkEffect.Cast();
+                YQL_ENSURE(SinkEffects.emplace(std::pair(sinkEffect.Stage().Raw(), FromString<ui64>(sinkEffect.SinkIndex())), sinkEffect).second, "Found two effects with same sink");
+            }
+            Exprs.push_back(expr);
+        }
+
+    private:
+        TVector<TExprNode::TPtr> Exprs;
+    };
+
 public:
     TKqpBuildTxsTransformer(const TIntrusivePtr<TKqpOptimizeContext>& kqpCtx,
         const TIntrusivePtr<TKqpBuildQueryContext>& buildCtx, TAutoPtr<IGraphTransformer>&& typeAnnTransformer,
@@ -575,8 +611,11 @@ public:
 
         if (!query.Effects().Empty()) {
             auto collectedEffects = CollectEffects(query.Effects(), ctx, *KqpCtx);
+            if (!collectedEffects) {
+                return TStatus::Error;
+            }
 
-            for (auto& effects : collectedEffects) {
+            for (auto& effects : *collectedEffects) {
                 auto tx = BuildTx(effects.Ptr(), ctx, /* isPrecompute */ false);
                 if (!tx) {
                     return TStatus::Error;
@@ -598,38 +637,30 @@ public:
     }
 
 private:
-    TVector<TExprList> CollectEffects(const TExprList& list, TExprContext& ctx, TKqpOptimizeContext& kqpCtx) {
-        struct TEffectsInfo {
-            enum class EType {
-                KQP_EFFECT,
-                KQP_SINK,
-                KQP_BATCH_SINK,
-                EXTERNAL_SINK,
-            };
+    static TDqSink GetStageSink(const TKqpSinkEffect& effect) {
+        // (KqpSinkEffect (DqStage (... ((DqSink '0 (DataSink '"kikimr") ...)))) '0)
+        const auto maybeStage = effect.Stage().Maybe<TDqStageBase>();
+        YQL_ENSURE(maybeStage);
+        const auto stage = maybeStage.Cast();
+        YQL_ENSURE(stage.Outputs());
+        const auto outputs = stage.Outputs().Cast();
+        const size_t sinkIndex = FromString(effect.SinkIndex().Value());
+        YQL_ENSURE(sinkIndex < outputs.Size());
+        const auto maybeSink = outputs.Item(sinkIndex).Maybe<TDqSink>();
+        YQL_ENSURE(maybeSink);
+        return maybeSink.Cast();
+    }
 
-            EType Type;
-            THashSet<TStringBuf> TablesPathIds;
-            TVector<TExprNode::TPtr> Exprs;
-        };
+    std::optional<TVector<TExprList>> CollectEffects(const TExprList& list, TExprContext& ctx, TKqpOptimizeContext& kqpCtx) {
         TVector<TEffectsInfo> effectsInfos;
+        TVector<TExprNode::TPtr> externalEffects;
 
         for (const auto& expr : list) {
             if (auto sinkEffect = expr.Maybe<TKqpSinkEffect>()) {
-                const size_t sinkIndex = FromString(TStringBuf(sinkEffect.Cast().SinkIndex()));
-                const auto stage = sinkEffect.Cast().Stage().Maybe<TDqStageBase>();
-                YQL_ENSURE(stage);
-                YQL_ENSURE(stage.Cast().Outputs());
-                const auto outputs = stage.Cast().Outputs().Cast();
-                YQL_ENSURE(sinkIndex < outputs.Size());
-                const auto sink = outputs.Item(sinkIndex).Maybe<TDqSink>();
-                YQL_ENSURE(sink);
-
-                const auto sinkSettings = sink.Cast().Settings().Maybe<TKqpTableSinkSettings>();
+                const auto sinkSettings = GetStageSink(sinkEffect.Cast()).Settings().Maybe<TKqpTableSinkSettings>();
                 if (!sinkSettings) {
-                    // External writes always use their own physical transaction.
-                    effectsInfos.emplace_back();
-                    effectsInfos.back().Type = TEffectsInfo::EType::EXTERNAL_SINK;
-                    effectsInfos.back().Exprs.push_back(expr.Ptr());
+                    // External writes always added into one physical transaction.
+                    externalEffects.emplace_back(expr.Ptr());
                 } else {
                     // Two table sinks can't be executed in one physical transaction if they write into same table and have same priority.
 
@@ -652,7 +683,7 @@ private:
                             it->Type = TEffectsInfo::EType::KQP_SINK;
                         }
                         it->TablesPathIds.insert(tablePathId);
-                        it->Exprs.push_back(expr.Ptr());
+                        it->AddExpr(expr.Ptr());
                     } else {
                         auto it = std::find_if(
                             std::begin(effectsInfos),
@@ -663,7 +694,7 @@ private:
                             it = std::prev(std::end(effectsInfos));
                             it->Type = TEffectsInfo::EType::KQP_BATCH_SINK;
                         }
-                        it->Exprs.push_back(expr.Ptr());
+                        it->AddExpr(expr.Ptr());
                     }
                 }
             } else {
@@ -677,7 +708,16 @@ private:
                     it = std::prev(std::end(effectsInfos));
                     it->Type = TEffectsInfo::EType::KQP_EFFECT;
                 }
-                it->Exprs.push_back(expr.Ptr());
+                it->AddExpr(expr.Ptr());
+            }
+        }
+
+        if (externalEffects) {
+            if (!effectsInfos) {
+                effectsInfos.emplace_back();
+            }
+            for (const auto& expr : externalEffects) {
+                effectsInfos.back().AddExpr(expr);
             }
         }
 
@@ -685,32 +725,80 @@ private:
 
         for (const auto& effects : effectsInfos) {
             auto builder = Build<TExprList>(ctx, list.Pos());
-            for (const auto& expr : effects.Exprs) {
+            for (const auto& expr : effects.GetExprs()) {
                 builder.Add(expr);
             }
-            results.push_back(builder.Done());
+            auto effect = builder.Done();
+
+            // Check that effect does not contain DQ sinks from other effects.
+            TVector<TDqStage> stagesToReplace;
+            VisitExpr(effect.Ptr(), [](const TExprNode::TPtr& node) {
+                return !node->IsLambda();
+            }, [&](const TExprNode::TPtr& node) {
+                if (const auto maybeStage = TMaybeNode<TDqStage>(node)) {
+                    if (const auto stage = maybeStage.Cast(); const auto maybeOutputs = stage.Outputs()) {
+                        for (size_t i = 0; i < maybeOutputs.Cast().Size(); ++i) {
+                            if (!effects.GetSinkEffect(stage, i)) {
+                                stagesToReplace.emplace_back(stage);
+                                break;
+                            }
+                        }
+                    }
+                }
+                return true;
+            });
+
+            // Remove sinks corresponding to other effects and adjust sink indices.
+            TNodeOnNodeOwnedMap replaces(stagesToReplace.size());
+            for (const auto& stage : stagesToReplace) {
+                size_t sinkIndex = 0;
+                auto outputsBuilder = Build<TDqStageOutputsList>(ctx, stage.Pos());
+                const auto outputs = stage.Outputs().Cast();
+                for (size_t i = 0; i < outputs.Size(); ++i) {
+                    const auto maybeEffectNode = effects.GetSinkEffect(stage, i);
+                    if (!maybeEffectNode) {
+                        continue;
+                    }
+
+                    outputsBuilder.Add(outputs.Item(i));
+
+                    const auto effectNode = maybeEffectNode.Cast();
+                    const auto effectReplace = Build<TKqpSinkEffect>(ctx, effectNode.Pos())
+                        .InitFrom(effectNode)
+                        .SinkIndex().Build(sinkIndex++)
+                        .Done();
+                    YQL_ENSURE(replaces.emplace(effectNode.Raw(), effectReplace.Ptr()).second);
+                }
+
+                auto stageBuilder = Build<TDqStage>(ctx, stage.Pos()).InitFrom(stage);
+                if (sinkIndex) {
+                    stageBuilder.Outputs(outputsBuilder.Done());
+                } else {
+                    stageBuilder.Outputs(TMaybeNode<TDqStageOutputsList>{});
+                }
+                YQL_ENSURE(replaces.emplace(stage.Raw(), stageBuilder.Done().Ptr()).second);
+            }
+
+            if (replaces.empty()) {
+                results.emplace_back(effect);
+            } else {
+                TExprNode::TPtr output;
+                TOptimizeExprSettings settings(nullptr);
+                settings.VisitLambdas = false;
+                if (RemapExpr(effect.Ptr(), output, replaces, ctx, settings).Level == TStatus::Error) {
+                    return std::nullopt;
+                }
+                results.emplace_back(output);
+            }
         }
 
-        return results;
+        return std::move(results);
     }
 
     bool HasTableEffects(const TExprList& effectsList) const {
         for (const TExprBase& effect : effectsList) {
             if (auto maybeSinkEffect = effect.Maybe<TKqpSinkEffect>()) {
-                // (KqpSinkEffect (DqStage (... ((DqSink '0 (DataSink '"kikimr") ...)))) '0)
-                auto sinkEffect = maybeSinkEffect.Cast();
-                const size_t sinkIndex = FromString(TStringBuf(sinkEffect.SinkIndex()));
-                auto stageExpr = sinkEffect.Stage();
-                auto maybeStageBase = stageExpr.Maybe<TDqStageBase>();
-                YQL_ENSURE(maybeStageBase);
-                auto stage = maybeStageBase.Cast();
-                YQL_ENSURE(stage.Outputs());
-                auto outputs = stage.Outputs().Cast();
-                YQL_ENSURE(sinkIndex < outputs.Size());
-                auto maybeSink = outputs.Item(sinkIndex);
-                YQL_ENSURE(maybeSink.Maybe<TDqSink>());
-                auto sink = maybeSink.Cast<TDqSink>();
-                auto dataSink = TCoDataSink(sink.DataSink().Ptr());
+                auto dataSink = TCoDataSink(GetStageSink(maybeSinkEffect.Cast()).DataSink().Ptr());
                 if (dataSink.Category() == YdbProviderName || dataSink.Category() == KikimrProviderName) {
                     return true;
                 }

--- a/ydb/core/kqp/opt/kqp_opt_phy_check.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_phy_check.cpp
@@ -102,15 +102,12 @@ TAutoPtr<IGraphTransformer> CreateKqpCheckPhysicalQueryTransformer() {
                             }
                             usedOutputs.Set(outputIndex);
                         } else {
-                            // There can be also an effect with stage that has dq sinks
+                            // There can be also an effect(s) with stage that has dq sinks
                             // Check the following structure:
                             // TKqlQuery (tuple with 2 elems) - results and effects
                             auto stageParentsIt = parentsMap.find(stage.Raw());
                             YQL_ENSURE(stageParentsIt != parentsMap.end());
-                            if (stageParentsIt->second.size() != 1) {
-                                hasMultipleConsumers = true;
-                            } else {
-                                const TExprNode* effectNode = *stageParentsIt->second.begin();
+                            for (const TExprNode* effectNode : stageParentsIt->second) {
                                 auto effectParentIt = parentsMap.find(effectNode);
                                 YQL_ENSURE(effectParentIt != parentsMap.end());
                                 if (effectParentIt->second.size() != 1) {

--- a/ydb/core/kqp/opt/kqp_opt_phy_check.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_phy_check.cpp
@@ -88,6 +88,10 @@ TAutoPtr<IGraphTransformer> CreateKqpCheckPhysicalQueryTransformer() {
                     const auto& stageConsumers = GetConsumers(stage, parentsMap);
                     bool stageWithResult = false;
 
+                    // Allowed stage consumers:
+                    // - Multiple DQ output channels
+                    // - Multiple sink effects
+
                     TDynBitMap usedOutputs;
                     for (auto consumer : stageConsumers) {
                         if (auto maybeOutput = TExprBase(consumer).Maybe<TDqOutput>()) {
@@ -105,20 +109,29 @@ TAutoPtr<IGraphTransformer> CreateKqpCheckPhysicalQueryTransformer() {
                             // There can be also an effect(s) with stage that has dq sinks
                             // Check the following structure:
                             // TKqlQuery (tuple with 2 elems) - results and effects
-                            auto stageParentsIt = parentsMap.find(stage.Raw());
-                            YQL_ENSURE(stageParentsIt != parentsMap.end());
-                            for (const TExprNode* effectNode : stageParentsIt->second) {
-                                auto effectParentIt = parentsMap.find(effectNode);
-                                YQL_ENSURE(effectParentIt != parentsMap.end());
-                                if (effectParentIt->second.size() != 1) {
-                                    hasMultipleConsumers = true;
-                                } else {
-                                    const TExprNode* queryNode = *effectParentIt->second.begin();
-                                    YQL_ENSURE(queryNode->GetTypeAnn()->GetKind() == ETypeAnnotationKind::Tuple,
-                                        "Stage #" << PrintKqpStageOnly(stage, ctx) << " has unexpected consumer: "
-                                            << consumer->Content());
-                                }
+                            auto effectParentIt = parentsMap.find(consumer);
+                            YQL_ENSURE(effectParentIt != parentsMap.end());
+                            if (effectParentIt->second.size() != 1) {
+                                hasMultipleConsumers = true;
+                            } else {
+                                const TExprNode* queryNode = *effectParentIt->second.begin();
+                                YQL_ENSURE(queryNode->GetTypeAnn()->GetKind() == ETypeAnnotationKind::Tuple,
+                                    "Stage #" << PrintKqpStageOnly(stage, ctx) << " has unexpected consumer: "
+                                        << consumer->Content());
                             }
+                        }
+                    }
+
+                    if (const auto outputs = stage.Outputs()) {
+                        for (const auto& output : outputs.Cast()) {
+                            const auto outputIndex = FromString<ui32>(output.Index().Value());
+                            if (usedOutputs.Test(outputIndex)) {
+                                hasMultipleConsumers = true;
+                                YQL_CLOG(ERROR, ProviderKqp) << "Stage #" << node.Ref().UniqueId()
+                                    << ", output " << outputIndex << " has multiple consumers (output used by channel and sink)";
+                                return false;
+                            }
+                            usedOutputs.Set(outputIndex);
                         }
                     }
 

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -245,7 +245,6 @@ public:
                 planNode.TypeName = "Effect";
                 Visit(TExprBase(stage), planNode);
             } else if (stageBase.Outputs()) { // Sink
-                AFL_ENSURE(stageBase.Outputs().Cast().Size() == 1);
                 auto& planNode = AddPlanNode(phaseNode);
                 Visit(TExprBase(stage), planNode);
             }
@@ -1096,7 +1095,6 @@ private:
             if (auto outputs = expr.Cast<TDqStageBase>().Outputs()) {
                 for (auto output : outputs.Cast()) {
                     if (auto sink = output.Maybe<TDqSink>()) {
-                        AFL_ENSURE(outputs.Cast().Size() == 1);
                         Visit(sink.Cast(), expr.Cast<TDqStageBase>(), planNode);
                     }
                 }

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -359,9 +359,22 @@ public:
 
     // Query client SDK
 
-    std::vector<TResultSet> ExecQuery(const TString& query, EStatus expectedStatus = EStatus::SUCCESS, const TString& expectedError = "") {
-        auto result = GetQueryClient()->ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+    std::vector<TResultSet> ExecQuery(const TString& query, EStatus expectedStatus = EStatus::SUCCESS, const TString& expectedError = "", std::function<void(const TString&)> astValidator = nullptr) {
+        auto settings = TExecuteQuerySettings();
+        if (astValidator) {
+            settings.StatsMode(EStatsMode::Full);
+        }
+
+        auto result = GetQueryClient()->ExecuteQuery(query, TTxControl::NoTx(), settings).ExtractValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToOneLineString());
+
+        if (astValidator) {
+            const auto& stats = result.GetStats();
+            UNIT_ASSERT(stats);
+            const auto& ast = stats->GetAst();
+            UNIT_ASSERT(ast);
+            astValidator(TString(*ast));
+        }
 
         if (expectedError) {
             UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), expectedError);
@@ -1777,6 +1790,199 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
             "ydb_source"_a = ydbSourceName,
             "table"_a = ydbTable
         ), EStatus::SCHEME_ERROR, "Cannot find table '/Root/unknown-datasource.[unknown-topic]' because it does not exist or you do not have access permissions");
+    }
+
+    Y_UNIT_TEST_F(ReplicatedFederativeWriting, TStreamingTestFixture) {
+        constexpr char firstOutputTopic[] = "replicatedWritingOutputTopicName1";
+        constexpr char secondOutputTopic[] = "replicatedWritingOutputTopicName2";
+        constexpr char pqSource[] = "pqSourceName";
+        CreateTopic(firstOutputTopic);
+        CreateTopic(secondOutputTopic);
+        CreatePqSource(pqSource);
+
+        constexpr char solomonSink[] = "solomonSinkName";
+        ExecQuery(fmt::format(R"(
+            CREATE EXTERNAL DATA SOURCE `{solomon_source}` WITH (
+                SOURCE_TYPE = "Solomon",
+                LOCATION = "localhost:{solomon_port}",
+                AUTH_METHOD = "NONE",
+                USE_TLS = "false"
+            );)",
+            "solomon_source"_a = solomonSink,
+            "solomon_port"_a = getenv("SOLOMON_HTTP_PORT")
+        ));
+
+        constexpr char sourceTable[] = "source";
+        constexpr char rowSinkTable[] = "rowSink";
+        constexpr char columnSinkTable[] = "columnSink";
+        ExecQuery(fmt::format(R"(
+            CREATE TABLE `{source_table}` (
+                Data String NOT NULL,
+                PRIMARY KEY (Data)
+            );
+            CREATE TABLE `{row_table}` (
+                B Utf8 NOT NULL,
+                PRIMARY KEY (B)
+            );
+            CREATE TABLE `{column_table}` (
+                C String NOT NULL,
+                PRIMARY KEY (C)
+            ) WITH (
+                STORE = COLUMN
+            );)",
+            "source_table"_a = sourceTable,
+            "row_table"_a = rowSinkTable,
+            "column_table"_a = columnSinkTable
+        ));
+
+        ExecQuery(fmt::format(R"(
+            UPSERT INTO `{table}`
+                (Data)
+            VALUES
+                ("{{\"Val\": \"ABC\"}}");)",
+            "table"_a = sourceTable
+        ));
+
+        const auto astChecker = [](ui64 txCount, ui64 stagesCount) {
+            const auto stringCounter = [](const TString& str, const TString& subStr) {
+                ui64 count = 0;
+                for (size_t i = str.find(subStr); i != TString::npos; i = str.find(subStr, i + subStr.size())) {
+                    ++count;
+                }
+                return count;
+            };
+
+            return [txCount, stagesCount, stringCounter](const TString& ast) {
+                UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "KqpPhysicalTx"), txCount);
+                UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "DqPhyStage"), stagesCount);
+            };
+        };
+
+        TInstant disposition = TInstant::Now();
+
+        // Double PQ insert
+        {
+            ExecQuery(fmt::format(R"(
+                $rows = SELECT Data FROM `{source_table}`;
+                INSERT INTO `{pq_source}`.`{output_topic1}` SELECT Unwrap(CAST("[" || Data || "]" AS Json)) AS A FROM $rows;
+                INSERT INTO `{pq_source}`.`{output_topic2}` SELECT Unwrap(CAST(Data || "-B" AS String)) AS B FROM $rows;)",
+                "source_table"_a = sourceTable,
+                "pq_source"_a = pqSource,
+                "output_topic1"_a = firstOutputTopic,
+                "output_topic2"_a = secondOutputTopic
+            ), EStatus::SUCCESS, "", astChecker(1, 1));
+
+            ReadTopicMessage(firstOutputTopic, R"([{"Val": "ABC"}])", disposition);
+            ReadTopicMessage(secondOutputTopic, R"({"Val": "ABC"}-B)", disposition);
+            disposition = TInstant::Now();
+        }
+
+        // Double solomon insert
+        {
+            const TSolomonLocation firstSoLocation = {
+                .ProjectId = "cloudId1",
+                .FolderId = "folderId1",
+                .Service = "custom1",
+                .IsCloud = false,
+            };
+            const TSolomonLocation secondSoLocation = {
+                .ProjectId = "cloudId2",
+                .FolderId = "folderId2",
+                .Service = "custom2",
+                .IsCloud = false,
+            };
+
+            CleanupSolomon(firstSoLocation);
+            CleanupSolomon(secondSoLocation);
+
+            ExecQuery(fmt::format(R"(
+                $rows = SELECT Data FROM `{source_table}`;
+
+                INSERT INTO `{solomon_sink}`.`{first_solomon_project}/{first_solomon_folder}/{first_solomon_service}`
+                SELECT Unwrap(CAST("[" || Data || "]" AS Json)) AS sensor, 1 AS value, Timestamp("2025-03-12T14:40:39Z") AS ts FROM $rows;
+
+                INSERT INTO `{solomon_sink}`.`{second_solomon_project}/{second_solomon_folder}/{second_solomon_service}`
+                SELECT Unwrap(CAST(Data || "-B" AS String)) AS sensor, 2 AS value, Timestamp("2025-03-12T14:40:39Z") AS ts FROM $rows;)",
+                "source_table"_a = sourceTable,
+                "solomon_sink"_a = solomonSink,
+                "first_solomon_project"_a = firstSoLocation.ProjectId,
+                "first_solomon_folder"_a = firstSoLocation.FolderId,
+                "first_solomon_service"_a = firstSoLocation.Service,
+                "second_solomon_project"_a = secondSoLocation.ProjectId,
+                "second_solomon_folder"_a = secondSoLocation.FolderId,
+                "second_solomon_service"_a = secondSoLocation.Service
+            ), EStatus::SUCCESS, "", astChecker(1, 1));
+
+            TString expectedMetrics = R"([
+  {
+    "labels": [
+      [
+        "name",
+        "value"
+      ],
+      [
+        "sensor",
+        "[{\"Val\": \"ABC\"}]"
+      ]
+    ],
+    "ts": 1741790439,
+    "value": 1
+  }
+])";
+            UNIT_ASSERT_STRINGS_EQUAL(GetSolomonMetrics(firstSoLocation), expectedMetrics);
+
+            expectedMetrics = R"([
+  {
+    "labels": [
+      [
+        "name",
+        "value"
+      ],
+      [
+        "sensor",
+        "{\"Val\": \"ABC\"}-B"
+      ]
+    ],
+    "ts": 1741790439,
+    "value": 2
+  }
+])";
+            UNIT_ASSERT_STRINGS_EQUAL(GetSolomonMetrics(secondSoLocation), expectedMetrics);
+        }
+
+        // Mixed external and kqp writing
+        {
+            ExecQuery(fmt::format(R"(
+                $rows = SELECT Data FROM `{source_table}`;
+                UPSERT INTO `{column_table}` SELECT Unwrap(CAST(Data || "-C" AS String)) AS C FROM $rows;
+                INSERT INTO `{pq_source}`.`{output_topic}` SELECT Unwrap(CAST("[" || Data || "]" AS Json)) AS A FROM $rows;
+                UPSERT INTO `{row_table}` SELECT Unwrap(CAST(Data || "-B" AS Utf8)) AS B FROM $rows;)",
+                "source_table"_a = sourceTable,
+                "pq_source"_a = pqSource,
+                "output_topic"_a = firstOutputTopic,
+                "row_table"_a = rowSinkTable,
+                "column_table"_a = columnSinkTable
+            ), EStatus::SUCCESS, "", astChecker(2, 4));
+
+            ReadTopicMessage(firstOutputTopic, R"([{"Val": "ABC"}])", disposition);
+            disposition = TInstant::Now();
+
+            const auto& results = ExecQuery(fmt::format(R"(
+                SELECT * FROM `{row_table}`;
+                SELECT * FROM `{column_table}`;)",
+                "row_table"_a = rowSinkTable,
+                "column_table"_a = columnSinkTable
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(results.size(), 2);
+
+            CheckScriptResult(results[0], 1, 1, [&](TResultSetParser& resultSet) {
+                UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("B").GetUtf8(), R"({"Val": "ABC"}-B)");
+            });
+
+            CheckScriptResult(results[1], 1, 1, [&](TResultSetParser& resultSet) {
+                UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("C").GetString(), R"({"Val": "ABC"}-C)");
+            });
+        }
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported multi sink DQ replicate for PQ and Solomon inserts. Also placed all external effects into single transaction.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

It allows to write queries:

```sql
$rows = SELECT Unwrap(Data) AS Data FROM pq.input_topic;
INSERT INTO pq.output_topic1 SELECT Unwrap(CAST("[" || Data || "]" AS Json)) AS A FROM $rows;
INSERT INTO pq.output_topic2 SELECT Unwrap(CAST(Data || "-B" AS String)) AS B FROM $rows;
```

Same for solomon insert.