### PR TITLE
TLI: Store BreakerQuerySpanId in lock, propagate deferred breaker info through commit pipeline

### DIFF
--- a/ydb/core/kqp/common/kqp_tli.h
+++ b/ydb/core/kqp/common/kqp_tli.h
@@ -74,22 +74,21 @@ class TQueryTextCollector {
 public:
     // First query always stored (for victim stats); subsequent only if TLI enabled
     void AddQueryText(ui64 querySpanId, const TString& queryText) {
-        if (queryText.empty()) {
+        if (querySpanId == 0 || queryText.empty()) {
             return;
         }
+
         TNodeQueryTextCache::Instance().Add(querySpanId, queryText);
 
-        if (QueryTexts.empty() || IS_INFO_LOG_ENABLED(NKikimrServices::TLI)) {
-            // Deduplicate consecutive identical entries
-            if (QueryTexts.empty() ||
-                QueryTexts.back().first != querySpanId ||
-                QueryTexts.back().second != queryText) {
-                QueryTexts.push_back({querySpanId, queryText});
-                // Keep only the last N queries to prevent unbounded memory growth
-                constexpr size_t MAX_QUERY_TEXTS = 100;
-                while (QueryTexts.size() > MAX_QUERY_TEXTS) {
-                    QueryTexts.pop_front();
-                }
+        // Deduplicate consecutive identical entries
+        if (QueryTexts.empty() ||
+            QueryTexts.back().first != querySpanId ||
+            QueryTexts.back().second != queryText) {
+            QueryTexts.push_back({querySpanId, queryText});
+            // Keep only the last N queries to prevent unbounded memory growth
+            constexpr size_t MAX_QUERY_TEXTS = 100;
+            while (QueryTexts.size() > MAX_QUERY_TEXTS) {
+                QueryTexts.pop_front();
             }
         }
     }

--- a/ydb/core/kqp/common/kqp_tli.h
+++ b/ydb/core/kqp/common/kqp_tli.h
@@ -226,7 +226,14 @@ inline void LogTli(const TTliLogParams& params, const NActors::TActorContext& ct
         LogKeyValue("VictimQueryTexts", EscapeC(params.QueryTexts), ss, true);
     }
 
-    LOG_INFO_S(ctx, NKikimrServices::TLI, ss.Str());
+    auto infoMsg = ss.Str();
+    LOG_TRACE_S(ctx, NKikimrServices::TLI,
+        "TLI TRACE LogTli: emitting INFO record"
+        << " isBreaker=" << isBreaker
+        << " msgLen=" << infoMsg.size()
+        << " BreakerQuerySpanId=" << (params.BreakerQuerySpanId.Defined() ? ToString(*params.BreakerQuerySpanId) : "none")
+        << " VictimQuerySpanId=" << (params.VictimQuerySpanId.Defined() ? ToString(*params.VictimQuerySpanId) : "none"));
+    LOG_INFO_S(ctx, NKikimrServices::TLI, infoMsg);
 }
 
 }

--- a/ydb/core/kqp/common/kqp_tli.h
+++ b/ydb/core/kqp/common/kqp_tli.h
@@ -92,6 +92,13 @@ public:
                 }
             }
         }
+
+        if (IS_LOG_PRIORITY_ENABLED(NActors::NLog::PRI_TRACE, NKikimrServices::TLI)) {
+            LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::TLI,
+                "TLI TRACE AddQueryText: querySpanId=" << querySpanId
+                << " queryTextLen=" << queryText.size()
+                << " totalCollected=" << QueryTexts.size());
+        }
     }
 
     // Combine all query texts into a single string for logging
@@ -176,6 +183,15 @@ struct TTliLogParams {
 };
 
 inline void LogTli(const TTliLogParams& params, const NActors::TActorContext& ctx) {
+    LOG_TRACE_S(ctx, NKikimrServices::TLI,
+        "TLI TRACE LogTli: Component=" << params.Component
+        << " Message=" << params.Message
+        << " BreakerQuerySpanId=" << (params.BreakerQuerySpanId.Defined() ? ToString(*params.BreakerQuerySpanId) : "none")
+        << " VictimQuerySpanId=" << (params.VictimQuerySpanId.Defined() ? ToString(*params.VictimQuerySpanId) : "none")
+        << " CurrentQuerySpanId=" << (params.CurrentQuerySpanId.Defined() ? ToString(*params.CurrentQuerySpanId) : "none")
+        << " QueryText=" << params.QueryText.size() << "ch"
+        << " IsCommitAction=" << params.IsCommitAction);
+
     if (!IS_INFO_LOG_ENABLED(NKikimrServices::TLI)) {
         return;
     }

--- a/ydb/core/kqp/common/kqp_tli.h
+++ b/ydb/core/kqp/common/kqp_tli.h
@@ -92,13 +92,6 @@ public:
                 }
             }
         }
-
-        if (IS_LOG_PRIORITY_ENABLED(NActors::NLog::PRI_TRACE, NKikimrServices::TLI)) {
-            LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::TLI,
-                "TLI TRACE AddQueryText: querySpanId=" << querySpanId
-                << " queryTextLen=" << queryText.size()
-                << " totalCollected=" << QueryTexts.size());
-        }
     }
 
     // Combine all query texts into a single string for logging
@@ -183,15 +176,6 @@ struct TTliLogParams {
 };
 
 inline void LogTli(const TTliLogParams& params, const NActors::TActorContext& ctx) {
-    LOG_TRACE_S(ctx, NKikimrServices::TLI,
-        "TLI TRACE LogTli: Component=" << params.Component
-        << " Message=" << params.Message
-        << " BreakerQuerySpanId=" << (params.BreakerQuerySpanId.Defined() ? ToString(*params.BreakerQuerySpanId) : "none")
-        << " VictimQuerySpanId=" << (params.VictimQuerySpanId.Defined() ? ToString(*params.VictimQuerySpanId) : "none")
-        << " CurrentQuerySpanId=" << (params.CurrentQuerySpanId.Defined() ? ToString(*params.CurrentQuerySpanId) : "none")
-        << " QueryText=" << params.QueryText.size() << "ch"
-        << " IsCommitAction=" << params.IsCommitAction);
-
     if (!IS_INFO_LOG_ENABLED(NKikimrServices::TLI)) {
         return;
     }
@@ -226,14 +210,7 @@ inline void LogTli(const TTliLogParams& params, const NActors::TActorContext& ct
         LogKeyValue("VictimQueryTexts", EscapeC(params.QueryTexts), ss, true);
     }
 
-    auto infoMsg = ss.Str();
-    LOG_TRACE_S(ctx, NKikimrServices::TLI,
-        "TLI TRACE LogTli: emitting INFO record"
-        << " isBreaker=" << isBreaker
-        << " msgLen=" << infoMsg.size()
-        << " BreakerQuerySpanId=" << (params.BreakerQuerySpanId.Defined() ? ToString(*params.BreakerQuerySpanId) : "none")
-        << " VictimQuerySpanId=" << (params.VictimQuerySpanId.Defined() ? ToString(*params.VictimQuerySpanId) : "none"));
-    LOG_INFO_S(ctx, NKikimrServices::TLI, infoMsg);
+    LOG_INFO_S(ctx, NKikimrServices::TLI, ss.Str());
 }
 
 }

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -314,9 +314,6 @@ public:
     }
 
     void HandleFinalize(TEvKqpBuffer::TEvResult::TPtr& ev) {
-        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
-            "TLI TRACE DataExecuter HandleFinalize: hasStats=" << (ev->Get()->Stats.has_value())
-            << " hasStatsObj=" << (Stats != nullptr));
         if (ev->Get()->Stats && Stats) {
             Stats->AddBufferStats(std::move(*ev->Get()->Stats));
         }
@@ -1265,9 +1262,6 @@ private:
 
     void Handle(TEvKqpBuffer::TEvError::TPtr& ev) {
         auto& msg = *ev->Get();
-        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
-            "TLI TRACE DataExecuter Handle(TEvError): hasStats=" << msg.Stats.has_value()
-            << " statusCode=" << NYql::NDqProto::StatusIds_StatusCode_Name(msg.StatusCode));
         if (msg.Stats && Stats) {
             Stats->AddBufferStats(std::move(*msg.Stats));
         }
@@ -3123,17 +3117,7 @@ private:
                 {
                     const auto& traceIds = info.GetDeferredBreakerQuerySpanIds();
                     const auto& nodeIds = info.GetDeferredBreakerNodeIds();
-                    if (!traceIds.empty()) {
-                        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
-                            "TLI TRACE DataExecuter: collecting " << traceIds.size()
-                            << " deferred breakers from read actor result"
-                            << " nodeIds.size=" << nodeIds.size());
-                    }
                     for (int i = 0; i < traceIds.size(); ++i) {
-                        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
-                            "TLI TRACE DataExecuter: deferred breaker[" << i
-                            << "] spanId=" << traceIds[i]
-                            << " nodeId=" << (i < nodeIds.size() ? nodeIds[i] : 0u));
                         ResponseEv->DeferredBreakers.push_back({
                             traceIds[i],
                             i < nodeIds.size() ? nodeIds[i] : 0u

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -314,6 +314,9 @@ public:
     }
 
     void HandleFinalize(TEvKqpBuffer::TEvResult::TPtr& ev) {
+        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
+            "TLI TRACE DataExecuter HandleFinalize: hasStats=" << (ev->Get()->Stats.has_value())
+            << " hasStatsObj=" << (Stats != nullptr));
         if (ev->Get()->Stats && Stats) {
             Stats->AddBufferStats(std::move(*ev->Get()->Stats));
         }
@@ -1262,6 +1265,9 @@ private:
 
     void Handle(TEvKqpBuffer::TEvError::TPtr& ev) {
         auto& msg = *ev->Get();
+        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
+            "TLI TRACE DataExecuter Handle(TEvError): hasStats=" << msg.Stats.has_value()
+            << " statusCode=" << NYql::NDqProto::StatusIds_StatusCode_Name(msg.StatusCode));
         if (msg.Stats && Stats) {
             Stats->AddBufferStats(std::move(*msg.Stats));
         }
@@ -3117,7 +3123,17 @@ private:
                 {
                     const auto& traceIds = info.GetDeferredBreakerQuerySpanIds();
                     const auto& nodeIds = info.GetDeferredBreakerNodeIds();
+                    if (!traceIds.empty()) {
+                        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
+                            "TLI TRACE DataExecuter: collecting " << traceIds.size()
+                            << " deferred breakers from read actor result"
+                            << " nodeIds.size=" << nodeIds.size());
+                    }
                     for (int i = 0; i < traceIds.size(); ++i) {
+                        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
+                            "TLI TRACE DataExecuter: deferred breaker[" << i
+                            << "] spanId=" << traceIds[i]
+                            << " nodeId=" << (i < nodeIds.size() ? nodeIds[i] : 0u));
                         ResponseEv->DeferredBreakers.push_back({
                             traceIds[i],
                             i < nodeIds.size() ? nodeIds[i] : 0u

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -7,6 +7,7 @@
 
 #include <ydb/core/kqp/common/kqp_ru_calc.h>
 #include <ydb/core/kqp/common/kqp_lwtrace_probes.h>
+#include <ydb/library/services/services.pb.h>
 #include <ydb/core/kqp/common/kqp_types.h>
 #include <ydb/core/kqp/runtime/kqp_transport.h>
 #include <ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h>
@@ -1486,6 +1487,14 @@ protected:
                 }
             }
         }
+
+        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
+            "TLI TRACE Executer MakeResponseAndPassAway:"
+            << " Stats->LocksBrokenAsBreaker=" << Stats->LocksBrokenAsBreaker
+            << " Stats->LocksBrokenAsVictim=" << Stats->LocksBrokenAsVictim
+            << " Stats->BreakerQuerySpanIds.size=" << Stats->BreakerQuerySpanIds.size()
+            << " ResponseEv->BreakerQuerySpanIds.size=" << ResponseEv->BreakerQuerySpanIds.size()
+            << " ResponseEv->DeferredBreakers.size=" << ResponseEv->DeferredBreakers.size());
 
         Request.Transactions.crop(0);
         this->Send(Target, ResponseEv.release());

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -7,7 +7,6 @@
 
 #include <ydb/core/kqp/common/kqp_ru_calc.h>
 #include <ydb/core/kqp/common/kqp_lwtrace_probes.h>
-#include <ydb/library/services/services.pb.h>
 #include <ydb/core/kqp/common/kqp_types.h>
 #include <ydb/core/kqp/runtime/kqp_transport.h>
 #include <ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h>
@@ -1496,15 +1495,6 @@ protected:
                 }
             }
         }
-
-        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
-            "TLI TRACE Executer MakeResponseAndPassAway:"
-            << " Stats->LocksBrokenAsBreaker=" << Stats->LocksBrokenAsBreaker
-            << " Stats->LocksBrokenAsVictim=" << Stats->LocksBrokenAsVictim
-            << " Stats->BreakerQuerySpanIds.size=" << Stats->BreakerQuerySpanIds.size()
-            << " ResponseEv->BreakerQuerySpanIds.size=" << ResponseEv->BreakerQuerySpanIds.size()
-            << " Stats->DeferredBreakers.size=" << Stats->DeferredBreakers.size()
-            << " ResponseEv->DeferredBreakers.size=" << ResponseEv->DeferredBreakers.size());
 
         Request.Transactions.crop(0);
         this->Send(Target, ResponseEv.release());

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1487,6 +1487,15 @@ protected:
                 }
             }
         }
+        // Transfer deferred breaker info from stats to response
+        {
+            THashSet<ui64> seen;
+            for (const auto& breaker : Stats->DeferredBreakers) {
+                if (seen.insert(breaker.QuerySpanId).second) {
+                    ResponseEv->DeferredBreakers.push_back({breaker.QuerySpanId, breaker.NodeId});
+                }
+            }
+        }
 
         LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
             "TLI TRACE Executer MakeResponseAndPassAway:"
@@ -1494,6 +1503,7 @@ protected:
             << " Stats->LocksBrokenAsVictim=" << Stats->LocksBrokenAsVictim
             << " Stats->BreakerQuerySpanIds.size=" << Stats->BreakerQuerySpanIds.size()
             << " ResponseEv->BreakerQuerySpanIds.size=" << ResponseEv->BreakerQuerySpanIds.size()
+            << " Stats->DeferredBreakers.size=" << Stats->DeferredBreakers.size()
             << " ResponseEv->DeferredBreakers.size=" << ResponseEv->DeferredBreakers.size());
 
         Request.Transactions.crop(0);

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -1,8 +1,6 @@
 #include "kqp_executer_stats.h"
 
 #include <ydb/core/protos/kqp_stats.pb.h>
-#include <ydb/library/actors/core/log.h>
-#include <ydb/library/services/services.pb.h>
 
 namespace NKikimr::NKqp {
 
@@ -862,16 +860,6 @@ ui64 TQueryExecutionStats::EstimateFinishMem() {
 }
 
 void TQueryExecutionStats::CollectLockStats(const NKikimrQueryStats::TTxStats& txStats) {
-    if (txStats.GetLocksBrokenAsBreaker() > 0 || txStats.GetLocksBrokenAsVictim() > 0) {
-        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
-            "TLI TRACE CollectLockStats(DataShard): incoming LocksBrokenAsBreaker=" << txStats.GetLocksBrokenAsBreaker()
-            << " LocksBrokenAsVictim=" << txStats.GetLocksBrokenAsVictim()
-            << " BreakerQuerySpanIds.size=" << txStats.BreakerQuerySpanIdsSize()
-            << " DeferredBreakerQuerySpanIds.size=" << txStats.DeferredBreakerQuerySpanIdsSize()
-            << " accumulated LocksBrokenAsBreaker=" << LocksBrokenAsBreaker
-            << " accumulated BreakerQuerySpanIds.size=" << BreakerQuerySpanIds.size()
-            << " accumulated DeferredBreakers.size=" << DeferredBreakers.size());
-    }
     LocksBrokenAsBreaker += txStats.GetLocksBrokenAsBreaker();
     LocksBrokenAsVictim += txStats.GetLocksBrokenAsVictim();
     if (txStats.GetLocksBrokenAsBreaker() > 0) {
@@ -928,14 +916,6 @@ void TQueryExecutionStats::AddDatashardStats(NKikimrQueryStats::TTxStats&& txSta
 void TQueryExecutionStats::AddBufferStats(NYql::NDqProto::TDqTaskStats&& taskStats) {
     NKqpProto::TKqpTaskExtraStats extraStats;
     if (taskStats.GetExtra().UnpackTo(&extraStats)) {
-        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
-            "TLI TRACE AddBufferStats: incoming BrokenAsBreaker=" << extraStats.GetLockStats().GetBrokenAsBreaker()
-            << " BrokenAsVictim=" << extraStats.GetLockStats().GetBrokenAsVictim()
-            << " BreakerQuerySpanIds.size=" << extraStats.GetLockStats().BreakerQuerySpanIdsSize()
-            << " DeferredBreakerQuerySpanIds.size=" << extraStats.GetLockStats().DeferredBreakerQuerySpanIdsSize()
-            << " accumulated LocksBrokenAsBreaker=" << LocksBrokenAsBreaker
-            << " accumulated BreakerQuerySpanIds.size=" << BreakerQuerySpanIds.size()
-            << " accumulated DeferredBreakers.size=" << DeferredBreakers.size());
         LocksBrokenAsBreaker += extraStats.GetLockStats().GetBrokenAsBreaker();
         LocksBrokenAsVictim += extraStats.GetLockStats().GetBrokenAsVictim();
         for (auto id : extraStats.GetLockStats().GetBreakerQuerySpanIds()) {
@@ -955,9 +935,6 @@ void TQueryExecutionStats::AddBufferStats(NYql::NDqProto::TDqTaskStats&& taskSta
                 }
             }
         }
-    } else {
-        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
-            "TLI TRACE AddBufferStats: failed to unpack TKqpTaskExtraStats from buffer");
     }
     UpdateStorageTables(taskStats, nullptr);
 }

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -1,6 +1,8 @@
 #include "kqp_executer_stats.h"
 
 #include <ydb/core/protos/kqp_stats.pb.h>
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/services/services.pb.h>
 
 namespace NKikimr::NKqp {
 
@@ -860,6 +862,14 @@ ui64 TQueryExecutionStats::EstimateFinishMem() {
 }
 
 void TQueryExecutionStats::CollectLockStats(const NKikimrQueryStats::TTxStats& txStats) {
+    if (txStats.GetLocksBrokenAsBreaker() > 0 || txStats.GetLocksBrokenAsVictim() > 0) {
+        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
+            "TLI TRACE CollectLockStats(DataShard): incoming LocksBrokenAsBreaker=" << txStats.GetLocksBrokenAsBreaker()
+            << " LocksBrokenAsVictim=" << txStats.GetLocksBrokenAsVictim()
+            << " BreakerQuerySpanIds.size=" << txStats.BreakerQuerySpanIdsSize()
+            << " accumulated LocksBrokenAsBreaker=" << LocksBrokenAsBreaker
+            << " accumulated BreakerQuerySpanIds.size=" << BreakerQuerySpanIds.size());
+    }
     LocksBrokenAsBreaker += txStats.GetLocksBrokenAsBreaker();
     LocksBrokenAsVictim += txStats.GetLocksBrokenAsVictim();
     if (txStats.GetLocksBrokenAsBreaker() > 0) {
@@ -906,6 +916,12 @@ void TQueryExecutionStats::AddDatashardStats(NKikimrQueryStats::TTxStats&& txSta
 void TQueryExecutionStats::AddBufferStats(NYql::NDqProto::TDqTaskStats&& taskStats) {
     NKqpProto::TKqpTaskExtraStats extraStats;
     if (taskStats.GetExtra().UnpackTo(&extraStats)) {
+        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
+            "TLI TRACE AddBufferStats: incoming BrokenAsBreaker=" << extraStats.GetLockStats().GetBrokenAsBreaker()
+            << " BrokenAsVictim=" << extraStats.GetLockStats().GetBrokenAsVictim()
+            << " BreakerQuerySpanIds.size=" << extraStats.GetLockStats().BreakerQuerySpanIdsSize()
+            << " accumulated LocksBrokenAsBreaker=" << LocksBrokenAsBreaker
+            << " accumulated BreakerQuerySpanIds.size=" << BreakerQuerySpanIds.size());
         LocksBrokenAsBreaker += extraStats.GetLockStats().GetBrokenAsBreaker();
         LocksBrokenAsVictim += extraStats.GetLockStats().GetBrokenAsVictim();
         for (auto id : extraStats.GetLockStats().GetBreakerQuerySpanIds()) {
@@ -913,6 +929,9 @@ void TQueryExecutionStats::AddBufferStats(NYql::NDqProto::TDqTaskStats&& taskSta
                 BreakerQuerySpanIds.push_back(id);
             }
         }
+    } else {
+        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TLI,
+            "TLI TRACE AddBufferStats: failed to unpack TKqpTaskExtraStats from buffer");
     }
     UpdateStorageTables(taskStats, nullptr);
 }

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.h
@@ -405,6 +405,12 @@ public:
     ui64 LocksBrokenAsVictim = 0;
     TVector<ui64> BreakerQuerySpanIds;
 
+    struct TDeferredBreakerInfo {
+        ui64 QuerySpanId = 0;
+        ui32 NodeId = 0;
+    };
+    TVector<TDeferredBreakerInfo> DeferredBreakers;
+
     void CollectLockStats(const NKikimrQueryStats::TTxStats& txStats);
 
     void UpdateQueryTables(const NYql::NDqProto::TDqTaskStats& taskStats, NKikimrQueryStats::TTxStats* txStats);

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -4845,6 +4845,11 @@ public:
             for (ui64 id : txStats.GetBreakerQuerySpanIds()) {
                 BreakerQuerySpanIds.push_back(id);
             }
+            for (size_t i = 0; i < static_cast<size_t>(txStats.DeferredBreakerQuerySpanIdsSize()); ++i) {
+                DeferredBreakerQuerySpanIds.push_back(txStats.GetDeferredBreakerQuerySpanIds(i));
+                DeferredBreakerNodeIds.push_back(
+                    i < static_cast<size_t>(txStats.DeferredBreakerNodeIdsSize()) ? txStats.GetDeferredBreakerNodeIds(i) : 0u);
+            }
         }
     }
 
@@ -5110,8 +5115,10 @@ public:
             "TLI TRACE BufferWriteActor BuildStats:"
             << " LocksBrokenAsBreaker=" << LocksBrokenAsBreaker
             << " LocksBrokenAsVictim=" << LocksBrokenAsVictim
-            << " BreakerQuerySpanIds.size=" << BreakerQuerySpanIds.size());
-        TKqpTableWriterStatistics::AddLockStats(&result, LocksBrokenAsBreaker, LocksBrokenAsVictim, BreakerQuerySpanIds);
+            << " BreakerQuerySpanIds.size=" << BreakerQuerySpanIds.size()
+            << " DeferredBreakerQuerySpanIds.size=" << DeferredBreakerQuerySpanIds.size());
+        TKqpTableWriterStatistics::AddLockStats(&result, LocksBrokenAsBreaker, LocksBrokenAsVictim, BreakerQuerySpanIds,
+                                                DeferredBreakerQuerySpanIds, DeferredBreakerNodeIds);
         return result;
     }
 
@@ -5189,6 +5196,8 @@ private:
     ui64 LocksBrokenAsBreaker = 0;
     ui64 LocksBrokenAsVictim = 0;
     TVector<ui64> BreakerQuerySpanIds;
+    TVector<ui64> DeferredBreakerQuerySpanIds;
+    TVector<ui32> DeferredBreakerNodeIds;
 
     // Deferred error for STATUS_LOCKS_BROKEN during distributed prepare/commit.
     // Allows remaining shards to respond (with breaker TLI stats) before

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -4809,6 +4809,9 @@ public:
         if (IsImmediateCommit || PendingLocksBrokenError) {
             return false;
         }
+        if (!IS_INFO_LOG_ENABLED(NKikimrServices::TLI)) {
+            return false;
+        }
         PendingLocksBrokenError.emplace(NYql::NDqProto::StatusIds::ABORTED, std::move(issues));
         if (CurrentStateFunc() == &TThis::StateCommit) {
             if (TxManager->ConsumeCommitResult(shardId)) {

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -104,9 +104,13 @@ public:
             KqpSessionSpan.Attribute("database", AppData()->TenantName);
         }
         if (IS_INFO_LOG_ENABLED(NKikimrServices::TLI)) {
-            QuerySpanId = KqpSessionSpan ?
-                *reinterpret_cast<const ui64*>(KqpSessionSpan.GetTraceId().GetSpanIdPtr()) :
-                RandomNumber<ui64>();
+            if (KqpSessionSpan) {
+                QuerySpanId = *reinterpret_cast<const ui64*>(KqpSessionSpan.GetTraceId().GetSpanIdPtr());
+            } else {
+                while (QuerySpanId == 0) { // avoid 0 as query span id
+                    QuerySpanId = RandomNumber<ui64>();
+                }
+            }
         }
         if (RequestEv->GetUserRequestContext()) {
             UserRequestContext = RequestEv->GetUserRequestContext();

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2294,9 +2294,9 @@ public:
     }
 
     // Emit TLI breaker logs for direct lock breaks (one log per shard that broke locks).
-    void EmitBreakerTliLogs(TEvKqpExecuter::TEvTxResponse* ev) {
+    void EmitBreakerLogs(TEvKqpExecuter::TEvTxResponse* ev) {
         LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-            "TLI TRACE EmitBreakerTliLogs: LocksBrokenAsBreaker=" << ev->LocksBrokenAsBreaker
+            "TLI TRACE EmitBreakerLogs: LocksBrokenAsBreaker=" << ev->LocksBrokenAsBreaker
             << " BreakerQuerySpanIds.size=" << ev->BreakerQuerySpanIds.size()
             << " IS_INFO_LOG_ENABLED=" << IS_INFO_LOG_ENABLED(NKikimrServices::TLI)
             << " Action=" << static_cast<int>(QueryState->GetAction())
@@ -2304,7 +2304,7 @@ public:
 
         if (ev->LocksBrokenAsBreaker == 0 || !IS_INFO_LOG_ENABLED(NKikimrServices::TLI)) {
             LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                "TLI TRACE EmitBreakerTliLogs: skipped"
+                "TLI TRACE EmitBreakerLogs: skipped"
                 << " LocksBrokenAsBreaker=" << ev->LocksBrokenAsBreaker
                 << " IS_INFO=" << IS_INFO_LOG_ENABLED(NKikimrServices::TLI));
             return;
@@ -2316,7 +2316,7 @@ public:
         if (!ev->BreakerQuerySpanIds.empty()) {
             TString combinedQueryTexts = QueryState->TxCtx ? QueryState->TxCtx->QueryTextCollector.CombineQueryTexts() : TString();
             LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                "TLI TRACE EmitBreakerTliLogs: emitting " << ev->BreakerQuerySpanIds.size()
+                "TLI TRACE EmitBreakerLogs: emitting " << ev->BreakerQuerySpanIds.size()
                 << " breaker records, isCommitAction=" << isCommitAction
                 << " hasTxCtx=" << (QueryState->TxCtx != nullptr)
                 << " combinedQueryTexts.size=" << combinedQueryTexts.size());
@@ -2326,13 +2326,13 @@ public:
                     breakerQueryText = QueryState->TxCtx->QueryTextCollector.GetQueryTextBySpanId(breakerQuerySpanId);
                 }
                 LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                    "TLI TRACE EmitBreakerTliLogs: spanId=" << breakerQuerySpanId
+                    "TLI TRACE EmitBreakerLogs: spanId=" << breakerQuerySpanId
                     << " queryTextFromCollector=" << (breakerQueryText.empty() ? "empty" : "found")
                     << " queryTextLen=" << breakerQueryText.size());
                 if (breakerQueryText.empty()) {
                     breakerQueryText = QueryState->ExtractQueryText();
                     LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                        "TLI TRACE EmitBreakerTliLogs: fallback to ExtractQueryText, len=" << breakerQueryText.size());
+                        "TLI TRACE EmitBreakerLogs: fallback to ExtractQueryText, len=" << breakerQueryText.size());
                 }
 
                 NDataIntegrity::LogTli(NDataIntegrity::TTliLogParams{
@@ -2347,7 +2347,7 @@ public:
             }
         } else {
             LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                "TLI TRACE EmitBreakerTliLogs: fallback path (no BreakerQuerySpanIds)"
+                "TLI TRACE EmitBreakerLogs: fallback path (no BreakerQuerySpanIds)"
                 << " currentQuerySpanId=" << QueryState->GetQuerySpanId());
             NDataIntegrity::LogTli(NDataIntegrity::TTliLogParams{
                 .Component = "SessionActor",
@@ -2362,13 +2362,13 @@ public:
     }
 
     // Emit TLI breaker logs for deferred lock scenarios (lock broken between snapshot and re-read).
-    void EmitDeferredBreakerTliLogs(TEvKqpExecuter::TEvTxResponse* ev) {
+    void EmitDeferredBreakerLogs(TEvKqpExecuter::TEvTxResponse* ev) {
         LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-            "TLI TRACE EmitDeferredBreakerTliLogs: DeferredBreakers.size=" << ev->DeferredBreakers.size());
+            "TLI TRACE EmitDeferredBreakerLogs: DeferredBreakers.size=" << ev->DeferredBreakers.size());
 
         if (ev->DeferredBreakers.empty() || !IS_INFO_LOG_ENABLED(NKikimrServices::TLI)) {
             LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                "TLI TRACE EmitDeferredBreakerTliLogs: skipped"
+                "TLI TRACE EmitDeferredBreakerLogs: skipped"
                 << " DeferredBreakers.empty=" << ev->DeferredBreakers.empty());
             return;
         }
@@ -2381,7 +2381,7 @@ public:
             TString breakerQueryText = NDataIntegrity::TNodeQueryTextCache::Instance().Get(breaker.QuerySpanId);
 
             LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                "TLI TRACE EmitDeferredBreakerTliLogs: breaker spanId=" << breaker.QuerySpanId
+                "TLI TRACE EmitDeferredBreakerLogs: breaker spanId=" << breaker.QuerySpanId
                 << " nodeId=" << breaker.NodeId
                 << " localNodeId=" << localNodeId
                 << " cacheHit=" << !breakerQueryText.empty()
@@ -2395,7 +2395,7 @@ public:
                 }
 
                 LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                    "TLI TRACE EmitDeferredBreakerTliLogs: emitting local deferred breaker log"
+                    "TLI TRACE EmitDeferredBreakerLogs: emitting local deferred breaker log"
                     << " spanId=" << breaker.QuerySpanId);
 
                 NDataIntegrity::LogTli(NDataIntegrity::TTliLogParams{
@@ -2409,7 +2409,7 @@ public:
                 }, TlsActivationContext->AsActorContext());
             } else {
                 LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-                    "TLI TRACE EmitDeferredBreakerTliLogs: spawning TDeferredTliLogActor"
+                    "TLI TRACE EmitDeferredBreakerLogs: spawning TDeferredTliLogActor"
                     << " spanId=" << breaker.QuerySpanId
                     << " remoteNodeId=" << breaker.NodeId);
                 Register(new TDeferredTliLogActor(
@@ -2552,8 +2552,8 @@ public:
             << " status=" << response->GetStatus()
             << " TraceId=" << TraceId());
 
-        EmitBreakerTliLogs(ev);
-        EmitDeferredBreakerTliLogs(ev);
+        EmitBreakerLogs(ev);
+        EmitDeferredBreakerLogs(ev);
 
         if (QueryState->TxCtx->TxManager) {
             QueryState->ParticipantNodes = QueryState->TxCtx->TxManager->GetParticipantNodes();

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2580,7 +2580,6 @@ public:
             switch (status) {
                 case Ydb::StatusIds::ABORTED: {
                     if (QueryState->TxCtx->TxManager && QueryState->TxCtx->TxManager->BrokenLocks()) {
-                        YQL_ENSURE(!issues.Empty());
                         auto brokenLockQuerySpanId = QueryState->TxCtx->TxManager->GetVictimQuerySpanId();
                         // Use TxManager's broken locks count as fallback when executer stats don't
                         // carry LocksBrokenAsVictim (e.g. lock invalidation detected via AddLock

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -206,11 +206,13 @@ private:
     }
 
     void HandleUndelivered(TEvents::TEvUndelivered::TPtr&) {
+        // Target node unreachable, emit log with empty query text
         EmitLog("");
         PassAway();
     }
 
     void HandleTimeout() {
+        // Lookup timed out, emit log with empty query text to avoid leaking actors
         EmitLog("");
         PassAway();
     }
@@ -2312,6 +2314,7 @@ public:
                 }, TlsActivationContext->AsActorContext());
             }
         } else {
+            // Fallback: no BreakerQuerySpanIds from DataShard, use current query
             NDataIntegrity::LogTli(NDataIntegrity::TTliLogParams{
                 .Component = "SessionActor",
                 .Message = isCommitAction ? "Commit had broken other locks" : "Query had broken other locks",

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2364,15 +2364,12 @@ public:
     // Emit TLI breaker logs for deferred lock scenarios (lock broken between snapshot and re-read).
     void EmitDeferredBreakerTliLogs(TEvKqpExecuter::TEvTxResponse* ev) {
         LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
-            "TLI TRACE EmitDeferredBreakerTliLogs: DeferredBreakers.size=" << ev->DeferredBreakers.size()
-            << " IS_INFO_LOG_ENABLED=" << IS_INFO_LOG_ENABLED(NKikimrServices::TLI)
-            << " TraceId=" << TraceId());
+            "TLI TRACE EmitDeferredBreakerTliLogs: DeferredBreakers.size=" << ev->DeferredBreakers.size());
 
         if (ev->DeferredBreakers.empty() || !IS_INFO_LOG_ENABLED(NKikimrServices::TLI)) {
             LOG_TRACE_S(TlsActivationContext->AsActorContext(), NKikimrServices::TLI,
                 "TLI TRACE EmitDeferredBreakerTliLogs: skipped"
-                << " DeferredBreakers.empty=" << ev->DeferredBreakers.empty()
-                << " IS_INFO=" << IS_INFO_LOG_ENABLED(NKikimrServices::TLI));
+                << " DeferredBreakers.empty=" << ev->DeferredBreakers.empty());
             return;
         }
 

--- a/ydb/core/protos/kqp_stats.proto
+++ b/ydb/core/protos/kqp_stats.proto
@@ -52,6 +52,8 @@ message TKqpLockStats {
     uint64 BrokenAsBreaker = 1;
     uint64 BrokenAsVictim = 2;
     repeated uint64 BreakerQuerySpanIds = 4;  // QuerySpanIds of all queries that broke locks (one per shard/table)
+    repeated uint64 DeferredBreakerQuerySpanIds = 5;  // QuerySpanIds of breakers found via deferred lock validation
+    repeated uint32 DeferredBreakerNodeIds = 6;  // Node IDs matching DeferredBreakerQuerySpanIds
 }
 
 // extra for NYql.NDqProto.TDqTaskStats

--- a/ydb/core/protos/query_stats.proto
+++ b/ydb/core/protos/query_stats.proto
@@ -47,6 +47,8 @@ message TTxStats {
     optional uint64 LocksBrokenAsBreaker = 5; // locks broken by this transaction
     optional uint64 LocksBrokenAsVictim = 6;  // this transaction's locks were broken by others
     repeated uint64 BreakerQuerySpanIds = 9; // QuerySpanIds of queries that wrote to this shard and broke other locks
+    repeated uint64 DeferredBreakerQuerySpanIds = 10; // QuerySpanIds of breakers found via deferred lock validation at commit
+    repeated uint32 DeferredBreakerNodeIds = 11; // Node IDs matching DeferredBreakerQuerySpanIds
 
     // TODO:
     // optional uint64 CommitLatencyUsec = 3;

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2549,6 +2549,8 @@ message TInMemoryLockInfo {
     repeated NKikimrProto.TPathID ReadTables = 8;
     repeated NKikimrProto.TPathID WriteTables = 9;
     optional uint64 VictimQuerySpanId = 10;
+    optional uint64 BreakerQuerySpanId = 11;
+    optional uint32 BreakerNodeId = 12;
 }
 
 // In-memory ranges associated with the lock

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -2693,11 +2693,6 @@ private:
             victimQuerySpanId = state.QuerySpanId;
         }
 
-        LOG_TRACE_S(ctx, NKikimrServices::TLI,
-            "TLI TRACE DataShard " << Self->TabletID()
-            << ": broken lock in ApplyLocks, lockId=" << lock.LockId
-            << " victimQuerySpanId=" << (victimQuerySpanId ? ToString(*victimQuerySpanId) : "none"));
-
         NDataIntegrity::LogVictimDetected(ctx, Self->TabletID(),
             "Read transaction was a victim of broken locks",
             victimQuerySpanId,
@@ -3410,11 +3405,6 @@ public:
                     TMaybe<ui64> victimQuerySpanId = state.Lock->GetVictimQuerySpanId()
                         ? TMaybe<ui64>(state.Lock->GetVictimQuerySpanId())
                         : (state.QuerySpanId ? TMaybe<ui64>(state.QuerySpanId) : Nothing());
-
-                    LOG_TRACE_S(ctx, NKikimrServices::TLI,
-                        "TLI TRACE DataShard " << Self->TabletID()
-                        << ": broken lock in TTxReadContinue, lockId=" << state.Lock->GetLockId()
-                        << " victimQuerySpanId=" << (victimQuerySpanId ? ToString(*victimQuerySpanId) : "none"));
 
                     NDataIntegrity::LogVictimDetected(ctx, Self->TabletID(),
                         "Read transaction was a victim of broken locks",

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3155,17 +3155,6 @@ public:
         return result;
     }
 
-    // Find breaker info for the write that happened at exactly the given version
-    TVector<TBreakerInfo> FindBreakerInfoForTliAtVersion(const TRowVersion& breakVersion) const {
-        TVector<TBreakerInfo> result;
-        for (const auto& entry : RecentWritesForTli) {
-            if (entry.WriteVersion == breakVersion) {
-                result.push_back({entry.QuerySpanId, entry.SenderNodeId});
-            }
-        }
-        return result;
-    }
-
     auto& GetLockChangeRecords() {
         return LockChangeRecords;
     }

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3155,6 +3155,17 @@ public:
         return result;
     }
 
+    // Find breaker info for the write that happened at exactly the given version
+    TVector<TBreakerInfo> FindBreakerInfoForTliAtVersion(const TRowVersion& breakVersion) const {
+        TVector<TBreakerInfo> result;
+        for (const auto& entry : RecentWritesForTli) {
+            if (entry.WriteVersion == breakVersion) {
+                result.push_back({entry.QuerySpanId, entry.SenderNodeId});
+            }
+        }
+        return result;
+    }
+
     auto& GetLockChangeRecords() {
         return LockChangeRecords;
     }

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3112,7 +3112,7 @@ private:
     // Cache for tracking recent writes for TLI breaker linkage in deferred lock creation scenarios
     // Maps (MvccVersion) -> QuerySpanId for writes that may have broken locks
     // Used when InvisibleRowSkips are detected to identify the breaker
-    static constexpr size_t MaxRecentWritesForTli = 1000;
+    static constexpr size_t MaxRecentWritesForTli = 10000;
     struct TRecentWriteForTli {
         TRowVersion WriteVersion;
         ui64 QuerySpanId;

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -541,12 +541,6 @@ public:
                     for (const auto& brokenLock : brokenLocks) {
                         FillDeferredBreakerInfo(brokenLock.GetLockId(), txStats);
                     }
-                    if (txStats->DeferredBreakerQuerySpanIdsSize() > 0) {
-                        LOG_TRACE_S(ctx, NKikimrServices::TLI,
-                            "TLI TRACE DataShard " << tabletId
-                            << ": victim commit found " << txStats->DeferredBreakerQuerySpanIdsSize()
-                            << " deferred breakers");
-                    }
                 }
 
                 for (auto& brokenLock : brokenLocks) {

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -105,6 +105,13 @@ public:
 
             NDataIntegrity::LogLocksBroken(ctx, DataShard.TabletID(), message,
                 otherLocksBroken, primaryBreakerSpanId, victimQuerySpanIds);
+
+            for (ui64 lockId : otherLocksBroken) {
+                auto lockInfo = DataShard.SysLocksTable().GetRawLock(lockId);
+                if (lockInfo) {
+                    lockInfo->ConsumeBreakerInfo();
+                }
+            }
         }
         return otherLocksBroken.size();
     }

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -43,12 +43,12 @@ public:
 
     void FillDeferredBreakerInfo(ui64 lockTxId, NKikimrQueryStats::TTxStats* txStats) {
         auto lockInfo = DataShard.SysLocksTable().GetRawLock(lockTxId);
-        if (lockInfo && lockInfo->GetBreakVersion()) {
-            auto breakers = DataShard.FindBreakerInfoForTliAtVersion(*lockInfo->GetBreakVersion());
-            for (const auto& breaker : breakers) {
-                txStats->AddDeferredBreakerQuerySpanIds(breaker.QuerySpanId);
-                txStats->AddDeferredBreakerNodeIds(breaker.SenderNodeId);
-            }
+        if (!lockInfo || !lockInfo->GetBreakVersion()) {
+            return;
+        }
+        if (lockInfo->GetBreakerQuerySpanId() && !lockInfo->IsBreakerConsumed()) {
+            txStats->AddDeferredBreakerQuerySpanIds(lockInfo->GetBreakerQuerySpanId());
+            txStats->AddDeferredBreakerNodeIds(lockInfo->GetBreakerNodeId());
         }
     }
 

--- a/ydb/core/tx/datashard/memory_state_migration.cpp
+++ b/ydb/core/tx/datashard/memory_state_migration.cpp
@@ -167,6 +167,10 @@ private:
                 if (protoLock.HasVictimQuerySpanId()) {
                     row.VictimQuerySpanId = protoLock.GetVictimQuerySpanId();
                 }
+                if (protoLock.HasBreakerQuerySpanId()) {
+                    row.BreakerQuerySpanId = protoLock.GetBreakerQuerySpanId();
+                    row.BreakerNodeId = protoLock.GetBreakerNodeId();
+                }
                 if (protoLock.HasBreakVersion()) {
                     row.BreakVersion = TRowVersion::FromProto(protoLock.GetBreakVersion());
                 }
@@ -635,6 +639,10 @@ TDataShard::TPreservedInMemoryState TDataShard::PreserveInMemoryState() {
         protoLockInfo->SetFlags((ui64)lockInfo.GetFlags());
         if (ui64 victimId = lockInfo.GetVictimQuerySpanId(); victimId != 0) {
             protoLockInfo->SetVictimQuerySpanId(victimId);
+        }
+        if (ui64 breakerSpanId = lockInfo.GetBreakerQuerySpanId(); breakerSpanId != 0) {
+            protoLockInfo->SetBreakerQuerySpanId(breakerSpanId);
+            protoLockInfo->SetBreakerNodeId(lockInfo.GetBreakerNodeId());
         }
         if (const auto& version = lockInfo.GetBreakVersion()) {
             version->ToProto(protoLockInfo->MutableBreakVersion());

--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -1206,7 +1206,7 @@ std::pair<TVector<TSysLocks::TLock>, TVector<ui64>> TSysLocks::ApplyLocks() {
         } else {
             lock = Locker.GetOrAddLock(Update->LockTxId, Update->LockNodeId);
         }
-        if (lock && Update->QuerySpanId != 0) {
+        if (lock && Update->QuerySpanId != 0 && lock->GetVictimQuerySpanId() == 0) {
             lock->SetVictimQuerySpanId(Update->QuerySpanId);
         }
         if (!lock) {
@@ -1641,7 +1641,7 @@ EEnsureCurrentLock TSysLocks::EnsureCurrentLock(bool createMissing) {
     if (!Update->Lock) {
         return EEnsureCurrentLock::TooMany;
     }
-    if (Update->QuerySpanId != 0) {
+    if (Update->QuerySpanId != 0 && Update->Lock->GetVictimQuerySpanId() == 0) {
         Update->Lock->SetVictimQuerySpanId(Update->QuerySpanId);
     }
 

--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -1153,9 +1153,8 @@ std::pair<TVector<TSysLocks::TLock>, TVector<ui64>> TSysLocks::ApplyLocks() {
     brokenLocks.reserve(Update->BreakLocks.Size());
     if (Update->BreakLocks) {
         Locker.BreakLocks(Update->BreakLocks, breakVersion);
-        bool isWriteOp = !Update->WriteTables.Empty();
-        ui64 breakerSpanId = isWriteOp ? Update->GetEffectiveBreakerQuerySpanId() : 0;
-        ui32 breakerNodeId = isWriteOp ? Update->LockNodeId : 0;
+        ui64 breakerSpanId = Update->GetEffectiveBreakerQuerySpanId();
+        ui32 breakerNodeId = breakerSpanId != 0 ? Update->LockNodeId : 0;
         for (auto& lock : Update->BreakLocks) {
             if (breakerSpanId) {
                 lock.SetBreakerInfo(breakerSpanId, breakerNodeId);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR improves the TLI logging to correctly identify breaker transactions in deferred lock break scenarios (where a lock is broken between snapshot and re-read, or detected at commit time).

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Previous PR [#31376](https://github.com/ydb-platform/ydb/pull/31376)
