### PR TITLE
YQ-4550 supported infinite retries for streaming query

### DIFF
--- a/ydb/core/fq/libs/control_plane_storage/config.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/config.cpp
@@ -59,8 +59,12 @@ TControlPlaneStorageConfig::TControlPlaneStorageConfig(const NConfig::TControlPl
     }
 
     if (Proto.HasTaskLeaseRetryPolicy()) {
-        TaskLeaseRetryPolicy.RetryCount = Proto.GetTaskLeaseRetryPolicy().GetRetryCount();
-        TaskLeaseRetryPolicy.RetryPeriod = GetDuration(Proto.GetTaskLeaseRetryPolicy().GetRetryPeriod(), TDuration::Days(1));
+        TaskLeaseRetryPolicy = NKikimr::NKqp::TRetryPolicyItem(
+            Proto.GetTaskLeaseRetryPolicy().GetRetryCount(),
+            0,
+            GetDuration(Proto.GetTaskLeaseRetryPolicy().GetRetryPeriod(), TDuration::Days(1)),
+            TDuration::Zero()
+        );
     }
 }
 

--- a/ydb/core/fq/libs/control_plane_storage/internal/task_ping.cpp
+++ b/ydb/core/fq/libs/control_plane_storage/internal/task_ping.cpp
@@ -391,7 +391,7 @@ void TControlPlaneStorageBase::UpdateTaskInfo(
             backoff = TDuration::Zero();
             TStringBuilder builder;
             builder << "Query failed with code " << NYql::NDqProto::StatusIds_StatusCode_Name(request.status_code());
-            if (policy.RetryCount) {
+            if (policy.PolicyInitialized) {
                 builder << " (" << retryLimiter.LastError << ")";
             }
             builder << " at " << now;

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1826,7 +1826,7 @@ private:
         policy.SetJitterFactor(0.1);
         *policy.MutableInitialBackoff() = NProtoInterop::CastToProto(TDuration::Seconds(1));
         *policy.MutableMaxBackoff() = NProtoInterop::CastToProto(TDuration::Minutes(1));
-        *policy.MutableResetBackoffThreshold() = NProtoInterop::CastToProto(TDuration::Hours(1)); // Query retry count set to 0 if uptime > 1h
+        *policy.MutableResetBackoffThreshold() = NProtoInterop::CastToProto(TDuration::Hours(1)); // Backoff state reset if uptime > 1h (next retry treated as first after reset)
         *policy.MutableQueryUptimeThreshold() = NProtoInterop::CastToProto(TDuration::Minutes(1)); // Query retried immediately if uptime > 1m
 
         return {std::move(mapping)};

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1811,66 +1811,25 @@ private:
     static std::vector<NKikimrKqp::TScriptExecutionRetryState::TMapping> CreateDefaultRetryMapping() {
         // Retried all statuses except of SUCCESS, CANCELLED
 
-        std::vector<NKikimrKqp::TScriptExecutionRetryState::TMapping> result;
+        NKikimrKqp::TScriptExecutionRetryState::TMapping mapping;
 
-        {   // Immediate retry policy
-            // Query will retry infinitely, if it runtime >= 864s (<= 100 retries per day)
-            // Used for internal / user errors and temporary unavailability
-            NKikimrKqp::TScriptExecutionRetryState::TMapping mapping;
-            mapping.AddStatusCode(Ydb::StatusIds::UNAVAILABLE);
-            mapping.AddStatusCode(Ydb::StatusIds::INTERNAL_ERROR);
-            mapping.AddStatusCode(Ydb::StatusIds::STATUS_CODE_UNSPECIFIED);
-            mapping.AddStatusCode(Ydb::StatusIds::UNDETERMINED);
-            mapping.AddStatusCode(Ydb::StatusIds::ABORTED);
-            mapping.AddStatusCode(Ydb::StatusIds::SESSION_BUSY);
-            mapping.AddStatusCode(Ydb::StatusIds::BAD_SESSION);
-            mapping.AddStatusCode(Ydb::StatusIds::TIMEOUT);
-            mapping.AddStatusCode(Ydb::StatusIds::ALREADY_EXISTS);
-            mapping.AddStatusCode(Ydb::StatusIds::SCHEME_ERROR);
-            mapping.AddStatusCode(Ydb::StatusIds::GENERIC_ERROR);
-            mapping.AddStatusCode(Ydb::StatusIds::PRECONDITION_FAILED);
-            mapping.AddStatusCode(Ydb::StatusIds::SESSION_EXPIRED);
-            mapping.AddStatusCode(Ydb::StatusIds::UNSUPPORTED);
-
-            auto& policy = *mapping.MutableBackoffPolicy();
-            policy.SetRetryPeriodMs(TDuration::Days(1).MilliSeconds());
-            policy.SetRetryRateLimit(100);
-
-            result.push_back(std::move(mapping));
+        const auto* statusDescriptor = Ydb::StatusIds::StatusCode_descriptor();
+        for (int i = 0; i < statusDescriptor->value_count(); ++i) {
+            const auto status = static_cast<Ydb::StatusIds::StatusCode>(statusDescriptor->value(i)->number());
+            if (!IsIn({Ydb::StatusIds::SUCCESS, Ydb::StatusIds::CANCELLED}, status)) {
+                mapping.AddStatusCode(status);
+            }
         }
 
-        {   // Short backoff retry policy
-            // Query will retry infinitely, if it runtime >= 662s (<= 130 retries per day), maximal backoff period is 202s
-            // Used for potentially external errors
-            NKikimrKqp::TScriptExecutionRetryState::TMapping mapping;
-            mapping.AddStatusCode(Ydb::StatusIds::EXTERNAL_ERROR);
-            mapping.AddStatusCode(Ydb::StatusIds::BAD_REQUEST);
-            mapping.AddStatusCode(Ydb::StatusIds::UNAUTHORIZED);
-            mapping.AddStatusCode(Ydb::StatusIds::NOT_FOUND);
+        auto& policy = *mapping.MutableExponentialDelayPolicy();
+        policy.SetBackoffMultiplier(1.5);
+        policy.SetJitterFactor(0.1);
+        *policy.MutableInitialBackoff() = NProtoInterop::CastToProto(TDuration::Seconds(1));
+        *policy.MutableMaxBackoff() = NProtoInterop::CastToProto(TDuration::Minutes(1));
+        *policy.MutableResetBackoffThreshold() = NProtoInterop::CastToProto(TDuration::Hours(1)); // Query retry count set to 0 if uptime > 1h
+        *policy.MutableQueryUptimeThreshold() = NProtoInterop::CastToProto(TDuration::Minutes(1)); // Query retried immediately if uptime > 1m
 
-            auto& policy = *mapping.MutableBackoffPolicy();
-            policy.SetRetryPeriodMs(TDuration::Days(1).MilliSeconds());
-            policy.SetRetryRateLimit(100);
-            policy.SetBackoffPeriodMs(TDuration::Seconds(2).MilliSeconds());
-
-            result.push_back(std::move(mapping));
-        }
-
-        {   // Long backoff retry policy
-            // Query will retry infinitely, if it runtime >= 448s (<= 192 retries per day), maximal backoff period is 404s
-            // Used for cluster overloaded errors
-            NKikimrKqp::TScriptExecutionRetryState::TMapping mapping;
-            mapping.AddStatusCode(Ydb::StatusIds::OVERLOADED);
-
-            auto& policy = *mapping.MutableBackoffPolicy();
-            policy.SetRetryPeriodMs(TDuration::Days(1).MilliSeconds());
-            policy.SetRetryRateLimit(100);
-            policy.SetBackoffPeriodMs(TDuration::Seconds(4).MilliSeconds());
-
-            result.push_back(std::move(mapping));
-        }
-
-        return result;
+        return {std::move(mapping)};
     }
 
 private:

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -3943,23 +3943,17 @@ struct LeaseFinalizationInfo {
     ELeaseState NewLeaseState = ELeaseState::ScriptFinalizing;
 };
 
-LeaseFinalizationInfo GetLeaseFinalizationSql(TInstant now, Ydb::StatusIds::StatusCode status, NKikimrKqp::TScriptExecutionRetryState& retryState, NYql::TIssues& issues) {
+LeaseFinalizationInfo GetLeaseFinalizationSql(TInstant startedAt, TInstant now, Ydb::StatusIds::StatusCode status, NKikimrKqp::TScriptExecutionRetryState& retryState, NYql::TIssues& issues) {
     const auto& policy = TRetryPolicyItem::FromProto(status, retryState);
-    TRetryLimiter retryLimiter(
-        retryState.GetRetryCounter(),
-        NProtoInterop::CastFromProto(retryState.GetRetryCounterUpdatedAt()),
-        retryState.GetRetryRate()
-    );
+    TRetryLimiter retryLimiter(retryState);
 
-    const bool retry = policy && retryLimiter.UpdateOnRetry(TInstant::Now(), *policy);
-    retryState.SetRetryCounter(retryLimiter.RetryCount);
-    *retryState.MutableRetryCounterUpdatedAt() = NProtoInterop::CastToProto(now);
-    retryState.SetRetryRate(retryLimiter.RetryRate);
+    const bool retry = policy && retryLimiter.UpdateOnRetry(startedAt, TInstant::Now(), *policy);
+    retryLimiter.SaveToProto(retryState);
 
     if (retry) {
         issues = AddRootIssue(TStringBuilder()
             << "Script execution operation failed with code " << Ydb::StatusIds::StatusCode_Name(status)
-            << " and will be restarted (RetryCount: " << retryLimiter.RetryCount << ", Backoff: " << retryLimiter.Backoff << ", RetryRate: " << retryLimiter.RetryRate << ")"
+            << " and will be restarted (RetryCount: " << retryLimiter.RetryCount << ", Backoff: " << retryLimiter.Backoff << ")"
             << " at " << now, issues);
 
         return {
@@ -3977,7 +3971,7 @@ LeaseFinalizationInfo GetLeaseFinalizationSql(TInstant now, Ydb::StatusIds::Stat
         if (policy) {
             TStringBuilder finalIssue;
             finalIssue << "Script execution operation failed with code " << Ydb::StatusIds::StatusCode_Name(status);
-            if (policy->RetryCount) {
+            if (policy->PolicyInitialized) {
                 finalIssue << " (" << retryLimiter.LastError << ")";
             }
             issues = AddRootIssue(finalIssue << " at " << now, issues);
@@ -4018,6 +4012,7 @@ public:
                 script_sinks,
                 script_secret_names,
                 retry_state,
+                start_ts,
                 graph_compressed IS NOT NULL AS has_graph
             FROM `.metadata/script_executions`
             WHERE database = $database AND execution_id = $execution_id AND
@@ -4153,6 +4148,12 @@ public:
                 // Disable retries if state not saved
                 RetryState.ClearRetryPolicyMapping();
             }
+
+            if (const auto startTs = result.ColumnParser("start_ts").GetOptionalTimestamp()) {
+                StartedAt = *startTs;
+            } else {
+                return Finish(Ydb::StatusIds::INTERNAL_ERROR, "Missing operation start timestamp");
+            }
         }
 
         {   // Lease info
@@ -4230,7 +4231,7 @@ public:
         TInstant retryDeadline = TInstant::Now();
         ELeaseState leaseState = ELeaseState::ScriptFinalizing;
         if (!Response->ApplicateScriptExternalEffectRequired) {
-            const auto leaseInfo = GetLeaseFinalizationSql(retryDeadline, Request.OperationStatus, RetryState, Request.Issues);
+            const auto leaseInfo = GetLeaseFinalizationSql(StartedAt, retryDeadline, Request.OperationStatus, RetryState, Request.Issues);
             sql << leaseInfo.Sql;
             retryDeadline += leaseInfo.Backoff;
             leaseState = leaseInfo.NewLeaseState;
@@ -4366,6 +4367,7 @@ private:
     std::optional<TString> SerializedSinks;
     std::optional<TString> SerializedSecretNames;
     NKikimrKqp::TScriptExecutionRetryState RetryState;
+    TInstant StartedAt;
 };
 
 class TScriptFinalizationFinisherActor : public TQueryBase {
@@ -4398,6 +4400,7 @@ public:
                 issues,
                 retry_state,
                 meta,
+                start_ts,
                 graph_compressed IS NOT NULL AS has_graph
             FROM `.metadata/script_executions`
             WHERE database = $database AND execution_id = $execution_id AND
@@ -4519,6 +4522,12 @@ public:
                     RetryState.ClearRetryPolicyMapping();
                 }
             }
+
+            if (const auto startTs = result.ColumnParser("start_ts").GetOptionalTimestamp()) {
+                StartedAt = *startTs;
+            } else {
+                return Finish(Ydb::StatusIds::INTERNAL_ERROR, "Missing operation start timestamp");
+            }
         }
 
         UpdateOperationFinalStatus();
@@ -4551,7 +4560,7 @@ public:
         Y_ENSURE(OperationStatus);
 
         TInstant retryDeadline = TInstant::Now();
-        const auto leaseInfo = GetLeaseFinalizationSql(retryDeadline, *OperationStatus, RetryState, OperationIssues);
+        const auto leaseInfo = GetLeaseFinalizationSql(StartedAt, retryDeadline, *OperationStatus, RetryState, OperationIssues);
         sql << leaseInfo.Sql;
         retryDeadline += leaseInfo.Backoff;
         WaitRetry = leaseInfo.NewLeaseState == ELeaseState::WaitRetry;
@@ -4616,6 +4625,7 @@ private:
     Ydb::Query::ExecStatus ExecutionStatus = Ydb::Query::EXEC_STATUS_UNSPECIFIED;
     NYql::TIssues OperationIssues;
     NKikimrKqp::TScriptExecutionRetryState RetryState;
+    TInstant StartedAt;
     const i64 LeaseGeneration;
     bool AlreadyFinished = false;
     bool WaitRetry = false;

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -759,7 +759,7 @@ Y_UNIT_TEST_SUITE(TestScriptExecutionsUtils) {
 
         const auto checkStatus = [&](Ydb::StatusIds::StatusCode status, bool expectedPolicy) {
             const auto policy = TRetryPolicyItem::FromProto(status, retryState);
-            UNIT_ASSERT_VALUES_EQUAL_C(expectedPolicy, policy->PolicyInitialized, status);
+            UNIT_ASSERT_VALUES_EQUAL_C(expectedPolicy, policy && policy->PolicyInitialized, status);
         };
 
         checkStatus(Ydb::StatusIds::SCHEME_ERROR, true);

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -14,7 +14,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/services/ydb/ydb_common_ut.h>
 
-#include <contrib/libs/fmt/include/fmt/format.h>
+#include <fmt/format.h>
 
 #include <library/cpp/protobuf/interop/cast.h>
 

--- a/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_retries.cpp
+++ b/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_retries.cpp
@@ -1,14 +1,178 @@
 #include "kqp_script_execution_retries.h"
 
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
+#include <contrib/libs/protobuf/src/google/protobuf/timestamp.pb.h>
+
+#include <library/cpp/protobuf/interop/cast.h>
+
+#include <util/random/random.h>
 #include <util/string/builder.h>
 
 namespace NKikimr::NKqp {
 
-TRetryPolicyItem::TRetryPolicyItem(ui64 retryCount, ui64 retryLimit, TDuration retryPeriod, TDuration backoffPeriod)
+namespace {
+
+class TLinearBackoffPolicy final : public TRetryPolicyItem::IPolicy {
+    using TResult = TRetryPolicyItem::TRetryResult;
+
+public:
+    TLinearBackoffPolicy() = default;
+
+    explicit TLinearBackoffPolicy(const NKikimrKqp::TScriptExecutionRetryState::TBackoffPolicy& config)
+        : RetryPeriod(TDuration::MilliSeconds(config.GetRetryPeriodMs()))
+        , BackoffPeriod(TDuration::MilliSeconds(config.GetBackoffPeriodMs()))
+        , RetryRateLimit(config.GetRetryRateLimit())
+        , RetryCountLimit(config.GetRetryCountLimit())
+    {}
+
+    TLinearBackoffPolicy(ui64 retryCount, ui64 retryLimit, TDuration retryPeriod, TDuration backoffPeriod)
+        : RetryPeriod(retryPeriod)
+        , BackoffPeriod(backoffPeriod)
+        , RetryRateLimit(retryCount)
+        , RetryCountLimit(retryLimit)
+    {}
+
+    TResult Update(TInstant startedAt, TInstant lastSeenAt, TInstant now, TRetryPolicyState& state) const final {
+        Y_UNUSED(startedAt);
+
+        const auto lastPeriod = lastSeenAt - state.RetryCounterUpdatedAt;
+        if (lastPeriod >= RetryPeriod) {
+            state.RetryRate = 0.0;
+        } else {
+            state.RetryRate += 1.0;
+            const auto rate = lastPeriod / RetryPeriod * RetryRateLimit;
+            if (state.RetryRate > rate) {
+                state.RetryRate -= rate;
+            } else {
+                state.RetryRate = 0.0;
+            }
+        }
+
+        state.RetryCounterUpdatedAt = now;
+
+        TResult result;
+        if (state.RetryRate >= RetryRateLimit) {
+            result.LastError = TStringBuilder() << "failure rate " << state.RetryRate << " exceeds limit of " << RetryRateLimit;
+        } else if (RetryCountLimit && state.RetryCount >= RetryCountLimit) {
+            result.LastError = TStringBuilder() << "retry count reached limit of " << RetryCountLimit;
+        } else {
+            state.RetryCount++;
+            result.Retry = true;
+            result.Backoff = BackoffPeriod * (state.RetryRate + 1);
+        }
+
+        return result;
+    }
+
+    bool IsInitialized() const final {
+        return RetryRateLimit > 0;
+    }
+
+private:
+    const TDuration RetryPeriod = TDuration::Seconds(1);
+    const TDuration BackoffPeriod;
+    const ui64 RetryRateLimit = 0;
+    const ui64 RetryCountLimit = 0;
+};
+
+class TExponentialBackoffPolicy final : public TRetryPolicyItem::IPolicy {
+    using TResult = TRetryPolicyItem::TRetryResult;
+
+public:
+    explicit TExponentialBackoffPolicy(const NKikimrKqp::TScriptExecutionRetryState::TExponentialDelayPolicy& config)
+        : BackoffMultiplier(config.GetBackoffMultiplier())
+        , InitialBackoff(NProtoInterop::CastFromProto(config.GetInitialBackoff()))
+        , MaxBackoff(NProtoInterop::CastFromProto(config.GetMaxBackoff()))
+        , ResetBackoffThreshold(NProtoInterop::CastFromProto(config.GetResetBackoffThreshold()))
+        , QueryUptimeThreshold(NProtoInterop::CastFromProto(config.GetQueryUptimeThreshold()))
+        , JitterFactor(config.GetJitterFactor())
+    {
+        Y_VALIDATE(BackoffMultiplier > 1.0, "Backoff multiplier should be greater than 1.0");
+        Y_VALIDATE(InitialBackoff > TDuration::Zero(), "Initial backoff should be non zero");
+        Y_VALIDATE(JitterFactor >= 0.0 && JitterFactor <= 1.0, "Jitter factor should be in range [0.0, 1.0]");
+
+        if (QueryUptimeThreshold && ResetBackoffThreshold) {
+            Y_VALIDATE(QueryUptimeThreshold <= ResetBackoffThreshold, "Immediate retry duration should be not greater than reset retry state threshold");
+        }
+    }
+
+    TResult Update(TInstant startedAt, TInstant lastSeenAt, TInstant now, TRetryPolicyState& state) const final {
+        const auto uptime = lastSeenAt - startedAt;
+        if (ResetBackoffThreshold && uptime >= ResetBackoffThreshold) {
+            // Reset retry state after uptime threshold
+            state.RetryCount = 0;
+        }
+
+        state.RetryCounterUpdatedAt = now;
+        state.RetryCount++;
+        TResult result = {.Retry = true};
+
+        if (QueryUptimeThreshold && uptime >= QueryUptimeThreshold) {
+            // Immediate retry after uptime threshold
+            return result;
+        }
+
+        double backoff = InitialBackoff.GetValue();
+        const double maxBackoff = MaxBackoff ? MaxBackoff.GetValue() : MaxFloor<TDuration::TValue>();
+        for (ui64 i = 0; i < state.RetryCount && backoff < maxBackoff; ++i) {
+            backoff *= BackoffMultiplier;
+        }
+        backoff = std::min(backoff, maxBackoff);
+
+        if (JitterFactor) {
+            backoff = std::min(backoff * (1 + (1 - 2 * RandomNumber<double>()) * JitterFactor), maxBackoff);
+        }
+
+        result.Backoff = TDuration::FromValue(backoff);
+        return result;
+    }
+
+    bool IsInitialized() const final {
+        return true;
+    }
+
+private:
+    const double BackoffMultiplier = 0.0;
+    const TDuration InitialBackoff;
+    const TDuration MaxBackoff;
+    const TDuration ResetBackoffThreshold;
+    const TDuration QueryUptimeThreshold;
+    const double JitterFactor = 0.0;
+};
+
+} // anonymous namespace
+
+TRetryPolicyState::TRetryPolicyState(ui64 retryCount, TInstant retryCounterUpdatedAt, double retryRate)
     : RetryCount(retryCount)
-    , RetryLimit(retryLimit)
-    , RetryPeriod(retryPeriod)
-    , BackoffPeriod(backoffPeriod)
+    , RetryCounterUpdatedAt(retryCounterUpdatedAt)
+    , RetryRate(retryRate)
+{}
+
+TRetryPolicyState::TRetryPolicyState(const NKikimrKqp::TScriptExecutionRetryState& retryState)
+    : RetryCount(retryState.GetRetryCounter())
+    , RetryCounterUpdatedAt(NProtoInterop::CastFromProto(retryState.GetRetryCounterUpdatedAt()))
+    , RetryRate(retryState.GetRetryRate())
+{}
+
+void TRetryPolicyState::SaveToProto(NKikimrKqp::TScriptExecutionRetryState& retryState) const {
+    retryState.SetRetryCounter(RetryCount);
+    *retryState.MutableRetryCounterUpdatedAt() = NProtoInterop::CastToProto(RetryCounterUpdatedAt);
+    retryState.SetRetryRate(RetryRate);
+}
+
+TRetryPolicyItem::TRetryPolicyItem()
+    : Policy(std::make_shared<TLinearBackoffPolicy>())
+{}
+
+TRetryPolicyItem::TRetryPolicyItem(ui64 retryCount, ui64 retryLimit, TDuration retryPeriod, TDuration backoffPeriod)
+    : Policy(std::make_shared<TLinearBackoffPolicy>(retryCount, retryLimit, retryPeriod, backoffPeriod))
+    , PolicyInitialized(Policy->IsInitialized())
+{}
+
+TRetryPolicyItem::TRetryPolicyItem(IPolicy::TPtr policy)
+    : Policy(std::move(policy))
+    , PolicyInitialized(Policy && Policy->IsInitialized())
 {}
 
 std::optional<TRetryPolicyItem> TRetryPolicyItem::FromProto(Ydb::StatusIds::StatusCode status, const NKikimrKqp::TScriptExecutionRetryState& retryState) {
@@ -20,13 +184,10 @@ std::optional<TRetryPolicyItem> TRetryPolicyItem::FromProto(Ydb::StatusIds::Stat
 
             switch (mapping.GetPolicyCase()) {
                 case NKikimrKqp::TScriptExecutionRetryState::TMapping::kBackoffPolicy: {
-                    const auto& backoffPolicy = mapping.GetBackoffPolicy();
-                    return TRetryPolicyItem(
-                        backoffPolicy.GetRetryRateLimit(),
-                        backoffPolicy.GetRetryCountLimit(),
-                        TDuration::MilliSeconds(backoffPolicy.GetRetryPeriodMs()),
-                        TDuration::MilliSeconds(backoffPolicy.GetBackoffPeriodMs())
-                    );
+                    return TRetryPolicyItem(std::make_shared<TLinearBackoffPolicy>(mapping.GetBackoffPolicy()));
+                }
+                case NKikimrKqp::TScriptExecutionRetryState::TMapping::kExponentialDelayPolicy: {
+                    return TRetryPolicyItem(std::make_shared<TExponentialBackoffPolicy>(mapping.GetExponentialDelayPolicy()));
                 }
                 default: {
                     throw std::runtime_error(TStringBuilder() << "Unsupported retry policy: " << mapping.DebugString());
@@ -38,12 +199,6 @@ std::optional<TRetryPolicyItem> TRetryPolicyItem::FromProto(Ydb::StatusIds::Stat
     return std::nullopt;
 }
 
-TRetryLimiter::TRetryLimiter(ui64 retryCount, TInstant retryCounterUpdatedAt, double retryRate)
-    : RetryCount(retryCount)
-    , RetryCounterUpdatedAt(retryCounterUpdatedAt)
-    , RetryRate(retryRate)
-{}
-
 void TRetryLimiter::Assign(ui64 retryCount, TInstant retryCounterUpdatedAt, double retryRate) {
     RetryCount = retryCount;
     RetryCounterUpdatedAt = retryCounterUpdatedAt;
@@ -51,35 +206,24 @@ void TRetryLimiter::Assign(ui64 retryCount, TInstant retryCounterUpdatedAt, doub
 }
 
 bool TRetryLimiter::UpdateOnRetry(TInstant lastSeenAt, const TRetryPolicyItem& policy, TInstant now) {
-    const auto lastPeriod = lastSeenAt - RetryCounterUpdatedAt;
-    if (lastPeriod >= policy.RetryPeriod) {
-        RetryRate = 0.0;
-    } else {
-        RetryRate += 1.0;
-        const auto rate = lastPeriod / policy.RetryPeriod * policy.RetryCount;
-        if (RetryRate > rate) {
-            RetryRate -= rate;
-        } else {
-            RetryRate = 0.0;
-        }
+    return UpdateOnRetry(RetryCounterUpdatedAt, lastSeenAt, policy, now);
+}
+
+bool TRetryLimiter::UpdateOnRetry(TInstant startedAt, TInstant lastSeenAt, const TRetryPolicyItem& policy, TInstant now) {
+    if (!policy.Policy) {
+        LastError = "No retry policy set";
+        return false;
     }
 
-    bool shouldRetry = true;
-    if (RetryRate >= policy.RetryCount) {
-        shouldRetry = false;
-        LastError = TStringBuilder() << "failure rate " << RetryRate << " exceeds limit of "  << policy.RetryCount;
-    } else if (policy.RetryLimit && RetryCount >= policy.RetryLimit) {
-        shouldRetry = false;
-        LastError = TStringBuilder() << "retry count reached limit of " << policy.RetryLimit;
+    auto result = policy.Policy->Update(startedAt, lastSeenAt, now, *this);
+    LastError = std::move(result.LastError);
+    Backoff = result.Backoff;
+
+    if (!result.Retry && !LastError) {
+        LastError = "Retry limit reached";
     }
 
-    if (shouldRetry) {
-        RetryCount++;
-        RetryCounterUpdatedAt = now;
-        Backoff = policy.BackoffPeriod * (RetryRate + 1);
-    }
-
-    return shouldRetry;
+    return result.Retry;
 }
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_retries.cpp
+++ b/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_retries.cpp
@@ -2,7 +2,7 @@
 
 #include <ydb/library/yverify_stream/yverify_stream.h>
 
-#include <contrib/libs/protobuf/src/google/protobuf/timestamp.pb.h>
+#include <google/protobuf/timestamp.pb.h>
 
 #include <library/cpp/protobuf/interop/cast.h>
 

--- a/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_retries.cpp
+++ b/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_retries.cpp
@@ -115,7 +115,7 @@ public:
 
         double backoff = InitialBackoff.GetValue();
         const double maxBackoff = MaxBackoff ? MaxBackoff.GetValue() : MaxFloor<TDuration::TValue>();
-        for (ui64 i = 0; i < state.RetryCount && backoff < maxBackoff; ++i) {
+        for (ui64 i = 0; i + 1 < state.RetryCount && backoff < maxBackoff; ++i) {
             backoff *= BackoffMultiplier;
         }
         backoff = std::min(backoff, maxBackoff);

--- a/ydb/core/kqp/proxy_service/script_executions_utils/ya.make
+++ b/ydb/core/kqp/proxy_service/script_executions_utils/ya.make
@@ -7,8 +7,10 @@ SRCS(
 
 PEERDIR(
     library/cpp/blockcodecs
+    library/cpp/protobuf/interop
     ydb/core/protos
     ydb/core/tx/datashard
+    ydb/library/yverify_stream
     ydb/public/api/protos
     yql/essentials/public/issue
 )

--- a/ydb/core/kqp/proxy_service/ut/ya.make
+++ b/ydb/core/kqp/proxy_service/ut/ya.make
@@ -10,14 +10,15 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/protobuf/interop
     ydb/core/kqp/run_script_actor
     ydb/core/kqp/proxy_service
     ydb/core/kqp/ut/common
     ydb/core/kqp/workload_service/ut/common
-    yql/essentials/sql/pg_dummy
-    ydb/public/sdk/cpp/src/client/query
     ydb/public/sdk/cpp/src/client/driver
+    ydb/public/sdk/cpp/src/client/query
     ydb/services/ydb
+    yql/essentials/sql/pg_dummy
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -17,7 +17,9 @@
 #include <ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_scripting.h>
 
-#include <fmt/format.h>
+#include <contrib/libs/fmt/include/fmt/format.h>
+
+#include <library/cpp/protobuf/interop/cast.h>
 
 namespace NKikimr::NKqp {
 
@@ -606,10 +608,10 @@ public:
             retryMapping.AddStatusCode(status);
         }
 
-        auto& policy = *retryMapping.MutableBackoffPolicy();
-        policy.SetRetryPeriodMs(backoffDuration.MilliSeconds());
-        policy.SetBackoffPeriodMs(backoffDuration.MilliSeconds());
-        policy.SetRetryRateLimit(1);
+        auto& policy = *retryMapping.MutableExponentialDelayPolicy();
+        policy.SetBackoffMultiplier(1.5);
+        *policy.MutableInitialBackoff() = NProtoInterop::CastToProto(backoffDuration);
+        *policy.MutableMaxBackoff() = NProtoInterop::CastToProto(backoffDuration);
 
         return retryMapping;
     }

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -17,7 +17,7 @@
 #include <ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_scripting.h>
 
-#include <contrib/libs/fmt/include/fmt/format.h>
+#include <fmt/format.h>
 
 #include <library/cpp/protobuf/interop/cast.h>
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/ya.make
+++ b/ydb/core/kqp/ut/federated_query/datastreams/ya.make
@@ -15,6 +15,7 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/protobuf/interop
     library/cpp/threading/local_executor
     ydb/core/cms/console
     ydb/core/kqp

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -13,6 +13,8 @@
 
 #include <yql/essentials/utils/log/log.h>
 
+#include <library/cpp/protobuf/interop/cast.h>
+
 #include <fmt/format.h>
 
 namespace NKikimr::NKqp {
@@ -3102,10 +3104,10 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
 
             NKikimrKqp::TScriptExecutionRetryState::TMapping retryMapping;
             retryMapping.AddStatusCode(Ydb::StatusIds::PRECONDITION_FAILED);
-            auto& policy = *retryMapping.MutableBackoffPolicy();
-            policy.SetRetryPeriodMs(BACKOFF_DURATION.MilliSeconds());
-            policy.SetBackoffPeriodMs(BACKOFF_DURATION.MilliSeconds());
-            policy.SetRetryRateLimit(1);
+            auto& policy = *retryMapping.MutableExponentialDelayPolicy();
+            policy.SetBackoffMultiplier(1.5);
+            *policy.MutableInitialBackoff() = NProtoInterop::CastToProto(TDuration::Seconds(1));
+            *policy.MutableMaxBackoff() = NProtoInterop::CastToProto(TDuration::Seconds(5));
 
             NKikimrKqp::TEvQueryRequest queryProto;
             queryProto.SetUserToken(NACLib::TUserToken(BUILTIN_ACL_ROOT, TVector<NACLib::TSID>{runtime.GetAppData().AllAuthenticatedUsers}).SerializeAsString());

--- a/ydb/core/kqp/ut/federated_query/s3/ya.make
+++ b/ydb/core/kqp/ut/federated_query/s3/ya.make
@@ -16,6 +16,7 @@ SRCS(
 
 PEERDIR(
     contrib/libs/aws-sdk-cpp/aws-cpp-sdk-s3
+    library/cpp/protobuf/interop
     ydb/core/kqp/ut/common
     ydb/core/kqp/ut/federated_query/common
     ydb/library/testlib/s3_recipe_helper

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -966,11 +966,21 @@ message TScriptExecutionRetryState {
         optional uint64 RetryCountLimit = 4;
     }
 
+    message TExponentialDelayPolicy {
+        optional double BackoffMultiplier = 1;
+        optional google.protobuf.Duration InitialBackoff = 2;
+        optional google.protobuf.Duration MaxBackoff = 3;
+        optional google.protobuf.Duration ResetBackoffThreshold = 4;
+        optional google.protobuf.Duration QueryUptimeThreshold = 5;
+        optional double JitterFactor = 6;
+    }
+
     message TMapping {
         repeated Ydb.StatusIds.StatusCode StatusCode = 1;
 
         oneof Policy {
             TBackoffPolicy BackoffPolicy = 2;
+            TExponentialDelayPolicy ExponentialDelayPolicy = 3;
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported infinite retries for streaming query

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Bugfix ticket: https://st.yandex-team.ru/YQ-4550

Retry policy now:

1. If query uptime > 1h -> reset retry state (`RetriesCount` := 0)
2. If query uptime > 1m -> perform immediate retry
3. Otherwise perform retry with `Backoff` = min(1s * 1.5^`RetriesCount`, 1m), with jitter factor 0.1

So in case of release update query will be retried immediately after each node restart, but if query causes some bug and trigger node fault - it will be retried with exponential backoff after second retry (and query start frequency will become 1m in any case of uptime).
