### PR TITLE
Enable direct read without consumer (LOGBROKER-9364)

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/impl/direct_reader.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/direct_reader.cpp
@@ -517,23 +517,23 @@ void TDirectReadSession::OnReadDone(NYdbGrpc::TGrpcStatus&& grpcStatus, size_t c
 
         if (!IsErrorMessage(*ServerMessage)) {
             if (ServerMessage->server_message_case() != TDirectReadServerMessage::kDirectReadResponse) {
-                LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "XXXXX subsession got message = " << ServerMessage->ShortDebugString());
+                LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "subsession got message = " << ServerMessage->ShortDebugString());
             } else {
                 const auto& data = ServerMessage->direct_read_response().partition_data();
                 const auto partitionSessionId = ServerMessage->direct_read_response().partition_session_id();
                 auto partitionSessionIt = PartitionSessions.find(partitionSessionId);
                 if (partitionSessionIt == PartitionSessions.end()) {
-                    LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "XXXXX subsession got message = DirectReadResponse partitionSessionId=" << partitionSessionId << " not found");
+                    LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "subsession got message = DirectReadResponse partitionSessionId=" << partitionSessionId << " not found");
                 }
                 if (data.batches_size() == 0) {
-                    LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "XXXXX subsession got message = DirectReadResponse EMPTY");
+                    LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "subsession got message = DirectReadResponse EMPTY");
                 } else {
                     const auto& firstBatch = data.batches(0);
                     const auto firstOffset = firstBatch.message_data(0).offset();
                     const auto& lastBatch = data.batches(data.batches_size() - 1);
                     const auto lastOffset = lastBatch.message_data(lastBatch.message_data_size() - 1).offset();
                     auto partitionId = partitionSessionIt == PartitionSessions.end() ? -1 : partitionSessionIt->second.PartitionId;
-                    LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "XXXXX subsession got message = DirectReadResponse"
+                    LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "subsession got message = DirectReadResponse"
                         << " partitionSessionId = " << partitionSessionId
                         << " partitionId = " << partitionId
                         << " directReadId = " << ServerMessage->direct_read_response().direct_read_id()
@@ -788,7 +788,7 @@ void TDirectReadSession::WriteToProcessorImpl(TDirectReadClientMessage&& req) {
     Y_ABORT_UNLESS(Lock.IsLocked());
 
     if (Processor) {
-        LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "XXXXX subsession send message = " << req.ShortDebugString());
+        LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "subsession send message = " << req.ShortDebugString());
         Processor->Write(std::move(req));
     }
 }

--- a/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
@@ -641,10 +641,6 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
     }
 
     Y_UNIT_TEST(ReadWithoutConsumerWithRestarts) {
-        if (EnableDirectRead) {
-            // TODO(qyryq) Enable the test when LOGBROKER-9364 is done.
-            return;
-        }
         TTopicSdkTestSetup setup(TEST_CASE_NAME);
         auto compressor = std::make_shared<TSyncExecutor>();
         auto decompressor = CreateThreadPoolManagedExecutor(1);
@@ -657,7 +653,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
             .MaxMemoryUsageBytes(1_MB)
             .DecompressionExecutor(decompressor)
             .AppendTopics(topic)
-            // .DirectRead(EnableDirectRead)
+            .DirectRead(EnableDirectRead)
             ;
 
         TWriteSessionSettings writeSettings;

--- a/ydb/public/sdk/cpp/src/client/topic/ut/direct_read_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/direct_read_ut.cpp
@@ -47,7 +47,7 @@ Y_UNIT_TEST_SUITE(DirectReadWithServer) {
         auto readerSettings = TReadSessionSettings()
             .ConsumerName(setup.GetConsumerName())
             .AppendTopics(setup.GetTopicPath())
-            // .DirectRead(true)
+            .DirectRead(true)
             ;
 
         TIntrusivePtr<TPartitionSession> partitionSession;
@@ -129,7 +129,7 @@ Y_UNIT_TEST_SUITE(DirectReadWithServer) {
         auto readerSettings = TReadSessionSettings()
             .ConsumerName(setup.GetConsumerName())
             .AppendTopics(setup.GetTopicPath())
-            // .DirectRead(true)
+            .DirectRead(true)
             ;
 
         TIntrusivePtr<TPartitionSession> partitionSession;
@@ -175,6 +175,7 @@ Y_UNIT_TEST_SUITE(DirectReadWithServer) {
 
         reader->Close();
     }
+
 } // Y_UNIT_TEST_SUITE_F(DirectReadWithServer)
 
 } // namespace NYdb::NTopic::NTests

--- a/ydb/services/persqueue_v1/actors/direct_read_actor.h
+++ b/ydb/services/persqueue_v1/actors/direct_read_actor.h
@@ -150,6 +150,7 @@ private:
     TString PeerName;
 
     bool InitDone;
+    bool ReadWithoutConsumer;
 
     TString Auth;
 


### PR DESCRIPTION
Server changes:
- direct_read_actor.cpp: Handle empty consumer using CLIENTID_WITHOUT_CONSUMER
- direct_read_actor.h: Add ReadWithoutConsumer member variable

Test changes:
- basic_usage_ut.cpp: Enable direct read for ReadWithoutConsumerWithRestarts test

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
