### PR TITLE
Avoid some tablet crashes when loading corrupted blobs

### DIFF
--- a/ydb/core/tablet_flat/defs.cpp
+++ b/ydb/core/tablet_flat/defs.cpp
@@ -1,0 +1,5 @@
+#include "defs.h"
+
+Y_DECLARE_OUT_SPEC(, NKikimr::NTable::TTxStamp, stream, value) {
+    stream << value.Gen() << ":" << value.Step();
+}

--- a/ydb/core/tablet_flat/defs.h
+++ b/ydb/core/tablet_flat/defs.h
@@ -27,6 +27,8 @@ namespace NTable {
 
     using TRawVals = TArrayRef<const TRawTypeValue>;
 
+    static constexpr size_t MaxDecompressedBlobSize = 0xffffffffffULL; // 1 byte less than 1TiB
+
     class TEpoch : public TTypeSafeAlias<TEpoch, i64> {
     public:
         // N.B. this catches accidental legacy conversions
@@ -117,5 +119,6 @@ namespace NTable {
 namespace NTabletFlatExecutor {
     using TTxStamp = NTable::TTxStamp;
     using TRawVals = NTable::TRawVals;
+    using NTable::MaxDecompressedBlobSize;
 }
 }

--- a/ydb/core/tablet_flat/flat_boot_env.h
+++ b/ydb/core/tablet_flat/flat_boot_env.h
@@ -48,8 +48,9 @@ namespace NBoot {
 
         void Execute()
         {
-            for (; Queue; Queue.pop_front()) {
+            while (Queue) {
                 auto order = std::move(Queue.front());
+                Queue.pop_front();
 
                 switch (order.Op) {
                     case EOp::Start: {

--- a/ydb/core/tablet_flat/flat_boot_gclog.h
+++ b/ydb/core/tablet_flat/flat_boot_gclog.h
@@ -56,6 +56,12 @@ namespace NBoot {
                 auto gen = head->LargeGlobId.Lead.Generation();
                 auto step = head->LargeGlobId.Lead.Step();
 
+                size_t decompressedSize = Codec->DecompressedLength(head->Body);
+                Y_ENSURE(decompressedSize <= MaxDecompressedBlobSize,
+                    "GC entry " << NFmt::Do(head->LargeGlobId)
+                    << " has an unexpected decompressed size of " << decompressedSize << " bytes"
+                    << ", possible data corruption");
+
                 Apply(gen, step, Codec->Decode(head->Body));
 
                 ++Skip, Queue.pop_front();

--- a/ydb/core/tablet_flat/flat_boot_loans.h
+++ b/ydb/core/tablet_flat/flat_boot_loans.h
@@ -53,6 +53,12 @@ namespace NBoot {
         void Flush()
         {
             for (TBody *head = nullptr; Queue && *(head = &Queue[0]); ) {
+                size_t decompressedSize = Codec->DecompressedLength(head->Body);
+                Y_ENSURE(decompressedSize <= MaxDecompressedBlobSize,
+                    "Loan entry " << NFmt::Do(head->LargeGlobId)
+                    << " has an unexpected decompressed size of " << decompressedSize << " bytes"
+                    << ", possible data corruption");
+
                 Apply(head->LargeGlobId.Lead, Codec->Decode(head->Body));
 
                 ++Skip, Queue.pop_front();

--- a/ydb/core/tablet_flat/flat_boot_redo.h
+++ b/ydb/core/tablet_flat/flat_boot_redo.h
@@ -69,6 +69,12 @@ namespace NBoot {
                 if (head->LargeGlobId && index != TCookie::EIdx::RedoLz4) {
                     Apply(head->Stamp, *head, head->Body);
                 } else {
+                    size_t decompressedSize = Codec->DecompressedLength(head->Body);
+                    Y_ENSURE(decompressedSize <= MaxDecompressedBlobSize,
+                        "Commit " << head->Stamp << " " << NFmt::Do(head->LargeGlobId)
+                        << " has an unexpected decompressed size of " << decompressedSize << " bytes"
+                        << ", possible data corruption");
+
                     Apply(head->Stamp, *head, Codec->Decode(head->Body));
                 }
 

--- a/ydb/core/tablet_flat/flat_boot_snap.h
+++ b/ydb/core/tablet_flat/flat_boot_snap.h
@@ -61,6 +61,12 @@ namespace NBoot {
         void Apply(const NPageCollection::TLargeGlobId &snap, TArrayRef<const char> body)
         {
             if (EIdx::SnapLz4 == TCookie(snap.Lead.Cookie()).Index()) {
+                size_t decompressedSize = Codec->DecompressedLength(body);
+                Y_ENSURE(decompressedSize <= MaxDecompressedBlobSize,
+                    "Snapshot " << NFmt::Do(snap)
+                    << " has an unexpected decompressed size of " << decompressedSize << " bytes"
+                    << ", possible data corruption");
+
                 Decode(snap, Codec->Decode(body));
             } else {
                 Decode(snap, body);

--- a/ydb/core/tablet_flat/flat_boot_turns.h
+++ b/ydb/core/tablet_flat/flat_boot_turns.h
@@ -60,6 +60,12 @@ namespace NBoot {
             if (index != TCookie::EIdx::TurnLz4) {
                 Apply(entry, body);
             } else {
+                size_t decompressedSize = Codec->DecompressedLength(body);
+                Y_ENSURE(decompressedSize <= MaxDecompressedBlobSize,
+                    "Switch entry " << NFmt::Do(entry.LargeGlobId)
+                    << " has an unexpected decompressed size of " << decompressedSize << " bytes"
+                    << ", possible data corruption");
+
                 Apply(entry, Codec->Decode(body));
             }
         }

--- a/ydb/core/tablet_flat/flat_sausage_solid.h
+++ b/ydb/core/tablet_flat/flat_sausage_solid.h
@@ -39,9 +39,12 @@ namespace NPageCollection {
 
         void Describe(IOutputStream &out) const
         {
-            out
-                << "TLargeGlobId{" << Lead << " ~" << Bytes
-                << "b, grp " << Group << "}";
+            if (Bytes > 0) {
+                out << "TLargeGlobId{" << Lead << " ~" << Bytes
+                    << "b, group " << Group << "}";
+            } else {
+                out << "TLargeGlobId{}";
+            }
         }
 
         explicit operator bool() const noexcept

--- a/ydb/core/tablet_flat/ya.make
+++ b/ydb/core/tablet_flat/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    defs.cpp
     defs.h
     flat_backup.cpp
     flat_backup.h

--- a/ydb/core/util/pb.h
+++ b/ydb/core/util/pb.h
@@ -40,7 +40,7 @@ template<typename TProto>
 struct TProtoBox : public TProto {
     TProtoBox(TArrayRef<const char> plain) {
         bool ok = ParseFromStringNoSizeLimit(*this, plain);
-        Y_ABORT_UNLESS(ok, "Cannot parse proto %s", TypeName<TProto>().c_str());
+        Y_ENSURE(ok, "Cannot parse proto " << TypeName<TProto>());
     }
 };
 
@@ -57,7 +57,7 @@ inline TString SingleLineProto(const NProtoBuf::Message& message) {
     p.SetSingleLineMode(true);
     TString res;
     const bool success = p.PrintToString(message, &res);
-    Y_ABORT_UNLESS(success);
+    Y_ENSURE(success);
     return res;
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Try to reboot tablet with an error and some context (tablet id and relevant blob id) instead of crashing the process when loading corrupted blobs. Fixes #32941.