### PR TITLE
EXT-1935 Object Storage Listing speed and observability improvement

### DIFF
--- a/ydb/core/client/object_storage_listing_ut.cpp
+++ b/ydb/core/client/object_storage_listing_ut.cpp
@@ -3,10 +3,17 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/public/api/protos/draft/ydb_object_storage.pb.h>
 #include <ydb/public/api/grpc/draft/ydb_object_storage_v1.grpc.pb.h>
+#include <ydb/public/api/protos/ydb_table.pb.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/core/tablet_flat/shared_sausagecache.h>
+#include <ydb/core/grpc_services/base/base.h>
+#include <ydb/core/grpc_services/local_rpc/local_rpc.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <grpc++/client_context.h>
 #include <grpc++/create_channel.h>
+#include <util/datetime/base.h>
+#include <util/string/cast.h>
+#include <regex>
 
 namespace NKikimr {
 namespace NFlatTests {
@@ -17,6 +24,20 @@ using NClient::TValue;
 Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
 
     static int GRPC_PORT = 0;
+
+    TServerSettings MakeObjectStorageServerSettings(ui16 port, bool enableParameterizedDecimal = false) {
+        TServerSettings settings(port);
+
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableLocalDBBtreeIndex(false);
+        featureFlags.SetEnableLocalDBFlatIndex(false);
+        if (enableParameterizedDecimal) {
+            featureFlags.SetEnableParameterizedDecimal(true);
+        }
+
+        settings.SetFeatureFlags(featureFlags);
+        return settings;
+    }
 
     void S3WriteRow(TTestActorRuntime* runtime, TFlatMsgBusClient& annoyingClient, ui64 hash, TString name, TString path, ui64 version, ui64 ts, TString data, TString table, bool someBool = true) {
         TString insertRowQuery =  R"(
@@ -43,6 +64,69 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         annoyingClient.FlatQuery(runtime, Sprintf(insertRowQuery.data(), hash, name.data(), path.data(), version, ts, data.data(), someBool ? "true" : "false", table.data()));
     }
 
+    void S3BulkUpsertRows(TTestActorRuntime* runtime, ui64 hash, const TString& name, const TVector<TString>& paths,
+                          ui64 version, ui64 ts, const TString& data, const TString& table, bool someBool = true) {
+        using TEvBulkUpsertRequest = NGRpcService::TGrpcRequestOperationCall<
+            Ydb::Table::BulkUpsertRequest,
+            Ydb::Table::BulkUpsertResponse>;
+
+        Ydb::Table::BulkUpsertRequest request;
+        request.set_table("/dc-1/Dir/" + table);
+        auto* rows = request.mutable_rows();
+
+        auto* rowType = rows->mutable_type()->mutable_list_type()->mutable_item()->mutable_struct_type();
+
+        auto* hashType = rowType->add_members();
+        hashType->set_name("Hash");
+        hashType->mutable_type()->set_type_id(Ydb::Type::UINT64);
+
+        auto* nameType = rowType->add_members();
+        nameType->set_name("Name");
+        nameType->mutable_type()->set_type_id(Ydb::Type::UTF8);
+
+        auto* pathType = rowType->add_members();
+        pathType->set_name("Path");
+        pathType->mutable_type()->set_type_id(Ydb::Type::UTF8);
+
+        auto* versionType = rowType->add_members();
+        versionType->set_name("Version");
+        versionType->mutable_type()->set_type_id(Ydb::Type::UINT64);
+
+        auto* tsType = rowType->add_members();
+        tsType->set_name("Timestamp");
+        tsType->mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(Ydb::Type::UINT64);
+
+        auto* dataType = rowType->add_members();
+        dataType->set_name("Data");
+        dataType->mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(Ydb::Type::STRING);
+
+        auto* someBoolType = rowType->add_members();
+        someBoolType->set_name("SomeBool");
+        someBoolType->mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(Ydb::Type::BOOL);
+
+        auto* reqRows = rows->mutable_value();
+        for (const auto& path : paths) {
+            auto* row = reqRows->add_items();
+            row->add_items()->set_uint64_value(hash);
+            row->add_items()->set_text_value(name);
+            row->add_items()->set_text_value(path);
+            row->add_items()->set_uint64_value(version);
+            row->add_items()->set_uint64_value(ts);
+            row->add_items()->set_bytes_value(data);
+            row->add_items()->set_bool_value(someBool);
+        }
+
+        auto future = NRpcService::DoLocalRpc<TEvBulkUpsertRequest>(
+            std::move(request), "", "", runtime->GetActorSystem(0));
+        auto response = runtime->WaitFuture(std::move(future));
+
+        UNIT_ASSERT(response.operation().ready());
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            response.operation().status(),
+            Ydb::StatusIds::SUCCESS,
+            response.operation().DebugString());
+    }
+
     void S3DeleteRow(TTestActorRuntime* runtime, TFlatMsgBusClient& annoyingClient, ui64 hash, TString name, TString path, ui64 version, TString table) {
         TString eraseRowQuery =  R"(
                     (
@@ -60,6 +144,48 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
                 )";
 
         annoyingClient.FlatQuery(runtime, Sprintf(eraseRowQuery.data(), hash, name.data(), path.data(), version, table.data()));
+    }
+
+    void S3BulkDeleteRows(ui16 grpcPort, ui64 hash, const TString& name,
+                             const TString& pathBegin, const TString& pathEnd,
+                             ui64 version, const TString& table) {
+        auto driverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(TStringBuilder() << "localhost:" << grpcPort);
+        NYdb::TDriver driver(driverConfig);
+        NYdb::NTable::TTableClient tableClient(driver);
+
+        auto sessionResult = tableClient.CreateSession().GetValueSync();
+        UNIT_ASSERT_C(sessionResult.IsSuccess(), sessionResult.GetIssues().ToString());
+        auto session = sessionResult.GetSession();
+
+        auto params = NYdb::TParamsBuilder()
+            .AddParam("$hash").Uint64(hash).Build()
+            .AddParam("$name").Utf8(name).Build()
+            .AddParam("$pathBegin").Utf8(pathBegin).Build()
+            .AddParam("$pathEnd").Utf8(pathEnd).Build()
+            .AddParam("$version").Uint64(version).Build()
+            .Build();
+
+        const TString query = Sprintf(R"(
+            DECLARE $hash AS Uint64;
+            DECLARE $name AS Utf8;
+            DECLARE $pathBegin AS Utf8;
+            DECLARE $pathEnd AS Utf8;
+            DECLARE $version AS Uint64;
+
+            DELETE FROM `/dc-1/Dir/%s`
+            WHERE Hash = $hash
+              AND Name = $name
+              AND Path >= $pathBegin
+              AND Path < $pathEnd
+              AND Version = $version;
+        )", table.data());
+
+        auto result = session.ExecuteDataQuery(
+            query,
+            NYdb::NTable::TTxControl::BeginTx(NYdb::NTable::TTxSettings::SerializableRW()).CommitTx(),
+            params).GetValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
     }
 
     void CreateS3Table(TFlatMsgBusClient& annoyingClient) {
@@ -509,7 +635,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(Listing) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port));
+        TServer cleverServer = TServer(MakeObjectStorageServerSettings(port));
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);
 
@@ -556,7 +682,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(MaxKeysAndSharding) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port));
+        TServer cleverServer = TServer(MakeObjectStorageServerSettings(port));
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);
 
@@ -619,7 +745,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(SchemaChecks) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port));
+        TServer cleverServer = TServer(MakeObjectStorageServerSettings(port));
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);
 
@@ -689,7 +815,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(Split) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port));
+        TServer cleverServer = TServer(MakeObjectStorageServerSettings(port));
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);
         SetSplitMergePartCountLimit(cleverServer.GetRuntime(), -1);
@@ -727,7 +853,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(SuffixColumns) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port));
+        TServer cleverServer = TServer(MakeObjectStorageServerSettings(port));
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);
         TFlatMsgBusClient annoyingClient(port);
@@ -766,9 +892,9 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(ManyDeletes) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServerSettings settings(port);
+        TServerSettings settings = MakeObjectStorageServerSettings(port);
         settings.NodeCount = 1;
-        TServer cleverServer = TServer(TServerSettings(port));
+        TServer cleverServer = TServer(settings);
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);
 
@@ -828,10 +954,109 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         CompareS3Listing(cleverServer.GetRuntime(), annoyingClient, 100, "/Videos/", "/", "", 1000, {});
     }
 
+    Y_UNIT_TEST(TombstoneRestarts) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServerSettings serverSettings = MakeObjectStorageServerSettings(port);
+
+        TStringStream ss;
+        serverSettings.SetLogBackend(new TStreamWithContextLogBackend(&ss));
+
+        TServer cleverServer = TServer(serverSettings);
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+
+        // Disable shared cache to trigger restarts
+        cleverServer.GetRuntime()->Send(NSharedCache::MakeSharedPageCacheId(), TActorId{}, new NMemory::TEvConsumerLimit(0));
+
+        TFlatMsgBusClient annoyingClient(port);
+        PrepareS3Data(cleverServer.GetRuntime(), annoyingClient);
+
+        const size_t N_ROWS = 4000;
+
+        TString bigData(200, 'a');
+
+        const size_t BULK_UPSERT_BATCH_SIZE = 500;
+        for (size_t i = 0; i < N_ROWS; i += BULK_UPSERT_BATCH_SIZE) {
+            const size_t batchEnd = i + BULK_UPSERT_BATCH_SIZE < N_ROWS ? i + BULK_UPSERT_BATCH_SIZE : N_ROWS;
+
+            TVector<TString> paths;
+            paths.reserve(batchEnd - i);
+            for (size_t j = i; j < batchEnd; ++j) {
+                paths.emplace_back("/Tomb/" + ToString(j));
+            }
+
+            S3BulkUpsertRows(cleverServer.GetRuntime(), 100, "Bucket100", paths, 1, 1100, bigData, "Table");
+        }
+
+        S3BulkDeleteRows(GRPC_PORT, 100, "Bucket100", "/Tomb/", "/Tomb0", 1, "Table");
+
+        {
+            size_t insertAfter = 100;
+            TVector<TString> paths;
+            paths.reserve(insertAfter);
+            size_t last = N_ROWS + 1;
+            for (size_t i = last; i < last + insertAfter; ++i) {
+                paths.emplace_back("/Tomb/" + ToString(i));
+            }
+
+            S3BulkUpsertRows(cleverServer.GetRuntime(), 100, "Bucket100", paths, 1, 1100, bigData, "Table");
+        }
+
+        {
+            size_t insertNonMatching = 500;
+            TVector<TString> paths;
+            paths.reserve(insertNonMatching);
+            for (size_t i = 0; i < insertNonMatching; ++i) {
+                paths.emplace_back("/Tomc/" + ToString(i));
+            }
+
+            S3BulkUpsertRows(cleverServer.GetRuntime(), 100, "Bucket100", paths, 1, 1100, bigData, "Table");
+        }
+
+        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_DEBUG);
+
+        TVector<TString> commonPrefixes;
+        TVector<TString> contents;
+        DoS3Listing(GRPC_PORT, 100, "/Tomb/", "/", "", "", {}, 1, commonPrefixes, contents);
+        UNIT_ASSERT_VALUES_EQUAL(0, commonPrefixes.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, contents.size());
+        UNIT_ASSERT_VALUES_EQUAL("/Tomb/4001", contents[0]);
+
+        auto restartsCount = [](const TString& log) {
+            static const std::regex pattern(R"(restarted:\s*([0-9]+))");
+            size_t lineEnd = log.size();
+            while (lineEnd > 0) {
+                size_t lineBegin = log.rfind(';', lineEnd - 1);
+                if (lineBegin == TString::npos) {
+                    lineBegin = 0;
+                } else {
+                    ++lineBegin;
+                }
+
+                const TStringBuf line(log.data() + lineBegin, lineEnd - lineBegin);
+                std::cmatch match;
+                if (std::regex_search(line.data(), line.data() + line.size(), match, pattern)) {
+                    return FromString<ui32>(TStringBuf(match[1].first, static_cast<size_t>(match[1].length())));
+                }
+
+                if (lineBegin == 0) {
+                    break;
+                }
+                lineEnd = lineBegin - 1;
+            }
+            return 0u;
+        };
+
+        ui32 restarts = restartsCount(ss.Str());
+        // Without precharge it's in magnitude of 1000. With precharge it should be less than 10.
+        UNIT_ASSERT_C(restarts <= 10, TStringBuilder() << "expected <= 10 restarts, got " << restarts);
+    }
+
     Y_UNIT_TEST(CornerCases) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port));
+        TServer cleverServer = TServer(MakeObjectStorageServerSettings(port));
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);
 
@@ -890,7 +1115,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(TestFilter) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServer cleverServer = TServer(TServerSettings(port));
+        TServer cleverServer = TServer(MakeObjectStorageServerSettings(port));
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);
 
@@ -971,7 +1196,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(TestSkipShards) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        TServerSettings serverSettings(port);
+        TServerSettings serverSettings = MakeObjectStorageServerSettings(port);
 
         TStringStream ss;
 
@@ -1078,10 +1303,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     Y_UNIT_TEST(Decimal) {
         TPortManager pm;
         ui16 port = pm.GetPort(2134);
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableParameterizedDecimal(true);
-        TServerSettings serverSettings(port);
-        serverSettings.SetFeatureFlags(featureFlags);
+        TServerSettings serverSettings = MakeObjectStorageServerSettings(port, true);
         TServer cleverServer = TServer(serverSettings);
         GRPC_PORT = pm.GetPort(2135);
         cleverServer.EnableGRpc(GRPC_PORT);

--- a/ydb/core/grpc_services/rpc_object_storage.cpp
+++ b/ydb/core/grpc_services/rpc_object_storage.cpp
@@ -15,6 +15,8 @@
 #include <ydb/core/scheme/scheme_type_info.h>
 #include <util/system/unaligned_mem.h>
 
+#include <ydb/library/wilson_ids/wilson.h>
+
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 
 namespace NKikimr {
@@ -62,6 +64,8 @@ private:
     TVector<TString> CommonPrefixesRows;
     TVector<TSerializedCellVec> ContentsRows;
 
+    NWilson::TSpan Span;
+
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
         return NKikimrServices::TActivity::GRPC_REQ;
@@ -78,6 +82,7 @@ public:
         , WaitingResolveReply(false)
         , Finished(false)
         , CurrentShardIdx(0)
+        , Span(TWilsonGrpc::RequestActor, GrpcRequest->GetWilsonTraceId(), "ObjectStorageListingRpc")
     {
     }
 
@@ -142,7 +147,7 @@ private:
         }
         entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpTable;
         request->ResultSet.emplace_back(entry);
-        ctx.Send(SchemeCache, new TEvTxProxySchemeCache::TEvNavigateKeySet(request));
+        ctx.Send(SchemeCache, new TEvTxProxySchemeCache::TEvNavigateKeySet(request), 0, 0, Span.GetTraceId());
 
         TimeoutTimerActorId = CreateLongTimer(ctx, Timeout,
             new IEventHandle(ctx.SelfID, ctx.SelfID, new TEvents::TEvWakeup()));
@@ -168,6 +173,10 @@ private:
         GrpcRequest->Reply(resp, grpcStatus);
 
         Finished = true;
+
+        if (Span) {
+            Span.EndError(message);
+        }
 
         // We cannot Die() while scheme cache request is in flight because that request has pointer to
         // KeyRange member so we must not destroy it before we get the response
@@ -448,7 +457,7 @@ private:
         request->ResultSet.emplace_back(std::move(KeyRange));
 
         TAutoPtr<TEvTxProxySchemeCache::TEvResolveKeySet> resolveReq(new TEvTxProxySchemeCache::TEvResolveKeySet(request));
-        ctx.Send(SchemeCache, resolveReq.Release());
+        ctx.Send(SchemeCache, resolveReq.Release(), 0, 0, Span.GetTraceId());
 
         TBase::Become(&TThis::StateWaitResolveShards);
         WaitingResolveReply = true;
@@ -580,7 +589,7 @@ private:
 
         LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Sending request to shards " << shardId);
 
-        ctx.Send(LeaderPipeCache, new TEvPipeCache::TEvForward(ev.Release(), shardId, true), IEventHandle::FlagTrackDelivery);
+        ctx.Send(LeaderPipeCache, new TEvPipeCache::TEvForward(ev.Release(), shardId, true), IEventHandle::FlagTrackDelivery, 0, Span.GetTraceId());
 
         TBase::Become(&TThis::StateWaitResults);
     }
@@ -828,6 +837,11 @@ private:
         }
 
         Finished = true;
+
+        if (Span) {
+            Span.EndOk();
+        }
+
         Die(ctx);
     }
 };

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -1488,9 +1488,6 @@ namespace TEvDataShard {
                             NKikimrTxDataShard::TEvObjectStorageListingRequest,
                             TEvDataShard::EvObjectStorageListingRequest> {
         TEvObjectStorageListingRequest() = default;
-
-        // Wilson span for this request.
-        NWilson::TSpan ListingSpan;
     };
 
     struct TEvObjectStorageListingResponse

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -1488,6 +1488,9 @@ namespace TEvDataShard {
                             NKikimrTxDataShard::TEvObjectStorageListingRequest,
                             TEvDataShard::EvObjectStorageListingRequest> {
         TEvObjectStorageListingRequest() = default;
+
+        // Wilson span for this request.
+        NWilson::TSpan ListingSpan;
     };
 
     struct TEvObjectStorageListingResponse

--- a/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
+++ b/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
@@ -8,6 +8,12 @@ using namespace NTabletFlatExecutor;
 
 class TDataShard::TTxObjectStorageListing : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
 private:
+    // This is the same timeout as in RpcObjectStorage's handler.
+    // We don't need to run this Tx for a longer time than Rpc handler waits.
+    static constexpr TDuration MAX_TIMEOUT = TDuration::Minutes(5);
+    static constexpr ui64 PRECHARGE_ITEMS = Max<ui64>(); // no limit on items to precharge in order to skip big hunks of erased rows, limit only by bytes
+    static constexpr ui64 PRECHARGE_BYTES = 50_MB; // we want to avoid precharging too much, but object storages usually have lots of rows, so we need to precharge at least some reasonable amount of data
+
     TEvDataShard::TEvObjectStorageListingRequest::TPtr Ev;
     TAutoPtr<TEvDataShard::TEvObjectStorageListingResponse> Result;
 
@@ -16,11 +22,26 @@ private:
     // consitency within the shard. This in not a big deal because listings are not consistent across shards.
     TString LastPath;
     TString LastCommonPath;
+    bool LastProcessedKeyErased = false;
     ui32 RestartCount;
+    bool StartTsInitialized = false;
+    TMonotonic StartTs;
+
+    // Stats for current Execute() call.
+    struct TIterationStats {
+        ui64 ScannedRows = 0;
+        ui64 LeafRows = 0;
+        ui64 ErasedRows = 0;
+        ui64 FilteredOutRows = 0;
+        ui64 SkipToCount = 0;
+        bool SkipToFailed = false;
+        ui64 DeletedRowSkips = 0;
+        bool Advanced = false;
+    };
 
 public:
-    TTxObjectStorageListing(TDataShard* ds, TEvDataShard::TEvObjectStorageListingRequest::TPtr ev)
-        : TBase(ds)
+    TTxObjectStorageListing(TDataShard* ds, TEvDataShard::TEvObjectStorageListingRequest::TPtr ev, NWilson::TTraceId &&traceId)
+        : TBase(ds, std::move(traceId))
         , Ev(ev)
         , RestartCount(0)
     {}
@@ -30,6 +51,29 @@ public:
     bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
         ++RestartCount;
 
+        NWilson::TSpan execSpan;
+        if (txc.TransactionExecutionSpan) {
+            execSpan = NWilson::TSpan(
+                TWilsonTablet::TabletDetailed,
+                txc.TransactionExecutionSpan.GetTraceId(),
+                "Datashard.ObjectStorageListing.Execute",
+                NWilson::EFlags::AUTO_END);
+            if (execSpan && RestartCount > 1) {
+                execSpan.Attribute("Restart", std::to_string(RestartCount));
+            }
+        }
+
+        TIterationStats stats;
+
+        const auto now = AppData(ctx)->MonotonicTimeProvider->Now();
+        if (!StartTsInitialized) {
+            StartTsInitialized = true;
+            StartTs = now;
+        } else if (now - StartTs >= MAX_TIMEOUT) {
+            SetError(execSpan, stats, NKikimrTxDataShard::TError::EXECUTION_CANCELLED, "Request timed out");
+            return true;
+        }
+
         if (!Result) {
             Result = new TEvDataShard::TEvObjectStorageListingResponse(Self->TabletID());
         }
@@ -38,8 +82,8 @@ public:
             Self->State != TShardState::Readonly &&
             Self->State != TShardState::SplitSrcWaitForNoTxInFlight &&
             Self->State != TShardState::Frozen) {
-            SetError(NKikimrTxDataShard::TError::WRONG_SHARD_STATE,
-                        Sprintf("Wrong shard state: %" PRIu32 " tablet id: %" PRIu64, Self->State, Self->TabletID()));
+            TString errorReason = Sprintf("Wrong shard state: %" PRIu32 " tablet id: %" PRIu64, Self->State, Self->TabletID());
+            SetError(execSpan, stats, NKikimrTxDataShard::TError::WRONG_SHARD_STATE, errorReason);
             return true;
         }
 
@@ -47,13 +91,14 @@ public:
         const ui64 maxKeys = Ev->Get()->Record.GetMaxKeys();
 
         if (!Self->TableInfos.contains(tableId)) {
-            SetError(NKikimrTxDataShard::TError::SCHEME_ERROR, Sprintf("Unknown table id %" PRIu64, tableId));
+            TString errorReason = Sprintf("Unknown table id %" PRIu64, tableId);
+            SetError(execSpan, stats, NKikimrTxDataShard::TError::SCHEME_ERROR, errorReason);
             return true;
         }
 
         const TUserTable& tableInfo = *Self->TableInfos[tableId];
         if (tableInfo.IsBackup) {
-            SetError(NKikimrTxDataShard::TError::SCHEME_ERROR, "Cannot read from a backup table");
+            SetError(execSpan, stats, NKikimrTxDataShard::TError::SCHEME_ERROR, "Cannot read from a backup table");
             return true;
         }
 
@@ -155,6 +200,7 @@ public:
 
         if (!maxKeys) {
             // Nothing to return, don't bother searching
+            FillSpan(execSpan, stats);
             return true;
         }
 
@@ -169,7 +215,8 @@ public:
 
         if (LastPath) {
             // Don't include the last key in case of restart
-            keyRange.MinInclusive = false;
+            // Include last key if it was erased to allow erase cache to extend across restarts
+            keyRange.MinInclusive = LastProcessedKeyErased;
         }
 
         bool hasFilter = Ev->Get()->Record.has_filter();
@@ -187,7 +234,8 @@ public:
             
             for (const auto& matchType : filter.matchtypes()) {
                 if (!NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_IsValid(matchType)) {
-                    SetError(NKikimrTxDataShard::TError::BAD_ARGUMENT, Sprintf("Unknown match type %" PRIu32, matchType));
+                    TString errorReason = Sprintf("Unknown match type %" PRIu32, matchType);
+                    SetError(execSpan, stats, NKikimrTxDataShard::TError::BAD_ARGUMENT, errorReason);
                     return true;
                 }
                 matchTypes.push_back(static_cast<NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType>(matchType));
@@ -197,7 +245,17 @@ public:
         TAutoPtr<NTable::TTableIter> iter = txc.DB.IterateRange(localTableId, keyRange, columnsToReturn);
 
         ui64 foundKeys = Result->Record.ContentsRowsSize() + Result->Record.CommonPrefixesRowsSize();
-        while (iter->Next(NTable::ENext::All) == NTable::EReady::Data) {
+        while (iter->Next(NTable::ENext::Data) == NTable::EReady::Data) {
+            // NOTE: We intentionally iterate with ENext::Data instead of ENext::All.
+            // This means the iterator only returns visible (non-erased) rows; erased rows are
+            // not surfaced as separate items but are accounted for via DeletedRowSkips stats
+            // (see the logic below that updates stats.ErasedRows).
+            if (iter->Stats.DeletedRowSkips != stats.DeletedRowSkips) {
+                stats.ErasedRows += iter->Stats.DeletedRowSkips - stats.DeletedRowSkips;
+                stats.DeletedRowSkips = iter->Stats.DeletedRowSkips;
+            }
+            ++stats.ScannedRows;
+            stats.Advanced = true;
             TDbTupleRef currentKey = iter->GetKey();
 
             // Check all columns that prefix columns are in the current key are equal to the specified values
@@ -215,12 +273,7 @@ public:
             TString path = TString((const char*)pathCell.Data(), pathCell.Size());
 
             LastPath = path;
-
-            // Explicitly skip erased rows after saving LastPath. This allows to continue exactly from
-            // this key in case of restart
-            if (iter->Row().GetRowState() == NTable::ERowOp::Erase) {
-                continue;
-            }
+            LastProcessedKeyErased = false;
 
             // Check that path begins with the specified prefix
             Y_VERIFY_DEBUG(path.StartsWith(pathPrefix),
@@ -240,6 +293,7 @@ public:
                 "\"" << path << "\"" << (isLeafPath ? " -> " + DbgPrintTuple(value, *AppData(ctx)->TypeRegistry) : TString()));
 
             if (isLeafPath) {
+                ++stats.LeafRows;
                 Y_ENSURE(value.Cells()[0].Size() >= 1);
                 Y_ENSURE(path == TStringBuf((const char*)value.Cells()[0].Data(), value.Cells()[0].Size()),
                     "Path column must be requested at pos 0");
@@ -282,6 +336,7 @@ public:
                         }
 
                         if (!matches) {
+                            ++stats.FilteredOutRows;
                             continue;
                         }
                     }
@@ -332,6 +387,7 @@ public:
                     }
 
                     if (!matches) {
+                        ++stats.FilteredOutRows;
                         continue;
                     }
                 }
@@ -357,12 +413,42 @@ public:
                 key.emplace_back(lookup.data(), lookup.size(), NScheme::NTypeIds::Utf8);
                 key.resize(columnCount);
 
+                ++stats.SkipToCount;
                 if (!iter->SkipTo(key, /* inclusive = */ true)) {
+                    stats.SkipToFailed = true;
+                    FillSpan(execSpan, stats);
                     return false;
                 }
             }
         }
 
+        if (iter->Stats.DeletedRowSkips != stats.DeletedRowSkips) {
+            stats.ErasedRows += iter->Stats.DeletedRowSkips - stats.DeletedRowSkips;
+            stats.DeletedRowSkips = iter->Stats.DeletedRowSkips;
+        }
+
+        if (iter->Last() == NTable::EReady::Page) {
+            auto lastKeyCells = iter->GetKey().Cells();
+            // Same as in DataShard ReadIterator.
+            if (lastKeyCells && (stats.Advanced || iter->Stats.DeletedRowSkips >= 4)) {
+                Y_ENSURE(lastKeyCells.size() > pathColPos);
+                Y_ENSURE(iter->GetKey().Types[pathColPos].GetTypeId() == NScheme::NTypeIds::Utf8);
+                const TCell& pathCell = lastKeyCells[pathColPos];
+                LastPath = TString((const char*)pathCell.Data(), pathCell.Size());
+                LastProcessedKeyErased = (iter->GetKeyState() == NTable::ERowOp::Erase);
+            }
+
+            if (lastKeyCells) {
+                TVector<TRawTypeValue> prechargeMinKey = ToRawTypeValue(lastKeyCells, tableInfo, false);
+                txc.DB.Precharge(localTableId, prechargeMinKey, keyRange.MaxKey,
+                    columnsToReturn, 0, PRECHARGE_ITEMS, PRECHARGE_BYTES);
+            } else {
+                txc.DB.Precharge(localTableId, keyRange.MinKey, keyRange.MaxKey,
+                    columnsToReturn, 0, PRECHARGE_ITEMS, PRECHARGE_BYTES);
+            }
+        }
+
+        FillSpan(execSpan, stats);
         return iter->Last() != NTable::EReady::Page;
     }
 
@@ -373,14 +459,64 @@ public:
                     << " contents: " << Result->Record.ContentsRowsSize()
                     << " common prefixes: " << Result->Record.CommonPrefixesRowsSize());
         ctx.Send(Ev->Sender, Result.Release());
+
+        NWilson::TSpan& listingSpan = Ev->Get()->ListingSpan;
+        if (listingSpan) {
+            // If there was an error, it was already reported in SetError.
+            listingSpan.EndOk();
+        }
     }
 
 private:
-    void SetError(ui32 status, TString descr) {
+    static TVector<TRawTypeValue> ToRawTypeValue(
+        TArrayRef<const TCell> keyCells,
+        const TUserTable& tableInfo,
+        bool addNulls)
+    {
+        TVector<TRawTypeValue> result;
+        result.reserve(keyCells.size());
+
+        for (ui32 i = 0; i < keyCells.size(); ++i) {
+            result.emplace_back(keyCells[i].AsRef(), tableInfo.KeyColumnTypes[i].GetTypeId());
+        }
+
+        if (addNulls) {
+            result.resize(tableInfo.KeyColumnTypes.size());
+        }
+
+        return result;
+    }
+
+    void FillSpan(NWilson::TSpan& execSpan, TIterationStats& stats, const TString& errorReason = "") {
+        if (!execSpan) {
+            return;
+        }
+        execSpan.Attribute("Shard", std::to_string(this->Self->TabletID()));
+        execSpan.Attribute("ScannedRows", std::to_string(stats.ScannedRows));
+        execSpan.Attribute("LeafRows", std::to_string(stats.LeafRows));
+        execSpan.Attribute("ErasedRows", std::to_string(stats.ErasedRows));
+        execSpan.Attribute("FilteredOutRows", std::to_string(stats.FilteredOutRows));
+        execSpan.Attribute("SkipToCount", std::to_string(stats.SkipToCount));
+        execSpan.Attribute("SkipToFailed", std::to_string(stats.SkipToFailed));
+        if (errorReason) {
+            execSpan.EndError(errorReason);
+        } else {
+            execSpan.EndOk();
+        }
+    }
+
+    void SetError(NWilson::TSpan& execSpan, TIterationStats& stats, ui32 status, TString descr) {
         Result = new TEvDataShard::TEvObjectStorageListingResponse(Self->TabletID());
 
         Result->Record.SetStatus(status);
         Result->Record.SetErrorDescription(descr);
+
+        FillSpan(execSpan, stats, descr);
+
+        NWilson::TSpan& listingSpan = Ev->Get()->ListingSpan;
+        if (listingSpan) {
+            listingSpan.EndError(descr);
+        }
     }
 
     static bool IsKeyInRange(TArrayRef<const TRawTypeValue> key, const TUserTable& tableInfo) {
@@ -420,7 +556,16 @@ private:
 };
 
 void TDataShard::Handle(TEvDataShard::TEvObjectStorageListingRequest::TPtr& ev, const TActorContext& ctx) {
-    Executor()->Execute(new TTxObjectStorageListing(this, ev), ctx);
+    auto* request = ev->Get();
+    
+    if (ev->TraceId) {
+        request->ListingSpan = NWilson::TSpan(TWilsonTablet::TabletTopLevel, std::move(ev->TraceId), "Datashard.ObjectStorageListing", NWilson::EFlags::AUTO_END);
+        if (request->ListingSpan) {
+            request->ListingSpan.Attribute("Shard", std::to_string(TabletID()));
+        }
+    }
+
+    Executor()->Execute(new TTxObjectStorageListing(this, ev, request->ListingSpan.GetTraceId()), ctx);
 }
 
 } // namespace NDataShard

--- a/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
+++ b/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
@@ -16,6 +16,7 @@ private:
 
     TEvDataShard::TEvObjectStorageListingRequest::TPtr Ev;
     TAutoPtr<TEvDataShard::TEvObjectStorageListingResponse> Result;
+    NWilson::TSpan ListingSpan;
 
     // Used to continue iteration from last known position instead of restarting from the beginning
     // This greatly improves performance for the cases with many deletion markers but sacrifices
@@ -40,9 +41,10 @@ private:
     };
 
 public:
-    TTxObjectStorageListing(TDataShard* ds, TEvDataShard::TEvObjectStorageListingRequest::TPtr ev, NWilson::TTraceId &&traceId)
-        : TBase(ds, std::move(traceId))
+    TTxObjectStorageListing(TDataShard* ds, TEvDataShard::TEvObjectStorageListingRequest::TPtr ev, NWilson::TSpan &&listingSpan)
+        : TBase(ds, listingSpan.GetTraceId())
         , Ev(ev)
+        , ListingSpan(std::move(listingSpan))
         , RestartCount(0)
     {}
 
@@ -460,10 +462,9 @@ public:
                     << " common prefixes: " << Result->Record.CommonPrefixesRowsSize());
         ctx.Send(Ev->Sender, Result.Release());
 
-        NWilson::TSpan& listingSpan = Ev->Get()->ListingSpan;
-        if (listingSpan) {
+        if (ListingSpan) {
             // If there was an error, it was already reported in SetError.
-            listingSpan.EndOk();
+            ListingSpan.EndOk();
         }
     }
 
@@ -513,9 +514,8 @@ private:
 
         FillSpan(execSpan, stats, descr);
 
-        NWilson::TSpan& listingSpan = Ev->Get()->ListingSpan;
-        if (listingSpan) {
-            listingSpan.EndError(descr);
+        if (ListingSpan) {
+            ListingSpan.EndError(descr);
         }
     }
 
@@ -556,16 +556,16 @@ private:
 };
 
 void TDataShard::Handle(TEvDataShard::TEvObjectStorageListingRequest::TPtr& ev, const TActorContext& ctx) {
-    auto* request = ev->Get();
-    
+    NWilson::TSpan listingSpan;
+
     if (ev->TraceId) {
-        request->ListingSpan = NWilson::TSpan(TWilsonTablet::TabletTopLevel, std::move(ev->TraceId), "Datashard.ObjectStorageListing", NWilson::EFlags::AUTO_END);
-        if (request->ListingSpan) {
-            request->ListingSpan.Attribute("Shard", std::to_string(TabletID()));
+        listingSpan = NWilson::TSpan(TWilsonTablet::TabletTopLevel, std::move(ev->TraceId), "Datashard.ObjectStorageListing", NWilson::EFlags::AUTO_END);
+        if (listingSpan) {
+            listingSpan.Attribute("Shard", std::to_string(TabletID()));
         }
     }
 
-    Executor()->Execute(new TTxObjectStorageListing(this, ev, request->ListingSpan.GetTraceId()), ctx);
+    Executor()->Execute(new TTxObjectStorageListing(this, ev, std::move(listingSpan)), ctx);
 }
 
 } // namespace NDataShard


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Added precharging for the datashard object storage listing transaction.
Added otel tracing spans the datashard object storage listing RPC and transaction.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
