### PR TITLE
26-1-1: Fixing bugs in backups on FS & index_population_mode in ImportFs

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_export_uploaders_fallback.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export_uploaders_fallback.cpp
@@ -67,9 +67,9 @@ private:
 template <typename TSettings>
 IActor* CreateSchemeUploaderFallback(TActorId schemeShard, ui64 exportId, ui32 itemIdx, TPathId sourcePathId,
     const TSettings& settings, const TString& databaseRoot, const TString& metadata,
-    bool enablePermissions, const TMaybe<NBackup::TEncryptionIV>& iv
+    bool enablePermissions, bool enableChecksums, const TMaybe<NBackup::TEncryptionIV>& iv
 ) {
-    Y_UNUSED(sourcePathId, settings, databaseRoot, metadata, enablePermissions, iv);
+    Y_UNUSED(sourcePathId, settings, databaseRoot, metadata, enablePermissions, enableChecksums, iv);
     return new TSchemeUploaderFallback<TSettings>(schemeShard, exportId, itemIdx);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -474,13 +474,10 @@ void TSchemeShard::LoadTableProfiles(const NKikimrConfig::TTableProfilesConfig* 
 }
 
 bool NeedToBuildIndexes(const TImportInfo& importInfo, ui32 itemIdx) {
-    if (importInfo.Kind != TImportInfo::EKind::S3) {
-        return true;
-    }
     Y_ABORT_UNLESS(itemIdx < importInfo.Items.size());
     auto& item = importInfo.Items.at(itemIdx);
 
-    switch (importInfo.GetS3Settings().index_population_mode()) {
+    switch (importInfo.GetIndexPopulationMode()) {
         case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_BUILD:
             return true;
         case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_AUTO:

--- a/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
@@ -1013,7 +1013,7 @@ public:
         , MetadataKey(MetadataKeyFromSettings(*ImportInfo, itemIdx))
         , SchemeKey(SchemeKeyFromSettings(*ImportInfo, itemIdx, "scheme.pb"))
         , PermissionsKey(PermissionsKeyFromSettings(*ImportInfo, itemIdx))
-        , IndexPopulationMode(ImportInfo->Kind == TImportInfo::EKind::S3 ? ImportInfo->GetS3Settings().index_population_mode() : Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_UNSPECIFIED)
+        , IndexPopulationMode(ImportInfo->GetIndexPopulationMode())
         , NeedDownloadPermissions(!ImportInfo->GetNoAcl())
         , NeedValidateChecksums(!ImportInfo->GetSkipChecksumValidation())
     {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3433,6 +3433,12 @@ public:
         });
     }
 
+    Ydb::Import::ImportFromS3Settings::IndexPopulationMode GetIndexPopulationMode() const {
+        return Visit([](const auto& settings) {
+            return settings.index_population_mode();
+        });
+    }
+
     bool CompileExcludeRegexps(TString& errorDescription);
 
     bool IsExcludedFromImport(const TString& path) const;

--- a/ydb/core/wrappers/fs_storage_ut.cpp
+++ b/ydb/core/wrappers/fs_storage_ut.cpp
@@ -1,0 +1,119 @@
+#include "fs_storage_config.h"
+#include "s3_wrapper.h"
+
+#include <ydb/core/protos/fs_settings.pb.h>
+#include <ydb/library/services/services.pb.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/wrappers/events/common.h>
+
+#include <ydb/library/actors/core/log.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/folder/path.h>
+#include <util/folder/tempdir.h>
+#include <util/stream/file.h>
+#include <util/system/file.h>
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NWrappers;
+using namespace NKikimr::NWrappers::NExternalStorage;
+using namespace Aws::S3::Model;
+
+class TFsStorageTestBase : public NUnitTest::TTestBase {
+protected:
+    void SetUp() override {
+        TempDir = MakeHolder<TTempDir>();
+
+        Runtime = MakeHolder<TTestBasicRuntime>();
+        Runtime->Initialize(TAppPrepare().Unwrap());
+        Runtime->SetLogPriority(NKikimrServices::FS_WRAPPER, NLog::PRI_DEBUG);
+
+        NKikimrSchemeOp::TFSSettings settings;
+        settings.SetBasePath(TempDir->Name());
+        auto config = std::make_shared<TFsExternalStorageConfig>(settings);
+
+        Wrapper = Runtime->Register(NWrappers::CreateStorageWrapper(config->ConstructStorageOperator()));
+        Edge = Runtime->AllocateEdgeActor();
+    }
+
+    void TearDown() override {
+        Runtime.Reset();
+        TempDir.Reset();
+    }
+
+    TString KeyPath(const TString& name) const {
+        return (TFsPath(TempDir->Name()) / name).GetPath();
+    }
+
+    template <typename TEvResponse>
+    auto Send(IEventBase* ev) {
+        Runtime->Send(new IEventHandle(Wrapper, Edge, ev));
+        return Runtime->GrabEdgeEvent<TEvResponse>(Edge);
+    }
+
+    auto PutObject(const TString& key, TString body) {
+        auto request = PutObjectRequest().WithKey(key);
+        auto response = Send<TEvPutObjectResponse>(
+            new TEvPutObjectRequest(request, std::move(body)));
+        UNIT_ASSERT(response->Get());
+        return response->Get()->Result;
+    }
+
+protected:
+    THolder<TTempDir> TempDir;
+    THolder<TTestBasicRuntime> Runtime;
+    TActorId Wrapper;
+    TActorId Edge;
+};
+
+class TFsStorageTests : public TFsStorageTestBase {
+    UNIT_TEST_SUITE(TFsStorageTests);
+
+    UNIT_TEST(PutObjectDoesNotTruncateLockedFile);
+    UNIT_TEST_SUITE_END();
+
+public:
+    void PutObjectDoesNotTruncateLockedFile() {
+        const TString key = KeyPath("data.csv");
+        const TVector<TString> originalContent = {"generation1.0", "generation1.1"};
+        const TString newContent      = "generation2";
+
+        {
+            TFileOutput f(key);
+            f.Write(originalContent[0]);
+        }
+
+        TFile externalLock(key, OpenExisting | RdWr);
+        externalLock.Flock(LOCK_EX | LOCK_NB);
+
+        {
+            auto result = PutObject(key, newContent);
+            UNIT_ASSERT(!result.IsSuccess());
+            UNIT_ASSERT(result.GetError().ShouldRetry());
+
+            TFileInput f(key);
+            const TString actualContent = f.ReadAll();
+            UNIT_ASSERT_VALUES_EQUAL(actualContent, originalContent[0]);
+        }
+
+        {
+            TFileOutput f(key);
+            f.Write(originalContent[1]);
+        }
+
+        externalLock.Flock(LOCK_UN);
+        externalLock.Close();
+
+        {
+            auto result = PutObject(key, newContent);
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetError().GetMessage());
+
+            TFileInput f(key);
+            UNIT_ASSERT_VALUES_EQUAL(f.ReadAll(), newContent);
+        }
+    }
+};
+
+UNIT_TEST_SUITE_REGISTRATION(TFsStorageTests);

--- a/ydb/core/wrappers/ut/ya.make
+++ b/ydb/core/wrappers/ut/ya.make
@@ -17,6 +17,7 @@ IF (NOT OS_WINDOWS)
     )
     SRCS(
         s3_wrapper_ut.cpp
+        fs_storage_ut.cpp
     )
 ENDIF()
 

--- a/ydb/public/api/protos/ydb_import.proto
+++ b/ydb/public/api/protos/ydb_import.proto
@@ -198,6 +198,10 @@ message ImportFromFsSettings {
     // - Patterns are matched against the database object names stored in the backup listing.
     // - Object is excluded from import operation if it matches any of the specified exclude regexps.
     repeated string exclude_regexps = 9;
+
+    // Index population mode.
+    // If not specified, indexes will be built.
+    ImportFromS3Settings.IndexPopulationMode index_population_mode = 10;
 }
 
 message ImportFromFsResult {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/import/import.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/import/import.h
@@ -169,6 +169,7 @@ struct TImportFromFsSettings : public TOperationRequestSettings<TImportFromFsSet
     FLUENT_SETTING_OPTIONAL(uint32_t, NumberOfRetries);
     FLUENT_SETTING_OPTIONAL(bool, NoACL);
     FLUENT_SETTING_OPTIONAL(bool, SkipChecksumValidation);
+    FLUENT_SETTING_DEFAULT(EIndexPopulationMode, IndexPopulationMode, EIndexPopulationMode::Build);
     FLUENT_SETTING_VECTOR(std::string, ExcludeRegexp);
 };
 

--- a/ydb/public/sdk/cpp/src/client/import/import.cpp
+++ b/ydb/public/sdk/cpp/src/client/import/import.cpp
@@ -104,6 +104,7 @@ TImportFromFsResponse::TImportFromFsResponse(TStatus&& status, Ydb::Operations::
 
     Metadata_.Settings.Description(metadata.settings().description());
     Metadata_.Settings.NumberOfRetries(metadata.settings().number_of_retries());
+    Metadata_.Settings.IndexPopulationMode(TProtoAccessor::FromProto(metadata.settings().index_population_mode()));
 
     if (metadata.settings().no_acl()) {
         Metadata_.Settings.NoACL(metadata.settings().no_acl());
@@ -352,6 +353,8 @@ TAsyncImportFromFsResponse TImportClient::ImportFromFs(const TImportFromFsSettin
     if (settings.SkipChecksumValidation_) {
         settingsProto.set_skip_checksum_validation(settings.SkipChecksumValidation_.value());
     }
+
+    settingsProto.set_index_population_mode(TProtoAccessor::GetProto(settings.IndexPopulationMode_));
 
     for (const std::string& excludeRegexp : settings.ExcludeRegexp_) {
         settingsProto.add_exclude_regexps(excludeRegexp);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Починена сборка под Windows;
- исправлена потенциальная гонка при экспорте на FS при одновременном PutObject по одному ключу;
- добавлен `fsync` для директорий при экспорте на FS, чтобы избежать ситуации некорректного состояния ФС при сбое;
- исправлена ошибка в разыменовании пустого `TlsActivationContext` в логах в функции `CleanupActiveSessions` при явном вызове деструктора `TFsOperationActor`;
- добавлено поле `index_population_mode` в импорте из ФС.
