### PR TITLE
25-2-1-e: Save the value of the `IsRestore` flag for index tables

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.cpp
@@ -224,12 +224,20 @@ void FillIndexImplTableColumns(
     }
 }
 
+bool GetIsRestore(const NSchemeShard::TTableInfo::TPtr& tableInfo) {
+    return tableInfo->IsRestore;
+}
+
 const auto& GetPartitionConfig(const NSchemeShard::TTableInfo::TPtr& tableInfo) {
     return tableInfo->PartitionConfig();
 }
 
 const auto& GetColumns(const NSchemeShard::TTableInfo::TPtr& tableInfo) {
     return tableInfo->Columns;
+}
+
+bool GetIsRestore(const NKikimrSchemeOp::TTableDescription& tableDescr) {
+    return tableDescr.GetIsRestore();
 }
 
 const auto& GetPartitionConfig(const NKikimrSchemeOp::TTableDescription& tableDescr) {
@@ -247,6 +255,7 @@ auto CalcImplTableDescImpl(
 {
     NKikimrSchemeOp::TTableDescription implTableDesc;
     implTableDesc.SetName(NTableIndex::ImplTable);
+    implTableDesc.SetIsRestore(GetIsRestore(baseTable));
     SetImplTablePartitionConfig(GetPartitionConfig(baseTable), indexTableDesc, implTableDesc);
     FillIndexImplTableColumns(GetColumns(baseTable), implTableColumns.Keys, implTableColumns.Columns, implTableDesc);
     if (indexTableDesc.HasReplicationConfig()) {

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -3906,6 +3906,66 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
         env.TestWaitNotification(runtime, txId);
     }
 
+    Y_UNIT_TEST(CopyIndexedTablesForBackup) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Table"
+              Columns { Name: "key" Type: "Uint32"}
+              Columns { Name: "value" Type: "Utf8"}
+              KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+              Name: "Index"
+              KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/Index/indexImplTable"), {
+            NLs::IsBackupTable(false),
+        });
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "CopyTable"
+            CopyFromTable: "/MyRoot/Table"
+            IsBackup: true
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/CopyTable/Index/indexImplTable"), {
+            NLs::IsBackupTable(true),
+        });
+    }
+
+    Y_UNIT_TEST(CreateIndexedTablesForRestore) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Table"
+              Columns { Name: "key" Type: "Uint32"}
+              Columns { Name: "value" Type: "Utf8"}
+              KeyColumnNames: ["key"]
+              IsRestore: true
+            }
+            IndexDescription {
+              Name: "Index"
+              KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/Index/indexImplTable"), {
+            NLs::IsRestoreTable(true),
+        });
+    }
+
     Y_UNIT_TEST(CreateIndexedTableAfterBackup) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -1187,6 +1187,12 @@ TCheckFunc IsBackupTable(bool value) {
     };
 }
 
+TCheckFunc IsRestoreTable(bool value) {
+    return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
+        UNIT_ASSERT_VALUES_EQUAL(value, record.GetPathDescription().GetTable().GetIsRestore());
+    };
+}
+
 TCheckFunc ReplicationMode(NKikimrSchemeOp::TTableReplicationConfig::EReplicationMode mode) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
         const auto& table = record.GetPathDescription().GetTable();

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
@@ -128,6 +128,7 @@ namespace NLs {
         NKikimrSchemeOp::TTTLSettings::EUnit columnUnit = NKikimrSchemeOp::TTTLSettings::UNIT_AUTO);
     TCheckFunc HasTtlDisabled();
     TCheckFunc IsBackupTable(bool value);
+    TCheckFunc IsRestoreTable(bool value);
     TCheckFunc ReplicationMode(NKikimrSchemeOp::TTableReplicationConfig::EReplicationMode mode);
     TCheckFunc ReplicationState(NKikimrReplication::TReplicationState::StateCase state);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed an [issue](https://github.com/ydb-platform/ydb/issues/34247) where the value of the `IsRestore` flag for index tables was not being saved. This could lead to an error when restoring data in index tables.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

main: https://github.com/ydb-platform/ydb/pull/34260