### PR TITLE
Remove prefix columns from ReadMain if not used in SELECT list (fix #33674)

### DIFF
--- a/ydb/core/kqp/ut/indexes/kqp_indexes_prefixed_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_prefixed_vector_ut.cpp
@@ -104,9 +104,25 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
         std::string metric = std::format("Knn::{}({}, {})", function, left, right);
         // no metric in result
         {
-            // TODO(vitaliff): Exclude index-covered WHERE fields from KqpReadTableRanges.
-            // Currently even if we SELECT only pk, emb, data WHERE user=xxx we also get `user`
-            // in SELECT columns and thus it's required to add it to covered columns.
+            // We don't select user column so it's not required to be in COVER()
+            const TString plainQuery(Q1_(std::format(R"({}
+                SELECT pk, emb, data FROM `/Root/TestTable`
+                WHERE user = $user
+                ORDER BY {} {}
+                LIMIT 3;
+            )", init, metric, direction)));
+            const TString indexQuery(Q1_(std::format(R"(
+                pragma ydb.KMeansTreeSearchTopSize = "3";
+                {}
+                SELECT pk, emb, data FROM `/Root/TestTable` VIEW index
+                WHERE user = $user
+                ORDER BY {} {}
+                LIMIT 3;
+            )", init, metric, direction)));
+            DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery, flags, count);
+        }
+        if (flags & F_COVERING) {
+            // check the same but with user column in select to check that it's not mistakenly removed
             const TString plainQuery(Q1_(std::format(R"({}
                 SELECT * FROM `/Root/TestTable`
                 WHERE user = $user
@@ -121,19 +137,20 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
                 ORDER BY {} {}
                 LIMIT 3;
             )", init, metric, direction)));
-            DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery, flags, count);
+            // select * will read from the main table
+            DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery, flags & ~F_COVERING, count);
         }
         // metric in result
         {
             const TString plainQuery(Q1_(std::format(R"({}
-                SELECT {}, `/Root/TestTable`.* FROM `/Root/TestTable`
+                SELECT {}, pk, emb, data FROM `/Root/TestTable`
                 WHERE user = $user
                 ORDER BY {} {}
                 LIMIT 3;
             )", init, metric, metric, direction)));
             const TString indexQuery(Q1_(std::format(R"({}
                 pragma ydb.KMeansTreeSearchTopSize = "2";
-                SELECT {}, `/Root/TestTable`.* FROM `/Root/TestTable` VIEW index
+                SELECT {}, pk, emb, data FROM `/Root/TestTable` VIEW index
                 WHERE user = $user
                 ORDER BY {} {}
                 LIMIT 3;
@@ -144,7 +161,7 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
         // TODO(mbkkt) fix this behavior too
         if constexpr (false) {
             const TString plainQuery(Q1_(std::format(R"({}
-                SELECT {} AS m, `/Root/TestTable`.* FROM `/Root/TestTable`
+                SELECT {} AS m, pk, emb, data FROM `/Root/TestTable`
                 WHERE user = $user
                 ORDER BY m {}
                 LIMIT 3;
@@ -152,7 +169,7 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
             const TString indexQuery(Q1_(std::format(R"(
                 pragma ydb.KMeansTreeSearchTopSize = "1";
                 {}
-                SELECT {} AS m, `/Root/TestTable`.* FROM `/Root/TestTable` VIEW index
+                SELECT {} AS m, pk, emb, data FROM `/Root/TestTable` VIEW index
                 WHERE user = $user
                 ORDER BY m {}
                 LIMIT 3;
@@ -255,7 +272,7 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
                 kmeans.Levels = 2;
                 std::vector<std::string> dataColumns;
                 if (flags & F_COVERING) {
-                    dataColumns = {"user", "emb", "data"};
+                    dataColumns = {"emb", "data"};
                 }
                 tableBuilder.AddVectorKMeansTreeIndex("index", {"user", "emb"}, dataColumns, kmeans);
             }
@@ -320,7 +337,7 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
     void DoCreatePrefixedVectorIndex(TSession & session, int levels, int flags = 0) {
         const char* cover = "";
         if (flags & F_COVERING) {
-            cover = (flags & F_SUFFIX_PK) ? " COVER (emb, data)" : " COVER (user, emb, data)";
+            cover = " COVER (emb, data)";
         }
 
         const TString createIndex(Q_(Sprintf(R"(
@@ -373,12 +390,7 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
             std::vector<std::string> indexKeyColumns{"user", "emb"};
             UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
             if (flags & F_COVERING) {
-                std::vector<std::string> indexDataColumns;
-                if (flags & F_SUFFIX_PK) {
-                    indexDataColumns = {"emb", "data"};
-                } else {
-                    indexDataColumns = {"user", "emb", "data"};
-                }
+                std::vector<std::string> indexDataColumns{"emb", "data"};
                 UNIT_ASSERT_EQUAL(indexes[0].GetDataColumns(), indexDataColumns);
             }
             const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Упрощённая версия прошлого ПР. А тот отдельно будет.

Тут только фикс того, что в префиксных запросах префикс запрашивался всегда, даже когда не нужен.