### PR TITLE
Fix VERIFY caused by dstool group take-snapshot when VDisk is in NotReady or Error state

### DIFF
--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -1215,11 +1215,11 @@ namespace NKikimr {
         }
 
         void DatabaseErrorHandle(TEvBlobStorage::TEvMonStreamQuery::TPtr& ev, const TActorContext& ctx) {
-            ctx.Send(ev->Sender, new NMon::TEvHttpInfoRes("ERROR"));
+            ctx.Send(ev->Sender, new NMon::TEvHttpInfoRes("ERROR"), 0, ev->Cookie);
         }
 
         void DatabaseNotReadyHandle(TEvBlobStorage::TEvMonStreamQuery::TPtr& ev, const TActorContext& ctx) {
-            ctx.Send(ev->Sender, new NMon::TEvHttpInfoRes("NOT_READY"));
+            ctx.Send(ev->Sender, new NMon::TEvHttpInfoRes("NOT_READY"), 0, ev->Cookie);
         }
 
         template <class TEventPtr>

--- a/ydb/tests/functional/dstool/canondata/result.json
+++ b/ydb/tests/functional/dstool/canondata/result.json
@@ -75,6 +75,18 @@
             "uri": "file://test_canonical_requests.Test.test_essential/results.txt.8"
         }
     ],
+    "test_canonical_requests.Test.test_group_take_snapshot": [
+        {
+            "uri": "file://test_canonical_requests.Test.test_group_take_snapshot/results.txt"
+        },
+        {
+            "uri": "file://test_canonical_requests.Test.test_group_take_snapshot/results.txt.0"
+        },
+        null,
+        {
+            "uri": "file://test_canonical_requests.Test.test_group_take_snapshot/results.txt.1"
+        }
+    ],
     "test_canonical_requests.Test.test_infer_pdisk_slot_count": [
         {
             "uri": "file://test_canonical_requests.Test.test_infer_pdisk_slot_count/results.txt"

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt
@@ -1,0 +1,4 @@
+dstool -e <endpoint> --mon-port <mon_port> group take-snapshot --group-ids=0 --output=group0_1.bin
+Exit Status: 0
+===== stderr =====
+WARNING: endpoint for http requests is not specified, grpc endpoints will be used instead with conversion to http. You can specify additional endpoints with "http" or "https" protocol.

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt.0
@@ -1,0 +1,4 @@
+dstool -e <endpoint> --mon-port <mon_port> pdisk stop --node-id=1 --pdisk-id=1
+Exit Status: 0
+===== stderr =====
+success

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt.1
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt.1
@@ -1,0 +1,2 @@
+dstool -e <endpoint> --mon-port <mon_port> group take-snapshot --group-ids=0 --output=group0_2.bin
+Exit Status: 0

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -219,10 +219,20 @@ class Test(TestBase):
         ]
 
     def test_group_take_snapshot(self):
+        retry_assertions(self.check_vdisks_state_ok)
+
+        def check_vdisk_state_error():
+            base_config = self.cluster.client.query_base_config().BaseConfig
+            vslots = [vslot for vslot in base_config.VSlot if vslot.VSlotId.NodeId == 1 and vslot.VSlotId.PDiskId == 1]
+            assert len(vslots) == 1
+            vslot = vslots[0]
+            assert vslot.GroupId == 0
+            assert vslot.VDiskMetrics.State == EVDiskState.PDiskError
+
         return [
             self._trace('group', 'take-snapshot', '--group-ids=0', '--output=group0_1.bin'),
             self._trace('pdisk', 'stop', '--node-id=1', '--pdisk-id=1'),
-            time.sleep(1),
+            retry_assertions(check_vdisk_state_error, timeout_seconds=20),
             self._trace('group', 'take-snapshot', '--group-ids=0', '--output=group0_2.bin'),
         ]
 

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -218,6 +218,14 @@ class Test(TestBase):
             self._trace('--dry-run', 'cluster', 'set', '--disable-self-heal'),
         ]
 
+    def test_group_take_snapshot(self):
+        return [
+            self._trace('group', 'take-snapshot', '--group-ids=0', '--output=group0_1.bin'),
+            self._trace('pdisk', 'stop', '--node-id=1', '--pdisk-id=1'),
+            time.sleep(1),
+            self._trace('group', 'take-snapshot', '--group-ids=0', '--output=group0_2.bin'),
+        ]
+
     def test_infer_pdisk_slot_count(self):
         dynconfig_client = DynConfigClient(self.host, self.grpc_port)
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Fix VERIFY caused by `dstool group take-snapshot` when VDisk is in NotReady or Error state

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- https://nda.ya.ru/t/nwi5vqQv7Uk7oT

```
E   VERIFY failed (2026-02-18T20:15:33.776783+0300):
E   ydb/core/blobstorage/other/mon_vdisk_stream.cpp:74
E   Reply(): requirement it != RequestsInFlight.end() failed
E   0. /-S/util/system/yassert.cpp:86: NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char>>, char const*, unsigned long) @ 0xAB0A945
E   1. /-S/util/system/yassert.cpp:55: NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...) @ 0xAB033CB
E   2. /-S/ydb/core/blobstorage/other/mon_vdisk_stream.cpp:102: NKikimr::(anonymous namespace)::TMonVDiskStreamActor::StateFunc(TAutoPtr<NActors::IEventHandle, TDelete>&) @ 0x1AD541FE
E   3. /-S/ydb/library/actors/core/actor.cpp:350: NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) @ 0xB940F17
E   4. /-S/ydb/library/actors/core/executor_thread.cpp:267: NActors::TExecutorThread::Execute(NActors::TMailbox*, bool) @ 0xB991A74
E   5. /-S/ydb/library/actors/core/executor_thread.cpp:455: NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool) const @ 0xB995973
E   6. /-S/ydb/library/actors/core/executor_thread.cpp:507: NActors::TExecutorThread::ProcessExecutorPool() @ 0xB995600
E   7. /-S/ydb/library/actors/core/executor_thread.cpp:533: NActors::TExecutorThread::ThreadProc() @ 0xB99610E
E   8. /-S/util/system/thread.cpp:245: (anonymous namespace)::TPosixThread::ThreadProxy(void*) @ 0xAB0BF3C
E   9. ??:0: ?? @ 0x7FF2654E3608
E   10. ??:0: ?? @ 0x7FF265408352
```