### PR TITLE
Add SQL queries for muted tests statistics and blocked PRs

### DIFF
--- a/.github/scripts/analytics/data_mart_queries/muted_tests_statistic.sql
+++ b/.github/scripts/analytics/data_mart_queries/muted_tests_statistic.sql
@@ -1,0 +1,98 @@
+PRAGMA AnsiInForEmptyOrNullableItemsCollections;
+
+$prepared = (
+    SELECT
+        tm.date_window AS date_window,
+        Substring(CAST(tm.date_window AS String), 0, 7) AS ym, -- YYYY-MM
+        tm.branch AS branch,
+        tm.build_type AS build_type,
+        tm.owner AS owner,
+        tm.full_name AS full_name
+    FROM `test_results/analytics/tests_monitor` AS tm
+    WHERE tm.date_window >= CurrentUtcDate() - 365 * Interval("P1D")
+      AND (tm.branch = 'main' OR tm.branch LIKE 'stable-%' OR tm.branch LIKE 'stream-nb-25%')
+      AND tm.is_test_chunk = 0
+      AND tm.is_muted = 1
+);
+
+-- Дневная метрика
+$daily = (
+    SELECT
+        date_window,
+        ym,
+        branch,
+        build_type,
+        owner,
+        COUNT(DISTINCT full_name) AS daily_value
+    FROM $prepared
+    GROUP BY
+        date_window,
+        ym,
+        branch,
+        build_type,
+        owner
+);
+
+-- Последняя дата в каждом месяце по группе
+$month_last_day = (
+    SELECT
+        ym,
+        branch,
+        build_type,
+        owner,
+        MAX(date_window) AS last_day_in_month
+    FROM $daily
+    GROUP BY
+        ym,
+        branch,
+        build_type,
+        owner
+);
+
+-- Значение метрики на последнюю дату месяца
+$month_value = (
+    SELECT
+        m.ym AS ym,
+        m.branch AS branch,
+        m.build_type AS build_type,
+        m.owner AS owner,
+        m.last_day_in_month AS month_point_date,
+        d.daily_value AS month_value
+    FROM $month_last_day AS m
+    INNER JOIN $daily AS d
+        ON d.ym = m.ym
+        AND d.branch = m.branch
+        AND d.build_type = m.build_type
+        AND d.owner = m.owner
+        AND d.date_window = m.last_day_in_month
+);
+
+$ranked = (
+    SELECT
+        ym,
+        branch,
+        build_type,
+        owner,
+        month_point_date,
+        month_value,
+        LAG(month_value) OVER (
+            PARTITION BY branch, build_type, owner
+            ORDER BY ym
+        ) AS prev_month_value
+    FROM $month_value
+);
+
+SELECT
+    ym,
+    branch,
+    build_type,
+    owner,
+    month_point_date,
+    month_value AS count_of_muted_tests,
+    prev_month_value,
+    CASE
+        WHEN prev_month_value IS NOT NULL
+            THEN CAST(month_value AS Int64) - CAST(prev_month_value AS Int64)
+        ELSE NULL
+    END AS delta_vs_prev_month_end
+FROM $ranked;

--- a/.github/scripts/analytics/data_mart_queries/pr_blocked_by_failed_tests_rich_with_pr_and_mute.sql
+++ b/.github/scripts/analytics/data_mart_queries/pr_blocked_by_failed_tests_rich_with_pr_and_mute.sql
@@ -1,0 +1,102 @@
+SELECT 
+    t.full_name AS full_name,
+    t.suite_folder AS suite_folder,
+    t.test_name AS test_name,
+    t.pr_number AS pr_number,
+    t.job_id AS job_id,
+    t.run_url AS run_url,
+    t.last_run_timestamp AS last_run_timestamp,
+    t.branch AS branch,
+    t.build_type AS build_type,
+    t.status_description AS status_description,
+    t.attempt_number AS attempt_number,
+    t.is_last_run_in_pr AS is_last_run_in_pr,
+    COALESCE(pr.base_ref_name, '') AS pr_target_branch,
+    COALESCE(pr.pr_status, 'unknown') AS pr_status,
+    COALESCE(pr.state, '') AS pr_state,
+    pr.merged AS pr_merged,
+    pr.title AS pr_title,
+    pr.url AS pr_url,
+    pr.merged_at AS pr_merged_at,
+    pr.closed_at AS pr_closed_at,
+    CAST(COALESCE(m.is_muted, 0) AS Uint8) AS is_muted_today,
+    CAST(COALESCE(m_run.is_muted, 0) AS Uint8) AS is_muted_in_run_day,
+    COALESCE(m.owner, '') AS owner_today
+FROM 
+    `test_results/analytics/pr_blocked_by_failed_tests_rich` AS t
+LEFT JOIN 
+    (
+        SELECT 
+            pr_number,
+            base_ref_name,
+            state,
+            merged,
+            CASE 
+                WHEN merged = 1 THEN 'merged'
+                WHEN state = 'OPEN' THEN 'open'
+                WHEN state = 'CLOSED' THEN 'closed'
+                ELSE COALESCE(state, 'unknown')
+            END AS pr_status,
+            title,
+            url,
+            merged_at,
+            closed_at
+        FROM 
+            (
+                SELECT 
+                    pr_number,
+                    base_ref_name,
+                    state,
+                    merged,
+                    title,
+                    url,
+                    merged_at,
+                    closed_at,
+                    ROW_NUMBER() OVER (PARTITION BY pr_number ORDER BY exported_at DESC, created_date DESC) AS rn
+                FROM 
+                    `github_data/pull_requests`
+            ) AS ranked
+        WHERE 
+            ranked.rn = 1
+    ) AS pr
+ON 
+    CAST(t.pr_number AS Uint64) = pr.pr_number
+LEFT JOIN
+    (
+        SELECT
+            full_name,
+            branch,
+            build_type,
+            owner,
+            is_muted
+        FROM
+            `test_results/analytics/tests_monitor`
+        WHERE
+            date_window = CurrentUtcDate()
+    ) AS m
+ON
+    t.full_name = m.full_name
+    AND t.branch = m.branch
+    AND t.build_type = m.build_type
+LEFT JOIN
+    (
+        SELECT
+            full_name,
+            branch,
+            build_type,
+            date_window,
+            is_muted
+        FROM
+            `test_results/analytics/tests_monitor`
+    ) AS m_run
+ON
+    t.full_name = m_run.full_name
+    AND t.branch = m_run.branch
+    AND t.build_type = m_run.build_type
+    AND m_run.date_window = CAST(t.last_run_timestamp AS Date)
+WHERE
+    t.last_run_timestamp > CurrentUtcDate() - 1 * Interval("P1D")
+ORDER BY 
+    last_run_timestamp DESC,
+    pr_number,
+    full_name

--- a/.github/scripts/analytics/data_mart_queries/pr_blocked_by_failed_tests_rich_with_pr_and_mute.sql
+++ b/.github/scripts/analytics/data_mart_queries/pr_blocked_by_failed_tests_rich_with_pr_and_mute.sql
@@ -1,3 +1,21 @@
+-- PR blocked by failed tests (rich) + данные по PR и флаги мьюта.
+--
+-- Логика:
+--   1. Берём данные из test_results/analytics/pr_blocked_by_failed_tests_rich
+--      (тесты, упавшие в PR-check при стабильности в regression/nightly).
+--   2. Джойним актуальное состояние PR из github_data/pull_requests
+--      (последняя запись по pr_number: base_ref_name, state, merged, title, url и т.д.).
+--   3. Джойним tests_monitor на «сегодня» (date_window = CurrentUtcDate())
+--      — флаг is_muted_today и owner_today.
+--   4. Джойним tests_monitor на день запуска (date_window = день last_run_timestamp)
+--      — флаг is_muted_in_run_day.
+--   5. Ограничиваем выборку последними $lookback_days днями по last_run_timestamp.
+--
+-- Параметры:
+--   $lookback_days — окно выборки по дате прогона и по date_window в tests_monitor (дни). По умолчанию 30.
+
+$lookback_days = 1;
+
 SELECT 
     t.full_name AS full_name,
     t.suite_folder AS suite_folder,
@@ -88,6 +106,9 @@ LEFT JOIN
             is_muted
         FROM
             `test_results/analytics/tests_monitor`
+        WHERE
+            date_window >= CurrentUtcDate() - $lookback_days * Interval("P1D")
+            AND date_window <= CurrentUtcDate()
     ) AS m_run
 ON
     t.full_name = m_run.full_name
@@ -95,7 +116,7 @@ ON
     AND t.build_type = m_run.build_type
     AND m_run.date_window = CAST(t.last_run_timestamp AS Date)
 WHERE
-    t.last_run_timestamp > CurrentUtcDate() - 1 * Interval("P1D")
+    t.last_run_timestamp > CurrentUtcDate() - $lookback_days * Interval("P1D")
 ORDER BY 
     last_run_timestamp DESC,
     pr_number,

--- a/.github/workflows/collect_analytics_fast.yml
+++ b/.github/workflows/collect_analytics_fast.yml
@@ -55,12 +55,18 @@ jobs:
     - name: Upload FULL test monitor data mart
       continue-on-error: true
       run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/test_monitor_mart.sql --table_path test_results/analytics/test_monitor_mart --store_type column --partition_keys date_window branch build_type owner_team suite_folder --primary_keys date_window owner_team branch build_type suite_folder full_name --ttl_min 43200 --ttl_key date_window
+    - name: Upload muted tests statistic data mart
+      continue-on-error: true
+      run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/muted_tests_statistic.sql --table_path test_results/analytics/muted_tests_statistic --store_type column --partition_keys month_point_date branch build_type owner --primary_keys ym branch build_type owner
     - name: Upload postcommit retry data mart
       continue-on-error: true
       run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/datamart_postcommit_retry.sql --table_path test_results/test_results/analytics/postcommit_retry --store_type column --partition_keys postcommit_start_run_timestamp --primary_keys postcommit_start_run_timestamp commit --ttl_min 259200 --ttl_key postcommit_start_run_timestamp
     - name: Upload PR blocked by failed tests data mart
       continue-on-error: true
       run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_blocked_by_failed_tests_rich.sql --table_path test_results/analytics/pr_blocked_by_failed_tests_rich --store_type column --partition_keys last_run_timestamp --primary_keys last_run_timestamp full_name pr_number job_id
+    - name: Upload PR blocked by failed tests with PR info data mart
+      continue-on-error: true
+      run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_blocked_by_failed_tests_rich_with_pr_and_mute.sql --table_path test_results/analytics/pr_blocked_by_failed_tests_rich_with_pr_and_mute --store_type column --partition_keys last_run_timestamp --primary_keys last_run_timestamp full_name pr_number job_id
     - name: Upload PR with test failures (any failures, 1 day)
       continue-on-error: true
       run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_with_test_failures.sql --table_path test_results/analytics/pr_blocked_by_tests --store_type column --partition_keys last_run_timestamp --primary_keys last_run_timestamp full_name pr_number job_id


### PR DESCRIPTION
- Introduced `muted_tests_statistic.sql` to track statistics of muted tests over the past year.
- Added `pr_blocked_by_failed_tests_rich_with_pr_and_mute.sql` to enrich PR data with muted test information.
- Fixed `pr_blocked_by_failed_tests_rich` - there was issue with is_last_run_in_pr =  is_last_run was got from list of failed runs of pr, not from all runs of pr
- Updated `collect_analytics_fast.yml` workflow to include uploads for the new data marts.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
