### PR TITLE
fix u-a-f in TFakeActor/TFakeCA

### DIFF
--- a/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.cpp
+++ b/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.cpp
@@ -22,7 +22,7 @@ NYql::NDqProto::TCheckpoint CreateCheckpoint(ui64 id) {
     return checkpoint;
 }
 
-TFakeActor::TFakeActor(TAsyncInputPromises& sourcePromises, TAsyncOutputPromises& asyncOutputPromises)
+TFakeActor::TFakeActor(std::shared_ptr<TAsyncInputPromises> sourcePromises, std::shared_ptr<TAsyncOutputPromises> asyncOutputPromises)
     : TActor<TFakeActor>(&TFakeActor::StateFunc)
     , Alloc(__LOCATION__)
     , MemoryInfo("test")

--- a/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.h
+++ b/ydb/library/yql/providers/common/ut_helpers/dq_fake_ca.h
@@ -73,14 +73,14 @@ class TFakeActor : public NActors::TActor<TFakeActor> {
         explicit TAsyncInputEvents(TFakeActor& parent) : Parent(parent) {}
 
         void OnNewAsyncInputDataArrived(ui64) {
-            Parent.AsyncInputPromises.NewAsyncInputDataArrived.SetValue();
-            Parent.AsyncInputPromises.NewAsyncInputDataArrived = NThreading::NewPromise();
+            Parent.AsyncInputPromises->NewAsyncInputDataArrived.SetValue();
+            Parent.AsyncInputPromises->NewAsyncInputDataArrived = NThreading::NewPromise();
         }
 
         void OnAsyncInputError(ui64, const TIssues& issues, NYql::NDqProto::StatusIds::StatusCode fatalCode) {
             Y_UNUSED(fatalCode);
-            Parent.AsyncInputPromises.FatalError.SetValue(issues);
-            Parent.AsyncInputPromises.FatalError = NThreading::NewPromise<TIssues>();
+            Parent.AsyncInputPromises->FatalError.SetValue(issues);
+            Parent.AsyncInputPromises->FatalError = NThreading::NewPromise<TIssues>();
         }
 
         TFakeActor& Parent;
@@ -90,20 +90,20 @@ class TFakeActor : public NActors::TActor<TFakeActor> {
         explicit TAsyncOutputCallbacks(TFakeActor& parent) : Parent(parent) {}
 
         void ResumeExecution(EResumeSource) override {
-            Parent.AsyncOutputPromises.ResumeExecution.SetValue();
-            Parent.AsyncOutputPromises.ResumeExecution = NThreading::NewPromise();
+            Parent.AsyncOutputPromises->ResumeExecution.SetValue();
+            Parent.AsyncOutputPromises->ResumeExecution = NThreading::NewPromise();
         };
 
         void OnAsyncOutputError(ui64, const TIssues& issues, NYql::NDqProto::StatusIds::StatusCode fatalCode) override {
             Y_UNUSED(fatalCode);
-            Parent.AsyncOutputPromises.Issue.SetValue(issues);
-            Parent.AsyncOutputPromises.Issue = NThreading::NewPromise<TIssues>();
+            Parent.AsyncOutputPromises->Issue.SetValue(issues);
+            Parent.AsyncOutputPromises->Issue = NThreading::NewPromise<TIssues>();
         };
 
         void OnAsyncOutputStateSaved(TSinkState&& state, ui64 outputIndex, const NDqProto::TCheckpoint&) override {
             Y_UNUSED(outputIndex);
-            Parent.AsyncOutputPromises.StateSaved.SetValue(state);
-            Parent.AsyncOutputPromises.StateSaved = NThreading::NewPromise<TSinkState>();
+            Parent.AsyncOutputPromises->StateSaved.SetValue(state);
+            Parent.AsyncOutputPromises->StateSaved = NThreading::NewPromise<TSinkState>();
         };
 
         void OnAsyncOutputFinished(ui64 outputIndex) override {
@@ -114,7 +114,7 @@ class TFakeActor : public NActors::TActor<TFakeActor> {
     };
 
 public:
-    TFakeActor(TAsyncInputPromises& sourcePromises, TAsyncOutputPromises& asyncOutputPromises);
+    TFakeActor(std::shared_ptr<TAsyncInputPromises> sourcePromises, std::shared_ptr<TAsyncOutputPromises> asyncOutputPromises);
     ~TFakeActor();
 
     void InitAsyncOutput(IDqComputeActorAsyncOutput* dqAsyncOutput, IActor* dqAsyncOutputAsActor);
@@ -173,8 +173,8 @@ private:
     TAsyncInputEvents AsyncInputEvents;
     TAsyncOutputCallbacks AsyncOutputCallbacks;
 
-    TAsyncInputPromises& AsyncInputPromises;
-    TAsyncOutputPromises& AsyncOutputPromises;
+    std::shared_ptr<TAsyncInputPromises> AsyncInputPromises;
+    std::shared_ptr<TAsyncOutputPromises> AsyncOutputPromises;
 };
 
 struct TFakeCASetup {
@@ -205,7 +205,7 @@ struct TFakeCASetup {
                 result.emplace_back(*watermark);
             }
 
-            nextDataFutureOut = AsyncInputPromises.NewAsyncInputDataArrived.GetFuture();
+            nextDataFutureOut = AsyncInputPromises->NewAsyncInputDataArrived.GetFuture();
         });
 
         return result;
@@ -261,8 +261,8 @@ struct TFakeCASetup {
 public:
     TRuntimePtr Runtime;
     NActors::TActorId FakeActorId;
-    TAsyncInputPromises AsyncInputPromises;
-    TAsyncOutputPromises AsyncOutputPromises;
+    std::shared_ptr<TAsyncInputPromises> AsyncInputPromises = std::make_shared<TAsyncInputPromises>();
+    std::shared_ptr<TAsyncOutputPromises> AsyncOutputPromises = std::make_shared<TAsyncOutputPromises>();
 };
 
 } // namespace NKikimr::NMiniKQL

--- a/ydb/library/yql/providers/solomon/actors/ut/dq_solomon_write_actor_ut.cpp
+++ b/ydb/library/yql/providers/solomon/actors/ut/dq_solomon_write_actor_ut.cpp
@@ -24,7 +24,7 @@ void TestWriteBigBatch(bool isCloud) {
     TFakeCASetup setup;
     InitAsyncOutput(setup, BuildSolomonShardSettings(isCloud));
 
-    auto issue = setup.AsyncOutputPromises.Issue.GetFuture();
+    auto issue = setup.AsyncOutputPromises->Issue.GetFuture();
     setup.AsyncOutputWrite([](NKikimr::NMiniKQL::THolderFactory& holderFactory){
         TUnboxedValueBatch res;
         for (int i = 0; i < batchSize; i++) {
@@ -53,7 +53,7 @@ Y_UNIT_TEST_SUITE(TDqSolomonWriteActorTest) {
         TFakeCASetup setup;
         InitAsyncOutput(setup, BuildSolomonShardSettings(true));
 
-        auto issue = setup.AsyncOutputPromises.Issue.GetFuture();
+        auto issue = setup.AsyncOutputPromises->Issue.GetFuture();
         setup.AsyncOutputWrite([](NKikimr::NMiniKQL::THolderFactory& holderFactory){
             TUnboxedValueBatch res;
             res.emplace_back(CreateStruct(holderFactory, {
@@ -101,7 +101,7 @@ Y_UNIT_TEST_SUITE(TDqSolomonWriteActorTest) {
         TFakeCASetup setup;
         InitAsyncOutput(setup, BuildSolomonShardSettings(true));
 
-        auto issue = setup.AsyncOutputPromises.Issue.GetFuture();
+        auto issue = setup.AsyncOutputPromises->Issue.GetFuture();
         setup.AsyncOutputWrite([](NKikimr::NMiniKQL::THolderFactory& holderFactory){
             TUnboxedValueBatch res;
 
@@ -129,7 +129,7 @@ Y_UNIT_TEST_SUITE(TDqSolomonWriteActorTest) {
         CleanupSolomon(location);
         InitAsyncOutput(setup, BuildSolomonShardSettings(true));
 
-        auto stateSaved = setup.AsyncOutputPromises.StateSaved.GetFuture();
+        auto stateSaved = setup.AsyncOutputPromises->StateSaved.GetFuture();
         setup.AsyncOutputWrite([](NKikimr::NMiniKQL::THolderFactory& holderFactory){
             TUnboxedValueBatch res;
 
@@ -156,7 +156,7 @@ Y_UNIT_TEST_SUITE(TDqSolomonWriteActorTest) {
         CleanupSolomon(location);
         InitAsyncOutput(setup, BuildSolomonShardSettings(true));
 
-        auto stateSaved = setup.AsyncOutputPromises.StateSaved.GetFuture();
+        auto stateSaved = setup.AsyncOutputPromises->StateSaved.GetFuture();
         setup.AsyncOutputWrite([](NKikimr::NMiniKQL::THolderFactory& holderFactory){
             TUnboxedValueBatch res;
             res.emplace_back(CreateStruct(holderFactory, {
@@ -168,7 +168,7 @@ Y_UNIT_TEST_SUITE(TDqSolomonWriteActorTest) {
         }, CreateCheckpoint(1));
         UNIT_ASSERT(stateSaved.Wait(WaitTimeout));
 
-        auto issue = setup.AsyncOutputPromises.Issue.GetFuture();
+        auto issue = setup.AsyncOutputPromises->Issue.GetFuture();
         setup.AsyncOutputWrite([](NKikimr::NMiniKQL::THolderFactory& holderFactory){
             TUnboxedValueBatch res;
             res.emplace_back(CreateStruct(holderFactory, {

--- a/ydb/tests/fq/pq_async_io/ut/dq_pq_rd_read_actor_ut.cpp
+++ b/ydb/tests/fq/pq_async_io/ut/dq_pq_rd_read_actor_ut.cpp
@@ -411,7 +411,7 @@ Y_UNIT_TEST_SUITE(TDqPqRdReadActorTests) {
         StartSession(Settings);
 
         TInstant deadline = Now() + TDuration::Seconds(5);
-        auto future = CaSetup->AsyncInputPromises.FatalError.GetFuture();
+        auto future = CaSetup->AsyncInputPromises->FatalError.GetFuture();
         MockSessionError(RowDispatcherId1);
 
         bool failed = false;

--- a/ydb/tests/fq/pq_async_io/ut/dq_pq_read_actor_ut.cpp
+++ b/ydb/tests/fq/pq_async_io/ut/dq_pq_read_actor_ut.cpp
@@ -196,7 +196,7 @@ Y_UNIT_TEST_SUITE(TDqPqReadActorTest) {
         InitSource(topicName);
 
         TInstant deadline = Now() + TDuration::Seconds(5);
-        auto future = CaSetup->AsyncInputPromises.FatalError.GetFuture();
+        auto future = CaSetup->AsyncInputPromises->FatalError.GetFuture();
         bool failed = false;
         while (Now() < deadline) {
             SourceRead<TString>(UVParser);

--- a/ydb/tests/fq/pq_async_io/ut/dq_pq_write_actor_ut.cpp
+++ b/ydb/tests/fq/pq_async_io/ut/dq_pq_write_actor_ut.cpp
@@ -46,7 +46,7 @@ Y_UNIT_TEST_SUITE(TPqWriterTest) {
 
         const std::vector<TString> data = { "1", "2", "3" };
 
-        auto future = CaSetup->AsyncOutputPromises.ResumeExecution.GetFuture();
+        auto future = CaSetup->AsyncOutputPromises->ResumeExecution.GetFuture();
         AsyncOutputWrite(data);
         auto result = PQReadUntil(topicName, 3);
 
@@ -66,7 +66,7 @@ Y_UNIT_TEST_SUITE(TPqWriterTest) {
         InitAsyncOutput(topicName);
 
         const std::vector<TString> data = { "1" };
-        auto future = CaSetup->AsyncOutputPromises.Issue.GetFuture();
+        auto future = CaSetup->AsyncOutputPromises->Issue.GetFuture();
         AsyncOutputWrite(data);
 
         UNIT_ASSERT(future.Wait(WaitTimeout));
@@ -87,7 +87,7 @@ Y_UNIT_TEST_SUITE(TPqWriterTest) {
 
             const std::vector<TString> data2 = { "2", "3" };
             auto checkpoint = CreateCheckpoint();
-            auto future = setup.CaSetup->AsyncOutputPromises.StateSaved.GetFuture();
+            auto future = setup.CaSetup->AsyncOutputPromises->StateSaved.GetFuture();
             setup.AsyncOutputWrite(data2, checkpoint);
 
             UNIT_ASSERT(future.Wait(WaitTimeout));
@@ -131,7 +131,7 @@ Y_UNIT_TEST_SUITE(TPqWriterTest) {
 
             const std::vector<TString> data = {};
             auto checkpoint = CreateCheckpoint();
-            auto future = CaSetup->AsyncOutputPromises.StateSaved.GetFuture();
+            auto future = CaSetup->AsyncOutputPromises->StateSaved.GetFuture();
             AsyncOutputWrite(data, checkpoint);
 
             UNIT_ASSERT(future.Wait(WaitTimeout));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

FakeActor may outlive FaceCA and reference already freed Async*Promise; use shared_ptr instead of direct references
(Note: there may be more problems in this test)