### PR TITLE
fix: make incr backup py test a bit more reliable

### DIFF
--- a/ydb/tests/functional/backup_collection/basic_user_scenarios.py
+++ b/ydb/tests/functional/backup_collection/basic_user_scenarios.py
@@ -5,6 +5,7 @@ import logging
 import shutil
 import yatest
 import pytest
+import json
 import re
 import uuid
 from typing import List, Dict, Optional, Tuple
@@ -503,71 +504,80 @@ class BaseTestBackupInFiles(object):
             diag += f"  Last capture error: {last_exc}"
         raise AssertionError(diag)
 
-    def _count_restore_operations(self):
+    def _list_restore_operation_ids(self):
+        """Return a set of restore operation IDs from 'ydb operation list restore'."""
         endpoint = f"grpc://localhost:{self.cluster.nodes[1].grpc_port}"
         database = self.root_dir
 
-        cmd = [backup_bin(), "-e", endpoint, "-d", database, "operation", "list", "restore"]
+        cmd = [backup_bin(), "-e", endpoint, "-d", database,
+               "operation", "list", "restore", "--format", "proto-json-base64"]
         try:
             res = yatest.common.execute(cmd, check_exit_code=False)
             output = (res.std_out or b"").decode("utf-8", "ignore")
         except Exception as e:
-            return 0, 0, f"CLI failed: {e}"
+            logger.warning(f"Failed to list restore operations: {e}")
+            return set()
 
-        candidates = [
-            cand for cand in output.splitlines()
-            if "│" in cand and not cand.strip().startswith(("┌", "├", "└", "┬", "┴", "┼"))
-        ]
+        try:
+            data = json.loads(output)
+            return {op["id"] for op in data.get("operations", []) if "id" in op}
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            logger.warning(f"Failed to parse restore operations JSON: {e}")
+            return set()
 
-        header_idx = None
-        for i, ln in enumerate(candidates):
-            if re.search(r"\bid\b", ln, re.I) and re.search(r"\bstatus\b", ln, re.I):
-                header_idx = i
-                break
-        if header_idx is not None:
-            del candidates[header_idx]
-
-        total = len(candidates)
-        success_count = 0
-        for ln in candidates:
-            low = ln.lower()
-            if "success" in low or "true" in low:
-                success_count += 1
-
-        return total, success_count, output
-
-    def poll_restore_by_count(self, start_total: int, start_success: int, timeout_s: int = 180, poll_interval: float = 2.0, verbose: bool = True):
+    def _find_new_restore_operation(self, baseline_ids, timeout_s=30, poll_interval=1.0):
+        """Wait for a new restore operation to appear and return its ID."""
         deadline = time.time() + timeout_s
-        seen_more = False
-        last_total = start_total
-        last_success = start_success
+        while time.time() < deadline:
+            current_ids = self._list_restore_operation_ids()
+            new_ids = current_ids - baseline_ids
+            if new_ids:
+                op_id = sorted(new_ids)[-1]
+                logger.info(f"Found new restore operation: {op_id}")
+                return op_id
+            time.sleep(poll_interval)
+        logger.warning(f"No new restore operation found within {timeout_s}s")
+        return None
+
+    def poll_restore_by_id(self, op_id, timeout_s=180, poll_interval=2.0, verbose=True):
+        """Poll a specific restore operation by ID until it completes."""
+        endpoint = f"grpc://localhost:{self.cluster.nodes[1].grpc_port}"
+        database = self.root_dir
+        deadline = time.time() + timeout_s
+        last_status = {}
 
         while time.time() < deadline:
-            total, success, raw = self._count_restore_operations()
-            last_total, last_success, _ = total, success, raw
+            cmd = [backup_bin(), "-e", endpoint, "-d", database,
+                   "operation", "get", op_id, "--format", "proto-json-base64"]
+            try:
+                res = yatest.common.execute(cmd, check_exit_code=False)
+                output = (res.std_out or b"").decode("utf-8", "ignore")
+            except Exception as e:
+                logger.warning(f"Failed to get operation {op_id}: {e}")
+                time.sleep(poll_interval)
+                continue
+
+            try:
+                last_status = json.loads(output)
+            except (json.JSONDecodeError, TypeError):
+                last_status = {"raw": output}
 
             if verbose:
-                logger.info(f"[poll_restore] total={total} success={success} (start {start_total}/{start_success})")
+                ready = last_status.get("ready", False)
+                status = last_status.get("status", "UNKNOWN")
+                logger.info(f"[poll_restore_by_id] op={op_id} ready={ready} status={status}")
 
-            if total > start_total:
-                seen_more = True
-
-            if seen_more and success > start_success:
-                return True, {
-                    "start_total": start_total,
-                    "start_success": start_success,
-                    "last_total": last_total,
-                    "last_success": last_success,
-                }
+            if last_status.get("ready", False):
+                status = last_status.get("status", "")
+                if status == "SUCCESS":
+                    return True, {"operation_id": op_id, "status": last_status}
+                else:
+                    logger.error(f"Restore operation {op_id} finished with status={status}")
+                    return False, {"operation_id": op_id, "status": last_status}
 
             time.sleep(poll_interval)
 
-        return False, {
-            "start_total": start_total,
-            "start_success": start_success,
-            "last_total": last_total,
-            "last_success": last_success,
-        }
+        return False, {"operation_id": op_id, "status": last_status, "reason": "timeout"}
 
     def _copy_table(self, from_name: str, to_name: str):
         full_from = f"/Root/{from_name}"
@@ -1078,8 +1088,9 @@ class RestoreBuilder:
         # still being dropped or under CDC operation from a prior backup).
         max_retries = 10 if not self._should_fail else 0
         retry_delay = 2.0
+        baseline_ids = None
         for attempt in range(max_retries + 1):
-            start_total, start_success, _ = self.test._count_restore_operations()
+            baseline_ids = self.test._list_restore_operation_ids()
             res = self.test._execute_yql(f"RESTORE `{self._collection}`;")
 
             if res.exit_code == 0:
@@ -1122,14 +1133,20 @@ class RestoreBuilder:
             )
 
         if self._use_polling:
-            # Poll for completion
-            ok, info = self.test.poll_restore_by_count(
-                start_total=start_total,
-                start_success=start_success,
-                timeout_s=self._timeout,
-                poll_interval=2.0,
-                verbose=True
-            )
+            # Find the specific operation ID created by this RESTORE
+            new_op_id = self.test._find_new_restore_operation(baseline_ids)
+
+            if new_op_id:
+                ok, info = self.test.poll_restore_by_id(
+                    new_op_id,
+                    timeout_s=self._timeout,
+                    poll_interval=2.0,
+                    verbose=True
+                )
+            else:
+                logger.warning("Could not find restore operation ID, waiting for data directly")
+                ok = True
+                info = {"fallback": "no_operation_id"}
 
             if not ok:
                 return RestoreResult(
@@ -1669,6 +1686,10 @@ class TestFullCycleLocalBackupRestoreWIncr(BaseTestBackupInFiles):
             "CRITICAL: Restore from incremental-only collection succeeded but should have failed! "
             "This indicates a serious issue with incremental backup validation."
         )
+
+        # Wait for the failed operation to be fully finalized before
+        # proceeding to the next restore test.
+        time.sleep(5)
 
 
 class TestFullCycleLocalBackupRestoreWSchemaChange(BaseTestBackupInFiles):


### PR DESCRIPTION
Replace global restore operation counting (poll_restore_by_count) with
operation ID-based polling (poll_restore_by_id). The old approach counted
ALL restore operations via 'ydb operation list restore' and detected
completion by count deltas, which was racy — a late status update from a
prior restore could cause a false positive, making the test think the
current restore completed before it actually did.

Now we capture baseline operation IDs before RESTORE, diff after to find
the new operation, and poll it specifically with 'ydb operation get'.
Also add a settling delay after _test_incremental_only_restore_failure
to let its failed operation finalize before the next test starts.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
