### PR TITLE
dq: streamlookup join: implement fullscan support

### DIFF
--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -3180,9 +3180,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
                 .TableName = ydbTable,
                 .Columns = columns,
                 .DescribeCount = 2,
-                // Now List Split is done after type annotation, that is the
-                // reason why this value equal to 4 not 5
-                .ListSplitsCount = WithFeatureFlag ? 4 : 0,
+                .ListSplitsCount = WithFeatureFlag ? 7 : 0,
                 .ValidateListSplitsArgs = false
             });
 
@@ -3192,11 +3190,11 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
                 SetupMockConnectorTableData(connectorClient, {
                     .TableName = ydbTable,
                     .Columns = columns,
-                    .NumberReadSplits = 3,
+                    .NumberReadSplits = 6,
                     .ValidateReadSplitsArgs = false,
                     .ResultFactory = [&]() {
                         readSplitsCount += 1;
-                        const auto payloadColumn = readSplitsCount < 3
+                        const auto payloadColumn = readSplitsCount <= 4
                             ? std::vector<std::string>{"P1", "P2", "P3"}
                             : std::vector<std::string>{"P4", "P5", "P6"};
 
@@ -4121,7 +4119,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
                 .TableName = ydbTable,
                 .Columns = columns,
                 .DescribeCount = 2,
-                .ListSplitsCount = 4,
+                .ListSplitsCount = 7,
                 .ValidateListSplitsArgs = false
             });
 
@@ -4130,7 +4128,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             SetupMockConnectorTableData(connectorClient, {
                 .TableName = ydbTable,
                 .Columns = columns,
-                .NumberReadSplits = 3,
+                .NumberReadSplits = 6,
                 .ValidateReadSplitsArgs = false,
                 .ResultFactory = [&]() {
                     return MakeRecordBatch(

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -253,13 +253,6 @@ struct IDqAsyncLookupSource {
         {
             if (fullscanLimit > 0) {
                 Y_DEBUG_ABORT_UNLESS(resultRows <= fullscanLimit);
-                Y_DEBUG_ABORT_UNLESS(([result, resultRows]() {
-                    auto locked = result.lock();
-                    if (!locked) {
-                        return true;
-                    }
-                    return locked->size() <= resultRows;
-                }()));
             }
         }
         std::weak_ptr<TUnboxedValueMap> Result;

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -400,9 +400,9 @@ private:
             // TODO: try partially early resolve AwaitingQueue (for multiMatches we MUST ignore incomplete results)
         }
         if (!fullscan || (resultIncomplete && !IsMultiMatches)) {
-            for (auto&& [k, v]: *lookupResult) {
+            for (auto& [k, v]: *lookupResult) {
                 Y_DEBUG_ABORT_UNLESS(!fullscan || v);
-                LruCache->Update(NUdf::TUnboxedValue(const_cast<NUdf::TUnboxedValue&&>(k)), std::move(v), now + CacheTtl);
+                LruCache->Update(NUdf::TUnboxedValue(k), std::move(v), now + CacheTtl);
             }
             lookupResult->clear();
             lookupResult.reset();

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -50,7 +50,7 @@ public:
         TOutputRowColumnOrder&& outputRowColumnOrder,
         TDqComputeActorWatermarks* watermarksTracker,
         const THashMap<TString, TString>& secureParams,
-        size_t fullscanRowLimit = 1000)
+        size_t fullscanRowLimit = 5000)
         : TActor(&TInputTransformStreamLookupDerivedBase::StateFunc)
         , Alloc(alloc)
         , HolderFactory(holderFactory)

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -50,7 +50,7 @@ public:
         TOutputRowColumnOrder&& outputRowColumnOrder,
         TDqComputeActorWatermarks* watermarksTracker,
         const THashMap<TString, TString>& secureParams,
-        size_t maxFullscanRows = 1000)
+        size_t fullscanRowLimit = 1000)
         : TActor(&TInputTransformStreamLookupDerivedBase::StateFunc)
         , Alloc(alloc)
         , HolderFactory(holderFactory)
@@ -62,7 +62,7 @@ public:
         , Factory(factory)
         , Settings(std::move(settings))
         , SecureParams(secureParams)
-        , MaxFullscanRows(Min(maxFullscanRows, (size_t)Settings.GetCacheLimit()))
+        , FullscanRowLimit(Min(fullscanRowLimit, (size_t)Settings.GetCacheLimit()))
         , LookupInputIndexes(std::move(lookupInputIndexes))
         , OtherInputIndexes(std::move(otherInputIndexes))
         , InputRowType(inputRowType)
@@ -197,9 +197,9 @@ private: //IDqComputeActorAsyncInput
             MaxKeysInRequest = lookupSource->GetMaxSupportedKeysInRequest();
             LookupSourceId = this->RegisterWithSameMailbox(lookupSourceActor);
             KeysForLookup = std::make_shared<IDqAsyncLookupSource::TUnboxedValueMap>(MaxKeysInRequest, KeyTypeHelper->GetValueHash(), KeyTypeHelper->GetValueEqual());
-            MaxFullscanRows = Min(MaxFullscanRows, lookupSource->GetMaxSupportedFullscanRequest());
-            if (MaxFullscanRows > 0) {
-                FullscanRequest = std::make_shared<IDqAsyncLookupSource::TUnboxedValueMap>(MaxFullscanRows, KeyTypeHelper->GetValueHash(), KeyTypeHelper->GetValueEqual());
+            FullscanRowLimit = Min(FullscanRowLimit, lookupSource->GetMaxSupportedFullscanRequest());
+            if (FullscanRowLimit > 0) {
+                FullscanRequest = std::make_shared<IDqAsyncLookupSource::TUnboxedValueMap>(FullscanRowLimit, KeyTypeHelper->GetValueHash(), KeyTypeHelper->GetValueEqual());
                 FullscanExpireTime = std::chrono::steady_clock::now();
             } else {
                 FullscanRequested = true;
@@ -267,7 +267,7 @@ protected:
 protected:
     NActors::TActorId LookupSourceId;
     size_t MaxKeysInRequest;
-    size_t MaxFullscanRows;
+    size_t FullscanRowLimit;
     const TVector<size_t> LookupInputIndexes;
     const TVector<size_t> OtherInputIndexes;
     const NMiniKQL::TMultiType* const InputRowType;
@@ -486,10 +486,10 @@ private:
                     AddReadyQueue(key, other, &*lookupPayload);
                 } else {
                     if (!FullscanRequested && now >= FullscanExpireTime) {
-                        Y_DEBUG_ABORT_UNLESS(MaxFullscanRows > 0);
+                        Y_DEBUG_ABORT_UNLESS(FullscanRowLimit > 0);
                         FullscanRequested = true;
                         FullscanRequest->erase(FullscanRequest->begin(), FullscanRequest->end()); // don't ->clear();, it's O(reserved) instead of O(size)
-                        Send(LookupSourceId, new IDqAsyncLookupSource::TEvLookupRequest(FullscanRequest, MaxFullscanRows));
+                        Send(LookupSourceId, new IDqAsyncLookupSource::TEvLookupRequest(FullscanRequest, FullscanRowLimit));
                     }
                     if (AwaitingQueue.empty()) {
                         // look ahead at most MaxDelayedRows after first missing

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -282,6 +282,7 @@ protected:
     std::unique_ptr<NKikimr::NMiniKQL::TUnboxedKeyValueLruCacheWithTtl> LruCache;
     size_t MaxDelayedRows;
     std::chrono::seconds CacheTtl;
+    static constexpr auto MinFullscanFailureTtl = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::hours(1)); // TODO make tuneable
     const bool IsMultiMatches;
     size_t MinimumRowSize; // only account for unboxed parts
     size_t PayloadExtraSize; // non-embedded part of strings in ReadyQueue
@@ -389,12 +390,6 @@ private:
                 Y_DEBUG_ABORT_UNLESS(fullscan || lookupPayload != nullptr);
                 AddReadyQueue(lookupKey, inputOther, lookupPayload);
             }
-            if (fullscan) {
-                FullscanReady = true;
-#if 0 // TODO
-                LruCache->Clear(); // Erase now-useless LRU cache
-#endif
-            }
             PushReadyWatermark();
             Send(ComputeActorId, new TEvNewAsyncInputDataArrived{InputIndex});
         } else if (!IsMultiMatches) {
@@ -406,19 +401,28 @@ private:
             // (again, in case of MultiMatches, we cannot use partial results)
             for (auto& [k, v]: *lookupResult) {
                 Y_DEBUG_ABORT_UNLESS(v);
-                LruCache->OpportunisticUpdate(NUdf::TUnboxedValue(k), std::move(v), now + CacheTtl);
+                LruCache->Update<true>(NUdf::TUnboxedValue(k), std::move(v), now + CacheTtl);
             }
 #endif
         }
         if (fullscan) {
-            Y_DEBUG_ABORT_UNLESS(FullscanRequested);
             Y_DEBUG_ABORT_UNLESS(lookupResult == FullscanRequest);
+            lookupResult.reset();
+            Y_DEBUG_ABORT_UNLESS(FullscanRequested);
             FullscanRequested = false;
-            FullscanExpireTime = now + CacheTtl;
+            if (resultIncomplete) {
+                FullscanExpireTime = now + std::max(CacheTtl, MinFullscanFailureTtl);
+            } else {
+                FullscanExpireTime = now + CacheTtl;
+                FullscanReady = true;
+#if 0 // TODO
+                LruCache->Clear(); // Erase now-useless LRU cache
+#endif
+            }
         } else {
             Y_ABORT_UNLESS(lookupResult == KeysForLookup);
             lookupResult.reset();
-            if (!FullscanReady) { // don't use LRU cache when we have (complete) fullscan results
+            if (!FullscanReady) { // don't populate LRU cache when we have (complete) fullscan results
                 for (auto& [k, v]: *KeysForLookup) {
                     LruCache->Update(NUdf::TUnboxedValue(k), std::move(v), now + CacheTtl);
                 }
@@ -485,10 +489,11 @@ private:
                 } else if (auto lookupPayload = LruCache->Get(key, now)) {
                     AddReadyQueue(key, other, &*lookupPayload);
                 } else {
+                    // TODO collect statistics and only issue fullscan once we know it is expected to be effective
                     if (!FullscanRequested && now >= FullscanExpireTime) {
                         Y_DEBUG_ABORT_UNLESS(FullscanRowLimit > 0);
                         FullscanRequested = true;
-                        FullscanRequest->erase(FullscanRequest->begin(), FullscanRequest->end()); // don't ->clear();, it's O(reserved) instead of O(size)
+                        FullscanRequest->erase(FullscanRequest->begin(), FullscanRequest->end()); // don't ->clear();!
                         Send(LookupSourceId, new IDqAsyncLookupSource::TEvLookupRequest(FullscanRequest, FullscanRowLimit));
                     }
                     if (AwaitingQueue.empty()) {

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -8,6 +8,7 @@
 
 #include <ydb/core/kqp/ut/federated_query/common/common.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
+#include <ydb/library/testlib/common/test_utils.h>
 #include <ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h>
 #include <ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/test_creds.h>
 #include <ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.h>
@@ -41,12 +42,14 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&& alloc,
             TLookupActorFactory&& lookupActorFactory,
             TCallback&& callback,
-            const NActors::TActorId& edge)
+            const NActors::TActorId& edge,
+            size_t fullscanLimit = 0)
             : Alloc(std::move(alloc))
             , TypeEnv(std::make_shared<NKikimr::NMiniKQL::TTypeEnvironment>(*Alloc))
             , LookupActorFactory(std::move(lookupActorFactory))
             , Callback(std::move(callback))
             , Edge(edge)
+            , FullscanLimit(fullscanLimit)
         {
 
         }
@@ -58,7 +61,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             std::tie(actor, Request) = LookupActorFactory(SelfId(), Alloc, *TypeEnv);
             LookupActorFactory = {};
             LookupActor = RegisterWithSameMailbox(actor);
-            auto ev = new NYql::NDq::IDqAsyncLookupSource::TEvLookupRequest(Request);
+            auto ev = new NYql::NDq::IDqAsyncLookupSource::TEvLookupRequest(Request, FullscanLimit);
             TActivationContext::ActorSystem()->Send(new NActors::IEventHandle(LookupActor, SelfId(), ev));
         }
 
@@ -110,9 +113,10 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         TLookupActorFactory LookupActorFactory;
         TCallback Callback;
         NActors::TActorId Edge;
+        size_t FullscanLimit;
     };
 
-    Y_UNIT_TEST_TWIN(Lookup, MultiMatches) {
+    Y_UNIT_TEST_QUAD(Lookup, MultiMatches, Fullscan) {
         NKikimr::NMiniKQL::TMemoryUsageInfo memUsage("TestMemUsage");
         auto alloc = std::make_shared<NKikimr::NMiniKQL::TScopedAlloc>(__LOCATION__, NKikimr::TAlignedPagePoolCounters(), true, false);
         NKikimr::NMiniKQL::THolderFactory holderFactory(alloc->Ref(), memUsage);
@@ -137,6 +141,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
         auto connectorMock = std::make_shared<NYql::NConnector::NTest::TConnectorClientMock>();
 
+        constexpr size_t fullscanLimit = Fullscan ? 3 : 0;
         // clang-format off
         // step 1: ListSplits
         connectorMock->ExpectListSplits()
@@ -148,7 +153,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
                     .NullableColumn("string_value", Ydb::Type::STRING)
                     .Done()
                 .Table("lookup_test")
-                .Where()
+                .Where(/*skip=*/Fullscan)
                     .Filter()
                         .Disjunction()
                             .Operand()
@@ -178,7 +183,10 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
                             .Done()
                         .Done()
                     .Done()
+                .Limit(/*skip=*/!Fullscan)
+                    .Limit(fullscanLimit)
                 .Done()
+            .Done()
             .MaxSplitCount(1)
             .Result()
                 .AddResponse(NewSuccess())
@@ -240,12 +248,14 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
                 MultiMatches);
 
             auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
-            for (size_t i = 0; i != 3; ++i) {
-                NYql::NUdf::TUnboxedValue* keyItems;
-                auto key = holderFactory.CreateDirectArrayHolder(2, keyItems);
-                keyItems[0] = NYql::NUdf::TUnboxedValuePod(ui64(i));
-                keyItems[1] = NYql::NUdf::TUnboxedValuePod(ui64(100 + i));
-                request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
+            if (!Fullscan) {
+                for (size_t i = 0; i != 3; ++i) {
+                    NYql::NUdf::TUnboxedValue* keyItems;
+                    auto key = holderFactory.CreateDirectArrayHolder(2, keyItems);
+                    keyItems[0] = NYql::NUdf::TUnboxedValuePod(ui64(i));
+                    keyItems[1] = NYql::NUdf::TUnboxedValuePod(ui64(100 + i));
+                    request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
+                }
             }
 
             return std::pair { actor, std::move(request) };
@@ -256,7 +266,9 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             auto lookupResult = ev->Get()->Result.lock();
             UNIT_ASSERT(lookupResult);
 
-            UNIT_ASSERT_EQUAL(3, lookupResult->size());
+            UNIT_ASSERT_EQUAL(Fullscan ? 2 : 3, lookupResult->size());
+            UNIT_ASSERT_EQUAL(ev->Get()->FullscanLimit, fullscanLimit);
+            UNIT_ASSERT_EQUAL(ev->Get()->ResultRows, Fullscan ? 3 : 4);
             if (!MultiMatches) {
                 return;
             }
@@ -289,14 +301,14 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
                     ++ptr;
                 }
             }
-            {
+            if (!Fullscan) {
                 const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {2, 102}));
                 UNIT_ASSERT(v);
                 UNIT_ASSERT(!*v);
             }
         };
 
-        auto callLookupActor = new TCallLookupActor(std::move(alloc), std::move(lookupActorFactory), std::move(callback), edge);
+        auto callLookupActor = new TCallLookupActor(std::move(alloc), std::move(lookupActorFactory), std::move(callback), edge, fullscanLimit);
         runtime.Register(callLookupActor);
         runtime.GrabEdgeEventRethrow<NActors::TEvents::TEvWakeup>(edge);
     }

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -195,7 +195,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
         connectorMock->ExpectReadSplits()
             .DataSourceInstance(dsi)
-            .Filtering(NYql::NConnector::NApi::TReadSplitsRequest::FILTERING_MANDATORY)
+            .Filtering(Fullscan ? NYql::NConnector::NApi::TReadSplitsRequest::FILTERING_OPTIONAL : NYql::NConnector::NApi::TReadSplitsRequest::FILTERING_MANDATORY)
             .Split()
                 .Description("Actual split info is not important")
                 .Done()

--- a/ydb/library/yql/providers/generic/actors/yql_generic_base_actor.h
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_base_actor.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <variant>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/yql/providers/generic/connector/api/service/protos/connector.pb.h>
@@ -9,7 +10,7 @@
 
 namespace NYql::NDq {
 
-    template <typename TDerived>
+    template <typename TDerived, typename TEvState = std::monostate>
     class TGenericBaseActor: public NActors::TActorBootstrapped<TDerived> {
     protected: // Events
         // Event ids
@@ -35,6 +36,7 @@ namespace NYql::NDq {
             }
 
             NConnector::IListSplitsStreamIterator::TPtr Iterator;
+            TEvState State;
         };
 
         struct TEvListSplitsPart: NActors::TEventLocal<TEvListSplitsPart, EvListSplitsPart> {
@@ -44,6 +46,7 @@ namespace NYql::NDq {
             }
 
             NConnector::NApi::TListSplitsResponse Response;
+            TEvState State;
         };
 
         struct TEvListSplitsFinished: NActors::TEventLocal<TEvListSplitsFinished, EvListSplitsFinished> {
@@ -53,6 +56,7 @@ namespace NYql::NDq {
             }
 
             NYdbGrpc::TGrpcStatus Status;
+            TEvState State;
         };
 
         struct TEvReadSplitsIterator: NActors::TEventLocal<TEvReadSplitsIterator, EvReadSplitsIterator> {
@@ -62,6 +66,7 @@ namespace NYql::NDq {
             }
 
             NConnector::IReadSplitsStreamIterator::TPtr Iterator;
+            TEvState State;
         };
 
         struct TEvReadSplitsPart: NActors::TEventLocal<TEvReadSplitsPart, EvReadSplitsPart> {
@@ -71,6 +76,7 @@ namespace NYql::NDq {
             }
 
             NConnector::NApi::TReadSplitsResponse Response;
+            TEvState State;
         };
 
         struct TEvReadSplitsFinished: NActors::TEventLocal<TEvReadSplitsFinished, EvReadSplitsFinished> {
@@ -80,6 +86,7 @@ namespace NYql::NDq {
             }
 
             NYdbGrpc::TGrpcStatus Status;
+            TEvState State;
         };
 
         struct TEvError: NActors::TEventLocal<TEvError, EvError> {
@@ -89,6 +96,7 @@ namespace NYql::NDq {
             }
 
             NConnector::NApi::TError Error;
+            TEvState State;
         };
 
     protected: // TODO move common logic here

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -425,7 +425,6 @@ namespace NYql::NDq {
             }
             Request.reset();
             TActivationContext::ActorSystem()->Send(new NActors::IEventHandle(ParentId, SelfId(), ev));
-            LookupResult = {};
             ReadSplitsIterator = {};
         }
 
@@ -542,7 +541,6 @@ namespace NYql::NDq {
         const bool IsMultiMatches;
         std::shared_ptr<IDqAsyncLookupSource::TUnboxedValueMap> Request;
         NConnector::IReadSplitsStreamIterator::TPtr ReadSplitsIterator; // TODO move me to TEvReadSplitsPart
-        NKikimr::NMiniKQL::TKeyPayloadPairVector LookupResult;
         ILookupRetryPolicy::TPtr RetryPolicy;
         std::shared_ptr<ILookupRetryState> RetryState;
         ::NMonitoring::TDynamicCounters::TCounterPtr Count;

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -55,17 +55,24 @@ namespace NYql::NDq {
             return NThreading::TFuture<T>(f).ExtractValueSync();
         }
 
+        using ILookupRetryPolicy = IRetryPolicy<const NYdbGrpc::TGrpcStatus&>;
+        using ILookupRetryState = ILookupRetryPolicy::IRetryState;
+        struct TLookupState {
+            using TPtr = std::shared_ptr<TLookupState>;
+            std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap> Request;
+            NConnector::IReadSplitsStreamIterator::TPtr ReadSplitsIterator;
+            ILookupRetryState::TPtr RetryState;
+            TInstant SentTime;
+        };
     } // namespace
 
     class TGenericLookupActor
         : public NYql::NDq::IDqAsyncLookupSource,
-          public TGenericBaseActor<TGenericLookupActor> {
-        using TBase = TGenericBaseActor<TGenericLookupActor>;
-
-        using ILookupRetryPolicy = IRetryPolicy<const NYdbGrpc::TGrpcStatus&>;
-        using ILookupRetryState = ILookupRetryPolicy::IRetryState;
+          public TGenericBaseActor<TGenericLookupActor, TLookupState::TPtr> {
+        using TBase = TGenericBaseActor<TGenericLookupActor, TLookupState::TPtr>;
 
         struct TEvLookupRetry : NActors::TEventLocal<TEvLookupRetry, EvRetry> {
+            TLookupState::TPtr State;
         };
 
     public:
@@ -125,11 +132,11 @@ namespace NYql::NDq {
     private:
         void Free() {
             auto guard = Guard(*Alloc);
-            if (Request && InFlight) {
-                // If request fails on (unrecoverable) error or cancelled, we may end up with non-zero InFlight (when request successfully completed, @Request is nullptr)
-                InFlight->Dec();
+            if (InFlight) {
+                // If request fails on (unrecoverable) error or cancelled, we may end up with non-zero InFlight
+                InFlight->Sub(LocalInFlight);
             }
-            Request.reset();
+            LocalInFlight = 0;
             KeyTypeHelper.reset();
         }
         void InitMonCounters(const ::NMonitoring::TDynamicCounterPtr& taskCounters) {
@@ -195,16 +202,17 @@ namespace NYql::NDq {
                 [
                     actorSystem = TActivationContext::ActorSystem(),
                     selfId = SelfId(),
-                    retryState = RetryState
+                    state = std::move(ev->Get()->State)
                 ](const NConnector::TAsyncResult<NConnector::NApi::TListSplitsResponse>& asyncResult) {
                     YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << selfId << " Got TListSplitsResponse from Connector";
                     auto result = ExtractFromConstFuture(asyncResult);
                     if (result.Status.Ok()) {
                         Y_ABORT_UNLESS(result.Response);
                         auto ev = new TEvListSplitsPart(std::move(*result.Response));
+                        ev->State = std::move(state);
                         actorSystem->Send(new NActors::IEventHandle(selfId, selfId, ev));
                     } else {
-                        SendRetryOrError(actorSystem, selfId, result.Status, retryState);
+                        SendRetryOrError(actorSystem, selfId, result.Status, std::move(state));
                     }
                 });
         }
@@ -228,31 +236,32 @@ namespace NYql::NDq {
             Connector->ReadSplits(readRequest, RequestTimeout).Subscribe([
                     actorSystem = TActivationContext::ActorSystem(),
                     selfId = SelfId(),
-                    retryState = RetryState
+                    state = std::move(ev->Get()->State)
             ](const NConnector::TReadSplitsStreamIteratorAsyncResult& asyncResult) {
                 YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << selfId << " Got ReadSplitsStreamIterator from Connector";
                 auto result = ExtractFromConstFuture(asyncResult);
                 if (result.Status.Ok()) {
                     auto ev = new TEvReadSplitsIterator(std::move(result.Iterator));
+                    ev->State = std::move(state);
                     actorSystem->Send(new NActors::IEventHandle(selfId, selfId, ev));
                 } else {
-                    SendRetryOrError(actorSystem, selfId, result.Status, retryState);
+                    SendRetryOrError(actorSystem, selfId, result.Status, state);
                 }
             });
         }
 
         void Handle(TEvReadSplitsIterator::TPtr ev) {
-            ReadSplitsIterator = ev->Get()->Iterator;
-            ReadNextData();
+            ev->Get()->State->ReadSplitsIterator = std::move(ev->Get()->Iterator);
+            ReadNextData(std::move(ev->Get()->State));
         }
 
         void Handle(TEvReadSplitsPart::TPtr ev) {
-            ProcessReceivedData(ev->Get()->Response);
-            ReadNextData();
+            ProcessReceivedData(ev->Get()->Response, ev->Get()->State);
+            ReadNextData(std::move(ev->Get()->State));
         }
 
-        void Handle(TEvReadSplitsFinished::TPtr) {
-            FinalizeRequest();
+        void Handle(TEvReadSplitsFinished::TPtr ev) {
+            FinalizeRequest(std::move(ev->Get()->State));
         }
 
         void Handle(TEvError::TPtr ev) {
@@ -269,9 +278,9 @@ namespace NYql::NDq {
             Send(ParentId, new IDqComputeActorAsyncInput::TEvAsyncInputError(-1, std::move(issues), fatalCode));
         }
 
-        void Handle(TEvLookupRetry::TPtr) {
+        void Handle(TEvLookupRetry::TPtr ev) {
             auto guard = Guard(*Alloc);
-            SendRequest();
+            SendRequest(std::move(ev->Get()->State));
         }
 
         void Handle(NActors::TEvents::TEvPoison::TPtr) {
@@ -297,7 +306,6 @@ namespace NYql::NDq {
             if (!request) {
                 return;
             }
-            SentTime = TInstant::Now();
             YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << SelfId() << " Got LookupRequest for " << request->size() << " keys";
             Y_ABORT_IF(request->size() == 0 || request->size() > MaxKeysInRequest);
             if (Count) {
@@ -305,17 +313,21 @@ namespace NYql::NDq {
                 InFlight->Inc();
                 Keys->Add(request->size());
             }
+            ++LocalInFlight;
 
-            Request = std::move(request);
-            RetryState = std::shared_ptr<ILookupRetryState>(RetryPolicy->CreateRetryState());
-            SendRequest();
+            auto state = std::make_shared<TLookupState>(TLookupState {
+                .Request = std::move(request),
+                .RetryState = RetryPolicy->CreateRetryState(),
+                .SentTime = TInstant::Now(),
+            });
+            SendRequest(state);
         }
 
-        void SendRequest() {
+        void SendRequest(TLookupState::TPtr state) {
             auto startCycleCount = GetCycleCountFast();
             NConnector::NApi::TListSplitsRequest splitRequest;
 
-            auto error = FillSelect(*splitRequest.add_selects());
+            auto error = FillSelect(*splitRequest.add_selects(), state);
             if (error) {
                 SendError(TActivationContext::ActorSystem(), SelfId(), std::move(error));
                 return;
@@ -325,16 +337,17 @@ namespace NYql::NDq {
             Connector->ListSplits(splitRequest, RequestTimeout).Subscribe([
                     actorSystem = TActivationContext::ActorSystem(),
                     selfId = SelfId(),
-                    retryState = RetryState
+                    state = std::move(state)
             ](const NConnector::TListSplitsStreamIteratorAsyncResult& asyncResult) {
                 auto result = ExtractFromConstFuture(asyncResult);
                 if (result.Status.Ok()) {
                     YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << selfId << " Got TListSplitsStreamIterator";
                     Y_ABORT_UNLESS(result.Iterator, "Uninitialized iterator");
                     auto ev = new TEvListSplitsIterator(std::move(result.Iterator));
+                    ev->State = std::move(state);
                     actorSystem->Send(new NActors::IEventHandle(selfId, selfId, ev));
                 } else {
-                    SendRetryOrError(actorSystem, selfId, result.Status, retryState);
+                    SendRetryOrError(actorSystem, selfId, result.Status, std::move(state));
                 }
             });
             if (CpuTime) {
@@ -342,12 +355,15 @@ namespace NYql::NDq {
             }
         }
 
-        void ReadNextData() {
-            ReadSplitsIterator->ReadNext().Subscribe(
+        void ReadNextData(TLookupState::TPtr state) {
+            if (LocalInFlight == 0) { // PassAway was called
+                return;
+            }
+            state->ReadSplitsIterator->ReadNext().Subscribe(
                 [
                    actorSystem = TActivationContext::ActorSystem(),
                    selfId = SelfId(),
-                   retryState = RetryState
+                   state = state
                 ](const NConnector::TAsyncResult<NConnector::NApi::TReadSplitsResponse>& asyncResult) {
                     auto result = ExtractFromConstFuture(asyncResult);
                     if (result.Status.Ok()) {
@@ -357,6 +373,7 @@ namespace NYql::NDq {
                         // TODO: retry on some YDB errors
                         if (NConnector::IsSuccess(response)) {
                             auto ev = new TEvReadSplitsPart(std::move(response));
+                            ev->State = std::move(state);
                             actorSystem->Send(new NActors::IEventHandle(selfId, selfId, ev));
                         } else {
                             SendError(actorSystem, selfId, response.Geterror());
@@ -364,14 +381,15 @@ namespace NYql::NDq {
                     } else if (NConnector::GrpcStatusEndOfStream(result.Status)) {
                         YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << selfId << " Got EOF";
                         auto ev = new TEvReadSplitsFinished(std::move(result.Status));
+                        ev->State = std::move(state);
                         actorSystem->Send(new NActors::IEventHandle(selfId, selfId, ev));
                     } else {
-                        SendRetryOrError(actorSystem, selfId, result.Status, retryState);
+                        SendRetryOrError(actorSystem, selfId, result.Status, std::move(state));
                     }
                 });
         }
 
-        void ProcessReceivedData(const NConnector::NApi::TReadSplitsResponse& resp) {
+        void ProcessReceivedData(const NConnector::NApi::TReadSplitsResponse& resp, TLookupState::TPtr state) {
             auto startCycleCount = GetCycleCountFast();
             Y_ABORT_UNLESS(resp.payload_case() == NConnector::NApi::TReadSplitsResponse::PayloadCase::kArrowIpcStreaming);
             if (ResultChunks) {
@@ -402,7 +420,7 @@ namespace NYql::NDq {
                 for (size_t j = 0; j != columns.size(); ++j) {
                     (ColumnDestinations[j].first == EColumnDestination::Key ? keyItems : outputItems)[ColumnDestinations[j].second] = columns[j][i];
                 }
-                if (auto* v = Request->FindPtr(key)) {
+                if (auto* v = state->Request->FindPtr(key)) {
                     if (IsMultiMatches) {
                         *v = HolderFactory.CreateDirectListHolder((*v ? *NKikimr::NMiniKQL::GetDefaultListRepresentation(*v) : NKikimr::NMiniKQL::TDefaultListRepresentation{}).Append(std::move(output)));
                     } else {
@@ -415,17 +433,20 @@ namespace NYql::NDq {
             }
         }
 
-        void FinalizeRequest() {
-            YQL_CLOG(DEBUG, ProviderGeneric) << "Sending lookup results for " << Request->size() << " keys";
+        void FinalizeRequest(TLookupState::TPtr state) {
+            YQL_CLOG(DEBUG, ProviderGeneric) << "Sending lookup results for " << state->Request->size() << " keys";
+            if (LocalInFlight == 0) { // PassAway was called
+                return;
+            }
+            --LocalInFlight;
             auto guard = Guard(*Alloc);
-            auto ev = new IDqAsyncLookupSource::TEvLookupResult(Request);
+            auto ev = new IDqAsyncLookupSource::TEvLookupResult(std::move(state->Request));
             if (AnswerTime) {
-                AnswerTime->Add((TInstant::Now() - SentTime).MilliSeconds());
+                AnswerTime->Add((TInstant::Now() - state->SentTime).MilliSeconds());
                 InFlight->Dec();
             }
-            Request.reset();
+            state.reset();
             TActivationContext::ActorSystem()->Send(new NActors::IEventHandle(ParentId, SelfId(), ev));
-            ReadSplitsIterator = {};
         }
 
         static void SendError(NActors::TActorSystem* actorSystem, const NActors::TActorId& selfId, const NConnector::NApi::TError& error) {
@@ -435,11 +456,13 @@ namespace NYql::NDq {
                 new TEvError(std::move(error)));
         }
 
-        static void SendRetryOrError(NActors::TActorSystem* actorSystem, const NActors::TActorId& selfId, const NYdbGrpc::TGrpcStatus& status, std::shared_ptr<ILookupRetryState> retryState) {
-            auto nextRetry = retryState->GetNextRetryDelay(status);
-            if (nextRetry) {
+        static void SendRetryOrError(NActors::TActorSystem* actorSystem, const NActors::TActorId& selfId, const NYdbGrpc::TGrpcStatus& status, TLookupState::TPtr state) {
+            auto nextRetry = state->RetryState->GetNextRetryDelay(status);
+            if (nextRetry && LocalInFlight) {
                 YQL_CLOG(WARN, ProviderGeneric) << "ActorId=" << selfId << " Got retrievable GRPC Error from Connector: " << status.ToDebugString() << ", retry scheduled in " << *nextRetry;
-                actorSystem->Schedule(*nextRetry, new IEventHandle(selfId, selfId, new TEvLookupRetry()));
+                auto ev = new TEvLookupRetry();
+                ev->State = std::move(state);
+                actorSystem->Schedule(*nextRetry, new IEventHandle(selfId, selfId, ev));
                 return;
             }
             SendError(actorSystem, selfId, NConnector::ErrorFromGRPCStatus(status));
@@ -494,7 +517,7 @@ namespace NYql::NDq {
             }
         }
 
-        TString FillSelect(NConnector::NApi::TSelect& select) {
+        TString FillSelect(NConnector::NApi::TSelect& select, TLookupState::TPtr state) {
             auto dsi = LookupSource.data_source_instance();
             auto error = CredentialsProvider->FillCredentials(dsi);
             if (error) {
@@ -511,14 +534,14 @@ namespace NYql::NDq {
             select.mutable_from()->Settable(LookupSource.table());
 
             NConnector::NApi::TPredicate::TDisjunction disjunction;
-            for (const auto& [keys, _] : *Request) {
+            for (const auto& [keys, _] : *state->Request) {
                 // TODO consider skipping already retrieved keys
                 // ... but careful, can we end up with zero? TODO
                 AddClause(disjunction, KeyType->GetMembersCount(), keys);
             }
-            auto& keys = Request->begin()->first; // Request is never empty
+            auto& keys = state->Request->begin()->first; // Request is never empty
             // Pad query with dummy clauses to improve caching
-            for (ui32 nRequests = Request->size(); !IsPowerOf2(nRequests) && nRequests < MaxKeysInRequest; ++nRequests) {
+            for (ui32 nRequests = state->Request->size(); !IsPowerOf2(nRequests) && nRequests < MaxKeysInRequest; ++nRequests) {
                 AddClause(disjunction, KeyType->GetMembersCount(), keys);
             }
             *select.mutable_where()->mutable_filter_typed()->mutable_disjunction() = disjunction;
@@ -539,10 +562,8 @@ namespace NYql::NDq {
         const std::vector<std::pair<EColumnDestination, size_t>> ColumnDestinations;
         const size_t MaxKeysInRequest;
         const bool IsMultiMatches;
-        std::shared_ptr<IDqAsyncLookupSource::TUnboxedValueMap> Request;
-        NConnector::IReadSplitsStreamIterator::TPtr ReadSplitsIterator; // TODO move me to TEvReadSplitsPart
+        ui32 LocalInFlight = 0;
         ILookupRetryPolicy::TPtr RetryPolicy;
-        std::shared_ptr<ILookupRetryState> RetryState;
         ::NMonitoring::TDynamicCounters::TCounterPtr Count;
         ::NMonitoring::TDynamicCounters::TCounterPtr Keys;
         ::NMonitoring::TDynamicCounters::TCounterPtr ResultRows;
@@ -551,7 +572,6 @@ namespace NYql::NDq {
         ::NMonitoring::TDynamicCounters::TCounterPtr AnswerTime;
         ::NMonitoring::TDynamicCounters::TCounterPtr CpuTime;
         ::NMonitoring::TDynamicCounters::TCounterPtr InFlight;
-        TInstant SentTime;
     };
 
     std::pair<NYql::NDq::IDqAsyncLookupSource*, NActors::IActor*> CreateGenericLookupActor(

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -149,14 +149,14 @@ namespace NYql::NDq {
                 return;
             }
             auto component = taskCounters->GetSubgroup("component", "LookupSrc");
-            Count = component->GetCounter("Reqs");
-            Fullscans = component->GetCounter("Fullscans");
-            Keys = component->GetCounter("Keys");
-            ResultChunks = component->GetCounter("Chunks");
-            ResultRows = component->GetCounter("Rows");
-            ResultBytes = component->GetCounter("Bytes");
-            AnswerTime = component->GetCounter("AnswerMs");
-            CpuTime = component->GetCounter("CpuUs");
+            Count = component->GetCounter("Reqs", true);
+            Fullscans = component->GetCounter("Fullscans", true);
+            Keys = component->GetCounter("Keys", true);
+            ResultChunks = component->GetCounter("Chunks", true);
+            ResultRows = component->GetCounter("Rows", true);
+            ResultBytes = component->GetCounter("Bytes", true);
+            AnswerTime = component->GetCounter("AnswerMs", true);
+            CpuTime = component->GetCounter("CpuUs", true);
             InFlight = component->GetCounter("InFlight");
         }
     public:

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -265,6 +265,7 @@ namespace NYql::NDq {
 
         void Handle(TEvReadSplitsPart::TPtr ev) {
             auto state = std::move(ev->Get()->State);
+            Y_DEBUG_ABORT_UNLESS(state->ReadSplitsIterator);
             ProcessReceivedData(ev->Get()->Response, state);
 #if 1 // Temporary workaround for not-yet-deployed YQ-5124
             if (state->FullscanLimit > 0 && state->ResultRows == state->FullscanLimit) {
@@ -495,6 +496,7 @@ namespace NYql::NDq {
         }
 
         void FinalizeRequest(TLookupState::TPtr state) {
+            state->ReadSplitsIterator.reset();
             if (LocalInFlight == 0) { // PassAway was called
                 return;
             }
@@ -518,6 +520,7 @@ namespace NYql::NDq {
         }
 
         static void SendRetryOrError(NActors::TActorSystem* actorSystem, const NActors::TActorId& selfId, const NYdbGrpc::TGrpcStatus& status, TLookupState::TPtr state) {
+            state->ReadSplitsIterator.reset();
             auto nextRetry = state->RetryState->GetNextRetryDelay(status);
             if (nextRetry) {
                 YQL_CLOG(WARN, ProviderGeneric) << "ActorId=" << selfId << " Got retrievable GRPC Error from Connector: " << status.ToDebugString() << ", retry scheduled in " << *nextRetry;

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -650,7 +650,7 @@ namespace NYql::NDq {
         ::NMonitoring::TDynamicCounters::TCounterPtr AnswerTime;
         ::NMonitoring::TDynamicCounters::TCounterPtr CpuTime;
         ::NMonitoring::TDynamicCounters::TCounterPtr InFlight;
-        static constexpr size_t MaxSupportedFullscanRequest = 1000; // todo: consider making tweakable
+        static constexpr size_t MaxSupportedFullscanRequest = 5000; // todo: consider making tweakable
     };
 
     std::pair<NYql::NDq::IDqAsyncLookupSource*, NActors::IActor*> CreateGenericLookupActor(

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -59,8 +59,11 @@ namespace NYql::NDq {
         using ILookupRetryState = ILookupRetryPolicy::IRetryState;
         struct TLookupState {
             using TPtr = std::shared_ptr<TLookupState>;
-            std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap> Request;
+            std::weak_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap> Request;
+            // ^^^ must not be lock()ed without bound mkql allocator (e.g. in future
+            // handlers)
             NConnector::IReadSplitsStreamIterator::TPtr ReadSplitsIterator;
+            // ^^^ TODO: consider possible (temporal) circular ownership via Future and lambda capture
             ILookupRetryState::TPtr RetryState;
             TInstant SentTime;
             size_t FullscanLimit = 0;
@@ -284,13 +287,28 @@ namespace NYql::NDq {
         }
 
         void Handle(TEvLookupRetry::TPtr ev) {
+            if (LocalInFlight == 0) { // already passed away
+                YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << SelfId() << " Retry after PassAway";
+                return;
+            }
             auto guard = Guard(*Alloc);
             auto state = std::move(ev->Get()->State);
-            if (IsMultiMatches) {
-                for (auto& [_, value]: *state->Request) {
-                    value = NUdf::TUnboxedValue();
+            if (state->FullscanLimit > 0) {
+                if (auto request = state->Request.lock()) {
+                    request->erase(request->begin(), request->end());
+                } else {
+                    YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << SelfId() << " Retry: parent MIA";
+                }
+            } else if (IsMultiMatches) {
+                if (auto request = state->Request.lock()) {
+                    for (auto& [_, value]: *request) {
+                        value = NUdf::TUnboxedValue();
+                    }
+                } else {
+                    YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << SelfId() << " Retry: parent MIA";
                 }
             }
+            state->ResultRows = 0;
             SendRequest(std::move(state));
         }
 
@@ -315,6 +333,7 @@ namespace NYql::NDq {
 
         void CreateRequest(std::shared_ptr<IDqAsyncLookupSource::TUnboxedValueMap> request, size_t fullscanLimit = 0) {
             if (!request) {
+                YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << SelfId() << " CreateRequest: parent MIA";
                 return;
             }
             Y_DEBUG_ABORT_UNLESS(request->empty() == (fullscanLimit > 0));
@@ -328,7 +347,7 @@ namespace NYql::NDq {
             ++LocalInFlight;
 
             auto state = std::make_shared<TLookupState>(TLookupState {
-                .Request = std::move(request),
+                .Request = request,
                 .RetryState = RetryPolicy->CreateRetryState(),
                 .SentTime = TInstant::Now(),
                 .FullscanLimit = fullscanLimit
@@ -336,6 +355,7 @@ namespace NYql::NDq {
             SendRequest(state);
         }
 
+        // must be called with bound Alloc
         void SendRequest(TLookupState::TPtr state) {
             auto startCycleCount = GetCycleCountFast();
             NConnector::NApi::TListSplitsRequest splitRequest;
@@ -413,6 +433,11 @@ namespace NYql::NDq {
                 }
             }
             auto guard = Guard(*Alloc);
+            auto request = state->Request.lock();
+            if (!request) {
+                YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << SelfId() << " ProcessReceivedData: parent MIA";
+                return;
+            }
             NKikimr::NArrow::NSerialization::TSerializerContainer deser = NKikimr::NArrow::NSerialization::TSerializerContainer::GetDefaultSerializer(); // todo move to class' member
             const auto& data = deser->Deserialize(resp.arrow_ipc_streaming());
             Y_ABORT_UNLESS(data.ok());
@@ -437,9 +462,9 @@ namespace NYql::NDq {
 
                 NUdf::TUnboxedValue *v;
                 if (state->FullscanLimit > 0) {
-                    auto [it, _] = state->Request->emplace(key, NUdf::TUnboxedValue{});
+                    auto [it, _] = request->emplace(key, NUdf::TUnboxedValue{});
                     v = &(it->second);
-                } else if (auto it = state->Request->find(key); it != state->Request->end()) {
+                } else if (auto it = request->find(key); it != request->end()) {
                     v = &(it->second);
                 } else {
                     continue;
@@ -456,12 +481,12 @@ namespace NYql::NDq {
         }
 
         void FinalizeRequest(TLookupState::TPtr state) {
-            YQL_CLOG(DEBUG, ProviderGeneric) << "Sending lookup results for " << state->Request->size() << " keys";
             if (LocalInFlight == 0) { // PassAway was called
                 return;
             }
             --LocalInFlight;
             auto guard = Guard(*Alloc);
+            YQL_CLOG(DEBUG, ProviderGeneric) << "Sending lookup results with " << state->ResultRows << " rows";
             if (AnswerTime) {
                 AnswerTime->Add((TInstant::Now() - state->SentTime).MilliSeconds());
                 InFlight->Dec();
@@ -480,12 +505,8 @@ namespace NYql::NDq {
 
         static void SendRetryOrError(NActors::TActorSystem* actorSystem, const NActors::TActorId& selfId, const NYdbGrpc::TGrpcStatus& status, TLookupState::TPtr state) {
             auto nextRetry = state->RetryState->GetNextRetryDelay(status);
-            if (nextRetry && LocalInFlight) {
+            if (nextRetry) {
                 YQL_CLOG(WARN, ProviderGeneric) << "ActorId=" << selfId << " Got retrievable GRPC Error from Connector: " << status.ToDebugString() << ", retry scheduled in " << *nextRetry;
-                if (state->FullscanLimit > 0) {
-                    state->ResultRows = 0;
-                    state->Request->clear();
-                }
                 auto ev = new TEvLookupRetry();
                 ev->State = std::move(state);
                 actorSystem->Schedule(*nextRetry, new IEventHandle(selfId, selfId, ev));
@@ -543,6 +564,7 @@ namespace NYql::NDq {
             }
         }
 
+        // must be called with bound Alloc
         TString FillSelect(NConnector::NApi::TSelect& select, TLookupState::TPtr state) {
             auto dsi = LookupSource.data_source_instance();
             auto error = CredentialsProvider->FillCredentials(dsi);
@@ -567,14 +589,19 @@ namespace NYql::NDq {
             }
 
             NConnector::NApi::TPredicate::TDisjunction disjunction;
-            for (const auto& [keys, _] : *state->Request) {
+            auto request = state->Request.lock();
+            if (!request) {
+                YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << SelfId() << " FillSelect: parent MIA";
+                return "Actor destroyed";
+            }
+            for (const auto& [keys, _] : *request) {
                 // TODO consider skipping already retrieved keys
                 // ... but careful, can we end up with zero? TODO
                 AddClause(disjunction, KeyType->GetMembersCount(), keys);
             }
-            auto& keys = state->Request->begin()->first; // Request is never empty
+            auto& keys = request->begin()->first; // request is never empty
             // Pad query with dummy clauses to improve caching
-            for (ui32 nRequests = state->Request->size(); !IsPowerOf2(nRequests) && nRequests < MaxKeysInRequest; ++nRequests) {
+            for (ui32 nRequests = request->size(); !IsPowerOf2(nRequests) && nRequests < MaxKeysInRequest; ++nRequests) {
                 AddClause(disjunction, KeyType->GetMembersCount(), keys);
             }
             *select.mutable_where()->mutable_filter_typed()->mutable_disjunction() = disjunction;

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -63,6 +63,8 @@ namespace NYql::NDq {
             NConnector::IReadSplitsStreamIterator::TPtr ReadSplitsIterator;
             ILookupRetryState::TPtr RetryState;
             TInstant SentTime;
+            size_t FullscanLimit = 0;
+            size_t ResultRows = 0;
         };
     } // namespace
 
@@ -173,6 +175,9 @@ namespace NYql::NDq {
         size_t GetMaxSupportedKeysInRequest() const override {
             return MaxKeysInRequest;
         }
+        size_t GetMaxSupportedFullscanRequest() const override {
+            return MaxSupportedFullscanRequest;
+        }
         void AsyncLookup(std::weak_ptr<IDqAsyncLookupSource::TUnboxedValueMap> request) override {
             auto guard = Guard(*Alloc);
             CreateRequest(request.lock());
@@ -280,7 +285,13 @@ namespace NYql::NDq {
 
         void Handle(TEvLookupRetry::TPtr ev) {
             auto guard = Guard(*Alloc);
-            SendRequest(std::move(ev->Get()->State));
+            auto state = std::move(ev->Get()->State);
+            if (IsMultiMatches) {
+                for (auto& [_, value]: *state->Request) {
+                    value = NUdf::TUnboxedValue();
+                }
+            }
+            SendRequest(std::move(state));
         }
 
         void Handle(NActors::TEvents::TEvPoison::TPtr) {
@@ -289,7 +300,7 @@ namespace NYql::NDq {
 
         void Handle(TEvLookupRequest::TPtr ev) {
             auto guard = Guard(*Alloc);
-            CreateRequest(ev->Get()->Request.lock());
+            CreateRequest(ev->Get()->Request.lock(), ev->Get()->FullscanLimit);
         }
 
         void HandleException(const std::exception& e) {
@@ -302,12 +313,13 @@ namespace NYql::NDq {
             return TDuration::Seconds(NHPTimer::GetSeconds(GetCycleCountFast() - startCycleCount));
         }
 
-        void CreateRequest(std::shared_ptr<IDqAsyncLookupSource::TUnboxedValueMap> request) {
+        void CreateRequest(std::shared_ptr<IDqAsyncLookupSource::TUnboxedValueMap> request, size_t fullscanLimit = 0) {
             if (!request) {
                 return;
             }
+            Y_DEBUG_ABORT_UNLESS(request->empty() == (fullscanLimit > 0));
             YQL_CLOG(DEBUG, ProviderGeneric) << "ActorId=" << SelfId() << " Got LookupRequest for " << request->size() << " keys";
-            Y_ABORT_IF(request->size() == 0 || request->size() > MaxKeysInRequest);
+            Y_ABORT_IF((request->empty() == (fullscanLimit == 0)) || request->size() > MaxKeysInRequest);
             if (Count) {
                 Count->Inc();
                 InFlight->Inc();
@@ -319,6 +331,7 @@ namespace NYql::NDq {
                 .Request = std::move(request),
                 .RetryState = RetryPolicy->CreateRetryState(),
                 .SentTime = TInstant::Now(),
+                .FullscanLimit = fullscanLimit
             });
             SendRequest(state);
         }
@@ -412,6 +425,7 @@ namespace NYql::NDq {
             }
 
             auto height = columns[0].size();
+            state->ResultRows += height;
             for (size_t i = 0; i != height; ++i) {
                 NUdf::TUnboxedValue* keyItems;
                 NUdf::TUnboxedValue key = HolderFactory.CreateDirectArrayHolder(KeyType->GetMembersCount(), keyItems);
@@ -420,12 +434,20 @@ namespace NYql::NDq {
                 for (size_t j = 0; j != columns.size(); ++j) {
                     (ColumnDestinations[j].first == EColumnDestination::Key ? keyItems : outputItems)[ColumnDestinations[j].second] = columns[j][i];
                 }
-                if (auto* v = state->Request->FindPtr(key)) {
-                    if (IsMultiMatches) {
-                        *v = HolderFactory.CreateDirectListHolder((*v ? *NKikimr::NMiniKQL::GetDefaultListRepresentation(*v) : NKikimr::NMiniKQL::TDefaultListRepresentation{}).Append(std::move(output)));
-                    } else {
-                        *v = std::move(output); // duplicates will be overwritten
-                    }
+
+                NUdf::TUnboxedValue *v;
+                if (state->FullscanLimit > 0) {
+                    auto [it, _] = state->Request->emplace(key, NUdf::TUnboxedValue{});
+                    v = &(it->second);
+                } else if (auto it = state->Request->find(key); it != state->Request->end()) {
+                    v = &(it->second);
+                } else {
+                    continue;
+                }
+                if (IsMultiMatches) {
+                    *v = HolderFactory.CreateDirectListHolder((*v ? *NKikimr::NMiniKQL::GetDefaultListRepresentation(*v) : NKikimr::NMiniKQL::TDefaultListRepresentation{}).Append(std::move(output)));
+                } else {
+                    *v = std::move(output); // duplicates will be overwritten
                 }
             }
             if (CpuTime) {
@@ -440,11 +462,11 @@ namespace NYql::NDq {
             }
             --LocalInFlight;
             auto guard = Guard(*Alloc);
-            auto ev = new IDqAsyncLookupSource::TEvLookupResult(std::move(state->Request));
             if (AnswerTime) {
                 AnswerTime->Add((TInstant::Now() - state->SentTime).MilliSeconds());
                 InFlight->Dec();
             }
+            auto* ev = new IDqAsyncLookupSource::TEvLookupResult(std::move(state->Request), state->ResultRows, state->FullscanLimit);
             state.reset();
             TActivationContext::ActorSystem()->Send(new NActors::IEventHandle(ParentId, SelfId(), ev));
         }
@@ -460,6 +482,10 @@ namespace NYql::NDq {
             auto nextRetry = state->RetryState->GetNextRetryDelay(status);
             if (nextRetry && LocalInFlight) {
                 YQL_CLOG(WARN, ProviderGeneric) << "ActorId=" << selfId << " Got retrievable GRPC Error from Connector: " << status.ToDebugString() << ", retry scheduled in " << *nextRetry;
+                if (state->FullscanLimit > 0) {
+                    state->ResultRows = 0;
+                    state->Request->clear();
+                }
                 auto ev = new TEvLookupRetry();
                 ev->State = std::move(state);
                 actorSystem->Schedule(*nextRetry, new IEventHandle(selfId, selfId, ev));
@@ -504,7 +530,7 @@ namespace NYql::NDq {
             return result;
         }
 
-        void AddClause(NConnector::NApi::TPredicate::TDisjunction &disjunction, 
+        void AddClause(NConnector::NApi::TPredicate::TDisjunction &disjunction,
                        ui32 columnsCount, const NUdf::TUnboxedValue& keys) {
             NConnector::NApi::TPredicate::TConjunction& conjunction = *disjunction.mutable_operands()->Add()->mutable_conjunction();
             for (ui32 c = 0; c != columnsCount; ++c) {
@@ -532,6 +558,13 @@ namespace NYql::NDq {
             }
 
             select.mutable_from()->Settable(LookupSource.table());
+
+            if (state->FullscanLimit > 0) {
+                auto& limit = *select.mutable_limit();
+                limit.set_limit(state->FullscanLimit);
+                limit.set_offset(0);
+                return {};
+            }
 
             NConnector::NApi::TPredicate::TDisjunction disjunction;
             for (const auto& [keys, _] : *state->Request) {
@@ -572,6 +605,7 @@ namespace NYql::NDq {
         ::NMonitoring::TDynamicCounters::TCounterPtr AnswerTime;
         ::NMonitoring::TDynamicCounters::TCounterPtr CpuTime;
         ::NMonitoring::TDynamicCounters::TCounterPtr InFlight;
+        static constexpr size_t MaxSupportedFullscanRequest = 1000; // todo: consider making tweakable
     };
 
     std::pair<NYql::NDq::IDqAsyncLookupSource*, NActors::IActor*> CreateGenericLookupActor(

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -150,6 +150,7 @@ namespace NYql::NDq {
             }
             auto component = taskCounters->GetSubgroup("component", "LookupSrc");
             Count = component->GetCounter("Reqs");
+            Fullscans = component->GetCounter("Fullscans");
             Keys = component->GetCounter("Keys");
             ResultChunks = component->GetCounter("Chunks");
             ResultRows = component->GetCounter("Rows");
@@ -351,6 +352,9 @@ namespace NYql::NDq {
                 Count->Inc();
                 InFlight->Inc();
                 Keys->Add(request->size());
+                if (fullscanLimit > 0) {
+                    Fullscans->Inc();
+                }
             }
             ++LocalInFlight;
 
@@ -642,6 +646,7 @@ namespace NYql::NDq {
         ui32 LocalInFlight = 0;
         ILookupRetryPolicy::TPtr RetryPolicy;
         ::NMonitoring::TDynamicCounters::TCounterPtr Count;
+        ::NMonitoring::TDynamicCounters::TCounterPtr Fullscans;
         ::NMonitoring::TDynamicCounters::TCounterPtr Keys;
         ::NMonitoring::TDynamicCounters::TCounterPtr ResultRows;
         ::NMonitoring::TDynamicCounters::TCounterPtr ResultBytes;

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -264,8 +264,15 @@ namespace NYql::NDq {
         }
 
         void Handle(TEvReadSplitsPart::TPtr ev) {
-            ProcessReceivedData(ev->Get()->Response, ev->Get()->State);
-            ReadNextData(std::move(ev->Get()->State));
+            auto state = std::move(ev->Get()->State);
+            ProcessReceivedData(ev->Get()->Response, state);
+#if 1 // Temporary workaround for not-yet-deployed YQ-5124
+            if (state->FullscanLimit > 0 && state->ResultRows == state->FullscanLimit) {
+                FinalizeRequest(std::move(state));
+                return;
+            }
+#endif
+            ReadNextData(std::move(state));
         }
 
         void Handle(TEvReadSplitsFinished::TPtr ev) {
@@ -450,6 +457,13 @@ namespace NYql::NDq {
             }
 
             auto height = columns[0].size();
+#if 1 // Temporary workaround for not-yet-deployed YQ-5124
+            Y_DEBUG_ABORT_UNLESS(state->FullscanLimit == 0 || state->FullscanLimit > state->ResultRows);
+            if (state->FullscanLimit > 0 && height > state->FullscanLimit - state->ResultRows) {
+                YQL_CLOG(WARN, ProviderGeneric) << "ActorId=" << SelfId() << " YQ-5124 Workaround for unimplemented LIMIT invoked " << height << " > " << state->FullscanLimit << " - " << state->ResultRows;
+                height = state->FullscanLimit - state->ResultRows;
+            }
+#endif
             state->ResultRows += height;
             for (size_t i = 0; i != height; ++i) {
                 NUdf::TUnboxedValue* keyItems;

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -226,7 +226,7 @@ namespace NYql::NDq {
         }
 
         void Handle(TEvListSplitsPart::TPtr ev) {
-            auto response = ev->Get()->Response;
+            auto response = std::move(ev->Get()->Response);
             Y_ABORT_UNLESS(response.splits_size() == 1);
             auto& split = response.splits(0);
             NConnector::NApi::TReadSplitsRequest readRequest;
@@ -238,7 +238,7 @@ namespace NYql::NDq {
                 return;
             }
 
-            *readRequest.add_splits() = split;
+            *readRequest.add_splits() = std::move(split);
             readRequest.Setformat(NConnector::NApi::TReadSplitsRequest_EFormat::TReadSplitsRequest_EFormat_ARROW_IPC_STREAMING);
             readRequest.set_filtering(NConnector::NApi::TReadSplitsRequest::FILTERING_MANDATORY);
             Connector->ReadSplits(readRequest, RequestTimeout).Subscribe([

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -241,7 +241,7 @@ namespace NYql::NDq {
 
             *readRequest.add_splits() = std::move(split);
             readRequest.Setformat(NConnector::NApi::TReadSplitsRequest_EFormat::TReadSplitsRequest_EFormat_ARROW_IPC_STREAMING);
-            readRequest.set_filtering(NConnector::NApi::TReadSplitsRequest::FILTERING_MANDATORY);
+            readRequest.set_filtering(ev->Get()->State->FullscanLimit > 0 ? NConnector::NApi::TReadSplitsRequest::FILTERING_OPTIONAL : NConnector::NApi::TReadSplitsRequest::FILTERING_MANDATORY);
             Connector->ReadSplits(readRequest, RequestTimeout).Subscribe([
                     actorSystem = TActivationContext::ActorSystem(),
                     selfId = SelfId(),
@@ -268,12 +268,10 @@ namespace NYql::NDq {
             auto state = std::move(ev->Get()->State);
             Y_DEBUG_ABORT_UNLESS(state->ReadSplitsIterator);
             ProcessReceivedData(ev->Get()->Response, state);
-#if 1 // Temporary workaround for not-yet-deployed YQ-5124
             if (state->FullscanLimit > 0 && state->ResultRows == state->FullscanLimit) {
                 FinalizeRequest(std::move(state));
                 return;
             }
-#endif
             ReadNextData(std::move(state));
         }
 
@@ -462,13 +460,11 @@ namespace NYql::NDq {
             }
 
             auto height = columns[0].size();
-#if 1 // Temporary workaround for not-yet-deployed YQ-5124
             Y_DEBUG_ABORT_UNLESS(state->FullscanLimit == 0 || state->FullscanLimit > state->ResultRows);
             if (state->FullscanLimit > 0 && height > state->FullscanLimit - state->ResultRows) {
                 YQL_CLOG(WARN, ProviderGeneric) << "ActorId=" << SelfId() << " YQ-5124 Workaround for unimplemented LIMIT invoked " << height << " > " << state->FullscanLimit << " - " << state->ResultRows;
                 height = state->FullscanLimit - state->ResultRows;
             }
-#endif
             state->ResultRows += height;
             for (size_t i = 0; i != height; ++i) {
                 NUdf::TUnboxedValue* keyItems;

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/connector.d/Dockerfile
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/connector.d/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /opt/ydb/cfg/fq-connector-go.yaml

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server/connector.d/Dockerfile
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server/connector.d/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /opt/ydb/cfg/fq-connector-go.yaml

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/mysql/connector.d/Dockerfile
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/mysql/connector.d/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /opt/ydb/cfg/fq-connector-go.yaml

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/oracle/connector.d/Dockerfile
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/oracle/connector.d/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /opt/ydb/cfg/fq-connector-go.yaml

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/connector.d/Dockerfile
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/connector.d/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /opt/ydb/cfg/fq-connector-go.yaml

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/connector.d/Dockerfile
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/connector.d/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /opt/ydb/cfg/fq-connector-go.yaml

--- a/ydb/library/yql/providers/generic/connector/tests/join/connector.d/Dockerfile
+++ b/ydb/library/yql/providers/generic/connector/tests/join/connector.d/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /opt/ydb/cfg/fq-connector-go.yaml

--- a/ydb/tests/fq/generic/analytics/connector/Dockerfile
+++ b/ydb/tests/fq/generic/analytics/connector/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /fq-connector-go.yaml

--- a/ydb/tests/fq/generic/streaming/connector/Dockerfile
+++ b/ydb/tests/fq/generic/streaming/connector/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.7.2-rc.4@sha256:3dd675ebdba9ff4a1933443d801ba121d11a9eec20a6da8f0fa5dddc4ba97c0f
+ARG BASE_IMAGE=ghcr.io/ydb-platform/fq-connector-go:v0.11.0-rc.1@sha256:58a1e12de21ef3b403450b176b6220fd545d2802ce16dbc3b05ec4c91e075cdc
 FROM $BASE_IMAGE
 
 COPY ./fq-connector-go.yaml /fq-connector-go.yaml


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

There are two almost independent change:
1) prerequisite: lookup interface change with default `GetMaxSupportedFullscanRequest()` implementation;
2) in input transform (it won't do anything, as lookup will return zero limit),
3) fullscan implementation in generic lookup; with that implemented, input transform will start using fullscans;

- [x] fullscan requests interface addition
- [x] input transform side changes
- [x] generic lookup refactor
- [x] generic lookup side changes
- [x] TBD: yt lookup changes -> won't do now
- [x] generic lookup ut (refactored and added new test)
- [x] integration tests -> existing tests somewhat covers
- [x] implement LIMIT support to connector, and recheck with proper connector version
- [ ] Likely for followup pr: collect statistics and autotune issuing fullscan requests
- [ ] Likely for followup pr: increase Ttl for incomplete fullscan request
- [x] RFC: consider making LIMIT optional and keep workaround for exceeding limit