### PR TITLE
YQL-20095: Remove unused variables

### DIFF
--- a/ydb/core/client/minikql_compile/yql_expr_minikql_compile_ut.cpp
+++ b/ydb/core/client/minikql_compile/yql_expr_minikql_compile_ut.cpp
@@ -342,7 +342,6 @@ Y_UNIT_TEST_SUITE(TTestYqlToMiniKQLCompile) {
 
         TServices services;
         RegisterSampleTables(services);
-        auto pgm = ProgramText2Bin(programText, services);
         Y_DO_NOT_OPTIMIZE_AWAY(ProgramText2Bin(programText, services));
     }
 }

--- a/ydb/core/client/minikql_compile/yql_expr_minikql_compile_ut.cpp
+++ b/ydb/core/client/minikql_compile/yql_expr_minikql_compile_ut.cpp
@@ -343,6 +343,7 @@ Y_UNIT_TEST_SUITE(TTestYqlToMiniKQLCompile) {
         TServices services;
         RegisterSampleTables(services);
         auto pgm = ProgramText2Bin(programText, services);
+        Y_DO_NOT_OPTIMIZE_AWAY(ProgramText2Bin(programText, services));
     }
 }
 } // namespace NYql

--- a/ydb/library/yql/dq/tasks/dq_task_program.cpp
+++ b/ydb/library/yql/dq/tasks/dq_task_program.cpp
@@ -18,7 +18,7 @@ public:
 
     TCallableVisitFunc operator()(TInternName name) {
         if (SpillingSettings.IsGraceJoinSpillingEnabled() && (name == "GraceJoin" || name == "GraceSelfJoin")) {
-            return [name](NKikimr::NMiniKQL::TCallable& callable, const TTypeEnvironment& env) {
+            return [](NKikimr::NMiniKQL::TCallable& callable, const TTypeEnvironment& env) {
                 TCallableBuilder callableBuilder(env,
                     TStringBuilder() << callable.GetType()->GetName() << "WithSpilling",
                     callable.GetType()->GetReturnType(), false);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I am going to enable Clang Tidy `modernize-use-equals-default` check for `yql/essentials`. After replacement of trivial method implementations with `= default` compiler started to be able to infer unused variables, as destructor effectiveness can be inferred.

Destructor & Unused Var Example: https://godbolt.org/z/fvaMqPTzW.
Related PR: https://nda.ya.ru/t/q2zvboOh7VZept.
