### PR TITLE
Fix Knn pushdown for tagged vectors converted from parameters (fix #32767)

### DIFF
--- a/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
+++ b/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
@@ -264,6 +264,22 @@ Y_UNIT_TEST_SUITE(KqpKnn) {
                 .Build()
             .Build());
 
+        // Tagged vector converted from a parameter
+        runQueryWithParams(Q_(R"(
+            DECLARE $embedding AS List<Uint8>;
+            $TargetEmbedding = Knn::ToBinaryStringUint8($embedding);
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance(emb, $TargetEmbedding)
+            LIMIT 3
+        )"), db.GetParamsBuilder()
+            .AddParam("$embedding")
+                .BeginList()
+                    .AddListItem().Uint8(0x67)
+                    .AddListItem().Uint8(0x71)
+                .EndList()
+                .Build()
+            .Build());
+
         // LIMIT 1
         expectedLimit = 1;
         runQuery(Q_(R"(

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -133,6 +133,13 @@ void ValidateParamValue(std::string_view paramName, const TType* type, const NUd
             break;
         }
 
+        case TType::EKind::Tagged: {
+            auto taggedType = static_cast<const TTaggedType*>(type);
+            TType* baseType = taggedType->GetBaseType();
+            ValidateParamValue(paramName, baseType, value);
+            break;
+        }
+
         default:
             YQL_ENSURE(false, "Unexpected value type in parameter"
                 << ", parameter: " << paramName


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Error message from the test without the fix was:

```
assertion failed at ydb/core/kqp/ut/knn/kqp_knn_ut.cpp:182, auto NKikimr::NKqp::NTestSuiteKqpKnn::TTestCaseVectorSearchKnnPushdown<true>::Execute_(NUnitTest::TTestContext &)::(anonymous class)::operator()(const TString &, TParams) const [Nullable = true]: (result.IsSuccess()) <main>: Fatal: ydb/library/yql/dq/runtime/dq_tasks_runner.cpp:139  ValidateParamValue(): requirement false failed, message: Unexpected value type in parameter, parameter: %kqp%tx_result_binding_0_0, type: Tagged, code: 1
<main>: Error: Query invalidated on scheme/internal error during Data execution, code: 2019
```