### PR TITLE
Access levels in whoami

### DIFF
--- a/ydb/core/grpc_services/rpc_whoami.cpp
+++ b/ydb/core/grpc_services/rpc_whoami.cpp
@@ -45,7 +45,6 @@ private:
 
         // Add permission information (always returned)
         const auto* appData = AppData();
-        response->set_is_token_required(appData->EnforceUserTokenRequirement);
         bool isAdministrationAllowed = IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetAdministrationAllowedSIDs());
         bool isMonitoringAllowed = isAdministrationAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetMonitoringAllowedSIDs());
         bool isViewerAllowed = isMonitoringAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetViewerAllowedSIDs());

--- a/ydb/core/grpc_services/rpc_whoami.cpp
+++ b/ydb/core/grpc_services/rpc_whoami.cpp
@@ -49,10 +49,14 @@ private:
         bool isMonitoringAllowed = isAdministrationAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetMonitoringAllowedSIDs());
         bool isViewerAllowed = isMonitoringAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetViewerAllowedSIDs());
         bool isDatabaseAllowed = isViewerAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetDatabaseAllowedSIDs());
+        bool isRegisterNodeAllowed = IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetRegisterDynamicNodeAllowedSIDs());
+        bool isBootstrapAllowed = IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetBootstrapAllowedSIDs());
         response->set_is_administration_allowed(isAdministrationAllowed);
         response->set_is_monitoring_allowed(isMonitoringAllowed);
         response->set_is_viewer_allowed(isViewerAllowed);
         response->set_is_database_allowed(isDatabaseAllowed);
+        response->set_is_register_node_allowed(isRegisterNodeAllowed);
+        response->set_is_bootstrap_allowed(isBootstrapAllowed);
 
         Request->SendResult(*response, Ydb::StatusIds::SUCCESS);
     }

--- a/ydb/core/grpc_services/rpc_whoami.cpp
+++ b/ydb/core/grpc_services/rpc_whoami.cpp
@@ -41,19 +41,19 @@ private:
             for (const auto& group : userToken.GetGroupSIDs()) {
                 response->add_groups(group);
             }
-
-            // Add permission information
-            const auto* appData = AppData();
-            response->set_is_token_required(appData->EnforceUserTokenRequirement);
-            bool isAdministrationAllowed = IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetAdministrationAllowedSIDs());
-            bool isMonitoringAllowed = isAdministrationAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetMonitoringAllowedSIDs());
-            bool isViewerAllowed = isMonitoringAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetViewerAllowedSIDs());
-            bool isDatabaseAllowed = isViewerAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetDatabaseAllowedSIDs());
-            response->set_is_administration_allowed(isAdministrationAllowed);
-            response->set_is_monitoring_allowed(isMonitoringAllowed);
-            response->set_is_viewer_allowed(isViewerAllowed);
-            response->set_is_database_allowed(isDatabaseAllowed);
         }
+
+        // Add permission information (always returned)
+        const auto* appData = AppData();
+        response->set_is_token_required(appData->EnforceUserTokenRequirement);
+        bool isAdministrationAllowed = IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetAdministrationAllowedSIDs());
+        bool isMonitoringAllowed = isAdministrationAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetMonitoringAllowedSIDs());
+        bool isViewerAllowed = isMonitoringAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetViewerAllowedSIDs());
+        bool isDatabaseAllowed = isViewerAllowed || IsTokenAllowed(&userToken, appData->DomainsConfig.GetSecurityConfig().GetDatabaseAllowedSIDs());
+        response->set_is_administration_allowed(isAdministrationAllowed);
+        response->set_is_monitoring_allowed(isMonitoringAllowed);
+        response->set_is_viewer_allowed(isViewerAllowed);
+        response->set_is_database_allowed(isDatabaseAllowed);
 
         Request->SendResult(*response, Ydb::StatusIds::SUCCESS);
     }

--- a/ydb/public/api/protos/ydb_discovery.proto
+++ b/ydb/public/api/protos/ydb_discovery.proto
@@ -63,6 +63,16 @@ message WhoAmIResult {
     string user = 1;
     // List of group SIDs (Security IDs) for the user
     repeated string groups = 2;
+    // Whether user token is required for authentication
+    bool is_token_required = 3;
+    // Whether user is allowed to perform administration operations
+    bool is_administration_allowed = 4;
+    // Whether user is allowed to perform monitoring operations
+    bool is_monitoring_allowed = 5;
+    // Whether user is allowed to view data
+    bool is_viewer_allowed = 6;
+    // Whether user is allowed to access database
+    bool is_database_allowed = 7;
 }
 
 message WhoAmIResponse {

--- a/ydb/public/api/protos/ydb_discovery.proto
+++ b/ydb/public/api/protos/ydb_discovery.proto
@@ -71,6 +71,10 @@ message WhoAmIResult {
     bool is_viewer_allowed = 5;
     // Whether user is allowed to access database
     bool is_database_allowed = 6;
+    // Whether user is allowed to register dynamic node
+    bool is_register_node_allowed = 7;
+    // Whether user is allowed to bootstrap
+    bool is_bootstrap_allowed = 8;
 }
 
 message WhoAmIResponse {

--- a/ydb/public/api/protos/ydb_discovery.proto
+++ b/ydb/public/api/protos/ydb_discovery.proto
@@ -63,16 +63,14 @@ message WhoAmIResult {
     string user = 1;
     // List of group SIDs (Security IDs) for the user
     repeated string groups = 2;
-    // Whether user token is required for authentication
-    bool is_token_required = 3;
     // Whether user is allowed to perform administration operations
-    bool is_administration_allowed = 4;
+    bool is_administration_allowed = 3;
     // Whether user is allowed to perform monitoring operations
-    bool is_monitoring_allowed = 5;
+    bool is_monitoring_allowed = 4;
     // Whether user is allowed to view data
-    bool is_viewer_allowed = 6;
+    bool is_viewer_allowed = 5;
     // Whether user is allowed to access database
-    bool is_database_allowed = 7;
+    bool is_database_allowed = 6;
 }
 
 message WhoAmIResponse {

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -100,13 +100,13 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
             } else {
                 Cout << Endl << "User has no groups" << Endl;
             }
-        }
 
-        Cout << Endl << "Effective permissions:" << Endl;
-        Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
-        Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
-        Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
-        Cout << "Administration access allowed: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
+            Cout << Endl << "Effective permissions:" << Endl;
+            Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
+            Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
+            Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
+            Cout << "Administration access allowed: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
+        }
     }
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -100,14 +100,14 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
             } else {
                 Cout << Endl << "User has no groups" << Endl;
             }
-
-            Cout << Endl << "Effective permissions:" << Endl;
-            Cout << "Token required: " << (result.IsTokenRequired() ? "true" : "false") << Endl;
-            Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
-            Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
-            Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
-            Cout << "Administration access allowed: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
         }
+
+        Cout << Endl << "Effective permissions:" << Endl;
+        Cout << "Token required: " << (result.IsTokenRequired() ? "true" : "false") << Endl;
+        Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
+        Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
+        Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
+        Cout << "Administration access allowed: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
     }
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -101,11 +101,11 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
                 Cout << Endl << "User has no groups" << Endl;
             }
 
-        Cout << Endl << "Access level lists:" << Endl;
-        Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
-        Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
-        Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
-        Cout << "Administration access allowed: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
+        Cout << Endl << "Access levels:" << Endl;
+        Cout << "Database: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
+        Cout << "Viewer: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
+        Cout << "Monitoring: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
+        Cout << "Administration: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
         }
     }
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -101,11 +101,11 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
                 Cout << Endl << "User has no groups" << Endl;
             }
 
-            Cout << Endl << "Effective permissions:" << Endl;
-            Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
-            Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
-            Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
-            Cout << "Administration access allowed: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
+        Cout << Endl << "Access level lists:" << Endl;
+        Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
+        Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
+        Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
+        Cout << "Administration access allowed: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
         }
     }
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -100,6 +100,13 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
             } else {
                 Cout << Endl << "User has no groups" << Endl;
             }
+
+            Cout << Endl << "Effective permissions:" << Endl;
+            Cout << "Token required: " << (result.IsTokenRequired() ? "true" : "false") << Endl;
+            Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
+            Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
+            Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
+            Cout << "Administration access allowed: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
         }
     }
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -101,11 +101,18 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
                 Cout << Endl << "User has no groups" << Endl;
             }
 
-        Cout << Endl << "Access levels:" << Endl;
-        Cout << "Database: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
-        Cout << "Viewer: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
-        Cout << "Monitoring: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;
-        Cout << "Administration: " << (result.IsAdministrationAllowed() ? "true" : "false") << Endl;
+        bool hasAnyAccess = result.IsDatabaseAllowed() || result.IsViewerAllowed() ||
+            result.IsMonitoringAllowed() || result.IsAdministrationAllowed() ||
+            result.IsRegisterNodeAllowed() || result.IsBootstrapAllowed();
+        if (hasAnyAccess) {
+            Cout << Endl << "Access levels:" << Endl;
+            if (result.IsDatabaseAllowed()) Cout << "Database" << Endl;
+            if (result.IsViewerAllowed()) Cout << "Viewer" << Endl;
+            if (result.IsMonitoringAllowed()) Cout << "Monitoring" << Endl;
+            if (result.IsAdministrationAllowed()) Cout << "Administration" << Endl;
+            if (result.IsRegisterNodeAllowed()) Cout << "Register node" << Endl;
+            if (result.IsBootstrapAllowed()) Cout << "Bootstrap" << Endl;
+        }
         }
     }
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -70,16 +70,21 @@ TCommandWhoAmI::TCommandWhoAmI()
 
 void TCommandWhoAmI::Config(TConfig& config) {
     TYdbSimpleCommand::Config(config);
-    config.Opts->AddLongOption('g', "groups", "With groups").StoreTrue(&WithGroups);
-    config.Opts->AddLongOption('a', "access-levels", "With access levels").StoreTrue(&WithAccessLevels);
+    config.Opts->AddLongOption('g', "groups", "Show groups").StoreTrue(&WithGroups);
+    config.Opts->AddLongOption('l', "access-list", "Show access list").StoreTrue(&WithAccessList);
+    config.Opts->AddLongOption('a', "all", "Show all additional info (groups and access list)").StoreTrue(&WithAll);
     config.SetFreeArgsNum(0);
 }
 
 int TCommandWhoAmI::Run(TConfig& config) {
     auto driver = CreateDriver(config);
     NDiscovery::TDiscoveryClient client(driver);
+
+    // If --all is specified, enable both groups and access list
+    bool showGroups = WithGroups || WithAll;
+
     NDiscovery::TWhoAmIResult result = client.WhoAmI(
-        FillSettings(NDiscovery::TWhoAmISettings().WithGroups(WithGroups))
+        FillSettings(NDiscovery::TWhoAmISettings().WithGroups(showGroups))
     ).GetValueSync();
     NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
     PrintResponse(result);
@@ -91,7 +96,10 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
     const std::string& userName = result.GetUserName();
     if (!userName.empty()) {
         Cout << "User SID: " << userName << Endl;
-        if (WithGroups) {
+
+        // Show groups if --groups or --all is specified
+        bool showGroups = WithGroups || WithAll;
+        if (showGroups) {
             const std::vector<std::string>& groups = result.GetGroups();
             if (groups.size() > 0) {
                 Cout << Endl << "Group SIDs:" << Endl;
@@ -101,20 +109,22 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
             } else {
                 Cout << Endl << "User has no groups" << Endl;
             }
+        }
 
-            if (WithAccessLevels) {
-                bool hasAnyAccess = result.IsDatabaseAllowed() || result.IsViewerAllowed() ||
-                    result.IsMonitoringAllowed() || result.IsAdministrationAllowed() ||
-                    result.IsRegisterNodeAllowed() || result.IsBootstrapAllowed();
-                if (hasAnyAccess) {
-                    Cout << Endl << "Access levels:" << Endl;
-                    if (result.IsDatabaseAllowed()) Cout << "Database" << Endl;
-                    if (result.IsViewerAllowed()) Cout << "Viewer" << Endl;
-                    if (result.IsMonitoringAllowed()) Cout << "Monitoring" << Endl;
-                    if (result.IsAdministrationAllowed()) Cout << "Administration" << Endl;
-                    if (result.IsRegisterNodeAllowed()) Cout << "Register node" << Endl;
-                    if (result.IsBootstrapAllowed()) Cout << "Bootstrap" << Endl;
-                }
+        // Show access list if --access-list or --all is specified
+        bool showAccessList = WithAccessList || WithAll;
+        if (showAccessList) {
+            bool hasAnyAccess = result.IsDatabaseAllowed() || result.IsViewerAllowed() ||
+                result.IsMonitoringAllowed() || result.IsAdministrationAllowed() ||
+                result.IsRegisterNodeAllowed() || result.IsBootstrapAllowed();
+            if (hasAnyAccess) {
+                Cout << Endl << "Access levels:" << Endl;
+                if (result.IsDatabaseAllowed()) Cout << "Database" << Endl;
+                if (result.IsViewerAllowed()) Cout << "Viewer" << Endl;
+                if (result.IsMonitoringAllowed()) Cout << "Monitoring" << Endl;
+                if (result.IsAdministrationAllowed()) Cout << "Administration" << Endl;
+                if (result.IsRegisterNodeAllowed()) Cout << "Register node" << Endl;
+                if (result.IsBootstrapAllowed()) Cout << "Bootstrap" << Endl;
             }
         }
     }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -103,7 +103,6 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
         }
 
         Cout << Endl << "Effective permissions:" << Endl;
-        Cout << "Token required: " << (result.IsTokenRequired() ? "true" : "false") << Endl;
         Cout << "Database access allowed: " << (result.IsDatabaseAllowed() ? "true" : "false") << Endl;
         Cout << "Viewer access allowed: " << (result.IsViewerAllowed() ? "true" : "false") << Endl;
         Cout << "Monitoring access allowed: " << (result.IsMonitoringAllowed() ? "true" : "false") << Endl;

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -71,6 +71,7 @@ TCommandWhoAmI::TCommandWhoAmI()
 void TCommandWhoAmI::Config(TConfig& config) {
     TYdbSimpleCommand::Config(config);
     config.Opts->AddLongOption('g', "groups", "With groups").StoreTrue(&WithGroups);
+    config.Opts->AddLongOption('a', "access-levels", "With access levels").StoreTrue(&WithAccessLevels);
     config.SetFreeArgsNum(0);
 }
 
@@ -101,18 +102,20 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
                 Cout << Endl << "User has no groups" << Endl;
             }
 
-        bool hasAnyAccess = result.IsDatabaseAllowed() || result.IsViewerAllowed() ||
-            result.IsMonitoringAllowed() || result.IsAdministrationAllowed() ||
-            result.IsRegisterNodeAllowed() || result.IsBootstrapAllowed();
-        if (hasAnyAccess) {
-            Cout << Endl << "Access levels:" << Endl;
-            if (result.IsDatabaseAllowed()) Cout << "Database" << Endl;
-            if (result.IsViewerAllowed()) Cout << "Viewer" << Endl;
-            if (result.IsMonitoringAllowed()) Cout << "Monitoring" << Endl;
-            if (result.IsAdministrationAllowed()) Cout << "Administration" << Endl;
-            if (result.IsRegisterNodeAllowed()) Cout << "Register node" << Endl;
-            if (result.IsBootstrapAllowed()) Cout << "Bootstrap" << Endl;
-        }
+            if (WithAccessLevels) {
+                bool hasAnyAccess = result.IsDatabaseAllowed() || result.IsViewerAllowed() ||
+                    result.IsMonitoringAllowed() || result.IsAdministrationAllowed() ||
+                    result.IsRegisterNodeAllowed() || result.IsBootstrapAllowed();
+                if (hasAnyAccess) {
+                    Cout << Endl << "Access levels:" << Endl;
+                    if (result.IsDatabaseAllowed()) Cout << "Database" << Endl;
+                    if (result.IsViewerAllowed()) Cout << "Viewer" << Endl;
+                    if (result.IsMonitoringAllowed()) Cout << "Monitoring" << Endl;
+                    if (result.IsAdministrationAllowed()) Cout << "Administration" << Endl;
+                    if (result.IsRegisterNodeAllowed()) Cout << "Register node" << Endl;
+                    if (result.IsBootstrapAllowed()) Cout << "Bootstrap" << Endl;
+                }
+            }
         }
     }
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.h
@@ -35,6 +35,7 @@ private:
     void PrintResponse(NDiscovery::TWhoAmIResult& result);
 
     bool WithGroups = false;
+    bool WithAccessLevels = false;
 };
 
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.h
@@ -35,7 +35,8 @@ private:
     void PrintResponse(NDiscovery::TWhoAmIResult& result);
 
     bool WithGroups = false;
-    bool WithAccessLevels = false;
+    bool WithAccessList = false;
+    bool WithAll = false;
 };
 
 }

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
@@ -90,9 +90,19 @@ public:
     TWhoAmIResult(TStatus&& status, const Ydb::Discovery::WhoAmIResult& proto);
     const std::string& GetUserName() const;
     const std::vector<std::string>& GetGroups() const;
+    bool IsTokenRequired() const;
+    bool IsAdministrationAllowed() const;
+    bool IsMonitoringAllowed() const;
+    bool IsViewerAllowed() const;
+    bool IsDatabaseAllowed() const;
 private:
     std::string UserName_;
     std::vector<std::string> Groups_;
+    bool IsTokenRequired_ = false;
+    bool IsAdministrationAllowed_ = false;
+    bool IsMonitoringAllowed_ = false;
+    bool IsViewerAllowed_ = false;
+    bool IsDatabaseAllowed_ = false;
 };
 
 using TAsyncWhoAmIResult = NThreading::TFuture<TWhoAmIResult>;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
@@ -90,7 +90,6 @@ public:
     TWhoAmIResult(TStatus&& status, const Ydb::Discovery::WhoAmIResult& proto);
     const std::string& GetUserName() const;
     const std::vector<std::string>& GetGroups() const;
-    bool IsTokenRequired() const;
     bool IsAdministrationAllowed() const;
     bool IsMonitoringAllowed() const;
     bool IsViewerAllowed() const;
@@ -98,7 +97,6 @@ public:
 private:
     std::string UserName_;
     std::vector<std::string> Groups_;
-    bool IsTokenRequired_ = false;
     bool IsAdministrationAllowed_ = false;
     bool IsMonitoringAllowed_ = false;
     bool IsViewerAllowed_ = false;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
@@ -94,6 +94,8 @@ public:
     bool IsMonitoringAllowed() const;
     bool IsViewerAllowed() const;
     bool IsDatabaseAllowed() const;
+    bool IsRegisterNodeAllowed() const;
+    bool IsBootstrapAllowed() const;
 private:
     std::string UserName_;
     std::vector<std::string> Groups_;
@@ -101,6 +103,8 @@ private:
     bool IsMonitoringAllowed_ = false;
     bool IsViewerAllowed_ = false;
     bool IsDatabaseAllowed_ = false;
+    bool IsRegisterNodeAllowed_ = false;
+    bool IsBootstrapAllowed_ = false;
 };
 
 using TAsyncWhoAmIResult = NThreading::TFuture<TWhoAmIResult>;

--- a/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
+++ b/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
@@ -60,7 +60,6 @@ TWhoAmIResult::TWhoAmIResult(TStatus&& status, const Ydb::Discovery::WhoAmIResul
     for (const auto& group : groups) {
         Groups_.emplace_back(group);
     }
-    IsTokenRequired_ = proto.is_token_required();
     IsAdministrationAllowed_ = proto.is_administration_allowed();
     IsMonitoringAllowed_ = proto.is_monitoring_allowed();
     IsViewerAllowed_ = proto.is_viewer_allowed();
@@ -73,10 +72,6 @@ const std::string& TWhoAmIResult::GetUserName() const {
 
 const std::vector<std::string>& TWhoAmIResult::GetGroups() const {
     return Groups_;
-}
-
-bool TWhoAmIResult::IsTokenRequired() const {
-    return IsTokenRequired_;
 }
 
 bool TWhoAmIResult::IsAdministrationAllowed() const {

--- a/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
+++ b/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
@@ -60,6 +60,11 @@ TWhoAmIResult::TWhoAmIResult(TStatus&& status, const Ydb::Discovery::WhoAmIResul
     for (const auto& group : groups) {
         Groups_.emplace_back(group);
     }
+    IsTokenRequired_ = proto.is_token_required();
+    IsAdministrationAllowed_ = proto.is_administration_allowed();
+    IsMonitoringAllowed_ = proto.is_monitoring_allowed();
+    IsViewerAllowed_ = proto.is_viewer_allowed();
+    IsDatabaseAllowed_ = proto.is_database_allowed();
 }
 
 const std::string& TWhoAmIResult::GetUserName() const {
@@ -68,6 +73,26 @@ const std::string& TWhoAmIResult::GetUserName() const {
 
 const std::vector<std::string>& TWhoAmIResult::GetGroups() const {
     return Groups_;
+}
+
+bool TWhoAmIResult::IsTokenRequired() const {
+    return IsTokenRequired_;
+}
+
+bool TWhoAmIResult::IsAdministrationAllowed() const {
+    return IsAdministrationAllowed_;
+}
+
+bool TWhoAmIResult::IsMonitoringAllowed() const {
+    return IsMonitoringAllowed_;
+}
+
+bool TWhoAmIResult::IsViewerAllowed() const {
+    return IsViewerAllowed_;
+}
+
+bool TWhoAmIResult::IsDatabaseAllowed() const {
+    return IsDatabaseAllowed_;
 }
 
 TNodeLocation::TNodeLocation(const Ydb::Discovery::NodeLocation& location)

--- a/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
+++ b/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
@@ -64,6 +64,8 @@ TWhoAmIResult::TWhoAmIResult(TStatus&& status, const Ydb::Discovery::WhoAmIResul
     IsMonitoringAllowed_ = proto.is_monitoring_allowed();
     IsViewerAllowed_ = proto.is_viewer_allowed();
     IsDatabaseAllowed_ = proto.is_database_allowed();
+    IsRegisterNodeAllowed_ = proto.is_register_node_allowed();
+    IsBootstrapAllowed_ = proto.is_bootstrap_allowed();
 }
 
 const std::string& TWhoAmIResult::GetUserName() const {
@@ -88,6 +90,14 @@ bool TWhoAmIResult::IsViewerAllowed() const {
 
 bool TWhoAmIResult::IsDatabaseAllowed() const {
     return IsDatabaseAllowed_;
+}
+
+bool TWhoAmIResult::IsRegisterNodeAllowed() const {
+    return IsRegisterNodeAllowed_;
+}
+
+bool TWhoAmIResult::IsBootstrapAllowed() const {
+    return IsBootstrapAllowed_;
 }
 
 TNodeLocation::TNodeLocation(const Ydb::Discovery::NodeLocation& location)

--- a/ydb/services/ydb/ut/ya.make
+++ b/ydb/services/ydb/ut/ya.make
@@ -29,6 +29,7 @@ SRCS(
     ydb_ldap_login_ut.cpp
     ydb_login_ut.cpp
     ydb_object_storage_ut.cpp
+    ydb_whoami_ut.cpp
 )
 
 PEERDIR(
@@ -51,6 +52,7 @@ PEERDIR(
     ydb/public/lib/yson_value
     ydb/public/lib/ut_helpers
     ydb/public/lib/ydb_cli/commands
+    ydb/public/sdk/cpp/src/client/discovery
     ydb/public/sdk/cpp/src/client/draft
     ydb/public/sdk/cpp/src/client/coordination
     ydb/public/sdk/cpp/src/client/export

--- a/ydb/services/ydb/ydb_whoami_ut.cpp
+++ b/ydb/services/ydb/ydb_whoami_ut.cpp
@@ -75,7 +75,6 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
         // Verify groups are not returned when not requested
         UNIT_ASSERT_VALUES_EQUAL(result.GetGroups().size(), 0);
         // Permissions are always returned
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), false);
@@ -103,7 +102,7 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
         }
         UNIT_ASSERT_C(hasAllUsers, "Expected all-users@well-known group");
         // Permissions are always returned
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), false);
     }
 
     Y_UNIT_TEST(WhoAmIWithPermissions_NoPermissions) {
@@ -119,7 +118,6 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
         auto result = WhoAmI(grpc, "user1@builtin", true);
         UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
         UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), false);
@@ -136,7 +134,6 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
         auto result = WhoAmI(grpc, "user1@builtin", true);
         UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
         UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), false);
@@ -153,7 +150,6 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
         auto result = WhoAmI(grpc, "user1@builtin", true);
         UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
         UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), true);
@@ -171,7 +167,6 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
         auto result = WhoAmI(grpc, "user1@builtin", true);
         UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
         UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
         UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), true);
         // Monitoring implies viewer and database access
@@ -189,7 +184,6 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
         auto result = WhoAmI(grpc, "user1@builtin", true);
         UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
         UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), true);
         // Administration implies all other permissions
         UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), true);
@@ -205,7 +199,8 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
 
         auto result = WhoAmI(grpc, "user1@builtin", true);
         UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), false);
+        // With EnforceUserToken=false, user still gets database access (no token requirement)
+        UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), true);
     }
 
     Y_UNIT_TEST(WhoAmIWithoutGroups_PermissionsStillReturned) {
@@ -222,7 +217,6 @@ Y_UNIT_TEST_SUITE(TWhoAmI) {
         // Groups should be empty when not requested
         UNIT_ASSERT_VALUES_EQUAL(result.GetGroups().size(), 0);
         // Permissions are always returned regardless of groups flag
-        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), true);
         UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), true);

--- a/ydb/services/ydb/ydb_whoami_ut.cpp
+++ b/ydb/services/ydb/ydb_whoami_ut.cpp
@@ -1,0 +1,255 @@
+#include <library/cpp/testing/unittest/tests_data.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/core/base/storage_pools.h>
+#include <ydb/core/testlib/test_client.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h>
+
+#include "ydb_common_ut.h"
+
+namespace NKikimr {
+
+using namespace Tests;
+using namespace NYdb;
+
+namespace {
+
+struct TServerInitialization {
+    bool EnforceUserToken = true;
+    std::vector<TString> AdministrationAllowedSids = {};
+    std::vector<TString> MonitoringAllowedSids = {};
+    std::vector<TString> ViewerAllowedSids = {};
+    std::vector<TString> DatabaseAllowedSids = {};
+};
+
+NKikimrConfig::TAppConfig GetWhoAmIAppConfig(const TServerInitialization& serverInitialization) {
+    auto config = NKikimrConfig::TAppConfig();
+
+    auto& securityConfig = *config.MutableDomainsConfig()->MutableSecurityConfig();
+    securityConfig.SetEnforceUserTokenRequirement(serverInitialization.EnforceUserToken);
+
+    for (const auto& sid : serverInitialization.AdministrationAllowedSids) {
+        securityConfig.AddAdministrationAllowedSIDs(sid);
+    }
+    for (const auto& sid : serverInitialization.MonitoringAllowedSids) {
+        securityConfig.AddMonitoringAllowedSIDs(sid);
+    }
+    for (const auto& sid : serverInitialization.ViewerAllowedSids) {
+        securityConfig.AddViewerAllowedSIDs(sid);
+    }
+    for (const auto& sid : serverInitialization.DatabaseAllowedSids) {
+        securityConfig.AddDatabaseAllowedSIDs(sid);
+    }
+
+    return config;
+}
+
+NDiscovery::TWhoAmIResult WhoAmI(ui16 grpc, const TString& token, bool withGroups) {
+    TString location = TStringBuilder() << "localhost:" << grpc;
+    TDriverConfig config;
+    config.SetEndpoint(location);
+    config.SetAuthToken(token);
+    config.SetDatabase("/Root");
+    auto connection = NYdb::TDriver(config);
+    NYdb::NDiscovery::TDiscoveryClient discoveryClient = NYdb::NDiscovery::TDiscoveryClient(connection);
+    auto settings = NDiscovery::TWhoAmISettings().WithGroups(withGroups);
+    auto result = discoveryClient.WhoAmI(settings).GetValueSync();
+    connection.Stop(true);
+    return result;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TWhoAmI) {
+
+    Y_UNIT_TEST(WhoAmIBasic) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", false);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
+    }
+
+    Y_UNIT_TEST(WhoAmIWithGroups) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", true);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
+        // Check that we got groups (even if empty, the call should succeed)
+        auto groups = result.GetGroups();
+        // User might have groups or not, depending on setup
+    }
+
+    Y_UNIT_TEST(WhoAmIWithPermissions_NoPermissions) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true,
+            .AdministrationAllowedSids = {},
+            .MonitoringAllowedSids = {},
+            .ViewerAllowedSids = {},
+            .DatabaseAllowedSids = {}
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", true);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
+        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), false);
+    }
+
+    Y_UNIT_TEST(WhoAmIWithPermissions_DatabaseAllowed) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true,
+            .DatabaseAllowedSids = {"user1@builtin"}
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", true);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
+        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), true);
+    }
+
+    Y_UNIT_TEST(WhoAmIWithPermissions_ViewerAllowed) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true,
+            .ViewerAllowedSids = {"user1@builtin"}
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", true);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
+        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), true);
+        // Viewer implies database access
+        UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), true);
+    }
+
+    Y_UNIT_TEST(WhoAmIWithPermissions_MonitoringAllowed) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true,
+            .MonitoringAllowedSids = {"user1@builtin"}
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", true);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
+        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), true);
+        // Monitoring implies viewer and database access
+        UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), true);
+    }
+
+    Y_UNIT_TEST(WhoAmIWithPermissions_AdministrationAllowed) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true,
+            .AdministrationAllowedSids = {"user1@builtin"}
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", true);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
+        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), true);
+        // Administration implies all other permissions
+        UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), true);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), true);
+    }
+
+    Y_UNIT_TEST(WhoAmIWithPermissions_TokenNotRequired) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = false
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", true);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), false);
+    }
+
+    Y_UNIT_TEST(WhoAmIWithoutGroups_NoPermissions) {
+        // When withGroups is false, permission fields should not be populated
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true,
+            .AdministrationAllowedSids = {"user1@builtin"}
+        }));
+        ui16 grpc = server.GetPort();
+
+        auto result = WhoAmI(grpc, "user1@builtin", false);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+        UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "user1@builtin");
+        // Without groups flag, permissions should not be populated (all false)
+        UNIT_ASSERT_VALUES_EQUAL(result.IsTokenRequired(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), false);
+        UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), false);
+    }
+
+    Y_UNIT_TEST(WhoAmIWithPermissions_DifferentUser) {
+        TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuth> server(GetWhoAmIAppConfig({
+            .EnforceUserToken = true,
+            .AdministrationAllowedSids = {"admin@builtin"},
+            .ViewerAllowedSids = {"viewer@builtin"}
+        }));
+        ui16 grpc = server.GetPort();
+
+        // Test admin user
+        {
+            auto result = WhoAmI(grpc, "admin@builtin", true);
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+            UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "admin@builtin");
+            UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), true);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), true);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), true);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), true);
+        }
+
+        // Test viewer user
+        {
+            auto result = WhoAmI(grpc, "viewer@builtin", true);
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+            UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "viewer@builtin");
+            UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), true);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), true);
+        }
+
+        // Test regular user
+        {
+            auto result = WhoAmI(grpc, "regular@builtin", true);
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToOneLineString());
+            UNIT_ASSERT_STRINGS_EQUAL(result.GetUserName(), "regular@builtin");
+            UNIT_ASSERT_VALUES_EQUAL(result.IsAdministrationAllowed(), false);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsMonitoringAllowed(), false);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsViewerAllowed(), false);
+            UNIT_ASSERT_VALUES_EQUAL(result.IsDatabaseAllowed(), false);
+        }
+    }
+}
+
+} // namespace NKikimr


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added extended whoami output about [access level lists](https://ydb.tech/docs/en/reference/configuration/security_config?version=v25.2#security-access-levels).

New params:
`-l`, `--access-list`: show access lists
`-a`, `--all`: show all additional info (groups + access lists)

```
User SID: user@domain

Group SIDs:
group1@domain
group2@domain

Access levels:
Database
Viewer
```

Only access levels that are granted to the user are listed.

* **Database** (presence in `database_allowed_sids`):
Grants the right to access the web UI only as "database users": they can open the UI and see database-scoped data, but not cluster-wide data or cluster-level operations.

* **Viewer** (presence in `viewer_allowed_sids`):
Grants the right to access the web UI, without the ability to make changes.

* **Monitoring** (presence in `monitoring_allowed_sids`):
Grants the right to perform actions in the web UI that change the system state.

* **Administration** (presence in `administration_allowed_sids`):
Grants the right to perform administrative actions on databases or the cluster.

* **Register node** (presence in `register_dynamic_node_allowed_sids`):
Grants the right to register dynamic nodes with the cluster.

* **Bootstrap** (presence in `bootstrap_allowed_sids`):
Grants the right to perform bootstrap operations.

SIDs (user or group identifiers) are configured in the [cluster security config](https://ydb.tech/docs/en/reference/configuration/security_config?version=v25.2) (`TSecurityConfig` in `config.proto`).



### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
