### PR TITLE
[CPU Scheduler] Allow fair-share overlimit for equal-to-parent mode

### DIFF
--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -307,7 +307,7 @@ TQueryPtr TComputeScheduler::AddOrUpdateQuery(const NHdrf::TDatabaseId& database
         query->Update(attrs);
     } else {
         bool allowMinFairShare = (!pool->Limit || *pool->Limit > 0)
-            && (FairShareMode == NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            && (FairShareMode >= NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         query = std::make_shared<TQuery>(queryId, &DelayParams, allowMinFairShare, attrs);
         pool->AddQuery(query);
         Y_ENSURE(Queries.emplace(queryId, query).second);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)