### PR TITLE
Fix the build failure caused by the FormatPDisk() refactoring

### DIFF
--- a/ydb/core/base/ut/state_storage_follower_ids_ut.cpp
+++ b/ydb/core/base/ut/state_storage_follower_ids_ut.cpp
@@ -145,9 +145,6 @@ void SetupRuntimeAndHive(TTestBasicRuntime& runtime) {
 
             nodeWardenConfig->SectorMaps[pDiskPath] = sectorMap;
 
-            TFormatOptions formatOptions;
-            formatOptions.SectorMap = sectorMap;
-            formatOptions.EnableSmallDiskOptimization = false;
             FormatPDisk(
                 pDiskPath,
                 pDiskSize,
@@ -159,7 +156,10 @@ void SetupRuntimeAndHive(TTestBasicRuntime& runtime) {
                 0x7890123456,
                 NPDisk::YdbDefaultPDiskSequence,
                 TString(""),
-                formatOptions
+                {
+                    .SectorMap = sectorMap,
+                    .EnableSmallDiskOptimization = false,
+                }
             );
         }
 


### PR DESCRIPTION
### Changelog entry

Fix the build caused by the `FormatPDisk()` refactoring ([PR-32604](https://github.com/ydb-platform/ydb/pull/32604)).

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Updated the `TStateStorageFollowerIDsTest` test to use the new `FormatPDisk()` signature.