### PR TITLE
EXT-2203 BS requests sources

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -3,6 +3,7 @@
 
 #include "blobstorage_pdisk_category.h"
 #include "blobstorage_relevance.h"
+#include "blobstorage_write_source.h"
 #include "boot_type.h"
 #include "events.h"
 #include "tablet_types.h"
@@ -1116,6 +1117,7 @@ struct TEvBlobStorage {
         const TInstant Deadline;
         const NKikimrBlobStorage::EPutHandleClass HandleClass;
         const ETactic Tactic;
+        const TWriteSource WriteSource;
         const bool IssueKeepFlag = false;
         const bool IgnoreBlock = false;
         const bool AlreadyEncrypted = false; // when set to true, no encryption is required
@@ -1132,6 +1134,7 @@ struct TEvBlobStorage {
             TInstant Deadline;
             NKikimrBlobStorage::EPutHandleClass HandleClass = NKikimrBlobStorage::TabletLog;
             ETactic Tactic = TacticDefault;
+            TWriteSource WriteSource;
             bool IssueKeepFlag = false;
             bool IgnoreBlock = false;
             bool AlreadyEncrypted = false;
@@ -1147,6 +1150,7 @@ struct TEvBlobStorage {
             , Deadline(origin.Deadline)
             , HandleClass(origin.HandleClass)
             , Tactic(origin.Tactic)
+            , WriteSource(origin.WriteSource)
             , IssueKeepFlag(origin.IssueKeepFlag)
             , IgnoreBlock(origin.IgnoreBlock)
             , AlreadyEncrypted(origin.AlreadyEncrypted)
@@ -1163,6 +1167,7 @@ struct TEvBlobStorage {
             , Deadline(parameters.Deadline)
             , HandleClass(parameters.HandleClass)
             , Tactic(parameters.Tactic)
+            , WriteSource(parameters.WriteSource)
             , IssueKeepFlag(parameters.IssueKeepFlag)
             , IgnoreBlock(parameters.IgnoreBlock)
             , AlreadyEncrypted(parameters.AlreadyEncrypted)
@@ -1817,6 +1822,7 @@ struct TEvBlobStorage {
         const ui32 Generation;
         const TInstant Deadline;
         const ui64 IssuerGuid = RandomNumber<ui64>() | 1;
+        const TWriteSource WriteSource;
         bool IsMonitored = true;
 
         TEvBlock(TCloneEventPolicy, const TEvBlock& origin)
@@ -1824,20 +1830,25 @@ struct TEvBlobStorage {
             , Generation(origin.Generation)
             , Deadline(origin.Deadline)
             , IssuerGuid(origin.IssuerGuid)
+            , WriteSource(origin.WriteSource)
             , IsMonitored(origin.IsMonitored)
         {}
 
-        TEvBlock(ui64 tabletId, ui32 generation, TInstant deadline)
+        TEvBlock(ui64 tabletId, ui32 generation, TInstant deadline,
+                TWriteSource writeSource)
             : TabletId(tabletId)
             , Generation(generation)
             , Deadline(deadline)
+            , WriteSource(writeSource)
         {}
 
-        TEvBlock(ui64 tabletId, ui32 generation, TInstant deadline, ui64 issuerGuid)
+        TEvBlock(ui64 tabletId, ui32 generation, TInstant deadline, ui64 issuerGuid,
+                TWriteSource writeSource)
             : TabletId(tabletId)
             , Generation(generation)
             , Deadline(deadline)
             , IssuerGuid(issuerGuid)
+            , WriteSource(writeSource)
         {}
 
         TString Print(bool isFull) const {
@@ -2489,6 +2500,8 @@ struct TEvBlobStorage {
 
         bool Decommission = false;
 
+        const TWriteSource WriteSource;
+
         TEvCollectGarbage(TCloneEventPolicy, const TEvCollectGarbage& origin)
             : TabletId(origin.TabletId)
             , RecordGeneration(origin.RecordGeneration)
@@ -2505,12 +2518,13 @@ struct TEvBlobStorage {
             , IsMonitored(origin.IsMonitored)
             , IgnoreBlock(origin.IgnoreBlock)
             , Decommission(origin.Decommission)
+            , WriteSource(origin.WriteSource)
         {}
 
         TEvCollectGarbage(ui64 tabletId, ui32 recordGeneration, ui32 perGenerationCounter, ui32 channel,
                 bool collect, ui32 collectGeneration,
                 ui32 collectStep, TVector<TLogoBlobID> *keep, TVector<TLogoBlobID> *doNotKeep, TInstant deadline,
-                bool isMultiCollectAllowed, bool hard = false, bool ignoreBlock = false)
+                bool isMultiCollectAllowed, TWriteSource writeSource, bool hard = false, bool ignoreBlock = false)
             : TabletId(tabletId)
             , RecordGeneration(recordGeneration)
             , PerGenerationCounter(perGenerationCounter)
@@ -2524,10 +2538,12 @@ struct TEvBlobStorage {
             , Collect(collect)
             , IsMultiCollectAllowed(isMultiCollectAllowed)
             , IgnoreBlock(ignoreBlock)
+            , WriteSource(writeSource)
         {}
 
         TEvCollectGarbage(ui64 tabletId, ui32 recordGeneration, ui32 channel, bool collect, ui32 collectGeneration,
-                ui32 collectStep, TVector<TLogoBlobID> *keep, TVector<TLogoBlobID> *doNotKeep, TInstant deadline)
+                ui32 collectStep, TVector<TLogoBlobID> *keep, TVector<TLogoBlobID> *doNotKeep, TInstant deadline,
+                TWriteSource writeSource)
             : TabletId(tabletId)
             , RecordGeneration(recordGeneration)
             , PerGenerationCounter(0)
@@ -2540,13 +2556,15 @@ struct TEvBlobStorage {
             , Hard(false)
             , Collect(collect)
             , IsMultiCollectAllowed(true)
+            , WriteSource(writeSource)
         {}
 
         static THolder<TEvCollectGarbage> CreateHardBarrier(ui64 tabletId, ui32 recordGeneration,
-                ui32 perGenerationCounter, ui32 channel, ui32 collectGeneration, ui32 collectStep, TInstant deadline) {
+                ui32 perGenerationCounter, ui32 channel, ui32 collectGeneration, ui32 collectStep, TInstant deadline,
+                TWriteSource writeSource) {
             return MakeHolder<TEvCollectGarbage>(tabletId, recordGeneration, perGenerationCounter, channel,
                     true /*collect*/, collectGeneration, collectStep, nullptr /*keep*/, nullptr /*doNotKeep*/,
-                    deadline, false /*isMultiCollectAllowed*/, true /*hard*/);
+                    deadline, false /*isMultiCollectAllowed*/, writeSource, true /*hard*/, false /*ignoreBlock*/);
         }
 
         TString Print(bool isFull) const {

--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1134,7 +1134,7 @@ struct TEvBlobStorage {
             TInstant Deadline;
             NKikimrBlobStorage::EPutHandleClass HandleClass = NKikimrBlobStorage::TabletLog;
             ETactic Tactic = TacticDefault;
-            TWriteSource WriteSource;
+            TWriteSource WriteSource = UnknownWriteSource();
             bool IssueKeepFlag = false;
             bool IgnoreBlock = false;
             bool AlreadyEncrypted = false;
@@ -1835,7 +1835,7 @@ struct TEvBlobStorage {
         {}
 
         TEvBlock(ui64 tabletId, ui32 generation, TInstant deadline,
-                TWriteSource writeSource)
+                TWriteSource writeSource = UnknownWriteSource())
             : TabletId(tabletId)
             , Generation(generation)
             , Deadline(deadline)
@@ -1843,7 +1843,7 @@ struct TEvBlobStorage {
         {}
 
         TEvBlock(ui64 tabletId, ui32 generation, TInstant deadline, ui64 issuerGuid,
-                TWriteSource writeSource)
+                TWriteSource writeSource = UnknownWriteSource())
             : TabletId(tabletId)
             , Generation(generation)
             , Deadline(deadline)
@@ -2524,7 +2524,8 @@ struct TEvBlobStorage {
         TEvCollectGarbage(ui64 tabletId, ui32 recordGeneration, ui32 perGenerationCounter, ui32 channel,
                 bool collect, ui32 collectGeneration,
                 ui32 collectStep, TVector<TLogoBlobID> *keep, TVector<TLogoBlobID> *doNotKeep, TInstant deadline,
-                bool isMultiCollectAllowed, TWriteSource writeSource, bool hard = false, bool ignoreBlock = false)
+                bool isMultiCollectAllowed, TWriteSource writeSource = UnknownWriteSource(), bool hard = false,
+                bool ignoreBlock = false)
             : TabletId(tabletId)
             , RecordGeneration(recordGeneration)
             , PerGenerationCounter(perGenerationCounter)
@@ -2543,7 +2544,7 @@ struct TEvBlobStorage {
 
         TEvCollectGarbage(ui64 tabletId, ui32 recordGeneration, ui32 channel, bool collect, ui32 collectGeneration,
                 ui32 collectStep, TVector<TLogoBlobID> *keep, TVector<TLogoBlobID> *doNotKeep, TInstant deadline,
-                TWriteSource writeSource)
+                TWriteSource writeSource = UnknownWriteSource())
             : TabletId(tabletId)
             , RecordGeneration(recordGeneration)
             , PerGenerationCounter(0)
@@ -2561,7 +2562,7 @@ struct TEvBlobStorage {
 
         static THolder<TEvCollectGarbage> CreateHardBarrier(ui64 tabletId, ui32 recordGeneration,
                 ui32 perGenerationCounter, ui32 channel, ui32 collectGeneration, ui32 collectStep, TInstant deadline,
-                TWriteSource writeSource) {
+                TWriteSource writeSource = UnknownWriteSource()) {
             return MakeHolder<TEvCollectGarbage>(tabletId, recordGeneration, perGenerationCounter, channel,
                     true /*collect*/, collectGeneration, collectStep, nullptr /*keep*/, nullptr /*doNotKeep*/,
                     deadline, false /*isMultiCollectAllowed*/, writeSource, true /*hard*/, false /*ignoreBlock*/);

--- a/ydb/core/base/blobstorage_write_source.h
+++ b/ydb/core/base/blobstorage_write_source.h
@@ -1,0 +1,281 @@
+#pragma once
+
+#include <limits>
+#include <type_traits>
+
+#include <util/system/types.h>
+
+namespace NKikimr {
+
+// XX(enum name, stable proto value)
+#define YDB_BLOBSTORAGE_WRITE_SOURCES(XX) \
+    /* Source is not classified; the producer did not attach an operation code. */ \
+    XX(Unknown, 0) \
+    \
+    /* Tablet part: */ \
+    \
+    /* Tablet WriteLog component writes the primary serialized tablet log entry blob. */ \
+    XX(WriteLogEntry, 1) \
+    /* Tablet WriteLog component writes reference blobs linked from the same log entry. */ \
+    XX(WriteLogReference, 2) \
+    /* Tablet block component writes generation block markers for BlobStorage. */ \
+    XX(BlockBlobStorage, 3) \
+    /* Tablet system GC component writes log-channel barrier advancement records. */ \
+    XX(GcLogChannel, 4) \
+    /* Tablet deletion component writes terminal hard barriers across tablet channels. */ \
+    XX(DeleteHardBarrier, 5) \
+    /* Tablet FlatExecutor compaction component writes blobs produced by page compaction. */ \
+    XX(FlatCompactionPut, 6) \
+    /* Tablet FlatExecutor GC component writes keep/do-not-keep sets and barrier advancement. */ \
+    XX(FlatCollectGarbage, 7) \
+    \
+    /* VDisk part: */ \
+    \
+    /* VDisk Skeleton handoff-delete component writes delete records for handoff LogoBlobs. */ \
+    XX(SkeletonHandoffDelLogoBlob, 1001) \
+    /* VDisk Skeleton bulk-SST import component writes records for attaching prebuilt SST data. */ \
+    XX(SkeletonAddBulkSst, 1002) \
+    /* VDisk Skeleton local-sync component writes synchronization payload records. */ \
+    XX(SkeletonLocalSyncData, 1003) \
+    /* VDisk Skeleton repair component writes reconciliation updates from Anubis/Osiris. */ \
+    XX(SkeletonAnubisOsirisPut, 1004) \
+    /* VDisk Skeleton phantom-blob component writes phantom detection records. */ \
+    XX(SkeletonPhantomBlobs, 1005) \
+    /* VDisk SyncLogKeeper committer writes SyncLog data pages into chunk storage. */ \
+    XX(SyncLogCommitterWrite, 1006) \
+    /* VDisk SyncLogKeeper committer writes SyncLog entry-point checkpoints. */ \
+    XX(SyncLogCommitterCommit, 1007) \
+    /* VDisk HugeKeeper allocation component writes chunk allocation commits. */ \
+    XX(HugeKeeperAllocChunk, 1008) \
+    /* VDisk HugeKeeper reclamation component writes chunk release commits. */ \
+    XX(HugeKeeperFreeChunk, 1009) \
+    /* VDisk HugeKeeper checkpoint component writes entry-point state. */ \
+    XX(HugeKeeperEntryPoint, 1010) \
+    /* IncrHuge keeper logger writes chunk queue state. */ \
+    XX(HugeKeeperProcessChunkQueue, 1011) \
+    /* IncrHuge keeper logger writes blob deletion queue state. */ \
+    XX(HugeKeeperProcessDeleteChunkQueueItem, 1012) \
+    /* VDisk Hull DB commit component writes new Hull entry-point and related chunk metadata. */ \
+    XX(HullDbCommit, 1013) \
+    /* VDisk Hull compaction component writes non-inline compaction output. */ \
+    XX(HullCompactWorkerWrite, 1014) \
+    /* VDisk Hull SST writer component writes buffered SST fragments into chunks. */ \
+    XX(HullWriteSst, 1015) \
+    /* VDisk ChunkKeeper component writes entry-point updates for chunk ownership state. */ \
+    XX(ChunkKeeperCommit, 1016) \
+    /* VDisk metadata component writes metadata entry-point checkpoints. */ \
+    XX(MetadataCommit, 1017) \
+    /* VDisk scrub repair component writes regenerated SST index data. */ \
+    XX(ScrubWrite, 1018) \
+    /* VDisk scrub component writes scrub-state checkpoints. */ \
+    XX(ScrubCommit, 1019) \
+    /* VDisk log-cutter component writes FirstLsnToKeep progression. */ \
+    XX(LogCutterCutLog, 1020) \
+    /* VDisk syncer component writes synchronization state checkpoints. */ \
+    XX(SyncerCommit, 1021) \
+    /* Bridge syncer writes garbage-collection barriers and flags during pile merge. */ \
+    XX(SyncerMergeGC, 1022) \
+    /* Bridge syncer writes tablet block records during pile merge. */ \
+    XX(SyncerMergeBlock, 1023) \
+    /* VDisk recovery component writes recovered huge blobs back into normal storage. */ \
+    XX(RecoveredHugeBlob, 1024) \
+    /* VDisk blob balancer component writes blobs as part of rebalancing operations. */ \
+    XX(BlobBalancer, 1025) \
+    /* VDisk scrub restore component writes reconstructed corrupted blob parts. */ \
+    XX(RestoredCorruptedBlob, 1026) \
+    /* DSProxy GET acceleration writes restored parts back to VDisks. */ \
+    XX(DSProxyGetAccelerate, 1027) \
+    /* VDisk defragmentation component rewrites blobs into new locations. */ \
+    XX(DefragRewrite, 1028) \
+    /* VDisk Skeleton VPatch component writes patched blob parts. */ \
+    XX(SkeletonVPatch, 1029) \
+    /* VDisk Skeleton force-block helper writes block records. */ \
+    XX(SkeletonForceBlock, 1030) \
+    /* IncrHuge keeper writes huge blob data chunks. */ \
+    XX(IncrHugeWrite, 1031) \
+    /* IncrHuge keeper writes index chunks. */ \
+    XX(IncrHugeIndexWrite, 1032) \
+    /* DSProxy PATCH fallback writes fully patched blobs through regular Put. */ \
+    XX(DSProxyPatch, 1033) \
+    /* Bridge syncer writes blobs while merging data between bridge piles. */ \
+    XX(SyncerMergePut, 1034) \
+    /* Bridge proxy restores missing blob copies detected by read/discover/range requests. */ \
+    XX(BridgeProxyRestorePut, 1035) \
+    /* VDisk Skeleton VMovedPatch fallback writes fully patched blobs through regular Put. */ \
+    XX(SkeletonVMovedPatch, 1036) \
+    \
+    /* PDisk: */ \
+    \
+    /* PDisk writes padding data to fill up a chunk after shredding. */ \
+    XX(ShredPadding, 2001) \
+    \
+    /* DDisk: */ \
+    \
+    /* DDiskActorBoot component writes initial log records during DDisk boot phase. */ \
+    XX(DDiskBoot, 3001) \
+    \
+    /* BlobDepot */ \
+    \
+    /* BlobDepot component writes block records for blocked tablets. */ \
+    XX(BlobDepotBlock, 4001) \
+    /* BlobDepot component writes garbage-collection barriers and flags. */ \
+    XX(BlobDepotGC, 4002) \
+    /* BlobDepot component writes copied/restored blobs during assimilation and decommit. */ \
+    XX(BlobDepotPut, 4003) \
+    \
+    /* KV: */ \
+    \
+    /* KeyValue component writes user blobs. */ \
+    XX(KeyValuePut, 5001) \
+    /* KeyValue component writes garbage-collection barriers and flags. */ \
+    XX(KeyValueGC, 5002) \
+    \
+    /* ColumnShard: */ \
+    \
+    /* ColumnShard component writes blob batches. */ \
+    XX(ColumnShardPut, 6001) \
+    /* ColumnShard component writes garbage-collection barriers and flags. */ \
+    XX(ColumnShardGC, 6002) \
+    \
+    /* Misc: */ \
+    \
+    /* BlobStorage load-test component writes synthetic workload traffic. */ \
+    XX(GroupWriteLoadActor, 7001)
+
+enum class TWriteSource : ui16 {
+#define YDB_WRITE_SOURCE_ENUM(name, value) name = value,
+    YDB_BLOBSTORAGE_WRITE_SOURCES(YDB_WRITE_SOURCE_ENUM)
+#undef YDB_WRITE_SOURCE_ENUM
+};
+
+namespace NWriteSourcePrivate {
+
+enum class EWriteSourceOrdinal : size_t {
+#define YDB_WRITE_SOURCE_ORDINAL(name, value) name,
+    YDB_BLOBSTORAGE_WRITE_SOURCES(YDB_WRITE_SOURCE_ORDINAL)
+#undef YDB_WRITE_SOURCE_ORDINAL
+    Count
+};
+
+} // namespace NWriteSourcePrivate
+
+struct TWriteSourceInfo {
+    TWriteSource Source;
+    size_t Ordinal;
+    const char* Name;
+};
+
+constexpr TWriteSource UnknownWriteSource() {
+    return TWriteSource::Unknown;
+}
+
+constexpr size_t UnknownWriteSourceOrdinal() {
+    return static_cast<size_t>(NWriteSourcePrivate::EWriteSourceOrdinal::Unknown);
+}
+
+constexpr size_t WriteSourceCount() {
+    return static_cast<size_t>(NWriteSourcePrivate::EWriteSourceOrdinal::Count);
+}
+
+constexpr bool IsKnownWriteSource(TWriteSource op) {
+    switch (op) {
+#define YDB_WRITE_SOURCE_CASE(name, value) case TWriteSource::name:
+        YDB_BLOBSTORAGE_WRITE_SOURCES(YDB_WRITE_SOURCE_CASE)
+#undef YDB_WRITE_SOURCE_CASE
+            return true;
+    }
+    return false;
+}
+
+constexpr size_t WriteSourceOrdinal(TWriteSource source) {
+    switch (source) {
+#define YDB_WRITE_SOURCE_ORDINAL(name, value) \
+        case TWriteSource::name: \
+            return static_cast<size_t>(NWriteSourcePrivate::EWriteSourceOrdinal::name);
+        YDB_BLOBSTORAGE_WRITE_SOURCES(YDB_WRITE_SOURCE_ORDINAL)
+#undef YDB_WRITE_SOURCE_ORDINAL
+    }
+
+    return UnknownWriteSourceOrdinal();
+}
+
+constexpr const char* WriteSourceName(TWriteSource source) {
+    switch (source) {
+#define YDB_WRITE_SOURCE_NAME(name, value) case TWriteSource::name: return #name;
+        YDB_BLOBSTORAGE_WRITE_SOURCES(YDB_WRITE_SOURCE_NAME)
+#undef YDB_WRITE_SOURCE_NAME
+    }
+
+    return "Unknown";
+}
+
+template <typename TCallback>
+constexpr void ForEachWriteSourceInfo(TCallback&& callback) {
+#define YDB_WRITE_SOURCE_INFO(name, value) \
+    callback(TWriteSourceInfo{ \
+        TWriteSource::name, \
+        static_cast<size_t>(NWriteSourcePrivate::EWriteSourceOrdinal::name), \
+        #name \
+    });
+    YDB_BLOBSTORAGE_WRITE_SOURCES(YDB_WRITE_SOURCE_INFO)
+#undef YDB_WRITE_SOURCE_INFO
+}
+
+constexpr bool ValidateWriteSources() {
+    if (WriteSourceCount() == 0 || UnknownWriteSourceOrdinal() != 0) {
+        return false;
+    }
+
+    bool valid = true;
+    bool seen[WriteSourceCount()] = {};
+
+    ForEachWriteSourceInfo([&](const TWriteSourceInfo& info) constexpr {
+        if (info.Ordinal >= WriteSourceCount() || !info.Name || !IsKnownWriteSource(info.Source)) {
+            valid = false;
+            return;
+        }
+
+        if (seen[info.Ordinal]) {
+            valid = false;
+            return;
+        }
+        seen[info.Ordinal] = true;
+    });
+
+    if (!valid) {
+        return false;
+    }
+
+    for (size_t i = 0; i < WriteSourceCount(); ++i) {
+        if (!seen[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static_assert(ValidateWriteSources(),
+    "WriteSource table must contain unique values and dense ordinals with Unknown at ordinal 0");
+
+constexpr TWriteSource WriteSourceFromProto(ui32 op) {
+    using TUnderlying = std::underlying_type_t<TWriteSource>;
+    if (op > static_cast<ui32>(std::numeric_limits<TUnderlying>::max())) {
+        return UnknownWriteSource();
+    }
+
+    const TWriteSource value = static_cast<TWriteSource>(static_cast<TUnderlying>(op));
+    return IsKnownWriteSource(value)
+        ? value
+        : UnknownWriteSource();
+}
+
+constexpr ui32 WriteSourceToProto(TWriteSource op) {
+    return IsKnownWriteSource(op)
+        ? static_cast<ui32>(op)
+        : static_cast<ui32>(UnknownWriteSource());
+}
+
+#undef YDB_BLOBSTORAGE_WRITE_SOURCES
+
+} // namespace NKikimr

--- a/ydb/core/blob_depot/agent/storage_put.cpp
+++ b/ydb/core/blob_depot/agent/storage_put.cpp
@@ -190,7 +190,14 @@ namespace NKikimr::NBlobDepot {
                     const auto& [id, groupId] = kind.MakeBlobId(Agent, BlobSeqId, type, 0, buffer.size());
                     Y_ABORT_UNLESS(!locator->HasGroupId() || locator->GetGroupId() == groupId);
                     locator->SetGroupId(groupId);
-                    auto ev = std::make_unique<TEvBlobStorage::TEvPut>(id, std::move(buffer), Request.Deadline, Request.HandleClass, Request.Tactic);
+                    auto ev = std::make_unique<TEvBlobStorage::TEvPut>(TEvBlobStorage::TEvPut::TParameters{
+                        .BlobId = id,
+                        .Buffer = std::move(buffer),
+                        .Deadline = Request.Deadline,
+                        .HandleClass = Request.HandleClass,
+                        .Tactic = Request.Tactic,
+                        .WriteSource = Request.WriteSource,
+                    });
                     ev->ExtraBlockChecks = Request.ExtraBlockChecks;
                     ev->ExtraBlockChecks.emplace_back(Request.Id.TabletID(), Request.Id.Generation());
                     YDB_LOG_TRACE_COMP(BLOB_DEPOT_EVENTS, "TEvPut_sendToProxy",

--- a/ydb/core/blob_depot/assimilator.cpp
+++ b/ydb/core/blob_depot/assimilator.cpp
@@ -103,7 +103,7 @@ namespace NKikimr::NBlobDepot {
             const bool del = Barrier.Generation() == Max<ui32>() && Barrier.Step() == Max<ui32>();
             auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(
                 TabletId, Max<ui32>(), del ? Max<ui32>() : PerGenerationCounter, Channel, true, Barrier.Generation(),
-                Barrier.Step(), nullptr, nullptr, TInstant::Max(), false, /*hard=*/ true
+                Barrier.Step(), nullptr, nullptr, TInstant::Max(), false, TWriteSource::BlobDepotGC, /*hard=*/ true
             );
             ev->Decommission = true;
             TActivationContext::Send(ParentId, std::move(ev), 0, PerGenerationCounter);
@@ -552,7 +552,12 @@ namespace NKikimr::NBlobDepot {
                         const auto blobSeqId = TBlobSeqId::FromSequentalNumber(channel.Index, Self->Executor()->Generation(), value);
                         const TLogoBlobID id = blobSeqId.MakeBlobId(Self->TabletID(), EBlobType::VG_DATA_BLOB, 0, resp.Id.BlobSize());
                         const ui64 putId = NextPutId++;
-                        SendToBSProxy(SelfId(), channel.GroupId, new TEvBlobStorage::TEvPut(id, TRcBuf(resp.Buffer), TInstant::Max()), putId);
+                        SendToBSProxy(SelfId(), channel.GroupId, new TEvBlobStorage::TEvPut(TEvBlobStorage::TEvPut::TParameters{
+                            .BlobId = id,
+                            .Buffer = TRope(TRcBuf(resp.Buffer)),
+                            .Deadline = TInstant::Max(),
+                            .WriteSource = TWriteSource::BlobDepotPut,
+                        }), putId);
                         const bool inserted = channel.AssimilatedBlobsInFlight.insert(value).second; // prevent from barrier advancing
                         Y_ABORT_UNLESS(inserted);
                         const bool inserted1 = Puts.try_emplace(putId, TData::TKey(resp.Id), it->first).second;

--- a/ydb/core/blob_depot/blocks.cpp
+++ b/ydb/core/blob_depot/blocks.cpp
@@ -216,7 +216,7 @@ namespace NKikimr::NBlobDepot {
                 {"groupId", groupId},
                 {"issuerGuid", IssuerGuid});
             SendToBSProxy(SelfId(), groupId, new TEvBlobStorage::TEvBlock(TabletId, BlockedGeneration, TInstant::Max(),
-                IssuerGuid), groupId);
+                IssuerGuid, TWriteSource::BlobDepotBlock), groupId);
         }
 
         void Handle(TEvBlobStorage::TEvBlockResult::TPtr ev) {

--- a/ydb/core/blob_depot/data_decommit.cpp
+++ b/ydb/core/blob_depot/data_decommit.cpp
@@ -423,8 +423,12 @@ namespace NKikimr::NBlobDepot {
                     {"cookie", Ev->Cookie},
                     {"key", key},
                     {"blobId", id});
-                SendToBSProxy(SelfId(), channel.GroupId, new TEvBlobStorage::TEvPut(id, TRcBuf(buffer), TInstant::Max()),
-                    (ui64)keep | (ui64)doNotKeep << 1);
+                SendToBSProxy(SelfId(), channel.GroupId, new TEvBlobStorage::TEvPut(TEvBlobStorage::TEvPut::TParameters{
+                        .BlobId = id,
+                        .Buffer = TRope(TRcBuf(buffer)),
+                        .Deadline = TInstant::Max(),
+                        .WriteSource = TWriteSource::BlobDepotPut,
+                    }), (ui64)keep | (ui64)doNotKeep << 1);
                 const bool inserted = channel.AssimilatedBlobsInFlight.insert(value).second; // prevent from barrier advancing
                 Y_ABORT_UNLESS(inserted);
                 const bool inserted1 = IdToKey.try_emplace(id, std::move(key)).second;

--- a/ydb/core/blob_depot/data_trash.cpp
+++ b/ydb/core/blob_depot/data_trash.cpp
@@ -48,7 +48,7 @@ namespace NKikimr::NBlobDepot {
         if (record.HardGenStep < hardGenStep) {
             auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(Self->TabletID(), generation,
                 record.PerGenerationCounter++, record.Channel, true, hardGenStep.Generation(), hardGenStep.Step(),
-                nullptr, nullptr, TInstant::Max(), false /*isMultiCollectAllowed*/, true /*hard*/);
+                nullptr, nullptr, TInstant::Max(), false /*isMultiCollectAllowed*/, TWriteSource::BlobDepotGC, true /*hard*/);
 
             std::optional<TLogoBlobID> minTrashId = record.Trash.empty()
                 ? std::nullopt
@@ -177,7 +177,7 @@ namespace NKikimr::NBlobDepot {
 
             auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(Self->TabletID(), generation,
                 record.PerGenerationCounter, record.Channel, collect, nextGenStep.Generation(), nextGenStep.Step(),
-                keep_.get(), doNotKeep_.get(), TInstant::Max(), true);
+                keep_.get(), doNotKeep_.get(), TInstant::Max(), true /*isMultiCollectAllowed*/, TWriteSource::BlobDepotGC);
 
             keep_.release();
             doNotKeep_.release();

--- a/ydb/core/blobstorage/bridge/proxy/bridge_proxy.cpp
+++ b/ydb/core/blobstorage/bridge/proxy/bridge_proxy.cpp
@@ -448,8 +448,16 @@ namespace NKikimr {
                     Y_ABORT_UNLESS(item.Id);
                     Y_ABORT_UNLESS(item.Buffer.size() == item.Id.BlobSize());
                     self.SendQuery(shared_from_this(), bridgePileId, std::make_unique<TEvBlobStorage::TEvPut>(
-                        item.Id, TRcBuf(item.Buffer), TInstant::Max(), handleClass, TEvBlobStorage::TEvPut::TacticDefault,
-                        item.IssueKeepFlag, true), {.Index = index});
+                        TEvBlobStorage::TEvPut::TParameters{
+                            .BlobId = item.Id,
+                            .Buffer = TRope(TRcBuf(item.Buffer)),
+                            .Deadline = TInstant::Max(),
+                            .HandleClass = handleClass,
+                            .Tactic = TEvBlobStorage::TEvPut::TacticDefault,
+                            .WriteSource = TWriteSource::BridgeProxyRestorePut,
+                            .IssueKeepFlag = item.IssueKeepFlag,
+                            .IgnoreBlock = true,
+                        }), {.Index = index});
                 }
 
                 IsRestoring = true;
@@ -761,7 +769,7 @@ namespace NKikimr {
                         // allow only keep flags to be sent
                         res = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(ev.TabletId, ev.RecordGeneration,
                             ev.PerGenerationCounter, ev.Channel, false, 0, 0, new TVector<TLogoBlobID>(*ev.Keep),
-                            nullptr, ev.Deadline, true, false, false);
+                            nullptr, ev.Deadline, true, ev.WriteSource, false, false);
                     }
                     [[fallthrough]];
                 case NKikimrBridge::TGroupState::WRITE_KEEP_BARRIER_DONOTKEEP:

--- a/ydb/core/blobstorage/bridge/syncer/syncer.cpp
+++ b/ydb/core/blobstorage/bridge/syncer/syncer.cpp
@@ -142,11 +142,11 @@ namespace NKikimr::NBridge {
                 // synced group has lesser blocked generation for this tablet than unsynced one: we need to update
                 // blocked generation in source group and this will lead to possible tablet restart
                 Y_ABORT_UNLESS(targetGeneration);
-                IssueQuery(false, std::make_unique<TEvBlobStorage::TEvBlock>(tabletId, *targetGeneration, TInstant::Max()));
+                IssueQuery(false, std::make_unique<TEvBlobStorage::TEvBlock>(tabletId, *targetGeneration, TInstant::Max(), TWriteSource::SyncerMergeBlock));
             } else if (targetGeneration < sourceGeneration) {
                 // we just need to update target group generation to current one in source group
                 Y_ABORT_UNLESS(sourceGeneration);
-                IssueQuery(true, std::make_unique<TEvBlobStorage::TEvBlock>(tabletId, *sourceGeneration, TInstant::Max()));
+                IssueQuery(true, std::make_unique<TEvBlobStorage::TEvBlock>(tabletId, *sourceGeneration, TInstant::Max(), TWriteSource::SyncerMergeBlock));
             }
         };
 
@@ -190,7 +190,7 @@ namespace NKikimr::NBridge {
                 if (item.RecordGeneration || item.PerGenerationCounter || item.CollectGeneration || item.CollectStep) {
                     IssueQuery(true, std::make_unique<TEvBlobStorage::TEvCollectGarbage>(sourceItem->TabletId,
                         item.RecordGeneration, item.PerGenerationCounter, sourceItem->Channel, true,
-                        item.CollectGeneration, item.CollectStep, nullptr, nullptr, TInstant::Max(), false, hard, true));
+                        item.CollectGeneration, item.CollectStep, nullptr, nullptr, TInstant::Max(), false, TWriteSource::SyncerMergeGC, hard, true));
                 }
             };
             issueCollectGarbage(sourceItem->Soft, targetItem ? &targetItem->Soft : nullptr, false);
@@ -262,7 +262,7 @@ namespace NKikimr::NBridge {
                 std::ranges::set_difference(tempKeep, *dkv, std::back_inserter(*kv)); // do not keep flag overrides keep
                 IssueQuery(true, std::make_unique<TEvBlobStorage::TEvCollectGarbage>(tabletId, Max<ui32>(), 0u, 0u,
                     false, 0u, 0u, kv->empty() ? nullptr : kv.release(), dkv->empty() ? nullptr : dkv.release(),
-                    TInstant::Max(), true, false, true));
+                    TInstant::Max(), true, TWriteSource::SyncerMergeGC, false, true));
             }
         };
 
@@ -468,9 +468,16 @@ namespace NKikimr::NBridge {
             for (size_t i = 0; i < msg.ResponseSz; ++i) {
                 if (auto& r = msg.Responses[i]; r.Status == NKikimrProto::OK) {
                     // rewrite this blob with keep flag, if set
-                    IssueQuery(true, std::make_unique<TEvBlobStorage::TEvPut>(r.Id, TRcBuf(r.Buffer), TInstant::Max(),
-                        NKikimrBlobStorage::TabletLog, TEvBlobStorage::TEvPut::TacticDefault, r.Keep,
-                        /*ignoreBlocks=*/ true));
+                    IssueQuery(true, std::make_unique<TEvBlobStorage::TEvPut>(TEvBlobStorage::TEvPut::TParameters{
+                        .BlobId = r.Id,
+                        .Buffer = TRope(TRcBuf(r.Buffer)),
+                        .Deadline = TInstant::Max(),
+                        .HandleClass = NKikimrBlobStorage::TabletLog,
+                        .Tactic = TEvBlobStorage::TEvPut::TacticDefault,
+                        .WriteSource = TWriteSource::SyncerMergePut,
+                        .IssueKeepFlag = r.Keep,
+                        .IgnoreBlock = true,
+                    }));
                 } else if (r.Status == NKikimrProto::NODATA) {
                     // this blob may have vanished, it's okay if we couldn't have read it; there was no matching target item
                     // so we don't need to issue any keep flags

--- a/ydb/core/blobstorage/ddisk/ddisk_actor_boot.cpp
+++ b/ydb/core/blobstorage/ddisk/ddisk_actor_boot.cpp
@@ -209,7 +209,7 @@ namespace NKikimr::NDDisk {
         cr.DeleteChunks = std::move(chunksToDelete);
 
         Send(BaseInfo.PDiskActorID, new NPDisk::TEvLog(PDiskParams->Owner, PDiskParams->OwnerRound, signature, cr,
-            TRcBuf(std::move(buffer)), {lsn, lsn}, nullptr));
+            TRcBuf(std::move(buffer)), {lsn, lsn}, nullptr, TWriteSource::DDiskBoot));
 
         LogCallbacks.emplace(lsn, std::move(callback));
     }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_block.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_block.cpp
@@ -16,6 +16,7 @@ class TBlobStorageGroupBlockRequest : public TBlobStorageGroupRequestActor {
     const ui32 Generation;
     const TInstant Deadline;
     const ui64 IssuerGuid;
+    const TWriteSource WriteSource;
     bool SeenAlready = false;
 
     TGroupQuorumTracker QuorumTracker;
@@ -110,13 +111,14 @@ class TBlobStorageGroupBlockRequest : public TBlobStorageGroupRequestActor {
             << " vdiskId# " << vdiskId
             << " node# " << Info->GetActorId(vdiskId).NodeId());
 
-        auto msg = std::make_unique<TEvBlobStorage::TEvVBlock>(TabletId, Generation, vdiskId, Deadline, IssuerGuid);
+        auto msg = std::make_unique<TEvBlobStorage::TEvVBlock>(TabletId, Generation, vdiskId, Deadline, WriteSource,
+            IssuerGuid);
         SendToQueue(std::move(msg), cookie);
     }
 
     std::unique_ptr<IEventBase> RestartQuery(ui32 counter) override {
         ++*Mon->NodeMon->RestartBlock;
-        auto ev = std::make_unique<TEvBlobStorage::TEvBlock>(TabletId, Generation, Deadline, IssuerGuid);
+        auto ev = std::make_unique<TEvBlobStorage::TEvBlock>(TabletId, Generation, Deadline, IssuerGuid, WriteSource);
         ev->RestartCounter = counter;
         return ev;
     }
@@ -137,6 +139,7 @@ public:
         , Generation(params.Common.Event->Generation)
         , Deadline(params.Common.Event->Deadline)
         , IssuerGuid(params.Common.Event->IssuerGuid)
+        , WriteSource(params.Common.Event->WriteSource)
         , QuorumTracker(Info.Get())
     {}
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_collect.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_collect.cpp
@@ -26,6 +26,7 @@ class TBlobStorageGroupCollectGarbageRequest : public TBlobStorageGroupRequestAc
     const bool Collect;
     const bool Decommission;
     const bool IgnoreBlock;
+    const TWriteSource WriteSource;
 
     TGroupQuorumTracker QuorumTracker;
 
@@ -117,7 +118,8 @@ class TBlobStorageGroupCollectGarbageRequest : public TBlobStorageGroupRequestAc
     void SendCollectGarbageRequest(const TVDiskID& vdiskId) {
         const ui64 cookie = TVDiskIdShort(vdiskId).GetRaw();
         auto msg = std::make_unique<TEvBlobStorage::TEvVCollectGarbage>(TabletId, RecordGeneration, PerGenerationCounter,
-            Channel, Collect, CollectGeneration, CollectStep, Hard, Keep.get(), DoNotKeep.get(), vdiskId, Deadline);
+            Channel, Collect, CollectGeneration, CollectStep, Hard, Keep.get(), DoNotKeep.get(), vdiskId, Deadline,
+            WriteSource);
         if (IgnoreBlock) {
             msg->Record.SetIgnoreBlock(true);
         }
@@ -128,8 +130,8 @@ class TBlobStorageGroupCollectGarbageRequest : public TBlobStorageGroupRequestAc
     std::unique_ptr<IEventBase> RestartQuery(ui32 counter) override {
         ++*Mon->NodeMon->RestartCollectGarbage;
         auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, RecordGeneration, PerGenerationCounter,
-            Channel, Collect, CollectGeneration, CollectStep, Keep.release(), DoNotKeep.release(), Deadline, false, Hard,
-            IgnoreBlock);
+            Channel, Collect, CollectGeneration, CollectStep, Keep.release(), DoNotKeep.release(), Deadline, false, WriteSource,
+            Hard, IgnoreBlock);
         ev->RestartCounter = counter;
         ev->Decommission = Decommission;
         return ev;
@@ -159,6 +161,7 @@ public:
         , Collect(params.Common.Event->Collect)
         , Decommission(params.Common.Event->Decommission)
         , IgnoreBlock(params.Common.Event->IgnoreBlock)
+        , WriteSource(params.Common.Event->WriteSource)
         , QuorumTracker(Info.Get())
     {}
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
@@ -302,7 +302,7 @@ void TGetImpl::PrepareVPuts(TLogContext &logCtx, TDeque<std::unique_ptr<TEvBlobS
         const bool checksumming = Blackboard.GroupQueues->ChecksumExpected(Info->GetTopology(), vdiskId,
             TGroupQueues::TVDisk::TQueues::VDiskQueueId(Blackboard.PutHandleClass));
         auto vput = std::make_unique<TEvBlobStorage::TEvVPut>(put.Id, put.Buffer, vdiskId, true, nullptr, Deadline,
-            Blackboard.PutHandleClass, checksumming);
+            Blackboard.PutHandleClass, checksumming, TWriteSource::DSProxyGetAccelerate);
         DSP_LOG_DEBUG_SX(logCtx, "BPG15", "Send put to orderNumber# " << put.OrderNumber << " vput# " << vput->ToString());
         History.AddVPutToWaitingList(put.Id, put.OrderNumber);
         outVPuts.push_back(std::move(vput));

--- a/ydb/core/blobstorage/dsproxy/dsproxy_multicollect.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_multicollect.cpp
@@ -31,6 +31,7 @@ class TBlobStorageGroupMultiCollectRequest : public TBlobStorageGroupRequestActo
     const bool Collect;
     const bool Decommission;
     const bool IgnoreBlock;
+    const TWriteSource WriteSource;
 
     ui64 FlagRequestsInFlight;
     ui64 CollectRequestsInFlight;
@@ -106,6 +107,7 @@ public:
         , Collect(params.Common.Event->Collect)
         , Decommission(params.Common.Event->Decommission)
         , IgnoreBlock(params.Common.Event->IgnoreBlock)
+        , WriteSource(params.Common.Event->WriteSource)
         , FlagRequestsInFlight(0)
         , CollectRequestsInFlight(0)
     {
@@ -150,7 +152,7 @@ public:
         std::unique_ptr<TEvBlobStorage::TEvCollectGarbage> ev(new TEvBlobStorage::TEvCollectGarbage(
             TabletId, RecordGeneration, PerGenerationCounter, Channel,
             isCollect, CollectGeneration, CollectStep, keepPart.release(), doNotKeepPart.release(), Deadline, false,
-            Hard, IgnoreBlock));
+            WriteSource, Hard, IgnoreBlock));
         ev->Decommission = Decommission; // retain decommission flag
         DSP_LOG_DEBUG_S("BPMC3", "SendRequest idx# " << idx
             << " withCollect# " << withCollect

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -212,8 +212,15 @@ public:
         Buffer = result->Responses[0].Buffer.ConvertToString();
         ApplyDiffs();
 
-        std::unique_ptr<TEvBlobStorage::TEvPut> put = std::make_unique<TEvBlobStorage::TEvPut>(PatchedId, Buffer, Deadline,
-                NKikimrBlobStorage::AsyncBlob, TEvBlobStorage::TEvPut::TacticDefault);
+        std::unique_ptr<TEvBlobStorage::TEvPut> put = std::make_unique<TEvBlobStorage::TEvPut>(
+                TEvBlobStorage::TEvPut::TParameters{
+                    .BlobId = PatchedId,
+                    .Buffer = TRope(Buffer),
+                    .Deadline = Deadline,
+                    .HandleClass = NKikimrBlobStorage::AsyncBlob,
+                    .Tactic = TEvBlobStorage::TEvPut::TacticDefault,
+                    .WriteSource = TWriteSource::DSProxyPatch,
+                });
         put->Orbit = std::move(Orbit);
         SendToProxy(std::move(put), OriginalId.Hash(), Span.GetTraceId());
     }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -573,6 +573,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
                     .Deadline = item.Deadline,
                     .HandleClass = HandleClass,
                     .Tactic = Tactic,
+                    .WriteSource = item.WriteSource,
                     .IssueKeepFlag = item.IssueKeepFlag,
                     .IgnoreBlock = item.IgnoreBlock,
                     .AlreadyEncrypted = item.AlreadyEncrypted,

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
@@ -60,13 +60,14 @@ private:
         bool AlreadyEncrypted = false;
         bool IsZeroEntry = false;
         std::vector<std::pair<ui64, ui32>> ExtraBlockChecks;
+        TWriteSource WriteSource;
         NWilson::TSpan Span;
         std::shared_ptr<TEvBlobStorage::TExecutionRelay> ExecutionRelay;
         TInstant Deadline;
 
         TBlobInfo(TLogoBlobID id, TRope&& buffer, TActorId recipient, ui64 cookie, NWilson::TTraceId traceId,
                 NLWTrace::TOrbit&& orbit, bool issueKeepFlag, bool ignoreBlock, bool alreadyEncrypted, bool isZeroEntry,
-                std::vector<std::pair<ui64, ui32>> extraBlockChecks, bool single,
+                std::vector<std::pair<ui64, ui32>> extraBlockChecks, TWriteSource writeSource, bool single,
                 std::shared_ptr<TEvBlobStorage::TExecutionRelay> executionRelay, TInstant deadline)
             : BlobId(id)
             , Buffer(std::move(buffer))
@@ -79,6 +80,7 @@ private:
             , AlreadyEncrypted(alreadyEncrypted)
             , IsZeroEntry(isZeroEntry)
             , ExtraBlockChecks(std::move(extraBlockChecks))
+            , WriteSource(writeSource)
             , Span(single ? NWilson::TSpan() : NWilson::TSpan(TWilson::BlobStorage, std::move(traceId), "DSProxy.Put.Blob"))
             , ExecutionRelay(std::move(executionRelay))
             , Deadline(deadline)
@@ -133,8 +135,9 @@ public:
     {
         BlobMap.emplace(ev->Id, Blobs.size());
         Blobs.emplace_back(ev->Id, std::move(ev->Buffer), recipient, cookie, std::move(traceId), std::move(ev->Orbit),
-            ev->IssueKeepFlag, ev->IgnoreBlock, ev->AlreadyEncrypted, ev->IsZeroEntry, std::move(ev->ExtraBlockChecks),
-            true, std::move(ev->ExecutionRelay), ev->Deadline);
+            ev->IssueKeepFlag, ev->IgnoreBlock, ev->AlreadyEncrypted, ev->IsZeroEntry,std::move(ev->ExtraBlockChecks), ev->WriteSource, true,
+            std::move(ev->ExecutionRelay),
+            ev->Deadline);
 
         auto& blob = Blobs.back();
         LWPROBE(DSProxyBlobPutTactics, blob.BlobId.TabletID(), Info->GroupID.GetRawId(), blob.BlobId.ToString(), Tactic,
@@ -166,7 +169,8 @@ public:
             BlobMap.emplace(msg.Id, Blobs.size());
             Blobs.emplace_back(msg.Id, std::move(msg.Buffer), ev->Sender, ev->Cookie, std::move(ev->TraceId),
                 std::move(msg.Orbit), msg.IssueKeepFlag, msg.IgnoreBlock, msg.AlreadyEncrypted, msg.IsZeroEntry,
-                std::move(msg.ExtraBlockChecks), false, std::move(msg.ExecutionRelay), msg.Deadline);
+                std::move(msg.ExtraBlockChecks),
+                msg.WriteSource, false, std::move(msg.ExecutionRelay), msg.Deadline);
 
             auto& blob = Blobs.back();
             LWPROBE(DSProxyBlobPutTactics, blob.BlobId.TabletID(), Info->GroupID.GetRawId(), blob.BlobId.ToString(), Tactic,
@@ -252,7 +256,7 @@ public:
                 auto [orderNumber, ptr] = *it++;
                 TBlobInfo& blob = Blobs[ptr->BlobIdx];
                 auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(ptr->Id, ptr->Buffer, vdiskId, false, nullptr,
-                    blob.Deadline, Blackboard.PutHandleClass, checksumming);
+                    blob.Deadline, Blackboard.PutHandleClass, checksumming, blob.WriteSource);
 
                 auto& record = ev->Record;
                 for (const auto& [tabletId, generation] : blob.ExtraBlockChecks) {
@@ -293,7 +297,7 @@ public:
                     auto [orderNumber, ptr] = *it++;
                     TBlobInfo& blob = Blobs[ptr->BlobIdx];
                     ev->AddVPut(ptr->Id, TRcBuf(ptr->Buffer), nullptr, blob.IssueKeepFlag, blob.IgnoreBlock,
-                        blob.IsZeroEntry, &blob.ExtraBlockChecks, blob.Span.GetTraceId(), checksumming);
+                        blob.IsZeroEntry, &blob.ExtraBlockChecks, blob.Span.GetTraceId(), checksumming, blob.WriteSource);
                     HandoffPartsSent += ptr->IsHandoff;
                     vput.AddSubrequest(ptr->Id);
                 }

--- a/ydb/core/blobstorage/incrhuge/incrhuge_keeper_log.cpp
+++ b/ydb/core/blobstorage/incrhuge/incrhuge_keeper_log.cpp
@@ -445,7 +445,7 @@ namespace NKikimr {
             TLsnSeg seg(item.Lsn, item.Lsn);
             ctx.Send(Keeper.State.Settings.PDiskActorId, new NPDisk::TEvLog(Keeper.State.PDiskParams->Owner,
                     Keeper.State.PDiskParams->OwnerRound, TLogSignature::SignatureIncrHugeChunks, commit, data,
-                    seg, Keeper.RegisterYardCallback(MakeCallback(std::move(callback)))));
+                    seg, Keeper.RegisterYardCallback(MakeCallback(std::move(callback))), TWriteSource::HugeKeeperProcessChunkQueue));
 
             if (item.Entrypoint) {
                 ProcessedChunksWithoutEntrypoint = 0;
@@ -681,7 +681,7 @@ namespace NKikimr {
             TLsnSeg seg(item.Lsn, item.Lsn);
             ctx.Send(Keeper.State.Settings.PDiskActorId, new NPDisk::TEvLog(Keeper.State.PDiskParams->Owner,
                     Keeper.State.PDiskParams->OwnerRound, TLogSignature::SignatureIncrHugeDeletes, commit, data,
-                    seg, Keeper.RegisterYardCallback(MakeCallback(std::move(callback)))));
+                    seg, Keeper.RegisterYardCallback(MakeCallback(std::move(callback))), TWriteSource::HugeKeeperProcessDeleteChunkQueueItem));
         }
 
         void TLogger::ApplyLogDeleteItem(TDeleteQueueItem& item, NKikimrProto::EReplyStatus status, IEventBase *msg,

--- a/ydb/core/blobstorage/incrhuge/incrhuge_keeper_write.cpp
+++ b/ydb/core/blobstorage/incrhuge/incrhuge_keeper_write.cpp
@@ -323,7 +323,8 @@ namespace NKikimr {
             auto writeMsg = std::make_unique<NPDisk::TEvChunkWrite>(Keeper.State.PDiskParams->Owner,
                     Keeper.State.PDiskParams->OwnerRound, item.ChunkIdx, offset,
                     new NPDisk::TEvChunkWrite::TNonOwningParts(item.Parts.data(), numParts), Keeper.RegisterYardCallback(
-                    MakeCallback(std::move(callback))), true, NPriWrite::HullHugeUserData, true);
+                    MakeCallback(std::move(callback))), true, NPriWrite::HullHugeUserData, TWriteSource::IncrHugeWrite,
+                    true);
             ctx.Send(Keeper.State.Settings.PDiskActorId, writeMsg.release());
             ++CurrentChunkWritesInFlight;
 
@@ -572,7 +573,7 @@ namespace NKikimr {
                     Keeper.State.PDiskParams->OwnerRound, item.ChunkIdx, offset,
                     new NPDisk::TEvChunkWrite::TNonOwningParts(item.Parts.data(), numParts),
                     Keeper.RegisterYardCallback(MakeCallback(std::move(callback))), true, NPriWrite::HullHugeUserData,
-                    true));
+                    TWriteSource::IncrHugeIndexWrite, true));
 
             // clear current chunk state
             Keeper.State.CurrentChunk = 0;

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -479,7 +479,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         auto request = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(tabletId, Max<ui32>(), Max<ui32>(), ui32(0),
                                                                      true, Max<ui32>(), Max<ui32>(),
                                                                      nullptr, nullptr, TInstant::Max(),
-                                                                     true, true);
+                                                                     true, TWriteSource::Unknown, true);
         request->IsMonitored = isMonitored;
         SendToBsProxy(runtime, sender, groupId, request.release());
         auto reply = runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvCollectGarbageResult>(sender);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -386,7 +386,7 @@ struct TEvLog : TEventLocal<TEvLog, TEvBlobStorage::EvLog> {
     using TCallback = std::unique_ptr<ICallback>;
 
     explicit TEvLog(TOwner owner, TOwnerRound ownerRound, TLogSignature signature,
-                    const TRcBuf &data, TLsnSeg seg, void *cookie, TWriteSource writeSource,
+                    const TRcBuf &data, TLsnSeg seg, void *cookie, TWriteSource writeSource = UnknownWriteSource(),
                     TCallback &&cb = TCallback())
         : Owner(owner)
         , OwnerRound(ownerRound)
@@ -409,7 +409,7 @@ struct TEvLog : TEventLocal<TEvLog, TEvBlobStorage::EvLog> {
 
     explicit TEvLog(TOwner owner, TOwnerRound ownerRound, TLogSignature signature,
                     const TCommitRecord &commitRecord,
-                    const TRcBuf &data, TLsnSeg seg, void *cookie, TWriteSource writeSource,
+                    const TRcBuf &data, TLsnSeg seg, void *cookie, TWriteSource writeSource = UnknownWriteSource(),
                     TCallback &&cb = TCallback())
         : Owner(owner)
         , OwnerRound(ownerRound)
@@ -1206,7 +1206,8 @@ struct TEvChunkWrite : TEventLocal<TEvChunkWrite, TEvBlobStorage::EvChunkWrite> 
 
 
     TEvChunkWrite(TOwner owner, TOwnerRound ownerRound, TChunkIdx chunkIdx, ui32 offset, TPartsPtr partsPtr,
-            void *cookie, bool doFlush, ui8 priorityClass, TWriteSource writeSource, bool isSeqWrite = true)
+            void *cookie, bool doFlush, ui8 priorityClass, TWriteSource writeSource = UnknownWriteSource(),
+            bool isSeqWrite = true)
         : ChunkIdx(chunkIdx)
         , Offset(offset)
         , PartsPtr(partsPtr)

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -5,6 +5,7 @@
 #include "blobstorage_pdisk_params.h"
 #include "blobstorage_pdisk_config.h"
 
+#include <ydb/core/base/blobstorage_write_source.h>
 #include <ydb/core/blobstorage/base/vdisk_lsn.h>
 #include <ydb/core/blobstorage/base/blobstorage_vdiskid.h>
 #include <ydb/core/blobstorage/base/bufferwithgaps.h>
@@ -385,7 +386,8 @@ struct TEvLog : TEventLocal<TEvLog, TEvBlobStorage::EvLog> {
     using TCallback = std::unique_ptr<ICallback>;
 
     explicit TEvLog(TOwner owner, TOwnerRound ownerRound, TLogSignature signature,
-                    const TRcBuf &data, TLsnSeg seg, void *cookie, TCallback &&cb = TCallback())
+                    const TRcBuf &data, TLsnSeg seg, void *cookie, TWriteSource writeSource,
+                    TCallback &&cb = TCallback())
         : Owner(owner)
         , OwnerRound(ownerRound)
         , Signature(signature)
@@ -393,6 +395,7 @@ struct TEvLog : TEventLocal<TEvLog, TEvBlobStorage::EvLog> {
         , LsnSegmentStart(seg.First)
         , Lsn(seg.Last)
         , Cookie(cookie)
+        , WriteSource(writeSource)
         , LogCallback(std::move(cb))
     {
         Y_VERIFY(Owner);
@@ -406,7 +409,8 @@ struct TEvLog : TEventLocal<TEvLog, TEvBlobStorage::EvLog> {
 
     explicit TEvLog(TOwner owner, TOwnerRound ownerRound, TLogSignature signature,
                     const TCommitRecord &commitRecord,
-                    const TRcBuf &data, TLsnSeg seg, void *cookie, TCallback &&cb = TCallback())
+                    const TRcBuf &data, TLsnSeg seg, void *cookie, TWriteSource writeSource,
+                    TCallback &&cb = TCallback())
         : Owner(owner)
         , OwnerRound(ownerRound)
         , Signature(signature, /*commitRecord*/ true)
@@ -414,6 +418,7 @@ struct TEvLog : TEventLocal<TEvLog, TEvBlobStorage::EvLog> {
         , LsnSegmentStart(seg.First)
         , Lsn(seg.Last)
         , Cookie(cookie)
+        , WriteSource(writeSource)
         , LogCallback(std::move(cb))
         , CommitRecord(commitRecord)
     {
@@ -457,6 +462,7 @@ struct TEvLog : TEventLocal<TEvLog, TEvBlobStorage::EvLog> {
                             // usually LsnSegmentStart=Lsn and this diapason is a single point
     ui64 Lsn;
     void *Cookie;
+    const TWriteSource WriteSource;
     TCallback LogCallback;
     TCommitRecord CommitRecord;
 
@@ -1089,6 +1095,7 @@ struct TEvChunkWrite : TEventLocal<TEvChunkWrite, TEvBlobStorage::EvChunkWrite> 
     TOwnerRound OwnerRound;
     ui8 PriorityClass;
     bool DoFlush;
+    const TWriteSource WriteSource;
     bool IsSeqWrite; // sequential write to this chunk (normally, it is 'true', for huge blobs -- 'false')
     TLogoBlobID BlobId; // when set, this blob id is used to salt sector hash
 
@@ -1199,7 +1206,7 @@ struct TEvChunkWrite : TEventLocal<TEvChunkWrite, TEvBlobStorage::EvChunkWrite> 
 
 
     TEvChunkWrite(TOwner owner, TOwnerRound ownerRound, TChunkIdx chunkIdx, ui32 offset, TPartsPtr partsPtr,
-            void *cookie, bool doFlush, ui8 priorityClass, bool isSeqWrite = true)
+            void *cookie, bool doFlush, ui8 priorityClass, TWriteSource writeSource, bool isSeqWrite = true)
         : ChunkIdx(chunkIdx)
         , Offset(offset)
         , PartsPtr(partsPtr)
@@ -1208,6 +1215,7 @@ struct TEvChunkWrite : TEventLocal<TEvChunkWrite, TEvBlobStorage::EvChunkWrite> 
         , OwnerRound(ownerRound)
         , PriorityClass(priorityClass)
         , DoFlush(doFlush)
+        , WriteSource(writeSource)
         , IsSeqWrite(isSeqWrite)
     {
         Validate();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -754,6 +754,7 @@ public:
         THolder<NPDisk::TEvLogResult> result(new NPDisk::TEvLogResult(NKikimrProto::CORRUPTED, 0, str.Str(), 0));
         result->Results.push_back(NPDisk::TEvLogResult::TRecord(evLog.Lsn, evLog.Cookie));
         PDisk->Mon.WriteLog.CountRequest(0);
+        PDisk->Mon.CountLogWriteOpRequest(evLog.WriteSource, evLog.Data.size());
         Send(ev->Sender, result.Release());
         PDisk->Mon.WriteLog.CountResponse();
     }
@@ -778,6 +779,7 @@ public:
         THolder<NPDisk::TEvLogResult> result(new NPDisk::TEvLogResult(NKikimrProto::CORRUPTED, 0, str.Str(), 0));
         for (auto &[log, _] : evMultiLog.Logs) {
             result->Results.push_back(NPDisk::TEvLogResult::TRecord(log->Lsn, log->Cookie));
+            PDisk->Mon.CountLogWriteOpRequest(log->WriteSource, log->Data.size());
         }
         PDisk->Mon.WriteLog.CountRequest(0);
         Send(ev->Sender, result.Release());
@@ -813,7 +815,9 @@ public:
 
     void ErrorHandle(NPDisk::TEvChunkWrite::TPtr &ev) {
         const NPDisk::TEvChunkWrite &evChunkWrite = *ev->Get();
+        const ui32 size = evChunkWrite.PartsPtr ? evChunkWrite.PartsPtr->ByteSize() : 0;
         PDisk->Mon.GetWriteCounter(evChunkWrite.PriorityClass)->CountRequest(0);
+        PDisk->Mon.CountChunkWriteOpRequest(evChunkWrite.WriteSource, size);
         PDisk->Mon.GetWriteCounter(evChunkWrite.PriorityClass)->CountResponse();
         auto res = std::make_unique<NPDisk::TEvChunkWriteResult>(NKikimrProto::CORRUPTED,
             evChunkWrite.ChunkIdx, evChunkWrite.Cookie, 0, StateErrorReason);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -4575,7 +4575,7 @@ void TPDisk::ProgressShredState() {
                 while (ShredLogPaddingInFlight < 2) {
                     TRcBuf data = TRcBuf::Uninitialized(2<<20);
                     memset(data.GetDataMut(), 0, data.Size());
-                    TEvLog evLog(OwnerUnallocated, 0, {}, data, {}, 0);
+                    TEvLog evLog(OwnerUnallocated, 0, {}, data, {}, 0, TWriteSource::ShredPadding);
                     double burstMs;
                     TLogWrite* request = ReqCreator.CreateLogWrite(evLog, PCtx->PDiskActor, burstMs, {});
                     request->Orbit = std::move(evLog.Orbit);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
@@ -276,8 +276,8 @@ TPDiskMon::TPDiskMon(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& count
     ChunkWriteOpCounters.resize(WriteSourceCount());
     ForEachWriteSourceInfo([&](const TWriteSourceInfo& info) {
         Y_ABORT_UNLESS(info.Ordinal < LogWriteOpCounters.size());
-        LogWriteOpCounters[info.Ordinal].Setup(true, PDiskGroup, TString(info.Name), EVisibility::Public);
-        ChunkWriteOpCounters[info.Ordinal].Setup(false, PDiskGroup, TString(info.Name), EVisibility::Public);
+        LogWriteOpCounters[info.Ordinal].Setup("Log", PDiskGroup, TString(info.Name), visibilityForExtended);
+        ChunkWriteOpCounters[info.Ordinal].Setup("Chunk", PDiskGroup, TString(info.Name), visibilityForExtended);
     });
 
     COUNTER_INIT(PDiskGroup, PDiskThreadCPU, true);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.cpp
@@ -272,6 +272,14 @@ TPDiskMon::TPDiskMon(const TIntrusivePtr<::NMonitoring::TDynamicCounters>& count
     IO_REQ_INIT_IF_EXTENDED(PDiskGroup, WriteHugeLog, WriteHugeLog);
     IO_REQ_INIT_IF_EXTENDED(PDiskGroup, LogRead, ReadLog);
 
+    LogWriteOpCounters.resize(WriteSourceCount());
+    ChunkWriteOpCounters.resize(WriteSourceCount());
+    ForEachWriteSourceInfo([&](const TWriteSourceInfo& info) {
+        Y_ABORT_UNLESS(info.Ordinal < LogWriteOpCounters.size());
+        LogWriteOpCounters[info.Ordinal].Setup(true, PDiskGroup, TString(info.Name), EVisibility::Public);
+        ChunkWriteOpCounters[info.Ordinal].Setup(false, PDiskGroup, TString(info.Name), EVisibility::Public);
+    });
+
     COUNTER_INIT(PDiskGroup, PDiskThreadCPU, true);
     COUNTER_INIT(PDiskGroup, SubmitThreadCPU, true);
     COUNTER_INIT(PDiskGroup, GetThreadCPU, true);
@@ -472,6 +480,18 @@ void TPDiskMon::UpdateStats() {
 
     *FreeSpacePerMile = freePerMile;
     *UsedSpacePerMile = usedPerMile;
+}
+
+void TPDiskMon::CountLogWriteOpRequest(const TWriteSource& source, ui32 size) {
+    const size_t ordinal = WriteSourceOrdinal(source);
+    Y_ABORT_UNLESS(ordinal < LogWriteOpCounters.size());
+    LogWriteOpCounters[ordinal].CountRequest(size);
+}
+
+void TPDiskMon::CountChunkWriteOpRequest(const TWriteSource& source, ui32 size) {
+    const size_t ordinal = WriteSourceOrdinal(source);
+    Y_ABORT_UNLESS(ordinal < ChunkWriteOpCounters.size());
+    ChunkWriteOpCounters[ordinal].CountRequest(size);
 }
 
 TPDiskMon::TIoCounters *TPDiskMon::GetWriteCounter(ui8 priority) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/blobstorage/base/common_latency_hist_bounds.h>
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
+#include <ydb/core/base/blobstorage_write_source.h>
 #include <ydb/core/mon/mon.h>
 #include <ydb/core/protos/blobstorage_disk.pb.h>
 #include <ydb/core/protos/node_whiteboard.pb.h>
@@ -12,6 +13,7 @@
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/monlib/dynamic_counters/percentile/percentile_lg.h>
+#include <util/generic/vector.h>
 
 
 namespace NKikimr {
@@ -476,6 +478,23 @@ struct TPDiskMon {
         }
     };
 
+    struct TOpCounters {
+        ::NMonitoring::TDynamicCounters::TCounterPtr Requests;
+        ::NMonitoring::TDynamicCounters::TCounterPtr Bytes;
+
+        void Setup(const bool isLog, const TIntrusivePtr<::NMonitoring::TDynamicCounters>& group, TString name,
+                NMonitoring::TCountableBase::EVisibility vis) {
+            TIntrusivePtr<::NMonitoring::TDynamicCounters> subgroup = group->GetSubgroup("op", name);
+            Requests = subgroup->GetCounter(isLog ? "LogRequestsByOp" : "ChunkRequestsByOp", true, vis);
+            Bytes = subgroup->GetCounter(isLog? "LogBytesByOp" : "ChunkBytesByOp", true, vis);
+        }
+
+        void CountRequest(ui32 size) {
+            Requests->Inc();
+            *Bytes += size;
+        }
+    };
+
     // yard subgroup
     TIntrusivePtr<::NMonitoring::TDynamicCounters> PDiskGroup;
     TReqCounters YardInit;
@@ -513,8 +532,10 @@ struct TPDiskMon {
     TIoCounters WriteLog;
     TReqCounters WriteHugeLog;
     TIoCounters LogRead;
+    TVector<TOpCounters> LogWriteOpCounters;
+    TVector<TOpCounters> ChunkWriteOpCounters;
 
-
+public:
     // Halter
     i64 LastHaltDeviceTakeoffs = 0;
     i64 LastHaltDeviceLandings = 0;
@@ -541,6 +562,8 @@ struct TPDiskMon {
     void UpdateLights();
     bool UpdateDeviceHaltCounters();
     void UpdateStats();
+    void CountLogWriteOpRequest(const TWriteSource& source, ui32 size);
+    void CountChunkWriteOpRequest(const TWriteSource& source, ui32 size);
     TIoCounters *GetWriteCounter(ui8 priority);
     TIoCounters *GetReadCounter(ui8 priority);
 };

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
@@ -482,11 +482,11 @@ struct TPDiskMon {
         ::NMonitoring::TDynamicCounters::TCounterPtr Requests;
         ::NMonitoring::TDynamicCounters::TCounterPtr Bytes;
 
-        void Setup(const bool isLog, const TIntrusivePtr<::NMonitoring::TDynamicCounters>& group, TString name,
+        void Setup(TString metricPrefix, const TIntrusivePtr<::NMonitoring::TDynamicCounters>& group, TString opName,
                 NMonitoring::TCountableBase::EVisibility vis) {
-            TIntrusivePtr<::NMonitoring::TDynamicCounters> subgroup = group->GetSubgroup("op", name);
-            Requests = subgroup->GetCounter(isLog ? "LogRequestsByOp" : "ChunkRequestsByOp", true, vis);
-            Bytes = subgroup->GetCounter(isLog? "LogBytesByOp" : "ChunkBytesByOp", true, vis);
+            TIntrusivePtr<::NMonitoring::TDynamicCounters> subgroup = group->GetSubgroup("op", opName);
+            Requests = subgroup->GetCounter(metricPrefix + "RequestsByOp", true, vis);
+            Bytes = subgroup->GetCounter(metricPrefix + "BytesByOp", true, vis);
         }
 
         void CountRequest(ui32 size) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_req_creator.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_req_creator.h
@@ -241,6 +241,7 @@ public:
         Mon->QueueRequests->Inc();
         *Mon->QueueBytes += ev.Data.size();
         Mon->WriteLog.CountRequest(ev.Data.size());
+        Mon->CountLogWriteOpRequest(ev.WriteSource, ev.Data.size());
         if (ev.Data.size() > (1 << 20)) {
             Mon->WriteHugeLog.CountRequest();
         }
@@ -287,6 +288,7 @@ public:
         ev.Validate();
         *Mon->QueueBytes += size;
         Mon->GetWriteCounter(ev.PriorityClass)->CountRequest(size);
+        Mon->CountChunkWriteOpRequest(ev.WriteSource, size);
         return NewRequest(new TChunkWrite(ev, sender, reqId, std::move(span)), &burstMs);
     }
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.cpp
@@ -443,7 +443,8 @@ void TTestChunkWrite20Read02::TestFSM(const TActorContext &ctx) {
         ChunkWriteParts[0].Data = ChunkWriteData.data();
         ChunkWriteParts[0].Size = (ui32)ChunkWriteData.size();
         ctx.Send(Yard, new NPDisk::TEvChunkWrite(Owner, OwnerRound, ChunkIdx, BlockSize * 3,
-            new NPDisk::TEvChunkWrite::TNonOwningParts(ChunkWriteParts.Get(), 1), (void*)42, true, 1, false));
+            new NPDisk::TEvChunkWrite::TNonOwningParts(ChunkWriteParts.Get(), 1), (void*)42, true, 1,
+            TWriteSource::Unknown, false));
         break;
     }
     case 40:
@@ -455,7 +456,8 @@ void TTestChunkWrite20Read02::TestFSM(const TActorContext &ctx) {
         ChunkWriteParts[0].Data = ChunkWriteData.data();
         ChunkWriteParts[0].Size = (ui32)ChunkWriteData.size();
         ctx.Send(Yard, new NPDisk::TEvChunkWrite(Owner, OwnerRound, ChunkIdx, BlockSize,
-            new NPDisk::TEvChunkWrite::TNonOwningParts(ChunkWriteParts.Get(), 1), (void*)42, true, 1, false));
+            new NPDisk::TEvChunkWrite::TNonOwningParts(ChunkWriteParts.Get(), 1), (void*)42, true, 1,
+            TWriteSource::Unknown, false));
         break;
     }
     case 50:

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_ut.cpp
@@ -509,6 +509,29 @@ void TestPayloadOffset(ui64 firstSector, ui64 lastSector, ui64 currentSector, ui
         UNIT_ASSERT(memcmp(data.Get(), readData.Get(), size) == 0);
     }
 
+    Y_UNIT_TEST(TPDiskMonWriteOpCounters) {
+        TIntrusivePtr<::NMonitoring::TDynamicCounters> counters = new ::NMonitoring::TDynamicCounters;
+        THolder<TPDiskMon> mon(new TPDiskMon(counters, 0, nullptr));
+
+        mon->CountLogWriteOpRequest(TWriteSource::WriteLogEntry, 100);
+        mon->CountLogWriteOpRequest(TWriteSource::SyncLogCommitterCommit, 200);
+        mon->CountLogWriteOpRequest(TWriteSource::Unknown, 300);
+
+        auto pdiskGroup = counters->GetSubgroup("subsystem", "pdisk");
+        auto getCounterValue = [&](const TString& opName, const TString& counterName) -> i64 {
+            return pdiskGroup->GetSubgroup("op", opName)->GetCounter(counterName, true)->Val();
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(getCounterValue("WriteLogEntry", "LogRequestsByOp"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(getCounterValue("WriteLogEntry", "LogBytesByOp"), 100);
+
+        UNIT_ASSERT_VALUES_EQUAL(getCounterValue("SyncLogCommitterCommit", "LogRequestsByOp"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(getCounterValue("SyncLogCommitterCommit", "LogBytesByOp"), 200);
+
+        UNIT_ASSERT_VALUES_EQUAL(getCounterValue("Unknown", "LogRequestsByOp"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(getCounterValue("Unknown", "LogBytesByOp"), 300);
+    }
+
     Y_UNIT_TEST(FormatSectorMap) {
         TIntrusivePtr<TSectorMap> sectorMap(new TSectorMap(1024*1024*1024));
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters = new ::NMonitoring::TDynamicCounters;

--- a/ydb/core/blobstorage/ut_blobstorage/assimilation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/assimilation.cpp
@@ -61,7 +61,7 @@ void RunAssimilationTest(bool reverse) {
             const bool hard = RandomNumber(2u);
             SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvCollectGarbage(tabletId, recordGen,
                 recordGenCounter, channel, true, collectGen, collectStep, nullptr, nullptr, TInstant::Max(),
-                false, hard));
+                false, TWriteSource::Unknown, hard));
 
             auto& x = barriers[std::make_pair(tabletId, channel)];
             (hard ? x.first : x.second) = {recordGen, recordGenCounter, collectGen, collectStep};

--- a/ydb/core/blobstorage/ut_blobstorage/blob_depot_event_managers.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/blob_depot_event_managers.cpp
@@ -478,8 +478,9 @@ void SendTEvCollectGarbage(TEnvironmentSetup& env, TActorId sender, ui32 groupId
     ui32 collectStep, TVector<TLogoBlobID> *keep, TVector<TLogoBlobID> *doNotKeep,
     bool isMultiCollectAllowed, bool hard, ui64 cookie)
 {
-    auto ev = new TEvBlobStorage::TEvCollectGarbage(tabletId, recordGeneration, perGenerationCounter, channel, collect, collectGeneration, collectStep,
-                keep, doNotKeep, TInstant::Max(), isMultiCollectAllowed, hard);
+    auto ev = new TEvBlobStorage::TEvCollectGarbage(tabletId, recordGeneration, perGenerationCounter, channel,
+                collect, collectGeneration, collectStep, keep, doNotKeep, TInstant::Max(), isMultiCollectAllowed,
+                TWriteSource::Unknown, hard);
 
 #ifdef LOG_COLLECT_GARBAGE
     Cerr << "Request# " << ev->Print(false) << Endl;

--- a/ydb/core/blobstorage/ut_blobstorage/block_race.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/block_race.cpp
@@ -21,7 +21,7 @@ Y_UNIT_TEST_SUITE(BlobStorageBlockRace) {
             env.WithQueueId(vdiskId, NKikimrBlobStorage::EVDiskQueueId::PutTabletLog, [&](const TActorId& queueId) {
                 const TActorId edge = runtime->AllocateEdgeActor(queueId.NodeId(), __FILE__, __LINE__);
                 runtime->Send(new IEventHandle(queueId, edge, new TEvBlobStorage::TEvVBlock(tabletId, 1, vdiskId,
-                    TInstant::Max(), guid)), edge.NodeId());
+                    TInstant::Max(), TWriteSource::Unknown, guid)), edge.NodeId());
                 auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVBlockResult>(edge);
                 status = res->Get()->Record.GetStatus();
             });
@@ -85,7 +85,7 @@ Y_UNIT_TEST_SUITE(BlobStorageBlockRace) {
         auto issue = [&](ui32 begin, ui32 end, ui64 guid) {
             for (ui32 i = begin; i < end; ++i) {
                 env.Runtime->Send(new IEventHandle(queues[i], edge, new TEvBlobStorage::TEvVBlock(tabletId, generation,
-                    info->GetVDiskId(i), TInstant::Max(), guid)), edge.NodeId());
+                    info->GetVDiskId(i), TInstant::Max(), TWriteSource::Unknown, guid)), edge.NodeId());
                 ++responsesPending;
             }
         };
@@ -171,7 +171,7 @@ Y_UNIT_TEST_SUITE(BlobStorageBlockRace) {
         auto issue = [&](ui32 begin, ui32 end, ui64 guid) {
             for (ui32 i = begin; i < end; ++i) {
                 env.Runtime->Send(new IEventHandle(queues[i], edge, new TEvBlobStorage::TEvVBlock(tabletId, generation,
-                    info->GetVDiskId(i), TInstant::Max(), guid)), edge.NodeId());
+                    info->GetVDiskId(i), TInstant::Max(), TWriteSource::Unknown, guid)), edge.NodeId());
             }
         };
 

--- a/ydb/core/blobstorage/ut_blobstorage/deadlines.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/deadlines.cpp
@@ -309,7 +309,8 @@ Y_UNIT_TEST_SUITE(Deadlines) {
             TInstant now = TAppData::TimeProvider->Now();
             ctx.Env->Runtime->WrapInActorContext(ctx.Edge, [&] {
                 SendToBSProxy(ctx.Edge, ctx.GroupId, new TEvBlobStorage::TEvCollectGarbage(tabletId, generation, 1, channel,
-                        true, generation, steps / 2, keep.release(), nullptr, now + timeout, multicollect, hard));
+                        true, generation, steps / 2, keep.release(), nullptr, now + timeout, multicollect,
+                        TWriteSource::Unknown, hard));
             });
         };
 

--- a/ydb/core/blobstorage/ut_blobstorage/gc.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/gc.cpp
@@ -46,7 +46,7 @@ Y_UNIT_TEST_SUITE(GarbageCollection) {
         runtime->WrapInActorContext(edge, [&] {
             SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvCollectGarbage(tabletId, recordGeneration,
                 perGenerationCounter, channel, true, collectGeneration, collectStep, nullptr, nullptr, TInstant::Max(),
-                false, false));
+                false, TWriteSource::Unknown, false));
         });
         {
             auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvCollectGarbageResult>(edge);

--- a/ydb/core/blobstorage/ut_blobstorage/index_restore_get.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/index_restore_get.cpp
@@ -39,7 +39,7 @@ Y_UNIT_TEST_SUITE(IndexRestoreGet) {
             env.Runtime->WrapInActorContext(edge, [&] {
                 SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvCollectGarbage(id.TabletID(), id.Generation(),
                     1, id.Channel(), true, id.Generation(), id.Step(), new TVector<TLogoBlobID>{id}, nullptr,
-                    TInstant::Max(), true, false));
+                    TInstant::Max(), true, TWriteSource::Unknown, false));
             });
             auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvCollectGarbageResult>(edge);
             UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);

--- a/ydb/core/blobstorage/ut_blobstorage/lib/activity.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/activity.h
@@ -154,7 +154,7 @@ public:
             IssueWrites();
         } else {
             auto msg = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, Generation, 1, 0, true,
-                Generation - 1, Max<ui32>(), nullptr, nullptr, TInstant::Max(), false, false);
+                Generation - 1, Max<ui32>(), nullptr, nullptr, TInstant::Max(), false, TWriteSource::Unknown, false);
             YDB_LOG_DEBUG_COMP(NActorsServices::TEST, "Sending",
                 {"prefix", Prefix},
                 {"TEvCollectGarbage", msg->ToString()});

--- a/ydb/core/blobstorage/ut_blobstorage/phantom_blobs.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/phantom_blobs.cpp
@@ -64,7 +64,7 @@ Y_UNIT_TEST_SUITE(PhantomBlobs) {
                 TString data;
                 SendToBSProxy(Edge, GroupId, new TEvBlobStorage::TEvCollectGarbage(
                         TabletId, Generation, ++GenerationCtr, Channel, true, Generation, Step,
-                        keepFlags, doNotKeepFlags, TInstant::Max(), true, false));
+                        keepFlags, doNotKeepFlags, TInstant::Max(), true, TWriteSource::Unknown, false));
             });
             Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvCollectGarbageResult>(
                     Edge, false, TInstant::Max());

--- a/ydb/core/blobstorage/vdisk/balance/sender.cpp
+++ b/ydb/core/blobstorage/vdisk/balance/sender.cpp
@@ -178,7 +178,8 @@ namespace {
                             key, std::move(data), vDiskId,
                             true, nullptr,
                             TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::AsyncBlob,
-                            false
+                            false,
+                            TWriteSource::BlobBalancer
                         );
                         SendRequest(TVDiskIdShort(vDiskId), selfId, ev.release(), dataSize);
                     } else {
@@ -191,7 +192,7 @@ namespace {
                         }
 
                         // TODO(alexvru): checksumming here
-                        ev->AddVPut(key, TRcBuf(std::move(data)), nullptr, false, true, false, {}, NWilson::TTraceId(), false);
+                        ev->AddVPut(key, TRcBuf(std::move(data)), nullptr, false, true, false, {}, NWilson::TTraceId(), false, TWriteSource::BlobBalancer);
                     }
                 }
             }

--- a/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
@@ -460,7 +460,8 @@ private:
 
         auto commitMsg = std::make_unique<NPDisk::TEvLog>(Ctx.LogCtx->PDiskCtx->Dsk->Owner,
                 Ctx.LogCtx->PDiskCtx->Dsk->OwnerRound, TLogSignature::SignatureChunkKeeper,
-                std::move(commitRecord), SerializeEntryPoint(), seg, nullptr);
+                std::move(commitRecord), SerializeEntryPoint(), seg, nullptr, TWriteSource::ChunkKeeperCommit,
+                NPDisk::TEvLog::TCallback());
 
         STLOG(PRI_DEBUG, BS_CHUNK_KEEPER, BSCK15, VDISKP(Ctx.LogCtx->VCtx, "Sending TEvLog"),
                 (Event, commitMsg->ToString()));
@@ -482,7 +483,7 @@ private:
                     return;
                 }
             } else {
-                Y_VERIFY_DEBUG_S(!DeletionsInFlight.contains(chunkIdx), Ctx.LogCtx->VCtx->VDiskLogPrefix << 
+                Y_VERIFY_DEBUG_S(!DeletionsInFlight.contains(chunkIdx), Ctx.LogCtx->VCtx->VDiskLogPrefix <<
                         "Chunk is being allocated and deleted simultaneously, ChunkIdx# " << chunkIdx);
             }
             auto* chunk = proto.AddChunks();

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.cpp
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.cpp
@@ -152,7 +152,9 @@ namespace NKikimr {
                 ui8 signature = TLogSignature::SignatureHullCutLog;
                 ctx.Send(LogCutterCtx.LoggerId,
                     new NPDisk::TEvLog(LogCutterCtx.PDiskCtx->Dsk->Owner,
-                        LogCutterCtx.PDiskCtx->Dsk->OwnerRound, signature, commitRec, TRcBuf(), seg, nullptr));
+                        LogCutterCtx.PDiskCtx->Dsk->OwnerRound, signature, commitRec, TRcBuf(), seg, nullptr,
+                        TWriteSource::LogCutterCutLog,
+                        NPDisk::TEvLog::TCallback()));
                 WriteInProgress = true;
                 FirstLsnToKeepLastWritten = curLsn;
 

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -593,7 +593,7 @@ namespace NKikimr {
         TEvVPut(const TLogoBlobID &logoBlobId, TRope buffer, const TVDiskID &vdisk,
                 const bool ignoreBlock, const ui64 *cookie, TInstant deadline,
                 NKikimrBlobStorage::EPutHandleClass cls, bool checksumming,
-                TWriteSource writeSource)
+                TWriteSource writeSource = UnknownWriteSource())
         {
             InitWithoutBuffer(logoBlobId, vdisk, ignoreBlock, cookie, deadline, cls, writeSource);
             StorePayload(std::move(buffer), checksumming);
@@ -601,7 +601,7 @@ namespace NKikimr {
 
         void InitWithoutBuffer(const TLogoBlobID &logoBlobId, const TVDiskID &vdisk, const bool ignoreBlock,
                 const ui64 *cookie, TInstant deadline, NKikimrBlobStorage::EPutHandleClass cls,
-                TWriteSource writeSource)
+                TWriteSource writeSource = UnknownWriteSource())
         {
             REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&logoBlobId, sizeof(logoBlobId));
             REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&vdisk, sizeof(vdisk));
@@ -899,7 +899,7 @@ namespace NKikimr {
         void AddVPut(const TLogoBlobID &logoBlobId, const TRcBuf &buffer, ui64 *cookie, bool issueKeepFlag, bool ignoreBlock,
                 bool isZeroEntry, std::vector<std::pair<ui64, ui32>> *extraBlockChecks, NWilson::TTraceId traceId,
                 bool checksumming,
-                TWriteSource writeSource) {
+                TWriteSource writeSource = UnknownWriteSource()) {
             NKikimrBlobStorage::TVMultiPutItem *item = Record.AddItems();
             LogoBlobIDFromLogoBlobID(logoBlobId, item->MutableBlobID());
             item->SetFullDataSize(logoBlobId.BlobSize());
@@ -1865,8 +1865,8 @@ namespace NKikimr {
         TEvVBlock()
         {}
 
-        TEvVBlock(ui64 tabletId, ui32 generation, const TVDiskID &vdisk, TInstant deadline, TWriteSource writeSource,
-                ui64 issuerGuid = 0)
+        TEvVBlock(ui64 tabletId, ui32 generation, const TVDiskID &vdisk, TInstant deadline,
+                TWriteSource writeSource = UnknownWriteSource(), ui64 issuerGuid = 0)
         {
             Record.SetTabletId(tabletId);
             Record.SetGeneration(generation);
@@ -2433,7 +2433,7 @@ namespace NKikimr {
             ui32 collectGeneration, ui32 collectStep, bool hard,
             const TVector<TLogoBlobID> *keep, const TVector<TLogoBlobID> *doNotKeep,
             const TVDiskID &vdisk, TInstant deadline,
-            TWriteSource writeSource)
+            TWriteSource writeSource = UnknownWriteSource())
         {
             Record.SetTabletId(tabletId);
             Record.SetRecordGeneration(recordGeneration);

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -14,6 +14,7 @@
 #include <ydb/core/blobstorage/vdisk/protos/events.pb.h>
 #include <ydb/core/blobstorage/storagepoolmon/storagepool_counters.h>
 #include <ydb/core/base/blobstorage_common.h>
+#include <ydb/core/base/blobstorage_write_source.h>
 
 #include <ydb/core/base/event_filter.h>
 #include <ydb/core/base/interconnect_channels.h>
@@ -591,14 +592,16 @@ namespace NKikimr {
 
         TEvVPut(const TLogoBlobID &logoBlobId, TRope buffer, const TVDiskID &vdisk,
                 const bool ignoreBlock, const ui64 *cookie, TInstant deadline,
-                NKikimrBlobStorage::EPutHandleClass cls, bool checksumming)
+                NKikimrBlobStorage::EPutHandleClass cls, bool checksumming,
+                TWriteSource writeSource)
         {
-            InitWithoutBuffer(logoBlobId, vdisk, ignoreBlock, cookie, deadline, cls);
+            InitWithoutBuffer(logoBlobId, vdisk, ignoreBlock, cookie, deadline, cls, writeSource);
             StorePayload(std::move(buffer), checksumming);
         }
 
         void InitWithoutBuffer(const TLogoBlobID &logoBlobId, const TVDiskID &vdisk, const bool ignoreBlock,
-                const ui64 *cookie, TInstant deadline, NKikimrBlobStorage::EPutHandleClass cls)
+                const ui64 *cookie, TInstant deadline, NKikimrBlobStorage::EPutHandleClass cls,
+                TWriteSource writeSource)
         {
             REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&logoBlobId, sizeof(logoBlobId));
             REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&vdisk, sizeof(vdisk));
@@ -621,6 +624,9 @@ namespace NKikimr {
             }
             Record.SetHandleClass(cls);
             Record.MutableMsgQoS()->SetExtQueueId(HandleClassToQueueId(cls));
+            if (writeSource != TWriteSource::Unknown) {
+                Record.SetWriteSourceOp(WriteSourceToProto(writeSource));
+            }
         }
 
         bool GetIgnoreBlock() const {
@@ -892,7 +898,8 @@ namespace NKikimr {
 
         void AddVPut(const TLogoBlobID &logoBlobId, const TRcBuf &buffer, ui64 *cookie, bool issueKeepFlag, bool ignoreBlock,
                 bool isZeroEntry, std::vector<std::pair<ui64, ui32>> *extraBlockChecks, NWilson::TTraceId traceId,
-                bool checksumming) {
+                bool checksumming,
+                TWriteSource writeSource) {
             NKikimrBlobStorage::TVMultiPutItem *item = Record.AddItems();
             LogoBlobIDFromLogoBlobID(logoBlobId, item->MutableBlobID());
             item->SetFullDataSize(logoBlobId.BlobSize());
@@ -919,6 +926,9 @@ namespace NKikimr {
             }
             if (traceId) {
                 traceId.Serialize(item->MutableTraceId());
+            }
+            if (writeSource != TWriteSource::Unknown) {
+                item->SetWriteSourceOp(WriteSourceToProto(writeSource));
             }
         }
 
@@ -1855,7 +1865,8 @@ namespace NKikimr {
         TEvVBlock()
         {}
 
-        TEvVBlock(ui64 tabletId, ui32 generation, const TVDiskID &vdisk, TInstant deadline, ui64 issuerGuid = 0)
+        TEvVBlock(ui64 tabletId, ui32 generation, const TVDiskID &vdisk, TInstant deadline, TWriteSource writeSource,
+                ui64 issuerGuid = 0)
         {
             Record.SetTabletId(tabletId);
             Record.SetGeneration(generation);
@@ -1867,6 +1878,9 @@ namespace NKikimr {
                 Record.MutableMsgQoS()->SetDeadlineSeconds((ui32)deadline.Seconds());
             }
             Record.MutableMsgQoS()->SetExtQueueId(NKikimrBlobStorage::EVDiskQueueId::PutTabletLog);
+            if (writeSource != TWriteSource::Unknown) {
+                Record.SetWriteSourceOp(WriteSourceToProto(writeSource));
+            }
         }
     };
 
@@ -2418,7 +2432,8 @@ namespace NKikimr {
         TEvVCollectGarbage(ui64 tabletId, ui32 recordGeneration, ui32 perGenerationCounter, ui32 channel, bool collect,
             ui32 collectGeneration, ui32 collectStep, bool hard,
             const TVector<TLogoBlobID> *keep, const TVector<TLogoBlobID> *doNotKeep,
-            const TVDiskID &vdisk, TInstant deadline)
+            const TVDiskID &vdisk, TInstant deadline,
+            TWriteSource writeSource)
         {
             Record.SetTabletId(tabletId);
             Record.SetRecordGeneration(recordGeneration);
@@ -2444,6 +2459,9 @@ namespace NKikimr {
             }
             VDiskIDFromVDiskID(vdisk, Record.MutableVDiskID());
             Record.MutableMsgQoS()->SetExtQueueId(NKikimrBlobStorage::EVDiskQueueId::PutTabletLog);
+            if (writeSource != TWriteSource::Unknown) {
+                Record.SetWriteSourceOp(WriteSourceToProto(writeSource));
+            }
         }
 
         TString ToString() const override {

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
@@ -169,7 +169,7 @@ namespace NKikimr {
             auto msgSize = rope.size();
             auto writeEvent = std::make_unique<TEvBlobStorage::TEvVPut>(rec.LogoBlobId, std::move(rope),
                 SelfVDiskId, true, nullptr, TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::AsyncBlob,
-                DCtx->VCfg->BlobHeaderMode == EBlobHeaderMode::XXH3_64BIT_HEADER);
+                DCtx->VCfg->BlobHeaderMode == EBlobHeaderMode::XXH3_64BIT_HEADER, TWriteSource::DefragRewrite);
             writeEvent->RewriteBlob = true;
             TEventsQuoter::QuoteMessage(DCtx->Throttler, std::make_unique<IEventHandle>(DCtx->SkeletonId, SelfId(), writeEvent.release()),
                 msgSize, DCtx->VCfg->DefragThrottlerBytesRate);

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
@@ -214,7 +214,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             Span && Span.Event("Send_TEvChunkWrite", {{"ChunkId", chunkId}, {"Offset", offset}, {"WrittenSize", writtenSize}});
             auto ev = std::make_unique<NPDisk::TEvChunkWrite>(HugeKeeperCtx->PDiskCtx->Dsk->Owner,
                         HugeKeeperCtx->PDiskCtx->Dsk->OwnerRound, chunkId, offset,
-                        partsPtr, Cookie, true, GetWritePriority(), false);
+                        partsPtr, Cookie, true, GetWritePriority(), Item->WriteSource, false);
             if (AppData()->FeatureFlags.GetEnableBlobIdInSectorChecksum()) {
                 ev->BlobId = Item->LogoBlobId;
             }
@@ -237,7 +237,8 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             ctx.Send(NotifyID, new TEvHullHugeWritten(HugeSlot));
             ctx.Send(HugeKeeperCtx->SkeletonId, new TEvHullLogHugeBlob(WriteId, Item->LogoBlobId, Item->Ingress,
                 DiskAddr, Item->IgnoreBlock, Item->IssueKeepFlag, Item->SenderId, Item->Cookie, Item->HandleClass,
-                std::move(Item->Result), &Item->ExtraBlockChecks, Item->RewriteBlob), 0, 0, Span.GetTraceId());
+                std::move(Item->Result), &Item->ExtraBlockChecks, Item->WriteSource, Item->RewriteBlob), 0, 0,
+                Span.GetTraceId());
             LOG_DEBUG(ctx, BS_HULLHUGE,
                       VDISKP(HugeKeeperCtx->VCtx->VDiskLogPrefix,
                             "Writer: finish: id# %s diskAddr# %s",
@@ -347,7 +348,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
 
             ctx.Send(HugeKeeperCtx->LoggerId, new NPDisk::TEvLog(HugeKeeperCtx->PDiskCtx->Dsk->Owner,
                 HugeKeeperCtx->PDiskCtx->Dsk->OwnerRound, TLogSignature::SignatureHugeBlobAllocChunk,
-                commitRecord, data, TLsnSeg(Lsn, Lsn), nullptr));
+                commitRecord, data, TLsnSeg(Lsn, Lsn), nullptr, TWriteSource::HugeKeeperAllocChunk, NPDisk::TEvLog::TCallback()));
 
             // commit changes to the persistent state at once
             const ui64 prevLsn = std::exchange(Pers->LogPos.ChunkAllocationLsn, Lsn);
@@ -433,7 +434,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             // send log message
             ctx.Send(HugeKeeperCtx->LoggerId, new NPDisk::TEvLog(HugeKeeperCtx->PDiskCtx->Dsk->Owner,
                 HugeKeeperCtx->PDiskCtx->Dsk->OwnerRound, TLogSignature::SignatureHugeBlobFreeChunk,
-                commitRecord, data, TLsnSeg(Lsn, Lsn), nullptr));
+                commitRecord, data, TLsnSeg(Lsn, Lsn), nullptr, TWriteSource::HugeKeeperFreeChunk, NPDisk::TEvLog::TCallback()));
             TThis::Become(&TThis::StateFunc);
         }
 
@@ -497,7 +498,9 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             TLsnSeg seg(EntryPointLsn, EntryPointLsn);
             ctx.Send(HugeKeeperCtx->LoggerId,
                     new NPDisk::TEvLog(HugeKeeperCtx->PDiskCtx->Dsk->Owner, HugeKeeperCtx->PDiskCtx->Dsk->OwnerRound,
-                        TLogSignature::SignatureHugeBlobEntryPoint, commitRecord, TRcBuf(Serialized), seg, nullptr)); //FIXME(innokentii): wrapping
+                        TLogSignature::SignatureHugeBlobEntryPoint, commitRecord, TRcBuf(Serialized), seg, nullptr,
+                        TWriteSource::HugeKeeperEntryPoint,
+                        NPDisk::TEvLog::TCallback())); //FIXME(innokentii): wrapping
             TThis::Become(&TThis::StateFunc);
         }
 

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.h
@@ -39,7 +39,7 @@ namespace NKikimr {
                              NKikimrBlobStorage::EPutHandleClass handleClass,
                              std::unique_ptr<TEvBlobStorage::TEvVPutResult> result,
                              NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TEvVPut::TExtraBlockCheck> *extraBlockChecks,
-                             TWriteSource writeSource,
+                             TWriteSource writeSource = UnknownWriteSource(),
                              bool rewriteBlob = false)
             : SenderId(senderId)
             , Cookie(cookie)

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.h
@@ -22,6 +22,7 @@ namespace NKikimr {
         const bool IgnoreBlock;
         const bool IssueKeepFlag;
         const NKikimrBlobStorage::EPutHandleClass HandleClass;
+        const TWriteSource WriteSource;
         std::unique_ptr<TEvBlobStorage::TEvVPutResult> Result;
         NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TEvVPut::TExtraBlockCheck> ExtraBlockChecks;
         const bool RewriteBlob;
@@ -38,6 +39,7 @@ namespace NKikimr {
                              NKikimrBlobStorage::EPutHandleClass handleClass,
                              std::unique_ptr<TEvBlobStorage::TEvVPutResult> result,
                              NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TEvVPut::TExtraBlockCheck> *extraBlockChecks,
+                             TWriteSource writeSource,
                              bool rewriteBlob = false)
             : SenderId(senderId)
             , Cookie(cookie)
@@ -47,6 +49,7 @@ namespace NKikimr {
             , IgnoreBlock(ignoreBlock)
             , IssueKeepFlag(issueKeepFlag)
             , HandleClass(handleClass)
+            , WriteSource(writeSource)
             , Result(std::move(result))
             , RewriteBlob(rewriteBlob)
         {
@@ -80,6 +83,7 @@ namespace NKikimr {
         const TActorId OrigClient;
         const ui64 OrigCookie;
         const NKikimrBlobStorage::EPutHandleClass HandleClass;
+        const TWriteSource WriteSource;
         std::unique_ptr<TEvBlobStorage::TEvVPutResult> Result;
         NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TEvVPut::TExtraBlockCheck> ExtraBlockChecks;
         const bool RewriteBlob;
@@ -95,6 +99,7 @@ namespace NKikimr {
                            NKikimrBlobStorage::EPutHandleClass handleClass,
                            std::unique_ptr<TEvBlobStorage::TEvVPutResult> result,
                            NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TEvVPut::TExtraBlockCheck> *extraBlockChecks,
+                           TWriteSource writeSource,
                            bool rewriteBlob = false)
             : WriteId(writeId)
             , LogoBlobID(logoBlobID)
@@ -105,6 +110,7 @@ namespace NKikimr {
             , OrigClient(origClient)
             , OrigCookie(origCookie)
             , HandleClass(handleClass)
+            , WriteSource(writeSource)
             , Result(std::move(result))
             , RewriteBlob(rewriteBlob)
         {

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwritesst.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwritesst.h
@@ -123,7 +123,8 @@ namespace NKikimr {
                 Y_ABORT_UNLESS(offsetInChunk % AppendBlockSize == 0);
                 Y_ABORT_UNLESS(ChunkIdx);
                 NPDisk::TEvChunkWrite::TPartsPtr parts(new NPDisk::TEvChunkWrite::TBufBackedUpParts(std::move(Buffer)));
-                auto ev = std::make_unique<NPDisk::TEvChunkWrite>(Owner, OwnerRound, ChunkIdx, offsetInChunk, parts, nullptr, true, Priority);
+                auto ev = std::make_unique<NPDisk::TEvChunkWrite>(Owner, OwnerRound, ChunkIdx, offsetInChunk, parts,
+                    nullptr, true, Priority, TWriteSource::HullWriteSst, true);
                 MsgQueue.push(std::move(ev));
                 HasBuffer = false;
             }

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcommit.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcommit.h
@@ -280,7 +280,7 @@ namespace NKikimr {
                 TString data = GenerateEntryPointData();
                 // create sync log message covering this segment; it will be issued when log entry is written
                 CommitMsg = CreateHullUpdate(HullLogCtx, PDiskSignatureForHullDbKey<TKey>(), CommitRecord,
-                    data, LsnSeg, nullptr, nullptr);
+                    data, LsnSeg, nullptr, nullptr, TWriteSource::HullDbCommit);
             } else {
                 LsnSeg = Ctx->LsnMngr->AllocLsnForLocalUse();
                 DebugMessage << "Db# " << TKey::Name()
@@ -291,7 +291,7 @@ namespace NKikimr {
                 }
                 TRcBuf data = TRcBuf(GenerateEntryPointData());
                 CommitMsg = std::make_unique<NPDisk::TEvLog>(Ctx->PDiskCtx->Dsk->Owner, Ctx->PDiskCtx->Dsk->OwnerRound,
-                    PDiskSignatureForHullDbKey<TKey>(), CommitRecord, data, LsnSeg, nullptr);
+                    PDiskSignatureForHullDbKey<TKey>(), CommitRecord, data, LsnSeg, nullptr, TWriteSource::HullDbCommit, NPDisk::TEvLog::TCallback());
             }
         }
 

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
@@ -66,7 +66,8 @@ namespace NKikimr {
                     void *cookie = nullptr;
                     auto write = std::make_unique<NPDisk::TEvChunkWrite>(Worker->PDiskCtx->Dsk->Owner,
                         Worker->PDiskCtx->Dsk->OwnerRound, preallocatedLocation.ChunkIdx, preallocatedLocation.Offset,
-                        partsPtr, cookie, true, NPriWrite::HullComp, false);
+                        partsPtr, cookie, true, NPriWrite::HullComp, TWriteSource::HullCompactWorkerWrite,
+                        false);
                     Worker->PendingWrites.push_back(std::move(write));
                 }
             }

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hulllog.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hulllog.cpp
@@ -49,7 +49,8 @@ namespace NKikimr {
                                              TLsnSeg seg,
                                              void *cookie,
                                              std::unique_ptr<IEventBase> syncLogMsg,
-                                             std::unique_ptr<TEvHullHugeBlobLogged> hugeKeeperNotice)
+                                             std::unique_ptr<TEvHullHugeBlobLogged> hugeKeeperNotice,
+                                             TWriteSource writeSource)
     {
         auto callback = std::make_unique<THullCallback>(seg, hullLogCtx->VCtx, hullLogCtx->SkeletonId,
               hullLogCtx->SyncLogId, hullLogCtx->HugeKeeperId, std::move(syncLogMsg),
@@ -61,6 +62,7 @@ namespace NKikimr {
                                   TRcBuf(data), //FIXME(innokentii) wrapping
                                   seg,
                                   cookie,
+                                  writeSource,
                                   std::move(callback));
     }
 
@@ -71,7 +73,8 @@ namespace NKikimr {
                                              const TString &data,
                                              TLsnSeg seg,
                                              void *cookie,
-                                             std::unique_ptr<IEventBase> syncLogMsg)
+                                             std::unique_ptr<IEventBase> syncLogMsg,
+                                             TWriteSource writeSource)
     {
         auto callback = std::make_unique<THullCallback>(seg, hullLogCtx->VCtx, hullLogCtx->SkeletonId,
               hullLogCtx->SyncLogId, TActorId(), std::move(syncLogMsg), nullptr);
@@ -83,6 +86,7 @@ namespace NKikimr {
                                   TRcBuf(data), //FIXME(innokentii) wrapping
                                   seg,
                                   cookie,
+                                  writeSource,
                                   std::move(callback));
     }
     std::unique_ptr<NPDisk::TEvLog> CreateHullUpdate(const std::shared_ptr<THullLogCtx> &hullLogCtx,
@@ -91,7 +95,8 @@ namespace NKikimr {
                                              TLsnSeg seg,
                                              void *cookie,
                                              std::unique_ptr<IEventBase> syncLogMsg,
-                                             std::unique_ptr<TEvHullHugeBlobLogged> hugeKeeperNotice)
+                                             std::unique_ptr<TEvHullHugeBlobLogged> hugeKeeperNotice,
+                                             TWriteSource writeSource)
     {
         auto callback = std::make_unique<THullCallback>(seg, hullLogCtx->VCtx, hullLogCtx->SkeletonId,
               hullLogCtx->SyncLogId, hullLogCtx->HugeKeeperId, std::move(syncLogMsg),
@@ -103,6 +108,7 @@ namespace NKikimr {
                                   data,
                                   seg,
                                   cookie,
+                                  writeSource,
                                   std::move(callback));
     }
 
@@ -113,7 +119,8 @@ namespace NKikimr {
                                              const TRcBuf &data,
                                              TLsnSeg seg,
                                              void *cookie,
-                                             std::unique_ptr<IEventBase> syncLogMsg)
+                                             std::unique_ptr<IEventBase> syncLogMsg,
+                                             TWriteSource writeSource)
     {
         auto callback = std::make_unique<THullCallback>(seg, hullLogCtx->VCtx, hullLogCtx->SkeletonId,
               hullLogCtx->SyncLogId, TActorId(), std::move(syncLogMsg), nullptr);
@@ -125,6 +132,7 @@ namespace NKikimr {
                                   data,
                                   seg,
                                   cookie,
+                                  writeSource,
                                   std::move(callback));
     }
 

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hulllog.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hulllog.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/blobstorage/vdisk/common/vdisk_hulllogctx.h>
 #include <ydb/core/blobstorage/base/vdisk_lsn.h>
+#include <ydb/core/base/blobstorage_write_source.h>
 
 namespace NKikimr {
 
@@ -24,7 +25,8 @@ namespace NKikimr {
                                              TLsnSeg seg,
                                              void *cookie,
                                              std::unique_ptr<IEventBase> syncLogMsg,
-                                             std::unique_ptr<TEvHullHugeBlobLogged> hugeKeeperNotice);
+                                             std::unique_ptr<TEvHullHugeBlobLogged> hugeKeeperNotice,
+                                             TWriteSource writeSource);
 
     std::unique_ptr<NPDisk::TEvLog> CreateHullUpdate(const std::shared_ptr<THullLogCtx> &hullLogCtx,
                                              TLogSignature signature,
@@ -32,7 +34,8 @@ namespace NKikimr {
                                              const TString &data,
                                              TLsnSeg seg,
                                              void *cookie,
-                                             std::unique_ptr<IEventBase> syncLogMsg);
+                                             std::unique_ptr<IEventBase> syncLogMsg,
+                                             TWriteSource writeSource);
 
     std::unique_ptr<NPDisk::TEvLog> CreateHullUpdate(const std::shared_ptr<THullLogCtx> &hullLogCtx,
                                              TLogSignature signature,
@@ -40,7 +43,8 @@ namespace NKikimr {
                                              TLsnSeg seg,
                                              void *cookie,
                                              std::unique_ptr<IEventBase> syncLogMsg,
-                                             std::unique_ptr<TEvHullHugeBlobLogged> hugeKeeperNotice);
+                                             std::unique_ptr<TEvHullHugeBlobLogged> hugeKeeperNotice,
+                                             TWriteSource writeSource);
 
     std::unique_ptr<NPDisk::TEvLog> CreateHullUpdate(const std::shared_ptr<THullLogCtx> &hullLogCtx,
                                              TLogSignature signature,
@@ -48,7 +52,8 @@ namespace NKikimr {
                                              const TRcBuf &data,
                                              TLsnSeg seg,
                                              void *cookie,
-                                             std::unique_ptr<IEventBase> syncLogMsg);
+                                             std::unique_ptr<IEventBase> syncLogMsg,
+                                             TWriteSource writeSource);
 
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/metadata/metadata_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/metadata/metadata_actor.cpp
@@ -30,7 +30,8 @@ class TMetadataActor : public TActor<TMetadataActor> {
 
         auto msg = std::make_unique<NPDisk::TEvLog>(LogCtx->PDiskCtx->Dsk->Owner,
             LogCtx->PDiskCtx->Dsk->OwnerRound, TLogSignature::SignatureMetadata,
-            commitRecord, data, seg, nullptr);
+            commitRecord, data, seg, nullptr, TWriteSource::MetadataCommit,
+            NPDisk::TEvLog::TCallback());
 
         Send(LogCtx->LoggerId, msg.release());
 

--- a/ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.cpp
@@ -267,7 +267,7 @@ namespace NKikimr {
                 Y_VERIFY_S(buffer.size() == Info->Type.PartSize(blobId), VCtx->VDiskLogPrefix);
                 Y_VERIFY_S(WriteRestoredParts, VCtx->VDiskLogPrefix);
                 auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(blobId, buffer, vdiskId, true, &index, Deadline,
-                    NKikimrBlobStorage::EPutHandleClass::AsyncBlob, VCfg->BlobHeaderMode == EBlobHeaderMode::XXH3_64BIT_HEADER);
+                    NKikimrBlobStorage::EPutHandleClass::AsyncBlob, VCfg->BlobHeaderMode == EBlobHeaderMode::XXH3_64BIT_HEADER, TWriteSource::RestoredCorruptedBlob);
                 ev->RewriteBlob = true;
                 Send(SkeletonId, ev.release());
                 ++WritesPending;

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor.cpp
@@ -219,7 +219,8 @@ namespace NKikimr {
         NPDisk::TCommitRecord cr;
         cr.IsStartingPoint = true;
         Send(ScrubCtx->LoggerId, new NPDisk::TEvLog(ScrubCtx->PDiskCtx->Dsk->Owner, ScrubCtx->PDiskCtx->Dsk->OwnerRound,
-            TLogSignature::SignatureScrub, cr, data, seg, nullptr));
+            TLogSignature::SignatureScrub, cr, data, seg, nullptr, TWriteSource::ScrubCommit,
+            NPDisk::TEvLog::TCallback()));
     }
 
     void TScrubCoroImpl::Handle(NPDisk::TEvLogResult::TPtr ev) {

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor_pdisk.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor_pdisk.cpp
@@ -40,7 +40,9 @@ namespace NKikimr {
             MakeIntrusive<NPDisk::TEvChunkWrite::TAlignedParts>(std::move(data), alignedSize),
             nullptr,
             true,
-            NPriWrite::HullComp);
+            NPriWrite::HullComp,
+            TWriteSource::ScrubWrite,
+            true);
         ScrubCtx->VCtx->CountScrubCost(*msg);
         Send(ScrubCtx->PDiskCtx->PDiskId, msg.release());
         CurrentState = TStringBuilder() << "writing index to " << part.ToString();

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -444,10 +444,11 @@ namespace NKikimr {
             bool WrittenBeyondBarrier = false;
             bool IssueKeepFlag = false;
             bool IgnoreBlock = false;
+            TWriteSource WriteSource;
 
             TVPutInfo(TLogoBlobID blobId, TRope &&buffer, std::optional<ui64> checksum,
                     NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TEvVPut::TExtraBlockCheck> *extraBlockChecks,
-                    NWilson::TTraceId traceId, bool issueKeepFlag, bool ignoreBlock)
+                    TWriteSource writeSource, NWilson::TTraceId traceId, bool issueKeepFlag, bool ignoreBlock)
                 : Buffer(std::move(buffer))
                 , Checksum(checksum)
                 , BlobId(blobId)
@@ -455,6 +456,7 @@ namespace NKikimr {
                 , TraceId(std::move(traceId))
                 , IssueKeepFlag(issueKeepFlag)
                 , IgnoreBlock(ignoreBlock)
+                , WriteSource(writeSource)
             {
                 ExtraBlockChecks.Swap(extraBlockChecks);
             }
@@ -510,7 +512,7 @@ namespace NKikimr {
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignatureLogoBlobOpt, dataToWrite,
-                    seg, loggedRecCookie, std::move(syncLogMsg), nullptr);
+                    seg, loggedRecCookie, std::move(syncLogMsg), nullptr, info.WriteSource);
             // send prepared message to recovery log
             logMsg->Orbit = std::move(orbit);
             return {std::move(logMsg), loggedRec->GetTraceId()};
@@ -526,7 +528,7 @@ namespace NKikimr {
             UpdatePDiskWriteBytes(info.Buffer.GetSize());
             return std::make_unique<TEvHullWriteHugeBlob>(sender, cookie, info.BlobId, info.Ingress,
                 std::move(info.Buffer), ignoreBlock, info.IssueKeepFlag, handleClass, std::move(res),
-                &info.ExtraBlockChecks, rewriteBlob);
+                &info.ExtraBlockChecks, info.WriteSource, rewriteBlob);
         }
 
         THullCheckStatus ValidateVPut(const TActorContext &ctx, TString evPrefix,
@@ -622,6 +624,7 @@ namespace NKikimr {
                 TLogoBlobID blobId = LogoBlobIDFromLogoBlobID(item.GetBlobID());
                 putsInfo.emplace_back(blobId, ev->Get()->GetItemBuffer(itemIdx), item.HasChecksum() ?
                     std::make_optional(item.GetChecksum()) : std::nullopt, item.MutableExtraBlockChecks(),
+                    WriteSourceFromProto(item.GetWriteSourceOp()),
                     item.HasTraceId() ? item.GetTraceId() : NWilson::TTraceId(), item.GetIssueKeepFlag(),
                     item.GetIgnoreBlock());
                 TVPutInfo &info = putsInfo.back();
@@ -775,8 +778,9 @@ namespace NKikimr {
             LWTRACK(VDiskSkeletonVPutRecieved, ev->Get()->Orbit, VCtx->NodeId, VCtx->GroupId.GetRawId(),
                    VCtx->Top->GetFailDomainOrderNumber(VCtx->ShortSelfVDisk), id.TabletID(), id.BlobSize());
             TVPutInfo info(id, ev->Get()->GetBuffer(), record.HasChecksum() ? std::make_optional(record.GetChecksum()) :
-                std::nullopt, record.MutableExtraBlockChecks(), std::move(ev->TraceId), record.GetIssueKeepFlag(),
-                record.GetIgnoreBlock());
+                std::nullopt, record.MutableExtraBlockChecks(),
+                WriteSourceFromProto(record.GetWriteSourceOp()),
+                std::move(ev->TraceId), record.GetIssueKeepFlag(), record.GetIgnoreBlock());
             const ui64 bufSize = info.Buffer.GetSize();
 
             try {
@@ -861,7 +865,8 @@ namespace NKikimr {
                 ctx.Send(Db->HugeKeeperID, hugeWrite.release(), 0, 0, std::move(traceId));
             } else {
                 ctx.Send(SelfId(), new TEvHullLogHugeBlob(0, info.BlobId, info.Ingress, TDiskPart(), ignoreBlock,
-                    info.IssueKeepFlag, ev->Sender, ev->Cookie, handleClass, std::move(result), &info.ExtraBlockChecks),
+                    info.IssueKeepFlag, ev->Sender, ev->Cookie, handleClass, std::move(result), &info.ExtraBlockChecks,
+                    info.WriteSource),
                     0, 0, std::move(info.TraceId));
             }
         }
@@ -925,7 +930,7 @@ namespace NKikimr {
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignatureHugeLogoBlob, dataToWrite, seg,
-                    loggedRecCookie, std::move(syncLogMsg), nullptr);
+                    loggedRecCookie, std::move(syncLogMsg), nullptr, msg->WriteSource);
             // send prepared message to recovery log
             ctx.Send(Db->LoggerID, logMsg.release(), 0, 0, std::move(traceId));
         }
@@ -958,7 +963,8 @@ namespace NKikimr {
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignatureHandoffDelLogoBlob,
-                    serializedLogRecord, seg, loggedRecCookie, std::move(syncLogMsg), nullptr);
+                    serializedLogRecord, seg, loggedRecCookie, std::move(syncLogMsg), nullptr,
+                    TWriteSource::SkeletonHandoffDelLogoBlob);
             // send prepared message to recovery log
             ctx.Send(Db->LoggerID, logMsg.release());
         }
@@ -977,7 +983,7 @@ namespace NKikimr {
             auto traceId = ev->TraceId.Clone();
             intptr_t loggedRecId = LoggedRecsVault.Put(new TLoggedRecAddBulkSst(seg, false, ev));
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignatureAddBulkSst, commitRecord, data, seg,
-                reinterpret_cast<void*>(loggedRecId), nullptr);
+                reinterpret_cast<void*>(loggedRecId), nullptr, TWriteSource::SkeletonAddBulkSst);
             ctx.Send(Db->LoggerID, logMsg.release(), 0, 0, std::move(traceId));
         }
 
@@ -1163,7 +1169,8 @@ namespace NKikimr {
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignatureBlock,
-                    ev->GetChainBuffer()->GetString(), seg, loggedRecCookie, std::move(syncLogMsg), nullptr);
+                    ev->GetChainBuffer()->GetString(), seg, loggedRecCookie, std::move(syncLogMsg), nullptr,
+                    WriteSourceFromProto(record.GetWriteSourceOp()));
             // send prepared message to recovery log
             ctx.Send(Db->LoggerID, logMsg.release(), 0, 0, std::move(ev->TraceId));
         }
@@ -1268,7 +1275,8 @@ namespace NKikimr {
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignatureGC, data, seg, loggedRecCookie,
-                    std::move(syncLogMsg), nullptr);
+                    std::move(syncLogMsg), nullptr,
+                    WriteSourceFromProto(record.GetWriteSourceOp()));
             // send prepared message to recovery log
             ctx.Send(Db->LoggerID, logMsg.release(), 0, 0, std::move(traceId));
         }
@@ -1625,7 +1633,7 @@ namespace NKikimr {
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignatureLocalSyncData, data, seg,
-                    loggedRecCookie, nullptr, nullptr);
+                    loggedRecCookie, nullptr, nullptr, TWriteSource::SkeletonLocalSyncData);
             // send prepared message to recovery log
             ctx.Send(Db->LoggerID, logMsg.release(), 0, 0, std::move(traceId));
         }
@@ -1678,7 +1686,7 @@ namespace NKikimr {
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignatureAnubisOsirisPut, data, seg,
-                    loggedRecCookie, std::move(syncLogMsg), nullptr);
+                    loggedRecCookie, std::move(syncLogMsg), nullptr, TWriteSource::SkeletonAnubisOsirisPut);
             // send prepared message to recovery log
             ctx.Send(Db->LoggerID, logMsg.release());
         }
@@ -1769,10 +1777,12 @@ namespace NKikimr {
             TIngress ingress = *TIngress::CreateIngressWithLocal(VCtx->Top.get(), SelfVDiskId, id);
             if (buf) {
                 ctx.Send(Db->HugeKeeperID, new TEvHullWriteHugeBlob(ev->Sender, ev->Cookie, id, ingress, std::move(buf),
-                    true, false, NKikimrBlobStorage::EPutHandleClass::AsyncBlob, std::move(result), nullptr, false));
+                    true, false, NKikimrBlobStorage::EPutHandleClass::AsyncBlob, std::move(result), nullptr,
+                    TWriteSource::RecoveredHugeBlob, false));
             } else {
                 ctx.Send(SelfId(), new TEvHullLogHugeBlob(0, id, ingress, TDiskPart(), true, false, ev->Sender,
-                    ev->Cookie, NKikimrBlobStorage::EPutHandleClass::AsyncBlob, std::move(result), nullptr));
+                    ev->Cookie, NKikimrBlobStorage::EPutHandleClass::AsyncBlob, std::move(result), nullptr,
+                    TWriteSource::RecoveredHugeBlob));
             }
         }
 
@@ -1803,7 +1813,7 @@ namespace NKikimr {
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
             auto logMsg = CreateHullUpdate(HullLogCtx, TLogSignature::SignaturePhantomBlobs, data, seg,
-                    loggedRecCookie, std::move(syncLogMsg), nullptr);
+                    loggedRecCookie, std::move(syncLogMsg), nullptr, TWriteSource::SkeletonPhantomBlobs);
             // send prepared message to recovery log
             ctx.Send(Db->LoggerID, logMsg.release());
         }

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_block_and_get.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_block_and_get.cpp
@@ -46,7 +46,8 @@ public:
             Request->Get()->Record.GetForceBlockTabletData().GetId(),
             Request->Get()->Record.GetForceBlockTabletData().GetGeneration(),
             VDiskIDFromVDiskID(Request->Get()->Record.GetVDiskID()),
-            deadline
+            deadline,
+            TWriteSource::SkeletonForceBlock
         );
 
         // send TEvVBlock request

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_vmovedpatch_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_vmovedpatch_actor.cpp
@@ -154,8 +154,15 @@ namespace NKikimr {
                 // We have chosen UserData as PutHandleClass on purpose.
                 // If VMovedPatch and Put were AsyncWrite, it would become a deadlock
                 // because the put subrequest may not send and the moved patch request will end by timeout.
-                std::unique_ptr<TEvBlobStorage::TEvPut> put = std::make_unique<TEvBlobStorage::TEvPut>(PatchedId, Buffer, Deadline,
-                        NKikimrBlobStorage::UserData, TEvBlobStorage::TEvPut::TacticDefault);
+                std::unique_ptr<TEvBlobStorage::TEvPut> put = std::make_unique<TEvBlobStorage::TEvPut>(
+                        TEvBlobStorage::TEvPut::TParameters{
+                            .BlobId = PatchedId,
+                            .Buffer = TRope(Buffer),
+                            .Deadline = Deadline,
+                            .HandleClass = NKikimrBlobStorage::UserData,
+                            .Tactic = TEvBlobStorage::TEvPut::TacticDefault,
+                            .WriteSource = TWriteSource::SkeletonVMovedPatch,
+                        });
                 put->Orbit = std::move(Orbit);
 
                 LOG_DEBUG_S(ctx, NKikimrServices::BS_VDISK_PATCH, VCtx->VDiskLogPrefix

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor.cpp
@@ -503,7 +503,8 @@ namespace NKikimr::NPrivate {
             ui64 cookie = OriginalBlobId.Hash();
             // TODO(alexvru): checksumming here
             std::unique_ptr<IEventBase> put = std::make_unique<TEvBlobStorage::TEvVPut>(TLogoBlobID(PatchedBlobId, PatchedPartId),
-                    Buffer, VDiskId, false, &cookie, Deadline, NKikimrBlobStorage::AsyncBlob, false);
+                    Buffer, VDiskId, false, &cookie, Deadline, NKikimrBlobStorage::AsyncBlob, false,
+                    TWriteSource::SkeletonVPatch);
             AddMark("Send vPut");
             Send(LeaderId, put.release());
         }

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_committer.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_committer.cpp
@@ -148,7 +148,8 @@ namespace NKikimr {
             TLsnSeg seg = SyncerCtx->LsnMngr->AllocLsnForLocalUse();
             auto msg = std::make_unique<NPDisk::TEvLog>(SyncerCtx->PDiskCtx->Dsk->Owner,
                 SyncerCtx->PDiskCtx->Dsk->OwnerRound, TLogSignature::SignatureSyncerState,
-                commitRec, data, seg, nullptr);
+                commitRec, data, seg, nullptr, TWriteSource::SyncerCommit,
+                NPDisk::TEvLog::TCallback());
             SyncerCtx->MonGroup.SyncerLoggedBytes() += dataSize;
             ++SyncerCtx->MonGroup.SyncerLoggerRecords();
             ctx.Send(SyncerCtx->LoggerId, msg.release());

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.cpp
@@ -41,7 +41,9 @@ namespace NKikimr {
                 // commit msg
                 auto commitMsg = std::make_unique<NPDisk::TEvLog>(SlCtx->PDiskCtx->Dsk->Owner,
                         SlCtx->PDiskCtx->Dsk->OwnerRound, TLogSignature::SignatureSyncLogIdx,
-                        CommitRecord, TRcBuf(EntryPointSerializer.GetSerializedData()), seg, nullptr);
+                        CommitRecord, TRcBuf(EntryPointSerializer.GetSerializedData()), seg, nullptr,
+                        TWriteSource::SyncLogCommitterCommit,
+                        NPDisk::TEvLog::TCallback());
 
                 if (CommitRecord.CommitChunks || CommitRecord.DeleteChunks) {
                     LOG_INFO(ctx, NKikimrServices::BS_SKELETON,
@@ -108,7 +110,8 @@ namespace NKikimr {
                     ctx.Send(SlCtx->PDiskCtx->PDiskId,
                              new NPDisk::TEvChunkWrite(SlCtx->PDiskCtx->Dsk->Owner, SlCtx->PDiskCtx->Dsk->OwnerRound,
                                                        chunkIdx, offset, p, SyncLogCookie,
-                                                       true, NPriWrite::SyncLog));
+                                                       true, NPriWrite::SyncLog, TWriteSource::SyncLogCommitterWrite,
+                                                       true));
                     LOG_DEBUG(ctx, BS_SYNCLOG,
                               VDISKP(SlCtx->VCtx->VDiskLogPrefix,
                                     "COMMITTER: initial write: chunkIdx# %" PRIu32, chunkIdx));
@@ -159,7 +162,8 @@ namespace NKikimr {
                     ctx.Send(SlCtx->PDiskCtx->PDiskId,
                              new NPDisk::TEvChunkWrite(SlCtx->PDiskCtx->Dsk->Owner, SlCtx->PDiskCtx->Dsk->OwnerRound,
                                                        chunkIdx, offset, p, SyncLogCookie,
-                                                       true, NPriWrite::SyncLog));
+                                                       true, NPriWrite::SyncLog, TWriteSource::SyncLogCommitterWrite,
+                                                       true));
                     LOG_DEBUG(ctx, BS_SYNCLOG,
                               VDISKP(SlCtx->VCtx->VDiskLogPrefix,
                                     "COMMITTER: next write: chunkIdx# %" PRIu32, chunkIdx));

--- a/ydb/core/keyvalue/keyvalue_collector.cpp
+++ b/ydb/core/keyvalue/keyvalue_collector.cpp
@@ -95,7 +95,8 @@ public:
             auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletInfo->TabletID, RecordGeneration,
                 PerGenerationCounter, channel, advanceBarrier, CollectOperation->Header.CollectGeneration,
                 CollectOperation->Header.CollectStep, value.Keep ? new TVector<TLogoBlobID>(value.Keep) : nullptr,
-                value.DoNotKeep ? new TVector<TLogoBlobID>(value.DoNotKeep) : nullptr, TInstant::Max(), true);
+                value.DoNotKeep ? new TVector<TLogoBlobID>(value.DoNotKeep) : nullptr, TInstant::Max(), true,
+                TWriteSource::KeyValueGC);
             STLOG(PRI_DEBUG, KEYVALUE_GC, KVC00, "Sending TEvCollectGarbage", (TabletId, TabletInfo->TabletID),
                 (GroupId, groupId), (Channel, (int)channel), (RecordGeneration, RecordGeneration),
                 (PerGenerationCounter, PerGenerationCounter), (AdvanceBarrier, advanceBarrier),

--- a/ydb/core/keyvalue/keyvalue_state.cpp
+++ b/ydb/core/keyvalue/keyvalue_state.cpp
@@ -631,7 +631,7 @@ void TKeyValueState::InitExecute(ui64 tabletId, TActorId keyValueActorId, ui32 e
             const auto& [group, channel] = key;
             const auto& [generation, step] = barrier;
             auto ev = TEvBlobStorage::TEvCollectGarbage::CreateHardBarrier(info->TabletID, executorGeneration,
-                PerGenerationCounter, channel, generation, step, TInstant::Max());
+                PerGenerationCounter, channel, generation, step, TInstant::Max(), TWriteSource::KeyValueGC);
             ++PerGenerationCounter;
             ++InitialCollectsSent;
             SendToBSProxy(ctx, group, ev.Release(), (ui64)TKeyValueState::ECollectCookie::Hard);
@@ -682,7 +682,8 @@ void TKeyValueState::InitExecute(ui64 tabletId, TActorId keyValueActorId, ui32 e
             const auto& [group, channel] = key;
             auto ev = MakeHolder<TEvBlobStorage::TEvCollectGarbage>(info->TabletID, executorGeneration,
                     PerGenerationCounter, channel, true /*collect*/, barrierGeneration, barrierStep, keep.Release(),
-                    nullptr /*doNotKeep*/, TInstant::Max(), true /*isMultiCollectAllowed*/, false /*hard*/);
+                    nullptr /*doNotKeep*/, TInstant::Max(), true /*isMultiCollectAllowed*/, TWriteSource::KeyValueGC,
+                    false /*hard*/);
             ++PerGenerationCounter;
             ++InitialCollectsSent;
             SendToBSProxy(ctx, group, ev.Release(), (ui64)TKeyValueState::ECollectCookie::SoftInitial);

--- a/ydb/core/keyvalue/keyvalue_storage_request.cpp
+++ b/ydb/core/keyvalue/keyvalue_storage_request.cpp
@@ -723,11 +723,14 @@ public:
                     for (const TLogoBlobID& logoBlobId : request.LogoBlobIds) {
                         const auto begin = iter;
                         iter += logoBlobId.BlobSize();
-                        THolder<TEvBlobStorage::TEvPut> put(
-                            new TEvBlobStorage::TEvPut(
-                                logoBlobId, TRcBuf(TRope(begin, iter)),
-                                IntermediateResults->Deadline, request.HandleClass,
-                                request.Tactic));
+                        THolder<TEvBlobStorage::TEvPut> put(new TEvBlobStorage::TEvPut(TEvBlobStorage::TEvPut::TParameters{
+                            .BlobId = logoBlobId,
+                            .Buffer = TRope(begin, iter),
+                            .Deadline = IntermediateResults->Deadline,
+                            .HandleClass = request.HandleClass,
+                            .Tactic = request.Tactic,
+                            .WriteSource = TWriteSource::KeyValuePut,
+                        }));
                         const ui32 groupId = TabletInfo->GroupFor(logoBlobId.Channel(), logoBlobId.Generation());
                         Y_ABORT_UNLESS(groupId != Max<ui32>(), "Put Blob# %s is mapped to an invalid group (-1)!",
                                 logoBlobId.ToString().c_str());

--- a/ydb/core/load_test/group_write.cpp
+++ b/ydb/core/load_test/group_write.cpp
@@ -263,7 +263,13 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
             const TLogoBlobID id(tabletId, gen, step, channel, blobSize, BlobCookie++);
             const TRcBuf buffer = GenerateBuffer(id, contentType, nullptr, false, ctx);
             
-            auto ev = std::make_unique<TEvBlobStorage::TEvPut>(id, buffer, TInstant::Max(), PutHandleClass);
+            auto ev = std::make_unique<TEvBlobStorage::TEvPut>(TEvBlobStorage::TEvPut::TParameters{
+                .BlobId = id,
+                .Buffer = TRope(buffer),
+                .Deadline = TInstant::Max(),
+                .HandleClass = PutHandleClass,
+                .WriteSource = TWriteSource::GroupWriteLoadActor,
+            });
             InFlightTracker.Request(blobSize);
             return std::move(ev);
         }
@@ -293,7 +299,8 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
             }
 
             return std::make_unique<TEvBlobStorage::TEvCollectGarbage>(tabletId, gen, step, channel,
-                    !keep, gen, step, blobsToKeep.release(), blobsToCollect.release(), TInstant::Max(), false);
+                    !keep, gen, step, blobsToKeep.release(), blobsToCollect.release(), TInstant::Max(), false,
+                    TWriteSource::GroupWriteLoadActor, false, false);
         }
 
         TLogoBlobID GetRandomBlobId() {
@@ -665,7 +672,8 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
         }
 
         void IssueTEvBlock(const TActorContext& ctx) {
-            auto ev = std::make_unique<TEvBlobStorage::TEvBlock>(TabletId, Generation, TInstant::Max());
+            auto ev = std::make_unique<TEvBlobStorage::TEvBlock>(TabletId, Generation, TInstant::Max(),
+                    TWriteSource::GroupWriteLoadActor);
             LOG_DEBUG_S(ctx, NKikimrServices::BS_LOAD_TEST, PrintMe() << " going to send " << ev->ToString());
             auto callback = [this] (IEventBase *event, const TActorContext& ctx) {
                 auto *res = dynamic_cast<TEvBlobStorage::TEvBlockResult *>(event);
@@ -691,7 +699,13 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
             const ui32 lastStep = Max<ui32>();
             const TLogoBlobID id(TabletId, Generation, lastStep, Channel, size, 0);
             TRcBuf buffer = GenerateBuffer(id, ContentType, &Self.BlobData, WriteSettings.RdmaMode > 0, ctx);
-            auto ev = std::make_unique<TEvBlobStorage::TEvPut>(id, std::move(buffer), TInstant::Max(), PutHandleClass);
+            auto ev = std::make_unique<TEvBlobStorage::TEvPut>(TEvBlobStorage::TEvPut::TParameters{
+                .BlobId = id,
+                .Buffer = TRope(std::move(buffer)),
+                .Deadline = TInstant::Max(),
+                .HandleClass = PutHandleClass,
+                .WriteSource = TWriteSource::GroupWriteLoadActor,
+            });
 
             auto callback = [this] (IEventBase *event, const TActorContext& ctx) {
                 auto *res = dynamic_cast<TEvBlobStorage::TEvPutResult *>(event);
@@ -708,7 +722,7 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
 
         void IssueTEvCollectGarbageOnce(const TActorContext& ctx) {
             auto ev = TEvBlobStorage::TEvCollectGarbage::CreateHardBarrier(TabletId, Generation, GarbageCollectStep,
-                    Channel, Generation, 0, TInstant::Max());
+                    Channel, Generation, 0, TInstant::Max(), TWriteSource::GroupWriteLoadActor);
             LOG_DEBUG_S(ctx, NKikimrServices::BS_LOAD_TEST, PrintMe() << " going to send " << ev->ToString());
             ++GarbageCollectStep;
             auto callback = [this] (IEventBase *event, const TActorContext& ctx) {
@@ -792,7 +806,8 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
 
         void StopWorking(const TActorContext& ctx) {
             auto ev = TEvBlobStorage::TEvCollectGarbage::CreateHardBarrier(TabletId, Generation, GarbageCollectStep,
-                    Channel, Generation, Max<ui32>(), TInstant::Max());
+                    Channel, Generation, Max<ui32>(), TInstant::Max(),
+                    TWriteSource::GroupWriteLoadActor);
             LOG_DEBUG_S(ctx, NKikimrServices::BS_LOAD_TEST, PrintMe() << " end working, going to send " << ev->ToString());
             ++GarbageCollectStep;
             auto callback = [this](IEventBase *event, const TActorContext& ctx) {
@@ -1024,7 +1039,13 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
             }
             const TLogoBlobID id(TabletId, Generation, WriteStep, Channel, size, Cookie);
             TRcBuf buffer = GenerateBuffer(id, ContentType, &Self.BlobData, WriteSettings.RdmaMode > 0, ctx);
-            auto ev = std::make_unique<TEvBlobStorage::TEvPut>(id, std::move(buffer), TInstant::Max(), putHandleClass);
+            auto ev = std::make_unique<TEvBlobStorage::TEvPut>(TEvBlobStorage::TEvPut::TParameters{
+                .BlobId = id,
+                .Buffer = TRope(std::move(buffer)),
+                .Deadline = TInstant::Max(),
+                .HandleClass = putHandleClass,
+                .WriteSource = TWriteSource::GroupWriteLoadActor,
+            });
             const ui64 writeQueryId = ++WriteQueryId;
 
             auto writeCallback = [this, writeQueryId](IEventBase *event, const TActorContext& ctx) {
@@ -1048,7 +1069,8 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
 
                         auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, Generation,
                                 GarbageCollectStep, Channel, false, Generation, GarbageCollectStep,
-                                new TVector<TLogoBlobID>({id}), nullptr, TInstant::Max(), false);
+                                new TVector<TLogoBlobID>({id}), nullptr, TInstant::Max(), false,
+                                TWriteSource::GroupWriteLoadActor, false, false);
                         SendToBSProxy(ctx, GroupId, ev.release(), Self.QueryDispatcher.ObtainCookie(std::move(gcCallback)));
                     }
 
@@ -1162,7 +1184,8 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
             }
 
             auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(TabletId, Generation, GarbageCollectStep, Channel,
-                    true, Generation, GarbageCollectStep, nullptr, doNotKeeps, TInstant::Max(), false);
+                    true, Generation, GarbageCollectStep, nullptr, doNotKeeps, TInstant::Max(), false,
+                    TWriteSource::GroupWriteLoadActor, false, false);
             ConfirmedBlobIds.erase(ConfirmedBlobIds.begin(), it);
             auto callback = [this](IEventBase *event, const TActorContext& ctx) {
                 auto *res = dynamic_cast<TEvBlobStorage::TEvCollectGarbageResult *>(event);

--- a/ydb/core/load_test/pdisk_log.cpp
+++ b/ydb/core/load_test/pdisk_log.cpp
@@ -140,10 +140,10 @@ public:
                 CutLogLsn = *NextCutLogLsn;
                 CutLogBytesWritten = NextCutLogBytesWritten;
                 ev = std::make_unique<NPDisk::TEvLog>(PDiskParams->Owner, OwnerRound, TLogSignature(),
-                        record, DataBuffer, seg, nullptr);
+                        record, DataBuffer, seg, nullptr, TWriteSource::GroupWriteLoadActor);
             } else {
                 ev = std::make_unique<NPDisk::TEvLog>(PDiskParams->Owner, OwnerRound, TLogSignature(),
-                        DataBuffer, seg, nullptr);
+                        DataBuffer, seg, nullptr, TWriteSource::GroupWriteLoadActor);
             }
             BytesInFlight += DataBuffer.GetSize();
             ++LogInFlight;

--- a/ydb/core/load_test/pdisk_read.cpp
+++ b/ydb/core/load_test/pdisk_read.cpp
@@ -261,7 +261,8 @@ public:
                 ui64 requestIdx = NewTRequestInfo((ui32)DataBuffer.size(), chunkIdx, TAppData::TimeProvider->Now());
                 SendRequest(ctx, std::make_unique<NPDisk::TEvChunkWrite>(PDiskParams->Owner, PDiskParams->OwnerRound,
                             chunkIdx, 0u, new NPDisk::TEvChunkWrite::TAlignedParts(TString(DataBuffer)),
-                            reinterpret_cast<void*>(requestIdx), true, NPriWrite::HullHugeAsyncBlob, Sequential));
+                            reinterpret_cast<void*>(requestIdx), true, NPriWrite::HullHugeAsyncBlob,
+                            TWriteSource::GroupWriteLoadActor, Sequential));
                 ++ChunkWrite_RequestsSent;
             }
         } else {
@@ -431,7 +432,7 @@ public:
         ++Lsn;
         SendRequest(ctx, std::make_unique<NPDisk::TEvLog>(PDiskParams->Owner, PDiskParams->OwnerRound,
                 TLogSignature::SignatureHugeLogoBlob, record, TRcBuf(logRecord), seg,
-                reinterpret_cast<void*>(requestIdx)));
+                reinterpret_cast<void*>(requestIdx), TWriteSource::GroupWriteLoadActor));
         ++LogInFlight;
     }
 

--- a/ydb/core/load_test/pdisk_write.cpp
+++ b/ydb/core/load_test/pdisk_write.cpp
@@ -428,7 +428,8 @@ public:
             SendRequest(ctx, std::make_unique<NPDisk::TEvChunkWrite>(PDiskParams->Owner, PDiskParams->OwnerRound,
                     chunkIdx, offset,
                     new TParts{DataBuffer.data() + Rng() % (DataBuffer.size() - size), size},
-                    reinterpret_cast<void*>(requestIdx), true, NPriWrite::HullHugeAsyncBlob, Sequential));
+                    reinterpret_cast<void*>(requestIdx), true, NPriWrite::HullHugeAsyncBlob,
+                    TWriteSource::GroupWriteLoadActor, Sequential));
             ++ChunkWrite_RequestsSent;
 
             if (LogMode == NKikimr::TEvLoadTestRequest::LOG_PARALLEL) {
@@ -479,7 +480,7 @@ public:
         ++Lsn;
         SendRequest(ctx, std::make_unique<NPDisk::TEvLog>(PDiskParams->Owner, PDiskParams->OwnerRound,
                 TLogSignature::SignatureHugeLogoBlob, record, TRcBuf(logRecord), seg,
-                reinterpret_cast<void*>(requestIdx)));
+                reinterpret_cast<void*>(requestIdx), TWriteSource::GroupWriteLoadActor));
         ++LogInFlight;
     }
 

--- a/ydb/core/load_test/vdisk_write.cpp
+++ b/ydb/core/load_test/vdisk_write.cpp
@@ -192,7 +192,7 @@ namespace NKikimr {
                 GType.SplitData((TErasureType::ECrcMode)logoBlobId.CrcMode(), whole, parts);
                 auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(logoBlobId,
                     parts.Parts[logoBlobId.PartId() - 1].OwnedString, VDiskId, true, &cookie, TInstant::Max(),
-                    PutHandleClass, false);
+                    PutHandleClass, false, TWriteSource::GroupWriteLoadActor);
                 ctx.Send(QueueActorId, ev.release());
                 ++TEvVPutsSent;
             }
@@ -228,7 +228,7 @@ namespace NKikimr {
                         const ui32 collectStep = CollectStep++;
                         auto ev = std::make_unique<TEvBlobStorage::TEvVCollectGarbage>(TabletId, Generation, CollectCounter++,
                                 Channel, true, Generation, collectStep, false, nullptr, nullptr, VDiskId,
-                                TInstant::Max());
+                                TInstant::Max(), TWriteSource::GroupWriteLoadActor);
                         ctx.Send(QueueActorId, ev.release());
                         NextCollectRequestTimestamp = now + CollectIntervalGenerator.Generate();
 

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -328,7 +328,7 @@ message TVMultiPutItem {
     repeated TEvVPut.TExtraBlockCheck ExtraBlockChecks = 5;
 
     optional NActorsProto.TTraceId TraceId = 6;
-    optional uint32 WriteSourceOp = 10;
+    optional uint32 WriteSourceOp = 11;
 }
 
 message TEvVMultiPut {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -293,6 +293,7 @@ message TEvVPut {
     optional TTimestamps Timestamps = 23;
 
     repeated TExtraBlockCheck ExtraBlockChecks = 11;
+    optional uint32 WriteSourceOp = 24;
 }
 
 message TEvVPutResult {
@@ -327,6 +328,7 @@ message TVMultiPutItem {
     repeated TEvVPut.TExtraBlockCheck ExtraBlockChecks = 5;
 
     optional NActorsProto.TTraceId TraceId = 6;
+    optional uint32 WriteSourceOp = 10;
 }
 
 message TEvVMultiPut {
@@ -466,6 +468,7 @@ message TEvVBlock {
     optional NKikimrBlobStorage.TVDiskID VDiskID = 3;
     optional bool NotifyIfNotReady = 4;
     optional TMsgQoS MsgQoS = 10;
+    optional uint32 WriteSourceOp = 11;
 }
 
 message TEvVBlockResult {
@@ -601,6 +604,7 @@ message TEvVCollectGarbage {
     optional NKikimrBlobStorage.TVDiskID VDiskID = 8;
     optional bool NotifyIfNotReady = 9;
     optional TMsgQoS MsgQoS = 10;
+    optional uint32 WriteSourceOp = 14;
 }
 
 message TEvVCollectGarbageResult {

--- a/ydb/core/tablet/tablet_req_blockbs.cpp
+++ b/ydb/core/tablet/tablet_req_blockbs.cpp
@@ -20,7 +20,8 @@ public:
 
     void SendRequest() {
         const TActorId proxy = MakeBlobStorageProxyID(GroupId);
-        auto event = MakeHolder<TEvBlobStorage::TEvBlock>(TabletId, Generation, TInstant::Max(), IssuerGuid);
+        auto event = MakeHolder<TEvBlobStorage::TEvBlock>(TabletId, Generation, TInstant::Max(), IssuerGuid,
+            TWriteSource::BlockBlobStorage);
         event->IsMonitored = false;
         SendToBSProxy(TlsActivationContext->AsActorContext(), proxy, event.Release());
     }

--- a/ydb/core/tablet/tablet_req_delete.cpp
+++ b/ydb/core/tablet/tablet_req_delete.cpp
@@ -66,7 +66,8 @@ class TTabletReqDelete : public TActorBootstrapped<TTabletReqDelete> {
                     info.Channel,                     // channel
                     Generation,                       // collectGeneration
                     std::numeric_limits<ui32>::max(), // collectStep
-                    TInstant::Max());                 // deadline
+                    TInstant::Max(),                  // deadline
+                    TWriteSource::DeleteHardBarrier);
         event->IsMonitored = false;
         SendToBSProxy(ctx, info.GroupId, event.Release(), numRequest);
     }

--- a/ydb/core/tablet/tablet_req_writelog.cpp
+++ b/ydb/core/tablet/tablet_req_writelog.cpp
@@ -136,8 +136,8 @@ class TTabletReqWriteLog : public TActorBootstrapped<TTabletReqWriteLog> {
     }
 
     void SendToBS(const TLogoBlobID &id, const TString &buffer, const TActorContext &ctx,
-            NKikimrBlobStorage::EPutHandleClass handleClass, TEvBlobStorage::TEvPut::ETactic tactic,
-            NWilson::TTraceId traceId, bool isZeroEntry) {
+             NKikimrBlobStorage::EPutHandleClass handleClass,
+                  TEvBlobStorage::TEvPut::ETactic tactic, TWriteSource writeSource, NWilson::TTraceId traceId, bool isZeroEntry) {
         Y_ABORT_UNLESS(id.TabletID() == Info->TabletID);
         const TTabletChannelInfo *channelInfo = Info->ChannelInfo(id.Channel());
         Y_ABORT_UNLESS(channelInfo);
@@ -154,6 +154,7 @@ class TTabletReqWriteLog : public TActorBootstrapped<TTabletReqWriteLog> {
                 .Deadline = TInstant::Max(),
                 .HandleClass = handleClass,
                 .Tactic = tactic,
+                .WriteSource = writeSource,
                 .IsZeroEntry = isZeroEntry,
                 .ExternalRelevanceWatcher = Relevance,
             }), cookie, std::move(traceId));
@@ -196,7 +197,8 @@ public:
                 innerTraceId = res.first->second.GetTraceId();
             }
 
-            SendToBS(ref.Id, ref.Buffer, ctx, handleClass, ref.Tactic ? *ref.Tactic : CommitTactic, std::move(innerTraceId), false);
+            SendToBS(ref.Id, ref.Buffer, ctx, handleClass, ref.Tactic ? *ref.Tactic : CommitTactic,
+                TWriteSource::WriteLogReference, std::move(innerTraceId), false);
         }
 
         const TLogoBlobID actualLogEntryId = TLogoBlobID(
@@ -216,7 +218,8 @@ public:
             traceId = std::move(res.first->second.GetTraceId());
         }
 
-        SendToBS(actualLogEntryId, logEntryBuffer, ctx, NKikimrBlobStorage::TabletLog, CommitTactic, std::move(traceId),
+        SendToBS(actualLogEntryId, logEntryBuffer, ctx, NKikimrBlobStorage::TabletLog, CommitTactic,
+            TWriteSource::WriteLogEntry, std::move(traceId),
             IsZeroEntry);
 
         RepliesToWait = References.size() + 1;

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -1486,6 +1486,9 @@ void TTablet::GcLogChannel(ui32 step) {
                     true,
                     gen, step,
                     nullptr, nullptr, TInstant::Max(),
+                    false,
+                    TWriteSource::GcLogChannel,
+                    false,
                     false
                 )
             );
@@ -1498,9 +1501,12 @@ void TTablet::GcLogChannel(ui32 step) {
                 true,
                 gen, step,
                 nullptr, nullptr, TInstant::Max(),
+                false,
+                TWriteSource::GcLogChannel,
+                false,
                 false
-                )
-            );
+            )
+        );
     }
     GcInFlyStep = step;
     GcNextStep = 0;

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -377,7 +377,10 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbageEntry(
             keep.empty() ? nullptr : new TVector<TLogoBlobID>(std::move(keep)),
             notKeep.empty() ? nullptr : new TVector<TLogoBlobID>(std::move(notKeep)),
             TInstant::Max(),
-            true);
+            true,
+            TWriteSource::FlatCollectGarbage,
+            false,
+            false);
     GcCounter += ev->PerGenerationCounterStepSize();
     SendToBSProxy(ctx, bsgroup, ev.Release());
     ++GcWaitFor;

--- a/ydb/core/tablet_flat/flat_ops_compact.h
+++ b/ydb/core/tablet_flat/flat_ops_compact.h
@@ -603,6 +603,7 @@ namespace NTabletFlatExecutor {
                 .Deadline = TInstant::Max(),
                 .HandleClass = flag,
                 .Tactic = TEvBlobStorage::TEvPut::ETactic::TacticMaxThroughput,
+                .WriteSource = TWriteSource::FlatCompactionPut,
                 .ExternalRelevanceWatcher = RelevanceTracker,
             });
             auto ctx = ActorContext();

--- a/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/blob_manager.cpp
@@ -79,7 +79,14 @@ void TBlobBatch::SendWriteRequest(
     //auto handleClass = NKikimrBlobStorage::AsyncBlob; // TODO: what's the difference?
     auto tactic = TEvBlobStorage::TEvPut::TacticMaxThroughput;
 
-    THolder<TEvBlobStorage::TEvPut> put(new TEvBlobStorage::TEvPut(logoBlobId, data, deadline, handleClass, tactic));
+    THolder<TEvBlobStorage::TEvPut> put(new TEvBlobStorage::TEvPut(TEvBlobStorage::TEvPut::TParameters{
+        .BlobId = logoBlobId,
+        .Buffer = TRope(data),
+        .Deadline = deadline,
+        .HandleClass = handleClass,
+        .Tactic = tactic,
+        .WriteSource = TWriteSource::ColumnShardPut,
+    }));
     SendPutToGroup(ctx, groupId, BatchInfo->TabletInfo.Get(), std::move(put), cookie);
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
@@ -75,7 +75,8 @@ std::unique_ptr<TEvBlobStorage::TEvCollectGarbage> TGCTask::BuildRequest(const T
         !!CollectGenStepInFlight, CollectGenStepInFlight ? CollectGenStepInFlight->Generation() : 0,
         CollectGenStepInFlight ? CollectGenStepInFlight->Step() : 0,
         new TVector<TLogoBlobID>(it->second.KeepList.begin(), it->second.KeepList.end()),
-        new TVector<TLogoBlobID>(it->second.DontKeepList.begin(), it->second.DontKeepList.end()), TInstant::Max(), true, TWriteSource::ColumnShardGC);
+        new TVector<TLogoBlobID>(it->second.DontKeepList.begin(), it->second.DontKeepList.end()), TInstant::Max(), true,
+        TWriteSource::ColumnShardGC);
     result->PerGenerationCounter = PerGenerationCounter.Add(result->PerGenerationCounterStepSize());
     return std::move(result);
 }

--- a/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<TEvBlobStorage::TEvCollectGarbage> TGCTask::BuildRequest(const T
         !!CollectGenStepInFlight, CollectGenStepInFlight ? CollectGenStepInFlight->Generation() : 0,
         CollectGenStepInFlight ? CollectGenStepInFlight->Step() : 0,
         new TVector<TLogoBlobID>(it->second.KeepList.begin(), it->second.KeepList.end()),
-        new TVector<TLogoBlobID>(it->second.DontKeepList.begin(), it->second.DontKeepList.end()), TInstant::Max(), true);
+        new TVector<TLogoBlobID>(it->second.DontKeepList.begin(), it->second.DontKeepList.end()), TInstant::Max(), true, TWriteSource::ColumnShardGC);
     result->PerGenerationCounter = PerGenerationCounter.Add(result->PerGenerationCounterStepSize());
     return std::move(result);
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Adds new pdisk metrics: for each possible blobstorage write request source count requests count and bytes count.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

In `blobstorage_write_source.h` I generate a enum that is used everywhere blobstorage write requests are being sent (I consider `EvBlock` and `EvCollectGarbage` to be write requests too here). I store enum value in write request's proto (in an arbitrary `uint32` field) and pass it all the way down to the pdisk, so that pdisk mon would count requests and bytes. Note that by default these new metrics are PRIVATE (because there are a lot of them), but they can be enabled using a feature flag `extended_pdisk_sensors`
