### PR TITLE
Try to support Decimal and Uuid in arrow converters

### DIFF
--- a/ydb/core/formats/arrow/converter.h
+++ b/ydb/core/formats/arrow/converter.h
@@ -58,6 +58,11 @@ private:
         return MakeCellFromView<arrow::Decimal128Array>(column, row);
     }
 
+    template <>
+    TCell MakeCell<arrow::FixedSizeBinaryArray>(const std::shared_ptr<arrow::Array>& column, i64 row) {
+        return MakeCellFromView<arrow::FixedSizeBinaryArray>(column, row);
+    }
+
 public:
     static bool NeedDataConversion(const NScheme::TTypeInfo& colType);
     

--- a/ydb/core/formats/arrow/ut/ut_arrow.cpp
+++ b/ydb/core/formats/arrow/ut/ut_arrow.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/formats/arrow/reader/result_builder.h>
 
 #include <yql/essentials/types/binary_json/write.h>
+#include <yql/essentials/public/decimal/yql_decimal.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/string/printf.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/api.h>
@@ -625,6 +626,99 @@ Y_UNIT_TEST_SUITE(ArrowTest) {
         }
     }
 
+    Y_UNIT_TEST(BatchBuilder_Decimal) {
+        std::vector<std::pair<TString, TTypeInfo>> ydbSchema = {
+            {"decimal_col", TTypeInfo(NScheme::TDecimalType(NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE))}
+        };
+
+        TString err;
+        NArrow::TArrowBatchBuilder batchBuilder;
+        batchBuilder.Start(ydbSchema, 0, 0, err);
+        UNIT_ASSERT_C(err.empty(), err);
+
+        std::vector<std::string> testValues;
+        for (int i = 0; i < 5; ++i) {
+            auto decimal = NYql::NDecimal::FromString(TStringBuilder() << (i + 1) << ".123", NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE);
+            auto pair = NYql::NDecimal::MakePair(decimal);
+            std::string value(16, '\0');
+            std::memcpy(value.data(), &pair.first, sizeof(pair.first));
+            std::memcpy(value.data() + sizeof(pair.first), &pair.second, sizeof(pair.second));
+            testValues.push_back(value);
+        }
+
+        TTypeInfo decimalTypeInfo(NScheme::TDecimalType(NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE));
+        const TTypeInfo types[1] = {decimalTypeInfo};
+
+        for (const auto& value : testValues) {
+            TCell cells[1];
+            cells[0] = TCell(value.data(), value.size());
+            NKikimr::TDbTupleRef key;
+            NKikimr::TDbTupleRef row(types, cells, 1);
+            batchBuilder.AddRow(key, row);
+        }
+
+        auto batch = batchBuilder.FlushBatch(false);
+        UNIT_ASSERT(batch);
+        UNIT_ASSERT_VALUES_EQUAL(batch->num_rows(), testValues.size());
+
+        auto column = batch->column(0);
+        UNIT_ASSERT(column->type()->id() == arrow::Type::FIXED_SIZE_BINARY);
+        auto fsb_type = std::static_pointer_cast<arrow::FixedSizeBinaryType>(column->type());
+        UNIT_ASSERT_VALUES_EQUAL(fsb_type->byte_width(), NScheme::FSB_SIZE);
+
+        auto fsb_array = std::static_pointer_cast<arrow::FixedSizeBinaryArray>(column);
+        for (size_t i = 0; i < testValues.size(); ++i) {
+            auto value = fsb_array->GetString(i);
+            UNIT_ASSERT_VALUES_EQUAL(value, testValues[i]);
+        }
+    }
+
+    Y_UNIT_TEST(BatchBuilder_Uuid) {
+        std::vector<std::pair<TString, TTypeInfo>> ydbSchema = {
+            {"uuid_col", TTypeInfo(NTypeIds::Uuid)}
+        };
+
+        TString err;
+        NArrow::TArrowBatchBuilder batchBuilder;
+        batchBuilder.Start(ydbSchema, 0, 0, err);
+        UNIT_ASSERT_C(err.empty(), err);
+
+        std::vector<std::string> testValues;
+        for (int i = 0; i < 5; ++i) {
+            std::string uuid(16, '\0');
+            for (size_t j = 0; j < 16; ++j) {
+                uuid[j] = static_cast<char>((i * 16 + j) % 256);
+            }
+            testValues.push_back(uuid);
+        }
+
+        TTypeInfo uuidTypeInfo(NTypeIds::Uuid);
+        const TTypeInfo types[1] = {uuidTypeInfo};
+
+        for (const auto& value : testValues) {
+            TCell cells[1];
+            cells[0] = TCell(value.data(), value.size());
+            NKikimr::TDbTupleRef key;
+            NKikimr::TDbTupleRef row(types, cells, 1);
+            batchBuilder.AddRow(key, row);
+        }
+
+        auto batch = batchBuilder.FlushBatch(false);
+        UNIT_ASSERT(batch);
+        UNIT_ASSERT_VALUES_EQUAL(batch->num_rows(), testValues.size());
+
+        auto column = batch->column(0);
+        UNIT_ASSERT(column->type()->id() == arrow::Type::FIXED_SIZE_BINARY);
+        auto fsb_type = std::static_pointer_cast<arrow::FixedSizeBinaryType>(column->type());
+        UNIT_ASSERT_VALUES_EQUAL(fsb_type->byte_width(), NScheme::FSB_SIZE);
+
+        auto fsb_array = std::static_pointer_cast<arrow::FixedSizeBinaryArray>(column);
+        for (size_t i = 0; i < testValues.size(); ++i) {
+            auto value = fsb_array->GetString(i);
+            UNIT_ASSERT_VALUES_EQUAL(value, testValues[i]);
+        }
+    }
+
     Y_UNIT_TEST(ArrowToYdbConverter) {
         std::vector<TDataRow> rows = TestRows();
 
@@ -661,6 +755,103 @@ Y_UNIT_TEST_SUITE(ArrowTest) {
                             cellRows[i].data(), rowWriter.Rows[i].data(),
                             TDataRow::MakeTypeInfos(),
                             cellRows[i].size(), rowWriter.Rows[i].size()));
+        }
+    }
+
+        Y_UNIT_TEST(ArrowToYdbConverter_Decimal) {
+        std::vector<std::pair<TString, TTypeInfo>> ydbSchema = {
+            {"decimal_col", TTypeInfo(NScheme::TDecimalType(NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE))}
+        };
+
+        std::vector<std::string> testValues;
+        for (int i = 0; i < 5; ++i) {
+            auto decimal = NYql::NDecimal::FromString(TStringBuilder() << (i + 1) << ".456", NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE);
+            auto pair = NYql::NDecimal::MakePair(decimal);
+            std::string value(16, '\0');
+            std::memcpy(value.data(), &pair.first, sizeof(pair.first));
+            std::memcpy(value.data() + sizeof(pair.first), &pair.second, sizeof(pair.second));
+            testValues.push_back(value);
+        }
+
+        arrow::FixedSizeBinaryBuilder builder(arrow::fixed_size_binary(NScheme::FSB_SIZE), arrow::default_memory_pool());
+        for (const auto& value : testValues) {
+            UNIT_ASSERT(builder.Append(value).ok());
+        }
+        std::shared_ptr<arrow::FixedSizeBinaryArray> array;
+        UNIT_ASSERT(builder.Finish(&array).ok());
+
+        auto schema = std::make_shared<arrow::Schema>(std::vector<std::shared_ptr<arrow::Field>>{
+            arrow::field("decimal_col", arrow::fixed_size_binary(NScheme::FSB_SIZE))
+        });
+        auto batch = arrow::RecordBatch::Make(schema, testValues.size(), {array});
+
+        struct TRowWriter : public NArrow::IRowWriter {
+            std::vector<TOwnedCellVec> Rows;
+            void AddRow(const TConstArrayRef<TCell>& cells) override {
+                Rows.push_back(TOwnedCellVec(cells));
+            }
+        } rowWriter;
+
+        NArrow::TArrowToYdbConverter toYdbConverter(ydbSchema, rowWriter);
+        TString errStr;
+        bool ok = toYdbConverter.Process(*batch, errStr);
+        UNIT_ASSERT_C(ok, errStr);
+
+        UNIT_ASSERT_VALUES_EQUAL(rowWriter.Rows.size(), testValues.size());
+
+        for (size_t i = 0; i < testValues.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(rowWriter.Rows[i].size(), 1);
+            TCell cell = rowWriter.Rows[i][0];
+            UNIT_ASSERT_VALUES_EQUAL(cell.Size(), NScheme::FSB_SIZE);
+            UNIT_ASSERT_VALUES_EQUAL(std::string(cell.Data(), cell.Size()), testValues[i]);
+        }
+    }
+
+    Y_UNIT_TEST(ArrowToYdbConverter_Uuid) {
+        std::vector<std::pair<TString, TTypeInfo>> ydbSchema = {
+            {"uuid_col", TTypeInfo(NTypeIds::Uuid)}
+        };
+
+        std::vector<std::string> testValues;
+        for (int i = 0; i < 5; ++i) {
+            std::string uuid(16, '\0');
+            for (size_t j = 0; j < 16; ++j) {
+                uuid[j] = static_cast<char>((i * 32 + j) % 256);
+            }
+            testValues.push_back(uuid);
+        }
+
+        arrow::FixedSizeBinaryBuilder builder(arrow::fixed_size_binary(NScheme::FSB_SIZE), arrow::default_memory_pool());
+        for (const auto& value : testValues) {
+            UNIT_ASSERT(builder.Append(value).ok());
+        }
+        std::shared_ptr<arrow::FixedSizeBinaryArray> array;
+        UNIT_ASSERT(builder.Finish(&array).ok());
+
+        auto schema = std::make_shared<arrow::Schema>(std::vector<std::shared_ptr<arrow::Field>>{
+            arrow::field("uuid_col", arrow::fixed_size_binary(NScheme::FSB_SIZE))
+        });
+        auto batch = arrow::RecordBatch::Make(schema, testValues.size(), {array});
+
+        struct TRowWriter : public NArrow::IRowWriter {
+            std::vector<TOwnedCellVec> Rows;
+            void AddRow(const TConstArrayRef<TCell>& cells) override {
+                Rows.push_back(TOwnedCellVec(cells));
+            }
+        } rowWriter;
+
+        NArrow::TArrowToYdbConverter toYdbConverter(ydbSchema, rowWriter);
+        TString errStr;
+        bool ok = toYdbConverter.Process(*batch, errStr);
+        UNIT_ASSERT_C(ok, errStr);
+
+        UNIT_ASSERT_VALUES_EQUAL(rowWriter.Rows.size(), testValues.size());
+
+        for (size_t i = 0; i < testValues.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(rowWriter.Rows[i].size(), 1);
+            TCell cell = rowWriter.Rows[i][0];
+            UNIT_ASSERT_VALUES_EQUAL(cell.Size(), NScheme::FSB_SIZE);
+            UNIT_ASSERT_VALUES_EQUAL(std::string(cell.Data(), cell.Size()), testValues[i]);
         }
     }
 

--- a/ydb/core/formats/arrow/ut/ut_arrow.cpp
+++ b/ydb/core/formats/arrow/ut/ut_arrow.cpp
@@ -758,7 +758,7 @@ Y_UNIT_TEST_SUITE(ArrowTest) {
         }
     }
 
-        Y_UNIT_TEST(ArrowToYdbConverter_Decimal) {
+    Y_UNIT_TEST(ArrowToYdbConverter_Decimal) {
         std::vector<std::pair<TString, TTypeInfo>> ydbSchema = {
             {"decimal_col", TTypeInfo(NScheme::TDecimalType(NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE))}
         };

--- a/ydb/core/kqp/ut/arrow/kqp_result_set_formats_ut.cpp
+++ b/ydb/core/kqp/ut/arrow/kqp_result_set_formats_ut.cpp
@@ -2031,13 +2031,6 @@ R"(column0:   -- is_valid: all not null
     }
 
     Y_UNIT_TEST_TWIN(ArrowFormat_BulkUpsert, IsOlap) {
-
-        // FIXME: Uncaught exception for types: Uuid, Decimal(22, 0) -> FixedSizeBinary(16)
-        // https://github.com/ydb-platform/ydb/issues/34156
-        if (!IsOlap) {
-            return;
-        }
-
         auto kikimr = CreateKikimrRunner(/* withSampleTables */ false);
         auto queryClient = kikimr.GetQueryClient();
         auto tableClient = kikimr.GetTableClient();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Tests for `TArrowBatchBuilder` with types `Decimal` and `Uuid`.
- Tests for `TArrowToYdbConverter` with types `Decimal` and `Uuid`.
- Fixed #34156

...
