### PR TITLE
interconnect: add PER_HOST counters aggregation mode

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -236,6 +236,7 @@
 #include <ydb/library/actors/helpers/selfping_actor.h>
 #include <ydb/library/actors/http/http_proxy.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
+#include <ydb/library/actors/interconnect/interconnect_host_metrics_aggregator.h>
 #include <ydb/library/actors/interconnect/interconnect_mon.h>
 #include <ydb/library/actors/interconnect/interconnect_tcp_proxy.h>
 #include <ydb/library/actors/interconnect/interconnect_proxy_wrapper.h>
@@ -406,6 +407,9 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
             break;
         case NKikimrConfig::TInterconnectConfig::PER_DATA_CENTER:
             result.MergePerDataCenterCounters = true;
+            break;
+        case NKikimrConfig::TInterconnectConfig::PER_HOST:
+            result.MergePerHostCounters = true;
             break;
         case NKikimrConfig::TInterconnectConfig::NO_MERGE:
             break;
@@ -770,6 +774,13 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                 };
                 setup->LocalServices.emplace_back(NInterconnect::MakeInterconnectMonActorId(NodeId), TActorSetupCmd(
                     NInterconnect::CreateInterconnectMonActor(icCommon), TMailboxType::ReadAsFilled, systemPoolId));
+            }
+
+            if (settings.MergePerHostCounters) {
+                icCommon->HostMetricsAggregatorId = NActors::NInterconnectHostMetrics::MakeInterconnectHostMetricsAggregatorId(NodeId);
+                setup->LocalServices.emplace_back(icCommon->HostMetricsAggregatorId, TActorSetupCmd(
+                    NActors::NInterconnectHostMetrics::CreateInterconnectHostMetricsAggregatorActor(icCommon),
+                    TMailboxType::ReadAsFilled, interconnectPoolId));
             }
 
             if (nsConfig.HasClusterUUID()) {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -462,6 +462,7 @@ message TInterconnectConfig {
         PER_PEER = 1;
         PER_DATA_CENTER = 2;
         NO_MERGE = 3;
+        PER_HOST = 4;
     }
 
     enum EEncryptionMode {

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -39,6 +39,7 @@ namespace NActors {
         ui64 OutputBuffersTotalSizeLimitInMB = 0;
         ui32 TotalInflightAmountOfData = 0;
         bool MergePerPeerCounters = false;
+        bool MergePerHostCounters = false;
         bool MergePerDataCenterCounters = false;
         ui32 TCPSocketBufferSize = 0;
         TDuration PingPeriod = TDuration::Seconds(3);
@@ -143,6 +144,7 @@ namespace NActors {
         double CalculateNetworkUtilization();
         void AddSessionWithDataInQueue();
         void RemoveSessionWithDataInQueue();
+        TActorId HostMetricsAggregatorId;
 
         struct TVersionInfo {
             TString Tag; // version tag for this node

--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -1,9 +1,11 @@
 #include "interconnect_counters.h"
+#include "interconnect_host_metrics_aggregator.h"
 
 #include <library/cpp/monlib/metrics/metric_registry.h>
 #include <library/cpp/monlib/metrics/metric_sub_registry.h>
 
 #include <unordered_map>
+#include <utility>
 
 namespace NActors {
 
@@ -27,6 +29,15 @@ namespace {
                 prevIndex = index;
             }
         };
+
+        template <typename TEvent, typename... TArgs>
+        void SendHostMetricsEvent(const TInterconnectProxyCommon::TPtr& common, TArgs&&... args) {
+            if (!TlsActivationContext || !common->HostMetricsAggregatorId) {
+                return;
+            }
+            TActivationContext::Send(new IEventHandle(common->HostMetricsAggregatorId, TActorId(),
+                new TEvent(std::forward<TArgs>(args)...)));
+        }
     }
 
     class TInterconnectCounters: public IInterconnectMetrics {
@@ -105,6 +116,8 @@ namespace {
     private:
         const TInterconnectProxyCommon::TPtr Common;
         const bool MergePerDataCenterCounters;
+        const bool MergePerHostCounters;
+        const bool UseHostAggregation;
         const bool MergePerPeerCounters;
         const bool HasSessionCounters;
         NMonitoring::TDynamicCounterPtr Counters;
@@ -117,11 +130,19 @@ namespace {
         NMonitoring::TDynamicCounters::TCounterPtr Traffic;
         NMonitoring::TDynamicCounters::TCounterPtr Events;
         NMonitoring::TDynamicCounters::TCounterPtr ScopeErrors;
+        TString MetricPeerLabel;
+        TString HostAggregationLabel;
+        TString HostAggregationPeer;
+        ui32 ConnectedValue = 0;
+        i64 ClockSkewValue = 0;
+        bool HostAggregationRegistered = false;
 
     public:
         TInterconnectCounters(const TInterconnectProxyCommon::TPtr& common)
             : Common(common)
             , MergePerDataCenterCounters(common->Settings.MergePerDataCenterCounters)
+            , MergePerHostCounters(common->Settings.MergePerHostCounters)
+            , UseHostAggregation(MergePerHostCounters && common->HostMetricsAggregatorId)
             , MergePerPeerCounters(common->Settings.MergePerPeerCounters)
             , HasSessionCounters(!MergePerDataCenterCounters && !MergePerPeerCounters)
             , Counters(common->MonCounters)
@@ -129,6 +150,10 @@ namespace {
                     ? PerDataCenterCounters :
                     MergePerPeerCounters ? Counters : PerSessionCounters)
         {}
+
+        ~TInterconnectCounters() override {
+            UnregisterHostAggregation();
+        }
 
         void AddInflightDataAmount(ui64 value) override {
             *InflightDataAmount += value;
@@ -151,6 +176,16 @@ namespace {
         }
 
         void SetClockSkewMicrosec(i64 value) override {
+            if (UseHostAggregation) {
+                if (ClockSkewValue != value) {
+                    ClockSkewValue = value;
+                    if (HostAggregationRegistered) {
+                        SendHostMetricsEvent<NInterconnectHostMetrics::TEvUpdateClockSkew>(Common,
+                            HostAggregationLabel, HostAggregationPeer, ClockSkewValue);
+                    }
+                }
+                return;
+            }
             *ClockSkewMicrosec = value;
         }
 
@@ -163,6 +198,16 @@ namespace {
         }
 
         void SetConnected(ui32 value) override {
+            if (UseHostAggregation) {
+                if (ConnectedValue != value) {
+                    ConnectedValue = value;
+                    if (HostAggregationRegistered) {
+                        SendHostMetricsEvent<NInterconnectHostMetrics::TEvUpdateConnected>(Common,
+                            HostAggregationLabel, HostAggregationPeer, ConnectedValue);
+                    }
+                }
+                return;
+            }
             *Connected = value;
         }
 
@@ -233,6 +278,10 @@ namespace {
             ++*ch.Events;
         }
 
+        void IncScopeErrors() override {
+            ++*ScopeErrors;
+        }
+
         void IncRecvSyscalls(ui64 ns) override {
             ++*RecvSyscalls;
             *RecvSyscallsNs += ns;
@@ -275,10 +324,12 @@ namespace {
             UpdateUtilization(PrevStarvation, Starvation, starvation);
         }
 
-        void SetPeerInfo(ui32 nodeId, const TString& name, const TString& dataCenterId) override {
-            if (nodeId != PeerNodeId || name != HumanFriendlyPeerHostName) {
-                PeerNodeId = nodeId;
-                HumanFriendlyPeerHostName = name;
+        void SetPeerInfo(const TString& name, const TString& dataCenterId, const TString& peerLabel) override {
+            const TString effectivePeerLabel = peerLabel.empty() ? name : peerLabel;
+            if (name != std::exchange(HumanFriendlyPeerHostName, name)) {
+                PerSessionCounters.Reset();
+            }
+            if (effectivePeerLabel != std::exchange(MetricPeerLabel, effectivePeerLabel)) {
                 PerSessionCounters.Reset();
             }
             VALGRIND_MAKE_READABLE(&DataCenterId, sizeof(DataCenterId));
@@ -294,9 +345,7 @@ namespace {
             const bool updatePerSession = !PerSessionCounters || updatePerDataCenter;
             if (HasSessionCounters && updatePerSession) {
                 auto base = MergePerDataCenterCounters ? PerDataCenterCounters : Counters;
-                PerSessionCounters = base
-                    ->GetSubgroup("peer_node_id", ToString(*PeerNodeId))
-                    ->GetSubgroup("peer_name", *HumanFriendlyPeerHostName);
+                PerSessionCounters = base->GetSubgroup("peer", MetricPeerLabel);
             }
 
             const bool updateGlobal = !Initialized;
@@ -370,6 +419,10 @@ namespace {
                 ++*std::get<1>(Starvation[PrevStarvation]);
             }
 
+            if (UseHostAggregation && updatePerSession) {
+                RebindHostAggregation();
+            }
+
             Initialized = true;
         }
 
@@ -377,6 +430,33 @@ namespace {
             Y_ABORT_UNLESS(Initialized);
             const auto it = OutputChannels.find(index);
             return it != OutputChannels.end() ? it->second : OtherOutputChannel;
+        }
+
+        void UnregisterHostAggregation() {
+            if (!UseHostAggregation || !HostAggregationRegistered) {
+                return;
+            }
+            SendHostMetricsEvent<NInterconnectHostMetrics::TEvUnregisterPeer>(Common, HostAggregationLabel, HostAggregationPeer);
+            HostAggregationLabel.clear();
+            HostAggregationPeer.clear();
+            HostAggregationRegistered = false;
+        }
+
+        void RebindHostAggregation() {
+            if (!UseHostAggregation || MetricPeerLabel.empty() || !HumanFriendlyPeerHostName) {
+                return;
+            }
+            if (HostAggregationRegistered && HostAggregationLabel == MetricPeerLabel
+                    && HostAggregationPeer == *HumanFriendlyPeerHostName) {
+                return;
+            }
+            UnregisterHostAggregation();
+            HostAggregationLabel = MetricPeerLabel;
+            HostAggregationPeer = *HumanFriendlyPeerHostName;
+            HostAggregationRegistered = true;
+            SendHostMetricsEvent<NInterconnectHostMetrics::TEvRegisterPeer>(Common, HostAggregationLabel, HostAggregationPeer);
+            SendHostMetricsEvent<NInterconnectHostMetrics::TEvUpdateConnected>(Common, HostAggregationLabel, HostAggregationPeer, ConnectedValue);
+            SendHostMetricsEvent<NInterconnectHostMetrics::TEvUpdateClockSkew>(Common, HostAggregationLabel, HostAggregationPeer, ClockSkewValue);
         }
 
     private:
@@ -493,12 +573,18 @@ namespace {
         TInterconnectMetrics(const TInterconnectProxyCommon::TPtr& common)
             : Common(common)
             , MergePerDataCenterMetrics_(common->Settings.MergePerDataCenterCounters)
+            , MergePerHostMetrics_(common->Settings.MergePerHostCounters)
+            , UseHostAggregation_(MergePerHostMetrics_ && common->HostMetricsAggregatorId)
             , MergePerPeerMetrics_(common->Settings.MergePerPeerCounters)
             , Metrics_(common->Metrics)
             , AdaptiveMetrics_(MergePerDataCenterMetrics_
                                ? PerDataCenterMetrics_ :
                                MergePerPeerMetrics_ ? Metrics_ : PerSessionMetrics_)
         {}
+
+        ~TInterconnectMetrics() override {
+            UnregisterHostAggregation();
+        }
 
         void AddInflightDataAmount(ui64 value) override {
             InflightDataAmount_->Add(value);
@@ -521,6 +607,16 @@ namespace {
         }
 
         void SetClockSkewMicrosec(i64 value) override {
+            if (UseHostAggregation_) {
+                if (ClockSkewValue_ != value) {
+                    ClockSkewValue_ = value;
+                    if (HostAggregationRegistered_) {
+                        SendHostMetricsEvent<NInterconnectHostMetrics::TEvUpdateClockSkew>(Common,
+                            HostAggregationLabel_, HostAggregationPeer_, ClockSkewValue_);
+                    }
+                }
+                return;
+            }
             ClockSkewMicrosec_->Set(value);
         }
 
@@ -533,6 +629,16 @@ namespace {
         }
 
         void SetConnected(ui32 value) override {
+            if (UseHostAggregation_) {
+                if (ConnectedValue_ != value) {
+                    ConnectedValue_ = value;
+                    if (HostAggregationRegistered_) {
+                        SendHostMetricsEvent<NInterconnectHostMetrics::TEvUpdateConnected>(Common,
+                            HostAggregationLabel_, HostAggregationPeer_, ConnectedValue_);
+                    }
+                }
+                return;
+            }
             Connected_->Set(value);
         }
 
@@ -602,6 +708,10 @@ namespace {
             ch.Events->Inc();
         }
 
+        void IncScopeErrors() override {
+            ScopeErrors_->Inc();
+        }
+
         void IncRecvSyscalls(ui64 /*ns*/) override {
             RecvSyscalls_->Inc();
         }
@@ -651,10 +761,12 @@ namespace {
             UpdateUtilization(PrevStarvation_, Starvation_, starvation);
         }
 
-        void SetPeerInfo(ui32 nodeId, const TString& name, const TString& dataCenterId) override {
-            if (nodeId != PeerNodeId || name != HumanFriendlyPeerHostName) {
-                PeerNodeId = nodeId;
-                HumanFriendlyPeerHostName = name;
+        void SetPeerInfo(const TString& name, const TString& dataCenterId, const TString& peerLabel) override {
+            const TString effectivePeerLabel = peerLabel.empty() ? name : peerLabel;
+            if (name != std::exchange(HumanFriendlyPeerHostName, name)) {
+                PerSessionMetrics_.reset();
+            }
+            if (effectivePeerLabel != std::exchange(MetricPeerLabel_, effectivePeerLabel)) {
                 PerSessionMetrics_.reset();
             }
             VALGRIND_MAKE_READABLE(&DataCenterId, sizeof(DataCenterId));
@@ -672,10 +784,7 @@ namespace {
             if (updatePerSession) {
                 auto base = MergePerDataCenterMetrics_ ? PerDataCenterMetrics_ : Metrics_;
                 PerSessionMetrics_ = std::make_shared<NMonitoring::TMetricSubRegistry>(
-                    NMonitoring::TLabels{
-                        {"peer_node_id", ToString(*PeerNodeId)},
-                        {"peer_name", *HumanFriendlyPeerHostName},
-                    }, base);
+                        NMonitoring::TLabels{{"peer", MetricPeerLabel_}}, base);
             }
 
             const bool updateGlobal = !Initialized_;
@@ -767,6 +876,10 @@ namespace {
                 std::get<1>(Starvation_[PrevStarvation_])->Inc();
             }
 
+            if (UseHostAggregation_ && updatePerSession) {
+                RebindHostAggregation();
+            }
+
             Initialized_ = true;
         }
 
@@ -776,22 +889,59 @@ namespace {
             return it != OutputChannels_.end() ? it->second : OtherOutputChannel_;
         }
 
+        void UnregisterHostAggregation() {
+            if (!UseHostAggregation_ || !HostAggregationRegistered_) {
+                return;
+            }
+            SendHostMetricsEvent<NInterconnectHostMetrics::TEvUnregisterPeer>(Common, HostAggregationLabel_, HostAggregationPeer_);
+            HostAggregationLabel_.clear();
+            HostAggregationPeer_.clear();
+            HostAggregationRegistered_ = false;
+        }
+
+        void RebindHostAggregation() {
+            if (!UseHostAggregation_ || MetricPeerLabel_.empty() || !HumanFriendlyPeerHostName) {
+                return;
+            }
+            if (HostAggregationRegistered_ && HostAggregationLabel_ == MetricPeerLabel_
+                    && HostAggregationPeer_ == *HumanFriendlyPeerHostName) {
+                return;
+            }
+            UnregisterHostAggregation();
+            HostAggregationLabel_ = MetricPeerLabel_;
+            HostAggregationPeer_ = *HumanFriendlyPeerHostName;
+            HostAggregationRegistered_ = true;
+            SendHostMetricsEvent<NInterconnectHostMetrics::TEvRegisterPeer>(Common, HostAggregationLabel_, HostAggregationPeer_);
+            SendHostMetricsEvent<NInterconnectHostMetrics::TEvUpdateConnected>(Common,
+                HostAggregationLabel_, HostAggregationPeer_, ConnectedValue_);
+            SendHostMetricsEvent<NInterconnectHostMetrics::TEvUpdateClockSkew>(Common,
+                HostAggregationLabel_, HostAggregationPeer_, ClockSkewValue_);
+        }
+
     private:
         const TInterconnectProxyCommon::TPtr Common;
         const bool MergePerDataCenterMetrics_;
+        const bool MergePerHostMetrics_;
+        const bool UseHostAggregation_;
         const bool MergePerPeerMetrics_;
         std::shared_ptr<NMonitoring::IMetricRegistry> Metrics_;
         std::shared_ptr<NMonitoring::IMetricRegistry> PerSessionMetrics_;
         std::shared_ptr<NMonitoring::IMetricRegistry> PerDataCenterMetrics_;
         std::shared_ptr<NMonitoring::IMetricRegistry>& AdaptiveMetrics_;
         bool Initialized_ = false;
+        TString MetricPeerLabel_;
+        TString HostAggregationLabel_;
+        TString HostAggregationPeer_;
+        ui32 ConnectedValue_ = 0;
+        i64 ClockSkewValue_ = 0;
+        bool HostAggregationRegistered_ = false;
 
-        NMonitoring::IRate* Traffic_;
+        NMonitoring::IRate* Traffic_ = nullptr;
 
-        NMonitoring::IRate* Events_;
-        NMonitoring::IRate* ScopeErrors_;
-        NMonitoring::IRate* Disconnections_;
-        NMonitoring::IIntGauge* Connected_;
+        NMonitoring::IRate* Events_ = nullptr;
+        NMonitoring::IRate* ScopeErrors_ = nullptr;
+        NMonitoring::IRate* Disconnections_ = nullptr;
+        NMonitoring::IIntGauge* Connected_ = nullptr;
 
         NMonitoring::IRate* SessionDeaths_;
         NMonitoring::IRate* HandshakeFails_;

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -37,9 +37,10 @@ public:
     virtual void IncDisconnectByReason(const TString& s) = 0;
     virtual void IncUsefulReadWakeups() = 0;
     virtual void IncSpuriousReadWakeups() = 0;
-    virtual void SetPeerInfo(ui32 nodeId, const TString& name, const TString& dataCenterId) = 0;
+    virtual void SetPeerInfo(const TString& name, const TString& dataCenterId, const TString& peerLabel) = 0;
     virtual void AddInputChannelsIncomingTraffic(ui16 channel, ui64 incomingTraffic) = 0;
     virtual void IncInputChannelsIncomingEvents(ui16 channel) = 0;
+    virtual void IncScopeErrors() = 0;
     virtual void IncRecvSyscalls(ui64 ns) = 0;
     virtual void AddTotalBytesRead(ui64 value) = 0;
     virtual void UpdatePingTimeHistogram(ui64 value) = 0;

--- a/ydb/library/actors/interconnect/interconnect_host_metrics_aggregator.cpp
+++ b/ydb/library/actors/interconnect/interconnect_host_metrics_aggregator.cpp
@@ -1,0 +1,140 @@
+#include "interconnect_host_metrics_aggregator.h"
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <library/cpp/monlib/metrics/metric_registry.h>
+#include <library/cpp/monlib/metrics/metric_sub_registry.h>
+
+namespace NActors::NInterconnectHostMetrics {
+
+namespace {
+
+class TInterconnectHostMetricsAggregatorActor
+    : public TActorBootstrapped<TInterconnectHostMetricsAggregatorActor>
+{
+    struct TPeerState {
+        ui32 Connected = 0;
+        i64 ClockSkew = 0;
+    };
+
+    struct THostState {
+        THashMap<TString, TPeerState> Peers;
+        NMonitoring::TDynamicCounters::TCounterPtr ConnectedCounter;
+        NMonitoring::TDynamicCounters::TCounterPtr ClockSkewCounter;
+        NMonitoring::IIntGauge* ConnectedGauge = nullptr;
+        NMonitoring::IIntGauge* ClockSkewGauge = nullptr;
+    };
+
+public:
+    explicit TInterconnectHostMetricsAggregatorActor(TInterconnectProxyCommon::TPtr common)
+        : Common_(std::move(common))
+    {}
+
+    void Bootstrap() {
+        Become(&TThis::StateFunc);
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvRegisterPeer, Handle);
+        hFunc(TEvUpdateConnected, Handle);
+        hFunc(TEvUpdateClockSkew, Handle);
+        hFunc(TEvUnregisterPeer, Handle);
+    )
+
+private:
+    static ui64 Abs(i64 x) {
+        return x >= 0 ? x : ui64(-(x + 1)) + 1;
+    }
+
+    THostState& GetHostState(const TString& peerHost) {
+        auto [it, _] = Hosts_.try_emplace(peerHost);
+        THostState& host = it->second;
+        if (!host.ConnectedCounter && !host.ConnectedGauge) {
+            if (Common_->Metrics) {
+                const auto registry = std::make_shared<NMonitoring::TMetricSubRegistry>(
+                    NMonitoring::TLabels{{"peer", peerHost}}, Common_->Metrics);
+                host.ConnectedGauge = registry->IntGauge(
+                    NMonitoring::MakeLabels(NMonitoring::TLabels{{"sensor", "interconnect.connected"}}));
+                host.ClockSkewGauge = registry->IntGauge(
+                    NMonitoring::MakeLabels(NMonitoring::TLabels{{"sensor", "interconnect.clock_skew_microsec"}}));
+            } else {
+                const auto subgroup = Common_->MonCounters->GetSubgroup("peer", peerHost);
+                host.ConnectedCounter = subgroup->GetCounter("Connected");
+                host.ClockSkewCounter = subgroup->GetCounter("ClockSkewMicrosec");
+            }
+        }
+        return host;
+    }
+
+    void Publish(THostState& host, ui32 connected, i64 clockSkew) {
+        if (host.ConnectedGauge) {
+            host.ConnectedGauge->Set(connected);
+            host.ClockSkewGauge->Set(clockSkew);
+        } else {
+            *host.ConnectedCounter = connected;
+            *host.ClockSkewCounter = clockSkew;
+        }
+    }
+
+    void RecalculateAndPublish(THostState& host) {
+        ui32 connected = 0;
+        i64 clockSkew = 0;
+        ui64 maxAbsClockSkew = 0;
+
+        for (const auto& [_, peer] : host.Peers) {
+            connected += peer.Connected;
+            const ui64 absClockSkew = Abs(peer.ClockSkew);
+            if (absClockSkew > maxAbsClockSkew) {
+                maxAbsClockSkew = absClockSkew;
+                clockSkew = peer.ClockSkew;
+            }
+        }
+
+        Publish(host, connected, clockSkew);
+    }
+
+    void Handle(TEvRegisterPeer::TPtr& ev) {
+        auto& host = GetHostState(ev->Get()->PeerHost);
+        host.Peers.try_emplace(ev->Get()->PeerHumanName);
+        RecalculateAndPublish(host);
+    }
+
+    void Handle(TEvUpdateConnected::TPtr& ev) {
+        auto& host = GetHostState(ev->Get()->PeerHost);
+        auto& peer = host.Peers[ev->Get()->PeerHumanName];
+        peer.Connected = ev->Get()->Connected;
+        RecalculateAndPublish(host);
+    }
+
+    void Handle(TEvUpdateClockSkew::TPtr& ev) {
+        auto& host = GetHostState(ev->Get()->PeerHost);
+        auto& peer = host.Peers[ev->Get()->PeerHumanName];
+        peer.ClockSkew = ev->Get()->ClockSkew;
+        RecalculateAndPublish(host);
+    }
+
+    void Handle(TEvUnregisterPeer::TPtr& ev) {
+        if (auto it = Hosts_.find(ev->Get()->PeerHost); it != Hosts_.end()) {
+            auto& host = it->second;
+            host.Peers.erase(ev->Get()->PeerHumanName);
+            if (host.Peers.empty()) {
+                Publish(host, 0, 0);
+                Hosts_.erase(it);
+            } else {
+                RecalculateAndPublish(host);
+            }
+        }
+    }
+
+private:
+    TInterconnectProxyCommon::TPtr Common_;
+    THashMap<TString, THostState> Hosts_;
+};
+
+} // namespace
+
+IActor* CreateInterconnectHostMetricsAggregatorActor(TIntrusivePtr<TInterconnectProxyCommon> common) {
+    return new TInterconnectHostMetricsAggregatorActor(std::move(common));
+}
+
+} // namespace NActors::NInterconnectHostMetrics

--- a/ydb/library/actors/interconnect/interconnect_host_metrics_aggregator.h
+++ b/ydb/library/actors/interconnect/interconnect_host_metrics_aggregator.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <ydb/library/actors/core/actor.h>
+
+#include "interconnect_common.h"
+
+namespace NActors::NInterconnectHostMetrics {
+
+enum EHostMetricsAggregatorEvents {
+    EvRegisterPeer = EventSpaceBegin(TEvents::ES_PRIVATE) + 0x900,
+    EvUpdateConnected,
+    EvUpdateClockSkew,
+    EvUnregisterPeer,
+};
+
+struct TEvRegisterPeer : TEventLocal<TEvRegisterPeer, EvRegisterPeer> {
+    TString PeerHost;
+    TString PeerHumanName;
+
+    TEvRegisterPeer(TString peerHost, TString peerHumanName)
+        : PeerHost(std::move(peerHost))
+        , PeerHumanName(std::move(peerHumanName))
+    {}
+};
+
+struct TEvUpdateConnected : TEventLocal<TEvUpdateConnected, EvUpdateConnected> {
+    TString PeerHost;
+    TString PeerHumanName;
+    ui32 Connected = 0;
+
+    TEvUpdateConnected(TString peerHost, TString peerHumanName, ui32 connected)
+        : PeerHost(std::move(peerHost))
+        , PeerHumanName(std::move(peerHumanName))
+        , Connected(connected)
+    {}
+};
+
+struct TEvUpdateClockSkew : TEventLocal<TEvUpdateClockSkew, EvUpdateClockSkew> {
+    TString PeerHost;
+    TString PeerHumanName;
+    i64 ClockSkew = 0;
+
+    TEvUpdateClockSkew(TString peerHost, TString peerHumanName, i64 clockSkew)
+        : PeerHost(std::move(peerHost))
+        , PeerHumanName(std::move(peerHumanName))
+        , ClockSkew(clockSkew)
+    {}
+};
+
+struct TEvUnregisterPeer : TEventLocal<TEvUnregisterPeer, EvUnregisterPeer> {
+    TString PeerHost;
+    TString PeerHumanName;
+
+    TEvUnregisterPeer(TString peerHost, TString peerHumanName)
+        : PeerHost(std::move(peerHost))
+        , PeerHumanName(std::move(peerHumanName))
+    {}
+};
+
+NActors::IActor* CreateInterconnectHostMetricsAggregatorActor(TIntrusivePtr<NActors::TInterconnectProxyCommon> common);
+
+static inline NActors::TActorId MakeInterconnectHostMetricsAggregatorId(ui32 nodeId) {
+    char x[12] = {'I', 'C', 'H', 'o', 's', 't', 'M', 'e', 't', 'r', 'i', 'c'};
+    return NActors::TActorId(nodeId, TStringBuf(x, 12));
+}
+
+} // namespace NActors::NInterconnectHostMetrics

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -931,7 +931,10 @@ namespace NActors {
                 Params.PeerScopeId,
                 std::move(descr.TraceId));
             if (Common->EventFilter && !Common->EventFilter->CheckIncomingEvent(*ev, Common->LocalScopeId)) {
-                LOG_CRIT_IC_SESSION("ICIC03", "Event dropped due to scope error LocalScopeId# %s PeerScopeId# %s Type# 0x%08" PRIx32,
+                Metrics->IncScopeErrors();
+                LOG_CRIT_IC_SESSION("ICIC03", "Event dropped due to scope error PeerNodeId# %" PRIu32 " Peer# %s"
+                    " LocalScopeId# %s PeerScopeId# %s Type# 0x%08" PRIx32,
+                    NodeId, Metrics->GetHumanFriendlyPeerHostName().data(),
                     ScopeIdToString(Common->LocalScopeId).data(), ScopeIdToString(Params.PeerScopeId).data(), descr.Type);
                 ev.reset();
             }

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -114,7 +114,8 @@ namespace NActors {
             if (!Metrics) {
                 Metrics = Common->Metrics ? CreateInterconnectMetrics(Common) : CreateInterconnectCounters(Common);
             }
-            Metrics->SetPeerInfo(PeerNodeId, name, info.Location.GetDataCenterId());
+            const TString peerLabel = Common->Settings.MergePerHostCounters ? info.Host : name;
+            Metrics->SetPeerInfo(name, info.Location.GetDataCenterId(), peerLabel);
             PeerBridgePileName = info.Location.GetBridgePileName();
 
             LOG_DEBUG_IC("ICP02", "configured for host %s", name.data());
@@ -437,6 +438,11 @@ namespace NActors {
 
         if (Metrics) {
             Metrics->IncHandshakeFails();
+        }
+        if (Common->Settings.MergePerHostCounters) {
+            LOG_NOTICE_IC("ICP36", "peer-level handshake fail PeerNodeId# %" PRIu32 " Peer# %s Host# %s Temporary# %u"
+                " Explanation# %s", PeerNodeId, Metrics ? Metrics->GetHumanFriendlyPeerHostName().data() : "",
+                TechnicalPeerHostName.data(), ui32(ev->Get()->Temporary), ev->Get()->Explanation.data());
         }
 
         if (IncomingHandshakeActor || OutgoingHandshakeActor) {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -344,6 +344,10 @@ namespace NActors {
         LostConnectionWatchdog.Disarm();
         Proxy->Metrics->SetConnected(1);
         LOG_INFO(*TlsActivationContext, NActorsServices::INTERCONNECT_STATUS, "[%u] connected", Proxy->PeerNodeId);
+        if (Proxy->Common->Settings.MergePerHostCounters) {
+            LOG_INFO_IC_SESSION("ICS80", "peer-level connect PeerNodeId# %" PRIu32 " Peer# %s Host# %s",
+                Proxy->PeerNodeId, Proxy->Metrics->GetHumanFriendlyPeerHostName().data(), Proxy->TechnicalPeerHostName.data());
+        }
 
         // arm pinger timer
         ResetFlushLogic();
@@ -596,6 +600,11 @@ namespace NActors {
             Proxy->RegisterDisconnect();
             SetOutputStuckFlag(false);
             LOG_INFO(*TlsActivationContext, NActorsServices::INTERCONNECT_STATUS, "[%u] disconnected", Proxy->PeerNodeId);
+            if (Proxy->Common->Settings.MergePerHostCounters) {
+                LOG_NOTICE_IC_SESSION("ICS81", "peer-level disconnect PeerNodeId# %" PRIu32 " Peer# %s Host# %s Reason# %s",
+                    Proxy->PeerNodeId, Proxy->Metrics->GetHumanFriendlyPeerHostName().data(),
+                    Proxy->TechnicalPeerHostName.data(), reason.ToString().data());
+            }
         }
         if (XdcSocket) {
             // call shutdown but do not call close and do not free wrapper object - we need descriptor to finish ZC op

--- a/ydb/library/actors/interconnect/ut/channel_scheduler_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/channel_scheduler_ut.cpp
@@ -10,7 +10,7 @@ Y_UNIT_TEST_SUITE(ChannelScheduler) {
         auto common = MakeIntrusive<TInterconnectProxyCommon>();
         common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
         std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
-        ctr->SetPeerInfo(1, "peer", "1");
+        ctr->SetPeerInfo("peer", "1", "peer");
         auto callback = [](THolder<IEventBase>) {};
         TEventHolderPool pool(common, callback);
         TSessionParams p;

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -260,7 +260,7 @@ TEST_F(XdcRdmaTest, SerializeToRope) {
     auto common = MakeIntrusive<TInterconnectProxyCommon>();
     common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
     std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
-    ctr->SetPeerInfo(1, "peer", "1");
+    ctr->SetPeerInfo("peer", "1", "peer");
     auto callback = [](THolder<IEventBase>) {};
     TEventHolderPool pool(common, callback);
     TSessionParams p;

--- a/ydb/library/actors/interconnect/ya.make
+++ b/ydb/library/actors/interconnect/ya.make
@@ -24,6 +24,8 @@ SRCS(
     interconnect.h
     interconnect_handshake.cpp
     interconnect_handshake.h
+    interconnect_host_metrics_aggregator.cpp
+    interconnect_host_metrics_aggregator.h
     interconnect_impl.h
     interconnect_mon.cpp
     interconnect_mon.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Interconnect: add `CounterMergeMode=PER_HOST` to reduce interconnect metrics cardinality by aggregating counters per peer host.


### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

### Problem
Interconnect counters (`ClockSkewMicrosec`, `Connected`, `Disconnections`, `Events`, `ScopeErrors`, `Traffic`) were emitted per peer, which creates high cardinality in large deployments where many peers live on the same host.

### What was changed
1. Added new interconnect merge mode:
- `TInterconnectConfig::EMergeMode.PER_HOST` in `ydb/core/protos/config.proto`.

2. Added host metrics aggregator actor:
- New files:
  - `ydb/library/actors/interconnect/interconnect_host_metrics_aggregator.h`
  - `ydb/library/actors/interconnect/interconnect_host_metrics_aggregator.cpp`
- Actor is registered from `kikimr_services_initializers.cpp` when `MergePerHostCounters` is enabled.
- Aggregation semantics:
  - `Connected`: sum across peers of the host.
  - `ClockSkewMicrosec`: select peer with `max(abs(skew))`, report signed skew of that winner.
  - Rate metrics are aggregated via `peer=<host>` label.

3. Updated counters/metrics plumbing:
- `SetPeerInfo(...)` changed to accept effective label (`peerLabel`) used for metrics.
- In `PER_HOST` mode, proxy passes host as metric label.
- Added `IncScopeErrors()` path and host-mode handling in counters implementation.
- Updated interconnect call sites accordingly.

4. Added/kept peer-level observability via logs:
- Connect/disconnect and handshake-fail logs remain peer-specific.
- Scope drop increments `ScopeErrors` and remains peer-observable in logs.


### Backward compatibility
- Existing modes (`AUTO`, `PER_PEER`, `PER_DATA_CENTER`, `NO_MERGE`) remain unchanged.
- New behavior is enabled only when `CounterMergeMode=PER_HOST` is explicitly set.

### Validation
- Built and deployed patched `ydbd`.
- Verified on monitoring endpoint that in `PER_HOST` mode interconnect `peer` labels are host-based (`node-...`) instead of per-peer `nodeId:host:port`.
- Verified rollout behavior and metric visibility on updated vs non-updated pods.

