### PR TITLE
YQ-4603 supported multi insert in streaming query

### DIFF
--- a/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
@@ -125,6 +125,10 @@ public:
             }
         }
 
+        if (UserRequestContext && UserRequestContext->IsStreamingQuery) {
+            config->_KqpEnableSpilling = false;
+        }
+
         config->FreezeDefaults();
 
         return config;

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/optimization.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/optimization.cpp
@@ -19,7 +19,6 @@ struct TStreamingExploreCtx {
     TExprContext& Ctx;
     std::unordered_set<const TExprNode*> Visited;
     ui64 StreamingReads = 0;
-    ui64 Writes = 0;
 };
 
 bool ExploreStreamingQueryNode(TExprNode::TPtr node, TStreamingExploreCtx& res) {
@@ -53,8 +52,6 @@ bool ExploreStreamingQueryNode(TExprNode::TPtr node, TStreamingExploreCtx& res) 
     }
 
     if (const auto maybeDataSink = TMaybeNode<TCoDataSink>(providerArg)) {
-        ++res.Writes;
-
         const auto dataSinkCategory = maybeDataSink.Cast().Category().Value();
         if (IsIn({NYql::PqProviderName, NYql::SolomonProviderName, NYql::S3ProviderName}, dataSinkCategory)) {
             return true;

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/optimization.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/optimization.cpp
@@ -113,11 +113,6 @@ bool CheckStreamingQueryAst(TExprNode::TPtr ast, TExprContext& ctx) {
         return false;
     }
 
-    if (res.Writes > 1) {
-        ctx.AddError(NYql::TIssue(ctx.GetPosition(ast->Pos()), "Streaming query with more than one write is not supported now"));
-        return false;
-    }
-
     return true;
 }
 

--- a/ydb/core/kqp/opt/kqp_opt_build_txs.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_build_txs.cpp
@@ -665,6 +665,7 @@ private:
                     // Two table sinks can't be executed in one physical transaction if they write into same table and have same priority.
 
                     const bool needSingleEffect = sinkSettings.Cast().Mode() == "fill_table"
+                        || sinkSettings.Cast().InconsistentWrite().Value() == "true"sv
                         || (kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, sinkSettings.Cast().Table().Path()).Metadata->Kind == EKikimrTableKind::Olap);
 
                     if (needSingleEffect) {

--- a/ydb/core/kqp/opt/kqp_opt_effects.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_effects.cpp
@@ -209,7 +209,7 @@ bool BuildUpsertRowsEffect(const TKqlUpsertRows& node, TExprContext& ctx, const 
     const bool isIndexImplTable = table.Metadata->IsIndexImplTable;
 
     const bool isOlap = (table.Metadata->Kind == EKikimrTableKind::Olap);
-    const i64 priority = isOlap ? 0 : order;
+    const i64 priority = (isOlap || settings.AllowInconsistentWrites) ? 0 : order;
 
     if (isOlap && !(kqpCtx.IsGenericQuery() || (kqpCtx.IsDataQuery() && kqpCtx.Config->GetAllowOlapDataQuery()))) {
         ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -12492,28 +12492,6 @@ END DO)",
         {
             const auto result = db.ExecuteQuery(TStringBuilder() << prefix << R"()
                 AS DO BEGIN
-                    INSERT INTO MySource.MyTopic SELECT * FROM MySource.MyTopic;
-                    INSERT INTO MySource.MyTopic SELECT * FROM MySource.MyTopic;
-                END DO)",
-                NQuery::TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToOneLineString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Streaming query with more than one write is not supported now");
-        }
-
-        {
-            const auto result = db.ExecuteQuery(TStringBuilder() << prefix << R"()
-                AS DO BEGIN
-                    INSERT INTO MySource.MyTopic SELECT * FROM MySource.MyTopic;
-                    UPSERT INTO `MyFolder/MyTable` (Key) VALUES ("1");
-                END DO)",
-                NQuery::TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToOneLineString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Streaming query with more than one write is not supported now");
-        }
-
-        {
-            const auto result = db.ExecuteQuery(TStringBuilder() << prefix << R"()
-                AS DO BEGIN
                     SELECT 42;
                 END DO)",
                 NQuery::TTxControl::NoTx()).ExtractValueSync();

--- a/ydb/library/yql/dq/opt/dq_opt_phy.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_phy.cpp
@@ -643,6 +643,7 @@ TMaybeNode<TDqStage> DqPushLambdasToStage(const TDqStage& stage, const std::map<
                 .Body(ctx.ReplaceNodes(newProgram->TailPtr(), inputArgReplaces))
             .Build()
             .Settings(TDqStageSettings().BuildNode(ctx, stage.Pos()))
+            .Outputs(stage.Outputs())
             .Done();
 
     optCtx.RemapNode(stage.Ref(), newStage.Ptr());

--- a/ydb/library/yql/dq/opt/dq_opt_phy_finalizing.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_phy_finalizing.cpp
@@ -121,6 +121,7 @@ std::pair<TDqStage, TVector<TCoAtom>> ReplicateStageOutput(const TDqStage& stage
             .Body(ctx.ReplaceNodes(std::move(newResult), stageArgsReplaces))
             .Build()
         .Settings(TDqStageSettings().BuildNode(ctx, stage.Pos()))
+        .Outputs(stage.Outputs())
         .Done();
 
     YQL_CLOG(TRACE, CoreDq) << "new stage #" << newStage.Ref().UniqueId();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported multi insert in streaming query

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Supported construction:

```sql
CREATE STREAMING QUERY my_query AS
DO BEGIN
    $rows = SELECT * FROM input_topic;
    INSERT INTO output_topic1 SELECT * FROM $rows;
    INSERT INTO output_topic2 SELECT * FROM $rows;
END DO;
```
