### PR TITLE
grpc service: fix uaf in ydb over fq [alternative]

### DIFF
--- a/ydb/core/grpc_services/local_grpc/local_grpc.h
+++ b/ydb/core/grpc_services/local_grpc/local_grpc.h
@@ -41,7 +41,8 @@ public:
     TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const override {
         auto value = BaseRequest_->GetPeerMetaValues(TString{key});
         if (value) {
-            return {std::move(*value)};
+            MetaValueCache_ = std::move(*value);
+            return {TStringBuf(MetaValueCache_)};
         }
         return {};
     }
@@ -104,6 +105,7 @@ private:
 
     NYql::TIssueManager IssueManager_;
     google::protobuf::Arena Arena_;
+    mutable TString MetaValueCache_;
 };
 
 template<typename TReq, typename TResp>

--- a/ydb/core/public_http/grpc_request_context_wrapper.cpp
+++ b/ydb/core/public_http/grpc_request_context_wrapper.cpp
@@ -58,15 +58,17 @@ namespace NKikimr::NPublicHttp {
 
     TVector<TStringBuf> TGrpcRequestContextWrapper::GetPeerMetaValues(TStringBuf key) const {
         if (key == "x-ydb-database"sv) {
-            return { RequestContext.GetDb() };
+            MetaValueCache = RequestContext.GetDb();
+            return { TStringBuf(MetaValueCache) };
         }
 
         if (key == "x-ydb-fq-project"sv) {
-            return { LongProject };
+            return { TStringBuf(LongProject) };
         }
 
         if (key == "x-ydb-auth-ticket"sv) {
-            return { RequestContext.GetToken() };
+            MetaValueCache = RequestContext.GetToken();
+            return { TStringBuf(MetaValueCache) };
         }
 
         return { };

--- a/ydb/core/public_http/grpc_request_context_wrapper.h
+++ b/ydb/core/public_http/grpc_request_context_wrapper.h
@@ -20,6 +20,7 @@ private:
     google::protobuf::Arena Arena;
     TJsonSettings JsonSettings;
     TInstant DeadlineAt;
+    mutable TString MetaValueCache;
 
 public:
     TGrpcRequestContextWrapper(const THttpRequestContext& requestContext, std::unique_ptr<NProtoBuf::Message> request, TReplySender replySender);

--- a/ydb/tests/fq/s3/test_ydb_over_fq.py
+++ b/ydb/tests/fq/s3/test_ydb_over_fq.py
@@ -366,6 +366,7 @@ class TestYdbOverFq(TestYdsBase):
     @yq_all
     @pytest.mark.parametrize("client", [{"folder_id": "my_folder"}], indirect=True)
     def test_insert_data_query(self, kikimr, s3, client, unique_prefix, yq_version):
+        self.make_s3_client(s3)  # makes bucket
         kikimr.control_plane.wait_bootstrap()
         connection_id = client.create_storage_connection(unique_prefix + "fruitbucket", "fbucket").result.connection_id
         bind_name = unique_prefix + "fruits_bind"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

We returned `TStringBuf` reference to local `TString`; that's broken with (at least) sso (and msan complains);
Obviously, this variant is fragile, but it avoids interface change and I verified all current callers should be fine.
Closes: #34939