### PR TITLE
schemeshard: add batch processing for ttl responses

### DIFF
--- a/ydb/core/base/appdata.cpp
+++ b/ydb/core/base/appdata.cpp
@@ -22,6 +22,7 @@
 #include <ydb/core/protos/cms.pb.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/data_integrity_trails.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/datashard_config.pb.h>
 #include <ydb/core/protos/feature_flags.pb.h>
 #include <ydb/core/protos/key.pb.h>

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -66,6 +66,7 @@
 #include <ydb/core/protos/node_broker.pb.h>
 #include <ydb/core/protos/recoveryshard_config.pb.h>
 #include <ydb/core/protos/replication.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/stream.pb.h>
 #include <ydb/core/protos/workload_manager_config.pb.h>
 #include <ydb/core/protos/data_integrity_trails.pb.h>

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -13,8 +13,8 @@ import "ydb/core/protos/cms.proto";
 import "ydb/core/protos/compaction.proto";
 import "ydb/core/protos/config_metrics.proto";
 import "ydb/core/protos/config_units.proto";
-import "ydb/core/protos/counters_schemeshard.proto";
 import "ydb/core/protos/data_integrity_trails.proto";
+import "ydb/core/protos/schemeshard_config.proto";
 import "ydb/core/protos/datashard_config.proto";
 import "ydb/core/protos/drivemodel.proto";
 import "ydb/core/protos/feature_flags.proto";
@@ -2547,37 +2547,7 @@ message TColumnShardConfig {
     optional bool EnableCursorV1 = 68 [default = false];
 }
 
-message TSchemeShardConfig {
-    message TInFlightCounterConfig {
-        optional NKikimr.NSchemeShard.ESimpleCounters Type = 1;
-        // after this amount scheme shard begin to abort the operations
-        // to disable set to 0
-        optional uint32 InFlightLimit = 2 [default = 10000];
-    }
-    // after this amount of time we forcibly write full stats to local DB
-    // to disable set to 0
-    optional uint32 StatsBatchTimeoutMs = 1 [default = 100];
-
-    // number of shards stats to batch together
-    // to disable set to 0
-    optional uint32 StatsMaxBatchSize = 2 [default = 100];
-
-    optional uint32 StatsMaxExecuteMs = 3 [default = 10];
-
-    repeated TInFlightCounterConfig InFlightCounterConfig = 4;
-
-    // number of shards per table
-    optional uint32 MaxCdcInitialScanShardsInFlight = 5 [default = 32];
-
-    // number of shards per table
-    // 0 means default - NKikimrIndexBuilder.TIndexBuildSettings.max_shards_in_flight
-    optional uint32 MaxRestoreBuildIndexShardsInFlight = 6 [default = 1000];
-
-    // number of shards per table
-    // database level default for TTL mechanics
-    // 0 means no limit
-    optional uint32 MaxTTLShardsInFlight = 7 [default = 0];
-}
+// TSchemeShardConfig has been moved to ydb/core/protos/schemeshard_config.proto
 
 message TCompactionConfig {
     message TBackgroundCompactionConfig {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -253,4 +253,5 @@ message TFeatureFlags {
     optional bool EnableTopicsSqlIoOperations = 226 [default = false];
     optional bool EnableSysViewPermissionsExport = 227 [default = false];
     optional bool EnableCmsSmartAvailabilityMode = 228 [default = false];
+    optional bool EnableConditionalEraseResponseBatching = 229 [default = false];
 }

--- a/ydb/core/protos/schemeshard_config.proto
+++ b/ydb/core/protos/schemeshard_config.proto
@@ -1,0 +1,44 @@
+import "ydb/core/protos/counters_schemeshard.proto";
+
+package NKikimrConfig;
+option java_package = "ru.yandex.kikimr.proto";
+
+message TSchemeShardConfig {
+    message TInFlightCounterConfig {
+        optional NKikimr.NSchemeShard.ESimpleCounters Type = 1;
+        // after this amount scheme shard begin to abort the operations
+        // to disable set to 0
+        optional uint32 InFlightLimit = 2 [default = 10000];
+    }
+    // after this amount of time we forcibly write full stats to local DB
+    // to disable set to 0
+    optional uint32 StatsBatchTimeoutMs = 1 [default = 100];
+
+    // number of shards stats to batch together
+    // to disable set to 0
+    optional uint32 StatsMaxBatchSize = 2 [default = 100];
+
+    optional uint32 StatsMaxExecuteMs = 3 [default = 10];
+
+    repeated TInFlightCounterConfig InFlightCounterConfig = 4;
+
+    // number of shards per table
+    optional uint32 MaxCdcInitialScanShardsInFlight = 5 [default = 32];
+
+    // number of shards per table
+    // 0 means default - NKikimrIndexBuilder.TIndexBuildSettings.max_shards_in_flight
+    optional uint32 MaxRestoreBuildIndexShardsInFlight = 6 [default = 1000];
+
+    // number of shards per table
+    // database level default for TTL mechanics
+    // 0 means no limit
+    optional uint32 MaxTTLShardsInFlight = 7 [default = 0];
+
+    // number of conditional erase responses to batch together
+    // 0 disables batching (processes each response immediately via non-batch path)
+    // 1 processes each response immediately via batch path (not recommended)
+    optional uint32 CondEraseResponseBatchSize = 8 [default = 100];
+
+    // maximum time to hold an incomplete conditional erase response batch before processing
+    optional uint32 CondEraseResponseBatchMaxTimeMs = 9 [default = 100];
+}

--- a/ydb/core/protos/ya.make
+++ b/ydb/core/protos/ya.make
@@ -132,6 +132,7 @@ SRCS(
     scheme_log.proto
     scheme_type_metadata.proto
     scheme_type_operation.proto
+    schemeshard_config.proto
     serverless_proxy_config.proto
     shared_cache.proto
     sqs.proto

--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -21,6 +21,7 @@
 #include <ydb/core/protos/key.pb.h>
 #include <ydb/core/protos/netclassifier.pb.h>
 #include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/stream.pb.h>
 #include <ydb/core/protos/workload_manager_config.pb.h>
 

--- a/ydb/core/testlib/basics/appdata.h
+++ b/ydb/core/testlib/basics/appdata.h
@@ -14,6 +14,7 @@
 #include <ydb/core/protos/blobstorage.pb.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/datashard_config.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/kqp.pb.h>
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/core/protos/resource_broker.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
@@ -1,4 +1,5 @@
 #include "schemeshard_impl.h"
+#include "schemeshard__conditional_erase.h"
 
 #include <util/string/join.h>
 #include <ydb/core/base/table_index.h>
@@ -7,27 +8,29 @@
 namespace NKikimr {
 namespace NSchemeShard {
 
+std::function<void (const TInstant, const THashMap<TPathId, TCondEraseAffectedTable>&)> CondEraseTestObserver;
+
 using namespace NTabletFlatExecutor;
 
 namespace {
 
-    std::pair<TTableInfo::TPtr, TShardIdx> ResolveInfo(const TSchemeShard* self, TTabletId tabletId) {
+    std::tuple<TTableInfo::TPtr, TPathId, TShardIdx> ResolveInfo(const TSchemeShard* self, TTabletId tabletId) {
         const auto shardIdx = self->GetShardIdx(tabletId);
         if (!self->ShardInfos.contains(shardIdx)) {
-            return std::make_pair(nullptr, InvalidShardIdx);
+            return std::make_tuple(nullptr, InvalidPathId, InvalidShardIdx);
         }
 
         const auto& pathId = self->ShardInfos.at(shardIdx).PathId;
         if (!self->TTLEnabledTables.contains(pathId)) {
-            return std::make_pair(nullptr, InvalidShardIdx);
+            return std::make_tuple(nullptr, InvalidPathId, InvalidShardIdx);
         }
 
         auto tableInfo = self->TTLEnabledTables.at(pathId);
         if (!tableInfo->IsTTLEnabled()) {
-            return std::make_pair(nullptr, InvalidShardIdx);
+            return std::make_tuple(nullptr, InvalidPathId, InvalidShardIdx);
         }
 
-        return std::make_pair(tableInfo, shardIdx);
+        return std::make_tuple(tableInfo, pathId, shardIdx);
     }
 
 } // anonymous
@@ -200,8 +203,8 @@ struct TSchemeShard::TTxRunConditionalErase: public TSchemeShard::TRwTxBase {
             const auto& tabletId = kv.first;
             auto& request = kv.second;
 
-            auto [tableInfo, shardIdx] = ResolveInfo(Self, tabletId);
-            if (!tableInfo || shardIdx == InvalidShardIdx) {
+            const auto [tableInfo, tablePathId, shardIdx] = ResolveInfo(Self, tabletId);
+            if (!tableInfo || tablePathId == InvalidPathId || shardIdx == InvalidShardIdx) {
                 Y_DEBUG_ABORT("Unreachable");
                 continue;
             }
@@ -332,14 +335,16 @@ private:
 }; // TTxRunConditionalErase
 
 struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSchemeShard> {
-    TEvDataShard::TEvConditionalEraseRowsResponse::TPtr Ev;
-    THolder<NSysView::TEvSysView::TEvUpdateTtlStats> StatsCollectorEv;
-    TTableInfo::TPtr TableInfo;
+    TVector<TEvDataShard::TEvConditionalEraseRowsResponse::TPtr> Responses;
+    TInstant BatchStartTime;
+    TVector<THolder<NSysView::TEvSysView::TEvUpdateTtlStats>> StatsCollectorEvents;
 
-    TTxScheduleConditionalErase(TSelf* self, TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& ev)
+    THashMap<TPathId, TCondEraseAffectedTable> AffectedTables;
+
+    TTxScheduleConditionalErase(TSelf* self, TVector<TEvDataShard::TEvConditionalEraseRowsResponse::TPtr>&& responses, const TInstant batchStartTime)
         : TBase(self)
-        , Ev(ev)
-        , TableInfo(nullptr)
+        , Responses(std::move(responses))
+        , BatchStartTime(batchStartTime)
     {
     }
 
@@ -349,120 +354,175 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
         return TXTYPE_SCHEDULE_CONDITIONAL_ERASE;
     }
 
-    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
-        LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxScheduleConditionalErase Execute"
-            << ": at schemeshard: " << Self->TabletID());
-
-        if (!Self->AllowConditionalEraseOperations) {
-            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase operations are not allowed"
-                << ", skip TTxScheduleConditionalErase"
-                << ": at schemeshard: " << Self->TabletID());
-            return true;
-        }
-
-        const auto& record = Ev->Get()->Record;
-
-        const TTabletId tabletId(record.GetTabletID());
-        auto [tableInfo, shardIdx] = ResolveInfo(Self, tabletId);
-
-        if (!tableInfo || shardIdx == InvalidShardIdx) {
-            LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Unable to resolve info"
-                << ": tabletId: " << tabletId
-                << ", at schemeshard: " << Self->TabletID());
-            return true;
-        }
-
-        if (!tableInfo->GetInFlightCondErase().contains(shardIdx)) {
-            return true;
-        }
-
+    TDuration ProcessCondEraseResponse(
+        const TActorContext& ctx,
+        TPathId tablePathId,
+        TTableInfo::TPtr tableInfo,
+        TShardIdx shardIdx,
+        const NKikimrTxDataShard::TEvConditionalEraseRowsResponse& record,
+        TInstant now
+    ) {
         const auto& sysSettings = tableInfo->TTLSettings().GetEnabled().GetSysSettings();
         TDuration next = TDuration::FromValue(sysSettings.GetRunInterval());
 
         switch (record.GetStatus()) {
-        case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::PARTIAL:
-            // TODO: remember progress
-            return true;
+            case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::ACCEPTED:
+            case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::PARTIAL:
+                // Both cases are dead code here.
+                // Both do not affect state in any way and both processed at the event handler
+                // to avoid wasting a local transaction on a no-op.
+                //TODO: remember progress for PARTIAL (and until that, PARTIAL will not affect state)
+                return next;
 
-        case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::BAD_REQUEST:
-        case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::ABORTED:
-        case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::ERASE_ERROR:
-        case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::OVERLOADED:
-        case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::SCHEME_ERROR:
-            next = TDuration::FromValue(sysSettings.GetRetryInterval());
-            LOG_ERROR_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Unsuccessful conditional erase"
-                << ": tabletId: " << tabletId
-                << ", status: " << NKikimrTxDataShard::TEvConditionalEraseRowsResponse_EStatus_Name(record.GetStatus())
-                << ", error: " << record.GetErrorDescription()
-                << ", retry after: " << next
-                << ", at schemeshard: " << Self->TabletID());
-            break;
+            case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::OK:
+                LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Successful conditional erase"
+                    << ": tabletId: " << record.GetTabletID()
+                    << ", at schemeshard: " << Self->TabletID());
+                break;
 
-        case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::OK:
-            LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Successful conditional erase"
-                << ": tabletId: " << tabletId
-                << ", at schemeshard: " << Self->TabletID());
-            break;
-
-        default:
+            case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::BAD_REQUEST:
+            case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::ABORTED:
+            case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::ERASE_ERROR:
+            case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::OVERLOADED:
+            case NKikimrTxDataShard::TEvConditionalEraseRowsResponse::SCHEME_ERROR:
+                next = TDuration::FromValue(sysSettings.GetRetryInterval());
+                LOG_ERROR_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Unsuccessful conditional erase"
+                    << ": tabletId: " << record.GetTabletID()
+                    << ", status: " << NKikimrTxDataShard::TEvConditionalEraseRowsResponse_EStatus_Name(record.GetStatus())
+                    << ", error: " << record.GetErrorDescription()
+                    << ", retry after: " << next
+                    << ", at schemeshard: " << Self->TabletID());
+                break;
+        }
+        if (!NKikimrTxDataShard::TEvConditionalEraseRowsResponse_EStatus_IsValid(record.GetStatus())) {
             LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Unknown conditional erase status"
-                << ": tabletId: " << tabletId
+                << ": tabletId: " << record.GetTabletID()
                 << ", status: " << static_cast<ui32>(record.GetStatus())
                 << ", error: " << record.GetErrorDescription()
-                << ", at schemeshard: " << Self->TabletID());
-            break;
+                << ", at schemeshard: " << Self->TabletID()
+            );
         }
 
-        const auto& shardToPartition = tableInfo->GetShard2PartitionIdx();
-        Y_ABORT_UNLESS(shardToPartition.contains(shardIdx));
-        const ui64 partitionIdx = shardToPartition.at(shardIdx);
-
-        const auto& partitions = tableInfo->GetPartitions();
-        Y_ABORT_UNLESS(partitionIdx < partitions.size());
-        const auto& lag = partitions.at(partitionIdx).LastCondEraseLag;
-
-        if (lag) {
-            Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
-        } else {
-            Y_DEBUG_ABORT_UNLESS(false);
-        }
-
-        const auto now = ctx.Now();
-
-        NIceDb::TNiceDb db(txc.DB);
-        tableInfo->ScheduleNextCondErase(shardIdx, now, next);
-
-        Y_ABORT_UNLESS(Self->ShardInfos.contains(shardIdx));
-        const TPathId& tableId = Self->ShardInfos.at(shardIdx).PathId;
-
-        Self->PersistTablePartitionCondErase(db, tableId, partitionIdx, tableInfo);
-
-        StatsCollectorEv = MakeHolder<NSysView::TEvSysView::TEvUpdateTtlStats>(
-            Self->GetDomainKey(tableId), tableId, std::make_pair(ui64(shardIdx.GetOwnerId()), ui64(shardIdx.GetLocalId()))
+        auto statsEv = MakeHolder<NSysView::TEvSysView::TEvUpdateTtlStats>(
+            Self->GetDomainKey(tablePathId), tablePathId, std::make_pair(ui64(shardIdx.GetOwnerId()), ui64(shardIdx.GetLocalId()))
         );
 
-        auto& stats = StatsCollectorEv->Stats;
+        auto& stats = statsEv->Stats;
         stats.SetLastRunTime(now.MilliSeconds());
         stats.SetLastRowsProcessed(record.GetStats().GetRowsProcessed());
         stats.SetLastRowsErased(record.GetStats().GetRowsErased());
 
-        Y_ABORT_UNLESS(lag.Defined());
-        Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
+        StatsCollectorEvents.push_back(std::move(statsEv));
 
-        TableInfo = tableInfo;
+        return next;
+    }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxScheduleConditionalErase Execute"
+            << ": responses: " << Responses.size()
+            << ", at schemeshard: " << Self->TabletID());
+
+        if (!Self->AllowConditionalEraseOperations) {
+            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase operations are not allowed"
+                << ", skip TTxScheduleConditionalErase"
+                << ", at schemeshard: " << Self->TabletID());
+            return true;
+        }
+
+        const auto now = ctx.Now();
+
+        for (const auto& ev : Responses) {
+            const auto& record = ev->Get()->Record;
+            const TTabletId tabletId(record.GetTabletID());
+            const auto [tableInfo, tablePathId, shardIdx] = ResolveInfo(Self, tabletId);
+
+            if (!tableInfo || tablePathId == InvalidPathId || shardIdx == InvalidShardIdx) {
+                LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Unable to resolve info"
+                    << ": tabletId: " << tabletId
+                    << ", at schemeshard: " << Self->TabletID());
+                continue;
+            }
+
+            if (!tableInfo->GetInFlightCondErase().contains(shardIdx)) {
+                continue;
+            }
+
+            const auto& shardToPartition = tableInfo->GetShard2PartitionIdx();
+            Y_ABORT_UNLESS(shardToPartition.contains(shardIdx));
+            const ui64 partitionIdx = shardToPartition.at(shardIdx);
+            Y_ABORT_UNLESS(partitionIdx < tableInfo->GetPartitions().size());
+
+            TDuration next = ProcessCondEraseResponse(ctx, tablePathId, tableInfo, shardIdx, record, now);
+
+            // Track affected tables and shards
+            {
+                auto [it, _] = AffectedTables.try_emplace(tablePathId, TCondEraseAffectedTable{
+                    .TableInfo = tableInfo
+                });
+                it->second.AffectedShards.emplace_back(TCondEraseAffectedShard{
+                    .ShardIdx = shardIdx,
+                    .PartitionIdx = partitionIdx,
+                    .TabletId = tabletId,
+                    .Next = next,
+                });
+            }
+        }
+
+        // update CondErase states
+        for (const auto& item : AffectedTables | std::views::values) {
+            const auto& tableInfo = item.TableInfo;
+            for (const auto& i : item.AffectedShards) {
+                {
+                    const auto& lag = tableInfo->GetPartitions().at(i.PartitionIdx).LastCondEraseLag;
+                    if (lag) {
+                        Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
+                    } else {
+                        Y_DEBUG_ABORT_UNLESS(false);
+                    }
+                }
+
+                // ScheduleNextCondErase (also) changes LastCondEraseLag
+                tableInfo->ScheduleNextCondErase(i.ShardIdx, now, i.Next);
+
+                {
+                    const auto& lag = tableInfo->GetPartitions().at(i.PartitionIdx).LastCondEraseLag;
+                    Y_ABORT_UNLESS(lag.Defined());
+                    Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
+                }
+            }
+        }
+
+        // save CondErase states
+        NIceDb::TNiceDb db(txc.DB);
+        for (const auto& [tablePathId, item] : AffectedTables) {
+            const auto& tableInfo = item.TableInfo;
+            const auto& affectedShards = item.AffectedShards;
+            for (const auto& i : affectedShards) {
+                Self->PersistTablePartitionCondErase(db, tablePathId, i.PartitionIdx, tableInfo);
+            }
+        }
+
         return true;
     }
 
     void Complete(const TActorContext& ctx) override {
         LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxScheduleConditionalErase Complete"
-            << ": at schemeshard: " << Self->TabletID());
+            << ": affected tables: " << AffectedTables.size()
+            << ", at schemeshard: " << Self->TabletID());
 
-        if (StatsCollectorEv) {
-            ctx.Send(Self->SysPartitionStatsCollector, StatsCollectorEv.Release());
+        // Send stats events
+        for (auto& ev : StatsCollectorEvents) {
+            ctx.Send(Self->SysPartitionStatsCollector, ev.Release());
         }
 
-        if (TableInfo) {
-            Self->Execute(new TTxRunConditionalErase(Self, TableInfo), ctx);
+        // Report batch to the observer, if registered
+        if (CondEraseTestObserver) {
+            CondEraseTestObserver(BatchStartTime, AffectedTables);
+        }
+
+        // Trigger one TTxRunConditionalErase per affected table
+        for (const auto& [tablePathId, item] : AffectedTables) {
+            Self->Execute(new TTxRunConditionalErase(Self, item.TableInfo), ctx);
         }
     }
 
@@ -472,13 +532,13 @@ ITransaction* TSchemeShard::CreateTxRunConditionalErase(TEvPrivate::TEvRunCondit
     return new TTxRunConditionalErase(this, ev);
 }
 
-ITransaction* TSchemeShard::CreateTxScheduleConditionalErase(TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& ev) {
-    return new TTxScheduleConditionalErase(this, ev);
+ITransaction* TSchemeShard::CreateTxScheduleConditionalErase(TVector<TEvDataShard::TEvConditionalEraseRowsResponse::TPtr>&& responses, const TInstant batchStartTime) {
+    return new TTxScheduleConditionalErase(this, std::move(responses), batchStartTime);
 }
 
 void TSchemeShard::ConditionalEraseHandleDisconnect(TTabletId tabletId, const TActorId& clientId, const TActorContext& ctx) {
-    auto [tableInfo, shardIdx] = ResolveInfo(this, tabletId);
-    if (!tableInfo || shardIdx == InvalidShardIdx) {
+    auto [tableInfo, tablePathId, shardIdx] = ResolveInfo(this, tabletId);
+    if (!tableInfo || tablePathId == InvalidPathId || shardIdx == InvalidShardIdx) {
         return;
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.h
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <functional>
+#include <util/generic/vector.h>
+#include <util/generic/hash.h>
+#include <util/datetime/base.h>
+
+#include <ydb/core/tx/schemeshard/schemeshard_identificators.h>
+#include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
+
+namespace NKikimr::NSchemeShard {
+
+struct TCondEraseAffectedShard {
+    TShardIdx ShardIdx;
+    ui64 PartitionIdx;
+    TTabletId TabletId;
+    TDuration Next;
+};
+struct TCondEraseAffectedTable {
+    TTableInfo::TPtr TableInfo;
+    TVector<TCondEraseAffectedShard> AffectedShards;
+};
+
+extern std::function<void (const TInstant, const THashMap<TPathId, TCondEraseAffectedTable>&)> CondEraseTestObserver;
+
+}  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -16,6 +16,7 @@
 #include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/protos/feature_flags.pb.h>
 #include <ydb/core/protos/s3_settings.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/table_stats.pb.h>  // for TStoragePoolsStats
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/statistics/events.h>
@@ -5160,7 +5161,7 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     ConfigureStatsOperations(appData->SchemeShardConfig, ctx);
     MaxCdcInitialScanShardsInFlight = appData->SchemeShardConfig.GetMaxCdcInitialScanShardsInFlight();
     MaxRestoreBuildIndexShardsInFlight = appData->SchemeShardConfig.GetMaxRestoreBuildIndexShardsInFlight();
-    MaxTTLShardsInFlight = appData->SchemeShardConfig.GetMaxTTLShardsInFlight();
+    ConfigureCondErase(appData->SchemeShardConfig, ctx);
 
     SendStatsIntervalSecondsDedicated = appData->StatisticsConfig.GetBaseStatsSendIntervalSecondsDedicated();
     SendStatsIntervalSecondsServerless = appData->StatisticsConfig.GetBaseStatsSendIntervalSecondsServerless();
@@ -5346,6 +5347,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
 
         // conditional erase
         HFuncTraced(TEvPrivate::TEvRunConditionalErase, Handle);
+        HFuncTraced(TEvPrivate::TEvFlushConditionalEraseBatch, Handle);
         HFuncTraced(TEvDataShard::TEvConditionalEraseRowsResponse, Handle);
 
         HFuncTraced(TEvPrivate::TEvServerlessStorageBilling, Handle);
@@ -7114,12 +7116,39 @@ void TSchemeShard::Handle(TEvPrivate::TEvRunConditionalErase::TPtr& ev, const TA
     Execute(CreateTxRunConditionalErase(ev), ctx);
 }
 
-void TSchemeShard::ScheduleServerlessStorageBilling(const TActorContext &ctx) {
-    ctx.Send(SelfId(), new TEvPrivate::TEvServerlessStorageBilling());
+bool TSchemeShard::ProcessPendingConditionalEraseResponseBatch(const TInstant& now, const TActorContext& ctx) {
+    const bool completeBySize = (PendingCondEraseResponses.size() >= CondEraseResponseBatchSize);
+    const auto batchAge = (now - PendingCondEraseResponsesStartTime);
+    const bool completeByTime = (batchAge >= CondEraseResponseBatchMaxTime);
+
+    if (PendingCondEraseResponses.size() > 0 && (completeBySize || completeByTime)) {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase flush pending response batch (by " << (completeBySize ? "size" : "time") << ")"
+            << ", batch size " << PendingCondEraseResponses.size() << "/" << CondEraseResponseBatchSize
+            << ", batch age " << batchAge << "/" << CondEraseResponseBatchMaxTime
+            << ", at schemeshard: " << TabletID()
+        );
+
+        Execute(CreateTxScheduleConditionalErase(std::move(PendingCondEraseResponses), PendingCondEraseResponsesStartTime), ctx);
+        PendingCondEraseResponses.clear();
+
+        return true;
+    }
+
+    return false;
 }
 
-void TSchemeShard::Handle(TEvPrivate::TEvServerlessStorageBilling::TPtr &, const TActorContext &ctx) {
-    Execute(CreateTxServerlessStorageBilling(), ctx);
+void TSchemeShard::Handle(TEvPrivate::TEvFlushConditionalEraseBatch::TPtr& ev, const TActorContext& ctx) {
+    if (PendingCondEraseResponsesStartTime > ev->Get()->BatchStartTime) {
+        // Current batch is a new one, old batch was already processed.
+        return;
+    }
+
+    LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Handle: TEvFlushConditionalEraseBatch"
+        << ", at schemeshard: " << TabletID());
+
+    // This ensures incomplete batches don't get stuck indefinitely
+    // The batch's Complete() will also trigger TTxRunConditionalErase for affected tables
+    ProcessPendingConditionalEraseResponseBatch(ctx.Now(), ctx);
 }
 
 void TSchemeShard::Handle(TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& ev, const TActorContext& ctx) {
@@ -7134,14 +7163,62 @@ void TSchemeShard::Handle(TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& e
         return;
     }
 
+    // ACCEPTED and PARTIAL are handled here, outside a local transaction, since
+    // neither causes state changes and TTL response processing is a performance bottleneck.
     if (record.GetStatus() == NKikimrTxDataShard::TEvConditionalEraseRowsResponse::ACCEPTED) {
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase accepted"
             << ": tabletId: " << tabletId
             << ", at schemeshard: " << TabletID());
         return;
     }
+    if (record.GetStatus() == NKikimrTxDataShard::TEvConditionalEraseRowsResponse::PARTIAL) {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase already running"
+            << ": tabletId: " << tabletId
+            << ", at schemeshard: " << TabletID());
+        return;
+    }
 
-    Execute(CreateTxScheduleConditionalErase(ev), ctx);
+    // Check if batching is enabled and batch size is configured
+    const bool batchingEnabled = AppData(ctx)->FeatureFlags.GetEnableConditionalEraseResponseBatching()
+        && CondEraseResponseBatchSize > 0;
+
+    const auto now = ctx.Now();
+
+    // Accumulate response for batch processing
+    if (PendingCondEraseResponses.empty()) {
+        PendingCondEraseResponsesStartTime = now;
+    }
+    PendingCondEraseResponses.push_back(ev);
+
+    if (batchingEnabled) {
+        if (!ProcessPendingConditionalEraseResponseBatch(now, ctx)) {
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase finished"
+                << ", tabletId: " << tabletId
+                << ", status: " << record.GetStatus()
+                << ", batch size " << PendingCondEraseResponses.size() << "/" << CondEraseResponseBatchSize
+                << ", batch age " << (now - PendingCondEraseResponsesStartTime) << "/" << CondEraseResponseBatchMaxTime
+                << ", enqueued"
+                << ", at schemeshard: " << TabletID()
+            );
+
+            // for the new batch schedule end of time event
+            if (PendingCondEraseResponsesStartTime == now) {
+                ctx.Schedule(CondEraseResponseBatchMaxTime, new TEvPrivate::TEvFlushConditionalEraseBatch(PendingCondEraseResponsesStartTime));
+            }
+        }
+    } else {
+        // Process response immediately
+        Execute(CreateTxScheduleConditionalErase(std::move(PendingCondEraseResponses), PendingCondEraseResponsesStartTime), ctx);
+        PendingCondEraseResponses.clear();
+    }
+}
+
+void TSchemeShard::ScheduleServerlessStorageBilling(const TActorContext &ctx) {
+    ctx.Send(SelfId(), new TEvPrivate::TEvServerlessStorageBilling());
+}
+
+void TSchemeShard::Handle(TEvPrivate::TEvServerlessStorageBilling::TPtr &, const TActorContext &ctx) {
+    Execute(CreateTxServerlessStorageBilling(), ctx);
 }
 
 void TSchemeShard::Handle(TEvTxAllocatorClient::TEvAllocateResult::TPtr& ev, const TActorContext& ctx) {
@@ -7822,7 +7899,7 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TAppConfig& appConfi
         ConfigureStatsOperations(schemeShardConfig, ctx);
         MaxCdcInitialScanShardsInFlight = schemeShardConfig.GetMaxCdcInitialScanShardsInFlight();
         MaxRestoreBuildIndexShardsInFlight = schemeShardConfig.GetMaxRestoreBuildIndexShardsInFlight();
-        MaxTTLShardsInFlight = schemeShardConfig.GetMaxTTLShardsInFlight();
+        ConfigureCondErase(schemeShardConfig, ctx);
     }
 
     if (appConfig.HasTableProfilesConfig()) {
@@ -8105,6 +8182,20 @@ void TSchemeShard::ConfigureExternalSources(
     LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
         "ExternalSources configured: HostnamePatterns# " << Join(", ", hostnamePatterns)
         << ", AvailableExternalDataSources# " << Join(", ", availableExternalDataSources));
+}
+
+void TSchemeShard::ConfigureCondErase(const NKikimrConfig::TSchemeShardConfig& config, const TActorContext &ctx) {
+    MaxTTLShardsInFlight = config.GetMaxTTLShardsInFlight();
+    CondEraseResponseBatchSize = config.GetCondEraseResponseBatchSize();
+    CondEraseResponseBatchMaxTime = TDuration::MilliSeconds(
+        std::max(ui32(1), std::min(ui32(1000), config.GetCondEraseResponseBatchMaxTimeMs()))
+    );
+
+    LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "ConditionalErase configured"
+        << ": ShardsInFlight (for table) " << MaxTTLShardsInFlight
+        << ", BatchSize " << CondEraseResponseBatchSize
+        << ", BatchMaxTime " << CondEraseResponseBatchMaxTime
+    );
 }
 
 void TSchemeShard::StartStopCompactionQueues() {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -33,6 +33,7 @@
 #include <ydb/core/protos/follower_group.pb.h>
 #include <ydb/core/protos/index_builder.pb.h>
 #include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/core/protos/yql_translation_settings.pb.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -52,6 +52,7 @@ namespace TEvPrivate {
         EvLoginFinalize,
         EvContinuousBackupCleanerResult,
         EvTestNotifySubdomainCleanup,
+        EvFlushConditionalEraseBatch,
         EvEnd
     };
 
@@ -90,6 +91,14 @@ namespace TEvPrivate {
     };
 
     struct TEvRunConditionalErase: public TEventLocal<TEvRunConditionalErase, EvRunConditionalErase> {
+    };
+
+    struct TEvFlushConditionalEraseBatch : public TEventLocal<TEvFlushConditionalEraseBatch, EvFlushConditionalEraseBatch> {
+        TInstant BatchStartTime;
+
+        explicit TEvFlushConditionalEraseBatch(const TInstant& batchStartTime)
+            : BatchStartTime(batchStartTime)
+        { }
     };
 
     struct TEvIndexBuildingMakeABill: public TEventLocal<TEvIndexBuildingMakeABill, EvIndexBuildBilling> {

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -636,6 +636,14 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
         app.SchemeShardConfig.SetStatsBatchTimeoutMs(0);
     }
 
+    app.FeatureFlags.SetEnableConditionalEraseResponseBatching(opts.EnableConditionalEraseResponseBatching_);
+    if (opts.CondEraseResponseBatchSize_) {
+        app.SchemeShardConfig.SetCondEraseResponseBatchSize(*opts.CondEraseResponseBatchSize_);
+    }
+    if (opts.CondEraseResponseBatchMaxTimeMs_) {
+        app.SchemeShardConfig.SetCondEraseResponseBatchMaxTimeMs(*opts.CondEraseResponseBatchMaxTimeMs_);
+    }
+
     // graph settings
     if (opts.GraphBackendType_) {
         app.GraphConfig.SetBackendType(opts.GraphBackendType_.value());

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -85,6 +85,9 @@ namespace NSchemeShardUT_Private {
         OPTION(bool, EnableAlterDatabase, false);
         OPTION(std::optional<bool>, EnableAccessToIndexImplTables, std::nullopt);
         OPTION(std::optional<bool>, EnableIndexMaterialization, std::nullopt);
+        OPTION(bool, EnableConditionalEraseResponseBatching, false);
+        OPTION(std::optional<ui32>, CondEraseResponseBatchSize, std::nullopt);
+        OPTION(std::optional<ui32>, CondEraseResponseBatchMaxTimeMs, std::nullopt);
 
         #undef OPTION
     };
@@ -222,6 +225,7 @@ namespace NSchemeShardUT_Private {
         void Prepare(const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone);
         void EnableTabletResolverScheduling(ui32 nodeIdx = 0);
         void Finalize();
+
     private:
         virtual TTestEnv* CreateTestEnv();
         // Make sure that user requests are not dropped

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/protos/counters_schemeshard.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/tablet_flat/util_fmt_cell.h>
 #include <ydb/core/testlib/actors/block_events.h>


### PR DESCRIPTION
Add batch processing for ttl responses. See #30629 for details.

Changes:
- Add size- and time- based batching for `TEvConditionalEraseRowsResponse`. `TTxScheduleConditionalErase` now processes batches instead of individual responses.
- Process `TEvConditionalEraseRowsResponse::PARTIAL` response early, without entering a local transaction.
- Also move TSchemeShardConfig from `config.proto` to separate `schemeshard_config.proto`.

Configuration:
- `feature_flags.enable_conditional_erase_response_batching` — enables batching
- `schemeshard_config.cond_erase_response_batch_size` — batch size limit
	- default: 100
	- zero disables batching
- `schemeshard_config.cond_erase_response_batch_max_time_ms` — max pending batch time
	- default: 100 ms
	- value clamped between 1-1000 ms

Follow-ups:
- tests need more work: tidy up and add reboot tests

Closes #30629.