### PR TITLE
Used default EnableRealSystemViewPaths flag value in tests

### DIFF
--- a/ydb/core/sys_view/ut_auth.cpp
+++ b/ydb/core/sys_view/ut_auth.cpp
@@ -1423,8 +1423,8 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
         }
     }
 
-    Y_UNIT_TEST_TWIN(AuthOwners, EnableRealSystemViewPaths) {
-        TTestEnv env({ .EnableRealSystemViewPaths = EnableRealSystemViewPaths });
+    Y_UNIT_TEST(AuthOwners) {
+        TTestEnv env;
         SetupAuthEnvironment(env);
 
         {
@@ -1466,65 +1466,51 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
                 FROM `/Root/.sys/auth_owners`
             )").GetValueSync();
 
-            TString expectedYson;
-            if (EnableRealSystemViewPaths) {
-                expectedYson = R"([
-                    [["/Root"];["root@builtin"]];
-                    [["/Root/.metadata"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager/pools"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["metadata@system"]];
-                    [["/Root/.sys"];["metadata@system"]];[["/Root/.sys/auth_effective_permissions"];["metadata@system"]];
-                    [["/Root/.sys/auth_group_members"];["metadata@system"]];
-                    [["/Root/.sys/auth_groups"];["metadata@system"]];
-                    [["/Root/.sys/auth_owners"];["metadata@system"]];
-                    [["/Root/.sys/auth_permissions"];["metadata@system"]];
-                    [["/Root/.sys/auth_users"];["metadata@system"]];
-                    [["/Root/.sys/compile_cache_queries"];["metadata@system"]];
-                    [["/Root/.sys/ds_groups"];["metadata@system"]];
-                    [["/Root/.sys/ds_pdisks"];["metadata@system"]];
-                    [["/Root/.sys/ds_storage_pools"];["metadata@system"]];
-                    [["/Root/.sys/ds_storage_stats"];["metadata@system"]];
-                    [["/Root/.sys/ds_vslots"];["metadata@system"]];
-                    [["/Root/.sys/hive_tablets"];["metadata@system"]];
-                    [["/Root/.sys/nodes"];["metadata@system"]];
-                    [["/Root/.sys/partition_stats"];["metadata@system"]];
-                    [["/Root/.sys/pg_class"];["metadata@system"]];
-                    [["/Root/.sys/pg_tables"];["metadata@system"]];
-                    [["/Root/.sys/query_metrics_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/query_sessions"];["metadata@system"]];
-                    [["/Root/.sys/resource_pool_classifiers"];["metadata@system"]];
-                    [["/Root/.sys/resource_pools"];["metadata@system"]];
-                    [["/Root/.sys/streaming_queries"];["metadata@system"]];
-                    [["/Root/.sys/tables"];["metadata@system"]];
-                    [["/Root/.sys/top_partitions_by_tli_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_partitions_by_tli_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_partitions_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_partitions_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_cpu_time_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_cpu_time_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_duration_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_duration_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_read_bytes_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_read_bytes_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_request_units_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_request_units_one_minute"];["metadata@system"]];
-                    [["/Root/Dir1"];["user1"]];
-                    [["/Root/Dir1/SubDir1"];["user1"]];
-                    [["/Root/Table0"];["root@builtin"]];
-                ])";
-            } else {
-                expectedYson = R"([
-                    [["/Root"];["root@builtin"]];
-                    [["/Root/.metadata"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager/pools"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["metadata@system"]];
-                    [["/Root/Dir1"];["user1"]];
-                    [["/Root/Dir1/SubDir1"];["user1"]];
-                    [["/Root/Table0"];["root@builtin"]];
-                ])";
-            }
+            TString expectedYson = R"([
+                [["/Root"];["root@builtin"]];
+                [["/Root/.metadata"];["metadata@system"]];
+                [["/Root/.metadata/workload_manager"];["metadata@system"]];
+                [["/Root/.metadata/workload_manager/pools"];["metadata@system"]];
+                [["/Root/.metadata/workload_manager/pools/default"];["metadata@system"]];
+                [["/Root/.sys"];["metadata@system"]];[["/Root/.sys/auth_effective_permissions"];["metadata@system"]];
+                [["/Root/.sys/auth_group_members"];["metadata@system"]];
+                [["/Root/.sys/auth_groups"];["metadata@system"]];
+                [["/Root/.sys/auth_owners"];["metadata@system"]];
+                [["/Root/.sys/auth_permissions"];["metadata@system"]];
+                [["/Root/.sys/auth_users"];["metadata@system"]];
+                [["/Root/.sys/compile_cache_queries"];["metadata@system"]];
+                [["/Root/.sys/ds_groups"];["metadata@system"]];
+                [["/Root/.sys/ds_pdisks"];["metadata@system"]];
+                [["/Root/.sys/ds_storage_pools"];["metadata@system"]];
+                [["/Root/.sys/ds_storage_stats"];["metadata@system"]];
+                [["/Root/.sys/ds_vslots"];["metadata@system"]];
+                [["/Root/.sys/hive_tablets"];["metadata@system"]];
+                [["/Root/.sys/nodes"];["metadata@system"]];
+                [["/Root/.sys/partition_stats"];["metadata@system"]];
+                [["/Root/.sys/pg_class"];["metadata@system"]];
+                [["/Root/.sys/pg_tables"];["metadata@system"]];
+                [["/Root/.sys/query_metrics_one_minute"];["metadata@system"]];
+                [["/Root/.sys/query_sessions"];["metadata@system"]];
+                [["/Root/.sys/resource_pool_classifiers"];["metadata@system"]];
+                [["/Root/.sys/resource_pools"];["metadata@system"]];
+                [["/Root/.sys/streaming_queries"];["metadata@system"]];
+                [["/Root/.sys/tables"];["metadata@system"]];
+                [["/Root/.sys/top_partitions_by_tli_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_partitions_by_tli_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_partitions_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_partitions_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_cpu_time_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_cpu_time_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_duration_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_duration_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_read_bytes_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_read_bytes_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_request_units_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_request_units_one_minute"];["metadata@system"]];
+                [["/Root/Dir1"];["user1"]];
+                [["/Root/Dir1/SubDir1"];["user1"]];
+                [["/Root/Table0"];["root@builtin"]];
+            ])";
 
             NKqp::CompareYson(expectedYson, NKqp::StreamResultToYson(it));
         }
@@ -1539,59 +1525,45 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
                 FROM `/Root/Tenant1/.sys/auth_owners`
             )").GetValueSync();
 
-            TString expectedYson;
-            if (EnableRealSystemViewPaths) {
-                expectedYson = R"([
-                    [["/Root/Tenant1"];["root@builtin"]];
-                    [["/Root/Tenant1/.metadata"];["metadata@system"]];
-                    [["/Root/Tenant1/.metadata/workload_manager"];["metadata@system"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools"];["metadata@system"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/auth_effective_permissions"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/auth_group_members"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/auth_groups"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/auth_owners"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/auth_permissions"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/auth_users"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/compile_cache_queries"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/nodes"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/partition_stats"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/pg_class"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/pg_tables"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/query_metrics_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/query_sessions"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/resource_pool_classifiers"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/resource_pools"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/streaming_queries"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/tables"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_partitions_by_tli_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_partitions_by_tli_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_partitions_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_partitions_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_cpu_time_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_cpu_time_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_duration_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_duration_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_read_bytes_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_read_bytes_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_request_units_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_request_units_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant1/Dir2"];["user2"]];[["/Root/Tenant1/Dir2/SubDir2"];["user2"]];
-                    [["/Root/Tenant1/Table1"];["root@builtin"]];
-                ])";
-            } else {
-                expectedYson = R"([
-                    [["/Root/Tenant1"];["root@builtin"]];
-                    [["/Root/Tenant1/.metadata"];["metadata@system"]];
-                    [["/Root/Tenant1/.metadata/workload_manager"];["metadata@system"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools"];["metadata@system"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["metadata@system"]];
-                    [["/Root/Tenant1/Dir2"];["user2"]];
-                    [["/Root/Tenant1/Dir2/SubDir2"];["user2"]];
-                    [["/Root/Tenant1/Table1"];["root@builtin"]];
-                ])";
-            }
+            TString expectedYson = R"([
+                [["/Root/Tenant1"];["root@builtin"]];
+                [["/Root/Tenant1/.metadata"];["metadata@system"]];
+                [["/Root/Tenant1/.metadata/workload_manager"];["metadata@system"]];
+                [["/Root/Tenant1/.metadata/workload_manager/pools"];["metadata@system"]];
+                [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["metadata@system"]];
+                [["/Root/Tenant1/.sys"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/auth_effective_permissions"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/auth_group_members"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/auth_groups"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/auth_owners"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/auth_permissions"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/auth_users"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/compile_cache_queries"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/nodes"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/partition_stats"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/pg_class"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/pg_tables"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/query_metrics_one_minute"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/query_sessions"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/resource_pool_classifiers"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/resource_pools"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/streaming_queries"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/tables"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_partitions_by_tli_one_hour"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_partitions_by_tli_one_minute"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_partitions_one_hour"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_partitions_one_minute"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_queries_by_cpu_time_one_hour"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_queries_by_cpu_time_one_minute"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_queries_by_duration_one_hour"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_queries_by_duration_one_minute"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_queries_by_read_bytes_one_hour"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_queries_by_read_bytes_one_minute"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_queries_by_request_units_one_hour"];["metadata@system"]];
+                [["/Root/Tenant1/.sys/top_queries_by_request_units_one_minute"];["metadata@system"]];
+                [["/Root/Tenant1/Dir2"];["user2"]];[["/Root/Tenant1/Dir2/SubDir2"];["user2"]];
+                [["/Root/Tenant1/Table1"];["root@builtin"]];
+            ])";
 
             NKqp::CompareYson(expectedYson, NKqp::StreamResultToYson(it));
         }
@@ -1606,68 +1578,50 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
                 FROM `/Root/Tenant2/.sys/auth_owners`
             )").GetValueSync();
 
-            TString expectedYson;
-            if (EnableRealSystemViewPaths) {
-                expectedYson = R"([
-                    [["/Root/Tenant2"];["root@builtin"]];
-                    [["/Root/Tenant2/.metadata"];["metadata@system"]];
-                    [["/Root/Tenant2/.metadata/workload_manager"];["metadata@system"]];
-                    [["/Root/Tenant2/.metadata/workload_manager/pools"];["metadata@system"]];
-                    [["/Root/Tenant2/.metadata/workload_manager/pools/default"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/auth_effective_permissions"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/auth_group_members"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/auth_groups"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/auth_owners"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/auth_permissions"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/auth_users"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/compile_cache_queries"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/nodes"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/partition_stats"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/pg_class"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/pg_tables"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/query_metrics_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/query_sessions"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/resource_pool_classifiers"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/resource_pools"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/streaming_queries"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/tables"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_partitions_by_tli_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_partitions_by_tli_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_partitions_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_partitions_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_queries_by_cpu_time_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_queries_by_cpu_time_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_queries_by_duration_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_queries_by_duration_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_queries_by_read_bytes_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_queries_by_read_bytes_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_queries_by_request_units_one_hour"];["metadata@system"]];
-                    [["/Root/Tenant2/.sys/top_queries_by_request_units_one_minute"];["metadata@system"]];
-                    [["/Root/Tenant2/Dir3"];["user3"]];
-                    [["/Root/Tenant2/Dir3/SubDir33"];["group1"]];
-                    [["/Root/Tenant2/Dir3/SubDir34"];["root@builtin"]];
-                    [["/Root/Tenant2/Dir4"];["user4"]];
-                    [["/Root/Tenant2/Dir4/SubDir45"];["root@builtin"]];
-                    [["/Root/Tenant2/Dir4/SubDir46"];["user4"]];
-                    [["/Root/Tenant2/Table2"];["root@builtin"]];
-                ])";
-            } else {
-                expectedYson = R"([
-                    [["/Root/Tenant2"];["root@builtin"]];
-                    [["/Root/Tenant2/.metadata"];["metadata@system"]];
-                    [["/Root/Tenant2/.metadata/workload_manager"];["metadata@system"]];
-                    [["/Root/Tenant2/.metadata/workload_manager/pools"];["metadata@system"]];
-                    [["/Root/Tenant2/.metadata/workload_manager/pools/default"];["metadata@system"]];
-                    [["/Root/Tenant2/Dir3"];["user3"]];
-                    [["/Root/Tenant2/Dir3/SubDir33"];["group1"]];
-                    [["/Root/Tenant2/Dir3/SubDir34"];["root@builtin"]];
-                    [["/Root/Tenant2/Dir4"];["user4"]];
-                    [["/Root/Tenant2/Dir4/SubDir45"];["root@builtin"]];
-                    [["/Root/Tenant2/Dir4/SubDir46"];["user4"]];
-                    [["/Root/Tenant2/Table2"];["root@builtin"]];
-                ])";
-            }
+            TString expectedYson = R"([
+                [["/Root/Tenant2"];["root@builtin"]];
+                [["/Root/Tenant2/.metadata"];["metadata@system"]];
+                [["/Root/Tenant2/.metadata/workload_manager"];["metadata@system"]];
+                [["/Root/Tenant2/.metadata/workload_manager/pools"];["metadata@system"]];
+                [["/Root/Tenant2/.metadata/workload_manager/pools/default"];["metadata@system"]];
+                [["/Root/Tenant2/.sys"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/auth_effective_permissions"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/auth_group_members"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/auth_groups"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/auth_owners"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/auth_permissions"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/auth_users"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/compile_cache_queries"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/nodes"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/partition_stats"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/pg_class"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/pg_tables"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/query_metrics_one_minute"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/query_sessions"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/resource_pool_classifiers"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/resource_pools"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/streaming_queries"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/tables"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_partitions_by_tli_one_hour"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_partitions_by_tli_one_minute"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_partitions_one_hour"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_partitions_one_minute"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_queries_by_cpu_time_one_hour"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_queries_by_cpu_time_one_minute"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_queries_by_duration_one_hour"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_queries_by_duration_one_minute"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_queries_by_read_bytes_one_hour"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_queries_by_read_bytes_one_minute"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_queries_by_request_units_one_hour"];["metadata@system"]];
+                [["/Root/Tenant2/.sys/top_queries_by_request_units_one_minute"];["metadata@system"]];
+                [["/Root/Tenant2/Dir3"];["user3"]];
+                [["/Root/Tenant2/Dir3/SubDir33"];["group1"]];
+                [["/Root/Tenant2/Dir3/SubDir34"];["root@builtin"]];
+                [["/Root/Tenant2/Dir4"];["user4"]];
+                [["/Root/Tenant2/Dir4/SubDir45"];["root@builtin"]];
+                [["/Root/Tenant2/Dir4/SubDir46"];["user4"]];
+                [["/Root/Tenant2/Table2"];["root@builtin"]];
+            ])";
 
             NKqp::CompareYson(expectedYson, NKqp::StreamResultToYson(it));
         }
@@ -1846,8 +1800,8 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
         NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
     }
 
-    Y_UNIT_TEST_TWIN(AuthOwners_TableRange, EnableRealSystemViewPaths) {
-        TTestEnv env({ .EnableRealSystemViewPaths = EnableRealSystemViewPaths });
+    Y_UNIT_TEST(AuthOwners_TableRange) {
+        TTestEnv env;
         SetupAuthEnvironment(env);
 
         {
@@ -1890,93 +1844,65 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
                 FROM `/Root/.sys/auth_owners`
             )").GetValueSync();
 
-            TString expectedYson;
-            if (EnableRealSystemViewPaths) {
-                expectedYson = R"([
-                    [["/Root"];["root@builtin"]];
-                    [["/Root/.metadata"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager/pools"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["metadata@system"]];
-                    [["/Root/.sys"];["metadata@system"]];[["/Root/.sys/auth_effective_permissions"];["metadata@system"]];
-                    [["/Root/.sys/auth_group_members"];["metadata@system"]];
-                    [["/Root/.sys/auth_groups"];["metadata@system"]];
-                    [["/Root/.sys/auth_owners"];["metadata@system"]];
-                    [["/Root/.sys/auth_permissions"];["metadata@system"]];
-                    [["/Root/.sys/auth_users"];["metadata@system"]];
-                    [["/Root/.sys/compile_cache_queries"];["metadata@system"]];
-                    [["/Root/.sys/ds_groups"];["metadata@system"]];
-                    [["/Root/.sys/ds_pdisks"];["metadata@system"]];
-                    [["/Root/.sys/ds_storage_pools"];["metadata@system"]];
-                    [["/Root/.sys/ds_storage_stats"];["metadata@system"]];
-                    [["/Root/.sys/ds_vslots"];["metadata@system"]];
-                    [["/Root/.sys/hive_tablets"];["metadata@system"]];
-                    [["/Root/.sys/nodes"];["metadata@system"]];
-                    [["/Root/.sys/partition_stats"];["metadata@system"]];
-                    [["/Root/.sys/pg_class"];["metadata@system"]];
-                    [["/Root/.sys/pg_tables"];["metadata@system"]];
-                    [["/Root/.sys/query_metrics_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/query_sessions"];["metadata@system"]];
-                    [["/Root/.sys/resource_pool_classifiers"];["metadata@system"]];
-                    [["/Root/.sys/resource_pools"];["metadata@system"]];
-                    [["/Root/.sys/streaming_queries"];["metadata@system"]];
-                    [["/Root/.sys/tables"];["metadata@system"]];
-                    [["/Root/.sys/top_partitions_by_tli_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_partitions_by_tli_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_partitions_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_partitions_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_cpu_time_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_cpu_time_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_duration_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_duration_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_read_bytes_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_read_bytes_one_minute"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_request_units_one_hour"];["metadata@system"]];
-                    [["/Root/.sys/top_queries_by_request_units_one_minute"];["metadata@system"]];
-                    [["/Root/Dir0"];["root@builtin"]];
-                    [["/Root/Dir0/SubDir0"];["root@builtin"]];
-                    [["/Root/Dir0/SubDir1"];["root@builtin"]];
-                    [["/Root/Dir0/SubDir2"];["root@builtin"]];
-                    [["/Root/Dir1"];["root@builtin"]];
-                    [["/Root/Dir1/SubDir0"];["user0"]];
-                    [["/Root/Dir1/SubDir1"];["user1"]];
-                    [["/Root/Dir1/SubDir2"];["user2"]];
-                    [["/Root/Dir2"];["root@builtin"]];
-                    [["/Root/Dir2/SubDir0"];["root@builtin"]];
-                    [["/Root/Dir2/SubDir1"];["root@builtin"]];
-                    [["/Root/Dir2/SubDir2"];["root@builtin"]];
-                    [["/Root/Dir3"];["root@builtin"]];
-                    [["/Root/Dir3/SubDir0"];["root@builtin"]];
-                    [["/Root/Dir3/SubDir1"];["root@builtin"]];
-                    [["/Root/Dir3/SubDir2"];["root@builtin"]];
-                    [["/Root/Table0"];["root@builtin"]];
-                ])";
-            } else {
-                expectedYson = R"([
-                    [["/Root"];["root@builtin"]];
-                    [["/Root/.metadata"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager/pools"];["metadata@system"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["metadata@system"]];
-                    [["/Root/Dir0"];["root@builtin"]];
-                    [["/Root/Dir0/SubDir0"];["root@builtin"]];
-                    [["/Root/Dir0/SubDir1"];["root@builtin"]];
-                    [["/Root/Dir0/SubDir2"];["root@builtin"]];
-                    [["/Root/Dir1"];["root@builtin"]];
-                    [["/Root/Dir1/SubDir0"];["user0"]];
-                    [["/Root/Dir1/SubDir1"];["user1"]];
-                    [["/Root/Dir1/SubDir2"];["user2"]];
-                    [["/Root/Dir2"];["root@builtin"]];
-                    [["/Root/Dir2/SubDir0"];["root@builtin"]];
-                    [["/Root/Dir2/SubDir1"];["root@builtin"]];
-                    [["/Root/Dir2/SubDir2"];["root@builtin"]];
-                    [["/Root/Dir3"];["root@builtin"]];
-                    [["/Root/Dir3/SubDir0"];["root@builtin"]];
-                    [["/Root/Dir3/SubDir1"];["root@builtin"]];
-                    [["/Root/Dir3/SubDir2"];["root@builtin"]];
-                    [["/Root/Table0"];["root@builtin"]];
-                ])";
-            }
+            TString expectedYson = R"([
+                [["/Root"];["root@builtin"]];
+                [["/Root/.metadata"];["metadata@system"]];
+                [["/Root/.metadata/workload_manager"];["metadata@system"]];
+                [["/Root/.metadata/workload_manager/pools"];["metadata@system"]];
+                [["/Root/.metadata/workload_manager/pools/default"];["metadata@system"]];
+                [["/Root/.sys"];["metadata@system"]];[["/Root/.sys/auth_effective_permissions"];["metadata@system"]];
+                [["/Root/.sys/auth_group_members"];["metadata@system"]];
+                [["/Root/.sys/auth_groups"];["metadata@system"]];
+                [["/Root/.sys/auth_owners"];["metadata@system"]];
+                [["/Root/.sys/auth_permissions"];["metadata@system"]];
+                [["/Root/.sys/auth_users"];["metadata@system"]];
+                [["/Root/.sys/compile_cache_queries"];["metadata@system"]];
+                [["/Root/.sys/ds_groups"];["metadata@system"]];
+                [["/Root/.sys/ds_pdisks"];["metadata@system"]];
+                [["/Root/.sys/ds_storage_pools"];["metadata@system"]];
+                [["/Root/.sys/ds_storage_stats"];["metadata@system"]];
+                [["/Root/.sys/ds_vslots"];["metadata@system"]];
+                [["/Root/.sys/hive_tablets"];["metadata@system"]];
+                [["/Root/.sys/nodes"];["metadata@system"]];
+                [["/Root/.sys/partition_stats"];["metadata@system"]];
+                [["/Root/.sys/pg_class"];["metadata@system"]];
+                [["/Root/.sys/pg_tables"];["metadata@system"]];
+                [["/Root/.sys/query_metrics_one_minute"];["metadata@system"]];
+                [["/Root/.sys/query_sessions"];["metadata@system"]];
+                [["/Root/.sys/resource_pool_classifiers"];["metadata@system"]];
+                [["/Root/.sys/resource_pools"];["metadata@system"]];
+                [["/Root/.sys/streaming_queries"];["metadata@system"]];
+                [["/Root/.sys/tables"];["metadata@system"]];
+                [["/Root/.sys/top_partitions_by_tli_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_partitions_by_tli_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_partitions_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_partitions_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_cpu_time_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_cpu_time_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_duration_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_duration_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_read_bytes_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_read_bytes_one_minute"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_request_units_one_hour"];["metadata@system"]];
+                [["/Root/.sys/top_queries_by_request_units_one_minute"];["metadata@system"]];
+                [["/Root/Dir0"];["root@builtin"]];
+                [["/Root/Dir0/SubDir0"];["root@builtin"]];
+                [["/Root/Dir0/SubDir1"];["root@builtin"]];
+                [["/Root/Dir0/SubDir2"];["root@builtin"]];
+                [["/Root/Dir1"];["root@builtin"]];
+                [["/Root/Dir1/SubDir0"];["user0"]];
+                [["/Root/Dir1/SubDir1"];["user1"]];
+                [["/Root/Dir1/SubDir2"];["user2"]];
+                [["/Root/Dir2"];["root@builtin"]];
+                [["/Root/Dir2/SubDir0"];["root@builtin"]];
+                [["/Root/Dir2/SubDir1"];["root@builtin"]];
+                [["/Root/Dir2/SubDir2"];["root@builtin"]];
+                [["/Root/Dir3"];["root@builtin"]];
+                [["/Root/Dir3/SubDir0"];["root@builtin"]];
+                [["/Root/Dir3/SubDir1"];["root@builtin"]];
+                [["/Root/Dir3/SubDir2"];["root@builtin"]];
+                [["/Root/Table0"];["root@builtin"]];
+            ])";
 
             NKqp::CompareYson(expectedYson, NKqp::StreamResultToYson(it));
         }
@@ -2552,8 +2478,8 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
         NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
     }
 
-    Y_UNIT_TEST_TWIN(AuthEffectivePermissions, EnableRealSystemViewPaths) {
-        TTestEnv env({ .EnableRealSystemViewPaths = EnableRealSystemViewPaths });
+    Y_UNIT_TEST(AuthEffectivePermissions) {
+        TTestEnv env;
         SetupAuthEnvironment(env);
 
         {
@@ -2589,72 +2515,55 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
                 FROM `/Root/.sys/auth_effective_permissions`
             )").GetValueSync();
 
-            TString expectedYson;
-            if (EnableRealSystemViewPaths) {
-                expectedYson = R"([
-                    [["/Root"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.metadata"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.metadata/workload_manager"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.metadata/workload_manager/pools"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["root@builtin"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["root@builtin"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/auth_effective_permissions"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/auth_group_members"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/auth_groups"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/auth_owners"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/auth_permissions"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/auth_users"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/compile_cache_queries"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/ds_groups"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/ds_pdisks"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/ds_storage_pools"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/ds_storage_stats"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/ds_vslots"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/hive_tablets"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/nodes"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/partition_stats"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/pg_class"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/pg_tables"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/query_metrics_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/query_sessions"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/resource_pool_classifiers"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/resource_pools"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/streaming_queries"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/tables"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_partitions_by_tli_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_partitions_by_tli_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_partitions_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_partitions_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_queries_by_cpu_time_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_queries_by_cpu_time_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_queries_by_duration_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_queries_by_duration_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_queries_by_read_bytes_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_queries_by_read_bytes_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_queries_by_request_units_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.sys/top_queries_by_request_units_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Dir1"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Table0"];["ydb.generic.use"];["user1"]];
-                ])";
-            } else {
-                expectedYson = R"([
-                    [["/Root"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.metadata"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.metadata/workload_manager"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.metadata/workload_manager/pools"];["ydb.generic.use"];["user1"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["root@builtin"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["root@builtin"]];
-                    [["/Root/.metadata/workload_manager/pools/default"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Dir1"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Table0"];["ydb.generic.use"];["user1"]];
-                ])";
-            }
+            TString expectedYson = R"([
+                [["/Root"];["ydb.generic.use"];["user1"]];
+                [["/Root/.metadata"];["ydb.generic.use"];["user1"]];
+                [["/Root/.metadata/workload_manager"];["ydb.generic.use"];["user1"]];
+                [["/Root/.metadata/workload_manager/pools"];["ydb.generic.use"];["user1"]];
+                [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
+                [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
+                [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["root@builtin"]];
+                [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["root@builtin"]];
+                [["/Root/.metadata/workload_manager/pools/default"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/auth_effective_permissions"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/auth_group_members"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/auth_groups"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/auth_owners"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/auth_permissions"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/auth_users"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/compile_cache_queries"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/ds_groups"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/ds_pdisks"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/ds_storage_pools"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/ds_storage_stats"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/ds_vslots"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/hive_tablets"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/nodes"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/partition_stats"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/pg_class"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/pg_tables"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/query_metrics_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/query_sessions"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/resource_pool_classifiers"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/resource_pools"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/streaming_queries"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/tables"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_partitions_by_tli_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_partitions_by_tli_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_partitions_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_partitions_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_queries_by_cpu_time_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_queries_by_cpu_time_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_queries_by_duration_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_queries_by_duration_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_queries_by_read_bytes_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_queries_by_read_bytes_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_queries_by_request_units_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/.sys/top_queries_by_request_units_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/Dir1"];["ydb.generic.use"];["user1"]];
+                [["/Root/Table0"];["ydb.generic.use"];["user1"]];
+            ])";
 
             NKqp::CompareYson(expectedYson, NKqp::StreamResultToYson(it));
         }
@@ -2669,68 +2578,50 @@ Y_UNIT_TEST_SUITE(AuthSystemView) {
                 FROM `/Root/Tenant1/.sys/auth_effective_permissions`
             )").GetValueSync();
 
-            TString expectedYson;
-            if (EnableRealSystemViewPaths) {
-                expectedYson = R"([
-                    [["/Root/Tenant1"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.metadata"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.metadata/workload_manager"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["root@builtin"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["root@builtin"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/auth_effective_permissions"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/auth_group_members"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/auth_groups"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/auth_owners"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/auth_permissions"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/auth_users"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/compile_cache_queries"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/nodes"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/partition_stats"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/pg_class"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/pg_tables"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/query_metrics_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/query_sessions"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/resource_pool_classifiers"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/resource_pools"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/streaming_queries"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/tables"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_partitions_by_tli_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_partitions_by_tli_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_partitions_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_partitions_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_cpu_time_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_cpu_time_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_duration_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_duration_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_read_bytes_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_read_bytes_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_request_units_one_hour"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.sys/top_queries_by_request_units_one_minute"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/Dir2"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/Dir2"];["ydb.granular.select_row"];["user2"]];
-                    [["/Root/Tenant1/Table1"];["ydb.generic.use"];["user1"]];
-                ])";
-            } else {
-                expectedYson = R"([
-                    [["/Root/Tenant1"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.metadata"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.metadata/workload_manager"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["root@builtin"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["root@builtin"]];
-                    [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/Dir2"];["ydb.generic.use"];["user1"]];
-                    [["/Root/Tenant1/Dir2"];["ydb.granular.select_row"];["user2"]];
-                    [["/Root/Tenant1/Table1"];["ydb.generic.use"];["user1"]];
-                ])";
-            }
+            TString expectedYson = R"([
+                [["/Root/Tenant1"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.metadata"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.metadata/workload_manager"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.metadata/workload_manager/pools"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
+                [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
+                [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["root@builtin"]];
+                [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["root@builtin"]];
+                [["/Root/Tenant1/.metadata/workload_manager/pools/default"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/auth_effective_permissions"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/auth_group_members"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/auth_groups"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/auth_owners"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/auth_permissions"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/auth_users"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/compile_cache_queries"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/nodes"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/partition_stats"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/pg_class"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/pg_tables"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/query_metrics_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/query_sessions"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/resource_pool_classifiers"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/resource_pools"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/streaming_queries"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/tables"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_partitions_by_tli_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_partitions_by_tli_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_partitions_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_partitions_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_queries_by_cpu_time_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_queries_by_cpu_time_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_queries_by_duration_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_queries_by_duration_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_queries_by_read_bytes_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_queries_by_read_bytes_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_queries_by_request_units_one_hour"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/.sys/top_queries_by_request_units_one_minute"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/Dir2"];["ydb.generic.use"];["user1"]];
+                [["/Root/Tenant1/Dir2"];["ydb.granular.select_row"];["user2"]];
+                [["/Root/Tenant1/Table1"];["ydb.generic.use"];["user1"]];
+            ])";
 
             NKqp::CompareYson(expectedYson, NKqp::StreamResultToYson(it));
         }

--- a/ydb/core/sys_view/ut_common.cpp
+++ b/ydb/core/sys_view/ut_common.cpp
@@ -104,9 +104,6 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, const TTestEnvSettings& 
     featureFlags.SetEnableOlapCompression(settings.EnableOlapCompression);
     featureFlags.SetEnableTableCacheModes(settings.EnableTableCacheModes);
     featureFlags.SetEnableFulltextIndex(settings.EnableFulltextIndex);
-    if (settings.EnableRealSystemViewPaths) {
-        featureFlags.SetEnableRealSystemViewPaths(*settings.EnableRealSystemViewPaths);
-    }
 
     Settings->SetFeatureFlags(featureFlags);
 

--- a/ydb/core/sys_view/ut_common.h
+++ b/ydb/core/sys_view/ut_common.h
@@ -28,7 +28,6 @@ struct TTestEnvSettings {
     bool EnableOlapCompression = false;
     bool EnableTableCacheModes = false;
     bool EnableFulltextIndex = false;
-    TMaybe<bool> EnableRealSystemViewPaths;
     NKikimrProto::TAuthConfig AuthConfig = {};
     TMaybe<ui32> DataShardStatsReportIntervalSeconds;
     NKikimrConfig::TTableServiceConfig TableServiceConfig;

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -3799,53 +3799,29 @@ R"(CREATE TABLE `test_show_create` (
         check.Uint64(0); // IndexSize
     }
 
-    Y_UNIT_TEST_TWIN(Describe, EnableRealSystemViewPaths) {
-        TTestEnv env({ .EnableRealSystemViewPaths = EnableRealSystemViewPaths });
+    Y_UNIT_TEST(Describe) {
+        TTestEnv env;
         CreateRootTable(env);
 
         TTableClient client(env.GetDriver());
         auto session = client.CreateSession().GetValueSync().GetSession();
         {
-            if (EnableRealSystemViewPaths) {
-                auto result = session.DescribeSystemView("/Root/.sys/partition_stats").GetValueSync();
-                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            auto result = session.DescribeSystemView("/Root/.sys/partition_stats").GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
 
-                const auto& systemView = result.GetSystemViewDescription();
+            const auto& systemView = result.GetSystemViewDescription();
 
-                UNIT_ASSERT_VALUES_EQUAL(systemView.GetSysViewId(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(systemView.GetSysViewName(), "partition_stats");
+            UNIT_ASSERT_VALUES_EQUAL(systemView.GetSysViewId(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(systemView.GetSysViewName(), "partition_stats");
 
-                const auto& columns = systemView.GetTableColumns();
-                UNIT_ASSERT_VALUES_EQUAL(columns.size(), 31);
-                UNIT_ASSERT_STRINGS_EQUAL(columns[0].Name, "OwnerId");
-                UNIT_ASSERT_STRINGS_EQUAL(FormatType(columns[0].Type), "Uint64?");
+            const auto& columns = systemView.GetTableColumns();
+            UNIT_ASSERT_VALUES_EQUAL(columns.size(), 31);
+            UNIT_ASSERT_STRINGS_EQUAL(columns[0].Name, "OwnerId");
+            UNIT_ASSERT_STRINGS_EQUAL(FormatType(columns[0].Type), "Uint64?");
 
-                const auto& keyColumns = systemView.GetPrimaryKeyColumns();
-                UNIT_ASSERT_VALUES_EQUAL(keyColumns.size(), 4);
-                UNIT_ASSERT_STRINGS_EQUAL(keyColumns[0], "OwnerId");
-            } else {
-                auto settings = TDescribeTableSettings()
-                    .WithKeyShardBoundary(true)
-                    .WithTableStatistics(true)
-                    .WithPartitionStatistics(true);
-
-                auto result = session.DescribeTable("/Root/.sys/partition_stats", settings).GetValueSync();
-                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-
-                const auto& table = result.GetTableDescription();
-                const auto& columns = table.GetTableColumns();
-                const auto& keyColumns = table.GetPrimaryKeyColumns();
-
-                UNIT_ASSERT_VALUES_EQUAL(columns.size(), 31);
-                UNIT_ASSERT_STRINGS_EQUAL(columns[0].Name, "OwnerId");
-                UNIT_ASSERT_STRINGS_EQUAL(FormatType(columns[0].Type), "Uint64?");
-
-                UNIT_ASSERT_VALUES_EQUAL(keyColumns.size(), 4);
-                UNIT_ASSERT_STRINGS_EQUAL(keyColumns[0], "OwnerId");
-
-                UNIT_ASSERT_VALUES_EQUAL(table.GetPartitionStats().size(), 0);
-                UNIT_ASSERT_VALUES_EQUAL(table.GetPartitionsCount(), 0);
-            }
+            const auto& keyColumns = systemView.GetPrimaryKeyColumns();
+            UNIT_ASSERT_VALUES_EQUAL(keyColumns.size(), 4);
+            UNIT_ASSERT_STRINGS_EQUAL(keyColumns[0], "OwnerId");
         }
 
         TSchemeClient schemeClient(env.GetDriver());
@@ -3855,12 +3831,7 @@ R"(CREATE TABLE `test_show_create` (
 
             auto entry = result.GetEntry();
             UNIT_ASSERT_VALUES_EQUAL(entry.Name, "partition_stats");
-
-            if (EnableRealSystemViewPaths) {
-                UNIT_ASSERT_VALUES_EQUAL(entry.Type, ESchemeEntryType::SysView);
-            } else {
-                UNIT_ASSERT_VALUES_EQUAL(entry.Type, ESchemeEntryType::Table);
-            }
+            UNIT_ASSERT_VALUES_EQUAL(entry.Type, ESchemeEntryType::SysView);
         }
         {
             auto result = schemeClient.ListDirectory("/Root/.sys/partition_stats").GetValueSync();
@@ -3868,16 +3839,12 @@ R"(CREATE TABLE `test_show_create` (
 
             auto entry = result.GetEntry();
             UNIT_ASSERT_VALUES_EQUAL(entry.Name, "partition_stats");
-            if (EnableRealSystemViewPaths) {
-                UNIT_ASSERT_VALUES_EQUAL(entry.Type, ESchemeEntryType::SysView);
-            } else {
-                UNIT_ASSERT_VALUES_EQUAL(entry.Type, ESchemeEntryType::Table);
-            }
+            UNIT_ASSERT_VALUES_EQUAL(entry.Type, ESchemeEntryType::SysView);
         }
     }
 
-    Y_UNIT_TEST_TWIN(SystemViewFailOps, EnableRealSystemViewPaths) {
-        TTestEnv env({ .EnableRealSystemViewPaths = EnableRealSystemViewPaths });
+    Y_UNIT_TEST(SystemViewFailOps) {
+        TTestEnv env;
         env.GetServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_DEBUG);
 
         // Make AdministrationAllowedSIDs non-empty to deny any user cluster admin privilege.
@@ -3956,13 +3923,8 @@ R"(CREATE TABLE `test_show_create` (
         auto userSchemeClient = TSchemeClient(driver);
         {
             auto result = userSchemeClient.MakeDirectory("/Root/.sys").GetValueSync();
-            if (EnableRealSystemViewPaths) {
-                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-                UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(),
-                    "path exist", result.GetIssues().ToString());
-            } else {
-                UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SCHEME_ERROR);
-            }
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "path exist", result.GetIssues().ToString());
             result.GetIssues().PrintTo(Cerr);
         }
         {
@@ -3977,27 +3939,19 @@ R"(CREATE TABLE `test_show_create` (
         }
         {
             auto result = userSchemeClient.RemoveDirectory("/Root/.sys/partition_stats").GetValueSync();
-            if (EnableRealSystemViewPaths) {
-                UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
-            } else {
-                UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SCHEME_ERROR);
-            }
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
             result.GetIssues().PrintTo(Cerr);
         }
         {
             TModifyPermissionsSettings settings;
             auto result = userSchemeClient.ModifyPermissions("/Root/.sys/partition_stats", settings).GetValueSync();
-            if (EnableRealSystemViewPaths) {
-                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-            } else {
-                UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SCHEME_ERROR);
-            }
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
             result.GetIssues().PrintTo(Cerr);
         }
     }
 
-    Y_UNIT_TEST_TWIN(DescribeSystemFolder, EnableRealSystemViewPaths) {
-        TTestEnv env({ .EnableRealSystemViewPaths = EnableRealSystemViewPaths });
+    Y_UNIT_TEST(DescribeSystemFolder) {
+        TTestEnv env;
         CreateTenantsAndTables(env, true);
 
         TSchemeClient schemeClient(env.GetDriver());
@@ -4046,11 +4000,7 @@ R"(CREATE TABLE `test_show_create` (
             THashSet<TString> names;
             for (const auto& child : children) {
                 names.insert(TString{child.Name});
-                if (EnableRealSystemViewPaths) {
-                    UNIT_ASSERT_VALUES_EQUAL(child.Type, ESchemeEntryType::SysView);
-                } else {
-                    UNIT_ASSERT_VALUES_EQUAL(child.Type, ESchemeEntryType::Table);
-                }
+                UNIT_ASSERT_VALUES_EQUAL(child.Type, ESchemeEntryType::SysView);
             }
             UNIT_ASSERT(names.contains("partition_stats"));
         }
@@ -4069,11 +4019,7 @@ R"(CREATE TABLE `test_show_create` (
             THashSet<TString> names;
             for (const auto& child : children) {
                 names.insert(TString{child.Name});
-                if (EnableRealSystemViewPaths) {
-                    UNIT_ASSERT_VALUES_EQUAL(child.Type, ESchemeEntryType::SysView);
-                } else {
-                    UNIT_ASSERT_VALUES_EQUAL(child.Type, ESchemeEntryType::Table);
-                }
+                UNIT_ASSERT_VALUES_EQUAL(child.Type, ESchemeEntryType::SysView);
             }
             UNIT_ASSERT(names.contains("partition_stats"));
         }

--- a/ydb/core/tx/schemeshard/ut_olap_reboots/ut_olap_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap_reboots/ut_olap_reboots.cpp
@@ -415,7 +415,6 @@ Y_UNIT_TEST_SUITE(TOlapReboots) {
 
     Y_UNIT_TEST(CopyWithRebootsAtCommit) {
         TTestWithReboots t(true);
-        t.GetTestEnvOptions().EnableRealSystemViewPaths(false);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             runtime.SetLogPriority(NKikimrServices::TX_COLUMNSHARD, NActors::NLog::PRI_DEBUG);
             {
@@ -441,7 +440,7 @@ Y_UNIT_TEST_SUITE(TOlapReboots) {
             {
                 TInactiveZone inactive(activeZone);
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-                                   {NLs::ChildrenCount(3)});
+                                   {NLs::ChildrenCount(4)});
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/NewTable", true),
                                    {NLs::Finished, NLs::IsColumnTable});

--- a/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
@@ -153,9 +153,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(AsyncCreateDirWithSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true)
-                                               .EnableRealSystemViewPaths(false));
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
+
+        auto sysDirDesc = DescribePath(runtime, "/MyRoot/.sys");
+        TestForceDropUnsafe(runtime, ++txId, sysDirDesc.GetPathId());
+        env.TestWaitNotification(runtime, txId);
 
         AsyncMkDir(runtime, ++txId, "/MyRoot", ".sys");
         AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",


### PR DESCRIPTION
This PR makes tests work with default value of EnableRealSystemViewPaths flag to ensure that tests checks the current system behavior.
