### PR TITLE
Not to count system view paths in scheme limits

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -601,6 +601,7 @@ public:
 
         auto schema = Transaction.GetCreateTable();
         const bool isBackup = schema.GetIsBackup();
+        const EPathCategory pathCategory = isBackup ? EPathCategory::Backup : EPathCategory::Regular;
 
         TPath dstPath = parent.Child(name);
         {
@@ -886,7 +887,7 @@ public:
         const ui32 shardsToCreate = tableInfo->GetPartitions().size();
         Y_VERIFY_S(shardsToCreate <= maxShardsToCreate, "shardsToCreate: " << shardsToCreate << " maxShardsToCreate: " << maxShardsToCreate);
 
-        dstPath.DomainInfo()->IncPathsInside(context.SS, 1, isBackup);
+        dstPath.DomainInfo()->IncPathsInside(context.SS, 1, pathCategory);
         dstPath.DomainInfo()->AddInternalShards(txState, context.SS, isBackup);
         dstPath.Base()->IncShardsInside(shardsToCreate);
         IncAliveChildrenSafeWithUndo(OperationId, parent, context, isBackup);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_sysview.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_sysview.cpp
@@ -134,7 +134,7 @@ public:
                 .NotDeleted()
                 .NotUnderDeleting()
                 .IsCommonSensePath()
-                .IsSysViewDirectory();
+                .IsSystemDirectory();
 
             if (!checks) {
                 result->SetError(checks.GetStatus(), checks.GetError());
@@ -161,7 +161,6 @@ public:
                 checks
                     .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
-                    .PathsLimit()
                     .DirChildrenLimit()
                     .IsValidACL(acl);
             }
@@ -202,7 +201,7 @@ public:
         context.DbChanges.PersistTxState(OperationId);
 
         dstPath.MaterializeLeaf(owner, sysViewPathId);
-        dstPath.DomainInfo()->IncPathsInside(context.SS);
+        dstPath.DomainInfo()->IncPathsInside(context.SS, 1, EPathCategory::System);
         IncAliveChildrenSafeWithUndo(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
 
         result->SetPathId(sysViewPathId.LocalPathId);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_sysview.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_sysview.cpp
@@ -56,7 +56,7 @@ public:
         path->SetDropped(step, OperationId.GetTxId());
         context.SS->PersistDropStep(db, pathId, step, OperationId);
         auto domainInfo = context.SS->ResolveDomainInfo(pathId);
-        domainInfo->DecPathsInside(context.SS);
+        domainInfo->DecPathsInside(context.SS, 1, EPathCategory::System);
         DecAliveChildrenDirect(OperationId, parentDir, context); // for correct discard of ChildrenExist prop
 
         context.SS->TabletCounters->Simple()[COUNTER_SYS_VIEW_COUNT].Sub(1);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
@@ -38,9 +38,10 @@ void DropPath(NIceDb::TNiceDb& db,
     context.SS->PersistUserAttributes(db, path->PathId, path->UserAttrs, nullptr);
 
     const auto isBackupTable = context.SS->IsBackupTable(path->PathId);
+    const EPathCategory pathCategory = isBackupTable ? EPathCategory::Backup : EPathCategory::Regular;
 
     auto domainInfo = context.SS->ResolveDomainInfo(path->PathId);
-    domainInfo->DecPathsInside(context.SS, 1, isBackupTable);
+    domainInfo->DecPathsInside(context.SS, 1, pathCategory);
 
     auto parentDir = path.Parent();
     DecAliveChildrenDirect(operationId, parentDir.Base(), context, isBackupTable);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -175,8 +175,9 @@ void MarkSrcDropped(NIceDb::TNiceDb& db,
                     TPath& srcPath)
 {
     const auto isBackupTable = context.SS->IsBackupTable(srcPath->PathId);
+    const EPathCategory pathCategory = isBackupTable ? EPathCategory::Backup : EPathCategory::Regular;
     DecAliveChildrenDirect(operationId, srcPath.Parent().Base(), context, isBackupTable);
-    srcPath.DomainInfo()->DecPathsInside(context.SS, 1, isBackupTable);
+    srcPath.DomainInfo()->DecPathsInside(context.SS, 1, pathCategory);
 
     srcPath->SetDropped(txState.PlanStep, operationId.GetTxId());
     context.SS->PersistDropStep(db, srcPath->PathId, txState.PlanStep, operationId);
@@ -656,8 +657,8 @@ public:
     bool HandleReply(TEvColumnShard::TEvNotifyTxCompletionResult::TPtr& ev, TOperationContext& context) override {
         return HandleReplyImpl(ev, context);
     }
-};    
-    
+};
+
 class TDone: public TSubOperationState {
 private:
     TOperationId OperationId;
@@ -689,7 +690,7 @@ public:
         context.OnComplete.Send(ackTo, std::move(event));
         return false;
     }
-    
+
     bool HandleReply(TEvDataShard::TEvSchemaChanged::TPtr& ev, TOperationContext& context) override {
         return HandleReplyImpl(ev, context);
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_rmdir.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_rmdir.cpp
@@ -156,8 +156,10 @@ public:
         Y_ABORT_UNLESS(!path->Dropped());
         path->SetDropped(step, OperationId.GetTxId());
         context.SS->PersistDropStep(db, pathId, step, OperationId);
+
+        const EPathCategory pathCategory = path->IsSystemDirectory() ? EPathCategory::System : EPathCategory::Regular;
         auto domainInfo = context.SS->ResolveDomainInfo(pathId);
-        domainInfo->DecPathsInside(context.SS);
+        domainInfo->DecPathsInside(context.SS, 1, pathCategory);
         DecAliveChildrenDirect(OperationId, parentDir, context); // for correct discard of ChildrenExist prop
 
         ++parentDir->DirAlterVersion;

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5748,11 +5748,19 @@ THashSet<TShardIdx> TSchemeShard::CollectAllShards(const THashSet<TPathId> &path
 
 void TSchemeShard::UncountNode(TPathElement::TPtr node) {
     const auto isBackupTable = IsBackupTable(node->PathId);
+    EPathCategory pathCategory;
+    if (isBackupTable) {
+        pathCategory = EPathCategory::Backup;
+    } else if (node->IsSystemDirectory() || node->IsSysView()) {
+        pathCategory = EPathCategory::System;
+    } else {
+        pathCategory = EPathCategory::Regular;
+    }
 
     if (node->IsDomainRoot()) {
-        ResolveDomainInfo(node->ParentPathId)->DecPathsInside(this, 1, isBackupTable);
+        ResolveDomainInfo(node->ParentPathId)->DecPathsInside(this, 1, pathCategory);
     } else {
-        ResolveDomainInfo(node)->DecPathsInside(this, 1, isBackupTable);
+        ResolveDomainInfo(node)->DecPathsInside(this, 1, pathCategory);
     }
     PathsById.at(node->ParentPathId)->DecAliveChildrenPrivate(isBackupTable);
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -102,7 +102,7 @@ void TSubDomainInfo::ApplyAuditSettings(const TSubDomainInfo::TMaybeAuditSetting
 }
 
 void TSubDomainInfo::UpdateCounters(IQuotaCounters* counters) {
-    counters->SetPathCount(GetPathsInside());
+    counters->SetPathCount(GetPathsInside() - GetBackupPaths() - GetSystemPaths());
 
     const auto shardsTotal = GetShardsInside();
     const auto backupShards = GetBackupShards();

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -1690,6 +1690,12 @@ struct IQuotaCounters {
     virtual void SetShardsQuota(ui64 value) = 0;
 };
 
+enum class EPathCategory : ui8 {
+    Regular = 0,
+    Backup,
+    System,
+};
+
 struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     using TPtr = TIntrusivePtr<TSubDomainInfo>;
     using TConstPtr = TIntrusiveConstPtr<TSubDomainInfo>;
@@ -1904,27 +1910,51 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         return BackupPathsCount;
     }
 
-    void IncPathsInside(IQuotaCounters* counters, ui64 delta = 1, bool isBackup = false) {
+    ui64 GetSystemPaths() const {
+        return SystemPathsCount;
+    }
+
+    void IncPathsInside(IQuotaCounters* counters, ui64 delta = 1, EPathCategory category = EPathCategory::Regular) {
         Y_ENSURE(Max<ui64>() - PathsInsideCount >= delta);
         PathsInsideCount += delta;
 
-        if (isBackup) {
+        switch (category) {
+        case EPathCategory::Backup: {
             Y_ENSURE(Max<ui64>() - BackupPathsCount >= delta);
             BackupPathsCount += delta;
-        } else {
+            break;
+        }
+        case EPathCategory::System: {
+            Y_ENSURE(Max<ui64>() - SystemPathsCount >= delta);
+            SystemPathsCount += delta;
+            break;
+        }
+        case EPathCategory::Regular: {
             counters->ChangePathCount(delta);
+            break;
+        }
         }
     }
 
-    void DecPathsInside(IQuotaCounters* counters, ui64 delta = 1, bool isBackup = false) {
+    void DecPathsInside(IQuotaCounters* counters, ui64 delta = 1, EPathCategory category = EPathCategory::Regular) {
         Y_ENSURE(PathsInsideCount >= delta, "PathsInsideCount: " << PathsInsideCount << " delta: " << delta);
         PathsInsideCount -= delta;
 
-        if (isBackup) {
+        switch (category) {
+        case EPathCategory::Backup: {
             Y_ENSURE(BackupPathsCount >= delta, "BackupPathsCount: " << BackupPathsCount << " delta: " << delta);
             BackupPathsCount -= delta;
-        } else {
+            break;
+        }
+        case EPathCategory::System: {
+            Y_ENSURE(SystemPathsCount >= delta, "SystemPathsCount: " << SystemPathsCount << " delta: " << delta);
+            SystemPathsCount -= delta;
+            break;
+        }
+        case EPathCategory::Regular: {
             counters->ChangePathCount(-delta);
+            break;
+        }
         }
     }
 
@@ -2413,6 +2443,7 @@ private:
 
     ui64 PathsInsideCount = 0;
     ui64 BackupPathsCount = 0;
+    ui64 SystemPathsCount = 0;
     TDiskSpaceUsage DiskSpaceUsage;
 
     THashSet<TShardIdx> InternalShards;

--- a/ydb/core/tx/schemeshard/schemeshard_path.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path.h
@@ -85,7 +85,7 @@ public:
         const TChecker& IsCdcStream(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsLikeDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
-        const TChecker& IsSysViewDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
+        const TChecker& IsSystemDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsRtmrVolume(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsTheSameDomain(const TPath& another, EStatus status = EStatus::StatusInvalidParameter) const;
         const TChecker& FailOnWrongType(const TSet<TPathElement::EPathType>& expectedTypes) const;

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -1,5 +1,7 @@
 #include "schemeshard_path_element.h"
 
+#include <ydb/core/sys_view/common/path.h>
+
 #include <library/cpp/json/json_reader.h>
 
 namespace NKikimr::NSchemeShard {
@@ -107,6 +109,10 @@ bool TPathElement::IsRoot() const {
 
 bool TPathElement::IsDirectory() const {
     return PathType == EPathType::EPathTypeDir;
+}
+
+bool TPathElement::IsSystemDirectory() const {
+    return IsDirectory() && Name == NSysView::SysPathName;
 }
 
 bool TPathElement::IsTableIndex() const {

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -111,6 +111,7 @@ public:
     void DecShardsInside(ui64 delta = 1);
     bool IsRoot() const;
     bool IsDirectory() const;
+    bool IsSystemDirectory() const;
     bool IsTableIndex() const;
     bool IsCdcStream() const;
     bool IsTable() const;

--- a/ydb/core/tx/schemeshard/ut_base/ut_counters.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_counters.cpp
@@ -36,7 +36,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardCountersTest) {
             NLs::PathsInsideDomain(initPathsCount)
         });
 
-        UNIT_ASSERT_VALUES_EQUAL(schemeshard->TabletCounters->Simple()[COUNTER_PATHS].Get(), initPathsCount);
+        UNIT_ASSERT_VALUES_EQUAL(schemeshard->TabletCounters->Simple()[COUNTER_PATHS].Get(), 0);
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Dir/Table"
             Columns { Name: "key"   Type: "Uint64"}
@@ -48,7 +48,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardCountersTest) {
         TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
             NLs::PathsInsideDomain(initPathsCount)
         });
-        UNIT_ASSERT_VALUES_EQUAL(schemeshard->TabletCounters->Simple()[COUNTER_PATHS].Get(), initPathsCount);
+        UNIT_ASSERT_VALUES_EQUAL(schemeshard->TabletCounters->Simple()[COUNTER_PATHS].Get(), 0);
     }
 
 }

--- a/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
@@ -398,7 +398,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
             .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
-            .EnableRealSystemViewPaths(false)
         ;
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
@@ -450,7 +449,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                                     NLs::DomainLimitsIs(limits.MaxPaths, limits.MaxShards)});
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(2),
+                                   {NLs::ChildrenCount(3),
                                     NLs::DomainLimitsIs(limits.MaxPaths, limits.MaxShards)});
 
                 TestCreateTable(runtime, subdomainSchemeshard, ++t.TxId, "/MyRoot/USER_0", R"(
@@ -468,7 +467,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
 
     Y_UNIT_TEST(AlterSchemeLimits) {
         TTestWithReboots t;
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         //INFO: Temporarily this test will not run when EnableAlterDatabase is not set
         t.GetTestEnvOptions().EnableAlterDatabase(true);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
@@ -476,7 +474,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
             limits.MaxShards = 7;
             limits.MaxShardsInPath = 3;
             limits.MaxPaths = 5;
-            limits.MaxChildrenInDir = 3;
+            limits.MaxChildrenInDir = 4;
 
             {
                 TInactiveZone inactive(activeZone);
@@ -542,13 +540,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/Alice"), {
                     NLs::PathExist,
                     NLs::SchemeLimits(limits.AsProto()),
-                    NLs::ShardsInsideDomain(3),
-                    NLs::PathsInsideDomain(0)
+                    NLs::ShardsInsideDomain(3)
                 });
 
                 const auto defaultLimits = TSchemeLimits().AsProto();
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
-                    NLs::ChildrenCount(2),
+                    NLs::ChildrenCount(3),
                     NLs::SchemeLimits(defaultLimits)
                 });
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
@@ -225,27 +225,26 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
 
         auto describe = DescribePath(runtime, "/MyRoot/texts");
         UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), NKikimrScheme::StatusSuccess, "Unexpected status: " << describe.GetStatus());
-        auto curPaths = describe.GetPathDescription().GetDomainDescription().GetPathsInside();
         auto curShards = describe.GetPathDescription().GetDomainDescription().GetShardsInside();
 
         Ydb::Table::TableIndex index = FulltextIndexConfig();
 
         TSchemeLimits lowLimits;
 
-        lowLimits.MaxPaths = curPaths+5;
-        lowLimits.MaxShards = curShards+3;
+        lowLimits.MaxPaths = 6;
+        lowLimits.MaxShards = curShards + 3;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", index, Ydb::StatusIds::PRECONDITION_FAILED);
         env.TestWaitNotification(runtime, txId);
 
-        lowLimits.MaxPaths = curPaths+4;
-        lowLimits.MaxShards = curShards+4;
+        lowLimits.MaxPaths = 5;
+        lowLimits.MaxShards = curShards + 4;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", index, Ydb::StatusIds::PRECONDITION_FAILED);
         env.TestWaitNotification(runtime, txId);
 
-        lowLimits.MaxPaths = curPaths+5;
-        lowLimits.MaxShards = curShards+4;
+        lowLimits.MaxPaths = 6;
+        lowLimits.MaxShards = curShards + 4;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", index, Ydb::StatusIds::SUCCESS);
         env.TestWaitNotification(runtime, txId);

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -1847,19 +1847,18 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
 
         auto describe = DescribePath(runtime, "/MyRoot/Table");
         UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), NKikimrScheme::StatusSuccess, "Unexpected status: " << describe.GetStatus());
-        auto curPaths = describe.GetPathDescription().GetDomainDescription().GetPathsInside();
         auto curShards = describe.GetPathDescription().GetDomainDescription().GetShardsInside();
 
         TSchemeLimits lowLimits;
 
-        lowLimits.MaxPaths = curPaths+2;
-        lowLimits.MaxShards = curShards+2;
+        lowLimits.MaxPaths = 3;
+        lowLimits.MaxShards = curShards + 2;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildVectorIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", "idx_global", {"embedding"}, Ydb::StatusIds::PRECONDITION_FAILED);
         env.TestWaitNotification(runtime, txId);
 
-        lowLimits.MaxPaths = curPaths+3;
-        lowLimits.MaxShards = curShards+1;
+        lowLimits.MaxPaths = 4;
+        lowLimits.MaxShards = curShards + 1;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildVectorIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", "idx_global", {"embedding"}, Ydb::StatusIds::PRECONDITION_FAILED);
         env.TestWaitNotification(runtime, txId);
@@ -1867,8 +1866,8 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
         Ydb::Table::GlobalIndexSettings shardingProto;
         shardingProto.set_uniform_partitions(2);
         auto sharding = NYdb::NTable::TGlobalIndexSettings::FromProto(shardingProto);
-        lowLimits.MaxPaths = curPaths+3;
-        lowLimits.MaxShards = curShards+4;
+        lowLimits.MaxPaths = 4;
+        lowLimits.MaxShards = curShards + 4;
         lowLimits.MaxShardsInPath = 1;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", TBuildIndexConfig{
@@ -1900,25 +1899,24 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
 
         auto describe = DescribePath(runtime, "/MyRoot/Table");
         UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), NKikimrScheme::StatusSuccess, "Unexpected status: " << describe.GetStatus());
-        auto curPaths = describe.GetPathDescription().GetDomainDescription().GetPathsInside();
         auto curShards = describe.GetPathDescription().GetDomainDescription().GetShardsInside();
 
         TSchemeLimits lowLimits;
 
-        lowLimits.MaxPaths = curPaths+4;
-        lowLimits.MaxShards = curShards+4;
+        lowLimits.MaxPaths = 5;
+        lowLimits.MaxShards = curShards + 4;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildVectorIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", "idx_global", {"prefix", "embedding"}, Ydb::StatusIds::PRECONDITION_FAILED);
         env.TestWaitNotification(runtime, txId);
 
-        lowLimits.MaxPaths = curPaths+5;
-        lowLimits.MaxShards = curShards+3;
+        lowLimits.MaxPaths = 6;
+        lowLimits.MaxShards = curShards + 3;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildVectorIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", "idx_global", {"prefix", "embedding"}, Ydb::StatusIds::PRECONDITION_FAILED);
         env.TestWaitNotification(runtime, txId);
 
-        lowLimits.MaxPaths = curPaths+5;
-        lowLimits.MaxShards = curShards+4;
+        lowLimits.MaxPaths = 6;
+        lowLimits.MaxShards = curShards + 4;
         SetSchemeshardSchemaLimits(runtime, lowLimits);
         TestBuildVectorIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", "idx_global", {"prefix", "embedding"});
         env.TestWaitNotification(runtime, txId);

--- a/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
@@ -2224,6 +2224,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
         lowLimits.MaxShards = 3;
         lowLimits.MaxPQPartitions = 300;
 
+        SetSchemeshardSchemaLimits(runtime, lowLimits);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::PathExist
+                            , NLs::DomainLimitsIs(lowLimits.MaxPaths, lowLimits.MaxShards)});
+
         TestCreateSubDomain(runtime, txId++,  "/MyRoot",
                             "PlanResolution: 50 "
                             "Coordinators: 1 "
@@ -2235,8 +2241,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
                             "}");
         env.TestWaitNotification(runtime, 100);
         expectedDomainPaths += 1;
-
-        SetSchemeshardSchemaLimits(runtime, lowLimits);
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                            {NLs::PathExist
@@ -2274,6 +2278,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
         lowLimits.MaxShardsInPath = 4;
         lowLimits.MaxPQPartitions = 20;
 
+        SetSchemeshardSchemaLimits(runtime, lowLimits);
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::PathExist,
+                            NLs::DomainLimitsIs(lowLimits.MaxPaths, lowLimits.MaxShards, lowLimits.MaxPQPartitions)});
 
         //create subdomain
         {
@@ -2289,8 +2297,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
                                 "}");
             env.TestWaitNotification(runtime, txId - 1);
             expectedDomainPaths += 1;
-
-            SetSchemeshardSchemaLimits(runtime, lowLimits);
 
             TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                {NLs::PathExist,
@@ -2731,12 +2737,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        auto initialDomainDesc = DescribePath(runtime, "/MyRoot");
-        ui64 currentDomainPaths = initialDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
-
         TSchemeLimits lowLimits;
         lowLimits.MaxDepth = 4;
-        lowLimits.MaxPaths = currentDomainPaths + 3; // current paths + original limit
+        lowLimits.MaxPaths = 3;
         lowLimits.MaxChildrenInDir = 4;
         lowLimits.MaxAclBytesSize = 25;
         lowLimits.MaxTableColumns = 3;
@@ -2765,7 +2768,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
                                 "    data_stream_reserved_storage_quota: 200000"
                                 "}");
 
-            SetSchemeshardSchemaLimits(runtime, lowLimits);
         }
 
         //create column tables, column limits
@@ -2892,6 +2894,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
         lowLimits.MaxShardsInPath = 4;
         lowLimits.ExtraPathSymbolsAllowed = "_.-";
 
+        SetSchemeshardSchemaLimits(runtime, lowLimits);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::PathExist,
+                            NLs::DomainLimitsIs(lowLimits.MaxPaths, lowLimits.MaxShards)});
+
         //create subdomain
         {
             TestCreateSubDomain(runtime, txId++,  "/MyRoot",
@@ -2902,8 +2910,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
                                 "Name: \"USER_0\"");
             env.TestWaitNotification(runtime, txId - 1);
             expectedDomainPaths += 1;
-
-            SetSchemeshardSchemaLimits(runtime, lowLimits);
 
             TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                {NLs::PathExist,
@@ -3079,12 +3085,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        auto initialDomainDesc = DescribePath(runtime, "/MyRoot");
-        ui64 currentPaths = initialDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
-
         TSchemeLimits lowLimits;
         lowLimits.MaxDepth = 4;
-        lowLimits.MaxPaths = currentPaths + 5; // current paths + original limit
+        lowLimits.MaxPaths = 5;
         lowLimits.MaxChildrenInDir = 3;
         lowLimits.MaxTableIndices = 4;
         lowLimits.MaxShards = 7;


### PR DESCRIPTION
Ignore `.sys` and system view paths in checking scheme limits.
