### PR TITLE
Fixed OOM when reading from a topic with many partitions

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1863,7 +1863,7 @@ void TPartition::CheckHeadConsistency() const
 }
 
 ui64 TPartition::GetSizeLag(i64 offset) {
-    return BlobEncoder.GetSizeLag(offset);
+    return BlobEncoder.GetSizeLag(offset) + CompactionBlobEncoder.GetSizeLag(offset);
 }
 
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -206,7 +206,7 @@ ui64 TPartitionBlobEncoder::GetHeadGapSize() const
 ui64 TPartitionBlobEncoder::GetSizeLag(i64 offset) const
 {
     ui64 sizeLag = 0;
-    if (!DataKeysBody.empty() && PositionInBody(offset, 0)) { // there will be something in body
+    if (!DataKeysBody.empty()) { // there will be something in body
         auto it = std::upper_bound(DataKeysBody.begin(), DataKeysBody.end(), std::make_pair(offset, 0),
                 [](const std::pair<ui64, ui16>& offsetAndPartNo, const TDataKey& p) { return offsetAndPartNo.first < p.Key.GetOffset() || offsetAndPartNo.first == p.Key.GetOffset() && offsetAndPartNo.second < p.Key.GetPartNo();});
         if (it != DataKeysBody.begin())


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Мог случаться OOM в сессии чтения если из одной сессии чтения читать топик с большим кол-вом партиции

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

SPI-183603
https://github.com/ydb-platform/ydb/issues/33455
