### PR TITLE
Fixes for SET/DROP DEFAULT 

### DIFF
--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -19,6 +19,8 @@
 #include <library/cpp/containers/absl_flat_hash/flat_hash_set.h>
 #include <util/generic/is_in.h>
 
+#include <functional>
+
 namespace NYql {
 namespace {
 
@@ -372,6 +374,122 @@ namespace {
         return NKikimr::NScheme::TTypeInfo(typeId);
     }
 
+    const TTypeAnnotationNode* GetColumnTypeFromMetadata(const TKikimrColumnMetadata& column, TExprContext& ctx) {
+        const TTypeAnnotationNode* type;
+        switch (column.TypeInfo.GetTypeId()) {
+            case NKikimr::NScheme::NTypeIds::Pg: {
+                type = ctx.MakeType<TPgExprType>(NKikimr::NPg::PgTypeIdFromTypeDesc(column.TypeInfo.GetPgTypeDesc()));
+                break;
+            }
+            case NKikimr::NScheme::NTypeIds::Decimal: {
+                const NKikimr::NScheme::TDecimalType& decimal = column.TypeInfo.GetDecimalType();
+                type = ctx.MakeType<TDataExprParamsType>(EDataSlot::Decimal, ToString(decimal.GetPrecision()), ToString(decimal.GetScale()));
+                if (!column.NotNull)
+                    type = ctx.MakeType<TOptionalExprType>(type);
+                break;
+            }
+            default: {
+                type = ctx.MakeType<TDataExprType>(NKikimr::NUdf::GetDataSlot(column.Type));
+                if (!column.NotNull)
+                    type = ctx.MakeType<TOptionalExprType>(type);
+                break;
+            }
+        }
+        return type;
+    }
+
+    std::optional<IGraphTransformer::TStatus> ValidateDefaultColumn(const TTypeAnnotationNode* columnType, const TTypeAnnotationNode* defaultType,
+        const TExprBase& defaultExpr, TPositionHandle pos, const TString& name, const TKikimrTableDescription* table, TExprContext& ctx,
+        const TTypeAnnotationContext& typesCtx, std::function<void(TExprNode::TPtr)> onRepeat, const bool columnNotNull)
+    {
+        if (!defaultType) {
+            return std::nullopt;
+        }
+
+        const bool isPgNull = IsPgNullExprNode(defaultExpr);
+        if (defaultType->HasNull() || isPgNull) {
+            if (columnNotNull) {
+                if (table) {
+                    ctx.AddError(TIssue(ctx.GetPosition(pos), TStringBuilder()
+                        << "AlterTable : " << NCommon::FullTableName(table->Metadata->Cluster, table->Metadata->Name)
+                        << " Column: \"" << name
+                        << "\". Default expr is nullable or optional, but column has not null constraint."));
+                } else {
+                    ctx.AddError(TIssue(ctx.GetPosition(pos), TStringBuilder() << "Default expr " << name
+                        << " is nullable or optional, but column has not null constraint."));
+                }
+                return IGraphTransformer::TStatus::Error;
+            }
+
+            if (defaultExpr.Maybe<TCoNull>().IsValid() || isPgNull) {
+                if (table) {
+                    ctx.AddError(TIssue(ctx.GetPosition(pos), TStringBuilder()
+                        << "AlterTable : " << NCommon::FullTableName(table->Metadata->Cluster, table->Metadata->Name)
+                        << " Column: \"" << name
+                        << "\". Default expr with null is not supported. Use DROP DEFAULT to replace the default value by null."));
+                } else {
+                    ctx.AddError(TIssue(ctx.GetPosition(pos), TStringBuilder()
+                        << "Default expr " << name << " is null, but default expr with null is not supported. Try to set the column without DEFAULT clause instead."));
+                }
+                return IGraphTransformer::TStatus::Error;
+            }
+        }
+
+        if (!columnType) {
+            return std::nullopt;
+        }
+
+        auto type = &RemoveOptionality(*columnType);
+        auto defaultTypeUnwrapped = &RemoveOptionality(*defaultType);
+
+        const auto typeMismatchMessage = [&]() {
+            if (table) {
+                return TStringBuilder()
+                    << "AlterTable : " << NCommon::FullTableName(table->Metadata->Cluster, table->Metadata->Name)
+                    << " Column: \"" << name
+                    << "\". Default value type mismatch, expected: " << (*type) << ", actual: " << (*defaultTypeUnwrapped);
+            } else {
+                return TStringBuilder()
+                    << "Default expr " << name
+                    << " type mismatch, expected: " << (*type) << ", actual: " << (*defaultTypeUnwrapped);
+            }
+        };
+
+        if (defaultTypeUnwrapped->GetKind() != type->GetKind()) {
+            ctx.AddError(TIssue(ctx.GetPosition(pos), typeMismatchMessage()));
+            return IGraphTransformer::TStatus::Error;
+        }
+
+        bool skipAnnotationValidation = false;
+        if (defaultTypeUnwrapped->GetKind() == ETypeAnnotationKind::Pg) {
+            auto defaultPgType = defaultTypeUnwrapped->Cast<TPgExprType>();
+            if (defaultPgType->GetName() == "unknown") {
+                skipAnnotationValidation = true;
+            }
+        }
+
+        if (!skipAnnotationValidation && !IsSameAnnotation(*defaultTypeUnwrapped, *type)) {
+            auto defaultExprPtr = defaultExpr.Ptr();
+            auto status = TryConvertTo(defaultExprPtr, *columnType, ctx, typesCtx);
+            if (status == IGraphTransformer::TStatus::Error) {
+                ctx.AddError(TIssue(ctx.GetPosition(pos), typeMismatchMessage()));
+                return IGraphTransformer::TStatus::Error;
+            }
+
+            if (status == IGraphTransformer::TStatus::Repeat) {
+                auto evaluatedExpr = ctx.Builder(defaultExprPtr->Pos())
+                    .Callable("EvaluateExpr")
+                    .Add(0, defaultExprPtr)
+                    .Seal()
+                    .Build();
+                onRepeat(std::move(evaluatedExpr));
+                return IGraphTransformer::TStatus(IGraphTransformer::TStatus::Repeat, true);
+            }
+        }
+
+        return std::nullopt;
+    }
+
     bool ValidateColumnDataType(const TDataExprType* type, const TExprBase& typeNode, const TString& columnName,
             TExprContext& ctx) {
         auto columnTypeError = GetColumnTypeErrorFn(ctx);
@@ -405,55 +523,23 @@ namespace {
         auto columnName = TString(nameNode.Value());
         auto columnType = typeNode.Ref().GetTypeAnn();
         auto type = columnType->Cast<TTypeExprType>()->GetType();
-        auto isOptional = type->GetKind() == ETypeAnnotationKind::Optional;
-        auto actualType = !isOptional ? type : type->Cast<TOptionalExprType>()->GetItemType();
+        auto actualType = &RemoveOptionality(*type);
         if (constraint.Name() == "default") {
             auto defaultType = constraint.Value().Ref().GetTypeAnn();
-            YQL_ENSURE(constraint.Value().IsValid());
+            YQL_ENSURE(defaultType && constraint.Value().IsValid());
+
             TExprBase constrValue = constraint.Value().Cast();
 
-            const bool isNull = IsPgNullExprNode(constrValue) || defaultType->HasNull();
-            if (isNull && columnMeta.NotNull) {
-                ctx.AddError(TIssue(ctx.GetPosition(constraint.Pos()), TStringBuilder() << "Default expr " << columnName
-                    << " is nullable or optional, but column has not null constraint. "));
-                return false;
-            }
-
-            // unwrap optional
-            if (defaultType->GetKind() == ETypeAnnotationKind::Optional) {
-                defaultType = defaultType->Cast<TOptionalExprType>()->GetItemType();
-            }
-
-            if (defaultType->GetKind() != actualType->GetKind()) {
-                ctx.AddError(TIssue(ctx.GetPosition(constraint.Pos()), TStringBuilder() << "Default expr " << columnName
-                    << " type mismatch, expected: " << (*actualType) << ", actual: " << *(defaultType)));
-                return false;
-            }
-
-            bool skipAnnotationValidation = false;
-            if (defaultType->GetKind() == ETypeAnnotationKind::Pg) {
-                auto defaultPgType = defaultType->Cast<TPgExprType>();
-                if (defaultPgType->GetName() == "unknown") {
-                    skipAnnotationValidation = true;
-                }
-            }
-
-            if (!skipAnnotationValidation && !IsSameAnnotation(*defaultType, *actualType)) {
-                auto constrPtr = constraint.Value().Cast().Ptr();
-                auto status = TryConvertTo(constrPtr, *type, ctx, typeCtx);
-                if (status == IGraphTransformer::TStatus::Error) {
-                    ctx.AddError(TIssue(ctx.GetPosition(constraint.Pos()), TStringBuilder() << "Default expr " << columnName
-                        << " type mismatch, expected: " << (*actualType) << ", actual: " << *(defaultType)));
-                    return false;
-                } else if (status == IGraphTransformer::TStatus::Repeat) {
-                    auto evaluatedExpr = ctx.Builder(constrPtr->Pos())
-                        .Callable("EvaluateExpr")
-                        .Add(0, constrPtr)
-                        .Seal()
-                        .Build();
-
-                    constraint.Ptr()->ChildRef(TCoNameValueTuple::idx_Value) = evaluatedExpr;
+            if (auto status = ValidateDefaultColumn(type, defaultType, constraint.Value().Cast(), constraint.Pos(),
+                columnName, nullptr, ctx, typeCtx, [&](TExprNode::TPtr expr) {
+                    constraint.Ptr()->ChildRef(TCoNameValueTuple::idx_Value) = std::move(expr);
                     needEval = true;
+                }, columnMeta.NotNull))
+            {
+                if (*status == IGraphTransformer::TStatus::Error) {
+                    return false;
+                }
+                if (*status == IGraphTransformer::TStatus::Repeat) {
                     return true;
                 }
             }
@@ -466,8 +552,7 @@ namespace {
             }
 
             columnMeta.SetDefaultFromLiteral();
-            auto err = FillLiteralProto(constrValue, actualType, columnMeta.DefaultFromLiteral);
-            if (err) {
+            if (auto err = FillLiteralProto(constrValue, actualType, columnMeta.DefaultFromLiteral)) {
                 ctx.AddError(TIssue(ctx.GetPosition(constraint.Pos()), err.value()));
                 return false;
             }
@@ -953,11 +1038,7 @@ private:
             auto columnType = typeNode.Ref().GetTypeAnn();
             YQL_ENSURE(columnType && columnType->GetKind() == ETypeAnnotationKind::Type);
 
-            auto type = columnType->Cast<TTypeExprType>()->GetType();
-
-            auto isOptional = type->GetKind() == ETypeAnnotationKind::Optional;
-            auto actualType = !isOptional ? type : type->Cast<TOptionalExprType>()->GetItemType();
-
+            auto actualType = &RemoveOptionality(*columnType->Cast<TTypeExprType>()->GetType());
             if (actualType->GetKind() != ETypeAnnotationKind::Data
                 && actualType->GetKind() != ETypeAnnotationKind::Pg
             ) {
@@ -1586,10 +1667,7 @@ private:
                     auto typeNode = columnTuple.Item(1);
                     auto columnType = typeNode.Ref().GetTypeAnn();
                     YQL_ENSURE(columnType && columnType->GetKind() == ETypeAnnotationKind::Type);
-                    auto type = columnType->Cast<TTypeExprType>()->GetType();
-                    auto actualType = (type->GetKind() == ETypeAnnotationKind::Optional) ?
-                        type->Cast<TOptionalExprType>()->GetItemType() : type;
-
+                    auto actualType = &RemoveOptionality(*columnType->Cast<TTypeExprType>()->GetType());
 
                     if (actualType->GetKind() != ETypeAnnotationKind::Data
                         && actualType->GetKind() != ETypeAnnotationKind::Pg)
@@ -1735,14 +1813,43 @@ private:
                             return TStatus::Error;
                         }
 
+                        if (table->Metadata->Kind == EKikimrTableKind::Olap) {
+                            ctx.AddError(TIssue(ctx.GetPosition(alterColumnList.Pos()),
+                                "Default values are not supported in column tables"));
+                            return TStatus::Error;
+                        }
+
+                        auto* column = table->Metadata->Columns.FindPtr(name);
+                        if (column && column->IsDefaultFromSequence()) {
+                            ctx.AddError(TIssue(ctx.GetPosition(nameNode.Pos()), TStringBuilder()
+                                << "AlterTable : " << NCommon::FullTableName(table->Metadata->Cluster, table->Metadata->Name)
+                                << " Column: \"" << name
+                                << "\". Cannot set default for a serial/sequence column"));
+                            return TStatus::Error;
+                        }
+
                         auto defaultExpr = alterColumnList.Item(1);
-                        auto defaultType = defaultExpr.Ref().GetTypeAnn();
+                        const auto defaultType = defaultExpr.Ref().GetTypeAnn();
+
                         if (!defaultType) {
                             ctx.AddError(TIssue(ctx.GetPosition(nameNode.Pos()), TStringBuilder()
                                 << "AlterTable : " << NCommon::FullTableName(table->Metadata->Cluster, table->Metadata->Name)
                                 << " Column: \"" << name
                                 << "\". Cannot determine type of default value expression"));
                             return TStatus::Error;
+                        }
+
+                        const TTypeAnnotationNode* columnType = table->GetColumnType(name);
+                        if (!columnType && column) {
+                            columnType = GetColumnTypeFromMetadata(*column, ctx);
+                        }
+
+                        if (auto status = ValidateDefaultColumn(columnType, defaultType, defaultExpr, nameNode.Pos(), name, table, ctx, Types, [&](TExprNode::TPtr expr) {
+                            alterColumnList.Ptr()->ChildRef(1) = std::move(expr);
+                            ctx.Step.Repeat(TExprStep::ExprEval);
+                        }, column ? column->NotNull : false))
+                        {
+                            return *status;
                         }
                     } else if (alterColumnAction == "dropDefault") {
                         if (!SessionCtx->Config().FeatureFlags.GetEnableSetDropDefaultValue()) {
@@ -1772,13 +1879,6 @@ private:
                                     << "AlterTable : " << NCommon::FullTableName(table->Metadata->Cluster, table->Metadata->Name)
                                     << " Column: \"" << name
                                     << "\". Cannot drop default for a serial/sequence column"));
-                                return TStatus::Error;
-                            }
-                            if (column->NotNull) {
-                                ctx.AddError(TIssue(ctx.GetPosition(nameNode.Pos()), TStringBuilder()
-                                    << "AlterTable : " << NCommon::FullTableName(table->Metadata->Cluster, table->Metadata->Name)
-                                    << " Column: \"" << name
-                                    << "\". Cannot drop default for a NOT NULL column"));
                                 return TStatus::Error;
                             }
                         }

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -407,8 +407,7 @@ namespace {
             return std::nullopt;
         }
 
-        const bool isPgNull = IsPgNullExprNode(defaultExpr);
-        if (defaultType->HasNull() || isPgNull) {
+        if (defaultType->HasNull() || IsPgNullExprNode(defaultExpr)) {
             if (columnNotNull) {
                 if (table) {
                     ctx.AddError(TIssue(ctx.GetPosition(pos), TStringBuilder()
@@ -422,7 +421,7 @@ namespace {
                 return IGraphTransformer::TStatus::Error;
             }
 
-            if (defaultExpr.Maybe<TCoNull>().IsValid() || isPgNull) {
+            if (defaultExpr.Maybe<TCoNull>().IsValid()) {
                 if (table) {
                     ctx.AddError(TIssue(ctx.GetPosition(pos), TStringBuilder()
                         << "AlterTable : " << NCommon::FullTableName(table->Metadata->Cluster, table->Metadata->Name)

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -14,6 +14,7 @@
 #include <yql/essentials/parser/pg_wrapper/interface/type_desc.h>
 #include <yql/essentials/providers/common/provider/yql_provider.h>
 #include <ydb/library/yql/providers/dq/provider/yql_dq_datasource_type_ann.h>
+#include <ydb/library/yql/dq/opt/dq_opt_stat.h>
 #include <ydb/services/metadata/optimization/abstract.h>
 
 #include <library/cpp/containers/absl_flat_hash/flat_hash_set.h>
@@ -468,8 +469,8 @@ namespace {
             }
         }
 
+        auto defaultExprPtr = defaultExpr.Ptr();
         if (!skipAnnotationValidation && !IsSameAnnotation(*defaultTypeUnwrapped, *type)) {
-            auto defaultExprPtr = defaultExpr.Ptr();
             auto status = TryConvertTo(defaultExprPtr, *columnType, ctx, typesCtx);
             if (status == IGraphTransformer::TStatus::Error) {
                 ctx.AddError(TIssue(ctx.GetPosition(pos), typeMismatchMessage()));
@@ -485,6 +486,16 @@ namespace {
                 onRepeat(std::move(evaluatedExpr));
                 return IGraphTransformer::TStatus(IGraphTransformer::TStatus::Repeat, true);
             }
+        }
+
+        if (NDq::IsConstantExpr(defaultExprPtr) && !NDq::IsLiteralDataExpr(TExprBase(defaultExprPtr))) {
+            auto evaluatedExpr = ctx.Builder(defaultExprPtr->Pos())
+                .Callable("EvaluateExpr")
+                .Add(0, defaultExprPtr)
+                .Seal()
+                .Build();
+            onRepeat(std::move(evaluatedExpr));
+            return IGraphTransformer::TStatus(IGraphTransformer::TStatus::Repeat, true);
         }
 
         return std::nullopt;

--- a/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
@@ -583,6 +583,30 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
         }
     }
 
+    Y_UNIT_TEST(CreateTableDefaultNullIsNotAllowed) {
+        NKikimrConfig::TAppConfig appConfig;
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/CreateTableDefaultNullTest` (
+                    Key Int32,
+                    Value1 String,
+                    Value2 String DEFAULT NULL,
+                    PRIMARY KEY (Key)
+                );
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Default expr Value2 is null, but default expr with null is not supported. Try to set the column without DEFAULT clause instead.");
+        }
+    }
+
     Y_UNIT_TEST_TWIN(IndexedTableAndNotNullColumn, StreamIndex) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(StreamIndex);
@@ -1672,6 +1696,39 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
         }
     }
 
+    Y_UNIT_TEST(AlterTableAddColumnDefaultNullIsNotAllowed) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableAddColumsWithDefaults(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/AlterTableAddColumnDefaultNullTest` (
+                    Key Int32,
+                    PRIMARY KEY (Key)
+                );
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/AlterTableAddColumnDefaultNullTest` ADD COLUMN Extra Int32 DEFAULT NULL;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Default expr Extra is null, but default expr with null is not supported. Try to set the column without DEFAULT clause instead.");
+        }
+    }
+
     // Y_UNIT_TEST(SetNotNull) {
     //     struct TValue {
     //     private:
@@ -1959,7 +2016,7 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
         }
     }
 
-    Y_UNIT_TEST(AlterTableSetDefaultNull) {
+    Y_UNIT_TEST(AlterTableSetDefaultNullIsNotAllowed) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
 
@@ -1994,27 +2051,40 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
                 ALTER TABLE `/Root/SetDefaultNullTest` ALTER COLUMN Value SET DEFAULT NULL;
             )";
             auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Column: \"Value\". Default expr with null is not supported. Use DROP DEFAULT to replace the default value by null.");
+        }
+    }
+
+    Y_UNIT_TEST(AlterTableSetDefaultNullForNotNullColumn) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/SetDefaultNullForNotNullColumnTest` (
+                    Key Int32,
+                    Value String NOT NULL DEFAULT "original"u,
+                    PRIMARY KEY (Key)
+                );
+            )";
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
 
         {
             auto query = R"(
-                UPSERT INTO `/Root/SetDefaultNullTest` (Key) VALUES (2);
+                ALTER TABLE `/Root/SetDefaultNullForNotNullColumnTest` ALTER COLUMN Value SET DEFAULT NULL;
             )";
-            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        }
-
-        {
-            auto query = R"(
-                SELECT Key, Value FROM `/Root/SetDefaultNullTest` ORDER BY Key;
-            )";
-            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-            CompareYson(R"([
-                [[1];["original"]];
-                [[2];#]
-            ])", FormatResultSetYson(result.GetResultSet(0)));
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Column: \"Value\". Default expr is nullable or optional, but column has not null constraint.");
         }
     }
 
@@ -2082,6 +2152,38 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
         }
     }
 
+    Y_UNIT_TEST(AlterTableSetDefaultOnSequenceColumn) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/SetDefaultSerial` (
+                    Key Serial,
+                    Value String,
+                    PRIMARY KEY (Key)
+                );
+            )";
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/SetDefaultSerial` ALTER COLUMN Key SET DEFAULT 42;
+            )";
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Cannot set default for a serial/sequence column");
+        }
+    }
+
     Y_UNIT_TEST(AlterTableDropDefaultOnSequenceColumn) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
@@ -2114,7 +2216,7 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
         }
     }
 
-    Y_UNIT_TEST(AlterTableDropDefaultOnNotNullColumn) {
+    Y_UNIT_TEST(AlterTableSetAndDropDefaultOnNotNullColumn) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
 
@@ -2127,7 +2229,7 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
 
         {
             auto query = R"(
-                CREATE TABLE `/Root/DropDefaultNotNull` (
+                CREATE TABLE `/Root/SetAndDropDefaultNotNull` (
                     Key Int32,
                     Value String,
                     PRIMARY KEY (Key)
@@ -2139,7 +2241,7 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
 
         {
             auto query = R"(
-                ALTER TABLE `/Root/DropDefaultNotNull` ADD COLUMN Extra Int32 NOT NULL DEFAULT 0;
+                ALTER TABLE `/Root/SetAndDropDefaultNotNull` ADD COLUMN Extra Int32 NOT NULL DEFAULT 0;
             )";
             auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
@@ -2147,11 +2249,59 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
 
         {
             auto query = R"(
-                ALTER TABLE `/Root/DropDefaultNotNull` ALTER COLUMN Extra DROP DEFAULT;
+                UPSERT INTO `/Root/SetAndDropDefaultNotNull` (Key, Value) VALUES (1, "foo");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/SetAndDropDefaultNotNull` ALTER COLUMN Extra DROP DEFAULT;
             )";
             auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Cannot drop default for a NOT NULL column");
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                UPSERT INTO `/Root/SetAndDropDefaultNotNull` (Key, Value) VALUES (2, "test");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Missing not null column in input: Extra");
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/SetAndDropDefaultNotNull` ALTER COLUMN Extra SET DEFAULT 1;
+            )";
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                UPSERT INTO `/Root/SetAndDropDefaultNotNull` (Key, Value) VALUES (3, "bar");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                SELECT Key, Value, Extra FROM `/Root/SetAndDropDefaultNotNull` ORDER BY Key;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([
+                [[1];["foo"];0];
+                [[3];["bar"];1]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
         }
     }
 
@@ -2388,6 +2538,179 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
             auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Default values are not supported in column tables");
+        }
+    }
+
+    Y_UNIT_TEST(AlterTableSetDefaultOnPK) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/PrimaryKeyDefaultTest` (
+                    Key Int32,
+                    Value String,
+                    PRIMARY KEY (Key)
+                );
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/PrimaryKeyDefaultTest` ALTER COLUMN Key SET DEFAULT 42;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                UPSERT INTO `/Root/PrimaryKeyDefaultTest` (Value) VALUES ("test");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                SELECT Key, Value FROM `/Root/PrimaryKeyDefaultTest` ORDER BY Key;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([
+                [[42];["test"]]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST(AlterTableDropDefaultOnPK) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/PrimaryKeyDefaultTest` (
+                    Key Int32 DEFAULT 42,
+                    Value String,
+                    PRIMARY KEY (Key)
+                );
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                UPSERT INTO `/Root/PrimaryKeyDefaultTest` (Value) VALUES ("foo");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/PrimaryKeyDefaultTest` ALTER COLUMN Key DROP DEFAULT;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                UPSERT INTO `/Root/PrimaryKeyDefaultTest` (Value) VALUES ("test");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Missing key column in input: Key");
+        }
+
+        {
+            auto query = R"(
+                UPSERT INTO `/Root/PrimaryKeyDefaultTest` (Key, Value) VALUES (43, "test");
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                SELECT Key, Value FROM `/Root/PrimaryKeyDefaultTest` ORDER BY Key;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([
+                [[42];["foo"]];
+                [[43];["test"]]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST(AlterTableSetDefaultUnsupportedValue) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/UnsupportedValue` (
+                    Key Int32,
+                    Value1 String,
+                    Value2 Json,
+                    PRIMARY KEY (Key)
+                );
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/UnsupportedValue` ALTER COLUMN Value1 SET DEFAULT 13;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Default value type mismatch, expected: String, actual: Int32");
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/UnsupportedValue` ALTER COLUMN Value2 SET DEFAULT Json('{not json]');
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Invalid value \"{not json]\" for type Json");
         }
     }
 }

--- a/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
@@ -2796,6 +2796,50 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
     }
+
+    Y_UNIT_TEST(AlterTableDefaultUndeterministicExpression) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/UndeterministicExpressionTest` (
+                    Key Int32,
+                    Value Int32,
+                    PRIMARY KEY (Key)
+                );
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/UndeterministicExpressionTest` ALTER COLUMN Value SET DEFAULT CurrentUtcTimestamp();
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Column: \"Value\". Default value type mismatch, expected: Int32, actual: Timestamp");
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/UndeterministicExpressionTest` ADD COLUMN Value2 Timestamp NOT NULL DEFAULT CurrentUtcTimestamp();
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unsupported type of literal: CurrentUtcTimestamp");
+        }
+    }
 }
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
@@ -2713,6 +2713,89 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
             UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Invalid value \"{not json]\" for type Json");
         }
     }
+
+    Y_UNIT_TEST(AlterTableDefaultConstantExpression) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSetDropDefaultValue(true);
+
+        TKikimrRunner kikimr(TKikimrSettings(appConfig)
+            .SetWithSampleTables(false));
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE TABLE `/Root/ConstantExpressionTest` (
+                    Key Int32,
+                    Value Int32,
+                    PRIMARY KEY (Key)
+                );
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                UPSERT INTO `/Root/ConstantExpressionTest` (Key) VALUES (1);
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/ConstantExpressionTest` ALTER COLUMN Value SET DEFAULT 2 + 2;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/ConstantExpressionTest` ADD COLUMN Value2 Uint32 NOT NULL DEFAULT CAST(2 + 2 AS Uint32);
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE `/Root/ConstantExpressionTest` ADD COLUMN Value3 Uint32 DEFAULT CAST("abacaba" AS Uint32);
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unsupported type of literal: Nothing");
+        }
+
+        {
+            auto query = R"(
+                UPSERT INTO `/Root/ConstantExpressionTest` (Key) VALUES (2);
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                SELECT Key, Value, Value2 FROM `/Root/ConstantExpressionTest` ORDER BY Key;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            CompareYson(R"([
+                [[1];#;4u];
+                [[2];[4];4u]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
 }
 
 } // namespace NKikimr::NKqp

--- a/ydb/library/yql/dq/opt/dq_opt_stat.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_stat.cpp
@@ -238,6 +238,26 @@ bool NeedCalc(NNodes::TExprBase node) {
     return !node.Maybe<TCoDataCtor>();
 }
 
+bool IsLiteralDataExpr(NNodes::TExprBase node) {
+    auto type = node.Ref().GetTypeAnn();
+    if (type->IsSingleton()) {
+        return false;
+    }
+    if (node.Maybe<TCoDataCtor>()) {
+        return true;
+    }
+    if (node.Maybe<TCoNothing>()) {
+        return true;
+    }
+    if (auto maybeJust = node.Maybe<TCoJust>()) {
+        return IsLiteralDataExpr(maybeJust.Cast().Input());
+    }
+    if (node.Maybe<TCoPgConst>()) {
+        return true;
+    }
+    return false;
+}
+
 bool IsConstantExprPg(const TExprNode::TPtr& input) {
     if (input->GetTypeAnn()->GetKind() == ETypeAnnotationKind::Pg) {
         if (input->IsCallable("PgConst")) {

--- a/ydb/library/yql/dq/opt/dq_opt_stat.h
+++ b/ydb/library/yql/dq/opt/dq_opt_stat.h
@@ -150,6 +150,10 @@ private:
 };
 
 bool NeedCalc(NNodes::TExprBase node);
+// Returns true if the expression is already a fully-evaluated literal
+// (TCoDataCtor, TCoNothing, or TCoJust wrapping a literal) and
+// does not need further evaluation via EvaluateExpr.
+bool IsLiteralDataExpr(NNodes::TExprBase node);
 bool IsConstantExpr(const TExprNode::TPtr& input, bool foldUdfs = true);
 bool IsConstantExprWithParams(const TExprNode::TPtr& input);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- `DEFAULT NULL` is not allowed (set, drop, add, create table).
- `DROP DEFAULT` for `NOT NULL` columns is allowed.
- `SET DEFAULT` for `Serial` is not allowed.
- `SET DEFAULT` with nullable for `NOT NULL` columns is not allowed.
- `SET DEFAULT` checks different types and unsupported values.
- Units for everything (and default pk)!

From:
- #34826
- #34825

...

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
