### PR TITLE
Fixed OOM when reading from a topic with many partitions

### DIFF
--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
@@ -1736,8 +1736,13 @@ bool TReadSessionActor::ProcessReads(const TActorContext& ctx) {
         ui32 maxPartitions = MaxReadPartitionsCount;
         ui32 partitionsAsked = 0;
 
+        static constexpr size_t MAX_PARTITION_IN_READ_BATCH = 10;
+        size_t maxPartitionsInReadBatch = 0;
+
         TFormedReadResponse::TPtr formedResponse = new TFormedReadResponse(Reads.front()->Guid, ctx.Now());
-        while (!AvailablePartitions.empty()) {
+        while (!AvailablePartitions.empty() && maxPartitionsInReadBatch < MAX_PARTITION_IN_READ_BATCH) {
+            ++maxPartitionsInReadBatch;
+
             auto part = *AvailablePartitions.begin();
             AvailablePartitions.erase(AvailablePartitions.begin());
 

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -2241,7 +2241,10 @@ void TReadSessionActor<UseMigrationProtocol>::ProcessReads(const TActorContext& 
         typename TFormedReadResponse<TServerMessage>::TPtr formedResponse =
             new TFormedReadResponse<TServerMessage>(guid, ctx.Now());
 
-        while (!AvailablePartitions.empty()) {
+        size_t maxPartitionsInReadBatch = 0;
+        while (!AvailablePartitions.empty() && maxPartitionsInReadBatch < MAX_PARTITION_IN_READ_BATCH) {
+            ++maxPartitionsInReadBatch;
+
             auto part = *AvailablePartitions.begin();
             AvailablePartitions.erase(AvailablePartitions.begin());
 

--- a/ydb/services/persqueue_v1/actors/read_session_actor.h
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.h
@@ -202,6 +202,7 @@ private:
     static constexpr ui64 MAX_INFLY_BYTES = 25_MB;
     static constexpr ui32 MAX_INFLY_READS = 10;
     static constexpr ui32 MAX_PENDING_DIRECT_READ_ACKS = 10;
+    static constexpr ui32 MAX_PARTITION_IN_READ_BATCH = 10;
 
     static constexpr ui64 MAX_READ_SIZE = 100_MB;
     static constexpr ui64 READ_BLOCK_SIZE = 8_KB; // metering


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Мог случаться OOM в сессии чтения если из одной сессии чтения читать топик с большим кол-вом партиции

### Changelog category <!-- remove all except one -->

* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/pull/33491
SPI-183603
