### PR TITLE
LLVM deny specializations for some classes. Allow them explicitly

### DIFF
--- a/ydb/core/util/metrics.h
+++ b/ydb/core/util/metrics.h
@@ -7,10 +7,13 @@
 
 namespace std {
 
+Y_PRAGMA_DIAGNOSTIC_PUSH
+Y_PRAGMA("GCC diagnostic ignored \"-Winvalid-specialization\"")
 template <>
 struct make_signed<double> {
     using type = double;
 };
+Y_PRAGMA_DIAGNOSTIC_POP
 
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Since [23 Jan](https://github.com/llvm/llvm-project/commit/6f684816e25d8b4e5fb2cbc7d0560d608a8bd938) llvm deny some specializations.

Fix errors like
```
$(SOURCE_ROOT)//ydb/core/util/metrics.h:11:8: error: 'make_signed' cannot be specialized: Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
   11 | struct make_signed<double> {
      |        ^
$(SOURCE_ROOT)/libs/cxxsupp/libcxx/include/__type_traits/make_signed.h:73:8: note: marked 'no_specializations' here
   73 | struct _LIBCPP_NO_SPECIALIZATIONS make_signed {
      |        ^
$(SOURCE_ROOT)/libs/cxxsupp/libcxx/include/__config:1176:9: note: expanded from macro '_LIBCPP_NO_SPECIALIZATIONS'
 1176 |       [[_Clang::__no_specializations__("Users are not allowed to specialize this standard library entity")]]
      |         ^
1 error generated.
```