### PR TITLE
Fix FS storage races

### DIFF
--- a/ydb/core/wrappers/fs_storage.cpp
+++ b/ydb/core/wrappers/fs_storage.cpp
@@ -559,7 +559,6 @@ public:
                         << ", file# " << filePath);
                 }
                 ActiveUploads.erase(it);
-                session.File.Close();
 
                 FS_LOG_I("AbortMultipartUpload"
                     << ": uploadId# " << uploadId

--- a/ydb/core/wrappers/fs_storage.cpp
+++ b/ydb/core/wrappers/fs_storage.cpp
@@ -149,21 +149,27 @@ public:
 
 private:
     void CleanupActiveSessions() {
-        FS_LOG_D("TFsOperationActor: cleaning up"
-            << ": active MPU sessions# " << ActiveUploads.size());
+        if (TlsActivationContext) {
+            FS_LOG_D("TFsOperationActor: cleaning up"
+                << ": active MPU sessions# " << ActiveUploads.size());
+        }
         for (auto& [uploadId, session] : ActiveUploads) {
             try {
                 const TString filePath = session.Key;
                 NFs::Remove(filePath);
                 session.File.Close();
 
-                FS_LOG_T("TFsOperationActor: closed and deleted incomplete file"
-                    << ": uploadId# " << uploadId
-                    << ", file# " << filePath);
+                if (TlsActivationContext) {
+                    FS_LOG_T("TFsOperationActor: closed and deleted incomplete file"
+                        << ": uploadId# " << uploadId
+                        << ", file# " << filePath);
+                }
             } catch (const std::exception& ex) {
-                FS_LOG_W("Failed to cleanup MPU session"
-                    << ": uploadId# " << uploadId
-                    << ", error# " << ex.what());
+                if (TlsActivationContext) {
+                    FS_LOG_W("Failed to cleanup MPU session"
+                        << ": uploadId# " << uploadId
+                        << ", error# " << ex.what());
+                }
             }
         }
         ActiveUploads.clear();

--- a/ydb/core/wrappers/fs_storage.cpp
+++ b/ydb/core/wrappers/fs_storage.cpp
@@ -59,10 +59,13 @@ private:
         return RequiresKey<TEvResponse>::value;
     }
 
-    static void FsyncParentDir(const TString& filePath) {
-        TFsPath parent = TFsPath(filePath).Parent();
-        TFile dirFd(parent.GetPath(), RdOnly | Seq);
+    static void FsyncParentDir(const TFsPath& fsPath) {
+        TFile dirFd(fsPath.Parent().GetPath(), RdOnly | Seq);
         dirFd.Flush();
+    }
+
+    static void FsyncParentDir(const TString& filePath) {
+        FsyncParentDir(TFsPath(filePath));
     }
 
     template<typename TEvResponse>
@@ -211,7 +214,7 @@ public:
             TMultipartUploadSession session(key);
             session.File.Write(body.data(), body.size());
             session.File.Flush();
-            FsyncParentDir(key);
+            FsyncParentDir(fsPath);
             session.File.Close();
             ReplySuccess<TEvPutObjectResponse>(ev->Sender, key);
         } catch (const TSystemError& ex) {

--- a/ydb/core/wrappers/fs_storage.cpp
+++ b/ydb/core/wrappers/fs_storage.cpp
@@ -59,6 +59,12 @@ private:
         return RequiresKey<TEvResponse>::value;
     }
 
+    static void FsyncParentDir(const TString& filePath) {
+        TFsPath parent = TFsPath(filePath).Parent();
+        TFile dirFd(parent.GetPath(), RdOnly | Seq);
+        dirFd.Flush();
+    }
+
     template<typename TEvResponse>
     void ReplySuccess(const NActors::TActorId& sender, const std::optional<TString>& key) {
         typename TEvResponse::TAwsResult awsResult;
@@ -202,11 +208,11 @@ public:
             TFsPath fsPath(key);
             fsPath.Parent().MkDirs();
 
-            TFile file(fsPath.GetPath(), CreateAlways | WrOnly);
-            file.Flock(LOCK_EX | LOCK_NB);
-            file.Write(body.data(), body.size());
-            file.Flush();
-            file.Close();
+            TMultipartUploadSession session(key);
+            session.File.Write(body.data(), body.size());
+            session.File.Flush();
+            FsyncParentDir(key);
+            session.File.Close();
             ReplySuccess<TEvPutObjectResponse>(ev->Sender, key);
         } catch (const TSystemError& ex) {
             if (!HandleFileLockError<TEvPutObjectResponse>(ex, ev->Sender, key, "PutObject")) {
@@ -503,6 +509,7 @@ public:
             session.File.Flush();
 
             NFs::Rename(incompleteKey, key);
+            FsyncParentDir(key);
             session.File.Close();
 
             FS_LOG_I("CompleteMultipartUpload"
@@ -545,9 +552,14 @@ public:
                 auto& session = it->second;
                 const TString filePath = session.Key;
 
-                NFs::Remove(filePath);
-                session.File.Close();
+                bool removed = NFs::Remove(filePath);
+                if (!removed) {
+                    FS_LOG_W("AbortMultipartUpload: failed to delete incomplete file"
+                        << ": uploadId# " << uploadId
+                        << ", file# " << filePath);
+                }
                 ActiveUploads.erase(it);
+                session.File.Close();
 
                 FS_LOG_I("AbortMultipartUpload"
                     << ": uploadId# " << uploadId

--- a/ydb/core/wrappers/fs_storage.cpp
+++ b/ydb/core/wrappers/fs_storage.cpp
@@ -23,6 +23,12 @@ namespace NKikimr::NWrappers::NExternalStorage {
 #define FS_LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::FS_WRAPPER, stream)
 #define FS_LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::FS_WRAPPER, stream)
 
+#define FS_LOG_T_SAFE(stream) do { if (TlsActivationContext) { FS_LOG_T(stream); } } while (false)
+#define FS_LOG_I_SAFE(stream) do { if (TlsActivationContext) { FS_LOG_I(stream); } } while (false)
+#define FS_LOG_D_SAFE(stream) do { if (TlsActivationContext) { FS_LOG_D(stream); } } while (false)
+#define FS_LOG_W_SAFE(stream) do { if (TlsActivationContext) { FS_LOG_W(stream); } } while (false)
+#define FS_LOG_E_SAFE(stream) do { if (TlsActivationContext) { FS_LOG_E(stream); } } while (false)
+
 namespace {
 
 class TFsOperationActor : public TActorBootstrapped<TFsOperationActor> {
@@ -149,27 +155,21 @@ public:
 
 private:
     void CleanupActiveSessions() {
-        if (TlsActivationContext) {
-            FS_LOG_D("TFsOperationActor: cleaning up"
-                << ": active MPU sessions# " << ActiveUploads.size());
-        }
+        FS_LOG_D_SAFE("TFsOperationActor: cleaning up"
+            << ": active MPU sessions# " << ActiveUploads.size());
         for (auto& [uploadId, session] : ActiveUploads) {
             try {
                 const TString filePath = session.Key;
                 NFs::Remove(filePath);
                 session.File.Close();
 
-                if (TlsActivationContext) {
-                    FS_LOG_T("TFsOperationActor: closed and deleted incomplete file"
-                        << ": uploadId# " << uploadId
-                        << ", file# " << filePath);
-                }
+                FS_LOG_T_SAFE("TFsOperationActor: closed and deleted incomplete file"
+                    << ": uploadId# " << uploadId
+                    << ", file# " << filePath);
             } catch (const std::exception& ex) {
-                if (TlsActivationContext) {
-                    FS_LOG_W("Failed to cleanup MPU session"
-                        << ": uploadId# " << uploadId
-                        << ", error# " << ex.what());
-                }
+                FS_LOG_W_SAFE("Failed to cleanup MPU session"
+                    << ": uploadId# " << uploadId
+                    << ", error# " << ex.what());
             }
         }
         ActiveUploads.clear();

--- a/ydb/core/wrappers/fs_storage_ut.cpp
+++ b/ydb/core/wrappers/fs_storage_ut.cpp
@@ -34,7 +34,7 @@ protected:
         settings.SetBasePath(TempDir->Name());
         auto config = std::make_shared<TFsExternalStorageConfig>(settings);
 
-        Wrapper = Runtime->Register(NWrappers::CreateS3Wrapper(config->ConstructStorageOperator()));
+        Wrapper = Runtime->Register(NWrappers::CreateStorageWrapper(config->ConstructStorageOperator()));
         Edge = Runtime->AllocateEdgeActor();
     }
 

--- a/ydb/core/wrappers/fs_storage_ut.cpp
+++ b/ydb/core/wrappers/fs_storage_ut.cpp
@@ -6,7 +6,6 @@
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/wrappers/events/common.h>
-#include <ydb/core/wrappers/events/get_object.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -78,36 +77,39 @@ class TFsStorageTests : public TFsStorageTestBase {
 public:
     void PutObjectDoesNotTruncateLockedFile() {
         const TString key = KeyPath("data.csv");
-        const TString originalContent = "generation1_data_long_enough_to_notice_truncation";
-        const TString newContent      = "generation2_short";
+        const TVector<TString> originalContent = {"generation1.0", "generation1.1"};
+        const TString newContent      = "generation2";
 
         {
             TFileOutput f(key);
-            f.Write(originalContent);
+            f.Write(originalContent[0]);
         }
 
         TFile externalLock(key, OpenExisting | RdWr);
         externalLock.Flock(LOCK_EX | LOCK_NB);
 
-        auto result = PutObject(key, newContent);
-        UNIT_ASSERT_C(!result.IsSuccess(),
-            "Expected PutObject to fail while file is locked by external holder");
-        UNIT_ASSERT_C(result.GetError().ShouldRetry(),
-            "Expected retryable EWOULDBLOCK error, got: " << result.GetError().GetMessage());
-
         {
+            auto result = PutObject(key, newContent);
+            UNIT_ASSERT(!result.IsSuccess());
+            UNIT_ASSERT(result.GetError().ShouldRetry());
+
             TFileInput f(key);
             const TString actualContent = f.ReadAll();
-            UNIT_ASSERT_VALUES_EQUAL(actualContent, originalContent);
+            UNIT_ASSERT_VALUES_EQUAL(actualContent, originalContent[0]);
+        }
+
+        {
+            TFileOutput f(key);
+            f.Write(originalContent[1]);
         }
 
         externalLock.Flock(LOCK_UN);
         externalLock.Close();
 
-        auto result2 = PutObject(key, newContent);
-        UNIT_ASSERT_C(result2.IsSuccess(), result2.GetError().GetMessage());
-
         {
+            auto result = PutObject(key, newContent);
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetError().GetMessage());
+
             TFileInput f(key);
             UNIT_ASSERT_VALUES_EQUAL(f.ReadAll(), newContent);
         }

--- a/ydb/core/wrappers/fs_storage_ut.cpp
+++ b/ydb/core/wrappers/fs_storage_ut.cpp
@@ -22,10 +22,6 @@ using namespace NKikimr::NWrappers;
 using namespace NKikimr::NWrappers::NExternalStorage;
 using namespace Aws::S3::Model;
 
-// ---------------------------------------------------------------------------
-// Base test fixture
-// ---------------------------------------------------------------------------
-
 class TFsStorageTestBase : public NUnitTest::TTestBase {
 protected:
     void SetUp() override {
@@ -44,18 +40,10 @@ protected:
     }
 
     void TearDown() override {
-        // Do NOT send explicit Poison here: Runtime.Reset() destroys all actors
-        // via the actor system cleanup path where TlsActivationContext is null,
-        // so TFsExternalStorage::Shutdown() exits early (the null-check guards it).
-        // Sending Poison first and then immediately calling Reset() races with the
-        // runtime destructor, causing Shutdown() to Send() to an actor that is
-        // concurrently being destroyed → SIGSEGV.
         Runtime.Reset();
         TempDir.Reset();
     }
 
-    // Absolute path inside the temp directory that is used as the S3 "key"
-    // (fs_storage uses the key directly as a filesystem path).
     TString KeyPath(const TString& name) const {
         return (TFsPath(TempDir->Name()) / name).GetPath();
     }
@@ -66,81 +54,10 @@ protected:
         return Runtime->GrabEdgeEvent<TEvResponse>(Edge);
     }
 
-    // --- request helpers ---
-
     auto PutObject(const TString& key, TString body) {
         auto request = PutObjectRequest().WithKey(key);
         auto response = Send<TEvPutObjectResponse>(
             new TEvPutObjectRequest(request, std::move(body)));
-        UNIT_ASSERT(response->Get());
-        return response->Get()->Result;
-    }
-
-    auto HeadObject(const TString& key) {
-        auto request = HeadObjectRequest().WithKey(key);
-        auto response = Send<TEvHeadObjectResponse>(
-            new TEvHeadObjectRequest(request));
-        UNIT_ASSERT(response->Get());
-        return response->Get()->Result;
-    }
-
-    // Returns {Result, Body}
-    auto GetObject(const TString& key) {
-        auto request = GetObjectRequest().WithKey(key);
-        auto response = Send<TEvGetObjectResponse>(
-            new TEvGetObjectRequest(request));
-        UNIT_ASSERT(response->Get());
-        return std::make_pair(response->Get()->Result, response->Get()->Body);
-    }
-
-    auto GetObjectRange(const TString& key, ui64 from, ui64 to) {
-        auto request = GetObjectRequest()
-            .WithKey(key)
-            .WithRange(TStringBuilder() << "bytes=" << from << "-" << to);
-        auto response = Send<TEvGetObjectResponse>(
-            new TEvGetObjectRequest(request));
-        UNIT_ASSERT(response->Get());
-        return std::make_pair(response->Get()->Result, response->Get()->Body);
-    }
-
-    auto CreateMultipartUpload(const TString& key) {
-        auto request = CreateMultipartUploadRequest().WithKey(key);
-        auto response = Send<TEvCreateMultipartUploadResponse>(
-            new TEvCreateMultipartUploadRequest(request));
-        UNIT_ASSERT(response->Get());
-        return response->Get()->Result;
-    }
-
-    auto UploadPart(const TString& key, const TString& uploadId, int partNumber, TString body) {
-        auto request = UploadPartRequest()
-            .WithKey(key)
-            .WithUploadId(uploadId)
-            .WithPartNumber(partNumber);
-        auto response = Send<TEvUploadPartResponse>(
-            new TEvUploadPartRequest(request, std::move(body)));
-        UNIT_ASSERT(response->Get());
-        return response->Get()->Result;
-    }
-
-    auto CompleteMultipartUpload(const TString& key, const TString& uploadId,
-                                 const TVector<CompletedPart>& parts)
-    {
-        auto request = CompleteMultipartUploadRequest()
-            .WithKey(key)
-            .WithUploadId(uploadId)
-            .WithMultipartUpload(CompletedMultipartUpload().WithParts(parts));
-        auto response = Send<TEvCompleteMultipartUploadResponse>(
-            new TEvCompleteMultipartUploadRequest(request));
-        UNIT_ASSERT(response->Get());
-        return response->Get()->Result;
-    }
-
-    auto AbortMultipartUpload(const TString& key, const TString& uploadId) {
-        auto request = AbortMultipartUploadRequest()
-            .WithKey(key)
-            .WithUploadId(uploadId);
-        auto response = Send<TEvAbortMultipartUploadResponse>(
-            new TEvAbortMultipartUploadRequest(request));
         UNIT_ASSERT(response->Get());
         return response->Get()->Result;
     }
@@ -152,150 +69,48 @@ protected:
     TActorId Edge;
 };
 
-// ---------------------------------------------------------------------------
-// Test suite
-// ---------------------------------------------------------------------------
-
 class TFsStorageTests : public TFsStorageTestBase {
     UNIT_TEST_SUITE(TFsStorageTests);
 
-    // Group 2 – race / lock tests
     UNIT_TEST(PutObjectDoesNotTruncateLockedFile);
-    UNIT_TEST(PutObjectReturnsRetryableErrorWhenFileLocked);
-    UNIT_TEST(MultipartUploadReturnsRetryableErrorWhenFileLocked);
-
     UNIT_TEST_SUITE_END();
 
 public:
-    // -----------------------------------------------------------------------
-    // Group 2 – race / lock tests
-    // -----------------------------------------------------------------------
-
-    // TC-2.1: BUG-1 — PutObject must NOT truncate a file before acquiring the lock.
-    //
-    // Scenario: "generation 1" holds the file open with LOCK_EX (simulates a DataShard
-    // that is still writing).  "Generation 2" sends a PutObject to the same key.
-    //
-    // Before the fix (CreateAlways | WrOnly): the file was truncated to zero at open
-    // time, BEFORE flock — so generation 1's data was silently destroyed.
-    //
-    // After the fix (OpenAlways | WrOnly | ForAppend + Flock + Resize(0)): the file
-    // is not touched until the lock is held, so generation 1's data survives.
     void PutObjectDoesNotTruncateLockedFile() {
         const TString key = KeyPath("data.csv");
         const TString originalContent = "generation1_data_long_enough_to_notice_truncation";
         const TString newContent      = "generation2_short";
 
-        // Step 1: write "generation1" content directly (simulates a completed previous write)
         {
             TFileOutput f(key);
             f.Write(originalContent);
         }
 
-        // Step 2: acquire an external exclusive lock (simulates a DataShard generation
-        // that still holds the file open while exporting)
         TFile externalLock(key, OpenExisting | RdWr);
         externalLock.Flock(LOCK_EX | LOCK_NB);
 
-        // Step 3-4: PutObject from generation 2 — must fail with a retryable error
         auto result = PutObject(key, newContent);
         UNIT_ASSERT_C(!result.IsSuccess(),
             "Expected PutObject to fail while file is locked by external holder");
         UNIT_ASSERT_C(result.GetError().ShouldRetry(),
             "Expected retryable EWOULDBLOCK error, got: " << result.GetError().GetMessage());
 
-        // Step 5 — KEY CHECK: file content must NOT have been truncated.
-        // Before the fix PutObject used CreateAlways which truncates at open time
-        // (before flock), destroying generation 1's data even though the lock
-        // was never granted.
         {
             TFileInput f(key);
             const TString actualContent = f.ReadAll();
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                actualContent, originalContent,
-                "BUG-1 regression: file was truncated before lock was acquired!"
-                " actual_size=" << actualContent.size()
-                    << " expected_size=" << originalContent.size());
+            UNIT_ASSERT_VALUES_EQUAL(actualContent, originalContent);
         }
 
-        // Step 6: release the external lock
         externalLock.Flock(LOCK_UN);
         externalLock.Close();
 
-        // Step 7: retry PutObject — must now succeed
         auto result2 = PutObject(key, newContent);
         UNIT_ASSERT_C(result2.IsSuccess(), result2.GetError().GetMessage());
 
-        // Step 8: verify the new content is written correctly
         {
             TFileInput f(key);
             UNIT_ASSERT_VALUES_EQUAL(f.ReadAll(), newContent);
         }
-    }
-
-    // TC-2.2: error code returned when file is locked must be retryable
-    void PutObjectReturnsRetryableErrorWhenFileLocked() {
-        const TString key = KeyPath("locked.csv");
-
-        // Create the file first so flock can open it
-        {
-            TFileOutput f(key);
-            f.Write("existing");
-        }
-
-        TFile externalLock(key, OpenExisting | RdWr);
-        externalLock.Flock(LOCK_EX | LOCK_NB);
-
-        auto result = PutObject(key, "new_data");
-        UNIT_ASSERT(!result.IsSuccess());
-        UNIT_ASSERT_C(result.GetError().ShouldRetry(),
-            "Lock contention must produce a retryable error so the caller backs off and retries");
-
-        externalLock.Flock(LOCK_UN);
-        externalLock.Close();
-    }
-
-    // TC-2.3: CreateMultipartUpload must also return a retryable error when the
-    // .incomplete file is already locked (e.g. previous generation still writing)
-    void MultipartUploadReturnsRetryableErrorWhenFileLocked() {
-        const TString key            = KeyPath("mpu.csv");
-        const TString incompletePath = key + ".incomplete";
-
-        // Pre-create .incomplete and lock it
-        {
-            TFileOutput f(incompletePath);
-            f.Write("in_progress_data");
-        }
-        TFile externalLock(incompletePath, OpenExisting | RdWr);
-        externalLock.Flock(LOCK_EX | LOCK_NB);
-
-        auto result = CreateMultipartUpload(key);
-        UNIT_ASSERT(!result.IsSuccess());
-        UNIT_ASSERT_C(result.GetError().ShouldRetry(),
-            "Lock contention on .incomplete must produce a retryable error");
-
-        externalLock.Flock(LOCK_UN);
-        externalLock.Close();
-
-        // After releasing the lock a new MPU session must succeed
-        {
-            auto result2 = CreateMultipartUpload(key);
-            UNIT_ASSERT_C(result2.IsSuccess(), result2.GetError().GetMessage());
-
-            const TString uploadId = result2.GetResult().GetUploadId().c_str();
-            TVector<CompletedPart> parts;
-
-            auto up = UploadPart(key, uploadId, 1, "data");
-            UNIT_ASSERT_C(up.IsSuccess(), up.GetError().GetMessage());
-            parts.push_back(CompletedPart().WithPartNumber(1).WithETag(up.GetResult().GetETag()));
-
-            auto cmpl = CompleteMultipartUpload(key, uploadId, parts);
-            UNIT_ASSERT_C(cmpl.IsSuccess(), cmpl.GetError().GetMessage());
-        }
-
-        auto [getResult, body] = GetObject(key);
-        UNIT_ASSERT_C(getResult.IsSuccess(), getResult.GetError().GetMessage());
-        UNIT_ASSERT_VALUES_EQUAL(body, "data");
     }
 };
 

--- a/ydb/core/wrappers/fs_storage_ut.cpp
+++ b/ydb/core/wrappers/fs_storage_ut.cpp
@@ -1,0 +1,302 @@
+#include "fs_storage_config.h"
+#include "s3_wrapper.h"
+
+#include <ydb/core/protos/fs_settings.pb.h>
+#include <ydb/library/services/services.pb.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/wrappers/events/common.h>
+#include <ydb/core/wrappers/events/get_object.h>
+
+#include <ydb/library/actors/core/log.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/folder/path.h>
+#include <util/folder/tempdir.h>
+#include <util/stream/file.h>
+#include <util/system/file.h>
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NWrappers;
+using namespace NKikimr::NWrappers::NExternalStorage;
+using namespace Aws::S3::Model;
+
+// ---------------------------------------------------------------------------
+// Base test fixture
+// ---------------------------------------------------------------------------
+
+class TFsStorageTestBase : public NUnitTest::TTestBase {
+protected:
+    void SetUp() override {
+        TempDir = MakeHolder<TTempDir>();
+
+        Runtime = MakeHolder<TTestBasicRuntime>();
+        Runtime->Initialize(TAppPrepare().Unwrap());
+        Runtime->SetLogPriority(NKikimrServices::FS_WRAPPER, NLog::PRI_DEBUG);
+
+        NKikimrSchemeOp::TFSSettings settings;
+        settings.SetBasePath(TempDir->Name());
+        auto config = std::make_shared<TFsExternalStorageConfig>(settings);
+
+        Wrapper = Runtime->Register(NWrappers::CreateS3Wrapper(config->ConstructStorageOperator()));
+        Edge = Runtime->AllocateEdgeActor();
+    }
+
+    void TearDown() override {
+        // Do NOT send explicit Poison here: Runtime.Reset() destroys all actors
+        // via the actor system cleanup path where TlsActivationContext is null,
+        // so TFsExternalStorage::Shutdown() exits early (the null-check guards it).
+        // Sending Poison first and then immediately calling Reset() races with the
+        // runtime destructor, causing Shutdown() to Send() to an actor that is
+        // concurrently being destroyed → SIGSEGV.
+        Runtime.Reset();
+        TempDir.Reset();
+    }
+
+    // Absolute path inside the temp directory that is used as the S3 "key"
+    // (fs_storage uses the key directly as a filesystem path).
+    TString KeyPath(const TString& name) const {
+        return (TFsPath(TempDir->Name()) / name).GetPath();
+    }
+
+    template <typename TEvResponse>
+    auto Send(IEventBase* ev) {
+        Runtime->Send(new IEventHandle(Wrapper, Edge, ev));
+        return Runtime->GrabEdgeEvent<TEvResponse>(Edge);
+    }
+
+    // --- request helpers ---
+
+    auto PutObject(const TString& key, TString body) {
+        auto request = PutObjectRequest().WithKey(key);
+        auto response = Send<TEvPutObjectResponse>(
+            new TEvPutObjectRequest(request, std::move(body)));
+        UNIT_ASSERT(response->Get());
+        return response->Get()->Result;
+    }
+
+    auto HeadObject(const TString& key) {
+        auto request = HeadObjectRequest().WithKey(key);
+        auto response = Send<TEvHeadObjectResponse>(
+            new TEvHeadObjectRequest(request));
+        UNIT_ASSERT(response->Get());
+        return response->Get()->Result;
+    }
+
+    // Returns {Result, Body}
+    auto GetObject(const TString& key) {
+        auto request = GetObjectRequest().WithKey(key);
+        auto response = Send<TEvGetObjectResponse>(
+            new TEvGetObjectRequest(request));
+        UNIT_ASSERT(response->Get());
+        return std::make_pair(response->Get()->Result, response->Get()->Body);
+    }
+
+    auto GetObjectRange(const TString& key, ui64 from, ui64 to) {
+        auto request = GetObjectRequest()
+            .WithKey(key)
+            .WithRange(TStringBuilder() << "bytes=" << from << "-" << to);
+        auto response = Send<TEvGetObjectResponse>(
+            new TEvGetObjectRequest(request));
+        UNIT_ASSERT(response->Get());
+        return std::make_pair(response->Get()->Result, response->Get()->Body);
+    }
+
+    auto CreateMultipartUpload(const TString& key) {
+        auto request = CreateMultipartUploadRequest().WithKey(key);
+        auto response = Send<TEvCreateMultipartUploadResponse>(
+            new TEvCreateMultipartUploadRequest(request));
+        UNIT_ASSERT(response->Get());
+        return response->Get()->Result;
+    }
+
+    auto UploadPart(const TString& key, const TString& uploadId, int partNumber, TString body) {
+        auto request = UploadPartRequest()
+            .WithKey(key)
+            .WithUploadId(uploadId)
+            .WithPartNumber(partNumber);
+        auto response = Send<TEvUploadPartResponse>(
+            new TEvUploadPartRequest(request, std::move(body)));
+        UNIT_ASSERT(response->Get());
+        return response->Get()->Result;
+    }
+
+    auto CompleteMultipartUpload(const TString& key, const TString& uploadId,
+                                 const TVector<CompletedPart>& parts)
+    {
+        auto request = CompleteMultipartUploadRequest()
+            .WithKey(key)
+            .WithUploadId(uploadId)
+            .WithMultipartUpload(CompletedMultipartUpload().WithParts(parts));
+        auto response = Send<TEvCompleteMultipartUploadResponse>(
+            new TEvCompleteMultipartUploadRequest(request));
+        UNIT_ASSERT(response->Get());
+        return response->Get()->Result;
+    }
+
+    auto AbortMultipartUpload(const TString& key, const TString& uploadId) {
+        auto request = AbortMultipartUploadRequest()
+            .WithKey(key)
+            .WithUploadId(uploadId);
+        auto response = Send<TEvAbortMultipartUploadResponse>(
+            new TEvAbortMultipartUploadRequest(request));
+        UNIT_ASSERT(response->Get());
+        return response->Get()->Result;
+    }
+
+protected:
+    THolder<TTempDir> TempDir;
+    THolder<TTestBasicRuntime> Runtime;
+    TActorId Wrapper;
+    TActorId Edge;
+};
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+class TFsStorageTests : public TFsStorageTestBase {
+    UNIT_TEST_SUITE(TFsStorageTests);
+
+    // Group 2 – race / lock tests
+    UNIT_TEST(PutObjectDoesNotTruncateLockedFile);
+    UNIT_TEST(PutObjectReturnsRetryableErrorWhenFileLocked);
+    UNIT_TEST(MultipartUploadReturnsRetryableErrorWhenFileLocked);
+
+    UNIT_TEST_SUITE_END();
+
+public:
+    // -----------------------------------------------------------------------
+    // Group 2 – race / lock tests
+    // -----------------------------------------------------------------------
+
+    // TC-2.1: BUG-1 — PutObject must NOT truncate a file before acquiring the lock.
+    //
+    // Scenario: "generation 1" holds the file open with LOCK_EX (simulates a DataShard
+    // that is still writing).  "Generation 2" sends a PutObject to the same key.
+    //
+    // Before the fix (CreateAlways | WrOnly): the file was truncated to zero at open
+    // time, BEFORE flock — so generation 1's data was silently destroyed.
+    //
+    // After the fix (OpenAlways | WrOnly | ForAppend + Flock + Resize(0)): the file
+    // is not touched until the lock is held, so generation 1's data survives.
+    void PutObjectDoesNotTruncateLockedFile() {
+        const TString key = KeyPath("data.csv");
+        const TString originalContent = "generation1_data_long_enough_to_notice_truncation";
+        const TString newContent      = "generation2_short";
+
+        // Step 1: write "generation1" content directly (simulates a completed previous write)
+        {
+            TFileOutput f(key);
+            f.Write(originalContent);
+        }
+
+        // Step 2: acquire an external exclusive lock (simulates a DataShard generation
+        // that still holds the file open while exporting)
+        TFile externalLock(key, OpenExisting | RdWr);
+        externalLock.Flock(LOCK_EX | LOCK_NB);
+
+        // Step 3-4: PutObject from generation 2 — must fail with a retryable error
+        auto result = PutObject(key, newContent);
+        UNIT_ASSERT_C(!result.IsSuccess(),
+            "Expected PutObject to fail while file is locked by external holder");
+        UNIT_ASSERT_C(result.GetError().ShouldRetry(),
+            "Expected retryable EWOULDBLOCK error, got: " << result.GetError().GetMessage());
+
+        // Step 5 — KEY CHECK: file content must NOT have been truncated.
+        // Before the fix PutObject used CreateAlways which truncates at open time
+        // (before flock), destroying generation 1's data even though the lock
+        // was never granted.
+        {
+            TFileInput f(key);
+            const TString actualContent = f.ReadAll();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                actualContent, originalContent,
+                "BUG-1 regression: file was truncated before lock was acquired!"
+                " actual_size=" << actualContent.size()
+                    << " expected_size=" << originalContent.size());
+        }
+
+        // Step 6: release the external lock
+        externalLock.Flock(LOCK_UN);
+        externalLock.Close();
+
+        // Step 7: retry PutObject — must now succeed
+        auto result2 = PutObject(key, newContent);
+        UNIT_ASSERT_C(result2.IsSuccess(), result2.GetError().GetMessage());
+
+        // Step 8: verify the new content is written correctly
+        {
+            TFileInput f(key);
+            UNIT_ASSERT_VALUES_EQUAL(f.ReadAll(), newContent);
+        }
+    }
+
+    // TC-2.2: error code returned when file is locked must be retryable
+    void PutObjectReturnsRetryableErrorWhenFileLocked() {
+        const TString key = KeyPath("locked.csv");
+
+        // Create the file first so flock can open it
+        {
+            TFileOutput f(key);
+            f.Write("existing");
+        }
+
+        TFile externalLock(key, OpenExisting | RdWr);
+        externalLock.Flock(LOCK_EX | LOCK_NB);
+
+        auto result = PutObject(key, "new_data");
+        UNIT_ASSERT(!result.IsSuccess());
+        UNIT_ASSERT_C(result.GetError().ShouldRetry(),
+            "Lock contention must produce a retryable error so the caller backs off and retries");
+
+        externalLock.Flock(LOCK_UN);
+        externalLock.Close();
+    }
+
+    // TC-2.3: CreateMultipartUpload must also return a retryable error when the
+    // .incomplete file is already locked (e.g. previous generation still writing)
+    void MultipartUploadReturnsRetryableErrorWhenFileLocked() {
+        const TString key            = KeyPath("mpu.csv");
+        const TString incompletePath = key + ".incomplete";
+
+        // Pre-create .incomplete and lock it
+        {
+            TFileOutput f(incompletePath);
+            f.Write("in_progress_data");
+        }
+        TFile externalLock(incompletePath, OpenExisting | RdWr);
+        externalLock.Flock(LOCK_EX | LOCK_NB);
+
+        auto result = CreateMultipartUpload(key);
+        UNIT_ASSERT(!result.IsSuccess());
+        UNIT_ASSERT_C(result.GetError().ShouldRetry(),
+            "Lock contention on .incomplete must produce a retryable error");
+
+        externalLock.Flock(LOCK_UN);
+        externalLock.Close();
+
+        // After releasing the lock a new MPU session must succeed
+        {
+            auto result2 = CreateMultipartUpload(key);
+            UNIT_ASSERT_C(result2.IsSuccess(), result2.GetError().GetMessage());
+
+            const TString uploadId = result2.GetResult().GetUploadId().c_str();
+            TVector<CompletedPart> parts;
+
+            auto up = UploadPart(key, uploadId, 1, "data");
+            UNIT_ASSERT_C(up.IsSuccess(), up.GetError().GetMessage());
+            parts.push_back(CompletedPart().WithPartNumber(1).WithETag(up.GetResult().GetETag()));
+
+            auto cmpl = CompleteMultipartUpload(key, uploadId, parts);
+            UNIT_ASSERT_C(cmpl.IsSuccess(), cmpl.GetError().GetMessage());
+        }
+
+        auto [getResult, body] = GetObject(key);
+        UNIT_ASSERT_C(getResult.IsSuccess(), getResult.GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(body, "data");
+    }
+};
+
+UNIT_TEST_SUITE_REGISTRATION(TFsStorageTests);

--- a/ydb/core/wrappers/ut/ya.make
+++ b/ydb/core/wrappers/ut/ya.make
@@ -17,6 +17,7 @@ IF (NOT OS_WINDOWS)
     )
     SRCS(
         s3_wrapper_ut.cpp
+        fs_storage_ut.cpp
     )
 ENDIF()
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- убрал гонку в PutObject (второй поток мог перетереть файл пока в него писал первый);
- добавил `fsync` для директорий.
