### PR TITLE
[EDITED] mkql_computation_node_graph: disallow MultiHoppingCore caching

### DIFF
--- a/yql/essentials/minikql/computation/mkql_computation_node_graph.cpp
+++ b/yql/essentials/minikql/computation/mkql_computation_node_graph.cpp
@@ -482,7 +482,8 @@ private:
             name == "KqpWideReadTableRanges" ||
             name == "KqpBlockReadTableRanges" ||
             name == "KqpLookupTable" ||
-            name == "KqpReadTable"
+            name == "KqpReadTable" ||
+            name == "MultiHoppingCore"
         ) {
             PatternNodes->SuitableForCache = false;
         }


### PR DESCRIPTION
as it contains `&`reference to TDqTaskRunner (that's, of cause, fragile and should be eventually fixed) Triggers intermittent failures in contrib/ydb/tests/fq/streaming/test_watermarks.py commit_hash:26b7a37167ac6cd8fa9d84f0cfded8ece9f9e20d

(cherry picked from commit c5f9d4423c0821d6578c5f39f8448cede7019f69)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
