### PR TITLE
[EXT-1995] Revert TEvMon ids

### DIFF
--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1,6 +1,6 @@
 #include "mon.h"
 #include "mon_impl.h"
-#include "events_internal.h"
+#include "mon_events.h"
 #include "counters_adapter_impl.h"
 
 #include <ydb/core/base/appdata.h>
@@ -32,11 +32,11 @@
 #include <util/system/hostname.h>
 
 namespace NActors {
+using NMonitoring::TEvMon;
 
 namespace {
 
 using namespace NKikimr;
-using namespace NMonitoring::NPrivate;
 
 bool HasJsonContent(NHttp::THttpIncomingRequest* request) {
     if (request->Method == "POST") {

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -32,11 +32,11 @@
 #include <util/system/hostname.h>
 
 namespace NActors {
-using NMonitoring::TEvMon;
 
 namespace {
 
 using namespace NKikimr;
+using NMonitoring::TEvMon;
 
 bool HasJsonContent(NHttp::THttpIncomingRequest* request) {
     if (request->Method == "POST") {

--- a/ydb/core/mon/mon_events.h
+++ b/ydb/core/mon/mon_events.h
@@ -2,22 +2,20 @@
 
 #include <ydb/core/protos/mon.pb.h>
 
-namespace NMonitoring::NPrivate {
+namespace NMonitoring {
 
 struct TEvMon {
     enum {
-        EvBegin = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
-
-        EvMonitoringRequest = EvBegin,
+        EvMonitoringRequest = NActors::NMon::HttpInfo + 10,
         EvMonitoringResponse,
         EvRegisterHandler,
         EvMonitoringCancelRequest,
         EvCleanupProxy,
-
         End
     };
 
-    static_assert(End < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect End < EventSpaceEnd(TEvents::ES_PRIVATE)");
+    static_assert(EvMonitoringRequest > NActors::NMon::End, "expect EvMonitoringRequest > NMon::End");
+    static_assert(End < EventSpaceEnd(NActors::TEvents::ES_MON), "expect End < EventSpaceEnd(TEvents::ES_MON)");
 
     struct TEvMonitoringRequest : NActors::TEventPB<TEvMonitoringRequest, NKikimrMonProto::TEvMonitoringRequest, EvMonitoringRequest> {
         TEvMonitoringRequest() = default;
@@ -48,4 +46,4 @@ struct TEvMon {
     };
 };
 
-} // namespace NMonitoring::NPrivate
+} // namespace NMonitoring

--- a/ydb/core/mon/ya.make
+++ b/ydb/core/mon/ya.make
@@ -1,7 +1,7 @@
 LIBRARY()
 
 SRCS(
-    events_internal.h
+    mon_events.h
     mon.cpp
     mon.h
     crossref.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This change is a partial revert of https://github.com/ydb-platform/ydb/pull/25538.
Fixes cross-version viewer incompatibility caused by the changed EvMonitoringRequest event ID, which led to hanging requests.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
