### PR TITLE
NBS2: use hash maps instead of maps; do not use bad perf convert to string method

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.h
@@ -83,16 +83,16 @@ class TICStorageTransportActor
 private:
     ui64 RequestIdGenerator = 0;
 
-    TMap<ui64, TEvICStorageTransportPrivate::TEvConnect>
+    THashMap<ui64, TEvICStorageTransportPrivate::TEvConnect>
         ConnectEventsByRequestId;
-    TMap<ui64, TEvICStorageTransportPrivate::TEvWritePersistentBuffer>
+    THashMap<ui64, TEvICStorageTransportPrivate::TEvWritePersistentBuffer>
         WritePersistentBufferEventsByRequestId;
-    TMap<ui64, TEvICStorageTransportPrivate::TEvErasePersistentBuffer>
+    THashMap<ui64, TEvICStorageTransportPrivate::TEvErasePersistentBuffer>
         ErasePersistentBufferEventsByRequestId;
-    TMap<ui64, TEvICStorageTransportPrivate::TEvReadPersistentBuffer>
+    THashMap<ui64, TEvICStorageTransportPrivate::TEvReadPersistentBuffer>
         ReadPersistentBufferEventsByRequestId;
-    TMap<ui64, TEvICStorageTransportPrivate::TEvRead> ReadEventsByRequestId;
-    TMap<ui64, TEvICStorageTransportPrivate::TEvSyncWithPersistentBuffer>
+    THashMap<ui64, TEvICStorageTransportPrivate::TEvRead> ReadEventsByRequestId;
+    THashMap<ui64, TEvICStorageTransportPrivate::TEvSyncWithPersistentBuffer>
         SyncEventsByRequestId;
 
 public:

--- a/ydb/core/nbs/cloud/storage/core/libs/common/block_data_ref.h
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/block_data_ref.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <ydb/library/actors/util/rope.h>
+
 #include <util/generic/hash.h>
 #include <util/generic/strbuf.h>
 #include <util/generic/string.h>
@@ -47,6 +49,11 @@ public:
     static TBlockDataRef Create(const TVector<ui8>& data)
     {
         return {reinterpret_cast<const char*>(data.data()), data.size()};
+    }
+
+    static TBlockDataRef Create(const TRope& data)
+    {
+        return {data.Begin().ContiguousData(), data.GetSize()};
     }
 
     static TBlockDataRef CreateZeroBlock(size_t len)


### PR DESCRIPTION
use hash maps instead of maps; do not use bad perf convert to string method