### PR TITLE
Add mTLS support to monitoring

### DIFF
--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -299,6 +299,7 @@ struct TCommonAppOptions {
     ui32 MonitoringMaxRequestsPerSecond = 0;
     TString MonitoringCertificateFile;
     TString MonitoringPrivateKeyFile;
+    TString MonitoringCaFile;
     TString RestartsCountFile = "";
     size_t CompileInflightLimit = 100000; // MiniKQLCompileService
     TString UDFsDir;
@@ -398,6 +399,7 @@ struct TCommonAppOptions {
         opts.AddLongOption("mon-cert", "Path to monitoring certificate file (https)").OptionalArgument("PATH").StoreResult(&MonitoringCertificateFile);
         opts.AddLongOption("mon-key", "Path to monitoring private key file (https)").OptionalArgument("PATH").StoreResult(&MonitoringPrivateKeyFile);
         opts.AddLongOption("mon-threads", "Monitoring http server threads").RequiredArgument("NUM").StoreResult(&MonitoringThreads);
+        opts.AddLongOption("mon-ca", "Path to CA certificate file for verifying client certificates (mTLS)").OptionalArgument("PATH").StoreResult(&MonitoringCaFile);
         opts.AddLongOption("suppress-version-check", "Suppress version compatibility checking via IC").NoArgument().SetFlag(&SuppressVersionCheck);
 
         opts.AddLongOption("grpc-port", "enable gRPC server on port").RequiredArgument("PORT").StoreResult(&GRpcPort);
@@ -606,6 +608,10 @@ struct TCommonAppOptions {
         }
         if (MonitoringPrivateKeyFile) {
             appConfig.MutableMonitoringConfig()->SetMonitoringPrivateKeyFile(MonitoringPrivateKeyFile);
+            ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::MonitoringConfigItem, TConfigItemInfo::EUpdateKind::UpdateExplicitly);
+        }
+        if (MonitoringCaFile) {
+            appConfig.MutableMonitoringConfig()->SetMonitoringCaFile(MonitoringCaFile);
             ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::MonitoringConfigItem, TConfigItemInfo::EUpdateKind::UpdateExplicitly);
         }
         if (SqsHttpPort) {

--- a/ydb/core/driver_lib/run/config_parser.cpp
+++ b/ydb/core/driver_lib/run/config_parser.cpp
@@ -391,6 +391,7 @@ void TRunCommandConfigParser::ApplyParsedOptions() {
     Config.AppConfig.MutableMonitoringConfig()->SetInactivityTimeout(ToString(RunOpts.MonitoringInactivityTimeout.Seconds()));
     Config.AppConfig.MutableMonitoringConfig()->SetMonitoringCertificateFile(RunOpts.MonitoringCertificateFile);
     Config.AppConfig.MutableMonitoringConfig()->SetMonitoringPrivateKeyFile(RunOpts.MonitoringPrivateKeyFile);
+    Config.AppConfig.MutableMonitoringConfig()->SetMonitoringCaFile(RunOpts.MonitoringCaFile);
     Config.AppConfig.MutableRestartsCountConfig()->SetRestartsCountFile(RunOpts.RestartsCountFile);
 }
 

--- a/ydb/core/driver_lib/run/config_parser.cpp
+++ b/ydb/core/driver_lib/run/config_parser.cpp
@@ -268,6 +268,7 @@ void TRunCommandConfigParser::ParseRunOpts(int argc, char **argv) {
     opts.AddLongOption("mon-address", "Monitoring address").OptionalArgument("ADDR").StoreResult(&RunOpts.MonitoringAddress);
     opts.AddLongOption("mon-cert", "Path to monitoring certificate file (https)").OptionalArgument("PATH").StoreResult(&RunOpts.MonitoringCertificateFile);
     opts.AddLongOption("mon-key", "Path to monitoring private key file (https)").OptionalArgument("PATH").StoreResult(&RunOpts.MonitoringPrivateKeyFile);
+    opts.AddLongOption("mon-ca", "Path to CA certificate file for verifying client certificates (mTLS)").OptionalArgument("PATH").StoreResult(&RunOpts.MonitoringCaFile);
     opts.AddLongOption("mon-threads", "Monitoring http server threads").RequiredArgument("NUM").StoreResult(&RunOpts.MonitoringThreads);
 
     SetupLastGetOptForConfigFiles(opts);
@@ -306,7 +307,7 @@ void TRunCommandConfigParser::ParseRunOpts(int argc, char **argv) {
 }
 
 void TRunCommandConfigParser::ApplyParsedOptions() {
-    auto ensureFileExists = [](const TString& path, TStringBuf optName) {
+    auto ensureFileExistsIfSet = [](const TString& path, TStringBuf optName) {
         if (path.empty()) {
             return;
         }
@@ -317,8 +318,9 @@ void TRunCommandConfigParser::ApplyParsedOptions() {
         }
     };
 
-    ensureFileExists(RunOpts.MonitoringCertificateFile, "mon-cert");
-    ensureFileExists(RunOpts.MonitoringPrivateKeyFile, "mon-key");
+    ensureFileExistsIfSet(RunOpts.MonitoringCertificateFile, "mon-cert");
+    ensureFileExistsIfSet(RunOpts.MonitoringPrivateKeyFile, "mon-key");
+    ensureFileExistsIfSet(RunOpts.MonitoringCaFile, "mon-ca");
 
     // apply global options
     Config.AppConfig.MutableInterconnectConfig()->SetStartTcp(GlobalOpts.StartTcp);

--- a/ydb/core/driver_lib/run/config_parser.h
+++ b/ydb/core/driver_lib/run/config_parser.h
@@ -50,6 +50,7 @@ protected:
         TString MonitoringAddress;
         TString MonitoringCertificateFile;
         TString MonitoringPrivateKeyFile;
+        TString MonitoringCaFile;
         ui32 MonitoringThreads;
         ui32 MonitoringMaxRequestsPerSecond;
         TDuration MonitoringInactivityTimeout;

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -619,6 +619,7 @@ void TKikimrRunner::InitializeMonitoring(const TKikimrRunConfig& runConfig, bool
         monConfig.InactivityTimeout = TDuration::Parse(appConfig.GetMonitoringConfig().GetInactivityTimeout());
         monConfig.CertificateFile = appConfig.GetMonitoringConfig().GetMonitoringCertificateFile();
         monConfig.PrivateKeyFile = appConfig.GetMonitoringConfig().GetMonitoringPrivateKeyFile();
+        monConfig.CaFile = appConfig.GetMonitoringConfig().GetMonitoringCaFile();
         monConfig.RedirectMainPageTo = appConfig.GetMonitoringConfig().GetRedirectMainPageTo();
         monConfig.RequireCountersAuthentication = appConfig.GetMonitoringConfig().GetRequireCountersAuthentication();
         if (includeHostName) {

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -86,6 +86,8 @@ NActors::IEventHandle* SelectAuthorizationScheme(const NActors::TActorId& owner,
         return GetRequestAuthAndCheckHandle(owner, GetDatabase(request), TString(authorization), NMonitoring::NAudit::ExtractRemoteAddress(request));
     } else if (!ydbSessionId.empty()) {
         return GetRequestAuthAndCheckHandle(owner, GetDatabase(request), TString("Login ") + TString(ydbSessionId), NMonitoring::NAudit::ExtractRemoteAddress(request));
+    } else if (!request->MTlsClientCertificate.empty()) {
+        return GetRequestAuthAndCheckHandle(owner, GetDatabase(request), request->MTlsClientCertificate, NMonitoring::NAudit::ExtractRemoteAddress(request));
     } else {
         return nullptr;
     }
@@ -401,7 +403,9 @@ public:
     }
 
     bool CredentialsProvided() {
-        return Container.GetCookie("ydb_session_id") || Container.GetHeader("Authorization");
+        return Container.GetCookie("ydb_session_id") ||
+            Container.GetHeader("Authorization") ||
+            !Event->Get()->Request->MTlsClientCertificate.empty();
     }
 
     TString YdbToHttpError(Ydb::StatusIds::StatusCode status) {
@@ -1022,6 +1026,9 @@ public:
         if (cookies.Has("ydb_session_id")) {
             return true;
         }
+        if (!request->MTlsClientCertificate.empty()) {
+            return true;
+        }
         return false;
     }
 
@@ -1232,6 +1239,9 @@ public:
         }
         NHttp::TCookies cookies(headers["Cookie"]);
         if (cookies.Has("ydb_session_id")) {
+            return true;
+        }
+        if (!request->MTlsClientCertificate.empty()) {
             return true;
         }
         return false;
@@ -1667,6 +1677,7 @@ std::future<void> TMon::Start(TActorSystem* actorSystem) {
     addPort->SslCertificatePem = Config.Certificate;
     addPort->CertificateFile = Config.CertificateFile;
     addPort->PrivateKeyFile = Config.PrivateKeyFile;
+    addPort->CaFile = Config.CaFile;
     addPort->Secure = !Config.Certificate.empty() || !Config.CertificateFile.empty();
     addPort->MaxRequestsPerSecond = Config.MaxRequestsPerSecond;
 

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -39,6 +39,7 @@ public:
         TString Certificate; // certificate/private key data in PEM format
         TString CertificateFile; // certificate file path in PEM format (OpenSSL feature: may optionally contain both certificate chain and private key in the same PEM file if PrivateKeyFile is not set)
         TString PrivateKeyFile; // private key file path for the certificate in PEM format
+        TString CaFile; // CA certificate file path for verifying client certificates (mTLS)
         ui32 MaxRequestsPerSecond = 0;
         TDuration InactivityTimeout = TDuration::Minutes(2);
         TString AllowOrigin;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -615,6 +615,7 @@ message TMonitoringConfig {
     optional string MonitoringCertificate = 14 [(Ydb.sensitive) = true];
     optional string MonitoringCertificateFile = 15;
     optional string MonitoringPrivateKeyFile = 20;
+    optional string MonitoringCaFile = 22;
     optional string MemAllocDumpPathPrefix = 16;
     optional uint32 MaxRequestsPerSecond = 17 [default = 0];
     optional string InactivityTimeout = 18 [default = "2m"];

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -615,7 +615,7 @@ message TMonitoringConfig {
     optional string MonitoringCertificate = 14 [(Ydb.sensitive) = true];
     optional string MonitoringCertificateFile = 15;
     optional string MonitoringPrivateKeyFile = 20;
-    optional string MonitoringCaFile = 22;
+    optional string MonitoringCaFile = 23;
     optional string MemAllocDumpPathPrefix = 16;
     optional uint32 MaxRequestsPerSecond = 17 [default = 0];
     optional string InactivityTimeout = 18 [default = "2m"];

--- a/ydb/library/actors/http/http.h
+++ b/ydb/library/actors/http/http.h
@@ -964,6 +964,7 @@ public:
     std::shared_ptr<THttpEndpointInfo> Endpoint;
     THttpConfig::SocketAddressType Address;
     THPTimer Timer;
+    TString MTlsClientCertificate;
 
     THttpIncomingRequest()
         : Endpoint(std::make_shared<THttpEndpointInfo>())
@@ -974,11 +975,22 @@ public:
         , Address(address)
     {}
 
+    THttpIncomingRequest(std::shared_ptr<THttpEndpointInfo> endpoint, const THttpConfig::SocketAddressType& address, const TString& mTlsClientCertificate)
+        : Endpoint(std::move(endpoint))
+        , Address(address)
+        , MTlsClientCertificate(mTlsClientCertificate)
+    {}
+
     THttpIncomingRequest(TStringBuf content, std::shared_ptr<THttpEndpointInfo> endpoint, const THttpConfig::SocketAddressType& address)
         : THttpParser(content)
         , Endpoint(std::move(endpoint))
         , Address(address)
     {}
+
+    void Clear() {
+        THttpRequestParser::Clear();
+        MTlsClientCertificate.clear();
+    }
 
     bool IsConnectionClose() const {
         if (Connection.empty()) {

--- a/ydb/library/actors/http/http_proxy.h
+++ b/ydb/library/actors/http/http_proxy.h
@@ -75,6 +75,7 @@ struct TEvHttpProxy {
         TString CertificateFile;
         TString PrivateKeyFile;
         TString SslCertificatePem;
+        TString CaFile;
         std::vector<TString> CompressContentTypes;
         ui32 MaxRequestsPerSecond = 0;
         ui32 MaxRecycledRequestsCount = DEFAULT_MAX_RECYCLED_REQUESTS_COUNT;

--- a/ydb/library/actors/http/http_proxy_acceptor.cpp
+++ b/ydb/library/actors/http/http_proxy_acceptor.cpp
@@ -65,9 +65,9 @@ protected:
         int err = 0;
         if (Endpoint->Secure) {
             if (!event->Get()->SslCertificatePem.empty()) {
-                Endpoint->SecureContext = TSslHelpers::CreateServerContext(event->Get()->SslCertificatePem);
+                Endpoint->SecureContext = TSslHelpers::CreateServerContext(event->Get()->SslCertificatePem, event->Get()->CaFile);
             } else {
-                Endpoint->SecureContext = TSslHelpers::CreateServerContext(event->Get()->CertificateFile, event->Get()->PrivateKeyFile);
+                Endpoint->SecureContext = TSslHelpers::CreateServerContext(event->Get()->CertificateFile, event->Get()->PrivateKeyFile, event->Get()->CaFile);
             }
             if (Endpoint->SecureContext == nullptr) {
                 err = -1;

--- a/ydb/library/actors/http/http_proxy_incoming.cpp
+++ b/ydb/library/actors/http/http_proxy_incoming.cpp
@@ -1,5 +1,9 @@
 #include "http_proxy.h"
 #include "http_proxy_sock_impl.h"
+#include "http_proxy_ssl.h"
+
+#include <openssl/x509.h>
+#include <openssl/pem.h>
 
 namespace NHttp {
 
@@ -43,6 +47,8 @@ public:
 
     TPollerToken::TPtr PollerToken;
     TEvHttpProxy::TEvSubscribeForCancel::TPtr CancelSubscriber;
+
+    TString MTlsClientCertificate;
 
     TIncomingConnectionActor(
             std::shared_ptr<TPrivateEndpointInfo> endpoint,
@@ -115,8 +121,26 @@ protected:
             }
             break;
         }
+        ExtractClientCertificate();
         Become(&TIncomingConnectionActor::StateConnected);
         Send(SelfId(), new TEvPollerReady(nullptr, true, true));
+    }
+
+    void ExtractClientCertificate() {
+        if constexpr (std::is_base_of_v<TSecureSocketImpl, TSocketImpl>) {
+            if (Endpoint->Secure && this->Ssl) {
+                if (TSslHelpers::TSslHolder<X509> peerCert{SSL_get_peer_certificate(this->Ssl.Get())}) {
+                    TSslHelpers::TSslHolder<BIO> bio(BIO_new(BIO_s_mem()));
+                    if (bio && PEM_write_bio_X509(bio.Get(), peerCert.Get()) > 0) {
+                        char* pemData = nullptr;
+                        size_t pemLen = BIO_get_mem_data(bio.Get(), &pemData);
+                        if (pemData && pemLen > 0) {
+                            MTlsClientCertificate = TString(pemData, pemLen);
+                        }
+                    }
+                } // else: client did not provide certificate; that's OK
+            }
+        }
     }
 
     void HandleAccepting(TEvPollerRegisterResult::TPtr& ev) {
@@ -148,8 +172,9 @@ protected:
                         RecycledRequests.pop_front();
                         CurrentRequest->Address = Address;
                         CurrentRequest->Endpoint = Endpoint;
+                        CurrentRequest->MTlsClientCertificate = MTlsClientCertificate;
                     }  else {
-                        CurrentRequest = new THttpIncomingRequest(Endpoint, Address);
+                        CurrentRequest = new THttpIncomingRequest(Endpoint, Address, MTlsClientCertificate);
                     }
                 }
                 if (!CurrentRequest->EnsureEnoughSpaceAvailable()) {

--- a/ydb/library/actors/http/http_proxy_incoming.cpp
+++ b/ydb/library/actors/http/http_proxy_incoming.cpp
@@ -5,6 +5,8 @@
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 
+#include <type_traits>
+
 namespace NHttp {
 
 using namespace NActors;

--- a/ydb/library/actors/http/http_ut.cpp
+++ b/ydb/library/actors/http/http_ut.cpp
@@ -1468,7 +1468,7 @@ Y_UNIT_TEST_SUITE(THttpProxyWithMTls) {
             }
             Sleep(TDuration::MilliSeconds(50));
         }
-        UNIT_ASSERT_C(errorFound, "No connection error happend for untrusted client");
+        UNIT_ASSERT_C(errorFound, "No connection error happened for untrusted client");
 
         clientThread.join();
     }

--- a/ydb/library/actors/http/http_ut.cpp
+++ b/ydb/library/actors/http/http_ut.cpp
@@ -1,13 +1,16 @@
-#include <library/cpp/testing/unittest/registar.h>
-#include <library/cpp/testing/unittest/tests_data.h>
-#include <ydb/library/actors/core/executor_pool_basic.h>
-#include <ydb/library/actors/core/scheduler_basic.h>
-#include <ydb/library/actors/testlib/test_runtime.h>
-#include <util/system/tempfile.h>
 #include "http.h"
 #include "http_proxy.h"
 
-
+#include <ydb/core/security/certificate_check/cert_auth_utils.h>
+#include <ydb/library/actors/core/executor_pool_basic.h>
+#include <ydb/library/actors/core/scheduler_basic.h>
+#include <ydb/library/actors/testlib/test_runtime.h>
+#include <ydb/library/actors/http/ut/tls_client_connection.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
+#include <library/cpp/resource/resource.h>
+#include <util/system/tempfile.h>
+#include <thread>
 
 enum EService : NActors::NLog::EComponent {
     MIN,
@@ -1349,4 +1352,162 @@ CRA/5XcX13GJwHHj6LCoc3sL7mt8qV9HKY2AOZ88mpObzISZxgPpdKCfjsrdm63V
 
         UNIT_ASSERT_EQUAL(response2->Response->Status, "200");
     }
+}
+
+Y_UNIT_TEST_SUITE(THttpProxyWithMTls) {
+    struct TMtlsTestSetup {
+        TStringStream LogStream;
+        TAutoPtr<TLogBackend> LogBackend;
+        NKikimr::TCertAndKey CaCertAndKey;
+        NKikimr::TCertAndKey ServerCertAndKey;
+        NKikimr::TCertAndKey ClientCertAndKey;
+        NKikimr::TCertAndKey UntrustedCaCertAndKey;
+        NKikimr::TCertAndKey UntrustedClientCertAndKey;
+        TTempFileHandle CaCertFile;
+        TTempFileHandle ServerCertFile;
+        TTempFileHandle ServerKeyFile;
+        TTempFileHandle ClientCertFile;
+        TTempFileHandle ClientKeyFile;
+        TTempFileHandle UntrustedCaCertFile;
+        TTempFileHandle UntrustedClientCertFile;
+        TTempFileHandle UntrustedClientKeyFile;
+        NActors::TTestActorRuntimeBase ActorSystem;
+        TPortManager PortManager;
+        TIpPort Port;
+        NActors::TActorId ProxyId;
+        NActors::TActorId ServerId;
+
+        TMtlsTestSetup(const bool useRealThreads = false, const bool secureConnection = true)
+            : LogBackend(new TStreamLogBackend(&LogStream))
+            , ActorSystem(1, useRealThreads)
+        {
+            // Generate certificates
+            CaCertAndKey = NKikimr::GenerateCA(NKikimr::TProps::AsCA());
+            ServerCertAndKey = NKikimr::GenerateSignedCert(CaCertAndKey, NKikimr::TProps::AsServer());
+            ClientCertAndKey = NKikimr::GenerateSignedCert(CaCertAndKey, NKikimr::TProps::AsClient());
+
+            NKikimr::TProps untrustedCaProps = NKikimr::TProps::AsCA();
+            untrustedCaProps.CommonName = "Untrusted " + untrustedCaProps.CommonName;
+            UntrustedCaCertAndKey = NKikimr::GenerateCA(untrustedCaProps);
+
+            NKikimr::TProps untrustedClientProps = NKikimr::TProps::AsClient();
+            untrustedClientProps.CommonName = "Untrusted " + untrustedClientProps.CommonName;
+            UntrustedClientCertAndKey = NKikimr::GenerateSignedCert(UntrustedCaCertAndKey, untrustedClientProps);
+
+            // Write certificates to files
+            CaCertFile.Write(CaCertAndKey.Certificate.c_str(), CaCertAndKey.Certificate.size());
+            ServerCertFile.Write(ServerCertAndKey.Certificate.c_str(), ServerCertAndKey.Certificate.size());
+            ServerKeyFile.Write(ServerCertAndKey.PrivateKey.c_str(), ServerCertAndKey.PrivateKey.size());
+            ClientCertFile.Write(ClientCertAndKey.Certificate.c_str(), ClientCertAndKey.Certificate.size());
+            ClientKeyFile.Write(ClientCertAndKey.PrivateKey.c_str(), ClientCertAndKey.PrivateKey.size());
+            UntrustedCaCertFile.Write(UntrustedCaCertAndKey.Certificate.c_str(), UntrustedCaCertAndKey.Certificate.size());
+            UntrustedClientCertFile.Write(UntrustedClientCertAndKey.Certificate.c_str(), UntrustedClientCertAndKey.Certificate.size());
+            UntrustedClientKeyFile.Write(UntrustedClientCertAndKey.PrivateKey.c_str(), UntrustedClientCertAndKey.PrivateKey.size());
+
+            ActorSystem.SetLogBackend(LogBackend);
+            ActorSystem.Initialize();
+
+            NActors::IActor* proxy = NHttp::CreateHttpProxy();
+            ProxyId = ActorSystem.Register(proxy);
+
+            Port = PortManager.GetTcpPort();
+            THolder<NHttp::TEvHttpProxy::TEvAddListeningPort> add = MakeHolder<NHttp::TEvHttpProxy::TEvAddListeningPort>(Port);
+            if (secureConnection) {
+                add->Secure = true;
+                add->CertificateFile = ServerCertFile.Name();
+                add->PrivateKeyFile = ServerKeyFile.Name();
+                add->CaFile = CaCertFile.Name(); // enables mTLS
+            }
+            ActorSystem.Send(new NActors::IEventHandle(ProxyId, ActorSystem.AllocateEdgeActor(), add.Release()), 0, true);
+            TAutoPtr<NActors::IEventHandle> handle;
+            ActorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvConfirmListen>(handle);
+
+            ServerId = ActorSystem.AllocateEdgeActor();
+            ActorSystem.Send(new NActors::IEventHandle(ProxyId, ServerId, new NHttp::TEvHttpProxy::TEvRegisterHandler("/test", ServerId)), 0, true);
+        }
+    };
+
+    Y_UNIT_TEST(ValidClientCertificate) {
+        TMtlsTestSetup setup;
+
+        const TString httpRequest = "GET /test HTTP/1.1\r\nHost: 127.0.0.1:" + ToString(setup.Port) + "\r\nConnection: close\r\n\r\n";
+        std::thread clientThread([&setup, httpRequest]() {
+            // We run it in a separate thread because GrabEdgeEvent() blocks the main thread waiting for events.
+            // Without a separate thread, we would have a deadlock: main thread blocked in GrabEdgeEvent,
+            // client thread blocked waiting for response from server.
+            NHttp::NTest::SendTlsRequest(setup.Port, setup.ClientCertFile.Name(), setup.ClientKeyFile.Name(), setup.CaCertFile.Name(), httpRequest);
+        });
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        NHttp::TEvHttpProxy::TEvHttpIncomingRequest* request1 = setup.ActorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingRequest>(handle);
+        UNIT_ASSERT_EQUAL(request1->Request->URL, "/test");
+        UNIT_ASSERT(!request1->Request->MTlsClientCertificate.empty());
+
+        clientThread.join();
+    }
+
+    Y_UNIT_TEST(UntrustedClientCertificate) {
+        // Need real threads, since we can't use GrabEdgeEvent – there's no events to detect errors
+        TMtlsTestSetup setup(/* useRealThreads */ true);
+
+        const TString httpRequest = "GET /test HTTP/1.1\r\nHost: 127.0.0.1:" + ToString(setup.Port) + "\r\nConnection: close\r\n\r\n";
+        std::thread clientThread([&setup, httpRequest]() {
+            // We run it in a separate thread because GrabEdgeEvent() blocks the main thread waiting for events.
+            // Without a separate thread, we would have a deadlock: main thread blocked in GrabEdgeEvent,
+            // client thread blocked waiting for response from server.
+            NHttp::NTest::SendTlsRequest(setup.Port, setup.UntrustedClientCertFile.Name(), setup.UntrustedClientKeyFile.Name(), setup.CaCertFile.Name(), httpRequest);
+        });
+
+        const TDuration timeout = TDuration::Seconds(2);
+        const TInstant deadline = TInstant::Now() + timeout;
+        bool errorFound = false;
+        while (TInstant::Now() < deadline) {
+            if (setup.LogStream.Str().Contains("connection closed - error in Accept")) {
+                errorFound = true;
+                break;
+            }
+            Sleep(TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT_C(errorFound, "No connection error happend for untrusted client");
+
+        clientThread.join();
+    }
+
+    Y_UNIT_TEST(NoClientCertificate) {
+        TMtlsTestSetup setup;
+
+        const TString httpRequest = "GET /test HTTP/1.1\r\nHost: 127.0.0.1:" + ToString(setup.Port) + "\r\nConnection: close\r\n\r\n";
+        std::thread clientThread([&setup, httpRequest]() {
+            // We run it in a separate thread because GrabEdgeEvent() blocks the main thread waiting for events.
+            // Without a separate thread, we would have a deadlock: main thread blocked in GrabEdgeEvent,
+            // client thread blocked waiting for response from server.
+            NHttp::NTest::SendTlsRequest(setup.Port, "", "", setup.CaCertFile.Name(), httpRequest);
+        });
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        NHttp::TEvHttpProxy::TEvHttpIncomingRequest* request = setup.ActorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingRequest>(handle);
+        UNIT_ASSERT_EQUAL(request->Request->URL, "/test");
+        UNIT_ASSERT(request->Request->MTlsClientCertificate.empty());
+
+        clientThread.join();
+    }
+
+    Y_UNIT_TEST(NotSecureConnection) {
+        TMtlsTestSetup setup(/* useRealThreads */ false, /* secureConnection */ false);
+
+        NActors::TActorId clientId = setup.ActorSystem.AllocateEdgeActor();
+        NHttp::THttpOutgoingRequestPtr httpRequest = NHttp::THttpOutgoingRequest::CreateRequestGet("http://[::1]:" + ToString(setup.Port) + "/test");
+        setup.ActorSystem.Send(new NActors::IEventHandle(setup.ProxyId, clientId, new NHttp::TEvHttpProxy::TEvHttpOutgoingRequest(httpRequest)), 0, true);
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        NHttp::TEvHttpProxy::TEvHttpIncomingRequest* request = setup.ActorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingRequest>(handle);
+        UNIT_ASSERT_EQUAL(request->Request->URL, "/test");
+        UNIT_ASSERT(request->Request->MTlsClientCertificate.empty());
+
+        NHttp::THttpOutgoingResponsePtr httpResponse = request->Request->CreateResponseString("HTTP/1.1 200 OK\r\nConnection: Close\r\n\r\n");
+        setup.ActorSystem.Send(new NActors::IEventHandle(handle->Sender, setup.ServerId, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse)), 0, true);
+        NHttp::TEvHttpProxy::TEvHttpIncomingResponse* response = setup.ActorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingResponse>(handle);
+        UNIT_ASSERT_EQUAL(response->Response->Status, "200");
+    }
+
 }

--- a/ydb/library/actors/http/ut/tls_client_connection.cpp
+++ b/ydb/library/actors/http/ut/tls_client_connection.cpp
@@ -1,0 +1,43 @@
+#include "tls_client_connection.h"
+
+#include <Poco/Net/SecureStreamSocket.h>
+#include <Poco/Net/Context.h>
+#include <Poco/Net/SocketAddress.h>
+#include <Poco/Net/NetSSL.h>
+
+#include <util/string/cast.h>
+
+namespace NHttp::NTest {
+
+void SendTlsRequest(
+    const TIpPort port,
+    const TString& clientCertFile,
+    const TString& clientKeyFile,
+    const TString& caCertFile,
+    const TString& httpRequest
+) {
+    Poco::Net::initializeSSL();
+
+    // Create SSL context for client with mTLS
+    Poco::Net::Context::Params params;
+    params.privateKeyFile = clientKeyFile.empty() ? "" : clientKeyFile.data();
+    params.certificateFile = clientCertFile.empty() ? "" : clientCertFile.data();
+    params.caLocation = caCertFile.empty() ? "" : caCertFile.data();
+    Poco::Net::Context::Ptr pContext = new Poco::Net::Context(
+        Poco::Net::Context::CLIENT_USE,
+        params
+    );
+
+    // Send HTTP request via secure socket
+    Poco::Net::SocketAddress address("127.0.0.1", port);
+    Poco::Net::SecureStreamSocket socket(address, pContext);
+    socket.sendBytes(httpRequest.data(), httpRequest.size());
+
+    // Close connection (server will process the request asynchronously)
+    socket.shutdownSend();
+    socket.close();
+
+    Poco::Net::uninitializeSSL();
+}
+
+} // namespace NHttp::NTest

--- a/ydb/library/actors/http/ut/tls_client_connection.h
+++ b/ydb/library/actors/http/ut/tls_client_connection.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <util/network/ip.h>
+#include <util/generic/string.h>
+
+namespace NHttp::NTest {
+
+// Sends an HTTP request via TLS connection with client certificate (mTLS)
+void SendTlsRequest(
+    const TIpPort port,
+    const TString& clientCertFile,
+    const TString& clientKeyFile,
+    const TString& caCertFile,
+    const TString& httpRequest);
+
+} // namespace NHttp::NTest

--- a/ydb/library/actors/http/ut/ya.make
+++ b/ydb/library/actors/http/ut/ya.make
@@ -3,12 +3,19 @@ UNITTEST_FOR(ydb/library/actors/http)
 SIZE(SMALL)
 
 PEERDIR(
+    contrib/libs/poco/NetSSL_OpenSSL
+    contrib/libs/poco/Crypto
+    contrib/libs/poco/Foundation
+    contrib/libs/poco/Net
+    ydb/core/security/certificate_check
     ydb/library/actors/testlib
 )
+
 
 IF (NOT OS_WINDOWS)
 SRCS(
     http_ut.cpp
+    tls_client_connection.cpp
 )
 ELSE()
 ENDIF()

--- a/ydb/tests/functional/security/test_mon_mtls_auth.py
+++ b/ydb/tests/functional/security/test_mon_mtls_auth.py
@@ -2,7 +2,6 @@
 import copy
 import os
 import subprocess
-import tempfile
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
@@ -198,9 +197,9 @@ def ydb_cluster_configuration():
 
 
 @pytest.fixture(scope='module')
-def certificates():
-    certs_tmp_dir = tempfile.mkdtemp(prefix='monitoring_certs_')
-    return generate_certificates(certs_tmp_dir)
+def certificates(tmp_path_factory):
+    certs_tmp_dir = tmp_path_factory.mktemp('monitoring_certs_')
+    return generate_certificates(str(certs_tmp_dir))
 
 
 @pytest.fixture(scope='module')
@@ -283,7 +282,7 @@ def _test_endpoint_with_token(trace_endpoint, token, expected_status):
     ), f"Expected /trace with token {token} to return {expected_status}, got {response.status_code}"
 
 
-def test_mlts_auth(ydb_cluster, client_certificates):
+def test_mtls_auth(ydb_cluster, client_certificates):
     host = ydb_cluster.nodes[1].host
     mon_port = ydb_cluster.nodes[1].mon_port
     base_url = f'https://{host}:{mon_port}'

--- a/ydb/tests/functional/security/test_mon_mtls_auth.py
+++ b/ydb/tests/functional/security/test_mon_mtls_auth.py
@@ -1,0 +1,318 @@
+# -*- coding: utf-8 -*-
+import copy
+import os
+import subprocess
+import tempfile
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.ssl_ import create_urllib3_context
+
+import pytest
+
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+
+
+class MTLSAdapter(HTTPAdapter):
+    """Custom HTTPAdapter that uses client certificates for mTLS"""
+
+    def __init__(self, cert_file, key_file, ca_file, *args, **kwargs):
+        self.cert_file = cert_file
+        self.key_file = key_file
+        self.ca_file = ca_file
+        super(MTLSAdapter, self).__init__(*args, **kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        ctx = create_urllib3_context()
+        ctx.load_verify_locations(cafile=self.ca_file)
+        ctx.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
+        kwargs['ssl_context'] = ctx
+        return super(MTLSAdapter, self).init_poolmanager(*args, **kwargs)
+
+
+def _generate_client_certificate(certs_tmp_dir, client_name, cn_value, ca_crt, ca_key):
+    client_key = os.path.join(certs_tmp_dir, f'{client_name}.key')
+    client_crt = os.path.join(certs_tmp_dir, f'{client_name}.crt')
+    client_csr = os.path.join(certs_tmp_dir, f'{client_name}.csr')
+
+    subprocess.run(['openssl', 'genrsa', '-out', client_key, '2048'], check=True, capture_output=True)
+    subprocess.run(
+        [
+            'openssl',
+            'req',
+            '-new',
+            '-key',
+            client_key,
+            '-out',
+            client_csr,
+            '-subj',
+            f'/CN={cn_value}/O=YDB/C=RU',
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            'openssl',
+            'x509',
+            '-req',
+            '-in',
+            client_csr,
+            '-CA',
+            ca_crt,
+            '-CAkey',
+            ca_key,
+            '-CAcreateserial',
+            '-out',
+            client_crt,
+            '-days',
+            '3650',
+            '-sha256',
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return client_key, client_crt
+
+
+def generate_certificates(certs_tmp_dir):
+    ca_key = os.path.join(certs_tmp_dir, 'server_ca.key')
+    ca_crt = os.path.join(certs_tmp_dir, 'server_ca.crt')
+
+    subprocess.run(['openssl', 'genrsa', '-out', ca_key, '2048'], check=True, capture_output=True)
+
+    subprocess.run(
+        [
+            'openssl',
+            'req',
+            '-x509',
+            '-new',
+            '-nodes',
+            '-key',
+            ca_key,
+            '-sha256',
+            '-days',
+            '3650',
+            '-out',
+            ca_crt,
+            '-subj',
+            '/CN=Monitoring CA/O=YDB/C=RU',
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    # Generate server certificate with localhost in SAN
+    server_key = os.path.join(certs_tmp_dir, 'server.key')
+    server_crt = os.path.join(certs_tmp_dir, 'server.crt')
+    server_csr = os.path.join(certs_tmp_dir, 'server.csr')
+    server_conf = os.path.join(certs_tmp_dir, 'server.conf')
+
+    subprocess.run(['openssl', 'genrsa', '-out', server_key, '2048'], check=True, capture_output=True)
+
+    # Create OpenSSL config file with v3_req section and SAN
+    with open(server_conf, 'w') as f:
+        f.write('[req]\n')
+        f.write('distinguished_name = req_distinguished_name\n')
+        f.write('req_extensions = v3_req\n')
+        f.write('\n')
+        f.write('[req_distinguished_name]\n')
+        f.write('\n')
+        f.write('[v3_req]\n')
+        f.write('subjectAltName=DNS:localhost,DNS:test-server,IP:127.0.0.1\n')
+
+    # Generate CSR
+    subprocess.run(
+        [
+            'openssl',
+            'req',
+            '-new',
+            '-key',
+            server_key,
+            '-out',
+            server_csr,
+            '-subj',
+            '/CN=test-server/O=YDB/C=RU',
+            '-config',
+            server_conf,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    # Generate server certificate signed by CA
+    subprocess.run(
+        [
+            'openssl',
+            'x509',
+            '-req',
+            '-in',
+            server_csr,
+            '-CA',
+            ca_crt,
+            '-CAkey',
+            ca_key,
+            '-CAcreateserial',
+            '-out',
+            server_crt,
+            '-days',
+            '3650',
+            '-sha256',
+            '-extensions',
+            'v3_req',
+            '-extfile',
+            server_conf,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    admin_client_key, admin_client_crt = _generate_client_certificate(
+        certs_tmp_dir, 'admin_client', 'administration_allowed', ca_crt, ca_key
+    )
+
+    viewer_client_key, viewer_client_crt = _generate_client_certificate(
+        certs_tmp_dir, 'viewer_client', 'viewer_client', ca_crt, ca_key
+    )
+
+    return {
+        'server_cert': server_crt,
+        'server_key': server_key,
+        'server_ca': ca_crt,
+        'admin_client_crt': admin_client_crt,
+        'admin_client_key': admin_client_key,
+        'viewer_client_crt': viewer_client_crt,
+        'viewer_client_key': viewer_client_key,
+    }
+
+
+CLUSTER_CONFIG = dict(
+    enforce_user_token_requirement=True,
+    default_clusteradmin='root@builtin',
+)
+
+
+@pytest.fixture(scope='module')
+def ydb_cluster_configuration():
+    conf = copy.deepcopy(CLUSTER_CONFIG)
+    return conf
+
+
+@pytest.fixture(scope='module')
+def certificates():
+    certs_tmp_dir = tempfile.mkdtemp(prefix='monitoring_certs_')
+    return generate_certificates(certs_tmp_dir)
+
+
+@pytest.fixture(scope='module')
+def client_certificates(certificates):
+    """Extract client certificates from certificates"""
+    return {
+        'admin_cert': certificates['admin_client_crt'],
+        'admin_key': certificates['admin_client_key'],
+        'viewer_cert': certificates['viewer_client_crt'],
+        'viewer_key': certificates['viewer_client_key'],
+        'ca': certificates['server_ca'],
+    }
+
+
+@pytest.fixture(scope='module')
+def ydb_configurator(ydb_cluster_configuration, certificates):
+    config_generator = KikimrConfigGenerator(**ydb_cluster_configuration)
+
+    config_generator.yaml_config['client_certificate_authorization'] = {
+        'client_certificate_definitions': [
+            {
+                'member_groups': ['AdministrationClientAuth@cert'],
+                'subject_terms': [{'short_name': 'CN', 'values': ['administration_allowed']}],
+            },
+            {
+                'member_groups': ['ViewerClientAuth@cert'],
+                'subject_terms': [{'short_name': 'CN', 'values': ['viewer_client']}],
+            },
+        ]
+    }
+
+    security_config = config_generator.yaml_config['domains_config']['security_config']
+
+    if 'administration_allowed_sids' not in security_config:
+        security_config['administration_allowed_sids'] = []
+    security_config['administration_allowed_sids'].append('AdministrationClientAuth@cert')
+    if 'monitoring_allowed_sids' not in security_config:
+        security_config['monitoring_allowed_sids'] = []
+    security_config['monitoring_allowed_sids'].append('AdministrationClientAuth@cert')
+
+    if 'grpc_config' not in config_generator.yaml_config:
+        config_generator.yaml_config['grpc_config'] = {}
+    config_generator.yaml_config['grpc_config']['cert'] = certificates['server_cert']
+    config_generator.yaml_config['grpc_config']['key'] = certificates['server_key']
+    config_generator.yaml_config['grpc_config']['ca'] = certificates['server_ca']
+
+    config_generator.monitoring_tls_cert_path = certificates['server_cert']
+    config_generator.monitoring_tls_key_path = certificates['server_key']
+    config_generator.monitoring_tls_ca_path = certificates['server_ca']
+
+    return config_generator
+
+
+def _test_endpoint_with_certificate(trace_endpoint, client_certificates, cert_type, expected_status):
+    session = requests.Session()
+    adapter = MTLSAdapter(
+        cert_file=client_certificates[f'{cert_type}_cert'],
+        key_file=client_certificates[f'{cert_type}_key'],
+        ca_file=client_certificates['ca'],
+    )
+    session.mount('https://', adapter)
+    response = session.get(trace_endpoint, verify=client_certificates['ca'], timeout=5)
+    assert (
+        response.status_code == expected_status
+    ), f"Expected /trace with {cert_type} cert to return {expected_status}, got {response.status_code}"
+
+
+def _test_endpoint_without_any_auth(trace_endpoint):
+    response = requests.get(trace_endpoint, timeout=5, verify=False)
+    assert (
+        response.status_code == 401
+    ), f"Expected /trace without auth to return 401, got {response.status_code}"
+
+
+def _test_endpoint_with_token(trace_endpoint, token, expected_status):
+    headers = {'Authorization': token}
+    response = requests.get(trace_endpoint, headers=headers, timeout=5, verify=False)
+    assert (
+        response.status_code == expected_status
+    ), f"Expected /trace with token {token} to return {expected_status}, got {response.status_code}"
+
+
+def test_mlts_auth(ydb_cluster, client_certificates):
+    host = ydb_cluster.nodes[1].host
+    mon_port = ydb_cluster.nodes[1].mon_port
+    base_url = f'https://{host}:{mon_port}'
+    trace_endpoint = f'{base_url}/trace'
+
+    # Without any authentication
+    _test_endpoint_without_any_auth(trace_endpoint)
+
+    # With viewer certificate
+    _test_endpoint_with_certificate(trace_endpoint, client_certificates, 'viewer', 403)
+
+    # With administration certificate
+    _test_endpoint_with_certificate(trace_endpoint, client_certificates, 'admin', 200)
+
+
+def test_token_auth_when_mtls_is_enabled(ydb_cluster, client_certificates):
+    host = ydb_cluster.nodes[1].host
+    mon_port = ydb_cluster.nodes[1].mon_port
+    base_url = f'https://{host}:{mon_port}'
+    trace_endpoint = f'{base_url}/trace'
+
+    # Checks that mTLS is enabled
+    _test_endpoint_with_certificate(trace_endpoint, client_certificates, 'admin', 200)
+
+    # Without any authentication
+    _test_endpoint_without_any_auth(trace_endpoint)
+
+    # With NOT an admin token
+    _test_endpoint_with_token(trace_endpoint, 'user@builtin', 403)
+
+    # With an admin token
+    _test_endpoint_with_token(trace_endpoint, 'root@builtin', 200)

--- a/ydb/tests/functional/security/ya.make
+++ b/ydb/tests/functional/security/ya.make
@@ -5,8 +5,9 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
 TEST_SRCS(
     conftest.py
     test_grants.py
-    test_paths_lookup.py
     test_mon_endpoints_auth.py
+    test_mon_mtls_auth.py
+    test_paths_lookup.py
 )
 
 SPLIT_FACTOR(20)

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -244,6 +244,7 @@ class KikimrConfigGenerator(object):
 
         self.monitoring_tls_cert_path = None
         self.monitoring_tls_key_path = None
+        self.monitoring_tls_ca_path = None
 
         self.__binary_paths = binary_paths
         rings_count = 3 if erasure == Erasure.MIRROR_3_DC else 1

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -256,6 +256,11 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
                 "--mon-key=%s" % self.__configurator.monitoring_tls_key_path
             )
 
+        if self.__configurator.monitoring_tls_ca_path is not None:
+            command.append(
+                "--mon-ca=%s" % self.__configurator.monitoring_tls_ca_path
+            )
+
         if os.environ.get("YDB_ALLOCATE_PGWIRE_PORT", "") == "true":
             command.append("--pgwire-port=%d" % self.pgwire_port)
 


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Добавлена возможность аутентификации в мониторинге по mTLS. Она включается указанием CA файла для мониторинга. Клиент при этом по-прежнему может не слать клиентский сертификат – ошибок не будет ни в запросе, ни в логах (это делается опцией инициализации SSL_VERIFY_PEER). Это сделано в первом коммите.

Во втором коммите добавлены юниттесты. 

В третьем коммите добавлены функциональные тесты на коды ответов с клиентским сертификатом (200/401/403) и на проверку того, что при указании CA файла мониторинга по-прежнему можно аутентифицироваться не только через mTLS.