### PR TITLE
fix: E2EBackupCollection test flake with disabled Workload Manager

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_incremental_backup.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_incremental_backup.cpp
@@ -1406,6 +1406,8 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
 
         ExecSQL(server, edgeActor, R"(BACKUP `MyCollection`;)", false);
 
+        SimulateSleep(server, TDuration::Seconds(2));
+
         ExecSQL(server, edgeActor, R"(
             UPSERT INTO `/Root/Table` (key, value) VALUES
             (2, 200);


### PR DESCRIPTION
Add SimulateSleep between full and incremental backup to ensure ToX509String timestamps differ, avoiding CDC stream name collision.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
