### PR TITLE
Fix workload query oom

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed Out Of Memory issue in the `ydb workload query run` command for queries with large result sets.
 * Improved the `ydb init` and `ydb config profile` commands with interactive menus.
 * Added download progress bar to the `ydb update` command.
 * Improved progress bars: consistent MiB/GiB units, stable speed display, dual progress bar for the `ydb import file` command showing both in-progress and confirmed bytes.

--- a/ydb/public/lib/ydb_cli/commands/benchmark_utils.cpp
+++ b/ydb/public/lib/ydb_cli/commands/benchmark_utils.cpp
@@ -151,7 +151,7 @@ private:
     YDB_ACCESSOR_DEF(TString, ExecStats);
     TQueryBenchmarkResult::TRawResults RawResults;
     // Limit rows stored per result index
-    size_t MaxRowsPerResultIndex = 100;
+    size_t MaxRowsPerResultIndex = DefaultMaxRowsPerResultIndex;
 public:
     void SetMaxRowsPerResultIndex(size_t maxRows) {
         MaxRowsPerResultIndex = maxRows;

--- a/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
+++ b/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
@@ -8,6 +8,9 @@
 
 namespace NYdb::NConsoleClient::BenchmarkUtils {
 
+// Default number of rows to store per result index for output and comparison
+constexpr size_t DefaultMaxRowsPerResultIndex = 100;
+
 struct TTiming {
     TDuration Total = TDuration::Zero(); // timings captured by the client application. these timings include time RTT between server and the client application
     TDuration Server = TDuration::Zero(); // total query timings measured by the server
@@ -105,8 +108,8 @@ struct TQueryBenchmarkSettings {
     NYdb::NRetry::TRetryOperationSettings RetrySettings;
     // Maximum number of rows to store per result index.
     // Used both for CompareWithExpected and for output.
-    // Should be max(100, lines in expected).
-    size_t MaxRowsPerResultIndex = 100;
+    // Should be max(DefaultMaxRowsPerResultIndex, lines in expected).
+    size_t MaxRowsPerResultIndex = DefaultMaxRowsPerResultIndex;
 };
 
 TString FullTablePath(const TString& database, const TString& table);

--- a/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
+++ b/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
@@ -51,10 +51,13 @@ private:
     YDB_READONLY_DEF(TString, ExecStats);
     YDB_READONLY_DEF(TString, DiffErrors);
     YDB_READONLY_DEF(TString, DiffWarrnings);
+    // Pre-computed hash (for streaming mode when full results are not stored)
+    YDB_READONLY_DEF(TString, ResultHash);
     TQueryBenchmarkResult() = default;
 public:
     static TQueryBenchmarkResult Result(TRawResults&& rawResults,
-        const TTiming& timing, const TString& queryPlan, const TString& planAst, const TString& execStats, TStringBuf expected)
+        const TTiming& timing, const TString& queryPlan, const TString& planAst,
+        const TString& execStats, TStringBuf expected, const TString& resultHash = "")
     {
         TQueryBenchmarkResult result;
         result.RawResults = std::move(rawResults);
@@ -62,6 +65,7 @@ public:
         result.QueryPlan = queryPlan;
         result.PlanAst = planAst;
         result.ExecStats = execStats;
+        result.ResultHash = resultHash;
         result.CompareWithExpected(expected);
         return result;
     }
@@ -96,6 +100,11 @@ struct TQueryBenchmarkSettings {
     std::optional<TString> PlanFileName;
     bool WithProgress = false;
     NYdb::NRetry::TRetryOperationSettings RetrySettings;
+    // If true, store all results in memory (needed for CompareWithExpected).
+    // If false, stream results to OutputStream and don't store in memory.
+    bool StoreFullResults = true;
+    // Output stream for streaming results when StoreFullResults is false.
+    IOutputStream* OutputStream = nullptr;
 };
 
 TString FullTablePath(const TString& database, const TString& table);

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
@@ -345,8 +345,8 @@ public:
                     if (Owner.PlanFileName) {
                         settings.PlanFileName = TStringBuilder() << Owner.PlanFileName << "." << QueryName << "." << ToString(Iteration) << ".in_progress";
                     }
-                    // Store max(100, lines in expected) rows per result index
-                    settings.MaxRowsPerResultIndex = std::max<size_t>(StringSplitter(Expected.c_str()).Split('\n').Count(), 100);
+                    // Store max(DefaultMaxRowsPerResultIndex, lines in expected) rows per result index
+                    settings.MaxRowsPerResultIndex = std::max<size_t>(StringSplitter(Expected.c_str()).Split('\n').Count(), BenchmarkUtils::DefaultMaxRowsPerResultIndex);
 
                     Result = Execute(Query, Expected, *Owner.QueryClient, settings);
                 } else {

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
@@ -346,10 +346,7 @@ public:
                         settings.PlanFileName = TStringBuilder() << Owner.PlanFileName << "." << QueryName << "." << ToString(Iteration) << ".in_progress";
                     }
                     // Store max(100, lines in expected) rows per result index
-                    settings.MaxRowsPerResultIndex = std::max(
-                        StringSplitter(Expected.c_str()).Split('\n').Count(),
-                        (size_t)100
-                    );
+                    settings.MaxRowsPerResultIndex = std::max<size_t>(StringSplitter(Expected.c_str()).Split('\n').Count(), 100);
 
                     Result = Execute(Query, Expected, *Owner.QueryClient, settings);
                 } else {
@@ -506,7 +503,7 @@ int TWorkloadCommandBenchmark::RunBench(NYdbWorkload::IWorkloadQueryGenerator& w
                 ++successIteration;
                 if (successIteration == 1) {
                     outFStream << iterExec->GetQueryName() << ": " << Endl;
-                    PrintResult(iterExec->GetResult(), outFStream, iterExec->GetExpected());
+                    PrintResult(iterExec->GetResult(), outFStream);
                 }
                 const auto resHash = iterExec->GetResult().CalcHash();
                 if ((!prevResult || *prevResult != resHash) && iterExec->GetResult().GetDiffErrors()) {
@@ -515,7 +512,7 @@ int TWorkloadCommandBenchmark::RunBench(NYdbWorkload::IWorkloadQueryGenerator& w
                             << iterExec->GetQuery() << Endl << Endl <<
                             "UNEXPECTED DIFF: " << Endl
                             << "RESULT: " << Endl;
-                    PrintResult(iterExec->GetResult(), outFStream, iterExec->GetExpected());
+                    PrintResult(iterExec->GetResult(), outFStream);
                     outFStream << Endl
                             << "EXPECTATION: " << Endl << iterExec->GetExpected() << Endl;
                     prevResult = resHash;
@@ -581,8 +578,7 @@ int TWorkloadCommandBenchmark::RunBench(NYdbWorkload::IWorkloadQueryGenerator& w
     return (queriesWithSomeFails || queriesWithDiff) ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 
-void TWorkloadCommandBenchmark::PrintResult(const BenchmarkUtils::TQueryBenchmarkResult& res, IOutputStream& out, const std::string& expected) const {
-    Y_UNUSED(expected);
+void TWorkloadCommandBenchmark::PrintResult(const BenchmarkUtils::TQueryBenchmarkResult& res, IOutputStream& out) const {
     for (const auto& [i, resultData]: res.GetRawResults()) {
         TResultSetPrinter printer(TResultSetPrinter::TSettings()
             .SetOutput(&out)
@@ -600,7 +596,7 @@ void TWorkloadCommandBenchmark::PrintResult(const BenchmarkUtils::TQueryBenchmar
             out << "And " << (resultData.TotalRowsRead - printedRows) << " more lines, total " << resultData.TotalRowsRead << Endl;
         }
     }
-    out << Endl;
+    out << Endl << Endl;
 }
 
 void TWorkloadCommandBenchmark::SavePlans(const BenchmarkUtils::TQueryBenchmarkResult& res, TStringBuf queryName, const TStringBuf name) const {

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
@@ -25,7 +25,6 @@ private:
     void SavePlans(const BenchmarkUtils::TQueryBenchmarkResult& res, TStringBuf queryName, const TStringBuf name) const;
     void PrintResult(const BenchmarkUtils::TQueryBenchmarkResult& res, IOutputStream& out, const std::string& expected) const;
     BenchmarkUtils::TQueryBenchmarkSettings GetBenchmarkSettings(bool withProgress) const;
-    THolder<IOutputStream> OpenOutputFile(const TString& queryName) const;
 
 private:
     class TIterationExecution;

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
@@ -23,7 +23,7 @@ private:
 
     int RunBench(NYdbWorkload::IWorkloadQueryGenerator& workloadGen);
     void SavePlans(const BenchmarkUtils::TQueryBenchmarkResult& res, TStringBuf queryName, const TStringBuf name) const;
-    void PrintResult(const BenchmarkUtils::TQueryBenchmarkResult& res, IOutputStream& out, const std::string& expected) const;
+    void PrintResult(const BenchmarkUtils::TQueryBenchmarkResult& res, IOutputStream& out) const;
     BenchmarkUtils::TQueryBenchmarkSettings GetBenchmarkSettings(bool withProgress) const;
 
 private:

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
@@ -25,6 +25,7 @@ private:
     void SavePlans(const BenchmarkUtils::TQueryBenchmarkResult& res, TStringBuf queryName, const TStringBuf name) const;
     void PrintResult(const BenchmarkUtils::TQueryBenchmarkResult& res, IOutputStream& out, const std::string& expected) const;
     BenchmarkUtils::TQueryBenchmarkSettings GetBenchmarkSettings(bool withProgress) const;
+    THolder<IOutputStream> OpenOutputFile(const TString& queryName) const;
 
 private:
     class TIterationExecution;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

#### Summary

Fix Out Of Memory issue when running `ydb workload query run` with queries that return large result sets by limiting the number of rows stored in memory per result index.

#### Problem

Previously, all query results were accumulated in memory before being written to the output file. For queries returning millions of rows, this caused OOM.

#### Solution

- Store only the first N rows per result index, where N = max(100, lines in expected)
- Compute result hash incrementally for ALL data (including non-stored rows) to maintain diff detection capability
- Output message "And X more lines, total Y" when not all rows are shown

#### Changes

- Added `TResultData` struct to store result sets along with `TotalRowsRead` counter
- Modified `TQueryResultScanner::Scan` to limit stored rows while still computing hash for all data
- Added `MaxRowsPerResultIndex` parameter to `TQueryBenchmarkSettings`
- Simplified `PrintResult` to output all stored results and show total count

#### Behavior

- **With expected result**: Stores max(100, lines in expected) rows - enough for comparison
- **Without expected result**: Stores ~100 rows for output, computes hash for all data
- Hash comparison between iterations works correctly (computed from all data)
- Output shows "And X more lines, total Y" when result is truncated