### PR TITLE
Add custom auth flags to counters and all healthcheck formats

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -621,6 +621,7 @@ void TKikimrRunner::InitializeMonitoring(const TKikimrRunConfig& runConfig, bool
         monConfig.PrivateKeyFile = appConfig.GetMonitoringConfig().GetMonitoringPrivateKeyFile();
         monConfig.RedirectMainPageTo = appConfig.GetMonitoringConfig().GetRedirectMainPageTo();
         monConfig.RequireCountersAuthentication = appConfig.GetMonitoringConfig().GetRequireCountersAuthentication();
+        monConfig.RequireHealthcheckAuthentication = appConfig.GetMonitoringConfig().GetRequireHealthcheckAuthentication();
         if (includeHostName) {
             if (appConfig.HasNameserviceConfig() && appConfig.GetNameserviceConfig().NodeSize() > 0) {
                 for (const auto& it : appConfig.GetNameserviceConfig().GetNode()) {

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -665,7 +665,7 @@ void TKikimrRunner::InitializeMonitoringLogin(const TKikimrRunConfig&)
         Monitoring->RegisterActorHandler({
             .Path = "/login",
             .Handler = MakeWebLoginServiceId(),
-            .UseAuth = false, // we don't require token for the login page - it's the page to get the token
+            .AuthMode = TMon::EAuthMode::Disabled, // we don't require token for the login page - it's the page to get the token
         });
         Monitoring->RegisterActorHandler({
             .Path = "/logout",

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -3960,7 +3960,7 @@ public:
                 .RelPath = "status",
                 .ActorSystem = TActivationContext::ActorSystem(),
                 .ActorId = SelfId(),
-                .UseAuth = false,
+                .AuthMode = TMon::EAuthMode::Disabled,
             });
         }
         Become(&THealthCheckService::StateWork);

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1410,7 +1410,9 @@ public:
         if (ev->Get()->Request->Method == "OPTIONS") {
             return ReplyWithOptions(ev);
         }
-        Register(new THttpMonAuthorizedPageRequest(std::move(ev), Page.Get(), AllowedSIDs, Authorizer, true, AuthMode));
+        Register(new THttpMonAuthorizedPageRequest(
+            std::move(ev), Page.Get(), AllowedSIDs, Authorizer, /* authMode */ true, AuthMode)
+        );
     }
 
     STATEFN(StateWork) {

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -23,6 +23,12 @@ void MakeJsonErrorReply(NJson::TJsonValue& jsonResponse, TString& message, const
 
 class TMon {
 public:
+    enum class EAuthMode {
+        Disabled,      // Don't check authorization
+        Enforce,       // Check authorization in monitoring layer
+        ExtractOnly    // Extract token only, check authorization in handler
+    };
+
     using TRequestAuthorizer = std::function<IEventHandle*(const TActorId& owner, NHttp::THttpIncomingRequest* request)>;
 
     static IEventHandle* DefaultAuthorizer(const TActorId& owner, NHttp::THttpIncomingRequest* request);
@@ -63,8 +69,7 @@ public:
         NMonitoring::TIndexMonPage* Index;
         bool PreTag = false;
         TActorId ActorId;
-        bool UseAuth = true;
-        bool GetOnlyAuthInfo = false;  // If true, extract token but don't enforce authorization
+        EAuthMode AuthMode = EAuthMode::Enforce;
         TVector<TString> AllowedSIDs;
         bool SortPages = true;
         TString MonServiceName = "utils";
@@ -79,8 +84,7 @@ public:
     struct TRegisterHandlerFields {
         TString Path;
         TActorId Handler;
-        bool UseAuth = true;
-        bool GetOnlyAuthInfo = false;  // If true, extract token but don't enforce authorization
+        EAuthMode AuthMode = EAuthMode::Enforce;
         TVector<TString> AllowedSIDs;
     };
 
@@ -123,4 +127,4 @@ protected:
     void RegisterActorMonPage(const TActorMonPageInfo& pageInfo);
 };
 
-} // NActors
+} // namespace NActors

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -81,6 +81,8 @@ public:
     NMonitoring::IMonPage* RegisterCountersPage(const TString& path, const TString& title, TIntrusivePtr<::NMonitoring::TDynamicCounters> counters);
     NMonitoring::IMonPage* FindPage(const TString& relPath);
 
+    static TVector<TString> GetCountersAllowedSIDs(TActorSystem* actorSystem);
+
     struct TRegisterHandlerFields {
         TString Path;
         TActorId Handler;

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -43,6 +43,7 @@ public:
         TDuration InactivityTimeout = TDuration::Minutes(2);
         TString AllowOrigin;
         bool RequireCountersAuthentication = false;
+        bool RequireHealthcheckAuthentication = false;
     };
 
     TMon(TConfig config);
@@ -63,6 +64,7 @@ public:
         bool PreTag = false;
         TActorId ActorId;
         bool UseAuth = true;
+        bool GetOnlyAuthInfo = false;  // If true, extract token but don't enforce authorization
         TVector<TString> AllowedSIDs;
         bool SortPages = true;
         TString MonServiceName = "utils";
@@ -78,6 +80,7 @@ public:
         TString Path;
         TActorId Handler;
         bool UseAuth = true;
+        bool GetOnlyAuthInfo = false;  // If true, extract token but don't enforce authorization
         TVector<TString> AllowedSIDs;
     };
 

--- a/ydb/core/mon/mon_impl.h
+++ b/ydb/core/mon/mon_impl.h
@@ -142,7 +142,7 @@ class TActorMonPage: public IMonPage {
 public:
     TActorMonPage(const TString &path, const TString &title, const TString &host, bool preTag,
                     TActorSystem *actorSystem, const TActorId &actorId, const TVector<TString> &sids,
-                    TMon::TRequestAuthorizer authorizer, bool getOnlyAuthInfo = false, TString monServiceName = "utils")
+                    TMon::TRequestAuthorizer authorizer, TMon::EAuthMode authMode = TMon::EAuthMode::Enforce, TString monServiceName = "utils")
         : IMonPage(path, title)
         , Host(host)
         , PreTag(preTag)
@@ -150,7 +150,7 @@ public:
         , TargetActorId(actorId)
         , AllowedSIDs(sids)
         , Authorizer(std::move(authorizer))
-        , GetOnlyAuthInfo(getOnlyAuthInfo)
+        , AuthMode(authMode)
         , MonServiceName(monServiceName)
     {
     }
@@ -165,7 +165,7 @@ public:
     TActorId TargetActorId;
     const TVector<TString> AllowedSIDs;
     TMon::TRequestAuthorizer Authorizer;
-    bool GetOnlyAuthInfo;
+    TMon::EAuthMode AuthMode;
     TString MonServiceName;
 };
 

--- a/ydb/core/mon/mon_impl.h
+++ b/ydb/core/mon/mon_impl.h
@@ -142,7 +142,7 @@ class TActorMonPage: public IMonPage {
 public:
     TActorMonPage(const TString &path, const TString &title, const TString &host, bool preTag,
                     TActorSystem *actorSystem, const TActorId &actorId, const TVector<TString> &sids,
-                    TMon::TRequestAuthorizer authorizer, TString monServiceName = "utils")
+                    TMon::TRequestAuthorizer authorizer, bool getOnlyAuthInfo = false, TString monServiceName = "utils")
         : IMonPage(path, title)
         , Host(host)
         , PreTag(preTag)
@@ -150,6 +150,7 @@ public:
         , TargetActorId(actorId)
         , AllowedSIDs(sids)
         , Authorizer(std::move(authorizer))
+        , GetOnlyAuthInfo(getOnlyAuthInfo)
         , MonServiceName(monServiceName)
     {
     }
@@ -164,6 +165,7 @@ public:
     TActorId TargetActorId;
     const TVector<TString> AllowedSIDs;
     TMon::TRequestAuthorizer Authorizer;
+    bool GetOnlyAuthInfo;
     TString MonServiceName;
 };
 

--- a/ydb/core/mon/mon_ut.cpp
+++ b/ydb/core/mon/mon_ut.cpp
@@ -43,7 +43,7 @@ struct THttpMonTestEnvOptions {
     ERegKind RegKind = ERegKind::None;
     TVector<TString> ActorAllowedSIDs;
     TVector<TString> TicketParserGroupSIDs = DEFAULT_TICKET_PARSER_GROUPS;
-    bool UseAuth = true;
+    TMon::EAuthMode AuthMode = TMon::EAuthMode::Enforce;
 };
 
 class THttpMonTestEnv {
@@ -91,7 +91,7 @@ public:
                     .RelPath = TEST_MON_PATH,
                     .ActorSystem = Runtime->GetActorSystem(0),
                     .ActorId = TestActorId,
-                    .UseAuth = Options.UseAuth,
+                    .AuthMode = Options.AuthMode,
                     .AllowedSIDs = Options.ActorAllowedSIDs,
                 });
                 break;
@@ -102,7 +102,7 @@ public:
                 mon->RegisterActorHandler({
                     .Path = MakeDefaultUrl(),
                     .Handler = TestActorId,
-                    .UseAuth = Options.UseAuth,
+                    .AuthMode = Options.AuthMode,
                     .AllowedSIDs = Options.ActorAllowedSIDs,
                 });
                 break;
@@ -217,7 +217,7 @@ Y_UNIT_TEST_SUITE(ActorPage) {
     Y_UNIT_TEST(NoUseAuthOk) {
         THttpMonTestEnv env({
             .RegKind = THttpMonTestEnvOptions::ERegKind::ActorPage,
-            .UseAuth = false,
+            .AuthMode = TMon::EAuthMode::Disabled,
         });
 
         TStringStream responseStream;
@@ -308,7 +308,7 @@ Y_UNIT_TEST_SUITE(ActorHandler) {
     Y_UNIT_TEST(NoUseAuthOk) {
         THttpMonTestEnv env({
             .RegKind = THttpMonTestEnvOptions::ERegKind::ActorHandler,
-            .UseAuth = false,
+            .AuthMode = TMon::EAuthMode::Disabled,
         });
 
         TStringStream responseStream;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -620,6 +620,7 @@ message TMonitoringConfig {
     optional string InactivityTimeout = 18 [default = "2m"];
     optional bool HideHttpEndpoint = 19 [default = false];
     optional bool RequireCountersAuthentication = 21 [default = false];
+    optional bool RequireHealthcheckAuthentication = 22 [default = false];
 }
 
 message TRestartsCountConfig {

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -125,7 +125,8 @@ public:
                 .ActorId = ctx.SelfID,
                 .AuthMode = TMon::EAuthMode::Disabled,
             });
-            const bool requireCountersAuth = KikimrRunConfig.AppConfig.GetDomainsConfig().GetSecurityConfig().GetEnforceUserTokenRequirement() &&
+            const bool enforceUserToken = KikimrRunConfig.AppConfig.GetDomainsConfig().GetSecurityConfig().GetEnforceUserTokenRequirement();
+            const bool requireCountersAuth = enforceUserToken &&
                 KikimrRunConfig.AppConfig.GetMonitoringConfig().GetRequireCountersAuthentication();
             mon->RegisterActorPage({
                 .RelPath = "counters/hosts",
@@ -134,10 +135,8 @@ public:
                 .AuthMode = requireCountersAuth ? TMon::EAuthMode::Enforce : TMon::EAuthMode::Disabled,
                 .AllowedSIDs = requireCountersAuth ? databaseAllowedSIDs : TVector<TString>(),
             });
-            // For healthcheck, always extract token if enforce_user_token_requirement is enabled,
-            // so handler can check access. require_healthcheck_authentication only affects
-            // whether access is checked in monitoring layer or in handler.
-            const bool enforceUserToken = KikimrRunConfig.AppConfig.GetDomainsConfig().GetSecurityConfig().GetEnforceUserTokenRequirement();
+            // For healthcheck, always extract token if enforce_user_token_requirement is enabled, so access can be checked.
+            // requireHealthcheckAuth only affects whether access is checked in monitoring layer or in handler.
             const bool requireHealthcheckAuth = enforceUserToken &&
                 KikimrRunConfig.AppConfig.GetMonitoringConfig().GetRequireHealthcheckAuthentication();
             mon->RegisterActorPage({

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -125,17 +125,24 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
             });
+            const bool requireCountersAuth = KikimrRunConfig.AppConfig.GetDomainsConfig().GetSecurityConfig().GetEnforceUserTokenRequirement() &&
+                KikimrRunConfig.AppConfig.GetMonitoringConfig().GetRequireCountersAuthentication();
             mon->RegisterActorPage({
                 .RelPath = "counters/hosts",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = false,
+                .UseAuth = requireCountersAuth,
+                .AllowedSIDs = requireCountersAuth ? databaseAllowedSIDs : TVector<TString>(),
             });
+            const bool requireHealthcheckAuth = KikimrRunConfig.AppConfig.GetDomainsConfig().GetSecurityConfig().GetEnforceUserTokenRequirement() &&
+                KikimrRunConfig.AppConfig.GetMonitoringConfig().GetRequireHealthcheckAuthentication();
             mon->RegisterActorPage({
                 .RelPath = "healthcheck",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = false, // auth is checked inside handler
+                .UseAuth = requireHealthcheckAuth,
+                .GetOnlyAuthInfo = true, // Extract token but let handler check access
+                .AllowedSIDs = requireHealthcheckAuth ? databaseAllowedSIDs : TVector<TString>(),
             });
             mon->RegisterActorPage({
                 .RelPath = "vdisk",

--- a/ydb/tests/functional/security/test_mon_endpoints_auth.py
+++ b/ydb/tests/functional/security/test_mon_endpoints_auth.py
@@ -1,0 +1,530 @@
+# -*- coding: utf-8 -*-
+import os
+import subprocess
+import tempfile
+import urllib3
+
+import pytest
+import requests
+
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def generate_certificates(certs_tmp_dir):
+    ca_key = os.path.join(certs_tmp_dir, 'server_ca.key')
+    ca_crt = os.path.join(certs_tmp_dir, 'server_ca.crt')
+
+    subprocess.run(['openssl', 'genrsa', '-out', ca_key, '2048'], check=True, capture_output=True)
+
+    subprocess.run(
+        [
+            'openssl',
+            'req',
+            '-x509',
+            '-new',
+            '-nodes',
+            '-key',
+            ca_key,
+            '-sha256',
+            '-days',
+            '3650',
+            '-out',
+            ca_crt,
+            '-subj',
+            '/CN=Monitoring CA/O=YDB/C=RU',
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    # Generate server certificate with localhost in SAN
+    server_key = os.path.join(certs_tmp_dir, 'server.key')
+    server_crt = os.path.join(certs_tmp_dir, 'server.crt')
+    server_csr = os.path.join(certs_tmp_dir, 'server.csr')
+    server_conf = os.path.join(certs_tmp_dir, 'server.conf')
+
+    subprocess.run(['openssl', 'genrsa', '-out', server_key, '2048'], check=True, capture_output=True)
+
+    # Create OpenSSL config file with v3_req section and SAN
+    with open(server_conf, 'w') as f:
+        f.write('[req]\n')
+        f.write('distinguished_name = req_distinguished_name\n')
+        f.write('req_extensions = v3_req\n')
+        f.write('\n')
+        f.write('[req_distinguished_name]\n')
+        f.write('\n')
+        f.write('[v3_req]\n')
+        f.write('subjectAltName=DNS:localhost,DNS:test-server,IP:127.0.0.1\n')
+
+    # Generate CSR
+    subprocess.run(
+        [
+            'openssl',
+            'req',
+            '-new',
+            '-key',
+            server_key,
+            '-out',
+            server_csr,
+            '-subj',
+            '/CN=test-server/O=YDB/C=RU',
+            '-config',
+            server_conf,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    # Generate server certificate signed by CA
+    subprocess.run(
+        [
+            'openssl',
+            'x509',
+            '-req',
+            '-in',
+            server_csr,
+            '-CA',
+            ca_crt,
+            '-CAkey',
+            ca_key,
+            '-CAcreateserial',
+            '-out',
+            server_crt,
+            '-days',
+            '3650',
+            '-sha256',
+            '-extensions',
+            'v3_req',
+            '-extfile',
+            server_conf,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    return {
+        'server_cert': server_crt,
+        'server_key': server_key,
+    }
+
+
+def create_ydb_configurator(
+    certificates,
+    enforce_user_token_requirement=True,
+    require_counters_authentication=None,
+    require_healthcheck_authentication=None,
+    database_allowed_sids=['database@builtin'],
+    viewer_allowed_sids=['viewer@builtin'],
+    monitoring_allowed_sids=['monitoring@builtin'],
+):
+    cluster_config = {
+        'default_clusteradmin': 'root@builtin',
+        'enforce_user_token_requirement': enforce_user_token_requirement,
+    }
+    config_generator = KikimrConfigGenerator(**cluster_config)
+
+    if 'grpc_config' not in config_generator.yaml_config:
+        config_generator.yaml_config['grpc_config'] = {}
+    config_generator.yaml_config['grpc_config']['cert'] = certificates['server_cert']
+    config_generator.yaml_config['grpc_config']['key'] = certificates['server_key']
+
+    config_generator.monitoring_tls_cert_path = certificates['server_cert']
+    config_generator.monitoring_tls_key_path = certificates['server_key']
+
+    if require_counters_authentication is not None or require_healthcheck_authentication is not None:
+        if 'monitoring_config' not in config_generator.yaml_config:
+            config_generator.yaml_config['monitoring_config'] = {}
+        if require_counters_authentication is not None:
+            config_generator.yaml_config['monitoring_config'][
+                'require_counters_authentication'
+            ] = require_counters_authentication
+        if require_healthcheck_authentication is not None:
+            config_generator.yaml_config['monitoring_config'][
+                'require_healthcheck_authentication'
+            ] = require_healthcheck_authentication
+
+    if database_allowed_sids is not None:
+        config_generator.yaml_config['domains_config']['security_config'][
+            'database_allowed_sids'
+        ] = database_allowed_sids
+
+    if viewer_allowed_sids is not None:
+        config_generator.yaml_config['domains_config']['security_config']['viewer_allowed_sids'] = viewer_allowed_sids
+
+    if monitoring_allowed_sids is not None:
+        config_generator.yaml_config['domains_config']['security_config'][
+            'monitoring_allowed_sids'
+        ] = monitoring_allowed_sids
+
+    # administration_allowed_sids is already set due to default_clusteradmin
+
+    return config_generator
+
+
+@pytest.fixture(scope='module')
+def certificates():
+    certs_tmp_dir = tempfile.mkdtemp(prefix='monitoring_certs_')
+    return generate_certificates(certs_tmp_dir)
+
+
+@pytest.fixture(scope='module')
+def ydb_cluster_with_enforce_user_token(certificates):
+    configurator = create_ydb_configurator(
+        certificates,
+        enforce_user_token_requirement=True,
+    )
+    cluster = KiKiMR(configurator)
+    cluster.start()
+    yield cluster
+    cluster.stop()
+
+
+@pytest.fixture(scope='module')
+def ydb_cluster_without_enforce_user_token(certificates):
+    configurator = create_ydb_configurator(
+        certificates,
+        enforce_user_token_requirement=False,
+    )
+    cluster = KiKiMR(configurator)
+    cluster.start()
+    yield cluster
+    cluster.stop()
+
+
+@pytest.fixture(scope='module')
+def ydb_cluster_with_require_counters_auth(certificates):
+    configurator = create_ydb_configurator(
+        certificates,
+        enforce_user_token_requirement=True,
+        require_counters_authentication=True,
+    )
+    cluster = KiKiMR(configurator)
+    cluster.start()
+    yield cluster
+    cluster.stop()
+
+
+@pytest.fixture(scope='module')
+def ydb_cluster_with_require_healthcheck_auth(certificates):
+    configurator = create_ydb_configurator(
+        certificates,
+        enforce_user_token_requirement=True,
+        require_healthcheck_authentication=True,
+    )
+    cluster = KiKiMR(configurator)
+    cluster.start()
+    yield cluster
+    cluster.stop()
+
+
+EXPECTED_RESULTS_WITH_ENFORCE_USER_TOKEN = {
+    '/counters': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/counters/hosts': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/healthcheck?&format=prometheus': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/healthcheck': {
+        None: 403,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/ping': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/status': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/ver': {
+        None: 401,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/login': {
+        None: 400,
+        'user@builtin': 400,
+        'database@builtin': 400,
+        'viewer@builtin': 400,
+        'monitoring@builtin': 400,
+        'root@builtin': 400,
+    },
+    '/viewer/capabilities': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/static/css/bootstrap.min.css': {
+        None: 401,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/monitoring/': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/internal': {
+        None: 401,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/actors/': {
+        None: 401,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+}
+
+EXPECTED_RESULTS_WITHOUT_ENFORCE_USER_TOKEN = {
+    '/counters': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/counters/hosts': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/healthcheck?&format=prometheus': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/healthcheck': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/ping': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/status': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/ver': {
+        None: 200,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },  # TODO(yurikiselev): Fix 403 here and in other endpoints for non-enforced token (issue #33354)
+    '/login': {
+        None: 400,
+        'user@builtin': 400,
+        'database@builtin': 400,
+        'viewer@builtin': 400,
+        'monitoring@builtin': 400,
+        'root@builtin': 400,
+    },
+    '/viewer/capabilities': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/static/css/bootstrap.min.css': {
+        None: 200,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/monitoring/': {
+        None: 200,
+        'user@builtin': 200,
+        'database@builtin': 200,
+        'viewer@builtin': 200,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/internal': {
+        None: 200,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+    '/actors/': {
+        None: 200,
+        'user@builtin': 403,
+        'database@builtin': 403,
+        'viewer@builtin': 403,
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
+}
+
+
+assert len(EXPECTED_RESULTS_WITH_ENFORCE_USER_TOKEN) == len(
+    EXPECTED_RESULTS_WITHOUT_ENFORCE_USER_TOKEN
+), "Handlers list must be the same"
+
+
+def _test_endpoint(endpoint_url, endpoint_path, token, expected_status):
+    headers = {}
+    if token is not None:
+        headers['Authorization'] = token
+    response = requests.get(endpoint_url, headers=headers, verify=False)
+    token_desc = token if token is not None else "null"
+    assert (
+        response.status_code == expected_status
+    ), f"Expected {endpoint_path} with token={token_desc} to return {expected_status}, got {response.status_code}"
+
+
+def _test_endpoints(cluster, expected_results):
+    host = cluster.nodes[1].host
+    mon_port = cluster.nodes[1].mon_port
+    base_url = f'https://{host}:{mon_port}'
+
+    for endpoint_path, expected_statuses in expected_results.items():
+        endpoint_url = f'{base_url}{endpoint_path}'
+        for token, expected_status in expected_statuses.items():
+            _test_endpoint(endpoint_url, endpoint_path, token, expected_status)
+
+
+def test_with_enforce_user_token(ydb_cluster_with_enforce_user_token):
+    _test_endpoints(ydb_cluster_with_enforce_user_token, EXPECTED_RESULTS_WITH_ENFORCE_USER_TOKEN)
+
+
+def test_without_enforce_user_token(ydb_cluster_without_enforce_user_token):
+    _test_endpoints(ydb_cluster_without_enforce_user_token, EXPECTED_RESULTS_WITHOUT_ENFORCE_USER_TOKEN)
+
+
+def test_with_require_counters_authentication(ydb_cluster_with_require_counters_auth):
+    EXPECTED_RESULTS_WITH_REQUIRE_COUNTERS_AUTH = {
+        '/counters': {
+            None: 401,
+            'user@builtin': 403,
+            'database@builtin': 200,
+            'viewer@builtin': 200,
+            'monitoring@builtin': 200,
+            'root@builtin': 200,
+        },
+        '/counters/hosts': {
+            None: 401,
+            'user@builtin': 403,
+            'database@builtin': 200,
+            'viewer@builtin': 200,
+            'monitoring@builtin': 200,
+            'root@builtin': 200,
+        },
+        '/ping': {
+            None: 200,
+            'user@builtin': 200,
+            'database@builtin': 200,
+            'viewer@builtin': 200,
+            'monitoring@builtin': 200,
+            'root@builtin': 200,
+        },  # checks this just in case
+    }
+    _test_endpoints(ydb_cluster_with_require_counters_auth, EXPECTED_RESULTS_WITH_REQUIRE_COUNTERS_AUTH)
+
+
+def test_with_require_healthcheck_authentication(ydb_cluster_with_require_healthcheck_auth):
+    EXPECTED_RESULTS_WITH_REQUIRE_HEALTHCHECK_AUTH = {
+        '/healthcheck?&format=prometheus': {
+            None: 403,
+            'user@builtin': 403,
+            'database@builtin': 403,
+            'viewer@builtin': 403,
+            'monitoring@builtin': 200,
+            'root@builtin': 200,
+        },
+        '/healthcheck': {
+            None: 403,
+            'user@builtin': 403,
+            'database@builtin': 403,
+            'viewer@builtin': 403,
+            'monitoring@builtin': 200,
+            'root@builtin': 200,
+        },
+        '/ping': {
+            None: 200,
+            'user@builtin': 200,
+            'database@builtin': 200,
+            'viewer@builtin': 200,
+            'monitoring@builtin': 200,
+            'root@builtin': 200,
+        },  # checks this just in case
+    }
+    _test_endpoints(ydb_cluster_with_require_healthcheck_auth, EXPECTED_RESULTS_WITH_REQUIRE_HEALTHCHECK_AUTH)

--- a/ydb/tests/functional/security/ya.make
+++ b/ydb/tests/functional/security/ya.make
@@ -6,6 +6,7 @@ TEST_SRCS(
     conftest.py
     test_grants.py
     test_paths_lookup.py
+    test_mon_endpoints_auth.py
 )
 
 SPLIT_FACTOR(20)

--- a/ydb/tests/library/clients/kikimr_monitoring.py
+++ b/ydb/tests/library/clients/kikimr_monitoring.py
@@ -3,26 +3,44 @@ import time
 import json
 import collections
 from six.moves.urllib import request
+import ssl
+import urllib.request
 
 
 class KikimrMonitor(object):
-    def __init__(self, host, mon_port, update_interval_seconds=1.0):
+    def __init__(self, host, mon_port, update_interval_seconds=1.0, use_https=False, token=None):
         super(KikimrMonitor, self).__init__()
         self.__host = host
         self.__mon_port = mon_port
-        self.__url = "http://{host}:{mon_port}/counters/json".format(host=host, mon_port=mon_port)
+        protocol = "https" if use_https else "http"
+        self.__monitoring_address = "{protocol}://{host}:{mon_port}".format(protocol=protocol, host=host, mon_port=mon_port)
+        self.__counters_url = "{monitoring_address}/counters/json".format(monitoring_address=self.__monitoring_address)
+        self.__use_https = use_https
+        self.__token = token
         self.__pdisks = set()
         self.__data = {}
         self.__next_update_time = time.time()
         self.__update_interval_seconds = update_interval_seconds
         self._by_sensor_name = collections.defaultdict(list)
 
+    def __open_url(self, url_str):
+        """Open URL with optional HTTPS and token authentication"""
+        req = urllib.request.Request(url_str)
+        if self.__token:
+            req.add_header('Authorization', self.__token)
+        if self.__use_https:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            return urllib.request.urlopen(req, context=ctx)
+        else:
+            return request.urlopen(req)
+
     def tabletcounters(self, tablet_id):
-        url = request.urlopen(
-            "http://{host}:{mon_port}/viewer/json/tabletcounters?tablet_id={tablet_id}".format(
-                host=self.__host, mon_port=self.__mon_port, tablet_id=tablet_id
-            )
+        url_str = "{monitoring_address}/viewer/json/tabletcounters?tablet_id={tablet_id}".format(
+            monitoring_address=self.__monitoring_address, tablet_id=tablet_id
         )
+        url = self.__open_url(url_str)
         return json.load(url)
 
     @property
@@ -38,7 +56,7 @@ class KikimrMonitor(object):
             return
 
         try:
-            url = request.urlopen(self.__url)
+            url = self.__open_url(self.__counters_url)
         except Exception:
             return False
         try:

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -242,6 +242,9 @@ class KikimrConfigGenerator(object):
             self.__grpc_tls_key = key_pem
             self.__grpc_tls_cert = cert_pem
 
+        self.monitoring_tls_cert_path = None
+        self.monitoring_tls_key_path = None
+
         self.__binary_paths = binary_paths
         rings_count = 3 if erasure == Erasure.MIRROR_3_DC else 1
         if nodes is None:

--- a/ydb/tests/library/harness/kikimr_node_interface.py
+++ b/ydb/tests/library/harness/kikimr_node_interface.py
@@ -41,7 +41,7 @@ class NodeInterface(object):
 
     @property
     def monitor(self):
-        return KikimrMonitor(self.host, self.mon_port)
+        return KikimrMonitor(self.host, self.mon_port, use_https=getattr(self, 'mon_uses_https', False), token=getattr(self, '_monitor_token', None))
 
     @abc.abstractproperty
     def cwd(self):

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -72,6 +72,7 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
         self._tenant_affiliation = tenant_affiliation
         self.grpc_port = port_allocator.grpc_port
         self.mon_port = port_allocator.mon_port
+        self.mon_uses_https = self.__configurator.monitoring_tls_cert_path is not None
         self.ic_port = port_allocator.ic_port
         self.grpc_ssl_port = port_allocator.grpc_ssl_port
         self.pgwire_port = port_allocator.pgwire_port
@@ -243,6 +244,16 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
                 "--ic-port=%d" % self.ic_port,
             ]
         )
+
+        if self.__configurator.monitoring_tls_cert_path is not None:
+            command.append(
+                "--mon-cert=%s" % self.__configurator.monitoring_tls_cert_path
+            )
+
+        if self.__configurator.monitoring_tls_key_path is not None:
+            command.append(
+                "--mon-key=%s" % self.__configurator.monitoring_tls_key_path
+            )
 
         if os.environ.get("YDB_ALLOCATE_PGWIRE_PORT", "") == "true":
             command.append("--pgwire-port=%d" % self.pgwire_port)
@@ -553,7 +564,8 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
         bs_needed = ('blob_storage_config' in self.__configurator.yaml_config) or self.__configurator.use_self_management
 
         if bs_needed:
-            self.__wait_for_bs_controller_to_start(timeout_seconds=timeout_seconds)
+            token = self.root_token or self.__configurator.default_clusteradmin
+            self.__wait_for_bs_controller_to_start(timeout_seconds=timeout_seconds, token=token)
             if not self.__configurator.use_self_management:
                 self.__add_bs_box()
 
@@ -910,7 +922,10 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
         self._bs_config_invoke(request)
         return name
 
-    def __wait_for_bs_controller_to_start(self, timeout_seconds=240):
+    def __wait_for_bs_controller_to_start(self, timeout_seconds=240, token=None):
+        if token:
+            for node in self.nodes.values():
+                node._monitor_token = token
         monitors = [node.monitor for node in self.nodes.values()]
 
         def predicate():


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
- В тестах добавлена возможность ходить в мониторинг по https, чтобы можно было включать "защищённые режимы".
- Добавлен файл с тестами на множество ручек по различным группам СИДов.
- Починен баг с тем, что даже админам ручка хелсчека возвращала 403 https://github.com/ydb-platform/ydb/issues/33400.
- Добавлена настройка `RequireHealthcheckAuthentication` – включает обязательную аутентификацию в ручке хелсчека даже для формата Prometheus (саппорт https://nda.ya.ru/t/muUjYAMG7TSMXH).
- Настройка `RequireCountersAuthentication` сейчас дополнительно закрывает `/counters/hosts` и даёт доступ сидам database_allowed_sids и им подобным (саппорт https://nda.ya.ru/t/muUjYAMG7TSMXH).