### PR TITLE
Fix broken async retries and leaks (#33961), (#33962), (#33963), (#33964)

### DIFF
--- a/ydb/library/actors/core/invoke.h
+++ b/ydb/library/actors/core/invoke.h
@@ -113,34 +113,32 @@ namespace NActors {
     class TScheduledInvokeActivity: public TActor<TScheduledInvokeActivity<TInvokeExecutor>> {
     private:
         using TBase = TActor<TScheduledInvokeActivity<TInvokeExecutor>>;
-        const TMonotonic Timestamp;
         TInvokeExecutor Executor;
+        
     public:
-        TScheduledInvokeActivity(TInvokeExecutor&& executor, const TMonotonic timestamp)
+        TScheduledInvokeActivity(TInvokeExecutor&& executor)
             : TBase(&TBase::TThis::StateFunc)
-            , Timestamp(timestamp)
             , Executor(std::move(executor)) {
         }
 
-        void StateFunc(STFUNC_SIG) {
+        STFUNC(StateFunc) {
             Y_ABORT_UNLESS(ev->GetTypeRewrite() == TEvents::TSystem::Wakeup);
             auto g = TBase::PassAwayGuard();
             Executor();
-        }
-
-        void Registered(TActorSystem* sys, const TActorId& owner) override {
-            sys->Schedule(Timestamp, new IEventHandle(TEvents::TSystem::Wakeup, 0, TBase::SelfId(), owner, nullptr, 0));
         }
     };
 
     template<class TInvokeExecutor>
     void ScheduleInvokeActivity(TInvokeExecutor&& executor, const TDuration d) {
-        TActivationContext::Register(new TScheduledInvokeActivity<TInvokeExecutor>(std::move(executor), TMonotonic::Now() + d));
+        auto deadline = TActivationContext::Monotonic() + d;
+        auto actorId = TActivationContext::Register(new TScheduledInvokeActivity<TInvokeExecutor>(std::move(executor)));
+        TActivationContext::Schedule(deadline, new IEventHandle(actorId, actorId, new TEvents::TEvWakeup()));
     }
 
     template<class TInvokeExecutor>
     void ScheduleInvokeActivity(TInvokeExecutor&& executor, const TMonotonic timestamp) {
-        TActivationContext::Register(new TScheduledInvokeActivity<TInvokeExecutor>(std::move(executor), timestamp));
+        auto actorId = TActivationContext::Register(new TScheduledInvokeActivity<TInvokeExecutor>(std::move(executor)));
+        TActivationContext::Schedule(timestamp, new IEventHandle(actorId, actorId, new TEvents::TEvWakeup()));
     }
 
 } // NActors

--- a/ydb/library/actors/core/invoke.h
+++ b/ydb/library/actors/core/invoke.h
@@ -129,16 +129,14 @@ namespace NActors {
     };
 
     template<class TInvokeExecutor>
-    void ScheduleInvokeActivity(TInvokeExecutor&& executor, const TDuration d) {
-        auto deadline = TActivationContext::Monotonic() + d;
+    void ScheduleInvokeActivity(TInvokeExecutor&& executor, const TMonotonic timestamp) {
         auto actorId = TActivationContext::Register(new TScheduledInvokeActivity<TInvokeExecutor>(std::move(executor)));
-        TActivationContext::Schedule(deadline, new IEventHandle(actorId, actorId, new TEvents::TEvWakeup()));
+        TActivationContext::Schedule(timestamp, new IEventHandle(TEvents::TSystem::Wakeup, 0, actorId, actorId, nullptr, 0));
     }
 
     template<class TInvokeExecutor>
-    void ScheduleInvokeActivity(TInvokeExecutor&& executor, const TMonotonic timestamp) {
-        auto actorId = TActivationContext::Register(new TScheduledInvokeActivity<TInvokeExecutor>(std::move(executor)));
-        TActivationContext::Schedule(timestamp, new IEventHandle(actorId, actorId, new TEvents::TEvWakeup()));
+    void ScheduleInvokeActivity(TInvokeExecutor&& executor, const TDuration d) {
+        ScheduleInvokeActivity(std::move(executor), TActivationContext::Monotonic() + d);
     }
 
 } // NActors

--- a/ydb/services/metadata/initializer/accessor_init.cpp
+++ b/ydb/services/metadata/initializer/accessor_init.cpp
@@ -25,11 +25,10 @@ void TDSAccessorInitialized::DoNextModifier(const bool doPop) {
     }
     if (Modifiers.size()) {
         ALS_INFO(NKikimrServices::METADATA_INITIALIZER) << "modifiers count: " << Modifiers.size();
-        Modifiers.front()->Execute(SelfPtr, Config);
+        Modifiers.front()->Execute(GetSelfPtr(), Config);
     } else {
         ALS_INFO(NKikimrServices::METADATA_INITIALIZER) << "initialization finished";
         ExternalController->OnInitializationFinished(ComponentId);
-        SelfPtr.reset();
     }
 }
 
@@ -45,16 +44,25 @@ TDSAccessorInitialized::TDSAccessorInitialized(const NRequest::TConfig& config,
 {
 }
 
+TDSAccessorInitialized::~TDSAccessorInitialized() {
+    if (!Modifiers.empty()) {
+        ALS_WARN(NKikimrServices::METADATA_INITIALIZER)
+            << "Try to destroy TDSAccessorInitialized with remaining modifiers: " 
+            << Modifiers.size() << Endl;
+    }
+}
+
 void TDSAccessorInitialized::OnModificationFinished(const TString& modificationId) {
     ALS_INFO(NKikimrServices::METADATA_INITIALIZER) << "modifiers count: " << Modifiers.size();
     Y_ABORT_UNLESS(Modifiers.size());
     Y_ABORT_UNLESS(Modifiers.front()->GetModificationId() == modificationId);
+
     if (NProvider::TServiceOperator::IsEnabled() && InitializationSnapshotOwner->HasInitializationSnapshot()) {
         TDBInitialization dbInit(ComponentId, Modifiers.front()->GetModificationId());
         NModifications::IOperationsManager::TExternalModificationContext extContext;
         extContext.SetUserToken(NACLib::TSystemUsers::Metadata());
         auto alterCommand = std::make_shared<NModifications::TUpsertObjectCommand<TDBInitialization>>(
-            dbInit.SerializeToRecord(), TDBInitialization::GetBehaviour(), SelfPtr,
+            dbInit.SerializeToRecord(), TDBInitialization::GetBehaviour(), GetSelfPtr(),
             NModifications::IOperationsManager::TInternalModificationContext(extContext));
 
         TActorContext::AsActorContext().Send(NProvider::MakeServiceId(TActorContext::AsActorContext().SelfID.NodeId()),
@@ -69,17 +77,20 @@ void TDSAccessorInitialized::OnPreparationFinished(const TVector<ITableModifier:
         TDBInitializationKey key(ComponentId, i->GetModificationId());
         Modifiers.emplace_back(i);
     }
+
     DoNextModifier(false);
 }
 
 void TDSAccessorInitialized::OnPreparationProblem(const TString& errorMessage) const {
     AFL_ERROR(NKikimrServices::METADATA_INITIALIZER)("event", "OnPreparationProblem")("error", errorMessage);
-    NActors::ScheduleInvokeActivity([self = this->SelfPtr]() {self->InitializationBehaviour->Prepare(self); }, TDuration::Seconds(1));
+    NActors::ScheduleInvokeActivity([self = GetSelfPtr()]() {
+        self->InitializationBehaviour->Prepare(self); 
+    }, TDuration::Seconds(1));
 }
 
 void TDSAccessorInitialized::OnAlteringProblem(const TString& errorMessage) {
     AFL_ERROR(NKikimrServices::METADATA_INITIALIZER)("event", "OnAlteringProblem")("error", errorMessage);
-    NActors::ScheduleInvokeActivity([self = this->SelfPtr]() {
+    NActors::ScheduleInvokeActivity([self = GetSelfPtr()]() {
         Y_ABORT_UNLESS(self->Modifiers.size());
         self->OnModificationFinished(self->Modifiers.front()->GetModificationId());
     }, TDuration::Seconds(1));
@@ -87,7 +98,7 @@ void TDSAccessorInitialized::OnAlteringProblem(const TString& errorMessage) {
 
 void TDSAccessorInitialized::OnModificationFailed(Ydb::StatusIds::StatusCode /*status*/, const TString& errorMessage, const TString& modificationId) {
     AFL_ERROR(NKikimrServices::METADATA_INITIALIZER)("event", "OnModificationFailed")("error", errorMessage)("modificationId", modificationId);
-    NActors::ScheduleInvokeActivity([self = this->SelfPtr]() {
+    NActors::ScheduleInvokeActivity([self = GetSelfPtr()]() {
         Y_ABORT_UNLESS(self->Modifiers.size());
         self->DoNextModifier(false);
     }, TDuration::Seconds(1));
@@ -104,9 +115,8 @@ void TDSAccessorInitialized::Execute(const NRequest::TConfig& config, const TStr
     AFL_VERIFY(snapshotOwner);
     std::shared_ptr<TDSAccessorInitialized> initializer(new TDSAccessorInitialized(config,
         componentId, initializationBehaviour, controller, snapshotOwner));
-    initializer->SelfPtr = initializer;
 
     initializationBehaviour->Prepare(initializer);
 }
 
-}
+} // NKikimr::NMetadata::NInitializer

--- a/ydb/services/metadata/initializer/accessor_init.cpp
+++ b/ydb/services/metadata/initializer/accessor_init.cpp
@@ -10,6 +10,8 @@
 
 namespace NKikimr::NMetadata::NInitializer {
 
+constexpr auto RETRY_AFTER_DURATION = TDuration::Seconds(1);
+
 void TDSAccessorInitialized::DoNextModifier(const bool doPop) {
     if (InitializationSnapshotOwner->HasInitializationSnapshot() && !doPop) {
         while (Modifiers.size() && Modifiers.front()->GetSupportDbCache() && !doPop) {
@@ -85,7 +87,7 @@ void TDSAccessorInitialized::OnPreparationProblem(const TString& errorMessage) c
     AFL_ERROR(NKikimrServices::METADATA_INITIALIZER)("event", "OnPreparationProblem")("error", errorMessage);
     NActors::ScheduleInvokeActivity([self = GetSelfPtr()]() {
         self->InitializationBehaviour->Prepare(self); 
-    }, TDuration::Seconds(1));
+    }, RETRY_AFTER_DURATION);
 }
 
 void TDSAccessorInitialized::OnAlteringProblem(const TString& errorMessage) {
@@ -93,7 +95,7 @@ void TDSAccessorInitialized::OnAlteringProblem(const TString& errorMessage) {
     NActors::ScheduleInvokeActivity([self = GetSelfPtr()]() {
         Y_ABORT_UNLESS(self->Modifiers.size());
         self->OnModificationFinished(self->Modifiers.front()->GetModificationId());
-    }, TDuration::Seconds(1));
+    }, RETRY_AFTER_DURATION);
 }
 
 void TDSAccessorInitialized::OnModificationFailed(Ydb::StatusIds::StatusCode /*status*/, const TString& errorMessage, const TString& modificationId) {
@@ -101,7 +103,7 @@ void TDSAccessorInitialized::OnModificationFailed(Ydb::StatusIds::StatusCode /*s
     NActors::ScheduleInvokeActivity([self = GetSelfPtr()]() {
         Y_ABORT_UNLESS(self->Modifiers.size());
         self->DoNextModifier(false);
-    }, TDuration::Seconds(1));
+    }, RETRY_AFTER_DURATION);
 }
 
 void TDSAccessorInitialized::OnAlteringFinished() {

--- a/ydb/services/metadata/initializer/accessor_init.h
+++ b/ydb/services/metadata/initializer/accessor_init.h
@@ -15,18 +15,10 @@
 namespace NKikimr::NMetadata::NInitializer {
 
 class TDSAccessorInitialized: public IInitializerInput,
+    public std::enable_shared_from_this<TDSAccessorInitialized>,
     public NModifications::IAlterController,
     public NMetadata::NInitializer::IModifierExternalController
 {
-private:
-    mutable TDeque<ITableModifier::TPtr> Modifiers;
-    const NRequest::TConfig Config;
-    IInitializationBehaviour::TPtr InitializationBehaviour;
-    IInitializerOutput::TPtr ExternalController;
-    const std::shared_ptr<NProvider::TInitializationSnapshotOwner> InitializationSnapshotOwner;
-    const TString ComponentId;
-    std::shared_ptr<TDSAccessorInitialized> SelfPtr;
-
     void DoNextModifier(const bool doPop);
     virtual void OnPreparationFinished(const TVector<ITableModifier::TPtr>& modifiers) override;
     virtual void OnPreparationProblem(const TString& errorMessage) const override;
@@ -40,12 +32,30 @@ private:
         const TString& componentId,
         IInitializationBehaviour::TPtr initializationBehaviour,
         IInitializerOutput::TPtr controller, const std::shared_ptr<NProvider::TInitializationSnapshotOwner>& snapshotOwner);
+    
+    ///
+    /// Casts const shared_ptr to non-const to satisfy async retry interfaces 
+    /// (needed for 'const override' methods like OnPreparationProblem).
+    ///
+    std::shared_ptr<TDSAccessorInitialized> GetSelfPtr() const {
+        return std::const_pointer_cast<TDSAccessorInitialized>(shared_from_this());
+    }
+
 public:
+    virtual ~TDSAccessorInitialized();
+
     static void Execute(const NRequest::TConfig& config,
         const TString& componentId,
         IInitializationBehaviour::TPtr initializationBehaviour,
         IInitializerOutput::TPtr controller, const std::shared_ptr<NProvider::TInitializationSnapshotOwner>& initializationSnapshotOwner);
 
+private:
+    mutable TDeque<ITableModifier::TPtr> Modifiers;
+    const NRequest::TConfig Config;
+    IInitializationBehaviour::TPtr InitializationBehaviour;
+    IInitializerOutput::TPtr ExternalController;
+    const std::shared_ptr<NProvider::TInitializationSnapshotOwner> InitializationSnapshotOwner;
+    const TString ComponentId;
 };
 
 }

--- a/ydb/services/metadata/initializer/accessor_init.h
+++ b/ydb/services/metadata/initializer/accessor_init.h
@@ -14,7 +14,7 @@
 
 namespace NKikimr::NMetadata::NInitializer {
 
-class TDSAccessorInitialized: public IInitializerInput,
+class TDSAccessorInitialized final : public IInitializerInput,
     public std::enable_shared_from_this<TDSAccessorInitialized>,
     public NModifications::IAlterController,
     public NMetadata::NInitializer::IModifierExternalController
@@ -42,7 +42,7 @@ class TDSAccessorInitialized: public IInitializerInput,
     }
 
 public:
-    virtual ~TDSAccessorInitialized();
+    ~TDSAccessorInitialized();
 
     static void Execute(const NRequest::TConfig& config,
         const TString& componentId,

--- a/ydb/services/metadata/initializer/ut/ut_init.cpp
+++ b/ydb/services/metadata/initializer/ut/ut_init.cpp
@@ -26,20 +26,21 @@
 #include <util/system/type_name.h>
 
 namespace NKikimr {
+
 namespace {
 
-class TTestInitializer: public NMetadata::NInitializer::IInitializationBehaviour {
+class TTestInitializer : public NMetadata::NInitializer::IInitializationBehaviour {
 public:
     bool IsObjectLeaked() const {
         return !LifetimeTracker.expired();
     }
 
 protected:
-    virtual void DoPrepare(NMetadata::NInitializer::IInitializerInput::TPtr controller) const override {
+    void DoPrepare(NMetadata::NInitializer::IInitializerInput::TPtr controller) const override {
         LifetimeTracker = controller;
 
         TVector<NMetadata::NInitializer::ITableModifier::TPtr> result;
-        const TString tablePath = "/Root/.metadata/test";
+        constexpr char tablePath[] = "/Root/.metadata/test";
         {
             Ydb::Table::CreateTableRequest request;
             request.set_session_id("");
@@ -55,6 +56,7 @@ protected:
         result.emplace_back(NMetadata::NInitializer::TACLModifierConstructor::GetReadOnlyModifier(tablePath, "acl"));
         controller->OnPreparationFinished(result);
     }
+
 private:
     mutable std::weak_ptr<NMetadata::NInitializer::IInitializerInput> LifetimeTracker;
 };
@@ -129,31 +131,34 @@ protected:
             controller->OnPreparationFinished(result);
         }
     }
+
 private:
     mutable std::weak_ptr<NMetadata::NInitializer::IInitializerInput> LifetimeTracker;
     mutable bool FailedOnce = false;
 };
 
 template<typename TInitializer>
-class TInitBehaviourTest: public NMetadata::IClassBehaviour {
+class TInitBehaviourTest : public NMetadata::IClassBehaviour {
 public:
     explicit TInitBehaviourTest(std::shared_ptr<TInitializer> init)
         : Initializer(std::move(init))
     {}
 
 protected:
-    virtual TString GetInternalStorageTablePath() const override { return "test"; }
+    TString GetInternalStorageTablePath() const override {
+        return "test";
+    }
     
-    virtual std::shared_ptr<NMetadata::NInitializer::IInitializationBehaviour> ConstructInitializer() const override {
+    std::shared_ptr<NMetadata::NInitializer::IInitializationBehaviour> ConstructInitializer() const override {
         return Initializer;
     }
     
-    virtual std::shared_ptr<NMetadata::NModifications::IOperationsManager> GetOperationsManager() const override {
+    std::shared_ptr<NMetadata::NModifications::IOperationsManager> GetOperationsManager() const override {
         return nullptr;
     }
 
 public:
-    virtual TString GetTypeId() const override {
+    TString GetTypeId() const override {
         return TypeName<TInitBehaviourTest<TInitializer>>();
     }
 
@@ -161,7 +166,7 @@ private:
     std::shared_ptr<TInitializer> Initializer;
 };
 
-class TInitUserEmulator: public NActors::TActorBootstrapped<TInitUserEmulator> {
+class TInitUserEmulator : public NActors::TActorBootstrapped<TInitUserEmulator> {
 private:
     using TBase = NActors::TActorBootstrapped<TInitUserEmulator>;
     using TThis = TInitUserEmulator;
@@ -278,4 +283,5 @@ Y_UNIT_TEST_SUITE(Initializer) {
             "Memory Leak detected: TDSAccessorInitialized instance is still alive!");
     }
 }
+
 } // NKikimr

--- a/ydb/services/metadata/initializer/ut/ut_init.cpp
+++ b/ydb/services/metadata/initializer/ut/ut_init.cpp
@@ -26,82 +26,182 @@
 #include <util/system/type_name.h>
 
 namespace NKikimr {
+namespace {
 
-Y_UNIT_TEST_SUITE(Initializer) {
+class TTestInitializer: public NMetadata::NInitializer::IInitializationBehaviour {
+public:
+    bool IsObjectLeaked() const {
+        return !LifetimeTracker.expired();
+    }
 
-    class TTestInitializer: public NMetadata::NInitializer::IInitializationBehaviour {
-    protected:
-        virtual void DoPrepare(NMetadata::NInitializer::IInitializerInput::TPtr controller) const override {
-            TVector<NMetadata::NInitializer::ITableModifier::TPtr> result;
-            const TString tablePath = "/Root/.metadata/test";
+protected:
+    virtual void DoPrepare(NMetadata::NInitializer::IInitializerInput::TPtr controller) const override {
+        LifetimeTracker = controller;
+
+        TVector<NMetadata::NInitializer::ITableModifier::TPtr> result;
+        const TString tablePath = "/Root/.metadata/test";
+        {
+            Ydb::Table::CreateTableRequest request;
+            request.set_session_id("");
+            request.set_path(tablePath);
+            request.add_primary_key("test");
             {
-                Ydb::Table::CreateTableRequest request;
-                request.set_session_id("");
-                request.set_path(tablePath);
-                request.add_primary_key("test");
-                {
-                    auto& column = *request.add_columns();
-                    column.set_name("test");
-                    column.mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(Ydb::Type::STRING);
-                }
-                result.emplace_back(new NMetadata::NInitializer::TGenericTableModifier<NMetadata::NRequest::TDialogCreateTable>(request, "create"));
+                auto& column = *request.add_columns();
+                column.set_name("test");
+                column.mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(Ydb::Type::STRING);
             }
-            result.emplace_back(NMetadata::NInitializer::TACLModifierConstructor::GetReadOnlyModifier(tablePath, "acl"));
+            result.emplace_back(new NMetadata::NInitializer::TGenericTableModifier<NMetadata::NRequest::TDialogCreateTable>(request, "create"));
+        }
+        result.emplace_back(NMetadata::NInitializer::TACLModifierConstructor::GetReadOnlyModifier(tablePath, "acl"));
+        controller->OnPreparationFinished(result);
+    }
+private:
+    mutable std::weak_ptr<NMetadata::NInitializer::IInitializerInput> LifetimeTracker;
+};
+
+/**
+ * A mock implementation of ITableModifier for testing asynchronous error handling.
+ * 
+ * Main goals:
+ * 1. Test Retry Path: Specifically triggers the 'OnModificationFailed' branch 
+ *    in TDSAccessorInitialized to verify the correctness of the 1-second 
+ *    delayed retry (ScheduleInvokeActivity).
+ * 
+ * 2. Self-Correction: Successfully completes on the second attempt (after failure) 
+ *    to ensure the initialization chain can finish and drop all references.
+ * 
+ * 3. Leak Verification: Used by the test to check if capturing shared_ptr in 
+ *    retry lambdas leads to memory leaks after the final execution.
+ */
+class TMockModifier : public NMetadata::NInitializer::ITableModifier {
+public:
+    explicit TMockModifier(const TString& id)
+        : ITableModifier(id)
+    {}
+
+protected:
+    bool DoExecute(NMetadata::NInitializer::IModifierExternalController::TPtr controller, const NMetadata::NRequest::TConfig&) const override {
+        if (!FailedOnce) {
+            FailedOnce = true;
+            controller->OnModificationFailed(Ydb::StatusIds::BAD_REQUEST, "Simulated Modification Error", GetModificationId());
+        } else {
+            controller->OnModificationFinished(GetModificationId());
+        }
+        return true;
+    }
+
+private:
+    mutable bool FailedOnce = false;
+};
+
+/**
+ * A mock implementation of IInitializationBehaviour designed to check TDSAccessorInitialized.
+ * 
+ * Main goals:
+ * 1. Test failure resilience: Simulates failures during different initialization phases 
+ *    (Preparation, Modification) to trigger asynchronous retry paths 
+ *    (e.g., ScheduleInvokeActivity).
+ * 
+ * 2. Lifecycle tracking: Captures a weak_ptr to the TDSAccessorInitialized instance. 
+ *    This allows verifying that the object is properly destroyed after the 
+ *    initialization chain completes, ensuring no circular dependencies (leaks) 
+ *    exist due to SelfPtr or lambda captures.
+ */
+class TMockInitializer : public NMetadata::NInitializer::IInitializationBehaviour {
+public:
+    bool IsObjectLeaked() const {
+        return !LifetimeTracker.expired();
+    }
+
+protected:
+    virtual void DoPrepare(NMetadata::NInitializer::IInitializerInput::TPtr controller) const override {
+        LifetimeTracker = controller;
+        
+        if (!FailedOnce) {
+            FailedOnce = true;
+            controller->OnPreparationProblem("Simulated preparation failure");
+        } else {
+            TVector<NMetadata::NInitializer::ITableModifier::TPtr> result;
+
+            result.push_back(std::make_shared<TMockModifier>("test_mod_1"));
+            result.push_back(std::make_shared<TMockModifier>("test_mod_2"));
+
             controller->OnPreparationFinished(result);
         }
-    public:
-    };
+    }
+private:
+    mutable std::weak_ptr<NMetadata::NInitializer::IInitializerInput> LifetimeTracker;
+    mutable bool FailedOnce = false;
+};
 
-    class TInitBehaviourTest: public NMetadata::IClassBehaviour {
-    protected:
-        virtual TString GetInternalStorageTablePath() const override {
-            return "test";
-        }
-        virtual std::shared_ptr<NMetadata::NInitializer::IInitializationBehaviour> ConstructInitializer() const override {
-            return std::make_shared<TTestInitializer>();
-        }
-        virtual std::shared_ptr<NMetadata::NModifications::IOperationsManager> GetOperationsManager() const override {
-            return nullptr;
-        }
-    public:
-        virtual TString GetTypeId() const override {
-            return TypeName<TInitBehaviourTest>();
-        }
+template<typename TInitializer>
+class TInitBehaviourTest: public NMetadata::IClassBehaviour {
+public:
+    explicit TInitBehaviourTest(std::shared_ptr<TInitializer> init)
+        : Initializer(std::move(init))
+    {}
 
-        static IClassBehaviour::TPtr GetInstance() {
-            static std::shared_ptr<TInitBehaviourTest> result = std::make_shared<TInitBehaviourTest>();
-            return result;
+protected:
+    virtual TString GetInternalStorageTablePath() const override { return "test"; }
+    
+    virtual std::shared_ptr<NMetadata::NInitializer::IInitializationBehaviour> ConstructInitializer() const override {
+        return Initializer;
+    }
+    
+    virtual std::shared_ptr<NMetadata::NModifications::IOperationsManager> GetOperationsManager() const override {
+        return nullptr;
+    }
+
+public:
+    virtual TString GetTypeId() const override {
+        return TypeName<TInitBehaviourTest<TInitializer>>();
+    }
+
+private:
+    std::shared_ptr<TInitializer> Initializer;
+};
+
+class TInitUserEmulator: public NActors::TActorBootstrapped<TInitUserEmulator> {
+private:
+    using TBase = NActors::TActorBootstrapped<TInitUserEmulator>;
+    using TThis = TInitUserEmulator;
+
+    YDB_READONLY_FLAG(Initialized, false);
+    NMetadata::IClassBehaviour::TPtr ClassBehavior; 
+
+public:
+    explicit TInitUserEmulator(NMetadata::IClassBehaviour::TPtr cb)
+        : ClassBehavior(std::move(cb))
+    {}
+
+    STATEFN(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NMetadata::NProvider::TEvManagerPrepared, Handle);
+            default:
+                Y_ABORT_UNLESS(false);
         }
-    };
+    }
 
-    class TInitUserEmulator: public NActors::TActorBootstrapped<TInitUserEmulator> {
-    private:
-        using TBase = NActors::TActorBootstrapped<TInitUserEmulator>;
-        YDB_READONLY_FLAG(Initialized, false);
-    public:
+    void Handle(NMetadata::NProvider::TEvManagerPrepared::TPtr& /*ev*/) {
+        InitializedFlag = true;
+    }
 
-        STATEFN(StateWork) {
-            switch (ev->GetTypeRewrite()) {
-                hFunc(NMetadata::NProvider::TEvManagerPrepared, Handle);
-                default:
-                    Y_ABORT_UNLESS(false);
-            }
-        }
+    void Bootstrap() {
+        TBase::Become(&TThis::StateWork);
+        this->template Sender<NMetadata::NProvider::TEvPrepareManager>(ClassBehavior)
+            .SendTo(NMetadata::NProvider::MakeServiceId(this->SelfId().NodeId()));
+    }
+};
 
-        void Handle(NMetadata::NProvider::TEvManagerPrepared::TPtr& /*ev*/) {
-            InitializedFlag = true;
-        }
+class TMetaServiceFixture : public NUnitTest::TBaseFixture {
+public:
+    TMetaServiceFixture()
+        : Server(GetServer(PortManager))
+        , Runtime(*Server->GetRuntime())
+        , Helper(*Server)
+    {}
 
-        void Bootstrap() {
-            Become(&TThis::StateWork);
-            Sender<NMetadata::NProvider::TEvPrepareManager>(TInitBehaviourTest::GetInstance()).
-                SendTo(NMetadata::NProvider::MakeServiceId(SelfId().NodeId()));
-        }
-    };
-
-    Y_UNIT_TEST(Simple) {
-        TPortManager pm;
-
+    static Tests::TServer::TPtr GetServer(TPortManager& pm) {
         ui32 grpcPort = pm.GetPort();
         ui32 msgbPort = pm.GetPort();
 
@@ -114,36 +214,68 @@ Y_UNIT_TEST_SUITE(Initializer) {
             .SetUseRealThreads(false)
             .SetEnableMetadataProvider(true)
             .SetEnableOlapSchemaOperations(true);
-        ;
 
-        Tests::TServer::TPtr server = new Tests::TServer(serverSettings);
+        auto server = MakeIntrusive<Tests::TServer>(serverSettings);
         server->EnableGRpc(grpcPort);
-
-        Tests::TClient client(serverSettings);
-
-        auto& runtime = *server->GetRuntime();
-
-        auto sender = runtime.AllocateEdgeActor();
+        
+        auto sender = server->GetRuntime()->AllocateEdgeActor();
         server->SetupRootStoragePools(sender);
+        return server;
+    }
 
-        Tests::NCS::THelper lHelper(*server);
-        lHelper.StartDataRequest("SELECT * FROM `/Root/.metadata/test`", false);
+protected:
+    // Should be first to hold ports
+    TPortManager PortManager;
+    Tests::TServer::TPtr Server;
+    TTestActorRuntime& Runtime;
+    Tests::NCS::THelper Helper;
+};
 
-        TInitUserEmulator* emulator = new TInitUserEmulator;
-        runtime.Register(emulator);
+} // anonymous namespace
 
-        const TInstant start = Now();
-        while (Now() - start < TDuration::Seconds(35) && !emulator->IsInitialized()) {
-            runtime.SimulateSleep(TDuration::Seconds(1));
-        }
+Y_UNIT_TEST_SUITE(Initializer) {
+    Y_UNIT_TEST_F(TestRunWithoutErrors, TMetaServiceFixture) {
+        Helper.StartDataRequest("SELECT * FROM `/Root/.metadata/test`", false);
+        
+        auto tracker = std::make_shared<TTestInitializer>();
+        auto classBehavior = std::make_shared<TInitBehaviourTest<TTestInitializer>>(tracker);
+
+        auto emulator = new TInitUserEmulator(classBehavior);
+        Runtime.Register(emulator);
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] { return emulator->IsInitialized(); };
+        Runtime.DispatchEvents(options);
+
         UNIT_ASSERT(emulator->IsInitialized());
         Cerr << "Initialization finished" << Endl;
 
-        lHelper.StartDataRequest("SELECT * FROM `/Root/.metadata/test`");
-        lHelper.StartSchemaRequest("DROP TABLE `/Root/.metadata/test`", false);
-        lHelper.StartDataRequest("SELECT * FROM `/Root/.metadata/initialization/migrations`");
-        lHelper.StartSchemaRequest("DELETE FROM `/Root/.metadata/initialization/migrations`", false);
-        lHelper.StartSchemaRequest("DROP TABLE `/Root/.metadata/initialization/migrations`", false);
+        Helper.StartDataRequest("SELECT * FROM `/Root/.metadata/test`");
+        Helper.StartSchemaRequest("DROP TABLE `/Root/.metadata/test`", false);
+        Helper.StartDataRequest("SELECT * FROM `/Root/.metadata/initialization/migrations`");
+        Helper.StartSchemaRequest("DELETE FROM `/Root/.metadata/initialization/migrations`", false);
+        Helper.StartSchemaRequest("DROP TABLE `/Root/.metadata/initialization/migrations`", false);
+
+        UNIT_ASSERT_C(!tracker->IsObjectLeaked(), 
+            "Memory Leak detected: TDSAccessorInitialized instance is still alive!");
+    }
+
+    Y_UNIT_TEST_F(TestRunWithErrors, TMetaServiceFixture) {
+        auto tracker = std::make_shared<TMockInitializer>();
+        auto classBehavior = std::make_shared<TInitBehaviourTest<TMockInitializer>>(tracker);
+        auto emulator = new TInitUserEmulator(classBehavior); 
+
+        Runtime.Register(emulator);
+        
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] { return emulator->IsInitialized(); };
+        Runtime.DispatchEvents(options);
+
+        UNIT_ASSERT(emulator->IsInitialized());
+        Cerr << "Initialization finished" << Endl;
+
+        UNIT_ASSERT_C(!tracker->IsObjectLeaked(), 
+            "Memory Leak detected: TDSAccessorInitialized instance is still alive!");
     }
 }
-}
+} // NKikimr


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix broken async retries and leaks

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Broken ScheduleInvokeActivity: The system implementation in library/actors/core/invoke.h was using the real OS monotonic clock (TMonotonic::Now()), this caused a massive gap, preventing any scheduled retry from ever firing during a test.
- Memory Leaks on Failure: TDSAccessorInitialized relied on a manual SelfPtr (a shared_ptr to itself) captured by value in retry lambdas. Because the retries were broken or interrupted, the circular reference was never broken by a final .reset() call, leading to permanent memory leaks.

Fixes: #33961, #33962, #33963, #33964