### PR TITLE
Turn off metadata service for tx test (#33895)

### DIFF
--- a/ydb/core/tx/tx_proxy/proxy_ut_helpers.h
+++ b/ydb/core/tx/tx_proxy/proxy_ut_helpers.h
@@ -119,6 +119,7 @@ public:
         GetSettings().SetNodeCount(staticNodes);
         GetSettings().SetDynamicNodeCount(dynamicNodes);
         GetSettings().SetEnableRealSystemViewPaths(enableRealSystemViewPaths);
+        GetSettings().SetEnableMetadataProvider(false);
 
         Server = new Tests::TServer(Settings);
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR disables the metadata service for transaction tests. This change ensures that tests are isolated from external metadata provider dependencies, improving the stability and reliability of the test environment.

Fixes #33895
