### PR TITLE
testlib: print event type also on pipe resets

### DIFF
--- a/ydb/core/testlib/tablet_helpers.cpp
+++ b/ydb/core/testlib/tablet_helpers.cpp
@@ -413,11 +413,13 @@ namespace NKikimr {
 
             HasReset0 = true;
 
-            if (ENABLE_REBOOT_DISPATCH_LOG)
-                Cerr << "!Reset pipe\n";
+            TActorId targetActorId = event->GetRecipientRewrite();
+
+            if (ENABLE_REBOOT_DISPATCH_LOG) {
+                Cerr << "!Reset pipe (actor " << targetActorId << ") on event " << event->GetTypeName() << Endl;
+            }
 
             // Replace the event with PoisonPill in order to kill PipeClient or PipeServer
-            TActorId targetActorId = event->GetRecipientRewrite();
             runtime.Send(new IEventHandle(targetActorId, TActorId(), new TEvents::TEvPoisonPill()));
 
             return TTestActorRuntime::EEventAction::DROP;


### PR DESCRIPTION
Improved debug logging in tablet_helpers.cpp pipe reset simulation to match reboot logging. The log now shows both the target actor ID and the event type that triggered the reset, making debugging easier.

Changed from:
```
!Reset pipe
```

To:
```
!Reset pipe (actor <ActorId>) on event <EventType>
```
