### PR TITLE
25-4: schemeshard: add batch processing for ttl responses

### DIFF
--- a/ydb/core/base/appdata.cpp
+++ b/ydb/core/base/appdata.cpp
@@ -22,6 +22,7 @@
 #include <ydb/core/protos/cms.pb.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/data_integrity_trails.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/datashard_config.pb.h>
 #include <ydb/core/protos/feature_flags.pb.h>
 #include <ydb/core/protos/key.pb.h>

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -65,6 +65,7 @@
 #include <ydb/core/protos/http_config.pb.h>
 #include <ydb/core/protos/node_broker.pb.h>
 #include <ydb/core/protos/replication.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/stream.pb.h>
 #include <ydb/core/protos/workload_manager_config.pb.h>
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -13,8 +13,8 @@ import "ydb/core/protos/cms.proto";
 import "ydb/core/protos/compaction.proto";
 import "ydb/core/protos/config_metrics.proto";
 import "ydb/core/protos/config_units.proto";
-import "ydb/core/protos/counters_schemeshard.proto";
 import "ydb/core/protos/data_integrity_trails.proto";
+import "ydb/core/protos/schemeshard_config.proto";
 import "ydb/core/protos/datashard_config.proto";
 import "ydb/core/protos/drivemodel.proto";
 import "ydb/core/protos/feature_flags.proto";
@@ -2167,37 +2167,7 @@ message TColumnShardConfig {
     }
 }
 
-message TSchemeShardConfig {
-    message TInFlightCounterConfig {
-        optional NKikimr.NSchemeShard.ESimpleCounters Type = 1;
-        // after this amount scheme shard begin to abort the operations
-        // to disable set to 0
-        optional uint32 InFlightLimit = 2 [default = 10000];
-    }
-    // after this amount of time we forcibly write full stats to local DB
-    // to disable set to 0
-    optional uint32 StatsBatchTimeoutMs = 1 [default = 100];
-
-    // number of shards stats to batch together
-    // to disable set to 0
-    optional uint32 StatsMaxBatchSize = 2 [default = 100];
-
-    optional uint32 StatsMaxExecuteMs = 3 [default = 10];
-
-    repeated TInFlightCounterConfig InFlightCounterConfig = 4;
-
-    // number of shards per table
-    optional uint32 MaxCdcInitialScanShardsInFlight = 5 [default = 32];
-
-    // number of shards per table
-    // 0 means default - NKikimrIndexBuilder.TIndexBuildSettings.max_shards_in_flight
-    optional uint32 MaxRestoreBuildIndexShardsInFlight = 6 [default = 1000];
-
-    // number of shards per table
-    // database level default for TTL mechanics
-    // 0 means no limit
-    optional uint32 MaxTTLShardsInFlight = 7 [default = 0];
-}
+// TSchemeShardConfig has been moved to ydb/core/protos/schemeshard_config.proto
 
 message TCompactionConfig {
     message TBackgroundCompactionConfig {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -242,4 +242,5 @@ message TFeatureFlags {
     optional bool UseYdsTopicStorageMetering = 220 [default = false];
     optional bool EnableFsBackups = 222 [default = false];
     optional bool EnableResourcePoolsScheduler = 224 [default = true]; // works only with EnableResourcePools = true
+    optional bool EnableConditionalEraseResponseBatching = 229 [default = false];
 }

--- a/ydb/core/protos/schemeshard_config.proto
+++ b/ydb/core/protos/schemeshard_config.proto
@@ -1,0 +1,44 @@
+import "ydb/core/protos/counters_schemeshard.proto";
+
+package NKikimrConfig;
+option java_package = "ru.yandex.kikimr.proto";
+
+message TSchemeShardConfig {
+    message TInFlightCounterConfig {
+        optional NKikimr.NSchemeShard.ESimpleCounters Type = 1;
+        // after this amount scheme shard begin to abort the operations
+        // to disable set to 0
+        optional uint32 InFlightLimit = 2 [default = 10000];
+    }
+    // after this amount of time we forcibly write full stats to local DB
+    // to disable set to 0
+    optional uint32 StatsBatchTimeoutMs = 1 [default = 100];
+
+    // number of shards stats to batch together
+    // to disable set to 0
+    optional uint32 StatsMaxBatchSize = 2 [default = 100];
+
+    optional uint32 StatsMaxExecuteMs = 3 [default = 10];
+
+    repeated TInFlightCounterConfig InFlightCounterConfig = 4;
+
+    // number of shards per table
+    optional uint32 MaxCdcInitialScanShardsInFlight = 5 [default = 32];
+
+    // number of shards per table
+    // 0 means default - NKikimrIndexBuilder.TIndexBuildSettings.max_shards_in_flight
+    optional uint32 MaxRestoreBuildIndexShardsInFlight = 6 [default = 1000];
+
+    // number of shards per table
+    // database level default for TTL mechanics
+    // 0 means no limit
+    optional uint32 MaxTTLShardsInFlight = 7 [default = 0];
+
+    // number of conditional erase responses to batch together
+    // 0 disables batching (processes each response immediately via non-batch path)
+    // 1 processes each response immediately via batch path (not recommended)
+    optional uint32 CondEraseResponseBatchSize = 8 [default = 100];
+
+    // maximum time to hold an incomplete conditional erase response batch before processing
+    optional uint32 CondEraseResponseBatchMaxTimeMs = 9 [default = 100];
+}

--- a/ydb/core/protos/ya.make
+++ b/ydb/core/protos/ya.make
@@ -124,6 +124,7 @@ SRCS(
     scheme_log.proto
     scheme_type_metadata.proto
     scheme_type_operation.proto
+    schemeshard_config.proto
     serverless_proxy_config.proto
     shared_cache.proto
     sqs.proto

--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -21,6 +21,7 @@
 #include <ydb/core/protos/key.pb.h>
 #include <ydb/core/protos/netclassifier.pb.h>
 #include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/stream.pb.h>
 #include <ydb/core/protos/workload_manager_config.pb.h>
 

--- a/ydb/core/testlib/basics/appdata.h
+++ b/ydb/core/testlib/basics/appdata.h
@@ -14,6 +14,7 @@
 #include <ydb/core/protos/blobstorage.pb.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/datashard_config.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/kqp.pb.h>
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/core/protos/resource_broker.pb.h>

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
@@ -457,6 +457,10 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
 
         const auto now = ctx.Now();
 
+        //NOTE: Batch may contain multiple responses for a single shard.
+        // NextCondErase must be updated for each response, but the next
+        // cond-erase run should be scheduled only once per shard.
+
         for (const auto& ev : Responses) {
             const auto& record = ev->Get()->Record;
             const TTabletId tabletId(record.GetTabletID());
@@ -507,8 +511,8 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
                     }
                 }
 
-                // ScheduleNextCondErase (also) changes LastCondEraseLag
-                tableInfo->ScheduleNextCondErase(i.ShardIdx, now, i.Next);
+                // UpdateNextCondErase also changes LastCondEraseLag
+                tableInfo->UpdateNextCondErase(i.ShardIdx, now, i.Next);
 
                 {
                     const auto& lag = tableInfo->GetPartitions().at(i.PartitionIdx).LastCondEraseLag;
@@ -525,6 +529,16 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
             const auto& affectedShards = item.AffectedShards;
             for (const auto& i : affectedShards) {
                 Self->PersistTablePartitionCondErase(db, tablePathId, i.PartitionIdx, tableInfo);
+            }
+        }
+
+        // schedule next CondErase (once per shard)
+        for (const auto& item : AffectedTables | std::views::values) {
+            const auto& tableInfo = item.TableInfo;
+            for (const auto& i : item.AffectedShards) {
+                if (tableInfo->GetInFlightCondErase().contains(i.ShardIdx)) {
+                    tableInfo->RescheduleCondErase(i.ShardIdx);
+                }
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.h
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <functional>
+#include <util/generic/vector.h>
+#include <util/generic/hash.h>
+#include <util/datetime/base.h>
+
+#include <ydb/core/tx/schemeshard/schemeshard_identificators.h>
+#include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
+
+namespace NKikimr::NSchemeShard {
+
+struct TCondEraseAffectedShard {
+    TShardIdx ShardIdx;
+    ui64 PartitionIdx;
+    TTabletId TabletId;
+    TDuration Next;
+};
+struct TCondEraseAffectedTable {
+    TTableInfo::TPtr TableInfo;
+    TVector<TCondEraseAffectedShard> AffectedShards;
+};
+
+extern std::function<void (const TInstant, const THashMap<TPathId, TCondEraseAffectedTable>&)> CondEraseTestObserver;
+
+}  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -16,6 +16,7 @@
 #include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/protos/feature_flags.pb.h>
 #include <ydb/core/protos/s3_settings.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/table_stats.pb.h>  // for TStoragePoolsStats
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/statistics/events.h>
@@ -5098,7 +5099,7 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     ConfigureStatsOperations(appData->SchemeShardConfig, ctx);
     MaxCdcInitialScanShardsInFlight = appData->SchemeShardConfig.GetMaxCdcInitialScanShardsInFlight();
     MaxRestoreBuildIndexShardsInFlight = appData->SchemeShardConfig.GetMaxRestoreBuildIndexShardsInFlight();
-    MaxTTLShardsInFlight = appData->SchemeShardConfig.GetMaxTTLShardsInFlight();
+    ConfigureCondErase(appData->SchemeShardConfig, ctx);
 
     SendStatsIntervalSecondsDedicated = appData->StatisticsConfig.GetBaseStatsSendIntervalSecondsDedicated();
     SendStatsIntervalSecondsServerless = appData->StatisticsConfig.GetBaseStatsSendIntervalSecondsServerless();
@@ -5281,6 +5282,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
 
         // conditional erase
         HFuncTraced(TEvPrivate::TEvRunConditionalErase, Handle);
+        HFuncTraced(TEvPrivate::TEvFlushConditionalEraseBatch, Handle);
         HFuncTraced(TEvDataShard::TEvConditionalEraseRowsResponse, Handle);
 
         HFuncTraced(TEvPrivate::TEvServerlessStorageBilling, Handle);
@@ -7047,12 +7049,39 @@ void TSchemeShard::Handle(TEvPrivate::TEvRunConditionalErase::TPtr& ev, const TA
     Execute(CreateTxRunConditionalErase(ev), ctx);
 }
 
-void TSchemeShard::ScheduleServerlessStorageBilling(const TActorContext &ctx) {
-    ctx.Send(SelfId(), new TEvPrivate::TEvServerlessStorageBilling());
+bool TSchemeShard::ProcessPendingConditionalEraseResponseBatch(const TInstant& now, const TActorContext& ctx) {
+    const bool completeBySize = (PendingCondEraseResponses.size() >= CondEraseResponseBatchSize);
+    const auto batchAge = (now - PendingCondEraseResponsesStartTime);
+    const bool completeByTime = (batchAge >= CondEraseResponseBatchMaxTime);
+
+    if (PendingCondEraseResponses.size() > 0 && (completeBySize || completeByTime)) {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase flush pending response batch (by " << (completeBySize ? "size" : "time") << ")"
+            << ", batch size " << PendingCondEraseResponses.size() << "/" << CondEraseResponseBatchSize
+            << ", batch age " << batchAge << "/" << CondEraseResponseBatchMaxTime
+            << ", at schemeshard: " << TabletID()
+        );
+
+        Execute(CreateTxScheduleConditionalErase(std::move(PendingCondEraseResponses), PendingCondEraseResponsesStartTime), ctx);
+        PendingCondEraseResponses.clear();
+
+        return true;
+    }
+
+    return false;
 }
 
-void TSchemeShard::Handle(TEvPrivate::TEvServerlessStorageBilling::TPtr &, const TActorContext &ctx) {
-    Execute(CreateTxServerlessStorageBilling(), ctx);
+void TSchemeShard::Handle(TEvPrivate::TEvFlushConditionalEraseBatch::TPtr& ev, const TActorContext& ctx) {
+    if (PendingCondEraseResponsesStartTime > ev->Get()->BatchStartTime) {
+        // Current batch is a new one, old batch was already processed.
+        return;
+    }
+
+    LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Handle: TEvFlushConditionalEraseBatch"
+        << ", at schemeshard: " << TabletID());
+
+    // This ensures incomplete batches don't get stuck indefinitely
+    // The batch's Complete() will also trigger TTxRunConditionalErase for affected tables
+    ProcessPendingConditionalEraseResponseBatch(ctx.Now(), ctx);
 }
 
 void TSchemeShard::Handle(TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& ev, const TActorContext& ctx) {
@@ -7067,14 +7096,62 @@ void TSchemeShard::Handle(TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& e
         return;
     }
 
+    // ACCEPTED and PARTIAL are handled here, outside a local transaction, since
+    // neither causes state changes and TTL response processing is a performance bottleneck.
     if (record.GetStatus() == NKikimrTxDataShard::TEvConditionalEraseRowsResponse::ACCEPTED) {
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase accepted"
             << ": tabletId: " << tabletId
             << ", at schemeshard: " << TabletID());
         return;
     }
+    if (record.GetStatus() == NKikimrTxDataShard::TEvConditionalEraseRowsResponse::PARTIAL) {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase already running"
+            << ": tabletId: " << tabletId
+            << ", at schemeshard: " << TabletID());
+        return;
+    }
 
-    Execute(CreateTxScheduleConditionalErase(ev), ctx);
+    // Check if batching is enabled and batch size is configured
+    const bool batchingEnabled = AppData(ctx)->FeatureFlags.GetEnableConditionalEraseResponseBatching()
+        && CondEraseResponseBatchSize > 0;
+
+    const auto now = ctx.Now();
+
+    // Accumulate response for batch processing
+    if (PendingCondEraseResponses.empty()) {
+        PendingCondEraseResponsesStartTime = now;
+    }
+    PendingCondEraseResponses.push_back(ev);
+
+    if (batchingEnabled) {
+        if (!ProcessPendingConditionalEraseResponseBatch(now, ctx)) {
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Conditional erase finished"
+                << ", tabletId: " << tabletId
+                << ", status: " << record.GetStatus()
+                << ", batch size " << PendingCondEraseResponses.size() << "/" << CondEraseResponseBatchSize
+                << ", batch age " << (now - PendingCondEraseResponsesStartTime) << "/" << CondEraseResponseBatchMaxTime
+                << ", enqueued"
+                << ", at schemeshard: " << TabletID()
+            );
+
+            // for the new batch schedule end of time event
+            if (PendingCondEraseResponsesStartTime == now) {
+                ctx.Schedule(CondEraseResponseBatchMaxTime, new TEvPrivate::TEvFlushConditionalEraseBatch(PendingCondEraseResponsesStartTime));
+            }
+        }
+    } else {
+        // Process response immediately
+        Execute(CreateTxScheduleConditionalErase(std::move(PendingCondEraseResponses), PendingCondEraseResponsesStartTime), ctx);
+        PendingCondEraseResponses.clear();
+    }
+}
+
+void TSchemeShard::ScheduleServerlessStorageBilling(const TActorContext &ctx) {
+    ctx.Send(SelfId(), new TEvPrivate::TEvServerlessStorageBilling());
+}
+
+void TSchemeShard::Handle(TEvPrivate::TEvServerlessStorageBilling::TPtr &, const TActorContext &ctx) {
+    Execute(CreateTxServerlessStorageBilling(), ctx);
 }
 
 void TSchemeShard::Handle(TEvTxAllocatorClient::TEvAllocateResult::TPtr& ev, const TActorContext& ctx) {
@@ -7755,7 +7832,7 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TAppConfig& appConfi
         ConfigureStatsOperations(schemeShardConfig, ctx);
         MaxCdcInitialScanShardsInFlight = schemeShardConfig.GetMaxCdcInitialScanShardsInFlight();
         MaxRestoreBuildIndexShardsInFlight = schemeShardConfig.GetMaxRestoreBuildIndexShardsInFlight();
-        MaxTTLShardsInFlight = schemeShardConfig.GetMaxTTLShardsInFlight();
+        ConfigureCondErase(schemeShardConfig, ctx);
     }
 
     if (appConfig.HasTableProfilesConfig()) {
@@ -8039,6 +8116,20 @@ void TSchemeShard::ConfigureExternalSources(
     LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
         "ExternalSources configured: HostnamePatterns# " << Join(", ", hostnamePatterns)
         << ", AvailableExternalDataSources# " << Join(", ", availableExternalDataSources));
+}
+
+void TSchemeShard::ConfigureCondErase(const NKikimrConfig::TSchemeShardConfig& config, const TActorContext &ctx) {
+    MaxTTLShardsInFlight = config.GetMaxTTLShardsInFlight();
+    CondEraseResponseBatchSize = config.GetCondEraseResponseBatchSize();
+    CondEraseResponseBatchMaxTime = TDuration::MilliSeconds(
+        std::max(ui32(1), std::min(ui32(1000), config.GetCondEraseResponseBatchMaxTimeMs()))
+    );
+
+    LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "ConditionalErase configured"
+        << ": ShardsInFlight (for table) " << MaxTTLShardsInFlight
+        << ", BatchSize " << CondEraseResponseBatchSize
+        << ", BatchMaxTime " << CondEraseResponseBatchMaxTime
+    );
 }
 
 void TSchemeShard::StartStopCompactionQueues() {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -247,6 +247,12 @@ public:
 
     THashMap<TPathId, TTableInfo::TPtr> Tables;
     THashMap<TPathId, TTableInfo::TPtr> TTLEnabledTables;
+
+    // Batch processing for conditional erase responses
+    TVector<TEvDataShard::TEvConditionalEraseRowsResponse::TPtr> PendingCondEraseResponses;
+    TInstant PendingCondEraseResponsesStartTime;
+    ui32 CondEraseResponseBatchSize = 100;
+    TDuration CondEraseResponseBatchMaxTime = TDuration::MilliSeconds(100);
     ui32 MaxTTLShardsInFlight = 0;
 
     THashMap<TPathId, TTableIndexInfo::TPtr> Indexes;
@@ -543,6 +549,8 @@ public:
     void ConfigureExternalSources(
         const NKikimrConfig::TQueryServiceConfig& config,
         const TActorContext& ctx);
+
+    void ConfigureCondErase(const NKikimrConfig::TSchemeShardConfig& config, const TActorContext &ctx);
 
     void StartStopCompactionQueues();
 
@@ -1058,7 +1066,7 @@ public:
     NTabletFlatExecutor::ITransaction* CreateTxRunConditionalErase(TEvPrivate::TEvRunConditionalErase::TPtr& ev);
 
     struct TTxScheduleConditionalErase;
-    NTabletFlatExecutor::ITransaction* CreateTxScheduleConditionalErase(TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxScheduleConditionalErase(TVector<TEvDataShard::TEvConditionalEraseRowsResponse::TPtr>&& responses, const TInstant batchStartTime);
 
     struct TTxSyncTenant;
     NTabletFlatExecutor::ITransaction* CreateTxSyncTenant(TPathId tabletId);
@@ -1278,8 +1286,11 @@ public:
 
     void Handle(TEvSchemeShard::TEvFindTabletSubDomainPathId::TPtr& ev, const TActorContext& ctx);
 
+    bool ProcessPendingConditionalEraseResponseBatch(const TInstant& now, const TActorContext& ctx);
     void ScheduleConditionalEraseRun(const TActorContext& ctx);
     void Handle(TEvPrivate::TEvRunConditionalErase::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvFlushConditionalEraseBatch::TPtr& ev, const TActorContext& ctx);
+
     void Handle(TEvDataShard::TEvConditionalEraseRowsResponse::TPtr& ev, const TActorContext& ctx);
     void ConditionalEraseHandleDisconnect(TTabletId tabletId, const TActorId& clientId, const TActorContext& ctx);
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -943,18 +943,13 @@ public:
         InFlightCondErase.erase(shardIdx);
     }
 
-    void ScheduleNextCondErase(const TShardIdx& shardIdx, const TInstant& now, const TDuration& next) {
-        Y_ENSURE(InFlightCondErase.contains(shardIdx));
-
+    void UpdateNextCondErase(const TShardIdx& shardIdx, const TInstant& now, const TDuration& next) {
         auto it = FindPartition(shardIdx);
         Y_ENSURE(it != Partitions.end());
 
         it->LastCondErase = now;
         it->NextCondErase = now + next;
         it->LastCondEraseLag = TDuration::Zero();
-
-        CondEraseSchedule.push(it);
-        InFlightCondErase.erase(shardIdx);
     }
 
     bool IsUsingSequence(const TString& name) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -29,6 +29,7 @@
 #include <ydb/core/protos/follower_group.pb.h>
 #include <ydb/core/protos/index_builder.pb.h>
 #include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/core/protos/yql_translation_settings.pb.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -52,6 +52,7 @@ namespace TEvPrivate {
         EvLoginFinalize,
         EvContinuousBackupCleanerResult,
         EvTestNotifySubdomainCleanup,
+        EvFlushConditionalEraseBatch,
         EvEnd
     };
 
@@ -90,6 +91,14 @@ namespace TEvPrivate {
     };
 
     struct TEvRunConditionalErase: public TEventLocal<TEvRunConditionalErase, EvRunConditionalErase> {
+    };
+
+    struct TEvFlushConditionalEraseBatch : public TEventLocal<TEvFlushConditionalEraseBatch, EvFlushConditionalEraseBatch> {
+        TInstant BatchStartTime;
+
+        explicit TEvFlushConditionalEraseBatch(const TInstant& batchStartTime)
+            : BatchStartTime(batchStartTime)
+        { }
     };
 
     struct TEvIndexBuildingMakeABill: public TEventLocal<TEvIndexBuildingMakeABill, EvIndexBuildBilling> {

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -635,6 +635,14 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
         app.SchemeShardConfig.SetStatsBatchTimeoutMs(0);
     }
 
+    app.FeatureFlags.SetEnableConditionalEraseResponseBatching(opts.EnableConditionalEraseResponseBatching_);
+    if (opts.CondEraseResponseBatchSize_) {
+        app.SchemeShardConfig.SetCondEraseResponseBatchSize(*opts.CondEraseResponseBatchSize_);
+    }
+    if (opts.CondEraseResponseBatchMaxTimeMs_) {
+        app.SchemeShardConfig.SetCondEraseResponseBatchMaxTimeMs(*opts.CondEraseResponseBatchMaxTimeMs_);
+    }
+
     // graph settings
     if (opts.GraphBackendType_) {
         app.GraphConfig.SetBackendType(opts.GraphBackendType_.value());

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -84,6 +84,9 @@ namespace NSchemeShardUT_Private {
         OPTION(ui32, NStoragePools, 2);
         OPTION(std::optional<ui32>, DataShardStatsReportIntervalSeconds, std::nullopt);
         OPTION(bool, EnableAlterDatabase, false);
+        OPTION(bool, EnableConditionalEraseResponseBatching, false);
+        OPTION(std::optional<ui32>, CondEraseResponseBatchSize, std::nullopt);
+        OPTION(std::optional<ui32>, CondEraseResponseBatchMaxTimeMs, std::nullopt);
 
         #undef OPTION
     };
@@ -221,6 +224,7 @@ namespace NSchemeShardUT_Private {
         void Prepare(const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone);
         void EnableTabletResolverScheduling(ui32 nodeIdx = 0);
         void Finalize();
+
     private:
         virtual TTestEnv* CreateTestEnv();
         // Make sure that user requests are not dropped

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/protos/counters_schemeshard.pb.h>
+#include <ydb/core/protos/schemeshard_config.pb.h>
 #include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/tablet_flat/util_fmt_cell.h>
 #include <ydb/core/testlib/actors/block_events.h>

--- a/ydb/core/tx/schemeshard/ut_ttl/ut_ttl.cpp
+++ b/ydb/core/tx/schemeshard/ut_ttl/ut_ttl.cpp
@@ -2,6 +2,8 @@
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_private.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/schemeshard__conditional_erase.h>
+#include <ydb/core/testlib/tablet_helpers.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -47,7 +49,20 @@ void CheckTtlSettings(TTestActorRuntime& runtime, NLs::TCheckFunc func, const ch
     );
 }
 
+void WriteTTLRow(TTestActorRuntime& runtime, ui64 tabletId, ui64 key, TInstant ts, const TString& table) {
+    NKikimrMiniKQL::TResult result;
+    TString error;
+    NKikimrProto::EReplyStatus status = LocalMiniKQL(runtime, tabletId, Sprintf(R"(
+        (
+            (let key   '( '('key (Uint64 '%lu ) ) ) )
+            (let row   '( '('ts (Timestamp '%lu) ) ) )
+            (return (AsList (UpdateRow '__user__%s key row) ))
+        )
+    )", key, ts.GetValue(), table.c_str()), result, error);
+    UNIT_ASSERT_VALUES_EQUAL_C(status, NKikimrProto::EReplyStatus::OK, error);
 }
+
+}  // anonymous namespace
 
 Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
     void CreateTableShouldSucceed(const char* name, const char* ttlColumnType, bool enableTablePgTypes, const char* unit = "UNIT_AUTO") {
@@ -214,7 +229,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
               }
             }
         )", {{NKikimrScheme::StatusSchemeError, "TTL should be less than"}});
-    }    
+    }
 
     void CreateTableOnIndexedTable(NKikimrSchemeOp::EIndexType indexType) {
         TTestBasicRuntime runtime;
@@ -458,28 +473,60 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
     using TEvCondEraseReq = TEvDataShard::TEvConditionalEraseRowsRequest;
     using TEvCondEraseResp = TEvDataShard::TEvConditionalEraseRowsResponse;
 
-    void WaitForCondErase(TTestActorRuntimeBase& runtime, TEvCondEraseResp::ProtoRecordType::EStatus status = TEvCondEraseResp::ProtoRecordType::OK) {
+    void WaitForCondErase(TTestActorRuntimeBase& runtime, TEvCondEraseResp::ProtoRecordType::EStatus status = TEvCondEraseResp::ProtoRecordType::OK, ui32 count = 1) {
         TDispatchOptions opts;
-        opts.FinalEvents.emplace_back([status](IEventHandle& ev) -> bool {
+        opts.FinalEvents.emplace_back([status, &count](IEventHandle& ev) -> bool {
             if (ev.GetTypeRewrite() != TEvCondEraseResp::EventType) {
                 return false;
             }
 
-            auto resp = ev.Get<TEvCondEraseResp>();
-            if (resp->Record.GetStatus() == TEvCondEraseResp::ProtoRecordType::ACCEPTED) {
+            const auto& response = ev.Get<TEvCondEraseResp>()->Record;
+
+            if (response.GetStatus() == TEvCondEraseResp::ProtoRecordType::ACCEPTED
+                || response.GetStatus() == TEvCondEraseResp::ProtoRecordType::PARTIAL) {
                 return false;
             }
 
-            UNIT_ASSERT_VALUES_EQUAL_C(resp->Record.GetStatus(), status, resp->Record.GetErrorDescription());
-            return true;
+            UNIT_ASSERT_VALUES_EQUAL_C(response.GetStatus(), status, response.GetErrorDescription());
+            return (--count == 0);
         });
 
         runtime.DispatchEvents(opts);
     }
 
-    Y_UNIT_TEST(ConditionalErase) {
+    TPathId GetTablePathId(TTestActorRuntime& runtime, const TString& tablePath) {
+        const auto& describe = DescribePath(runtime, tablePath);
+        TestDescribeResult(describe, {NLs::PathExist, NLs::IsTable});
+        return TPathId(describe.GetPathDescription().GetSelf().GetSchemeshardId(), describe.GetPathDescription().GetSelf().GetPathId());
+    };
+
+    THashMap<TPathId, TCondEraseAffectedTable> WaitForCondEraseBatch(TTestActorRuntimeBase& runtime, TPathId tablePathId, TDuration duration) {
+        TInstant batchStartTime;
+        THashMap<TPathId, TCondEraseAffectedTable> lastBatch;
+        NSchemeShard::CondEraseTestObserver = [&](const auto batchStartTime_, const auto& affectedTables) {
+            lastBatch = affectedTables;
+            batchStartTime = batchStartTime_;
+        };
+
+        const auto startTime = runtime.GetCurrentTime();
+
+        runtime.AdvanceCurrentTime(duration);
+
+        runtime.WaitFor("single conditional erase batch completed", [&]() {
+            return batchStartTime > startTime && !lastBatch.empty() && lastBatch.contains(tablePathId);
+        });
+
+        NSchemeShard::CondEraseTestObserver = nullptr;
+
+        return lastBatch;
+    }
+
+    Y_UNIT_TEST_FLAG(ConditionalErase, EnableConditionalEraseResponseBatching) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions()
+            .EnableConditionalEraseResponseBatching(EnableConditionalEraseResponseBatching)
+            .CondEraseResponseBatchSize(5)
+        );
 
         auto writeRow = [&](ui64 tabletId, ui64 key, TInstant ts, const char* table, const char* ct = "Timestamp") {
             NKikimrMiniKQL::TResult result;
@@ -532,6 +579,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         ui64 txId = 100;
 
         {
+            Cerr << "TEST 1" << Endl;
+
             TestCreateTable(runtime, ++txId, "/MyRoot", R"(
                 Name: "TTLEnabledTable1"
                 Columns { Name: "key" Type: "Uint64" }
@@ -545,14 +594,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
             )");
             env.TestWaitNotification(runtime, txId);
 
+            auto tablePathId = GetTablePathId(runtime, "/MyRoot/TTLEnabledTable1");
+
             writeRow(tabletId, 1, now, "TTLEnabledTable1");
             {
                 auto result = readTable(tabletId, "TTLEnabledTable1");
                 NKqp::CompareYson(R"([[[[[["1"]]];%false]]])", result);
             }
 
-            runtime.AdvanceCurrentTime(TDuration::Minutes(1));
-            WaitForCondErase(runtime);
+            WaitForCondEraseBatch(runtime, tablePathId, TDuration::Minutes(1));
+
             {
                 auto result = readTable(tabletId, "TTLEnabledTable1");
                 NKqp::CompareYson(R"([[[[];%false]]])", result);
@@ -560,6 +611,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         }
 
         {
+            Cerr << "TEST 2" << Endl;
+
             ++tabletId;
             TestCreateTable(runtime, ++txId, "/MyRoot", R"(
                 Name: "TTLEnabledTable2"
@@ -579,6 +632,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
             )");
             env.TestWaitNotification(runtime, txId);
 
+            auto tablePathId = GetTablePathId(runtime, "/MyRoot/TTLEnabledTable2");
+
             writeRow(tabletId, 1, now - TDuration::Hours(1), "TTLEnabledTable2");
             writeRow(tabletId, 2, now, "TTLEnabledTable2");
             {
@@ -586,15 +641,23 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
                 NKqp::CompareYson(R"([[[[[["1"]];[["2"]]];%false]]])", result);
             }
 
-            runtime.AdvanceCurrentTime(TDuration::Minutes(1));
-            WaitForCondErase(runtime);
+            Cerr << "TEST 2.1" << Endl;
+
+            // Trigger immediate conditional erase since NextCondErase is set to 'now' at table creation
+            // This should delete row 1 (expired) but keep row 2 (not expired yet)
+            WaitForCondEraseBatch(runtime, tablePathId, TDuration::Minutes(1));
+
             {
                 auto result = readTable(tabletId, "TTLEnabledTable2");
                 NKqp::CompareYson(R"([[[[[["2"]]];%false]]])", result);
             }
 
-            runtime.AdvanceCurrentTime(TDuration::Hours(1));
-            WaitForCondErase(runtime);
+            Cerr << "TEST 2.2" << Endl;
+
+            // Wait for conditional erase to delete row 2
+            // The conditional erase should run now that we've advanced past NextCondErase
+            WaitForCondEraseBatch(runtime, tablePathId, TDuration::Hours(1));
+
             {
                 auto result = readTable(tabletId, "TTLEnabledTable2");
                 NKqp::CompareYson(R"([[[[];%false]]])", result);
@@ -602,6 +665,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         }
 
         {
+            Cerr << "TEST 3" << Endl;
+
             setAllowConditionalEraseOperations(false);
 
             ++tabletId;
@@ -640,6 +705,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         }
 
         {
+            Cerr << "TEST 4" << Endl;
+
             setAllowConditionalEraseOperations(true);
 
             ++tabletId;
@@ -657,6 +724,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
             )");
             env.TestWaitNotification(runtime, txId);
 
+            auto tablePathId = GetTablePathId(runtime, "/MyRoot/TTLEnabledTable4");
+
             writeRow(tabletId, 1, now, "TTLEnabledTable4", "Uint64");
             writeRow(tabletId, 2, now + TDuration::Days(1), "TTLEnabledTable4", "Uint64");
             {
@@ -664,8 +733,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
                 NKqp::CompareYson(R"([[[[[["1"]];[["2"]]];%false]]])", result);
             }
 
-            runtime.AdvanceCurrentTime(TDuration::Minutes(1));
-            WaitForCondErase(runtime);
+            WaitForCondEraseBatch(runtime, tablePathId, TDuration::Minutes(1));
             {
                 auto result = readTable(tabletId, "TTLEnabledTable4");
                 NKqp::CompareYson(R"([[[[[["2"]]];%false]]])", result);
@@ -673,6 +741,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         }
 
         {
+            Cerr << "TEST 5" << Endl;
+
             ++tabletId;
             TestConsistentCopyTables(runtime, ++txId, "/", R"(
                 CopyTableDescriptions {
@@ -682,14 +752,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
             )");
             env.TestWaitNotification(runtime, txId);
 
+            auto tablePathId = GetTablePathId(runtime, "/MyRoot/TTLEnabledTable5");
+
             writeRow(tabletId, 1, now, "TTLEnabledTable5", "Uint64");
             {
                 auto result = readTable(tabletId, "TTLEnabledTable5");
                 NKqp::CompareYson(R"([[[[[["1"]];[["2"]]];%false]]])", result);
             }
 
-            runtime.AdvanceCurrentTime(TDuration::Hours(1));
-            WaitForCondErase(runtime);
+            WaitForCondEraseBatch(runtime, tablePathId, TDuration::Hours(1));
+
             {
                 auto result = readTable(tabletId, "TTLEnabledTable5");
                 NKqp::CompareYson(R"([[[[[["2"]]];%false]]])", result);
@@ -697,9 +769,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         }
 
         {
+            Cerr << "TEST 6" << Endl;
+
             ++tabletId;
             TestCopyTable(runtime, ++txId, "/MyRoot", "TTLEnabledTable6", "/MyRoot/TTLEnabledTable5");
             env.TestWaitNotification(runtime, txId);
+
+            auto tablePathId = GetTablePathId(runtime, "/MyRoot/TTLEnabledTable6");
 
             writeRow(tabletId, 1, now, "TTLEnabledTable6", "Uint64");
             {
@@ -707,8 +783,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
                 NKqp::CompareYson(R"([[[[[["1"]];[["2"]]];%false]]])", result);
             }
 
-            runtime.AdvanceCurrentTime(TDuration::Hours(1));
-            WaitForCondErase(runtime);
+            WaitForCondEraseBatch(runtime, tablePathId, TDuration::Hours(1));
+
             {
                 auto result = readTable(tabletId, "TTLEnabledTable6");
                 NKqp::CompareYson(R"([[[[[["2"]]];%false]]])", result);
@@ -1077,9 +1153,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        Cerr << "TEST 1" << Endl;
+
         // just after create
         CheckSimpleCounter(runtime, "SchemeShard/TTLEnabledTables", 1);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 0}, {"1800", 0}, {"inf", 1}});
+
+        Cerr << "TEST 2" << Endl;
 
         // after erase
         WaitForCondErase(runtime);
@@ -1090,24 +1170,34 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         }
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 1}, {"1800", 0}, {"inf", 0}});
 
+        Cerr << "TEST 3" << Endl;
+
         // after a little more time
         runtime.AdvanceCurrentTime(TDuration::Minutes(20));
         WaitForStats(runtime, 1);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 0}, {"1800", 1}, {"inf", 0}});
 
+        Cerr << "TEST 4" << Endl;
+
         // copy table
         TestCopyTable(runtime, ++txId, "/MyRoot", "TTLEnabledTableCopy", "/MyRoot/TTLEnabledTable");
         env.TestWaitNotification(runtime, txId);
 
+        Cerr << "TEST 5" << Endl;
+
         // just after copy
         CheckSimpleCounter(runtime, "SchemeShard/TTLEnabledTables", 2);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 0}, {"1800", 2}, {"inf", 0}});
+
+        Cerr << "TEST 6" << Endl;
 
         // after erase
         runtime.AdvanceCurrentTime(TDuration::Hours(1));
         WaitForCondErase(runtime);
         WaitForStats(runtime, 2);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 2}, {"1800", 0}, {"inf", 0}});
+
+        Cerr << "TEST 7" << Endl;
 
         // alter (disable ttl)
         TestAlterTable(runtime, ++txId, "/MyRoot", R"(
@@ -1123,6 +1213,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         CheckSimpleCounter(runtime, "SchemeShard/TTLEnabledTables", 1);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 1}, {"1800", 0}, {"inf", 0}});
 
+        Cerr << "TEST 8" << Endl;
+
         // drop
         TestDropTable(runtime, ++txId, "/MyRoot", "TTLEnabledTableCopy");
         env.TestWaitNotification(runtime, txId);
@@ -1130,6 +1222,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         // just after drop
         CheckSimpleCounter(runtime, "SchemeShard/TTLEnabledTables", 0);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 0}, {"1800", 0}, {"inf", 0}});
+
+        Cerr << "TEST 9" << Endl;
 
         // alter (enable ttl)
         TestAlterTable(runtime, ++txId, "/MyRoot", R"(
@@ -1146,10 +1240,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         CheckSimpleCounter(runtime, "SchemeShard/TTLEnabledTables", 1);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 1}, {"1800", 0}, {"inf", 0}});
 
+        Cerr << "TEST 10" << Endl;
+
         // after a little more time
         runtime.AdvanceCurrentTime(TDuration::Minutes(20));
         WaitForStats(runtime, 1);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 0}, {"1800", 1}, {"inf", 0}});
+
+        Cerr << "TEST 11" << Endl;
 
         // split
         TestSplitTable(runtime, ++txId, "/MyRoot/TTLEnabledTable", Sprintf(R"(
@@ -1164,9 +1262,11 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
 
         // after erase
         runtime.AdvanceCurrentTime(TDuration::Hours(1));
-        WaitForCondErase(runtime);
+        WaitForCondErase(runtime, TEvCondEraseResp::ProtoRecordType::OK, 2);
         WaitForStats(runtime, 2);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 2}, {"1800", 0}, {"inf", 0}});
+
+        Cerr << "TEST 12" << Endl;
 
         // move table
         TestMoveTable(runtime, ++txId, "/MyRoot/TTLEnabledTable", "/MyRoot/TTLEnabledTableMoved");
@@ -1181,16 +1281,382 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         WaitForStats(runtime, 2);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 0}, {"1800", 2}, {"inf", 0}});
 
+        Cerr << "TEST 13" << Endl;
+
         // after erase
         runtime.AdvanceCurrentTime(TDuration::Minutes(40));
-        WaitForCondErase(runtime);
+        // runtime.SimulateSleep(TDuration::Minutes(1));
+        WaitForCondErase(runtime, TEvCondEraseResp::ProtoRecordType::OK, 2);
+        Cerr << "TEST 13.2" << Endl;
         WaitForStats(runtime, 2);
+        Cerr << "TEST 13.3" << Endl;
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"0", 2}, {"900", 0}, {"1800", 0}, {"inf", 0}});
+
+        Cerr << "TEST 14" << Endl;
 
         // after a while
         runtime.AdvanceCurrentTime(TDuration::Minutes(10));
         WaitForStats(runtime, 2);
         CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 2}, {"1800", 0}, {"inf", 0}});
+
+        Cerr << "TEST 15" << Endl;
+
+    }
+
+    Y_UNIT_TEST_FLAG(BatchingDoesNotAffectCorrectness, EnableConditionalEraseResponseBatching) {
+        // Test that batching and non-batching produce identical results
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions()
+            .EnableConditionalEraseResponseBatching(EnableConditionalEraseResponseBatching)
+        );
+
+        const TInstant now = TInstant::ParseIso8601("2020-09-18T18:00:00.000000Z");
+        runtime.UpdateCurrentTime(now);
+
+        ui64 tabletId = TTestTxConfig::FakeHiveTablets;
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTableCorrectness"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "ts" Type: "Timestamp" }
+            KeyColumnNames: ["key"]
+            TTLSettings {
+              Enabled {
+                ColumnName: "ts"
+                ExpireAfterSeconds: 3600
+                Tiers: {
+                  ApplyAfterSeconds: 3600
+                  Delete: {}
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Write test data - half expired, half not
+        for (ui32 i = 0; i < 10; ++i) {
+            TInstant ts = (i % 2 == 0) ? now - TDuration::Hours(2) : now - TDuration::Minutes(30);
+            WriteTTLRow(runtime, tabletId, i, ts, "TTLTableCorrectness");
+        }
+
+        // Trigger conditional erase
+        runtime.AdvanceCurrentTime(TDuration::Minutes(1));
+        WaitForCondErase(runtime);
+
+        // Verify that half the rows remain (5 out of 10)
+        ui32 remainingRows = CountRows(runtime, "/MyRoot/TTLTableCorrectness");
+        UNIT_ASSERT_VALUES_EQUAL(remainingRows, 5);
+    }
+
+    Y_UNIT_TEST(DynamicBatchingToggle) {
+        TTestBasicRuntime runtime;
+        // Start with batching disabled
+        TTestEnv env(runtime, TTestEnvOptions()
+            .EnableConditionalEraseResponseBatching(false)
+            .CondEraseResponseBatchSize(1)
+        );
+
+        const TInstant now = TInstant::ParseIso8601("2020-09-18T18:00:00.000000Z");
+        runtime.UpdateCurrentTime(now);
+
+        ui64 txId = 100;
+        ui64 tabletId = TTestTxConfig::FakeHiveTablets;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTableDynamic"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "ts" Type: "Timestamp" }
+            KeyColumnNames: ["key"]
+            TTLSettings {
+              Enabled {
+                ColumnName: "ts"
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+
+        auto readTable = [&]() {
+            NKikimrMiniKQL::TResult result;
+            TString error;
+            NKikimrProto::EReplyStatus status = LocalMiniKQL(runtime, tabletId, R"(
+                (
+                    (let range '( '('key (Uint64 '0) (Void) )))
+                    (let columns '('key) )
+                    (let result (SelectRange '__user__TTLTableDynamic range columns '()))
+                    (return (AsList (SetResult 'Result result) ))
+                )
+            )", result, error);
+            UNIT_ASSERT_VALUES_EQUAL_C(status, NKikimrProto::EReplyStatus::OK, error);
+            return result;
+        };
+
+        // Write rows immediately after table creation
+        // Row 1: expired (ts = now - 1h, with ExpireAfterSeconds=0 expires at now - 1h, already expired)
+        WriteTTLRow(runtime, tabletId, 1, now - TDuration::Hours(1), "TTLTableDynamic");
+        // Row 2: not expired (ts = now + 2h, with ExpireAfterSeconds=0 expires at now + 2h, not yet expired)
+        WriteTTLRow(runtime, tabletId, 2, now + TDuration::Hours(2), "TTLTableDynamic");
+
+        // Trigger conditional erase with batching disabled
+        // NextCondErase is set to 'now' at table creation, so advancing by 1 minute triggers it
+        runtime.AdvanceCurrentTime(TDuration::Minutes(1));
+        WaitForCondErase(runtime);
+
+        {
+            auto result = readTable();
+            NKqp::CompareYson(R"([[[[[["2"]]];%false]]])", result);
+        }
+
+        // Enable batching dynamically
+        runtime.GetAppData().FeatureFlags.SetEnableConditionalEraseResponseBatching(true);
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Write more rows and erase with batching enabled
+        // Row 3: expired (ts = now - 1h, with ExpireAfterSeconds=0 expires at now - 1h, already expired)
+        WriteTTLRow(runtime, tabletId, 3, now - TDuration::Hours(1), "TTLTableDynamic");
+        // Row 4: not expired (ts = now + 2h, with ExpireAfterSeconds=0 expires at now + 2h, not yet expired)
+        WriteTTLRow(runtime, tabletId, 4, now + TDuration::Hours(2), "TTLTableDynamic");
+
+        // After first conditional erase, NextCondErase is set to now + RunInterval (1 hour)
+        // So we need to advance by more than 1 hour to trigger the second conditional erase
+        runtime.AdvanceCurrentTime(TDuration::Hours(1) + TDuration::Minutes(1));
+        WaitForCondErase(runtime);
+
+        {
+            auto result = readTable();
+            NKqp::CompareYson(R"([[[[[["2"]];[["4"]]];%false]]])", result);
+        }
+    }
+
+    Y_UNIT_TEST_FLAG(MultipleTablesConditionalErase, EnableConditionalEraseResponseBatching) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions()
+            .EnableConditionalEraseResponseBatching(EnableConditionalEraseResponseBatching)
+            .CondEraseResponseBatchSize(1)
+        );
+
+        const TInstant now = TInstant::ParseIso8601("2020-09-18T18:00:00.000000Z");
+        runtime.UpdateCurrentTime(now);
+
+        ui64 txId = 100;
+        ui64 tabletId = TTestTxConfig::FakeHiveTablets;
+
+        // Create a table with TTL
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTableMulti"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "ts" Type: "Timestamp" }
+            KeyColumnNames: ["key"]
+            TTLSettings {
+              Enabled {
+                ColumnName: "ts"
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Write rows
+        // Row 1: expired (ts = now - 1h, with ExpireAfterSeconds=0 expires at now - 1h, already expired)
+        WriteTTLRow(runtime, tabletId, 1, now - TDuration::Hours(1), "TTLTableMulti");
+        // Row 2: not expired (ts = now + 1h, with ExpireAfterSeconds=0 expires at now + 1h, not yet expired)
+        WriteTTLRow(runtime, tabletId, 2, now + TDuration::Hours(1), "TTLTableMulti");
+
+        // Trigger conditional erase
+        runtime.AdvanceCurrentTime(TDuration::Minutes(1));
+        WaitForCondErase(runtime);
+
+        // Verify expired row is deleted
+        NKikimrMiniKQL::TResult result;
+        TString error;
+        NKikimrProto::EReplyStatus status = LocalMiniKQL(runtime, tabletId, R"(
+            (
+                (let range '( '('key (Uint64 '0) (Void) )))
+                (let columns '('key) )
+                (let result (SelectRange '__user__TTLTableMulti range columns '()))
+                (return (AsList (SetResult 'Result result) ))
+            )
+        )", result, error);
+        UNIT_ASSERT_VALUES_EQUAL_C(status, NKikimrProto::EReplyStatus::OK, error);
+
+        NKqp::CompareYson(R"([[[[[["2"]]];%false]]])", result);
+    }
+
+    struct TBatchSizeTestCase {
+        TString Tag;
+        bool EnableBatching;
+        ui32 BatchSize;
+    };
+
+    void ConfigurableBatchSize_TestImpl(NUnitTest::TTestContext&, const TBatchSizeTestCase& params) {
+        TTestBasicRuntime runtime;
+        // Configure batch size and feature flag
+        TTestEnv env(runtime, TTestEnvOptions()
+            .EnableConditionalEraseResponseBatching(params.EnableBatching)
+            .CondEraseResponseBatchSize(params.BatchSize)
+        );
+
+        const TInstant now = TInstant::ParseIso8601("2020-09-18T18:00:00.000000Z");
+        runtime.UpdateCurrentTime(now);
+
+        ui64 txId = 100;
+        ui64 tabletId = TTestTxConfig::FakeHiveTablets;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTableBatchSize"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "ts" Type: "Timestamp" }
+            KeyColumnNames: ["key"]
+            TTLSettings {
+              Enabled {
+                ColumnName: "ts"
+                ExpireAfterSeconds: 3600
+                Tiers: {
+                  ApplyAfterSeconds: 3600
+                  Delete: {}
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Write 10 rows: 5 expired (> 1 hour old), 5 not expired (< 1 hour old)
+        for (ui32 i = 0; i < 10; ++i) {
+            TInstant ts = (i % 2 == 0) ? now - TDuration::Hours(2) : now - TDuration::Minutes(30);
+            WriteTTLRow(runtime, tabletId, i, ts, "TTLTableBatchSize");
+        }
+
+        // Verify all rows are present before conditional erase
+        UNIT_ASSERT_VALUES_EQUAL(CountRows(runtime, "/MyRoot/TTLTableBatchSize"), 10);
+
+        // Trigger conditional erase
+        runtime.AdvanceCurrentTime(TDuration::Minutes(1));
+        WaitForCondErase(runtime);
+
+        // Verify that expired rows were deleted (5 should remain)
+        ui32 remainingRows = CountRows(runtime, "/MyRoot/TTLTableBatchSize");
+        UNIT_ASSERT_VALUES_EQUAL_C(remainingRows, 5,
+            "Expected 5 rows to remain after conditional erase with BatchSize=" << params.BatchSize
+            << ", EnableBatching=" << params.EnableBatching);
+
+        // Verify the table still exists and is functional
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/TTLTableBatchSize"),
+            {NLs::PathExist});
+    }
+
+    static const std::vector<TBatchSizeTestCase> ConfigurableBatchSize_Tests = {
+        { .Tag = "BatchingDisabled-Size0", .EnableBatching = true, .BatchSize = 0 },      // Batch size 0 disables batching
+        { .Tag = "BatchingDisabled-FlagOff", .EnableBatching = false, .BatchSize = 100 }, // Feature flag off
+        { .Tag = "BatchSize1", .EnableBatching = true, .BatchSize = 1 },                  // Process one at a time via batch path
+        { .Tag = "BatchSize10", .EnableBatching = true, .BatchSize = 10 },                // Small batch
+        { .Tag = "BatchSize100", .EnableBatching = true, .BatchSize = 100 },              // Default batch size
+        { .Tag = "BatchSize1000", .EnableBatching = true, .BatchSize = 1000 },            // Large batch
+    };
+
+    struct TTestRegistration_ConfigurableBatchSize {
+        TTestRegistration_ConfigurableBatchSize() {
+            static std::vector<TString> TestNames;
+            for (size_t testId = 0; const auto& entry : ConfigurableBatchSize_Tests) {
+                TestNames.emplace_back(TStringBuilder() << "ConfigurableBatchSize-" << entry.Tag << "-" << ++testId);
+                TCurrentTest::AddTest(TestNames.back().c_str(), std::bind(ConfigurableBatchSize_TestImpl, std::placeholders::_1, entry), false);
+            }
+        }
+    };
+    static TTestRegistration_ConfigurableBatchSize testRegistration_ConfigurableBatchSize;
+
+    Y_UNIT_TEST(CondEraseOverReboot) {
+        // Test: Verify TTL operations work correctly with explicit tablet reboots
+        // This test uses RebootTablet() instead of complex reboot framework
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions()
+            .EnableConditionalEraseResponseBatching(true)
+            .CondEraseResponseBatchSize(2)
+        );
+        ui64 txId = 100;
+
+        const TInstant now = TInstant::ParseIso8601("2020-09-18T18:00:00.000000Z");
+        runtime.UpdateCurrentTime(now);
+
+        ui64 tabletId = TTestTxConfig::FakeHiveTablets;
+
+        // Create table with TTL
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLRebootTable"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "ts" Type: "Timestamp" }
+            KeyColumnNames: ["key"]
+            TTLSettings {
+              Enabled {
+                ColumnName: "ts"
+                ExpireAfterSeconds: 3600
+                SysSettings {
+                  RunInterval: 900000000
+                  RetryInterval: 900000000
+                }
+                Tiers: {
+                  ApplyAfterSeconds: 3600
+                  Delete: {}
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto tablePathId = GetTablePathId(runtime, "/MyRoot/TTLRebootTable");
+
+        WriteTTLRow(runtime, tabletId, 1, now - TDuration::Hours(1), "TTLRebootTable");
+
+        Cerr << "TEST 1" << Endl;
+
+        WaitForCondEraseBatch(runtime, tablePathId, TDuration::Minutes(1));
+        WaitForStats(runtime, 1);
+
+        Cerr << "TEST 2" << Endl;
+
+        // Verify row is deleted
+        UNIT_ASSERT_VALUES_EQUAL(CountRows(runtime, "/MyRoot/TTLRebootTable"), 0);
+
+        // Write another expired row with batch size 2
+        WriteTTLRow(runtime, tabletId, 2, now - TDuration::Hours(1), "TTLRebootTable");
+
+        Cerr << "TEST 3" << Endl;
+
+        // Reboot the datashard tablet before waiting for conditional erase
+        RebootTablet(runtime, tabletId, runtime.AllocateEdgeActor());
+
+        Cerr << "TEST 4" << Endl;
+
+        // Wait for TTL processing after reboot - with RunInterval: 900000000 (900 seconds), TTL runs every 15 minutes
+        WaitForCondEraseBatch(runtime, tablePathId, TDuration::Minutes(15));
+        WaitForStats(runtime, 1);
+
+        Cerr << "TEST 5" << Endl;
+
+        // Verify row is deleted after reboot
+        UNIT_ASSERT_VALUES_EQUAL(CountRows(runtime, "/MyRoot/TTLRebootTable"), 0);
+
+        Cerr << "TEST 6" << Endl;
+
+        // Change batch size to 5
+        runtime.GetAppData().SchemeShardConfig.SetCondEraseResponseBatchSize(5);
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Write another expired row with batch size 5
+        WriteTTLRow(runtime, tabletId, 3, now - TDuration::Hours(2), "TTLRebootTable");
+
+        // Reboot the datashard tablet again
+        RebootTablet(runtime, tabletId, runtime.AllocateEdgeActor());
+
+        Cerr << "TEST 7" << Endl;
+
+        // Wait for TTL processing after reboot with new batch size
+        WaitForCondEraseBatch(runtime, tablePathId, TDuration::Minutes(15));
+        WaitForStats(runtime, 1);
+
+        Cerr << "TEST 8" << Endl;
+
+        // Verify row is deleted after reboot with new batch size
+        UNIT_ASSERT_VALUES_EQUAL(CountRows(runtime, "/MyRoot/TTLRebootTable"), 0);
     }
 
     Y_UNIT_TEST(TtlTiersValidation) {


### PR DESCRIPTION
Cherry-pick from `main`:
- f00690a, https://github.com/ydb-platform/ydb/pull/33867
- f397b00, https://github.com/ydb-platform/ydb/pull/33955
- 5ebef98, https://github.com/ydb-platform/ydb/pull/34330

Changes:
- Add size- and time- based batching for `TEvConditionalEraseRowsResponse`. `TTxScheduleConditionalErase` now processes batches instead of individual responses.
- Process `TEvConditionalEraseRowsResponse::PARTIAL` response early, without entering a local transaction.
- Make table checks once per table, not once per shard.