### PR TITLE
Made tests independent on sys views creation P.3

### DIFF
--- a/ydb/core/tx/schemeshard/ut_export_reboots_s3/ut_export_reboots_s3.cpp
+++ b/ydb/core/tx/schemeshard/ut_export_reboots_s3/ut_export_reboots_s3.cpp
@@ -791,7 +791,6 @@ Y_UNIT_TEST_SUITE(TExportToS3WithRebootsTests) {
         TPortManager portManager;
         const ui16 port = portManager.GetPort();
 
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         TS3Mock s3Mock({}, TS3Mock::TSettings(port));
         UNIT_ASSERT(s3Mock.Start());
 
@@ -815,8 +814,8 @@ Y_UNIT_TEST_SUITE(TExportToS3WithRebootsTests) {
                 TestGetExport(runtime, exportId, "/MyRoot");
                 TestRmDir(runtime, ++t.TxId, "/MyRoot", "DirA");
                 auto desc = DescribePath(runtime, "/MyRoot");
-                UNIT_ASSERT_EQUAL(desc.GetPathDescription().ChildrenSize(), 1);
-                UNIT_ASSERT_EQUAL(desc.GetPathDescription().GetChildren(0).GetName(), "Table");
+                UNIT_ASSERT_EQUAL(desc.GetPathDescription().ChildrenSize(), 2);
+                UNIT_ASSERT_EQUAL(desc.GetPathDescription().GetChildren(1).GetName(), "Table");
             }
         });
     }
@@ -825,7 +824,6 @@ Y_UNIT_TEST_SUITE(TExportToS3WithRebootsTests) {
         TPortManager portManager;
         const ui16 port = portManager.GetPort();
 
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         TS3Mock s3Mock({}, TS3Mock::TSettings(port));
         UNIT_ASSERT(s3Mock.Start());
 
@@ -849,9 +847,9 @@ Y_UNIT_TEST_SUITE(TExportToS3WithRebootsTests) {
                 TestGetExport(runtime, exportId, "/MyRoot");
                 TestRmDir(runtime, ++t.TxId, "/MyRoot", "DirA");
                 auto desc = DescribePath(runtime, "/MyRoot");
-                UNIT_ASSERT_EQUAL(desc.GetPathDescription().ChildrenSize(), 2);
-                const auto namesVector = {desc.GetPathDescription().GetChildren(0).GetName(),
-                                          desc.GetPathDescription().GetChildren(1).GetName()};
+                UNIT_ASSERT_EQUAL(desc.GetPathDescription().ChildrenSize(), 3);
+                const auto namesVector = {desc.GetPathDescription().GetChildren(1).GetName(),
+                                          desc.GetPathDescription().GetChildren(2).GetName()};
                 UNIT_ASSERT(IsIn(namesVector, "Table"));
                 UNIT_ASSERT(IsIn(namesVector, "export-1003"));
             }

--- a/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
@@ -15,10 +15,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     Y_UNIT_TEST_FLAG(CreateExtSubdomainWithHive, AlterDatabaseCreateHiveFirst) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
-            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
-            .EnableRealSystemViewPaths(false);
+            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            TLocalPathId subDomainPathId;
+            {
+                TInactiveZone inactive(activeZone);
+                subDomainPathId = GetNextLocalPathId(runtime, t.TxId);
+            }
 
             TestCreateExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
                 R"(Name: "USER_0")"
@@ -30,16 +34,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                    {NLs::PathExist,
                                     NLs::IsExternalSubDomain("USER_0"),
-                                    NLs::DomainKey(3, TTestTxConfig::SchemeShard),
+                                    NLs::DomainKey(subDomainPathId, TTestTxConfig::SchemeShard),
                                     NLs::DomainCoordinators({}),
                                     NLs::DomainMediators({}),
                                     NLs::DomainSchemeshard(0),
                                     NLs::DomainHive(0)
                                     });
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(2)});
-                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", 3));
-                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", 3));
+                                   {NLs::ChildrenCount(3)});
+                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subDomainPathId));
+                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subDomainPathId));
             }
 
             TestAlterExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
@@ -72,7 +76,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                    {NLs::PathExist,
                                     NLs::IsExternalSubDomain("USER_0"),
-                                    NLs::DomainKey(3, TTestTxConfig::SchemeShard),
+                                    NLs::DomainKey(subDomainPathId, TTestTxConfig::SchemeShard),
                                     NLs::ShardsInsideDomain(7),
                                     // internal knowledge of shard declaration sequence is used here
                                     NLs::DomainHive(TTestTxConfig::FakeHiveTablets),
@@ -85,7 +89,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, subdomainSchemeshard, "/MyRoot/USER_0"),
                                    {NLs::PathExist,
                                     NLs::IsSubDomain("MyRoot/USER_0"),
-                                    NLs::DomainKey(3, TTestTxConfig::SchemeShard),
+                                    NLs::DomainKey(subDomainPathId, TTestTxConfig::SchemeShard),
                                     NLs::ShardsInsideDomain(7),
                                     // internal knowledge of shard declaration sequence is used here
                                     NLs::DomainHive(TTestTxConfig::FakeHiveTablets),
@@ -94,7 +98,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                                     NLs::DomainMediators({subdomainHiveTablets+4, subdomainHiveTablets+5}),
                                    });
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(2)});
+                                   {NLs::ChildrenCount(3)});
             }
 
         });
@@ -103,15 +107,23 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     Y_UNIT_TEST_FLAGS(DropExtSubdomain, AlterDatabaseCreateHiveFirst, ExternalHive) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
-            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
-            .EnableRealSystemViewPaths(false);
+            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            ui64 expectedDomainPaths;
+            TLocalPathId expectedSubDomainPathId;
+            {
+                TInactiveZone inactive(activeZone);
+                auto initialDomainDesc = DescribePath(runtime, "/MyRoot");
+                expectedDomainPaths = initialDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
+                expectedSubDomainPathId = GetNextLocalPathId(runtime, t.TxId);
+            }
 
             TestCreateExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
                 R"(Name: "USER_0")"
             );
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            expectedDomainPaths += 1;
 
             TPathId subdomainPathId;
             {
@@ -128,10 +140,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 });
                 const auto& domainKey = describe.GetPathDescription().GetDomainDescription().GetDomainKey();
                 subdomainPathId = TPathId::FromDomainKey(domainKey);
-                UNIT_ASSERT_VALUES_EQUAL(subdomainPathId.LocalPathId, 3);
+                UNIT_ASSERT_VALUES_EQUAL(subdomainPathId.LocalPathId, expectedSubDomainPathId);
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
-                    NLs::ChildrenCount(2)
+                    NLs::ChildrenCount(3)
                 });
 
                 UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
@@ -188,6 +200,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
             // drop extsubdomain
             TestForceDropExtSubDomain(runtime, ++t.TxId, "/MyRoot", "USER_0");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            expectedDomainPaths -= 1;
 
             {
                 TInactiveZone inactive(activeZone);
@@ -217,7 +230,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
                     NLs::PathExist,
-                    NLs::PathsInsideDomain(1)  // infamous /MyRoot/DirA, created in TTestWithReboots::Prepare()
+                    NLs::PathsInsideDomain(expectedDomainPaths)  // infamous /MyRoot/DirA, created in TTestWithReboots::Prepare()
                 });
 
                 {
@@ -238,10 +251,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     Y_UNIT_TEST_FLAG(CreateExtSubdomainNoHive, AlterDatabaseCreateHiveFirst) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
-            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
-            .EnableRealSystemViewPaths(false);
+            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            TLocalPathId subDomainPathId;
+            {
+                TInactiveZone inactive(activeZone);
+                subDomainPathId = GetNextLocalPathId(runtime, t.TxId);
+            }
 
             TestCreateExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
                 R"(Name: "USER_0")"
@@ -253,16 +270,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                    {NLs::PathExist,
                                     NLs::IsExternalSubDomain("USER_0"),
-                                    NLs::DomainKey(3, TTestTxConfig::SchemeShard),
+                                    NLs::DomainKey(subDomainPathId, TTestTxConfig::SchemeShard),
                                     NLs::DomainCoordinators({}),
                                     NLs::DomainMediators({}),
                                     NLs::DomainSchemeshard(0),
                                     NLs::DomainHive(0)
                                     });
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(2)});
-                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", 3));
-                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", 3));
+                                   {NLs::ChildrenCount(3)});
+                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subDomainPathId));
+                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subDomainPathId));
             }
 
             TestAlterExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
@@ -288,7 +305,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                    {NLs::PathExist,
                                     NLs::IsExternalSubDomain("USER_0"),
-                                    NLs::DomainKey(3, TTestTxConfig::SchemeShard),
+                                    NLs::DomainKey(subDomainPathId, TTestTxConfig::SchemeShard),
                                     NLs::ShardsInsideDomain(6),
                                     // internal knowledge of shard declaration sequence is used here
                                     NLs::DomainSchemeshard(TTestTxConfig::FakeHiveTablets),
@@ -300,7 +317,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, TTestTxConfig::FakeHiveTablets, "/MyRoot/USER_0"),
                                    {NLs::PathExist,
                                     NLs::IsSubDomain("MyRoot/USER_0"),
-                                    NLs::DomainKey(3, TTestTxConfig::SchemeShard),
+                                    NLs::DomainKey(subDomainPathId, TTestTxConfig::SchemeShard),
                                     NLs::ShardsInsideDomain(6),
                                     // internal knowledge of shard declaration sequence is used here
                                     NLs::DomainSchemeshard(TTestTxConfig::FakeHiveTablets),
@@ -308,7 +325,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                                     NLs::DomainMediators({TTestTxConfig::FakeHiveTablets+4, TTestTxConfig::FakeHiveTablets+5}),
                                    });
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(2)});
+                                   {NLs::ChildrenCount(3)});
             }
 
         });
@@ -317,10 +334,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     Y_UNIT_TEST_FLAG(CreateForceDrop, AlterDatabaseCreateHiveFirst) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
-            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
-            .EnableRealSystemViewPaths(false);
+            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            TLocalPathId subDomainPathId;
+            {
+                TInactiveZone inactive(activeZone);
+                subDomainPathId = GetNextLocalPathId(runtime, t.TxId);
+            }
 
             AsyncCreateExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
                 R"(Name: "USER_0")"
@@ -334,9 +355,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                    {NLs::PathNotExist});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(1, NKikimrSchemeOp::EPathState::EPathStateNoChanges)});
-                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", 3));
-                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", 3));
+                                   {NLs::ChildrenCount(2, NKikimrSchemeOp::EPathState::EPathStateNoChanges)});
+                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subDomainPathId));
+                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subDomainPathId));
             }
         });
     }
@@ -344,12 +365,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     Y_UNIT_TEST_FLAGS(AlterForceDrop, AlterDatabaseCreateHiveFirst, ExternalHive) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
-            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
-            .EnableRealSystemViewPaths(false);
+            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            TLocalPathId subDomainPathId;
             {
                 TInactiveZone inactive(activeZone);
+                subDomainPathId = GetNextLocalPathId(runtime, t.TxId);
                 TestCreateExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
                     R"(Name: "USER_0")"
                 );
@@ -385,14 +407,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                    {NLs::PathNotExist});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(1, NKikimrSchemeOp::EPathState::EPathStateNoChanges)});
+                                   {NLs::ChildrenCount(2, NKikimrSchemeOp::EPathState::EPathStateNoChanges)});
                 t.TestEnv->TestWaitShardDeletion(runtime, {1, 2, 3, 4, 5, 6});
-                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", 3));
-                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", 3));
+                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subDomainPathId));
+                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subDomainPathId));
             }
         });
     }
-
 
     Y_UNIT_TEST_FLAGS(SchemeLimits, AlterDatabaseCreateHiveFirst, ExternalHive) {
         TTestWithReboots t;

--- a/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
@@ -19,8 +19,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
             .EnableLocalDBBtreeIndex(enableLocalDBBtreeIndex)
-            .EnablePersistentPartitionStats(enablePersistentPartitionStats)
-            .EnableRealSystemViewPaths(false);
+            .EnablePersistentPartitionStats(enablePersistentPartitionStats);
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;
@@ -53,7 +52,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
 
                 pathVersion = TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                    {NLs::PathExist,
-                                    NLs::ChildrenCount(2),
+                                    NLs::ChildrenCount(3),
                                     NLs::ShardsInsideDomain(1)});
 
                 auto tableVersion = TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"),
@@ -87,7 +86,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
             {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(2),
+                                   {NLs::ChildrenCount(3),
                                     NLs::ShardsInsideDomain(1)});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/TableMove"),
                                    {NLs::PathVersionEqual(5),
@@ -234,7 +233,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
 
     Y_UNIT_TEST(Replace) {
         TTestWithReboots t(true);
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;
             {
@@ -282,7 +280,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
             {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(2),
+                                   {NLs::ChildrenCount(3),
                                     NLs::ShardsInsideDomainOneOf({1,2,3,4})});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"),
                                    {NLs::PathVersionEqual(5),
@@ -295,7 +293,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
 
     Y_UNIT_TEST(Chain) {
         TTestWithReboots t(true);
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;
             {
@@ -344,7 +341,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
                 TInactiveZone inactive(activeZone);
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(3)});
+                                   {NLs::ChildrenCount(4)});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/backup"),
                                    {NLs::PathVersionEqual(5),
                                     NLs::IsTable});
@@ -359,10 +356,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
 
     Y_UNIT_TEST(AlterAfter) {
         TTestWithReboots t;
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            ui64 expectedDomainPaths;
             {
                 TInactiveZone inactive(activeZone);
+                auto initialDomainDesc = DescribePath(runtime, "/MyRoot");
+                expectedDomainPaths = initialDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
+
                 TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
                                 Name: "Table"
                                 Columns { Name: "key"   Type: "Uint64" }
@@ -370,6 +370,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
                                 KeyColumnNames: ["key"]
                                 )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                expectedDomainPaths += 1;
 
                 // Write some data to the user table
                 auto fnWriteRow = [&] (ui64 tabletId) {
@@ -390,7 +392,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                    {NLs::PathExist,
-                                    NLs::ChildrenCount(2),
+                                    NLs::ChildrenCount(3),
                                     NLs::ShardsInsideDomain(1)});
 
                 TestMoveTable(runtime, ++t.TxId, "/MyRoot/Table", "/MyRoot/TableMove");
@@ -405,13 +407,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
             {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(2),
+                                   {NLs::ChildrenCount(3),
                                     NLs::ShardsInsideDomain(1)});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/TableMove"),
                                    {NLs::IsTable,
                                     NLs::PathVersionEqual(6),
                                     NLs::CheckColumns("TableMove", {"key", "value", "add"}, {}, {"key"}),
-                                    NLs::PathsInsideDomain(2),
+                                    NLs::PathsInsideDomain(expectedDomainPaths),
                                     NLs::ShardsInsideDomain(1)});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"),
                                    {NLs::PathNotExist});

--- a/ydb/core/tx/schemeshard/ut_reboots/ut_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_reboots/ut_reboots.cpp
@@ -473,7 +473,6 @@ Y_UNIT_TEST_SUITE(TConsistentOpsWithReboots) {
 
     Y_UNIT_TEST(CreateIndexedTableAndForceDrop) {
         TTestWithReboots t;
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion dirAVersion;
 
@@ -503,7 +502,7 @@ Y_UNIT_TEST_SUITE(TConsistentOpsWithReboots) {
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                    {NLs::Finished,
-                                    NLs::ChildrenCount(2)});
+                                    NLs::ChildrenCount(3)});
 
                 dirAVersion = TestDescribeResult(DescribePath(runtime, "/MyRoot/DirB"),
                                                  {NLs::Finished,
@@ -519,14 +518,13 @@ Y_UNIT_TEST_SUITE(TConsistentOpsWithReboots) {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                    {NLs::Finished,
-                                    NLs::ChildrenCount(1)});
+                                    NLs::ChildrenCount(2)});
             }
         });
     }
 
     Y_UNIT_TEST(CreateIndexedTableAndForceDropSimultaneously) {
         TTestWithReboots t;
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion dirAVersion;
             {
@@ -561,14 +559,13 @@ Y_UNIT_TEST_SUITE(TConsistentOpsWithReboots) {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                    {NLs::Finished,
-                                    NLs::ChildrenCount(0)});
+                                    NLs::ChildrenCount(1)});
             }
         });
     }
 
     Y_UNIT_TEST(DropIndexedTableAndForceDropSimultaneously) {
         TTestWithReboots t;
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion dirAVersion;
 
@@ -618,8 +615,8 @@ Y_UNIT_TEST_SUITE(TConsistentOpsWithReboots) {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                    {NLs::Finished,
-                                    NLs::PathVersionOneOf({10, 11}),
-                                    NLs::ChildrenCount(1)});
+                                    NLs::PathVersionOneOf({13, 14}),
+                                    NLs::ChildrenCount(2)});
             }
         });
     }


### PR DESCRIPTION
Many SchemeShard tests rely on number of created objects so after changing the number of initial paths tests become failed.
Have to fix it, getting a initial paths count during tests.
