### PR TITLE
Fix port manager usage in olap tests

### DIFF
--- a/ydb/tests/library/harness/kikimr_port_allocator.py
+++ b/ydb/tests/library/harness/kikimr_port_allocator.py
@@ -2,7 +2,7 @@
 import abc
 import os
 import yatest
-import yatest.common.network
+import library.python.port_manager
 
 
 class KikimrNodePortAllocatorInterface(object):
@@ -152,7 +152,7 @@ class KikimrPortManagerNodePortAllocator(KikimrNodePortAllocatorInterface):
 class KikimrPortManagerPortAllocator(KikimrPortAllocatorInterface):
     def __init__(self, port_manager=None):
         super(KikimrPortManagerPortAllocator, self).__init__()
-        self.__port_manager = yatest.common.network.PortManager() if port_manager is None else port_manager
+        self.__port_manager = library.python.port_manager.PortManager() if port_manager is None else port_manager
         self.__nodes_allocators = []
         self.__slots_allocators = []
 

--- a/ydb/tests/olap/common/s3_client.py
+++ b/ydb/tests/olap/common/s3_client.py
@@ -5,13 +5,13 @@ from typing import Tuple, Optional
 import boto3
 import yatest.common
 from library.recipes import common as recipes_common
-
+import library.python.port_manager
 
 class S3Mock:
     def __init__(self, moto_server_path: str):
         self.moto_server_path = moto_server_path
         self.s3_pid_file = "s3.pid"
-        self.port_manager = yatest.common.network.PortManager()
+        self.port_manager = library.python.port_manager.PortManager()
 
         self.endpoint: Optional[str] = None
         self.s3_pid: Optional[int] = None

--- a/ydb/tests/olap/s3_import/base.py
+++ b/ydb/tests/olap/s3_import/base.py
@@ -26,6 +26,7 @@ class S3ImportTestBase(object):
     @classmethod
     def _get_ydb_config(cls):
         config = KikimrConfigGenerator(
+            port_allocator=KikimrPortManagerPortAllocator(port_manager=cls.s3_mock.port_manager),
             extra_feature_flags={
                 "enable_external_data_sources": True,
                 "enable_move_column_table": True,

--- a/ydb/tests/olap/s3_import/base.py
+++ b/ydb/tests/olap/s3_import/base.py
@@ -5,6 +5,7 @@ from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.olap.common.s3_client import S3Mock, S3Client
 from ydb.tests.olap.common.ydb_client import YdbClient
+from ydb.tests.library.harness.kikimr_port_allocator import KikimrPortManagerPortAllocator
 
 import yatest.common
 
@@ -14,8 +15,8 @@ logger = logging.getLogger(__name__)
 class S3ImportTestBase(object):
     @classmethod
     def setup_class(cls):
-        cls._setup_ydb()
         cls._setup_s3()
+        cls._setup_ydb()
 
     @classmethod
     def teardown_class(cls):

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -26,7 +26,7 @@ from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.library.harness.kikimr_port_allocator import KikimrPortManagerPortAllocator
 
 from ydb import PrimitiveType, StatusCode
-import yatest.common
+import library.python.port_manager
 from moto.server import ThreadedMotoServer
 
 import boto3
@@ -54,7 +54,7 @@ class TestLoop:
 
 
 class S3:
-    def __init__(self, self.port_manager):
+    def __init__(self, port_manager):
         self.port_manager = port_manager
         self._server = None
 
@@ -125,12 +125,20 @@ class TieringTestBase(BaseTestSet):
             ),
         )
 
+    @classmethod
+    def setup_class(cls):
+        cls.port_manager = library.python.port_manager.PortManager()
+        super().setup_class()
+
+    @classmethod
+    def teardown_class(cls):
+        super().teardown_class()
+        cls.port_manager.release()
+
     def _setup_tiering_test(self, ctx):
         random.seed(0)
 
         LOGGER.info('Initializing test parameters')
-        if self.port_manager is None:
-            self.port_manager = yatest.common.network.PortManager()
         self.s3_endpoint = get_external_param('s3-endpoint', '')
         self.s3_buckets = list(get_external_param('s3-buckets', 'ydb-tiering-test-1,ydb-tiering-test-2').split(','))
         self.s3_access_key = os.getenv('S3_ACCESS_KEY', 'access_key')

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -23,6 +23,7 @@ from ydb.tests.olap.lib.utils import get_external_param
 from ydb.tests.olap.lib.ydb_cluster import YdbCluster
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
+from ydb.tests.library.harness.kikimr_port_allocator import KikimrPortManagerPortAllocator
 
 from ydb import PrimitiveType, StatusCode
 import yatest.common
@@ -53,11 +54,13 @@ class TestLoop:
 
 
 class S3:
-    def __init__(self):
+    def __init__(self, self.port_manager):
+        self.port_manager = port_manager
         self._server = None
 
     def start_server(self) -> str:
-        port = yatest.common.network.PortManager().get_port()
+        port = self.port_manager.get_port()
+
         self._server = ThreadedMotoServer(port=port)
         self._server.start()
         return f'http://localhost:{port}'
@@ -98,6 +101,7 @@ class TieringTestBase(BaseTestSet):
     @classmethod
     def _get_cluster_config(cls):
         return KikimrConfigGenerator(
+            port_allocator=KikimrPortManagerPortAllocator(port_manager=cls.port_manager),
             extra_feature_flags=[
                 'enable_external_data_sources',
                 'enable_tiering_in_column_shard',
@@ -125,6 +129,8 @@ class TieringTestBase(BaseTestSet):
         random.seed(0)
 
         LOGGER.info('Initializing test parameters')
+        if self.port_manager is None:
+            self.port_manager = yatest.common.network.PortManager()
         self.s3_endpoint = get_external_param('s3-endpoint', '')
         self.s3_buckets = list(get_external_param('s3-buckets', 'ydb-tiering-test-1,ydb-tiering-test-2').split(','))
         self.s3_access_key = os.getenv('S3_ACCESS_KEY', 'access_key')
@@ -132,7 +138,7 @@ class TieringTestBase(BaseTestSet):
 
         assert len(self.s3_buckets) == 2, len(self.s3_buckets)
 
-        self.s3 = S3()
+        self.s3 = S3(self.port_manager)
         if not self.s3_endpoint:
             LOGGER.info('Starting S3 server')
             self.s3_endpoint = self.s3.start_server()


### PR DESCRIPTION
port manager was created twice which lead to "port already allocated" errors locally(i've reproduced these errors with high, ~100, test running parallelism)
...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
