### PR TITLE
Implement raw reads and writes in PDisk

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -779,6 +779,8 @@ struct TEvBlobStorage {
         EvFullSyncFinished,
         EvAddFullSyncSsts,
         EvAddFullSyncSstsResult,
+        EvChunkReadRaw,
+        EvChunkWriteRaw,
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,
@@ -836,6 +838,8 @@ struct TEvBlobStorage {
         EvCommitVDiskMetadata,
         EvCommitVDiskMetadataDone,
         EvChangeExpectedSlotCountResult,
+        EvChunkReadRawResult,
+        EvChunkWriteRawResult,
 
         // internal proxy interface
         EvUnusedLocal1 = EvPut + 10 * 512, // Not used.    /// 268 637 184

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.cpp
@@ -47,8 +47,8 @@ namespace NKikimr::NDDisk {
             hFunc(NPDisk::TEvLogResult, Handle)
             hFunc(TEvPrivate::TEvHandleEventForChunk, Handle)
             hFunc(NPDisk::TEvCutLog, Handle)
-            hFunc(NPDisk::TEvChunkWriteResult, Handle)
-            hFunc(NPDisk::TEvChunkReadResult, Handle)
+            hFunc(NPDisk::TEvChunkWriteRawResult, Handle)
+            hFunc(NPDisk::TEvChunkReadRawResult, Handle)
 
             cFunc(TEvents::TSystem::Poison, PassAway)
         )

--- a/ydb/core/blobstorage/ddisk/ddisk_actor.h
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor.h
@@ -115,8 +115,8 @@ namespace NKikimr::NDDisk {
         std::queue<std::tuple<ui64, ui64>> ChunkAllocateQueue;
         THashMap<ui64, std::function<void()>> LogCallbacks;
         ui64 NextCookie = 1;
-        THashMap<void*, std::function<void(NPDisk::TEvChunkWriteResult&)>> WriteCallbacks;
-        THashMap<void*, std::function<void(NPDisk::TEvChunkReadResult&)>> ReadCallbacks;
+        THashMap<ui64, std::function<void(NPDisk::TEvChunkWriteRawResult&)>> WriteCallbacks;
+        THashMap<ui64, std::function<void(NPDisk::TEvChunkReadRawResult&)>> ReadCallbacks;
 
         void IssueChunkAllocation(ui64 tabletId, ui64 vChunkIndex);
         void Handle(NPDisk::TEvChunkReserveResult::TPtr ev);
@@ -126,8 +126,8 @@ namespace NKikimr::NDDisk {
 
         void Handle(NPDisk::TEvCutLog::TPtr ev);
 
-        void Handle(NPDisk::TEvChunkWriteResult::TPtr ev);
-        void Handle(NPDisk::TEvChunkReadResult::TPtr ev);
+        void Handle(NPDisk::TEvChunkWriteRawResult::TPtr ev);
+        void Handle(NPDisk::TEvChunkReadRawResult::TPtr ev);
 
         ui64 GetFirstLsnToKeep() const;
 
@@ -205,9 +205,6 @@ namespace NKikimr::NDDisk {
         // Read/write
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        THashMap<TString, size_t> BlockRefCount;
-        THashMap<std::tuple<ui64, ui64, ui32>, const TString*> Blocks;
-
         void Handle(TEvWrite::TPtr ev);
         void Handle(TEvRead::TPtr ev);
 
@@ -225,6 +222,7 @@ namespace NKikimr::NDDisk {
             std::map<ui64, TRecord> Records;
         };
 
+        THashMap<TString, size_t> BlockRefCount;
         std::map<std::tuple<ui64, ui64>, TPersistentBuffer> PersistentBuffers;
 
         struct TWriteInFlight {

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_read_write.cpp
@@ -30,57 +30,34 @@ namespace NKikimr::NDDisk {
 
         Y_ABORT_UNLESS(chunkRef.ChunkIdx);
 
-//        void *cookie = reinterpret_cast<void*>(NextCookie++);
-//        Send(BaseInfo.PDiskActorId, new NPDisk::TEvChunkWrite(
-//            PDiskParams->Owner,
-//            PDiskParams->OwnerRound,
-//            chunkRef.ChunkIdx,
-//            selector.OffsetInBytes,
-//            MakeIntrusive<NPDisk::TEvChunkWrite::TRopeAlignedParts>(std::move(data), data.size()),
-//            cookie,
-//            false /*doFlush*/,
-//            NPriWrite::HullHugeUserData,
-//            false /*isSeqWrite*/));
-//        WriteCallbacks.emplace(cookie, [&](NPDisk::TEvChunkWriteResult& ev) {
-//        });
+        const ui64 cookie = NextCookie++;
+        Send(BaseInfo.PDiskActorID, new NPDisk::TEvChunkWriteRaw(
+            PDiskParams->Owner,
+            PDiskParams->OwnerRound,
+            chunkRef.ChunkIdx,
+            selector.OffsetInBytes,
+            std::move(data)), 0, cookie);
 
-        std::tuple<ui64, ui64, ui32> blockId{
-            creds.TabletId,
-            selector.VChunkIndex,
-            selector.OffsetInBytes / BlockSize,
-        };
-        auto dataIter = data.Begin();
-        for (size_t offs = 0; offs < selector.Size; offs += BlockSize, ++std::get<2>(blockId)) {
-            TString block = TString::Uninitialized(BlockSize);
-            dataIter.ExtractPlainDataAndAdvance(block.Detach(), block.size());
-
-            // insert block into block map
-            const auto [it, _] = BlockRefCount.try_emplace(std::move(block));
-            ++it->second;
-
-            // replace block data
-            if (const TString *prev = std::exchange(Blocks[blockId], &it->first)) {
-                const auto kt = BlockRefCount.find(*prev);
-                Y_ABORT_UNLESS(kt != BlockRefCount.end());
-                if (!--kt->second) {
-                    BlockRefCount.erase(kt);
-                }
+        WriteCallbacks.emplace(cookie, [this, sender = ev->Sender, cookie = ev->Cookie, session = ev->InterconnectSession](
+                NPDisk::TEvChunkWriteRawResult& /*ev*/) {
+            auto reply = std::make_unique<TEvWriteResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK);
+            auto h = std::make_unique<IEventHandle>(sender, SelfId(), reply.release(), 0, cookie);
+            if (session) {
+                h->Rewrite(TEvInterconnect::EvForward, session);
             }
-        }
-
-
-        SendReply(*ev, std::make_unique<TEvWriteResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK));
+            TActivationContext::Send(h.release());
+        });
     }
 
-	void TDDiskActor::Handle(NPDisk::TEvChunkWriteResult::TPtr ev) {
+	void TDDiskActor::Handle(NPDisk::TEvChunkWriteRawResult::TPtr ev) {
         auto& msg = *ev->Get();
-        STLOG(PRI_DEBUG, BS_DDISK, BSDD07, "TDDiskActor::Handle(TEvChunkWriteResult)", (DDiskId, DDiskId), (Msg, msg.ToString()));
+        STLOG(PRI_DEBUG, BS_DDISK, BSDD07, "TDDiskActor::Handle(TEvChunkWriteRawResult)", (DDiskId, DDiskId), (Msg, msg.ToString()));
         
         if (msg.Status != NKikimrProto::OK) {
             Y_ABORT();
         }
 
-        const auto it = WriteCallbacks.find(msg.Cookie);
+        const auto it = WriteCallbacks.find(ev->Cookie);
         Y_ABORT_UNLESS(it != WriteCallbacks.end());
         it->second(msg);
         WriteCallbacks.erase(it);
@@ -100,41 +77,43 @@ namespace NKikimr::NDDisk {
         TChunkRef& chunkRef = ChunkRefs[creds.TabletId][selector.VChunkIndex];
         if (!chunkRef.PendingEventsForChunk.empty()) {
             chunkRef.PendingEventsForChunk.emplace(ev.Release());
-            return;
         } else if (!chunkRef.ChunkIdx) {
             auto zero = TRcBuf::Uninitialized(selector.Size);
             memset(zero.GetDataMut(), 0, zero.size());
             result.Insert(result.End(), std::move(zero));
+            SendReply(*ev, std::make_unique<TEvReadResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
+                std::move(result)));
         } else {
-            std::tuple<ui64, ui64, ui32> blockId{
-                creds.TabletId,
-                selector.VChunkIndex,
-                selector.OffsetInBytes / BlockSize,
-            };
-            for (size_t offs = 0; offs < selector.Size; offs += BlockSize, ++std::get<2>(blockId)) {
-                if (const auto it = Blocks.find(blockId); it != Blocks.end()) {
-                    result.Insert(result.End(), TRope(*it->second));
-                } else {
-                    TString zero = TString::Uninitialized(BlockSize);
-                    memset(zero.Detach(), 0, zero.size());
-                    result.Insert(result.End(), TRope(std::move(zero)));
-                }
-            }
-        }
+            const ui64 cookie = NextCookie++;
+            Send(BaseInfo.PDiskActorID, new NPDisk::TEvChunkReadRaw(
+                PDiskParams->Owner,
+                PDiskParams->OwnerRound,
+                chunkRef.ChunkIdx,
+                selector.OffsetInBytes,
+                selector.Size), 0, cookie);
 
-        SendReply(*ev, std::make_unique<TEvReadResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
-            std::move(result)));
+            ReadCallbacks.emplace(cookie, [this, sender = ev->Sender, cookie = ev->Cookie, session = ev->InterconnectSession](
+                    NPDisk::TEvChunkReadRawResult& ev) {
+                auto reply = std::make_unique<TEvReadResult>(NKikimrBlobStorage::NDDisk::TReplyStatus::OK, std::nullopt,
+                    std::move(ev.Data));
+                auto h = std::make_unique<IEventHandle>(sender, SelfId(), reply.release(), 0, cookie);
+                if (session) {
+                    h->Rewrite(TEvInterconnect::EvForward, session);
+                }
+                TActivationContext::Send(h.release());
+            });
+        }
     }
 
-	void TDDiskActor::Handle(NPDisk::TEvChunkReadResult::TPtr ev) {
+	void TDDiskActor::Handle(NPDisk::TEvChunkReadRawResult::TPtr ev) {
         auto& msg = *ev->Get();
-        STLOG(PRI_DEBUG, BS_DDISK, BSDD08, "TDDiskActor::Handle(TEvChunkReadResult)", (DDiskId, DDiskId), (Msg, msg.ToString()));
+        STLOG(PRI_DEBUG, BS_DDISK, BSDD08, "TDDiskActor::Handle(TEvChunkReadRawResult)", (DDiskId, DDiskId), (Msg, msg.ToString()));
 
         if (msg.Status != NKikimrProto::OK) {
             Y_ABORT();
         }
 
-        const auto it = ReadCallbacks.find(msg.Cookie);
+        const auto it = ReadCallbacks.find(ev->Cookie);
         Y_ABORT_UNLESS(it != ReadCallbacks.end());
         it->second(msg);
         ReadCallbacks.erase(it);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -188,7 +188,7 @@ struct TEvYardInitResult : TEventLocal<TEvYardInitResult, TEvBlobStorage::EvYard
     TEvYardInitResult(const NKikimrProto::EReplyStatus status, TString errorReason)
         : Status(status)
         , StatusFlags(0)
-        , PDiskParams(new TPDiskParams(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, DEVICE_TYPE_ROT, false))
+        , PDiskParams(new TPDiskParams(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, DEVICE_TYPE_ROT, false, 0))
         , ErrorReason(std::move(errorReason))
     {
         Y_VERIFY(status != NKikimrProto::OK, "Single-parameter constructor is for error responses only");
@@ -199,7 +199,8 @@ struct TEvYardInitResult : TEventLocal<TEvYardInitResult, TEvBlobStorage::EvYard
             ui64 bulkWriteBlockSize, ui32 chunkSize, ui32 appendBlockSize,
             TOwner owner, TOwnerRound ownerRound, ui32 slotSizeInUnits,
             TStatusFlags statusFlags, TVector<TChunkIdx> ownedChunks,
-            EDeviceType trueMediaType, bool isTinyDisk, TString errorReason)
+            EDeviceType trueMediaType, bool isTinyDisk, ui32 rawSectorSize,
+            TString errorReason)
         : Status(status)
         , StatusFlags(statusFlags)
         , PDiskParams(new TPDiskParams(
@@ -215,7 +216,8 @@ struct TEvYardInitResult : TEventLocal<TEvYardInitResult, TEvBlobStorage::EvYard
                     writeBlockSize,
                     bulkWriteBlockSize,
                     trueMediaType,
-                    isTinyDisk))
+                    isTinyDisk,
+                    rawSectorSize))
         , OwnedChunks(std::move(ownedChunks))
         , ErrorReason(std::move(errorReason))
     {}
@@ -1275,6 +1277,91 @@ struct TEvChunkWriteResult : TEventLocal<TEvChunkWriteResult, TEvBlobStorage::Ev
         str << " StatusFlags# " << StatusFlagsToString(record.StatusFlags);
         str << "}";
         return str.Str();
+    }
+};
+
+struct TEvChunkReadRaw : TEventLocal<TEvChunkReadRaw, TEvBlobStorage::EvChunkReadRaw> {
+    TOwner Owner;
+    TOwnerRound OwnerRound;
+    TChunkIdx ChunkIdx;
+    ui32 Offset;
+    ui32 Size;
+
+    TEvChunkReadRaw(TOwner owner, TOwnerRound ownerRound, TChunkIdx chunkIdx, ui32 offset, ui32 size)
+        : Owner(owner)
+        , OwnerRound(ownerRound)
+        , ChunkIdx(chunkIdx)
+        , Offset(offset)
+        , Size(size)
+    {}
+
+    TString ToString() const {
+        return TStringBuilder() << "{TEvChunkReadRaw Owner# " << Owner
+            << " OwnerRound# " << OwnerRound
+            << " ChunkIdx# " << ChunkIdx
+            << " Offset# " << Offset
+            << " Size# " << Size << "}";
+    }
+};
+
+struct TEvChunkReadRawResult : TEventLocal<TEvChunkReadRawResult, TEvBlobStorage::EvChunkReadRawResult> {
+    NKikimrProto::EReplyStatus Status;
+    TString ErrorReason;
+    TRope Data;
+
+    TEvChunkReadRawResult(NKikimrProto::EReplyStatus status, TString errorReason)
+        : Status(status)
+        , ErrorReason(std::move(errorReason))
+    {}
+
+    TEvChunkReadRawResult(TRope&& data)
+        : Status(NKikimrProto::OK)
+        , Data(std::move(data))
+    {}
+
+    TString ToString() const {
+        return TStringBuilder() << "{TEvChunkReadRawResult Status# " << NKikimrProto::EReplyStatus_Name(Status)
+            << " ErrorReason# '" << ErrorReason << "'"
+            << " Data.size# " << Data.size() << "}";
+    }
+};
+
+struct TEvChunkWriteRaw : TEventLocal<TEvChunkWriteRaw, TEvBlobStorage::EvChunkWriteRaw> {
+    TOwner Owner;
+    TOwnerRound OwnerRound;
+    TChunkIdx ChunkIdx;
+    ui32 Offset;
+    TRope Data;
+
+    TEvChunkWriteRaw(TOwner owner, TOwnerRound ownerRound, TChunkIdx chunkIdx, ui32 offset, TRope&& data)
+        : Owner(owner)
+        , OwnerRound(ownerRound)
+        , ChunkIdx(chunkIdx)
+        , Offset(offset)
+        , Data(std::move(data))
+    {}
+
+    TString ToString() const {
+        return TStringBuilder() << "{TEvChunkWriteRaw Owner# " << Owner
+            << " OwnerRound# " << OwnerRound
+            << " ChunkIdx# " << ChunkIdx
+            << " Offset# " << Offset
+            << " Data.size# " << Data.size() << "}";
+    }
+};
+
+struct TEvChunkWriteRawResult : TEventLocal<TEvChunkWriteRawResult, TEvBlobStorage::EvChunkWriteRawResult> {
+    NKikimrProto::EReplyStatus Status;
+    TString ErrorReason;
+
+    TEvChunkWriteRawResult(NKikimrProto::EReplyStatus status, TString errorReason)
+        : Status(status)
+        , ErrorReason(std::move(errorReason))
+    {}
+
+    TString ToString() const {
+        return TStringBuilder() << "{TEvChunkWriteRawResult Status# " << NKikimrProto::EReplyStatus_Name(Status)
+            << " ErrorReason# '" << ErrorReason << "'" << "}";
     }
 };
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -791,6 +791,14 @@ public:
         PDisk->Mon.LogRead.CountResponse();
     }
 
+    void ErrorHandle(NPDisk::TEvChunkWriteRaw::TPtr ev) {
+        Send(ev->Sender, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::CORRUPTED, StateErrorReason), 0, ev->Cookie);
+    }
+
+    void ErrorHandle(NPDisk::TEvChunkReadRaw::TPtr ev) {
+        Send(ev->Sender, new NPDisk::TEvChunkReadRawResult(NKikimrProto::CORRUPTED, StateErrorReason), 0, ev->Cookie);
+    }
+
     void ErrorHandle(NPDisk::TEvChunkWrite::TPtr &ev) {
         const NPDisk::TEvChunkWrite &evChunkWrite = *ev->Get();
         PDisk->Mon.GetWriteCounter(evChunkWrite.PriorityClass)->CountRequest(0);
@@ -955,6 +963,14 @@ public:
         double burstMs;
         auto* request = PDisk->ReqCreator.CreateFromEvPtr<TLogRead>(ev, &burstMs);
         PDisk->InputRequest(request);
+    }
+
+    void Handle(NPDisk::TEvChunkWriteRaw::TPtr ev) {
+        PDisk->InputRequest(PDisk->ReqCreator.CreateChunkWriteRaw(*ev));
+    }
+
+    void Handle(NPDisk::TEvChunkReadRaw::TPtr ev) {
+        PDisk->InputRequest(PDisk->ReqCreator.CreateChunkReadRaw(*ev));
     }
 
     void Handle(NPDisk::TEvChunkWrite::TPtr &ev) {
@@ -1471,6 +1487,8 @@ public:
             hFunc(NPDisk::TEvReadLog, ErrorHandle);
             hFunc(NPDisk::TEvChunkWrite, ErrorHandle);
             hFunc(NPDisk::TEvChunkRead, ErrorHandle);
+            hFunc(NPDisk::TEvChunkWriteRaw, ErrorHandle);
+            hFunc(NPDisk::TEvChunkReadRaw, ErrorHandle);
             hFunc(NPDisk::TEvHarakiri, ErrorHandle);
             hFunc(NPDisk::TEvSlay, InitHandle);
             hFunc(NPDisk::TEvChunkReserve, ErrorHandle);
@@ -1513,6 +1531,8 @@ public:
             hFunc(NPDisk::TEvReadLog, Handle);
             hFunc(NPDisk::TEvChunkWrite, Handle);
             hFunc(NPDisk::TEvChunkRead, Handle);
+            hFunc(NPDisk::TEvChunkWriteRaw, Handle);
+            hFunc(NPDisk::TEvChunkReadRaw, Handle);
             hFunc(NPDisk::TEvHarakiri, Handle);
             hFunc(NPDisk::TEvSlay, Handle);
             hFunc(NPDisk::TEvChunkReserve, Handle);
@@ -1553,6 +1573,8 @@ public:
             hFunc(NPDisk::TEvReadLog, ErrorHandle);
             hFunc(NPDisk::TEvChunkWrite, ErrorHandle);
             hFunc(NPDisk::TEvChunkRead, ErrorHandle);
+            hFunc(NPDisk::TEvChunkWriteRaw, ErrorHandle);
+            hFunc(NPDisk::TEvChunkReadRaw, ErrorHandle);
             hFunc(NPDisk::TEvHarakiri, ErrorHandle);
             hFunc(NPDisk::TEvSlay, ErrorHandle);
             hFunc(NPDisk::TEvChunkReserve, ErrorHandle);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.cpp
@@ -13,7 +13,7 @@ namespace NKikimr {
                                ui32 chunkSize, ui32 appendBlockSize,
                                ui64 seekTimeUs, ui64 readSpeedBps, ui64 writeSpeedBps, ui64 readBlockSize,
                                ui64 writeBlockSize, ui64 bulkWriteBlockSize, NPDisk::EDeviceType trueMediaType,
-                               bool isTinyDisk)
+                               bool isTinyDisk, ui32 rawSectorSize)
         : Owner(owner)
         , OwnerRound(ownerRound)
         , SlotSizeInUnits(slotSizeInUnits)
@@ -30,6 +30,7 @@ namespace NKikimr {
         , GlueRequestDistanceBytes(CalculateGlueRequestDistanceBytes(seekTimeUs, readSpeedBps))
         , TrueMediaType(trueMediaType)
         , IsTinyDisk(isTinyDisk)
+        , RawSectorSize(rawSectorSize)
     {
         Y_VERIFY_DEBUG(AppendBlockSize <= ChunkSize);
     }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.h
@@ -32,6 +32,8 @@ namespace NKikimr {
 
         bool IsTinyDisk;
 
+        const ui32 RawSectorSize;
+
         static ui32 CalculateRecommendedReadSize(ui64 seekTimeUs, ui64 readSpeedBps, ui64 appendBlockSize);
         static ui64 CalculatePrefetchSizeBytes(ui64 seekTimeUs, ui64 readSpeedBps);
         static ui64 CalculateGlueRequestDistanceBytes(ui64 seekTimeUs, ui64 readSpeedBps);
@@ -40,7 +42,7 @@ namespace NKikimr {
                      ui32 chunkSize, ui32 appendBlockSize,
                      ui64 seekTimeUs, ui64 readSpeedBps, ui64 writeSpeedBps, ui64 readBlockSize,
                      ui64 writeBlockSize, ui64 bulkWriteBlockSize, NPDisk::EDeviceType trueMediaType,
-                     bool isTinyDisk);
+                     bool isTinyDisk, ui32 rawSectorSize);
         void OutputHtml(IOutputStream &str) const;
         TString ToString() const;
     };

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_req_creator.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_req_creator.h
@@ -265,6 +265,13 @@ public:
         return NewRequest(read, &burstMs);
     }
 
+    [[nodiscard]] TChunkReadRaw *CreateChunkReadRaw(TEventHandle<TEvChunkReadRaw>& ev) {
+        NWilson::TSpan span(TWilson::PDiskTopLevel, std::move(ev.TraceId), "PDisk.ChunkReadRaw", NWilson::EFlags::AUTO_END,
+            PCtx->ActorSystem);
+        span.Attribute("pdisk_id", PCtx->PDiskId);
+        return NewRequest(new TChunkReadRaw(*ev.Get(), ev.Sender, ev.Cookie, AtomicIncrement(LastReqId), std::move(span)));
+    }
+
     [[nodiscard]] TChunkWrite* CreateChunkWrite(const NPDisk::TEvChunkWrite &ev, const TActorId &sender, double& burstMs,
             NWilson::TTraceId traceId) {
         NWilson::TSpan span(TWilson::PDiskTopLevel, std::move(traceId), "PDisk.ChunkWrite", NWilson::EFlags::AUTO_END, PCtx->ActorSystem);
@@ -282,6 +289,14 @@ public:
         Mon->GetWriteCounter(ev.PriorityClass)->CountRequest(size);
         return NewRequest(new TChunkWrite(ev, sender, reqId, std::move(span)), &burstMs);
     }
+
+    [[nodiscard]] TChunkWriteRaw *CreateChunkWriteRaw(TEventHandle<TEvChunkWriteRaw>& ev) {
+        NWilson::TSpan span(TWilson::PDiskTopLevel, std::move(ev.TraceId), "PDisk.ChunkWriteRaw", NWilson::EFlags::AUTO_END,
+            PCtx->ActorSystem);
+        span.Attribute("pdisk_id", PCtx->PDiskId);
+        return NewRequest(new TChunkWriteRaw(*ev.Get(), ev.Sender, ev.Cookie, AtomicIncrement(LastReqId), std::move(span)));
+    }
+
 };
 
 } // namespace NKikimr::NPDisk {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_request_id.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_request_id.h
@@ -99,6 +99,8 @@ struct TReqId {
         MarkDirtySysLog = 80,
         YardResize = 81,
         ChangeExpectedSlotCount = 82,
+        ChunkReadRaw = 83,
+        ChunkWriteRaw = 84,
     };
 
     // 56 bit idx, 8 bit source
@@ -170,6 +172,8 @@ enum class ERequestType {
     RequestContinueShred,
     RequestYardResize,
     RequestChangeExpectedSlotCount,
+    RequestChunkReadRaw,
+    RequestChunkWriteRaw,
 };
 
 inline IOutputStream& operator <<(IOutputStream& out, const TReqId& reqId) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
@@ -1300,5 +1300,47 @@ public:
     }
 };
 
+class TChunkReadRaw : public TRequestBase {
+public:
+    TChunkIdx ChunkIdx;
+    ui32 Offset;
+    ui32 Size;
+
+public:
+    TChunkReadRaw(const NPDisk::TEvChunkReadRaw& ev, const TActorId& sender, ui64 cookie, TAtomicBase reqIdx, NWilson::TSpan span)
+        : TRequestBase(sender, TReqId(TReqId::ChunkReadRaw, reqIdx), ev.Owner, ev.OwnerRound, NPriInternal::Other, std::move(span))
+        , ChunkIdx(ev.ChunkIdx)
+        , Offset(ev.Offset)
+        , Size(ev.Size)
+    {
+        SetCookie(cookie);
+    }
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestChunkReadRaw;
+    }
+};
+
+class TChunkWriteRaw : public TRequestBase {
+public:
+    TChunkIdx ChunkIdx;
+    ui32 Offset;
+    TRope Data;
+
+public:
+    TChunkWriteRaw(NPDisk::TEvChunkWriteRaw& ev, const TActorId& sender, ui64 cookie, TAtomicBase reqIdx, NWilson::TSpan span)
+        : TRequestBase(sender, TReqId(TReqId::ChunkWriteRaw, reqIdx), ev.Owner, ev.OwnerRound, NPriInternal::Other, std::move(span))
+        , ChunkIdx(ev.ChunkIdx)
+        , Offset(ev.Offset)
+        , Data(std::move(ev.Data))
+    {
+        SetCookie(cookie);
+    }
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestChunkWriteRaw;
+    }
+};
+
 } // NPDisk
 } // NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.h
@@ -2464,5 +2464,18 @@ public:
     {}
 };
 
+class TTestRawReadsAndWrites : public TBaseTest {
+    NPDisk::TOwner Owner;
+    NPDisk::TOwnerRound OwnerRound;
+    TChunkIdx ChunkIdx;
+
+    void TestFSM(const TActorContext& ctx);
+
+public:
+    TTestRawReadsAndWrites(const TIntrusivePtr<TTestConfig>& cfg)
+        : TBaseTest(cfg)
+    {}
+};
+
 
 } // NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
@@ -880,6 +880,20 @@ YARD_UNIT_TEST(TestStartingPointReboots) {
     }
 }
 
+YARD_UNIT_TEST(TestRawReadsAndWrites) {
+    TTestContext tc(true);
+    ui32 chunkSize = MIN_CHUNK_SIZE;
+    TString dataPath;
+    if (tc.TempDir) {
+        TString databaseDirectory = MakeDatabasePath((*tc.TempDir)().c_str());
+        dataPath = MakePDiskPath((*tc.TempDir)().c_str());
+        MakeDirIfNotExist(databaseDirectory.c_str());
+    }
+    SafeEntropyPoolRead(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
+    FormatPDiskForTest(dataPath, tc.PDiskGuid, chunkSize, 1 << 30, false, tc.SectorMap);
+    Run<TTestRawReadsAndWrites>(&tc, 1, chunkSize);
+}
+
 YARD_UNIT_TEST(TestRestartAtNonceJump) {
     TTestContext tc(true);
     ui32 chunkSize = MIN_CHUNK_SIZE;

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -38,9 +38,10 @@ struct TPDiskMockState::TImpl {
     const ui32 PDiskId;
     ui64 PDiskGuid;
     const ui64 Size;
+    const ui32 SectorSize;
+    const ui32 AppendBlockSize;
     const ui32 ChunkSize;
     const ui32 TotalChunks;
-    const ui32 AppendBlockSize;
     bool IsDiskReadOnly;
     std::map<ui8, TOwner> Owners;
     std::set<ui32> FreeChunks;
@@ -63,9 +64,10 @@ struct TPDiskMockState::TImpl {
         , PDiskId(pdiskId)
         , PDiskGuid(pdiskGuid)
         , Size(size)
-        , ChunkSize(chunkSize)
+        , SectorSize(4096)
+        , AppendBlockSize(SectorSize)
+        , ChunkSize(chunkSize / SectorSize * AppendBlockSize)
         , TotalChunks(Size / ChunkSize)
-        , AppendBlockSize(4096)
         , IsDiskReadOnly(isDiskReadOnly)
         , NextFreeChunk(1)
         , StatusFlags(NPDisk::TStatusFlags{})
@@ -491,7 +493,8 @@ public:
             const ui64 bulkWriteBlockSize = 65536;
             res = std::make_unique<NPDisk::TEvYardInitResult>(NKikimrProto::OK, seekTimeUs, readSpeedBps, writeSpeedBps,
                 readBlockSize, writeBlockSize, bulkWriteBlockSize, Impl.ChunkSize, Impl.AppendBlockSize, ownerId,
-                owner->OwnerRound, 0u, GetStatusFlags(), std::move(ownedChunks), NPDisk::DEVICE_TYPE_NVME, false, TString());
+                owner->OwnerRound, 0u, GetStatusFlags(), std::move(ownedChunks), NPDisk::DEVICE_TYPE_NVME, false,
+                Impl.AppendBlockSize, TString());
             res->StartingPoints = owner->StartingPoints;
         } else {
             res = std::make_unique<NPDisk::TEvYardInitResult>(NKikimrProto::INVALID_ROUND, "invalid owner round");
@@ -892,6 +895,101 @@ public:
         Send(ev->Sender, res.release());
     }
 
+    void Handle(NPDisk::TEvChunkReadRaw::TPtr ev) {
+        auto *msg = ev->Get();
+        auto res = std::make_unique<NPDisk::TEvChunkReadRawResult>(NKikimrProto::OK, TString());
+        if (TImpl::TOwner *owner = Impl.FindOwner(msg, res)) {
+            Y_VERIFY_S(owner->ReservedChunks.count(msg->ChunkIdx) || owner->CommittedChunks.count(msg->ChunkIdx),
+                "VDiskId# " << owner->VDiskId << " ChunkIdx# " << msg->ChunkIdx);
+
+            const ui32 offset = msg->Offset;
+            ui32 size = msg->Size;
+
+            Y_VERIFY(offset % Impl.SectorSize == 0);
+            Y_VERIFY(size % Impl.SectorSize == 0);
+            Y_VERIFY(offset < Impl.ChunkSize && offset + size <= Impl.ChunkSize && size);
+
+            auto data = TRcBuf::Uninitialized(size);
+
+            const auto chunkIt = owner->ChunkData.find(msg->ChunkIdx);
+            if (chunkIt == owner->ChunkData.end()) {
+                memset(data.GetDataMut(), 0, size); // no such chunk at all
+            } else {
+                TImpl::TChunkData& chunk = chunkIt->second;
+                char *dest = data.GetDataMut();
+                for (ui32 blockIdx = offset / Impl.SectorSize; size; size -= Impl.SectorSize, ++blockIdx, dest += Impl.SectorSize) {
+                    const auto it = chunk.Blocks.find(blockIdx);
+                    if (it == chunk.Blocks.end()) {
+                        memset(dest, 0, Impl.SectorSize);
+                    } else {
+                        Y_ABORT_UNLESS(it->second->size() == Impl.SectorSize);
+                        memcpy(dest, it->second->data(), Impl.SectorSize);
+                    }
+                }
+            }
+
+            res->Data = std::move(data);
+        }
+        Send(ev->Sender, res.release(), 0, ev->Cookie);
+    }
+
+    void Handle(NPDisk::TEvChunkWriteRaw::TPtr ev) {
+        Y_VERIFY(!Impl.CheckIsReadOnlyOwner(ev->Get()));
+        auto *msg = ev->Get();
+        auto res = std::make_unique<NPDisk::TEvChunkWriteRawResult>(NKikimrProto::OK, TString());
+        if (TImpl::TOwner *owner = Impl.FindOwner(msg, res)) {
+            Y_ABORT_UNLESS(msg->ChunkIdx);
+            Y_VERIFY(owner->ReservedChunks.count(msg->ChunkIdx) || owner->CommittedChunks.count(msg->ChunkIdx));
+            Y_VERIFY(msg->Offset % Impl.SectorSize == 0);
+            const TRope& data = msg->Data;
+            Y_VERIFY(data.size() % Impl.SectorSize == 0);
+            Y_VERIFY(msg->Offset + data.size() <= Impl.ChunkSize);
+
+            const ui32 offset = msg->Offset;
+            TImpl::TChunkData& chunk = owner->ChunkData[msg->ChunkIdx];
+
+            ui32 blockIdx = offset / Impl.SectorSize;
+            TString currentBlock;
+            char *ptr, *end;
+            auto push = [&](const void *data, size_t len) {
+                ui32 offset = 0;
+                while (offset != len) {
+                    if (!currentBlock) {
+                        currentBlock = TString::Uninitialized(Impl.SectorSize);
+                        ptr = currentBlock.Detach();
+                        end = ptr + currentBlock.size();
+                    }
+                    const ui32 num = Min<ui32>(end - ptr, len - offset); // calculate number of bytes to move
+                    if (data) {
+                        memcpy(ptr, static_cast<const char*>(data) + offset, num);
+                    } else {
+                        memset(ptr, 0, num);
+                    }
+                    offset += num;
+                    ptr += num;
+                    if (ptr == end) { // commit full block
+                        auto&& [it, inserted] = Impl.Blocks.try_emplace(std::move(currentBlock), 0);
+                        ++it->second;
+                        if (const TString *prev = std::exchange(chunk.Blocks[blockIdx++], &it->first)) {
+                            Y_ABORT_UNLESS(prev->size() == Impl.SectorSize);
+                            const auto it = Impl.Blocks.find(*prev);
+                            Y_VERIFY(it != Impl.Blocks.end());
+                            if (!--it->second) {
+                                Impl.Blocks.erase(it);
+                            }
+                        }
+                        currentBlock = {};
+                    }
+                }
+            };
+            for (auto iter = data.Begin(); iter.Valid(); iter.AdvanceToNextContiguousBlock()) {
+                push(iter.ContiguousData(), iter.ContiguousSize());
+            }
+        }
+
+        Send(ev->Sender, res.release(), 0, ev->Cookie);
+    }
+
     void Handle(NPDisk::TEvHarakiri::TPtr ev) {
         auto *msg = ev->Get();
         PDISK_MOCK_LOG(INFO, PDM18, "received TEvHarakiri", (Msg, msg->ToString()));
@@ -1029,6 +1127,14 @@ public:
         Send(ev->Sender, result.Release());
     }
 
+    void ErrorHandle(NPDisk::TEvChunkWriteRaw::TPtr ev) {
+        Send(ev->Sender, new NPDisk::TEvChunkWriteRawResult(NKikimrProto::CORRUPTED, State->GetStateErrorReason()), 0, ev->Cookie);
+    }
+
+    void ErrorHandle(NPDisk::TEvChunkReadRaw::TPtr ev) {
+        Send(ev->Sender, new NPDisk::TEvChunkReadRawResult(NKikimrProto::CORRUPTED, State->GetStateErrorReason()), 0, ev->Cookie);
+    }
+
     void ErrorHandle(NPDisk::TEvHarakiri::TPtr &ev) {
         Send(ev->Sender, new NPDisk::TEvHarakiriResult(NKikimrProto::CORRUPTED, 0, State->GetStateErrorReason()));
     }
@@ -1114,6 +1220,8 @@ public:
         hFunc(NPDisk::TEvChunkReserve, Handle);
         hFunc(NPDisk::TEvChunkRead, Handle);
         hFunc(NPDisk::TEvChunkWrite, Handle);
+        hFunc(NPDisk::TEvChunkReadRaw, Handle);
+        hFunc(NPDisk::TEvChunkWriteRaw, Handle);
         hFunc(NPDisk::TEvCheckSpace, Handle);
         hFunc(NPDisk::TEvSlay, Handle);
         hFunc(NPDisk::TEvHarakiri, Handle);
@@ -1141,6 +1249,8 @@ public:
         hFunc(NPDisk::TEvReadLog, ErrorHandle);
         hFunc(NPDisk::TEvChunkWrite, ErrorHandle);
         hFunc(NPDisk::TEvChunkRead, ErrorHandle);
+        hFunc(NPDisk::TEvChunkWriteRaw, ErrorHandle);
+        hFunc(NPDisk::TEvChunkReadRaw, ErrorHandle);
         hFunc(NPDisk::TEvHarakiri, ErrorHandle);
         hFunc(NPDisk::TEvSlay, ErrorHandle);
         hFunc(NPDisk::TEvChunkReserve, ErrorHandle);

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst_ut.cpp
@@ -16,7 +16,7 @@ std::shared_ptr<TReplCtx> CreateReplCtx(TVector<TVDiskID>& vdisks, const TIntrus
         nullptr, NPDisk::DEVICE_TYPE_UNKNOWN);
     auto hugeBlobCtx = std::make_shared<THugeBlobCtx>("", nullptr, EBlobHeaderMode::OLD_HEADER);
     auto dsk = MakeIntrusive<TPDiskParams>(ui8(1), 1u, 0u, 128u << 20, 4096u, 0u, 1000000000u, 1000000000u, 65536u, 65536u, 65536u,
-            NPDisk::DEVICE_TYPE_UNKNOWN, false);
+            NPDisk::DEVICE_TYPE_UNKNOWN, false, 4096u);
     auto pdiskCtx = std::make_shared<TPDiskCtx>(dsk, TActorId(), TString());
     auto replCtx = std::make_shared<TReplCtx>(
         vctx,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Implement raw reads and writes in PDisk

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch adds TEvChunkReadRaw/TEvChunkWriteRaw events to PDisk to allow reading and writing raw device chunks without any scheduling, encyption and validation.
