### PR TITLE
Clear StaticCredentialsProvider singleton after cluster cleanup

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -84,6 +84,7 @@
 
 #include <ydb/core/base/tablet_resolver.h>
 #include <ydb/core/security/login_page.h>
+#include <ydb/core/security/sasl/static_credentials_provider.h>
 #include <ydb/core/tablet/bootstrapper.h>
 #include <ydb/core/tablet/resource_broker.h>
 #include <ydb/core/tablet/node_tablet_monitor.h>
@@ -634,6 +635,8 @@ TKikimrRunner::~TKikimrRunner() {
         ActorSystem->Stop();
         ActorSystem.Destroy();
     }
+
+    NSasl::TStaticCredentialsProvider::GetInstance().Clear();
 }
 
 void TKikimrRunner::AddGlobalObject(std::shared_ptr<void> object) {

--- a/ydb/core/security/sasl/static_credentials_provider.cpp
+++ b/ydb/core/security/sasl/static_credentials_provider.cpp
@@ -38,7 +38,7 @@ TStaticCredentialsProvider::GetUserHashInitParams(const std::string& database, c
 void TStaticCredentialsProvider::UpdateDatabaseUsers(const NLoginProto::TSecurityState& securityState) {
     const auto& database = securityState.GetAudience();
     // Create a new map for updated user hashes
-    TTrueAtomicSharedPtr usersHashes(new std::unordered_map<std::string, THashInitParams>());
+    TTrueAtomicSharedPtr usersHashes = MakeTrueAtomicShared<std::unordered_map<std::string, THashInitParams>>();
     usersHashes->reserve(securityState.SidsSize());
     for (const auto& sid : securityState.GetSids()) {
         if (sid.GetType() == NLoginProto::ESidType::USER) {
@@ -58,7 +58,7 @@ void TStaticCredentialsProvider::UpdateDatabaseUsers(const NLoginProto::TSecurit
     if (itDb == staticCredsStorage->end()) {
         // Database doesn't exist - create a new storage map to avoid modifying the existing one
         // that other threads might be reading. This ensures thread-safe copy-on-write behavior.
-        TTrueAtomicSharedPtr newStaticCredsStorage(new std::unordered_map<std::string, TDatabaseUsersHashes>);
+        TTrueAtomicSharedPtr newStaticCredsStorage = MakeTrueAtomicShared<std::unordered_map<std::string, TDatabaseUsersHashes>>();
         // Copy all existing databases (only increments reference counters for nested shared pointers)
         for (const auto& [databaseName, databaseUsersHashes] : *staticCredsStorage) {
             newStaticCredsStorage->emplace(databaseName, databaseUsersHashes);
@@ -86,7 +86,7 @@ void TStaticCredentialsProvider::DeleteDatabaseUsers(const std::string& database
     if (itDb != staticCredsStorage->end()) {
         // Database exists - create a new storage map to avoid modifying the existing one
         // that other threads might be reading. This ensures thread-safe copy-on-write behavior.
-        TTrueAtomicSharedPtr newStaticCredsStorage(new std::unordered_map<std::string, TDatabaseUsersHashes>);
+        TTrueAtomicSharedPtr newStaticCredsStorage = MakeTrueAtomicShared<std::unordered_map<std::string, TDatabaseUsersHashes>>();
         // Copy all databases except the one being deleted (only increments reference counters for nested shared pointers)
         for (const auto& [databaseName, databaseUsersHashes] : *staticCredsStorage) {
             if (databaseName != database) {
@@ -97,6 +97,13 @@ void TStaticCredentialsProvider::DeleteDatabaseUsers(const std::string& database
         // Atomically swap the storage pointer
         StaticCredsStorage.swap(newStaticCredsStorage);
     }
+}
+
+void TStaticCredentialsProvider::Clear() {
+    // Create a new empty storage map to avoid modifying the existing one
+    TTrueAtomicSharedPtr newStaticCredsStorage = MakeTrueAtomicShared<std::unordered_map<std::string, TDatabaseUsersHashes>>();
+    // Atomically swap the storage pointer
+    StaticCredsStorage.swap(newStaticCredsStorage);
 }
 
 } // namespace NKikimr::NSasl

--- a/ydb/core/security/sasl/static_credentials_provider.h
+++ b/ydb/core/security/sasl/static_credentials_provider.h
@@ -51,6 +51,7 @@ public:
         const std::string& username) const;
     void UpdateDatabaseUsers(const NLoginProto::TSecurityState& securityState);
     void DeleteDatabaseUsers(const std::string& database);
+    void Clear();
 
 private:
     TStaticCredentialsProvider();

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -63,6 +63,7 @@
 #include <ydb/core/security/ldap_auth_provider/ldap_auth_provider.h>
 #include <ydb/core/security/token_manager/token_manager.h>
 #include <ydb/core/security/ticket_parser_settings.h>
+#include <ydb/core/security/sasl/static_credentials_provider.h>
 #include <ydb/core/base/user_registry.h>
 #include <ydb/core/health_check/health_check.h>
 #include <ydb/core/kafka_proxy/actors/kafka_metrics_actor.h>
@@ -1861,6 +1862,7 @@ namespace Tests {
 
     TServer::~TServer() {
         ShutdownGRpc();
+        NSasl::TStaticCredentialsProvider::GetInstance().Clear();
 
         if (YqSharedResources) {
             YqSharedResources->Stop();


### PR DESCRIPTION
In some tests the same process is used to run YDB cluster several times so to avoid sharing users between runs I added Clear method to StaticCredentialsProvider singleton.
