### PR TITLE
[25-4-1] Fix select from prefixed vector index when the index contains PK columns

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -867,14 +867,18 @@ TExprBase DoRewriteTopSortOverPrefixedKMeansTree(
         auto optionalIf = newLambda.Body().Cast<TCoOptionalIf>();
         auto oldValue = optionalIf.Value().Maybe<TCoAsStruct>();
         if (!oldValue) {
+            // SELECT *
+            prefixInResult = true;
             return newLambda.Ptr();
         }
+        // SELECT specific fields
         auto args = newLambda.Args();
         mainLambda = NewLambdaFrom(ctx, pos, replaces, args.Ref(), oldValue.Cast());
+        auto arg0 = mainLambda.Cast().Args().Arg(0).Raw();
         VisitExpr(mainLambda.Cast().Ptr(), [&](const TExprNode::TPtr& node) {
             if (const auto maybeMember = TMaybeNode<TCoMember>(node)) {
                 const auto member = maybeMember.Cast();
-                if (member.Struct().Raw() == args.Arg(0).Raw() &&
+                if (member.Struct().Raw() == arg0 &&
                     prefixColumnSet.contains(member.Name().Value())) {
                     prefixInResult = true;
                     return false;

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_prefixed_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_prefixed_vector_ut.cpp
@@ -27,13 +27,14 @@ using namespace NYdb::NTable;
 
 Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
 
-    constexpr int F_NULLABLE   = 1 << 0;
-    constexpr int F_COVERING   = 1 << 1;
-    constexpr int F_RETURNING  = 1 << 2;
-    constexpr int F_SIMILARITY = 1 << 3;
-    constexpr int F_SUFFIX_PK  = 1 << 4;
-    constexpr int F_WITH_INDEX = 1 << 5;
-    constexpr int F_OVERLAP    = 1 << 6;
+    constexpr int F_NULLABLE    = 1 << 0;
+    constexpr int F_COVERING    = 1 << 1;
+    constexpr int F_RETURNING   = 1 << 2;
+    constexpr int F_SIMILARITY  = 1 << 3;
+    constexpr int F_SUFFIX_PK   = 1 << 4;
+    constexpr int F_WITH_INDEX  = 1 << 5;
+    constexpr int F_OVERLAP     = 1 << 6;
+    constexpr int F_WITH_PREFIX = 1 << 7;
 
     std::vector<i64> DoPositiveQueryVectorIndex(TSession& session, const TString& query, int flags = 0) {
         {
@@ -62,6 +63,10 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
             for (const auto& set : sets) {
                 TResultSetParser parser{set};
                 while (parser.TryNextRow()) {
+                    if (flags & F_WITH_PREFIX) {
+                        auto value = parser.GetValue("user");
+                        UNIT_ASSERT_C(value.GetProto().has_bytes_value(), value.GetProto().ShortUtf8DebugString());
+                    }
                     auto value = parser.GetValue("pk");
                     UNIT_ASSERT_C(value.GetProto().has_int64_value(), value.GetProto().ShortUtf8DebugString());
                     r.push_back(value.GetProto().int64_value());
@@ -121,7 +126,7 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
             )", init, metric, direction)));
             DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery, flags, count);
         }
-        if (flags & F_COVERING) {
+        {
             // check the same but with user column in select to check that it's not mistakenly removed
             const TString plainQuery(Q1_(std::format(R"({}
                 SELECT * FROM `/Root/TestTable`
@@ -138,7 +143,7 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
                 LIMIT 3;
             )", init, metric, direction)));
             // select * will read from the main table
-            DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery, flags & ~F_COVERING, count);
+            DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery, flags & ~F_COVERING | F_WITH_PREFIX, count);
         }
         // metric in result
         {
@@ -149,7 +154,7 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
                 LIMIT 3;
             )", init, metric, metric, direction)));
             const TString indexQuery(Q1_(std::format(R"({}
-                pragma ydb.KMeansTreeSearchTopSize = "2";
+                pragma ydb.KMeansTreeSearchTopSize = "3";
                 SELECT {}, pk, emb, data FROM `/Root/TestTable` VIEW index
                 WHERE user = $user
                 ORDER BY {} {}
@@ -460,6 +465,37 @@ Y_UNIT_TEST_SUITE(KqpPrefixedVectorIndexes) {
 
     Y_UNIT_TEST_TWIN(CosineDistanceWithPkSuffixWithOverlap, Covered) {
         DoTestOrderByCosine(2, F_SUFFIX_PK | F_OVERLAP | (Covered ? F_COVERING : 0));
+    }
+
+    Y_UNIT_TEST(SubPrefix) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, 0);
+
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, pk, emb)
+                    WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+                )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        // index on (user, pk, emb) but selecting on (user order by emb)
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session, 0);
     }
 
     void DoTestPrefixedVectorIndexInsert(int flags) {


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Cherry-pick of #34261