### PR TITLE
[CBO] Predict CBO optimization time using symbolic regression model & disable CBO if it exceeds budget

### DIFF
--- a/ydb/core/kqp/opt/cbo/cbo_optimizer_new.h
+++ b/ydb/core/kqp/opt/cbo/cbo_optimizer_new.h
@@ -402,7 +402,7 @@ public:
 };
 
 struct TCBOSettings {
-    ui32 MaxDPhypDPTableSize = 100000;
+    ui32 CBOTimeout = 1'000ULL; // 1s
     ui32 ShuffleEliminationJoinNumCutoff = 14;
 };
 

--- a/ydb/core/kqp/opt/cbo/solver/bitset.h
+++ b/ydb/core/kqp/opt/cbo/solver/bitset.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdlib.h>
+#include <bitset>
 
 /*
  * This header contains helper functions for working with bitsets.

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_cbo_latency_predictor.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_cbo_latency_predictor.cpp
@@ -1,0 +1,173 @@
+#include "kqp_opt_cbo_latency_predictor.h"
+#include <cmath>
+#include <optional>
+#include <vector>
+#include <set>
+#include <iomanip>
+
+namespace NKikimr::NKqp {
+
+    // ==================== Helper Functions ====================
+
+    double ComputeStdDev(const std::vector<double>& values) {
+        if (values.empty()) {
+            return 0.0;
+        }
+
+        double mean = 0.0;
+        for (double val : values) {
+            mean += val;
+        }
+        mean /= values.size();
+
+        double variance = 0.0;
+        for (double val : values) {
+            variance += (val - mean) * (val - mean);
+        }
+        variance /= values.size();
+
+        return std::sqrt(variance);
+    }
+
+    std::pair<double, double> ComputeMeanAndStdDev(const std::vector<double>& values) {
+        if (values.empty()) {
+            return {0.0, 0.0};
+        }
+
+        double mean = 0.0;
+        for (double val : values) {
+            mean += val;
+        }
+        mean /= values.size();
+
+        double variance = 0.0;
+        for (double val : values) {
+            variance += (val - mean) * (val - mean);
+        }
+        variance /= values.size();
+
+        return {mean, std::sqrt(variance)};
+    }
+
+    std::optional<double> ComputeAssortativity(
+        const std::vector<double>& sourceDegrees,
+        const std::vector<double>& targetDegrees
+    ) {
+        if (sourceDegrees.size() != targetDegrees.size() || sourceDegrees.empty()) {
+            return std::nullopt;
+        }
+
+        double sumSource = 0.0, sumTarget = 0.0;
+        double sumSourceTarget = 0.0;
+        double sumSourceSq = 0.0, sumTargetSq = 0.0;
+        size_t numEdges = sourceDegrees.size();
+
+        for (size_t idx = 0; idx < numEdges; ++idx) {
+            double source = sourceDegrees[idx];
+            double target = targetDegrees[idx];
+            sumSource += source;
+            sumTarget += target;
+            sumSourceTarget += source * target;
+            sumSourceSq += source * source;
+            sumTargetSq += target * target;
+        }
+
+        double numEdgesD = static_cast<double>(numEdges);
+        double varSource = numEdgesD * sumSourceSq - sumSource * sumSource;
+        double varTarget = numEdgesD * sumTargetSq - sumTarget * sumTarget;
+
+        if (varSource < 1e-12 || varTarget < 1e-12) {
+            return 0.0;
+        }
+
+        return (numEdgesD * sumSourceTarget - sumSource * sumTarget) / std::sqrt(varSource * varTarget);
+    }
+
+    // ==================== Safe Operators ====================
+
+    const double EPSILON = 1e-9;
+
+    template <typename T>
+    T Signum(T value) {
+        return (T(0) < value) - (value < T(0));
+    }
+
+    double SafeDiv(double a, double b) {
+        if (b == 0.0) {
+            return a / EPSILON;
+        }
+
+        return a / (Signum(b) * std::max(std::abs(b), EPSILON));
+    }
+
+    double SafeSqrt(double a) {
+        return std::sqrt(std::abs(a));
+    }
+
+    double SafeLog(double a) {
+        return std::log(std::max(std::abs(a), EPSILON));
+    }
+
+    double SafePow(double base, double exponent) {
+        return std::pow(std::abs(base), exponent);
+    }
+
+    double SafeExpm1(double a) {
+        // 40 is a bit shy of 44 (for safety) which is the maximum
+        // whole number for which the result will fit in ui64
+        if (a > 40.0) {
+            return std::exp(40.0);
+        }
+        if (a < 0) {
+            return 0;
+        }
+        return std::exp(a) - 1;
+    }
+
+    std::pair<std::string, double> SelectUnit(ui64 nanoseconds) {
+        if (nanoseconds >= 1'000'000'000) {
+            return {"s", 1e9};
+        } else if (nanoseconds >= 1'000'000) {
+            return {"ms", 1e6};
+        } else if (nanoseconds >= 1'000) {
+            return {"mcs", 1e3};
+        } else {
+            return {"ns", 1.0};
+        }
+    }
+
+    int GetDecimalPlaces(double scaledValue) {
+        if (scaledValue < 0.01) {
+            return 4;
+        }
+
+        double absValue = std::abs(scaledValue);
+
+        if (absValue >= 1000.0) {
+            return 0;
+        } else if (absValue >= 100.0) {
+            return 1;
+        } else if (absValue >= 10.0) {
+            return 2;
+        } else if (absValue >= 1.0) {
+            return 2;
+        } else if (absValue >= 0.1) {
+            return 3;
+        } else {
+            return 4;
+        }
+    }
+
+    std::string FormatTime(ui64 valueNs) {
+        auto [unit, scale] = SelectUnit(valueNs);
+        double scaledValue = valueNs / scale;
+
+        int decimalPlaces = GetDecimalPlaces(scaledValue);
+
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(decimalPlaces);
+        oss << scaledValue << " " << unit;
+
+        return oss.str();
+    }
+} // end namespace NKikimr::NKqp

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_cbo_latency_predictor.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_cbo_latency_predictor.h
@@ -1,0 +1,391 @@
+#pragma once
+
+#include "kqp_opt_join_hypergraph.h"
+#include <cmath>
+#include <optional>
+#include <vector>
+#include <set>
+
+namespace NKikimr::NKqp {
+
+    template <typename TNodeSet>
+    struct THypergraphFeatures {
+        size_t NumHyperedges = 0;
+        double InnerJoinRatio = 0.0;
+        double HyperedgeVolumeStd = 0.0;
+        double DegreesStd = 0.0;
+        double DegreesMean = 0.0;
+        double PrimalAssortativity = 0.0;
+        size_t PrimalDegeneracy = 0;
+        double PrimalDensity = 0.0;
+        double PrimalHeterogeneity = 0.0;
+        double BipartiteAssortativity = 0.0;
+        size_t BipartiteLeafNodes = 0;
+    };
+
+    // ==================== Helper Functions ====================
+
+    double ComputeStdDev(const std::vector<double>& values);
+
+    std::pair<double, double> ComputeMeanAndStdDev(const std::vector<double>& values);
+
+    std::optional<double> ComputeAssortativity(
+        const std::vector<double>& sourceDegrees,
+        const std::vector<double>& targetDegrees
+    );
+
+    // ==================== Primal Graph Builder ====================
+
+    template <typename TNodeSet>
+    std::vector<std::set<size_t>> BuildPrimalAdjacency(TJoinHypergraph<TNodeSet>& graph) {
+        std::vector<std::set<size_t>> adjacency(graph.GetNodes().size());
+
+        for (const auto& edge : graph.GetEdges()) {
+            if (edge.IsReversed) {
+                continue;
+            }
+            for (auto leftIt = TSetBitsIt(edge.Left); leftIt.HasNext(); ) {
+                size_t leftNode = leftIt.Next();
+                for (auto rightIt = TSetBitsIt(edge.Right); rightIt.HasNext(); ) {
+                    size_t rightNode = rightIt.Next();
+                    adjacency[leftNode].insert(rightNode);
+                    adjacency[rightNode].insert(leftNode);
+                }
+            }
+        }
+
+        return adjacency;
+    }
+
+    template <typename TNodeSet>
+    std::vector<double> GetPrimalDegrees(const std::vector<std::set<size_t>>& adjacency) {
+        std::vector<double> degrees;
+        degrees.reserve(adjacency.size());
+        for (const auto& neighbors : adjacency) {
+            degrees.push_back(static_cast<double>(neighbors.size()));
+        }
+        return degrees;
+    }
+
+    // ==================== Feature Functions ====================
+
+    template <typename TNodeSet>
+    size_t ComputeNumHyperedges(TJoinHypergraph<TNodeSet>& graph) {
+        size_t count = 0;
+        for (const auto& edge : graph.GetEdges()) {
+            if (!edge.IsReversed) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    template <typename TNodeSet>
+    double ComputeInnerJoinRatio(TJoinHypergraph<TNodeSet>& graph) {
+        size_t total = 0;
+        size_t inner = 0;
+        for (const auto& edge : graph.GetEdges()) {
+            if (edge.IsReversed) {
+                continue;
+            }
+            total++;
+            if (edge.JoinKind == EJoinKind::InnerJoin) {
+                inner++;
+            }
+        }
+        return total > 0 ? static_cast<double>(inner) / total : 0.0;
+    }
+
+    template <typename TNodeSet>
+    size_t PopCount(const TNodeSet& nodeSet) {
+        size_t count = 0;
+        for (auto it = TSetBitsIt(nodeSet); it.HasNext(); ) {
+            it.Next();
+            count++;
+        }
+        return count;
+    }
+
+    template <typename TNodeSet>
+    double ComputeHyperedgeVolumeStd(TJoinHypergraph<TNodeSet>& graph) {
+        std::vector<double> volumes;
+        for (const auto& edge : graph.GetEdges()) {
+            if (edge.IsReversed) {
+                continue;
+            }
+            size_t volume = PopCount(edge.Left | edge.Right);
+            volumes.push_back(static_cast<double>(volume));
+        }
+        return ComputeStdDev(volumes);
+    }
+
+    template <typename TNodeSet>
+    std::pair<double, double> ComputeNodeDegreeStats(TJoinHypergraph<TNodeSet>& graph) {
+        std::vector<size_t> degreeCounts(graph.GetNodes().size(), 0);
+
+        for (const auto& edge : graph.GetEdges()) {
+            if (edge.IsReversed) {
+                continue;
+            }
+            TNodeSet combined = edge.Left | edge.Right;
+            for (auto it = TSetBitsIt(combined); it.HasNext(); ) {
+                degreeCounts[it.Next()]++;
+            }
+        }
+
+        std::vector<double> degrees;
+        degrees.reserve(degreeCounts.size());
+        for (size_t deg : degreeCounts) {
+            degrees.push_back(static_cast<double>(deg));
+        }
+
+        return ComputeMeanAndStdDev(degrees);
+    }
+
+    template <typename TNodeSet>
+    std::optional<double> ComputePrimalAssortativity(TJoinHypergraph<TNodeSet>& graph) {
+        auto adjacency = BuildPrimalAdjacency(graph);
+        auto degrees = GetPrimalDegrees<TNodeSet>(adjacency);
+
+        std::vector<double> sourceDegrees;
+        std::vector<double> targetDegrees;
+
+        for (size_t node = 0; node < adjacency.size(); ++node) {
+            for (size_t neighbor : adjacency[node]) {
+                if (node < neighbor) {
+                    sourceDegrees.push_back(degrees[node]);
+                    targetDegrees.push_back(degrees[neighbor]);
+                }
+            }
+        }
+
+        return ComputeAssortativity(sourceDegrees, targetDegrees);
+    }
+
+    template <typename TNodeSet>
+    size_t ComputePrimalDegeneracy(TJoinHypergraph<TNodeSet>& graph) {
+        auto adjacency = BuildPrimalAdjacency(graph);
+        size_t numNodes = adjacency.size();
+
+        std::vector<size_t> degree(numNodes);
+        for (size_t idx = 0; idx < numNodes; ++idx) {
+            degree[idx] = adjacency[idx].size();
+        }
+
+        std::vector<size_t> coreNumber(numNodes, 0);
+        std::vector<bool> removed(numNodes, false);
+        size_t remaining = numNodes;
+
+        for (size_t currentCore = 0; remaining > 0; ) {
+            bool foundNode = false;
+            for (size_t idx = 0; idx < numNodes; ++idx) {
+                if (!removed[idx] && degree[idx] <= currentCore) {
+                    removed[idx] = true;
+                    coreNumber[idx] = currentCore;
+                    remaining--;
+                    foundNode = true;
+                    for (size_t neighbor : adjacency[idx]) {
+                        if (!removed[neighbor]) {
+                            degree[neighbor]--;
+                        }
+                    }
+                }
+            }
+            if (!foundNode) {
+                currentCore++;
+            }
+        }
+
+        size_t maxCore = 0;
+        for (size_t core : coreNumber) {
+            maxCore = std::max(maxCore, core);
+        }
+        return maxCore;
+    }
+
+    template <typename TNodeSet>
+    double ComputePrimalDensity(TJoinHypergraph<TNodeSet>& graph) {
+        size_t numNodes = graph.GetNodes().size();
+        if (numNodes < 2) {
+            return 0.0;
+        }
+
+        auto adjacency = BuildPrimalAdjacency(graph);
+
+        size_t numEdges = 0;
+        for (size_t idx = 0; idx < adjacency.size(); ++idx) {
+            for (size_t neighbor : adjacency[idx]) {
+                if (idx < neighbor) {
+                    numEdges++;
+                }
+            }
+        }
+
+        size_t maxEdges = numNodes * (numNodes - 1) / 2;
+        return static_cast<double>(numEdges) / maxEdges;
+    }
+
+    template <typename TNodeSet>
+    double ComputePrimalHeterogeneity(TJoinHypergraph<TNodeSet>& graph) {
+        auto adjacency = BuildPrimalAdjacency(graph);
+        auto degrees = GetPrimalDegrees<TNodeSet>(adjacency);
+
+        if (degrees.empty()) {
+            return 0.0;
+        }
+
+        double sumDegree = 0.0;
+        double sumDegreeSq = 0.0;
+        for (double deg : degrees) {
+            sumDegree += deg;
+            sumDegreeSq += deg * deg;
+        }
+
+        if (sumDegreeSq < 1e-12) {
+            return 0.0;
+        }
+
+        double numNodes = static_cast<double>(degrees.size());
+        return (sumDegree / numNodes) / (sumDegreeSq / numNodes);
+    }
+
+    template <typename TNodeSet>
+    std::optional<double> ComputeBipartiteAssortativity(TJoinHypergraph<TNodeSet>& graph) {
+        std::vector<size_t> nodeDegree(graph.GetNodes().size(), 0);
+        std::vector<std::pair<size_t, std::vector<size_t>>> hyperedges;
+
+        for (const auto& edge : graph.GetEdges()) {
+            if (edge.IsReversed) {
+                continue;
+            }
+            std::vector<size_t> edgeNodes;
+            TNodeSet combined = edge.Left | edge.Right;
+            for (auto it = TSetBitsIt(combined); it.HasNext(); ) {
+                size_t nodeIdx = it.Next();
+                edgeNodes.push_back(nodeIdx);
+                nodeDegree[nodeIdx]++;
+            }
+            hyperedges.emplace_back(edgeNodes.size(), std::move(edgeNodes));
+        }
+
+        if (hyperedges.empty()) {
+            return std::nullopt;
+        }
+
+        std::vector<double> sourceDegrees;
+        std::vector<double> targetDegrees;
+
+        for (const auto& [hyperedgeSize, nodes] : hyperedges) {
+            double edgeDegree = static_cast<double>(hyperedgeSize);
+            for (size_t nodeIdx : nodes) {
+                sourceDegrees.push_back(static_cast<double>(nodeDegree[nodeIdx]));
+                targetDegrees.push_back(edgeDegree);
+            }
+        }
+
+        return ComputeAssortativity(sourceDegrees, targetDegrees);
+    }
+
+    template <typename TNodeSet>
+    size_t ComputeBipartiteLeafNodes(TJoinHypergraph<TNodeSet>& graph) {
+        std::vector<size_t> nodeDegree(graph.GetNodes().size(), 0);
+        size_t hyperedgeLeaves = 0;
+
+        for (const auto& edge : graph.GetEdges()) {
+            if (edge.IsReversed) {
+                continue;
+            }
+            TNodeSet combined = edge.Left | edge.Right;
+            size_t edgeSize = PopCount(combined);
+            if (edgeSize == 1) {
+                hyperedgeLeaves++;
+            }
+            for (auto it = TSetBitsIt(combined); it.HasNext(); ) {
+                nodeDegree[it.Next()]++;
+            }
+        }
+
+        size_t nodeLeaves = 0;
+        for (size_t deg : nodeDegree) {
+            if (deg == 1) {
+                nodeLeaves++;
+            }
+        }
+
+        return nodeLeaves + hyperedgeLeaves;
+    }
+
+    template <typename TNodeSet>
+    THypergraphFeatures<TNodeSet> ComputeAllFeatures(TJoinHypergraph<TNodeSet>& graph) {
+        THypergraphFeatures<TNodeSet> features;
+
+        features.NumHyperedges = ComputeNumHyperedges(graph);
+        features.InnerJoinRatio = ComputeInnerJoinRatio(graph);
+        features.HyperedgeVolumeStd = ComputeHyperedgeVolumeStd(graph);
+
+        auto [degreesMean, degreesStd] = ComputeNodeDegreeStats(graph);
+        features.DegreesMean = degreesMean;
+        features.DegreesStd = degreesStd;
+
+        features.PrimalAssortativity = ComputePrimalAssortativity(graph).value_or(0.0);
+        features.PrimalDegeneracy = ComputePrimalDegeneracy(graph);
+        features.PrimalDensity = ComputePrimalDensity(graph);
+        features.PrimalHeterogeneity = ComputePrimalHeterogeneity(graph);
+
+        features.BipartiteAssortativity = ComputeBipartiteAssortativity(graph).value_or(0.0);
+        features.BipartiteLeafNodes = ComputeBipartiteLeafNodes(graph);
+
+        return features;
+    }
+
+    // ==================== Safe Operators ====================
+
+    double SafeDiv(double a, double b);
+    double SafeSqrt(double a);
+    double SafeLog(double a);
+    double SafePow(double base, double exponent);
+    double SafeExpm1(double a);
+
+    // ==================== The predictor ====================
+
+    // This prediction function is created by running symbolic
+    // regression on a dataset of randomized join graphs
+    // (collected by kqp_join_topology_ut.cpp)
+
+    // It is a subject to change if CBO's enumeration algorithm
+    // changes. E.g. a different approach, pruning states,
+    // adding features like auto-selection of indexes, etc.
+
+    // The set of features is designed to be mostly reusable
+    // even if CBO optimization time changes and it needs to be
+    // retrained and updated.
+
+    // This function is specifically trained to predict
+    // time of CBO with Shuffle Elimination enabled.
+    template <typename TNodeSet>
+    ui64 PredictCBOTime(TJoinHypergraph<TNodeSet>& hypergraph) {
+        auto f = ComputeAllFeatures(hypergraph);
+        double log1pTime =
+            - f.DegreesStd * std::tanh(f.PrimalAssortativity + 0.887)
+            - 1.79 * f.BipartiteAssortativity
+            + SafeDiv(f.BipartiteAssortativity, f.DegreesMean + f.PrimalAssortativity)
+            + SafeSqrt(
+                f.NumHyperedges
+                * SafeDiv(
+                    (SafeDiv(
+                       SafePow(f.PrimalDensity, f.DegreesMean - 0.664),
+                       (f.DegreesStd - f.BipartiteAssortativity + 0.646))
+                     + 0.328 * f.DegreesStd),
+                    f.PrimalDensity
+                  )
+              )
+            + 9.26;
+        return SafeExpm1(log1pTime);
+    }
+
+
+    // ==================== Displaying predictions ====================
+
+    std::string FormatTime(ui64 valueNs);
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
@@ -1,6 +1,7 @@
 #include "kqp_opt_join_cost_based.h"
 #include "kqp_opt_dphyp_solver.h"
 #include "kqp_opt_make_join_hypergraph.h"
+#include "kqp_opt_cbo_latency_predictor.h"
 
 #include <yql/essentials/core/expr_nodes/yql_expr_nodes.h>
 #include <yql/essentials/core/yql_join.h>
@@ -388,13 +389,35 @@ private:
         TJoinHypergraph<TNodeSet> hypergraph = MakeJoinHypergraph<TNodeSet>(joinTree, hints);
         TDPHypImpl solver = GetDPHypImpl<TNodeSet, TDPHypImpl>(hypergraph);
         YQL_CLOG(TRACE, CoreDq) << "Enumeration algorithm chosen: " << solver.Type();
-        if (solver.CountCC(OptimizerSettings_.MaxDPhypDPTableSize) >= OptimizerSettings_.MaxDPhypDPTableSize) {
-            YQL_CLOG(TRACE, CoreDq) << "Maximum DPhyp threshold exceeded";
+
+        // Use fast ML model to predict approximately how long it would take to run full CBO
+        // on this query and find the optimal plan
+        ui64 approxNanosToOptimize = PredictCBOTime(hypergraph);
+        ui64 approxMillisToOptimize = static_cast<ui64>(std::ceil(approxNanosToOptimize / 1'000'000.0));
+        ui64 timeBudgetNanos = OptimizerSettings_.CBOTimeout /* Millis */ * 1'000'000ULL;
+
+        std::string timeBudgetStr = FormatTime(timeBudgetNanos);
+        std::string predictedCBOTimeStr = FormatTime(approxNanosToOptimize);
+
+        YQL_CLOG(TRACE, CoreDq) << "CBO is predicted to take " << predictedCBOTimeStr
+                                << " (" << approxNanosToOptimize << ")";
+
+        if (approxNanosToOptimize > timeBudgetNanos) {
+            YQL_CLOG(TRACE, CoreDq) << "CBO time budget exceeded: "
+                                    << predictedCBOTimeStr << " > " << timeBudgetStr
+                                    << " - CBO disabled for this query";
+
+            TStringBuilder message;
+            message << "Cost based optimizer was disabled for this query because predicted "
+                    << "optimization time (it will take approximately " << predictedCBOTimeStr << ") "
+                    << "exceeds given time budget (" << timeBudgetStr << "). "
+                    << "Use PRAGMA ydb.CBOTimeout='" << approxMillisToOptimize << "' "
+                    << "or higher to run CBO for this query anyway.";
+
             ExprCtx.AddWarning(
                 YqlIssue(
                     {}, TIssuesIds::CBO_ENUM_LIMIT_REACHED,
-                    "Cost Based Optimizer could not be applied to this query: "
-                    "Enumeration is too large, use PRAGMA ydb.MaxDPHypDPTableSize='4294967295' to disable the limitation"
+                    message
                 )
             );
             ComputeStatistics(joinTree, this->Pctx);

--- a/ydb/core/kqp/opt/cbo/solver/ya.make
+++ b/ydb/core/kqp/opt/cbo/solver/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
 )
 
 SRCS(
+    kqp_opt_cbo_latency_predictor.cpp
     kqp_opt_conflict_rules_collector.cpp
     kqp_opt_join.cpp
     kqp_opt_join_cbo_factory.cpp

--- a/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
@@ -201,7 +201,7 @@ protected:
 
     TMaybeNode<TExprBase> OptimizeEquiJoinWithCosts(TExprBase node, TExprContext& ctx) {
         TCBOSettings settings{
-            .MaxDPhypDPTableSize = Config->MaxDPHypDPTableSize.Get().GetOrElse(TDqSettings::TDefault::MaxDPHypDPTableSize),
+            .CBOTimeout = Config->CBOTimeout.Get().GetOrElse(NKikimr::NKqp::TCBOSettings{}.CBOTimeout),
             .ShuffleEliminationJoinNumCutoff = Config->ShuffleEliminationJoinNumCutoff.Get().GetOrElse(TDqSettings::TDefault::ShuffleEliminationJoinNumCutoff)
         };
 

--- a/ydb/core/kqp/opt/rbo/rules/apply_cbo.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/apply_cbo.cpp
@@ -184,7 +184,7 @@ TIntrusivePtr<IOperator> TOptimizeCBOTreeRule::SimpleMatchAndApply(const TIntrus
     }
 
     TCBOSettings settings{
-        .MaxDPhypDPTableSize = Config->MaxDPHypDPTableSize.Get().GetOrElse(TDqSettings::TDefault::MaxDPHypDPTableSize),
+        .CBOTimeout = Config->CBOTimeout.Get().GetOrElse(NKikimr::NKqp::TCBOSettings{}.CBOTimeout),
         .ShuffleEliminationJoinNumCutoff = Config->ShuffleEliminationJoinNumCutoff.Get().GetOrElse(TDqSettings::TDefault::ShuffleEliminationJoinNumCutoff)
     };
 

--- a/ydb/core/kqp/provider/yql_kikimr_settings.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.cpp
@@ -130,7 +130,7 @@ TKikimrConfiguration::TKikimrConfiguration() {
     );
     REGISTER_SETTING(*this, UseBlockReader);
 
-    REGISTER_SETTING(*this, MaxDPHypDPTableSize);
+    REGISTER_SETTING(*this, CBOTimeout);
     REGISTER_SETTING(*this, ShuffleEliminationJoinNumCutoff);
 
     REGISTER_SETTING(*this, MaxTasksPerStage);

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -98,7 +98,7 @@ public:
     NCommon::TConfSetting<NDq::EHashShuffleFuncType , Static> HashShuffleFuncType;
     NCommon::TConfSetting<NDq::EHashShuffleFuncType , Static> ColumnShardHashShuffleFuncType;
 
-    NCommon::TConfSetting<ui32, Static> MaxDPHypDPTableSize;
+    NCommon::TConfSetting<ui32, Static> CBOTimeout;
     NCommon::TConfSetting<ui32, Static> ShuffleEliminationJoinNumCutoff;
 
     NCommon::TConfSetting<ui32, Static> MaxTasksPerStage;

--- a/ydb/core/kqp/ut/join/kqp_join_topology_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_join_topology_ut.cpp
@@ -70,7 +70,7 @@ Y_UNIT_TEST_SUITE(KqpJoinTopology) {
         std::string queryWithShuffleElimination = "PRAGMA ydb.OptShuffleElimination=\"";
         queryWithShuffleElimination += enableShuffleElimination ? "true" : "false";
         queryWithShuffleElimination += "\";\n";
-        queryWithShuffleElimination += "PRAGMA ydb.MaxDPHypDPTableSize='4294967295';\n";
+        queryWithShuffleElimination += "PRAGMA ydb.CBOTimeout='" + std::to_string(UINT32_MAX) + "';\n";
         queryWithShuffleElimination += "PRAGMA ydb.ShuffleEliminationJoinNumCutoff='" + std::to_string(UINT32_MAX) + "';\n";
         queryWithShuffleElimination += "PRAGMA ydb.CostBasedOptimizationLevel=\"" + std::to_string(optLevel) + "\";\n";
         queryWithShuffleElimination += query;


### PR DESCRIPTION
This PR implements symbolic regression model that was trained for predicting CBO optimization time.

It replaces MaxDPHypTableSize pragma with a significantly more intuitive CBOTimeout which allows to specify approximate time (in milliseconds) you are prepared to wait for CBO. Note that this time is approximate, i.e. it is not a hard timeout. Predictor will compare the time it predicts it will take to run CBO with given budget and only enable CBO if it's lower. 

NOTE: Predictions do not take CPU other other performance characteristics of the server into account, so they are expected to be usually off by a coefficient (except for the machine on which the model was trained).

Resolves #30247