### PR TITLE
NBYDB-1942: add replication quoters metrics

### DIFF
--- a/ydb/core/blobstorage/vdisk/balance/defs.h
+++ b/ydb/core/blobstorage/vdisk/balance/defs.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/blobstorage/vdisk/common/vdisk_context.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_pdiskctx.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_hugeblobctx.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_hulllogctx.h>
@@ -36,6 +37,7 @@ namespace NKikimr {
         THugeBlobCtxPtr HugeBlobCtx;
         TActorId SkeletonId;
         NMonGroup::TBalancingGroup MonGroup;
+        NMonGroup::TReplGroup ReplMonGroup;
 
         NKikimr::THullDsSnap Snap;
 
@@ -61,6 +63,7 @@ namespace NKikimr {
             , HugeBlobCtx(std::move(hugeBlobCtx))
             , SkeletonId(skeletonId)
             , MonGroup(VCtx->VDiskCounters, "subsystem", "balancing")
+            , ReplMonGroup(VCtx->VDiskCounters, "subsystem", "repl")
             , Snap(std::move(snap))
             , VDiskCfg(std::move(vDiskCfg))
             , GInfo(std::move(gInfo))

--- a/ydb/core/blobstorage/vdisk/balance/deleter.cpp
+++ b/ydb/core/blobstorage/vdisk/balance/deleter.cpp
@@ -23,6 +23,7 @@ namespace {
         const TActorId NotifyId;
         TVector<TLogoBlobID> Parts;
         TReplQuoter::TPtr Quoter;
+        NMonitoring::TDynamicCounters::TCounterPtr QuoterThrottledCounter;
         TIntrusivePtr<TBlobStorageGroupInfo> GInfo;
         TQueueActorMapPtr QueueActorMapPtr;
         NMonGroup::TBalancingGroup& MonGroup;
@@ -32,10 +33,11 @@ namespace {
         ui32 Responses = 0;
     public:
 
-        TPartsRequester(TActorId notifyId, TVector<TLogoBlobID>&& parts, TReplQuoter::TPtr quoter, TIntrusivePtr<TBlobStorageGroupInfo> gInfo, TQueueActorMapPtr queueActorMapPtr, NMonGroup::TBalancingGroup& monGroup)
+        TPartsRequester(TActorId notifyId, TVector<TLogoBlobID>&& parts, TReplQuoter::TPtr quoter, NMonitoring::TDynamicCounters::TCounterPtr quoterThrottledCounter, TIntrusivePtr<TBlobStorageGroupInfo> gInfo, TQueueActorMapPtr queueActorMapPtr, NMonGroup::TBalancingGroup& monGroup)
             : NotifyId(notifyId)
             , Parts(std::move(parts))
             , Quoter(quoter)
+            , QuoterThrottledCounter(quoterThrottledCounter)
             , GInfo(gInfo)
             , QueueActorMapPtr(queueActorMapPtr)
             , MonGroup(monGroup)
@@ -72,7 +74,9 @@ namespace {
                 TReplQuoter::QuoteMessage(
                     Quoter,
                     std::make_unique<IEventHandle>(QueueActorMapPtr->at(TVDiskIdShort(vDiskId)), selfId, ev.release()),
-                    msgSize
+                    msgSize,
+                    0,
+                    QuoterThrottledCounter
                 );
                 ++RequestsSent;
             }
@@ -301,7 +305,7 @@ namespace {
             : NotifyId(notifyId)
             , Ctx(ctx)
             , GInfo(ctx->GInfo)
-            , PartsRequester(SelfId(), std::move(parts), Ctx->VCtx->ReplNodeRequestQuoter, GInfo, queueActorMapPtr, Ctx->MonGroup)
+            , PartsRequester(SelfId(), std::move(parts), Ctx->VCtx->ReplNodeRequestQuoter, Ctx->ReplMonGroup.ReplNodeRequestThrottledMicrosecondsPtr(), GInfo, queueActorMapPtr, Ctx->MonGroup)
             , PartsDeleter(ctx, GInfo)
         {
         }

--- a/ydb/core/blobstorage/vdisk/balance/sender.cpp
+++ b/ydb/core/blobstorage/vdisk/balance/sender.cpp
@@ -21,17 +21,18 @@ namespace {
         TPDiskCtxPtr PDiskCtx;
         TVector<TPartInfo> Parts;
         TReplQuoter::TPtr Quoter;
+        NMonitoring::TDynamicCounters::TCounterPtr QuoterThrottledCounter;
         const TBlobStorageGroupType GType;
         NMonGroup::TBalancingGroup& MonGroup;
-
         TVector<TPart> Result;
         ui32 Responses = 0;
     public:
 
-        TReader(TPDiskCtxPtr pDiskCtx, TVector<TPartInfo>&& parts, TReplQuoter::TPtr replPDiskReadQuoter, TBlobStorageGroupType gType, NMonGroup::TBalancingGroup& monGroup)
+        TReader(TPDiskCtxPtr pDiskCtx, TVector<TPartInfo>&& parts, TReplQuoter::TPtr replPDiskReadQuoter, NMonitoring::TDynamicCounters::TCounterPtr quoterThrottledCounter, TBlobStorageGroupType gType, NMonGroup::TBalancingGroup& monGroup)
             : PDiskCtx(pDiskCtx)
             , Parts(std::move(parts))
             , Quoter(replPDiskReadQuoter)
+            , QuoterThrottledCounter(quoterThrottledCounter)
             , GType(gType)
             , MonGroup(monGroup)
             , Result(Parts.size())
@@ -62,7 +63,9 @@ namespace {
                         TReplQuoter::QuoteMessage(
                             Quoter,
                             std::make_unique<IEventHandle>(PDiskCtx->PDiskId, selfId, ev.release()),
-                            diskPart.Size
+                            diskPart.Size,
+                            0,
+                            QuoterThrottledCounter
                         );
                         MonGroup.ReadFromHandoffBytes() += diskPart.Size;
                     }
@@ -117,6 +120,7 @@ namespace {
         std::shared_ptr<TBalancingCtx> Ctx;
         TIntrusivePtr<TBlobStorageGroupInfo> GInfo;
         TQueueActorMapPtr QueueActorMapPtr;
+        NMonGroup::TReplGroup& ReplMonGroup;
 
         ui32 RequestsSent = 0;
         ui32 Responses = 0;
@@ -125,11 +129,13 @@ namespace {
         TPartsSender(
             std::shared_ptr<TBalancingCtx> ctx,
             TIntrusivePtr<TBlobStorageGroupInfo> gInfo,
-            TQueueActorMapPtr queueActorMapPtr
+            TQueueActorMapPtr queueActorMapPtr,
+            NMonGroup::TReplGroup& replMonGroup
         )
             : Ctx(ctx)
             , GInfo(gInfo)
             , QueueActorMapPtr(queueActorMapPtr)
+            , ReplMonGroup(replMonGroup)
         {}
 
         void SendRequest(const TVDiskIdShort& vDiskId, const TActorId& selfId, IEventBase* ev, ui32 dataSize) {
@@ -137,7 +143,9 @@ namespace {
             TReplQuoter::QuoteMessage(
                 Ctx->VCtx->ReplNodeRequestQuoter,
                 std::make_unique<IEventHandle>(queue, selfId, ev),
-                dataSize
+                dataSize,
+                0,
+                ReplMonGroup.ReplNodeRequestThrottledMicrosecondsPtr()
             );
             RequestsSent++;
             Ctx->MonGroup.SentOnMainBytes() += dataSize;
@@ -358,8 +366,8 @@ namespace {
             , QueueActorMapPtr(queueActorMapPtr)
             , Ctx(ctx)
             , GInfo(ctx->GInfo)
-            , Reader(Ctx->PDiskCtx, std::move(parts), ctx->VCtx->ReplPDiskReadQuoter, GInfo->GetTopology().GType, Ctx->MonGroup)
-            , Sender(ctx, GInfo, queueActorMapPtr)
+            , Reader(Ctx->PDiskCtx, std::move(parts), ctx->VCtx->ReplPDiskReadQuoter, ctx->ReplMonGroup.ReplPDiskReadThrottledMicrosecondsPtr(), GInfo->GetTopology().GType, Ctx->MonGroup)
+            , Sender(ctx, GInfo, queueActorMapPtr, Ctx->ReplMonGroup)
         {}
 
         void Bootstrap() {

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events_quoter.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events_quoter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 namespace NKikimr {
 
     class TEventsQuoter {
@@ -11,17 +13,21 @@ namespace NKikimr {
         static_assert(TAtomicMonotonic::is_always_lock_free);
 
         TAtomicMonotonic NextQueueItemTimestamp;
+        // End of last throttled interval
+        TAtomicMonotonic ThrottledUntilTimestamp;
         std::atomic_uint64_t DefaultBytesPerSecond = 0;
 
     public:
         TEventsQuoter() {
             NextQueueItemTimestamp = TMonotonic::Zero();
+            ThrottledUntilTimestamp = TMonotonic::Zero();
         }
 
         TEventsQuoter(ui64 bytesPerSecond)
             : DefaultBytesPerSecond(bytesPerSecond)
         {
             NextQueueItemTimestamp = TMonotonic::Zero();
+            ThrottledUntilTimestamp = TMonotonic::Zero();
         }
 
         TDuration Take(TMonotonic now, ui64 bytes, ui64 bytesPerSecond = 0) {
@@ -46,12 +52,18 @@ namespace NKikimr {
             DefaultBytesPerSecond.store(defaultBytesPerSecond);
         }
 
-        static void QuoteMessage(const TPtr& quoter, std::unique_ptr<IEventHandle> ev, ui64 bytes, ui64 bytesPerSecond = 0) {
+        static void QuoteMessage(const TPtr& quoter, std::unique_ptr<IEventHandle> ev, ui64 bytes, ui64 bytesPerSecond = 0,
+            ::NMonitoring::TDynamicCounters::TCounterPtr throttledCounter = {}) {
+            const TMonotonic now = TActivationContext::Monotonic();
             const TDuration timeout = quoter
-                ? quoter->Take(TActivationContext::Monotonic(), bytes, bytesPerSecond)
+                ? quoter->Take(now, bytes, bytesPerSecond)
                 : TDuration::Zero();
             if (timeout != TDuration::Zero()) {
                 TActivationContext::Schedule(timeout, ev.release());
+                const ui64 deltaMicrosec = quoter->MergeThrottledIntervalAndGetDeltaMicrosec(now, timeout);
+                if (throttledCounter && deltaMicrosec) {
+                    throttledCounter->Add(deltaMicrosec);
+                }
             } else {
                 TActivationContext::Send(ev.release());
             }
@@ -67,6 +79,18 @@ namespace NKikimr {
 
         static constexpr TDuration GetCapacity() {
             return TDuration::MilliSeconds(100);
+        }
+
+        ui64 MergeThrottledIntervalAndGetDeltaMicrosec(TMonotonic now, TDuration timeout) {
+            for (;;) {
+                TMonotonic currentThrottledUntil = ThrottledUntilTimestamp.load();
+                const TMonotonic scheduledAt = now + timeout;
+                const TMonotonic newThrottledUntil = Max(currentThrottledUntil, scheduledAt);
+                if (ThrottledUntilTimestamp.compare_exchange_weak(currentThrottledUntil, newThrottledUntil)) {
+                    const TMonotonic start = Max(now, currentThrottledUntil);
+                    return (scheduledAt > start) ? (scheduledAt - start).MicroSeconds() : 0;
+                }
+            }
         }
 
     private:

--- a/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
@@ -314,6 +314,10 @@ public:                                                                         
                 COUNTER_INIT_IF_EXTENDED(ReplTotalBlobsWithProblems, false);
                 COUNTER_INIT_IF_EXTENDED(ReplPhantomBlobsWithProblems, false);
                 COUNTER_INIT_IF_EXTENDED(ReplMadeNoProgress, false);
+                COUNTER_INIT_IF_EXTENDED(ReplPDiskWriteThrottledMicroseconds, false);
+                COUNTER_INIT_IF_EXTENDED(ReplNodeRequestThrottledMicroseconds, false);
+                COUNTER_INIT_IF_EXTENDED(ReplNodeResponseThrottledMicroseconds, false);
+                COUNTER_INIT_IF_EXTENDED(ReplPDiskReadThrottledMicroseconds, false);
             }
 
             COUNTER_DEF(SyncerVSyncMessagesSent);
@@ -339,6 +343,10 @@ public:                                                                         
             COUNTER_DEF(ReplTotalBlobsWithProblems);
             COUNTER_DEF(ReplPhantomBlobsWithProblems);
             COUNTER_DEF(ReplMadeNoProgress);
+            COUNTER_DEF(ReplPDiskWriteThrottledMicroseconds);
+            COUNTER_DEF(ReplNodeRequestThrottledMicroseconds);
+            COUNTER_DEF(ReplNodeResponseThrottledMicroseconds);
+            COUNTER_DEF(ReplPDiskReadThrottledMicroseconds);
         };
 
         ///////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/query/query_base.h
+++ b/ydb/core/blobstorage/vdisk/query/query_base.h
@@ -40,7 +40,7 @@ namespace NKikimr {
             , ParentId(parentId)
             , LogoBlobsSnapshot(std::move(logoBlobsSnapshot))
             , BarriersSnapshot(std::move(barrierSnapshot))
-            , BatcherCtx(new TReadBatcherCtx(QueryCtx->HullCtx->VCtx, QueryCtx->PDiskCtx, ev))
+            , BatcherCtx(new TReadBatcherCtx(QueryCtx->HullCtx->VCtx, QueryCtx->PDiskCtx, ev, QueryCtx->ReplMonGroup))
             , Record(BatcherCtx->OrigEv->Get()->Record)
             , ShowInternals(Record.GetShowInternals())
             , Result(std::move(result))

--- a/ydb/core/blobstorage/vdisk/query/query_extr.cpp
+++ b/ydb/core/blobstorage/vdisk/query/query_extr.cpp
@@ -314,11 +314,14 @@ namespace NKikimr {
             if (IsRepl()) {
                 quoter = QueryCtx->HullCtx->VCtx->ReplNodeResponseQuoter;
             }
+            const TMonotonic now = TActivationContext::Monotonic();
             const TDuration duration = quoter
-                ? quoter->Take(TActivationContext::Monotonic(), Result->CalculateSerializedSizeCached())
+                ? quoter->Take(now, Result->CalculateSerializedSizeCached())
                 : TDuration::Zero();
             if (duration != TDuration::Zero()) {
                 Schedule(duration, new TEvents::TEvWakeup);
+                const auto deltaMicrosec = quoter->MergeThrottledIntervalAndGetDeltaMicrosec(now, duration);
+                QueryCtx->ReplMonGroup.ReplNodeResponseThrottledMicroseconds() += deltaMicrosec;
                 Become(&TThis::StateFunc);
             } else {
                 SendResponse(ctx);

--- a/ydb/core/blobstorage/vdisk/query/query_public.h
+++ b/ydb/core/blobstorage/vdisk/query/query_public.h
@@ -17,6 +17,7 @@ namespace NKikimr {
         TIntrusivePtr<THullCtx> HullCtx;
         TPDiskCtxPtr PDiskCtx;
         NMonGroup::TInterfaceGroup MonGroup;
+        NMonGroup::TReplGroup ReplMonGroup;
         std::atomic<ui64> PDiskReadBytes;
         TActorId SkeletonId;
 
@@ -24,6 +25,7 @@ namespace NKikimr {
             : HullCtx(std::move(hullCtx))
             , PDiskCtx(std::move(pdiskCtx))
             , MonGroup(HullCtx->VCtx->VDiskCounters, "subsystem", "interface")
+            , ReplMonGroup(HullCtx->VCtx->VDiskCounters, "subsystem", "repl")
             , PDiskReadBytes(0)
             , SkeletonId(skeletonId)
         {}

--- a/ydb/core/blobstorage/vdisk/query/query_readactor.cpp
+++ b/ydb/core/blobstorage/vdisk/query/query_readactor.cpp
@@ -30,8 +30,10 @@ namespace NKikimr {
             Y_DEBUG_ABORT_UNLESS(!Result->GlueReads.empty());
 
             TReplQuoter::TPtr quoter;
+            NMonitoring::TDynamicCounters::TCounterPtr quoterThrottledCounter;
             if (IsRepl) {
                 quoter = Ctx->VCtx->ReplPDiskReadQuoter;
+                quoterThrottledCounter = Ctx->ReplMonGroup.ReplPDiskReadThrottledMicrosecondsPtr();
             }
 
             // make read requests
@@ -49,7 +51,7 @@ namespace NKikimr {
 
                 // send request
                 TReplQuoter::QuoteMessage(quoter, std::make_unique<IEventHandle>(Ctx->PDiskCtx->PDiskId, SelfId(),
-                    msg.release(), 0, 0, nullptr, Span.GetTraceId()), it->Part.Size);
+                    msg.release(), 0, 0, nullptr, Span.GetTraceId()), it->Part.Size, 0, quoterThrottledCounter);
 
                 Counter++;
             }

--- a/ydb/core/blobstorage/vdisk/query/query_readbatch.h
+++ b/ydb/core/blobstorage/vdisk/query/query_readbatch.h
@@ -269,14 +269,16 @@ namespace NKikimr {
         TVDiskContextPtr VCtx;
         TPDiskCtxPtr PDiskCtx;
         TEvBlobStorage::TEvVGet::TPtr OrigEv;
-
+        NMonGroup::TReplGroup& ReplMonGroup;
 
         TReadBatcherCtx(TVDiskContextPtr vctx,
                         TPDiskCtxPtr pdiskCtx,
-                        TEvBlobStorage::TEvVGet::TPtr &ev)
+                        TEvBlobStorage::TEvVGet::TPtr &ev,
+                        NMonGroup::TReplGroup& replMonGroup)
             : VCtx(std::move(vctx))
             , PDiskCtx(std::move(pdiskCtx))
             , OrigEv(ev)
+            , ReplMonGroup(replMonGroup)
         {}
     };
 

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullrepljob.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullrepljob.cpp
@@ -543,7 +543,8 @@ namespace NKikimr {
                             ReplInfo->SstBytesWritten += bytes;
                             // and check if we have to postpone it
                             TReplQuoter::QuoteMessage(ReplCtx->VCtx->ReplPDiskWriteQuoter, std::make_unique<IEventHandle>(
-                                ReplCtx->PDiskCtx->PDiskId, SelfId(), msg.release()), bytes);
+                                ReplCtx->PDiskCtx->PDiskId, SelfId(), msg.release()), bytes, 0, ReplCtx->MonGroup.ReplPDiskWriteThrottledMicrosecondsPtr()
+                            );
                         } else {
                             Send(ReplCtx->PDiskCtx->PDiskId, msg.release());
                         }
@@ -852,7 +853,7 @@ namespace NKikimr {
                     const ui64 bytes = front.Data.GetSize();
                     TReplQuoter::QuoteMessage(ReplCtx->VCtx->ReplPDiskWriteQuoter, std::make_unique<IEventHandle>(
                         ReplCtx->SkeletonId, SelfId(), new TEvRecoveredHugeBlob(front.Id, std::move(front.Data))),
-                        bytes);
+                        bytes, 0, ReplCtx->MonGroup.ReplPDiskWriteThrottledMicrosecondsPtr());
 
                     RecoveryQueue.pop();
                     continue;

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_replproxy.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_replproxy.cpp
@@ -274,12 +274,15 @@ namespace NKikimr {
 
                 // limit bandwidth
                 const auto& quoter = ReplCtx->VCtx->ReplNodeRequestQuoter;
+                const TMonotonic now = TActivationContext::Monotonic();
                 const TDuration duration = quoter
-                    ? quoter->Take(TActivationContext::Monotonic(), actualBytes)
+                    ? quoter->Take(now, actualBytes)
                     : TDuration::Zero();
                 std::unique_ptr<TEvBlobStorage::TEvVGetResult> event(ev->Release().Release());
                 if (duration != TDuration::Zero()) {
                     Schedule(duration, new TEvProcessDelayedEvent(std::move(event)));
+                    auto deltaMicrosec = quoter->MergeThrottledIntervalAndGetDeltaMicrosec(now, duration);
+                    ReplCtx->MonGroup.ReplNodeRequestThrottledMicroseconds() += deltaMicrosec;
                 } else {
                     ProcessScheduledResult(event);
                 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

NBYDB-1942: add replication throttling metrics for the quoters (ReplPDiskWrite, ReplPDiskRead, ReplNodeRequest, ReplNodeResponse)

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
