### PR TITLE
Restore test ydb/core/tx/replication/service/ut_s3_writer from death

### DIFF
--- a/ydb/core/tx/replication/service/s3_writer.cpp
+++ b/ydb/core/tx/replication/service/s3_writer.cpp
@@ -4,6 +4,7 @@
 #include "worker.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/tx/replication/ydb_proxy/topic_message.h>
 #include <ydb/core/wrappers/s3_storage_config.h>
 #include <ydb/core/wrappers/s3_wrapper.h>
 #include <ydb/library/actors/core/actor.h>
@@ -166,7 +167,7 @@ class TS3Writer
             return;
         }
 
-        const TString key = GetPartKey(ev->Get()->Records[0].Offset, WriterName);
+        const TString key = GetPartKey(ev->Get()->Records[0].GetOffset(), WriterName);
 
         auto request = Aws::S3::Model::PutObjectRequest()
             .WithKey(key);
@@ -174,7 +175,7 @@ class TS3Writer
         TStringBuilder buffer;
 
         for (auto& rec : ev->Get()->Records) {
-            buffer << rec.Data << '\n';
+            buffer << rec.GetData() << '\n';
         }
 
         RequestInFlight = std::make_unique<TS3Request>(std::move(request), std::move(buffer));

--- a/ydb/core/tx/replication/service/s3_writer_ut.cpp
+++ b/ydb/core/tx/replication/service/s3_writer_ut.cpp
@@ -7,17 +7,15 @@
 #include <ydb/core/wrappers/ut_helpers/s3_mock.h>
 #include <ydb/core/wrappers/s3_wrapper.h>
 #include <ydb/core/wrappers/s3_storage_config.h>
+#include <ydb/core/util/aws.h>
 
 #include <library/cpp/string_utils/base64/base64.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/string/printf.h>
 
-#include <contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/Aws.h>
-#include <contrib/libs/curl/include/curl/curl.h>
-
 struct TAwsApiGuard {
-    Aws::SDKOptions Options;
+    NKikimr::TAwsClientConfig Config;
 
     TAwsApiGuard() {
         InitAwsAPI();
@@ -28,13 +26,11 @@ struct TAwsApiGuard {
     }
 
     void InitAwsAPI() {
-        curl_global_init(CURL_GLOBAL_ALL);
-        Aws::InitAPI(Options);
+        NKikimr::InitAwsAPI(Config);
     }
 
     void ShutdownAwsAPI() {
-        Aws::ShutdownAPI(Options);
-        curl_global_cleanup();
+        NKikimr::ShutdownAwsAPI(Config);
     }
 };
 

--- a/ydb/core/tx/replication/service/s3_writer_ut.cpp
+++ b/ydb/core/tx/replication/service/s3_writer_ut.cpp
@@ -13,12 +13,38 @@
 
 #include <util/string/printf.h>
 
+#include <contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/Aws.h>
+#include <contrib/libs/curl/include/curl/curl.h>
+
+struct TAwsApiGuard {
+    Aws::SDKOptions Options;
+
+    TAwsApiGuard() {
+        InitAwsAPI();
+    }
+
+    ~TAwsApiGuard() {
+        ShutdownAwsAPI();
+    }
+
+    void InitAwsAPI() {
+        curl_global_init(CURL_GLOBAL_ALL);
+        Aws::InitAPI(Options);
+    }
+
+    void ShutdownAwsAPI() {
+        Aws::ShutdownAPI(Options);
+        curl_global_cleanup();
+    }
+};
+
 namespace NKikimr::NReplication::NService {
 
 Y_UNIT_TEST_SUITE(S3Writer) {
     using namespace NTestHelpers;
 
     Y_UNIT_TEST(WriteTableS3) {
+        TAwsApiGuard apiGuard;
         using namespace NWrappers::NTestHelpers;
         TPortManager portManager;
         const ui16 port = portManager.GetPort();

--- a/ydb/core/tx/replication/service/ut_s3_writer/ya.make
+++ b/ydb/core/tx/replication/service/ut_s3_writer/ya.make
@@ -5,6 +5,7 @@ FORK_SUBTESTS()
 SIZE(MEDIUM)
 
 PEERDIR(
+    ydb/core/wrappers/ut_helpers
     ydb/core/tx/replication/ut_helpers
     ydb/core/tx/replication/ydb_proxy
     library/cpp/string_utils/base64

--- a/ydb/core/tx/replication/service/ut_s3_writer/ya.make
+++ b/ydb/core/tx/replication/service/ut_s3_writer/ya.make
@@ -8,6 +8,7 @@ PEERDIR(
     ydb/core/wrappers/ut_helpers
     ydb/core/tx/replication/ut_helpers
     ydb/core/tx/replication/ydb_proxy
+    ydb/core/util
     library/cpp/string_utils/base64
     library/cpp/testing/unittest
 )

--- a/ydb/core/tx/replication/service/ya.make
+++ b/ydb/core/tx/replication/service/ya.make
@@ -31,7 +31,7 @@ GENERATE_ENUM_SERIALIZATION(worker.h)
 
 YQL_LAST_ABI_VERSION()
 
-IF (!OS_WINDOWS)
+IF (NOT OS_WINDOWS)
     SRCS(
         s3_writer.cpp
     )
@@ -46,7 +46,7 @@ RECURSE_FOR_TESTS(
     ut_worker
 )
 
-IF (!OS_WINDOWS)
+IF (NOT OS_WINDOWS)
     RECURSE_FOR_TESTS(
         ut_s3_writer
     )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I accidentally noticed that the expression `IF (!OS_WINDOWS)` in ya.make works absolutely not as we expect from it. As a result, we didn't have `ydb/core/tx/replication/service/s3_writer.cpp` and its test at all.
