### PR TITLE
Basic tests for lock dependencies, behavior when locks are broken

### DIFF
--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -81,6 +81,7 @@ public:
         if (auto* info = Self.GetVolatileTxManager().FindByCommitTxId(txId)) {
             if (info->State != EVolatileTxState::Aborting) {
                 VolatileVersion = Max(VolatileVersion, info->Version);
+                Self.SysLocksTable().AddVolatileDependency(txId);
             }
         } else {
             Self.SysLocksTable().AddReadConflict(txId);
@@ -306,6 +307,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
         auto it = LockRowsRequests.find(requestId);
         Y_ABORT_UNLESS(it != LockRowsRequests.end());
         Y_ABORT_UNLESS(&it->second == &state);
+        state.Scope.Cancel();
         state.Finished.NotifyAll();
         LockRowsRequests.erase(it);
         // Note: update counters unless actor system is shutting down
@@ -493,13 +495,21 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
 
     for (;;) {
         bool reschedule = false;
-        std::optional<ui64> waitForLock;
+        TLockInfo::TPtr waitForLock;
 
         // We need to run each iteration in a transaction
         co_await TTxLockRows::Run(this, [&](TTransactionContext& txc) {
             if (lock && lock->IsBroken()) {
                 state.Result = makeError(NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN, TStringBuilder()
-                    << "Lock " << lockId << " is broken or cannot be created at shard " << TabletID());
+                    << "Lock " << lockId << " is broken at shard " << TabletID());
+                state.Result->AddLock(
+                    lockId,
+                    TabletID(),
+                    lock->GetGeneration(),
+                    lock->GetCounter(),
+                    tableId.PathId.OwnerId,
+                    tableId.PathId.LocalPathId,
+                    lock->IsWriteLock());
                 return ETxLockRows::Rollback;
             }
 
@@ -529,8 +539,9 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                         Y_ENSURE(lock == guardLocks.Lock);
                     } else {
                         lock = guardLocks.Lock;
+                        lock->SetPessimistic();
+                        StartLockRowsLockWatcher(requestId, tableId, lock);
                     }
-                    guardLocks.PreserveEmptyLock = true;
                     SubscribeNewLocks();
                     break;
 
@@ -628,7 +639,17 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
 
                 if (row.LockMode != NTable::ELockMode::None) {
                     auto currentOwner = SysLocksTable().GetRawLock(row.LockTxId);
-                    if (currentOwner) {
+                    auto* info = GetVolatileTxManager().FindByCommitTxId(row.LockTxId);
+                    // Note: when current owner is broken we assume the row is
+                    // unlocked. In reality the transaction may be waiting for
+                    // the volatile commit decision at the moment, so it may be
+                    // neither committed nor aborted, and we would overwrite
+                    // uncommitted changes by another transaction. However, it
+                    // would have performed all checks and applied all side-
+                    // effects, which we track as volatile dependencies anyway.
+                    // Locks are advisory and the transaction no longer needs
+                    // them, so overwriting it is OK.
+                    if (currentOwner && !currentOwner->IsBroken() && !info) {
                         if (skipLocked) {
                             success->Record.AddSkippedKeys(processedKeys);
                             runtimeLock.Reset();
@@ -636,7 +657,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                             continue;
                         }
 
-                        waitForLock = row.LockTxId;
+                        waitForLock = currentOwner;
 
                         applyLocks();
 
@@ -696,28 +717,21 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                 TLockRowsNotifyWaitGuard waitGuard(*this, state, lock, runtimeLock.Predecessor().GetLock());
                 // Wait until lock predecessor changes
                 co_await runtimeLock.OnChangedEvent.Wait([&]{
-                    // TODO: we need to somehow notify the service about new waiting graph edges,
-                    // which must also take into account that earlier requests may be cancelled while
-                    // we wait, and the previous runtime lock in the waiting list might change.
                     setWaiting(true);
                 });
             }
 
             if (waitForLock) {
-                // Wait until current row's persistent owner is removed
-                auto currentOwner = SysLocksTable().GetRawLock(*waitForLock);
-                if (currentOwner) {
+                // Wait until current row's persistent owner is broken or removed
+                if (!waitForLock->IsBroken()) {
                     // Notify long tx service abour waiting for the predecessor
-                    TLockRowsNotifyWaitGuard waitGuard(*this, state, lock, currentOwner);
-                    // Wake up when current row owner is removed entirely
-                    // TODO: we probably want to wait until it is broken in the future
-                    co_await currentOwner->OnRemovedEvent.Wait([&]{
-                        // TODO: we need to somehow notify the service about new waiting graph edge
-                        // between our lockId and *waitForLock id.
+                    TLockRowsNotifyWaitGuard waitGuard(*this, state, lock, waitForLock);
+                    // Wake up when current row owner is broken (removing it also breaks)
+                    co_await waitForLock->OnBrokenEvent.Wait([&]{
                         setWaiting(true);
                     });
                 }
-                waitForLock.reset();
+                waitForLock.Reset();
             }
         }
 
@@ -735,7 +749,7 @@ void TDataShard::HandleLockRowsCancel(NEvents::TDataEvents::TEvLockRowsCancel::T
     auto it = LockRowsRequests.find(requestId);
     if (it != LockRowsRequests.end()) {
         it->second.Scope.Cancel();
-            // Note: awaiter queue size may change when Cancel is called
+        // Note: awaiter queue size may change when Cancel is called
         UpdateProposeQueueSize();
     }
 }
@@ -752,6 +766,46 @@ void TDataShard::HandleLockRowsDeadlock(TEvLongTxService::TEvWaitingLockDeadlock
                 NKikimrDataEvents::TEvLockRowsResult::STATUS_DEADLOCK,
                 TStringBuilder() << "Deadlock with another transaction detected at shard " << TabletID());
             state.Scope.Cancel();
+            // Note: awaiter queue size may change when Cancel is called
+            UpdateProposeQueueSize();
+        }
+    }
+}
+
+void TDataShard::StartLockRowsLockWatcher(TLockRowsRequestId requestId, TTableId tableId, TLockInfo::TPtr lock) {
+    // Note: this watcher uses unstructured concurrency to watch when an
+    // acquired lock breaks while the request is waiting. This function starts
+    // recursively while inside the transaction, so we can be sure the request
+    // is still valid and lock is not broken yet. However the request may exit
+    // at any time, invalidating the state.
+    TLockRowsRequestState* state = LockRowsRequests.FindPtr(requestId);
+    Y_ENSURE(state, "TEvLockRows request state must be wait in StartLockRowsLockWatcher");
+    Y_ENSURE(!lock->IsBroken(), "Unexpected broken lock in StartLockRowsLockWatcher");
+    // We attach to the same scope, which will cancel the wait along with the
+    // request. The return value will be true when the callback returns
+    // normally, i.e. when the lock becomes broken or is removed.
+    bool ok = co_await state->Scope.Wrap([&]() -> async<void> {
+        co_await lock->OnBrokenEvent.Wait();
+    });
+    if (ok && lock->IsBroken()) {
+        // Even when this coroutine is resumed because the lock becomes broken,
+        // the request may have been destroyed concurrently. Make sure we don't
+        // try working with the missing request.
+        state = LockRowsRequests.FindPtr(requestId);
+        if (state && !state->Result) {
+            state->Result = std::make_unique<NEvents::TDataEvents::TEvLockRowsResult>(
+                TabletID(), requestId.RequestId,
+                NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN,
+                TStringBuilder() << "Lock " << lock->GetLockId() << " is broken at shard " << TabletID());
+            state->Result->AddLock(
+                lock->GetLockId(),
+                TabletID(),
+                lock->GetGeneration(),
+                lock->GetCounter(),
+                tableId.PathId.OwnerId,
+                tableId.PathId.LocalPathId,
+                lock->IsWriteLock());
+            state->Scope.Cancel();
             // Note: awaiter queue size may change when Cancel is called
             UpdateProposeQueueSize();
         }

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -493,7 +493,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
     auto success = std::make_unique<NEvents::TDataEvents::TEvLockRowsResult>(
             TabletID(), requestId.RequestId, NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
 
-    for (;;) {
+    while (!state.Result) {
         bool reschedule = false;
         TLockInfo::TPtr waitForLock;
 
@@ -540,7 +540,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     } else {
                         lock = guardLocks.Lock;
                         lock->SetPessimistic();
-                        StartLockRowsLockWatcher(requestId, tableId, lock);
+                        StartLockRowsBrokenWatcher(requestId, tableId, lock);
                     }
                     SubscribeNewLocks();
                     break;
@@ -702,8 +702,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
         });
 
         if (state.Result) {
-            Send(ev->Sender, state.Result.release(), 0, ev->Cookie);
-            co_return;
+            break;
         }
 
         if (reschedule) {
@@ -740,6 +739,8 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
         // Cycle in the low-priority queue before doing anything expensive
         co_await LowPriorityQueue.Next();
     }
+
+    Send(ev->Sender, state.Result.release(), 0, ev->Cookie);
 }
 
 void TDataShard::HandleLockRowsCancel(NEvents::TDataEvents::TEvLockRowsCancel::TPtr& ev) {
@@ -772,15 +773,15 @@ void TDataShard::HandleLockRowsDeadlock(TEvLongTxService::TEvWaitingLockDeadlock
     }
 }
 
-void TDataShard::StartLockRowsLockWatcher(TLockRowsRequestId requestId, TTableId tableId, TLockInfo::TPtr lock) {
+void TDataShard::StartLockRowsBrokenWatcher(TLockRowsRequestId requestId, TTableId tableId, TLockInfo::TPtr lock) {
     // Note: this watcher uses unstructured concurrency to watch when an
     // acquired lock breaks while the request is waiting. This function starts
     // recursively while inside the transaction, so we can be sure the request
     // is still valid and lock is not broken yet. However the request may exit
     // at any time, invalidating the state.
     TLockRowsRequestState* state = LockRowsRequests.FindPtr(requestId);
-    Y_ENSURE(state, "TEvLockRows request state must be wait in StartLockRowsLockWatcher");
-    Y_ENSURE(!lock->IsBroken(), "Unexpected broken lock in StartLockRowsLockWatcher");
+    Y_ENSURE(state, "TEvLockRows request state must be wait in StartLockRowsBrokenWatcher");
+    Y_ENSURE(!lock->IsBroken(), "Unexpected broken lock in StartLockRowsBrokenWatcher");
     // We attach to the same scope, which will cancel the wait along with the
     // request. The return value will be true when the callback returns
     // normally, i.e. when the lock becomes broken or is removed.

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1277,7 +1277,7 @@ class TDataShard
     void HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr ev);
     void HandleLockRowsCancel(NEvents::TDataEvents::TEvLockRowsCancel::TPtr& ev);
     void HandleLockRowsDeadlock(TEvLongTxService::TEvWaitingLockDeadlock::TPtr& ev);
-    void StartLockRowsLockWatcher(TLockRowsRequestId requestId, TTableId tableId, TLockInfo::TPtr lock);
+    void StartLockRowsBrokenWatcher(TLockRowsRequestId requestId, TTableId tableId, TLockInfo::TPtr lock);
     void Handle(TEvTxProcessing::TEvPlanStep::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProcessing::TEvReadSet::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvTxProcessing::TEvReadSetAck::TPtr &ev, const TActorContext &ctx);

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1277,6 +1277,7 @@ class TDataShard
     void HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr ev);
     void HandleLockRowsCancel(NEvents::TDataEvents::TEvLockRowsCancel::TPtr& ev);
     void HandleLockRowsDeadlock(TEvLongTxService::TEvWaitingLockDeadlock::TPtr& ev);
+    void StartLockRowsLockWatcher(TLockRowsRequestId requestId, TTableId tableId, TLockInfo::TPtr lock);
     void Handle(TEvTxProcessing::TEvPlanStep::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProcessing::TEvReadSet::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvTxProcessing::TEvReadSetAck::TPtr &ev, const TActorContext &ctx);

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -9,6 +9,27 @@
 
 #include <util/digest/multi.h>
 
+namespace {
+    struct TRequestId {
+        NActors::TActorId Sender;
+        ui64 Id;
+
+        friend bool operator==(const TRequestId&, const TRequestId&) = default;
+    };
+} // namespace
+
+template<> struct THash<TRequestId> {
+    size_t operator()(const TRequestId& value) const {
+        return ::MultiHash(value.Sender, value.Id);
+    }
+};
+
+template<> struct std::hash<TRequestId> {
+    size_t operator()(const TRequestId& value) const {
+        return ::THash<TRequestId>()(value);
+    }
+};
+
 namespace NKikimr {
 
 using namespace NKikimr::NDataShard;
@@ -18,22 +39,6 @@ using namespace NSchemeShard;
 using namespace Tests;
 
 Y_UNIT_TEST_SUITE(DataShardLockRows) {
-
-    struct TRequestId {
-        TActorId Sender;
-        ui64 RequestId;
-
-        operator size_t() const {
-            return ::MultiHash(Sender, RequestId);
-        }
-    };
-
-    struct TWaitGraphEdge {
-        ui64 LockId;
-        ui64 OtherLockId;
-
-        friend std::strong_ordering operator<=>(const TWaitGraphEdge&, const TWaitGraphEdge&) = default;
-    };
 
     std::tuple<TTestActorRuntime&, Tests::TServer::TPtr, TActorId> TestCreateServer(TPortManager& pm, std::optional<TServerSettings> serverSettings = {}) {
         if (!serverSettings) {
@@ -66,6 +71,14 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             Runtime.ClosePipe(PipeActor, TActorId(), nodeIndex);
         }
 
+        ui64 GetTabletId() const {
+            return TabletId;
+        }
+
+        ui32 GetNodeIndex() const {
+            return PipeActor.NodeId() - Runtime.GetNodeId(0);
+        }
+
         void Send(const TActorId& sender, IEventBase* payload, ui64 cookie = 0) {
             ui32 nodeIndex = PipeActor.NodeId() - Runtime.GetNodeId(0);
             Runtime.SendToPipe(PipeActor, sender, payload, nodeIndex, cookie);
@@ -75,6 +88,133 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         TTestActorRuntime& Runtime;
         const ui64 TabletId;
         TActorId PipeActor;
+    };
+
+    class TKeysBuilder {
+    public:
+        TKeysBuilder() = default;
+
+        TKeysBuilder&& Add(i32 key) && {
+            Cells.push_back(TCell::Make(key));
+            ++Rows;
+            return std::move(*this);
+        }
+
+        TSerializedCellMatrix Build() && {
+            return TSerializedCellMatrix(TSerializedCellMatrix::Serialize(Cells, Rows, 1));
+        }
+
+    private:
+        TVector<TCell> Cells;
+        size_t Rows = 0;
+    };
+
+    class TLockRowsHelper {
+    public:
+        TLockRowsHelper(TTestActorRuntime& runtime, TTestPipe& pipe)
+            : Runtime(runtime)
+            , Pipe(pipe)
+            , Sender(Runtime.AllocateEdgeActor(pipe.GetNodeIndex()))
+        {}
+
+        template<class TCallback>
+        ui64 SendRequest(const TLockHandle& lock, const TTableId& tableId, TSerializedCellMatrix keys, const TCallback& callback) {
+            ui64 requestId = NextRequestId++;
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(requestId);
+            req->Record.SetLockId(lock.GetLockId());
+            req->Record.SetLockNodeId(lock.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            req->SetCellMatrix(keys.ReleaseBuffer());
+            callback(req.get());
+            Pipe.Send(Sender, req.release());
+            return requestId;
+        }
+
+        ui64 SendRequest(const TLockHandle& lock, const TTableId& tableId, TSerializedCellMatrix keys) {
+            return SendRequest(lock, tableId, std::move(keys), [](auto*){});
+        }
+
+        std::unique_ptr<NEvents::TDataEvents::TEvLockRowsResult> ExpectResult(ui64 requestId, NKikimrDataEvents::TEvLockRowsResult::EStatus status = NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS, TDuration simTimeout = TDuration::Seconds(1)) {
+            auto ev = Runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(Sender, simTimeout);
+            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult was not received after " << simTimeout);
+            std::unique_ptr<NEvents::TDataEvents::TEvLockRowsResult> res(ev->Release().Release());
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), requestId);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), status);
+            return res;
+        }
+
+        void ExpectNoResult(TDuration simTimeout = TDuration::Seconds(1)) {
+            auto ev = Runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(Sender, simTimeout);
+            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult received: RequestId# " << ev->Get()->Record.GetRequestId() << " Status# " << ev->Get()->Record.GetStatus());
+        }
+
+    private:
+        TTestActorRuntime& Runtime;
+        TTestPipe& Pipe;
+        const TActorId Sender;
+        ui64 NextRequestId = 1;
+    };
+
+    struct TWaitGraphEdge {
+        ui64 LockId;
+        ui64 OtherLockId;
+
+        friend std::strong_ordering operator<=>(const TWaitGraphEdge&, const TWaitGraphEdge&) = default;
+    };
+
+    class TWaitGraphInterceptor : public THashMap<TRequestId, TWaitGraphEdge> {
+    public:
+        TWaitGraphInterceptor(TTestActorRuntime& runtime)
+            : Runtime(runtime)
+            , AddObserver(Runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>(
+                [this](auto& ev) {
+                    auto* msg = ev->Get();
+                    (*this)[TRequestId{ ev->Sender, msg->RequestId }] = TWaitGraphEdge{ msg->Lock.LockId, msg->OtherLock.LockId };
+                    // Prevent long tx service from processing this event
+                    ev.Reset();
+                }))
+            , RemoveObserver(Runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>(
+                [this](auto& ev) {
+                    auto* msg = ev->Get();
+                    (*this).erase(TRequestId{ ev->Sender, msg->RequestId });
+                    // Prevent long tx service from processing this event
+                }))
+        {}
+
+        void SendDeadlock(ui64 lockId, ui64 otherLockId) const {
+            for (const auto& pr : *this) {
+                if (pr.second.LockId == lockId && pr.second.OtherLockId == otherLockId) {
+                    ui32 nodeIndex = pr.first.Sender.NodeId() - Runtime.GetNodeId(0);
+                    Runtime.Send(
+                        new IEventHandle(
+                            pr.first.Sender,
+                            TActorId(),
+                            new TEvLongTxService::TEvWaitingLockDeadlock(pr.first.Id)),
+                        nodeIndex, /* viaActorSystem */ true);
+                }
+            }
+        }
+
+        TString ToString() const {
+            TVector<TWaitGraphEdge> edges;
+            for (auto& pr : *this) {
+                edges.push_back(pr.second);
+            }
+            std::sort(edges.begin(), edges.end());
+            TStringBuilder sb;
+            for (auto& edge : edges) {
+                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
+            }
+            return sb;
+        }
+
+    private:
+        TTestActorRuntime& Runtime;
+        TTestActorRuntime::TEventObserverHolder AddObserver;
+        TTestActorRuntime::TEventObserverHolder RemoveObserver;
     };
 
     Y_UNIT_TEST(Basics) {
@@ -94,86 +234,30 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
-        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
         // Lock key 1 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
 
         // Try locking key 1 by lock 2
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock2.GetLockId());
-            req->Record.SetLockNodeId(lock2.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
 
         // Try locking key 1 by lock 1 again
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(3);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 3u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req3 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req3);
 
         // Try waiting for lock 2 some more
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        lockRows.ExpectNoResult();
 
         // Destroy lock 1 handle, it must rollback all changes
         lock1.Reset();
 
-        // Try waiting for lock 2 now
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        // Try waiting for lock 2 result now
+        lockRows.ExpectResult(req2);
     }
 
     Y_UNIT_TEST(RequestCancelledOnSplit) {
@@ -193,48 +277,17 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
-        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
         // Lock key 1 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
 
         // Try locking key 1 by lock 2
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock2.GetLockId());
-            req->Record.SetLockNodeId(lock2.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
 
         // Split would fail otherwise :(
         SetSplitMergePartCountLimit(&runtime, -1);
@@ -249,13 +302,7 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         ui64 txId = AsyncSplitTable(server, senderSplit, "/Root/table", shards.at(0), makeSplitKey(3));
         WaitTxNotification(server, senderSplit, txId);
 
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(ev, "Unexpected failure to receive TEvLockRowsResult");
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_OVERLOADED);
-        }
+        lockRows.ExpectResult(req2, NKikimrDataEvents::TEvLockRowsResult::STATUS_OVERLOADED);
     }
 
     Y_UNIT_TEST(RequestCancelledOnGracefulRestart) {
@@ -275,58 +322,21 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
-        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
         // Lock key 1 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
 
         // Try locking key 1 by lock 2
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock2.GetLockId());
-            req->Record.SetLockNodeId(lock2.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
 
         GracefulRestartTablet(runtime, shards.at(0), sender);
 
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(ev, "Unexpected failure to receive TEvLockRowsResult");
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_OVERLOADED);
-        }
+        lockRows.ExpectResult(req2, NKikimrDataEvents::TEvLockRowsResult::STATUS_OVERLOADED);
     }
 
     Y_UNIT_TEST(BrokenOwnerUnblocksAwaiter) {
@@ -346,77 +356,22 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
-        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
-        THashMap<TRequestId, TWaitGraphEdge> waitGraph;
-        auto waitGraphAddObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>([&](auto& ev) {
-            auto* msg = ev->Get();
-            waitGraph[TRequestId{ ev->Sender, msg->RequestId }] = { msg->Lock.LockId, msg->OtherLock.LockId };
-            ev.Reset();
-        });
-        auto waitGraphRemoveObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>([&](auto& ev) {
-            auto* msg = ev->Get();
-            waitGraph.erase(TRequestId{ ev->Sender, msg->RequestId });
-            ev.Reset();
-        });
-        auto waitGraphString = [&]() -> TString {
-            TVector<TWaitGraphEdge> edges;
-            for (auto& pr : waitGraph) {
-                edges.push_back(pr.second);
-            }
-            std::sort(edges.begin(), edges.end());
-            TStringBuilder sb;
-            for (auto& edge : edges) {
-                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
-            }
-            return sb;
-        };
+        TWaitGraphInterceptor waitGraph(runtime);
 
         // Lock keys 1 and 2 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Add(2).Build());
+        lockRows.ExpectResult(req1);
 
         // Lock keys 2 and 3 by lock 2
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock2.GetLockId());
-            req->Record.SetLockNodeId(lock2.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(2)),
-                TCell::Make(i32(3)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(2).Add(3).Build());
+        lockRows.ExpectNoResult();
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "234 -> 123\n");
 
         UNIT_ASSERT_VALUES_EQUAL(
@@ -425,16 +380,11 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             )"),
             "<empty>");
 
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the current owner is broken");
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        // Lock 2 must succeed when the current owner is broken
+        lockRows.ExpectResult(req2);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "");
     }
 
@@ -455,77 +405,22 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
-        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
-        THashMap<TRequestId, TWaitGraphEdge> waitGraph;
-        auto waitGraphAddObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>([&](auto& ev) {
-            auto* msg = ev->Get();
-            waitGraph[TRequestId{ ev->Sender, msg->RequestId }] = { msg->Lock.LockId, msg->OtherLock.LockId };
-            ev.Reset();
-        });
-        auto waitGraphRemoveObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>([&](auto& ev) {
-            auto* msg = ev->Get();
-            waitGraph.erase(TRequestId{ ev->Sender, msg->RequestId });
-            ev.Reset();
-        });
-        auto waitGraphString = [&]() -> TString {
-            TVector<TWaitGraphEdge> edges;
-            for (auto& pr : waitGraph) {
-                edges.push_back(pr.second);
-            }
-            std::sort(edges.begin(), edges.end());
-            TStringBuilder sb;
-            for (auto& edge : edges) {
-                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
-            }
-            return sb;
-        };
+        TWaitGraphInterceptor waitGraph(runtime);
 
         // Lock keys 1 and 2 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Add(2).Build());
+        lockRows.ExpectResult(req1);
 
         // Lock keys 3 and 2 by lock 2
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock2.GetLockId());
-            req->Record.SetLockNodeId(lock2.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(3)),
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(3).Add(2).Build());
+        lockRows.ExpectNoResult();
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "234 -> 123\n");
 
         UNIT_ASSERT_VALUES_EQUAL(
@@ -534,16 +429,11 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             )"),
             "<empty>");
 
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the awaiter is broken");
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
-        }
+        // Lock 2 must fail as soon as its lock is broken
+        lockRows.ExpectResult(req2, NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "");
     }
 
@@ -564,92 +454,32 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
-        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
-        THashMap<TRequestId, TWaitGraphEdge> waitGraph;
-        auto waitGraphAddObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>([&](auto& ev) {
-            auto* msg = ev->Get();
-            waitGraph[TRequestId{ ev->Sender, msg->RequestId }] = { msg->Lock.LockId, msg->OtherLock.LockId };
-            ev.Reset();
-        });
-        auto waitGraphRemoveObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>([&](auto& ev) {
-            auto* msg = ev->Get();
-            waitGraph.erase(TRequestId{ ev->Sender, msg->RequestId });
-            ev.Reset();
-        });
-        auto waitGraphString = [&]() -> TString {
-            TVector<TWaitGraphEdge> edges;
-            for (auto& pr : waitGraph) {
-                edges.push_back(pr.second);
-            }
-            std::sort(edges.begin(), edges.end());
-            TStringBuilder sb;
-            for (auto& edge : edges) {
-                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
-            }
-            return sb;
-        };
+        TWaitGraphInterceptor waitGraph(runtime);
 
         // Lock keys 1 and 2 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Add(2).Build());
+        lockRows.ExpectResult(req1);
 
         // Lock keys 3 and 2 by lock 2
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock2.GetLockId());
-            req->Record.SetLockNodeId(lock2.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(3)),
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(3).Add(2).Build());
+        lockRows.ExpectNoResult();
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "234 -> 123\n");
 
         // Break the second lock (it will notify the long tx service and rollback datashard changes)
         lock2.Reset();
 
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the awaiter is broken");
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
-        }
+        // Lock 2 must fail as soon as its lock is rolled back
+        lockRows.ExpectResult(req2, NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "");
     }
 
@@ -670,98 +500,27 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
-        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
-        NLongTxService::TLockHandle lock3(345, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock3(345, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
-        THashMap<TRequestId, TWaitGraphEdge> waitGraph;
-        auto waitGraphAddObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>([&](auto& ev) {
-            auto* msg = ev->Get();
-            waitGraph[TRequestId{ ev->Sender, msg->RequestId }] = { msg->Lock.LockId, msg->OtherLock.LockId };
-            ev.Reset();
-        });
-        auto waitGraphRemoveObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>([&](auto& ev) {
-            auto* msg = ev->Get();
-            waitGraph.erase(TRequestId{ ev->Sender, msg->RequestId });
-            ev.Reset();
-        });
-        auto waitGraphString = [&]() -> TString {
-            TVector<TWaitGraphEdge> edges;
-            for (auto& pr : waitGraph) {
-                edges.push_back(pr.second);
-            }
-            std::sort(edges.begin(), edges.end());
-            TStringBuilder sb;
-            for (auto& edge : edges) {
-                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
-            }
-            return sb;
-        };
+        TWaitGraphInterceptor waitGraph(runtime);
 
         // Lock keys 1 and 2 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Add(2).Build());
+        lockRows.ExpectResult(req1);
 
         // Lock keys 2 and 3 by lock 2
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock2.GetLockId());
-            req->Record.SetLockNodeId(lock2.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(2)),
-                TCell::Make(i32(3)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(2).Add(3).Build());
+        lockRows.ExpectNoResult();
 
         // Lock keys 3 and 2 by lock 3
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(3);
-            req->Record.SetLockId(lock3.GetLockId());
-            req->Record.SetLockNodeId(lock3.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(3)),
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        auto req3 = lockRows.SendRequest(lock3, tableId, TKeysBuilder().Add(3).Add(2).Build());
+        lockRows.ExpectNoResult();
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "234 -> 123\n"
             "345 -> 234\n");
 
@@ -773,52 +532,30 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             "<empty>");
 
         // Both operations should be blocked waiting for each other
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        lockRows.ExpectNoResult();
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "234 -> 345\n"
             "345 -> 234\n");
 
         // Ask the third (yongest) operation to break the deadlock
-        for (auto& pr : waitGraph) {
-            if (pr.second.LockId == 345) {
-                runtime.Send(new IEventHandle(pr.first.Sender, TActorId(), new TEvLongTxService::TEvWaitingLockDeadlock(pr.first.RequestId)), 0, true);
-            }
-        }
+        waitGraph.SendDeadlock(345, 234);
 
         // The third operation should reply with the STATUS_DEADLOCK
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the deadlock notification");
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 3u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_DEADLOCK);
-        }
+        lockRows.ExpectResult(req3, NKikimrDataEvents::TEvLockRowsResult::STATUS_DEADLOCK);
 
         // Perhaps unexpectedly the row 3 is still locked until the lock is broken or removed
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
-        }
+        lockRows.ExpectNoResult();
 
         // Reset the third lock (it will notify the long tx service and rollback datashard changes)
         lock3.Reset();
 
         // Finally the second operation should successfully lock all rows
-        {
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
-            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the deadlock notification");
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        lockRows.ExpectResult(req2);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            waitGraphString(),
+            waitGraph.ToString(),
             "");
     }
 
@@ -839,7 +576,8 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
         // Write an uncommitted row at key 1
         TString sessionId, txId;
@@ -851,25 +589,8 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             "{ items { int32_value: 1 } items { int32_value: 101 } }");
 
         // Lock key 1 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
 
         // Commit the previous transaction
         UNIT_ASSERT_VALUES_EQUAL(
@@ -877,25 +598,8 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             "{ items { int32_value: 1 } }");
 
         // Lock key 2 by lock 1 (lock must be broken now)
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
-        }
+        auto req2 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(2).Build());
+        lockRows.ExpectResult(req2, NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
     }
 
     Y_UNIT_TEST(UncommittedChangeOverLockThenCommitBreaksLock) {
@@ -915,28 +619,12 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         TTestPipe pipe(runtime, shards.at(0));
 
-        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
 
         // Lock key 1 by lock 1
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(1)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
 
         // Write an uncommitted row at key 1
         TString sessionId, txId;
@@ -948,25 +636,8 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             "{ items { int32_value: 1 } items { int32_value: 101 } }");
 
         // Lock key 2 by lock 1 (lock not broken yet)
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(2)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
-        }
+        auto req2 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(2).Build());
+        lockRows.ExpectResult(req2);
 
         // Commit the previous transaction
         UNIT_ASSERT_VALUES_EQUAL(
@@ -974,25 +645,8 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             "{ items { int32_value: 1 } }");
 
         // Lock key 3 by lock 1 (lock must be broken now)
-        {
-            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(3);
-            req->Record.SetLockId(lock1.GetLockId());
-            req->Record.SetLockNodeId(lock1.GetLockNodeId());
-            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-            req->SetTableId(tableId);
-            req->Record.AddColumnIds(1);
-            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            TVector<TCell> cells({
-                TCell::Make(i32(3)),
-            });
-            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
-            pipe.Send(sender, req.release());
-
-            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
-            auto* res = ev->Get();
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 3u);
-            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
-        }
+        auto req3 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(3).Build());
+        lockRows.ExpectResult(req3, NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
     }
 
 } // Y_UNIT_TEST_SUITE(DataShardLockRows)

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -822,6 +822,179 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             "");
     }
 
+    Y_UNIT_TEST(LockOverUncommittedChangeThenCommitBreaksLock) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
+
+        // Write an uncommitted row at key 1
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (1, 101);
+                SELECT key, value FROM `/Root/table` WHERE key = 1;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 101 } }");
+
+        // Lock key 1 by lock 1
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(1)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        // Commit the previous transaction
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(SELECT 1)"),
+            "{ items { int32_value: 1 } }");
+
+        // Lock key 2 by lock 1 (lock must be broken now)
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
+        }
+    }
+
+    Y_UNIT_TEST(UncommittedChangeOverLockThenCommitBreaksLock) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
+
+        // Lock key 1 by lock 1
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(1)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        // Write an uncommitted row at key 1
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (1, 101);
+                SELECT key, value FROM `/Root/table` WHERE key = 1;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 101 } }");
+
+        // Lock key 2 by lock 1 (lock not broken yet)
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        // Commit the previous transaction
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(SELECT 1)"),
+            "{ items { int32_value: 1 } }");
+
+        // Lock key 3 by lock 1 (lock must be broken now)
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(3);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(3)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 1, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 3u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
+        }
+    }
+
 } // Y_UNIT_TEST_SUITE(DataShardLockRows)
 
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -7,14 +7,33 @@
 #include <ydb/core/tx/long_tx_service/public/lock_handle.h>
 #include "datashard_ut_common_kqp.h"
 
+#include <util/digest/multi.h>
+
 namespace NKikimr {
 
 using namespace NKikimr::NDataShard;
 using namespace NKikimr::NDataShard::NKqpHelpers;
+using namespace NLongTxService;
 using namespace NSchemeShard;
 using namespace Tests;
 
 Y_UNIT_TEST_SUITE(DataShardLockRows) {
+
+    struct TRequestId {
+        TActorId Sender;
+        ui64 RequestId;
+
+        operator size_t() const {
+            return ::MultiHash(Sender, RequestId);
+        }
+    };
+
+    struct TWaitGraphEdge {
+        ui64 LockId;
+        ui64 OtherLockId;
+
+        friend std::strong_ordering operator<=>(const TWaitGraphEdge&, const TWaitGraphEdge&) = default;
+    };
 
     std::tuple<TTestActorRuntime&, Tests::TServer::TPtr, TActorId> TestCreateServer(TPortManager& pm, std::optional<TServerSettings> serverSettings = {}) {
         if (!serverSettings) {
@@ -308,6 +327,499 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
             UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_OVERLOADED);
         }
+    }
+
+    Y_UNIT_TEST(BrokenOwnerUnblocksAwaiter) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
+        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+
+        THashMap<TRequestId, TWaitGraphEdge> waitGraph;
+        auto waitGraphAddObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>([&](auto& ev) {
+            auto* msg = ev->Get();
+            waitGraph[TRequestId{ ev->Sender, msg->RequestId }] = { msg->Lock.LockId, msg->OtherLock.LockId };
+            ev.Reset();
+        });
+        auto waitGraphRemoveObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>([&](auto& ev) {
+            auto* msg = ev->Get();
+            waitGraph.erase(TRequestId{ ev->Sender, msg->RequestId });
+            ev.Reset();
+        });
+        auto waitGraphString = [&]() -> TString {
+            TVector<TWaitGraphEdge> edges;
+            for (auto& pr : waitGraph) {
+                edges.push_back(pr.second);
+            }
+            std::sort(edges.begin(), edges.end());
+            TStringBuilder sb;
+            for (auto& edge : edges) {
+                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
+            }
+            return sb;
+        };
+
+        // Lock keys 1 and 2 by lock 1
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(1)),
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        // Lock keys 2 and 3 by lock 2
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
+            req->Record.SetLockId(lock2.GetLockId());
+            req->Record.SetLockNodeId(lock2.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(2)),
+                TCell::Make(i32(3)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "234 -> 123\n");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (1, 101);
+            )"),
+            "<empty>");
+
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the current owner is broken");
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "");
+    }
+
+    Y_UNIT_TEST(BrokenAwaiterUnblocksAwait) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
+        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+
+        THashMap<TRequestId, TWaitGraphEdge> waitGraph;
+        auto waitGraphAddObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>([&](auto& ev) {
+            auto* msg = ev->Get();
+            waitGraph[TRequestId{ ev->Sender, msg->RequestId }] = { msg->Lock.LockId, msg->OtherLock.LockId };
+            ev.Reset();
+        });
+        auto waitGraphRemoveObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>([&](auto& ev) {
+            auto* msg = ev->Get();
+            waitGraph.erase(TRequestId{ ev->Sender, msg->RequestId });
+            ev.Reset();
+        });
+        auto waitGraphString = [&]() -> TString {
+            TVector<TWaitGraphEdge> edges;
+            for (auto& pr : waitGraph) {
+                edges.push_back(pr.second);
+            }
+            std::sort(edges.begin(), edges.end());
+            TStringBuilder sb;
+            for (auto& edge : edges) {
+                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
+            }
+            return sb;
+        };
+
+        // Lock keys 1 and 2 by lock 1
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(1)),
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        // Lock keys 3 and 2 by lock 2
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
+            req->Record.SetLockId(lock2.GetLockId());
+            req->Record.SetLockNodeId(lock2.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(3)),
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "234 -> 123\n");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (3, 101);
+            )"),
+            "<empty>");
+
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the awaiter is broken");
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "");
+    }
+
+    Y_UNIT_TEST(RollbackAwaiterUnblocksAwait) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
+        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+
+        THashMap<TRequestId, TWaitGraphEdge> waitGraph;
+        auto waitGraphAddObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>([&](auto& ev) {
+            auto* msg = ev->Get();
+            waitGraph[TRequestId{ ev->Sender, msg->RequestId }] = { msg->Lock.LockId, msg->OtherLock.LockId };
+            ev.Reset();
+        });
+        auto waitGraphRemoveObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>([&](auto& ev) {
+            auto* msg = ev->Get();
+            waitGraph.erase(TRequestId{ ev->Sender, msg->RequestId });
+            ev.Reset();
+        });
+        auto waitGraphString = [&]() -> TString {
+            TVector<TWaitGraphEdge> edges;
+            for (auto& pr : waitGraph) {
+                edges.push_back(pr.second);
+            }
+            std::sort(edges.begin(), edges.end());
+            TStringBuilder sb;
+            for (auto& edge : edges) {
+                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
+            }
+            return sb;
+        };
+
+        // Lock keys 1 and 2 by lock 1
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(1)),
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        // Lock keys 3 and 2 by lock 2
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
+            req->Record.SetLockId(lock2.GetLockId());
+            req->Record.SetLockNodeId(lock2.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(3)),
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "234 -> 123\n");
+
+        // Break the second lock (it will notify the long tx service and rollback datashard changes)
+        lock2.Reset();
+
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the awaiter is broken");
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "");
+    }
+
+    Y_UNIT_TEST(DeadlockDetectionUnblocksAwait) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        NLongTxService::TLockHandle lock1(123, runtime.GetActorSystem(0));
+        NLongTxService::TLockHandle lock2(234, runtime.GetActorSystem(0));
+        NLongTxService::TLockHandle lock3(345, runtime.GetActorSystem(0));
+
+        THashMap<TRequestId, TWaitGraphEdge> waitGraph;
+        auto waitGraphAddObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockAdd>([&](auto& ev) {
+            auto* msg = ev->Get();
+            waitGraph[TRequestId{ ev->Sender, msg->RequestId }] = { msg->Lock.LockId, msg->OtherLock.LockId };
+            ev.Reset();
+        });
+        auto waitGraphRemoveObserver = runtime.AddObserver<TEvLongTxService::TEvWaitingLockRemove>([&](auto& ev) {
+            auto* msg = ev->Get();
+            waitGraph.erase(TRequestId{ ev->Sender, msg->RequestId });
+            ev.Reset();
+        });
+        auto waitGraphString = [&]() -> TString {
+            TVector<TWaitGraphEdge> edges;
+            for (auto& pr : waitGraph) {
+                edges.push_back(pr.second);
+            }
+            std::sort(edges.begin(), edges.end());
+            TStringBuilder sb;
+            for (auto& edge : edges) {
+                sb << edge.LockId << " -> " << edge.OtherLockId << "\n";
+            }
+            return sb;
+        };
+
+        // Lock keys 1 and 2 by lock 1
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(1);
+            req->Record.SetLockId(lock1.GetLockId());
+            req->Record.SetLockNodeId(lock1.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(1)),
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        // Lock keys 2 and 3 by lock 2
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(2);
+            req->Record.SetLockId(lock2.GetLockId());
+            req->Record.SetLockNodeId(lock2.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(2)),
+                TCell::Make(i32(3)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
+        }
+
+        // Lock keys 3 and 2 by lock 3
+        {
+            auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(3);
+            req->Record.SetLockId(lock3.GetLockId());
+            req->Record.SetLockNodeId(lock3.GetLockNodeId());
+            req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+            req->SetTableId(tableId);
+            req->Record.AddColumnIds(1);
+            req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+            TVector<TCell> cells({
+                TCell::Make(i32(3)),
+                TCell::Make(i32(2)),
+            });
+            req->SetCellMatrix(TSerializedCellMatrix::Serialize(cells, 2, 1));
+            pipe.Send(sender, req.release());
+
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "234 -> 123\n"
+            "345 -> 234\n");
+
+        // Break the current owner
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (1, 101);
+            )"),
+            "<empty>");
+
+        // Both operations should be blocked waiting for each other
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "234 -> 345\n"
+            "345 -> 234\n");
+
+        // Ask the third (yongest) operation to break the deadlock
+        for (auto& pr : waitGraph) {
+            if (pr.second.LockId == 345) {
+                runtime.Send(new IEventHandle(pr.first.Sender, TActorId(), new TEvLongTxService::TEvWaitingLockDeadlock(pr.first.RequestId)), 0, true);
+            }
+        }
+
+        // The third operation should reply with the STATUS_DEADLOCK
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the deadlock notification");
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 3u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_DEADLOCK);
+        }
+
+        // Perhaps unexpectedly the row 3 is still locked until the lock is broken or removed
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected TEvLockRowsResult with status " << ev->Get()->Record.GetStatus());
+        }
+
+        // Reset the third lock (it will notify the long tx service and rollback datashard changes)
+        lock3.Reset();
+
+        // Finally the second operation should successfully lock all rows
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "Expected TEvLockRowsResult after the deadlock notification");
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetRequestId(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus(), NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraphString(),
+            "");
     }
 
 } // Y_UNIT_TEST_SUITE(DataShardLockRows)

--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -206,6 +206,8 @@ void TLockInfo::SetBroken(TRowVersion at) {
             Ranges.clear();
             Locker->ScheduleBrokenLock(this);
         }
+
+        OnBrokenEvent.NotifyAll();
     }
 }
 
@@ -215,6 +217,7 @@ void TLockInfo::OnRemoved() {
         Counter = Max<ui64>();
         Points.clear();
         Ranges.clear();
+        OnBrokenEvent.NotifyAll();
     }
 
     OnRemovedEvent.NotifyAll();
@@ -838,6 +841,8 @@ void TLockLocker::RemoveBrokenRanges() {
                 Tables.at(tableId)->RemoveWriteLock(lock.Get());
             }
             lock->CleanupConflicts();
+
+            lock->OnBrokenEvent.NotifyAll();
         }
     }
 }

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -226,6 +226,7 @@ enum class ELockFlags : ui64 {
     WholeShard = 2,
     Persistent = 4,
     Removed = 8,
+    Pessimistic = 16,
     PersistentMask = Frozen,
 };
 
@@ -321,6 +322,7 @@ public:
     bool Empty() const {
         return !(
             IsPersistent() ||
+            IsPessimistic() ||
             !ReadTables.empty() ||
             !WriteTables.empty() ||
             IsBroken());
@@ -437,6 +439,9 @@ public:
     bool IsFrozen() const { return !!(Flags & ELockFlags::Frozen); }
     void SetFrozen(ILocksDb* db = nullptr);
 
+    bool IsPessimistic() const { return !!(Flags & ELockFlags::Pessimistic); }
+    void SetPessimistic() { Flags |= ELockFlags::Pessimistic; }
+
     bool IsPersisting() const { return WaitPersistentCounter > 0; }
     void AddWaitPersistentCallback(ILocksDb* db);
 
@@ -489,6 +494,7 @@ private:
     ui64 WaitPersistentCounter = 0;
 
 public:
+    TAsyncEvent OnBrokenEvent;
     TAsyncEvent OnRemovedEvent;
 };
 
@@ -915,7 +921,6 @@ struct TLocksUpdate {
     // QuerySpanId captured at the moment a lock break is first detected (AddBreakLock).
     ui64 ConflictBreakerQuerySpanId = 0;
     TLockInfo::TPtr Lock;
-    bool PreserveEmptyLock = false;
 
     // Returns effective BreakerQuerySpanId: explicit override (commit path) if set,
     // then conflict-derived SpanId (from AddBreakLock), then falls back to QuerySpanId.
@@ -1077,7 +1082,7 @@ public:
 
     void ResetUpdate() {
         if (Y_LIKELY(Update)) {
-            if (Update->Lock && Update->Lock->Empty() && !Update->PreserveEmptyLock) {
+            if (Update->Lock && Update->Lock->Empty()) {
                 Locker.RemoveLock(Update->LockTxId, nullptr);
             }
             Update = nullptr;

--- a/ydb/core/tx/long_tx_service/public/events.h
+++ b/ydb/core/tx/long_tx_service/public/events.h
@@ -273,6 +273,11 @@ namespace NLongTxService {
             struct TLockInfo {
                 ui64 LockId;
                 ui32 LockNodeId;
+
+                TLockInfo(ui64 lockId, ui32 lockNodeId)
+                    : LockId(lockId)
+                    , LockNodeId(lockNodeId)
+                {}
             };
 
             TEvWaitingLockAdd(ui64 requestId, TLockInfo lock, TLockInfo otherLock)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds more basic tests for pessimistic lock dependencies, and ensures pessimistic lock operations wait until the lock is broken, not when it's fully removed and rolled back.

Related to #25253.