### PR TITLE
Add checksums to system tablet backup snapshot

### DIFF
--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -356,7 +356,7 @@ public:
             manifestFile.Write(manifestStr.data(), manifestStr.size());
             manifestFile.Flush();
 
-            auto manifestDigest = NOpenSsl::NSha256::Calc(manifestStr);
+            const auto manifestDigest = NOpenSsl::NSha256::Calc(manifestStr);
             TString manifestChecksum = to_lower(HexEncode(manifestDigest.data(), manifestDigest.size()));
 
             auto checksumPath = SnapshotPath.Child("manifest.json.sha256");

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -357,7 +357,7 @@ public:
             manifestFile.Flush();
 
             const auto manifestDigest = NOpenSsl::NSha256::Calc(manifestStr);
-            TString manifestChecksum = to_lower(HexEncode(manifestDigest.data(), manifestDigest.size()));
+            const TString manifestChecksum = to_lower(HexEncode(manifestDigest.data(), manifestDigest.size()));
 
             auto checksumPath = SnapshotPath.Child("manifest.json.sha256");
             TFile checksumFile(checksumPath, EOpenModeFlag::CreateNew | EOpenModeFlag::WrOnly);
@@ -371,7 +371,7 @@ public:
             TFile snapshotDir(SnapshotPath, EOpenModeFlag::RdOnly);
             snapshotDir.Flush();
         } catch (const TIoException& e) {
-            return ReplyAndDie(false, TStringBuilder() << "Failed to fsync temporary snapshot dir " << SnapshotPath << ": " << e.what());
+            return ReplyAndDie(false, TStringBuilder() << "Failed to flush temporary snapshot dir " << SnapshotPath << ": " << e.what());
         }
 
         try {
@@ -384,7 +384,7 @@ public:
             TFile parentDir(FinalSnapshotPath.Parent(), EOpenModeFlag::RdOnly);
             parentDir.Flush();
         } catch (const TIoException& e) {
-            return ReplyAndDie(false, TStringBuilder() << "Failed to fsync parent dir after rename " << FinalSnapshotPath.Parent() << ": " << e.what());
+            return ReplyAndDie(false, TStringBuilder() << "Failed to flush parent dir after rename " << FinalSnapshotPath.Parent() << ": " << e.what());
         }
 
         return ReplyAndDie();

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -371,7 +371,7 @@ public:
             TFile snapshotDir(SnapshotPath, EOpenModeFlag::RdOnly);
             snapshotDir.Flush();
         } catch (const TIoException& e) {
-            return ReplyAndDie(false, TStringBuilder() << "Failed to fsync snapshot dir " << SnapshotPath << ": " << e.what());
+            return ReplyAndDie(false, TStringBuilder() << "Failed to fsync temporary snapshot dir " << SnapshotPath << ": " << e.what());
         }
 
         try {

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -19,12 +19,14 @@
 
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
+#include <library/cpp/openssl/crypto/sha.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 #include <library/cpp/protobuf/json/util.h>
 #include <library/cpp/string_utils/base64/base64.h>
 
 #include <util/stream/buffer.h>
 #include <util/stream/file.h>
+#include <util/string/hex.h>
 
 #define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::LOCAL_DB_BACKUP, stream)
 
@@ -175,18 +177,25 @@ public:
     struct TTableFile {
         TString Name;
         TFile File;
+        std::unique_ptr<NOpenSsl::NSha256::TCalcer> Sha256;
     };
 
     TSnapshotWriter(TActorId owner, const TFsPath& path,
                     const THashMap<ui32, TScheme::TTableInfo>& tables,
+                    TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation, ui32 step,
                     TAutoPtr<TSchemeChanges> schema, TIntrusiveConstPtr<TBackupExclusion> exclusion)
         : Owner(owner)
-        , SnapshotPath(path.Child("snapshot"))
+        , SnapshotPath(path.Child("snapshot.tmp"))
+        , FinalSnapshotPath(path.Child("snapshot"))
+        , TabletType(tabletType)
+        , TabletId(tabletId)
+        , Generation(generation)
+        , Step(step)
         , Schema(schema)
         , Exclusion(exclusion)
     {
         for (const auto& [tableId, table] : tables) {
-            Tables.emplace(tableId, TTableFile(table.Name, {}));
+            Tables.emplace(tableId, TTableFile{table.Name, {}, std::make_unique<NOpenSsl::NSha256::TCalcer>()});
         }
     }
 
@@ -209,13 +218,14 @@ public:
                 .MapAsObject = true,
             });
             SchemaFile.Write(stringOut.Data(), stringOut.Size());
+            SchemaSha256.Update(stringOut.Data(), stringOut.Size());
             WrittenBytes += stringOut.Size();
         } catch (const TIoException& e) {
             return ReplyAndDie(false, TStringBuilder() << "Failed to create snapshot schema file " << schemaPath << ": " << e.what());
         }
 
         if (Tables.empty()) {
-            return ReplyAndDie();
+            return Finalize();
         }
 
         for (auto& [tableId, table] : Tables) {
@@ -262,6 +272,7 @@ public:
         if (!msg->SnapshotData.Empty()) {
             try {
                 it->second.File.Write(msg->SnapshotData.Data(), msg->SnapshotData.Size());
+                it->second.Sha256->Update(msg->SnapshotData.Data(), msg->SnapshotData.Size());
                 WrittenBytes += msg->SnapshotData.Size();
             } catch (const TIoException& e) {
                 return ReplyAndDie(false, TStringBuilder() << "Failed to write snapshot table data " << it->second.File.GetName() << ": " << e.what());
@@ -291,22 +302,92 @@ public:
     void ScanDone(ui32 tableId) {
         DoneTables.insert(tableId);
         if (DoneTables.size() == Tables.size()) {
-            try {
-                SchemaFile.Flush();
-            } catch (const TIoException& e) {
-                return ReplyAndDie(false, TStringBuilder() << "Failed to flush snapshot schema " << SchemaFile.GetName() << ": " << e.what());
-            }
-
-            for (auto& [_, table] : Tables) {
-                try {
-                    table.File.Flush();
-                } catch (const TIoException& e) {
-                    return ReplyAndDie(false, TStringBuilder() << "Failed to flush snapshot table data " << table.File.GetName() << ": " << e.what());
-                }
-            }
-
-            return ReplyAndDie();
+            return Finalize();
         }
+    }
+
+    static TString FinalizeDigest(NOpenSsl::NSha256::TCalcer& calcer) {
+        auto digest = calcer.Final();
+        return to_lower(HexEncode(digest.data(), digest.size()));
+    }
+
+    static NJson::TJsonValue MakeFileEntry(const TString& name, NOpenSsl::NSha256::TCalcer& calcer) {
+        NJson::TJsonValue entry;
+        entry["name"] = name;
+        entry["sha256"] = FinalizeDigest(calcer);
+        return entry;
+    }
+
+    void Finalize() {
+        try {
+            SchemaFile.Flush();
+        } catch (const TIoException& e) {
+            return ReplyAndDie(false, TStringBuilder() << "Failed to flush snapshot schema " << SchemaFile.GetName() << ": " << e.what());
+        }
+
+        for (auto& [_, table] : Tables) {
+            try {
+                table.File.Flush();
+            } catch (const TIoException& e) {
+                return ReplyAndDie(false, TStringBuilder() << "Failed to flush snapshot table data " << table.File.GetName() << ": " << e.what());
+            }
+        }
+
+        try {
+            NJson::TJsonValue manifest;
+            TString tabletTypeName = TTabletTypes::EType_Name(TabletType);
+            NProtobufJson::ToSnakeCaseDense(&tabletTypeName);
+            manifest["tablet_type"] = tabletTypeName;
+            manifest["tablet_id"] = TabletId;
+            manifest["generation"] = Generation;
+            manifest["step"] = Step;
+
+            auto& files = manifest["files"];
+            files.SetType(NJson::JSON_ARRAY);
+            files.AppendValue(MakeFileEntry("schema.json", SchemaSha256));
+            for (auto& [_, table] : Tables) {
+                files.AppendValue(MakeFileEntry(table.Name + ".json", *table.Sha256));
+            }
+
+            TString manifestStr = NJson::WriteJson(manifest, /*formatOutput=*/ false);
+
+            auto manifestPath = SnapshotPath.Child("manifest.json");
+            TFile manifestFile(manifestPath, EOpenModeFlag::CreateNew | EOpenModeFlag::WrOnly);
+            manifestFile.Write(manifestStr.data(), manifestStr.size());
+            manifestFile.Flush();
+
+            auto manifestDigest = NOpenSsl::NSha256::Calc(manifestStr);
+            TString manifestChecksum = to_lower(HexEncode(manifestDigest.data(), manifestDigest.size()));
+
+            auto checksumPath = SnapshotPath.Child("manifest.json.sha256");
+            TFile checksumFile(checksumPath, EOpenModeFlag::CreateNew | EOpenModeFlag::WrOnly);
+            checksumFile.Write(manifestChecksum.data(), manifestChecksum.size());
+            checksumFile.Flush();
+        } catch (const TIoException& e) {
+            return ReplyAndDie(false, TStringBuilder() << "Failed to write manifest: " << e.what());
+        }
+
+        try {
+            TFile snapshotDir(SnapshotPath, EOpenModeFlag::RdOnly);
+            snapshotDir.Flush();
+        } catch (const TIoException& e) {
+            return ReplyAndDie(false, TStringBuilder() << "Failed to fsync snapshot dir " << SnapshotPath << ": " << e.what());
+        }
+
+        try {
+            SnapshotPath.RenameTo(FinalSnapshotPath);
+        } catch (const TIoException& e) {
+            return ReplyAndDie(false, TStringBuilder() << "Failed to rename snapshot " << SnapshotPath << " to " << FinalSnapshotPath << ": " << e.what());
+        }
+
+        try {
+            TFile parentDir(FinalSnapshotPath.Parent(), EOpenModeFlag::RdOnly);
+            parentDir.Flush();
+        } catch (const TIoException& e) {
+            return ReplyAndDie(false, TStringBuilder() << "Failed to fsync parent dir after rename " << FinalSnapshotPath.Parent() << ": " << e.what());
+        }
+
+        return ReplyAndDie();
     }
 
     void ScanFailed(const TString& tableName, const TString& error) {
@@ -317,11 +398,18 @@ private:
     TActorId Owner;
 
     TFsPath SnapshotPath;
+    TFsPath FinalSnapshotPath;
+
+    TTabletTypes::EType TabletType;
+    ui64 TabletId;
+    ui32 Generation;
+    ui32 Step;
 
     THashMap<ui32, TTableFile> Tables;
     THashSet<ui32> DoneTables;
 
     TFile SchemaFile;
+    NOpenSsl::NSha256::TCalcer SchemaSha256;
     TAutoPtr<TSchemeChanges> Schema;
 
     TIntrusiveConstPtr<TBackupExclusion> Exclusion;
@@ -823,7 +911,7 @@ IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletB
     if (config.HasFilesystem()) {
         auto path = TFsPath(config.GetFilesystem().GetPath())
             .Child(CreateBackupPath(tabletType, tabletId, generation, step));
-        return new TSnapshotWriter(owner, path, tables, schema, exclusion);
+        return new TSnapshotWriter(owner, path, tables, tabletType, tabletId, generation, step, schema, exclusion);
     } else {
         return nullptr;
     }

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -349,7 +349,7 @@ public:
                 files.AppendValue(MakeFileEntry(table.Name + ".json", *table.Sha256));
             }
 
-            TString manifestStr = NJson::WriteJson(manifest, /*formatOutput=*/ false);
+            const TString manifestStr = NJson::WriteJson(manifest, /*formatOutput=*/ false);
 
             auto manifestPath = SnapshotPath.Child("manifest.json");
             TFile manifestFile(manifestPath, EOpenModeFlag::CreateNew | EOpenModeFlag::WrOnly);

--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -16,6 +16,7 @@
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/openssl/crypto/sha.h>
 #include <library/cpp/protobuf/json/json2proto.h>
+#include <library/cpp/protobuf/json/util.h>
 #include <library/cpp/string_utils/base64/base64.h>
 
 #include <util/stream/file.h>
@@ -269,7 +270,7 @@ public:
 
     void Handle(TEvRestoreBackup::TPtr& ev) {
         if (RestoreState == ERestoreState::NotStarted) {
-            StartRestore(ev->Get()->BackupPath, ev->Sender);
+            StartRestore(ev->Get()->BackupPath, ev->Sender, ev->Get()->SkipChecksumValidation);
         }
     }
 
@@ -297,13 +298,13 @@ public:
         Execute(CreateTxUploadChangelog(ev));
     }
 
-    void StartRestore(const TString& backupPath, TActorId subscriber = {}) {
+    void StartRestore(const TString& backupPath, TActorId subscriber = {}, bool skipChecksumValidation = false) {
         RestoreState = ERestoreState::InProgress;
 
         BackupPath = backupPath;
         RestoreSubscriber = subscriber;
 
-        BackupReader = Register(CreateBackupReader(SelfId(), backupPath), TMailboxType::HTSwap, AppData()->IOPoolId);
+        BackupReader = Register(CreateBackupReader(SelfId(), backupPath, TabletType(), TabletID(), skipChecksumValidation), TMailboxType::HTSwap, AppData()->IOPoolId);
     }
 
     void CompleteRestore(bool success, const TString& error) {
@@ -402,7 +403,8 @@ public:
         auto cgi = ev->Get()->Cgi();
         if (const auto& path = cgi.Get("restoreBackup")) {
             if (RestoreState == ERestoreState::NotStarted) {
-                StartRestore(path);
+                bool skipChecksum = cgi.Has("skipChecksumValidation");
+                StartRestore(path, {}, skipChecksum);
             }
         }
 
@@ -418,6 +420,15 @@ public:
                             DIV_CLASS("col-sm-10") {
                                 str << "<input type='text' id='restoreBackup' name='restoreBackup' class='form-control' "
                                     << "placeholder='/tmp/backup/gen_312' required>";
+                            }
+                        }
+
+                        DIV_CLASS("form-group") {
+                            DIV_CLASS("col-sm-offset-2 col-sm-10") {
+                                str << "<div class='checkbox'><label>"
+                                    << "<input type='checkbox' id='skipChecksumValidation' name='skipChecksumValidation'>"
+                                    << " Skip Checksum Validation"
+                                    << "</label></div>";
                             }
                         }
 
@@ -797,12 +808,17 @@ ITransaction* TRecoveryShard::CreateTxUploadChangelog(TEvChangelogData::TPtr ev,
 
 class TBackupReader : public TActorBootstrapped<TBackupReader> {
 public:
-    TBackupReader(TActorId owner, const TString& backupPath)
+    TBackupReader(TActorId owner, const TString& backupPath,
+                  TTabletTypes::EType tabletType, ui64 tabletId,
+                  bool skipChecksumValidation)
         : Owner(owner)
         , BackupPath(backupPath)
         , SnapshotDirPath(BackupPath.Child("snapshot"))
         , SchemaFilePath(SnapshotDirPath.Child("schema.json"))
         , ChangelogFilePath(BackupPath.Child("changelog.json"))
+        , ExpectedTabletType(tabletType)
+        , ExpectedTabletId(tabletId)
+        , SkipChecksumValidation(skipChecksumValidation)
     {}
 
     void Bootstrap() {
@@ -934,31 +950,33 @@ public:
         try {
             manifestStr = TFileInput(manifestFile).ReadAll();
         } catch (const TIoException& e) {
-            SendResultAndDie(false, TStringBuilder() << "Failed to read manifest" << manifestFile << ": " << e.what());
+            SendResultAndDie(false, TStringBuilder() << "Failed to read manifest " << manifestFile << ": " << e.what());
             return false;
         }
 
-        auto manifestChecksumFile = snapshotDir.Child("manifest.json.sha256");
-        if (!manifestChecksumFile.Exists()) {
-            SendResultAndDie(false, TStringBuilder() << "Manifest checksum file doesn't exist: " << manifestChecksumFile);
-            return false;
-        }
+        if (!SkipChecksumValidation) {
+            auto manifestChecksumFile = snapshotDir.Child("manifest.json.sha256");
+            if (!manifestChecksumFile.Exists()) {
+                SendResultAndDie(false, TStringBuilder() << "Manifest checksum file doesn't exist: " << manifestChecksumFile);
+                return false;
+            }
 
-        TString expectedManifestChecksum;
-        try {
-            expectedManifestChecksum = TFileInput(manifestChecksumFile).ReadAll();
-        } catch (const TIoException& e) {
-            SendResultAndDie(false, TStringBuilder() << "Failed to read manifest checksum: " << manifestChecksumFile << ": " << e.what());
-            return false;
-        }
+            TString expectedManifestChecksum;
+            try {
+                expectedManifestChecksum = TFileInput(manifestChecksumFile).ReadAll();
+            } catch (const TIoException& e) {
+                SendResultAndDie(false, TStringBuilder() << "Failed to read manifest checksum: " << manifestChecksumFile << ": " << e.what());
+                return false;
+            }
 
-        auto manifestDigest = NOpenSsl::NSha256::Calc(manifestStr);
-        TString actualManifestChecksum = to_lower(HexEncode(manifestDigest.data(), manifestDigest.size()));
-        if (actualManifestChecksum != expectedManifestChecksum) {
-            SendResultAndDie(false, TStringBuilder() << "Manifest checksum mismatch: "
-                                                     << "expected " << expectedManifestChecksum
-                                                     << ", got " << actualManifestChecksum);
-            return false;
+            auto manifestDigest = NOpenSsl::NSha256::Calc(manifestStr);
+            TString actualManifestChecksum = to_lower(HexEncode(manifestDigest.data(), manifestDigest.size()));
+            if (actualManifestChecksum != expectedManifestChecksum) {
+                SendResultAndDie(false, TStringBuilder() << "Manifest checksum mismatch: "
+                                                         << "expected " << expectedManifestChecksum
+                                                         << ", got " << actualManifestChecksum);
+                return false;
+            }
         }
 
         NJson::TJsonValue manifest;
@@ -969,19 +987,47 @@ public:
             return false;
         }
 
-        for (const auto& fileEntry : manifest["files"].GetArray()) {
+        if (!manifest.Has("tablet_type") || !manifest["tablet_type"].IsString()) {
+            SendResultAndDie(false, TStringBuilder() << "Manifest is missing 'tablet_type' field or it is not a string: " << manifest);
+            return false;
+        }
+
+        TString actualTypeName = manifest["tablet_type"].GetString();
+        TString expectedTypeName = TTabletTypes::EType_Name(ExpectedTabletType);
+        NProtobufJson::ToSnakeCaseDense(&expectedTypeName);
+        if (actualTypeName != expectedTypeName) {
+            SendResultAndDie(false, TStringBuilder()
+                << "Manifest tablet type mismatch: expected " << expectedTypeName
+                << ", got " << actualTypeName);
+            return false;
+        }
+
+        if (!manifest.Has("tablet_id") || !manifest["tablet_id"].IsUInteger()) {
+            SendResultAndDie(false, TStringBuilder() << "Manifest is missing 'tablet_id' field or it is not an unsigned integer: " << manifest);
+            return false;
+        }
+
+        ui64 actualTabletId = manifest["tablet_id"].GetUInteger();
+        if (actualTabletId != ExpectedTabletId) {
+            SendResultAndDie(false, TStringBuilder()
+                << "Manifest tablet id mismatch: expected " << ExpectedTabletId
+                << ", got " << actualTabletId);
+            return false;
+        }
+
+        if (!manifest.Has("files") || !manifest["files"].IsArray()) {
+            SendResultAndDie(false, TStringBuilder() << "Manifest is missing 'files' array or it is not an array: " << manifest);
+            return false;
+        }
+
+        const auto& files = manifest["files"].GetArray();
+        for (const auto& fileEntry : files) {
             if (!fileEntry.Has("name") || !fileEntry["name"].IsString()) {
                 SendResultAndDie(false, TStringBuilder() << "Manifest file entry is missing 'name' field: " << fileEntry);
                 return false;
             }
 
-            if (!fileEntry.Has("sha256") || !fileEntry["sha256"].IsString()) {
-                SendResultAndDie(false, TStringBuilder() << "Manifest file entry is missing 'sha256' field: " << fileEntry);
-                return false;
-            }
-
             TString name = fileEntry["name"].GetString();
-            TString expectedFileSha256 = fileEntry["sha256"].GetString();
 
             auto filePath = snapshotDir.Child(name);
             if (!filePath.Exists()) {
@@ -994,26 +1040,35 @@ public:
                 SnapshotFiles.push_back(filePath);
             }
 
-            NOpenSsl::NSha256::TCalcer calcer;
-            try {
-                TFileInput input(filePath, 1_MB);
-                char buf[64_KB];
-                size_t bytesRead;
-                while ((bytesRead = input.Read(buf, sizeof(buf))) > 0) {
-                    calcer.Update(buf, bytesRead);
+            if (!SkipChecksumValidation) {
+                if (!fileEntry.Has("sha256") || !fileEntry["sha256"].IsString()) {
+                    SendResultAndDie(false, TStringBuilder() << "Manifest file entry is missing 'sha256' field: " << fileEntry);
+                    return false;
                 }
-            } catch (const TIoException& e) {
-                SendResultAndDie(false, TStringBuilder() << "Failed to read file " << filePath << " for checksum validation: " << e.what());
-                return false;
-            }
 
-            auto fileDigest = calcer.Final();
-            TString actualFileSha256 = to_lower(HexEncode(fileDigest.data(), fileDigest.size()));
-            if (actualFileSha256 != expectedFileSha256) {
-                SendResultAndDie(false, TStringBuilder() << "Checksum mismatch for " << filePath
-                                         << ": expected " << expectedFileSha256
-                                         << ", got " << actualFileSha256);
-                return false;
+                TString expectedFileSha256 = fileEntry["sha256"].GetString();
+
+                NOpenSsl::NSha256::TCalcer calcer;
+                try {
+                    TFileInput input(filePath, 1_MB);
+                    char buf[64_KB];
+                    size_t bytesRead;
+                    while ((bytesRead = input.Read(buf, sizeof(buf))) > 0) {
+                        calcer.Update(buf, bytesRead);
+                    }
+                } catch (const TIoException& e) {
+                    SendResultAndDie(false, TStringBuilder() << "Failed to read file " << filePath << " for checksum validation: " << e.what());
+                    return false;
+                }
+
+                auto fileDigest = calcer.Final();
+                TString actualFileSha256 = to_lower(HexEncode(fileDigest.data(), fileDigest.size()));
+                if (actualFileSha256 != expectedFileSha256) {
+                    SendResultAndDie(false, TStringBuilder() << "Checksum mismatch for " << filePath
+                                             << ": expected " << expectedFileSha256
+                                             << ", got " << actualFileSha256);
+                    return false;
+                }
             }
         }
 
@@ -1048,6 +1103,10 @@ private:
     const TFsPath SchemaFilePath;
     const TFsPath ChangelogFilePath;
 
+    const TTabletTypes::EType ExpectedTabletType;
+    const ui64 ExpectedTabletId;
+    const bool SkipChecksumValidation;
+
     TDeque<TFsPath> SnapshotFiles;
 
     TFsPath CurrentFilePath;
@@ -1060,8 +1119,10 @@ IActor* CreateRecoveryShard(const TActorId &tablet, TTabletStorageInfo *info) {
     return new TRecoveryShard(tablet, info);
 }
 
-IActor* CreateBackupReader(TActorId owner, const TString& backupPath) {
-    return new TBackupReader(owner, backupPath);
+IActor* CreateBackupReader(TActorId owner, const TString& backupPath,
+                           TTabletTypes::EType tabletType, ui64 tabletId,
+                           bool skipChecksumValidation) {
+    return new TBackupReader(owner, backupPath, tabletType, tabletId, skipChecksumValidation);
 }
 
 } //namespace NKikimr::NTabletFlatExecutor::NRecovery

--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -13,10 +13,13 @@
 #include <yql/essentials/types/binary_json/read.h>
 #include <yql/essentials/types/binary_json/write.h>
 
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/openssl/crypto/sha.h>
 #include <library/cpp/protobuf/json/json2proto.h>
 #include <library/cpp/string_utils/base64/base64.h>
 
 #include <util/stream/file.h>
+#include <util/string/hex.h>
 
 
 namespace NKikimr::NTabletFlatExecutor::NRecovery {
@@ -797,52 +800,34 @@ public:
     TBackupReader(TActorId owner, const TString& backupPath)
         : Owner(owner)
         , BackupPath(backupPath)
+        , SnapshotDirPath(BackupPath.Child("snapshot"))
+        , SchemaFilePath(SnapshotDirPath.Child("schema.json"))
+        , ChangelogFilePath(BackupPath.Child("changelog.json"))
     {}
 
     void Bootstrap() {
-        auto snapshotDir = BackupPath.Child("snapshot");
-        if (!snapshotDir.Exists()) {
-            return SendResultAndDie(false, TStringBuilder() << "Snapshot dir doesn't exist: " << snapshotDir);
+        if (!SnapshotDirPath.Exists()) {
+            return SendResultAndDie(false, TStringBuilder() << "Snapshot dir doesn't exist: " << SnapshotDirPath);
         }
 
-        auto schemaFile = snapshotDir.Child("schema.json");
-        if (!schemaFile.Exists()) {
-            return SendResultAndDie(false, TStringBuilder() << "Snapshot schema file doesn't exist: " << schemaFile);
+        if (!ValidateManifest(SnapshotDirPath)) {
+            return;
         }
 
-        auto changelogFile = BackupPath.Child("changelog.json");
-        if (!changelogFile.Exists()) {
-            return SendResultAndDie(false, TStringBuilder() << "Changelog file doesn't exist: " << changelogFile);
+        if (!SchemaFilePath.Exists()) {
+            return SendResultAndDie(false, TStringBuilder() << "Snapshot schema file doesn't exist: " << SchemaFilePath);
         }
 
-        // Calculate total size and collect snapshot files
+        if (!ChangelogFilePath.Exists()) {
+            return SendResultAndDie(false, TStringBuilder() << "Changelog file doesn't exist: " << ChangelogFilePath);
+        }
+
         ui64 totalBytes = 0;
-
         try {
-            TFileStat stat(changelogFile);
-            totalBytes += stat.Size;
+            totalBytes = CalculateTotalSize();
         } catch (const TIoException& e) {
-            return SendResultAndDie(false, TStringBuilder() << "Cannot get size of " << changelogFile << ": " << e.what());
+            return SendResultAndDie(false, TStringBuilder() << "Cannot calculate total size: " << e.what());
         }
-
-        TVector<TFsPath> snapshotFiles;
-        snapshotDir.List(snapshotFiles);
-
-        for (const auto& file : snapshotFiles) {
-            if (file.Basename() != "schema.json") {
-                SnapshotFiles.push_back(file);
-            }
-
-            try {
-                TFileStat stat(file);
-                totalBytes += stat.Size;
-            } catch (const TIoException& e) {
-                return SendResultAndDie(false, TStringBuilder() << "Cannot get size of " << file << ": " << e.what());
-            }
-        }
-
-        SchemaFilePath = schemaFile;
-        ChangelogFilePath = changelogFile;
 
         Send(Owner, new TEvBackupInfo(totalBytes));
         Become(&TThis::StateWork);
@@ -938,6 +923,118 @@ public:
         }
     }
 
+    bool ValidateManifest(const TFsPath& snapshotDir) {
+        auto manifestFile = snapshotDir.Child("manifest.json");
+        if (!manifestFile.Exists()) {
+            SendResultAndDie(false, TStringBuilder() << "Manifest file doesn't exist: " << manifestFile);
+            return false;
+        }
+
+        TString manifestStr;
+        try {
+            manifestStr = TFileInput(manifestFile).ReadAll();
+        } catch (const TIoException& e) {
+            SendResultAndDie(false, TStringBuilder() << "Failed to read manifest" << manifestFile << ": " << e.what());
+            return false;
+        }
+
+        auto manifestChecksumFile = snapshotDir.Child("manifest.json.sha256");
+        if (!manifestChecksumFile.Exists()) {
+            SendResultAndDie(false, TStringBuilder() << "Manifest checksum file doesn't exist: " << manifestChecksumFile);
+            return false;
+        }
+
+        TString expectedManifestChecksum;
+        try {
+            expectedManifestChecksum = TFileInput(manifestChecksumFile).ReadAll();
+        } catch (const TIoException& e) {
+            SendResultAndDie(false, TStringBuilder() << "Failed to read manifest checksum: " << manifestChecksumFile << ": " << e.what());
+            return false;
+        }
+
+        auto manifestDigest = NOpenSsl::NSha256::Calc(manifestStr);
+        TString actualManifestChecksum = to_lower(HexEncode(manifestDigest.data(), manifestDigest.size()));
+        if (actualManifestChecksum != expectedManifestChecksum) {
+            SendResultAndDie(false, TStringBuilder() << "Manifest checksum mismatch: "
+                                                     << "expected " << expectedManifestChecksum
+                                                     << ", got " << actualManifestChecksum);
+            return false;
+        }
+
+        NJson::TJsonValue manifest;
+        try {
+            NJson::ReadJsonTree(manifestStr, &manifest, true);
+        } catch (const std::exception& e) {
+            SendResultAndDie(false, TStringBuilder() << "Failed to parse manifest: " << manifestFile << ": " << e.what());
+            return false;
+        }
+
+        for (const auto& fileEntry : manifest["files"].GetArray()) {
+            if (!fileEntry.Has("name") || !fileEntry["name"].IsString()) {
+                SendResultAndDie(false, TStringBuilder() << "Manifest file entry is missing 'name' field: " << fileEntry);
+                return false;
+            }
+
+            if (!fileEntry.Has("sha256") || !fileEntry["sha256"].IsString()) {
+                SendResultAndDie(false, TStringBuilder() << "Manifest file entry is missing 'sha256' field: " << fileEntry);
+                return false;
+            }
+
+            TString name = fileEntry["name"].GetString();
+            TString expectedFileSha256 = fileEntry["sha256"].GetString();
+
+            auto filePath = snapshotDir.Child(name);
+            if (!filePath.Exists()) {
+                SendResultAndDie(false, TStringBuilder() << "File listed in manifest not found: " << filePath);
+                return false;
+            }
+
+            TString basename = filePath.Basename();
+            if (basename != "schema.json") {
+                SnapshotFiles.push_back(filePath);
+            }
+
+            NOpenSsl::NSha256::TCalcer calcer;
+            try {
+                TFileInput input(filePath, 1_MB);
+                char buf[64_KB];
+                size_t bytesRead;
+                while ((bytesRead = input.Read(buf, sizeof(buf))) > 0) {
+                    calcer.Update(buf, bytesRead);
+                }
+            } catch (const TIoException& e) {
+                SendResultAndDie(false, TStringBuilder() << "Failed to read file " << filePath << " for checksum validation: " << e.what());
+                return false;
+            }
+
+            auto fileDigest = calcer.Final();
+            TString actualFileSha256 = to_lower(HexEncode(fileDigest.data(), fileDigest.size()));
+            if (actualFileSha256 != expectedFileSha256) {
+                SendResultAndDie(false, TStringBuilder() << "Checksum mismatch for " << filePath
+                                         << ": expected " << expectedFileSha256
+                                         << ", got " << actualFileSha256);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    ui64 CalculateTotalSize() const {
+        ui64 totalBytes = 0;
+        totalBytes += GetFileSize(ChangelogFilePath);
+        totalBytes += GetFileSize(SchemaFilePath);
+        for (const auto& file : SnapshotFiles) {
+            totalBytes += GetFileSize(file);
+        }
+        return totalBytes;
+    }
+
+    ui64 GetFileSize(const TFsPath& path) const {
+        TFileStat stat(path);
+        return stat.Size;
+    }
+
     void SendResultAndDie(bool success, const TString& error = "") {
         Send(Owner, new TEvBackupReaderResult(success, error));
         PassAway();
@@ -947,8 +1044,10 @@ private:
     const TActorId Owner;
     const TFsPath BackupPath;
 
-    TFsPath SchemaFilePath;
-    TFsPath ChangelogFilePath;
+    const TFsPath SnapshotDirPath;
+    const TFsPath SchemaFilePath;
+    const TFsPath ChangelogFilePath;
+
     TDeque<TFsPath> SnapshotFiles;
 
     TFsPath CurrentFilePath;

--- a/ydb/core/tablet_flat/flat_executor_recovery.h
+++ b/ydb/core/tablet_flat/flat_executor_recovery.h
@@ -26,11 +26,13 @@ enum EEv {
 static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_FLAT_EXECUTOR));
 
 struct TEvRestoreBackup : public TEventLocal<TEvRestoreBackup, EvRestoreBackup> {
-    TEvRestoreBackup(const TString& backupPath)
+    TEvRestoreBackup(const TString& backupPath, bool skipChecksumValidation = false)
         : BackupPath(backupPath)
+        , SkipChecksumValidation(skipChecksumValidation)
     {}
 
     TString BackupPath;
+    bool SkipChecksumValidation = false;
 };
 
 struct TEvRestoreCompleted : public TEventLocal<TEvRestoreCompleted, EvRestoreCompleted> {
@@ -108,6 +110,8 @@ enum class ERestoreState : ui8 {
 };
 
 IActor* CreateRecoveryShard(const TActorId &tablet, TTabletStorageInfo *info);
-IActor* CreateBackupReader(TActorId owner, const TString& backupPath);
+IActor* CreateBackupReader(TActorId owner, const TString& backupPath,
+                           TTabletTypes::EType tabletType, ui64 tabletId,
+                           bool skipChecksumValidation = false);
 
 } // namespace NKikimr::NTabletFlatExecutor::NRecovery

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -794,12 +794,12 @@ struct TEnv : public TMyEnvBase {
         Env.DispatchEvents(options);
     }
 
-    void RestoreBackup(const TString& backupPath, ui32 TestTabletFlags) {
+    void RestoreBackup(const TString& backupPath, ui32 TestTabletFlags, bool skipChecksumValidation = false) {
         Cerr << "...restarting dummy tablet in recovery mode" << Endl;
         RestartTabletInRecoveryMode();
 
         Cerr << "...restoring backup" << Endl;
-        SendAsync(new NRecovery::TEvRestoreBackup(backupPath));
+        SendAsync(new NRecovery::TEvRestoreBackup(backupPath, skipChecksumValidation));
 
         TAutoPtr<IEventHandle> handle;
         auto result = Env.GrabEdgeEventRethrow<NRecovery::TEvRestoreCompleted>(handle);
@@ -831,7 +831,9 @@ struct TEnv : public TMyEnvBase {
         return genDirs.back();
     }
 
-    void RestoreBackupExpectFailure(const TFsPath& backupPath) {
+    void RestoreLastBackupExpectFail() {
+        auto backupPath = GetLastBackupPath();
+
         Cerr << "...restarting dummy tablet in recovery mode" << Endl;
         RestartTabletInRecoveryMode();
 
@@ -1835,7 +1837,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Corrupt schema.json with invalid JSON
         WriteFileContent(snapshotDir.Child("schema.json"), "this is not valid json{{{");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSchemaExtraTable) {
@@ -1859,7 +1861,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Rename Data.json to FakeTable.json - table not in schema
         snapshotDir.Child("Data.json").RenameTo(snapshotDir.Child("FakeTable.json"));
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSchemaExtraColumn) {
@@ -1884,7 +1886,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         WriteFileContent(snapshotDir.Child("Data.json"),
             R"({"Key":1,"Value":10,"BinaryValue":"aGVsbG8=","DefaultValue":null,"FakeColumn":42})""\n");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSchemaRemoved) {
@@ -1923,7 +1925,7 @@ Y_UNIT_TEST_SUITE(Backup) {
 
         WriteFileContent(schemaPath, NJson::WriteJson(schema, false));
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSnapshotInvalidJSON) {
@@ -1947,7 +1949,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Write invalid JSON to Data.json
         WriteFileContent(snapshotDir.Child("Data.json"), "this is not valid json{{{");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSnapshotMissingKey) {
@@ -1972,7 +1974,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         WriteFileContent(snapshotDir.Child("Data.json"),
             R"({"Value":10,"BinaryValue":"aGVsbG8=","DefaultValue":null})""\n");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSnapshotWrongType) {
@@ -1997,7 +1999,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         WriteFileContent(snapshotDir.Child("Data.json"),
             R"({"Key":1,"Value":"not_a_number","BinaryValue":"aGVsbG8=","DefaultValue":null})""\n");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSnapshotExtraField) {
@@ -2022,7 +2024,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         WriteFileContent(snapshotDir.Child("Data.json"),
             R"({"Key":1,"Value":10,"BinaryValue":"aGVsbG8=","DefaultValue":null,"UnknownField":42})" "\n");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSnapshotInvalidBase64) {
@@ -2047,7 +2049,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         WriteFileContent(snapshotDir.Child("Data.json"),
             R"({"Key":1,"Value":10,"BinaryValue":"!!!not-valid-base64!!!","DefaultValue":null})" "\n");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSnapshotNullKey) {
@@ -2072,7 +2074,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         WriteFileContent(snapshotDir.Child("Data.json"),
             R"({"Key":null,"Value":10,"BinaryValue":"aGVsbG8=","DefaultValue":null})" "\n");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(CorruptedSnapshotRemoved) {
@@ -2096,7 +2098,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Remove a row from the snapshot (truncate the file)
         WriteFileContent(snapshotDir.Child("Data.json"), "");
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(MissingSnapshotDir) {
@@ -2118,7 +2120,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Remove the snapshot directory
         backupPath.Child("snapshot").ForceDelete();
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(MissingSchemaFile) {
@@ -2141,7 +2143,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Remove schema.json from the snapshot dir
         snapshotDir.Child("schema.json").DeleteIfExists();
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(MissingTableFile) {
@@ -2165,7 +2167,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Remove a table data file from the snapshot
         snapshotDir.Child("Data.json").DeleteIfExists();
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(MissingChangelogFile) {
@@ -2187,7 +2189,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Remove changelog.json
         backupPath.Child("changelog.json").DeleteIfExists();
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(WrongFilePermissions) {
@@ -2210,7 +2212,124 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Remove read permissions from manifest.json
         chmod(snapshotDir.Child("manifest.json").c_str(), 0);
 
-        env.RestoreBackupExpectFailure(backupPath);
+        env.RestoreLastBackupExpectFail();
+    }
+
+    Y_UNIT_TEST(CorruptedManifestContent) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        WriteFileContent(snapshotDir.Child("manifest.json"), "this is not valid json{{{");
+
+        env.RestoreLastBackupExpectFail();
+    }
+
+    Y_UNIT_TEST(CorruptedManifestChecksum) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        WriteFileContent(snapshotDir.Child("manifest.json.sha256"), "0000000000000000000000000000000000000000000000000000000000000000");
+
+        env.RestoreLastBackupExpectFail();
+    }
+
+    Y_UNIT_TEST(SkipChecksumValidation) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        WriteFileContent(snapshotDir.Child("manifest.json.sha256"), "0000000000000000000000000000000000000000000000000000000000000000");
+
+        env.RestoreBackup(backupPath, TestTabletFlags, true);
+
+        UNIT_ASSERT_VALUES_EQUAL(env.CountRows<TSchema::Data>(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(env.ReadValue<TSchema::Data::Value>(1), 10);
+        UNIT_ASSERT_VALUES_EQUAL(env.ReadBinaryValue(1), "hello");
+    }
+
+    Y_UNIT_TEST(MissingManifestFile) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        snapshotDir.Child("manifest.json").DeleteIfExists();
+
+        env.RestoreLastBackupExpectFail();
+    }
+
+    Y_UNIT_TEST(MissingManifestChecksumFile) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        snapshotDir.Child("manifest.json.sha256").DeleteIfExists();
+
+        env.RestoreLastBackupExpectFail();
     }
 
     Y_UNIT_TEST(NewSnapshotChangelogSize) {

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/testlib/actors/block_events.h>
 
 #include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/json_writer.h>
 #include <library/cpp/json/writer/json_value.h>
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -607,6 +608,12 @@ struct TTxReadCompositePK : public ITransaction {
     }
 }; // TTxReadCompositePK
 
+void WriteFileContent(const TFsPath& path, const TString& content) {
+    TFile file(path, CreateAlways | WrOnly);
+    file.Write(content.data(), content.size());
+    file.Flush();
+}
+
 struct TRecoveryStarter : public NFake::TStarter {
     using TBase = NFake::TStarter;
 
@@ -806,6 +813,10 @@ struct TEnv : public TMyEnvBase {
     }
 
     void RestoreLastBackup(ui32 TestTabletFlags) {
+        RestoreBackup(GetLastBackupPath(), TestTabletFlags);
+    }
+
+    TFsPath GetLastBackupPath() {
         auto tabletIdDir = TFsPath(Env.GetTempDir())
             .Child("dummy")
             .Child(ToString(Tablet));
@@ -817,7 +828,20 @@ struct TEnv : public TMyEnvBase {
             return a.Basename() < b.Basename();
         });
 
-        RestoreBackup(genDirs.back(), TestTabletFlags);
+        return genDirs.back();
+    }
+
+    void RestoreBackupExpectFailure(const TFsPath& backupPath) {
+        Cerr << "...restarting dummy tablet in recovery mode" << Endl;
+        RestartTabletInRecoveryMode();
+
+        Cerr << "...restoring backup (expecting failure)" << Endl;
+        SendAsync(new NRecovery::TEvRestoreBackup(backupPath));
+
+        TAutoPtr<IEventHandle> handle;
+        auto result = Env.GrabEdgeEventRethrow<NRecovery::TEvRestoreCompleted>(handle);
+        Cerr << "...restore result: Success=" << result->Success << ", Error=" << result->Error << Endl;
+        UNIT_ASSERT_C(!result->Success, "Restore should have failed but succeeded");
     }
 }; // TEnv
 
@@ -898,7 +922,8 @@ Y_UNIT_TEST_SUITE(Backup) {
         snapshotDir.List(tables);
 
         std::erase_if(tables, [](const TFsPath& path) {
-            return path.Basename() == "schema.json";
+            TString basename = path.Basename();
+            return basename == "schema.json" || basename == "manifest.json" || basename == "manifest.json.sha256";
         });
 
         UNIT_ASSERT(tables.size() == 3);
@@ -979,7 +1004,8 @@ Y_UNIT_TEST_SUITE(Backup) {
         snapshotDir.List(tables);
 
         std::erase_if(tables, [](const TFsPath& path) {
-            return path.Basename() == "schema.json";
+            TString basename = path.Basename();
+            return basename == "schema.json" || basename == "manifest.json" || basename == "manifest.json.sha256";
         });
 
         UNIT_ASSERT(tables.size() == 3);
@@ -1786,6 +1812,405 @@ Y_UNIT_TEST_SUITE(Backup) {
         // Restore last backup
         env.RestoreBackup(genDirs.back(), TestTabletFlags);
         assertState();
+    }
+
+    Y_UNIT_TEST(CorruptedSchemaInvalidJSON) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Corrupt schema.json with invalid JSON
+        WriteFileContent(snapshotDir.Child("schema.json"), "this is not valid json{{{");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSchemaExtraTable) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Rename Data.json to FakeTable.json - table not in schema
+        snapshotDir.Child("Data.json").RenameTo(snapshotDir.Child("FakeTable.json"));
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSchemaExtraColumn) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Add an unknown column to the data row
+        WriteFileContent(snapshotDir.Child("Data.json"),
+            R"({"Key":1,"Value":10,"BinaryValue":"aGVsbG8=","DefaultValue":null,"FakeColumn":42})""\n");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSchemaRemoved) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Remove Data table definition from schema.json
+        auto schemaPath = snapshotDir.Child("schema.json");
+        TString schemaStr = TFileInput(schemaPath).ReadAll();
+        NJson::TJsonValue schema;
+        NJson::ReadJsonTree(schemaStr, &schema, true);
+
+        NJson::TJsonValue filteredDeltas;
+        filteredDeltas.SetType(NJson::JSON_ARRAY);
+        for (const auto& delta : schema["delta"].GetArray()) {
+            if (delta.Has("table_id") && delta["table_id"].GetInteger() == 1) {
+                continue; // skip Data table (table_id=1) entries
+            }
+            filteredDeltas.AppendValue(delta);
+        }
+        schema["delta"] = filteredDeltas;
+
+        WriteFileContent(schemaPath, NJson::WriteJson(schema, false));
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSnapshotInvalidJSON) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Write invalid JSON to Data.json
+        WriteFileContent(snapshotDir.Child("Data.json"), "this is not valid json{{{");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSnapshotMissingKey) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Row without primary key column
+        WriteFileContent(snapshotDir.Child("Data.json"),
+            R"({"Value":10,"BinaryValue":"aGVsbG8=","DefaultValue":null})""\n");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSnapshotWrongType) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Wrong data type: Value (Uint32) gets a string
+        WriteFileContent(snapshotDir.Child("Data.json"),
+            R"({"Key":1,"Value":"not_a_number","BinaryValue":"aGVsbG8=","DefaultValue":null})""\n");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSnapshotExtraField) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Row with unknown field
+        WriteFileContent(snapshotDir.Child("Data.json"),
+            R"({"Key":1,"Value":10,"BinaryValue":"aGVsbG8=","DefaultValue":null,"UnknownField":42})" "\n");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSnapshotInvalidBase64) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Invalid Base64 in binary column
+        WriteFileContent(snapshotDir.Child("Data.json"),
+            R"({"Key":1,"Value":10,"BinaryValue":"!!!not-valid-base64!!!","DefaultValue":null})" "\n");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSnapshotNullKey) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Null primary key value
+        WriteFileContent(snapshotDir.Child("Data.json"),
+            R"({"Key":null,"Value":10,"BinaryValue":"aGVsbG8=","DefaultValue":null})" "\n");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(CorruptedSnapshotRemoved) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteTwoColumns(1, 10, "hello");
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Remove a row from the snapshot (truncate the file)
+        WriteFileContent(snapshotDir.Child("Data.json"), "");
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(MissingSnapshotDir) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+
+        // Remove the snapshot directory
+        backupPath.Child("snapshot").ForceDelete();
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(MissingSchemaFile) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Remove schema.json from the snapshot dir
+        snapshotDir.Child("schema.json").DeleteIfExists();
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(MissingTableFile) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema and writing data" << Endl;
+        env.InitSchema();
+        env.WriteValue(1, 10);
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Remove a table data file from the snapshot
+        snapshotDir.Child("Data.json").DeleteIfExists();
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(MissingChangelogFile) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+
+        // Remove changelog.json
+        backupPath.Child("changelog.json").DeleteIfExists();
+
+        env.RestoreBackupExpectFailure(backupPath);
+    }
+
+    Y_UNIT_TEST(WrongFilePermissions) {
+        TEnv env;
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        Cerr << "...restarting tablet" << Endl;
+        env.RestartTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        auto backupPath = env.GetLastBackupPath();
+        auto snapshotDir = backupPath.Child("snapshot");
+
+        // Remove read permissions from manifest.json
+        chmod(snapshotDir.Child("manifest.json").c_str(), 0);
+
+        env.RestoreBackupExpectFailure(backupPath);
     }
 
     Y_UNIT_TEST(NewSnapshotChangelogSize) {

--- a/ydb/core/tablet_flat/ya.make
+++ b/ydb/core/tablet_flat/ya.make
@@ -120,6 +120,7 @@ PEERDIR(
     library/cpp/json/writer
     library/cpp/lwtrace
     library/cpp/lwtrace/mon
+    library/cpp/openssl/crypto
     ydb/core/base
     ydb/core/control/lib
     ydb/core/protos


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Changes:**
- Added manifest.json file with SHA-256 checksums for all snapshot files (schema.json and table data files)
- Added manifest.json.sha256 file containing the checksum of the manifest itself
- Implemented atomic snapshot creation using temporary directory and rename
- Added Skip Checksum Validation checkbox
- Added comprehensive corruption detection tests covering various failure scenarios
