### PR TITLE
Fix Hive rebalance all

### DIFF
--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -3053,7 +3053,7 @@ public:
         , Source(source)
         , Event(ev->Release())
     {
-        TenantName = GetParams(ev->Get()).Get("tenantName");
+        TenantName = GetParams(Event.Get()).Get("tenantName");
     }
 
     TTxType GetTxType() const override { return NHive::TXTYPE_MON_REBALANCE_FROM_SCRATCH; }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix Rebalance ALL tablets FROM SCRATCH button in Embedded Hive UI https://github.com/ydb-platform/ydb/issues/34823

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

`ev` is released before accessing:
```cpp
, Event(ev->Release())
```
It is AutoPtr and can't be used after release.
Because of that this button
<img width="788" height="209" alt="image" src="https://github.com/user-attachments/assets/ec5d3f1f-ed08-4bf5-9741-844b2e87a958" />
didn't work