### PR TITLE
[EXT-2005] Fallback DC and Rack values to Interconnect info

### DIFF
--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -566,8 +566,6 @@ message TNodeInfo {
     float CpuUsage = 5;
     float DiskSpaceUsage = 6;
     optional uint32 Connections = 7; // total number of live connections
-    optional string DataCenter = 8;
-    optional string Rack = 9;
     EFlag ConnectStatus = 10; // Max
     optional uint64 ReceiveThroughput = 11;
     optional uint64 SendThroughput = 12;

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -566,6 +566,8 @@ message TNodeInfo {
     float CpuUsage = 5;
     float DiskSpaceUsage = 6;
     optional uint32 Connections = 7; // total number of live connections
+    optional string DataCenter = 8;
+    optional string Rack = 9;
     EFlag ConnectStatus = 10; // Max
     optional uint64 ReceiveThroughput = 11;
     optional uint64 SendThroughput = 12;

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -276,6 +276,38 @@ class TJsonNodes : public TViewerPipeClient {
             return SystemState.GetLocation().GetBridgePileName();
         }
 
+        void ApplyInterconnectLocationFallback() {
+            std::optional<TString> dataCenter;
+            std::optional<TString> rack;
+            std::optional<TString> unit;
+            for (const auto& [key, value] : NodeInfo.Location.GetItems()) {
+                switch (key) {
+                    case NActors::TNodeLocation::TKeys::DataCenter:
+                        dataCenter = value;
+                        break;
+                    case NActors::TNodeLocation::TKeys::Rack:
+                        rack = value;
+                        break;
+                    case NActors::TNodeLocation::TKeys::Unit:
+                        unit = value;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            auto* location = SystemState.MutableLocation();
+            if (!location->HasDataCenter() && dataCenter.has_value()) {
+                location->SetDataCenter(*dataCenter);
+            }
+            if (!location->HasRack() && rack.has_value()) {
+                location->SetRack(*rack);
+            }
+            if (!location->HasUnit() && unit.has_value()) {
+                location->SetUnit(*unit);
+            }
+        }
+
         void Cleanup() {
             if (SystemState.HasSystemLocation()) {
                 SystemState.ClearSystemLocation();
@@ -3331,6 +3363,7 @@ public:
         }
         if (NodeGroups.empty()) {
             for (TNode* node : NodeView) {
+                node->ApplyInterconnectLocationFallback();
                 NKikimrViewer::TNodeInfo& jsonNode = *json.AddNodes();
                 if (FieldsAvailable.test(+ENodeFields::NodeInfo)) {
                     jsonNode.SetNodeId(node->GetNodeId());
@@ -3364,12 +3397,6 @@ public:
                 }
                 if (FieldsAvailable.test(+ENodeFields::CapacityAlert) && FieldsRequested.test(+ENodeFields::CapacityAlert)) {
                     jsonNode.SetCapacityAlert(NKikimrBlobStorage::TPDiskSpaceColor::E_Name(node->CapacityAlert));
-                }
-                if (FieldsAvailable.test(+ENodeFields::DC) && FieldsRequested.test(+ENodeFields::DC)) {
-                    jsonNode.SetDataCenter(node->GetDataCenter());
-                }
-                if (FieldsAvailable.test(+ENodeFields::Rack) && FieldsRequested.test(+ENodeFields::Rack)) {
-                    jsonNode.SetRack(node->GetRack());
                 }
                 if (FieldsAvailable.test(+ENodeFields::Connections) && FieldsRequested.test(+ENodeFields::Connections)) {
                     jsonNode.SetConnections(node->Connections);

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -276,24 +276,6 @@ class TJsonNodes : public TViewerPipeClient {
             return SystemState.GetLocation().GetBridgePileName();
         }
 
-        void FillLocationFromInterconnect() {
-            for (const auto& [key, value] : NodeInfo.Location.GetItems()) {
-                switch (key) {
-                    case TNodeLocation::TKeys::DataCenter:
-                        SystemState.MutableLocation()->SetDataCenter(value);
-                        break;
-                    case TNodeLocation::TKeys::Rack:
-                        SystemState.MutableLocation()->SetRack(value);
-                        break;
-                    case TNodeLocation::TKeys::Unit:
-                        SystemState.MutableLocation()->SetUnit(value);
-                        break;
-                    default:
-                        break;
-                }
-            }
-        }
-
         void Cleanup() {
             if (SystemState.HasSystemLocation()) {
                 SystemState.ClearSystemLocation();
@@ -1906,7 +1888,6 @@ public:
                         if (ni.Host && !node.SystemState.GetHost()) {
                             node.SystemState.SetHost(ni.Host);
                         }
-                        node.FillLocationFromInterconnect();
                         if (ni.Location.GetDataCenterId() != 0) {
                             seenDC = true;
                         }
@@ -3383,6 +3364,12 @@ public:
                 }
                 if (FieldsAvailable.test(+ENodeFields::CapacityAlert) && FieldsRequested.test(+ENodeFields::CapacityAlert)) {
                     jsonNode.SetCapacityAlert(NKikimrBlobStorage::TPDiskSpaceColor::E_Name(node->CapacityAlert));
+                }
+                if (FieldsAvailable.test(+ENodeFields::DC) && FieldsRequested.test(+ENodeFields::DC)) {
+                    jsonNode.SetDataCenter(node->GetDataCenter());
+                }
+                if (FieldsAvailable.test(+ENodeFields::Rack) && FieldsRequested.test(+ENodeFields::Rack)) {
+                    jsonNode.SetRack(node->GetRack());
                 }
                 if (FieldsAvailable.test(+ENodeFields::Connections) && FieldsRequested.test(+ENodeFields::Connections)) {
                     jsonNode.SetConnections(node->Connections);

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -276,6 +276,24 @@ class TJsonNodes : public TViewerPipeClient {
             return SystemState.GetLocation().GetBridgePileName();
         }
 
+        void FillLocationFromInterconnect() {
+            for (const auto& [key, value] : NodeInfo.Location.GetItems()) {
+                switch (key) {
+                    case TNodeLocation::TKeys::DataCenter:
+                        SystemState.MutableLocation()->SetDataCenter(value);
+                        break;
+                    case TNodeLocation::TKeys::Rack:
+                        SystemState.MutableLocation()->SetRack(value);
+                        break;
+                    case TNodeLocation::TKeys::Unit:
+                        SystemState.MutableLocation()->SetUnit(value);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
         void Cleanup() {
             if (SystemState.HasSystemLocation()) {
                 SystemState.ClearSystemLocation();
@@ -1888,6 +1906,7 @@ public:
                         if (ni.Host && !node.SystemState.GetHost()) {
                             node.SystemState.SetHost(ni.Host);
                         }
+                        node.FillLocationFromInterconnect();
                         if (ni.Location.GetDataCenterId() != 0) {
                             seenDC = true;
                         }

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -267,28 +267,23 @@ class TJsonNodes : public TViewerPipeClient {
             return SystemState.GetLocation().GetBridgePileName();
         }
 
-        void ApplyNodeInfoLocationFallback() {
+        void MergeInterconnectLocation() {
             std::optional<TString> dataCenter;
             std::optional<TString> rack;
             std::optional<TString> unit;
             std::optional<TString> bridgePileName;
-            bool hasLocationFallback = false;
             for (const auto& [key, value] : NodeInfo.Location.GetItems()) {
                 switch (key) {
                     case NActors::TNodeLocation::TKeys::BridgePileName:
-                        hasLocationFallback = true;
                         bridgePileName = value;
                         break;
                     case NActors::TNodeLocation::TKeys::DataCenter:
-                        hasLocationFallback = true;
                         dataCenter = value;
                         break;
                     case NActors::TNodeLocation::TKeys::Rack:
-                        hasLocationFallback = true;
                         rack = value;
                         break;
                     case NActors::TNodeLocation::TKeys::Unit:
-                        hasLocationFallback = true;
                         unit = value;
                         break;
                     default:
@@ -296,7 +291,7 @@ class TJsonNodes : public TViewerPipeClient {
                 }
             }
 
-            if (!hasLocationFallback) {
+            if (!bridgePileName && !dataCenter && !rack && !unit) {
                 return;
             }
 
@@ -1924,7 +1919,7 @@ public:
                     for (const auto& ni : NodesInfoResponse->Get()->Nodes) {
                         TNode& node = NodeData.emplace_back();
                         node.NodeInfo = ni;
-                        node.ApplyNodeInfoLocationFallback();
+                        node.MergeInterconnectLocation();
 
                         if (ni.Host && !node.SystemState.GetHost()) {
                             node.SystemState.SetHost(ni.Host);

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -268,46 +268,9 @@ class TJsonNodes : public TViewerPipeClient {
         }
 
         void MergeInterconnectLocation() {
-            std::optional<TString> dataCenter;
-            std::optional<TString> rack;
-            std::optional<TString> unit;
-            std::optional<TString> bridgePileName;
-            for (const auto& [key, value] : NodeInfo.Location.GetItems()) {
-                switch (key) {
-                    case NActors::TNodeLocation::TKeys::BridgePileName:
-                        bridgePileName = value;
-                        break;
-                    case NActors::TNodeLocation::TKeys::DataCenter:
-                        dataCenter = value;
-                        break;
-                    case NActors::TNodeLocation::TKeys::Rack:
-                        rack = value;
-                        break;
-                    case NActors::TNodeLocation::TKeys::Unit:
-                        unit = value;
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-            if (!bridgePileName && !dataCenter && !rack && !unit) {
-                return;
-            }
-
-            auto* location = SystemState.MutableLocation();
-            if (!location->HasBridgePileName() && bridgePileName.has_value()) {
-                location->SetBridgePileName(*bridgePileName);
-            }
-            if (!location->HasDataCenter() && dataCenter.has_value()) {
-                location->SetDataCenter(*dataCenter);
-            }
-            if (!location->HasRack() && rack.has_value()) {
-                location->SetRack(*rack);
-            }
-            if (!location->HasUnit() && unit.has_value()) {
-                location->SetUnit(*unit);
-            }
+            NActorsInterconnect::TNodeLocation location;
+            NodeInfo.Location.Serialize(&location, false);
+            SystemState.MutableLocation()->MergeFrom(location);
         }
 
         void Cleanup() {

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -256,23 +256,14 @@ class TJsonNodes : public TViewerPipeClient {
         }
 
         TString GetDataCenter() const {
-            if (NodeInfo.Location.GetDataCenterId()) {
-                return NodeInfo.Location.GetDataCenterId();
-            }
             return SystemState.GetLocation().GetDataCenter();
         }
 
         TString GetRack() const {
-            if (NodeInfo.Location.GetRackId()) {
-                return NodeInfo.Location.GetRackId();
-            }
             return SystemState.GetLocation().GetRack();
         }
 
         TString GetPileName() const {
-            if (NodeInfo.Location.GetBridgePileName()) {
-                return NodeInfo.Location.GetBridgePileName().value_or("");
-            }
             return SystemState.GetLocation().GetBridgePileName();
         }
 
@@ -280,15 +271,24 @@ class TJsonNodes : public TViewerPipeClient {
             std::optional<TString> dataCenter;
             std::optional<TString> rack;
             std::optional<TString> unit;
+            std::optional<TString> bridgePileName;
+            bool hasLocationFallback = false;
             for (const auto& [key, value] : NodeInfo.Location.GetItems()) {
                 switch (key) {
+                    case NActors::TNodeLocation::TKeys::BridgePileName:
+                        hasLocationFallback = true;
+                        bridgePileName = value;
+                        break;
                     case NActors::TNodeLocation::TKeys::DataCenter:
+                        hasLocationFallback = true;
                         dataCenter = value;
                         break;
                     case NActors::TNodeLocation::TKeys::Rack:
+                        hasLocationFallback = true;
                         rack = value;
                         break;
                     case NActors::TNodeLocation::TKeys::Unit:
+                        hasLocationFallback = true;
                         unit = value;
                         break;
                     default:
@@ -296,11 +296,14 @@ class TJsonNodes : public TViewerPipeClient {
                 }
             }
 
-            if (!dataCenter.has_value() && !rack.has_value() && !unit.has_value()) {
+            if (!hasLocationFallback) {
                 return;
             }
 
             auto* location = SystemState.MutableLocation();
+            if (!location->HasBridgePileName() && bridgePileName.has_value()) {
+                location->SetBridgePileName(*bridgePileName);
+            }
             if (!location->HasDataCenter() && dataCenter.has_value()) {
                 location->SetDataCenter(*dataCenter);
             }

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -276,7 +276,7 @@ class TJsonNodes : public TViewerPipeClient {
             return SystemState.GetLocation().GetBridgePileName();
         }
 
-        void ApplyInterconnectLocationFallback() {
+        void ApplyNodeInfoLocationFallback() {
             std::optional<TString> dataCenter;
             std::optional<TString> rack;
             std::optional<TString> unit;
@@ -294,6 +294,10 @@ class TJsonNodes : public TViewerPipeClient {
                     default:
                         break;
                 }
+            }
+
+            if (!dataCenter.has_value() && !rack.has_value() && !unit.has_value()) {
+                return;
             }
 
             auto* location = SystemState.MutableLocation();
@@ -1917,6 +1921,8 @@ public:
                     for (const auto& ni : NodesInfoResponse->Get()->Nodes) {
                         TNode& node = NodeData.emplace_back();
                         node.NodeInfo = ni;
+                        node.ApplyNodeInfoLocationFallback();
+
                         if (ni.Host && !node.SystemState.GetHost()) {
                             node.SystemState.SetHost(ni.Host);
                         }
@@ -3363,7 +3369,6 @@ public:
         }
         if (NodeGroups.empty()) {
             for (TNode* node : NodeView) {
-                node->ApplyInterconnectLocationFallback();
                 NKikimrViewer::TNodeInfo& jsonNode = *json.AddNodes();
                 if (FieldsAvailable.test(+ENodeFields::NodeInfo)) {
                     jsonNode.SetNodeId(node->GetNodeId());

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -245,17 +245,6 @@ Y_UNIT_TEST_SUITE(Viewer) {
         ev->Swap(newEv);
     }
 
-    void ChangeListNodesLocation(TEvInterconnect::TEvNodesInfo::TPtr* ev, const TString& dc, const TString& rack, const TString& unit) {
-        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>((*ev)->Get()->Nodes);
-        for (auto& node : *nodes) {
-            node.Location = TNodeLocation(dc, "", rack, unit);
-        }
-        auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
-            new IEventHandle((*ev)->Recipient, (*ev)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
-        );
-        ev->Swap(newEv);
-    }
-
     void ChangeTabletStateResponse(TEvWhiteboard::TEvTabletStateResponse::TPtr* ev, int tabletsTotal, int& tabletId, int& nodeId) {
         ui64* cookie = const_cast<ui64*>(&(ev->Get()->Cookie));
         *cookie = nodeId;
@@ -831,7 +820,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TAutoPtr<IEventHandle> handle;
 
         std::shared_ptr<NHttp::THttpEndpointInfo> endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
-        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest("GET /viewer/json/nodes?database=/Root/serverless&direct=1 HTTP/1.1\r\n\r\n", endpoint, {});
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest("GET /viewer/json/nodes?database=/Root/serverless&direct=1&fields_required=DC,Rack HTTP/1.1\r\n\r\n", endpoint, {});
 
         //size_t staticNodeId = runtime.GetNodeId(0);
         size_t sharedDynNodeId = runtime.GetNodeId(1);
@@ -851,6 +840,18 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 case TEvHive::EvResponseHiveNodeStats: {
                     auto *x = reinterpret_cast<TEvHive::TEvResponseHiveNodeStats::TPtr*>(&ev);
                     ChangeResponseHiveNodeStatsServerless(x, sharedDynNodeId, exclusiveDynNodeId);
+                    break;
+                }
+                case TEvInterconnect::EvNodesInfo: {
+                    auto* x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
+                    auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>((*x)->Get()->Nodes);
+                    for (auto& nodeInfo : *nodes) {
+                        nodeInfo.Location = TNodeLocation("az-2", "", "eu-north1-c-13ct2", "1");
+                    }
+                    auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
+                        new IEventHandle((*x)->Recipient, (*x)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
+                    );
+                    x->Swap(newEv);
                     break;
                 }
             }
@@ -875,6 +876,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().at("Nodes").GetArray().size(), 1);
         auto node = json.GetMap().at("Nodes").GetArray()[0].GetMap();
         UNIT_ASSERT_VALUES_EQUAL(node.at("NodeId"), exclusiveDynNodeId);
+        UNIT_ASSERT_VALUES_EQUAL(node.at("DataCenter").GetStringSafe(), "az-2");
+        UNIT_ASSERT_VALUES_EQUAL(node.at("Rack").GetStringSafe(), "eu-north1-c-13ct2");
     }
 
     Y_UNIT_TEST(SharedDoesntShowExclusiveNodes)
@@ -1020,61 +1023,6 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL(tablet.at("Type"), "DataShard");
         UNIT_ASSERT_VALUES_EQUAL(tablet.at("State"), "Green");
         UNIT_ASSERT_VALUES_EQUAL(tablet.at("Count"), 1);
-    }
-
-    Y_UNIT_TEST(NodesDcRackFallbackToInterconnect)
-    {
-        TPortManager tp;
-        ui16 port = tp.GetPort(2134);
-        ui16 grpcPort = tp.GetPort(2135);
-        auto settings = TServerSettings(port)
-                .SetNodeCount(1)
-                .SetUseRealThreads(false)
-                .SetDomainName("Root")
-                .SetUseSectorMap(true)
-                .InitKikimrRunConfig();
-        TServer server(settings);
-        server.EnableGRpc(grpcPort);
-
-        TClient client(settings);
-        TTestActorRuntime& runtime = *server.GetRuntime();
-
-        TActorId sender = runtime.AllocateEdgeActor();
-        TAutoPtr<IEventHandle> handle;
-
-        std::shared_ptr<NHttp::THttpEndpointInfo> endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
-        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest("GET /viewer/json/nodes?direct=1&fields_required=DC,Rack HTTP/1.1\r\n\r\n", endpoint, {});
-
-        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
-            switch (ev->GetTypeRewrite()) {
-                case TEvInterconnect::EvNodesInfo: {
-                    auto* x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    ChangeListNodesLocation(x, "az-2", "eu-north1-c-13ct2", "1");
-                    break;
-                }
-                case TEvWhiteboard::EvSystemStateResponse: {
-                    auto* x = reinterpret_cast<TEvWhiteboard::TEvSystemStateResponse::TPtr*>(&ev);
-                    (*x)->Get()->Record.ClearSystemStateInfo();
-                    break;
-                }
-            }
-            return TTestActorRuntime::EEventAction::PROCESS;
-        };
-        runtime.SetObserverFunc(observerFunc);
-
-        runtime.Send(new IEventHandle(NKikimr::NViewer::MakeViewerID(0), sender, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(request), 0));
-        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* result = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
-
-        NJson::TJsonValue json;
-        NJson::ReadJsonTree(result->Response->Body, &json, true);
-        const auto& nodes = json.GetMap().at("Nodes").GetArraySafe();
-        UNIT_ASSERT(!nodes.empty());
-        UNIT_ASSERT(nodes.front().GetMap().contains("Disconnected"));
-        UNIT_ASSERT_VALUES_EQUAL(nodes.front().GetMap().at("Disconnected").GetBooleanSafe(), true);
-
-        UNIT_ASSERT_VALUES_EQUAL(nodes.front().GetMap().at("DataCenter").GetStringSafe(), "az-2");
-        UNIT_ASSERT_VALUES_EQUAL(nodes.front().GetMap().at("Rack").GetStringSafe(), "eu-north1-c-13ct2");
-        UNIT_ASSERT(!nodes.front().GetMap().contains("SystemState"));
     }
 
     Y_UNIT_TEST(LevenshteinDistance)

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1022,7 +1022,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL(tablet.at("Count"), 1);
     }
 
-    Y_UNIT_TEST(NodesLocationFallsBackToInterconnectWhenSystemStateMissing)
+    Y_UNIT_TEST(NodesDcRackFallbackToInterconnect)
     {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
@@ -1043,7 +1043,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TAutoPtr<IEventHandle> handle;
 
         std::shared_ptr<NHttp::THttpEndpointInfo> endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
-        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest("GET /viewer/json/nodes?direct=1 HTTP/1.1\r\n\r\n", endpoint, {});
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest("GET /viewer/json/nodes?direct=1&fields_required=DC,Rack HTTP/1.1\r\n\r\n", endpoint, {});
 
         auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
             switch (ev->GetTypeRewrite()) {
@@ -1072,10 +1072,9 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT(nodes.front().GetMap().contains("Disconnected"));
         UNIT_ASSERT_VALUES_EQUAL(nodes.front().GetMap().at("Disconnected").GetBooleanSafe(), true);
 
-        const auto& location = nodes.front().GetMap().at("SystemState").GetMap().at("Location").GetMap();
-        UNIT_ASSERT_VALUES_EQUAL(location.at("DataCenter").GetStringSafe(), "az-2");
-        UNIT_ASSERT_VALUES_EQUAL(location.at("Rack").GetStringSafe(), "eu-north1-c-13ct2");
-        UNIT_ASSERT_VALUES_EQUAL(location.at("Unit").GetStringSafe(), "1");
+        UNIT_ASSERT_VALUES_EQUAL(nodes.front().GetMap().at("DataCenter").GetStringSafe(), "az-2");
+        UNIT_ASSERT_VALUES_EQUAL(nodes.front().GetMap().at("Rack").GetStringSafe(), "eu-north1-c-13ct2");
+        UNIT_ASSERT(!nodes.front().GetMap().contains("SystemState"));
     }
 
     Y_UNIT_TEST(LevenshteinDistance)

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -245,6 +245,17 @@ Y_UNIT_TEST_SUITE(Viewer) {
         ev->Swap(newEv);
     }
 
+    void ChangeListNodesLocation(TEvInterconnect::TEvNodesInfo::TPtr* ev, const TString& dc, const TString& rack, const TString& unit) {
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>((*ev)->Get()->Nodes);
+        for (auto& node : *nodes) {
+            node.Location = TNodeLocation(dc, "", rack, unit);
+        }
+        auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
+            new IEventHandle((*ev)->Recipient, (*ev)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
+        );
+        ev->Swap(newEv);
+    }
+
     void ChangeTabletStateResponse(TEvWhiteboard::TEvTabletStateResponse::TPtr* ev, int tabletsTotal, int& tabletId, int& nodeId) {
         ui64* cookie = const_cast<ui64*>(&(ev->Get()->Cookie));
         *cookie = nodeId;
@@ -1009,6 +1020,62 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL(tablet.at("Type"), "DataShard");
         UNIT_ASSERT_VALUES_EQUAL(tablet.at("State"), "Green");
         UNIT_ASSERT_VALUES_EQUAL(tablet.at("Count"), 1);
+    }
+
+    Y_UNIT_TEST(NodesLocationFallsBackToInterconnectWhenSystemStateMissing)
+    {
+        TPortManager tp;
+        ui16 port = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        auto settings = TServerSettings(port)
+                .SetNodeCount(1)
+                .SetUseRealThreads(false)
+                .SetDomainName("Root")
+                .SetUseSectorMap(true)
+                .InitKikimrRunConfig();
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+
+        TClient client(settings);
+        TTestActorRuntime& runtime = *server.GetRuntime();
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        TAutoPtr<IEventHandle> handle;
+
+        std::shared_ptr<NHttp::THttpEndpointInfo> endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest("GET /viewer/json/nodes?direct=1 HTTP/1.1\r\n\r\n", endpoint, {});
+
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+                case TEvInterconnect::EvNodesInfo: {
+                    auto* x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
+                    ChangeListNodesLocation(x, "az-2", "eu-north1-c-13ct2", "1");
+                    break;
+                }
+                case TEvWhiteboard::EvSystemStateResponse: {
+                    auto* x = reinterpret_cast<TEvWhiteboard::TEvSystemStateResponse::TPtr*>(&ev);
+                    (*x)->Get()->Record.ClearSystemStateInfo();
+                    break;
+                }
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        runtime.Send(new IEventHandle(NKikimr::NViewer::MakeViewerID(0), sender, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(request), 0));
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* result = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+
+        NJson::TJsonValue json;
+        NJson::ReadJsonTree(result->Response->Body, &json, true);
+        const auto& nodes = json.GetMap().at("Nodes").GetArraySafe();
+        UNIT_ASSERT(!nodes.empty());
+        UNIT_ASSERT(nodes.front().GetMap().contains("Disconnected"));
+        UNIT_ASSERT_VALUES_EQUAL(nodes.front().GetMap().at("Disconnected").GetBooleanSafe(), true);
+
+        const auto& location = nodes.front().GetMap().at("SystemState").GetMap().at("Location").GetMap();
+        UNIT_ASSERT_VALUES_EQUAL(location.at("DataCenter").GetStringSafe(), "az-2");
+        UNIT_ASSERT_VALUES_EQUAL(location.at("Rack").GetStringSafe(), "eu-north1-c-13ct2");
+        UNIT_ASSERT_VALUES_EQUAL(location.at("Unit").GetStringSafe(), "1");
     }
 
     Y_UNIT_TEST(LevenshteinDistance)

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -820,7 +820,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TAutoPtr<IEventHandle> handle;
 
         std::shared_ptr<NHttp::THttpEndpointInfo> endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
-        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest("GET /viewer/json/nodes?database=/Root/serverless&direct=1&fields_required=DC,Rack HTTP/1.1\r\n\r\n", endpoint, {});
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest("GET /viewer/json/nodes?database=/Root/serverless&direct=1&fields_required=SystemState HTTP/1.1\r\n\r\n", endpoint, {});
 
         //size_t staticNodeId = runtime.GetNodeId(0);
         size_t sharedDynNodeId = runtime.GetNodeId(1);
@@ -854,6 +854,17 @@ Y_UNIT_TEST_SUITE(Viewer) {
                     x->Swap(newEv);
                     break;
                 }
+                case TEvWhiteboard::EvSystemStateResponse: {
+                    auto* x = reinterpret_cast<TEvWhiteboard::TEvSystemStateResponse::TPtr*>(&ev);
+                    for (auto& systemStateInfo : *(*x)->Get()->Record.MutableSystemStateInfo()) {
+                        systemStateInfo.MutableLocation()->ClearDataCenter();
+                        systemStateInfo.MutableLocation()->ClearRack();
+                        systemStateInfo.MutableLocation()->ClearUnit();
+                        systemStateInfo.ClearDataCenter();
+                        systemStateInfo.ClearRack();
+                    }
+                    break;
+                }
             }
 
             return TTestActorRuntime::EEventAction::PROCESS;
@@ -876,8 +887,14 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().at("Nodes").GetArray().size(), 1);
         auto node = json.GetMap().at("Nodes").GetArray()[0].GetMap();
         UNIT_ASSERT_VALUES_EQUAL(node.at("NodeId"), exclusiveDynNodeId);
-        UNIT_ASSERT_VALUES_EQUAL(node.at("DataCenter").GetStringSafe(), "az-2");
-        UNIT_ASSERT_VALUES_EQUAL(node.at("Rack").GetStringSafe(), "eu-north1-c-13ct2");
+        UNIT_ASSERT(!node.contains("DataCenter"));
+        UNIT_ASSERT(!node.contains("Rack"));
+        UNIT_ASSERT(node.contains("SystemState"));
+        const auto& systemState = node.at("SystemState").GetMap();
+        UNIT_ASSERT(systemState.contains("Location"));
+        const auto& location = systemState.at("Location").GetMap();
+        UNIT_ASSERT_VALUES_EQUAL(location.at("DataCenter").GetStringSafe(), "az-2");
+        UNIT_ASSERT_VALUES_EQUAL(location.at("Rack").GetStringSafe(), "eu-north1-c-13ct2");
     }
 
     Y_UNIT_TEST(SharedDoesntShowExclusiveNodes)

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -887,8 +887,6 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().at("Nodes").GetArray().size(), 1);
         auto node = json.GetMap().at("Nodes").GetArray()[0].GetMap();
         UNIT_ASSERT_VALUES_EQUAL(node.at("NodeId"), exclusiveDynNodeId);
-        UNIT_ASSERT(!node.contains("DataCenter"));
-        UNIT_ASSERT(!node.contains("Rack"));
         UNIT_ASSERT(node.contains("SystemState"));
         const auto& systemState = node.at("SystemState").GetMap();
         UNIT_ASSERT(systemState.contains("Location"));

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -846,7 +846,12 @@ Y_UNIT_TEST_SUITE(Viewer) {
                     auto* x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
                     auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>((*x)->Get()->Nodes);
                     for (auto& nodeInfo : *nodes) {
-                        nodeInfo.Location = TNodeLocation("az-2", "", "eu-north1-c-13ct2", "1");
+                        NActorsInterconnect::TNodeLocation location;
+                        location.SetBridgePileName("pile0");
+                        location.SetDataCenter("az-2");
+                        location.SetRack("eu-north1-c-13ct2");
+                        location.SetUnit("1");
+                        nodeInfo.Location = TNodeLocation(location);
                     }
                     auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
                         new IEventHandle((*x)->Recipient, (*x)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
@@ -857,6 +862,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 case TEvWhiteboard::EvSystemStateResponse: {
                     auto* x = reinterpret_cast<TEvWhiteboard::TEvSystemStateResponse::TPtr*>(&ev);
                     for (auto& systemStateInfo : *(*x)->Get()->Record.MutableSystemStateInfo()) {
+                        systemStateInfo.MutableLocation()->ClearBridgePileName();
                         systemStateInfo.MutableLocation()->ClearDataCenter();
                         systemStateInfo.MutableLocation()->ClearRack();
                         systemStateInfo.MutableLocation()->ClearUnit();
@@ -891,8 +897,10 @@ Y_UNIT_TEST_SUITE(Viewer) {
         const auto& systemState = node.at("SystemState").GetMap();
         UNIT_ASSERT(systemState.contains("Location"));
         const auto& location = systemState.at("Location").GetMap();
+        UNIT_ASSERT_VALUES_EQUAL(location.at("BridgePileName").GetStringSafe(), "pile0");
         UNIT_ASSERT_VALUES_EQUAL(location.at("DataCenter").GetStringSafe(), "az-2");
         UNIT_ASSERT_VALUES_EQUAL(location.at("Rack").GetStringSafe(), "eu-north1-c-13ct2");
+        UNIT_ASSERT_VALUES_EQUAL(location.at("Unit").GetStringSafe(), "1");
     }
 
     Y_UNIT_TEST(SharedDoesntShowExclusiveNodes)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fallback DC and Rack values to Interconnect info

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

UI takes `DC`/`Rack` in nodes API only from Whiteboard (`SystemState.Location`). When a node becomes `Unavailable`, Whiteboard data may be missing/incomplete, and `DC` could disappear from the UI.

This PR fills `DC` and `Rack` fields using node location data from Interconnect. As a result, location fields remain available for unavailable nodes and showing this location is more stable.

Testing:
- Added unit tests covering the new logic.
- Verified behavior on the test environment with intentionally unavailable nodes.