### PR TITLE
Fix dstool corner cases with partially missing information

### DIFF
--- a/ydb/apps/dstool/lib/bs_layout.py
+++ b/ydb/apps/dstool/lib/bs_layout.py
@@ -3,6 +3,7 @@ from ydb.apps.dstool.lib.common import kikimr_bsconfig
 from operator import itemgetter, attrgetter
 from collections import OrderedDict
 import ydb.core.protos.blobstorage_pb2 as kikimr_bs
+import sys
 
 
 class IdBase(object):
@@ -274,9 +275,14 @@ class BlobStorageLayout(object):
         for group in self.groups.values():
             sp_id = StoragePoolId(group.base.BoxId, group.base.StoragePoolId)
             if sp_id != StoragePoolId(0, 0):
-                sp = self.storage_pools[sp_id]
-                group.storage_pool = sp
-                sp.groups.add(group)
+                # Check if the storage pool exists before accessing it
+                if sp_id in self.storage_pools:
+                    sp = self.storage_pools[sp_id]
+                    group.storage_pool = sp
+                    sp.groups.add(group)
+                else:
+                    # Handle missing storage pool gracefully
+                    print(f"WARNING: Storage pool {sp_id} not found for group {group.base.GroupId}", file=sys.stderr)
 
     def fetch_node_mon_endpoints(self, nodes=None):
         """ Fetch monitoring endpoints for specific nodes (if set) or for all of them. """

--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -64,11 +64,15 @@ class ClusterInfo:
         info.pdisk_usage_w_donors = common.build_pdisk_usage_map(info.base_config, count_donors=True)
 
         info.storage_pool_names_map = common.build_storage_pool_names_map(info.storage_pools)
-        info.group_id_to_storage_pool_name_map = {
-            group_id: info.storage_pool_names_map[(group.BoxId, group.StoragePoolId)]
-            for group_id, group in common.build_group_map(info.base_config).items()
-            if (group.BoxId, group.StoragePoolId) != (0, 0)  # static group
-        }
+        info.group_id_to_storage_pool_name_map = {}
+        for group_id, group in common.build_group_map(info.base_config).items():
+            if (group.BoxId, group.StoragePoolId) == (0, 0):  # static group
+                continue
+            sp_key = (group.BoxId, group.StoragePoolId)
+            if sp_key in info.storage_pool_names_map:
+                info.group_id_to_storage_pool_name_map[group_id] = info.storage_pool_names_map[sp_key]
+            else:
+                info.group_id_to_storage_pool_name_map[group_id] = 'unknown'
 
         info.vdisks_groups_count_map = defaultdict(int)
         for group in info.base_config.Group:

--- a/ydb/apps/dstool/lib/dstool_cmd_group_check.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_group_check.py
@@ -55,9 +55,21 @@ def check_failure_model(args):
     error_reason = ''
     for sp in storage_pools:
         sp_name = sp.Name
-        location_id_map = box_geoms[sp.BoxId, geom_key(sp.Geometry)]
+        geom_key_value = geom_key(sp.Geometry)
+        if (sp.BoxId, geom_key_value) in box_geoms:
+            location_id_map = box_geoms[sp.BoxId, geom_key_value]
+        else:
+            print(f"WARNING: Geometry for box {sp.BoxId} not found", file=sys.stderr)
+            continue
 
-        for group in storage_pool_groups_map[sp.BoxId, sp.StoragePoolId]:
+        sp_key = (sp.BoxId, sp.StoragePoolId)
+        if sp_key in storage_pool_groups_map:
+            groups = storage_pool_groups_map[sp_key]
+        else:
+            print(f"WARNING: No groups found for storage pool {sp_key}", file=sys.stderr)
+            continue
+
+        for group in groups:
             location_map = {}
             vslot_map = {}
             for id_ in group.VSlotId:

--- a/ydb/apps/dstool/lib/dstool_cmd_group_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_group_list.py
@@ -84,7 +84,11 @@ def do(args):
     for group_id, group in group_map.items():
         group_stat = group_stat_map[group_id]
         group_stat['BoxId:PoolId'] = '[%d:%d]' % (group.BoxId, group.StoragePoolId)
-        group_stat['PoolName'] = sp_name[(group.BoxId, group.StoragePoolId)]
+        sp_key = (group.BoxId, group.StoragePoolId)
+        if sp_key in sp_name:
+            group_stat['PoolName'] = sp_name[sp_key]
+        else:
+            group_stat['PoolName'] = 'unknown'
         group_stat['GroupId'] = group.GroupId
         group_stat['Generation'] = group.GroupGeneration
         group_stat['ErasureSpecies'] = group.ErasureSpecies

--- a/ydb/apps/dstool/lib/dstool_cmd_pool_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pool_list.py
@@ -2,6 +2,7 @@ import ydb.core.protos.blobstorage_config_pb2 as kikimr_bsconfig
 import ydb.apps.dstool.lib.common as common
 import ydb.apps.dstool.lib.table as table
 import math
+import sys
 from collections import defaultdict
 
 description = 'List pools'
@@ -140,7 +141,12 @@ def do(args):
 
     group_map = common.build_group_map(base_config)
     for group_id, group in group_map.items():
-        pool = box_pool_map[group.BoxId, group.StoragePoolId]
+        sp_key = (group.BoxId, group.StoragePoolId)
+        if sp_key in box_pool_map:
+            pool = box_pool_map[sp_key]
+        else:
+            print(f"WARNING: Storage pool {sp_key} not found for group {group.GroupId}", file=sys.stderr)
+            continue
 
         if 'groups' not in pool:
             pool['groups'] = defaultdict(int)
@@ -159,7 +165,12 @@ def do(args):
             continue
 
         group = group_map[vslot.GroupId]
-        pool = box_pool_map[group.BoxId, group.StoragePoolId]
+        sp_key = (group.BoxId, group.StoragePoolId)
+        if sp_key in box_pool_map:
+            pool = box_pool_map[sp_key]
+        else:
+            print(f"WARNING: Storage pool {sp_key} not found for group {group.GroupId}", file=sys.stderr)
+            continue
 
         if 'vslots' not in pool:
             pool['vslots'] = defaultdict(int)
@@ -186,7 +197,12 @@ def do(args):
         row['VDiskKind'] = sp.VDiskKind
         row['ItemConfigGeneration'] = sp.ItemConfigGeneration
 
-        pool = box_pool_map[sp.BoxId, sp.StoragePoolId]
+        sp_key = (sp.BoxId, sp.StoragePoolId)
+        if sp_key in box_pool_map:
+            pool = box_pool_map[sp_key]
+        else:
+            print(f"WARNING: Storage pool {sp_key} not found", file=sys.stderr)
+            continue
 
         # fill in groups data
         if 'groups' not in pool:

--- a/ydb/apps/dstool/lib/dstool_cmd_vdisk_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_vdisk_list.py
@@ -26,10 +26,13 @@ def do(args):
         for sp in storage_pools
     }
 
-    group_to_sp_name = {
-        group_id: sp_name[group.BoxId, group.StoragePoolId]
-        for group_id, group in group_map.items()
-    }
+    group_to_sp_name = {}
+    for group_id, group in group_map.items():
+        sp_key = (group.BoxId, group.StoragePoolId)
+        if sp_key in sp_name:
+            group_to_sp_name[group_id] = sp_name[sp_key]
+        else:
+            group_to_sp_name[group_id] = 'unknown'
 
     all_columns = [
         'VDiskId',

--- a/ydb/apps/dstool/lib/dstool_cmd_vdisk_wipe.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_vdisk_wipe.py
@@ -95,7 +95,12 @@ def do(args):
             wiped = group_vslots & set(v[1:] for v in wipe_set)
             if not wiped:
                 continue  # ignore groups we are not going to wipe
-            sp = storage_pools_map[group.BoxId, group.StoragePoolId]
+            sp_key = (group.BoxId, group.StoragePoolId)
+            if sp_key in storage_pools_map:
+                sp = storage_pools_map[sp_key]
+            else:
+                print(f"WARNING: Storage pool {sp_key} not found for group {group.GroupId}", file=sys.stderr)
+                continue
             current = {
                 vslot_coord[v]: vslot_status[v]
                 for v in group_vslots


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required) 

### Description for reviewers <!-- (optional) description for those who read this PR -->

```console
~/ydb/ydb/apps/dstool$ ./dstool --endpoint grpc://myt0-7678.search.yandex.net:2135 pool list
┌──────────────┬──────────────┬────────────────┬──────┬─────────────────────────┬──────────────┬──────────────┐
│ BoxId:PoolId │ PoolName     │ ErasureSpecies │ Kind │ DefaultGroupSizeInUnits │ Groups_TOTAL │ VDisks_TOTAL │
├──────────────┼──────────────┼────────────────┼──────┼─────────────────────────┼──────────────┼──────────────┤
│ [1:1]        │ /dev/NBS:ssd │ block-4-2      │ ssd  │ 0                       │ 20           │ 160          │
└──────────────┴──────────────┴────────────────┴──────┴─────────────────────────┴──────────────┴──────────────┘
```

```console
~/ydb/ydb/apps/dstool$ ./dstool --endpoint grpc://myt0-7678.search.yandex.net:2135 group list
Unexpected Error: (1, 2)
Traceback (most recent call last):
  File "ydb/apps/dstool/main.py", line 33, in main
    commands.run_command(command_map, args)
  File "ydb/apps/dstool/lib/commands.py", line 159, in run_command
    command_map.get(args.global_command)(args)
  File "ydb/apps/dstool/lib/commands.py", line 101, in <lambda>
    command_map[command_group_name] = lambda args: command_map[new_prefix_for_command + getattr(args, command_dest)](args)
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ydb/apps/dstool/lib/dstool_cmd_group_list.py", line 87, in do
    group_stat['PoolName'] = sp_name[(group.BoxId, group.StoragePoolId)]
                             ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: (1, 2)
```

Fixed:

```console
~/ydb/ydb/apps/dstool$ ./dstool --endpoint grpc://myt0-7678.search.yandex.net:2135 group list
┌────────────┬──────────────┬──────────────┬────────────┬────────────────┬─────────────┬─────────────────┬──────────────┐
│ GroupId    │ BoxId:PoolId │ PoolName     │ Generation │ ErasureSpecies │ SizeInUnits │ OperatingStatus │ VDisks_TOTAL │
├────────────┼──────────────┼──────────────┼────────────┼────────────────┼─────────────┼─────────────────┼──────────────┤
│ 2181038080 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038081 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038082 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038083 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038084 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038085 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038086 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038087 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038088 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038089 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038090 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038091 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038092 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038093 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038094 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038095 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038096 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038097 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038098 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038099 │ [1:1]        │ /dev/NBS:ssd │ 1          │ block-4-2      │ 0           │ FULL            │ 8            │
│ 2181038100 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038101 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038102 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038103 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038104 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038105 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038106 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038107 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038108 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
│ 2181038109 │ [1:2]        │ unknown      │ 1          │ none           │ 1           │ DISINTEGRATED   │ 5            │
└────────────┴──────────────┴──────────────┴────────────┴────────────────┴─────────────┴─────────────────┴──────────────┘
```
