### PR TITLE
Keep resource id during configuration change

### DIFF
--- a/ydb/core/tx/replication/controller/replication.cpp
+++ b/ydb/core/tx/replication/controller/replication.cpp
@@ -245,7 +245,35 @@ public:
         Issue = TruncatedIssue(issue);
     }
 
+    static void KeepResourceId(
+            const NKikimrReplication::TReplicationConfig& oldConfig,
+            NKikimrReplication::TReplicationConfig& newConfig)
+    {
+        const auto& oldParams = oldConfig.GetSrcConnectionParams();
+        if (!oldParams.HasIamCredentials()) {
+            return;
+        }
+
+        const auto& oldIam = oldParams.GetIamCredentials();
+        if (!oldIam.HasResourceId()) {
+            return;
+        }
+
+        if (!newConfig.HasSrcConnectionParams()) {
+            return;
+        }
+
+        auto& newParams = *newConfig.MutableSrcConnectionParams();
+        if (!newParams.HasIamCredentials()) {
+            return;
+        }
+
+        auto& newIam = *newParams.MutableIamCredentials();
+        newIam.SetResourceId(oldIam.GetResourceId());
+    }
+
     void SetConfig(NKikimrReplication::TReplicationConfig&& config) {
+        KeepResourceId(Config, config);
         Config = config;
     }
 

--- a/ydb/core/tx/replication/controller/replication_ut.cpp
+++ b/ydb/core/tx/replication/controller/replication_ut.cpp
@@ -1,0 +1,43 @@
+#include "replication.h"
+
+#include <ydb/core/protos/replication.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NReplication::NController {
+
+Y_UNIT_TEST_SUITE(Replication) {
+    Y_UNIT_TEST(ResourceId) {
+        const ui64 id = 1;
+        const auto pathId = TPathId(1, 2);
+        const auto resourceId = "resource-id";
+        NKikimrReplication::TReplicationConfig config;
+
+        // init with resource id
+        config.MutableSrcConnectionParams()->MutableIamCredentials()->SetResourceId(resourceId);
+        auto replication = MakeIntrusive<TReplication>(id, pathId, std::move(config), "/Root/db");
+        UNIT_ASSERT_VALUES_EQUAL(replication->GetConfig().GetSrcConnectionParams().GetIamCredentials().GetResourceId(), resourceId);
+
+        // try to change resource id
+        config.MutableSrcConnectionParams()->MutableIamCredentials()->SetResourceId("");
+        replication->SetConfig(std::move(config));
+        UNIT_ASSERT_VALUES_EQUAL(replication->GetConfig().GetSrcConnectionParams().GetIamCredentials().GetResourceId(), resourceId);
+
+        // clear iam credentials
+        config.MutableSrcConnectionParams()->ClearIamCredentials();
+        replication->SetConfig(std::move(config));
+        UNIT_ASSERT_VALUES_EQUAL(replication->GetConfig().GetSrcConnectionParams().GetIamCredentials().GetResourceId(), "");
+
+        // set resource id back
+        config.MutableSrcConnectionParams()->MutableIamCredentials()->SetResourceId(resourceId);
+        replication->SetConfig(std::move(config));
+        UNIT_ASSERT_VALUES_EQUAL(replication->GetConfig().GetSrcConnectionParams().GetIamCredentials().GetResourceId(), resourceId);
+
+        // clear entire connection params
+        config.ClearSrcConnectionParams();
+        replication->SetConfig(std::move(config));
+        UNIT_ASSERT_VALUES_EQUAL(replication->GetConfig().GetSrcConnectionParams().GetIamCredentials().GetResourceId(), "");
+    }
+}
+
+}

--- a/ydb/core/tx/replication/controller/tx_alter_replication.cpp
+++ b/ydb/core/tx/replication/controller/tx_alter_replication.cpp
@@ -40,7 +40,7 @@ public:
         bool alter = false;
 
         const auto& oldConfig = Replication->GetConfig();
-        const auto& newConfig = record.GetConfig();
+        auto newConfig = std::move(*record.MutableConfig());
 
         if (oldConfig.HasTransferSpecific()) {
             auto& oldSpecific = oldConfig.GetTransferSpecific();
@@ -87,12 +87,12 @@ public:
             }
         }
 
-        Replication->SetConfig(std::move(*record.MutableConfig()));
+        Replication->SetConfig(std::move(newConfig));
         Replication->ResetCredentials(ctx);
 
         NIceDb::TNiceDb db(txc.DB);
         db.Table<Schema::Replications>().Key(Replication->GetId()).Update(
-            NIceDb::TUpdate<Schema::Replications::Config>(record.GetConfig().SerializeAsString()),
+            NIceDb::TUpdate<Schema::Replications::Config>(Replication->GetConfig().SerializeAsString()),
             NIceDb::TUpdate<Schema::Replications::DesiredState>(desiredState),
             NIceDb::TUpdate<Schema::Replications::Issue>(issue)
         );

--- a/ydb/core/tx/replication/controller/ut_replication/ya.make
+++ b/ydb/core/tx/replication/controller/ut_replication/ya.make
@@ -1,0 +1,21 @@
+UNITTEST_FOR(ydb/core/tx/replication/controller)
+
+FORK_SUBTESTS()
+
+SIZE(SMALL)
+
+TIMEOUT(60)
+
+PEERDIR(
+    ydb/core/protos
+    ydb/core/testlib/pg
+    library/cpp/testing/unittest
+)
+
+SRCS(
+    replication_ut.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/tx/replication/controller/ya.make
+++ b/ydb/core/tx/replication/controller/ya.make
@@ -75,6 +75,7 @@ END()
 RECURSE_FOR_TESTS(
     ut_assign_tx_id
     ut_dst_creator
+    ut_replication
     ut_stream_creator
     ut_target_discoverer
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
