### PR TITLE
YQ-5089: WM: Fixed query execution after tenant recreation

### DIFF
--- a/ydb/core/kqp/workload_service/kqp_workload_service.cpp
+++ b/ydb/core/kqp/workload_service/kqp_workload_service.cpp
@@ -88,6 +88,13 @@ public:
     void HandlePoison() {
         LOG_W("Got poison, stop workload service");
 
+        // Unsubscribe from all scheme cache watches
+        for (const auto& [_, databaseState] : DatabaseToState) {
+            if (databaseState.WatchKey) {
+                Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvWatchRemove(databaseState.WatchKey));
+            }
+        }
+
         for (const auto& [_, poolState] : PoolIdToState) {
             Send(poolState.PoolHandler, new TEvents::TEvPoison());
             if (poolState.NewPoolHandler) {
@@ -239,16 +246,98 @@ public:
         hFunc(TEvPrivate::TEvCpuLoadResponse, Handle);
         hFunc(TEvPrivate::TEvResignPoolHandler, Handle);
         hFunc(TEvPrivate::TEvStopPoolHandlerResponse, Handle);
+        hFunc(TEvTxProxySchemeCache::TEvWatchNotifyDeleted, Handle);
+        IgnoreFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated);
     )
 
 private:
+    ///
+    /// Fetches database metadata and subscribes to Scheme Cache Watch via db's PathId.
+    ///
     void Handle(TEvFetchDatabaseResponse::TPtr& ev) {
+        const TString& databaseId = ev->Get()->DatabaseId;
+
         if (ev->Get()->Status == Ydb::StatusIds::SUCCESS) {
-            LOG_D("Successfully fetched database info, DatabaseId: " << ev->Get()->DatabaseId << ", Serverless: " << ev->Get()->Serverless);
+            LOG_D("Successfully fetched database info, DatabaseId: " << databaseId
+                << ", Serverless: " << ev->Get()->Serverless
+                << ", PathId: " << ev->Get()->PathId
+            );
+
+            // Subscribe to scheme cache watch for this PathId
+            auto databaseState = GetOrCreateDatabaseState(databaseId);
+
+            if (!databaseState->WatchKey) {
+                databaseState->WatchKey = ++FreeWatchKey;
+                auto subscribeEvent = new TEvTxProxySchemeCache::TEvWatchPathId(
+                    ev->Get()->PathId, databaseState->WatchKey);
+
+                Send(MakeSchemeCacheID(), subscribeEvent);
+
+                LOG_D("Subscribed to scheme cache watch for database: " << databaseId
+                    << ", PathId: " << ev->Get()->PathId
+                    << ", WatchKey: " << databaseState->WatchKey
+                );
+            }
         } else {
-            LOG_D("Failed to fetch database info, DatabaseId: " << ev->Get()->DatabaseId << ", Status: " << ev->Get()->Status << ", Issues: " << ev->Get()->Issues.ToOneLineString());
+            LOG_D("Failed to fetch database info, DatabaseId: " << databaseId
+                << ", Status: " << ev->Get()->Status
+                << ", Issues: " << ev->Get()->Issues.ToOneLineString());
         }
-        GetOrCreateDatabaseState(ev->Get()->DatabaseId)->UpdateDatabaseInfo(ev);
+
+        GetOrCreateDatabaseState(databaseId)->UpdateDatabaseInfo(ev);
+    }
+
+    ///
+    /// Handles database deletion to prevent stale PathId mismatch on recreation.
+    ///
+    void Handle(TEvTxProxySchemeCache::TEvWatchNotifyDeleted::TPtr& ev) {
+        const TString& databasePath = ev->Get()->Path;
+        LOG_W("Database deleted: " << databasePath << ". Cleaning all related states.");
+
+        // Find all database states for this path
+        std::vector<TString> databaseIdsToRemove;
+        for (const auto& [databaseId, databaseState] : DatabaseToState) {
+            if (DatabaseIdToDatabase(databaseId) == databasePath) {
+                databaseIdsToRemove.push_back(databaseId);
+            }
+        }
+
+        // Cleaning all pools and database state for each matching database ID
+        for (const TString& databaseId : databaseIdsToRemove) {
+            LOG_I("Removing database state for: " << databaseId);
+            CleanupDatabasePools(databaseId);
+            DatabaseToState.erase(databaseId);
+        }
+    }
+
+    ///
+    /// Stops all active pool handlers and clears database state.
+    ///
+    void CleanupDatabasePools(const TString& databaseId) {
+        std::vector<TString> poolsToRemove;
+        const TString prefix = CanonizePath(databaseId) + "/";
+
+        for (const auto& [poolKey, poolState] : PoolIdToState) {
+            if (poolKey.StartsWith(prefix)) {
+                LOG_I("Cleaning pool handler for: " << poolKey);
+                Send(poolState.PoolHandler, new TEvPrivate::TEvStopPoolHandler(true));
+
+                if (poolState.NewPoolHandler) {
+                    Send(*poolState.NewPoolHandler, new TEvPrivate::TEvStopPoolHandler(true));
+                }
+
+                for (const auto& previousHandler : poolState.PreviousPoolHandlers) {
+                    Send(previousHandler, new TEvPrivate::TEvStopPoolHandler(true));
+                }
+
+                poolsToRemove.push_back(poolKey);
+            }
+        }
+
+        for (const auto& poolKey : poolsToRemove) {
+            Counters.ActivePools->Dec();
+            PoolIdToState.erase(poolKey);
+        }
     }
 
     void Handle(TEvPrivate::TEvFetchPoolResponse::TPtr& ev) {
@@ -257,10 +346,10 @@ private:
 
         TActorId poolHandler;
         if (ev->Get()->Status == Ydb::StatusIds::SUCCESS) {
-            LOG_D("Successfully fetched pool " << poolId << ", DatabaseId: " << databaseId);
+            LOG_D("Successfully fetched pool: " << poolId << ", DatabaseId: " << databaseId);
             poolHandler = GetOrCreatePoolState(databaseId, poolId, ev->Get()->PoolConfig)->PoolHandler;
         } else {
-            LOG_W("Failed to fetch pool " << poolId << ", DatabaseId: " << databaseId << ", status: " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+            LOG_W("Failed to fetch pool: " << poolId << ", DatabaseId: " << databaseId << ", status: " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString());
         }
 
         GetOrCreateDatabaseState(databaseId)->UpdatePoolInfo(ev, poolHandler);
@@ -562,9 +651,11 @@ private:
 
     TDatabaseState* GetOrCreateDatabaseState(TString databaseId) {
         auto databaseIt = DatabaseToState.find(databaseId);
+
         if (databaseIt != DatabaseToState.end()) {
             return &databaseIt->second;
         }
+
         LOG_I("Creating new database state for id " << databaseId);
         return &DatabaseToState.insert({databaseId, TDatabaseState{.SelfId = SelfId(), .EnabledResourcePoolsOnServerless = EnabledResourcePoolsOnServerless, .WorkloadManagerConfig = WorkloadManagerConfig}}).first->second;
     }
@@ -617,6 +708,7 @@ private:
     NKikimrConfig::TWorkloadManagerConfig WorkloadManagerConfig;
     ETablesCreationStatus TablesCreationStatus = ETablesCreationStatus::Cleanup;
     std::unordered_set<TString> PendingHandlers;  // DatabaseID/PoolID
+    ui32 FreeWatchKey = 0;
 
     std::unordered_map<TString, TDatabaseState> DatabaseToState;  // DatabaseID to state
     std::unordered_map<TString, TPoolState> PoolIdToState;  // DatabaseID/PoolID to state

--- a/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
+++ b/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
@@ -27,6 +27,7 @@ struct TDatabaseState {
     bool HasDefaultPool = false;
     bool Serverless = false;
     bool DatabaseUnsupported = false;
+    ui32 WatchKey = 0;
 
     TInstant LastUpdateTime = TInstant::Zero();
 

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -298,7 +298,7 @@ private:
         featureFlags.SetEnableExternalDataSourcesOnServerless(Settings_.EnableExternalDataSourcesOnServerless_);
         featureFlags.SetEnableExternalDataSources(true);
         featureFlags.SetEnableResourcePoolsCounters(true);
-        featureFlags.SetEnableStreamingQueries(true);
+        featureFlags.SetEnableStreamingQueries(Settings_.EnableStreamingQueries_);
         featureFlags.SetEnableResourcePoolsScheduler(Settings_.EnableResourcePoolsScheduler_);
 
         auto& queryServiceConfig = *appConfig.MutableQueryServiceConfig();
@@ -399,6 +399,10 @@ private:
         ui32 grpcPort = PortManager_.GetPort();
         TServerSettings serverSettings = GetServerSettings(grpcPort);
 
+        if (SettingsTweakFnc_) {
+            SettingsTweakFnc_(serverSettings);
+        }
+
         Server_ = MakeIntrusive<TServer>(serverSettings);
         Server_->EnableGRpc(grpcPort);
         GetRuntime()->SetDispatchTimeout(FUTURE_WAIT_TIMEOUT);
@@ -431,8 +435,10 @@ private:
     }
 
 public:
-    explicit TWorkloadServiceYdbSetup(const TYdbSetupSettings& settings)
+    explicit TWorkloadServiceYdbSetup(const TYdbSetupSettings& settings,
+        std::function<void(Tests::TServerSettings&)> fnc = nullptr)
         : Settings_(settings)
+        , SettingsTweakFnc_(fnc)
     {
         if (Settings_.WorkSafeWithGlobalObjects_) {
             GetGlobalObjectHolder();
@@ -440,7 +446,10 @@ public:
 
         EnableYDBBacktraceFormat();
         InitializeServer();
-        CreateSamplePool();
+
+        if (Settings_.CreateSamplePool_) {
+            CreateSamplePool();
+        }
     }
 
     virtual ~TWorkloadServiceYdbSetup() {
@@ -566,21 +575,13 @@ public:
     }
 
     // Pools actions
-    void CreateResourcePool(const TString& poolId, const NResourcePool::TPoolSettings& settings) const override {
-        auto edgeActor = GetRuntime()->AllocateEdgeActor();
-
-        GetRuntime()->Register(CreatePoolCreatorActor(edgeActor, Settings_.DomainName_, poolId, settings, nullptr, {}));
-        auto response = GetRuntime()->GrabEdgeEvent<TEvPrivate::TEvCreatePoolResponse>(edgeActor, FUTURE_WAIT_TIMEOUT);
-        UNIT_ASSERT_VALUES_EQUAL_C(response->Get()->Status, Ydb::StatusIds::SUCCESS, response->Get()->Issues.ToOneLineString());
-    }
-
-    void CreateSamplePoolOn(const TString& databaseId) const override {
+    void CreateResourcePool(const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& settings) const override {
         auto edgeActor = GetRuntime()->AllocateEdgeActor();
         auto actor = CreatePoolCreatorActor(
             edgeActor,
             databaseId,
-            Settings_.PoolId_,
-            Settings_.GetDefaultPoolSettings(),
+            poolId,
+            settings,
             nullptr,
             {}
         );
@@ -588,6 +589,14 @@ public:
         GetRuntime()->Register(actor);
         auto response = GetRuntime()->GrabEdgeEvent<TEvPrivate::TEvCreatePoolResponse>(edgeActor, FUTURE_WAIT_TIMEOUT);
         UNIT_ASSERT_VALUES_EQUAL_C(response->Get()->Status, Ydb::StatusIds::SUCCESS, response->Get()->Issues.ToOneLineString());
+    }
+
+    void CreateResourcePool(const TString& poolId, const NResourcePool::TPoolSettings& settings) const override {
+        CreateResourcePool(Settings_.DomainName_, poolId, settings);
+    }
+
+    void CreateSamplePoolOn(const TString& databaseId) const override {
+        CreateResourcePool(databaseId, Settings_.PoolId_, Settings_.GetDefaultPoolSettings());
     }
 
     TPoolStateDescription GetPoolDescription(TDuration leaseDuration = FUTURE_WAIT_TIMEOUT, const TString& poolId = "") const override {
@@ -689,6 +698,26 @@ public:
         return sharedInfo;
     }
 
+    void CreateDedicatedTenant(const TString& path) override {
+        Ydb::Cms::CreateDatabaseRequest request;
+        request.set_path(path);
+
+        auto storage = request.mutable_resources()->add_storage_units();
+        storage->set_unit_kind("test-recreated-db");
+        storage->set_count(1);
+
+        Tenants_->CreateTenant(std::move(request));
+
+        auto tenants = Tenants_->List(path);
+        if (!tenants.empty()) {
+            Server_->EnableGRpc(PortManager_.GetPort(), tenants[0], path);
+        }
+    }
+
+    void DropDedicatedTenant(const TString& path) override {
+        Tenants_->RemoveTenant(path);
+    }
+
 private:
     void SetupDefaultSettings(TQueryRunnerSettings& settings, bool asyncExecution) const {
         UNIT_ASSERT_C(!settings.HangUpDuringExecution_ || asyncExecution, "Hang up during execution is not supported for sync queries");
@@ -748,6 +777,7 @@ private:
 
 private:
     const TYdbSetupSettings Settings_;
+    std::function<void(TServerSettings&)> SettingsTweakFnc_;
 
     TPortManager PortManager_;
     TServer::TPtr Server_;
@@ -812,8 +842,8 @@ NResourcePool::TPoolSettings TYdbSetupSettings::GetDefaultPoolSettings() const {
     return poolConfig;
 }
 
-TIntrusivePtr<IYdbSetup> TYdbSetupSettings::Create() const {
-    return MakeIntrusive<TWorkloadServiceYdbSetup>(*this);
+TIntrusivePtr<IYdbSetup> TYdbSetupSettings::Create(std::function<void(Tests::TServerSettings&)> fnc) const {
+    return MakeIntrusive<TWorkloadServiceYdbSetup>(*this, fnc);
 }
 
 TString TYdbSetupSettings::GetDedicatedTenantName() const {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -698,12 +698,12 @@ public:
         return sharedInfo;
     }
 
-    void CreateDedicatedTenant(const TString& path) override {
+    void CreateDedicatedTenant(const TString& path, const TString& unitKind) override {
         Ydb::Cms::CreateDatabaseRequest request;
         request.set_path(path);
 
         auto storage = request.mutable_resources()->add_storage_units();
-        storage->set_unit_kind("test-recreated-db");
+        storage->set_unit_kind(unitKind);
         storage->set_count(1);
 
         Tenants_->CreateTenant(std::move(request));

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -4,6 +4,7 @@
 
 #include <ydb/core/testlib/actors/test_runtime.h>
 
+#include <ydb/core/testlib/test_client.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 
 #include <ydb/public/lib/yson_value/ydb_yson_value.h>
@@ -71,11 +72,13 @@ struct TYdbSetupSettings {
     FLUENT_SETTING_DEFAULT(ui32, NodeCount, 1);
     FLUENT_SETTING_DEFAULT(TString, DomainName, "Root");
     FLUENT_SETTING_DEFAULT(bool, CreateSampleTenants, false);
+    FLUENT_SETTING_DEFAULT(bool, CreateSamplePool, true);
     FLUENT_SETTING_DEFAULT(bool, EnableResourcePools, true);
     FLUENT_SETTING_DEFAULT(bool, EnableResourcePoolsScheduler, true);
     FLUENT_SETTING_DEFAULT(bool, EnableResourcePoolsOnServerless, false);
     FLUENT_SETTING_DEFAULT(bool, EnableMetadataObjectsOnServerless, true);
     FLUENT_SETTING_DEFAULT(bool, EnableExternalDataSourcesOnServerless, true);
+    FLUENT_SETTING_DEFAULT(bool, EnableStreamingQueries, true);
     FLUENT_SETTING(NKikimrConfig::TWorkloadManagerConfig, WorkloadManagerConfig);
     FLUENT_SETTING_DEFAULT(i32, DedicatedDiskQuota, -1);
 
@@ -90,7 +93,7 @@ struct TYdbSetupSettings {
     FLUENT_SETTING_DEFAULT(bool, WorkSafeWithGlobalObjects, true);
 
     NResourcePool::TPoolSettings GetDefaultPoolSettings() const;
-    TIntrusivePtr<IYdbSetup> Create() const;
+    TIntrusivePtr<IYdbSetup> Create(std::function<void(Tests::TServerSettings&)> fnc = nullptr) const;
 
     TString GetDedicatedTenantName() const;
     TString GetSharedTenantName() const;
@@ -121,6 +124,7 @@ public:
     // Pools actions
     virtual void CreateResourcePool(const TString& poolId, const NResourcePool::TPoolSettings& settings) const = 0;
     virtual void CreateSamplePoolOn(const TString& databaseId) const = 0;
+    virtual void CreateResourcePool(const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& settings) const = 0;
     virtual TPoolStateDescription GetPoolDescription(TDuration leaseDuration = FUTURE_WAIT_TIMEOUT, const TString& poolId = "") const = 0;
     virtual void WaitPoolState(const TPoolStateDescription& state, const TString& poolId = "") const = 0;
     virtual void WaitPoolHandlersCount(i64 finalCount, std::optional<i64> initialCount = std::nullopt, TDuration timeout = FUTURE_WAIT_TIMEOUT) const = 0;
@@ -133,6 +137,10 @@ public:
     virtual TTestActorRuntime* GetRuntime() const = 0;
     virtual const TYdbSetupSettings& GetSettings() const = 0;
     static void WaitFor(TDuration timeout, TString description, std::function<bool(TString&)> callback);
+
+    // Db management
+    virtual void CreateDedicatedTenant(const TString& path) = 0;
+    virtual void DropDedicatedTenant(const TString& path) = 0;
 
     struct TTenantInfo {
         TLocalPathId PathId;

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -139,7 +139,7 @@ public:
     static void WaitFor(TDuration timeout, TString description, std::function<bool(TString&)> callback);
 
     // Db management
-    virtual void CreateDedicatedTenant(const TString& path) = 0;
+    virtual void CreateDedicatedTenant(const TString& path, const TString& unitKind) = 0;
     virtual void DropDedicatedTenant(const TString& path) = 0;
 
     struct TTenantInfo {

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -385,6 +385,60 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
     Y_UNIT_TEST(TestDiskIsFullRunOverQueryLimit) {
         TestWhenDiskSpaceIsExhausted(1, "delayed_requests");
     }
+
+    // Verifies that resource pools function correctly after tenant recreation.
+    // Even if the DatabaseId (path) remains the same, a recreated tenant receives
+    // a new internal PathId. Crucially, all previous resource pools are dropped
+    // along with the old tenant and are not present in the fresh instance.
+    // The workload service must detect this lifecycle change, invalidate any
+    // cached state tied to the old PathId, and re-resolve metadata to avoid
+    // "PathId mismatch" or "Pool not found" errors in the new database.
+    Y_UNIT_TEST(TestResourcePoolAfterTenantRecreation) {
+        auto tweakFnc = [](Tests::TServerSettings& serverSettings) -> void {
+            serverSettings.SetDynamicNodeCount(1).AddStoragePool(
+                "test-recreated-db",
+                "/Root/test-recreated-db:test-recreated-db"
+            );
+        };
+
+        auto ydb = TYdbSetupSettings()
+            .NodeCount(1)
+            .CreateSampleTenants(false)
+            .EnableResourcePools(true)
+            // turn off to reduce "noise" in a log
+            .EnableStreamingQueries(false)
+            .CreateSamplePool(false)
+            .Create(tweakFnc);
+
+        auto dbName = "/Root/test-recreated-db";
+        auto myPoolId = "my_pool";
+
+        auto defPool = TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID).Database(dbName);
+        auto myPool = TQueryRunnerSettings().PoolId(myPoolId).Database(dbName);
+
+        Cerr << "------ Creating Tenant" << Endl;
+        ydb->CreateDedicatedTenant(dbName);
+        ydb->CreateResourcePool(dbName, myPoolId, NResourcePool::TPoolSettings());
+
+        TSampleQueries::TSelect42::CheckResult(
+            ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+
+        TSampleQueries::TSelect42::CheckResult(
+            ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, defPool));
+
+        Cerr << "------ Droping Tenant" << Endl;
+        ydb->DropDedicatedTenant(dbName);
+
+        Cerr << "------ Creating Tenant" << Endl;
+        ydb->CreateDedicatedTenant(dbName);
+
+        // The custom pool is still alive, is it a bug or feature?
+        TSampleQueries::TSelect42::CheckResult(
+            ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, myPool));
+
+        TSampleQueries::TSelect42::CheckResult(
+            ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, defPool));
+    }
 }
 
 Y_UNIT_TEST_SUITE(KqpWorkloadServiceDistributed) {

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -386,18 +386,24 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
         TestWhenDiskSpaceIsExhausted(1, "delayed_requests");
     }
 
+    //
     // Verifies that resource pools function correctly after tenant recreation.
     // Even if the DatabaseId (path) remains the same, a recreated tenant receives
-    // a new internal PathId. Crucially, all previous resource pools are dropped
-    // along with the old tenant and are not present in the fresh instance.
+    // a new internal PathId. The workload service uses DatabaseId as a key for
+    // a cache.
+    //
     // The workload service must detect this lifecycle change, invalidate any
-    // cached state tied to the old PathId, and re-resolve metadata to avoid
-    // "PathId mismatch" or "Pool not found" errors in the new database.
+    // cached state tied to the same DatabaseId but a different PathId,
+    // and re-resolve metadata to avoid "PathId mismatch" or "Pool not found"
+    // errors in the new database.
+    //
     Y_UNIT_TEST(TestResourcePoolAfterTenantRecreation) {
-        auto tweakFnc = [](Tests::TServerSettings& serverSettings) -> void {
+        auto unitKind = "test-recreated-db";
+        auto dbName = "/Root/test-recreated-db";
+        auto tweakFnc = [&](Tests::TServerSettings& serverSettings) -> void {
             serverSettings.SetDynamicNodeCount(1).AddStoragePool(
-                "test-recreated-db",
-                "/Root/test-recreated-db:test-recreated-db"
+                unitKind,
+                TStringBuilder() << dbName << ":" << unitKind
             );
         };
 
@@ -410,14 +416,12 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
             .CreateSamplePool(false)
             .Create(tweakFnc);
 
-        auto dbName = "/Root/test-recreated-db";
         auto myPoolId = "my_pool";
-
         auto defPool = TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID).Database(dbName);
         auto myPool = TQueryRunnerSettings().PoolId(myPoolId).Database(dbName);
 
         Cerr << "------ Creating Tenant" << Endl;
-        ydb->CreateDedicatedTenant(dbName);
+        ydb->CreateDedicatedTenant(dbName, unitKind);
         ydb->CreateResourcePool(dbName, myPoolId, NResourcePool::TPoolSettings());
 
         TSampleQueries::TSelect42::CheckResult(
@@ -430,7 +434,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
         ydb->DropDedicatedTenant(dbName);
 
         Cerr << "------ Creating Tenant" << Endl;
-        ydb->CreateDedicatedTenant(dbName);
+        ydb->CreateDedicatedTenant(dbName, unitKind);
 
         // The custom pool is still alive, is it a bug or feature?
         TSampleQueries::TSelect42::CheckResult(

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -3551,6 +3551,75 @@ namespace Tests {
         ythrow yexception() << "Waiting tenant status RUNNING timeout. Spent time " << TInstant::Now() - start << " exceeds limit " << timeout << ". Last tenant description:\n" << getTenantResult.DebugString();
     }
 
+    void TTenants::RemoveTenant(Ydb::Cms::RemoveDatabaseRequest request, TDuration timeout) {
+        const TString path = request.path();
+        auto& runtime = *Server->GetRuntime();
+
+        // Check if serverless
+        bool isServerless = false;
+        {
+            auto getStatusRequest = std::make_unique<NConsole::TEvConsole::TEvGetTenantStatusRequest>();
+            getStatusRequest->Record.MutableRequest()->set_path(path);
+            const TActorId edgeActor = runtime.AllocateEdgeActor();
+
+            runtime.SendToPipe(MakeConsoleID(), edgeActor, getStatusRequest.release(), 0, GetPipeConfigWithRetries());
+            auto response = runtime.GrabEdgeEvent<NConsole::TEvConsole::TEvGetTenantStatusResponse>(edgeActor, timeout);
+
+            if (response && response->Get()->Record.GetResponse().operation().status() == Ydb::StatusIds::SUCCESS) {
+                Ydb::Cms::GetDatabaseStatusResult status;
+                response->Get()->Record.GetResponse().operation().result().UnpackTo(&status);
+                // Serverless if serverless_resources is set
+                isServerless = status.has_serverless_resources();
+            }
+        }
+
+        // Stop dedicated nodes
+        if (!isServerless) {
+            Stop(path);
+        }
+
+        // Remove
+        const auto result = NKikimr::NRpcService::DoLocalRpc<
+            NKikimr::NGRpcService::TGrpcRequestOperationCall<Ydb::Cms::RemoveDatabaseRequest, Ydb::Cms::RemoveDatabaseResponse>
+        >(std::move(request), "", "", runtime.GetActorSystem(0), true).ExtractValueSync();
+
+        if (result.operation().status() != Ydb::StatusIds::SUCCESS) {
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(result.operation().issues(), issues);
+            ythrow yexception() << "Failed to remove tenant " << path
+                << ", status: " << result.operation().status()
+                << ", reason:\n" << issues.ToString();
+        }
+
+        // Wait for NOT_FOUND
+        const TActorId edgeActor = runtime.AllocateEdgeActor();
+        const TInstant start = TInstant::Now();
+
+        while (TInstant::Now() - start <= timeout) {
+            auto getStatusRequest = std::make_unique<NConsole::TEvConsole::TEvGetTenantStatusRequest>();
+            getStatusRequest->Record.MutableRequest()->set_path(path);
+
+            runtime.SendToPipe(MakeConsoleID(), edgeActor, getStatusRequest.release(), 0, GetPipeConfigWithRetries());
+
+            auto response = runtime.GrabEdgeEvent<NConsole::TEvConsole::TEvGetTenantStatusResponse>(edgeActor, timeout);
+            if (response) {
+                auto status = response->Get()->Record.GetResponse().operation().status();
+                if (status == Ydb::StatusIds::NOT_FOUND) {
+                    return;
+                }
+            }
+            Sleep(TDuration::MilliSeconds(100));
+        }
+
+        ythrow yexception() << "Waiting tenant removal timeout for " << path;
+    }
+
+    void TTenants::RemoveTenant(const TString& path, TDuration timeout) {
+        Ydb::Cms::RemoveDatabaseRequest request;
+        request.set_path(path);
+        RemoveTenant(std::move(request), timeout);
+    }
+
     TVector<ui32> &TTenants::Nodes(const TString &name) {
         return Tenants[name];
     }

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -855,6 +855,8 @@ namespace Tests {
         ui32 Capacity() const;
 
         void CreateTenant(Ydb::Cms::CreateDatabaseRequest request, ui32 nodes = 1, TDuration timeout = TDuration::Seconds(30), bool acceptAlreadyExist = false);
+        void RemoveTenant(Ydb::Cms::RemoveDatabaseRequest request, TDuration timeout = TDuration::Seconds(30));
+        void RemoveTenant(const TString& path, TDuration timeout = TDuration::Seconds(30));
 
     private:
         TVector<ui32>& Nodes(const TString &name);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed query execution after tenant recreation (#YQ-5089)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

In YDB, when a tenant is recreated, it is assigned a new PathId (subdomain identifier). However, the Workload Service used the database's Path as the unique Database ID for caching its internal state and pool metadata.
Because the Path (Database ID) remained identical after recreation, the Workload Service continued to use stale data from its cache, which was tied to the previous PathId. The service had no mechanism to detect that the underlying database object had been replaced, leading to permanent query failures.

Closes #35090
