### PR TITLE
generic lookup ut: fix racing

### DIFF
--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -58,7 +58,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             std::tie(actor, Request) = LookupActorFactory(SelfId(), Alloc, *TypeEnv);
             LookupActorFactory = {};
             LookupActor = RegisterWithSameMailbox(actor);
-            auto ev = new NYql::NDq::IDqAsyncLookupSource::TEvLookupRequest(std::move(Request));
+            auto ev = new NYql::NDq::IDqAsyncLookupSource::TEvLookupRequest(Request);
             TActivationContext::ActorSystem()->Send(new NActors::IEventHandle(LookupActor, SelfId(), ev));
         }
 

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -33,7 +33,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
     // Simple actor to call IDqAsyncLookupSource::AsyncLookup from an actor system's thread
     class TCallLookupActor: public TActorBootstrapped<TCallLookupActor> {
-        using TLookupActorFactory = std::function<std::pair<NActors::IActor*, std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>>(const NActors::TActorId&, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&)>;
+        using TLookupActorFactory = std::function<std::pair<NActors::IActor*, std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>>(const NActors::TActorId&, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&, NKikimr::NMiniKQL::TTypeEnvironment&)>;
         using TCallback = std::function<void(std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&, NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr&)>;
     public:
         TCallLookupActor(
@@ -42,6 +42,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             TCallback&& callback,
             const NActors::TActorId& edge)
             : Alloc(std::move(alloc))
+            , TypeEnv(std::make_shared<NKikimr::NMiniKQL::TTypeEnvironment>(*Alloc))
             , LookupActorFactory(std::move(lookupActorFactory))
             , Callback(std::move(callback))
             , Edge(edge)
@@ -53,7 +54,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             Become(&TCallLookupActor::StateFunc);
             auto guard = Guard(*Alloc);
             NActors::IActor* actor;
-            std::tie(actor, Request) = LookupActorFactory(SelfId(), Alloc);
+            std::tie(actor, Request) = LookupActorFactory(SelfId(), Alloc, *TypeEnv);
             LookupActorFactory = {};
             LookupActor = RegisterWithSameMailbox(actor);
             auto ev = new NYql::NDq::IDqAsyncLookupSource::TEvLookupRequest(std::move(Request));
@@ -83,6 +84,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             if (Alloc) {
                 auto guard = Guard(*Alloc);
                 Request.reset();
+                TypeEnv.reset();
             }
             Alloc.reset();
         }
@@ -97,6 +99,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
     private:
         std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
         std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap> Request;
+        std::shared_ptr<NKikimr::NMiniKQL::TTypeEnvironment> TypeEnv;
         NActors::TActorId LookupActor;
         TLookupActorFactory LookupActorFactory;
         TCallback Callback;
@@ -202,8 +205,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
 
-        auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc) {
-        NKikimr::NMiniKQL::TTypeEnvironment typeEnv(*alloc);
+        auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc, NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) {
         NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
 
         NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
@@ -419,8 +421,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
 
-        auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc) {
-        NKikimr::NMiniKQL::TTypeEnvironment typeEnv(*alloc);
+        auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc, NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) {
         NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
 
         NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -33,25 +33,58 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
     // Simple actor to call IDqAsyncLookupSource::AsyncLookup from an actor system's thread
     class TCallLookupActor: public TActorBootstrapped<TCallLookupActor> {
+        using TLookupActorFactory = std::function<std::pair<NActors::IActor*, std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>>(const NActors::TActorId&, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&)>;
+        using TCallback = std::function<void(std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&, NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr&)>;
     public:
         TCallLookupActor(
-            std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
-            const NActors::TActorId& lookupActor,
-            std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap> request)
-            : Alloc(alloc)
-            , LookupActor(lookupActor)
-            , Request(request)
+            std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&& alloc,
+            TLookupActorFactory&& lookupActorFactory,
+            TCallback&& callback,
+            const NActors::TActorId& edge)
+            : Alloc(std::move(alloc))
+            , LookupActorFactory(std::move(lookupActorFactory))
+            , Callback(std::move(callback))
+            , Edge(edge)
         {
+
         }
 
         void Bootstrap() {
-            auto ev = new NYql::NDq::IDqAsyncLookupSource::TEvLookupRequest(Request);
+            Become(&TCallLookupActor::StateFunc);
+            auto guard = Guard(*Alloc);
+            NActors::IActor* actor;
+            std::tie(actor, Request) = LookupActorFactory(SelfId(), Alloc);
+            LookupActorFactory = {};
+            LookupActor = RegisterWithSameMailbox(actor);
+            auto ev = new NYql::NDq::IDqAsyncLookupSource::TEvLookupRequest(std::move(Request));
             TActivationContext::ActorSystem()->Send(new NActors::IEventHandle(LookupActor, SelfId(), ev));
         }
 
+    private:
+        STFUNC(StateFunc) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(NYql::NDq::IDqAsyncLookupSource::TEvLookupResult, Handle);
+            }
+        }
+
+        void Handle(NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr& ev) {
+            Callback(Alloc, ev);
+            {
+                auto guard = Guard(*Alloc);
+                Request.reset();
+                Callback = {};
+            }
+            Send(LookupActor, new NActors::TEvents::TEvPoison());
+            Send(Edge, new NActors::TEvents::TEvWakeup());
+        }
+    public:
+
         void PassAway() override {
-            auto guard = Guard(*Alloc);
-            Request.reset();
+            if (Alloc) {
+                auto guard = Guard(*Alloc);
+                Request.reset();
+            }
+            Alloc.reset();
         }
 
         ~TCallLookupActor() {
@@ -63,166 +96,17 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
     private:
         std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
-        const NActors::TActorId LookupActor;
         std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap> Request;
+        NActors::TActorId LookupActor;
+        TLookupActorFactory LookupActorFactory;
+        TCallback Callback;
+        NActors::TActorId Edge;
     };
 
-    Y_UNIT_TEST(Lookup) {
-        auto alloc = std::make_shared<NKikimr::NMiniKQL::TScopedAlloc>(__LOCATION__, NKikimr::TAlignedPagePoolCounters(), true, false);
+    Y_UNIT_TEST_TWIN(Lookup, MultiMatches) {
         NKikimr::NMiniKQL::TMemoryUsageInfo memUsage("TestMemUsage");
-        NKikimr::NMiniKQL::THolderFactory holderFactory(alloc->Ref(), memUsage);
-        NKikimr::NMiniKQL::TTypeEnvironment typeEnv(*alloc);
-        NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
-
-        auto loggerConfig = NYql::NProto::TLoggingConfig();
-        loggerConfig.set_allcomponentslevel(::NYql::NProto::TLoggingConfig_ELevel::TLoggingConfig_ELevel_TRACE);
-        NYql::NLog::InitLogger(loggerConfig, false);
-
-        TTestActorRuntimeBase runtime;
-        runtime.Initialize();
-        auto edge = runtime.AllocateEdgeActor();
-
-        NYql::TGenericDataSourceInstance dsi;
-        dsi.Setkind(NYql::EGenericDataSourceKind::YDB);
-        dsi.mutable_endpoint()->Sethost("some_host");
-        dsi.mutable_endpoint()->Setport(2135);
-        dsi.Setdatabase("some_db");
-        dsi.Setuse_tls(true);
-        dsi.set_protocol(::NYql::EGenericProtocol::NATIVE);
-        auto token = dsi.mutable_credentials()->mutable_token();
-        token->Settype("IAM");
-        token->Setvalue("token_value");
-
-        auto connectorMock = std::make_shared<NYql::NConnector::NTest::TConnectorClientMock>();
-
-        // clang-format off
-        // step 1: ListSplits
-        connectorMock->ExpectListSplits()
-            .Select()
-                .DataSourceInstance(dsi)
-                .What()
-                    .Column("id", Ydb::Type::UINT64)
-                    .NullableColumn("optional_id", Ydb::Type::UINT64)
-                    .NullableColumn("string_value", Ydb::Type::STRING)
-                    .Done()
-                .Table("lookup_test")
-                .Where()
-                    .Filter()
-                        .Disjunction()
-                            .Operand()
-                                .Conjunction()
-                                    .Operand().Equal().Column("id").Value<ui64>(2).Done().Done()
-                                    .Operand().Equal().Column("optional_id").OptionalValue<ui64>(102).Done().Done()
-                                    .Done()
-                                .Done()
-                            .Operand()
-                                .Conjunction()
-                                    .Operand().Equal().Column("id").Value<ui64>(1).Done().Done()
-                                    .Operand().Equal().Column("optional_id").OptionalValue<ui64>(101).Done().Done()
-                                    .Done()
-                                .Done()
-                            .Operand()
-                                .Conjunction()
-                                    .Operand().Equal().Column("id").Value<ui64>(0).Done().Done()
-                                    .Operand().Equal().Column("optional_id").OptionalValue<ui64>(100).Done().Done()
-                                    .Done()
-                                .Done()
-                            .Operand()
-                                .Conjunction()
-                                    .Operand().Equal().Column("id").Value<ui64>(2).Done().Done()
-                                    .Operand().Equal().Column("optional_id").OptionalValue<ui64>(102).Done().Done()
-                                    .Done()
-                                .Done()
-                            .Done()
-                        .Done()
-                    .Done()
-                .Done()
-            .MaxSplitCount(1)
-            .Result()
-                .AddResponse(NewSuccess())
-                    .Description("Actual split info is not important")
-        ;
-
-        connectorMock->ExpectReadSplits()
-            .DataSourceInstance(dsi)
-            .Filtering(NYql::NConnector::NApi::TReadSplitsRequest::FILTERING_MANDATORY)
-            .Split()
-                .Description("Actual split info is not important")
-                .Done()
-            .Result()
-                .AddResponse(
-                    MakeRecordBatch(
-                        MakeArray<arrow::UInt64Builder, uint64_t>("id", {0, 1, 2}, arrow::uint64()),
-                        MakeArray<arrow::UInt64Builder, uint64_t>("optional_id", {100, 101, 103}, arrow::uint64()), // the last value is intentionally wrong
-                        MakeArray<arrow::StringBuilder, std::string>("string_value", {"a", "b", "c"}, arrow::utf8())
-                    ),
-                    NewSuccess()
-                )
-        ;
-        // clang-format on
-
-        NYql::Generic::TLookupSource lookupSourceSettings;
-        *lookupSourceSettings.mutable_data_source_instance() = dsi;
-        lookupSourceSettings.Settable("lookup_test");
-        lookupSourceSettings.SetTokenName("test_token");
-
-        google::protobuf::Any packedLookupSource;
-        Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
-
-        NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
-        keyTypeBuilder.Add("id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, false));
-        keyTypeBuilder.Add("optional_id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, true));
-        NKikimr::NMiniKQL::TStructTypeBuilder outputypeBuilder{typeEnv};
-        outputypeBuilder.Add("string_value", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::String, true));
-
-        auto guard = Guard(*alloc.get());
-        auto keyTypeHelper = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TKeyTypeHelper>(keyTypeBuilder.Build());
-
-        auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
-            connectorMock,
-            NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
-            edge,
-            nullptr,
-            alloc,
-            keyTypeHelper,
-            std::move(lookupSourceSettings),
-            keyTypeBuilder.Build(),
-            outputypeBuilder.Build(),
-            typeEnv,
-            holderFactory,
-            1'000'000,
-            {{"test_token", "{\"token\": \"token_value\"}"}});
-        auto lookupActor = runtime.Register(actor);
-
-        auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
-        for (size_t i = 0; i != 3; ++i) {
-            NYql::NUdf::TUnboxedValue* keyItems;
-            auto key = holderFactory.CreateDirectArrayHolder(2, keyItems);
-            keyItems[0] = NYql::NUdf::TUnboxedValuePod(ui64(i));
-            keyItems[1] = NYql::NUdf::TUnboxedValuePod(ui64(100 + i));
-            request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
-        }
-
-        guard.Release(); // let actors use alloc
-
-        auto callLookupActor = new TCallLookupActor(alloc, lookupActor, request);
-        runtime.Register(callLookupActor);
-
-        auto ev = runtime.GrabEdgeEventRethrow<NYql::NDq::IDqAsyncLookupSource::TEvLookupResult>(edge);
-        auto guard2 = Guard(*alloc.get());
-        auto lookupResult = ev->Get()->Result.lock();
-        UNIT_ASSERT(lookupResult);
-
-        UNIT_ASSERT_EQUAL(3, lookupResult->size());
-    }
-
-    Y_UNIT_TEST(LookupMultiMatches) {
         auto alloc = std::make_shared<NKikimr::NMiniKQL::TScopedAlloc>(__LOCATION__, NKikimr::TAlignedPagePoolCounters(), true, false);
-        NKikimr::NMiniKQL::TMemoryUsageInfo memUsage("TestMemUsage");
         NKikimr::NMiniKQL::THolderFactory holderFactory(alloc->Ref(), memUsage);
-        NKikimr::NMiniKQL::TTypeEnvironment typeEnv(*alloc);
-        NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
-
         auto loggerConfig = NYql::NProto::TLoggingConfig();
         loggerConfig.set_allcomponentslevel(::NYql::NProto::TLoggingConfig_ELevel::TLoggingConfig_ELevel_TRACE);
         NYql::NLog::InitLogger(loggerConfig, false);
@@ -318,6 +202,10 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
 
+        auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc) {
+        NKikimr::NMiniKQL::TTypeEnvironment typeEnv(*alloc);
+        NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
+
         NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
         keyTypeBuilder.Add("id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, false));
         keyTypeBuilder.Add("optional_id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, true));
@@ -330,7 +218,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
             connectorMock,
             NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
-            edge,
+            caller,
             nullptr,
             alloc,
             keyTypeHelper,
@@ -341,8 +229,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             holderFactory,
             1'000'000,
             {{"test_token", "{\"token\": \"token_value\"}"}},
-            true);
-        auto lookupActor = runtime.Register(actor);
+            MultiMatches);
 
         auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
         for (size_t i = 0; i != 3; ++i) {
@@ -353,17 +240,19 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
         }
 
-        guard.Release(); // let actors use alloc
-
-        auto callLookupActor = new TCallLookupActor(alloc, lookupActor, request);
-        runtime.Register(callLookupActor);
-
-        auto ev = runtime.GrabEdgeEventRethrow<NYql::NDq::IDqAsyncLookupSource::TEvLookupResult>(edge);
+        return std::pair { actor, std::move(request) };
+        };
+        auto callback = [&](std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc,
+                NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr& ev) {
+        connectorMock.reset();
         auto guard2 = Guard(*alloc.get());
         auto lookupResult = ev->Get()->Result.lock();
         UNIT_ASSERT(lookupResult);
 
         UNIT_ASSERT_EQUAL(3, lookupResult->size());
+        if (!MultiMatches) {
+            return;
+        }
         {
             const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {0, 100}));
             UNIT_ASSERT(v);
@@ -398,14 +287,17 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             UNIT_ASSERT(v);
             UNIT_ASSERT(!*v);
         }
+        };
+
+        auto callLookupActor = new TCallLookupActor(std::move(alloc), std::move(lookupActorFactory), std::move(callback), edge);
+        runtime.Register(callLookupActor);
+        runtime.GrabEdgeEventRethrow<NActors::TEvents::TEvWakeup>(edge);
     }
 
     Y_UNIT_TEST(LookupWithErrors) {
         auto alloc = std::make_shared<NKikimr::NMiniKQL::TScopedAlloc>(__LOCATION__, NKikimr::TAlignedPagePoolCounters(), true, false);
         NKikimr::NMiniKQL::TMemoryUsageInfo memUsage("TestMemUsage");
         NKikimr::NMiniKQL::THolderFactory holderFactory(alloc->Ref(), memUsage);
-        NKikimr::NMiniKQL::TTypeEnvironment typeEnv(*alloc);
-        NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
 
         auto loggerConfig = NYql::NProto::TLoggingConfig();
         loggerConfig.set_allcomponentslevel(::NYql::NProto::TLoggingConfig_ELevel::TLoggingConfig_ELevel_TRACE);
@@ -527,6 +419,10 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
 
+        auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc) {
+        NKikimr::NMiniKQL::TTypeEnvironment typeEnv(*alloc);
+        NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
+
         NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
         keyTypeBuilder.Add("id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, false));
         keyTypeBuilder.Add("optional_id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, true));
@@ -539,7 +435,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
             connectorMock,
             NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
-            edge,
+            caller,
             nullptr,
             alloc,
             keyTypeHelper,
@@ -550,7 +446,6 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             holderFactory,
             1'000'000,
             {{"test_token", "{\"token\": \"token_value\"}"}});
-        auto lookupActor = runtime.Register(actor);
 
         auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
         for (size_t i = 0; i != 3; ++i) {
@@ -561,12 +456,11 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
         }
 
-        guard.Release(); // let actors use alloc
-
-        auto callLookupActor = new TCallLookupActor(alloc, lookupActor, request);
-        runtime.Register(callLookupActor);
-
-        auto ev = runtime.GrabEdgeEventRethrow<NYql::NDq::IDqAsyncLookupSource::TEvLookupResult>(edge);
+        return std::pair { actor, std::move(request) };
+        };
+        auto callback = [&](std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc,
+                NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr& ev) {
+        connectorMock.reset();
         auto guard2 = Guard(*alloc.get());
         auto lookupResult = ev->Get()->Result.lock();
         UNIT_ASSERT(lookupResult);
@@ -589,6 +483,11 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             UNIT_ASSERT(v);
             UNIT_ASSERT(!*v);
         }
+        };
+
+        auto callLookupActor = new TCallLookupActor(std::move(alloc), std::move(lookupActorFactory), std::move(callback), edge);
+        runtime.Register(callLookupActor);
+        runtime.GrabEdgeEventRethrow<NActors::TEvents::TEvWakeup>(edge);
     }
 
 } // Y_UNIT_TEST_SUITE(GenericProviderLookupActor)

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -211,7 +211,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
 
-        auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc, NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) {
+        auto lookupActorFactory = [&holderFactory, connectorMock = std::move(connectorMock), lookupSourceSettings = std::move(lookupSourceSettings)](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc, NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) mutable {
             NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
 
             NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
@@ -224,7 +224,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             auto keyTypeHelper = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TKeyTypeHelper>(keyTypeBuilder.Build());
 
             auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
-                connectorMock,
+                std::move(connectorMock),
                 NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
                 caller,
                 nullptr,
@@ -250,9 +250,8 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
             return std::pair { actor, std::move(request) };
         };
-        auto callback = [&](std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc,
+        auto callback = [&holderFactory](std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc,
                 NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr& ev) {
-            connectorMock.reset();
             auto guard2 = Guard(*alloc.get());
             auto lookupResult = ev->Get()->Result.lock();
             UNIT_ASSERT(lookupResult);
@@ -427,7 +426,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         google::protobuf::Any packedLookupSource;
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
 
-        auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc, NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) {
+        auto lookupActorFactory = [&holderFactory, connectorMock = std::move(connectorMock), lookupSourceSettings = std::move(lookupSourceSettings)](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc, NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) mutable {
             NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
 
             NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
@@ -440,7 +439,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             auto keyTypeHelper = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TKeyTypeHelper>(keyTypeBuilder.Build());
 
             auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
-                connectorMock,
+                std::move(connectorMock),
                 NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
                 caller,
                 nullptr,
@@ -465,9 +464,8 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
             return std::pair { actor, std::move(request) };
         };
-        auto callback = [&](std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc,
+        auto callback = [&holderFactory](std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc,
                 NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr& ev) {
-            connectorMock.reset();
             auto guard2 = Guard(*alloc.get());
             auto lookupResult = ev->Get()->Result.lock();
             UNIT_ASSERT(lookupResult);

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -33,6 +33,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
     // Simple actor to call IDqAsyncLookupSource::AsyncLookup from an actor system's thread
     class TCallLookupActor: public TActorBootstrapped<TCallLookupActor> {
+        using TBase = TActorBootstrapped<TCallLookupActor>;
         using TLookupActorFactory = std::function<std::pair<NActors::IActor*, std::shared_ptr<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>>(const NActors::TActorId&, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&, NKikimr::NMiniKQL::TTypeEnvironment&)>;
         using TCallback = std::function<void(std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>&, NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr&)>;
     public:
@@ -78,9 +79,8 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             Send(LookupActor, new NActors::TEvents::TEvPoison());
             Send(Edge, new NActors::TEvents::TEvWakeup());
         }
-    public:
 
-        void PassAway() override {
+        void Free() {
             if (Alloc) {
                 auto guard = Guard(*Alloc);
                 Request.reset();
@@ -89,8 +89,14 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
             Alloc.reset();
         }
 
+    public:
+        void PassAway() override {
+            Free();
+            TBase::PassAway();
+        }
+
         ~TCallLookupActor() {
-            PassAway();
+            Free();
         }
 
     private:

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -212,89 +212,89 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
 
         auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc, NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) {
-        NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
+            NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
 
-        NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
-        keyTypeBuilder.Add("id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, false));
-        keyTypeBuilder.Add("optional_id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, true));
-        NKikimr::NMiniKQL::TStructTypeBuilder outputypeBuilder{typeEnv};
-        outputypeBuilder.Add("string_value", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::String, true));
+            NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
+            keyTypeBuilder.Add("id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, false));
+            keyTypeBuilder.Add("optional_id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, true));
+            NKikimr::NMiniKQL::TStructTypeBuilder outputypeBuilder{typeEnv};
+            outputypeBuilder.Add("string_value", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::String, true));
 
-        auto guard = Guard(*alloc.get());
-        auto keyTypeHelper = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TKeyTypeHelper>(keyTypeBuilder.Build());
+            auto guard = Guard(*alloc.get());
+            auto keyTypeHelper = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TKeyTypeHelper>(keyTypeBuilder.Build());
 
-        auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
-            connectorMock,
-            NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
-            caller,
-            nullptr,
-            alloc,
-            keyTypeHelper,
-            std::move(lookupSourceSettings),
-            keyTypeBuilder.Build(),
-            outputypeBuilder.Build(),
-            typeEnv,
-            holderFactory,
-            1'000'000,
-            {{"test_token", "{\"token\": \"token_value\"}"}},
-            MultiMatches);
+            auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
+                connectorMock,
+                NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
+                caller,
+                nullptr,
+                alloc,
+                keyTypeHelper,
+                std::move(lookupSourceSettings),
+                keyTypeBuilder.Build(),
+                outputypeBuilder.Build(),
+                typeEnv,
+                holderFactory,
+                1'000'000,
+                {{"test_token", "{\"token\": \"token_value\"}"}},
+                MultiMatches);
 
-        auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
-        for (size_t i = 0; i != 3; ++i) {
-            NYql::NUdf::TUnboxedValue* keyItems;
-            auto key = holderFactory.CreateDirectArrayHolder(2, keyItems);
-            keyItems[0] = NYql::NUdf::TUnboxedValuePod(ui64(i));
-            keyItems[1] = NYql::NUdf::TUnboxedValuePod(ui64(100 + i));
-            request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
-        }
+            auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
+            for (size_t i = 0; i != 3; ++i) {
+                NYql::NUdf::TUnboxedValue* keyItems;
+                auto key = holderFactory.CreateDirectArrayHolder(2, keyItems);
+                keyItems[0] = NYql::NUdf::TUnboxedValuePod(ui64(i));
+                keyItems[1] = NYql::NUdf::TUnboxedValuePod(ui64(100 + i));
+                request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
+            }
 
-        return std::pair { actor, std::move(request) };
+            return std::pair { actor, std::move(request) };
         };
         auto callback = [&](std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc,
                 NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr& ev) {
-        connectorMock.reset();
-        auto guard2 = Guard(*alloc.get());
-        auto lookupResult = ev->Get()->Result.lock();
-        UNIT_ASSERT(lookupResult);
+            connectorMock.reset();
+            auto guard2 = Guard(*alloc.get());
+            auto lookupResult = ev->Get()->Result.lock();
+            UNIT_ASSERT(lookupResult);
 
-        UNIT_ASSERT_EQUAL(3, lookupResult->size());
-        if (!MultiMatches) {
-            return;
-        }
-        {
-            const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {0, 100}));
-            UNIT_ASSERT(v);
-            UNIT_ASSERT_VALUES_EQUAL(v->GetListLength(), 1);
-            auto ptr = v->GetElements();
-            UNIT_ASSERT(ptr);
-            {
-                auto val = ptr->GetElement(0);
-                UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("a"));
-                ++ptr;
-            }
-        }
-        {
-            const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {1, 101}));
-            UNIT_ASSERT(v);
-            UNIT_ASSERT_VALUES_EQUAL(v->GetListLength(), 2);
-            auto ptr = v->GetElements();
-            UNIT_ASSERT(ptr);
-            {
-                auto val = ptr->GetElement(0);
-                UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("b"));
-                ++ptr;
+            UNIT_ASSERT_EQUAL(3, lookupResult->size());
+            if (!MultiMatches) {
+                return;
             }
             {
-                auto val = ptr->GetElement(0);
-                UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("ba"));
-                ++ptr;
+                const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {0, 100}));
+                UNIT_ASSERT(v);
+                UNIT_ASSERT_VALUES_EQUAL(v->GetListLength(), 1);
+                auto ptr = v->GetElements();
+                UNIT_ASSERT(ptr);
+                {
+                    auto val = ptr->GetElement(0);
+                    UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("a"));
+                    ++ptr;
+                }
             }
-        }
-        {
-            const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {2, 102}));
-            UNIT_ASSERT(v);
-            UNIT_ASSERT(!*v);
-        }
+            {
+                const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {1, 101}));
+                UNIT_ASSERT(v);
+                UNIT_ASSERT_VALUES_EQUAL(v->GetListLength(), 2);
+                auto ptr = v->GetElements();
+                UNIT_ASSERT(ptr);
+                {
+                    auto val = ptr->GetElement(0);
+                    UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("b"));
+                    ++ptr;
+                }
+                {
+                    auto val = ptr->GetElement(0);
+                    UNIT_ASSERT_VALUES_EQUAL(TString(val.AsStringRef()), TStringBuf("ba"));
+                    ++ptr;
+                }
+            }
+            {
+                const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {2, 102}));
+                UNIT_ASSERT(v);
+                UNIT_ASSERT(!*v);
+            }
         };
 
         auto callLookupActor = new TCallLookupActor(std::move(alloc), std::move(lookupActorFactory), std::move(callback), edge);
@@ -428,68 +428,68 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
         Y_ABORT_UNLESS(packedLookupSource.PackFrom(lookupSourceSettings));
 
         auto lookupActorFactory = [&](const NActors::TActorId& caller, std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc, NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) {
-        NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
+            NKikimr::NMiniKQL::TTypeBuilder typeBuilder(typeEnv);
 
-        NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
-        keyTypeBuilder.Add("id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, false));
-        keyTypeBuilder.Add("optional_id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, true));
-        NKikimr::NMiniKQL::TStructTypeBuilder outputypeBuilder{typeEnv};
-        outputypeBuilder.Add("string_value", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::String, true));
+            NKikimr::NMiniKQL::TStructTypeBuilder keyTypeBuilder{typeEnv};
+            keyTypeBuilder.Add("id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, false));
+            keyTypeBuilder.Add("optional_id", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::Uint64, true));
+            NKikimr::NMiniKQL::TStructTypeBuilder outputypeBuilder{typeEnv};
+            outputypeBuilder.Add("string_value", typeBuilder.NewDataType(NYql::NUdf::EDataSlot::String, true));
 
-        auto guard = Guard(*alloc.get());
-        auto keyTypeHelper = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TKeyTypeHelper>(keyTypeBuilder.Build());
+            auto guard = Guard(*alloc.get());
+            auto keyTypeHelper = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TKeyTypeHelper>(keyTypeBuilder.Build());
 
-        auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
-            connectorMock,
-            NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
-            caller,
-            nullptr,
-            alloc,
-            keyTypeHelper,
-            std::move(lookupSourceSettings),
-            keyTypeBuilder.Build(),
-            outputypeBuilder.Build(),
-            typeEnv,
-            holderFactory,
-            1'000'000,
-            {{"test_token", "{\"token\": \"token_value\"}"}});
+            auto [lookupSource, actor] = NYql::NDq::CreateGenericLookupActor(
+                connectorMock,
+                NKikimr::NKqp::NFederatedQueryTest::CreateCredentialsFactory("token_value"),
+                caller,
+                nullptr,
+                alloc,
+                keyTypeHelper,
+                std::move(lookupSourceSettings),
+                keyTypeBuilder.Build(),
+                outputypeBuilder.Build(),
+                typeEnv,
+                holderFactory,
+                1'000'000,
+                {{"test_token", "{\"token\": \"token_value\"}"}});
 
-        auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
-        for (size_t i = 0; i != 3; ++i) {
-            NYql::NUdf::TUnboxedValue* keyItems;
-            auto key = holderFactory.CreateDirectArrayHolder(2, keyItems);
-            keyItems[0] = NYql::NUdf::TUnboxedValuePod(ui64(i));
-            keyItems[1] = NYql::NUdf::TUnboxedValuePod(ui64(100 + i));
-            request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
-        }
+            auto request = std::make_shared<NYql::NDq::IDqAsyncLookupSource::TUnboxedValueMap>(3, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
+            for (size_t i = 0; i != 3; ++i) {
+                NYql::NUdf::TUnboxedValue* keyItems;
+                auto key = holderFactory.CreateDirectArrayHolder(2, keyItems);
+                keyItems[0] = NYql::NUdf::TUnboxedValuePod(ui64(i));
+                keyItems[1] = NYql::NUdf::TUnboxedValuePod(ui64(100 + i));
+                request->emplace(std::move(key), NYql::NUdf::TUnboxedValue{});
+            }
 
-        return std::pair { actor, std::move(request) };
+            return std::pair { actor, std::move(request) };
         };
         auto callback = [&](std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>& alloc,
                 NYql::NDq::IDqAsyncLookupSource::TEvLookupResult::TPtr& ev) {
-        connectorMock.reset();
-        auto guard2 = Guard(*alloc.get());
-        auto lookupResult = ev->Get()->Result.lock();
-        UNIT_ASSERT(lookupResult);
+            connectorMock.reset();
+            auto guard2 = Guard(*alloc.get());
+            auto lookupResult = ev->Get()->Result.lock();
+            UNIT_ASSERT(lookupResult);
 
-        UNIT_ASSERT_EQUAL(3, lookupResult->size());
-        {
-            const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {0, 100}));
-            UNIT_ASSERT(v);
-            NYql::NUdf::TUnboxedValue val = v->GetElement(0);
-            UNIT_ASSERT(val.AsStringRef() == TStringBuf("a"));
-        }
-        {
-            const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {1, 101}));
-            UNIT_ASSERT(v);
-            NYql::NUdf::TUnboxedValue val = v->GetElement(0);
-            UNIT_ASSERT(val.AsStringRef() == TStringBuf("b"));
-        }
-        {
-            const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {2, 102}));
-            UNIT_ASSERT(v);
-            UNIT_ASSERT(!*v);
-        }
+            UNIT_ASSERT_EQUAL(3, lookupResult->size());
+            {
+                const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {0, 100}));
+                UNIT_ASSERT(v);
+                NYql::NUdf::TUnboxedValue val = v->GetElement(0);
+                UNIT_ASSERT(val.AsStringRef() == TStringBuf("a"));
+            }
+            {
+                const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {1, 101}));
+                UNIT_ASSERT(v);
+                NYql::NUdf::TUnboxedValue val = v->GetElement(0);
+                UNIT_ASSERT(val.AsStringRef() == TStringBuf("b"));
+            }
+            {
+                const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {2, 102}));
+                UNIT_ASSERT(v);
+                UNIT_ASSERT(!*v);
+            }
         };
 
         auto callLookupActor = new TCallLookupActor(std::move(alloc), std::move(lookupActorFactory), std::move(callback), edge);


### PR DESCRIPTION
generic lookup requires client and lookup to be registered on same mailbox (and never concurrently claim same mkql allocator). ut violated this requirement.

Closes: #34937

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TODO: reindent
