### PR TITLE
Fix compatibility between QueryService Arrow Format and BulkUpsert Arrow Format

### DIFF
--- a/ydb/core/formats/arrow/converter.cpp
+++ b/ydb/core/formats/arrow/converter.cpp
@@ -17,7 +17,9 @@
 
 namespace NKikimr::NArrow {
 
-static bool ConvertData(TCell& cell, const NScheme::TTypeInfo& colType, TMemoryPool& memPool, TString& errorMessage, const bool allowInfDouble) {
+static bool ConvertData(TCell& cell, const NScheme::TTypeInfo& colType, TMemoryPool& memPool,
+    TString& errorMessage, const bool allowInfDouble)
+{
     if (!cell.AsBuf()) {
         cell = TCell();
         return true;
@@ -33,6 +35,7 @@ static bool ConvertData(TCell& cell, const NScheme::TTypeInfo& colType, TMemoryP
             cell = TCell(dyNumberInPool.data(), dyNumberInPool.size());
             break;
         }
+
         case NScheme::NTypeIds::JsonDocument: {
             const auto binaryJson = NBinaryJson::SerializeToBinaryJson(cell.AsBuf(), allowInfDouble);
             if (std::holds_alternative<TString>(binaryJson)) {
@@ -44,37 +47,36 @@ static bool ConvertData(TCell& cell, const NScheme::TTypeInfo& colType, TMemoryP
             cell = TCell(saved.data(), saved.size());
             break;
         }
+
         default:
             break;
     }
     return true;
 }
 
-static arrow::Status ConvertColumn(
-    const NScheme::TTypeInfo colType, std::shared_ptr<arrow::Array>& column, std::shared_ptr<arrow::Field>& field, const bool allowInfDouble)
+static arrow::Status ConvertColumn(const NScheme::TTypeInfo colType, std::shared_ptr<arrow::Array>& column,
+    std::shared_ptr<arrow::Field>& field, const bool allowInfDouble)
 {
-    const static TSet<arrow::Type::type> serializedArrowTypes{ arrow::Type::BINARY, arrow::Type::STRING };
-
     switch (colType.GetTypeId()) {
-        case NScheme::NTypeIds::Decimal:
-            return arrow::Status::OK();
         case NScheme::NTypeIds::DyNumber: {
-            if (!serializedArrowTypes.contains(column->type()->id())) {
+            if (!arrow::is_binary_like(column->type()->id())) {
                 return arrow::Status::TypeError("Cannot convert DyNumber to ", column->type()->ToString());
             }
             break;
         }
+
         case NScheme::NTypeIds::JsonDocument: {
-            if (!serializedArrowTypes.contains(column->type()->id())) {
+            if (!arrow::is_binary_like(column->type()->id())) {
                 return arrow::Status::TypeError("Cannot convert JsonDocument to ", column->type()->ToString());
             }
             break;
         }
-        default:
+
+        default: {
             if (column->type()->id() != arrow::Type::BINARY) {
                 return arrow::Status::TypeError("Cannot convert ", NScheme::TypeName(colType), " to ", column->type()->ToString());
             }
-            break;
+        }
     }
 
     auto& binaryArray = static_cast<arrow::BinaryArray&>(*column);
@@ -97,6 +99,7 @@ static arrow::Status ConvertColumn(
             }
 	        break;
         }
+
         case NScheme::NTypeIds::JsonDocument: {
             for (i32 i = 0; i < binaryArray.length(); ++i) {
                 auto value = binaryArray.Value(i);
@@ -125,6 +128,7 @@ static arrow::Status ConvertColumn(
             }
 	        break;
         }
+
         default:
             break;
     }
@@ -150,11 +154,13 @@ static arrow::Status ConvertColumn(
     return arrow::Status::OK();
 }
 
-arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertColumns(
-    const std::shared_ptr<arrow::RecordBatch>& batch, const THashMap<TString, NScheme::TTypeInfo>& columnsToConvert, const bool allowInfDouble) {
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertColumns(const std::shared_ptr<arrow::RecordBatch>& batch,
+    const THashMap<TString, NScheme::TTypeInfo>& columnsToConvert, const bool allowInfDouble)
+{
     std::vector<std::shared_ptr<arrow::Array>> columns = batch->columns();
     std::vector<std::shared_ptr<arrow::Field>> fields = batch->schema()->fields();
     Y_ABORT_UNLESS(columns.size() == fields.size());
+
     for (i32 i = 0; i < batch->num_columns(); ++i) {
         auto& colName = batch->column_name(i);
         auto it = columnsToConvert.find(TString(colName.data(), colName.size()));
@@ -168,8 +174,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertColumns(
     return arrow::RecordBatch::Make(std::make_shared<arrow::Schema>(std::move(fields)), batch->num_rows(), std::move(columns));
 }
 
-static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<arrow::Array>& column,
-                                                   NScheme::TTypeInfo colType) {
+static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<arrow::Array>& column, NScheme::TTypeInfo colType) {
     switch (colType.GetTypeId()) {
         case NScheme::NTypeIds::Bytes: {
             Y_ABORT_UNLESS(column->type()->id() == arrow::Type::STRING);
@@ -177,6 +182,7 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
                 arrow::ArrayData::Make(arrow::binary(), column->data()->length,
                     column->data()->buffers, column->data()->null_count, column->data()->offset));
         }
+
         case NScheme::NTypeIds::Date: {
             Y_ABORT_UNLESS(arrow::is_primitive(column->type()->id()));
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 16);
@@ -185,6 +191,7 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
             newData->type = arrow::uint16();
             return std::make_shared<arrow::NumericArray<arrow::UInt16Type>>(newData);
         }
+
         case NScheme::NTypeIds::Datetime: {
             Y_ABORT_UNLESS(arrow::is_primitive(column->type()->id()));
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 32);
@@ -193,6 +200,7 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
             newData->type = arrow::uint32();
             return std::make_shared<arrow::NumericArray<arrow::UInt32Type>>(newData);
         }
+
         case NScheme::NTypeIds::Timestamp: {
             Y_ABORT_UNLESS(arrow::is_primitive(column->type()->id()));
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 64);
@@ -201,31 +209,33 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
             newData->type = arrow::timestamp(arrow::TimeUnit::MICRO);
             return std::make_shared<arrow::TimestampArray>(newData);
         }
-        case NScheme::NTypeIds::Date32: {
 
+        case NScheme::NTypeIds::Date32: {
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 32);
 
             auto newData = column->data()->Copy();
             newData->type = arrow::int32();
             return std::make_shared<arrow::NumericArray<arrow::Int32Type>>(newData);
         }
+
         case NScheme::NTypeIds::Timestamp64:
         case NScheme::NTypeIds::Interval64:
         case NScheme::NTypeIds::Datetime64: {
-
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 64);
 
             auto newData = column->data()->Copy();
             newData->type = arrow::int64();
             return std::make_shared<arrow::NumericArray<arrow::Int64Type>>(newData);
         }
+
         default:
             return {};
     }
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> InplaceConvertColumns(const std::shared_ptr<arrow::RecordBatch>& batch,
-                                                          const THashMap<TString, NScheme::TTypeInfo>& columnsToConvert) {
+    const THashMap<TString, NScheme::TTypeInfo>& columnsToConvert)
+{
     std::vector<std::shared_ptr<arrow::Array>> columns = batch->columns();
     std::vector<std::shared_ptr<arrow::Field>> fields;
     fields.reserve(batch->num_columns());
@@ -251,7 +261,6 @@ bool TArrowToYdbConverter::NeedDataConversion(const NScheme::TTypeInfo& colType)
     switch (colType.GetTypeId()) {
         case NScheme::NTypeIds::DyNumber:
         case NScheme::NTypeIds::JsonDocument:
-        case NScheme::NTypeIds::Decimal:
             return true;
         default:
             break;
@@ -272,8 +281,6 @@ bool TArrowToYdbConverter::NeedInplaceConversion(const NScheme::TTypeInfo& typeI
         case NScheme::NTypeIds::Date32:
         case NScheme::NTypeIds::Datetime:
             return typeInRequest.GetTypeId() == NScheme::NTypeIds::Int32;
-        case NScheme::NTypeIds::Interval:
-            return typeInRequest.GetTypeId() == NScheme::NTypeIds::Int64;
         case NScheme::NTypeIds::Timestamp:
             if (typeInRequest.GetTypeId() == NScheme::NTypeIds::Uint64) {
                 return true;

--- a/ydb/core/formats/arrow/converter.cpp
+++ b/ydb/core/formats/arrow/converter.cpp
@@ -91,7 +91,7 @@ static arrow::Status ConvertColumn(
                     return arrow::Status::SerializationError("Cannot parse dy number: ", value);
                 }
                 auto appendResult = builder.Append((*dyNumber).data(), (*dyNumber).size());
-                if (appendResult.ok()) {
+                if (!appendResult.ok()) {
                     return appendResult;
                 }
             }

--- a/ydb/core/formats/arrow/converter.cpp
+++ b/ydb/core/formats/arrow/converter.cpp
@@ -17,9 +17,7 @@
 
 namespace NKikimr::NArrow {
 
-static bool ConvertData(TCell& cell, const NScheme::TTypeInfo& colType, TMemoryPool& memPool,
-    TString& errorMessage, const bool allowInfDouble)
-{
+static bool ConvertData(TCell& cell, const NScheme::TTypeInfo& colType, TMemoryPool& memPool, TString& errorMessage, const bool allowInfDouble) {
     if (!cell.AsBuf()) {
         cell = TCell();
         return true;
@@ -35,7 +33,6 @@ static bool ConvertData(TCell& cell, const NScheme::TTypeInfo& colType, TMemoryP
             cell = TCell(dyNumberInPool.data(), dyNumberInPool.size());
             break;
         }
-
         case NScheme::NTypeIds::JsonDocument: {
             const auto binaryJson = NBinaryJson::SerializeToBinaryJson(cell.AsBuf(), allowInfDouble);
             if (std::holds_alternative<TString>(binaryJson)) {
@@ -47,35 +44,30 @@ static bool ConvertData(TCell& cell, const NScheme::TTypeInfo& colType, TMemoryP
             cell = TCell(saved.data(), saved.size());
             break;
         }
-
         default:
             break;
     }
     return true;
 }
 
-static arrow::Status ConvertColumn(const NScheme::TTypeInfo colType, std::shared_ptr<arrow::Array>& column,
-    std::shared_ptr<arrow::Field>& field, const bool allowInfDouble)
-{
+static arrow::Status ConvertColumn(
+    const NScheme::TTypeInfo colType, std::shared_ptr<arrow::Array>& column, std::shared_ptr<arrow::Field>& field, const bool allowInfDouble) {
     switch (colType.GetTypeId()) {
-        case NScheme::NTypeIds::DyNumber: {
-            if (!arrow::is_binary_like(column->type()->id())) {
-                return arrow::Status::TypeError("Cannot convert DyNumber to ", column->type()->ToString());
-            }
-            break;
+    case NScheme::NTypeIds::DyNumber: {
+        if (!arrow::is_binary_like(column->type()->id())) {
+            return arrow::Status::TypeError("Cannot convert DyNumber to ", column->type()->ToString());
         }
-
-        case NScheme::NTypeIds::JsonDocument: {
-            if (!arrow::is_binary_like(column->type()->id())) {
-                return arrow::Status::TypeError("Cannot convert JsonDocument to ", column->type()->ToString());
-            }
-            break;
+        break;
+    }
+    case NScheme::NTypeIds::JsonDocument: {
+        if (!arrow::is_binary_like(column->type()->id())) {
+            return arrow::Status::TypeError("Cannot convert JsonDocument to ", column->type()->ToString());
         }
-
-        default: {
-            if (column->type()->id() != arrow::Type::BINARY) {
-                return arrow::Status::TypeError("Cannot convert ", NScheme::TypeName(colType), " to ", column->type()->ToString());
-            }
+        break;
+    }
+    default:
+        if (column->type()->id() != arrow::Type::BINARY) {
+            return arrow::Status::TypeError("Cannot convert ", NScheme::TypeName(colType), " to ", column->type()->ToString());
         }
     }
 
@@ -97,9 +89,8 @@ static arrow::Status ConvertColumn(const NScheme::TTypeInfo colType, std::shared
                     return appendResult;
                 }
             }
-	        break;
+	    break;
         }
-
         case NScheme::NTypeIds::JsonDocument: {
             for (i32 i = 0; i < binaryArray.length(); ++i) {
                 auto value = binaryArray.Value(i);
@@ -126,9 +117,8 @@ static arrow::Status ConvertColumn(const NScheme::TTypeInfo colType, std::shared
                     }
                 }
             }
-	        break;
+	    break;
         }
-
         default:
             break;
     }
@@ -154,9 +144,8 @@ static arrow::Status ConvertColumn(const NScheme::TTypeInfo colType, std::shared
     return arrow::Status::OK();
 }
 
-arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertColumns(const std::shared_ptr<arrow::RecordBatch>& batch,
-    const THashMap<TString, NScheme::TTypeInfo>& columnsToConvert, const bool allowInfDouble)
-{
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertColumns(
+    const std::shared_ptr<arrow::RecordBatch>& batch, const THashMap<TString, NScheme::TTypeInfo>& columnsToConvert, const bool allowInfDouble) {
     std::vector<std::shared_ptr<arrow::Array>> columns = batch->columns();
     std::vector<std::shared_ptr<arrow::Field>> fields = batch->schema()->fields();
     Y_ABORT_UNLESS(columns.size() == fields.size());
@@ -174,7 +163,8 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertColumns(const std::sha
     return arrow::RecordBatch::Make(std::make_shared<arrow::Schema>(std::move(fields)), batch->num_rows(), std::move(columns));
 }
 
-static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<arrow::Array>& column, NScheme::TTypeInfo colType) {
+static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<arrow::Array>& column,
+                                                   NScheme::TTypeInfo colType) {
     switch (colType.GetTypeId()) {
         case NScheme::NTypeIds::Bytes: {
             Y_ABORT_UNLESS(column->type()->id() == arrow::Type::STRING);
@@ -182,7 +172,6 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
                 arrow::ArrayData::Make(arrow::binary(), column->data()->length,
                     column->data()->buffers, column->data()->null_count, column->data()->offset));
         }
-
         case NScheme::NTypeIds::Date: {
             Y_ABORT_UNLESS(arrow::is_primitive(column->type()->id()));
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 16);
@@ -191,7 +180,6 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
             newData->type = arrow::uint16();
             return std::make_shared<arrow::NumericArray<arrow::UInt16Type>>(newData);
         }
-
         case NScheme::NTypeIds::Datetime: {
             Y_ABORT_UNLESS(arrow::is_primitive(column->type()->id()));
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 32);
@@ -200,7 +188,6 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
             newData->type = arrow::uint32();
             return std::make_shared<arrow::NumericArray<arrow::UInt32Type>>(newData);
         }
-
         case NScheme::NTypeIds::Timestamp: {
             Y_ABORT_UNLESS(arrow::is_primitive(column->type()->id()));
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 64);
@@ -209,7 +196,6 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
             newData->type = arrow::timestamp(arrow::TimeUnit::MICRO);
             return std::make_shared<arrow::TimestampArray>(newData);
         }
-
         case NScheme::NTypeIds::Date32: {
             Y_ABORT_UNLESS(arrow::bit_width(column->type()->id()) == 32);
 
@@ -217,7 +203,6 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
             newData->type = arrow::int32();
             return std::make_shared<arrow::NumericArray<arrow::Int32Type>>(newData);
         }
-
         case NScheme::NTypeIds::Timestamp64:
         case NScheme::NTypeIds::Interval64:
         case NScheme::NTypeIds::Datetime64: {
@@ -227,15 +212,13 @@ static std::shared_ptr<arrow::Array> InplaceConvertColumn(const std::shared_ptr<
             newData->type = arrow::int64();
             return std::make_shared<arrow::NumericArray<arrow::Int64Type>>(newData);
         }
-
         default:
             return {};
     }
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> InplaceConvertColumns(const std::shared_ptr<arrow::RecordBatch>& batch,
-    const THashMap<TString, NScheme::TTypeInfo>& columnsToConvert)
-{
+                                                          const THashMap<TString, NScheme::TTypeInfo>& columnsToConvert) {
     std::vector<std::shared_ptr<arrow::Array>> columns = batch->columns();
     std::vector<std::shared_ptr<arrow::Field>> fields;
     fields.reserve(batch->num_columns());

--- a/ydb/core/formats/arrow/converter.cpp
+++ b/ydb/core/formats/arrow/converter.cpp
@@ -57,11 +57,19 @@ static arrow::Status ConvertColumn(
         if (!arrow::is_binary_like(column->type()->id())) {
             return arrow::Status::TypeError("Cannot convert DyNumber to ", column->type()->ToString());
         }
+
+        if (field->type()->id() == arrow::Type::STRING) {
+            field = std::make_shared<arrow::Field>(field->name(), std::make_shared<arrow::BinaryType>(), field->nullable());
+        }
         break;
     }
     case NScheme::NTypeIds::JsonDocument: {
         if (!arrow::is_binary_like(column->type()->id())) {
             return arrow::Status::TypeError("Cannot convert JsonDocument to ", column->type()->ToString());
+        }
+
+        if (field->type()->id() == arrow::Type::STRING) {
+            field = std::make_shared<arrow::Field>(field->name(), std::make_shared<arrow::BinaryType>(), field->nullable());
         }
         break;
     }
@@ -130,17 +138,6 @@ static arrow::Status ConvertColumn(
     }
 
     column = result;
-    switch (colType.GetTypeId()) {
-        case NScheme::NTypeIds::DyNumber:
-        case NScheme::NTypeIds::JsonDocument:
-            if (field->type()->id() == arrow::Type::STRING) {
-                field = std::make_shared<arrow::Field>(field->name(), std::make_shared<arrow::BinaryType>(), field->nullable());
-            }
-            break;
-        default:
-            break;
-    }
-
     return arrow::Status::OK();
 }
 

--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -74,10 +74,7 @@ bool ConvertArrowToYdbPrimitive(const arrow::DataType& type, Ydb::Type& toType, 
             toType.set_type_id(Ydb::Type::INTERVAL);
             return true;
         case arrow::Type::FIXED_SIZE_BINARY: {
-            if (!tableColumnType) {
-                break;
-            }
-            if (dynamic_cast<const arrow::FixedSizeBinaryType&>(type).byte_width() != NScheme::FSB_SIZE) {
+            if (!tableColumnType || dynamic_cast<const arrow::FixedSizeBinaryType&>(type).byte_width() != NScheme::FSB_SIZE) {
                 break;
             }
 

--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -74,13 +74,23 @@ bool ConvertArrowToYdbPrimitive(const arrow::DataType& type, Ydb::Type& toType, 
             toType.set_type_id(Ydb::Type::INTERVAL);
             return true;
         case arrow::Type::FIXED_SIZE_BINARY: {
-            if (tableColumnType && tableColumnType->GetTypeId() == NScheme::NTypeIds::Decimal) {
-                Ydb::DecimalType* decimalType = toType.mutable_decimal_type();
-                decimalType->set_precision(tableColumnType->GetDecimalType().GetPrecision());
-                decimalType->set_scale(tableColumnType->GetDecimalType().GetScale());
-                return true;
+            if (!tableColumnType) {
+                break;
             }
 
+            switch (tableColumnType->GetTypeId()) {
+                case NScheme::NTypeIds::Decimal: {
+                    Ydb::DecimalType* decimalType = toType.mutable_decimal_type();
+                    decimalType->set_precision(tableColumnType->GetDecimalType().GetPrecision());
+                    decimalType->set_scale(tableColumnType->GetDecimalType().GetScale());
+                    return true;
+                }
+
+                case NScheme::NTypeIds::Uuid: {
+                    toType.set_type_id(Ydb::Type::UUID);
+                    return true;
+                }
+            }
             break;
         }
         case arrow::Type::BOOL:

--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -77,6 +77,9 @@ bool ConvertArrowToYdbPrimitive(const arrow::DataType& type, Ydb::Type& toType, 
             if (!tableColumnType) {
                 break;
             }
+            if (dynamic_cast<const arrow::FixedSizeBinaryType&>(type).byte_width() != NScheme::FSB_SIZE) {
+                break;
+            }
 
             switch (tableColumnType->GetTypeId()) {
                 case NScheme::NTypeIds::Decimal: {

--- a/ydb/core/kqp/ut/arrow/kqp_result_set_formats_ut.cpp
+++ b/ydb/core/kqp/ut/arrow/kqp_result_set_formats_ut.cpp
@@ -78,6 +78,7 @@ void CreateAllTypesColumnTable(TQueryClient& client) {
     auto createResult = client.ExecuteQuery(R"(
         CREATE TABLE `/Root/ColumnTable` (
             Key Uint64 NOT NULL,
+            BoolValue Bool,
             Int8Value Int8,
             Uint8Value Uint8,
             Int16Value Int16,
@@ -104,8 +105,8 @@ void CreateAllTypesColumnTable(TQueryClient& client) {
     UNIT_ASSERT_C(createResult.IsSuccess(), createResult.GetIssues().ToString());
 
     auto insertResult = client.ExecuteQuery(R"(
-        INSERT INTO `/Root/ColumnTable` (Key, Int8Value, Uint8Value, Int16Value, Uint16Value, Int32Value, Uint32Value, Int64Value, Uint64Value, FloatValue, DoubleValue, StringValue, Utf8Value, DateValue, DatetimeValue, TimestampValue, JsonValue, YsonValue, JsonDocumentValue) VALUES
-        (42, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]"));
+        INSERT INTO `/Root/ColumnTable` (Key, BoolValue, Int8Value, Uint8Value, Int16Value, Uint16Value, Int32Value, Uint32Value, Int64Value, Uint64Value, FloatValue, DoubleValue, StringValue, Utf8Value, DateValue, DatetimeValue, TimestampValue, JsonValue, YsonValue, JsonDocumentValue) VALUES
+        (42, true, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]"));
     )", TTxControl::BeginTx().CommitTx()).GetValueSync();
     UNIT_ASSERT_C(insertResult.IsSuccess(), insertResult.GetIssues().ToString());
 }
@@ -649,10 +650,10 @@ Y_UNIT_TEST_SUITE(KqpResultSetFormats) {
         if (isOlap) {
             CreateAllTypesColumnTable(client);
             query = R"(
-                UPSERT INTO `/Root/ColumnTable` (Key, Int8Value, Uint8Value, Int16Value, Uint16Value, Int32Value, Uint32Value, Int64Value, Uint64Value, FloatValue, DoubleValue, StringValue, Utf8Value, DateValue, DatetimeValue, TimestampValue, JsonValue, YsonValue, JsonDocumentValue) VALUES
-                (43, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]")),
-                (44, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]")),
-                (45, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]"))
+                UPSERT INTO `/Root/ColumnTable` (Key, BoolValue, Int8Value, Uint8Value, Int16Value, Uint16Value, Int32Value, Uint32Value, Int64Value, Uint64Value, FloatValue, DoubleValue, StringValue, Utf8Value, DateValue, DatetimeValue, TimestampValue, JsonValue, YsonValue, JsonDocumentValue) VALUES
+                (43, false, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]")),
+                (44, true, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]")),
+                (45, false, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]"))
                 RETURNING *;
             )";
         } else {
@@ -2026,6 +2027,177 @@ R"(column0:   -- is_valid: all not null
     ]
 )";
             UNIT_ASSERT_VALUES_EQUAL(batch->ToString(), expected);
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(ArrowFormat_BulkUpsert, IsOlap) {
+
+        // FIXME: Uncaught exception for types: Uuid, Decimal(22, 0) -> FixedSizeBinary(16)
+        // https://github.com/ydb-platform/ydb/issues/34156
+        if (!IsOlap) {
+            return;
+        }
+
+        auto kikimr = CreateKikimrRunner(/* withSampleTables */ false);
+        auto queryClient = kikimr.GetQueryClient();
+        auto tableClient = kikimr.GetTableClient();
+
+        std::vector<std::pair<std::string, std::string>> types = {
+            {"Bool", "Bool"},
+            {"Uint8", "Uint8"},
+            {"Int8", "Int8"},
+            {"Uint16", "Uint16"},
+            {"Int16", "Int16"},
+            {"Uint32", "Uint32"},
+            {"Int32", "Int32"},
+            {"Uint64", "Uint64"},
+            {"Int64", "Int64"},
+            {"Float", "Float"},
+            {"Double", "Double"},
+            {"Date", "Date"},
+            {"Datetime", "Datetime"},
+            {"Timestamp", "Timestamp"},
+            {"String", "String"},
+            {"Utf8", "Utf8"},
+            {"Date32", "Date32"},
+            {"Datetime64", "Datetime64"},
+            {"Timestamp64", "Timestamp64"},
+            {"Interval64", "Interval64"},
+            {"Json", "Json"},
+            {"JsonDocument", "JsonDocument"},
+            {"Yson", "Yson"},
+            {"Decimal", "Decimal(22, 9)"}
+        };
+
+        if (!IsOlap) {
+            types.push_back({"Interval", "Interval"});
+            types.push_back({"DyNumber", "DyNumber"});
+            types.push_back({"Uuid", "Uuid"});
+        }
+
+        {
+            std::string query = "CREATE TABLE SomeTypes (";
+            query += "Key Uint64 NOT NULL";
+            for (const auto& [name, type] : types) {
+                query += std::format(", {}Value {}", name, type);
+            }
+            query += ", PRIMARY KEY (Key))";
+
+            if (IsOlap) {
+                query += " WITH (STORE = COLUMN)";
+            }
+
+            auto result = queryClient.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            std::string query = "INSERT INTO SomeTypes (";
+            query += "Key";
+
+            for (const auto& [name, type] : types) {
+                query += std::format(", {}Value", name);
+            }
+            query += ") VALUES ";
+            query += "(1, true, 1, -1, 1, -1, 1, -1, 1, -1, 1.0f, 1.0, Date('2025-01-01'), Datetime('2025-01-01T00:00:00Z'), Timestamp('2025-01-01T00:00:00Z'), '1', '1'u, Date32('2025-01-01'), Datetime64('2025-01-01T00:00:00Z'), Timestamp64('2025-01-01T00:00:00Z'), Interval64('P1D'), Json(@@[1]@@), JsonDocument('[1]'), Yson('[1]'), Decimal('1', 22, 9)";
+
+            if (!IsOlap) {
+                query += ", Interval('P1D'), DyNumber('1'), Uuid('f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc1')";
+            }
+            query += "),";
+
+            query += "(2, false, 2, -2, 2, -2, 2, -2, 2, -2, 2.0f, 2.0, Date('2025-02-02'), Datetime('2025-02-02T00:00:00Z'), Timestamp('2025-02-02T00:00:00Z'), '2', '2'u, Date32('2025-02-02'), Datetime64('2025-02-02T00:00:00Z'), Timestamp64('2025-02-02T00:00:00Z'), Interval64('P2D'), Json(@@[2]@@), JsonDocument('[2]'), Yson('[2]'), Decimal('2', 22, 9)";
+
+            if (!IsOlap) {
+                query += ", Interval('P2D'), DyNumber('2'), Uuid('f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc2')";
+            }
+            query += "),";
+
+            query += "(3, true, 3, -3, 3, -3, 3, -3, 3, -3, 3.0f, 3.0, Date('2025-03-03'), Datetime('2025-03-03T00:00:00Z'), Timestamp('2025-03-03T00:00:00Z'), '3', '3'u, Date32('2025-03-03'), Datetime64('2025-03-03T00:00:00Z'), Timestamp64('2025-03-03T00:00:00Z'), Interval64('P3D'), Json(@@[3]@@), JsonDocument('[3]'), Yson('[3]'), Decimal('3', 22, 9)";
+
+            if (!IsOlap) {
+                query += ", Interval('P3D'), DyNumber('3'), Uuid('f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc3')";
+            }
+            query += ")";
+
+            auto result = queryClient.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            TString query = "SELECT ";
+            query += "Key + 3 AS Key";
+            for (const auto& [name, type] : types) {
+                query += std::format(", {}Value", name);
+            }
+            query += " FROM SomeTypes ORDER BY Key;";
+
+            auto batches = ExecuteAndCombineBatches(queryClient, query);
+
+            UNIT_ASSERT_C(batches.size() == 1, "Batches must be exactly one");
+
+            const auto& batch = batches.front();
+            const auto& schema = batch->schema();
+
+            UNIT_ASSERT_C(schema->field(0)->name() == "Key", "Key column must be present");
+            for (size_t i = 0; i < types.size(); ++i) {
+                UNIT_ASSERT_C(schema->field(i + 1)->name() == std::format("{}Value", types[i].first), "Column " << types[i].first << "Value must be present");
+            }
+
+            auto serializedSchema = NArrow::SerializeSchema(*schema);
+            auto serializedBatch = NArrow::SerializeBatchNoCompression(batch);
+
+            auto bulkResult = tableClient.BulkUpsert("/Root/SomeTypes", NYdb::NTable::EDataFormat::ApacheArrow, serializedBatch, serializedSchema).GetValueSync();
+            UNIT_ASSERT_C(bulkResult.IsSuccess(), bulkResult.GetIssues().ToString());
+
+            std::string selectQuery = "SELECT ";
+            selectQuery += "Key";
+            for (const auto& [name, type] : types) {
+                selectQuery += std::format(", {}Value", name);
+            }
+            selectQuery += " FROM SomeTypes ORDER BY Key;";
+
+
+            auto result = queryClient.ExecuteQuery(selectQuery, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            TString expected = "[";
+
+            expected += R"([1u;[%true];[1u];[-1];[1u];[-1];[1u];[-1];[1u];[-1];[1.];[1.];[20089u];[1735689600u];[1735689600000000u];["1"];["1"];[20089];[1735689600];[1735689600000000];[86400000000];["[1]"];["[1]"];["[1]"];["1"])";
+            if (!IsOlap) {
+                expected += R"(;[86400000000];[".1e1"];["f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc1"])";
+            }
+            expected += "];";
+
+            expected += R"([2u;[%false];[2u];[-2];[2u];[-2];[2u];[-2];[2u];[-2];[2.];[2.];[20121u];[1738454400u];[1738454400000000u];["2"];["2"];[20121];[1738454400];[1738454400000000];[172800000000];["[2]"];["[2]"];["[2]"];["2"])";
+            if (!IsOlap) {
+                expected += R"(;[172800000000];[".2e1"];["f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc2"])";
+            }
+            expected += "];";
+
+            expected += R"([3u;[%true];[3u];[-3];[3u];[-3];[3u];[-3];[3u];[-3];[3.];[3.];[20150u];[1740960000u];[1740960000000000u];["3"];["3"];[20150];[1740960000];[1740960000000000];[259200000000];["[3]"];["[3]"];["[3]"];["3"])";
+            if (!IsOlap) {
+                expected += R"(;[259200000000];[".3e1"];["f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc3"])";
+            }
+            expected += "];";
+
+            expected += R"([4u;[%true];[1u];[-1];[1u];[-1];[1u];[-1];[1u];[-1];[1.];[1.];[20089u];[1735689600u];[1735689600000000u];["1"];["1"];[20089];[1735689600];[1735689600000000];[86400000000];["[1]"];["[1]"];["[1]"];["1"])";
+            if (!IsOlap) {
+                expected += R"(;[86400000000];[".1e1"];["f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc1"])";
+            }
+            expected += "];";
+
+            expected += R"([5u;[%false];[2u];[-2];[2u];[-2];[2u];[-2];[2u];[-2];[2.];[2.];[20121u];[1738454400u];[1738454400000000u];["2"];["2"];[20121];[1738454400];[1738454400000000];[172800000000];["[2]"];["[2]"];["[2]"];["2"])";
+            if (!IsOlap) {
+                expected += R"(;[172800000000];[".2e1"];["f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc2"])";
+            }
+            expected += "];";
+
+            expected += R"([6u;[%true];[3u];[-3];[3u];[-3];[3u];[-3];[3u];[-3];[3.];[3.];[20150u];[1740960000u];[1740960000000000u];["3"];["3"];[20150];[1740960000];[1740960000000000];[259200000000];["[3]"];["[3]"];["[3]"];["3"])";
+            if (!IsOlap) {
+                expected += R"(;[259200000000];[".3e1"];["f9d5cc3f-f1dc-4d9c-b97e-766e57ca4cc3"])";
+            }
+            expected += "]]";
+
+            CompareYson(expected, FormatResultSetYson(result.GetResultSet(0)));
         }
     }
 }

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -348,6 +348,10 @@ private:
         if (!ok && allowConvert) {
             ok = NArrow::TArrowToYdbConverter::NeedConversion(type1, type2);
         }
+        if (!ok) {
+            // TODO: SwitchYqlTypeToArrowType(Interval) == arrow::Type::DURATION, but YQL Interval is Int64
+            ok = type1.GetTypeId() == NScheme::NTypeIds::Int64 && type2.GetTypeId() == NScheme::NTypeIds::Interval;
+        }
         return ok;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Important changes:

- `DyNumber` can be arrow::StringArray like `JsonDocument` (string representation from QueryService)
- `Interval` can be arrow::Int64Array and `Timestamp` can be arrow::UInt64Array (YQL physical representation)
- Supported `Uuid` with arrow type: FixedSizeBinary(16)
- Remove `Decimal` from `NeedInplaceConversion` (it does nothing)
- Added a new test: `BulkUpsert` with `arrow::RecordBatch` from `ExecuteQuery("SELECT ...", FORMAT_ARROW)` (it does not work with datashards now: #34156)
...
