### PR TITLE
Compression for ui64/double in-memory aggregation states & memory size estimation for spilled input tuples

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/dq_hash_combine.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_combine.h
@@ -5,6 +5,11 @@
 namespace NKikimr {
 namespace NMiniKQL {
 
+class TDqHashCombineTestPoints {
+public:
+    virtual void DisableStateDehydration(const bool disable) = 0;
+};
+
 IComputationNode* WrapDqHashCombine(TCallable& callable, const TComputationNodeFactoryContext& ctx);
 IComputationNode* WrapDqHashAggregate(TCallable& callable, const TComputationNodeFactoryContext& ctx);
 

--- a/ydb/library/yql/dq/comp_nodes/ut/dq_hash_combine_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/ut/dq_hash_combine_ut.cpp
@@ -555,9 +555,22 @@ void RunDqCombineWideTest(const bool useFlow, StreamCreator streamCreator)
     AssertMapsEqual(refResult, graphResult);
 }
 
+void DisableDehydration(THolder<IComputationGraph>& graph)
+{
+    for (auto& node : graph->GetNodes()) {
+        auto* testPoints = dynamic_cast<TDqHashCombineTestPoints*>(node.Get());
+        if (!testPoints) {
+            continue;
+        }
+        testPoints->DisableStateDehydration(true);
+        return;
+    }
+    UNIT_ASSERT_C(false, "Couldn't find a DqHashCombine node wrapper in the graph");
+}
+
 template<bool UseLLVM, bool Spilling, typename StreamCreator, typename StreamChecker>
 void RunDqAggregateEarlyStopTest(TDqSetup<UseLLVM, Spilling>& setup, const bool useFlow,
-    StreamCreator streamCreator, StreamChecker streamChecker)
+    StreamCreator streamCreator, StreamChecker streamChecker, const bool disableDehydration)
 {
     setup.Alloc.Ref().ForcefullySetMemoryYellowZone(false);
 
@@ -567,6 +580,10 @@ void RunDqAggregateEarlyStopTest(TDqSetup<UseLLVM, Spilling>& setup, const bool 
 
     if (Spilling) {
         graph->GetContext().SpillerFactory = CreateSpillerFactory();
+    }
+
+    if (disableDehydration) {
+        DisableDehydration(graph);
     }
 
     std::unordered_map<std::string, std::vector<ui64>> refResult;
@@ -629,13 +646,7 @@ void RunDqAggregateWideTest(TDqSetup<LLVM, Spilling>& setup, const bool useFlow,
     }
 
     if (disableDehydration) {
-        for (auto& node : graph->GetNodes()) {
-            auto* testPoints = dynamic_cast<TDqHashCombineTestPoints*>(node.Get());
-            if (!testPoints) {
-                continue;
-            }
-            testPoints->DisableStateDehydration(true);
-        }
+        DisableDehydration(graph);
     }
 
     std::unordered_map<std::string, std::vector<ui64>> refResult;
@@ -813,62 +824,111 @@ Y_UNIT_TEST_SUITE(TDqHashCombineTest) {
     Y_UNIT_TEST_QUAD(TestEarlyStop, UseLLVM, UseFlow) {
         TDqSetup<UseLLVM, false> setup(GetDqNodeFactory());
         size_t lineCount = 0;
+
+        auto streamCreator = [&](TComputationContext& ctx, std::vector<TType*>& columnTypes, auto& refMap) {
+            return new TWideKVStream(ctx, 100, 1, columnTypes, refMap);
+        };
+
+        auto streamChecker = [&lineCount](NUdf::EFetchStatus fetchStatus) -> bool {
+            if (fetchStatus == NUdf::EFetchStatus::Ok) {
+                ++lineCount;
+            }
+            return lineCount < 90;
+        };
+
         RunDqAggregateEarlyStopTest(
             setup,
             UseFlow,
-            [&](TComputationContext& ctx, std::vector<TType*>& columnTypes, auto& refMap) {
-                return new TWideKVStream(ctx, 100, 1, columnTypes, refMap);
-            },
-            [&lineCount](NUdf::EFetchStatus fetchStatus) -> bool {
-                if (fetchStatus == NUdf::EFetchStatus::Ok) {
-                    ++lineCount;
-                }
-                return lineCount < 90;
-            }
+            streamCreator,
+            streamChecker,
+            false
+        );
+
+        lineCount = 0;
+
+        RunDqAggregateEarlyStopTest(
+            setup,
+            UseFlow,
+            streamCreator,
+            streamChecker,
+            true
         );
     }
 
     Y_UNIT_TEST_QUAD(TestEarlyStopInSpilling, UseLLVM, UseFlow) {
         TDqSetup<UseLLVM, true> setup(GetDqNodeFactory());
+
         bool stopping = false;
+
+        auto streamCreator = [&](TComputationContext& ctx, std::vector<TType*>& columnTypes, auto& refMap) {
+            return new TWideKVStream(ctx, 1000, 1, columnTypes, refMap, [&](const size_t rowNum, bool& yield) {
+                if (rowNum == 100) {
+                    setup.Alloc.Ref().ForcefullySetMemoryYellowZone(true);
+                } else if (rowNum == 200) {
+                    stopping = true;
+                    yield = true;
+                }
+            });
+        };
+
+        auto streamChecker = [&stopping](NUdf::EFetchStatus fetchStatus) -> bool {
+            return !(fetchStatus == NUdf::EFetchStatus::Yield && stopping);
+        };
+
         RunDqAggregateEarlyStopTest(
             setup,
             UseFlow,
-            [&](TComputationContext& ctx, std::vector<TType*>& columnTypes, auto& refMap) {
-                return new TWideKVStream(ctx, 1000, 1, columnTypes, refMap, [&](const size_t rowNum, bool& yield) {
-                    if (rowNum == 100) {
-                        setup.Alloc.Ref().ForcefullySetMemoryYellowZone(true);
-                    } else if (rowNum == 200) {
-                        stopping = true;
-                        yield = true;
-                    }
-                });
-            },
-            [&stopping](NUdf::EFetchStatus fetchStatus) -> bool {
-                return !(fetchStatus == NUdf::EFetchStatus::Yield && stopping);
-            }
+            streamCreator,
+            streamChecker,
+            false
+        );
+
+        stopping = false;
+
+        RunDqAggregateEarlyStopTest(
+            setup,
+            UseFlow,
+            streamCreator,
+            streamChecker,
+            true
         );
     }
 
     Y_UNIT_TEST_QUAD(TestEarlyStopAfterSpilling, UseLLVM, UseFlow) {
         TDqSetup<UseLLVM, true> setup(GetDqNodeFactory());
         size_t lineCount = 0;
+
+        auto streamCreator = [&](TComputationContext& ctx, std::vector<TType*>& columnTypes, auto& refMap) {
+            return new TWideKVStream(ctx, 100000, 1, columnTypes, refMap, [&](const size_t rowNum, [[maybe_unused]] bool& yield) {
+                if (rowNum == 100) {
+                    setup.Alloc.Ref().ForcefullySetMemoryYellowZone(true);
+                }
+            });
+        };
+
+        auto streamChecker = [&lineCount](NUdf::EFetchStatus fetchStatus) -> bool {
+            if (fetchStatus == NUdf::EFetchStatus::Ok) {
+                ++lineCount;
+            }
+            return lineCount < 90;
+        };
+
         RunDqAggregateEarlyStopTest(
             setup,
             UseFlow,
-            [&](TComputationContext& ctx, std::vector<TType*>& columnTypes, auto& refMap) {
-                return new TWideKVStream(ctx, 100000, 1, columnTypes, refMap, [&](const size_t rowNum, [[maybe_unused]] bool& yield) {
-                    if (rowNum == 100) {
-                        setup.Alloc.Ref().ForcefullySetMemoryYellowZone(true);
-                    }
-                });
-            },
-            [&lineCount](NUdf::EFetchStatus fetchStatus) -> bool {
-                if (fetchStatus == NUdf::EFetchStatus::Ok) {
-                    ++lineCount;
-                }
-                return lineCount < 90;
-            }
+            streamCreator,
+            streamChecker,
+            false
+        );
+
+        lineCount = 0;
+
+        RunDqAggregateEarlyStopTest(
+            setup,
+            UseFlow,
+            streamCreator,
+            streamChecker,
+            true
         );
     }
 } // Y_UNIT_TEST_SUITE

--- a/ydb/library/yql/dq/comp_nodes/ut/dq_hash_combine_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/ut/dq_hash_combine_ut.cpp
@@ -616,7 +616,7 @@ void RunDqAggregateBlockTest(TDqSetup<UseLLVM, Spilling>& setup, const bool useF
 }
 
 template<bool LLVM, bool Spilling, typename StreamCreator>
-void RunDqAggregateWideTest(TDqSetup<LLVM, Spilling>& setup, const bool useFlow, StreamCreator streamCreator)
+void RunDqAggregateWideTest(TDqSetup<LLVM, Spilling>& setup, const bool useFlow, StreamCreator streamCreator, const bool disableDehydration = false)
 {
     setup.Alloc.Ref().ForcefullySetMemoryYellowZone(false);
 
@@ -626,6 +626,16 @@ void RunDqAggregateWideTest(TDqSetup<LLVM, Spilling>& setup, const bool useFlow,
 
     if (Spilling) {
         graph->GetContext().SpillerFactory = CreateSpillerFactory();
+    }
+
+    if (disableDehydration) {
+        for (auto& node : graph->GetNodes()) {
+            auto* testPoints = dynamic_cast<TDqHashCombineTestPoints*>(node.Get());
+            if (!testPoints) {
+                continue;
+            }
+            testPoints->DisableStateDehydration(true);
+        }
     }
 
     std::unordered_map<std::string, std::vector<ui64>> refResult;
@@ -762,6 +772,17 @@ Y_UNIT_TEST_SUITE(TDqHashCombineTest) {
                 }
             });
         });
+    }
+
+    Y_UNIT_TEST_QUAD(TestWideModeAggregationWithSpillingNonDehydrated, UseLLVM, UseFlow) {
+        TDqSetup<UseLLVM, true> setup(GetDqNodeFactory());
+        RunDqAggregateWideTest(setup, UseFlow, [&](TComputationContext& ctx, std::vector<TType*>& columnTypes, auto& refMap) {
+            return new TWideKVStream(ctx, 100000, 10, columnTypes, refMap, [&](const size_t rowNum, [[maybe_unused]] bool& yield) {
+                if (rowNum == 100000) {
+                    setup.Alloc.Ref().ForcefullySetMemoryYellowZone(true);
+                }
+            });
+        }, true);
     }
 
     Y_UNIT_TEST_QUAD(TestWideModeAggregationMultiRowNoSpilling, UseLLVM, UseFlow) {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Store raw 64-bit aggregated values if the aggregation state consists entirely of unsigned 64-bit ints/doubles
- Better control memory usage when buffering input tuples for spilling by calculating the average size of a tuple including string allocations, etc.