### PR TITLE
Made tests independent on sys views creation P.5

### DIFF
--- a/ydb/core/tx/schemeshard/ut_base_reboots/ut_base_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_base_reboots/ut_base_reboots.cpp
@@ -35,10 +35,13 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
     }
 
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(CopyWithRebootsAtCommit, 2, 1, true) {
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            ui64 expectedDomainPaths;
             {
                 TInactiveZone inactive(activeZone);
+                auto initialDomainDesc = DescribePath(runtime, "/MyRoot");
+                expectedDomainPaths = initialDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
+
                 t.TestEnv->ReliablePropose(runtime, CreateTableRequest(++t.TxId,
                                                                        "/MyRoot",
                                                                        "Name: \"Table\""
@@ -50,23 +53,25 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
                                                                        "UniformPartitionsCount: 2"),
                                            {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists, NKikimrScheme::StatusMultipleModifications});
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
+                expectedDomainPaths += 1;
             }
 
             t.TestEnv->ReliablePropose(runtime, CopyTableRequest(++t.TxId, "/MyRoot", "NewTable", "/MyRoot/Table"),
                                        {NKikimrScheme::StatusAccepted, NKikimrScheme::StatusAlreadyExists, NKikimrScheme::StatusMultipleModifications});
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            expectedDomainPaths += 1;
 
             {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(3)});
+                                   {NLs::ChildrenCount(4)});
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/NewTable", true),
                                    {NLs::Finished,
                                     NLs::IsTable,
                                     NLs::PartitionCount(2),
                                     NLs::ShardsInsideDomain(4),
-                                    NLs::PathsInsideDomain(3)});
+                                    NLs::PathsInsideDomain(expectedDomainPaths)});
             }
         });
     }
@@ -623,7 +628,6 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
     }
 
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(AlterAndForceDrop, 2, 1, false) {
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TPathVersion pathVersion;
             {
@@ -658,13 +662,12 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
                 TInactiveZone inactive(activeZone);
                 t.TestEnv->TestWaitTabletDeletion(runtime, xrange(TTestTxConfig::FakeHiveTablets, TTestTxConfig::FakeHiveTablets + 1));
                 TestDescribeResult(DescribePath(runtime, "/MyRoot")
-                                       , {NLs::NoChildren});
+                                       , {NLs::ChildrenCount(1)});
             }
         });
     }
 
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(CopyTableWithReboots, 2, 1, false) {
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
                 TInactiveZone inactive(activeZone);
@@ -689,7 +692,7 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
             {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "MyRoot"),
-                                   {NLs::ChildrenCount(4)});
+                                   {NLs::ChildrenCount(5)});
                 TestDescribeResult(DescribePath(runtime, "MyRoot/Table"),
                                    {NLs::PathExist});
                 TestDescribeResult(DescribePath(runtime, "MyRoot/NewTable1"),
@@ -701,7 +704,6 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
     }
 
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(CopyIndexedTableWithReboots, 2, 1, false) {
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
                 TInactiveZone inactive(activeZone);
@@ -747,7 +749,7 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
             {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "MyRoot"),
-                                   {NLs::ChildrenCount(4)});
+                                   {NLs::ChildrenCount(5)});
                 TestDescribeResult(DescribePath(runtime, "MyRoot/Table"),
                                    {NLs::PathExist, NLs::IndexesCount(1)});
                 TestDescribeResult(DescribePath(runtime, "MyRoot/NewTable1"),
@@ -948,8 +950,14 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
     }
 
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(SimultaneousDropForceDrop, 2, 1, false) {
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            ui64 expectedDomainPaths;
+            {
+                TInactiveZone inactive(activeZone);
+                auto initialDomainDesc = DescribePath(runtime, "/MyRoot");
+                expectedDomainPaths = initialDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
+            }
+
             TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
                 Name: "Table1"
                 Columns { Name: "key"   Type: "Uint64" }
@@ -957,10 +965,11 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
                 KeyColumnNames: ["key"]
             )");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            expectedDomainPaths += 1;
 
             TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                {NLs::PathExist,
-                                NLs::ChildrenCount(2)});
+                                NLs::ChildrenCount(3)});
             auto pathVer = TestDescribeResult(DescribePath(runtime, "/MyRoot/Table1"),
                                               {NLs::PathExist,
                                                NLs::PathVersionEqual(3)});
@@ -970,6 +979,7 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
             AsyncForceDropUnsafe(runtime, ++t.TxId,  pathVer.PathId.LocalPathId);
 
             t.TestEnv->TestWaitNotification(runtime, {t.TxId - 1, t.TxId});
+            expectedDomainPaths -= 1;
             t.TestEnv->TestWaitTabletDeletion(runtime, xrange(TTestTxConfig::FakeHiveTablets, TTestTxConfig::FakeHiveTablets + 2));
 
             {
@@ -977,8 +987,8 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Table1"),
                                    {NLs::PathNotExist});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(1),
-                                    NLs::PathsInsideDomain(1),
+                                   {NLs::ChildrenCount(2),
+                                    NLs::PathsInsideDomain(expectedDomainPaths),
                                     NLs::ShardsInsideDomainOneOf({0,1})});
             }
         });

--- a/ydb/core/tx/schemeshard/ut_bsvolume/ut_bsvolume.cpp
+++ b/ydb/core/tx/schemeshard/ut_bsvolume/ut_bsvolume.cpp
@@ -219,7 +219,7 @@ Y_UNIT_TEST_SUITE(TBSV) {
 
     Y_UNIT_TEST(CreateBlockStoreVolumeDirect) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         NKikimrSchemeOp::TBlockStoreVolumeDescription vdescr;
@@ -242,17 +242,17 @@ Y_UNIT_TEST_SUITE(TBSV) {
 
         // Test that schema operation is accepted and recognizes TabletVersion=3
         AsyncCreateBlockStoreVolume(runtime, ++txId, "/MyRoot", vdescr.DebugString());
-        
+
         // Wait for the operation to complete
         env.TestWaitNotification(runtime, txId);
-        
+
         // Verify that the schemeshard created shards for the volume
         // With TabletVersion=3 and 1 partition, we should have 2 shards:
         // - 1 BlockStorePartitionDirect shard
         // - 1 BlockStoreVolumeDirect shard
         TestDescribeResult(DescribePath(runtime, "/MyRoot/BSVolumeDirect"),
                            {NLs::PathExist, NLs::Finished});
-        
+
         // Also verify the partition exists and shard count
         TestDescribeResult(DescribePath(runtime, "/MyRoot/BSVolumeDirect", true, true, true),
                            {NLs::PathExist, NLs::ShardsInsideDomain(2)});


### PR DESCRIPTION
Many SchemeShard tests rely on number of created objects so after changing the number of initial paths tests become failed.
Have to fix it, getting a initial paths count during tests.