### PR TITLE
Make agents.md shorter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,62 +1,34 @@
-# Project Agents.md Guide for AI Agents
+## Project
 
-This file provides comprehensive guidance for AI agents working with this codebase.
+## Structure
 
-## More Information About the Project
+Every directory is a library or program.
 
-The documentation is available at <https://ydb.tech/docs/en/>.
+- `/ydb/core`: Core modules
+- `/ydb/library`: YDB libraries
+- `/ydb/docs`: YDB documentation
+- `/library`, `/util`: Common libraries; never change them
 
-## Project Structure for AI Agents Navigation
+## Build & Test
 
-Every directory is a project (a library or a program).
-
-- `/ydb/core`: Core modules.
-- `/ydb/library`: YDB libraries.
-- `/ydb/docs`: YDB documentation.
-- `/library`: Common libraries; never change them.
-- `/util`: Common libraries; never change them.
-
-## Building and Testing Requirements for AI Agents
-
-Building and testing are performed using the Ya utility (`ya-tool`), which is located in the root of the codebase: `/ya`.
-
-To build a project, an AI agent should run:
 
 ```bash
-cd path/to/project
-/ya make
+# Build
+./ya make --build relwithdebinfo <folder>
+
+# Run all tests
+./ya make --build relwithdebinfo -tA <folder>
+
+# Run specific test
+./ya make --build relwithdebinfo -tA <folder> -F *test-filter*
 ```
 
-To test a project, an AI agent should run:
+- Tests include build
+- No `-j`, no force rebuild
+- Use `2>&1 | tail` for test output
 
-```bash
-cd path/to/project
-/ya make -A
-```
+## C++
 
-More information is available at <https://ydb.tech/docs/en/contributor/build-ya>.
+- Use C++20 or earlier
 
-## Coding Conventions for AI agents
 
-### C++ Standards for AI Agents
-
-- Use modern C++ (no later than C++20).
-
-### Documentation Guidelines for AI Agents
-
-- Follow the style guide: <https://ydb.tech/docs/en/contributor/documentation/style-guide>
-- Keep the structure consistent: <https://ydb.tech/docs/en/contributor/documentation/structure>
-
-## Pull Request Guidelines for AI Agents
-
-- Pull request descriptions must include a changelog entry (a short summary of the changes), followed by a detailed description for reviewers.
-- Specify exactly one of the following PR categories:
-  - New Feature
-  - Experimental Feature
-  - Improvement
-  - Performance Improvement
-  - User Interface
-  - Bugfix
-  - Backward-Incompatible Change
-  - Documentation (changelog entry is not required)
-  - Not for Changelog (changelog entry is not required)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,6 @@
-## Project
-
-## Structure
-
-Every directory is a library or program.
-
-- `/ydb/core`: Core modules
-- `/ydb/library`: YDB libraries
-- `/ydb/docs`: YDB documentation
-- `/library`, `/util`: Common libraries; never change them
+# Project
 
 ## Build & Test
-
 
 ```bash
 # Build
@@ -24,7 +14,8 @@ Every directory is a library or program.
 ```
 
 - Tests include build
-- No `-j`, no force rebuild
+- No `-j`
+- No force rebuild
 - Use `2>&1 | tail` for test output
 
 ## C++

--- a/ydb/docs/.ruler/AGENTS.md
+++ b/ydb/docs/.ruler/AGENTS.md
@@ -1,5 +1,0 @@
-# AGENTS.md
-
-Centralised AI agent instructions. Add coding guidelines, style guides, and project context here.
-
-Ruler concatenates all .md files in this directory (and subdirectories), starting with AGENTS.md (if present), then remaining files in sorted order.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* All the build and test commands use `--build relwithdebinfo`
* AI agents usually do not open external links, so they are removed.
* The whole document has made shorter in order to save tokens.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
