### PR TITLE
Validate existing locks and notify long tx service on wait

### DIFF
--- a/ydb/core/protos/data_events.proto
+++ b/ydb/core/protos/data_events.proto
@@ -245,6 +245,7 @@ message TEvLockRowsResult {
         STATUS_SCHEME_ERROR = 6;
         STATUS_SCHEME_CHANGED = 7;
         STATUS_INTERNAL_ERROR = 8;
+        STATUS_DEADLOCK = 9;
     }
 
     // TabletId of the replying shard

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -113,19 +113,20 @@ private:
 
 class TDataShard::TLockRowsNotifyWaitGuard {
 public:
-    TLockRowsNotifyWaitGuard(TDataShard& self, TLockInfo::TPtr lock, TLockInfo::TPtr otherLock)
+    TLockRowsNotifyWaitGuard(TDataShard& self, TLockRowsRequestState& state, TLockInfo::TPtr lock, TLockInfo::TPtr otherLock)
         : Self(self)
         , Lock(std::move(lock))
         , OtherLock(std::move(otherLock))
         , RequestId(Self.NextTieBreakerIndex++)
     {
         if (Lock->GetLockId() != OtherLock->GetLockId()) {
+            Self.LockRowsWaitRequests[RequestId] = &state;
             Self.Send(
                 MakeLongTxServiceID(Self.SelfId().NodeId()),
                 new TEvLongTxService::TEvWaitingLockAdd(
                     RequestId,
-                    Lock->GetLockId(), Lock->GetLockNodeId(),
-                    OtherLock->GetLockId(), OtherLock->GetLockNodeId()));
+                    { Lock->GetLockId(), Lock->GetLockNodeId() },
+                    { OtherLock->GetLockId(), OtherLock->GetLockNodeId() }));
             Sent = true;
         }
     }
@@ -136,6 +137,10 @@ public:
                 MakeLongTxServiceID(Self.SelfId().NodeId()),
                 new TEvLongTxService::TEvWaitingLockRemove(RequestId));
         }
+        // Note: we may fail to send the request with an exception, after
+        // inserting request into LockRowsWaitRequests. Make sure the request
+        // is removed when we exit the scope.
+        Self.LockRowsWaitRequests.erase(RequestId);
     }
 
 private:
@@ -688,7 +693,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
         if (runtimeLock.IsValid()) {
             while (!runtimeLock.IsOwner()) {
                 // Notify long tx service about waiting for the predecessor
-                TLockRowsNotifyWaitGuard waitGuard(*this, lock, runtimeLock.Predecessor().GetLock());
+                TLockRowsNotifyWaitGuard waitGuard(*this, state, lock, runtimeLock.Predecessor().GetLock());
                 // Wait until lock predecessor changes
                 co_await runtimeLock.OnChangedEvent.Wait([&]{
                     // TODO: we need to somehow notify the service about new waiting graph edges,
@@ -703,7 +708,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                 auto currentOwner = SysLocksTable().GetRawLock(*waitForLock);
                 if (currentOwner) {
                     // Notify long tx service abour waiting for the predecessor
-                    TLockRowsNotifyWaitGuard waitGuard(*this, lock, currentOwner);
+                    TLockRowsNotifyWaitGuard waitGuard(*this, state, lock, currentOwner);
                     // Wake up when current row owner is removed entirely
                     // TODO: we probably want to wait until it is broken in the future
                     co_await currentOwner->OnRemovedEvent.Wait([&]{
@@ -730,8 +735,26 @@ void TDataShard::HandleLockRowsCancel(NEvents::TDataEvents::TEvLockRowsCancel::T
     auto it = LockRowsRequests.find(requestId);
     if (it != LockRowsRequests.end()) {
         it->second.Scope.Cancel();
-        // Note: awaiter queue size changes when Cancel is called
+            // Note: awaiter queue size may change when Cancel is called
         UpdateProposeQueueSize();
+    }
+}
+
+void TDataShard::HandleLockRowsDeadlock(TEvLongTxService::TEvWaitingLockDeadlock::TPtr& ev) {
+    auto* msg = ev->Get();
+
+    auto it = LockRowsWaitRequests.find(msg->RequestId);
+    if (it != LockRowsWaitRequests.end()) {
+        TLockRowsRequestState& state = *it->second;
+        if (!state.Result) {
+            state.Result = std::make_unique<NEvents::TDataEvents::TEvLockRowsResult>(
+                TabletID(), state.RequestId.RequestId,
+                NKikimrDataEvents::TEvLockRowsResult::STATUS_DEADLOCK,
+                TStringBuilder() << "Deadlock with another transaction detected at shard " << TabletID());
+            state.Scope.Cancel();
+            // Note: awaiter queue size may change when Cancel is called
+            UpdateProposeQueueSize();
+        }
     }
 }
 

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -6,6 +6,8 @@
 
 namespace NKikimr::NDataShard {
 
+using namespace NLongTxService;
+
 enum class ETxLockRows {
     Restart,
     Rollback,
@@ -107,6 +109,41 @@ public:
 
 private:
     TDataShard& Self;
+};
+
+class TDataShard::TLockRowsNotifyWaitGuard {
+public:
+    TLockRowsNotifyWaitGuard(TDataShard& self, TLockInfo::TPtr lock, TLockInfo::TPtr otherLock)
+        : Self(self)
+        , Lock(std::move(lock))
+        , OtherLock(std::move(otherLock))
+        , RequestId(Self.NextTieBreakerIndex++)
+    {
+        if (Lock->GetLockId() != OtherLock->GetLockId()) {
+            Self.Send(
+                MakeLongTxServiceID(Self.SelfId().NodeId()),
+                new TEvLongTxService::TEvWaitingLockAdd(
+                    RequestId,
+                    Lock->GetLockId(), Lock->GetLockNodeId(),
+                    OtherLock->GetLockId(), OtherLock->GetLockNodeId()));
+            Sent = true;
+        }
+    }
+
+    ~TLockRowsNotifyWaitGuard() {
+        if (Sent && TlsActivationContext) {
+            Self.Send(
+                MakeLongTxServiceID(Self.SelfId().NodeId()),
+                new TEvLongTxService::TEvWaitingLockRemove(RequestId));
+        }
+    }
+
+private:
+    TDataShard& Self;
+    const TLockInfo::TPtr Lock;
+    const TLockInfo::TPtr OtherLock;
+    const ui64 RequestId;
+    bool Sent = false;
 };
 
 void TDataShard::CheckLockRowsRejectAll() {
@@ -409,9 +446,38 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                 takenLocks[0].Counter = TSysTables::TLocksTable::TLock::ErrorBroken;
             }
         }
-        SubscribeNewLocks();
         return ok;
     };
+
+    TLockInfo::TPtr lock;
+    for (const auto& protoLock : msg->Record.GetExistingLocks()) {
+        auto existingLockId = protoLock.GetLockId();
+        auto existingLock = SysLocksTable().GetRawLock(existingLockId);
+
+        bool isBroken = (
+            !existingLock ||
+            existingLock->IsBroken() ||
+            existingLock->GetGeneration() != protoLock.GetGeneration() ||
+            existingLock->GetCounter() != protoLock.GetCounter());
+
+        if (isBroken) {
+            state.Result = makeError(NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN, TStringBuilder()
+                << "Lock " << existingLockId << " is broken at shard " << TabletID());
+            state.Result->AddLock(
+                existingLockId,
+                TabletID(),
+                existingLock ? existingLock->GetGeneration() : Generation(),
+                existingLock ? existingLock->GetCounter() : Max<ui64>(),
+                tableId.PathId.OwnerId,
+                tableId.PathId.LocalPathId,
+                existingLock ? existingLock->IsWriteLock() : false);
+            co_return;
+        }
+
+        if (lockId == existingLockId) {
+            lock = existingLock;
+        }
+    }
 
     TRuntimeLockHolder runtimeLock;
     TVector<TRawTypeValue> typedKey;
@@ -426,6 +492,12 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
 
         // We need to run each iteration in a transaction
         co_await TTxLockRows::Run(this, [&](TTransactionContext& txc) {
+            if (lock && lock->IsBroken()) {
+                state.Result = makeError(NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN, TStringBuilder()
+                    << "Lock " << lockId << " is broken or cannot be created at shard " << TabletID());
+                return ETxLockRows::Rollback;
+            }
+
             if (CheckLockRowsReject(state)) {
                 Y_ENSURE(state.Result);
                 return ETxLockRows::Rollback;
@@ -443,10 +515,18 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
             TDataShardLocksDb locksDb(*this, txc);
             TSetupSysLocks guardLocks(lockId, lockNodeId, *this, &locksDb);
 
-            // 1. Ensure lock exists or is allowed to be created
+            // Ensure lock exists or is allowed to be created
+            // We need to do that even when we already have a valid lock pointer to establish a lock update
             switch (SysLocksTable().EnsureCurrentLock()) {
                 case EEnsureCurrentLock::Success:
                     // Lock is valid, we may continue with reads and side-effects
+                    if (lock) {
+                        Y_ENSURE(lock == guardLocks.Lock);
+                    } else {
+                        lock = guardLocks.Lock;
+                    }
+                    guardLocks.PreserveEmptyLock = true;
+                    SubscribeNewLocks();
                     break;
 
                 case EEnsureCurrentLock::Broken:
@@ -552,7 +632,9 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                         }
 
                         waitForLock = row.LockTxId;
+
                         applyLocks();
+
                         return ETxLockRows::CommitAsync;
                     }
                 }
@@ -604,38 +686,29 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
         }
 
         if (runtimeLock.IsValid()) {
-            struct TResumeCallback : public TLockCallback {
-                TAsyncContinuation<void> Continuation;
-
-                void Run() override {
-                    if (Continuation) {
-                        Continuation.Resume();
-                    }
-                }
-            } resumeCallback;
-
-            if (!runtimeLock.IsOwner()) {
-                // Wait until runtime lock becomes the owner
-                co_await WithAsyncContinuation<void>([&](auto continuation) {
+            while (!runtimeLock.IsOwner()) {
+                // Notify long tx service about waiting for the predecessor
+                TLockRowsNotifyWaitGuard waitGuard(*this, lock, runtimeLock.Predecessor().GetLock());
+                // Wait until lock predecessor changes
+                co_await runtimeLock.OnChangedEvent.Wait([&]{
                     // TODO: we need to somehow notify the service about new waiting graph edges,
                     // which must also take into account that earlier requests may be cancelled while
                     // we wait, and the previous runtime lock in the waiting list might change.
-                    resumeCallback.Continuation = std::move(continuation);
-                    runtimeLock.AddActivationCallback(resumeCallback);
                     setWaiting(true);
                 });
-                Y_ENSURE(runtimeLock.IsOwner());
             }
 
             if (waitForLock) {
                 // Wait until current row's persistent owner is removed
                 auto currentOwner = SysLocksTable().GetRawLock(*waitForLock);
                 if (currentOwner) {
-                    co_await WithAsyncContinuation<void>([&](auto continuation) {
+                    // Notify long tx service abour waiting for the predecessor
+                    TLockRowsNotifyWaitGuard waitGuard(*this, lock, currentOwner);
+                    // Wake up when current row owner is removed entirely
+                    // TODO: we probably want to wait until it is broken in the future
+                    co_await currentOwner->OnRemovedEvent.Wait([&]{
                         // TODO: we need to somehow notify the service about new waiting graph edge
                         // between our lockId and *waitForLock id.
-                        resumeCallback.Continuation = std::move(continuation);
-                        currentOwner->AddOnRemovedCallback(resumeCallback);
                         setWaiting(true);
                     });
                 }

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -254,6 +254,7 @@ class TDataShard
 
     class TTxLockRows;
     class TLockRowsTxObserver;
+    class TLockRowsNotifyWaitGuard;
 
     void HandleMonIndexPage(NMon::TEvRemoteHttpInfo::TPtr& ev);
     void HandleMonVolatileTxs(NMon::TEvRemoteHttpInfo::TPtr& ev);

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1276,6 +1276,7 @@ class TDataShard
     bool CheckLockRowsReject(TLockRowsRequestState& state);
     void HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr ev);
     void HandleLockRowsCancel(NEvents::TDataEvents::TEvLockRowsCancel::TPtr& ev);
+    void HandleLockRowsDeadlock(TEvLongTxService::TEvWaitingLockDeadlock::TPtr& ev);
     void Handle(TEvTxProcessing::TEvPlanStep::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProcessing::TEvReadSet::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvTxProcessing::TEvReadSetAck::TPtr &ev, const TActorContext &ctx);
@@ -3096,6 +3097,7 @@ private:
     THashMap<TActorId, TReadIteratorSession> ReadIteratorSessions;
 
     THashMap<TLockRowsRequestId, TLockRowsRequestState> LockRowsRequests;
+    THashMap<ui64, TLockRowsRequestState*> LockRowsWaitRequests;
 
     NTable::ITransactionObserverPtr BreakWriteConflictsTxObserver;
 
@@ -3304,6 +3306,7 @@ protected:
             HFunc(NEvents::TDataEvents::TEvWrite, Handle);
             hFunc(NEvents::TDataEvents::TEvLockRows, HandleLockRowsRequest);
             hFunc(NEvents::TDataEvents::TEvLockRowsCancel, HandleLockRowsCancel);
+            hFunc(TEvLongTxService::TEvWaitingLockDeadlock, HandleLockRowsDeadlock);
             hFunc(TEvDataShard::TEvGetInfoRequest, Handle);
             hFunc(TEvDataShard::TEvListOperationsRequest, Handle);
             hFunc(TEvDataShard::TEvGetDataHistogramRequest, Handle);

--- a/ydb/core/tx/locks/ya.make
+++ b/ydb/core/tx/locks/ya.make
@@ -11,6 +11,7 @@ SRCS(
 PEERDIR(
     ydb/core/protos
     ydb/core/tablet_flat
+    ydb/library/actors/async
     ydb/library/range_treap
 )
 

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
@@ -1053,5 +1053,13 @@ void TLongTxServiceActor::RemoveUnavailableLock(TProxyNodeState& node, TProxyLoc
     node.Locks.erase(lockId);
 }
 
+void TLongTxServiceActor::Handle(TEvLongTxService::TEvWaitingLockAdd::TPtr& ev) {
+    Y_UNUSED(ev);
+}
+
+void TLongTxServiceActor::Handle(TEvLongTxService::TEvWaitingLockRemove::TPtr& ev) {
+    Y_UNUSED(ev);
+}
+
 } // namespace NLongTxService
 } // namespace NKikimr

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.h
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.h
@@ -297,6 +297,8 @@ namespace NLongTxService {
                 hFunc(TEvLongTxService::TEvSubscribeLock, Handle);
                 hFunc(TEvLongTxService::TEvLockStatus, Handle);
                 hFunc(TEvLongTxService::TEvUnsubscribeLock, Handle);
+                hFunc(TEvLongTxService::TEvWaitingLockAdd, Handle);
+                hFunc(TEvLongTxService::TEvWaitingLockRemove, Handle);
                 hFunc(TEvInterconnect::TEvNodeConnected, Handle);
                 hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
                 hFunc(TEvPrivate::TEvReconnect, Handle);
@@ -321,6 +323,8 @@ namespace NLongTxService {
         void Handle(TEvLongTxService::TEvSubscribeLock::TPtr& ev);
         void Handle(TEvLongTxService::TEvLockStatus::TPtr& ev);
         void Handle(TEvLongTxService::TEvUnsubscribeLock::TPtr& ev);
+        void Handle(TEvLongTxService::TEvWaitingLockAdd::TPtr& ev);
+        void Handle(TEvLongTxService::TEvWaitingLockRemove::TPtr& ev);
 
     private:
         void SendViaSession(const TActorId& sessionId, const TActorId& recipient,

--- a/ydb/core/tx/long_tx_service/public/events.h
+++ b/ydb/core/tx/long_tx_service/public/events.h
@@ -33,6 +33,8 @@ namespace NLongTxService {
             EvSubscribeLock,
             EvLockStatus,
             EvUnsubscribeLock,
+            EvWaitingLockAdd,
+            EvWaitingLockRemove,
             EvEnd,
         };
 
@@ -262,6 +264,34 @@ namespace NLongTxService {
                 Record.SetLockId(lockId);
                 Record.SetLockNode(lockNode);
             }
+        };
+
+        struct TEvWaitingLockAdd
+            : TEventLocal<TEvWaitingLockAdd, EvWaitingLockAdd>
+        {
+            TEvWaitingLockAdd(ui64 requestId, ui64 lockId, ui32 lockNodeId, ui64 otherLockId, ui32 otherLockNodeId)
+                : RequestId(requestId)
+                , LockId(lockId)
+                , OtherLockId(otherLockId)
+                , LockNodeId(lockNodeId)
+                , OtherLockNodeId(otherLockNodeId)
+            {}
+
+            ui64 RequestId;
+            ui64 LockId;
+            ui64 OtherLockId;
+            ui32 LockNodeId;
+            ui32 OtherLockNodeId;
+        };
+
+        struct TEvWaitingLockRemove
+            : TEventLocal<TEvWaitingLockRemove, EvWaitingLockRemove>
+        {
+            TEvWaitingLockRemove(ui64 requestId)
+                : RequestId(requestId)
+            {}
+
+            ui64 RequestId;
         };
     };
 

--- a/ydb/core/tx/long_tx_service/public/events.h
+++ b/ydb/core/tx/long_tx_service/public/events.h
@@ -35,6 +35,7 @@ namespace NLongTxService {
             EvUnsubscribeLock,
             EvWaitingLockAdd,
             EvWaitingLockRemove,
+            EvWaitingLockDeadlock,
             EvEnd,
         };
 
@@ -269,25 +270,36 @@ namespace NLongTxService {
         struct TEvWaitingLockAdd
             : TEventLocal<TEvWaitingLockAdd, EvWaitingLockAdd>
         {
-            TEvWaitingLockAdd(ui64 requestId, ui64 lockId, ui32 lockNodeId, ui64 otherLockId, ui32 otherLockNodeId)
+            struct TLockInfo {
+                ui64 LockId;
+                ui32 LockNodeId;
+            };
+
+            TEvWaitingLockAdd(ui64 requestId, TLockInfo lock, TLockInfo otherLock)
                 : RequestId(requestId)
-                , LockId(lockId)
-                , OtherLockId(otherLockId)
-                , LockNodeId(lockNodeId)
-                , OtherLockNodeId(otherLockNodeId)
+                , Lock(lock)
+                , OtherLock(otherLock)
             {}
 
             ui64 RequestId;
-            ui64 LockId;
-            ui64 OtherLockId;
-            ui32 LockNodeId;
-            ui32 OtherLockNodeId;
+            TLockInfo Lock;
+            TLockInfo OtherLock;
         };
 
         struct TEvWaitingLockRemove
             : TEventLocal<TEvWaitingLockRemove, EvWaitingLockRemove>
         {
             TEvWaitingLockRemove(ui64 requestId)
+                : RequestId(requestId)
+            {}
+
+            ui64 RequestId;
+        };
+
+        struct TEvWaitingLockDeadlock
+            : TEventLocal<TEvWaitingLockDeadlock, EvWaitingLockDeadlock>
+        {
+            TEvWaitingLockDeadlock(ui64 requestId)
                 : RequestId(requestId)
             {}
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR validates existing locks when present in TEvLockRows request, and also grabs the current lock object to revalidate on every iteration, which avoids some unexpected lock recreation pitfalls. Additionally notify long tx service when waiting edges between locks are added/removed, which could be used later for deadlock detection.

Related to #25253.