### PR TITLE
[CBO] Fix interesting orderings lookup: make it order-sensitive, i.e. shuffle [A, B] != [B, A]

### DIFF
--- a/ydb/core/kqp/ut/join/data/join_order/reuse_shuffle_with_wrong_order_bug_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/reuse_shuffle_with_wrong_order_bug_column_store.json
@@ -1,0 +1,49 @@
+{
+  "op_name":"InnerJoin (Grace)",
+  "args":
+    [
+      {
+        "op_name":"HashShuffle",
+        "args":
+          [
+            {
+              "op_name":"LeftSemiJoin (Grace)",
+              "args":
+                [
+                  {
+                    "op_name":"HashShuffle",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"customer"
+                        }
+                      ]
+                  },
+                  {
+                    "op_name":"HashShuffle",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"oorder"
+                        }
+                      ]
+                  }
+                ]
+            }
+          ]
+      },
+      {
+        "op_name":"HashShuffle",
+        "args":
+          [
+            {
+              "op_name":"TableFullScan",
+              "table":"new_order"
+            }
+          ]
+      }
+    ]
+}
+

--- a/ydb/core/kqp/ut/join/data/queries/reuse_shuffle_with_wrong_order_bug.sql
+++ b/ydb/core/kqp/ut/join/data/queries/reuse_shuffle_with_wrong_order_bug.sql
@@ -1,0 +1,15 @@
+PRAGMA TablePathPrefix = "/Root/test/tpcc/";
+
+$semi_join = (
+    SELECT *
+    FROM customer c
+    LEFT SEMI JOIN oorder o
+      ON c.C_W_ID = o.O_W_ID
+     AND c.C_D_ID = o.O_D_ID
+);
+
+SELECT s.C_W_ID, s.C_D_ID, n.NO_O_ID
+FROM $semi_join s
+INNER JOIN new_order as n
+  ON s.C_W_ID = n.NO_W_ID
+ AND s.C_D_ID = n.NO_D_ID;

--- a/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
@@ -1279,6 +1279,14 @@ Y_UNIT_TEST_SUITE(KqpJoinOrder) {
         );
     }
 
+    Y_UNIT_TEST(CanonizedJoinOrderReuseShuffleWithWrongOrderBug) {
+        CanonizedJoinOrderTest(
+            "queries/reuse_shuffle_with_wrong_order_bug.sql",
+            "stats/tpcc.json",
+            "join_order/reuse_shuffle_with_wrong_order_bug.json", false, true
+        );
+    }
+
 }
 }
 }


### PR DESCRIPTION
Interesting orderings FSM, considers shuffles "not natural" (before this PR), i.e. the order doesn't matter. Since our hash function is order-depended this leads to correctness bugs.

For example, this SQL query:
```sql
$semi_join = (
    SELECT *
    FROM customer c
    LEFT SEMI JOIN oorder o
      ON c.C_W_ID = o.O_W_ID
     AND c.C_D_ID = o.O_D_ID
);

SELECT s.C_W_ID, s.C_D_ID, n.NO_O_ID
FROM $semi_join s
INNER JOIN new_order as n
  ON s.C_W_ID = n.NO_W_ID
 AND s.C_D_ID = n.NO_D_ID;
```

Used to produce this plan:
```
┌> ResultSet
└─┬> InnerJoin (Grace) (c.C_D_ID,c.C_W_ID = n.NO_D_ID,n.NO_W_ID)
  ├─┬> LeftSemiJoin (Grace) (c.C_D_ID,c.C_W_ID = o.O_W_ID,o.O_D_ID)
  │ ├─┬> HashShuffle (KeyColumns: ["C_W_ID","C_D_ID"], HashFunc: "HashV2")
  │ │ └──> TableFullScan (Table: customer, ReadColumns: ["C_W_ID (-∞, +∞)","C_D_ID (-∞, +∞)","C_ID (-∞, +∞)"])
  │ └─┬> HashShuffle (KeyColumns: ["O_W_ID","O_D_ID"], HashFunc: "HashV2")
  │   └──> TableFullScan (Table: oorder, ReadColumns: ["O_W_ID (-∞, +∞)","O_D_ID (-∞, +∞)","O_ID (-∞, +∞)"])
  └─┬> HashShuffle (KeyColumns: ["NO_W_ID","NO_D_ID"], HashFunc: "HashV2")
    └──> TableFullScan (Table: new_order, ReadColumns: ["NO_W_ID (-∞, +∞)","NO_D_ID (-∞, +∞)","NO_O_ID (-∞, +∞)"])
```

This plan is wrong, because InnerJoin reuses [C_W_ID, C_D_ID] shuffle, when it really needs [C_D_ID, C_W_ID] - this will lead to incorrect result if executed on more than 1 node with overwhelming probability.

After this PR, it produces a correct plan
```
┌> ResultSet
└─┬> InnerJoin (Grace) (c.C_D_ID,c.C_W_ID = n.NO_D_ID,n.NO_W_ID)
  ├─┬> HashShuffle (KeyColumns: ["c.C_D_ID","c.C_W_ID"], HashFunc: "HashV2")
  │ └─┬> LeftSemiJoin (Grace) (c.C_D_ID,c.C_W_ID = o.O_W_ID,o.O_D_ID)
  │   ├─┬> HashShuffle (KeyColumns: ["C_W_ID","C_D_ID"], HashFunc: "HashV2")
  │   │ └──> TableFullScan (Table: customer, ReadColumns: ["C_W_ID (-∞, +∞)","C_D_ID (-∞, +∞)","C_ID (-∞, +∞)"])
  │   └─┬> HashShuffle (KeyColumns: ["O_W_ID","O_D_ID"], HashFunc: "HashV2")
  │     └──> TableFullScan (Table: oorder, ReadColumns: ["O_W_ID (-∞, +∞)","O_D_ID (-∞, +∞)","O_ID (-∞, +∞)"])
  └─┬> HashShuffle (KeyColumns: ["NO_D_ID","NO_W_ID"], HashFunc: "HashV2")
    └──> TableFullScan (Table: new_order, ReadColumns: ["NO_W_ID (-∞, +∞)","NO_D_ID (-∞, +∞)","NO_O_ID (-∞, +∞)"])
```