### PR TITLE
26-1: Fix use-after-free

### DIFF
--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -2980,7 +2980,7 @@ public:
         , Source(source)
         , Event(ev->Release())
     {
-        auto cgi = GetParams(ev->Get());
+        auto cgi = GetParams(Event.Get());
         MaxMovements = FromStringWithDefault(cgi.Get("movements"), MaxMovements);
         MaxInFlight = FromStringWithDefault(cgi.Get("inflight"), MaxInFlight);
     }
@@ -3019,7 +3019,7 @@ public:
         , Source(source)
         , Event(ev->Release())
     {
-        auto cgi = GetParams(ev->Get());
+        auto cgi = GetParams(Event.Get());
         Settings.NumReassigns = FromStringWithDefault(cgi.Get("reassigns"), 1000);
         Settings.MaxInFlight = FromStringWithDefault(cgi.Get("inflight"), 1);
         Settings.StoragePool = cgi.Get("pool");

--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -3053,7 +3053,7 @@ public:
         , Source(source)
         , Event(ev->Release())
     {
-        TenantName = GetParams(ev->Get()).Get("tenantName");
+        TenantName = GetParams(Event.Get()).Get("tenantName");
     }
 
     TTxType GetTxType() const override { return NHive::TXTYPE_MON_REBALANCE_FROM_SCRATCH; }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed use-after-free in some Hive internal monitoring handlers.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

main:
- https://github.com/ydb-platform/ydb/pull/34822
- https://github.com/ydb-platform/ydb/pull/34854