### PR TITLE
Fix `/healthcheck` access for `enforce_user_token_requirement`

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -664,7 +664,7 @@ void TKikimrRunner::InitializeMonitoringLogin(const TKikimrRunConfig&)
         Monitoring->RegisterActorHandler({
             .Path = "/login",
             .Handler = MakeWebLoginServiceId(),
-            .UseAuth = false, // we don't require token for the login page - it's the page to get the token
+            .AuthMode = TMon::EAuthMode::Disabled, // we don't require token for the login page - it's the page to get the token
         });
         Monitoring->RegisterActorHandler({
             .Path = "/logout",

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -3960,7 +3960,7 @@ public:
                 .RelPath = "status",
                 .ActorSystem = TActivationContext::ActorSystem(),
                 .ActorId = SelfId(),
-                .UseAuth = false,
+                .AuthMode = TMon::EAuthMode::Disabled,
             });
         }
         Become(&THealthCheckService::StateWork);

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -169,7 +169,7 @@ IMonPage* TMon::RegisterActorPage(TIndexMonPage* index, const TString& relPath,
         .Index = index,
         .PreTag = preTag,
         .ActorId = actorId,
-        .UseAuth = useAuth,
+        .AuthMode = useAuth ? TMon::EAuthMode::Enforce : TMon::EAuthMode::Disabled,
         .SortPages = sortPages,
     });
 }
@@ -518,6 +518,11 @@ public:
         if (result.UserToken) {
             AuditCtx.SetSubjectType(result.UserToken->GetSubjectType());
             Event->Get()->UserToken = result.UserToken->GetSerializedToken();
+        }
+        if (ActorMonPage->AuthMode == TMon::EAuthMode::ExtractOnly) {
+            // Extract token but don't enforce authorization - let the handler decide
+            SendRequest(&result);
+            return;
         }
         if (result.Status != Ydb::StatusIds::SUCCESS) {
             return ReplyErrorAndPassAway(result);
@@ -994,7 +999,7 @@ public:
     void Bootstrap() {
         AuditCtx.InitAudit(Event);
         Send(Event->Sender, new NHttp::TEvHttpProxy::TEvSubscribeForCancel(), IEventHandle::FlagTrackDelivery);
-        if (Fields.UseAuth && Authorizer) {
+        if (Fields.AuthMode != TMon::EAuthMode::Disabled && Authorizer) {
             NActors::IEventHandle* handle = Authorizer(SelfId(), Event->Get()->Request.Get());
             if (handle) {
                 Send(handle);
@@ -1141,6 +1146,11 @@ public:
             AuditCtx.SetSubjectType(result.UserToken->GetSubjectType());
             Event->Get()->UserToken = result.UserToken->GetSerializedToken();
         }
+        if (Fields.AuthMode == TMon::EAuthMode::ExtractOnly) {
+            // Extract token but don't enforce authorization - let the handler decide
+            SendRequest(&result);
+            return;
+        }
         if (result.Status != Ydb::StatusIds::SUCCESS) {
             return ReplyErrorAndPassAway(result);
         }
@@ -1192,13 +1202,18 @@ public:
     TMon::TRequestAuthorizer Authorizer;
     NMonitoring::NAudit::TAuditCtx AuditCtx;
     bool NeedAudit;
+    TMon::EAuthMode AuthMode;
 
-    THttpMonAuthorizedPageRequest(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, NMonitoring::IMonPage* page, TVector<TString> allowedSIDs, TMon::TRequestAuthorizer authorizer, bool needAudit = true)
+    THttpMonAuthorizedPageRequest(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, NMonitoring::IMonPage* page,
+        TVector<TString> allowedSIDs, TMon::TRequestAuthorizer authorizer, bool needAudit = true,
+        TMon::EAuthMode authMode = TMon::EAuthMode::Enforce
+    )
         : Event(std::move(event))
         , Container(Event->Get()->Request, page)
         , AllowedSIDs(std::move(allowedSIDs))
         , Authorizer(std::move(authorizer))
         , NeedAudit(needAudit)
+        , AuthMode(authMode)
     {}
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -1324,6 +1339,11 @@ public:
             AuditCtx.SetSubjectType(result.UserToken->GetSubjectType());
             Event->Get()->UserToken = result.UserToken->GetSerializedToken();
         }
+        if (AuthMode == TMon::EAuthMode::ExtractOnly) {
+            // Extract token but don't enforce authorization - let the handler decide
+            ProcessRequest();
+            return;
+        }
         if (result.Status != Ydb::StatusIds::SUCCESS) {
             return ReplyErrorAndPassAway(result);
         }
@@ -1348,14 +1368,19 @@ class THttpMonPageService : public TActor<THttpMonPageService> {
     TIntrusivePtr<NMonitoring::IMonPage> Page;
     TMon::TRequestAuthorizer Authorizer;
     TVector<TString> AllowedSIDs;
+    TMon::EAuthMode AuthMode;
 
 public:
-    THttpMonPageService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring::IMonPage> page, TMon::TRequestAuthorizer authorizer = {}, TVector<TString> allowedSIDs = {})
+THttpMonPageService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring::IMonPage> page,
+    TMon::TRequestAuthorizer authorizer = {}, TVector<TString> allowedSIDs = {},
+    TMon::EAuthMode authMode = TMon::EAuthMode::Enforce
+)
         : TActor(&THttpMonPageService::StateWork)
         , HttpProxyActorId(httpProxyActorId)
         , Page(std::move(page))
         , Authorizer(std::move(authorizer))
         , AllowedSIDs(std::move(allowedSIDs))
+        , AuthMode(authMode)
     {
     }
 
@@ -1390,7 +1415,9 @@ public:
         if (ev->Get()->Request->Method == "OPTIONS") {
             return ReplyWithOptions(ev);
         }
-        Register(new THttpMonAuthorizedPageRequest(std::move(ev), Page.Get(), AllowedSIDs, Authorizer));
+        Register(new THttpMonAuthorizedPageRequest(
+            std::move(ev), Page.Get(), AllowedSIDs, Authorizer, /* authMode */ true, AuthMode)
+        );
     }
 
     STATEFN(StateWork) {
@@ -1587,7 +1614,7 @@ void TMon::RegisterLwtrace() {
     RegisterActorHandler({
         .Path = "/trace",
         .Handler = HttpAuthMonServiceActorId,
-        .UseAuth = true,
+        .AuthMode = TMon::EAuthMode::Enforce,
         .AllowedSIDs = monitoringAllowedSIDs,
     });
 }
@@ -1741,7 +1768,8 @@ NMonitoring::IMonPage* TMon::RegisterActorPage(TRegisterActorPageFields fields) 
         fields.ActorSystem,
         fields.ActorId,
         fields.AllowedSIDs ? fields.AllowedSIDs : Config.AllowedSIDs,
-        fields.UseAuth ? Config.Authorizer : TRequestAuthorizer(),
+        fields.AuthMode != TMon::EAuthMode::Disabled ? Config.Authorizer : TRequestAuthorizer(),
+        fields.AuthMode,
         fields.MonServiceName);
     if (fields.Index) {
         fields.Index->Register(page);

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1416,7 +1416,7 @@ THttpMonPageService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring:
             return ReplyWithOptions(ev);
         }
         Register(new THttpMonAuthorizedPageRequest(
-            std::move(ev), Page.Get(), AllowedSIDs, Authorizer, /* authMode */ true, AuthMode)
+            std::move(ev), Page.Get(), AllowedSIDs, Authorizer, /* needAudit */ true, AuthMode)
         );
     }
 

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -23,6 +23,12 @@ void MakeJsonErrorReply(NJson::TJsonValue& jsonResponse, TString& message, const
 
 class TMon {
 public:
+    enum class EAuthMode {
+        Disabled,      // Don't check authorization
+        Enforce,       // Check authorization in monitoring layer
+        ExtractOnly    // Extract token only, check authorization in handler
+    };
+
     using TRequestAuthorizer = std::function<IEventHandle*(const TActorId& owner, NHttp::THttpIncomingRequest* request)>;
 
     static IEventHandle* DefaultAuthorizer(const TActorId& owner, NHttp::THttpIncomingRequest* request);
@@ -43,6 +49,7 @@ public:
         TDuration InactivityTimeout = TDuration::Minutes(2);
         TString AllowOrigin;
         bool RequireCountersAuthentication = false;
+        bool RequireHealthcheckAuthentication = false;
     };
 
     TMon(TConfig config);
@@ -62,7 +69,7 @@ public:
         NMonitoring::TIndexMonPage* Index;
         bool PreTag = false;
         TActorId ActorId;
-        bool UseAuth = true;
+        EAuthMode AuthMode = EAuthMode::Enforce;
         TVector<TString> AllowedSIDs;
         bool SortPages = true;
         TString MonServiceName = "utils";
@@ -77,7 +84,7 @@ public:
     struct TRegisterHandlerFields {
         TString Path;
         TActorId Handler;
-        bool UseAuth = true;
+        EAuthMode AuthMode = EAuthMode::Enforce;
         TVector<TString> AllowedSIDs;
     };
 
@@ -120,4 +127,4 @@ protected:
     void RegisterActorMonPage(const TActorMonPageInfo& pageInfo);
 };
 
-} // NActors
+} // namespace NActors

--- a/ydb/core/mon/mon_impl.h
+++ b/ydb/core/mon/mon_impl.h
@@ -142,7 +142,8 @@ class TActorMonPage: public IMonPage {
 public:
     TActorMonPage(const TString &path, const TString &title, const TString &host, bool preTag,
                     TActorSystem *actorSystem, const TActorId &actorId, const TVector<TString> &sids,
-                    TMon::TRequestAuthorizer authorizer, TString monServiceName = "utils")
+                    TMon::TRequestAuthorizer authorizer, TMon::EAuthMode authMode = TMon::EAuthMode::Enforce,
+                    TString monServiceName = "utils")
         : IMonPage(path, title)
         , Host(host)
         , PreTag(preTag)
@@ -150,6 +151,7 @@ public:
         , TargetActorId(actorId)
         , AllowedSIDs(sids)
         , Authorizer(std::move(authorizer))
+        , AuthMode(authMode)
         , MonServiceName(monServiceName)
     {
     }
@@ -164,6 +166,7 @@ public:
     TActorId TargetActorId;
     const TVector<TString> AllowedSIDs;
     TMon::TRequestAuthorizer Authorizer;
+    TMon::EAuthMode AuthMode;
     TString MonServiceName;
 };
 

--- a/ydb/core/mon/mon_ut.cpp
+++ b/ydb/core/mon/mon_ut.cpp
@@ -43,7 +43,7 @@ struct THttpMonTestEnvOptions {
     ERegKind RegKind = ERegKind::None;
     TVector<TString> ActorAllowedSIDs;
     TVector<TString> TicketParserGroupSIDs = DEFAULT_TICKET_PARSER_GROUPS;
-    bool UseAuth = true;
+    TMon::EAuthMode AuthMode = TMon::EAuthMode::Enforce;
 };
 
 class THttpMonTestEnv {
@@ -91,7 +91,7 @@ public:
                     .RelPath = TEST_MON_PATH,
                     .ActorSystem = Runtime->GetActorSystem(0),
                     .ActorId = TestActorId,
-                    .UseAuth = Options.UseAuth,
+                    .AuthMode = Options.AuthMode,
                     .AllowedSIDs = Options.ActorAllowedSIDs,
                 });
                 break;
@@ -102,7 +102,7 @@ public:
                 mon->RegisterActorHandler({
                     .Path = MakeDefaultUrl(),
                     .Handler = TestActorId,
-                    .UseAuth = Options.UseAuth,
+                    .AuthMode = Options.AuthMode,
                     .AllowedSIDs = Options.ActorAllowedSIDs,
                 });
                 break;
@@ -217,7 +217,7 @@ Y_UNIT_TEST_SUITE(ActorPage) {
     Y_UNIT_TEST(NoUseAuthOk) {
         THttpMonTestEnv env({
             .RegKind = THttpMonTestEnvOptions::ERegKind::ActorPage,
-            .UseAuth = false,
+            .AuthMode = TMon::EAuthMode::Disabled,
         });
 
         TStringStream responseStream;
@@ -308,7 +308,7 @@ Y_UNIT_TEST_SUITE(ActorHandler) {
     Y_UNIT_TEST(NoUseAuthOk) {
         THttpMonTestEnv env({
             .RegKind = THttpMonTestEnvOptions::ERegKind::ActorHandler,
-            .UseAuth = false,
+            .AuthMode = TMon::EAuthMode::Disabled,
         });
 
         TStringStream responseStream;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -620,6 +620,7 @@ message TMonitoringConfig {
     optional string InactivityTimeout = 18 [default = "2m"];
     optional bool HideHttpEndpoint = 19 [default = false];
     optional bool RequireCountersAuthentication = 21 [default = false];
+    optional bool RequireHealthcheckAuthentication = 22 [default = false];
 }
 
 message TRestartsCountConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -620,7 +620,6 @@ message TMonitoringConfig {
     optional string InactivityTimeout = 18 [default = "2m"];
     optional bool HideHttpEndpoint = 19 [default = false];
     optional bool RequireCountersAuthentication = 21 [default = false];
-    optional bool RequireHealthcheckAuthentication = 22 [default = false];
 }
 
 message TRestartsCountConfig {

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -103,14 +103,14 @@ public:
                 .RelPath = "viewer",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = true,
+                .AuthMode = TMon::EAuthMode::Enforce,
                 .AllowedSIDs = databaseAllowedSIDs,
             });
             mon->RegisterActorPage({
                 .RelPath = "viewer/capabilities",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = false,
+                .AuthMode = TMon::EAuthMode::Disabled,
             });
             mon->RegisterActorPage({
                 .Title = "Viewer",
@@ -123,60 +123,63 @@ public:
                 .RelPath = "monitoring",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = false,
+                .AuthMode = TMon::EAuthMode::Disabled,
             });
             mon->RegisterActorPage({
                 .RelPath = "counters/hosts",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = false,
+                .AuthMode = TMon::EAuthMode::Disabled,
             });
+            // For healthcheck, always extract token if enforce_user_token_requirement is enabled, so access can be checked in handler.
+            const bool enforceUserToken = KikimrRunConfig.AppConfig.GetDomainsConfig().GetSecurityConfig().GetEnforceUserTokenRequirement();
             mon->RegisterActorPage({
                 .RelPath = "healthcheck",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = false, // auth is checked inside handler
+                .AuthMode = enforceUserToken ? TMon::EAuthMode::ExtractOnly : TMon::EAuthMode::Disabled,
+                .AllowedSIDs = enforceUserToken ? databaseAllowedSIDs : TVector<TString>(),
             });
             mon->RegisterActorPage({
                 .RelPath = "vdisk",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = true,
+                .AuthMode = TMon::EAuthMode::Enforce,
                 .AllowedSIDs = viewerAllowedSIDs,
             });
             mon->RegisterActorPage({
                 .RelPath = "pdisk",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = true,
+                .AuthMode = TMon::EAuthMode::Enforce,
                 .AllowedSIDs = viewerAllowedSIDs,
             });
             mon->RegisterActorPage({
                 .RelPath = "operation",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = true,
+                .AuthMode = TMon::EAuthMode::Enforce,
                 .AllowedSIDs = databaseAllowedSIDs,
             });
             mon->RegisterActorPage({
                 .RelPath = "query",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = true,
+                .AuthMode = TMon::EAuthMode::Enforce,
                 .AllowedSIDs = databaseAllowedSIDs,
             });
             mon->RegisterActorPage({
                 .RelPath = "scheme",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = true,
+                .AuthMode = TMon::EAuthMode::Enforce,
                 .AllowedSIDs = databaseAllowedSIDs,
             });
             mon->RegisterActorPage({
                 .RelPath = "storage",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = true,
+                .AuthMode = TMon::EAuthMode::Enforce,
                 .AllowedSIDs = databaseAllowedSIDs,
             });
             if (!KikimrRunConfig.AppConfig.GetMonitoringConfig().GetHideHttpEndpoint()) {
@@ -218,7 +221,7 @@ public:
                     mon->RegisterActorHandler({
                         .Path = name,
                         .Handler = ctx.SelfID,
-                        .UseAuth = true,
+                        .AuthMode = TMon::EAuthMode::Enforce,
                         .AllowedSIDs = databaseAllowedSIDs,
                     });
                 }

--- a/ydb/tests/functional/security/test_mon_endpoints_auth.py
+++ b/ydb/tests/functional/security/test_mon_endpoints_auth.py
@@ -198,9 +198,9 @@ EXPECTED_RESULTS_WITH_ENFORCE_USER_TOKEN = {
         'user@builtin': 403,
         'database@builtin': 403,
         'viewer@builtin': 403,
-        'monitoring@builtin': 403,
-        'root@builtin': 403,
-    },  # TODO(yurikiselev): Fix 403 for admins (issue #33400)
+        'monitoring@builtin': 200,
+        'root@builtin': 200,
+    },
     '/ping': {
         None: 200,
         'user@builtin': 200,


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
По идее это баг, но не в проде – оставил категорию Not for changelog.

Хелсчек в режиме `UseAuth = false` должен проверять аутентификацию внутри хендлера https://github.com/ydb-platform/ydb/blob/129c91e2594c63842ba1cd020363da17dbfaf98f/ydb/core/viewer/viewer_healthcheck.h#L92, но это не получается сделать, т.к. токен не извлекаеся. Добавил `EAuthMode`, чтобы можно было работать в режимах: без аутентификации (`Disabled`), аутентификация обычная внутри мониторинга (`Enforce`), аутентификация внутри хендлера с извлеченим токена (`ExtractOnly`).