### PR TITLE
Support ydb_configure drive.pdisk_config

### DIFF
--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -313,7 +313,6 @@ class ClusterDetailsProvider(object):
         self.table_profiles_config = self.__cluster_description.get("table_profiles_config")
         self.http_proxy_config = self.__cluster_description.get("http_proxy_config")
         self.blob_storage_config = self.__cluster_description.get("blob_storage_config")
-        self.infer_pdisk_slot_count = self._extract_infer_pdisk_slot_count(self.blob_storage_config)
         self.bootstrap_config = self.__cluster_description.get("bootstrap_config")
         self.memory_controller_config = self.__cluster_description.get("memory_controller_config")
         self.kafka_proxy_config = self.__cluster_description.get("kafka_proxy_config")
@@ -359,15 +358,6 @@ class ClusterDetailsProvider(object):
         subjective_description.set_validator(validator)
         subjective_description.validate()
         return subjective_description
-
-    def _extract_infer_pdisk_slot_count(self, blob_storage_config):
-        if blob_storage_config is None:
-            return None
-        if 'infer_pdisk_slot_count' not in blob_storage_config:
-            return None
-        infer_pdisk_slot_count = blob_storage_config['infer_pdisk_slot_count']
-        del blob_storage_config['infer_pdisk_slot_count']
-        return infer_pdisk_slot_count
 
     @property
     def storage_config_generation(self):

--- a/ydb/tools/cfg/dynamic.py
+++ b/ydb/tools/cfg/dynamic.py
@@ -189,7 +189,11 @@ class DynamicConfigGenerator(object):
                 Type=drive.type,
                 Kind=drive.kind,
             )
-            if drive.expected_slot_count is not None:
+            if drive.pdisk_config is not None:
+                pc = pdisk_config.TPDiskConfig()
+                utils.wrap_parse_dict(drive.pdisk_config, pc)
+                kwargs.update(PDiskConfig=pc)
+            elif drive.expected_slot_count is not None:
                 pc = pdisk_config.TPDiskConfig(ExpectedSlotCount=drive.expected_slot_count)
                 kwargs.update(PDiskConfig=pc)
             array.add(**kwargs)

--- a/ydb/tools/cfg/dynamic.py
+++ b/ydb/tools/cfg/dynamic.py
@@ -192,12 +192,6 @@ class DynamicConfigGenerator(object):
             if drive.expected_slot_count is not None:
                 pc = pdisk_config.TPDiskConfig(ExpectedSlotCount=drive.expected_slot_count)
                 kwargs.update(PDiskConfig=pc)
-
-            if self._cluster_details.infer_pdisk_slot_count is not None:
-                infer_settings = self._cluster_details.infer_pdisk_slot_count.get(str(drive.type).lower())
-                if infer_settings is not None:
-                    kwargs.update(InferPDiskSlotCountFromUnitSize=infer_settings['unit_size'])
-                    kwargs.update(InferPDiskSlotCountMax=infer_settings['max_slots'])
             array.add(**kwargs)
 
         for host_config in self._cluster_details.host_configs:

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -465,29 +465,6 @@ class StaticConfigGenerator(object):
             return yaml_config
         return result
 
-    def _apply_infer_pdisk_slot_count_to_host_config(self, host_config):
-        infer_settings = self.__cluster_details.infer_pdisk_slot_count
-        if infer_settings is None:
-            return
-
-        target_cfg = {
-            'infer_pdisk_slot_count_from_unit_size': {},
-            'infer_pdisk_slot_count_max': {},
-        }
-
-        ssd_settings = infer_settings.get('ssd')
-        if ssd_settings:
-            target_cfg['infer_pdisk_slot_count_from_unit_size']['ssd'] = ssd_settings['unit_size']
-            target_cfg['infer_pdisk_slot_count_max']['ssd'] = ssd_settings['max_slots']
-
-        rot_settings = infer_settings.get('rot')
-        if rot_settings:
-            target_cfg['infer_pdisk_slot_count_from_unit_size']['rot'] = rot_settings['unit_size']
-            target_cfg['infer_pdisk_slot_count_max']['rot'] = rot_settings['max_slots']
-
-        if target_cfg["infer_pdisk_slot_count_from_unit_size"]:
-            host_config.update(target_cfg)
-
     def get_normalized_config(self):
         app_config = self.get_app_config()
         dictionary = json_format.MessageToDict(app_config, preserving_proto_field_name=True)
@@ -524,8 +501,6 @@ class StaticConfigGenerator(object):
                             )
 
                             drive['pdisk_config'] = self.normalize_dictionary(json_format.MessageToDict(pd))
-
-                self._apply_infer_pdisk_slot_count_to_host_config(host_config)
 
         if self.table_service_config:
             normalized_config["table_service_config"] = self.table_service_config


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

1. Revert "Configure infer_pdisk_slot_count with ydb_configure (#29778)" to address https://github.com/ydb-platform/ydb/pull/32113
2. Account `drive.pdisk_config` when generating DefineBoxAndStoragePools.txt

Config example:

```
host_configs:
- drive:
  - path: /dev/disk/by-partlabel/kikimr_ssd_01
    pdisk_config:
      expected_slot_count: 18
      slot_size_in_units: 1
    type: SSD
```