### PR TITLE
Explicitly disable NormalizeEqualityFilterOverJoin for YDB

### DIFF
--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1981,6 +1981,7 @@ private:
             TypesCtx->OptimizerFlags.insert("sqlinwithnothingornull");
             TypesCtx->OptimizerFlags.insert("filterpushdownoverjoinoptionalsideignoreonlykeys");
         }
+        TypesCtx->OptimizerFlags.insert("disablenormalizeequalityfilteroverjoin");
 
         TypesCtx->IgnoreExpandPg = SessionCtx->ConfigPtr()->GetEnableNewRBO();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* Explicitly disable NormalizeEqualityFilterOverJoin for YDB

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Enabling this optimizer currently causes some issues for YDB tests in arcadia
