### PR TITLE
[ICRDMA] Allow to split RDMA credentials in to multiple parts (#32622) EXT-1874

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -153,8 +153,13 @@ namespace NActors {
         struct TRdmaSerializationArtifacts {
             NActorsInterconnect::TRdmaCreds RdmaCreds;
             ui32 CheckSum = 0;
+            // Variable is used to split creds if the serialized size is grather than one IC packet
+            ui32 PartCredPos = 0;
+            float CredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
+
         };
         std::optional<TRdmaSerializationArtifacts> SendViaRdma;
+        const static ui32 RdmaCredsMinSizeSerialized;
 
         template<bool External>
         bool SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, size_t *bytesSerialized);
@@ -163,7 +168,7 @@ namespace NActors {
         bool FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex);
         std::optional<bool> FeedInlinePayload(TTcpPacketOutTask& task, TEventHolder& event);
         std::optional<bool> FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event);
-        std::optional<bool> FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex);
+        std::optional<bool> FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event);
 
         bool FeedDescriptor(TTcpPacketOutTask& task, TEventHolder& event);
 

--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -252,6 +252,10 @@ namespace {
             RdmaReadTimeHistogram->Collect(value);
         }
 
+        void IncRdmaMultipartEvents() override {
+            ++*RdmaMultipartEvents;
+        }
+
         void UpdateOutputChannelTraffic(ui16 channel, ui64 value) override {
             auto& ch = GetOutputChannel(channel);
             if (ch.OutgoingTraffic) {
@@ -338,6 +342,7 @@ namespace {
                     "InterconnectQueueTimeHistogramUs", NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 RdmaReadTimeHistogram = AdaptiveCounters->GetHistogram(
 +                    "RdmaReadTimeUs", NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
+                RdmaMultipartEvents = AdaptiveCounters->GetCounter("RdmaMultipartEvents", true);
             }
 
             if (updateGlobal) {
@@ -403,6 +408,7 @@ namespace {
         NMonitoring::THistogramPtr PingTimeHistogram;
         NMonitoring::THistogramPtr InterconnectQueueTimeHistogram;
         NMonitoring::THistogramPtr RdmaReadTimeHistogram;
+        NMonitoring::TDynamicCounters::TCounterPtr RdmaMultipartEvents;
 
         std::unordered_map<ui16, TOutputChannel> OutputChannels;
         TOutputChannel OtherOutputChannel;
@@ -620,6 +626,10 @@ namespace {
             RdmaReadTimeHistogram_->Record(value);
         }
 
+        void IncRdmaMultipartEvents() override {
+            RdmaMultipartEvents_->Inc();
+        }
+
         void UpdateOutputChannelTraffic(ui16 channel, ui64 value) override {
             auto& ch = GetOutputChannel(channel);
             if (ch.OutgoingTraffic) {
@@ -717,6 +727,7 @@ namespace {
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ic_queue_time_us"}}), NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 RdmaReadTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.rdma_read_time_us"}}), NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
+                RdmaMultipartEvents_ = createRate(AdaptiveMetrics_, "interconnect.rdma_multipart_events");
             }
 
             if (updateGlobal) {
@@ -804,6 +815,7 @@ namespace {
         NMonitoring::IHistogram* PingTimeHistogram_;
         NMonitoring::IHistogram* InterconnectQueueTimeHistogram_;
         NMonitoring::IHistogram* RdmaReadTimeHistogram_;
+        NMonitoring::IRate* RdmaMultipartEvents_;
 
         THashMap<ui16, TOutputChannel> OutputChannels_;
         TOutputChannel OtherOutputChannel_;

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -48,6 +48,7 @@ public:
     virtual void UpdateOutputChannelTraffic(ui16 channel, ui64 value) = 0;
     virtual void UpdateOutputChannelEvents(ui16 channel) = 0;
     virtual void SetUtilization(ui32 total, ui32 starvation) = 0;
+    virtual void IncRdmaMultipartEvents() = 0;
     TString GetHumanFriendlyPeerHostName() const {
         return HumanFriendlyPeerHostName.value_or(TString());
     }

--- a/ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h
+++ b/ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h
@@ -38,7 +38,8 @@ private:
 
 public:
     TTestICCluster(ui32 numNodes = 1, NActors::TChannelsConfig channelsConfig = NActors::TChannelsConfig(),
-                   TTrafficInterrupterSettings* tiSettings = nullptr, TIntrusivePtr<NLog::TSettings> loggerSettings = nullptr, Flags flags = EMPTY, TDuration deadPeerTimeout = TDuration::Seconds(2))
+                   TTrafficInterrupterSettings* tiSettings = nullptr, TIntrusivePtr<NLog::TSettings> loggerSettings = nullptr, Flags flags = EMPTY,
+                   TDuration deadPeerTimeout = TDuration::Seconds(2), ui32 inflight = TNode::DefaultInflight())
         : NumNodes(numNodes)
         , DeadPeerTimeout(deadPeerTimeout)
         , Counters(new NMonitoring::TDynamicCounters)
@@ -72,7 +73,7 @@ public:
         for (ui32 i = 1; i <= NumNodes; ++i) {
             auto& portMap = tiSettings ? specificNodePortMap[i] : nodeToPortMap;
             Nodes.emplace(i, MakeHolder<TNode>(i, NumNodes, portMap, Address, Counters, DeadPeerTimeout, ChannelsConfig,
-                /*numDynamicNodes=*/0, /*numThreads=*/1, LoggerSettings, TNode::DefaultInflight(),
+                /*numDynamicNodes=*/0, /*numThreads=*/1, LoggerSettings, inflight,
                 flags & USE_ZC ? ESocketSendOptimization::IC_MSG_ZEROCOPY : ESocketSendOptimization::DISABLED,
                 flags & USE_TLS, flags & RDMA_POLLING_CQ ? NInterconnect::NRdma::ECqMode::POLLING : NInterconnect::NRdma::ECqMode::EVENT));
         }

--- a/ydb/library/actors/interconnect/ut/lib/node.h
+++ b/ydb/library/actors/interconnect/ut/lib/node.h
@@ -87,7 +87,7 @@ public:
         setup.LocalServices.emplace_back(MakePollerActorId(), TActorSetupCmd(CreatePollerActor(),
             TMailboxType::ReadAsFilled, 0));
         setup.LocalServices.emplace_back(NInterconnect::NRdma::MakeCqActorId(),
-            TActorSetupCmd(NInterconnect::NRdma::CreateCqActor(-1, 32, rdmaCqMode, nullptr),
+            TActorSetupCmd(NInterconnect::NRdma::CreateCqActor(-1, 1024, rdmaCqMode, nullptr),
             TMailboxType::ReadAsFilled, 0));
 
         const TActorId loggerActorId = loggerSettings ? loggerSettings->LoggerActorId : TActorId(0, "logger");

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -132,7 +132,12 @@ struct TEventsForTest {
             const bool isInline = i % 3 == 0;
             const bool isXdc = i % 3 == 1;
             const bool isRdma = i % 3 == 2;
-            const ui32 numPayloads = i % 5 + (isXdc || isRdma);
+            ui32 numPayloads = i % 5 + (isXdc || isRdma);
+            ui32 sz = 5000;
+            if (i % 128 == 127) {
+                numPayloads += 500;
+                sz = 512;
+            }
 
             auto ev = new TEvTestSerialization();
             ev->Record.SetBlobID(i);
@@ -141,12 +146,13 @@ struct TEventsForTest {
                 if (isInline) {
                     ev->AddPayload(TRope(TString(10 + j, j + i)));
                 } else if (isXdc) {
-                    ev->AddPayload(TRope(TString(5000 + j, j + i)));
+                    ev->AddPayload(TRope(TString(sz + j, j + i)));
                 } else if (isRdma) {
-                    auto buf = memPool->AllocRcBuf(5000 + j, 0).value();
-                    std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000 + j, j + i);
+                    auto buf = memPool->AllocRcBuf(sz + j, 0).value();
+                    Y_ABORT_UNLESS(buf);
+                    std::fill(buf.GetDataMut(), buf.GetDataMut() + sz + j, j + i);
                     ev->AddPayload(TRope(std::move(buf)));
-                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), 5000 + j);
+                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), sz + j);
                 }
             }
 
@@ -156,12 +162,12 @@ struct TEventsForTest {
 
             Events.push_back(ev);
 
-            Checks.emplace(i, [i, numPayloads, isInline](TEvTestSerialization* ev) {
+            Checks.emplace(i, [i, numPayloads, isInline, sz](TEvTestSerialization* ev) {
                 UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBlobID(), i);
                 UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBuffer(), TStringBuilder{} << "hello world " << i);
                 UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().size(), numPayloads);
                 for (ui32 j = 0; j < numPayloads; ++j) {
-                    ui32 payloadSize = isInline ? 10 + j : 5000 + j;
+                    ui32 payloadSize = isInline ? 10 + j : sz + j;
                     UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload()[j].GetSize(), payloadSize);
                     UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload()[j].ConvertToString(), TString(payloadSize, j + i));
                 }
@@ -201,7 +207,7 @@ TEvTestSerialization* MakeTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool*
     if (!memPool) {
         TRope tmp(TString(5000, 'X'));
         if (withOffset) {
-            tmp.Insert(tmp.End(), TRope(TString(999, 'Z'))); 
+            tmp.Insert(tmp.End(), TRope(TString(999, 'Z')));
         }
         ev->AddPayload(std::move(tmp));
     } else {
@@ -239,14 +245,14 @@ TEvTestSerialization* MakeTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool*
             if (withOffset) {
                 TRcBuf rcbuf3 = memPool->AllocRcBuf(999, 0).value();
                 std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 999, 'Z');
-                tmp.Insert(tmp.End(), TRope(std::move(rcbuf3))); 
+                tmp.Insert(tmp.End(), TRope(std::move(rcbuf3)));
             }
             ev->AddPayload(std::move(tmp));
             UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), withOffset ? 5999u : 5000u);
         }
     }
     bool done = ev->AllowExternalDataChannel();
-    UNIT_ASSERT_VALUES_EQUAL(done, true); 
+    UNIT_ASSERT_VALUES_EQUAL(done, true);
     return ev;
 }
 
@@ -585,14 +591,20 @@ TEST_P(XdcRdmaTestCqMode, SendMixBig) {
         flags = TTestICCluster::RDMA_POLLING_CQ;
     }
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, flags);
-    TEventsForTest events(1000);
+    std::mutex mtx;
+    mtx.lock();
+    TEventsForTest events(500);
+    mtx.unlock();
 
-    auto recieverPtr = new TReceiveActor([&events](TEvTestSerialization::TPtr ev) {
+    auto recieverPtr = new TReceiveActor([&events, &mtx](TEvTestSerialization::TPtr ev) {
         ui64 blobId = ev->Get()->Record.GetBlobID();
-        auto checkIt = events.Checks.find(blobId);
-        UNIT_ASSERT(checkIt != events.Checks.end());
-        checkIt->second(ev->Get());
-        events.Checks.erase(checkIt);
+        {
+            std::lock_guard<std::mutex> guard(mtx);
+            auto checkIt = events.Checks.find(blobId);
+            UNIT_ASSERT(checkIt != events.Checks.end());
+            checkIt->second(ev->Get());
+            events.Checks.erase(checkIt);
+        }
     });
     const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
     Sleep(TDuration::MilliSeconds(1000));
@@ -602,12 +614,169 @@ TEST_P(XdcRdmaTestCqMode, SendMixBig) {
         cluster.RegisterActor(senderPtr, 2);
     }
 
-    for (ui32 attempt = 0; attempt < 10 && !events.Checks.empty(); ++attempt) {
+    for (ui32 attempt = 0; attempt < 50; ++attempt) {
+        {
+            std::lock_guard<std::mutex> guard(mtx);
+            if (events.Checks.empty()) {
+                break;
+            }
+        }
         Sleep(TDuration::MilliSeconds(1000));
     }
     UNIT_ASSERT_VALUES_EQUAL(events.Checks.size(), 0u);
 }
 
+static void DoSendHugePayloadsNum(const ui32 numPayloads, const size_t payloadSz, TTestICCluster& cluster,
+    std::shared_ptr<NInterconnect::NRdma::IMemPool> pool)
+{
+    auto ev = new TEvTestSerialization();
+    ev->Record.SetBlobID(0);
+    ev->Record.SetBuffer(TStringBuilder{} << "hello world ");
+    for (ui32 j = 0; j < numPayloads; ++j) {
+        auto buf = pool->AllocRcBuf(payloadSz, NInterconnect::NRdma::IMemPool::PAGE_ALIGNED).value();
+        ui32* p = reinterpret_cast<ui32*>(buf.GetDataMut());
+        std::fill(p, p + (payloadSz / sizeof(*p)), j);
+        ev->AddPayload(TRope(std::move(buf)));
+    }
+    UNIT_ASSERT(ev->AllowExternalDataChannel());
+
+    auto recieverPtr = new TReceiveActor([numPayloads, payloadSz](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayloadCount(), numPayloads);
+        for (ui32 j = 0; j < numPayloads; ++j) {
+            TRope buf = ev->Get()->GetPayload(j);
+            auto span = buf.GetContiguousSpan();
+            const ui32* p = reinterpret_cast<const ui32*>(span.GetData());
+            UNIT_ASSERT_VALUES_EQUAL(span.GetSize(), payloadSz);
+
+            while (p < reinterpret_cast<const ui32*>(span.GetData() + payloadSz)) {
+                UNIT_ASSERT_VALUES_EQUAL(*p, j);
+                p++;
+            }
+        }
+    });
+    const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
+
+    Sleep(TDuration::MilliSeconds(100));
+
+    {
+        auto senderPtr = new TSendActor(receiver, ev);
+        cluster.RegisterActor(senderPtr, 2);
+    }
+
+    UNIT_ASSERT(recieverPtr->WhaitForRecieve(1, 20));
+}
+
+TEST_F(XdcRdmaTest, Send1Payload) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    DoSendHugePayloadsNum(1, 8192, cluster, pool);
+}
+
+TEST_F(XdcRdmaTest, Send2Payloads) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    DoSendHugePayloadsNum(2, 8192, cluster, pool);
+}
+
+TEST_F(XdcRdmaTest, Send250Payloads) {
+        const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    DoSendHugePayloadsNum(250, 512, cluster, pool);
+}
+
+TEST_F(XdcRdmaTest, Send500Payloads) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    DoSendHugePayloadsNum(500, 512, cluster, pool);
+}
+
+TEST_F(XdcRdmaTest, Send4000Payloads) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    DoSendHugePayloadsNum(4000, 512, cluster, pool);
+}
+
+TEST_F(XdcRdmaTest, Send16000Payloads) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    DoSendHugePayloadsNum(16000, 512, cluster, pool);
+}
+
+TEST_F(XdcRdmaTest, Send32000Payloads) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    DoSendHugePayloadsNum(32000, 512, cluster, pool);
+}
+
+TEST_F(XdcRdmaTest, SendXPayloads) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    for (size_t i = 640; i < 650; i++) {
+        DoSendHugePayloadsNum(i, 512, cluster, pool);
+    }
+}
+
+TEST_F(XdcRdmaTest, SendXPayloadsWithRandSize) {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
+        .SizeLimitMb = 256
+    };
+    auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
+
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+
+    for (size_t i = 640; i < 650; i++) {
+        DoSendHugePayloadsNum(i, 512 + (RandomNumber<ui16>(4096) * 4), cluster, pool);
+    }
+}
 
 INSTANTIATE_TEST_SUITE_P(
     XdcRdmaTest,


### PR DESCRIPTION


If the ammount of payloads for events become huge
the metadata size will be grather than size of one IC packet. In this case we can split rdma credentioals in to multiple IC packets.

The current implementation requires to set inflight limit grater that max expected rdma event size, otherwise we can stuck due to no ACK from receiver for non completed rdma event. This well be solved in a future.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
