### PR TITLE
pq_composite: fix potential verify failure

### DIFF
--- a/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
+++ b/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
@@ -846,8 +846,9 @@ private:
         {
             const auto update = [&](TPartitionSet& p) {
                 while (!p.empty() && (*p.begin())->IsIdle()) {
-                    Y_VALIDATE(IdlePartitions.emplace(*p.begin()).second, "Unexpected IdlePartitions");
+                    auto key = *p.begin();
                     p.erase(p.begin());
+                    Y_VALIDATE(IdlePartitions.emplace(key).second, "Unexpected IdlePartitions");
                 }
             };
             update(SuspendedPartitions);
@@ -858,8 +859,9 @@ private:
         const auto timeLowerBound = std::min(ExternalReadTime, GetMinimalLocalReadTime());
         while (!SuspendedPartitions.empty() && (*SuspendedPartitions.begin())->GetReadTime() <= timeLowerBound + MaxPartitionReadSkew / 3) {
             unsuspendedPartitionsCount++;
-            DistributePartitionSession(*SuspendedPartitions.begin());
+            auto key = *SuspendedPartitions.begin();
             SuspendedPartitions.erase(SuspendedPartitions.begin());
+            DistributePartitionSession(key);
         }
 
         SRC_LOG_AS_T("Unsuspended partitions count: " << unsuspendedPartitionsCount);
@@ -964,13 +966,14 @@ private:
                     continue;
                 }
 
-                if ((*it)->IsSuspended(timeLowerBound)) {
-                    Y_VALIDATE(SuspendedPartitions.emplace(*it).second, "Unexpected SuspendedPartitions");
-                } else {
-                    Y_VALIDATE(ReadyPartitions.emplace(*it).second, "Unexpected ReadyPartitions");
-                }
-
+                auto key = *it;
                 it = p.erase(it);
+
+                if (key->IsSuspended(timeLowerBound)) {
+                    Y_VALIDATE(SuspendedPartitions.emplace(key).second, "Unexpected SuspendedPartitions");
+                } else {
+                    Y_VALIDATE(ReadyPartitions.emplace(key).second, "Unexpected ReadyPartitions");
+                }
             }
         };
         update(PendingPartitions);

--- a/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
+++ b/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
@@ -934,8 +934,8 @@ private:
 
         if (!key->WaitEvent().IsReady()) {
             // There are no ready events in this partition, so move it to pending / idle
-            DistributePartitionSession(key);
             NextReadyPartition = ReadyPartitions.erase(NextReadyPartition);
+            DistributePartitionSession(key);
         } else {
             // Move to next partition
             NextReadyPartition++;

--- a/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
+++ b/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
@@ -846,9 +846,8 @@ private:
         {
             const auto update = [&](TPartitionSet& p) {
                 while (!p.empty() && (*p.begin())->IsIdle()) {
-                    auto key = *p.begin();
+                    Y_VALIDATE(IdlePartitions.emplace(*p.begin()).second, "Unexpected IdlePartitions");
                     p.erase(p.begin());
-                    Y_VALIDATE(IdlePartitions.emplace(key).second, "Unexpected IdlePartitions");
                 }
             };
             update(SuspendedPartitions);
@@ -859,9 +858,8 @@ private:
         const auto timeLowerBound = std::min(ExternalReadTime, GetMinimalLocalReadTime());
         while (!SuspendedPartitions.empty() && (*SuspendedPartitions.begin())->GetReadTime() <= timeLowerBound + MaxPartitionReadSkew / 3) {
             unsuspendedPartitionsCount++;
-            auto key = *SuspendedPartitions.begin();
+            DistributePartitionSession(*SuspendedPartitions.begin());
             SuspendedPartitions.erase(SuspendedPartitions.begin());
-            DistributePartitionSession(key);
         }
 
         SRC_LOG_AS_T("Unsuspended partitions count: " << unsuspendedPartitionsCount);
@@ -966,14 +964,13 @@ private:
                     continue;
                 }
 
-                auto key = *it;
-                it = p.erase(it);
-
-                if (key->IsSuspended(timeLowerBound)) {
-                    Y_VALIDATE(SuspendedPartitions.emplace(key).second, "Unexpected SuspendedPartitions");
+                if ((*it)->IsSuspended(timeLowerBound)) {
+                    Y_VALIDATE(SuspendedPartitions.emplace(*it).second, "Unexpected SuspendedPartitions");
                 } else {
-                    Y_VALIDATE(ReadyPartitions.emplace(key).second, "Unexpected ReadyPartitions");
+                    Y_VALIDATE(ReadyPartitions.emplace(*it).second, "Unexpected ReadyPartitions");
                 }
+
+                it = p.erase(it);
             }
         };
         update(PendingPartitions);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

IsReady() result may change from false to true and re-insert into `Ready*` -> either Y_VALIDATE failure, or would lead to loosing partition