### PR TITLE
Incremental GC in TSharedPageCache actor

### DIFF
--- a/ydb/core/protos/shared_cache.proto
+++ b/ydb/core/protos/shared_cache.proto
@@ -16,4 +16,5 @@ message TSharedCacheConfig {
     optional TReplacementPolicy ReplacementPolicy = 6 [default = S3FIFO]; // deprecated, always S3FIFO
     reserved 7;
     optional uint64 InMemoryInFlyLimit = 8 [default = 536870912];
+    optional uint64 MaxEvictedBytesInSingleGCRun = 9 [default = 10485760];
 }

--- a/ydb/core/protos/shared_cache.proto
+++ b/ydb/core/protos/shared_cache.proto
@@ -16,5 +16,5 @@ message TSharedCacheConfig {
     optional TReplacementPolicy ReplacementPolicy = 6 [default = S3FIFO]; // deprecated, always S3FIFO
     reserved 7;
     optional uint64 InMemoryInFlyLimit = 8 [default = 536870912];
-    optional uint64 MaxEvictedBytesInSingleGCRun = 9 [default = 10485760];
+    optional uint64 MaxLimitDecreaseStepBytes = 9 [default = 10485760];
 }

--- a/ydb/core/tablet_flat/shared_cache_counters.cpp
+++ b/ydb/core/tablet_flat/shared_cache_counters.cpp
@@ -24,6 +24,9 @@ TSharedPageCacheCounters::TSharedPageCacheCounters(const TIntrusivePtr<::NMonito
     , LoadInFlyBytes(counters->GetCounter("LoadInFlyBytes"))
     , TargetInMemoryBytes(counters->GetCounter("TargetInMemoryBytes"))
     , ActiveInMemoryBytes(counters->GetCounter("ActiveInMemoryBytes"))
+    , EvictedPages(counters->GetCounter("EvictedPages", true))
+    , EvictedBytes(counters->GetCounter("EvictedBytes", true))
+    , S3FIFOEvictOps(counters->GetCounter("S3FIFOEvictOps", true))
     // page collection counters:
     , PageCollections(counters->GetCounter("PageCollections"))
     , Owners(counters->GetCounter("Owners"))
@@ -32,6 +35,7 @@ TSharedPageCacheCounters::TSharedPageCacheCounters(const TIntrusivePtr<::NMonito
     , PendingRequests(counters->GetCounter("PendingRequests"))
     , SucceedRequests(counters->GetCounter("SucceedRequests", true))
     , FailedRequests(counters->GetCounter("FailedRequests", true))
+    , UnfinishedGCRuns(counters->GetCounter("UnfinishedGCRuns", true))
 { }
 
 } // namespace NKikimr::NSharedCache

--- a/ydb/core/tablet_flat/shared_cache_counters.cpp
+++ b/ydb/core/tablet_flat/shared_cache_counters.cpp
@@ -35,7 +35,6 @@ TSharedPageCacheCounters::TSharedPageCacheCounters(const TIntrusivePtr<::NMonito
     , PendingRequests(counters->GetCounter("PendingRequests"))
     , SucceedRequests(counters->GetCounter("SucceedRequests", true))
     , FailedRequests(counters->GetCounter("FailedRequests", true))
-    , UnfinishedGCRuns(counters->GetCounter("UnfinishedGCRuns", true))
 { }
 
 } // namespace NKikimr::NSharedCache

--- a/ydb/core/tablet_flat/shared_cache_counters.h
+++ b/ydb/core/tablet_flat/shared_cache_counters.h
@@ -44,7 +44,6 @@ struct TSharedPageCacheCounters final : public TAtomicRefCount<TSharedPageCacheC
     const TCounterPtr PendingRequests;
     const TCounterPtr SucceedRequests;
     const TCounterPtr FailedRequests;
-    const TCounterPtr UnfinishedGCRuns;
 
     explicit TSharedPageCacheCounters(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters);
 };

--- a/ydb/core/tablet_flat/shared_cache_counters.h
+++ b/ydb/core/tablet_flat/shared_cache_counters.h
@@ -31,6 +31,9 @@ struct TSharedPageCacheCounters final : public TAtomicRefCount<TSharedPageCacheC
     const TCounterPtr LoadInFlyBytes;
     const TCounterPtr TargetInMemoryBytes;
     const TCounterPtr ActiveInMemoryBytes;
+    const TCounterPtr EvictedPages;
+    const TCounterPtr EvictedBytes;
+    const TCounterPtr S3FIFOEvictOps;
 
     // page collection counters:
     const TCounterPtr PageCollections;
@@ -41,6 +44,7 @@ struct TSharedPageCacheCounters final : public TAtomicRefCount<TSharedPageCacheC
     const TCounterPtr PendingRequests;
     const TCounterPtr SucceedRequests;
     const TCounterPtr FailedRequests;
+    const TCounterPtr UnfinishedGCRuns;
 
     explicit TSharedPageCacheCounters(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters);
 };

--- a/ydb/core/tablet_flat/shared_cache_events.h
+++ b/ydb/core/tablet_flat/shared_cache_events.h
@@ -18,7 +18,7 @@ namespace NKikimr::NSharedCache {
     enum class EWakeupTag {
         DoGCScheduled = 1,
         DoGCManual = 2,
-        DoGCContinuation = 3,
+        DoLimitDecrease = 3,
     };
 
     enum EEv {

--- a/ydb/core/tablet_flat/shared_cache_events.h
+++ b/ydb/core/tablet_flat/shared_cache_events.h
@@ -17,7 +17,8 @@ namespace NKikimr::NSharedCache {
 
     enum class EWakeupTag {
         DoGCScheduled = 1,
-        DoGCManual = 2
+        DoGCManual = 2,
+        DoGCContinuation = 3,
     };
 
     enum EEv {

--- a/ydb/core/tablet_flat/shared_cache_s3fifo.h
+++ b/ydb/core/tablet_flat/shared_cache_s3fifo.h
@@ -169,6 +169,10 @@ public:
         return SmallQueue.Size + MainQueue.Size;
     }
 
+    ui64 GetEvictOpsCounter() const {
+        return EvictOpsCounter;
+    }
+
     TString Dump() const {
         TStringBuilder result;
 
@@ -208,6 +212,8 @@ private:
         ui32 mainQueueReinserts = 0;
 
         while (GetSize() > Limit.TotalLimit) {
+            ++EvictOpsCounter;
+
             if (SmallQueue.Size > Limit.SmallQueueLimit) {
                 TPage* page = Pop(SmallQueue);
                 if (ui32 frequency = TPageTraits::GetFrequency(page); frequency > 0) {
@@ -285,6 +291,7 @@ private:
     TQueue MainQueue;
     TS3FIFOGhostPageQueue<TPageTraits> GhostQueue;
 
+    ui64 EvictOpsCounter = 0;
 };
 
 }

--- a/ydb/core/tablet_flat/shared_cache_tiered.h
+++ b/ydb/core/tablet_flat/shared_cache_tiered.h
@@ -62,6 +62,10 @@ namespace NKikimr::NSharedCache {
             return RegularTier->GetSize() + TryKeepInMemoryTier->GetSize();
         }
 
+        ui64 GetEvictOpsCounter() const {
+            return RegularTier->GetEvictOpsCounter() + TryKeepInMemoryTier->GetEvictOpsCounter();
+        }
+
         TString Dump() const {
             TStringBuilder result;
             bool first = true;

--- a/ydb/core/tablet_flat/shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/shared_sausagecache.cpp
@@ -173,54 +173,70 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
     ui64 ActiveInMemoryBytes = 0;
     ui64 InFlyInMemoryBytes = 0;
 
-    // True if after after a big drop in cache size, we couldn't finish GC during
-    // a single event handler invocation and yielded to process other events.
-    bool GcInProgress = false;
+    // True if after a large drop in target cache limit, we couldn't decrease it right away
+    // and yielded to process other events.
+    bool LimitDecreaseScheduled = false;
+
+    ui64 GetTargetCacheLimitBytes() const {
+        if (Config.HasMemoryLimit()) {
+            return Min(MemLimitBytes, Config.GetMemoryLimit());
+        }
+        return MemLimitBytes;
+    }
 
     ui64 GetInMemoryLimitBytes() {
         ui64 remainInFlyLimit = Config.GetInMemoryInFlyLimit() > InFlyInMemoryBytes ? Config.GetInMemoryInFlyLimit() - InFlyInMemoryBytes : 0;
         return Min(AliveInMemoryBytes + remainInFlyLimit, TargetInMemoryBytes);
     }
 
-    // Returns true if the limit is fully in sync with the config.
-    bool ActualizeCacheSizeLimit() {
-        ui64 limitBytes = MemLimitBytes;
-        if (Config.HasMemoryLimit()) {
-            limitBytes = Min(limitBytes, Config.GetMemoryLimit());
-            Counters.ConfigLimitBytes->Set(Config.GetMemoryLimit());
-        } else {
-            Counters.ConfigLimitBytes->Set(0);
-        }
+    void ActualizeCacheSizeLimit() {
+        Counters.ConfigLimitBytes->Set(Config.HasMemoryLimit() ? Config.GetMemoryLimit() : 0);
 
-        ui64 effectiveLimit = Cache.GetLimit() > limitBytes + Config.GetMaxEvictedBytesInSingleGCRun()
-            ? Cache.GetLimit() - Config.GetMaxEvictedBytesInSingleGCRun()
-            : limitBytes;
+        const ui64 currentLimit = Cache.GetLimit();
+        const ui64 targetLimit = GetTargetCacheLimitBytes();
+        ui64 newLimit;
+        if (targetLimit >= currentLimit) {
+            // Limit increased, no problem, do it right away.
+            newLimit = targetLimit;
+        } else if (LimitDecreaseScheduled) {
+            // Limit decreased, but we can't update it yet.
+            newLimit = currentLimit;
+        } else if (targetLimit + Config.GetMaxLimitDecreaseStepBytes() >= currentLimit) {
+            // Limit decreased by a small amount, do it right away.
+            newLimit = targetLimit;
+        } else {
+            // A large decrease in target limit, decrease the current limit for a bit
+            // and schedule another decrease after we process the current event queue.
+            newLimit = currentLimit - Config.GetMaxLimitDecreaseStepBytes();
+            LimitDecreaseScheduled = true;
+            ActorContext().Send(
+                    SelfId(),
+                    new TKikimrEvents::TEvWakeup(static_cast<ui64>(EWakeupTag::DoLimitDecrease)));
+        }
 
         // limit of cache depends only on config and mem because passive pages may go in and out arbitrary
         // we may have some passive bytes, so if we fully fill this Cache we may exceed the limit
         // because of that DoGC should be called to ensure limits
-        Cache.UpdateLimit(effectiveLimit, GetInMemoryLimitBytes());
-        Counters.ActiveLimitBytes->Set(effectiveLimit);
-
-        return effectiveLimit == limitBytes;
+        Cache.UpdateLimit(newLimit, GetInMemoryLimitBytes());
+        Counters.ActiveLimitBytes->Set(newLimit);
     }
 
-    // Return true when actually finished
-    bool DoGC() {
+    void DoGC() {
         // maybe we already have enough useless pages
         // update StatActiveBytes + StatPassiveBytes
         ProcessGCList();
 
+        const ui64 cacheLimit = Cache.GetLimit();
         // TODO: get rid of active pages reservation
-        ui64 configActiveReservedBytes = (Config.HasMemoryLimit() ? Config.GetMemoryLimit() : 0)
-            * Config.GetActivePagesReservationPercent() / 100;
+        const ui64 configActiveReservedBytes = cacheLimit * Config.GetActivePagesReservationPercent() / 100;
 
         THashSet<TCollection*> recheck;
         ui64 evictedBytes = 0;
         ui64 evictedInMemoryBytes = 0;
-        while (GetStatAllBytes() > MemLimitBytes
-            || GetStatAllBytes() > (Config.HasMemoryLimit() ? Config.GetMemoryLimit() : Max<ui64>()) && StatActiveBytes > configActiveReservedBytes)
-        {
+        // Evict pages from the cache until *all* used bytes get under the cache limit,
+        // but stop if *active* bytes get under configActiveReservedBytes to avoid the case
+        // where we just make all pages passive without actually freeing any memory.
+        while (GetStatAllBytes() > cacheLimit && StatActiveBytes > configActiveReservedBytes) {
             if (TPage* evictedPage = Cache.EvictNext()) {
                 auto pageSize = TPageTraits::GetSize(evictedPage);
                 evictedBytes += pageSize;
@@ -228,9 +244,6 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
                     evictedInMemoryBytes += pageSize;
                 }
                 EvictNow(evictedPage, recheck);
-                if (evictedBytes > Config.GetMaxEvictedBytesInSingleGCRun()) {
-                    break;
-                }
             } else {
                 break;
             }
@@ -247,15 +260,13 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
 
         LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TABLET_SAUSAGECACHE, "GC has finished with"
             << " Limit: " << HumanReadableBytes(Cache.GetLimit())
+            << " TargetLimit: " << HumanReadableBytes(GetTargetCacheLimitBytes())
             << " Active: " << HumanReadableBytes(StatActiveBytes)
             << " Passive: " << HumanReadableBytes(StatPassiveBytes)
             << " LoadInFly: " << HumanReadableBytes(StatLoadInFlyBytes)
             << " EvictedBytes: " << HumanReadableBytes(evictedBytes)
             << " EvictedInMemoryBytes: " << HumanReadableBytes(evictedInMemoryBytes)
         );
-
-        const bool cacheSizeInSync = ActualizeCacheSizeLimit();
-        return cacheSizeInSync && evictedBytes <= Config.GetMaxEvictedBytesInSingleGCRun();
     }
 
     void Handle(NMemory::TEvConsumerRegistered::TPtr &ev, const TActorContext& ctx) {
@@ -891,13 +902,16 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
         switch (tag) {
         case EWakeupTag::DoGCScheduled:
             ScheduleGC();
-            [[fallthrough]];
+            break;
         case EWakeupTag::DoGCManual:
-        case EWakeupTag::DoGCContinuation:
-            // DoGC will be called at the end of StateFunc
-            GcInProgress = false;
+            break;
+        case EWakeupTag::DoLimitDecrease:
+            LimitDecreaseScheduled = false;
+            ActualizeCacheSizeLimit();
             break;
         }
+
+        // DoGC will be called at the end of StateFunc
     }
 
     void ProcessGCList() {
@@ -1356,10 +1370,11 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
     }
 
     void Evict(TIntrusiveList<TPage>&& pages) {
-        size_t evictedPages = pages.Size();
+        size_t evictedPages = 0;
         ui64 evictedBytes = 0;
         while (!pages.Empty()) {
             TPage* page = pages.PopFront();
+            auto pageSize = TPageTraits::GetSize(page);
 
             page->EnsureNoCacheFlags();
 
@@ -1372,7 +1387,8 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
                 SharedCachePages->GCList->PushGC(page);
             }
 
-            evictedBytes += TPageTraits::GetSize(page);
+            ++evictedPages;
+            evictedBytes += pageSize;
         }
 
         Counters.EvictedPages->Add(evictedPages);
@@ -1380,6 +1396,7 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
     }
 
     void EvictNow(TPage* page, THashSet<TCollection*>& recheck) {
+        auto pageSize = TPageTraits::GetSize(page);
         page->EnsureNoCacheFlags();
 
         Y_ENSURE(page->State == PageStateLoaded, "unexpected " << page->State << " page state");
@@ -1392,7 +1409,7 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
         }
 
         Counters.EvictedPages->Inc();
-        Counters.EvictedBytes->Add(TPageTraits::GetSize(page));
+        Counters.EvictedBytes->Add(pageSize);
     }
 
     void Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr& ev, const TActorContext& ctx) {
@@ -1548,19 +1565,7 @@ public:
             HFunc(NMemory::TEvConsumerLimit, Handle);
         }
 
-        const bool gcFinished = DoGC();
-        if (gcFinished) {
-            GcInProgress = false;
-        } else {
-            Counters.UnfinishedGCRuns->Inc();
-            if (!GcInProgress) {
-                GcInProgress = true;
-                ActorContext().Send(
-                    SelfId(),
-                    new TKikimrEvents::TEvWakeup(static_cast<ui64>(EWakeupTag::DoGCContinuation)));
-            }
-        }
-
+        DoGC();
         TryLoadInMemoryCollections();
     }
 

--- a/ydb/core/tablet_flat/shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/shared_sausagecache.cpp
@@ -209,9 +209,7 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
             // and schedule another decrease after we process the current event queue.
             newLimit = currentLimit - Config.GetMaxLimitDecreaseStepBytes();
             LimitDecreaseScheduled = true;
-            ActorContext().Send(
-                    SelfId(),
-                    new TKikimrEvents::TEvWakeup(static_cast<ui64>(EWakeupTag::DoLimitDecrease)));
+            Send(SelfId(), new TKikimrEvents::TEvWakeup(static_cast<ui64>(EWakeupTag::DoLimitDecrease)));
         }
 
         // limit of cache depends only on config and mem because passive pages may go in and out arbitrary

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
@@ -2365,7 +2365,7 @@ Y_UNIT_TEST_SUITE(TSharedPageCache_Actor) {
 
     Y_UNIT_TEST(IncrementalGC) {
         auto config = TSharedPageCacheMock::DefaultConfig();
-        config.SetMaxEvictedBytesInSingleGCRun(PAGE_TOTAL_SIZE);
+        config.SetMaxLimitDecreaseStepBytes(PAGE_TOTAL_SIZE);
         TSharedPageCacheMock sharedCache(config);
         ui64 fetchNo = 0;
 
@@ -2380,7 +2380,6 @@ Y_UNIT_TEST_SUITE(TSharedPageCache_Actor) {
 
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->ActivePages->Val(), 4);
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->EvictedPages->Val(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->UnfinishedGCRuns->Val(), 0);
 
         // We'll need 3 wakeups to reach the target limit and evict extra pages.
         sharedCache.SetLimit(PAGE_TOTAL_SIZE);


### PR DESCRIPTION
### Changelog entry 

Fix latency spikes that could happen when the shared cache limit got lowered by a lot.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

SPI-169443

Decrease the cache limit in TSharedPageCacheActor in 10MB steps (evicting 10MB corresponds to ~5ms runtime) and let other requests run between steps.