### PR TITLE
EXT-1844 Improve memory consumption for Top/TopSort comp nodes

### DIFF
--- a/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
@@ -1477,6 +1477,90 @@ Y_UNIT_TEST_SUITE(KqpLimits) {
         }
     }
 
+    Y_UNIT_TEST(BigSortingLimitInParam) {
+        return; // TODO: remove
+        SetRandomSeed(42);
+
+        auto settings = TKikimrSettings()
+            .SetWithSampleTables(false)
+            .SetLogSettings(TTestLogSettings()
+                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_COMPILE_ACTOR, NLog::EPriority::PRI_DEBUG)
+                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_NODE, NLog::EPriority::PRI_DEBUG)
+                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_COMPILE_SERVICE, NLog::EPriority::PRI_DEBUG))
+            .SetLogStream(&Cerr);
+        // This line will fix the test: // TODO: remove
+        //settings.AppConfig.MutableTableServiceConfig()->SetBlockChannelsMode(NKikimrConfig::TTableServiceConfig::BLOCK_CHANNELS_SCALAR);
+        TKikimrRunner kikimr(settings);
+
+        auto db = kikimr.GetQueryClient();
+        auto tableClient = kikimr.GetTableClient();
+        auto sessionResult = tableClient.GetSession().GetValueSync();
+        UNIT_ASSERT_C(sessionResult.IsSuccess(), sessionResult.GetIssues().ToString());
+        auto session = sessionResult.GetSession();
+        auto res = session.ExecuteSchemeQuery(R"(
+            --!syntax_v1
+            CREATE TABLE TableWithIndex (
+                Id Utf8,
+                ForeignId Utf8,
+                Name Utf8,
+                Description Utf8,
+                PRIMARY KEY (Id),
+                INDEX Index GLOBAL ON (ForeignId, Name)
+            );
+        )").GetValueSync();
+        UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+
+        for (const char* additionalColumn : {"", ", Description"}) {
+            NYdb::NQuery::TExecuteQuerySettings querySettings;
+            querySettings.StatsMode(NYdb::NQuery::EStatsMode::Full);
+
+            auto result = db.ExecuteQuery(
+                Sprintf(R"(
+                    DECLARE $ForeignId AS Utf8;
+                    DECLARE $Name     AS Utf8;
+                    DECLARE $Id       AS Utf8;
+                    DECLARE $Limit    AS Uint64;
+
+                    SELECT
+                        Id,
+                        ForeignId,
+                        Name
+                        %s
+                    FROM
+                        TableWithIndex
+                    VIEW
+                        Index
+                    WHERE
+                        ForeignId = $ForeignId AND ((Name = $Name AND Id > $Id) OR Name > $Name)
+                    ORDER BY
+                        ForeignId, Name, Id
+                    LIMIT
+                        $Limit
+                )", additionalColumn),
+            NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+            NYdb::TParamsBuilder()
+                .AddParam("$ForeignId")
+                    .Utf8("")
+                    .Build()
+                .AddParam("$Name")
+                    .Utf8("")
+                    .Build()
+                .AddParam("$Id")
+                    .Utf8("")
+                    .Build()
+                .AddParam("$Limit")
+                    .Uint64(ui32(-1)) // big limit, but YDB does not fail
+                    .Build()
+                .Build(),
+            querySettings).ExtractValueSync();
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, "AdditionalColumn parameter: \"" << additionalColumn << "\". Issues:\n" << result.GetIssues().ToString());
+
+            const auto resultSet = result.GetResultSet(0);
+            UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 0);
+        }
+    }
+
     Y_UNIT_TEST_TWIN(QSReplySize, useSink) {
         auto app = NKikimrConfig::TAppConfig();
         app.MutableTableServiceConfig()->SetEnableOltpSink(useSink);

--- a/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
@@ -1478,18 +1478,10 @@ Y_UNIT_TEST_SUITE(KqpLimits) {
     }
 
     Y_UNIT_TEST(BigSortingLimitInParam) {
-        return; // TODO: remove
         SetRandomSeed(42);
 
         auto settings = TKikimrSettings()
-            .SetWithSampleTables(false)
-            .SetLogSettings(TTestLogSettings()
-                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_COMPILE_ACTOR, NLog::EPriority::PRI_DEBUG)
-                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_NODE, NLog::EPriority::PRI_DEBUG)
-                .AddLogPriority(NKikimrServices::EServiceKikimr::KQP_COMPILE_SERVICE, NLog::EPriority::PRI_DEBUG))
-            .SetLogStream(&Cerr);
-        // This line will fix the test: // TODO: remove
-        //settings.AppConfig.MutableTableServiceConfig()->SetBlockChannelsMode(NKikimrConfig::TTableServiceConfig::BLOCK_CHANNELS_SCALAR);
+            .SetWithSampleTables(false);
         TKikimrRunner kikimr(settings);
 
         auto db = kikimr.GetQueryClient();

--- a/yql/essentials/minikql/comp_nodes/mkql_wide_top_sort.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_wide_top_sort.cpp
@@ -12,6 +12,7 @@
 
 #include <yql/essentials/utils/sort.h>
 
+#include <deque>
 
 namespace NKikimr {
 namespace NMiniKQL {
@@ -85,6 +86,7 @@ using NYql::TChunkedBuffer;
 using TAsyncWriteOperation = std::optional<NThreading::TFuture<ISpiller::TKey>>;
 using TAsyncReadOperation = std::optional<NThreading::TFuture<std::optional<TChunkedBuffer>>>;
 using TStorage = std::vector<NUdf::TUnboxedValue, TMKQLAllocator<NUdf::TUnboxedValue, EMemorySubPool::Temporary>>;
+using TStorageDeque = std::deque<TStorage, TMKQLAllocator<TStorage, EMemorySubPool::Temporary>>;
 
 struct TSpilledData {
     using TPtr = TSpilledData*;
@@ -209,10 +211,30 @@ private:
         return std::max<size_t>(Count << 2ULL, 1ULL << 8ULL);
     }
 
+    static constexpr size_t GetStorageBlockSize() {
+        return 1ULL << 10ULL;
+    }
+
     void ResetFields() {
+        MaybeGrowStorage();
         auto ptr = Tongue = Free.back();
         std::for_each(Indexes.cbegin(), Indexes.cend(), [&](ui32 index) { Fields[index] = static_cast<NUdf::TUnboxedValue*>(ptr++); });
     }
+
+    void MaybeGrowStorage() {
+        if (Free.empty()) {
+            const size_t fieldsCount = Indexes.size();
+            const size_t blockSize = std::min(GetStorageBlockSize(), GetStorageSize());
+            TStorage& newStorageBlock = Storage.emplace_back(blockSize * fieldsCount);
+            auto* ptr = newStorageBlock.data();
+            Free.reserve(Free.size() + blockSize);
+            for (size_t i = 0; i < blockSize; ++i) {
+                Free.emplace_back(ptr);
+                ptr += fieldsCount;
+            }
+        }
+    }
+
 public:
     TState(TMemoryUsageInfo* memInfo, ui64 count, const bool* directons, size_t keyWidth, const TCompareFunc& compare, const std::vector<ui32>& indexes)
         : TBase(memInfo)
@@ -222,16 +244,8 @@ public:
         , LessFunc(std::bind(std::less<int>(), std::bind(compare, Directions.data(), std::placeholders::_1, std::placeholders::_2), 0))
         , Fields(Indexes.size(), nullptr)
     {
-        Storage.resize(GetStorageSize() * Indexes.size());
-        Free.resize(GetStorageSize(), nullptr);
         if (Count) {
-            Full.reserve(GetStorageSize());
-            auto ptr = Storage.data();
-            std::generate(Free.begin(), Free.end(), [&ptr, this]() {
-                const auto p = ptr;
-                ptr += Indexes.size();
-                return p;
-            });
+            Full.reserve(std::min(GetStorageBlockSize(), GetStorageSize()));
             ResetFields();
         } else
             InputStatus = EFetchResult::Finish;
@@ -300,7 +314,7 @@ private:
     const std::vector<ui32> Indexes;
     const std::vector<bool> Directions;
     const std::function<bool(const NUdf::TUnboxedValuePod*, const NUdf::TUnboxedValuePod*)> LessFunc;
-    TStorage Storage;
+    TStorageDeque Storage;
     TPointers Free, Full;
     TFields Fields;
 };

--- a/yql/essentials/minikql/comp_nodes/ut/mkql_wide_top_sort_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_wide_top_sort_ut.cpp
@@ -259,6 +259,43 @@ Y_UNIT_TEST_SUITE(TMiniKQLWideTopTest) {
         UNIT_ASSERT(!iterator.Next(item));
     }
 
+    Y_UNIT_TEST_LLVM(TopWithLargeCount) {
+        TSetup<LLVM> setup;
+        setup.Alloc.SetLimit(1_MB);
+        TProgramBuilder& pb = *setup.PgmBuilder;
+
+        const auto dataType = pb.NewDataType(NUdf::TDataType<const char*>::Id);
+        const auto tupleType = pb.NewTupleType({dataType, dataType});
+
+        const auto keyOne = pb.NewDataLiteral<NUdf::EDataSlot::String>("key one");
+        const auto keyTwo = pb.NewDataLiteral<NUdf::EDataSlot::String>("key two");
+
+        const auto value1 = pb.NewDataLiteral<NUdf::EDataSlot::String>("value 1");
+        const auto value2 = pb.NewDataLiteral<NUdf::EDataSlot::String>("value 2");
+
+        const auto data1 = pb.NewTuple(tupleType, {keyOne, value1});
+        const auto data2 = pb.NewTuple(tupleType, {keyTwo, value2});
+
+        const auto list = pb.NewList(tupleType, {data1, data2});
+
+        const auto pgmReturn = pb.Collect(pb.NarrowMap(pb.WideTop(pb.ExpandMap(pb.ToFlow(list),
+                                                                            [&](TRuntimeNode item) -> TRuntimeNode::TList { return {pb.Nth(item, 0U), pb.Nth(item, 1U)}; }),
+                                                                pb.NewDataLiteral<ui64>(4000000000ULL), {{0U, pb.NewDataLiteral<bool>(true)}}),
+                                                    [&](TRuntimeNode::TList items) -> TRuntimeNode { return pb.NewTuple(tupleType, items); }));
+
+        const auto graph = setup.BuildGraph(pgmReturn);
+        const auto iterator = graph->GetValue().GetListIterator();
+        NUdf::TUnboxedValue item;
+        UNIT_ASSERT(iterator.Next(item));
+        UNBOXED_VALUE_STR_EQUAL(item.GetElement(0), "key two");
+        UNBOXED_VALUE_STR_EQUAL(item.GetElement(1), "value 2");
+        UNIT_ASSERT(iterator.Next(item));
+        UNBOXED_VALUE_STR_EQUAL(item.GetElement(0), "key one");
+        UNBOXED_VALUE_STR_EQUAL(item.GetElement(1), "value 1");
+        UNIT_ASSERT(!iterator.Next(item));
+        UNIT_ASSERT(!iterator.Next(item));
+    }
+
     Y_UNIT_TEST_LLVM(TopSortByFirstSecondAscDesc) {
         TSetup<LLVM> setup;
         TProgramBuilder& pb = *setup.PgmBuilder;
@@ -561,6 +598,43 @@ Y_UNIT_TEST_SUITE(TMiniKQLWideTopTest) {
         UNIT_ASSERT(!iterator.Next(item));
         UNIT_ASSERT(!iterator.Next(item));
     }
+
+    Y_UNIT_TEST_LLVM(TopSortLargeCount) {
+        TSetup<LLVM> setup;
+        setup.Alloc.SetLimit(1_MB);
+        TProgramBuilder& pb = *setup.PgmBuilder;
+
+        const auto dataType = pb.NewDataType(NUdf::TDataType<const char*>::Id);
+        const auto tupleType = pb.NewTupleType({dataType, dataType});
+
+        const auto keyOne = pb.NewDataLiteral<NUdf::EDataSlot::String>("key one");
+        const auto keyTwo = pb.NewDataLiteral<NUdf::EDataSlot::String>("key two");
+
+        const auto value1 = pb.NewDataLiteral<NUdf::EDataSlot::String>("value 1");
+        const auto value2 = pb.NewDataLiteral<NUdf::EDataSlot::String>("value 2");
+
+        const auto data1 = pb.NewTuple(tupleType, {keyOne, value1});
+        const auto data2 = pb.NewTuple(tupleType, {keyTwo, value2});
+
+        const auto list = pb.NewList(tupleType, {data1, data2});
+
+        const auto pgmReturn = pb.Collect(pb.NarrowMap(pb.WideTopSort(pb.ExpandMap(pb.ToFlow(list),
+                                                                                [&](TRuntimeNode item) -> TRuntimeNode::TList { return {pb.Nth(item, 0U), pb.Nth(item, 1U)}; }),
+                                                                    pb.NewDataLiteral<ui64>(4000000000ULL), {{0U, pb.NewDataLiteral<bool>(true)}, {1U, pb.NewDataLiteral<bool>(false)}}),
+                                                    [&](TRuntimeNode::TList items) -> TRuntimeNode { return pb.NewTuple(tupleType, items); }));
+
+        const auto graph = setup.BuildGraph(pgmReturn);
+        const auto iterator = graph->GetValue().GetListIterator();
+        NUdf::TUnboxedValue item;
+        UNIT_ASSERT(iterator.Next(item));
+        UNBOXED_VALUE_STR_EQUAL(item.GetElement(0), "key one");
+        UNBOXED_VALUE_STR_EQUAL(item.GetElement(1), "value 1");
+        UNIT_ASSERT(iterator.Next(item));
+        UNBOXED_VALUE_STR_EQUAL(item.GetElement(0), "key two");
+        UNBOXED_VALUE_STR_EQUAL(item.GetElement(1), "value 2");
+        UNIT_ASSERT(!iterator.Next(item));
+        UNIT_ASSERT(!iterator.Next(item));
+    }
 }
 #endif
 
@@ -648,4 +722,3 @@ Y_UNIT_TEST_SUITE(TMiniKQLWideSortTest) {
 
 }
 }
-


### PR DESCRIPTION
Improve memory consumption for the cases when the result is much less than max count parameter. This improvement fixes the bug: https://github.com/ydb-platform/ydb/issues/31905

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/1571 commit_hash:8be1e47fedf238d3b1d401dfb7b6d0eebae36313

(cherry picked from commit 441c4b5665c697e12e1316da1ea63fd522746bb0)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
