### PR TITLE
Copy arrow blocks for tracking when memory profiler option is on

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
@@ -12,7 +12,6 @@
 #include <ydb/core/kqp/runtime/kqp_scan_data.h>
 #include <ydb/core/kqp/runtime/kqp_tasks_runner.h>
 #include <ydb/core/protos/kqp_stats.pb.h>
-#include <ydb/library/formats/arrow/arrow_helpers.h>
 
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h>
 
@@ -195,8 +194,7 @@ void TKqpScanComputeActor::Handle(TEvScanExchange::TEvSendData::TPtr& ev) {
 
     auto guard = TaskRunner->BindAllocator();
     if (!!msg.GetArrowBatch()) {
-        auto arrowBatch = NArrow::ClaimMemoryOwnership(msg.GetArrowBatch());
-        ScanData->AddData(NMiniKQL::TBatchDataAccessor(arrowBatch, std::move(msg.MutableDataIndexes()), BlockTrackingMode), msg.GetTabletId(), TaskRunner->GetHolderFactory(), msg.GetCpuTimeUs(), msg.GetWaitTimeUs(), msg.GetWaitOutputTimeUs(), msg.GetFinished());
+        ScanData->AddData(NMiniKQL::TBatchDataAccessor(msg.GetArrowBatch(), std::move(msg.MutableDataIndexes()), BlockTrackingMode), msg.GetTabletId(), TaskRunner->GetHolderFactory(), msg.GetCpuTimeUs(), msg.GetWaitTimeUs(), msg.GetWaitOutputTimeUs(), msg.GetFinished());
     } else if (!msg.GetRows().empty()) {
         ScanData->AddData(std::move(msg.MutableRows()), msg.GetTabletId(), TaskRunner->GetHolderFactory(), msg.GetCpuTimeUs(), msg.GetWaitTimeUs(), msg.GetWaitOutputTimeUs(), msg.GetFinished());
     } else {

--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
@@ -12,6 +12,7 @@
 #include <ydb/core/kqp/runtime/kqp_scan_data.h>
 #include <ydb/core/kqp/runtime/kqp_tasks_runner.h>
 #include <ydb/core/protos/kqp_stats.pb.h>
+#include <ydb/library/formats/arrow/arrow_helpers.h>
 
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h>
 
@@ -194,7 +195,8 @@ void TKqpScanComputeActor::Handle(TEvScanExchange::TEvSendData::TPtr& ev) {
 
     auto guard = TaskRunner->BindAllocator();
     if (!!msg.GetArrowBatch()) {
-        ScanData->AddData(NMiniKQL::TBatchDataAccessor(msg.GetArrowBatch(), std::move(msg.MutableDataIndexes()), BlockTrackingMode), msg.GetTabletId(), TaskRunner->GetHolderFactory(), msg.GetCpuTimeUs(), msg.GetWaitTimeUs(), msg.GetWaitOutputTimeUs(), msg.GetFinished());
+        auto arrowBatch = NArrow::ClaimMemoryOwnership(msg.GetArrowBatch());
+        ScanData->AddData(NMiniKQL::TBatchDataAccessor(arrowBatch, std::move(msg.MutableDataIndexes()), BlockTrackingMode), msg.GetTabletId(), TaskRunner->GetHolderFactory(), msg.GetCpuTimeUs(), msg.GetWaitTimeUs(), msg.GetWaitOutputTimeUs(), msg.GetFinished());
     } else if (!msg.GetRows().empty()) {
         ScanData->AddData(std::move(msg.MutableRows()), msg.GetTabletId(), TaskRunner->GetHolderFactory(), msg.GetCpuTimeUs(), msg.GetWaitTimeUs(), msg.GetWaitOutputTimeUs(), msg.GetFinished());
     } else {

--- a/ydb/core/kqp/compute_actor/kqp_scan_fetcher_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_fetcher_actor.cpp
@@ -1,6 +1,7 @@
 #include "kqp_scan_fetcher_actor.h"
 
 #include <ydb/core/actorlib_impl/long_timer.h>
+#include <ydb/library/formats/arrow/arrow_helpers.h>
 #include <ydb/core/kqp/common/kqp_resolve.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
@@ -150,6 +151,9 @@ void TKqpScanFetcherActor::HandleExecute(TEvKqpCompute::TEvScanData::TPtr& ev) {
     if (ev->Get()->Finished) {
         state->State = EShardState::PostRunning;
     }
+
+    ev->Get()->ArrowBatch = NArrow::ClaimMemoryOwnership(ev->Get()->ArrowBatch);
+
     PendingScanData.emplace_back(std::make_pair(ev, startTime));
 
     ProcessScanData();

--- a/ydb/core/kqp/executer_actor/kqp_executer.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer.h
@@ -162,6 +162,13 @@ struct TExecuterConfig : TNonCopyable {
         , TableServiceConfig(tableServiceConfig)
         , TliConfig(tliConfig)
     {}
+
+    NKikimrConfig::TTableServiceConfig::EBlockTrackingMode GetBlockTrackingMode() const {
+#ifdef PROFILE_MEMORY_ALLOCATIONS
+        return NKikimrConfig::TTableServiceConfig::BLOCK_TRACKING_DEEP_COPY;
+#endif
+        return TableServiceConfig.GetBlockTrackingMode();
+    }
 };
 
 IActor* CreateKqpExecuter(IKqpGateway::TExecPhysicalRequest&& request, const TString& database,

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -151,7 +151,7 @@ public:
         , ExecuterRetriesConfig(executerConfig.TableServiceConfig.GetExecuterRetriesConfig())
         , AggregationSettings(executerConfig.TableServiceConfig.GetAggregationConfig())
         , StatementResultIndex(statementResultIndex)
-        , BlockTrackingMode(executerConfig.TableServiceConfig.GetBlockTrackingMode())
+        , BlockTrackingMode(executerConfig.GetBlockTrackingMode())
         , VerboseMemoryLimitException(executerConfig.MutableConfig->VerboseMemoryLimitException.load())
         , BatchOperationSettings(std::move(batchOperationSettings))
         , AccountDefaultPoolInScheduler(executerConfig.TableServiceConfig.GetComputeSchedulerSettings().GetAccountDefaultPool())

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
@@ -1,6 +1,7 @@
 #include "actor.h"
 
 #include <ydb/core/formats/arrow/reader/position.h>
+#include <ydb/library/formats/arrow/arrow_helpers.h>
 #include <ydb/core/tx/columnshard/blobs_reader/read_coordinator.h>
 #include <ydb/core/tx/columnshard/engines/reader/tracing/probes.h>
 #include <ydb/core/tx/columnshard/resource_subscriber/actor.h>
@@ -452,6 +453,8 @@ bool TColumnShardScan::SendResult(bool pageFault, bool lastBatch) {
             }
         }
     }
+
+    Result->ArrowBatch = NArrow::ClaimMemoryOwnership(Result->ArrowBatch);
 
     LWPROBE(SendResult, TabletId, ScanId, TxId, Result->GetRowsCount(), (Result->ArrowBatch ? NArrow::GetTableDataSize(Result->ArrowBatch) : 0), Result->CpuTime, Result->WaitTime, TInstant::Now() - LastSend, Result->Finished);
     Send(ScanComputeActorId, Result.Release(), IEventHandle::FlagTrackDelivery);   // TODO: FlagSubscribeOnSession ?

--- a/ydb/library/formats/arrow/arrow_helpers.h
+++ b/ydb/library/formats/arrow/arrow_helpers.h
@@ -121,6 +121,9 @@ std::shared_ptr<arrow::RecordBatch> Reorder(
 // Deep-copies all internal arrow::buffers - and makes sure that new buffers don't have any parents.
 std::shared_ptr<arrow::Table> DeepCopy(const std::shared_ptr<arrow::Table>& table, arrow::MemoryPool* pool = arrow::default_memory_pool());
 
+// When PROFILE_MEMORY_ALLOCATIONS is enabled, performs a deep copy of the table
+// so that all Arrow buffers are re-allocated through the given memory pool,
+// making memory ownership explicit and trackable. Otherwise returns the original table as-is.
 inline std::shared_ptr<arrow::Table> ClaimMemoryOwnership(const std::shared_ptr<arrow::Table>& table, [[maybe_unused]] arrow::MemoryPool* pool = arrow::default_memory_pool()) {
 #ifdef PROFILE_MEMORY_ALLOCATIONS
     return table ? DeepCopy(table, pool) : table;

--- a/ydb/library/formats/arrow/arrow_helpers.h
+++ b/ydb/library/formats/arrow/arrow_helpers.h
@@ -121,4 +121,12 @@ std::shared_ptr<arrow::RecordBatch> Reorder(
 // Deep-copies all internal arrow::buffers - and makes sure that new buffers don't have any parents.
 std::shared_ptr<arrow::Table> DeepCopy(const std::shared_ptr<arrow::Table>& table, arrow::MemoryPool* pool = arrow::default_memory_pool());
 
+inline std::shared_ptr<arrow::Table> ClaimMemoryOwnership(const std::shared_ptr<arrow::Table>& table, [[maybe_unused]] arrow::MemoryPool* pool = arrow::default_memory_pool()) {
+#ifdef PROFILE_MEMORY_ALLOCATIONS
+    return table ? DeepCopy(table, pool) : table;
+#else
+    return table;
+#endif
+}
+
 }   // namespace NKikimr::NArrow


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
In case of OOM, we only see where memory was allocated, so it's hard to find the leak.
That’s why we make copies in profiling mode to get correct stacks on OOM.
...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->


...
