### PR TITLE
Threads for Configurator and Describer

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -348,6 +348,24 @@ void TTopicOperationsScenario::StartConfiguratorThread(std::vector<std::future<v
     threads.push_back(std::async([params = std::move(params)]() { TTopicWorkloadWriterWorker::RetryableConfiguratorLoop(params); }));
 }
 
+void TTopicOperationsScenario::StartDescriberThread(std::vector<std::future<void>>& threads,
+                                                    const TString& database)
+{
+    if (!NeedDescribeTopic) {
+        return;
+    }
+    TTopicWorkloadDescriberParams params{
+        .TotalSec = TotalSec.Seconds(),
+        .WarmupSec = WarmupSec.Seconds(),
+        .Driver = *Driver,
+        .Log = Log,
+        .ErrorFlag = ErrorFlag,
+        .Database = database,
+        .TopicName = TopicName,
+    };
+    threads.push_back(std::async([params = std::move(params)]() { TTopicWorkloadWriterWorker::RetryableDescriberLoop(params); }));
+}
+
 void TTopicOperationsScenario::JoinThreads(const std::vector<std::future<void>>& threads)
 {
     for (auto& future : threads) {

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -5,6 +5,7 @@
 #include <ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h>
 #include <ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_keyed_writer.h>
 #include <ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h>
+#include <ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.h>
 #include <ydb/public/lib/ydb_cli/commands/ydb_common.h>
 #include <ydb/public/lib/ydb_cli/common/log.h>
 
@@ -326,6 +327,25 @@ void TTopicOperationsScenario::StartProducerThreads(std::vector<std::future<void
     while (*count != ProducerThreadCount) {
         Sleep(TDuration::MilliSeconds(10));
     }
+}
+
+void TTopicOperationsScenario::StartConfiguratorThread(std::vector<std::future<void>>& threads,
+                                                       const TString& database)
+{
+    if (!ConfigConsumerCount) {
+        return;
+    }
+    TTopicWorkloadConfiguratorParams params{
+        .TotalSec = TotalSec.Seconds(),
+        .WarmupSec = WarmupSec.Seconds(),
+        .Driver = *Driver,
+        .Log = Log,
+        .ErrorFlag = ErrorFlag,
+        .Database = database,
+        .TopicName = TopicName,
+        .ConsumerCount = ConfigConsumerCount
+    };
+    threads.push_back(std::async([params = std::move(params)]() { TTopicWorkloadWriterWorker::RetryableConfiguratorLoop(params); }));
 }
 
 void TTopicOperationsScenario::JoinThreads(const std::vector<std::future<void>>& threads)

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -335,6 +335,7 @@ void TTopicOperationsScenario::StartConfiguratorThread(std::vector<std::future<v
     if (!ConfigConsumerCount) {
         return;
     }
+
     TTopicWorkloadConfiguratorParams params{
         .TotalSec = TotalSec.Seconds(),
         .WarmupSec = WarmupSec.Seconds(),
@@ -351,9 +352,10 @@ void TTopicOperationsScenario::StartConfiguratorThread(std::vector<std::future<v
 void TTopicOperationsScenario::StartDescriberThread(std::vector<std::future<void>>& threads,
                                                     const TString& database)
 {
-    if (!NeedDescribeTopic) {
+    if (!NeedDescribeTopic && DescribeConsumerName.empty()) {
         return;
     }
+
     TTopicWorkloadDescriberParams params{
         .TotalSec = TotalSec.Seconds(),
         .WarmupSec = WarmupSec.Seconds(),
@@ -362,6 +364,9 @@ void TTopicOperationsScenario::StartDescriberThread(std::vector<std::future<void
         .ErrorFlag = ErrorFlag,
         .Database = database,
         .TopicName = TopicName,
+        .ConsumerName = DescribeConsumerName,
+        .NeedDescribeTopic = NeedDescribeTopic,
+        .NeedDescribeConsumer = !DescribeConsumerName.empty()
     };
     threads.push_back(std::async([params = std::move(params)]() { TTopicWorkloadWriterWorker::RetryableDescriberLoop(params); }));
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -91,6 +91,7 @@ public:
     size_t ProducerKeysCount = 0;
     bool KeyedWrites = false;
     size_t ConfigConsumerCount = 0;
+    bool NeedDescribeTopic = false;
 
 protected:
     void CreateTopic(const TString& database,
@@ -120,6 +121,8 @@ protected:
                               const TString& database);
     void StartConfiguratorThread(std::vector<std::future<void>>& threads,
                                  const TString& database);
+    void StartDescriberThread(std::vector<std::future<void>>& threads,
+                              const TString& database);
     void JoinThreads(const std::vector<std::future<void>>& threads);
 
     bool AnyErrors() const;

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -92,6 +92,7 @@ public:
     bool KeyedWrites = false;
     size_t ConfigConsumerCount = 0;
     bool NeedDescribeTopic = false;
+    TString DescribeConsumerName;
 
 protected:
     void CreateTopic(const TString& database,

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -90,6 +90,7 @@ public:
     std::optional<size_t> ProducerMaxMemoryUsageBytes;
     size_t ProducerKeysCount = 0;
     bool KeyedWrites = false;
+    size_t ConfigConsumerCount = 0;
 
 protected:
     void CreateTopic(const TString& database,
@@ -117,6 +118,8 @@ protected:
                               ui32 partitionSeed,
                               const std::vector<TString>& generatedMessages,
                               const TString& database);
+    void StartConfiguratorThread(std::vector<std::future<void>>& threads,
+                                 const TString& database);
     void JoinThreads(const std::vector<std::future<void>>& threads);
 
     bool AnyErrors() const;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.cpp
@@ -1,0 +1,65 @@
+#include "topic_workload_configurator.h"
+#include "topic_workload_defines.h"
+
+using namespace NYdb::NConsoleClient;
+
+TTopicWorkloadConfiguratorWorker::TTopicWorkloadConfiguratorWorker(const TTopicWorkloadConfiguratorParams& params)
+    : Params(params)
+{
+}
+
+void TTopicWorkloadConfiguratorWorker::Process(TInstant endTime)
+{
+    Sleep(TDuration::Seconds(Params.WarmupSec));
+
+    NYdb::NTopic::TTopicClient client(Params.Driver);
+
+    while (!*Params.ErrorFlag) {
+        auto now = Now();
+        if (now > endTime) {
+            break;
+        }
+
+        AddConsumers(client);
+        DropConsumers(client);
+    }
+}
+
+TString TTopicWorkloadConfiguratorWorker::GetConsumerName(size_t index)
+{
+    return TStringBuilder() << "test-consumer-" << index;
+}
+
+void TTopicWorkloadConfiguratorWorker::AddConsumers(NYdb::NTopic::TTopicClient& client) const
+{
+    NYdb::NTopic::TAlterTopicSettings settings;
+
+    for (size_t j = 0; j < Params.ConsumerCount; ++j) {
+        settings.BeginAddConsumer(GetConsumerName(j));
+    }
+
+    AlterTopic(client, settings);
+
+    WRITE_LOG(Params.Log, ELogPriority::TLOG_DEBUG, TStringBuilder()
+              << Params.ConsumerCount << " consumers have been added to the topic " << Params.TopicName);
+}
+
+void TTopicWorkloadConfiguratorWorker::DropConsumers(NYdb::NTopic::TTopicClient& client) const
+{
+    NYdb::NTopic::TAlterTopicSettings settings;
+
+    for (size_t j = 0; j < Params.ConsumerCount; ++j) {
+        settings.DropConsumers_.push_back(GetConsumerName(j));
+    }
+
+    AlterTopic(client, settings);
+
+    WRITE_LOG(Params.Log, ELogPriority::TLOG_DEBUG, TStringBuilder()
+              << Params.ConsumerCount << " consumers were deleted from the topic " << Params.TopicName);
+}
+
+void TTopicWorkloadConfiguratorWorker::AlterTopic(NYdb::NTopic::TTopicClient& client,
+                                                  const NYdb::NTopic::TAlterTopicSettings& settings) const
+{
+    client.AlterTopic(Params.TopicName, settings).GetValueSync();
+}

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.cpp
@@ -22,6 +22,8 @@ void TTopicWorkloadConfiguratorWorker::Process(TInstant endTime)
 
         AddConsumers(client);
         DropConsumers(client);
+
+        Sleep(TDuration::Seconds(3));
     }
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.cpp
@@ -63,5 +63,10 @@ void TTopicWorkloadConfiguratorWorker::DropConsumers(NYdb::NTopic::TTopicClient&
 void TTopicWorkloadConfiguratorWorker::AlterTopic(NYdb::NTopic::TTopicClient& client,
                                                   const NYdb::NTopic::TAlterTopicSettings& settings) const
 {
-    client.AlterTopic(Params.TopicName, settings).GetValueSync();
+    auto result = client.AlterTopic(Params.TopicName, settings).GetValueSync();
+    if (!result.IsSuccess()) {
+        WRITE_LOG(Params.Log, ELogPriority::TLOG_ERR, TStringBuilder()
+                  << "Failed to alter topic " << Params.TopicName
+                  << ": " << result.GetIssues().ToOneLineString());
+    }
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.cpp
@@ -51,7 +51,7 @@ void TTopicWorkloadConfiguratorWorker::DropConsumers(NYdb::NTopic::TTopicClient&
     NYdb::NTopic::TAlterTopicSettings settings;
 
     for (size_t j = 0; j < Params.ConsumerCount; ++j) {
-        settings.DropConsumers_.push_back(GetConsumerName(j));
+        settings.AppendDropConsumers(GetConsumerName(j));
     }
 
     AlterTopic(client, settings);
@@ -63,5 +63,10 @@ void TTopicWorkloadConfiguratorWorker::DropConsumers(NYdb::NTopic::TTopicClient&
 void TTopicWorkloadConfiguratorWorker::AlterTopic(NYdb::NTopic::TTopicClient& client,
                                                   const NYdb::NTopic::TAlterTopicSettings& settings) const
 {
-    client.AlterTopic(Params.TopicName, settings).GetValueSync();
+    auto result = client.AlterTopic(Params.TopicName, settings).GetValueSync();
+    if (!result.IsSuccess()) {
+        WRITE_LOG(Params.Log, ELogPriority::TLOG_ERR, TStringBuilder()
+                  << "Failed to alter topic " << Params.TopicName
+                  << ": " << result.GetIssues().ToOneLineString());
+    }
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_configurator.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+
+#include <library/cpp/logger/log.h>
+#include <util/generic/string.h>
+
+#include <atomic>
+#include <memory>
+
+#include <cstddef>
+
+namespace NYdb::NConsoleClient {
+
+struct TTopicWorkloadConfiguratorParams {
+    size_t TotalSec;
+    size_t WarmupSec;
+    const NYdb::TDriver& Driver;
+    std::shared_ptr<TLog> Log;
+    std::shared_ptr<std::atomic<bool>> ErrorFlag;
+    TString Database;
+    TString TopicName;
+    size_t ConsumerCount = 0;
+};
+
+class TTopicWorkloadConfiguratorWorker {
+public:
+    explicit TTopicWorkloadConfiguratorWorker(const TTopicWorkloadConfiguratorParams& params);
+
+    void Process(TInstant endTime);
+
+private:
+    void AddConsumers(NYdb::NTopic::TTopicClient& client) const;
+    void DropConsumers(NYdb::NTopic::TTopicClient& client) const;
+
+    void AlterTopic(NYdb::NTopic::TTopicClient& client,
+                    const NYdb::NTopic::TAlterTopicSettings& settings) const;
+
+    static TString GetConsumerName(size_t index);
+
+    TTopicWorkloadConfiguratorParams Params;
+};
+
+}

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_describe.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_describe.cpp
@@ -1,7 +1,5 @@
 #include "topic_workload_describe.h"
-
 #include "topic_workload_defines.h"
-
 
 using namespace NYdb::NConsoleClient;
 
@@ -34,4 +32,25 @@ NYdb::NTopic::TTopicDescription TCommandWorkloadTopicDescribe::DescribeTopic(con
     }
 
     return description;
+}
+
+TTopicWorkloadDescriberWorker::TTopicWorkloadDescriberWorker(const TTopicWorkloadDescriberParams& params)
+    : Params(params)
+{
+}
+
+void TTopicWorkloadDescriberWorker::Process(TInstant endTime)
+{
+    Sleep(TDuration::Seconds(Params.WarmupSec));
+
+    while (!*Params.ErrorFlag) {
+        auto now = Now();
+        if (now > endTime) {
+            break;
+        }
+
+        TCommandWorkloadTopicDescribe::DescribeTopic(Params.Database, Params.TopicName, Params.Driver);
+
+        Sleep(TDuration::Seconds(3));
+    }
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_describe.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_describe.cpp
@@ -19,7 +19,7 @@ NYdb::NTopic::TConsumerDescription TCommandWorkloadTopicDescribe::DescribeConsum
     TString fullTopicName = GenerateFullTopicName(database, topicName);
     auto result = topicClient.DescribeConsumer(fullTopicName, consumerName, {}).GetValueSync();
 
-    if (!result.IsSuccess() || result.GetIssues()) {
+    if (!result.IsSuccess()) {
         throw yexception() << "Error describe consumer '" << consumerName << "' for topic '" << fullTopicName << "'";
     }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_describe.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_describe.h
@@ -18,6 +18,7 @@ namespace NYdb::NConsoleClient {
 class TCommandWorkloadTopicDescribe {
 public:
     static TString GenerateConsumerName(const TString& consumerPrefix, ui32 consumerIdx);
+    static NTopic::TConsumerDescription DescribeConsumer(const TString& database, const TString& topicName, const TString& consumerName, const NYdb::TDriver& driver);
     static TString GenerateFullTopicName(const TString& database, const TString& topicName);
     static NTopic::TTopicDescription DescribeTopic(const TString& database, const TString& topicName, const NYdb::TDriver& driver);
 };
@@ -30,6 +31,9 @@ struct TTopicWorkloadDescriberParams {
     std::shared_ptr<std::atomic<bool>> ErrorFlag;
     TString Database;
     TString TopicName;
+    TString ConsumerName;
+    bool NeedDescribeTopic = false;
+    bool NeedDescribeConsumer = false;
 };
 
 class TTopicWorkloadDescriberWorker {

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_describe.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_describe.h
@@ -1,17 +1,45 @@
 #pragma once
 
-#include <util/system/types.h>
-#include <util/string/type.h>
-
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 
-namespace NYdb {
-    namespace NConsoleClient {
-        class TCommandWorkloadTopicDescribe {
-        public:
-            static TString GenerateConsumerName(const TString& consumerPrefix, ui32 consumerIdx);
-            static TString GenerateFullTopicName(const TString& database, const TString& topicName);
-            static NTopic::TTopicDescription DescribeTopic(const TString& database, const TString& topicName, const NYdb::TDriver& driver);
-        };
-    }
+#include <library/cpp/logger/log.h>
+#include <util/datetime/base.h>
+#include <util/generic/string.h>
+#include <util/system/types.h>
+
+#include <atomic>
+#include <memory>
+
+#include <cstddef>
+
+namespace NYdb::NConsoleClient {
+
+class TCommandWorkloadTopicDescribe {
+public:
+    static TString GenerateConsumerName(const TString& consumerPrefix, ui32 consumerIdx);
+    static TString GenerateFullTopicName(const TString& database, const TString& topicName);
+    static NTopic::TTopicDescription DescribeTopic(const TString& database, const TString& topicName, const NYdb::TDriver& driver);
+};
+
+struct TTopicWorkloadDescriberParams {
+    size_t TotalSec;
+    size_t WarmupSec;
+    const NYdb::TDriver& Driver;
+    std::shared_ptr<TLog> Log;
+    std::shared_ptr<std::atomic<bool>> ErrorFlag;
+    TString Database;
+    TString TopicName;
+};
+
+class TTopicWorkloadDescriberWorker {
+public:
+    explicit TTopicWorkloadDescriberWorker(const TTopicWorkloadDescriberParams& params);
+
+    void Process(TInstant endTime);
+
+private:
+    TTopicWorkloadDescriberParams Params;
+};
+
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -117,6 +117,7 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .DefaultValue(0)
         .Hidden()
         .StoreResult(&Scenario.ProducerKeysCount);
+
     config.Opts->AddLongOption("configure-consumers", "The number of consumers to change the topic configuration. "
                                                       "If the value is greater than 0, the program will continuously "
                                                       "change the topic configuration.")
@@ -124,11 +125,15 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .Hidden()
         .DefaultValue(0)
         .StoreResult(&Scenario.ConfigConsumerCount);
-    config.Opts->AddLongOption("describe-topic", "The program constantly calls the DescripeTopic method")
+    config.Opts->AddLongOption("describe-topic", "The program constantly calls the DescribeTopic method")
         .Optional()
         .Hidden()
         .DefaultValue(false)
         .StoreTrue(&Scenario.NeedDescribeTopic);
+    config.Opts->AddLongOption("describe-consumer", "The program constantly calls the DescribeConsumer method")
+        .Optional()
+        .Hidden()
+        .StoreResult(&Scenario.DescribeConsumerName);
 
     config.IsNetworkIntensive = true;
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -117,6 +117,14 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .DefaultValue(0)
         .Hidden()
         .StoreResult(&Scenario.ProducerKeysCount);
+    config.Opts->AddLongOption("configure-consumers", "The number of consumers to change the topic configuration. "
+                                                      "If the value is greater than 0, the program will continuously "
+                                                      "change the topic configuration.")
+        .Optional()
+        .Hidden()
+        .DefaultValue(0)
+        .StoreResult(&Scenario.ConfigConsumerCount);
+
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -124,6 +124,11 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .Hidden()
         .DefaultValue(0)
         .StoreResult(&Scenario.ConfigConsumerCount);
+    config.Opts->AddLongOption("describe-topic", "The program constantly calls the DescripeTopic method")
+        .Optional()
+        .Hidden()
+        .DefaultValue(false)
+        .StoreTrue(&Scenario.NeedDescribeTopic);
 
     config.IsNetworkIntensive = true;
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -1,6 +1,7 @@
 #include "topic_workload_writer.h"
 #include "topic_workload_writer_producer.h"
 #include "topic_workload_writer_worker_common.h"
+#include "topic_workload_configurator.h"
 
 #include <util/generic/overloaded.h>
 #include <util/generic/guid.h>
@@ -211,6 +212,39 @@ void TTopicWorkloadWriterWorker::WriterLoop(const TTopicWorkloadWriterParams& pa
     }
 
     WRITE_LOG(writer.Params.Log, ELogPriority::TLOG_INFO, TStringBuilder() << "Writer finished " << Now().ToStringUpToSeconds());
+}
+
+void TTopicWorkloadWriterWorker::RetryableConfiguratorLoop(const TTopicWorkloadConfiguratorParams& params)
+{
+    auto errorFlag = params.ErrorFlag;
+
+    const TInstant endTime = Now() + TDuration::Seconds(params.TotalSec + 3);
+
+    while (!*errorFlag && Now() < endTime) {
+        try {
+            ConfiguratorLoop(params, endTime);
+        } catch (const yexception& ex) {
+            WRITE_LOG(params.Log, ELogPriority::TLOG_WARNING, TStringBuilder() << ex);
+        }
+    }
+}
+
+void TTopicWorkloadWriterWorker::ConfiguratorLoop(const TTopicWorkloadConfiguratorParams& params, TInstant endTime)
+{
+    WRITE_LOG(params.Log, ELogPriority::TLOG_INFO, TStringBuilder() << "Configurator started " << Now().ToStringUpToSeconds());
+
+    try {
+        TTopicWorkloadConfiguratorWorker configurator(params);
+        configurator.Process(endTime);
+    } catch (const std::runtime_error& re) {
+        WRITE_LOG(params.Log, ELogPriority::TLOG_ERR, TStringBuilder()
+            << "Configurator failed with error: " << re.what());
+    } catch (...) {
+        WRITE_LOG(params.Log, ELogPriority::TLOG_ERR, TStringBuilder()
+            << "Configurator caught unknown exception: " << CurrentExceptionMessage());
+    }
+
+    WRITE_LOG(params.Log, ELogPriority::TLOG_INFO, TStringBuilder() << "Configurator finished " << Now().ToStringUpToSeconds());
 }
 
 void TTopicWorkloadWriterWorker::TryCommitTx(TInstant& commitTime)

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -44,13 +44,21 @@ namespace NYdb {
             std::optional<size_t> MaxMemoryUsageBytes = 15_MB;
         };
 
+        struct TTopicWorkloadConfiguratorParams;
+
         class TTopicWorkloadWriterProducer;
         class TTopicWorkloadWriterWorker {
         public:
             static const size_t GENERATED_MESSAGES_COUNT = 32;
+
             static void RetryableWriterLoop(const TTopicWorkloadWriterParams& params);
             static void WriterLoop(const TTopicWorkloadWriterParams& params, TInstant endTime);
+
             static std::vector<TString> GenerateMessages(size_t messageSize);
+
+            static void RetryableConfiguratorLoop(const TTopicWorkloadConfiguratorParams& params);
+            static void ConfiguratorLoop(const TTopicWorkloadConfiguratorParams& params, TInstant endTime);
+
         private:
             TTopicWorkloadWriterWorker(const TTopicWorkloadWriterParams& params);
             ~TTopicWorkloadWriterWorker();

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -45,6 +45,7 @@ namespace NYdb {
         };
 
         struct TTopicWorkloadConfiguratorParams;
+        struct TTopicWorkloadDescriberParams;
 
         class TTopicWorkloadWriterProducer;
         class TTopicWorkloadWriterWorker {
@@ -58,6 +59,9 @@ namespace NYdb {
 
             static void RetryableConfiguratorLoop(const TTopicWorkloadConfiguratorParams& params);
             static void ConfiguratorLoop(const TTopicWorkloadConfiguratorParams& params, TInstant endTime);
+
+            static void RetryableDescriberLoop(const TTopicWorkloadDescriberParams& params);
+            static void DescriberLoop(const TTopicWorkloadDescriberParams& params, TInstant endTime);
 
         private:
             TTopicWorkloadWriterWorker(const TTopicWorkloadWriterParams& params);

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
@@ -2,6 +2,7 @@ LIBRARY(topic_workload)
 
 SRCS(
     topic_workload_clean.cpp
+    topic_workload_configurator.cpp
     topic_workload_describe.cpp
     topic_workload_init.cpp
     topic_workload_params.cpp

--- a/ydb/public/lib/ydb_cli/commands/topic_write_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_write_scenario.cpp
@@ -22,6 +22,7 @@ int TTopicWriteScenario::DoRun(const TClientCommand::TConfig& config)
 
     StartConsumerThreads(threads, config.Database);
     StartProducerThreads(threads, partitionCount, partitionSeed, generatedMessages, config.Database);
+    StartConfiguratorThread(threads, config.Database);
 
     StatsCollector->PrintWindowStatsLoop();
 

--- a/ydb/public/lib/ydb_cli/commands/topic_write_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_write_scenario.cpp
@@ -23,6 +23,7 @@ int TTopicWriteScenario::DoRun(const TClientCommand::TConfig& config)
     StartConsumerThreads(threads, config.Database);
     StartProducerThreads(threads, partitionCount, partitionSeed, generatedMessages, config.Database);
     StartConfiguratorThread(threads, config.Database);
+    StartDescriberThread(threads, config.Database);
 
     StatsCollector->PrintWindowStatsLoop();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added hidden options `--configure-consumers`, `--describe-topic` and `--describe-consumer`.
The `--configure-consumers` option starts a thread that periodically changes the topic configuration - creates and deletes a set number of consumers.
The `--describe-topic` and `--describe-consumer` options starts a thread that periodically calls DescripeTopic and DescribeConsumer.
The options are needed for testing topics.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
