### PR TITLE
Deferred TEvReadSetAck queues

### DIFF
--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -3474,7 +3474,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
                     " for TxId " << event.GetTxId() <<
                     " will be sent later");
 
-        AddDeferredReadSetAck({.Sender = ev->Sender, .Ack = std::move(ack)});
+        AddPendingDeferredReadSetAck({.Sender = ev->Sender, .Ack = std::move(ack)});
     }
 }
 
@@ -3484,7 +3484,7 @@ void TPersQueue::MovePendingDeferredReadSetAcks()
     PendingDeferredReadSetAcks.clear();
 }
 
-void TPersQueue::AddDeferredReadSetAck(TDeferredReadSetAck&& ack)
+void TPersQueue::AddPendingDeferredReadSetAck(TDeferredReadSetAck&& ack)
 {
     PendingDeferredReadSetAcks.push_back(std::move(ack));
 }

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -1059,15 +1059,12 @@ void TPersQueue::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
     case WRITE_TX_COOKIE:
         PQ_LOG_D("Handle TEvKeyValue::TEvResponse (WRITE_TX_COOKIE)");
         EndWriteTxs(resp, ctx);
+        // Завершилась операция с CmdWrite. Можно отправлять отложенные TEvReadSetAck
+        SendDeferredReadSetAcks(ctx);
         break;
     default:
         PQ_LOG_ERROR("Unexpected KV response: " << ev->Get()->ToString() << " " << ctx.SelfID);
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
-    }
-
-    // Завершилась операция с CmdWrite. Можно отправлять отложенные TEvReadSetAck
-    if (resp.GetCookie() != READ_TXS_COOKIE) {
-        SendDefferedReadSetAcks(ctx);
     }
 }
 
@@ -3477,23 +3474,30 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
                     " for TxId " << event.GetTxId() <<
                     " will be sent later");
 
-        TDefferedReadSetAck item;
-        item.Sender = ev->Sender;
-        item.Ack = std::move(ack);
-
-        DefferedReadSetAcks.push_back(std::move(item));
+        AddDeferredReadSetAck({.Sender = ev->Sender, .Ack = std::move(ack)});
     }
 }
 
-void TPersQueue::SendDefferedReadSetAcks(const TActorContext& ctx)
+void TPersQueue::MovePendingDeferredReadSetAcks()
 {
-    for (auto& e : DefferedReadSetAcks) {
+    DeferredReadSetAcks = std::move(PendingDeferredReadSetAcks);
+    PendingDeferredReadSetAcks.clear();
+}
+
+void TPersQueue::AddDeferredReadSetAck(TDeferredReadSetAck&& ack)
+{
+    PendingDeferredReadSetAcks.push_back(std::move(ack));
+}
+
+void TPersQueue::SendDeferredReadSetAcks(const TActorContext& ctx)
+{
+    for (auto& e : DeferredReadSetAcks) {
         PQ_LOG_TX_I("send TEvReadSetAck to " << e.Ack->Record.GetTabletSource() <<
                     " for TxId " << e.Ack->Record.GetTxId());
         ctx.Send(e.Sender, e.Ack.release());
     }
 
-    DefferedReadSetAcks.clear();
+    DeferredReadSetAcks.clear();
 }
 
 void TPersQueue::Handle(TEvTxProcessing::TEvReadSetAck::TPtr& ev, const TActorContext& ctx)
@@ -3653,6 +3657,8 @@ void TPersQueue::BeginWriteTxs(const TActorContext& ctx)
     ProcessProposeTransactionQueue(ctx, request->Record);
     ProcessWriteTxs(ctx, request->Record);
     AddCmdWriteTabletTxInfo(request->Record);
+
+    MovePendingDeferredReadSetAcks();
 
     WriteTxsInProgress = true;
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -1064,6 +1064,8 @@ void TPersQueue::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
         PQ_LOG_ERROR("Unexpected KV response: " << ev->Get()->ToString() << " " << ctx.SelfID);
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
     }
+
+    SendDefferedReadSetAcks(ctx);
 }
 
 void TPersQueue::SetCacheCounters(TEvPQ::TEvTabletCacheCounters::TCacheCounters& cacheCounters)
@@ -3450,7 +3452,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         if ((tx->State > NKikimrPQ::TTransaction::EXECUTED) ||
             ((tx->State == NKikimrPQ::TTransaction::EXECUTED) && !tx->WriteInProgress)) {
             if (ack) {
-                PQ_LOG_TX_I("send TEvReadSetAck to " << event.GetTabletProducer() << " tx " << event.GetTxId());
+                PQ_LOG_TX_I("send TEvReadSetAck to " << event.GetTabletProducer() << " for TxId " << event.GetTxId());
                 ctx.Send(ev->Sender, ack.release());
                 return;
             }
@@ -3468,12 +3470,27 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
             TryWriteTxs(ctx);
         }
     } else if (ack) {
-        PQ_LOG_TX_I("send TEvReadSetAck to " << event.GetTabletProducer() << " tx " << event.GetTxId());
-        //
-        // для неизвестных транзакций подтверждение отправляется сразу
-        //
-        ctx.Send(ev->Sender, ack.release());
+        PQ_LOG_TX_I("a TEvReadSetAck message to " << event.GetTabletProducer() <<
+                    " for TxId " << event.GetTxId() <<
+                    " will be sent later");
+
+        TDefferedReadSetAck item;
+        item.Sender = ev->Sender;
+        item.Ack = std::move(ack);
+
+        DefferedReadSetAcks.push_back(std::move(item));
     }
+}
+
+void TPersQueue::SendDefferedReadSetAcks(const TActorContext& ctx)
+{
+    for (auto& e : DefferedReadSetAcks) {
+        PQ_LOG_TX_I("send TEvReadSetAck to " << e.Ack->Record.GetTabletSource() <<
+                    " for TxId " << e.Ack->Record.GetTxId());
+        ctx.Send(e.Sender, e.Ack.release());
+    }
+
+    DefferedReadSetAcks.clear();
 }
 
 void TPersQueue::Handle(TEvTxProcessing::TEvReadSetAck::TPtr& ev, const TActorContext& ctx)

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -1065,7 +1065,10 @@ void TPersQueue::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
     }
 
-    SendDefferedReadSetAcks(ctx);
+    // Завершилась операция с CmdWrite. Можно отправлять отложенные TEvReadSetAck
+    if (resp.GetCookie() != READ_TXS_COOKIE) {
+        SendDefferedReadSetAcks(ctx);
+    }
 }
 
 void TPersQueue::SetCacheCounters(TEvPQ::TEvTabletCacheCounters::TCacheCounters& cacheCounters)

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -656,7 +656,7 @@ private:
     TDeque<TDeferredReadSetAck> DeferredReadSetAcks;        // ждут пока завершится цикл записи WRITE_TX_COOKIE
 
     void MovePendingDeferredReadSetAcks();
-    void AddDeferredReadSetAck(TDeferredReadSetAck&& ack);
+    void AddPendingDeferredReadSetAck(TDeferredReadSetAck&& ack);
     void SendDeferredReadSetAcks(const TActorContext& ctx);
 };
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -645,6 +645,14 @@ private:
     bool HasTxPersistSpan = false;
     bool HasTxDeleteSpan = false;
     ui8 WriteTxsSpanVerbosity = 0;
+
+    struct TDefferedReadSetAck {
+        TActorId Sender;
+        std::unique_ptr<TEvTxProcessing::TEvReadSetAck> Ack;
+    };
+    TDeque<TDefferedReadSetAck> DefferedReadSetAcks;
+
+    void SendDefferedReadSetAcks(const TActorContext& ctx);
 };
 
 }// NPQ

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -646,13 +646,18 @@ private:
     bool HasTxDeleteSpan = false;
     ui8 WriteTxsSpanVerbosity = 0;
 
-    struct TDefferedReadSetAck {
+    // Список TEvReadSetAck для неизвестных транзакций. Их нужно отправлять только когда
+    // завершиться запись в цикле WRITE_TX_COOKIE. Так мы уверены, что таблетка является лидером
+    struct TDeferredReadSetAck {
         TActorId Sender;
         std::unique_ptr<TEvTxProcessing::TEvReadSetAck> Ack;
     };
-    TDeque<TDefferedReadSetAck> DefferedReadSetAcks;
+    TDeque<TDeferredReadSetAck> PendingDeferredReadSetAcks; // ждут очередной итерации цикла записи WRITE_TX_COOKIE
+    TDeque<TDeferredReadSetAck> DeferredReadSetAcks;        // ждут пока завершится цикл записи WRITE_TX_COOKIE
 
-    void SendDefferedReadSetAcks(const TActorContext& ctx);
+    void MovePendingDeferredReadSetAcks();
+    void AddDeferredReadSetAck(TDeferredReadSetAck&& ack);
+    void SendDeferredReadSetAcks(const TActorContext& ctx);
 };
 
 }// NPQ


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

TEvReadSetAck messages for unknown transactions or from unknown senders are postponed until the next WRITE_TX_COOKIE operation.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
