### PR TITLE
Add smart mode to CMS

### DIFF
--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -26,6 +26,8 @@ namespace {
             return NKikimrCms::MODE_KEEP_AVAILABLE;
         case Ydb::Maintenance::AVAILABILITY_MODE_FORCE:
             return NKikimrCms::MODE_FORCE_RESTART;
+        case Ydb::Maintenance::AVAILABILITY_MODE_SMART:
+            return NKikimrCms::MODE_SMART_AVAILABILITY;
         default:
             Y_ABORT("unreachable");
         }
@@ -39,6 +41,8 @@ namespace {
             return Ydb::Maintenance::AVAILABILITY_MODE_WEAK;
         case NKikimrCms::MODE_FORCE_RESTART:
             return Ydb::Maintenance::AVAILABILITY_MODE_FORCE;
+        case NKikimrCms::MODE_SMART_AVAILABILITY:
+            return Ydb::Maintenance::AVAILABILITY_MODE_SMART;
         default:
             Y_ABORT("unreachable");
         }

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -523,6 +523,7 @@ class TCreateMaintenanceTask
         case Ydb::Maintenance::AVAILABILITY_MODE_STRONG:
         case Ydb::Maintenance::AVAILABILITY_MODE_WEAK:
         case Ydb::Maintenance::AVAILABILITY_MODE_FORCE:
+        case Ydb::Maintenance::AVAILABILITY_MODE_SMART:
             break;
         default:
             Reply(Ydb::StatusIds::BAD_REQUEST, "Unknown availability mode");

--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -105,7 +105,7 @@ bool TLockableItem::IsDown(TErrorInfo &error, TInstant defaultDeadline) const
 
 void TLockableItem::RollbackLocks(ui64 point)
 {
-    for (auto it = TempLocks.begin(); it != TempLocks.end(); ++it) {
+    for (auto it = TempLocks.begin(); it != TempLocks.end();) {
         if (it->RollbackPoint >= point) {
             RemoveLockByRequest(it->RequestId);
             it = TempLocks.erase(it);

--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -107,6 +107,7 @@ void TLockableItem::RollbackLocks(ui64 point)
 {
     for (auto it = TempLocks.begin(); it != TempLocks.end(); ++it)
         if (it->RollbackPoint >= point) {
+            RemoveLocksByRequest(it->RequestId, 1);
             TempLocks.erase(it, TempLocks.end());
             break;
         }
@@ -124,9 +125,31 @@ void TLockableItem::SetPriorityToCheck(i32 priority)
 
 void TLockableItem::RemoveScheduledLocks(const TString &requestId)
 {
-    ScheduledLocks.remove_if([&requestId](auto &lock) {
-            return lock.RequestId == requestId;
-        });
+    size_t removed = ScheduledLocks.remove_if([&requestId](auto &lock) {
+        return lock.RequestId == requestId;
+    });
+    RemoveLocksByRequest(requestId, removed);
+}
+
+void TLockableItem::AddLockByRequest(const TString &requestId)
+{
+    ++RequestLockCount[requestId];
+}
+
+void TLockableItem::RemoveLocksByRequest(const TString &requestId, size_t count)
+{
+    auto it = RequestLockCount.find(requestId);
+    Y_ABORT_UNLESS(it != RequestLockCount.end() && it->second >= count);
+
+    it->second -= count;
+    if (--it->second == 0) {
+        RequestLockCount.erase(it);
+    }
+}
+
+bool TLockableItem::IsLockedByRequest(const TString &requestId) const
+{
+    return RequestLockCount.contains(requestId);
 }
 
 void TLockableItem::MigrateOldInfo(const TLockableItem &old)
@@ -309,19 +332,26 @@ void TVDiskInfo::MigrateOldInfo(const TLockableItem &old)
 
 TStateStorageRingInfo::RingState TStateStorageRingInfo::CountState(TInstant now,
                                                                    TDuration retryTime,
-                                                                   TDuration duration) const
+                                                                   TDuration duration,
+                                                                   const TString &requestId) const
 {
     if (IsDisabled) {
         return Disabled;
     }
 
-    ui32 unavailableReplicas = 0;
+    bool hasUnavailableReplicas = false;
+    bool hasUnavailableReplicasByThisRequest = false;
     bool hasTimeout = false;
     TErrorInfo error;
     for (auto &node : Replicas) {
         if (node->IsDown(error, now + retryTime)
             || node->IsLocked(error, retryTime, now, duration)) {
-            ++unavailableReplicas;
+            hasUnavailableReplicas = true;
+
+            if (node->IsLockedByRequest(requestId)) {
+                hasUnavailableReplicasByThisRequest = true;
+            }
+
             continue;
         }
 
@@ -330,7 +360,11 @@ TStateStorageRingInfo::RingState TStateStorageRingInfo::CountState(TInstant now,
         }
     }
 
-    if (unavailableReplicas > 0) {
+    if (hasUnavailableReplicasByThisRequest) {
+        return RestartByThisRequest;
+    }
+
+    if (hasUnavailableReplicas) {
         return Restart;
     }
 
@@ -604,22 +638,22 @@ void TClusterInfo::AddNodeTenants(ui32 nodeId, const NKikimrTenantPool::TTenantP
     TenantToNodeId.emplace(nodeTenant, nodeId);
 }
 
-void TClusterInfo::AddNodeTempLock(ui32 nodeId, const NKikimrCms::TAction &action)
+void TClusterInfo::AddNodeTempLock(ui32 nodeId, const NKikimrCms::TAction &action, const TString &requestId)
 {
     auto &node = NodeRef(nodeId);
-    node.TempLocks.push_back({RollbackPoint, action});
+    node.TempLocks.push_back({RollbackPoint, action, requestId});
 }
 
-void TClusterInfo::AddPDiskTempLock(TPDiskID pdiskId, const NKikimrCms::TAction &action)
+void TClusterInfo::AddPDiskTempLock(TPDiskID pdiskId, const NKikimrCms::TAction &action, const TString &requestId)
 {
     auto &pdisk = PDiskRef(pdiskId);
-    pdisk.TempLocks.push_back({RollbackPoint, action});
+    pdisk.TempLocks.push_back({RollbackPoint, action, requestId});
 }
 
-void TClusterInfo::AddVDiskTempLock(TVDiskID vdiskId, const NKikimrCms::TAction &action)
+void TClusterInfo::AddVDiskTempLock(TVDiskID vdiskId, const NKikimrCms::TAction &action, const TString &requestId)
 {
     auto &vdisk = VDiskRef(vdiskId);
-    vdisk.TempLocks.push_back({RollbackPoint, action});
+    vdisk.TempLocks.push_back({RollbackPoint, action, requestId});
 }
 
 static TServices MakeServices(const NKikimrCms::TAction &action) {
@@ -639,11 +673,13 @@ static TServices MakeServices(const NKikimrCms::TAction &action) {
     return services;
 }
 
-void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action, i32 priority)
+void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action, i32 priority, const TString &requestId)
 {
     if (ActionRequiresHost(action) && !HasNode(action.GetHost())) {
         return;
     }
+
+    TNodeLockContext ctx(priority, requestId);
 
     switch (action.GetType()) {
     case TAction::RESTART_SERVICES:
@@ -653,7 +689,7 @@ void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action, i32 
             for (const auto node : nodes) {
                 for (auto &nodeGroup: node->NodeGroups) {
                     if (!nodeGroup->IsNodeLocked(node->NodeId, priority)) {
-                        nodeGroup->LockNode(node->NodeId, priority);
+                        nodeGroup->LockNode(node->NodeId, ctx);
                     }
                 }
             }
@@ -665,14 +701,14 @@ void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action, i32 
                 auto pdisk = &PDiskRef(device);
                 for (auto &nodeGroup: NodeRef(pdisk->NodeId).NodeGroups) {
                     if (!nodeGroup->IsNodeLocked(pdisk->NodeId, priority)) {
-                        nodeGroup->LockNode(pdisk->NodeId, priority);
+                        nodeGroup->LockNode(pdisk->NodeId, ctx);
                     }
                 }
             } else if (HasVDisk(device)) {
                 auto vdisk = &VDiskRef(device);
                 for (auto &nodeGroup: NodeRef(vdisk->NodeId).NodeGroups) {
                     if (!nodeGroup->IsNodeLocked(vdisk->NodeId, priority)) {
-                        nodeGroup->LockNode(vdisk->NodeId, priority);
+                        nodeGroup->LockNode(vdisk->NodeId, ctx);
                     }
                 }
             }
@@ -785,7 +821,7 @@ ui64 TClusterInfo::AddLocks(const TPermissionInfo &permission, const TActorConte
         }
     }
 
-    ApplyActionWithoutLog(permission.Action, permission.Priority);
+    ApplyActionWithoutLog(permission.Action, permission.Priority, permission.RequestId);
 
     return locks;
 }
@@ -795,7 +831,7 @@ ui64 TClusterInfo::AddExternalLocks(const TNotificationInfo &notification, const
     ui64 locks = 0;
     for (const auto &action : notification.Notification.GetActions()) {
         auto items = FindLockedItems(action, ctx);
-        ApplyActionWithoutLog(action, 0);
+        ApplyActionWithoutLog(action, 0, notification.NotificationId);
 
         for (auto item : items) {
             if (ctx)
@@ -851,14 +887,14 @@ void TClusterInfo::UpdateDowntimes(TDowntimes &downtimes, const TActorContext &c
     }
 }
 
-ui64 TClusterInfo::AddTempLocks(const NKikimrCms::TAction &action, i32 priority, const TActorContext *ctx)
+ui64 TClusterInfo::AddTempLocks(const NKikimrCms::TAction &action, i32 priority, const TString &requestId, const TActorContext *ctx)
 {
     auto items = FindLockedItems(action, ctx);
 
-    LogManager.ApplyAction(action, priority, this);
+    LogManager.ApplyAction(action, priority, requestId, this);
 
     for (auto item : items)
-        item->TempLocks.push_back({RollbackPoint, action});
+        item->AddTempLock({RollbackPoint, action, requestId});
 
     return items.size();
 }
@@ -1048,8 +1084,10 @@ void TClusterInfo::DebugDump(const TActorContext &ctx) const
 }
 
 void TOperationLogManager::ApplyAction(const NKikimrCms::TAction &action, i32 priority,
-                                      TClusterInfoPtr clusterState)
+                                       const TString &requestId, TClusterInfoPtr clusterState)
 {
+    TNodeLockContext ctx(priority, requestId);
+    
     switch (action.GetType()) {
     case NKikimrCms::TAction::RESTART_SERVICES:
     case NKikimrCms::TAction::SHUTDOWN_HOST:
@@ -1058,7 +1096,7 @@ void TOperationLogManager::ApplyAction(const NKikimrCms::TAction &action, i32 pr
             for (const auto node : nodes) {
                 for (auto &nodeGroup: node->NodeGroups) {
                     if (!nodeGroup->IsNodeLocked(node->NodeId, priority)) {
-                        AddNodeLockOperation(node->NodeId, priority, nodeGroup);
+                        AddNodeLockOperation(node->NodeId, ctx, nodeGroup);
                     }
                 }
             }
@@ -1070,14 +1108,14 @@ void TOperationLogManager::ApplyAction(const NKikimrCms::TAction &action, i32 pr
                 auto pdisk = &clusterState->PDisk(device);
                 for (auto &nodeGroup: clusterState->NodeRef(pdisk->NodeId).NodeGroups) {
                     if (!nodeGroup->IsNodeLocked(pdisk->NodeId, priority)) {
-                        AddNodeLockOperation(pdisk->NodeId, priority, nodeGroup);
+                        AddNodeLockOperation(pdisk->NodeId, ctx, nodeGroup);
                     }
                 }
             } else if (clusterState->HasVDisk(device)) {
                 auto vdisk = &clusterState->VDisk(device);
                 for (auto &nodeGroup: clusterState->NodeRef(vdisk->NodeId).NodeGroups) {
                     if (!nodeGroup->IsNodeLocked(vdisk->NodeId, priority)) {
-                        AddNodeLockOperation(vdisk->NodeId, priority, nodeGroup);
+                        AddNodeLockOperation(vdisk->NodeId, ctx, nodeGroup);
                     }
                 }
             }

--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -665,7 +665,7 @@ void TClusterInfo::ApplyActionWithoutLog(const NKikimrCms::TAction &action, i32 
         return;
     }
 
-    TNodeLockContext ctx(priority, requestId);
+    TNodeLockContext ctx(priority, requestId, NKikimrCms::MODE_MAX_AVAILABILITY);
 
     switch (action.GetType()) {
     case TAction::RESTART_SERVICES:

--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -227,9 +227,10 @@ public:
     };
 
     struct TTemporaryLock : TBaseLock {
-        TTemporaryLock(ui64 point, const NKikimrCms::TAction &action)
+        TTemporaryLock(ui64 point, const NKikimrCms::TAction &action, const TString &requestId)
             : TBaseLock("", action)
             , RollbackPoint(point)
+            , RequestId(requestId)
         {
         }
 
@@ -240,6 +241,7 @@ public:
         TTemporaryLock &operator=(TTemporaryLock &&other) = default;
 
         ui64 RollbackPoint;
+        TString RequestId;
     };
 
     TLockableItem() = default;
@@ -259,6 +261,7 @@ public:
 
     void AddLock(const TPermissionInfo &permission) {
         AddPriorityLock(Locks, TLock(permission));
+        AddLockByRequest(permission.RequestId);
     }
 
     void AddExternalLock(const TNotificationInfo &notification,
@@ -269,13 +272,20 @@ public:
                 return l.LockStart < r.LockStart;
             });
         ExternalLocks.insert(pos, std::move(lock));
+        AddLockByRequest(notification.NotificationId);
     }
 
     void ScheduleLock(TScheduledLock &&lock) {
         auto pos = LowerBound(ScheduledLocks.begin(), ScheduledLocks.end(), lock, [](auto &l, auto &r) {
             return l.Priority < r.Priority;
         });
-        ScheduledLocks.insert(pos, lock);
+        ScheduledLocks.insert(pos, std::move(lock));
+        AddLockByRequest(lock.RequestId);
+    }
+
+    void AddTempLock(TTemporaryLock &&lock) {
+        TempLocks.push_back(std::move(lock));
+        AddLockByRequest(lock.RequestId);
     }
 
     bool IsLocked(TErrorInfo &error, TDuration defaultRetryTime, TInstant no, TDuration durationw) const;
@@ -288,6 +298,10 @@ public:
 
     void RemoveScheduledLocks(const TString &requestId);
 
+    void AddLockByRequest(const TString &requestId);
+    void RemoveLocksByRequest(const TString &requestId, size_t count);
+    bool IsLockedByRequest(const TString &requestId) const;
+
     // Fill some item info (e.g. Downtime) basing on previous item state.
     virtual void MigrateOldInfo(const TLockableItem &old);
 
@@ -297,6 +311,9 @@ public:
     NKikimrCms::EState State = NKikimrCms::UNKNOWN;
     // Recent item downtimes.
     TDowntime Downtime = TDowntime(TDuration::Zero());
+
+    // Counts all locks hold by requests
+    THashMap<TString, size_t> RequestLockCount;
 
     std::list<TLock> Locks;
     std::list<TExternalLock> ExternalLocks;
@@ -503,13 +520,17 @@ public:
      *
      * Restart:     has some restarting or down nodes. We can still restart
      *              nodes from this ring;
+     *
+     * RestartByThisRequest: same as Restart, but provide additional info.
     */
+
     enum RingState : ui8 {
         Unknown = 0,
         Ok,
         Locked,
         Disabled,
         Restart,
+        RestartByThisRequest,
     };
 
     TStateStorageRingInfo() = default;
@@ -533,6 +554,9 @@ public:
             case Restart:
                 return "Restart";
                 break;
+            case RestartByThisRequest:
+                return "Restart by this request";
+                break;
             default:
                 return "Unknown ring state";
                 break;
@@ -547,7 +571,7 @@ public:
         IsDisabled = true;
     }
 
-    RingState CountState(TInstant now, TDuration retryTime, TDuration duration) const;
+    RingState CountState(TInstant now, TDuration retryTime, TDuration duration, const TString &requestId) const;
 
     ui32 RingId = 0;
     bool IsDisabled = false;
@@ -583,16 +607,16 @@ public:
 class TLockNodeOperation : public TOperationBase {
 public:
     const ui32 NodeId;
-    const i32 Priority;
+    const TNodeLockContext LockContext;
 
 private:
     TSimpleSharedPtr<INodesChecker> NodesState;
 
 public:
-    TLockNodeOperation(ui32 nodeId, i32 priority, TSimpleSharedPtr<INodesChecker> nodesState)
+    TLockNodeOperation(ui32 nodeId, const TNodeLockContext& ctx, TSimpleSharedPtr<INodesChecker> nodesState)
         : TOperationBase(OPERATION_TYPE_LOCK_NODE)
         , NodeId(nodeId)
-        , Priority(priority)
+        , LockContext(ctx)
         , NodesState(nodesState)
     {
     }
@@ -600,11 +624,11 @@ public:
     ~TLockNodeOperation() = default;
 
     void Do() override final {
-        NodesState->LockNode(NodeId, Priority);
+        NodesState->LockNode(NodeId, LockContext);
     }
 
     void Undo() override final {
-        NodesState->UnlockNode(NodeId, Priority);
+        NodesState->UnlockNode(NodeId, LockContext);
     }
 };
 
@@ -632,8 +656,8 @@ public:
         Log.emplace_back(new TLogRollbackPoint());
     }
 
-    void AddNodeLockOperation(ui32 nodeId, i32 priority, TSimpleSharedPtr<INodesChecker> nodesState) {
-        Log.emplace_back(new TLockNodeOperation(nodeId, priority, nodesState))->Do();
+    void AddNodeLockOperation(ui32 nodeId, const TNodeLockContext& ctx, TSimpleSharedPtr<INodesChecker> nodesState) {
+        Log.emplace_back(new TLockNodeOperation(nodeId, ctx, nodesState))->Do();
     }
 
     void RollbackOperations() {
@@ -647,7 +671,7 @@ public:
         }
     }
 
-    void ApplyAction(const NKikimrCms::TAction &action, i32 priority, TClusterInfoPtr clusterState);
+    void ApplyAction(const NKikimrCms::TAction &action, i32 priority, const TString &requestId, TClusterInfoPtr clusterState);
 };
 
 /**
@@ -679,7 +703,7 @@ public:
     TOperationLogManager LogManager;
     TOperationLogManager ScheduledLogManager;
 
-    void ApplyActionWithoutLog(const NKikimrCms::TAction &action, i32 priority);
+    void ApplyActionWithoutLog(const NKikimrCms::TAction &action, i32 priority, const TString &requestId);
     void ApplyNodeLimits(ui32 clusterLimit, ui32 clusterRatioLimit, ui32 tenantLimit, ui32 tenantRatioLimit);
 
     TClusterInfo() = default;
@@ -901,9 +925,9 @@ public:
     void AddBSGroup(const NKikimrBlobStorage::TBaseConfig::TGroup &info);
     void AddNodeTenants(ui32 nodeId, const NKikimrTenantPool::TTenantPoolStatus &info);
 
-    void AddNodeTempLock(ui32 nodeId, const NKikimrCms::TAction &action);
-    void AddPDiskTempLock(TPDiskID pdiskId, const NKikimrCms::TAction &action);
-    void AddVDiskTempLock(TVDiskID vdiskId, const NKikimrCms::TAction &action);
+    void AddNodeTempLock(ui32 nodeId, const NKikimrCms::TAction &action, const TString &requestId);
+    void AddPDiskTempLock(TPDiskID pdiskId, const NKikimrCms::TAction &action, const TString &requestId);
+    void AddVDiskTempLock(TVDiskID vdiskId, const NKikimrCms::TAction &action, const TString &requestId);
 
     ui64 AddLocks(const TPermissionInfo &permission, const TActorContext *ctx);
 
@@ -923,7 +947,7 @@ public:
     void ApplyDowntimes(const TDowntimes &downtimes);
     void UpdateDowntimes(TDowntimes &downtimes, const TActorContext &ctx);
 
-    ui64 AddTempLocks(const NKikimrCms::TAction &action, i32 priority, const TActorContext *ctx);
+    ui64 AddTempLocks(const NKikimrCms::TAction &action, i32 priority, const TString &requestId, const TActorContext *ctx);
     ui64 ScheduleActions(const TRequestInfo &request, const TActorContext *ctx);
     void UnscheduleActions(const TString &requestId);
 

--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -260,8 +260,8 @@ public:
     }
 
     void AddLock(const TPermissionInfo &permission) {
-        AddPriorityLock(Locks, TLock(permission));
         AddLockByRequest(permission.RequestId);
+        AddPriorityLock(Locks, TLock(permission));
     }
 
     void AddExternalLock(const TNotificationInfo &notification,
@@ -279,13 +279,13 @@ public:
         auto pos = LowerBound(ScheduledLocks.begin(), ScheduledLocks.end(), lock, [](auto &l, auto &r) {
             return l.Priority < r.Priority;
         });
-        ScheduledLocks.insert(pos, std::move(lock));
         AddLockByRequest(lock.RequestId);
+        ScheduledLocks.insert(pos, std::move(lock));
     }
 
     void AddTempLock(TTemporaryLock &&lock) {
-        TempLocks.push_back(std::move(lock));
         AddLockByRequest(lock.RequestId);
+        TempLocks.push_back(std::move(lock));
     }
 
     bool IsLocked(TErrorInfo &error, TDuration defaultRetryTime, TInstant no, TDuration durationw) const;

--- a/ydb/core/cms/cluster_info_ut.cpp
+++ b/ydb/core/cms/cluster_info_ut.cpp
@@ -387,7 +387,7 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
 
         auto point1 = cluster->PushRollbackPoint();
         auto action1 = MakeAction(TAction::SHUTDOWN_HOST, 3, 60000000);
-        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action1, 0, nullptr), 1);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action1, 0, "", nullptr), 1);
         UNIT_ASSERT_VALUES_EQUAL(cluster->Node(3).TempLocks.size(), 1);
 
         cluster->RollbackLocks(point1);
@@ -403,7 +403,7 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
         UNIT_ASSERT_VALUES_EQUAL(cluster->AddLocks(permission, nullptr), 2);
         UNIT_ASSERT(!cluster->PDisk(NCms::TPDiskID(1, 1)).Locks.empty());
         UNIT_ASSERT(!cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).Locks.empty());
-        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action2, 0, nullptr), 2);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action2, 0, "", nullptr), 2);
         UNIT_ASSERT_VALUES_EQUAL(cluster->PDisk(NCms::TPDiskID(1, 1)).TempLocks.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).TempLocks.size(), 1);
         cluster->RollbackLocks(point2);

--- a/ydb/core/cms/cluster_info_ut.cpp
+++ b/ydb/core/cms/cluster_info_ut.cpp
@@ -361,6 +361,7 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
         permission.Owner = "user";
         permission.Action = MakeAction(TAction::SHUTDOWN_HOST, "test1", 60000000);
         permission.Deadline = now - TDuration::Seconds(61);
+        permission.RequestId = "1";
         UNIT_ASSERT_VALUES_EQUAL(cluster->AddLocks(permission, nullptr), 0);
 
         permission.Action.SetHost("test2");
@@ -387,7 +388,7 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
 
         auto point1 = cluster->PushRollbackPoint();
         auto action1 = MakeAction(TAction::SHUTDOWN_HOST, 3, 60000000);
-        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action1, 0, "", nullptr), 1);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action1, 0, "request", nullptr), 1);
         UNIT_ASSERT_VALUES_EQUAL(cluster->Node(3).TempLocks.size(), 1);
 
         cluster->RollbackLocks(point1);
@@ -403,7 +404,7 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
         UNIT_ASSERT_VALUES_EQUAL(cluster->AddLocks(permission, nullptr), 2);
         UNIT_ASSERT(!cluster->PDisk(NCms::TPDiskID(1, 1)).Locks.empty());
         UNIT_ASSERT(!cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).Locks.empty());
-        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action2, 0, "", nullptr), 2);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->AddTempLocks(action2, 0, "request", nullptr), 2);
         UNIT_ASSERT_VALUES_EQUAL(cluster->PDisk(NCms::TPDiskID(1, 1)).TempLocks.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(cluster->VDisk(TVDiskID(0, 1, 0, 1, 0)).TempLocks.size(), 1);
         cluster->RollbackLocks(point2);

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -321,6 +321,7 @@ namespace {
 bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
                                   TPermissionResponse &response,
                                   TPermissionRequest &scheduled,
+                                  const TString &requestId,
                                   const TActorContext &ctx)
 {
     static THashMap<EStatusCode, ui32> CodesRate = BuildCodesRateMap({
@@ -368,6 +369,14 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
     case MODE_KEEP_AVAILABLE:
     case MODE_FORCE_RESTART:
         break;
+    case MODE_SMART_AVAILABILITY:
+        if (!AppData(ctx)->FeatureFlags.GetEnableCmsSmartAvailabilityMode()) {
+            response.MutableStatus()->SetCode(TStatus::WRONG_REQUEST);
+            response.MutableStatus()->SetReason("Smart availability mode is not enabled. "
+                                                "Enable feature flag EnableCmsSmartAvailabilityMode");
+            return false;
+        }
+        break;
     default:
         response.MutableStatus()->SetCode(TStatus::WRONG_REQUEST);
         response.MutableStatus()
@@ -391,6 +400,7 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
         opts.AvailabilityMode = request.GetAvailabilityMode();
         opts.PartialPermissionAllowed = allowPartial;
         opts.Priority = request.GetPriority();
+        opts.RequestId = requestId;
 
         TErrorInfo error;
 
@@ -410,7 +420,7 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
             permission->SetDeadline(error.Deadline.GetValue());
             AddPermissionExtensions(action, *permission);
 
-            ClusterInfo->AddTempLocks(action, request.GetPriority(), &ctx);
+            ClusterInfo->AddTempLocks(action, request.GetPriority(), requestId, &ctx);
         } else {
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Result: %s (reason: %s)",
                       ToString(error.Code).data(), error.Reason.GetMessage().data());
@@ -749,6 +759,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
     const ui32 nToSelect = ClusterInfo->StateStorageInfo->RingGroups[ringGroupId].NToSelect;
     const ui32 currentRing = ClusterInfo->GetRingId(node.NodeId);
     ui8 currentRingState = TStateStorageRingInfo::Unknown;
+    bool hasRestartRingsByThisRequest = false;
     ui32 restartRings = 0;
     ui32 lockedRings = 0;
     ui32 disabledRings = 0;
@@ -758,6 +769,11 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
         auto state = ringInfo->CountState(now, State->Config.DefaultRetryTime, duration);
         LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS, "Ring: " << ringInfo->RingId
                                                                  << "; State: " << TStateStorageRingInfo::RingStateToString(state));
+        
+        if (state == TStateStorageRingInfo::RestartByThisRequest) {
+            hasRestartRingsByThisRequest = true;
+            state = TStateStorageRingInfo::Restart;
+        }
 
         if (ringInfo->RingId == currentRing) {
             if (state == TStateStorageRingInfo::Disabled) {
@@ -787,9 +803,15 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
     // Add current ring to restart rings
     ++restartRings;
 
+    const ui32 maxAvailabilityLimit = 1;
+    const ui32 keepAvailableLimit = (nToSelect - 1) / 2;
+
+    const bool maxAvailabilityOk = restartRings + lockedRings <= maxAvailabilityLimit;
+    const bool keepAvailableOk = restartRings + lockedRings + disabledRings <= keepAvailableLimit;
+
     switch (opts.AvailabilityMode) {
         case MODE_MAX_AVAILABILITY:
-            if (restartRings + lockedRings > 1) {
+            if (!maxAvailabilityOk) {
                 error.Code = TStatus::DISALLOW_TEMP;
                 error.Reason = TReason(
                     TStringBuilder() << "Too many unavailable state storage rings"
@@ -797,7 +819,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
                     << (currentRingState == TStateStorageRingInfo::Restart ? restartRings : restartRings - 1)
                     << ". Temporary (for a 2 minutes) locked rings: "
                     << (currentRingState == TStateStorageRingInfo::Locked ? lockedRings + 1 : lockedRings)
-                    << ". Maximum allowed number of unavailable rings for this mode: " << 1,
+                    << ". Maximum allowed number of unavailable rings for this mode: " << maxAvailabilityLimit,
                     TReason::EType::TooManyUnavailableStateStorageRings
                 );
                 error.Deadline = defaultDeadline;
@@ -805,7 +827,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
             }
             break;
         case MODE_KEEP_AVAILABLE:
-            if (restartRings + lockedRings + disabledRings > (nToSelect - 1) / 2) {
+            if (!keepAvailableOk) {
                 error.Code = TStatus::DISALLOW_TEMP;
                 error.Reason = TReason(
                     TStringBuilder() << "Too many unavailable state storage rings"
@@ -814,7 +836,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
                     << ". Temporary (for a 2 minutes) locked rings: "
                     << (currentRingState == TStateStorageRingInfo::Locked ? lockedRings + 1 : lockedRings)
                     << ". Disabled rings: " << disabledRings
-                    << ". Maximum allowed number of unavailable rings for this mode: " << (nToSelect - 1) / 2,
+                    << ". Maximum allowed number of unavailable rings for this mode: " << keepAvailableLimit,
                     TReason::EType::TooManyUnavailableStateStorageRings
                 );
                 error.Deadline = defaultDeadline;
@@ -823,6 +845,32 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
             break;
         case MODE_FORCE_RESTART:
             break;
+        case MODE_SMART_AVAILABILITY: {
+            ui32 limit = maxAvailabilityLimit;
+            if (maxAvailabilityOk) {
+                break;
+            }
+            
+            if (!hasRestartRingsByThisRequest) {
+                limit = keepAvailableLimit;
+                if (keepAvailableOk) {
+                    break;
+                }
+            }
+
+            error.Code = TStatus::DISALLOW_TEMP;
+            error.Reason = TReason(
+                TStringBuilder() << "Too many unavailable state storage rings"
+                << ". Restarting rings: "
+                << (currentRingState == TStateStorageRingInfo::Restart ? restartRings : restartRings - 1)
+                << ". Temporary (for a 2 minutes) locked rings: "
+                << (currentRingState == TStateStorageRingInfo::Locked ? lockedRings + 1 : lockedRings)
+                << ". Maximum allowed number of unavailable rings for this mode: " << limit,
+                TReason::EType::TooManyUnavailableStateStorageRings
+            );
+            error.Deadline = defaultDeadline;
+            return false;
+        }
         default:
             error.Code = TStatus::WRONG_REQUEST;
             error.Reason = Sprintf("Unknown availability mode: %s (%" PRIu32 ")",
@@ -844,7 +892,8 @@ bool TCms::CheckSysTabletsNode(const TActionOptions &opts,
     }
 
     for (auto &tabletType : ClusterInfo->NodeToTabletTypes[node.NodeId]) {
-        if (!ClusterInfo->SysNodesCheckers[node.PileId.GetOrElse(0)][tabletType]->TryToLockNode(node.NodeId, opts.AvailabilityMode, opts.Priority, error.Reason)) {
+        TNodeLockContext lockCtx(opts.Priority, opts.RequestId, opts.AvailabilityMode);
+        if (!ClusterInfo->SysNodesCheckers[node.PileId.GetOrElse(0)][tabletType]->TryToLockNode(node.NodeId, lockCtx, error.Reason)) {
             error.Code = TStatus::DISALLOW_TEMP;
             error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;
             return false;
@@ -862,7 +911,8 @@ bool TCms::TryToLockNode(const TAction& action,
     TDuration duration = TDuration::MicroSeconds(action.GetDuration());
     duration += opts.PermissionDuration;
 
-    if (!ClusterInfo->ClusterNodes[node.PileId.GetOrElse(0)]->TryToLockNode(node.NodeId, opts.AvailabilityMode, opts.Priority, error.Reason)) {
+    TNodeLockContext lockCtx(opts.Priority, opts.RequestId, opts.AvailabilityMode);
+    if (!ClusterInfo->ClusterNodes[node.PileId.GetOrElse(0)]->TryToLockNode(node.NodeId, lockCtx, error.Reason)) {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;
         return false;
@@ -870,7 +920,7 @@ bool TCms::TryToLockNode(const TAction& action,
 
     if (node.Tenant
         && opts.TenantPolicy != NONE
-        && !ClusterInfo->TenantNodesChecker[node.PileId.GetOrElse(0)][node.Tenant]->TryToLockNode(node.NodeId, opts.AvailabilityMode, opts.Priority, error.Reason))
+        && !ClusterInfo->TenantNodesChecker[node.PileId.GetOrElse(0)][node.Tenant]->TryToLockNode(node.NodeId, lockCtx, error.Reason))
     {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;
@@ -911,7 +961,7 @@ bool TCms::TryToLockVDisks(const TAction &action,
     for (const auto &vdId : vdisks) {
         const auto &vdisk = ClusterInfo->VDisk(vdId);
         if (TryToLockVDisk(opts, vdisk, duration, error)) {
-            ClusterInfo->AddVDiskTempLock(vdId, action);
+            ClusterInfo->AddVDiskTempLock(vdId, action, opts.RequestId);
         } else {
             res = false;
             break;
@@ -960,7 +1010,7 @@ bool TCms::TryToLockVDisk(const TActionOptions& opts,
         }
 
         auto counters = CreateErasureCounter(ClusterInfo->BSGroup(groupId).Erasure.GetErasure(), vdisk, groupId, TabletCounters);
-        counters->CountGroupState(ClusterInfo, State->Config.DefaultRetryTime, duration, error);
+        counters->CountGroupState(ClusterInfo, State->Config.DefaultRetryTime, duration, error, opts.RequestId);
 
         switch (opts.AvailabilityMode) {
         case MODE_MAX_AVAILABILITY:
@@ -975,6 +1025,11 @@ bool TCms::TryToLockVDisk(const TActionOptions& opts,
             break;
         case MODE_FORCE_RESTART:
             // Any number of down disks is OK for this mode.
+            break;
+        case MODE_SMART_AVAILABILITY:
+            if (!counters->CheckForSmartAvailability(ClusterInfo, error, defaultDeadline, opts.PartialPermissionAllowed)) {
+                return false;
+            }
             break;
         default:
             error.Code = TStatus::WRONG_REQUEST;
@@ -1002,7 +1057,7 @@ bool TCms::CheckActionReplaceDevices(const TAction &action,
         if (ClusterInfo->HasPDisk(device)) {
             const auto &pdisk = ClusterInfo->PDisk(device);
             if (TryToLockPDisk(action, opts, pdisk, error))
-                ClusterInfo->AddPDiskTempLock(pdisk.PDiskId, action);
+                ClusterInfo->AddPDiskTempLock(pdisk.PDiskId, action, opts.RequestId);
             else {
                 res = false;
                 break;
@@ -1010,7 +1065,7 @@ bool TCms::CheckActionReplaceDevices(const TAction &action,
         } else if (ClusterInfo->HasPDisk(action.GetHost(), device)) {
             const auto &pdisk = ClusterInfo->PDisk(action.GetHost(), device);
             if (TryToLockPDisk(action, opts, pdisk, error))
-                ClusterInfo->AddPDiskTempLock(pdisk.PDiskId, action);
+                ClusterInfo->AddPDiskTempLock(pdisk.PDiskId, action, opts.RequestId);
             else {
                 res = false;
                 break;
@@ -1018,7 +1073,7 @@ bool TCms::CheckActionReplaceDevices(const TAction &action,
         } else if (ClusterInfo->HasVDisk(device)) {
             const auto &vdisk = ClusterInfo->VDisk(device);
             if (TryToLockVDisk(opts, vdisk, duration, error))
-                ClusterInfo->AddVDiskTempLock(vdisk.VDiskId, action);
+                ClusterInfo->AddVDiskTempLock(vdisk.VDiskId, action, opts.RequestId);
             else {
                 res = false;
                 break;
@@ -2097,15 +2152,19 @@ void TCms::Handle(TEvCms::TEvPermissionRequest::TPtr &ev,
 
     ClusterInfo->LogManager.PushRollbackPoint();
     const i32 priority = rec.GetPriority();
-    for (const auto &[_, scheduledRequest] : State->ScheduledRequests) {
+    for (const auto &[id, scheduledRequest] : State->ScheduledRequests) {
         if (scheduledRequest.Priority < priority) {
             for (const auto &action : scheduledRequest.Request.GetActions()) {
-                ClusterInfo->LogManager.ApplyAction(action, scheduledRequest.Priority, ClusterInfo);
+                ClusterInfo->LogManager.ApplyAction(action, scheduledRequest.Priority, id, ClusterInfo);
             }
         }
     }
+
+    TString user = rec.GetUser();
+    auto reqId = user + "-r-" + ToString(State->NextRequestId + 1);
+
     ClusterInfo->SetPriorityToCheck(priority);
-    bool ok = CheckPermissionRequest(rec, resp->Record, scheduled.Request, ctx);
+    bool ok = CheckPermissionRequest(rec, resp->Record, scheduled.Request, reqId, ctx);
     ClusterInfo->ResetPriorityToCheck();
     ClusterInfo->LogManager.RollbackOperations();
 
@@ -2113,8 +2172,7 @@ void TCms::Handle(TEvCms::TEvPermissionRequest::TPtr &ev,
     if (rec.GetDryRun()) {
         Reply(ev, std::move(resp), ctx);
     } else {
-        TString user = rec.GetUser();
-        auto reqId = user + "-r-" + ToString(State->NextRequestId++);
+        State->NextRequestId++;
         resp->Record.SetRequestId(reqId);
 
         TAutoPtr<TRequestInfo> copy;
@@ -2178,13 +2236,13 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
     for (const auto &scheduled_request : State->ScheduledRequests) {
         if (scheduled_request.second.Priority < request.Priority) {
             for (const auto &action : scheduled_request.second.Request.GetActions())
-                ClusterInfo->LogManager.ApplyAction(action, scheduled_request.second.Priority, ClusterInfo);
+                ClusterInfo->LogManager.ApplyAction(action, scheduled_request.second.Priority, scheduled_request.first, ClusterInfo);
         }
     }
 
     ClusterInfo->SetPriorityToCheck(request.Priority);
     request.Request.SetAvailabilityMode(rec.GetAvailabilityMode());
-    bool ok = CheckPermissionRequest(request.Request, resp->Record, scheduled.Request, ctx);
+    bool ok = CheckPermissionRequest(request.Request, resp->Record, scheduled.Request, rec.GetRequestId(), ctx);
     ClusterInfo->ResetPriorityToCheck();
     ClusterInfo->LogManager.RollbackOperations();
 

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -114,6 +114,7 @@ private:
         NKikimrCms::EAvailabilityMode AvailabilityMode;
         bool PartialPermissionAllowed;
         i32 Priority;
+        TString RequestId;
 
         TActionOptions(TDuration dur)
             : PermissionDuration(dur)
@@ -309,6 +310,7 @@ private:
     bool CheckPermissionRequest(const NKikimrCms::TPermissionRequest &request,
         NKikimrCms::TPermissionResponse &response,
         NKikimrCms::TPermissionRequest &scheduled,
+        const TString &requestId,
         const TActorContext &ctx);
     bool IsActionHostValid(const NKikimrCms::TAction &action, TErrorInfo &error) const;
     bool ParseServices(const NKikimrCms::TAction &action, TServices &services, TErrorInfo &error) const;

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -148,7 +148,8 @@ private:
     ITransaction *CreateTxRemoveWalleTask(const TString &id);
     ITransaction *CreateTxRemoveMaintenanceTask(const TString &id);
     ITransaction *CreateTxStorePermissions(THolder<IEventBase> req, TAutoPtr<IEventHandle> resp,
-                                           const TString &owner, TAutoPtr<TRequestInfo> scheduled,
+                                           const TString &owner, const TString &requestId, i32 priority,
+                                           TAutoPtr<TRequestInfo> scheduled,
                                            const TMaybe<TString> &maintenanceTaskId = {});
     ITransaction *CreateTxStoreWalleTask(const TTaskInfo &task, THolder<IEventBase> req, TAutoPtr<IEventHandle> resp);
     ITransaction *CreateTxUpdateConfig(TEvCms::TEvSetConfigRequest::TPtr &ev);

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -2889,6 +2889,171 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         env.CheckDonePermission("user", r3.GetPermissions(0).GetId());
         env.CheckListPermissions("user", 0);
     }
+
+    Y_UNIT_TEST(TestSmartAvailabilityModeFeatureFlagDisabled)
+    {
+        // Test that Smart mode is rejected when feature flag is disabled
+        TCmsTestEnv env(8);
+
+        // Smart mode should be rejected with WRONG_REQUEST
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::WRONG_REQUEST,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000));
+    }
+
+    Y_UNIT_TEST(TestSmartAvailabilityModeZeroPriorLocksFallsBackToWeak)
+    {
+        // Test: with zero prior locks, Smart mode should fallback to Weak mode when Strong denies
+        // Setup: 8 nodes with block-4-2 erasure (8 VDisks per group, can lose 2)
+        // In Strong mode (MODE_MAX_AVAILABILITY): only 1 VDisk can be locked per group
+        // In Weak mode (MODE_KEEP_AVAILABLE): up to 2 VDisks can be locked per group
+        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCmsSmartAvailabilityMode());
+        env.AdvanceCurrentTime(TDuration::Minutes(3));
+
+        // Lock first node - should succeed in both Strong and Smart mode
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000));
+
+        // Lock second node - Strong mode would deny (only 1 allowed), but Smart mode
+        // with zero prior locks should fallback to Weak mode and allow (up to 2)
+        // Note: this is a new request, so it has zero locks initially
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(1), 60000000));
+
+        // Verify that Strong mode would have denied the second request
+        env.CheckPermissionRequest("user", false, true, false,
+                                   true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(2), 60000000));
+
+        // Third node should be denied in Smart mode too (Weak mode limit of 2 reached)
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(2), 60000000));
+    }
+
+    Y_UNIT_TEST(TestSmartAvailabilityModeWithExistingLocksStaysStrong)
+    {
+        // Test: when a request already holds locks, Smart mode should stay in Strong mode
+        // Setup: Use scheduled request with multiple actions in a fresh environment
+        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCmsSmartAvailabilityMode());
+        env.AdvanceCurrentTime(TDuration::Minutes(3));
+
+        // Create a scheduled request with partial permissions for multiple nodes
+        // In Smart mode with zero locks, the first action should use Strong mode.
+        // If Strong allows, it proceeds. If Strong denies and zero locks, fallback to Weak.
+        // Once a lock is granted, subsequent actions in the same request stay in Strong mode.
+        auto res1 = env.ExtractPermissions(
+            env.CheckPermissionRequest("user", true, false, true,
+                                       true, MODE_SMART_AVAILABILITY, TStatus::ALLOW_PARTIAL,
+                                       MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000),
+                                       MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(1), 60000000),
+                                       MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(2), 60000000)));
+
+        // First action should get a permission (allowed in Strong mode since it's the first lock)
+        UNIT_ASSERT_VALUES_EQUAL(res1.second.size(), 1);
+
+        // Now the request has a lock. When checking the next action,
+        // Smart mode should stay in Strong mode. Since only 1 VDisk allowed per group in Strong mode,
+        // the second action should be denied.
+        env.CheckRequest("user", res1.first, false, MODE_SMART_AVAILABILITY, TStatus::DISALLOW_TEMP, 0);
+
+        // Complete the first permission
+        env.CheckDonePermission("user", res1.second[0]);
+
+        // Now the request has zero locks again (the permission is completed).
+        // The next action should be allowed with fallback to Weak mode.
+        // But once the first action (node 1) is granted, the request has a lock again
+        // and must stay in Strong mode - so the second action (node 2) will be denied.
+        // Result: ALLOW_PARTIAL with 1 permission.
+        env.CheckRequest("user", res1.first, false, MODE_SMART_AVAILABILITY, TStatus::ALLOW_PARTIAL, 1);
+    }
+
+    Y_UNIT_TEST(TestSmartAvailabilityModeForStateStorage)
+    {
+        // Test Smart mode for state storage rings
+        // Setup: Multiple rings, verify correct ring lock counting
+        TCmsTestEnv env(TTestEnvOpts(8, 1, {}).WithEnableCmsSmartAvailabilityMode());
+        env.AdvanceCurrentTime(TDuration::Minutes(3));
+        env.EnableSysNodeChecking();
+
+        // In Strong mode (MODE_MAX_AVAILABILITY) for state storage: only 1 ring can be locked
+        // In Weak mode (MODE_KEEP_AVAILABLE): up to (nToSelect - 1) / 2 rings can be locked
+
+        // First request - should be allowed in Strong mode
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000));
+
+        // Second request for a different node - Smart mode should try Strong first,
+        // fail, then fallback to Weak mode (if zero locks)
+        // The behavior depends on the ring configuration
+        auto result = env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(1), 60000000));
+
+        // Verify that the request was processed (either allowed or denied based on ring config)
+        // The key point is that Smart mode doesn't crash and handles state storage correctly
+    }
+
+    Y_UNIT_TEST(TestSmartAvailabilityModeForSystemTablets)
+    {
+        // Test Smart mode for system tablets node checking
+        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCmsSmartAvailabilityMode());
+        env.AdvanceCurrentTime(TDuration::Minutes(3));
+        env.EnableSysNodeChecking();
+
+        // Lock first node - should succeed
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000));
+
+        // Lock second node - Smart mode should fallback to Weak mode and allow
+        // (since this is a new request with zero locks)
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(1), 60000000));
+
+        // Third node should be denied - Weak mode limit of 2 VDisks per group is reached
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(2), 60000000));
+    }
+
+    Y_UNIT_TEST(TestSmartAvailabilityModeCompareWithStrongAndWeak)
+    {
+        // Test that Smart mode behaves correctly compared to Strong and Weak modes
+        // This test verifies the fallback logic by comparing results
+        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCmsSmartAvailabilityMode());
+        env.AdvanceCurrentTime(TDuration::Minutes(3));
+
+        // First, lock one node
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000));
+
+        // Check that Strong mode would deny the second node
+        env.CheckPermissionRequest("user", false, true, false,
+                                   true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(1), 60000000));
+
+        // Check that Weak mode would allow the second node
+        env.CheckPermissionRequest("user", false, true, false,
+                                   true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(1), 60000000));
+
+        // Smart mode with a NEW request (zero locks) should also allow the second node
+        // because it falls back to Weak mode
+        env.CheckPermissionRequest("user", false, false, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(1), 60000000));
+
+        // Now try a third node - should be denied in all modes
+        env.CheckPermissionRequest("user", false, true, false,
+                                   true, MODE_SMART_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(2), 60000000));
+    }
 }
 
 }

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -603,6 +603,7 @@ static void SetupServices(TTestBasicRuntime &runtime, const TTestEnvOpts &option
     appConfig.MutableFeatureFlags()->SetEnableCMSRequestPriorities(options.EnableCMSRequestPriorities);
     appConfig.MutableFeatureFlags()->SetEnableSingleCompositeActionGroup(options.EnableSingleCompositeActionGroup);
     appConfig.MutableFeatureFlags()->SetEnableCmsLocksPriority(options.EnableCmsLocksPriority);
+    appConfig.MutableFeatureFlags()->SetEnableCmsSmartAvailabilityMode(options.EnableCmsSmartAvailabilityMode);
     runtime.AddLocalService(
         MakeConfigsDispatcherID(
             runtime.GetNodeId(0)),
@@ -626,6 +627,7 @@ static void SetupServices(TTestBasicRuntime &runtime, const TTestEnvOpts &option
     runtime.GetAppData().DisableCheckingSysNodesCms = true;
     runtime.GetAppData().BootstrapConfig = TFakeNodeWhiteboardService::BootstrapConfig;
     runtime.GetAppData().FeatureFlags.SetEnableCmsLocksPriority(options.EnableCmsLocksPriority);
+    runtime.GetAppData().FeatureFlags.SetEnableCmsSmartAvailabilityMode(options.EnableCmsSmartAvailabilityMode);
 
     if (options.IsBridgeMode) {
         for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -97,6 +97,7 @@ struct TTestEnvOpts {
     bool IsBridgeMode;
     bool EnableSimpleStateStorageConfig;
     bool EnableCmsLocksPriority;
+    bool EnableCmsSmartAvailabilityMode;
 
     using TNodeLocationCallback = std::function<TNodeLocation(ui32)>;
     TNodeLocationCallback NodeLocationCallback;
@@ -124,6 +125,7 @@ struct TTestEnvOpts {
         , IsBridgeMode(false)
         , EnableSimpleStateStorageConfig(false)
         , EnableCmsLocksPriority(false)
+        , EnableCmsSmartAvailabilityMode(false)
     {
     }
 
@@ -144,6 +146,11 @@ struct TTestEnvOpts {
 
     TTestEnvOpts& WithEnableCmsLocksPriority() {
         EnableCmsLocksPriority = true;
+        return *this;
+    }
+
+    TTestEnvOpts& WithEnableCmsSmartAvailabilityMode() {
+        EnableCmsSmartAvailabilityMode = true;
         return *this;
     }
 

--- a/ydb/core/cms/downtime_ut.cpp
+++ b/ydb/core/cms/downtime_ut.cpp
@@ -107,6 +107,7 @@ Y_UNIT_TEST_SUITE(TDowntimeTest) {
         permission1.Action = action1;
         permission1.PermissionId = "permission-1";
         permission1.Deadline = t9;
+        permission1.RequestId = "request-1";
         pdisk.AddLock(permission1);
         TNotificationInfo notification1;
         notification1.NotificationId = "notification-1";
@@ -133,6 +134,7 @@ Y_UNIT_TEST_SUITE(TDowntimeTest) {
         permission2.Action = action1;
         permission2.PermissionId = "permission-2";
         permission2.Deadline = t2;
+        permission2.RequestId = "request-2";
         pdisk.AddLock(permission2);
         downtime2.Clear();
         downtime2.AddDowntime(pdisk, t3);

--- a/ydb/core/cms/erasure_checkers.cpp
+++ b/ydb/core/cms/erasure_checkers.cpp
@@ -58,14 +58,6 @@ bool TErasureCounterBase::IsLocked(const TVDiskInfo &vdisk, TClusterInfoPtr info
         || vdisk.IsLockedByRequest(requestId);
 }
 
-bool TErasureCounterBase::GroupAlreadyHasTempLockedDisks() const {
-    return HasAlreadyTempLockedDisks;
-}
-
-bool TErasureCounterBase::GroupHasMoreThanOneDiskPerNode() const {
-    return HasMoreThanOneDiskPerNode;
-}
-
 static TString DumpVDisksInfo(const THashMap<TVDiskID, TString>& vdisks, TClusterInfoPtr info) {
     if (vdisks.empty()) {
         return "<empty>";

--- a/ydb/core/cms/erasure_checkers.cpp
+++ b/ydb/core/cms/erasure_checkers.cpp
@@ -42,8 +42,24 @@ bool TErasureCounterBase::IsLocked(const TVDiskInfo &vdisk, TClusterInfoPtr info
         || vdisk.IsLocked(error, retryTime, TActivationContext::Now(), duration);
 }
 
-bool TErasureCounterBase::GroupAlreadyHasLockedDisks() const {
-    return HasAlreadyLockedDisks;
+ bool TErasureCounterBase::IsLockedByRequest(const TVDiskInfo& vdisk, TClusterInfoPtr info,
+        const TString &requestId)
+{
+    const auto &node = info->Node(vdisk.NodeId);
+    const auto &pdisk = info->PDisk(vdisk.PDiskId);
+
+    // Check we received info for VDisk.
+    if (!vdisk.NodeId || !vdisk.PDiskId) {
+        return false;
+    }
+
+    return node.IsLockedByRequest(requestId)
+        || pdisk.IsLockedByRequest(requestId)
+        || vdisk.IsLockedByRequest(requestId);
+}
+
+bool TErasureCounterBase::GroupAlreadyHasTempLockedDisks() const {
+    return HasAlreadyTempLockedDisks;
 }
 
 bool TErasureCounterBase::GroupHasMoreThanOneDiskPerNode() const {
@@ -76,7 +92,7 @@ static TString DumpVDisksInfo(const THashMap<TVDiskID, TString>& vdisks, TCluste
 
 bool TErasureCounterBase::CheckForMaxAvailability(TClusterInfoPtr info, TErrorInfo &error, TInstant &defaultDeadline, bool allowPartial) const {
     if (Locked.size() + Down.size() > 1) {
-        if (HasAlreadyLockedDisks && !allowPartial) {
+        if (HasAlreadyTempLockedDisks && !allowPartial) {
             error.Code = TStatus::DISALLOW;
             error.Reason = "The request is incorrect: too many disks from the one group. "
                            "Fix the request or set PartialPermissionAllowed to true";
@@ -98,8 +114,22 @@ bool TErasureCounterBase::CheckForMaxAvailability(TClusterInfoPtr info, TErrorIn
     return true;
 }
 
+bool TErasureCounterBase::CheckForSmartAvailability(TClusterInfoPtr info, TErrorInfo &error, TInstant &defaultDeadline, bool allowPartial) const {
+    if (CheckForMaxAvailability(info, error, defaultDeadline, allowPartial)) {
+        return true;
+    }
+
+    if (!HasAlreadyLockedDisks) {
+        if (CheckForKeepAvailability(info, error, defaultDeadline, allowPartial)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool TErasureCounterBase::CountVDisk(const TVDiskInfo &vdisk, TClusterInfoPtr info, TDuration retryTime,
-        TDuration duration, TErrorInfo &error)
+        TDuration duration, TErrorInfo &error, const TString &requestId)
 {
     Y_DEBUG_ABORT_UNLESS(vdisk.VDiskId != VDisk.VDiskId);
 
@@ -111,6 +141,10 @@ bool TErasureCounterBase::CountVDisk(const TVDiskInfo &vdisk, TClusterInfoPtr in
         error.Reason = TStringBuilder() << "Issue in affected group with id '" << GroupId << "'"
             << ": " << err.Reason;
         error.Deadline = Max(error.Deadline, err.Deadline);
+
+        if (IsLockedByRequest(vdisk, info, requestId)) {
+            HasAlreadyLockedDisks = true;
+        }
         return true;
     }
 
@@ -127,21 +161,24 @@ bool TErasureCounterBase::CountVDisk(const TVDiskInfo &vdisk, TClusterInfoPtr in
     return false;
 }
 
-void TErasureCounterBase::CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo &error) {
+void TErasureCounterBase::CountGroupState(TClusterInfoPtr info, TDuration retryTime,
+        TDuration duration, TErrorInfo &error, const TString &requestId)
+{
     const auto& group = info->BSGroup(GroupId);
 
     TSet<ui32> groupNodes;
     for (const auto &vdId : group.VDisks) {
         const auto &vd = info->VDisk(vdId);
         if (vd.VDiskId != VDisk.VDiskId)
-            CountVDisk(vd, info, retryTime, duration, error);
+            CountVDisk(vd, info, retryTime, duration, error, requestId);
         groupNodes.insert(vd.NodeId);
     }
 
     HasMoreThanOneDiskPerNode = group.VDisks.size() > groupNodes.size();
 
+    // Check if vdisks in group are locked by temp lock
     if (Locked && error.Code == TStatus::DISALLOW) {
-        HasAlreadyLockedDisks = true;
+        HasAlreadyTempLockedDisks = true;
     }
 
     Locked.emplace(VDisk.VDiskId, TStringBuilder() << VDisk.PrettyItemName() << " is locked by this request");
@@ -150,7 +187,7 @@ void TErasureCounterBase::CountGroupState(TClusterInfoPtr info, TDuration retryT
 bool TDefaultErasureCounter::CheckForKeepAvailability(TClusterInfoPtr info, TErrorInfo &error,
         TInstant &defaultDeadline, bool allowPartial) const
 {
-    if (HasAlreadyLockedDisks && !HasMoreThanOneDiskPerNode && allowPartial) {
+    if (HasAlreadyTempLockedDisks && !HasMoreThanOneDiskPerNode && allowPartial) {
         CmsCounters->Cumulative()[COUNTER_PARTIAL_PERMISSIONS_OPTIMIZED].Increment(1);
         error.Code = TStatus::DISALLOW_TEMP;
         error.Reason = "You cannot get two or more disks from the same group at the same time"
@@ -160,7 +197,7 @@ bool TDefaultErasureCounter::CheckForKeepAvailability(TClusterInfoPtr info, TErr
     }
 
     if (Down.size() + Locked.size() > info->BSGroup(GroupId).Erasure.ParityParts()) {
-        if (HasAlreadyLockedDisks && !allowPartial) {
+        if (HasAlreadyTempLockedDisks && !allowPartial) {
             error.Code = TStatus::DISALLOW;
             error.Reason = "The request is incorrect: too many disks from the one group. "
                            "Fix the request or set PartialPermissionAllowed to true";
@@ -185,7 +222,7 @@ bool TDefaultErasureCounter::CheckForKeepAvailability(TClusterInfoPtr info, TErr
 bool TMirror3dcCounter::CheckForKeepAvailability(TClusterInfoPtr info, TErrorInfo &error,
         TInstant &defaultDeadline, bool allowPartial) const
 {
-    if (HasAlreadyLockedDisks && !HasMoreThanOneDiskPerNode && allowPartial) {
+    if (HasAlreadyTempLockedDisks && !HasMoreThanOneDiskPerNode && allowPartial) {
         CmsCounters->Cumulative()[COUNTER_PARTIAL_PERMISSIONS_OPTIMIZED].Increment(1);
         error.Code = TStatus::DISALLOW_TEMP;
         error.Reason = "You cannot get two or more disks from the same group at the same time"
@@ -204,7 +241,7 @@ bool TMirror3dcCounter::CheckForKeepAvailability(TClusterInfoPtr info, TErrorInf
         return true;
     }
 
-    if (HasAlreadyLockedDisks && !allowPartial) {
+    if (HasAlreadyTempLockedDisks && !allowPartial) {
         error.Code = TStatus::DISALLOW;
         error.Reason = "The request is incorrect: too many disks from the one group. "
                        "Fix the request or set PartialPermissionAllowed to true";
@@ -239,17 +276,19 @@ bool TMirror3dcCounter::CheckForKeepAvailability(TClusterInfoPtr info, TErrorInf
 }
 
 bool TMirror3dcCounter::CountVDisk(const TVDiskInfo &vdisk, TClusterInfoPtr info, TDuration retryTime,
-        TDuration duration, TErrorInfo &error)
+        TDuration duration, TErrorInfo &error, const TString &requestId)
 {
-    const bool disabled = TErasureCounterBase::CountVDisk(vdisk, info, retryTime, duration, error);
+    const bool disabled = TErasureCounterBase::CountVDisk(vdisk, info, retryTime, duration, error, requestId);
     if (disabled) {
         ++DataCenterDisabledNodes[vdisk.VDiskId.FailRealm];
     }
     return disabled;
 }
 
-void TMirror3dcCounter::CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo &error) {
-    TErasureCounterBase::CountGroupState(info, retryTime, duration, error);
+void TMirror3dcCounter::CountGroupState(TClusterInfoPtr info,
+        TDuration retryTime, TDuration duration, TErrorInfo &error, const TString &requestId)
+{
+    TErasureCounterBase::CountGroupState(info, retryTime, duration, error, requestId);
     ++DataCenterDisabledNodes[VDisk.VDiskId.FailRealm];
 }
 

--- a/ydb/core/cms/erasure_checkers.h
+++ b/ydb/core/cms/erasure_checkers.h
@@ -20,8 +20,6 @@ protected:
 public:
     virtual ~IErasureCounter() = default;
 
-    virtual bool GroupAlreadyHasTempLockedDisks() const = 0;
-    virtual bool GroupHasMoreThanOneDiskPerNode() const = 0;
     virtual bool CheckForMaxAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const = 0;
     virtual bool CheckForKeepAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const = 0;
     virtual bool CheckForSmartAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const = 0;
@@ -59,8 +57,6 @@ public:
     {
     }
 
-    bool GroupAlreadyHasTempLockedDisks() const final;
-    bool GroupHasMoreThanOneDiskPerNode() const final;
     bool CheckForMaxAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const final;
     bool CheckForSmartAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const final;
     void CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo &error, const TString &requestId) override;

--- a/ydb/core/cms/erasure_checkers.h
+++ b/ydb/core/cms/erasure_checkers.h
@@ -14,16 +14,18 @@ using namespace NKikimrCms;
 
 class IErasureCounter {
 protected:
-    virtual bool CountVDisk(const TVDiskInfo& vdisk, TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo& error) = 0;
+    virtual bool CountVDisk(const TVDiskInfo& vdisk, TClusterInfoPtr info, TDuration retryTime,
+                            TDuration duration, TErrorInfo& error, const TString &requestId) = 0;
 
 public:
     virtual ~IErasureCounter() = default;
 
-    virtual bool GroupAlreadyHasLockedDisks() const = 0;
+    virtual bool GroupAlreadyHasTempLockedDisks() const = 0;
     virtual bool GroupHasMoreThanOneDiskPerNode() const = 0;
     virtual bool CheckForMaxAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const = 0;
     virtual bool CheckForKeepAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const = 0;
-    virtual void CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo& error) = 0;
+    virtual bool CheckForSmartAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const = 0;
+    virtual void CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo& error, const TString &requestId) = 0;
 };
 
 class TErasureCounterBase: public IErasureCounter {
@@ -33,6 +35,7 @@ protected:
     THashMap<TVDiskID, TString> Locked;
     const TVDiskInfo& VDisk;
     const ui32 GroupId;
+    bool HasAlreadyTempLockedDisks;
     bool HasAlreadyLockedDisks;
     bool HasMoreThanOneDiskPerNode;
 
@@ -41,22 +44,26 @@ protected:
 protected:
     bool IsDown(const TVDiskInfo& vdisk, TClusterInfoPtr info, TDuration& retryTime, TErrorInfo& error);
     bool IsLocked(const TVDiskInfo& vdisk, TClusterInfoPtr info, TDuration& retryTime, TDuration& duration, TErrorInfo& error);
-    bool CountVDisk(const TVDiskInfo& vdisk, TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo& error) override;
+    bool IsLockedByRequest(const TVDiskInfo& vdisk, TClusterInfoPtr info, const TString &requestId);
+    bool CountVDisk(const TVDiskInfo& vdisk, TClusterInfoPtr info, TDuration retryTime,
+                    TDuration duration, TErrorInfo& error, const TString &requestId) override;
 
 public:
     TErasureCounterBase(const TVDiskInfo& vdisk, ui32 groupId, TTabletCountersBase* cmsCounters)
         : VDisk(vdisk)
         , GroupId(groupId)
+        , HasAlreadyTempLockedDisks(false)
         , HasAlreadyLockedDisks(false)
         , HasMoreThanOneDiskPerNode(false)
         , CmsCounters(cmsCounters)
     {
     }
 
-    bool GroupAlreadyHasLockedDisks() const final;
+    bool GroupAlreadyHasTempLockedDisks() const final;
     bool GroupHasMoreThanOneDiskPerNode() const final;
     bool CheckForMaxAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const final;
-    void CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo &error) override;
+    bool CheckForSmartAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const final;
+    void CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo &error, const TString &requestId) override;
 };
 
 class TDefaultErasureCounter: public TErasureCounterBase {
@@ -73,7 +80,8 @@ class TMirror3dcCounter: public TErasureCounterBase {
     THashMap<ui8, ui32> DataCenterDisabledNodes;
 
 protected:
-    bool CountVDisk(const TVDiskInfo& vdisk, TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo& error) override;
+    bool CountVDisk(const TVDiskInfo& vdisk, TClusterInfoPtr info, TDuration retryTime,
+                    TDuration duration, TErrorInfo& error, const TString &requestId) override;
 
 public:
     TMirror3dcCounter(const TVDiskInfo& vdisk, ui32 groupId, TTabletCountersBase* cmsCounters)
@@ -82,7 +90,7 @@ public:
     }
 
     bool CheckForKeepAvailability(TClusterInfoPtr info, TErrorInfo& error, TInstant& defaultDeadline, bool allowPartial) const override;
-    void CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo &error) override;
+    void CountGroupState(TClusterInfoPtr info, TDuration retryTime, TDuration duration, TErrorInfo &error, const TString &requestId) override;
 };
 
 TSimpleSharedPtr<IErasureCounter> CreateErasureCounter(TErasureType::EErasureSpecies es,

--- a/ydb/core/cms/node_checkers.cpp
+++ b/ydb/core/cms/node_checkers.cpp
@@ -90,7 +90,7 @@ void TNodesCounterBase::UnlockNode(ui32 nodeId, const TNodeLockContext& ctx) {
     RemovePriorityLocks(node.Locks, ctx.Priority);
 
     auto it = RequestLockCount.find(ctx.RequestId);
-    Y_ABORT_UNLESS(it != RequestLockCount.end());
+    Y_ABORT_UNLESS(it != RequestLockCount.end() && it->second >= 1);
     if (--it->second == 0) {
         RequestLockCount.erase(it);
     }

--- a/ydb/core/cms/node_checkers.h
+++ b/ydb/core/cms/node_checkers.h
@@ -17,12 +17,7 @@ struct TNodeLockContext {
     TString RequestId;
     NKikimrCms::EAvailabilityMode Mode = NKikimrCms::MODE_MAX_AVAILABILITY;
 
-    TNodeLockContext(i32 priority, const TString& requestId = "",
-                     NKikimrCms::EAvailabilityMode mode = NKikimrCms::MODE_MAX_AVAILABILITY)
-        : Priority(priority)
-        , RequestId(requestId)
-        , Mode(mode)
-    {}
+    TNodeLockContext(i32 priority, const TString& requestId, NKikimrCms::EAvailabilityMode mode);
 };
 
 /**
@@ -75,7 +70,6 @@ protected:
     THashMap<ui32, TNodeInfo> Nodes;
     ui32 LockedNodesCount;
     ui32 DownNodesCount;
-    THashMap<TString, size_t> RequestLockCount;
 
 public:
     TNodesCounterBase()
@@ -167,6 +161,7 @@ public:
 class TSysTabletsNodesCounter : public TNodesCounterBase {
 private:
     const NKikimrConfig::TBootstrap::ETabletType TabletType;
+    THashMap<TString, size_t> LockedByRequests;
 
 public:
     explicit TSysTabletsNodesCounter(NKikimrConfig::TBootstrap::ETabletType tabletType)
@@ -174,6 +169,8 @@ public:
     {
     }
 
+    void LockNode(ui32 nodeId, const TNodeLockContext& ctx) override;
+    void UnlockNode(ui32 nodeId, const TNodeLockContext& ctx) override;
     bool TryToLockNode(ui32 nodeId, const TNodeLockContext& ctx, TReason& reason) const override final;
 };
 

--- a/ydb/core/cms/node_checkers.h
+++ b/ydb/core/cms/node_checkers.h
@@ -17,7 +17,7 @@ struct TNodeLockContext {
     TString RequestId;
     NKikimrCms::EAvailabilityMode Mode = NKikimrCms::MODE_MAX_AVAILABILITY;
 
-    TNodeLockContext(i32 priority, const TString& requestId, NKikimrCms::EAvailabilityMode mode);
+    TNodeLockContext(i32 priority, const TString& requestId, NKikimrCms::EAvailabilityMode mode = NKikimrCms::MODE_MAX_AVAILABILITY);
 };
 
 /**

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -164,7 +164,7 @@ enum EAvailabilityMode {
     MODE_FORCE_RESTART = 2;
     // Behaves like MODE_MAX_AVAILABILITY but automatically
     // falls back to MODE_KEEP_AVAILABLE when it is not possible
-    // to restart nodes in group using MODE_MAX_AVAILABILITY.
+    // to restart nodes using MODE_MAX_AVAILABILITY.
     MODE_SMART_AVAILABILITY = 3;
 }
 

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -159,14 +159,13 @@ enum EAvailabilityMode {
     // of parity parts in that group.
     // Compute nodes are handled as in default mode.
     MODE_KEEP_AVAILABLE = 1;
-    // In this mode CMS allows at most 1 locked disk in a group
-    // ignoring its parity parts count. Allows to restart nodes
-    // even if multiple disks of some group are down. Using
-    // this mode might cause data unavailability.
-    // For compute nodes CMS follows tenant and cluster policies
-    // but allows to restart at least one node for tenant or
-    // cluster.
+    // This mode ignores all cluster availability checks.
+    // Using this mode might cause data unavailability.
     MODE_FORCE_RESTART = 2;
+    // Behaves like MODE_MAX_AVAILABILITY but automatically
+    // falls back to MODE_KEEP_AVAILABLE when it is not possible
+    // to restart nodes in group using MODE_MAX_AVAILABILITY.
+    MODE_SMART_AVAILABILITY = 3;
 }
 
 message TPermissionRequest {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -252,4 +252,5 @@ message TFeatureFlags {
     optional bool EnableTruncateTable = 225 [default = false];
     optional bool EnableTopicsSqlIoOperations = 226 [default = false];
     optional bool EnableSysViewPermissionsExport = 227 [default = false];
+    optional bool EnableCmsSmartAvailabilityMode = 228 [default = false];
 }

--- a/ydb/public/api/protos/draft/ydb_maintenance.proto
+++ b/ydb/public/api/protos/draft/ydb_maintenance.proto
@@ -80,6 +80,12 @@ enum AvailabilityMode {
     // Ignore any storage group & state storage checks.
     // Using this mode might cause data unavailability.
     AVAILABILITY_MODE_FORCE = 3;
+
+    // In this mode:
+    // - attempts to apply AVAILABILITY_MODE_STRONG;
+    // - if strong constraints cannot be satisfied, falls back to AVAILABILITY_MODE_WEAK;
+    // - never escalates to AVAILABILITY_MODE_FORCE.
+    AVAILABILITY_MODE_SMART = 4;
 }
 
 message MaintenanceTaskOptions {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add smart availability mode to CMS that behaves like strong, but fall backs to weak when necessary.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

This pull request adds a new "smart" availability mode to the Cluster Management System (CMS) that provides intelligent fallback behavior for maintenance operations. The smart mode attempts to apply strict availability constraints (MODE_MAX_AVAILABILITY) first, but automatically falls back to relaxed constraints (MODE_KEEP_AVAILABLE) when the strict constraints cannot be satisfied by requests that haven't already locked resources.

**Changes:**
- Added AVAILABILITY_MODE_SMART enum to public maintenance API and internal CMS protos
- Implemented smart mode logic for VDisks (storage groups), system tablets, and state storage replicas
- Added feature flag EnableCmsSmartAvailabilityMode to control the availability of this mode
- Added request ID tracking to lockable items to enable smart fallback decisions
