### PR TITLE
docs: fix Go pagination example link (ydb-go-sdk)

### DIFF
--- a/ydb/docs/en/core/dev/paging.md
+++ b/ydb/docs/en/core/dev/paging.md
@@ -51,4 +51,4 @@ In {{ ydb-short-name }}, all columns, including key ones, may have a NULL value.
 {% endif %}
 * [Java](https://github.com/ydb-platform/ydb-java-examples/tree/master/ydb-cookbook/src/main/java/tech/ydb/examples/pagination)
 * [Python](https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/pagination)
-* [Go](https://github.com/ydb-platform/ydb-go-examples/tree/master/pagination)
+* [Go](https://github.com/ydb-platform/ydb-go-sdk/tree/master/examples/pagination)

--- a/ydb/docs/ru/core/dev/paging.md
+++ b/ydb/docs/ru/core/dev/paging.md
@@ -51,4 +51,4 @@ LIMIT $limit;
 {% endif %}
 * [Java](https://github.com/ydb-platform/ydb-java-examples/tree/master/ydb-cookbook/src/main/java/tech/ydb/examples/pagination)
 * [Python](https://github.com/ydb-platform/ydb-python-sdk/tree/main/examples/pagination)
-* [Go](https://github.com/ydb-platform/ydb-go-examples/tree/master/pagination)
+* [Go](https://github.com/ydb-platform/ydb-go-sdk/tree/master/examples/pagination)


### PR DESCRIPTION
## Category
**Documentation** (changelog entry is not required)

## Description for reviewers

### Summary
Обновлена ссылка на пример реализации постраничного вывода для Go в документации «Paginated output» / «Постраничный вывод».

### Changes
- **Файлы:** `ydb/docs/en/core/dev/paging.md`, `ydb/docs/ru/core/dev/paging.md`
- **Было:** `https://github.com/ydb-platform/ydb-go-examples/tree/master/pagination`
- **Стало:** `https://github.com/ydb-platform/ydb-go-sdk/tree/master/examples/pagination`

Примеры для Go SDK перенесены из репозитория `ydb-go-examples` в `ydb-go-sdk`, путь к примеру пагинации — `examples/pagination`. Ссылка в документации приведена в соответствие с актуальным расположением кода.

Made with [Cursor](https://cursor.com)