### PR TITLE
Fix bug in VDisk related to huge blob compaction when changing size limit and improve unit test

### DIFF
--- a/ydb/core/blobstorage/ut_vdisk2/ya.make
+++ b/ydb/core/blobstorage/ut_vdisk2/ya.make
@@ -15,6 +15,7 @@ SRCS(
 )
 
 PEERDIR(
+    contrib/libs/xxhash
     ydb/apps/version
     library/cpp/testing/unittest
     ydb/core/blobstorage/backpressure

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
@@ -310,7 +310,7 @@ namespace NKikimr {
                 case NHullComp::ActDeleteSsts: {
                     Y_VERIFY_S(CompactionTask->GetSstsToAdd().Empty() && !CompactionTask->GetSstsToDelete().Empty(),
                         HullDs->HullCtx->VCtx->VDiskLogPrefix);
-                    if (CompactionTask->GetHugeBlobsToDelete().Empty()) {
+                    if (CompactionTask->GetHugeBlobsToDelete().Empty() && CompactionTask->GetHugeBlobsAllocated().Empty()) {
                         ApplyCompactionResult(ctx, {}, {}, 0);
                     } else {
                         // switch compaction state to pre-compaction to block any attempts of concurrent compaction
@@ -473,7 +473,7 @@ namespace NKikimr {
             }
             THullChange *msg = ev->Get();
 
-            if (!msg->FreedHugeBlobs.Empty() && !wId && !msg->Aborted) {
+            if ((!msg->FreedHugeBlobs.Empty() || !msg->AllocatedHugeBlobs.Empty()) && !wId && !msg->Aborted) {
                 const ui64 cookie = NextPreCompactCookie++;
                 LOG_DEBUG_S(ctx, NKikimrServices::BS_HULLCOMP, HullDs->HullCtx->VCtx->VDiskLogPrefix
                     << "requesting PreCompact for THullChange");

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcommit.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcommit.h
@@ -327,7 +327,8 @@ namespace NKikimr {
             , CallerInfo(callerInfo)
             , WId(wId)
         {
-            Y_VERIFY_S(!WId == Metadata.RemovedHugeBlobs.Empty(), HullLogCtx->VCtx->VDiskLogPrefix);
+            Y_VERIFY_S(!WId == (Metadata.RemovedHugeBlobs.Empty() && Metadata.AllocatedHugeBlobs.Empty()),
+                HullLogCtx->VCtx->VDiskLogPrefix);
             // we create commit message in the constructor to avoid race condition
             GenerateCommitMessage();
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix bug in VDisk related to huge blob compaction when changing size limit and improve unit test

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes very rare case when blob has been written as inplace one and still in fresh, while huge blob size suddenly changes and fresh compaction writes this blob into a huge slot.
