### PR TITLE
PQv1: passthrough the '_advanced_monitoring' attribute

### DIFF
--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue.cpp
@@ -124,6 +124,8 @@ TDescribeTopicResult::TTopicSettings::TTopicSettings(const Ydb::PersQueue::V1::T
             AbcSlug_ = pair.second;
         } else if (pair.first == "_federation_account") {
             FederationAccount_ = pair.second;
+       } else if (pair.first == "_advanced_monitoring") {
+            AdvancedMonitoringSettings_ = pair.second;
         }
     }
     for (const auto& readRule : settings.read_rules()) {

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue.cpp
@@ -124,7 +124,7 @@ TDescribeTopicResult::TTopicSettings::TTopicSettings(const Ydb::PersQueue::V1::T
             AbcSlug_ = pair.second;
         } else if (pair.first == "_federation_account") {
             FederationAccount_ = pair.second;
-       } else if (pair.first == "_advanced_monitoring") {
+        } else if (pair.first == "_advanced_monitoring") {
             AdvancedMonitoringSettings_ = pair.second;
         }
     }

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue_impl.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue_impl.h
@@ -101,6 +101,7 @@ public:
         if (settings.AbcSlug_) (*props.mutable_attributes())["_abc_slug"] = *settings.AbcSlug_;
         if (settings.FederationAccount_) (*props.mutable_attributes())["_federation_account"] = ToString(*settings.FederationAccount_);
         if (settings.MetricsLevel_.has_value()) { props.set_metrics_level(*settings.MetricsLevel_); }
+        if (!settings.AdvancedMonitoringSettings_.empty()) (*props.mutable_attributes())["_advanced_monitoring"] = settings.AdvancedMonitoringSettings_;
 
         for (const auto& readRule : settings.ReadRules_) {
             Ydb::PersQueue::V1::TopicSettings::ReadRule& rrProps = *props.add_read_rules();

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue_impl.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue_impl.h
@@ -101,7 +101,7 @@ public:
         if (settings.AbcSlug_) (*props.mutable_attributes())["_abc_slug"] = *settings.AbcSlug_;
         if (settings.FederationAccount_) (*props.mutable_attributes())["_federation_account"] = ToString(*settings.FederationAccount_);
         if (settings.MetricsLevel_.has_value()) { props.set_metrics_level(*settings.MetricsLevel_); }
-        if (!settings.AdvancedMonitoringSettings_.empty()) (*props.mutable_attributes())["_advanced_monitoring"] = settings.AdvancedMonitoringSettings_;
+        if (settings.AdvancedMonitoringSettings_.has_value()) (*props.mutable_attributes())["_advanced_monitoring"] = *settings.AdvancedMonitoringSettings_;
 
         for (const auto& readRule : settings.ReadRules_) {
             Ydb::PersQueue::V1::TopicSettings::ReadRule& rrProps = *props.add_read_rules();

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
@@ -116,7 +116,6 @@ struct TDescribeTopicResult : public TStatus {
         GETTER(std::optional<ui32>, MetricsLevel);
         GETTER(std::string, AdvancedMonitoringSettings);
 
-
         const std::vector<TReadRule>& ReadRules() const {
             return ReadRules_;
         }
@@ -284,7 +283,6 @@ struct TTopicSettings : public TOperationRequestSettings<TDerived> {
         FederationAccount_ = settings.FederationAccount();
         MetricsLevel_ = settings.MetricsLevel();
         AdvancedMonitoringSettings_ = settings.AdvancedMonitoringSettings();
-
         ReadRules_.clear();
         for (const auto& readRule : settings.ReadRules()) {
             ReadRules_.push_back({});

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
@@ -114,7 +114,7 @@ struct TDescribeTopicResult : public TStatus {
         GETTER(std::optional<std::string>, AbcSlug);
         GETTER(std::optional<std::string>, FederationAccount);
         GETTER(std::optional<ui32>, MetricsLevel);
-        GETTER(std::string, AdvancedMonitoringSettings);
+        GETTER(std::optional<std::string>, AdvancedMonitoringSettings);
 
         const std::vector<TReadRule>& ReadRules() const {
             return ReadRules_;
@@ -149,7 +149,7 @@ struct TDescribeTopicResult : public TStatus {
         std::optional<std::string> AbcSlug_;
         std::string FederationAccount_;
         std::optional<ui32> MetricsLevel_;
-        std::string AdvancedMonitoringSettings_;
+        std::optional<std::string> AdvancedMonitoringSettings_;
 
         std::optional<uint64_t> MaxPartitionsCount_;
         std::optional<TDuration> StabilizationWindow_;
@@ -256,7 +256,7 @@ struct TTopicSettings : public TOperationRequestSettings<TDerived> {
     FLUENT_SETTING_OPTIONAL(std::string, AbcSlug);
     FLUENT_SETTING_OPTIONAL(std::string, FederationAccount);
     FLUENT_SETTING_OPTIONAL(ui32, MetricsLevel);
-    FLUENT_SETTING(std::string, AdvancedMonitoringSettings);
+    FLUENT_SETTING_OPTIONAL(std::string, AdvancedMonitoringSettings);
 
     //TODO: FLUENT_SETTING_VECTOR
     FLUENT_SETTING_DEFAULT(std::vector<TReadRuleSettings>, ReadRules, {});

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
@@ -114,6 +114,8 @@ struct TDescribeTopicResult : public TStatus {
         GETTER(std::optional<std::string>, AbcSlug);
         GETTER(std::optional<std::string>, FederationAccount);
         GETTER(std::optional<ui32>, MetricsLevel);
+        GETTER(std::string, AdvancedMonitoringSettings);
+
 
         const std::vector<TReadRule>& ReadRules() const {
             return ReadRules_;
@@ -148,6 +150,7 @@ struct TDescribeTopicResult : public TStatus {
         std::optional<std::string> AbcSlug_;
         std::string FederationAccount_;
         std::optional<ui32> MetricsLevel_;
+        std::string AdvancedMonitoringSettings_;
 
         std::optional<uint64_t> MaxPartitionsCount_;
         std::optional<TDuration> StabilizationWindow_;
@@ -254,6 +257,7 @@ struct TTopicSettings : public TOperationRequestSettings<TDerived> {
     FLUENT_SETTING_OPTIONAL(std::string, AbcSlug);
     FLUENT_SETTING_OPTIONAL(std::string, FederationAccount);
     FLUENT_SETTING_OPTIONAL(ui32, MetricsLevel);
+    FLUENT_SETTING(std::string, AdvancedMonitoringSettings);
 
     //TODO: FLUENT_SETTING_VECTOR
     FLUENT_SETTING_DEFAULT(std::vector<TReadRuleSettings>, ReadRules, {});
@@ -279,6 +283,8 @@ struct TTopicSettings : public TOperationRequestSettings<TDerived> {
         AbcSlug_ = settings.AbcSlug();
         FederationAccount_ = settings.FederationAccount();
         MetricsLevel_ = settings.MetricsLevel();
+        AdvancedMonitoringSettings_ = settings.AdvancedMonitoringSettings();
+
         ReadRules_.clear();
         for (const auto& readRule : settings.ReadRules()) {
             ReadRules_.push_back({});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


Добавлен проброс атрибута для настроек отгрузки метрик. Используется только в федерации.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->


LOGBROKER-10245 
LOGBROKER-10205
