### PR TITLE
Fix timeout values in Go example

### DIFF
--- a/ydb/docs/en/core/dev/timeouts.md
+++ b/ydb/docs/en/core/dev/timeouts.md
@@ -78,16 +78,17 @@ Timeout usage example:
   ```go
   import (
     "context"
+    "time"
 
     ydb "github.com/ydb-platform/ydb-go-sdk/v3"
     "github.com/ydb-platform/ydb-go-sdk/v3/table"
   )
 
   func executeInTx(ctx context.Context, s table.Session, query string) {
-  ctx, cancel := context.WithTimeout(ctx, time.Millisecond*300) // client and by default operation timeout
+  ctx, cancel := context.WithTimeout(ctx, time.Millisecond*500) // transport timeout
   defer cancel()
-  ctx = ydb.WithOperationTimeout(ctx, time.Millisecond*400)     // operation timeout override
-  ctx = ydb.WithOperationCancelAfter(ctx, time.Millisecond*300) // cancel after timeout
+  ctx = ydb.WithOperationTimeout(ctx, time.Millisecond*400)     // operation timeout
+  ctx = ydb.WithOperationCancelAfter(ctx, time.Millisecond*400) // cancel after timeout
   tx := table.TxControl(table.BeginTx(table.WithSerializableReadWrite()), table.CommitTx())
   _, res, err := s.Execute(ctx, tx, query, table.NewQueryParameters())
   }

--- a/ydb/docs/ru/core/dev/timeouts.md
+++ b/ydb/docs/ru/core/dev/timeouts.md
@@ -89,16 +89,17 @@
   ```go
   import (
     "context"
+    "time"
 
     ydb "github.com/ydb-platform/ydb-go-sdk/v3"
     "github.com/ydb-platform/ydb-go-sdk/v3/table"
   )
 
   func executeInTx(ctx context.Context, s table.Session, query string) {
-  ctx, cancel := context.WithTimeout(ctx, time.Millisecond*300) // client and by default operation timeout
+  ctx, cancel := context.WithTimeout(ctx, time.Millisecond*500) // transport timeout
   defer cancel()
-  ctx = ydb.WithOperationTimeout(ctx, time.Millisecond*400)     // operation timeout override
-  ctx = ydb.WithOperationCancelAfter(ctx, time.Millisecond*300) // cancel after timeout
+  ctx = ydb.WithOperationTimeout(ctx, time.Millisecond*400)     // operation timeout
+  ctx = ydb.WithOperationCancelAfter(ctx, time.Millisecond*400) // cancel after timeout
   tx := table.TxControl(table.BeginTx(table.WithSerializableReadWrite()), table.CommitTx())
   _, res, err := s.Execute(ctx, tx, query, table.NewQueryParameters())
   }


### PR DESCRIPTION
## Changelog
Bugfix: Fixed incorrect timeout values in Go example for timeouts documentation

## Description
Fixed incorrect timeout values in Go example for timeouts documentation:
- Changed transport timeout from 300ms to 500ms (should be 50-100ms more than operation timeout)
- Changed cancel_after from 300ms to 400ms (should match operation timeout)
- Added missing 'time' import

Applied fixes to both Russian and English versions.

## Category
Bugfix