### PR TITLE
Some fixes for BATCH operations with index

### DIFF
--- a/ydb/core/kqp/common/kqp_batch_operations.cpp
+++ b/ydb/core/kqp/common/kqp_batch_operations.cpp
@@ -2,6 +2,22 @@
 
 namespace NKikimr::NKqp::NBatchOperations {
 
+bool IsIndexSupported(NYql::TIndexDescription::EType type, bool enabledIndexStreamWrite) {
+    switch (type) {
+        case NYql::TIndexDescription::EType::GlobalSync:
+        case NYql::TIndexDescription::EType::GlobalAsync:
+            return true;
+        case NYql::TIndexDescription::EType::GlobalSyncUnique:
+            return enabledIndexStreamWrite;
+        case NYql::TIndexDescription::EType::GlobalSyncVectorKMeansTree:
+        case NYql::TIndexDescription::EType::GlobalFulltextPlain:
+        case NYql::TIndexDescription::EType::GlobalFulltextRelevance:
+            return false;
+    }
+    Y_UNREACHABLE();
+    return false;
+}
+
 TSerializedTableRange MakePartitionRange(TMaybe<TKeyDesc::TPartitionRangeInfo> begin, TMaybe<TKeyDesc::TPartitionRangeInfo> end, size_t keySize) {
     TVector<TCell> tableBegin;
     TVector<TCell> tableEnd;

--- a/ydb/core/kqp/common/kqp_batch_operations.h
+++ b/ydb/core/kqp/common/kqp_batch_operations.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <ydb/core/kqp/provider/yql_kikimr_gateway.h>
 #include <ydb/core/protos/table_service_config.pb.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
 
 #include <util/generic/fwd.h>
 
 namespace NKikimr::NKqp::NBatchOperations {
+
+bool IsIndexSupported(NYql::TIndexDescription::EType type, bool enabledIndexStreamWrite = false);
 
 TSerializedTableRange MakePartitionRange(TMaybe<TKeyDesc::TPartitionRangeInfo> begin, TMaybe<TKeyDesc::TPartitionRangeInfo> end, size_t keySize);
 

--- a/ydb/core/kqp/executer_actor/kqp_partitioned_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_partitioned_executer.cpp
@@ -454,6 +454,7 @@ private:
         switch (settings->GetType()) {
             case NKikimrKqp::TKqpTableSinkSettings::MODE_UPSERT:
             case NKikimrKqp::TKqpTableSinkSettings::MODE_UPSERT_INCREMENT:
+            case NKikimrKqp::TKqpTableSinkSettings::MODE_UPDATE_CONDITIONAL:
                 OperationType = TKeyDesc::ERowOperation::Update;
                 break;
             case NKikimrKqp::TKqpTableSinkSettings::MODE_DELETE:

--- a/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
+++ b/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
@@ -312,7 +312,8 @@
             "Children": [
                 {"Index": 3, "Name": "ReturningColumns", "Type": "TCoAtomList"},
                 {"Index": 4, "Name": "GenerateColumnsIfInsert", "Type": "TCoAtomList"},
-                {"Index": 5, "Name": "Settings", "Type": "TCoNameValueTupleList", "Optional": true}
+                {"Index": 5, "Name": "IsBatch", "Type": "TCoAtom"},
+                {"Index": 6, "Name": "Settings", "Type": "TCoNameValueTupleList", "Optional": true}
             ]
         },
         {
@@ -363,7 +364,8 @@
             "Base": "TKqlUpdateRowsBase",
             "Match": {"Type": "Callable", "Name": "TKqlUpdateRowsIndex"},
             "Children": [
-                {"Index": 4, "Name": "Settings", "Type": "TCoNameValueTupleList", "Optional": true}
+                {"Index": 4, "Name": "IsBatch", "Type": "TCoAtom"},
+                {"Index": 5, "Name": "Settings", "Type": "TCoNameValueTupleList", "Optional": true}
             ]
         },
         {
@@ -574,7 +576,8 @@
             "Match": {"Type": "Callable", "Name": "KqlDeleteRowsIndex"},
             "Children": [
                 {"Index": 2, "Name": "ReturningColumns", "Type": "TCoAtomList"},
-                {"Index": 3, "Name": "Settings", "Type": "TCoNameValueTupleList", "Optional": true}
+                {"Index": 3, "Name": "IsBatch", "Type": "TCoAtom"},
+                {"Index": 4, "Name": "Settings", "Type": "TCoNameValueTupleList", "Optional": true}
             ]
         },
         {

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -1,5 +1,6 @@
 #include "kqp_opt_impl.h"
 
+#include <ydb/core/kqp/common/kqp_batch_operations.h>
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
 
 #include <yql/essentials/core/yql_opt_utils.h>
@@ -135,6 +136,23 @@ bool HasIndexesToWrite(const TKikimrTableDescription& tableData) {
     }
 
     return hasIndexesToWrite;
+}
+
+TString IndexTypeToName(NYql::TIndexDescription::EType type) {
+    switch (type) {
+        case NYql::TIndexDescription::EType::GlobalSync:
+            return "global sync secondary";
+        case NYql::TIndexDescription::EType::GlobalAsync:
+            return "global async secondary";
+        case NYql::TIndexDescription::EType::GlobalSyncUnique:
+            return "global sync unique secondary";
+        case NYql::TIndexDescription::EType::GlobalSyncVectorKMeansTree:
+            return "global sync vector_kmeans_tree";
+        case NYql::TIndexDescription::EType::GlobalFulltextPlain:
+            return "global sync fulltext_plain";
+        case NYql::TIndexDescription::EType::GlobalFulltextRelevance:
+            return "global sync fulltext_relevance";
+    }
 }
 
 TExprBase BuildReadTable(const TCoAtomList& columns, TPositionHandle pos, const TKikimrTableDescription& tableData, bool forcePrimary, TMaybe<ui64> tabletId,
@@ -413,6 +431,7 @@ TExprBase BuildUpsertTableWithIndex(const TKiWriteTable& write, const TCoAtomLis
         .Columns(columns.Ptr())
         .ReturningColumns(write.ReturningColumns())
         .GenerateColumnsIfInsert(generateColumnsIfInsert)
+        .IsBatch(ctx.NewAtom(write.Pos(), "false"))
         .Settings(settings)
         .Done();
 
@@ -452,6 +471,7 @@ TExprBase BuildReplaceTableWithIndex(const TKiWriteTable& write, const TCoAtomLi
         .Columns(columns.Ptr())
         .ReturningColumns(write.ReturningColumns())
         .GenerateColumnsIfInsert<TCoAtomList>().Build()
+        .IsBatch(ctx.NewAtom(write.Pos(), "false"))
         .Settings(settings)
         .Done();
 
@@ -559,6 +579,7 @@ TExprBase BuildUpdateOnTableWithIndex(const TKiWriteTable& write, const TCoAtomL
         .Build()
         .Columns(inputColumns)
         .ReturningColumns(write.ReturningColumns())
+        .IsBatch(ctx.NewAtom(write.Pos(), "false"))
         .Settings(IsUpdateSetting(isStreamIndexWrite, ctx, write.Pos()))
         .Done();
 }
@@ -581,6 +602,7 @@ TExprBase BuildDeleteTableWithIndex(const TKiWriteTable& write, const TKikimrTab
         .Table(BuildTableMeta(tableData, write.Pos(), ctx))
         .Input(keysToDelete)
         .ReturningColumns(write.ReturningColumns())
+        .IsBatch(ctx.NewAtom(write.Pos(), "false"))
         .Done();
 }
 
@@ -623,6 +645,7 @@ TExprBase BuildDeleteTableWithIndex(const TKiDeleteTable& del, const TKikimrTabl
         .Table(BuildTableMeta(tableData, del.Pos(), ctx))
         .Input(rowsToDelete)
         .ReturningColumns(del.ReturningColumns())
+        .IsBatch(del.IsBatch())
         .Settings(settings.BuildNode(ctx, del.Pos()))
         .Done();
 }
@@ -772,10 +795,11 @@ TExprBase BuildUpdateTableWithIndex(const TKiUpdateTable& update, const TKikimrT
                 .Input(updatedRows)
                 .Columns(GetPgNotNullColumns(tableData, update.Pos(), ctx))
             .Build()
-            .ReturningColumns<TCoAtomList>().Build()
             .Columns<TCoAtomList>()
                 .Add(updateColumnsList)
                 .Build()
+            .ReturningColumns<TCoAtomList>().Build()
+            .IsBatch(update.IsBatch())
             .Settings(IsConditionalUpdateSetting(useStreamIndex, ctx, update.Pos()))
             .Done();
     }
@@ -827,7 +851,7 @@ TExprBase BuildUpdateTableWithIndex(const TKiUpdateTable& update, const TKikimrT
                 .Table(indexMeta)
                 .Input(ProjectColumns(rowsToUpdate, indexTableColumns, ctx))
                 .ReturningColumns<TCoAtomList>().Build()
-                .IsBatch(update.IsBatch())
+                .IsBatch(ctx.NewAtom(update.Pos(), "false"))
                 .Done();
 
             effects.push_back(indexDelete);
@@ -863,7 +887,7 @@ TExprBase BuildUpdateTableWithIndex(const TKiUpdateTable& update, const TKikimrT
                 .Columns()
                     .Add(indexColumnsList)
                     .Build()
-                .IsBatch(update.IsBatch())
+                .IsBatch(ctx.NewAtom(update.Pos(), "false"))
                 .DefaultColumns<TCoAtomList>().Build()
                 .Settings().Build()
                 .Done();
@@ -1031,6 +1055,17 @@ TExprNode::TPtr HandleUpdateTable(const TKiUpdateTable& update, TExprContext& ct
         return nullptr;
     }
 
+    if (update.IsBatch() == "true") {
+        const bool enabledIndexStreamWrite = kqpCtx.Config->GetEnableIndexStreamWrite();
+        for (const auto& index : tableData.Metadata->Indexes) {
+            if (!NBatchOperations::IsIndexSupported(index.Type, enabledIndexStreamWrite)) {
+                const TString err = "BATCH operations are not supported for tables with " + IndexTypeToName(index.Type) + " indexes (index: `" + index.Name + "`)." ;
+                ctx.AddError(YqlIssue(ctx.GetPosition(update.Pos()), NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED, err));
+                return nullptr;
+            }
+        }
+    }
+
     if (HasIndexesToWrite(tableData)) {
         return BuildUpdateTableWithIndex(update, tableData, withSystemColumns, ctx, kqpCtx).Ptr();
     } else {
@@ -1051,6 +1086,17 @@ TExprNode::TPtr HandleDeleteTable(const TKiDeleteTable& del, TExprContext& ctx, 
         const TString err = "BATCH operations are not supported at the current time.";
         ctx.AddError(YqlIssue(ctx.GetPosition(del.Pos()), TIssuesIds::KIKIMR_PRECONDITION_FAILED, err));
         return nullptr;
+    }
+
+    if (del.IsBatch() == "true") {
+        const bool enabledIndexStreamWrite = kqpCtx.Config->GetEnableIndexStreamWrite();
+        for (const auto& index : tableData.Metadata->Indexes) {
+            if (!NBatchOperations::IsIndexSupported(index.Type, enabledIndexStreamWrite)) {
+                const TString err = "BATCH operations are not supported for tables with " + IndexTypeToName(index.Type) + " indexes (index: `" + index.Name + "`)." ;
+                ctx.AddError(YqlIssue(ctx.GetPosition(del.Pos()), NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED, err));
+                return nullptr;
+            }
+        }
     }
 
     if (HasIndexesToWrite(tableData)) {

--- a/ydb/core/kqp/opt/kqp_type_ann.cpp
+++ b/ydb/core/kqp/opt/kqp_type_ann.cpp
@@ -1030,7 +1030,7 @@ TStatus AnnotateUpdateRows(const TExprNode::TPtr& node, TExprContext& ctx, const
         return TStatus::Error;
     }
 
-    if (!EnsureMaxArgsCount(*node, 5, ctx)) {
+    if (!EnsureMaxArgsCount(*node, 6, ctx)) {
         return TStatus::Error;
     }
 

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_delete_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_delete_index.cpp
@@ -51,7 +51,7 @@ TExprBase BuildDeleteIndexStagesImpl(const TKikimrTableDescription& table,
         .Table(del.Table())
         .Input(lookupKeys)
         .ReturningColumns(del.ReturningColumns())
-        .IsBatch(ctx.NewAtom(del.Pos(), "false"))
+        .IsBatch(del.IsBatch())
         .Done();
 
     TVector<TExprBase> effects;

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
@@ -83,7 +83,8 @@ NYql::NNodes::TMaybeNode<NYql::NNodes::TExprList> KqpPhyUpsertIndexEffectsImpl(T
     const NYql::NNodes::TCoAtomList& returningColumns,
     const NYql::NNodes::TCoAtomList& columnsWithDefaults,
     const NYql::NNodes::TExprBase& tableExpr,
-    const NYql::TKikimrTableDescription& table, const NYql::NNodes::TMaybeNode<NYql::NNodes::TCoNameValueTupleList>& settings,
+    const NYql::TKikimrTableDescription& table, const bool isBatch,
+    const NYql::NNodes::TMaybeNode<NYql::NNodes::TCoNameValueTupleList>& settings,
     NYql::TPositionHandle pos, NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx);
 
 

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_returning.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_returning.cpp
@@ -250,7 +250,7 @@ TExprBase KqpRewriteReturningUpsert(TExprBase node, TExprContext& ctx, const TKq
                 .Build()
             .Table(upsert.Table())
             .Columns(upsert.Columns())
-            .IsBatch(upsert.IsBatch())
+            .IsBatch(ctx.NewAtom(upsert.Pos(), "false"))
             .DefaultColumns(upsert.DefaultColumns())
             .Settings(upsert.Settings())
             .ReturningColumns(upsert.ReturningColumns())
@@ -273,7 +273,7 @@ TExprBase KqpRewriteReturningDelete(TExprBase node, TExprContext& ctx, const TKq
                 .Input(del.Input())
                 .Build()
             .Table(del.Table())
-            .IsBatch(del.IsBatch())
+            .IsBatch(ctx.NewAtom(del.Pos(), "false"))
             .ReturningColumns(del.ReturningColumns())
             .Done();
 }

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_update_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_update_index.cpp
@@ -19,7 +19,7 @@ TExprBase KqpBuildUpdateIndexStages(TExprBase node, TExprContext& ctx, const TKq
 
     auto effects = KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode::UpdateOn, update.Input(),
         update.Columns(), update.ReturningColumns(), empty, update.Table(), table,
-        update.Settings(), update.Pos(), ctx, kqpCtx);
+        update.IsBatch() == "true", update.Settings(), update.Pos(), ctx, kqpCtx);
 
     if (!effects) {
         return node;

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
@@ -615,7 +615,7 @@ RewriteInputForConstraint(const TExprBase& inputRows, const THashSet<TStringBuf>
 
 TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, const TExprBase& inputRows,
     const TCoAtomList& inputColumns, const TCoAtomList& returningColumns, const TCoAtomList& columnsWithDefaults,
-    const TExprBase& tableExpr, const TKikimrTableDescription& table,
+    const TExprBase& tableExpr, const TKikimrTableDescription& table, const bool isBatch,
     const TMaybeNode<NYql::NNodes::TCoNameValueTupleList>& settings, TPositionHandle pos,
     TExprContext& ctx, const TKqpOptimizeContext& kqpCtx)
 {
@@ -660,7 +660,7 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
             .Input(inputRows.Ptr())
             .Columns(inputColumns)
             .ReturningColumns(returningColumns.Ptr())
-            .IsBatch(ctx.NewAtom(pos, "false"))
+            .IsBatch(isBatch ? ctx.NewAtom(pos, "true") : ctx.NewAtom(pos, "false"))
             .DefaultColumns(columnsWithDefaults)
             .Settings(settings)
             .Done());
@@ -727,7 +727,7 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
         .Input(tableUpsertRows)
         .Columns(inputColumns)
         .ReturningColumns(returningColumns)
-        .IsBatch(ctx.NewAtom(pos, "false"))
+        .IsBatch(isBatch ? ctx.NewAtom(pos, "true") : ctx.NewAtom(pos, "false"))
         .DefaultColumns(columnsWithDefaults)
         .Settings(settings)
         .Done());
@@ -1116,7 +1116,7 @@ TExprBase KqpBuildUpsertIndexStages(TExprBase node, TExprContext& ctx, const TKq
 
     auto effects = KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode::Upsert, upsert.Input(), upsert.Columns(),
         upsert.ReturningColumns(), upsert.GenerateColumnsIfInsert(), upsert.Table(), table,
-        upsert.Settings(), upsert.Pos(), ctx, kqpCtx);
+        upsert.IsBatch() == "true", upsert.Settings(), upsert.Pos(), ctx, kqpCtx);
 
     if (!effects) {
         return node;

--- a/ydb/core/kqp/ut/batch_operations/kqp_batch_update_ut.cpp
+++ b/ydb/core/kqp/ut/batch_operations/kqp_batch_update_ut.cpp
@@ -8,11 +8,12 @@ using namespace NYdb::NQuery;
 namespace {
 
 TKikimrSettings GetTestSettings(size_t maxBatchSize = 10000, size_t partitionLimit = 10,
-    bool enableOltpSink = true, bool enableBatchUpdates = true)
+    bool enableOltpSink = true, bool enableBatchUpdates = true, bool enableIndexStreamWrite = true)
 {
     auto app = NKikimrConfig::TAppConfig();
     app.MutableTableServiceConfig()->SetEnableOlapSink(true);
     app.MutableTableServiceConfig()->SetEnableOltpSink(enableOltpSink);
+    app.MutableTableServiceConfig()->SetEnableIndexStreamWrite(enableIndexStreamWrite);
     app.MutableTableServiceConfig()->SetEnableBatchUpdates(enableBatchUpdates);
     app.MutableTableServiceConfig()->MutableBatchOperationSettings()->SetMaxBatchSize(maxBatchSize);
     app.MutableTableServiceConfig()->MutableBatchOperationSettings()->SetPartitionExecutionLimit(partitionLimit);
@@ -744,6 +745,376 @@ Y_UNIT_TEST_SUITE(KqpBatchUpdate) {
                 UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "BATCH operations are not supported at the current time.", result.GetIssues().ToString());
             }
         }
+    }
+
+    Y_UNIT_TEST_TWIN(TableWithSyncIndex, EnableIndexStreamWrite) {
+        TKikimrRunner kikimr(GetTestSettings(10000, 10, true, true, EnableIndexStreamWrite).SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteQuery(R"(
+                CREATE TABLE global_sync_idx (
+                    k Int32 NOT NULL,
+                    v1 String,
+                    v2 String,
+                    v3 String,
+                    PRIMARY KEY (k),
+                    INDEX idx GLOBAL SYNC ON (v1) COVER (v2)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                UPSERT INTO global_sync_idx (k, v1, v2, v3) VALUES
+                    (1, "123", "456", "789"),
+                    (2, "123", "456", "789"),
+                    (3, "123", "456", "789"),
+                    (4, "123", "456", "789"),
+                    (5, "123", "456", "789");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE global_sync_idx
+                    SET v1 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE global_sync_idx
+                    SET v2 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE global_sync_idx
+                    SET v3 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM global_sync_idx
+                WHERE v1 != "0" OR v2 != "0" OR v3 != "0";
+        )");
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM `/Root/global_sync_idx/idx/indexImplTable`
+                WHERE v1 != "0" OR v2 != "0";
+        )");
+
+        {
+            const auto query = R"(
+                BATCH UPDATE global_sync_idx
+                    SET v1 = "1", v2 = "2", v3 = "3";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM global_sync_idx
+                WHERE v1 != "1" OR v2 != "2" OR v3 != "3";
+        )");
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM `/Root/global_sync_idx/idx/indexImplTable`
+                WHERE v1 != "1" OR v2 != "2";
+        )");
+    }
+
+    Y_UNIT_TEST_TWIN(TableWithUniqueSyncIndex, EnableIndexStreamWrite) {
+        TKikimrRunner kikimr(GetTestSettings(10000, 10, true, true, EnableIndexStreamWrite).SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteQuery(R"(
+                CREATE TABLE global_unique_sync_idx (
+                    k Int32 NOT NULL,
+                    v1 String,
+                    v2 String,
+                    v3 String,
+                    PRIMARY KEY (k),
+                    INDEX idx GLOBAL UNIQUE SYNC ON (v1) COVER (v2)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                UPSERT INTO global_unique_sync_idx (k, v1, v2, v3) VALUES
+                    (1, "123", "456", "789"),
+                    (2, "124", "456", "789"),
+                    (3, "125", "456", "789"),
+                    (4, "126", "456", "789"),
+                    (5, "127", "456", "789");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE global_unique_sync_idx SET v1 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+
+            if (EnableIndexStreamWrite) {
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Duplicated keys found");
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "BATCH operations are not supported for tables with global sync unique secondary indexes (index: `idx`)");
+            }
+        }
+
+        if (!EnableIndexStreamWrite) {
+            return;
+        }
+
+        {
+            const auto query = R"(
+                BATCH UPDATE global_unique_sync_idx SET v2 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE global_unique_sync_idx SET v3 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM global_unique_sync_idx WHERE v2 != "0" OR v3 != "0";
+        )");
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM `/Root/global_unique_sync_idx/idx/indexImplTable` WHERE v2 != "0";
+        )");
+
+        {
+            const auto query = R"(
+                BATCH UPDATE global_unique_sync_idx SET v2 = "2", v3 = "3";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM global_unique_sync_idx WHERE v2 != "2" OR v3 != "3";
+        )");
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM `/Root/global_unique_sync_idx/idx/indexImplTable` WHERE v2 != "2";
+        )");
+    }
+
+    Y_UNIT_TEST_TWIN(TableWithAsyncIndex, EnableIndexStreamWrite) {
+        TKikimrRunner kikimr(GetTestSettings(10000, 10, true, true, EnableIndexStreamWrite).SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteQuery(R"(
+                CREATE TABLE global_async_idx (
+                    k Int32 NOT NULL,
+                    v1 String,
+                    v2 String,
+                    v3 String,
+                    PRIMARY KEY (k),
+                    INDEX idx GLOBAL ASYNC ON (v1) COVER (v2)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                UPSERT INTO global_async_idx (k, v1, v2, v3) VALUES
+                    (1, "123", "456", "789"),
+                    (2, "123", "456", "789"),
+                    (3, "123", "456", "789"),
+                    (4, "123", "456", "789"),
+                    (5, "123", "456", "789");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE global_async_idx SET v1 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE global_async_idx SET v2 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE global_async_idx SET v3 = "0";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM global_async_idx WHERE v1 != "0" OR v2 != "0" OR v3 != "0";
+        )");
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM `/Root/global_async_idx/idx/indexImplTable` WHERE v1 != "0" OR v2 != "0";
+        )", TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx());
+
+        {
+            const auto query = R"(
+                BATCH UPDATE global_async_idx SET v1 = "1", v2 = "2", v3 = "3";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM global_async_idx WHERE v1 != "1" OR v2 != "2" OR v3 != "3";
+        )");
+
+        ExecQueryAndTestEmpty(session, R"(
+            SELECT count(*) FROM `/Root/global_async_idx/idx/indexImplTable` WHERE v1 != "1" OR v2 != "2";
+        )", TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx());
+    }
+
+    Y_UNIT_TEST(TableWithVectorIndex) {
+        TKikimrRunner kikimr(GetTestSettings().SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteQuery(R"(
+                CREATE TABLE vector_idx (
+                    k Int32 NOT NULL,
+                    v String,
+                    PRIMARY KEY (k),
+                    INDEX idx GLOBAL SYNC USING vector_kmeans_tree ON (v) WITH (
+                        distance="cosine",
+                        vector_type="uint8",
+                        vector_dimension=3,
+                        clusters=2,
+                        levels=3
+                    )
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE vector_idx SET v = "123";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "BATCH operations are not supported for tables with global sync vector_kmeans_tree indexes (index: `idx`)");
+        }
+    }
+
+    Y_UNIT_TEST(TableWithFullTextIndex) {
+        auto settings = GetTestSettings().SetWithSampleTables(false);
+
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableFulltextIndex(true);
+        settings.SetFeatureFlags(featureFlags);
+
+        auto kikimr = TKikimrRunner(settings);
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteQuery(R"(
+                CREATE TABLE fulltext_plain_idx (
+                    k Int32 NOT NULL,
+                    v1 String,
+                    v2 String,
+                    v3 String,
+                    PRIMARY KEY (k),
+                    INDEX idx GLOBAL SYNC USING fulltext_plain ON (v1) COVER (v2) WITH (
+                        tokenizer=standard,
+                        use_filter_lowercase=true
+                    )
+                );
+
+                CREATE TABLE fulltext_relevance_idx (
+                    k Int32 NOT NULL,
+                    v1 String,
+                    v2 String,
+                    v3 String,
+                    PRIMARY KEY (k),
+                    INDEX idx GLOBAL SYNC USING fulltext_relevance ON (v1) COVER (v2) WITH (
+                        tokenizer=standard,
+                        use_filter_lowercase=true
+                    )
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE fulltext_plain_idx SET v1 = "123";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "BATCH operations are not supported for tables with global sync fulltext_plain indexes (index: `idx`)");
+        }
+
+        /*
+            TODO:
+            Fatal: ydb/core/kqp/provider/yql_kikimr_opt_build.cpp:243  AddUpdateOpToQueryBlock():
+            requirement indexTables.size() == 1 failed, message: Only index with one impl table is supported
+
+        {
+            const auto query = R"(
+                BATCH UPDATE fulltext_relevance_idx SET v1 = "123";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "BATCH operations are not supported for tables with global sync fulltext_relevance indexes (index: `idx`)");
+        }
+        */
     }
 }
 

--- a/ydb/core/kqp/ut/common/kqp_ut_common.cpp
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.cpp
@@ -850,9 +850,8 @@ TDataQueryResult ExecQueryAndTestResult(TSession& session, const TString& query,
     return result;
 }
 
-NYdb::NQuery::TExecuteQueryResult ExecQueryAndTestEmpty(NYdb::NQuery::TSession& session, const TString& query) {
-    auto result = session.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx())
-        .ExtractValueSync();
+NYdb::NQuery::TExecuteQueryResult ExecQueryAndTestEmpty(NYdb::NQuery::TSession& session, const TString& query, NYdb::NQuery::TTxControl txControl) {
+    auto result = session.ExecuteQuery(query, txControl).ExtractValueSync();
     UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
     CompareYson("[[0u]]", FormatResultSetYson(result.GetResultSet(0)));
     return result;

--- a/ydb/core/kqp/ut/common/kqp_ut_common.h
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.h
@@ -359,7 +359,7 @@ inline NYdb::NTable::TDataQueryResult ExecQueryAndTestResult(NYdb::NTable::TSess
     return ExecQueryAndTestResult(session, query, NYdb::TParamsBuilder().Build(), expectedYson);
 }
 
-NYdb::NQuery::TExecuteQueryResult ExecQueryAndTestEmpty(NYdb::NQuery::TSession& session, const TString& query);
+NYdb::NQuery::TExecuteQueryResult ExecQueryAndTestEmpty(NYdb::NQuery::TSession& session, const TString& query, NYdb::NQuery::TTxControl txControl = NYdb::NQuery::TTxControl::NoTx());
 
 class TStreamReadError : public yexception {
 public:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- BATCH is disabled for vector indexes.
- BATCH is disabled for fulltext indexes.
- BATCH is disabled for unique without `EnableIndexStreamWrite`.
- Fix problems and lost parameters for BATCH operations with `EnableIndexStreamWrite`.

Problem: `BATCH UPDATE` is executed like basic `UPDATE`: #33128
...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
