### PR TITLE
Disable KeepSocket option for DNS resolver.

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -185,7 +185,7 @@ message TStaticNameserviceConfig {
     repeated string AcceptUUID = 3;
     optional bool SuppressVersionCheck = 4;
     optional ENameserviceType Type = 5;
-    optional bool KeepSocket = 6 [default = true];
+    optional bool KeepSocket = 6 [default = false];
     optional bool ForceTcp = 7 [default = false];
     optional EDnsResolverType DnsResolverType = 8 [default = ARES];
     optional bool AddTrailingDot = 9 [default = false];

--- a/ydb/library/actors/dnsresolver/dnsresolver.h
+++ b/ydb/library/actors/dnsresolver/dnsresolver.h
@@ -97,7 +97,7 @@ namespace NDnsResolver {
         // Optional list of custom dns servers (ip.v4[:port], ip::v6 or [ip::v6]:port format)
         TVector<TString> Servers;
         // Keep soket open between dns requests
-        bool KeepSocket = true;
+        bool KeepSocket = false;
         // Force tcp to perform dns requests
         bool ForceTcp = false;
         // Add trailing dot to hostname


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

In modern environment (k8s + cilius) keeping udp socket often cause issiues is forwarding was changed after socket creation. https://github.com/ydb-platform/ydb/issues/33688

We do not expect any degradation because socket creation is not bottleneck.
### Changelog category <!-- remove all except one -->


* Improvement


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
