### PR TITLE
Print full version to stdout and log

### DIFF
--- a/ydb/core/driver_lib/run/main.cpp
+++ b/ydb/core/driver_lib/run/main.cpp
@@ -27,6 +27,8 @@
 #include <sys/mman.h>
 #endif
 
+#include <library/cpp/svnversion/svnversion.h>
+
 #include <filesystem>
 
 namespace NKikimr {
@@ -38,8 +40,8 @@ int MainRun(const TKikimrRunConfig& runConfig, std::shared_ptr<TModuleFactories>
 #endif
 
     TKikimrRunner::SetSignalHandlers();
-    Cout << "Starting Kikimr r" << GetArcadiaLastChange()
-         << " built by " << GetProgramBuildUser() << Endl;
+    Cout << "Starting Kikimr" << Endl;
+    Cout << GetProgramSvnVersion() << Endl;
 
     TIntrusivePtr<TKikimrRunner> runner = TKikimrRunner::CreateKikimrRunner(runConfig, std::move(factories));
     if (runner) {

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -174,8 +174,6 @@
 #endif
 #include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
 
-#include <library/cpp/svnversion/svnversion.h>
-
 #include <util/charset/wide.h>
 #include <util/folder/dirut.h>
 #include <util/system/file.h>

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -174,6 +174,8 @@
 #endif
 #include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
 
+#include <library/cpp/svnversion/svnversion.h>
+
 #include <util/charset/wide.h>
 #include <util/folder/dirut.h>
 #include <util/system/file.h>
@@ -2159,6 +2161,7 @@ void TKikimrRunner::KikimrStart() {
     ThreadSigmask(SIG_BLOCK);
     if (ActorSystem) {
         ActorSystem->Start();
+        LOG_NOTICE_S(*ActorSystem, NActorsServices::GLOBAL, GetProgramSvnVersion());
     }
 
     if (!!Monitoring) {


### PR DESCRIPTION
Subj 

Sample stdout content:
```
Determined node ID: 1
configured
Starting Kikimr
Git info:
    Commit: aa45ab3a0fa7e2d27fdbe64c7147c7734ecb7947
    Branch: heads/main
    Author: YDBot <ydbot@ydb.tech>
    Summary: Update muted_ya.txt in main (#33260)
Other info:
    Build by: maxim-yurchuk
    Top src dir: /home/maxim-yurchuk/ydb
    Top build dir: /home/maxim-yurchuk/.ya/build
    Hostname: yurchuk-turbo2.sas.yp-c.yandex.net    Host information: 
        Linux yurchuk-turbo2.sas.yp-c.yandex.net 5.4.210-39.1 #1 SMP Thu Jan 12 13:13:41 UTC 2023 x86_64

     
UDFsDir is not specified, no dynamic UDFs will be loaded. 
Shutting Kikimr down
```

Sample logs content:
```
2026-02-04T21:16:34.226645Z :TABLET_SAUSAGECACHE NOTICE: shared_sausagecache.cpp:1530: Bootstrap with config 
2026-02-04T21:16:34.226655Z :BLOB_CACHE NOTICE: ctor_logger.h:56: MaxCacheDataSize: 1048576000 InFlightDataSize: 0
2026-02-04T21:16:34.227072Z :GRPC_SERVER NOTICE: grpc_request_proxy.cpp:373: Grpc request proxy started, nodeid# 1, serve as static node
2026-02-04T21:16:34.227080Z :GRPC_SERVER NOTICE: grpc_request_proxy.cpp:373: Grpc request proxy started, nodeid# 1, serve as static node
2026-02-04T21:16:34.228318Z :TX_CONVEYOR NOTICE: log.cpp:841: fline=service.cpp:26;name=COMPOSITE_CONVEYOR;action=conveyor_registered;config={{Categories:[{category=insert;queue_limit=262144;pools=2;};{category=compaction;queue_limit=262144;pools=1;};{category=normalizer;queue_limit=262144;pools=0;};{category=scan;queue_limit=262144;pools=3;};{category=deduplication;queue_limit=262144;pools=4;};]};{WorkerPools:[{id=0;threads={f=0.33;};links=[{c=normalizer;w=1;};];};{id=1;threads={f=0.33;};links=[{c=compaction;w=1;};];};{id=2;threads={f=0.2;};links=[{c=insert;w=1;};];};{id=3;threads={f=0.4;};links=[{c=scan;w=1;};];};{id=4;threads={f=0.3;};links=[{c=deduplication;w=1;};];};]};Enabled=1;};actor_id=[1:7603122022135858065:2096];manager={0,0,0,0,0,;};
2026-02-04T21:16:34.228326Z :GENERAL_CACHE NOTICE: log.cpp:841: fline=manager.h:385;event=general_cache_manager;owner_actor_id=[1:7603122022135858066:2097];config={MemoryLimit=(NULL);DirectInflightSourceLimit=2000;DirectInflightGlobalLimit=20000;};
2026-02-04T21:16:34.228329Z :GENERAL_CACHE NOTICE: log.cpp:841: fline=manager.h:385;event=general_cache_manager;owner_actor_id=[1:7603122022135858067:2098];config={MemoryLimit=(NULL);DirectInflightSourceLimit=2000;DirectInflightGlobalLimit=20000;};
2026-02-04T21:16:34.228403Z :MEMORY_PROFILER NOTICE: monitor.cpp:332: Bootstrapped
2026-02-04T21:16:34.229866Z :TABLET_SAUSAGECACHE NOTICE: shared_sausagecache.cpp:271: Register memory consumer
2026-02-04T21:16:34.230905Z :SCHEME_BOARD_SUBSCRIBER NOTICE: subscriber.cpp:849: [main][1:7603122022135858107:2121][/Root] Set up state: owner# [1:7603122022135858030:2072], state# { Deleted: 1 Strong: 0 Version: <Invalid> DomainId: <Invalid> AbandonedSchemeShards: there are 0 elements }
2026-02-04T21:16:34.230921Z :SCHEME_BOARD_SUBSCRIBER NOTICE: subscriber.cpp:849: [main][1:7603122022135858108:2122][/Root] Set up state: owner# [1:7603122022135858031:2073], state# { Deleted: 1 Strong: 0 Version: <Invalid> DomainId: <Invalid> AbandonedSchemeShards: there are 0 elements }
2026-02-04T21:16:34.230928Z :GRPC_SERVER WARN: grpc_request_proxy.cpp:579: SchemeBoardDelete /Root Strong=0
2026-02-04T21:16:34.230929Z :GRPC_SERVER WARN: grpc_request_proxy.cpp:579: SchemeBoardDelete /Root Strong=0
2026-02-04T21:16:34.230968Z :TENANT_POOL NOTICE: tenant_pool.cpp:526: TDomainTenantPool(Root) started tenant /Root
2026-02-04T21:16:34.231021Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594037968897, type: Hive, boot
2026-02-04T21:16:34.231033Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594037932033, type: BSController, boot
2026-02-04T21:16:34.231035Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594046678944, type: SchemeShard, boot
2026-02-04T21:16:34.231037Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594046316545, type: Coordinator, boot
2026-02-04T21:16:34.231040Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594046382081, type: Mediator, boot
2026-02-04T21:16:34.231044Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594046447617, type: TxAllocator, boot
2026-02-04T21:16:34.231046Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594037936128, type: Cms, boot
2026-02-04T21:16:34.231049Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594037936129, type: NodeBroker, boot
2026-02-04T21:16:34.231051Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594037936130, type: TenantSlotBroker, boot
2026-02-04T21:16:34.231053Z :BOOTSTRAPPER NOTICE: bootstrapper.cpp:698: tablet: 72057594037936131, type: Console, boot
2026-02-04T21:16:34.231080Z :GLOBAL NOTICE: run.cpp:2164: Git info:
    Commit: aa45ab3a0fa7e2d27fdbe64c7147c7734ecb7947
    Branch: heads/main
    Author: YDBot <ydbot@ydb.tech>
    Summary: Update muted_ya.txt in main (#33260)
Other info:
    Build by: maxim-yurchuk
    Top src dir: /home/maxim-yurchuk/ydb
    Top build dir: /home/maxim-yurchuk/.ya/build
    Hostname: yurchuk-turbo2.sas.yp-c.yandex.net    Host information: 
        Linux yurchuk-turbo2.sas.yp-c.yandex.net 5.4.210-39.1 #1 SMP Thu Jan 12 13:13:41 UTC 2023 x86_64

     
2026-02-04T21:16:34.233668Z :BS_NODE WARN: {NW89@node_warden_pdisk.cpp:124} Can't write new MockDevicesConfig to file Path# /Berkanavt/kikimr/testing/mock_devices.txt
2026-02-04T21:16:34.288458Z :BS_PDISK NOTICE: {BPD38@blobstorage_pdisk_impl.cpp:2900}  OnDriveStartup  Path# "SectorMap:1:64" PDiskId# 1

```