### PR TITLE
EXT-1189: [ydb-dstool] parse pdisk move ids with colon

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_pdisk_move.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pdisk_move.py
@@ -20,11 +20,11 @@ def create_request(args, source_pdisk, target_pdisk):
     request = common.create_bsc_request(args)
     cmd = request.Command.add().MovePDisk
 
-    cmd.SourcePDisk.TargetPDiskId.NodeId = int(source_pdisk.split(';')[0])
-    cmd.SourcePDisk.TargetPDiskId.PDiskId = int(source_pdisk.split(';')[1])
+    cmd.SourcePDisk.TargetPDiskId.NodeId = int(source_pdisk.split(':')[0])
+    cmd.SourcePDisk.TargetPDiskId.PDiskId = int(source_pdisk.split(':')[1])
 
-    cmd.DestinationPDisk.TargetPDiskId.NodeId = int(target_pdisk.split(';')[0])
-    cmd.DestinationPDisk.TargetPDiskId.PDiskId = int(target_pdisk.split(';')[1])
+    cmd.DestinationPDisk.TargetPDiskId.NodeId = int(target_pdisk.split(':')[0])
+    cmd.DestinationPDisk.TargetPDiskId.PDiskId = int(target_pdisk.split(':')[1])
 
     return request
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fix bug - semicolon was parsed instead of colon

### Changelog category <!-- remove all except one -->

* Not for changelog 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
