### PR TITLE
Unstable test

### DIFF
--- a/ydb/core/persqueue/pqtablet/quota/write_quoter_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/write_quoter_ut.cpp
@@ -75,7 +75,7 @@ Y_UNIT_TEST(WaitDeduplicationIdQuota) {
     UNIT_ASSERT(WaitForQuotaApproved(runtime));
 
     auto duration = TInstant::Now() - start;
-    UNIT_ASSERT_GE_C(duration, TDuration::Seconds(1), "duration: " << duration);
+    UNIT_ASSERT_GT_C(duration, TDuration::MilliSeconds(950), "duration: " << duration);
 }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

In the test, we expect the quoter to pause execution for 1 second or more. But in reality, the difference may be 200 microseconds less.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
