### PR TITLE
25-4: DataShard: restore uncommitted persistent state on migration

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -5414,17 +5414,17 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorConsistency) {
         }
         runtime.SimulateSleep(TDuration::Seconds(1));
 
-        // Commit the 1st transaction
+        // Commit the 1st transaction (it must abort, lock removal is migrated)
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSimpleCommit(runtime, session1, tx1, R"(SELECT 1)"),
-            "{ items { int32_value: 1 } }");
+            "ERROR: ABORTED");
 
         // Commit the 2nd transaction writing to the same index
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSimpleCommit(runtime, session2, tx2, R"(
                 UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 4003);
                 )"),
-            "ERROR: ABORTED");
+            "<empty>");
     }
 
     Y_UNIT_TEST(ReadLockConflictUncommittedBreakMigration) {
@@ -5534,17 +5534,294 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorConsistency) {
         }
         runtime.SimulateSleep(TDuration::Seconds(1));
 
-        // Commit the 1st transaction (it must succeed)
+        // Commit the 1st transaction (it must abort, lock break is migrated)
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSimpleCommit(runtime, session1, tx1, R"(SELECT 1)"),
-            "{ items { int32_value: 1 } }");
+            "ERROR: ABORTED");
 
         // Commit the 2nd transaction writing to the same index
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSimpleCommit(runtime, session2, tx2, R"(
                 UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 4003);
                 )"),
+            "<empty>");
+    }
+
+    Y_UNIT_TEST(ReadLockUncommittedRemoveThenNewConflictMigration) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(1)
+            .SetUseRealThreads(false);
+
+        // This test requires in-memory state migration to work
+        serverSettings.FeatureFlags.SetEnableDataShardInMemoryStateMigration(true);
+
+        TServer::TPtr server = new TServer(serverSettings);
+
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, index int, value int, PRIMARY KEY (key, index))
+                WITH (PARTITION_AT_KEYS = (10));
+            )"),
+            "SUCCESS"
+        );
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+
+        // Populate tables with initial values
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, index, value) VALUES
+                (1, 0, 1001),
+                (1, 1, 1002),
+                (11, 0, 2001);
+        )");
+
+        ui64 tx1lockId = 0;
+        ui32 tx1lockNode = 0;
+        auto shard1actor = ResolveTablet(runtime, shards.at(0));
+        auto lockStatusObserver = runtime.AddObserver<TEvLongTxService::TEvLockStatus>(
+            [&](auto& ev) {
+                if (ev->GetRecipientRewrite() == shard1actor) {
+                    auto* msg = ev->Get();
+                    tx1lockId = msg->Record.GetLockId();
+                    tx1lockNode = msg->Record.GetLockNode();
+                }
+            });
+
+        // Begin the 1st transaction appending to key 1
+        TString session1, tx1;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, session1, tx1, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 3003);
+                SELECT key, index, value FROM `/Root/table` WHERE key = 2 ORDER BY key, index;
+                SELECT key, index, value FROM `/Root/table` WHERE key = 11 ORDER BY key, index;
+                )"),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }"
+            "\n"
+            // empty result set
+            "\n"
+            "{ items { int32_value: 11 } items { int32_value: 0 } items { int32_value: 2001 } }");
+
+        runtime.WaitFor("subscribed lock", [&]{ return tx1lockId != 0; });
+        lockStatusObserver.Remove();
+
+        // Begin the 2nd transaction reading key 1
+        TString session2, tx2;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, session2, tx2, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+                )"),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }");
+
+        // Block reads, so the next tx uses the current snapshot, but executes much later
+        TBlockEvents<TEvDataShard::TEvRead> blockedReads(runtime);
+
+        // Begin the 3rd transaction reading key 1
+        TString session3, tx3;
+        auto readFuture = KqpSimpleBeginSend(runtime, session3, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+            )");
+        runtime.WaitFor("blocked read", [&]{ return blockedReads.size() >= 1; });
+        blockedReads.Stop();
+
+        // Make sure everything settles down
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Block commits and try to simulate a lock timeout which starts a rollback
+        TBlockEvents<TEvBlobStorage::TEvPut> blockedCommits(runtime, [&](auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Id.Channel() == 0 && msg->Id.TabletID() == shards.at(0)) {
+                Cerr << "... blocking commit " << msg->Id << Endl;
+                return true;
+            }
+            return false;
+        });
+        runtime.Send(
+            new IEventHandle(shard1actor, {},
+                new TEvLongTxService::TEvLockStatus(tx1lockId, tx1lockNode, NKikimrLongTxService::TEvLockStatus::STATUS_UNAVAILABLE)),
+            0, true);
+        runtime.WaitFor("blocked commits", [&]{ return blockedCommits.size() >= 1; });
+
+        // Unblock the 3rd transaction and ensure the read succeeds
+        blockedReads.Unblock();
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBeginWait(runtime, tx3, std::move(readFuture)),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }");
+
+        // Stop blocking commits and make them fail (will cause shards to restart)
+        blockedCommits.Stop();
+        for (auto& ev : blockedCommits) {
+            auto proxy = ev->Recipient;
+            ui32 groupId = GroupIDFromBlobStorageProxyID(proxy);
+            auto response = ev->Get()->MakeErrorResponse(NKikimrProto::ERROR, "Something went wrong", TGroupId::FromValue(groupId));
+            runtime.Send(new IEventHandle(ev->Sender, proxy, response.release()), 0, true);
+        }
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Commit the 1st transaction (it must abort, lock removal is migrated)
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, session1, tx1, R"(SELECT 1)"),
             "ERROR: ABORTED");
+
+        // Commit the 3rd transaction writing to the same index
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, session3, tx3, R"(
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 4003);
+                )"),
+            "<empty>");
+    }
+
+    Y_UNIT_TEST(ReadLockUncommittedBreakThenNewConflictMigration) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(1)
+            .SetUseRealThreads(false);
+
+        // This test requires in-memory state migration to work
+        serverSettings.FeatureFlags.SetEnableDataShardInMemoryStateMigration(true);
+
+        TServer::TPtr server = new TServer(serverSettings);
+
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, index int, value int, PRIMARY KEY (key, index))
+                WITH (PARTITION_AT_KEYS = (10));
+            )"),
+            "SUCCESS"
+        );
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+
+        // Populate tables with initial values
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, index, value) VALUES
+                (1, 0, 1001),
+                (1, 1, 1002),
+                (11, 0, 2001);
+        )");
+
+        ui64 tx1lockId = 0;
+        ui32 tx1lockNode = 0;
+        auto shard1actor = ResolveTablet(runtime, shards.at(0));
+        auto lockStatusObserver = runtime.AddObserver<TEvLongTxService::TEvLockStatus>(
+            [&](auto& ev) {
+                if (ev->GetRecipientRewrite() == shard1actor) {
+                    auto* msg = ev->Get();
+                    tx1lockId = msg->Record.GetLockId();
+                    tx1lockNode = msg->Record.GetLockNode();
+                }
+            });
+
+        // Begin the 1st transaction appending to key 1
+        TString session1, tx1;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, session1, tx1, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 3003);
+                SELECT key, index, value FROM `/Root/table` WHERE key = 2 ORDER BY key, index;
+                SELECT key, index, value FROM `/Root/table` WHERE key = 11 ORDER BY key, index;
+                )"),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }"
+            "\n"
+            // empty result set
+            "\n"
+            "{ items { int32_value: 11 } items { int32_value: 0 } items { int32_value: 2001 } }");
+
+        runtime.WaitFor("subscribed lock", [&]{ return tx1lockId != 0; });
+        lockStatusObserver.Remove();
+
+        // Begin the 2nd transaction reading key 1
+        TString session2, tx2;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, session2, tx2, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+                )"),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }");
+
+        // Block reads, so the next tx uses the current snapshot, but executes much later
+        TBlockEvents<TEvDataShard::TEvRead> blockedReads(runtime);
+
+        // Begin the 3rd transaction reading key 1
+        TString session3, tx3;
+        auto readFuture = KqpSimpleBeginSend(runtime, session3, R"(
+                SELECT key, index, value FROM `/Root/table` WHERE key = 1 ORDER BY key, index;
+            )");
+        runtime.WaitFor("blocked read", [&]{ return blockedReads.size() >= 1; });
+        blockedReads.Stop();
+
+        // Make sure everything settles down
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Block commits and try to break the first transaction by a blind upsert
+        TBlockEvents<TEvBlobStorage::TEvPut> blockedCommits(runtime, [&](auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Id.Channel() == 0 && msg->Id.TabletID() == shards.at(0)) {
+                Cerr << "... blocking commit " << msg->Id << Endl;
+                return true;
+            }
+            return false;
+        });
+        KqpSimpleSend(runtime, R"(
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (2, 0, 4001);
+            )");
+        runtime.WaitFor("blocked commits", [&]{ return blockedCommits.size() >= 1; });
+
+        // Unblock the 3rd transaction and ensure the read succeeds
+        blockedReads.Unblock();
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBeginWait(runtime, tx3, std::move(readFuture)),
+            "{ items { int32_value: 1 } items { int32_value: 0 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 1 } items { int32_value: 1 } items { int32_value: 1002 } }");
+
+        // Stop blocking commits and make them fail (will cause shards to restart)
+        blockedCommits.Stop();
+        for (auto& ev : blockedCommits) {
+            auto proxy = ev->Recipient;
+            ui32 groupId = GroupIDFromBlobStorageProxyID(proxy);
+            auto response = ev->Get()->MakeErrorResponse(NKikimrProto::ERROR, "Something went wrong", TGroupId::FromValue(groupId));
+            runtime.Send(new IEventHandle(ev->Sender, proxy, response.release()), 0, true);
+        }
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Commit the 1st transaction (it must abort, lock break is migrated)
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, session1, tx1, R"(SELECT 1)"),
+            "ERROR: ABORTED");
+
+        // Commit the 3rd transaction writing to the same index
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, session3, tx3, R"(
+                UPSERT INTO `/Root/table` (key, index, value) VALUES (1, 2, 4003);
+                )"),
+            "<empty>");
     }
 
 }

--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -862,6 +862,20 @@ TLockInfo::TPtr TLockLocker::RestoreInMemoryLock(const ILocksDb::TLockRow& row) 
         // This includes coarse ranges, flags and break versions which could fail to persist
         auto it = Locks.find(row.LockId);
         if (it != Locks.end() && it->second->IsPersistent()) {
+            if (!!(flags & ELockFlags::Removed)) {
+                // Lock was removed in the previous generation, but that removal
+                // has failed to commit. Since subsequent reads may not have
+                // detected conflicts we need to repeat the removal.
+                PendingRestoreRemoveQueue.PushBack(it->second.Get());
+                return nullptr;
+            }
+            if (!it->second->BreakVersion && (row.BreakVersion != TRowVersion::Max() || row.Counter == Max<ui64>())) {
+                // Lock was broken in the previous generation, but that break
+                // has failed to commit. Since subsequent reads may not have
+                // detected conflicts we need to repeat the break.
+                PendingRestoreBreakQueue.PushBack(it->second.Get());
+                return nullptr;
+            }
             // Accurate ranges are not persistent, this will attempt to restore them
             if (it->second->RestoreInMemoryState(row)) {
                 return it->second;
@@ -1617,5 +1631,25 @@ void TSysLocks::RestoreInMemoryLocks(THashMap<ui64, ILocksDb::TLockRow>&& rows) 
     }
 }
 
+bool TSysLocks::RestorePersistentState(ILocksDb* db) {
+    while (Locker.PendingRestoreRemoveQueue) {
+        TLockInfo* lock = Locker.PendingRestoreRemoveQueue.PopFront();
+        ui64 lockId = lock->GetLockId();
+        Locker.RemoveOneLock(lockId, db);
+        if (db->HasChanges()) {
+            return true;
+        }
+    }
+    while (Locker.PendingRestoreBreakQueue) {
+        TLockInfo* lock = Locker.PendingRestoreBreakQueue.PopFront();
+        lock->SetBroken(TRowVersion::Min());
+        Locker.RemoveBrokenRanges();
+        Locker.SaveBrokenPersistentLocks(db);
+        if (db->HasChanges()) {
+            return true;
+        }
+    }
+    return false;
+}
 
 }}

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -49,6 +49,8 @@ public:
         TVector<TPathId> WriteTables;
     };
 
+    virtual bool HasChanges() const = 0;
+
     virtual bool Load(TVector<TLockRow>& rows) = 0;
 
     // Returns true when a new lock may be added with the given lockId
@@ -676,6 +678,8 @@ public:
         CleanupPending.clear();
         CleanupCandidates.clear();
         PendingSubscribeLocks.clear();
+        PendingRestoreRemoveQueue.Clear();
+        PendingRestoreBreakQueue.Clear();
     }
 
     const THashMap<ui64, TLockInfo::TPtr>& GetLocks() const {
@@ -705,6 +709,9 @@ private:
     TPriorityQueue<TVersionedLockId> CleanupCandidates;
     TList<TPendingSubscribeLock> PendingSubscribeLocks;
     ui64 Counter = 0;
+
+    TIntrusiveList<TLockInfo, TLockInfoExpireListTag> PendingRestoreRemoveQueue;
+    TIntrusiveList<TLockInfo, TLockInfoExpireListTag> PendingRestoreBreakQueue;
 
     TTableLocks::TPtr GetTableLocks(const TTableId& table) const {
         auto it = Tables.find(table.PathId);
@@ -963,7 +970,22 @@ public:
 
     bool Load(ILocksDb& db);
 
+    /**
+     * Restores in-memory lock state migrated from previous generations
+     *
+     * May also enqueue some persistent changes to be applied later.
+     */
     void RestoreInMemoryLocks(THashMap<ui64, ILocksDb::TLockRow>&& rows);
+
+    /**
+     * Restores persistent lock state migrated from previous generations
+     *
+     * Returns true after performing some enqueued persistent changes, or false
+     * when there are no changes and the queue is empty. Caller needs to call
+     * this method until it returns false, possibly spanning multiple tablet
+     * transactions.
+     */
+    bool RestorePersistentState(ILocksDb* db);
 
     const THashMap<ui64, TLockInfo::TPtr>& GetLocks() const {
         return Locker.GetLocks();

--- a/ydb/core/tx/locks/locks_db.h
+++ b/ydb/core/tx/locks/locks_db.h
@@ -14,7 +14,7 @@ public:
         , DB(txc.DB)
     { }
 
-    bool HasChanges() const {
+    bool HasChanges() const override {
         return HasChanges_;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix a rare serializable isolation issue during graceful shard migration. Fixes #31961.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Jepsen observed that serializable isolation could sometimes be violated during graceful shard migration between nodes. The issue was that when transactions try to commit breaking conflicting persistent locks, their commit may ultimately fail due to storage failure or races. Such broken locks no longer participate in acquiring new conflicts, however when migrated their persistent state won out, effectively resurrecting them without all necessary conflict edges.

We now compare loaded persistent state and migrated state, and remove/break persistent locks when their state doesn't match, attempting to replay changes which failed to commit. This makes sure restored in-memory locks and persistent locks are consistent when migration succeeds. In cases when migration fails persistent locks may restore to their pre-remove or pre-break state, however the full state is then restored from disk and remains consistent.

Related to #27123.
Merge #32779.
