### PR TITLE
Make timeout on reestablishing sessions in BSQueue longer on high load (#18258)

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -762,6 +762,7 @@ struct TEvBlobStorage {
         EvQuerySyncToken,
         EvSyncToken,
         EvReleaseSyncToken,
+        EvBSQueueResetConnection, // for test purposes
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,

--- a/ydb/core/blobstorage/backpressure/load_based_timeout.cpp
+++ b/ydb/core/blobstorage/backpressure/load_based_timeout.cpp
@@ -1,0 +1,32 @@
+#include "load_based_timeout.h"
+
+namespace NKikimr {
+
+TLoadBasedTimeoutManager::TLoadBasedTimeoutManager(TDuration minimumTimeout, TDuration timePerRequestInFlight)
+    : MinimumTimeout(minimumTimeout)
+    , TimePerRequestInFlight(timePerRequestInFlight)
+    , ActiveRequest(false)
+{}
+
+TDuration TLoadBasedTimeoutManager::GetTimeoutForNewRequest() {
+    // if there is active request we don't increment counter
+    ui32 delta = std::exchange(ActiveRequest, true) ? 0 : 1;
+    ui32 requestsInFlight = RequestsInFlight.fetch_add(delta) + delta;
+    return std::max(MinimumTimeout, TimePerRequestInFlight * requestsInFlight);
+}
+
+void TLoadBasedTimeoutManager::RequestCompleted() {
+    if (std::exchange(ActiveRequest, false)) {
+        ui32 prev = RequestsInFlight.fetch_sub(1);
+        Y_DEBUG_ABORT_UNLESS(prev > 0);
+    }
+}
+
+
+TLoadBasedTimeoutManager::~TLoadBasedTimeoutManager() {
+    RequestCompleted();
+}
+
+std::atomic<ui32> TLoadBasedTimeoutManager::RequestsInFlight = 0;
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/backpressure/load_based_timeout.h
+++ b/ydb/core/blobstorage/backpressure/load_based_timeout.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "defs.h"
+#include <algorithm>
+#include <atomic>
+
+namespace NKikimr {
+
+// We assume only one active request can be in flight
+class TLoadBasedTimeoutManager {
+public:
+    TLoadBasedTimeoutManager(TDuration minimumTimeout, TDuration timePerRequestInFlight);
+    ~TLoadBasedTimeoutManager();
+
+    TDuration GetTimeoutForNewRequest();
+    void RequestCompleted();
+
+private:
+    TDuration MinimumTimeout;
+    TDuration TimePerRequestInFlight;
+    static std::atomic<ui32> RequestsInFlight;
+    bool ActiveRequest;
+};
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/backpressure/queue_backpressure_client.h
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_client.h
@@ -46,6 +46,10 @@ namespace NKikimr {
         : public TEventLocal<TEvRequestProxyQueueState, TEvBlobStorage::EvRequestProxyQueueState>
     {};
 
+    struct TEvBSQueueResetConnection
+        : public TEventLocal<TEvBSQueueResetConnection, TEvBlobStorage::EvBSQueueResetConnection>
+    {};
+
     IActor* CreateVDiskBackpressureClient(const TIntrusivePtr<TBlobStorageGroupInfo>& info, TVDiskIdShort vdiskId,
         NKikimrBlobStorage::EVDiskQueueId queueId,const TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters,
         const TBSProxyContextPtr& bspctx, const NBackpressure::TQueueClientId& clientId, const TString& queueName,

--- a/ydb/core/blobstorage/backpressure/ya.make
+++ b/ydb/core/blobstorage/backpressure/ya.make
@@ -16,6 +16,7 @@ SRCS(
     defs.h
     event.cpp
     event.h
+    load_based_timeout.cpp
     queue.cpp
     queue.h
     queue_backpressure_client.cpp

--- a/ydb/core/blobstorage/ut_blobstorage/backpressure.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/backpressure.cpp
@@ -1,0 +1,66 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h>
+
+#define Ctest Cnull
+
+Y_UNIT_TEST_SUITE(NodeDisconnected) {
+    Y_UNIT_TEST(BsQueueRetries) {
+        ui32 nodeCount = 8;
+        TEnvironmentSetup env{{
+            .NodeCount = nodeCount,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block
+        }};
+        env.CreateBoxAndPool(1, 1);
+        env.Sim(TDuration::Seconds(60));
+
+        std::vector<ui32> groups = env.GetGroups();
+        // ui32 groupId = groups.front();
+        Y_ABORT_UNLESS(groups.size() == 1);
+        TIntrusivePtr<TBlobStorageGroupInfo> info = env.GetGroupInfo(groups.front());
+
+        const ui32 queuesCount = 800'000;
+        ui32 orderNumber = 1;
+
+        TVDiskID vdiskId = info->GetVDiskId(orderNumber);
+        ui32 badNodeId = info->GetActorId(orderNumber).NodeId();
+        ui32 goodNodeId = nodeCount + 1 - badNodeId;
+        Y_VERIFY(badNodeId != goodNodeId);
+
+        TActorId edge = env.Runtime->AllocateEdgeActor(goodNodeId);
+
+        std::vector<TActorId> queues;
+
+        for (ui32 i = 0; i < queuesCount; ++i) {
+            queues.push_back(env.CreateQueueActor(vdiskId, NKikimrBlobStorage::PutTabletLog, i, goodNodeId));
+        }
+
+        ui32 ctr = 0;
+
+        for (const TActorId actorId : queues) {
+            env.Runtime->Send(new IEventHandle(actorId, edge, new TEvBSQueueResetConnection), edge.NodeId());
+        }
+
+        env.Sim(TDuration::Seconds(60));
+
+        env.Runtime->StopNode(badNodeId);
+
+        env.Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->Type == TEvBlobStorage::TEvVCheckReadiness::EventType) {
+                ++ctr;
+            }
+            return true;
+        };
+
+        for (const TActorId actorId : queues) {
+            env.Runtime->Send(new IEventHandle(actorId, edge, new TEvBSQueueResetConnection), edge.NodeId());
+            // env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVStatus>(edge, false, TInstant::Max());
+        }
+
+        const ui32 simSeconds = 60;
+
+        env.Sim(TDuration::Seconds(simSeconds));
+        Cerr << "CTR " << ctr << Endl;
+
+        UNIT_ASSERT(ctr < queuesCount * simSeconds / 10);
+    }
+}

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -676,7 +676,7 @@ struct TEnvironmentSetup {
         return nullptr;
     }
 
-    TActorId CreateQueueActor(const TVDiskID& vdiskId, NKikimrBlobStorage::EVDiskQueueId queueId, ui32 index) {
+    TActorId CreateQueueActor(const TVDiskID& vdiskId, NKikimrBlobStorage::EVDiskQueueId queueId, ui32 index, ui32 nodeId = 0) {
         TBSProxyContextPtr bspctx = MakeIntrusive<TBSProxyContext>(MakeIntrusive<::NMonitoring::TDynamicCounters>());
         auto flowRecord = MakeIntrusive<NBackpressure::TFlowRecord>();
         auto groupInfo = GetGroupInfo(vdiskId.GroupID.GetRawId());
@@ -684,9 +684,9 @@ struct TEnvironmentSetup {
             MakeIntrusive<::NMonitoring::TDynamicCounters>(), bspctx,
             NBackpressure::TQueueClientId(NBackpressure::EQueueClientType::DSProxy, index), TStringBuilder()
             << "test# " << index, 0, false, TDuration::Seconds(60), flowRecord, NMonitoring::TCountableBase::EVisibility::Private));
-        const ui32 nodeId = Settings.ControllerNodeId;
-        const TActorId edge = Runtime->AllocateEdgeActor(nodeId, __FILE__, __LINE__);
-        const TActorId actorId = Runtime->Register(actor.release(), edge, {}, {}, nodeId);
+        const ui32 chosenNodeId = nodeId ? nodeId : Settings.ControllerNodeId;
+        const TActorId edge = Runtime->AllocateEdgeActor(chosenNodeId, __FILE__, __LINE__);
+        const TActorId actorId = Runtime->Register(actor.release(), edge, {}, {}, chosenNodeId);
         const TInstant deadline = Runtime->GetClock() + TDuration::Minutes(1);
         for (;;) {
             auto ev = WaitForEdgeActorEvent<TEvProxyQueueState>(edge, false, deadline);

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -16,6 +16,7 @@ ENDIF()
 SRCS(
     acceleration.cpp
     assimilation.cpp
+    backpressure.cpp
     block_race.cpp
     counting_events.cpp
     deadlines.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Increase timeout on BS_QUEUE reestablishing session when many actors try to reconnect simultaneously

### Changelog category <!-- remove all except one -->

* Improvement
