### PR TITLE
SchemeShard: add get operation and tx notification for forced compactions [WIP: second part]

### DIFF
--- a/ydb/core/protos/forced_compaction.proto
+++ b/ydb/core/protos/forced_compaction.proto
@@ -35,3 +35,14 @@ message TEvCreateResponse {
     repeated Ydb.Issue.IssueMessage Issues = 3;
     optional TForcedCompaction ForcedCompaction = 4;
 }
+
+message TEvGetRequest {
+    optional string DatabaseName = 1;
+    optional uint64 ForcedCompactionId = 2;
+}
+
+message TEvGetResponse {
+    optional Ydb.StatusIds.StatusCode Status = 1;
+    repeated Ydb.Issue.IssueMessage Issues = 2;
+    optional TForcedCompaction ForcedCompaction = 3;
+}

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -5621,9 +5621,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         compactionsRowset.GetValue<Schema::ForcedCompactions::TableOwnerId>(),
                         compactionsRowset.GetValue<Schema::ForcedCompactions::TableLocalId>()
                 );
-                info->DomainPathId = TPathId(
-                        compactionsRowset.GetValue<Schema::ForcedCompactions::DomainOwnerId>(),
-                        compactionsRowset.GetValue<Schema::ForcedCompactions::DomainLocalId>()
+                info->SubdomainPathId = TPathId(
+                        compactionsRowset.GetValue<Schema::ForcedCompactions::SubdomainOwnerId>(),
+                        compactionsRowset.GetValue<Schema::ForcedCompactions::SubdomainLocalId>()
                 );
                 info->Cascade = compactionsRowset.GetValue<Schema::ForcedCompactions::Cascade>();
                 info->MaxShardsInFlight = compactionsRowset.GetValue<Schema::ForcedCompactions::MaxShardsInFlight>();

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -5621,6 +5621,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         compactionsRowset.GetValue<Schema::ForcedCompactions::TableOwnerId>(),
                         compactionsRowset.GetValue<Schema::ForcedCompactions::TableLocalId>()
                 );
+                info->DomainPathId = TPathId(
+                        compactionsRowset.GetValue<Schema::ForcedCompactions::DomainOwnerId>(),
+                        compactionsRowset.GetValue<Schema::ForcedCompactions::DomainLocalId>()
+                );
                 info->Cascade = compactionsRowset.GetValue<Schema::ForcedCompactions::Cascade>();
                 info->MaxShardsInFlight = compactionsRowset.GetValue<Schema::ForcedCompactions::MaxShardsInFlight>();
                 if (compactionsRowset.HaveValue<Schema::ForcedCompactions::UserSID>()) {

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -34,7 +34,9 @@ void TSchemeShard::PersistForcedCompactionState(NIceDb::TNiceDb& db, const TForc
         NIceDb::TUpdate<Schema::ForcedCompactions::StartTime>(info.StartTime.Seconds()),
         NIceDb::TUpdate<Schema::ForcedCompactions::EndTime>(info.EndTime.Seconds()),
         NIceDb::TUpdate<Schema::ForcedCompactions::TotalShardCount>(info.TotalShardCount),
-        NIceDb::TUpdate<Schema::ForcedCompactions::DoneShardCount>(info.DoneShardCount)
+        NIceDb::TUpdate<Schema::ForcedCompactions::DoneShardCount>(info.DoneShardCount),
+        NIceDb::TUpdate<Schema::ForcedCompactions::DomainOwnerId>(info.DomainPathId.OwnerId),
+        NIceDb::TUpdate<Schema::ForcedCompactions::DomainLocalId>(info.DomainPathId.LocalPathId)
     );
 
     if (info.UserSID) {
@@ -135,6 +137,10 @@ void TSchemeShard::ProcessForcedCompactionQueues() {
 
 void TSchemeShard::Handle(TEvForcedCompaction::TEvCreateRequest::TPtr& ev, const TActorContext& ctx) {
     Execute(CreateTxCreateForcedCompaction(ev), ctx);
+}
+
+void TSchemeShard::Handle(TEvForcedCompaction::TEvGetRequest::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxGetForcedCompaction(ev), ctx);
 }
 
 NOperationQueue::EStartStatus TSchemeShard::StartForcedCompaction(const TShardIdx& shardIdx) {

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -35,8 +35,8 @@ void TSchemeShard::PersistForcedCompactionState(NIceDb::TNiceDb& db, const TForc
         NIceDb::TUpdate<Schema::ForcedCompactions::EndTime>(info.EndTime.Seconds()),
         NIceDb::TUpdate<Schema::ForcedCompactions::TotalShardCount>(info.TotalShardCount),
         NIceDb::TUpdate<Schema::ForcedCompactions::DoneShardCount>(info.DoneShardCount),
-        NIceDb::TUpdate<Schema::ForcedCompactions::DomainOwnerId>(info.DomainPathId.OwnerId),
-        NIceDb::TUpdate<Schema::ForcedCompactions::DomainLocalId>(info.DomainPathId.LocalPathId)
+        NIceDb::TUpdate<Schema::ForcedCompactions::SubdomainOwnerId>(info.SubdomainPathId.OwnerId),
+        NIceDb::TUpdate<Schema::ForcedCompactions::SubdomainLocalId>(info.SubdomainPathId.LocalPathId)
     );
 
     if (info.UserSID) {

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.h
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.h
@@ -10,6 +10,8 @@ struct TEvForcedCompaction {
     enum EEv {
         EvCreateRequest = EventSpaceBegin(TKikimrEvents::ES_FORCED_COMPACTION),
         EvCreateResponse,
+        EvGetRequest,
+        EvGetResponse,
 
         EvEnd
     };
@@ -34,6 +36,19 @@ struct TEvForcedCompaction {
         explicit TEvCreateResponse(const ui64 txId) {
             Record.SetTxId(txId);
         }
+    };
+
+    struct TEvGetRequest: public TEventPB<TEvGetRequest, NKikimrForcedCompaction::TEvGetRequest, EvGetRequest> {
+        TEvGetRequest() = default;
+
+        explicit TEvGetRequest(const TString& dbName, const ui64 forcedCompactionId) {
+            Record.SetDatabaseName(dbName);
+            Record.SetForcedCompactionId(forcedCompactionId);
+        }
+    };
+
+    struct TEvGetResponse: public TEventPB<TEvGetResponse, NKikimrForcedCompaction::TEvGetResponse, EvGetResponse> {
+        TEvGetResponse() = default;
     };
 
 };

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
@@ -69,6 +69,7 @@ struct TSchemeShard::TForcedCompaction::TTxCreate: public TRwTxBase {
         info->Id = id;
         info->State = TForcedCompactionInfo::EState::InProgress;
         info->TablePathId = tablePath.Base()->PathId;
+        info->DomainPathId = domainPath.Base()->PathId;
         info->Cascade = settings.cascade();
         info->MaxShardsInFlight = settings.max_shards_in_flight();
         info->StartTime = TAppData::TimeProvider->Now();
@@ -125,6 +126,7 @@ struct TSchemeShard::TForcedCompaction::TTxCreate: public TRwTxBase {
         SideEffects.ApplyOnComplete(Self, ctx);
     }
 
+private:
     void Reply(
         THolder<TEvForcedCompaction::TEvCreateResponse> response,
         const Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS,

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
@@ -32,9 +32,9 @@ struct TSchemeShard::TForcedCompaction::TTxCreate: public TRwTxBase {
                 << "Forced compaction with id '" << id << "' already exists");
         }
 
-        const auto domainPath = TPath::Resolve(request.GetDatabaseName(), Self);
+        const auto subdomainPath = TPath::Resolve(request.GetDatabaseName(), Self);
         {
-            const auto checks = domainPath.Check();
+            const auto checks = subdomainPath.Check();
             checks
                 .IsAtLocalSchemeShard()
                 .IsResolved()
@@ -58,7 +58,7 @@ struct TSchemeShard::TForcedCompaction::TTxCreate: public TRwTxBase {
                 .NotUnderDeleting()
                 .IsTable()
                 .IsCommonSensePath()
-                .IsTheSameDomain(domainPath);
+                .IsTheSameDomain(subdomainPath);
 
             if (!checks) {
                 return Reply(std::move(response), Ydb::StatusIds::BAD_REQUEST, checks.GetError());
@@ -69,7 +69,7 @@ struct TSchemeShard::TForcedCompaction::TTxCreate: public TRwTxBase {
         info->Id = id;
         info->State = TForcedCompactionInfo::EState::InProgress;
         info->TablePathId = tablePath.Base()->PathId;
-        info->DomainPathId = domainPath.Base()->PathId;
+        info->SubdomainPathId = subdomainPath.Base()->PathId;
         info->Cascade = settings.cascade();
         info->MaxShardsInFlight = settings.max_shards_in_flight();
         info->StartTime = TAppData::TimeProvider->Now();

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__get.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__get.cpp
@@ -58,7 +58,6 @@ struct TSchemeShard::TForcedCompaction::TTxGet: public TRwTxBase {
     }
 
 private:
-
     void Reply(
         THolder<TEvForcedCompaction::TEvGetResponse> response,
         const Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS,

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__get.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__get.cpp
@@ -25,7 +25,7 @@ struct TSchemeShard::TForcedCompaction::TTxGet: public TRwTxBase {
                 TStringBuilder() << "Database " << request.GetDatabaseName() << " not found"
             );
         }
-        const TPathId domainPathId = database.GetPathIdForDomain();
+        const TPathId subdomainPathId = database.GetPathIdForDomain();
         
         auto compactionId = request.GetForcedCompactionId();
         const auto* forcedCompactionInfoPtr = Self->ForcedCompactions.FindPtr(compactionId);
@@ -37,7 +37,7 @@ struct TSchemeShard::TForcedCompaction::TTxGet: public TRwTxBase {
             );
         }
         const auto& forcedCompactionInfo = *forcedCompactionInfoPtr->get();
-        if (forcedCompactionInfo.DomainPathId != domainPathId) {
+        if (forcedCompactionInfo.SubdomainPathId != subdomainPathId) {
             return Reply(
                 std::move(response),
                 Ydb::StatusIds::NOT_FOUND,

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__get.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__get.cpp
@@ -1,0 +1,88 @@
+#include "schemeshard_impl.h"
+
+#define LOG_N(stream) LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << Self->SelfTabletId() << "][ForcedCompaction] " << stream)
+
+namespace NKikimr::NSchemeShard {
+
+using namespace NTabletFlatExecutor;
+
+struct TSchemeShard::TForcedCompaction::TTxGet: public TRwTxBase {
+    explicit TTxGet(TSelf* self, TEvForcedCompaction::TEvGetRequest::TPtr& ev)
+        : TRwTxBase(self)
+        , Request(ev)
+    {}
+
+    void DoExecute(TTransactionContext& txc, const TActorContext& ctx) override {
+        const auto& request = Request->Get()->Record;
+        LOG_N("TForcedCompaction::TTxGet DoExecute " << request.ShortDebugString());
+
+        auto response = MakeHolder<TEvForcedCompaction::TEvGetResponse>();
+        TPath database = TPath::Resolve(request.GetDatabaseName(), Self);
+        if (!database.IsResolved()) {
+            return Reply(
+                std::move(response),
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "Database " << request.GetDatabaseName() << " not found"
+            );
+        }
+        const TPathId domainPathId = database.GetPathIdForDomain();
+        
+        auto compactionId = request.GetForcedCompactionId();
+        const auto* forcedCompactionInfoPtr = Self->ForcedCompactions.FindPtr(compactionId);
+        if (!forcedCompactionInfoPtr) {
+            return Reply(
+                std::move(response),
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "Forced compaction with id " << compactionId << " not found"
+            );
+        }
+        const auto& forcedCompactionInfo = *forcedCompactionInfoPtr->get();
+        if (forcedCompactionInfo.DomainPathId != domainPathId) {
+            return Reply(
+                std::move(response),
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "Forced compaction with id " << compactionId << " not found in database " << request.GetDatabaseName()
+            );
+        }
+
+        Self->FromForcedCompactionInfo(*response->Record.MutableForcedCompaction(), forcedCompactionInfo);
+
+        Reply(std::move(response));
+
+        SideEffects.ApplyOnExecute(Self, txc, ctx);
+    }
+
+    void DoComplete(const TActorContext &ctx) override {
+        LOG_N("TForcedCompaction::TTxGet DoComplete");
+        SideEffects.ApplyOnComplete(Self, ctx);
+    }
+
+private:
+
+    void Reply(
+        THolder<TEvForcedCompaction::TEvGetResponse> response,
+        const Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS,
+        const TString& errorMessage = TString())
+    {
+        auto& record = response->Record;
+        record.SetStatus(status);
+        if (errorMessage) {
+            auto& issue = *record.MutableIssues()->Add();
+            issue.set_severity(NYql::TSeverityIds::S_ERROR);
+            issue.set_message(errorMessage);
+
+        }
+
+        SideEffects.Send(Request->Sender, std::move(response), 0, Request->Cookie);
+    }
+
+private:
+    TSideEffects SideEffects;
+    TEvForcedCompaction::TEvGetRequest::TPtr Request;
+};
+
+ITransaction* TSchemeShard::CreateTxGetForcedCompaction(TEvForcedCompaction::TEvGetRequest::TPtr& ev) {
+    return new TForcedCompaction::TTxGet(this, ev);
+}
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp
@@ -1,6 +1,7 @@
 
 #include "schemeshard_impl.h"
 
+#define LOG_T(stream) LOG_TRACE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << Self->SelfTabletId() << "][ForcedCompaction] " << stream)
 #define LOG_N(stream) LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << Self->SelfTabletId() << "][ForcedCompaction] " << stream)
 
 namespace NKikimr::NSchemeShard {
@@ -17,16 +18,17 @@ struct TSchemeShard::TForcedCompaction::TTxProgress: public TRwTxBase {
         NIceDb::TNiceDb db(txc.DB);
         THashSet<TForcedCompactionInfo::TPtr> compactionsToPersist;
         for (auto& [shardIdx, forcedCompactionInfo] : Self->DoneShardsToPersist) {
-            forcedCompactionInfo->DoneShardCount++;
+            if (Self->InProgressForcedCompactionsByShard.erase(shardIdx)) {
+                forcedCompactionInfo->DoneShardCount++;
+            }
             compactionsToPersist.insert(forcedCompactionInfo);
-            Self->InProgressForcedCompactionsByShard.erase(shardIdx);
             Self->PersistForcedCompactionDoneShard(db, shardIdx);
         }
 
         for (auto& forcedCompactionInfo : compactionsToPersist) {
             const auto* shardsQueue = Self->ForcedCompactionShardsByTable.FindPtr(forcedCompactionInfo->TablePathId);
             bool compactionCompleted = (!shardsQueue || shardsQueue->Empty()) && forcedCompactionInfo->ShardsInFlight.empty();
-            if (compactionCompleted) {
+            if (compactionCompleted && forcedCompactionInfo->State != TForcedCompactionInfo::EState::Cancelled) {
                 if (!shardsQueue) {
                     Self->ForcedCompactionShardsByTable.erase(forcedCompactionInfo->TablePathId);
                     Self->ForcedCompactionTablesQueue.Remove(forcedCompactionInfo->TablePathId);
@@ -36,13 +38,36 @@ struct TSchemeShard::TForcedCompaction::TTxProgress: public TRwTxBase {
                 Self->InProgressForcedCompactionsByTable.erase(forcedCompactionInfo->TablePathId);
             }
             Self->PersistForcedCompactionState(db, *forcedCompactionInfo);
+            SendNotificationsIfFinished(*forcedCompactionInfo, ctx);
         }
+        SideEffects.ApplyOnExecute(Self, txc, ctx);
     }
 
     void DoComplete(const TActorContext &ctx) override {
         LOG_N("TForcedCompaction::TTxProgress DoComplete");
         Self->DoneShardsToPersist.clear();
+        SideEffects.ApplyOnComplete(Self, ctx);
     }
+
+private:
+    void SendNotificationsIfFinished(TForcedCompactionInfo& info, const TActorContext& ctx) {
+        if (!info.IsFinished()) {
+            return;
+        }
+
+        LOG_T("TForcedCompaction::TTxProgress SendNotifications: "
+            << ": id# " << info.Id
+            << ", subscribers count# " << info.Subscribers.size());
+
+        TSet<TActorId> toAnswer;
+        toAnswer.swap(info.Subscribers);
+        for (auto& actorId: toAnswer) {
+            SideEffects.Send(actorId, MakeHolder<TEvSchemeShard::TEvNotifyTxCompletionResult>(info.Id));
+        }
+    }
+
+private:
+    TSideEffects SideEffects;
 };
 
 ITransaction* TSchemeShard::CreateTxProgressForcedCompaction() {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5459,6 +5459,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
 
         // namespace NForcedCompaction {
         HFuncTraced(TEvForcedCompaction::TEvCreateRequest, Handle);
+        HFuncTraced(TEvForcedCompaction::TEvGetRequest, Handle);
         // } // NForcedCompaction
 
         //namespace NCdcStreamScan {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1750,6 +1750,7 @@ public:
 
     struct TForcedCompaction {
         struct TTxCreate;
+        struct TTxGet;
         struct TTxProgress;
     };
 
@@ -1771,9 +1772,11 @@ public:
     void HandleForcedCompactionResult(TEvDataShard::TEvCompactTableResult::TPtr &ev, const TActorContext &ctx);
 
     NTabletFlatExecutor::ITransaction* CreateTxCreateForcedCompaction(TEvForcedCompaction::TEvCreateRequest::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxGetForcedCompaction(TEvForcedCompaction::TEvGetRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxProgressForcedCompaction();
 
     void Handle(TEvForcedCompaction::TEvCreateRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvForcedCompaction::TEvGetRequest::TPtr& ev, const TActorContext& ctx);
     // } // NForcedCompaction
 
     // namespace NCdcStreamScan {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2887,5 +2887,14 @@ void TImportInfo::TFillItemsFromSchemaMappingResult::AddError(const TString& err
     ErrorMessage += err;
 }
 
+bool TForcedCompactionInfo::IsFinished() const {
+    return State == EState::Done || State == EState::Cancelled;
+}
+
+void TForcedCompactionInfo::AddNotifySubscriber(const TActorId& actorId) {
+    Y_ENSURE(!IsFinished());
+    Subscribers.insert(actorId);
+}
+
 } // namespace NSchemeShard
 } // namespace NKikimr

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3860,7 +3860,7 @@ struct TForcedCompactionInfo : TSimpleRefCount<TForcedCompactionInfo> {
     ui64 Id;  // TxId from the original TEvCreateRequest
     EState State = EState::Invalid; 
     TPathId TablePathId;
-    TPathId DomainPathId;
+    TPathId SubdomainPathId;
     bool Cascade;
     ui32 MaxShardsInFlight;
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3854,11 +3854,13 @@ struct TForcedCompactionInfo : TSimpleRefCount<TForcedCompactionInfo> {
         Invalid = 0,
         InProgress = 1,
         Done = 2,
+        Cancelled = 3,
     };
 
     ui64 Id;  // TxId from the original TEvCreateRequest
     EState State = EState::Invalid; 
     TPathId TablePathId;
+    TPathId DomainPathId;
     bool Cascade;
     ui32 MaxShardsInFlight;
 
@@ -3871,6 +3873,11 @@ struct TForcedCompactionInfo : TSimpleRefCount<TForcedCompactionInfo> {
     ui32 DoneShardCount = 0; // updates only when persisting
 
     THashSet<TShardIdx> ShardsInFlight;
+
+    TSet<TActorId> Subscribers;
+
+    bool IsFinished() const;
+    void AddNotifySubscriber(const TActorId& actorId);
 };
 // } // NForcedCompaction
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2288,6 +2288,8 @@ struct Schema : NIceDb::Schema {
         struct EndTime : Column<9, NScheme::NTypeIds::Uint64> {};
         struct TotalShardCount : Column<10, NScheme::NTypeIds::Uint32> {};
         struct DoneShardCount : Column<11, NScheme::NTypeIds::Uint32> {};
+        struct DomainOwnerId : Column<12, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
+        struct DomainLocalId : Column<13, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<
@@ -2301,7 +2303,9 @@ struct Schema : NIceDb::Schema {
             StartTime,
             EndTime,
             TotalShardCount,
-            DoneShardCount
+            DoneShardCount,
+            DomainOwnerId,
+            DomainLocalId
         >;
     };
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2288,8 +2288,8 @@ struct Schema : NIceDb::Schema {
         struct EndTime : Column<9, NScheme::NTypeIds::Uint64> {};
         struct TotalShardCount : Column<10, NScheme::NTypeIds::Uint32> {};
         struct DoneShardCount : Column<11, NScheme::NTypeIds::Uint32> {};
-        struct DomainOwnerId : Column<12, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
-        struct DomainLocalId : Column<13, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
+        struct SubdomainOwnerId : Column<12, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
+        struct SubdomainLocalId : Column<13, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<
@@ -2304,8 +2304,8 @@ struct Schema : NIceDb::Schema {
             EndTime,
             TotalShardCount,
             DoneShardCount,
-            DomainOwnerId,
-            DomainLocalId
+            SubdomainOwnerId,
+            SubdomainLocalId
         >;
     };
 

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -454,10 +454,14 @@ namespace NSchemeShardUT_Private {
     NKikimrIndexBuilder::TEvForgetResponse TestForgetBuildIndex(TTestActorRuntime& runtime, const ui64 id, const ui64 schemeShard, const TString &dbName, const ui64 buildIndexId, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
 
     // forced compaction
-    void AsyncCompact(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 id, const TString& dbName, const TString& tablePath);
-    void AsyncCompact(TTestActorRuntime& runtime, ui64 id, const TString& dbName, const TString& tablePath);
-    void TestCompact(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 id, const TString& dbName, const TString& tablePath, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
-    void TestCompact(TTestActorRuntime& runtime, ui64 id, const TString& dbName, const TString& tablaPath, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    void AsyncCompact(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 id, const TString& dbName, const TString& tablePath, ui32 maxShardsInFlight = 1);
+    void AsyncCompact(TTestActorRuntime& runtime, ui64 id, const TString& dbName, const TString& tablePath, ui32 maxShardsInFlight = 1);
+    void TestCompact(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 id, const TString& dbName, const TString& tablePath, ui32 maxShardsInFlight = 1, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    void TestCompact(TTestActorRuntime& runtime, ui64 id, const TString& dbName, const TString& tablaPath, ui32 maxShardsInFlight = 1, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    NKikimrForcedCompaction::TEvGetResponse TestGetCompaction(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 id, const TString& dbName,
+            Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    NKikimrForcedCompaction::TEvGetResponse TestGetCompaction(TTestActorRuntime& runtime, ui64 id, const TString& dbName,
+            Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
 
     ////////// export
     TVector<TString> GetExportTargetPaths(const TString& requestStr);

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -457,7 +457,7 @@ namespace NSchemeShardUT_Private {
     void AsyncCompact(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 id, const TString& dbName, const TString& tablePath, ui32 maxShardsInFlight = 1);
     void AsyncCompact(TTestActorRuntime& runtime, ui64 id, const TString& dbName, const TString& tablePath, ui32 maxShardsInFlight = 1);
     void TestCompact(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 id, const TString& dbName, const TString& tablePath, ui32 maxShardsInFlight = 1, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
-    void TestCompact(TTestActorRuntime& runtime, ui64 id, const TString& dbName, const TString& tablaPath, ui32 maxShardsInFlight = 1, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    void TestCompact(TTestActorRuntime& runtime, ui64 id, const TString& dbName, const TString& tablePath, ui32 maxShardsInFlight = 1, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
     NKikimrForcedCompaction::TEvGetResponse TestGetCompaction(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 id, const TString& dbName,
             Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
     NKikimrForcedCompaction::TEvGetResponse TestGetCompaction(TTestActorRuntime& runtime, ui64 id, const TString& dbName,

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -244,10 +244,11 @@ SRCS(
     schemeshard_backup_incremental__get.cpp
     schemeshard_backup_incremental__list.cpp
     schemeshard_backup_incremental__progress.cpp
-    schemeshard_restore_incremental__forget.cpp
     schemeshard_forced_compaction__create.cpp
+    schemeshard_forced_compaction__get.cpp
     schemeshard_forced_compaction__progress.cpp
     schemeshard_forced_compaction.cpp
+    schemeshard_restore_incremental__forget.cpp
     schemeshard_restore_incremental__get.cpp
     schemeshard_restore_incremental__list.cpp
     schemeshard_bg_tasks__list.cpp

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -9392,6 +9392,16 @@
                 "ColumnId": 11,
                 "ColumnName": "DoneShardCount",
                 "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "DomainOwnerId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 13,
+                "ColumnName": "DomainLocalId",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -9408,7 +9418,9 @@
                     8,
                     9,
                     10,
-                    11
+                    11,
+                    12,
+                    13
                 ],
                 "RoomID": 0,
                 "Codec": 0,

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -9395,12 +9395,12 @@
             },
             {
                 "ColumnId": 12,
-                "ColumnName": "DomainOwnerId",
+                "ColumnName": "SubdomainOwnerId",
                 "ColumnType": "Uint64"
             },
             {
                 "ColumnId": 13,
-                "ColumnName": "DomainLocalId",
+                "ColumnName": "SubdomainLocalId",
                 "ColumnType": "Uint64"
             }
         ],


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Next part after https://github.com/ydb-platform/ydb/pull/33975
- added 'get' handler for forced compactions
- support forced compactions in TEvNotifyTxCompletion/TEvNotifyTxCompletionResult 
- add 'Cancelled' status (not used yet)
- fix DoneShardCount incrementing in case of transaction retrying
