### PR TITLE
Don't make unnecessary dynamic allocations/deallocations on startup and shutdown.

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_sectormap.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_sectormap.cpp
@@ -34,7 +34,7 @@ Y_UNIT_TEST_SUITE(TSectorMapPerformance) {
 
         auto deviceType = NPDisk::NSectorMap::DiskModeToDeviceType(diskMode);
         ui64 diskRate;
-        const auto& performanceParams = NPDisk::DevicePerformance.at(deviceType);
+        const auto& performanceParams = NPDisk::TDevicePerformanceParams::Get(deviceType);
         if (operationType == EOperationType::OperationRead) {
             diskRate = (sectorPosition == ESectorPosition::SectorFirst)
                     ? performanceParams.FirstSectorReadBytesPerSec

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -484,7 +484,7 @@ public:
 
             // fill in the response
             TVector<TChunkIdx> ownedChunks(owner->CommittedChunks.begin(), owner->CommittedChunks.end());
-            const auto& performanceParams = NPDisk::DevicePerformance.at(Impl.DeviceType);
+            const auto& performanceParams = NPDisk::TDevicePerformanceParams::Get(Impl.DeviceType);
             const ui64 seekTimeUs = (performanceParams.SeekTimeNs + 1000) / 1000 - 1;
             const ui64 readSpeedBps = performanceParams.FirstSectorReadBytesPerSec;
             const ui64 writeSpeedBps = performanceParams.FirstSectorWriteBytesPerSec;

--- a/ydb/library/pdisk_io/device_type.cpp
+++ b/ydb/library/pdisk_io/device_type.cpp
@@ -3,6 +3,62 @@
 
 
 namespace NKikimr::NPDisk {
+
+namespace {
+
+constexpr TDevicePerformanceParams DevicePerformance[] = {
+    // DEVICE_TYPE_ROT = 0,
+    TDevicePerformanceParams{
+        .SeekTimeNs = 8000000,
+        .FirstSectorReadBytesPerSec = 200ull * 1024 * 1024,
+        .LastSectorReadBytesPerSec = 66ull * 1024 * 1024,
+        .FirstSectorWriteBytesPerSec = 200ull * 1024 * 1024,
+        .LastSectorWriteBytesPerSec = 66ull * 1024 * 1024,
+        .BurstThresholdNs = 200'000'000,
+    },
+    // DEVICE_TYPE_SSD = 1,
+    TDevicePerformanceParams{
+        .SeekTimeNs = 40000,
+        .FirstSectorReadBytesPerSec = 500ull * 1024 * 1024,
+        .LastSectorReadBytesPerSec = 500ull * 1024 * 1024,
+        .FirstSectorWriteBytesPerSec = 500ull * 1024 * 1024,
+        .LastSectorWriteBytesPerSec = 500ull * 1024 * 1024,
+        .BurstThresholdNs = 50'000'000,
+    },
+    // DEVICE_TYPE_NVME = 2,
+    TDevicePerformanceParams{
+        .SeekTimeNs = 40000,
+        .FirstSectorReadBytesPerSec = 1000ull * 1024 * 1024,
+        .LastSectorReadBytesPerSec = 1000ull * 1024 * 1024,
+        .FirstSectorWriteBytesPerSec = 1000ull * 1024 * 1024,
+        .LastSectorWriteBytesPerSec = 1000ull * 1024 * 1024,
+        .BurstThresholdNs = 32'000'000,
+    },
+    // DEVICE_TYPE_UNKNOWN = 255,
+    TDevicePerformanceParams{
+        .SeekTimeNs = 0,
+        .FirstSectorReadBytesPerSec = 0,
+        .LastSectorReadBytesPerSec = 0,
+        .FirstSectorWriteBytesPerSec = 0,
+        .LastSectorWriteBytesPerSec = 0,
+        .BurstThresholdNs = 1'000'000'000,
+    },
+};
+
+} // namespace
+
+    // static
+    const TDevicePerformanceParams& TDevicePerformanceParams::Get(EDeviceType deviceType) {
+        switch (deviceType) {
+            case DEVICE_TYPE_ROT:
+            case DEVICE_TYPE_SSD:
+            case DEVICE_TYPE_NVME:
+                return DevicePerformance[deviceType];
+            default:
+                return DevicePerformance[3];
+        }
+    }
+
     EDeviceType DeviceTypeFromStr(const TString &typeName) {
         if (typeName == "ROT" || typeName == "DEVICE_TYPE_ROT") {
             return DEVICE_TYPE_ROT;

--- a/ydb/library/pdisk_io/device_type.h
+++ b/ydb/library/pdisk_io/device_type.h
@@ -3,8 +3,6 @@
 #include <util/generic/string.h>
 #include <util/system/types.h>
 
-#include <unordered_map>
-
 namespace NKikimr::NPDisk {
     enum EDeviceType : ui8 {
         DEVICE_TYPE_ROT = 0,
@@ -20,41 +18,8 @@ namespace NKikimr::NPDisk {
         ui64 FirstSectorWriteBytesPerSec;
         ui64 LastSectorWriteBytesPerSec;
         ui64 BurstThresholdNs;
-    };
 
-    const static std::unordered_map<EDeviceType, TDevicePerformanceParams> DevicePerformance = {
-        { DEVICE_TYPE_UNKNOWN, TDevicePerformanceParams{
-            .SeekTimeNs = 0,
-            .FirstSectorReadBytesPerSec = 0,
-            .LastSectorReadBytesPerSec = 0,
-            .FirstSectorWriteBytesPerSec = 0,
-            .LastSectorWriteBytesPerSec = 0,
-            .BurstThresholdNs = 1'000'000'000,
-        } },
-        { DEVICE_TYPE_ROT, TDevicePerformanceParams{
-            .SeekTimeNs = 8000000,
-            .FirstSectorReadBytesPerSec = 200ull * 1024 * 1024,
-            .LastSectorReadBytesPerSec = 66ull * 1024 * 1024,
-            .FirstSectorWriteBytesPerSec = 200ull * 1024 * 1024,
-            .LastSectorWriteBytesPerSec = 66ull * 1024 * 1024,
-            .BurstThresholdNs = 200'000'000,
-        } },
-        { DEVICE_TYPE_SSD, TDevicePerformanceParams{
-            .SeekTimeNs = 40000,
-            .FirstSectorReadBytesPerSec = 500ull * 1024 * 1024,
-            .LastSectorReadBytesPerSec = 500ull * 1024 * 1024,
-            .FirstSectorWriteBytesPerSec = 500ull * 1024 * 1024,
-            .LastSectorWriteBytesPerSec = 500ull * 1024 * 1024,
-            .BurstThresholdNs = 50'000'000,
-        } },
-        { DEVICE_TYPE_NVME, TDevicePerformanceParams{
-            .SeekTimeNs = 40000,
-            .FirstSectorReadBytesPerSec = 1000ull * 1024 * 1024,
-            .LastSectorReadBytesPerSec = 1000ull * 1024 * 1024,
-            .FirstSectorWriteBytesPerSec = 1000ull * 1024 * 1024,
-            .LastSectorWriteBytesPerSec = 1000ull * 1024 * 1024,
-            .BurstThresholdNs = 32'000'000,
-        } },
+        static const TDevicePerformanceParams& Get(EDeviceType deviceType);
     };
 
     TString DeviceTypeStr(const EDeviceType type, bool isShort);

--- a/ydb/library/pdisk_io/sector_map.h
+++ b/ydb/library/pdisk_io/sector_map.h
@@ -127,11 +127,12 @@ public:
 
         Y_ABORT_UNLESS((ui32)diskMode < DM_COUNT);
         EDeviceType deviceType = DiskModeToDeviceType(diskMode);
-        DiskModeParams.SeekSleepMicroSeconds = (DevicePerformance.at(deviceType).SeekTimeNs + 1000) / 1000 - 1;
-        DiskModeParams.FirstSectorReadRate = DevicePerformance.at(deviceType).FirstSectorReadBytesPerSec;
-        DiskModeParams.LastSectorReadRate = DevicePerformance.at(deviceType).LastSectorReadBytesPerSec;
-        DiskModeParams.FirstSectorWriteRate = DevicePerformance.at(deviceType).FirstSectorWriteBytesPerSec;
-        DiskModeParams.LastSectorWriteRate = DevicePerformance.at(deviceType).LastSectorWriteBytesPerSec;
+        const auto &devicePerformance = TDevicePerformanceParams::Get(deviceType);
+        DiskModeParams.SeekSleepMicroSeconds = (devicePerformance.SeekTimeNs + 1000) / 1000 - 1;
+        DiskModeParams.FirstSectorReadRate = devicePerformance.FirstSectorReadBytesPerSec;
+        DiskModeParams.LastSectorReadRate = devicePerformance.LastSectorReadBytesPerSec;
+        DiskModeParams.FirstSectorWriteRate = devicePerformance.FirstSectorWriteBytesPerSec;
+        DiskModeParams.LastSectorWriteRate = devicePerformance.LastSectorWriteBytesPerSec;
 
         MaxSector = sectors - 1;
         MostRecentlyUsedSector = 0;
@@ -257,7 +258,7 @@ public:
                 Y_VERIFY_S(offset + 4096 <= DeviceSize, "It is not possible to shrink TSectorMap with data");
             }
         }
-        
+
         DeviceSize = size;
 
         InitSectorOperationThrottler();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Using unordered_map leads to memory allocation at the start of the application and an attempt to free it at the end. Which can lead to a crash if the memory allocator was replaced. 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
