### PR TITLE
IgnoredTableRegexes for TLI logs

### DIFF
--- a/ydb/core/base/appdata.cpp
+++ b/ydb/core/base/appdata.cpp
@@ -86,6 +86,7 @@ struct TAppData::TImpl {
     NKikimrConfig::TSystemTabletBackupConfig SystemTabletBackupConfig;
     NKikimrConfig::TRecoveryShardConfig RecoveryShardConfig;
     NKikimrConfig::TClusterDiagnosticsConfig ClusterDiagnosticsConfig;
+    NKikimrConfig::TTliConfig TliConfig;
 };
 
 TAppData::TAppData(
@@ -155,6 +156,7 @@ TAppData::TAppData(
     , SystemTabletBackupConfig(Impl->SystemTabletBackupConfig)
     , RecoveryShardConfig(Impl->RecoveryShardConfig)
     , ClusterDiagnosticsConfig(Impl->ClusterDiagnosticsConfig)
+    , TliConfig(Impl->TliConfig)
     , KikimrShouldContinue(kikimrShouldContinue)
     , TracingConfigurator(MakeIntrusive<NJaegerTracing::TSamplingThrottlingConfigurator>(TimeProvider, RandomProvider))
 {}

--- a/ydb/core/base/appdata_fwd.h
+++ b/ydb/core/base/appdata_fwd.h
@@ -84,6 +84,7 @@ namespace NKikimrConfig {
     class TSystemTabletBackupConfig;
     class TRecoveryShardConfig;
     class TClusterDiagnosticsConfig;
+    class TTliConfig;
 }
 
 namespace NKikimrReplication {
@@ -276,6 +277,7 @@ struct TAppData {
     NKikimrConfig::TSystemTabletBackupConfig& SystemTabletBackupConfig;
     NKikimrConfig::TRecoveryShardConfig& RecoveryShardConfig;
     NKikimrConfig::TClusterDiagnosticsConfig& ClusterDiagnosticsConfig;
+    NKikimrConfig::TTliConfig& TliConfig;
     bool EnforceUserTokenRequirement = false;
     bool EnforceUserTokenCheckRequirement = false; // check token if it was specified
     bool AllowHugeKeyValueDeletes = true; // delete when all clients limit deletes per request

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1635,6 +1635,10 @@ void TKikimrRunner::InitializeAppData(const TKikimrRunConfig& runConfig)
         AppData->ClusterDiagnosticsConfig.CopyFrom(runConfig.AppConfig.GetClusterDiagnosticsConfig());
     }
 
+    if (runConfig.AppConfig.HasTliConfig()) {
+        AppData->TliConfig = runConfig.AppConfig.GetTliConfig();
+    }
+
     TAppDataInitializersList appDataInitializers;
     // setup domain info
     appDataInitializers.AddAppDataInitializer(new TDomainsInitializer(runConfig));

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -854,7 +854,7 @@ protected:
         TasksGraph.GetMeta().SetLockNodeId(SelfId().NodeId());
         TasksGraph.GetMeta().SetQuerySpanId(Request.QuerySpanId);
         for (const auto& regex : AppData()->TliConfig.GetIgnoredTableRegexes()) {
-            TasksGraph.GetMeta().IgnoredTableRegexes.insert(regex);
+            TasksGraph.GetMeta().AddIgnoredTliTableRegex(regex);
         }
 
         switch (Request.IsolationLevel) {

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -853,6 +853,11 @@ protected:
         TasksGraph.GetMeta().SetLockTxId(lockTxId);
         TasksGraph.GetMeta().SetLockNodeId(SelfId().NodeId());
         TasksGraph.GetMeta().SetQuerySpanId(Request.QuerySpanId);
+        if (AppData()) {
+            for (const auto& path : AppData()->TliConfig.GetIgnoredTablePaths()) {
+                TasksGraph.GetMeta().IgnoredTablePaths.push_back(path);
+            }
+        }
 
         switch (Request.IsolationLevel) {
             case NKqpProto::ISOLATION_LEVEL_SNAPSHOT_RW:

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -853,10 +853,8 @@ protected:
         TasksGraph.GetMeta().SetLockTxId(lockTxId);
         TasksGraph.GetMeta().SetLockNodeId(SelfId().NodeId());
         TasksGraph.GetMeta().SetQuerySpanId(Request.QuerySpanId);
-        if (AppData()) {
-            for (const auto& path : AppData()->TliConfig.GetIgnoredTablePaths()) {
-                TasksGraph.GetMeta().IgnoredTablePaths.push_back(path);
-            }
+        for (const auto& path : AppData()->TliConfig.GetIgnoredTablePaths()) {
+            TasksGraph.GetMeta().IgnoredTablePaths.insert(path);
         }
 
         switch (Request.IsolationLevel) {

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -853,8 +853,8 @@ protected:
         TasksGraph.GetMeta().SetLockTxId(lockTxId);
         TasksGraph.GetMeta().SetLockNodeId(SelfId().NodeId());
         TasksGraph.GetMeta().SetQuerySpanId(Request.QuerySpanId);
-        for (const auto& path : AppData()->TliConfig.GetIgnoredTablePaths()) {
-            TasksGraph.GetMeta().IgnoredTablePaths.insert(path);
+        for (const auto& regex : AppData()->TliConfig.GetIgnoredTableRegexes()) {
+            TasksGraph.GetMeta().IgnoredTableRegexes.insert(regex);
         }
 
         switch (Request.IsolationLevel) {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -683,7 +683,6 @@ void TKqpTasksGraph::BuildStreamLookupChannels(const TStageInfo& stageInfo, ui32
     streamLookupTransform.OutputType = streamLookup.GetResultType();
     TTaskInputMeta meta;
     meta.StreamLookupSettings = settings;
-    meta.TablePath = stageInfo.Meta.TablePath;
     BuildTransformChannels(streamLookupTransform, meta, "StreamLookup/Map", stageInfo, inputIndex,
         inputStageInfo, outputIndex, enableSpilling, logFunc);
 }
@@ -1429,7 +1428,7 @@ void TKqpTasksGraph::FillInputDesc(NYql::NDqProto::TTaskInput& inputDesc, const 
 
             if (!isTableImmutable) {
                 const ui64 effectiveSpanId = GetMeta().GetEffectiveQuerySpanId(
-                    GetMeta().QuerySpanId, input.Meta.TablePath);
+                    GetMeta().QuerySpanId, input.Meta.StreamLookupSettings->GetTable().GetPath());
                 if (effectiveSpanId) {
                     input.Meta.StreamLookupSettings->SetQuerySpanId(effectiveSpanId);
                 }

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -683,6 +683,7 @@ void TKqpTasksGraph::BuildStreamLookupChannels(const TStageInfo& stageInfo, ui32
     streamLookupTransform.OutputType = streamLookup.GetResultType();
     TTaskInputMeta meta;
     meta.StreamLookupSettings = settings;
+    meta.TablePath = stageInfo.Meta.TablePath;
     BuildTransformChannels(streamLookupTransform, meta, "StreamLookup/Map", stageInfo, inputIndex,
         inputStageInfo, outputIndex, enableSpilling, logFunc);
 }
@@ -747,6 +748,7 @@ void TKqpTasksGraph::BuildVectorResolveChannels(const TStageInfo& stageInfo, ui3
     vectorResolveTransform.OutputType = vectorResolve.GetOutputType();
     TTaskInputMeta meta;
     meta.VectorResolveSettings = settings;
+    meta.TablePath = stageInfo.Meta.TablePath;
     BuildTransformChannels(vectorResolveTransform, meta, "VectorResolve/Map", stageInfo, inputIndex,
         inputStageInfo, outputIndex, enableSpilling, logFunc);
 }
@@ -1425,8 +1427,12 @@ void TKqpTasksGraph::FillInputDesc(NYql::NDqProto::TTaskInput& inputDesc, const 
                         : NKikimrDataEvents::OPTIMISTIC);
             }
 
-            if (GetMeta().QuerySpanId && !isTableImmutable) {
-                input.Meta.StreamLookupSettings->SetQuerySpanId(GetMeta().QuerySpanId);
+            if (!isTableImmutable) {
+                const ui64 effectiveSpanId = GetMeta().GetEffectiveQuerySpanId(
+                    GetMeta().QuerySpanId, input.Meta.TablePath);
+                if (effectiveSpanId) {
+                    input.Meta.StreamLookupSettings->SetQuerySpanId(effectiveSpanId);
+                }
             }
 
             transformProto->MutableSettings()->PackFrom(*input.Meta.StreamLookupSettings);
@@ -1449,8 +1455,12 @@ void TKqpTasksGraph::FillInputDesc(NYql::NDqProto::TTaskInput& inputDesc, const 
                 input.Meta.VectorResolveSettings->SetLockMode(*GetMeta().LockMode);
             }
 
-            if (GetMeta().QuerySpanId) {
-                input.Meta.VectorResolveSettings->SetQuerySpanId(GetMeta().QuerySpanId);
+            {
+                const ui64 effectiveSpanId = GetMeta().GetEffectiveQuerySpanId(
+                    GetMeta().QuerySpanId, input.Meta.TablePath);
+                if (effectiveSpanId) {
+                    input.Meta.VectorResolveSettings->SetQuerySpanId(effectiveSpanId);
+                }
             }
 
             transformProto->MutableSettings()->PackFrom(*input.Meta.VectorResolveSettings);
@@ -2564,8 +2574,10 @@ void TKqpTasksGraph::FillScanTaskLockTxId(NKikimrTxDataShard::TKqpReadRangesSour
         settings.SetLockTxId(*lockTxId);
         settings.SetLockNodeId(GetMeta().ExecuterId.NodeId());
     }
-    if (GetMeta().QuerySpanId) {
-        settings.SetQuerySpanId(GetMeta().QuerySpanId);
+    const ui64 effectiveSpanId = GetMeta().GetEffectiveQuerySpanId(
+        GetMeta().QuerySpanId, settings.GetTable().GetTablePath());
+    if (effectiveSpanId) {
+        settings.SetQuerySpanId(effectiveSpanId);
     }
 }
 
@@ -2885,10 +2897,14 @@ void TKqpTasksGraph::FillKqpTableSinkSettings(NKikimrKqp::TKqpTableSinkSettings&
         settings.SetLockMode(*GetMeta().LockMode);
     }
         // Use per-transaction QuerySpanId if available (for deferred effects),
-        // otherwise fall back to global QuerySpanId
-        ui64 querySpanId = GetMeta().GetTxQuerySpanId(task.StageId.TxId);
-        if (querySpanId) {
-            settings.SetQuerySpanId(querySpanId);
+        // otherwise fall back to global QuerySpanId; apply per-table suppression.
+        {
+            const ui64 rawSpanId = GetMeta().GetTxQuerySpanId(task.StageId.TxId);
+            const ui64 effectiveSpanId = GetMeta().GetEffectiveQuerySpanId(
+                rawSpanId, settings.GetTable().GetPath());
+            if (effectiveSpanId) {
+                settings.SetQuerySpanId(effectiveSpanId);
+            }
         }
 
     auto sinkPosition = std::lower_bound(

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -258,8 +258,21 @@ struct TGraphMeta {
         return QuerySpanId;  // Fall back to global QuerySpanId
     }
 
+    ui64 GetEffectiveQuerySpanId(ui64 spanId, const TString& tablePath) const {
+        if (spanId == 0) {
+            return 0;
+        }
+        for (const auto& path : IgnoredTablePaths) {
+            if (tablePath == path) {
+                return 0;
+            }
+        }
+        return spanId;
+    }
+
     ui64 QuerySpanId = 0;
     THashMap<ui32, ui64> TxQuerySpanIds;  // Per-transaction QuerySpanIds (for deferred effects)
+    TVector<TString> IgnoredTablePaths;
 };
 
 struct TTaskInputMeta {
@@ -269,6 +282,8 @@ struct TTaskInputMeta {
     NKikimrKqp::TKqpStreamLookupSettings* StreamLookupSettings = nullptr;
     NKikimrKqp::TKqpSequencerSettings* SequencerSettings = nullptr;
     NKikimrTxDataShard::TKqpVectorResolveSettings* VectorResolveSettings = nullptr;
+    // Fully-qualified table path for TLI filtering; populated for stream lookup and vector resolve inputs.
+    TString TablePath;
 };
 
 struct TTaskOutputMeta {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -259,20 +259,18 @@ struct TGraphMeta {
     }
 
     ui64 GetEffectiveQuerySpanId(ui64 spanId, const TString& tablePath) const {
-        if (spanId == 0) {
-            return 0;
+        if (spanId == 0 || tablePath.empty()) {
+            return spanId;
         }
-        for (const auto& path : IgnoredTablePaths) {
-            if (tablePath == path) {
-                return 0;
-            }
+        if (IgnoredTablePaths.contains(tablePath)) {
+            return 0;
         }
         return spanId;
     }
 
     ui64 QuerySpanId = 0;
     THashMap<ui32, ui64> TxQuerySpanIds;  // Per-transaction QuerySpanIds (for deferred effects)
-    TVector<TString> IgnoredTablePaths;
+    THashSet<TString> IgnoredTablePaths;
 };
 
 struct TTaskInputMeta {
@@ -282,7 +280,8 @@ struct TTaskInputMeta {
     NKikimrKqp::TKqpStreamLookupSettings* StreamLookupSettings = nullptr;
     NKikimrKqp::TKqpSequencerSettings* SequencerSettings = nullptr;
     NKikimrTxDataShard::TKqpVectorResolveSettings* VectorResolveSettings = nullptr;
-    // Fully-qualified table path for TLI filtering; populated for stream lookup and vector resolve inputs.
+    // Fully-qualified table path for TLI filtering (vector resolve only;
+    // stream lookup reads path from its proto settings directly).
     TString TablePath;
 };
 

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "shard_key_ranges.h"
+#include <regex>
 
 #include <ydb/core/kqp/common/kqp_tx_manager.h>
 #include <ydb/core/kqp/common/kqp_user_request_context.h>
@@ -262,15 +263,18 @@ struct TGraphMeta {
         if (spanId == 0 || tablePath.empty()) {
             return spanId;
         }
-        if (IgnoredTablePaths.contains(tablePath)) {
-            return 0;
+        for (const auto& pattern : IgnoredTableRegexes) {
+            std::regex regexPattern(pattern.c_str());
+            if (std::regex_match(tablePath.c_str(), regexPattern)) {
+                return 0;
+            }
         }
         return spanId;
     }
 
     ui64 QuerySpanId = 0;
     THashMap<ui32, ui64> TxQuerySpanIds;  // Per-transaction QuerySpanIds (for deferred effects)
-    THashSet<TString> IgnoredTablePaths;
+    THashSet<TString> IgnoredTableRegexes;
 };
 
 struct TTaskInputMeta {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -263,18 +263,28 @@ struct TGraphMeta {
         if (spanId == 0 || tablePath.empty()) {
             return spanId;
         }
-        for (const auto& pattern : IgnoredTableRegexes) {
-            std::regex regexPattern(pattern.c_str());
-            if (std::regex_match(tablePath.c_str(), regexPattern)) {
+        for (const auto& regex : IgnoredTliTableRegexes) {
+            if (std::regex_match(tablePath.begin(), tablePath.end(), regex)) {
                 return 0;
             }
         }
         return spanId;
     }
 
+    bool AddIgnoredTliTableRegex(const TString& pattern) {
+        try {
+            IgnoredTliTableRegexes.emplace_back(std::string(pattern));
+            return true;
+        } catch (const std::regex_error&) {
+            // Invalid regex pattern - silently ignore it
+            // The pattern will not be added to the list, so no tables will be filtered by it
+            return false;
+        }
+    }
+
     ui64 QuerySpanId = 0;
     THashMap<ui32, ui64> TxQuerySpanIds;  // Per-transaction QuerySpanIds (for deferred effects)
-    THashSet<TString> IgnoredTableRegexes;
+    TVector<std::regex> IgnoredTliTableRegexes;  // Pre-compiled regexes for ignored tables
 };
 
 struct TTaskInputMeta {

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -1496,7 +1496,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
             "T should emit breaker TLI log for tWriteTable1 (T is both breaker and victim)");
     }
 
-    Y_UNIT_TEST(IgnoredTablePaths) {
+    Y_UNIT_TEST(IgnoredTableRegexes) {
         TStringStream ss;
 
         TKikimrSettings settings = MakeKikimrSettings(ss);
@@ -1540,7 +1540,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         VerifyNoTliLogsForIgnoredTable(issues, ss, breakerUpdate1);
     }
 
-    Y_UNIT_TEST(IgnoredTablePathsSeparateQueries) {
+    Y_UNIT_TEST(IgnoredTableRegexesSeparateQueries) {
         TStringStream ss;
 
         TKikimrSettings settings = MakeKikimrSettings(ss);

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -1500,7 +1500,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         TStringStream ss;
 
         TKikimrSettings settings = MakeKikimrSettings(ss);
-        settings.AppConfig.MutableTliConfig()->AddIgnoredTablePaths("/Root/Tenant1/Table1");
+        settings.AppConfig.MutableTliConfig()->AddIgnoredTableRegexes("/Root/.*/Table1");
         TTliTestContext ctx(std::move(settings));
 
         ctx.CreateAndSeedTables(3);
@@ -1544,7 +1544,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         TStringStream ss;
 
         TKikimrSettings settings = MakeKikimrSettings(ss);
-        settings.AppConfig.MutableTliConfig()->AddIgnoredTablePaths("/Root/Tenant1/Table1");
+        settings.AppConfig.MutableTliConfig()->AddIgnoredTableRegexes("/Root/Tenant1/Table1");
         TTliTestContext ctx(std::move(settings));
 
         ctx.CreateAndSeedTables(3);

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -536,6 +536,15 @@ namespace {
             ConfigureKikimrForTli(Kikimr, logEnabled);
         }
 
+        TTliTestContext(TKikimrSettings settings)
+            : Kikimr(std::move(settings))
+            , Client(Kikimr.GetQueryClient())
+            , Session(Client.GetSession().GetValueSync().GetSession())
+            , VictimSession(Client.GetSession().GetValueSync().GetSession())
+        {
+            ConfigureKikimrForTli(Kikimr);
+        }
+
         void CreateTable(const TString& tableName) {
             CreateTableInSession(Session, tableName);
         }
@@ -769,6 +778,24 @@ namespace {
 
         UNIT_ASSERT_C(ss.Str().find("TLI INFO") == TString::npos,
             "no TLI INFO logs expected when TLI logs are disabled");
+    }
+
+    void VerifyNoTliLogsForIgnoredTable(
+        const TString& issues,
+        TStringStream& ss,
+        const TString& breakerQueryText)
+    {
+        UNIT_ASSERT_C(issues.Contains("Transaction locks invalidated"),
+            "Issue should contain 'Transaction locks invalidated': " << issues);
+
+        UNIT_ASSERT_C(!issues.Contains("BreakerQuerySpanId:"),
+            "Issue should NOT contain 'BreakerQuerySpanId:': " << issues);
+
+        const auto patterns = MakeTliLogPatterns();
+        auto breakerSpan = ExtractBreakerQuerySpanId(ss.Str(), "SessionActor",
+            patterns.BreakerSessionActorMessagePattern, breakerQueryText);
+        UNIT_ASSERT_C(!breakerSpan,
+            "BreakerQuerySpanId for ignored table should be absent in TLI logs, breakerQuery: " << breakerQueryText);
     }
 
     // ==================== DataQuery backward-compatibility helpers ====================
@@ -1469,6 +1496,102 @@ Y_UNIT_TEST_SUITE(KqpTli) {
             "T should emit breaker TLI log for tWriteTable1 (T is both breaker and victim)");
     }
 
+    Y_UNIT_TEST(IgnoredTablePaths) {
+        TStringStream ss;
+
+        TKikimrSettings settings = MakeKikimrSettings(ss);
+        settings.AppConfig.MutableTliConfig()->AddIgnoredTablePaths("/Root/Tenant1/Table1");
+        TTliTestContext ctx(std::move(settings));
+
+        ctx.CreateAndSeedTables(3);
+
+        // Victim: JOIN of 3 tables — Table1 is ignored, Table2 and Table3 are not
+        const TString victimQueryText = R"(
+            SELECT t1.Value, t2.Value, t3.Value
+            FROM `/Root/Tenant1/Table1` AS t1
+            JOIN `/Root/Tenant1/Table2` AS t2 ON t1.Key = t2.Key
+            JOIN `/Root/Tenant1/Table3` AS t3 ON t1.Key = t3.Key
+            WHERE t1.Key = 1u
+        )";
+        const TString victimCommitText = "UPDATE `/Root/Tenant1/Table3` SET Value = \"VictimUpdate\" WHERE Key = 1u";
+
+        const TString breakerUpdate1 = "UPDATE `/Root/Tenant1/Table1` SET Value = \"Breaker1\" WHERE Key = 1u";
+        const TString breakerUpdate2 = "UPDATE `/Root/Tenant1/Table2` SET Value = \"Breaker2\" WHERE Key = 1u";
+        const TString breakerUpdate3 = "UPDATE `/Root/Tenant1/Table3` SET Value = \"Breaker3\" WHERE Key = 1u";
+
+        auto victimTx = BeginReadTx(ctx.VictimSession, victimQueryText);
+        ExecuteInTx(ctx.VictimSession, victimTx, victimCommitText);
+
+        auto breakerTx = BeginTx(ctx.Session, breakerUpdate1);
+        ExecuteInTx(ctx.Session, *breakerTx, breakerUpdate2);
+        ExecuteAndCommitTx(ctx.Session, *breakerTx, breakerUpdate3);
+
+        auto [status, issues] = CommitTxWithIssues(victimTx);
+        UNIT_ASSERT_VALUES_EQUAL(status, EStatus::ABORTED);
+
+        // Table2 and Table3 (NOT ignored): full TLI verification
+        // 3 breaker records: Table2 immediate + Table3 immediate + Table3 deferred
+        VerifyTliIssueAndLogs(issues, ss, breakerUpdate2, victimQueryText, victimCommitText,
+            /* expectedBreakerCount */ 3, /* expectedVictimCount */ 1);
+        VerifyTliIssueAndLogs(issues, ss, breakerUpdate3, victimQueryText, victimCommitText,
+            /* expectedBreakerCount */ 3, /* expectedVictimCount */ 1);
+
+        // Table1 (IGNORED): no breaker TLI records
+        VerifyNoTliLogsForIgnoredTable(issues, ss, breakerUpdate1);
+    }
+
+    Y_UNIT_TEST(IgnoredTablePathsSeparateQueries) {
+        TStringStream ss;
+
+        TKikimrSettings settings = MakeKikimrSettings(ss);
+        settings.AppConfig.MutableTliConfig()->AddIgnoredTablePaths("/Root/Tenant1/Table1");
+        TTliTestContext ctx(std::move(settings));
+
+        ctx.CreateAndSeedTables(3);
+        const TString tablePathPrefix = "PRAGMA TablePathPrefix = \"/Root/Tenant1\";\n";
+
+        // Two victims: both touch ignored Table1 first, then lock different non-ignored tables.
+        TSession victim2Session = ctx.Client.GetSession().GetValueSync().GetSession();
+
+        const TString victim1ReadIgnored = tablePathPrefix + "SELECT * FROM Table1 WHERE Key = 1u";
+        const TString victim1QueryText = tablePathPrefix + "SELECT * FROM Table2 WHERE Key = 1u";
+        const TString victim1CommitText = tablePathPrefix + "UPDATE Table2 SET Value = \"Victim2Update\" WHERE Key = 1u";
+
+        const TString victim2ReadIgnored = tablePathPrefix + "SELECT * FROM Table1 WHERE Key = 1u";
+        const TString victim2QueryText = tablePathPrefix + "SELECT * FROM Table3 WHERE Key = 1u";
+        const TString victim2CommitText = tablePathPrefix + "UPDATE Table3 SET Value = \"Victim3Update\" WHERE Key = 1u";
+
+        const TString breakerUpdate1 = tablePathPrefix + "UPDATE Table1 SET Value = \"Breaker1\" WHERE Key = 1u";
+        const TString breakerUpdate2 = tablePathPrefix + "UPDATE Table2 SET Value = \"Breaker2\" WHERE Key = 1u";
+        const TString breakerUpdate3 = tablePathPrefix + "UPDATE Table3 SET Value = \"Breaker3\" WHERE Key = 1u";
+
+        auto victim1Tx = BeginReadTx(ctx.VictimSession, victim1ReadIgnored);
+        ExecuteInTx(ctx.VictimSession, victim1Tx, victim1QueryText);
+
+        auto victim2Tx = BeginReadTx(victim2Session, victim2ReadIgnored);
+        ExecuteInTx(victim2Session, victim2Tx, victim2QueryText);
+
+        auto breakerTx = BeginTx(ctx.Session, breakerUpdate1);
+        ExecuteInTx(ctx.Session, *breakerTx, breakerUpdate2);
+        ExecuteInTx(ctx.Session, *breakerTx, breakerUpdate3);
+        NKqp::AssertSuccessResult(breakerTx->Commit().GetValueSync());
+
+        auto [status1, issues1] = ExecuteVictimCommitWithIssues(ctx.VictimSession, victim1Tx, victim1CommitText);
+        UNIT_ASSERT_VALUES_EQUAL(status1, EStatus::ABORTED);
+
+        auto [status2, issues2] = ExecuteVictimCommitWithIssues(victim2Session, victim2Tx, victim2CommitText);
+        UNIT_ASSERT_VALUES_EQUAL(status2, EStatus::ABORTED);
+
+        // Verify each non-ignored table independently like other multi-victim tests.
+        VerifyTliIssueAndLogs(issues1, ss, breakerUpdate2, victim1QueryText, victim1CommitText,
+            /* expectedBreakerCount */ 4, /* expectedVictimCount */ 2);
+        VerifyTliIssueAndLogs(issues2, ss, breakerUpdate3, victim2QueryText, victim2CommitText,
+            /* expectedBreakerCount */ 4, /* expectedVictimCount */ 2);
+
+        // Table1 (IGNORED): no breaker TLI records.
+        VerifyNoTliLogsForIgnoredTable(issues1, ss, breakerUpdate1);
+    }
+
     // ==================== DataQuery backward-compatibility tests ====================
     // These tests verify that TLI logging works correctly with the legacy DataQuery API
     // (NYdb::NTable::TTableClient / ExecuteDataQuery).
@@ -1523,6 +1646,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
 
         VerifyTliIssueAndLogs(issues, ss, breakerQueryText, victimQueryText, victimCommitText);
     }
+
 }
 
 } // namespace NKqp

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2984,6 +2984,10 @@ message TNbsConfig {
     optional NYdb.NBS.NProto.TStorageServiceConfig NbsStorageConfig = 2;
 }
 
+message TTliConfig {
+    repeated string IgnoredTablePaths = 1;
+}
+
 message TAppConfig {
     option (NMarkers.Root) = true;
     optional TActorSystemConfig ActorSystemConfig = 1;
@@ -3100,6 +3104,8 @@ message TAppConfig {
     optional TClusterDiagnosticsConfig ClusterDiagnosticsConfig = 118;
 
     optional TNbsConfig NbsConfig = 119;
+
+    optional TTliConfig TliConfig = 120;
 }
 
 message TYdbVersion {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2985,7 +2985,7 @@ message TNbsConfig {
 }
 
 message TTliConfig {
-    repeated string IgnoredTablePaths = 1;
+    repeated string IgnoredTableRegexes = 1;
 }
 
 message TAppConfig {

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -576,6 +576,7 @@ namespace Tests {
             MERGE_CFG_FROM_SETTINGS(BridgeConfig);
             MERGE_CFG_FROM_APP_CFG(StatisticsConfig);
             MERGE_CFG_FROM_APP_CFG(SystemTabletBackupConfig);
+            MERGE_CFG_FROM_APP_CFG(TliConfig);
 #undef MERGE_CFG_FROM_SETTINGS
 #undef MERGE_APP_CFG_FROM
 #undef MERGE_CFG_FROM_APP_CFG


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Ignoring using a regular expression over the table name in TLI logging.

```text
message TTliConfig {
    repeated string IgnoredTableRegexes = 1;
}
```
If a query references multiple tables, one can be excluded from logging while the other one will still be logged.

#### For example:
```
IgnoredTableRegexes = Table1
```
Queries:

```sql
SELECT t1.Value, t2.Value, t3.Value
FROM `/Root/Tenant1/Table1` AS t1
JOIN `/Root/Tenant1/Table2` AS t2 ON t1.Key = t2.Key
WHERE t1.Key = 1u;

UPDATE `/Root/Tenant1/Table2` SET Value = "VictimUpdate" WHERE Key = 1u;
```
or

```sql
SELECT * FROM Table1 WHERE Key = 1u;
SELECT * FROM Table2 WHERE Key = 1u;
UPDATE Table2 SET Value = "Victim2Update" WHERE Key = 1u;
```

In TLI logs, Table1 will not be tracked - only Table2 will.

The only place where Table1 will be mentioned is in the full query texts within the logs related to Table2.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
