### PR TITLE
Migrate ydb config profile commands to ftxui interactive UI

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Improved the `ydb init` and `ydb config profile` commands with interactive menus.
 * Added download progress bar to the `ydb update` command.
 * Improved progress bars: consistent MiB/GiB units, stable speed display, dual progress bar for the `ydb import file` command showing both in-progress and confirmed bytes.
 * Interactive mode enhancements:

--- a/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
@@ -164,6 +164,8 @@ namespace {
         if (*newValue) {
             PutAuthMethod(profile, id, *newValue);
             Cout << "Saved " << fullName << " for profile \"" << profileName << "\"." << Endl;
+        } else {
+            Cout << "Empty value not saved." << Endl;
         }
     }
 
@@ -187,6 +189,8 @@ namespace {
             } else {
                 Cout << "Saved credentials for profile \"" << profileName << "\"." << Endl;
             }
+        } else {
+            Cout << "Empty username not saved." << Endl;
         }
     }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
@@ -1,6 +1,7 @@
 #include "ydb_profile.h"
 
 #include <ydb/public/lib/ydb_cli/common/colors.h>
+#include <ydb/public/lib/ydb_cli/common/ftxui.h>
 #include <ydb/public/lib/ydb_cli/common/interactive.h>
 #include <ydb/public/lib/ydb_cli/common/print_utils.h>
 
@@ -52,45 +53,76 @@ namespace {
         return std::string(in.length(), '*');
     }
 
-    void SetupProfileName(TString& profileName, std::shared_ptr<IProfileManager> profileManager, bool verbose) {
+    void SetupProfileName(TString& profileName, std::shared_ptr<IProfileManager> profileManager) {
         if (profileName) {
             return;
         }
 
         const auto profileNames = profileManager->ListProfiles();
-        if (!profileNames) {
+        if (profileNames.empty()) {
             Cout << "You have no existing profiles yet." << Endl;
-            profileName = AskAnyInputWithPrompt("Please enter name for a new profile: ", verbose);
-        }
-
-        Cout << "Please choose profile to configure:" << Endl;
-        TNumericOptionsPicker picker(verbose);
-        picker.AddInputOption(
-            "Create a new profile",
-            "Please enter name for a new profile: ",
-            [&profileName](const TString& input) {
-                profileName = input;
-            }
-        );
-
-        const auto& colors = NConsoleClient::AutoColors(Cout);
-        const auto& activeProfileName = profileManager->GetActiveProfileName();
-        for (size_t i = 0; i < profileNames.size(); ++i) {
-            TStringBuilder description;
-            TString currentProfile = profileNames[i];
-            description << currentProfile;
-            if (currentProfile == activeProfileName) {
-                description << " (" << colors.Green() << "active" << colors.OldColor() << ")";
-            }
-            picker.AddOption(
-                description,
-                [&profileName, currentProfile]() {
-                    profileName = currentProfile;
+            auto result = RunFtxuiInput(
+                "Please enter name for a new profile",
+                "",
+                [](const TString& input, TString& error) {
+                    if (input.empty()) {
+                        error = "Profile name cannot be empty";
+                        return false;
+                    }
+                    return true;
                 }
             );
+            if (result) {
+                profileName = *result;
+            } else {
+                Cout << "Cancelled." << Endl;
+                exit(EXIT_SUCCESS);
+            }
+            return;
         }
 
-        picker.PickOptionAndDoAction();
+        // Build menu options
+        std::vector<TString> options;
+        options.push_back("Create a new profile");
+
+        const auto& activeProfileName = profileManager->GetActiveProfileName();
+        for (const auto& name : profileNames) {
+            TStringBuilder description;
+            description << name;
+            if (name == activeProfileName) {
+                description << "\t(active)";
+            }
+            options.push_back(description);
+        }
+
+        auto selectedIdx = RunFtxuiMenu("Please choose profile to configure", options);
+        if (!selectedIdx) {
+            Cout << "Cancelled." << Endl;
+            exit(EXIT_SUCCESS);
+        }
+
+        if (*selectedIdx == 0) {
+            // Create a new profile
+            auto result = RunFtxuiInput(
+                "Please enter name for a new profile",
+                "",
+                [](const TString& input, TString& error) {
+                    if (input.empty()) {
+                        error = "Profile name cannot be empty";
+                        return false;
+                    }
+                    return true;
+                }
+            );
+            if (result) {
+                profileName = *result;
+            } else {
+                Cout << "Cancelled." << Endl;
+                exit(EXIT_SUCCESS);
+            }
+        } else {
+            profileName = profileNames[*selectedIdx - 1];
+        }
     }
 
     void PutAuthMethod(std::shared_ptr<IProfile> profile, const TString& id, const TString& value) {
@@ -123,19 +155,34 @@ namespace {
     }
 
     void SetAuthMethod(const TString& id, const TString& fullName, std::shared_ptr<IProfile> profile, const TString& profileName) {
-        if (auto newValue = AskAnyInputWithPrompt(TStringBuilder() << "Please enter " << fullName << " (" << id << "): ")) {
-            Cout << "Setting " << fullName << " for profile \"" << profileName << "\"" << Endl;
-            PutAuthMethod( profile, id, newValue );
+        TString title = TStringBuilder() << "Please enter " << fullName << " (" << id << ")";
+        auto newValue = RunFtxuiInput(title);
+        if (!newValue) {
+            Cout << "Cancelled." << Endl;
+            return;
+        }
+        if (*newValue) {
+            PutAuthMethod(profile, id, *newValue);
+            Cout << "Saved " << fullName << " for profile \"" << profileName << "\"." << Endl;
         }
     }
 
     void SetStaticCredentials(std::shared_ptr<IProfile> profile, const TString& profileName) {
-        TString userName = AskAnyInputWithPrompt("Please enter user name: ");
-        Cout << "Please enter password: ";
-        TString userPassword = InputPassword();
-        if (userName) {
-            Cout << "Setting user & password for profile \"" << profileName << "\"" << Endl;
-            PutAuthStatic(profile, userName, userPassword, false);
+        auto userName = RunFtxuiInput("Please enter user name");
+        if (!userName) {
+            Cout << "Cancelled." << Endl;
+            return;
+        }
+
+        auto userPassword = RunFtxuiPasswordInput("Please enter password");
+        if (!userPassword) {
+            Cout << "Cancelled." << Endl;
+            return;
+        }
+
+        if (*userName) {
+            PutAuthStatic(profile, *userName, *userPassword, false);
+            Cout << "Saved credentials for profile \"" << profileName << "\"." << Endl;
         }
     }
 
@@ -304,7 +351,7 @@ int TCommandInit::Run(TConfig& config) {
     Cout << "Welcome! This command will take you through the configuration process." << Endl;
     auto profileManager = CreateProfileManager(config.ProfileFile);
     TString profileName;
-    SetupProfileName(profileName, profileManager, config.IsVerbose());
+    SetupProfileName(profileName, profileManager);
     ConfigureProfile(profileName, profileManager, config, /* interactive */ true, /* cmdLine */ false);
     return EXIT_SUCCESS;
 }
@@ -390,8 +437,8 @@ void TCommandProfileCommon::ConfigureProfile(const TString& profileName, std::sh
     bool existingProfile = profileManager->HasProfile(profileName);
     auto profile = profileManager->GetProfile(profileName);
     if (interactive) {
-        Cout << "Configuring " << (existingProfile ? "existing" : "new")
-             << " profile \"" << profileName << "\"." << Endl;
+        Cout << Endl << (existingProfile ? "Updating" : "Creating")
+             << " profile \"" << profileName << "\"..." << Endl;
     }
     SetupProfileSetting("endpoint", Endpoint, existingProfile, profileName, profile, interactive, cmdLine, config.IsVerbose());
     SetupProfileSetting("database", Database, existingProfile, profileName, profile, interactive, cmdLine, config.IsVerbose());
@@ -412,25 +459,26 @@ void TCommandProfileCommon::ConfigureProfile(const TString& profileName, std::sh
     if (interactive) {
         TString activeProfileName = profileManager->GetActiveProfileName();
         if (profileName != activeProfileName) {
-            auto query = TStringBuilder() << Endl << "Activate profile \"" << profileName << "\" to use by default? (current active profile is ";
+            TStringBuilder query;
+            query << "Activate profile \"" << profileName << "\" to use by default? (current active profile is ";
             TString currentActiveProfile = profileManager->GetActiveProfileName();
             if (currentActiveProfile) {
                 query << "\"" << currentActiveProfile << "\"";
             } else {
                 query << "not set";
             }
-            query << ") y/n: ";
-            if (AskYesOrNo(query)) {
+            query << ")";
+            if (AskYesNoFtxui(query, /* defaultAnswer */ true)) {
                 profileManager->SetActiveProfile(profileName);
-                Cout << "Profile \"" << profileName << "\" was set as active." << Endl;
+                Cout << "Profile \"" << profileName << "\" is now active." << Endl;
             }
         }
-        Cout << "Configuration process for profile \"" << profileName << "\" is complete." << Endl;
+        Cout << "Profile \"" << profileName << "\" configured successfully." << Endl;
     }
 }
 
 void TCommandProfileCommon::SetupProfileSetting(const TString& name, const TString& value, bool existingProfile, const TString& profileName,
-    std::shared_ptr<IProfile> profile, bool interactive, bool cmdLine, bool verbose)
+    std::shared_ptr<IProfile> profile, bool interactive, bool cmdLine, bool /* verbose */)
 {
     if (cmdLine) {
         if (value) {
@@ -442,33 +490,44 @@ void TCommandProfileCommon::SetupProfileSetting(const TString& name, const TStri
         return;
     }
 
-    Cout << Endl << "Pick desired action to configure " << name << " in profile \"" << profileName << "\":" << Endl;
-
-    TNumericOptionsPicker picker(verbose);
-    picker.AddInputOption(
-        TStringBuilder() << "Set a new " << name << " value",
-        TStringBuilder() << "Please enter new " << name << " value: ",
-        [&name, &profileName, &profile](const TString& input) {
-            if (input) {
-                Cout << "Setting " << name << " value \"" << input << "\" for profile \"" << profileName
-                        << "\"" << Endl;
-                profile->SetValue(name, input);
-            }
-        }
-    );
-    picker.AddOption(
-        TStringBuilder() << "Don't save " << name << " for profile \"" << profileName << "\"",
-        [&name, &profile]() {
-            profile->RemoveValue(name);
-        }
-    );
+    // Build menu options
+    std::vector<TString> options;
+    options.push_back(TStringBuilder() << "Set a new " << name << " value");
+    options.push_back(TStringBuilder() << "Don't save " << name);
     if (existingProfile && profile->Has(name)) {
-        picker.AddOption(
-            TStringBuilder() << "Use current " << name << " value \"" << profile->GetValue(name).as<TString>() << "\"",
-            []() {}
-        );
+        options.push_back(TStringBuilder() << "Use current " << name << " value\t" << profile->GetValue(name).as<TString>());
     }
-    picker.PickOptionAndDoAction();
+
+    TString title = TStringBuilder() << "Pick desired action to configure " << name << " in profile \"" << profileName << "\"";
+    auto selectedIdx = RunFtxuiMenu(title, options);
+    if (!selectedIdx) {
+        Cout << "Cancelled." << Endl;
+        exit(EXIT_SUCCESS);
+    }
+
+    switch (*selectedIdx) {
+        case 0: {
+            // Set a new value
+            TString inputTitle = TStringBuilder() << "Please enter new " << name << " value";
+            auto input = RunFtxuiInput(inputTitle);
+            if (!input) {
+                Cout << "Cancelled." << Endl;
+                exit(EXIT_SUCCESS);
+            }
+            if (*input) {
+                profile->SetValue(name, *input);
+                Cout << "Saved " << name << " \"" << *input << "\" for profile \"" << profileName << "\"." << Endl;
+            }
+            break;
+        }
+        case 1:
+            // Don't save
+            profile->RemoveValue(name);
+            break;
+        case 2:
+            // Use current value - do nothing
+            break;
+    }
 }
 
 void TCommandProfileCommon::SetupProfileAuthentication(bool existingProfile, const TString& profileName, std::shared_ptr<IProfile> profile,
@@ -482,92 +541,85 @@ void TCommandProfileCommon::SetupProfileAuthentication(bool existingProfile, con
     if (!interactive) {
         return;
     }
-    Cout << Endl << "Pick desired action to configure authentication method:" << Endl;
-    TNumericOptionsPicker picker(config.IsVerbose());
+
+    // Build menu options with corresponding actions
+    std::vector<TString> options;
+    std::vector<std::function<void()>> actions;
+
     if (config.UseStaticCredentials) {
-        picker.AddOption(
-            "Use static credentials (user & password)",
-            [&profile, &profileName]() {
-                SetStaticCredentials(profile, profileName);
-            }
-        );
+        options.push_back("Use static credentials\t(user & password)");
+        actions.push_back([&profile, &profileName]() {
+            SetStaticCredentials(profile, profileName);
+        });
     }
     if (config.UseIamAuth) {
-        picker.AddOption(
-            "Use IAM token (iam-token) cloud.yandex.ru/docs/iam/concepts/authorization/iam-token",
-            [&profile, &profileName]() {
-                SetAuthMethod("iam-token", "IAM token", profile, profileName);
-            }
-        );
-        picker.AddOption(
-            "Use OAuth token of a Yandex Passport user (yc-token). Doesn't work with federative accounts."
-            " cloud.yandex.ru/docs/iam/concepts/authorization/oauth-token",
-            [&profile, &profileName]() {
-                SetAuthMethod("yc-token", "OAuth token of a Yandex Passport user", profile, profileName);
-            }
-        );
-        picker.AddOption(
-            "Use OAuth 2.0 RFC8693 token exchange credentials parameters json file.",
-            [&profile, &profileName]() {
-                SetAuthMethod("oauth2-key-file", "OAuth 2.0 RFC8693 token exchange credentials parameters json file", profile, profileName);
-            }
-        );
-        picker.AddOption(
-            "Use metadata service on a virtual machine (use-metadata-credentials)"
-            " cloud.yandex.ru/docs/compute/operations/vm-connect/auth-inside-vm",
-            [&profile, &profileName]() {
-                Cout << "Setting metadata service usage for profile \"" << profileName << "\"" << Endl;
-                PutAuthMethodWithoutPars(profile, "use-metadata-credentials");
-            }
-        );
-        picker.AddOption(
-            "Use service account key file (sa-key-file)"
-            " cloud.yandex.ru/docs/iam/operations/iam-token/create-for-sa",
-            [&profile, &profileName]() {
-                SetAuthMethod("sa-key-file", "Path to service account key file", profile, profileName);
-            }
-        );
+        options.push_back("Use IAM token\t(iam-token) cloud.yandex.ru/docs/iam/concepts/authorization/iam-token");
+        actions.push_back([&profile, &profileName]() {
+            SetAuthMethod("iam-token", "IAM token", profile, profileName);
+        });
+
+        options.push_back("Use OAuth token of a Yandex Passport user\t(yc-token) cloud.yandex.ru/docs/iam/concepts/authorization/oauth-token");
+        actions.push_back([&profile, &profileName]() {
+            SetAuthMethod("yc-token", "OAuth token of a Yandex Passport user", profile, profileName);
+        });
+
+        options.push_back("Use OAuth 2.0 token exchange credentials\t(oauth2-key-file)");
+        actions.push_back([&profile, &profileName]() {
+            SetAuthMethod("oauth2-key-file", "OAuth 2.0 RFC8693 token exchange credentials parameters json file", profile, profileName);
+        });
+
+        options.push_back("Use metadata service on a virtual machine\t(use-metadata-credentials) cloud.yandex.ru/docs/compute/operations/vm-connect/auth-inside-vm");
+        actions.push_back([&profile, &profileName]() {
+            PutAuthMethodWithoutPars(profile, "use-metadata-credentials");
+            Cout << "Metadata service authentication enabled for profile \"" << profileName << "\"." << Endl;
+        });
+
+        options.push_back("Use service account key file\t(sa-key-file) cloud.yandex.ru/docs/iam/operations/iam-token/create-for-sa");
+        actions.push_back([&profile, &profileName]() {
+            SetAuthMethod("sa-key-file", "Path to service account key file", profile, profileName);
+        });
     }
     if (config.UseAccessToken) {
-        picker.AddOption(
-            "Set new access token (ydb-token)",
-            [&profile, &profileName]() {
-                SetAuthMethod("ydb-token", "YDB token", profile, profileName);
-            }
-        );
+        options.push_back("Set new access token\t(ydb-token)");
+        actions.push_back([&profile, &profileName]() {
+            SetAuthMethod("ydb-token", "YDB token", profile, profileName);
+        });
     }
-    picker.AddOption(
-        TStringBuilder() << "Set anonymous authentication for profile \"" << profileName << "\"",
-        [&profile, &profileName]() {
-            Cout << "Setting anonymous authentication method for profile \"" << profileName << "\"" << Endl;
-            PutAuthMethodWithoutPars(profile, "anonymous-auth");
-        }
-    );
-    picker.AddOption(
-        TStringBuilder() << "Don't save authentication data for profile (environment variables can be used) \"" << profileName << "\"",
-        [&profile]() {
-            profile->RemoveValue(AuthNode);
-        }
-    );
+
+    options.push_back("Set anonymous authentication");
+    actions.push_back([&profile, &profileName]() {
+        PutAuthMethodWithoutPars(profile, "anonymous-auth");
+        Cout << "Anonymous authentication enabled for profile \"" << profileName << "\"." << Endl;
+    });
+
+    options.push_back("Don't save authentication data\t(environment variables can be used)");
+    actions.push_back([&profile]() {
+        profile->RemoveValue(AuthNode);
+    });
+
     if (existingProfile && profile->Has(AuthNode)) {
         auto& authValue = profile->GetValue(AuthNode);
         if (authValue["method"]) {
             TString method = authValue["method"].as<TString>();
             TStringBuilder description;
-            description << "Use current settings with method \"" << method << "\"";
+            description << "Use current settings\t" << method;
             if (method == "iam-token" || method == "yc-token" || method == "ydb-token") {
-                description << " and value \"" << BlurSecret(authValue["data"].as<TString>()) << "\"";
+                description << ": " << BlurSecret(authValue["data"].as<TString>());
             } else if (method == "sa-key-file" || method == "token-file" || method == "yc-token-file" || method == "oauth2-key-file") {
-                description << " and value \"" << authValue["data"].as<TString>() << "\"";
+                description << ": " << authValue["data"].as<TString>();
             }
-            picker.AddOption(
-                description,
-                []() {}
-            );
+            options.push_back(description);
+            actions.push_back([]() {});
         }
     }
 
-    picker.PickOptionAndDoAction();
+    auto selectedIdx = RunFtxuiMenu("Pick desired action to configure authentication method", options);
+    if (!selectedIdx) {
+        Cout << "Cancelled." << Endl;
+        exit(EXIT_SUCCESS);
+    }
+
+    actions[*selectedIdx]();
 }
 
 bool TCommandProfileCommon::SetAuthFromCommandLine(std::shared_ptr<IProfile> profile) {
@@ -737,7 +789,23 @@ int TCommandCreateProfile::Run(TConfig& config) {
         profileManager->CreateProfile(ProfileName);
     }
     if (!profileName) {
-        profileName = AskAnyInputWithPrompt("Please enter configuration profile name to create or re-configure: ", config.IsVerbose());
+        auto result = RunFtxuiInput(
+            "Please enter configuration profile name to create or re-configure",
+            "",
+            [](const TString& input, TString& error) {
+                if (input.empty()) {
+                    error = "Profile name cannot be empty";
+                    return false;
+                }
+                return true;
+            }
+        );
+        if (result) {
+            profileName = *result;
+        } else {
+            Cout << "Cancelled." << Endl;
+            return EXIT_SUCCESS;
+        }
     }
     ConfigureProfile(profileName, profileManager, config, Interactive, true);
     return EXIT_SUCCESS;
@@ -782,29 +850,26 @@ int TCommandDeleteProfile::Run(TConfig& config) {
     }
     if (!ProfileName) {
         if (profileNames.size()) {
-            TMaybe<int> returnCode;
-            Cout << "Please choose profile to remove:" << Endl;
-            TNumericOptionsPicker picker(config.IsVerbose());
-            picker.AddOption(
-                "Don't remove anything, just exit",
-                [&returnCode]() {
-                    Cout << "Nothing is done." << Endl;
-                    returnCode = EXIT_SUCCESS;
+            // Build menu options
+            std::vector<TString> options;
+            options.push_back("Don't remove anything, just exit");
+            TString activeProfileName = profileManager->GetActiveProfileName();
+            for (const auto& name : profileNames) {
+                TStringBuilder description;
+                description << name;
+                if (name == activeProfileName) {
+                    description << "\t(active)";
                 }
-            );
-            for (size_t i = 0; i < profileNames.size(); ++i) {
-                TString currentProfileName = profileNames[i];
-                picker.AddOption(
-                    currentProfileName,
-                    [this, currentProfileName]() {
-                        ProfileName = currentProfileName;
-                    }
-                );
+                options.push_back(description);
             }
-            picker.PickOptionAndDoAction();
-            if (returnCode.Defined()) {
-                return returnCode.GetRef();
+
+            auto selectedIdx = RunFtxuiMenu("Please choose profile to remove", options);
+            if (!selectedIdx || *selectedIdx == 0) {
+                Cout << "No changes made." << Endl;
+                return EXIT_SUCCESS;
             }
+
+            ProfileName = profileNames[*selectedIdx - 1];
         } else {
             Cerr << "You have no existing profiles yet." << Endl;
             return EXIT_FAILURE;
@@ -813,15 +878,16 @@ int TCommandDeleteProfile::Run(TConfig& config) {
     if (Force) {
         profileManager->RemoveProfile(ProfileName);
     } else {
-        if (AskYesOrNo(TStringBuilder() << "Profile \"" << ProfileName << "\" will be permanently removed. Continue? (y/n): ")) {
+        TString question = TStringBuilder() << "Profile \"" << ProfileName << "\" will be permanently removed. Continue?";
+        if (AskYesNoFtxui(question)) {
             if (profileManager->RemoveProfile(ProfileName)) {
-                Cout << "Profile \"" << ProfileName << "\" was removed." << Endl;
+                Cout << "Profile \"" << ProfileName << "\" deleted." << Endl;
             } else {
-                Cerr << "Profile \"" << ProfileName << "\" was not removed." << Endl;
+                Cerr << "Failed to delete profile \"" << ProfileName << "\"." << Endl;
                 return EXIT_FAILURE;
             }
         } else {
-            Cout << "Nothing is done." << Endl;
+            Cout << "No changes made." << Endl;
             return EXIT_SUCCESS;
         }
     }
@@ -861,52 +927,47 @@ int TCommandActivateProfile::Run(TConfig& config) {
     if (!ProfileName) {
         const auto profileNames = profileManager->ListProfiles();
         if (profileNames.size()) {
-            TMaybe<int> returnCode;
-            Cout << "Please choose profile to activate:" << Endl;
-            TNumericOptionsPicker picker(config.IsVerbose());
-            picker.AddOption(
-                "Don't do anything, just exit",
-                [&returnCode]() {
-                    Cout << "Nothing is done." << Endl;
-                    returnCode = EXIT_SUCCESS;
-                }
-            );
+            // Build menu options
+            std::vector<TString> options;
+            options.push_back("Don't do anything, just exit");
             if (currentActiveProfileName) {
-                picker.AddOption(
-                    TStringBuilder() << "Deactivate current active profile \"" << currentActiveProfileName << "\"",
-                    [&returnCode, &profileManager, &currentActiveProfileName]() {
-                        profileManager->DeactivateProfile();
-                        Cout << "Current active profile \"" << currentActiveProfileName << "\" was deactivated." << Endl;
-                        returnCode = EXIT_SUCCESS;
-                    }
-                );
+                options.push_back(TStringBuilder() << "Deactivate current active profile\t" << currentActiveProfileName);
             }
-            for (size_t i = 0; i < profileNames.size(); ++i) {
-                TString currentProfileName = profileNames[i];
+            for (const auto& name : profileNames) {
                 TStringBuilder description;
-                description << currentProfileName;
-                if (currentProfileName == currentActiveProfileName) {
-                    description << " (active)";
+                description << name;
+                if (name == currentActiveProfileName) {
+                    description << "\t(active)";
                 }
-                picker.AddOption(
-                    description,
-                    [this, currentProfileName]() {
-                        ProfileName = currentProfileName;
-                    }
-                );
+                options.push_back(description);
             }
-            picker.PickOptionAndDoAction();
-            if (returnCode.Defined()) {
-                return returnCode.GetRef();
+
+            auto selectedIdx = RunFtxuiMenu("Please choose profile to activate", options);
+            if (!selectedIdx || *selectedIdx == 0) {
+                Cout << "No changes made." << Endl;
+                return EXIT_SUCCESS;
             }
+
+            size_t optionOffset = 1; // "Don't do anything" option
+            if (currentActiveProfileName) {
+                if (*selectedIdx == 1) {
+                    // Deactivate current profile
+                    profileManager->DeactivateProfile();
+                    Cout << "Profile \"" << currentActiveProfileName << "\" deactivated." << Endl;
+                    return EXIT_SUCCESS;
+                }
+                optionOffset = 2; // "Don't do anything" + "Deactivate" options
+            }
+
+            ProfileName = profileNames[*selectedIdx - optionOffset];
         } else {
-            Cerr << "You have no existing profiles yet. Run \"ydb init\" to create one" << Endl;
+            Cerr << "You have no existing profiles yet. Run \"ydb init\" to create one." << Endl;
             return EXIT_FAILURE;
         }
     }
     if (currentActiveProfileName != ProfileName) {
         profileManager->SetActiveProfile(ProfileName);
-        Cout << "Profile \"" << ProfileName << "\" was activated." << Endl;
+        Cout << "Profile \"" << ProfileName << "\" is now active." << Endl;
     } else {
         Cout << "Profile \"" << ProfileName << "\" is already active." << Endl;
     }
@@ -928,9 +989,9 @@ int TCommandDeactivateProfile::Run(TConfig& config) {
     TString currentActiveProfileName = profileManager->GetActiveProfileName();
     if (currentActiveProfileName) {
         profileManager->DeactivateProfile();
-        Cout << "Profile \"" << currentActiveProfileName << "\" was deactivated." << Endl;
+        Cout << "Profile \"" << currentActiveProfileName << "\" deactivated." << Endl;
     } else {
-        Cout << "There is no profile active. Nothing is done." << Endl;
+        Cout << "No active profile to deactivate." << Endl;
     }
     return EXIT_SUCCESS;
 }
@@ -1000,24 +1061,25 @@ int TCommandGetProfile::Run(TConfig& config) {
     if (!ProfileName) {
         const auto profileNames = profileManager->ListProfiles();
         if (profileNames.size()) {
-            Cout << "Please choose profile to list its values:" << Endl;
-            TNumericOptionsPicker picker(config.IsVerbose());
+            // Build menu options
+            std::vector<TString> options;
             TString activeProfileName = profileManager->GetActiveProfileName();
-            for (size_t i = 0; i < profileNames.size(); ++i) {
-                TString currentProfileName = profileNames[i];
+            for (const auto& name : profileNames) {
                 TStringBuilder description;
-                description << currentProfileName;
-                if (currentProfileName == activeProfileName) {
-                    description << " (active)";
+                description << name;
+                if (name == activeProfileName) {
+                    description << "\t(active)";
                 }
-                picker.AddOption(
-                    description,
-                    [this, currentProfileName]() {
-                        ProfileName = currentProfileName;
-                    }
-                );
+                options.push_back(description);
             }
-            picker.PickOptionAndDoAction();
+
+            auto selectedIdx = RunFtxuiMenu("Please choose profile to list its values", options);
+            if (!selectedIdx) {
+                Cout << "Cancelled." << Endl;
+                return EXIT_SUCCESS;
+            }
+
+            ProfileName = profileNames[*selectedIdx];
         } else {
             Cerr << "You have no existing profiles yet. Run \"ydb init\" to create one" << Endl;
             return EXIT_FAILURE;
@@ -1153,7 +1215,7 @@ int TCommandReplaceProfile::Run(TConfig& config) {
     auto profileManager = CreateProfileManager(config.ProfileFile);
     if (profileManager->HasProfile(ProfileName)) {
         if (!Force) {
-            if (!AskYesOrNo("Current profile will be replaced with a new one. All current profile data will be lost. Continue? (y/n): ")) {
+            if (!AskYesNoFtxui("Current profile will be replaced with a new one. All current profile data will be lost. Continue?")) {
                 return EXIT_FAILURE;
             }
         }

--- a/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
@@ -182,7 +182,11 @@ namespace {
 
         if (*userName) {
             PutAuthStatic(profile, *userName, *userPassword, false);
-            Cout << "Saved credentials for profile \"" << profileName << "\"." << Endl;
+            if (userPassword->empty()) {
+                Cout << "Saved credentials with empty password for profile \"" << profileName << "\"." << Endl;
+            } else {
+                Cout << "Saved credentials for profile \"" << profileName << "\"." << Endl;
+            }
         }
     }
 

--- a/ydb/public/lib/ydb_cli/common/ftxui.h
+++ b/ydb/public/lib/ydb_cli/common/ftxui.h
@@ -23,20 +23,24 @@ std::optional<size_t> RunFtxuiMenu(const TString& title, const std::vector<TStri
 
 bool RunFtxuiMenuWithActions(const TString& title, const std::vector<TMenuEntry>& options, size_t maxPageSize = 20);
 
-std::optional<TString> RunFtxuiInput(const TString& title, const TString& initial, const std::function<bool(const TString&, TString&)>& validator);
+std::optional<TString> RunFtxuiInput(
+    const TString& title,
+    const TString& initial = "",
+    const std::function<bool(const TString&, TString&)>& validator = {});
 
 std::optional<TString> RunFtxuiInputWithSuffix(
     const TString& title,
     const TString& initial,
     const TString& suffix,
-    const std::function<bool(const TString&, TString&)>& validator);
+    const std::function<bool(const TString&, TString&)>& validator = {});
 
 bool AskYesNoFtxui(const TString& question, bool defaultAnswer = false);
+
+// Password input with masking (shows asterisks)
+std::optional<TString> RunFtxuiPasswordInput(const TString& title);
 
 void PrintFtxuiMessage(std::optional<ftxui::Element> message, const TString& title = "", ftxui::Color color = ftxui::Color::Cyan);
 
 void PrintFtxuiMessage(const TString& body, const TString& title = "", ftxui::Color color = ftxui::Color::Cyan);
 
 } // namespace NYdb::NConsoleClient
-
-

--- a/ydb/tests/functional/ydb_cli/test_ydb_profile.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_profile.py
@@ -453,7 +453,7 @@ class TestProfileListNonInteractive(ProfileTestBase):
         assert result['exit_code'] == 0
         # active_one should be marked as active
         lines = result['stdout'].split('\n')
-        active_line = [l for l in lines if 'active_one' in l][0]
+        active_line = [line for line in lines if 'active_one' in line][0]
         assert '(active)' in active_line
 
     def test_list_with_content(self):
@@ -678,35 +678,35 @@ class TestProfileInitInteractive(ProfileTestBase):
         # Wait for Input to be ready (shown by "Enter to confirm")
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("new_full_profile")
+        child.send("new_full_profile\r")
 
         # Endpoint menu - "Set a new endpoint value" is first option
         child.expect("endpoint", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         # Enter endpoint value - wait for Input
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("grpc://newhost:2136")
+        child.send("grpc://newhost:2136\r")
 
         # Database menu - "Set a new database value" is first option
         child.expect("database", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         # Enter database value - wait for Input
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("/NewDatabase")
+        child.send("/NewDatabase\r")
 
         # Auth menu - select anonymous (index 7)
         child.expect("authentication", timeout=5)
         for _ in range(7):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - Yes
         child.expect("Activate", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -727,33 +727,32 @@ class TestProfileInitInteractive(ProfileTestBase):
         # Wait for Input to be ready
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("endpoint_only_init")
+        child.send("endpoint_only_init\r")
 
         # Endpoint menu - "Set a new endpoint value"
-        child.expect("endpoint", timeout=5)
-        time.sleep(self.FTXUI_INPUT_DELAY)
-        child.send('\n')
+        child.expect("Set a new endpoint", timeout=5)
+        child.send('\r')
 
         # Enter endpoint value
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("grpc://endpoint-only:2136")
+        child.send("grpc://endpoint-only:2136\r")
 
         # Database menu - "Don't save database" (index 1)
-        child.expect("database", timeout=5)
+        child.expect("Set a new database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth menu - "Don't save authentication data" (index 8)
         child.expect("authentication", timeout=5)
         for _ in range(8):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - No
         child.expect("Activate", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -771,35 +770,35 @@ class TestProfileInitInteractive(ProfileTestBase):
         # Wait for Input to be ready
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("metadata_init_profile")
+        child.send("metadata_init_profile\r")
 
         # Endpoint menu - Set new endpoint
         child.expect("endpoint", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         # Enter endpoint
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("grpc://metadata-test:2136")
+        child.send("grpc://metadata-test:2136\r")
 
         # Database - Set new database
         child.expect("database", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         # Enter database
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("/MetadataDb")
+        child.send("/MetadataDb\r")
 
         # Auth menu - "Use metadata service" (index 4)
         child.expect("authentication", timeout=5)
         for _ in range(4):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - Yes
         child.expect("Activate", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -819,28 +818,28 @@ class TestProfileInitInteractive(ProfileTestBase):
         # Wait for Input to be ready
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("minimal_init_profile")
+        child.send("minimal_init_profile\r")
 
         # Endpoint menu - "Don't save endpoint" (index 1)
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Database menu - "Don't save database" (index 1)
         child.expect("database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth menu - anonymous (index 7)
         child.expect("authentication", timeout=5)
         for _ in range(7):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - No
         child.expect("Activate", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -861,36 +860,36 @@ class TestProfileInitInteractive(ProfileTestBase):
         child.expect("Please choose profile to configure", timeout=5)
 
         # "Create a new profile" is first option (index 0)
-        child.send('\n')
+        child.send('\r')
 
         # Wait for Input to be ready
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("second_profile")
+        child.send("second_profile\r")
 
         # Endpoint menu - Set new endpoint
         child.expect("endpoint", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         # Enter endpoint
         child.expect("Enter to confirm", timeout=5)
         time.sleep(self.FTXUI_INPUT_DELAY)
-        child.sendline("grpc://second:2136")
+        child.send("grpc://second:2136\r")
 
         # Database - Don't save
         child.expect("database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth - anonymous
         child.expect("authentication", timeout=5)
         for _ in range(7):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - Yes
         child.expect("Activate", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -913,7 +912,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Navigate down to existing_profile and select
         child.send('\x1b[B')  # Down arrow
-        child.send('\n')  # Select
+        child.send('\r')  # Select
 
         # Should now be in endpoint menu for existing profile
         child.expect("endpoint", timeout=5)
@@ -937,31 +936,31 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile (second option)
         child.send('\x1b[B')  # Down to profile
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint menu - "Use current endpoint value" is third option (index 2)
         # Options: 0=Set new, 1=Don't save, 2=Use current
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')  # Down
         child.send('\x1b[B')  # Down to "Use current"
-        child.send('\n')
+        child.send('\r')
 
         # Database menu - "Use current database value" is third option
         child.expect("database", timeout=5)
         child.send('\x1b[B')  # Down
         child.send('\x1b[B')  # Down to "Use current"
-        child.send('\n')
+        child.send('\r')
 
         # Auth menu - "Don't save authentication data" is last option (index 8)
         child.expect("authentication", timeout=5)
         for _ in range(8):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - No (second option)
         child.expect("Activate", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -982,18 +981,18 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint - Use current
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Database - Don't save (second option, index 1)
         child.expect("database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth menu - "Set anonymous authentication" is index 7
         # 0: static-credentials, 1: iam-token, 2: yc-token, 3: oauth2-key-file
@@ -1001,11 +1000,11 @@ class TestProfileInitInteractive(ProfileTestBase):
         child.expect("authentication", timeout=5)
         for _ in range(7):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - Yes (first option)
         child.expect("Activate", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1025,29 +1024,29 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint - Use current
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Database - Don't save
         child.expect("database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth menu - "Use metadata service" is index 4
         child.expect("authentication", timeout=5)
         for _ in range(4):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - No
         child.expect("Activate", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1066,28 +1065,28 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint - Don't save (index 1)
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Database - Don't save (index 1)
         child.expect("database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth - Don't save (index 8)
         child.expect("authentication", timeout=5)
         for _ in range(8):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - No
         child.expect("Activate", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1112,28 +1111,28 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint - Use current
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Database - Don't save
         child.expect("database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth - Don't save
         child.expect("authentication", timeout=5)
         for _ in range(8):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - Yes (first option)
         child.expect("Activate", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1156,29 +1155,29 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile (second option - our test profile)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint - Use current
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Database - Don't save
         child.expect("database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth - Don't save
         child.expect("authentication", timeout=5)
         for _ in range(8):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - No (second option)
         child.expect("Activate", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1212,7 +1211,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # At endpoint menu - press Escape
         child.expect("endpoint", timeout=5)
@@ -1231,12 +1230,12 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint - Don't save
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # At database menu - press Escape
         child.expect("database", timeout=5)
@@ -1255,17 +1254,17 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Select existing profile
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint - Don't save
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Database - Don't save
         child.expect("database", timeout=5)
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # At auth menu - press Escape
         child.expect("authentication", timeout=5)
@@ -1286,7 +1285,7 @@ class TestProfileDeleteInteractive(ProfileTestBase):
         # Confirmation prompt - default is No (index 1), need to go up to Yes
         child.expect("will be permanently removed", timeout=5)
         child.send('\x1b[A')  # Up to Yes
-        child.send('\n')  # Confirm
+        child.send('\r')  # Confirm
 
         child.expect("deleted", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1302,7 +1301,7 @@ class TestProfileDeleteInteractive(ProfileTestBase):
 
         child.expect("will be permanently removed", timeout=5)
         # Default is No (index 1), just press Enter to decline
-        child.send('\n')
+        child.send('\r')
 
         child.expect("No changes made", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1323,12 +1322,12 @@ class TestProfileDeleteInteractive(ProfileTestBase):
         # First option is "Don't remove anything"
         # Select profile_a (second option)
         child.send('\x1b[B')  # Down
-        child.send('\n')
+        child.send('\r')
 
         # Confirm - default is No, need to go up to Yes
         child.expect("will be permanently removed", timeout=5)
         child.send('\x1b[A')  # Up to Yes
-        child.send('\n')
+        child.send('\r')
 
         child.expect("deleted", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1346,7 +1345,7 @@ class TestProfileDeleteInteractive(ProfileTestBase):
         child.expect("Please choose profile to remove", timeout=5)
 
         # Select "Don't remove anything" (first option)
-        child.send('\n')
+        child.send('\r')
 
         child.expect("No changes made", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1371,7 +1370,7 @@ class TestProfileActivateInteractive(ProfileTestBase):
         # Select profile_b (third option - after "Don't do anything")
         child.send('\x1b[B')  # Down
         child.send('\x1b[B')  # Down
-        child.send('\n')
+        child.send('\r')
 
         child.expect("is now active", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1393,7 +1392,7 @@ class TestProfileActivateInteractive(ProfileTestBase):
         # 1: Deactivate current
         # 2+: profiles
         child.send('\x1b[B')  # Down to "Deactivate"
-        child.send('\n')
+        child.send('\r')
 
         child.expect("deactivated", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -1416,7 +1415,7 @@ class TestProfileGetInteractive(ProfileTestBase):
         child = self.spawn_ydb_cli(["config", "profile", "get"])
 
         child.expect("Please choose profile to list its values", timeout=5)
-        child.send('\n')  # Select first profile
+        child.send('\r')  # Select first profile
 
         child.expect("endpoint:", timeout=5)
         child.expect("grpc://localhost:2136", timeout=5)
@@ -1450,7 +1449,7 @@ class TestProfileReplaceInteractive(ProfileTestBase):
         # Confirmation - default is No, need to go up to Yes
         child.expect("will be replaced", timeout=5)
         child.send('\x1b[A')  # Up to Yes
-        child.send('\n')
+        child.send('\r')
 
         child.expect(pexpect.EOF, timeout=5)
 
@@ -1468,7 +1467,7 @@ class TestProfileReplaceInteractive(ProfileTestBase):
 
         # Confirmation - default is No, just press Enter to decline
         child.expect("will be replaced", timeout=5)
-        child.send('\n')
+        child.send('\r')
 
         child.expect(pexpect.EOF, timeout=5)
 
@@ -1587,7 +1586,7 @@ class TestProfileEdgeCases(ProfileTestBase):
         child.expect("Please enter configuration profile name", timeout=5)
 
         # Try to submit empty name
-        child.send('\n')  # Just press Enter without typing anything
+        child.send('\r')  # Just press Enter without typing anything
 
         # Should show error and not proceed
         child.expect("cannot be empty", timeout=5)
@@ -2015,12 +2014,12 @@ class TestProfileMenuNavigation(ProfileTestBase):
         child.expect("Please enter configuration profile name", timeout=5)
 
         # Try empty name
-        child.send('\n')  # Press Enter without typing
+        child.send('\r')  # Press Enter without typing
         child.expect("cannot be empty", timeout=5)
 
         # Now enter valid name
         child.send("valid_name")
-        child.send('\n')  # Confirm
+        child.send('\r')  # Confirm
 
         # Should proceed to endpoint menu
         child.expect("endpoint", timeout=5)
@@ -2044,7 +2043,7 @@ class TestProfileMenuNavigation(ProfileTestBase):
             child.send('\x1b[B')  # Down
 
         # Select current option
-        child.send('\n')
+        child.send('\r')
 
         # Should show profile content
         child.expect("endpoint:", timeout=5)
@@ -2065,30 +2064,30 @@ class TestProfileMenuNavigation(ProfileTestBase):
 
         # Select existing profile
         child.send('\x1b[B')  # Down to existing
-        child.send('\n')
+        child.send('\r')
 
         # Endpoint menu - select "Use current endpoint value"
         child.expect("endpoint", timeout=5)
         child.send('\x1b[B')  # Down
         child.send('\x1b[B')  # Down to "Use current"
-        child.send('\n')
+        child.send('\r')
 
         # Database menu - select "Use current database value"
         child.expect("database", timeout=5)
         child.send('\x1b[B')
         child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Auth menu - select "Don't save authentication data" (index 8)
         child.expect("authentication", timeout=5)
         for _ in range(8):
             child.send('\x1b[B')
-        child.send('\n')
+        child.send('\r')
 
         # Activate - No
         child.expect("Activate", timeout=5)
         child.send('\x1b[B')  # No
-        child.send('\n')
+        child.send('\r')
 
         child.expect("configured successfully", timeout=5)
         child.expect(pexpect.EOF, timeout=5)
@@ -2097,10 +2096,6 @@ class TestProfileMenuNavigation(ProfileTestBase):
         config = self.read_profile_file()
         assert config['profiles']['existing']['endpoint'] == 'grpc://original:2136'
         assert config['profiles']['existing']['database'] == '/OriginalDb'
-
-
-
-
 
 
 class TestProfileStdinInputAdditional(ProfileTestBase):
@@ -2491,7 +2486,7 @@ class TestProfileReplaceEdgeCases(ProfileTestBase):
         # Should ask for confirmation
         child.expect("replaced", timeout=5)
         child.send('\x1b[B')  # Down to No
-        child.send('\n')
+        child.send('\r')
 
         child.expect(pexpect.EOF, timeout=5)
 
@@ -2720,8 +2715,6 @@ class TestProfilePrintContent(ProfileTestBase):
         result = self.run_ydb_cli(["config", "profile", "get", "fullssl_test"])
         assert result.returncode == 0
         assert "client-cert-key-password-file" in result.stdout
-
-
 
 
 class TestProfileIamTokenFile(ProfileTestBase):

--- a/ydb/tests/functional/ydb_cli/test_ydb_profile.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_profile.py
@@ -31,6 +31,11 @@ def ydb_bin():
 class ProfileTestBase:
     """Base class for profile tests with common utilities"""
 
+    # Delay required before sending input to ftxui Input fields.
+    # Without this delay, input sent immediately after expect() may be lost
+    # because the ftxui component hasn't finished rendering yet.
+    FTXUI_INPUT_DELAY = 0.3
+
     @pytest.fixture(autouse=True)
     def setup_profile_file(self, tmp_path):
         """Create isolated profile file for each test"""
@@ -672,7 +677,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Wait for Input to be ready (shown by "Enter to confirm")
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("new_full_profile")
 
         # Endpoint menu - "Set a new endpoint value" is first option
@@ -681,7 +686,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Enter endpoint value - wait for Input
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("grpc://newhost:2136")
 
         # Database menu - "Set a new database value" is first option
@@ -690,7 +695,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Enter database value - wait for Input
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("/NewDatabase")
 
         # Auth menu - select anonymous (index 7)
@@ -721,17 +726,17 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Wait for Input to be ready
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.3)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("endpoint_only_init")
 
         # Endpoint menu - "Set a new endpoint value"
         child.expect("endpoint", timeout=5)
-        time.sleep(0.1)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.send('\n')
 
         # Enter endpoint value
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.3)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("grpc://endpoint-only:2136")
 
         # Database menu - "Don't save database" (index 1)
@@ -765,7 +770,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Wait for Input to be ready
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("metadata_init_profile")
 
         # Endpoint menu - Set new endpoint
@@ -774,7 +779,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Enter endpoint
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("grpc://metadata-test:2136")
 
         # Database - Set new database
@@ -783,7 +788,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Enter database
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("/MetadataDb")
 
         # Auth menu - "Use metadata service" (index 4)
@@ -813,7 +818,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Wait for Input to be ready
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("minimal_init_profile")
 
         # Endpoint menu - "Don't save endpoint" (index 1)
@@ -860,7 +865,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Wait for Input to be ready
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("second_profile")
 
         # Endpoint menu - Set new endpoint
@@ -869,7 +874,7 @@ class TestProfileInitInteractive(ProfileTestBase):
 
         # Enter endpoint
         child.expect("Enter to confirm", timeout=5)
-        time.sleep(0.2)
+        time.sleep(self.FTXUI_INPUT_DELAY)
         child.sendline("grpc://second:2136")
 
         # Database - Don't save

--- a/ydb/tests/functional/ydb_cli/test_ydb_profile.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_profile.py
@@ -1,0 +1,2741 @@
+# -*- coding: utf-8 -*-
+"""
+Functional tests for YDB CLI profile management commands.
+
+Tests cover both interactive (ftxui-based) and non-interactive modes
+for all profile-related commands: init, create, delete, activate,
+deactivate, list, get, update, replace.
+"""
+
+import os
+import logging
+import sys
+import time
+import uuid
+import yaml
+
+import pytest
+import pexpect
+
+import yatest
+
+logger = logging.getLogger(__name__)
+
+
+def ydb_bin():
+    if os.getenv("YDB_CLI_BINARY"):
+        return yatest.common.binary_path(os.getenv("YDB_CLI_BINARY"))
+    raise RuntimeError("YDB_CLI_BINARY environment variable is not specified")
+
+
+class ProfileTestBase:
+    """Base class for profile tests with common utilities"""
+
+    @pytest.fixture(autouse=True)
+    def setup_profile_file(self, tmp_path):
+        """Create isolated profile file for each test"""
+        self.tmp_path = tmp_path
+        self.profile_file = str(tmp_path / f"profile_{uuid.uuid4().hex}.yaml")
+        yield
+        # Cleanup handled by tmp_path fixture
+
+    def execute_ydb_cli(self, args, stdin=None, check_exit_code=True):
+        """Execute YDB CLI command non-interactively"""
+        full_args = ["--profile-file", self.profile_file] + args
+
+        # Convert string stdin to a temp file for yatest.common.execute
+        stdin_file = None
+        temp_stdin_path = None
+        if stdin is not None:
+            if isinstance(stdin, str):
+                temp_stdin_path = str(self.tmp_path / f"stdin_{uuid.uuid4().hex}.txt")
+                with open(temp_stdin_path, 'w') as f:
+                    f.write(stdin)
+                stdin_file = open(temp_stdin_path, 'r')
+            else:
+                stdin_file = stdin
+
+        try:
+            execution = yatest.common.execute(
+                [ydb_bin()] + full_args,
+                stdin=stdin_file,
+                check_exit_code=False
+            )
+        finally:
+            if stdin_file and temp_stdin_path:
+                stdin_file.close()
+
+        result = {
+            'stdout': execution.std_out.decode('utf-8') if execution.std_out else '',
+            'stderr': execution.std_err.decode('utf-8') if execution.std_err else '',
+            'exit_code': execution.exit_code
+        }
+        logger.debug("Command: %s", full_args)
+        logger.debug("Exit code: %d", result['exit_code'])
+        logger.debug("stdout:\n%s", result['stdout'])
+        logger.debug("stderr:\n%s", result['stderr'])
+        if check_exit_code and result['exit_code'] != 0:
+            raise RuntimeError(f"Command failed: {result['stderr']}")
+        return result
+
+    def spawn_ydb_cli(self, args, timeout=10, debug=False):
+        """Spawn YDB CLI for interactive testing with pexpect"""
+        full_args = ["--profile-file", self.profile_file] + args
+        env = os.environ.copy()
+        env["TERM"] = "xterm-256color"
+
+        child = pexpect.spawn(
+            ydb_bin(),
+            full_args,
+            encoding='utf-8',
+            timeout=timeout,
+            env=env
+        )
+        # For debugging, enable output to stdout
+        if debug:
+            child.logfile_read = sys.stdout
+        return child
+
+    def read_profile_file(self):
+        """Read and parse the profile YAML file"""
+        if not os.path.exists(self.profile_file):
+            return None
+        with open(self.profile_file, 'r') as f:
+            return yaml.safe_load(f)
+
+    def write_profile_file(self, content):
+        """Write content to profile file"""
+        os.makedirs(os.path.dirname(self.profile_file), exist_ok=True)
+        with open(self.profile_file, 'w') as f:
+            yaml.dump(content, f)
+
+    def create_test_profile(self, name, endpoint=None, database=None, auth=None, active=False,
+                            token_file=None, ca_file=None, user=None, password_file=None):
+        """Helper to create a test profile programmatically"""
+        config = self.read_profile_file() or {}
+        if 'profiles' not in config:
+            config['profiles'] = {}
+
+        profile_data = {}
+        if endpoint:
+            profile_data['endpoint'] = endpoint
+        if database:
+            profile_data['database'] = database
+        if auth:
+            profile_data['authentication'] = auth
+        if token_file:
+            profile_data['authentication'] = {'method': 'token-file', 'data': token_file}
+        if ca_file:
+            profile_data['ca-file'] = ca_file
+        if user:
+            auth_data = {'method': 'static-credentials', 'data': {'user': user}}
+            if password_file:
+                auth_data['data']['password-file'] = password_file
+            profile_data['authentication'] = auth_data
+
+        config['profiles'][name] = profile_data
+        if active:
+            config['active_profile'] = name
+
+        self.write_profile_file(config)
+
+    def create_temp_file(self, content, filename):
+        """Create a temporary file with given content and return its path"""
+        filepath = str(self.tmp_path / filename)
+        with open(filepath, 'w') as f:
+            f.write(content)
+        return filepath
+
+    def set_active_profile(self, name):
+        """Set the active profile in config file"""
+        config = self.read_profile_file() or {}
+        config['active_profile'] = name
+        self.write_profile_file(config)
+
+    def run_ydb_cli(self, args, stdin=None):
+        """Execute YDB CLI and return result object with returncode, stdout, stderr"""
+        result = self.execute_ydb_cli(args, stdin=stdin, check_exit_code=False)
+
+        class Result:
+            pass
+
+        r = Result()
+        r.returncode = result['exit_code']
+        r.stdout = result['stdout']
+        r.stderr = result['stderr']
+        return r
+
+
+# =============================================================================
+# Non-interactive tests (command line arguments)
+# =============================================================================
+
+class TestProfileCreateNonInteractive(ProfileTestBase):
+    """Test 'ydb config profile create' with command line arguments"""
+
+    def test_create_profile_with_endpoint_and_database(self):
+        """Create profile with endpoint and database from command line"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "test_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--database", "/Root"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config is not None
+        assert 'profiles' in config
+        assert 'test_profile' in config['profiles']
+        assert config['profiles']['test_profile']['endpoint'] == 'grpc://localhost:2136'
+        assert config['profiles']['test_profile']['database'] == '/Root'
+
+    def test_create_profile_with_token_file(self):
+        """Create profile with token-file authentication"""
+        token_file = str(self.tmp_path / "token.txt")
+        with open(token_file, 'w') as f:
+            f.write("test_token")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "token_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--database", "/Root",
+            "--token-file", token_file
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['token_profile']['authentication']['method'] == 'token-file'
+        assert config['profiles']['token_profile']['authentication']['data'] == token_file
+
+    def test_create_profile_with_anonymous_auth(self):
+        """Create profile with anonymous authentication"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "anon_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--anonymous-auth"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['anon_profile']['authentication']['method'] == 'anonymous-auth'
+
+    def test_create_profile_with_static_credentials(self):
+        """Create profile with static credentials (user + password file)"""
+        password_file = str(self.tmp_path / "password.txt")
+        with open(password_file, 'w') as f:
+            f.write("test_password")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "static_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--user", "test_user",
+            "--password-file", password_file
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        auth = config['profiles']['static_profile']['authentication']
+        assert auth['method'] == 'static-credentials'
+        assert auth['data']['user'] == 'test_user'
+        assert auth['data']['password-file'] == password_file
+
+    def test_create_profile_with_ca_file(self):
+        """Create profile with CA file for SSL"""
+        ca_file = str(self.tmp_path / "ca.pem")
+        with open(ca_file, 'w') as f:
+            f.write("fake_ca_cert")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "ssl_profile",
+            "--endpoint", "grpcs://localhost:2136",
+            "--ca-file", ca_file
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['ssl_profile']['ca-file'] == ca_file
+
+    def test_create_profile_with_client_cert(self):
+        """Create profile with client certificate for mTLS"""
+        cert_file = str(self.tmp_path / "client.pem")
+        key_file = str(self.tmp_path / "client.key")
+        with open(cert_file, 'w') as f:
+            f.write("fake_cert")
+        with open(key_file, 'w') as f:
+            f.write("fake_key")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "mtls_profile",
+            "--endpoint", "grpcs://localhost:2136",
+            "--client-cert-file", cert_file,
+            "--client-cert-key-file", key_file
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['mtls_profile']['client-cert-file'] == cert_file
+        assert config['profiles']['mtls_profile']['client-cert-key-file'] == key_file
+
+    def test_create_existing_profile_fails(self):
+        """Creating existing profile without interactive mode should fail"""
+        # First create a profile
+        self.execute_ydb_cli([
+            "config", "profile", "create", "existing",
+            "--endpoint", "grpc://localhost:2136"
+        ])
+
+        # Try to create it again
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "existing",
+            "--endpoint", "grpc://localhost:9999"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "already exists" in result['stderr']
+
+    def test_create_profile_multiple_auth_methods_fails(self):
+        """Creating profile with multiple auth methods should fail"""
+        token_file = str(self.tmp_path / "token.txt")
+        with open(token_file, 'w') as f:
+            f.write("test_token")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "bad_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--token-file", token_file,
+            "--anonymous-auth"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "authentication method" in result['stderr'].lower() or "2" in result['stderr']
+
+
+class TestProfileDeleteNonInteractive(ProfileTestBase):
+    """Test 'ydb config profile delete' with command line arguments"""
+
+    def test_delete_profile_with_force(self):
+        """Delete profile with --force flag (no confirmation)"""
+        self.create_test_profile("to_delete", endpoint="grpc://localhost:2136")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "delete", "to_delete", "--force"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config is None or 'to_delete' not in config.get('profiles', {})
+
+    def test_delete_nonexistent_profile_fails(self):
+        """Deleting non-existent profile should fail"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "delete", "nonexistent"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "No existing profile" in result['stderr']
+
+    def test_delete_nonexistent_profile_force_succeeds(self):
+        """Deleting non-existent profile with --force should succeed"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "delete", "nonexistent", "--force"
+        ])
+        assert result['exit_code'] == 0
+
+    def test_delete_without_name_and_force_fails(self):
+        """Delete without profile name and with --force should fail"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "delete", "--force"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+
+
+class TestProfileActivateNonInteractive(ProfileTestBase):
+    """Test 'ydb config profile activate' with command line arguments"""
+
+    def test_activate_profile(self):
+        """Activate a profile by name"""
+        self.create_test_profile("to_activate", endpoint="grpc://localhost:2136")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "activate", "to_activate"
+        ])
+        assert result['exit_code'] == 0
+        assert "is now active" in result['stdout']
+
+        config = self.read_profile_file()
+        assert config['active_profile'] == 'to_activate'
+
+    def test_activate_already_active_profile(self):
+        """Activating already active profile should show appropriate message"""
+        self.create_test_profile("active_one", endpoint="grpc://localhost:2136", active=True)
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "activate", "active_one"
+        ])
+        assert result['exit_code'] == 0
+        assert "already active" in result['stdout']
+
+    def test_activate_nonexistent_profile_fails(self):
+        """Activating non-existent profile should fail"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "activate", "nonexistent"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "No existing profile" in result['stderr']
+
+
+class TestProfileDeactivateNonInteractive(ProfileTestBase):
+    """Test 'ydb config profile deactivate'"""
+
+    def test_deactivate_active_profile(self):
+        """Deactivate currently active profile"""
+        self.create_test_profile("active_profile", endpoint="grpc://localhost:2136", active=True)
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "deactivate"
+        ])
+        assert result['exit_code'] == 0
+        assert "deactivated" in result['stdout']
+
+        config = self.read_profile_file()
+        assert config.get('active_profile') is None or config.get('active_profile') == ''
+
+    def test_deactivate_when_no_active_profile(self):
+        """Deactivate when no profile is active"""
+        self.create_test_profile("inactive", endpoint="grpc://localhost:2136", active=False)
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "deactivate"
+        ])
+        assert result['exit_code'] == 0
+        assert "No active profile" in result['stdout']
+
+
+class TestProfileListNonInteractive(ProfileTestBase):
+    """Test 'ydb config profile list'"""
+
+    def test_list_empty(self):
+        """List profiles when none exist"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "list"
+        ])
+        assert result['exit_code'] == 0
+        # Output should be empty or just whitespace
+        assert result['stdout'].strip() == ''
+
+    def test_list_profiles(self):
+        """List existing profiles"""
+        self.create_test_profile("profile_a", endpoint="grpc://localhost:2136")
+        self.create_test_profile("profile_b", endpoint="grpc://localhost:2137")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "list"
+        ])
+        assert result['exit_code'] == 0
+        assert "profile_a" in result['stdout']
+        assert "profile_b" in result['stdout']
+
+    def test_list_shows_active_profile(self):
+        """List should show which profile is active"""
+        self.create_test_profile("inactive_one", endpoint="grpc://localhost:2136")
+        self.create_test_profile("active_one", endpoint="grpc://localhost:2137", active=True)
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "list"
+        ])
+        assert result['exit_code'] == 0
+        # active_one should be marked as active
+        lines = result['stdout'].split('\n')
+        active_line = [l for l in lines if 'active_one' in l][0]
+        assert '(active)' in active_line
+
+    def test_list_with_content(self):
+        """List profiles with --with-content flag"""
+        self.create_test_profile(
+            "detailed_profile",
+            endpoint="grpc://localhost:2136",
+            database="/Root"
+        )
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "list", "--with-content"
+        ])
+        assert result['exit_code'] == 0
+        assert "detailed_profile" in result['stdout']
+        assert "endpoint:" in result['stdout']
+        assert "grpc://localhost:2136" in result['stdout']
+        assert "database:" in result['stdout']
+        assert "/Root" in result['stdout']
+
+
+class TestProfileGetNonInteractive(ProfileTestBase):
+    """Test 'ydb config profile get'"""
+
+    def test_get_profile(self):
+        """Get profile content by name"""
+        self.create_test_profile(
+            "get_test",
+            endpoint="grpc://localhost:2136",
+            database="/Root",
+            auth={'method': 'anonymous-auth'}
+        )
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "get", "get_test"
+        ])
+        assert result['exit_code'] == 0
+        assert "endpoint:" in result['stdout']
+        assert "grpc://localhost:2136" in result['stdout']
+        assert "database:" in result['stdout']
+        assert "/Root" in result['stdout']
+        assert "anonymous-auth" in result['stdout']
+
+    def test_get_nonexistent_profile_fails(self):
+        """Getting non-existent profile should fail"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "get", "nonexistent"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "No existing profile" in result['stderr']
+
+
+class TestProfileUpdateNonInteractive(ProfileTestBase):
+    """Test 'ydb config profile update'"""
+
+    def test_update_endpoint(self):
+        """Update profile endpoint"""
+        self.create_test_profile("update_test", endpoint="grpc://old:2136")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "update_test",
+            "--endpoint", "grpc://new:2136"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['update_test']['endpoint'] == 'grpc://new:2136'
+
+    def test_update_add_database(self):
+        """Add database to profile that didn't have one"""
+        self.create_test_profile("update_test", endpoint="grpc://localhost:2136")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "update_test",
+            "--database", "/NewDb"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['update_test']['database'] == '/NewDb'
+
+    def test_update_remove_endpoint(self):
+        """Remove endpoint from profile with --no-endpoint"""
+        self.create_test_profile(
+            "update_test",
+            endpoint="grpc://localhost:2136",
+            database="/Root"
+        )
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "update_test",
+            "--no-endpoint"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'endpoint' not in config['profiles']['update_test']
+        assert config['profiles']['update_test']['database'] == '/Root'
+
+    def test_update_remove_database(self):
+        """Remove database from profile with --no-database"""
+        self.create_test_profile(
+            "update_test",
+            endpoint="grpc://localhost:2136",
+            database="/Root"
+        )
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "update_test",
+            "--no-database"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'database' not in config['profiles']['update_test']
+        assert config['profiles']['update_test']['endpoint'] == 'grpc://localhost:2136'
+
+    def test_update_remove_auth(self):
+        """Remove authentication from profile with --no-auth"""
+        self.create_test_profile(
+            "update_test",
+            endpoint="grpc://localhost:2136",
+            auth={'method': 'anonymous-auth'}
+        )
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "update_test",
+            "--no-auth"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'authentication' not in config['profiles']['update_test']
+
+    def test_update_nonexistent_profile_fails(self):
+        """Updating non-existent profile should fail"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "nonexistent",
+            "--endpoint", "grpc://localhost:2136"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "No existing profile" in result['stderr']
+
+    def test_update_mutually_exclusive_options_fail(self):
+        """Using --endpoint and --no-endpoint together should fail"""
+        self.create_test_profile("update_test", endpoint="grpc://localhost:2136")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "update_test",
+            "--endpoint", "grpc://new:2136",
+            "--no-endpoint"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "mutually exclusive" in result['stderr']
+
+    def test_update_auth_and_no_auth_fail(self):
+        """Using authentication option and --no-auth together should fail"""
+        self.create_test_profile("update_test", endpoint="grpc://localhost:2136")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "update_test",
+            "--anonymous-auth",
+            "--no-auth"
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+
+
+class TestProfileReplaceNonInteractive(ProfileTestBase):
+    """Test 'ydb config profile replace'"""
+
+    def test_replace_profile_with_force(self):
+        """Replace profile with --force (no confirmation)"""
+        self.create_test_profile(
+            "replace_test",
+            endpoint="grpc://old:2136",
+            database="/OldDb"
+        )
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "replace", "replace_test",
+            "--endpoint", "grpc://new:2136",
+            "--database", "/NewDb",
+            "--force"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['replace_test']['endpoint'] == 'grpc://new:2136'
+        assert config['profiles']['replace_test']['database'] == '/NewDb'
+
+    def test_replace_creates_new_profile(self):
+        """Replace creates profile if it doesn't exist"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "replace", "new_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--force"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'new_profile' in config['profiles']
+
+
+# =============================================================================
+# Interactive tests (ftxui menus via pexpect)
+# =============================================================================
+
+class TestProfileInitInteractive(ProfileTestBase):
+    """Test 'ydb init' interactive command"""
+
+    def test_init_create_new_profile_full(self):
+        """Create new profile with endpoint, database and anonymous auth via init"""
+        # When no profiles exist, init goes directly to profile name input
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+
+        # Wait for Input to be ready (shown by "Enter to confirm")
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("new_full_profile")
+
+        # Endpoint menu - "Set a new endpoint value" is first option
+        child.expect("endpoint", timeout=5)
+        child.send('\n')
+
+        # Enter endpoint value - wait for Input
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("grpc://newhost:2136")
+
+        # Database menu - "Set a new database value" is first option
+        child.expect("database", timeout=5)
+        child.send('\n')
+
+        # Enter database value - wait for Input
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("/NewDatabase")
+
+        # Auth menu - select anonymous (index 7)
+        child.expect("authentication", timeout=5)
+        for _ in range(7):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - Yes
+        child.expect("Activate", timeout=5)
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert 'new_full_profile' in config['profiles']
+        assert config['profiles']['new_full_profile']['endpoint'] == 'grpc://newhost:2136'
+        assert config['profiles']['new_full_profile']['database'] == '/NewDatabase'
+        assert config['profiles']['new_full_profile']['authentication']['method'] == 'anonymous-auth'
+        assert config.get('active_profile') == 'new_full_profile'
+
+    def test_init_create_new_profile_endpoint_only(self):
+        """Create new profile with only endpoint via init"""
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+
+        # Wait for Input to be ready
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.3)
+        child.sendline("endpoint_only_init")
+
+        # Endpoint menu - "Set a new endpoint value"
+        child.expect("endpoint", timeout=5)
+        time.sleep(0.1)
+        child.send('\n')
+
+        # Enter endpoint value
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.3)
+        child.sendline("grpc://endpoint-only:2136")
+
+        # Database menu - "Don't save database" (index 1)
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth menu - "Don't save authentication data" (index 8)
+        child.expect("authentication", timeout=5)
+        for _ in range(8):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - No
+        child.expect("Activate", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert 'endpoint_only_init' in config['profiles']
+        assert config['profiles']['endpoint_only_init']['endpoint'] == 'grpc://endpoint-only:2136'
+
+    def test_init_create_new_profile_with_metadata_auth(self):
+        """Create new profile with metadata authentication via init"""
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+
+        # Wait for Input to be ready
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("metadata_init_profile")
+
+        # Endpoint menu - Set new endpoint
+        child.expect("endpoint", timeout=5)
+        child.send('\n')
+
+        # Enter endpoint
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("grpc://metadata-test:2136")
+
+        # Database - Set new database
+        child.expect("database", timeout=5)
+        child.send('\n')
+
+        # Enter database
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("/MetadataDb")
+
+        # Auth menu - "Use metadata service" (index 4)
+        child.expect("authentication", timeout=5)
+        for _ in range(4):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - Yes
+        child.expect("Activate", timeout=5)
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert 'metadata_init_profile' in config['profiles']
+        assert config['profiles']['metadata_init_profile']['endpoint'] == 'grpc://metadata-test:2136'
+        assert config['profiles']['metadata_init_profile']['database'] == '/MetadataDb'
+        assert config['profiles']['metadata_init_profile']['authentication']['method'] == 'use-metadata-credentials'
+
+    def test_init_create_profile_no_endpoint_no_database(self):
+        """Create new profile without endpoint and database via init"""
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+
+        # Wait for Input to be ready
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("minimal_init_profile")
+
+        # Endpoint menu - "Don't save endpoint" (index 1)
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Database menu - "Don't save database" (index 1)
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth menu - anonymous (index 7)
+        child.expect("authentication", timeout=5)
+        for _ in range(7):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - No
+        child.expect("Activate", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert 'minimal_init_profile' in config['profiles']
+        assert config['profiles']['minimal_init_profile']['authentication']['method'] == 'anonymous-auth'
+
+    def test_init_create_second_profile_via_menu(self):
+        """Create a second profile by selecting 'Create new' from menu"""
+        # First create an existing profile
+        self.create_test_profile("existing", endpoint="grpc://old:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        # Now menu appears because profile exists
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # "Create a new profile" is first option (index 0)
+        child.send('\n')
+
+        # Wait for Input to be ready
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("second_profile")
+
+        # Endpoint menu - Set new endpoint
+        child.expect("endpoint", timeout=5)
+        child.send('\n')
+
+        # Enter endpoint
+        child.expect("Enter to confirm", timeout=5)
+        time.sleep(0.2)
+        child.sendline("grpc://second:2136")
+
+        # Database - Don't save
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth - anonymous
+        child.expect("authentication", timeout=5)
+        for _ in range(7):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - Yes
+        child.expect("Activate", timeout=5)
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert 'second_profile' in config['profiles']
+        assert config['profiles']['second_profile']['endpoint'] == 'grpc://second:2136'
+        assert config.get('active_profile') == 'second_profile'
+
+    def test_init_select_existing_profile(self):
+        """Select existing profile to modify in init"""
+        self.create_test_profile("existing_profile", endpoint="grpc://old:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+
+        # Menu should show "Create a new profile" and "existing_profile"
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Navigate down to existing_profile and select
+        child.send('\x1b[B')  # Down arrow
+        child.send('\n')  # Select
+
+        # Should now be in endpoint menu for existing profile
+        child.expect("endpoint", timeout=5)
+
+        # Cancel the rest
+        child.send('\x1b')
+        child.expect(pexpect.EOF, timeout=10)
+
+    def test_init_keep_all_current_values(self):
+        """Test init with 'Use current value' for endpoint/database"""
+        self.create_test_profile(
+            "current_values_test",
+            endpoint="grpc://original:2136",
+            database="/OriginalDb"
+        )
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile (second option)
+        child.send('\x1b[B')  # Down to profile
+        child.send('\n')
+
+        # Endpoint menu - "Use current endpoint value" is third option (index 2)
+        # Options: 0=Set new, 1=Don't save, 2=Use current
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')  # Down
+        child.send('\x1b[B')  # Down to "Use current"
+        child.send('\n')
+
+        # Database menu - "Use current database value" is third option
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')  # Down
+        child.send('\x1b[B')  # Down to "Use current"
+        child.send('\n')
+
+        # Auth menu - "Don't save authentication data" is last option (index 8)
+        child.expect("authentication", timeout=5)
+        for _ in range(8):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - No (second option)
+        child.expect("Activate", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        # Verify original values preserved
+        config = self.read_profile_file()
+        assert config['profiles']['current_values_test']['endpoint'] == 'grpc://original:2136'
+        assert config['profiles']['current_values_test']['database'] == '/OriginalDb'
+
+    def test_init_with_anonymous_auth(self):
+        """Test init selecting anonymous authentication"""
+        self.create_test_profile("anon_test", endpoint="grpc://test:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Endpoint - Use current
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Database - Don't save (second option, index 1)
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth menu - "Set anonymous authentication" is index 7
+        # 0: static-credentials, 1: iam-token, 2: yc-token, 3: oauth2-key-file
+        # 4: metadata, 5: sa-key-file, 6: ydb-token, 7: anonymous, 8: don't save
+        child.expect("authentication", timeout=5)
+        for _ in range(7):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - Yes (first option)
+        child.expect("Activate", timeout=5)
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert config['profiles']['anon_test']['authentication']['method'] == 'anonymous-auth'
+        assert config.get('active_profile') == 'anon_test'
+
+    def test_init_with_metadata_credentials(self):
+        """Test init selecting metadata credentials authentication"""
+        self.create_test_profile("meta_test", endpoint="grpc://test:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Endpoint - Use current
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Database - Don't save
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth menu - "Use metadata service" is index 4
+        child.expect("authentication", timeout=5)
+        for _ in range(4):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - No
+        child.expect("Activate", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert config['profiles']['meta_test']['authentication']['method'] == 'use-metadata-credentials'
+
+    def test_init_dont_save_anything(self):
+        """Test init with 'Don't save' for all options"""
+        self.create_test_profile("empty_test", endpoint="grpc://old:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Endpoint - Don't save (index 1)
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Database - Don't save (index 1)
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth - Don't save (index 8)
+        child.expect("authentication", timeout=5)
+        for _ in range(8):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - No
+        child.expect("Activate", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        # Profile should exist but be empty
+        assert 'empty_test' in config['profiles']
+
+    def test_init_activate_profile(self):
+        """Test init with profile activation"""
+        self.create_test_profile("activate_test", endpoint="grpc://test:2136")
+        # Ensure no active profile
+        config = self.read_profile_file()
+        if 'active_profile' in config:
+            del config['active_profile']
+            self.write_profile_file(config)
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Endpoint - Use current
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Database - Don't save
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth - Don't save
+        child.expect("authentication", timeout=5)
+        for _ in range(8):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - Yes (first option)
+        child.expect("Activate", timeout=5)
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert config.get('active_profile') == 'activate_test'
+
+    def test_init_dont_activate_profile(self):
+        """Test init without profile activation"""
+        self.create_test_profile("no_activate_test", endpoint="grpc://test:2136")
+        # Set different active profile
+        config = self.read_profile_file()
+        config['active_profile'] = 'other'
+        self.write_profile_file(config)
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile (second option - our test profile)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Endpoint - Use current
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Database - Don't save
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth - Don't save
+        child.expect("authentication", timeout=5)
+        for _ in range(8):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - No (second option)
+        child.expect("Activate", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        # Active profile should remain unchanged
+        assert config.get('active_profile') == 'other'
+
+    def test_init_cancel_at_profile_selection(self):
+        """Test canceling init at profile selection menu"""
+        self.create_test_profile("cancel_test", endpoint="grpc://test:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Press Escape to cancel
+        child.send('\x1b')
+
+        child.expect(pexpect.EOF, timeout=5)
+
+    def test_init_cancel_at_endpoint_menu(self):
+        """Test canceling init at endpoint menu"""
+        self.create_test_profile("cancel_ep_test", endpoint="grpc://test:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # At endpoint menu - press Escape
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b')
+
+        child.expect(pexpect.EOF, timeout=5)
+
+    def test_init_cancel_at_database_menu(self):
+        """Test canceling init at database menu"""
+        self.create_test_profile("cancel_db_test", endpoint="grpc://test:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Endpoint - Don't save
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # At database menu - press Escape
+        child.expect("database", timeout=5)
+        child.send('\x1b')
+
+        child.expect(pexpect.EOF, timeout=5)
+
+    def test_init_cancel_at_auth_menu(self):
+        """Test canceling init at authentication menu"""
+        self.create_test_profile("cancel_auth_test", endpoint="grpc://test:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Endpoint - Don't save
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Database - Don't save
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # At auth menu - press Escape
+        child.expect("authentication", timeout=5)
+        child.send('\x1b')
+
+        child.expect(pexpect.EOF, timeout=5)
+
+
+class TestProfileDeleteInteractive(ProfileTestBase):
+    """Test 'ydb config profile delete' interactive mode"""
+
+    def test_delete_profile_interactive_confirm(self):
+        """Delete profile with interactive confirmation"""
+        self.create_test_profile("to_delete", endpoint="grpc://localhost:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "delete", "to_delete"])
+
+        # Confirmation prompt - default is No (index 1), need to go up to Yes
+        child.expect("will be permanently removed", timeout=5)
+        child.send('\x1b[A')  # Up to Yes
+        child.send('\n')  # Confirm
+
+        child.expect("deleted", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert config is None or 'to_delete' not in config.get('profiles', {})
+
+    def test_delete_profile_interactive_decline(self):
+        """Decline deletion in interactive mode"""
+        self.create_test_profile("keep_me", endpoint="grpc://localhost:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "delete", "keep_me"])
+
+        child.expect("will be permanently removed", timeout=5)
+        # Default is No (index 1), just press Enter to decline
+        child.send('\n')
+
+        child.expect("No changes made", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        # Profile should still exist
+        config = self.read_profile_file()
+        assert 'keep_me' in config['profiles']
+
+    def test_delete_profile_select_from_menu(self):
+        """Select profile to delete from menu"""
+        self.create_test_profile("profile_a", endpoint="grpc://a:2136")
+        self.create_test_profile("profile_b", endpoint="grpc://b:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "delete"])
+
+        child.expect("Please choose profile to remove", timeout=5)
+
+        # First option is "Don't remove anything"
+        # Select profile_a (second option)
+        child.send('\x1b[B')  # Down
+        child.send('\n')
+
+        # Confirm - default is No, need to go up to Yes
+        child.expect("will be permanently removed", timeout=5)
+        child.send('\x1b[A')  # Up to Yes
+        child.send('\n')
+
+        child.expect("deleted", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert 'profile_a' not in config.get('profiles', {})
+        assert 'profile_b' in config['profiles']
+
+    def test_delete_cancel_at_menu(self):
+        """Cancel deletion at menu selection"""
+        self.create_test_profile("keep_it", endpoint="grpc://localhost:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "delete"])
+
+        child.expect("Please choose profile to remove", timeout=5)
+
+        # Select "Don't remove anything" (first option)
+        child.send('\n')
+
+        child.expect("No changes made", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert 'keep_it' in config['profiles']
+
+
+class TestProfileActivateInteractive(ProfileTestBase):
+    """Test 'ydb config profile activate' interactive mode"""
+
+    def test_activate_select_from_menu(self):
+        """Select profile to activate from menu"""
+        self.create_test_profile("profile_a", endpoint="grpc://a:2136")
+        self.create_test_profile("profile_b", endpoint="grpc://b:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "activate"])
+
+        child.expect("Please choose profile to activate", timeout=5)
+
+        # First option is "Don't do anything"
+        # Select profile_b (third option - after "Don't do anything")
+        child.send('\x1b[B')  # Down
+        child.send('\x1b[B')  # Down
+        child.send('\n')
+
+        child.expect("is now active", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert config['active_profile'] == 'profile_b'
+
+    def test_activate_deactivate_option(self):
+        """Deactivate current profile from activate menu"""
+        self.create_test_profile("active_one", endpoint="grpc://localhost:2136", active=True)
+        self.create_test_profile("other", endpoint="grpc://other:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "activate"])
+
+        child.expect("Please choose profile to activate", timeout=5)
+
+        # When there's an active profile, option order is:
+        # 0: Don't do anything
+        # 1: Deactivate current
+        # 2+: profiles
+        child.send('\x1b[B')  # Down to "Deactivate"
+        child.send('\n')
+
+        child.expect("deactivated", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert config.get('active_profile') is None or config.get('active_profile') == ''
+
+
+class TestProfileGetInteractive(ProfileTestBase):
+    """Test 'ydb config profile get' interactive mode"""
+
+    def test_get_select_from_menu(self):
+        """Select profile to view from menu"""
+        self.create_test_profile(
+            "view_me",
+            endpoint="grpc://localhost:2136",
+            database="/Root"
+        )
+
+        child = self.spawn_ydb_cli(["config", "profile", "get"])
+
+        child.expect("Please choose profile to list its values", timeout=5)
+        child.send('\n')  # Select first profile
+
+        child.expect("endpoint:", timeout=5)
+        child.expect("grpc://localhost:2136", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+    def test_get_cancel_at_menu(self):
+        """Cancel get at menu selection"""
+        self.create_test_profile("profile", endpoint="grpc://localhost:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "get"])
+
+        child.expect("Please choose profile", timeout=5)
+        child.send('\x1b')  # Escape
+
+        child.expect("Cancelled", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+
+class TestProfileReplaceInteractive(ProfileTestBase):
+    """Test 'ydb config profile replace' interactive mode"""
+
+    def test_replace_confirm(self):
+        """Replace profile with confirmation"""
+        self.create_test_profile("replace_me", endpoint="grpc://old:2136")
+
+        child = self.spawn_ydb_cli([
+            "config", "profile", "replace", "replace_me",
+            "--endpoint", "grpc://new:2136"
+        ])
+
+        # Confirmation - default is No, need to go up to Yes
+        child.expect("will be replaced", timeout=5)
+        child.send('\x1b[A')  # Up to Yes
+        child.send('\n')
+
+        child.expect(pexpect.EOF, timeout=5)
+
+        config = self.read_profile_file()
+        assert config['profiles']['replace_me']['endpoint'] == 'grpc://new:2136'
+
+    def test_replace_decline(self):
+        """Decline replacement"""
+        self.create_test_profile("keep_me", endpoint="grpc://old:2136")
+
+        child = self.spawn_ydb_cli([
+            "config", "profile", "replace", "keep_me",
+            "--endpoint", "grpc://new:2136"
+        ])
+
+        # Confirmation - default is No, just press Enter to decline
+        child.expect("will be replaced", timeout=5)
+        child.send('\n')
+
+        child.expect(pexpect.EOF, timeout=5)
+
+        # Original should be preserved
+        config = self.read_profile_file()
+        assert config['profiles']['keep_me']['endpoint'] == 'grpc://old:2136'
+
+
+# =============================================================================
+# Edge cases and error handling
+# =============================================================================
+
+class TestProfileIamAuth(ProfileTestBase):
+    """Test IAM authentication options"""
+
+    def test_create_profile_with_sa_key_file(self):
+        """Create profile with service account key file"""
+        sa_key_file = str(self.tmp_path / "sa_key.json")
+        with open(sa_key_file, 'w') as f:
+            f.write('{"id": "test", "service_account_id": "sa1", "private_key": "key"}')
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "sa_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--sa-key-file", sa_key_file
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['sa_profile']['authentication']['method'] == 'sa-key-file'
+        assert config['profiles']['sa_profile']['authentication']['data'] == sa_key_file
+
+    def test_create_profile_with_oauth2_key_file(self):
+        """Create profile with OAuth2 key file"""
+        oauth2_file = str(self.tmp_path / "oauth2.json")
+        with open(oauth2_file, 'w') as f:
+            f.write('{"grant-type": "urn:ietf:params:oauth:grant-type:token-exchange"}')
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "oauth2_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--oauth2-key-file", oauth2_file
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['oauth2_profile']['authentication']['method'] == 'oauth2-key-file'
+        assert config['profiles']['oauth2_profile']['authentication']['data'] == oauth2_file
+
+    def test_create_profile_with_metadata_credentials(self):
+        """Create profile with metadata credentials (VM auth)"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "vm_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--use-metadata-credentials"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['vm_profile']['authentication']['method'] == 'use-metadata-credentials'
+
+    def test_create_profile_with_iam_endpoint(self):
+        """Create profile with custom IAM endpoint"""
+        sa_key_file = str(self.tmp_path / "sa_key.json")
+        with open(sa_key_file, 'w') as f:
+            f.write('{"id": "test"}')
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "iam_profile",
+            "--endpoint", "grpc://localhost:2136",
+            "--sa-key-file", sa_key_file,
+            "--iam-endpoint", "iam.api.cloud.yandex.net:443"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['iam_profile']['iam-endpoint'] == 'iam.api.cloud.yandex.net:443'
+
+    def test_update_remove_iam_endpoint(self):
+        """Remove IAM endpoint with --no-iam-endpoint"""
+        self.create_test_profile("iam_test", endpoint="grpc://localhost:2136")
+        # Manually add iam-endpoint
+        config = self.read_profile_file()
+        config['profiles']['iam_test']['iam-endpoint'] = 'iam.example.com'
+        self.write_profile_file(config)
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "iam_test",
+            "--no-iam-endpoint"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'iam-endpoint' not in config['profiles']['iam_test']
+
+
+class TestProfileEdgeCases(ProfileTestBase):
+    """Test edge cases and error handling"""
+
+    def test_profile_name_with_special_characters(self):
+        """Profile names with special characters"""
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "test-profile_123",
+            "--endpoint", "grpc://localhost:2136"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'test-profile_123' in config['profiles']
+
+    def test_empty_profile_name_fails_interactive(self):
+        """Empty profile name should be rejected"""
+        child = self.spawn_ydb_cli(["config", "profile", "create"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please enter configuration profile name", timeout=5)
+
+        # Try to submit empty name
+        child.send('\n')  # Just press Enter without typing anything
+
+        # Should show error and not proceed
+        child.expect("cannot be empty", timeout=5)
+
+        child.send('\x1b')  # Cancel
+        child.expect(pexpect.EOF, timeout=10)
+
+    def test_password_file_without_user_fails(self):
+        """Using --password-file without --user should fail"""
+        password_file = str(self.tmp_path / "password.txt")
+        with open(password_file, 'w') as f:
+            f.write("test_password")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "bad_profile",
+            "--password-file", password_file
+        ], check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "password-file without user" in result['stderr']
+
+    def test_endpoint_with_database_in_url_via_stdin(self):
+        """Endpoint URL with database parameter via stdin (ParseUrl extracts database)"""
+        # Note: database extraction from URL only works when reading from stdin,
+        # not when using --endpoint command line option
+        stdin_content = """endpoint: grpc://localhost:2136?database=/Root
+"""
+        stdin_file = str(self.tmp_path / "stdin_url.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "url_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        # Should extract database from URL
+        assert config['profiles']['url_profile']['endpoint'] == 'grpc://localhost:2136'
+        assert config['profiles']['url_profile']['database'] == '/Root'
+
+    def test_profile_with_all_ssl_options(self):
+        """Create profile with all SSL/TLS options"""
+        ca_file = str(self.tmp_path / "ca.pem")
+        cert_file = str(self.tmp_path / "cert.pem")
+        key_file = str(self.tmp_path / "key.pem")
+        key_password_file = str(self.tmp_path / "key_password.txt")
+
+        for f in [ca_file, cert_file, key_file, key_password_file]:
+            with open(f, 'w') as fh:
+                fh.write("fake_content")
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "create", "full_ssl",
+            "--endpoint", "grpcs://localhost:2136",
+            "--ca-file", ca_file,
+            "--client-cert-file", cert_file,
+            "--client-cert-key-file", key_file,
+            "--client-cert-key-password-file", key_password_file
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        profile = config['profiles']['full_ssl']
+        assert profile['ca-file'] == ca_file
+        assert profile['client-cert-file'] == cert_file
+        assert profile['client-cert-key-file'] == key_file
+        assert profile['client-cert-key-password-file'] == key_password_file
+
+    def test_update_remove_ssl_options(self):
+        """Remove SSL options with --no-* flags"""
+        ca_file = str(self.tmp_path / "ca.pem")
+        cert_file = str(self.tmp_path / "cert.pem")
+        key_file = str(self.tmp_path / "key.pem")
+
+        for f in [ca_file, cert_file, key_file]:
+            with open(f, 'w') as fh:
+                fh.write("fake")
+
+        self.execute_ydb_cli([
+            "config", "profile", "create", "ssl_remove_test",
+            "--endpoint", "grpcs://localhost:2136",
+            "--ca-file", ca_file,
+            "--client-cert-file", cert_file,
+            "--client-cert-key-file", key_file
+        ])
+
+        result = self.execute_ydb_cli([
+            "config", "profile", "update", "ssl_remove_test",
+            "--no-ca-file",
+            "--no-client-cert-file",
+            "--no-client-cert-key-file"
+        ])
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        profile = config['profiles']['ssl_remove_test']
+        assert 'ca-file' not in profile
+        assert 'client-cert-file' not in profile
+        assert 'client-cert-key-file' not in profile
+
+    def test_multiple_profiles_management(self):
+        """Test managing multiple profiles"""
+        # Create several profiles
+        for i in range(5):
+            self.execute_ydb_cli([
+                "config", "profile", "create", f"profile_{i}",
+                "--endpoint", f"grpc://host{i}:2136",
+                "--database", f"/Db{i}"
+            ])
+
+        # Verify all created
+        config = self.read_profile_file()
+        assert len(config['profiles']) == 5
+
+        # Activate one
+        self.execute_ydb_cli(["config", "profile", "activate", "profile_2"])
+        config = self.read_profile_file()
+        assert config['active_profile'] == 'profile_2'
+
+        # Delete one
+        self.execute_ydb_cli(["config", "profile", "delete", "profile_3", "--force"])
+        config = self.read_profile_file()
+        assert 'profile_3' not in config['profiles']
+        assert len(config['profiles']) == 4
+
+        # Update one
+        self.execute_ydb_cli([
+            "config", "profile", "update", "profile_4",
+            "--endpoint", "grpc://updated:2136"
+        ])
+        config = self.read_profile_file()
+        assert config['profiles']['profile_4']['endpoint'] == 'grpc://updated:2136'
+
+
+class TestProfileStdinInput(ProfileTestBase):
+    """Test profile creation from stdin (non-interactive piped input)"""
+
+    def test_create_profile_from_stdin(self):
+        """Create profile with options piped via stdin"""
+        stdin_content = """endpoint: grpc://stdin-host:2136
+database: /StdinDb
+anonymous-auth
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "stdin_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'stdin_profile' in config['profiles']
+        assert config['profiles']['stdin_profile']['endpoint'] == 'grpc://stdin-host:2136'
+        assert config['profiles']['stdin_profile']['database'] == '/StdinDb'
+        assert config['profiles']['stdin_profile']['authentication']['method'] == 'anonymous-auth'
+
+    def test_create_profile_from_stdin_with_token(self):
+        """Create profile with token-file from stdin"""
+        token_file = str(self.tmp_path / "token.txt")
+        with open(token_file, 'w') as f:
+            f.write("my_token")
+
+        stdin_content = f"""endpoint: grpc://localhost:2136
+database: /Root
+token-file: {token_file}
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "token_stdin"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['token_stdin']['authentication']['method'] == 'token-file'
+
+    def test_create_profile_from_stdin_with_static_creds(self):
+        """Create profile with static credentials from stdin"""
+        password_file = str(self.tmp_path / "password.txt")
+        with open(password_file, 'w') as f:
+            f.write("secret_password")
+
+        stdin_content = f"""endpoint: grpc://localhost:2136
+database: /Root
+user: admin
+password-file: {password_file}
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "static_stdin"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        auth = config['profiles']['static_stdin']['authentication']
+        assert auth['method'] == 'static-credentials'
+        assert auth['data']['user'] == 'admin'
+
+    def test_create_profile_from_stdin_duplicate_option_fails(self):
+        """Duplicate options in stdin should fail"""
+        stdin_content = """endpoint: grpc://host1:2136
+endpoint: grpc://host2:2136
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "dup_profile"
+            ], stdin=f, check_exit_code=False)
+
+        assert result['exit_code'] != 0
+        assert "too many" in result['stderr'].lower()
+
+    def test_create_profile_with_sa_key_file(self):
+        """Create profile with service account key file auth"""
+        sa_key_content = '{"id": "key123", "service_account_id": "sa123", "private_key": "key"}'
+        sa_key_file = str(self.tmp_path / "sa_key.json")
+        with open(sa_key_file, 'w') as f:
+            f.write(sa_key_content)
+
+        stdin_content = f"""endpoint: grpc://localhost:2136
+database: /Root
+sa-key-file: {sa_key_file}
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "sa_key_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'sa_key_profile' in config['profiles']
+        assert config['profiles']['sa_key_profile']['authentication']['method'] == 'sa-key-file'
+
+    def test_create_profile_with_yc_token_file(self):
+        """Create profile with yc-token-file auth"""
+        yc_token_file = str(self.tmp_path / "yc_token.txt")
+        with open(yc_token_file, 'w') as f:
+            f.write("yc_oauth_token_content")
+
+        stdin_content = f"""endpoint: grpc://localhost:2136
+yc-token-file: {yc_token_file}
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "yc_token_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['yc_token_profile']['authentication']['method'] == 'yc-token-file'
+
+    def test_create_profile_with_oauth2_key_file(self):
+        """Create profile with oauth2-key-file auth"""
+        oauth2_file = str(self.tmp_path / "oauth2.json")
+        with open(oauth2_file, 'w') as f:
+            f.write('{"token_endpoint": "https://example.com/token"}')
+
+        stdin_content = f"""endpoint: grpc://localhost:2136
+oauth2-key-file: {oauth2_file}
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "oauth2_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['oauth2_profile']['authentication']['method'] == 'oauth2-key-file'
+
+    def test_create_profile_with_iam_token_file(self):
+        """Create profile with iam-token-file auth"""
+        iam_token_file = str(self.tmp_path / "iam_token.txt")
+        with open(iam_token_file, 'w') as f:
+            f.write("iam_token_content_here")
+
+        stdin_content = f"""endpoint: grpc://localhost:2136
+iam-token-file: {iam_token_file}
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "iam_token_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        # IAM token file is stored as token-file method
+        assert config['profiles']['iam_token_profile']['authentication']['method'] == 'token-file'
+
+    def test_create_profile_with_ca_file(self):
+        """Create profile with CA certificate file"""
+        ca_file = str(self.tmp_path / "ca.pem")
+        with open(ca_file, 'w') as f:
+            f.write("-----BEGIN CERTIFICATE-----\nCA_CERT_CONTENT\n-----END CERTIFICATE-----")
+
+        stdin_content = f"""endpoint: grpcs://localhost:2136
+ca-file: {ca_file}
+anonymous-auth
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "ca_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert 'ca_profile' in config['profiles']
+        assert config['profiles']['ca_profile']['ca-file'] == ca_file
+
+    def test_create_profile_with_iam_endpoint(self):
+        """Create profile with custom IAM endpoint"""
+        sa_key_content = '{"id": "key123"}'
+        sa_key_file = str(self.tmp_path / "sa_key.json")
+        with open(sa_key_file, 'w') as f:
+            f.write(sa_key_content)
+
+        stdin_content = f"""endpoint: grpc://localhost:2136
+sa-key-file: {sa_key_file}
+iam-endpoint: https://custom-iam.example.com/v1/tokens
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "iam_endpoint_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['iam_endpoint_profile']['iam-endpoint'] == 'https://custom-iam.example.com/v1/tokens'
+
+    def test_create_profile_only_endpoint(self):
+        """Create profile with only endpoint"""
+        stdin_content = """endpoint: grpc://endpoint-only:2136
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "endpoint_only_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['endpoint_only_profile']['endpoint'] == 'grpc://endpoint-only:2136'
+        # No auth should be set
+        assert 'authentication' not in config['profiles']['endpoint_only_profile']
+
+    def test_create_profile_only_database(self):
+        """Create profile with only database"""
+        stdin_content = """database: /DbOnly
+"""
+        stdin_file = str(self.tmp_path / "stdin.txt")
+        with open(stdin_file, 'w') as f:
+            f.write(stdin_content)
+
+        with open(stdin_file, 'r') as f:
+            result = self.execute_ydb_cli([
+                "config", "profile", "create", "db_only_profile"
+            ], stdin=f)
+
+        assert result['exit_code'] == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['db_only_profile']['database'] == '/DbOnly'
+
+
+class TestProfileMenuNavigation(ProfileTestBase):
+    """Test interactive menu navigation edge cases"""
+
+    def test_input_validation_retry(self):
+        """Test that invalid input shows error and allows retry"""
+        child = self.spawn_ydb_cli(["config", "profile", "create"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please enter configuration profile name", timeout=5)
+
+        # Try empty name
+        child.send('\n')  # Press Enter without typing
+        child.expect("cannot be empty", timeout=5)
+
+        # Now enter valid name
+        child.send("valid_name")
+        child.send('\n')  # Confirm
+
+        # Should proceed to endpoint menu
+        child.expect("endpoint", timeout=5)
+
+        # Cancel
+        child.send('\x1b')
+        child.expect(pexpect.EOF, timeout=10)
+
+    def test_page_navigation_in_large_menu(self):
+        """Test pagination in menu with many options"""
+        # Create many profiles to trigger pagination
+        for i in range(20):
+            self.create_test_profile(f"profile_{i:02d}", endpoint=f"grpc://host{i}:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "get"])
+
+        child.expect("Please choose profile", timeout=5)
+
+        # Navigate down through pages
+        for _ in range(15):
+            child.send('\x1b[B')  # Down
+
+        # Select current option
+        child.send('\n')
+
+        # Should show profile content
+        child.expect("endpoint:", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+    def test_use_current_value_option(self):
+        """Test 'Use current value' option when modifying existing profile"""
+        self.create_test_profile(
+            "existing",
+            endpoint="grpc://original:2136",
+            database="/OriginalDb"
+        )
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Select existing profile
+        child.send('\x1b[B')  # Down to existing
+        child.send('\n')
+
+        # Endpoint menu - select "Use current endpoint value"
+        child.expect("endpoint", timeout=5)
+        child.send('\x1b[B')  # Down
+        child.send('\x1b[B')  # Down to "Use current"
+        child.send('\n')
+
+        # Database menu - select "Use current database value"
+        child.expect("database", timeout=5)
+        child.send('\x1b[B')
+        child.send('\x1b[B')
+        child.send('\n')
+
+        # Auth menu - select "Don't save authentication data" (index 8)
+        child.expect("authentication", timeout=5)
+        for _ in range(8):
+            child.send('\x1b[B')
+        child.send('\n')
+
+        # Activate - No
+        child.expect("Activate", timeout=5)
+        child.send('\x1b[B')  # No
+        child.send('\n')
+
+        child.expect("configured successfully", timeout=5)
+        child.expect(pexpect.EOF, timeout=5)
+
+        # Verify original values preserved
+        config = self.read_profile_file()
+        assert config['profiles']['existing']['endpoint'] == 'grpc://original:2136'
+        assert config['profiles']['existing']['database'] == '/OriginalDb'
+
+
+
+
+
+
+class TestProfileStdinInputAdditional(ProfileTestBase):
+    """Additional stdin input tests"""
+
+    def test_stdin_with_metadata_credentials(self):
+        """Test profile creation from stdin with metadata credentials"""
+        stdin_data = "endpoint: grpc://metadata:2136\nuse-metadata-credentials\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "metadata_profile"],
+            stdin=stdin_data
+        )
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'metadata_profile' in config['profiles']
+        assert config['profiles']['metadata_profile']['endpoint'] == 'grpc://metadata:2136'
+        assert config['profiles']['metadata_profile']['authentication']['method'] == 'use-metadata-credentials'
+
+    def test_stdin_with_anonymous_auth(self):
+        """Test profile creation from stdin with anonymous auth"""
+        stdin_data = "endpoint: grpc://anon:2136\nanonymous-auth\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "anon_stdin_profile"],
+            stdin=stdin_data
+        )
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'anon_stdin_profile' in config['profiles']
+        assert config['profiles']['anon_stdin_profile']['authentication']['method'] == 'anonymous-auth'
+
+    def test_stdin_with_iam_endpoint(self):
+        """Test profile creation from stdin with IAM endpoint"""
+        sa_key_file = self.create_temp_file('{"id": "key1"}', "sa_key.json")
+        stdin_data = f"endpoint: grpc://iam:2136\nsa-key-file: {sa_key_file}\niam-endpoint: iam.api.cloud.yandex.net\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "iam_stdin_profile"],
+            stdin=stdin_data
+        )
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'iam_stdin_profile' in config['profiles']
+        assert config['profiles']['iam_stdin_profile']['iam-endpoint'] == 'iam.api.cloud.yandex.net'
+
+    def test_stdin_duplicate_endpoint_fails(self):
+        """Test that duplicate endpoint in stdin fails"""
+        stdin_data = "endpoint: grpc://first:2136\nendpoint: grpc://second:2136\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "dup_endpoint"],
+            stdin=stdin_data
+        )
+        assert result.returncode != 0
+        assert "too many" in result.stderr.lower()
+
+    def test_stdin_duplicate_database_fails(self):
+        """Test that duplicate database in stdin fails"""
+        stdin_data = "database: /First\ndatabase: /Second\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "dup_db"],
+            stdin=stdin_data
+        )
+        assert result.returncode != 0
+        assert "too many" in result.stderr.lower()
+
+    def test_stdin_duplicate_metadata_credentials_fails(self):
+        """Test that duplicate metadata credentials in stdin fails"""
+        stdin_data = "use-metadata-credentials\nuse-metadata-credentials\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "dup_meta"],
+            stdin=stdin_data
+        )
+        assert result.returncode != 0
+
+    def test_stdin_duplicate_anonymous_auth_fails(self):
+        """Test that duplicate anonymous auth in stdin fails"""
+        stdin_data = "anonymous-auth\nanonymous-auth\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "dup_anon"],
+            stdin=stdin_data
+        )
+        assert result.returncode != 0
+
+
+class TestProfileYcTokenAuth(ProfileTestBase):
+    """Test YC token authentication"""
+
+    def test_create_profile_with_yc_token_file(self):
+        """Test profile creation with YC token file"""
+        yc_token_file = self.create_temp_file("yc-oauth-token-content", "yc_token.txt")
+        result = self.run_ydb_cli([
+            "config", "profile", "create", "yc_profile",
+            "--yc-token-file", yc_token_file
+        ])
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'yc_profile' in config['profiles']
+        assert config['profiles']['yc_profile']['authentication']['method'] == 'yc-token-file'
+        assert config['profiles']['yc_profile']['authentication']['data'] == yc_token_file
+
+    def test_stdin_with_yc_token_file(self):
+        """Test profile creation from stdin with YC token file"""
+        yc_token_file = self.create_temp_file("yc-oauth-token", "yc.txt")
+        stdin_data = f"endpoint: grpc://yc:2136\nyc-token-file: {yc_token_file}\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "yc_stdin_profile"],
+            stdin=stdin_data
+        )
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'yc_stdin_profile' in config['profiles']
+        assert config['profiles']['yc_stdin_profile']['authentication']['method'] == 'yc-token-file'
+
+
+class TestProfileValidationErrors(ProfileTestBase):
+    """Test validation error cases"""
+
+    def test_multiple_auth_methods_detailed(self):
+        """Test error message lists all provided auth methods"""
+        token_file = self.create_temp_file("token", "t.txt")
+        sa_key_file = self.create_temp_file('{"id": "k"}', "sa.json")
+
+        result = self.run_ydb_cli([
+            "config", "profile", "create", "multi_auth",
+            "--token-file", token_file,
+            "--sa-key-file", sa_key_file
+        ])
+        assert result.returncode != 0
+        assert "2 authentication methods" in result.stderr
+
+    def test_token_file_and_metadata_fails(self):
+        """Test that token file and metadata credentials together fail"""
+        token_file = self.create_temp_file("token", "t.txt")
+        result = self.run_ydb_cli([
+            "config", "profile", "create", "conflict_auth",
+            "--token-file", token_file,
+            "--use-metadata-credentials"
+        ])
+        assert result.returncode != 0
+
+    def test_token_file_and_anonymous_fails(self):
+        """Test that token file and anonymous auth together fail"""
+        token_file = self.create_temp_file("token", "t.txt")
+        result = self.run_ydb_cli([
+            "config", "profile", "create", "conflict_auth2",
+            "--token-file", token_file,
+            "--anonymous-auth"
+        ])
+        assert result.returncode != 0
+
+    def test_user_and_token_file_fails(self):
+        """Test that user and token file together fail"""
+        token_file = self.create_temp_file("token", "t.txt")
+        password_file = self.create_temp_file("pass", "p.txt")
+        result = self.run_ydb_cli([
+            "config", "profile", "create", "conflict_auth3",
+            "--token-file", token_file,
+            "--user", "testuser",
+            "--password-file", password_file
+        ])
+        assert result.returncode != 0
+
+
+class TestProfileUpdateAdditional(ProfileTestBase):
+    """Additional update command tests"""
+
+    def test_update_replace_auth_method(self):
+        """Test updating profile to replace auth method"""
+        # Create with token
+        token_file = self.create_temp_file("original-token", "token.txt")
+        self.create_test_profile("test", token_file=token_file)
+
+        # Update with different auth
+        new_token_file = self.create_temp_file("new-token", "new_token.txt")
+        result = self.run_ydb_cli([
+            "config", "profile", "update", "test",
+            "--token-file", new_token_file
+        ])
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['test']['authentication']['data'] == new_token_file
+
+    def test_update_add_ca_file(self):
+        """Test adding CA file to existing profile"""
+        self.create_test_profile("test", endpoint="grpc://test:2136")
+
+        ca_file = self.create_temp_file("CA-CERT", "ca.pem")
+        result = self.run_ydb_cli([
+            "config", "profile", "update", "test",
+            "--ca-file", ca_file
+        ])
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert config['profiles']['test']['ca-file'] == ca_file
+
+    def test_update_becomes_empty_recreates(self):
+        """Test that update that removes all values recreates profile"""
+        self.create_test_profile("test", endpoint="grpc://test:2136")
+
+        result = self.run_ydb_cli([
+            "config", "profile", "update", "test",
+            "--no-endpoint"
+        ])
+        assert result.returncode == 0
+
+        # Profile should still exist (empty profiles are valid)
+        config = self.read_profile_file()
+        assert 'test' in config['profiles']
+
+
+class TestProfileGetAdditional(ProfileTestBase):
+    """Additional get profile tests"""
+
+    def test_get_profile_with_all_auth_types_display(self):
+        """Test get profile displays various auth types correctly"""
+        # Test with static credentials
+        password_file = self.create_temp_file("secret", "pass.txt")
+        self.write_profile_file({
+            'profiles': {
+                'static_test': {
+                    'endpoint': 'grpc://test:2136',
+                    'authentication': {
+                        'method': 'static-credentials',
+                        'data': {
+                            'user': 'testuser',
+                            'password-file': password_file
+                        }
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "static_test"])
+        assert result.returncode == 0
+        assert "static-credentials" in result.stdout
+        assert "testuser" in result.stdout
+
+    def test_get_profile_with_iam_endpoint(self):
+        """Test get profile displays IAM endpoint"""
+        sa_key_file = self.create_temp_file('{"id": "key"}', "sa.json")
+        self.write_profile_file({
+            'profiles': {
+                'iam_test': {
+                    'endpoint': 'grpc://test:2136',
+                    'iam-endpoint': 'iam.api.cloud.yandex.net',
+                    'authentication': {
+                        'method': 'sa-key-file',
+                        'data': sa_key_file
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "iam_test"])
+        assert result.returncode == 0
+        assert "iam-endpoint" in result.stdout
+
+    def test_get_profile_with_ssl_options(self):
+        """Test get profile displays SSL options"""
+        ca_file = self.create_temp_file("CA", "ca.pem")
+        cert_file = self.create_temp_file("CERT", "cert.pem")
+        key_file = self.create_temp_file("KEY", "key.pem")
+
+        self.write_profile_file({
+            'profiles': {
+                'ssl_test': {
+                    'endpoint': 'grpcs://test:2136',
+                    'ca-file': ca_file,
+                    'client-cert-file': cert_file,
+                    'client-cert-key-file': key_file
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "ssl_test"])
+        assert result.returncode == 0
+        assert "ca-file" in result.stdout
+        assert "client-cert-file" in result.stdout
+        assert "client-cert-key-file" in result.stdout
+
+
+class TestProfileListAdditional(ProfileTestBase):
+    """Additional list profiles tests"""
+
+    def test_list_with_content_shows_auth_methods(self):
+        """Test list --with-content shows authentication methods"""
+        token_file = self.create_temp_file("token", "t.txt")
+        self.write_profile_file({
+            'profiles': {
+                'token_profile': {
+                    'endpoint': 'grpc://test:2136',
+                    'authentication': {
+                        'method': 'token-file',
+                        'data': token_file
+                    }
+                },
+                'anon_profile': {
+                    'endpoint': 'grpc://anon:2136',
+                    'authentication': {
+                        'method': 'anonymous-auth'
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "list", "--with-content"])
+        assert result.returncode == 0
+        assert "token-file" in result.stdout or "token_profile" in result.stdout
+        assert "anonymous-auth" in result.stdout or "anon_profile" in result.stdout
+
+
+class TestProfileActivateEdgeCases(ProfileTestBase):
+    """Edge cases for activate/deactivate"""
+
+    def test_activate_when_no_profiles_exist(self):
+        """Test activate fails when no profiles exist"""
+        # Ensure no profiles
+        self.write_profile_file({'profiles': {}})
+
+        result = self.run_ydb_cli(["config", "profile", "activate", "nonexistent"])
+        assert result.returncode != 0
+
+    def test_activate_interactive_exit_without_selection(self):
+        """Test activate interactive mode with Escape cancels"""
+        self.create_test_profile("test", endpoint="grpc://test:2136")
+
+        child = self.spawn_ydb_cli(["config", "profile", "activate"])
+
+        child.expect("Please choose profile to activate", timeout=5)
+        child.send('\x1b')  # Escape
+
+        child.expect(pexpect.EOF, timeout=5)
+
+
+class TestProfileDeleteEdgeCases(ProfileTestBase):
+    """Edge cases for delete command"""
+
+    def test_delete_active_profile(self):
+        """Test deleting the currently active profile"""
+        self.create_test_profile("active_test", endpoint="grpc://test:2136")
+        self.set_active_profile("active_test")
+
+        result = self.run_ydb_cli([
+            "config", "profile", "delete", "active_test", "--force"
+        ])
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'active_test' not in config.get('profiles', {})
+
+    def test_delete_when_no_profiles_exist(self):
+        """Test delete fails gracefully when no profiles exist"""
+        self.write_profile_file({'profiles': {}})
+
+        result = self.run_ydb_cli(["config", "profile", "delete", "nonexistent"])
+        assert result.returncode != 0
+
+
+class TestProfileReplaceEdgeCases(ProfileTestBase):
+    """Edge cases for replace command"""
+
+    def test_replace_nonexistent_creates(self):
+        """Test replace creates profile if it doesn't exist"""
+        result = self.run_ydb_cli([
+            "config", "profile", "replace", "new_replace",
+            "--endpoint", "grpc://new:2136"
+        ])
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'new_replace' in config['profiles']
+        assert config['profiles']['new_replace']['endpoint'] == 'grpc://new:2136'
+
+    def test_replace_interactive_decline(self):
+        """Test replace with interactive decline"""
+        self.create_test_profile("to_replace", endpoint="grpc://original:2136")
+
+        child = self.spawn_ydb_cli([
+            "config", "profile", "replace", "to_replace",
+            "--endpoint", "grpc://new:2136"
+        ])
+
+        # Should ask for confirmation
+        child.expect("replaced", timeout=5)
+        child.send('\x1b[B')  # Down to No
+        child.send('\n')
+
+        child.expect(pexpect.EOF, timeout=5)
+
+        # Original should be preserved
+        config = self.read_profile_file()
+        assert config['profiles']['to_replace']['endpoint'] == 'grpc://original:2136'
+
+
+class TestProfileUrlParsing(ProfileTestBase):
+    """Test URL parsing with database in query string"""
+
+    def test_url_with_database_query_param(self):
+        """Test endpoint URL with database in query parameter"""
+        stdin_data = "endpoint: grpc://test:2136/?database=/QueryDb\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "url_test"],
+            stdin=stdin_data
+        )
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'url_test' in config['profiles']
+        # Database should be extracted from URL
+        assert config['profiles']['url_test'].get('database') == '/QueryDb'
+
+    def test_url_and_separate_database_fails(self):
+        """Test that URL with database and separate database option fails"""
+        stdin_data = "endpoint: grpc://test:2136/?database=/QueryDb\ndatabase: /AnotherDb\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "url_conflict"],
+            stdin=stdin_data
+        )
+        assert result.returncode != 0
+        assert "too many" in result.stderr.lower()
+
+
+class TestProfileInitEdgeCases(ProfileTestBase):
+    """Edge cases for init command"""
+
+    def test_init_with_many_profiles_pagination(self):
+        """Test init with many profiles shows pagination"""
+        # Create many profiles to trigger pagination
+        for i in range(25):
+            self.create_test_profile(f"profile_{i:02d}", endpoint=f"grpc://test{i}:2136")
+
+        child = self.spawn_ydb_cli(["init"])
+
+        child.expect("Welcome", timeout=5)
+        child.expect("Please choose profile to configure", timeout=5)
+
+        # Navigate through pages
+        child.send('\x1b[C')  # Right arrow for next page
+
+        # Cancel
+        child.send('\x1b')
+
+        child.expect(pexpect.EOF, timeout=5)
+
+
+class TestProfilePrintContent(ProfileTestBase):
+    """Test profile content display for various auth types"""
+
+    def test_display_ydb_token_auth(self):
+        """Test display of ydb-token authentication"""
+        self.write_profile_file({
+            'profiles': {
+                'token_test': {
+                    'authentication': {
+                        'method': 'ydb-token',
+                        'data': 'secret-token-value-12345'
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "token_test"])
+        assert result.returncode == 0
+        assert "ydb-token" in result.stdout
+
+    def test_display_iam_token_auth(self):
+        """Test display of iam-token authentication"""
+        self.write_profile_file({
+            'profiles': {
+                'iam_test': {
+                    'authentication': {
+                        'method': 'iam-token',
+                        'data': 'iam-token-secret-value'
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "iam_test"])
+        assert result.returncode == 0
+        assert "iam-token" in result.stdout
+
+    def test_display_yc_token_auth(self):
+        """Test display of yc-token authentication"""
+        self.write_profile_file({
+            'profiles': {
+                'yc_test': {
+                    'authentication': {
+                        'method': 'yc-token',
+                        'data': 'yc-oauth-token-secret'
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "yc_test"])
+        assert result.returncode == 0
+        assert "yc-token" in result.stdout
+
+    def test_display_static_credentials_with_password(self):
+        """Test display of static credentials with password"""
+        self.write_profile_file({
+            'profiles': {
+                'static_test': {
+                    'authentication': {
+                        'method': 'static-credentials',
+                        'data': {
+                            'user': 'myuser',
+                            'password': 'secret123'
+                        }
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "static_test"])
+        assert result.returncode == 0
+        assert "static-credentials" in result.stdout
+        assert "myuser" in result.stdout
+        # Password should be shown (possibly blurred in interactive mode)
+        assert "password" in result.stdout.lower()
+
+    def test_display_use_metadata_credentials(self):
+        """Test display of use-metadata-credentials"""
+        self.write_profile_file({
+            'profiles': {
+                'meta_test': {
+                    'authentication': {
+                        'method': 'use-metadata-credentials'
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "meta_test"])
+        assert result.returncode == 0
+        assert "use-metadata-credentials" in result.stdout
+
+    def test_display_oauth2_key_file(self):
+        """Test display of oauth2-key-file authentication"""
+        oauth2_file = self.create_temp_file('{"key": "value"}', "oauth2.json")
+        self.write_profile_file({
+            'profiles': {
+                'oauth2_test': {
+                    'authentication': {
+                        'method': 'oauth2-key-file',
+                        'data': oauth2_file
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "oauth2_test"])
+        assert result.returncode == 0
+        assert "oauth2-key-file" in result.stdout
+
+    def test_display_token_file(self):
+        """Test display of token-file authentication"""
+        token_file = self.create_temp_file("my-token", "token.txt")
+        self.write_profile_file({
+            'profiles': {
+                'tf_test': {
+                    'authentication': {
+                        'method': 'token-file',
+                        'data': token_file
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "tf_test"])
+        assert result.returncode == 0
+        assert "token-file" in result.stdout
+
+    def test_display_yc_token_file(self):
+        """Test display of yc-token-file authentication"""
+        yc_token_file = self.create_temp_file("yc-token", "yc.txt")
+        self.write_profile_file({
+            'profiles': {
+                'yctf_test': {
+                    'authentication': {
+                        'method': 'yc-token-file',
+                        'data': yc_token_file
+                    }
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "yctf_test"])
+        assert result.returncode == 0
+        assert "yc-token-file" in result.stdout
+
+    def test_display_client_cert_key_password_file(self):
+        """Test display of client cert key password file"""
+        ca_file = self.create_temp_file("CA", "ca.pem")
+        cert_file = self.create_temp_file("CERT", "cert.pem")
+        key_file = self.create_temp_file("KEY", "key.pem")
+        password_file = self.create_temp_file("pass", "keypass.txt")
+
+        self.write_profile_file({
+            'profiles': {
+                'fullssl_test': {
+                    'endpoint': 'grpcs://test:2136',
+                    'ca-file': ca_file,
+                    'client-cert-file': cert_file,
+                    'client-cert-key-file': key_file,
+                    'client-cert-key-password-file': password_file
+                }
+            }
+        })
+
+        result = self.run_ydb_cli(["config", "profile", "get", "fullssl_test"])
+        assert result.returncode == 0
+        assert "client-cert-key-password-file" in result.stdout
+
+
+
+
+class TestProfileIamTokenFile(ProfileTestBase):
+    """Test iam-token-file option (mapped to token-file internally)"""
+
+    def test_create_with_iam_token_file_hidden(self):
+        """Test that iam-token-file is treated as token-file"""
+        # iam-token-file is a hidden option that maps to token-file
+        token_file = self.create_temp_file("iam-token-content", "iam.txt")
+
+        # Use stdin to provide the option
+        stdin_data = f"iam-token-file: {token_file}\n"
+        result = self.run_ydb_cli(
+            ["config", "profile", "create", "iam_file_test"],
+            stdin=stdin_data
+        )
+        assert result.returncode == 0
+
+        config = self.read_profile_file()
+        assert 'iam_file_test' in config['profiles']
+        # Should be stored as token-file
+        assert config['profiles']['iam_file_test']['authentication']['method'] == 'token-file'

--- a/ydb/tests/functional/ydb_cli/ya.make
+++ b/ydb/tests/functional/ydb_cli/ya.make
@@ -6,6 +6,7 @@ TEST_SRCS(
     test_ydb_common.py
     test_ydb_flame_graph.py
     test_ydb_impex.py
+    test_ydb_profile.py
     test_ydb_recursive_remove.py
     test_ydb_scheme.py
     test_ydb_scripting.py
@@ -30,7 +31,9 @@ DEPENDS(
 )
 
 PEERDIR(
+    contrib/python/pexpect
     contrib/python/pyarrow
+    contrib/python/PyYAML
     ydb/tests/library
     ydb/tests/library/fixtures
     ydb/tests/oss/canonical


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR migrates the profile management commands from readline-based text input to ftxui interactive UI components.

#### Changes in ydb_profile.cpp

**Replaced readline prompts with ftxui components:**
- `AskYesOrNo()` → ftxui Menu with Yes/No options
- `Prompt()` for text input → ftxui Input fields
- `Choose()` for selection → ftxui Menu

**Commands migrated:**
- `ydb init` - initial profile setup wizard
- `ydb config profile create` - interactive profile creation
- `ydb config profile activate` - profile activation selection
- `ydb config profile delete` - profile deletion with confirmation

**Benefits:**
- Consistent UI across all CLI interactive commands
- Better user experience with arrow key navigation
- Visual feedback for current selection
- Support for "Use current value" and "Don't save" options in menus

#### Tests

Added 127 functional tests covering:
- Profile creation with Input fields (endpoint, database, auth)
- Menu navigation and selection
- All authentication methods (anonymous, metadata, static, token file, IAM)
- Cancel scenarios at each step
- Profile listing, activation, deletion flows
