### PR TITLE
Forbid requests with empty database to static nodes P.1

### DIFF
--- a/ydb/core/client/server/grpc_server.cpp
+++ b/ydb/core/client/server/grpc_server.cpp
@@ -126,6 +126,7 @@ void TGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                       \
         YDB_API_DEFAULT_COUNTER_BLOCK(legacy, methodName), \
         auditMode,                                         \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,          \
         COMMON,                                            \
         TGrpcRequestLegacyCall,                            \
         GRpcRequestProxyId_,                               \

--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -423,6 +423,11 @@ struct TAuditMode {
     }
 };
 
+enum class EEmptyDatabaseMode {
+    EmptyDatabaseAllowed,
+    EmptyDatabaseForbidden,
+};
+
 class ICheckerIface;
 
 // The way to pass some common data to request processing
@@ -438,6 +443,7 @@ struct TRequestAuxSettings {
     void (*CustomAttributeProcessor)(const NKikimrScheme::TEvDescribeSchemeResult& schemeData, ICheckerIface*) = nullptr;
     TAuditMode AuditMode = {};
     NJaegerTracing::ERequestType RequestType = NJaegerTracing::ERequestType::UNSPECIFIED;
+    EEmptyDatabaseMode EmptyDatabaseMode = EEmptyDatabaseMode::EmptyDatabaseForbidden;
 };
 
 class TGRpcRequestProxySimple;
@@ -510,6 +516,10 @@ public:
     }
     virtual void SetAuditLogHook(TAuditLogHook&& hook) = 0;
     virtual void SetDiskQuotaExceeded(bool disk) = 0;
+
+    virtual EEmptyDatabaseMode GetEmptyDatabaseMode() const {
+        return EEmptyDatabaseMode::EmptyDatabaseForbidden;
+    }
 
     virtual TString GetRpcMethodName() const = 0;
 };
@@ -768,6 +778,10 @@ public:
 
     void SetAuditLogHook(TAuditLogHook&&) override {
         Y_ABORT("unimplemented for TRefreshTokenImpl");
+    }
+
+    EEmptyDatabaseMode GetEmptyDatabaseMode() const override {
+        return EEmptyDatabaseMode::EmptyDatabaseForbidden;
     }
 
     TString GetRpcMethodName() const override {
@@ -1039,6 +1053,10 @@ public:
 
     bool* IsTracingDecided() override {
         return &IsTracingDecided_;
+    }
+
+    EEmptyDatabaseMode GetEmptyDatabaseMode() const override {
+        return AuxSettings.EmptyDatabaseMode;
     }
 
     // IRequestCtxBase
@@ -1666,6 +1684,10 @@ public:
         return AuxSettings.AuditMode.IsModifying && AuxSettings.AuditMode.LogClass == TAuditMode::TLogClassConfig::Dml && !this->IsInternalCall();
     }
 
+    EEmptyDatabaseMode GetEmptyDatabaseMode() const override {
+        return AuxSettings.EmptyDatabaseMode;
+    }
+
 private:
     std::function<void(std::unique_ptr<TRequestIface>, const IFacilityProvider&)> PassMethod;
     const TRequestAuxSettings AuxSettings;
@@ -2007,6 +2029,10 @@ public:
 
     TAuditMode GetAuditMode() const override {
         return AuditMode;
+    }
+
+    EEmptyDatabaseMode GetEmptyDatabaseMode() const override {
+        return EEmptyDatabaseMode::EmptyDatabaseAllowed;
     }
 
     TString GetRpcMethodName() const override {

--- a/ydb/core/grpc_services/grpc_request_proxy.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy.cpp
@@ -183,6 +183,7 @@ private:
         // do not check connect rights for the deprecated requests without database
         // remove this along with AllowYdbRequestsWithoutDatabase flag
         bool skipCheckConnectRights = false;
+        const EEmptyDatabaseMode emptyDatabaseMode = requestBaseCtx->GetEmptyDatabaseMode();
 
         if (state.State == NYdbGrpc::TAuthState::AS_NOT_PERFORMED) {
             if (IsBootstrapClusterEvent(event)) {
@@ -196,7 +197,9 @@ private:
             } else {
                 if (!std::is_same_v<TEvent, TEvRequestAuthAndCheck>) { // TEvRequestAuthAndCheck is allowed to be processed without database
                     Counters->IncEmptyDatabaseNameCounter();
-                    if (DynamicNode && !AllowYdbRequestsWithoutDatabase) {
+                    if (!AllowYdbRequestsWithoutDatabase &&
+                        (DynamicNode || emptyDatabaseMode == EEmptyDatabaseMode::EmptyDatabaseForbidden))
+                    {
                         requestBaseCtx->ReplyUnauthenticated("Requests without specified database are not allowed");
                         requestBaseCtx->FinishSpan();
                         return;

--- a/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
+++ b/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
@@ -334,6 +334,7 @@ TMaybe<NYdb::TResultSet> THttpProxyTestMock::RunYqlDataQuery(TString query) {
     TString endpoint = TStringBuilder() << "localhost:" << KikimrGrpcPort;
     auto driverConfig = NYdb::TDriverConfig()
         .SetEndpoint(endpoint)
+        .SetDatabase("/Root")
         .SetAuthToken("root@builtin")
         .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
     NYdb::TDriver driver(driverConfig);

--- a/ydb/core/statistics/database/ut/ut_database.cpp
+++ b/ydb/core/statistics/database/ut/ut_database.cpp
@@ -101,6 +101,7 @@ Y_UNIT_TEST_SUITE(StatisticsSaveLoad) {
         auto test = [&] () {
             auto driverConfig = NYdb::TDriverConfig()
                 .SetEndpoint(env.GetEndpoint())
+                .SetDatabase("/Root")
                 .SetAuthToken("user@builtin");
             auto driver = NYdb::TDriver(driverConfig);
             auto db = NYdb::NTable::TTableClient(driver);

--- a/ydb/library/grpc/server/grpc_method_setup.h
+++ b/ydb/library/grpc/server/grpc_method_setup.h
@@ -22,7 +22,7 @@
 #define STREAMING_REQUEST_CLASS(inputType, outputType) ::NKikimr::NGRpcServer::TGRpcStreamingRequest<inputType, outputType, std::remove_reference_t<decltype(*this)>, ::NKikimrServices::GRPC_SERVER>
 
 // Implies usage from inside grpc service class, derived from TGrpcServiceBase
-#define SETUP_RUNTIME_EVENT_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, counterBlock, auditMode, runtimeEventType, operationCallClass, grpcProxyId, cq, limiter, customAttributeProcessorCallback) \
+#define SETUP_RUNTIME_EVENT_METHOD(methodName, inputType, outputType, methodCallback, rlMode, requestType, counterBlock, auditMode, emptyDatabaseMode, runtimeEventType, operationCallClass, grpcProxyId, cq, limiter, customAttributeProcessorCallback) \
     MakeIntrusive<::NKikimr::NGRpcService::TGRpcRequest<                                                  \
         inputType,                                                                                        \
         outputType,                                                                                       \
@@ -45,6 +45,7 @@
                         .CustomAttributeProcessor = customAttributeProcessorCallback,                     \
                         .AuditMode = auditMode,                                                           \
                         .RequestType = ::NKikimr::NJaegerTracing::ERequestType::requestType,              \
+                        .EmptyDatabaseMode = emptyDatabaseMode,                                           \
                     }));                                                                                  \
         },                                                                                                \
         &TGrpcAsyncService::Y_CAT(Request, methodName),                                                   \
@@ -55,7 +56,7 @@
     )->Run()
 
 // Setup for bidirectional streaming
-#define SETUP_RUNTIME_EVENT_STREAM_METHOD(methodName, inputType, outputType, rlMode, requestType, counterBlock, auditMode, operationCallClass, grpcProxyId, cq, limiter, customAttributeProcessorCallback) \
+#define SETUP_RUNTIME_EVENT_STREAM_METHOD(methodName, inputType, outputType, rlMode, requestType, counterBlock, auditMode, emptyDatabaseMode, operationCallClass, grpcProxyId, cq, limiter, customAttributeProcessorCallback)  \
     STREAMING_REQUEST_CLASS(inputType, outputType)::Start(this,                                                         \
         &Service_,                                                                                                      \
         cq,                                                                                                             \
@@ -71,6 +72,7 @@
                         .CustomAttributeProcessor = customAttributeProcessorCallback,                                   \
                         .AuditMode = auditMode,                                                                         \
                         .RequestType = ::NKikimr::NJaegerTracing::ERequestType::requestType,                            \
+                        .EmptyDatabaseMode = emptyDatabaseMode,                                                         \
                     }                                                                                                   \
                 )                                                                                                       \
             );                                                                                                          \
@@ -83,21 +85,22 @@
 
 // Common macro for gRPC methods setup
 // Use RLSWITCH or RLMODE macro for rlMode
-#define SETUP_METHOD(methodName, methodCallback, rlMode, requestType, counterName, auditMode)             \
-    SETUP_RUNTIME_EVENT_METHOD(methodName,                                                                \
-        YDB_API_DEFAULT_REQUEST_TYPE(methodName),                                                         \
-        YDB_API_DEFAULT_RESPONSE_TYPE(methodName),                                                        \
-        methodCallback,                                                                                   \
-        rlMode,                                                                                           \
-        requestType,                                                                                      \
-        YDB_API_DEFAULT_COUNTER_BLOCK(counterName, methodName),                                           \
-        auditMode,                                                                                        \
-        COMMON,                                                                                           \
-        ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                                               \
-        GRpcRequestProxyId_,                                                                              \
-        CQ_,                                                                                              \
-        nullptr,                                                                                          \
-        nullptr                                                                                           \
+#define SETUP_METHOD(methodName, methodCallback, rlMode, requestType, counterName, auditMode, emptyDatabaseMode)    \
+    SETUP_RUNTIME_EVENT_METHOD(methodName,                                                                          \
+        YDB_API_DEFAULT_REQUEST_TYPE(methodName),                                                                   \
+        YDB_API_DEFAULT_RESPONSE_TYPE(methodName),                                                                  \
+        methodCallback,                                                                                             \
+        rlMode,                                                                                                     \
+        requestType,                                                                                                \
+        YDB_API_DEFAULT_COUNTER_BLOCK(counterName, methodName),                                                     \
+        auditMode,                                                                                                  \
+        emptyDatabaseMode,                                                                                          \
+        COMMON,                                                                                                     \
+        ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                                                         \
+        GRpcRequestProxyId_,                                                                                        \
+        CQ_,                                                                                                        \
+        nullptr,                                                                                                    \
+        nullptr                                                                                                     \
     )
 
 #endif // GRPC_METHOD_SETUP_H

--- a/ydb/services/auth/grpc_service.cpp
+++ b/ydb/services/auth/grpc_service.cpp
@@ -29,7 +29,7 @@ void TGRpcAuthService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_LOGIN_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, login, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, login, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
 
     SETUP_LOGIN_METHOD(Login, DoLoginRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Login));
 

--- a/ydb/services/backup/grpc_service.cpp
+++ b/ydb/services/backup/grpc_service.cpp
@@ -18,7 +18,7 @@ void TGRpcBackupService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_BACKUP_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, backup, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, backup, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_BACKUP_METHOD(FetchBackupCollections, DoFetchBackupCollectionsRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_BACKUP_METHOD(ListBackupCollections, DoListBackupCollectionsRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());

--- a/ydb/services/bridge/grpc_service.cpp
+++ b/ydb/services/bridge/grpc_service.cpp
@@ -31,7 +31,7 @@ void TBridgeGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_BRIDGE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, bridge, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, bridge, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
 
     SETUP_BRIDGE_METHOD(GetClusterState, DoGetClusterState, RLMODE(Rps), BRIDGE_GETCLUSTERSTATE, TAuditMode::NonModifying());
     SETUP_BRIDGE_METHOD(UpdateClusterState, DoUpdateClusterState, RLMODE(Rps), BRIDGE_UPDATECLUSTERSTATE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/services/cms/cms_ut.cpp
+++ b/ydb/services/cms/cms_ut.cpp
@@ -46,7 +46,7 @@ struct TCmsTestSettingsWithAuth : TCmsTestSettings {
 
 using TKikimrWithGrpcAndRootSchema = NYdb::TBasicKikimrWithGrpcAndRootSchema<TCmsTestSettings>;
 
-static Ydb::StatusIds::StatusCode WaitForOperationStatus(std::shared_ptr<grpc::Channel> channel, const TString& opId, const TString &token = "") {
+static Ydb::StatusIds::StatusCode WaitForOperationStatus(std::shared_ptr<grpc::Channel> channel, const TString& opId,  const TString& database, const TString &token = "") {
     std::unique_ptr<Ydb::Operation::V1::OperationService::Stub> stub;
     stub = Ydb::Operation::V1::OperationService::NewStub(channel);
     Ydb::Operations::GetOperationRequest request;
@@ -57,6 +57,8 @@ static Ydb::StatusIds::StatusCode WaitForOperationStatus(std::shared_ptr<grpc::C
         grpc::ClientContext context;
         if (token)
             context.AddMetadata(YDB_AUTH_TICKET_HEADER, token);
+        context.AddMetadata(YDB_DATABASE_HEADER, database);
+
         auto status = stub->GetOperation(&context, request, &response);
         UNIT_ASSERT(status.ok());  //GRpc layer - OK
         if (response.operation().ready() == false) {
@@ -172,7 +174,7 @@ static void doSimpleTenantsTest(bool sync) {
     }
 
     if (!sync) {
-        auto status = WaitForOperationStatus(channel, id);
+        auto status = WaitForOperationStatus(channel, id, "/Root");
         UNIT_ASSERT_EQUAL(status, Ydb::StatusIds::SUCCESS);
     }
 
@@ -251,7 +253,7 @@ static void doSimpleTenantsTest(bool sync) {
         }
     }
     if (!sync) {
-        auto status = WaitForOperationStatus(channel, id);
+        auto status = WaitForOperationStatus(channel, id, "/Root");
         UNIT_ASSERT(status == Ydb::StatusIds::SUCCESS);
     }
 
@@ -321,7 +323,7 @@ void CheckCreateDatabase(NYdb::TBasicKikimrWithGrpcAndRootSchema<TTestSettings> 
         id = response.operation().id();
     }
     {
-        auto status = WaitForOperationStatus(channel, id, token);
+        auto status = WaitForOperationStatus(channel, id, "/Root", token);
         UNIT_ASSERT_VALUES_EQUAL(status, Ydb::StatusIds::SUCCESS);
     }
 
@@ -357,7 +359,7 @@ void CheckRemoveDatabase(std::shared_ptr<grpc::Channel> channel,
     }
 
     {
-        auto status = WaitForOperationStatus(channel, id);
+        auto status = WaitForOperationStatus(channel, id, "/Root");
         UNIT_ASSERT(status == code);
     }
 }

--- a/ydb/services/cms/grpc_service.cpp
+++ b/ydb/services/cms/grpc_service.cpp
@@ -25,6 +25,7 @@ void TGRpcCmsService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                                                                     \
         YDB_API_DEFAULT_COUNTER_BLOCK(cms, methodName),                                                  \
         auditMode,                                                                                       \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,                                                        \
         COMMON,                                                                                          \
         operationCallClass,                                                                              \
         GRpcRequestProxyId_,                                                                             \

--- a/ydb/services/config/grpc_service.cpp
+++ b/ydb/services/config/grpc_service.cpp
@@ -35,7 +35,7 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_BS_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, config, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
 
 #define SETUP_BOOTSTRAP_CLUSTER_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
     SETUP_RUNTIME_EVENT_METHOD(methodName,                 \
@@ -46,6 +46,7 @@ void TConfigGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                       \
         YDB_API_DEFAULT_COUNTER_BLOCK(config, methodName), \
         auditMode,                                         \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,          \
         BOOTSTRAP_CLUSTER,                                 \
         TGrpcRequestOperationCall,                         \
         GRpcRequestProxyId_,                               \

--- a/ydb/services/datastreams/grpc_service.cpp
+++ b/ydb/services/datastreams/grpc_service.cpp
@@ -53,6 +53,7 @@ void TGRpcDataStreamsService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
         requestType,                                             \
         YDB_API_DEFAULT_COUNTER_BLOCK(data_streams, methodName), \
         auditMode,                                               \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,              \
         COMMON,                                                  \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,      \
         GRpcRequestProxyId_,                                     \

--- a/ydb/services/discovery/grpc_service.cpp
+++ b/ydb/services/discovery/grpc_service.cpp
@@ -19,7 +19,7 @@ void TGRpcDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_DISCOVERY_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, discovery, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, discovery, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
 
     SETUP_DISCOVERY_METHOD(WhoAmI, DoWhoAmIRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_DISCOVERY_METHOD(NodeRegistration, DoNodeRegistrationRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::NodeRegistration));

--- a/ydb/services/dynamic_config/grpc_service.cpp
+++ b/ydb/services/dynamic_config/grpc_service.cpp
@@ -17,7 +17,7 @@ void TGRpcDynamicConfigService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logge
 #endif
 
 #define SETUP_CFG_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, console, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, console, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
 
     SETUP_CFG_METHOD(SetConfig, DoSetConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
     SETUP_CFG_METHOD(ReplaceConfig, DoReplaceConfigRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/services/fq/private_grpc.cpp
+++ b/ydb/services/fq/private_grpc.cpp
@@ -28,7 +28,7 @@ void TGRpcFqPrivateTaskService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logge
 #endif
 
 #define SETUP_FQ_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, fq_internal, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, fq_internal, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
 
     SETUP_FQ_METHOD(PingTask, DoFqPrivatePingTaskRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_FQ_METHOD(GetTask, DoFqPrivateGetTaskRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());

--- a/ydb/services/fq/ut_integration/fq_ut.cpp
+++ b/ydb/services/fq/ut_integration/fq_ut.cpp
@@ -118,9 +118,13 @@ namespace {
 Y_UNIT_TEST_SUITE(Yq_1) {
     Y_UNIT_TEST(Basic) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
-        ui16 grpc        = server.GetPort();
+        ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver      = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const auto folderId = "some_folder_id";
         const auto queryId = CreateNewHistoryAndWaitFinish(folderId, client, "select 1", FederatedQuery::QueryMeta::COMPLETED);
@@ -206,7 +210,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const TString folderId = "some_folder_id";
         auto expectedStatus = FederatedQuery::QueryMeta::COMPLETED;
@@ -217,7 +225,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const TString folderId = "some_folder_id";
         auto expectedStatus = FederatedQuery::QueryMeta::COMPLETED;
@@ -228,7 +240,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const TString folderId = "some_folder_id";
         auto expectedStatus = FederatedQuery::QueryMeta::COMPLETED;
@@ -239,7 +255,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const TString folderId = "some_folder_id";
 
@@ -252,7 +272,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const TString folderId = "some_folder_id";
         Warmup(folderId, client);
@@ -288,7 +312,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const size_t conns = 3;
         const auto folderId = TString(__func__) + "folder_id";
@@ -350,7 +378,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const TString folderId = "some_folder_id";
         Warmup(folderId, client);
@@ -371,7 +403,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TString location = TStringBuilder() << "localhost:" << grpc;
         TString userToken = "root@builtin";
         TString userId = "root";
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken(userToken);
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const auto folderId = TString(__func__) + "folder_id";
         Warmup(folderId, client);
@@ -423,7 +459,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const auto folderId = TString(__func__) + "folder_id";
         Warmup(folderId, client);
@@ -457,7 +497,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
         TString userToken = "root@builtin";
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken(userToken);
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
 
         const auto folderId = TString(__func__) + "folder_id";
@@ -492,7 +536,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
         TString userToken = "root@builtin";
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken(userToken);
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
 
         const auto folderId = TString(__func__) + "folder_id";
@@ -527,7 +575,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
         TString userToken = "root@builtin";
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken(userToken);
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const auto folderId = TString(__func__) + "folder_id";
         Warmup(folderId, client);
@@ -566,7 +618,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
         TString userToken = "root@builtin";
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken(userToken);
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
 
         const auto folderId = TString(__func__) + "folder_id";
@@ -620,7 +676,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
         TString userToken = "root@builtin";
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken(userToken);
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
 
         const TString yqlText  = "select count(*) from testdbWTF.connections";
@@ -633,7 +693,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
         TString userToken = "root@builtin";
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken(userToken);
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
 
         const auto folderId = TString(__func__) + "folder_id";
@@ -669,7 +733,11 @@ Y_UNIT_TEST_SUITE(Yq_1) {
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
         TString userToken = "root@builtin";
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken(userToken);
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
 
         const auto folderId = TString(__func__) + "folder_id";
@@ -707,9 +775,13 @@ Y_UNIT_TEST_SUITE(Yq_1) {
 
     Y_UNIT_TEST(DescribeJob) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
-        ui16 grpc        = server.GetPort();
+        ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver      = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const auto folderId = "some_folder_id";
         const auto queryId = CreateNewHistoryAndWaitFinish(folderId, client, "select 1", FederatedQuery::QueryMeta::COMPLETED);
@@ -746,9 +818,13 @@ Y_UNIT_TEST_SUITE(Yq_1) {
 
     Y_UNIT_TEST(DescribeQuery) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
-        ui16 grpc        = server.GetPort();
+        ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver      = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driverConfig = TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin");
+        auto driver = TDriver(driverConfig);
         NYdb::NFq::TClient client(driver);
         const auto folderId = "some_folder_id";
         const auto queryId = CreateNewHistoryAndWaitFinish(folderId, client, "select 1", FederatedQuery::QueryMeta::COMPLETED);

--- a/ydb/services/fq/ydb_over_fq.cpp
+++ b/ydb/services/fq/ydb_over_fq.cpp
@@ -32,6 +32,7 @@ void TGRpcYdbOverFqService::InitService(grpc::ServerCompletionQueue *cq, NYdbGrp
         requestType,                                                \
         YDB_API_DEFAULT_COUNTER_BLOCK(ydb_over_fq, methodName),     \
         auditMode,                                                  \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,                   \
         COMMON,                                                     \
         operationCallClass,                                         \
         GRpcRequestProxyId_,                                        \

--- a/ydb/services/kesus/grpc_service.cpp
+++ b/ydb/services/kesus/grpc_service.cpp
@@ -663,6 +663,7 @@ void TKesusGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             requestType,                                                               \
             YDB_API_DEFAULT_COUNTER_BLOCK(coordination, methodName),                   \
             auditMode,                                                                 \
+            EEmptyDatabaseMode::EmptyDatabaseForbidden,                                \
             COMMON,                                                                    \
             ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                        \
             GRpcRequestProxyId_,                                                       \
@@ -683,6 +684,7 @@ void TKesusGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             requestType,                                                                                   \
             YDB_API_DEFAULT_STREAM_COUNTER_BLOCK(coordination, methodName),                                \
             auditMode,                                                                                     \
+            EEmptyDatabaseMode::EmptyDatabaseForbidden,                                                    \
             operationCallClass,                                                                            \
             GRpcRequestProxyId_,                                                                           \
             cq,                                                                                            \

--- a/ydb/services/keyvalue/grpc_service_ut.cpp
+++ b/ydb/services/keyvalue/grpc_service_ut.cpp
@@ -66,7 +66,7 @@ namespace {
     struct VersionHolder {
         static constexpr Version version = StubVersion;
     };
-    
+
     template <Version StubVersion, typename Request>
     struct RequestToResponse {
         static_assert(false);
@@ -294,6 +294,7 @@ Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
 
     template <typename TCtx>
     void AdjustCtxForDB(TCtx &ctx) {
+        ctx.AddMetadata(NYdb::YDB_DATABASE_HEADER, "/Root");
         ctx.AddMetadata(NYdb::YDB_AUTH_TICKET_HEADER, "root@builtin");
     }
 

--- a/ydb/services/keyvalue/grpc_service_v1.cpp
+++ b/ydb/services/keyvalue/grpc_service_v1.cpp
@@ -48,7 +48,7 @@ void TKeyValueGRpcServiceV1::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) 
 #endif
 
 #define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, keyvalue, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, keyvalue, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_KV_METHOD(CreateVolume, DoCreateVolumeKeyValue, RLMODE(Rps), KEYVALUE_CREATEVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_KV_METHOD(DropVolume, DoDropVolumeKeyValue, RLMODE(Rps), KEYVALUE_DROPVOLUME, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));

--- a/ydb/services/keyvalue/grpc_service_v2.cpp
+++ b/ydb/services/keyvalue/grpc_service_v2.cpp
@@ -48,21 +48,22 @@ void TKeyValueGRpcServiceV2::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) 
 #error SETUP_KV_METHOD macro already defined
 #endif
 
-#define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditMode)             \
-    SETUP_RUNTIME_EVENT_METHOD(methodName,                                                                \
-        YDB_API_DEFAULT_REQUEST_TYPE(methodName),                                                         \
-        Y_CAT(methodName, Result),                                                        \
-        methodCallback,                                                                                   \
-        rlMode,                                                                                           \
-        requestType,                                                                                      \
-        YDB_API_DEFAULT_COUNTER_BLOCK(keyvalue_v2, methodName),                                           \
-        auditMode,                                                                                        \
-        COMMON,                                                                                           \
-        ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                                               \
-        GRpcRequestProxyId_,                                                                              \
-        CQ_,                                                                                              \
-        nullptr,                                                                                          \
-        nullptr                                                                                           \
+#define SETUP_KV_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
+    SETUP_RUNTIME_EVENT_METHOD(methodName,                                          \
+        YDB_API_DEFAULT_REQUEST_TYPE(methodName),                                   \
+        Y_CAT(methodName, Result),                                                  \
+        methodCallback,                                                             \
+        rlMode,                                                                     \
+        requestType,                                                                \
+        YDB_API_DEFAULT_COUNTER_BLOCK(keyvalue_v2, methodName),                     \
+        auditMode,                                                                  \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,                                 \
+        COMMON,                                                                     \
+        ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                       \
+        GRpcRequestProxyId_,                                                        \
+        CQ_,                                                                        \
+        nullptr,                                                                    \
+        nullptr                                                                     \
     )
 
     SETUP_KV_METHOD(AcquireLock, DoAcquireLockKeyValueV2, RLMODE(Rps), KEYVALUE_ACQUIRELOCK, TAuditMode::NonModifying());

--- a/ydb/services/local_discovery/grpc_service.cpp
+++ b/ydb/services/local_discovery/grpc_service.cpp
@@ -75,6 +75,7 @@ void TGRpcLocalDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logg
         requestType,                                          \
         YDB_API_DEFAULT_COUNTER_BLOCK(discovery, methodName), \
         auditMode,                                            \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,             \
         COMMON,                                               \
         operationCallClass,                                   \
         GRpcRequestProxyId_,                                  \

--- a/ydb/services/maintenance/grpc_service.cpp
+++ b/ydb/services/maintenance/grpc_service.cpp
@@ -26,6 +26,7 @@ void TGRpcMaintenanceService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
         requestType,                                            \
         YDB_API_DEFAULT_COUNTER_BLOCK(maintenance, methodName), \
         auditMode,                                              \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,               \
         COMMON,                                                 \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,     \
         GRpcRequestProxyId_,                                    \

--- a/ydb/services/monitoring/grpc_service.cpp
+++ b/ydb/services/monitoring/grpc_service.cpp
@@ -27,6 +27,7 @@ void TGRpcMonitoringService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) 
         requestType,                                                                                     \
         YDB_API_DEFAULT_COUNTER_BLOCK(monitoring, methodName),                                           \
         auditMode,                                                                                       \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,                                                        \
         COMMON,                                                                                          \
         operationCallClass,                                                                              \
         GRpcRequestProxyId_,                                                                             \

--- a/ydb/services/nbs/grpc_service.cpp
+++ b/ydb/services/nbs/grpc_service.cpp
@@ -31,7 +31,7 @@ void TNbsGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_NBS_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, nbs, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, nbs, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
 
     SETUP_NBS_METHOD(CreatePartition, DoCreatePartition, RLMODE(Rps), NBS_CREATEPARTITION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Default));
     SETUP_NBS_METHOD(DeletePartition, DoDeletePartition, RLMODE(Rps), NBS_DELETEPARTITION, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Default));

--- a/ydb/services/persqueue_cluster_discovery/grpc_service.cpp
+++ b/ydb/services/persqueue_cluster_discovery/grpc_service.cpp
@@ -78,7 +78,7 @@ void TGRpcPQClusterDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr 
 #endif
 
 #define SETUP_PQCD_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, pq_cluster_discovery, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, pq_cluster_discovery, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
 
     SETUP_PQCD_METHOD(DiscoverClusters, DoDiscoverPQClustersRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
 

--- a/ydb/services/persqueue_v1/persqueue.cpp
+++ b/ydb/services/persqueue_v1/persqueue.cpp
@@ -58,6 +58,7 @@ void TGRpcPersQueueService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                                 \
         YDB_API_DEFAULT_COUNTER_BLOCK(persistent_queue, methodName), \
         auditMode,                                                   \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,                    \
         COMMON,                                                      \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,          \
         GRpcRequestProxyId_,                                         \
@@ -76,6 +77,7 @@ void TGRpcPersQueueService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             requestType,                                                        \
             YDB_API_DEFAULT_STREAM_COUNTER_BLOCK(persistent_queue, methodName), \
             auditMode,                                                          \
+            EEmptyDatabaseMode::EmptyDatabaseAllowed,                           \
             operationCallClass,                                                 \
             GRpcRequestProxyId_,                                                \
             CQ_,                                                                \

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -565,6 +565,9 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         server.EnablePQLogs({ NKikimrServices::KQP_PROXY }, NLog::EPriority::PRI_EMERG);
         server.EnablePQLogs({ NKikimrServices::FLAT_TX_SCHEMESHARD }, NLog::EPriority::PRI_ERROR);
 
+        const TString databaseName = "/" + server.GetServerSettings().DomainName;
+        rcontext.AddMetadata(NYdb::YDB_DATABASE_HEADER, databaseName);
+
         auto readStream = StubP_->StreamRead(&rcontext);
         UNIT_ASSERT(readStream);
 
@@ -602,7 +605,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             //lock partition
             UNIT_ASSERT(readStream->Read(&resp));
             UNIT_ASSERT(resp.server_message_case() == Ydb::Topic::StreamReadMessage::FromServer::kStartPartitionSessionRequest);
-            UNIT_ASSERT_VALUES_EQUAL(resp.start_partition_session_request().partition_session().path(), "acc/topic1");
+            UNIT_ASSERT_VALUES_EQUAL(resp.start_partition_session_request().partition_session().path(), "topic1");
             UNIT_ASSERT(resp.start_partition_session_request().partition_session().partition_id() == 0);
 
             assignId = resp.start_partition_session_request().partition_session().partition_session_id();
@@ -1920,6 +1923,8 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         server.EnablePQLogs({ NKikimrServices::KQP_PROXY }, NLog::EPriority::PRI_EMERG);
         server.EnablePQLogs({ NKikimrServices::FLAT_TX_SCHEMESHARD }, NLog::EPriority::PRI_ERROR);
 
+        const TString databaseName = "/" + server.GetServerSettings().DomainName;
+        rcontext.AddMetadata(NYdb::YDB_DATABASE_HEADER, databaseName);
         rcontext.AddMetadata("x-ydb-auth-ticket", "user@" BUILTIN_ACL_DOMAIN);
 
         std::vector<std::pair<std::string, std::vector<std::string>>> permissions;
@@ -1971,7 +1976,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             //lock partition
             UNIT_ASSERT(readStream->Read(&resp));
             UNIT_ASSERT(resp.server_message_case() == Ydb::Topic::StreamReadMessage::FromServer::kStartPartitionSessionRequest);
-            UNIT_ASSERT_VALUES_EQUAL(resp.start_partition_session_request().partition_session().path(), "acc/topic1");
+            UNIT_ASSERT_VALUES_EQUAL(resp.start_partition_session_request().partition_session().path(), "topic1");
             UNIT_ASSERT(resp.start_partition_session_request().partition_session().partition_id() == 0);
 
             assignId = resp.start_partition_session_request().partition_session().partition_session_id();

--- a/ydb/services/persqueue_v1/topic.cpp
+++ b/ydb/services/persqueue_v1/topic.cpp
@@ -87,6 +87,7 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                                                                      \
         YDB_API_DEFAULT_COUNTER_BLOCK(topic, methodName),                                                 \
         auditMode,                                                                                        \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,                                                         \
         COMMON,                                                                                           \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                                               \
         GRpcRequestProxyId_,                                                                              \
@@ -102,6 +103,7 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             requestType,                                             \
             YDB_API_DEFAULT_STREAM_COUNTER_BLOCK(topic, methodName), \
             auditMode,                                               \
+            EEmptyDatabaseMode::EmptyDatabaseAllowed,                \
             operationCallClass,                                      \
             GRpcRequestProxyId_,                                     \
             CQ_,                                                     \

--- a/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
@@ -37,8 +37,9 @@ using namespace NThreading;
 using namespace NNetClassifier;
 
 
-#define MAKE_WRITE_STREAM(TOKEN)                                     \
+#define MAKE_WRITE_STREAM(DATABASE, TOKEN)                           \
     grpc::ClientContext context;                                     \
+    context.AddMetadata(NYdb::YDB_DATABASE_HEADER, DATABASE);        \
     context.AddMetadata(NYdb::YDB_AUTH_TICKET_HEADER, TOKEN);        \
     auto stream = server.ServiceStub->StreamingWrite(&context);      \
 
@@ -70,10 +71,12 @@ public:
         runtime->GetAppData().PQConfig.SetRequireCredentialsInNewProtocol(true);
         runtime->GetAppData().EnforceUserTokenRequirement = true;
         TVector<TString> invalidTokens = {TString(), "test_user", "test_user@invalid_domain"};
+        const TString databaseName = "/" + server.GetServerSettings().DomainName;
 
         for (const auto &invalidToken : invalidTokens) {
             Cerr << "Invalid token under test is '" << invalidToken << "'" << Endl;
-            MAKE_WRITE_STREAM(invalidToken);
+
+            MAKE_WRITE_STREAM(databaseName, invalidToken);
 
             // TODO: Message should be written to gRPC in order to get error. Fix gRPC data plane API code if our expectations are different.
             // Note that I check that initial metadata is sent during gRPC stream constructor.
@@ -101,7 +104,8 @@ public:
 
         server.ModifyTopicACL(server.GetFullTopicPath(), permissions);
 
-        MAKE_WRITE_STREAM(GenerateValidToken(0));
+        const TString databaseName = "/" + server.GetServerSettings().DomainName;
+        MAKE_WRITE_STREAM(databaseName, GenerateValidToken(0));
 
         StreamingWriteClientMessage clientMessage;
         StreamingWriteServerMessage serverMessage;
@@ -127,11 +131,12 @@ public:
         TPersQueueV1TestServer server = CreateServer();
 
         const auto token = GenerateValidToken();
+        const TString databaseName = "/" + server.GetServerSettings().DomainName;
 
         server.ModifyTopicACL(server.GetFullTopicPath(), {{token, {"ydb.generic.write"}}});
         Cerr << "===Make write stream\n";
 
-        MAKE_WRITE_STREAM(token);
+        MAKE_WRITE_STREAM(databaseName, token);
 
         StreamingWriteClientMessage clientMessage;
         StreamingWriteServerMessage serverMessage;
@@ -183,7 +188,9 @@ public:
 
 
         server.ModifyTopicACL(server.GetFullTopicPath(), permissions);
-        MAKE_WRITE_STREAM(GenerateValidToken(0));
+
+        const TString databaseName = "/" + server.GetServerSettings().DomainName;
+        MAKE_WRITE_STREAM(databaseName, GenerateValidToken(0));
 
         StreamingWriteClientMessage clientMessage;
         StreamingWriteServerMessage serverMessage;
@@ -224,10 +231,11 @@ public:
         // TODO: Why test fails with 'BUILTIN_ACL_DOMAIN' as domain in invalid token?
         TVector<TString> invalidTokens = {TString(), "test_user", "test_user@invalid_domain"};
         server.ModifyTopicACLAndWait(server.GetFullTopicPath(), {{validToken, {"ydb.generic.write"}}});
+        const TString databaseName = "/" + server.GetServerSettings().DomainName;
 
         for (const auto &invalidToken : invalidTokens) {
             Cerr << "Invalid token under test is '" << invalidToken << "'" << Endl;
-            MAKE_WRITE_STREAM(validToken);
+            MAKE_WRITE_STREAM(databaseName, validToken);
 
             StreamingWriteClientMessage clientMessage;
             StreamingWriteServerMessage serverMessage;
@@ -258,8 +266,9 @@ public:
                                      BUILTIN_ACL_DOMAIN;
 
         server.ModifyTopicACL(server.GetFullTopicPath(), {{validToken, {"ydb.generic.write"}}});
+        const TString databaseName = "/" + server.GetServerSettings().DomainName;
 
-        MAKE_WRITE_STREAM(validToken);
+        MAKE_WRITE_STREAM(databaseName, validToken);
 
         StreamingWriteClientMessage clientMessage;
         StreamingWriteServerMessage serverMessage;

--- a/ydb/services/rate_limiter/grpc_service.cpp
+++ b/ydb/services/rate_limiter/grpc_service.cpp
@@ -34,7 +34,7 @@ void TRateLimiterGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
 #endif
 
 #define SETUP_RL_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, rate_limiter, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_RL_METHOD(CreateResource, DoCreateRateLimiterResource, RLMODE(Rps), RATELIMITER_CREATE_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_RL_METHOD(AlterResource, DoAlterRateLimiterResource, RLMODE(Rps), RATELIMITER_ALTER_RESOURCE, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));

--- a/ydb/services/replication/grpc_service.cpp
+++ b/ydb/services/replication/grpc_service.cpp
@@ -18,7 +18,7 @@ void TGRpcReplicationService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
 #endif
 
 #define SETUP_REPLICATION_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, replication, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, replication, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_REPLICATION_METHOD(DescribeReplication, DoDescribeReplication, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_REPLICATION_METHOD(DescribeTransfer, DoDescribeTransfer, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());

--- a/ydb/services/tablet/ydb_tablet.cpp
+++ b/ydb/services/tablet/ydb_tablet.cpp
@@ -38,6 +38,7 @@ void TGRpcYdbTabletService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 requestType,                                                           \
                 YDB_API_DEFAULT_COUNTER_BLOCK(tablet, methodName),                     \
                 auditMode,                                                             \
+                EEmptyDatabaseMode::EmptyDatabaseAllowed,                              \
                 COMMON,                                                                \
                 ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                  \
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \

--- a/ydb/services/test_shard/grpc_service.cpp
+++ b/ydb/services/test_shard/grpc_service.cpp
@@ -31,7 +31,7 @@ void TTestShardGRpcService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_TESTSHARD_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, testshard, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, testshard, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_TESTSHARD_METHOD(CreateTestShard, DoCreateTestShard, RLMODE(Rps), TESTSHARD_CREATETESTSHARD, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));
     SETUP_TESTSHARD_METHOD(DeleteTestShard, DoDeleteTestShard, RLMODE(Rps), TESTSHARD_DELETETESTSHARD, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ClusterAdmin));

--- a/ydb/services/view/grpc_service.cpp
+++ b/ydb/services/view/grpc_service.cpp
@@ -16,7 +16,7 @@ void TGRpcViewService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_VIEW_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, view, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, view, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_VIEW_METHOD(DescribeView, DoDescribeView, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
 

--- a/ydb/services/ydb/ydb_clickhouse_internal.cpp
+++ b/ydb/services/ydb/ydb_clickhouse_internal.cpp
@@ -44,6 +44,7 @@ void TGRpcYdbClickhouseInternalService::SetupIncomingRequests(NYdbGrpc::TLoggerP
         requestType,                                                                \
         YDB_API_DEFAULT_COUNTER_BLOCK(clickhouse_internal, methodName),             \
         auditMode,                                                                  \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,                                   \
         COMMON,                                                                     \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                         \
         GRpcRequestProxyId_,                                                        \

--- a/ydb/services/ydb/ydb_coordination_ut.cpp
+++ b/ydb/services/ydb/ydb_coordination_ut.cpp
@@ -52,6 +52,7 @@ struct TClientContext {
             bool secure)
     {
         TDriverConfig params;
+        params.SetDatabase("/Root");
         params.SetEndpoint(endpoint);
         if (token) {
             params.SetAuthToken(token);

--- a/ydb/services/ydb/ydb_debug.cpp
+++ b/ydb/services/ydb/ydb_debug.cpp
@@ -63,6 +63,7 @@ void TGRpcYdbDebugService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 requestType,                                                           \
                 YDB_API_DEFAULT_COUNTER_BLOCK(ping, methodName),                       \
                 auditMode,                                                             \
+                EEmptyDatabaseMode::EmptyDatabaseAllowed,                              \
                 COMMON,                                                                \
                 ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                  \
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \

--- a/ydb/services/ydb/ydb_dummy.cpp
+++ b/ydb/services/ydb/ydb_dummy.cpp
@@ -172,12 +172,18 @@ void TGRpcYdbDummyService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             CQ_,
             &Draft::Dummy::DummyService::AsyncService::RequestBiStreamPing,
             [this](TIntrusivePtr<TBiStreamGRpcRequest::IContext> context) {
-                ActorSystem_->Send(GRpcRequestProxyId_, new TEvBiStreamPingRequest(context));
+                ActorSystem_->Send(
+                    GRpcRequestProxyId_,
+                    new TEvBiStreamPingRequest(
+                        context,
+                        NGRpcService::TRequestAuxSettings{
+                            .EmptyDatabaseMode = EEmptyDatabaseMode::EmptyDatabaseAllowed
+                        }
+                    )
+                );
             },
-            *ActorSystem_,
-            "BiStreamPing",
-            getCounterBlock("dummy", "biStreamPing", true),
-            nullptr);
+            *ActorSystem_, "BiStreamPing",
+            getCounterBlock("dummy", "biStreamPing", true), nullptr);
     }
 }
 

--- a/ydb/services/ydb/ydb_export.cpp
+++ b/ydb/services/ydb/ydb_export.cpp
@@ -17,7 +17,7 @@ void TGRpcYdbExportService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_EXPORT_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, export, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, export, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_EXPORT_METHOD(ExportToYt, DoExportToYtRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ExportImport));
     SETUP_EXPORT_METHOD(ExportToS3, DoExportToS3Request, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ExportImport));

--- a/ydb/services/ydb/ydb_import.cpp
+++ b/ydb/services/ydb/ydb_import.cpp
@@ -17,7 +17,7 @@ void TGRpcYdbImportService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_IMPORT_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, import, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, import, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_IMPORT_METHOD(ImportFromS3, DoImportFromS3Request, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ExportImport));
     SETUP_IMPORT_METHOD(ImportFromFs, DoImportFromFsRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::ExportImport));

--- a/ydb/services/ydb/ydb_logstore.cpp
+++ b/ydb/services/ydb/ydb_logstore.cpp
@@ -16,7 +16,7 @@ void TGRpcYdbLogStoreService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger)
 #endif
 
 #define SETUP_LOGSTORE_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, logstore, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, logstore, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_LOGSTORE_METHOD(CreateLogStore, DoCreateLogStoreRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_LOGSTORE_METHOD(DescribeLogStore, DoDescribeLogStoreRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());

--- a/ydb/services/ydb/ydb_object_storage.cpp
+++ b/ydb/services/ydb/ydb_object_storage.cpp
@@ -26,6 +26,7 @@ void TGRpcYdbObjectStorageService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr lo
         requestType,                                                    \
         YDB_API_DEFAULT_COUNTER_BLOCK(object-storage-list, methodName), \
         auditMode,                                                      \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,                       \
         COMMON,                                                         \
         TGrpcRequestNoOperationCall,                                    \
         GRpcRequestProxyId_,                                            \

--- a/ydb/services/ydb/ydb_operation.cpp
+++ b/ydb/services/ydb/ydb_operation.cpp
@@ -27,6 +27,7 @@ void TGRpcOperationService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                          \
         YDB_API_DEFAULT_COUNTER_BLOCK(operation, methodName), \
         auditMode,                                            \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,           \
         COMMON,                                               \
         operationCallClass,                                   \
         GRpcRequestProxyId_,                                  \

--- a/ydb/services/ydb/ydb_query.cpp
+++ b/ydb/services/ydb/ydb_query.cpp
@@ -50,6 +50,7 @@ void TGRpcYdbQueryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 requestType,                                                           \
                 YDB_API_DEFAULT_COUNTER_BLOCK(query, methodName),                      \
                 auditMode,                                                             \
+                EEmptyDatabaseMode::EmptyDatabaseForbidden,                            \
                 COMMON,                                                                \
                 ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                  \
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \

--- a/ydb/services/ydb/ydb_scheme.cpp
+++ b/ydb/services/ydb/ydb_scheme.cpp
@@ -22,7 +22,7 @@ void TGRpcYdbSchemeService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_SCHEME_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, scheme, auditMode)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, scheme, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_SCHEME_METHOD(MakeDirectory, DoMakeDirectoryRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));
     SETUP_SCHEME_METHOD(RemoveDirectory, DoRemoveDirectoryRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Ddl));

--- a/ydb/services/ydb/ydb_scripting.cpp
+++ b/ydb/services/ydb/ydb_scripting.cpp
@@ -27,6 +27,7 @@ void TGRpcYdbScriptingService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger
         requestType,                                          \
         YDB_API_DEFAULT_COUNTER_BLOCK(scripting, methodName), \
         auditMode,                                            \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,           \
         COMMON,                                               \
         operationCallClass,                                   \
         GRpcRequestProxyId_,                                  \

--- a/ydb/services/ydb/ydb_table.cpp
+++ b/ydb/services/ydb/ydb_table.cpp
@@ -65,6 +65,7 @@ void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 requestType,                                                           \
                 YDB_API_DEFAULT_COUNTER_BLOCK(table, methodName),                      \
                 auditMode,                                                             \
+                EEmptyDatabaseMode::EmptyDatabaseForbidden,                            \
                 COMMON,                                                                \
                 ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                    \
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                      \
@@ -91,6 +92,7 @@ void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                 requestType,                                                                                                  \
                 YDB_API_DEFAULT_COUNTER_BLOCK(table, methodName),                                                             \
                 auditMode,                                                                                                    \
+                EEmptyDatabaseMode::EmptyDatabaseForbidden,                                                                   \
                 COMMON,                                                                                                       \
                 ::NKikimr::NGRpcService::TGrpcRequestNoOperationCall,                                                         \
                 GRpcProxies_[proxyCounter % GRpcProxies_.size()],                                                             \

--- a/ydb/services/ydb/ydb_table_ut.cpp
+++ b/ydb/services/ydb/ydb_table_ut.cpp
@@ -75,6 +75,7 @@ static void MultiTenantSDK(bool asyncDiscovery) {
         TDriverConfig()
             .SetAuthToken("badguy@builtin")
             .UseSecureConnection(TKikimrTestWithAuthAndSsl::GetCaCrt())
+            .SetDatabase("/Root")
             .SetEndpoint(location)
             .SetDiscoveryMode(asyncDiscovery ? EDiscoveryMode::Async : EDiscoveryMode::Sync));
 
@@ -92,7 +93,7 @@ static void MultiTenantSDK(bool asyncDiscovery) {
     NYdb::NTable::TTableClient clientbad2(driver, settings2);
 */
     const TString sql = R"__(
-        CREATE TABLE `Root/Test` (
+        CREATE TABLE `/Root/Test` (
             Key Uint32,
             Value String,
             PRIMARY KEY (Key)
@@ -692,13 +693,14 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
             TDriverConfig()
                 .SetAuthToken("root@builtin")
                 .UseSecureConnection(TKikimrTestWithAuthAndSsl::GetCaCrt())
+                .SetDatabase("/Root")
                 .SetEndpoint(location));
 
         {
             auto session = CreateSession(connection, "root@builtin");
             {
                 auto status = session.ExecuteSchemeQuery(R"__(
-                CREATE TABLE `Root/Test` (
+                CREATE TABLE `/Root/Test` (
                     Key Uint32,
                     Value String,
                     PRIMARY KEY (Key)
@@ -709,7 +711,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
             }
             {
                 auto scheme = NYdb::NScheme::TSchemeClient(connection);
-                auto status = scheme.ModifyPermissions("Root/Test",
+                auto status = scheme.ModifyPermissions("/Root/Test",
                     NYdb::NScheme::TModifyPermissionsSettings()
                         .AddGrantPermissions(
                             NYdb::NScheme::TPermissions("pupkin@builtin", {"ydb.tables.modify"})
@@ -726,7 +728,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
             }
             {
                 auto scheme = NYdb::NScheme::TSchemeClient(connection);
-                auto status = scheme.DescribePath("Root/Test").ExtractValueSync();
+                auto status = scheme.DescribePath("/Root/Test").ExtractValueSync();
                 UNIT_ASSERT_EQUAL(status.IsTransportError(), false);
                 UNIT_ASSERT_EQUAL(status.GetStatus(), EStatus::SUCCESS);
                 auto entry = status.GetEntry();
@@ -745,7 +747,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
 
             {
                 auto status = session.ExecuteDataQuery(R"__(
-                    SELECT * FROM `Root/Test`;
+                    SELECT * FROM `/Root/Test`;
                 )__",TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
 
                 UNIT_ASSERT_EQUAL(status.IsTransportError(), false);
@@ -766,27 +768,6 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
         server.Server_->GetRuntime()->SetLogPriority(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, NActors::NLog::PRI_DEBUG);
 
         ui16 grpc = server.GetPort();
-
-        { // no db
-            TString location = TStringBuilder() << "localhost:" << grpc;
-            auto driver = NYdb::TDriver(
-                TDriverConfig()
-                    .SetEndpoint(location));
-
-            NYdb::NTable::TClientSettings settings;
-            settings.AuthToken(clusterAdminToken);
-
-            NYdb::NTable::TTableClient client(driver, settings);
-            auto call = [] (NYdb::NTable::TTableClient& client) -> NYdb::TStatus {
-                Cerr << "Call\n";
-                return client.CreateSession().ExtractValueSync();
-            };
-            auto status = client.RetryOperationSync(call);
-
-            // KIKIMR-14509 - reslore old behaviour allow requests without database for storage nodes
-            UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::SUCCESS, status.GetIssues().ToString());
-
-        }
         TString location = TStringBuilder() << "localhost:" << grpc;
         auto driver = NYdb::TDriver(
             TDriverConfig()

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -583,6 +583,7 @@ Y_UNIT_TEST_SUITE(TGRpcNewClient) {
             TDriverConfig()
                 .SetAuthToken("test_user@builtin")
                 .UseSecureConnection(TKikimrTestWithAuthAndSsl::GetCaCrt())
+                .SetDatabase("/Root")
                 .SetEndpoint(location));
 
         auto client = NYdb::NTable::TTableClient(connection);

--- a/ydb/services/ymq/grpc_service.cpp
+++ b/ydb/services/ymq/grpc_service.cpp
@@ -29,6 +29,7 @@ void TGRpcYmqService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                        \
         YDB_API_DEFAULT_COUNTER_BLOCK(ymq, methodName),     \
         auditMode,                                          \
+        EEmptyDatabaseMode::EmptyDatabaseAllowed,           \
         COMMON,                                             \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall, \
         GRpcRequestProxyId_,                                \


### PR DESCRIPTION
Requests with empty database name were forbidden for next grpc services:

- BackupService
- DataStreamsService
- KesusGRpcService
- KeyValueGRpcServiceV1
- KeyValueGRpcServiceV2
- RateLimiterGRpcService
- ReplicationService
- TestShardGRpcService
- ViewService
- YdbExportService
- YdbImportService
- YdbLogStoreService
- OperationService
- YdbQueryService
- YdbSchemeService
- YdbScriptingService
- YdbTableService
