### PR TITLE
Suppress TSAN data race in grpcio PollerCompletionQueue

### DIFF
--- a/ydb/tests/tsan.supp
+++ b/ydb/tests/tsan.supp
@@ -1,2 +1,7 @@
 # see https://github.com/ydb-platform/ydb/issues/34930
 race:free_threadstate
+
+# see https://github.com/ydb-platform/ydb/issues/34938
+# Data race in grpcio PollerCompletionQueue: _poll (worker thread) vs shutdown (main thread during finalization).
+# The race is inside the grpcio Cython code, not in YDB.
+race:PollerCompletionQueue


### PR DESCRIPTION
## Changelog entry

Suppress known TSAN false-positive data race in grpcio `PollerCompletionQueue` for Python tests. 

**Category:** Bugfix

## Description

Added a TSAN suppression for a data race inside `grpcio` Cython code (`PollerCompletionQueue._poll` vs `PollerCompletionQueue.shutdown`). The race occurs during Python interpreter finalization when the GC deallocates `AioChannel`, triggering `shutdown` while a worker thread is still polling. This is entirely within `grpcio` internals, not in YDB code.

Closes #34938