### PR TITLE
Add arbitrary deltas to cs scan stats

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_compute_events_stats.h
+++ b/ydb/core/kqp/compute_actor/kqp_compute_events_stats.h
@@ -16,7 +16,7 @@ struct TPerStepScanStatistics {
 
 struct TScanStatistics{
     TMap<ui32, TPerStepScanStatistics> PerStepStats;
-    TMap<TString, ui64> ArbitraryDeltaCounters;
+    TMap<TString, ui64> ExtraDeltaCounters;
 };
 
 }   // namespace NKikimr::NKqp

--- a/ydb/core/kqp/compute_actor/kqp_compute_events_stats.h
+++ b/ydb/core/kqp/compute_actor/kqp_compute_events_stats.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <util/datetime/base.h>
+#include <util/generic/map.h>
 namespace NKikimr::NKqp {
 TString FormatDurationAsMilliseconds(TDuration duration);
 
@@ -13,6 +14,9 @@ struct TPerStepScanStatistics {
     TString DebugString() const;
 };
 
-using TScanStatistics = TMap<ui32, TPerStepScanStatistics>;
+struct TScanStatistics{
+    TMap<ui32, TPerStepScanStatistics> PerStepStats;
+    TMap<TString, ui64> ArbitraryDeltaCounters;
+};
 
 }   // namespace NKikimr::NKqp

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
@@ -31,7 +31,7 @@ NKqp::TScanStatistics TColumnShardScan::GetScanStats() {
     NKqp::TScanStatistics stats;
     int index = 0;
     for(auto& v: timesPerStep) {
-        stats.emplace(index, std::move(v));
+        stats.PerStepStats.emplace(index, std::move(v));
         index++;
     }
     return stats;


### PR DESCRIPTION
хочется пробрасывать какие-то статистики по запросу, чтобы для конкретного запроса, например, можно было увидеть количество срабатываний skip index'a, или количество прочитанных блобов с диска, или что угодно.

Также не хочется каждый раз дергать сашу, поэтому - мапа, а не много разных полей

следующим шагом закину сюда счетчики(примерно вот эти https://github.com/ydb-platform/ydb/blob/56eaa08841e2c84a3671273e8688cd724cc80ab1/ydb/core/tx/columnshard/hooks/testing/ro_controller.h#L28-L30) чтобы смотреть на эффективность minmax индекса в рамках реализации #32910 
...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
