### PR TITLE
[Backport stable-25-3][COMMON] [ICRDMA] Fix unrealizable IContiguousChunk EXT-1594 (#27371)

### DIFF
--- a/ydb/core/blobstorage/crypto/ut/ut_helpers.h
+++ b/ydb/core/blobstorage/crypto/ut/ut_helpers.h
@@ -52,6 +52,10 @@ public:
         return BufSize;
     }
 
+    size_t GetAlign() const {
+        return Align;
+    }
+
     ~TAlignedBuf() {
         delete[] Buf;
     }
@@ -69,16 +73,18 @@ public:
         return {reinterpret_cast<const char *>(Buffer.Data()), Buffer.Size()};
     }
 
-    TMutableContiguousSpan GetDataMut() override {
-        return {reinterpret_cast<char *>(Buffer.Data()), Buffer.Size()};
-    }
-
     TMutableContiguousSpan UnsafeGetDataMut() override {
         return {reinterpret_cast<char *>(Buffer.Data()), Buffer.Size()};
     }
 
     size_t GetOccupiedMemorySize() const override {
         return Buffer.Size();
+    }
+
+    IContiguousChunk::TPtr Clone() override {
+        auto newBackend = MakeIntrusive<TRopeAlignedBufferBackend>(Buffer.Size(), Buffer.GetAlign());
+        ::memcpy(newBackend->UnsafeGetDataMut().data(), GetData().data(), GetData().size());
+        return newBackend;
     }
 };
 

--- a/ydb/core/blobstorage/vdisk/hulldb/base/hullds_arena.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/hullds_arena.h
@@ -22,12 +22,19 @@ namespace NKikimr {
             return Capacity;
         }
 
-        TMutableContiguousSpan GetDataMut() override {
+        TMutableContiguousSpan UnsafeGetDataMut() override {
             return {Data, Capacity};
         }
 
         static TIntrusivePtr<IContiguousChunk> Allocate() {
             return MakeIntrusive<TRopeArenaBackend>();
+        }
+
+        IContiguousChunk::TPtr Clone() override {
+            IContiguousChunk::TPtr buf = Allocate();
+            TContiguousSpan src = GetData();
+            ::memcpy(buf->UnsafeGetDataMut().GetData(), src.Data(), src.GetSize());
+            return buf;
         }
     };
 

--- a/ydb/core/erasure/erasure_split.cpp
+++ b/ydb/core/erasure/erasure_split.cpp
@@ -10,16 +10,16 @@ namespace NKikimr {
             return {ZeroData, sizeof(ZeroData)};
         }
 
-        TMutableContiguousSpan GetDataMut() override {
-            return {const_cast<char*>(ZeroData), sizeof(ZeroData)};
-        }
-
         TMutableContiguousSpan UnsafeGetDataMut() override {
             return {const_cast<char*>(ZeroData), sizeof(ZeroData)};
         }
 
         size_t GetOccupiedMemorySize() const override {
             return sizeof(ZeroData);
+        }
+
+        IContiguousChunk::TPtr Clone() noexcept override {
+            return this;
         }
     };
 

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -270,6 +270,11 @@ public:
 struct IContiguousChunk : TThrRefBase {
     using TPtr = TIntrusivePtr<IContiguousChunk>;
 
+    enum EInnerType {
+        OTHER=0,
+        RDMA_MEM_REG=1,
+    };
+
     virtual ~IContiguousChunk() = default;
 
     /**
@@ -278,31 +283,35 @@ struct IContiguousChunk : TThrRefBase {
     virtual TContiguousSpan GetData() const = 0;
 
     /**
-     * Should give mutable access to underlying data
-     * If data is shared - data should be copied
-     * E.g. for TString str.Detach() should be used
-     * Possibly invalidates previous *GetData*() calls
-     */
-    virtual TMutableContiguousSpan GetDataMut() = 0;
-
-    /**
      * Should give mutable access to undelying data as fast as possible
      * Even if data is shared this property should be ignored
      * E.g. in TString const_cast<char *>(str.data()) should be used
      * Possibly invalidates previous *GetData*() calls
      */
-    virtual TMutableContiguousSpan UnsafeGetDataMut() {
-        return GetDataMut();
-    }
+    virtual TMutableContiguousSpan UnsafeGetDataMut() = 0;
 
     /**
-     * Should return true if GetDataMut() would not copy contents when called.
+     * Must return false if the implementation shares data
      */
     virtual bool IsPrivate() const {
-        return true;
+        return RefCount() == 1;
     }
 
     virtual size_t GetOccupiedMemorySize() const = 0;
+
+    /**
+     * Returns type of the inner data
+     * Used to distinguish between different types of data and downcast
+     */
+    virtual EInnerType GetInnerType() const noexcept {
+        return OTHER;
+    }
+
+    /**
+     * Allocate new chunk and copy data into it
+     * NOTE: The actual implementation of clonned chunk may be different
+     */
+    virtual IContiguousChunk::TPtr Clone() = 0;
 };
 
 class TRope;
@@ -445,7 +454,7 @@ class TRcBuf {
                 } else if constexpr (std::is_same_v<T, TString>) {
                     return value.IsDetached();
                 } else if constexpr (std::is_same_v<T, IContiguousChunk::TPtr>) {
-                    return value.RefCount() == 1 && value->IsPrivate();
+                    return value->IsPrivate();
                 } else {
                     static_assert(TDependentFalse<T>);
                 }
@@ -487,7 +496,10 @@ class TRcBuf {
                     }
                     return {value.mutable_data(), value.size()};
                 } else if constexpr (std::is_same_v<T, IContiguousChunk::TPtr>) {
-                    return value->GetDataMut();
+                    if (!value->IsPrivate()) {
+                        value = value->Clone();
+                    }
+                    return value->UnsafeGetDataMut();
                 } else {
                     static_assert(TDependentFalse<T>, "unexpected type");
                 }

--- a/ydb/library/actors/util/rc_buf_ut.cpp
+++ b/ydb/library/actors/util/rc_buf_ut.cpp
@@ -63,11 +63,23 @@ Y_UNIT_TEST_SUITE(TRcBuf) {
     Y_UNIT_TEST(Detach) {
         TRcBuf data = TRcBuf::Copy(TString("test"));
         TRcBuf data2 = data;
+        UNIT_ASSERT_EQUAL(data.GetData(), data2.GetData());
         char* res = data2.Detach();
         UNIT_ASSERT_UNEQUAL(data.GetData(), data2.GetData());
         UNIT_ASSERT_EQUAL(res, data2.GetData());
         UNIT_ASSERT_EQUAL(::memcmp(res, "test", 4), 0);
         UNIT_ASSERT_EQUAL(::memcmp(data.GetData(), "test", 4), 0);
+    }
+
+    Y_UNIT_TEST(DetachAndDestroySrc) {
+        TRcBuf data = TRcBuf::Copy(TString("test"));
+        TRcBuf data2 = data;
+        data = {};
+        UNIT_ASSERT_EQUAL(data2.GetSize(), 4);
+        char* res = data2.Detach();
+        UNIT_ASSERT_EQUAL(data2.GetSize(), 4);
+        UNIT_ASSERT_EQUAL(res, data2.GetData());
+        UNIT_ASSERT_EQUAL(::memcmp(res, "test", 4), 0);
     }
 
     Y_UNIT_TEST(Resize) {

--- a/ydb/library/actors/util/rope.h
+++ b/ydb/library/actors/util/rope.h
@@ -20,7 +20,7 @@ class TRopeAlignedBuffer : public IContiguousChunk {
     static constexpr size_t Alignment = 16;
     static constexpr size_t MallocAlignment = sizeof(size_t);
 
-    ui32 Size;
+    const ui32 Size;
     const ui32 Capacity;
     const ui32 Offset;
     alignas(Alignment) char Data[];
@@ -36,6 +36,13 @@ class TRopeAlignedBuffer : public IContiguousChunk {
 public:
     static TIntrusivePtr<TRopeAlignedBuffer> Allocate(size_t size) {
         return new(malloc(sizeof(TRopeAlignedBuffer) + size + Alignment - MallocAlignment)) TRopeAlignedBuffer(size);
+    }
+
+    IContiguousChunk::TPtr Clone() override {
+        TIntrusivePtr<TRopeAlignedBuffer> buf = Allocate(Size);
+        TContiguousSpan src = GetData();
+        ::memcpy(buf->UnsafeGetDataMut().GetData(), src.Data(), src.GetSize());
+        return buf;
     }
 
     void *operator new(size_t) {
@@ -59,7 +66,7 @@ public:
         return {Data + Offset, Size};
     }
 
-    TMutableContiguousSpan GetDataMut() override {
+    TMutableContiguousSpan UnsafeGetDataMut() override {
         return {Data + Offset, Size};
     }
 

--- a/ydb/library/actors/util/rope_ut.cpp
+++ b/ydb/library/actors/util/rope_ut.cpp
@@ -15,16 +15,18 @@ public:
         return {Buffer.data(), Buffer.size()};
     }
 
-    TMutableContiguousSpan GetDataMut() override {
-        return {Buffer.Detach(), Buffer.size()};
-    }
-
     TMutableContiguousSpan UnsafeGetDataMut() override {
         return {const_cast<char*>(Buffer.data()), Buffer.size()};
     }
 
     size_t GetOccupiedMemorySize() const override {
         return Buffer.capacity();
+    }
+
+    IContiguousChunk::TPtr Clone() override {
+        auto ptr = MakeIntrusive<TRopeStringBackend>(Buffer);
+        ptr->Buffer.Detach();
+        return ptr;
     }
 };
 

--- a/ydb/library/actors/util/shared_data_rope_backend.h
+++ b/ydb/library/actors/util/shared_data_rope_backend.h
@@ -18,23 +18,26 @@ public:
         return {Buffer.data(), Buffer.size()};
     }
 
-    TMutableContiguousSpan GetDataMut() override {
-        if(Buffer.IsShared()) {
+    TMutableContiguousSpan UnsafeGetDataMut() override {
+        // Actualy should newer be true, but acciording to the API this class can share TSharedData with some external buffer
+        if (Buffer.IsShared()) {
             Buffer = TSharedData::Copy(Buffer.data(), Buffer.size());
         }
         return {Buffer.mutable_data(), Buffer.size()};
     }
 
-    TMutableContiguousSpan UnsafeGetDataMut() override {
-        return {const_cast<char *>(Buffer.data()), Buffer.size()};
-    }
-
     bool IsPrivate() const override {
-        return Buffer.IsPrivate();
+        return RefCount() == 1 && Buffer.IsPrivate();
     }
 
     size_t GetOccupiedMemorySize() const override {
         return Buffer.size();
+    }
+
+    IContiguousChunk::TPtr Clone() override {
+        auto backend = MakeIntrusive<TRopeSharedDataBackend>(Buffer);
+        backend->Buffer.Detach();
+        return backend;
     }
 };
 

--- a/ydb/library/yql/dq/common/rope_over_buffer.cpp
+++ b/ydb/library/yql/dq/common/rope_over_buffer.cpp
@@ -18,12 +18,17 @@ private:
         return Span_;
     }
 
-    TMutableContiguousSpan GetDataMut() override {
+    TMutableContiguousSpan UnsafeGetDataMut() override {
         YQL_ENSURE(false, "Payload mutation is not supported");
     }
 
     size_t GetOccupiedMemorySize() const override {
         return Span_.GetSize();
+    }
+
+    IContiguousChunk::TPtr Clone() noexcept override {
+        // Mutable call is not supported.
+        return this;
     }
 
     const std::shared_ptr<const void> Owner_;


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

Commit from PR https://github.com/ydb-platform/ydb/pull/27371

WITHOUT making any changes to the `interconnect/rdma` directory, because ICRDMA code has not been merged into the stable branches

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The issue was:

Caller has a pointer to IContiguousChunk
If caller calls GetDataMut() and the object is not "private" (ref count is not equal to 1) the implementation had to perform "Detach()" and return pointer to copyed data. But we have no place to store newly allocated object. Ooops...

The solution:
Replace IContiguousChunk::GetDataMut() with IContiguousChunk::Clone() + IContiguousChunk::UnsafeGetDataMut()

### Changelog category <!-- remove all except one -->

* Bugfix 
