### PR TITLE
YQ-5077: WM: Add Workload Manager State to .sys/query_sessions

### DIFF
--- a/ydb/core/kqp/common/events/query.h
+++ b/ydb/core/kqp/common/events/query.h
@@ -15,6 +15,12 @@
 #include <ydb/library/actors/core/event_pb.h>
 #include <ydb/library/actors/core/event_local.h>
 
+#include <memory>
+
+namespace NKikimr::NKqp {
+    struct IWmSessionUpdater;
+}
+
 namespace NKikimr::NKqp::NPrivateEvents {
 
 struct TEvQueryRequestRemote: public TEventPB<TEvQueryRequestRemote, NKikimrKqp::TEvQueryRequest,
@@ -347,6 +353,14 @@ public:
         return UserRequestContext;
     }
 
+    void SetWmSessionUpdater(const std::shared_ptr<IWmSessionUpdater>& wmSessionUpdater) {
+        WmSessionUpdater = wmSessionUpdater;
+    }
+
+    std::shared_ptr<IWmSessionUpdater> GetWmSessionUpdater() const {
+        return WmSessionUpdater;
+    }
+
     void SetProgressStatsPeriod(TDuration progressStatsPeriod) {
         ProgressStatsPeriod = progressStatsPeriod;
     }
@@ -483,6 +497,7 @@ private:
     std::shared_ptr<const NKikimrKqp::TQueryPhysicalGraph> QueryPhysicalGraph;
     i64 Generation = 0;
     bool DisableDefaultTimeout = false;
+    std::shared_ptr<IWmSessionUpdater> WmSessionUpdater;
 };
 
 struct TEvDataQueryStreamPart: public TEventPB<TEvDataQueryStreamPart,

--- a/ydb/core/kqp/common/events/workload_service.h
+++ b/ydb/core/kqp/common/events/workload_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/kqp/common/simple/kqp_event_ids.h>
+
 #include <ydb/core/resource_pools/resource_pool_settings.h>
 #include <ydb/core/scheme/scheme_pathid.h>
 
@@ -10,6 +11,12 @@
 
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 #include <yql/essentials/core/issue/yql_issue.h>
+
+#include <memory>
+
+namespace NKikimr::NKqp {
+    struct IWmSessionUpdater;
+}
 
 namespace NKikimr::NKqp::NWorkload {
 
@@ -24,12 +31,13 @@ struct TEvSubscribeOnPoolChanges : public NActors::TEventLocal<TEvSubscribeOnPoo
 };
 
 struct TEvPlaceRequestIntoPool : public NActors::TEventLocal<TEvPlaceRequestIntoPool, TKqpWorkloadServiceEvents::EvPlaceRequestIntoPool> {
-    TEvPlaceRequestIntoPool(const TString& databaseId, const TString& sessionId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& requestText = "")
+    TEvPlaceRequestIntoPool(const TString& databaseId, const TString& sessionId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& requestText = "", std::shared_ptr<IWmSessionUpdater> wmSessionUpdater = nullptr)
         : DatabaseId(databaseId)
         , SessionId(sessionId)
         , PoolId(poolId)
         , UserToken(userToken)
         , RequestText(requestText)
+        , WmSessionUpdater(wmSessionUpdater)
     {}
 
     const TString DatabaseId;
@@ -37,6 +45,7 @@ struct TEvPlaceRequestIntoPool : public NActors::TEventLocal<TEvPlaceRequestInto
     TString PoolId;  // Can be changed to default pool id
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     const TString RequestText;
+    std::shared_ptr<IWmSessionUpdater> WmSessionUpdater;
 };
 
 struct TEvContinueRequest : public NActors::TEventLocal<TEvContinueRequest, TKqpWorkloadServiceEvents::EvContinueRequest> {

--- a/ydb/core/kqp/common/simple/kqp_event_ids.h
+++ b/ydb/core/kqp/common/simple/kqp_event_ids.h
@@ -198,7 +198,6 @@ struct TKqpWorkloadServiceEvents {
         EvUpdatePoolInfo,
         EvSubscribeOnPoolChanges,
         EvFetchDatabaseResponse,
-        EvUpdateSessionWMState,
     };
 };
 

--- a/ydb/core/kqp/common/simple/kqp_event_ids.h
+++ b/ydb/core/kqp/common/simple/kqp_event_ids.h
@@ -198,6 +198,7 @@ struct TKqpWorkloadServiceEvents {
         EvUpdatePoolInfo,
         EvSubscribeOnPoolChanges,
         EvFetchDatabaseResponse,
+        EvUpdateSessionWMState,
     };
 };
 

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -729,9 +729,9 @@ public:
             }
             LocalSessions->AttachQueryText(sessionInfo, ev->Get()->GetQuery());
             
-            // Pass WMState from session to the event
-            Y_ABORT_UNLESS(sessionInfo->WMState, "WMState must be initialized in session constructor");
-            ev->Get()->SetWmSessionUpdater(sessionInfo->WMState);
+            // Pass WmState from session to the event
+            Y_ABORT_UNLESS(sessionInfo->WmState, "WmState must be initialized in session constructor");
+            ev->Get()->SetWmSessionUpdater(sessionInfo->WmState);
         }
 
         if (!TryFillPoolInfoFromCache(ev, requestId)) {

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -728,6 +728,10 @@ public:
                 return;
             }
             LocalSessions->AttachQueryText(sessionInfo, ev->Get()->GetQuery());
+            
+            // Pass WMState from session to the event
+            Y_ABORT_UNLESS(sessionInfo->WMState, "WMState must be initialized in session constructor");
+            ev->Get()->SetWmSessionUpdater(sessionInfo->WMState);
         }
 
         if (!TryFillPoolInfoFromCache(ev, requestId)) {

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -5,6 +5,7 @@
 #include <ydb/core/kqp/common/kqp.h>
 #include <ydb/core/kqp/common/events/workload_service.h>
 #include <ydb/core/kqp/counters/kqp_counters.h>
+#include <ydb/core/kqp/proxy_service/kqp_session_state.h>
 #include <ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
 #include <ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h>
@@ -73,6 +74,53 @@ public:
     }
 };
 
+class TWmSessionUpdater final : public IWmSessionUpdater {
+public:
+    using EWMState = IWmSessionUpdater::EWMState;
+
+    void SetRequestState(EWMState state, TInstant timestamp) override {
+        const ui64 ts = timestamp.MicroSeconds();
+        
+        if (state == EWMState::PENDING || state == EWMState::DELAYED) {
+            EnterTimeUs.store(ts, std::memory_order_relaxed);
+        } else if (state == EWMState::EXITED) {
+            ExitTimeUs.store(ts, std::memory_order_relaxed);
+        }
+        
+        State.store(state, std::memory_order_release);
+    }
+
+    void SetPoolId(TString poolId) override {
+        TGuard<TAdaptiveLock> guard(PoolIdLock);
+        PoolId = std::move(poolId);
+    }
+    
+    EWMState GetState() const {
+        return State.load(std::memory_order_acquire);
+    }
+
+    TInstant GetEnterTime() const {
+        return TInstant::MicroSeconds(EnterTimeUs.load(std::memory_order_relaxed));
+    }
+
+    TInstant GetExitTime() const {
+        return TInstant::MicroSeconds(ExitTimeUs.load(std::memory_order_relaxed));
+    }
+
+    TString GetPoolId() const {
+        TGuard<TAdaptiveLock> guard(PoolIdLock);
+        return PoolId;
+    }
+
+private:
+    std::atomic<EWMState> State{EWMState::NONE};
+    std::atomic<ui64> EnterTimeUs{0};
+    std::atomic<ui64> ExitTimeUs{0};
+
+    mutable TAdaptiveLock PoolIdLock;
+    TString PoolId;
+};
+
 template<typename TValue>
 struct TProcessResult {
     Ydb::StatusIds::StatusCode YdbStatus;
@@ -110,6 +158,7 @@ struct TKqpSessionInfo {
     TInstant SessionStartedAt;
     TInstant StateChangeAt;
     TInstant QueryStartAt;
+    std::shared_ptr<TWmSessionUpdater> WMState;
 
     ESessionState State = ESessionState::IDLE;
     bool Closing = false;
@@ -145,6 +194,7 @@ struct TKqpSessionInfo {
         , AttachedNodeId(0)
         , PgWire(pgWire)
         , SessionStartedAt(std::move(sessionStartedAt))
+        , WMState(std::make_shared<TWmSessionUpdater>())
     {
     }
 

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -76,14 +76,14 @@ public:
 
 class TWmSessionUpdater final : public IWmSessionUpdater {
 public:
-    using EWMState = IWmSessionUpdater::EWMState;
+    using EWmState = IWmSessionUpdater::EWmState;
 
-    void SetRequestState(EWMState state, TInstant timestamp) override {
+    void SetRequestState(EWmState state, TInstant timestamp) override {
         const ui64 ts = timestamp.MicroSeconds();
         
-        if (state == EWMState::PENDING || state == EWMState::DELAYED) {
+        if (state == EWmState::PENDING || state == EWmState::DELAYED) {
             EnterTimeUs.store(ts, std::memory_order_relaxed);
-        } else if (state == EWMState::EXITED) {
+        } else if (state == EWmState::EXITED) {
             ExitTimeUs.store(ts, std::memory_order_relaxed);
         }
         
@@ -95,7 +95,7 @@ public:
         PoolId = std::move(poolId);
     }
     
-    EWMState GetState() const {
+    EWmState GetState() const {
         return State.load(std::memory_order_acquire);
     }
 
@@ -113,7 +113,7 @@ public:
     }
 
 private:
-    std::atomic<EWMState> State{EWMState::NONE};
+    std::atomic<EWmState> State{EWmState::NONE};
     std::atomic<ui64> EnterTimeUs{0};
     std::atomic<ui64> ExitTimeUs{0};
 
@@ -158,7 +158,7 @@ struct TKqpSessionInfo {
     TInstant SessionStartedAt;
     TInstant StateChangeAt;
     TInstant QueryStartAt;
-    std::shared_ptr<TWmSessionUpdater> WMState;
+    std::shared_ptr<TWmSessionUpdater> WmState;
 
     ESessionState State = ESessionState::IDLE;
     bool Closing = false;
@@ -194,7 +194,7 @@ struct TKqpSessionInfo {
         , AttachedNodeId(0)
         , PgWire(pgWire)
         , SessionStartedAt(std::move(sessionStartedAt))
-        , WMState(std::make_shared<TWmSessionUpdater>())
+        , WmState(std::make_shared<TWmSessionUpdater>())
     {
     }
 

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -80,13 +80,13 @@ public:
 
     void SetRequestState(EWmState state, TInstant timestamp) override {
         const ui64 ts = timestamp.MicroSeconds();
-        
+
         if (state == EWmState::PENDING || state == EWmState::DELAYED) {
-            EnterTimeUs.store(ts, std::memory_order_relaxed);
+            EnterTimeUs.store(ts, std::memory_order_release);
         } else if (state == EWmState::EXITED) {
-            ExitTimeUs.store(ts, std::memory_order_relaxed);
+            ExitTimeUs.store(ts, std::memory_order_release);
         }
-        
+
         State.store(state, std::memory_order_release);
     }
 
@@ -100,16 +100,26 @@ public:
     }
 
     TInstant GetEnterTime() const {
-        return TInstant::MicroSeconds(EnterTimeUs.load(std::memory_order_relaxed));
+        return TInstant::MicroSeconds(EnterTimeUs.load(std::memory_order_acquire));
     }
 
     TInstant GetExitTime() const {
-        return TInstant::MicroSeconds(ExitTimeUs.load(std::memory_order_relaxed));
+        return TInstant::MicroSeconds(ExitTimeUs.load(std::memory_order_acquire));
     }
 
     TString GetPoolId() const {
         TGuard<TAdaptiveLock> guard(PoolIdLock);
         return PoolId;
+    }
+
+    void Clean() {
+        EnterTimeUs.store(0, std::memory_order_release);
+        ExitTimeUs.store(0, std::memory_order_release);
+        {
+            TGuard<TAdaptiveLock> guard(PoolIdLock);
+            PoolId.clear();
+        }
+        State.store(EWmState::NONE, std::memory_order_release);
     }
 
 private:
@@ -233,6 +243,7 @@ public:
         auto curNow = TInstant::Now();
         const_cast<TKqpSessionInfo*>(sessionInfo)->QueryStartAt = curNow;
         const_cast<TKqpSessionInfo*>(sessionInfo)->StateChangeAt = curNow;
+        const_cast<TKqpSessionInfo*>(sessionInfo)->WmState->Clean();
     }
 
     void DetachQueryText(const TKqpSessionInfo* sessionInfo) {

--- a/ydb/core/kqp/proxy_service/kqp_session_info.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_session_info.cpp
@@ -75,6 +75,48 @@ void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFiel
     if (fieldsMap.NeedField(VSessions::UserSID::ColumnId)) {  // 14
         proto->SetUserSID(ClientSID);
     }
+
+    if (fieldsMap.NeedField(VSessions::WMPoolId::ColumnId)) { // 17
+        if (WMState) {
+            proto->SetWMPoolId(WMState->GetPoolId());
+        }
+    }
+
+    if (fieldsMap.NeedField(VSessions::WMState::ColumnId)) { // 18
+        if (WMState) {
+            using EWMState = IWmSessionUpdater::EWMState;
+            switch(WMState->GetState()) {
+                case EWMState::NONE: {
+                    proto->SetWMState("NONE");
+                    break;
+                }
+                case EWMState::PENDING: {
+                    proto->SetWMState("PENDING");
+                    break;
+                }
+                case EWMState::DELAYED: {
+                    proto->SetWMState("DELAYED");
+                    break;
+                }
+                case EWMState::EXITED: {
+                    proto->SetWMState("EXITED");
+                    break;
+                }
+            }
+        }
+    }
+
+    if (fieldsMap.NeedField(VSessions::WMEnterTime::ColumnId)) { // 19
+        if (WMState) {
+            proto->SetWMEnterTime(WMState->GetEnterTime().MicroSeconds());
+        }
+    }
+
+    if (fieldsMap.NeedField(VSessions::WMExitTime::ColumnId)) { // 20
+        if (WMState) {
+            proto->SetWMExitTime(WMState->GetExitTime().MicroSeconds());
+        }
+    }
 }
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/proxy_service/kqp_session_info.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_session_info.cpp
@@ -76,45 +76,45 @@ void TKqpSessionInfo::SerializeTo(::NKikimrKqp::TSessionInfo* proto, const TFiel
         proto->SetUserSID(ClientSID);
     }
 
-    if (fieldsMap.NeedField(VSessions::WMPoolId::ColumnId)) { // 17
-        if (WMState) {
-            proto->SetWMPoolId(WMState->GetPoolId());
+    if (fieldsMap.NeedField(VSessions::WmPoolId::ColumnId)) { // 17
+        if (WmState) {
+            proto->SetWmPoolId(WmState->GetPoolId());
         }
     }
 
-    if (fieldsMap.NeedField(VSessions::WMState::ColumnId)) { // 18
-        if (WMState) {
-            using EWMState = IWmSessionUpdater::EWMState;
-            switch(WMState->GetState()) {
-                case EWMState::NONE: {
-                    proto->SetWMState("NONE");
+    if (fieldsMap.NeedField(VSessions::WmState::ColumnId)) { // 18
+        if (WmState) {
+            using EWmState = IWmSessionUpdater::EWmState;
+            switch(WmState->GetState()) {
+                case EWmState::NONE: {
+                    proto->SetWmState("NONE");
                     break;
                 }
-                case EWMState::PENDING: {
-                    proto->SetWMState("PENDING");
+                case EWmState::PENDING: {
+                    proto->SetWmState("PENDING");
                     break;
                 }
-                case EWMState::DELAYED: {
-                    proto->SetWMState("DELAYED");
+                case EWmState::DELAYED: {
+                    proto->SetWmState("DELAYED");
                     break;
                 }
-                case EWMState::EXITED: {
-                    proto->SetWMState("EXITED");
+                case EWmState::EXITED: {
+                    proto->SetWmState("EXITED");
                     break;
                 }
             }
         }
     }
 
-    if (fieldsMap.NeedField(VSessions::WMEnterTime::ColumnId)) { // 19
-        if (WMState) {
-            proto->SetWMEnterTime(WMState->GetEnterTime().MicroSeconds());
+    if (fieldsMap.NeedField(VSessions::WmEnterTime::ColumnId)) { // 19
+        if (WmState) {
+            proto->SetWmEnterTime(WmState->GetEnterTime().MicroSeconds());
         }
     }
 
-    if (fieldsMap.NeedField(VSessions::WMExitTime::ColumnId)) { // 20
-        if (WMState) {
-            proto->SetWMExitTime(WMState->GetExitTime().MicroSeconds());
+    if (fieldsMap.NeedField(VSessions::WmExitTime::ColumnId)) { // 20
+        if (WmState) {
+            proto->SetWmExitTime(WmState->GetExitTime().MicroSeconds());
         }
     }
 }

--- a/ydb/core/kqp/proxy_service/kqp_session_state.h
+++ b/ydb/core/kqp/proxy_service/kqp_session_state.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <util/datetime/base.h>
+#include <util/generic/string.h>
+
+namespace NKikimr::NKqp {
+
+struct IWmSessionUpdater {
+    enum EWMState : ui32 {
+        NONE = 0,      // Request is not in workload manager queue
+        PENDING = 1,   // Request is in local pending queue, waiting to be delayed or started
+        DELAYED = 2,   // Request is in delayed_requests table, waiting for available slot
+        EXITED = 3     // Request has exited WM queue and started execution
+    };
+
+    virtual ~IWmSessionUpdater() = default;
+
+    virtual void SetRequestState(EWMState state, TInstant timestamp) = 0;
+    virtual void SetPoolId(TString poolId) = 0;
+};
+
+}

--- a/ydb/core/kqp/proxy_service/kqp_session_state.h
+++ b/ydb/core/kqp/proxy_service/kqp_session_state.h
@@ -14,7 +14,7 @@ struct IWmSessionUpdater {
         NONE = 0,      // Request is not in workload manager queue
         PENDING = 1,   // Request is in local pending queue, waiting to be delayed or started
         DELAYED = 2,   // Request is in delayed_requests table, waiting for available slot
-        EXITED = 3     // Request has exited WM queue and started execution
+        EXITED = 3     // Request has exited from WM
     };
 
     virtual ~IWmSessionUpdater() = default;

--- a/ydb/core/kqp/proxy_service/kqp_session_state.h
+++ b/ydb/core/kqp/proxy_service/kqp_session_state.h
@@ -5,8 +5,12 @@
 
 namespace NKikimr::NKqp {
 
+///
+/// Interface for updating the execution state of a KQP session within the Workload Manager (WM).
+/// Used to track request progression through WM queues (pending, delayed) and execution start.
+///   
 struct IWmSessionUpdater {
-    enum EWMState : ui32 {
+    enum EWmState : ui32 {
         NONE = 0,      // Request is not in workload manager queue
         PENDING = 1,   // Request is in local pending queue, waiting to be delayed or started
         DELAYED = 2,   // Request is in delayed_requests table, waiting for available slot
@@ -15,7 +19,7 @@ struct IWmSessionUpdater {
 
     virtual ~IWmSessionUpdater() = default;
 
-    virtual void SetRequestState(EWMState state, TInstant timestamp) = 0;
+    virtual void SetRequestState(EWmState state, TInstant timestamp) = 0;
     virtual void SetPoolId(TString poolId) = 0;
 };
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -372,7 +372,8 @@ public:
             SessionId,
             QueryState->UserRequestContext->PoolId,
             QueryState->UserToken,
-            QueryState->GetQuery()
+            QueryState->GetQuery(),
+            QueryState->RequestEv->GetWmSessionUpdater()
         ), IEventHandle::FlagTrackDelivery);
 
         QueryState->PoolHandlerActor = MakeKqpWorkloadServiceId(SelfId().NodeId());

--- a/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
@@ -274,7 +274,7 @@ private:
         // Notify proxy that request entered WM queue (Pending state) via shared interface
         if (wmSessionUpdater) {
             wmSessionUpdater->SetPoolId(PoolId);
-            wmSessionUpdater->SetRequestState(IWmSessionUpdater::EWMState::PENDING, TInstant::Now());
+            wmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::PENDING, TInstant::Now());
         }
 
         UpdatePoolConfig(ev->Get()->PoolConfig);
@@ -951,7 +951,7 @@ private:
 
                     // Notify proxy that request exited WM queue (started running) via shared interface
                     if (request->WmSessionUpdater) {
-                        request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWMState::EXITED, TInstant::Now());
+                        request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::EXITED, TInstant::Now());
                     }
                 } else {
                     // Request was dropped due to lease expiration
@@ -1040,7 +1040,7 @@ private:
 
             // Notify proxy that request moved to Delayed state via shared interface
             if (request->WmSessionUpdater) {
-                request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWMState::DELAYED, TInstant::Now());
+                request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::DELAYED, TInstant::Now());
             }
         }
     }

--- a/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
@@ -270,11 +270,9 @@ private:
         Counters.LocalDelayedRequests->Inc();
 
         LOG_REQ_PENDING(PoolId, request);
-        
-        // Notify proxy that request entered WM queue (Pending state) via shared interface
+
         if (wmSessionUpdater) {
             wmSessionUpdater->SetPoolId(PoolId);
-            wmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::PENDING, TInstant::Now());
         }
 
         UpdatePoolConfig(ev->Get()->PoolConfig);
@@ -372,6 +370,10 @@ public:
 
     void ReplyContinue(TRequest* request, Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS, const NYql::TIssues& issues = {}) {
         this->Send(request->WorkerActorId, new TEvContinueRequest(status, PoolId, PoolConfig, issues));
+        
+        if (request->WmSessionUpdater) {
+            request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::EXITED, TInstant::Now());
+        }
 
         if (status == Ydb::StatusIds::SUCCESS) {
             LocalInFlight++;
@@ -719,6 +721,11 @@ protected:
             << ", queue size: " << PendingRequests.size()
         );
 
+        // Notify proxy that request entered WM pending queue via shared interface
+        if (request->WmSessionUpdater) {
+            request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::PENDING, TInstant::Now());
+        }
+
         if (!PreparingFinished) {
             this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvPrepareTablesRequest(DatabaseId, PoolId));
         }
@@ -869,6 +876,10 @@ private:
         TRequest* request = GetRequestSafe(sessionId);
         if (request) {
             LOG_REQ_QUEUED(PoolId, request, GlobalState.DelayedRequests);
+            // Notify proxy that request moved to Delayed state via shared interface
+            if (request->WmSessionUpdater) {
+                request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::DELAYED, TInstant::Now());
+            }
         } else {
             LOG_D("successfully delayed request, session id: " << sessionId);
         }
@@ -948,11 +959,6 @@ private:
                     GlobalState.RunningRequests++;
                     FifoCounters.GlobalInFly->Inc();
                     ReplyContinue(request);
-
-                    // Notify proxy that request exited WM queue (started running) via shared interface
-                    if (request->WmSessionUpdater) {
-                        request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::EXITED, TInstant::Now());
-                    }
                 } else {
                     // Request was dropped due to lease expiration
                     PendingRequests.emplace_front(request->SessionId);
@@ -1037,11 +1043,6 @@ private:
             this->Register(CreateDelayRequestActor(this->SelfId(), DatabaseId, PoolId, sessionId, request->StartTime, GetWaitDeadline(request->StartTime), LEASE_DURATION, Counters.CountersSubgroup));
             DelayedRequests.emplace_back(sessionId);
             request->CleanupRequired = true;
-
-            // Notify proxy that request moved to Delayed state via shared interface
-            if (request->WmSessionUpdater) {
-                request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::DELAYED, TInstant::Now());
-            }
         }
     }
 

--- a/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
@@ -4,6 +4,7 @@
 
 #include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/kqp/proxy_service/kqp_session_state.h>
 #include <ydb/core/kqp/workload_service/common/events.h>
 #include <ydb/core/kqp/workload_service/common/helpers.h>
 #include <ydb/core/kqp/workload_service/tables/table_queries.h>
@@ -106,10 +107,11 @@ protected:
             Canceling   // after TEvCancelRequest
         };
 
-        TRequest(const TActorId& workerActorId, const TString& sessionId, const TString& requestText = "")
+        TRequest(const TActorId& workerActorId, const TString& sessionId, const TString& requestText = "", std::shared_ptr<IWmSessionUpdater> wmSessionUpdater = nullptr)
             : WorkerActorId(workerActorId)
             , SessionId(sessionId)
             , SplittedRequestText(GetChunks(requestText))
+            , WmSessionUpdater(wmSessionUpdater)
         {}
 
         std::vector<TString> GetChunks(const TString& requestText, size_t chunkSize = SQL_TEXT_MAX_SIZE) const {
@@ -171,6 +173,7 @@ protected:
         const std::vector<TString> SplittedRequestText;
         const TInstant StartTime = TInstant::Now();
         TInstant ContinueTime;
+        std::shared_ptr<IWmSessionUpdater> WmSessionUpdater;
 
         EState State = EState::Pending;
         bool Started = false;  // after TEvContinueRequest success
@@ -244,6 +247,7 @@ private:
         auto event = std::move(ev->Get()->Event);
         const TString& sessionId = event->Get()->SessionId;
         const TString& requestText = event->Get()->RequestText;
+        auto wmSessionUpdater = event->Get()->WmSessionUpdater;
         this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvPlaceRequestIntoPoolResponse(DatabaseId, PoolId, sessionId));
 
         const TActorId& workerActorId = event->Sender;
@@ -262,10 +266,16 @@ private:
             this->Schedule(cancelAfter, new TEvPrivate::TEvCancelRequest(sessionId));
         }
 
-        TRequest* request = &LocalSessions.insert({sessionId, TRequest(workerActorId, sessionId, requestText)}).first->second;
+        TRequest* request = &LocalSessions.insert({sessionId, TRequest(workerActorId, sessionId, requestText, wmSessionUpdater)}).first->second;
         Counters.LocalDelayedRequests->Inc();
 
         LOG_REQ_PENDING(PoolId, request);
+        
+        // Notify proxy that request entered WM queue (Pending state) via shared interface
+        if (wmSessionUpdater) {
+            wmSessionUpdater->SetPoolId(PoolId);
+            wmSessionUpdater->SetRequestState(IWmSessionUpdater::EWMState::PENDING, TInstant::Now());
+        }
 
         UpdatePoolConfig(ev->Get()->PoolConfig);
         UpdateSchemeboardSubscription(ev->Get()->PathId);
@@ -938,8 +948,13 @@ private:
                     GlobalState.RunningRequests++;
                     FifoCounters.GlobalInFly->Inc();
                     ReplyContinue(request);
+
+                    // Notify proxy that request exited WM queue (started running) via shared interface
+                    if (request->WmSessionUpdater) {
+                        request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWMState::EXITED, TInstant::Now());
+                    }
                 } else {
-                    // Request was dropped due to lease expiration 
+                    // Request was dropped due to lease expiration
                     PendingRequests.emplace_front(request->SessionId);
                     FifoCounters.PendingRequestsCount->Inc();
                 }
@@ -1022,6 +1037,11 @@ private:
             this->Register(CreateDelayRequestActor(this->SelfId(), DatabaseId, PoolId, sessionId, request->StartTime, GetWaitDeadline(request->StartTime), LEASE_DURATION, Counters.CountersSubgroup));
             DelayedRequests.emplace_back(sessionId);
             request->CleanupRequired = true;
+
+            // Notify proxy that request moved to Delayed state via shared interface
+            if (request->WmSessionUpdater) {
+                request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWMState::DELAYED, TInstant::Now());
+            }
         }
     }
 

--- a/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/pool_handlers_actors.cpp
@@ -372,7 +372,7 @@ public:
         this->Send(request->WorkerActorId, new TEvContinueRequest(status, PoolId, PoolConfig, issues));
         
         if (request->WmSessionUpdater) {
-            request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::EXITED, TInstant::Now());
+            request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::EXITED, TActivationContext::Now());
         }
 
         if (status == Ydb::StatusIds::SUCCESS) {
@@ -723,7 +723,7 @@ protected:
 
         // Notify proxy that request entered WM pending queue via shared interface
         if (request->WmSessionUpdater) {
-            request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::PENDING, TInstant::Now());
+            request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::PENDING, TActivationContext::Now());
         }
 
         if (!PreparingFinished) {
@@ -878,7 +878,7 @@ private:
             LOG_REQ_QUEUED(PoolId, request, GlobalState.DelayedRequests);
             // Notify proxy that request moved to Delayed state via shared interface
             if (request->WmSessionUpdater) {
-                request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::DELAYED, TInstant::Now());
+                request->WmSessionUpdater->SetRequestState(IWmSessionUpdater::EWmState::DELAYED, TActivationContext::Now());
             }
         } else {
             LOG_D("successfully delayed request, session id: " << sessionId);

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -496,7 +496,13 @@ public:
 
     // Scheme queries helpers
     NYdb::NScheme::TSchemeClient GetSchemeClient() const override {
+        Y_ENSURE(YdbDriver_);
         return NYdb::NScheme::TSchemeClient(*YdbDriver_);
+    }
+
+    NYdb::NTable::TTableClient GetTableClient(NYdb::NTable::TClientSettings settings) const override {
+        Y_ENSURE(YdbDriver_);
+        return NYdb::NTable::TTableClient(*YdbDriver_, settings.UseQueryCache(false));
     }
 
     void ExecuteSchemeQuery(const TString& query, NYdb::EStatus expectedStatus = NYdb::EStatus::SUCCESS, const TString& expectedMessage = "") const override {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -13,6 +13,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
 
 #include <ydb/core/protos/workload_manager_config.pb.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
 
 namespace NKikimr::NKqp::NWorkload {
@@ -104,6 +105,9 @@ class IYdbSetup : public TThrRefBase {
 public:
     // Cluster helpers
     virtual void UpdateNodeCpuInfo(double usage, ui32 threads, ui64 nodeIndex = 0) = 0;
+
+    virtual NYdb::NTable::TTableClient GetTableClient(
+        NYdb::NTable::TClientSettings settings = NYdb::NTable::TClientSettings()) const = 0;
 
     // Scheme queries helpers
     virtual NYdb::NScheme::TSchemeClient GetSchemeClient() const = 0;

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
@@ -12,10 +12,6 @@ using namespace NActors;
 // Interceptor actor that sits between Pool Handler and KQP Proxy
 class TKqpProxyInterceptor : public TActor<TKqpProxyInterceptor> {
 public:
-    // Note: TEvUpdateSessionWMState has been removed. WM state is now updated
-    // directly through shared IWmSessionUpdater interface, not via events.
-    // This interceptor now only handles cancel requests.
-
     TKqpProxyInterceptor(TActorId realKqpProxy)
         : TActor(&TKqpProxyInterceptor::StateFunc)
         , RealKqpProxy(realKqpProxy)
@@ -54,16 +50,16 @@ R GetFieldFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex, TFetchFunc&& 
     return fnc(parser);
 }
 
-TString GetWMStateFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
+TString GetWmStateFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
     return GetFieldFromResultSet<TString>(rs, rowIndex, [](NYdb::TResultSetParser& parser) {
-        auto opt = parser.ColumnParser("WMState").GetOptionalUtf8();
+        auto opt = parser.ColumnParser("WmState").GetOptionalUtf8();
         return opt ? TString(*opt) : TString();
     });
 }
 
 TString GetWMPoolIdFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
     return GetFieldFromResultSet<TString>(rs, rowIndex, [](NYdb::TResultSetParser& parser) {
-        auto opt = parser.ColumnParser("WMPoolId").GetOptionalUtf8();
+        auto opt = parser.ColumnParser("WmPoolId").GetOptionalUtf8();
         return opt ? TString(*opt) : TString();
     });
 }
@@ -71,8 +67,8 @@ TString GetWMPoolIdFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
 }  // anonymous namespace
 
 Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
-    Y_UNIT_TEST(TestWMStateNone) {
-        // Test that queries not using workload manager have WMState=0 (NONE)
+    Y_UNIT_TEST(TestWmStateNone) {
+        // Test that queries not using workload manager have WmState=0 (NONE)
         auto ydb = TYdbSetupSettings()
             .EnableResourcePools(false)  // Disable WM
             .Create();
@@ -95,7 +91,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
 
         // Query .sys/query_sessions while query is running
         auto sessionsResult = ydb->ExecuteQuery(R"(
-            SELECT SessionId, WMPoolId, WMState
+            SELECT SessionId, WMPoolId, WmState
             FROM `.sys/query_sessions`
             WHERE State = 'EXECUTING'
         )");
@@ -105,9 +101,9 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
 
         auto rs = sessionsResult.GetResultSet(0);
         
-        // Verify WMState is NONE (0)
-        auto wmState = GetWMStateFromResultSet(rs, 0);
-        UNIT_ASSERT_VALUES_EQUAL_C(wmState, "NONE", "Expected WMState=0 (NONE) for query without WM");
+        // Verify WmState is NONE (0)
+        auto wmState = GetWmStateFromResultSet(rs, 0);
+        UNIT_ASSERT_VALUES_EQUAL_C(wmState, "NONE", "Expected WmState=0 (NONE) for query without WM");
         
         // Verify WMPoolId is empty
         TString poolId = GetWMPoolIdFromResultSet(rs, 0);
@@ -117,7 +113,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         TSampleQueries::TSelect42::CheckResult(hangingRequest.GetResult());
     }
 
-    Y_UNIT_TEST(TestWMStateInterception) {
+    Y_UNIT_TEST(TestWmStateInterception) {
         // Test intercepting WM state updates between Pool Handler and KQP Proxy
         auto ydb = TYdbSetupSettings()
             .ConcurrentQueryLimit(2)
@@ -158,7 +154,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
     }
 
-    Y_UNIT_TEST(TestWMStateTransitions) {
+    Y_UNIT_TEST(TestWmStateTransitions) {
         // Test that we can observe all WM state transitions
         auto ydb = TYdbSetupSettings()
             .ConcurrentQueryLimit(1)  // Force queueing
@@ -186,7 +182,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         
         // Query sessions to verify states
         auto sessionsResult = ydb->ExecuteQuery(R"(
-            SELECT SessionId, WMPoolId, WMState, State
+            SELECT SessionId, WMPoolId, WmState, State
             FROM `.sys/query_sessions`
             WHERE State = 'EXECUTING' OR State = 'PENDING'
             ORDER BY StartTime

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
@@ -1,0 +1,213 @@
+#include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+using namespace NWorkload;
+using namespace NYdb;
+using namespace NActors;
+
+// Interceptor actor that sits between Pool Handler and KQP Proxy
+class TKqpProxyInterceptor : public TActor<TKqpProxyInterceptor> {
+public:
+    // Note: TEvUpdateSessionWMState has been removed. WM state is now updated
+    // directly through shared IWmSessionUpdater interface, not via events.
+    // This interceptor now only handles cancel requests.
+
+    TKqpProxyInterceptor(TActorId realKqpProxy)
+        : TActor(&TKqpProxyInterceptor::StateFunc)
+        , RealKqpProxy(realKqpProxy)
+    {}
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvKqp::TEvCancelQueryRequest, Handle);
+        cFunc(TEvents::TEvPoison::EventType, PassAway);
+    )
+
+    void Handle(TEvKqp::TEvCancelQueryRequest::TPtr& ev) {
+        auto* msg = ev->Get();
+        
+        Cerr << "=== Intercepted Cancel Request ===" << Endl;
+        Cerr << "  SessionId: " << msg->Record.GetRequest().GetSessionId() << Endl;
+        
+        // Forward to real KQP Proxy
+        Send(RealKqpProxy, ev->Release().Release());
+    }
+
+private:
+    TActorId RealKqpProxy;
+    std::vector<TInterceptedEvent> InterceptedEvents;
+};
+
+// Helper to parse fields from result set
+template<typename R, typename TFetchFunc>
+R GetFieldFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex, TFetchFunc&& fnc) {
+    NYdb::TResultSetParser parser(rs);
+    parser.TryNextRow();
+
+    for (size_t i = 0; i < rowIndex; ++i) {
+        parser.TryNextRow();
+    }
+
+    return fnc(parser);
+}
+
+TString GetWMStateFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
+    return GetFieldFromResultSet<TString>(rs, rowIndex, [](NYdb::TResultSetParser& parser) {
+        auto opt = parser.ColumnParser("WMState").GetOptionalUtf8();
+        return opt ? TString(*opt) : TString();
+    });
+}
+
+TString GetWMPoolIdFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
+    return GetFieldFromResultSet<TString>(rs, rowIndex, [](NYdb::TResultSetParser& parser) {
+        auto opt = parser.ColumnParser("WMPoolId").GetOptionalUtf8();
+        return opt ? TString(*opt) : TString();
+    });
+}
+
+}  // anonymous namespace
+
+Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
+    Y_UNIT_TEST(TestWMStateNone) {
+        // Test that queries not using workload manager have WMState=0 (NONE)
+        auto ydb = TYdbSetupSettings()
+            .EnableResourcePools(false)  // Disable WM
+            .Create();
+
+        auto runtime = ydb->GetRuntime();
+        auto nodeId = runtime->GetNodeId(0);
+        auto realKqpProxy = MakeKqpProxyID(nodeId);
+
+        auto interceptor = runtime->Register(new TKqpProxyInterceptor(realKqpProxy));
+        runtime->RegisterService(MakeKqpProxyID(nodeId), interceptor);
+
+
+        // Start a query without WM
+        auto hangingRequest = ydb->ExecuteQueryAsync(
+            TSampleQueries::TSelect42::Query,
+            TQueryRunnerSettings().HangUpDuringExecution(true)
+        );
+
+        ydb->WaitQueryExecution(hangingRequest);
+
+        // Query .sys/query_sessions while query is running
+        auto sessionsResult = ydb->ExecuteQuery(R"(
+            SELECT SessionId, WMPoolId, WMState
+            FROM `.sys/query_sessions`
+            WHERE State = 'EXECUTING'
+        )");
+
+        UNIT_ASSERT_VALUES_EQUAL_C(sessionsResult.GetStatus(), NYdb::EStatus::SUCCESS, sessionsResult.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL(sessionsResult.GetResultSets().size(), 1);
+
+        auto rs = sessionsResult.GetResultSet(0);
+        
+        // Verify WMState is NONE (0)
+        auto wmState = GetWMStateFromResultSet(rs, 0);
+        UNIT_ASSERT_VALUES_EQUAL_C(wmState, "NONE", "Expected WMState=0 (NONE) for query without WM");
+        
+        // Verify WMPoolId is empty
+        TString poolId = GetWMPoolIdFromResultSet(rs, 0);
+        UNIT_ASSERT_C(poolId.empty(), "Expected empty WMPoolId for query without WM");
+
+        ydb->ContinueQueryExecution(hangingRequest);
+        TSampleQueries::TSelect42::CheckResult(hangingRequest.GetResult());
+    }
+
+    Y_UNIT_TEST(TestWMStateInterception) {
+        // Test intercepting WM state updates between Pool Handler and KQP Proxy
+        auto ydb = TYdbSetupSettings()
+            .ConcurrentQueryLimit(2)
+            .Create();
+        
+        TTestActorRuntime* runtime = ydb->GetRuntime();
+        ui32 nodeId = runtime->GetNodeId(0);
+        
+        // Get the real KQP Proxy actor ID
+        TActorId realKqpProxy = MakeKqpProxyID(nodeId);
+        
+        // Create and register our interceptor
+        TActorId interceptor = runtime->Register(new TKqpProxyInterceptor(realKqpProxy));
+        
+        // Replace KQP Proxy with our interceptor
+        runtime->RegisterService(MakeKqpProxyID(nodeId), interceptor);
+        
+        Cerr << "=== Test Setup Complete ===" << Endl;
+        Cerr << "  Real KQP Proxy: " << realKqpProxy << Endl;
+        Cerr << "  Interceptor: " << interceptor << Endl;
+        
+        // Create pool and execute query
+        ydb->CreateSamplePoolOn(ydb->GetSettings().GetDedicatedTenantName());
+        
+        Cerr << "=== Executing Query ===" << Endl;
+        auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query);
+        TSampleQueries::TSelect42::CheckResult(result);
+        
+        Cerr << "=== Query Completed ===" << Endl;
+        
+        // Note: In a real test, you would need to access the interceptor actor
+        // to verify the intercepted events. This requires either:
+        // 1. Making the interceptor a singleton with static access
+        // 2. Using a shared data structure
+        // 3. Sending a query message to the interceptor to get its state
+        
+        // For demonstration, we'll just verify the query succeeded
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+    }
+
+    Y_UNIT_TEST(TestWMStateTransitions) {
+        // Test that we can observe all WM state transitions
+        auto ydb = TYdbSetupSettings()
+            .ConcurrentQueryLimit(1)  // Force queueing
+            .QueueSize(5)
+            .Create();
+        
+        ydb->CreateSamplePoolOn(ydb->GetSettings().GetDedicatedTenantName());
+        
+        // Start first query and hang it
+        auto hangingRequest = ydb->ExecuteQueryAsync(
+            TSampleQueries::TSelect42::Query,
+            TQueryRunnerSettings().HangUpDuringExecution(true)
+        );
+        
+        ydb->WaitQueryExecution(hangingRequest);
+        
+        // Start second query - it should be delayed
+        auto delayedRequest = ydb->ExecuteQueryAsync(
+            TSampleQueries::TSelect42::Query,
+            TQueryRunnerSettings().HangUpDuringExecution(true)
+        );
+        
+        // Give it time to enter delayed state
+        Sleep(TDuration::MilliSeconds(500));
+        
+        // Query sessions to verify states
+        auto sessionsResult = ydb->ExecuteQuery(R"(
+            SELECT SessionId, WMPoolId, WMState, State
+            FROM `.sys/query_sessions`
+            WHERE State = 'EXECUTING' OR State = 'PENDING'
+            ORDER BY StartTime
+        )");
+        
+        UNIT_ASSERT_VALUES_EQUAL_C(sessionsResult.GetStatus(), NYdb::EStatus::SUCCESS,
+                                   sessionsResult.GetIssues().ToString());
+        
+        auto rs = sessionsResult.GetResultSet(0);
+        Cerr << "=== Query Sessions ===" << Endl;
+        Cerr << "  Row count: " << rs.RowsCount() << Endl;
+        
+        // Complete the queries
+        ydb->ContinueQueryExecution(hangingRequest);
+        TSampleQueries::TSelect42::CheckResult(hangingRequest.GetResult());
+        
+        ydb->WaitQueryExecution(delayedRequest);
+        ydb->ContinueQueryExecution(delayedRequest);
+        TSampleQueries::TSelect42::CheckResult(delayedRequest.GetResult());
+    }
+
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/kqp/proxy_service/kqp_session_state.h>
 #include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
 
 namespace NKikimr::NKqp {
@@ -9,35 +10,71 @@ using namespace NWorkload;
 using namespace NYdb;
 using namespace NActors;
 
-// Interceptor actor that sits between Pool Handler and KQP Proxy
-class TKqpProxyInterceptor : public TActor<TKqpProxyInterceptor> {
+class TWmSwallowerMock : public IWmSessionUpdater {
 public:
-    TKqpProxyInterceptor(TActorId realKqpProxy)
-        : TActor(&TKqpProxyInterceptor::StateFunc)
-        , RealKqpProxy(realKqpProxy)
+    TWmSwallowerMock() 
     {}
 
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvKqp::TEvCancelQueryRequest, Handle);
-        cFunc(TEvents::TEvPoison::EventType, PassAway);
-    )
+    void SetUpdater(std::shared_ptr<IWmSessionUpdater> inner) {
+        Inner = std::move(inner);
+    }
 
-    void Handle(TEvKqp::TEvCancelQueryRequest::TPtr& ev) {
-        auto* msg = ev->Get();
-        
-        Cerr << "=== Intercepted Cancel Request ===" << Endl;
-        Cerr << "  SessionId: " << msg->Record.GetRequest().GetSessionId() << Endl;
-        
-        // Forward to real KQP Proxy
-        Send(RealKqpProxy, ev->Release().Release());
+    std::shared_ptr<IWmSessionUpdater> GetUpdater() const {
+        return Inner;
+    }
+
+    void SetRequestState(EWmState, TInstant timestamp) override {
+        Cerr << "--- Captured state: at " << timestamp << Endl;
+    }
+
+    void SetPoolId(TString poolId) override {
+        Inner->SetPoolId(poolId);
+        Cerr << "--- Set pool Id " << poolId << Endl;
     }
 
 private:
-    TActorId RealKqpProxy;
-    std::vector<TInterceptedEvent> InterceptedEvents;
+    std::shared_ptr<IWmSessionUpdater> Inner;
 };
 
-// Helper to parse fields from result set
+class TKqpWorkloadProxyActor : public TActorBootstrapped<TKqpWorkloadProxyActor> {
+    TActorId WorkloadServiceId;
+    std::shared_ptr<TWmSwallowerMock> WmSessionUpdaterMock;
+
+public:
+    TKqpWorkloadProxyActor(std::shared_ptr<TWmSwallowerMock> mock)
+        : WmSessionUpdaterMock(mock)
+    {}
+
+    void SetWorkloadServiceId(TActorId realServiceId) {
+        WorkloadServiceId = realServiceId;
+    }
+
+    void Bootstrap(const TActorContext&) {
+        Become(&TKqpWorkloadProxyActor::StateWork);
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NWorkload::TEvPlaceRequestIntoPool, HandlePlaceRequest);
+            default:
+                Send(ev->Forward(WorkloadServiceId));
+        }
+    }
+
+    void HandlePlaceRequest(NWorkload::TEvPlaceRequestIntoPool::TPtr& ev) {
+        auto* msg = ev->Get();
+        WmSessionUpdaterMock->SetUpdater(msg->WmSessionUpdater);
+        
+        auto proxyMsg = new NWorkload::TEvPlaceRequestIntoPool(
+            msg->DatabaseId, msg->SessionId, msg->PoolId,
+            msg->UserToken, msg->RequestText, WmSessionUpdaterMock
+        );
+
+        Send(new IEventHandle(WorkloadServiceId, ev->Sender, proxyMsg));
+    }
+};
+
+/*
 template<typename R, typename TFetchFunc>
 R GetFieldFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex, TFetchFunc&& fnc) {
     NYdb::TResultSetParser parser(rs);
@@ -63,147 +100,39 @@ TString GetWMPoolIdFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
         return opt ? TString(*opt) : TString();
     });
 }
+*/
 
 }  // anonymous namespace
 
 Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
-    Y_UNIT_TEST(TestWmStateNone) {
-        // Test that queries not using workload manager have WmState=0 (NONE)
-        auto ydb = TYdbSetupSettings()
-            .EnableResourcePools(false)  // Disable WM
-            .Create();
-
-        auto runtime = ydb->GetRuntime();
-        auto nodeId = runtime->GetNodeId(0);
-        auto realKqpProxy = MakeKqpProxyID(nodeId);
-
-        auto interceptor = runtime->Register(new TKqpProxyInterceptor(realKqpProxy));
-        runtime->RegisterService(MakeKqpProxyID(nodeId), interceptor);
-
-
-        // Start a query without WM
-        auto hangingRequest = ydb->ExecuteQueryAsync(
-            TSampleQueries::TSelect42::Query,
-            TQueryRunnerSettings().HangUpDuringExecution(true)
-        );
-
-        ydb->WaitQueryExecution(hangingRequest);
-
-        // Query .sys/query_sessions while query is running
-        auto sessionsResult = ydb->ExecuteQuery(R"(
-            SELECT SessionId, WMPoolId, WmState
-            FROM `.sys/query_sessions`
-            WHERE State = 'EXECUTING'
-        )");
-
-        UNIT_ASSERT_VALUES_EQUAL_C(sessionsResult.GetStatus(), NYdb::EStatus::SUCCESS, sessionsResult.GetIssues().ToString());
-        UNIT_ASSERT_VALUES_EQUAL(sessionsResult.GetResultSets().size(), 1);
-
-        auto rs = sessionsResult.GetResultSet(0);
-        
-        // Verify WmState is NONE (0)
-        auto wmState = GetWmStateFromResultSet(rs, 0);
-        UNIT_ASSERT_VALUES_EQUAL_C(wmState, "NONE", "Expected WmState=0 (NONE) for query without WM");
-        
-        // Verify WMPoolId is empty
-        TString poolId = GetWMPoolIdFromResultSet(rs, 0);
-        UNIT_ASSERT_C(poolId.empty(), "Expected empty WMPoolId for query without WM");
-
-        ydb->ContinueQueryExecution(hangingRequest);
-        TSampleQueries::TSelect42::CheckResult(hangingRequest.GetResult());
-    }
-
     Y_UNIT_TEST(TestWmStateInterception) {
-        // Test intercepting WM state updates between Pool Handler and KQP Proxy
         auto ydb = TYdbSetupSettings()
-            .ConcurrentQueryLimit(2)
+            .NodeCount(1)
+            .EnableResourcePools(true)
+            // turn off to reduce "noise" in a log
+            .EnableStreamingQueries(false)
+            .CreateSamplePool(true)
+            .PoolId("my_pool")
             .Create();
-        
-        TTestActorRuntime* runtime = ydb->GetRuntime();
-        ui32 nodeId = runtime->GetNodeId(0);
-        
-        // Get the real KQP Proxy actor ID
-        TActorId realKqpProxy = MakeKqpProxyID(nodeId);
-        
-        // Create and register our interceptor
-        TActorId interceptor = runtime->Register(new TKqpProxyInterceptor(realKqpProxy));
-        
-        // Replace KQP Proxy with our interceptor
-        runtime->RegisterService(MakeKqpProxyID(nodeId), interceptor);
-        
-        Cerr << "=== Test Setup Complete ===" << Endl;
-        Cerr << "  Real KQP Proxy: " << realKqpProxy << Endl;
-        Cerr << "  Interceptor: " << interceptor << Endl;
-        
-        // Create pool and execute query
-        ydb->CreateSamplePoolOn(ydb->GetSettings().GetDedicatedTenantName());
-        
-        Cerr << "=== Executing Query ===" << Endl;
-        auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query);
-        TSampleQueries::TSelect42::CheckResult(result);
-        
-        Cerr << "=== Query Completed ===" << Endl;
-        
-        // Note: In a real test, you would need to access the interceptor actor
-        // to verify the intercepted events. This requires either:
-        // 1. Making the interceptor a singleton with static access
-        // 2. Using a shared data structure
-        // 3. Sending a query message to the interceptor to get its state
-        
-        // For demonstration, we'll just verify the query succeeded
-        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
-    }
 
-    Y_UNIT_TEST(TestWmStateTransitions) {
-        // Test that we can observe all WM state transitions
-        auto ydb = TYdbSetupSettings()
-            .ConcurrentQueryLimit(1)  // Force queueing
-            .QueueSize(5)
-            .Create();
+        auto& runtime = *ydb->GetRuntime();
+        auto workloadServiceId = MakeKqpWorkloadServiceId(runtime.GetNodeId(0));
+        auto mock = std::make_shared<TWmSwallowerMock>();
         
-        ydb->CreateSamplePoolOn(ydb->GetSettings().GetDedicatedTenantName());
+        auto actor = new TKqpWorkloadProxyActor(mock);
+        auto newId = runtime.Register(actor);
+        auto oldId = runtime.RegisterService(workloadServiceId, newId);
         
-        // Start first query and hang it
-        auto hangingRequest = ydb->ExecuteQueryAsync(
-            TSampleQueries::TSelect42::Query,
-            TQueryRunnerSettings().HangUpDuringExecution(true)
-        );
-        
-        ydb->WaitQueryExecution(hangingRequest);
-        
-        // Start second query - it should be delayed
-        auto delayedRequest = ydb->ExecuteQueryAsync(
-            TSampleQueries::TSelect42::Query,
-            TQueryRunnerSettings().HangUpDuringExecution(true)
-        );
-        
-        // Give it time to enter delayed state
-        Sleep(TDuration::MilliSeconds(500));
-        
-        // Query sessions to verify states
-        auto sessionsResult = ydb->ExecuteQuery(R"(
-            SELECT SessionId, WMPoolId, WmState, State
-            FROM `.sys/query_sessions`
-            WHERE State = 'EXECUTING' OR State = 'PENDING'
-            ORDER BY StartTime
-        )");
-        
-        UNIT_ASSERT_VALUES_EQUAL_C(sessionsResult.GetStatus(), NYdb::EStatus::SUCCESS,
-                                   sessionsResult.GetIssues().ToString());
-        
-        auto rs = sessionsResult.GetResultSet(0);
-        Cerr << "=== Query Sessions ===" << Endl;
-        Cerr << "  Row count: " << rs.RowsCount() << Endl;
-        
-        // Complete the queries
-        ydb->ContinueQueryExecution(hangingRequest);
-        TSampleQueries::TSelect42::CheckResult(hangingRequest.GetResult());
-        
-        ydb->WaitQueryExecution(delayedRequest);
-        ydb->ContinueQueryExecution(delayedRequest);
-        TSampleQueries::TSelect42::CheckResult(delayedRequest.GetResult());
-    }
+        actor->SetWorkloadServiceId(oldId);
 
+        auto myPoolId = "my_pool";
+        auto defPool = TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID);
+        auto myPool = TQueryRunnerSettings().PoolId(myPoolId);
+
+        TSampleQueries::TSelect42::CheckResult(
+            ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+
+    }
 }
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
@@ -98,29 +98,34 @@ public:
             SELECT SessionId, WmPoolId, WmState
             FROM `.sys/query_sessions`
             WHERE State = 'EXECUTING'
+            ORDER By WmState
         )");
 
         UNIT_ASSERT_VALUES_EQUAL_C(Result.GetStatus(), NYdb::EStatus::SUCCESS, Result.GetIssues().ToString());
 
         auto rs = Result.GetResultSet(0);
-        Parser = std::make_unique<NYdb::TResultSetParser>(rs);
+        auto parser = std::make_unique<NYdb::TResultSetParser>(rs);
+
+        while (parser->TryNextRow()) {
+            auto wmState = parser->ColumnParser("WmState").GetOptionalUtf8();
+            auto wmPoolId = parser->ColumnParser("WmPoolId").GetOptionalUtf8();
+
+            Results.push_back(Row{.WmPoolId = wmPoolId, .WmState = wmState});
+        }
     }
 
-    size_t TotalRows() const {
-        return Result.GetResultSets().size();
+    Row operator[](size_t index) const {
+        Y_ENSURE(index < Results.size());
+        return Results[index];
     }
 
-    Row Fetch() const {
-        Parser->TryNextRow();
-        auto wmState = Parser->ColumnParser("WmState").GetOptionalUtf8();
-        auto wmPoolId = Parser->ColumnParser("WmPoolId").GetOptionalUtf8();
-
-        return Row{.WmPoolId = wmPoolId, .WmState = wmState};
+    size_t Size() const {
+        return Results.size();
     }
 
 private:
     TQueryRunnerResult Result;
-    std::unique_ptr<NYdb::TResultSetParser> Parser;
+    std::vector<Row> Results;
 };
 
 class TQuerySessionTestFixture {
@@ -168,10 +173,11 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         TSampleQueries::TSelect42::CheckResult(
             f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
 
-        auto r = f.GetReader().Fetch();
+        auto r = f.GetReader();
 
-        UNIT_ASSERT_VALUES_EQUAL(r.WmState, "NONE");
-        UNIT_ASSERT_VALUES_EQUAL(r.WmPoolId, "my_pool");
+        UNIT_ASSERT_VALUES_EQUAL(r.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(r[0].WmState, "NONE");
+        UNIT_ASSERT_VALUES_EQUAL(r[0].WmPoolId, "my_pool");
     }
 
     Y_UNIT_TEST(TestWmStatePending) {
@@ -181,32 +187,38 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         TSampleQueries::TSelect42::CheckResult(
             f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
 
-        auto r = f.GetReader().Fetch();
+        auto r = f.GetReader();
 
-        UNIT_ASSERT_VALUES_EQUAL(r.WmState, "PENDING");
-        UNIT_ASSERT_VALUES_EQUAL(r.WmPoolId, "my_pool");
+        UNIT_ASSERT_VALUES_EQUAL(r.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(r[0].WmState, "PENDING");
+        UNIT_ASSERT_VALUES_EQUAL(r[0].WmPoolId, "my_pool");
     }
 
     Y_UNIT_TEST(TestWmStateDelayed) {
-        TQuerySessionTestFixture f(IWmSessionUpdater::PENDING, "my_pool", 1);
+        TQuerySessionTestFixture f(IWmSessionUpdater::DELAYED, "my_pool", 1);
         auto myPool = TQueryRunnerSettings().PoolId("my_pool");
 
         auto hangingRequest = f.GetYdb()->ExecuteQueryAsync(
-            TSampleQueries::TSelect42::Query,
-            TQueryRunnerSettings().HangUpDuringExecution(true).PoolId("my_pool")
+            "select 121;",
+            myPool.HangUpDuringExecution(true)
         );
 
         f.GetYdb()->WaitQueryExecution(hangingRequest);
 
-        TSampleQueries::TSelect42::CheckResult(
-            f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+        auto delayedRequest = f.GetYdb()->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, myPool);
 
+        f.GetYdb()->WaitPoolState({.DelayedRequests = 1, .RunningRequests = 1});
         f.GetYdb()->ContinueQueryExecution(hangingRequest);
+        f.GetYdb()->WaitQueryExecution(delayedRequest, TDuration::Seconds(5));
 
-        auto r = f.GetReader().Fetch();
+        auto hangingResult = hangingRequest.GetResult();
+        auto delayedResult = delayedRequest.GetResult();
 
-        UNIT_ASSERT_VALUES_EQUAL(r.WmState, "DELAYED");
-        UNIT_ASSERT_VALUES_EQUAL(r.WmPoolId, "my_pool");
+        auto r = f.GetReader();
+
+        UNIT_ASSERT_VALUES_EQUAL(r.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(r[0].WmState, "DELAYED");
+        UNIT_ASSERT_VALUES_EQUAL(r[0].WmPoolId, "my_pool");
     }
 
     Y_UNIT_TEST(TestWmStateExited) {
@@ -216,10 +228,11 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         TSampleQueries::TSelect42::CheckResult(
             f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
 
-        auto r = f.GetReader().Fetch();
+        auto r = f.GetReader();
 
-        UNIT_ASSERT_VALUES_EQUAL(r.WmState, "EXITED");
-        UNIT_ASSERT_VALUES_EQUAL(r.WmPoolId, "my_pool");
+        UNIT_ASSERT_VALUES_EQUAL(r.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(r[0].WmState, "EXITED");
+        UNIT_ASSERT_VALUES_EQUAL(r[0].WmPoolId, "my_pool");
     }
 
 }

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
@@ -10,9 +10,11 @@ using namespace NWorkload;
 using namespace NYdb;
 using namespace NActors;
 
-class TWmSwallowerMock : public IWmSessionUpdater {
+class TWmSessionUpdaterWrapper : public IWmSessionUpdater {
 public:
-    TWmSwallowerMock() 
+    TWmSessionUpdaterWrapper(EWmState finalState, std::shared_ptr<IWmSessionUpdater> inner)
+        : Inner(inner)
+        , FinalState(finalState)
     {}
 
     void SetUpdater(std::shared_ptr<IWmSessionUpdater> inner) {
@@ -23,26 +25,27 @@ public:
         return Inner;
     }
 
-    void SetRequestState(EWmState, TInstant timestamp) override {
-        Cerr << "--- Captured state: at " << timestamp << Endl;
+    void SetRequestState(EWmState state, TInstant timestamp) override {
+        if (state > FinalState) {
+            return;
+        }
+
+        Inner->SetRequestState(state, timestamp);
     }
 
     void SetPoolId(TString poolId) override {
         Inner->SetPoolId(poolId);
-        Cerr << "--- Set pool Id " << poolId << Endl;
     }
 
 private:
     std::shared_ptr<IWmSessionUpdater> Inner;
+    EWmState FinalState;
 };
 
 class TKqpWorkloadProxyActor : public TActorBootstrapped<TKqpWorkloadProxyActor> {
-    TActorId WorkloadServiceId;
-    std::shared_ptr<TWmSwallowerMock> WmSessionUpdaterMock;
-
 public:
-    TKqpWorkloadProxyActor(std::shared_ptr<TWmSwallowerMock> mock)
-        : WmSessionUpdaterMock(mock)
+    TKqpWorkloadProxyActor(IWmSessionUpdater::EWmState finalState)
+        : FinalState(finalState)
     {}
 
     void SetWorkloadServiceId(TActorId realServiceId) {
@@ -63,76 +66,162 @@ public:
 
     void HandlePlaceRequest(NWorkload::TEvPlaceRequestIntoPool::TPtr& ev) {
         auto* msg = ev->Get();
-        WmSessionUpdaterMock->SetUpdater(msg->WmSessionUpdater);
+        auto m = std::make_shared<TWmSessionUpdaterWrapper>(FinalState, msg->WmSessionUpdater);
         
         auto proxyMsg = new NWorkload::TEvPlaceRequestIntoPool(
-            msg->DatabaseId, msg->SessionId, msg->PoolId,
-            msg->UserToken, msg->RequestText, WmSessionUpdaterMock
+            msg->DatabaseId,
+            msg->SessionId,
+            msg->PoolId,
+            msg->UserToken,
+            msg->RequestText,
+            m
         );
 
         Send(new IEventHandle(WorkloadServiceId, ev->Sender, proxyMsg));
     }
+
+private:
+    TActorId WorkloadServiceId;
+    IWmSessionUpdater::EWmState FinalState;
 };
 
-/*
-template<typename R, typename TFetchFunc>
-R GetFieldFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex, TFetchFunc&& fnc) {
-    NYdb::TResultSetParser parser(rs);
-    parser.TryNextRow();
+class TQuerySessionReader {
+public:
+    struct Row {
+        std::optional<std::string> WmPoolId;
+        std::optional<std::string> WmState;
+    };
 
-    for (size_t i = 0; i < rowIndex; ++i) {
-        parser.TryNextRow();
+public:
+    TQuerySessionReader(TIntrusivePtr<IYdbSetup> ydb) {
+        auto Result = ydb->ExecuteQuery(R"(
+            SELECT SessionId, WmPoolId, WmState
+            FROM `.sys/query_sessions`
+            WHERE State = 'EXECUTING'
+        )");
+
+        UNIT_ASSERT_VALUES_EQUAL_C(Result.GetStatus(), NYdb::EStatus::SUCCESS, Result.GetIssues().ToString());
+
+        auto rs = Result.GetResultSet(0);
+        Parser = std::make_unique<NYdb::TResultSetParser>(rs);
     }
 
-    return fnc(parser);
-}
+    size_t TotalRows() const {
+        return Result.GetResultSets().size();
+    }
 
-TString GetWmStateFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
-    return GetFieldFromResultSet<TString>(rs, rowIndex, [](NYdb::TResultSetParser& parser) {
-        auto opt = parser.ColumnParser("WmState").GetOptionalUtf8();
-        return opt ? TString(*opt) : TString();
-    });
-}
+    Row Fetch() const {
+        Parser->TryNextRow();
+        auto wmState = Parser->ColumnParser("WmState").GetOptionalUtf8();
+        auto wmPoolId = Parser->ColumnParser("WmPoolId").GetOptionalUtf8();
 
-TString GetWMPoolIdFromResultSet(const Ydb::ResultSet& rs, size_t rowIndex) {
-    return GetFieldFromResultSet<TString>(rs, rowIndex, [](NYdb::TResultSetParser& parser) {
-        auto opt = parser.ColumnParser("WmPoolId").GetOptionalUtf8();
-        return opt ? TString(*opt) : TString();
-    });
-}
-*/
+        return Row{.WmPoolId = wmPoolId, .WmState = wmState};
+    }
 
-}  // anonymous namespace
+private:
+    TQueryRunnerResult Result;
+    std::unique_ptr<NYdb::TResultSetParser> Parser;
+};
 
-Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
-    Y_UNIT_TEST(TestWmStateInterception) {
-        auto ydb = TYdbSetupSettings()
+class TQuerySessionTestFixture {
+public:
+    TQuerySessionTestFixture(IWmSessionUpdater::EWmState state, const TString myPoolId, size_t limit = 10) {
+        Ydb = TYdbSetupSettings()
             .NodeCount(1)
             .EnableResourcePools(true)
             // turn off to reduce "noise" in a log
             .EnableStreamingQueries(false)
+            .ConcurrentQueryLimit(limit)
             .CreateSamplePool(true)
-            .PoolId("my_pool")
+            .PoolId(myPoolId)
             .Create();
 
-        auto& runtime = *ydb->GetRuntime();
+        auto& runtime = *Ydb->GetRuntime();
         auto workloadServiceId = MakeKqpWorkloadServiceId(runtime.GetNodeId(0));
-        auto mock = std::make_shared<TWmSwallowerMock>();
         
-        auto actor = new TKqpWorkloadProxyActor(mock);
+        auto actor = new TKqpWorkloadProxyActor(state);
         auto newId = runtime.Register(actor);
         auto oldId = runtime.RegisterService(workloadServiceId, newId);
         
         actor->SetWorkloadServiceId(oldId);
+    }
 
-        auto myPoolId = "my_pool";
-        auto defPool = TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID);
-        auto myPool = TQueryRunnerSettings().PoolId(myPoolId);
+    TIntrusivePtr<IYdbSetup> GetYdb() {
+        return Ydb;
+    }
+
+    TQuerySessionReader GetReader() {
+        return TQuerySessionReader(Ydb);
+    }
+
+private:
+    TIntrusivePtr<IYdbSetup> Ydb;
+};
+
+}  // anonymous namespace
+
+Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
+    Y_UNIT_TEST(TestWmStateNone) {
+        TQuerySessionTestFixture f(IWmSessionUpdater::NONE, "my_pool");
+        auto myPool = TQueryRunnerSettings().PoolId("my_pool");
 
         TSampleQueries::TSelect42::CheckResult(
-            ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+            f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
 
+        auto r = f.GetReader().Fetch();
+
+        UNIT_ASSERT_VALUES_EQUAL(r.WmState, "NONE");
+        UNIT_ASSERT_VALUES_EQUAL(r.WmPoolId, "my_pool");
     }
+
+    Y_UNIT_TEST(TestWmStatePending) {
+        TQuerySessionTestFixture f(IWmSessionUpdater::PENDING, "my_pool");
+        auto myPool = TQueryRunnerSettings().PoolId("my_pool");
+
+        TSampleQueries::TSelect42::CheckResult(
+            f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+
+        auto r = f.GetReader().Fetch();
+
+        UNIT_ASSERT_VALUES_EQUAL(r.WmState, "PENDING");
+        UNIT_ASSERT_VALUES_EQUAL(r.WmPoolId, "my_pool");
+    }
+
+    Y_UNIT_TEST(TestWmStateDelayed) {
+        TQuerySessionTestFixture f(IWmSessionUpdater::PENDING, "my_pool", 1);
+        auto myPool = TQueryRunnerSettings().PoolId("my_pool");
+
+        auto hangingRequest = f.GetYdb()->ExecuteQueryAsync(
+            TSampleQueries::TSelect42::Query,
+            TQueryRunnerSettings().HangUpDuringExecution(true).PoolId("my_pool")
+        );
+
+        f.GetYdb()->WaitQueryExecution(hangingRequest);
+
+        TSampleQueries::TSelect42::CheckResult(
+            f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+
+        f.GetYdb()->ContinueQueryExecution(hangingRequest);
+
+        auto r = f.GetReader().Fetch();
+
+        UNIT_ASSERT_VALUES_EQUAL(r.WmState, "DELAYED");
+        UNIT_ASSERT_VALUES_EQUAL(r.WmPoolId, "my_pool");
+    }
+
+    Y_UNIT_TEST(TestWmStateExited) {
+        TQuerySessionTestFixture f(IWmSessionUpdater::EXITED, "my_pool");
+        auto myPool = TQueryRunnerSettings().PoolId("my_pool");
+
+        TSampleQueries::TSelect42::CheckResult(
+            f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+
+        auto r = f.GetReader().Fetch();
+
+        UNIT_ASSERT_VALUES_EQUAL(r.WmState, "EXITED");
+        UNIT_ASSERT_VALUES_EQUAL(r.WmPoolId, "my_pool");
+    }
+
 }
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
@@ -1,6 +1,10 @@
+#include <fmt/format.h>
+
+#include <ydb/core/kqp/common/events/workload_service.h>
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/proxy_service/kqp_session_state.h>
 #include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
 namespace NKikimr::NKqp {
 
@@ -10,6 +14,11 @@ using namespace NWorkload;
 using namespace NYdb;
 using namespace NActors;
 
+///
+/// Wraps the real IWmSessionUpdater and suppresses state transitions beyond
+/// FinalState. This lets a test freeze the WM state visible in
+/// .sys/query_sessions at a chosen level.
+///
 class TWmSessionUpdaterWrapper : public IWmSessionUpdater {
 public:
     TWmSessionUpdaterWrapper(EWmState finalState, std::shared_ptr<IWmSessionUpdater> inner)
@@ -17,19 +26,10 @@ public:
         , FinalState(finalState)
     {}
 
-    void SetUpdater(std::shared_ptr<IWmSessionUpdater> inner) {
-        Inner = std::move(inner);
-    }
-
-    std::shared_ptr<IWmSessionUpdater> GetUpdater() const {
-        return Inner;
-    }
-
     void SetRequestState(EWmState state, TInstant timestamp) override {
         if (state > FinalState) {
             return;
         }
-
         Inner->SetRequestState(state, timestamp);
     }
 
@@ -42,15 +42,101 @@ private:
     EWmState FinalState;
 };
 
-class TKqpWorkloadProxyActor : public TActorBootstrapped<TKqpWorkloadProxyActor> {
+///
+/// A proxy actor assigned to a specific KQP session to intercept its workload events.
+/// It acts as a middleman between the Workload Service and the session actor,
+/// allowing the test to 'freeze' the request flow at the Edge Actor level.
+/// This enables thread-safe inspection of system tables before the session
+/// actually starts its SQL execution.
+///
+class TSessionProxyActor : public TActorBootstrapped<TSessionProxyActor> {
 public:
-    TKqpWorkloadProxyActor(IWmSessionUpdater::EWmState finalState)
-        : FinalState(finalState)
+    TSessionProxyActor(TActorId sessionActorId, TActorId edgeActorId)
+        : SessionActorId(sessionActorId)
+        , EdgeActorId(edgeActorId)
     {}
 
-    void SetWorkloadServiceId(TActorId realServiceId) {
-        WorkloadServiceId = realServiceId;
+    void Bootstrap(const TActorContext&) {
+        Become(&TSessionProxyActor::StateWork);
     }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NWorkload::TEvContinueRequest, HandleContinueRequest);
+            default:
+                Send(ev->Forward(SessionActorId));
+        }
+    }
+
+    void HandleContinueRequest(NWorkload::TEvContinueRequest::TPtr& ev) {
+        senderId = ev->Sender;
+        Send(new IEventHandle(EdgeActorId, SelfId(), ev->Release().Release()));
+        Become(&TSessionProxyActor::StateWait);
+    }
+
+    STFUNC(StateWait) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NWorkload::TEvContinueRequest, HandleRelease);
+            default:
+                Send(ev->Forward(SessionActorId));
+        }
+    }
+
+    void HandleRelease(NWorkload::TEvContinueRequest::TPtr& ev) {
+        Send(new IEventHandle(SessionActorId, senderId, ev->Release().Release()));
+    }
+
+private:
+    TActorId SessionActorId;
+    TActorId EdgeActorId;
+    TActorId senderId;
+};
+
+///
+/// Thread-safe mapping of a query text to an edge actor for interception
+/// Used by the proxy to decide which requests should be 'parked'
+///
+struct TInterceptorRules {
+    // Query Text -> EdgeActor
+    std::unordered_map<TString, TActorId> ActiveRules;
+    std::mutex Lock;
+
+    void Add(TString query, TActorId edge) {
+        std::lock_guard<std::mutex> g(Lock);
+        ActiveRules[query] = edge;
+    }
+
+    std::optional<TActorId> GetEdge(const TString& query) {
+        std::lock_guard<std::mutex> g(Lock);
+        if (auto it = ActiveRules.find(query); it != ActiveRules.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+};
+
+struct TEvIntercepted : public TEventLocal<TEvIntercepted, 101010101> {
+    TActorId SessionActorId;
+
+    explicit TEvIntercepted(TActorId sessionActorId)
+        : SessionActorId(sessionActorId)
+    {}
+};
+
+///
+/// Replaces the real KQP workload service in the actor system.
+///
+class TKqpWorkloadProxyActor : public TActorBootstrapped<TKqpWorkloadProxyActor> {
+public:
+    TKqpWorkloadProxyActor(
+        IWmSessionUpdater::EWmState finalState,
+        TActorId realWorkloadServiceId,
+        std::shared_ptr<TInterceptorRules> rules
+    )
+        : FinalState(finalState)
+        , WorkloadServiceId(realWorkloadServiceId)
+        , Rules(rules)
+    {}
 
     void Bootstrap(const TActorContext&) {
         Become(&TKqpWorkloadProxyActor::StateWork);
@@ -66,25 +152,36 @@ public:
 
     void HandlePlaceRequest(NWorkload::TEvPlaceRequestIntoPool::TPtr& ev) {
         auto* msg = ev->Get();
-        auto m = std::make_shared<TWmSessionUpdaterWrapper>(FinalState, msg->WmSessionUpdater);
-        
-        auto proxyMsg = new NWorkload::TEvPlaceRequestIntoPool(
+        auto wrapper = std::make_shared<TWmSessionUpdaterWrapper>(FinalState, msg->WmSessionUpdater);
+
+        auto* proxyMsg = new NWorkload::TEvPlaceRequestIntoPool(
             msg->DatabaseId,
             msg->SessionId,
             msg->PoolId,
             msg->UserToken,
             msg->RequestText,
-            m
+            wrapper
         );
 
-        Send(new IEventHandle(WorkloadServiceId, ev->Sender, proxyMsg));
+        TActorId senderForWorkload = ev->Sender;
+
+        if (auto edge = Rules->GetEdge(msg->RequestText)) {
+            auto* interceptor = new TSessionProxyActor(ev->Sender, *edge);
+            senderForWorkload = Register(interceptor);
+        }
+
+        Send(new IEventHandle(WorkloadServiceId, senderForWorkload, proxyMsg));
     }
 
 private:
-    TActorId WorkloadServiceId;
     IWmSessionUpdater::EWmState FinalState;
+    TActorId WorkloadServiceId;
+    std::shared_ptr<TInterceptorRules> Rules;
 };
 
+///
+/// Reads .sys/query_sessions for EXECUTING sessions.
+///
 class TQuerySessionReader {
 public:
     struct Row {
@@ -93,17 +190,27 @@ public:
     };
 
 public:
-    TQuerySessionReader(TIntrusivePtr<IYdbSetup> ydb) {
-        auto Result = ydb->ExecuteQuery(R"(
+    TQuerySessionReader(TIntrusivePtr<IYdbSetup> ydb)
+        : Ydb(ydb)
+    {}
+
+    void FetchAll(const TString& query) {
+        using namespace fmt::literals;
+
+        Results.clear();
+        TString q = fmt::format(R"(
             SELECT SessionId, WmPoolId, WmState
             FROM `.sys/query_sessions`
-            WHERE State = 'EXECUTING'
+            WHERE State = 'EXECUTING' and Query = '{query}'
             ORDER By WmState
-        )");
+        )",
+            "query"_a = query
+        );
 
-        UNIT_ASSERT_VALUES_EQUAL_C(Result.GetStatus(), NYdb::EStatus::SUCCESS, Result.GetIssues().ToString());
+        auto result = Ydb->ExecuteQuery(q, TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
 
-        auto rs = Result.GetResultSet(0);
+        auto rs = result.GetResultSet(0);
         auto parser = std::make_unique<NYdb::TResultSetParser>(rs);
 
         while (parser->TryNextRow()) {
@@ -124,13 +231,16 @@ public:
     }
 
 private:
-    TQueryRunnerResult Result;
+    TIntrusivePtr<IYdbSetup> Ydb;
     std::vector<Row> Results;
 };
 
 class TQuerySessionTestFixture {
 public:
-    TQuerySessionTestFixture(IWmSessionUpdater::EWmState state, const TString myPoolId, size_t limit = 10) {
+    TQuerySessionTestFixture(const TString myPoolId, IWmSessionUpdater::EWmState state, size_t limit = 10)
+        : State(state)
+        , Rules(std::make_shared<TInterceptorRules>())
+    {
         Ydb = TYdbSetupSettings()
             .NodeCount(1)
             .EnableResourcePools(true)
@@ -143,98 +253,137 @@ public:
 
         auto& runtime = *Ydb->GetRuntime();
         auto workloadServiceId = MakeKqpWorkloadServiceId(runtime.GetNodeId(0));
-        
-        auto actor = new TKqpWorkloadProxyActor(state);
-        auto newId = runtime.Register(actor);
-        auto oldId = runtime.RegisterService(workloadServiceId, newId);
-        
-        actor->SetWorkloadServiceId(oldId);
+        auto realWorkloadServiceId = runtime.GetLocalServiceId(workloadServiceId);
+        auto proxyActor = new TKqpWorkloadProxyActor(State, realWorkloadServiceId, Rules);
+
+        ProxyActorId = runtime.Register(proxyActor);
+
+        runtime.RegisterService(workloadServiceId, ProxyActorId);
     }
+
+    ~TQuerySessionTestFixture() {
+        if (ProxyActorId && Ydb) {
+            Ydb->GetRuntime()->Send(new IEventHandle(ProxyActorId, TActorId(), new TEvents::TEvPoisonPill()));
+        }
+    }
+
+    TActorId GetProxyId() const { return ProxyActorId; }
 
     TIntrusivePtr<IYdbSetup> GetYdb() {
         return Ydb;
     }
 
-    TQuerySessionReader GetReader() {
-        return TQuerySessionReader(Ydb);
+    TActorId SetupInterceptor(const TString& query) {
+        auto& runtime = *Ydb->GetRuntime();
+        TActorId edgeActor = runtime.AllocateEdgeActor();
+        Rules->Add(query, edgeActor);
+        return edgeActor;
     }
 
 private:
+    IWmSessionUpdater::EWmState State;
     TIntrusivePtr<IYdbSetup> Ydb;
+    TActorId ProxyActorId;
+    std::shared_ptr<TInterceptorRules> Rules;
 };
 
 }  // anonymous namespace
 
 Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
-    Y_UNIT_TEST(TestWmStateNone) {
-        TQuerySessionTestFixture f(IWmSessionUpdater::NONE, "my_pool");
+
+    TQuerySessionReader ReadQuerySessionAfterState(IWmSessionUpdater::EWmState state) {
+        TQuerySessionTestFixture f("my_pool", state);
         auto myPool = TQueryRunnerSettings().PoolId("my_pool");
+        const TString& query = TSampleQueries::TSelect42::Query;
+        TActorId edge = f.SetupInterceptor(query);
+        auto future = f.GetYdb()->ExecuteQueryAsync(query, myPool);
+        auto runtime = f.GetYdb()->GetRuntime();
 
-        TSampleQueries::TSelect42::CheckResult(
-            f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+        // Stop a request before a real execution to prevent read races from a .sys/query_sessions
+        // The request is now 'parked' in the interceptor actor
+        auto ev = runtime->GrabEdgeEvent<NWorkload::TEvContinueRequest>(edge);
 
-        auto r = f.GetReader();
+        TQuerySessionReader reader(f.GetYdb());
+        reader.FetchAll(query);
 
-        UNIT_ASSERT_VALUES_EQUAL(r.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(r[0].WmState, "NONE");
-        UNIT_ASSERT_VALUES_EQUAL(r[0].WmPoolId, "my_pool");
+        // Continue a request execution by sending the event back to the interceptor
+        runtime->Send(new IEventHandle(ev->Sender, edge, ev->Release().Release()));
+
+        auto result = future.GetResult();
+        TSampleQueries::TSelect42::CheckResult(result);
+
+        return reader;
+    }
+
+    Y_UNIT_TEST(TestWmStateNone) {
+        auto reader = ReadQuerySessionAfterState(IWmSessionUpdater::NONE);
+
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "NONE");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
     }
 
     Y_UNIT_TEST(TestWmStatePending) {
-        TQuerySessionTestFixture f(IWmSessionUpdater::PENDING, "my_pool");
-        auto myPool = TQueryRunnerSettings().PoolId("my_pool");
+        auto reader = ReadQuerySessionAfterState(IWmSessionUpdater::PENDING);
 
-        TSampleQueries::TSelect42::CheckResult(
-            f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
-
-        auto r = f.GetReader();
-
-        UNIT_ASSERT_VALUES_EQUAL(r.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(r[0].WmState, "PENDING");
-        UNIT_ASSERT_VALUES_EQUAL(r[0].WmPoolId, "my_pool");
-    }
-
-    Y_UNIT_TEST(TestWmStateDelayed) {
-        TQuerySessionTestFixture f(IWmSessionUpdater::DELAYED, "my_pool", 1);
-        auto myPool = TQueryRunnerSettings().PoolId("my_pool");
-
-        auto hangingRequest = f.GetYdb()->ExecuteQueryAsync(
-            "select 121;",
-            myPool.HangUpDuringExecution(true)
-        );
-
-        f.GetYdb()->WaitQueryExecution(hangingRequest);
-
-        auto delayedRequest = f.GetYdb()->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, myPool);
-
-        f.GetYdb()->WaitPoolState({.DelayedRequests = 1, .RunningRequests = 1});
-        f.GetYdb()->ContinueQueryExecution(hangingRequest);
-        f.GetYdb()->WaitQueryExecution(delayedRequest, TDuration::Seconds(5));
-
-        auto hangingResult = hangingRequest.GetResult();
-        auto delayedResult = delayedRequest.GetResult();
-
-        auto r = f.GetReader();
-
-        UNIT_ASSERT_VALUES_EQUAL(r.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(r[0].WmState, "DELAYED");
-        UNIT_ASSERT_VALUES_EQUAL(r[0].WmPoolId, "my_pool");
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "PENDING");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
     }
 
     Y_UNIT_TEST(TestWmStateExited) {
-        TQuerySessionTestFixture f(IWmSessionUpdater::EXITED, "my_pool");
-        auto myPool = TQueryRunnerSettings().PoolId("my_pool");
+        auto reader = ReadQuerySessionAfterState(IWmSessionUpdater::EXITED);
 
-        TSampleQueries::TSelect42::CheckResult(
-            f.GetYdb()->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
-
-        auto r = f.GetReader();
-
-        UNIT_ASSERT_VALUES_EQUAL(r.Size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(r[0].WmState, "EXITED");
-        UNIT_ASSERT_VALUES_EQUAL(r[0].WmPoolId, "my_pool");
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "EXITED");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
     }
 
+    Y_UNIT_TEST(TestWmStateDelayedToExited) {
+        TQuerySessionTestFixture f("my_pool", IWmSessionUpdater::EXITED, /*limit=*/1);
+        auto myPool = TQueryRunnerSettings().PoolId("my_pool");
+        auto& runtime = *f.GetYdb()->GetRuntime();
+
+        const TString qHanging = "SELECT 'hanging' AS x;";
+        const TString qDelayed = TSampleQueries::TSelect42::Query;
+
+        TActorId edgeHanging = f.SetupInterceptor(qHanging);
+        TActorId edgeDelayed = f.SetupInterceptor(qDelayed);
+
+        // Stop a first request before a real execution to fill limits
+        auto hangingRequest = f.GetYdb()->ExecuteQueryAsync(qHanging, myPool);
+        auto evHanging = runtime.GrabEdgeEvent<NWorkload::TEvContinueRequest>(edgeHanging);
+
+        // Run a second request which has to be placed in a Delayed Queue
+        auto delayedRequest = f.GetYdb()->ExecuteQueryAsync(qDelayed, myPool);
+
+        // Wait for condition
+        f.GetYdb()->WaitPoolState({.DelayedRequests = 1, .RunningRequests = 1});
+
+        TQuerySessionReader reader(f.GetYdb());
+        reader.FetchAll(qDelayed);
+
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "DELAYED");
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
+
+        // Continue the first request and wait for the second request to be about to execute
+        runtime.Send(new IEventHandle(evHanging->Sender, edgeHanging, evHanging->Release().Release()));
+        auto evDelayed = runtime.GrabEdgeEvent<NWorkload::TEvContinueRequest>(edgeDelayed);
+
+        TQuerySessionReader reader2(f.GetYdb());
+        reader2.FetchAll(qDelayed);
+
+        UNIT_ASSERT_VALUES_EQUAL(reader2.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader2[0].WmState, "EXITED");
+        UNIT_ASSERT_VALUES_EQUAL(reader2[0].WmPoolId, "my_pool");
+
+        // Continue the second request
+        runtime.Send(new IEventHandle(evDelayed->Sender, edgeDelayed, evDelayed->Release().Release()));
+
+        hangingRequest.GetResult();
+        TSampleQueries::TSelect42::CheckResult(delayedRequest.GetResult());
+    }
 }
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
@@ -115,14 +115,6 @@ struct TInterceptorRules {
     }
 };
 
-struct TEvIntercepted : public TEventLocal<TEvIntercepted, 101010101> {
-    TActorId SessionActorId;
-
-    explicit TEvIntercepted(TActorId sessionActorId)
-        : SessionActorId(sessionActorId)
-    {}
-};
-
 ///
 /// Replaces the real KQP workload service in the actor system.
 ///
@@ -304,7 +296,7 @@ private:
 Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
     ///
     /// Executes a query and processes all WM states up to the specified final state.
-    /// It captures session data from .sys/query_sessions by 'parking' the request 
+    /// It captures session data from .sys/query_sessions by 'parking' the request
     /// in the interceptor actor, ensuring a race-free read before actual SQL execution starts.
     ///
     TQuerySessionReader ReadQuerySessionAfterState(IWmSessionUpdater::EWmState state) {

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_query_sessions_ut.cpp
@@ -187,6 +187,9 @@ public:
     struct Row {
         std::optional<std::string> WmPoolId;
         std::optional<std::string> WmState;
+        std::optional<std::string> SessionId;
+        std::optional<TInstant> WmEnterTime;
+        std::optional<TInstant> WmExitTime;
     };
 
 public:
@@ -199,7 +202,7 @@ public:
 
         Results.clear();
         TString q = fmt::format(R"(
-            SELECT SessionId, WmPoolId, WmState
+            SELECT SessionId, WmPoolId, WmState, WmEnterTime, WmExitTime
             FROM `.sys/query_sessions`
             WHERE State = 'EXECUTING' and Query = '{query}'
             ORDER By WmState
@@ -216,8 +219,17 @@ public:
         while (parser->TryNextRow()) {
             auto wmState = parser->ColumnParser("WmState").GetOptionalUtf8();
             auto wmPoolId = parser->ColumnParser("WmPoolId").GetOptionalUtf8();
+            auto sessionId = parser->ColumnParser("SessionId").GetOptionalUtf8();
+            auto wmEnterTime = parser->ColumnParser("WmEnterTime").GetOptionalTimestamp();
+            auto wmExitTime = parser->ColumnParser("WmExitTime").GetOptionalTimestamp();
 
-            Results.push_back(Row{.WmPoolId = wmPoolId, .WmState = wmState});
+            Results.push_back(Row{
+                .WmPoolId = wmPoolId,
+                .WmState = wmState,
+                .SessionId = sessionId,
+                .WmEnterTime = wmEnterTime,
+                .WmExitTime = wmExitTime
+            });
         }
     }
 
@@ -290,7 +302,11 @@ private:
 }  // anonymous namespace
 
 Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
-
+    ///
+    /// Executes a query and processes all WM states up to the specified final state.
+    /// It captures session data from .sys/query_sessions by 'parking' the request 
+    /// in the interceptor actor, ensuring a race-free read before actual SQL execution starts.
+    ///
     TQuerySessionReader ReadQuerySessionAfterState(IWmSessionUpdater::EWmState state) {
         TQuerySessionTestFixture f("my_pool", state);
         auto myPool = TQueryRunnerSettings().PoolId("my_pool");
@@ -315,12 +331,14 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         return reader;
     }
 
-    Y_UNIT_TEST(TestWmStateNone) {
+    Y_UNIT_TEST(TestWmStateNone) {  
         auto reader = ReadQuerySessionAfterState(IWmSessionUpdater::NONE);
 
         UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "NONE");
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
+        UNIT_ASSERT(!reader[0].WmEnterTime);
+        UNIT_ASSERT(!reader[0].WmExitTime);
     }
 
     Y_UNIT_TEST(TestWmStatePending) {
@@ -329,6 +347,8 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "PENDING");
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
+        UNIT_ASSERT(reader[0].WmEnterTime);
+        UNIT_ASSERT(!reader[0].WmExitTime);
     }
 
     Y_UNIT_TEST(TestWmStateExited) {
@@ -337,14 +357,24 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "EXITED");
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
+        UNIT_ASSERT(reader[0].WmEnterTime);
+        UNIT_ASSERT(reader[0].WmExitTime);
+        UNIT_ASSERT(*reader[0].WmEnterTime < *reader[0].WmExitTime);
     }
 
+    ///
+    /// Verifies the full lifecycle of a queued request within a Resource Pool.
+    /// The test simulates a pool limit exhaustion (limit=1), forcing the second
+    /// query into a 'DELAYED' state. It then ensures that once the first query
+    /// is released, the second one correctly transitions to 'EXITED' state,
+    /// preserving its original 'WmEnterTime' and recording a valid 'WmExitTime'.
+    ///
     Y_UNIT_TEST(TestWmStateDelayedToExited) {
         TQuerySessionTestFixture f("my_pool", IWmSessionUpdater::EXITED, /*limit=*/1);
         auto myPool = TQueryRunnerSettings().PoolId("my_pool");
         auto& runtime = *f.GetYdb()->GetRuntime();
 
-        const TString qHanging = "SELECT 'hanging' AS x;";
+        const TString qHanging = "SELECT 11;";
         const TString qDelayed = TSampleQueries::TSelect42::Query;
 
         TActorId edgeHanging = f.SetupInterceptor(qHanging);
@@ -353,7 +383,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
         // Stop a first request before a real execution to fill limits
         auto hangingRequest = f.GetYdb()->ExecuteQueryAsync(qHanging, myPool);
         auto evHanging = runtime.GrabEdgeEvent<NWorkload::TEvContinueRequest>(edgeHanging);
-
+        
         // Run a second request which has to be placed in a Delayed Queue
         auto delayedRequest = f.GetYdb()->ExecuteQueryAsync(qDelayed, myPool);
 
@@ -362,27 +392,86 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceQuerySessions) {
 
         TQuerySessionReader reader(f.GetYdb());
         reader.FetchAll(qDelayed);
-
         UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "DELAYED");
         UNIT_ASSERT_VALUES_EQUAL(reader[0].WmPoolId, "my_pool");
+        UNIT_ASSERT(reader[0].WmEnterTime);
+        UNIT_ASSERT(!reader[0].WmExitTime);
 
         // Continue the first request and wait for the second request to be about to execute
         runtime.Send(new IEventHandle(evHanging->Sender, edgeHanging, evHanging->Release().Release()));
         auto evDelayed = runtime.GrabEdgeEvent<NWorkload::TEvContinueRequest>(edgeDelayed);
-
+ 
         TQuerySessionReader reader2(f.GetYdb());
         reader2.FetchAll(qDelayed);
-
         UNIT_ASSERT_VALUES_EQUAL(reader2.Size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(reader2[0].WmState, "EXITED");
         UNIT_ASSERT_VALUES_EQUAL(reader2[0].WmPoolId, "my_pool");
+        UNIT_ASSERT(reader2[0].WmEnterTime);
+        UNIT_ASSERT(reader2[0].WmExitTime);
+        UNIT_ASSERT(*reader2[0].WmEnterTime < *reader2[0].WmExitTime);
+        UNIT_ASSERT_VALUES_EQUAL(*reader[0].WmEnterTime, *reader2[0].WmEnterTime);
 
         // Continue the second request
         runtime.Send(new IEventHandle(evDelayed->Sender, edgeDelayed, evDelayed->Release().Release()));
 
         hangingRequest.GetResult();
         TSampleQueries::TSelect42::CheckResult(delayedRequest.GetResult());
+    }
+
+    ///
+    /// Verifies that session metadata and Workload Manager (WM) state are correctly
+    /// cleaned up and reset when a KQP session is reused for a new query.
+    /// The test ensures that reusing a session via TableClient properly invokes
+    /// WmState->Clean(), resetting timestamps and states in the .sys/query_sessions table.
+    ///
+    Y_UNIT_TEST(TestWmStateCleanupOnSessionReuse) {
+        using namespace NYdb::NTable;
+
+        // We use PENDING state because AttachQueryText calls Clean() before placing request into pool
+        TQuerySessionTestFixture f(NResourcePool::DEFAULT_POOL_ID, IWmSessionUpdater::PENDING);
+        auto& runtime = *f.GetYdb()->GetRuntime();
+
+        auto db = f.GetYdb()->GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto sessionId = session.GetId();
+
+        // Execute the first query
+        const TString qFirst = "SELECT 11;";
+        TActorId edge1 = f.SetupInterceptor(qFirst);
+        auto future1 = session.ExecuteDataQuery(qFirst, TTxControl::BeginTx().CommitTx());
+        auto ev1 = runtime.GrabEdgeEvent<NWorkload::TEvContinueRequest>(edge1);
+        
+        TQuerySessionReader reader(f.GetYdb());
+        reader.FetchAll(qFirst);
+        UNIT_ASSERT_VALUES_EQUAL(reader.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].SessionId, sessionId);
+        UNIT_ASSERT_VALUES_EQUAL(reader[0].WmState, "PENDING");
+        UNIT_ASSERT(reader[0].WmEnterTime);
+        UNIT_ASSERT(!reader[0].WmExitTime);
+
+        // Resume and wait for the first query to finish
+        runtime.Send(new IEventHandle(ev1->Sender, edge1, ev1->Release().Release()));
+        UNIT_ASSERT(future1.GetValueSync().IsSuccess());
+
+        // Execute the second query in the same session
+        const TString qSecond = "SELECT 12;";
+        TActorId edge2 = f.SetupInterceptor(qSecond);
+        auto future2 = session.ExecuteDataQuery(qSecond, TTxControl::BeginTx().CommitTx());
+        auto ev2 = runtime.GrabEdgeEvent<NWorkload::TEvContinueRequest>(edge2);
+
+        TQuerySessionReader reader2(f.GetYdb());
+        reader2.FetchAll(qSecond);
+        UNIT_ASSERT_VALUES_EQUAL(reader2.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(reader2[0].SessionId, sessionId);
+        UNIT_ASSERT_VALUES_EQUAL(reader2[0].WmState, "PENDING");
+        UNIT_ASSERT(reader2[0].WmEnterTime);
+        UNIT_ASSERT(!reader2[0].WmExitTime);
+        UNIT_ASSERT(*reader[0].WmEnterTime < *reader2[0].WmEnterTime);
+        
+        // Resume and wait for the second query to finish
+        runtime.Send(new IEventHandle(ev2->Sender, edge2, ev2->Release().Release()));
+        UNIT_ASSERT(future2.GetValueSync().IsSuccess());
     }
 }
 

--- a/ydb/core/kqp/workload_service/ut/ya.make
+++ b/ydb/core/kqp/workload_service/ut/ya.make
@@ -7,6 +7,7 @@ SIZE(MEDIUM)
 SRCS(
     kqp_workload_service_actors_ut.cpp
     kqp_workload_service_tables_ut.cpp
+    kqp_workload_service_query_sessions_ut.cpp
     kqp_workload_service_ut.cpp
 )
 

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -358,6 +358,10 @@ message TSessionInfo {
     optional string UserSID = 14;
     optional bool PgWire = 15 [default = false];
     optional string UserName = 16;
+    optional string WMPoolId = 17;
+    optional string WMState = 18;
+    optional int64 WMEnterTime = 19;
+    optional int64 WMExitTime = 20;
 }
 
 message TEvListSessionsRequest {

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -358,10 +358,10 @@ message TSessionInfo {
     optional string UserSID = 14;
     optional bool PgWire = 15 [default = false];
     optional string UserName = 16;
-    optional string WMPoolId = 17;
-    optional string WMState = 18;
-    optional int64 WMEnterTime = 19;
-    optional int64 WMExitTime = 20;
+    optional string WmPoolId = 17;
+    optional string WmState = 18;
+    optional int64 WmEnterTime = 19;
+    optional int64 WmExitTime = 20;
 }
 
 message TEvListSessionsRequest {

--- a/ydb/core/sys_view/common/registry.h
+++ b/ydb/core/sys_view/common/registry.h
@@ -589,10 +589,10 @@ struct Schema : NIceDb::Schema {
         struct QueryStartAt       : Column<12, NScheme::NTypeIds::Timestamp> {};
         struct StateChangeAt      : Column<13, NScheme::NTypeIds::Timestamp> {};
         struct UserSID            : Column<14, NScheme::NTypeIds::Utf8> {};
-        struct WMPoolId           : Column<17, NScheme::NTypeIds::Utf8> {};
-        struct WMState            : Column<18, NScheme::NTypeIds::Utf8> {};
-        struct WMEnterTime        : Column<19, NScheme::NTypeIds::Timestamp> {};
-        struct WMExitTime         : Column<20, NScheme::NTypeIds::Timestamp> {};
+        struct WmPoolId           : Column<17, NScheme::NTypeIds::Utf8> {};
+        struct WmState            : Column<18, NScheme::NTypeIds::Utf8> {};
+        struct WmEnterTime        : Column<19, NScheme::NTypeIds::Timestamp> {};
+        struct WmExitTime         : Column<20, NScheme::NTypeIds::Timestamp> {};
 
         using TKey = TableKey<SessionId>;
         using TColumns = TableColumns<
@@ -610,10 +610,10 @@ struct Schema : NIceDb::Schema {
             QueryStartAt,
             StateChangeAt,
             UserSID,
-            WMPoolId,
-            WMState,
-            WMEnterTime,
-            WMExitTime>;
+            WmPoolId,
+            WmState,
+            WmEnterTime,
+            WmExitTime>;
     };
 
     struct PrimaryIndexPortionStats : Table<14> {

--- a/ydb/core/sys_view/common/registry.h
+++ b/ydb/core/sys_view/common/registry.h
@@ -589,6 +589,10 @@ struct Schema : NIceDb::Schema {
         struct QueryStartAt       : Column<12, NScheme::NTypeIds::Timestamp> {};
         struct StateChangeAt      : Column<13, NScheme::NTypeIds::Timestamp> {};
         struct UserSID            : Column<14, NScheme::NTypeIds::Utf8> {};
+        struct WMPoolId           : Column<17, NScheme::NTypeIds::Utf8> {};
+        struct WMState            : Column<18, NScheme::NTypeIds::Utf8> {};
+        struct WMEnterTime        : Column<19, NScheme::NTypeIds::Timestamp> {};
+        struct WMExitTime         : Column<20, NScheme::NTypeIds::Timestamp> {};
 
         using TKey = TableKey<SessionId>;
         using TColumns = TableColumns<
@@ -605,7 +609,11 @@ struct Schema : NIceDb::Schema {
             SessionStartAt,
             QueryStartAt,
             StateChangeAt,
-            UserSID>;
+            UserSID,
+            WMPoolId,
+            WMState,
+            WMEnterTime,
+            WMExitTime>;
     };
 
     struct PrimaryIndexPortionStats : Table<14> {

--- a/ydb/core/sys_view/sessions/sessions.cpp
+++ b/ydb/core/sys_view/sessions/sessions.cpp
@@ -89,6 +89,22 @@ public:
             insert({TSchema::UserSID::ColumnId, [] (const TNodeInfo& info, ui32) {   // 14
                 return TCell(info.GetUserSID().data(), info.GetUserSID().size());
             }});
+
+            insert({TSchema::WMPoolId::ColumnId, [] (const TNodeInfo& info, ui32) {   // 17
+                return TCell(info.GetWMPoolId().data(), info.GetWMPoolId().size());
+            }});
+
+            insert({TSchema::WMState::ColumnId, [] (const TNodeInfo& info, ui32) {   // 18
+                return TCell(info.GetWMState().data(), info.GetWMState().size());
+            }});
+
+            insert({TSchema::WMEnterTime::ColumnId, [] (const TNodeInfo& info, ui32) {  // 19
+                return info.GetWMEnterTime() ? TCell::Make<ui64>(info.GetWMEnterTime()) : TCell();
+            }});
+
+            insert({TSchema::WMExitTime::ColumnId, [] (const TNodeInfo& info, ui32) {  // 20
+                return info.GetWMExitTime() ? TCell::Make<ui64>(info.GetWMExitTime()) : TCell();
+            }});
         }
     };
 

--- a/ydb/core/sys_view/sessions/sessions.cpp
+++ b/ydb/core/sys_view/sessions/sessions.cpp
@@ -90,20 +90,20 @@ public:
                 return TCell(info.GetUserSID().data(), info.GetUserSID().size());
             }});
 
-            insert({TSchema::WMPoolId::ColumnId, [] (const TNodeInfo& info, ui32) {   // 17
-                return TCell(info.GetWMPoolId().data(), info.GetWMPoolId().size());
+            insert({TSchema::WmPoolId::ColumnId, [] (const TNodeInfo& info, ui32) {   // 17
+                return TCell(info.GetWmPoolId().data(), info.GetWmPoolId().size());
             }});
 
-            insert({TSchema::WMState::ColumnId, [] (const TNodeInfo& info, ui32) {   // 18
-                return TCell(info.GetWMState().data(), info.GetWMState().size());
+            insert({TSchema::WmState::ColumnId, [] (const TNodeInfo& info, ui32) {   // 18
+                return TCell(info.GetWmState().data(), info.GetWmState().size());
             }});
 
-            insert({TSchema::WMEnterTime::ColumnId, [] (const TNodeInfo& info, ui32) {  // 19
-                return info.GetWMEnterTime() ? TCell::Make<ui64>(info.GetWMEnterTime()) : TCell();
+            insert({TSchema::WmEnterTime::ColumnId, [] (const TNodeInfo& info, ui32) {  // 19
+                return info.GetWmEnterTime() ? TCell::Make<ui64>(info.GetWmEnterTime()) : TCell();
             }});
 
-            insert({TSchema::WMExitTime::ColumnId, [] (const TNodeInfo& info, ui32) {  // 20
-                return info.GetWMExitTime() ? TCell::Make<ui64>(info.GetWMExitTime()) : TCell();
+            insert({TSchema::WmExitTime::ColumnId, [] (const TNodeInfo& info, ui32) {  // 20
+                return info.GetWmExitTime() ? TCell::Make<ui64>(info.GetWmExitTime()) : TCell();
             }});
         }
     };

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -944,6 +944,22 @@
       {
         "name": "UserSID",
         "type": "Utf8?"
+      },
+      {
+        "name": "WmPoolId",
+        "type": "Utf8?"
+      },
+      {
+        "name": "WmState",
+        "type": "Utf8?"
+      },
+      {
+        "name": "WmEnterTime",
+        "type": "Timestamp?"
+      },
+      {
+        "name": "WmExitTime",
+        "type": "Timestamp?"
       }
     ],
     "primary_key": [

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -536,6 +536,22 @@
       {
         "name": "UserSID",
         "type": "Utf8?"
+      },
+      {
+        "name": "WmPoolId",
+        "type": "Utf8?"
+      },
+      {
+        "name": "WmState",
+        "type": "Utf8?"
+      },
+      {
+        "name": "WmEnterTime",
+        "type": "Timestamp?"
+      },
+      {
+        "name": "WmExitTime",
+        "type": "Timestamp?"
       }
     ],
     "primary_key": [


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add Workload Manager State to .sys/query_sessions

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Adds runtime tracking of Workload Manager (WM) queue state to the .sys/query_sessions system view, allowing users to monitor query lifecycle through WM queues.

New Columns in .sys/query_sessions:

- WmPoolId (Utf8) - Resource pool ID
- WmState (Utf8) - Queue state: None, Pending, Delayed, Exited
- WmEnterTime (Timestamp) - When query entered WM Pending or Delayed State
- WmExitTime (Timestamp) - When query exited WM queue

Resolve YQ-5077
Resolve #35788, #35789, #35790, #35791, #35792