### PR TITLE
Automerge update muted_ya.txt for stable branches and once a day main

### DIFF
--- a/.github/workflows/automerge_for_muted_ya.yml
+++ b/.github/workflows/automerge_for_muted_ya.yml
@@ -1,5 +1,4 @@
 # Adds automerge label to open mute-unmute PRs targeting main. Runs at 08:00 UTC daily.
-# Squash and stable-* automerge label are set in update_muted_ya.yml.
 name: Automerge for muted_ya (main)
 
 on:

--- a/.github/workflows/automerge_for_muted_ya.yml
+++ b/.github/workflows/automerge_for_muted_ya.yml
@@ -1,6 +1,6 @@
 # Adds automerge label to open mute-unmute PRs targeting main. Runs at 08:00 UTC daily.
 # Squash and stable-* automerge label are set in update_muted_ya.yml.
-name: Set automerge for mute-unmute PRs (main)
+name: Automerge for muted_ya (main)
 
 on:
   schedule:
@@ -16,11 +16,12 @@ jobs:
         with:
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
-            const { data: issues } = await github.rest.issues.listForRepo({
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'mute-unmute'
+              labels: 'mute-unmute',
+              per_page: 100
             });
             const prs = issues.filter(i => i.pull_request);
             core.info(`mute-unmute PRs: ${prs.length}`);

--- a/.github/workflows/set_automerge_mute_unmute_prs.yml
+++ b/.github/workflows/set_automerge_mute_unmute_prs.yml
@@ -4,7 +4,7 @@ name: Set automerge for mute-unmute PRs
 
 on:
   schedule:
-    - cron: "0 4-21/1 * * *"   # Every hour 4–21 UTC (same window as update_muted_ya)
+    - cron: "15 4-21/1 * * *"  # Every hour 4–21 UTC, offset 15 minutes from update_muted_ya
   workflow_dispatch:
     inputs:
       run_hour_utc:

--- a/.github/workflows/set_automerge_mute_unmute_prs.yml
+++ b/.github/workflows/set_automerge_mute_unmute_prs.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: "0 4-21/1 * * *"   # Every hour 4–21 UTC (same window as update_muted_ya)
   workflow_dispatch:
+    inputs:
+      run_hour_utc:
+        description: "Override UTC hour for main-branch logic (e.g. 07). Empty = use current time (for testing)."
+        required: false
+        type: string
 
 env:
   # Label that identifies PRs to process (we look for open PRs with this label)
@@ -19,7 +24,14 @@ jobs:
     steps:
       - name: Get run hour UTC
         id: hour
-        run: echo "hour=$(date -u +%H)" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.run_hour_utc }}" ]; then
+            h="${{ github.event.inputs.run_hour_utc }}"
+            printf -v hour "%02d" "$((10#$h))"
+            echo "hour=$hour" >> $GITHUB_OUTPUT
+          else
+            echo "hour=$(date -u +%H)" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set automerge on qualifying PRs
         uses: actions/github-script@v7
@@ -44,9 +56,14 @@ jobs:
             const prNumbers = issues.filter(i => i.pull_request).map(i => i.number);
             if (prNumbers.length === 0) {
               console.log(`No open PRs with label ${prLabelFilter}`);
+              core.summary.addHeading(`PRs with ${prLabelFilter}`);
+              core.summary.addRaw('No open PRs found.').addEol();
+              await core.summary.write();
               return;
             }
             console.log(`Found ${prNumbers.length} PR(s) with ${prLabelFilter}: ${prNumbers.join(', ')}`);
+
+            const prsWithBase = [];
 
             for (const number of prNumbers) {
               const { data: pr } = await github.rest.pulls.get({
@@ -61,6 +78,7 @@ jobs:
               const shouldAutomerge = (base === 'main' && runHourUtc === '07') || base.startsWith('stable-');
               if (!shouldAutomerge) {
                 console.log(`PR #${number} (base=${base}): skip automerge (main only at 7 UTC, run hour=${runHourUtc})`);
+                prsWithBase.push({ number, base, status: 'skipped' });
                 continue;
               }
 
@@ -81,6 +99,7 @@ jobs:
               // Enable squash auto-merge if not already enabled
               if (pr.auto_merge) {
                 console.log(`PR #${number}: auto-merge already enabled`);
+                prsWithBase.push({ number, base, status: 'already_set' });
                 continue;
               }
               const mutation = `
@@ -96,7 +115,18 @@ jobs:
               try {
                 await github.graphql(mutation);
                 console.log(`PR #${number} (base=${base}): enabled auto-merge (squash)`);
+                prsWithBase.push({ number, base, status: 'applied' });
               } catch (err) {
                 console.error(`PR #${number}: failed to enable auto-merge:`, err.message);
+                prsWithBase.push({ number, base, status: 'error' });
               }
             }
+
+            // Job summary: list of branches (base) with links to PRs and status
+            core.summary.addHeading(`PRs with ${prLabelFilter}`);
+            for (const { number, base, status } of prsWithBase) {
+              const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${number}`;
+              const suffix = status === 'skipped' ? ' _(skipped)_' : status === 'already_set' ? ' _(automerge already set)_' : status === 'error' ? ' _(failed to enable)_' : '';
+              core.summary.addRaw(`- \`${base}\`: [PR #${number}](${url})${suffix}`).addEol();
+            }
+            await core.summary.write();

--- a/.github/workflows/set_automerge_mute_unmute_prs.yml
+++ b/.github/workflows/set_automerge_mute_unmute_prs.yml
@@ -1,136 +1,45 @@
-# Sets automerge (label + enable squash merge) on open PRs that have the filter label.
-# Rules: main — only when run is at 7 UTC (once per day); stable-* — every run.
-name: Set automerge for mute-unmute PRs
+# Adds automerge label to open mute-unmute PRs targeting main. Runs at 08:00 UTC daily.
+# Squash and stable-* automerge label are set in update_muted_ya.yml.
+name: Set automerge for mute-unmute PRs (main)
 
 on:
   schedule:
-    - cron: "15 4-21/1 * * *"  # Every hour 4–21 UTC, offset 15 minutes from update_muted_ya
+    - cron: "0 8 * * *"
   workflow_dispatch:
-    inputs:
-      run_hour_utc:
-        description: "Override UTC hour for main-branch logic (e.g. 07). Empty = use current time (for testing)."
-        required: false
-        type: string
-
-env:
-  # Label that identifies PRs to process (we look for open PRs with this label)
-  PR_LABEL_FILTER: mute-unmute
-  # Label we add and use to gate auto-merge
-  AUTOMERGE_LABEL: automerge
 
 jobs:
   set-automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: Get run hour UTC
-        id: hour
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.run_hour_utc }}" ]; then
-            h="${{ github.event.inputs.run_hour_utc }}"
-            printf -v hour "%02d" "$((10#$h))"
-            echo "hour=$hour" >> $GITHUB_OUTPUT
-          else
-            echo "hour=$(date -u +%H)" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set automerge on qualifying PRs
+      - name: Add automerge label to main-branch mute-unmute PRs
         uses: actions/github-script@v7
-        env:
-          RUN_HOUR_UTC: ${{ steps.hour.outputs.hour }}
-          PR_LABEL_FILTER: ${{ env.PR_LABEL_FILTER }}
-          AUTOMERGE_LABEL: ${{ env.AUTOMERGE_LABEL }}
         with:
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
-            const runHourUtc = process.env.RUN_HOUR_UTC;
-            const prLabelFilter = process.env.PR_LABEL_FILTER;
-            const automergeLabel = process.env.AUTOMERGE_LABEL;
-
-            // List open PRs that have the filter label
-            const issues = await github.paginate(
-              github.rest.issues.listForRepo,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                labels: prLabelFilter,
-                per_page: 100,
-              }
-            );
-            const prNumbers = issues.filter(i => i.pull_request).map(i => i.number);
-            if (prNumbers.length === 0) {
-              console.log(`No open PRs with label ${prLabelFilter}`);
-              core.summary.addHeading(`PRs with ${prLabelFilter}`);
-              core.summary.addRaw('No open PRs found.').addEol();
-              await core.summary.write();
-              return;
-            }
-            console.log(`Found ${prNumbers.length} PR(s) with ${prLabelFilter}: ${prNumbers.join(', ')}`);
-
-            const prsWithBase = [];
-
-            for (const number of prNumbers) {
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'mute-unmute'
+            });
+            const prs = issues.filter(i => i.pull_request);
+            core.info(`mute-unmute PRs: ${prs.length}`);
+            let added = 0;
+            for (const issue of prs) {
               const { data: pr } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: number
+                pull_number: issue.number
               });
-              const base = pr.base.ref;
-
-              // Main: automerge only for the 7 UTC run (PR ~8 UTC, ~10 min checks -> merge ~11 MSK)
-              // Stable branches: always automerge
-              const shouldAutomerge = (base === 'main' && runHourUtc === '07') || base.startsWith('stable-');
-              if (!shouldAutomerge) {
-                console.log(`PR #${number} (base=${base}): skip automerge (main only at 7 UTC, run hour=${runHourUtc})`);
-                prsWithBase.push({ number, base, status: 'skipped' });
-                continue;
-              }
-
-              // Add automerge label if missing
-              const hasLabel = pr.labels?.some(l => l.name === automergeLabel);
-              if (!hasLabel) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: number,
-                  labels: [automergeLabel]
-                });
-                console.log(`PR #${number} (base=${base}): added ${automergeLabel} label`);
-              } else {
-                console.log(`PR #${number} (base=${base}): already has ${automergeLabel} label`);
-              }
-
-              // Enable squash auto-merge if not already enabled
-              if (pr.auto_merge) {
-                console.log(`PR #${number}: auto-merge already enabled`);
-                prsWithBase.push({ number, base, status: 'already_set' });
-                continue;
-              }
-              const mutation = `
-                mutation EnableAutoMerge {
-                  enablePullRequestAutoMerge(input: {
-                    pullRequestId: "${pr.node_id}",
-                    mergeMethod: SQUASH
-                  }) {
-                    clientMutationId
-                  }
-                }
-              `;
-              try {
-                await github.graphql(mutation);
-                console.log(`PR #${number} (base=${base}): enabled auto-merge (squash)`);
-                prsWithBase.push({ number, base, status: 'applied' });
-              } catch (err) {
-                console.error(`PR #${number}: failed to enable auto-merge:`, err.message);
-                prsWithBase.push({ number, base, status: 'error' });
-              }
+              if (pr.base.ref !== 'main') continue;
+              if (pr.labels?.some(l => l.name === 'automerge')) continue;
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['automerge']
+              });
+              core.info(`#${issue.number} (main): added automerge`);
+              added++;
             }
-
-            // Job summary: list of branches (base) with links to PRs and status
-            core.summary.addHeading(`PRs with ${prLabelFilter}`);
-            for (const { number, base, status } of prsWithBase) {
-              const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${number}`;
-              const suffix = status === 'skipped' ? ' _(skipped)_' : status === 'already_set' ? ' _(automerge already set)_' : status === 'error' ? ' _(failed to enable)_' : '';
-              core.summary.addRaw(`- \`${base}\`: [PR #${number}](${url})${suffix}`).addEol();
-            }
-            await core.summary.write();
+            core.info(`done; added automerge to ${added} PR(s)`);

--- a/.github/workflows/set_automerge_mute_unmute_prs.yml
+++ b/.github/workflows/set_automerge_mute_unmute_prs.yml
@@ -1,0 +1,102 @@
+# Sets automerge (label + enable squash merge) on open PRs that have the filter label.
+# Rules: main — only when run is at 7 UTC (once per day); stable-* — every run.
+name: Set automerge for mute-unmute PRs
+
+on:
+  schedule:
+    - cron: "0 4-21/1 * * *"   # Every hour 4–21 UTC (same window as update_muted_ya)
+  workflow_dispatch:
+
+env:
+  # Label that identifies PRs to process (we look for open PRs with this label)
+  PR_LABEL_FILTER: mute-unmute
+  # Label we add and use to gate auto-merge
+  AUTOMERGE_LABEL: automerge
+
+jobs:
+  set-automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get run hour UTC
+        id: hour
+        run: echo "hour=$(date -u +%H)" >> $GITHUB_OUTPUT
+
+      - name: Set automerge on qualifying PRs
+        uses: actions/github-script@v7
+        env:
+          RUN_HOUR_UTC: ${{ steps.hour.outputs.hour }}
+          PR_LABEL_FILTER: ${{ env.PR_LABEL_FILTER }}
+          AUTOMERGE_LABEL: ${{ env.AUTOMERGE_LABEL }}
+        with:
+          github-token: ${{ secrets.YDBOT_TOKEN }}
+          script: |
+            const runHourUtc = process.env.RUN_HOUR_UTC;
+            const prLabelFilter = process.env.PR_LABEL_FILTER;
+            const automergeLabel = process.env.AUTOMERGE_LABEL;
+
+            // List open PRs that have the filter label
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: prLabelFilter
+            });
+            const prNumbers = issues.filter(i => i.pull_request).map(i => i.number);
+            if (prNumbers.length === 0) {
+              console.log(`No open PRs with label ${prLabelFilter}`);
+              return;
+            }
+            console.log(`Found ${prNumbers.length} PR(s) with ${prLabelFilter}: ${prNumbers.join(', ')}`);
+
+            for (const number of prNumbers) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: number
+              });
+              const base = pr.base.ref;
+
+              // Main: automerge only for the 7 UTC run (PR ~8 UTC, ~10 min checks -> merge ~11 MSK)
+              // Stable branches: always automerge
+              const shouldAutomerge = (base === 'main' && runHourUtc === '07') || base.startsWith('stable-');
+              if (!shouldAutomerge) {
+                console.log(`PR #${number} (base=${base}): skip automerge (main only at 7 UTC, run hour=${runHourUtc})`);
+                continue;
+              }
+
+              // Add automerge label if missing
+              const hasLabel = pr.labels?.some(l => l.name === automergeLabel);
+              if (!hasLabel) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  labels: [automergeLabel]
+                });
+                console.log(`PR #${number} (base=${base}): added ${automergeLabel} label`);
+              } else {
+                console.log(`PR #${number} (base=${base}): already has ${automergeLabel} label`);
+              }
+
+              // Enable squash auto-merge if not already enabled
+              if (pr.auto_merge) {
+                console.log(`PR #${number}: auto-merge already enabled`);
+                continue;
+              }
+              const mutation = `
+                mutation EnableAutoMerge {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: "${pr.node_id}",
+                    mergeMethod: SQUASH
+                  }) {
+                    clientMutationId
+                  }
+                }
+              `;
+              try {
+                await github.graphql(mutation);
+                console.log(`PR #${number} (base=${base}): enabled auto-merge (squash)`);
+              } catch (err) {
+                console.error(`PR #${number}: failed to enable auto-merge:`, err.message);
+              }
+            }

--- a/.github/workflows/set_automerge_mute_unmute_prs.yml
+++ b/.github/workflows/set_automerge_mute_unmute_prs.yml
@@ -47,12 +47,16 @@ jobs:
             const automergeLabel = process.env.AUTOMERGE_LABEL;
 
             // List open PRs that have the filter label
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: prLabelFilter
-            });
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: prLabelFilter,
+                per_page: 100,
+              }
+            );
             const prNumbers = issues.filter(i => i.pull_request).map(i => i.number);
             if (prNumbers.length === 0) {
               console.log(`No open PRs with label ${prLabelFilter}`);

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -2,7 +2,7 @@ name: Update Muted tests
 
 on:
   schedule:
-    - cron: "0 4-21/1 * * *"  # Every 1 hours from 4:00 to 21:00 UTC
+    - cron: "0 4-21/1 * * *"  # Every hour from 4:00 to 21:00 UTC
   workflow_dispatch:
     inputs:
       branches:
@@ -296,6 +296,7 @@ jobs:
         env:
           LABELS: ${{ env.LABELS }}
           REVIEWERS: ${{ env.REVIEWERS }}
+          BASE_BRANCH: ${{ matrix.BASE_BRANCH }}
         with:
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
@@ -311,8 +312,11 @@ jobs:
               body: commentBody
             });
 
-            // Base labels from env LABELS. Automerge is set by set_automerge_mute_unmute_prs workflow.
+            // Labels from env; for stable-* add automerge (automerge_pr merges after checks).
             const labelsToAdd = process.env.LABELS.split(',').map(l => l.trim());
+            if (process.env.BASE_BRANCH.startsWith('stable-')) {
+              labelsToAdd.push('automerge');
+            }
             core.info(`Applying labels: ${labelsToAdd.join(', ')}`);
             await github.rest.issues.addLabels({
               ...context.repo,
@@ -320,7 +324,7 @@ jobs:
               labels: labelsToAdd
             });
 
-            // Add reviewers from env REVIEWERS
+            // Request reviewers from env
             const reviewers = JSON.parse(process.env.REVIEWERS);
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
@@ -328,4 +332,33 @@ jobs:
               pull_number: ${{ steps.create_or_update_pr.outputs.pr_number }},
               team_reviewers: reviewers
             });
+
+      - name: Enable auto-merge (squash)
+        if: env.changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.YDBOT_TOKEN }}
+          script: |
+            const pr = ${{ steps.create_or_update_pr.outputs.pr_number }};
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr
+            });
+            const mutation = `
+              mutation EnableAutoMerge {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: "${pullRequest.node_id}",
+                  mergeMethod: SQUASH
+                }) {
+                  clientMutationId
+                }
+              }
+            `;
+            try {
+              await github.graphql(mutation);
+              console.log("Auto-merge with squash successfully enabled");
+            } catch (error) {
+              console.error("Failed to enable auto-merge with squash:", error);
+            }
 

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -299,52 +299,31 @@ jobs:
         env:
           LABELS: ${{ env.LABELS }}
           REVIEWERS: ${{ env.REVIEWERS }}
-          BASE_BRANCH: ${{ matrix.BASE_BRANCH }}
-          RUN_HOUR_UTC: ${{ needs.setup.outputs.run_hour_utc }}
         with:
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
             const fs = require('fs');
-            
-            // Read comment from file
+
+            // Read comment from file and post to PR
             const commentFile = '${{ steps.comment_pr.outputs.PR_COMMENT_FILE }}';
             const commentBody = fs.readFileSync(commentFile, 'utf8');
-            
-            // Add comment to PR
             await github.rest.issues.createComment({
               issue_number: ${{ steps.create_or_update_pr.outputs.pr_number }},
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: commentBody
             });
-            
-            const baseBranch = process.env.BASE_BRANCH;
-            const runHourUtc = process.env.RUN_HOUR_UTC;
-            core.info(`Labels: base_branch=${baseBranch}, run_hour_utc=${runHourUtc}`);
 
-            // Base labels
+            // Base labels from env LABELS. Automerge is set by set_automerge_mute_unmute_prs workflow.
             const labelsToAdd = process.env.LABELS.split(',').map(l => l.trim());
-
-            // Main: automerge only for the 7 UTC run (PR ~8 UTC, ~10 min checks -> merge ~11 MSK)
-            if (baseBranch === 'main' && runHourUtc === '07') {
-              labelsToAdd.push('automerge');
-              core.info(`Added 'automerge' (main, 7 UTC run - merge ~11 MSK).`);
-            }
-
-            // Stable branches: always automerge
-            if (baseBranch.startsWith('stable-')) {
-              labelsToAdd.push('automerge');
-              core.info(`Added 'automerge' (base is stable-*).`);
-            }
-
             core.info(`Applying labels: ${labelsToAdd.join(', ')}`);
             await github.rest.issues.addLabels({
               ...context.repo,
               issue_number: ${{ steps.create_or_update_pr.outputs.pr_number }},
               labels: labelsToAdd
             });
-            
-            // Add reviewers
+
+            // Add reviewers from env REVIEWERS
             const reviewers = JSON.parse(process.env.REVIEWERS);
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
@@ -352,36 +331,4 @@ jobs:
               pull_number: ${{ steps.create_or_update_pr.outputs.pr_number }},
               team_reviewers: reviewers
             });
-
-      - name: Enable auto-merge (squash)
-        if: env.changes == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.YDBOT_TOKEN }}
-          script: |
-            const pr = ${{ steps.create_or_update_pr.outputs.pr_number }};
-            
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr
-            });
-            
-            const mutation = `
-              mutation EnableAutoMerge {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: "${pullRequest.node_id}",
-                  mergeMethod: SQUASH
-                }) {
-                  clientMutationId
-                }
-              }
-            `;
-            
-            try {
-              await github.graphql(mutation);
-              console.log("Auto-merge with squash successfully enabled");
-            } catch (error) {
-              console.error("Failed to enable auto-merge with squash:", error);
-            }
 

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -313,7 +313,9 @@ jobs:
             });
 
             // Labels from env; for stable-* add automerge (automerge_pr merges after checks).
-            const labelsToAdd = process.env.LABELS.split(',').map(l => l.trim());
+            const labelsToAdd = Array.from(new Set(
+              (process.env.LABELS || '').split(',').map(l => l.trim()).filter(l => l)
+            ));
             if (process.env.BASE_BRANCH.startsWith('stable-')) {
               labelsToAdd.push('automerge');
             }

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -296,6 +296,7 @@ jobs:
         env:
           LABELS: ${{ env.LABELS }}
           REVIEWERS: ${{ env.REVIEWERS }}
+          BASE_BRANCH: ${{ matrix.BASE_BRANCH }}
         with:
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
@@ -313,8 +314,11 @@ jobs:
               body: commentBody
             });
             
-            // Добавляем лейблы
-            const labelsToAdd = process.env.LABELS.split(',');
+            // Лейблы: базовые + automerge для stable-* (слияние через automerge_pr workflow после прохождения checks_integrated)
+            const labelsToAdd = process.env.LABELS.split(',').map(l => l.trim());
+            if (process.env.BASE_BRANCH.startsWith('stable-')) {
+              labelsToAdd.push('automerge');
+            }
             await github.rest.issues.addLabels({
               ...context.repo,
               issue_number: ${{ steps.create_or_update_pr.outputs.pr_number }},
@@ -329,7 +333,7 @@ jobs:
               pull_number: ${{ steps.create_or_update_pr.outputs.pr_number }},
               team_reviewers: reviewers
             });
-          
+
       - name: Enable auto-merge (squash)
         if: env.changes == 'true'
         uses: actions/github-script@v7

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -24,10 +24,7 @@ jobs:
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     outputs:
       matrix_branches: ${{ steps.set-matrix.outputs.branches }}
-      run_hour_utc: ${{ steps.utc-hour.outputs.hour }}
     steps:
-      - id: utc-hour
-        run: echo "hour=$(date -u +%H)" >> $GITHUB_OUTPUT
       - name: Checkout branches config
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -313,9 +313,10 @@ jobs:
             });
 
             // Labels from env; for stable-* add automerge (automerge_pr merges after checks).
-            const labelsToAdd = Array.from(new Set(
-              (process.env.LABELS || '').split(',').map(l => l.trim()).filter(l => l)
-            ));
+            const labelsToAdd = (process.env.LABELS || "")
+              .split(',')
+              .map(l => l.trim())
+              .filter(l => l);
             if (process.env.BASE_BRANCH.startsWith('stable-')) {
               labelsToAdd.push('automerge');
             }

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -24,7 +24,10 @@ jobs:
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     outputs:
       matrix_branches: ${{ steps.set-matrix.outputs.branches }}
+      run_hour_utc: ${{ steps.utc-hour.outputs.hour }}
     steps:
+      - id: utc-hour
+        run: echo "hour=$(date -u +%H)" >> $GITHUB_OUTPUT
       - name: Checkout branches config
         uses: actions/checkout@v4
         with:
@@ -297,6 +300,7 @@ jobs:
           LABELS: ${{ env.LABELS }}
           REVIEWERS: ${{ env.REVIEWERS }}
           BASE_BRANCH: ${{ matrix.BASE_BRANCH }}
+          RUN_HOUR_UTC: ${{ needs.setup.outputs.run_hour_utc }}
         with:
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
@@ -314,11 +318,23 @@ jobs:
               body: commentBody
             });
             
-            // Лейблы: базовые + automerge для stable-* (слияние через automerge_pr workflow после прохождения checks_integrated)
+            // Лейблы: базовые + automerge для stable-* и для main при запуске в 7 UTC (раз в сутки)
+            const baseBranch = process.env.BASE_BRANCH;
+            const runHourUtc = process.env.RUN_HOUR_UTC;
+            core.info(`Labels: base_branch=${baseBranch}, run_hour_utc=${runHourUtc}`);
             const labelsToAdd = process.env.LABELS.split(',').map(l => l.trim());
-            if (process.env.BASE_BRANCH.startsWith('stable-')) {
+            if (baseBranch.startsWith('stable-')) {
               labelsToAdd.push('automerge');
+              core.info(`Added 'automerge' (base is stable-*).`);
             }
+            if (baseBranch === 'main' && runHourUtc === '07') {
+              labelsToAdd.push('automerge');
+              core.info(`Added 'automerge' (main, 7 UTC run — daily auto-merge).`);
+            }
+            if (!labelsToAdd.includes('automerge')) {
+              core.info(`No automerge for this PR (main only gets automerge at 7 UTC).`);
+            }
+            core.info(`Applying labels: ${labelsToAdd.join(', ')}`);
             await github.rest.issues.addLabels({
               ...context.repo,
               issue_number: ${{ steps.create_or_update_pr.outputs.pr_number }},

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -92,7 +92,7 @@ jobs:
           PR_BRANCH="${{ env.PR_BRANCH_PREFIX }}_${{ matrix.BASE_BRANCH }}"
           echo "PR_BRANCH=${PR_BRANCH}" >> $GITHUB_ENV
 
-      # Всегда checkout main для получения актуальных скриптов
+      # Always checkout main to get up-to-date scripts
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
@@ -110,7 +110,7 @@ jobs:
         with:
           ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
 
-      # Получаем base_muted_ya.txt из целевой ветки
+      # Get base_muted_ya.txt from target branch
       - name: Get base muted_ya.txt from target branch
         run: |
           echo "Getting base muted_ya.txt from branch: ${{ env.BASE_BRANCH }}"
@@ -154,13 +154,13 @@ jobs:
       - name: Create PR branch and apply changes
         if: env.changes == 'true'
         run: |
-          # Создаем PR ветку на основе целевой ветки
+          # Create PR branch from target branch
           git checkout -B ${{ env.PR_BRANCH }} origin/${{ env.BASE_BRANCH }}
           
-          # Копируем новый файл в PR ветку (файл остается в рабочей директории)
+          # Copy new file into PR branch (file stays in working dir)
           cp mute_update/new_muted_ya.txt .github/config/muted_ya.txt
           
-          # Коммитим изменения
+          # Commit changes
           git add .github/config/muted_ya.txt
           git commit -m "Update muted YA file for ${{ env.BASE_BRANCH }}"
           
@@ -267,7 +267,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.YDBOT_TOKEN }}
         run: |
-          # Возвращаемся на main для доступа к скриптам
+          # Checkout main again for script access
           git checkout main
           
           python .github/scripts/create_or_update_pr.py create_or_update \
@@ -280,7 +280,7 @@ jobs:
         if: env.changes == 'true'
         id: comment_pr
         run: |
-          # Читаем содержимое PR body
+          # Read PR body content
           PR_BODY_CONTENT=$(cat pr_body_content.txt)
           WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           COMPLETE_BODY=$(cat << EOF
@@ -306,11 +306,11 @@ jobs:
           script: |
             const fs = require('fs');
             
-            // Читаем комментарий из файла
+            // Read comment from file
             const commentFile = '${{ steps.comment_pr.outputs.PR_COMMENT_FILE }}';
             const commentBody = fs.readFileSync(commentFile, 'utf8');
             
-            // Добавляем комментарий
+            // Add comment to PR
             await github.rest.issues.createComment({
               issue_number: ${{ steps.create_or_update_pr.outputs.pr_number }},
               owner: context.repo.owner,
@@ -318,22 +318,25 @@ jobs:
               body: commentBody
             });
             
-            // Лейблы: базовые + automerge для stable-* и для main при запуске в 7 UTC (раз в сутки)
             const baseBranch = process.env.BASE_BRANCH;
             const runHourUtc = process.env.RUN_HOUR_UTC;
             core.info(`Labels: base_branch=${baseBranch}, run_hour_utc=${runHourUtc}`);
+
+            // Base labels
             const labelsToAdd = process.env.LABELS.split(',').map(l => l.trim());
+
+            // Main: automerge only for the 7 UTC run (PR ~8 UTC, ~10 min checks -> merge ~11 MSK)
+            if (baseBranch === 'main' && runHourUtc === '07') {
+              labelsToAdd.push('automerge');
+              core.info(`Added 'automerge' (main, 7 UTC run - merge ~11 MSK).`);
+            }
+
+            // Stable branches: always automerge
             if (baseBranch.startsWith('stable-')) {
               labelsToAdd.push('automerge');
               core.info(`Added 'automerge' (base is stable-*).`);
             }
-            if (baseBranch === 'main' && runHourUtc === '07') {
-              labelsToAdd.push('automerge');
-              core.info(`Added 'automerge' (main, 7 UTC run — daily auto-merge).`);
-            }
-            if (!labelsToAdd.includes('automerge')) {
-              core.info(`No automerge for this PR (main only gets automerge at 7 UTC).`);
-            }
+
             core.info(`Applying labels: ${labelsToAdd.join(', ')}`);
             await github.rest.issues.addLabels({
               ...context.repo,
@@ -341,7 +344,7 @@ jobs:
               labels: labelsToAdd
             });
             
-            // Добавляем ревьюеров
+            // Add reviewers
             const reviewers = JSON.parse(process.env.REVIEWERS);
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

## Summary

Extracted auto-merge logic into a separate scheduled workflow to avoid race conditions and improve maintainability.

## Changes

- **New workflow**: `.github/workflows/automerge_for_muted_ya.yml`
  - Runs hourly  at hh-15 min (4-21 UTC, same as `update_muted_ya`)
  - Finds open PRs with `mute-unmute` label
  - Adds `automerge` label + enables squash auto-merge
  - For `main` branch: only runs at 7 UTC (once per day)
  - For `stable-*` branches: runs every time

- **Updated workflow**: `.github/workflows/update_muted_ya.yml`
  - Removed inline auto-merge step (was causing race conditions)
  - Now only adds base labels (`mute-unmute`, `do-not-merge/waiting-for-tests`)
  - Auto-merge is handled by the separate scheduled workflow
  - Minor: replaced Russian comments with English


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
