### PR TITLE
Ignore vectors in bad format during SampleKScan

### DIFF
--- a/ydb/core/base/kmeans_clusters.cpp
+++ b/ydb/core/base/kmeans_clusters.cpp
@@ -399,7 +399,7 @@ public:
     }
 
     bool IsExpectedFormat(const TArrayRef<const char>& data) override {
-        if (FormatByte != data.back()) {
+        if (!data.size() || FormatByte != data.back()) {
             return false;
         }
 

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1582,6 +1582,8 @@ message TEvSampleKRequest {
 
     optional uint64 SeqNoGeneration = 11;
     optional uint64 SeqNoRound = 12;
+
+    optional Ydb.Table.VectorIndexSettings Settings = 13;
 }
 
 message TEvSampleKResponse {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -655,6 +655,8 @@ private:
             path->PathId.ToProto(ev->Record.MutablePathId());
         }
 
+        *ev->Record.MutableSettings() = std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(
+            buildInfo.SpecializedIndexDescription).GetSettings().settings();
         ev->Record.SetK(buildInfo.KMeans.K);
         ev->Record.SetMaxProbability(buildInfo.Sample.MaxProbability);
         if (buildInfo.KMeans.Parent != 0) {


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Проблемы было две:

1) если в таблице с >1 шардом был хотя бы 1 пустой вектор (пустая строка), то даташарды падали с VERIFY - баг актуален только для main, в 25-4 и ранее его не было (в доработках по битовой квантизации)
2) если в таблице с >1 шардом оказывалось значительное количество строк с векторами в некорректном формате (не только пустых, а также некорректной длины), то построение индекса завершалось неудачей - баг был и в более ранних версиях