### PR TITLE
Use ttl for uploaded temporary files

### DIFF
--- a/ydb/library/yql/providers/dq/actors/yt/yt_wrapper.cpp
+++ b/ydb/library/yql/providers/dq/actors/yt/yt_wrapper.cpp
@@ -338,7 +338,7 @@ namespace NYql {
                                         return MakeFuture(TErrorOr<void>(yexception() << "request complete"));
                                     }
                                     TVector<NYT::TFuture<void>> futures;
-                                    futures.reserve(attributes.size());
+                                    futures.reserve(attributes.size() + 1);
                                     for (const auto& [k, v]: attributes) {
                                         futures.push_back(
                                             req->Client->SetNode(
@@ -346,6 +346,11 @@ namespace NYql {
                                                 NYT::NYson::TYsonString(NYT::NodeToYsonString(v)),
                                                 NYT::NApi::TSetNodeOptions()));
                                     }
+                                    futures.push_back(
+                                        req->Client->SetNode(
+                                            req->NodePathTmp + "/@expiration_timeout",
+                                            NYT::NYson::TYsonString(NYT::NodeToYsonString(NYT::TNode(86400000))), // 24 hours
+                                            NYT::NApi::TSetNodeOptions()));
                                     return NYT::AllSucceeded(futures).As<void>();
                                 }))
                                 .Apply(BIND([request]() mutable {
@@ -363,6 +368,15 @@ namespace NYql {
                                     auto moveOptions = NYT::NApi::TMoveNodeOptions();
                                     moveOptions.Force = true;
                                     return req->Client->MoveNode(req->NodePathTmp, req->NodePath, moveOptions).As<void>();
+                                }))
+                                .Apply(BIND([request] () {
+                                    auto req = request.Lock();
+                                    if (!req) {
+                                        return MakeFuture(TErrorOr<void>(yexception() << "request complete"));
+                                    }
+                                    auto removeOptions = NYT::NApi::TRemoveNodeOptions();
+                                    removeOptions.Force = true;
+                                    return req->Client->RemoveNode(req->NodePath + "/@expiration_timeout", removeOptions).As<void>();
                                 }));
                         }
 


### PR DESCRIPTION
Temporary files are excluded from regular cleanup, so use YT ttl to control lifetime.

YQL-20990


* Not for changelog (changelog entry is not required)
