### PR TITLE
Fix dstool group take-snapshot cmd

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_group_take_snapshot.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_group_take_snapshot.py
@@ -37,7 +37,8 @@ def do(args):
             if group.base.GroupId in args.group_ids:
                 for index, vslot in enumerate(group.vslots_of_group):
                     id_ = vslot.base.VSlotId
-                    yield group.base.GroupId, index, vslot.pdisk.node.node_mon_endpoint, id_.PDiskId, id_.VSlotId
+                    if vslot.pdisk.node.node_mon_endpoint is not None:
+                        yield group.base.GroupId, index, vslot.pdisk.node.node_mon_endpoint, id_.PDiskId, id_.VSlotId
 
     global output_file
     output_file = args.output


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix dstool group take-snapshot cmd

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This makes mentioned command working correctly when one of VDisks is missing.
