### PR TITLE
tests: mark schemeshard/ut_login_large as manual

### DIFF
--- a/ydb/core/tx/schemeshard/ut_login_large/ya.make
+++ b/ydb/core/tx/schemeshard/ut_login_large/ya.make
@@ -5,6 +5,8 @@ FORK_SUBTESTS()
 SIZE(LARGE)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
 
+TAG(ya:manual)
+
 PEERDIR(
     ydb/core/testlib/default
     ydb/core/tx


### PR DESCRIPTION
ut_login_large is a dev-time performance check disguised as a unit test. Adding ya:manual tag to exclude it from regular runs.