### PR TITLE
[25-4-1] Fix clearing FilterBorderRows when forgetting an index build with overlap

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
@@ -346,6 +346,32 @@ void TSchemeShard::PersistBuildIndexSampleForget(NIceDb::TNiceDb& db, const TInd
     }
 }
 
+bool TSchemeShard::PersistBuildIndexSampleForgetAll(NIceDb::TNiceDb& db, const TIndexBuildInfo& info) {
+    // There may be more KMeansTreeSamples than 2*K when an index is build with overlap
+    // We want forget to work correctly even with index builds failed because of some reason
+    // So we don't want to remove all samples instead of relying on FilterBorderRows.size()
+    Y_ENSURE(info.IsBuildVectorIndex());
+    ui32 maxCount = 0;
+    {
+        auto rowset = db.Table<Schema::KMeansTreeSample>().Reverse().Range(info.Id).Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+        while (!rowset.EndOfSet()) {
+            TIndexBuildId id = rowset.template GetValue<Schema::KMeansTreeSample::Id>();
+            if (id != info.Id) {
+                break;
+            }
+            maxCount = rowset.template GetValue<Schema::KMeansTreeSample::Row>();
+            break;
+        }
+    }
+    for (ui32 row = 0; row <= maxCount; ++row) {
+        db.Table<Schema::KMeansTreeSample>().Key(info.Id, row).Delete();
+    }
+    return true;
+}
+
 void TSchemeShard::PersistBuildIndexSampleToClusters(NIceDb::TNiceDb& db, TIndexBuildInfo& info) {
     TVector<TString> clusters;
     for (const auto& [_, row] : info.Sample.Rows) {
@@ -413,7 +439,7 @@ void TSchemeShard::PersistBuildIndexClustersForget(NIceDb::TNiceDb& db, const TI
     }
 }
 
-void TSchemeShard::PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& info) {
+bool TSchemeShard::PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& info) {
     db.Table<Schema::IndexBuild>().Key(info.Id).Delete();
 
     ui32 columnNo = 0;
@@ -436,9 +462,12 @@ void TSchemeShard::PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuil
 
     if (info.IsBuildVectorIndex()) {
         db.Table<Schema::KMeansTreeProgress>().Key(info.Id).Delete();
-        PersistBuildIndexSampleForget(db, info);
+        if (!PersistBuildIndexSampleForgetAll(db, info)) {
+            return false;
+        }
         PersistBuildIndexClustersForget(db, info);
     }
+    return true;
 }
 
 void TSchemeShard::Resume(const TDeque<TIndexBuildId>& indexIds, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__forget.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__forget.cpp
@@ -50,7 +50,9 @@ public:
         }
 
         NIceDb::TNiceDb db(txc.DB);
-        Self->PersistBuildIndexForget(db, indexBuildInfo);
+        if (!Self->PersistBuildIndexForget(db, indexBuildInfo)) {
+            return false;
+        }
 
         EraseBuildInfo(indexBuildInfo);
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -2879,11 +2879,14 @@ public:
                     << "At " << state << " state got unsuccess propose result"
                     << ", status: " << NKikimrScheme::EStatus_Name(record.GetStatus())
                     << ", reason: " << record.GetReason());
-                Self->PersistBuildIndexForget(db, buildInfo);
+                if (!Self->PersistBuildIndexForget(db, buildInfo)) {
+                    return false;
+                }
                 EraseBuildInfo(buildInfo);
             }
 
             ReplyOnCreation(buildInfo, statusCode);
+            return true;
         };
 
         auto ifErrorMoveTo = [&] (TIndexBuildInfo::EState to) {
@@ -2909,7 +2912,9 @@ public:
             buildInfo.LockTxStatus = record.GetStatus();
             Self->PersistBuildIndexLockTxStatus(db, buildInfo);
 
-            replyOnCreation();
+            if (!replyOnCreation()) {
+                return false;
+            }
             break;
         }
         case TIndexBuildInfo::EState::AlterMainTable:

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1549,11 +1549,12 @@ public:
 
     void PersistBuildIndexKMeansState(NIceDb::TNiceDb& db, const TIndexBuildInfo& buildInfo);
     void PersistBuildIndexSampleForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
+    bool PersistBuildIndexSampleForgetAll(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexSampleToClusters(NIceDb::TNiceDb& db, TIndexBuildInfo& indexInfo);
     void PersistBuildIndexClustersToSample(NIceDb::TNiceDb& db, TIndexBuildInfo& indexInfo);
     void PersistBuildIndexClustersUpdate(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexClustersForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
-    void PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
+    bool PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
 
     struct TIndexBuilder {
         class TTxBase;


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Cherry-pick of #34606
