### PR TITLE
[CBO] Introduce support for hard timeouts inside CBO

### DIFF
--- a/ydb/core/kqp/opt/cbo/cbo_optimizer_new.h
+++ b/ydb/core/kqp/opt/cbo/cbo_optimizer_new.h
@@ -403,6 +403,7 @@ public:
 
 struct TCBOSettings {
     ui32 CBOTimeout = 1'000ULL; // 1s
+    ui32 CBOHardTimeout = UINT32_MAX; // disabled by default
     ui32 ShuffleEliminationJoinNumCutoff = 14;
 };
 

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_dphyp_solver.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_dphyp_solver.h
@@ -4,6 +4,8 @@
 #include "kqp_opt_join_tree_node.h"
 #include "bitset.h"
 
+#include <util/generic/yexception.h>
+
 namespace NKikimr::NKqp {
 
 TString GetJoinOrderString(const std::shared_ptr<IBaseOptimizerNode>& node) {
@@ -47,12 +49,15 @@ public:
     TDPHypSolverBase(
         TJoinHypergraph<TNodeSet>& graph,
         IProviderContext& ctx,
-        TDerived& derived
+        TDerived& derived,
+        std::chrono::milliseconds hardTimeout
     )
         : Graph_(graph)
         , NNodes_(graph.GetNodes().size())
         , Pctx_(ctx)
         , Derived(derived)
+        , EnumerationStart_(std::chrono::high_resolution_clock::now())
+        , HardTimeout_(hardTimeout)
     {}
 
     // Run DPHyp algorithm and produce the join tree in CBO's internal representation
@@ -114,6 +119,23 @@ protected:
     THashMap<TNodeSet, TCardinalityHints::TCardinalityHint*, std::hash<TNodeSet>> BytesHintsTable_;
     THashMap<TNodeSet, TCardinalityHints::TCardinalityHint*, std::hash<TNodeSet>> CardHintsTable_;
     THashMap<TNodeSet, TJoinAlgoHints::TJoinAlgoHint*, std::hash<TNodeSet>> JoinAlgoHintsTable_;
+
+    std::chrono::time_point<std::chrono::high_resolution_clock> EnumerationStart_;
+    std::chrono::milliseconds HardTimeout_;
+
+    ui32 TimeoutCheckThrottleCounter_ = 0;
+
+    bool HasTimedOut() {
+        return (std::chrono::high_resolution_clock::now() - EnumerationStart_) >= HardTimeout_;
+    }
+
+    void CheckTimeout() {
+        if (++TimeoutCheckThrottleCounter_ % 128 == 0) {
+            if (HasTimedOut()) {
+                ythrow yexception() << "CBO timed out";
+            }
+        }
+    }
 };
 
 template <typename TNodeSet>
@@ -122,9 +144,10 @@ public:
     TDPHypSolverShuffleElimination(
         TJoinHypergraph<TNodeSet>& graph,
         IProviderContext& ctx,
-        TOrderingsStateMachine& orderingFSM
+        TOrderingsStateMachine& orderingFSM,
+        std::chrono::milliseconds hardTimeout = std::chrono::milliseconds(UINT32_MAX)
     )
-        : TDPHypSolverBase<TNodeSet, TDPHypSolverShuffleElimination<TNodeSet>>(graph, ctx, *this)
+        : TDPHypSolverBase<TNodeSet, TDPHypSolverShuffleElimination<TNodeSet>>(graph, ctx, *this, hardTimeout)
         , OrderingsFSM(orderingFSM)
     {}
 
@@ -229,9 +252,10 @@ class TDPHypSolverClassic : public TDPHypSolverBase<TNodeSet, TDPHypSolverClassi
 public:
     TDPHypSolverClassic(
         TJoinHypergraph<TNodeSet>& graph,
-        IProviderContext& ctx
+        IProviderContext& ctx,
+        std::chrono::milliseconds hardTimeout = std::chrono::milliseconds(UINT32_MAX)
     )
-        : TDPHypSolverBase<TNodeSet, TDPHypSolverClassic<TNodeSet>>(graph, ctx, *this)
+        : TDPHypSolverBase<TNodeSet, TDPHypSolverClassic<TNodeSet>>(graph, ctx, *this, hardTimeout)
     {}
 
     std::string Type() const {
@@ -497,6 +521,9 @@ template<typename TNodeSet, typename TDerived> TNodeSet TDPHypSolverBase<TNodeSe
 }
 
 template<typename TNodeSet,  typename TDerived> std::shared_ptr<TJoinOptimizerNodeInternal> TDPHypSolverBase<TNodeSet, TDerived>::Solve(const TOptimizerHints& hints) {
+    // Record start time for timeouts
+    EnumerationStart_ = std::chrono::high_resolution_clock::now();
+
     for (auto& h : hints.CardinalityHints->Hints) {
         TNodeSet hintSet = Graph_.GetNodesByRelNames(h.JoinLabels);
         CardHintsTable_[hintSet] = &h;
@@ -553,6 +580,8 @@ template<typename TNodeSet,  typename TDerived> std::shared_ptr<TJoinOptimizerNo
  * Then it recurses on the S fused with its neighbors.
  */
 template <typename TNodeSet, typename TDerived> void TDPHypSolverBase<TNodeSet, TDerived>::EnumerateCsgRec(const TNodeSet& s1, const TNodeSet& x) {
+    this->CheckTimeout();
+
     TNodeSet neighs =  Neighs(s1, x);
 
     if (neighs == TNodeSet{}) {
@@ -573,6 +602,7 @@ template <typename TNodeSet, typename TDerived> void TDPHypSolverBase<TNodeSet, 
             break;
         }
         prev = next;
+        this->CheckTimeout();
     }
 
     prev.reset();
@@ -596,6 +626,7 @@ template <typename TNodeSet, typename TDerived> void TDPHypSolverBase<TNodeSet, 
  * (S,S2), where S2 is the neighbor of S. Then it recursively emits complement pairs
  */
 template <typename TNodeSet, typename TDerived> void TDPHypSolverBase<TNodeSet, TDerived>::EmitCsg(const TNodeSet& s1) {
+    this->CheckTimeout();
     TNodeSet x = s1 | MakeBiMin(s1);
     TNodeSet neighs = Neighs(s1, x);
 
@@ -614,6 +645,7 @@ template <typename TNodeSet, typename TDerived> void TDPHypSolverBase<TNodeSet, 
 
             EnumerateCmpRec(s1, s2, x | MakeB(neighs, GetLowestSetBit(s2)));
         }
+        this->CheckTimeout();
     }
 }
 
@@ -624,6 +656,8 @@ template <typename TNodeSet, typename TDerived> void TDPHypSolverBase<TNodeSet, 
  * Then it recusrses into pairs (S1,S2+next)
  */
 template <typename TNodeSet, typename TDerived> void TDPHypSolverBase<TNodeSet, TDerived>::EnumerateCmpRec(const TNodeSet& s1, const TNodeSet& s2, const TNodeSet& x) {
+    this->CheckTimeout();
+
     TNodeSet neighs = Neighs(s2, x);
 
     if (neighs == TNodeSet{}) {
@@ -647,6 +681,7 @@ template <typename TNodeSet, typename TDerived> void TDPHypSolverBase<TNodeSet, 
         }
 
         prev = next;
+        this->CheckTimeout();
     }
 
     prev.reset();
@@ -1036,6 +1071,7 @@ template<typename TNodeSet> void TDPHypSolverShuffleElimination<TNodeSet>::EmitC
     const typename TJoinHypergraph<TNodeSet>::TEdge* csgCmpEdge,
     const typename TJoinHypergraph<TNodeSet>::TEdge* reversedCsgCmpEdge
 ) {
+    this->CheckTimeout();
     // Here we actually build the join and choose and compare the
     // new plan to what's in the dpTable, if it there
 
@@ -1106,6 +1142,7 @@ template<typename TNodeSet> void TDPHypSolverShuffleElimination<TNodeSet>::EmitC
                     AddNodeToDpTableEntries(std::move(trees[i]), this->DpTable_[joined]);
                 }
             }
+            this->CheckTimeout();
         }
     }
 

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
@@ -327,8 +327,7 @@ public:
         TExprContext& exprCtx,
         bool enableShuffleElimination,
         TSimpleSharedPtr<TOrderingsStateMachine> orderingsFSM,
-        TTableAliasMap* tableAliases,
-        std::chrono::milliseconds hardTimeout
+        TTableAliasMap* tableAliases
     )
         : IOptimizerNew(ctx)
         , OptimizerSettings_(optimizerSettings)
@@ -336,7 +335,6 @@ public:
         , EnableShuffleElimination(enableShuffleElimination && orderingsFSM != nullptr)
         , OrderingsFSM(orderingsFSM)
         , TableAliases(tableAliases)
-        , HardTimeout_(hardTimeout)
     {}
 
     std::shared_ptr<TJoinOptimizerNode> JoinSearch(
@@ -375,10 +373,11 @@ private:
             assigner.Assign(*OrderingsFSM);
         }
 
+        auto hardTimeout = std::chrono::milliseconds(OptimizerSettings_.CBOHardTimeout);
         if constexpr (std::is_same_v<TDpHypImpl, TDPHypSolverClassic<TNodeSet>>) {
-            return TDPHypSolverClassic<TNodeSet>(hypergraph, this->Pctx, HardTimeout_);
+            return TDPHypSolverClassic<TNodeSet>(hypergraph, this->Pctx, hardTimeout);
         } else if constexpr (std::is_same_v<TDpHypImpl, TDPHypSolverShuffleElimination<TNodeSet>>) {
-            return TDPHypSolverShuffleElimination<TNodeSet>(hypergraph, this->Pctx, *OrderingsFSM, HardTimeout_);
+            return TDPHypSolverShuffleElimination<TNodeSet>(hypergraph, this->Pctx, *OrderingsFSM, hardTimeout);
         } else {
             static_assert(false, "No such DPHyp implementation");
         }
@@ -435,7 +434,9 @@ private:
             YQL_CLOG(WARN, CoreDq) << "CBO hard timeout exceeded, falling back to default join order: " << e.what();
             ExprCtx.AddWarning(YqlIssue(
                 {}, TIssuesIds::CBO_ENUM_LIMIT_REACHED,
-                TStringBuilder() << "Cost based optimizer timed out and was disabled for this query."
+                TStringBuilder() << "Cost based optimizer timed out and was disabled for this query. "
+                                 << "Use PRAGMA ydb.CBOHardTimeout='"
+                                 << OptimizerSettings_.CBOHardTimeout << "' or higher to extend the time budget."
             ));
             ComputeStatistics(joinTree, this->Pctx);
             return joinTree;
@@ -556,8 +557,6 @@ private:
 
     TSimpleSharedPtr<TOrderingsStateMachine> OrderingsFSM;
     TTableAliasMap* TableAliases;
-
-    std::chrono::milliseconds HardTimeout_;
 };
 
 IOptimizerNew* MakeNativeOptimizerNew(
@@ -566,10 +565,9 @@ IOptimizerNew* MakeNativeOptimizerNew(
     TExprContext& ectx,
     bool enableShuffleElimination,
     TSimpleSharedPtr<TOrderingsStateMachine> orderingsFSM,
-    TTableAliasMap* tableAliases,
-    std::chrono::milliseconds hardTimeout
+    TTableAliasMap* tableAliases
 ) {
-    return new TOptimizerNativeNew(pctx, settings, ectx, enableShuffleElimination, orderingsFSM, tableAliases, hardTimeout);
+    return new TOptimizerNativeNew(pctx, settings, ectx, enableShuffleElimination, orderingsFSM, tableAliases);
 }
 
 void CollectInterestingOrderingsFromJoinTree(

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
@@ -428,7 +428,18 @@ private:
             return joinTree;
         }
 
-        auto bestJoinOrder = solver.Solve(hints);
+        std::shared_ptr<TJoinOptimizerNodeInternal> bestJoinOrder;
+        try {
+            bestJoinOrder = solver.Solve(hints);
+        } catch (const std::exception& e) {
+            YQL_CLOG(WARN, CoreDq) << "CBO hard timeout exceeded, falling back to default join order: " << e.what();
+            ExprCtx.AddWarning(YqlIssue(
+                {}, TIssuesIds::CBO_ENUM_LIMIT_REACHED,
+                TStringBuilder() << "Cost based optimizer timed out and was disabled for this query."
+            ));
+            ComputeStatistics(joinTree, this->Pctx);
+            return joinTree;
+        }
         if (postEnumerationShuffleElimination) {
             Y_ENSURE(OrderingsFSM != nullptr);
 

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
@@ -9,6 +9,8 @@
 #include <ydb/library/yql/dq/opt/dq_opt.h>
 #include <yql/essentials/utils/log/log.h>
 
+#include <chrono>
+
 namespace NKikimr::NKqp {
 
 using namespace NYql::NNodes;
@@ -325,7 +327,8 @@ public:
         TExprContext& exprCtx,
         bool enableShuffleElimination,
         TSimpleSharedPtr<TOrderingsStateMachine> orderingsFSM,
-        TTableAliasMap* tableAliases
+        TTableAliasMap* tableAliases,
+        std::chrono::milliseconds hardTimeout
     )
         : IOptimizerNew(ctx)
         , OptimizerSettings_(optimizerSettings)
@@ -333,6 +336,7 @@ public:
         , EnableShuffleElimination(enableShuffleElimination && orderingsFSM != nullptr)
         , OrderingsFSM(orderingsFSM)
         , TableAliases(tableAliases)
+        , HardTimeout_(hardTimeout)
     {}
 
     std::shared_ptr<TJoinOptimizerNode> JoinSearch(
@@ -372,9 +376,9 @@ private:
         }
 
         if constexpr (std::is_same_v<TDpHypImpl, TDPHypSolverClassic<TNodeSet>>) {
-            return TDPHypSolverClassic<TNodeSet>(hypergraph, this->Pctx);
+            return TDPHypSolverClassic<TNodeSet>(hypergraph, this->Pctx, HardTimeout_);
         } else if constexpr (std::is_same_v<TDpHypImpl, TDPHypSolverShuffleElimination<TNodeSet>>) {
-            return TDPHypSolverShuffleElimination<TNodeSet>(hypergraph, this->Pctx, *OrderingsFSM);
+            return TDPHypSolverShuffleElimination<TNodeSet>(hypergraph, this->Pctx, *OrderingsFSM, HardTimeout_);
         } else {
             static_assert(false, "No such DPHyp implementation");
         }
@@ -541,6 +545,8 @@ private:
 
     TSimpleSharedPtr<TOrderingsStateMachine> OrderingsFSM;
     TTableAliasMap* TableAliases;
+
+    std::chrono::milliseconds HardTimeout_;
 };
 
 IOptimizerNew* MakeNativeOptimizerNew(
@@ -549,9 +555,10 @@ IOptimizerNew* MakeNativeOptimizerNew(
     TExprContext& ectx,
     bool enableShuffleElimination,
     TSimpleSharedPtr<TOrderingsStateMachine> orderingsFSM,
-    TTableAliasMap* tableAliases
+    TTableAliasMap* tableAliases,
+    std::chrono::milliseconds hardTimeout
 ) {
-    return new TOptimizerNativeNew(pctx, settings, ectx, enableShuffleElimination, orderingsFSM, tableAliases);
+    return new TOptimizerNativeNew(pctx, settings, ectx, enableShuffleElimination, orderingsFSM, tableAliases, hardTimeout);
 }
 
 void CollectInterestingOrderingsFromJoinTree(

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.h
@@ -66,8 +66,7 @@ IOptimizerNew* MakeNativeOptimizerNew(
     NYql::TExprContext& ectx,
     bool enableShuffleElimination,
     TSimpleSharedPtr<TOrderingsStateMachine> orderingsFSM = nullptr,
-    TTableAliasMap* tableAliases = nullptr,
-    std::chrono::milliseconds hardTimeout = std::chrono::milliseconds(UINT32_MAX)
+    TTableAliasMap* tableAliases = nullptr
 );
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.h
@@ -66,7 +66,8 @@ IOptimizerNew* MakeNativeOptimizerNew(
     NYql::TExprContext& ectx,
     bool enableShuffleElimination,
     TSimpleSharedPtr<TOrderingsStateMachine> orderingsFSM = nullptr,
-    TTableAliasMap* tableAliases = nullptr
+    TTableAliasMap* tableAliases = nullptr,
+    std::chrono::milliseconds hardTimeout = std::chrono::milliseconds(UINT32_MAX)
 );
 
 } // namespace NKikimr::NKqp


### PR DESCRIPTION
Implements simple timeouts for collecting dataset of CBO optimization time #30336.

This is just the machinery, there is currently no way to set the timeout externally (as shown in #28642). The only thing that's missing is integration with CompilationTimeout and proper recovery after the timeout.

