### PR TITLE
[ICRDMA] add RDMA support for XDC shuffle (shuffle-only path)

### DIFF
--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -37,7 +37,7 @@ namespace NActors {
         }
         virtual ui32 Type() const = 0;
         virtual bool SerializeToArcadiaStream(TChunkSerializer*) const = 0;
-        virtual std::optional<TRope> SerializeToRope(NInterconnect::NRdma::IMemPool*) const {
+        virtual std::optional<TRope> SerializeToRope(IRcBufAllocator*) const {
             return std::nullopt;
         }
         virtual bool IsSerializable() const = 0;

--- a/ydb/library/actors/core/event_load.cpp
+++ b/ydb/library/actors/core/event_load.cpp
@@ -1,5 +1,31 @@
 #include "event_load.h"
 
+#include <util/string/builder.h>
+
 namespace NActors {
+
+TString TEventSectionInfo::ToString() const {
+    return TStringBuilder()
+        << "{headroom# " << Headroom
+        << " size# " << Size
+        << " tailroom# " << Tailroom
+        << " alignment# " << Alignment
+        << " inline# " << IsInline
+        << " rdma# " << IsRdmaCapable
+        << "}";
+}
+
+TString SerializeEventSections(const TEventSerializationInfo& info) {
+    TStringBuilder sections;
+    sections << "[";
+    for (size_t i = 0; i < info.Sections.size(); ++i) {
+        if (i) {
+            sections << ", ";
+        }
+        sections << "{idx# " << i << " section# " << info.Sections[i].ToString() << "}";
+    }
+    sections << "]";
+    return sections;
+}
 
 }

--- a/ydb/library/actors/core/event_load.h
+++ b/ydb/library/actors/core/event_load.h
@@ -26,6 +26,8 @@ namespace NActors {
         size_t Alignment = 0; // required alignment
         bool IsInline = false; // if true, goes through ordinary channel
         bool IsRdmaCapable = false; // if true, could go through RDMA
+
+        TString ToString() const;
     };
 
     struct TEventSerializationInfo {
@@ -33,6 +35,8 @@ namespace NActors {
         std::vector<TEventSectionInfo> Sections;
         // total sum of Size for every section must match actual serialized size of the event
     };
+
+    TString SerializeEventSections(const TEventSerializationInfo& info);
 
     class TEventSerializedData
        : public TThrRefBase

--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -339,22 +339,22 @@ namespace NActors {
         return true;
     }
 
-    std::optional<TRope> SerializeToRopeImpl(const google::protobuf::MessageLite& msg, const TVector<TRope>& payload, NInterconnect::NRdma::IMemPool* pool) {
+    std::optional<TRope> SerializeToRopeImpl(const google::protobuf::MessageLite& msg, const TVector<TRope>& payload, IRcBufAllocator* allocator) {
         TRope result;
         auto sz = CalculateSerializedHeaderSizeImpl(payload);
         if (sz) {
-            std::optional<TRcBuf> headerBuf = pool->AllocRcBuf(sz, NInterconnect::NRdma::IMemPool::EMPTY);
+            TRcBuf headerBuf = allocator->AllocRcBuf(sz, 0, 0);
             if (!headerBuf) {
                 return {};
             }
-            char* data = headerBuf->GetDataMut();
+            char* data = headerBuf.GetDataMut();
             auto append = [&data](const char *p, size_t len) {
                 std::memcpy(data, p, len);
                 data += len;
                 return true;
             };
             SerializeHeaderCommon(payload, append);
-            result.Insert(result.End(), std::move(headerBuf.value()));
+            result.Insert(result.End(), std::move(headerBuf));
 
             auto appendRope = [&](TRope rope) {
                 result.Insert(result.End(), std::move(rope));
@@ -365,13 +365,13 @@ namespace NActors {
 
         {
             ui32 size = msg.ByteSizeLong();
-            std::optional<TRcBuf> recordsSerializedBuf = pool->AllocRcBuf(size, NInterconnect::NRdma::IMemPool::EMPTY);
+            TRcBuf recordsSerializedBuf = allocator->AllocRcBuf(size, 0, 0);
             if (!recordsSerializedBuf) {
                 return {};
             }
-            bool serializationDone = msg.SerializePartialToArray(recordsSerializedBuf->GetDataMut(), size);
+            bool serializationDone = msg.SerializePartialToArray(recordsSerializedBuf.GetDataMut(), size);
             Y_ABORT_UNLESS(serializationDone);
-            result.Insert(result.End(), std::move(recordsSerializedBuf.value()));
+            result.Insert(result.End(), std::move(recordsSerializedBuf));
         }
 
         return result;
@@ -472,14 +472,14 @@ namespace NActors {
                 for (const TRope& rope : payload) {
                     headerLen += SerializeNumber(rope.size(), temp);
                 }
-                info.Sections.push_back(TEventSectionInfo{0, headerLen, 0, 0, true, true});
+                info.Sections.push_back(TEventSectionInfo{0, headerLen, 0, 0, true, false});
                 for (const TRope& rope : payload) {
                     info.Sections.push_back(TEventSectionInfo{0, rope.size(), 0, 0, false, IsRdma(rope)});
                 }
             }
 
             const size_t byteSize = Max<ssize_t>(0, recordSize) + preserializedSize;
-            info.Sections.push_back(TEventSectionInfo{0, byteSize, 0, 0, true, true}); // protobuf itself
+            info.Sections.push_back(TEventSectionInfo{0, byteSize, 0, 0, true, false}); // protobuf itself
 
 #ifndef NDEBUG
             size_t total = 0;

--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -167,7 +167,7 @@ namespace NActors {
     void ParseExtendedFormatPayload(TRope::TConstIterator &iter, size_t &size, TVector<TRope> &payload, size_t &totalPayloadSize);
     bool SerializeToArcadiaStreamImpl(TChunkSerializer* chunker, const TVector<TRope> &payload);
     ui32 CalculateSerializedHeaderSizeImpl(const TVector<TRope> &payload);
-    std::optional<TRope> SerializeToRopeImpl(const google::protobuf::MessageLite& msg, const TVector<TRope>& payload, NInterconnect::NRdma::IMemPool* pool);
+    std::optional<TRope> SerializeToRopeImpl(const google::protobuf::MessageLite& msg, const TVector<TRope>& payload, IRcBufAllocator* allocator);
     ui32 CalculateSerializedSizeImpl(const TVector<TRope> &payload, ssize_t recordSize);
     TEventSerializationInfo CreateSerializationInfoImpl(size_t preserializedSize, bool allowExternalDataChannel, const TVector<TRope> &payload, ssize_t recordSize);
 
@@ -226,8 +226,8 @@ namespace NActors {
             return CalculateSerializedSizeImpl(Payload, Record.ByteSize());
         }
 
-        std::optional<TRope> SerializeToRope(NInterconnect::NRdma::IMemPool* pool) const override {
-            return NActors::SerializeToRopeImpl(Record, Payload, pool);
+        std::optional<TRope> SerializeToRope(IRcBufAllocator* allocator) const override {
+            return NActors::SerializeToRopeImpl(Record, Payload, allocator);
         }
 
         static TEv* Load(const TEventSerializedData *input) {

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -2,6 +2,7 @@
 #include "interconnect_zc_processor.h"
 #include "rdma/mem_pool.h"
 
+#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/executor_thread.h>
 #include <ydb/library/actors/core/log.h>
@@ -96,7 +97,9 @@ namespace NActors {
                         Metrics->UpdateIcQueueTimeHistogram(duration.MicroSeconds());
                     }
                     event.Span && event.Span.Event("FeedBuf:INITIAL");
-                    SendViaRdma.reset();
+                    RdmaCredsBuffer.Clear();
+                    RdmaCredPartPos = 0;
+                    RdmaCredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
                     if (event.Buffer) {
                         State = EState::BODY;
                         Iter = event.Buffer->GetBeginIter();
@@ -123,22 +126,15 @@ namespace NActors {
                     } else if (Params.UseExternalDataChannel && !SerializationInfo->Sections.empty()) {
                         State = EState::SECTIONS;
                         SectionIndex = 0;
+                        XXH3_64bits_reset(&RdmaCumulativeChecksumState);
 
-                        size_t totalSize = 0;
-                        // It is possible to have event without payload. Such events has only one section.
-                        // We do not send such events via rdma.
-                        bool sendViaRdma = Params.UseRdma && RdmaMemPool && SerializationInfo->Sections.size() > 2;
+                        bool hasRdmaSections = false;
                         // Check each section can be send via rdma
                         for (const auto& section : SerializationInfo->Sections) {
-                            sendViaRdma &= section.IsRdmaCapable;
-                            totalSize += section.Size;
+                            hasRdmaSections |= section.IsRdmaCapable;
                         }
-                        if (sendViaRdma) {
-                            Y_ABORT_UNLESS(totalSize, "got empty sz, sections: %d type: %d ", SerializationInfo->Sections.size(),  event.Event->Type());
-                            NActorsInterconnect::TRdmaCreds rdmaCreds;
-                            ui32 checkSum = 0;
-                            if (SerializeEventRdma(event, rdmaCreds, task.Params.ChecksumRdmaEvent ? &checkSum : nullptr, rdmaDeviceIndex)) {
-                                SendViaRdma.emplace(TRdmaSerializationArtifacts{std::move(rdmaCreds), checkSum});
+                        if (hasRdmaSections && Params.UseXdcShuffle && Params.UseRdma && RdmaMemPool) {
+                            if (SerializeEventRdma(event)) {
                                 Chunker.DiscardEvent();
                             }
                         }
@@ -187,7 +183,7 @@ namespace NActors {
                         if (section.IsInline && Params.UseXdcShuffle) {
                             type = static_cast<ui8>(EXdcCommand::DECLARE_SECTION_INLINE);
                         }
-                        if (SendViaRdma) {
+                        if (Params.UseXdcShuffle && section.IsRdmaCapable && Params.UseRdma && RdmaMemPool) {
                             type = static_cast<ui8>(EXdcCommand::DECLARE_SECTION_RDMA);
                         }
                         Y_ABORT_UNLESS(p <= std::end(sectionInfo));
@@ -281,21 +277,25 @@ namespace NActors {
     bool TEventOutputChannel::FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex) {
         for (;;) {
             // calculate inline or external part size (it may cover a few sections, not just single one)
-            while (!PartLenRemain) {
+            while (!PartLenRemain && RdmaCredsBuffer.CredsSize() == 0) {
                 const auto& sections = SerializationInfo->Sections;
                 if (!Params.UseExternalDataChannel || sections.empty()) {
                     // all data goes inline
                     IsPartInline = true;
+                    IsPartRdma = false;
                     PartLenRemain = Max<size_t>();
-                } else if (!Params.UseXdcShuffle || SendViaRdma) {
+                } else if (!Params.UseXdcShuffle) {
                     // when UseXdcShuffle feature is not supported by the remote side, we transfer whole event over XDC
-                    // also when we use RDMA, we transfer whole over RDMA
                     IsPartInline = false;
+                    IsPartRdma = false;
                     PartLenRemain = Max<size_t>();
                 } else {
                     Y_ABORT_UNLESS(SectionIndex < sections.size());
                     IsPartInline = sections[SectionIndex].IsInline;
-                    while (SectionIndex < sections.size() && IsPartInline == sections[SectionIndex].IsInline) {
+                    IsPartRdma = sections[SectionIndex].IsRdmaCapable;
+                    while (SectionIndex < sections.size()
+                            && IsPartInline == sections[SectionIndex].IsInline
+                            && IsPartRdma == sections[SectionIndex].IsRdmaCapable) {
                         PartLenRemain += sections[SectionIndex].Size;
                         ++SectionIndex;
                     }
@@ -306,9 +306,8 @@ namespace NActors {
             std::optional<bool> complete = false;
             if (IsPartInline) {
                 complete = FeedInlinePayload(task, event);
-            } else if (SendViaRdma) {
-                Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
-                complete = FeedRdmaPayload(task, event);
+            } else if (IsPartRdma && rdmaDeviceIndex >= 0) {
+                complete = FeedRdmaPayload(task, event, rdmaDeviceIndex, task.Params.ChecksumRdmaEvent);
             } else {
                 complete = FeedExternalPayload(task, event);
             }
@@ -344,57 +343,81 @@ namespace NActors {
         return complete;
     }
 
-    bool TEventOutputChannel::SerializeEventRdma(TEventHolder& event, NActorsInterconnect::TRdmaCreds& rdmaCreds,
-        ui32* checksum, ssize_t rdmaDeviceIndex)
-    {
+    bool TEventOutputChannel::SerializeEventRdma(TEventHolder& event) {
         if (!event.Buffer && event.Event) {
-            std::optional<TRope> rope = event.Event->SerializeToRope(RdmaMemPool.get());
+            std::optional<TRope> rope = event.Event->SerializeToRope(GetDefaultRcBufAllocator());
             if (!rope) {
                 return false; // serialization failed
             }
             event.Buffer = MakeIntrusive<TEventSerializedData>(
                 std::move(*rope), event.Event->CreateSerializationInfo(Params.UseExternalDataChannel)
             );
+            event.Event = nullptr;
             Iter = event.Buffer->GetBeginIter();
-        }
-
-        XXH3_state_t state;
-        if (checksum) {
-            XXH3_64bits_reset(&state);
-        }
-
-        if (event.Buffer) {
-            for (; Iter.Valid(); ++Iter) {
-                TRcBuf buf = Iter.GetChunk();
-                auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(buf);
-                if (memReg.Empty()) {
-                    // TODO: may be copy to RDMA buffer ?????
-                    Iter = event.Buffer->GetBeginIter();
-                    return false;
-                }
-                if (checksum) {
-                    XXH3_64bits_update(&state, buf.GetData(), buf.GetSize());
-                }
-                auto cred = rdmaCreds.AddCreds();
-                cred->SetAddress(reinterpret_cast<ui64>(memReg.GetAddr()));
-                cred->SetSize(memReg.GetSize());
-                cred->SetRkey(memReg.GetRKey(rdmaDeviceIndex));
-            }
-        }
-
-        if (checksum) {
-            *checksum = XXH3_64bits_digest(&state);
         }
         return true;
     }
 
-    std::optional<bool> TEventOutputChannel::FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event) {
-        // The part layout is:
-        // Part = | TChannelPart | EXdcCommand::RDMA_READ (ui8)| rdmaCreds.Size (ui16) | seialized rdmaCreds | checkSum (ui32) |
+    std::optional<bool> TEventOutputChannel::FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex, bool checksumming) {
+        Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
+
+        Y_ABORT_UNLESS(event.Buffer);
+        if (RdmaCredsBuffer.CredsSize() == 0) {
+            auto prevIter = Iter;
+            size_t prevPartLenRemain = PartLenRemain;
+            const ui32 prevEventActuallySerialized = event.EventActuallySerialized;
+            XXH3_state_t prevRdmaCumulativeChecksumState;
+            if (checksumming) {
+                prevRdmaCumulativeChecksumState = RdmaCumulativeChecksumState;
+            }
+            for (; Iter.Valid() && PartLenRemain; ) {
+                TRcBuf buf = Iter.GetChunk();
+                auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(buf);
+                if (memReg.Empty()) {
+                    Iter = prevIter;
+                    IsPartRdma = false;
+                    RdmaCredsBuffer.Clear();
+                    RdmaCredPartPos = 0;
+                    PartLenRemain = prevPartLenRemain;
+                    // Fallback to PUSH_DATA must roll back all RDMA preparation progress to avoid double-accounting.
+                    event.EventActuallySerialized = prevEventActuallySerialized;
+                    if (checksumming) {
+                        RdmaCumulativeChecksumState = prevRdmaCumulativeChecksumState;
+                    }
+                    return false;
+                }
+
+                const char* data = Iter.ContiguousData();
+                Y_ABORT_UNLESS(data >= buf.GetData() && data <= buf.GetData() + buf.GetSize());
+                const size_t offset = data - buf.GetData();
+                const size_t leftInChunk = buf.GetSize() - offset;
+                const size_t chunkSize = Min(leftInChunk, PartLenRemain);
+
+                if (checksumming) {
+                    XXH3_64bits_update(&RdmaCumulativeChecksumState, data, chunkSize);
+                }
+                auto cred = RdmaCredsBuffer.AddCreds();
+                cred->SetAddress(reinterpret_cast<ui64>(memReg.GetAddr()) + offset);
+                cred->SetSize(chunkSize);
+                cred->SetRkey(memReg.GetRKey(rdmaDeviceIndex));
+
+                event.EventActuallySerialized += chunkSize;
+                PartLenRemain -= chunkSize;
+                Iter += chunkSize;
+            }
+        }
+        Y_ABORT_UNLESS(PartLenRemain == 0);
+
+        if (RdmaCredsBuffer.CredsSize() == 0) {
+            RdmaCredPartPos = 0;
+            return !Iter.Valid();
+        }
+
+        // Part = | TChannelPart | EXdcCommand::RDMA_READ | rdmaCreds.Size | rdmaCreds | checkSum |
         const size_t fixedPartSize = sizeof(TChannelPart) + sizeof(ui8) + sizeof(ui16) + sizeof(ui32);
+        const size_t maxSerializedPart = Min<size_t>(task.GetInternalFreeAmount(), Max<ui16>());
         const ui32 minThreshold = fixedPartSize + RdmaCredsMinSizeSerialized;
-        // No free amount even for one rdma cred - we need new packet
-        if (task.GetInternalFreeAmount() < minThreshold) {
+        if (maxSerializedPart < minThreshold) {
             return std::nullopt;
         }
 
@@ -402,59 +425,44 @@ namespace NActors {
             return (freeAmount - fixedPartSize) * credsPerByteAvg;
         };
 
-        const NActorsInterconnect::TRdmaCreds* rdmaCreds = &SendViaRdma->RdmaCreds;
-
-        NActorsInterconnect::TRdmaCreds tmpCreds; 
+        const NActorsInterconnect::TRdmaCreds* rdmaCreds = &RdmaCredsBuffer;
+        NActorsInterconnect::TRdmaCreds tmpCreds;
 
         bool lastPart = true;
-
-        size_t partSize;
-        size_t credsSerializedSize;
+        size_t partSize = 0;
+        size_t credsSerializedSize = 0;
 
         size_t curPartCredLen = 0;
-        /*
-         * Split rdma creds in to multiple parts if serialized credential data doesn't fit in to one IC packets.
-         * Prerequisites:
-         * - We assume this situation should be quite rare, so do not perform any additional copy in happy path
-         * - If we need to split (and credential copy to perform serialization of its part) we want to reduce number of itterations
-         * - There is no guarantee to get task with well known ammount of free space
-         */
         for (;;) {
-            if (Y_UNLIKELY(curPartCredLen || SendViaRdma->PartCredPos)) {
-                // First iteration for non first part
+            if (Y_UNLIKELY(curPartCredLen || RdmaCredPartPos)) {
                 if (!curPartCredLen) {
-                    curPartCredLen = calcPartCredLen(task.GetInternalFreeAmount(), SendViaRdma->CredsPerByteAvg);
+                    curPartCredLen = calcPartCredLen(maxSerializedPart, RdmaCredsPerByteAvg);
                     if (!curPartCredLen) {
                         return std::nullopt;
                     }
                 }
-                // Check is it a last part?
-                if (SendViaRdma->PartCredPos + curPartCredLen >= SendViaRdma->RdmaCreds.CredsSize()) {
-                    curPartCredLen = SendViaRdma->RdmaCreds.CredsSize() - SendViaRdma->PartCredPos; 
+                if (RdmaCredPartPos + curPartCredLen >= RdmaCredsBuffer.CredsSize()) {
+                    curPartCredLen = RdmaCredsBuffer.CredsSize() - RdmaCredPartPos;
                     lastPart = true;
                 } else {
                     lastPart = false;
                 }
 
-                //TODO: Find the way to perform partial serialzation of repeated field
                 tmpCreds.Clear();
-                for (size_t i = 0, j = SendViaRdma->PartCredPos; i < curPartCredLen; i++, j++) {
-                    tmpCreds.AddCreds()->CopyFrom(SendViaRdma->RdmaCreds.GetCreds(j));
+                for (size_t i = 0, j = RdmaCredPartPos; i < curPartCredLen; ++i, ++j) {
+                    tmpCreds.AddCreds()->CopyFrom(RdmaCredsBuffer.GetCreds(j));
                 }
                 rdmaCreds = &tmpCreds;
             }
 
             credsSerializedSize = rdmaCreds->ByteSizeLong();
-
             partSize = fixedPartSize + credsSerializedSize;
 
-            if (Y_UNLIKELY(partSize > task.GetInternalFreeAmount())) {
-                SendViaRdma->CredsPerByteAvg = rdmaCreds->CredsSize() / (double)credsSerializedSize; 
-                size_t newLen = calcPartCredLen(task.GetInternalFreeAmount(), SendViaRdma->CredsPerByteAvg);
-
-                // Guarantee progress even in case of huge error of average calculation
+            if (Y_UNLIKELY(partSize > maxSerializedPart)) {
+                RdmaCredsPerByteAvg = rdmaCreds->CredsSize() / (double)credsSerializedSize;
+                size_t newLen = calcPartCredLen(maxSerializedPart, RdmaCredsPerByteAvg);
                 if (newLen >= curPartCredLen) {
-                    curPartCredLen--;
+                    curPartCredLen = curPartCredLen ? curPartCredLen - 1 : newLen;
                 } else {
                     curPartCredLen = newLen;
                 }
@@ -463,18 +471,14 @@ namespace NActors {
                     return std::nullopt;
                 }
             } else {
-                // Report to mon if it is first part of multipart rdma events
-                // huge number of multipart events may be a reason of some additional latency
-                if (Y_UNLIKELY(SendViaRdma->PartCredPos == 0 && curPartCredLen != 0)) {
+                if (Y_UNLIKELY(RdmaCredPartPos == 0 && curPartCredLen != 0)) {
                     Metrics->IncRdmaMultipartEvents();
                 }
-                // Shift start position for the next packet
-                SendViaRdma->PartCredPos += curPartCredLen; 
+                RdmaCredPartPos += curPartCredLen;
                 break;
             }
         }
 
-        const ui32 checkSum = SendViaRdma->CheckSum;
         char buffer[partSize];
         TChannelPart *part = reinterpret_cast<TChannelPart*>(buffer);
         *part = {
@@ -493,17 +497,20 @@ namespace NActors {
 
         Y_ABORT_UNLESS(rdmaCreds->SerializePartialToArray(ptr, credsSerializedSize));
         ptr += credsSerializedSize;
-        WriteUnaligned<ui32>(ptr, checkSum);
-
-        if (lastPart) {
-            OutputQueueSize -= event.EventSerializedSize;
-        }
+        WriteUnaligned<ui32>(ptr, checksumming ? XXH3_64bits_digest(&RdmaCumulativeChecksumState) : 0);
+        OutputQueueSize -= payloadSz;
 
         task.Write<false>(buffer, partSize);
 
         task.AttachRdmaPayloadSize(payloadSz);
 
-        return lastPart;
+        if (lastPart) {
+            RdmaCredsBuffer.Clear();
+            RdmaCredPartPos = 0;
+            RdmaCredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
+        }
+
+        return lastPart ? !Iter.Valid() : false;
     }
 
     std::optional<bool> TEventOutputChannel::FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event) {

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -34,7 +34,7 @@ namespace NActors {
     const ui32 TEventOutputChannel::RdmaCredsMinSizeSerialized = CalcRdmaCredsMinSizeSerialized();
 
     namespace {
-        bool CanUseRdmaForCurrentEvent(const TEventHolder& event, ssize_t rdmaDeviceIndex) {
+        bool IsRdmaSectionLayoutConsistentWithData(const TEventHolder& event, ssize_t rdmaDeviceIndex) {
 #ifdef NDEBUG
             Y_UNUSED(event);
             Y_UNUSED(rdmaDeviceIndex);
@@ -45,8 +45,10 @@ namespace NActors {
 
             auto iter = event.Buffer->GetBeginIter();
             const auto& sections = event.Buffer->GetSerializationInfo().Sections;
-            for (const auto& section : sections) {
+            for (size_t sectionIndex = 0; sectionIndex < sections.size(); ++sectionIndex) {
+                const auto& section = sections[sectionIndex];
                 size_t bytesLeft = section.Size;
+                size_t chunkIndex = 0;
                 while (bytesLeft) {
                     Y_ABORT_UNLESS(iter.Valid());
                     TRcBuf buf = iter.GetChunk();
@@ -59,6 +61,22 @@ namespace NActors {
                     if (section.IsRdmaCapable) {
                         auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(buf);
                         if (memReg.Empty()) {
+                            if (NActors::TlsActivationContext) {
+                                LOG_WARN_S(*NActors::TlsActivationContext, NActorsServices::INTERCONNECT_SESSION,
+                                    TStringBuilder() << "IsRdmaSectionLayoutConsistentWithData: RDMA preflight failed,"
+                                        << " eventType# " << event.Descr.Type
+                                        << " eventSerializedSize# " << event.EventSerializedSize
+                                        << " bufferSize# " << event.Buffer->GetSize()
+                                        << " sectionIndex# " << sectionIndex
+                                        << " sectionSize# " << section.Size
+                                        << " bytesLeft# " << bytesLeft
+                                        << " chunkIndex# " << chunkIndex
+                                        << " chunkOffset# " << offset
+                                        << " chunkSize# " << chunkSize
+                                        << " chunkBufSize# " << buf.GetSize()
+                                        << " rdmaDeviceIndex# " << rdmaDeviceIndex
+                                        << " sections# " << SerializeEventSections(event.Buffer->GetSerializationInfo()));
+                            }
                             return false;
                         }
                         Y_UNUSED(memReg.GetRKey(rdmaDeviceIndex));
@@ -66,6 +84,7 @@ namespace NActors {
 
                     iter += chunkSize;
                     bytesLeft -= chunkSize;
+                    ++chunkIndex;
                 }
             }
 
@@ -178,7 +197,7 @@ namespace NActors {
                         if (hasRdmaSections && Params.UseXdcShuffle && Params.UseRdma && RdmaMemPool && rdmaDeviceIndex >= 0) {
                             if (SerializeEventRdma(event)) {
                                 SerializationInfo = &event.Buffer->GetSerializationInfo();
-                                UseRdmaForCurrentEvent = CanUseRdmaForCurrentEvent(event, rdmaDeviceIndex);
+                                UseRdmaForCurrentEvent = IsRdmaSectionLayoutConsistentWithData(event, rdmaDeviceIndex);
                                 Chunker.DiscardEvent();
                             }
                         }

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -2,7 +2,6 @@
 #include "interconnect_zc_processor.h"
 #include "rdma/mem_pool.h"
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/executor_thread.h>
 #include <ydb/library/actors/core/log.h>
@@ -10,6 +9,7 @@
 #include <ydb/library/actors/protos/interconnect.pb.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
 #include <ydb/library/actors/prof/tag.h>
+#include <ydb/library/actors/util/rc_buf.h>
 #include <library/cpp/digest/crc32c/crc32c.h>
 
 LWTRACE_USING(ACTORLIB_PROVIDER);
@@ -32,6 +32,47 @@ static ui32 CalcRdmaCredsMinSizeSerialized() noexcept {
 
 namespace NActors {
     const ui32 TEventOutputChannel::RdmaCredsMinSizeSerialized = CalcRdmaCredsMinSizeSerialized();
+
+    namespace {
+        bool CanUseRdmaForCurrentEvent(const TEventHolder& event, ssize_t rdmaDeviceIndex) {
+#ifdef NDEBUG
+            Y_UNUSED(event);
+            Y_UNUSED(rdmaDeviceIndex);
+            return true;
+#else
+            Y_ABORT_UNLESS(event.Buffer);
+            Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
+
+            auto iter = event.Buffer->GetBeginIter();
+            const auto& sections = event.Buffer->GetSerializationInfo().Sections;
+            for (const auto& section : sections) {
+                size_t bytesLeft = section.Size;
+                while (bytesLeft) {
+                    Y_ABORT_UNLESS(iter.Valid());
+                    TRcBuf buf = iter.GetChunk();
+                    const char* data = iter.ContiguousData();
+                    Y_ABORT_UNLESS(data >= buf.GetData() && data <= buf.GetData() + buf.GetSize());
+                    const size_t offset = data - buf.GetData();
+                    const size_t leftInChunk = buf.GetSize() - offset;
+                    const size_t chunkSize = Min(leftInChunk, bytesLeft);
+
+                    if (section.IsRdmaCapable) {
+                        auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(buf);
+                        if (memReg.Empty()) {
+                            return false;
+                        }
+                        Y_UNUSED(memReg.GetRKey(rdmaDeviceIndex));
+                    }
+
+                    iter += chunkSize;
+                    bytesLeft -= chunkSize;
+                }
+            }
+
+            return true;
+#endif
+        }
+    }
 
     bool TEventOutputChannel::FeedDescriptor(TTcpPacketOutTask& task, TEventHolder& event) {
         const size_t amount = sizeof(TChannelPart) + sizeof(TEventDescr2);
@@ -97,6 +138,7 @@ namespace NActors {
                         Metrics->UpdateIcQueueTimeHistogram(duration.MicroSeconds());
                     }
                     event.Span && event.Span.Event("FeedBuf:INITIAL");
+                    UseRdmaForCurrentEvent = false;
                     RdmaCredsBuffer.Clear();
                     RdmaCredPartPos = 0;
                     RdmaCredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
@@ -133,8 +175,10 @@ namespace NActors {
                         for (const auto& section : SerializationInfo->Sections) {
                             hasRdmaSections |= section.IsRdmaCapable;
                         }
-                        if (hasRdmaSections && Params.UseXdcShuffle && Params.UseRdma && RdmaMemPool) {
+                        if (hasRdmaSections && Params.UseXdcShuffle && Params.UseRdma && RdmaMemPool && rdmaDeviceIndex >= 0) {
                             if (SerializeEventRdma(event)) {
+                                SerializationInfo = &event.Buffer->GetSerializationInfo();
+                                UseRdmaForCurrentEvent = CanUseRdmaForCurrentEvent(event, rdmaDeviceIndex);
                                 Chunker.DiscardEvent();
                             }
                         }
@@ -183,7 +227,7 @@ namespace NActors {
                         if (section.IsInline && Params.UseXdcShuffle) {
                             type = static_cast<ui8>(EXdcCommand::DECLARE_SECTION_INLINE);
                         }
-                        if (Params.UseXdcShuffle && section.IsRdmaCapable && Params.UseRdma && RdmaMemPool) {
+                        if (UseRdmaForCurrentEvent && section.IsRdmaCapable) {
                             type = static_cast<ui8>(EXdcCommand::DECLARE_SECTION_RDMA);
                         }
                         Y_ABORT_UNLESS(p <= std::end(sectionInfo));
@@ -275,6 +319,9 @@ namespace NActors {
     }
 
     bool TEventOutputChannel::FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex) {
+        if (UseRdmaForCurrentEvent) {
+            Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
+        }
         for (;;) {
             // calculate inline or external part size (it may cover a few sections, not just single one)
             while (!PartLenRemain && RdmaCredsBuffer.CredsSize() == 0) {
@@ -306,7 +353,7 @@ namespace NActors {
             std::optional<bool> complete = false;
             if (IsPartInline) {
                 complete = FeedInlinePayload(task, event);
-            } else if (IsPartRdma && rdmaDeviceIndex >= 0) {
+            } else if (UseRdmaForCurrentEvent && IsPartRdma) {
                 complete = FeedRdmaPayload(task, event, rdmaDeviceIndex, task.Params.ChecksumRdmaEvent);
             } else {
                 complete = FeedExternalPayload(task, event);
@@ -363,28 +410,11 @@ namespace NActors {
 
         Y_ABORT_UNLESS(event.Buffer);
         if (RdmaCredsBuffer.CredsSize() == 0) {
-            auto prevIter = Iter;
-            size_t prevPartLenRemain = PartLenRemain;
-            const ui32 prevEventActuallySerialized = event.EventActuallySerialized;
-            XXH3_state_t prevRdmaCumulativeChecksumState;
-            if (checksumming) {
-                prevRdmaCumulativeChecksumState = RdmaCumulativeChecksumState;
-            }
             for (; Iter.Valid() && PartLenRemain; ) {
                 TRcBuf buf = Iter.GetChunk();
                 auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(buf);
                 if (memReg.Empty()) {
-                    Iter = prevIter;
-                    IsPartRdma = false;
-                    RdmaCredsBuffer.Clear();
-                    RdmaCredPartPos = 0;
-                    PartLenRemain = prevPartLenRemain;
-                    // Fallback to PUSH_DATA must roll back all RDMA preparation progress to avoid double-accounting.
-                    event.EventActuallySerialized = prevEventActuallySerialized;
-                    if (checksumming) {
-                        RdmaCumulativeChecksumState = prevRdmaCumulativeChecksumState;
-                    }
-                    return false;
+                    Y_ABORT_UNLESS(false, "RDMA section contains a non-RDMA chunk after RDMA preflight");
                 }
 
                 const char* data = Iter.ContiguousData();

--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -146,29 +146,25 @@ namespace NActors {
         TEventSerializationInfo SerializationInfoContainer;
         const TEventSerializationInfo *SerializationInfo = nullptr;
         bool IsPartInline = false;
+        bool IsPartRdma = false;
+        NActorsInterconnect::TRdmaCreds RdmaCredsBuffer;
+        ui32 RdmaCredPartPos = 0;
+        float RdmaCredsPerByteAvg = 1.0f;
         size_t PartLenRemain = 0;
         size_t SectionIndex = 0;
         std::vector<char> XdcData;
         std::shared_ptr<NInterconnect::NRdma::IMemPool> RdmaMemPool;
-        struct TRdmaSerializationArtifacts {
-            NActorsInterconnect::TRdmaCreds RdmaCreds;
-            ui32 CheckSum = 0;
-            // Variable is used to split creds if the serialized size is grather than one IC packet
-            ui32 PartCredPos = 0;
-            float CredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
-
-        };
-        std::optional<TRdmaSerializationArtifacts> SendViaRdma;
+        XXH3_state_t RdmaCumulativeChecksumState;
         const static ui32 RdmaCredsMinSizeSerialized;
 
         template<bool External>
         bool SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, size_t *bytesSerialized);
-        bool SerializeEventRdma(TEventHolder& event, NActorsInterconnect::TRdmaCreds& rdmaCreds, ui32* checkSum, ssize_t rdmaDeviceIndex);
+        bool SerializeEventRdma(TEventHolder& event);
 
         bool FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex);
         std::optional<bool> FeedInlinePayload(TTcpPacketOutTask& task, TEventHolder& event);
         std::optional<bool> FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event);
-        std::optional<bool> FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event);
+        std::optional<bool> FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex, bool checksumming);
 
         bool FeedDescriptor(TTcpPacketOutTask& task, TEventHolder& event);
 

--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -147,6 +147,7 @@ namespace NActors {
         const TEventSerializationInfo *SerializationInfo = nullptr;
         bool IsPartInline = false;
         bool IsPartRdma = false;
+        bool UseRdmaForCurrentEvent = false;
         NActorsInterconnect::TRdmaCreds RdmaCredsBuffer;
         ui32 RdmaCredPartPos = 0;
         float RdmaCredsPerByteAvg = 1.0f;

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -54,11 +54,14 @@ namespace NActors {
         }
     }
 
-    void TReceiveContext::TPerChannelContext::FetchBuffers(ui16 channel, size_t numBytes,
+    int TReceiveContext::TPerChannelContext::FetchBuffers(ui16 channel, size_t numBytes,
             std::deque<std::tuple<ui16, TMutableContiguousSpan>>& outQ) {
         Y_DEBUG_ABORT_UNLESS(numBytes);
         auto it = XdcBuffers.begin() + FetchIndex;
         for (;;) {
+            if (it == XdcBuffers.end()) {
+                return -1;
+            }
             Y_DEBUG_ABORT_UNLESS(it != XdcBuffers.end());
             const TMutableContiguousSpan span = it->SubSpan(FetchOffset, numBytes);
             outQ.emplace_back(channel, span);
@@ -73,6 +76,7 @@ namespace NActors {
                 break;
             }
         }
+        return 0;
     }
 
     static bool NeedReallocateRdma(const NInterconnect::NRdma::TMemRegionSlice& region) {
@@ -764,7 +768,10 @@ namespace NActors {
                         XdcCatchStream.Markup.emplace_back(channel, apply, size);
                     } else {
                         // find buffers and acquire data buffer pointers
-                        context.FetchBuffers(channel, size, XdcInputQ);
+                        if (context.FetchBuffers(channel, size, XdcInputQ) == -1) {
+                            LOG_CRIT_IC_SESSION("ICIS28", "FetchBuffers: end of buffers");
+                            throw TExDestroySession{TDisconnectReason::FormatError()};
+                        }
                     }
 
                     ptr += cmdLen;
@@ -817,10 +824,11 @@ namespace NActors {
                     Y_ABORT_UNLESS(creds.ParseFromArray(ptr, credsSerializedSize));
                     ptr += credsSerializedSize;
                     if (Params.ChecksumRdmaEvent) {
-                        context.PendingEvents.back().RdmaCheckSum = ReadUnaligned<ui32>(ptr);
+                        context.PendingEvents.back().RdmaCumulativeCheckSum = ReadUnaligned<ui32>(ptr);
                     } else {
-                        context.PendingEvents.back().RdmaCheckSum = 0;
+                        context.PendingEvents.back().RdmaCumulativeCheckSum = 0;
                     }
+
                     ptr += sizeof(ui32);
                     auto err = context.ScheduleRdmaReadRequests(creds, RdmaCq, SelfId(), channel);
                     if (std::holds_alternative<ICq::TBusy>(err)) {
@@ -912,18 +920,23 @@ namespace NActors {
                 for (const auto&& [data, size] : payload) {
                     checksum = Crc32cExtendMSanCompatible(checksum, data, size);
                 }
-            } else if (pendingEvent.RdmaCheckSum) {
+                if (checksum != descr.Checksum) {
+                    LOG_CRIT_IC_SESSION("ICIS05", "event checksum error Type# 0x%08" PRIx32, descr.Type);
+                    throw TExReestablishConnection{TDisconnectReason::ChecksumError()};
+                }
+            }
+            if (pendingEvent.RdmaCumulativeCheckSum) {
                 XXH3_state_t state;
                 XXH3_64bits_reset(&state);
-                for (const auto&& [data, size] : payload) {
-                    XXH3_64bits_update(&state, data, size);
+                for (auto iter = payload.Begin(); iter.Valid(); ++iter) {
+                    auto memRegion = NInterconnect::NRdma::TryExtractFromRcBuf(iter.GetChunk());
+                    if (!memRegion.Empty()) {
+                        XXH3_64bits_update(&state, memRegion.GetAddr(), memRegion.GetSize());
+                    }
                 }
                 checksum = XXH3_64bits_digest(&state);
-            }
-            ui32 expectedChecksum = descr.Checksum ?: pendingEvent.RdmaCheckSum;
-            if (expectedChecksum) {
-                if (checksum != expectedChecksum) {
-                    LOG_CRIT_IC_SESSION("ICIS05", "event checksum error Type# 0x%08" PRIx32, descr.Type);
+                if (checksum != pendingEvent.RdmaCumulativeCheckSum) {
+                    LOG_CRIT_IC_SESSION("ICIS05", "event rdma checksum error Type# 0x%08" PRIx32, descr.Type);
                     throw TExReestablishConnection{TDisconnectReason::ChecksumError()};
                 }
             }

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -1074,7 +1074,7 @@ namespace NActors {
             const ui32 gross = grossAfter - grossBefore;
             channel->UnaccountedTraffic += gross;
             const ui64 netAfter = channel->GetBufferedAmountOfData();
-            Y_DEBUG_ABORT_UNLESS(netAfter <= netBefore); // net amount should shrink
+            Y_DEBUG_ABORT_UNLESS(netAfter <= netBefore, "netBefore# %" PRIu64 " netAfter# %" PRIu64, netBefore, netAfter); // net amount should shrink
             const ui64 net = netBefore - netAfter; // number of net bytes serialized
 
             // adjust metrics for local and global queue size

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -155,7 +155,7 @@ namespace NActors {
                 std::deque<NInterconnect::NRdma::TMemRegionSlice> RdmaBuffers;
                 TRdmaReadContext::TPtr RdmaReadContext = nullptr;
                 size_t RdmaSize = 0;
-                ui32 RdmaCheckSum = 0;
+                ui32 RdmaCumulativeCheckSum = 0;
             };
 
             std::deque<TPendingEvent> PendingEvents;
@@ -168,7 +168,7 @@ namespace NActors {
 
             void PrepareCatchBuffer();
             void ApplyCatchBuffer();
-            void FetchBuffers(ui16 channel, size_t numBytes, std::deque<std::tuple<ui16, TMutableContiguousSpan>>& outQ);
+            int FetchBuffers(ui16 channel, size_t numBytes, std::deque<std::tuple<ui16, TMutableContiguousSpan>>& outQ);
             void DropFront(TRope *from, size_t numBytes);
 
             struct TRdmaReadReqOk {};

--- a/ydb/library/actors/interconnect/rdma/ut/rdma_low_ut.cpp
+++ b/ydb/library/actors/interconnect/rdma/ut/rdma_low_ut.cpp
@@ -27,7 +27,7 @@ class TCqMode : public TSkipFixtureWithParams<NInterconnect::NRdma::ECqMode> {};
 static NInterconnect::NRdma::TMemRegionPtr AllocSourceRegion(std::shared_ptr<IMemPool> memPool) {
     auto reg = memPool->Alloc(MEM_REG_SZ, IMemPool::EMPTY);
     memset(reg->GetAddr(), 0, MEM_REG_SZ);
-    const char* testString = "-_RMDA_YDB_INTERCONNRCT_-";
+    const char* testString = "-_RDMA_YDB_INTERCONNECT_-";
     strncpy((char*)reg->GetAddr(), testString, MEM_REG_SZ);
     return reg;
 }
@@ -52,9 +52,9 @@ TEST_P(TCqMode, ReadInOneProcessIpV6) {
 }
 
 /*
- * This test cover the sutuation when sender going to reuse memory but has no
+ * This test covers the situation when sender is going to reuse memory but has no
  * information about remote reading in progress.
- * In this case we change QP on the sender to the 'Reset' state and expect reader will fail with read error
+ * In this case we change QP on the sender to the 'Reset' state and expect reader will fail with read error.
  */
 TEST_P(TCqMode, ReadInOneProcessWithQpInterruption) {
     TString addr = "127.0.0.1";
@@ -62,12 +62,12 @@ TEST_P(TCqMode, ReadInOneProcessWithQpInterruption) {
     auto rdma = InitLocalRdmaStuff(addr, GetParam());
 
     THolder<IThreadPool> pool = CreateThreadPool(2, 2);
-    const int intialAttempts = 50000;
+    const int initialAttempts = 50000;
 
-    // Use attempt as timeout to delay to run mem corrupter 
-    int attempt = intialAttempts;
+    // Use attempt as timeout to delay the memory corruptor.
+    int attempt = initialAttempts;
 
-    // bin search works unstable here due to small ammount of time to trigger race
+    // Binary search is unstable here due to the small amount of time to trigger the race.
     while (attempt--) {
         auto reg1 = AllocSourceRegion(rdma->MemPool);
         auto reg2 = rdma->MemPool->Alloc(reg1->GetSize(), 0);
@@ -77,9 +77,9 @@ TEST_P(TCqMode, ReadInOneProcessWithQpInterruption) {
         NThreading::TPromise<void> promise = NThreading::NewPromise<void>();
         NThreading::TFuture<void> done = promise.GetFuture();
 
-        class TMemCorrupter : public IObjectInQueue {
+        class TMemCorruptor : public IObjectInQueue {
         public:
-            TMemCorrupter(char* mem, size_t sz, TQueuePair* qp, int attempt, NThreading::TPromise<void> promise)
+            TMemCorruptor(char* mem, size_t sz, TQueuePair* qp, int attempt, NThreading::TPromise<void> promise)
                 : Mem(mem)
                 , Sz(sz)
                 , Qp(qp)
@@ -87,7 +87,7 @@ TEST_P(TCqMode, ReadInOneProcessWithQpInterruption) {
                 , Promise(std::move(promise))
             {}
             virtual void Process(void*) override {
-                // Delay to get a chanse to triger memset just during the RDMA read.
+                // Delay to get a chance to trigger memset just during the RDMA read.
                 Sleep(TDuration::MicroSeconds(Attempt / 128));
                 Qp->ToErrorState();
                 memset(Mem, 'Q', Sz);
@@ -104,18 +104,18 @@ TEST_P(TCqMode, ReadInOneProcessWithQpInterruption) {
 
         std::function<void()> srcInterruptHook = [&]() noexcept {
             bool added = pool->Add(
-                new TMemCorrupter((char*)reg1->GetAddr(), reg1->GetSize(), rdma->Qp1.get(), attempt, std::move(promise))
+                new TMemCorruptor((char*)reg1->GetAddr(), reg1->GetSize(), rdma->Qp1.get(), attempt, std::move(promise))
             );
             Y_ABORT_UNLESS(added);
         };
 
         auto readResult = ReadOneMemRegion(rdma, rdma->Qp2, reg1->GetAddr(), reg1->GetRKey(rdma->Ctx->GetDeviceIndex()), MEM_REG_SZ, reg2, std::move(srcInterruptHook));
 
-        // Whait until corrupter finished
+        // Wait until corruptor finished.
         done.Wait();
 
         switch (readResult) {
-            case EReadResult::OK: // corrupter fired too late, just check data is ok
+            case EReadResult::OK: // corruptor fired too late, just check data is ok
                 {
                     ASSERT_TRUE(strncmp(expected.data(), (char*)reg2->GetAddr(), MEM_REG_SZ) == 0);
                     // Additional check cq is empty after all this stuff
@@ -124,8 +124,8 @@ TEST_P(TCqMode, ReadInOneProcessWithQpInterruption) {
                     EXPECT_TRUE(stats.Ready == stats.Total);
                 }
                 break;
-            case EReadResult::WRPOST_ERR: // currupter fired too early, increase timeout
-                attempt = std::min(intialAttempts, attempt *= 2);
+            case EReadResult::WRPOST_ERR: // corruptor fired too early, increase timeout
+                attempt = std::min(initialAttempts, attempt *= 2);
                 break;
             case EReadResult::READ_ERR:
                 Cerr << "passed at " << attempt << Endl;
@@ -133,7 +133,7 @@ TEST_P(TCqMode, ReadInOneProcessWithQpInterruption) {
         }
         if (attempt == 0) {
             Cerr << "race was not triggered, restart..." << Endl;
-            attempt = intialAttempts;
+            attempt = initialAttempts;
         }
 
         {

--- a/ydb/library/actors/interconnect/rdma/ut/utils.h
+++ b/ydb/library/actors/interconnect/rdma/ut/utils.h
@@ -16,7 +16,7 @@ namespace NInterconnect::NRdma {
 namespace NRdmaTest {
 
 inline void GTestSkip() {
-    GTEST_SKIP() << "Skipping all rdma tests for suit, set \""
+    GTEST_SKIP() << "Skipping all rdma tests for suite, set \""
                  << RdmaTestEnvSwitchName << "\" env if it is RDMA compatible";
 }
 
@@ -68,4 +68,3 @@ protected:
         }
     }
 };
-

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/library/actors/core/event_pb.h>
+#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/interconnect/rdma/ut/utils/utils.h>
 #include <ydb/library/actors/interconnect/rdma/mem_pool.h>
 
@@ -119,15 +120,17 @@ private:
 struct TEventsForTest {
     std::vector<TEvTestSerialization*> Events;
     std::unordered_map<ui64, std::function<void(TEvTestSerialization*)>> Checks;
+    NMonitoring::TDynamicCounterPtr Counters;
     std::shared_ptr<NInterconnect::NRdma::IMemPool> MemPool;
 
-    TEventsForTest(ui32 numEvents)
-        : MemPool(NInterconnect::NRdma::CreateDummyMemPool())
+    TEventsForTest(ui32 numEvents, bool shuffle = false)
+        : Counters(new NMonitoring::TDynamicCounters())
+        , MemPool(NInterconnect::NRdma::CreateSlotMemPool(Counters.Get(), {}))
     {
-        Generate(numEvents, MemPool.get());
+        Generate(numEvents, MemPool.get(), shuffle);
     }
 
-    void Generate(ui32 numEvents, NInterconnect::NRdma::IMemPool* memPool) {
+    void Generate(ui32 numEvents, NInterconnect::NRdma::IMemPool* memPool, bool shuffle = false) {
         for (ui32 i = 0; i < numEvents; ++i) {
             const bool isInline = i % 3 == 0;
             const bool isXdc = i % 3 == 1;
@@ -155,6 +158,16 @@ struct TEventsForTest {
                     UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), sz + j);
                 }
             }
+            if (shuffle) {
+                for (ui32 j = 0; j < numPayloads; ++j) {
+                    ev->AddPayload(TRope(TString(10 + j, j + i)));
+                    ev->AddPayload(TRope(TString(5000 + j, j + i)));
+                    auto buf = memPool->AllocRcBuf(5000 + j, 0).value();
+                    std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000 + j, j + i);
+                    ev->AddPayload(TRope(std::move(buf)));
+                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), 5000 + j);
+                }
+            }
 
             if (isXdc || isRdma) {
                 UNIT_ASSERT(ev->AllowExternalDataChannel());
@@ -162,10 +175,10 @@ struct TEventsForTest {
 
             Events.push_back(ev);
 
-            Checks.emplace(i, [i, numPayloads, isInline, sz](TEvTestSerialization* ev) {
+            Checks.emplace(i, [i, numPayloads, isInline, sz, shuffle](TEvTestSerialization* ev) {
                 UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBlobID(), i);
                 UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBuffer(), TStringBuilder{} << "hello world " << i);
-                UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().size(), numPayloads);
+                UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().size(), numPayloads * (shuffle ? 4 : 1));
                 for (ui32 j = 0; j < numPayloads; ++j) {
                     ui32 payloadSize = isInline ? 10 + j : sz + j;
                     UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload()[j].GetSize(), payloadSize);
@@ -289,8 +302,8 @@ TEST_F(XdcRdmaTest, SerializeToRope) {
     }
 
     auto mempool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
-
-    auto serializedRope = ev->SerializeToRope(mempool.get());
+    TRdmaAllocatorWithFallback allocator(mempool);
+    auto serializedRope = ev->SerializeToRope(&allocator);
 
     ASSERT_TRUE(serializedRope.has_value());
     auto rope = serializedRope->ConvertToString();
@@ -328,6 +341,362 @@ TEST_F(XdcRdmaTest, SerializeToRope) {
     UNIT_ASSERT_VALUES_EQUAL(parsedEvent->GetPayload()[0].ConvertToString(), TString(5000, 'X'));
 }
 
+namespace {
+    struct TXdcCommandCounters {
+        ui32 DeclareSection = 0;
+        ui32 DeclareSectionInline = 0;
+        ui32 DeclareSectionRdma = 0;
+        ui32 PushData = 0;
+        ui32 RdmaRead = 0;
+    };
+
+    static TString CollectStreamData(NInterconnect::TOutgoingStream& stream) {
+        TVector<TConstIoVec> data;
+        stream.ProduceIoVec(data, 256, Max<size_t>());
+        TString packet;
+        for (const auto& [ptr, len] : data) {
+            packet.append(static_cast<const char*>(ptr), len);
+        }
+        return packet;
+    }
+
+    static void AccumulateXdcCommandCounters(const TString& packet, TXdcCommandCounters& counters) {
+        UNIT_ASSERT_C(packet.size() >= sizeof(TTcpPacketHeader_v2), "packet too short");
+
+        const char* ptr = packet.data() + sizeof(TTcpPacketHeader_v2);
+        const char* end = packet.data() + packet.size();
+        while (ptr < end) {
+            UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= sizeof(TChannelPart), "missing channel part header");
+            TChannelPart part;
+            memcpy(&part, ptr, sizeof(part));
+            ptr += sizeof(part);
+            UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= part.Size, "invalid channel part payload size");
+
+            const char* partEnd = ptr + part.Size;
+            if (!part.IsXdc()) {
+                ptr = partEnd;
+                continue;
+            }
+
+            while (ptr < partEnd) {
+                const EXdcCommand cmd = static_cast<EXdcCommand>(*ptr++);
+                switch (cmd) {
+                    case EXdcCommand::DECLARE_SECTION:
+                    case EXdcCommand::DECLARE_SECTION_INLINE:
+                    case EXdcCommand::DECLARE_SECTION_RDMA: {
+                        for (ui32 i = 0; i < 4; ++i) {
+                            const ui64 value = NInterconnect::NDetail::DeserializeNumber(&ptr, partEnd);
+                            UNIT_ASSERT_VALUES_UNEQUAL(value, Max<ui64>());
+                        }
+                        if (cmd == EXdcCommand::DECLARE_SECTION) {
+                            ++counters.DeclareSection;
+                        } else if (cmd == EXdcCommand::DECLARE_SECTION_INLINE) {
+                            ++counters.DeclareSectionInline;
+                        } else {
+                            ++counters.DeclareSectionRdma;
+                        }
+                        break;
+                    }
+                    case EXdcCommand::PUSH_DATA: {
+                        constexpr size_t cmdLen = sizeof(ui16) + sizeof(ui32);
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= cmdLen, "invalid PUSH_DATA");
+                        ptr += cmdLen;
+                        ++counters.PushData;
+                        break;
+                    }
+                    case EXdcCommand::RDMA_READ: {
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= sizeof(ui16), "invalid RDMA_READ");
+                        const ui16 credsSerializedSize = ReadUnaligned<ui16>(ptr);
+                        ptr += sizeof(ui16);
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= credsSerializedSize + sizeof(ui32),
+                            "invalid RDMA_READ payload");
+                        ptr += credsSerializedSize;
+                        ptr += sizeof(ui32);
+                        ++counters.RdmaRead;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+TEST_F(XdcRdmaTest, ShuffleRdmaUsesIteratorOffsetInsideChunk) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo("peer", "1", "peer");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t prefixSize = 17;
+    constexpr size_t rdmaSize = 100;
+    constexpr size_t totalSize = prefixSize + rdmaSize;
+
+    auto rcBuf = memPool->AllocRcBuf(totalSize, 0).value();
+    for (size_t i = 0; i < totalSize; ++i) {
+        rcBuf.GetDataMut()[i] = static_cast<char>(i);
+    }
+
+    const auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(rcBuf);
+    UNIT_ASSERT(!memReg.Empty());
+    const ui64 expectedAddr = reinterpret_cast<ui64>(memReg.GetAddr()) + prefixSize;
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, prefixSize, 0, 0, false, false});
+    info.Sections.push_back(TEventSectionInfo{0, rdmaSize, 0, 0, false, true});
+    auto serialized = MakeIntrusive<TEventSerializedData>(TRope(std::move(rcBuf)), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    NInterconnect::TOutgoingStream main;
+    NInterconnect::TOutgoingStream xdc;
+    TTcpPacketOutTask task(p, main, xdc);
+    UNIT_ASSERT(channel.FeedBuf(task, 0, 0));
+    task.Finish(1, 0);
+
+    TVector<TConstIoVec> mainData;
+    main.ProduceIoVec(mainData, 100, 10000);
+
+    TString packet;
+    for (const auto& [ptr, len] : mainData) {
+        packet.append(static_cast<const char*>(ptr), len);
+    }
+    UNIT_ASSERT(packet.size() >= sizeof(TTcpPacketHeader_v2));
+
+    bool foundRdmaRead = false;
+    ui64 rdmaReadAddr = 0;
+    ui64 rdmaReadSize = 0;
+
+    const char* ptr = packet.data() + sizeof(TTcpPacketHeader_v2);
+    const char* end = packet.data() + packet.size();
+    while (ptr < end) {
+        UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= sizeof(TChannelPart), "missing channel part header");
+        TChannelPart part;
+        memcpy(&part, ptr, sizeof(part));
+        ptr += sizeof(part);
+        UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= part.Size, "invalid channel part payload size");
+
+        const char* partEnd = ptr + part.Size;
+        if (part.IsXdc()) {
+            while (ptr < partEnd) {
+                const EXdcCommand cmd = static_cast<EXdcCommand>(*ptr++);
+                switch (cmd) {
+                    case EXdcCommand::DECLARE_SECTION:
+                    case EXdcCommand::DECLARE_SECTION_INLINE:
+                    case EXdcCommand::DECLARE_SECTION_RDMA: {
+                        for (ui32 i = 0; i < 4; ++i) {
+                            const ui64 value = NInterconnect::NDetail::DeserializeNumber(&ptr, partEnd);
+                            UNIT_ASSERT_VALUES_UNEQUAL(value, Max<ui64>());
+                        }
+                        break;
+                    }
+                    case EXdcCommand::PUSH_DATA: {
+                        constexpr size_t cmdLen = sizeof(ui16) + sizeof(ui32);
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= cmdLen, "invalid PUSH_DATA");
+                        ptr += cmdLen;
+                        break;
+                    }
+                    case EXdcCommand::RDMA_READ: {
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= sizeof(ui16), "invalid RDMA_READ");
+                        const ui16 credsSerializedSize = ReadUnaligned<ui16>(ptr);
+                        ptr += sizeof(ui16);
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= credsSerializedSize + sizeof(ui32),
+                            "invalid RDMA_READ payload");
+                        NActorsInterconnect::TRdmaCreds creds;
+                        UNIT_ASSERT(creds.ParseFromArray(ptr, credsSerializedSize));
+                        ptr += credsSerializedSize;
+                        ptr += sizeof(ui32); // checksum
+                        UNIT_ASSERT_VALUES_EQUAL(creds.CredsSize(), 1u);
+                        rdmaReadAddr = creds.GetCreds(0).GetAddress();
+                        rdmaReadSize = creds.GetCreds(0).GetSize();
+                        foundRdmaRead = true;
+                        break;
+                    }
+                }
+            }
+        } else {
+            ptr = partEnd;
+        }
+    }
+
+    UNIT_ASSERT(foundRdmaRead);
+    UNIT_ASSERT_VALUES_EQUAL(rdmaReadSize, rdmaSize);
+    UNIT_ASSERT_VALUES_EQUAL(rdmaReadAddr, expectedAddr);
+}
+
+TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo("peer", "1", "peer");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t payloadSize = 128;
+    auto rcBuf = memPool->AllocRcBuf(payloadSize, 0).value();
+    memset(rcBuf.GetDataMut(), 0xAB, payloadSize);
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, payloadSize, 0, 0, false, true});
+    auto serialized = MakeIntrusive<TEventSerializedData>(TRope(std::move(rcBuf)), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    NInterconnect::TOutgoingStream main;
+    NInterconnect::TOutgoingStream xdc;
+    TTcpPacketOutTask task(p, main, xdc);
+    UNIT_ASSERT(channel.FeedBuf(task, 1, -1));
+    task.Finish(1, 0);
+
+    TXdcCommandCounters counters;
+    AccumulateXdcCommandCounters(CollectStreamData(main), counters);
+
+    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.PushData > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+}
+
+TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenChunkIsNotRdmaRegistered) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo("peer", "1", "peer");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t payloadSize = 128;
+    auto nonRdmaBuf = TRcBuf::Uninitialized(payloadSize);
+    memset(nonRdmaBuf.GetDataMut(), 0xCD, payloadSize);
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, payloadSize, 0, 0, false, true});
+    auto serialized = MakeIntrusive<TEventSerializedData>(TRope(std::move(nonRdmaBuf)), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    TXdcCommandCounters counters;
+    bool done = false;
+    for (ui64 serial = 1; serial <= 4 && !done; ++serial) {
+        NInterconnect::TOutgoingStream main;
+        NInterconnect::TOutgoingStream xdc;
+        TTcpPacketOutTask task(p, main, xdc);
+        done = channel.FeedBuf(task, serial, 0);
+        task.Finish(serial, 0);
+        AccumulateXdcCommandCounters(CollectStreamData(main), counters);
+    }
+
+    UNIT_ASSERT(done);
+    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.PushData > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+}
+
+TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunks) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo("peer", "1", "peer");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t rdmaChunkSize = 64;
+    constexpr size_t nonRdmaChunkSize = 48;
+    constexpr size_t payloadSize = rdmaChunkSize + nonRdmaChunkSize;
+
+    auto rdmaBuf = memPool->AllocRcBuf(rdmaChunkSize, 0).value();
+    memset(rdmaBuf.GetDataMut(), 0xE1, rdmaChunkSize);
+    auto nonRdmaBuf = TRcBuf::Uninitialized(nonRdmaChunkSize);
+    memset(nonRdmaBuf.GetDataMut(), 0xE2, nonRdmaChunkSize);
+
+    TRope payload(std::move(rdmaBuf));
+    payload.Insert(payload.End(), TRope(std::move(nonRdmaBuf)));
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, payloadSize, 0, 0, false, true});
+    auto serialized = MakeIntrusive<TEventSerializedData>(std::move(payload), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    TXdcCommandCounters counters;
+    bool done = false;
+    for (ui64 serial = 1; serial <= 4 && !done; ++serial) {
+        NInterconnect::TOutgoingStream main;
+        NInterconnect::TOutgoingStream xdc;
+        TTcpPacketOutTask task(p, main, xdc);
+        done = channel.FeedBuf(task, serial, 0);
+        task.Finish(serial, 0);
+        AccumulateXdcCommandCounters(CollectStreamData(main), counters);
+    }
+
+    UNIT_ASSERT(done);
+    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.PushData > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+}
+
 TEST_F(XdcRdmaTest, SendRdma) {
     TTestICCluster cluster(2);
     auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
@@ -348,6 +717,46 @@ TEST_F(XdcRdmaTest, SendRdma) {
     auto senderPtr = new TSendActor(receiver, ev);
     cluster.RegisterActor(senderPtr, 2);
     UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+}
+
+TEST_F(XdcRdmaTest, SendRdmaWithShuffledPayload) {
+    TTestICCluster cluster(2);
+    auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    auto ev = new TEvTestSerialization();
+    ev->Record.SetBlobID(123);
+    ev->Record.SetBuffer("hello world");
+    for (ui32 i = 0; i < 10; ++i) {
+        if (i % 2 == 0) {
+            TRope tmp(TString(5000, 'X'));
+            ev->AddPayload(std::move(tmp));
+        } else {
+            auto buf = memPool->AllocRcBuf(5000, 0).value();
+            std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000, 'Y');
+            ev->AddPayload(TRope(std::move(buf)));
+        }
+    }
+
+    auto recieverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 123u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 10u);
+        for (ui32 i = 0; i < 10; ++i) {
+            if (i % 2 == 0) {
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].GetSize(), 5000u);
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].ConvertToString(), TString(5000, 'X'));
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].GetSize(), 5000u);
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].ConvertToString(), TString(5000, 'Y'));
+            }
+        }
+    });
+    const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
+
+    Sleep(TDuration::MilliSeconds(1000));
+
+    auto senderPtr = new TSendActor(receiver, ev);
+    cluster.RegisterActor(senderPtr, 2);
+    UNIT_ASSERT(recieverPtr->WhaitForReceive(1, 20));
 }
 
 TEST_F(XdcRdmaTest, SendRdmaWithRegionOffset) {
@@ -456,7 +865,7 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(9999)); //Disable dead peer detection to parallel activity
 
-    std::vector<NInterconnect::NRdma::TMemRegionPtr> regions;
+    std::vector<TRcBuf> occupiedBuffers;
 
     // Create receiver
     ui32 index = 0;
@@ -482,10 +891,16 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
         UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
     }
 
-    // Allocate all rdma memory to trigger an error during the next transmissions
-    for (size_t i = 0; i < 7; i++) {
-        regions.emplace_back(pool->Alloc(32u << 20, 0));
+    // Exhaust the same allocation class (5KB) that receiver uses for RDMA sections.
+    // This makes the "undelivered due to no RDMA memory on receiver" check deterministic.
+    for (;;) {
+        auto buf = pool->AllocRcBuf(5000, 0);
+        if (!buf) {
+            break;
+        }
+        occupiedBuffers.emplace_back(std::move(*buf));
     }
+    UNIT_ASSERT(!occupiedBuffers.empty());
 
     // Send more
     {
@@ -524,7 +939,7 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
     }
     UNIT_ASSERT(receiverPtr->WhaitForReceive(2, 20));
     // Free memory
-    regions.clear();
+    occupiedBuffers.clear();
     // Whait for the pending hendshake timer
     Sleep(TDuration::MilliSeconds(5000));
 
@@ -621,6 +1036,32 @@ TEST_P(XdcRdmaTestCqMode, SendMixBig) {
                 break;
             }
         }
+        Sleep(TDuration::MilliSeconds(1000));
+    }
+    UNIT_ASSERT_VALUES_EQUAL(events.Checks.size(), 0u);
+}
+
+TEST_F(XdcRdmaTest, SendMixBigShuffle) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TEventsForTest events(1000, true);
+
+    auto recieverPtr = new TReceiveActor([&events](TEvTestSerialization::TPtr ev) {
+        ui64 blobId = ev->Get()->Record.GetBlobID();
+        auto checkIt = events.Checks.find(blobId);
+        UNIT_ASSERT(checkIt != events.Checks.end());
+        checkIt->second(ev->Get());
+        events.Checks.erase(checkIt);
+    });
+    const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
+    Sleep(TDuration::MilliSeconds(1000));
+
+    for (auto* ev : events.Events) {
+        auto senderPtr = new TSendActor(receiver, ev);
+        cluster.RegisterActor(senderPtr, 2);
+    }
+
+    for (ui32 attempt = 0; attempt < 10 && !events.Checks.empty(); ++attempt) {
         Sleep(TDuration::MilliSeconds(1000));
     }
     UNIT_ASSERT_VALUES_EQUAL(events.Checks.size(), 0u);

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -16,6 +16,45 @@ using namespace NActors;
 
 struct TEvTestSerialization : public TEventPB<TEvTestSerialization, NInterconnectTest::TEvTestSerialization, 123> {};
 
+struct TEvSerializeToRopeFailure : public TEventBase<TEvSerializeToRopeFailure, 124> {
+    TString Payload;
+    mutable ui32 SerializeToRopeCallCount = 0;
+
+    explicit TEvSerializeToRopeFailure(size_t payloadSize = 5000)
+        : Payload(payloadSize, 'R')
+    {}
+
+    TString ToStringHeader() const override {
+        return "TEvSerializeToRopeFailure";
+    }
+
+    bool SerializeToArcadiaStream(TChunkSerializer* serializer) const override {
+        return serializer->WriteString(&Payload);
+    }
+
+    std::optional<TRope> SerializeToRope(IRcBufAllocator*) const override {
+        ++SerializeToRopeCallCount;
+        return std::nullopt;
+    }
+
+    TEventSerializationInfo CreateSerializationInfo(bool allowExternalDataChannel) const override {
+        if (!allowExternalDataChannel) {
+            return {};
+        }
+        TEventSerializationInfo info;
+        info.Sections.push_back(TEventSectionInfo{0, Payload.size(), 0, 0, false, true});
+        return info;
+    }
+
+    ui32 CalculateSerializedSize() const override {
+        return Payload.size();
+    }
+
+    bool IsSerializable() const override {
+        return true;
+    }
+};
+
 static void GTestSkip() {
     GTEST_SKIP() << "Skipping all rdma tests for suite, set \""
                  << NRdmaTest::RdmaTestEnvSwitchName << "\" env if it is RDMA compatible";
@@ -590,6 +629,45 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid) {
     UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
 }
 
+TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenSerializeToRopeFails) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo("peer", "1", "peer");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    auto* ev = new TEvSerializeToRopeFailure();
+    auto evHandle = MakeHolder<IEventHandle>(TActorId(), TActorId(), ev);
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    TXdcCommandCounters counters;
+    bool done = false;
+    for (ui64 serial = 1; serial <= 4 && !done; ++serial) {
+        NInterconnect::TOutgoingStream main;
+        NInterconnect::TOutgoingStream xdc;
+        TTcpPacketOutTask task(p, main, xdc);
+        done = channel.FeedBuf(task, serial, 0);
+        task.Finish(serial, 0);
+        AccumulateXdcCommandCounters(CollectStreamData(main), counters);
+    }
+
+    UNIT_ASSERT(done);
+    UNIT_ASSERT_C(ev->SerializeToRopeCallCount > 0u, "SerializeToRope should be attempted for RDMA-capable sections");
+    UNIT_ASSERT(counters.DeclareSection > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 0u);
+    UNIT_ASSERT(counters.PushData > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+}
+
+#ifndef NDEBUG
 TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenChunkIsNotRdmaRegistered) {
     auto common = MakeIntrusive<TInterconnectProxyCommon>();
     common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -699,6 +777,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunk
     UNIT_ASSERT(counters.PushData > 0u);
     UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
 }
+#endif
 
 TEST_F(XdcRdmaTest, SendRdma) {
     TTestICCluster cluster(2);

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -17,7 +17,7 @@ using namespace NActors;
 struct TEvTestSerialization : public TEventPB<TEvTestSerialization, NInterconnectTest::TEvTestSerialization, 123> {};
 
 static void GTestSkip() {
-    GTEST_SKIP() << "Skipping all rdma tests for suit, set \""
+    GTEST_SKIP() << "Skipping all rdma tests for suite, set \""
                  << NRdmaTest::RdmaTestEnvSwitchName << "\" env if it is RDMA compatible";
 }
 
@@ -45,7 +45,7 @@ class TSendActor: public TActorBootstrapped<TSendActor> {
 public:
     struct TExtCtx {
         std::atomic<bool> Undelivered = false;
-        bool WhaitForUndelivered(ui32 maxAttempt) {
+        bool WaitForUndelivered(ui32 maxAttempt) {
             while (Undelivered.load(std::memory_order_relaxed) == false && maxAttempt) {
                 Sleep(TDuration::MilliSeconds(1000));
                 maxAttempt--;
@@ -102,7 +102,7 @@ public:
     )
 public:
     std::atomic<ui32> ReceivedEvents = 0;
-    bool WhaitForReceive(ui32 expected, ui32 maxAttempt) {
+    bool WaitForReceive(ui32 expected, ui32 maxAttempt) {
         while (ReceivedEvents.load(std::memory_order_relaxed) != expected && maxAttempt) {
             Sleep(TDuration::MilliSeconds(1000));
             maxAttempt--;
@@ -192,7 +192,7 @@ struct TEventsForTest {
     }
 };
 
-TEvTestSerialization* MakeMultuGlueTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool* memPool) {
+TEvTestSerialization* MakeMultiGlueTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool* memPool) {
     auto ev = new TEvTestSerialization();
     ev->Record.SetBlobID(blobId);
     ev->Record.SetBuffer("hello world");
@@ -225,7 +225,7 @@ TEvTestSerialization* MakeTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool*
         ev->AddPayload(std::move(tmp));
     } else {
         auto buf = memPool->AllocRcBuf(5000, 0).value();
-        // TRope can "glue" rcbufs in they have same backend and placed in the contiguous memory regions
+        // TRope can "glue" rcbufs if they have the same backend and are placed in contiguous memory regions.
         if (withGlue) {
             auto b = buf.data();
             TRcBuf rcbuf1(TRcBuf::Piece, b, b + 2500, buf);
@@ -719,7 +719,7 @@ TEST_F(XdcRdmaTest, SendRdma) {
 
     auto senderPtr = new TSendActor(receiver, ev);
     cluster.RegisterActor(senderPtr, 2);
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
 TEST_F(XdcRdmaTest, SendRdmaWithShuffledPayload) {
@@ -739,7 +739,7 @@ TEST_F(XdcRdmaTest, SendRdmaWithShuffledPayload) {
         }
     }
 
-    auto recieverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 123u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 10u);
@@ -753,13 +753,13 @@ TEST_F(XdcRdmaTest, SendRdmaWithShuffledPayload) {
             }
         }
     });
-    const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
 
     Sleep(TDuration::MilliSeconds(1000));
 
     auto senderPtr = new TSendActor(receiver, ev);
     cluster.RegisterActor(senderPtr, 2);
-    UNIT_ASSERT(recieverPtr->WhaitForReceive(1, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
 TEST_F(XdcRdmaTest, SendRdmaWithRegionOffset) {
@@ -781,7 +781,7 @@ TEST_F(XdcRdmaTest, SendRdmaWithRegionOffset) {
 
     auto senderPtr = new TSendActor(receiver, ev);
     cluster.RegisterActor(senderPtr, 2);
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
 TEST_F(XdcRdmaTest, SendRdmaWithGlueWithRegionOffset) {
@@ -807,7 +807,7 @@ TEST_F(XdcRdmaTest, SendRdmaWithGlueWithRegionOffset) {
 
     auto senderPtr = new TSendActor(receiver, ev);
     cluster.RegisterActor(senderPtr, 2);
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
 TEST_F(XdcRdmaTest, SendRdmaWithGlue) {
@@ -831,13 +831,13 @@ TEST_F(XdcRdmaTest, SendRdmaWithGlue) {
 
     auto senderPtr = new TSendActor(receiver, ev);
     cluster.RegisterActor(senderPtr, 2);
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
 TEST_F(XdcRdmaTest, SendRdmaWithMultiGlue) {
     TTestICCluster cluster(2);
     auto memPool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
-    auto* ev = MakeMultuGlueTestEvent(123, memPool.get());
+    auto* ev = MakeMultiGlueTestEvent(123, memPool.get());
 
     auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
         Cerr << "Blob ID: " << ev->Get()->Record.GetBlobID() << Endl;
@@ -857,7 +857,7 @@ TEST_F(XdcRdmaTest, SendRdmaWithMultiGlue) {
 
     auto senderPtr = new TSendActor(receiver, ev);
     cluster.RegisterActor(senderPtr, 2);
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
 TEST_F(XdcRdmaTest, RestoreRdmaSession) {
@@ -891,7 +891,7 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
         auto senderPtr = new TSendActor(receiver, ev);
         cluster.RegisterActor(senderPtr, 2);
 
-        UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+        UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
     }
 
     // Exhaust the same allocation class (5KB) that receiver uses for RDMA sections.
@@ -913,14 +913,14 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
         auto senderPtr = new TSendActor(receiver, ev, extCtx);
         cluster.RegisterActor(senderPtr, 2);
         // Undelivered because we can't allocate memory on the receiver side
-        UNIT_ASSERT(extCtx->WhaitForUndelivered(10));
+        UNIT_ASSERT(extCtx->WaitForUndelivered(10));
     }
 
     // The event was not delivered
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 
-    // Session is going to be recreated without rdma
-    // but pending handshake timer are triggered (we can't check it directly in this ut(()
+    // Session is going to be recreated without RDMA,
+    // but pending handshake timers are triggered (we can't check it directly in this UT).
     TString lastRdmaStatus;
     for (size_t i = 0; i < 10; i++) {
         lastRdmaStatus = GetRdmaChecksumStatus(cluster, 2, 1);
@@ -940,17 +940,17 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
         auto senderPtr = new TSendActor(receiver, ev);
         cluster.RegisterActor(senderPtr, 2);
     }
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(2, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(2, 20));
     // Free memory
     occupiedBuffers.clear();
-    // Whait for the pending hendshake timer
+    // Wait for the pending handshake timer
     Sleep(TDuration::MilliSeconds(5000));
 
     for (size_t i = 0; i < 5; i++) {
         try {
             lastRdmaStatus = GetRdmaChecksumStatus(cluster, 2, 1);
         } catch (const TPatternNotFound&) {
-            // retry case if the session was not created yiet
+            // retry case if the session was not created yet
             Sleep(TDuration::Seconds(1));
             continue;
         }
@@ -966,7 +966,7 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
         auto senderPtr = new TSendActor(receiver, ev);
         cluster.RegisterActor(senderPtr, 2);
     }
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(3, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(3, 20));
     lastRdmaStatus = GetRdmaChecksumStatus(cluster, 2, 1);
     UNIT_ASSERT_VALUES_EQUAL(lastRdmaStatus, "On | SoftwareChecksum");
 }
@@ -1000,7 +1000,7 @@ TEST_P(XdcRdmaTestCqMode, SendMix) {
         cluster.RegisterActor(senderPtr, 2);
     }
 
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(numEvents, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(numEvents, 20));
 }
 
 TEST_P(XdcRdmaTestCqMode, SendMixBig) {
@@ -1049,14 +1049,14 @@ TEST_F(XdcRdmaTest, SendMixBigShuffle) {
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
     TEventsForTest events(1000, true);
 
-    auto recieverPtr = new TReceiveActor([&events](TEvTestSerialization::TPtr ev) {
+    auto receiverPtr = new TReceiveActor([&events](TEvTestSerialization::TPtr ev) {
         ui64 blobId = ev->Get()->Record.GetBlobID();
         auto checkIt = events.Checks.find(blobId);
         UNIT_ASSERT(checkIt != events.Checks.end());
         checkIt->second(ev->Get());
         events.Checks.erase(checkIt);
     });
-    const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
     Sleep(TDuration::MilliSeconds(1000));
 
     for (auto* ev : events.Events) {
@@ -1107,7 +1107,7 @@ static void DoSendHugePayloadsNum(const ui32 numPayloads, const size_t payloadSz
         cluster.RegisterActor(senderPtr, 2);
     }
 
-    UNIT_ASSERT(receiverPtr->WhaitForReceive(1, 20));
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
 TEST_F(XdcRdmaTest, Send1Payload) {

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -584,7 +584,8 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid) {
     TXdcCommandCounters counters;
     AccumulateXdcCommandCounters(CollectStreamData(main), counters);
 
-    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.DeclareSection > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 0u);
     UNIT_ASSERT(counters.PushData > 0u);
     UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
 }
@@ -634,7 +635,8 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenChunkIsNotRdmaRegistered) 
     }
 
     UNIT_ASSERT(done);
-    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.DeclareSection > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 0u);
     UNIT_ASSERT(counters.PushData > 0u);
     UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
 }
@@ -692,7 +694,8 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunk
     }
 
     UNIT_ASSERT(done);
-    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.DeclareSection > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 0u);
     UNIT_ASSERT(counters.PushData > 0u);
     UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add RDMA support for XDC shuffle

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implement RDMA transport for XDC shuffle sections, remove the legacy full-event SendViaRdma flow, and harden fallback semantics when RDMA preparation cannot be completed for a section.

Changes:
- Route RDMA only through the shuffle path (UseXdcShuffle && UseRdma)
- Remove legacy SendViaRdma state and whole-event RDMA credential emission
- Keep section-level RDMA credential splitting across IC packets
- Preserve fallback to external XDC PUSH_DATA when RDMA read cannot be prepared
- Fix rollback for partial RDMA preparation before fallback: restore EventActuallySerialized and RDMA checksum state
- Keep RDMA address calculation based on iterator offset inside chunk

Tests:
- Add XdcRdmaTest.ShuffleRdmaUsesIteratorOffsetInsideChunk to validate non-zero iterator offset (offset != 0) in RDMA credential address generation
- Add XdcRdmaTest.ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid
- Add XdcRdmaTest.ShuffleRdmaFallsBackToPushDataWhenChunkIsNotRdmaRegistered
- Add XdcRdmaTest.ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunks to cover mixed RDMA/non-RDMA chunk rollback and PUSH_DATA fallback

Compatibility:
- XDC behavior with RDMA disabled remains unchanged for both shuffle modes (traffic is sent via PUSH_DATA)
- This branch assumes RDMA is used only when shuffle is enabled during rollout

