### PR TITLE
Fix the lost planStep problem

### DIFF
--- a/ydb/core/tx/columnshard/transactions/operators/propose_tx.cpp
+++ b/ydb/core/tx/columnshard/transactions/operators/propose_tx.cpp
@@ -3,14 +3,7 @@
 namespace NKikimr::NColumnShard {
 
 void IProposeTxOperator::DoSendReply(TColumnShard& owner, const TActorContext& ctx) {
-    if (owner.CurrentSchemeShardId) {
-        AFL_VERIFY(owner.CurrentSchemeShardId);
-        ctx.Send(MakePipePerNodeCacheID(false),
-            new TEvPipeCache::TEvForward(BuildProposeResultEvent(owner).release(), (ui64)owner.CurrentSchemeShardId, true));
-    } else {
-        AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "scheme_shard_tablet_not_initialized")("source", GetTxInfo().Source);
-        ctx.Send(GetTxInfo().Source, BuildProposeResultEvent(owner).release());
-    }
+    ctx.Send(GetTxInfo().Source, BuildProposeResultEvent(owner).release());
 }
 
 std::unique_ptr<NKikimr::TEvColumnShard::TEvProposeTransactionResult> IProposeTxOperator::BuildProposeResultEvent(const TColumnShard& owner) const {

--- a/ydb/core/tx/columnshard/ut_schema/ut_columnshard_schema.cpp
+++ b/ydb/core/tx/columnshard/ut_schema/ut_columnshard_schema.cpp
@@ -12,6 +12,7 @@
 #include <ydb/core/tx/columnshard/blobs_reader/actor.h>
 #include <ydb/core/tx/columnshard/test_helper/controllers.h>
 #include <ydb/core/tx/columnshard/engines/changes/ttl.h>
+#include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/util/aws.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
@@ -1030,6 +1031,59 @@ void TestCompaction(std::optional<ui32> numWrites = {}) {
     }
 }
 
+void TestProposeResultNotViaPipe() {
+    TTestBasicRuntime runtime;
+    TTester::Setup(runtime);
+    auto csDefaultControllerGuard = NKikimr::NYDBTest::TControllers::RegisterCSControllerGuard<TDefaultTestsController>();
+
+    TActorId sender = runtime.AllocateEdgeActor();
+    CreateTestBootstrapper(
+        runtime,
+        CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::ColumnShard),
+        &CreateColumnShard
+    );
+
+    TDispatchOptions options;
+    options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot));
+    runtime.DispatchEvents(options);
+
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(5);
+    while (csDefaultControllerGuard->GetShardActualsCount() == 0 && TInstant::Now() < deadline) {
+        runtime.SimulateSleep(TDuration::MilliSeconds(100));
+    }
+    UNIT_ASSERT_VALUES_EQUAL(csDefaultControllerGuard->GetShardActualsCount(), 1);
+
+    const ui64 tableId = 1;
+    const ui64 txId = 100;
+    const ui64 schemeShardId = 4242;
+
+    bool checkedRecipient = false;
+    runtime.SetEventFilter([&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+        if (ev->GetTypeRewrite() == TEvPipeCache::TEvForward::EventType) {
+            auto* forward = ev->Get<TEvPipeCache::TEvForward>();
+            if (forward->TabletId == schemeShardId
+                && forward->Ev
+                && forward->Ev->Type() == TEvColumnShard::EvProposeTransactionResult) {
+                UNIT_FAIL("ProposeResult must not be forwarded via pipe cache. Because the pipe lets the message to be delivered to the next generation of the tablet (in case of restart). And that causes subtle bugs that are very hard to debug.");
+            }
+        } else if (ev->GetTypeRewrite() == TEvColumnShard::EvProposeTransactionResult) {
+            checkedRecipient = true;
+            UNIT_ASSERT_VALUES_EQUAL(ev->Recipient, sender);
+        }
+        return false;
+    });
+    auto txBody = TTestSchema::CreateInitShardTxBody(tableId, testYdbSchema, testYdbPk, {}, "/Root/olapStore");
+    auto event = std::make_unique<TEvColumnShard::TEvProposeTransaction>(NKikimrTxColumnShard::TX_KIND_SCHEMA, schemeShardId, sender, txId, txBody, 0, 0);
+    ForwardToTablet(runtime, TTestTxConfig::TxTablet0, sender, event.release());
+
+    auto ev = runtime.GrabEdgeEvent<TEvColumnShard::TEvProposeTransactionResult>(sender);
+    UNIT_ASSERT(ev);
+    const auto& res = ev->Get()->Record;
+    UNIT_ASSERT_EQUAL(res.GetTxId(), txId);
+    UNIT_ASSERT_EQUAL(res.GetTxKind(), NKikimrTxColumnShard::TX_KIND_SCHEMA);
+    UNIT_ASSERT(checkedRecipient);
+}
+
 }
 
 namespace NColumnShard {
@@ -1148,6 +1202,10 @@ Y_UNIT_TEST_SUITE(TColumnShardTestSchema) {
 
     Y_UNIT_TEST_QUATRO(CreateTable, Reboots, GenerateInternalPathId) {
         CreateTable(Reboots, GenerateInternalPathId);
+    }
+
+    Y_UNIT_TEST(ProposeResultNotViaPipe) {
+        TestProposeResultNotViaPipe();
     }
 
     Y_UNIT_TEST_OCTO(TTL, Reboot, Internal, FirstPkColumn) {


### PR DESCRIPTION
fixes #15494

See details and explanation of the fix under the issue.

In a nutshell, after the fix, columnshard answers to schemeshard via direct messages using the actorId from the request. It excludes the possibility to deliver the response to the next generation schemeshard (it has a different actorId).
