### PR TITLE
SchemeShard: Fix heap-use-after-free in forced_compaction logic

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -124,8 +124,8 @@ void TSchemeShard::ProcessForcedCompactionQueues() {
         }
         if (shards.Empty()) {
             tablesWithoutCandidates.insert(tablePathId);
-            ForcedCompactionTablesQueue.PopFront();
             ForcedCompactionShardsByTable.erase(tablePathId);
+            ForcedCompactionTablesQueue.PopFront();
         } else {
             if (compaction->MaxShardsInFlight <= compaction->ShardsInFlight.size()) {
                 tablesWithoutCandidates.insert(tablePathId);

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -113,7 +113,7 @@ void TSchemeShard::ProcessForcedCompactionQueues() {
     auto initialQueueSize = ForcedCompactionTablesQueue.Size();
     THashSet<TPathId> tablesWithoutCandidates;
     while (!ForcedCompactionTablesQueue.Empty() && tablesWithoutCandidates.size() < initialQueueSize) {
-        const auto& tablePathId = ForcedCompactionTablesQueue.Front();
+        auto tablePathId = ForcedCompactionTablesQueue.Front();
         auto& compaction = InProgressForcedCompactionsByTable.at(tablePathId);
         auto& shards = ForcedCompactionShardsByTable.at(tablePathId);
         if (!shards.Empty() && compaction->MaxShardsInFlight > compaction->ShardsInFlight.size()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
