### PR TITLE
Fix flaky ut TPDiskTest.ChunkWriteDifferentOffsetAndSize

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -38,7 +38,7 @@ NPDisk::TEvChunkWrite::TPartsPtr GenParts(TReallyFastRng32& rng, size_t size) {
             size_t createdBytes = 0;
             if (size >= partsCount) {
                 for (size_t i = 0; i < partsCount - 1; ++i) {
-                    TRope x(PrepareData(rng.Uniform(1, size / partsCount)));
+                    TRope x(PrepareData(1 + rng.Uniform(size / partsCount)));
                     createdBytes += x.size();
                     rope.Insert(rope.End(), std::move(x));
                 }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Close https://github.com/ydb-platform/ydb/issues/34400

Flaky test:

```
VERIFY failed (2026-02-16T03:23:04.874435Z): Invalid random number range [0, 0)
  util/random/common_ops.h:50
  GenUniform(): requirement max > 0 failed
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char>>, char const*, unsigned long)+438 (0x24556C6)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+263 (0x244C257)
NKikimr::GenParts(TReallyFastRng32&, unsigned long)+2428 (0x20AAE5C)
NKikimr::NTestSuiteTPDiskTest::ChunkWriteDifferentOffsetAndSizeImpl(bool, bool)+1843 (0x20F9523)
NKikimr::NTestSuiteTPDiskTest::TTestCaseChunkWriteDifferentOffsetAndSize::Execute_(NUnitTest::TTestContext&)+13 (0x20FA45D)
NKikimr::NTestSuiteTPDiskTest::TCurrentTest::Execute()::'lambda'()::operator()() const+71 (0x2124177)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+120 (0x24E9ED8)
NKikimr::NTestSuiteTPDiskTest::TCurrentTest::Execute()+435 (0x2123B23)
NUnitTest::TTestFactory::Execute()+817 (0x24EA621)
NUnitTest::RunMain(int, char**)+3229 (0x24FCE4D)
??+0 (0x7F0754CCBD90)
__libc_start_main+128 (0x7F0754CCBE40)
_start+41 (0x2042029)
```
