### PR TITLE
Add direct include required by libcxx

### DIFF
--- a/ydb/core/kqp/compile_service/helpers/kqp_compile_service_helpers.h
+++ b/ydb/core/kqp/compile_service/helpers/kqp_compile_service_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <vector>
 #include <util/generic/string.h>
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix errors like
```
$(SOURCE_ROOT)/contrib/ydb/core/kqp/compile_service/helpers/kqp_compile_service_helpers.h:12:6: error: no template named 'optional' in namespace 'std'
   12 | std::optional<TString> ShouldInvalidateCompileCache(const NKikimrConfig::TTableServiceConfig& prev, const NKikimrConfig::TTableServiceConfig& next);
      | ~~~~~^
1 error generated.
```
