### PR TITLE
events: make type names useful for serialized events

### DIFF
--- a/ydb/library/actors/core/event.cpp
+++ b/ydb/library/actors/core/event.cpp
@@ -12,7 +12,9 @@ namespace NActors {
     const TEventSerializedData IEventHandle::EmptyBuffer;
 
     TString IEventHandle::GetTypeName() const {
-        return HasEvent() ? TypeName(*(const_cast<IEventHandle*>(this)->GetBase())) : TypeName(*this);
+        return HasEvent()
+            ? TypeName(*(const_cast<IEventHandle*>(this)->GetBase()))
+            : TStringBuilder() << "ev_serialized_" << (GetTypeRewrite() >> 16u) << "_" << (GetTypeRewrite() & ((1u << 16u) - 1));
     }
 
     TString IEventHandle::ToString() const {


### PR DESCRIPTION
Currently, `IEventHandle::GetTypeName()` returns `NActors::IEventHandle` for any serialized event, losing type information.

This change returns type names based on the actual event type: `ev_serialized_{event-space}_{event-id}` (for serialized events only).

Example: If `GetTypeRewrite()` returns `0x00020005`, the method now returns `ev_serialized_2_5` instead of the generic `NActors::IEventHandle`.

This improves debugging and logging by providing specific information about serialized event types, making it easier to identify the event space and ID.