### PR TITLE
schemeshard: fix Y_UNIT_TEST_WITH_REBOOTS_BUCKETS

### DIFF
--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -1293,7 +1293,7 @@ NSchemeShardUT_Private::TTestEnv* NSchemeShardUT_Private::TTestWithReboots::Crea
 
 
 void NSchemeShardUT_Private::TTestWithReboots::Prepare(const TString &dispatchName, std::function<void (TTestActorRuntime &)> setup, bool &outActiveZone) {
-    Cdbg << Endl << "=========== RUN: "<< dispatchName << " ===========" << Endl;
+    Cdbg << Endl << "======" << TInstant::Now() << "===== RUN: "<< dispatchName << " ===========" << Endl;
 
     outActiveZone = false;
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h
@@ -9,9 +9,12 @@ public:
     explicit TTestWithTabletReboots(bool killOnCommit = false)
         : TTestWithReboots(killOnCommit)
     {}
-    void Run(std::function<void(TTestActorRuntime& runtime, bool& activeZone)> testScenario) override {
-        TDatashardLogBatchingSwitch logBatchingSwitch(false /* without batching */);
+    void Run(std::function<void(TTestActorRuntime& runtime, bool& activeZone)> testScenario, bool allowLogBatching) override {
+        TDatashardLogBatchingSwitch logBatchingSwitch(allowLogBatching);
         RunWithTabletReboots(testScenario);
+    }
+    void Run(std::function<void(TTestActorRuntime& runtime, bool& activeZone)> testScenario) override {
+        Run(testScenario, false /* without batching */);
     }
 };
 
@@ -20,9 +23,12 @@ public:
     explicit TTestWithPipeResets(bool killOnCommit = false)
         : TTestWithReboots(killOnCommit)
     {}
-    void Run(std::function<void(TTestActorRuntime& runtime, bool& activeZone)> testScenario) override {
-        TDatashardLogBatchingSwitch logBatchingSwitch(false /* without batching */);
+    void Run(std::function<void(TTestActorRuntime& runtime, bool& activeZone)> testScenario, bool allowLogBatching) override {
+        TDatashardLogBatchingSwitch logBatchingSwitch(allowLogBatching);
         RunWithPipeResets(testScenario);
+    }
+    void Run(std::function<void(TTestActorRuntime& runtime, bool& activeZone)> testScenario) override {
+        Run(testScenario, false /* without batching */);
     }
 };
 


### PR DESCRIPTION
Fix `Y_UNIT_TEST_WITH_REBOOTS_BUCKETS` to avoid running unnecessary test iterations.

Fixed performance issue where `TTestWithTabletReboots` and `TTestWithPipeResets` were inheriting the base class `Run()` method that executes both tablet reboots and pipe resets, causing tests to run twice as many iterations as needed. Now each derived class properly overrides `Run()` to execute only its specific test type.

Also added timestamp logging on reboot iterations to help measure iteration times.