### PR TITLE
[NBS-6905]: Add new volume, partition tablet types for NBS2

### DIFF
--- a/ydb/core/mind/hive/hive.cpp
+++ b/ydb/core/mind/hive/hive.cpp
@@ -187,6 +187,8 @@ const std::unordered_map<TTabletTypes::EType, TString> TABLET_TYPE_SHORT_NAMES =
                                                                                   {TTabletTypes::Mediator, "M"},
                                                                                   {TTabletTypes::BlockStoreVolume, "BV"},
                                                                                   {TTabletTypes::BlockStorePartition2, "BP"},
+                                                                                  {TTabletTypes::BlockStoreVolumeDirect, "DV"},
+                                                                                  {TTabletTypes::BlockStorePartitionDirect, "DP"},
                                                                                   {TTabletTypes::Kesus, "K"},
                                                                                   {TTabletTypes::SysViewProcessor, "SV"},
                                                                                   {TTabletTypes::FileStore, "FS"},

--- a/ydb/core/mind/hive/tx__seize_tablets.cpp
+++ b/ydb/core/mind/hive/tx__seize_tablets.cpp
@@ -32,7 +32,9 @@ public:
                 && tablet.Type != TTabletTypes::Hive // because we leave hive(s) in root hive
                 && tablet.Type != TTabletTypes::BlockStoreVolume // because we don't have support for NBS yet
                 && tablet.Type != TTabletTypes::BlockStorePartition // because we don't have support for NBS yet
-                && tablet.Type != TTabletTypes::BlockStorePartition2; // because we don't have support for NBS yet
+                && tablet.Type != TTabletTypes::BlockStorePartition2 // because we don't have support for NBS yet
+                && tablet.Type != TTabletTypes::BlockStoreVolumeDirect // because we don't have support for NBS yet
+                && tablet.Type != TTabletTypes::BlockStorePartitionDirect; // because we don't have support for NBS yet
 
     }
 

--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -272,6 +272,9 @@ enum ESimpleCounters {
     COUNTER_IN_FLIGHT_OPS_TxAlterStreamingQuery = 212  [(CounterOpts) = {Name: "InFlightOps/AlterStreamingQuery"}];
 
     COUNTER_IN_FLIGHT_OPS_TxTruncateTable = 213 [(CounterOpts) = {Name: "InFlightOps/TruncateTable"}];
+
+    COUNTER_BLOCKSTORE_VOLUME_DIRECT_SHARD_COUNT = 214            [(CounterOpts) = {Name: "BlockStoreVolumeDirectShards"}];
+    COUNTER_BLOCKSTORE_PARTITION_DIRECT_SHARD_COUNT = 215        [(CounterOpts) = {Name: "BlockStorePartitionDirectShards"}];
 }
 
 enum ECumulativeCounters {

--- a/ydb/core/protos/tablet.proto
+++ b/ydb/core/protos/tablet.proto
@@ -51,14 +51,16 @@ message TTabletTypes {
         StatisticsAggregator = 40;
         GraphShard = 41;
         BackupController = 42;
+        BlockStorePartitionDirect = 43;
+        BlockStoreVolumeDirect = 44;
 
         // when adding a new tablet type and keeping parse compatibility with the old version
         // rename existing reserved item to desired one, and add new reserved item to
         // the end of reserved list
-        Reserved43 = 43;
-        Reserved44 = 44;
         Reserved45 = 45;
         Reserved46 = 46;
+        Reserved47 = 47;
+        Reserved48 = 48;
 
         UserTypeStart = 255;
         TypeInvalid = -1;

--- a/ydb/core/testlib/tablet_helpers.cpp
+++ b/ydb/core/testlib/tablet_helpers.cpp
@@ -1345,10 +1345,6 @@ namespace NKikimr {
                     bootstrapperActorId = Boot(ctx, type, &NStat::CreateStatisticsAggregator, DataGroupErasure);
                 } else if (type == TTabletTypes::GraphShard) {
                     bootstrapperActorId = Boot(ctx, type, &NGraph::CreateGraphShard, DataGroupErasure);
-                } else if (type == TTabletTypes::BlockStoreVolumeDirect || type == TTabletTypes::BlockStorePartitionDirect) {
-                    // BlockStoreVolumeDirect and BlockStorePartitionDirect are not fully implemented in FakeHive yet
-                    // Just accept the tablet creation without actually booting it
-                    LOG_INFO_S(ctx, NKikimrServices::HIVE, logPrefix << "accepting tablet creation without boot (external-like)");
                 } else {
                     status = NKikimrProto::ERROR;
                 }

--- a/ydb/core/testlib/tablet_helpers.cpp
+++ b/ydb/core/testlib/tablet_helpers.cpp
@@ -1345,6 +1345,10 @@ namespace NKikimr {
                     bootstrapperActorId = Boot(ctx, type, &NStat::CreateStatisticsAggregator, DataGroupErasure);
                 } else if (type == TTabletTypes::GraphShard) {
                     bootstrapperActorId = Boot(ctx, type, &NGraph::CreateGraphShard, DataGroupErasure);
+                } else if (type == TTabletTypes::BlockStoreVolumeDirect || type == TTabletTypes::BlockStorePartitionDirect) {
+                    // BlockStoreVolumeDirect and BlockStorePartitionDirect are not fully implemented in FakeHive yet
+                    // Just accept the tablet creation without actually booting it
+                    LOG_INFO_S(ctx, NKikimrServices::HIVE, logPrefix << "accepting tablet creation without boot (external-like)");
                 } else {
                     status = NKikimrProto::ERROR;
                 }

--- a/ydb/core/tx/schemeshard/schemeshard__delete_tablet_reply.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__delete_tablet_reply.cpp
@@ -77,6 +77,12 @@ struct TSchemeShard::TTxDeleteTabletReply : public TSchemeShard::TRwTxBase {
             case ETabletType::BlockStorePartition2:
                 Self->TabletCounters->Simple()[COUNTER_BLOCKSTORE_PARTITION2_SHARD_COUNT].Sub(1);
                 break;
+            case ETabletType::BlockStoreVolumeDirect:
+                Self->TabletCounters->Simple()[COUNTER_BLOCKSTORE_VOLUME_DIRECT_SHARD_COUNT].Sub(1);
+                break;
+            case ETabletType::BlockStorePartitionDirect:
+                Self->TabletCounters->Simple()[COUNTER_BLOCKSTORE_PARTITION_DIRECT_SHARD_COUNT].Sub(1);
+                break;
             case ETabletType::FileStore:
                 Self->TabletCounters->Simple()[COUNTER_FILESTORE_SHARD_COUNT].Sub(1);
                 break;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2244,6 +2244,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         pqBalancers[shard.PathId] = idx;
                         break;
                     case ETabletType::BlockStoreVolume:
+                    case ETabletType::BlockStoreVolumeDirect:
                         nbsVolumeShards[shard.PathId] = idx;
                         break;
                     case ETabletType::FileStore:
@@ -4224,6 +4225,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 break;
             case ETabletType::BlockStorePartition2:
                 Self->TabletCounters->Simple()[COUNTER_BLOCKSTORE_PARTITION2_SHARD_COUNT].Add(1);
+                break;
+            case ETabletType::BlockStoreVolumeDirect:
+                Self->TabletCounters->Simple()[COUNTER_BLOCKSTORE_VOLUME_DIRECT_SHARD_COUNT].Add(1);
+                break;
+            case ETabletType::BlockStorePartitionDirect:
+                Self->TabletCounters->Simple()[COUNTER_BLOCKSTORE_PARTITION_DIRECT_SHARD_COUNT].Add(1);
                 break;
             case ETabletType::FileStore:
                 Self->TabletCounters->Simple()[COUNTER_FILESTORE_COUNT].Add(1);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -23,7 +23,8 @@ THolder<TEvHive::TEvCreateTablet> CreateEvCreateTablet(TPathElement::TPtr target
     const auto& shard = context.SS->ShardInfos[shardIdx];
 
     if (shard.TabletType == ETabletType::BlockStorePartition ||
-        shard.TabletType == ETabletType::BlockStorePartition2)
+        shard.TabletType == ETabletType::BlockStorePartition2 ||
+        shard.TabletType == ETabletType::BlockStorePartitionDirect)
     {
         auto it = context.SS->BlockStoreVolumes.FindPtr(targetPath->PathId);
         Y_ABORT_UNLESS(it, "Missing BlockStoreVolume while creating BlockStorePartition tablet");
@@ -84,6 +85,7 @@ THolder<TEvHive::TEvCreateTablet> CreateEvCreateTablet(TPathElement::TPtr target
         shard.TabletType == ETabletType::BlockStorePartition2 ||
         shard.TabletType == ETabletType::RTMRPartition) {
         // Partitions should never be booted by local
+        // Except for BlockStorePartitionDirect
         ev->Record.SetTabletBootMode(NKikimrHive::TABLET_BOOT_MODE_EXTERNAL);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -84,8 +84,8 @@ THolder<TEvHive::TEvCreateTablet> CreateEvCreateTablet(TPathElement::TPtr target
     if (shard.TabletType == ETabletType::BlockStorePartition   ||
         shard.TabletType == ETabletType::BlockStorePartition2 ||
         shard.TabletType == ETabletType::RTMRPartition) {
-        // Partitions should never be booted by local
-        // Except for BlockStorePartitionDirect
+        // These partitions should never be booted by local.
+        // BlockStorePartitionDirect is intentionally omitted and may be booted local for now.
         ev->Record.SetTabletBootMode(NKikimrHive::TABLET_BOOT_MODE_EXTERNAL);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_bsv.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_bsv.cpp
@@ -86,11 +86,13 @@ bool TConfigureParts::ProgressState(TOperationContext& context) {
 
     for (auto shard : txState->Shards) {
         if (shard.TabletType == ETabletType::BlockStorePartition ||
-            shard.TabletType == ETabletType::BlockStorePartition2) {
+            shard.TabletType == ETabletType::BlockStorePartition2 ||
+            shard.TabletType == ETabletType::BlockStorePartitionDirect) {
             continue;
         }
 
-        Y_ABORT_UNLESS(shard.TabletType == ETabletType::BlockStoreVolume);
+        Y_ABORT_UNLESS(shard.TabletType == ETabletType::BlockStoreVolume
+            || shard.TabletType == ETabletType::BlockStoreVolumeDirect);
         TShardIdx shardIdx = shard.Idx;
         TTabletId tabletId = context.SS->ShardInfos[shardIdx].TabletID;
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_bsv.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_bsv.cpp
@@ -50,13 +50,19 @@ TBlockStoreVolumeInfo::TPtr CreateBlockStoreVolumeInfo(const NKikimrSchemeOp::TB
 void ApplySharding(TTxId txId, TPathId pathId, TBlockStoreVolumeInfo::TPtr volume, TTxState& txState,
                    const TChannelsBindings& partitionChannels, const TChannelsBindings& volumeChannels,
                    TOperationContext& context) {
-    Y_ABORT_UNLESS(volume->VolumeConfig.GetTabletVersion() <= 2);
+    Y_ABORT_UNLESS(volume->VolumeConfig.GetTabletVersion() <= 3);
     ui64 count = volume->DefaultPartitionCount;
     txState.Shards.reserve(count + 1);
 
     for (ui64 i = 0; i < count; ++i) {
         TShardIdx shardIdx;
-        if (volume->VolumeConfig.GetTabletVersion() == 2) {
+        if (volume->VolumeConfig.GetTabletVersion() == 3) {
+            shardIdx = context.SS->RegisterShardInfo(
+                TShardInfo::BlockStorePartitionDirectInfo(txId, pathId)
+                    .WithBindedChannels(partitionChannels));
+            context.SS->TabletCounters->Simple()[COUNTER_BLOCKSTORE_PARTITION_DIRECT_SHARD_COUNT].Add(1);
+            txState.Shards.emplace_back(shardIdx, ETabletType::BlockStorePartitionDirect, TTxState::CreateParts);
+        } else if (volume->VolumeConfig.GetTabletVersion() == 2) {
             shardIdx = context.SS->RegisterShardInfo(
                 TShardInfo::BlockStorePartition2Info(txId, pathId)
                     .WithBindedChannels(partitionChannels));
@@ -76,12 +82,22 @@ void ApplySharding(TTxId txId, TPathId pathId, TBlockStoreVolumeInfo::TPtr volum
         volume->Shards[shardIdx] = std::move(part);
     }
 
-    const auto shardIdx = context.SS->RegisterShardInfo(
+    if (volume->VolumeConfig.GetTabletVersion() == 3) {
+        const auto shardIdx = context.SS->RegisterShardInfo(
+        TShardInfo::BlockStoreVolumeDirectInfo(txId, pathId)
+            .WithBindedChannels(volumeChannels));
+        context.SS->TabletCounters->Simple()[COUNTER_BLOCKSTORE_VOLUME_DIRECT_SHARD_COUNT].Add(1);
+        txState.Shards.emplace_back(shardIdx, ETabletType::BlockStoreVolumeDirect, TTxState::CreateParts);
+        volume->VolumeShardIdx = shardIdx;
+    } else {
+        const auto shardIdx = context.SS->RegisterShardInfo(
         TShardInfo::BlockStoreVolumeInfo(txId, pathId)
             .WithBindedChannels(volumeChannels));
-    context.SS->TabletCounters->Simple()[COUNTER_BLOCKSTORE_VOLUME_SHARD_COUNT].Add(1);
-    txState.Shards.emplace_back(shardIdx, ETabletType::BlockStoreVolume, TTxState::CreateParts);
-    volume->VolumeShardIdx = shardIdx;
+        context.SS->TabletCounters->Simple()[COUNTER_BLOCKSTORE_VOLUME_SHARD_COUNT].Add(1);
+        txState.Shards.emplace_back(shardIdx, ETabletType::BlockStoreVolume, TTxState::CreateParts);
+        volume->VolumeShardIdx = shardIdx;
+    }
+
 }
 
 TTxState& PrepareChanges(TOperationId operationId, TPathElement::TPtr parentDir,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_bsv.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_bsv.cpp
@@ -84,15 +84,15 @@ void ApplySharding(TTxId txId, TPathId pathId, TBlockStoreVolumeInfo::TPtr volum
 
     if (volume->VolumeConfig.GetTabletVersion() == 3) {
         const auto shardIdx = context.SS->RegisterShardInfo(
-        TShardInfo::BlockStoreVolumeDirectInfo(txId, pathId)
-            .WithBindedChannels(volumeChannels));
+            TShardInfo::BlockStoreVolumeDirectInfo(txId, pathId)
+                .WithBindedChannels(volumeChannels));
         context.SS->TabletCounters->Simple()[COUNTER_BLOCKSTORE_VOLUME_DIRECT_SHARD_COUNT].Add(1);
         txState.Shards.emplace_back(shardIdx, ETabletType::BlockStoreVolumeDirect, TTxState::CreateParts);
         volume->VolumeShardIdx = shardIdx;
     } else {
         const auto shardIdx = context.SS->RegisterShardInfo(
-        TShardInfo::BlockStoreVolumeInfo(txId, pathId)
-            .WithBindedChannels(volumeChannels));
+            TShardInfo::BlockStoreVolumeInfo(txId, pathId)
+                .WithBindedChannels(volumeChannels));
         context.SS->TabletCounters->Simple()[COUNTER_BLOCKSTORE_VOLUME_SHARD_COUNT].Add(1);
         txState.Shards.emplace_back(shardIdx, ETabletType::BlockStoreVolume, TTxState::CreateParts);
         volume->VolumeShardIdx = shardIdx;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -1385,6 +1385,14 @@ struct TShardInfo {
         return TShardInfo(txId, pathId, ETabletType::BlockStorePartition2);
     }
 
+    static TShardInfo BlockStoreVolumeDirectInfo(TTxId txId, TPathId pathId) {
+        return TShardInfo(txId, pathId, ETabletType::BlockStoreVolumeDirect);
+    }
+
+    static TShardInfo BlockStorePartitionDirectInfo(TTxId txId, TPathId pathId) {
+        return TShardInfo(txId, pathId, ETabletType::BlockStorePartitionDirect);
+    }
+
     static TShardInfo FileStoreInfo(TTxId txId, TPathId pathId) {
         return TShardInfo(txId, pathId, ETabletType::FileStore);
     }

--- a/ydb/core/tx/schemeshard/ut_bsvolume/ut_bsvolume.cpp
+++ b/ydb/core/tx/schemeshard/ut_bsvolume/ut_bsvolume.cpp
@@ -229,22 +229,17 @@ Y_UNIT_TEST_SUITE(TBSV) {
         // Test that schema operation is accepted and recognizes TabletVersion=3
         AsyncCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
         
-        // Wait for the operation to be accepted
-        TAutoPtr<IEventHandle> handle;
-        auto createEvent = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>(handle);
-        UNIT_ASSERT(createEvent);
-        UNIT_ASSERT_VALUES_EQUAL(createEvent->Record.GetStatus(), NKikimrScheme::StatusAccepted);
+        // Wait for the operation to complete
+        env.TestWaitNotification(runtime, txId);
         
         // Verify that the schemeshard created shards for the volume
         // With TabletVersion=3 and 1 partition, we should have 2 shards:
         // - 1 BlockStorePartitionDirect shard
         // - 1 BlockStoreVolumeDirect shard
-        // Note: We don't wait for completion because FakeHive doesn't fully support
-        // BlockStoreVolumeDirect tablets yet, but we can verify the shards were registered
         TestDescribeResult(DescribePath(runtime, "/MyRoot/BSVolumeDirect"),
-                           {NLs::PathExist});
+                           {NLs::PathExist, NLs::Finished});
         
-        // Also verify the partition exists
+        // Also verify the partition exists and shard count
         TestDescribeResult(DescribePath(runtime, "/MyRoot/BSVolumeDirect", true, true, true),
                            {NLs::PathExist, NLs::ShardsInsideDomain(2)});
 

--- a/ydb/core/tx/schemeshard/ut_bsvolume/ut_bsvolume.cpp
+++ b/ydb/core/tx/schemeshard/ut_bsvolume/ut_bsvolume.cpp
@@ -202,4 +202,63 @@ Y_UNIT_TEST_SUITE(TBSV) {
         TestDropBlockStoreVolume(runtime, ++txId, root, name);
         env.TestWaitNotification(runtime, txId);
     }
+
+    Y_UNIT_TEST(CreateBlockStoreVolumeDirect) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
+        vdescr.SetName("BSVolumeDirect");
+        auto& vc = *vdescr.MutableVolumeConfig();
+
+        // Set TabletVersion = 3 for BlockStoreVolumeDirect
+        vc.SetTabletVersion(3);
+        vc.SetBlockSize(4096);
+        vc.AddPartitions()->SetBlockCount(16);
+
+        // Add channel profiles for partition (only 2 channels)
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+        vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+
+        // Add volume channel profiles for BlockStoreVolumeDirect
+        vc.AddVolumeExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+        vc.AddVolumeExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+        vc.AddVolumeExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+
+        // Test that schema operation is accepted and recognizes TabletVersion=3
+        AsyncCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
+        
+        // Wait for the operation to be accepted
+        TAutoPtr<IEventHandle> handle;
+        auto createEvent = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>(handle);
+        UNIT_ASSERT(createEvent);
+        UNIT_ASSERT_VALUES_EQUAL(createEvent->Record.GetStatus(), NKikimrScheme::StatusAccepted);
+        
+        // Verify that the schemeshard created shards for the volume
+        // With TabletVersion=3 and 1 partition, we should have 2 shards:
+        // - 1 BlockStorePartitionDirect shard
+        // - 1 BlockStoreVolumeDirect shard
+        // Note: We don't wait for completion because FakeHive doesn't fully support
+        // BlockStoreVolumeDirect tablets yet, but we can verify the shards were registered
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/BSVolumeDirect"),
+                           {NLs::PathExist});
+        
+        // Also verify the partition exists
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/BSVolumeDirect", true, true, true),
+                           {NLs::PathExist, NLs::ShardsInsideDomain(2)});
+
+        // Verify that the actual tablet types are BlockStoreVolumeDirect and BlockStorePartitionDirect
+        ui32 volumeDirectCount = 0;
+        ui32 partitionDirectCount = 0;
+        for (const auto& kv : env.GetHiveState()->Tablets) {
+            if (kv.second.Type == TTabletTypes::BlockStoreVolumeDirect) {
+                ++volumeDirectCount;
+            } else if (kv.second.Type == TTabletTypes::BlockStorePartitionDirect) {
+                ++partitionDirectCount;
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(volumeDirectCount, 1);
+        UNIT_ASSERT_VALUES_EQUAL(partitionDirectCount, 1);
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -85,6 +85,41 @@ private:
     }
 };
 
+// BlockStorePartitionDirect mock for testing schemeshard
+class TFakeBlockStorePartitionDirect : public TActor<TFakeBlockStorePartitionDirect>, public NTabletFlatExecutor::TTabletExecutedFlat {
+public:
+    TFakeBlockStorePartitionDirect(const TActorId& tablet, TTabletStorageInfo* info)
+        : TActor(&TThis::StateInit)
+          , TTabletExecutedFlat(info, tablet,  new NMiniKQL::TMiniKQLFactory)
+    {}
+
+    void DefaultSignalTabletActive(const TActorContext&) override {
+        // must be empty
+    }
+
+    void OnActivateExecutor(const TActorContext& ctx) override {
+        Become(&TThis::StateWork);
+        SignalTabletActive(ctx);
+    }
+
+    void OnDetach(const TActorContext& ctx) override {
+        Die(ctx);
+    }
+
+    void OnTabletDead(TEvTablet::TEvTabletDead::TPtr& ev, const TActorContext& ctx) override {
+        Y_UNUSED(ev);
+        Die(ctx);
+    }
+
+    STFUNC(StateInit) {
+        StateInitImpl(ev, SelfId());
+    }
+
+    STFUNC(StateWork) {
+        HandleDefaultEvents(ev, SelfId());
+    }
+};
+
 class TFakeFileStore : public TActor<TFakeFileStore>, public NTabletFlatExecutor::TTabletExecutedFlat {
 public:
     TFakeFileStore(const TActorId& tablet, TTabletStorageInfo* info)
@@ -995,8 +1030,13 @@ void NSchemeShardUT_Private::TTestEnv::SimulateSleep(NActors::TTestActorRuntime 
 std::function<NActors::IActor *(const NActors::TActorId &, NKikimr::TTabletStorageInfo *)> NSchemeShardUT_Private::TTestEnv::GetTabletCreationFunc(ui32 type) {
     switch (type) {
     case TTabletTypes::BlockStoreVolume:
+    case TTabletTypes::BlockStoreVolumeDirect:
         return [](const TActorId& tablet, TTabletStorageInfo* info) {
             return new TFakeBlockStoreVolume(tablet, info);
+        };
+    case TTabletTypes::BlockStorePartitionDirect:
+        return [](const TActorId& tablet, TTabletStorageInfo* info) {
+            return new TFakeBlockStorePartitionDirect(tablet, info);
         };
     case TTabletTypes::FileStore:
         return [](const TActorId& tablet, TTabletStorageInfo* info) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add new volume, partition tablet types for NBS2.
If tablet type is set to 3, create new type of partition, volume tablet for NBS 2.
For now hive will start both partition and volume tablets for NBS 2.