### PR TITLE
[25-4-1] Fix Knn pushdown for tagged vectors converted from parameters (fix #32767)

### DIFF
--- a/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
+++ b/ydb/core/kqp/ut/knn/kqp_knn_ut.cpp
@@ -234,6 +234,22 @@ Y_UNIT_TEST_SUITE(KqpKnn) {
                 .Build()
             .Build());
 
+        // Tagged vector converted from a parameter
+        runQueryWithParams(Q_(R"(
+            DECLARE $embedding AS List<Uint8>;
+            $TargetEmbedding = Knn::ToBinaryStringUint8($embedding);
+            SELECT * FROM `/Root/TestTable`
+            ORDER BY Knn::CosineDistance(emb, $TargetEmbedding)
+            LIMIT 3
+        )"), db.GetParamsBuilder()
+            .AddParam("$embedding")
+                .BeginList()
+                    .AddListItem().Uint8(0x67)
+                    .AddListItem().Uint8(0x71)
+                .EndList()
+                .Build()
+            .Build());
+
         // LIMIT 1
         expectedLimit = 1;
         runQuery(Q_(R"(

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -132,6 +132,13 @@ void ValidateParamValue(std::string_view paramName, const TType* type, const NUd
             break;
         }
 
+        case TType::EKind::Tagged: {
+            auto taggedType = static_cast<const TTaggedType*>(type);
+            TType* baseType = taggedType->GetBaseType();
+            ValidateParamValue(paramName, baseType, value);
+            break;
+        }
+
         default:
             YQL_ENSURE(false, "Unexpected value type in parameter"
                 << ", parameter: " << paramName


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers