### PR TITLE
Group concurrent TEvLockRows requests and test cancellation

### DIFF
--- a/ydb/core/tx/data_events/events.h
+++ b/ydb/core/tx/data_events/events.h
@@ -229,6 +229,10 @@ struct TDataEvents {
     struct TEvLockRowsCancel : public NActors::TEventPB<TEvLockRowsCancel, NKikimrDataEvents::TEvLockRowsCancel, TDataEvents::EvLockRowsCancel> {
     public:
         TEvLockRowsCancel() = default;
+
+        explicit TEvLockRowsCancel(ui64 requestId) {
+            Record.SetRequestId(requestId);
+        }
     };
 
     struct TEvLockRowsResult : public NActors::TEventPB<TEvLockRowsResult, NKikimrDataEvents::TEvLockRowsResult, TDataEvents::EvLockRowsResult> {

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -3801,6 +3801,9 @@ void TDataShard::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr &ev, const TA
     }
 
     PipeServers.erase(it);
+
+    // Note: awaiter queue size may change when Cancel is called
+    UpdateProposeQueueSize();
 }
 
 void TDataShard::Handle(TEvMediatorTimecast::TEvRegisterTabletResult::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -613,11 +613,12 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
 
                 // Key is either not locked, or locked by someone else
                 // We need to establish a runtime lock for fair locking
-                // TODO: we need to jump the queue when another lock from the
-                // current transaction is waiting already, or owns the lock.
-                // Otherwise transaction may indirectly start waiting on itself,
-                // causing deadlocks.
                 if (!runtimeLock.IsValid()) {
+                    // Note: AddRuntimeLock will group multiple runtime locks
+                    // with the same key and lock together, however it will not
+                    // do that for different (related) locks. When implementing
+                    // safepoints we would need to group all locks from the same
+                    // transaction, not just having the same LockId.
                     runtimeLock = SysLocksTable().AddRuntimeLock(tableId, key);
                     Y_ENSURE(runtimeLock.IsValid());
                     if (!runtimeLock.IsOwner()) {

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -62,13 +62,25 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         TTestPipe(TTestActorRuntime& runtime, ui64 tabletId, ui32 nodeIndex = 0)
             : Runtime(runtime)
             , TabletId(tabletId)
+            , NodeIndex(nodeIndex)
         {
-            PipeActor = Runtime.ConnectToPipe(TabletId, TActorId(), nodeIndex, NTabletPipe::TClientConfig{});
+            Reopen();
         }
 
         ~TTestPipe() {
-            ui32 nodeIndex = PipeActor.NodeId() - Runtime.GetNodeId(0);
-            Runtime.ClosePipe(PipeActor, TActorId(), nodeIndex);
+            Close();
+        }
+
+        void Reopen() {
+            Close();
+            PipeActor = Runtime.ConnectToPipe(TabletId, TActorId(), NodeIndex, NTabletPipe::TClientConfig{});
+        }
+
+        void Close() {
+            if (PipeActor) {
+                Runtime.ClosePipe(PipeActor, TActorId(), NodeIndex);
+                PipeActor = {};
+            }
         }
 
         ui64 GetTabletId() const {
@@ -87,6 +99,7 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
     private:
         TTestActorRuntime& Runtime;
         const ui64 TabletId;
+        const ui32 NodeIndex;
         TActorId PipeActor;
     };
 
@@ -135,6 +148,10 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         ui64 SendRequest(const TLockHandle& lock, const TTableId& tableId, TSerializedCellMatrix keys) {
             return SendRequest(lock, tableId, std::move(keys), [](auto*){});
+        }
+
+        void SendCancel(ui64 requestId) {
+            Pipe.Send(Sender, new NEvents::TDataEvents::TEvLockRowsCancel(requestId));
         }
 
         std::unique_ptr<NEvents::TDataEvents::TEvLockRowsResult> ExpectResult(ui64 requestId, NKikimrDataEvents::TEvLockRowsResult::EStatus status = NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS, TDuration simTimeout = TDuration::Seconds(1)) {
@@ -647,6 +664,257 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         // Lock key 3 by lock 1 (lock must be broken now)
         auto req3 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(3).Build());
         lockRows.ExpectResult(req3, NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
+    }
+
+    Y_UNIT_TEST(ExplicitCancellation) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock3(345, runtime.GetActorSystem(0));
+        TLockHandle lock4(456, runtime.GetActorSystem(0));
+        TLockHandle lock5(567, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        TWaitGraphInterceptor waitGraph(runtime);
+
+        // Lock key 1 by lock 1
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        // Lock key 1 by lock 2
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // Lock key 1 by lock 3
+        auto req3 = lockRows.SendRequest(lock3, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // Lock key 1 by lock 4
+        auto req4 = lockRows.SendRequest(lock4, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // Lock key 1 by lock 5
+        auto req5 = lockRows.SendRequest(lock5, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // We must have a chain of 4 awaiters now
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "234 -> 123\n"
+            "345 -> 234\n"
+            "456 -> 345\n"
+            "567 -> 456\n");
+
+        // Cancel the current runtime lock owner, the next one must become the head
+        lockRows.SendCancel(req2);
+        lockRows.ExpectNoResult();
+
+        // We must have a chain of 3 awaiters now
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "345 -> 123\n"
+            "456 -> 345\n"
+            "567 -> 456\n");
+
+        // Cancel the middle of the chain
+        lockRows.SendCancel(req4);
+        lockRows.ExpectNoResult();
+
+        // We must have a chain of 2 awaiters now
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "345 -> 123\n"
+            "567 -> 345\n");
+
+        // Cancel the end of the chain
+        lockRows.SendCancel(req5);
+        lockRows.ExpectNoResult();
+
+        // We must have a simple awaiter now
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "345 -> 123\n");
+
+        // Drop the first lock, then lock 3 must succeed
+        lock1.Reset();
+        lockRows.ExpectResult(req3);
+    }
+
+    Y_UNIT_TEST(ImplicitCancellation) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        TTestPipe pipe2(runtime, shards.at(0));
+        TLockRowsHelper lockRows2(runtime, pipe2);
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock3(345, runtime.GetActorSystem(0));
+        TLockHandle lock4(456, runtime.GetActorSystem(0));
+        TLockHandle lock5(567, runtime.GetActorSystem(0));
+
+        TWaitGraphInterceptor waitGraph(runtime);
+
+        // Lock key 1 by lock 1
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        // Lock key 1 by lock 2
+        lockRows2.SendRequest(lock2, tableId, TKeysBuilder().Add(1).Build());
+        lockRows2.ExpectNoResult();
+
+        // Lock key 1 by lock 3
+        lockRows.SendRequest(lock3, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // Lock key 1 by lock 4
+        lockRows2.SendRequest(lock4, tableId, TKeysBuilder().Add(1).Build());
+        lockRows2.ExpectNoResult();
+
+        // Lock key 1 by lock 5
+        lockRows.SendRequest(lock5, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // We must have a chain of 4 awaiters now
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "234 -> 123\n"
+            "345 -> 234\n"
+            "456 -> 345\n"
+            "567 -> 456\n");
+
+        // Close the second pipe, it must cancel requests 2 and 4
+        pipe2.Close();
+        lockRows2.ExpectNoResult();
+
+        // We must have 2 awaiters left
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "345 -> 123\n"
+            "567 -> 345\n");
+
+        // Reopen the first pipe, it must cancel requests 3 and 5
+        pipe.Reopen();
+        lockRows.ExpectNoResult();
+        UNIT_ASSERT_VALUES_EQUAL(waitGraph.ToString(), "");
+
+        // The key 1 must still be locked, and lock attempts must be retriable
+        lockRows.SendRequest(lock3, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // We must have an awaiter
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "345 -> 123\n");
+    }
+
+    Y_UNIT_TEST(NoSameKeyChainDeadlock) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock3(345, runtime.GetActorSystem(0));
+
+        TWaitGraphInterceptor waitGraph(runtime);
+
+        // Lock key 1 by lock 1
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        // Lock key 1 by lock 2 (it will start waiting for lock 1)
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // Lock key 1 by lock 3 (it will start waiting for lock 2)
+        auto req3 = lockRows.SendRequest(lock3, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "234 -> 123\n"
+            "345 -> 234\n");
+
+        // Lock key 1 by lock 2 again (e.g. a concurrent request)
+        // It must jump the queue at the currently waiting lock, and not
+        // self-deadlock waiting for lock 3 which is waiting for lock 2.
+        auto req4 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        // Lock key 1 by lock 3 again
+        // This must be enqueued after req3
+        auto req5 = lockRows.SendRequest(lock3, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "234 -> 123\n"
+            "345 -> 234\n");
+
+        // Cancel req3, the wait graph must still have the 345 -> 234 edge
+        lockRows.SendCancel(req3);
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "234 -> 123\n"
+            "345 -> 234\n");
+
+        // Remove lock 1, requests 2 and 4 must succeed in that order
+        lock1.Reset();
+        lockRows.ExpectResult(req2);
+        lockRows.ExpectResult(req4);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            waitGraph.ToString(),
+            "345 -> 234\n");
+
+        // Finally remove lock 2, it must unblock req5
+        lock2.Reset();
+        lockRows.ExpectResult(req5);
     }
 
 } // Y_UNIT_TEST_SUITE(DataShardLockRows)

--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -567,12 +567,15 @@ void TLockInfo::AddWaitPersistentCallback(ILocksDb* db, TVector<TLockInfo::TPtr>
 // TTableLocks
 
 TTableLocks::~TTableLocks() {
-    for (auto it = RuntimeLocks.begin(); it != RuntimeLocks.end(); ++it) {
-        // Make sure to detach all lock holders
-        while (it->second) {
-            it->second.PopFront();
-        }
+}
+
+TTableLocks::TRuntimeLockHolderList::~TRuntimeLockHolderList() {
+    while (!Empty()) {
+        // We must detach all lock holders and make them invalid
+        TRuntimeLockHolder* holder = PopFront();
+        holder->Self = nullptr;
     }
+    LockTails.clear();
 }
 
 void TTableLocks::AddShardLock(TLockInfo* lock) {
@@ -642,17 +645,46 @@ TTableLocks::TRuntimeLockHolder TTableLocks::AddRuntimeLock(TConstArrayRef<TCell
         it = res.first;
     }
     TRuntimeLockHolder holder(this, it, std::move(lock));
-    it->second.PushBack(&holder);
+    auto& tail = it->second.LockTails[holder.Lock];
+    if (!tail) {
+        it->second.PushBack(&holder);
+    } else {
+        // Note: we don't need to activate the next lock holder because the lock doesn't change
+        holder.LinkAfter(tail);
+    }
+    tail = &holder;
     return holder;
+}
+
+void TTableLocks::MovedRuntimeLock(TRuntimeLocks::iterator key, TRuntimeLockHolder* holder, TRuntimeLockHolder* was) {
+    Y_ENSURE(key->second);
+    auto& tail = key->second.LockTails[holder->Lock];
+    Y_ENSURE(tail, "Unexpected move of an unregistered lock holder");
+    if (tail == was) {
+        tail = holder;
+    }
 }
 
 void TTableLocks::RemoveRuntimeLock(TRuntimeLocks::iterator key, TRuntimeLockHolder* holder) {
     Y_ENSURE(key->second);
+    auto& tail = key->second.LockTails[holder->Lock];
+    Y_ENSURE(tail, "Unexpected remove of an unregistered lock holder");
+    TRuntimeLockHolder* prev = key->second.Front() != holder ? holder->Prev()->Node() : nullptr;
     TRuntimeLockHolder* next = key->second.Back() != holder ? holder->Next()->Node() : nullptr;
+    bool predecessorChanged = !prev || prev->Lock != holder->Lock;
+    if (tail == holder) {
+        if (predecessorChanged) {
+            key->second.LockTails.erase(holder->Lock);
+        } else {
+            tail = prev;
+        }
+    }
     holder->Unlink();
     if (next) {
-        // Activate the next lock holder (predecessor changed)
-        next->OnChangedEvent.NotifyAll();
+        // Activate the next lock holder when predecessor lock changes
+        if (predecessorChanged) {
+            next->OnChangedEvent.NotifyAll();
+        }
     } else if (!key->second) {
         // This key has no holders, remove
         RuntimeLocks.erase(key);

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -597,7 +597,15 @@ public:
 
 public:
     class TRuntimeLockHolder;
-    using TRuntimeLockHolderList = TIntrusiveList<TRuntimeLockHolder>;
+    class TRuntimeLockHolderList : public TIntrusiveList<TRuntimeLockHolder> {
+        friend TTableLocks;
+
+    public:
+        ~TRuntimeLockHolderList();
+
+    private:
+        THashMap<TLockInfo::TPtr, TRuntimeLockHolder*> LockTails;
+    };
 
 private:
     class TRuntimeLockKeyComparator {
@@ -653,6 +661,9 @@ public:
             rhs.Unlink();
             rhs.Self = nullptr;
             rhs.Lock = nullptr;
+            if (Self) {
+                Self->MovedRuntimeLock(Key, this, &rhs);
+            }
         }
 
         TRuntimeLockHolder& operator=(TRuntimeLockHolder&& rhs) {
@@ -665,6 +676,9 @@ public:
                 rhs.Unlink();
                 rhs.Self = nullptr;
                 rhs.Lock = nullptr;
+                if (Self) {
+                    Self->MovedRuntimeLock(Key, this, &rhs);
+                }
             }
             return *this;
         }
@@ -718,6 +732,7 @@ public:
     TRuntimeLockHolder AddRuntimeLock(TConstArrayRef<TCell> key, TLockInfo::TPtr lock);
 
 private:
+    void MovedRuntimeLock(TRuntimeLocks::iterator it, TRuntimeLockHolder* holder, TRuntimeLockHolder* was);
     void RemoveRuntimeLock(TRuntimeLocks::iterator it, TRuntimeLockHolder* holder);
 
 private:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR implements request grouping the the same transaction tries to lock the same key concurrently and tests cancellation. Related to #25253.