### PR TITLE
Disable Scan Query use llvm by default

### DIFF
--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -422,7 +422,7 @@ message TTableServiceConfig {
 
     optional bool EnableSimpleProgramsSinglePartitionOptimization = 96 [default = false, (InvalidateCompileCache) = true];
 
-    optional bool EnableKqpScanQueryUseLlvm = 97 [default = true];
+    optional bool EnableKqpScanQueryUseLlvm = 97 [default = false];
 
     optional bool EnableOlapPushdownAggregate = 98  [ default = false, (InvalidateCompileCache) = true ];
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Scan Query by default uses common Compile Pattern Cache

### Changelog category <!-- remove all except one -->

* Performance improvement