### PR TITLE
ANALYZE: per-shard column table scans

### DIFF
--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -186,7 +186,7 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
     // Add tasks to calculate simple column statistics.
     for (size_t i = 0; i < Columns.size(); ++i) {
         const auto& col = Columns[i];
-        PendingTasks.push(TEvalTask{
+        PendingTasks.push(TColumnStatEvalTask{
             .ColumnIdx = i,
             .SimpleStatEval = std::make_unique<TSimpleColumnStatisticEval>(
                 col.Type, col.PgTypeMod),
@@ -249,7 +249,7 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& 
         return;
         // TODO: retries, unsubscribe, etc.
     } else {
-        DispatchScanActors();
+        StartColumnStatEvalTasks();
         Become(&TThis::StateScan);
     }
 }
@@ -268,11 +268,11 @@ void TAnalyzeActor::Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev) {
         tablets.insert(tablets.end(), node.GetTabletIds().begin(), node.GetTabletIds().end());
     }
 
-    DispatchScanActors();
+    StartColumnStatEvalTasks();
     Become(&TThis::StateScan);
 }
 
-void TAnalyzeActor::DispatchScanActors() {
+void TAnalyzeActor::StartColumnStatEvalTasks() {
     Y_ENSURE(ScanActorsInFlight.empty());
     Y_ENSURE(NodeId2PendingTablets.empty());
     Y_ENSURE(InProgressTasks.empty());
@@ -280,7 +280,7 @@ void TAnalyzeActor::DispatchScanActors() {
 
     NodeId2PendingTablets = NodeId2Tablets;
 
-    SelectBuilder.emplace(/*final=*/!IsColumnTable);
+    SelectBuilder.emplace(/*isIntermediateAggregation=*/IsColumnTable);
     size_t totalSize = 0;
 
     if (!CountSeq && !RowCount) {
@@ -429,7 +429,7 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
                 if (statEval->EstimateSize() > MAX_STATISTIC_SIZE) {
                     continue;
                 }
-                PendingTasks.push(TEvalTask{
+                PendingTasks.push(TColumnStatEvalTask{
                     .ColumnIdx = task.ColumnIdx,
                     .Stage2StatEval = std::move(statEval),
                 });
@@ -452,7 +452,7 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
     if (isFinalResult) {
         PassAway();
     } else {
-        DispatchScanActors();
+        StartColumnStatEvalTasks();
     }
 }
 

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -211,7 +211,7 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
         TVector<TCell> plusInf;
         TTableRange range(minusInf, true, plusInf, true, false);
         auto keyDesc = MakeHolder<TKeyDesc>(
-            PathId, range, TKeyDesc::ERowOperation::Unknown,TVector<NScheme::TTypeInfo>{}, TVector<TKeyDesc::TColumnOp>{});
+            PathId, range, TKeyDesc::ERowOperation::Unknown, KeyColumnTypes, TVector<TKeyDesc::TColumnOp>{});
 
         auto resolveRequest = std::make_unique<NSchemeCache::TSchemeCacheRequest>();
         resolveRequest->DatabaseName = DatabaseName;
@@ -285,7 +285,7 @@ void TAnalyzeActor::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr&) {
 }
 
 void TAnalyzeActor::TryScheduleHiveRetry(const TStringBuf& issue) {
-    if (HiveRetryCount > MaxHiveRetryCount) {
+    if (HiveRetryCount >= MaxHiveRetryCount) {
         FinishWithFailure(
             TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
             NYql::TIssue(issue));
@@ -515,16 +515,13 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
     }
 }
 
-void TAnalyzeActor::Handle(TEvents::TEvPoison::TPtr&) {
+void TAnalyzeActor::PassAway() {
     for (const auto& [id, info] : ScanActorsInFlight){
         Send(id, new TEvents::TEvPoison());
     }
 
-    PassAway();
-}
-
-void TAnalyzeActor::PassAway() {
     Send(MakePipePerNodeCacheID(EPipePerNodeCache::Leader), new TEvPipeCache::TEvUnlink(0));
+
     TActorBootstrapped::PassAway();
 }
 

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -1,5 +1,4 @@
 #include "analyze_actor.h"
-#include "select_builder.h"
 
 #include <ydb/library/query_actor/query_actor.h>
 #include <ydb/core/statistics/common.h>
@@ -146,6 +145,7 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
 
     // TODO: escape table path
     TableName = "/" + JoinVectorIntoString(entry.Path, "/");
+    IsColumnTable = !!entry.ColumnTableInfo;
 
     THashMap<ui32, TSysTables::TTableColumnInfo> tag2Column;
     for (const auto& col : entry.Columns) {
@@ -232,21 +232,21 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& 
         ShardIds.push_back(part.ShardId);
     }
 
-    DispatchScanActor();
+    DispatchScanActors();
     Become(&TThis::StateScan);
 }
 
-void TAnalyzeActor::DispatchScanActor() {
-    Y_ENSURE(!ScanActorId);
+void TAnalyzeActor::DispatchScanActors() {
+    Y_ENSURE(ScanActorIds.empty());
     Y_ENSURE(InProgressTasks.empty());
     Y_ENSURE(!PendingTasks.empty());
 
-    TSelectBuilder selectBuilder;
+    SelectBuilder.emplace(/*final=*/!IsColumnTable);
     size_t totalSize = 0;
 
-    if (!CountSeq) {
+    if (!CountSeq && !RowCount) {
         // Calculate total row count in the first scan we dispatch
-        CountSeq = selectBuilder.AddBuiltinAggregation({}, "count");
+        CountSeq = SelectBuilder->AddBuiltinAggregation({}, "count");
     }
 
     while (!PendingTasks.empty()) {
@@ -262,21 +262,33 @@ void TAnalyzeActor::DispatchScanActor() {
         const auto& col = Columns.at(task.ColumnIdx);
         totalSize += resultSize;
         if (task.SimpleStatEval) {
-            task.SimpleStatEval->AddAggregations(col.Name, selectBuilder);
+            task.SimpleStatEval->AddAggregations(col.Name, *SelectBuilder);
         } else if (task.Stage2StatEval) {
-            task.Stage2StatEval->AddAggregations(col.Name, selectBuilder);
+            task.Stage2StatEval->AddAggregations(col.Name, *SelectBuilder);
         }
         InProgressTasks.push_back(std::move(task));
         PendingTasks.pop();
     }
 
-    auto actor = std::make_unique<TScanActor>(
-        SelfId(), DatabaseName, selectBuilder.Build(TableName), selectBuilder.ColumnCount());
-    ScanActorId = Register(actor.release());
+    auto addScanActor = [&](std::optional<ui64> shardId) {
+        auto actor = std::make_unique<TScanActor>(
+            SelfId(), DatabaseName,
+            SelectBuilder->Build(TableName, shardId), SelectBuilder->ColumnCount());
+        ScanActorIds.insert(Register(actor.release()));
+    };
+
+    if (IsColumnTable) {
+        for (ui64 shardId : ShardIds) {
+            addScanActor(shardId);
+        }
+    } else {
+        addScanActor(std::nullopt);
+    }
 }
 
 void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
-    ScanActorId = {};
+    Y_ENSURE(ScanActorIds.erase(ev->Sender));
+
     auto& result = *ev->Get();
     if (result.Status != Ydb::StatusIds::SUCCESS) {
         NYql::TIssue error(TStringBuilder() << "Statistics calculation query failed with " << result.Status);
@@ -286,16 +298,34 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
         return;
     }
 
+    if (CountSeq) {
+        NYdb::TValueParser val(result.AggColumns.at(CountSeq.value()));
+        ui64 count = val.GetUint64();
+        RowCount = count + RowCount.value_or(0);
+    }
+
+    if (!ScanActorIds.empty()) {
+        for (const auto& task : InProgressTasks) {
+            Y_ENSURE(!task.SimpleStatEval != !task.Stage2StatEval);
+            if (task.SimpleStatEval) {
+                task.SimpleStatEval->Merge(result.AggColumns);
+            } else {
+                task.Stage2StatEval->Merge(result.AggColumns);
+            }
+        }
+        return;
+    }
+
+    // Finalize results for the current column batch.
+
     std::vector<TStatisticsItem> resultItems;
 
-    if (!RowCount) {
-        NYdb::TValueParser val(result.AggColumns.at(CountSeq.value()));
-        RowCount = val.GetUint64();
-
+    if (CountSeq) {
         NKikimrStat::TTableSummaryStatistics tableSummary;
         tableSummary.SetRowCount(*RowCount);
         resultItems.emplace_back(
             std::nullopt, EStatType::TABLE_SUMMARY, tableSummary.SerializeAsString());
+        CountSeq.reset();
     }
 
     auto supportedStatTypes = IStage2ColumnStatisticEval::SupportedTypes();
@@ -305,7 +335,7 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
         Y_ENSURE(!task.SimpleStatEval != !task.Stage2StatEval);
 
         if (task.SimpleStatEval) {
-            auto simpleStats = task.SimpleStatEval->Extract(*RowCount, result.AggColumns);
+            auto simpleStats = task.SimpleStatEval->Extract(RowCount.value(), result.AggColumns);
             resultItems.emplace_back(
                 col.Tag,
                 task.SimpleStatEval->GetType(),
@@ -331,6 +361,7 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
                 task.Stage2StatEval->ExtractData(result.AggColumns));
         }
     }
+
     InProgressTasks.clear();
 
     const bool isFinalResult = PendingTasks.empty();
@@ -341,13 +372,13 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
     if (isFinalResult) {
         PassAway();
     } else {
-        DispatchScanActor();
+        DispatchScanActors();
     }
 }
 
 void TAnalyzeActor::Handle(TEvents::TEvPoison::TPtr&) {
-    if (ScanActorId) {
-        Send(ScanActorId, new TEvents::TEvPoison());
+    for (const auto& id : ScanActorIds){
+        Send(id, new TEvents::TEvPoison());
     }
 
     PassAway();

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -79,7 +79,7 @@ private:
     }
 
     void Handle(TEvents::TEvPoison::TPtr&) {
-        SA_LOG_D("Got TEvPoison");
+        SA_LOG_D("[" << SelfId() << "]: Got TEvPoison");
         Finish(Ydb::StatusIds::ABORTED, "Query aborted");
     }
 
@@ -132,7 +132,7 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
     const NSchemeCache::TSchemeCacheNavigate::TEntry& entry = request.ResultSet.front();
 
     if (entry.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
-        SA_LOG_W("Navigate request failed with " << entry.Status
+        SA_LOG_W("[" << SelfId() << "]: Navigate request failed with " << entry.Status
             << ", operationId: " << OperationId.Quote()
             << ", PathId: " << PathId
             << ", DatabaseName: " << DatabaseName);
@@ -223,7 +223,7 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& 
     const NSchemeCache::TSchemeCacheRequest::TEntry& entry = request.ResultSet.front();
 
     if (entry.Status != NSchemeCache::TSchemeCacheRequest::EStatus::OkData) {
-        SA_LOG_W("Resolve request failed with " << entry.Status
+        SA_LOG_W("[" << SelfId() << "]: Resolve request failed with " << entry.Status
             << ", operationId: " << OperationId.Quote()
             << ", PathId: " << PathId
             << ", DatabaseName: " << DatabaseName);
@@ -335,7 +335,7 @@ void TAnalyzeActor::DispatchSomeScanActors() {
 
     if (!IsColumnTable) {
         Y_ENSURE(ScanActorsInFlight.empty());
-        SA_LOG_D("Dispatching scan actor for the whole table");
+        SA_LOG_D("[" << SelfId() << "]: Dispatching scan actor for the whole table");
         dispatchActor(0, std::nullopt);
         return;
     }
@@ -368,7 +368,8 @@ void TAnalyzeActor::DispatchSomeScanActors() {
         Y_ENSURE(!node->PendingTablets.empty());
         ui64 tabletId = node->PendingTablets.back();
 
-        SA_LOG_D("Dispatching scan actor, tabletId: " << tabletId << ", nodeId: " << node->Id);
+        SA_LOG_D("[" << SelfId() << "]: Dispatching scan actor"
+            << ", tabletId: " << tabletId << ", nodeId: " << node->Id);
         dispatchActor(node->Id, tabletId);
         node->PendingTablets.pop_back();
         ++node->TabletsInFlight;

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -150,6 +150,11 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
     THashMap<ui32, TSysTables::TTableColumnInfo> tag2Column;
     for (const auto& col : entry.Columns) {
         tag2Column[col.second.Id] = col.second;
+
+        if (col.second.KeyOrder >= 0) {
+            KeyColumnTypes.resize(Max<size_t>(KeyColumnTypes.size(), col.second.KeyOrder + 1));
+            KeyColumnTypes[col.second.KeyOrder] = col.second.PType;
+        }
     }
 
     auto addColumn = [&](const TSysTables::TTableColumnInfo& colInfo) {
@@ -189,8 +194,46 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
         return;
     }
 
-    Become(&TThis::StateQuery);
+    // Resolve table shards
+    TVector<TCell> minusInf(KeyColumnTypes.size());
+    TVector<TCell> plusInf;
+    TTableRange range(minusInf, true, plusInf, true, false);
+    auto keyDesc = MakeHolder<TKeyDesc>(
+        PathId, range, TKeyDesc::ERowOperation::Unknown,TVector<NScheme::TTypeInfo>{}, TVector<TKeyDesc::TColumnOp>{});
+
+    auto resolveRequest = std::make_unique<NSchemeCache::TSchemeCacheRequest>();
+    resolveRequest->DatabaseName = DatabaseName;
+    resolveRequest->ResultSet.emplace_back(std::move(keyDesc));
+    Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvResolveKeySet(resolveRequest.release()));
+
+    Become(&TThis::StateResolve);
+}
+
+void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev) {
+    const auto& request = *ev->Get()->Request;
+    Y_ABORT_UNLESS(request.ResultSet.size() == 1);
+    const NSchemeCache::TSchemeCacheRequest::TEntry& entry = request.ResultSet.front();
+
+    if (entry.Status != NSchemeCache::TSchemeCacheRequest::EStatus::OkData) {
+        SA_LOG_W("Resolve request failed with " << entry.Status
+            << ", operationId: " << OperationId.Quote()
+            << ", PathId: " << PathId
+            << ", DatabaseName: " << DatabaseName);
+
+        FinishWithFailure(
+            entry.Status == NSchemeCache::TSchemeCacheRequest::EStatus::PathErrorNotExist
+            ? TEvStatistics::TEvAnalyzeActorResult::EStatus::TableNotFound
+            : TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+            NYql::TIssue(TStringBuilder() << "Resolve request failed with " << entry.Status));
+        return;
+    }
+
+    for (const auto& part : entry.KeyDescription->GetPartitions()) {
+        ShardIds.push_back(part.ShardId);
+    }
+
     DispatchScanActor();
+    Become(&TThis::StateScan);
 }
 
 void TAnalyzeActor::DispatchScanActor() {

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -264,8 +264,11 @@ void TAnalyzeActor::Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev) {
             return;
             // TODO: retries
         }
-        auto& tablets = NodeId2Tablets[node.GetNodeId()];
-        tablets.insert(tablets.end(), node.GetTabletIds().begin(), node.GetTabletIds().end());
+
+        if (!node.GetTabletIds().empty()) {
+            auto& tablets = NodeId2Tablets[node.GetNodeId()];
+            tablets.insert(tablets.end(), node.GetTabletIds().begin(), node.GetTabletIds().end());
+        }
     }
 
     StartColumnStatEvalTasks();
@@ -274,11 +277,19 @@ void TAnalyzeActor::Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev) {
 
 void TAnalyzeActor::StartColumnStatEvalTasks() {
     Y_ENSURE(ScanActorsInFlight.empty());
-    Y_ENSURE(NodeId2PendingTablets.empty());
+    Y_ENSURE(NodeId2State.empty());
     Y_ENSURE(InProgressTasks.empty());
     Y_ENSURE(!PendingTasks.empty());
 
-    NodeId2PendingTablets = NodeId2Tablets;
+    if (IsColumnTable) {
+        for (const auto& [id, tabletIds] : NodeId2Tablets) {
+            NodeId2State[id] = TNodeState {
+                .Id = id,
+                .TabletsInFlight = 0,
+                .PendingTablets = tabletIds,
+            };
+        }
+    }
 
     SelectBuilder.emplace(/*isIntermediateAggregation=*/IsColumnTable);
     size_t totalSize = 0;
@@ -309,8 +320,11 @@ void TAnalyzeActor::StartColumnStatEvalTasks() {
         PendingTasks.pop();
     }
 
-    auto addScanActor = [&](ui32 nodeId, std::optional<ui64> tabletId) {
-        SA_LOG_D("Launching scan actor, tabletId: " << tabletId << ", tabletNodeId: " << nodeId);
+    DispatchSomeScanActors();
+}
+
+void TAnalyzeActor::DispatchSomeScanActors() {
+    auto dispatchActor = [&](ui32 nodeId, std::optional<ui64> tabletId) {
         auto actor = std::make_unique<TScanActor>(
             SelfId(), DatabaseName,
             SelectBuilder->Build(TableName, tabletId), SelectBuilder->ColumnCount());
@@ -319,22 +333,49 @@ void TAnalyzeActor::StartColumnStatEvalTasks() {
         };
     };
 
-    if (IsColumnTable) {
-        for (auto it = NodeId2PendingTablets.begin(); it != NodeId2PendingTablets.end(); ) {
-            ui32 nodeId = it->first;
-            auto& tabletIds = it->second;
-            Y_ENSURE(!tabletIds.empty());
+    if (!IsColumnTable) {
+        Y_ENSURE(ScanActorsInFlight.empty());
+        SA_LOG_D("Dispatching scan actor for the whole table");
+        dispatchActor(0, std::nullopt);
+        return;
+    }
 
-            addScanActor(nodeId, tabletIds.back());
-            tabletIds.pop_back();
-            if (!tabletIds.empty()) {
-                ++it;
-            } else {
-                NodeId2PendingTablets.erase(it++);
-            }
+    // Run a simple scheduling algorithm, dispatching scans fairly among nodes hosting tablets,
+    // and for nodes with the same number of in-flight scans, favoring nodes with the
+    // longer tablet ids queue.
+
+    auto isSchedulable = [](const TNodeState& node) {
+        return !node.PendingTablets.empty()
+            && node.TabletsInFlight < MaxPerNodeScanActorsInFlight;
+    };
+
+    auto nodeCmp = [](TNodeState* left, TNodeState* right) {
+        return std::tuple(-left->TabletsInFlight, left->PendingTablets.size())
+            < std::tuple(-right->TabletsInFlight, right->PendingTablets.size());
+    };
+
+    std::priority_queue<TNodeState*, std::vector<TNodeState*>, decltype(nodeCmp)> schedulableQueue;
+    for (auto& [id, node] : NodeId2State) {
+        if (isSchedulable(node)) {
+            schedulableQueue.emplace(&node);
         }
-    } else {
-        addScanActor(0, std::nullopt);
+    }
+
+    while (!schedulableQueue.empty()
+            && ScanActorsInFlight.size() < MaxTotalScanActorsInFlight) {
+        auto* node = schedulableQueue.top();
+        schedulableQueue.pop();
+        Y_ENSURE(!node->PendingTablets.empty());
+        ui64 tabletId = node->PendingTablets.back();
+
+        SA_LOG_D("Dispatching scan actor, tabletId: " << tabletId << ", nodeId: " << node->Id);
+        dispatchActor(node->Id, tabletId);
+        node->PendingTablets.pop_back();
+        ++node->TabletsInFlight;
+
+        if (isSchedulable(*node)) {
+            schedulableQueue.push(node);
+        }
     }
 }
 
@@ -354,28 +395,14 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
     }
 
     if (tabletNodeId) {
-        // TODO: unify with code in DispatchScanActors
-
-        auto nodeIt = NodeId2PendingTablets.find(tabletNodeId);
-        if (nodeIt != NodeId2PendingTablets.end()) {
-            auto& tabletIds = nodeIt->second;
-            Y_ENSURE(!tabletIds.empty());
-
-            ui64 tabletId = tabletIds.back();
-            SA_LOG_D("Launching next scan actor, tabletId: "
-                << tabletId << ", tabletNodeId: " << tabletNodeId);
-            auto actor = std::make_unique<TScanActor>(
-                SelfId(), DatabaseName,
-                SelectBuilder->Build(TableName, tabletId), SelectBuilder->ColumnCount());
-            ScanActorsInFlight[Register(actor.release())] = TScanActorInfo{
-                .TabletNodeId = tabletNodeId,
-            };
-
-            tabletIds.pop_back();
-            if (tabletIds.empty()) {
-                NodeId2PendingTablets.erase(nodeIt);
-            }
+        auto nodeIt = NodeId2State.find(tabletNodeId);
+        Y_ENSURE(nodeIt != NodeId2State.end());
+        --nodeIt->second.TabletsInFlight;
+        if (!nodeIt->second.TabletsInFlight && nodeIt->second.PendingTablets.empty()) {
+            NodeId2State.erase(nodeIt);
         }
+
+        DispatchSomeScanActors();
     }
 
     if (CountSeq) {
@@ -385,6 +412,8 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
     }
 
     if (!ScanActorsInFlight.empty()) {
+        // More scan results coming for the current column tasks batch, merge the current one
+        // and wait for more.
         for (const auto& task : InProgressTasks) {
             Y_ENSURE(!task.SimpleStatEval != !task.Stage2StatEval);
             if (task.SimpleStatEval) {
@@ -396,7 +425,7 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
         return;
     }
 
-    // Finalize results for the current column batch.
+    // This is the last scan result for the current column tasks batch, finalize the result.
 
     std::vector<TStatisticsItem> resultItems;
 

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -1,7 +1,5 @@
 #include "analyze_actor.h"
 
-#include <ydb/core/base/hive.h>
-#include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/library/query_actor/query_actor.h>
 #include <ydb/core/statistics/common.h>
 #include <ydb/core/statistics/events.h>
@@ -149,7 +147,12 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
     if (!HiveId) {
         HiveId = AppData()->DomainsInfo->GetHive();
     }
-    // TODO: return error if can't determine hive id
+    if (!HiveId) {
+        FinishWithFailure(
+            TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+            NYql::TIssue("Could not determine Hive ID."));
+        return;
+    }
 
     // TODO: escape table path
     TableName = "/" + JoinVectorIntoString(entry.Path, "/");
@@ -202,19 +205,22 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
         return;
     }
 
-    // Resolve table shards
-    TVector<TCell> minusInf(KeyColumnTypes.size());
-    TVector<TCell> plusInf;
-    TTableRange range(minusInf, true, plusInf, true, false);
-    auto keyDesc = MakeHolder<TKeyDesc>(
-        PathId, range, TKeyDesc::ERowOperation::Unknown,TVector<NScheme::TTypeInfo>{}, TVector<TKeyDesc::TColumnOp>{});
+    if (IsColumnTable) {
+        // Resolve table shard ids.
+        TVector<TCell> minusInf(KeyColumnTypes.size());
+        TVector<TCell> plusInf;
+        TTableRange range(minusInf, true, plusInf, true, false);
+        auto keyDesc = MakeHolder<TKeyDesc>(
+            PathId, range, TKeyDesc::ERowOperation::Unknown,TVector<NScheme::TTypeInfo>{}, TVector<TKeyDesc::TColumnOp>{});
 
-    auto resolveRequest = std::make_unique<NSchemeCache::TSchemeCacheRequest>();
-    resolveRequest->DatabaseName = DatabaseName;
-    resolveRequest->ResultSet.emplace_back(std::move(keyDesc));
-    Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvResolveKeySet(resolveRequest.release()));
-
-    Become(&TThis::StateResolve);
+        auto resolveRequest = std::make_unique<NSchemeCache::TSchemeCacheRequest>();
+        resolveRequest->DatabaseName = DatabaseName;
+        resolveRequest->ResultSet.emplace_back(std::move(keyDesc));
+        Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvResolveKeySet(resolveRequest.release()));
+    } else {
+        StartColumnStatEvalTasks();
+        Become(&TThis::StateScan);
+    }
 }
 
 void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev) {
@@ -237,42 +243,57 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& 
     }
 
     for (const auto& part : entry.KeyDescription->GetPartitions()) {
-        TabletIds.push_back(part.ShardId);
+        TabletIdsToLocate.insert(part.ShardId);
     }
 
-    if (IsColumnTable) {
-        auto reqDistribution = std::make_unique<TEvHive::TEvRequestTabletDistribution>();
-        reqDistribution->Record.MutableTabletIds()->Add(
-            TabletIds.begin(), TabletIds.end());
-        Send(MakePipePerNodeCacheID(false),
-            new TEvPipeCache::TEvForward(reqDistribution.release(), HiveId, true));
-        return;
-        // TODO: retries, unsubscribe, etc.
-    } else {
-        StartColumnStatEvalTasks();
-        Become(&TThis::StateScan);
-    }
+    Send(SelfId(), new TEvPrivate::TEvRequestTableDistribution);
+    Become(&TThis::StateLocateTablets);
+}
+
+void TAnalyzeActor::Handle(TEvPrivate::TEvRequestTableDistribution::TPtr&) {
+    auto req = std::make_unique<TEvHive::TEvRequestTabletDistribution>();
+    req->Record.MutableTabletIds()->Add(TabletIdsToLocate.begin(), TabletIdsToLocate.end());
+    Send(MakePipePerNodeCacheID(EPipePerNodeCache::Leader),
+        new TEvPipeCache::TEvForward(req.release(), HiveId, true));
 }
 
 void TAnalyzeActor::Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev) {
     const auto& msg = ev->Get()->Record;
     for (const auto& node : msg.GetNodes()) {
-        if (!node.GetNodeId()) {
-            FinishWithFailure(
-                TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
-                NYql::TIssue("Resolving tablet node ids failed."));
-            return;
-            // TODO: retries
-        }
-
-        if (!node.GetTabletIds().empty()) {
-            auto& tablets = NodeId2Tablets[node.GetNodeId()];
-            tablets.insert(tablets.end(), node.GetTabletIds().begin(), node.GetTabletIds().end());
+        if (node.GetNodeId()) {
+            for (auto tabletId : node.GetTabletIds()) {
+                TabletId2NodeId[tabletId] = node.GetNodeId();
+                TabletIdsToLocate.erase(tabletId);
+            }
         }
     }
 
+    if (!TabletIdsToLocate.empty()) {
+        SA_LOG_W("[" << SelfId() << "]: unable to locate " << TabletIdsToLocate.size() << " tablets");
+        TryScheduleHiveRetry("Unable to locate some tablets.");
+        return;
+    }
+
+    Send(MakePipePerNodeCacheID(EPipePerNodeCache::Leader), new TEvPipeCache::TEvUnlink(0));
     StartColumnStatEvalTasks();
     Become(&TThis::StateScan);
+}
+
+void TAnalyzeActor::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr&) {
+    SA_LOG_W("[" << SelfId() << "]: got TEvDeliveryProblem");
+    TryScheduleHiveRetry("Problem connecting to Hive");
+}
+
+void TAnalyzeActor::TryScheduleHiveRetry(const TStringBuf& issue) {
+    if (HiveRetryCount > MaxHiveRetryCount) {
+        FinishWithFailure(
+            TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+            NYql::TIssue(issue));
+        return;
+    }
+
+    ++HiveRetryCount;
+    Schedule(HiveRetryInterval, new TEvPrivate::TEvRequestTableDistribution);
 }
 
 void TAnalyzeActor::StartColumnStatEvalTasks() {
@@ -282,12 +303,8 @@ void TAnalyzeActor::StartColumnStatEvalTasks() {
     Y_ENSURE(!PendingTasks.empty());
 
     if (IsColumnTable) {
-        for (const auto& [id, tabletIds] : NodeId2Tablets) {
-            NodeId2State[id] = TNodeState {
-                .Id = id,
-                .TabletsInFlight = 0,
-                .PendingTablets = tabletIds,
-            };
+        for (const auto& [tabletId, nodeId] : TabletId2NodeId) {
+            NodeId2State.try_emplace(nodeId, nodeId).first->second.PendingTablets.push_back(tabletId);
         }
     }
 
@@ -504,6 +521,11 @@ void TAnalyzeActor::Handle(TEvents::TEvPoison::TPtr&) {
     }
 
     PassAway();
+}
+
+void TAnalyzeActor::PassAway() {
+    Send(MakePipePerNodeCacheID(EPipePerNodeCache::Leader), new TEvPipeCache::TEvUnlink(0));
+    TActorBootstrapped::PassAway();
 }
 
 } // NKikimr::NStat

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -1,5 +1,7 @@
 #include "analyze_actor.h"
 
+#include <ydb/core/base/hive.h>
+#include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/library/query_actor/query_actor.h>
 #include <ydb/core/statistics/common.h>
 #include <ydb/core/statistics/events.h>
@@ -143,6 +145,12 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
         return;
     }
 
+    HiveId = entry.DomainInfo->ExtractHive();
+    if (!HiveId) {
+        HiveId = AppData()->DomainsInfo->GetHive();
+    }
+    // TODO: return error if can't determine hive id
+
     // TODO: escape table path
     TableName = "/" + JoinVectorIntoString(entry.Path, "/");
     IsColumnTable = !!entry.ColumnTableInfo;
@@ -229,7 +237,35 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& 
     }
 
     for (const auto& part : entry.KeyDescription->GetPartitions()) {
-        ShardIds.push_back(part.ShardId);
+        TabletIds.push_back(part.ShardId);
+    }
+
+    if (IsColumnTable) {
+        auto reqDistribution = std::make_unique<TEvHive::TEvRequestTabletDistribution>();
+        reqDistribution->Record.MutableTabletIds()->Add(
+            TabletIds.begin(), TabletIds.end());
+        Send(MakePipePerNodeCacheID(false),
+            new TEvPipeCache::TEvForward(reqDistribution.release(), HiveId, true));
+        return;
+        // TODO: retries, unsubscribe, etc.
+    } else {
+        DispatchScanActors();
+        Become(&TThis::StateScan);
+    }
+}
+
+void TAnalyzeActor::Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev) {
+    const auto& msg = ev->Get()->Record;
+    for (const auto& node : msg.GetNodes()) {
+        if (!node.GetNodeId()) {
+            FinishWithFailure(
+                TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+                NYql::TIssue("Resolving tablet node ids failed."));
+            return;
+            // TODO: retries
+        }
+        auto& tablets = NodeId2Tablets[node.GetNodeId()];
+        tablets.insert(tablets.end(), node.GetTabletIds().begin(), node.GetTabletIds().end());
     }
 
     DispatchScanActors();
@@ -237,9 +273,12 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& 
 }
 
 void TAnalyzeActor::DispatchScanActors() {
-    Y_ENSURE(ScanActorIds.empty());
+    Y_ENSURE(ScanActorsInFlight.empty());
+    Y_ENSURE(NodeId2PendingTablets.empty());
     Y_ENSURE(InProgressTasks.empty());
     Y_ENSURE(!PendingTasks.empty());
+
+    NodeId2PendingTablets = NodeId2Tablets;
 
     SelectBuilder.emplace(/*final=*/!IsColumnTable);
     size_t totalSize = 0;
@@ -270,24 +309,40 @@ void TAnalyzeActor::DispatchScanActors() {
         PendingTasks.pop();
     }
 
-    auto addScanActor = [&](std::optional<ui64> shardId) {
+    auto addScanActor = [&](ui32 nodeId, std::optional<ui64> tabletId) {
+        SA_LOG_D("Launching scan actor, tabletId: " << tabletId << ", tabletNodeId: " << nodeId);
         auto actor = std::make_unique<TScanActor>(
             SelfId(), DatabaseName,
-            SelectBuilder->Build(TableName, shardId), SelectBuilder->ColumnCount());
-        ScanActorIds.insert(Register(actor.release()));
+            SelectBuilder->Build(TableName, tabletId), SelectBuilder->ColumnCount());
+        ScanActorsInFlight[Register(actor.release())] = TScanActorInfo{
+            .TabletNodeId = nodeId,
+        };
     };
 
     if (IsColumnTable) {
-        for (ui64 shardId : ShardIds) {
-            addScanActor(shardId);
+        for (auto it = NodeId2PendingTablets.begin(); it != NodeId2PendingTablets.end(); ) {
+            ui32 nodeId = it->first;
+            auto& tabletIds = it->second;
+            Y_ENSURE(!tabletIds.empty());
+
+            addScanActor(nodeId, tabletIds.back());
+            tabletIds.pop_back();
+            if (!tabletIds.empty()) {
+                ++it;
+            } else {
+                NodeId2PendingTablets.erase(it++);
+            }
         }
     } else {
-        addScanActor(std::nullopt);
+        addScanActor(0, std::nullopt);
     }
 }
 
 void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
-    Y_ENSURE(ScanActorIds.erase(ev->Sender));
+    auto actorIt = ScanActorsInFlight.find(ev->Sender);
+    Y_ENSURE(actorIt != ScanActorsInFlight.end());
+    const ui32 tabletNodeId = actorIt->second.TabletNodeId;
+    ScanActorsInFlight.erase(actorIt);
 
     auto& result = *ev->Get();
     if (result.Status != Ydb::StatusIds::SUCCESS) {
@@ -298,13 +353,38 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
         return;
     }
 
+    if (tabletNodeId) {
+        // TODO: unify with code in DispatchScanActors
+
+        auto nodeIt = NodeId2PendingTablets.find(tabletNodeId);
+        if (nodeIt != NodeId2PendingTablets.end()) {
+            auto& tabletIds = nodeIt->second;
+            Y_ENSURE(!tabletIds.empty());
+
+            ui64 tabletId = tabletIds.back();
+            SA_LOG_D("Launching next scan actor, tabletId: "
+                << tabletId << ", tabletNodeId: " << tabletNodeId);
+            auto actor = std::make_unique<TScanActor>(
+                SelfId(), DatabaseName,
+                SelectBuilder->Build(TableName, tabletId), SelectBuilder->ColumnCount());
+            ScanActorsInFlight[Register(actor.release())] = TScanActorInfo{
+                .TabletNodeId = tabletNodeId,
+            };
+
+            tabletIds.pop_back();
+            if (tabletIds.empty()) {
+                NodeId2PendingTablets.erase(nodeIt);
+            }
+        }
+    }
+
     if (CountSeq) {
         NYdb::TValueParser val(result.AggColumns.at(CountSeq.value()));
         ui64 count = val.GetUint64();
         RowCount = count + RowCount.value_or(0);
     }
 
-    if (!ScanActorIds.empty()) {
+    if (!ScanActorsInFlight.empty()) {
         for (const auto& task : InProgressTasks) {
             Y_ENSURE(!task.SimpleStatEval != !task.Stage2StatEval);
             if (task.SimpleStatEval) {
@@ -377,7 +457,7 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
 }
 
 void TAnalyzeActor::Handle(TEvents::TEvPoison::TPtr&) {
-    for (const auto& id : ScanActorIds){
+    for (const auto& [id, info] : ScanActorsInFlight){
         Send(id, new TEvents::TEvPoison());
     }
 

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -379,7 +379,7 @@ void TAnalyzeActor::DispatchSomeScanActors() {
     }
 }
 
-void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
+void TAnalyzeActor::HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
     auto actorIt = ScanActorsInFlight.find(ev->Sender);
     Y_ENSURE(actorIt != ScanActorsInFlight.end());
     const ui32 tabletNodeId = actorIt->second.TabletNodeId;
@@ -482,6 +482,18 @@ void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
         PassAway();
     } else {
         StartColumnStatEvalTasks();
+    }
+}
+
+void TAnalyzeActor::Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev) {
+    try {
+        HandleImpl(ev);
+    } catch (const std::exception& ex) {
+        NYql::TIssue error(TStringBuilder()
+            << "Processing statistics scan results failed with " << ex.what());
+        FinishWithFailure(
+            TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+            std::move(error));
     }
 }
 

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -5,6 +5,7 @@
 
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/base/hive.h>
+#include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/actorid.h>
@@ -20,16 +21,45 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     TPathId PathId;
     TVector<ui32> RequestedColumnTags;
 
+    struct TEvPrivate {
+        enum EEv {
+            EvAnalyzeScanResult = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+            EvRetryTableDistributionRequest,
+            EvEnd,
+        };
+
+        static_assert(
+            EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE),
+            "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
+
+        struct TEvAnalyzeScanResult : public TEventLocal<
+            TEvAnalyzeScanResult, EvAnalyzeScanResult>
+        {
+            Ydb::StatusIds::StatusCode Status;
+            NYql::TIssues Issues;
+            TVector<NYdb::TValue> AggColumns;
+
+            explicit TEvAnalyzeScanResult(TVector<NYdb::TValue> aggColumns)
+            : Status(Ydb::StatusIds::SUCCESS)
+            , AggColumns(std::move(aggColumns))
+            {}
+
+            TEvAnalyzeScanResult(
+                Ydb::StatusIds::StatusCode status,
+                NYql::TIssues&& issues)
+            : Status(status)
+            , Issues(std::move(issues))
+            {}
+        };
+
+        struct TEvRequestTableDistribution : public TEventLocal<
+            TEvRequestTableDistribution, EvRetryTableDistributionRequest>
+        {};
+    };
+
     void FinishWithFailure(TEvStatistics::TEvAnalyzeActorResult::EStatus, NYql::TIssue);
 
     // StateNavigate
-
-    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
-
-    // StateResolve
-
-    void Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev);
-    void Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev);
 
     struct TColumnDesc {
         ui32 Tag;
@@ -53,8 +83,25 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     TVector<NScheme::TTypeInfo> KeyColumnTypes;
     ui64 HiveId = 0;
 
-    TVector<ui64> TabletIds;
-    THashMap<ui32, TVector<ui64>> NodeId2Tablets;
+    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
+    void Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev);
+
+    // StateLocateTablets
+
+    // In this stage tablet -> node correspondence is resolved. Currently this is only needed
+    // to avoid scheduling too many queries that scan tablets on one node.
+
+    THashSet<ui64> TabletIdsToLocate;
+    THashMap<ui64, ui32> TabletId2NodeId;
+
+    size_t HiveRetryCount = 0;
+    static constexpr size_t MaxHiveRetryCount = 3;
+    static constexpr TDuration HiveRetryInterval = TDuration::Seconds(5);
+
+    void Handle(TEvPrivate::TEvRequestTableDistribution::TPtr& ev);
+    void Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev);
+    void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev);
+    void TryScheduleHiveRetry(const TStringBuf& issue);
 
     // StateScan
 
@@ -96,6 +143,8 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
         ui32 Id = 0;
         i64 TabletsInFlight = 0;
         TVector<ui64> PendingTablets;
+
+        explicit TNodeState(ui32 id) : Id(id) {}
     };
     THashMap<ui32, TNodeState> NodeId2State;
 
@@ -105,37 +154,6 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     THashMap<TActorId, TScanActorInfo> ScanActorsInFlight;
 
     std::optional<ui64> RowCount;
-
-    struct TEvPrivate {
-        enum EEv {
-            EvAnalyzeScanResult = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
-            EvEnd,
-        };
-
-        static_assert(
-            EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE),
-            "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
-
-        struct TEvAnalyzeScanResult : public TEventLocal<
-            TEvAnalyzeScanResult, EvAnalyzeScanResult>
-        {
-            Ydb::StatusIds::StatusCode Status;
-            NYql::TIssues Issues;
-            TVector<NYdb::TValue> AggColumns;
-
-            explicit TEvAnalyzeScanResult(TVector<NYdb::TValue> aggColumns)
-            : Status(Ydb::StatusIds::SUCCESS)
-            , AggColumns(std::move(aggColumns))
-            {}
-
-            TEvAnalyzeScanResult(
-                Ydb::StatusIds::StatusCode status,
-                NYql::TIssues&& issues)
-            : Status(status)
-            , Issues(std::move(issues))
-            {}
-        };
-    };
 
     class TScanActor;
 
@@ -161,18 +179,21 @@ public:
     {}
 
     void Bootstrap();
+    void PassAway() final;
 
     STFUNC(StateNavigate) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
+            hFunc(TEvTxProxySchemeCache::TEvResolveKeySetResult, Handle);
             hFunc(TEvents::TEvPoison, Handle);
         }
     }
 
-    STFUNC(StateResolve) {
+    STFUNC(StateLocateTablets) {
         switch (ev->GetTypeRewrite()) {
-            hFunc(TEvTxProxySchemeCache::TEvResolveKeySetResult, Handle);
+            hFunc(TEvPrivate::TEvRequestTableDistribution, Handle);
             hFunc(TEvHive::TEvResponseTabletDistribution, Handle);
+            hFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
             hFunc(TEvents::TEvPoison, Handle);
         }
     }

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "column_statistic_eval.h"
+#include "select_builder.h"
 
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
@@ -55,6 +56,7 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     };
 
     TString TableName;
+    bool IsColumnTable = false;
     TVector<TColumnDesc> Columns;
     TVector<NScheme::TTypeInfo> KeyColumnTypes;
 
@@ -62,9 +64,10 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 
     std::queue<TEvalTask> PendingTasks;
 
+    std::optional<TSelectBuilder> SelectBuilder;
     std::optional<ui32> CountSeq;
     std::vector<TEvalTask> InProgressTasks;
-    TActorId ScanActorId;
+    THashSet<TActorId> ScanActorIds;
 
     std::optional<ui64> RowCount;
 
@@ -101,7 +104,7 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 
     class TScanActor;
 
-    void DispatchScanActor();
+    void DispatchScanActors();
 
     void Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
     void Handle(TEvents::TEvPoison::TPtr& ev);

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -31,8 +31,6 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     void Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev);
     void Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev);
 
-    // StateQuery
-
     struct TColumnDesc {
         ui32 Tag;
         NScheme::TTypeInfo Type;
@@ -49,14 +47,6 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
         TColumnDesc& operator=(TColumnDesc&&) noexcept = default;
     };
 
-    struct TEvalTask {
-        size_t ColumnIdx = -1;
-
-        // One of the following
-        TSimpleColumnStatisticEval::TPtr SimpleStatEval;
-        IStage2ColumnStatisticEval::TPtr Stage2StatEval;
-    };
-
     TString TableName;
     bool IsColumnTable = false;
     TVector<TColumnDesc> Columns;
@@ -66,11 +56,38 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     TVector<ui64> TabletIds;
     THashMap<ui32, TVector<ui64>> NodeId2Tablets;
 
-    std::queue<TEvalTask> PendingTasks;
+    // StateScan
+
+    // In the simplest case, the table is scanned 2 times:
+    // First, simple column statistics (count distinct, min/max, etc.) for each column are
+    // calculated and used to determine parameters for stage 2 statistics.
+    // Second, stage 2 statistics such as count-min sketches and histograms are calculated.
+    //
+    // In more complicated cases, we have to split scans both horizontally (scan different
+    // columns with different SELECTs) and vertically (scan different parts of the table
+    // with different selects). Horizontal splits are needed to prevent the single scan
+    // result row from becoming too big, and vertical splits are needed if the table is
+    // so big that we cant scan the whole table at once.
+    //
+    // The order of scanning is as follows: we start a batch of TColumnStatEvalTasks
+    // and dispatch individual scans for parts of the table until we scan the whole table.
+    // Then we finalize the results, send them to StatisticsAggregator to save and
+    // move on to the next batch of of TColumnStatEvalTasks.
+
+    // Represents a task to calculate a single (column, statistic type) pair.
+    struct TColumnStatEvalTask {
+        size_t ColumnIdx = -1;
+
+        // One of the following
+        TSimpleColumnStatisticEval::TPtr SimpleStatEval;
+        IStage2ColumnStatisticEval::TPtr Stage2StatEval;
+    };
+
+    std::queue<TColumnStatEvalTask> PendingTasks;
 
     std::optional<TSelectBuilder> SelectBuilder;
     std::optional<ui32> CountSeq;
-    std::vector<TEvalTask> InProgressTasks;
+    std::vector<TColumnStatEvalTask> InProgressTasks;
 
     THashMap<ui32, TVector<ui64>> NodeId2PendingTablets;
 
@@ -114,7 +131,7 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 
     class TScanActor;
 
-    void DispatchScanActors();
+    void StartColumnStatEvalTasks();
 
     void Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
     void Handle(TEvents::TEvPoison::TPtr& ev);

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -162,7 +162,6 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 
     void HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
     void Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
-    void Handle(TEvents::TEvPoison::TPtr& ev);
 
 public:
     TAnalyzeActor(
@@ -185,7 +184,7 @@ public:
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
             hFunc(TEvTxProxySchemeCache::TEvResolveKeySetResult, Handle);
-            hFunc(TEvents::TEvPoison, Handle);
+            sFunc(TEvents::TEvPoison, PassAway);
         }
     }
 
@@ -194,14 +193,14 @@ public:
             hFunc(TEvPrivate::TEvRequestTableDistribution, Handle);
             hFunc(TEvHive::TEvResponseTabletDistribution, Handle);
             hFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
-            hFunc(TEvents::TEvPoison, Handle);
+            sFunc(TEvents::TEvPoison, PassAway);
         }
     }
 
     STFUNC(StateScan) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvPrivate::TEvAnalyzeScanResult, Handle);
-            hFunc(TEvents::TEvPoison, Handle);
+            sFunc(TEvents::TEvPoison, PassAway);
         }
     }
 };

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -4,6 +4,7 @@
 #include "select_builder.h"
 
 #include <ydb/core/statistics/events.h>
+#include <ydb/core/base/hive.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/actorid.h>
@@ -28,6 +29,7 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     // StateResolve
 
     void Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev);
+    void Handle(TEvHive::TEvResponseTabletDistribution::TPtr& ev);
 
     // StateQuery
 
@@ -59,15 +61,23 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     bool IsColumnTable = false;
     TVector<TColumnDesc> Columns;
     TVector<NScheme::TTypeInfo> KeyColumnTypes;
+    ui64 HiveId = 0;
 
-    TVector<ui64> ShardIds;
+    TVector<ui64> TabletIds;
+    THashMap<ui32, TVector<ui64>> NodeId2Tablets;
 
     std::queue<TEvalTask> PendingTasks;
 
     std::optional<TSelectBuilder> SelectBuilder;
     std::optional<ui32> CountSeq;
     std::vector<TEvalTask> InProgressTasks;
-    THashSet<TActorId> ScanActorIds;
+
+    THashMap<ui32, TVector<ui64>> NodeId2PendingTablets;
+
+    struct TScanActorInfo {
+        ui32 TabletNodeId = 0;
+    };
+    THashMap<TActorId, TScanActorInfo> ScanActorsInFlight;
 
     std::optional<ui64> RowCount;
 
@@ -135,6 +145,7 @@ public:
     STFUNC(StateResolve) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvTxProxySchemeCache::TEvResolveKeySetResult, Handle);
+            hFunc(TEvHive::TEvResponseTabletDistribution, Handle);
             hFunc(TEvents::TEvPoison, Handle);
         }
     }

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -142,6 +142,7 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     void StartColumnStatEvalTasks();
     void DispatchSomeScanActors();
 
+    void HandleImpl(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
     void Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
     void Handle(TEvents::TEvPoison::TPtr& ev);
 

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -89,7 +89,15 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     std::optional<ui32> CountSeq;
     std::vector<TColumnStatEvalTask> InProgressTasks;
 
-    THashMap<ui32, TVector<ui64>> NodeId2PendingTablets;
+    static constexpr ui64 MaxTotalScanActorsInFlight = 100;
+    static constexpr i64 MaxPerNodeScanActorsInFlight = 1;
+
+    struct TNodeState {
+        ui32 Id = 0;
+        i64 TabletsInFlight = 0;
+        TVector<ui64> PendingTablets;
+    };
+    THashMap<ui32, TNodeState> NodeId2State;
 
     struct TScanActorInfo {
         ui32 TabletNodeId = 0;
@@ -132,6 +140,7 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
     class TScanActor;
 
     void StartColumnStatEvalTasks();
+    void DispatchSomeScanActors();
 
     void Handle(TEvPrivate::TEvAnalyzeScanResult::TPtr& ev);
     void Handle(TEvents::TEvPoison::TPtr& ev);

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -24,6 +24,10 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
 
+    // StateResolve
+
+    void Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev);
+
     // StateQuery
 
     struct TColumnDesc {
@@ -52,6 +56,9 @@ class TAnalyzeActor : public NActors::TActorBootstrapped<TAnalyzeActor> {
 
     TString TableName;
     TVector<TColumnDesc> Columns;
+    TVector<NScheme::TTypeInfo> KeyColumnTypes;
+
+    TVector<ui64> ShardIds;
 
     std::queue<TEvalTask> PendingTasks;
 
@@ -122,7 +129,14 @@ public:
         }
     }
 
-    STFUNC(StateQuery) {
+    STFUNC(StateResolve) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvTxProxySchemeCache::TEvResolveKeySetResult, Handle);
+            hFunc(TEvents::TEvPoison, Handle);
+        }
+    }
+
+    STFUNC(StateScan) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvPrivate::TEvAnalyzeScanResult, Handle);
             hFunc(TEvents::TEvPoison, Handle);

--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -12,14 +12,14 @@
 
 namespace NKikimr::NStat {
 
-struct TSimpleColumnStatisticEval::TState {
+struct TSimpleColumnStatisticEval::TIntermediateState {
     using THLLState = NAggFuncs::THybridHyperLogLog<std::allocator>;
 
     THLLState Hll;
     std::optional<NYdb::TValue> Min;
     std::optional<NYdb::TValue> Max;
 
-    TState()
+    TIntermediateState()
         : Hll(THLLState::Create(NAggFuncs::THLLAggFunc::DEFAULT_PRECISION))
     {}
 };
@@ -41,11 +41,11 @@ size_t TSimpleColumnStatisticEval::EstimateSize() const {
 
 void TSimpleColumnStatisticEval::AddAggregations(
         const TString& columnName, TSelectBuilder& builder) {
-    if (builder.Final()) {
-        CountDistinctSeq = builder.AddBuiltinAggregation(columnName, "HLL");
-    } else {
-        State = std::make_unique<TState>();
+    if (builder.IsIntermediateAggregation()) {
+        IntermediateState = std::make_unique<TIntermediateState>();
         CountDistinctSeq = builder.AddUDAFAggregation(columnName, "HLL");
+    } else {
+        CountDistinctSeq = builder.AddBuiltinAggregation(columnName, "HLL");
     }
 
     if (IStage2ColumnStatisticEval::AreMinMaxNeeded(Type)) {
@@ -101,7 +101,7 @@ static void UpdateMinmax(std::optional<NYdb::TValue>& left, const NYdb::TValue& 
 };
 
 void TSimpleColumnStatisticEval::Merge(const TVector<NYdb::TValue>& aggColumns) {
-    Y_ENSURE(State);
+    Y_ENSURE(IntermediateState);
 
     {
         NYdb::TValueParser hllVal(aggColumns.at(CountDistinctSeq.value()));
@@ -110,15 +110,15 @@ void TSimpleColumnStatisticEval::Merge(const TVector<NYdb::TValue>& aggColumns) 
             return;
         }
         TMemoryInput is(hllVal.GetBytes().data(), hllVal.GetBytes().size());
-        auto hll = TState::THLLState::Load(is);
-        State->Hll.Merge(hll);
+        auto hll = TIntermediateState::THLLState::Load(is);
+        IntermediateState->Hll.Merge(hll);
     }
 
     if (MinSeq) {
-        UpdateMinmax<std::less>(State->Min, aggColumns.at(*MinSeq));
+        UpdateMinmax<std::less>(IntermediateState->Min, aggColumns.at(*MinSeq));
     }
     if (MaxSeq) {
-        UpdateMinmax<std::greater>(State->Max, aggColumns.at(*MaxSeq));
+        UpdateMinmax<std::greater>(IntermediateState->Max, aggColumns.at(*MaxSeq));
     }
 }
 
@@ -132,14 +132,14 @@ NKikimrStat::TSimpleColumnStatistics TSimpleColumnStatisticEval::Extract(
         NScheme::ProtoFromTypeInfo(Type, PgTypeMod, *result.MutableTypeInfo());
     }
 
-    if (State) {
+    if (IntermediateState) {
         Merge(aggColumns);
-        result.SetCountDistinct(State->Hll.Estimate());
-        if (State->Min) {
-            result.MutableMin()->CopyFrom(State->Min->GetProto());
+        result.SetCountDistinct(IntermediateState->Hll.Estimate());
+        if (IntermediateState->Min) {
+            result.MutableMin()->CopyFrom(IntermediateState->Min->GetProto());
         }
-        if (State->Max) {
-            result.MutableMax()->CopyFrom(State->Max->GetProto());
+        if (IntermediateState->Max) {
+            result.MutableMax()->CopyFrom(IntermediateState->Max->GetProto());
         }
     } else {
         NYdb::TValueParser hllVal(aggColumns.at(CountDistinctSeq.value()));
@@ -162,7 +162,7 @@ class TCMSEval : public IStage2ColumnStatisticEval {
     ui64 Depth = DEFAULT_DEPTH;
 
     std::optional<ui32> Seq;
-    std::unique_ptr<TCountMinSketch> State;
+    std::unique_ptr<TCountMinSketch> IntermediateState;
 
     static constexpr ui64 MIN_WIDTH = 4096;
     static constexpr ui64 DEFAULT_DEPTH = 8;
@@ -198,13 +198,13 @@ public:
     void AddAggregations(const TString& columnName, TSelectBuilder& builder) final {
         Seq = builder.AddUDAFAggregation(columnName, "CMS", Width, Depth);
 
-        if (!builder.Final()) {
-            State = std::unique_ptr<TCountMinSketch>(TCountMinSketch::Create(Width, Depth));
+        if (builder.IsIntermediateAggregation()) {
+            IntermediateState = std::unique_ptr<TCountMinSketch>(TCountMinSketch::Create(Width, Depth));
         }
     }
 
     void Merge(const TVector<NYdb::TValue>& aggColumns) final {
-        Y_ENSURE(State);
+        Y_ENSURE(IntermediateState);
         NYdb::TValueParser val(aggColumns.at(Seq.value()));
         val.OpenOptional();
         if (val.IsNull()) {
@@ -212,13 +212,13 @@ public:
         }
         auto cms = std::unique_ptr<TCountMinSketch>(TCountMinSketch::FromString(
             val.GetBytes().data(), val.GetBytes().size()));
-        *State += *cms;
+        *IntermediateState += *cms;
     }
 
     TString ExtractData(const TVector<NYdb::TValue>& aggColumns) final {
-        if (State) {
+        if (IntermediateState) {
             Merge(aggColumns);
-            auto bytes = State->AsStringBuf();
+            auto bytes = IntermediateState->AsStringBuf();
             return TString(bytes.data(), bytes.size());
         }
 
@@ -252,7 +252,7 @@ class TEWHEval : public IStage2ColumnStatisticEval {
     TBorder RangeEnd;
 
     std::optional<ui32> Seq;
-    std::unique_ptr<TEqWidthHistogram> State;
+    std::unique_ptr<TEqWidthHistogram> IntermediateState;
 
 private:
     TEqWidthHistogram CreateEmpty() const {
@@ -389,13 +389,13 @@ public:
     void AddAggregations(const TString& columnName, TSelectBuilder& builder) final {
         Seq = builder.AddUDAFAggregation(columnName, "EWH", NumBuckets, RangeStart, RangeEnd);
 
-        if (!builder.Final()) {
-            State = std::make_unique<TEqWidthHistogram>(CreateEmpty());
+        if (builder.IsIntermediateAggregation()) {
+            IntermediateState = std::make_unique<TEqWidthHistogram>(CreateEmpty());
         }
     }
 
     void Merge(const TVector<NYdb::TValue>& aggColumns) final {
-        Y_ENSURE(State);
+        Y_ENSURE(IntermediateState);
 
         NYdb::TValueParser val(aggColumns.at(Seq.value()));
         val.OpenOptional();
@@ -405,13 +405,13 @@ public:
 
         const auto& bytes = val.GetBytes();
         TEqWidthHistogram merged(bytes.data(), bytes.size());
-        State->Aggregate(merged);
+        IntermediateState->Aggregate(merged);
     }
 
     TString ExtractData(const TVector<NYdb::TValue>& aggColumns) final {
-        if (State) {
+        if (IntermediateState) {
             Merge(aggColumns);
-            return State->Serialize();
+            return IntermediateState->Serialize();
         }
 
         NYdb::TValueParser val(aggColumns.at(Seq.value()));

--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -3,6 +3,7 @@
 
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/public/api/protos/ydb_value.pb.h>
+#include <ydb/library/yql/udfs/statistics_internal/all_agg_funcs.h>
 #include <yql/essentials/core/minsketch/count_min_sketch.h>
 #include <yql/essentials/core/histogram/eq_width_histogram.h>
 #include <yql/essentials/public/udf/udf_data_type.h>
@@ -11,43 +12,146 @@
 
 namespace NKikimr::NStat {
 
+struct TSimpleColumnStatisticEval::TState {
+    using THLLState = NAggFuncs::THybridHyperLogLog<std::allocator>;
+
+    THLLState Hll;
+    std::optional<NYdb::TValue> Min;
+    std::optional<NYdb::TValue> Max;
+
+    TState()
+        : Hll(THLLState::Create(NAggFuncs::THLLAggFunc::DEFAULT_PRECISION))
+    {}
+};
+
+TSimpleColumnStatisticEval::TSimpleColumnStatisticEval(NScheme::TTypeInfo type, TString pgTypeMod)
+    : Type(std::move(type))
+    , PgTypeMod(std::move(pgTypeMod))
+{}
+
+TSimpleColumnStatisticEval::~TSimpleColumnStatisticEval() = default;
+
 EStatType TSimpleColumnStatisticEval::GetType() const {
     return EStatType::SIMPLE_COLUMN;
 }
 
 size_t TSimpleColumnStatisticEval::EstimateSize() const {
-    constexpr size_t DEFAULT_HLL_PRECISION = 14;
-    return 1u << DEFAULT_HLL_PRECISION;
+    return 1u << NAggFuncs::THLLAggFunc::DEFAULT_PRECISION;
 }
 
 void TSimpleColumnStatisticEval::AddAggregations(
         const TString& columnName, TSelectBuilder& builder) {
-    CountDistinctSeq = builder.AddBuiltinAggregation(columnName, "HLL");
+    if (builder.Final()) {
+        CountDistinctSeq = builder.AddBuiltinAggregation(columnName, "HLL");
+    } else {
+        State = std::make_unique<TState>();
+        CountDistinctSeq = builder.AddUDAFAggregation(columnName, "HLL");
+    }
+
     if (IStage2ColumnStatisticEval::AreMinMaxNeeded(Type)) {
         MinSeq = builder.AddBuiltinAggregation(columnName, "min");
         MaxSeq = builder.AddBuiltinAggregation(columnName, "max");
     }
 }
 
+template<template<typename> class TCmp>
+static void UpdateMinmax(std::optional<NYdb::TValue>& left, const NYdb::TValue& right) {
+    if (!left) {
+        left = right;
+        return;
+    }
+
+    TCmp cmp;
+    auto& leftProto = left->GetProto();
+    const auto& rightProto = right.GetProto();
+    switch (leftProto.value_case()) {
+    case Ydb::Value::kInt32Value:
+        if (cmp(rightProto.int32_value(), leftProto.int32_value())) {
+            leftProto.set_int32_value(rightProto.int32_value());
+        }
+        break;
+    case Ydb::Value::kUint32Value:
+        if (cmp(rightProto.uint32_value(), leftProto.uint32_value())) {
+            leftProto.set_uint32_value(rightProto.uint32_value());
+        }
+        break;
+    case Ydb::Value::kInt64Value:
+        if (cmp(rightProto.int64_value(), leftProto.int64_value())) {
+            leftProto.set_int64_value(rightProto.int64_value());
+        }
+        break;
+    case Ydb::Value::kUint64Value:
+        if (cmp(rightProto.uint64_value(), leftProto.uint64_value())) {
+            leftProto.set_uint64_value(rightProto.uint64_value());
+        }
+        break;
+    case Ydb::Value::kFloatValue:
+        if (cmp(rightProto.float_value(), leftProto.float_value())) {
+            leftProto.set_float_value(rightProto.float_value());
+        }
+        break;
+    case Ydb::Value::kDoubleValue:
+        if (cmp(rightProto.double_value(), leftProto.double_value())) {
+            leftProto.set_double_value(rightProto.double_value());
+        }
+        break;
+    default:
+        Y_ENSURE(false, "unexpected value type");
+    }
+};
+
+void TSimpleColumnStatisticEval::Merge(const TVector<NYdb::TValue>& aggColumns) {
+    Y_ENSURE(State);
+
+    {
+        NYdb::TValueParser hllVal(aggColumns.at(CountDistinctSeq.value()));
+        hllVal.OpenOptional();
+        if (hllVal.IsNull()) {
+            return;
+        }
+        TMemoryInput is(hllVal.GetBytes().data(), hllVal.GetBytes().size());
+        auto hll = TState::THLLState::Load(is);
+        State->Hll.Merge(hll);
+    }
+
+    if (MinSeq) {
+        UpdateMinmax<std::less>(State->Min, aggColumns.at(*MinSeq));
+    }
+    if (MaxSeq) {
+        UpdateMinmax<std::greater>(State->Max, aggColumns.at(*MaxSeq));
+    }
+}
+
 NKikimrStat::TSimpleColumnStatistics TSimpleColumnStatisticEval::Extract(
-        ui64 rowCount, const TVector<NYdb::TValue>& aggColumns) const {
+        ui64 rowCount, const TVector<NYdb::TValue>& aggColumns) {
     NKikimrStat::TSimpleColumnStatistics result;
     result.SetCount(rowCount);
-
-    NYdb::TValueParser hllVal(aggColumns.at(CountDistinctSeq.value()));
-    ui64 countDistinct = hllVal.GetOptionalUint64().value_or(0);
-    result.SetCountDistinct(countDistinct);
 
     result.SetTypeId(Type.GetTypeId());
     if (NScheme::NTypeIds::IsParametrizedType(Type.GetTypeId())) {
         NScheme::ProtoFromTypeInfo(Type, PgTypeMod, *result.MutableTypeInfo());
     }
 
-    if (MinSeq) {
-        result.MutableMin()->CopyFrom(aggColumns.at(*MinSeq).GetProto());
-    }
-    if (MaxSeq) {
-        result.MutableMax()->CopyFrom(aggColumns.at(*MaxSeq).GetProto());
+    if (State) {
+        Merge(aggColumns);
+        result.SetCountDistinct(State->Hll.Estimate());
+        if (State->Min) {
+            result.MutableMin()->CopyFrom(State->Min->GetProto());
+        }
+        if (State->Max) {
+            result.MutableMax()->CopyFrom(State->Max->GetProto());
+        }
+    } else {
+        NYdb::TValueParser hllVal(aggColumns.at(CountDistinctSeq.value()));
+        ui64 countDistinct = hllVal.GetOptionalUint64().value_or(0);
+        result.SetCountDistinct(countDistinct);
+
+        if (MinSeq) {
+            result.MutableMin()->CopyFrom(aggColumns.at(*MinSeq).GetProto());
+        }
+        if (MaxSeq) {
+            result.MutableMax()->CopyFrom(aggColumns.at(*MaxSeq).GetProto());
+        }
     }
 
     return result;
@@ -56,7 +160,9 @@ NKikimrStat::TSimpleColumnStatistics TSimpleColumnStatisticEval::Extract(
 class TCMSEval : public IStage2ColumnStatisticEval {
     ui64 Width;
     ui64 Depth = DEFAULT_DEPTH;
+
     std::optional<ui32> Seq;
+    std::unique_ptr<TCountMinSketch> State;
 
     static constexpr ui64 MIN_WIDTH = 4096;
     static constexpr ui64 DEFAULT_DEPTH = 8;
@@ -91,9 +197,31 @@ public:
 
     void AddAggregations(const TString& columnName, TSelectBuilder& builder) final {
         Seq = builder.AddUDAFAggregation(columnName, "CMS", Width, Depth);
+
+        if (!builder.Final()) {
+            State = std::unique_ptr<TCountMinSketch>(TCountMinSketch::Create(Width, Depth));
+        }
     }
 
-    TString ExtractData(const TVector<NYdb::TValue>& aggColumns) const final {
+    void Merge(const TVector<NYdb::TValue>& aggColumns) final {
+        Y_ENSURE(State);
+        NYdb::TValueParser val(aggColumns.at(Seq.value()));
+        val.OpenOptional();
+        if (val.IsNull()) {
+            return;
+        }
+        auto cms = std::unique_ptr<TCountMinSketch>(TCountMinSketch::FromString(
+            val.GetBytes().data(), val.GetBytes().size()));
+        *State += *cms;
+    }
+
+    TString ExtractData(const TVector<NYdb::TValue>& aggColumns) final {
+        if (State) {
+            Merge(aggColumns);
+            auto bytes = State->AsStringBuf();
+            return TString(bytes.data(), bytes.size());
+        }
+
         NYdb::TValueParser val(aggColumns.at(Seq.value()));
         val.OpenOptional();
         if (!val.IsNull()) {
@@ -110,21 +238,36 @@ public:
 
 struct TBorder {
     std::variant<ui64, i64, float, double> Val;
+    NYql::NUdf::TUnboxedValuePod YqlVal;
 
     template<typename T>
-    explicit TBorder(T val) : Val(val) {}
+    explicit TBorder(T val) : Val(val), YqlVal(val) {}
 };
 
 class TEWHEval : public IStage2ColumnStatisticEval {
+    NScheme::TTypeInfo ColumnType;
+
     ui32 NumBuckets;
     TBorder RangeStart;
     TBorder RangeEnd;
 
     std::optional<ui32> Seq;
+    std::unique_ptr<TEqWidthHistogram> State;
+
+private:
+    TEqWidthHistogram CreateEmpty() const {
+        std::array<NYql::NUdf::TUnboxedValuePod, 3> params {
+            NYql::NUdf::TUnboxedValuePod(NumBuckets),
+            RangeStart.YqlVal,
+            RangeEnd.YqlVal,
+        };
+        return NAggFuncs::TEWHAggFunc::CreateState(ColumnType.GetTypeId(), params);
+    }
 
 public:
-    TEWHEval(ui32 numBuckets, TBorder rangeStart, TBorder rangeEnd)
-        : NumBuckets(numBuckets)
+    TEWHEval(NScheme::TTypeInfo columnType, ui32 numBuckets, TBorder rangeStart, TBorder rangeEnd)
+        : ColumnType(columnType)
+        , NumBuckets(numBuckets)
         , RangeStart(std::move(rangeStart))
         , RangeEnd(std::move(rangeEnd))
     {}
@@ -236,7 +379,7 @@ public:
             return TPtr{};
         }
         return std::make_unique<TEWHEval>(
-            numBuckets, domainRange->first, domainRange->second);
+            type, numBuckets, domainRange->first, domainRange->second);
     }
 
     EStatType GetType() const final { return EStatType::EQ_WIDTH_HISTOGRAM; }
@@ -245,14 +388,41 @@ public:
 
     void AddAggregations(const TString& columnName, TSelectBuilder& builder) final {
         Seq = builder.AddUDAFAggregation(columnName, "EWH", NumBuckets, RangeStart, RangeEnd);
+
+        if (!builder.Final()) {
+            State = std::make_unique<TEqWidthHistogram>(CreateEmpty());
+        }
     }
 
-    TString ExtractData(const TVector<NYdb::TValue>& aggColumns) const final {
+    void Merge(const TVector<NYdb::TValue>& aggColumns) final {
+        Y_ENSURE(State);
+
         NYdb::TValueParser val(aggColumns.at(Seq.value()));
         val.OpenOptional();
-        Y_ENSURE(!val.IsNull()); // Makes no sense to calculate histograms for empty tables.
+        if (val.IsNull()) {
+            return;
+        }
+
         const auto& bytes = val.GetBytes();
-        return TString(bytes.data(), bytes.size());
+        TEqWidthHistogram merged(bytes.data(), bytes.size());
+        State->Aggregate(merged);
+    }
+
+    TString ExtractData(const TVector<NYdb::TValue>& aggColumns) final {
+        if (State) {
+            Merge(aggColumns);
+            return State->Serialize();
+        }
+
+        NYdb::TValueParser val(aggColumns.at(Seq.value()));
+        val.OpenOptional();
+        if (!val.IsNull()) {
+            const auto& bytes = val.GetBytes();
+            return TString(bytes.data(), bytes.size());
+        } else {
+            auto empty = CreateEmpty();
+            return empty.Serialize();
+        }
     }
 };
 

--- a/ydb/core/statistics/aggregator/column_statistic_eval.h
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.h
@@ -16,19 +16,21 @@ class TSimpleColumnStatisticEval {
     std::optional<ui32> CountDistinctSeq;
     std::optional<ui32> MinSeq;
     std::optional<ui32> MaxSeq;
+
+    struct TState;
+    std::unique_ptr<TState> State;
+
 public:
     using TPtr = std::unique_ptr<TSimpleColumnStatisticEval>;
 
-    explicit TSimpleColumnStatisticEval(NScheme::TTypeInfo type, TString pgTypeMod)
-        : Type(std::move(type))
-        , PgTypeMod(std::move(pgTypeMod))
-    {}
+    TSimpleColumnStatisticEval(NScheme::TTypeInfo type, TString pgTypeMod);
+    ~TSimpleColumnStatisticEval();
 
     EStatType GetType() const;
     size_t EstimateSize() const;
     void AddAggregations(const TString& columnName, TSelectBuilder& builder);
-    NKikimrStat::TSimpleColumnStatistics Extract(
-        ui64 rowCount, const TVector<NYdb::TValue>& aggColumns) const;
+    void Merge(const TVector<NYdb::TValue>& aggColumns);
+    NKikimrStat::TSimpleColumnStatistics Extract(ui64 rowCount, const TVector<NYdb::TValue>& aggColumns);
 };
 
 // Base class for classes that manage evaluation of column statistics
@@ -47,7 +49,8 @@ public:
     virtual EStatType GetType() const = 0;
     virtual size_t EstimateSize() const = 0;
     virtual void AddAggregations(const TString& columnName, TSelectBuilder&) = 0;
-    virtual TString ExtractData(const TVector<NYdb::TValue>& aggColumns) const = 0;
+    virtual void Merge(const TVector<NYdb::TValue>& aggColumns) = 0;
+    virtual TString ExtractData(const TVector<NYdb::TValue>& aggColumns) = 0;
     virtual ~IStage2ColumnStatisticEval() = default;
 };
 

--- a/ydb/core/statistics/aggregator/column_statistic_eval.h
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.h
@@ -17,8 +17,8 @@ class TSimpleColumnStatisticEval {
     std::optional<ui32> MinSeq;
     std::optional<ui32> MaxSeq;
 
-    struct TState;
-    std::unique_ptr<TState> State;
+    struct TIntermediateState;
+    std::unique_ptr<TIntermediateState> IntermediateState;
 
 public:
     using TPtr = std::unique_ptr<TSimpleColumnStatisticEval>;

--- a/ydb/core/statistics/aggregator/select_builder.cpp
+++ b/ydb/core/statistics/aggregator/select_builder.cpp
@@ -41,7 +41,7 @@ ui32 TSelectBuilder::AddFactory(const TStringBuf& udafName, size_t paramCount) {
     return it->second.Id;
 }
 
-TString TSelectBuilder::Build(const TStringBuf& table, std::optional<ui64> shardId) const {
+TString TSelectBuilder::Build(const TStringBuf& table, std::optional<ui64> tabletId) const {
     TStringBuilder res;
     for (const auto& [udaf, factory] : Udaf2Factory) {
         TStringBuilder paramsStr;
@@ -52,7 +52,7 @@ TString TSelectBuilder::Build(const TStringBuf& table, std::optional<ui64> shard
             paramsStr << "$p" << i;
         }
 
-        std::string_view finalizeFunc = Final_ ? "Finalize" : "Serialize";
+        std::string_view finalizeFunc = IsIntermediateAggregation_ ? "Serialize" : "Finalize";
 
         res << std::format(R"($f{0} = ({2}) -> {{ return AggregationFactory(
     "UDAF",
@@ -92,8 +92,8 @@ TString TSelectBuilder::Build(const TStringBuf& table, std::optional<ui64> shard
     }
 
     res << " FROM " << TEscapedId{table};
-    if (shardId) {
-        res << " WITH TabletId = '" << *shardId << "'";
+    if (tabletId) {
+        res << " WITH TabletId = '" << *tabletId << "'";
     }
     return res;
 }

--- a/ydb/core/statistics/aggregator/select_builder.cpp
+++ b/ydb/core/statistics/aggregator/select_builder.cpp
@@ -41,7 +41,7 @@ ui32 TSelectBuilder::AddFactory(const TStringBuf& udafName, size_t paramCount) {
     return it->second.Id;
 }
 
-TString TSelectBuilder::Build(const TStringBuf& table) const {
+TString TSelectBuilder::Build(const TStringBuf& table, std::optional<ui64> shardId) const {
     TStringBuilder res;
     for (const auto& [udaf, factory] : Udaf2Factory) {
         TStringBuilder paramsStr;
@@ -52,18 +52,20 @@ TString TSelectBuilder::Build(const TStringBuf& table) const {
             paramsStr << "$p" << i;
         }
 
+        std::string_view finalizeFunc = Final_ ? "Finalize" : "Serialize";
+
         res << std::format(R"($f{0} = ({2}) -> {{ return AggregationFactory(
     "UDAF",
     ($item,$parent) -> {{ return Udf(StatisticsInternal::{1}Create, $parent as Depends)($item,{2}) }},
     ($state,$item,$parent) -> {{ return Udf(StatisticsInternal::{1}AddValue, $parent as Depends)($state, $item) }},
     StatisticsInternal::{1}Merge,
-    StatisticsInternal::{1}Finalize,
+    StatisticsInternal::{1}{3},
     StatisticsInternal::{1}Serialize,
     StatisticsInternal::{1}Deserialize,
 )
 }};
 )",
-            factory.Id, std::string_view(factory.Udaf), std::string_view(paramsStr));
+            factory.Id, std::string_view(factory.Udaf), std::string_view(paramsStr), finalizeFunc);
     }
 
     res << "SELECT ";
@@ -90,6 +92,9 @@ TString TSelectBuilder::Build(const TStringBuf& table) const {
     }
 
     res << " FROM " << TEscapedId{table};
+    if (shardId) {
+        res << " WITH TabletId = '" << *shardId << "'";
+    }
     return res;
 }
 

--- a/ydb/core/statistics/aggregator/select_builder.h
+++ b/ydb/core/statistics/aggregator/select_builder.h
@@ -10,12 +10,16 @@ namespace NKikimr::NStat {
 // Class that is used to build internal SELECT queries used to calculate column statistics.
 class TSelectBuilder {
 public:
+    explicit TSelectBuilder(bool final) : Final_(final) {}
+
+    bool Final() const { return Final_; }
+
     ui32 AddBuiltinAggregation(std::optional<TString> columnName, TString aggName);
 
     template<typename... TArgs>
     ui32 AddUDAFAggregation(TString columnName, const TStringBuf& udafName, TArgs&&... params);
 
-    TString Build(const TStringBuf& table) const;
+    TString Build(const TStringBuf& table, std::optional<ui64> shardId) const;
 
     size_t ColumnCount() const {
         return Columns.size();
@@ -25,6 +29,8 @@ private:
     ui32 AddFactory(const TStringBuf& udafName, size_t paramCount);
 
 private:
+    bool Final_;
+
     struct TFactory {
         TFactory(ui32 id, const TStringBuf& udaf, size_t paramCount)
             : Id(id), Udaf(udaf), ParamCount(paramCount)
@@ -47,6 +53,19 @@ private:
 
     TVector<TAggColumn> Columns;
 };
+
+template<>
+inline ui32 TSelectBuilder::AddUDAFAggregation(TString columnName, const TStringBuf& udafName) {
+    auto factory = AddFactory(udafName, 0);
+
+    auto column = TAggColumn{
+        .Seq = static_cast<ui32>(Columns.size()),
+        .ColumnName = std::move(columnName),
+        .UdafFactory = factory,
+    };
+    Columns.push_back(std::move(column));
+    return Columns.back().Seq;
+}
 
 template<typename... TArgs>
 ui32 TSelectBuilder::AddUDAFAggregation(TString columnName, const TStringBuf& udafName, TArgs&&... params) {

--- a/ydb/core/statistics/aggregator/select_builder.h
+++ b/ydb/core/statistics/aggregator/select_builder.h
@@ -10,16 +10,22 @@ namespace NKikimr::NStat {
 // Class that is used to build internal SELECT queries used to calculate column statistics.
 class TSelectBuilder {
 public:
-    explicit TSelectBuilder(bool final) : Final_(final) {}
+    // If isIntermediateAggregation is true, results of several SELECTs over different
+    // parts of the table are expected to be combined into the final result.
+    // UDAFs won't finalize their result and will return an intermediate aggregation state
+    // that can be merged with intermediate states.
+    explicit TSelectBuilder(bool isIntermediateAggregation)
+        : IsIntermediateAggregation_(isIntermediateAggregation)
+    {}
 
-    bool Final() const { return Final_; }
+    bool IsIntermediateAggregation() const { return IsIntermediateAggregation_; }
 
     ui32 AddBuiltinAggregation(std::optional<TString> columnName, TString aggName);
 
     template<typename... TArgs>
     ui32 AddUDAFAggregation(TString columnName, const TStringBuf& udafName, TArgs&&... params);
 
-    TString Build(const TStringBuf& table, std::optional<ui64> shardId) const;
+    TString Build(const TStringBuf& table, std::optional<ui64> tabletId) const;
 
     size_t ColumnCount() const {
         return Columns.size();
@@ -29,7 +35,7 @@ private:
     ui32 AddFactory(const TStringBuf& udafName, size_t paramCount);
 
 private:
-    bool Final_;
+    bool IsIntermediateAggregation_;
 
     struct TFactory {
         TFactory(ui32 id, const TStringBuf& udaf, size_t paramCount)

--- a/ydb/core/statistics/aggregator/ya.make
+++ b/ydb/core/statistics/aggregator/ya.make
@@ -39,6 +39,7 @@ PEERDIR(
     ydb/core/tablet
     ydb/core/tablet_flat
     ydb/core/statistics/database
+    ydb/library/yql/udfs/statistics_internal
     yql/essentials/core/minsketch
 )
 

--- a/ydb/core/statistics/service/ut/ut_column_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_column_statistics.cpp
@@ -77,8 +77,9 @@ ui16 GetTag(const std::string_view& columnName, const std::vector<TColumnDesc>& 
 
 TTableInfo PrepareTable(
         TTestEnv& env, const TString& databaseName, const TString& tableName,
-        const std::vector<TColumnDesc>& columns = GetColumns()) {
-    auto info = CreateColumnTable(env, databaseName, tableName, 4, columns);
+        const std::vector<TColumnDesc>& columns = GetColumns(),
+        size_t shardCount = 4) {
+    auto info = CreateColumnTable(env, databaseName, tableName, shardCount, columns);
     InsertDataIntoTable(env, databaseName, tableName, ColumnTableRowsNumber, columns);
     return info;
 }
@@ -148,6 +149,17 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
 
         ValidateCountMinSketch(runtime, table1.PathId);
         ValidateCountMinSketch(runtime, table2.PathId);
+    }
+
+    Y_UNIT_TEST(CountMinSketchManyNodes) {
+        TTestEnv env(1, 3);
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database", 3);
+        const auto tableInfo = PrepareTable(env, "Database", "Table1", GetColumns(), /*shardCount=*/8);
+        Analyze(runtime, tableInfo.SaTabletId, {tableInfo.PathId});
+
+        ValidateCountMinSketch(runtime, tableInfo.PathId);
     }
 
     Y_UNIT_TEST(SimpleColumnStatistics) {

--- a/ydb/core/statistics/ut_common/ut_common.cpp
+++ b/ydb/core/statistics/ut_common/ut_common.cpp
@@ -41,6 +41,10 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, bool useRealThreads,
     Settings->AppConfig->MutableStatisticsConfig()->SetBaseStatsSendIntervalSecondsServerless(6);
     Settings->AppConfig->MutableStatisticsConfig()->SetBaseStatsPropagateIntervalSecondsServerless(6);
 
+    // With LLVM enabled, scan queries calculating column statistics are very slow for some reason
+    // (10s of seconds), so we disable it.
+    Settings->AppConfig->MutableTableServiceConfig()->SetEnableKqpScanQueryUseLlvm(false);
+
     NKikimrConfig::TFeatureFlags featureFlags;
     featureFlags.SetEnableStatistics(true);
     featureFlags.SetEnableColumnStatistics(true);

--- a/ydb/library/yql/udfs/statistics_internal/all_agg_funcs.h
+++ b/ydb/library/yql/udfs/statistics_internal/all_agg_funcs.h
@@ -2,12 +2,14 @@
 
 #include "cms_agg_func.h"
 #include "ewh_agg_func.h"
+#include "hll_agg_func.h"
 
 namespace NKikimr::NStat::NAggFuncs {
 
 using TAllAggFuncsList = TTypeList<
     TCMSAggFunc,
-    TEWHAggFunc
+    TEWHAggFunc,
+    THLLAggFunc
 >;
 
 } // NKikimr::NStat::NAggFuncs

--- a/ydb/library/yql/udfs/statistics_internal/hll_agg_func.h
+++ b/ydb/library/yql/udfs/statistics_internal/hll_agg_func.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include "common.h"
+
+#include <library/cpp/hyperloglog/hyperloglog.h>
+
+#include <util/digest/murmur.h>
+#include <util/generic/hash_set.h>
+#include <util/stream/mem.h>
+#include <util/string/cast.h>
+
+#include <variant>
+
+namespace NKikimr::NStat::NAggFuncs {
+
+// Adapted from yql/essentials/udfs/common/hyperloglog/hyperloglog_udf.cpp
+template<template<typename> typename TAlloc>
+class THybridHyperLogLog {
+private:
+    using THybridSet = THashSet<ui64, std::hash<ui64>, std::equal_to<ui64>, TAlloc<ui64>>;
+    using THybridHll = THyperLogLogWithAlloc<TAlloc<ui8>>;
+
+    explicit THybridHyperLogLog(ui32 precision)
+        : Var_(THybridSet())
+        , SizeLimit_((1u << precision) / 8)
+        , Precision_(precision)
+    {
+    }
+
+    THybridHll ConvertToHyperLogLog() const {
+        auto res = THybridHll::Create(Precision_);
+        for (auto& el : GetSetRef()) {
+            res.Update(el);
+        }
+        return res;
+    }
+
+    bool IsSet() const {
+        return Var_.index() == 1;
+    }
+
+    const THybridSet& GetSetRef() const {
+        return std::get<1>(Var_);
+    }
+
+    THybridSet& GetMutableSetRef() {
+        return std::get<1>(Var_);
+    }
+
+    const THybridHll& GetHllRef() const {
+        return std::get<0>(Var_);
+    }
+
+    THybridHll& GetMutableHllRef() {
+        return std::get<0>(Var_);
+    }
+
+public:
+    THybridHyperLogLog(THybridHyperLogLog&&) = default;
+
+    THybridHyperLogLog& operator=(THybridHyperLogLog&&) = default;
+
+    void Update(ui64 hash) {
+        if (IsSet()) {
+            GetMutableSetRef().insert(hash);
+            if (GetSetRef().size() >= SizeLimit_) {
+                Var_ = ConvertToHyperLogLog();
+            }
+        } else {
+            GetMutableHllRef().Update(hash);
+        }
+    }
+
+    void Merge(const THybridHyperLogLog& rh) {
+        if (IsSet() && rh.IsSet()) {
+            GetMutableSetRef().insert(rh.GetSetRef().begin(), rh.GetSetRef().end());
+            if (GetSetRef().size() >= SizeLimit_) {
+                Var_ = ConvertToHyperLogLog();
+            }
+        } else {
+            if (IsSet()) {
+                Var_ = ConvertToHyperLogLog();
+            }
+            if (rh.IsSet()) {
+                GetMutableHllRef().Merge(rh.ConvertToHyperLogLog());
+            } else {
+                GetMutableHllRef().Merge(rh.GetHllRef());
+            }
+        }
+    }
+
+    void Save(IOutputStream& out) const {
+        out.Write(static_cast<char>(Var_.index()));
+        out.Write(static_cast<char>(Precision_));
+        if (IsSet()) {
+            ::Save(&out, GetSetRef());
+        } else {
+            GetHllRef().Save(out);
+        }
+    }
+
+    ui64 Estimate() const {
+        if (IsSet()) {
+            return GetSetRef().size();
+        }
+        return GetHllRef().Estimate();
+    }
+
+    static THybridHyperLogLog Create(unsigned precision) {
+        Y_ENSURE(precision >= THyperLogLog::PRECISION_MIN && precision <= THyperLogLog::PRECISION_MAX);
+        return THybridHyperLogLog(precision);
+    }
+
+    static THybridHyperLogLog Load(IInputStream& in) {
+        char type;
+        Y_ENSURE(in.ReadChar(type));
+        char precision;
+        Y_ENSURE(in.ReadChar(precision));
+        auto res = Create(precision);
+        if (type) {
+            ::Load(&in, res.GetMutableSetRef());
+        } else {
+            res.Var_ = THybridHll::Load(in);
+        }
+        return res;
+    }
+
+private:
+    std::variant<THybridHll, THybridSet> Var_;
+
+    size_t SizeLimit_;
+
+    ui32 Precision_;
+};
+
+// UDAF to calculate count of distinct column values.
+class THLLAggFunc {
+public:
+    static constexpr std::string_view GetName() { return "HLL"; }
+
+    using TState = THybridHyperLogLog<NYql::NUdf::TStdAllocatorForUdf>;
+
+    static constexpr ui32 DEFAULT_PRECISION = 14;
+    static constexpr size_t ParamsCount = 0;
+
+    static TState CreateState(
+            TTypeId /*columnTypeId*/, const std::span<const TValue, ParamsCount>&) {
+        return TState::Create(DEFAULT_PRECISION);
+    }
+    static auto CreateStateUpdater(TTypeId columnTypeId) {
+        return [columnTypeId](TState& state, const TValue& val) {
+            VisitValue(columnTypeId, val, RawDataVisitor(
+                [&state](const char* data, size_t size) {
+                    state.Update(MurmurHash<ui64>(data, size));
+                }));
+        };
+    }
+    static void MergeStates(const TState& left, TState& right) {
+        right.Merge(left);
+    }
+    static TString SerializeState(const TState& state) {
+        TStringStream os;
+        state.Save(os);
+        return std::move(os).Str();
+    }
+    static TState DeserializeState(const char* data, size_t size) {
+        TMemoryInput is(data, size);
+        return TState::Load(is);
+    }
+    static TString FinalizeState(const TState& state) {
+        return ToString(state.Estimate());
+    }
+};
+
+} // NKikimr::NStat::NAggFuncs

--- a/ydb/library/yql/udfs/statistics_internal/ya.make
+++ b/ydb/library/yql/udfs/statistics_internal/ya.make
@@ -9,6 +9,7 @@ YQL_ABI_VERSION(
 SRCS(
     cms_agg_func.h
     ewh_agg_func.h
+    hll_agg_func.h
     all_agg_funcs.cpp
     all_agg_funcs.h
     common.h
@@ -16,6 +17,7 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/hyperloglog
     yql/essentials/core/minsketch
     yql/essentials/core/histogram
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Добавил возможность считать колоночные статистики частично (на подмножестве строк таблицы) и объединять результаты. Это в дальнейшем может быть использовано для семплирования, чекпоинтов промежуточного состояния и т.п. Но в этом PR эта возможность используется, чтобы считать статистику каждого шарда колоночных таблиц отдельно, это позволяет уйти от ограничения в 10минут на один scan-запрос, соответственно таким способом можно просканировать таблицу побольше.
