### PR TITLE
Fix case when ProposedConfigHashVersion is not reseted during ProposeConfig

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_console.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_console.cpp
@@ -120,6 +120,7 @@ namespace NKikimr::NStorage {
             case NKikimrBlobStorage::TEvControllerProposeConfigResponse::CommitIsNotNeeded:
                 // it's okay, just wait for another configuration change or something like that
                 ConfigCommittedToConsole = true;
+                ProposedConfigHashVersion.reset();
                 break;
 
             case NKikimrBlobStorage::TEvControllerProposeConfigResponse::ReverseCommit:


### PR DESCRIPTION
Fix case when ProposedConfigHashVersion is not reseted during ProposeConfig

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix case when ProposedConfigHashVersion is not reseted during ProposeConfig

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
