### PR TITLE
Fix datashard not allowing row deletions when out of disk space quota

### DIFF
--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -247,6 +247,8 @@ TVector<TKeyValidator::TColumnWriteMeta> TValidatedWriteTxOperation::GetColumnWr
 
 void TValidatedWriteTxOperation::SetTxKeys(const TUserTable& tableInfo, ui64 tabletId, TKeyValidator& keyValidator)
 {
+    bool isErase = GetOperationType() == NKikimrDataEvents::TEvWrite::TOperation::OPERATION_DELETE;
+
     auto columnsWrites = GetColumnWrites();
 
     TVector<TCell> keyCells;
@@ -258,7 +260,7 @@ void TValidatedWriteTxOperation::SetTxKeys(const TUserTable& tableInfo, ui64 tab
             << "write point " << DebugPrintPoint(tableInfo.KeyColumnTypes, keyCells, *AppData()->TypeRegistry));
 
         TTableRange tableRange(keyCells);
-        keyValidator.AddWriteRange(TableId, tableRange, tableInfo.KeyColumnTypes, columnsWrites, false);
+        keyValidator.AddWriteRange(TableId, tableRange, tableInfo.KeyColumnTypes, columnsWrites, isErase);
     }
 }
 

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -2,6 +2,7 @@
 import functools
 import logging
 import os
+import re
 import time
 import copy
 import pytest
@@ -60,11 +61,17 @@ CLUSTER_CONFIG = dict(
         'disabled_on_scheme_shard': False,
     },
     table_service_config={
-        'enable_oltp_sink': False,
+        'enable_oltp_sink': True,
     },
 )
 
-DATABASE_DISK_SPACE_QUOTA_EXCEEDED = 'DATABASE_DISK_SPACE_QUOTA_EXCEEDED'  # change to '2033' if enable_oltp_sink: True
+
+# regex matching error mesages when database exceeds its disk space quota
+RE_DISK_SPACE_QUOTA_EXCEEDED = re.compile(r'.*out of disk space.*')
+
+
+def is_disk_space_quota_exceeded_exception(e: BaseException):
+    return RE_DISK_SPACE_QUOTA_EXCEEDED.match(str(e))
 
 
 @pytest.fixture(scope='module', params=[True, False], ids=['enable_alter_database_create_hive_first--true', 'enable_alter_database_create_hive_first--false'])
@@ -386,7 +393,7 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
                         commit_tx=True,
                     )
         except ydb.Unavailable as e:
-            if not ignore_out_of_space or DATABASE_DISK_SPACE_QUOTA_EXCEEDED not in str(e):
+            if not ignore_out_of_space or not is_disk_space_quota_exceeded_exception(e):
                 raise
 
     @restart_coro_on_bad_session
@@ -459,9 +466,9 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
 
         # Writes should be denied when database moves into DiskQuotaExceeded state
         time.sleep(1)
-        with pytest.raises(ydb.Unavailable, match=r'.*{}.*'.format(DATABASE_DISK_SPACE_QUOTA_EXCEEDED)):
+        with pytest.raises(ydb.Unavailable, match=RE_DISK_SPACE_QUOTA_EXCEEDED):
             IOLoop.current().run_sync(lambda: async_write_key(path, 0, 'test', ignore_out_of_space=False))
-        with pytest.raises(ydb.Unavailable, match=r'.*out of disk space.*'):
+        with pytest.raises(ydb.Unavailable, match=RE_DISK_SPACE_QUOTA_EXCEEDED):
             IOLoop.current().run_sync(lambda: async_bulk_upsert(path, [BulkUpsertRow(0, 'test')]))
 
         for start in range(0, 1000, 100):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix datashard not allowing row deletions when out of disk space quota. Fixes #34108.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Additionally stop relying on accidental datashard internal error codes in tests.