### PR TITLE
25-3-1: Fix TSeat::UniqID constructor type mismatch

### DIFF
--- a/ydb/core/tablet_flat/flat_exec_seat.h
+++ b/ydb/core/tablet_flat/flat_exec_seat.h
@@ -26,7 +26,7 @@ namespace NTabletFlatExecutor {
     struct TSeat : public TIntrusiveListItem<TSeat> {
         TSeat(const TSeat&) = delete;
 
-        TSeat(ui32 uniqId, TAutoPtr<ITransaction> self)
+        TSeat(ui64 uniqId, TAutoPtr<ITransaction> self)
             : UniqID(uniqId)
             , Self(self)
             , TxType(Self->GetTxType())
@@ -87,7 +87,7 @@ namespace NTabletFlatExecutor {
         ui32 NotEnoughMemoryCount = 0;
         ui64 TaskId = 0;
 
-        ESeatState State = ESeatState::Done;
+        ESeatState State = ESeatState::None;
         bool LowPriority = false;
         bool Cancelled = false;
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -1962,13 +1962,6 @@ bool TExecutor::CancelTransaction(ui64 id) {
 
     TSeat* seat = it->second.get();
     switch (seat->State) {
-        case ESeatState::None:
-            // Transaction is not paused in any way
-            Y_DEBUG_ABORT_UNLESS(false,
-                "Tablet %" PRIu64 " CancelTransaction(%" PRIu64 ") from inside transaction?",
-                TabletId(), id);
-            return false;
-
         case ESeatState::Active:
             ActivationQueue.Remove(seat);
             Y_ENSURE(ActivateTransactionWaiting > 0);
@@ -1997,9 +1990,7 @@ bool TExecutor::CancelTransaction(ui64 id) {
             return true;
 
         default:
-            Y_DEBUG_ABORT_UNLESS(false,
-                "Tablet %" PRIu64 " CancelTransaction(% " PRIu64 ") for a finished transaction",
-                TabletId(), id);
+            // Transaction is either running right now or it has finished already
             return false;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TSeat constructor historically had `ui32 uniqId` argument in constructor, which didn't match `ui64 UniqID` field. It wasn't a problem while this field was purely informational for logs, but since it is now used as a key in the running transactions hash map it overflows after ~4 billion transactions and causes tablets to restart with an error after a while. Additionally, since we're changing these files anyway, this PR changes `TSeat::State` to the correct default value (it wasn't affecting anything, but was confusing, since currently running transaction shouldn't be in the `Done` state) and removes pedantic assertions in `CancelTransaction`, which didn't really protect against errors and prevented datashard from using it in many more cases.

Fixes #29258.
Merges #33186.
