### PR TITLE
Fix uaf in ydb-over-fq

### DIFF
--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -793,21 +793,21 @@ private:
     NYql::TIssueManager IssueManager_;
 };
 
-inline TMaybe<TString> ToMaybe(const TVector<TStringBuf>& vec) {
+inline TMaybe<TString> ToMaybe(const TVector<TString>& vec) {
     if (vec.empty()) {
         return {};
     }
     return TString{vec[0]};
 }
 
-inline const TMaybe<TString> ExtractYdbToken(const TVector<TStringBuf>& authHeadValues) {
+inline const TMaybe<TString> ExtractYdbToken(const TVector<TString>& authHeadValues) {
     if (authHeadValues.empty()) {
         return {};
     }
     return TString{authHeadValues[0]};
 }
 
-inline const TMaybe<TString> ExtractDatabaseName(const TVector<TStringBuf>& dbHeaderValues) {
+inline const TMaybe<TString> ExtractDatabaseName(const TVector<TString>& dbHeaderValues) {
     if (dbHeaderValues.empty()) {
         return {};
     }

--- a/ydb/core/grpc_services/local_grpc/local_grpc.h
+++ b/ydb/core/grpc_services/local_grpc/local_grpc.h
@@ -38,7 +38,7 @@ public:
         return {};
     }
 
-    TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const override {
+    TVector<TString> GetPeerMetaValues(TStringBuf key) const override {
         auto value = BaseRequest_->GetPeerMetaValues(TString{key});
         if (value) {
             return {std::move(*value)};

--- a/ydb/core/grpc_services/local_rpc/local_rpc_bi_streaming.h
+++ b/ydb/core/grpc_services/local_rpc/local_rpc_bi_streaming.h
@@ -168,25 +168,25 @@ public:
         return PeerName;
     }
 
-    TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const override {
+    TVector<TString> GetPeerMetaValues(TStringBuf key) const override {
         if (key == NYdb::YDB_DATABASE_HEADER) {
-            return {TStringBuf(Database)};
+            return {Database};
         }
         if (key == NYdb::YDB_AUTH_TICKET_HEADER) {
-            return Token ? TVector{TStringBuf(*Token)} : TVector<TStringBuf>();
+            return Token ? TVector{*Token} : TVector<TString>();
         }
         if (key == NYdb::YDB_REQUEST_TYPE_HEADER) {
-            return RequestType ? TVector{TStringBuf(*RequestType)} : TVector<TStringBuf>();
+            return RequestType ? TVector{*RequestType} : TVector<TString>();
         }
         if (key == NYdb::YDB_TRACE_ID_HEADER) {
-            return TraceId ? TVector{TStringBuf(TraceId)} : TVector<TStringBuf>();
+            return TraceId ? TVector{TraceId} : TVector<TString>();
         }
         if (key == NYdb::OTEL_TRACE_HEADER) {
-            return ParentTraceId ? TVector{TStringBuf(ParentTraceId)} : TVector<TStringBuf>();
+            return ParentTraceId ? TVector{ParentTraceId} : TVector<TString>();
         }
 
         const auto it = PeerMeta.find(TString(key));
-        return it != PeerMeta.end() ? TVector{TStringBuf(it->second)} : TVector<TStringBuf>();
+        return it != PeerMeta.end() ? TVector{it->second} : TVector<TString>();
     }
 
     void PutPeerMeta(const TString& key, const TString& value) {

--- a/ydb/core/grpc_services/ydb_over_fq/fq_local_grpc_events.h
+++ b/ydb/core/grpc_services/ydb_over_fq/fq_local_grpc_events.h
@@ -20,7 +20,7 @@ public:
         , Scope_{"yandexcloud:/" + TBase::GetBaseRequest().GetDatabaseName().GetOrElse("/")}
     {}
 
-    TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const override {
+    TVector<TString> GetPeerMetaValues(TStringBuf key) const override {
         if (key == "x-ydb-fq-project") {
             return {Scope_};
         }

--- a/ydb/core/grpc_streaming/grpc_streaming.h
+++ b/ydb/core/grpc_streaming/grpc_streaming.h
@@ -75,7 +75,7 @@ public:
 
     virtual NYdbGrpc::TAuthState& GetAuthState() const = 0;
     virtual TString GetPeerName() const = 0;
-    virtual TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const = 0;
+    virtual TVector<TString> GetPeerMetaValues(TStringBuf key) const = 0;
     virtual grpc_compression_level GetCompressionLevel() const = 0;
     virtual void UseDatabase(const TString& database) = 0;
     virtual TString GetRpcMethodName() const = 0;
@@ -656,7 +656,7 @@ private:
             return Self->GetPeer();
         }
 
-        TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const override {
+        TVector<TString> GetPeerMetaValues(TStringBuf key) const override {
             return Self->GetPeerMetaValues(key);
         }
 

--- a/ydb/core/public_http/grpc_request_context_wrapper.cpp
+++ b/ydb/core/public_http/grpc_request_context_wrapper.cpp
@@ -56,7 +56,7 @@ namespace NKikimr::NPublicHttp {
         return {};
     }
 
-    TVector<TStringBuf> TGrpcRequestContextWrapper::GetPeerMetaValues(TStringBuf key) const {
+    TVector<TString> TGrpcRequestContextWrapper::GetPeerMetaValues(TStringBuf key) const {
         if (key == "x-ydb-database"sv) {
             return { RequestContext.GetDb() };
         }

--- a/ydb/core/public_http/grpc_request_context_wrapper.h
+++ b/ydb/core/public_http/grpc_request_context_wrapper.h
@@ -31,7 +31,7 @@ public:
     virtual void ReplyError(grpc::StatusCode code, const TString& msg, const TString& details);
     virtual TInstant Deadline() const;
     virtual TSet<TStringBuf> GetPeerMetaKeys() const;
-    virtual TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const;
+    virtual TVector<TString> GetPeerMetaValues(TStringBuf key) const;
     virtual TVector<TStringBuf> FindClientCert() const {return {};}
     virtual grpc_compression_level GetCompressionLevel() const { return GRPC_COMPRESS_LEVEL_NONE; }
     virtual TString GetEndpointId() const;

--- a/ydb/library/grpc/server/grpc_async_ctx_base.h
+++ b/ydb/library/grpc/server/grpc_async_ctx_base.h
@@ -58,14 +58,14 @@ public:
         return keys;
     }
 
-    TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const {
+    TVector<TString> GetPeerMetaValues(TStringBuf key) const {
         const auto& clientMetadata = Context.client_metadata();
         const auto range = clientMetadata.equal_range(grpc::string_ref{key.data(), key.size()});
         if (range.first == range.second) {
             return {};
         }
 
-        TVector<TStringBuf> values;
+        TVector<TString> values;
         values.reserve(std::distance(range.first, range.second));
 
         for (auto it = range.first; it != range.second; ++it) {

--- a/ydb/library/grpc/server/grpc_request.h
+++ b/ydb/library/grpc/server/grpc_request.h
@@ -180,7 +180,7 @@ public:
         return TBaseAsyncContext<TService>::GetPeerMetaKeys();
     }
 
-    TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const override {
+    TVector<TString> GetPeerMetaValues(TStringBuf key) const override {
         return TBaseAsyncContext<TService>::GetPeerMetaValues(key);
     }
 

--- a/ydb/library/grpc/server/grpc_request_base.h
+++ b/ydb/library/grpc/server/grpc_request_base.h
@@ -84,7 +84,7 @@ public:
     virtual TSet<TStringBuf> GetPeerMetaKeys() const = 0;
 
     //! Returns peer optional metavalue
-    virtual TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const = 0;
+    virtual TVector<TString> GetPeerMetaValues(TStringBuf key) const = 0;
 
     virtual TVector<TStringBuf> FindClientCert() const = 0;
 

--- a/ydb/tests/fq/s3/test_ydb_over_fq.py
+++ b/ydb/tests/fq/s3/test_ydb_over_fq.py
@@ -366,6 +366,7 @@ class TestYdbOverFq(TestYdsBase):
     @yq_all
     @pytest.mark.parametrize("client", [{"folder_id": "my_folder"}], indirect=True)
     def test_insert_data_query(self, kikimr, s3, client, unique_prefix, yq_version):
+        self.make_s3_client(s3)  # makes bucket
         kikimr.control_plane.wait_bootstrap()
         connection_id = client.create_storage_connection(unique_prefix + "fruitbucket", "fbucket").result.connection_id
         bind_name = unique_prefix + "fruits_bind"


### PR DESCRIPTION
In some places, `TMaybe<TString> ` extracted to temporary value and then `TVector<TStringBuf>` returned.
Use TString instead of TStringBuf
Closes: #34939

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

~~TODO~~: there are users of GetPeerMetaValues in arcadia, change needs verification;
Affects only yf, fix will need to be cherry-picked into gh->arc sync
