### PR TITLE
[Backport stable-25-4-1] PR #33057: Fix c-ares race condition in Workload Manager tests (#31876)#33187

### DIFF
--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
@@ -316,6 +316,7 @@ namespace {
         }
 
         auto result = TKqpFederatedQuerySetup{
+            Driver,
             HttpGateway,
             ConnectorClient,
             CredentialsFactory,
@@ -332,7 +333,7 @@ namespace {
             PqGatewayConfig,
             PqGateway,
             ActorSystemPtr,
-            Driver};
+        };
 
         // Init DatabaseAsyncResolver only if all requirements are met
         if (DatabaseResolverActorId && MdbEndpointGenerator &&

--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.h
@@ -50,6 +50,11 @@ namespace NKikimr::NKqp {
     NYql::IPqGateway::TPtr MakePqGateway(const std::shared_ptr<NYdb::TDriver>& driver);
 
     struct TKqpFederatedQuerySetup {
+        // This Driver must be declared FIRST in this struct.
+        // Placing it first (destruction is in reverse order) ensures
+        // it outlives all other objects here that might hold
+        // gRPC contexts, preventing deadlocks during graceful shutdown.
+        std::shared_ptr<NYdb::TDriver> Driver;
         NYql::IHTTPGateway::TPtr HttpGateway;
         NYql::NConnector::IClient::TPtr ConnectorClient;
         NYql::ISecuredServiceAccountCredentialsFactory::TPtr CredentialsFactory;
@@ -66,7 +71,6 @@ namespace NKikimr::NKqp {
         NYql::TPqGatewayConfig PqGatewayConfig;
         NYql::IPqGateway::TPtr PqGateway;
         NKikimr::TDeferredActorLogBackend::TSharedAtomicActorSystemPtr ActorSystemPtr;
-        std::shared_ptr<NYdb::TDriver> Driver;
     };
 
     struct IKqpFederatedQuerySetupFactory {
@@ -158,11 +162,11 @@ namespace NKikimr::NKqp {
 
         std::optional<TKqpFederatedQuerySetup> Make(NActors::TActorSystem*) override {
             return TKqpFederatedQuerySetup{
-                HttpGateway, ConnectorClient, CredentialsFactory,
+                Driver, HttpGateway, ConnectorClient, CredentialsFactory,
                 DatabaseAsyncResolver, S3GatewayConfig, GenericGatewayConfig,
                 YtGatewayConfig, YtGateway, SolomonGatewayConfig,
                 SolomonGateway, ComputationFactory, S3ReadActorFactoryConfig,
-                DqTaskTransformFactory, PqGatewayConfig, PqGateway, ActorSystemPtr, Driver};
+                DqTaskTransformFactory, PqGatewayConfig, PqGateway, ActorSystemPtr};
         }
 
         void Cleanup() override {

--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.h
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.h
@@ -40,7 +40,12 @@ namespace NKikimr::NKqp {
 
     NYdb::NTopic::TTopicClientSettings MakeCommonTopicClientSettings(ui64 handlersExecutorThreadsNum, ui64 compressionExecutorThreadsNum);
 
-    std::shared_ptr<NYdb::TDriver> MakeYdbDriver(NKikimr::TDeferredActorLogBackend::TSharedAtomicActorSystemPtr actorSystemPtr, const NKikimrConfig::TStreamingQueriesConfig_TExternalTopicsSettings& config);
+    std::unique_ptr<NYdb::TDriver> MakeYdbDriver(NKikimr::TDeferredActorLogBackend::TSharedAtomicActorSystemPtr actorSystemPtr, const NKikimrConfig::TStreamingQueriesConfig_TExternalTopicsSettings& config);
+
+    ///
+    /// This method creates a shared YDB driver that will be gracefully stopped before destruction.
+    ///
+    std::shared_ptr<NYdb::TDriver> MakeSharedYdbDriverWithStop(std::unique_ptr<NYdb::TDriver> driver);
 
     NYql::IPqGateway::TPtr MakePqGateway(const std::shared_ptr<NYdb::TDriver>& driver);
 

--- a/ydb/core/kqp/ut/common/kqp_ut_common.cpp
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.cpp
@@ -634,6 +634,9 @@ void TKikimrRunner::CreateSampleTables() {
             (9, 4, 13, "94", 2);
     )", TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).GetValueSync());
 
+    auto r = session.Close().GetValueSync();
+    client.Stop();
+    driver.Stop(true);
 }
 
 static TMaybe<NActors::NLog::EPriority> ParseLogLevel(const TString& level) {

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -55,7 +55,7 @@ TIntrusivePtr<IKqpHost> CreateKikimrQueryProcessor(TIntrusivePtr<IKqpGateway> ga
     UNIT_ASSERT(TryParseFromTextFormat(defaultSettingsStream, defaultSettings));
     kikimrConfig->Init(defaultSettings.GetDefaultSettings(), cluster, settings, true);
 
-    auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({NYql::IHTTPGateway::Make(), nullptr, nullptr, nullptr, {}, {}, {}, nullptr, {}, nullptr, nullptr, {}, nullptr, {}, nullptr, nullptr, nullptr});
+    auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({nullptr, NYql::IHTTPGateway::Make(), nullptr, nullptr, nullptr, {}, {}, {}, nullptr, {}, nullptr, nullptr, {}, nullptr, {}, nullptr, nullptr});
     return NKqp::CreateKqpHost(gateway, cluster, "/Root", kikimrConfig, moduleResolver,
                                federatedQuerySetup, nullptr, nullptr, NKikimrConfig::TQueryServiceConfig(), {}, funcRegistry, funcRegistry, keepConfigChanges, nullptr, actorSystem, nullptr);
 }

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -11,7 +11,8 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
-
+#include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
+#include <ydb/library/yql/utils/actor_log/log.h>
 
 namespace NKikimr::NKqp::NWorkload {
 
@@ -245,7 +246,44 @@ IActor* CreateFakeTicketParser(const TTicketParserSettings&) {
     return new TFakeTicketParserActor();
 }
 
+///
+/// The HttpGateway is created as a singleton and stored in a shared_ptr.
+/// The HttpGateway is destroyed when its reference count reaches zero.
+///
+/// Destruction triggers the cleanup of libcurl, which in turn clears c-ares.
+/// During tests, this can race with gRPC threads that also use c-ares.
+///
+/// This class holds a reference to the HttpGateway during test execution
+/// to prevent repeated create/destroy/create cycles.
+///
+/// HttpGateway requires logging, so LoggerScope must be created before
+/// the HttpGateway is initialized
+///
+struct TGlobalObjectHolder {
+    std::shared_ptr<NYql::NLog::YqlLoggerScope> LoggerScope;
+    NYql::IHTTPGateway::TPtr HttpGateway;
+
+    TGlobalObjectHolder()
+        : LoggerScope(std::make_shared<NYql::NLog::YqlLoggerScope>(
+            new NYql::NLog::TTlsLogBackend(new TNullLogBackend())
+          ))
+        , HttpGateway(NYql::IHTTPGateway::Make())
+    {}
+
+    ~TGlobalObjectHolder() {
+        // By this point, all threads using c-ares must be stopped.
+        // Use this line to set a breakpoint while debugging c-ares races.
+        HttpGateway.reset();
+        LoggerScope.reset();
+    }
+};
+
 // Ydb setup
+const TGlobalObjectHolder& GetGlobalObjectHolder() {
+    static const TGlobalObjectHolder holder_;
+    Y_ENSURE(holder_.HttpGateway);
+    return holder_;
+}
 
 class TWorkloadServiceYdbSetup : public IYdbSetup {
 private:
@@ -293,6 +331,10 @@ private:
             .SetFeatureFlags(appConfig.GetFeatureFlags())
             .SetInitializeFederatedQuerySetupFactory(true);
 
+        if (Settings_.WorkSafeWithGlobalObjects_) {
+            serverSettings.SetKqpLoggerScope(GetGlobalObjectHolder().LoggerScope);
+        }
+
         if (Settings_.CreateSampleTenants_) {
             const auto dedicatedPoolKind = SplitPath(Settings_.GetDedicatedTenantName()).back();
             const auto sharedPoolKind = SplitPath(Settings_.GetSharedTenantName()).back();
@@ -305,7 +347,6 @@ private:
         SetLoggerSettings(serverSettings);
 
         serverSettings.CreateTicketParser = CreateFakeTicketParser;
-
         return serverSettings;
     }
 
@@ -389,9 +430,21 @@ public:
     explicit TWorkloadServiceYdbSetup(const TYdbSetupSettings& settings)
         : Settings_(settings)
     {
+        if (Settings_.WorkSafeWithGlobalObjects_) {
+            GetGlobalObjectHolder();
+        }
+
         EnableYDBBacktraceFormat();
         InitializeServer();
         CreateSamplePool();
+    }
+
+    virtual ~TWorkloadServiceYdbSetup() {
+        if (YdbDriver_) {
+            // Stop requests and wait for their completion
+            YdbDriver_->Stop(true);
+            YdbDriver_.reset();
+        }
     }
 
     void UpdateNodeCpuInfo(double usage, ui32 threads, ui64 nodeIndex = 0) override {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -87,6 +87,8 @@ struct TYdbSetupSettings {
     FLUENT_SETTING_DEFAULT(double, QueryMemoryLimitPercentPerNode, -1);
     FLUENT_SETTING_DEFAULT(double, DatabaseLoadCpuThreshold, -1);
 
+    FLUENT_SETTING_DEFAULT(bool, WorkSafeWithGlobalObjects, true);
+
     NResourcePool::TPoolSettings GetDefaultPoolSettings() const;
     TIntrusivePtr<IYdbSetup> Create() const;
 

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
@@ -7,14 +7,12 @@
 #include <ydb/core/kqp/workload_service/tables/table_queries.h>
 #include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
 
-
 namespace NKikimr::NKqp {
 
 namespace {
 
 using namespace NActors;
 using namespace NWorkload;
-
 
 void CheckPoolDescription(TIntrusivePtr<IYdbSetup> ydb, ui64 expectedQueueSize, ui64 expectedInFlight, TDuration leaseDuration = FUTURE_WAIT_TIMEOUT) {
     const auto& description = ydb->GetPoolDescription(leaseDuration);
@@ -48,7 +46,7 @@ void StartRequest(TIntrusivePtr<IYdbSetup> ydb, const TString& sessionId, TDurat
 }  // anonymous namespace
 
 Y_UNIT_TEST_SUITE(KqpWorkloadServiceTables) {
-    Y_UNIT_TEST(TestCreateWorkloadSerivceTables) {
+    Y_UNIT_TEST(TestCreateWorkloadServiceTables) {
         constexpr ui32 nodesCount = 5;
         auto ydb = TYdbSetupSettings()
             .NodeCount(nodesCount)

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -828,7 +828,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
     }
 
     void WaitForSuccess(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings) {
-        ydb->WaitFor(TDuration::Seconds(20), "Resource pool classifier success", [ydb, settings](TString& errorString) {
+        ydb->WaitFor(TDuration::Seconds(30), "Resource pool classifier success", [ydb, settings](TString& errorString) {
             auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
 
             errorString = result.GetIssues().ToOneLineString();

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1359,7 +1359,7 @@ namespace Tests {
                 }
 
                 auto uniqueDriver = NKqp::MakeYdbDriver(actorSystemPtr, queryServiceConfig.GetStreamingQueries().GetTopicSdkSettings());
-                auto FederatedQuerySetupDriver_ = NKqp::MakeSharedYdbDriverWithStop(std::move(uniqueDriver));
+                FederatedQuerySetupDriver_ = NKqp::MakeSharedYdbDriverWithStop(std::move(uniqueDriver));
                 auto pqGateway = NKqp::MakePqGateway(FederatedQuerySetupDriver_);
 
                 federatedQuerySetupFactory = std::make_shared<NKikimr::NKqp::TKqpFederatedQuerySetupFactoryMock>(

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -430,6 +430,14 @@ namespace Tests {
         const bool UseStoragePools;
 
         std::shared_ptr<void> KqpLoggerScope;
+        // This Driver is used exclusively by TKqpFederatedQuerySetup
+        // (DO NOT USE IT IN A TSERVER), but is stored here in
+        // TServer to ensure it outlives TTestActorRuntime. During
+        // graceful shutdown, the Driver must be destroyed after all
+        // actors are gone; otherwise, lingering gRPC contexts or
+        // background operations can cause the gRPC client to hang
+        // or trigger use-after-free during its destruction.
+        std::shared_ptr<NYdb::TDriver> FederatedQuerySetupDriver_;
         THolder<TTestActorRuntime> Runtime;
         THolder<NYdb::TDriver> Driver;
         TIntrusivePtr<NBus::TBusMessageQueue> Bus;

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -191,7 +191,9 @@ namespace Tests {
         std::function<IActor*(const TTokenManagerSettings&)> CreateTokenManager = NKikimr::CreateTokenManager;
         std::shared_ptr<TGrpcServiceFactory> GrpcServiceFactory;
         std::shared_ptr<NYql::NDq::IS3ActorsFactory> S3ActorsFactory = NYql::NDq::CreateDefaultS3ActorsFactory();
+        std::shared_ptr<void> KqpLoggerScope;
 
+        TServerSettings& SetKqpLoggerScope(std::shared_ptr<void> value) { KqpLoggerScope = value; return *this; }
         TServerSettings& SetGrpcPort(ui16 value) { GrpcPort = value; return *this; }
         TServerSettings& SetGrpcHost(TString value) { GrpcHost = value; return *this; }
         TServerSettings& SetGrpcMaxMessageSize(int value) { GrpcMaxMessageSize = value; return *this; }

--- a/ydb/tools/query_replay/query_compiler.cpp
+++ b/ydb/tools/query_replay/query_compiler.cpp
@@ -297,7 +297,7 @@ public:
 
         Gateway = CreateKikimrIcGateway(Query->Cluster, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY, Query->Database, Query->DatabaseId, std::move(loader),
             TActivationContext::ActorSystem(), SelfId().NodeId(), counters);
-        auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({NYql::IHTTPGateway::Make(), nullptr, nullptr, nullptr, {}, {}, {}, nullptr, {}, nullptr, nullptr, {}, nullptr, {}, nullptr, nullptr, nullptr});
+        auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({nullptr, NYql::IHTTPGateway::Make(), nullptr, nullptr, nullptr, {}, {}, {}, nullptr, {}, nullptr, nullptr, {}, nullptr, {}, nullptr, nullptr});
         KqpHost = CreateKqpHost(Gateway, Query->Cluster, Query->Database, Config, ModuleResolverState->ModuleResolver,
             federatedQuerySetup, nullptr, GUCSettings, NKikimrConfig::TQueryServiceConfig(), Nothing(), FunctionRegistry, false);
 

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -576,7 +576,7 @@ private:
 
         Gateway = CreateKikimrIcGateway(Query->Cluster, queryType, Query->Database, Query->DatabaseId, std::move(loader),
             TActivationContext::ActorSystem(), SelfId().NodeId(), counters);
-        auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({HttpGateway, nullptr, nullptr, nullptr, {}, {}, {}, nullptr, {}, nullptr, nullptr, {}, nullptr, {}, nullptr, nullptr, nullptr});
+        auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({nullptr, HttpGateway, nullptr, nullptr, nullptr, {}, {}, {}, nullptr, {}, nullptr, nullptr, {}, nullptr, {}, nullptr, nullptr});
         KqpHost = CreateKqpHost(Gateway, Query->Cluster, Query->Database, Config, ModuleResolverState->ModuleResolver,
             federatedQuerySetup, nullptr, GUCSettings, NKikimrConfig::TQueryServiceConfig(), Nothing(), FunctionRegistry, false);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix c-ares race condition in Workload Manager tests (#31876): Fix c-ares race condition in Workload Manager tests

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

#### Original PR(s)
* PR https://github.com/ydb-platform/ydb/pull/33057

#### Metadata
- **Original PR author(s):** @buhtr
- **Cherry-picked by:** @buhtr
- **Related issues:** #31876