### PR TITLE
Fix Schemeshard crash in case of MoveTable to the inactive path. EXT-1963 (#34373)

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -590,7 +590,7 @@ public:
             }
         }
 
-        TPath dstPath = TPath::Resolve(dstPathStr, context.SS);
+        TPath dstPath = TPath::ResolveWithInactive(OperationId, dstPathStr, context.SS);
         TPath dstParent = dstPath.Parent();
 
         {
@@ -601,23 +601,28 @@ public:
                 .IsResolved()
                 .FailOnRestrictedCreateInTempZone(Transaction.GetAllowCreateInTempDir());
 
-                if (dstParent.IsUnderDeleting()) {
-                    checks
-                        .IsUnderDeleting()
-                        .IsUnderTheSameOperation(OperationId.GetTxId());
-                } else if (dstParent.IsUnderMoving()) {
-                    // it means that dstPath is free enough to be the move destination
-                    checks
-                        .IsUnderMoving()
-                        .IsUnderTheSameOperation(OperationId.GetTxId());
-                } else if (dstParent.IsUnderCreating()) {
-                    checks
-                        .IsUnderCreating()
-                        .IsUnderTheSameOperation(OperationId.GetTxId());
-                } else {
-                    checks
-                        .NotUnderOperation();
-                }
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+
+            if (dstParent.IsUnderDeleting()) {
+                checks
+                    .IsUnderDeleting()
+                    .IsUnderTheSameOperation(OperationId.GetTxId());
+            } else if (dstParent.IsUnderMoving()) {
+                // it means that dstPath is free enough to be the move destination
+                checks
+                    .IsUnderMoving()
+                    .IsUnderTheSameOperation(OperationId.GetTxId());
+            } else if (dstParent.IsUnderCreating()) {
+                checks
+                    .IsUnderCreating()
+                    .IsUnderTheSameOperation(OperationId.GetTxId());
+            } else {
+                checks
+                    .NotUnderOperation();
+            }
 
             if (!checks) {
                 result->SetError(checks.GetStatus(), checks.GetError());

--- a/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
+++ b/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
@@ -510,11 +510,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
         expectedDomainPaths += 1;
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                           {NLs::ChildrenCount(3),
+                           {NLs::ChildrenCount(2),
                             NLs::PathsInsideDomain(expectedDomainPaths),
                             NLs::ShardsInsideDomain(4)});
 
-        TLocalPathId movedTablePathId = GetNextLocalPathId(runtime, txId);
         {
             ++txId;
             auto first = DropTableRequest(txId,  "/MyRoot", "Dst");
@@ -535,7 +534,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst"),
                            {NLs::IsTable,
-                            NLs::PathIdEqual(movedTablePathId),
+                            NLs::PathIdEqual(8),
                             NLs::PathVersionEqual(5),
                             NLs::CheckColumns("Dst", {"key", "value0", "value1"}, {}, {"key"}),
                             NLs::IndexesCount(2)});
@@ -553,7 +552,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
                             NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                           {NLs::ChildrenCount(2),
+                           {NLs::ChildrenCount(1),
                             NLs::PathsInsideDomain(expectedDomainPaths),
                             NLs::ShardsInsideDomain(3)});
 
@@ -579,7 +578,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
 
         expectedDomainPaths += 5;
 
-        movedTablePathId = GetNextLocalPathId(runtime, txId);
         {
             ++txId;
             auto first = DropTableRequest(txId,  "/MyRoot", "Dst");
@@ -599,7 +597,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst"),
                            {NLs::IsTable,
-                            NLs::PathIdEqual(movedTablePathId),
+                            NLs::PathIdEqual(18),
                             NLs::PathVersionEqual(5),
                             NLs::CheckColumns("Dst", {"key", "value0", "value1"}, {}, {"key"}),
                             NLs::IndexesCount(2)});
@@ -617,7 +615,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
                             NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                           {NLs::ChildrenCount(2),
+                           {NLs::ChildrenCount(1),
                             NLs::PathsInsideDomain(expectedDomainPaths),
                             NLs::ShardsInsideDomain(3)});
     }
@@ -675,11 +673,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
         expectedDomainPaths += 5;
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                           {NLs::ChildrenCount(3),
+                           {NLs::ChildrenCount(2),
                             NLs::PathsInsideDomain(expectedDomainPaths),
                             NLs::ShardsInsideDomain(6)});
-
-        TLocalPathId movedTablePathId = GetNextLocalPathId(runtime, txId);
         {
             ++txId;
             auto first = DropTableRequest(txId, "/MyRoot", "Dst");
@@ -699,7 +695,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst"),
                            {NLs::IsTable,
-                            NLs::PathIdEqual(movedTablePathId),
+                            NLs::PathIdEqual(12),
                             NLs::PathVersionEqual(5),
                             NLs::CheckColumns("Dst", {"key", "value0", "value1"}, {}, {"key"}),
                             NLs::IndexesCount(2)});
@@ -723,7 +719,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
                            {NLs::PathNotExist});
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                           {NLs::ChildrenCount(2),
+                           {NLs::ChildrenCount(1),
                             NLs::PathsInsideDomain(expectedDomainPaths),
                             NLs::ShardsInsideDomain(3)});
     }

--- a/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
+++ b/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
@@ -111,6 +111,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
 
         {
             ++txId;
+            auto op = MoveTableRequest(txId,  "/MyRoot/Table1", "/MyRoot/NoSuchDir/Moved1");
+            AsyncSend(runtime, TTestTxConfig::SchemeShard, op);
+            TestModificationResult(runtime, txId, NKikimrScheme::StatusPathDoesNotExist);
+        }
+
+        {
+            ++txId;
             auto first = MoveTableRequest(txId,  "/MyRoot/Table1", "/MyRoot/Moved1");
             auto second = MoveTableRequest(txId,  "/MyRoot/Table1", "/MyRoot/Moved2");
             auto combination = CombineSchemeTransactions({first, second});
@@ -458,6 +465,269 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
                             NLs::PathsInsideDomain(5),
                             NLs::ShardsInsideDomain(3)});
     }
+
+    Y_UNIT_TEST(Replace2) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        auto initialDomainDesc = DescribePath(runtime, "/MyRoot");
+        ui64 expectedDomainPaths = initialDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Src"
+              Columns { Name: "key"   Type: "Uint64" }
+              Columns { Name: "value0" Type: "Utf8" }
+              Columns { Name: "value1" Type: "Utf8" }
+              KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+              Name: "Sync"
+              KeyColumnNames: ["value0"]
+            }
+            IndexDescription {
+              Name: "Async"
+              KeyColumnNames: ["value1"]
+              Type: EIndexTypeGlobalAsync
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        expectedDomainPaths += 5;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Dst"
+              Columns { Name: "key"   Type: "Uint64" }
+              Columns { Name: "value0" Type: "Utf8" }
+              Columns { Name: "value1" Type: "Utf8" }
+              KeyColumnNames: ["key"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        expectedDomainPaths += 1;
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::ChildrenCount(3),
+                            NLs::PathsInsideDomain(expectedDomainPaths),
+                            NLs::ShardsInsideDomain(4)});
+
+        TLocalPathId movedTablePathId = GetNextLocalPathId(runtime, txId);
+        {
+            ++txId;
+            auto first = DropTableRequest(txId,  "/MyRoot", "Dst");
+            auto second = MoveTableRequest(txId,  "/MyRoot/Src", "/MyRoot/Dst");
+            auto combination = CombineSchemeTransactions({first, second});
+            AsyncSend(runtime, TTestTxConfig::SchemeShard, combination);
+            TestModificationResult(runtime, txId);
+            env.TestWaitNotification(runtime, txId);
+
+            expectedDomainPaths -= 1;
+        }
+
+        env.TestWaitTabletDeletion(runtime, TTestTxConfig::FakeHiveTablets + 3);
+
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Src"),
+                           {NLs::PathNotExist});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst"),
+                           {NLs::IsTable,
+                            NLs::PathIdEqual(movedTablePathId),
+                            NLs::PathVersionEqual(5),
+                            NLs::CheckColumns("Dst", {"key", "value0", "value1"}, {}, {"key"}),
+                            NLs::IndexesCount(2)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst/Sync", true, true, true),
+                           {NLs::PathExist,
+                            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobal),
+                            NLs::IndexKeys({"value0"}),
+                            NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst/Async", true, true, true),
+                           {NLs::PathExist,
+                            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalAsync),
+                            NLs::IndexKeys({"value1"}),
+                            NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::ChildrenCount(2),
+                            NLs::PathsInsideDomain(expectedDomainPaths),
+                            NLs::ShardsInsideDomain(3)});
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Src"
+              Columns { Name: "key"   Type: "Uint64" }
+              Columns { Name: "value0" Type: "Utf8" }
+              Columns { Name: "value1" Type: "Utf8" }
+              KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+              Name: "Sync"
+              KeyColumnNames: ["value0"]
+            }
+            IndexDescription {
+              Name: "Async"
+              KeyColumnNames: ["value1"]
+              Type: EIndexTypeGlobalAsync
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        expectedDomainPaths += 5;
+
+        movedTablePathId = GetNextLocalPathId(runtime, txId);
+        {
+            ++txId;
+            auto first = DropTableRequest(txId,  "/MyRoot", "Dst");
+            auto second = MoveTableRequest(txId,  "/MyRoot/Src", "/MyRoot/Dst");
+            auto combination = CombineSchemeTransactions({first, second});
+            AsyncSend(runtime, TTestTxConfig::SchemeShard, combination);
+            TestModificationResult(runtime, txId);
+            env.TestWaitNotification(runtime, txId);
+
+            expectedDomainPaths -= 5;
+        }
+
+        env.TestWaitTabletDeletion(runtime, xrange(TTestTxConfig::FakeHiveTablets, TTestTxConfig::FakeHiveTablets+3));
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Src"),
+                           {NLs::PathNotExist});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst"),
+                           {NLs::IsTable,
+                            NLs::PathIdEqual(movedTablePathId),
+                            NLs::PathVersionEqual(5),
+                            NLs::CheckColumns("Dst", {"key", "value0", "value1"}, {}, {"key"}),
+                            NLs::IndexesCount(2)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst/Sync", true, true, true),
+                           {NLs::PathExist,
+                            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobal),
+                            NLs::IndexKeys({"value0"}),
+                            NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst/Async", true, true, true),
+                           {NLs::PathExist,
+                            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalAsync),
+                            NLs::IndexKeys({"value1"}),
+                            NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::ChildrenCount(2),
+                            NLs::PathsInsideDomain(expectedDomainPaths),
+                            NLs::ShardsInsideDomain(3)});
+    }
+
+    Y_UNIT_TEST(ReplaceWithDifferentIndexNames) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        auto initialDomainDesc = DescribePath(runtime, "/MyRoot");
+        ui64 expectedDomainPaths = initialDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Src"
+              Columns { Name: "key"   Type: "Uint64" }
+              Columns { Name: "value0" Type: "Utf8" }
+              Columns { Name: "value1" Type: "Utf8" }
+              KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+              Name: "SrcSync"
+              KeyColumnNames: ["value0"]
+            }
+            IndexDescription {
+              Name: "SrcAsync"
+              KeyColumnNames: ["value1"]
+              Type: EIndexTypeGlobalAsync
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        expectedDomainPaths += 5;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Dst"
+              Columns { Name: "key"   Type: "Uint64" }
+              Columns { Name: "value0" Type: "Utf8" }
+              Columns { Name: "value1" Type: "Utf8" }
+              KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+              Name: "DstSync"
+              KeyColumnNames: ["value0"]
+            }
+            IndexDescription {
+              Name: "DstAsync"
+              KeyColumnNames: ["value1"]
+              Type: EIndexTypeGlobalAsync
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        expectedDomainPaths += 5;
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::ChildrenCount(3),
+                            NLs::PathsInsideDomain(expectedDomainPaths),
+                            NLs::ShardsInsideDomain(6)});
+
+        TLocalPathId movedTablePathId = GetNextLocalPathId(runtime, txId);
+        {
+            ++txId;
+            auto first = DropTableRequest(txId, "/MyRoot", "Dst");
+            auto second = MoveTableRequest(txId, "/MyRoot/Src", "/MyRoot/Dst");
+            auto combination = CombineSchemeTransactions({first, second});
+            AsyncSend(runtime, TTestTxConfig::SchemeShard, combination);
+            TestModificationResult(runtime, txId);
+            env.TestWaitNotification(runtime, txId);
+
+            expectedDomainPaths -= 5;
+        }
+
+        env.TestWaitTabletDeletion(runtime, xrange(TTestTxConfig::FakeHiveTablets + 3, TTestTxConfig::FakeHiveTablets + 6));
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Src"),
+                           {NLs::PathNotExist});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst"),
+                           {NLs::IsTable,
+                            NLs::PathIdEqual(movedTablePathId),
+                            NLs::PathVersionEqual(5),
+                            NLs::CheckColumns("Dst", {"key", "value0", "value1"}, {}, {"key"}),
+                            NLs::IndexesCount(2)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst/SrcSync", true, true, true),
+                           {NLs::PathExist,
+                            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobal),
+                            NLs::IndexKeys({"value0"}),
+                            NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst/SrcAsync", true, true, true),
+                           {NLs::PathExist,
+                            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalAsync),
+                            NLs::IndexKeys({"value1"}),
+                            NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst/DstSync", true, true, true),
+                           {NLs::PathNotExist});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dst/DstAsync", true, true, true),
+                           {NLs::PathNotExist});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::ChildrenCount(2),
+                            NLs::PathsInsideDomain(expectedDomainPaths),
+                            NLs::ShardsInsideDomain(3)});
+    }
+
 
     Y_UNIT_TEST(Chain) {
         TTestBasicRuntime runtime;


### PR DESCRIPTION
    Fix Schemeshard crash in case of MoveTable to the inactive path. EXT-1963 (#34373)

    resolve destination with ResolveWithInactive in MoveTable::Propose

    prevent verify on unresolved destination parent by validating IsResolved() before parent state checks

    add regression tests for: replace move into dropped destination without indexes replace move when source/destination index names differ move into non-existent destination path (expect StatusPathDoesNotExist)

    #34374

    (cherry picked from commit 450b02ee0ea40ac15e1eb2229f4c48b622f2c549)