### PR TITLE
25-4: Fix use-after-free

### DIFF
--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -2892,7 +2892,7 @@ public:
         , Source(source)
         , Event(ev->Release())
     {
-        auto cgi = GetParams(ev->Get());
+        auto cgi = GetParams(Event.Get());
         MaxMovements = FromStringWithDefault(cgi.Get("movements"), MaxMovements);
         MaxInFlight = FromStringWithDefault(cgi.Get("inflight"), MaxInFlight);
     }
@@ -2931,7 +2931,7 @@ public:
         , Source(source)
         , Event(ev->Release())
     {
-        auto cgi = GetParams(ev->Get());
+        auto cgi = GetParams(Event.Get());
         Settings.NumReassigns = FromStringWithDefault(cgi.Get("reassigns"), 1000);
         Settings.MaxInFlight = FromStringWithDefault(cgi.Get("inflight"), 1);
         Settings.StoragePool = cgi.Get("pool");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed use-after-free in some Hive internal monitoring handlers.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

main: https://github.com/ydb-platform/ydb/pull/34854
