### PR TITLE
Basic retro-tracing support for DSProxy and BSQueue

### DIFF
--- a/ydb/core/blobstorage/backpressure/queue.cpp
+++ b/ydb/core/blobstorage/backpressure/queue.cpp
@@ -226,8 +226,10 @@ void TBlobStorageQueue::ReplyWithError(TItem& item, NKikimrProto::EReplyStatus s
         << " cookie# " << item.Event.GetCookie()
         << " processingTime# " << processingTime);
 
-    item.Span.EndError(TStringBuilder() << NKikimrProto::EReplyStatus_Name(status) << ": " << errorReason);
-    item.Span = {};
+    if (item.Span) {
+        item.Span.EndError(TStringBuilder() << NKikimrProto::EReplyStatus_Name(status) << ": " << errorReason);
+    }
+    item.Span.Reset();
 
     ctx.Send(item.Event.GetSender(), item.Event.MakeErrorReply(status, errorReason, QueueDeserializedItems,
             QueueDeserializedBytes), 0, item.Event.GetCookie());

--- a/ydb/core/blobstorage/backpressure/queue.cpp
+++ b/ydb/core/blobstorage/backpressure/queue.cpp
@@ -228,8 +228,8 @@ void TBlobStorageQueue::ReplyWithError(TItem& item, NKikimrProto::EReplyStatus s
 
     if (item.Span) {
         item.Span.EndError(TStringBuilder() << NKikimrProto::EReplyStatus_Name(status) << ": " << errorReason);
+        item.Span.Reset();
     }
-    item.Span.Reset();
 
     ctx.Send(item.Event.GetSender(), item.Event.MakeErrorReply(status, errorReason, QueueDeserializedItems,
             QueueDeserializedBytes), 0, item.Event.GetCookie());

--- a/ydb/core/blobstorage/backpressure/queue.h
+++ b/ydb/core/blobstorage/backpressure/queue.h
@@ -4,6 +4,8 @@
 #include "common.h"
 #include "event.h"
 
+#include <ydb/core/retro_tracing_impl/lazy_retro_span.h>
+
 namespace NKikimr::NBsQueue {
 
 static constexpr size_t MaxUnusedItems = 1024;
@@ -34,7 +36,7 @@ class TBlobStorageQueue {
     struct TItem {
         EItemQueue Queue;
         TCostModel::TMessageCostEssence CostEssence;
-        NWilson::TSpan Span;
+        TLazyRetroSpan Span;
         TEventHolder Event;
         ui64 MsgId;
         ui64 SequenceId;

--- a/ydb/core/blobstorage/backpressure/ya.make
+++ b/ydb/core/blobstorage/backpressure/ya.make
@@ -9,6 +9,7 @@ PEERDIR(
     ydb/core/blobstorage/lwtrace_probes
     ydb/core/blobstorage/vdisk/common
     ydb/core/protos
+    ydb/core/retro_tracing_impl
 )
 
 SRCS(

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -241,8 +241,8 @@ public:
             Span.Attribute("storagePool", Info->GetStoragePoolName());
             params.Common.Event->ToSpan(*Span.GetWilsonSpanPtr());
         } else {
-            Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
-                    "DSProxy.RTX");
+            // Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
+            //         "DSProxy.RTX");
         }
 
         Y_ABORT_UNLESS(CostModel);

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -4,6 +4,7 @@
 #include "dsproxy_put_impl.h"
 #include <ydb/core/blobstorage/dsproxy/dsproxy_request_reporting.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
+#include <ydb/library/actors/retro_tracing/retro_collector.h>
 
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <ydb/core/util/stlog.h>
@@ -532,6 +533,11 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
             SendResponse(std::move(putResult), TimeStatsEnabled ? &TimeStats : nullptr,
                 PutImpl.Blobs[blobIdx].Recipient, PutImpl.Blobs[blobIdx].Cookie, false);
             PutImpl.Blobs[blobIdx].Replied = true;
+        }
+        if (const TNamedSpan* span = Span.GetRetroSpanPtr()) {
+            if (!RandomNumber<ui32>(100)) {
+                NRetroTracing::DemandTrace(span->GetTraceId());
+            }
         }
     }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -4,7 +4,6 @@
 #include "dsproxy_put_impl.h"
 #include <ydb/core/blobstorage/dsproxy/dsproxy_request_reporting.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
-#include <ydb/library/actors/retro_tracing/retro_collector.h>
 
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <ydb/core/util/stlog.h>

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -534,11 +534,6 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
                 PutImpl.Blobs[blobIdx].Recipient, PutImpl.Blobs[blobIdx].Cookie, false);
             PutImpl.Blobs[blobIdx].Replied = true;
         }
-        if (const TNamedSpan* span = Span.GetRetroSpanPtr()) {
-            if (!RandomNumber<ui32>(100)) {
-                NRetroTracing::DemandTrace(span->GetTraceId());
-            }
-        }
     }
 
     TString BlobIdSequenceToString() const {

--- a/ydb/core/blobstorage/dsproxy/ya.make
+++ b/ydb/core/blobstorage/dsproxy/ya.make
@@ -71,6 +71,7 @@ PEERDIR(
     ydb/core/blobstorage/vdisk/common
     ydb/core/blobstorage/vdisk/ingress
     ydb/core/control/lib
+    ydb/core/retro_tracing_impl
     ydb/core/util
 )
 

--- a/ydb/core/retro_tracing_impl/named_span.h
+++ b/ydb/core/retro_tracing_impl/named_span.h
@@ -10,6 +10,7 @@ class TNamedSpan final : public NRetroTracing::TTypedRetroSpan<TNamedSpan, Named
 public:
     void SetName(const char* name);
     TString GetName() const override;
+    std::unique_ptr<NWilson::TSpan> MakeWilsonSpan() override;
 
 public:
     constexpr static size_t MaxNameSize = 64 - sizeof(ui32);

--- a/ydb/core/retro_tracing_impl/universal_span_wilson_api.h
+++ b/ydb/core/retro_tracing_impl/universal_span_wilson_api.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "named_span.h"
 #include <ydb/library/actors/retro_tracing/universal_span.h>
 
 namespace NKikimr {
@@ -10,11 +11,15 @@ public:
     TUniversalSpanWilsonApi() = default;
 
     TUniversalSpanWilsonApi(ui8 verbosity, NWilson::TTraceId parentId, const char* name,
-            NWilson::TFlags flags = NWilson::EFlags::NONE,
+            NWilson::TFlags flags = NWilson::EFlags::AUTO_END,
             NActors::TActorSystem* actorSystem = nullptr)
         : NRetroTracing::TUniversalSpan<TRetroSpanType>(verbosity, std::move(parentId),
                 name, flags, actorSystem)
-    {}
+    {
+        if constexpr (std::is_same_v<TRetroSpanType, TNamedSpan>) {
+            std::get<TRetroSpanType>(this->Span).SetName(name);
+        }
+    }
 
     TUniversalSpanWilsonApi(NWilson::TSpan&& span)
         : NRetroTracing::TUniversalSpan<TRetroSpanType>(std::move(span))
@@ -24,18 +29,78 @@ public:
         : NRetroTracing::TUniversalSpan<TRetroSpanType>(std::move(span))
     {}
 
-    TUniversalSpanWilsonApi(TUniversalSpanWilsonApi&& span) = default;
-    TUniversalSpanWilsonApi(const TUniversalSpanWilsonApi& span) = delete;
+    TUniversalSpanWilsonApi(TUniversalSpanWilsonApi&&) = default;
+    TUniversalSpanWilsonApi(const TUniversalSpanWilsonApi&) = delete;
 
-    template<typename T>
-    TUniversalSpanWilsonApi& Name(T&& name) {
+    TUniversalSpanWilsonApi& operator=(TUniversalSpanWilsonApi&&) = default;
+    TUniversalSpanWilsonApi& operator=(const TUniversalSpanWilsonApi&) = delete;
+
+    TUniversalSpanWilsonApi& operator=(TRetroSpanType&& span) {
+        this->Span.template emplace<TRetroSpanType>(std::forward<TRetroSpanType>(span));
+        return *this;
+    }
+
+    TUniversalSpanWilsonApi& operator=(NWilson::TSpan&& span) {
+        this->Span.template emplace<NWilson::TSpan>(std::move(span));
+        return *this;
+    }
+
+    void Reset() {
+        this->Span.template emplace<std::monostate>();
+    }
+
+    void ConstructRetroSpan(ui8 verbosity, NWilson::TTraceId parentId, const char* name,
+            NWilson::TFlags flags = NWilson::EFlags::AUTO_END,
+            NActors::TActorSystem* actorSystem = nullptr) {
+        Y_ABORT_UNLESS(parentId.IsRetroTrace());
+        this->Span.template emplace<TRetroSpanType>();
+        std::get<TRetroSpanType>(this->Span).Initialize(verbosity, std::move(parentId), name, flags, actorSystem);
+        if constexpr (std::is_same_v<TRetroSpanType, TNamedSpan>) {
+            std::get<TRetroSpanType>(this->Span).SetName(name);
+        }
+    }
+
+    void ConstructWilsonSpan(ui8 verbosity, NWilson::TTraceId parentId,
+            std::variant<std::optional<TString>, const char*> name,
+            NWilson::TFlags flags = NWilson::EFlags::AUTO_END,
+            NActors::TActorSystem* actorSystem = nullptr) {
+        Y_ABORT_UNLESS(parentId.IsWilsonTrace());
+        this->Span.template emplace<NWilson::TSpan>(verbosity, std::move(parentId), std::move(name), flags, actorSystem);
+    }
+
+    explicit operator bool() const {
+        bool res = false;
         std::visit(TOverloaded{
-            [&](NWilson::TSpan& span) -> void {
-                span.Name(std::move(name));
+            [&](const NWilson::TSpan& span) -> void {
+                res = (bool)span;
             },
             [&](const TRetroSpanType&) -> void {},
             [&](const std::monostate&) -> void {},
         }, this->Span);
+        return res;
+    }
+
+    template <typename T>
+    TUniversalSpanWilsonApi& Name(T&& name) {
+        if constexpr (std::is_same_v<TRetroSpanType, TNamedSpan>) {
+            std::visit(TOverloaded{
+                [&](NWilson::TSpan& span) -> void {
+                    span.Name(std::forward<T>(name));
+                },
+                [&](const TRetroSpanType&) -> void {},
+                [&](const std::monostate&) -> void {},
+            }, this->Span);
+        } else {
+            std::visit(TOverloaded{
+                [&](NWilson::TSpan& span) -> void {
+                    span.Name(std::forward<T>(name));
+                },
+                [&](TRetroSpanType& span) -> void {
+                    span.SetName(std::forward<T>(name));
+                },
+                [&](const std::monostate&) -> void {},
+            }, this->Span);
+        }
         return *this;
     }
 

--- a/ydb/core/retro_tracing_impl/universal_span_wilson_api.h
+++ b/ydb/core/retro_tracing_impl/universal_span_wilson_api.h
@@ -17,7 +17,9 @@ public:
                 name, flags, actorSystem)
     {
         if constexpr (std::is_same_v<TRetroSpanType, TNamedSpan>) {
-            std::get<TRetroSpanType>(this->Span).SetName(name);
+            if (TNamedSpan* span = this->GetRetroSpanPtr()) {
+                span->SetName(name);
+            }
         }
     }
 
@@ -87,7 +89,9 @@ public:
                 [&](NWilson::TSpan& span) -> void {
                     span.Name(std::forward<T>(name));
                 },
-                [&](const TRetroSpanType&) -> void {},
+                [&](TRetroSpanType& span) -> void {
+                    span.SetName(std::forward<T>(name));
+                },
                 [&](const std::monostate&) -> void {},
             }, this->Span);
         } else {
@@ -95,9 +99,7 @@ public:
                 [&](NWilson::TSpan& span) -> void {
                     span.Name(std::forward<T>(name));
                 },
-                [&](TRetroSpanType& span) -> void {
-                    span.SetName(std::forward<T>(name));
-                },
+                [&](const TRetroSpanType&) -> void {},
                 [&](const std::monostate&) -> void {},
             }, this->Span);
         }

--- a/ydb/library/actors/retro_tracing/retro_collector.cpp
+++ b/ydb/library/actors/retro_tracing/retro_collector.cpp
@@ -37,6 +37,7 @@ private:
         for (const std::unique_ptr<TRetroSpan>& span : spans) {
             std::unique_ptr<NWilson::TSpan> wilson = span->MakeWilsonSpan();
             wilson->Attribute("type", "RETRO");
+            wilson->EndOk();
             wilson.reset();
         }
     }

--- a/ydb/library/actors/retro_tracing/retro_collector.cpp
+++ b/ydb/library/actors/retro_tracing/retro_collector.cpp
@@ -37,8 +37,7 @@ private:
         for (const std::unique_ptr<TRetroSpan>& span : spans) {
             std::unique_ptr<NWilson::TSpan> wilson = span->MakeWilsonSpan();
             wilson->Attribute("type", "RETRO");
-            wilson->EndOk();
-            wilson.reset();
+            wilson->End();
         }
     }
 

--- a/ydb/library/actors/retro_tracing/retro_span.cpp
+++ b/ydb/library/actors/retro_tracing/retro_span.cpp
@@ -41,11 +41,19 @@ void* TRetroSpan::GetDataMut() {
 }
 
 NWilson::TTraceId TRetroSpan::GetParentId() const {
-    return NWilson::TTraceId(ParentId);
+    if (!ParentId) {
+        return NWilson::TTraceId{};
+    } else {
+        return NWilson::TTraceId(ParentId);
+    }
 }
 
 NWilson::TTraceId TRetroSpan::GetTraceId() const {
-    return NWilson::TTraceId(SpanId);
+    if (!SpanId) {
+        return NWilson::TTraceId{};
+    } else {
+        return NWilson::TTraceId(SpanId);
+    }
 }
 
 void TRetroSpan::AttachToTrace(const NWilson::TTraceId& parentId) {
@@ -101,7 +109,7 @@ TInstant TRetroSpan::GetEndTs() const {
 }
 
 TString TRetroSpan::GetName() const {
-    return "Unnamed retro span";
+    return "UnnamedRetroSpan";
 }
 
 void TRetroSpan::EnableAutoEnd() {

--- a/ydb/library/actors/retro_tracing/retro_span.h
+++ b/ydb/library/actors/retro_tracing/retro_span.h
@@ -28,6 +28,12 @@ public:
     TRetroSpan(ui32 type, ui32 size);
     virtual ~TRetroSpan();
 
+    TRetroSpan(TRetroSpan&&) = default;
+    TRetroSpan(const TRetroSpan&) = default;
+
+    TRetroSpan& operator=(TRetroSpan&&) = default;
+    TRetroSpan& operator=(const TRetroSpan&) = default;
+
     static std::unique_ptr<TRetroSpan> DeserializeToUnique(const void* data);
 
     ui32 GetType() const;

--- a/ydb/library/actors/retro_tracing/typed_retro_span.h
+++ b/ydb/library/actors/retro_tracing/typed_retro_span.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <util/system/type_name.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
 #include "retro_span.h"
@@ -29,7 +30,7 @@ public:
     }
 
     virtual TString GetName() const override {
-        return typeid(T).name();
+        return TypeName<T>();
     }
 };
 

--- a/ydb/library/actors/retro_tracing/universal_span.h
+++ b/ydb/library/actors/retro_tracing/universal_span.h
@@ -44,8 +44,11 @@ public:
         : Span(std::move(span))
     {}
 
-    TUniversalSpan(TUniversalSpan&& span) = default;
-    TUniversalSpan(const TUniversalSpan& span) = delete;
+    TUniversalSpan(TUniversalSpan&&) = default;
+    TUniversalSpan(const TUniversalSpan&) = delete;
+
+    TUniversalSpan& operator=(TUniversalSpan&&) = default;
+    TUniversalSpan& operator=(const TUniversalSpan&) = delete;
 
     NWilson::TSpan* GetWilsonSpanPtr() {
         NWilson::TSpan* res;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support basic retro-tracing spans for DSProxy and BSQueue

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)