### PR TITLE
YQ-5154 fixed unit tests for PartitionBalancingBetweenTwoSessions

### DIFF
--- a/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
+++ b/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
@@ -639,6 +639,7 @@ public:
         RefreshReadyPartitions();
         if (!ReadyPartitions.empty()) {
             // There are already ready events
+            SRC_LOG_AS_T("WaitEvent, ready partitions #" << ReadyPartitions.size());
             return NThreading::MakeFuture();
         }
 
@@ -654,6 +655,7 @@ public:
 
         waitPendingPartitions = PendingPartitions.size();
         waitIdlePartitions = IdlePartitions.size();
+        SRC_LOG_AS_T("WaitEvent, suspended partitions #" << SuspendedPartitions.size() << ", pending partitions #" << PendingPartitions.size() << ", idle partitions #" << IdlePartitions.size());
 
         if (!SuspendedPartitions.empty()) {
             // Wait for advance time, when some partition will be unsuspended
@@ -718,6 +720,7 @@ public:
         auto maybeEvent = ReadEventFromReadyPartitions(settings);
 
         RefreshReadyPartitions();
+        SRC_LOG_AS_T("GetEvent, suspended partitions #" << SuspendedPartitions.size() << ", ready partitions #" << ReadyPartitions.size() << ", pending partitions #" << PendingPartitions.size() << ", idle partitions #" << IdlePartitions.size());
 
         if (!maybeEvent) {
             maybeEvent = ReadEventFromReadyPartitions(settings);
@@ -759,6 +762,8 @@ public:
     // ICompositeTopicReadSessionControl
 
     void AdvancePartitionTime(ui64 partitionId, TInstant lastEventTime) final {
+        SRC_LOG_AS_T("AdvancePartitionTime, partitionId: " << partitionId << ", lastEventTime: " << lastEventTime);
+
         const auto it = PartitionSessions.find(partitionId);
         Y_VALIDATE(it != PartitionSessions.end(), "Partition " << partitionId << " not found");
         const TPartitionKey key(it->second);
@@ -862,7 +867,7 @@ private:
             SuspendedPartitions.erase(SuspendedPartitions.begin());
         }
 
-        SRC_LOG_AS_T("Unsuspended partitions count: " << unsuspendedPartitionsCount);
+        SRC_LOG_AS_T("RefreshPartitionsState, unsuspended partitions count: " << unsuspendedPartitionsCount << ", suspended partitions #" << SuspendedPartitions.size() << ", ready partitions #" << ReadyPartitions.size() << ", pending partitions #" << PendingPartitions.size() << ", idle partitions #" << IdlePartitions.size());
 
         // Suspend some partitions
         {
@@ -934,8 +939,8 @@ private:
 
         if (!key->WaitEvent().IsReady()) {
             // There are no ready events in this partition, so move it to pending / idle
-            DistributePartitionSession(key);
             NextReadyPartition = ReadyPartitions.erase(NextReadyPartition);
+            DistributePartitionSession(key);
         } else {
             // Move to next partition
             NextReadyPartition++;

--- a/ydb/library/yql/providers/pq/gateway/ut/composite_client_ut.cpp
+++ b/ydb/library/yql/providers/pq/gateway/ut/composite_client_ut.cpp
@@ -25,6 +25,8 @@ struct TEvCompositeSessionTest {
         EvBegin = EventSpaceBegin(TEvents::ES_USERSPACE),
         EvCreateSession = EvBegin,
         EvSessionCreated,
+        EvLock,
+        EvLockReceived,
         EvEnd
     };
 
@@ -33,12 +35,10 @@ struct TEvCompositeSessionTest {
     struct TEvCreateSession : public TEventLocal<TEvCreateSession, EvCreateSession> {
         IMockPqGateway* Gateway = nullptr;
         TCompositeTopicReadSessionSettings Settings;
-        TActorId ReplyTo;
 
-        TEvCreateSession(IMockPqGateway* gateway, TCompositeTopicReadSessionSettings settings, TActorId replyTo)
+        TEvCreateSession(IMockPqGateway* gateway, TCompositeTopicReadSessionSettings settings)
             : Gateway(gateway)
             , Settings(std::move(settings))
-            , ReplyTo(replyTo)
         {}
     };
 
@@ -51,38 +51,126 @@ struct TEvCompositeSessionTest {
             , Control(std::move(control))
         {}
     };
+
+    struct TEvLock : public TEventLocal<TEvLock, EvLock> {
+        NThreading::TFuture<void> Future;
+
+        explicit TEvLock(NThreading::TFuture<void> future)
+            : Future(std::move(future))
+        {}
+    };
+
+    struct TEvLockReceived : public TEventLocal<TEvLockReceived, EvLockReceived> {
+    };
 };
 
-class TCompositeSessionCreatorActor : public TActorBootstrapped<TCompositeSessionCreatorActor> {
+class TCompositeSessionCreatorActor : public TActor<TCompositeSessionCreatorActor> {
 public:
-    void Bootstrap() {
-        Become(&TThis::StateFunc);
-    }
+    TCompositeSessionCreatorActor()
+        : TActor(&TCompositeSessionCreatorActor::StateFunc)
+    {}
 
-    STFUNC(StateFunc) {
-        switch (ev->GetTypeRewrite()) {
-            hFunc(TEvCompositeSessionTest::TEvCreateSession, HandleCreate);
-        }
-    }
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvCompositeSessionTest::TEvCreateSession, Handle)
+        hFunc(TEvCompositeSessionTest::TEvLock, Handle)
+        hFunc(TEvents::TEvPoison, Handle)
+    )
 
-    void HandleCreate(TEvCompositeSessionTest::TEvCreateSession::TPtr& ev) {
-        Y_ABORT_UNLESS(ev->Get()->Gateway && ev->Get()->ReplyTo);
+private:
+    void Handle(TEvCompositeSessionTest::TEvCreateSession::TPtr& ev) {
+        Y_ABORT_UNLESS(ev->Get()->Gateway);
 
         IMockPqGateway* gateway = ev->Get()->Gateway;
         TCompositeTopicReadSessionSettings settings = std::move(ev->Get()->Settings);
-        const TActorId replyTo = ev->Get()->ReplyTo;
 
         NYdb::TDriver driver(NYdb::TDriverConfig().SetEndpoint("localhost:1"));
         auto topicClient = gateway->GetTopicClient(driver, gateway->GetTopicClientSettings());
         auto [session, control] = CreateCompositeTopicReadSession(ActorContext(), *topicClient, settings);
 
-        Send(replyTo, new TEvCompositeSessionTest::TEvSessionCreated(std::move(session), std::move(control)));
+        Send(ev->Sender, new TEvCompositeSessionTest::TEvSessionCreated(std::move(session), std::move(control)));
+    }
+
+    void Handle(TEvCompositeSessionTest::TEvLock::TPtr& ev) {
+        Send(ev->Sender, new TEvCompositeSessionTest::TEvLockReceived());
+        ev->Get()->Future.Wait(TDuration::Seconds(10));
+    }
+
+    void Handle(TEvents::TEvPoison::TPtr&) {
         PassAway();
     }
 };
 
 class TCompositeClientTestFixture : public TTestWithActorSystemFixture {
     using TBase = TTestWithActorSystemFixture;
+
+    template <typename TValue>
+    class TActorGuard {
+    public:
+        TActorGuard(NActors::TTestActorRuntime* runtime, TActorId actorId, std::shared_ptr<TValue> value)
+            : Value(std::move(value))
+            , LockPromise(NThreading::NewPromise<void>())
+        {
+            const auto edge = runtime->AllocateEdgeActor();
+            runtime->Send(actorId, edge, new TEvCompositeSessionTest::TEvLock(LockPromise.GetFuture()));
+            UNIT_ASSERT(runtime->GrabEdgeEvent<TEvCompositeSessionTest::TEvLockReceived>(edge));
+        }
+
+        ~TActorGuard() {
+            LockPromise.SetValue();
+        }
+
+        TValue* operator->() const {
+            return Value.get();
+        }
+
+    private:
+        const std::shared_ptr<TValue> Value;
+        NThreading::TPromise<void> LockPromise;
+    };
+
+    class TSessionHolder {
+    public:
+        using TPtr = std::shared_ptr<TSessionHolder>;
+
+        TSessionHolder(NActors::TTestActorRuntime* runtime, IMockPqGateway* gateway, const TCompositeTopicReadSessionSettings& settings)
+            : Runtime(runtime)
+            , SessionCreator(Runtime->Register(new TCompositeSessionCreatorActor()))
+        {
+            const TActorId edge = Runtime->AllocateEdgeActor();
+            Runtime->Send(SessionCreator, edge, new TEvCompositeSessionTest::TEvCreateSession(gateway, settings));
+
+            auto ev = Runtime->GrabEdgeEvent<TEvCompositeSessionTest::TEvSessionCreated>(edge);
+            UNIT_ASSERT(ev);
+            UNIT_ASSERT(ev->Get()->Session != nullptr);
+            UNIT_ASSERT(ev->Get()->Control != nullptr);
+            Session = std::move(ev->Get()->Session);
+            Control = std::move(ev->Get()->Control);
+        }
+
+        void Close() {
+            if (SessionCreator) {
+                Runtime->Send(SessionCreator, Runtime->AllocateEdgeActor(), new TEvents::TEvPoison());
+                SessionCreator = {};
+            }
+
+            Session.reset();
+            Control.reset();
+        }
+
+        TActorGuard<IReadSession> GetSession() {
+            return TActorGuard<IReadSession>(Runtime, SessionCreator, Session);
+        }
+
+        TActorGuard<ICompositeTopicReadSessionControl> GetControl() {
+            return TActorGuard<ICompositeTopicReadSessionControl>(Runtime, SessionCreator, Control);
+        }
+
+    private:
+        NActors::TTestActorRuntime* const Runtime = nullptr;
+        TActorId SessionCreator;
+        std::shared_ptr<IReadSession> Session;
+        ICompositeTopicReadSessionControl::TPtr Control;
+    };
 
 public:
     using TBase::TBase;
@@ -91,6 +179,13 @@ public:
         Settings.LogSettings.AddLogPriority(NKikimrServices::EServiceKikimr::KQP_COMPUTE, NLog::PRI_TRACE);
         TBase::SetUp(ctx);
         AggregatorActorId = Runtime.Register(CreateDqPqInfoAggregationActor("test_tx"));
+    }
+
+    void TearDown(NUnitTest::TTestContext& ctx) override {
+        for (const auto& session : Sessions) {
+            session->Close();
+        }
+        TBase::TearDown(ctx);
     }
 
 protected:
@@ -126,22 +221,14 @@ protected:
         return settings;
     }
 
-    std::pair<std::shared_ptr<IReadSession>, ICompositeTopicReadSessionControl::TPtr> CreateSession(
-        IMockPqGateway* gateway,
-        const TCompositeTopicReadSessionSettings& settings)
-    {
-        const TActorId edge = Runtime.AllocateEdgeActor();
-        const TActorId creator = Runtime.Register(new TCompositeSessionCreatorActor());
-        Runtime.Send(creator, edge, new TEvCompositeSessionTest::TEvCreateSession(gateway, settings, edge));
-
-        auto ev = Runtime.GrabEdgeEvent<TEvCompositeSessionTest::TEvSessionCreated>(edge);
-        UNIT_ASSERT(ev);
-        UNIT_ASSERT(ev->Get()->Session != nullptr);
-        UNIT_ASSERT(ev->Get()->Control != nullptr);
-        return {std::move(ev->Get()->Session), std::move(ev->Get()->Control)};
+    TSessionHolder::TPtr CreateSession(IMockPqGateway* gateway, const TCompositeTopicReadSessionSettings& settings) {
+        auto session = std::make_shared<TSessionHolder>(&Runtime, gateway, settings);
+        Sessions.push_back(session);
+        return session;
     }
 
     TActorId AggregatorActorId;
+    std::vector<TSessionHolder::TPtr> Sessions;
 };
 
 } // anonymous namespace
@@ -151,19 +238,19 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
-        UNIT_ASSERT(!session->GetSessionId().empty());
-        UNIT_ASSERT(session->GetSessionId().find("0=") != TString::npos);
+        UNIT_ASSERT(!holder->GetSession()->GetSessionId().empty());
+        UNIT_ASSERT(holder->GetSession()->GetSessionId().find("0=") != TString::npos);
     }
 
     Y_UNIT_TEST_F(GetEventWhenNoDataReturnsNullopt, TCompositeClientTestFixture) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
-        auto event = session->GetEvent(
+        auto event = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(!event.has_value());
     }
@@ -172,13 +259,13 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
         auto mockSession = gateway->ExtractReadSession("topic");
         UNIT_ASSERT(mockSession != nullptr);
         mockSession->AddDataReceivedEvent(0, "msg1");
 
-        auto event = session->GetEvent(
+        auto event = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event.has_value());
 
@@ -192,13 +279,13 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
         auto mockSession = gateway->ExtractReadSession("topic");
         UNIT_ASSERT(mockSession != nullptr);
         mockSession->AddDataReceivedEvent(0, "msg1");
 
-        auto event = session->GetEvent(
+        auto event = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event.has_value());
 
@@ -208,12 +295,12 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         const ui64 partitionId = dataEv->GetPartitionSession()->GetPartitionId();
         const TInstant eventTime = TInstant::MilliSeconds(100);
 
-        control->AdvancePartitionTime(partitionId, eventTime);
+        holder->GetControl()->AdvancePartitionTime(partitionId, eventTime);
 
         mockSession->AddDataReceivedEvent(1, "msg2");
-        session->WaitEvent().Wait(TDuration::Seconds(2));
+        holder->GetSession()->WaitEvent().Wait(TDuration::Seconds(2));
 
-        auto event2 = session->GetEvent(
+        auto event2 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event2.has_value());
         const auto* dataEv2 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event2);
@@ -226,24 +313,24 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
         auto mockSession = gateway->ExtractReadSession("topic");
         UNIT_ASSERT(mockSession != nullptr);
         mockSession->AddDataReceivedEvent(0, "a", T0);
 
-        auto event1 = session->GetEvent(
+        auto event1 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event1.has_value());
         const auto* data1 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event1);
         UNIT_ASSERT(data1 != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(std::string(data1->GetMessages()[0].GetData()), "a");
         const ui64 partitionId = data1->GetPartitionSession()->GetPartitionId();
-        control->AdvancePartitionTime(partitionId, T0);
+        holder->GetControl()->AdvancePartitionTime(partitionId, T0);
 
         mockSession->AddDataReceivedEvent({{.Offset = 1, .Data = "b", .MessageTime = T0}, {.Offset = 2, .Data = "c", .MessageTime = T0}});
-        session->WaitEvent().Wait(TDuration::Seconds(2));
-        auto event2 = session->GetEvent(
+        holder->GetSession()->WaitEvent().Wait(TDuration::Seconds(2));
+        auto event2 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event2.has_value());
         const auto* data2 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event2);
@@ -257,12 +344,12 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
         auto mockSession = gateway->ExtractReadSession("topic");
         UNIT_ASSERT(mockSession != nullptr);
 
-        NThreading::TFuture<void> waitFuture = session->WaitEvent();
+        NThreading::TFuture<void> waitFuture = holder->GetSession()->WaitEvent();
         UNIT_ASSERT(!waitFuture.HasValue());
 
         mockSession->AddDataReceivedEvent(0, "wake");
@@ -275,9 +362,9 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
-        bool closed = session->Close(TDuration::Zero());
+        bool closed = holder->GetSession()->Close(TDuration::Zero());
         UNIT_ASSERT(closed);
     }
 
@@ -285,13 +372,13 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
         auto mockSession = gateway->ExtractReadSession("topic");
         UNIT_ASSERT(mockSession != nullptr);
         mockSession->AddDataReceivedEvent(0, "msg1");
 
-        auto event = session->GetEvent(
+        auto event = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event.has_value());
 
@@ -300,14 +387,14 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         const ui64 partitionId = dataEv->GetPartitionSession()->GetPartitionId();
         const TInstant eventTime = TInstant::MilliSeconds(100);
 
-        control->AdvancePartitionTime(partitionId, eventTime);
-        control->AdvancePartitionTime(partitionId, TInstant::MilliSeconds(50));
-        control->AdvancePartitionTime(partitionId, eventTime);
+        holder->GetControl()->AdvancePartitionTime(partitionId, eventTime);
+        holder->GetControl()->AdvancePartitionTime(partitionId, TInstant::MilliSeconds(50));
+        holder->GetControl()->AdvancePartitionTime(partitionId, eventTime);
 
         mockSession->AddDataReceivedEvent(1, "msg2");
-        session->WaitEvent().Wait(TDuration::Seconds(2));
+        holder->GetSession()->WaitEvent().Wait(TDuration::Seconds(2));
 
-        auto event2 = session->GetEvent(
+        auto event2 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event2.has_value());
         const auto* dataEv2 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event2);
@@ -319,7 +406,7 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
         auto mockSession = gateway->ExtractReadSession("topic");
         UNIT_ASSERT(mockSession != nullptr);
@@ -327,7 +414,7 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         mockSession->AddDataReceivedEvent(1, "b");
         mockSession->AddDataReceivedEvent(2, "c");
 
-        auto events = session->GetEvents(
+        auto events = holder->GetSession()->GetEvents(
             NYdb::NTopic::TReadSessionGetEventSettings()
                 .MaxEventsCount(1)
                 .MaxByteSize(65536));
@@ -342,23 +429,23 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0});
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
         auto mockSession = gateway->ExtractReadSession("topic");
         UNIT_ASSERT(mockSession != nullptr);
         mockSession->AddStartSessionEvent();
         mockSession->AddDataReceivedEvent(0, "after_start", T0);
 
-        auto event = session->GetEvent(
+        auto event = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event.has_value());
         const auto* startEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*event);
         UNIT_ASSERT(startEv != nullptr);
         const ui64 partitionId = startEv->GetPartitionSession() ? startEv->GetPartitionSession()->GetPartitionId() : 0u;
-        control->AdvancePartitionTime(partitionId, T0);
-        session->WaitEvent().Wait(TDuration::Seconds(2));
+        holder->GetControl()->AdvancePartitionTime(partitionId, T0);
+        holder->GetSession()->WaitEvent().Wait(TDuration::Seconds(2));
 
-        auto event2 = session->GetEvent(
+        auto event2 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event2.has_value());
         const auto* dataEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event2);
@@ -369,12 +456,12 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
     Y_UNIT_TEST_F(IdleTimeoutPartitionStillReceivesData, TCompositeClientTestFixture) {
         const TDuration shortIdle = TDuration::MilliSeconds(50);
         const TDuration skew = TDuration::Seconds(1);
-        const TInstant T0 = TInstant::MilliSeconds(100);
-        const TInstant T1 = TInstant::MilliSeconds(900);
+        const TInstant T0 = TInstant::MilliSeconds(10000);
+        const TInstant T1 = TInstant::MilliSeconds(90000);
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0, 1}, {}, shortIdle, skew);
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
         auto mockP0 = gateway->GetReadSession("topic", 0);
         auto mockP1 = gateway->GetReadSession("topic", 1);
         UNIT_ASSERT(mockP0 != nullptr);
@@ -382,55 +469,53 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
 
         mockP0->AddDataReceivedEvent(0, "p0_first", T0);
         mockP1->AddDataReceivedEvent(0, "p1_first", T1);
-        auto ev0 = session->GetEvent(
+        auto ev0 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev0.has_value());
         const auto* d0 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev0);
         UNIT_ASSERT(d0 != nullptr);
-        control->AdvancePartitionTime(d0->GetPartitionSession()->GetPartitionId(), d0->GetPartitionSession()->GetPartitionId() == 0 ? T0 : T1);
-        auto ev1 = session->GetEvent(
+        holder->GetControl()->AdvancePartitionTime(d0->GetPartitionSession()->GetPartitionId(), d0->GetPartitionSession()->GetPartitionId() == 0 ? T0 : T1);
+        auto ev1 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev1.has_value());
         const auto* d1 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev1);
         UNIT_ASSERT(d1 != nullptr);
-        control->AdvancePartitionTime(d1->GetPartitionSession()->GetPartitionId(), d1->GetPartitionSession()->GetPartitionId() == 0 ? T0 : T1);
+        holder->GetControl()->AdvancePartitionTime(d1->GetPartitionSession()->GetPartitionId(), d1->GetPartitionSession()->GetPartitionId() == 0 ? T0 : T1);
 
-        TString state = control->GetInternalState();
+        TString state = holder->GetControl()->GetInternalState();
         UNIT_ASSERT_C(state.Contains("SuspendedPartitions"), "Partition 1 should be suspended: " << state);
 
-        Sleep(shortIdle + TDuration::MilliSeconds(30));
+        Sleep(shortIdle + TDuration::Seconds(3));
 
-        mockP0->AddDataReceivedEvent(1, "after_idle");
         mockP1->AddDataReceivedEvent(1, "p1_after_idle_unsuspend", T1);
-        session->WaitEvent().Wait(TDuration::Seconds(2));
-        auto event1 = session->GetEvent(
+        holder->GetSession()->WaitEvent().Wait(TDuration::Seconds(2));
+        auto event1 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event1.has_value());
         const auto* dataEv1 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event1);
         UNIT_ASSERT(dataEv1 != nullptr);
         TString content1(dataEv1->GetMessages()[0].GetData());
-        UNIT_ASSERT_C(content1 == "after_idle" || content1 == "p1_after_idle_unsuspend",
-            "Expected after_idle or p1_after_idle_unsuspend, got: " << content1);
+        UNIT_ASSERT_C(content1 == "p1_after_idle_unsuspend", "Expected p1_after_idle_unsuspend, got: " << content1);
 
-        session->WaitEvent().Wait(TDuration::Seconds(2));
-        auto event2 = session->GetEvent(
+        mockP0->AddDataReceivedEvent(1, "after_idle", T1);
+        holder->GetSession()->WaitEvent().Wait(TDuration::Seconds(2));
+        auto event2 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(event2.has_value());
         const auto* dataEv2 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event2);
         UNIT_ASSERT(dataEv2 != nullptr);
         TString content2(dataEv2->GetMessages()[0].GetData());
-        UNIT_ASSERT_C(content2 == "after_idle" || content2 == "p1_after_idle_unsuspend", "Got: " << content2);
-        UNIT_ASSERT(content1 != content2);
+        UNIT_ASSERT_C(content2 == "after_idle", "Got: " << content2);
     }
 
     Y_UNIT_TEST_F(PartitionBalancingInsideOneSession, TCompositeClientTestFixture) {
         const TDuration skew = TDuration::Seconds(1);
-        const TInstant T0 = TInstant::MilliSeconds(100);
-        const TInstant T1 = TInstant::MilliSeconds(900);
+        const TInstant T0 = TInstant::MilliSeconds(10000);
+        const TInstant T1 = TInstant::MilliSeconds(90000);
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0, 1}, {}, std::nullopt, skew);
 
-        auto [session, control] = CreateSession(gateway.Get(), settings);
+        auto holder = CreateSession(gateway.Get(), settings);
 
         auto mockP0 = gateway->GetReadSession("topic", 0);
         auto mockP1 = gateway->GetReadSession("topic", 1);
@@ -438,36 +523,36 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         UNIT_ASSERT(mockP1 != nullptr);
 
         mockP0->AddDataReceivedEvent(0, "p0_msg", T0);
-        auto ev0 = session->GetEvent(
+        auto ev0 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev0.has_value());
         const auto* data0 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev0);
         UNIT_ASSERT(data0 != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(std::string(data0->GetMessages()[0].GetData()), "p0_msg");
-        control->AdvancePartitionTime(0, T0);
+        holder->GetControl()->AdvancePartitionTime(0, T0);
 
         mockP1->AddDataReceivedEvent(0, "p1_msg", T1);
-        auto ev1 = session->GetEvent(
+        auto ev1 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev1.has_value());
         const auto* data1 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev1);
         UNIT_ASSERT(data1 != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(std::string(data1->GetMessages()[0].GetData()), "p1_msg");
-        control->AdvancePartitionTime(1, T1);
+        holder->GetControl()->AdvancePartitionTime(1, T1);
 
-        TString state = control->GetInternalState();
+        TString state = holder->GetControl()->GetInternalState();
         UNIT_ASSERT_C(state.Contains("SuspendedPartitions"), "Expected suspended partitions: " << state);
         UNIT_ASSERT_C(state.Contains("PartitionId: 1"), "Partition 1 should be suspended (ahead in time): " << state);
 
-        auto evNone = session->GetEvent(
+        auto evNone = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT_C(!evNone.has_value(), "No event while partition 1 is suspended");
 
-        control->AdvancePartitionTime(0, T1);
+        holder->GetControl()->AdvancePartitionTime(0, T1);
 
         mockP1->AddDataReceivedEvent(1, "after_unsuspend", T1);
-        session->WaitEvent().Wait(TDuration::Seconds(2));
-        auto ev2 = session->GetEvent(
+        holder->GetSession()->WaitEvent().Wait(TDuration::Seconds(2));
+        auto ev2 = holder->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev2.has_value());
         const auto* data2 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev2);
@@ -479,10 +564,10 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
 
         auto settingsA = MakeSettings("topic_a", {0}, {}, std::nullopt, std::nullopt, 0);
-        auto [sessionA, controlA] = CreateSession(gateway.Get(), settingsA);
+        auto holderA = CreateSession(gateway.Get(), settingsA);
 
         auto settingsB = MakeSettings("topic_b", {0}, {}, std::nullopt, std::nullopt, 1);
-        auto [sessionB, controlB] = CreateSession(gateway.Get(), settingsB);
+        auto holderB = CreateSession(gateway.Get(), settingsB);
 
         auto mockA = gateway->ExtractReadSession("topic_a");
         auto mockB = gateway->ExtractReadSession("topic_b");
@@ -492,9 +577,9 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         mockA->AddDataReceivedEvent(0, "data_a");
         mockB->AddDataReceivedEvent(0, "data_b");
 
-        auto evA = sessionA->GetEvent(
+        auto evA = holderA->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
-        auto evB = sessionB->GetEvent(
+        auto evB = holderB->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
 
         UNIT_ASSERT(evA.has_value());
@@ -513,7 +598,7 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
         auto settings = MakeSettings("topic", {0, 1});
 
-        auto [session1, control1] = CreateSession(gateway.Get(), settings);
+        auto holder1 = CreateSession(gateway.Get(), settings);
         auto mockP0_1 = gateway->GetReadSession("topic", 0);
         auto mockP1_1 = gateway->GetReadSession("topic", 1);
         UNIT_ASSERT(mockP0_1 != nullptr);
@@ -521,26 +606,26 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
 
         mockP0_1->AddDataReceivedEvent(0, "first_p0", T0);
         mockP1_1->AddDataReceivedEvent(0, "first_p1", T1);
-        auto ev0 = session1->GetEvent(
+        auto ev0 = holder1->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev0.has_value());
         const auto* d0 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev0);
         UNIT_ASSERT(d0 != nullptr);
         ui64 pid0 = d0->GetPartitionSession()->GetPartitionId();
-        control1->AdvancePartitionTime(pid0, pid0 == 0 ? T0 : T1);
-        auto ev1 = session1->GetEvent(
+        holder1->GetControl()->AdvancePartitionTime(pid0, pid0 == 0 ? T0 : T1);
+        auto ev1 = holder1->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev1.has_value());
         const auto* d1 = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev1);
         UNIT_ASSERT(d1 != nullptr);
         ui64 pid1 = d1->GetPartitionSession()->GetPartitionId();
-        control1->AdvancePartitionTime(pid1, pid1 == 0 ? T0 : T1);
+        holder1->GetControl()->AdvancePartitionTime(pid1, pid1 == 0 ? T0 : T1);
         UNIT_ASSERT(pid0 != pid1);
 
-        UNIT_ASSERT(session1->Close(TDuration::Zero()));
+        UNIT_ASSERT(holder1->GetSession()->Close(TDuration::Zero()));
 
-        auto [session2, control2] = CreateSession(gateway.Get(), settings);
-        UNIT_ASSERT(!session2->GetSessionId().empty());
+        auto holder2 = CreateSession(gateway.Get(), settings);
+        UNIT_ASSERT(!holder2->GetSession()->GetSessionId().empty());
         auto mockP0_2 = gateway->GetReadSession("topic", 0);
         auto mockP1_2 = gateway->GetReadSession("topic", 1);
         UNIT_ASSERT(mockP0_2 != nullptr);
@@ -548,7 +633,7 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
 
         mockP0_2->AddDataReceivedEvent(1, "reconnected_p0", T0);
         mockP1_2->AddDataReceivedEvent(1, "reconnected_p1", T1);
-        auto ev2a = session2->GetEvent(
+        auto ev2a = holder2->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev2a.has_value());
         const auto* d2a = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev2a);
@@ -556,9 +641,9 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         TString content2a(d2a->GetMessages()[0].GetData());
         UNIT_ASSERT(content2a == "reconnected_p0" || content2a == "reconnected_p1");
         ui64 pid2a = d2a->GetPartitionSession()->GetPartitionId();
-        control2->AdvancePartitionTime(pid2a, pid2a == 0 ? T0 : T1);
-        session2->WaitEvent().Wait(TDuration::Seconds(2));
-        auto ev2b = session2->GetEvent(
+        holder2->GetControl()->AdvancePartitionTime(pid2a, pid2a == 0 ? T0 : T1);
+        holder2->GetSession()->WaitEvent().Wait(TDuration::Seconds(2));
+        auto ev2b = holder2->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(ev2b.has_value());
         const auto* d2b = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev2b);
@@ -570,8 +655,8 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
 
     Y_UNIT_TEST_F(PartitionBalancingBetweenTwoSessions, TCompositeClientTestFixture) {
         const TDuration skew = TDuration::Seconds(1);
-        const TInstant T0 = TInstant::MilliSeconds(100);
-        const TInstant T1 = TInstant::MilliSeconds(1200);
+        const TInstant T0 = TInstant::MilliSeconds(10000);
+        const TInstant T1 = TInstant::MilliSeconds(120000);
         auto gateway = CreateMockPqGateway({.OperationTimeout = TDuration::Seconds(5), .Runtime = &Runtime});
 
         auto settingsA = MakeSettings("topic", {0}, {}, std::nullopt, skew, 0);
@@ -580,8 +665,8 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         // becomes true when both have started and aggregator can propagate read_time.
         settingsA.AmountPartitionsCount = 2;
         settingsB.AmountPartitionsCount = 2;
-        auto [sessionA, controlA] = CreateSession(gateway.Get(), settingsA);
-        auto [sessionB, controlB] = CreateSession(gateway.Get(), settingsB);
+        auto holderA = CreateSession(gateway.Get(), settingsA);
+        auto holderB = CreateSession(gateway.Get(), settingsB);
 
         auto mockP0 = gateway->GetReadSession("topic", 0);
         auto mockP1 = gateway->GetReadSession("topic", 1);
@@ -589,37 +674,37 @@ Y_UNIT_TEST_SUITE(TCompositeTopicReadSessionTest) {
         UNIT_ASSERT(mockP1 != nullptr);
 
         mockP0->AddDataReceivedEvent(0, "p0_msg", T0);
-        auto evA = sessionA->GetEvent(
+        auto evA = holderA->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(evA.has_value());
         const auto* dataA = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*evA);
         UNIT_ASSERT(dataA != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(std::string(dataA->GetMessages()[0].GetData()), "p0_msg");
-        controlA->AdvancePartitionTime(0, T0);
+        holderA->GetControl()->AdvancePartitionTime(0, T0);
 
         mockP1->AddDataReceivedEvent(0, "p1_msg", T1);
-        auto evB = sessionB->GetEvent(
+        auto evB = holderB->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT(evB.has_value());
         const auto* dataB = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*evB);
         UNIT_ASSERT(dataB != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(std::string(dataB->GetMessages()[0].GetData()), "p1_msg");
-        controlB->AdvancePartitionTime(1, T1);
+        holderB->GetControl()->AdvancePartitionTime(1, T1);
 
-        TString stateB = controlB->GetInternalState();
+        TString stateB = holderB->GetControl()->GetInternalState();
         UNIT_ASSERT_C(stateB.Contains("SuspendedPartitions"), "Session B should have suspended partition: " << stateB);
 
         mockP1->AddDataReceivedEvent(1, "blocked_until_a_advances", T1);
-        auto evNone = sessionB->GetEvent(
+        auto evNone = holderB->GetSession()->GetEvent(
             NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
         UNIT_ASSERT_C(!evNone.has_value(), "Session B should not get event while its partition is suspended (waiting for A)");
 
-        controlA->AdvancePartitionTime(0, T1);
+        holderA->GetControl()->AdvancePartitionTime(0, T1);
         std::optional<NYdb::NTopic::TReadSessionEvent::TEvent> evB2;
         const auto deadline = TInstant::Now() + TDuration::Seconds(10);
         while (TInstant::Now() < deadline) {
-            sessionB->WaitEvent().Wait(TDuration::Seconds(1));
-            evB2 = sessionB->GetEvent(
+            holderB->GetSession()->WaitEvent().Wait(TDuration::Seconds(1));
+            evB2 = holderB->GetSession()->GetEvent(
                 NYdb::NTopic::TReadSessionGetEventSettings().MaxEventsCount(1).MaxByteSize(4096));
             if (evB2.has_value()) {
                 break;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed unit tests for PartitionBalancingBetweenTwoSessions

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

[...](https://github.com/ydb-platform/ydb/issues/35355)
