### PR TITLE
Prefix Bloom filter

### DIFF
--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -975,16 +975,24 @@ public:
                 if (!metadata->Indexes.empty() || !sequences.empty()) {
                     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateIndexedTable);
                     tableDesc = schemeTx.MutableCreateIndexedTable()->MutableTableDescription();
+                    TSet<ui32> bloomPrefixes;
                     for (auto&& index : metadata->Indexes) {
                         const bool isLocalBloom = (index.Type == TIndexDescription::EType::LocalBloomFilter ||
                                     index.Type == TIndexDescription::EType::LocalBloomNgramFilter);
 
                         if (isLocalBloom) {
-                            if (metadata->StoreType != EStoreType::Column) {
-                                tablePromise.SetValue(ResultFromError<TGenericResult>("Local bloom indexes are supported only for column tables"));
+                            if (index.Type == TIndexDescription::EType::LocalBloomNgramFilter &&
+                                metadata->StoreType != EStoreType::Column) {
+                                tablePromise.SetValue(ResultFromError<TGenericResult>("Local bloom ngram indexes are supported only for column tables"));
                                 return;
                             }
 
+                            if (metadata->StoreType == EStoreType::Column) {
+                                continue; // handled by OLAP path below
+                            }
+
+                            // Row-store LocalBloomFilter: collect prefix lengths for de-duplication
+                            bloomPrefixes.insert(static_cast<ui32>(index.KeyColumns.size()));
                             continue;
                         }
 
@@ -1016,6 +1024,9 @@ public:
                             default:
                                 break;
                         }
+                    }
+                    for (ui32 prefix : bloomPrefixes) {
+                        tableDesc->MutablePartitionConfig()->AddByKeyFilterPrefixes(prefix);
                     }
                     if (!FillCreateTableColumnDesc(*tableDesc, pathPair.second, metadata, columnError)) {
                         tablePromise.SetValue(ResultFromError<TGenericResult>(columnError));

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -1182,11 +1182,10 @@ private:
                 YQL_ENSURE(false, "Unknown index type: " << type);
             }
 
-            if ((indexType == TIndexDescription::EType::LocalBloomFilter ||
-                 indexType == TIndexDescription::EType::LocalBloomNgramFilter) &&
+            if (indexType == TIndexDescription::EType::LocalBloomNgramFilter &&
                 meta->StoreType != EStoreType::Column) {
                 ctx.AddError(TIssue(ctx.GetPosition(index.Pos()),
-                    "Local bloom indexes are supported only for column tables"));
+                    "Local bloom ngram indexes are supported only for column tables"));
                 return TStatus::Error;
             }
 
@@ -1297,10 +1296,39 @@ private:
                     break;
                 }
                 case TIndexDescription::EType::LocalBloomFilter:
-                    if (indexColums.size() != 1 || !dataColums.empty()) {
+                    if (!dataColums.empty()) {
                         ctx.AddError(TIssue(ctx.GetPosition(index.Pos()),
-                            "Local bloom index requires exactly one index column and does not support data columns"));
+                            "Local bloom index does not support data columns"));
                         return IGraphTransformer::TStatus::Error;
+                    }
+                    if (meta->StoreType == EStoreType::Column) {
+                        // Column-store: keep existing restriction of exactly 1 column
+                        if (indexColums.size() != 1) {
+                            ctx.AddError(TIssue(ctx.GetPosition(index.Pos()),
+                                "Local bloom index on column tables requires exactly one index column"));
+                            return IGraphTransformer::TStatus::Error;
+                        }
+                    } else {
+                        // Row-store: columns must be a left-prefix of PK
+                        if (indexColums.empty()) {
+                            ctx.AddError(TIssue(ctx.GetPosition(index.Pos()),
+                                "Local bloom index requires at least one PK prefix column"));
+                            return IGraphTransformer::TStatus::Error;
+                        }
+                        if (indexColums.size() > meta->KeyColumnNames.size()) {
+                            ctx.AddError(TIssue(ctx.GetPosition(index.Pos()),
+                                "Bloom filter prefix columns exceed the number of primary key columns"));
+                            return IGraphTransformer::TStatus::Error;
+                        }
+                        for (size_t i = 0; i < indexColums.size(); ++i) {
+                            if (indexColums[i] != meta->KeyColumnNames[i]) {
+                                ctx.AddError(TIssue(ctx.GetPosition(index.Pos()), TStringBuilder()
+                                    << "Bloom filter column '" << indexColums[i]
+                                    << "' does not match PK column '" << meta->KeyColumnNames[i]
+                                    << "' at position " << i));
+                                return IGraphTransformer::TStatus::Error;
+                            }
+                        }
                     }
 
                     specializedIndexDescription = std::move(localBloomFilterDescription);

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -208,6 +208,7 @@ message TPartitionConfig {
     repeated NKikimrHive.TFollowerGroup FollowerGroups = 23;
     reserved 24; // EMvccState MvccState = 24; no longer used
     optional uint64 KeepSnapshotTimeout = 25; // milliseconds
+    repeated uint32 ByKeyFilterPrefixes = 26; // Build per-part bloom filters on PK prefixes of these lengths (number of leading key columns)
 }
 
 message TSplitBoundary {

--- a/ydb/core/protos/scheme_log.proto
+++ b/ydb/core/protos/scheme_log.proto
@@ -64,6 +64,7 @@ message TAlterRecord {
     optional bytes Default = 10;    // Serialized default value for cell
     optional bool NotNull = 24 [default = false];
     optional bool IsSensitive = 28 [default = false];
+    repeated uint32 ByKeyFilterPrefixes = 29; // Prefix bloom filter column counts (number of leading PK columns)
 
     optional uint64 ExecutorCacheSize = 100;
     optional NKikimrCompaction.TCompactionPolicy CompactionPolicy = 101;

--- a/ydb/core/tablet_flat/flat_bloom_writer.h
+++ b/ydb/core/tablet_flat/flat_bloom_writer.h
@@ -21,6 +21,7 @@ namespace NBloom {
         virtual void Reset() = 0;
         virtual ui64 EstimateBytesUsed(size_t extraItems) const = 0;
         virtual void Add(TArrayRef<const TCell> row) = 0;
+        virtual void Add(THashRoot root) = 0;
         virtual TSharedData Make() = 0;
     };
 
@@ -105,7 +106,7 @@ namespace NBloom {
             return Raw.size();
         }
 
-        void Add(THashRoot root)
+        void Add(THashRoot root) override
         {
             THash hash(root);
 
@@ -158,10 +159,15 @@ namespace NBloom {
             return sizeof(NPage::TLabel) + sizeof(THeader) + array;
         }
 
+        void Add(THashRoot root) override
+        {
+            Roots.push_back(root);
+        }
+
         void Add(TArrayRef<const TCell> row) override
         {
             const TPrefix prefix(row);
-            Roots.push_back(THash::Root(prefix.Get(row.size())));
+            Add(THash::Root(prefix.Get(row.size())));
         }
 
         TSharedData Make() override

--- a/ydb/core/tablet_flat/flat_dbase_apply.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_apply.cpp
@@ -148,8 +148,33 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
         auto &tableInfo = *Table(table);
 
         if (delta.HasByKeyFilter()) {
-            bool enabled = delta.GetByKeyFilter();
-            changes |= ChangeTableSetting(table, tableInfo.ByKeyFilter, enabled);
+            // Legacy: convert ByKeyFilter bool to a prefix entry for full key
+            ui32 keyCount = tableInfo.KeyColumns.size();
+            TVector<ui32> prefixes = tableInfo.ByKeyFilterPrefixes;
+            if (delta.GetByKeyFilter()) {
+                if (std::find(prefixes.begin(), prefixes.end(), keyCount) == prefixes.end()) {
+                    prefixes.push_back(keyCount);
+                    Sort(prefixes);
+                }
+            } else {
+                auto it = std::find(prefixes.begin(), prefixes.end(), keyCount);
+                if (it != prefixes.end()) {
+                    prefixes.erase(it);
+                }
+            }
+            changes |= ChangeTableSetting(table, tableInfo.ByKeyFilterPrefixes, prefixes);
+        }
+
+        if (delta.ByKeyFilterPrefixesSize() > 0) {
+            TVector<ui32> prefixes;
+            for (auto p : delta.GetByKeyFilterPrefixes()) {
+                if (p > 0) {
+                    prefixes.push_back(p);
+                }
+            }
+            SortUnique(prefixes);
+            // A single 0 entry means "clear all", resulting in empty vector
+            changes |= ChangeTableSetting(table, tableInfo.ByKeyFilterPrefixes, prefixes);
         }
 
         if (delta.HasEraseCacheEnabled()) {

--- a/ydb/core/tablet_flat/flat_dbase_apply.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_apply.cpp
@@ -152,13 +152,13 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
             ui32 keyCount = tableInfo.KeyColumns.size();
             TVector<ui32> prefixes = tableInfo.ByKeyFilterPrefixes;
             if (delta.GetByKeyFilter()) {
-                if (std::find(prefixes.begin(), prefixes.end(), keyCount) == prefixes.end()) {
-                    prefixes.push_back(keyCount);
-                    Sort(prefixes);
+                auto it = std::lower_bound(prefixes.begin(), prefixes.end(), keyCount);
+                if (it == prefixes.end() || *it != keyCount) {
+                    prefixes.insert(it, keyCount);
                 }
             } else {
-                auto it = std::find(prefixes.begin(), prefixes.end(), keyCount);
-                if (it != prefixes.end()) {
+                auto it = std::lower_bound(prefixes.begin(), prefixes.end(), keyCount);
+                if (it != prefixes.end() && *it == keyCount) {
                     prefixes.erase(it);
                 }
             }
@@ -166,9 +166,12 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
         }
 
         if (delta.ByKeyFilterPrefixesSize() > 0) {
+            ui32 keyCount = tableInfo.KeyColumns.size();
             TVector<ui32> prefixes;
             for (auto p : delta.GetByKeyFilterPrefixes()) {
                 if (p > 0) {
+                    Y_ENSURE(p <= keyCount,
+                        "Bloom filter prefix " << p << " exceeds key column count " << keyCount);
                     prefixes.push_back(p);
                 }
             }

--- a/ydb/core/tablet_flat/flat_dbase_scheme.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.cpp
@@ -72,7 +72,7 @@ TAutoPtr<TSchemeChanges> TScheme::GetSnapshot() const {
                 itTable.second.EraseCacheMaxBytes);
 
         // N.B. must be last for compatibility with older versions :(
-        delta.SetByKeyFilter(table, itTable.second.ByKeyFilter);
+        delta.SetByKeyFilterPrefixes(table, itTable.second.ByKeyFilterPrefixes);
         delta.SetColdBorrow(table, itTable.second.ColdBorrow);
     }
 
@@ -341,12 +341,20 @@ TAlter& TAlter::SetCompactionPolicy(ui32 tableId, const TCompactionPolicy& newPo
     return ApplyLastRecord();
 }
 
-TAlter& TAlter::SetByKeyFilter(ui32 tableId, bool enabled)
+TAlter& TAlter::SetByKeyFilterPrefixes(ui32 tableId, const TVector<ui32>& prefixes)
 {
     TAlterRecord &delta = *Log.AddDelta();
     delta.SetDeltaType(TAlterRecord::SetTable);
     delta.SetTableId(tableId);
-    delta.SetByKeyFilter(enabled ? 1 : 0);
+    if (prefixes.empty()) {
+        // Sentinel: a single 0 entry means "clear all prefix bloom filters"
+        delta.AddByKeyFilterPrefixes(0);
+    } else {
+        for (ui32 p : prefixes) {
+            Y_ENSURE(p > 0, "Prefix length must be positive");
+            delta.AddByKeyFilterPrefixes(p);
+        }
+    }
 
     return ApplyLastRecord();
 }

--- a/ydb/core/tablet_flat/flat_dbase_scheme.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.cpp
@@ -71,6 +71,18 @@ TAutoPtr<TSchemeChanges> TScheme::GetSnapshot() const {
                 itTable.second.EraseCacheMinRows,
                 itTable.second.EraseCacheMaxBytes);
 
+        // For backward compatibility: if full-key bloom filter is enabled,
+        // also set legacy ByKeyFilter=true so older versions understand it
+        bool hasFullKeyBloom = std::find(
+            itTable.second.ByKeyFilterPrefixes.begin(),
+            itTable.second.ByKeyFilterPrefixes.end(),
+            itTable.second.KeyColumns.size()
+        ) != itTable.second.ByKeyFilterPrefixes.end();
+
+        if (hasFullKeyBloom) {
+            delta.SetByKeyFilter(table, true);
+        }
+
         // N.B. must be last for compatibility with older versions :(
         delta.SetByKeyFilterPrefixes(table, itTable.second.ByKeyFilterPrefixes);
         delta.SetColdBorrow(table, itTable.second.ColdBorrow);
@@ -337,6 +349,16 @@ TAlter& TAlter::SetCompactionPolicy(ui32 tableId, const TCompactionPolicy& newPo
     delta.SetDeltaType(TAlterRecord::SetCompactionPolicy);
     delta.SetTableId(tableId);
     newPolicy.Serialize(*delta.MutableCompactionPolicy());
+
+    return ApplyLastRecord();
+}
+
+TAlter& TAlter::SetByKeyFilter(ui32 tableId, bool enabled)
+{
+    TAlterRecord &delta = *Log.AddDelta();
+    delta.SetDeltaType(TAlterRecord::SetTable);
+    delta.SetTableId(tableId);
+    delta.SetByKeyFilter(enabled ? 1 : 0);
 
     return ApplyLastRecord();
 }

--- a/ydb/core/tablet_flat/flat_dbase_scheme.h
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.h
@@ -83,7 +83,7 @@ public:
 
         TIntrusiveConstPtr<TCompactionPolicy> CompactionPolicy;
         bool ColdBorrow = false;
-        bool ByKeyFilter = false;
+        TVector<ui32> ByKeyFilterPrefixes; // Prefix column counts for bloom filters (full-key = keyColumnCount entry)
         bool EraseCacheEnabled = false;
         ui32 EraseCacheMinRows = 0; // 0 means use default
         ui32 EraseCacheMaxBytes = 0; // 0 means use default
@@ -248,7 +248,7 @@ public:
     TAlter& SetExecutorLimitInFlyTx(ui32 limitTxInFly);
     TAlter& SetExecutorResourceProfile(const TString &name);
     TAlter& SetCompactionPolicy(ui32 tableId, const TCompactionPolicy& newPolicy);
-    TAlter& SetByKeyFilter(ui32 tableId, bool enabled);
+    TAlter& SetByKeyFilterPrefixes(ui32 tableId, const TVector<ui32>& prefixes);
     TAlter& SetColdBorrow(ui32 tableId, bool enabled);
     TAlter& SetEraseCache(ui32 tableId, bool enabled, ui32 minRows, ui32 maxBytes);
     TAlter& SetRewrite();

--- a/ydb/core/tablet_flat/flat_dbase_scheme.h
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.h
@@ -248,6 +248,7 @@ public:
     TAlter& SetExecutorLimitInFlyTx(ui32 limitTxInFly);
     TAlter& SetExecutorResourceProfile(const TString &name);
     TAlter& SetCompactionPolicy(ui32 tableId, const TCompactionPolicy& newPolicy);
+    TAlter& SetByKeyFilter(ui32 tableId, bool enabled);
     TAlter& SetByKeyFilterPrefixes(ui32 tableId, const TVector<ui32>& prefixes);
     TAlter& SetColdBorrow(ui32 tableId, bool enabled);
     TAlter& SetEraseCache(ui32 tableId, bool enabled, ui32 minRows, ui32 maxBytes);

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -4823,10 +4823,15 @@ bool TExecutor::HasSchemaChanges(const NTable::TPartView& partView, const NTable
         return false;
     }
 
-    { // Check by key filter existence
-        bool partByKeyFilter = bool(partView->ByKey);
-        bool schemeByKeyFilter = tableInfo.ByKeyFilter;
-        if (partByKeyFilter != schemeByKeyFilter) {
+    { // Check bloom filters
+        TVector<ui32> partPrefixes;
+        for (const auto& [prefixLen, bloom] : partView->ByKeyPrefixes) {
+            if (bloom) partPrefixes.push_back(prefixLen);
+        }
+        Sort(partPrefixes);
+        auto schemePrefixes = tableInfo.ByKeyFilterPrefixes;
+        Sort(schemePrefixes);
+        if (partPrefixes != schemePrefixes) {
             return true;
         }
     }
@@ -4899,7 +4904,7 @@ ui64 TExecutor::BeginCompaction(THolder<NTable::TCompactionParams> params)
     comp->Layout.WriteFlatIndex = AppData()->FeatureFlags.GetEnableLocalDBFlatIndex();
     comp->Writer.StickyFlatIndex = !comp->Layout.WriteBTreeIndex;
     comp->Layout.MaxRows = snapshot->Subset->MaxRows();
-    comp->Layout.ByKeyFilter = tableInfo->ByKeyFilter;
+    comp->Layout.ByKeyFilterPrefixes = tableInfo->ByKeyFilterPrefixes;
     comp->Layout.UnderlayMask = comp->Params->UnderlayMask.Get();
     comp->Layout.SplitKeys = comp->Params->SplitKeys.Get();
     comp->Layout.MinRowVersion = snapshot->Subset->MinRowVersion();

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -4828,10 +4828,7 @@ bool TExecutor::HasSchemaChanges(const NTable::TPartView& partView, const NTable
         for (const auto& [prefixLen, bloom] : partView->ByKeyPrefixes) {
             if (bloom) partPrefixes.push_back(prefixLen);
         }
-        Sort(partPrefixes);
-        auto schemePrefixes = tableInfo.ByKeyFilterPrefixes;
-        Sort(schemePrefixes);
-        if (partPrefixes != schemePrefixes) {
+        if (partPrefixes != tableInfo.ByKeyFilterPrefixes) {
             return true;
         }
     }

--- a/ydb/core/tablet_flat/flat_page_conf.h
+++ b/ydb/core/tablet_flat/flat_page_conf.h
@@ -88,7 +88,7 @@ namespace NPage {
         ui32 MaxLargeBlob = 8 * 1024 * 1024 - 8; /* Maximum large blob size */
         ui32 LargeEdge = Max<ui32>();   /* External blob edge size      */
         ui32 SmallEdge = Max<ui32>();   /* Outer blobs edge bytes limit */
-        bool ByKeyFilter = false;       /* Per-part bloom filter        */
+        TVector<ui32> ByKeyFilterPrefixes; /* Bloom filters on PK prefixes of these lengths */
         ui64 MaxRows = 0;               /* Used to set up bloom filter size */
         ui64 SliceSize = Max<ui64>();   /* Data size for slice creation */
         ui64 MainPageCollectionEdge = Max<ui64>();

--- a/ydb/core/tablet_flat/flat_part_dump.cpp
+++ b/ydb/core/tablet_flat/flat_part_dump.cpp
@@ -46,7 +46,9 @@ namespace {
         if (auto *frames = part.Small.Get()) Frames(*frames, "Small");
         if (auto *frames = part.Large.Get()) Frames(*frames, "Large");
         if (auto *blobs = part.Blobs.Get())  Blobs(*blobs);
-        if (auto *bloom = part.ByKey.Get())  Bloom(*bloom);
+        for (const auto& [prefixLen, bloom] : part.ByKeyPrefixes) {
+            if (bloom) Bloom(*bloom);
+        }
 
         Index(part, depth);
         BTreeIndex(part);

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -63,6 +63,10 @@ void TLoader::StageParseMeta()
         LargeId = layout.HasLarge() ? layout.GetLarge() : LargeId;
         SmallId = layout.HasSmall() ? layout.GetSmall() : SmallId;
         ByKeyId = layout.HasByKey() ? layout.GetByKey() : ByKeyId;
+        ByKeyPrefixMetas.clear();
+        for (const auto& meta : layout.GetByKeyPrefixes()) {
+            ByKeyPrefixMetas.push_back({meta.GetPageId(), meta.GetPrefixColumns()});
+        }
         GarbageStatsId = layout.HasGarbageStats() ? layout.GetGarbageStats() : GarbageStatsId;
         TxIdStatsId = layout.HasTxIdStats() ? layout.GetTxIdStats() : TxIdStatsId;
 
@@ -184,6 +188,10 @@ TLoader::TFetch TLoader::StageCreatePartView(bool preloadIndex)
         getPage(pageId);
     }
 
+    for (const auto& meta : ByKeyPrefixMetas) {
+        getPage(meta.PageId);
+    }
+
     if (auto fetch = LoaderEnv->GetFetch()) {
         return fetch;
     }
@@ -230,14 +238,30 @@ TLoader::TFetch TLoader::StageCreatePartView(bool preloadIndex)
         }
     }
 
+    auto partScheme = TPartScheme::Parse(*scheme, Rooted);
+
+    TVector<std::pair<ui32, TIntrusiveConstPtr<NPage::TBloom>>> byKeyPrefixes;
+    // Convert legacy full-key bloom to a prefix entry
+    if (byKey) {
+        ui32 keyCount = partScheme->Groups[0].KeyTypes.size();
+        byKeyPrefixes.emplace_back(keyCount, new NPage::TBloom(*byKey));
+    }
+    for (const auto& meta : ByKeyPrefixMetas) {
+        if (meta.PageId != Max<TPageId>()) {
+            if (auto* page = getPage(meta.PageId)) {
+                byKeyPrefixes.emplace_back(meta.PrefixColumns, new NPage::TBloom(*page));
+            }
+        }
+    }
+
     auto *partStore = new TPartStore(
         PageCollections.front()->PageCollection->Label(),
         {
             epoch,
-            TPartScheme::Parse(*scheme, Rooted),
+            std::move(partScheme),
             { FlatGroupIndexes, FlatHistoricIndexes, BTreeGroupIndexes, BTreeHistoricIndexes },
             blobs ? new NPage::TExtBlobs(*blobs, extra) : nullptr,
-            byKey ? new NPage::TBloom(*byKey) : nullptr,
+            std::move(byKeyPrefixes),
             large ? new NPage::TFrames(*large) : nullptr,
             small ? new NPage::TFrames(*small) : nullptr,
             indexesRawSize,

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -241,16 +241,21 @@ TLoader::TFetch TLoader::StageCreatePartView(bool preloadIndex)
     auto partScheme = TPartScheme::Parse(*scheme, Rooted);
 
     TVector<std::pair<ui32, TIntrusiveConstPtr<NPage::TBloom>>> byKeyPrefixes;
-    // Convert legacy full-key bloom to a prefix entry
-    if (byKey) {
-        ui32 keyCount = partScheme->Groups[0].KeyTypes.size();
-        byKeyPrefixes.emplace_back(keyCount, new NPage::TBloom(*byKey));
-    }
     for (const auto& meta : ByKeyPrefixMetas) {
         if (meta.PageId != Max<TPageId>()) {
             if (auto* page = getPage(meta.PageId)) {
                 byKeyPrefixes.emplace_back(meta.PrefixColumns, new NPage::TBloom(*page));
             }
+        }
+    }
+    // Convert legacy full-key bloom to a prefix entry.
+    // Skip if the same page is already referenced in ByKeyPrefixMetas (written by new code for compatibility).
+    if (byKey) {
+        bool alreadyPresent = std::any_of(ByKeyPrefixMetas.begin(), ByKeyPrefixMetas.end(),
+            [&](const auto& meta) { return meta.PageId == ByKeyId; });
+        if (!alreadyPresent) {
+            ui32 keyCount = partScheme->Groups[0].KeyTypes.size();
+            byKeyPrefixes.emplace_back(keyCount, new NPage::TBloom(*byKey));
         }
     }
 

--- a/ydb/core/tablet_flat/flat_part_loader.h
+++ b/ydb/core/tablet_flat/flat_part_loader.h
@@ -284,6 +284,11 @@ namespace NTable {
         TPageId LargeId = Max<TPageId>();
         TPageId SmallId = Max<TPageId>();
         TPageId ByKeyId = Max<TPageId>();
+        struct TByKeyPrefixMeta {
+            TPageId PageId = Max<TPageId>();
+            ui32 PrefixColumns = 0;
+        };
+        TVector<TByKeyPrefixMeta> ByKeyPrefixMetas;
         TPageId GarbageStatsId = Max<TPageId>();
         TPageId TxIdStatsId = Max<TPageId>();
         TVector<TPageId> FlatGroupIndexes;

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -63,11 +63,11 @@ namespace NTable {
                 Histories.emplace_back(scheme, conf, tags, NPage::TGroupId(group, true));
             }
 
-            if (conf.ByKeyFilter) {
+            for (ui32 prefixLen : conf.ByKeyFilterPrefixes) {
                 if (MainPageCollectionEdge || SmallPageCollectionEdge || !conf.MaxRows) {
-                    ByKey.Reset(new NBloom::TQueue(0.0001));
+                    ByKeyPrefixes.emplace_back(prefixLen, MakeHolder<NBloom::TQueue>(0.0001));
                 } else {
-                    ByKey.Reset(new NBloom::TWriter(conf.MaxRows, 0.0001));
+                    ByKeyPrefixes.emplace_back(prefixLen, MakeHolder<NBloom::TWriter>(conf.MaxRows, 0.0001));
                 }
             }
 
@@ -363,8 +363,8 @@ namespace NTable {
         {
             KeyState.RowId = Groups[0].Data.GetLastRowId();
 
-            if (ByKey) {
-                ByKey->Add(KeyState.Key);
+            for (auto& [prefixLen, writer] : ByKeyPrefixes) {
+                writer->Add(TArrayRef<const TCell>(KeyState.Key.data(), Min<size_t>(prefixLen, KeyState.Key.size())));
             }
 
             for (auto& g : Groups) {
@@ -501,6 +501,11 @@ namespace NTable {
                     // Main index always includes an entry for the last key
                     indexSize += Groups[0].NextIndexSize;
 
+                    ui64 byKeyPrefixesSize = 0;
+                    for (auto& [_, writer] : ByKeyPrefixes) {
+                        byKeyPrefixesSize += writer->EstimateBytesUsed(1);
+                    }
+
                     ui64 mainPageCollectionSize = Current.MainWritten
                             + Groups[0].Data.BytesUsed()
                             + Groups[0].NextDataSize.DataPageSize
@@ -508,7 +513,7 @@ namespace NTable {
                             + FrameS.EstimateBytesUsed(smallRefs)
                             + FrameL.EstimateBytesUsed(largeRefs)
                             + Globs.EstimateBytesUsed(largeRefs)
-                            + (ByKey ? ByKey->EstimateBytesUsed(1) : 0)
+                            + byKeyPrefixesSize
                             + SchemeData.size();
 
                     // On overflow we would have to start a new data page
@@ -588,8 +593,12 @@ namespace NTable {
                 Current.Large = WriteIf(FrameL.Make(), EPage::Frames);
                 Current.Small = WriteIf(FrameS.Make(), EPage::Frames);
                 Current.Globs = WriteIf(Globs.Make(), EPage::Globs);
-                if (ByKey) {
-                    Current.ByKey = WriteIf(ByKey->Make(), EPage::Bloom);
+                Current.ByKeyPrefixPages.clear();
+                for (auto& [prefixLen, writer] : ByKeyPrefixes) {
+                    TPageId pageId = WriteIf(writer->Make(), EPage::Bloom);
+                    if (pageId != Max<TPageId>()) {
+                        Current.ByKeyPrefixPages.emplace_back(prefixLen, pageId);
+                    }
                 }
 
                 if (Current.GarbageStatsBuilder) {
@@ -624,8 +633,8 @@ namespace NTable {
                 FrameL.Reset();
                 FrameS.Reset();
                 Globs.Reset();
-                if (ByKey) {
-                    ByKey->Reset();
+                for (auto& [_, writer] : ByKeyPrefixes) {
+                    writer->Reset();
                 }
                 Slices.Reset();
 
@@ -702,8 +711,11 @@ namespace NTable {
                     lay->SetLarge(Current.Large);
                 if (Current.Small != Max<TPageId>())
                     lay->SetSmall(Current.Small);
-                if (Current.ByKey != Max<TPageId>())
-                    lay->SetByKey(Current.ByKey);
+                for (auto& [prefixLen, pageId] : Current.ByKeyPrefixPages) {
+                    auto* meta = lay->AddByKeyPrefixes();
+                    meta->SetPageId(pageId);
+                    meta->SetPrefixColumns(prefixLen);
+                }
 
                 for (TPageId page : Current.FlatGroupIndexes) {
                     lay->AddGroupIndexes(page);
@@ -1106,7 +1118,7 @@ namespace NTable {
         NPage::TFrameWriter FrameL; /* Large blobs inverted index   */
         NPage::TFrameWriter FrameS; /* Packed blobs inverted index */
         NPage::TExtBlobsWriter Globs;
-        THolder<NBloom::IWriter> ByKey;
+        TVector<std::pair<ui32, THolder<NBloom::IWriter>>> ByKeyPrefixes;
         TWriteStats WriteStats;
         TStackVec<TCell, 16> Key;
         TStackVec<TCell, 16> PrevPageLastKey;
@@ -1190,7 +1202,7 @@ namespace NTable {
             TPageId Large = Max<TPageId>();
             TPageId Small = Max<TPageId>();
             TPageId Globs = Max<TPageId>();
-            TPageId ByKey = Max<TPageId>();
+            TVector<std::pair<ui32, TPageId>> ByKeyPrefixPages; // {prefixLen, pageId}
             TPageId GarbageStats = Max<TPageId>();
             TPageId TxIdStats = Max<TPageId>();
 

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -64,6 +64,8 @@ namespace NTable {
             }
 
             for (ui32 prefixLen : conf.ByKeyFilterPrefixes) {
+                Y_ENSURE(prefixLen > 0 && prefixLen <= Scheme->Groups[0].ColsKeyData.size(),
+                    "Bloom filter prefix " << prefixLen << " exceeds key column count " << Scheme->Groups[0].ColsKeyData.size());
                 if (MainPageCollectionEdge || SmallPageCollectionEdge || !conf.MaxRows) {
                     ByKeyPrefixes.emplace_back(prefixLen, MakeHolder<NBloom::TQueue>(0.0001));
                 } else {
@@ -363,8 +365,11 @@ namespace NTable {
         {
             KeyState.RowId = Groups[0].Data.GetLastRowId();
 
-            for (auto& [prefixLen, writer] : ByKeyPrefixes) {
-                writer->Add(TArrayRef<const TCell>(KeyState.Key.data(), Min<size_t>(prefixLen, KeyState.Key.size())));
+            if (!ByKeyPrefixes.empty()) {
+                const NBloom::TPrefix prefix(KeyState.Key);
+                for (auto& [prefixLen, writer] : ByKeyPrefixes) {
+                    writer->Add(NBloom::THash::Root(prefix.Get(prefixLen)));
+                }
             }
 
             for (auto& g : Groups) {

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -712,6 +712,10 @@ namespace NTable {
                 if (Current.Small != Max<TPageId>())
                     lay->SetSmall(Current.Small);
                 for (auto& [prefixLen, pageId] : Current.ByKeyPrefixPages) {
+                    // For backward compatibility: also set legacy ByKey field for full-key bloom filters
+                    if (prefixLen == Scheme->Groups[0].ColsKeyData.size()) {
+                        lay->SetByKey(pageId);
+                    }
                     auto* meta = lay->AddByKeyPrefixes();
                     meta->SetPageId(pageId);
                     meta->SetPrefixColumns(prefixLen);

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
@@ -224,7 +224,9 @@ bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramBu
     for (const auto& part : subset.Flatten) {
         LOG_BUILD_STATS("adding part " << part->Label.ToString() << " data size (" << HumanReadableSize(part->DataSize(), SF_BYTES) << " in total)");
         stats.IndexSize.Add(part->IndexesRawSize, part->Label.Channel());
-        stats.ByKeyFilterSize += part->ByKey ? part->ByKey->Raw.size() : 0;
+        for (const auto& [_, bloom] : part->ByKeyPrefixes) {
+            if (bloom) stats.ByKeyFilterSize += bloom->Raw.size();
+        }
         ready &= AddDataSize(part, stats, env, yieldHandler, logPrefix);
     }
 

--- a/ydb/core/tablet_flat/flat_stat_table_mixed_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_mixed_index.h
@@ -22,7 +22,9 @@ inline bool BuildStatsMixedIndex(const TSubset& subset, TStats& stats, ui64 rowC
     bool started = true;
     for (const auto& part : subset.Flatten) {
         stats.IndexSize.Add(part->IndexesRawSize, part->Label.Channel());
-        stats.ByKeyFilterSize += part->ByKey ? part->ByKey->Raw.size() : 0;
+        for (const auto& [_, bloom] : part->ByKeyPrefixes) {
+            if (bloom) stats.ByKeyFilterSize += bloom->Raw.size();
+        }
         TAutoPtr<TStatsScreenedPartIterator> iter = new TStatsScreenedPartIterator(part, env, subset.Scheme->Keys, part->Small, part->Large, 
             rowCountResolution / resolutionDivider, dataSizeResolution / resolutionDivider);
         auto ready = iter->Start();

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -924,7 +924,7 @@ TPrechargeResult TTable::Precharge(TRawVals minKey_, TRawVals maxKey_, TTagsRef 
             if (pos != run.end()) {
                 const auto* part = pos->Part.Get();
                 if ((flg & EHint::NoByKey) ||
-                    part->MightHaveKey(prefix.Get(part->Scheme->Groups[0].KeyTypes.size())))
+                    part->MightHaveKeyPrefix(prefix))
                 {
                     TRowId row1 = pos->Slice.BeginRowId();
                     TRowId row2 = pos->Slice.EndRowId() - 1;
@@ -1438,7 +1438,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
                 if (pos != run.end()) {
                     const auto* part = pos->Part.Get();
                     if ((flg & EHint::NoByKey) ||
-                        part->MightHaveKey(prefix.Get(part->Scheme->Groups[0].KeyTypes.size())))
+                        part->MightHaveKeyPrefix(prefix))
                     {
                         ++stats.Sieved;
                         TPartIter& it = tempIterators.emplace_back(part, tags, Scheme->Keys, env);
@@ -1582,7 +1582,7 @@ TSelectRowVersionResult TTable::SelectRowVersion(
             if (pos != run.end()) {
                 const auto* part = pos->Part.Get();
                 if ((readFlags & EHint::NoByKey) ||
-                    part->MightHaveKey(prefix.Get(part->Scheme->Groups[0].KeyTypes.size())))
+                    part->MightHaveKeyPrefix(prefix))
                 {
                     TPartIter it(part, { }, Scheme->Keys, env);
                     it.SetBounds(pos->Slice);
@@ -1675,7 +1675,9 @@ void TPartStats::Add(const TPartView& partView)
     } else {
         FlatIndexBytes += partView->IndexesRawSize;
     }
-    ByKeyBytes += partView->ByKey ? partView->ByKey->Raw.size() : 0;
+    for (const auto& [_, bloom] : partView->ByKeyPrefixes) {
+        ByKeyBytes += bloom ? bloom->Raw.size() : 0;
+    }
     PlainBytes += partView->Stat.Bytes;
     CodedBytes += partView->Stat.Coded;
     RowsErase += partView->Stat.Drops;
@@ -1698,7 +1700,9 @@ bool TPartStats::Remove(const TPartView& partView)
     } else {
         NUtil::SubSafe(FlatIndexBytes, partView->IndexesRawSize);
     }
-    NUtil::SubSafe(ByKeyBytes, partView->ByKey ? partView->ByKey->Raw.size() : 0);
+    for (const auto& [_, bloom] : partView->ByKeyPrefixes) {
+        NUtil::SubSafe(ByKeyBytes, bloom ? bloom->Raw.size() : 0);
+    }
     NUtil::SubSafe(PlainBytes, partView->Stat.Bytes);
     NUtil::SubSafe(CodedBytes, partView->Stat.Coded);
     NUtil::SubSafe(RowsErase, partView->Stat.Drops);

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -8,6 +8,7 @@
 #include "flat_page_blobs.h"
 #include "flat_page_frames.h"
 #include "flat_page_bloom.h"
+#include "flat_bloom_hash.h"
 #include "flat_page_gstat.h"
 #include "flat_page_txidstat.h"
 #include "flat_page_txstatus.h"
@@ -89,7 +90,7 @@ namespace NTable {
             TIntrusiveConstPtr<TPartScheme> Scheme;
             TIndexPages IndexPages;
             TIntrusiveConstPtr<NPage::TExtBlobs> Blobs;
-            TIntrusiveConstPtr<NPage::TBloom> ByKey;
+            TVector<std::pair<ui32, TIntrusiveConstPtr<NPage::TBloom>>> ByKeyPrefixes;
             TIntrusiveConstPtr<NPage::TFrames> Large;
             TIntrusiveConstPtr<NPage::TFrames> Small;
             size_t IndexesRawSize;
@@ -116,7 +117,7 @@ namespace NTable {
             , Large(std::move(params.Large))
             , Small(std::move(params.Small))
             , IndexPages(std::move(params.IndexPages))
-            , ByKey(std::move(params.ByKey))
+            , ByKeyPrefixes(std::move(params.ByKeyPrefixes))
             , GarbageStats(std::move(params.GarbageStats))
             , TxIdStats(std::move(params.TxIdStats))
             , Stat(stat)
@@ -141,9 +142,17 @@ namespace NTable {
                 << Stat.Coded << "b " << Stat.Rows << "r}";
         }
 
-        bool MightHaveKey(TStringBuf serializedKey) const
+        bool MightHaveKeyPrefix(const NBloom::TPrefix& prefix) const
         {
-            return ByKey ? ByKey->MightHave(serializedKey) : true;
+            for (const auto& [prefixLen, bloom] : ByKeyPrefixes) {
+                if (!bloom || prefixLen == 0) {
+                    continue;
+                }
+                if (!bloom->MightHave(prefix.Get(Min<ui32>(prefixLen, Scheme->Groups[0].KeyTypes.size())))) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         /**
@@ -169,7 +178,7 @@ namespace NTable {
             , Large(src.Large)
             , Small(src.Small)
             , IndexPages(src.IndexPages)
-            , ByKey(src.ByKey)
+            , ByKeyPrefixes(src.ByKeyPrefixes)
             , GarbageStats(src.GarbageStats)
             , Stat(src.Stat)
             , GroupsCount(src.GroupsCount)
@@ -187,7 +196,7 @@ namespace NTable {
         const TIntrusiveConstPtr<NPage::TFrames> Large;
         const TIntrusiveConstPtr<NPage::TFrames> Small;
         const TIndexPages IndexPages;
-        const TIntrusiveConstPtr<NPage::TBloom> ByKey;
+        const TVector<std::pair<ui32, TIntrusiveConstPtr<NPage::TBloom>>> ByKeyPrefixes;
         const TIntrusiveConstPtr<NPage::TGarbageStats> GarbageStats;
         const TIntrusiveConstPtr<NPage::TTxIdStatsPage> TxIdStats;
         const TStat Stat;

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -131,6 +131,9 @@ namespace NTable {
                 "Part has scheme with " << Scheme->Groups.size() << " groups, but " << GroupsCount << " indexes");
             Y_ENSURE(!HistoricGroupsCount || HistoricGroupsCount == GroupsCount,
                 "Part has " << GroupsCount << " indexes, but " << HistoricGroupsCount << " historic indexes");
+            Y_ENSURE(std::is_sorted(ByKeyPrefixes.begin(), ByKeyPrefixes.end(),
+                [](const auto& a, const auto& b) { return a.first < b.first; }),
+                "ByKeyPrefixes must be sorted by prefix length");
         }
 
         virtual ~TPart() = default;
@@ -144,12 +147,11 @@ namespace NTable {
 
         bool MightHaveKeyPrefix(const NBloom::TPrefix& prefix) const
         {
-            for (const auto& [prefixLen, bloom] : ByKeyPrefixes) {
-                if (!bloom || prefixLen == 0) {
-                    continue;
-                }
-                if (!bloom->MightHave(prefix.Get(Min<ui32>(prefixLen, Scheme->Groups[0].KeyTypes.size())))) {
-                    return false;
+            // ByKeyPrefixes are sorted by prefixLen; pick the longest (most selective) filter
+            for (auto it = ByKeyPrefixes.rbegin(); it != ByKeyPrefixes.rend(); ++it) {
+                const auto& [prefixLen, bloom] = *it;
+                if (bloom && prefixLen > 0) {
+                    return bloom->MightHave(prefix.Get(prefixLen));
                 }
             }
             return true;

--- a/ydb/core/tablet_flat/protos/flat_table_part.proto
+++ b/ydb/core/tablet_flat/protos/flat_table_part.proto
@@ -33,6 +33,11 @@ message TBTreeIndexMeta {
     optional uint64 GroupDataSize = 7; // Group pages data size (includes history and external blobs)
 }
 
+message TBloomFilterMeta {
+    optional uint32 PageId = 1;         // EPage::Bloom page identifier
+    optional uint32 PrefixColumns = 2;  // Number of leading PK columns in this bloom filter
+}
+
 message TLayout {
     optional uint32 Index = 1;
     optional uint32 Globs = 2;  // EPage::Globs, external blobs catalog
@@ -47,6 +52,7 @@ message TLayout {
     repeated TBTreeIndexMeta BTreeGroupIndexes = 11;
     repeated TBTreeIndexMeta BTreeHistoricIndexes = 12;
     optional uint32 BTreeIndexesFormatVersion = 13;
+    repeated TBloomFilterMeta ByKeyPrefixes = 14; // Per-prefix bloom filter pages
 }
 
 message TStat {

--- a/ydb/core/tablet_flat/test/libs/table/test_dbase.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_dbase.h
@@ -295,7 +295,7 @@ namespace NTest {
 
             NPage::TConf conf{ last, 8291, family->Large };
 
-            conf.ByKeyFilter = Base->GetScheme().GetTableInfo(table)->ByKeyFilter;
+            conf.ByKeyFilterPrefixes = Base->GetScheme().GetTableInfo(table)->ByKeyFilterPrefixes;
             conf.MaxRows = subset->MaxRows();
             conf.MinRowVersion = subset->MinRowVersion();
             conf.SmallEdge = family->Small;

--- a/ydb/core/tablet_flat/test/libs/table/test_writer.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_writer.h
@@ -90,16 +90,32 @@ namespace NTest {
                 }
             }
 
+            auto partScheme = TPartScheme::Parse(*eggs.Scheme, eggs.Rooted);
+
+            TVector<std::pair<ui32, TIntrusiveConstPtr<NPage::TBloom>>> byKeyPrefixes;
+            // Convert legacy full-key bloom to a prefix entry
+            if (eggs.ByKey) {
+                ui32 keyCount = partScheme->Groups[0].KeyTypes.size();
+                byKeyPrefixes.emplace_back(keyCount, new TBloom(*eggs.ByKey));
+            }
+            if (root.HasLayout()) {
+                for (const auto& meta : root.GetLayout().GetByKeyPrefixes()) {
+                    if (auto *page = Store->GetPage(0, meta.GetPageId())) {
+                        byKeyPrefixes.emplace_back(meta.GetPrefixColumns(), new TBloom(*page));
+                    }
+                }
+            }
+
             return
                 new TPartStore(
                     std::move(Store),
                     token,
                     {
                         epoch,
-                        TPartScheme::Parse(*eggs.Scheme, eggs.Rooted),
+                        std::move(partScheme),
                         { eggs.FlatGroupIndexes, eggs.FlatHistoricIndexes, eggs.BTreeGroupIndexes, eggs.BTreeHistoricIndexes },
                         eggs.Blobs ? new TExtBlobs(*eggs.Blobs, { }) : nullptr,
-                        eggs.ByKey ? new TBloom(*eggs.ByKey) : nullptr,
+                        std::move(byKeyPrefixes),
                         eggs.Large ? new TFrames(*eggs.Large) : nullptr,
                         eggs.Small ? new TFrames(*eggs.Small) : nullptr,
                         indexesRawSize,

--- a/ydb/core/tablet_flat/test/libs/table/test_writer.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_writer.h
@@ -93,17 +93,17 @@ namespace NTest {
             auto partScheme = TPartScheme::Parse(*eggs.Scheme, eggs.Rooted);
 
             TVector<std::pair<ui32, TIntrusiveConstPtr<NPage::TBloom>>> byKeyPrefixes;
-            // Convert legacy full-key bloom to a prefix entry
-            if (eggs.ByKey) {
-                ui32 keyCount = partScheme->Groups[0].KeyTypes.size();
-                byKeyPrefixes.emplace_back(keyCount, new TBloom(*eggs.ByKey));
-            }
             if (root.HasLayout()) {
                 for (const auto& meta : root.GetLayout().GetByKeyPrefixes()) {
                     if (auto *page = Store->GetPage(0, meta.GetPageId())) {
                         byKeyPrefixes.emplace_back(meta.GetPrefixColumns(), new TBloom(*page));
                     }
                 }
+            }
+            // Fall back to legacy ByKey if no ByKeyPrefixes are present (old SST format)
+            if (byKeyPrefixes.empty() && eggs.ByKey) {
+                ui32 keyCount = partScheme->Groups[0].KeyTypes.size();
+                byKeyPrefixes.emplace_back(keyCount, new TBloom(*eggs.ByKey));
             }
 
             return

--- a/ydb/core/tablet_flat/ut/flat_comp_ut_common.h
+++ b/ydb/core/tablet_flat/ut/flat_comp_ut_common.h
@@ -148,7 +148,7 @@ public:
         conf.SmallEdge = family->Small;
         conf.LargeEdge = family->Large;
         conf.MaxRows = subset->MaxRows();
-        conf.ByKeyFilter = scheme.GetTableInfo(params->Table)->ByKeyFilter;
+        conf.ByKeyFilterPrefixes = scheme.GetTableInfo(params->Table)->ByKeyFilterPrefixes;
 
         // Don't care about moving blobs by reference
         TAutoPtr<IPages> env = new TTestEnv;

--- a/ydb/core/tablet_flat/ut/ut_bloom.cpp
+++ b/ydb/core/tablet_flat/ut/ut_bloom.cpp
@@ -180,7 +180,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
         {
             auto subset = me->Subset(1, TEpoch::Max(), { }, { });
 
-            UNIT_ASSERT(subset->Flatten.size() == 1 && !subset->Flatten[0]->ByKey);
+            UNIT_ASSERT(subset->Flatten.size() == 1 && subset->Flatten[0]->ByKeyPrefixes.empty());
 
             auto &stats = me.Relax().BackLog().Stats;
 
@@ -191,7 +191,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
 
         /*_ 20: Make next part Pw with enabled by key bloom filter */
 
-        me.To(20).Begin().Apply(*TAlter().SetByKeyFilter(1, true));
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2}));
         me.To(21).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1, false);
         me.To(22).Select(1).Has(ru1, ru2, rw1, rw2, rw3).NoKey(no1, no2, no3);
 
@@ -199,7 +199,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
             auto subset = me->Subset(1, TEpoch::Max(), { }, { });
 
             UNIT_ASSERT(
-                subset->Flatten.at(0)->ByKey || subset->Flatten.at(1)->ByKey);
+                !subset->Flatten.at(0)->ByKeyPrefixes.empty() || !subset->Flatten.at(1)->ByKeyPrefixes.empty());
 
             auto &stats = me.Relax().BackLog().Stats;
 
@@ -220,7 +220,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
         {
             const auto subset = me->Subset(1, TEpoch::Max(), { }, { });
 
-            UNIT_ASSERT(subset->Flatten.size() == 1 && subset->Flatten[0]->ByKey);
+            UNIT_ASSERT(subset->Flatten.size() == 1 && !subset->Flatten[0]->ByKeyPrefixes.empty());
 
             auto &stats = me.Relax().BackLog().Stats;
 
@@ -233,13 +233,362 @@ Y_UNIT_TEST_SUITE(Bloom) {
 
         /*_ 40: Disable filter then check that is really gone */
 
-        me.To(40).Begin().Apply(*TAlter().SetByKeyFilter(1, false));
+        me.To(40).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {}));
         me.To(41).Commit().Compact(1, true /* final compaction */);
 
         {
             const auto subset = me->Subset(1, TEpoch::Max(), { }, { });
 
-            UNIT_ASSERT(subset->Flatten.size() == 1 && !subset->Flatten[0]->ByKey);
+            UNIT_ASSERT(subset->Flatten.size() == 1 && subset->Flatten[0]->ByKeyPrefixes.empty());
+        }
+    }
+
+    Y_UNIT_TEST(PrefixBloom)
+    {
+        TDbExec me;
+
+        /* Table with 3-column PK: (name: String, salt: Uint64, sub: String) */
+        {
+            TAlter alter;
+            alter
+                .AddTable("me", 1)
+                .AddColumn(1, "name", 1, ETypes::String, false, false)
+                .AddColumn(1, "salt", 2, ETypes::Uint64, false, false)
+                .AddColumn(1, "sub",  3, ETypes::String, false, false)
+                .AddColumnToKey(1, 1)
+                .AddColumnToKey(1, 2)
+                .AddColumnToKey(1, 3);
+
+            me.To(10).Begin().Apply(*alter).Commit();
+        }
+
+        /* Rows that share the same first column "aaa" */
+        const auto rw1 = *me.SchemedCookRow(1).Col("aaa", 100_u64, "x1");
+        const auto rw2 = *me.SchemedCookRow(1).Col("aaa", 200_u64, "x2");
+
+        /* Rows with a different first column "bbb" */
+        const auto rw3 = *me.SchemedCookRow(1).Col("bbb", 300_u64, "x3");
+
+        /* Non-existing keys: same first column "aaa" but different rest
+           (within range of part, so bloom is checked but passes) */
+        const auto noSame = *me.SchemedCookRow(1).Col("aaa", 999_u64, "zz");
+        /* Non-existing keys: different first column but within range [aaa..bbb]
+           (within range of part, so bloom is checked and rejects) */
+        const auto noDiff1 = *me.SchemedCookRow(1).Col("aab", 100_u64, "x1");
+        const auto noDiff2 = *me.SchemedCookRow(1).Col("aac", 200_u64, "x2");
+
+        /*_ 10: Enable prefix bloom on first PK column only */
+
+        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {1}));
+        me.To(12).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1);
+        me.To(13).Select(1).Has(rw1, rw2, rw3).NoKey(noSame, noDiff1, noDiff2);
+
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes[0].first == 1);
+
+            auto &stats = me.Relax().BackLog().Stats;
+
+            /* noDiff1 ("aab") and noDiff2 ("aac") have first column
+               not in the bloom {aaa, bbb} → should be Weeded.
+               noSame ("aaa") is in the bloom → not weeded (Sieved). */
+            UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 2);
+        }
+
+        /*_ 20: Recompact all to one part, verify prefix bloom persists */
+
+        me.To(20).Compact(1, true /* final */);
+        me.To(21).Select(1).Has(rw1, rw2, rw3).NoKey(noDiff1, noDiff2);
+
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 1);
+
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 2);
+        }
+
+        /*_ 30: Disable prefix bloom, recompact, verify it's gone */
+
+        me.To(30).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {}));
+        me.To(31).Commit().Compact(1, true /* final */);
+        me.To(32).Select(1).Has(rw1);
+
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.empty());
+            me.Relax();
+        }
+    }
+
+    Y_UNIT_TEST(PrefixBloomWithFullKey)
+    {
+        /* Test that prefix bloom on 1 column and full-key bloom (as prefix=3) coexist.
+           A part is skipped if EITHER bloom says "definitely not". */
+        TDbExec me;
+
+        {
+            TAlter alter;
+            alter
+                .AddTable("me", 1)
+                .AddColumn(1, "name", 1, ETypes::String, false, false)
+                .AddColumn(1, "salt", 2, ETypes::Uint64, false, false)
+                .AddColumn(1, "sub",  3, ETypes::String, false, false)
+                .AddColumnToKey(1, 1)
+                .AddColumnToKey(1, 2)
+                .AddColumnToKey(1, 3);
+
+            me.To(10).Begin().Apply(*alter).Commit();
+        }
+
+        const auto rw1 = *me.SchemedCookRow(1).Col("aaa", 100_u64, "x1");
+        const auto rw2 = *me.SchemedCookRow(1).Col("aaa", 200_u64, "x2");
+        const auto rw3 = *me.SchemedCookRow(1).Col("bbb", 300_u64, "x3");
+
+        /* Key with same prefix "aaa" but non-existing rest — prefix bloom on col 1 passes,
+           full-key bloom (prefix=3) rejects (different salt+sub combination) */
+        const auto noSamePrefix = *me.SchemedCookRow(1).Col("aaa", 999_u64, "zz");
+        /* Key with different prefix — prefix bloom on col 1 rejects */
+        const auto noDiffPrefix = *me.SchemedCookRow(1).Col("aab", 100_u64, "x1");
+
+        /* Enable prefix bloom on 1 column and full-key bloom (prefix=3) */
+        me.To(11).Begin()
+            .Apply(*TAlter().SetByKeyFilterPrefixes(1, {1, 3}));
+        me.To(12).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1);
+        me.To(13).Select(1).Has(rw1, rw2, rw3).NoKey(noSamePrefix, noDiffPrefix);
+
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 2); /* prefix=1 and prefix=3 */
+
+            auto &stats = me.Relax().BackLog().Stats;
+
+            /* noSamePrefix: prefix=1 bloom passes (aaa in bloom), but prefix=3 rejects → Weeded
+               noDiffPrefix: prefix=1 bloom rejects (aab not in bloom) → Weeded
+               Both should be weeded. */
+            UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 2);
+        }
+    }
+
+    Y_UNIT_TEST(MultiplePrefixes)
+    {
+        /* Test two prefix bloom filters simultaneously: on 1 and 2 PK columns. */
+        TDbExec me;
+
+        {
+            TAlter alter;
+            alter
+                .AddTable("me", 1)
+                .AddColumn(1, "name", 1, ETypes::String, false, false)
+                .AddColumn(1, "salt", 2, ETypes::Uint64, false, false)
+                .AddColumn(1, "sub",  3, ETypes::String, false, false)
+                .AddColumnToKey(1, 1)
+                .AddColumnToKey(1, 2)
+                .AddColumnToKey(1, 3);
+
+            me.To(10).Begin().Apply(*alter).Commit();
+        }
+
+        const auto rw1 = *me.SchemedCookRow(1).Col("aaa", 100_u64, "x1");
+        const auto rw2 = *me.SchemedCookRow(1).Col("aaa", 200_u64, "x2");
+        const auto rw3 = *me.SchemedCookRow(1).Col("bbb", 300_u64, "x3");
+
+        /* Same 1st column "aaa", different 2nd column — passes bloom-on-1, rejected by bloom-on-2 */
+        const auto noPassesFirst = *me.SchemedCookRow(1).Col("aaa", 999_u64, "zz");
+        /* Different 1st column — rejected by bloom-on-1 already */
+        const auto noDiff = *me.SchemedCookRow(1).Col("aab", 100_u64, "x1");
+
+        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {1, 2}));
+        me.To(12).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1);
+        me.To(13).Select(1).Has(rw1, rw2, rw3).NoKey(noPassesFirst, noDiff);
+
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 2);
+
+            auto &stats = me.Relax().BackLog().Stats;
+
+            /* noPassesFirst (aaa,999,...): bloom-on-1 passes (aaa exists), but
+               bloom-on-2 rejects (aaa,999 not in bloom) → Weeded.
+               noDiff (aab,...): bloom-on-1 rejects (aab not in bloom) → Weeded.
+               Both should be weeded. */
+            UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 2);
+        }
+    }
+
+    Y_UNIT_TEST(LegacyByKeyFilterAlter)
+    {
+        /* Use case: a tablet boots from old schema log containing legacy
+           ByKeyFilter=1 records. Bloom filtering should work identically
+           to the new prefix-based API. Legacy disable should remove filtering. */
+        TDbExec me;
+
+        me.To(10).Begin().Apply(*MakeAlter()).Commit();
+
+        const auto rw1 = *me.SchemedCookRow(1).Col("ba0_huxu", 01234_u64);
+        const auto rw2 = *me.SchemedCookRow(1).Col("ba2_d7mj", 12340_u64);
+        const auto no1 = *me.SchemedCookRow(1).Col("ba1_p9lw", 53543_u64);
+
+        /* Enable bloom via legacy ByKeyFilter=1 alter record (raw proto) */
+        {
+            NTabletFlatScheme::TSchemeChanges changes;
+            auto* delta = changes.AddDelta();
+            delta->SetDeltaType(NTabletFlatScheme::TAlterRecord::SetTable);
+            delta->SetTableId(1);
+            delta->SetByKeyFilter(1); /* legacy enable */
+            me.To(20).Begin().Apply(changes);
+        }
+        me.To(21).Put(1, rw1, rw2).Commit().Snap(1).Compact(1);
+
+        /* Bloom must filter absent keys — same behavior as new API */
+        me.To(22).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes[0].first == 2);
+
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT(stats.SelectWeeded > 0);
+        }
+
+        /* Disable bloom via legacy ByKeyFilter=0, recompact */
+        {
+            NTabletFlatScheme::TSchemeChanges changes;
+            auto* delta = changes.AddDelta();
+            delta->SetDeltaType(NTabletFlatScheme::TAlterRecord::SetTable);
+            delta->SetTableId(1);
+            delta->SetByKeyFilter(0); /* legacy disable */
+            me.To(30).Begin().Apply(changes);
+        }
+        me.To(31).Commit().Compact(1, true);
+
+        /* After disable + recompact, no filtering should occur */
+        me.To(32).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.empty());
+
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 0);
+        }
+    }
+
+    Y_UNIT_TEST(SnapshotRoundTrip)
+    {
+        /* Use case: tablet restarts (Boot) or follower syncs (Redo).
+           Bloom filter settings must survive and continue filtering. */
+        TDbExec me;
+
+        me.To(10).Begin().Apply(*MakeAlter()).Commit();
+
+        const auto rw1 = *me.SchemedCookRow(1).Col("ba0_huxu", 01234_u64);
+        const auto rw2 = *me.SchemedCookRow(1).Col("ba2_d7mj", 12340_u64);
+        const auto no1 = *me.SchemedCookRow(1).Col("ba1_p9lw", 53543_u64);
+
+        /* Enable bloom, write data, compact */
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2}));
+        me.To(21).Put(1, rw1, rw2).Commit().Snap(1).Compact(1);
+
+        /* Bloom filters before restart */
+        me.To(22).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT(stats.SelectWeeded > 0);
+        }
+
+        /* Restart via Boot — bloom must still filter after recompaction */
+        me.Replay(EPlay::Boot);
+        me.To(30).Snap(1).Compact(1, true);
+        me.To(31).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(!subset->Flatten[0]->ByKeyPrefixes.empty());
+
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT(stats.SelectWeeded > 0);
+        }
+
+        /* Restart via Redo (follower sync) — same */
+        me.Replay(EPlay::Redo);
+        me.To(40).Snap(1).Compact(1, true);
+        me.To(41).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(!subset->Flatten[0]->ByKeyPrefixes.empty());
+
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT(stats.SelectWeeded > 0);
+        }
+    }
+
+    Y_UNIT_TEST(ClearBloomSnapshotRoundTrip)
+    {
+        /* Use case: bloom is enabled then disabled, tablet restarts.
+           The disabled state must survive — no filtering after restart. */
+        TDbExec me;
+
+        me.To(10).Begin().Apply(*MakeAlter()).Commit();
+
+        const auto rw1 = *me.SchemedCookRow(1).Col("ba0_huxu", 01234_u64);
+        const auto rw2 = *me.SchemedCookRow(1).Col("ba2_d7mj", 12340_u64);
+        const auto no1 = *me.SchemedCookRow(1).Col("ba1_p9lw", 53543_u64);
+
+        /* Enable bloom, write data, compact */
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2}));
+        me.To(21).Put(1, rw1, rw2).Commit().Snap(1).Compact(1);
+
+        /* Bloom filters initially */
+        me.To(22).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT(stats.SelectWeeded > 0);
+        }
+
+        /* Disable bloom, recompact */
+        me.To(30).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {}));
+        me.To(31).Commit().Compact(1, true);
+
+        /* No filtering after disable */
+        me.To(32).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 0);
+        }
+
+        /* Restart via Boot — disabled state survives */
+        me.Replay(EPlay::Boot);
+        me.To(40).Snap(1).Compact(1, true);
+        me.To(41).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.empty());
+
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 0);
+        }
+
+        /* Restart via Redo — disabled state survives */
+        me.Replay(EPlay::Redo);
+        me.To(50).Snap(1).Compact(1, true);
+        me.To(51).Select(1).Has(rw1, rw2).NoKey(no1);
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.empty());
+
+            auto &stats = me.Relax().BackLog().Stats;
+            UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 0);
         }
     }
 
@@ -263,7 +612,11 @@ Y_UNIT_TEST_SUITE(Bloom) {
             auto name = Sprintf("sub_%04u", col);
             alter.AddColumn(1, name, col, ETypes::String, false, false);
             alter.AddColumnToKey(1, col);
-            alter.SetByKeyFilter(1, col > 10); /* first 8 parts w/o filter */
+            if (col > 10) {
+                alter.SetByKeyFilterPrefixes(1, {col}); /* enable bloom on full key */
+            } else {
+                alter.SetByKeyFilterPrefixes(1, {}); /* no bloom for first 8 parts */
+            }
 
             me.To(col * 10 + 1001).Begin().Apply(*alter).Commit();
 

--- a/ydb/core/tablet_flat/ut/ut_bloom.cpp
+++ b/ydb/core/tablet_flat/ut/ut_bloom.cpp
@@ -328,7 +328,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
     Y_UNIT_TEST(PrefixBloomWithFullKey)
     {
         /* Test that prefix bloom on 1 column and full-key bloom (as prefix=3) coexist.
-           A part is skipped if EITHER bloom says "definitely not". */
+           Only the longest prefix bloom (prefix=3) is used for lookups. */
         TDbExec me;
 
         {
@@ -349,10 +349,10 @@ Y_UNIT_TEST_SUITE(Bloom) {
         const auto rw2 = *me.SchemedCookRow(1).Col("aaa", 200_u64, "x2");
         const auto rw3 = *me.SchemedCookRow(1).Col("bbb", 300_u64, "x3");
 
-        /* Key with same prefix "aaa" but non-existing rest — prefix bloom on col 1 passes,
-           full-key bloom (prefix=3) rejects (different salt+sub combination) */
+        /* Key with same prefix "aaa" but non-existing rest — full-key bloom (prefix=3)
+           rejects (different salt+sub combination) */
         const auto noSamePrefix = *me.SchemedCookRow(1).Col("aaa", 999_u64, "zz");
-        /* Key with different prefix — prefix bloom on col 1 rejects */
+        /* Key with different prefix — full-key bloom (prefix=3) rejects */
         const auto noDiffPrefix = *me.SchemedCookRow(1).Col("aab", 100_u64, "x1");
 
         /* Enable prefix bloom on 1 column and full-key bloom (prefix=3) */
@@ -365,19 +365,20 @@ Y_UNIT_TEST_SUITE(Bloom) {
             auto subset = me->Subset(1, TEpoch::Max(), { }, { });
             UNIT_ASSERT(subset->Flatten.size() == 1);
             UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 2); /* prefix=1 and prefix=3 */
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes[0].first < subset->Flatten[0]->ByKeyPrefixes[1].first);
 
             auto &stats = me.Relax().BackLog().Stats;
 
-            /* noSamePrefix: prefix=1 bloom passes (aaa in bloom), but prefix=3 rejects → Weeded
-               noDiffPrefix: prefix=1 bloom rejects (aab not in bloom) → Weeded
-               Both should be weeded. */
+            /* noSamePrefix: full-key bloom (prefix=3) rejects (aaa,999,zz not in bloom) → Weeded
+               noDiffPrefix: full-key bloom (prefix=3) rejects (aab,100,x1 not in bloom) → Weeded */
             UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 2);
         }
     }
 
     Y_UNIT_TEST(MultiplePrefixes)
     {
-        /* Test two prefix bloom filters simultaneously: on 1 and 2 PK columns. */
+        /* Test two prefix bloom filters on 1 and 2 PK columns.
+           Only the longest prefix bloom (prefix=2) is used for lookups. */
         TDbExec me;
 
         {
@@ -398,12 +399,12 @@ Y_UNIT_TEST_SUITE(Bloom) {
         const auto rw2 = *me.SchemedCookRow(1).Col("aaa", 200_u64, "x2");
         const auto rw3 = *me.SchemedCookRow(1).Col("bbb", 300_u64, "x3");
 
-        /* Same 1st column "aaa", different 2nd column — passes bloom-on-1, rejected by bloom-on-2 */
+        /* Same 1st column "aaa", different 2nd column — rejected by bloom-on-2 (longest) */
         const auto noPassesFirst = *me.SchemedCookRow(1).Col("aaa", 999_u64, "zz");
-        /* Different 1st column — rejected by bloom-on-1 already */
+        /* Different 1st column — rejected by bloom-on-2 (longest) */
         const auto noDiff = *me.SchemedCookRow(1).Col("aab", 100_u64, "x1");
 
-        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {1, 2}));
+        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2, 1})); /* deliberately reversed */
         me.To(12).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1);
         me.To(13).Select(1).Has(rw1, rw2, rw3).NoKey(noPassesFirst, noDiff);
 
@@ -411,13 +412,12 @@ Y_UNIT_TEST_SUITE(Bloom) {
             auto subset = me->Subset(1, TEpoch::Max(), { }, { });
             UNIT_ASSERT(subset->Flatten.size() == 1);
             UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 2);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes[0].first < subset->Flatten[0]->ByKeyPrefixes[1].first);
 
             auto &stats = me.Relax().BackLog().Stats;
 
-            /* noPassesFirst (aaa,999,...): bloom-on-1 passes (aaa exists), but
-               bloom-on-2 rejects (aaa,999 not in bloom) → Weeded.
-               noDiff (aab,...): bloom-on-1 rejects (aab not in bloom) → Weeded.
-               Both should be weeded. */
+            /* noPassesFirst (aaa,999,...): bloom-on-2 rejects (aaa,999 not in bloom) → Weeded.
+               noDiff (aab,...): bloom-on-2 rejects (aab,100 not in bloom) → Weeded. */
             UNIT_ASSERT_VALUES_EQUAL(stats.SelectWeeded, 2);
         }
     }

--- a/ydb/core/tablet_flat/ut/ut_bloom.cpp
+++ b/ydb/core/tablet_flat/ut/ut_bloom.cpp
@@ -592,6 +592,40 @@ Y_UNIT_TEST_SUITE(Bloom) {
         }
     }
 
+    Y_UNIT_TEST(SnapshotBackwardCompatibility)
+    {
+        /* Regression test: when snapshot is created with ByKeyFilterPrefixes for full key,
+           GetSnapshot() must also set the legacy ByKeyFilter field.
+           This ensures older versions understand that bloom filtering is active
+           and don't disable it during their own snapshots. */
+        TDbExec me;
+
+        me.To(10).Begin().Apply(*MakeAlter()).Commit();
+
+        /* Enable full-key (2-column) bloom filter using new API */
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2})).Commit();
+
+        /* GetSnapshot() must include both legacy ByKeyFilter and new ByKeyFilterPrefixes */
+        {
+            auto snapshot = me->GetScheme().GetSnapshot();
+            bool foundLegacy = false;
+            bool foundNew = false;
+            for (const auto& delta : snapshot->GetDelta()) {
+                if (delta.GetDeltaType() == NTabletFlatScheme::TAlterRecord::SetTable &&
+                    delta.GetTableId() == 1) {
+                    if (delta.HasByKeyFilter() && delta.GetByKeyFilter() != 0) {
+                        foundLegacy = true;
+                    }
+                    if (delta.ByKeyFilterPrefixesSize() > 0) {
+                        foundNew = true;
+                    }
+                }
+            }
+            UNIT_ASSERT_C(foundLegacy, "GetSnapshot() must set legacy ByKeyFilter for full-key bloom");
+            UNIT_ASSERT_C(foundNew, "GetSnapshot() must set ByKeyFilterPrefixes");
+        }
+    }
+
     Y_UNIT_TEST(Stairs)
     {
         const ui32 Height = 99;

--- a/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
+++ b/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
@@ -106,15 +106,15 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
                     .Is(EReady::Gone);
 
                 // Verify bloom filter correctness
-                if (conf.ByKeyFilter) {
+                if (!conf.ByKeyFilterPrefixes.empty()) {
                     TRowTool tool(*born.Scheme);
                     for (auto it : xrange(size)) {
                         const auto key = tool.KeyCells(rows[it]);
                         const NBloom::TPrefix prefix(key);
                         auto* part = born.At(it >= split ? 1 : 0).Get();
-                        UNIT_ASSERT_C(part->ByKey, "Part is missing a bloom filter");
+                        UNIT_ASSERT_C(!part->ByKeyPrefixes.empty(), "Part is missing a bloom filter");
                         UNIT_ASSERT_C(
-                            part->MightHaveKey(prefix.Get(key.size())),
+                            part->MightHaveKeyPrefix(prefix),
                             "Part's bloom filter is missing key for row "
                             << tool.Describe(rows[it]));
                     }
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         initialConf.CutIndexKeys = false;
         initialConf.SmallEdge = 19;
         initialConf.LargeEdge = 29;
-        initialConf.ByKeyFilter = true;
+        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
         initialConf.MaxRows = mass.Saved.Size();
 
         RunMainEdgeTest(mass.Model->Scheme, mass.Saved, initialConf, false, 2);
@@ -147,7 +147,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         initialConf.CutIndexKeys = false;
         initialConf.SmallEdge = 19;
         initialConf.LargeEdge = 29;
-        initialConf.ByKeyFilter = true;
+        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
         initialConf.MaxRows = mass.Saved.Size();
 
         auto initial =
@@ -196,7 +196,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilter = true;
+        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
         initialConf.MaxRows = rows.Size();
 
         RunMainEdgeTest(lay.RowScheme(), rows, initialConf);
@@ -227,7 +227,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilter = true;
+        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
         initialConf.MaxRows = rows.Size();
         initialConf.SmallEdge = 13;
 
@@ -259,7 +259,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilter = true;
+        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
         initialConf.MaxRows = rows.Size();
         initialConf.LargeEdge = 13;
 

--- a/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
+++ b/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
@@ -196,7 +196,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
+        initialConf.ByKeyFilterPrefixes = {1}; /* full-key bloom for 1-column PK */
         initialConf.MaxRows = rows.Size();
 
         RunMainEdgeTest(lay.RowScheme(), rows, initialConf);
@@ -227,7 +227,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
+        initialConf.ByKeyFilterPrefixes = {1}; /* full-key bloom for 1-column PK */
         initialConf.MaxRows = rows.Size();
         initialConf.SmallEdge = 13;
 
@@ -259,7 +259,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
+        initialConf.ByKeyFilterPrefixes = {1}; /* full-key bloom for 1-column PK */
         initialConf.MaxRows = rows.Size();
         initialConf.LargeEdge = 13;
 

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -1,6 +1,8 @@
 #include "datashard_user_table.h"
 
 #include <ydb/core/base/path.h>
+
+#include <util/generic/algorithm.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
@@ -480,8 +482,21 @@ void TUserTable::DoApplyCreate(
         alter.SetCompactionPolicy(tid, *NLocalDb::CreateDefaultUserTablePolicy());
     }
 
-    if (partConfig.HasEnableFilterByKey()) {
-        alter.SetByKeyFilter(tid, partConfig.GetEnableFilterByKey());
+    {
+        // Unify EnableFilterByKey and ByKeyFilterPrefixes into a single prefix list
+        TVector<ui32> prefixes;
+        for (auto p : partConfig.GetByKeyFilterPrefixes()) {
+            if (p > 0) {
+                prefixes.push_back(p);
+            }
+        }
+        if (partConfig.HasEnableFilterByKey() && partConfig.GetEnableFilterByKey()) {
+            prefixes.push_back(KeyColumnIds.size());
+        }
+        SortUnique(prefixes);
+        if (!prefixes.empty()) {
+            alter.SetByKeyFilterPrefixes(tid, prefixes);
+        }
     }
 
     // N.B. some settings only apply to the main table
@@ -613,10 +628,49 @@ void TUserTable::ApplyAlter(
         }
     }
 
-    if (configDelta.HasEnableFilterByKey()) {
-        config.SetEnableFilterByKey(configDelta.GetEnableFilterByKey());
+    if (configDelta.HasEnableFilterByKey() || configDelta.ByKeyFilterPrefixesSize() > 0) {
+        // Rebuild unified prefix list from current config + delta
+        TVector<ui32> prefixes;
+        // Start with existing prefixes from current config
+        for (auto p : config.GetByKeyFilterPrefixes()) {
+            if (p > 0) {
+                prefixes.push_back(p);
+            }
+        }
+        ui32 keyCount = KeyColumnIds.size();
+
+        if (configDelta.HasEnableFilterByKey()) {
+            config.SetEnableFilterByKey(configDelta.GetEnableFilterByKey());
+            if (configDelta.GetEnableFilterByKey()) {
+                prefixes.push_back(keyCount);
+            } else {
+                // Remove full-key entry
+                prefixes.erase(std::remove(prefixes.begin(), prefixes.end(), keyCount), prefixes.end());
+            }
+        }
+
+        if (configDelta.ByKeyFilterPrefixesSize() > 0) {
+            // Delta replaces the explicit prefix list
+            prefixes.clear();
+            for (auto p : configDelta.GetByKeyFilterPrefixes()) {
+                if (p > 0) {
+                    prefixes.push_back(p);
+                }
+            }
+            // Re-add full-key entry if EnableFilterByKey is enabled
+            if (config.GetEnableFilterByKey()) {
+                prefixes.push_back(keyCount);
+            }
+        }
+
+        SortUnique(prefixes);
+
+        config.ClearByKeyFilterPrefixes();
+        for (auto p : prefixes) {
+            config.AddByKeyFilterPrefixes(p);
+        }
         for (ui32 tid : tids) {
-            alter.SetByKeyFilter(tid, configDelta.GetEnableFilterByKey());
+            alter.SetByKeyFilterPrefixes(tid, prefixes);
         }
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1066,6 +1066,20 @@ bool TPartitionConfigMerger::ApplyChanges(
         result.SetEnableFilterByKey(changes.GetEnableFilterByKey());
     }
 
+    if (changes.ByKeyFilterPrefixesSize() > 0) {
+        TVector<ui32> prefixes;
+        for (auto p : changes.GetByKeyFilterPrefixes()) {
+            if (p > 0) {
+                prefixes.push_back(p);
+            }
+        }
+        SortUnique(prefixes);
+        result.ClearByKeyFilterPrefixes();
+        for (auto p : prefixes) {
+            result.AddByKeyFilterPrefixes(p);
+        }
+    }
+
     if (changes.HasExecutorFastLogPolicy()) {
         result.SetExecutorFastLogPolicy(changes.GetExecutorFastLogPolicy());
     }

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1690,16 +1690,51 @@ namespace NSchemeShardUT_Private {
         NKikimrProto::EReplyStatus status = LocalSchemeTx(runtime, tabletId, "", true, scheme, err);
         UNIT_ASSERT_VALUES_EQUAL(status, NKikimrProto::EReplyStatus::OK);
         //Cdbg << scheme << "\n";
+
+        // Find the table info to get key column count
+        ui32 keyColumnCount = 0;
+        for (ui32 i = 0; i < scheme.DeltaSize(); ++i) {
+            const auto& d = scheme.GetDelta(i);
+            if (d.GetDeltaType() == NTabletFlatScheme::TAlterRecord::AddTable &&
+                d.GetTableId() == table)
+            {
+                // Count key columns by counting subsequent AddColumnToKey deltas for this table
+                for (ui32 j = i + 1; j < scheme.DeltaSize(); ++j) {
+                    const auto& dj = scheme.GetDelta(j);
+                    if (dj.GetDeltaType() == NTabletFlatScheme::TAlterRecord::AddTable) {
+                        // Stop at the next table definition
+                        break;
+                    }
+                    if (dj.GetDeltaType() == NTabletFlatScheme::TAlterRecord::AddColumnToKey &&
+                        dj.GetTableId() == table)
+                    {
+                        keyColumnCount++;
+                    }
+                }
+                break;
+            }
+        }
+
+        // With unified system, ByKeyFilter is now stored as a ByKeyFilterPrefixes entry
+        // with prefix length = key column count
         for (ui32 i = 0; i < scheme.DeltaSize(); ++i) {
             const auto& d = scheme.GetDelta(i);
             if (d.GetDeltaType() == NTabletFlatScheme::TAlterRecord::SetTable &&
                 d.GetTableId() == table &&
-                d.HasByKeyFilter())
+                d.ByKeyFilterPrefixesSize() > 0)
             {
-                return d.GetByKeyFilter();
+                // Check if full-key bloom is enabled
+                // Full-key bloom is represented as a prefix entry with length = key column count
+                for (ui32 j = 0; j < d.ByKeyFilterPrefixesSize(); ++j) {
+                    if (d.GetByKeyFilterPrefixes(j) == keyColumnCount && keyColumnCount > 0) {
+                        return true;
+                    }
+                }
+                return false;
             }
         }
-        UNIT_ASSERT_C(false, "ByKeyFilter delta record not found");
+
+        // No SetTable delta found with ByKeyFilterPrefixes - bloom is disabled
         return false;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

#### Summary
* Add prefix bloom filter support for row tables via `INDEX ... LOCAL USING bloom_filter ON (columns)` SQL syntax
* Unify the legacy full-key bloom filter `(KEY_BLOOM_FILTER = ENABLED)` with the new prefix bloom filter system — they now share the same storage, schema path, query logic, and writer code
* A table can have multiple bloom filters with different prefix lengths (e.g., {1, 3} for a 3-column PK creates blooms on the first column and on the full key)
* Prefix lengths are stored de-duplicated in the partition config
* At query time, all bloom filters are checked — a row is skipped if any bloom rejects it


#### Not yet done
* `ALTER TABLE ... DROP INDEX` does not work for local bloom filter indexes on row tables. Local bloom filters are stored directly in PartitionConfig.ByKeyFilterPrefixes and are not registered in the schemeshard's index catalog (context.SS->Indexes). The DROP INDEX operation expects a TTableIndex path child, which doesn't exist for local blooms. 
* Schemeshard index registration: Local bloom filter indexes should be registered as TTableIndex entries in the schemeshard (similar to global indexes but without creating a separate table). This would enable: (1) DROP INDEX by name, (2) SHOW CREATE TABLE listing bloom indexes, (3) preventing duplicate indexes with the same column set, (4) proper schema introspection. Currently the index name from INDEX bf LOCAL USING bloom_filter ON (...) is discarded at the gateway level — only the prefix column count is stored.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
