### PR TITLE
merge to q-stable-2025-05-15 LOGBROKER-7430-add-unit-test-on-reading-with-restarts

### DIFF
--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/read_session_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/read_session_ut.cpp
@@ -1918,14 +1918,15 @@ Y_UNIT_TEST_SUITE(ReadSessionImplTest) {
                                                                    0);
 
         std::atomic<bool> ready = true;
+        std::atomic<bool> abandoned = false;
 
-        stream->InsertDataEvent(0, 0, data, ready);
+        stream->InsertDataEvent(0, 0, data, ready, abandoned);
         stream->InsertEvent(TServiceEvent{stream, 0, 0, 0, {}});
-        stream->InsertDataEvent(0, 0, data, ready);
-        stream->InsertDataEvent(0, 0, data, ready);
+        stream->InsertDataEvent(0, 0, data, ready, abandoned);
+        stream->InsertDataEvent(0, 0, data, ready, abandoned);
         stream->InsertEvent(TServiceEvent{stream, 0, 0, 0, {}});
         stream->InsertEvent(TServiceEvent{stream, 0, 0, 0, {}});
-        stream->InsertDataEvent(0, 0, data, ready);
+        stream->InsertDataEvent(0, 0, data, ready, abandoned);
 
         TDeferredActions actions;
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -339,7 +339,7 @@ private:
     std::vector<TMessageMetaPtrVector> MessagesMeta;
     TCallbackContextPtr<UseMigrationProtocol> CbContext;
     bool DoDecompress;
-    i64 ServerBytesSize = 0;
+    std::atomic<i64> ServerBytesSize = 0;
     std::atomic<i64> SourceDataNotProcessed = 0;
     std::pair<size_t, size_t> CurrentDecompressingMessage = {0, 0}; // (Batch, Message)
     std::deque<TReadyMessageThreshold> ReadyThresholds;

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -164,6 +164,7 @@ private:
     void Reconnect();
     void SignalWaiters();
     void StartSessions();
+    void DestroyDecompressionInfos();
 
 private:
     // Read.
@@ -204,6 +205,8 @@ public:
         i64 serverBytesSize = 0 // to increment read request bytes size
     );
     ~TDataDecompressionInfo();
+
+    void Cleanup();
 
     i64 StartDecompressionTasks(const typename IAExecutor<UseMigrationProtocol>::TPtr& executor,
                                 i64 availableMemory,
@@ -271,17 +274,12 @@ public:
         return MessagesMeta[batchIndex][messageIndex];
     }
 
-    bool HasMoreData() const {
-        return CurrentReadingMessage.first < static_cast<size_t>(GetServerMessage().batches_size());
-    }
-
-    bool HasReadyUnreadData() const;
-
     void PutDecompressionError(std::exception_ptr error, size_t batch, size_t message);
     std::exception_ptr GetDecompressionError(size_t batch, size_t message);
 
     void OnDataDecompressed(i64 sourceSize, i64 estimatedDecompressedSize, i64 decompressedSize, size_t messagesCount);
     void OnUserRetrievedEvent(i64 decompressedDataSize, size_t messagesCount);
+    void OnTaskCanceled(i64 sourceSize, size_t messagesCount);
 
 private:
     // Special struct for marking (batch/message) as ready.
@@ -289,6 +287,7 @@ private:
         size_t Batch = 0; // Last ready batch with message index.
         size_t Message = 0; // Last ready message index.
         std::atomic<bool> Ready = false;
+        std::atomic<bool> Abandoned = false; // Marked by true either when decompression is completed or message is not needed anymore
     };
 
     struct TDecompressionTask {
@@ -340,7 +339,6 @@ private:
     std::atomic<i64> SourceDataNotProcessed = 0;
     std::pair<size_t, size_t> CurrentDecompressingMessage = {0, 0}; // (Batch, Message)
     std::deque<TReadyMessageThreshold> ReadyThresholds;
-    std::pair<size_t, size_t> CurrentReadingMessage = {0, 0}; // (Batch, Message)
 
     // Decompression exceptions.
     // Optimization for rare using.
@@ -358,16 +356,26 @@ private:
 template <bool UseMigrationProtocol>
 class TDataDecompressionEvent {
 public:
-    TDataDecompressionEvent(size_t batch, size_t message, TDataDecompressionInfoPtr<UseMigrationProtocol> parent, std::atomic<bool>& ready) :
+    TDataDecompressionEvent(size_t batch, size_t message, TDataDecompressionInfoPtr<UseMigrationProtocol> parent, std::atomic<bool>& ready, std::atomic<bool>& abandoned) :
         Batch{batch},
         Message{message},
         Parent{std::move(parent)},
-        Ready{ready}
+        Ready{ready},
+        Abandoned{abandoned}
     {
     }
 
     bool IsReady() const {
         return Ready;
+    }
+
+    bool SetAbandoned() {
+        if (bool expected = false; Abandoned.compare_exchange_strong(expected, true)) {
+            return true;
+        }
+
+        Y_ASSERT(Ready);
+        return false;
     }
 
     void TakeData(TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream,
@@ -385,6 +393,7 @@ private:
     size_t Message;
     TDataDecompressionInfoPtr<UseMigrationProtocol> Parent;
     std::atomic<bool>& Ready;
+    std::atomic<bool>& Abandoned;
 };
 
 template <bool UseMigrationProtocol>
@@ -449,12 +458,14 @@ struct TRawPartitionStreamEvent {
     TRawPartitionStreamEvent(size_t batch,
                              size_t message,
                              TDataDecompressionInfoPtr<UseMigrationProtocol> parent,
-                             std::atomic<bool> &ready)
+                             std::atomic<bool> &ready,
+                             std::atomic<bool>& abandoned)
         : Event(std::in_place_type_t<TDataDecompressionEvent<UseMigrationProtocol>>(),
                 batch,
                 message,
                 std::move(parent),
-                ready)
+                ready,
+                abandoned)
     {
     }
 
@@ -466,6 +477,11 @@ struct TRawPartitionStreamEvent {
 
     bool IsDataEvent() const {
         return std::holds_alternative<TDataDecompressionEvent<UseMigrationProtocol>>(Event);
+    }
+
+    TDataDecompressionEvent<UseMigrationProtocol>& GetDataEvent() {
+        Y_ASSERT(IsDataEvent());
+        return std::get<TDataDecompressionEvent<UseMigrationProtocol>>(Event);
     }
 
     const TDataDecompressionEvent<UseMigrationProtocol>& GetDataEvent() const {
@@ -547,6 +563,10 @@ public:
                           std::vector<typename TADataReceivedEvent<UseMigrationProtocol>::TMessage>& messages,
                           std::vector<typename TADataReceivedEvent<UseMigrationProtocol>::TCompressedMessage>& compressedMessages,
                           TUserRetrievedEventsInfoAccumulator<UseMigrationProtocol>& accumulator);
+
+    ui64 GetReadyEventsCount() const {
+        return Ready.size();
+    }
 
 private:
     static void GetDataEventImpl(TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream,
@@ -659,9 +679,10 @@ public:
     void InsertDataEvent(size_t batch,
                          size_t message,
                          TDataDecompressionInfoPtr<UseMigrationProtocol> parent,
-                         std::atomic<bool> &ready)
+                         std::atomic<bool>& ready,
+                         std::atomic<bool>& abandoned)
     {
-        EventsQueue.emplace_back(batch, message, std::move(parent), ready);
+        EventsQueue.emplace_back(batch, message, std::move(parent), ready, abandoned);
     }
 
     bool HasEvents() const {
@@ -763,6 +784,10 @@ public:
         return Lock;
     }
 
+    ui64 GetReadyEventsCount() const {
+        return EventsQueue.GetReadyEventsCount();
+    }
+
 private:
     const TKey Key;
     ui64 AssignId;
@@ -858,7 +883,8 @@ public:
                        size_t batch,
                        size_t message,
                        TDataDecompressionInfoPtr<UseMigrationProtocol> parent,
-                       std::atomic<bool> &ready);
+                       std::atomic<bool>& ready,
+                       std::atomic<bool>& abandoned);
 
     void SignalEventImpl(TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream,
                          TDeferredActions<UseMigrationProtocol>& deferred,
@@ -1023,6 +1049,10 @@ private:
         return visitor.Visit();
     }
 
+    void SelfCheck() final {
+        CbContext->LockShared()->SelfCheck();
+    }
+
 private:
     bool HasEventCallbacks;
     TCallbackContextPtr<UseMigrationProtocol> CbContext;
@@ -1114,6 +1144,7 @@ public:
                                         TDeferredActions<UseMigrationProtocol>& deferred);
 
     void OnDataDecompressed(i64 sourceSize, i64 estimatedDecompressedSize, i64 decompressedSize, size_t messagesCount, i64 serverBytesSize = 0);
+    void OnDecompressionTaskCanceled(i64 sourceSize, size_t messagesCount, i64 serverBytesSize);
 
     TReadSessionEventsQueue<UseMigrationProtocol>* GetEventsQueue() {
         return EventsQueue.get();
@@ -1170,6 +1201,8 @@ public:
     void CollectOffsets(TTransactionBase& tx,
                         const TReadSessionEvent::TEvent& event,
                         std::shared_ptr<TTopicClient::TImpl> client);
+
+    void SelfCheck();
 
 private:
     void BreakConnectionAndReconnectImpl(TPlainStatus&& status, TDeferredActions<UseMigrationProtocol>& deferred);
@@ -1350,6 +1383,7 @@ private:
     typename IProcessor::TPtr Processor;
     typename IARetryPolicy<UseMigrationProtocol>::IRetryState::TPtr RetryState; // Current retry state (if now we are (re)connecting).
     size_t ConnectionAttemptsDone = 0;
+    TInstant LastActiveTime = TInstant::Now();
 
     // Memory usage.
     i64 CompressedDataSize = 0;

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -244,6 +244,10 @@ public:
         return ServerBytesSize;
     }
 
+    size_t GetNotStartedTasksCunt() const {
+        return Tasks.size();
+    }
+
     std::optional<std::pair<size_t, size_t>> GetReadyThreshold() const {
         size_t readyCount = 0;
         std::pair<size_t, size_t> ret;
@@ -374,8 +378,8 @@ public:
             return true;
         }
 
-        Y_ASSERT(Ready);
-        return false;
+        // If Ready=false, decompression task already successfully cancelled
+        return !Ready;
     }
 
     void TakeData(TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>> partitionStream,
@@ -383,6 +387,8 @@ public:
                   std::vector<typename TADataReceivedEvent<UseMigrationProtocol>::TCompressedMessage>& compressedMessages,
                   size_t& maxByteSize,
                   size_t& dataSize) const;
+
+    size_t GetDataSize() const;
 
     TDataDecompressionInfoPtr<UseMigrationProtocol> GetParent() const {
         return Parent;
@@ -547,6 +553,10 @@ public:
         (NotReady.empty() ? Ready : NotReady).pop_back();
     }
 
+    size_t size() const {
+        return NotReady.size() + Ready.size();
+    }
+
     void clear() noexcept {
         NotReady.clear();
         Ready.clear();
@@ -564,7 +574,7 @@ public:
                           std::vector<typename TADataReceivedEvent<UseMigrationProtocol>::TCompressedMessage>& compressedMessages,
                           TUserRetrievedEventsInfoAccumulator<UseMigrationProtocol>& accumulator);
 
-    ui64 GetReadyEventsCount() const {
+    size_t GetReadyEventAmount() const {
         return Ready.size();
     }
 
@@ -784,8 +794,12 @@ public:
         return Lock;
     }
 
-    ui64 GetReadyEventsCount() const {
-        return EventsQueue.GetReadyEventsCount();
+    size_t GetEventAmount() const {
+        return EventsQueue.size();
+    }
+
+    size_t GetReadyEventAmount() const {
+        return EventsQueue.GetReadyEventAmount();
     }
 
 private:

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -204,7 +204,15 @@ void TRawPartitionStreamEventQueue<UseMigrationProtocol>::DeleteNotReadyTail(TDe
     std::deque<TRawPartitionStreamEvent<UseMigrationProtocol>> ready;
 
     auto i = NotReady.begin();
-    for (; (i != NotReady.end()) && i->IsReady(); ++i) {
+    for (; i != NotReady.end(); ++i) {
+        if (!i->IsReady()) {
+            // Cancel inflight decompression tasks if any
+            if (!i->IsDataEvent() || i->GetDataEvent().SetAbandoned()) {
+                break;
+            }
+            // Message was decompressed and become ready
+        }
+
         ready.push_back(std::move(*i));
     }
 
@@ -803,6 +811,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnUserRetrievedEvent(i
 
     Y_ABORT_UNLESS(decompressedSize <= DecompressedDataSize);
     DecompressedDataSize -= decompressedSize;
+    LastActiveTime = TInstant::Now();
 
     ContinueReadingDataImpl();
     StartDecompressionTasksImpl(deferred);
@@ -856,6 +865,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ReadFromProcessorImpl(
             }
         };
 
+        LastActiveTime = TInstant::Now();
         deferred.DeferReadFromProcessor(Processor, ServerMessage.get(), std::move(callback));
     }
 }
@@ -1525,6 +1535,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::StartDecompressionTask
                                                                            deferred);
         DecompressedDataSize += sentToDecompress;
         if (current.BatchInfo->AllDecompressionTasksStarted()) {
+            deferred.DeferDestroyDecompressionInfos({current.BatchInfo});
             DecompressionQueue.pop_front();
         } else {
             break;
@@ -1604,8 +1615,9 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDataDecompressed(i64
     UpdateMemoryUsageStatisticsImpl();
     CompressedDataSize -= sourceSize;
     DecompressedDataSize += decompressedSize - estimatedDecompressedSize;
+    LastActiveTime = TInstant::Now();
     constexpr double weight = 0.6;
-    if (sourceSize > 0) {
+    if (sourceSize > 0 && decompressedSize > 0) {
         AverageCompressionRatio = weight * static_cast<double>(decompressedSize) / static_cast<double>(sourceSize) + (1 - weight) * AverageCompressionRatio;
     }
     if (Aborting) {
@@ -1615,6 +1627,34 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDataDecompressed(i64
         LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "Returning serverBytesSize = " << serverBytesSize << " to budget");
         ReadSizeBudget += serverBytesSize;
     }
+    ContinueReadingDataImpl();
+    StartDecompressionTasksImpl(deferred);
+}
+
+template<bool UseMigrationProtocol>
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDecompressionTaskCanceled(i64 sourceSize, size_t messagesCount, i64 serverBytesSize) {
+    LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "The application data decompression is cancelled. Number of messages " << messagesCount << ", size " << sourceSize << " bytes");
+
+    *Settings.Counters_->BytesReadCompressed += sourceSize;
+    *Settings.Counters_->MessagesRead += messagesCount;
+    *Settings.Counters_->BytesInflightCompressed -= sourceSize;
+    *Settings.Counters_->BytesInflightTotal -= sourceSize;
+    *Settings.Counters_->MessagesInflight -= messagesCount;
+
+    TDeferredActions<UseMigrationProtocol> deferred;
+    std::lock_guard guard(Lock);
+    UpdateMemoryUsageStatisticsImpl();
+
+    CompressedDataSize -= sourceSize;
+    LastActiveTime = TInstant::Now();
+    if (Aborting) {
+        return;
+    }
+    if constexpr (!UseMigrationProtocol) {
+        LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "Returning serverBytesSize = " << serverBytesSize << " to budget");
+        ReadSizeBudget += serverBytesSize;
+    }
+
     ContinueReadingDataImpl();
     StartDecompressionTasksImpl(deferred);
 }
@@ -1912,6 +1952,48 @@ bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::AllParentSessionsHasBe
 }
 
 template<bool UseMigrationProtocol>
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::SelfCheck() {
+    const auto delta = TInstant::Now() - LastActiveTime;
+    if (delta < TDuration::Minutes(1)) {
+        // Session ok, we got at least one event from server since last 1 minute
+        return;
+    }
+
+    if (WaitingReadResponse) {
+        // We sent to server non zero memory budget, but don't get read response since last 1 minute
+        LOG_LAZY(Log, TLOG_INFO, GetLogPrefix() << "[SelfCheck] There is no server events since last: " << delta << ", most likely there is no data in topic partitions");
+        return;
+    }
+
+    if (DecompressionTasksInflight) {
+        LOG_LAZY(Log, TLOG_INFO, GetLogPrefix() << "[SelfCheck] There is still inflight decompression tasks since last: " << delta << ", read session was stopped by back pressure, most likely decompression is too slow");
+        return;
+    }
+
+    ui64 readyEventsCount = 0;
+    std::unordered_set<ui64> handledPartitionStreams;
+    for (const auto& [assignId, stream] : PartitionStreams) {
+        handledPartitionStreams.emplace(assignId);
+        readyEventsCount += stream->GetReadyEventsCount();
+    }
+
+    // Some streams may have some ready events after finish
+    for (const auto& decompressionItem : DecompressionQueue) {
+        if (const auto& stream = *decompressionItem.PartitionStream; handledPartitionStreams.emplace(stream.GetAssignId()).second) {
+            readyEventsCount += stream.GetReadyEventsCount();
+        }
+    }
+
+    if (readyEventsCount) {
+        LOG_LAZY(Log, TLOG_INFO, GetLogPrefix() << "[SelfCheck] There is still " << readyEventsCount << " pending ready events since last: " << delta << ", read session was stopped by back pressure, most likely extraction pipeline is too slow");
+        return;
+    }
+
+    // No read from server inflight, no ready events and no decompression tasks inflight => most likely hanging
+    LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "[SelfCheck] There is no ready events / inflight decompression since last: " << delta << ", most likely hanged after stop by back pressure");
+}
+
+template<bool UseMigrationProtocol>
 void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStreamEnd(TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, const std::vector<ui32>& childIds) {
     ReadingFinishedData.insert(partitionStream->GetPartitionSessionId());
     for (auto& [_, s] : PartitionStreams) {
@@ -2096,6 +2178,7 @@ bool TReadSessionEventsQueue<UseMigrationProtocol>::PushEvent(TIntrusivePtr<TPar
 
     if (std::holds_alternative<TClosedEvent>(event)) {
         stream->DeleteNotReadyTail(deferred);
+        SignalReadyEventsImpl(stream, deferred);
     }
 
     if (!HasDataEventCallback() && !std::holds_alternative<TADataReceivedEvent<UseMigrationProtocol>>(event)) {
@@ -2145,14 +2228,15 @@ bool TReadSessionEventsQueue<UseMigrationProtocol>::PushDataEvent(TIntrusivePtr<
                                                                   size_t batch,
                                                                   size_t message,
                                                                   TDataDecompressionInfoPtr<UseMigrationProtocol> parent,
-                                                                  std::atomic<bool>& ready)
+                                                                  std::atomic<bool>& ready,
+                                                                  std::atomic<bool>& abandoned)
 {
 
     std::lock_guard<std::mutex> guard(TParent::Mutex);
     if (this->Closed) {
         return false;
     }
-    partitionStream->InsertDataEvent(batch, message, parent, ready);
+    partitionStream->InsertDataEvent(batch, message, parent, ready, abandoned);
     return true;
 }
 
@@ -2494,6 +2578,18 @@ TDataDecompressionInfo<UseMigrationProtocol>::~TDataDecompressionInfo()
 }
 
 template<bool UseMigrationProtocol>
+void TDataDecompressionInfo<UseMigrationProtocol>::Cleanup() {
+    auto session = CbContext->LockShared();
+    Y_ASSERT(session);
+
+    while (!Tasks.empty()) {
+        const auto& task = Tasks.front();
+        OnTaskCanceled(task.AddedDataSize(), task.AddedMessagesCount());
+        Tasks.pop_front();
+    }
+}
+
+template<bool UseMigrationProtocol>
 void TDataDecompressionInfo<UseMigrationProtocol>::BuildBatchesMeta() {
     BatchesMeta.reserve(ServerMessage.batches_size());
     if constexpr (!UseMigrationProtocol) {
@@ -2610,7 +2706,8 @@ void TDataDecompressionInfo<UseMigrationProtocol>::PlanDecompressionTasks(double
                                                      CurrentDecompressingMessage.first,
                                                      CurrentDecompressingMessage.second,
                                                      TDataDecompressionInfo::shared_from_this(),
-                                                     ReadyThresholds.back().Ready);
+                                                     ReadyThresholds.back().Ready,
+                                                     ReadyThresholds.back().Abandoned);
             if (!pushRes) {
                 session->AbortImpl();
                 return;
@@ -2739,15 +2836,6 @@ void TDataDecompressionEvent<UseMigrationProtocol>::TakeData(TIntrusivePtr<TPart
 }
 
 template<bool UseMigrationProtocol>
-bool TDataDecompressionInfo<UseMigrationProtocol>::HasReadyUnreadData() const {
-    std::optional<std::pair<size_t, size_t>> threshold = GetReadyThreshold();
-    if (!threshold) {
-        return false;
-    }
-    return CurrentReadingMessage <= *threshold;
-}
-
-template<bool UseMigrationProtocol>
 void TDataDecompressionInfo<UseMigrationProtocol>::OnDataDecompressed(i64 sourceSize, i64 estimatedDecompressedSize, i64 decompressedSize, size_t messagesCount)
 {
     CompressedDataSize -= sourceSize;
@@ -2768,6 +2856,18 @@ void TDataDecompressionInfo<UseMigrationProtocol>::OnUserRetrievedEvent(i64 deco
 
     if (auto session = CbContext->LockShared()) {
         session->OnUserRetrievedEvent(decompressedSize, messagesCount);
+    }
+}
+
+template<bool UseMigrationProtocol>
+void TDataDecompressionInfo<UseMigrationProtocol>::OnTaskCanceled(i64 sourceSize, size_t messagesCount)
+{
+    SourceDataNotProcessed -= sourceSize;
+    CompressedDataSize -= sourceSize;
+    MessagesInflight -= messagesCount;
+
+    if (auto session = CbContext->LockShared()) {
+        session->OnDecompressionTaskCanceled(sourceSize, messagesCount, ServerBytesSize.exchange(0));
     }
 }
 
@@ -2869,6 +2969,11 @@ void TDataDecompressionInfo<UseMigrationProtocol>::TDecompressionTask::operator(
     if (auto session = parent->CbContext->LockShared()) {
         session->GetEventsQueue()->SignalReadyEvents(PartitionStream);
     }
+
+    if (bool expected = false; !Ready->Abandoned.compare_exchange_strong(expected, true)) {
+        // Message is dropped due to partition stream cancellation, we should release decompressed memory
+        parent->OnUserRetrievedEvent(DecompressedSize, messagesProcessed);
+    }
 }
 
 template<bool UseMigrationProtocol>
@@ -2960,7 +3065,7 @@ void TDeferredActions<UseMigrationProtocol>::DeferSignalWaiter(TWaiter&& waiter)
 template<bool UseMigrationProtocol>
 void TDeferredActions<UseMigrationProtocol>::DeferDestroyDecompressionInfos(std::vector<TDataDecompressionInfoPtr<UseMigrationProtocol>>&& infos)
 {
-    DecompressionInfos = std::move(infos);
+    DecompressionInfos.insert(DecompressionInfos.end(), infos.begin(), infos.end());
 }
 
 template<bool UseMigrationProtocol>
@@ -2971,6 +3076,7 @@ void TDeferredActions<UseMigrationProtocol>::DoActions() {
     Reconnect();
     SignalWaiters();
     StartSessions();
+    DestroyDecompressionInfos();
 }
 
 template<bool UseMigrationProtocol>
@@ -3023,6 +3129,13 @@ template<bool UseMigrationProtocol>
 void TDeferredActions<UseMigrationProtocol>::SignalWaiters() {
     for (auto& w : Waiters) {
         w.Signal();
+    }
+}
+
+template<bool UseMigrationProtocol>
+void TDeferredActions<UseMigrationProtocol>::DestroyDecompressionInfos() {
+    for (const auto& info : DecompressionInfos) {
+        info->Cleanup();
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -2878,7 +2878,7 @@ void TDataDecompressionInfo<UseMigrationProtocol>::OnDataDecompressed(i64 source
     if (auto session = CbContext->LockShared()) {
         // TODO (ildar-khisam@): distribute total ServerBytesSize in proportion of source size
         // Use CompressedDataSize, sourceSize, ServerBytesSize
-        session->OnDataDecompressed(sourceSize, estimatedDecompressedSize, decompressedSize, messagesCount, std::exchange(ServerBytesSize, 0));
+        session->OnDataDecompressed(sourceSize, estimatedDecompressedSize, decompressedSize, messagesCount, ServerBytesSize.exchange(0));
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -202,29 +202,35 @@ template<bool UseMigrationProtocol>
 void TRawPartitionStreamEventQueue<UseMigrationProtocol>::DeleteNotReadyTail(TDeferredActions<UseMigrationProtocol>& deferred)
 {
     std::deque<TRawPartitionStreamEvent<UseMigrationProtocol>> ready;
-
-    auto i = NotReady.begin();
-    for (; i != NotReady.end(); ++i) {
-        if (!i->IsReady()) {
-            // Cancel inflight decompression tasks if any
-            if (!i->IsDataEvent() || i->GetDataEvent().SetAbandoned()) {
-                break;
-            }
-            // Message was decompressed and become ready
-        }
-
-        ready.push_back(std::move(*i));
-    }
-
     std::vector<TDataDecompressionInfoPtr<UseMigrationProtocol>> infos;
+    TUserRetrievedEventsInfoAccumulator<UseMigrationProtocol> accumulator;
 
-    for (; i != NotReady.end(); ++i) {
-        if (i->IsDataEvent()) {
-            infos.push_back(i->GetDataEvent().GetParent());
+    bool hasNonReadyEvents = false;
+    for (auto& event : NotReady) {
+        const bool isDataEvent = event.IsDataEvent();
+
+        if (event.IsReady() ||
+            (isDataEvent && !event.GetDataEvent().SetAbandoned()) // Try to cancel inflight decompression tasks if any (returns true if message was decompressed and become ready)
+        ) {
+            if (!hasNonReadyEvents) {
+                // Continue ready events prefix
+                ready.push_back(std::move(event));
+            } else if (isDataEvent) {
+                // We should release memory for this ready event here
+                accumulator.Add(event.GetDataEvent().GetParent(), event.GetDataEvent().GetDataSize());
+            }
+        } else {
+            hasNonReadyEvents = true;
+
+            if (isDataEvent) {
+                // We should release memory for non ready data events and cancel decompression tasks
+                infos.push_back(event.GetDataEvent().GetParent());
+            }
         }
     }
 
     deferred.DeferDestroyDecompressionInfos(std::move(infos));
+    accumulator.OnUserRetrievedEvent();
 
     swap(ready, NotReady);
 }
@@ -1954,7 +1960,7 @@ bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::AllParentSessionsHasBe
 template<bool UseMigrationProtocol>
 void TSingleClusterReadSessionImpl<UseMigrationProtocol>::SelfCheck() {
     const auto delta = TInstant::Now() - LastActiveTime;
-    if (delta < TDuration::Minutes(1)) {
+    if (delta < TDuration::Seconds(30)) {
         // Session ok, we got at least one event from server since last 1 minute
         return;
     }
@@ -1971,16 +1977,21 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::SelfCheck() {
     }
 
     ui64 readyEventsCount = 0;
+    ui64 amountEvents = 0;
     std::unordered_set<ui64> handledPartitionStreams;
     for (const auto& [assignId, stream] : PartitionStreams) {
         handledPartitionStreams.emplace(assignId);
-        readyEventsCount += stream->GetReadyEventsCount();
+        readyEventsCount += stream->GetReadyEventAmount();
+        amountEvents += stream->GetEventAmount();
     }
 
     // Some streams may have some ready events after finish
+    ui64 notStartedTasks = 0;
     for (const auto& decompressionItem : DecompressionQueue) {
         if (const auto& stream = *decompressionItem.PartitionStream; handledPartitionStreams.emplace(stream.GetAssignId()).second) {
-            readyEventsCount += stream.GetReadyEventsCount();
+            readyEventsCount += stream.GetReadyEventAmount();
+            amountEvents += stream.GetEventAmount();
+            notStartedTasks += decompressionItem.BatchInfo->GetNotStartedTasksCunt();
         }
     }
 
@@ -1990,7 +2001,20 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::SelfCheck() {
     }
 
     // No read from server inflight, no ready events and no decompression tasks inflight => most likely hanging
-    LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "[SelfCheck] There is no ready events / inflight decompression since last: " << delta << ", most likely hanged after stop by back pressure");
+    LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix()
+        << "[SelfCheck] There is no ready events / inflight decompression since last: " << delta
+        << ", most likely hung after stop by back pressure. Session state: "
+        << "grpc connection alive: " << (Processor ? "yes" : "no")
+        << ", waiting grpc reconnect: " << (ConnectDelayContext && !ConnectDelayContext->IsCancelled() ? "yes" : "no")
+        << ", reconnect attempts done: " << ConnectionAttemptsDone
+        << ", pending decompression batches: " << DecompressionQueue.size()
+        << ", not ready data events: " << amountEvents
+        << ", alive partition streams: " << PartitionStreams.size()
+        << ", unhandled compressed data size: " << CompressedDataSize
+        << ", unhandled decompressed data size: " << DecompressedDataSize
+        << ", avg compression ratio: " << AverageCompressionRatio
+        << ", free memory to request: " << ReadSizeServerDelta
+        << ", not started tasks after reconnect: " << notStartedTasks);
 }
 
 template<bool UseMigrationProtocol>
@@ -2582,11 +2606,16 @@ void TDataDecompressionInfo<UseMigrationProtocol>::Cleanup() {
     auto session = CbContext->LockShared();
     Y_ASSERT(session);
 
+    ui64 sourceSize = 0;
+    ui64 messagesCount = 0;
     while (!Tasks.empty()) {
         const auto& task = Tasks.front();
-        OnTaskCanceled(task.AddedDataSize(), task.AddedMessagesCount());
+        sourceSize += task.AddedDataSize();
+        messagesCount += task.AddedMessagesCount();
         Tasks.pop_front();
     }
+
+    OnTaskCanceled(sourceSize, messagesCount);
 }
 
 template<bool UseMigrationProtocol>
@@ -2833,6 +2862,11 @@ void TDataDecompressionEvent<UseMigrationProtocol>::TakeData(TIntrusivePtr<TPart
                                         << "Take Data. Partition " << partitionStream->GetPartitionId()
                                         << ". Read: {" << Batch << ", " << Message << "} ("
                                         << minOffset << "-" << maxOffset << ")");
+}
+
+template<bool UseMigrationProtocol>
+size_t TDataDecompressionEvent<UseMigrationProtocol>::GetDataSize() const {
+    return Parent->GetServerMessage().batches(Batch).message_data(Message).data().size();
 }
 
 template<bool UseMigrationProtocol>

--- a/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
@@ -380,15 +380,15 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
 
     Y_UNIT_TEST(ReadWithRestartsAndLargeData) {
         TTopicSdkTestSetup setup(TEST_CASE_NAME);
-        auto compressor = std::make_shared<TSyncExecutor>();
+        auto compressor = new TSyncExecutor();
         auto decompressor = CreateThreadPoolManagedExecutor(1);
 
         TReadSessionSettings readSettings;
         readSettings
-            .ConsumerName(setup.GetConsumerName())
+        .ConsumerName(TEST_CONSUMER)
             .MaxMemoryUsageBytes(1_MB)
             .DecompressionExecutor(decompressor)
-            .AppendTopics(setup.GetTopicPath())
+            .AppendTopics(TEST_TOPIC)
             // .DirectRead(EnableDirectRead)
             ;
 

--- a/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
@@ -67,7 +67,7 @@ void WriteAndReadToEndWithRestarts(TReadSessionSettings readSettings, TWriteSess
         WaitPlannedTasks(e, n);
         size_t completed = e->GetExecutedCount();
 
-        setup.GetServer().KillTopicPqrbTablet(JoinPath({"/Root", setup.GetTopicPath()}));
+        setup.GetServer().KillTopicPqrbTablet(setup.GetTopicPath());
         Sleep(TDuration::MilliSeconds(100));
 
         e->StartFuncs(tasks);

--- a/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/basic_usage_ut.cpp
@@ -22,7 +22,9 @@
 
 namespace NYdb::NTopic::NTests {
 
-void WriteAndReadToEndWithRestarts(TReadSessionSettings readSettings, TWriteSessionSettings writeSettings, const std::string& message, ui32 count, TTopicSdkTestSetup& setup, TIntrusivePtr<TManagedExecutor> decompressor) {
+void WriteAndReadToEndWithRestarts(TReadSessionSettings readSettings, TWriteSessionSettings writeSettings, const std::string& message,
+    ui32 count, TTopicSdkTestSetup& setup, TIntrusivePtr<TManagedExecutor> decompressor, ui32 restartPeriod = 7, ui32 maxRestartsCount = 10)
+{
     auto client = setup.MakeClient();
     auto session = client.CreateSimpleBlockingWriteSession(writeSettings);
 
@@ -37,10 +39,11 @@ void WriteAndReadToEndWithRestarts(TReadSessionSettings readSettings, TWriteSess
 
     TTopicClient topicClient = setup.MakeClient();
 
-
-    auto WaitTasks = [&](auto f, size_t c) {
+    auto WaitTasks = [&, timeout = TInstant::Now() + TDuration::Seconds(60)](auto f, size_t c) {
         while (f() < c) {
             Sleep(TDuration::MilliSeconds(100));
+            UNIT_ASSERT(timeout > TInstant::Now());
+            ReadSession->WaitEvent();
         };
     };
     auto WaitPlannedTasks = [&](auto e, size_t count) {
@@ -64,7 +67,7 @@ void WriteAndReadToEndWithRestarts(TReadSessionSettings readSettings, TWriteSess
         WaitPlannedTasks(e, n);
         size_t completed = e->GetExecutedCount();
 
-        setup.GetServer().KillTopicPqrbTablet(setup.GetTopicPath());
+        setup.GetServer().KillTopicPqrbTablet(JoinPath({"/Root", setup.GetTopicPath()}));
         Sleep(TDuration::MilliSeconds(100));
 
         e->StartFuncs(tasks);
@@ -86,9 +89,17 @@ void WriteAndReadToEndWithRestarts(TReadSessionSettings readSettings, TWriteSess
 
     ReadSession = topicClient.CreateReadSession(readSettings);
 
+    Cerr << ">>> TEST: start reading" << Endl;
+
     ui32 i = 0;
+    ui32 restartCount = 0;
     while (AtomicGet(lastOffset) + 1 < count) {
-        RunTasks(decompressor, {i++});
+        if (restartCount < maxRestartsCount && i % restartPeriod == 1) {
+            PlanTasksAndRestart(decompressor, {i++});
+            restartCount++;
+        } else {
+            RunTasks(decompressor, {i++});
+        }
     }
 
     ReadSession->Close(TDuration::MilliSeconds(10));
@@ -363,6 +374,32 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
 
         ui32 count = 700;
         std::string message(2'000, 'x');
+
+        WriteAndReadToEndWithRestarts(readSettings, writeSettings, message, count, setup, decompressor);
+    }
+
+    Y_UNIT_TEST(ReadWithRestartsAndLargeData) {
+        TTopicSdkTestSetup setup(TEST_CASE_NAME);
+        auto compressor = std::make_shared<TSyncExecutor>();
+        auto decompressor = CreateThreadPoolManagedExecutor(1);
+
+        TReadSessionSettings readSettings;
+        readSettings
+            .ConsumerName(setup.GetConsumerName())
+            .MaxMemoryUsageBytes(1_MB)
+            .DecompressionExecutor(decompressor)
+            .AppendTopics(setup.GetTopicPath())
+            // .DirectRead(EnableDirectRead)
+            ;
+
+        TWriteSessionSettings writeSettings;
+        writeSettings
+            .Path(setup.GetTopicPath()).MessageGroupId(TEST_MESSAGE_GROUP_ID)
+            .Codec(ECodec::RAW)
+            .CompressionExecutor(compressor);
+
+            ui32 count = 3000;
+        std::string message(8'000, 'x');
 
         WriteAndReadToEndWithRestarts(readSettings, writeSettings, message, count, setup, decompressor);
     }

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/managed_executor.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/managed_executor.cpp
@@ -52,6 +52,7 @@ void TManagedExecutor::StartFuncs(const std::vector<size_t>& indicies)
             Y_ABORT_UNLESS(Funcs[index]);
 
             RunTask(std::move(Funcs[index]));
+            Funcs[index] = nullptr;
         }
     }
 }
@@ -84,6 +85,7 @@ void TManagedExecutor::RunAllTasks()
         for (auto& func : Funcs) {
             if (func) {
                 RunTask(std::move(func));
+                func = nullptr;
             }
         }
     }

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.cpp
@@ -1,13 +1,52 @@
 #include "topic_sdk_test_setup.h"
 
+#include <ydb/core/base/backtrace.h>
+
 using namespace NYdb;
 using namespace NYdb::NTopic;
 using namespace NYdb::NTopic::NTests;
+
+namespace {
+
+void TerminateHandler() {
+    Cerr << "======= terminate() call stack ========" << Endl;
+    FormatBackTrace(&Cerr);
+    if (const auto& backtrace = TBackTrace::FromCurrentException(); backtrace.size() > 0) {
+        Cerr << "======== exception call stack =========" << Endl;
+        backtrace.PrintTo(Cerr);
+    }
+    Cerr << "=======================================" << Endl;
+
+    if (std::current_exception()) {
+        Cerr << "Uncaught exception: " << CurrentExceptionMessage() << Endl;
+    } else {
+        Cerr << "Terminate for unknown reason (no current exception)" << Endl;
+    }
+
+    abort();
+}
+
+void BackTraceSignalHandler(int signal) {
+    Cerr << "======= Signal " << signal << " call stack ========" << Endl;
+    FormatBackTrace(&Cerr);
+    Cerr << "===============================================" << Endl;
+
+    abort();
+}
+
+} // anonymous namespace
 
 TTopicSdkTestSetup::TTopicSdkTestSetup(const TString& testCaseName, const NKikimr::Tests::TServerSettings& settings, bool createTopic)
     : Database("/Root")
     , Server(settings, false)
 {
+    NKikimr::EnableYDBBacktraceFormat();
+
+    std::set_terminate(&TerminateHandler);
+    for (auto sig : {SIGFPE, SIGILL, SIGSEGV}) {
+        signal(sig, &BackTraceSignalHandler);
+    }
+
     Log.SetFormatter([testCaseName](ELogPriority priority, TStringBuf message) {
         return TStringBuilder() << TInstant::Now() << " :" << testCaseName << " " << priority << ": " << message << Endl;
     });

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/ya.make
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
     ydb/library/grpc/server
     library/cpp/testing/unittest
     library/cpp/threading/chunk_queue
+    ydb/core/base
     ydb/core/testlib/default
     ydb/public/sdk/cpp/src/library/persqueue/topic_parser_public
     ydb/public/sdk/cpp/src/client/driver


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed partition reading hanging in topic sdk

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Bugfix ticket: https://st.yandex-team.ru/LOGBROKER-7430
