### PR TITLE
fix: quoter flaky test

### DIFF
--- a/ydb/core/quoter/kesus_quoter_ut.cpp
+++ b/ydb/core/quoter/kesus_quoter_ut.cpp
@@ -84,8 +84,9 @@ Y_UNIT_TEST_SUITE(QuoterWithKesusTest) {
         setup.CreateKesusResource(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", cfg);
 
         setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf"); // stabilization
-        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", rate * prefetch * 0.9, TDuration::MilliSeconds(500));
-        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", rate * prefetch * 0.2, TDuration::MilliSeconds(500));
+        // Consume exactly both ticks' worth: rate * prefetch * 2 = 200,000
+        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", rate * prefetch * 2, TDuration::Seconds(10));
+        // Channel is now exhausted and Balance = 0. This must timeout.
         setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", 1, TDuration::MilliSeconds(500), TEvQuota::TEvClearance::EResult::Deadline);
     }
 


### PR DESCRIPTION
The test consumed 110,001 units (0.9 + 0.2 of rate*prefetch) leaving
~80,000 Balance in tick 2. The final 1-unit request was timing-dependent:
arriving in the same tick saw Balance > 0 (Success/flake), while crossing
the tick boundary found the channel expired (Deadline/expected).

Consume exactly rate * prefetch * 2 = 200,000 units to fully drain both
ticks, making the outcome deterministic regardless of scheduling.

Fixes #26966

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
