### PR TITLE
YQ-4649 supported scalar writing into PQ and solomon

### DIFF
--- a/ydb/core/kqp/opt/kqp_opt_build_txs.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_build_txs.cpp
@@ -653,14 +653,13 @@ private:
 
     std::optional<TVector<TExprList>> CollectEffects(const TExprList& list, TExprContext& ctx, TKqpOptimizeContext& kqpCtx) {
         TVector<TEffectsInfo> effectsInfos;
-        TVector<TExprNode::TPtr> externalEffects;
+        TVector<TKqpSinkEffect> externalEffects;
 
         for (const auto& expr : list) {
             if (auto sinkEffect = expr.Maybe<TKqpSinkEffect>()) {
                 const auto sinkSettings = GetStageSink(sinkEffect.Cast()).Settings().Maybe<TKqpTableSinkSettings>();
                 if (!sinkSettings) {
-                    // External writes always added into one physical transaction.
-                    externalEffects.emplace_back(expr.Ptr());
+                    externalEffects.emplace_back(sinkEffect.Cast());
                 } else {
                     // Two table sinks can't be executed in one physical transaction if they write into same table and have same priority.
 
@@ -713,13 +712,22 @@ private:
             }
         }
 
-        if (externalEffects) {
-            if (!effectsInfos) {
+        for (const auto& sinkEffect : externalEffects) {
+            // Two external writes can not be in single physical transaction if they use same sink of same stage.
+
+            auto it = std::find_if(
+                effectsInfos.begin(),
+                effectsInfos.end(),
+                [id = std::pair(sinkEffect.Stage().Raw(), FromString<ui64>(sinkEffect.SinkIndex()))](const TEffectsInfo& effectsInfo) {
+                    return !effectsInfo.SinkEffects.contains(id);
+                });
+
+            if (it == effectsInfos.end()) {
                 effectsInfos.emplace_back();
+                it = std::prev(effectsInfos.end());
             }
-            for (const auto& expr : externalEffects) {
-                effectsInfos.back().AddExpr(expr);
-            }
+
+            it->AddExpr(sinkEffect.Ptr());
         }
 
         TVector<TExprList> results;

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -2120,7 +2120,6 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
   }
 ])";
         UNIT_ASSERT_VALUES_EQUAL(GetSolomonMetrics(soLocation), expectedMetrics);
->>>>>>> b1f82a22e3e (Supported scalar writing into PQ and solomon)
     }
 }
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -792,6 +792,23 @@ public:
         }
     }
 
+    // Other helpers
+
+    static std::function<void(const TString)> AstChecker(ui64 txCount, ui64 stagesCount) {
+        const auto stringCounter = [](const TString& str, const TString& subStr) {
+            ui64 count = 0;
+            for (size_t i = str.find(subStr); i != TString::npos; i = str.find(subStr, i + subStr.size())) {
+                ++count;
+            }
+            return count;
+        };
+
+        return [txCount, stagesCount, stringCounter](const TString& ast) {
+            UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "KqpPhysicalTx"), txCount);
+            UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "DqPhyStage"), stagesCount);
+        };
+    }
+
 private:
     void EnsureNotInitialized(const TString& info) {
         UNIT_ASSERT_C(!Kikimr, "Kikimr runner is already initialized, can not setup " << info);
@@ -1870,21 +1887,6 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
             "table"_a = sourceTable
         ));
 
-        const auto astChecker = [](ui64 txCount, ui64 stagesCount) {
-            const auto stringCounter = [](const TString& str, const TString& subStr) {
-                ui64 count = 0;
-                for (size_t i = str.find(subStr); i != TString::npos; i = str.find(subStr, i + subStr.size())) {
-                    ++count;
-                }
-                return count;
-            };
-
-            return [txCount, stagesCount, stringCounter](const TString& ast) {
-                UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "KqpPhysicalTx"), txCount);
-                UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "DqPhyStage"), stagesCount);
-            };
-        };
-
         TInstant disposition = TInstant::Now();
 
         // Double PQ insert
@@ -1897,7 +1899,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
                 "pq_source"_a = pqSource,
                 "output_topic1"_a = firstOutputTopic,
                 "output_topic2"_a = secondOutputTopic
-            ), EStatus::SUCCESS, "", astChecker(1, 1));
+            ), EStatus::SUCCESS, "", AstChecker(1, 1));
 
             ReadTopicMessage(firstOutputTopic, R"([{"Val": "ABC"}])", disposition);
             ReadTopicMessage(secondOutputTopic, R"({"Val": "ABC"}-B)", disposition);
@@ -1938,7 +1940,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
                 "second_solomon_project"_a = secondSoLocation.ProjectId,
                 "second_solomon_folder"_a = secondSoLocation.FolderId,
                 "second_solomon_service"_a = secondSoLocation.Service
-            ), EStatus::SUCCESS, "", astChecker(1, 1));
+            ), EStatus::SUCCESS, "", AstChecker(1, 1));
 
             TString expectedMetrics = R"([
   {
@@ -1989,7 +1991,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
                 "output_topic"_a = firstOutputTopic,
                 "row_table"_a = rowSinkTable,
                 "column_table"_a = columnSinkTable
-            ), EStatus::SUCCESS, "", astChecker(2, 4));
+            ), EStatus::SUCCESS, "", AstChecker(2, 4));
 
             ReadTopicMessage(firstOutputTopic, R"([{"Val": "ABC"}])", disposition);
             disposition = TInstant::Now();
@@ -2040,6 +2042,85 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
 
         const auto result = asyncResult.ExtractValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+    }
+
+    Y_UNIT_TEST_F(ScalarFederativeWriting, TStreamingTestFixture) {
+        constexpr char firstOutputTopic[] = "replicatedWritingOutputTopicName1";
+        constexpr char secondOutputTopic[] = "replicatedWritingOutputTopicName2";
+        constexpr char pqSource[] = "pqSourceName";
+        CreateTopic(firstOutputTopic);
+        CreateTopic(secondOutputTopic);
+        CreatePqSource(pqSource);
+
+        constexpr char solomonSink[] = "solomonSinkName";
+        CreateSolomonSource(solomonSink);
+
+        const TSolomonLocation soLocation = {
+            .ProjectId = "cloudId1",
+            .FolderId = "folderId1",
+            .Service = "custom1",
+            .IsCloud = false,
+        };
+        CleanupSolomon(soLocation);
+        ExecQuery(fmt::format(R"(
+            INSERT INTO `{pq_source}`.`{output_topic1}` SELECT "TestData1";
+            INSERT INTO `{pq_source}`.`{output_topic2}` SELECT "TestData2" AS Data;
+            INSERT INTO `{pq_source}`.`{output_topic2}`(Data) VALUES ("TestData2");
+
+            INSERT INTO `{solomon_sink}`.`{solomon_project}/{solomon_folder}/{solomon_service}`
+            SELECT
+                13333 AS value,
+                "test-insert" AS sensor,
+                Timestamp("2025-03-12T14:40:39Z") AS ts;
+
+            INSERT INTO `{solomon_sink}`.`{solomon_project}/{solomon_folder}/{solomon_service}`
+                (value, sensor, ts)
+            VALUES
+                (23333, "test-insert-2", Timestamp("2025-03-12T14:40:39Z"));)",
+            "pq_source"_a = pqSource,
+            "output_topic1"_a = firstOutputTopic,
+            "output_topic2"_a = secondOutputTopic,
+            "solomon_sink"_a = solomonSink,
+            "solomon_project"_a = soLocation.ProjectId,
+            "solomon_folder"_a = soLocation.FolderId,
+            "solomon_service"_a = soLocation.Service
+        ), EStatus::SUCCESS, "", AstChecker(2, 5));
+
+        ReadTopicMessage(firstOutputTopic, "TestData1");
+        ReadTopicMessages(secondOutputTopic, {"TestData2", "TestData2"});
+
+        TString expectedMetrics = R"([
+  {
+    "labels": [
+      [
+        "name",
+        "value"
+      ],
+      [
+        "sensor",
+        "test-insert"
+      ]
+    ],
+    "ts": 1741790439,
+    "value": 13333
+  },
+  {
+    "labels": [
+      [
+        "name",
+        "value"
+      ],
+      [
+        "sensor",
+        "test-insert-2"
+      ]
+    ],
+    "ts": 1741790439,
+    "value": 23333
+  }
+])";
+        UNIT_ASSERT_VALUES_EQUAL(GetSolomonMetrics(soLocation), expectedMetrics);
+>>>>>>> b1f82a22e3e (Supported scalar writing into PQ and solomon)
     }
 }
 

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_physical_optimize.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_physical_optimize.cpp
@@ -83,7 +83,41 @@ public:
         return TExprBase(maybeRead.Cast().World().Ptr());
     }
 
-    TMaybe<TDqStage> BuildSinkStage(TPositionHandle writePos, TSoDataSink dataSink, TCoAtom writeShard, TExprBase input, TExprContext& ctx, const TGetParents& getParents) const {
+    TMaybe<TDqStage> BuildSinkStage(TPositionHandle writePos, TSoDataSink dataSink, TCoAtom writeShard, TExprBase input, TExprContext& ctx, const TGetParents& getParents, bool alowPureStage) const {
+        const auto* typeAnn = input.Ref().GetTypeAnn();
+        const TTypeAnnotationNode* inputItemType = nullptr;
+        if (!EnsureNewSeqType<false, true, false>(input.Pos(), *typeAnn, ctx, &inputItemType)) {
+            return {};
+        }
+
+        const TExprBase rowTypeNode(ExpandType(writePos, *inputItemType, ctx));
+        const TString solomonCluster(dataSink.Cluster());
+        auto dqSinkBuilder = Build<TDqSink>(ctx, writePos)
+            .DataSink(dataSink)
+            .Settings(BuildSolomonShard(writeShard, rowTypeNode, ctx, solomonCluster));
+
+        if (alowPureStage && IsDqPureExpr(input)) {
+            YQL_CLOG(INFO, ProviderSolomon) << "Optimize insert into solomon (SoWriteToShard / SoInsert), build pure stage with sink";
+
+            const auto dqSink = dqSinkBuilder
+                .Index().Build(0)
+                .Done();
+
+            return Build<TDqStage>(ctx, writePos)
+                .Inputs().Build()
+                .Program<TCoLambda>()
+                    .Args({})
+                    .Body<TCoToFlow>()
+                        .Input(input)
+                        .Build()
+                    .Build()
+                .Outputs()
+                    .Add(dqSink)
+                    .Build()
+                .Settings().Build()
+                .Done();
+        }
+        
         const auto maybeDqUnion = input.Maybe<TDqCnUnionAll>();
         if (!maybeDqUnion) {
             // If input is not DqCnUnionAll, it means not all dq optimizations are done yet
@@ -91,26 +125,13 @@ public:
         }
 
         const auto dqUnion = maybeDqUnion.Cast();
-        const auto* parentsMap = getParents();
-        if (!NDq::IsSingleConsumerConnection(dqUnion, *parentsMap)) {
+        if (!NDq::IsSingleConsumerConnection(dqUnion, *getParents())) {
             return {};
         }
 
-        YQL_CLOG(INFO, ProviderSolomon) << "Optimize insert into solomon (SoWriteToShard / SoInsert)";
+        YQL_CLOG(INFO, ProviderSolomon) << "Optimize insert into solomon (SoWriteToShard / SoInsert), push into existing stage";
 
-        const auto* typeAnn = input.Ref().GetTypeAnn();
-        const TTypeAnnotationNode* inputItemType = nullptr;
-        if (!EnsureNewSeqType<false, true, false>(input.Pos(), *typeAnn, ctx, &inputItemType)) {
-            return {};
-        }
-
-        const auto rowTypeNode = ExpandType(writePos, *inputItemType, ctx);
-        const TString solomonCluster(dataSink.Cluster());
-        const auto shard = BuildSolomonShard(writeShard, TExprBase(rowTypeNode), ctx, solomonCluster);
-
-        const auto dqSink = Build<TDqSink>(ctx, writePos)
-            .DataSink(dataSink)
-            .Settings(shard)
+        const auto dqSink = dqSinkBuilder
             .Index(dqUnion.Output().Index())
             .Done();
 
@@ -134,7 +155,7 @@ public:
         }
 
         const auto write = node.Cast<TSoWriteToShard>();
-        const auto stage = BuildSinkStage(write.Pos(), write.DataSink(), write.Shard(), write.Input(), ctx, getParents);
+        const auto stage = BuildSinkStage(write.Pos(), write.DataSink(), write.Shard(), write.Input(), ctx, getParents, /* alowPureStage */ false);
         if (!stage) {
             return node;
         }
@@ -150,21 +171,22 @@ public:
     TMaybeNode<TExprBase> SoInsert(TExprBase node, TExprContext& ctx, IOptimizationContext& optCtx, const TGetParents& getParents) const {
         const auto insert = node.Cast<TSoInsert>();
         const auto input = insert.Input();
-        const auto maybeDqUnion = input.Maybe<TDqCnUnionAll>();
-        if (!maybeDqUnion) {
-            return node;
-        }
-
-        const auto maybeStage = BuildSinkStage(insert.Pos(), insert.DataSink(), insert.Shard(), input, ctx, getParents);
+        const auto maybeStage = BuildSinkStage(insert.Pos(), insert.DataSink(), insert.Shard(), input, ctx, getParents, /* alowPureStage */ true);
         if (!maybeStage) {
             return node;
         }
 
         const auto newStage = *maybeStage;
-
         YQL_ENSURE(newStage.Outputs());
-        if (const auto outputsCount = newStage.Outputs().Cast().Size(); outputsCount > 1) {
+        const auto outputsCount = newStage.Outputs().Cast().Size();
+        if (outputsCount > 1) {
             YQL_ENSURE(newStage.Program().Body().Maybe<TDqReplicate>(), "Can not push multiple async outputs into stage without TDqReplicate");
+        }
+
+        const auto maybeDqUnion = input.Maybe<TDqCnUnionAll>();
+        if (!maybeDqUnion) {
+            YQL_ENSURE(outputsCount == 1, "Expected only one sink for pure stage");
+            return newStage;
         }
 
         const auto dqUnionOutput = maybeDqUnion.Cast().Output();

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_physical_optimize.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_physical_optimize.cpp
@@ -83,7 +83,7 @@ public:
         return TExprBase(maybeRead.Cast().World().Ptr());
     }
 
-    TMaybe<TDqStage> BuildSinkStage(TPositionHandle writePos, TSoDataSink dataSink, TCoAtom writeShard, TExprBase input, TExprContext& ctx, const TGetParents& getParents, bool alowPureStage) const {
+    TMaybe<TDqStage> BuildSinkStage(TPositionHandle writePos, TSoDataSink dataSink, TCoAtom writeShard, TExprBase input, TExprContext& ctx, const TGetParents& getParents, bool allowPureStage) const {
         const auto* typeAnn = input.Ref().GetTypeAnn();
         const TTypeAnnotationNode* inputItemType = nullptr;
         if (!EnsureNewSeqType<false, true, false>(input.Pos(), *typeAnn, ctx, &inputItemType)) {
@@ -96,7 +96,7 @@ public:
             .DataSink(dataSink)
             .Settings(BuildSolomonShard(writeShard, rowTypeNode, ctx, solomonCluster));
 
-        if (alowPureStage && IsDqPureExpr(input)) {
+        if (allowPureStage && IsDqPureExpr(input)) {
             YQL_CLOG(INFO, ProviderSolomon) << "Optimize insert into solomon (SoWriteToShard / SoInsert), build pure stage with sink";
 
             const auto dqSink = dqSinkBuilder
@@ -155,7 +155,7 @@ public:
         }
 
         const auto write = node.Cast<TSoWriteToShard>();
-        const auto stage = BuildSinkStage(write.Pos(), write.DataSink(), write.Shard(), write.Input(), ctx, getParents, /* alowPureStage */ false);
+        const auto stage = BuildSinkStage(write.Pos(), write.DataSink(), write.Shard(), write.Input(), ctx, getParents, /* allowPureStage */ false);
         if (!stage) {
             return node;
         }
@@ -171,7 +171,7 @@ public:
     TMaybeNode<TExprBase> SoInsert(TExprBase node, TExprContext& ctx, IOptimizationContext& optCtx, const TGetParents& getParents) const {
         const auto insert = node.Cast<TSoInsert>();
         const auto input = insert.Input();
-        const auto maybeStage = BuildSinkStage(insert.Pos(), insert.DataSink(), insert.Shard(), input, ctx, getParents, /* alowPureStage */ true);
+        const auto maybeStage = BuildSinkStage(insert.Pos(), insert.DataSink(), insert.Shard(), input, ctx, getParents, /* allowPureStage */ true);
         if (!maybeStage) {
             return node;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported scalar and precomputes writing into PQ and solomon

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Supported constructions:

```sql
INSERT INTO my_topic SELECT "Data";

INSERT INTO my_topic(Data) VALUES ("Data");

INSERT INTO my_topic
SELECT CAST(COUNT(*) AS String) AS matches -- Precompute
FROM my_table;
```
