### PR TITLE
Fix validated write TxId mismatch between initial and restored data

### DIFF
--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -588,7 +588,7 @@ ERestoreDataStatus TWriteOperation::RestoreTxData(TDataShard* self, NTable::TDat
 
     bool extractKeys = WriteTx->IsTxInfoLoaded();
 
-    WriteTx = std::make_shared<TValidatedWriteTx>(self, GetTxId(), GetReceivedAt(), *WriteRequest, IsMvccSnapshotRead());
+    WriteTx = std::make_shared<TValidatedWriteTx>(self, GetGlobalTxId(), GetReceivedAt(), *WriteRequest, IsMvccSnapshotRead());
     if (WriteTx->Ready() && extractKeys) {
         WriteTx->ExtractKeys(db.GetScheme(), true);
     }

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -326,7 +326,7 @@ public:
         }
 
         NMiniKQL::TEngineHostCounters engineHostCounters;
-        const ui64 txId = writeTx->GetTxId();
+        const ui64 txId = op->GetTxId();
         const auto mvccVersion = DataShard.GetMvccVersion(writeOp);
 
         TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), mvccVersion, engineHostCounters, TAppData::TimeProvider->Now());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

As it turned out, the incorrect TxId didn't really affect anything, and mostly looked confusing with my private debug-info patches. Partially it's because of a copy-paste errors in the initial implementation. Nevertheless, it's better to fix and make it consistent, as well as use the correct non-zero txId in the local variable.

Fixes #33393.