### PR TITLE
fix: correct struct.pack format string for float vectors in docs

### DIFF
--- a/ydb/docs/ru/core/recipes/ydb-sdk/vector-search.md
+++ b/ydb/docs/ru/core/recipes/ydb-sdk/vector-search.md
@@ -134,7 +134,7 @@
     import struct
 
     def convert_vector_to_bytes(vector: list[float]) -> bytes:
-        b = struct.pack("<f" * len(vector), *vector)
+        b = struct.pack("f" * len(vector), *vector)
         return b + b"\x01"
 
     def insert_items_vector_as_bytes(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes the `convert_vector_to_bytes` in docs to match [the provided example](https://github.com/ydb-platform/ydb/blob/6e26daa7e593d763e34cf18d4bdcc76094c2c3ef/ydb/public/sdk/python/examples/vector_search/vector_search.py#L8).

The one in the docs **is also simply incorrect** and will lead to an error.
