### PR TITLE
sqs: delete idempodency

### DIFF
--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -659,9 +659,8 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
         UNIT_ASSERT(!receiptHandle.empty());
 
         DeleteMessage({{"QueueUrl", path.QueueUrl}, {"ReceiptHandle", receiptHandle}});
-        if (!"X-Fail") { // TODO MLP commit idempotence
-            DeleteMessage({{"QueueUrl", path.QueueUrl}, {"ReceiptHandle", receiptHandle}});
-        }
+        // MLP commit idempotence
+        DeleteMessage({{"QueueUrl", path.QueueUrl}, {"ReceiptHandle", receiptHandle}});
     }
 
     Y_UNIT_TEST_F(TestDeleteMessageBatch, TFixture) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -53,7 +53,7 @@ void TStorage::SetDeadLetterPolicy(std::optional<NKikimrPQ::TPQTabletConfig::EDe
         case NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_DELETE:
             for (auto [offset, _] : std::exchange(DLQMessages, {})) {
                 size_t c = 0;
-                DoCommit(offset, c);
+                DoCommit(offset, false, c);
                 ++Metrics.TotalDeletedByDeadlinePolicyMessageCount;
             }
             break;
@@ -140,7 +140,7 @@ std::optional<ui64> TStorage::Next(TInstant deadline, TPosition& position) {
 }
 
 bool TStorage::Commit(ui64 messageId) {
-    return DoCommit(messageId, Metrics.TotalCommittedMessageCount);
+    return DoCommit(messageId, true, Metrics.TotalCommittedMessageCount);
 }
 
 bool TStorage::Unlock(ui64 messageId) {
@@ -484,7 +484,7 @@ bool TStorage::MarkDLQMoved(TDLQMessage message) {
     }
 
     if (it != DLQMessages.end() && it->second == message.SeqNo) {
-        DoCommit(message.Offset, Metrics.TotalMovedToDLQMessageCount);
+        DoCommit(message.Offset, false, Metrics.TotalMovedToDLQMessageCount);
         return true;
     }
 
@@ -642,7 +642,7 @@ ui64 TStorage::NormalizeDeadline(TInstant deadline) {
 
 ui64 TStorage::DoLock(ui64 offset, TMessage& message, TInstant& deadline) {
     auto now = TimeProvider->Now();
-    
+
     AFL_VERIFY(message.GetStatus() == EMessageStatus::Unprocessed)("status", message.GetStatus());
     message.SetStatus(EMessageStatus::Locked);
     message.DeadlineDelta = NormalizeDeadline(deadline);
@@ -698,7 +698,10 @@ void TStorage::UpdateMessageLockingDurationMetrics(const TMessage& message) {
     Metrics.MessageLockingDuration.IncrementFor(lockingDuration.MilliSeconds());
 }
 
-bool TStorage::DoCommit(ui64 offset, size_t& totalMetrics) {
+bool TStorage::DoCommit(ui64 offset, bool userRequest, size_t& totalMetrics) {
+    if (userRequest) {
+        Batch.SetHasUserCommit();
+    }
     auto [message, slowZone] = GetMessageInt(offset);
     if (!message) {
         return false;
@@ -824,7 +827,7 @@ void TStorage::DoUnlock(ui64 offset, TMessage& message) {
                 return;
             }
             case NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_DELETE:
-                DoCommit(offset, Metrics.TotalDeletedByDeadlinePolicyMessageCount);
+                DoCommit(offset, false, Metrics.TotalDeletedByDeadlinePolicyMessageCount);
                 return;
             case NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_UNSPECIFIED:
                 break;
@@ -1020,6 +1023,10 @@ void TStorage::TBatch::SetPurged() {
     Purged = true;
 }
 
+void TStorage::TBatch::SetHasUserCommit() {
+    HasUserCommit = true;
+}
+
 void TStorage::TBatch::Compacted(size_t count) {
     CompactedMessages += count;
 }
@@ -1038,7 +1045,8 @@ bool TStorage::TBatch::Empty() const {
         && MovedToSlowZone.empty()
         && DeletedFromSlowZone.empty()
         && CompactedMessages == 0
-        && !Purged;
+        && !Purged
+        && !HasUserCommit;
 }
 
 size_t TStorage::TBatch::AddedMessageCount() const {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -128,6 +128,7 @@ public:
         void MoveToSlow(ui64 offset);
         void DeleteFromSlow(ui64 offset);
         void SetPurged();
+        void SetHasUserCommit();
 
         void Compacted(size_t count);
         void MoveBaseTime(TInstant baseDeadline, TInstant baseWriteTimestamp);
@@ -143,6 +144,9 @@ public:
         std::vector<ui64> DeletedFromSlowZone;
         size_t CompactedMessages = 0;
         bool Purged = false;
+        // The commit may or may not have changed the state, but it should still trigger persistence.
+        // The internal commits caused by DLQ operations do not set this flag.
+        bool HasUserCommit = false;
 
         std::optional<TInstant> BaseDeadline;
         std::optional<TInstant> BaseWriteTimestamp;
@@ -214,7 +218,7 @@ private:
     ui64 NormalizeDeadline(TInstant deadline);
 
     ui64 DoLock(ui64 offset, TMessage& message, TInstant& deadline);
-    bool DoCommit(ui64 offset, size_t& totalMetrics);
+    bool DoCommit(ui64 offset, bool userRequest, size_t& totalMetrics);
     bool DoUnlock(ui64 offset);
     void DoUnlock(ui64 offset, TMessage& message);
     bool DoUndelay(ui64 offset);


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

На любой вызов Storage->Commit выставляем флаг, что нужно сделать persist, чтобы потом сформировать ответ за конечное время.

Commit может ссылаться на уже закомиченное сообщение, а может и вообще указать сообщение за пределами зоны.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10302
