### PR TITLE
streamlookup: split sensors by task id (backport #27393)

### DIFF
--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -1098,6 +1098,10 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
         lookupPayloadColumns,
         inputColumns
     );
+    auto taskCounters = args.TaskCounters;
+    if (taskCounters) {
+        taskCounters = taskCounters->GetSubgroup("task_id", ToString(args.TaskId))->GetSubgroup("input", ToString(args.InputIndex));
+    }
     if (settings.GetIsMultiget()) {
         auto actor = isWide ?
             (TInputTransformStreamMultiLookupBase*)new TInputTransformStreamMultiLookupWide(
@@ -1107,7 +1111,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
                 args.InputIndex,
                 args.TransformInput,
                 args.ComputeActorId,
-                args.TaskCounters,
+                taskCounters,
                 factory,
                 std::move(settings),
                 std::move(lookupKeyInputIndexes),
@@ -1126,7 +1130,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
                 args.InputIndex,
                 args.TransformInput,
                 args.ComputeActorId,
-                args.TaskCounters,
+                taskCounters,
                 factory,
                 std::move(settings),
                 std::move(lookupKeyInputIndexes),
@@ -1148,7 +1152,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
             args.InputIndex,
             args.TransformInput,
             args.ComputeActorId,
-            args.TaskCounters,
+            taskCounters,
             factory,
             std::move(settings),
             std::move(lookupKeyInputIndexes),
@@ -1167,7 +1171,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
             args.InputIndex,
             args.TransformInput,
             args.ComputeActorId,
-            args.TaskCounters,
+            taskCounters,
             factory,
             std::move(settings),
             std::move(lookupKeyInputIndexes),


### PR DESCRIPTION
(cherry picked from commit 69bf1c3f8013ba8e6daf4f594cb66e546982dca5)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
