### PR TITLE
[26-1-1] Fix clearing FilterBorderRows when forgetting an index build with overlap

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_build_index__forget.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__forget.cpp
@@ -50,7 +50,9 @@ public:
         }
 
         NIceDb::TNiceDb db(txc.DB);
-        Self->PersistBuildIndexForget(db, indexBuildInfo);
+        if (!Self->PersistBuildIndexForget(db, indexBuildInfo)) {
+            return false;
+        }
 
         EraseBuildInfo(indexBuildInfo);
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1647,11 +1647,12 @@ public:
 
     void PersistBuildIndexKMeansState(NIceDb::TNiceDb& db, const TIndexBuildInfo& buildInfo);
     void PersistBuildIndexSampleForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
+    bool PersistBuildIndexSampleForgetAll(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexSampleToClusters(NIceDb::TNiceDb& db, TIndexBuildInfo& indexInfo);
     void PersistBuildIndexClustersToSample(NIceDb::TNiceDb& db, TIndexBuildInfo& indexInfo);
     void PersistBuildIndexClustersUpdate(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexClustersForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
-    void PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
+    bool PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
 
     struct TIndexBuilder {
         class TTxBase;


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Cherry-pick of #34606
