### PR TITLE
Fix VDisk keep and donotkeep flags processing during compaction

### DIFF
--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
@@ -601,8 +601,14 @@ namespace NKikimr {
                 const ui32 wholeKeep = IndexMerger.GetNumKeepFlags() - subsKeep; // they are counted too
                 const ui32 wholeDoNotKeep = IndexMerger.GetNumDoNotKeepFlags() - subsDoNotKeep; // so are they
 
-                keep = Barriers->Keep(Key, IndexMerger.GetMemRecForBarriers(), {subsKeep, subsDoNotKeep, wholeKeep,
-                    wholeDoNotKeep}, HullCtx->AllowKeepFlags, AllowGarbageCollection);
+                NGcOpt::TKeepFlagStat keepFlagStat;
+                if (IsFresh) {
+                    keepFlagStat.Needed = true;
+                } else {
+                    keepFlagStat = {subsKeep, subsDoNotKeep, wholeKeep, wholeDoNotKeep};
+                }
+                keep = Barriers->Keep(Key, IndexMerger.GetMemRecForBarriers(), keepFlagStat, HullCtx->AllowKeepFlags,
+                    AllowGarbageCollection);
 
                 const TLogoBlobID& id = Key.LogoBlobID();
                 if (!TBlobStorageGroupType::IsCrcModeValid(id.CrcMode())) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix VDisk keep and donotkeep flags processing during compaction

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes possible loss of DoNotKeep flag during parallel fresh and level compactions leading to leakage of blob data.
