### PR TITLE
EXT-1685: don't print history log if vdisk is unavailable (#29097)

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_get.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get.cpp
@@ -410,11 +410,14 @@ class TBlobStorageGroupGetRequest : public TBlobStorageGroupRequestActor<TBlobSt
                     (History, GetImpl.PrintHistory()));
         }
 
-        STLOG(GetImpl.WasNotOkResponses() && AllowToReport(handleClass) ? PRI_NOTICE : PRI_DEBUG, \
-                BS_PROXY_GET, BPG72, "Query history",                                             \
-                (GroupId, Info->GroupID),                                                         \
-                (HandleClass, NKikimrBlobStorage::EGetHandleClass_Name(handleClass)),             \
+        auto resultStatusPriority = PriorityForStatusResult(evResult->Status);
+        if (IS_LOG_PRIORITY_ENABLED(resultStatusPriority, LogCtx.LogComponent) && AllowToReport(handleClass)) {
+            STLOG(resultStatusPriority,
+                BS_PROXY_GET, BPG72, "Query history",
+                (GroupId, Info->GroupID),
+                (HandleClass, NKikimrBlobStorage::EGetHandleClass_Name(handleClass)),
                 (History, GetImpl.PrintHistory()));
+        }
 
         return SendResponseAndDie(std::unique_ptr<TEvBlobStorage::TEvGetResult>(evResult.Release()));
     }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.h
@@ -54,8 +54,6 @@ class TGetImpl {
 
     THistory History;
 
-    bool AtLeastOneResponseWasNotOk = false;
-
     friend class TBlobStorageGroupGetRequest;
     friend class THistory;
 
@@ -237,7 +235,6 @@ public:
                 R_LOG_DEBUG_SX(logCtx, "BPG60", "Got# " << NKikimrProto::EReplyStatus_Name(replyStatus).data()
                     << " orderNumber# " << orderNumber << " vDiskId# " << vdisk.ToString());
                 Blackboard.AddErrorResponse(blobId, orderNumber);
-                AtLeastOneResponseWasNotOk = true;
             } else if (replyStatus == NKikimrProto::NOT_YET) {
                 R_LOG_DEBUG_SX(logCtx, "BPG67", "Got# NOT_YET orderNumber# " << orderNumber
                         << " vDiskId# " << vdisk.ToString());
@@ -294,10 +291,6 @@ public:
 
     TString PrintHistory() const {
         return History.Print((QuerySize == 0) ? nullptr : &Queries[0].Id);
-    }
-
-    bool WasNotOkResponses() {
-        return AtLeastOneResponseWasNotOk;
     }
 
 protected:

--- a/ydb/core/blobstorage/dsproxy/dsproxy_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_impl.cpp
@@ -72,10 +72,11 @@ namespace NKikimr {
             case NKikimrProto::BLOCKED:
             case NKikimrProto::DEADLINE:
             case NKikimrProto::RACE:
-            case NKikimrProto::ERROR:
                 return NActors::NLog::EPriority::PRI_INFO;
             case NKikimrProto::NODATA:
                 return NActors::NLog::EPriority::PRI_NOTICE;
+            case NKikimrProto::ERROR:
+                return NActors::NLog::EPriority::PRI_ERROR;
             default:
                 return NActors::NLog::EPriority::PRI_ERROR;
         }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -454,12 +454,12 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor<TBlobSt
                     (History, PutImpl.PrintHistory()));
         }
 
-        if (ResponsesSent == PutImpl.Blobs.size()) {
-            STLOG(PutImpl.WasNotOkResponses() && AllowToReport(HandleClass) ? PRI_NOTICE : PRI_DEBUG, \
-                    BS_PROXY_PUT, BPP72, "Query history",                                             \
-                    (GroupId, Info->GroupID),                                                         \
-                    (HandleClass, NKikimrBlobStorage::EPutHandleClass_Name(HandleClass)),             \
-                    (Tactic, TEvBlobStorage::TEvPut::TacticName(Tactic)),                             \
+        if (ResponsesSent == PutImpl.Blobs.size() && IS_LOG_PRIORITY_ENABLED(PutImpl.ResultPriority, LogCtx.LogComponent) && AllowToReport(HandleClass)) {
+            STLOG(PutImpl.ResultPriority,
+                    BS_PROXY_PUT, BPP72, "Query history",
+                    (GroupId, Info->GroupID),
+                    (HandleClass, NKikimrBlobStorage::EPutHandleClass_Name(HandleClass)),
+                    (Tactic, TEvBlobStorage::TEvPut::TacticName(Tactic)),
                     (History, PutImpl.PrintHistory()));
         }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.cpp
@@ -70,6 +70,7 @@ void TPutImpl::PrepareOneReply(NKikimrProto::EReplyStatus status, size_t blobIdx
         ev->ErrorReason = std::move(errorReason);
         const NLog::EPriority priority = GetPriorityForReply(Info->PutErrorMuteChecker, status);
         A_LOG_LOG_SX(logCtx, true, priority, "BPP12", "Result# " << ev->Print(false) << " GroupId# " << Info->GroupID);
+        ResultPriority = std::min(ResultPriority, PriorityForStatusResult(status));
         outPutResults.emplace_back(blobIdx, std::move(ev));
     }
 }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
@@ -40,7 +40,7 @@ private:
     ui32 VPutResponses = 0;
     ui32 VMultiPutRequests = 0;
     ui32 VMultiPutResponses = 0;
-    bool AtLeastOneResponseWasNotOk = false;
+    NActors::NLog::EPriority ResultPriority = NActors::NLog::PRI_DEBUG;
     bool EnableRequestMod3x3ForMinLatecy = false;
 
     const TEvBlobStorage::TEvPut::ETactic Tactic;
@@ -299,10 +299,6 @@ public:
         return it->second;
     }
 
-    bool WasNotOkResponses() {
-        return AtLeastOneResponseWasNotOk;
-    }
-
 protected:
     void RunStrategies(TLogContext &logCtx, TPutResultVec &outPutResults, const TBlobStorageGroupInfo::TGroupVDisks& expired,
         bool accelerate);
@@ -328,7 +324,6 @@ protected:
             case NKikimrProto::VDISK_ERROR_STATE:
             case NKikimrProto::OUT_OF_SPACE:
                 Blackboard.AddErrorResponse(blobId, orderNumber);
-                AtLeastOneResponseWasNotOk = true;
                 break;
             case NKikimrProto::OK:
             case NKikimrProto::ALREADY:

--- a/ydb/core/blobstorage/dsproxy/request_history.h
+++ b/ydb/core/blobstorage/dsproxy/request_history.h
@@ -73,7 +73,7 @@ public:
                 << " NodeId# "      << info->GetActorId(OrderNumber).NodeId()
                 << " Status# "      << NKikimrProto::EReplyStatus_Name(Status);
             if (ErrorReason) {
-                str << "ErrorReason# \"" << ErrorReason << "\"";
+                str << " ErrorReason# \"" << ErrorReason << "\"";
             }
             str << " }";
         }


### PR DESCRIPTION
(cherry picked from commit b83c53c209dfe72b2a329859db45c6647ac87c4b)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
