### PR TITLE
NBYDB-1939 Implement the busy sensor for SkeletonFront

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
@@ -89,9 +89,12 @@ TPDiskMon::TPDiskMon(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& count
     COUNTER_INIT(StateGroup, AtLeastOneVDiskNotLogged, false);
     COUNTER_INIT(StateGroup, TooMuchLogChunks, false);
     COUNTER_INIT(StateGroup, SerialNumberMismatched, false);
-    L6. Initialize(StateGroup, "L6");
-    L7. Initialize(StateGroup, "L7");
-    IdleLight.Initialize(StateGroup, "DeviceBusyPeriods", "DeviceIdleTimeMsPerSec", "DeviceBusyTimeMsPerSec");
+    L6.Initialize(StateGroup, TLightCounterConfig::WithDefaultLightSet("L6"));
+    L7.Initialize(StateGroup, TLightCounterConfig::WithDefaultLightSet("L7"));
+    IdleLight.Initialize(StateGroup, TLightCounterConfig::Create()
+        .WithCount("DeviceBusyPeriods")
+        .WithRedMs("DeviceIdleTimeMsPerSec")
+        .WithGreenMs("DeviceBusyTimeMsPerSec"));
 
     COUNTER_INIT_IF_EXTENDED(StateGroup, OwnerIdsIssued, false);
     COUNTER_INIT_IF_EXTENDED(StateGroup, LastOwnerId, false);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
@@ -92,7 +92,6 @@ TPDiskMon::TPDiskMon(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& count
     L6.Initialize(StateGroup, TLightCounterConfig::WithDefaultLightSet("L6"));
     L7.Initialize(StateGroup, TLightCounterConfig::WithDefaultLightSet("L7"));
     IdleLight.Initialize(StateGroup, TLightCounterConfig::Create()
-        .WithCount("DeviceBusyPeriods")
         .WithRedMs("DeviceIdleTimeMsPerSec")
         .WithGreenMs("DeviceBusyTimeMsPerSec"));
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_ut.cpp
@@ -111,7 +111,7 @@ Y_UNIT_TEST_SUITE(TPDiskUtil) {
     Y_UNIT_TEST(Light) {
         TLight l;
         TIntrusivePtr<::NMonitoring::TDynamicCounters> c(new ::NMonitoring::TDynamicCounters());
-        l.Initialize(c, "l");
+        l.Initialize(c, TLightCounterConfig::WithDefaultLightSet("l"));
         auto state = c->GetCounter("l_state");
         auto count = c->GetCounter("l_count");
 
@@ -240,7 +240,7 @@ Y_UNIT_TEST_SUITE(TPDiskUtil) {
     Y_UNIT_TEST(LightOverflow) {
         TLight l;
         TIntrusivePtr<::NMonitoring::TDynamicCounters> c(new ::NMonitoring::TDynamicCounters());
-        l.Initialize(c, "l");
+        l.Initialize(c, TLightCounterConfig::WithDefaultLightSet("l"));
         auto state = c->GetCounter("l_state");
         auto count = c->GetCounter("l_count");
 

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.cpp
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.cpp
@@ -53,7 +53,7 @@ TBsCostTracker::TBsCostTracker(const TBlobStorageGroupType& groupType, NPDisk::E
     , DiskTimeAvailableScale(costMetricsParameters.DiskTimeAvailableScale)
 {
     BucketUpperLimit.store(BurstThresholdNs * GetDiskTimeAvailableScale());
-    BurstDetector.Initialize(CostCounters, "BurstDetector");
+    BurstDetector.Initialize(CostCounters, TLightCounterConfig::WithDefaultLightSet("BurstDetector"));
     switch (GroupType.GetErasure()) {
     case TBlobStorageGroupType::ErasureMirror3dc:
         CostModel = std::make_unique<TBsCostModelMirror3dc>(diskType);

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -3108,7 +3108,7 @@ namespace NKikimr {
         {
             auto cpuGroup = VCtx->VDiskCounters->GetSubgroup("subsystem", "cpu");
             SkeletonBusyTimeUs = cpuGroup->GetCounter("skeletonBusyTimeUs");
-            ActorQueueLight.Initialize(cpuGroup, "Queue");
+            ActorQueueLight.Initialize(cpuGroup, TLightCounterConfig::WithDefaultLightSet("Queue"));
         }
 
         virtual ~TSkeleton() {

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -225,7 +225,7 @@ namespace NKikimr {
                 , SkeletonFrontCostProcessed(MakeCounter(skeletonFrontGroup, "CostProcessed", true, true))
             {
                 SkeletonFrontMaxInFlightCount.Init(MakeCounter(skeletonFrontGroup, "MaxInFlightCount", false, false));
-                InitializeLight(IdleLight, skeletonFrontGroup, "BusyPeriods", "IdleTimeMsPerSec", "BusyTimeMsPerSec");
+                IdleLight.Initialize(skeletonFrontGroup, TLightCounterConfig::Create().WithGreenMs("SkeletonFront/" + Name + "/" + "BusyTimeMsPerSec"));
             }
 
             ::NMonitoring::TDynamicCounters::TCounterPtr MakeCounter(TIntrusivePtr<::NMonitoring::TDynamicCounters> skeletonFrontGroup, const TString& sensorType, bool derivative, bool reportOnlyIfExtendedSensors) {
@@ -233,13 +233,6 @@ namespace NKikimr {
                     return skeletonFrontGroup->GetCounter("SkeletonFront/" + Name + "/" + sensorType, derivative, NMonitoring::TCountableBase::EVisibility::Private);
                 }
                 return skeletonFrontGroup->GetCounter("SkeletonFront/" + Name + "/" + sensorType, derivative);
-            }
-
-            void InitializeLight(TLight& light, TIntrusivePtr<::NMonitoring::TDynamicCounters> skeletonFrontGroup, const TString& countName, const TString& redMsName, const TString& greenMsName) {
-                light.Initialize(skeletonFrontGroup,
-                    "SkeletonFront/" + Name + "/" + countName,
-                    "SkeletonFront/" + Name + "/" + redMsName,
-                    "SkeletonFront/" + Name + "/" + greenMsName);
             }
 
             ui64 GetSize() const {

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -225,7 +225,7 @@ namespace NKikimr {
                 , SkeletonFrontCostProcessed(MakeCounter(skeletonFrontGroup, "CostProcessed", true, true))
             {
                 SkeletonFrontMaxInFlightCount.Init(MakeCounter(skeletonFrontGroup, "MaxInFlightCount", false, false));
-                IdleLight.Initialize(skeletonFrontGroup, "BusyPeriods", "IdleTimeMsPerSec", "BusyTimeMsPerSec");
+                InitializeLight(IdleLight, skeletonFrontGroup, "BusyPeriods", "IdleTimeMsPerSec", "BusyTimeMsPerSec");
             }
 
             ::NMonitoring::TDynamicCounters::TCounterPtr MakeCounter(TIntrusivePtr<::NMonitoring::TDynamicCounters> skeletonFrontGroup, const TString& sensorType, bool derivative, bool reportOnlyIfExtendedSensors) {
@@ -233,6 +233,13 @@ namespace NKikimr {
                     return skeletonFrontGroup->GetCounter("SkeletonFront/" + Name + "/" + sensorType, derivative, NMonitoring::TCountableBase::EVisibility::Private);
                 }
                 return skeletonFrontGroup->GetCounter("SkeletonFront/" + Name + "/" + sensorType, derivative);
+            }
+
+            void InitializeLight(TLight& light, TIntrusivePtr<::NMonitoring::TDynamicCounters> skeletonFrontGroup, const TString& countName, const TString& redMsName, const TString& greenMsName) {
+                light.Initialize(skeletonFrontGroup,
+                    "SkeletonFront/" + Name + "/" + countName,
+                    "SkeletonFront/" + Name + "/" + redMsName,
+                    "SkeletonFront/" + Name + "/" + greenMsName);
             }
 
             ui64 GetSize() const {
@@ -347,7 +354,8 @@ namespace NKikimr {
                          << " msgCtx# " << msgCtx.ToString()
                          << " Deadlines# " << Deadlines);
 
-                IdleLight.Set(--InFlightCount == 0, ++IdleLightSeqNo);
+                --InFlightCount;
+                IdleLight.Set(InFlightCount == 0, ++IdleLightSeqNo);
                 InFlightCost -= msgCtx.Cost;
                 InFlightBytes -= msgCtx.RecByteSize;
 

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -225,7 +225,7 @@ namespace NKikimr {
                 , SkeletonFrontCostProcessed(MakeCounter(skeletonFrontGroup, "CostProcessed", true, true))
             {
                 SkeletonFrontMaxInFlightCount.Init(MakeCounter(skeletonFrontGroup, "MaxInFlightCount", false, false));
-                IdleLight.Initialize(skeletonFrontGroup, "Idle");
+                IdleLight.Initialize(skeletonFrontGroup, "BusyPeriods", "IdleTimeMsPerSec", "BusyTimeMsPerSec");
             }
 
             ::NMonitoring::TDynamicCounters::TCounterPtr MakeCounter(TIntrusivePtr<::NMonitoring::TDynamicCounters> skeletonFrontGroup, const TString& sensorType, bool derivative, bool reportOnlyIfExtendedSensors) {
@@ -308,9 +308,9 @@ namespace NKikimr {
                             ++Deadlines;
                             front.GetExtQueue(rec->ExtQueueId).DeadlineHappened(ctx, rec, now, front);
                         } else {
-                            IdleLight.Set(true, ++IdleLightSeqNo);
                             ctx.Send(rec->Ev.release());
 
+                            IdleLight.Set(true, ++IdleLightSeqNo);
                             ++InFlightCount;
                             InFlightCost += cost;
                             InFlightBytes += recByteSize;

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -19,6 +19,7 @@
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
 #include <ydb/core/blobstorage/backpressure/queue_backpressure_server.h>
 
+#include <ydb/core/util/light.h>
 #include <ydb/core/util/max_tracker.h>
 #include <ydb/core/util/queue_inplace.h>
 #include <ydb/core/util/stlog.h>
@@ -186,6 +187,8 @@ namespace NKikimr {
             ::NMonitoring::TDynamicCounters::TCounterPtr SkeletonFrontDelayedCount;
             ::NMonitoring::TDynamicCounters::TCounterPtr SkeletonFrontDelayedBytes;
             ::NMonitoring::TDynamicCounters::TCounterPtr SkeletonFrontCostProcessed;
+            TLight IdleLight;
+            ui16 IdleLightSeqNo = 0;
 
             bool CanSendToSkeleton(ui64 cost) const {
                 bool inFlightCond = InFlightCount < MaxInFlightCount;
@@ -222,6 +225,7 @@ namespace NKikimr {
                 , SkeletonFrontCostProcessed(MakeCounter(skeletonFrontGroup, "CostProcessed", true, true))
             {
                 SkeletonFrontMaxInFlightCount.Init(MakeCounter(skeletonFrontGroup, "MaxInFlightCount", false, false));
+                IdleLight.Initialize(skeletonFrontGroup, "Idle");
             }
 
             ::NMonitoring::TDynamicCounters::TCounterPtr MakeCounter(TIntrusivePtr<::NMonitoring::TDynamicCounters> skeletonFrontGroup, const TString& sensorType, bool derivative, bool reportOnlyIfExtendedSensors) {
@@ -244,6 +248,7 @@ namespace NKikimr {
                 if (!Queue.Head() && CanSendToSkeleton(cost)) {
                     // send to Skeleton for further processing
                     ctx.Send(converted.release());
+                    IdleLight.Set(true, ++IdleLightSeqNo);
                     ++InFlightCount;
                     InFlightCost += cost;
                     InFlightBytes += recByteSize;
@@ -303,6 +308,7 @@ namespace NKikimr {
                             ++Deadlines;
                             front.GetExtQueue(rec->ExtQueueId).DeadlineHappened(ctx, rec, now, front);
                         } else {
+                            IdleLight.Set(true, ++IdleLightSeqNo);
                             ctx.Send(rec->Ev.release());
 
                             ++InFlightCount;
@@ -341,6 +347,7 @@ namespace NKikimr {
                          << " msgCtx# " << msgCtx.ToString()
                          << " Deadlines# " << Deadlines);
 
+                IdleLight.Set(false, ++IdleLightSeqNo);
                 --InFlightCount;
                 InFlightCost -= msgCtx.Cost;
                 InFlightBytes -= msgCtx.RecByteSize;

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -347,8 +347,7 @@ namespace NKikimr {
                          << " msgCtx# " << msgCtx.ToString()
                          << " Deadlines# " << Deadlines);
 
-                IdleLight.Set(false, ++IdleLightSeqNo);
-                --InFlightCount;
+                IdleLight.Set(--InFlightCount == 0, ++IdleLightSeqNo);
                 InFlightCost -= msgCtx.Cost;
                 InFlightBytes -= msgCtx.RecByteSize;
 

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -493,6 +493,7 @@ namespace NKikimr {
 
             // refresh statistics for window-based counters
             void UpdateCounters() {
+                IdleLight.Update();
                 SkeletonFrontMaxInFlightCount.Update();
             }
         };

--- a/ydb/core/util/light.h
+++ b/ydb/core/util/light.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <ydb/core/mon/mon.h>
 
 #include "hp_timer_helpers.h"

--- a/ydb/core/util/light.h
+++ b/ydb/core/util/light.h
@@ -1,10 +1,53 @@
 #pragma once
 
+#include <optional>
+
 #include <ydb/core/mon/mon.h>
 
 #include "hp_timer_helpers.h"
 
 namespace NKikimr {
+
+class TLightCounterConfig {
+public:
+    std::optional<TString> StateName;
+    std::optional<TString> CountName;
+    std::optional<TString> RedMsName;
+    std::optional<TString> GreenMsName;
+
+    static TLightCounterConfig Create() {
+        return {};
+    }
+
+    TLightCounterConfig& WithState(const TString& name) {
+        StateName = name;
+        return *this;
+    }
+
+    TLightCounterConfig& WithCount(const TString& name) {
+        CountName = name;
+        return *this;
+    }
+
+    TLightCounterConfig& WithRedMs(const TString& name) {
+        RedMsName = name;
+        return *this;
+    }
+
+    TLightCounterConfig& WithGreenMs(const TString& name) {
+        GreenMsName = name;
+        return *this;
+    }
+
+    static TLightCounterConfig WithDefaultLightSet(const TString& baseName) {
+        TLightCounterConfig config;
+        config.StateName = baseName + "_state";
+        config.CountName = baseName + "_count";
+        config.RedMsName = baseName + "_redMs";
+        config.GreenMsName = baseName + "_greenMs";
+        return config;
+    }
+};
 
 class TLightBase {
 protected:
@@ -20,21 +63,19 @@ private:
     NHPTimer::STime LastNow = 0;
     ui64 UpdateThreshold = 0;
 public:
-    void Initialize(TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters, const TString& name) {
-        Name = name;
-        State = counters->GetCounter(name + "_state");
-        Count = counters->GetCounter(name + "_count", true);
-        RedMs = counters->GetCounter(name + "_redMs", true);
-        GreenMs = counters->GetCounter(name + "_greenMs", true);
-        UpdateThreshold = HPCyclesMs(100);
-        AdvancedTill = Now();
-    }
-
-    void Initialize(TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters, const TString& countName,
-            const TString& redMsName,const TString& greenMsName) {
-        Count = counters->GetCounter(countName, true);
-        RedMs = counters->GetCounter(redMsName, true);
-        GreenMs = counters->GetCounter(greenMsName, true);
+    void Initialize(TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters, const TLightCounterConfig& config) {
+        if (config.StateName) {
+            State = counters->GetCounter(*config.StateName);
+        }
+        if (config.CountName) {
+            Count = counters->GetCounter(*config.CountName, true);
+        }
+        if (config.RedMsName) {
+            RedMs = counters->GetCounter(*config.RedMsName, true);
+        }
+        if (config.GreenMsName) {
+            GreenMs = counters->GetCounter(*config.GreenMsName, true);
+        }
         UpdateThreshold = HPCyclesMs(100);
         AdvancedTill = Now();
     }
@@ -56,7 +97,9 @@ protected:
             if (State) {
                 *State = true;
             }
-            (*Count)++;
+            if (Count) {
+                (*Count)++;
+            }
             return;
         }
         if (!state && prevState) { // Switched to OFF state
@@ -72,10 +115,10 @@ protected:
             return;
         }
         Elapsed(state, now - AdvancedTill);
-        if (RedCycles > UpdateThreshold) {
+        if (RedMs && RedCycles > UpdateThreshold) {
             *RedMs += CutMs(RedCycles);
         }
-        if (GreenCycles > UpdateThreshold) {
+        if (GreenMs && GreenCycles > UpdateThreshold) {
             *GreenMs += CutMs(GreenCycles);
         }
         AdvancedTill = now;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR adds the `Idle` sensor signal in SkeletonFront to indicate when the queue is not actually processing any requests but waiting for Skeleton.

### Changelog category <!-- remove all except one -->

* New feature
### Description for reviewers <!-- (optional) description for those who read this PR -->

...
