### PR TITLE
Make TServer driver private

### DIFF
--- a/ydb/core/testlib/common_helper.cpp
+++ b/ydb/core/testlib/common_helper.cpp
@@ -53,7 +53,7 @@ void THelper::WaitForSchemeOperation(TActorId sender, ui64 txId) {
 }
 
 void THelper::StartScanRequest(const TString& request, const bool expectSuccess, TVector<THashMap<TString, NYdb::TValue>>* result) const {
-    NYdb::NTable::TTableClient tClient(Server.GetDriver(),
+    NYdb::NTable::TTableClient tClient(*Driver,
         NYdb::NTable::TClientSettings().UseQueryCache(false).AuthToken(AuthToken));
     auto expectation = expectSuccess;
     bool resultReady = false;
@@ -109,7 +109,7 @@ void THelper::StartScanRequest(const TString& request, const bool expectSuccess,
 }
 
 void THelper::StartDataRequest(const TString& request, const bool expectSuccess, TString* result) const {
-    NYdb::NTable::TTableClient tClient(Server.GetDriver(),
+    NYdb::NTable::TTableClient tClient(*Driver,
         NYdb::NTable::TClientSettings().UseQueryCache(false).AuthToken(AuthToken));
     auto expectation = expectSuccess;
     bool resultReady = false;
@@ -144,7 +144,7 @@ void THelper::StartDataRequest(const TString& request, const bool expectSuccess,
 }
 
 void THelper::StartSchemaRequestTableServiceImpl(const TString& request, const bool expectation, const bool waiting) const {
-    NYdb::NTable::TTableClient tClient(Server.GetDriver(),
+    NYdb::NTable::TTableClient tClient(*Driver,
         NYdb::NTable::TClientSettings().UseQueryCache(false).AuthToken(AuthToken));
 
     std::shared_ptr<bool> rrPtr = std::make_shared<bool>(false);
@@ -171,7 +171,7 @@ void THelper::StartSchemaRequestTableServiceImpl(const TString& request, const b
 }
 
 void THelper::StartSchemaRequestQueryServiceImpl(const TString& request, const bool expectation, const bool waiting) const {
-    NYdb::NQuery::TQueryClient qClient(Server.GetDriver(),
+    NYdb::NQuery::TQueryClient qClient(*Driver,
         NYdb::NQuery::TClientSettings().AuthToken(AuthToken));
 
     std::shared_ptr<bool> rrPtr = std::make_shared<bool>(false);

--- a/ydb/core/testlib/common_helper.h
+++ b/ydb/core/testlib/common_helper.h
@@ -66,11 +66,24 @@ protected:
     void StartSchemaRequestQueryServiceImpl(const TString& request, const bool expectSuccess, const bool waiting) const;
 
     Tests::TServer& Server;
+    THolder<NYdb::TDriver> Driver;
     bool UseQueryService = false;
 public:
     THelper(TServer& server)
-        : Server(server) {
+        : Server(server)
+    {
+        TString endpoint = "localhost:" + ToString(Server.GetSettings().GrpcPort);
+        auto driverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(endpoint)
+            .SetDatabase("/" + Server.GetSettings().DomainName);
 
+        // In simulated runtime, use async discovery mode
+        // to avoid blocking on endpoint discovery during event dispatching
+        if (!Server.GetSettings().UseRealThreads) {
+            driverConfig.SetDiscoveryMode(NYdb::EDiscoveryMode::Async);
+        }
+
+        Driver = MakeHolder<NYdb::TDriver>(driverConfig);
     }
 
     void SetUseQueryService(bool use = true) {

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1493,7 +1493,10 @@ namespace Tests {
             Runtime->RegisterService(NIcNodeCache::CreateICNodesInfoCacheServiceId(), icCacheId, nodeIdx);
         }
         {
-            auto driverConfig = NYdb::TDriverConfig().SetEndpoint(TStringBuilder() << "localhost:" << Settings->GrpcPort);
+            TString endpoint = "localhost:" + ToString(Settings->GrpcPort);
+            auto driverConfig = NYdb::TDriverConfig()
+                .SetEndpoint(endpoint);
+
             if (!Driver) {
                 Driver.Reset(new NYdb::TDriver(driverConfig));
             }
@@ -1827,11 +1830,6 @@ namespace Tests {
 
     const NMiniKQL::IFunctionRegistry* TServer::GetFunctionRegistry() {
         return Runtime->GetAppData().FunctionRegistry;
-    }
-
-    const NYdb::TDriver& TServer::GetDriver() const {
-        Y_ABORT_UNLESS(Driver);
-        return *Driver;
     }
 
     const NYdbGrpc::TGRpcServer& TServer::GetGRpcServer() const {

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -405,7 +405,6 @@ namespace Tests {
         const TServerSettings& GetSettings() const;
         const NScheme::TTypeRegistry* GetTypeRegistry();
         const NMiniKQL::IFunctionRegistry* GetFunctionRegistry();
-        const NYdb::TDriver& GetDriver() const;
         const NYdbGrpc::TGRpcServer& GetGRpcServer() const;
         const NYdbGrpc::TGRpcServer& GetTenantGRpcServer(const TString& tenant) const;
         TIntrusivePtr<NMemory::IProcessMemoryInfoProvider> GetProcessMemoryInfoProvider() const;

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -866,7 +866,12 @@ Y_UNIT_TEST_SUITE(Cdc) {
             WaitTxNotification(Server, EdgeActor, AsyncAlterAddStream(Server, database, tableName, streamDesc));
 
             if (useRealThreads) {
-                Client = TDerived::MakeClient(Server->GetDriver(), database);
+                TString endpoint = "localhost:" + ToString(settings.GrpcPort);
+                auto driverConfig = NYdb::TDriverConfig()
+                    .SetEndpoint(endpoint)
+                    .SetDatabase("/" + settings.DomainName);
+                auto driver = NYdb::TDriver(driverConfig);
+                Client = TDerived::MakeClient(driver, database);
             }
         }
 
@@ -1427,7 +1432,7 @@ Y_UNIT_TEST_SUITE(Cdc) {
         }
 
         static void Read(const TShardedTableOptions& tableDesc, const TCdcStream& streamDesc,
-                const TVector<TString>& queries, const TVector<TJsonString>& records, bool checkKey = true, 
+                const TVector<TString>& queries, const TVector<TJsonString>& records, bool checkKey = true,
                 const TString& userSID = TString())
         {
             Y_UNUSED(checkKey);
@@ -2633,7 +2638,7 @@ Y_UNIT_TEST_SUITE(Cdc) {
                     }
                 }
                 return TTestActorRuntime::EEventAction::PROCESS;
-            
+
             case NKikimr::NEvents::TDataEvents::EvWriteResult:
                 if (auto* msg = ev->Get<NKikimr::NEvents::TDataEvents::TEvWriteResult>()) {
                     if (msg->GetStatus() == NKikimrDataEvents::TEvWriteResult::STATUS_COMPLETED) {

--- a/ydb/core/tx/datashard/datashard_ut_erase_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_erase_rows.cpp
@@ -395,7 +395,7 @@ Y_UNIT_TEST_SUITE(EraseRowsTests) {
 
     Y_UNIT_TEST(EraseRowsCdc) {
         TPortManager pm;
-        
+
         NKikimrPQ::TPQConfig pqConfig;
         pqConfig.SetEnabled(true);
         pqConfig.SetEnableProtoSourceIdInfo(true);
@@ -413,7 +413,7 @@ Y_UNIT_TEST_SUITE(EraseRowsTests) {
         serverSettings.SetUseRealThreads(true)
             .SetDomainName(databaseName)
             .SetGrpcPort(pm.GetPort(2135));
-        
+
         TServer::TPtr server = new TServer(serverSettings);
         server->EnableGRpc(serverSettings.GrpcPort);
         auto& runtime = *server->GetRuntime();
@@ -452,7 +452,13 @@ Y_UNIT_TEST_SUITE(EraseRowsTests) {
         UNIT_ASSERT_STRINGS_EQUAL(StripInPlace(content), "key = 3, value = 2020-04-15T00:00:00.000000Z");
 
         // open client
-        auto client = MakeHolder<NYdb::NPersQueue::TPersQueueClient>(server->GetDriver(), NYdb::NPersQueue::TPersQueueClientSettings().Database(databaseName));
+        TString endpoint = "localhost:" + ToString(serverSettings.GrpcPort);
+        auto driverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(endpoint)
+            .SetDatabase("/" + serverSettings.DomainName);
+        auto driver = NYdb::TDriver(driverConfig);
+
+        auto client = MakeHolder<NYdb::NPersQueue::TPersQueueClient>(driver, NYdb::NPersQueue::TPersQueueClientSettings().Database(databaseName));
 
         // add consumer
         const TString consumerName{"user"};
@@ -471,7 +477,7 @@ Y_UNIT_TEST_SUITE(EraseRowsTests) {
         );
 
         // fetch stream
-        
+
         ui32 reads = 0;
         while (reads < 2) {
             auto ev = reader->GetEvent(true);
@@ -491,7 +497,7 @@ Y_UNIT_TEST_SUITE(EraseRowsTests) {
                     TString itemUser = itemJson["user"].GetString();
                     UNIT_ASSERT_VALUES_EQUAL(itemUser, "ttl@system");
                 }
-            } 
+            }
             else if (auto* create = std::get_if<NYdb::NPersQueue::TReadSessionEvent::TCreatePartitionStreamEvent>(&*ev)) {
                 pStream = create->GetPartitionStream();
                 create->Confirm();

--- a/ydb/core/tx/replication/ut_helpers/test_env.h
+++ b/ydb/core/tx/replication/ut_helpers/test_env.h
@@ -34,6 +34,11 @@ class TEnv {
         Endpoint = "localhost:" + ToString(grpcPort);
         Database = "/" + ToString(DomainName);
 
+        auto driverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(Endpoint)
+            .SetDatabase(Database);
+        Driver = MakeHolder<NYdb::TDriver>(driverConfig);
+
         YdbProxy = Server.GetRuntime()->Register(CreateYdbProxy(
             Endpoint, UseDatabase ? Database : "", false /* ssl */, "" /* cert */, std::forward<Args>(args)...));
         Sender = Server.GetRuntime()->AllocateEdgeActor();
@@ -220,7 +225,7 @@ public:
     }
 
     const NYdb::TDriver& GetDriver() const {
-        return Server.GetDriver();
+        return *Driver;
     }
 
     const TString& GetEndpoint() const {
@@ -244,6 +249,7 @@ private:
     Tests::TServerSettings Settings;
     Tests::TServer Server;
     Tests::TClient Client;
+    THolder<NYdb::TDriver> Driver;
     TString Endpoint;
     TString Database;
     TActorId YdbProxy;

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h
@@ -23,6 +23,7 @@ public:
         : PortManager(portManager.GetOrElse(MakeSimpleShared<TPortManager>()))
         , Port(PortManager->GetPort(2134))
         , GrpcPort(PortManager->GetPort(2135))
+        , Endpoint("localhost:" + ToString(GrpcPort))
         , ServerSettings(settings)
         , GrpcServerOptions(NYdbGrpc::TServerOptions().SetHost("[::1]").SetPort(GrpcPort))
     {
@@ -61,6 +62,11 @@ public:
 
         CleverServer = MakeHolder<NKikimr::Tests::TServer>(ServerSettings);
         CleverServer->EnableGRpc(GrpcServerOptions);
+
+        auto driverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(Endpoint)
+            .SetDatabase("/" + ServerSettings.DomainName);
+        Driver = MakeHolder<NYdb::TDriver>(driverConfig);
 
         Log << TLOG_INFO << "TTestServer started on Port " << Port << " GrpcPort " << GrpcPort;
 
@@ -121,7 +127,7 @@ public:
     }
 
     const NYdb::TDriver& GetDriver() const {
-        return CleverServer->GetDriver();
+        return *Driver;
     }
 
     void KillTopicPqrbTablet(const TString& topicPath) {
@@ -164,6 +170,7 @@ public:
     TSimpleSharedPtr<TPortManager> PortManager;
     ui16 Port;
     ui16 GrpcPort;
+    TString Endpoint;
 
     THolder<NKikimr::Tests::TServer> CleverServer;
     NKikimr::Tests::TServerSettings ServerSettings;
@@ -176,6 +183,8 @@ public:
 
 
     static const TVector<NKikimrServices::EServiceKikimr> LOGGED_SERVICES;
+private:
+    THolder<NYdb::TDriver> Driver;
 };
 
 } // namespace NPersQueue

--- a/ydb/services/metadata/secret/ut/ut_secret.cpp
+++ b/ydb/services/metadata/secret/ut/ut_secret.cpp
@@ -285,13 +285,13 @@ Y_UNIT_TEST_SUITE(Secret) {
             lHelper.StartSchemaRequest("ALTER OBJECT secret1 (TYPE SECRET) SET value = `abcde`", false);
             lHelper.StartSchemaRequest("CREATE OBJECT secret1 (TYPE SECRET) WITH value = `100`");
             lHelper.StartSchemaRequest("ALTER OBJECT secret1 (TYPE SECRET) SET value = `abcde`");
-            lHelper.StartSchemaRequest("CREATE OBJECT `secret1:test@test1` (TYPE SECRET_ACCESS)");
-            lHelper.StartSchemaRequest("CREATE OBJECT `secret2:test@test1` (TYPE SECRET_ACCESS)", false);
-            lHelper.StartSchemaRequest("CREATE OBJECT IF NOT EXISTS `secret1:test@test1` (TYPE SECRET_ACCESS)");
+            lHelper.StartSchemaRequest("CREATE OBJECT `secret1:test@builtin` (TYPE SECRET_ACCESS)");
+            lHelper.StartSchemaRequest("CREATE OBJECT `secret2:test@builtin` (TYPE SECRET_ACCESS)", false);
+            lHelper.StartSchemaRequest("CREATE OBJECT IF NOT EXISTS `secret1:test@builtin` (TYPE SECRET_ACCESS)");
             lHelper.StartSchemaRequest("DROP OBJECT `secret1` (TYPE SECRET)", false);
             lHelper.StartDataRequest("SELECT * FROM `/Root/.metadata/secrets/values`", false);
 
-            lHelper.SetAuthToken("test@test1");
+            lHelper.SetAuthToken("test@builtin");
             lHelper.StartSchemaRequest("CREATE OBJECT secret1 (TYPE SECRET) WITH value = `100`", false);
             lHelper.StartSchemaRequest("UPSERT OBJECT secret1 (TYPE SECRET) WITH value = `100`", false);
             lHelper.StartSchemaRequest("CREATE OBJECT secret2 (TYPE SECRET) WITH value = `100`");


### PR DESCRIPTION
To avoid difficult to detect bugs related to TServer internal driver I decided to hide it from external usage:
There were several possible misuse of this driver:

- use it without GrpcEnable call caused unsuccessful discovery service lookup because the service hadn't been run
- use it in `UseRealThreads == false` mode and default Sync Discovery Mode caused connection timeout because SDK call processing was blocked.
