### PR TITLE
Add TRUNCATE TABLE implementation for tables with vector indexes

### DIFF
--- a/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
@@ -222,27 +222,54 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         return session;
     }
 
-    TSession DoCreateTableForVectorIndex(TTableClient& db, int flags = 0) {
-        const char* dataCol = flags & F_UNDERSCORE_DATA ? "___data" : "data";
-        auto session = DoOnlyCreateTableForVectorIndex(db, flags);
-        {
-            const TString query1 = TStringBuilder()
-                << "UPSERT INTO `/Root/TestTable` (pk, emb, " << dataCol << ") VALUES "
-                << "(0, \"\x03\x30\x02\", \"0\"),"
-                    "(1, \"\x13\x31\x02\", \"1\"),"
-                    "(2, \"\x23\x32\x02\", \"2\"),"
-                    "(3, \"\x53\x33\x02\", \"3\"),"
-                    "(4, \"\x43\x34\x02\", \"4\"),"
-                    "(5, \"\x50\x60\x02\", \"5\"),"
-                    "(6, \"\x61\x11\x02\", \"6\"),"
-                    "(7, \"\x12\x62\x02\", \"7\"),"
-                    "(8, \"\x75\x76\x02\", \"8\"),"
-                    "(9, \"\x76\x76\x02\", \"9\");";
+    void DoTruncateTable(TSession& session) {
+        const TString truncateTable(Q_(R"(
+            TRUNCATE TABLE `/Root/TestTable`;
+        )"));
 
-            auto result = session.ExecuteDataQuery(Q_(query1), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
-                .ExtractValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        }
+        auto result = session.ExecuteSchemeQuery(truncateTable).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
+
+    bool IsTableEmpty(TSession& session, const TString& tablePath) {
+        TString query = Sprintf(R"(
+            SELECT COUNT(*) FROM `%s`;
+        )"
+        , tablePath.c_str());
+
+        auto result = session.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        auto resultSet = result.GetResultSet(0);
+        TResultSetParser parser(resultSet);
+        UNIT_ASSERT(parser.TryNextRow());
+        auto count = parser.ColumnParser(0).GetUint64();
+        return count == 0;
+    }
+
+    void DoOnlyUpsertValuesIntoTable(TSession& session, int flags = 0) {
+        const char* dataCol = flags & F_UNDERSCORE_DATA ? "___data" : "data";
+        const TString query1 = TStringBuilder()
+            << "UPSERT INTO `/Root/TestTable` (pk, emb, " << dataCol << ") VALUES "
+            << "(0, \"\x03\x30\x02\", \"0\"),"
+                "(1, \"\x13\x31\x02\", \"1\"),"
+                "(2, \"\x23\x32\x02\", \"2\"),"
+                "(3, \"\x53\x33\x02\", \"3\"),"
+                "(4, \"\x43\x34\x02\", \"4\"),"
+                "(5, \"\x50\x60\x02\", \"5\"),"
+                "(6, \"\x61\x11\x02\", \"6\"),"
+                "(7, \"\x12\x62\x02\", \"7\"),"
+                "(8, \"\x75\x76\x02\", \"8\"),"
+                "(9, \"\x76\x76\x02\", \"9\");";
+
+        auto result = session.ExecuteDataQuery(Q_(query1), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+            .ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
+
+    TSession DoCreateTableForVectorIndex(TTableClient& db, int flags = 0) {
+        auto session = DoOnlyCreateTableForVectorIndex(db, flags);
+        DoOnlyUpsertValuesIntoTable(session, flags);
         return session;
     }
 
@@ -1266,6 +1293,48 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         }
     }
 
+    Y_UNIT_TEST_QUAD(VectorIndexTruncateTable, Covered, Overlap) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableTruncateTable(true);
+        auto serverSettings = TKikimrSettings().SetFeatureFlags(featureFlags);
+        TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        const int flags = F_NULLABLE | (Covered ? F_COVERING : 0) | (Overlap ? F_OVERLAP : 0);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForVectorIndex(db, flags);
+
+        {
+            const TString createIndex(Q_(Sprintf(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (emb)%s
+                    WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=1, clusters=2%s);
+                )",
+                (flags & F_COVERING ? " COVER (data, emb)" : ""),
+                (flags & F_OVERLAP ? ", overlap_clusters=2" : ""))));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                            .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        DoPositiveQueriesVectorIndexOrderByCosine(session);
+
+        UNIT_ASSERT(!IsTableEmpty(session, "/Root/TestTable"));
+        UNIT_ASSERT(!IsTableEmpty(session, "/Root/TestTable/index/indexImplPostingTable"));
+        UNIT_ASSERT(!IsTableEmpty(session, "/Root/TestTable/index/indexImplLevelTable"));
+        DoTruncateTable(session);
+        UNIT_ASSERT(IsTableEmpty(session, "/Root/TestTable"));
+        UNIT_ASSERT(IsTableEmpty(session, "/Root/TestTable/index/indexImplPostingTable"));
+        UNIT_ASSERT(!IsTableEmpty(session, "/Root/TestTable/index/indexImplLevelTable"));
+
+        DoOnlyUpsertValuesIntoTable(session);
+        DoPositiveQueriesVectorIndexOrderByCosine(session);
+    }
 }
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
@@ -395,14 +395,15 @@ bool DfsOnTableChildrenTree(TOperationId opId, const TTxTransaction& tx, TOperat
                                 return false;
                             }
                             case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree: {
-                                size_t numberOfChildren = srcChildPath.Base()->GetChildren().size();
-                                Y_ABORT_UNLESS(numberOfChildren == 2 || numberOfChildren == 3);
+                                const auto& index = context.SS->Indexes.at(childPathId);
+                                bool isGlobalVectorIndex = index->IndexKeys.size() == 1;
+                                bool isPrefixVectorIndex = index->IndexKeys.size() > 1;
 
-                                if (numberOfChildren == 2) { // GlobalVectorIndex contains two implTables
+                                if (isGlobalVectorIndex) { // GlobalVectorIndex contains two implTables
                                     if (!DfsOnTableChildrenTree(opId, tx, context, childPathId, result, ESchemeObjectType::GlobalVectorIndex)) {
                                         return false;
                                     }
-                                } else if (numberOfChildren == 3) { // PrefixVectorIndex contains three implTables
+                                } else if (isPrefixVectorIndex) { // PrefixVectorIndex contains three implTables
                                     if (!DfsOnTableChildrenTree(opId, tx, context, childPathId, result, ESchemeObjectType::PrefixVectorIndex)) {
                                         return false;
                                     }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds the ability to run TRUNCATE TABLE on tables that have global vector index and prefix vector index.