### PR TITLE
Make nodes not create a DSProxy for a static group on start

### DIFF
--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -1312,6 +1312,111 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         CheckVDiskStateUpdate(runtime, fakeWhiteboard, groupId, 2, 2u);
     }
 
+    struct TStaticGroupProxyTestSetup {
+        TTestActorSystem Runtime;
+        ui32 NodeId = 1;
+        ui32 StaticGroupId;
+        TActorId NodeWardenId;
+
+        TStaticGroupProxyTestSetup(ui32 maxStaticNodeId)
+            : Runtime(1, NLog::PRI_ERROR, MakeIntrusive<TDomainsInfo>())
+            , StaticGroupId(TGroupID(EGroupConfigurationType::Static, 1, 0).GetRaw())
+        {
+            Runtime.Start();
+
+            auto& appData = *Runtime.GetNode(1)->AppData;
+            appData.DomainsInfo->AddDomain(TDomainsInfo::TDomain::ConstructEmptyDomain("dom", 1).Release());
+            appData.DynamicNameserviceConfig = new TDynamicNameserviceConfig();
+            appData.DynamicNameserviceConfig->MaxStaticNodeId = maxStaticNodeId;
+
+            TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig(new TNodeWardenConfig(
+                static_cast<IPDiskServiceFactory*>(new TRealPDiskServiceFactory())));
+            ObtainStaticKey(&nodeWardenConfig->StaticKey);
+
+            auto* serviceSet = nodeWardenConfig->BlobStorageConfig.MutableServiceSet();
+            auto* group = serviceSet->AddGroups();
+            group->SetGroupID(StaticGroupId);
+            group->SetGroupGeneration(1);
+            group->SetErasureSpecies(TErasureType::ErasureNone);
+            auto* ring = group->AddRings();
+            auto* failDomain = ring->AddFailDomains();
+            auto* vdiskLoc = failDomain->AddVDiskLocations();
+            vdiskLoc->SetNodeID(NodeId);
+            vdiskLoc->SetPDiskID(1);
+            vdiskLoc->SetVDiskSlotID(0);
+            vdiskLoc->SetPDiskGuid(12345);
+
+            IActor* ac = CreateBSNodeWarden(nodeWardenConfig.Release());
+            NodeWardenId = Runtime.Register(ac, NodeId);
+            Runtime.RegisterService(MakeBlobStorageNodeWardenID(NodeId), NodeWardenId);
+        }
+
+        void Bootstrap() {
+            Runtime.WrapInActorContext(NodeWardenId, [](IActor* wardenActor) {
+                auto& warden = *dynamic_cast<NStorage::TNodeWarden*>(wardenActor);
+                warden.Bootstrap();
+            });
+        }
+
+        bool HasGroupProxy() {
+            bool result = false;
+            Runtime.WrapInActorContext(NodeWardenId, [this, &result](IActor* wardenActor) {
+                auto& warden = *dynamic_cast<NStorage::TNodeWarden*>(wardenActor);
+                result = warden.HasGroupProxy(StaticGroupId);
+            });
+            return result;
+        }
+
+        void SimulateForwardedRequest() {
+            Runtime.WrapInActorContext(NodeWardenId, [this](IActor* wardenActor) {
+                auto& warden = *dynamic_cast<NStorage::TNodeWarden*>(wardenActor);
+                TActorId sender = Runtime.AllocateEdgeActor(NodeId);
+                TActorId proxyId = MakeBlobStorageProxyID(StaticGroupId);
+                auto ev = std::make_unique<TEvBlobStorage::TEvStatus>(TInstant::Max());
+                TAutoPtr<IEventHandle> handle(new IEventHandle(
+                    warden.SelfId(),
+                    sender,
+                    ev.release(),
+                    IEventHandle::FlagForwardOnNondelivery,
+                    0,
+                    &proxyId
+                ));
+                warden.HandleForwarded(handle);
+            });
+        }
+    };
+
+    Y_UNIT_TEST(TestDynamicNodeLazyStaticGroupProxyCreation) {
+        // MaxStaticNodeId = 0 means node 1 is a dynamic node
+        TStaticGroupProxyTestSetup setup(0);
+        setup.Bootstrap();
+
+        UNIT_ASSERT_C(!setup.HasGroupProxy(),
+            "Static group proxy should not be created at startup on dynamic node");
+
+        setup.SimulateForwardedRequest();
+
+        UNIT_ASSERT_C(setup.HasGroupProxy(),
+            "Static group proxy should be created on-demand after a request on dynamic node");
+    }
+
+    Y_UNIT_TEST(TestStaticNodeLazyStaticGroupProxyCreation) {
+        // MaxStaticNodeId = 100 means node 1 is a static node
+        TStaticGroupProxyTestSetup setup(100);
+        setup.Bootstrap();
+
+        // Verify proxy is NOT created at startup even on static node
+        UNIT_ASSERT_C(!setup.HasGroupProxy(),
+            "Static group proxy should NOT be created at startup even on static node");
+
+        // Simulate a forwarded request to trigger on-demand proxy creation
+        setup.SimulateForwardedRequest();
+
+        // Verify proxy is created after the request
+        UNIT_ASSERT_C(setup.HasGroupProxy(),
+            "Static group proxy should be created on-demand after a request on static node");
+    }
+
 }
 
 } // namespace NBlobStorageNodeWardenTest

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -1405,14 +1405,11 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         TStaticGroupProxyTestSetup setup(100);
         setup.Bootstrap();
 
-        // Verify proxy is NOT created at startup even on static node
         UNIT_ASSERT_C(!setup.HasGroupProxy(),
             "Static group proxy should NOT be created at startup even on static node");
 
-        // Simulate a forwarded request to trigger on-demand proxy creation
         setup.SimulateForwardedRequest();
 
-        // Verify proxy is created after the request
         UNIT_ASSERT_C(setup.HasGroupProxy(),
             "Static group proxy should be created on-demand after a request on static node");
     }

--- a/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
@@ -321,6 +321,11 @@ namespace NKikimr::NStorage {
         }
     }
 
+    bool TNodeWarden::HasGroupProxy(ui32 groupId) const {
+        auto it = Groups.find(groupId);
+        return it != Groups.end() && it->second.ProxyId;
+    }
+
     void TNodeWarden::Handle(TEvBlobStorage::TEvUpdateGroupInfo::TPtr ev) {
         auto *msg = ev->Get();
         bool fromResolver = false;

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -525,7 +525,6 @@ void TNodeWarden::Bootstrap() {
         } else {
             Groups.try_emplace(0); // group is gonna be configured soon by DistributedConfigKeeper
         }
-        StartStaticProxies();
     }
     EstablishPipe();
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -317,7 +317,6 @@ namespace NKikimr::NStorage {
         void StopInvalidGroupProxy();
         void StartLocalProxy(ui32 groupId);
         void StartVirtualGroupAgent(ui32 groupId);
-        void StartStaticProxies();
         void StartRequestReportingThrottler();
 
         /**
@@ -566,6 +565,9 @@ namespace NKikimr::NStorage {
         // this function returns group info if possible, or otherwise starts requesting group info and/or proposing key
         // if needed
         TIntrusivePtr<TBlobStorageGroupInfo> NeedGroupInfo(ui32 groupId);
+
+        // check if a proxy exists for a given group
+        bool HasGroupProxy(ui32 groupId) const;
 
         // propose group key
         void ProposeKey(ui32 groupId, const TEncryptionKey& mainKey, const NKikimrBlobStorage::TGroupInfo& encryptionParams);

--- a/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
@@ -128,13 +128,6 @@ void TNodeWarden::StartVirtualGroupAgent(ui32 groupId) {
     as->RegisterLocalService(MakeBlobStorageProxyID(groupId), group.ProxyId);
 }
 
-void TNodeWarden::StartStaticProxies() {
-    Y_ABORT_UNLESS(Cfg->BlobStorageConfig.HasServiceSet());
-    for (const auto& group : Cfg->BlobStorageConfig.GetServiceSet().GetGroups()) {
-        StartLocalProxy(group.GetGroupID());
-    }
-}
-
 void TNodeWarden::HandleForwarded(TAutoPtr<::NActors::IEventHandle> &ev) {
     const TGroupID groupId(GroupIDFromBlobStorageProxyID(ev->GetForwardOnNondeliveryRecipient()));
     const ui32 id = groupId.GetRaw();
@@ -150,15 +143,31 @@ void TNodeWarden::HandleForwarded(TAutoPtr<::NActors::IEventHandle> &ev) {
         TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, errorProxy, {}, nullptr, 0));
         return;
     } else if (groupId.ConfigurationType() == EGroupConfigurationType::Static && !Groups.count(id)) {
-        const auto [it, inserted] = GroupPendingQueue.try_emplace(id);
-        auto& queue = it->second;
-        TMonotonic expiration = TActivationContext::Monotonic() + TDuration::Seconds(5);
-        if (queue.empty()) {
-            TimeoutToQueue.emplace(expiration, &*it);
+        // for static groups, try to find the group configuration in Cfg and apply it
+        bool found = false;
+        if (Cfg->BlobStorageConfig.HasServiceSet()) {
+            for (const auto& groupProto : Cfg->BlobStorageConfig.GetServiceSet().GetGroups()) {
+                if (groupProto.GetGroupID() == id) {
+                    ApplyGroupInfo(id, groupProto.GetGroupGeneration(), &groupProto, true, false);
+                    found = true;
+                    break;
+                }
+            }
         }
-        queue.emplace_back(expiration, std::unique_ptr<IEventHandle>(ev.Release()));
-        return;
-    } else if (TGroupRecord& group = Groups[id]; !group.ProxyId) {
+        if (!found) {
+            // group not found in static config, put request in pending queue
+            const auto [it, inserted] = GroupPendingQueue.try_emplace(id);
+            auto& queue = it->second;
+            TMonotonic expiration = TActivationContext::Monotonic() + TDuration::Seconds(5);
+            if (queue.empty()) {
+                TimeoutToQueue.emplace(expiration, &*it);
+            }
+            queue.emplace_back(expiration, std::unique_ptr<IEventHandle>(ev.Release()));
+            return;
+        }
+    }
+
+    if (TGroupRecord& group = Groups[id]; !group.ProxyId) {
         if (TGroupID(id).ConfigurationType() == EGroupConfigurationType::Virtual) {
             StartVirtualGroupAgent(id);
         } else {

--- a/ydb/core/tablet/tablet_pipecache_ut.cpp
+++ b/ydb/core/tablet/tablet_pipecache_ut.cpp
@@ -175,6 +175,12 @@ Y_UNIT_TEST_SUITE(TPipeCacheTest) {
                 return new TCustomTablet(tablet, info);
             });
 
+        {
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+            runtime.DispatchEvents(options);
+        }
+
         auto config = MakeIntrusive<TPipePerNodeCacheConfig>();
         auto cacheActor = runtime.Register(CreatePipePerNodeCache(config));
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make dynnodes not create a DSProxy for a static group on start

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
