### PR TITLE
dq/kqp: propagate watermark settings from sources

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -1005,6 +1005,9 @@ void TKqpTasksGraph::FillChannelDesc(NDqProto::TChannel& channelDesc, const TCha
     channelDesc.SetEnableSpilling(enableSpilling);
     channelDesc.SetCheckpointingMode(channel.CheckpointingMode);
     channelDesc.SetWatermarksMode(channel.WatermarksMode);
+    if (channel.WatermarksIdleTimeoutUs) {
+        channelDesc.SetWatermarksIdleTimeoutUs(*channel.WatermarksIdleTimeoutUs);
+    }
 
     const auto& resultChannelProxies = GetMeta().ResultChannelProxies;
 
@@ -1303,6 +1306,9 @@ void TKqpTasksGraph::FillInputDesc(NYql::NDqProto::TTaskInput& inputDesc, const 
         case NYql::NDq::TTaskInputType::Source:
             inputDesc.MutableSource()->SetType(input.SourceType);
             inputDesc.MutableSource()->SetWatermarksMode(input.WatermarksMode);
+            if (input.WatermarksIdleTimeoutUs) {
+                inputDesc.MutableSource()->SetWatermarksIdleTimeoutUs(*input.WatermarksIdleTimeoutUs);
+            }
             if (Y_LIKELY(input.Meta.SourceSettings)) {
                 enableMetering = true;
                 YQL_ENSURE(input.Meta.SourceSettings->HasTable());
@@ -1558,6 +1564,9 @@ void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeRes
             channel.InMemory = protoInfo.GetInMemory();
             channel.CheckpointingMode = protoInfo.GetCheckpointingMode();
             channel.WatermarksMode = protoInfo.GetWatermarksMode();
+            if (protoInfo.HasWatermarksIdleTimeoutUs()) {
+                channel.WatermarksIdleTimeoutUs = protoInfo.GetWatermarksIdleTimeoutUs();
+            }
         }
 
         return channel;
@@ -1659,6 +1668,9 @@ void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeRes
                     const auto& sourceInfo = inputInfo.GetSource();
                     newInput.SourceType = sourceInfo.GetType();
                     newInput.WatermarksMode = sourceInfo.GetWatermarksMode();
+                    if (sourceInfo.HasWatermarksIdleTimeoutUs()) {
+                        newInput.WatermarksIdleTimeoutUs = sourceInfo.GetWatermarksIdleTimeoutUs();
+                    }
                     if (sourceInfo.HasSettings()) {
                         const auto& settings = sourceInfo.GetSettings();
                         if (settings.Is<NKikimrTxDataShard::TKqpReadRangesSourceSettings>()) {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -2375,6 +2375,13 @@ void TKqpTasksGraph::BuildReadTasksFromSource(TStageInfo& stageInfo, const TVect
             input.ConnectionInfo = NYql::NDq::TSourceInput{};
             input.SourceSettings = externalSource.GetSettings();
             input.SourceType = externalSource.GetType();
+            if (externalSource.HasWatermarksSettings()) {
+                const auto& watermarksSettings = externalSource.GetWatermarksSettings();
+                input.WatermarksMode = NYql::NDqProto::EWatermarksMode::WATERMARKS_MODE_DEFAULT;
+                if (watermarksSettings.HasIdleTimeoutUs()) {
+                    input.WatermarksIdleTimeoutUs = watermarksSettings.GetIdleTimeoutUs();
+                }
+            }
         }
 
         FillReadTaskFromSource(task, sourceName, structuredToken, resourceSnapshot, nodeOffset++);

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -1237,9 +1237,6 @@ TMaybe<TKqlQueryList> BuildKqlQuery(TKiDataQueryBlocks dataQueryBlocks, const TK
                             if (kqpCtx->Config->GetEnableWatermarks()) {
                                 wrSettings = {
                                     .WatermarksMode = "default",
-                                    .WatermarksGranularityMs = 1000,
-                                    .WatermarksLateArrivalDelayMs = 5000,
-                                    .WatermarksEnableIdlePartitions = false,
                                 };
                             }
                             auto newRead = dqIntegration->WrapRead(input.Cast().Ptr(), ctx, wrSettings);

--- a/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
@@ -143,9 +143,7 @@ protected:
                 input.Cast(),
                 false,
                 TDuration::MilliSeconds(TDqSettings::TDefault::WatermarksLateArrivalDelayMs),
-                KqpCtx.Config->GetEnableWatermarks(),
-                false
-            );
+                KqpCtx.Config->GetEnableWatermarks());
         } else {
             NDq::TSpillingSettings spillingSettings(KqpCtx.Config->GetEnabledSpillingNodes());
             output = DqRewriteAggregate(node, ctx, TypesCtx, false, KqpCtx.Config->HasOptEnableOlapPushdown() || KqpCtx.Config->HasOptUseFinalizeByKey(), KqpCtx.Config->HasOptUseFinalizeByKey(), spillingSettings.IsAggregationSpillingEnabled());

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1509,6 +1509,13 @@ private:
             google::protobuf::Any& settings = *externalSource.MutableSettings();
             TString& sourceType = *externalSource.MutableType();
             dqIntegration->FillSourceSettings(*source, settings, sourceType, maxTasksPerStage, ctx);
+            TMaybe<IDqIntegration::TSourceWatermarksSettings> watermarksSettings = dqIntegration->ExtractSourceWatermarksSettings(*source, settings, sourceType);
+            if (watermarksSettings) {
+                auto& protoWatermarksSettings = *externalSource.MutableWatermarksSettings();
+                if (watermarksSettings->IdleTimeoutUs) {
+                    protoWatermarksSettings.SetIdleTimeoutUs(*watermarksSettings->IdleTimeoutUs);
+                }
+            }
             YQL_ENSURE(!settings.type_url().empty(), "Data source provider \"" << dataSourceCategory << "\" didn't fill dq source settings for its dq source node");
             YQL_ENSURE(sourceType, "Data source provider \"" << dataSourceCategory << "\" didn't fill dq source settings type for its dq source node");
         } else {

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -456,6 +456,11 @@ message TKqpExternalSource {
 
     string SourceName = 5;
     string AuthInfo = 6;
+
+    message TWatermarksSettings {
+        optional uint64 IdleTimeoutUs = 1;
+    };
+    optional TWatermarksSettings WatermarksSettings = 8;
 }
 
 message TKqpSource {

--- a/ydb/library/yql/dq/opt/dq_opt_hopping.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_hopping.cpp
@@ -73,9 +73,7 @@ TMaybeNode<TExprBase> RewriteAsHoppingWindowFullOutput(
     const TDqConnection& input,
     bool analyticsMode,
     TDuration lateArrivalDelay,
-    bool defaultWatermarksMode,
-    bool syncActor) {
-    Y_UNUSED(syncActor);
+    bool defaultWatermarksMode) {
     const auto aggregate = node.Cast<TCoAggregate>();
     const auto pos = aggregate.Pos();
 
@@ -236,10 +234,9 @@ TMaybeNode<TExprBase> RewriteAsHoppingWindow(
     const TDqConnection& input,
     bool analyticsMode,
     TDuration lateArrivalDelay,
-    bool defaultWatermarksMode,
-    bool syncActor)
+    bool defaultWatermarksMode)
 {
-    auto result = RewriteAsHoppingWindowFullOutput(node, ctx, input, analyticsMode, lateArrivalDelay, defaultWatermarksMode, syncActor);
+    auto result = RewriteAsHoppingWindowFullOutput(node, ctx, input, analyticsMode, lateArrivalDelay, defaultWatermarksMode);
     if (!result) {
         return result;
     }

--- a/ydb/library/yql/dq/opt/dq_opt_hopping.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_hopping.cpp
@@ -67,32 +67,6 @@ TExprNode::TPtr WrapToShuffle(
         .Ptr();
 }
 
-TMaybe<bool> BuildWatermarkMode(
-    const TCoAggregate& aggregate,
-    const TCoHoppingTraits& hoppingTraits,
-    TExprContext& ctx,
-    bool analyticsMode,
-    bool defaultWatermarksMode,
-    bool syncActor)
-{
-    const auto hoppingVersion = hoppingTraits.Version().Cast<TCoAtom>().StringValue();
-    const bool enableWatermarks = !analyticsMode && defaultWatermarksMode;
-
-    if (enableWatermarks && syncActor) {
-        ctx.AddError(TIssue(ctx.GetPosition(aggregate.Pos()), "Watermarks should be used only with async compute actor"));
-        return Nothing();
-    }
-
-    if (hoppingVersion == "v1" && enableWatermarks) {
-        ctx.AddError(TIssue(
-            ctx.GetPosition(aggregate.Pos()),
-            "HOP requires watermarks to be disabled. Use HoppingWindow instead."));
-        return Nothing();
-    }
-
-    return enableWatermarks;
-}
-
 TMaybeNode<TExprBase> RewriteAsHoppingWindowFullOutput(
     const TExprBase node,
     TExprContext& ctx,
@@ -101,6 +75,7 @@ TMaybeNode<TExprBase> RewriteAsHoppingWindowFullOutput(
     TDuration lateArrivalDelay,
     bool defaultWatermarksMode,
     bool syncActor) {
+    Y_UNUSED(syncActor);
     const auto aggregate = node.Cast<TCoAggregate>();
     const auto pos = aggregate.Pos();
 
@@ -139,10 +114,7 @@ TMaybeNode<TExprBase> RewriteAsHoppingWindowFullOutput(
     const auto loadLambda = BuildLoadHopLambda(aggregate, ctx);
     const auto mergeLambda = BuildMergeHopLambda(aggregate, ctx);
     const auto finishLambda = BuildFinishHopLambda(aggregate, keysDescription.GetActualGroupKeys(), hopTraits.Column, ctx);
-    const auto enableWatermarks = BuildWatermarkMode(aggregate, hopTraits.Traits, ctx, analyticsMode, defaultWatermarksMode, syncActor);
-    if (!enableWatermarks) {
-        return nullptr;
-    }
+    const bool enableWatermarks = hopTraits.Traits.Version().Cast<TCoAtom>().StringValue() == "v2" && !analyticsMode && defaultWatermarksMode;
 
     const auto streamArg = Build<TCoArgument>(ctx, pos).Name("stream").Done();
     auto multiHoppingCoreBuilder = Build<TCoMultiHoppingCore>(ctx, pos)
@@ -157,10 +129,10 @@ TMaybeNode<TExprBase> RewriteAsHoppingWindowFullOutput(
         .FinishHandler(finishLambda)
         .SaveHandler(saveLambda)
         .LoadHandler(loadLambda)
-        .WatermarkMode<TCoAtom>().Build(ToString(*enableWatermarks))
+        .WatermarkMode<TCoAtom>().Build(ToString(enableWatermarks))
         .HoppingColumn<TCoAtom>().Build(hopTraits.Column);
 
-    if (*enableWatermarks) {
+    if (enableWatermarks) {
         const auto hop = hopTraits.Hop;
         const auto delay = lateArrivalDelay ? (lateArrivalDelay.MicroSeconds() + hop - 1) / hop * hop : hop;
         multiHoppingCoreBuilder.Delay<TCoInterval>()

--- a/ydb/library/yql/dq/opt/dq_opt_hopping.h
+++ b/ydb/library/yql/dq/opt/dq_opt_hopping.h
@@ -12,7 +12,6 @@ NNodes::TMaybeNode<NNodes::TExprBase> RewriteAsHoppingWindow(
     const NNodes::TDqConnection& input,
     bool analyticsHopping,
     TDuration lateArrivalDelay,
-    bool defaultWatermarksMode,
-    bool syncActor);
+    bool defaultWatermarksMode);
 
 } // namespace NYql::NDq::NHopping

--- a/ydb/library/yql/dq/tasks/dq_tasks_graph.h
+++ b/ydb/library/yql/dq/tasks/dq_tasks_graph.h
@@ -472,6 +472,7 @@ public:
                 for (auto& input : task.Inputs) {
                     input.WatermarksMode = NDqProto::WATERMARKS_MODE_DISABLED;
                     input.WatermarksIdleTimeoutUs.Clear();
+                    /* note: GetChannel().WatermarksMode default-initialized to DISABLED */
                 }
             }
 

--- a/ydb/library/yql/dq/tasks/dq_tasks_graph.h
+++ b/ydb/library/yql/dq/tasks/dq_tasks_graph.h
@@ -387,7 +387,7 @@ public:
         return sourceType == "PqSource"; // Now it is the only infinite source type. Others are finite.
     }
 
-    void BuildCheckpointingAndWatermarksMode(bool enableCheckpoints, bool enableWatermarks, TMaybe<ui64> watermarksIdleTimeoutUs = Nothing()) {
+    void BuildCheckpointingAndWatermarksMode(bool enableCheckpoints, bool enableWatermarks) {
         if (!enableCheckpoints && !enableWatermarks) {
             return;
         }
@@ -453,10 +453,9 @@ public:
             if (enableWatermarks) {
                 for (auto& input : task.Inputs) {
                     if (input.SourceType) {
-                        if (IsInfiniteSourceType(input.SourceType)) {
+                        if (input.WatermarksMode == NDqProto::WATERMARKS_MODE_DEFAULT) {
+                            Y_DEBUG_ABORT_UNLESS(IsInfiniteSourceType(input.SourceType));
                             watermarksMode = NDqProto::WATERMARKS_MODE_DEFAULT;
-                            input.WatermarksIdleTimeoutUs = watermarksIdleTimeoutUs; // TODO extract from source settings
-                            input.WatermarksMode = NDqProto::WATERMARKS_MODE_DEFAULT;
                         }
                     } else {
                         for (ui64 channelId : input.Channels) {
@@ -468,6 +467,11 @@ public:
                         }
                     }
                     task.WatermarksIdleTimeoutUs = Max(task.WatermarksIdleTimeoutUs, input.WatermarksIdleTimeoutUs);
+                }
+            } else {
+                for (auto& input : task.Inputs) {
+                    input.WatermarksMode = NDqProto::WATERMARKS_MODE_DISABLED;
+                    input.WatermarksIdleTimeoutUs.Clear();
                 }
             }
 

--- a/ydb/library/yql/providers/dq/opt/logical_optimize.cpp
+++ b/ydb/library/yql/providers/dq/opt/logical_optimize.cpp
@@ -189,8 +189,7 @@ protected:
                     .Get()
                     .GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs));
                 bool defaultWatermarksMode = Config->WatermarksMode.Get() == "default";
-                bool syncActor = Config->ComputeActorType.Get() != "async";
-                return NHopping::RewriteAsHoppingWindow(node, ctx, input.Cast(), analyticsHopping, lateArrivalDelay, defaultWatermarksMode, syncActor);
+                return NHopping::RewriteAsHoppingWindow(node, ctx, input.Cast(), analyticsHopping, lateArrivalDelay, defaultWatermarksMode);
             } else {
                 NDq::TSpillingSettings spillingSettings(Config->GetEnabledSpillingNodes());
                 return DqRewriteAggregate(node, ctx, TypesCtx, true, Config->UseAggPhases.Get().GetOrElse(false), Config->UseFinalizeByKey.Get().GetOrElse(false), spillingSettings.IsAggregationSpillingEnabled());

--- a/ydb/library/yql/providers/dq/planner/execution_planner.h
+++ b/ydb/library/yql/providers/dq/planner/execution_planner.h
@@ -74,8 +74,6 @@ namespace NYql::NDqs {
         void FillOutputDesc(NDqProto::TTaskOutput& outputDesc, const TTaskOutput& output, bool enableSpilling);
 
         void GatherPhyMapping(THashMap<std::tuple<TString, TString>, TString>& clusters, THashMap<std::tuple<TString, TString, TString>, TString>& tables);
-        void BuildCheckpointingAndWatermarksMode(bool enableCheckpoints, bool enableWatermarks);
-        bool IsEgressTask(const TDqsTasksGraph::TTaskType& task) const;
 
     private:
         const TDqSettings::TPtr Settings;

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -102,12 +102,6 @@ public:
             TString serializedWatermarkExpr;
             if (const auto maybeWatermark = pqReadTopic.Watermark()) {
                 const auto watermark = maybeWatermark.Cast();
-                const auto enableWatermarks = wrSettings.WatermarksMode.GetOrElse("") == "default";
-
-                if (!enableWatermarks) {
-                    ctx.AddError(TIssue(ctx.GetPosition(pqReadTopic.Pos()), R"(Enable watermarks using "PRAGMA dq.WatermarksMode="default";")"));
-                    return {};
-                }
 
                 TStringBuilder err;
                 NYql::NConnector::NApi::TExpression watermarkExprProto;
@@ -185,6 +179,24 @@ public:
         case NYql::TPqClusterConfig::CT_DATA_STREAMS:
             return NPq::NProto::DataStreams;
         }
+    }
+
+    TMaybe<TSourceWatermarksSettings> ExtractSourceWatermarksSettings(const TExprNode& /*node*/, const ::google::protobuf::Any& protoSettings, const TString& sourceType) override {
+        YQL_ENSURE(sourceType == "PqSource");
+        YQL_ENSURE(protoSettings.Is<NPq::NProto::TDqPqTopicSource>());
+        NYql::NPq::NProto::TDqPqTopicSource srcDesc;
+        if (!protoSettings.UnpackTo(&srcDesc)) {
+            return Nothing();
+        }
+        if (!srcDesc.HasWatermarks()) {
+            return Nothing();
+        }
+        TSourceWatermarksSettings watermarksSettings;
+        const auto& watermarks = srcDesc.GetWatermarks();
+        if (watermarks.HasIdleTimeoutUs()) {
+            watermarksSettings.IdleTimeoutUs = watermarks.GetIdleTimeoutUs();
+        }
+        return watermarksSettings;
     }
 
     void FillSourceSettings(const TExprNode& node, ::google::protobuf::Any& protoSettings, TString& sourceType, size_t, TExprContext& ctx) override {
@@ -401,6 +413,49 @@ public:
         return Nothing();
     }
 
+private:
+    // Extract watermark delay from fixed-format expression:
+    // WITH ( ...
+    //   WATERMARK = (SystemMetadata('write_time') - Interval('PT5S'))
+    // Only used (and useful) for non-shared-reading pq source
+    // (in this case, flexible watermark expression is not implented)
+    static TMaybe<ui64> ExtractWatermarkDelay(const TCoLambda& watermark) {
+        if (watermark.Args().Size() != 1) {
+            return Nothing();
+        }
+        const auto arg = watermark.Args().Arg(0);
+        const auto body = watermark.Body();
+        const auto maybeSub = body.Maybe<TCoSub>();
+        if (!maybeSub) {
+            return Nothing();
+        }
+        const auto sub = maybeSub.Cast();
+        {
+            const auto maybeMember = sub.Left().Maybe<TCoMember>();
+            if (!maybeMember) {
+                return Nothing();
+            }
+            const auto member = maybeMember.Cast();
+            if (const auto& maybeArg = member.Struct().Maybe<TCoArgument>()) {
+                if (maybeArg.Cast().Name() != arg.Name()) {
+                    return Nothing();
+                }
+            }
+            if (!IsIn({"_yql_sys_tsp_write_time", "_yql_sys_write_time"}, member.Name())) {
+                return Nothing();
+            }
+        }
+        {
+            auto maybeInterval = sub.Right().Maybe<TCoInterval>();
+            if (!maybeInterval) {
+                return Nothing();
+            }
+            auto interval = maybeInterval.Cast();
+            return TryFromString<ui64>(interval.Literal().Value());
+        }
+    }
+
+public:
     TExprNode::TPtr BuildTopicReadSettings(
         const TPqReadTopic& pqReadTopic,
         TExprContext& ctx,
@@ -410,6 +465,7 @@ public:
         const auto& cluster = pqReadTopic.DataSource().Cluster().StringValue();
         const auto format = pqReadTopic.Format().Ref().Content();
         const auto& settings = pqReadTopic.Settings();
+        const auto maybeWatermark = pqReadTopic.Watermark();
 
         TVector<TCoNameValueTuple> props;
 
@@ -420,7 +476,8 @@ public:
         auto clusterConfiguration = GetClusterConfiguration(cluster);
 
         Add(props, EndpointSetting, clusterConfiguration->Endpoint, pos, ctx);
-        Add(props, SharedReading, ToString(UseSharedReading(clusterConfiguration, format)), pos, ctx);
+        const bool useSharedReading = UseSharedReading(clusterConfiguration, format);
+        Add(props, SharedReading, ToString(useSharedReading), pos, ctx);
         Add(props, ReconnectPeriod, ToString(clusterConfiguration->ReconnectPeriod), pos, ctx);
         Add(props, Format, format, pos, ctx);
         Add(props, ReadGroup, clusterConfiguration->ReadGroup, pos, ctx);
@@ -435,8 +492,16 @@ public:
 
         bool streamingTopicReadEnabled = State_->StreamingTopicsReadByDefault;
         TMaybe<TString> watermarksLateEventsPolicy;
-        TMaybe<ui64> watermarksGranularityMs;
-        TMaybe<ui64> watermarksIdleTimeoutMs;
+        TMaybe<ui64> watermarksGranularityUs;
+        TMaybe<ui64> watermarksIdleTimeoutUs;
+        TMaybe<ui64> watermarksLateArrivalDelayUs;
+        if (!useSharedReading && maybeWatermark) {
+            watermarksLateArrivalDelayUs = ExtractWatermarkDelay(maybeWatermark.Cast());
+            if (!watermarksLateArrivalDelayUs) {
+                ctx.AddError(TIssue(ctx.GetPosition(pqReadTopic.Pos()), "Unrecognized watermark expression, flexible watermark expressions are only implemented in shared reading mode, please use WATERMARK = (SystemMetadata('write_time') - Interval('PT5S'))"));
+                return {};
+            }
+        }
         for (const auto& setting : settings.Raw()->Children()) {
             const auto settingName = setting->Child(0)->Content();
             if ("skip.json.errors" == settingName) {
@@ -456,7 +521,7 @@ public:
                 if (!skipJsonErrors) {
                     continue;
                 }
-                if (!UseSharedReading(clusterConfiguration, format)) {
+                if (!useSharedReading) {
                     ctx.AddError(TIssue(ctx.GetPosition(pqReadTopic.Pos()), "`skip.json.errors` is supported only in shared reading mode"));
                     return {};
                 }
@@ -530,7 +595,7 @@ public:
                     return {};
                 }
 
-                watermarksGranularityMs = TDuration::MicroSeconds(out.Get<ui64>()).MilliSeconds();
+                watermarksGranularityUs = out.Get<ui64>();
             } else if ("watermarkidletimeout" == settingName) {
                 if (setting->ChildrenSize() != 2) {
                     ctx.AddError(TIssue(ctx.GetPosition(pqReadTopic.Pos()), "Expected WATERMARK_IDLE_TIMEOUT = value"));
@@ -547,7 +612,7 @@ public:
                     return {};
                 }
 
-                watermarksIdleTimeoutMs = TDuration::MicroSeconds(out.Get<ui64>()).MilliSeconds();
+                watermarksIdleTimeoutUs = out.Get<ui64>();
             } else if ("streaming" == settingName) {
                 if (const auto parseResult = TTopicKeyParser::ParseStreamingTopicRead(*setting, ctx)) {
                     streamingTopicReadEnabled = *parseResult;
@@ -563,31 +628,41 @@ public:
             return nullptr;
         }
 
-        if (wrSettings.WatermarksMode.GetOrElse("") == "default") {
+        if (wrSettings.WatermarksMode.GetOrElse("") == "default" && maybeWatermark) {
             Add(props, WatermarksEnableSetting, ToString(true), pos, ctx);
-
-            const auto granularity = TDuration::MilliSeconds(watermarksGranularityMs
-                .OrElse(wrSettings.WatermarksGranularityMs)
-                .GetOrElse(TDqSettings::TDefault::WatermarksGranularityMs));
-            Add(props, WatermarksGranularityUsSetting, ToString(granularity.MicroSeconds()), pos, ctx);
-
-            const auto lateArrivalDelay = TDuration::MilliSeconds(wrSettings
-                .WatermarksLateArrivalDelayMs
-                .GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs));
-            Add(props, WatermarksLateArrivalDelayUsSetting, ToString(lateArrivalDelay.MicroSeconds()), pos, ctx);
+            Add(props, WatermarksGranularityUsSetting,
+                ToString(watermarksGranularityUs.GetOrElse(TDuration::MilliSeconds(wrSettings.WatermarksGranularityMs.GetOrElse(TDqSettings::TDefault::WatermarksGranularityMs)).MicroSeconds())), pos, ctx);
+            Add(props, WatermarksLateArrivalDelayUsSetting,
+                ToString(watermarksLateArrivalDelayUs.GetOrElse(TDuration::MilliSeconds(wrSettings.WatermarksLateArrivalDelayMs.GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs)).MicroSeconds())), pos, ctx);
 
             const auto lateEventsPolicy = watermarksLateEventsPolicy
                 .GetOrElse("adjust");
             Add(props, WatermarksLateEventsPolicySetting, lateEventsPolicy, pos, ctx);
-        }
 
-        if (wrSettings.WatermarksEnableIdlePartitions.GetOrElse(false)) {
-            Add(props, WatermarksIdlePartitionsSetting, ToString(true), pos, ctx);
-
-            const auto idleTimeout = TDuration::MilliSeconds(watermarksIdleTimeoutMs
-                .OrElse(wrSettings.WatermarksIdleTimeoutMs)
-                .GetOrElse(TDqSettings::TDefault::WatermarksIdleTimeoutMs));
-            Add(props, WatermarksIdleTimeoutUsSetting, ToString(idleTimeout.MicroSeconds()), pos, ctx);
+            if (wrSettings.WatermarksEnableIdlePartitions.GetOrElse(true)) {
+                if (wrSettings.WatermarksEnableIdlePartitions.Defined() && !watermarksIdleTimeoutUs) {
+                    watermarksIdleTimeoutUs = TDuration::MilliSeconds(wrSettings.WatermarksIdleTimeoutMs.GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs)).MicroSeconds();
+                }
+                if (watermarksIdleTimeoutUs) {
+                    Add(props, WatermarksIdlePartitionsSetting, ToString(true), pos, ctx);
+                    Add(props, WatermarksIdleTimeoutUsSetting, ToString(*watermarksIdleTimeoutUs), pos, ctx);
+                }
+            } else {
+                if (watermarksIdleTimeoutUs) {
+                    ctx.AddWarning(TIssue(ctx.GetPosition(pqReadTopic.Pos()), "WATERMARK_IDLE_TIMEOUT specified, but watermarks idle partitions explicitly disabled"));
+                }
+            }
+        } else {
+            if (maybeWatermark) {
+                ctx.AddError(TIssue(ctx.GetPosition(pqReadTopic.Pos()), "WATERMARK expression specified, but watermarks are disabled"));
+                return {};
+            }
+            if (watermarksGranularityUs) {
+                ctx.AddWarning(TIssue(ctx.GetPosition(pqReadTopic.Pos()), "WATERMARK_GRANULARITY specified, but watermarks are disabled"));
+            }
+            if (watermarksIdleTimeoutUs) {
+                ctx.AddWarning(TIssue(ctx.GetPosition(pqReadTopic.Pos()), "WATERMARK_IDLE_TIMEOUT specified, but watermarks are disabled"));
+            }
         }
 
         return Build<TCoNameValueTupleList>(ctx, pos)

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -641,7 +641,7 @@ public:
 
             if (wrSettings.WatermarksEnableIdlePartitions.GetOrElse(true)) {
                 if (wrSettings.WatermarksEnableIdlePartitions.Defined() && !watermarksIdleTimeoutUs) {
-                    watermarksIdleTimeoutUs = TDuration::MilliSeconds(wrSettings.WatermarksIdleTimeoutMs.GetOrElse(TDqSettings::TDefault::WatermarksLateArrivalDelayMs)).MicroSeconds();
+                    watermarksIdleTimeoutUs = TDuration::MilliSeconds(wrSettings.WatermarksIdleTimeoutMs.GetOrElse(TDqSettings::TDefault::WatermarksIdleTimeoutMs)).MicroSeconds();
                 }
                 if (watermarksIdleTimeoutUs) {
                     Add(props, WatermarksIdlePartitionsSetting, ToString(true), pos, ctx);

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -1108,32 +1108,27 @@ class TestJoinStreaming(TestYdsBase):
             '''
 
         messages = [
-            (R'{"ts":12, "user": 1}', ),   # 0 # w 9->8
-            (R'{"ts":10, "user": 1}', ),   # 1 # w 7->6
-            (R'{"ts":11, "user": 2}', ),   # 2 # w 8->8
-            (R'{"ts":13, "user": 10}', ),  # 3 # w 10->10 -> close :=10
-            (R'{"ts":16, "user": 3}', ),   # 4 # w 13->12
-            (                              # 5 # w 14->14
-                R'{"ts":17, "user": 1, "skip": true}',
-            ),
+            (R'{"ts":12, "user": 1}',),  # ############ 0 # w 9->8
+            (R'{"ts":10, "user": 1}',),  # ############ 1 # w 7->6
+            (R'{"ts":11, "user": 2}',),  # ############ 2 # w 8->8
+            (R'{"ts":13, "user": 10}',),  # ########### 3 # w 10->10 -> close :=10
+            (R'{"ts":16, "user": 3}',),  # ############ 4 # w 13->12
+            ('{"ts":17, "user": 1, "skip": true}',),  # 5 # w 14->14
             (
-                R'{"ts":19, "user": 4}',   # 6 # w 16->16 -> close :=15
+                R'{"ts":19, "user": 4}',  # ########### 6 # w 16->16 -> close :=15
                 R'{"uid": null,   "hopTime":15, "tsList":[13]}',
                 R'{"uid":"ydb10", "hopTime":15, "tsList":[10, 12]}',
                 R'{"uid":"ydb20", "hopTime":15, "tsList":[11]}',
             ),
-            (
-                R'{"ts":18, "user": 4}',   # 7 # w 15->14
-            ),
-            (                              # 8 # w 18->18
-                R'{"ts":21, "user": 9}',),
-            (                              # 9 # w 25 -> 24 -> close :=20
+            (R'{"ts":18, "user": 4}',),  # ############ 7 # w 15->14
+            (R'{"ts":21, "user": 9}',),  # ############ 8 # w 18->18
+            (  # ###################################### 9 # w 25 -> 24 -> close :=20
                 R'{"ts":28, "user": 5, "skip": true}',
                 R'{"uid": null,   "hopTime":20, "tsList":[13, 18, 19]}',
                 R'{"uid":"ydb10", "hopTime":20, "tsList":[10, 12]}',
                 R'{"uid":"ydb20", "hopTime":20, "tsList":[11]}',
                 R'{"uid":"ydb30", "hopTime":20, "tsList":[16]}',
-            )
+            ),
         ]
         messages = messages[:limit]
 

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -1025,3 +1025,167 @@ class TestJoinStreaming(TestYdsBase):
         status = describe_response.result.query.meta.status
         assert not describe_response.issues, str(describe_response.issues)
         assert status == fq.QueryMeta.ABORTED_BY_USER, fq.QueryMeta.ComputeStatus.Name(status)
+
+    @yq_v1
+    @pytest.mark.parametrize(
+        "mvp_external_ydb_endpoint", [{"endpoint": "tests-fq-generic-streaming-ydb:2136"}], indirect=True
+    )
+    @pytest.mark.parametrize("fq_client", [{"folder_id": "my_folder_slj"}], indirect=True)
+    @pytest.mark.parametrize("partitions_count", [1])
+    @pytest.mark.parametrize("tasks", [1])
+    @pytest.mark.parametrize("streamlookup", [True, False])
+    @pytest.mark.parametrize("ca", ["sync", "async"])
+    @pytest.mark.parametrize("limit", [6, 7, 8, 9, None])
+    def test_streamlookup_with_watermarks(
+        self,
+        kikimr,
+        ca,
+        limit,
+        streamlookup,
+        tasks,
+        partitions_count,
+        fq_client: FederatedQueryClient,
+        yq_version,
+    ):
+        self.init_topics(
+            f"slj_wm_{partitions_count}{streamlookup}{limit}{ca}{tasks}_{yq_version}",
+            partitions_count=partitions_count,
+        )
+        fq_client.create_yds_connection(
+            "wmyds",
+            os.getenv("YDB_DATABASE"),
+            os.getenv("YDB_ENDPOINT"),
+            shared_reading=True,
+        )
+
+        table_name = 'join_table'
+        ydb_conn_name = f'ydb_conn_{table_name}'
+
+        fq_client.create_ydb_connection(
+            name=ydb_conn_name,
+            database_id='local',
+        )
+
+        options = ()
+        streamlookup_hint = Rf'/*+ streamlookup({" ".join(options)}) */' if streamlookup else ''
+        idle_clause = R", WATERMARK_IDLE_TIMEOUT = 'PT5S'" if tasks > 1 or partitions_count > 1 else ""
+        sql = Rf'''
+            PRAGMA dq.ComputeActorType = "{ca}";
+            PRAGMA dq.WatermarksMode = "default";
+            PRAGMA dq.MaxTasksPerStage = "{tasks}";
+            PRAGMA dq.WatermarksGranularityMs = "2000";
+
+            $event_time = ($ts) -> (CAST(($ts*1000000ul) AS Timestamp));
+
+            $input = SELECT * FROM wmyds.`{self.input_topic}`
+                    WITH (
+                        FORMAT=json_each_row,
+                        SCHEMA (
+                            ts Uint64,
+                            user Int32,
+                            skip Bool
+                        )
+                        , WATERMARK AS ($event_time(`ts`) - Interval('PT3S'))
+                        , WATERMARK_GRANULARITY = 'PT2S'
+                        {idle_clause}
+                    )            ;
+            $input =
+                SELECT e.*, $event_time(ts) AS event_time FROM $input AS e WHERE skip IS DISTINCT FROM true;
+            $enriched = SELECT event_time, ts, u.data as uid
+                FROM
+                    $input as e
+                LEFT JOIN {streamlookup_hint} ANY ydb_conn_{table_name}.{table_name} AS u
+                ON(e.user = u.id)
+            ;
+            $enriched =
+                SELECT CAST(HOP_END() AS Uint64)/1000000ul as hopTime, uid, ListSort(AGGREGATE_LIST(ts)) AS tsList FROM $enriched
+                    GROUP BY HoppingWindow(event_time, 'PT5S', 'PT10S', "max" AS TimeLimit)
+                            , uid
+                ;
+
+            insert into wmyds.`{self.output_topic}`
+            select Unwrap(Yson::SerializeJson(Yson::From(TableRow()))) from $enriched;
+            '''
+
+        messages = [
+            (R'{"ts":12, "user": 1}', ),   # 0 # w 9->8
+            (R'{"ts":10, "user": 1}', ),   # 1 # w 7->6
+            (R'{"ts":11, "user": 2}', ),   # 2 # w 8->8
+            (R'{"ts":13, "user": 10}', ),  # 3 # w 10->10 -> close :=10
+            (R'{"ts":16, "user": 3}', ),   # 4 # w 13->12
+            (                              # 5 # w 14->14
+                R'{"ts":17, "user": 1, "skip": true}',
+            ),
+            (
+                R'{"ts":19, "user": 4}',   # 6 # w 16->16 -> close :=15
+                R'{"uid": null,   "hopTime":15, "tsList":[13]}',
+                R'{"uid":"ydb10", "hopTime":15, "tsList":[10, 12]}',
+                R'{"uid":"ydb20", "hopTime":15, "tsList":[11]}',
+            ),
+            (
+                R'{"ts":18, "user": 4}',   # 7 # w 15->14
+            ),
+            (                              # 8 # w 18->18
+                R'{"ts":21, "user": 9}',),
+            (                              # 9 # w 25 -> 24 -> close :=20
+                R'{"ts":28, "user": 5, "skip": true}',
+                R'{"uid": null,   "hopTime":20, "tsList":[13, 18, 19]}',
+                R'{"uid":"ydb10", "hopTime":20, "tsList":[10, 12]}',
+                R'{"uid":"ydb20", "hopTime":20, "tsList":[11]}',
+                R'{"uid":"ydb30", "hopTime":20, "tsList":[16]}',
+            )
+        ]
+        messages = messages[:limit]
+
+        one_time_waiter.wait()
+
+        query_id = fq_client.create_query(
+            f"slj_wm_{partitions_count}{streamlookup}{limit}{ca}{tasks}", sql, type=fq.QueryContent.QueryType.STREAMING
+        ).result.query_id
+
+        fq_client.wait_query_status(query_id, fq.QueryMeta.RUNNING)
+        kikimr.compute_plane.wait_zero_checkpoint(query_id)
+
+        for offset in range(0, len(messages), MAX_WRITE_STREAM_SIZE):
+            self.write_stream(map(lambda x: x[0], messages[offset : offset + MAX_WRITE_STREAM_SIZE]))
+
+        expected_len = sum(map(len, messages)) - len(messages)
+        read_data = self.read_stream(expected_len)
+        if DEBUG:
+            print(streamlookup, file=sys.stderr)
+            print(sql, file=sys.stderr)
+            print(*zip(messages, read_data), file=sys.stderr, sep="\n")
+        read_data_ctr = Counter(map(freeze, map(json.loads, read_data)))
+        messages_ctr = Counter(map(freeze, map(json.loads, chain(*map(lambda row: islice(row, 1, None), messages)))))
+        assert read_data_ctr == messages_ctr
+
+        for node_index in kikimr.compute_plane.kikimr_cluster.nodes:
+            sensors = kikimr.compute_plane.get_sensors(node_index, "dq_tasks")
+            for component in ["Lookup", "LookupSrc"]:
+                componentSensors = sensors.find_sensors(
+                    labels={"operation": query_id, "component": component},
+                    key_label="sensor",
+                )
+                for k in componentSensors:
+                    print(
+                        f'node[{node_index}].operation[{query_id}].component[{component}].{k} = {componentSensors[k]}',
+                        file=sys.stderr,
+                    )
+            sensors = kikimr.compute_plane.get_sensors(node_index, "yq")
+            mkqlSensors = sensors.find_sensors(
+                labels={"query_id": query_id, "sensor": "MkqlMaxMemoryUsage"},
+                key_label="Stage",
+            )
+            for k in mkqlSensors:
+                print(
+                    f'node[{node_index}].query_id[{query_id}].Stage[{k}].MkqlMaxMemoryUsage = {mkqlSensors[k]}',
+                    file=sys.stderr,
+                )
+
+        fq_client.abort_query(query_id)
+        fq_client.wait_query(query_id)
+
+        describe_response = fq_client.describe_query(query_id)
+        status = describe_response.result.query.meta.status
+        assert not describe_response.issues, str(describe_response.issues)
+        assert status == fq.QueryMeta.ABORTED_BY_USER, fq.QueryMeta.ComputeStatus.Name(status)

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindow-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindow-default.txt_/ast.txt
@@ -18,7 +18,7 @@
 (let $17 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $18 '('"SharedReading" '"1"))
 (let $19 '('"UseSsl" '"1"))
-(let $20 '('('"Consumer" '"test_client") $17 $18 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $19 '('"WatermarksEnable" '"1") '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $20 '('('"Consumer" '"test_client") $17 $18 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $19))
 (let $21 (SecureParam '"cluster:default_pq"))
 (let $22 (DqPqTopicSource $6 $15 $16 $20 $21 '"" $14 '""))
 (let $23 (DqStage '((DqSource $7 $22)) (lambda '($27) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowByStringKey-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowByStringKey-default.txt_/ast.txt
@@ -18,7 +18,7 @@
 (let $17 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $18 '('"SharedReading" '"1"))
 (let $19 '('"UseSsl" '"1"))
-(let $20 '('('"Consumer" '"test_client") $17 $18 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $19 '('"WatermarksEnable" '"1") '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $20 '('('"Consumer" '"test_client") $17 $18 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $19))
 (let $21 (SecureParam '"cluster:default_pq"))
 (let $22 (DqPqTopicSource $6 $15 $16 $20 $21 '"" $14 '""))
 (let $23 (DqStage '((DqSource $7 $22)) (lambda '($27) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowExprKey-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowExprKey-default.txt_/ast.txt
@@ -16,7 +16,7 @@
 (let $15 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $16 '('"SharedReading" '"1"))
 (let $17 '('"UseSsl" '"1"))
-(let $18 '('('"Consumer" '"test_client") $15 $16 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $17 '('"WatermarksEnable" '"1") '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $18 '('('"Consumer" '"test_client") $15 $16 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $17))
 (let $19 (SecureParam '"cluster:default_pq"))
 (let $20 (DqPqTopicSource $6 $13 $14 $18 $19 '"" $12 '""))
 (let $21 (DqStage '((DqSource $7 $20)) (lambda '($25) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowListKey-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowListKey-default.txt_/ast.txt
@@ -16,7 +16,7 @@
 (let $15 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $16 '('"SharedReading" '1))
 (let $17 '('"UseSsl" '1))
-(let $18 '('('"Consumer" '"test_client") $15 $16 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $17 '('"WatermarksEnable" '1) '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $18 '('('"Consumer" '"test_client") $15 $16 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $17))
 (let $19 (SecureParam '"cluster:default_pq"))
 (let $20 (DqPqTopicSource $6 $13 $14 $18 $19 '"" $12 '""))
 (let $21 (DqStage '((DqSource $7 $20)) (lambda '($25) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowNoKey-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowNoKey-default.txt_/ast.txt
@@ -15,7 +15,7 @@
 (let $14 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $15 '('"SharedReading" '"1"))
 (let $16 '('"UseSsl" '"1"))
-(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16 '('"WatermarksEnable" '"1") '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16))
 (let $18 (SecureParam '"cluster:default_pq"))
 (let $19 (DqPqTopicSource $6 $13 '('"t" '"v") $17 $18 '"" $12 '""))
 (let $20 (DqStage '((DqSource $7 $19)) (lambda '($24) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowPercentile-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowPercentile-default.txt_/ast.txt
@@ -15,7 +15,7 @@
 (let $14 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $15 '('"SharedReading" '1))
 (let $16 '('"UseSsl" '1))
-(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16 '('"WatermarksEnable" '1) '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16))
 (let $18 (SecureParam '"cluster:default_pq"))
 (let $19 (DqPqTopicSource $6 $13 '('"t" '"v") $17 $18 '"" $12 '""))
 (let $20 (DqStage '((DqSource $7 $19)) (lambda '($25) (block '(

--- a/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowTimeExtractorUnusedColumns-default.txt_/ast.txt
+++ b/ydb/tests/fq/streaming_optimize/canondata/test_sql_streaming.test_hopping_window-GroupByHoppingWindowTimeExtractorUnusedColumns-default.txt_/ast.txt
@@ -15,7 +15,7 @@
 (let $14 '('"Endpoint" '"<pq_pq_endpoint>"))
 (let $15 '('"SharedReading" '1))
 (let $16 '('"UseSsl" '1))
-(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16 '('"WatermarksEnable" '1) '('"WatermarksGranularityUs" '"1000000") '('"WatermarksLateArrivalDelayUs" '"5000000") '('"WatermarksLateEventsPolicy" '"adjust")))
+(let $17 '('('"Consumer" '"test_client") $14 $15 '('"ReconnectPeriod" '"") '('"Format" '"json_each_row") '('"ReadGroup" '"fqrun") $16))
 (let $18 (SecureParam '"cluster:default_pq"))
 (let $19 (DqPqTopicSource $6 $13 '('"t" '"v") $17 $18 '"" $12 '""))
 (let $20 (DqStage '((DqSource $7 $19)) (lambda '($25) (block '(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

YQ-4955
`PRAGMA dq.WatermarksMode="default"` (or respective flag in kqp) plays role of feature-flag; watermarks only enabled when both feature flag and watermark expression `WITH (...WATERMARK = (...))` are specified.
Idle partitions/channels settings are propagated from `WITH (... WATERMARK_IDLE_TIMEOUT="PTxyz")`.
For backward compatibility, those settings may be taken from `PRAGMA dq`:
- when `dq.WatermarksEnableIdlePartitions="true"`, idle enabled with default timeout of 5s;
- when `dqWatermarksIdlePartitions` is also specified, it overrides default timeout;
- when `WITH (... WATERMARK_IDLE_TIMEOUT)` is specified, it override PRAGMA value and implicitly enables idle watermarks;
- when `dq.WatermarksEnableIdlePartitions="false"` it prohibits everything else (`PRAGMA` timeout, `WITH`)

Granularity is taken from `WITH (...WATERMARK_GRANULARITY=...`, with fallback to PRAGMA, with fallback to default value of 1s