### PR TITLE
fix: few quoter bugs

### DIFF
--- a/ydb/core/kesus/tablet/quoter_resource_tree.cpp
+++ b/ydb/core/kesus/tablet/quoter_resource_tree.cpp
@@ -228,6 +228,10 @@ public:
 
     void DeactivateIfFull(TInstant now);
 
+    bool IsEffectivePropsChanged() const override {
+        return EffectivePropsChanged_;
+    }
+
     void SetResourceCounters(TIntrusivePtr<::NMonitoring::TDynamicCounters> resourceCounters) override;
 
     void SetLimitCounter();
@@ -281,6 +285,7 @@ private:
     double BucketSize = 0.0;
 
     bool Active = false;
+    bool EffectivePropsChanged_ = false;
     THierarchicalDRRResourceConsumer* CurrentActiveChild = nullptr;
     size_t ActiveChildrenCount = 0;
     size_t ActiveV1ChildrenCount = 0;
@@ -727,6 +732,8 @@ void THierarchicalDRRQuoterResourceTree::CalcParameters() {
         PrefetchWatermark = parent->PrefetchWatermark;
     }
 
+    const double prevResourceTickQuantum = ResourceTickQuantum;
+
     ResourceTickQuantum = MaxUnitsPerSecond >= 0.0 ? MaxUnitsPerSecond / TICKS_PER_SECOND : 0.0;
     ResourceFillingEpsilon = ResourceTickQuantum * EPSILON_COEFFICIENT;
     TickSize = TDuration::Seconds(1) / TICKS_PER_SECOND;
@@ -745,7 +752,20 @@ void THierarchicalDRRQuoterResourceTree::CalcParameters() {
         parent->ActiveChildrenWeight += weightDiff;
     }
 
-    FreeResource = Min(FreeResource, HasActiveChildren() ? ResourceTickQuantum : GetBurst());
+    // Only clamp FreeResource if limits got tighter
+    const double freeResourceLimit = HasActiveChildren() ? ResourceTickQuantum : GetBurst();
+    if (ResourceTickQuantum < prevResourceTickQuantum || FreeResource > freeResourceLimit) {
+        FreeResource = Min(FreeResource, freeResourceLimit);
+    }
+
+    // Detect effective props changes before updating
+    {
+        const auto& oldEffCfg = EffectiveProps.GetHierarchicalDRRResourceConfig();
+        EffectivePropsChanged_ = (MaxUnitsPerSecond != oldEffCfg.GetMaxUnitsPerSecond() ||
+                                  PrefetchCoefficient != oldEffCfg.GetPrefetchCoefficient() ||
+                                  PrefetchWatermark != oldEffCfg.GetPrefetchWatermark() ||
+                                  Weight != oldEffCfg.GetWeight());
+    }
 
     // Update in props
     auto* effectiveConfig = EffectiveProps.MutableHierarchicalDRRResourceConfig();
@@ -1283,11 +1303,13 @@ const TQuoterSession* TQuoterResources::FindSession(const NActors::TActorId& cli
 }
 
 void TQuoterResources::OnUpdateResourceProps(TQuoterResourceTree* rootResource) {
-    const ui64 resId = rootResource->GetResourceId();
-    for (const auto& [sessionActor, _] : rootResource->GetSessions()) {
-        TQuoterSession* session = FindSession(sessionActor, resId);
-        Y_ABORT_UNLESS(session);
-        session->OnPropsChanged();
+    if (rootResource->IsEffectivePropsChanged()) {
+        const ui64 resId = rootResource->GetResourceId();
+        for (const auto& [sessionActor, _] : rootResource->GetSessions()) {
+            TQuoterSession* session = FindSession(sessionActor, resId);
+            Y_ABORT_UNLESS(session);
+            session->OnPropsChanged();
+        }
     }
     for (TQuoterResourceTree* child : rootResource->GetChildren()) {
         OnUpdateResourceProps(child);

--- a/ydb/core/kesus/tablet/quoter_resource_tree.cpp
+++ b/ydb/core/kesus/tablet/quoter_resource_tree.cpp
@@ -229,7 +229,7 @@ public:
     void DeactivateIfFull(TInstant now);
 
     bool IsEffectivePropsChanged() const override {
-        return EffectivePropsChanged_;
+        return EffectivePropsChanged;
     }
 
     void SetResourceCounters(TIntrusivePtr<::NMonitoring::TDynamicCounters> resourceCounters) override;
@@ -285,7 +285,7 @@ private:
     double BucketSize = 0.0;
 
     bool Active = false;
-    bool EffectivePropsChanged_ = false;
+    bool EffectivePropsChanged = false;
     THierarchicalDRRResourceConsumer* CurrentActiveChild = nullptr;
     size_t ActiveChildrenCount = 0;
     size_t ActiveV1ChildrenCount = 0;
@@ -752,16 +752,14 @@ void THierarchicalDRRQuoterResourceTree::CalcParameters() {
         parent->ActiveChildrenWeight += weightDiff;
     }
 
-    // Only clamp FreeResource if limits got tighter
     const double freeResourceLimit = HasActiveChildren() ? ResourceTickQuantum : GetBurst();
     if (ResourceTickQuantum < prevResourceTickQuantum || FreeResource > freeResourceLimit) {
         FreeResource = Min(FreeResource, freeResourceLimit);
     }
 
-    // Detect effective props changes before updating
     {
         const auto& oldEffCfg = EffectiveProps.GetHierarchicalDRRResourceConfig();
-        EffectivePropsChanged_ = (MaxUnitsPerSecond != oldEffCfg.GetMaxUnitsPerSecond() ||
+        EffectivePropsChanged = (MaxUnitsPerSecond != oldEffCfg.GetMaxUnitsPerSecond() ||
                                   PrefetchCoefficient != oldEffCfg.GetPrefetchCoefficient() ||
                                   PrefetchWatermark != oldEffCfg.GetPrefetchWatermark() ||
                                   Weight != oldEffCfg.GetWeight());

--- a/ydb/core/kesus/tablet/quoter_resource_tree.h
+++ b/ydb/core/kesus/tablet/quoter_resource_tree.h
@@ -263,6 +263,10 @@ public:
         return Children;
     }
 
+    virtual bool IsEffectivePropsChanged() const {
+        return true; // default: assume changed for safety
+    }
+
     virtual void ReportConsumed(double consumed, TTickProcessorQueue& queue, TInstant now) = 0;
 
     // Static children manipulation.

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -162,18 +162,18 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
         {}
 
         void AddUpdate(TEvQuota::TEvProxyUpdate& ev) const {
+            constexpr double rateBurst = 2.0;
+            constexpr ui32 ticks = 2;
+            constexpr double ticksD = static_cast<double>(ticks);
+
             TVector<TEvQuota::TUpdateTick> update;
             double sustainedRate = 0.0;
             if (Available > 0.0) {
-                constexpr double rateBurst = 2.0;
-                constexpr ui32 ticks = 2;
-                constexpr double ticksD = static_cast<double>(ticks);
                 update.emplace_back(0, ticks, Available * (rateBurst / ticksD), TEvQuota::ETickPolicy::Front);
                 sustainedRate = Available * rateBurst;
             } else {
-                // Send zero-rate channel that keeps the channel alive (Ticks > 0)
-                // instead of default TUpdateTick{Ticks=0} which erases the channel
-                update.emplace_back(0, 2, 0.0, TEvQuota::ETickPolicy::Front);
+                // Ticks > 0 keeps the channel alive (Ticks=0 would erase it)
+                update.emplace_back(0, ticks, 0.0, TEvQuota::ETickPolicy::Front);
             }
             ev.Resources.emplace_back(ResId, sustainedRate, std::move(update), TEvQuota::EUpdateState::Normal);
         }
@@ -211,9 +211,8 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
                         SetAvailable(maxAvailable); // Update resource props with smaller quota.
                     }
                 } else if (InitedProps && ResourceBucketMaxSize > prevBucketMaxSize && prevBucketMaxSize > 0) {
-                    // Scale up proportionally on increase to preserve relative fill level
                     const double scale = ResourceBucketMaxSize / prevBucketMaxSize;
-                    SetAvailable(Min(Available * scale, ResourceBucketMaxSize));
+                    SetAvailable(Min(Max(Available, 0.0) * scale, ResourceBucketMaxSize));
                 }
             }
 

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -171,7 +171,9 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
                 update.emplace_back(0, ticks, Available * (rateBurst / ticksD), TEvQuota::ETickPolicy::Front);
                 sustainedRate = Available * rateBurst;
             } else {
-                update.emplace_back();
+                // Send zero-rate channel that keeps the channel alive (Ticks > 0)
+                // instead of default TUpdateTick{Ticks=0} which erases the channel
+                update.emplace_back(0, 2, 0.0, TEvQuota::ETickPolicy::Front);
             }
             ev.Resources.emplace_back(ResId, sustainedRate, std::move(update), TEvQuota::EUpdateState::Normal);
         }
@@ -198,7 +200,7 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
             ResourceBucketMinSize = ResourceBucketMaxSize * watermark;
             Y_ABORT_UNLESS(ResourceBucketMinSize <= ResourceBucketMaxSize);
 
-            // Decrease available resource if speed or prefetch settings have been changed.
+            // Adjust available resource if speed or prefetch settings have been changed.
             if (prefetch > 0.0) { // RTMR-3774
                 if (InitedProps && ResourceBucketMaxSize < prevBucketMaxSize) {
                     if (const double maxAvailable = ResourceBucketMaxSize + QueueWeight; Available > maxAvailable) {
@@ -208,6 +210,10 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
                         }
                         SetAvailable(maxAvailable); // Update resource props with smaller quota.
                     }
+                } else if (InitedProps && ResourceBucketMaxSize > prevBucketMaxSize && prevBucketMaxSize > 0) {
+                    // Scale up proportionally on increase to preserve relative fill level
+                    const double scale = ResourceBucketMaxSize / prevBucketMaxSize;
+                    SetAvailable(Min(Available * scale, ResourceBucketMaxSize));
                 }
             }
 

--- a/ydb/core/quoter/ut_helpers.cpp
+++ b/ydb/core/quoter/ut_helpers.cpp
@@ -377,11 +377,14 @@ bool TKesusProxyTestSetup::ConsumeResource(ui64 resId, double amount, TDuration 
                     UNIT_ASSERT_VALUES_EQUAL(updateTick.Channel, 0);
                     UNIT_ASSERT_VALUES_EQUAL(updateTick.Policy, TEvQuota::ETickPolicy::Front);
                     const bool noAmount = updateTick.Rate <= 0.0;
-                    if (!noAmount) {
-                        UNIT_ASSERT(res.SustainedRate > 0);
-                        UNIT_ASSERT_VALUES_EQUAL(updateTick.Ticks, 2);
-                        UNIT_ASSERT(updateTick.Rate > 0);
+                    if (noAmount) {
+                        // Zero-rate channel (keep-alive with Ticks > 0) — no quota available yet, keep trying
+                        continue;
                     }
+
+                    UNIT_ASSERT(res.SustainedRate > 0);
+                    UNIT_ASSERT_VALUES_EQUAL(updateTick.Ticks, 2);
+                    UNIT_ASSERT(updateTick.Rate > 0);
 
                     const TDuration timeToCharge = amount / updateTick.Rate * tickSize;
                     if (Runtime->GetCurrentTime() - start >= timeToCharge || amount <= updateTick.Rate) {

--- a/ydb/core/quoter/ut_helpers.cpp
+++ b/ydb/core/quoter/ut_helpers.cpp
@@ -376,7 +376,7 @@ bool TKesusProxyTestSetup::ConsumeResource(ui64 resId, double amount, TDuration 
                     const auto& updateTick = res.Update.front();
                     UNIT_ASSERT_VALUES_EQUAL(updateTick.Channel, 0);
                     UNIT_ASSERT_VALUES_EQUAL(updateTick.Policy, TEvQuota::ETickPolicy::Front);
-                    const bool noAmount = updateTick.Rate == 0 && updateTick.Ticks == 0;
+                    const bool noAmount = updateTick.Rate <= 0.0;
                     if (!noAmount) {
                         UNIT_ASSERT(res.SustainedRate > 0);
                         UNIT_ASSERT_VALUES_EQUAL(updateTick.Ticks, 2);


### PR DESCRIPTION
**Kesus side:** FreeResource clamping was unconditional -- every CalcParameters() call destroyed accumulated quota buffer on children, even when their effective speed didn't change. Now clamping only triggers when the resource's speed actually decreased or the buffer exceeds the current limit.

 **Proxy side**: Available was not adjusted on bucket size increase. After a parent speed bump, proxies sat with stale low Available relative to a larger bucket, starving requests until natural catch-up. Now Available scales proportionally with the bucket.


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
