### PR TITLE
Close driver in stress tests

### DIFF
--- a/ydb/tests/library/stress/fixtures.py
+++ b/ydb/tests/library/stress/fixtures.py
@@ -39,4 +39,5 @@ class StressFixture:
         )
         self.driver.wait(timeout=60)
         yield
+        self.driver.stop()
         self.cluster.stop()

--- a/ydb/tests/stress/backup/__main__.py
+++ b/ydb/tests/stress/backup/__main__.py
@@ -14,5 +14,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     client = InstrumentedYdbClient(args.endpoint, args.database, True)
     client.wait_connection()
-    with WorkloadRunnerBackup(client, args.duration, args.backup_interval) as runner:
-        runner.run()
+    try:
+        with WorkloadRunnerBackup(client, args.duration, args.backup_interval) as runner:
+            runner.run()
+    finally:
+        client.close()

--- a/ydb/tests/stress/cdc/__main__.py
+++ b/ydb/tests/stress/cdc/__main__.py
@@ -15,5 +15,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     client = InstrumentedYdbClient(args.endpoint, args.database, True)
     client.wait_connection()
-    with WorkloadRunner(client, args.duration) as runner:
-        runner.run()
+    try:
+        with WorkloadRunner(client, args.duration) as runner:
+            runner.run()
+    finally:
+        client.close()

--- a/ydb/tests/stress/common/common.py
+++ b/ydb/tests/stress/common/common.py
@@ -77,6 +77,10 @@ class YdbClient:
             raise f"{path} has unexpected type"
         return self._remove_recursively(path)
 
+    def close(self):
+        self.session_pool.stop()
+        self.driver.stop()
+
 
 class WorkloadBase:
     def __init__(self, client, tables_prefix, workload_name, stop):

--- a/ydb/tests/stress/ctas/__main__.py
+++ b/ydb/tests/stress/ctas/__main__.py
@@ -15,5 +15,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     client = InstrumentedYdbClient(args.endpoint, args.database, True)
     client.wait_connection()
-    with WorkloadRunner(client, args.path, args.duration) as runner:
-        runner.run()
+    try:
+        with WorkloadRunner(client, args.path, args.duration) as runner:
+            runner.run()
+    finally:
+        client.close()

--- a/ydb/tests/stress/node_broker/__main__.py
+++ b/ydb/tests/stress/node_broker/__main__.py
@@ -16,5 +16,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     client = InstrumentedYdbClient(args.endpoint, args.database, True)
     client.wait_connection()
-    with WorkloadRunner(client, args.mon_endpoint, args.duration) as runner:
-        runner.run()
+    try:
+        with WorkloadRunner(client, args.mon_endpoint, args.duration) as runner:
+            runner.run()
+    finally:
+        client.close()

--- a/ydb/tests/stress/olap_workload/__main__.py
+++ b/ydb/tests/stress/olap_workload/__main__.py
@@ -16,5 +16,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     client = InstrumentedYdbClient(args.endpoint, args.database, True)
     client.wait_connection()
-    with WorkloadRunner(client, args.path, args.duration, args.allow_nullables_in_pk) as runner:
-        runner.run()
+    try:
+        with WorkloadRunner(client, args.path, args.duration, args.allow_nullables_in_pk) as runner:
+            runner.run()
+    finally:
+        client.close()

--- a/ydb/tests/stress/oltp_workload/__main__.py
+++ b/ydb/tests/stress/oltp_workload/__main__.py
@@ -19,5 +19,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     client = InstrumentedYdbClient(args.endpoint, args.database, True, sessions=3000)
     client.wait_connection()
-    with WorkloadRunner(client, args.path, args.duration) as runner:
-        runner.run()
+    try:
+        with WorkloadRunner(client, args.path, args.duration) as runner:
+            runner.run()
+    finally:
+        client.close()

--- a/ydb/tests/stress/oltp_workload/tests/test_workload.py
+++ b/ydb/tests/stress/oltp_workload/tests/test_workload.py
@@ -21,5 +21,8 @@ class TestYdbWorkload(StressFixture):
     def test(self):
         client = YdbClient(self.endpoint, self.database, True)
         client.wait_connection()
-        with WorkloadRunner(client, 'oltp_workload', 120) as runner:
-            runner.run()
+        try:
+            with WorkloadRunner(client, 'oltp_workload', 120) as runner:
+                runner.run()
+        finally:
+            client.close()

--- a/ydb/tests/stress/reconfig_state_storage_workload/workload/__init__.py
+++ b/ydb/tests/stress/reconfig_state_storage_workload/workload/__init__.py
@@ -322,6 +322,7 @@ class WorkloadRunner:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._cleanup()
+        self.client.close()
 
     def _cleanup(self):
         logger.info(f"Cleaning up {self.tables_prefix}...")

--- a/ydb/tests/stress/result_set_format/__main__.py
+++ b/ydb/tests/stress/result_set_format/__main__.py
@@ -21,5 +21,8 @@ if __name__ == "__main__":
     logging.basicConfig(level=args.log_level)
     client = YdbClient(args.endpoint, args.database, True, sessions=3000)
     client.wait_connection()
-    with WorkloadRunner(client, args.path, args.duration, args.format) as runner:
-        runner.run()
+    try:
+        with WorkloadRunner(client, args.path, args.duration, args.format) as runner:
+            runner.run()
+    finally:
+        client.close()

--- a/ydb/tests/stress/s3_backups/__main__.py
+++ b/ydb/tests/stress/s3_backups/__main__.py
@@ -15,5 +15,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     client = InstrumentedYdbClient(args.endpoint, args.database, True)
     client.wait_connection()
-    with WorkloadRunner(client, args.endpoint, args.duration) as runner:
-        runner.run()
+    try:
+        with WorkloadRunner(client, args.endpoint, args.duration) as runner:
+            runner.run()
+    finally:
+        client.close()

--- a/ydb/tests/stress/scheme_board/pile_promotion/workload/__init__.py
+++ b/ydb/tests/stress/scheme_board/pile_promotion/workload/__init__.py
@@ -292,6 +292,7 @@ class WorkloadRunner:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._cleanup()
+        self.client.close()
 
     def _cleanup(self):
         logger.info(f"Cleaning up {self.tables_prefix}...")


### PR DESCRIPTION
Fixing problems like 

```
==================
WARNING: ThreadSanitizer: data race (pid=10822)
  Write of size 8 at 0x72480004c518 by main thread:
    #0 free /-S/contrib/libs/clang20-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:741:3 (ydb-tests-stress-ctas-tests+0x45e987a) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #1 _PyMem_RawFree /-S/contrib/tools/python3/Objects/obmalloc.c:90:5 (ydb-tests-stress-ctas-tests+0x4a8cba9) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #2 PyMem_RawFree /-S/contrib/tools/python3/Objects/obmalloc.c:1005:5 (ydb-tests-stress-ctas-tests+0x4a8e778) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #3 free_threadstate /-S/contrib/tools/python3/Python/pystate.c:1476:9 (ydb-tests-stress-ctas-tests+0x50fb6a2) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #4 _PyThreadState_DeleteList /-S/contrib/tools/python3/Python/pystate.c:1940:9 (ydb-tests-stress-ctas-tests+0x50fb6a2)
    #5 _Py_Finalize /-S/contrib/tools/python3/Python/pylifecycle.c:2092:5 (ydb-tests-stress-ctas-tests+0x50f2503) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #6 Py_Exit /-S/contrib/tools/python3/Python/pylifecycle.c:3519:9 (ydb-tests-stress-ctas-tests+0x50f4996) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #7 handle_system_exit /-S/contrib/tools/python3/Python/pythonrun.c:679:9 (ydb-tests-stress-ctas-tests+0x50ffaa8) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #8 _PyErr_PrintEx /-S/contrib/tools/python3/Python/pythonrun.c:688:5 (ydb-tests-stress-ctas-tests+0x50ffaa8)
    #9 PyErr_PrintEx /-S/contrib/tools/python3/Python/pythonrun.c:768:5 (ydb-tests-stress-ctas-tests+0x50fe0c3) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #10 PyErr_Print /-S/contrib/tools/python3/Python/pythonrun.c:774:5 (ydb-tests-stress-ctas-tests+0x50fe0c3)
    #11 pymain /-S/library/python/runtime_py3/main/main.c:222:17 (ydb-tests-stress-ctas-tests+0x539feaf) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #12 main /-S/library/python/runtime_py3/main/main.c:251:12 (ydb-tests-stress-ctas-tests+0x53a02ad) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)

  Previous atomic read of size 8 at 0x72480004c518 by thread T56:
    #0 _Py_atomic_load_uintptr_relaxed /-S/contrib/tools/python3/Include/cpython/pyatomic_gcc.h:347:10 (ydb-tests-stress-ctas-tests+0x4b6bd8c) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #1 _Py_eval_breaker_bit_is_set /-S/contrib/tools/python3/Include/internal/pycore_ceval.h:292:19 (ydb-tests-stress-ctas-tests+0x4b6bd8c)
    #2 drop_gil /-S/contrib/tools/python3/Python/ceval_gil.c:266:9 (ydb-tests-stress-ctas-tests+0x4b6bd8c)
    #3 _PyEval_ReleaseLock /-S/contrib/tools/python3/Python/ceval_gil.c:603:5 (ydb-tests-stress-ctas-tests+0x4b6bf47) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #4 detach_thread /-S/contrib/tools/python3/Python/pystate.c:2151:5 (ydb-tests-stress-ctas-tests+0x50f9ac9) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #5 _PyThreadState_Detach /-S/contrib/tools/python3/Python/pystate.c:2157:5 (ydb-tests-stress-ctas-tests+0x50f9ac9)
    #6 PyEval_SaveThread /-S/contrib/tools/python3/Python/ceval_gil.c:647:5 (ydb-tests-stress-ctas-tests+0x4b6c0b1) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #7 __pyx_f_4grpc_7_cython_6cygrpc__next(grpc_completion_queue*, _object*) /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:41095:9 (ydb-tests-stress-ctas-tests+0x5876a24) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #8 __pyx_f_4grpc_7_cython_6cygrpc__internal_latent_event(__pyx_obj_4grpc_7_cython_6cygrpc__LatentEventArg*) /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:41475:15 (ydb-tests-stress-ctas-tests+0x589bfa3) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #9 __pyx_f_4grpc_7_cython_6cygrpc__latent_event(grpc_completion_queue*, _object*) /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:41669:17 (ydb-tests-stress-ctas-tests+0x589bcf6) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #10 __pyx_f_4grpc_7_cython_6cygrpc__watch_connectivity_state /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:24835:15 (ydb-tests-stress-ctas-tests+0x58a259b) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #11 __pyx_pf_4grpc_7_cython_6cygrpc_7Channel_12watch_connectivity_state /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:27855:15 (ydb-tests-stress-ctas-tests+0x58a259b)
    #12 __pyx_pw_4grpc_7_cython_6cygrpc_7Channel_13watch_connectivity_state(_object*, _object* const*, long, _object*) /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:27825:13 (ydb-tests-stress-ctas-tests+0x58a259b)
    #13 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS(_object*, _object* const*, unsigned long, _object*) /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:159469:12 (ydb-tests-stress-ctas-tests+0x591b8e6) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #14 _PyObject_VectorcallTstate /-S/contrib/tools/python3/Include/internal/pycore_call.h:168:11 (ydb-tests-stress-ctas-tests+0x49f8545) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #15 PyObject_Vectorcall /-S/contrib/tools/python3/Objects/call.c:327:12 (ydb-tests-stress-ctas-tests+0x49f8545)
    #16 _PyEval_EvalFrameDefault /-S/contrib/tools/python3/Python/generated_cases.c.h:1850:23 (ydb-tests-stress-ctas-tests+0x4b5d024) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #17 _PyEval_EvalFrame /-S/contrib/tools/python3/Include/internal/pycore_ceval.h:120:16 (ydb-tests-stress-ctas-tests+0x4b5793a) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #18 _PyEval_Vector /-S/contrib/tools/python3/Python/ceval.c:1820:12 (ydb-tests-stress-ctas-tests+0x4b5793a)
    #19 _PyFunction_Vectorcall /-S/contrib/tools/python3/Objects/call.c (ydb-tests-stress-ctas-tests+0x49f893c) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #20 _PyObject_VectorcallTstate /-S/contrib/tools/python3/Include/internal/pycore_call.h:168:11 (ydb-tests-stress-ctas-tests+0x4b904a2) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #21 context_run /-S/contrib/tools/python3/Python/context.c:658:29 (ydb-tests-stress-ctas-tests+0x4b904a2)
    #22 cfunction_vectorcall_FASTCALL_KEYWORDS /-S/contrib/tools/python3/Objects/methodobject.c:440:24 (ydb-tests-stress-ctas-tests+0x4a5c026) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #23 _PyVectorcall_Call /-S/contrib/tools/python3/Objects/call.c:273:16 (ydb-tests-stress-ctas-tests+0x49f8473) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #24 PyVectorcall_Call /-S/contrib/tools/python3/Objects/call.c:318:12 (ydb-tests-stress-ctas-tests+0x49f833a) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #25 cfunction_call /-S/contrib/tools/python3/Objects/methodobject.c:529:16 (ydb-tests-stress-ctas-tests+0x4a5c816) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #26 __Pyx_PyObject_Call /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:157371:14 (ydb-tests-stress-ctas-tests+0x592afb4) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #27 __pyx_pf_4grpc_7_cython_6cygrpc_17_run_with_context__run /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:65694:15 (ydb-tests-stress-ctas-tests+0x592afb4)
    #28 __pyx_pw_4grpc_7_cython_6cygrpc_17_run_with_context_1_run(_object*, _object*, _object*) /-B/contrib/python/grpcio/py3/grpc/_cython/cygrpc.pyx.cpp:65652:13 (ydb-tests-stress-ctas-tests+0x592afb4)
    #29 __Pyx_CyFunction_CallMethod(_object*, _object*, _object*, _object*) /-B/library/python/strings/strings.py.py3.cpp:14997:16 (ydb-tests-stress-ctas-tests+0x512b6e3) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #30 __Pyx_CyFunction_Call /-B/library/python/strings/strings.py.py3.cpp:15057:14 (ydb-tests-stress-ctas-tests+0x512af0c) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #31 __Pyx_CyFunction_CallAsMethod(_object*, _object*, _object*) /-B/library/python/strings/strings.py.py3.cpp:15098:18 (ydb-tests-stress-ctas-tests+0x512af0c)
    #32 _PyObject_Call /-S/contrib/tools/python3/Objects/call.c:361:18 (ydb-tests-stress-ctas-tests+0x49f8696) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #33 PyObject_Call /-S/contrib/tools/python3/Objects/call.c:373:12 (ydb-tests-stress-ctas-tests+0x49f8734) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #34 _PyEval_EvalFrameDefault /-S/contrib/tools/python3/Python/generated_cases.c.h:1362:26 (ydb-tests-stress-ctas-tests+0x4b5b857) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #35 _PyEval_EvalFrame /-S/contrib/tools/python3/Include/internal/pycore_ceval.h:120:16 (ydb-tests-stress-ctas-tests+0x4b5793a) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #36 _PyEval_Vector /-S/contrib/tools/python3/Python/ceval.c:1820:12 (ydb-tests-stress-ctas-tests+0x4b5793a)
    #37 _PyFunction_Vectorcall /-S/contrib/tools/python3/Objects/call.c (ydb-tests-stress-ctas-tests+0x49f893c) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #38 _PyObject_VectorcallTstate /-S/contrib/tools/python3/Include/internal/pycore_call.h:168:11 (ydb-tests-stress-ctas-tests+0x4a708c7) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #39 method_vectorcall /-S/contrib/tools/python3/Objects/classobject.c:71:20 (ydb-tests-stress-ctas-tests+0x4a708c7)
    #40 _PyVectorcall_Call /-S/contrib/tools/python3/Objects/call.c:273:16 (ydb-tests-stress-ctas-tests+0x49f8473) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #41 _PyObject_Call /-S/contrib/tools/python3/Objects/call.c:348:16 (ydb-tests-stress-ctas-tests+0x49f866d) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #42 PyObject_Call /-S/contrib/tools/python3/Objects/call.c:373:12 (ydb-tests-stress-ctas-tests+0x49f8734) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #43 thread_run /-S/contrib/tools/python3/Modules/_threadmodule.c:343:21 (ydb-tests-stress-ctas-tests+0x5022443) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)
    #44 pythread_wrapper /-S/contrib/tools/python3/Python/thread_pthread.h:242:5 (ydb-tests-stress-ctas-tests+0x51158ea) (BuildId: 0b40e35a0c558442af6ef11f05dcfacd3f68fd39)

```