### PR TITLE
Make sure truncate garbage collects removed data as soon as possible

### DIFF
--- a/ydb/core/base/tablet.h
+++ b/ydb/core/base/tablet.h
@@ -56,6 +56,7 @@ struct TEvTablet {
         EvReady,
         EvFollowerDetached, // from leader to user tablet when a follower is removed
         EvCompleteRecoveryBoot, // from user tablet to sys tablet
+        EvSnapshotConfirmed, // from sys tablet to user tablet
 
         EvCommit = EvBoot + 512,
         EvAux,
@@ -410,6 +411,18 @@ struct TEvTablet {
             , ApproximateFreeSpaceShareByChannel(std::move(approximateFreeSpaceShareByChannel))
             , GroupWrittenBytes(std::move(written))
             , GroupWrittenOps(std::move(writtenOps))
+        {}
+    };
+
+    struct TEvSnapshotConfirmed : public TEventLocal<TEvSnapshotConfirmed, EvSnapshotConfirmed> {
+        const ui64 TabletID;
+        const ui32 Generation;
+        const ui32 Step;
+
+        TEvSnapshotConfirmed(ui64 tabletId, ui32 gen, ui32 step)
+            : TabletID(tabletId)
+            , Generation(gen)
+            , Step(step)
         {}
     };
 

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -225,6 +225,7 @@ void TTablet::WriteZeroEntry(TEvTablet::TDependencyGraph *graph) {
         graph->Entries.erase(graph->Entries.begin(), snapIterator); // erase head of graph
 
     Graph.Snapshot = snapshot;
+    Graph.SnapshotSource = {};
 
     const TLogoBlobID logid(TabletID(), StateStorageInfo.KnownGeneration, 0, 0, 0, 0);
     TVector<TEvTablet::TLogEntryReference> refs;
@@ -1540,6 +1541,8 @@ bool TTablet::ProgressCommitQueue() {
 
         if (entry->IsSnapshot) {
             Graph.Snapshot = std::pair<ui32, ui32>(StateStorageInfo.KnownGeneration, step);
+            Graph.SnapshotSource = entry->Source;
+            Graph.SnapshotCookie = entry->SourceCookie;
             GcLogChannel(entry->ConfirmedOnSend);
         }
 
@@ -1644,7 +1647,19 @@ void TTablet::ProgressFollowerQueue() {
         Graph.PostponedFollowerUpdates.pop_front();
     }
 
-    if (Graph.PostponedFollowerUpdates && Graph.Queue.empty() && Graph.SyncCommit.SyncStep == 0) {
+    bool needSyncCommit = (
+        // We must have committed and confirmed all commits
+        Graph.Queue.empty() &&
+        // We must not have another sync commit inflight
+        Graph.SyncCommit.SyncStep == 0 &&
+        (
+            // And either there are pending follower updates waiting for confirmation
+            Graph.PostponedFollowerUpdates ||
+            // Or the latest snapshot wasn't confirmed by the last commit
+            Graph.Snapshot > std::make_pair(StateStorageInfo.KnownGeneration, Graph.ConfirmedCommited)
+        ));
+
+    if (needSyncCommit) {
         Graph.SyncCommit.SyncStep = Graph.NextEntry - 1;
         if (GcInFly) {
             // Since we always confirm the last commit it should be impossible
@@ -1663,6 +1678,13 @@ void TTablet::ProgressFollowerQueue() {
 
         Y_DEBUG_ABORT_UNLESS(Graph.Confirmed == Graph.SyncCommit.SyncStep); // last entry must be confirmed
         Y_DEBUG_ABORT_UNLESS(Graph.SyncCommit.SyncStep > Graph.ConfirmedCommited); // commit should make some progress
+
+        if (Graph.Snapshot > std::make_pair(StateStorageInfo.KnownGeneration, Graph.ConfirmedCommited)) {
+            // We are confirming the last committed snapshot
+            Graph.SyncCommit.Snapshot = Graph.Snapshot.second;
+            Graph.SyncCommit.SnapshotSource = Graph.SnapshotSource;
+            Graph.SyncCommit.SnapshotCookie = Graph.SnapshotCookie;
+        }
 
         TVector<TEvTablet::TLogEntryReference> refs;
         Register(
@@ -1736,8 +1758,19 @@ void TTablet::Handle(TEvTabletBase::TEvWriteLogResult::TPtr &ev) {
         } else {
             Y_DEBUG_ABORT_UNLESS(logid.Cookie() == 1 && step == Graph.SyncCommit.SyncStep);
 
+            if (Graph.SyncCommit.Snapshot != 0) {
+                // This snapshot is now confirmed
+                Send(Graph.SyncCommit.SnapshotSource,
+                    new TEvTablet::TEvSnapshotConfirmed(
+                        TabletID(),
+                        StateStorageInfo.KnownGeneration,
+                        Graph.SyncCommit.Snapshot),
+                    0, Graph.SyncCommit.SnapshotCookie);
+            }
+
             Graph.ConfirmedCommited = Max(Graph.ConfirmedCommited, step);
             Graph.SyncCommit.SyncStep = 0;
+            Graph.SyncCommit.Snapshot = 0;
             if (GcInFly == 0 && GcNextStep != 0) {
                 GcLogChannel(std::exchange(GcNextStep, 0));
             }

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -1561,6 +1561,7 @@ bool TTablet::ProgressCommitQueue() {
     }
 
     ProgressFollowerQueue();
+    ProgressSendSyncCommit();
     TryFinishFollowerSync();
     return true;
 }
@@ -1646,7 +1647,9 @@ void TTablet::ProgressFollowerQueue() {
 
         Graph.PostponedFollowerUpdates.pop_front();
     }
+}
 
+void TTablet::ProgressSendSyncCommit() {
     bool needSyncCommit = (
         // We must have committed and confirmed all commits
         Graph.Queue.empty() &&

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -127,9 +127,14 @@ class TTablet : public TActor<TTablet> {
         ui64 BytesInFlight;
 
         std::pair<ui32, ui32> Snapshot;
+        TActorId SnapshotSource;
+        ui64 SnapshotCookie = 0;
 
         struct {
             ui32 SyncStep = 0;
+            ui32 Snapshot = 0;
+            TActorId SnapshotSource;
+            ui64 SnapshotCookie = 0;
         } SyncCommit;
 
         TGraph()

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -388,6 +388,7 @@ class TTablet : public TActor<TTablet> {
 
     bool ProgressCommitQueue();
     void ProgressFollowerQueue();
+    void ProgressSendSyncCommit();
     void SpreadFollowerAuxUpdate(const TString& auxUpdate);
     void SendFollowerAuxUpdate(TLeaderInfo& info, const TActorId& follower, const TString& auxUpdate);
 

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -485,7 +485,7 @@ class TExecutor
     ui64 TransactionUniqCounter = 0;
 
     bool LogBatchFlushScheduled = false;
-    bool NeedFollowerSnapshot = false;
+    bool NeedLogSnapshot = false;
 
     mutable bool HadRejectProbabilityByTxInFly = false;
     mutable bool HadRejectProbabilityByOverload = false;
@@ -584,6 +584,7 @@ class TExecutor
     void Handle(TEvPrivate::TEvLeaseExtend::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvTablet::TEvConfirmLeaderResult::TPtr &ev);
     void Handle(TEvTablet::TEvCommitResult::TPtr &ev, const TActorContext &ctx);
+    void Handle(TEvTablet::TEvSnapshotConfirmed::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvPrivate::TEvActivateExecution::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvPrivate::TEvActivateLowExecution::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvPrivate::TEvBrokenTransaction::TPtr &ev, const TActorContext &ctx);

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -124,6 +124,14 @@ void TExecutorGCLogic::OnCommitLog(ui32 step, ui32 confirmedOnSend, const TActor
         SendCollectGarbage(ctx);
 }
 
+void TExecutorGCLogic::OnConfirmSnapshot(ui32 step, const TActorContext &ctx) {
+    ConfirmedOnSendStep = Max(ConfirmedOnSendStep, step);
+
+    if (step >= SnapshotStep) {
+        SendCollectGarbage(ctx);
+    }
+}
+
 TDuration TExecutorGCLogic::OnCollectGarbageResult(TEvBlobStorage::TEvCollectGarbageResult::TPtr &ptr) {
     TEvBlobStorage::TEvCollectGarbageResult* ev = ptr->Get();
     TChannelInfo& channel = ChannelInfo[ev->Channel];

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -43,6 +43,7 @@ public:
     TGCLogEntry SnapshotLog(ui32 step);
     void SnapToLog(NKikimrExecutorFlat::TLogSnapshot &logSnapshot, ui32 step);
     void OnCommitLog(ui32 step, ui32 confirmedOnSend, const TActorContext &ctx);                 // notification about log commit - could send GC to blob storage
+    void OnConfirmSnapshot(ui32 step, const TActorContext &ctx);                                 // notification about snapshot confirmation - will GC blobs in storage
     TDuration OnCollectGarbageResult(TEvBlobStorage::TEvCollectGarbageResult::TPtr& ev);         // notification on any garbage collection results
     void ApplyLogEntry(TGCLogEntry &entry);                                                      // apply one log entry, used during recovery and also from WriteToLog
     void ApplyLogSnapshot(TGCLogEntry &snapshot, const  TVector<std::pair<ui32, ui64>> &barriers);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When table is truncated all blobs are added to the `GcDelta.Deleted` (`GcLeft` in the commit proto) list in the same commit, so the data is eventually deleted. However, this list is lazily applied to storage, and often required at least two new log snapshots (600-1000 subsequent commits) before this data is marked for deletion.

This PR changes the logic in the following ways:

* LocalDB will make sure a new log snapshot is committed after any table is truncated (a new snapshot is also generated when restarting)
* Sys tablet will now make an additional confirmation log entry when there is a committed, but not yet persistently confirmed snapshot, and the commit queue is empty. This will make sure that eventually (either by subsequent commits, or by this confirmation log entry) the latest snapshot will become the guaranteed commit graph head that doesn't depend on earlier commits. These confirmation log entries have already been used extensively to confirm commit graph tail for followers.
* When the snapshot is confirmed in that way sys tablet notifies the executor using the new `TEvSnapshotConfirmed` event, which executor uses to garbage collect everything before the latest log snapshot.

Fixes #34367.