### PR TITLE
Support SASL EXTERNAL bind to LDAP server

### DIFF
--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -116,7 +116,7 @@ message TLdapAuthentication {
 
     message TExtendedSettings {
         optional bool EnableNestedGroupsSearch = 1 [default = false];
-        optional bool EnableMtlsAuth = 2 [default = false];
+        optional bool EnableSaslExternalBind = 2 [default = false];
     }
 
     optional string Host = 1; // DEPRECATED: Use Hosts instead it

--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -110,10 +110,13 @@ message TLdapAuthentication {
         optional bool Enable = 1 [default = false];
         optional string CaCertFile = 2;
         optional TCertRequire CertRequire = 3 [default = DEMAND];
+        optional string CertFile = 4;
+        optional string KeyFile = 5;
     }
 
     message TExtendedSettings {
         optional bool EnableNestedGroupsSearch = 1 [default = false];
+        optional bool EnableMtlsAuth = 2 [default = false];
     }
 
     optional string Host = 1; // DEPRECATED: Use Hosts instead it

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -193,7 +193,13 @@ private:
         }
 
         LDAP_LOG_D("bind: bindDn: " << Settings.GetBindDn());
-        result = NKikimrLdap::Bind(*ld, Settings.GetBindDn(), Settings.GetBindPassword());
+        if (Settings.GetExtendedSettings().GetEnableMtlsAuth()) {
+            result = NKikimrLdap::Bind(*ld, "", NKikimrLdap::ESaslMechanism::EXTERNAL, nullptr);
+        } else {
+            const TString& bindPassword = Settings.GetBindPassword();
+            std::vector<char> credentials(bindPassword.begin(), bindPassword.end());
+            result = NKikimrLdap::Bind(*ld, Settings.GetBindDn(), NKikimrLdap::ESaslMechanism::SIMPLE, &credentials);
+        }
         if (!NKikimrLdap::IsSuccess(result)) {
             TStringBuilder logErrorMessage;
             logErrorMessage << "Could not perform initial LDAP bind for dn " << Settings.GetBindDn() << " on server " + UrisCreator.GetUris() << ". "
@@ -226,6 +232,28 @@ private:
                 NKikimrLdap::Unbind(*ld);
                 return {{NKikimrLdap::ErrorToStatus(result),
                         {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)}}};
+            }
+            const TString& certFile = Settings.GetUseTls().GetCertFile();
+            const TString& keyFile = Settings.GetUseTls().GetKeyFile();
+            if (!certFile.empty() && !keyFile.empty()) {
+                result = NKikimrLdap::SetOption(*ld, NKikimrLdap::EOption::TLS_CERTFILE, certFile.c_str());
+                if (!NKikimrLdap::IsSuccess(result)) {
+                    TStringBuilder logErrorMessage;
+                    logErrorMessage << "Could not set LDAP client certificate file \"" << certFile + "\": " << NKikimrLdap::ErrorToString(result);
+                    LDAP_LOG_D(logErrorMessage);
+                    NKikimrLdap::Unbind(*ld);
+                    return {{NKikimrLdap::ErrorToStatus(result),
+                            {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)}}};
+                }
+                result = NKikimrLdap::SetOption(*ld, NKikimrLdap::EOption::TLS_KEYFILE, keyFile.c_str());
+                if (!NKikimrLdap::IsSuccess(result)) {
+                    TStringBuilder logErrorMessage;
+                    logErrorMessage << "Could not set LDAP client key file \"" << keyFile + "\": " << NKikimrLdap::ErrorToString(result);
+                    LDAP_LOG_D(logErrorMessage);
+                    NKikimrLdap::Unbind(*ld);
+                    return {{NKikimrLdap::ErrorToStatus(result),
+                            {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)}}};
+                }
             }
         }
 
@@ -284,7 +312,8 @@ private:
         }
         TEvLdapAuthProvider::TError error;
         LDAP_LOG_D("bind: bindDn: " << dn);
-        int result = NKikimrLdap::Bind(*request.Ld, dn, request.Password);
+        std::vector<char> credentials(request.Password.begin(), request.Password.end());
+        int result = NKikimrLdap::Bind(*request.Ld, dn, NKikimrLdap::ESaslMechanism::SIMPLE, &credentials);
         if (!NKikimrLdap::IsSuccess(result)) {
             TStringBuilder logErrorMessage;
             logErrorMessage << "LDAP login failed for user " << TString(dn) << " on server " << UrisCreator.GetUris() << ". "

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -194,12 +194,12 @@ private:
 
         if (Settings.GetExtendedSettings().GetEnableSaslExternalBind()) {
             LDAP_LOG_D("bind: Sasl EXTERNAL");
-            result = NKikimrLdap::Bind(*ld, "", NKikimrLdap::ESaslMechanism::EXTERNAL, nullptr);
+            result = NKikimrLdap::Bind(*ld, "", NLoginProto::ESaslAuthMech::External, nullptr);
         } else {
             LDAP_LOG_D("bind: bindDn: " << Settings.GetBindDn());
             const TString& bindPassword = Settings.GetBindPassword();
             std::vector<char> credentials(bindPassword.begin(), bindPassword.end());
-            result = NKikimrLdap::Bind(*ld, Settings.GetBindDn(), NKikimrLdap::ESaslMechanism::SIMPLE, &credentials);
+            result = NKikimrLdap::Bind(*ld, Settings.GetBindDn(), NLoginProto::ESaslAuthMech::Simple, &credentials);
         }
         if (!NKikimrLdap::IsSuccess(result)) {
             TStringBuilder logErrorMessage;
@@ -314,7 +314,7 @@ private:
         TEvLdapAuthProvider::TError error;
         LDAP_LOG_D("bind: bindDn: " << dn);
         std::vector<char> credentials(request.Password.begin(), request.Password.end());
-        int result = NKikimrLdap::Bind(*request.Ld, dn, NKikimrLdap::ESaslMechanism::SIMPLE, &credentials);
+        int result = NKikimrLdap::Bind(*request.Ld, dn, NLoginProto::ESaslAuthMech::Simple, &credentials);
         if (!NKikimrLdap::IsSuccess(result)) {
             TStringBuilder logErrorMessage;
             logErrorMessage << "LDAP login failed for user " << TString(dn) << " on server " << UrisCreator.GetUris() << ". "

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -192,7 +192,7 @@ private:
             }
         }
 
-        if (Settings.GetExtendedSettings().GetEnableMtlsAuth()) {
+        if (Settings.GetExtendedSettings().GetEnableSaslExternalBind()) {
             LDAP_LOG_D("bind: Sasl EXTERNAL");
             result = NKikimrLdap::Bind(*ld, "", NKikimrLdap::ESaslMechanism::EXTERNAL, nullptr);
         } else {
@@ -473,10 +473,10 @@ private:
         if (Settings.GetBaseDn().empty()) {
             return {TEvLdapAuthProvider::EStatus::UNAVAILABLE, {.Message = ERROR_MESSAGE, .LogMessage = "Parameter BaseDn is empty", .Retryable = false}};
         }
-        if (Settings.GetBindDn().empty() && !Settings.GetExtendedSettings().GetEnableMtlsAuth()) {
+        if (Settings.GetBindDn().empty() && !Settings.GetExtendedSettings().GetEnableSaslExternalBind()) {
             return {TEvLdapAuthProvider::EStatus::UNAVAILABLE, {.Message = ERROR_MESSAGE, .LogMessage = "Parameter BindDn is empty", .Retryable = false}};
         }
-        if (Settings.GetBindPassword().empty() && !Settings.GetExtendedSettings().GetEnableMtlsAuth()) {
+        if (Settings.GetBindPassword().empty() && !Settings.GetExtendedSettings().GetEnableSaslExternalBind()) {
             return {TEvLdapAuthProvider::EStatus::UNAVAILABLE, {.Message = ERROR_MESSAGE, .LogMessage = "Parameter BindPassword is empty", .Retryable = false}};
         }
         return {TEvLdapAuthProvider::EStatus::SUCCESS, {}};

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -192,13 +192,15 @@ private:
             }
         }
 
-        LDAP_LOG_D("bind: bindDn: " << Settings.GetBindDn());
         if (Settings.GetExtendedSettings().GetEnableMtlsAuth()) {
+            LDAP_LOG_D("bind: Sasl EXTERNAL");
             result = NKikimrLdap::Bind(*ld, "", NKikimrLdap::ESaslMechanism::EXTERNAL, nullptr);
         } else {
+            LDAP_LOG_D("bind: bindDn: " << Settings.GetBindDn());
             const TString& bindPassword = Settings.GetBindPassword();
             std::vector<char> credentials(bindPassword.begin(), bindPassword.end());
             result = NKikimrLdap::Bind(*ld, Settings.GetBindDn(), NKikimrLdap::ESaslMechanism::SIMPLE, &credentials);
+
         }
         if (!NKikimrLdap::IsSuccess(result)) {
             TStringBuilder logErrorMessage;
@@ -471,7 +473,7 @@ private:
         if (Settings.GetBaseDn().empty()) {
             return {TEvLdapAuthProvider::EStatus::UNAVAILABLE, {.Message = ERROR_MESSAGE, .LogMessage = "Parameter BaseDn is empty", .Retryable = false}};
         }
-        if (Settings.GetBindDn().empty()) {
+        if (Settings.GetBindDn().empty() && !Settings.GetExtendedSettings().GetEnableMtlsAuth()) {
             return {TEvLdapAuthProvider::EStatus::UNAVAILABLE, {.Message = ERROR_MESSAGE, .LogMessage = "Parameter BindDn is empty", .Retryable = false}};
         }
         if (Settings.GetBindPassword().empty() && !Settings.GetExtendedSettings().GetEnableMtlsAuth()) {

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -474,7 +474,7 @@ private:
         if (Settings.GetBindDn().empty()) {
             return {TEvLdapAuthProvider::EStatus::UNAVAILABLE, {.Message = ERROR_MESSAGE, .LogMessage = "Parameter BindDn is empty", .Retryable = false}};
         }
-        if (Settings.GetBindPassword().empty()) {
+        if (Settings.GetBindPassword().empty() && !Settings.GetExtendedSettings().GetEnableMtlsAuth()) {
             return {TEvLdapAuthProvider::EStatus::UNAVAILABLE, {.Message = ERROR_MESSAGE, .LogMessage = "Parameter BindPassword is empty", .Retryable = false}};
         }
         return {TEvLdapAuthProvider::EStatus::SUCCESS, {}};

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -200,7 +200,6 @@ private:
             const TString& bindPassword = Settings.GetBindPassword();
             std::vector<char> credentials(bindPassword.begin(), bindPassword.end());
             result = NKikimrLdap::Bind(*ld, Settings.GetBindDn(), NKikimrLdap::ESaslMechanism::SIMPLE, &credentials);
-
         }
         if (!NKikimrLdap::IsSuccess(result)) {
             TStringBuilder logErrorMessage;

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider_ut.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider_ut.cpp
@@ -597,8 +597,6 @@ void CheckRequiredLdapSettings(std::function<void(NKikimrProto::TLdapAuthenticat
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
     UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, expectedErrorMessage);
-
-    ldapServer.Stop();
 }
 
 void LdapFetchGroupsWithDefaultGroupAttributeGood(const ESecurityConnectionType& secureType) {
@@ -633,7 +631,6 @@ void LdapFetchGroupsWithDefaultGroupAttributeGood(const ESecurityConnectionType&
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 } // namespace
@@ -676,7 +673,6 @@ Y_UNIT_TEST(CanFetchGroupsWithDefaultGroupAttributeDisableNestedGroups) {
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanFetchGroupsFromAdServer) {
@@ -703,7 +699,6 @@ Y_UNIT_TEST(CanFetchGroupsFromAdServer) {
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanFetchGroupsWithDisabledRequestToAD) {
@@ -730,7 +725,6 @@ Y_UNIT_TEST(CanFetchGroupsWithDisabledRequestToAD) {
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanFetchGroupsWithDefaultGroupAttributeUseListOfHosts) {
@@ -757,7 +751,6 @@ Y_UNIT_TEST(CanFetchGroupsWithDefaultGroupAttributeUseListOfHosts) {
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanFetchGroupsWithCustomGroupAttribute) {
@@ -784,7 +777,6 @@ Y_UNIT_TEST(CanFetchGroupsWithCustomGroupAttribute) {
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanFetchGroupsWithDontExistGroupAttribute) {
@@ -831,7 +823,6 @@ Y_UNIT_TEST(CanFetchGroupsWithDontExistGroupAttribute) {
     const auto& fetchedGroups = ticketParserResult->Token->GetGroupSIDs();
     UNIT_ASSERT_EQUAL(fetchedGroups.size(), 1);
     UNIT_ASSERT_STRINGS_EQUAL(fetchedGroups.front(), "all-users@well-known");
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanNotFetchGroupsWithInvalidRobotUserLogin) {
@@ -850,7 +841,6 @@ Y_UNIT_TEST(CanNotFetchGroupsWithInvalidRobotUserLogin) {
     UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanNotFetchGroupsWithInvalidRobotUserPassword) {
@@ -869,7 +859,6 @@ Y_UNIT_TEST(CanNotFetchGroupsWithInvalidRobotUserPassword) {
     UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanNotFetchGroupsWithRemovedUserCredentials) {
@@ -903,7 +892,6 @@ Y_UNIT_TEST(CanNotFetchGroupsWithRemovedUserCredentials) {
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
     UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanNotFetchGroupsUseInvalidSearchFilter) {
@@ -921,7 +909,6 @@ Y_UNIT_TEST(CanNotFetchGroupsUseInvalidSearchFilter) {
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
     UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanRefreshGroupsInfo) {
@@ -976,7 +963,6 @@ Y_UNIT_TEST(CanRefreshGroupsInfo) {
     for (const auto& expectedGroup : newExpectedGroups) {
         UNIT_ASSERT_C(newGroups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanRefreshGroupsInfoWithDisabledNestedGroups) {
@@ -1031,7 +1017,6 @@ Y_UNIT_TEST(CanRefreshGroupsInfoWithDisabledNestedGroups) {
     for (const auto& expectedGroup : newExpectedGroups) {
         UNIT_ASSERT_C(newGroups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanNotRefreshRemovedUser) {
@@ -1083,7 +1068,6 @@ Y_UNIT_TEST(CanNotRefreshRemovedUser) {
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
     UNIT_ASSERT_EQUAL(ticketParserResult->Error.Retryable, false);
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanRefreshGroupsInfoWithError) {
@@ -1138,7 +1122,6 @@ Y_UNIT_TEST(CanRefreshGroupsInfoWithError) {
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 
@@ -1199,7 +1182,6 @@ Y_UNIT_TEST(CanFetchGroupsWithDelayUpdateSecurityState) {
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanGetErrorIfAppropriateLoginProviderIsAbsent) {
@@ -1229,7 +1211,6 @@ Y_UNIT_TEST(CanGetErrorIfAppropriateLoginProviderIsAbsent) {
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
     UNIT_ASSERT_EQUAL_C(ticketParserResult->Error.Message, "Login state is not available", ticketParserResult->Error);
     UNIT_ASSERT_EQUAL_C(ticketParserResult->Error.Retryable, false, ticketParserResult->Error.Retryable);
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanFetchGroupsWithValidCredentialsUseExternalSaslAuth) {
@@ -1244,7 +1225,7 @@ Y_UNIT_TEST(CanFetchGroupsWithValidCredentialsUseExternalSaslAuth) {
     });
 
     LdapMock::TLdapMockResponses responses = TCorrectLdapResponse::GetResponses(login);
-    responses.BindResponses.push_back({{{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "", .Mechanism = LdapMock::ESaslMechanism::EXTERNAL}}, {.Status = LdapMock::EStatus::SUCCESS}});
+    responses.BindResponses.push_back({{{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "", .Mechanism = "external"}}, {.Status = LdapMock::EStatus::SUCCESS}});
 
     LdapMock::TSimpleServer ldapServer({
         .Port = ydbServer.GetLdapPort(),
@@ -1274,7 +1255,6 @@ Y_UNIT_TEST(CanFetchGroupsWithValidCredentialsUseExternalSaslAuth) {
     for (const auto& expectedGroup : expectedGroups) {
         UNIT_ASSERT_C(groups.contains(expectedGroup), "Can not find " + expectedGroup);
     }
-    ldapServer.Stop();
 }
 
 Y_UNIT_TEST(CanNotFetchGroupsOverSaslExternalWithoutClientCert) {
@@ -1287,7 +1267,7 @@ Y_UNIT_TEST(CanNotFetchGroupsOverSaslExternalWithoutClientCert) {
     });
 
     LdapMock::TLdapMockResponses responses = TCorrectLdapResponse::GetResponses(login);
-    responses.BindResponses.push_back({{{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "", .Mechanism = LdapMock::ESaslMechanism::EXTERNAL}}, {.Status = LdapMock::EStatus::SUCCESS}});
+    responses.BindResponses.push_back({{{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "", .Mechanism = "external"}}, {.Status = LdapMock::EStatus::SUCCESS}});
 
     LdapMock::TSimpleServer ldapServer({
         .Port = ydbServer.GetLdapPort(),
@@ -1304,9 +1284,8 @@ Y_UNIT_TEST(CanNotFetchGroupsOverSaslExternalWithoutClientCert) {
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
     UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Should be error");
-     UNIT_ASSERT_EQUAL_C(ticketParserResult->Error.Message, "Could not login via LDAP", ticketParserResult->Error);
+    UNIT_ASSERT_EQUAL_C(ticketParserResult->Error.Message, "Could not login via LDAP", ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
-    ldapServer.Stop();
 }
 
 } // LdapAuthProviderTests

--- a/ydb/core/security/ldap_auth_provider/ldap_compat.h
+++ b/ydb/core/security/ldap_auth_provider/ldap_compat.h
@@ -20,11 +20,19 @@ enum class EOption {
     DEBUG,
     TLS_CACERTFILE,
     TLS_CACERTDIR,
+    TLS_CERTFILE,
+    TLS_KEYFILE,
     TLS_REQUIRE_CERT,
     PROTOCOL_VERSION,
 };
 
-int Bind(LDAP* ld, const TString& dn, const TString& password);
+enum class ESaslMechanism {
+    SIMPLE,
+    PLAIN,
+    EXTERNAL,
+};
+
+int Bind(LDAP* ld, const TString& dn, const ESaslMechanism& mechanism, std::vector<char>* credentials);
 int Unbind(LDAP* ld);
 int Init(LDAP** ld, const TString& scheme, const TString& uris, ui32 port);
 int Search(LDAP* ld,

--- a/ydb/core/security/ldap_auth_provider/ldap_compat.h
+++ b/ydb/core/security/ldap_auth_provider/ldap_compat.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <ydb/library/login/protos/login.pb.h>
 #include <util/generic/string.h>
 
 #ifndef LDAP_NO_ATTRS
@@ -26,13 +27,7 @@ enum class EOption {
     PROTOCOL_VERSION,
 };
 
-enum class ESaslMechanism {
-    SIMPLE,
-    PLAIN,
-    EXTERNAL,
-};
-
-int Bind(LDAP* ld, const TString& dn, const ESaslMechanism& mechanism, std::vector<char>* credentials);
+int Bind(LDAP* ld, const TString& dn, const NLoginProto::ESaslAuthMech::SaslAuthMech& mechanism, std::vector<char>* credentials);
 int Unbind(LDAP* ld);
 int Init(LDAP** ld, const TString& scheme, const TString& uris, ui32 port);
 int Search(LDAP* ld,

--- a/ydb/core/security/ldap_auth_provider/test_utils/test_settings.cpp
+++ b/ydb/core/security/ldap_auth_provider/test_utils/test_settings.cpp
@@ -126,10 +126,11 @@ void InitLdapSettingsDisableSearchNestedGroups(NKikimrProto::TLdapAuthentication
     extendedSettings->SetEnableNestedGroupsSearch(false);
 }
 
-void InitLdapSettingsWithMtlsAuth(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions) {
+void InitLdapSettingsWithSaslExternalBind(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions) {
     InitLdapSettings(ldapSettings, ldapPort, ldapClientOptions);
+    ldapSettings->SetBindDn("");
     ldapSettings->SetBindPassword("");
-    ldapSettings->MutableExtendedSettings()->SetEnableMtlsAuth(true);
+    ldapSettings->MutableExtendedSettings()->SetEnableSaslExternalBind(true);
 }
 
 } // NKikimr

--- a/ydb/core/security/ldap_auth_provider/test_utils/test_settings.cpp
+++ b/ydb/core/security/ldap_auth_provider/test_utils/test_settings.cpp
@@ -6,11 +6,14 @@ namespace NKikimr {
 
 TCertStorage::TCertStorage()
     : CaCertAndKey(GenerateCA(TProps::AsCA()))
-    , ServerCertAndKey(GenerateSignedCert(CaCertAndKey, TProps::AsClientServer()))
+    , ServerCertAndKey(GenerateSignedCert(CaCertAndKey, TProps::AsServer()))
+    , ClientCertAndKey(GenerateSignedCert(CaCertAndKey, TProps::AsClientServer()))
 {
     CaCertFile.Write(CaCertAndKey.Certificate.c_str(), CaCertAndKey.Certificate.size());
     ServerCertFile.Write(ServerCertAndKey.Certificate.c_str(), ServerCertAndKey.Certificate.size());
     ServerKeyFile.Write(ServerCertAndKey.PrivateKey.c_str(), ServerCertAndKey.PrivateKey.size());
+    ClientCertFile.Write(ClientCertAndKey.Certificate.c_str(), ClientCertAndKey.Certificate.size());
+    ClientKeyFile.Write(ClientCertAndKey.PrivateKey.c_str(), ClientCertAndKey.PrivateKey.size());
 }
 
 TString TCertStorage::GetCaCertFileName() const {
@@ -23,6 +26,14 @@ TString TCertStorage::GetServerCertFileName() const {
 
 TString TCertStorage::GetServerKeyFileName() const {
     return ServerKeyFile.Name();
+}
+
+TString TCertStorage::GetClientCertFileName() const {
+    return ClientCertFile.Name();
+}
+
+TString TCertStorage::GetClientKeyFileName() const {
+    return ClientKeyFile.Name();
 }
 
 void InitLdapSettings(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions) {
@@ -40,6 +51,8 @@ void InitLdapSettings(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldap
         useTls->SetEnable(useStartTls);
         useTls->SetCaCertFile(ldapClientOptions.CaCertFile);
         useTls->SetCertRequire(NKikimrProto::TLdapAuthentication::TUseTls::DEMAND);
+        useTls->SetCertFile(ldapClientOptions.CertFile);
+        useTls->SetKeyFile(ldapClientOptions.KeyFile);
     };
 
     switch (ldapClientOptions.Type) {
@@ -111,6 +124,12 @@ void InitLdapSettingsDisableSearchNestedGroups(NKikimrProto::TLdapAuthentication
     InitLdapSettings(ldapSettings, ldapPort, ldapClientOptions);
     auto extendedSettings = ldapSettings->MutableExtendedSettings();
     extendedSettings->SetEnableNestedGroupsSearch(false);
+}
+
+void InitLdapSettingsWithMtlsAuth(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions) {
+    InitLdapSettings(ldapSettings, ldapPort, ldapClientOptions);
+    ldapSettings->SetBindPassword("");
+    ldapSettings->MutableExtendedSettings()->SetEnableMtlsAuth(true);
 }
 
 } // NKikimr

--- a/ydb/core/security/ldap_auth_provider/test_utils/test_settings.h
+++ b/ydb/core/security/ldap_auth_provider/test_utils/test_settings.h
@@ -32,13 +32,18 @@ public:
     TString GetCaCertFileName() const;
     TString GetServerCertFileName() const;
     TString GetServerKeyFileName() const;
+    TString GetClientCertFileName() const;
+    TString GetClientKeyFileName() const;
 
 private:
     TCertAndKey CaCertAndKey;
     TCertAndKey ServerCertAndKey;
+    TCertAndKey ClientCertAndKey;
     TTempFileHandle CaCertFile;
     TTempFileHandle ServerCertFile;
     TTempFileHandle ServerKeyFile;
+    TTempFileHandle ClientCertFile;
+    TTempFileHandle ClientKeyFile;
 };
 
 void InitLdapSettings(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
@@ -53,5 +58,6 @@ void InitLdapSettingsWithEmptyBindPassword(NKikimrProto::TLdapAuthentication* ld
 void InitLdapSettingsWithCustomGroupAttribute(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
 void InitLdapSettingsWithListOfHosts(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
 void InitLdapSettingsDisableSearchNestedGroups(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
+void InitLdapSettingsWithMtlsAuth(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
 
 } // NKikimr

--- a/ydb/core/security/ldap_auth_provider/test_utils/test_settings.h
+++ b/ydb/core/security/ldap_auth_provider/test_utils/test_settings.h
@@ -58,6 +58,6 @@ void InitLdapSettingsWithEmptyBindPassword(NKikimrProto::TLdapAuthentication* ld
 void InitLdapSettingsWithCustomGroupAttribute(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
 void InitLdapSettingsWithListOfHosts(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
 void InitLdapSettingsDisableSearchNestedGroups(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
-void InitLdapSettingsWithMtlsAuth(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
+void InitLdapSettingsWithSaslExternalBind(NKikimrProto::TLdapAuthentication* ldapSettings, ui16 ldapPort, const TLdapClientOptions& ldapClientOptions);
 
 } // NKikimr

--- a/ydb/core/security/ldap_auth_provider/ya.make
+++ b/ydb/core/security/ldap_auth_provider/ya.make
@@ -26,6 +26,7 @@ PEERDIR(
     ydb/core/base
     ydb/core/protos
     ydb/core/util
+    ydb/library/login/protos
 )
 
 END()

--- a/ydb/core/security/ut_common.cpp
+++ b/ydb/core/security/ut_common.cpp
@@ -82,10 +82,6 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, const TTestEnvSettings& 
 
 TTestEnv::~TTestEnv() {
     Driver->Stop(true);
-
-    if (LdapServer) {
-        LdapServer->Stop();
-    }
 }
 
 } // NKikimr

--- a/ydb/library/login/protos/login.proto
+++ b/ydb/library/login/protos/login.proto
@@ -22,6 +22,8 @@ message ESaslAuthMech {
         Unknown = 0;
         Plain = 1;
         Scram = 2;
+        Simple = 3;
+        External = 4;
     }
 }
 

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.cpp
@@ -61,7 +61,7 @@ bool AreFiltersEqual(const TSearchRequestInfo::TSearchFilter& filter1, const TSe
 }
 } // namespace
 
-TBindRequestInfo::TBindRequestInfo(const TString& login, const TString& password, const ESaslMechanism& mechanism)
+TBindRequestInfo::TBindRequestInfo(const TString& login, const TString& password, const TString& mechanism)
     : Login(login)
     , Password(password)
     , Mechanism(mechanism)

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.cpp
@@ -61,17 +61,20 @@ bool AreFiltersEqual(const TSearchRequestInfo::TSearchFilter& filter1, const TSe
 }
 } // namespace
 
-TBindRequestInfo::TBindRequestInfo(const TString& login, const TString& password)
+TBindRequestInfo::TBindRequestInfo(const TString& login, const TString& password, const ESaslMechanism& mechanism)
     : Login(login)
     , Password(password)
+    , Mechanism(mechanism)
 {}
 
 TBindRequestInfo::TBindRequestInfo(const TInitializeList& list)
-    : TBindRequestInfo(list.Login, list.Password)
+    : TBindRequestInfo(list.Login, list.Password, list.Mechanism)
 {}
 
 bool TBindRequestInfo::operator==(const TBindRequestInfo& otherRequest) const {
-    return (this->Login == otherRequest.Login && this->Password == otherRequest.Password);
+    return (this->Login == otherRequest.Login
+        && this->Password == otherRequest.Password
+        && this->Mechanism == otherRequest.Mechanism);
 }
 
 TSearchRequestInfo::TSearchRequestInfo(const TString& baseDn,

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.h
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.h
@@ -56,17 +56,31 @@ enum EElementType {
     SET = 0x31,
 };
 
+enum class ESaslMechanism {
+    SIMPLE,
+    PLAIN,
+    EXTERNAL,
+};
+
+enum EAuthMethod {
+    LDAP_AUTH_NONE = 0x00U,
+    LDAP_AUTH_SIMPLE = 0x80U,
+    LDAP_AUTH_SASL = 0xa3U,
+};
+
 struct TBindRequestInfo {
     struct TInitializeList {
         TString Login;
         TString Password;
+        ESaslMechanism Mechanism = ESaslMechanism::SIMPLE;
     };
 
     TString Login;
     TString Password;
+    ESaslMechanism Mechanism;
 
     TBindRequestInfo() = default;
-    TBindRequestInfo(const TString& login, const TString& password);
+    TBindRequestInfo(const TString& login, const TString& password, const ESaslMechanism& mechanism);
     TBindRequestInfo(const TInitializeList& list);
 
     bool operator==(const TBindRequestInfo& otherRequest) const;

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.h
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_defines.h
@@ -56,12 +56,6 @@ enum EElementType {
     SET = 0x31,
 };
 
-enum class ESaslMechanism {
-    SIMPLE,
-    PLAIN,
-    EXTERNAL,
-};
-
 enum EAuthMethod {
     LDAP_AUTH_NONE = 0x00U,
     LDAP_AUTH_SIMPLE = 0x80U,
@@ -72,15 +66,15 @@ struct TBindRequestInfo {
     struct TInitializeList {
         TString Login;
         TString Password;
-        ESaslMechanism Mechanism = ESaslMechanism::SIMPLE;
+        TString Mechanism = "simple";
     };
 
     TString Login;
     TString Password;
-    ESaslMechanism Mechanism;
+    TString Mechanism = "unknown";
 
     TBindRequestInfo() = default;
-    TBindRequestInfo(const TString& login, const TString& password, const ESaslMechanism& mechanism);
+    TBindRequestInfo(const TString& login, const TString& password, const TString& mechanism);
     TBindRequestInfo(const TInitializeList& list);
 
     bool operator==(const TBindRequestInfo& otherRequest) const;

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
@@ -72,8 +72,9 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> CreateSearchEntryResponses(c
 
 } // namespace
 
-TLdapRequestProcessor::TLdapRequestProcessor(std::shared_ptr<TSocket> socket)
+TLdapRequestProcessor::TLdapRequestProcessor(std::shared_ptr<TSocket> socket, const THashMap<TString, TString>& externalAuthMap)
     : Socket(socket)
+    , ExternalAuthMap(externalAuthMap)
 {}
 
 unsigned char TLdapRequestProcessor::GetByte() {
@@ -210,10 +211,41 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
 
     requestInfo.Login = GetString();
 
-    unsigned char authType = GetByte();
-    Y_UNUSED(authType);
-
-    requestInfo.Password = GetString();
+    unsigned char authMethod = GetByte();
+    switch (authMethod) {
+    case EAuthMethod::LDAP_AUTH_NONE:
+        break;
+    case EAuthMethod::LDAP_AUTH_SIMPLE:
+        requestInfo.Mechanism = ESaslMechanism::SIMPLE;
+        requestInfo.Password = GetString();
+        break;
+    case EAuthMethod::LDAP_AUTH_SASL:
+        size_t authMessageLength = GetLength();
+        if (authMessageLength == 0) {
+            responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+            Cerr << "LDAP_MOCK: BindRequest, protocol error, auth message length is zero" << Endl;
+            return {responseOpData};
+        }
+        elementType = GetByte();
+        if (elementType != EElementType::STRING) {
+            responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+            Cerr << "LDAP_MOCK: BindRequest, protocol error, sasl mechanism is not a string" << Endl;
+            return {responseOpData};
+        }
+        TString saslMechanism = GetString();
+        if (saslMechanism == "EXTERNAL") {
+            requestInfo.Mechanism = ESaslMechanism::EXTERNAL;
+            TString bindDn = GetBindDnFromClientCert();
+            if (bindDn.empty()) {
+                responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+                Cerr << "LDAP_MOCK: BindRequest, protocol error, can not find login for client subject name" << Endl;
+                return {responseOpData};
+            }
+            requestInfo.Login = bindDn;
+            requestInfo.Password = "";
+        }
+        break;
+    }
 
     const auto it = std::find_if(responses.begin(), responses.end(), [&requestInfo] (const std::pair<TBindRequestInfo, TBindResponseInfo>& el) {
         const auto& expectedRequestInfo = el.first;
@@ -459,6 +491,11 @@ void TLdapRequestProcessor::ProcessFilterOr(TSearchRequestInfo::TSearchFilter* f
     while (ReadBytes < limit) {
         filter->NestedFilters.push_back(std::make_shared<TSearchRequestInfo::TSearchFilter>(ProcessFilter()));
     }
+}
+
+TString TLdapRequestProcessor::GetBindDnFromClientCert() {
+    auto it = ExternalAuthMap.find(Socket->GetClientCertSubjectName());
+    return (it != ExternalAuthMap.end() ? it->second : "");
 }
 
 }

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
@@ -233,6 +233,14 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
             return {responseOpData};
         }
         TString saslMechanism = GetString();
+        elementType = GetByte();
+        if (elementType != EElementType::STRING) {
+            responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+            Cerr << "LDAP_MOCK: BindRequest, protocol error, sasl mechanism is not a string" << Endl;
+            return {responseOpData};
+        }
+        TString credentials = GetString();
+        Y_UNUSED(credentials);
         if (saslMechanism == "EXTERNAL") {
             requestInfo.Mechanism = ESaslMechanism::EXTERNAL;
             TString bindDn = GetBindDnFromClientCert();

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
@@ -216,7 +216,7 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
     case EAuthMethod::LDAP_AUTH_NONE:
         break;
     case EAuthMethod::LDAP_AUTH_SIMPLE:
-        requestInfo.Mechanism = ESaslMechanism::SIMPLE;
+        requestInfo.Mechanism = "simple";
         requestInfo.Password = GetString();
         break;
     case EAuthMethod::LDAP_AUTH_SASL:
@@ -242,7 +242,7 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
         TString credentials = GetString();
         Y_UNUSED(credentials);
         if (saslMechanism == "EXTERNAL") {
-            requestInfo.Mechanism = ESaslMechanism::EXTERNAL;
+            requestInfo.Mechanism = "external";
             TString bindDn = GetBindDnFromClientCert();
             if (bindDn.empty()) {
                 responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
@@ -236,7 +236,7 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
         elementType = GetByte();
         if (elementType != EElementType::STRING) {
             responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
-            Cerr << "LDAP_MOCK: BindRequest, protocol error, sasl mechanism is not a string" << Endl;
+            Cerr << "LDAP_MOCK: BindRequest, protocol error, credentials is not a string" << Endl;
             return {responseOpData};
         }
         TString credentials = GetString();

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
@@ -503,7 +503,7 @@ void TLdapRequestProcessor::ProcessFilterOr(TSearchRequestInfo::TSearchFilter* f
 
 TString TLdapRequestProcessor::GetBindDnFromClientCert() {
     auto it = ExternalAuthMap.find(Socket->GetClientCertSubjectName());
-    return (it != ExternalAuthMap.end() ? it->second : "");
+    return (it != ExternalAuthMap.end() ? it->second : Socket->GetClientCertSubjectName());
 }
 
 }

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.h
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <util/generic/ptr.h>
 #include <util/generic/string.h>
+#include <util/generic/hash.h>
 #include "ldap_defines.h"
 #include "socket.h"
 
@@ -15,7 +16,7 @@ public:
         TString Data;
     };
 
-    TLdapRequestProcessor(std::shared_ptr<TSocket> socket);
+    TLdapRequestProcessor(std::shared_ptr<TSocket> socket, const THashMap<TString, TString>& externalAuthMap);
     int ExtractMessageId();
     std::vector<TProtocolOpData> Process(std::shared_ptr<const TLdapMockResponses> responses);
     unsigned char GetByte();
@@ -32,10 +33,12 @@ private:
     void ProcessFilterEquality(TSearchRequestInfo::TSearchFilter* filter);
     void ProcessFilterExtensibleMatch(TSearchRequestInfo::TSearchFilter* filter, size_t lengthFilter);
     void ProcessFilterOr(TSearchRequestInfo::TSearchFilter* filter, size_t lengthFilter);
+    TString GetBindDnFromClientCert();
 
 private:
     std::shared_ptr<TSocket> Socket;
     size_t ReadBytes = 0;
+    THashMap<TString, TString> ExternalAuthMap;
 };
 
 }

--- a/ydb/library/testlib/service_mocks/ldap_mock/simple_server.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/simple_server.cpp
@@ -87,7 +87,7 @@ void TSimpleServer::HandleClient_(int fd) {
     }
 
     while (Running) {
-        TLdapRequestProcessor requestProcessor(socket);
+        TLdapRequestProcessor requestProcessor(socket, Opt.ExternalAuthMap);
         unsigned char elementType = requestProcessor.GetByte();
         if (elementType != EElementType::SEQUENCE) {
             if (TLdapResponse().Send(socket)) {
@@ -188,9 +188,9 @@ bool TSimpleServer::InitTlsCtx() {
         }
     }
 
-
     int mode = SSL_VERIFY_NONE;
     if (Opt.RequireClientCert) {
+        // mode = SSL_VERIFY_PEER;
         mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
     } else if (!Opt.CaCertFile.empty()) {
         mode = SSL_VERIFY_PEER;

--- a/ydb/library/testlib/service_mocks/ldap_mock/simple_server.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/simple_server.cpp
@@ -190,7 +190,6 @@ bool TSimpleServer::InitTlsCtx() {
 
     int mode = SSL_VERIFY_NONE;
     if (Opt.RequireClientCert) {
-        // mode = SSL_VERIFY_PEER;
         mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
     } else if (!Opt.CaCertFile.empty()) {
         mode = SSL_VERIFY_PEER;

--- a/ydb/library/testlib/service_mocks/ldap_mock/simple_server.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/simple_server.cpp
@@ -85,9 +85,9 @@ void TSimpleServer::HandleClient_(int fd) {
     if (Opt.UseTls) {
         socket->UpgradeToTls(Ctx.Get());
     }
+    TLdapRequestProcessor requestProcessor(socket, Opt.ExternalAuthMap);
 
     while (Running) {
-        TLdapRequestProcessor requestProcessor(socket, Opt.ExternalAuthMap);
         unsigned char elementType = requestProcessor.GetByte();
         if (elementType != EElementType::SEQUENCE) {
             if (TLdapResponse().Send(socket)) {

--- a/ydb/library/testlib/service_mocks/ldap_mock/simple_server.h
+++ b/ydb/library/testlib/service_mocks/ldap_mock/simple_server.h
@@ -1,10 +1,10 @@
 #pragma once
 #include "ldap_defines.h"
 
-#include <util/system/types.h>
+#include <util/generic/hash.h>
 #include <util/generic/ptr.h>
 #include <util/generic/string.h>
-#include <util/generic/hash.h>
+#include <util/system/types.h>
 
 #include <openssl/ssl.h>
 

--- a/ydb/library/testlib/service_mocks/ldap_mock/simple_server.h
+++ b/ydb/library/testlib/service_mocks/ldap_mock/simple_server.h
@@ -4,6 +4,7 @@
 #include <util/system/types.h>
 #include <util/generic/ptr.h>
 #include <util/generic/string.h>
+#include <util/generic/hash.h>
 
 #include <openssl/ssl.h>
 
@@ -49,9 +50,13 @@ public:
         TString KeyFile;
         bool UseTls = false;
         bool RequireClientCert = false;
+        THashMap<TString, TString> ExternalAuthMap;
     };
 
     TSimpleServer(const TOptions& options, TLdapMockResponses responses);
+    ~TSimpleServer() {
+        Stop();
+    }
 
     bool Start();
     void Stop();

--- a/ydb/library/testlib/service_mocks/ldap_mock/socket.h
+++ b/ydb/library/testlib/service_mocks/ldap_mock/socket.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <util/generic/ptr.h>
+#include <util/generic/string.h>
 #include <sys/socket.h>
 #include <openssl/ssl.h>
 
@@ -26,6 +27,7 @@ public:
     bool Receive(void* buf, size_t len);
     bool Send(const void* msg, size_t len);
     bool UpgradeToTls(SSL_CTX* ctx);
+    TString GetClientCertSubjectName() const;
 
 private:
     bool ReceivePlain(void* buf, size_t len);
@@ -37,6 +39,7 @@ private:
     int Fd{0};
     bool UseTls = false;
     TSslHolder<SSL> Ssl = nullptr;
+    TString ClientSubjectName;
 };
 
 } // LdapMock

--- a/ydb/services/ydb/ydb_ldap_login_ut.cpp
+++ b/ydb/services/ydb/ydb_ldap_login_ut.cpp
@@ -125,7 +125,6 @@ void LdapAuthWithValidCredentials(const ESecurityConnectionType& secureType) {
     UNIT_ASSERT(!token.empty());
 
     loginConnection.Stop();
-    ldapServer.Stop();
 }
 
 } // namespace
@@ -161,7 +160,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Could not login via LDAP");
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 
     Y_UNIT_TEST(LdapAuthWithInvalidRobouserPassword) {
@@ -180,7 +178,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Could not login via LDAP");
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 
     Y_UNIT_TEST(LdapAuthWithInvalidSearchFilter) {
@@ -199,7 +196,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Could not login via LDAP");
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 
     void CheckRequiredLdapSettings(std::function<void(NKikimrProto::TLdapAuthentication*, ui16, const TLdapClientOptions&)> initLdapSettings, const TString& expectedErrorMessage) {
@@ -216,7 +212,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, expectedErrorMessage);
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 
     Y_UNIT_TEST(LdapAuthServerIsUnavailable) {
@@ -271,7 +266,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Could not login via LDAP");
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 
     Y_UNIT_TEST(LdapAuthWithInvalidPassword) {
@@ -313,7 +307,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Could not login via LDAP");
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 
     Y_UNIT_TEST(LdapAuthWithEmptyPassword) {
@@ -354,7 +347,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Could not login via LDAP");
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 
     Y_UNIT_TEST(LdapAuthSetIncorrectDomain) {
@@ -391,7 +383,7 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         TString password = "ldapUserPassword";
 
         LdapMock::TLdapMockResponses responses;
-        responses.BindResponses.push_back({{{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "", .Mechanism = LdapMock::ESaslMechanism::EXTERNAL}}, {.Status = LdapMock::EStatus::SUCCESS}});
+        responses.BindResponses.push_back({{{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "", .Mechanism = "external"}}, {.Status = LdapMock::EStatus::SUCCESS}});
         responses.BindResponses.push_back({{{.Login = "uid=" + login + ",dc=search,dc=yandex,dc=net", .Password = password}}, {.Status = LdapMock::EStatus::SUCCESS}});
 
         LdapMock::TSearchRequestInfo fetchUserSearchRequestInfo {
@@ -443,7 +435,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT(!token.empty());
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 
     Y_UNIT_TEST(CanNotAuthOverSaslExternalWithoutClientCert) {
@@ -451,7 +442,7 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         TString password = "ldapUserPassword";
 
         LdapMock::TLdapMockResponses responses;
-        responses.BindResponses.push_back({{{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "", .Mechanism = LdapMock::ESaslMechanism::EXTERNAL}}, {.Status = LdapMock::EStatus::SUCCESS}});
+        responses.BindResponses.push_back({{{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "", .Mechanism = "external"}}, {.Status = LdapMock::EStatus::SUCCESS}});
         responses.BindResponses.push_back({{{.Login = "uid=" + login + ",dc=search,dc=yandex,dc=net", .Password = password}}, {.Status = LdapMock::EStatus::SUCCESS}});
 
         LdapMock::TSearchRequestInfo fetchUserSearchRequestInfo {
@@ -501,7 +492,6 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         UNIT_ASSERT(token.empty());
 
         loginConnection.Stop();
-        ldapServer.Stop();
     }
 }
 } //namespace NKikimr


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added ability to authenticate ldap service account over mTLS and do not use simple bind with password in configuration

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Add using `ldap_sasl_bind_s` function with sasl mechanism EXTERNAL
* Remove deprecated functions for unbind and search and use `ldap_unbind_ext_s` and `ldap_search_ext_s`
* Add ability to parse sasl credentials in bind request in ldap mock
