### PR TITLE
fix profile mem alloc

### DIFF
--- a/ydb/library/actors/prof/tag.cpp
+++ b/ydb/library/actors/prof/tag.cpp
@@ -7,7 +7,6 @@
 
 #if defined(PROFILE_MEMORY_ALLOCATIONS)
 #include <library/cpp/lfalloc/dbg_info/dbg_info.h>
-#include <library/cpp/ytalloc/api/ytalloc.h>
 #include <library/cpp/yt/memory/memory_tag.h>
 #endif
 

--- a/ydb/library/actors/prof/ya.make
+++ b/ydb/library/actors/prof/ya.make
@@ -16,7 +16,6 @@ IF (PROFILE_MEMORY_ALLOCATIONS)
     PEERDIR(
         library/cpp/malloc/api
         library/cpp/lfalloc/dbg_info
-        library/cpp/ytalloc/api
         library/cpp/yt/memory
     )
 ENDIF()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Fix build with `-DPROFILE_MEMORY_ALLOCATIONS`
...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Build with `-DPROFILE_MEMORY_ALLOCATIONS` is currently failing with:

`Error[-WBadDir]: in $B/ydb/library/actors/prof/liblibrary-actors-prof.a: PEERDIR to directory without ya.make: $S/library/cpp/ytalloc/api`

probably after https://github.com/ydb-platform/ydb/commit/ef88ddededc09660d4a265a630a89bcdb9c84c89
...
