### PR TITLE
Support ALTER TABLE COMPACT in kqp and rpc_alter_table

### DIFF
--- a/ydb/core/grpc_services/operation_helpers.cpp
+++ b/ydb/core/grpc_services/operation_helpers.cpp
@@ -14,6 +14,7 @@
 #include <ydb/core/tx/schemeshard/schemeshard_import.h>
 
 #include <ydb/core/protos/index_builder.pb.h>
+#include <ydb/core/protos/forced_compaction.pb.h>
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h>
 
@@ -39,6 +40,14 @@ Ydb::TOperationId ToOperationId(const NKikimrIndexBuilder::TIndexBuild& build) {
     Ydb::TOperationId operationId;
     operationId.SetKind(Ydb::TOperationId::BUILD_INDEX);
     NOperationId::AddOptionalValue(operationId, "id", ToString(build.GetId()));
+
+    return operationId;
+}
+
+Ydb::TOperationId ToOperationId(const NKikimrForcedCompaction::TForcedCompaction& compaction) {
+    Ydb::TOperationId operationId;
+    operationId.SetKind(Ydb::TOperationId::COMPACTION);
+    NOperationId::AddOptionalValue(operationId, "id", ToString(compaction.GetId()));
 
     return operationId;
 }
@@ -82,6 +91,37 @@ void ToOperation(const NKikimrIndexBuilder::TIndexBuild& build, Ydb::Operations:
 
     auto data = operation->mutable_metadata();
     data->PackFrom(metadata);
+}
+
+void ToOperation(const NKikimrForcedCompaction::TForcedCompaction& compaction, Ydb::Operations::Operation* operation) {
+    operation->set_id(NOperationId::ProtoToString(ToOperationId(compaction)));
+    if (compaction.HasStartTime()) {
+        *operation->mutable_create_time() = compaction.GetStartTime();
+    }
+    if (compaction.HasEndTime()) {
+        *operation->mutable_end_time() = compaction.GetEndTime();
+    }
+    if (compaction.HasUserSID()) {
+        operation->set_created_by(compaction.GetUserSID());
+    }
+
+    switch (compaction.GetState()) {
+        case Ydb::Table::CompactState::STATE_DONE:
+            operation->set_ready(true);
+            operation->set_status(Ydb::StatusIds::SUCCESS);
+        case Ydb::Table::CompactState::STATE_CANCELLED:
+            operation->set_ready(true);
+            operation->set_status(Ydb::StatusIds::CANCELLED);
+        default:
+            operation->set_ready(false);
+            break;
+    }
+
+    Ydb::Table::CompactMetadata metadata;
+    metadata.set_path(compaction.GetSettings().source_path());
+    metadata.set_cascade(compaction.GetSettings().cascade());
+    metadata.set_max_shards_in_flight(compaction.GetSettings().max_shards_in_flight());
+    metadata.set_progress(compaction.GetProgress());
 }
 
 bool TryGetId(const NOperationId::TOperationId& operationId, ui64& id) {

--- a/ydb/core/grpc_services/operation_helpers.cpp
+++ b/ydb/core/grpc_services/operation_helpers.cpp
@@ -106,15 +106,20 @@ void ToOperation(const NKikimrForcedCompaction::TForcedCompaction& compaction, Y
     }
 
     switch (compaction.GetState()) {
-        case Ydb::Table::CompactState::STATE_DONE:
+        case Ydb::Table::CompactState::STATE_DONE: {
             operation->set_ready(true);
             operation->set_status(Ydb::StatusIds::SUCCESS);
-        case Ydb::Table::CompactState::STATE_CANCELLED:
+            break;
+        }
+        case Ydb::Table::CompactState::STATE_CANCELLED: {
             operation->set_ready(true);
             operation->set_status(Ydb::StatusIds::CANCELLED);
-        default:
+            break;
+        }
+        default: {
             operation->set_ready(false);
             break;
+        }
     }
 
     Ydb::Table::CompactMetadata metadata;
@@ -122,6 +127,10 @@ void ToOperation(const NKikimrForcedCompaction::TForcedCompaction& compaction, Y
     metadata.set_cascade(compaction.GetSettings().cascade());
     metadata.set_max_shards_in_flight(compaction.GetSettings().max_shards_in_flight());
     metadata.set_progress(compaction.GetProgress());
+    metadata.set_state(compaction.GetState());
+
+    auto data = operation->mutable_metadata();
+    data->PackFrom(metadata);
 }
 
 bool TryGetId(const NOperationId::TOperationId& operationId, ui64& id) {

--- a/ydb/core/grpc_services/operation_helpers.h
+++ b/ydb/core/grpc_services/operation_helpers.h
@@ -8,6 +8,10 @@ namespace NKikimrIndexBuilder {
     class TIndexBuild;
 }
 
+namespace NKikimrForcedCompaction {
+    class TForcedCompaction;
+}
+
 namespace Ydb {
 namespace Operations {
     class Operation;
@@ -22,7 +26,9 @@ class IRequestOpCtx;
 IEventBase* CreateNavigateForPath(const TString& path);
 TActorId CreatePipeClient(ui64 id, const TActorContext& ctx);
 Ydb::TOperationId ToOperationId(const NKikimrIndexBuilder::TIndexBuild& build);
+Ydb::TOperationId ToOperationId(const NKikimrForcedCompaction::TForcedCompaction& compaction);
 void ToOperation(const NKikimrIndexBuilder::TIndexBuild& build, Ydb::Operations::Operation* operation);
+void ToOperation(const NKikimrForcedCompaction::TForcedCompaction& build, Ydb::Operations::Operation* operation);
 bool TryGetId(const NOperationId::TOperationId& operationId, ui64& id);
 
 

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -1712,7 +1712,8 @@ private:
                     && name != "addChangefeed"
                     && name != "dropChangefeed"
                     && name != "renameIndexTo"
-                    && name != "alterIndex")
+                    && name != "alterIndex"
+                    && name != "compact")
             {
                 ctx.AddError(TIssue(ctx.GetPosition(action.Name().Pos()),
                     TStringBuilder() << "Unknown alter table action: " << name));

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -255,4 +255,5 @@ message TFeatureFlags {
     optional bool EnableCmsSmartAvailabilityMode = 228 [default = false];
     optional bool EnableConditionalEraseResponseBatching = 229 [default = false];
     optional bool EnablePDiskDataEncryption = 230 [default = true];
+    optional bool EnableForcedCompactions = 231 [default = false];
 }

--- a/ydb/core/protos/forced_compaction.proto
+++ b/ydb/core/protos/forced_compaction.proto
@@ -1,6 +1,7 @@
 import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/ydb_operation.proto";
 import "ydb/public/api/protos/ydb_status_codes.proto";
+import "ydb/public/api/protos/ydb_table.proto";
 import "google/protobuf/timestamp.proto";
 
 package NKikimrForcedCompaction;
@@ -19,6 +20,7 @@ message TForcedCompaction {
     optional google.protobuf.Timestamp StartTime = 4;
     optional google.protobuf.Timestamp EndTime = 5;
     optional string UserSID = 6;
+    optional Ydb.Table.CompactState.State State = 7;
 }
 
 message TEvCreateRequest {

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -13,6 +13,7 @@ import "ydb/library/yql/dq/proto/dq_tasks.proto";
 import "ydb/public/api/protos/ydb_table.proto";
 import "ydb/public/api/protos/ydb_value.proto";
 import "ydb/core/protos/index_builder.proto";
+import "ydb/core/protos/forced_compaction.proto";
 import "ydb/core/protos/sys_view_types.proto";
 
 enum EIsolationLevel {
@@ -626,6 +627,7 @@ message TKqpSchemeOperation {
         NKikimrSchemeOp.TModifyScheme AlterSecret = 60;
         NKikimrSchemeOp.TModifyScheme DropSecret = 61;
         NKikimrSchemeOp.TModifyScheme TruncateTable = 62;
+        NKikimrForcedCompaction.TForcedCompactionSettings CompactTable = 63;
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2897,5 +2897,9 @@ void TForcedCompactionInfo::AddNotifySubscriber(const TActorId& actorId) {
     Subscribers.insert(actorId);
 }
 
+float TForcedCompactionInfo::CalcProgress() const {
+    return TotalShardCount > 0 ? (100.f * DoneShardCount / TotalShardCount) : 0;
+}
+
 } // namespace NSchemeShard
 } // namespace NKikimr

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3878,6 +3878,7 @@ struct TForcedCompactionInfo : TSimpleRefCount<TForcedCompactionInfo> {
 
     bool IsFinished() const;
     void AddNotifySubscriber(const TActorId& actorId);
+    float CalcProgress() const;
 };
 // } // NForcedCompaction
 

--- a/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
+++ b/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
@@ -1981,6 +1981,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
             UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetSettings().cascade(), false);
             UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetSettings().max_shards_in_flight(), 3);
             UNIT_ASSERT_DOUBLES_EQUAL(response.GetForcedCompaction().GetProgress(), 0.0, 1e-7);
+            UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetState(), Ydb::Table::CompactState::STATE_IN_PROGRESS);
         }
 
         block.Stop().Unblock();
@@ -1992,6 +1993,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
             UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetSettings().cascade(), false);
             UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetSettings().max_shards_in_flight(), 3);
             UNIT_ASSERT_DOUBLES_EQUAL(response.GetForcedCompaction().GetProgress(), 100.0, 1e-7);
+            UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetState(), Ydb::Table::CompactState::STATE_DONE);
         }
     }
 

--- a/ydb/core/ydb_convert/table_description.h
+++ b/ydb/core/ydb_convert/table_description.h
@@ -4,6 +4,7 @@
 
 #include <ydb/library/mkql_proto/protos/minikql.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>
+#include <ydb/core/protos/forced_compaction.pb.h>
 #include <ydb/core/protos/index_builder.pb.h>
 #include <ydb/core/scheme/scheme_type_info.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
@@ -25,6 +26,8 @@ enum class EAlterOperationKind {
     DropChangefeed,
     // rename index
     RenameIndex,
+    // compact table, possibly with indices
+    Compact,
 };
 
 struct TPathId;
@@ -48,6 +51,9 @@ bool FillAlterTableSettingsDesc(NKikimrSchemeOp::TTableDescription& out,
 
 bool BuildAlterTableAddIndexRequest(const Ydb::Table::AlterTableRequest* req, NKikimrIndexBuilder::TIndexBuildSettings* settings,
     ui64 flags,
+    Ydb::StatusIds::StatusCode& status, TString& error);
+
+bool BuildAlterTableCompactRequest(const Ydb::Table::AlterTableRequest* req, NKikimrForcedCompaction::TForcedCompactionSettings* settings,
     Ydb::StatusIds::StatusCode& status, TString& error);
 
 // out

--- a/ydb/core/ydb_convert/ya.make
+++ b/ydb/core/ydb_convert/ya.make
@@ -32,6 +32,8 @@ PEERDIR(
     ydb/public/api/protos
 )
 
+GENERATE_ENUM_SERIALIZATION(table_description.h)
+
 YQL_LAST_ABI_VERSION()
 
 END()

--- a/ydb/public/api/protos/out/out.cpp
+++ b/ydb/public/api/protos/out/out.cpp
@@ -56,3 +56,7 @@ Y_DECLARE_OUT_SPEC(, Ydb::Maintenance::ActionState::ActionReason, stream, value)
 Y_DECLARE_OUT_SPEC(, Ydb::Backup::BackupProgress::Progress, stream, value) {
     stream << Ydb::Backup::BackupProgress::Progress_Name(value);
 }
+
+Y_DECLARE_OUT_SPEC(, Ydb::Table::CompactState_State, stream, value) {
+    stream << CompactState_State_Name(value);
+}

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -938,6 +938,31 @@ message RenameIndexItem {
     bool replace_destination = 3;
 }
 
+// State of compact operation
+message CompactState {
+    enum State {
+        STATE_UNSPECIFIED = 0;
+        STATE_IN_PROGRESS = 1;
+        STATE_DONE = 2;
+        STATE_CANCELLED = 3;
+    }
+}
+
+message CompactItem {
+    // Compact table with all indices
+    optional bool cascade = 1;
+    // Max shards in flight per operation
+    optional uint32 max_shards_in_flight = 2;
+}
+
+message CompactMetadata {
+    optional string path = 1;
+    optional bool cascade = 2;
+    optional uint32 max_shards_in_flight = 3;
+    optional CompactState.State state = 4;
+    optional float progress = 5;
+}
+
 // Alter table with given path
 message AlterTableRequest {
     // Session identifier
@@ -984,6 +1009,8 @@ message AlterTableRequest {
     // Rename existed index
     repeated RenameIndexItem rename_indexes = 21;
     reserved 22, 23;
+    // Start compaction for table 
+    CompactItem compact = 24;
 }
 
 message AlterTableResponse {

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -1009,7 +1009,7 @@ message AlterTableRequest {
     // Rename existed index
     repeated RenameIndexItem rename_indexes = 21;
     reserved 22, 23;
-    // Start compaction for table 
+    // Start compaction for table
     CompactItem compact = 24;
 }
 

--- a/ydb/public/sdk/cpp/src/library/operation_id/operation_id.cpp
+++ b/ydb/public/sdk/cpp/src/library/operation_id/operation_id.cpp
@@ -72,6 +72,9 @@ std::string ProtoToString(const Ydb::TOperationId& proto) {
         case Ydb::TOperationId::RESTORE:
             res << "ydb://restore";
             break;
+        case Ydb::TOperationId::COMPACTION:
+            res << "ydb://compaction";
+            break;
         default:
             Y_ABORT_UNLESS(false, "unexpected kind");
     }

--- a/ydb/public/sdk/cpp/src/library/operation_id/protos/operation_id.proto
+++ b/ydb/public/sdk/cpp/src/library/operation_id/protos/operation_id.proto
@@ -17,6 +17,7 @@ message TOperationId {
         SS_BG_TASKS = 10;
         INCREMENTAL_BACKUP = 11;
         RESTORE = 12;
+        COMPACTION = 13;
     }
 
     message TData {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Internal design doc: https://nda.ya.ru/t/pt_4yINs7UpV9r

- Support ALTER TABLE COMPACT in kqp
- Support compact operation in rpc_alter_table
- SDK: add new operation messages and enum values in operation_id.proto and in ydb_table.proto
- SchemeShard: add status to TForcedCompaction message

TODO:
- Add cancel/forget/list operations in rpc
- Add tests with query service
