### PR TITLE
Consumers partition metrics: process the '_advanced_monitoring' attribute only in federation

### DIFF
--- a/ydb/services/persqueue_v1/actors/schema_actors.cpp
+++ b/ydb/services/persqueue_v1/actors/schema_actors.cpp
@@ -184,7 +184,7 @@ void TPQDescribeTopicActor::HandleCacheNavigateResponse(TEvTxProxySchemeCache::T
                 customMonitoringSettings["monitoring_project_id"] = monitoringProjectId;
             }
             if (customMonitoringSettings.IsDefined()) { // at least one attribute is set
-                consumersAdvancedMonitoringSettings[consumer.GetName()] = std::move(customMonitoringSettings);
+                consumersAdvancedMonitoringSettings[consumerName] = std::move(customMonitoringSettings);
             }
         }
         if (consumersAdvancedMonitoringSettings.IsDefined()) { // at least one consumer has custom monitoring settings


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10245 
LOGBROKER-10205

