### PR TITLE
remove unused TThrRefBase base class from the public interface ISimpleBlockingWriteSession

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
@@ -232,7 +232,7 @@ public:
 };
 
 //! Simple write session. Does not need event handlers. Does not provide Events, ContinuationTokens, write Acks.
-class ISimpleBlockingWriteSession : public TThrRefBase {
+class ISimpleBlockingWriteSession {
 public:
     //! Write single message. Blocks for up to blockTimeout if inflight is full or memoryUsage is exceeded;
     //! return - true if write succeeded, false if message was not enqueued for write within blockTimeout.

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/include/write_session.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/include/write_session.h
@@ -137,7 +137,7 @@ struct TWriteSessionSettings : public TRequestSettings<TWriteSessionSettings> {
 };
 
 //! Simple write session. Does not need event handlers. Does not provide Events, ContinuationTokens, write Acks.
-class ISimpleBlockingWriteSession : public TThrRefBase {
+class ISimpleBlockingWriteSession {
 public:
     //! Write single message. Blocks for up to blockTimeout if inflight is full or memoryUsage is exceeded;
     //! return - true if write succeeded, false if message was not enqueued for write within blockTimeout.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TThrRefBase нужен для TIntrusivePtr, а везде в коде используется std::shared_ptr.
Нужно оставить только один тип умных указателей:
Во-первых, это лишнее поле.
Во-вторых, при попытке воспользоваться TIntrusivePtr случиться double-free или какая-нибудь подобная пакость, так как два умных указателя не будут знать друг о друге.

зелёная проверка в apкaдии https://nda.ya.ru/t/LCTg7Lwm7Tn4kb