### PR TITLE
Improve TSpanCircleBuffer multi-threaded performance

### DIFF
--- a/ydb/library/actors/retro_tracing/span_buffer.cpp
+++ b/ydb/library/actors/retro_tracing/span_buffer.cpp
@@ -7,7 +7,8 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
-#include <util/system/spinlock.h>
+
+#include <util/generic/bitops.h>
 
 namespace NRetroTracing {
 
@@ -15,17 +16,13 @@ class TSpanCircleBuffer {
 public:
     TSpanCircleBuffer()
         : Head(0)
+        , Capacity(BufferSize / CellSize)
+        , CapacityMask(FastClp2(Capacity) - 1)
     {
         std::fill(Buffer, Buffer + BufferSize, 0);
     }
 
     void WriteSpan(const TRetroSpan* span) {
-        std::unique_lock guard(Lock, std::try_to_lock);
-        if (!guard.owns_lock()) {
-            // read is in progress, reject span
-            return;
-        }
-
         if (!span->IsEnded()) {
             // unable to write non-ended span
             return;
@@ -36,11 +33,17 @@ public:
             // invalid span size, reject span
             return;
         }
-        if (Head + CellSize >= BufferSize) {
-            Head = 0;
+
+        { // critical section
+            std::unique_lock guard(Lock, std::try_to_lock);
+            if (!guard.owns_lock()) {
+                // read is in progress, reject span
+                return;
+            }
+            ui64 head = Head & CapacityMask;
+            std::memcpy(static_cast<void*>(Buffer + head * CellSize), static_cast<const void*>(span), spanSize);
+            ++Head;
         }
-        std::memcpy(static_cast<void*>(Buffer + Head), static_cast<const void*>(span), spanSize);
-        Head += CellSize;
     }
 
     std::vector<std::unique_ptr<TRetroSpan>> GetSpans(const NWilson::TTraceId& traceId, bool getAll) {
@@ -64,11 +67,16 @@ private:
     static constexpr ui32 CellSize = 1_KB;
     static constexpr ui32 BufferSize = 5_MB;
     char Buffer[BufferSize] = {0};
-    // TODO: more effective locking mechanism, remove second tmp buffer
-    char TmpBuffer[BufferSize] = {0};
-    ui32 Head = 0;
-    TSpinLock Lock;
+    static char TmpBuffer[BufferSize];
+
+    ui64 Head = 0;
+    const ui64 Capacity = 0;
+    const ui64 CapacityMask = 0;
+
+    std::mutex Lock;
 };
+
+char TSpanCircleBuffer::TmpBuffer[BufferSize] = {0};
 
 static thread_local std::shared_ptr<TSpanCircleBuffer> SpanBuffer;
 static std::mutex Mutex;

--- a/ydb/library/actors/retro_tracing/span_buffer.cpp
+++ b/ydb/library/actors/retro_tracing/span_buffer.cpp
@@ -8,8 +8,6 @@
 #include <thread>
 #include <unordered_map>
 
-#include <util/generic/bitops.h>
-
 namespace NRetroTracing {
 
 class TSpanCircleBuffer {

--- a/ydb/library/actors/retro_tracing/span_buffer.cpp
+++ b/ydb/library/actors/retro_tracing/span_buffer.cpp
@@ -13,15 +13,16 @@
 namespace NRetroTracing {
 
 class TSpanCircleBuffer {
-public:
-    TSpanCircleBuffer()
-        : Head(0)
-        , Capacity(BufferSize / CellSize)
-        , CapacityMask(FastClp2(Capacity) - 1)
-    {
-        std::fill(Buffer, Buffer + BufferSize, 0);
-    }
+private:
+    static constexpr ui32 CellSize = 1 << 10;
+    static constexpr ui32 BufferSize = 4 << 20;
+    static constexpr ui32 Capacity = BufferSize / CellSize;
+    static constexpr ui32 CapacityMask = Capacity - 1;
 
+public:
+    using TBuffer = std::array<char, BufferSize>;
+
+public:
     void WriteSpan(const TRetroSpan* span) {
         if (!span->IsEnded()) {
             // unable to write non-ended span
@@ -41,21 +42,31 @@ public:
                 return;
             }
             ui64 head = Head & CapacityMask;
-            std::memcpy(static_cast<void*>(Buffer + head * CellSize), static_cast<const void*>(span), spanSize);
+            std::memcpy(
+                static_cast<void*>(Buffer.data() + head * CellSize),
+                static_cast<const void*>(span),
+                spanSize);
             ++Head;
         }
     }
 
-    std::vector<std::unique_ptr<TRetroSpan>> GetSpans(const NWilson::TTraceId& traceId, bool getAll) {
+    std::vector<std::unique_ptr<TRetroSpan>> GetSpans(TBuffer& readBuffer,
+            const NWilson::TTraceId& traceId, bool getAll) {
         {
             std::lock_guard guard(Lock);
-            std::memcpy(static_cast<void*>(TmpBuffer), static_cast<const void*>(Buffer), BufferSize);
+            std::memcpy(
+                static_cast<void*>(readBuffer.data()),
+                static_cast<const void*>(Buffer.data()),
+                BufferSize);
         }
         TRetroSpan spanHeader(0, sizeof(TRetroSpan));
         std::vector<std::unique_ptr<TRetroSpan>> res;
         for (ui32 pos = 0; pos < BufferSize; pos += CellSize) {
-            const void* ptr = TmpBuffer + pos;
-            std::memcpy(reinterpret_cast<void*>(&spanHeader), ptr, sizeof(TRetroSpan));
+            const void* ptr = readBuffer.data() + pos;
+            std::memcpy(
+                reinterpret_cast<void*>(&spanHeader),
+                ptr,
+                sizeof(TRetroSpan));
             if (spanHeader.GetTraceId() && (getAll || spanHeader.GetTraceId().IsSameTrace(traceId))) {
                 res.push_back(TRetroSpan::DeserializeToUnique(ptr));
             }
@@ -64,19 +75,12 @@ public:
     }
 
 private:
-    static constexpr ui32 CellSize = 1_KB;
-    static constexpr ui32 BufferSize = 5_MB;
-    char Buffer[BufferSize] = {0};
-    static char TmpBuffer[BufferSize];
-
+    TBuffer Buffer = {0};
     ui64 Head = 0;
-    const ui64 Capacity = 0;
-    const ui64 CapacityMask = 0;
-
     std::mutex Lock;
 };
 
-char TSpanCircleBuffer::TmpBuffer[BufferSize] = {0};
+// char TSpanCircleBuffer::TmpBuffer[BufferSize] = {0};
 
 static thread_local std::shared_ptr<TSpanCircleBuffer> SpanBuffer;
 static std::mutex Mutex;
@@ -96,11 +100,12 @@ void WriteSpan(const TRetroSpan* span) {
 }
 
 static std::vector<std::unique_ptr<TRetroSpan>> GetSpans(const NWilson::TTraceId& traceId, bool getAll) {
+    static TSpanCircleBuffer::TBuffer readBuffer;
     std::vector<std::unique_ptr<TRetroSpan>> res;
     std::lock_guard guard(Mutex);
     for (const auto& [id, buffer] : SpanBuffers) {
         if (std::shared_ptr<TSpanCircleBuffer> locked = buffer.lock()) {
-            std::vector<std::unique_ptr<TRetroSpan>> spans = locked->GetSpans(traceId, getAll);
+            std::vector<std::unique_ptr<TRetroSpan>> spans = locked->GetSpans(readBuffer, traceId, getAll);
             std::move(spans.begin(), spans.end(), std::back_inserter(res));
         }
     }

--- a/ydb/library/actors/retro_tracing/ut/main.cpp
+++ b/ydb/library/actors/retro_tracing/ut/main.cpp
@@ -191,7 +191,7 @@ Y_UNIT_TEST_SUITE(SpanBuffer) {
 
         std::vector<std::thread> threads;
         
-        ui32 readers = 2;
+        ui32 readers = 1;
         ui32 writers = 10;
 
         TInstant start = TInstant::Now();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Replace spinlock with std::mutex+try_to_lock.
Make spanbuffer MPSC queue.

### Changelog category <!-- remove all except one -->

* Improvement