### PR TITLE
fq/kqp: disable broken test

### DIFF
--- a/ydb/tests/fq/yt/cfg/test_whitelist.txt
+++ b/ydb/tests/fq/yt/cfg/test_whitelist.txt
@@ -686,7 +686,6 @@ order_by/sort_with_take
 params/struct
 pg/aggregate_combine_all
 pg/bit_const
-optimizers/yql-10042_disable_flow_fuse_depends_on
 pg/pg_corr_offset
 key_filter/ranges
 join/yql-14829_leftonly


### PR DESCRIPTION
optimizers/yql-10042_disable_flow_fuse_depends_on test now uses pragma config_flags that is not whitelisted in kqp_host.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
