### PR TITLE
[EXT-2003] MVP: load secrets from file

### DIFF
--- a/ydb/mvp/core/mvp_startup_options_validation.cpp
+++ b/ydb/mvp/core/mvp_startup_options_validation.cpp
@@ -28,10 +28,6 @@ NMvp::TOAuth2Exchange::TCredentials::EType InferCredsType(const NMvp::TOAuth2Exc
 }
 
 void NormalizeSecretInfo(NMvp::TSecretInfo* secretInfo) {
-    if (!secretInfo->GetSecret().empty()) {
-        secretInfo->SetSecret(StripString(secretInfo->GetSecret()));
-    }
-
     const bool hasSecret = !secretInfo->GetSecret().empty();
     const bool hasSecretFile = !secretInfo->GetSecretFile().empty();
 

--- a/ydb/mvp/core/mvp_startup_options_validation.cpp
+++ b/ydb/mvp/core/mvp_startup_options_validation.cpp
@@ -28,6 +28,7 @@ NMvp::TOAuth2Exchange::TCredentials::EType InferCredsType(const NMvp::TOAuth2Exc
 }
 
 void NormalizeSecretInfo(NMvp::TSecretInfo* secretInfo) {
+    secretInfo->SetSecret(StripString(secretInfo->GetSecret()));
     const bool hasSecret = !secretInfo->GetSecret().empty();
     const bool hasSecretFile = !secretInfo->GetSecretFile().empty();
 

--- a/ydb/mvp/core/mvp_startup_options_validation.cpp
+++ b/ydb/mvp/core/mvp_startup_options_validation.cpp
@@ -28,6 +28,10 @@ NMvp::TOAuth2Exchange::TCredentials::EType InferCredsType(const NMvp::TOAuth2Exc
 }
 
 void NormalizeSecretInfo(NMvp::TSecretInfo* secretInfo) {
+    if (!secretInfo->GetSecret().empty()) {
+        secretInfo->SetSecret(StripString(secretInfo->GetSecret()));
+    }
+
     const bool hasSecret = !secretInfo->GetSecret().empty();
     const bool hasSecretFile = !secretInfo->GetSecretFile().empty();
 
@@ -60,6 +64,7 @@ void NormalizeSecretInfo(NMvp::TSecretInfo* secretInfo) {
         }
 
         secretInfo->SetSecret(std::move(secret));
+        secretInfo->ClearSecretFile();
     }
 }
 

--- a/ydb/mvp/core/mvp_startup_options_validation.cpp
+++ b/ydb/mvp/core/mvp_startup_options_validation.cpp
@@ -4,6 +4,8 @@
 
 #include <util/generic/yexception.h>
 #include <util/string/builder.h>
+#include <util/string/strip.h>
+#include <util/stream/file.h>
 
 namespace NMVP {
 namespace {
@@ -23,6 +25,42 @@ NMvp::TOAuth2Exchange::TCredentials::EType InferCredsType(const NMvp::TOAuth2Exc
         return TCreds::FIXED;
     }
     return TCreds::TYPE_UNSPECIFIED;
+}
+
+void NormalizeSecretInfo(NMvp::TSecretInfo* secretInfo) {
+    const bool hasSecret = !secretInfo->GetSecret().empty();
+    const bool hasSecretFile = !secretInfo->GetSecretFile().empty();
+
+    if (hasSecret && hasSecretFile) {
+        ythrow yexception() << CONFIG_ERROR_PREFIX
+                            << "secret_info '" << secretInfo->GetName()
+                            << "' must not set both secret and secret_file.";
+    }
+
+    if (!hasSecret && !hasSecretFile) {
+        ythrow yexception() << CONFIG_ERROR_PREFIX
+                            << "secret_info '" << secretInfo->GetName()
+                            << "' requires either secret or secret_file.";
+    }
+
+    if (hasSecretFile) {
+        TString secret;
+        try {
+            secret = StripString(TFileInput(secretInfo->GetSecretFile()).ReadAll());
+        } catch (const std::exception& e) {
+            ythrow yexception() << CONFIG_ERROR_PREFIX
+                                << "unable to read secret_file for secret_info '" << secretInfo->GetName()
+                                << "': " << e.what();
+        }
+
+        if (secret.empty()) {
+            ythrow yexception() << CONFIG_ERROR_PREFIX
+                                << "secret_file for secret_info '" << secretInfo->GetName()
+                                << "' resolved to empty secret.";
+        }
+
+        secretInfo->SetSecret(std::move(secret));
+    }
 }
 
 } // namespace
@@ -101,6 +139,10 @@ void TMvpStartupOptions::ValidateOAuth2CredentialsFields(
 }
 
 void TMvpStartupOptions::ValidateTokensConfig() {
+    for (auto& secretInfo : *Tokens.MutableSecretInfo()) {
+        NormalizeSecretInfo(&secretInfo);
+    }
+
     for (const auto& tokenExchangeInfo : Tokens.GetOAuth2Exchange()) {
         RequireNonEmptyField(tokenExchangeInfo.GetTokenEndpoint(), "'token_endpoint'", "in oauth2_exchange token config");
         if (!tokenExchangeInfo.HasSubjectCredentials()) {

--- a/ydb/mvp/core/mvp_startup_options_validation_ut.cpp
+++ b/ydb/mvp/core/mvp_startup_options_validation_ut.cpp
@@ -194,4 +194,28 @@ SecretInfo {
             "mvp_validation_secret_missing",
             "requires either secret or secret_file");
     }
+
+    Y_UNIT_TEST(SecretInfoWithUnreadableSecretFileThrows) {
+        AssertTokenFileConfigThrows(R"pb(
+AccessServiceType: nebius_v1
+SecretInfo {
+  Name: "secret-name"
+  SecretFile: "/definitely/not/existing/secret.txt"
+}
+)pb",
+            "mvp_validation_secret_unreadable",
+            "unable to read secret_file for secret_info 'secret-name'");
+    }
+
+    Y_UNIT_TEST(SecretInfoWithWhitespaceSecretFileThrows) {
+        TTempFileHandle secretFile = MakeTestFile("   \n\t  ", "mvp_validation_empty_secret", ".txt");
+        AssertTokenFileConfigThrows(TStringBuilder()
+                << "AccessServiceType: nebius_v1\n"
+                << "SecretInfo {\n"
+                << "  Name: \"secret-name\"\n"
+                << "  SecretFile: \"" << secretFile.Name() << "\"\n"
+                << "}\n",
+            "mvp_validation_secret_empty_after_strip",
+            "resolved to empty secret");
+    }
 }

--- a/ydb/mvp/core/mvp_startup_options_validation_ut.cpp
+++ b/ydb/mvp/core/mvp_startup_options_validation_ut.cpp
@@ -170,4 +170,28 @@ generic:
 )",
             "auth.tokens.access_service_type must match access_service_type");
     }
+
+    Y_UNIT_TEST(SecretInfoWithSecretAndSecretFileThrows) {
+        AssertTokenFileConfigThrows(R"pb(
+AccessServiceType: nebius_v1
+SecretInfo {
+  Name: "secret-name"
+  Secret: "inline-secret"
+  SecretFile: "/tmp/secret.txt"
+}
+)pb",
+            "mvp_validation_secret_and_secret_file",
+            "must not set both secret and secret_file");
+    }
+
+    Y_UNIT_TEST(SecretInfoWithoutSecretAndSecretFileThrows) {
+        AssertTokenFileConfigThrows(R"pb(
+AccessServiceType: nebius_v1
+SecretInfo {
+  Name: "secret-name"
+}
+)pb",
+            "mvp_validation_secret_missing",
+            "requires either secret or secret_file");
+    }
 }

--- a/ydb/mvp/core/mvp_startup_options_validation_ut.cpp
+++ b/ydb/mvp/core/mvp_startup_options_validation_ut.cpp
@@ -32,6 +32,21 @@ generic:
     AssertYamlThrows(yaml, errorPart);
 }
 
+TMvpStartupOptions MakeOptsFromTokenFileConfig(const TString& tokenFileProto,
+                                               const TString& tokenFileName)
+{
+    TTempFileHandle tmpToken = MakeTestFile(tokenFileProto, tokenFileName, ".pb.txt");
+    TTempFileHandle tmpYaml = MakeTestFile(TStringBuilder() << R"(
+generic:
+  access_service_type: "nebius_v1"
+  auth:
+    token_file: )" << tmpToken.Name() << "\n",
+        "mvp_startup_options_validation",
+        ".yaml");
+    const char* argv[] = {"mvp_test", "--config", tmpYaml.Name().c_str()};
+    return MakeOpts(argv);
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TMvpStartupOptionsValidation) {
@@ -217,5 +232,22 @@ SecretInfo {
                 << "}\n",
             "mvp_validation_secret_empty_after_strip",
             "resolved to empty secret");
+    }
+
+    Y_UNIT_TEST(SecretInfoFromSecretFileIsNormalized) {
+        TTempFileHandle secretFile = MakeTestFile("  normalized-secret \n", "mvp_validation_secret_normalize", ".txt");
+        TMvpStartupOptions opts = MakeOptsFromTokenFileConfig(TStringBuilder()
+                << "AccessServiceType: nebius_v1\n"
+                << "SecretInfo {\n"
+                << "  Name: \"secret-name\"\n"
+                << "  SecretFile: \"" << secretFile.Name() << "\"\n"
+                << "}\n",
+            "mvp_validation_secret_normalize");
+
+        UNIT_ASSERT_VALUES_EQUAL(opts.Tokens.SecretInfoSize(), 1);
+        const auto& secretInfo = opts.Tokens.GetSecretInfo(0);
+        UNIT_ASSERT_VALUES_EQUAL(secretInfo.GetName(), "secret-name");
+        UNIT_ASSERT_VALUES_EQUAL(secretInfo.GetSecret(), "normalized-secret");
+        UNIT_ASSERT(secretInfo.GetSecretFile().empty());
     }
 }

--- a/ydb/mvp/core/protos/mvp.proto
+++ b/ydb/mvp/core/protos/mvp.proto
@@ -56,6 +56,7 @@ message TOAuthInfo {
 message TSecretInfo {
     optional string Name = 1;
     optional string Secret = 2;
+    optional string SecretFile = 3;
 }
 
 message TMetadataTokenInfo {

--- a/ydb/mvp/oidc_proxy/mvp_config_validation_ut.cpp
+++ b/ydb/mvp/oidc_proxy/mvp_config_validation_ut.cpp
@@ -97,35 +97,4 @@ oidc:
         UNIT_ASSERT_EXCEPTION_CONTAINS(TMVP(3, argv), yexception, "requires either secret or secret_file");
     }
 
-    Y_UNIT_TEST(SecretInfoValueCanBeLoadedFromSecretFile) {
-        TTempFileHandle tmpSecretFile = MakeTestFile("secret-from-file", "mvp_oidc_proxy_secret_value", ".txt");
-        TString tokenFile = TStringBuilder()
-            << "OAuthInfo {\n"
-            << "  Name: \"service-account-jwt\"\n"
-            << "  Endpoint: \"grpc://localhost:8655\"\n"
-            << "  Token: \"oauth-token\"\n"
-            << "}\n"
-            << "SecretInfo {\n"
-            << "  Name: \"secret-name\"\n"
-            << "  SecretFile: \"" << tmpSecretFile.Name() << "\"\n"
-            << "}\n";
-        TTempFileHandle tmpTokenFile = MakeTestFile(tokenFile, "mvp_oidc_proxy_secret_info_file", ".pb.txt");
-
-        TString yaml = TStringBuilder() << R"(
-generic:
-  access_service_type: "yandex_v2"
-  auth:
-    token_file: )" << tmpTokenFile.Name() << R"(
-oidc:
-  client_id: "test-client"
-  secret_name: "secret-name"
-  session_service_endpoint: "localhost:8655"
-  session_service_token_name: "service-account-jwt"
-  authorization_server_address: "http://auth.test.net"
-)";
-        TTempFileHandle tmpYaml = MakeTestFile(yaml, "mvp_oidc_proxy_secret_info_file_yaml", ".yaml");
-
-        const char* argv[] = {"mvp_test", "--config", tmpYaml.Name().c_str()};
-        UNIT_ASSERT_NO_EXCEPTION(TMVP(3, argv));
-    }
 }

--- a/ydb/mvp/oidc_proxy/mvp_config_validation_ut.cpp
+++ b/ydb/mvp/oidc_proxy/mvp_config_validation_ut.cpp
@@ -94,6 +94,38 @@ oidc:
         TTempFileHandle tmpYaml = MakeTestFile(yaml, "mvp_oidc_proxy_empty_secret_info", ".yaml");
 
         const char* argv[] = {"mvp_test", "--config", tmpYaml.Name().c_str()};
-        UNIT_ASSERT_EXCEPTION_CONTAINS(TMVP(3, argv), yexception, "has empty value in auth token config secret_info");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(TMVP(3, argv), yexception, "requires either secret or secret_file");
+    }
+
+    Y_UNIT_TEST(SecretInfoValueCanBeLoadedFromSecretFile) {
+        TTempFileHandle tmpSecretFile = MakeTestFile("secret-from-file", "mvp_oidc_proxy_secret_value", ".txt");
+        TString tokenFile = TStringBuilder()
+            << "OAuthInfo {\n"
+            << "  Name: \"service-account-jwt\"\n"
+            << "  Endpoint: \"grpc://localhost:8655\"\n"
+            << "  Token: \"oauth-token\"\n"
+            << "}\n"
+            << "SecretInfo {\n"
+            << "  Name: \"secret-name\"\n"
+            << "  SecretFile: \"" << tmpSecretFile.Name() << "\"\n"
+            << "}\n";
+        TTempFileHandle tmpTokenFile = MakeTestFile(tokenFile, "mvp_oidc_proxy_secret_info_file", ".pb.txt");
+
+        TString yaml = TStringBuilder() << R"(
+generic:
+  access_service_type: "yandex_v2"
+  auth:
+    token_file: )" << tmpTokenFile.Name() << R"(
+oidc:
+  client_id: "test-client"
+  secret_name: "secret-name"
+  session_service_endpoint: "localhost:8655"
+  session_service_token_name: "service-account-jwt"
+  authorization_server_address: "http://auth.test.net"
+)";
+        TTempFileHandle tmpYaml = MakeTestFile(yaml, "mvp_oidc_proxy_secret_info_file_yaml", ".yaml");
+
+        const char* argv[] = {"mvp_test", "--config", tmpYaml.Name().c_str()};
+        UNIT_ASSERT_NO_EXCEPTION(TMVP(3, argv));
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds support for providing SecretInfo values via an on-disk file and validates SecretInfo configuration accordingly, primarily to support OIDC proxy secret loading from the token file config.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Extend TSecretInfo proto with SecretFile.
- Add startup options validation + normalization that loads secrets from secret_file.
- Update/extend unit tests to cover the new validation rules and file-based secret loading.
