### PR TITLE
Fix timeout for TRegisterNodeOverDiscoveryService suite

### DIFF
--- a/ydb/services/ydb/ydb_register_node_ut.cpp
+++ b/ydb/services/ydb/ydb_register_node_ut.cpp
@@ -158,6 +158,12 @@ void CheckAccessDenied(const NDiscovery::TNodeRegistrationResult& result, const 
     UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), expectedError);
 }
 
+void CheckAccessDenied(const NDiscovery::TNodeRegistrationResult& result, const EStatus& expectedStatus) {
+    UNIT_ASSERT_C(result.IsTransportError(), result.GetIssues().ToOneLineString());
+    UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToOneLineString());
+    UNIT_ASSERT_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToOneLineString());
+}
+
 void CheckAccessDeniedRegisterNode(const NDiscovery::TNodeRegistrationResult& result, const TString& expectedError) {
     UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToOneLineString());
     UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), expectedError);
@@ -607,17 +613,13 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesServerCerts) {
     }
 }
 
-Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedCert) {
-    const TCertAndKey& caCert = TKikimrTestWithServerCert::GetCACertAndKey();
-    TCertAndKey clientServerCert = GenerateSignedCert(caCert, TProps::AsClientServer());
-    if (clientServerCert.Certificate[50] != 'a') {
-        clientServerCert.Certificate[50] = 'a';
-    } else {
-        clientServerCert.Certificate[50] = 'b';
-    }
-    {
+void TestCorruptedClientAuthData(const TCertAndKey& caCert, const TCertAndKey& clientServerCert) {
+    const auto timeout = TDuration::Seconds(2);
+    const auto expectedStatus = EStatus::CLIENT_DEADLINE_EXCEEDED;
+
+    for (bool enforceUserToken : {true, false}) {
         TKikimrServerForTestNodeRegistration server({
-            .EnforceUserToken = true,
+            .EnforceUserToken = enforceUserToken,
             .EnableDynamicNodeAuth = true,
             .SetNodeAuthValues = true
         });
@@ -631,34 +633,22 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedCert) {
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
             .SetEndpoint(location);
 
-        const auto timeout = TDuration::Seconds(2);
-        const TString expectedError = "Deadline Exceeded";
-        CheckAccessDenied(RegisterNode(config, timeout), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config, timeout), expectedStatus);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedStatus);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedStatus);
     }
-    {
-        TKikimrServerForTestNodeRegistration serverDoesNotRequireToken({
-            .EnforceUserToken = false,
-            .EnableDynamicNodeAuth = true,
-            .SetNodeAuthValues = true
-        });
-        ui16 grpc = serverDoesNotRequireToken.GetPort();
-        TString location = TStringBuilder() << "localhost:" << grpc;
+}
 
-        SetLogPriority(serverDoesNotRequireToken);
-
-        TDriverConfig config;
-        config.UseSecureConnection(caCert.Certificate.c_str())
-            .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
-            .SetEndpoint(location);
-
-        const auto timeout = TDuration::Seconds(2);
-        const TString expectedError = "Deadline Exceeded";
-        CheckAccessDenied(RegisterNode(config, timeout), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedError);
+Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedCert) {
+    const TCertAndKey& caCert = TKikimrTestWithServerCert::GetCACertAndKey();
+    TCertAndKey clientServerCert = GenerateSignedCert(caCert, TProps::AsClientServer());
+    if (clientServerCert.Certificate[50] != 'a') {
+        clientServerCert.Certificate[50] = 'a';
+    } else {
+        clientServerCert.Certificate[50] = 'b';
     }
+
+    TestCorruptedClientAuthData(caCert, clientServerCert);
 }
 
 Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedPrivatekey) {
@@ -669,50 +659,8 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedPrivatekey) {
     } else {
         clientServerCert.PrivateKey[20] = 'b';
     }
-    {
-        TKikimrServerForTestNodeRegistration server({
-            .EnforceUserToken = true,
-            .EnableDynamicNodeAuth = true,
-            .SetNodeAuthValues = true
-        });
-        ui16 grpc = server.GetPort();
-        TString location = TStringBuilder() << "localhost:" << grpc;
 
-        SetLogPriority(server);
-
-        TDriverConfig config;
-        config.UseSecureConnection(caCert.Certificate.c_str())
-            .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
-            .SetEndpoint(location);
-
-        const auto timeout = TDuration::Seconds(2);
-        const TString expectedError = "Deadline Exceeded";
-        CheckAccessDenied(RegisterNode(config, timeout), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedError);
-    }
-    {
-        TKikimrServerForTestNodeRegistration serverDoesNotRequireToken({
-            .EnforceUserToken = false,
-            .EnableDynamicNodeAuth = true,
-            .SetNodeAuthValues = true
-        });
-        ui16 grpc = serverDoesNotRequireToken.GetPort();
-        TString location = TStringBuilder() << "localhost:" << grpc;
-
-        SetLogPriority(serverDoesNotRequireToken);
-
-        TDriverConfig config;
-        config.UseSecureConnection(caCert.Certificate.c_str())
-            .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
-            .SetEndpoint(location);
-
-        const auto timeout = TDuration::Seconds(2);
-        const TString expectedError = "Deadline Exceeded";
-        CheckAccessDenied(RegisterNode(config, timeout), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedError);
-    }
+    TestCorruptedClientAuthData(caCert, clientServerCert);
 }
 
 Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesExpiredCert) {

--- a/ydb/services/ydb/ydb_register_node_ut.cpp
+++ b/ydb/services/ydb/ydb_register_node_ut.cpp
@@ -135,10 +135,14 @@ void SetLogPriority(TKikimrServerForTestNodeRegistration& server) {
     server.GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
 }
 
-NDiscovery::TNodeRegistrationResult RegisterNode(const TDriverConfig& config) {
+NDiscovery::TNodeRegistrationResult RegisterNode(const TDriverConfig& config, const TMaybe<TDuration>& clientTimeout = Nothing()) {
     auto connection = NYdb::TDriver(config);
     NYdb::NDiscovery::TDiscoveryClient discoveryClient = NYdb::NDiscovery::TDiscoveryClient(connection);
-    const auto result = discoveryClient.NodeRegistration(GetNodeRegistrationSettings()).GetValueSync();
+    auto settings = GetNodeRegistrationSettings();
+    if (clientTimeout.Defined()) {
+        settings.ClientTimeout(*clientTimeout);
+    }
+    const auto result = discoveryClient.NodeRegistration(settings).GetValueSync();
     connection.Stop(true);
     return result;
 }
@@ -627,10 +631,11 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedCert) {
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
             .SetEndpoint(location);
 
-        const TString expectedError = "empty address list";
-        CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
+        const auto timeout = TDuration::Seconds(2);
+        const TString expectedError = "Deadline Exceeded";
+        CheckAccessDenied(RegisterNode(config, timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedError);
     }
     {
         TKikimrServerForTestNodeRegistration serverDoesNotRequireToken({
@@ -648,10 +653,11 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedCert) {
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
             .SetEndpoint(location);
 
-        const TString expectedError = "empty address list";
-        CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
+        const auto timeout = TDuration::Seconds(2);
+        const TString expectedError = "Deadline Exceeded";
+        CheckAccessDenied(RegisterNode(config, timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedError);
     }
 }
 
@@ -661,7 +667,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedPrivatekey) {
     if (clientServerCert.PrivateKey[20] != 'a') {
         clientServerCert.PrivateKey[20] = 'a';
     } else {
-        clientServerCert.Certificate[20] = 'b';
+        clientServerCert.PrivateKey[20] = 'b';
     }
     {
         TKikimrServerForTestNodeRegistration server({
@@ -679,10 +685,11 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedPrivatekey) {
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
             .SetEndpoint(location);
 
-        const TString expectedError = "empty address list";
-        CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
+        const auto timeout = TDuration::Seconds(2);
+        const TString expectedError = "Deadline Exceeded";
+        CheckAccessDenied(RegisterNode(config, timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedError);
     }
     {
         TKikimrServerForTestNodeRegistration serverDoesNotRequireToken({
@@ -700,10 +707,11 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedPrivatekey) {
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
             .SetEndpoint(location);
 
-        const TString expectedError = "empty address list";
-        CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
+        const auto timeout = TDuration::Seconds(2);
+        const TString expectedError = "Deadline Exceeded";
+        CheckAccessDenied(RegisterNode(config, timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedError);
     }
 }
 


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers
Проблема – после обновления grpc-c++ с `1.54.3` на `1.60.2` тесты с невалидными сертификатами начали зависать (они замьючены сейчас в мейне).
Раньше битый сертификат приводил к быстрой транспортной ошибке, а сейчас там случаются ретраи и по сути клиент получает таймаут в конце концов. В тесте добавлен клиентский таймаут, но в проде возможна такая же проблема. Тикет на починку в SDK здесь https://github.com/ydb-platform/ydb/issues/35479