### PR TITLE
metaservice: fix path mutation (#35017)

### DIFF
--- a/ydb/services/metadata/abstract/kqp_common.cpp
+++ b/ydb/services/metadata/abstract/kqp_common.cpp
@@ -10,7 +10,7 @@ namespace {
 
 TString GetStoragePrefix() {
     TString path = NMetadata::NProvider::TServiceOperator::GetPath();
-    Y_ENSURE(path, "Service operator path must not be empty");
+    Y_ABORT_UNLESS(path);
     return "/" + AppData()->TenantName + "/" + path;
 }
 

--- a/ydb/services/metadata/abstract/kqp_common.cpp
+++ b/ydb/services/metadata/abstract/kqp_common.cpp
@@ -11,7 +11,7 @@ namespace {
 TString GetStoragePrefix() {
     TString path = NMetadata::NProvider::TServiceOperator::GetPath();
     Y_ENSURE(path, "Service operator path must not be empty");
-    return CanonizePath("/" + AppData()->TenantName + "/" + path);
+    return "/" + AppData()->TenantName + "/" + path;
 }
 
 } // anonymous namespace

--- a/ydb/services/metadata/abstract/kqp_common.cpp
+++ b/ydb/services/metadata/abstract/kqp_common.cpp
@@ -1,17 +1,24 @@
 #include "initialization.h"
 #include "kqp_common.h"
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/path.h>
 #include <ydb/services/metadata/manager/abstract.h>
 #include <ydb/services/metadata/service.h>
 
 namespace NKikimr::NMetadata {
+
+TString GetStoragePrefix() {
+    TString path = NMetadata::NProvider::TServiceOperator::GetPath();
+    Y_ENSURE(path, "Service operator path must not be empty");
+    return CanonizePath("/" + AppData()->TenantName + "/" + path);
+}
 
 TString IClassBehaviour::GetStorageTableDirectory() const {
     return TFsPath(GetStorageTablePath()).Fix().Parent().GetPath();
 }
 
 TString IClassBehaviour::GetStorageTablePath() const {
-    return "/" + AppData()->TenantName + "/" + NMetadata::NProvider::TServiceOperator::GetPath() + "/" + GetInternalStorageTablePath();
+    return GetStoragePrefix() + "/" + GetInternalStorageTablePath();
 }
 
 TString IClassBehaviour::GetStorageHistoryTablePath() const {
@@ -19,7 +26,8 @@ TString IClassBehaviour::GetStorageHistoryTablePath() const {
     if (!internalTablePath) {
         return "";
     }
-    return "/" + AppData()->TenantName + "/" + NMetadata::NProvider::TServiceOperator::GetPath() + "/" + internalTablePath;
+
+    return GetStoragePrefix() + "/" + internalTablePath;
 }
 
 NInitializer::IInitializationBehaviour::TPtr IClassBehaviour::GetInitializer() const {

--- a/ydb/services/metadata/abstract/kqp_common.cpp
+++ b/ydb/services/metadata/abstract/kqp_common.cpp
@@ -6,12 +6,15 @@
 #include <ydb/services/metadata/service.h>
 
 namespace NKikimr::NMetadata {
+namespace {
 
 TString GetStoragePrefix() {
     TString path = NMetadata::NProvider::TServiceOperator::GetPath();
     Y_ENSURE(path, "Service operator path must not be empty");
     return CanonizePath("/" + AppData()->TenantName + "/" + path);
 }
+
+} // anonymous namespace
 
 TString IClassBehaviour::GetStorageTableDirectory() const {
     return TFsPath(GetStorageTablePath()).Fix().Parent().GetPath();

--- a/ydb/services/metadata/abstract/kqp_common.h
+++ b/ydb/services/metadata/abstract/kqp_common.h
@@ -16,12 +16,15 @@ class IClassBehaviour {
 public:
     using TFactory = NObjectFactory::TObjectFactory<IClassBehaviour, TString>;
     using TPtr = std::shared_ptr<IClassBehaviour>;
+
 private:
     mutable std::shared_ptr<NInitializer::IInitializationBehaviour> Initializer;
+
 protected:
     virtual std::shared_ptr<NInitializer::IInitializationBehaviour> ConstructInitializer() const = 0;
     virtual TString GetInternalStorageTablePath() const = 0;
     virtual TString GetInternalStorageHistoryTablePath() const;
+
 public:
     virtual ~IClassBehaviour() = default;
     TString GetStorageTablePath() const;

--- a/ydb/services/metadata/ds_table/accessor_snapshot_base.cpp
+++ b/ydb/services/metadata/ds_table/accessor_snapshot_base.cpp
@@ -29,10 +29,21 @@ void TDSAccessorBase::Handle(NRequest::TEvRequestResult<NRequest::TDialogYQLRequ
     Y_ABORT_UNLESS(managers.size());
     Ydb::Table::ExecuteQueryResult qResultFull;
     ui32 replyIdx = 0;
+
     for (auto&& i : managers) {
         auto it = CurrentExistence.find(i->GetStorageTablePath());
+
+        // If the current dynamic path is not found (due to mutation),
+        // fallback to the pinned path that was used for this manager in the YQL request
+        if (it == CurrentExistence.end()) {
+            auto itPinnedPath = ManagerPinPath.find(i);
+            Y_ABORT_UNLESS(itPinnedPath != ManagerPinPath.end());
+            it = CurrentExistence.find(itPinnedPath->second);
+        }
+
         Y_ABORT_UNLESS(it != CurrentExistence.end());
         Y_ABORT_UNLESS(it->second.State != EState::UNKNOWN);
+
         if (it->second.State == EState::EXISTS) {
             Y_ABORT_UNLESS((int)replyIdx < qResult.result_sets().size());
             *qResultFull.add_result_sets() = std::move(qResult.result_sets()[replyIdx]);
@@ -41,9 +52,12 @@ void TDSAccessorBase::Handle(NRequest::TEvRequestResult<NRequest::TDialogYQLRequ
             qResultFull.add_result_sets();
         }
     }
+
     Y_ABORT_UNLESS((int)replyIdx == qResult.result_sets().size());
     Y_ABORT_UNLESS((size_t)qResultFull.result_sets().size() == SnapshotConstructor->GetManagers().size());
+    
     auto parsedSnapshot = SnapshotConstructor->ParseSnapshot(qResultFull, RequestedActuality);
+
     if (!parsedSnapshot) {
         OnConstructSnapshotError("snapshot is null after parsing");
     } else {
@@ -128,11 +142,17 @@ void TDSAccessorBase::StartSnapshotsFetchingImpl() {
     TStringBuilder sb;
     sb << "/*UI-QUERY-EXCLUDE*/" << Endl;
     for (auto&& i : managers) {
-        auto it = CurrentExistence.find(i->GetStorageTablePath());
+        auto path = i->GetStorageTablePath();
+        auto it = CurrentExistence.find(path);
         Y_ABORT_UNLESS(it != CurrentExistence.end());
         Y_ABORT_UNLESS(it->second.State != EState::UNKNOWN);
+
+        // Pin the current path to isolate the manager from potential
+        // GetStorageTablePath mutations during the asynchronous YQL execution
+        ManagerPinPath[i] = path;
+
         if (it->second.State == EState::EXISTS) {
-            sb << "SELECT * FROM `" + EscapeC(i->GetStorageTablePath()) + "`;" << Endl;
+            sb << "SELECT * FROM `" + EscapeC(path) + "`;" << Endl;
         }
     }
     NRequest::TYQLRequestExecutor::Execute(sb, NACLib::TSystemUsers::Metadata(), InternalController, true);

--- a/ydb/services/metadata/ds_table/accessor_snapshot_base.h
+++ b/ydb/services/metadata/ds_table/accessor_snapshot_base.h
@@ -80,9 +80,11 @@ private:
     using TBase = NActors::TActorBootstrapped<TDSAccessorBase>;
     YDB_READONLY(TInstant, RequestedActuality, TInstant::Zero());
     const NRequest::TConfig Config;
+    std::map<IClassBehaviour::TPtr, TString> ManagerPinPath;
     std::map<TString, TTableInfo> ExistenceChecks;
     std::map<TString, TTableInfo> CurrentExistence;
     void StartSnapshotsFetchingImpl();
+
 protected:
     std::shared_ptr<TRefreshInternalController> InternalController;
     NFetcher::ISnapshotsFetcher::TPtr SnapshotConstructor;
@@ -102,6 +104,19 @@ protected:
     void Handle(NRequest::TEvRequestFailed::TPtr& ev);
     void Handle(TTableExistsActor::TEvController::TEvError::TPtr& ev);
     void Handle(TTableExistsActor::TEvController::TEvResult::TPtr& ev);
+
+    ///
+    /// This method only for testing purpose, do not use it
+    ///
+    bool IsPathPinned(const TString& path) const {
+        for (const auto& p : ManagerPinPath) {
+            if (p.second == path) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 public:
     void Bootstrap();
 

--- a/ydb/services/metadata/ds_table/ut/ut_accessor_snapshot_base.cpp
+++ b/ydb/services/metadata/ds_table/ut/ut_accessor_snapshot_base.cpp
@@ -88,7 +88,7 @@ void SetServicePath(const TString& path) {
 
 std::unique_ptr<NRequest::TEvRequestResult<NRequest::TDialogYQLRequest>> 
 CreateYQLResponse(ui32 resultSetsCount = 1) {
-    typename NRequest::TDialogYQLRequest::TResponse response;
+    NRequest::TDialogYQLRequest::TResponse response;
     
     Ydb::Table::ExecuteQueryResult qResult;
     for (ui32 i = 0; i < resultSetsCount; ++i) {
@@ -158,7 +158,7 @@ Y_UNIT_TEST_SUITE(TDSAccessorPathDrift) {
         // Messages sent to a non-existent service (e.g., MakeSchemeCacheID()) 
         // are dropped by the runtime and won't reach the ObserverFunc.
         // We must register the service ID to ensure TEvTxProxySchemeCache events 
-        // are intercepted correctly. Jut use dummy actor.
+        // are intercepted correctly. Just use a dummy actor.
         TActorId s = runtime.AllocateEdgeActor();
         runtime.RegisterService(MakeSchemeCacheID(), s);
 

--- a/ydb/services/metadata/ds_table/ut/ut_accessor_snapshot_base.cpp
+++ b/ydb/services/metadata/ds_table/ut/ut_accessor_snapshot_base.cpp
@@ -20,9 +20,11 @@ protected:
         // Accept any data, parse nothing
         return true; 
     }
+
     TString DoSerializeToString() const override {
         return "test_snapshot";
     }
+
 public:
     using NFetcher::ISnapshot::ISnapshot;
 };
@@ -31,7 +33,7 @@ class TMockFetcher : public NFetcher::ISnapshotsFetcher {
     std::vector<IClassBehaviour::TPtr> Managers;
 public:
     TMockFetcher(std::vector<IClassBehaviour::TPtr> managers) 
-        : Managers(std::move(managers)) 
+        : Managers(std::move(managers))
     {}
 
 protected:
@@ -52,17 +54,20 @@ public:
     TTestAccessor(const NRequest::TConfig& cfg,
                   ISnapshotConstructorController::TPtr out,
                   NFetcher::ISnapshotsFetcher::TPtr fetcher)
-        : TDSAccessorBase(cfg, fetcher), OutputController(out) {}
+        : TDSAccessorBase(cfg, fetcher)
+        , OutputController(out)
+    {}
 
     void OnBootstrap() override {
         Become(&TDSAccessorBase::StateMain);
-        // Populates ManagersByPath and ExistenceChecks
         StartSnapshotsFetching();
     }
+
     void OnNewEnrichedSnapshot(NFetcher::ISnapshot::TPtr s) override {
         OutputController->OnSnapshotConstructionResult(s);
         PassAway();
     }
+
     void OnConstructSnapshotError(const TString& msg) override {
         TDSAccessorBase::OnConstructSnapshotError(msg);
         PassAway();

--- a/ydb/services/metadata/ds_table/ut/ut_accessor_snapshot_base.cpp
+++ b/ydb/services/metadata/ds_table/ut/ut_accessor_snapshot_base.cpp
@@ -1,0 +1,193 @@
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/services/metadata/ds_table/accessor_snapshot_base.h>
+#include <ydb/services/metadata/ds_table/service.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NMetadata::NProvider {
+
+class TTestBehaviour : public IClassBehaviour {
+public:
+    TString GetInternalStorageTablePath() const override { return "my_table"; }
+    TString GetTypeId() const override { return "test_type"; }
+    std::shared_ptr<NInitializer::IInitializationBehaviour> ConstructInitializer() const override { return nullptr; }
+    std::shared_ptr<NModifications::IOperationsManager> GetOperationsManager() const override { return nullptr; }
+};
+
+class TTestSnapshot : public NFetcher::ISnapshot {
+protected:
+    bool DoDeserializeFromResultSet(const Ydb::Table::ExecuteQueryResult&) override {
+        // Accept any data, parse nothing
+        return true; 
+    }
+    TString DoSerializeToString() const override {
+        return "test_snapshot";
+    }
+public:
+    using NFetcher::ISnapshot::ISnapshot;
+};
+
+class TMockFetcher : public NFetcher::ISnapshotsFetcher {
+    std::vector<IClassBehaviour::TPtr> Managers;
+public:
+    TMockFetcher(std::vector<IClassBehaviour::TPtr> managers) 
+        : Managers(std::move(managers)) 
+    {}
+
+protected:
+    std::vector<IClassBehaviour::TPtr> DoGetManagers() const override {
+        return Managers;
+    }
+
+    NFetcher::ISnapshot::TPtr CreateSnapshot(const TInstant actuality) const override {
+        return std::make_shared<TTestSnapshot>(actuality); 
+    }
+
+public:
+};
+
+class TTestAccessor : public TDSAccessorBase {
+    ISnapshotConstructorController::TPtr OutputController;
+public:
+    TTestAccessor(const NRequest::TConfig& cfg,
+                  ISnapshotConstructorController::TPtr out,
+                  NFetcher::ISnapshotsFetcher::TPtr fetcher)
+        : TDSAccessorBase(cfg, fetcher), OutputController(out) {}
+
+    void OnBootstrap() override {
+        Become(&TDSAccessorBase::StateMain);
+        // Populates ManagersByPath and ExistenceChecks
+        StartSnapshotsFetching();
+    }
+    void OnNewEnrichedSnapshot(NFetcher::ISnapshot::TPtr s) override {
+        OutputController->OnSnapshotConstructionResult(s);
+        PassAway();
+    }
+    void OnConstructSnapshotError(const TString& msg) override {
+        TDSAccessorBase::OnConstructSnapshotError(msg);
+        PassAway();
+    }
+
+    using TDSAccessorBase::IsPathPinned;
+};
+
+void SetServicePath(const TString& path) {
+    NKikimrConfig::TMetadataProviderConfig proto1;
+    proto1.SetPath(path);
+    NProvider::TConfig config1;
+    config1.DeserializeFromProto(proto1);
+
+    // Change path in a TServiceOperator via TService
+    NProvider::TService service1(config1);
+}
+
+std::unique_ptr<NRequest::TEvRequestResult<NRequest::TDialogYQLRequest>> 
+CreateYQLResponse(ui32 resultSetsCount = 1) {
+    typename NRequest::TDialogYQLRequest::TResponse response;
+    
+    Ydb::Table::ExecuteQueryResult qResult;
+    for (ui32 i = 0; i < resultSetsCount; ++i) {
+        qResult.add_result_sets();
+    }
+
+    auto* op = response.mutable_operation();
+    op->set_ready(true);
+    op->set_status(Ydb::StatusIds::SUCCESS);
+    op->mutable_result()->PackFrom(qResult);
+    
+    return std::make_unique<NRequest::TEvRequestResult<NRequest::TDialogYQLRequest>>(std::move(response));
+}
+
+template <typename TExtractor>
+auto RunInContext(TTestBasicRuntime& runtime, TExtractor&& extractor) {
+    return runtime.RunCall([&]() {
+        return extractor();
+    });
+}
+
+Y_UNIT_TEST_SUITE(TDSAccessorPathDrift) {
+    ///
+    /// The test simulates a race condition where the IBehavior table path
+    /// prefix changes. Mutation can happen via GetStorageTablePath while
+    /// a YQL query is already in flight. It ensures that
+    /// TDSAccessorBase "pins" the path used for the YQL request and
+    /// uses this pinned path for subsequent result mapping, preventing
+    /// lookup failures in CurrentExistence maps and ABORTs.
+    ///
+    Y_UNIT_TEST(TestPathConsistencyDuringMutation) {
+        TTestBasicRuntime runtime(1, false);
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.GetAppData().TenantName = "test_db";
+        runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvTxProxySchemeCache::TEvNavigateKeySet::EventType) {
+                Cerr <<"Sender:"<< ev->Sender << Endl;
+                Cerr <<"Recipient:"<< ev->Recipient << Endl;
+
+                auto nav = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+                auto& entry = nav->ResultSet.emplace_back();
+                entry.Status = NSchemeCache::TSchemeCacheNavigate::EStatus::Ok;
+                entry.Kind   = NSchemeCache::TSchemeCacheNavigate::EKind::KindTable;
+                runtime.Send(new IEventHandle(
+                    ev->Sender, ev->Recipient,
+                    new TEvTxProxySchemeCache::TEvNavigateKeySetResult(nav.Release())));
+
+                return TTestActorRuntimeBase::EEventAction::DROP;
+            }
+
+            return TTestActorRuntimeBase::EEventAction::PROCESS;
+        });
+
+        // Set init path
+        SetServicePath("v1_path");
+        
+        auto manager = std::make_shared<TTestBehaviour>();
+        auto fetcher = std::make_shared<TMockFetcher>(std::vector<IClassBehaviour::TPtr>{manager});
+
+        // AppData exists only in a runtime context
+        const TString path1 = RunInContext(runtime, [&] { 
+            return manager->GetStorageTablePath(); 
+        });
+
+        UNIT_ASSERT_EQUAL(path1, "/test_db/v1_path/my_table");
+
+        // Messages sent to a non-existent service (e.g., MakeSchemeCacheID()) 
+        // are dropped by the runtime and won't reach the ObserverFunc.
+        // We must register the service ID to ensure TEvTxProxySchemeCache events 
+        // are intercepted correctly. Jut use dummy actor.
+        TActorId s = runtime.AllocateEdgeActor();
+        runtime.RegisterService(MakeSchemeCacheID(), s);
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        auto outputController = std::make_shared<TDSAccessorSimple::TEvController>(TActorIdentity(sender));
+
+        NRequest::TConfig regConfig;
+        auto actor = new TTestAccessor(regConfig, outputController, fetcher);
+        TActorId accessorId = runtime.Register(actor);
+
+        // Wait until the manager's storage path is pinned and sent to YQL
+        TDispatchOptions options2;
+        options2.FinalEvents.emplace_back([](IEventHandle&) { return false; });
+        options2.CustomFinalCondition = [&]() -> bool {
+            return actor->IsPathPinned("/test_db/v1_path/my_table");
+        };
+        runtime.DispatchEvents(options2);
+
+        // Mutate path
+        SetServicePath("v2_new_path");
+        const TString path2 = RunInContext(runtime, [&] { 
+            return manager->GetStorageTablePath(); 
+        });
+
+        UNIT_ASSERT_EQUAL(path2, "/test_db/v2_new_path/my_table");
+
+        // As YQL is missing in the runtime and TDSAccessorBase does not receive answer
+        // make it manually. Check that TDSAccessorBase works after path mutation.
+        runtime.Send(new IEventHandle(accessorId, sender, CreateYQLResponse(1).release()));
+
+        auto res = runtime.GrabEdgeEvent<TDSAccessorSimple::TEvController::TEvResult>(sender);
+        UNIT_ASSERT(res);
+        UNIT_ASSERT(res->Get()->GetResult());
+    }
+}
+
+}

--- a/ydb/services/metadata/ds_table/ut/ut_accessor_snapshot_base.cpp
+++ b/ydb/services/metadata/ds_table/ut/ut_accessor_snapshot_base.cpp
@@ -120,8 +120,8 @@ Y_UNIT_TEST_SUITE(TDSAccessorPathDrift) {
         runtime.GetAppData().TenantName = "test_db";
         runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
             if (ev->GetTypeRewrite() == TEvTxProxySchemeCache::TEvNavigateKeySet::EventType) {
-                Cerr <<"Sender:"<< ev->Sender << Endl;
-                Cerr <<"Recipient:"<< ev->Recipient << Endl;
+                Cerr << "Sender: " << ev->Sender << Endl;
+                Cerr << "Recipient: " << ev->Recipient << Endl;
 
                 auto nav = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
                 auto& entry = nav->ResultSet.emplace_back();

--- a/ydb/services/metadata/ds_table/ut/ya.make
+++ b/ydb/services/metadata/ds_table/ut/ya.make
@@ -1,0 +1,30 @@
+UNITTEST_FOR(ydb/services/metadata/initializer)
+
+FORK_SUBTESTS()
+
+SPLIT_FACTOR(10)
+
+IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
+    SIZE(LARGE)
+    TAG(ya:fat)
+    REQUIREMENTS(ram:16)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+PEERDIR(
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/testlib/default
+    ydb/services/metadata
+    ydb/public/lib/yson_value
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    ut_accessor_snapshot_base.cpp
+)
+
+END()

--- a/ydb/services/metadata/ds_table/ut/ya.make
+++ b/ydb/services/metadata/ds_table/ut/ya.make
@@ -1,4 +1,4 @@
-UNITTEST_FOR(ydb/services/metadata/initializer)
+UNITTEST_FOR(ydb/services/metadata/ds_table)
 
 FORK_SUBTESTS()
 

--- a/ydb/services/metadata/ds_table/ya.make
+++ b/ydb/services/metadata/ds_table/ya.make
@@ -25,3 +25,7 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

metaservice: fix path mutation (#35017)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

The IBehavior::GetStorageTablePath can mutate as it dynamically constructs the path based on AppData()->TenantName and the TServiceOperator singleton's Path. These components can change during node start/stop procedures or reconfiguration, leading to a race condition in TDSAccessorBase. Specifically, the path used to dispatch a YQL query may differ from the path used when processing the result, causing lookup failures and ABORTs.

This fix introduces a path-pinning mechanism within TDSAccessorBase. The accessor now "pins" the specific path at the moment of YQL query dispatch and uses this pinned version as a fallback during result mapping. This ensures that the metadata fetch cycle remains consistent even if global path prefixes change mid-operation.



 Fixes #35017