### PR TITLE
Add an optional timestamp for locks in long tx service

### DIFF
--- a/ydb/core/protos/long_tx_service.proto
+++ b/ydb/core/protos/long_tx_service.proto
@@ -91,6 +91,7 @@ message TEvLockStatus {
     optional uint64 LockId = 1;
     optional uint32 LockNode = 2;
     optional EStatus Status = 3;
+    optional uint64 LockTimestamp = 4;
 }
 
 message TEvUnsubscribeLock {

--- a/ydb/core/protos/long_tx_service.proto
+++ b/ydb/core/protos/long_tx_service.proto
@@ -91,7 +91,14 @@ message TEvLockStatus {
     optional uint64 LockId = 1;
     optional uint32 LockNode = 2;
     optional EStatus Status = 3;
-    optional uint64 LockTimestamp = 4;
+
+    // Lock creation timestamp in microseconds since the unix epoch, used to
+    // choose the yongest victim among deadlocked transactions.
+    // May be zero (unset) when this lock is not expected to cause a deadlock,
+    // this includes serializable transactions which never acquire pessimistic
+    // locks, and placeholder (MultiXact) locks which are used in place of
+    // a set of other transactions or savepoints.
+    optional uint64 LockTimestampUs = 4;
 }
 
 message TEvUnsubscribeLock {

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
@@ -465,12 +465,16 @@ void TLongTxServiceActor::Handle(TEvPrivate::TEvAcquireSnapshotFinished::TPtr& e
 void TLongTxServiceActor::Handle(TEvLongTxService::TEvRegisterLock::TPtr& ev) {
     auto* msg = ev->Get();
     ui64 lockId = msg->LockId;
-    TXLOG_DEBUG("Received TEvRegisterLock for LockId# " << lockId);
+    TInstant lockTimestamp = msg->LockTimestamp;
+    TXLOG_DEBUG("Received TEvRegisterLock for LockId# " << lockId << " LockTimestamp# " << lockTimestamp);
 
     Y_ABORT_UNLESS(lockId, "Unexpected registration of a zero LockId");
 
     auto& lock = Locks[lockId];
     ++lock.RefCount;
+    if (lockTimestamp && !lock.Timestamp) {
+        lock.Timestamp = lockTimestamp;
+    }
 }
 
 void TLongTxServiceActor::Handle(TEvLongTxService::TEvUnregisterLock::TPtr& ev) {
@@ -550,7 +554,8 @@ void TLongTxServiceActor::Handle(TEvLongTxService::TEvSubscribeLock::TPtr& ev) {
             Send(ev->Sender,
                 new TEvLongTxService::TEvLockStatus(
                     lockId, lockNode,
-                    NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED),
+                    NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED,
+                    lock.Timestamp),
                 0, ev->Cookie);
             lock.RepliedSubscribers[ev->Sender] = ev->Cookie;
             return;
@@ -597,18 +602,21 @@ void TLongTxServiceActor::Handle(TEvLongTxService::TEvSubscribeLock::TPtr& ev) {
         ev->InterconnectSession, ev->Sender,
         new TEvLongTxService::TEvLockStatus(
             lockId, lockNode,
-            NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED),
+            NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED,
+            lock.Timestamp),
         0, ev->Cookie);
 }
 
 void TLongTxServiceActor::Handle(TEvLongTxService::TEvLockStatus::TPtr& ev) {
-    auto& record = ev->Get()->Record;
+    auto* msg = ev->Get();
+    auto& record = msg->Record;
     ui64 lockId = record.GetLockId();
     ui32 lockNode = record.GetLockNode();
     auto lockStatus = record.GetStatus();
+    auto lockTimestamp = msg->GetLockTimestamp();
     TXLOG_DEBUG("Received TEvLockStatus from " << ev->Sender
             << " for LockId# " << lockId << " LockNode# " << lockNode
-            << " LockStatus# " << lockStatus);
+            << " LockStatus# " << lockStatus << " LockTimestamp# " << lockTimestamp);
 
     auto* node = ProxyNodes.FindPtr(lockNode);
     if (!node || node->State != EProxyState::Connected) {
@@ -642,9 +650,12 @@ void TLongTxServiceActor::Handle(TEvLongTxService::TEvLockStatus::TPtr& ev) {
     // Special handling for successful lock subscriptions
     if (lockStatus == NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED) {
         lock.State = EProxyLockState::Subscribed;
+        if (lockTimestamp && !lock.Timestamp) {
+            lock.Timestamp = lockTimestamp;
+        }
         for (auto& pr : lock.NewSubscribers) {
             Send(pr.first,
-                new TEvLongTxService::TEvLockStatus(lockId, lockNode, lockStatus),
+                new TEvLongTxService::TEvLockStatus(lockId, lockNode, lockStatus, lock.Timestamp),
                 0, pr.second);
             lock.RepliedSubscribers[pr.first] = pr.second;
         }

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.h
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.h
@@ -84,6 +84,7 @@ namespace NLongTxService {
             ui64 Cookie = 0;
             THashMap<TActorId, ui64> NewSubscribers;
             THashMap<TActorId, ui64> RepliedSubscribers;
+            TInstant Timestamp = TInstant::Zero();
             // Intrusive heap support
             size_t HeapIndex = -1;
             TMonotonic ExpiresAt;
@@ -147,6 +148,7 @@ namespace NLongTxService {
 
         struct TLockState {
             ui64 RefCount = 0;
+            TInstant Timestamp = TInstant::Zero();
 
             THashMap<TActorId, ui64> LocalSubscribers;
             THashMap<TActorId, THashMap<TActorId, ui64>> RemoteSubscribers;

--- a/ydb/core/tx/long_tx_service/long_tx_service_ut.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_ut.cpp
@@ -237,7 +237,8 @@ Y_UNIT_TEST_SUITE(LongTxService) {
         TTenantTestRuntime runtime(MakeTenantTestConfig(true));
         runtime.SetLogPriority(NKikimrServices::LONG_TX_SERVICE, NLog::PRI_DEBUG);
 
-        TLockHandle handle(123, runtime.GetActorSystem(0));
+        TInstant lockTimestamp = TInstant::MicroSeconds(123456789);
+        TLockHandle handle(123, runtime.GetActorSystem(0), lockTimestamp);
 
         auto node1 = runtime.GetNodeId(0);
         auto sender1 = runtime.AllocateEdgeActor(0);
@@ -280,6 +281,7 @@ Y_UNIT_TEST_SUITE(LongTxService) {
             UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetLockId(), 123u);
             UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetLockNode(), node1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetStatus(), NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED);
+            UNIT_ASSERT_VALUES_EQUAL(msg->GetLockTimestamp(), lockTimestamp);
         }
 
         {
@@ -292,6 +294,7 @@ Y_UNIT_TEST_SUITE(LongTxService) {
             UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetLockId(), 123u);
             UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetLockNode(), node1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetStatus(), NKikimrLongTxService::TEvLockStatus::STATUS_SUBSCRIBED);
+            UNIT_ASSERT_VALUES_EQUAL(msg->GetLockTimestamp(), lockTimestamp);
         }
 
         {

--- a/ydb/core/tx/long_tx_service/public/events.h
+++ b/ydb/core/tx/long_tx_service/public/events.h
@@ -256,12 +256,12 @@ namespace NLongTxService {
                 Record.SetLockNode(lockNode);
                 Record.SetStatus(status);
                 if (lockTimestamp) {
-                    Record.SetLockTimestamp(lockTimestamp.MicroSeconds());
+                    Record.SetLockTimestampUs(lockTimestamp.MicroSeconds());
                 }
             }
 
             TInstant GetLockTimestamp() const {
-                return TInstant::MicroSeconds(Record.GetLockTimestamp());
+                return TInstant::MicroSeconds(Record.GetLockTimestampUs());
             }
         };
 

--- a/ydb/core/tx/long_tx_service/public/events.h
+++ b/ydb/core/tx/long_tx_service/public/events.h
@@ -215,9 +215,11 @@ namespace NLongTxService {
             : TEventLocal<TEvRegisterLock, EvRegisterLock>
         {
             const ui64 LockId;
+            const TInstant LockTimestamp;
 
-            explicit TEvRegisterLock(ui64 lockId)
+            explicit TEvRegisterLock(ui64 lockId, TInstant lockTimestamp)
                 : LockId(lockId)
+                , LockTimestamp(lockTimestamp)
             { }
         };
 
@@ -249,10 +251,17 @@ namespace NLongTxService {
 
             TEvLockStatus() = default;
 
-            TEvLockStatus(ui64 lockId, ui32 lockNode, EStatus status) {
+            TEvLockStatus(ui64 lockId, ui32 lockNode, EStatus status, TInstant lockTimestamp = TInstant::Zero()) {
                 Record.SetLockId(lockId);
                 Record.SetLockNode(lockNode);
                 Record.SetStatus(status);
+                if (lockTimestamp) {
+                    Record.SetLockTimestamp(lockTimestamp.MicroSeconds());
+                }
+            }
+
+            TInstant GetLockTimestamp() const {
+                return TInstant::MicroSeconds(Record.GetLockTimestamp());
             }
         };
 

--- a/ydb/core/tx/long_tx_service/public/lock_handle.cpp
+++ b/ydb/core/tx/long_tx_service/public/lock_handle.cpp
@@ -11,10 +11,10 @@ namespace NLongTxService {
         return as->NodeId;
     }
 
-    void TLockHandle::Register(ui64 lockId, TActorSystem* as) noexcept {
+    void TLockHandle::Register(ui64 lockId, TActorSystem* as, TInstant lockTimestamp) noexcept {
         Y_ABORT_UNLESS(lockId, "Cannot register a zero lock id");
         Y_ABORT_UNLESS(as, "Cannot register without a valid actor system");
-        as->Send(MakeLongTxServiceID(as->NodeId), new TEvLongTxService::TEvRegisterLock(lockId));
+        as->Send(MakeLongTxServiceID(as->NodeId), new TEvLongTxService::TEvRegisterLock(lockId, lockTimestamp));
     }
 
     void TLockHandle::Unregister(ui64 lockId, TActorSystem* as) noexcept {

--- a/ydb/core/tx/long_tx_service/public/lock_handle.h
+++ b/ydb/core/tx/long_tx_service/public/lock_handle.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <util/datetime/base.h>
 #include <util/system/compiler.h>
 #include <util/system/types.h>
 
@@ -19,21 +20,24 @@ namespace NLongTxService {
             , ActorSystem(nullptr)
         { }
 
-        TLockHandle(ui64 lockId, NActors::TActorSystem* as) noexcept
+        TLockHandle(ui64 lockId, NActors::TActorSystem* as, TInstant lockTimestamp = TInstant::Zero()) noexcept
             : LockId(lockId)
             , ActorSystem(as)
+            , LockTimestamp(lockTimestamp)
         {
             if (LockId) {
-                Register(LockId, ActorSystem);
+                Register(LockId, ActorSystem, LockTimestamp);
             }
         }
 
         TLockHandle(TLockHandle&& rhs) noexcept
             : LockId(rhs.LockId)
             , ActorSystem(rhs.ActorSystem)
+            , LockTimestamp(rhs.LockTimestamp)
         {
             rhs.LockId = 0;
             rhs.ActorSystem = nullptr;
+            rhs.LockTimestamp = TInstant::Zero();
         }
 
         ~TLockHandle() noexcept {
@@ -45,8 +49,10 @@ namespace NLongTxService {
                 Reset();
                 LockId = rhs.LockId;
                 ActorSystem = rhs.ActorSystem;
+                LockTimestamp = rhs.LockTimestamp;
                 rhs.LockId = 0;
                 rhs.ActorSystem = nullptr;
+                rhs.LockTimestamp = TInstant::Zero();
             }
             return *this;
         }
@@ -60,6 +66,7 @@ namespace NLongTxService {
                 Unregister(LockId, ActorSystem);
                 LockId = 0;
                 ActorSystem = nullptr;
+                LockTimestamp = TInstant::Zero();
             }
         }
 
@@ -71,14 +78,19 @@ namespace NLongTxService {
             return ActorSystem ? GetNodeId(ActorSystem) : 0;
         }
 
+        TInstant GetLockTimestamp() const noexcept {
+            return LockTimestamp;
+        }
+
     private:
         static ui32 GetNodeId(NActors::TActorSystem* as) noexcept;
-        static void Register(ui64 lockId, NActors::TActorSystem* as) noexcept;
+        static void Register(ui64 lockId, NActors::TActorSystem* as, TInstant lockTimestamp) noexcept;
         static void Unregister(ui64 lockId, NActors::TActorSystem* as) noexcept;
 
     private:
         ui64 LockId;
         NActors::TActorSystem* ActorSystem;
+        TInstant LockTimestamp;
     };
 
 } // namespace NLongTxService


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Since long tx service will be ultimately responsible for deadlock detection and choosing youngest transactions to abort, it makes sense to choose lock timestamp once when registering the lock, and forwarding this timestamp when subscribing to locks from other nodes.

This PR adds a lockTimestamp parameter to `TLockHandle` and forwarding it between nodes in `TEvLockStatus` messages. Related to #25253.