### PR TITLE
Remove scheduled trigger from automerge workflow

### DIFF
--- a/.github/workflows/automerge_for_muted_ya.yml
+++ b/.github/workflows/automerge_for_muted_ya.yml
@@ -2,7 +2,7 @@
 name: Automerge for muted_ya (main)
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: #cron disabled cause of bug in github api: automerge lead to missing of labels in on close pull events env
 
 jobs:
   set-automerge:

--- a/.github/workflows/automerge_for_muted_ya.yml
+++ b/.github/workflows/automerge_for_muted_ya.yml
@@ -2,8 +2,6 @@
 name: Automerge for muted_ya (main)
 
 on:
-  schedule:
-    - cron: "0 8 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
cron disabled cause of bug in github api: automerge lead to missing of labels in on close pull events env

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
