### PR TITLE
Refactoring: Hide TActivationContext::ExecutorThread as private implementation detail

### DIFF
--- a/ydb/core/actorlib_impl/actor_tracker.cpp
+++ b/ydb/core/actorlib_impl/actor_tracker.cpp
@@ -1,6 +1,5 @@
 #include "actor_tracker.h"
 #include <ydb/library/actors/core/actor.h>
-#include <ydb/library/actors/core/executor_thread.h>
 #include <ydb/library/actors/core/hfunc.h>
 
 namespace NActors {
@@ -78,7 +77,7 @@ namespace NActors {
         // we have finished processing the query; send TEvPoisonTaken message and Die
         if (currentValue == StopBit && RegisteredActors.empty()) {
             ctx.Send(KillerActorId, new TEvents::TEvPoisonTaken);
-            ctx.ExecutorThread.UnregisterActor(&ctx.Mailbox, ctx.SelfID);
+            ctx.UnregisterActor(&ctx.Mailbox, ctx.SelfID);
         }
     }
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -14,7 +14,6 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/counters.h>
 #include <ydb/core/blobstorage/base/html.h>
-#include <ydb/library/actors/core/executor_thread.h>
 #include <ydb/core/blobstorage/base/blobstorage_events.h>
 #include <ydb/core/blobstorage/crypto/secured_block.h>
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
@@ -39,17 +38,17 @@ namespace NPDisk {
 
 LWTRACE_USING(BLOBSTORAGE_PROVIDER);
 
-void CreatePDiskActor(TExecutorThread& executorThread,
+void CreatePDiskActor(const TActorContext& ctx,
         const TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters,
         const TIntrusivePtr<TPDiskConfig> &cfg,
         const NPDisk::TMainKey &mainKey,
         ui32 pDiskID, ui32 poolId, ui32 nodeId) {
-    TActorId actorId = executorThread.RegisterActor(CreatePDisk(cfg, mainKey, cfg->MetadataOnly
+    TActorId actorId = ctx.Register(CreatePDisk(cfg, mainKey, cfg->MetadataOnly
         ? MakeIntrusive<NMonitoring::TDynamicCounters>() : counters), TMailboxType::ReadAsFilled, poolId);
 
     TActorId pDiskServiceId = MakeBlobStoragePDiskID(nodeId, pDiskID);
 
-    executorThread.ActorSystem->RegisterLocalService(pDiskServiceId, actorId);
+    ctx.GetActorSystem()->RegisterLocalService(pDiskServiceId, actorId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1307,11 +1306,9 @@ public:
 
             auto& counters = AppData(actorCtx)->Counters;
 
-            TExecutorThread& executorThread = actorCtx.ExecutorThread;
-
             PassAway();
 
-            CreatePDiskActor(executorThread, counters, actorCfg, newMainKey, pdiskId, poolId, nodeId);
+            CreatePDiskActor(actorCtx, counters, actorCfg, newMainKey, pdiskId, poolId, nodeId);
 
             Send(ev->Sender, new TEvBlobStorage::TEvNotifyWardenPDiskRestarted(pdiskId));
         }
@@ -1628,7 +1625,7 @@ IActor* CreatePDisk(const TIntrusivePtr<TPDiskConfig> &cfg, const NPDisk::TMainK
 
 void TRealPDiskServiceFactory::Create(const TActorContext &ctx, ui32 pDiskID,
         const TIntrusivePtr<TPDiskConfig> &cfg, const NPDisk::TMainKey &mainKey, ui32 poolId, ui32 nodeId) {
-    CreatePDiskActor(ctx.ExecutorThread, AppData(ctx)->Counters, cfg, mainKey, pDiskID, poolId, nodeId);
+    CreatePDiskActor(ctx, AppData(ctx)->Counters, cfg, mainKey, pDiskID, poolId, nodeId);
 }
 
 } // NKikimr

--- a/ydb/core/grpc_services/rpc_ping.cpp
+++ b/ydb/core/grpc_services/rpc_ping.cpp
@@ -8,7 +8,6 @@
 #include <ydb/public/api/protos/ydb_debug.pb.h>
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/executor_thread.h>
 
 namespace NKikimr::NGRpcService {
 
@@ -281,7 +280,7 @@ private:
                 RegisterWithSameMailbox(nextChainActor);
             } else {
                 // same mailbox + tail
-                TlsActivationContext->ExecutorThread.RegisterActor<ESendingType::Tail>(
+                TlsActivationContext->RegisterActor<ESendingType::Tail>(
                     nextChainActor,
                     &TlsActivationContext->Mailbox,
                     this->SelfId());
@@ -380,7 +379,7 @@ private:
             nextChainActorId = RegisterWithSameMailbox(nextChainActor);
         } else {
             // same mailbox + tail
-            nextChainActorId = TlsActivationContext->ExecutorThread.RegisterActor<ESendingType::Tail>(
+            nextChainActorId = TlsActivationContext->RegisterActor<ESendingType::Tail>(
                 nextChainActor,
                 &TlsActivationContext->Mailbox,
                 this->SelfId());

--- a/ydb/core/tablet_flat/tablet_flat_executed.h
+++ b/ydb/core/tablet_flat/tablet_flat_executed.h
@@ -38,7 +38,7 @@ protected:
     const NTable::TScheme& Scheme() const;
 
     TActorContext ExecutorCtx(const TActivationContext &ctx) {
-        return TActorContext(ctx.Mailbox, ctx.ExecutorThread, ctx.EventStart, ExecutorID());
+        return ctx.MakeFor(ExecutorID());
     }
 
     virtual void OnActivateExecutor(const TActorContext &ctx) = 0;

--- a/ydb/library/actors/async/async.cpp
+++ b/ydb/library/actors/async/async.cpp
@@ -1,7 +1,6 @@
 #include "async.h"
 #include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/events.h>
-#include <ydb/library/actors/core/executor_thread.h>
 
 namespace NActors::NDetail {
 
@@ -30,7 +29,7 @@ namespace NActors::NDetail {
         {
             TActivationContext* ctx = TlsActivationContext;
             Y_ABORT_UNLESS(ctx, "Unexpected missing activation context");
-            ActorSystem = ctx->ExecutorThread.ActorSystem;
+            ActorSystem = ctx->GetActorSystem();
             Mailbox = &ctx->Mailbox;
         }
 
@@ -86,7 +85,7 @@ namespace NActors::NDetail {
         {
             TActivationContext* ctx = TlsActivationContext;
             Y_ABORT_UNLESS(ctx, "Unexpected missing activation context");
-            ActorSystem = ctx->ExecutorThread.ActorSystem;
+            ActorSystem = ctx->GetActorSystem();
             Mailbox = &ctx->Mailbox;
         }
 

--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -84,16 +84,28 @@ namespace NActors {
         return SelfActorId.Send(recipient, ev, flags, cookie, std::move(traceId));
     }
 
+    void TActivationContext::DoSchedule(TInstant deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie) const {
+        ExecutorThread.Schedule(deadline, ev, cookie);
+    }
+
+    void TActivationContext::DoSchedule(TMonotonic deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie) const {
+        ExecutorThread.Schedule(deadline, ev, cookie);
+    }
+
+    void TActivationContext::DoSchedule(TDuration delta, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie) const {
+        ExecutorThread.Schedule(delta, ev, cookie);
+    }
+
     void TActivationContext::Schedule(TInstant deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie) {
-        TlsActivationContext->ExecutorThread.Schedule(deadline, ev, cookie);
+        TlsActivationContext->DoSchedule(deadline, ev, cookie);
     }
 
     void TActivationContext::Schedule(TMonotonic deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie) {
-        TlsActivationContext->ExecutorThread.Schedule(deadline, ev, cookie);
+        TlsActivationContext->DoSchedule(deadline, ev, cookie);
     }
 
     void TActivationContext::Schedule(TDuration delta, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie) {
-        TlsActivationContext->ExecutorThread.Schedule(delta, ev, cookie);
+        TlsActivationContext->DoSchedule(delta, ev, cookie);
     }
 
     bool TActivationContext::Send(const TActorId& recipient, std::unique_ptr<IEventBase> ev, ui32 flags, ui64 cookie) {
@@ -115,23 +127,48 @@ namespace NActors {
     TActorId TActivationContext::RegisterWithSameMailbox(IActor* actor, TActorId parentId) {
         Y_DEBUG_ABORT_UNLESS(parentId);
         auto& ctx = *TlsActivationContext;
-        return ctx.ExecutorThread.RegisterActor(actor, &ctx.Mailbox, parentId);
+        return ctx.RegisterActor(actor, &ctx.Mailbox, parentId);
+    }
+
+    template TActorId TActivationContext::RegisterActor<ESendingType::Common>(IActor* actor, TMailbox* mailbox, TActorId parentId) const;
+    template TActorId TActivationContext::RegisterActor<ESendingType::Lazy>(IActor* actor, TMailbox* mailbox, TActorId parentId) const;
+    template TActorId TActivationContext::RegisterActor<ESendingType::Tail>(IActor* actor, TMailbox* mailbox, TActorId parentId) const;
+
+    template <ESendingType SendingType>
+    TActorId TActivationContext::RegisterActor(IActor* actor, TMailbox* mailbox, TActorId parentId) const {
+        return ExecutorThread.RegisterActor<SendingType>(actor, mailbox, parentId);
+    }
+
+    TActorId TActivationContext::RegisterAlias(TMailbox* mailbox, IActor* actor) const {
+        return ExecutorThread.RegisterAlias(mailbox, actor);
+    }
+
+    void TActivationContext::UnregisterAlias(TMailbox* mailbox, const TActorId& actorId) const {
+        ExecutorThread.UnregisterAlias(mailbox, actorId);
+    }
+
+    void TActivationContext::UnregisterActor(TMailbox* mailbox, TActorId actorId) const {
+        ExecutorThread.UnregisterActor(mailbox, actorId);
+    }
+
+    TActorSystem* TActivationContext::GetActorSystem() const {
+        return ExecutorThread.ActorSystem;
     }
 
     TActorId TActorContext::RegisterWithSameMailbox(IActor* actor) const {
-        return ExecutorThread.RegisterActor(actor, &Mailbox, SelfID);
+        return RegisterActor(actor, &Mailbox, SelfID);
     }
 
     TActorId IActor::RegisterWithSameMailbox(IActor* actor) const noexcept {
-        return TlsActivationContext->ExecutorThread.RegisterActor(actor, &TlsActivationContext->Mailbox, SelfActorId);
+        return TlsActivationContext->RegisterActor(actor, &TlsActivationContext->Mailbox, SelfActorId);
     }
 
     TActorId IActor::RegisterAlias() noexcept {
-        return TlsActivationContext->ExecutorThread.RegisterAlias(&TlsActivationContext->Mailbox, this);
+        return TlsActivationContext->RegisterAlias(&TlsActivationContext->Mailbox, this);
     }
 
     void IActor::UnregisterAlias(const TActorId& actorId) noexcept {
-        return TlsActivationContext->ExecutorThread.UnregisterAlias(&TlsActivationContext->Mailbox, actorId);
+        return TlsActivationContext->UnregisterAlias(&TlsActivationContext->Mailbox, actorId);
     }
 
     TActorId TActivationContext::InterconnectProxy(ui32 destinationNodeId) {
@@ -155,43 +192,43 @@ namespace NActors {
     }
 
     TActorId IActor::Register(IActor* actor, TMailboxType::EType mailboxType, ui32 poolId) const noexcept {
-        return TlsActivationContext->ExecutorThread.RegisterActor(actor, mailboxType, poolId, SelfActorId);
+        return TActivationContext::Register(actor, SelfActorId, mailboxType, poolId);
     }
 
     void TActorContext::Schedule(TInstant deadline, IEventBase* ev, ISchedulerCookie* cookie) const {
-        ExecutorThread.Schedule(deadline, new IEventHandle(SelfID, TActorId(), ev), cookie);
+        DoSchedule(deadline, new IEventHandle(SelfID, TActorId(), ev), cookie);
     }
 
     void TActorContext::Schedule(TMonotonic deadline, IEventBase* ev, ISchedulerCookie* cookie) const {
-        ExecutorThread.Schedule(deadline, new IEventHandle(SelfID, TActorId(), ev), cookie);
+        DoSchedule(deadline, new IEventHandle(SelfID, TActorId(), ev), cookie);
     }
 
     void TActorContext::Schedule(TDuration delta, IEventBase* ev, ISchedulerCookie* cookie) const {
-        ExecutorThread.Schedule(delta, new IEventHandle(SelfID, TActorId(), ev), cookie);
+        DoSchedule(delta, new IEventHandle(SelfID, TActorId(), ev), cookie);
     }
 
     void TActorContext::Schedule(TInstant deadline, std::unique_ptr<IEventHandle> ev, ISchedulerCookie* cookie) const {
-        ExecutorThread.Schedule(deadline, ev.release(), cookie);
+        DoSchedule(deadline, TAutoPtr<IEventHandle>(ev.release()), cookie);
     }
 
     void TActorContext::Schedule(TMonotonic deadline, std::unique_ptr<IEventHandle> ev, ISchedulerCookie* cookie) const {
-        ExecutorThread.Schedule(deadline, ev.release(), cookie);
+        DoSchedule(deadline, TAutoPtr<IEventHandle>(ev.release()), cookie);
     }
 
     void TActorContext::Schedule(TDuration delta, std::unique_ptr<IEventHandle> ev, ISchedulerCookie* cookie) const {
-        ExecutorThread.Schedule(delta, ev.release(), cookie);
+        DoSchedule(delta, TAutoPtr<IEventHandle>(ev.release()), cookie);
     }
 
     void IActor::Schedule(TInstant deadline, IEventBase* ev, ISchedulerCookie* cookie) const noexcept {
-        TlsActivationContext->ExecutorThread.Schedule(deadline, new IEventHandle(SelfActorId, TActorId(), ev), cookie);
+        TActivationContext::Schedule(deadline, new IEventHandle(SelfActorId, TActorId(), ev), cookie);
     }
 
     void IActor::Schedule(TMonotonic deadline, IEventBase* ev, ISchedulerCookie* cookie) const noexcept {
-        TlsActivationContext->ExecutorThread.Schedule(deadline, new IEventHandle(SelfActorId, TActorId(), ev), cookie);
+        TActivationContext::Schedule(deadline, new IEventHandle(SelfActorId, TActorId(), ev), cookie);
     }
 
     void IActor::Schedule(TDuration delta, IEventBase* ev, ISchedulerCookie* cookie) const noexcept {
-        TlsActivationContext->ExecutorThread.Schedule(delta, new IEventHandle(SelfActorId, TActorId(), ev), cookie);
+        TActivationContext::Schedule(delta, new IEventHandle(SelfActorId, TActorId(), ev), cookie);
     }
 
     TInstant TActivationContext::Now() {
@@ -203,11 +240,11 @@ namespace NActors {
     }
 
     TInstant TActorContext::Now() const {
-        return ExecutorThread.ActorSystem->Timestamp();
+        return GetActorSystem()->Timestamp();
     }
 
     TMonotonic TActorContext::Monotonic() const {
-        return ExecutorThread.ActorSystem->Monotonic();
+        return GetActorSystem()->Monotonic();
     }
 
     NLog::TSettings* TActivationContext::LoggerSettings() const {
@@ -259,7 +296,7 @@ namespace NActors {
 
     void IActor::FinishPassAway() {
         auto& cx = *TlsActivationContext;
-        cx.ExecutorThread.UnregisterActor(&cx.Mailbox, SelfActorId);
+        cx.UnregisterActor(&cx.Mailbox, SelfActorId);
     }
 
     void IActor::DestroyActorTasks() {
@@ -471,13 +508,22 @@ namespace NActors {
         ThreadCtx.Pool()->UnregisterAlias(mailbox, actorId);
     }
 
+    template bool TActivationContext::DoSend<ESendingType::Common>(TAutoPtr<IEventHandle> ev) const;
+    template bool TActivationContext::DoSend<ESendingType::Lazy>(TAutoPtr<IEventHandle> ev) const;
+    template bool TActivationContext::DoSend<ESendingType::Tail>(TAutoPtr<IEventHandle> ev) const;
+
+    template <ESendingType SendingType>
+    bool TActivationContext::DoSend(TAutoPtr<IEventHandle> ev) const {
+        return ExecutorThread.Send<SendingType>(ev);
+    }
+
     template bool TActivationContext::Send<ESendingType::Common>(TAutoPtr<IEventHandle> ev);
     template bool TActivationContext::Send<ESendingType::Lazy>(TAutoPtr<IEventHandle> ev);
     template bool TActivationContext::Send<ESendingType::Tail>(TAutoPtr<IEventHandle> ev);
 
     template <ESendingType SendingType>
     bool TActivationContext::Send(TAutoPtr<IEventHandle> ev) {
-        return TlsActivationContext->ExecutorThread.Send<SendingType>(ev);
+        return TlsActivationContext->DoSend<SendingType>(ev);
     }
 
     template bool TActivationContext::Send<ESendingType::Common>(std::unique_ptr<IEventHandle> &&ev);
@@ -486,7 +532,7 @@ namespace NActors {
 
     template <ESendingType SendingType>
     bool TActivationContext::Send(std::unique_ptr<IEventHandle> &&ev) {
-        return TlsActivationContext->ExecutorThread.Send<SendingType>(ev.release());
+        return TlsActivationContext->DoSend<SendingType>(TAutoPtr<IEventHandle>(ev.release()));
     }
 
     template bool TActivationContext::Forward<ESendingType::Common>(TAutoPtr<IEventHandle>& ev, const TActorId& recipient);
@@ -522,7 +568,7 @@ namespace NActors {
 
     template <ESendingType SendingType>
     bool TActorContext::Send(TAutoPtr<IEventHandle> ev) const {
-        return ExecutorThread.Send<SendingType>(ev);
+        return DoSend<SendingType>(ev);
     }
 
     template bool TActorContext::Forward<ESendingType::Common>(TAutoPtr<IEventHandle>& ev, const TActorId& recipient) const;
@@ -531,7 +577,7 @@ namespace NActors {
 
     template <ESendingType SendingType>
     bool TActorContext::Forward(TAutoPtr<IEventHandle>& ev, const TActorId& recipient) const {
-        return ExecutorThread.Send<SendingType>(IEventHandle::Forward(ev, recipient));
+        return DoSend<SendingType>(IEventHandle::Forward(ev, recipient));
     }
 
     template bool TActorContext::Forward<ESendingType::Common>(THolder<IEventHandle>& ev, const TActorId& recipient) const;
@@ -540,7 +586,16 @@ namespace NActors {
 
     template <ESendingType SendingType>
     bool TActorContext::Forward(THolder<IEventHandle>& ev, const TActorId& recipient) const {
-        return ExecutorThread.Send<SendingType>(IEventHandle::Forward(ev, recipient));
+        return DoSend<SendingType>(IEventHandle::Forward(ev, recipient));
+    }
+
+    template TActorId TActivationContext::DoRegister<ESendingType::Common>(IActor* actor, TActorId parentId, TMailboxType::EType mailboxType, ui32 poolId) const;
+    template TActorId TActivationContext::DoRegister<ESendingType::Lazy>(IActor* actor, TActorId parentId, TMailboxType::EType mailboxType, ui32 poolId) const;
+    template TActorId TActivationContext::DoRegister<ESendingType::Tail>(IActor* actor, TActorId parentId, TMailboxType::EType mailboxType, ui32 poolId) const;
+
+    template <ESendingType SendingType>
+    TActorId TActivationContext::DoRegister(IActor* actor, TActorId parentId, TMailboxType::EType mailboxType, ui32 poolId) const {
+        return ExecutorThread.RegisterActor<SendingType>(actor, mailboxType, poolId, parentId);
     }
 
     template TActorId TActivationContext::Register<ESendingType::Common>(IActor* actor, TActorId parentId, TMailboxType::EType mailboxType, ui32 poolId);
@@ -549,7 +604,7 @@ namespace NActors {
 
     template <ESendingType SendingType>
     TActorId TActivationContext::Register(IActor* actor, TActorId parentId, TMailboxType::EType mailboxType, ui32 poolId) {
-        return TlsActivationContext->ExecutorThread.RegisterActor<SendingType>(actor, mailboxType, poolId, parentId);
+        return TlsActivationContext->DoRegister<SendingType>(actor, parentId, mailboxType, poolId);
     }
 
     template TActorId TActorContext::Register<ESendingType::Common>(IActor* actor, TMailboxType::EType mailboxType, ui32 poolId) const;
@@ -558,7 +613,7 @@ namespace NActors {
 
     template <ESendingType SendingType>
     TActorId TActorContext::Register(IActor* actor, TMailboxType::EType mailboxType, ui32 poolId) const {
-        return ExecutorThread.RegisterActor<SendingType>(actor, mailboxType, poolId, SelfID);
+        return DoRegister<SendingType>(actor, SelfID, mailboxType, poolId);
     }
 
     template bool TActorIdentity::Send<ESendingType::Common>(const TActorId& recipient, IEventBase* ev, TEventFlags flags, ui64 cookie, NWilson::TTraceId traceId) const;
@@ -586,7 +641,7 @@ namespace NActors {
     template <ESendingType SendingType>
     TActorId IActor::Register(IActor* actor, TMailboxType::EType mailboxType, ui32 poolId) const noexcept {
         Y_ABORT_UNLESS(actor);
-        return TlsActivationContext->ExecutorThread.RegisterActor<SendingType>(actor, mailboxType, poolId, SelfActorId);
+        return TActivationContext::Register<SendingType>(actor, SelfActorId, mailboxType, poolId);
     }
 
     template TActorId TActorSystem::Register<ESendingType::Common>(IActor* actor, TMailboxType::EType mailboxType, ui32 executorPool,

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -47,14 +47,15 @@ namespace NActors {
     struct TActivationContext {
     public:
         TMailbox& Mailbox;
-        TExecutorThread& ExecutorThread;
         const NHPTimer::STime EventStart;
+
+        TActivationContext(const TActivationContext&) = default;
 
     protected:
         explicit TActivationContext(TMailbox& mailbox, TExecutorThread& executorThread, NHPTimer::STime eventStart)
             : Mailbox(mailbox)
-            , ExecutorThread(executorThread)
             , EventStart(eventStart)
+            , ExecutorThread(executorThread)
         {
         }
 
@@ -139,6 +140,37 @@ namespace NActors {
         static void SetOverwrittenEventsPerMailbox(ui32 value);
         static ui64 GetOverwrittenTimePerMailboxTs();
         static void SetOverwrittenTimePerMailboxTs(ui64 value);
+
+        // Instance methods mirroring TExecutorThread — use instead of accessing ExecutorThread directly
+
+        template <ESendingType SendingType = ESendingType::Common>
+        TActorId RegisterActor(IActor* actor, TMailbox* mailbox, TActorId parentId = TActorId()) const;
+
+        TActorId RegisterAlias(TMailbox* mailbox, IActor* actor) const;
+        void UnregisterAlias(TMailbox* mailbox, const TActorId& actorId) const;
+
+        void UnregisterActor(TMailbox* mailbox, TActorId actorId) const;
+
+        TActorSystem* GetActorSystem() const;
+
+        TActorContext MakeFor(TActorId id) const;
+
+    protected:
+        // Instance primitives — use the executor thread bound to this context.
+        // Static methods delegate through TlsActivationContext; TActorContext
+        // methods call these directly via inheritance so they use `this`.
+        template <ESendingType SendingType = ESendingType::Common>
+        bool DoSend(TAutoPtr<IEventHandle> ev) const;
+
+        void DoSchedule(TInstant deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie = nullptr) const;
+        void DoSchedule(TMonotonic deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie = nullptr) const;
+        void DoSchedule(TDuration delta, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie = nullptr) const;
+
+        template <ESendingType SendingType = ESendingType::Common>
+        TActorId DoRegister(IActor* actor, TActorId parentId, TMailboxType::EType mailboxType = TMailboxType::HTSwap, ui32 poolId = Max<ui32>()) const;
+
+    private:
+        TExecutorThread& ExecutorThread;
     };
 
     struct TActorContext: public TActivationContext {
@@ -146,6 +178,12 @@ namespace NActors {
         using TEventFlags = IEventHandle::TEventFlags;
         explicit TActorContext(TMailbox& mailbox, TExecutorThread& executorThread, NHPTimer::STime eventStart, const TActorId& selfID)
             : TActivationContext(mailbox, executorThread, eventStart)
+            , SelfID(selfID)
+        {
+        }
+
+        TActorContext(const TActivationContext& ctx, const TActorId& selfID)
+            : TActivationContext(ctx)
             , SelfID(selfID)
         {
         }
@@ -206,7 +244,7 @@ namespace NActors {
         void Schedule(TDuration delta, std::unique_ptr<IEventHandle> ev, ISchedulerCookie* cookie = nullptr) const;
 
         TActorContext MakeFor(const TActorId& otherId) const {
-            return TActorContext(Mailbox, ExecutorThread, EventStart, otherId);
+            return TActorContext(*this, otherId);
         }
 
         // register new actor in ActorSystem on new fresh mailbox.
@@ -222,6 +260,10 @@ namespace NActors {
 
         std::pair<ui32, ui32> CountMailboxEvents(ui32 maxTraverse = Max<ui32>()) const;
     };
+
+    inline TActorContext TActivationContext::MakeFor(TActorId id) const {
+        return TActorContext(*this, id);
+    }
 
     struct TActorIdentity: public TActorId {
         using TEventFlags = IEventHandle::TEventFlags;
@@ -968,8 +1010,7 @@ namespace NActors {
     }
 
     inline TActorContext TActivationContext::ActorContextFor(TActorId id) {
-        auto& tls = *TlsActivationContext;
-        return TActorContext(tls.Mailbox, tls.ExecutorThread, tls.EventStart, id);
+        return TActorContext(*TlsActivationContext, id);
     }
 
     class TDecorator : public IActorCallback {

--- a/ydb/library/actors/core/actor_coroutine.cpp
+++ b/ydb/library/actors/core/actor_coroutine.cpp
@@ -1,5 +1,4 @@
 #include "actor_coroutine.h"
-#include "executor_thread.h"
 
 #include <util/system/sanitizers.h>
 #include <util/system/type_name.h>
@@ -46,7 +45,7 @@ namespace NActors {
     }
 
     bool TActorCoroImpl::Send(TAutoPtr<IEventHandle> ev) {
-        return GetActorContext().ExecutorThread.Send(ev);
+        return GetActorContext().Send(ev);
     }
 
     THolder<IEventHandle> TActorCoroImpl::WaitForEvent(TMonotonic deadline) {
@@ -83,7 +82,7 @@ namespace NActors {
 
         // prepare actor context for in-coroutine use
         TActivationContext *ac = TlsActivationContext;
-        TActorContext actorContext(ac->Mailbox, ac->ExecutorThread, ac->EventStart, SelfActorId);
+        TActorContext actorContext = ac->MakeFor(SelfActorId);
         TlsActivationContext = &actorContext;
 
         Resume(std::move(ev));
@@ -171,7 +170,7 @@ namespace NActors {
     }
 
     TActorSystem *TActorCoroImpl::GetActorSystem() const {
-        return GetActorContext().ExecutorThread.ActorSystem;
+        return GetActorContext().GetActorSystem();
     }
 
     TActorCoro::~TActorCoro() {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`TExecutorThread& ExecutorThread` field in `TActivationContext` is now **private**.

All call sites that previously accessed it directly now use new instance methods on `TActivationContext`:

#### New public instance methods

- `RegisterActor<SendingType>(actor, mailbox, parentId)` — register actor on existing mailbox
- `RegisterAlias(mailbox, actor)` / `UnregisterAlias(mailbox, actorId)` — alias management
- `UnregisterActor(mailbox, actorId)` — actor unregistration
- `GetActorSystem()` — returns `TActorSystem*`
- `MakeFor(actorId)` — construct `TActorContext` sharing this context's state

#### New protected `Do*` primitives

- `DoSend<SendingType>(ev)`
- `DoSchedule(deadline, ev, cookie)` (3 overloads)
- `DoRegister<SendingType>(actor, parentId, mailboxType, poolId)`

Existing **static** methods (`Send`, `Schedule`, `Register`) now delegate through `TlsActivationContext->Do*()`. `TActorContext` calls inherited `Do*()` on `this` directly, preserving correct instance dispatch without TLS bounce.

#### TActorContext construction

Added a protected copy constructor to `TActivationContext` and a new `TActorContext(const TActivationContext&, TActorId)` constructor. This replaces direct field access in `MakeFor()` and `ActorContextFor()`.
