### PR TITLE
[ICRDMA] add RDMA support for XDC shuffle (shuffle-only path)

### DIFF
--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -43,7 +43,7 @@ namespace NActors {
         }
         virtual ui32 Type() const = 0;
         virtual bool SerializeToArcadiaStream(TChunkSerializer*) const = 0;
-        virtual std::optional<TRope> SerializeToRope(NInterconnect::NRdma::IMemPool*) const {
+        virtual std::optional<TRope> SerializeToRope(IRcBufAllocator*) const {
             return std::nullopt;
         }
         virtual bool IsSerializable() const = 0;

--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -333,22 +333,22 @@ namespace NActors {
         return true;
     }
 
-    std::optional<TRope> SerializeToRopeImpl(const google::protobuf::MessageLite& msg, const TVector<TRope>& payload, NInterconnect::NRdma::IMemPool* pool) {
+    std::optional<TRope> SerializeToRopeImpl(const google::protobuf::MessageLite& msg, const TVector<TRope>& payload, IRcBufAllocator* allocator) {
         TRope result;
         auto sz = CalculateSerializedHeaderSizeImpl(payload);
         if (sz) {
-            std::optional<TRcBuf> headerBuf = pool->AllocRcBuf(sz, NInterconnect::NRdma::IMemPool::EMPTY);
+            TRcBuf headerBuf = allocator->AllocRcBuf(sz, 0, 0);
             if (!headerBuf) {
                 return {};
             }
-            char* data = headerBuf->GetDataMut();
+            char* data = headerBuf.GetDataMut();
             auto append = [&data](const char *p, size_t len) {
                 std::memcpy(data, p, len);
                 data += len;
                 return true;
             };
             SerializeHeaderCommon(payload, append);
-            result.Insert(result.End(), std::move(headerBuf.value()));
+            result.Insert(result.End(), std::move(headerBuf));
 
             auto appendRope = [&](TRope rope) {
                 result.Insert(result.End(), std::move(rope));
@@ -359,13 +359,13 @@ namespace NActors {
 
         {
             ui32 size = msg.ByteSizeLong();
-            std::optional<TRcBuf> recordsSerializedBuf = pool->AllocRcBuf(size, NInterconnect::NRdma::IMemPool::EMPTY);
+            TRcBuf recordsSerializedBuf = allocator->AllocRcBuf(size, 0, 0);
             if (!recordsSerializedBuf) {
                 return {};
             }
-            bool serializationDone = msg.SerializePartialToArray(recordsSerializedBuf->GetDataMut(), size);
+            bool serializationDone = msg.SerializePartialToArray(recordsSerializedBuf.GetDataMut(), size);
             Y_ABORT_UNLESS(serializationDone);
-            result.Insert(result.End(), std::move(recordsSerializedBuf.value()));
+            result.Insert(result.End(), std::move(recordsSerializedBuf));
         }
 
         return result;
@@ -465,14 +465,14 @@ namespace NActors {
                     for (const TRope& rope : payload) {
                         headerLen += SerializeNumber(rope.size(), temp);
                     }
-                    info.Sections.push_back(TEventSectionInfo{0, headerLen, 0, 0, true, true});
+                    info.Sections.push_back(TEventSectionInfo{0, headerLen, 0, 0, true, false});
                     for (const TRope& rope : payload) {
                         info.Sections.push_back(TEventSectionInfo{0, rope.size(), 0, 0, false, IsRdma(rope)});
                     }
                 }
 
                 const size_t byteSize = Max<ssize_t>(0, recordSize) + preserializedSize;
-                info.Sections.push_back(TEventSectionInfo{0, byteSize, 0, 0, true, true}); // protobuf itself
+                info.Sections.push_back(TEventSectionInfo{0, byteSize, 0, 0, true, false}); // protobuf itself
 
 #ifndef NDEBUG
                 size_t total = 0;

--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -152,7 +152,7 @@ namespace NActors {
     void ParseExtendedFormatPayload(TRope::TConstIterator &iter, size_t &size, TVector<TRope> &payload, size_t &totalPayloadSize);
     bool SerializeToArcadiaStreamImpl(TChunkSerializer* chunker, const TVector<TRope> &payload);
     ui32 CalculateSerializedHeaderSizeImpl(const TVector<TRope> &payload);
-    std::optional<TRope> SerializeToRopeImpl(const google::protobuf::MessageLite& msg, const TVector<TRope>& payload, NInterconnect::NRdma::IMemPool* pool);
+    std::optional<TRope> SerializeToRopeImpl(const google::protobuf::MessageLite& msg, const TVector<TRope>& payload, IRcBufAllocator* allocator);
     ui32 CalculateSerializedSizeImpl(const TVector<TRope> &payload, ssize_t recordSize);
     TEventSerializationInfo CreateSerializationInfoImpl(size_t preserializedSize, bool allowExternalDataChannel, const TVector<TRope> &payload, ssize_t recordSize);
 
@@ -205,8 +205,8 @@ namespace NActors {
             return CalculateSerializedSizeImpl(Payload, Record.ByteSize());
         }
 
-        std::optional<TRope> SerializeToRope(NInterconnect::NRdma::IMemPool* pool) const override {
-            return NActors::SerializeToRopeImpl(Record, Payload, pool);
+        std::optional<TRope> SerializeToRope(IRcBufAllocator* allocator) const override {
+            return NActors::SerializeToRopeImpl(Record, Payload, allocator);
         }
 
         static TEv* Load(const TEventSerializedData *input) {

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -2,6 +2,7 @@
 #include "interconnect_zc_processor.h"
 #include "rdma/mem_pool.h"
 
+#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/executor_thread.h>
 #include <ydb/library/actors/core/log.h>
@@ -95,7 +96,9 @@ namespace NActors {
                         Metrics->UpdateIcQueueTimeHistogram(duration.MicroSeconds());
                     }
                     event.Span && event.Span.Event("FeedBuf:INITIAL");
-                    SendViaRdma.reset();
+                    RdmaCredsBuffer.Clear();
+                    RdmaCredPartPos = 0;
+                    RdmaCredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
                     if (event.Buffer) {
                         State = EState::BODY;
                         Iter = event.Buffer->GetBeginIter();
@@ -122,22 +125,15 @@ namespace NActors {
                     } else if (Params.UseExternalDataChannel && !SerializationInfo->Sections.empty()) {
                         State = EState::SECTIONS;
                         SectionIndex = 0;
+                        XXH3_64bits_reset(&RdmaCumulativeChecksumState);
 
-                        size_t totalSize = 0;
-                        // It is possible to have event without payload. Such events has only one section.
-                        // We do not send such events via rdma.
-                        bool sendViaRdma = Params.UseRdma && RdmaMemPool && SerializationInfo->Sections.size() > 2;
+                        bool hasRdmaSections = false;
                         // Check each section can be send via rdma
                         for (const auto& section : SerializationInfo->Sections) {
-                            sendViaRdma &= section.IsRdmaCapable;
-                            totalSize += section.Size;
+                            hasRdmaSections |= section.IsRdmaCapable;
                         }
-                        if (sendViaRdma) {
-                            Y_ABORT_UNLESS(totalSize, "got empty sz, sections: %d type: %d ", SerializationInfo->Sections.size(),  event.Event->Type());
-                            NActorsInterconnect::TRdmaCreds rdmaCreds;
-                            ui32 checkSum = 0;
-                            if (SerializeEventRdma(event, rdmaCreds, task.Params.ChecksumRdmaEvent ? &checkSum : nullptr, rdmaDeviceIndex)) {
-                                SendViaRdma.emplace(TRdmaSerializationArtifacts{std::move(rdmaCreds), checkSum});
+                        if (hasRdmaSections && Params.UseXdcShuffle && Params.UseRdma && RdmaMemPool) {
+                            if (SerializeEventRdma(event)) {
                                 Chunker.DiscardEvent();
                             }
                         }
@@ -186,7 +182,7 @@ namespace NActors {
                         if (section.IsInline && Params.UseXdcShuffle) {
                             type = static_cast<ui8>(EXdcCommand::DECLARE_SECTION_INLINE);
                         }
-                        if (SendViaRdma) {
+                        if (Params.UseXdcShuffle && section.IsRdmaCapable && Params.UseRdma && RdmaMemPool) {
                             type = static_cast<ui8>(EXdcCommand::DECLARE_SECTION_RDMA);
                         }
                         Y_ABORT_UNLESS(p <= std::end(sectionInfo));
@@ -280,21 +276,25 @@ namespace NActors {
     bool TEventOutputChannel::FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex) {
         for (;;) {
             // calculate inline or external part size (it may cover a few sections, not just single one)
-            while (!PartLenRemain) {
+            while (!PartLenRemain && RdmaCredsBuffer.CredsSize() == 0) {
                 const auto& sections = SerializationInfo->Sections;
                 if (!Params.UseExternalDataChannel || sections.empty()) {
                     // all data goes inline
                     IsPartInline = true;
+                    IsPartRdma = false;
                     PartLenRemain = Max<size_t>();
-                } else if (!Params.UseXdcShuffle || SendViaRdma) {
+                } else if (!Params.UseXdcShuffle) {
                     // when UseXdcShuffle feature is not supported by the remote side, we transfer whole event over XDC
-                    // also when we use RDMA, we transfer whole over RDMA
                     IsPartInline = false;
+                    IsPartRdma = false;
                     PartLenRemain = Max<size_t>();
                 } else {
                     Y_ABORT_UNLESS(SectionIndex < sections.size());
                     IsPartInline = sections[SectionIndex].IsInline;
-                    while (SectionIndex < sections.size() && IsPartInline == sections[SectionIndex].IsInline) {
+                    IsPartRdma = sections[SectionIndex].IsRdmaCapable;
+                    while (SectionIndex < sections.size()
+                            && IsPartInline == sections[SectionIndex].IsInline
+                            && IsPartRdma == sections[SectionIndex].IsRdmaCapable) {
                         PartLenRemain += sections[SectionIndex].Size;
                         ++SectionIndex;
                     }
@@ -305,9 +305,8 @@ namespace NActors {
             std::optional<bool> complete = false;
             if (IsPartInline) {
                 complete = FeedInlinePayload(task, event);
-            } else if (SendViaRdma) {
-                Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
-                complete = FeedRdmaPayload(task, event);
+            } else if (IsPartRdma && rdmaDeviceIndex >= 0) {
+                complete = FeedRdmaPayload(task, event, rdmaDeviceIndex, task.Params.ChecksumRdmaEvent);
             } else {
                 complete = FeedExternalPayload(task, event);
             }
@@ -343,57 +342,81 @@ namespace NActors {
         return complete;
     }
 
-    bool TEventOutputChannel::SerializeEventRdma(TEventHolder& event, NActorsInterconnect::TRdmaCreds& rdmaCreds,
-        ui32* checksum, ssize_t rdmaDeviceIndex)
-    {
+    bool TEventOutputChannel::SerializeEventRdma(TEventHolder& event) {
         if (!event.Buffer && event.Event) {
-            std::optional<TRope> rope = event.Event->SerializeToRope(RdmaMemPool.get());
+            std::optional<TRope> rope = event.Event->SerializeToRope(GetDefaultRcBufAllocator());
             if (!rope) {
                 return false; // serialization failed
             }
             event.Buffer = MakeIntrusive<TEventSerializedData>(
                 std::move(*rope), event.Event->CreateSerializationInfo()
             );
+            event.Event = nullptr;
             Iter = event.Buffer->GetBeginIter();
-        }
-
-        XXH3_state_t state;
-        if (checksum) {
-            XXH3_64bits_reset(&state);
-        }
-
-        if (event.Buffer) {
-            for (; Iter.Valid(); ++Iter) {
-                TRcBuf buf = Iter.GetChunk();
-                auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(buf);
-                if (memReg.Empty()) {
-                    // TODO: may be copy to RDMA buffer ?????
-                    Iter = event.Buffer->GetBeginIter();
-                    return false;
-                }
-                if (checksum) {
-                    XXH3_64bits_update(&state, buf.GetData(), buf.GetSize());
-                }
-                auto cred = rdmaCreds.AddCreds();
-                cred->SetAddress(reinterpret_cast<ui64>(memReg.GetAddr()));
-                cred->SetSize(memReg.GetSize());
-                cred->SetRkey(memReg.GetRKey(rdmaDeviceIndex));
-            }
-        }
-
-        if (checksum) {
-            *checksum = XXH3_64bits_digest(&state);
         }
         return true;
     }
 
-    std::optional<bool> TEventOutputChannel::FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event) {
-        // The part layout is:
-        // Part = | TChannelPart | EXdcCommand::RDMA_READ (ui8)| rdmaCreds.Size (ui16) | seialized rdmaCreds | checkSum (ui32) |
+    std::optional<bool> TEventOutputChannel::FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex, bool checksumming) {
+        Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
+
+        Y_ABORT_UNLESS(event.Buffer);
+        if (RdmaCredsBuffer.CredsSize() == 0) {
+            auto prevIter = Iter;
+            size_t prevPartLenRemain = PartLenRemain;
+            const ui32 prevEventActuallySerialized = event.EventActuallySerialized;
+            XXH3_state_t prevRdmaCumulativeChecksumState;
+            if (checksumming) {
+                prevRdmaCumulativeChecksumState = RdmaCumulativeChecksumState;
+            }
+            for (; Iter.Valid() && PartLenRemain; ) {
+                TRcBuf buf = Iter.GetChunk();
+                auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(buf);
+                if (memReg.Empty()) {
+                    Iter = prevIter;
+                    IsPartRdma = false;
+                    RdmaCredsBuffer.Clear();
+                    RdmaCredPartPos = 0;
+                    PartLenRemain = prevPartLenRemain;
+                    // Fallback to PUSH_DATA must roll back all RDMA preparation progress to avoid double-accounting.
+                    event.EventActuallySerialized = prevEventActuallySerialized;
+                    if (checksumming) {
+                        RdmaCumulativeChecksumState = prevRdmaCumulativeChecksumState;
+                    }
+                    return false;
+                }
+
+                const char* data = Iter.ContiguousData();
+                Y_ABORT_UNLESS(data >= buf.GetData() && data <= buf.GetData() + buf.GetSize());
+                const size_t offset = data - buf.GetData();
+                const size_t leftInChunk = buf.GetSize() - offset;
+                const size_t chunkSize = Min(leftInChunk, PartLenRemain);
+
+                if (checksumming) {
+                    XXH3_64bits_update(&RdmaCumulativeChecksumState, data, chunkSize);
+                }
+                auto cred = RdmaCredsBuffer.AddCreds();
+                cred->SetAddress(reinterpret_cast<ui64>(memReg.GetAddr()) + offset);
+                cred->SetSize(chunkSize);
+                cred->SetRkey(memReg.GetRKey(rdmaDeviceIndex));
+
+                event.EventActuallySerialized += chunkSize;
+                PartLenRemain -= chunkSize;
+                Iter += chunkSize;
+            }
+        }
+        Y_ABORT_UNLESS(PartLenRemain == 0);
+
+        if (RdmaCredsBuffer.CredsSize() == 0) {
+            RdmaCredPartPos = 0;
+            return !Iter.Valid();
+        }
+
+        // Part = | TChannelPart | EXdcCommand::RDMA_READ | rdmaCreds.Size | rdmaCreds | checkSum |
         const size_t fixedPartSize = sizeof(TChannelPart) + sizeof(ui8) + sizeof(ui16) + sizeof(ui32);
+        const size_t maxSerializedPart = Min<size_t>(task.GetInternalFreeAmount(), Max<ui16>());
         const ui32 minThreshold = fixedPartSize + RdmaCredsMinSizeSerialized;
-        // No free amount even for one rdma cred - we need new packet
-        if (task.GetInternalFreeAmount() < minThreshold) {
+        if (maxSerializedPart < minThreshold) {
             return std::nullopt;
         }
 
@@ -401,59 +424,44 @@ namespace NActors {
             return (freeAmount - fixedPartSize) * credsPerByteAvg;
         };
 
-        const NActorsInterconnect::TRdmaCreds* rdmaCreds = &SendViaRdma->RdmaCreds;
-
-        NActorsInterconnect::TRdmaCreds tmpCreds; 
+        const NActorsInterconnect::TRdmaCreds* rdmaCreds = &RdmaCredsBuffer;
+        NActorsInterconnect::TRdmaCreds tmpCreds;
 
         bool lastPart = true;
-
-        size_t partSize;
-        size_t credsSerializedSize;
+        size_t partSize = 0;
+        size_t credsSerializedSize = 0;
 
         size_t curPartCredLen = 0;
-        /*
-         * Split rdma creds in to multiple parts if serialized credential data doesn't fit in to one IC packets.
-         * Prerequisites:
-         * - We assume this situation should be quite rare, so do not perform any additional copy in happy path
-         * - If we need to split (and credential copy to perform serialization of its part) we want to reduce number of itterations
-         * - There is no guarantee to get task with well known ammount of free space
-         */
         for (;;) {
-            if (Y_UNLIKELY(curPartCredLen || SendViaRdma->PartCredPos)) {
-                // First iteration for non first part
+            if (Y_UNLIKELY(curPartCredLen || RdmaCredPartPos)) {
                 if (!curPartCredLen) {
-                    curPartCredLen = calcPartCredLen(task.GetInternalFreeAmount(), SendViaRdma->CredsPerByteAvg);
+                    curPartCredLen = calcPartCredLen(maxSerializedPart, RdmaCredsPerByteAvg);
                     if (!curPartCredLen) {
                         return std::nullopt;
                     }
                 }
-                // Check is it a last part?
-                if (SendViaRdma->PartCredPos + curPartCredLen >= SendViaRdma->RdmaCreds.CredsSize()) {
-                    curPartCredLen = SendViaRdma->RdmaCreds.CredsSize() - SendViaRdma->PartCredPos; 
+                if (RdmaCredPartPos + curPartCredLen >= RdmaCredsBuffer.CredsSize()) {
+                    curPartCredLen = RdmaCredsBuffer.CredsSize() - RdmaCredPartPos;
                     lastPart = true;
                 } else {
                     lastPart = false;
                 }
 
-                //TODO: Find the way to perform partial serialzation of repeated field
                 tmpCreds.Clear();
-                for (size_t i = 0, j = SendViaRdma->PartCredPos; i < curPartCredLen; i++, j++) {
-                    tmpCreds.AddCreds()->CopyFrom(SendViaRdma->RdmaCreds.GetCreds(j));
+                for (size_t i = 0, j = RdmaCredPartPos; i < curPartCredLen; ++i, ++j) {
+                    tmpCreds.AddCreds()->CopyFrom(RdmaCredsBuffer.GetCreds(j));
                 }
                 rdmaCreds = &tmpCreds;
             }
 
             credsSerializedSize = rdmaCreds->ByteSizeLong();
-
             partSize = fixedPartSize + credsSerializedSize;
 
-            if (Y_UNLIKELY(partSize > task.GetInternalFreeAmount())) {
-                SendViaRdma->CredsPerByteAvg = rdmaCreds->CredsSize() / (double)credsSerializedSize; 
-                size_t newLen = calcPartCredLen(task.GetInternalFreeAmount(), SendViaRdma->CredsPerByteAvg);
-
-                // Guarantee progress even in case of huge error of average calculation
+            if (Y_UNLIKELY(partSize > maxSerializedPart)) {
+                RdmaCredsPerByteAvg = rdmaCreds->CredsSize() / (double)credsSerializedSize;
+                size_t newLen = calcPartCredLen(maxSerializedPart, RdmaCredsPerByteAvg);
                 if (newLen >= curPartCredLen) {
-                    curPartCredLen--;
+                    curPartCredLen = curPartCredLen ? curPartCredLen - 1 : newLen;
                 } else {
                     curPartCredLen = newLen;
                 }
@@ -462,18 +470,14 @@ namespace NActors {
                     return std::nullopt;
                 }
             } else {
-                // Report to mon if it is first part of multipart rdma events
-                // huge number of multipart events may be a reason of some additional latency
-                if (Y_UNLIKELY(SendViaRdma->PartCredPos == 0 && curPartCredLen != 0)) {
+                if (Y_UNLIKELY(RdmaCredPartPos == 0 && curPartCredLen != 0)) {
                     Metrics->IncRdmaMultipartEvents();
                 }
-                // Shift start position for the next packet
-                SendViaRdma->PartCredPos += curPartCredLen; 
+                RdmaCredPartPos += curPartCredLen;
                 break;
             }
         }
 
-        const ui32 checkSum = SendViaRdma->CheckSum;
         char buffer[partSize];
         TChannelPart *part = reinterpret_cast<TChannelPart*>(buffer);
         *part = {
@@ -492,17 +496,20 @@ namespace NActors {
 
         Y_ABORT_UNLESS(rdmaCreds->SerializePartialToArray(ptr, credsSerializedSize));
         ptr += credsSerializedSize;
-        WriteUnaligned<ui32>(ptr, checkSum);
-
-        if (lastPart) {
-            OutputQueueSize -= event.EventSerializedSize;
-        }
+        WriteUnaligned<ui32>(ptr, checksumming ? XXH3_64bits_digest(&RdmaCumulativeChecksumState) : 0);
+        OutputQueueSize -= payloadSz;
 
         task.Write<false>(buffer, partSize);
 
         task.AttachRdmaPayloadSize(payloadSz);
 
-        return lastPart;
+        if (lastPart) {
+            RdmaCredsBuffer.Clear();
+            RdmaCredPartPos = 0;
+            RdmaCredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
+        }
+
+        return lastPart ? !Iter.Valid() : false;
     }
 
     std::optional<bool> TEventOutputChannel::FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event) {

--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -146,29 +146,25 @@ namespace NActors {
         TEventSerializationInfo SerializationInfoContainer;
         const TEventSerializationInfo *SerializationInfo = nullptr;
         bool IsPartInline = false;
+        bool IsPartRdma = false;
+        NActorsInterconnect::TRdmaCreds RdmaCredsBuffer;
+        ui32 RdmaCredPartPos = 0;
+        float RdmaCredsPerByteAvg = 1.0f;
         size_t PartLenRemain = 0;
         size_t SectionIndex = 0;
         std::vector<char> XdcData;
         std::shared_ptr<NInterconnect::NRdma::IMemPool> RdmaMemPool;
-        struct TRdmaSerializationArtifacts {
-            NActorsInterconnect::TRdmaCreds RdmaCreds;
-            ui32 CheckSum = 0;
-            // Variable is used to split creds if the serialized size is grather than one IC packet
-            ui32 PartCredPos = 0;
-            float CredsPerByteAvg = 1.0 / RdmaCredsMinSizeSerialized;
-
-        };
-        std::optional<TRdmaSerializationArtifacts> SendViaRdma;
+        XXH3_state_t RdmaCumulativeChecksumState;
         const static ui32 RdmaCredsMinSizeSerialized;
 
         template<bool External>
         bool SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, size_t *bytesSerialized);
-        bool SerializeEventRdma(TEventHolder& event, NActorsInterconnect::TRdmaCreds& rdmaCreds, ui32* checkSum, ssize_t rdmaDeviceIndex);
+        bool SerializeEventRdma(TEventHolder& event);
 
         bool FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex);
         std::optional<bool> FeedInlinePayload(TTcpPacketOutTask& task, TEventHolder& event);
         std::optional<bool> FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event);
-        std::optional<bool> FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event);
+        std::optional<bool> FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex, bool checksumming);
 
         bool FeedDescriptor(TTcpPacketOutTask& task, TEventHolder& event);
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -44,11 +44,14 @@ namespace NActors {
         }
     }
 
-    void TReceiveContext::TPerChannelContext::FetchBuffers(ui16 channel, size_t numBytes,
+    int TReceiveContext::TPerChannelContext::FetchBuffers(ui16 channel, size_t numBytes,
             std::deque<std::tuple<ui16, TMutableContiguousSpan>>& outQ) {
         Y_DEBUG_ABORT_UNLESS(numBytes);
         auto it = XdcBuffers.begin() + FetchIndex;
         for (;;) {
+            if (it == XdcBuffers.end()) {
+                return -1;
+            }
             Y_DEBUG_ABORT_UNLESS(it != XdcBuffers.end());
             const TMutableContiguousSpan span = it->SubSpan(FetchOffset, numBytes);
             outQ.emplace_back(channel, span);
@@ -63,6 +66,7 @@ namespace NActors {
                 break;
             }
         }
+        return 0;
     }
 
     static bool NeedReallocateRdma(const NInterconnect::NRdma::TMemRegionSlice& region) {
@@ -754,7 +758,10 @@ namespace NActors {
                         XdcCatchStream.Markup.emplace_back(channel, apply, size);
                     } else {
                         // find buffers and acquire data buffer pointers
-                        context.FetchBuffers(channel, size, XdcInputQ);
+                        if (context.FetchBuffers(channel, size, XdcInputQ) == -1) {
+                            LOG_CRIT_IC_SESSION("ICIS28", "FetchBuffers: end of buffers");
+                            throw TExDestroySession{TDisconnectReason::FormatError()};
+                        }
                     }
 
                     ptr += cmdLen;
@@ -807,10 +814,11 @@ namespace NActors {
                     Y_ABORT_UNLESS(creds.ParseFromArray(ptr, credsSerializedSize));
                     ptr += credsSerializedSize;
                     if (Params.ChecksumRdmaEvent) {
-                        context.PendingEvents.back().RdmaCheckSum = ReadUnaligned<ui32>(ptr);
+                        context.PendingEvents.back().RdmaCumulativeCheckSum = ReadUnaligned<ui32>(ptr);
                     } else {
-                        context.PendingEvents.back().RdmaCheckSum = 0;
+                        context.PendingEvents.back().RdmaCumulativeCheckSum = 0;
                     }
+
                     ptr += sizeof(ui32);
                     auto err = context.ScheduleRdmaReadRequests(creds, RdmaCq, SelfId(), channel);
                     if (std::holds_alternative<ICq::TBusy>(err)) {
@@ -902,18 +910,23 @@ namespace NActors {
                 for (const auto&& [data, size] : payload) {
                     checksum = Crc32cExtendMSanCompatible(checksum, data, size);
                 }
-            } else if (pendingEvent.RdmaCheckSum) {
+                if (checksum != descr.Checksum) {
+                    LOG_CRIT_IC_SESSION("ICIS05", "event checksum error Type# 0x%08" PRIx32, descr.Type);
+                    throw TExReestablishConnection{TDisconnectReason::ChecksumError()};
+                }
+            }
+            if (pendingEvent.RdmaCumulativeCheckSum) {
                 XXH3_state_t state;
                 XXH3_64bits_reset(&state);
-                for (const auto&& [data, size] : payload) {
-                    XXH3_64bits_update(&state, data, size);
+                for (auto iter = payload.Begin(); iter.Valid(); ++iter) {
+                    auto memRegion = NInterconnect::NRdma::TryExtractFromRcBuf(iter.GetChunk());
+                    if (!memRegion.Empty()) {
+                        XXH3_64bits_update(&state, memRegion.GetAddr(), memRegion.GetSize());
+                    }
                 }
                 checksum = XXH3_64bits_digest(&state);
-            }
-            ui32 expectedChecksum = descr.Checksum ?: pendingEvent.RdmaCheckSum;
-            if (expectedChecksum) {
-                if (checksum != expectedChecksum) {
-                    LOG_CRIT_IC_SESSION("ICIS05", "event checksum error Type# 0x%08" PRIx32, descr.Type);
+                if (checksum != pendingEvent.RdmaCumulativeCheckSum) {
+                    LOG_CRIT_IC_SESSION("ICIS05", "event rdma checksum error Type# 0x%08" PRIx32, descr.Type);
                     throw TExReestablishConnection{TDisconnectReason::ChecksumError()};
                 }
             }

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -1061,7 +1061,7 @@ namespace NActors {
             const ui32 gross = grossAfter - grossBefore;
             channel->UnaccountedTraffic += gross;
             const ui64 netAfter = channel->GetBufferedAmountOfData();
-            Y_DEBUG_ABORT_UNLESS(netAfter <= netBefore); // net amount should shrink
+            Y_DEBUG_ABORT_UNLESS(netAfter <= netBefore, "netBefore# %" PRIu64 " netAfter# %" PRIu64, netBefore, netAfter); // net amount should shrink
             const ui64 net = netBefore - netAfter; // number of net bytes serialized
 
             // adjust metrics for local and global queue size

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -155,7 +155,7 @@ namespace NActors {
                 std::deque<NInterconnect::NRdma::TMemRegionSlice> RdmaBuffers;
                 TRdmaReadContext::TPtr RdmaReadContext = nullptr;
                 size_t RdmaSize = 0;
-                ui32 RdmaCheckSum = 0;
+                ui32 RdmaCumulativeCheckSum = 0;
             };
 
             std::deque<TPendingEvent> PendingEvents;
@@ -168,7 +168,7 @@ namespace NActors {
 
             void PrepareCatchBuffer();
             void ApplyCatchBuffer();
-            void FetchBuffers(ui16 channel, size_t numBytes, std::deque<std::tuple<ui16, TMutableContiguousSpan>>& outQ);
+            int FetchBuffers(ui16 channel, size_t numBytes, std::deque<std::tuple<ui16, TMutableContiguousSpan>>& outQ);
             void DropFront(TRope *from, size_t numBytes);
 
             struct TRdmaReadReqOk {};

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/library/actors/core/event_pb.h>
+#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/interconnect/rdma/ut/utils/utils.h>
 #include <ydb/library/actors/interconnect/rdma/mem_pool.h>
 
@@ -119,15 +120,17 @@ private:
 struct TEventsForTest {
     std::vector<TEvTestSerialization*> Events;
     std::unordered_map<ui64, std::function<void(TEvTestSerialization*)>> Checks;
+    NMonitoring::TDynamicCounterPtr Counters;
     std::shared_ptr<NInterconnect::NRdma::IMemPool> MemPool;
 
-    TEventsForTest(ui32 numEvents)
-        : MemPool(NInterconnect::NRdma::CreateDummyMemPool())
+    TEventsForTest(ui32 numEvents, bool shuffle = false)
+        : Counters(new NMonitoring::TDynamicCounters())
+        , MemPool(NInterconnect::NRdma::CreateSlotMemPool(Counters.Get(), {}))
     {
-        Generate(numEvents, MemPool.get());
+        Generate(numEvents, MemPool.get(), shuffle);
     }
 
-    void Generate(ui32 numEvents, NInterconnect::NRdma::IMemPool* memPool) {
+    void Generate(ui32 numEvents, NInterconnect::NRdma::IMemPool* memPool, bool shuffle = false) {
         for (ui32 i = 0; i < numEvents; ++i) {
             const bool isInline = i % 3 == 0;
             const bool isXdc = i % 3 == 1;
@@ -155,6 +158,16 @@ struct TEventsForTest {
                     UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), sz + j);
                 }
             }
+            if (shuffle) {
+                for (ui32 j = 0; j < numPayloads; ++j) {
+                    ev->AddPayload(TRope(TString(10 + j, j + i)));
+                    ev->AddPayload(TRope(TString(5000 + j, j + i)));
+                    auto buf = memPool->AllocRcBuf(5000 + j, 0).value();
+                    std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000 + j, j + i);
+                    ev->AddPayload(TRope(std::move(buf)));
+                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), 5000 + j);
+                }
+            }
 
             if (isXdc || isRdma) {
                 UNIT_ASSERT(ev->AllowExternalDataChannel());
@@ -162,10 +175,10 @@ struct TEventsForTest {
 
             Events.push_back(ev);
 
-            Checks.emplace(i, [i, numPayloads, isInline, sz](TEvTestSerialization* ev) {
+            Checks.emplace(i, [i, numPayloads, isInline, sz, shuffle](TEvTestSerialization* ev) {
                 UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBlobID(), i);
                 UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBuffer(), TStringBuilder{} << "hello world " << i);
-                UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().size(), numPayloads);
+                UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().size(), numPayloads * (shuffle ? 4 : 1));
                 for (ui32 j = 0; j < numPayloads; ++j) {
                     ui32 payloadSize = isInline ? 10 + j : sz + j;
                     UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload()[j].GetSize(), payloadSize);
@@ -289,8 +302,8 @@ TEST_F(XdcRdmaTest, SerializeToRope) {
     }
 
     auto mempool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
-
-    auto serializedRope = ev->SerializeToRope(mempool.get());
+    TRdmaAllocatorWithFallback allocator(mempool);
+    auto serializedRope = ev->SerializeToRope(&allocator);
 
     ASSERT_TRUE(serializedRope.has_value());
     auto rope = serializedRope->ConvertToString();
@@ -328,18 +341,413 @@ TEST_F(XdcRdmaTest, SerializeToRope) {
     UNIT_ASSERT_VALUES_EQUAL(parsedEvent->GetPayload()[0].ConvertToString(), TString(5000, 'X'));
 }
 
+namespace {
+    struct TXdcCommandCounters {
+        ui32 DeclareSection = 0;
+        ui32 DeclareSectionInline = 0;
+        ui32 DeclareSectionRdma = 0;
+        ui32 PushData = 0;
+        ui32 RdmaRead = 0;
+    };
+
+    static TString CollectStreamData(NInterconnect::TOutgoingStream& stream) {
+        TVector<TConstIoVec> data;
+        stream.ProduceIoVec(data, 256, Max<size_t>());
+        TString packet;
+        for (const auto& [ptr, len] : data) {
+            packet.append(static_cast<const char*>(ptr), len);
+        }
+        return packet;
+    }
+
+    static void AccumulateXdcCommandCounters(const TString& packet, TXdcCommandCounters& counters) {
+        UNIT_ASSERT_C(packet.size() >= sizeof(TTcpPacketHeader_v2), "packet too short");
+
+        const char* ptr = packet.data() + sizeof(TTcpPacketHeader_v2);
+        const char* end = packet.data() + packet.size();
+        while (ptr < end) {
+            UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= sizeof(TChannelPart), "missing channel part header");
+            TChannelPart part;
+            memcpy(&part, ptr, sizeof(part));
+            ptr += sizeof(part);
+            UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= part.Size, "invalid channel part payload size");
+
+            const char* partEnd = ptr + part.Size;
+            if (!part.IsXdc()) {
+                ptr = partEnd;
+                continue;
+            }
+
+            while (ptr < partEnd) {
+                const EXdcCommand cmd = static_cast<EXdcCommand>(*ptr++);
+                switch (cmd) {
+                    case EXdcCommand::DECLARE_SECTION:
+                    case EXdcCommand::DECLARE_SECTION_INLINE:
+                    case EXdcCommand::DECLARE_SECTION_RDMA: {
+                        for (ui32 i = 0; i < 4; ++i) {
+                            const ui64 value = NInterconnect::NDetail::DeserializeNumber(&ptr, partEnd);
+                            UNIT_ASSERT_VALUES_UNEQUAL(value, Max<ui64>());
+                        }
+                        if (cmd == EXdcCommand::DECLARE_SECTION) {
+                            ++counters.DeclareSection;
+                        } else if (cmd == EXdcCommand::DECLARE_SECTION_INLINE) {
+                            ++counters.DeclareSectionInline;
+                        } else {
+                            ++counters.DeclareSectionRdma;
+                        }
+                        break;
+                    }
+                    case EXdcCommand::PUSH_DATA: {
+                        constexpr size_t cmdLen = sizeof(ui16) + sizeof(ui32);
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= cmdLen, "invalid PUSH_DATA");
+                        ptr += cmdLen;
+                        ++counters.PushData;
+                        break;
+                    }
+                    case EXdcCommand::RDMA_READ: {
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= sizeof(ui16), "invalid RDMA_READ");
+                        const ui16 credsSerializedSize = ReadUnaligned<ui16>(ptr);
+                        ptr += sizeof(ui16);
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= credsSerializedSize + sizeof(ui32),
+                            "invalid RDMA_READ payload");
+                        ptr += credsSerializedSize;
+                        ptr += sizeof(ui32);
+                        ++counters.RdmaRead;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+TEST_F(XdcRdmaTest, ShuffleRdmaUsesIteratorOffsetInsideChunk) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo(1, "peer", "1");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t prefixSize = 17;
+    constexpr size_t rdmaSize = 100;
+    constexpr size_t totalSize = prefixSize + rdmaSize;
+
+    auto rcBuf = memPool->AllocRcBuf(totalSize, 0).value();
+    for (size_t i = 0; i < totalSize; ++i) {
+        rcBuf.GetDataMut()[i] = static_cast<char>(i);
+    }
+
+    const auto memReg = NInterconnect::NRdma::TryExtractFromRcBuf(rcBuf);
+    UNIT_ASSERT(!memReg.Empty());
+    const ui64 expectedAddr = reinterpret_cast<ui64>(memReg.GetAddr()) + prefixSize;
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, prefixSize, 0, 0, false, false});
+    info.Sections.push_back(TEventSectionInfo{0, rdmaSize, 0, 0, false, true});
+    auto serialized = MakeIntrusive<TEventSerializedData>(TRope(std::move(rcBuf)), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    NInterconnect::TOutgoingStream main;
+    NInterconnect::TOutgoingStream xdc;
+    TTcpPacketOutTask task(p, main, xdc);
+    UNIT_ASSERT(channel.FeedBuf(task, 0, 0));
+    task.Finish(1, 0);
+
+    TVector<TConstIoVec> mainData;
+    main.ProduceIoVec(mainData, 100, 10000);
+
+    TString packet;
+    for (const auto& [ptr, len] : mainData) {
+        packet.append(static_cast<const char*>(ptr), len);
+    }
+    UNIT_ASSERT(packet.size() >= sizeof(TTcpPacketHeader_v2));
+
+    bool foundRdmaRead = false;
+    ui64 rdmaReadAddr = 0;
+    ui64 rdmaReadSize = 0;
+
+    const char* ptr = packet.data() + sizeof(TTcpPacketHeader_v2);
+    const char* end = packet.data() + packet.size();
+    while (ptr < end) {
+        UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= sizeof(TChannelPart), "missing channel part header");
+        TChannelPart part;
+        memcpy(&part, ptr, sizeof(part));
+        ptr += sizeof(part);
+        UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= part.Size, "invalid channel part payload size");
+
+        const char* partEnd = ptr + part.Size;
+        if (part.IsXdc()) {
+            while (ptr < partEnd) {
+                const EXdcCommand cmd = static_cast<EXdcCommand>(*ptr++);
+                switch (cmd) {
+                    case EXdcCommand::DECLARE_SECTION:
+                    case EXdcCommand::DECLARE_SECTION_INLINE:
+                    case EXdcCommand::DECLARE_SECTION_RDMA: {
+                        for (ui32 i = 0; i < 4; ++i) {
+                            const ui64 value = NInterconnect::NDetail::DeserializeNumber(&ptr, partEnd);
+                            UNIT_ASSERT_VALUES_UNEQUAL(value, Max<ui64>());
+                        }
+                        break;
+                    }
+                    case EXdcCommand::PUSH_DATA: {
+                        constexpr size_t cmdLen = sizeof(ui16) + sizeof(ui32);
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= cmdLen, "invalid PUSH_DATA");
+                        ptr += cmdLen;
+                        break;
+                    }
+                    case EXdcCommand::RDMA_READ: {
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= sizeof(ui16), "invalid RDMA_READ");
+                        const ui16 credsSerializedSize = ReadUnaligned<ui16>(ptr);
+                        ptr += sizeof(ui16);
+                        UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= credsSerializedSize + sizeof(ui32),
+                            "invalid RDMA_READ payload");
+                        NActorsInterconnect::TRdmaCreds creds;
+                        UNIT_ASSERT(creds.ParseFromArray(ptr, credsSerializedSize));
+                        ptr += credsSerializedSize;
+                        ptr += sizeof(ui32); // checksum
+                        UNIT_ASSERT_VALUES_EQUAL(creds.CredsSize(), 1u);
+                        rdmaReadAddr = creds.GetCreds(0).GetAddress();
+                        rdmaReadSize = creds.GetCreds(0).GetSize();
+                        foundRdmaRead = true;
+                        break;
+                    }
+                }
+            }
+        } else {
+            ptr = partEnd;
+        }
+    }
+
+    UNIT_ASSERT(foundRdmaRead);
+    UNIT_ASSERT_VALUES_EQUAL(rdmaReadSize, rdmaSize);
+    UNIT_ASSERT_VALUES_EQUAL(rdmaReadAddr, expectedAddr);
+}
+
+TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo(1, "peer", "1");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t payloadSize = 128;
+    auto rcBuf = memPool->AllocRcBuf(payloadSize, 0).value();
+    memset(rcBuf.GetDataMut(), 0xAB, payloadSize);
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, payloadSize, 0, 0, false, true});
+    auto serialized = MakeIntrusive<TEventSerializedData>(TRope(std::move(rcBuf)), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    NInterconnect::TOutgoingStream main;
+    NInterconnect::TOutgoingStream xdc;
+    TTcpPacketOutTask task(p, main, xdc);
+    UNIT_ASSERT(channel.FeedBuf(task, 1, -1));
+    task.Finish(1, 0);
+
+    TXdcCommandCounters counters;
+    AccumulateXdcCommandCounters(CollectStreamData(main), counters);
+
+    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.PushData > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+}
+
+TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenChunkIsNotRdmaRegistered) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo(1, "peer", "1");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t payloadSize = 128;
+    auto nonRdmaBuf = TRcBuf::Uninitialized(payloadSize);
+    memset(nonRdmaBuf.GetDataMut(), 0xCD, payloadSize);
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, payloadSize, 0, 0, false, true});
+    auto serialized = MakeIntrusive<TEventSerializedData>(TRope(std::move(nonRdmaBuf)), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    TXdcCommandCounters counters;
+    bool done = false;
+    for (ui64 serial = 1; serial <= 4 && !done; ++serial) {
+        NInterconnect::TOutgoingStream main;
+        NInterconnect::TOutgoingStream xdc;
+        TTcpPacketOutTask task(p, main, xdc);
+        done = channel.FeedBuf(task, serial, 0);
+        task.Finish(serial, 0);
+        AccumulateXdcCommandCounters(CollectStreamData(main), counters);
+    }
+
+    UNIT_ASSERT(done);
+    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.PushData > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+}
+
+TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunks) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo(1, "peer", "1");
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t rdmaChunkSize = 64;
+    constexpr size_t nonRdmaChunkSize = 48;
+    constexpr size_t payloadSize = rdmaChunkSize + nonRdmaChunkSize;
+
+    auto rdmaBuf = memPool->AllocRcBuf(rdmaChunkSize, 0).value();
+    memset(rdmaBuf.GetDataMut(), 0xE1, rdmaChunkSize);
+    auto nonRdmaBuf = TRcBuf::Uninitialized(nonRdmaChunkSize);
+    memset(nonRdmaBuf.GetDataMut(), 0xE2, nonRdmaChunkSize);
+
+    TRope payload(std::move(rdmaBuf));
+    payload.Insert(payload.End(), TRope(std::move(nonRdmaBuf)));
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, payloadSize, 0, 0, false, true});
+    auto serialized = MakeIntrusive<TEventSerializedData>(std::move(payload), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    TXdcCommandCounters counters;
+    bool done = false;
+    for (ui64 serial = 1; serial <= 4 && !done; ++serial) {
+        NInterconnect::TOutgoingStream main;
+        NInterconnect::TOutgoingStream xdc;
+        TTcpPacketOutTask task(p, main, xdc);
+        done = channel.FeedBuf(task, serial, 0);
+        task.Finish(serial, 0);
+        AccumulateXdcCommandCounters(CollectStreamData(main), counters);
+    }
+
+    UNIT_ASSERT(done);
+    UNIT_ASSERT(counters.DeclareSectionRdma > 0u);
+    UNIT_ASSERT(counters.PushData > 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+}
+
 TEST_F(XdcRdmaTest, SendRdma) {
     TTestICCluster cluster(2);
     auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
     auto* ev = MakeTestEvent(123, memPool.get());
 
     auto recieverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
-        Cerr << "Blob ID: " << ev->Get()->Record.GetBlobID() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 123u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].GetSize(), 5000u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].ConvertToString(), TString(5000, 'X'));
+    });
+    const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
+
+    Sleep(TDuration::MilliSeconds(1000));
+
+    auto senderPtr = new TSendActor(receiver, ev);
+    cluster.RegisterActor(senderPtr, 2);
+    UNIT_ASSERT(recieverPtr->WhaitForRecieve(1, 20));
+}
+
+TEST_F(XdcRdmaTest, SendRdmaWithShuffledPayload) {
+    TTestICCluster cluster(2);
+    auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+    auto ev = new TEvTestSerialization();
+    ev->Record.SetBlobID(123);
+    ev->Record.SetBuffer("hello world");
+    for (ui32 i = 0; i < 10; ++i) {
+        if (i % 2 == 0) {
+            TRope tmp(TString(5000, 'X'));
+            ev->AddPayload(std::move(tmp));
+        } else {
+            auto buf = memPool->AllocRcBuf(5000, 0).value();
+            std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000, 'Y');
+            ev->AddPayload(TRope(std::move(buf)));
+        }
+    }
+
+    auto recieverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 123u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 10u);
+        for (ui32 i = 0; i < 10; ++i) {
+            if (i % 2 == 0) {
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].GetSize(), 5000u);
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].ConvertToString(), TString(5000, 'X'));
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].GetSize(), 5000u);
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].ConvertToString(), TString(5000, 'Y'));
+            }
+        }
     });
     const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
 
@@ -356,7 +764,6 @@ TEST_F(XdcRdmaTest, SendRdmaWithRegionOffset) {
     auto* ev = MakeTestEvent(123, memPool.get(), false, true);
 
     auto recieverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
-        Cerr << "Blob ID: " << ev->Get()->Record.GetBlobID() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 123u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
@@ -378,7 +785,6 @@ TEST_F(XdcRdmaTest, SendRdmaWithGlueWithRegionOffset) {
     auto* ev = MakeTestEvent(123, memPool.get(), true, true);
 
     auto recieverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
-        Cerr << "Blob ID: " << ev->Get()->Record.GetBlobID() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 123u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 2u);
@@ -404,7 +810,6 @@ TEST_F(XdcRdmaTest, SendRdmaWithGlue) {
     auto* ev = MakeTestEvent(123, memPool.get(), true, false);
 
     auto recieverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
-        Cerr << "Blob ID: " << ev->Get()->Record.GetBlobID() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 123u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 2u);
@@ -428,7 +833,6 @@ TEST_F(XdcRdmaTest, SendRdmaWithMultiGlue) {
     auto* ev = MakeMultuGlueTestEvent(123, memPool.get());
 
     auto recieverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
-        Cerr << "Blob ID: " << ev->Get()->Record.GetBlobID() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 123u);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 3u);
@@ -456,12 +860,11 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TDuration::Minutes(9999)); //Disable dead peer detection to parallel activity
 
-    std::vector<NInterconnect::NRdma::TMemRegionPtr> regions;
+    std::vector<TRcBuf> occupiedBuffers;
 
     // Create reciever
     ui32 index = 0;
     auto recieverPtr = new TReceiveActor([&index](TEvTestSerialization::TPtr ev) {
-        Cerr << "Blob ID: " << ev->Get()->Record.GetBlobID() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), index++);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
@@ -482,10 +885,16 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
         UNIT_ASSERT(recieverPtr->WhaitForRecieve(1, 20));
     }
 
-    // Allocate all rdma memory to trigger an error during the next transmissions
-    for (size_t i = 0; i < 7; i++) {
-        regions.emplace_back(pool->Alloc(32u << 20, 0));
+    // Exhaust the same allocation class (5KB) that receiver uses for RDMA sections.
+    // This makes the "undelivered due to no RDMA memory on receiver" check deterministic.
+    for (;;) {
+        auto buf = pool->AllocRcBuf(5000, 0);
+        if (!buf) {
+            break;
+        }
+        occupiedBuffers.emplace_back(std::move(*buf));
     }
+    UNIT_ASSERT(!occupiedBuffers.empty());
 
     // Send more
     {
@@ -524,7 +933,7 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
     }
     UNIT_ASSERT(recieverPtr->WhaitForRecieve(2, 20));
     // Free memory
-    regions.clear();
+    occupiedBuffers.clear();
     // Whait for the pending hendshake timer
     Sleep(TDuration::MilliSeconds(5000));
 
@@ -562,7 +971,6 @@ TEST_P(XdcRdmaTestCqMode, SendMix) {
 
     ui32 index = 0;
     auto recieverPtr = new TReceiveActor([&index](TEvTestSerialization::TPtr ev) {
-        Cerr << "Blob ID: " << ev->Get()->Record.GetBlobID() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), index++);
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "hello world");
         UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
@@ -621,6 +1029,32 @@ TEST_P(XdcRdmaTestCqMode, SendMixBig) {
                 break;
             }
         }
+        Sleep(TDuration::MilliSeconds(1000));
+    }
+    UNIT_ASSERT_VALUES_EQUAL(events.Checks.size(), 0u);
+}
+
+TEST_F(XdcRdmaTest, SendMixBigShuffle) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
+        TDuration::Minutes(1), 50u << 20);
+    TEventsForTest events(1000, true);
+
+    auto recieverPtr = new TReceiveActor([&events](TEvTestSerialization::TPtr ev) {
+        ui64 blobId = ev->Get()->Record.GetBlobID();
+        auto checkIt = events.Checks.find(blobId);
+        UNIT_ASSERT(checkIt != events.Checks.end());
+        checkIt->second(ev->Get());
+        events.Checks.erase(checkIt);
+    });
+    const TActorId receiver = cluster.RegisterActor(recieverPtr, 1);
+    Sleep(TDuration::MilliSeconds(1000));
+
+    for (auto* ev : events.Events) {
+        auto senderPtr = new TSendActor(receiver, ev);
+        cluster.RegisterActor(senderPtr, 2);
+    }
+
+    for (ui32 attempt = 0; attempt < 10 && !events.Checks.empty(); ++attempt) {
         Sleep(TDuration::MilliSeconds(1000));
     }
     UNIT_ASSERT_VALUES_EQUAL(events.Checks.size(), 0u);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add RDMA support for XDC shuffle

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implement RDMA transport for XDC shuffle sections, remove the legacy full-event SendViaRdma flow, and harden fallback semantics when RDMA preparation cannot be completed for a section.

Changes:
- Route RDMA only through the shuffle path (UseXdcShuffle && UseRdma)
- Remove legacy SendViaRdma state and whole-event RDMA credential emission
- Keep section-level RDMA credential splitting across IC packets
- Preserve fallback to external XDC PUSH_DATA when RDMA read cannot be prepared
- Fix rollback for partial RDMA preparation before fallback: restore EventActuallySerialized and RDMA checksum state
- Keep RDMA address calculation based on iterator offset inside chunk

Tests:
- Add XdcRdmaTest.ShuffleRdmaUsesIteratorOffsetInsideChunk to validate non-zero iterator offset (offset != 0) in RDMA credential address generation
- Add XdcRdmaTest.ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid
- Add XdcRdmaTest.ShuffleRdmaFallsBackToPushDataWhenChunkIsNotRdmaRegistered
- Add XdcRdmaTest.ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunks to cover mixed RDMA/non-RDMA chunk rollback and PUSH_DATA fallback

Compatibility:
- XDC behavior with RDMA disabled remains unchanged for both shuffle modes (traffic is sent via PUSH_DATA)
- This branch assumes RDMA is used only when shuffle is enabled during rollout

