### PR TITLE
Transaction status at the start of the PQ tablet

### DIFF
--- a/ydb/core/persqueue/pqtablet/fix_transaction_states.cpp
+++ b/ydb/core/persqueue/pqtablet/fix_transaction_states.cpp
@@ -43,6 +43,9 @@ THashMap<ui64, NKikimrPQ::TTransaction> CollectTransactions(const TVector<NKikim
                 txId = tx.GetTxId();
                 current = 0;
                 expected = GetPartitionsCount(tx);
+                if (tx.GetState() == NKikimrPQ::TTransaction::CALCULATED) {
+                    tx.SetState(NKikimrPQ::TTransaction::PLANNED);
+                }
             } else {
                 // не может быть бесхозных субтранзакций
                 AFL_ENSURE(txId.Defined() && (*txId == tx.GetTxId()));

--- a/ydb/core/persqueue/pqtablet/partition/partition_monitoring.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_monitoring.cpp
@@ -67,6 +67,12 @@ void TPartition::HandleMonitoring(TEvPQ::TEvMonRequest::TPtr& ev, const TActorCo
                         PROPERTY("HeadOffset", BlobEncoder.Head.Offset << ", count: " << BlobEncoder.Head.GetCount());
                     }
 
+                    PROPERTIES("Transactions") {
+                        PROPERTY("Step", PlanStep);
+                        PROPERTY("TxId", TxId);
+                        PROPERTY("Inflight", TransactionsInflight.size());
+                    }
+
                     if (Compacter) {
                         auto step = [&]() {
                             switch(Compacter->Step) {

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -825,10 +825,10 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
     }
 
     for (const auto& [txId, tx] : Txs) {
-        PQ_LOG_D("TxId: " << txId <<
-                 ", Step: " << tx.Step <<
-                 ", State: " << NKikimrPQ::TTransaction_EState_Name(tx.State) <<
-                 ", Decision: " << NKikimrTx::TReadSetData_EDecision_Name(tx.ParticipantsDecision));
+        PQ_LOG_TX_D("TxId: " << txId <<
+                    ", Step: " << tx.Step <<
+                    ", State: " << NKikimrPQ::TTransaction_EState_Name(tx.State) <<
+                    ", Decision: " << NKikimrTx::TReadSetData_EDecision_Name(tx.ParticipantsDecision));
 
         if (tx.Step != Max<ui64>()) {
             PlannedTxs.emplace_back(tx.Step, txId);

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -794,23 +794,6 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
 
     TxWrites.clear();
 
-    for (const auto& readRange : readRanges) {
-        for (size_t i = 0; i < readRange.PairSize(); ++i) {
-            const auto& pair = readRange.GetPair(i);
-
-            NKikimrPQ::TTransaction tx;
-            AFL_ENSURE(tx.ParseFromString(pair.GetValue()));
-            AFL_ENSURE(tx.GetKind() != NKikimrPQ::TTransaction::KIND_UNKNOWN);
-
-            PQ_LOG_TX_D("key: " << pair.GetKey() <<
-                        ", TxId: " << tx.GetTxId() <<
-                        ", Step: " << tx.GetStep() <<
-                        ", State: " << NKikimrPQ::TTransaction_EState_Name(tx.GetState()) <<
-                        ", Predicate: " << tx.GetPredicate() << " (" << (tx.HasPredicate() ? "+" : "-") << ")" <<
-                        ", Operations: " << tx.OperationsSize());
-        }
-    }
-
     const auto txs = CollectTransactions(readRanges);
     for (const auto& [txId, tx] : txs) {
         if (tx.HasStep()) {
@@ -842,16 +825,24 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
     }
 
     for (const auto& [txId, tx] : Txs) {
-        PQ_LOG_TX_D("TxId: " << txId <<
-                    ", Step: " << tx.Step <<
-                    ", State: " << NKikimrPQ::TTransaction_EState_Name(tx.State) <<
-                    ", Decision: " << NKikimrTx::TReadSetData_EDecision_Name(tx.ParticipantsDecision));
+        PQ_LOG_D("TxId: " << txId <<
+                 ", Step: " << tx.Step <<
+                 ", State: " << NKikimrPQ::TTransaction_EState_Name(tx.State) <<
+                 ", Decision: " << NKikimrTx::TReadSetData_EDecision_Name(tx.ParticipantsDecision));
 
         if (tx.Step != Max<ui64>()) {
             PlannedTxs.emplace_back(tx.Step, txId);
         }
     }
 
+    // у таблетки 5 партиций. все участвуют в транзакции
+    // в очереди 2 транзакции
+    // первая транзакция выполнялась на stable-25-4 и только 4 партиции успели выполнить коммит
+    // таблетка переехала на stable-26-1, для второй транзакции дошли все предикаты и уже обе транзакции пошли выполняться в партициях
+    // оставшаяся партиция из первой транзакции и 5 партиций из второй транзакции записали субтранзакции
+    // таблетка снова перезапустилась и пытается восстановить транзакций
+    // у первой транзакции в очереди состояние PLANNED, а у второй - EXECUTED
+    // надо подправить состояние транзакций. можно продвинуть вперёд PLANNED -> EXECUTED, а можно наоборот
     std::sort(PlannedTxs.begin(), PlannedTxs.end());
     for (size_t i = 1; i < PlannedTxs.size(); ++i) {
         auto& prevTx = Txs.at(PlannedTxs[i - 1].second);
@@ -4998,7 +4989,7 @@ void TPersQueue::EndInitTransactions()
 
         if (!TxsOrder.contains(tx.State)) {
             PQ_LOG_TX_D("TxsOrder: " <<
-                     txId << " " << NKikimrPQ::TTransaction_EState_Name(tx.State) << " skip");
+                        tx.Step << " " << txId << " " << NKikimrPQ::TTransaction_EState_Name(tx.State) << " skip");
             continue;
         }
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -4978,7 +4978,7 @@ void TPersQueue::EndInitTransactions()
         PushTxInQueue(tx, tx.State);
 
         PQ_LOG_TX_D("TxsOrder: " <<
-                 txId << " " << NKikimrPQ::TTransaction_EState_Name(tx.State) << " " << tx.Pending);
+                    tx.Step << " " << txId << " " << NKikimrPQ::TTransaction_EState_Name(tx.State) << " " << tx.Pending);
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -794,6 +794,23 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
 
     TxWrites.clear();
 
+    for (const auto& readRange : readRanges) {
+        for (size_t i = 0; i < readRange.PairSize(); ++i) {
+            const auto& pair = readRange.GetPair(i);
+
+            NKikimrPQ::TTransaction tx;
+            AFL_ENSURE(tx.ParseFromString(pair.GetValue()));
+            AFL_ENSURE(tx.GetKind() != NKikimrPQ::TTransaction::KIND_UNKNOWN);
+
+            PQ_LOG_TX_D("key: " << pair.GetKey() <<
+                        ", TxId: " << tx.GetTxId() <<
+                        ", Step: " << tx.GetStep() <<
+                        ", State: " << NKikimrPQ::TTransaction_EState_Name(tx.GetState()) <<
+                        ", Predicate: " << tx.GetPredicate() << " (" << (tx.HasPredicate() ? "+" : "-") << ")" <<
+                        ", Operations: " << tx.OperationsSize());
+        }
+    }
+
     const auto txs = CollectTransactions(readRanges);
     for (const auto& [txId, tx] : txs) {
         if (tx.HasStep()) {
@@ -832,6 +849,16 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
 
         if (tx.Step != Max<ui64>()) {
             PlannedTxs.emplace_back(tx.Step, txId);
+        }
+    }
+
+    std::sort(PlannedTxs.begin(), PlannedTxs.end());
+    for (size_t i = 1; i < PlannedTxs.size(); ++i) {
+        auto& prevTx = Txs.at(PlannedTxs[i - 1].second);
+        auto& currentTx = Txs.at(PlannedTxs[i].second);
+
+        if (prevTx.State < currentTx.State) {
+            currentTx.State = prevTx.State;
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The PQ tablet can restore the transaction to an incorrect state.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
