### PR TITLE
[26-1-1] Remove Layout (FLAT/FLAT_RELEVANCE) from fulltext settings

### DIFF
--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -283,19 +283,12 @@ std::span<const std::string_view> GetImplTables(
                 return PrefixedGlobalKMeansTreeImplTables;
             }
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
-            return GetFulltextImplTables(Ydb::Table::FulltextIndexSettings::FLAT);
+            return GlobalFulltextPlainImplTables;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
-            return GetFulltextImplTables(Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE);
+            return GlobalFulltextWithRelevanceImplTables;
         default:
             Y_ENSURE(false, InvalidIndexType(indexType));
     }
-}
-
-std::span<const std::string_view> GetFulltextImplTables(Ydb::Table::FulltextIndexSettings::Layout layout) {
-    if (layout == Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE) {
-        return GlobalFulltextWithRelevanceImplTables;
-    }
-    return GlobalFulltextPlainImplTables;
 }
 
 bool IsImplTable(std::string_view tableName) {

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -54,7 +54,6 @@ NKikimrSchemeOp::EIndexType ConvertIndexType(Ydb::Table::TableIndex::TypeCase ty
 std::span<const std::string_view> GetImplTables(
     NKikimrSchemeOp::EIndexType indexType,
     std::span<const TString> indexKeys);
-std::span<const std::string_view> GetFulltextImplTables(Ydb::Table::FulltextIndexSettings::Layout layout);
 bool IsImplTable(std::string_view tableName);
 bool IsBuildImplTable(std::string_view tableName);
 

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -2505,6 +2505,7 @@ void TKqpTasksGraph::BuildFullTextScanTasksFromSource(TStageInfo& stageInfo, TQu
     settings->SetIndex(fullTextSource.GetIndex());
     settings->SetDatabase(GetMeta().Database);
     settings->MutableTable()->CopyFrom(fullTextSource.GetTable());
+    settings->SetIndexType(fullTextSource.GetIndexType());
     settings->MutableIndexDescription()->CopyFrom(fullTextSource.GetIndexDescription());
 
     auto guard = TxAlloc->TypeEnv.BindAllocator();
@@ -2520,7 +2521,6 @@ void TKqpTasksGraph::BuildFullTextScanTasksFromSource(TStageInfo& stageInfo, TQu
 
         settings->MutableQuerySettings()->SetQuery(TString(queryBuilder));
     }
-
 
     if (fullTextSource.HasTakeLimit())
     {

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_delete_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_delete_index.cpp
@@ -106,9 +106,7 @@ TExprBase BuildDeleteIndexStagesImpl(const TKikimrTableDescription& table,
                 const auto deletePrecompute = ReadInputToPrecompute(deleteIndexKeys, del.Pos(), ctx);
                 deleteIndexKeys = BuildFulltextIndexRows(table, indexDesc, deletePrecompute, indexTableColumnsSet, indexTableColumns,
                     true /*forDelete*/, del.Pos(), ctx);
-                const auto* fulltextDesc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexDesc->SpecializedIndexDescription);
-                YQL_ENSURE(fulltextDesc);
-                const bool withRelevance = fulltextDesc->GetSettings().layout() == Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE;
+                const bool withRelevance = indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance;
                 if (withRelevance) {
                     // Update dictionary rows
                     const auto& dictTable = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, TStringBuilder() << del.Table().Path().Value()

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_fulltext_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_fulltext_index.cpp
@@ -48,12 +48,7 @@ TExprBase BuildFulltextIndexRows(const TKikimrTableDescription& table, const TIn
     const NNodes::TExprBase& inputRows, const THashSet<TStringBuf>& inputColumns, TVector<TStringBuf>& indexTableColumns,
     bool forDelete, TPositionHandle pos, NYql::TExprContext& ctx)
 {
-    // Extract fulltext index settings
-    const auto* fulltextDesc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexDesc->SpecializedIndexDescription);
-    YQL_ENSURE(fulltextDesc, "Expected fulltext index description");
-
-    const auto& settings = fulltextDesc->GetSettings();
-    const bool withRelevance = settings.layout() == Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE;
+    const bool withRelevance = indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance;
 
     auto inputRowArg = TCoArgument(ctx.NewArgument(pos, "input_row"));
     auto tokenArg = TCoArgument(ctx.NewArgument(pos, "token"));

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_indexes.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_indexes.cpp
@@ -122,9 +122,7 @@ TVector<std::pair<TExprNode::TPtr, const TIndexDescription*>> BuildAffectedIndex
                 }
                 case TIndexDescription::EType::GlobalFulltextPlain:
                 case TIndexDescription::EType::GlobalFulltextRelevance: {
-                    const auto* fulltextDesc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index.SpecializedIndexDescription);
-                    YQL_ENSURE(fulltextDesc);
-                    const bool withRelevance = fulltextDesc->GetSettings().layout() == Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE;
+                    const bool withRelevance = index.Type == TIndexDescription::EType::GlobalFulltextRelevance;
                     if (withRelevance) {
                         while (implTable && !implTable->Name.EndsWith(NKikimr::NTableIndex::ImplTable)) {
                             implTable = implTable->Next;

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
@@ -239,9 +239,7 @@ TExprBase KqpBuildInsertIndexStages(TExprBase node, TExprContext& ctx, const TKq
                 auto insertPrecompute = ReadInputToPrecompute(*insertRows, insert.Pos(), ctx);
                 upsertIndexRows = BuildFulltextIndexRows(table, indexDesc, insertPrecompute, inputColumnsSet, indexTableColumns,
                     false /*forDelete*/, insert.Pos(), ctx);
-                const auto* fulltextDesc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexDesc->SpecializedIndexDescription);
-                YQL_ENSURE(fulltextDesc);
-                const bool withRelevance = fulltextDesc->GetSettings().layout() == Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE;
+                const bool withRelevance = indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance;
                 if (withRelevance) {
                     // Update dictionary rows
                     const auto& dictTable = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, TStringBuilder() << insert.Table().Path().Value()

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
@@ -941,8 +941,7 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
         }
 
         TVector<TExprBase> fulltextDictDelta;
-        const auto* fulltextDesc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexDesc->SpecializedIndexDescription);
-        const bool withRelevance = fulltextDesc && fulltextDesc->GetSettings().layout() == Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE;
+        const bool withRelevance = indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance;
         TMaybeNode<TKqpTable> docsTableNode;
         TMaybeNode<TExprBase> addedDocs, removedDocs;
         if (withRelevance) {

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -2448,8 +2448,6 @@ public:
                             break;
                         }
                         case Ydb::Table::TableIndex::kGlobalFulltextPlainIndex: {
-                            // Set layout based on index type
-                            add_index->mutable_global_fulltext_plain_index()->mutable_fulltext_settings()->set_layout(Ydb::Table::FulltextIndexSettings::FLAT);
                             TString error;
                             if (!NKikimr::NFulltext::ValidateSettings(add_index->global_fulltext_plain_index().fulltext_settings(), error)) {
                                 ctx.AddError(TIssue(ctx.GetPosition(action.Pos()), error));
@@ -2458,8 +2456,6 @@ public:
                             break;
                         }
                         case Ydb::Table::TableIndex::kGlobalFulltextRelevanceIndex: {
-                            // Set layout based on index type
-                            add_index->mutable_global_fulltext_relevance_index()->mutable_fulltext_settings()->set_layout(Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE);
                             TString error;
                             if (!NKikimr::NFulltext::ValidateSettings(add_index->global_fulltext_relevance_index().fulltext_settings(), error)) {
                                 ctx.AddError(TIssue(ctx.GetPosition(action.Pos()), error));

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -325,11 +325,9 @@ struct TIndexDescription {
             case EType::GlobalSyncUnique:
             case EType::GlobalAsync:
             case EType::GlobalSyncVectorKMeansTree:
-                return NKikimr::NTableIndex::GetImplTables(NYql::TIndexDescription::ConvertIndexType(Type), KeyColumns);
             case EType::GlobalFulltextPlain:
-                return NKikimr::NTableIndex::GetFulltextImplTables(Ydb::Table::FulltextIndexSettings::FLAT);
             case EType::GlobalFulltextRelevance:
-                return NKikimr::NTableIndex::GetFulltextImplTables(Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE);
+                return NKikimr::NTableIndex::GetImplTables(NYql::TIndexDescription::ConvertIndexType(Type), KeyColumns);
             case EType::LocalBloomFilter:
             case EType::LocalBloomNgramFilter:
                 return {};

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -1188,8 +1188,6 @@ private:
                     break;
                 }
                 case TIndexDescription::EType::GlobalFulltextPlain: {
-                    // Set layout based on index type
-                    fulltextIndexDescription.mutable_settings()->set_layout(Ydb::Table::FulltextIndexSettings::FLAT);
                     TString error;
                     if (!NKikimr::NFulltext::ValidateSettings(fulltextIndexDescription.GetSettings(), error)) {
                         ctx.AddError(TIssue(ctx.GetPosition(index.IndexSettings().Pos()), error));
@@ -1199,8 +1197,6 @@ private:
                     break;
                 }
                 case TIndexDescription::EType::GlobalFulltextRelevance: {
-                    // Set layout based on index type
-                    fulltextIndexDescription.mutable_settings()->set_layout(Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE);
                     TString error;
                     if (!NKikimr::NFulltext::ValidateSettings(fulltextIndexDescription.GetSettings(), error)) {
                         ctx.AddError(TIssue(ctx.GetPosition(index.IndexSettings().Pos()), error));

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1389,6 +1389,11 @@ private:
             auto* desc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index->SpecializedIndexDescription);
             YQL_ENSURE(desc, "unexpected index description type");
             fullTextProto.MutableIndexDescription()->MutableSettings()->CopyFrom(desc->GetSettings());
+            YQL_ENSURE(index->Type == TIndexDescription::EType::GlobalFulltextRelevance
+                || index->Type == TIndexDescription::EType::GlobalFulltextPlain);
+            fullTextProto.SetIndexType(index->Type == TIndexDescription::EType::GlobalFulltextRelevance
+                ? NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance
+                : NKqpProto::EKqpFullTextIndexType::EKqpFullTextPlain);
 
             auto fillCol = [&](const NYql::TKikimrColumnMetadata* columnMeta, NKikimrKqp::TKqpColumnMetadataProto* columnProto) {
                 columnProto->SetName(columnMeta->Name);

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_indexes_fulltext_ut.cpp
@@ -461,7 +461,6 @@ Y_UNIT_TEST(AddIndexWithRelevanceSettings) {
     {
         Ydb::Table::FulltextIndexSettings fulltextSettings;
         UNIT_ASSERT(google::protobuf::TextFormat::ParseFromString(R"(
-            layout: FLAT_RELEVANCE
             columns {
                 column: "Text"
                 analyzers {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_fulltext_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_fulltext_ut.cpp
@@ -54,7 +54,6 @@ Y_UNIT_TEST_SUITE(KqpSchemeFulltext) {
         auto session = db.CreateSession().GetValueSync().GetSession();
         {
             TFulltextIndexSettings indexSettings;
-            indexSettings.Layout = TFulltextIndexSettings::ELayout::Flat;
 
             TFulltextIndexSettings::TAnalyzers analyzers;
             analyzers.Tokenizer = TFulltextIndexSettings::ETokenizer::Whitespace;
@@ -91,7 +90,6 @@ Y_UNIT_TEST_SUITE(KqpSchemeFulltext) {
             UNIT_ASSERT_VALUES_EQUAL(indexDesc.GetDataColumns().size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(indexDesc.GetDataColumns()[0], "Data");
             auto indexSettings = std::get<TFulltextIndexSettings>(indexDesc.GetIndexSettings());
-            UNIT_ASSERT_VALUES_EQUAL(indexSettings.Layout.value_or(TFulltextIndexSettings::ELayout::Unspecified), TFulltextIndexSettings::ELayout::Flat);
             UNIT_ASSERT_VALUES_EQUAL(indexSettings.Columns.size(), 1);
             auto columnSettings = indexSettings.Columns[0];
             UNIT_ASSERT_VALUES_EQUAL(columnSettings.Column, "Text");
@@ -152,7 +150,6 @@ Y_UNIT_TEST_SUITE(KqpSchemeFulltext) {
         }
         {
             TFulltextIndexSettings indexSettings;
-            indexSettings.Layout = TFulltextIndexSettings::ELayout::Flat;
 
             TFulltextIndexSettings::TAnalyzers analyzers;
             analyzers.Tokenizer = TFulltextIndexSettings::ETokenizer::Whitespace;
@@ -186,7 +183,6 @@ Y_UNIT_TEST_SUITE(KqpSchemeFulltext) {
             UNIT_ASSERT_VALUES_EQUAL(indexDesc.GetDataColumns().size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(indexDesc.GetDataColumns()[0], "Data");
             auto indexSettings = std::get<TFulltextIndexSettings>(indexDesc.GetIndexSettings());
-            UNIT_ASSERT_VALUES_EQUAL(indexSettings.Layout.value_or(TFulltextIndexSettings::ELayout::Unspecified), TFulltextIndexSettings::ELayout::Flat);
             UNIT_ASSERT_VALUES_EQUAL(indexSettings.Columns.size(), 1);
             auto columnSettings = indexSettings.Columns[0];
             UNIT_ASSERT_VALUES_EQUAL(columnSettings.Column, "Text");

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -920,6 +920,8 @@ message TKqpFullTextSourceSettings {
     optional string DefaultOperator = 14;
     optional string MinimumShouldMatch = 15;
     optional string Mode = 16;
+
+    optional NKqpProto.EKqpFullTextIndexType IndexType = 17;
 };
 
 message TKqpSysViewSourceSettings {

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -395,6 +395,11 @@ message TKqpPhyConnection {
     };
 }
 
+enum EKqpFullTextIndexType {
+    EKqpFullTextPlain = 0;
+    EKqpFullTextRelevance = 1;
+}
+
 message TKqpFullTextSource {
     message TKqpQuerySettings {
         repeated NKikimrKqp.TKqpColumnMetadataProto Columns = 1;
@@ -426,6 +431,8 @@ message TKqpFullTextSource {
     TKqpPhyValue DefaultOperator = 12;
     TKqpPhyValue MinimumShouldMatch = 13;
     TKqpPhyValue Mode = 14;
+
+    optional EKqpFullTextIndexType IndexType = 15;
 }
 
 message TKqpReadRangesSource {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1899,6 +1899,11 @@ message TEvFilterKMeansResponse {
     repeated bytes LastKeyRows = 10;
 }
 
+enum EFulltextIndexType {
+    FulltextPlain = 0;
+    FulltextRelevance = 1;
+}
+
 message TEvBuildFulltextIndexRequest {
     optional uint64 Id = 1;
 
@@ -1921,6 +1926,8 @@ message TEvBuildFulltextIndexRequest {
     optional string DatabaseName = 12;
 
     optional string DocsTableName = 13;
+
+    optional EFulltextIndexType IndexType = 14;
 }
 
 message TEvBuildFulltextIndexResponse {

--- a/ydb/core/tx/datashard/build_index/fulltext_dict.cpp
+++ b/ydb/core/tx/datashard/build_index/fulltext_dict.cpp
@@ -424,9 +424,6 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildFulltextDictRequest::TPtr& ev,
             if (!NKikimr::NFulltext::ValidateSettings(request.GetSettings(), error)) {
                 badRequest(error);
             }
-            if (request.GetSettings().layout() != Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE) {
-                badRequest(TStringBuilder() << "FLAT_RELEVANCE index layout is required");
-            }
         }
 
         if (trySendBadRequest()) {

--- a/ydb/core/tx/datashard/build_index/ut/ut_fulltext.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_fulltext.cpp
@@ -47,8 +47,9 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
         request.SetSnapshotTxId(snapshot.TxId);
         request.SetSnapshotStep(snapshot.Step);
 
+        request.SetIndexType(NKikimrTxDataShard::EFulltextIndexType::FulltextPlain);
+
         FulltextIndexSettings settings;
-        settings.set_layout(FulltextIndexSettings::FLAT);
         auto column = settings.add_columns();
         column->set_column("text");
         column->mutable_analyzers()->set_tokenizer(FulltextIndexSettings::WHITESPACE);
@@ -214,7 +215,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextIndexScan) {
         }, "{ <main>: Error: Empty index table name }");
 
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextIndexRequest& request) {
-            request.MutableSettings()->set_layout(FulltextIndexSettings::FLAT_RELEVANCE);
+            request.SetIndexType(NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance);
             request.ClearDocsTableName();
         }, "{ <main>: Error: Empty index documents table name }");
 
@@ -406,7 +407,7 @@ __ydb_token = yellow, key = 3, text = yellow apple, subkey = 33, data = three
         CreateDocsTable(server, sender);
 
         auto reply = DoBuildRaw(server, sender, [](auto& request) {
-            request.MutableSettings()->set_layout(FulltextIndexSettings::FLAT_RELEVANCE);
+            request.SetIndexType(NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance);
         });
         auto& record = reply->Get()->Record;
 

--- a/ydb/core/tx/datashard/build_index/ut/ut_fulltext_dict.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_fulltext_dict.cpp
@@ -42,7 +42,6 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextDictScan) {
         tableId.PathId.ToProto(request.MutablePathId());
 
         FulltextIndexSettings settings;
-        settings.set_layout(FulltextIndexSettings::FLAT_RELEVANCE);
         auto column = settings.add_columns();
         column->set_column("text");
         column->mutable_analyzers()->set_tokenizer(FulltextIndexSettings::WHITESPACE);
@@ -180,10 +179,6 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildFulltextDictScan) {
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextDictRequest& request) {
             request.ClearOutputName();
         }, "{ <main>: Error: Empty output table name }");
-
-        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextDictRequest& request) {
-            request.MutableSettings()->set_layout(FulltextIndexSettings::FLAT);
-        }, "{ <main>: Error: FLAT_RELEVANCE index layout is required }");
 
         // test multiple issues:
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildFulltextDictRequest& request) {

--- a/ydb/core/tx/schemeshard/schemeshard_index_build_info.h
+++ b/ydb/core/tx/schemeshard/schemeshard_index_build_info.h
@@ -753,8 +753,7 @@ public:
         if (BuildKind != EBuildKind::BuildFulltext) {
             return false;
         }
-        auto settings = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(SpecializedIndexDescription).GetSettings();
-        return settings.layout() == Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE;
+        return IndexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance;
     }
 
     void AddNotifySubscriber(const TActorId& actorID) {

--- a/ydb/core/tx/schemeshard/ut_index/ut_fulltext_index.cpp
+++ b/ydb/core/tx/schemeshard/ut_index/ut_fulltext_index.cpp
@@ -19,7 +19,6 @@ Y_UNIT_TEST_SUITE(TFulltextIndexTests) {
         ui64 txId = 100;
 
         TString fulltextSettings = R"(
-            layout: FLAT
             columns: {
                 column: "text"
                 analyzers: {
@@ -85,7 +84,6 @@ Y_UNIT_TEST_SUITE(TFulltextIndexTests) {
         ui64 txId = 100;
 
         TString fulltextSettings = R"(
-            layout: FLAT
             columns: {
                 column: "text"
                 analyzers: {
@@ -128,7 +126,6 @@ Y_UNIT_TEST_SUITE(TFulltextIndexTests) {
         ui64 txId = 100;
 
         TString fulltextSettings = R"(
-            layout: FLAT
             columns: {
                 column: "text1"
                 analyzers: {
@@ -179,7 +176,6 @@ Y_UNIT_TEST_SUITE(TFulltextIndexTests) {
         ui64 txId = 100;
 
         TString fulltextSettings = R"(
-            layout: FLAT
             columns: {
                 column: "text"
                 analyzers: {
@@ -222,7 +218,6 @@ Y_UNIT_TEST_SUITE(TFulltextIndexTests) {
         ui64 txId = 100;
 
         TString fulltextSettings = R"(
-            layout: FLAT
             columns: {
                 column: "text_wrong"
                 analyzers: {
@@ -265,7 +260,6 @@ Y_UNIT_TEST_SUITE(TFulltextIndexTests) {
         ui64 txId = 100;
 
         TString fulltextSettings = R"(
-            layout: FLAT
         )";
         TestCreateIndexedTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
             TableDescription {
@@ -301,7 +295,6 @@ Y_UNIT_TEST_SUITE(TFulltextIndexTests) {
         ui64 txId = 100;
 
         TString fulltextSettings = R"(
-            layout: FLAT
             columns: {
                 column: "text"
                 analyzers: {

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_fulltext_build.cpp
@@ -33,7 +33,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
         index.set_name("fulltext_idx");
         index.add_index_columns("text");
         auto& fulltext = *index.mutable_global_fulltext_relevance_index()->mutable_fulltext_settings();
-        fulltext.set_layout(Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE);  // Layout is required for internal processing
         auto& analyzers = *fulltext.add_columns()->mutable_analyzers();
         fulltext.mutable_columns()->at(0).set_column("text");
         analyzers.set_tokenizer(Ydb::Table::FulltextIndexSettings::WHITESPACE);
@@ -75,7 +74,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTest) {
         index.add_index_columns("text");
         index.add_data_columns("data");
         auto& fulltext = *index.mutable_global_fulltext_plain_index()->mutable_fulltext_settings();
-        fulltext.set_layout(Ydb::Table::FulltextIndexSettings::FLAT);
         auto& analyzers = *fulltext.add_columns()->mutable_analyzers();
         fulltext.mutable_columns()->at(0).set_column("text");
         analyzers.set_tokenizer(Ydb::Table::FulltextIndexSettings::WHITESPACE);

--- a/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_fulltext_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_fulltext_index_build_reboots.cpp
@@ -71,7 +71,6 @@ Y_UNIT_TEST_SUITE(FulltextIndexBuildTestReboots) {
                     "index1", NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance, indexColumns, {"data"}, {}
                 });
                 auto& fulltext = *request->Record.MutableSettings()->mutable_index()->mutable_global_fulltext_relevance_index()->mutable_fulltext_settings();
-                fulltext.set_layout(Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE);  // Layout is required for internal processing
                 auto& analyzers = *fulltext.add_columns()->mutable_analyzers();
                 fulltext.mutable_columns()->at(0).set_column("text");
                 analyzers.set_tokenizer(Ydb::Table::FulltextIndexSettings::WHITESPACE);

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -118,86 +118,6 @@ message GlobalVectorKMeansTreeIndex {
 }
 
 message FulltextIndexSettings {
-    // Specifies the layout strategy for storing and updating the full-text index
-    enum Layout {
-        LAYOUT_UNSPECIFIED = 0;
-
-        // Simplest possible layout without support for relevance.
-        // Uses a single flat inverted index table (indexImplTable).
-        // Supports a single column only.
-        // Example source table:
-        //     ┌────┬────────────────────────────┐
-        //     │ id │ text                       │
-        //     ├────┼────────────────────────────┤
-        //     │ 1  │ "The quick brown fox"      │
-        //     │ 2  │ "The quick blue hare"      │
-        //     └────┴────────────────────────────┘
-        // Example inverted index table (indexImplTable):
-        //     ┌──────────────┬────┐
-        //     │ __ydb_token  │ id │
-        //     ├──────────────┼────┤
-        //     │ "The"        │ 1  │
-        //     │ "The"        │ 2  │
-        //     │ "blue"       │ 2  │
-        //     │ "brown"      │ 1  │
-        //     │ "fox"        │ 1  │
-        //     │ "hare"       │ 2  │
-        //     │ "quick"      │ 1  │
-        //     │ "quick"      │ 2  │
-        //     └──────────────┴────┘
-        FLAT = 1;
-
-        // Simple layout like FLAT, but with support for relevance.
-        // Uses multiple index tables. Supports a single column only.
-        // Example source table:
-        //     ┌────┬───────────────────────────────────────┐
-        //     │ id │ text                                  │
-        //     ├────┼───────────────────────────────────────┤
-        //     │ 1  │ "A quick fox catches quick hare"      │
-        //     │ 2  │ "The quick blue hare"                 │
-        //     └────┴───────────────────────────────────────┘
-        // Example inverted index table with term frequencies (indexImplTable):
-        //     ┌──────────────┬────┬────────────┐
-        //     │ __ydb_token  │ id │ __ydb_freq │
-        //     ├──────────────┼────┼────────────┤
-        //     │ "A"          │ 1  │ 1          │
-        //     │ "The"        │ 2  │ 1          │
-        //     │ "blue"       │ 2  │ 1          │
-        //     │ "catches"    │ 1  │ 1          │
-        //     │ "fox"        │ 1  │ 1          │
-        //     │ "hare"       │ 1  │ 1          │
-        //     │ "hare"       │ 2  │ 1          │
-        //     │ "quick"      │ 1  │ 2          │
-        //     │ "quick"      │ 2  │ 1          │
-        //     └──────────────┴────┴────────────┘
-        // Term dictionary table (indexImplDictTable):
-        //     ┌──────────────┬────────────┐
-        //     │ __ydb_token  │ __ydb_freq │
-        //     ├──────────────┼────────────┤
-        //     │ "A"          │ 1          │
-        //     │ "The"        │ 1          │
-        //     │ "blue"       │ 1          │
-        //     │ "catches"    │ 1          │
-        //     │ "fox"        │ 1          │
-        //     │ "hare"       │ 2          │
-        //     │ "quick"      │ 2          │
-        //     └──────────────┴────────────┘
-        // Document statistics table (indexImplDocsTable):
-        //     ┌────┬──────────────┐
-        //     │ id │ __ydb_length │
-        //     ├────┼──────────────┤
-        //     │ 1  │ 6            │
-        //     │ 2  │ 4            │
-        //     └────┴──────────────┘
-        // Global statistics table (indexImplStatsTable):
-        //     ┌──────────┬─────────────────┬────────────────────┐
-        //     │ __ydb_id │ __ydb_doc_count │ __ydb_total_length │
-        //     ├──────────┼─────────────────┼────────────────────┤
-        //     │ 1        │ 2               │ 10                 │
-        //     └──────────┴─────────────────┴────────────────────┘
-        FLAT_RELEVANCE = 2;
-    }
-
     // Specifies how text is tokenized during indexing
     enum Tokenizer {
         TOKENIZER_UNSPECIFIED = 0;
@@ -302,8 +222,8 @@ message FulltextIndexSettings {
         Analyzers analyzers = 2;
     }
 
-    // See Layout enum
-    optional Layout layout = 1;
+    // Removed Layout field
+    reserved 1;
 
     // List of columns and their fulltext settings
     // Currently, this list should contain a single entry with specified analyzers
@@ -312,11 +232,82 @@ message FulltextIndexSettings {
     repeated ColumnAnalyzers columns = 2;
 }
 
+// Simplest possible layout without support for relevance.
+// Uses a single flat inverted index table (indexImplTable).
+// Supports a single column only.
+// Example source table:
+//     ┌────┬────────────────────────────┐
+//     │ id │ text                       │
+//     ├────┼────────────────────────────┤
+//     │ 1  │ "The quick brown fox"      │
+//     │ 2  │ "The quick blue hare"      │
+//     └────┴────────────────────────────┘
+// Example inverted index table (indexImplTable):
+//     ┌──────────────┬────┐
+//     │ __ydb_token  │ id │
+//     ├──────────────┼────┤
+//     │ "The"        │ 1  │
+//     │ "The"        │ 2  │
+//     │ "blue"       │ 2  │
+//     │ "brown"      │ 1  │
+//     │ "fox"        │ 1  │
+//     │ "hare"       │ 2  │
+//     │ "quick"      │ 1  │
+//     │ "quick"      │ 2  │
+//     └──────────────┴────┘
 message GlobalFulltextPlainIndex {
     GlobalIndexSettings settings = 1;
     FulltextIndexSettings fulltext_settings = 2;
 }
 
+// Simple layout like Plain, but with support for relevance.
+// Uses multiple index tables. Supports a single column only.
+// Example source table:
+//     ┌────┬───────────────────────────────────────┐
+//     │ id │ text                                  │
+//     ├────┼───────────────────────────────────────┤
+//     │ 1  │ "A quick fox catches quick hare"      │
+//     │ 2  │ "The quick blue hare"                 │
+//     └────┴───────────────────────────────────────┘
+// Example inverted index table with term frequencies (indexImplTable):
+//     ┌──────────────┬────┬────────────┐
+//     │ __ydb_token  │ id │ __ydb_freq │
+//     ├──────────────┼────┼────────────┤
+//     │ "A"          │ 1  │ 1          │
+//     │ "The"        │ 2  │ 1          │
+//     │ "blue"       │ 2  │ 1          │
+//     │ "catches"    │ 1  │ 1          │
+//     │ "fox"        │ 1  │ 1          │
+//     │ "hare"       │ 1  │ 1          │
+//     │ "hare"       │ 2  │ 1          │
+//     │ "quick"      │ 1  │ 2          │
+//     │ "quick"      │ 2  │ 1          │
+//     └──────────────┴────┴────────────┘
+// Term dictionary table (indexImplDictTable):
+//     ┌──────────────┬────────────┐
+//     │ __ydb_token  │ __ydb_freq │
+//     ├──────────────┼────────────┤
+//     │ "A"          │ 1          │
+//     │ "The"        │ 1          │
+//     │ "blue"       │ 1          │
+//     │ "catches"    │ 1          │
+//     │ "fox"        │ 1          │
+//     │ "hare"       │ 2          │
+//     │ "quick"      │ 2          │
+//     └──────────────┴────────────┘
+// Document statistics table (indexImplDocsTable):
+//     ┌────┬──────────────┐
+//     │ id │ __ydb_length │
+//     ├────┼──────────────┤
+//     │ 1  │ 6            │
+//     │ 2  │ 4            │
+//     └────┴──────────────┘
+// Global statistics table (indexImplStatsTable):
+//     ┌──────────┬─────────────────┬────────────────────┐
+//     │ __ydb_id │ __ydb_doc_count │ __ydb_total_length │
+//     ├──────────┼─────────────────┼────────────────────┤
+//     │ 1        │ 2               │ 10                 │
+//     └──────────┴─────────────────┴────────────────────┘
 message GlobalFulltextRelevanceIndex {
     GlobalIndexSettings posting_table_settings = 1;
     FulltextIndexSettings fulltext_settings = 2;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -313,12 +313,6 @@ public:
 
 struct TFulltextIndexSettings {
 public:
-    enum class ELayout {
-        Unspecified = 0,
-        Flat,
-        FlatRelevance,
-    };
-
     enum class ETokenizer {
         Unspecified = 0,
         Whitespace,
@@ -345,7 +339,6 @@ public:
         std::optional<TAnalyzers> Analyzers;
     };
 
-    std::optional<ELayout> Layout;
     std::vector<TColumnAnalyzers> Columns;
 
     static TFulltextIndexSettings FromProto(const Ydb::Table::FulltextIndexSettings& proto);
@@ -820,8 +813,8 @@ private:
     void AddVectorKMeansTreeIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const TKMeansTreeSettings& indexSettings);
     void AddVectorKMeansTreeIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const std::vector<std::string>& dataColumns, const TKMeansTreeSettings& indexSettings);
     // fulltext
-    void AddFulltextIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const TFulltextIndexSettings& indexSettings);
-    void AddFulltextIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const std::vector<std::string>& dataColumns, const TFulltextIndexSettings& indexSettings);
+    void AddFulltextIndex(const std::string& indexName, EIndexType type, const std::vector<std::string>& indexColumns, const TFulltextIndexSettings& indexSettings);
+    void AddFulltextIndex(const std::string& indexName, EIndexType type, const std::vector<std::string>& indexColumns, const std::vector<std::string>& dataColumns, const TFulltextIndexSettings& indexSettings);
 
     // default
     void AddSecondaryIndex(const std::string& indexName, const std::vector<std::string>& indexColumns);
@@ -1066,6 +1059,8 @@ public:
     // fulltext
     TTableBuilder& AddFulltextIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const TFulltextIndexSettings& indexSettings);
     TTableBuilder& AddFulltextIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const std::vector<std::string>& dataColumns, const TFulltextIndexSettings& indexSettings);
+    TTableBuilder& AddFulltextRelevanceIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const TFulltextIndexSettings& indexSettings);
+    TTableBuilder& AddFulltextRelevanceIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const std::vector<std::string>& dataColumns, const TFulltextIndexSettings& indexSettings);
 
     // default
     TTableBuilder& AddSecondaryIndex(const std::string& indexName, const std::vector<std::string>& indexColumns, const std::vector<std::string>& dataColumns);

--- a/ydb/public/sdk/cpp/src/client/table/out.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/out.cpp
@@ -86,20 +86,6 @@ Y_DECLARE_OUT_SPEC(, NYdb::NTable::TKMeansTreeSettings, stream, value) {
         " }";
 }
 
-Y_DECLARE_OUT_SPEC(, NYdb::NTable::TFulltextIndexSettings::ELayout, stream, value) {
-    switch (value) {
-        case NYdb::NTable::TFulltextIndexSettings::ELayout::Flat:
-            stream << "flat";
-            break;
-        case NYdb::NTable::TFulltextIndexSettings::ELayout::FlatRelevance:
-            stream << "flat_relevance";
-            break;
-        case NYdb::NTable::TFulltextIndexSettings::ELayout::Unspecified:
-            stream << "unspecified";
-            break;
-    }
-}
-
 Y_DECLARE_OUT_SPEC(, NYdb::NTable::TFulltextIndexSettings::ETokenizer, stream, value) {
     switch (value) {
         case NYdb::NTable::TFulltextIndexSettings::ETokenizer::Whitespace:
@@ -164,9 +150,9 @@ Y_DECLARE_OUT_SPEC(, NYdb::NTable::TFulltextIndexSettings::TColumnAnalyzers, str
 }
 
 Y_DECLARE_OUT_SPEC(, NYdb::NTable::TFulltextIndexSettings, stream, value) {
-    stream << "{ layout: " << value.Layout.value_or(NYdb::NTable::TFulltextIndexSettings::ELayout::Unspecified);
+    stream << "{";
     if (!value.Columns.empty()) {
-        stream << ", columns: [";
+        stream << " columns: [";
         for (size_t i = 0; i < value.Columns.size(); ++i) {
             if (i > 0) stream << ", ";
             stream << value.Columns[i];

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -367,7 +367,6 @@ auto CreateHasIndexChecker(const TString& indexName, EIndexType indexType, bool 
                     Ydb::Table::FulltextIndexSettings settings;
                     std::get<TFulltextIndexSettings>(indexDesc.GetIndexSettings()).SerializeTo(settings);
                     Ydb::Table::FulltextIndexSettings expected;
-                    expected.set_layout(Ydb::Table::FulltextIndexSettings::FLAT);
                     auto column = expected.add_columns();
                     column->set_column("Value");
                     column->mutable_analyzers()->set_tokenizer(Ydb::Table::FulltextIndexSettings::STANDARD);
@@ -383,7 +382,6 @@ auto CreateHasIndexChecker(const TString& indexName, EIndexType indexType, bool 
                     Ydb::Table::FulltextIndexSettings settings;
                     std::get<TFulltextIndexSettings>(indexDesc.GetIndexSettings()).SerializeTo(settings);
                     Ydb::Table::FulltextIndexSettings expected;
-                    expected.set_layout(Ydb::Table::FulltextIndexSettings::FLAT_RELEVANCE);
                     auto column = expected.add_columns();
                     column->set_column("Value");
                     column->mutable_analyzers()->set_tokenizer(Ydb::Table::FulltextIndexSettings::STANDARD);


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Не успел до отведения ветки, это поле от пользователя уже было почти скрыто, но внутри во многих местах оставалось. В целом не хотим его уже светить, поэтому нужно поудалять из 26-1.

Исходный пр #34802.