### PR TITLE
Fix bug with TRUNCATE TABLE and fulltext index

### DIFF
--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -179,6 +179,15 @@ public:
         record.SetMaxRows(MaxRowsDefaultQuota);
         record.SetMaxBytes(MaxBytesDefaultQuota);
         record.SetResultFormat(UseArrowFormat ? NKikimrDataEvents::FORMAT_ARROW : NKikimrDataEvents::FORMAT_CELLVEC);
+
+        CA_LOG_E(TStringBuilder() << "Send EvRead (stream lookup) to shardId=" << shardId
+            << ", readId = " << record.GetReadId()
+            << ", snapshot=(txid=" << record.GetSnapshot().GetTxId() << ", step=" << record.GetSnapshot().GetStep() << ")"
+            << ", lockTxId=" << record.GetLockTxId()
+            << ", lockNodeId=" << record.GetLockNodeId()
+            << ", tableId=" << record.GetTableId().GetOwnerId() << ":" << record.GetTableId().GetTableId()
+            << ", schemaVersion =" << record.GetTableId().GetSchemaVersion());
+
         return request;
     }
 

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -180,14 +180,6 @@ public:
         record.SetMaxBytes(MaxBytesDefaultQuota);
         record.SetResultFormat(UseArrowFormat ? NKikimrDataEvents::FORMAT_ARROW : NKikimrDataEvents::FORMAT_CELLVEC);
 
-        CA_LOG_E(TStringBuilder() << "Send EvRead (stream lookup) to shardId=" << shardId
-            << ", readId = " << record.GetReadId()
-            << ", snapshot=(txid=" << record.GetSnapshot().GetTxId() << ", step=" << record.GetSnapshot().GetStep() << ")"
-            << ", lockTxId=" << record.GetLockTxId()
-            << ", lockNodeId=" << record.GetLockNodeId()
-            << ", tableId=" << record.GetTableId().GetOwnerId() << ":" << record.GetTableId().GetTableId()
-            << ", schemaVersion =" << record.GetTableId().GetSchemaVersion());
-
         return request;
     }
 

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -336,6 +336,10 @@ public:
                 if (source.GetTypeCase() == NKqpProto::TKqpSource::kReadRangesSource) {
                     addTable(source.GetReadRangesSource().GetTable());
                 }
+    
+                if (source.GetTypeCase() == NKqpProto::TKqpSource::kFullTextSource) {
+                    addTable(source.GetFullTextSource().GetTable());
+                }
             }
 
             for (const auto& sink : stage.GetSinks()) {

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -336,7 +336,7 @@ public:
                 if (source.GetTypeCase() == NKqpProto::TKqpSource::kReadRangesSource) {
                     addTable(source.GetReadRangesSource().GetTable());
                 }
-    
+
                 if (source.GetTypeCase() == NKqpProto::TKqpSource::kFullTextSource) {
                     addTable(source.GetFullTextSource().GetTable());
                 }

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
@@ -4618,47 +4618,6 @@ Y_UNIT_TEST(ExplainFulltextIndexScanQuery) {
     UNIT_ASSERT_VALUES_EQUAL(opProps.at("Index").GetStringSafe(), "fulltext_idx");
 }
 
-Y_UNIT_TEST(AddFullTextFlatIndexWithTruncate) {
-    NKikimrConfig::TFeatureFlags featureFlags;
-    featureFlags.SetEnableFulltextIndex(true);
-    featureFlags.SetEnableTruncateTable(true);
-
-    auto kikimr = Kikimr(std::move(featureFlags));
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
-    auto db = kikimr.GetQueryClient();
-
-    CreateTexts(db);
-    AddIndex(db);
-
-    auto verifyIndexWorksCorrectly = [&](){
-        UpsertTexts(db);
-        auto index = ReadIndex(db);
-        CompareYson(R"([
-            [[100u];"animals"];
-            [[100u];"cats"];
-            [[200u];"cats"];
-            [[300u];"cats"];
-            [[100u];"chase"];
-            [[200u];"chase"];
-            [[200u];"dogs"];
-            [[400u];"dogs"];
-            [[400u];"foxes"];
-            [[300u];"love"];
-            [[400u];"love"];
-            [[100u];"small"];
-            [[200u];"small"]
-        ])", NYdb::FormatResultSetYson(index));
-    };
-
-    verifyIndexWorksCorrectly();
-
-    for (size_t tryIndex = 0; tryIndex < 5; ++tryIndex) {
-        TruncateTable(db);
-        verifyIndexWorksCorrectly();
-    }
-}
-
 Y_UNIT_TEST(AddFullTextFlatIndexWithTruncateWithSelect) {
     NKikimrConfig::TFeatureFlags featureFlags;
     featureFlags.SetEnableFulltextIndex(true);

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
@@ -4685,7 +4685,7 @@ Y_UNIT_TEST(AddFullTextFlatIndexWithTruncate2) {
             TString query = R"sql(
                 SELECT `Key`, `Text`
                 FROM `/Root/Texts` VIEW `fulltext_idx`
-                WHERE FulltextContains(`Text`, "404 not found")
+                WHERE FulltextMatch(`Text`, "404 not found")
                 ORDER BY `Key`;
             )sql";
             auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
@@ -4704,17 +4704,19 @@ Y_UNIT_TEST(AddFullTextFlatIndexWithTruncate2) {
         }
     };
 
-    auto verifyIndexWorksCorrectly = [&](){
+    auto verifyIndexWorksCorrectly = [&](int count){
+        Cerr << "========================================================= begin verifyIndexWorksCorrectly " << count << Endl;
         retryableSelect();
         UpsertSomeTexts(db);
         retryableSelect();
+        Cerr << "========================================================= end verifyIndexWorksCorrectly " << count << Endl;
     };
 
-    verifyIndexWorksCorrectly();
+    verifyIndexWorksCorrectly(-1);
 
     for (size_t tryIndex = 0; tryIndex < 5; ++tryIndex) {
         TruncateTable(db);
-        verifyIndexWorksCorrectly();
+        verifyIndexWorksCorrectly(tryIndex);
     }
 }
 

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
@@ -4704,19 +4704,17 @@ Y_UNIT_TEST(AddFullTextFlatIndexWithTruncate2) {
         }
     };
 
-    auto verifyIndexWorksCorrectly = [&](int count){
-        Cerr << "========================================================= begin verifyIndexWorksCorrectly " << count << Endl;
+    auto verifyIndexWorksCorrectly = [&](){
         retryableSelect();
         UpsertSomeTexts(db);
         retryableSelect();
-        Cerr << "========================================================= end verifyIndexWorksCorrectly " << count << Endl;
     };
 
-    verifyIndexWorksCorrectly(-1);
+    verifyIndexWorksCorrectly();
 
     for (size_t tryIndex = 0; tryIndex < 5; ++tryIndex) {
         TruncateTable(db);
-        verifyIndexWorksCorrectly(tryIndex);
+        verifyIndexWorksCorrectly();
     }
 }
 

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
@@ -4647,6 +4647,8 @@ Y_UNIT_TEST(AddFullTextFlatIndexWithTruncateWithSelect) {
         auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
 
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        auto resultSet = result.GetResultSet(0);
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 0);
     };
 
     auto ensureTableIsEmpty = [&](){

--- a/ydb/tests/datashard/truncate/conftest.py
+++ b/ydb/tests/datashard/truncate/conftest.py
@@ -1,0 +1,5 @@
+# XXX: setting of pytest_plugins should work if specified directly in test modules
+# but somehow it does not
+#
+# for ydb_{cluster, database, ...} fixture family
+pytest_plugins = 'ydb.tests.library.fixtures'

--- a/ydb/tests/datashard/truncate/test_truncate_table_fulltext_index.py
+++ b/ydb/tests/datashard/truncate/test_truncate_table_fulltext_index.py
@@ -55,6 +55,12 @@ def test_truncate_table_with_fulltext_index_table_service(ydb_cluster, ydb_datab
                     TRUNCATE TABLE `Texts`;
                 ''')
 
+                result = session.transaction().execute('''
+                    SELECT *
+                    FROM `Texts`;
+                ''', commit_tx=True)
+                assert_that(len(result[0].rows), equal_to(0))
+
             def verify_index_works_correctly():
                 select_empty_results()
                 upsert_some_texts()
@@ -108,6 +114,12 @@ def test_truncate_table_with_fulltext_index_with_query_service(ydb_cluster, ydb_
             session_pool.execute_with_retries('''
                 TRUNCATE TABLE `Texts`;
             ''')
+
+            result = session_pool.execute_with_retries('''
+                SELECT *
+                FROM `Texts`;
+            ''')
+            assert_that(len(result[0].rows), equal_to(0))
 
         def verify_index_works_correctly():
             select_empty_results()
@@ -167,12 +179,18 @@ def test_truncate_table_with_fulltext_index_with_query_service_many_sessions(ydb
                     TRUNCATE TABLE `Texts`;
                 ''')
 
+                result = session_pool.execute_with_retries('''
+                    SELECT *
+                    FROM `Texts`;
+                ''')
+                assert_that(len(result[0].rows), equal_to(0))
+
         def verify_index_works_correctly():
             select_empty_results()
             upsert_some_texts()
             select_empty_results()
 
-        verify_index_works_correctly(-1)
+        verify_index_works_correctly()
 
         for _ in range(5):
             truncate_table()

--- a/ydb/tests/datashard/truncate/test_truncate_table_fulltext_index.py
+++ b/ydb/tests/datashard/truncate/test_truncate_table_fulltext_index.py
@@ -1,0 +1,153 @@
+import logging
+
+from hamcrest import assert_that, equal_to
+
+from ydb.tests.oss.ydb_sdk_import import ydb
+from ydb.tests.library.harness.util import LogLevels
+
+logger = logging.getLogger(__name__)
+
+CLUSTER_CONFIG = dict(
+    additional_log_configs={
+        'TX_DATASHARD': LogLevels.DEBUG,
+        'KQP_PROXY': LogLevels.DEBUG,
+    },
+    extra_feature_flags=["enable_fulltext_index", "enable_truncate_table"]
+)
+
+
+def test_truncate_table_with_fulltext_index(ydb_cluster, ydb_database, ydb_client):
+    logger.info("Starting AddFullTextFlatIndexWithTruncate2 Python version")
+
+    driver = ydb_client(ydb_database)
+    driver.wait(timeout=10)
+
+    with ydb.SessionPool(driver) as session_pool:
+        with session_pool.checkout() as session:
+            logger.info("Creating table")
+            session.execute_scheme('''
+                CREATE TABLE `/Root/test_truncate_table_with_fulltext_index/Texts` (
+                    Key Uint64,
+                    Text String,
+                    Data String,
+                    PRIMARY KEY (Key)
+                );
+            ''')
+
+            logger.info("Adding fulltext index")
+            session.execute_scheme('''
+                ALTER TABLE `/Root/test_truncate_table_with_fulltext_index/Texts` ADD INDEX fulltext_idx
+                    GLOBAL USING fulltext_plain
+                    ON (Text)
+                    WITH (tokenizer=standard, use_filter_lowercase=true)
+            ''')
+
+            def upsert_some_texts():
+                logger.info("Upserting some texts")
+                session.transaction().execute('''
+                    UPSERT INTO `/Root/test_truncate_table_with_fulltext_index/Texts` (Key, Text, Data) VALUES
+                        (100, "Cats love cats.", "cats data"),
+                        (200, "Dogs love foxes.", "dogs data")
+                ''', commit_tx=True)
+
+            def select_empty_results():
+                logger.info("Selecting empty results")
+                result = session.transaction().execute('''
+                    SELECT `Key`, `Text`
+                    FROM `/Root/test_truncate_table_with_fulltext_index/Texts` VIEW `fulltext_idx`
+                    WHERE FulltextMatch(`Text`, "404 not found")
+                    ORDER BY `Key`;
+                ''', commit_tx=True)
+                assert_that(len(result[0].rows), equal_to(0))
+
+            def truncate_table():
+                logger.info("Truncating table")
+                session.execute_scheme('''
+                    TRUNCATE TABLE `/Root/test_truncate_table_with_fulltext_index/Texts`;
+                ''')
+
+            def verify_index_works_correctly(count):
+                logger.info(f"========== begin verifyIndexWorksCorrectly {count} ==========")
+                select_empty_results()
+                upsert_some_texts()
+                select_empty_results()
+                logger.info(f"========== end verifyIndexWorksCorrectly {count} ==========")
+
+            # Initial verification
+            verify_index_works_correctly(-1)
+
+            # Test cycle: truncate and verify 5 times
+            for try_index in range(5):
+                logger.info(f"========== TRUNCATE cycle {try_index} ==========")
+                truncate_table()
+                verify_index_works_correctly(try_index)
+
+    logger.info("Test completed successfully")
+
+def test_truncate_table_with_fulltext_index_with_query_service(ydb_cluster, ydb_database, ydb_client):
+    logger.info("Starting AddFullTextFlatIndexWithTruncate2 Python version")
+
+    driver = ydb_client(ydb_database)
+    driver.wait(timeout=10)
+
+    with ydb.QuerySessionPool(driver) as session_pool:
+        logger.info("Creating table")
+        session_pool.execute_with_retries('''
+            CREATE TABLE `/Root/test_truncate_table_with_fulltext_index_with_query_service/Texts` (
+                Key Uint64,
+                Text String,
+                Data String,
+                PRIMARY KEY (Key)
+            );
+        ''')
+
+        logger.info("Adding fulltext index")
+        session_pool.execute_with_retries('''
+            ALTER TABLE `/Root/test_truncate_table_with_fulltext_index_with_query_service/Texts` ADD INDEX fulltext_idx
+                GLOBAL USING fulltext_plain
+                ON (Text)
+                WITH (tokenizer=standard, use_filter_lowercase=true)
+        ''')
+
+        def upsert_some_texts():
+            logger.info("Upserting some texts")
+            session_pool.execute_with_retries('''
+                UPSERT INTO `/Root/test_truncate_table_with_fulltext_index_with_query_service/Texts` (Key, Text, Data) VALUES
+                    (100, "Cats love cats.", "cats data"),
+                    (200, "Dogs love foxes.", "dogs data")
+            ''')
+
+        def select_empty_results():
+            logger.info("Selecting empty results")
+            result = session_pool.execute_with_retries('''
+                SELECT `Key`, `Text`
+                FROM `/Root/test_truncate_table_with_fulltext_index_with_query_service/Texts` VIEW `fulltext_idx`
+                WHERE FulltextMatch(`Text`, "404 not found")
+                ORDER BY `Key`;
+            ''')
+            assert_that(len(result[0].rows), equal_to(0))
+
+        def truncate_table():
+            logger.info("Truncating table")
+            session_pool.execute_with_retries('''
+                TRUNCATE TABLE `/Root/test_truncate_table_with_fulltext_index_with_query_service/Texts`;
+            ''')
+
+        def verify_index_works_correctly(count):
+            logger.info(f"========== begin verifyIndexWorksCorrectly {count} ==========")
+            select_empty_results()
+            upsert_some_texts()
+            select_empty_results()
+            logger.info(f"========== end verifyIndexWorksCorrectly {count} ==========")
+
+        # Initial verification
+        verify_index_works_correctly(-1)
+
+        # Test cycle: truncate and verify 5 times
+        for try_index in range(5):
+            logger.info(f"========== TRUNCATE cycle {try_index} ==========")
+            truncate_table()
+            verify_index_works_correctly(try_index)
+
+    logger.info("Test completed successfully")
+

--- a/ydb/tests/datashard/truncate/test_truncate_table_fulltext_index.py
+++ b/ydb/tests/datashard/truncate/test_truncate_table_fulltext_index.py
@@ -1,6 +1,3 @@
-import logging
-import itertools
-
 from hamcrest import assert_that, equal_to
 
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -69,6 +66,7 @@ def test_truncate_table_with_fulltext_index_table_service(ydb_cluster, ydb_datab
                 truncate_table()
                 verify_index_works_correctly()
 
+
 def test_truncate_table_with_fulltext_index_with_query_service(ydb_cluster, ydb_database, ydb_client):
     driver = ydb_client(ydb_database)
     driver.wait(timeout=10)
@@ -121,6 +119,7 @@ def test_truncate_table_with_fulltext_index_with_query_service(ydb_cluster, ydb_
         for _ in range(5):
             truncate_table()
             verify_index_works_correctly()
+
 
 def test_truncate_table_with_fulltext_index_with_query_service_many_sessions(ydb_cluster, ydb_database, ydb_client):
     driver = ydb_client(ydb_database)

--- a/ydb/tests/datashard/truncate/ya.make
+++ b/ydb/tests/datashard/truncate/ya.make
@@ -1,0 +1,26 @@
+PY3TEST()
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
+
+PY_SRCS (
+    conftest.py
+)
+
+TEST_SRCS(
+    test_truncate_table_fulltext_index.py
+)
+
+SIZE(MEDIUM)
+
+DEPENDS(
+)
+
+PEERDIR(
+    ydb/tests/library
+    ydb/tests/library/fixtures
+    ydb/tests/oss/ydb_sdk_import
+)
+
+FORK_SUBTESTS()
+FORK_TEST_FILES()
+
+END()

--- a/ydb/tests/functional/hive/test_drain.py
+++ b/ydb/tests/functional/hive/test_drain.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import logging
 
 import yatest
 from ydb.tests.library.common.delayed import wait_tablets_are_active

--- a/ydb/tests/functional/hive/test_drain.py
+++ b/ydb/tests/functional/hive/test_drain.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 
 import yatest
 from ydb.tests.library.common.delayed import wait_tablets_are_active


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

In the pull request https://github.com/ydb-platform/ydb/pull/32583, the interaction between TRUNCATE and the full-text index was implemented. However, it turned out that it contained a bug related to invalidating the SchemaVersion value of the full-text search Impl table in the KQP cache.

This change fixes that issue.