### PR TITLE
EXT-1794: Support decimal VDisk ids in ydb-dstool, improve help

### DIFF
--- a/ydb/apps/dstool/README.md
+++ b/ydb/apps/dstool/README.md
@@ -267,6 +267,8 @@ enables pdisk ```"[NODE_ID:PDISK_ID]"```. The ```--allow-working-disks``` comman
 
 ## Do things with vdisks
 
+VDisk ids can be specified in square-bracket hex format like `[8200001b:3:0:7:0]` or round-bracket decimal format like `(2181038107-3-0-7-0)`.
+
 ### List vdisks
 
 ```bash

--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -1240,12 +1240,18 @@ def add_host_access_options(parser):
 
 
 def add_vdisk_ids_option(g, required=False):
-    g.add_argument('--vdisk-ids', type=str, nargs='+', required=required,
-        help='Space separated list of vdisk ids in format [GroupId:_:FailRealm:FailDomain:VDiskIdx] or (GroupId-GroupGen-FailRealm-FailDomain-VDiskIdx)')
+    help_text = (
+        'Space separated list of vdisk ids in formats: '
+        '[GroupId(hex):_:FailRealm:FailDomain:VDiskIdx], '
+        '[GroupId(hex):GroupGen:FailRealm:FailDomain:VDiskIdx], '
+        'or (GroupId(dec)-GroupGen-FailRealm-FailDomain-VDiskIdx)'
+    )
+    g.add_argument('--vdisk-ids', type=str, nargs='+', required=required, help=help_text)
 
 
 def add_pdisk_ids_option(p, required=False):
-    p.add_argument('--pdisk-ids', type=str, nargs='+', required=required, help='Space separated list of pdisk ids in format [NodeId:PDiskId]')
+    p.add_argument('--pdisk-ids', type=str, nargs='+', required=required,
+                   help='Space separated list of pdisk ids in format [NodeId:PDiskId] (brackets optional)')
 
 
 def add_group_ids_option(p, required=False):

--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -1202,6 +1202,7 @@ def get_vslots_by_vdisk_ids(base_config, vdisk_ids):
     for v in base_config.VSlot:
         vdisk_vslot_map['[%08x:_:%u:%u:%u]' % (v.GroupId, v.FailRealmIdx, v.FailDomainIdx, v.VDiskIdx)] = v
         vdisk_vslot_map['[%08x:%u:%u:%u:%u]' % (v.GroupId, v.GroupGeneration, v.FailRealmIdx, v.FailDomainIdx, v.VDiskIdx)] = v
+        vdisk_vslot_map['(%d-%u-%u-%u-%u)' % (v.GroupId, v.GroupGeneration, v.FailRealmIdx, v.FailDomainIdx, v.VDiskIdx)] = v
 
     res = []
     for string in vdisk_ids:
@@ -1239,7 +1240,8 @@ def add_host_access_options(parser):
 
 
 def add_vdisk_ids_option(g, required=False):
-    g.add_argument('--vdisk-ids', type=str, nargs='+', required=required, help='Space separated list of vdisk ids in format [GroupId:_:FailRealm:FailDomain:VDiskIdx]')
+    g.add_argument('--vdisk-ids', type=str, nargs='+', required=required,
+        help='Space separated list of vdisk ids in format [GroupId:_:FailRealm:FailDomain:VDiskIdx] or (GroupId-GroupGen-FailRealm-FailDomain-VDiskIdx)')
 
 
 def add_pdisk_ids_option(p, required=False):

--- a/ydb/apps/dstool/lib/dstool_cmd_vdisk_set_read_only.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_vdisk_set_read_only.py
@@ -5,7 +5,7 @@ description = 'Set vdisk read-only mode (experimental mode that might help resto
 
 
 def add_options(p):
-    p.add_argument('--vdisk-id', type=str, required=True, help='Vdisk id in format [GroupId:_:FailRealm:FailDomain:VDiskIdx]')
+    p.add_argument('--vdisk-id', type=str, required=True, help='Vdisk id in format [GroupId:_:FailRealm:FailDomain:VDiskIdx] or (GroupId-GroupGen-FailRealm-FailDomain-VDiskIdx)')
     p.add_argument('value', type=str, choices=('true', 'false'), help='Use one of the values to set or unset read-only mode')
     common.add_ignore_degraded_group_check_option(p)
     common.add_ignore_disintegrated_group_check_option(p)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

support decimal group-id, the same format that is used in UI



### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
