### PR TITLE
Prepare for TCheckedDerefPtr

### DIFF
--- a/ydb/core/kqp/opt/kqp_type_ann.cpp
+++ b/ydb/core/kqp/opt/kqp_type_ann.cpp
@@ -1315,7 +1315,7 @@ TStatus AnnotateOlapProjections(const TExprNode::TPtr& node, TExprContext& ctx) 
     const auto* projections = node->Child(TKqpOlapProjections::idx_Projections);
     for (const auto& expr : TExprBase(projections).Cast<TExprList>()) {
         auto projection = TExprBase(expr).Cast<TKqpOlapProjection>();
-        const auto* projectionTypeAnn = projection.Ptr()->GetTypeAnn();
+        const auto projectionTypeAnn = projection.Ptr()->GetTypeAnn();
         // Expecting annotation for projection.
         if (!projectionTypeAnn) {
             return TStatus::Repeat;
@@ -1444,7 +1444,7 @@ bool ValidateOlapJsonOperation(const TExprNode::TPtr& node, TExprContext& ctx) {
         return false;
     }
     auto path = node->Child(TKqpOlapJsonOperationBase::idx_Path);
-    auto *pathTypeAnn = path->GetTypeAnn();
+    auto pathTypeAnn = path->GetTypeAnn();
     if (pathTypeAnn->GetKind() != ETypeAnnotationKind::Data || pathTypeAnn->Cast<TDataExprType>()->GetSlot() != EDataSlot::Utf8) {
         ctx.AddError(TIssue(ctx.GetPosition(node->Pos()),
             TStringBuilder() << "Expected Utf8 as path in OLAP JSON function, got: " << path->Content()
@@ -2569,8 +2569,8 @@ TStatus AnnotateOpMap(const TExprNode::TPtr& input, TExprContext& ctx, TTypeAnno
 
     for (size_t idx = 0; idx < input->ChildPtr(TKqpOpMap::idx_MapElements)->ChildrenSize(); idx++) {
         auto& element = input->ChildPtr(TKqpOpMap::idx_MapElements)->ChildRef(idx);
-        auto type = element->GetTypeAnn();
-        structItemTypes.push_back((TItemExprType*)type);
+        auto type = (const TTypeAnnotationNode*)element->GetTypeAnn();
+        structItemTypes.push_back((const TItemExprType*)type);
     }
 
     auto resultItemType = ctx.MakeType<TStructExprType>(structItemTypes);
@@ -2712,7 +2712,7 @@ TStatus AnnotateOpSort(const TExprNode::TPtr& input, TExprContext& ctx) {
 }
 
 TStatus AnnotateOpAggregate(const TExprNode::TPtr& input, TExprContext& ctx) {
-    const auto* inputType = input->ChildPtr(TKqpOpAggregate::idx_Input)->GetTypeAnn();
+    const auto inputType = input->ChildPtr(TKqpOpAggregate::idx_Input)->GetTypeAnn();
     const auto* structType = inputType->Cast<TListExprType>()->GetItemType()->Cast<TStructExprType>();
     auto opAggregate = TKqpOpAggregate(input);
 

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_build_stage.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_build_stage.cpp
@@ -88,7 +88,7 @@ TMaybeNode<TDqPhyPrecompute> BuildLookupKeysPrecompute(const TExprBase& input, T
 
 bool IsLiteralNothing(TExprBase node) {
     if (node.Maybe<TCoNothing>()) {
-        auto* type = node.Raw()->GetTypeAnn();
+        auto type = node.Raw()->GetTypeAnn();
         switch (type->GetKind()) {
             case ETypeAnnotationKind::Optional: {
                 type = type->Cast<TOptionalExprType>()->GetItemType();
@@ -636,7 +636,7 @@ NYql::NNodes::TExprBase KqpRewriteLookupTablePhy(NYql::NNodes::TExprBase node, N
 }
 
 NYql::NNodes::TExprBase KqpPrecomputeParameter(NYql::NNodes::TExprBase param, NYql::TExprContext& ctx) {
-    auto* type = param.Raw()->GetTypeAnn();
+    auto type = param.Raw()->GetTypeAnn();
     YQL_ENSURE(type);
     if (type->GetKind() == ETypeAnnotationKind::Optional) {
         param = Build<TCoUnwrap>(ctx, param.Pos())

--- a/ydb/core/kqp/opt/rbo/kqp_rewrite_select.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rewrite_select.cpp
@@ -1584,7 +1584,7 @@ TExprNode::TPtr RewriteSelect(const TExprNode::TPtr& node, TExprContext& ctx, co
                         .Done().Ptr();
 
                     if (!columnType) {
-                        YQL_CLOG(TRACE, CoreDq) << "didn't find " << inputColumn->Content() << " in: " << *(TTypeAnnotationNode*)itemType;
+                        YQL_CLOG(TRACE, CoreDq) << "didn't find " << inputColumn->Content() << " in: " << *(const TTypeAnnotationNode*)itemType;
                     }
                     Y_ENSURE(columnType);
 

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -391,7 +391,7 @@ void FillNothingPg(const TPgExprType& pgType, Ydb::TypedValue& value) {
 }
 
 void FillNothing(TCoNothing expr, Ydb::TypedValue& value) {
-    auto* typeann = expr.Raw()->GetTypeAnn();
+    auto typeann = expr.Raw()->GetTypeAnn();
     switch (typeann->GetKind()) {
         case ETypeAnnotationKind::Optional: {
             typeann = typeann->Cast<TOptionalExprType>()->GetItemType();

--- a/ydb/library/yql/dq/opt/dq_opt_phy.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_phy.cpp
@@ -3093,7 +3093,7 @@ TExprBase DqPropagatePrecomuteTake(TExprBase node, TExprContext& ctx, IOptimizat
         return node;
     }
 
-    auto* typeAnn = precompute.Connection().Raw()->GetTypeAnn();
+    auto typeAnn = precompute.Connection().Raw()->GetTypeAnn();
 
     YQL_ENSURE(typeAnn);
     typeAnn = GetSeqItemType(typeAnn);

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -99,7 +99,7 @@ TStatus AnnotateStage(const TExprNode::TPtr& stage, TExprContext& ctx) {
             return TStatus::Error;
         }
 
-        auto* argType = input->GetTypeAnn();
+        auto argType = input->GetTypeAnn();
         if constexpr (std::is_same_v<TStage, TDqPhyStage>) {
             if (TDqConnection::Match(input.Get()) && argType->GetKind() == ETypeAnnotationKind::List) {
                 auto* itemType = argType->Cast<TListExprType>()->GetItemType();
@@ -147,7 +147,7 @@ TStatus AnnotateStage(const TExprNode::TPtr& stage, TExprContext& ctx) {
         return TStatus::Error;
     }
 
-    auto* resultType = programLambda->GetTypeAnn();
+    auto resultType = programLambda->GetTypeAnn();
     if (!resultType) {
         return TStatus::Repeat;
     }
@@ -249,7 +249,7 @@ TStatus AnnotateStage(const TExprNode::TPtr& stage, TExprContext& ctx) {
             stageResultTypes.assign(programResultTypesTuple.begin(), programResultTypesTuple.end());
         } else {
             for (auto transform : transforms) {
-                auto* type = transform->GetTypeAnn();
+                auto type = transform->GetTypeAnn();
                 if (!EnsureListType(transform->Pos(), *type, ctx)) {
                     return TStatus::Error;
                 }

--- a/ydb/library/yql/providers/common/pushdown/type_ann.cpp
+++ b/ydb/library/yql/providers/common/pushdown/type_ann.cpp
@@ -19,7 +19,7 @@ IGraphTransformer::TStatus AnnotateFilterPredicate(const TExprNode::TPtr& input,
         return IGraphTransformer::TStatus::Error;
     }
 
-    if (const auto* filterLambdaType = filterLambda->GetTypeAnn()) {
+    if (const auto filterLambdaType = filterLambda->GetTypeAnn()) {
         if (filterLambdaType->GetKind() != ETypeAnnotationKind::Data) {
             return IGraphTransformer::TStatus::Error;
         }

--- a/ydb/library/yql/providers/pq/provider/yql_pq_ytflow_optimize.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_ytflow_optimize.cpp
@@ -80,7 +80,7 @@ public:
             return write;
         }
 
-        auto* listType = maybeWriteTopic.Cast().Input().Ref().GetTypeAnn();
+        auto listType = maybeWriteTopic.Cast().Input().Ref().GetTypeAnn();
         auto* itemType = listType->Cast<TListExprType>()->GetItemType();
 
         return Build<TPqWriteTopic>(ctx, write->Pos())

--- a/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_datasource_type_ann.cpp
@@ -437,7 +437,7 @@ public:
             return IGraphTransformer::TStatus::Error;
         }
 
-        if (const auto* filterLambdaType = filterLambda->GetTypeAnn()) {
+        if (const auto filterLambdaType = filterLambda->GetTypeAnn()) {
             if (filterLambdaType->GetKind() != ETypeAnnotationKind::Data) {
                 return IGraphTransformer::TStatus::Error;
             }

--- a/ydb/library/yql/providers/solomon/provider/yql_solomon_physical_optimize.cpp
+++ b/ydb/library/yql/providers/solomon/provider/yql_solomon_physical_optimize.cpp
@@ -84,7 +84,7 @@ public:
     }
 
     TMaybe<TDqStage> BuildSinkStage(TPositionHandle writePos, TSoDataSink dataSink, TCoAtom writeShard, TExprBase input, TExprContext& ctx, const TGetParents& getParents, bool allowPureStage) const {
-        const auto* typeAnn = input.Ref().GetTypeAnn();
+        const auto typeAnn = input.Ref().GetTypeAnn();
         const TTypeAnnotationNode* inputItemType = nullptr;
         if (!EnsureNewSeqType<false, true, false>(input.Pos(), *typeAnn, ctx, &inputItemType)) {
             return {};


### PR DESCRIPTION
Fixed build errors that occur when uncommenting the YQL_USE_CHECKED_DEREF_PTR_FOR_TYPE_ANN define in yql_expr.h. The define changes the return type of GetTypeAnn() from a raw pointer to TCheckedDerefPtr wrapper. Updated calling code to properly handle this type change.