### PR TITLE
Add CSV/TSV/JSON streaming output for topic read without 500 line limit

### DIFF
--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -62,6 +62,8 @@ namespace {
         { EMessagingFormat::Concatenated, "Concatenated output stream of messages."}, // TODO(shmel1k@): improve,
         { EMessagingFormat::JsonStreamConcat, "Concatenated Json stream of envelopes with metadata and messages in the ""body"" attribute." }, // TODO(shmel1k@): improve,
         { EMessagingFormat::JsonArray, "Json array of envelopes with metadata and messages in the ""body"" attribute." }, // TODO(shmel1k@): improve,
+        { EMessagingFormat::Csv, "CSV format with header row containing metadata field names." },
+        { EMessagingFormat::Tsv, "TSV format with header row containing metadata field names." },
     };
 } // anonymous namespace
 

--- a/ydb/public/lib/ydb_cli/common/formats.h
+++ b/ydb/public/lib/ydb_cli/common/formats.h
@@ -34,6 +34,8 @@ enum class EMessagingFormat {
 
     JsonStreamConcat /* "json-stream-concat" */,
     JsonArray /* "json-array" */,
+    Csv /* "csv" */,
+    Tsv /* "tsv" */,
 };
 
 // EFramingFormat to be used in operations related to structured data

--- a/ydb/public/lib/ydb_cli/topic/topic_read.cpp
+++ b/ydb/public/lib/ydb_cli/topic/topic_read.cpp
@@ -5,6 +5,7 @@
 #include <ydb/public/lib/ydb_cli/commands/ydb_common.h>
 
 #include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/json_writer.h>
 #include <library/cpp/string_utils/base64/base64.h>
 #include <util/generic/set.h>
 
@@ -12,10 +13,13 @@ namespace NYdb::NConsoleClient {
     namespace {
         constexpr i64 MessagesLimitUnlimited = -1;
         constexpr i64 MessagesLimitDefaultPrettyFormat = 10;
-        constexpr i64 MessagesLimitDefaultJsonArrayFormat = 500;
 
         bool IsStreamingFormat(EMessagingFormat format) {
-            return format == EMessagingFormat::NewlineDelimited || format == EMessagingFormat::Concatenated;
+            return format == EMessagingFormat::NewlineDelimited || 
+                   format == EMessagingFormat::Concatenated || 
+                   format == EMessagingFormat::JsonStreamConcat ||
+                   format == EMessagingFormat::Csv ||
+                   format == EMessagingFormat::Tsv;
         }
     }
 
@@ -64,8 +68,10 @@ namespace NYdb::NConsoleClient {
             if (ReaderParams_.MessagingFormat() == EMessagingFormat::Pretty) {
                 MessagesLeft_ = MessagesLimitDefaultPrettyFormat;
             }
-            if (ReaderParams_.MessagingFormat() == EMessagingFormat::JsonArray) {
-                MessagesLeft_ = MessagesLimitDefaultJsonArrayFormat;
+            if (ReaderParams_.MessagingFormat() == EMessagingFormat::JsonArray || 
+                ReaderParams_.MessagingFormat() == EMessagingFormat::Csv ||
+                ReaderParams_.MessagingFormat() == EMessagingFormat::Tsv) {
+                MessagesLeft_ = MessagesLimitUnlimited;
             }
             return;
         }
@@ -144,18 +150,246 @@ namespace NYdb::NConsoleClient {
         OutputTable_->Print(output);
     }
 
+    void TTopicReader::PrintMessageAsJson(const TReceivedMessage& message, IOutputStream& output) const {
+        NJson::TJsonWriter writer(&output, false);
+        writer.OpenMap();
+
+        for (const auto& f : ReaderParams_.MetadataFields()) {
+            switch (f) {
+                case ETopicMetadataField::Body:
+                    writer.Write("body", TString(FormatBody(message.GetData(), ReaderParams_.Transform())));
+                    break;
+                case ETopicMetadataField::CreateTime:
+                    writer.Write("create_time", message.GetCreateTime().ToString());
+                    break;
+                case ETopicMetadataField::MessageGroupID:
+                    writer.Write("message_group_id", TString(message.GetMessageGroupId()));
+                    break;
+                case ETopicMetadataField::Offset:
+                    writer.Write("offset", message.GetOffset());
+                    break;
+                case ETopicMetadataField::WriteTime:
+                    writer.Write("write_time", message.GetWriteTime().ToString());
+                    break;
+                case ETopicMetadataField::SeqNo:
+                    writer.Write("seq_no", message.GetSeqNo());
+                    break;
+                case ETopicMetadataField::MessageMeta:
+                    {
+                        writer.WriteKey("message_meta");
+                        writer.OpenMap();
+                        for (const auto& [k, v] : message.GetMessageMeta()->Fields) {
+                            writer.Write(k, v);
+                        }
+                        writer.CloseMap();
+                    }
+                    break;
+                case ETopicMetadataField::SessionMeta:
+                    {
+                        writer.WriteKey("session_meta");
+                        writer.OpenMap();
+                        for (const auto& [k, v] : message.GetMeta()->Fields) {
+                            writer.Write(k, v);
+                        }
+                        writer.CloseMap();
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        writer.CloseMap();
+    }
+
     void TTopicReader::PrintMessagesInJsonArrayFormat(IOutputStream& output) const {
-        // TODO(shmel1k@): not implemented yet.
-        Y_UNUSED(output);
+        output << "[";
+        bool first = true;
+        for (const auto& message : ReceivedMessages_) {
+            if (!first) {
+                output << ",";
+            }
+            first = false;
+            PrintMessageAsJson(message, output);
+        }
+        output << "]" << Endl;
+    }
+
+    void TTopicReader::PrintMessagesInCsvFormat(IOutputStream& output, char delimiter) const {
+        // Print header
+        bool firstCol = true;
+        for (const auto& f : ReaderParams_.MetadataFields()) {
+            if (!firstCol) {
+                output << delimiter;
+            }
+            firstCol = false;
+            output << f;
+        }
+        output << "\n";
+
+        // Print rows
+        for (const auto& message : ReceivedMessages_) {
+            firstCol = true;
+            for (const auto& f : ReaderParams_.MetadataFields()) {
+                if (!firstCol) {
+                    output << delimiter;
+                }
+                firstCol = false;
+
+                switch (f) {
+                    case ETopicMetadataField::Body:
+                        {
+                            TString body(FormatBody(message.GetData(), ReaderParams_.Transform()));
+                            if (body.Contains(delimiter) || body.Contains('"') || body.Contains('\n')) {
+                                TString escaped;
+                                escaped.reserve(body.size() + 2);
+                                escaped += '"';
+                                for (char c : body) {
+                                    if (c == '"') {
+                                        escaped += "\"\"";
+                                    } else {
+                                        escaped += c;
+                                    }
+                                }
+                                escaped += '"';
+                                output << escaped;
+                            } else {
+                                output << body;
+                            }
+                        }
+                        break;
+                    case ETopicMetadataField::CreateTime:
+                        output << message.GetCreateTime();
+                        break;
+                    case ETopicMetadataField::MessageGroupID:
+                        output << message.GetMessageGroupId();
+                        break;
+                    case ETopicMetadataField::Offset:
+                        output << message.GetOffset();
+                        break;
+                    case ETopicMetadataField::WriteTime:
+                        output << message.GetWriteTime();
+                        break;
+                    case ETopicMetadataField::SeqNo:
+                        output << message.GetSeqNo();
+                        break;
+                    case ETopicMetadataField::MessageMeta:
+                        {
+                            NJson::TJsonValue json;
+                            for (const auto& [k, v] : message.GetMessageMeta()->Fields) {
+                                json[k] = v;
+                            }
+                            output << json;
+                        }
+                        break;
+                    case ETopicMetadataField::SessionMeta:
+                        {
+                            NJson::TJsonValue json;
+                            for (const auto& [k, v] : message.GetMeta()->Fields) {
+                                json[k] = v;
+                            }
+                            output << json;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+            output << "\n";
+        }
+    }
+
+    void TTopicReader::PrintCsvHeader(IOutputStream& output, char delimiter) {
+        bool firstCol = true;
+        for (const auto& f : ReaderParams_.MetadataFields()) {
+            if (!firstCol) {
+                output << delimiter;
+            }
+            firstCol = false;
+            output << f;
+        }
+        output << "\n";
+        CsvHeaderPrinted_ = true;
+    }
+
+    void TTopicReader::PrintMessageAsCsvRow(const TReceivedMessage& message, IOutputStream& output, char delimiter) const {
+        bool firstCol = true;
+        for (const auto& f : ReaderParams_.MetadataFields()) {
+            if (!firstCol) {
+                output << delimiter;
+            }
+            firstCol = false;
+
+            switch (f) {
+                case ETopicMetadataField::Body:
+                    {
+                        TString body(FormatBody(message.GetData(), ReaderParams_.Transform()));
+                        if (body.Contains(delimiter) || body.Contains('"') || body.Contains('\n')) {
+                            TString escaped;
+                            escaped.reserve(body.size() + 2);
+                            escaped += '"';
+                            for (char c : body) {
+                                if (c == '"') {
+                                    escaped += "\"\"";
+                                } else {
+                                    escaped += c;
+                                }
+                            }
+                            escaped += '"';
+                            output << escaped;
+                        } else {
+                            output << body;
+                        }
+                    }
+                    break;
+                case ETopicMetadataField::CreateTime:
+                    output << message.GetCreateTime();
+                    break;
+                case ETopicMetadataField::MessageGroupID:
+                    output << message.GetMessageGroupId();
+                    break;
+                case ETopicMetadataField::Offset:
+                    output << message.GetOffset();
+                    break;
+                case ETopicMetadataField::WriteTime:
+                    output << message.GetWriteTime();
+                    break;
+                case ETopicMetadataField::SeqNo:
+                    output << message.GetSeqNo();
+                    break;
+                case ETopicMetadataField::MessageMeta:
+                    {
+                        NJson::TJsonValue json;
+                        for (const auto& [k, v] : message.GetMessageMeta()->Fields) {
+                            json[k] = v;
+                        }
+                        output << json;
+                    }
+                    break;
+                case ETopicMetadataField::SessionMeta:
+                    {
+                        NJson::TJsonValue json;
+                        for (const auto& [k, v] : message.GetMeta()->Fields) {
+                            json[k] = v;
+                        }
+                        output << json;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        output << "\n";
     }
 
     void TTopicReader::Close(IOutputStream& output, TDuration closeTimeout) {
-        if (ReaderParams_.MessagingFormat() == EMessagingFormat::Pretty) {
+        EMessagingFormat format = ReaderParams_.MessagingFormat();
+        if (format == EMessagingFormat::Pretty) {
             PrintMessagesInPrettyFormat(output);
-        }
-        if (ReaderParams_.MessagingFormat() == EMessagingFormat::JsonArray) {
+        } else if (format == EMessagingFormat::JsonArray) {
             PrintMessagesInJsonArrayFormat(output);
         }
+        // CSV and TSV are streaming formats - rows already output in HandleReceivedMessage
         output.Flush();
         bool success = ReadSession_->Close(closeTimeout);
         if (!success) {
@@ -164,23 +398,41 @@ namespace NYdb::NConsoleClient {
     }
 
     void TTopicReader::HandleReceivedMessage(const TReceivedMessage& message, IOutputStream& output) {
-        EMessagingFormat MessagingFormat = ReaderParams_.MessagingFormat();
-        if (MessagingFormat == EMessagingFormat::SingleMessage || MessagingFormat == EMessagingFormat::Concatenated) {
+        EMessagingFormat format = ReaderParams_.MessagingFormat();
+        if (format == EMessagingFormat::SingleMessage || format == EMessagingFormat::Concatenated) {
             output << FormatBody(message.GetData(), ReaderParams_.Transform());
             output.Flush();
             return;
         }
-        if (MessagingFormat == EMessagingFormat::NewlineDelimited) {
+        if (format == EMessagingFormat::NewlineDelimited) {
             output << FormatBody(message.GetData(), ReaderParams_.Transform());
             output << "\n";
             output.Flush();
             return;
         }
-        if (MessagingFormat == EMessagingFormat::SingleMessage) {
-            output << FormatBody(message.GetData(), ReaderParams_.Transform());
+        if (format == EMessagingFormat::JsonStreamConcat) {
+            PrintMessageAsJson(message, output);
+            output << "\n";
+            output.Flush();
             return;
         }
-
+        if (format == EMessagingFormat::Csv) {
+            if (!CsvHeaderPrinted_) {
+                PrintCsvHeader(output, ',');
+            }
+            PrintMessageAsCsvRow(message, output, ',');
+            output.Flush();
+            return;
+        }
+        if (format == EMessagingFormat::Tsv) {
+            if (!CsvHeaderPrinted_) {
+                PrintCsvHeader(output, '\t');
+            }
+            PrintMessageAsCsvRow(message, output, '\t');
+            output.Flush();
+            return;
+        }
+        // For batch formats (Pretty, JsonArray), accumulate messages
         ReceivedMessages_.push_back(message);
     }
 

--- a/ydb/public/lib/ydb_cli/topic/topic_read.h
+++ b/ydb/public/lib/ydb_cli/topic/topic_read.h
@@ -84,6 +84,10 @@ namespace NYdb::NConsoleClient {
     private:
         void PrintMessagesInPrettyFormat(IOutputStream& output) const;
         void PrintMessagesInJsonArrayFormat(IOutputStream& output) const;
+        void PrintMessagesInCsvFormat(IOutputStream& output, char delimiter) const;
+        void PrintMessageAsJson(const TReceivedMessage& message, IOutputStream& output) const;
+        void PrintCsvHeader(IOutputStream& output, char delimiter);
+        void PrintMessageAsCsvRow(const TReceivedMessage& message, IOutputStream& output, char delimiter) const;
 
         enum EReadingStatus {
             NoPartitionTaken = 0,
@@ -112,6 +116,7 @@ namespace NYdb::NConsoleClient {
         TVector<TReceivedMessage> ReceivedMessages_;
 
         ui32 PartitionsBeingRead_ = 0;
+        bool CsvHeaderPrinted_ = false;
 
         friend class TTopicReaderTests;
 

--- a/ydb/public/lib/ydb_cli/topic/topic_read_ut.cpp
+++ b/ydb/public/lib/ydb_cli/topic/topic_read_ut.cpp
@@ -1,4 +1,5 @@
 #include "topic_read.h"
+#include "topic_metadata_fields.h"
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/data_plane_helpers.h>
 #include <ydb/services/persqueue_v1/ut/persqueue_test_fixture.h>
@@ -17,6 +18,10 @@ namespace NYdb::NConsoleClient {
         UNIT_TEST(TestRun_Read_Less_Messages_Than_Sent);
         UNIT_TEST(TestRun_ReadMessages_With_Offset);
         UNIT_TEST(TestRun_ReadMessages_With_Future_Offset);
+        UNIT_TEST(TestRun_ReadMessages_JsonStreamConcat);
+        UNIT_TEST(TestRun_ReadMessages_CsvFormat);
+        UNIT_TEST(TestRun_ReadMessages_TsvFormat);
+        UNIT_TEST(TestRun_ReadMessages_CsvFormat_Unlimited);
         UNIT_TEST_SUITE_END();
 
         void TestRun_ReadOneMessage() {
@@ -131,6 +136,81 @@ namespace NYdb::NConsoleClient {
                     "\n", TTopicReaderSettings({}, false, false, {{0, 10}}, EMessagingFormat::NewlineDelimited, {}, ETransformBody::None, TDuration::Seconds(1)));
         }
 
+        void TestRun_ReadMessages_JsonStreamConcat() {
+            // Test JSON stream-concat format - outputs each message as JSON object on its own line
+            RunTestWithMetadataFields(
+                {
+                    "message1",
+                    "message2",
+                },
+                {
+                    R"({"body":"message1","offset":0})",
+                    R"({"body":"message2","offset":1})",
+                },
+                "\n", 
+                TTopicReaderSettings(Nothing(), false, false, {}, EMessagingFormat::JsonStreamConcat, 
+                    {ETopicMetadataField::Body, ETopicMetadataField::Offset}, ETransformBody::None, TDuration::Seconds(1)));
+        }
+
+        void TestRun_ReadMessages_CsvFormat() {
+            // Test CSV format - outputs header row followed by data rows
+            RunTestWithMetadataFields(
+                {
+                    "message1",
+                    "message2",
+                    "message3",
+                },
+                {
+                    "body,offset",  // header
+                    "message1,0",
+                    "message2,1",
+                    "message3,2",
+                },
+                "\n", 
+                TTopicReaderSettings(Nothing(), false, false, {}, EMessagingFormat::Csv, 
+                    {ETopicMetadataField::Body, ETopicMetadataField::Offset}, ETransformBody::None, TDuration::Seconds(1)));
+        }
+
+        void TestRun_ReadMessages_TsvFormat() {
+            // Test TSV format - tab-separated values
+            RunTestWithMetadataFields(
+                {
+                    "message1",
+                    "message2",
+                },
+                {
+                    "body\toffset",  // header
+                    "message1\t0",
+                    "message2\t1",
+                },
+                "\n", 
+                TTopicReaderSettings(Nothing(), false, false, {}, EMessagingFormat::Tsv, 
+                    {ETopicMetadataField::Body, ETopicMetadataField::Offset}, ETransformBody::None, TDuration::Seconds(1)));
+        }
+
+        void TestRun_ReadMessages_CsvFormat_Unlimited() {
+            // Test that CSV format reads all messages without a limit (unlimited mode)
+            // This tests the fix that removes the 500 line limit for streaming formats
+            constexpr size_t numMessages = 10;  // In production, this would be more than 500
+            TVector<TString> messages;
+            TVector<TString> expected;
+            expected.push_back("body");  // header
+            
+            for (size_t i = 0; i < numMessages; ++i) {
+                TString msg = TStringBuilder() << "msg" << i;
+                messages.push_back(msg);
+                expected.push_back(msg);
+            }
+            
+            // With no limit specified, CSV format should read all messages (unlimited)
+            RunTestWithMetadataFields(
+                messages,
+                expected,
+                "\n", 
+                TTopicReaderSettings(Nothing(), false, false, {}, EMessagingFormat::Csv, 
+                    {ETopicMetadataField::Body}, ETransformBody::None, TDuration::Seconds(2)));
+        }
+
     private:
         void WriteTestData(NYdb::TDriver* driver, const TString& topicPath, const TVector<TString>& data) {
             auto writer = CreateSimpleWriter(*driver, topicPath, "source1", {}, TString("raw"));
@@ -169,6 +249,48 @@ namespace NYdb::NConsoleClient {
             TVector<TString> split;
             Split(output.Str(), delimiter, split);
 
+
+            for (size_t i = 0; i < Min(split.size(), expected.size()); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C(split[i], expected[i], LabeledOutput(i));
+            }
+            UNIT_ASSERT_VALUES_EQUAL(split.size(), expected.size());
+        }
+
+        void RunTestWithMetadataFields(
+            const TVector<TString>& dataToWrite,
+            const TVector<TString>& expected,
+            const TString& delimiter,
+            TTopicReaderSettings&& settings) {
+            Cerr << "=== Starting PQ server\n";
+            TPersQueueV1TestServer server;
+            Cerr << "=== Started PQ server\n";
+
+            SET_LOCALS;
+
+            const TString topicPath = server.GetTopic();
+            auto driver = server.Server->AnnoyingClient->GetDriver();
+            NPersQueue::TPersQueueClient persQueueClient(*driver);
+
+            WriteTestData(driver, topicPath, dataToWrite);
+            NTopic::TReadSessionSettings readSessionSettings = PrepareReadSessionSettings(topicPath);
+            IReadSession sess = CreateTopicReader(*driver, readSessionSettings);
+            TTopicReader reader(sess, settings);
+            reader.Init();
+
+            TStringStream output;
+            int status = reader.Run(output);
+            UNIT_ASSERT_EQUAL(status, 0);
+
+            // Close to finalize batch formats
+            reader.Close(output, TDuration::Seconds(5));
+
+            TVector<TString> split;
+            Split(output.Str(), delimiter, split);
+            
+            // Remove trailing empty string if present
+            while (!split.empty() && split.back().empty()) {
+                split.pop_back();
+            }
 
             for (size_t i = 0; i < Min(split.size(), expected.size()); ++i) {
                 UNIT_ASSERT_VALUES_EQUAL_C(split[i], expected[i], LabeledOutput(i));


### PR DESCRIPTION
- Add Csv and Tsv values to EMessagingFormat enum
- Add streaming output support for json-stream-concat, csv, tsv formats
- Update IsStreamingFormat() to include new streaming formats
- Implement PrintMessageAsJson, PrintCsvHeader, PrintMessageAsCsvRow methods
- Remove 500 message limit for streaming formats (use unlimited mode)
- Add unit tests for new formats

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add JSON, CSV formats to CLI topic read command. Lift limit on the number of lines.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
