### PR TITLE
EXT-1956: Introduce new MaxTracket to monitor DeviceInFlight

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
@@ -968,10 +968,12 @@ protected:
             case IAsyncIoOperation::EType::PWrite:
                 (*Mon.DeviceInFlightBytesWrite) += size;
                 Mon.DeviceInFlightWrites->Inc();
+                Mon.MaxDeviceInFlightWrites.Collect(*Mon.DeviceInFlightWrites);
                 break;
             case IAsyncIoOperation::EType::PRead:
                 (*Mon.DeviceInFlightBytesRead) += size;
                 Mon.DeviceInFlightReads->Inc();
+                Mon.MaxDeviceInFlightReads.Collect(*Mon.DeviceInFlightReads);
                 break;
             default:
                 break;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
@@ -108,7 +108,9 @@ TPDiskMon::TPDiskMon(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& count
     COUNTER_INIT(DeviceGroup, DeviceInFlightBytesRead, false);
     COUNTER_INIT(DeviceGroup, DeviceInFlightBytesWrite, false);
     COUNTER_INIT(DeviceGroup, DeviceInFlightReads, false);
+    MaxDeviceInFlightReads.Init(DeviceGroup->GetCounter("MaxDeviceInFlightReads", false));
     COUNTER_INIT(DeviceGroup, DeviceInFlightWrites, false);
+    MaxDeviceInFlightWrites.Init(DeviceGroup->GetCounter("MaxDeviceInFlightWrites", false));
     COUNTER_INIT_IF_EXTENDED(DeviceGroup, DeviceTakeoffs, false);
     COUNTER_INIT_IF_EXTENDED(DeviceGroup, DeviceLandings, false);
     COUNTER_INIT(DeviceGroup, DeviceHaltDetected, false);
@@ -415,6 +417,9 @@ void TPDiskMon::UpdatePercentileTrackers() {
 
     InputQLA.Update();
     InputQCA.Update();
+
+    MaxDeviceInFlightReads.Update();
+    MaxDeviceInFlightWrites.Update();
 }
 
 void TPDiskMon::UpdateLights() {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
@@ -6,11 +6,13 @@
 #include <ydb/core/protos/blobstorage_disk.pb.h>
 #include <ydb/core/protos/node_whiteboard.pb.h>
 #include <ydb/core/util/light.h>
+#include <ydb/core/util/max_tracker.h>
 
 #include <library/cpp/bucket_quoter/bucket_quoter.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/monlib/dynamic_counters/percentile/percentile_lg.h>
+
 
 namespace NKikimr {
 
@@ -287,7 +289,9 @@ struct TPDiskMon {
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceInFlightBytesRead;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceInFlightBytesWrite;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceInFlightReads;
+    TMaxTracker MaxDeviceInFlightReads;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceInFlightWrites;
+    TMaxTracker MaxDeviceInFlightWrites;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceTakeoffs;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceLandings;
     ::NMonitoring::TDynamicCounters::TCounterPtr DeviceHaltDetected;

--- a/ydb/core/util/max_tracker.h
+++ b/ydb/core/util/max_tracker.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "defs.h"
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+
+namespace NKikimr {
+
+class TMaxTracker {
+    TVector<std::atomic<i64>> Slots;
+    std::atomic<size_t> CurrentIdx = 0;
+    TInstant Last = TInstant::Now();
+    ::NMonitoring::TDynamicCounters::TCounterPtr Counter;
+
+public:
+
+    TMaxTracker(size_t slots = 15) 
+        : Slots(std::max<size_t>(1, slots))
+    {
+        for (auto& a : Slots) {
+            a.store(0, std::memory_order_relaxed);
+        }
+    }
+
+    void Init(::NMonitoring::TDynamicCounters::TCounterPtr counter) {
+        Counter = counter;
+    }
+
+    void Collect(i64 val) {
+        const size_t idx = CurrentIdx.load(std::memory_order_acquire);
+        i64 oldVal = Slots[idx].load(std::memory_order_relaxed);
+        while (val > oldVal) {
+            if (Slots[idx].compare_exchange_weak(oldVal, val,
+                std::memory_order_release, std::memory_order_relaxed)) {
+                break;
+            }
+        }
+    }
+
+    // The function is supposed to be called every 1 second.
+    // Calling thread can differ from Collect's caller thread
+    void Update() {
+        if (Counter) {
+            i64 maxVal = Slots[0].load(std::memory_order_relaxed);
+            for (size_t i = 1; i < Slots.size(); ++i) {
+                maxVal = std::max(maxVal, Slots[i].load(std::memory_order_relaxed));
+            }
+            Counter->Set(maxVal);
+        }
+        const size_t idx = CurrentIdx.load(std::memory_order_relaxed);
+        const size_t newIdx = (idx + 1) % Slots.size();
+        Slots[newIdx].store(0, std::memory_order_relaxed);
+        CurrentIdx.store(newIdx, std::memory_order_release);
+    }
+};
+
+}

--- a/ydb/core/util/max_tracker_ut.cpp
+++ b/ydb/core/util/max_tracker_ut.cpp
@@ -1,0 +1,82 @@
+#include "max_tracker.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/random/fast.h>
+
+#include <thread>
+
+//////////
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/stream/output.h>
+
+#include <atomic>
+#include <chrono>
+#include <random>
+#include <thread>
+
+
+namespace NKikimr {
+Y_UNIT_TEST_SUITE(TMaxTracker) {
+    Y_UNIT_TEST(basic_test) {
+        TMaxTracker tracker(3);
+        tracker.Collect(5);
+        tracker.Collect(10);
+        ::NMonitoring::TDynamicCounters Counters;
+        auto counter = Counters.GetCounter("test");
+        *counter = 0;
+        tracker.Init(counter);
+        tracker.Update();
+        // should report proper max value
+        UNIT_ASSERT_EQUAL(*counter, 10);
+        tracker.Update();
+        tracker.Update();
+        tracker.Update();
+        // should reset max after N > slots updates called
+        UNIT_ASSERT_EQUAL(*counter, 0);
+    }
+
+    Y_UNIT_TEST(two_threads_collect_update_ops_per_sec) {
+        TMaxTracker tracker(5);
+        ::NMonitoring::TDynamicCounters Counters;
+        auto counter = Counters.GetCounter("test");
+        *counter = 0;
+        tracker.Init(counter);
+
+        std::atomic<bool> stop{false};
+        std::atomic<ui64> collectCount{0};
+
+        std::thread collector([&] {
+            std::mt19937 rng(42);
+            std::uniform_int_distribution<i64> dist(0, 1'000'000);
+            while (!stop.load(std::memory_order_relaxed)) {
+                tracker.Collect(dist(rng));
+                collectCount.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+
+        std::thread updater([&] {
+            while (!stop.load(std::memory_order_relaxed)) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                tracker.Update();
+            }
+        });
+
+        const auto start = std::chrono::steady_clock::now();
+        const auto duration = std::chrono::seconds(10);
+        std::this_thread::sleep_for(duration);
+        stop.store(true, std::memory_order_relaxed);
+
+        collector.join();
+        updater.join();
+
+        const auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(
+            std::chrono::steady_clock::now() - start);
+        const double opsPerSec = static_cast<double>(collectCount.load(std::memory_order_relaxed))
+            / elapsed.count();
+
+        Cerr << "Collect ops/sec: " << opsPerSec << Endl;
+        UNIT_ASSERT(collectCount.load(std::memory_order_relaxed) > 0);
+    }
+}
+}

--- a/ydb/core/util/ut/ya.make
+++ b/ydb/core/util/ut/ya.make
@@ -36,6 +36,7 @@ SRCS(
     lf_stack_ut.cpp
     log_priority_mute_checker_ut.cpp
     lz4_data_generator_ut.cpp
+    max_tracker_ut.cpp
     numerical_maybe_ut.cpp
     operation_queue_priority_ut.cpp
     operation_queue_ut.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

New simple TMaxTracker to monitor maximal value of a metric over specified time window

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
