### PR TITLE
Fulltext stress test fixes

### DIFF
--- a/ydb/tests/stress/oltp_workload/workload/type/fulltext_index.py
+++ b/ydb/tests/stress/oltp_workload/workload/type/fulltext_index.py
@@ -113,6 +113,7 @@ class WorkloadFulltextIndex(WorkloadBase):
             SELECT `pk`, `text`, FulltextScore(`text`, "{query}") as `rel`
             FROM `{table_path}`
             VIEW `{index_name}`
+            WHERE FulltextScore(`text`, "{query}") > 0
             ORDER BY `rel`
             LIMIT {self.limit};
         """
@@ -129,7 +130,7 @@ class WorkloadFulltextIndex(WorkloadBase):
             prev = rel
         return n
 
-    def _wait_index_ready(self, index_name, table_path, utf8):
+    def _wait_index_ready(self, index_name, table_path):
         start_time = time.time()
         while time.time() - start_time < 60:
             time.sleep(5)
@@ -137,7 +138,6 @@ class WorkloadFulltextIndex(WorkloadBase):
                 res = self._select_contains(
                     index_name=index_name,
                     table_path=table_path,
-                    utf8=utf8,
                 )
                 if res == 0:
                     continue
@@ -164,7 +164,6 @@ class WorkloadFulltextIndex(WorkloadBase):
         self._wait_index_ready(
             table_path=table_path,
             index_name=index_name,
-            utf8=utf8,
         )
         n = 0
         for i in range(0, self.query_count):
@@ -203,7 +202,7 @@ class WorkloadFulltextIndex(WorkloadBase):
         self._delete_rows(
             table_path=table_path,
             min_key=self.row_count-3,
-            max_key=self.row_count,
+            max_key=self.row_count+3,
         )
         # sometimes replace the index
         if random.randint(0, 1) == 0:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* Removed spurious utf8 keyword argument -- _wait_index_ready was passing utf8=utf8 to _select_contains(), but that method doesn't accept a utf8 parameter (and doesn't need one). I removed the argument from both the call site and the _wait_index_ready signature since it was unused there.

* Added required WHERE predicate to _select_relevance -- The query using FulltextScore() with a fulltext_relevance index requires a WHERE FulltextScore(...) > 0 clause in the predicate. Without it, the server rejects the query with "Score restriction is not found in the predicate."

* In _check_loop, keys 50-52 are created (via INSERT at line 188 and UPSERT at line 195), but the DELETE at line 202 only removes keys 47-49. So keys 50, 51, 52 remain. On the next loop iteration, the INSERT at line 188 fails because keys 51 and 52 already exist.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
